### PR TITLE
Fix embedded sub-group

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
@@ -48,8 +48,14 @@ Returns the group's id.
 %End
 
     void setId( const QString &id );
+%Docstring
+Sets the group's id.
+%End
 
     QString generateId( QString name ) const;
+%Docstring
+Generate the group's id, according to the groups's name (based on QgsMapLayer.generateId)
+%End
 
     QgsLayerTreeGroup *insertGroup( int index, const QString &name );
 %Docstring

--- a/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
@@ -42,6 +42,15 @@ Returns the group's name.
 Sets the group's name.
 %End
 
+    QString id() const;
+%Docstring
+Returns the group's id.
+%End
+
+    void setId( const QString &id );
+
+    QString generateId( QString name ) const;
+
     QgsLayerTreeGroup *insertGroup( int index, const QString &name );
 %Docstring
 Insert a new group node with given name at specified position. The newly created node is owned by this group.
@@ -211,6 +220,7 @@ of -1 will determine automatically (either first one currently checked or none)
 %Docstring
 Set check state of children - if mutually exclusive
 %End
+
 
 
 

--- a/python/core/auto_generated/layertree/qgslayertreeutils.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreeutils.sip.in
@@ -81,6 +81,11 @@ Updates an embedded ``group`` from a ``project``.
 Gets invisible layers
 %End
 
+    static QStringList uncheckedGroupList( QgsLayerTreeNode *node );
+%Docstring
+Gets unchecked group
+%End
+
     static void setLegendFilterByExpression( QgsLayerTreeLayer &layer, const QString &expr, bool enabled = true );
 %Docstring
 Sets the expression filter of a legend layer

--- a/python/core/auto_generated/layertree/qgslayertreeutils.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreeutils.sip.in
@@ -83,7 +83,7 @@ Gets invisible layers
 
     static QStringList uncheckedGroupList( QgsLayerTreeNode *node );
 %Docstring
-Gets unchecked group
+Gets unchecked groups
 %End
 
     static void setLegendFilterByExpression( QgsLayerTreeLayer &layer, const QString &expr, bool enabled = true );

--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -532,7 +532,7 @@ Returns project file path if layer is embedded from other project file. Returns 
 %End
 
 
-    QgsLayerTreeGroup *createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers, QgsProject::ReadFlags flags = QgsProject::ReadFlags() );
+    QgsLayerTreeGroup *createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers, const QStringList &uncheckedGroups, QgsProject::ReadFlags flags = QgsProject::ReadFlags() );
 %Docstring
 Create layer group instance defined in an arbitrary project file.
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12587,7 +12587,7 @@ void QgisApp::embedLayers()
     QStringList::const_iterator groupIt = groups.constBegin();
     for ( ; groupIt != groups.constEnd(); ++groupIt )
     {
-      QgsLayerTreeGroup *newGroup = QgsProject::instance()->createEmbeddedGroup( *groupIt, projectFile, QStringList() );
+      QgsLayerTreeGroup *newGroup = QgsProject::instance()->createEmbeddedGroup( *groupIt, projectFile, QStringList(), QStringList() );
 
       if ( newGroup )
         QgsProject::instance()->layerTreeRoot()->addChildNode( newGroup );

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -56,6 +56,21 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
     void setName( const QString &n ) override;
 
     /**
+     * Returns the group's id.
+     */
+    QString id() const;
+
+    /**
+     * Sets the group's id.
+     */
+    void setId( const QString &id );
+
+    /**
+     * Generate the group's id, according to the groups's name (based on QgsMapLayer::generateId)
+     */
+    QString generateId( QString name ) const;
+
+    /**
      * Insert a new group node with given name at specified position. The newly created node is owned by this group.
      */
     QgsLayerTreeGroup *insertGroup( int index, const QString &name );
@@ -216,6 +231,8 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
     void updateChildVisibilityMutuallyExclusive();
 
     QString mName;
+
+    QString mId;
 
     bool mChangingChildVisibility = false;
 

--- a/src/core/layertree/qgslayertreeutils.cpp
+++ b/src/core/layertree/qgslayertreeutils.cpp
@@ -386,7 +386,7 @@ QStringList QgsLayerTreeUtils::invisibleLayerList( QgsLayerTreeNode *node )
   return list;
 }
 
