### PR TITLE
fix deprecation warning in qgis.utils (fix #32786)

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -545,9 +545,12 @@ def reloadProjectMacros():
         return
 
     # create a new empty python module
-    import imp
-
-    mod = imp.new_module("proj_macros_mod")
+    if sys.version_info >= (3, 4):
+        import importlib
+        mod = importlib.util.module_from_spec(importlib.machinery.ModuleSpec("proj_macros_mod", None))
+    else:
+        import imp
+        mod = imp.new_module("proj_macros_mod")
 
     # set the module code and store it sys.modules
     exec(str(code), mod.__dict__)

--- a/python/utils.py
+++ b/python/utils.py
@@ -545,12 +545,8 @@ def reloadProjectMacros():
         return
 
     # create a new empty python module
-    if sys.version_info >= (3, 4):
-        import importlib
-        mod = importlib.util.module_from_spec(importlib.machinery.ModuleSpec("proj_macros_mod", None))
-    else:
-        import imp
-        mod = imp.new_module("proj_macros_mod")
+    import importlib
+    mod = importlib.util.module_from_spec(importlib.machinery.ModuleSpec("proj_macros_mod", None))
 
     # set the module code and store it sys.modules
     exec(str(code), mod.__dict__)


### PR DESCRIPTION
## Description
The`imp.new_module()` call was deprecated in Python 3.4, as result a deprecation warning shown in `qgis.utils` module. Fixes #32786.
