### PR TITLE
Vector tile layer - part 6 (writer)

### DIFF
--- a/python/core/auto_generated/vectortile/qgsvectortilewriter.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilewriter.sip.in
@@ -44,6 +44,8 @@ Currently the writer only support MVT encoding of data.
 {
 %Docstring
 Configuration of a single input vector layer to be included in the output
+
+.. versionadded:: 3.14
 %End
 
 %TypeHeaderCode
@@ -88,10 +90,13 @@ Sets the maximum zoom level of tiles. Allowed values are in interval [0,24]
 Sets vector layers and their configuration for output of vector tiles
 %End
 
-    bool writeTiles();
+    bool writeTiles( QgsFeedback *feedback = 0 );
 %Docstring
 Writes vector tiles according to the configuration.
 Returns true on success (upon failure one can get error cause using errorMessage())
+
+If a pointer to a feedback object is provided, it can be used to track progress or
+provide cancellation functionality.
 %End
 
     QString errorMessage() const;

--- a/python/core/auto_generated/vectortile/qgsvectortilewriter.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilewriter.sip.in
@@ -83,7 +83,7 @@ Sets the minimum zoom level of tiles. Allowed values are in interval [0,24]
 Sets the maximum zoom level of tiles. Allowed values are in interval [0,24]
 %End
 
-    void setLayers( const QList<Layer> &layers );
+    void setLayers( const QList<QgsVectorTileWriter::Layer> &layers );
 %Docstring
 Sets vector layers and their configuration for output of vector tiles
 %End

--- a/python/core/auto_generated/vectortile/qgsvectortilewriter.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilewriter.sip.in
@@ -1,0 +1,111 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/vectortile/qgsvectortilewriter.h                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsVectorTileWriter
+{
+%Docstring
+Takes care of writing vector tiles. The intended use is to set up the class
+by setting the destination URI, extent, zoom level range and input vector
+layers. Then with a call to writeTiles() the data gets written. In case
+of a failure, errorMessage() returns the cause of the problem during writing.
+
+The syntax of destination URIs is the same like the data source string
+used by vector tile layers: parameters are encoded as a HTTP query string,
+where "type" key determines the type of the destination container,
+the "url" key is normally the path. Currently supported types:
+
+- "xyz" - tile data written as local files, using a template where {x},{y},{z}
+are replaced by the actual tile column, row and zoom level numbers, e.g.:
+file:///home/qgis/tiles/{z}/{x}/{y}.pbf
+
+(More types such as "mbtiles" or "gpkg" may be added later.)
+
+Currently the writer only support MVT encoding of data.
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgsvectortilewriter.h"
+%End
+  public:
+    QgsVectorTileWriter();
+
+    class Layer
+{
+%Docstring
+Configuration of a single input vector layer to be included in the output
+%End
+
+%TypeHeaderCode
+#include "qgsvectortilewriter.h"
+%End
+      public:
+        explicit Layer( QgsVectorLayer *layer );
+%Docstring
+Constructs an entry for a vector layer
+%End
+
+        QgsVectorLayer *layer() const;
+%Docstring
+Returns vector layer of this entry
+%End
+
+    };
+
+    void setDestinationUri( const QString &uri );
+%Docstring
+Sets where and how the vector tiles will be written.
+See the class description about the syntax of destination URIs.
+%End
+
+    void setExtent( const QgsRectangle &extent );
+%Docstring
+Sets extent of vector tile output. Currently always in EPSG:3857.
+If unset, it will use the standard range of the Web Mercator system.
+%End
+
+    void setMinZoom( int minZoom );
+%Docstring
+Sets the minimum zoom level of tiles. Allowed values are in interval [0,24]
+%End
+    void setMaxZoom( int maxZoom );
+%Docstring
+Sets the maximum zoom level of tiles. Allowed values are in interval [0,24]
+%End
+
+    void setLayers( const QList<Layer> &layers );
+%Docstring
+Sets vector layers and their configuration for output of vector tiles
+%End
+
+    bool writeTiles();
+%Docstring
+Writes vector tiles according to the configuration.
+Returns true on success (upon failure one can get error cause using errorMessage())
+%End
+
+    QString errorMessage() const;
+%Docstring
+Returns error message related to the previous call to writeTiles(). Will return
+an empty string if writing was successful.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/vectortile/qgsvectortilewriter.h                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -547,6 +547,7 @@
 %Include auto_generated/vectortile/qgsvectortilelabeling.sip
 %Include auto_generated/vectortile/qgsvectortilelayer.sip
 %Include auto_generated/vectortile/qgsvectortilerenderer.sip
+%Include auto_generated/vectortile/qgsvectortilewriter.sip
 %Include auto_generated/gps/qgsqtlocationconnection.sip
 %Include auto_generated/gps/qgsgpsconnectionregistry.sip
 %Include auto_generated/symbology/qgsmasksymbollayer.sip

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1425,7 +1425,7 @@ protobuf_generate_cpp(VECTOR_TILE_PROTO_SRCS VECTOR_TILE_PROTO_HDRS vectortile/v
 SET(QGIS_CORE_SRCS ${QGIS_CORE_SRCS} ${VECTOR_TILE_PROTO_SRCS})
 SET(QGIS_CORE_HDRS ${QGIS_CORE_HDRS} ${VECTOR_TILE_PROTO_HDRS})
 IF (MSVC)
-  SET_SOURCE_FILES_PROPERTIES(${VECTOR_TILE_PROTO_SRCS} vectortile/qgsvectortilemvtdecoder.cpp PROPERTIES COMPILE_DEFINITIONS PROTOBUF_USE_DLLS)
+  SET_SOURCE_FILES_PROPERTIES(${VECTOR_TILE_PROTO_SRCS} vectortile/qgsvectortilemvtdecoder.cpp vectortile/qgsvectortilemvtencoder.cpp PROPERTIES COMPILE_DEFINITIONS PROTOBUF_USE_DLLS)
 ELSE (MSVC)
   # automatically generated file produces warnings (unused-parameter, unused-variable, misleading-indentation)
   SET_SOURCE_FILES_PROPERTIES(${VECTOR_TILE_PROTO_SRCS} PROPERTIES COMPILE_FLAGS -w)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -657,8 +657,11 @@ SET(QGIS_CORE_SRCS
   vectortile/qgsvectortilelayerrenderer.cpp
   vectortile/qgsvectortileloader.cpp
   vectortile/qgsvectortilemvtdecoder.cpp
+  vectortile/qgsvectortilemvtencoder.cpp
+  vectortile/qgsvectortilemvtutils.cpp
   vectortile/qgsvectortileprovidermetadata.cpp
   vectortile/qgsvectortileutils.cpp
+  vectortile/qgsvectortilewriter.cpp
 
   ${CMAKE_CURRENT_BINARY_DIR}/qgsexpression_texts.cpp
 
@@ -1368,9 +1371,12 @@ SET(QGIS_CORE_HDRS
   vectortile/qgsvectortilelayerrenderer.h
   vectortile/qgsvectortileloader.h
   vectortile/qgsvectortilemvtdecoder.h
+  vectortile/qgsvectortilemvtencoder.h
+  vectortile/qgsvectortilemvtutils.h
   vectortile/qgsvectortileprovidermetadata.h
   vectortile/qgsvectortilerenderer.h
   vectortile/qgsvectortileutils.h
+  vectortile/qgsvectortilewriter.h
 )
 
 SET(QGIS_CORE_PRIVATE_HDRS

--- a/src/core/vectortile/qgsvectortilemvtdecoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.cpp
@@ -235,26 +235,27 @@ QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString
           {
             tmpPoints.append( tmpPoints.first() );  // close the ring
 
-            if ( QgsVectorTileMVTUtils::isExteriorRing( tmpPoints ) )
+            std::unique_ptr<QgsLineString> ring( new QgsLineString( tmpPoints ) );
+            tmpPoints.clear();
+
+            if ( QgsVectorTileMVTUtils::isExteriorRing( ring.get() ) )
             {
               // start a new polygon
               QgsPolygon *p = new QgsPolygon;
-              p->setExteriorRing( new QgsLineString( tmpPoints ) );
+              p->setExteriorRing( ring.release() );
               outputPolygons.append( p );
-              tmpPoints.clear();
             }
             else
             {
               // interior ring (hole)
               if ( outputPolygons.count() != 0 )
               {
-                outputPolygons[outputPolygons.count() - 1]->addInteriorRing( new QgsLineString( tmpPoints ) );
+                outputPolygons[outputPolygons.count() - 1]->addInteriorRing( ring.release() );
               }
               else
               {
                 QgsDebugMsg( QStringLiteral( "Malformed geometry: first ring of a polygon is interior ring" ) );
               }
-              tmpPoints.clear();
             }
           }
 

--- a/src/core/vectortile/qgsvectortilemvtencoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtencoder.cpp
@@ -1,0 +1,357 @@
+/***************************************************************************
+  qgsvectortilemvtencoder.cpp
+  --------------------------------------
+  Date                 : April 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvectortilemvtencoder.h"
+
+#include "qgslinestring.h"
+#include "qgslogger.h"
+#include "qgsmultilinestring.h"
+#include "qgsmultipoint.h"
+#include "qgsmultipolygon.h"
+#include "qgspolygon.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectortilemvtutils.h"
+
+
+//! Helper class for writing of geometry commands
+struct MVTGeometryWriter
+{
+  vector_tile::Tile_Feature *feature = nullptr;
+  int resolution;
+  double tileXMin, tileYMax, tileDX, tileDY;
+  QPoint cursor;
+
+  MVTGeometryWriter( vector_tile::Tile_Feature *f, int res, const QgsRectangle &tileExtent )
+    : feature( f )
+    , resolution( res )
+    , tileXMin( tileExtent.xMinimum() )
+    , tileYMax( tileExtent.yMaximum() )
+    , tileDX( tileExtent.width() )
+    , tileDY( tileExtent.height() )
+  {
+  }
+
+  void addMoveTo( int count )
+  {
+    feature->add_geometry( 1 | ( count << 3 ) );
+  }
+  void addLineTo( int count )
+  {
+    feature->add_geometry( 2 | ( count << 3 ) );
+  }
+  void addClosePath()
+  {
+    feature->add_geometry( 7 | ( 1 << 3 ) );
+  }
+
+  void addPoint( const QgsPoint &pt )
+  {
+    addPoint( mapToTileCoordinates( pt ) );
+  }
+
+  void addPoint( const QPoint &pt )
+  {
+    qint32 vx = pt.x() - cursor.x();
+    qint32 vy = pt.y() - cursor.y();
+
+    feature->add_geometry( ( vx << 1 ) ^ ( vx >> 31 ) );
+    feature->add_geometry( ( vy << 1 ) ^ ( vy >> 31 ) );
+
+    cursor = pt;
+  }
+
+  QPoint mapToTileCoordinates( const QgsPoint &p )
+  {
+    return QPoint( static_cast<int>( round( ( p.x() - tileXMin ) * resolution / tileDX ) ),
+                   static_cast<int>( round( ( tileYMax - p.y() ) * resolution / tileDY ) ) );
+  }
+};
+
+
+static QVector<QgsPoint> pointsFromLineString( const QgsLineString *ls )
+{
+  QVector<QgsPoint> pts( ls->numPoints() );
+  for ( int i = 0; i < pts.count(); ++i )
+    pts[i] = ls->pointN( i );
+  return pts;
+}
+
+static void encodeLineString( const QVector<QgsPoint> &ls, bool isRing, bool reversed, MVTGeometryWriter &geomWriter )
+{
+  int count = ls.count();
+  if ( isRing )
+    count--;  // the last point in linear ring is repeated - but not in MVT
+
+  // de-duplicate points
+  QVector<QPoint> tilePoints;
+  QPoint last( -9999, -9999 );
+  tilePoints.reserve( count );
+  for ( int i = 0; i < count; ++i )
+  {
+    QPoint pt = geomWriter.mapToTileCoordinates( ls[i] );
+    if ( pt == last )
+      continue;
+
+    tilePoints << pt;
+    last = pt;
+  }
+  count = tilePoints.count();
+
+  geomWriter.addMoveTo( 1 );
+  geomWriter.addPoint( tilePoints[0] );
+  geomWriter.addLineTo( count - 1 );
+  if ( reversed )
+  {
+    for ( int i = count - 1; i >= 1; --i )
+      geomWriter.addPoint( tilePoints[i] );
+  }
+  else
+  {
+    for ( int i = 1; i < count; ++i )
+      geomWriter.addPoint( tilePoints[i] );
+  }
+}
+
+static void encodePolygon( const QgsPolygon *polygon, MVTGeometryWriter &geomWriter )
+{
+  QVector<QgsPoint> exterior = pointsFromLineString( qgsgeometry_cast<const QgsLineString *>( polygon->exteriorRing() ) );
+  encodeLineString( exterior, true, !QgsVectorTileMVTUtils::isExteriorRing( exterior ), geomWriter );
+  geomWriter.addClosePath();
+
+  for ( int i = 0; i < polygon->numInteriorRings(); ++i )
+  {
+    QVector<QgsPoint> interior = pointsFromLineString( qgsgeometry_cast<const QgsLineString *>( polygon->interiorRing( i ) ) );
+    encodeLineString( interior, true, QgsVectorTileMVTUtils::isExteriorRing( interior ), geomWriter );
+    geomWriter.addClosePath();
+  }
+}
+
+
+//
+
+
+QgsVectorTileMVTEncoder::QgsVectorTileMVTEncoder( QgsTileXYZ tileID )
+  : mTileID( tileID )
+{
+  QgsTileMatrix tm = QgsTileMatrix::fromWebMercator( mTileID.zoomLevel() );
+  mTileExtent = tm.tileExtent( mTileID );
+}
+
+void QgsVectorTileMVTEncoder::addLayer( QgsVectorLayer *layer, QString filterExpression, QString layerName )
+{
+  QgsCoordinateTransform ct( layer->crs(), QgsCoordinateReferenceSystem( "EPSG:3857" ), mTransformContext );
+
+  QgsRectangle layerTileExtent = mTileExtent;
+  try
+  {
+    layerTileExtent = ct.transformBoundingBox( layerTileExtent, QgsCoordinateTransform::ReverseTransform );
+    if ( !layerTileExtent.intersects( layer->extent() ) )
+    {
+      return;  // tile is completely outside of the layer'e extent
+    }
+  }
+  catch ( const QgsCsException & )
+  {
+    QgsDebugMsg( "Failed to reproject tile extent to the layer" );
+    return;
+  }
+
+  if ( layerName.isEmpty() )
+    layerName = layer->name();
+
+  // add buffer to both filter extent in layer CRS (for feature request) and tile extent in target CRS (for clipping)
+  double bufferRatio = static_cast<double>( mBuffer ) / mResolution;
+  QgsRectangle tileExtent = mTileExtent;
+  tileExtent.grow( bufferRatio * mTileExtent.width() );
+  layerTileExtent.grow( bufferRatio * std::max( layerTileExtent.width(), layerTileExtent.height() ) );
+
+  QgsFeatureRequest request;
+  request.setFilterRect( layerTileExtent );
+  if ( !filterExpression.isEmpty() )
+    request.setFilterExpression( filterExpression );
+  QgsFeatureIterator fit = layer->getFeatures( request );
+
+  QgsFeature f;
+  if ( !fit.nextFeature( f ) )
+  {
+    return;  // nothing to write - do not add the layer at all
+  }
+
+  vector_tile::Tile_Layer *tileLayer = tile.add_layers();
+  tileLayer->set_name( layerName.toUtf8() );
+  tileLayer->set_version( 2 );  // 2 means MVT spec version 2.1
+  tileLayer->set_extent( static_cast<::google::protobuf::uint32>( mResolution ) );
+
+  const QgsFields fields = layer->fields();
+  for ( int i = 0; i < fields.count(); ++i )
+  {
+    tileLayer->add_keys( fields[i].name().toUtf8() );
+  }
+
+  do
+  {
+    QgsGeometry g = f.geometry();
+
+    // reproject
+    try
+    {
+      g.transform( ct );
+    }
+    catch ( const QgsCsException & )
+    {
+      QgsDebugMsg( "Failed to reproject geometry " + QString::number( f.id() ) );
+      continue;
+    }
+
+    // clip
+    g = g.clipped( tileExtent );
+
+    f.setGeometry( g );
+
+    addFeature( tileLayer, f );
+  }
+  while ( fit.nextFeature( f ) );
+
+  mKnownValues.clear();
+}
+
+void QgsVectorTileMVTEncoder::addFeature( vector_tile::Tile_Layer *tileLayer, const QgsFeature &f )
+{
+  vector_tile::Tile_Feature *feature = tileLayer->add_features();
+
+  feature->set_id( static_cast<quint64>( f.id() ) );
+
+  //
+  // encode attributes
+  //
+
+  const QgsAttributes attrs = f.attributes();
+  for ( int i = 0; i < attrs.count(); ++i )
+  {
+    const QVariant v = attrs.at( i );
+    if ( !v.isValid() || v.isNull() )
+      continue;
+
+    int valueIndex;
+    if ( mKnownValues.contains( v ) )
+    {
+      valueIndex = mKnownValues[v];
+    }
+    else
+    {
+      vector_tile::Tile_Value *value = tileLayer->add_values();
+      valueIndex = tileLayer->values_size() - 1;
+      mKnownValues[v] = valueIndex;
+
+      if ( v.type() == QVariant::Double )
+        value->set_double_value( v.toDouble() );
+      else if ( v.type() == QVariant::Int )
+        value->set_int_value( v.toInt() );
+      else if ( v.type() == QVariant::Bool )
+        value->set_bool_value( v.toBool() );
+      else
+        value->set_string_value( v.toString().toUtf8().toStdString() );
+    }
+
+    feature->add_tags( static_cast<quint32>( i ) );
+    feature->add_tags( static_cast<quint32>( valueIndex ) );
+  }
+
+  //
+  // encode geometry
+  //
+
+  QgsGeometry g = f.geometry();
+  QgsWkbTypes::GeometryType geomType = g.type();
+  vector_tile::Tile_GeomType mvtGeomType = vector_tile::Tile_GeomType_UNKNOWN;
+  if ( geomType == QgsWkbTypes::PointGeometry )
+    mvtGeomType = vector_tile::Tile_GeomType_POINT;
+  else if ( geomType == QgsWkbTypes::LineGeometry )
+    mvtGeomType = vector_tile::Tile_GeomType_LINESTRING;
+  else if ( geomType == QgsWkbTypes::PolygonGeometry )
+    mvtGeomType = vector_tile::Tile_GeomType_POLYGON;
+  feature->set_type( mvtGeomType );
+
+  if ( QgsWkbTypes::isCurvedType( g.wkbType() ) )
+  {
+    g = QgsGeometry( g.get()->segmentize() );
+  }
+
+  MVTGeometryWriter geomWriter( feature, mResolution, mTileExtent );
+
+  const QgsAbstractGeometry *geom = g.constGet();
+  switch ( QgsWkbTypes::flatType( g.wkbType() ) )
+  {
+    case QgsWkbTypes::Point:
+    {
+      const QgsPoint *pt = static_cast<const QgsPoint *>( geom );
+      geomWriter.addMoveTo( 1 );
+      geomWriter.addPoint( *pt );
+    }
+    break;
+
+    case QgsWkbTypes::LineString:
+    {
+      QVector<QgsPoint> lineString = pointsFromLineString( qgsgeometry_cast<const QgsLineString *>( geom ) );
+      encodeLineString( lineString, true, false, geomWriter );
+    }
+    break;
+
+    case QgsWkbTypes::Polygon:
+    {
+      encodePolygon( static_cast<const QgsPolygon *>( geom ), geomWriter );
+    }
+    break;
+
+    case QgsWkbTypes::MultiPoint:
+    {
+      const QgsMultiPoint *mpt = static_cast<const QgsMultiPoint *>( geom );
+      geomWriter.addMoveTo( mpt->numGeometries() );
+      for ( int i = 0; i < mpt->numGeometries(); ++i )
+        geomWriter.addPoint( *static_cast<const QgsPoint *>( mpt->geometryN( i ) ) );
+    }
+    break;
+
+    case QgsWkbTypes::MultiLineString:
+    {
+      const QgsMultiLineString *mls = qgsgeometry_cast<const QgsMultiLineString *>( geom );
+      for ( int i = 0; i < mls->numGeometries(); ++i )
+      {
+        QVector<QgsPoint> lineString = pointsFromLineString( qgsgeometry_cast<const QgsLineString *>( mls->geometryN( i ) ) );
+        encodeLineString( lineString, true, false, geomWriter );
+      }
+    }
+    break;
+
+    case QgsWkbTypes::MultiPolygon:
+    {
+      const QgsMultiPolygon *mp = qgsgeometry_cast<const QgsMultiPolygon *>( geom );
+      for ( int i = 0; i < mp->numGeometries(); ++i )
+      {
+        encodePolygon( static_cast<const QgsPolygon *>( mp->geometryN( i ) ), geomWriter );
+      }
+    }
+    break;
+
+    default:
+      break;
+  }
+}
+
+
+QByteArray QgsVectorTileMVTEncoder::encode() const
+{
+  return QByteArray::fromStdString( tile.SerializeAsString() );
+}

--- a/src/core/vectortile/qgsvectortilemvtencoder.h
+++ b/src/core/vectortile/qgsvectortilemvtencoder.h
@@ -1,0 +1,83 @@
+/***************************************************************************
+  qgsvectortilemvtencoder.h
+  --------------------------------------
+  Date                 : April 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSVECTORTILEMVTENCODER_H
+#define QGSVECTORTILEMVTENCODER_H
+
+#define SIP_NO_FILE
+
+#include "qgstiles.h"
+#include "qgsvectortilerenderer.h"
+#include "vector_tile.pb.h"
+
+
+/**
+ * \ingroup core
+ * Handles conversion of vector features to Mapbox vector tiles encoding.
+ *
+ * Geometries are stored as a series of MoveTo / LineTo / ClosePath commands
+ * with coordinates in integer values (see resolution(), called "extent" in the spec).
+ * Attributes are stored as key-value pairs of tags: keys are always strings, values
+ * can be integers, floating point numbers, booleans or strings.
+ *
+ * See the specification for details:
+ * https://github.com/mapbox/vector-tile-spec/blob/master/2.1/README.md
+ *
+ * \since QGIS 3.14
+ */
+class CORE_EXPORT QgsVectorTileMVTEncoder
+{
+  public:
+    explicit QgsVectorTileMVTEncoder( QgsTileXYZ tileID );
+
+    //! Returns resolution of coordinates of geometries within the tile. The default is 4096.
+    int resolution() const { return mResolution; }
+    //! Sets the resolution of coordinates of geometries within the tile
+    void setResolution( int extent ) { mResolution = extent; }
+
+    //! Returns size of the buffer zone around tile edges in integer tile coordinates. The default is 256 (~6%)
+    int tileBuffer() const { return mBuffer; }
+    //! Sets size of the buffer zone around tile edges in integer tile coordinates
+    void setTileBuffer( int buffer ) { mBuffer = buffer; }
+
+    //! Sets coordinate transform context for transforms between layers and tile matrix CRS
+    void setTransformContext( const QgsCoordinateTransformContext &transformContext ) { mTransformContext = transformContext; }
+
+    //! Fetches data from vector layer for the given tile, does reprojection and clipping
+    void addLayer( QgsVectorLayer *layer, QString filterExpression = QString(), QString layerName = QString() );
+
+    //! Encodes MVT using data stored previously with addLayer() calls
+    QByteArray encode() const;
+
+  private:
+    void addFeature( vector_tile::Tile_Layer *tileLayer, const QgsFeature &f );
+
+  private:
+    QgsTileXYZ mTileID;
+    int mResolution = 4096;
+    int mBuffer = 256;
+    QgsCoordinateTransformContext mTransformContext;
+
+    QgsRectangle mTileExtent;
+
+    QgsVectorTileFeatures mFeatures;
+
+    vector_tile::Tile tile;
+
+    QMap<QVariant, int> mKnownValues;
+
+};
+
+#endif // QGSVECTORTILEMVTENCODER_H

--- a/src/core/vectortile/qgsvectortilemvtencoder.h
+++ b/src/core/vectortile/qgsvectortilemvtencoder.h
@@ -40,6 +40,7 @@
 class CORE_EXPORT QgsVectorTileMVTEncoder
 {
   public:
+    //! Creates MVT encoder for the given tile coordinates
     explicit QgsVectorTileMVTEncoder( QgsTileXYZ tileID );
 
     //! Returns resolution of coordinates of geometries within the tile. The default is 4096.
@@ -55,8 +56,12 @@ class CORE_EXPORT QgsVectorTileMVTEncoder
     //! Sets coordinate transform context for transforms between layers and tile matrix CRS
     void setTransformContext( const QgsCoordinateTransformContext &transformContext ) { mTransformContext = transformContext; }
 
-    //! Fetches data from vector layer for the given tile, does reprojection and clipping
-    void addLayer( QgsVectorLayer *layer, QString filterExpression = QString(), QString layerName = QString() );
+    /**
+     * Fetches data from vector layer for the given tile, does reprojection and clipping
+     *
+     * Optional feedback object may be provided to support cancellation.
+     */
+    void addLayer( QgsVectorLayer *layer, QgsFeedback *feedback = nullptr, QString filterExpression = QString(), QString layerName = QString() );
 
     //! Encodes MVT using data stored previously with addLayer() calls
     QByteArray encode() const;

--- a/src/core/vectortile/qgsvectortilemvtutils.cpp
+++ b/src/core/vectortile/qgsvectortilemvtutils.cpp
@@ -1,0 +1,38 @@
+/***************************************************************************
+  qgsvectortilemvtutils.cpp
+  --------------------------------------
+  Date                 : April 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvectortilemvtutils.h"
+
+#include "qgspoint.h"
+
+
+bool QgsVectorTileMVTUtils::isExteriorRing( const QVector<QgsPoint> &pts )
+{
+  // Exterior rings have POSITIVE area while interior rings have NEGATIVE area
+  // when calculated with https://en.wikipedia.org/wiki/Shoelace_formula
+  // The orientation of axes is that X grows to the right and Y grows to the bottom.
+  // the input data are expected to form a closed ring, i.e. first pt == last pt.
+
+  double total = 0.0;
+  const QgsPoint *ptsPtr = pts.constData();
+  int count = pts.count();
+  for ( int i = 0; i < count - 1; i++ )
+  {
+    double val = ( pts[i + 1].x() - ptsPtr[i].x() ) * ( ptsPtr[i + 1].y() + pts[i].y() );
+    //double val = ptsPtr[i].x() * (-ptsPtr[i+1].y()) - ptsPtr[i+1].x() * (-ptsPtr[i].y());  // gives the same result
+    total += val;
+  }
+  return total >= 0;
+}

--- a/src/core/vectortile/qgsvectortilemvtutils.cpp
+++ b/src/core/vectortile/qgsvectortilemvtutils.cpp
@@ -15,10 +15,10 @@
 
 #include "qgsvectortilemvtutils.h"
 
-#include "qgspoint.h"
+#include "qgslinestring.h"
 
 
-bool QgsVectorTileMVTUtils::isExteriorRing( const QVector<QgsPoint> &pts )
+bool QgsVectorTileMVTUtils::isExteriorRing( const QgsLineString *lineString )
 {
   // Exterior rings have POSITIVE area while interior rings have NEGATIVE area
   // when calculated with https://en.wikipedia.org/wiki/Shoelace_formula
@@ -26,12 +26,14 @@ bool QgsVectorTileMVTUtils::isExteriorRing( const QVector<QgsPoint> &pts )
   // the input data are expected to form a closed ring, i.e. first pt == last pt.
 
   double total = 0.0;
-  const QgsPoint *ptsPtr = pts.constData();
-  int count = pts.count();
+  int count = lineString->numPoints();
+  const double *xData = lineString->xData();
+  const double *yData = lineString->yData();
+
   for ( int i = 0; i < count - 1; i++ )
   {
-    double val = ( pts[i + 1].x() - ptsPtr[i].x() ) * ( ptsPtr[i + 1].y() + pts[i].y() );
-    //double val = ptsPtr[i].x() * (-ptsPtr[i+1].y()) - ptsPtr[i+1].x() * (-ptsPtr[i].y());  // gives the same result
+    double val = ( xData[i + 1] - xData[i] ) * ( yData[i + 1] + yData[i] );
+    //double val = xData[i] * (-yData[i+1]) - xData[i+1] * (-yData[i]);  // gives the same result
     total += val;
   }
   return total >= 0;

--- a/src/core/vectortile/qgsvectortilemvtutils.h
+++ b/src/core/vectortile/qgsvectortilemvtutils.h
@@ -1,0 +1,43 @@
+/***************************************************************************
+  qgsvectortilemvtutils.h
+  --------------------------------------
+  Date                 : April 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSVECTORTILEMVTUTILS_H
+#define QGSVECTORTILEMVTUTILS_H
+
+#define SIP_NO_FILE
+
+#include <QVector>
+
+class QgsPoint;
+
+
+/**
+ * \ingroup core
+ * Assorted utility functions used during MVT decoding and encoding.
+ *
+ * \since QGIS 3.14
+ */
+class QgsVectorTileMVTUtils
+{
+  public:
+
+    /**
+     * Returns whether this linear ring forms an exterior ring according to MVT spec
+     * (depending on the orientation - clockwise or counter-clockwise)
+     */
+    static bool isExteriorRing( const QVector<QgsPoint> &pts );
+};
+
+#endif // QGSVECTORTILEMVTUTILS_H

--- a/src/core/vectortile/qgsvectortilemvtutils.h
+++ b/src/core/vectortile/qgsvectortilemvtutils.h
@@ -18,9 +18,7 @@
 
 #define SIP_NO_FILE
 
-#include <QVector>
-
-class QgsPoint;
+class QgsLineString;
 
 
 /**
@@ -37,7 +35,7 @@ class QgsVectorTileMVTUtils
      * Returns whether this linear ring forms an exterior ring according to MVT spec
      * (depending on the orientation - clockwise or counter-clockwise)
      */
-    static bool isExteriorRing( const QVector<QgsPoint> &pts );
+    static bool isExteriorRing( const QgsLineString *lineString );
 };
 
 #endif // QGSVECTORTILEMVTUTILS_H

--- a/src/core/vectortile/qgsvectortilewriter.cpp
+++ b/src/core/vectortile/qgsvectortilewriter.cpp
@@ -1,0 +1,119 @@
+/***************************************************************************
+  qgsvectortilewriter.cpp
+  --------------------------------------
+  Date                 : April 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvectortilewriter.h"
+
+#include "qgsdatasourceuri.h"
+
+#include "qgsvectortilemvtencoder.h"
+#include "qgsvectortileutils.h"
+
+#include "qgstiles.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QUrl>
+
+#include <QtDebug>
+#include "qgsvectorlayer.h"
+
+QgsVectorTileWriter::QgsVectorTileWriter()
+{
+  mExtent = QgsTileMatrix::fromWebMercator( 0 ).tileExtent( QgsTileXYZ( 0, 0, 0 ) );
+}
+
+
+bool QgsVectorTileWriter::writeTiles()
+{
+  if ( mMinZoom < 0 )
+  {
+    mErrorMessage = "Invalid min. zoom level";
+    return false;
+  }
+  if ( mMaxZoom > 24 )
+  {
+    mErrorMessage = "Invalid max. zoom level";
+    return false;
+  }
+
+  QgsDataSourceUri dsUri;
+  dsUri.setEncodedUri( mDestinationUri );
+
+  QString sourceType = dsUri.param( QStringLiteral( "type" ) );
+  QString sourcePath = dsUri.param( QStringLiteral( "url" ) );
+  if ( sourceType != QStringLiteral( "xyz" ) )
+  {
+    mErrorMessage = "Unsupported source type for writing: " + sourceType;
+    return false;
+  }
+
+  // remove the initial file:// scheme
+  sourcePath = QUrl( sourcePath ).toLocalFile();
+
+  for ( int zoomLevel = mMinZoom; zoomLevel <= mMaxZoom; ++zoomLevel )
+  {
+    QgsTileMatrix tileMatrix = QgsTileMatrix::fromWebMercator( zoomLevel );
+
+    QgsTileRange tileRange = tileMatrix.tileRangeFromExtent( mExtent );
+    for ( int row = tileRange.startRow(); row <= tileRange.endRow(); ++row )
+    {
+      for ( int col = tileRange.startColumn(); col <= tileRange.endColumn(); ++col )
+      {
+        QgsTileXYZ tileID( col, row, zoomLevel );
+        QgsVectorTileMVTEncoder encoder( tileID );
+
+        for ( const Layer &layer : qgis::as_const( mLayers ) )
+        {
+          encoder.addLayer( layer.layer() );
+        }
+
+        QByteArray tileData = encoder.encode();
+
+        if ( tileData.isEmpty() )
+        {
+          // skipping empty tile - no need to write it
+          continue;
+        }
+
+        QString filePath = QgsVectorTileUtils::formatXYZUrlTemplate( sourcePath, tileID );
+
+        // make dirs if needed
+        QFileInfo fi( filePath );
+        QDir fileDir = fi.dir();
+        if ( !fileDir.exists() )
+        {
+          if ( !fileDir.mkpath( "." ) )
+          {
+            mErrorMessage = "Cannot create directory " + fileDir.path();
+            return false;
+          }
+        }
+
+        QFile f( filePath );
+        if ( !f.open( QIODevice::WriteOnly ) )
+        {
+          mErrorMessage = "Cannot open file for writing " + filePath;
+          return false;
+        }
+
+        f.write( tileData );
+        f.close();
+      }
+    }
+  }
+
+  return true;
+}

--- a/src/core/vectortile/qgsvectortilewriter.h
+++ b/src/core/vectortile/qgsvectortilewriter.h
@@ -87,7 +87,7 @@ class CORE_EXPORT QgsVectorTileWriter
     void setMaxZoom( int maxZoom ) { mMaxZoom = maxZoom; }
 
     //! Sets vector layers and their configuration for output of vector tiles
-    void setLayers( const QList<Layer> &layers ) { mLayers = layers; }
+    void setLayers( const QList<QgsVectorTileWriter::Layer> &layers ) { mLayers = layers; }
 
     /**
      * Writes vector tiles according to the configuration.

--- a/src/core/vectortile/qgsvectortilewriter.h
+++ b/src/core/vectortile/qgsvectortilewriter.h
@@ -1,0 +1,114 @@
+/***************************************************************************
+  qgsvectortilewriter.h
+  --------------------------------------
+  Date                 : April 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSVECTORTILEWRITER_H
+#define QGSVECTORTILEWRITER_H
+
+#include "qgsrectangle.h"
+
+class QgsVectorLayer;
+
+
+/**
+ * \ingroup core
+ * Takes care of writing vector tiles. The intended use is to set up the class
+ * by setting the destination URI, extent, zoom level range and input vector
+ * layers. Then with a call to writeTiles() the data gets written. In case
+ * of a failure, errorMessage() returns the cause of the problem during writing.
+ *
+ * The syntax of destination URIs is the same like the data source string
+ * used by vector tile layers: parameters are encoded as a HTTP query string,
+ * where "type" key determines the type of the destination container,
+ * the "url" key is normally the path. Currently supported types:
+ *
+ * - "xyz" - tile data written as local files, using a template where {x},{y},{z}
+ *   are replaced by the actual tile column, row and zoom level numbers, e.g.:
+ *   file:///home/qgis/tiles/{z}/{x}/{y}.pbf
+ *
+ * (More types such as "mbtiles" or "gpkg" may be added later.)
+ *
+ * Currently the writer only support MVT encoding of data.
+ *
+ * \since QGIS 3.14
+ */
+class CORE_EXPORT QgsVectorTileWriter
+{
+  public:
+    QgsVectorTileWriter();
+
+    /**
+     * Configuration of a single input vector layer to be included in the output
+     */
+    class Layer
+    {
+      public:
+        //! Constructs an entry for a vector layer
+        explicit Layer( QgsVectorLayer *layer )
+          : mLayer( layer )
+        {
+        }
+
+        //! Returns vector layer of this entry
+        QgsVectorLayer *layer() const { return mLayer; }
+
+      private:
+        QgsVectorLayer *mLayer;
+        //QString mFilterExpression;
+        //QString mLayerName;
+    };
+
+    /**
+     * Sets where and how the vector tiles will be written.
+     * See the class description about the syntax of destination URIs.
+     */
+    void setDestinationUri( const QString &uri ) { mDestinationUri = uri; }
+
+    /**
+     * Sets extent of vector tile output. Currently always in EPSG:3857.
+     * If unset, it will use the standard range of the Web Mercator system.
+     */
+    void setExtent( const QgsRectangle &extent ) { mExtent = extent; }
+
+    //! Sets the minimum zoom level of tiles. Allowed values are in interval [0,24]
+    void setMinZoom( int minZoom ) { mMinZoom = minZoom; }
+    //! Sets the maximum zoom level of tiles. Allowed values are in interval [0,24]
+    void setMaxZoom( int maxZoom ) { mMaxZoom = maxZoom; }
+
+    //! Sets vector layers and their configuration for output of vector tiles
+    void setLayers( const QList<Layer> &layers ) { mLayers = layers; }
+
+    /**
+     * Writes vector tiles according to the configuration.
+     * Returns true on success (upon failure one can get error cause using errorMessage())
+     */
+    bool writeTiles();
+
+    /**
+     * Returns error message related to the previous call to writeTiles(). Will return
+     * an empty string if writing was successful.
+     */
+    QString errorMessage() const { return mErrorMessage; }
+
+  private:
+    QgsRectangle mExtent;
+    int mMinZoom = 0;
+    int mMaxZoom = 4;
+    QList<Layer> mLayers;
+    QString mDestinationUri;
+
+    QString mErrorMessage;
+};
+
+#endif // QGSVECTORTILEWRITER_H

--- a/src/core/vectortile/qgsvectortilewriter.h
+++ b/src/core/vectortile/qgsvectortilewriter.h
@@ -16,8 +16,10 @@
 #ifndef QGSVECTORTILEWRITER_H
 #define QGSVECTORTILEWRITER_H
 
+#include <QCoreApplication>
 #include "qgsrectangle.h"
 
+class QgsFeedback;
 class QgsVectorLayer;
 
 
@@ -45,11 +47,15 @@ class QgsVectorLayer;
  */
 class CORE_EXPORT QgsVectorTileWriter
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsVectorTileWriter )
+
   public:
     QgsVectorTileWriter();
 
     /**
+     * \ingroup core
      * Configuration of a single input vector layer to be included in the output
+     * \since QGIS 3.14
      */
     class Layer
     {
@@ -92,8 +98,11 @@ class CORE_EXPORT QgsVectorTileWriter
     /**
      * Writes vector tiles according to the configuration.
      * Returns true on success (upon failure one can get error cause using errorMessage())
+     *
+     * If a pointer to a feedback object is provided, it can be used to track progress or
+     * provide cancellation functionality.
      */
-    bool writeTiles();
+    bool writeTiles( QgsFeedback *feedback = nullptr );
 
     /**
      * Returns error message related to the previous call to writeTiles(). Will return

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -241,6 +241,7 @@ SET(TESTS
  testqgsvectorlayer.cpp
  testqgsvectorlayerutils.cpp
  testqgsvectortilelayer.cpp
+ testqgsvectortilewriter.cpp
  testqgsziputils.cpp
  testziplayer.cpp
  testqgslayerdefinition.cpp

--- a/tests/src/core/testqgsvectortilewriter.cpp
+++ b/tests/src/core/testqgsvectortilewriter.cpp
@@ -41,9 +41,7 @@ class TestQgsVectorTileWriter : public QObject
 
   private:
     QString mDataDir;
-    //QgsVectorTileLayer *mLayer = nullptr;
     QString mReport;
-    QgsMapSettings *mMapSettings = nullptr;
 
   private slots:
     void initTestCase();// will be called before the first testfunction is executed.

--- a/tests/src/core/testqgsvectortilewriter.cpp
+++ b/tests/src/core/testqgsvectortilewriter.cpp
@@ -1,0 +1,147 @@
+/***************************************************************************
+  testqgsvectortilewriter.cpp
+  --------------------------------------
+  Date                 : April 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+#include <QObject>
+#include <QString>
+
+//qgis includes...
+#include "qgsapplication.h"
+#include "qgsproject.h"
+#include "qgstiles.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectortilemvtdecoder.h"
+#include "qgsvectortilelayer.h"
+#include "qgsvectortilewriter.h"
+
+#include <QTemporaryDir>
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test for vector tile writing
+ */
+class TestQgsVectorTileWriter : public QObject
+{
+    Q_OBJECT
+
+  public:
+    TestQgsVectorTileWriter() = default;
+
+  private:
+    QString mDataDir;
+    //QgsVectorTileLayer *mLayer = nullptr;
+    QString mReport;
+    QgsMapSettings *mMapSettings = nullptr;
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init() {} // will be called before each testfunction is executed.
+    void cleanup() {} // will be called after every testfunction.
+
+    void test_basic();
+};
+
+
+void TestQgsVectorTileWriter::initTestCase()
+{
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  QgsApplication::showSettings();
+  mDataDir = QString( TEST_DATA_DIR ); //defined in CmakeLists.txt
+}
+
+void TestQgsVectorTileWriter::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+
+void TestQgsVectorTileWriter::test_basic()
+{
+  QTemporaryDir dir;
+  dir.setAutoRemove( false );  // so that we can inspect the results later
+  QString tmpDir = dir.path();
+
+  QgsDataSourceUri ds;
+  ds.setParam( "type", "xyz" );
+  ds.setParam( "url", QUrl::fromLocalFile( tmpDir ).toString() + "/{z}-{x}-{y}.pbf" );
+
+  QgsVectorLayer *vlPoints = new QgsVectorLayer( mDataDir + "/points.shp", "points", "ogr" );
+  QgsVectorLayer *vlLines = new QgsVectorLayer( mDataDir + "/lines.shp", "lines", "ogr" );
+  QgsVectorLayer *vlPolys = new QgsVectorLayer( mDataDir + "/polys.shp", "polys", "ogr" );
+
+  QList<QgsVectorTileWriter::Layer> layers;
+  layers << QgsVectorTileWriter::Layer( vlPoints );
+  layers << QgsVectorTileWriter::Layer( vlLines );
+  layers << QgsVectorTileWriter::Layer( vlPolys );
+
+  QgsVectorTileWriter writer;
+  writer.setDestinationUri( ds.encodedUri() );
+  writer.setMaxZoom( 3 );
+  writer.setLayers( layers );
+
+  bool res = writer.writeTiles();
+  QVERIFY( res );
+  QVERIFY( writer.errorMessage().isEmpty() );
+
+  delete vlPoints;
+  delete vlLines;
+  delete vlPolys;
+
+  // check on the file level
+  QDir dirInfo( tmpDir );
+  QStringList dirFiles = dirInfo.entryList( QStringList( "*.pbf" ) );
+  QCOMPARE( dirFiles.count(), 8 );   // 1 tile at z0, 1 tile at z1, 2 tiles at z2, 4 tiles at z3
+  QVERIFY( dirFiles.contains( "0-0-0.pbf" ) );
+
+  QgsVectorTileLayer *vtLayer = new QgsVectorTileLayer( ds.encodedUri(), "output" );
+
+  QByteArray tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
+  QgsVectorTileMVTDecoder decoder;
+  bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0 );
+  QVERIFY( resDecode0 );
+  QStringList layerNames = decoder.layers();
+  QCOMPARE( layerNames, QStringList() << "points" << "lines" << "polys" );
+  QStringList fieldNamesLines = decoder.layerFieldNames( "lines" );
+  QCOMPARE( fieldNamesLines, QStringList() << "Name" << "Value" );
+
+  QgsFields fieldsPolys;
+  fieldsPolys.append( QgsField( "Name", QVariant::String ) );
+  QMap<QString, QgsFields> perLayerFields;
+  perLayerFields["polys"] = fieldsPolys;
+  perLayerFields["lines"] = QgsFields();
+  perLayerFields["points"] = QgsFields();
+  QgsVectorTileFeatures features0 = decoder.layerFeatures( perLayerFields, QgsCoordinateTransform() );
+  QCOMPARE( features0["points"].count(), 17 );
+  QCOMPARE( features0["lines"].count(), 6 );
+  QCOMPARE( features0["polys"].count(), 10 );
+
+  QCOMPARE( features0["points"][0].geometry().wkbType(), QgsWkbTypes::Point );
+  QCOMPARE( features0["lines"][0].geometry().wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( features0["polys"][0].geometry().wkbType(), QgsWkbTypes::MultiPolygon );   // source geoms in shp are multipolygons
+
+  QgsAttributes attrsPolys0_0 = features0["polys"][0].attributes();
+  QCOMPARE( attrsPolys0_0.count(), 1 );
+  QString attrNamePolys0_0 = attrsPolys0_0[0].toString();
+  QVERIFY( attrNamePolys0_0 == "Dam" || attrNamePolys0_0 == "Lake" );
+
+  delete vtLayer;
+}
+
+
+QGSTEST_MAIN( TestQgsVectorTileWriter )
+#include "testqgsvectortilewriter.moc"


### PR DESCRIPTION
Continued work on vector tile layer implementation.

See the QEP: qgis/QGIS-Enhancement-Proposals#162

Initial work on vector tile writer. Currently supporting output to a directory based on XYZ template, using Mapbox vector tiles encoding. So far no user-facing way how to use this (only Python API).

New classes:
- QgsVectorTileMVTEncoder - low-level class that operates on a single tile, converts vector features to raw tile byte array, for internal use
- QgsVectorTileWriter - higher level class that manages generation of multiple tiles, for use by clients
- QgsVectorTileMVTUtils - assorted helper functions for MVT encoding/decoding

Sample code to generate vector tiles from a single layer:

```
uri = QgsDataSourceUri()
uri.setParam("type", "xyz")
uri.setParam("url", "file:///tmp/test/{z}/{x}-{y}.pbf")
lyr = QgsVectorTileWriter.Layer(iface.activeLayer())
writer = QgsVectorTileWriter()
writer.setDestinationUri(bytes(uri.encodedUri()).decode('utf-8'))
writer.setLayers([lyr])
writer.setMinZoom(0)
writer.setMaxZoom(3)
# writer.setExtent(QgsRectangle(...))
writer.writeTiles()
```

## Thanks

Huge thanks to all funders who have contributed to the crowdfunding and made this possible :clap: :clap: :clap:
https://www.lutraconsulting.co.uk/blog/2020/04/02/vectortiles-donors/