-QStringList QgsLayerTreeUtils::uncheckedGroupList( QgsLayerTreeNode *node )
+QStringList QgsLayerTreeUtils::uncheckedGroupList( QgsLayerTreeNode *node, int index )
 {
   QStringList list;
 
@@ -395,15 +395,41 @@ QStringList QgsLayerTreeUtils::uncheckedGroupList( QgsLayerTreeNode *node )
     const auto constChildren = QgsLayerTree::toGroup( node )->children();
     for ( QgsLayerTreeNode *child : constChildren )
     {
-      if ( child->itemVisibilityChecked() == Qt::Unchecked )
+      index++;
+      if ( QgsLayerTree::isGroup( child ) )
       {
-        QgsLayerTreeGroup *group = QgsLayerTree::toGroup( child );
-        list << group->name() ;
+        if ( child->itemVisibilityChecked() == Qt::Unchecked )
+        {
+          list << QString::number( index ) ;
+        }
+        list << uncheckedGroupList( child, index );
+        index += child->children().count();
       }
-      list << uncheckedGroupList( child );
     }
   }
   return list;
+}
+
+void QgsLayerTreeUtils::setUncheckedGroup( QgsLayerTreeNode *node, const QStringList uncheckedIndexes, int index )
+{
+  if ( QgsLayerTree::isGroup( node ) )
+  {
+    const auto constChildren = QgsLayerTree::toGroup( node )->children();
+    for ( QgsLayerTreeNode *child : constChildren )
+    {
+      index++;
+      if ( QgsLayerTree::isGroup( child ) )
+      {
+        if ( uncheckedIndexes.contains( QString::number( index ) ) )
+        {
+          QgsLayerTreeGroup *group = QgsLayerTree::toGroup( child ) ;
+          group->setItemVisibilityChecked( false );
+        }
+        setUncheckedGroup( child, uncheckedIndexes, index );
+        index += child->children().count();
+      }
+    }
+  }
 }
 
 void QgsLayerTreeUtils::replaceChildrenOfEmbeddedGroups( QgsLayerTreeGroup *group )
@@ -416,7 +442,7 @@ void QgsLayerTreeUtils::replaceChildrenOfEmbeddedGroups( QgsLayerTreeGroup *grou
       if ( child->customProperty( QStringLiteral( "embedded" ) ).toInt() )
       {
         child->setCustomProperty( QStringLiteral( "embedded-invisible-layers" ), invisibleLayerList( child ) );
-        child->setCustomProperty( QStringLiteral( "embedded-unchecked-groups" ), uncheckedGroupList( child ) );
+        child->setCustomProperty( QStringLiteral( "embedded-unchecked-groups" ), uncheckedGroupList( child, 0 ) );
         QgsLayerTree::toGroup( child )->removeAllChildren();
       }
       else

--- a/src/core/layertree/qgslayertreeutils.cpp
+++ b/src/core/layertree/qgslayertreeutils.cpp
@@ -386,6 +386,26 @@ QStringList QgsLayerTreeUtils::invisibleLayerList( QgsLayerTreeNode *node )
   return list;
 }
 
+QStringList QgsLayerTreeUtils::uncheckedGroupList( QgsLayerTreeNode *node )
+{
+  QStringList list;
+
+  if ( QgsLayerTree::isGroup( node ) )
+  {
+    const auto constChildren = QgsLayerTree::toGroup( node )->children();
+    for ( QgsLayerTreeNode *child : constChildren )
+    {
+      if ( child->itemVisibilityChecked() == Qt::Unchecked )
+      {
+        QgsLayerTreeGroup *group = QgsLayerTree::toGroup( child );
+        list << group->name() ;
+      }
+      list << uncheckedGroupList( child );
+    }
+  }
+  return list;
+}
+
 void QgsLayerTreeUtils::replaceChildrenOfEmbeddedGroups( QgsLayerTreeGroup *group )
 {
   const auto constChildren = group->children();
@@ -396,6 +416,7 @@ void QgsLayerTreeUtils::replaceChildrenOfEmbeddedGroups( QgsLayerTreeGroup *grou
       if ( child->customProperty( QStringLiteral( "embedded" ) ).toInt() )
       {
         child->setCustomProperty( QStringLiteral( "embedded-invisible-layers" ), invisibleLayerList( child ) );
+        child->setCustomProperty( QStringLiteral( "embedded-unchecked-groups" ), uncheckedGroupList( child ) );
         QgsLayerTree::toGroup( child )->removeAllChildren();
       }
       else

--- a/src/core/layertree/qgslayertreeutils.cpp
+++ b/src/core/layertree/qgslayertreeutils.cpp
@@ -386,7 +386,7 @@ QStringList QgsLayerTreeUtils::invisibleLayerList( QgsLayerTreeNode *node )
   return list;
 }
 
-QStringList QgsLayerTreeUtils::uncheckedGroupList( QgsLayerTreeNode *node, int index )
+QStringList QgsLayerTreeUtils::uncheckedGroupList( QgsLayerTreeNode *node )
 {
   QStringList list;
 
@@ -395,41 +395,17 @@ QStringList QgsLayerTreeUtils::uncheckedGroupList( QgsLayerTreeNode *node, int i
     const auto constChildren = QgsLayerTree::toGroup( node )->children();
     for ( QgsLayerTreeNode *child : constChildren )
     {
-      index++;
       if ( QgsLayerTree::isGroup( child ) )
       {
         if ( child->itemVisibilityChecked() == Qt::Unchecked )
         {
-          list << QString::number( index ) ;
+          list << QgsLayerTree::toGroup( child )->id() ;
         }
-        list << uncheckedGroupList( child, index );
-        index += child->children().count();
+        list << uncheckedGroupList( child );
       }
     }
   }
   return list;
-}
-
-void QgsLayerTreeUtils::setUncheckedGroup( QgsLayerTreeNode *node, const QStringList uncheckedIndexes, int index )
-{
-  if ( QgsLayerTree::isGroup( node ) )
-  {
-    const auto constChildren = QgsLayerTree::toGroup( node )->children();
-    for ( QgsLayerTreeNode *child : constChildren )
-    {
-      index++;
-      if ( QgsLayerTree::isGroup( child ) )
-      {
-        if ( uncheckedIndexes.contains( QString::number( index ) ) )
-        {
-          QgsLayerTreeGroup *group = QgsLayerTree::toGroup( child ) ;
-          group->setItemVisibilityChecked( false );
-        }
-        setUncheckedGroup( child, uncheckedIndexes, index );
-        index += child->children().count();
-      }
-    }
-  }
 }
 
 void QgsLayerTreeUtils::replaceChildrenOfEmbeddedGroups( QgsLayerTreeGroup *group )
@@ -442,7 +418,7 @@ void QgsLayerTreeUtils::replaceChildrenOfEmbeddedGroups( QgsLayerTreeGroup *grou
       if ( child->customProperty( QStringLiteral( "embedded" ) ).toInt() )
       {
         child->setCustomProperty( QStringLiteral( "embedded-invisible-layers" ), invisibleLayerList( child ) );
-        child->setCustomProperty( QStringLiteral( "embedded-unchecked-groups" ), uncheckedGroupList( child, 0 ) );
+        child->setCustomProperty( QStringLiteral( "embedded-unchecked-groups" ), uncheckedGroupList( child ) );
         QgsLayerTree::toGroup( child )->removeAllChildren();
       }
       else

--- a/src/core/layertree/qgslayertreeutils.h
+++ b/src/core/layertree/qgslayertreeutils.h
@@ -79,11 +79,8 @@ class CORE_EXPORT QgsLayerTreeUtils
     //! Gets invisible layers
     static QStringList invisibleLayerList( QgsLayerTreeNode *node );
 
-    //! Gets unchecked group
-    static QStringList uncheckedGroupList( QgsLayerTreeNode *node, int i );
-
-    //! Set embedded group checked state according to the project
-    static void setUncheckedGroup( QgsLayerTreeNode *node, const QStringList uncheckedIndexes, int index );
+    //! Gets unchecked groups
+    static QStringList uncheckedGroupList( QgsLayerTreeNode *node );
 
     //! Sets the expression filter of a legend layer
     static void setLegendFilterByExpression( QgsLayerTreeLayer &layer, const QString &expr, bool enabled = true );

--- a/src/core/layertree/qgslayertreeutils.h
+++ b/src/core/layertree/qgslayertreeutils.h
@@ -79,6 +79,9 @@ class CORE_EXPORT QgsLayerTreeUtils
     //! Gets invisible layers
     static QStringList invisibleLayerList( QgsLayerTreeNode *node );
 
+    //! Gets unchecked group
+    static QStringList uncheckedGroupList( QgsLayerTreeNode *node );
+
     //! Sets the expression filter of a legend layer
     static void setLegendFilterByExpression( QgsLayerTreeLayer &layer, const QString &expr, bool enabled = true );
     //! Returns the expression filter of a legend layer

--- a/src/core/layertree/qgslayertreeutils.h
+++ b/src/core/layertree/qgslayertreeutils.h
@@ -80,7 +80,10 @@ class CORE_EXPORT QgsLayerTreeUtils
     static QStringList invisibleLayerList( QgsLayerTreeNode *node );
 
     //! Gets unchecked group
-    static QStringList uncheckedGroupList( QgsLayerTreeNode *node );
+    static QStringList uncheckedGroupList( QgsLayerTreeNode *node, int i );
+
+    //! Set embedded group checked state according to the project
+    static void setUncheckedGroup( QgsLayerTreeNode *node, const QStringList uncheckedIndexes, int index );
 
     //! Sets the expression filter of a legend layer
     static void setLegendFilterByExpression( QgsLayerTreeLayer &layer, const QString &expr, bool enabled = true );

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -2861,7 +2861,15 @@ QgsLayerTreeGroup *QgsProject::createEmbeddedGroup( const QString &groupName, co
     }
   }
 
-  QgsLayerTreeUtils::setUncheckedGroup( newGroup, uncheckedGroups, 0 );
+  const auto constChildren = newGroup->children();
+  for ( QgsLayerTreeNode *child : constChildren )
+  {
+    if ( QgsLayerTree::isGroup( child ) )
+    {
+      child->resolveReferences( this );
+      child->setItemVisibilityChecked( !uncheckedGroups.contains( QgsLayerTree::toGroup( child )->id() ) );
+    }
+  }
 
   return newGroup;
 }

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1722,7 +1722,7 @@ bool QgsProject::loadEmbeddedNodes( QgsLayerTreeGroup *group, QgsProject::ReadFl
         // make sure to convert the path from relative to absolute
         QString projectPath = readPath( childGroup->customProperty( QStringLiteral( "embedded_project" ) ).toString() );
         childGroup->setCustomProperty( QStringLiteral( "embedded_project" ), projectPath );
-        QgsLayerTreeGroup *newGroup = createEmbeddedGroup( childGroup->name(), projectPath, childGroup->customProperty( QStringLiteral( "embedded-invisible-layers" ) ).toStringList(), flags );
+        QgsLayerTreeGroup *newGroup = createEmbeddedGroup( childGroup->name(), projectPath, childGroup->customProperty( QStringLiteral( "embedded-invisible-layers" ) ).toStringList(), childGroup->customProperty( QStringLiteral( "embedded-unchecked-groups" ) ).toStringList(), flags );
         if ( newGroup )
         {
           QList<QgsLayerTreeNode *> clonedChildren;
@@ -2788,7 +2788,7 @@ bool QgsProject::createEmbeddedLayer( const QString &layerId, const QString &pro
 }
 
 
-QgsLayerTreeGroup *QgsProject::createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers, QgsProject::ReadFlags flags )
+QgsLayerTreeGroup *QgsProject::createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers, const QStringList &uncheckedGroups, QgsProject::ReadFlags flags )
 {
   QString qgsProjectFile = projectFilePath;
   QgsProjectArchive archive;
@@ -2858,6 +2858,16 @@ QgsLayerTreeGroup *QgsProject::createEmbeddedGroup( const QString &groupName, co
     {
       layer->resolveReferences( this );
       layer->setItemVisibilityChecked( !invisibleLayers.contains( layerId ) );
+    }
+  }
+
+  const auto constFindGroups = newGroup->findGroups();
+  for ( QgsLayerTreeGroup *group : constFindGroups )
+  {
+    if ( group )
+    {
+      group->resolveReferences( this );
+      group->setItemVisibilityChecked( !uncheckedGroups.contains( group->name() ) );
     }
   }
 

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -2861,15 +2861,7 @@ QgsLayerTreeGroup *QgsProject::createEmbeddedGroup( const QString &groupName, co
     }
   }
 
-  const auto constFindGroups = newGroup->findGroups();
-  for ( QgsLayerTreeGroup *group : constFindGroups )
-  {
-    if ( group )
-    {
-      group->resolveReferences( this );
-      group->setItemVisibilityChecked( !uncheckedGroups.contains( group->name() ) );
-    }
-  }
+  QgsLayerTreeUtils::setUncheckedGroup( newGroup, uncheckedGroups, 0 );
 
   return newGroup;
 }

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -564,7 +564,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      *
      * \since QGIS 2.4
      */
-    QgsLayerTreeGroup *createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers, QgsProject::ReadFlags flags = QgsProject::ReadFlags() );
+    QgsLayerTreeGroup *createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers, const QStringList &uncheckedGroups, QgsProject::ReadFlags flags = QgsProject::ReadFlags() );
 
     //! Convenience function to set topological editing
     void setTopologicalEditing( bool enabled );

--- a/tests/src/core/testqgslayertree.cpp
+++ b/tests/src/core/testqgslayertree.cpp
@@ -555,6 +555,8 @@ void TestQgsLayerTree::testEmbeddedGroup()
   QgsVectorLayer *layer1 = new QgsVectorLayer( layerPath, QStringLiteral( "points 1" ), QStringLiteral( "ogr" ) );
   QgsVectorLayer *layer2 = new QgsVectorLayer( layerPath, QStringLiteral( "points 2" ), QStringLiteral( "ogr" ) );
   QgsVectorLayer *layer3 = new QgsVectorLayer( layerPath, QStringLiteral( "points 3" ), QStringLiteral( "ogr" ) );
+  QgsVectorLayer *layer4 = new QgsVectorLayer( layerPath, QStringLiteral( "points 4" ), QStringLiteral( "ogr" ) );
+  QgsVectorLayer *layer5 = new QgsVectorLayer( layerPath, QStringLiteral( "points 5" ), QStringLiteral( "ogr" ) );
 
   QVERIFY( layer1->isValid() );
 
@@ -564,6 +566,10 @@ void TestQgsLayerTree::testEmbeddedGroup()
   grp->addLayer( layer1 );
   grp->addLayer( layer2 );
   grp->addLayer( layer3 );
+  QgsLayerTreeGroup *subgrp1 = grp->addGroup( QStringLiteral( "EmbedSubGroup1" ) );
+  subgrp1->addLayer( layer4 );
+  QgsLayerTreeGroup *subgrp2 = grp->addGroup( QStringLiteral( "EmbedSubGroup2" ) );
+  subgrp2->addLayer( layer5 );
   project.write( projectFilename );
 
   //
@@ -573,13 +579,22 @@ void TestQgsLayerTree::testEmbeddedGroup()
   QgsProject projectMaster;
   QgsLayerTreeGroup *embeddedGroup = projectMaster.createEmbeddedGroup( grp->name(), projectFilename, QStringList(), QStringList() );
   QVERIFY( embeddedGroup );
-  QCOMPARE( embeddedGroup->children().size(), 3 );
+  QCOMPARE( embeddedGroup->children().size(), 5 );
 
   for ( QgsLayerTreeNode *child : embeddedGroup->children() )
   {
-    QVERIFY( QgsLayerTree::toLayer( child )->layer() );
+    if ( QgsLayerTree::isLayer( child ) )
+    {
+      QVERIFY( QgsLayerTree::toLayer( child )->layer() );
+    }
   }
   projectMaster.layerTreeRoot()->addChildNode( embeddedGroup );
+
+  QgsLayerTreeGroup *masterSubGroup1 = projectMaster.layerTreeRoot()->findGroup( QStringLiteral( "EmbedSubGroup1" ) );
+  QCOMPARE( masterSubGroup1->itemVisibilityChecked(), true );
+  QgsLayerTreeGroup *masterSubGroup2 = projectMaster.layerTreeRoot()->findGroup( QStringLiteral( "EmbedSubGroup2" ) );
+  QCOMPARE( masterSubGroup2->itemVisibilityChecked(), true );
+  masterSubGroup2->setItemVisibilityChecked( false );
 
   QString projectMasterFilename = dirPath + QStringLiteral( "/projectMaster.qgs" );
   projectMaster.write( projectMasterFilename );
@@ -589,12 +604,21 @@ void TestQgsLayerTree::testEmbeddedGroup()
   projectMasterCopy.read( projectMasterFilename );
   QgsLayerTreeGroup *masterEmbeddedGroup = projectMasterCopy.layerTreeRoot()->findGroup( QStringLiteral( "Embed" ) );
   QVERIFY( masterEmbeddedGroup );
-  QCOMPARE( masterEmbeddedGroup->children().size(), 3 );
+  QCOMPARE( masterEmbeddedGroup->children().size(), 5 );
 
   for ( QgsLayerTreeNode *child : masterEmbeddedGroup->children() )
   {
-    QVERIFY( QgsLayerTree::toLayer( child )->layer() );
+    if ( QgsLayerTree::isLayer( child ) )
+    {
+      QVERIFY( QgsLayerTree::toLayer( child )->layer() );
+    }
   }
+
+  QgsLayerTreeGroup *copyMasterSubGroup1 = masterEmbeddedGroup->findGroup( QStringLiteral( "EmbedSubGroup1" ) );
+  QCOMPARE( copyMasterSubGroup1->itemVisibilityChecked(), true );
+  QgsLayerTreeGroup *copyMasterSubGroup2 = masterEmbeddedGroup->findGroup( QStringLiteral( "EmbedSubGroup2" ) );
+  QCOMPARE( copyMasterSubGroup2->itemVisibilityChecked(), false );
+
 }
 
 void TestQgsLayerTree::testFindLayer()

--- a/tests/src/core/testqgslayertree.cpp
+++ b/tests/src/core/testqgslayertree.cpp
@@ -571,7 +571,7 @@ void TestQgsLayerTree::testEmbeddedGroup()
   //
 
   QgsProject projectMaster;
-  QgsLayerTreeGroup *embeddedGroup = projectMaster.createEmbeddedGroup( grp->name(), projectFilename, QStringList() );
+  QgsLayerTreeGroup *embeddedGroup = projectMaster.createEmbeddedGroup( grp->name(), projectFilename, QStringList(), QStringList() );
   QVERIFY( embeddedGroup );
   QCOMPARE( embeddedGroup->children().size(), 3 );
 

--- a/tests/src/core/testqgslayertree.cpp
+++ b/tests/src/core/testqgslayertree.cpp
@@ -591,9 +591,9 @@ void TestQgsLayerTree::testEmbeddedGroup()
   projectMaster.layerTreeRoot()->addChildNode( embeddedGroup );
 
   QgsLayerTreeGroup *masterSubGroup1 = projectMaster.layerTreeRoot()->findGroup( QStringLiteral( "EmbedSubGroup1" ) );
-  QCOMPARE( masterSubGroup1->itemVisibilityChecked(), true );
+  QVERIFY( masterSubGroup1->itemVisibilityChecked() );
   QgsLayerTreeGroup *masterSubGroup2 = projectMaster.layerTreeRoot()->findGroup( QStringLiteral( "EmbedSubGroup2" ) );
-  QCOMPARE( masterSubGroup2->itemVisibilityChecked(), true );
+  QVERIFY( masterSubGroup2->itemVisibilityChecked() );
   masterSubGroup2->setItemVisibilityChecked( false );
 
   QString projectMasterFilename = dirPath + QStringLiteral( "/projectMaster.qgs" );
@@ -615,9 +615,9 @@ void TestQgsLayerTree::testEmbeddedGroup()
   }
 
   QgsLayerTreeGroup *copyMasterSubGroup1 = masterEmbeddedGroup->findGroup( QStringLiteral( "EmbedSubGroup1" ) );
-  QCOMPARE( copyMasterSubGroup1->itemVisibilityChecked(), true );
+  QVERIFY( copyMasterSubGroup1->itemVisibilityChecked() );
   QgsLayerTreeGroup *copyMasterSubGroup2 = masterEmbeddedGroup->findGroup( QStringLiteral( "EmbedSubGroup2" ) );
-  QCOMPARE( copyMasterSubGroup2->itemVisibilityChecked(), false );
+  QVERIFY( !copyMasterSubGroup2->itemVisibilityChecked() );
 
 }
 

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -483,7 +483,7 @@ void TestQgsProject::testEmbeddedLayerGroupFromQgz()
 
   QgsProject p1;
   p1.createEmbeddedLayer( points->id(), p0.fileName(), brokenNodes );
-  p1.createEmbeddedGroup( "group1", p0.fileName(), QStringList() );
+  p1.createEmbeddedGroup( "group1", p0.fileName(), QStringList(), QStringList() );
 
   QCOMPARE( p1.layerIsEmbedded( points->id() ), path );
   QCOMPARE( p1.layerIsEmbedded( polys->id() ), path );


### PR DESCRIPTION
## Description

See #35872 

The embedded sub-group checked state is determined by the embedded project and not by the current project. So if the embedded project has an sub-group unchecked, there is no way to save it as checked in the current project.

As we handle layers visibility with the `embedded-invisible-layers` tag, I added a `embedded-unchecked-groups` to handle group checked state.

```xml
  <layer-tree-group>
    <customproperties/>
    <layer-tree-group name="group1" expanded="1" checked="Qt::Checked">
      <customproperties>
        <property key="embedded" value="1"/>
        <property key="embedded-invisible-layers"/>
        <property key="embedded-unchecked-groups" value="sub-group"/>
        <property key="embedded_project" value="./projet.qgs"/>
      </customproperties>
    </layer-tree-group>
```

I added elements in testEmbeddedGroup ([testqgslayertree.cpp](https://github.com/SebastienPeillet/QGIS/blob/9020f0dd97fcf2ef7c8e0f7ac5b5c0fd978a6067b/tests/src/core/testqgslayertree.cpp#L538)) to verify the sub-group checked state works.