### PR TITLE
[feature] Curved geometries support for trace tool

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1231,6 +1231,21 @@ Curved geometry types are automatically segmentized by this routine.
 .. versionadded:: 3.0
 %End
 
+    QgsGeometry convertToCurves( double distanceTolerance = 1e-8, double angleTolerance = 1e-8 ) const;
+%Docstring
+Attempts to convert a non-curved geometry into a curved geometry type (e.g.
+LineString to CompoundCurve, Polygon to CurvePolygon).
+
+The ``distanceTolerance`` specifies the maximum deviation allowed between the original location
+of vertices and where they would fall on the candidate curved geometry.
+
+This method only consider a segments as suitable for replacing with an arc if the points are all
+regularly spaced on the candidate arc. The ``pointSpacingAngleTolerance`` parameter specifies the maximum
+angular deviation (in radians) allowed when testing for regular point spacing.
+
+.. versionadded:: 3.14
+%End
+
     QgsGeometry centroid() const;
 %Docstring
 Returns the center of mass of a geometry.

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1243,6 +1243,10 @@ This method only consider a segments as suitable for replacing with an arc if th
 regularly spaced on the candidate arc. The ``pointSpacingAngleTolerance`` parameter specifies the maximum
 angular deviation (in radians) allowed when testing for regular point spacing.
 
+.. note::
+
+   The API is considered EXPERIMENTAL and can be changed without a notice
+
 .. versionadded:: 3.14
 %End
 

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -242,7 +242,7 @@ Project the point on a segment
 
     static int leftOfLine( const double x, const double y, const double x1, const double y1, const double x2, const double y2 );
 %Docstring
-Returns a value < 0 if the point (``x``, ``y``) is left of the line from (``x1``, ``y1``) -> ( ``x2``, ``y2``).
+Returns a value < 0 if the point (``x``, ``y``) is left of the line from (``x1``, ``y1``) -> (``x2``, ``y2``).
 A positive return value indicates the point is to the right of the line.
 
 If the return value is 0, then the test was unsuccessful (e.g. due to testing a point exactly
@@ -352,6 +352,22 @@ Calculates the direction angle of a circle tangent (clockwise from north in radi
 Convert circular arc defined by p1, p2, p3 (p1/p3 being start resp. end point, p2 lies on the arc) into a sequence of points.
 
 .. versionadded:: 3.0
+%End
+
+    static bool pointContinuesArc( const QgsPoint &a1, const QgsPoint &a2, const QgsPoint &a3, const QgsPoint &b, double distanceTolerance,
+                                   double pointSpacingAngleTolerance );
+%Docstring
+Returns true if point ``b`` is on the arc formed by points ``a1``, ``a2``, and ``a3``, but not within
+that arc portion already described by ``a1``, ``a2`` and ``a3``.
+
+The ``distanceTolerance`` specifies the maximum deviation allowed between the original location
+of point \b and where it would fall on the candidate arc.
+
+This method only consider a segments as continuing an arc if the points are all regularly spaced
+on the candidate arc. The ``pointSpacingAngleTolerance`` parameter specifies the maximum
+angular deviation (in radians) allowed when testing for regular point spacing.
+
+.. versionadded:: 3.14
 %End
 
     static int segmentSide( const QgsPoint &pt1, const QgsPoint &pt3, const QgsPoint &pt2 );

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -367,6 +367,10 @@ This method only consider a segments as continuing an arc if the points are all 
 on the candidate arc. The ``pointSpacingAngleTolerance`` parameter specifies the maximum
 angular deviation (in radians) allowed when testing for regular point spacing.
 
+.. note::
+
+   The API is considered EXPERIMENTAL and can be changed without a notice
+
 .. versionadded:: 3.14
 %End
 

--- a/python/gui/auto_generated/qgsmaptoolcapture.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolcapture.sip.in
@@ -27,12 +27,26 @@ class QgsMapToolCapture : QgsMapToolAdvancedDigitizing
       CapturePolygon
     };
 
+    enum Capability
+    {
+      NoCapabilities,
+      SupportsCurves,
+    };
+
+    typedef QFlags<QgsMapToolCapture::Capability> Capabilities;
+
+
     QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode );
 %Docstring
 constructor
 %End
 
     ~QgsMapToolCapture();
+
+    virtual QgsMapToolCapture::Capabilities capabilities() const;
+%Docstring
+Returns flags containing the supported capabilities
+%End
 
     virtual void activate();
 
@@ -265,6 +279,9 @@ Stop capturing
 %End
 
 };
+
+QFlags<QgsMapToolCapture::Capability> operator|(QgsMapToolCapture::Capability f1, QFlags<QgsMapToolCapture::Capability> f2);
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/gui/auto_generated/qgsmaptooldigitizefeature.sip.in
+++ b/python/gui/auto_generated/qgsmaptooldigitizefeature.sip.in
@@ -32,6 +32,9 @@ QgsMapToolDigitizeFeature is a map tool to digitize a feature geometry
 :param mode: type of geometry to capture (point/line/polygon), QgsMapToolCapture.CaptureNone to autodetect geometry
 %End
 
+    virtual QgsMapToolCapture::Capabilities capabilities() const;
+
+
     virtual void cadCanvasReleaseEvent( QgsMapMouseEvent *e );
 
 

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -39,6 +39,7 @@ SET(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmclip.cpp
   processing/qgsalgorithmconditionalbranch.cpp
   processing/qgsalgorithmconstantraster.cpp
+  processing/qgsalgorithmconverttocurves.cpp
   processing/qgsalgorithmconvexhull.cpp
   processing/qgsalgorithmdbscanclustering.cpp
   processing/qgsalgorithmdeleteduplicategeometries.cpp

--- a/src/analysis/processing/qgsalgorithmconverttocurves.cpp
+++ b/src/analysis/processing/qgsalgorithmconverttocurves.cpp
@@ -1,0 +1,157 @@
+/***************************************************************************
+                         qgsalgorithmconverttocurves.cpp
+                         ---------------------
+    begin                : March 2018
+    copyright            : (C) 2018 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmconverttocurves.h"
+
+///@cond PRIVATE
+
+QString QgsConvertToCurvesAlgorithm::name() const
+{
+  return QStringLiteral( "converttocurves" );
+}
+
+QString QgsConvertToCurvesAlgorithm::displayName() const
+{
+  return QObject::tr( "Convert to curved geometries" );
+}
+
+QStringList QgsConvertToCurvesAlgorithm::tags() const
+{
+  return QObject::tr( "straight,segmentize,curves,curved,circular" ).split( ',' );
+}
+
+QString QgsConvertToCurvesAlgorithm::group() const
+{
+  return QObject::tr( "Vector geometry" );
+}
+
+QString QgsConvertToCurvesAlgorithm::groupId() const
+{
+  return QStringLiteral( "vectorgeometry" );
+}
+
+QString QgsConvertToCurvesAlgorithm::outputName() const
+{
+  return QObject::tr( "Curves" );
+}
+
+QString QgsConvertToCurvesAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm converts a geometry into its curved geometry equivalent.\n\n"
+                      "Already curved geometries will be retained without change." );
+}
+
+QgsConvertToCurvesAlgorithm *QgsConvertToCurvesAlgorithm::createInstance() const
+{
+  return new QgsConvertToCurvesAlgorithm();
+}
+
+QList<int> QgsConvertToCurvesAlgorithm::inputLayerTypes() const
+{
+  return QList<int>() << QgsProcessing::TypeVectorLine << QgsProcessing::TypeVectorPolygon;
+}
+
+void QgsConvertToCurvesAlgorithm::initParameters( const QVariantMap & )
+{
+  std::unique_ptr< QgsProcessingParameterNumber > tolerance = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "DISTANCE" ),
+      QObject::tr( "Maximum distance tolerance" ), QgsProcessingParameterNumber::Double,
+      0.000001, false, 0, 10000000.0 );
+  tolerance->setIsDynamic( true );
+  tolerance->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "DISTANCE" ), QObject::tr( "Maximum distance tolerance" ), QgsPropertyDefinition::DoublePositive ) );
+  tolerance->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( tolerance.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > angleTolerance = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "ANGLE" ),
+      QObject::tr( "Maximum angle tolerance" ), QgsProcessingParameterNumber::Double,
+      0.000001, false, 0, 45.0 );
+  angleTolerance->setIsDynamic( true );
+  angleTolerance->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "ANGLE" ), QObject::tr( "Maximum angle tolerance" ), QgsPropertyDefinition::DoublePositive ) );
+  angleTolerance->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( angleTolerance.release() );
+}
+
+bool QgsConvertToCurvesAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  mTolerance = parameterAsDouble( parameters, QStringLiteral( "DISTANCE" ), context );
+  mDynamicTolerance = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "DISTANCE" ) );
+  if ( mDynamicTolerance )
+    mToleranceProperty = parameters.value( QStringLiteral( "DISTANCE" ) ).value< QgsProperty >();
+
+  mAngleTolerance = parameterAsDouble( parameters, QStringLiteral( "ANGLE" ), context );
+  mDynamicAngleTolerance = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "ANGLE" ) );
+  if ( mDynamicAngleTolerance )
+    mAngleToleranceProperty = parameters.value( QStringLiteral( "ANGLE" ) ).value< QgsProperty >();
+
+  return true;
+}
+
+QgsFeatureList QgsConvertToCurvesAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  QgsFeature f = feature;
+  if ( f.hasGeometry() )
+  {
+    QgsGeometry geometry = f.geometry();
+    double tolerance = mTolerance;
+    if ( mDynamicTolerance )
+      tolerance = mToleranceProperty.valueAsDouble( context.expressionContext(), tolerance );
+    double angleTolerance = mAngleTolerance;
+    if ( mDynamicAngleTolerance )
+      angleTolerance = mAngleToleranceProperty.valueAsDouble( context.expressionContext(), angleTolerance );
+
+    f.setGeometry( geometry.convertToCurves( tolerance, angleTolerance * M_PI / 180.0 ) );
+  }
+  return QgsFeatureList() << f;
+}
+
+QgsWkbTypes::Type QgsConvertToCurvesAlgorithm::outputWkbType( QgsWkbTypes::Type inputWkbType ) const
+{
+  if ( QgsWkbTypes::isCurvedType( inputWkbType ) )
+    return inputWkbType;
+
+  QgsWkbTypes::Type outType = QgsWkbTypes::Unknown;
+  switch ( QgsWkbTypes::geometryType( inputWkbType ) )
+  {
+    case QgsWkbTypes::PointGeometry:
+    case QgsWkbTypes::NullGeometry:
+    case QgsWkbTypes::UnknownGeometry:
+      return inputWkbType;
+
+    case QgsWkbTypes::LineGeometry:
+      outType = QgsWkbTypes::CompoundCurve;
+      break;
+
+    case QgsWkbTypes::PolygonGeometry:
+      outType = QgsWkbTypes::CurvePolygon;
+      break;
+  }
+
+  if ( QgsWkbTypes::isMultiType( inputWkbType ) )
+    outType = QgsWkbTypes::multiType( outType );
+
+  if ( QgsWkbTypes::hasZ( inputWkbType ) )
+    outType = QgsWkbTypes::addZ( outType );
+
+  if ( QgsWkbTypes::hasM( inputWkbType ) )
+    outType = QgsWkbTypes::addM( outType );
+
+  return outType;
+}
+
+
+///@endcond
+
+

--- a/src/analysis/processing/qgsalgorithmconverttocurves.h
+++ b/src/analysis/processing/qgsalgorithmconverttocurves.h
@@ -1,0 +1,70 @@
+/***************************************************************************
+                         qgsalgorithmconverttocurves.h
+                         ---------------------
+    begin                : March 2018
+    copyright            : (C) 2018 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMSEGMENTIZE_H
+#define QGSALGORITHMSEGMENTIZE_H
+
+#define SIP_NO_FILE
+
+#include "qgis.h"
+#include "qgsprocessingalgorithm.h"
+#include "qgsmaptopixelgeometrysimplifier.h"
+
+///@cond PRIVATE
+
+/**
+ * Native segmentize by maximum distance algorithm.
+ */
+class QgsConvertToCurvesAlgorithm : public QgsProcessingFeatureBasedAlgorithm
+{
+
+  public:
+
+    QgsConvertToCurvesAlgorithm() = default;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QgsConvertToCurvesAlgorithm *createInstance() const override SIP_FACTORY;
+    QList<int> inputLayerTypes() const override;
+    void initParameters( const QVariantMap &configuration = QVariantMap() ) override;
+
+  protected:
+    QString outputName() const override;
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &, QgsProcessingFeedback *feedback ) override;
+    QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type inputWkbType ) const override;
+
+  private:
+
+    double mTolerance = 0.000001;
+    bool mDynamicTolerance = false;
+    QgsProperty mToleranceProperty;
+
+    double mAngleTolerance = 0.000001;
+    bool mDynamicAngleTolerance = false;
+    QgsProperty mAngleToleranceProperty;
+
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMSEGMENTIZE_H
+
+

--- a/src/analysis/processing/qgsalgorithmconverttocurves.h
+++ b/src/analysis/processing/qgsalgorithmconverttocurves.h
@@ -15,8 +15,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef QGSALGORITHMSEGMENTIZE_H
-#define QGSALGORITHMSEGMENTIZE_H
+#ifndef QGSALGORITHMCONVERTTOCURVES_H
+#define QGSALGORITHMCONVERTTOCURVES_H
 
 #define SIP_NO_FILE
 
@@ -65,6 +65,6 @@ class QgsConvertToCurvesAlgorithm : public QgsProcessingFeatureBasedAlgorithm
 
 ///@endcond PRIVATE
 
-#endif // QGSALGORITHMSEGMENTIZE_H
+#endif // QGSALGORITHMCONVERTTOCURVES_H
 
 

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -34,6 +34,7 @@
 #include "qgsalgorithmclip.h"
 #include "qgsalgorithmconditionalbranch.h"
 #include "qgsalgorithmconstantraster.h"
+#include "qgsalgorithmconverttocurves.h"
 #include "qgsalgorithmconvexhull.h"
 #include "qgsalgorithmdbscanclustering.h"
 #include "qgsalgorithmdeleteduplicategeometries.h"
@@ -231,6 +232,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsCombineStylesAlgorithm() );
   addAlgorithm( new QgsConditionalBranchAlgorithm() );
   addAlgorithm( new QgsConstantRasterAlgorithm() );
+  addAlgorithm( new QgsConvertToCurvesAlgorithm() );
   addAlgorithm( new QgsConvexHullAlgorithm() );
   addAlgorithm( new QgsDbscanClusteringAlgorithm() );
   addAlgorithm( new QgsDeleteDuplicateGeometriesAlgorithm() );

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -35,6 +35,11 @@ QgsMapToolAddPart::QgsMapToolAddPart( QgsMapCanvas *canvas )
   connect( QgisApp::instance(), &QgisApp::projectRead, this, &QgsMapToolAddPart::stopCapturing );
 }
 
+QgsMapToolCapture::Capabilities QgsMapToolAddPart::capabilities() const
+{
+  return QgsMapToolCapture::SupportsCurves;
+}
+
 void QgsMapToolAddPart::canvasReleaseEvent( QgsMapMouseEvent *e )
 {
   if ( checkSelection() )

--- a/src/app/qgsmaptooladdpart.h
+++ b/src/app/qgsmaptooladdpart.h
@@ -23,6 +23,8 @@ class APP_EXPORT QgsMapToolAddPart : public QgsMapToolCapture
   public:
     QgsMapToolAddPart( QgsMapCanvas *canvas );
 
+    QgsMapToolCapture::Capabilities capabilities() const override;
+
     void canvasReleaseEvent( QgsMapMouseEvent *e ) override;
     void cadCanvasReleaseEvent( QgsMapMouseEvent *e ) override;
 

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -1110,6 +1110,8 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mOffsetQuadSegSpinBox->setValue( mSettings->value( QStringLiteral( "/qgis/digitizing/offset_quad_seg" ), 8 ).toInt() );
   mCurveOffsetMiterLimitComboBox->setValue( mSettings->value( QStringLiteral( "/qgis/digitizing/offset_miter_limit" ), 5.0 ).toDouble() );
 
+  mTracingConvertToCurveCheckBox->setChecked( mSettings->value( QStringLiteral( "/qgis/digitizing/convert_to_curve" ), false ).toBool() );
+
   // load gdal driver list only when gdal tab is first opened
   mLoadedGdalDriverList = false;
 
@@ -1712,6 +1714,8 @@ void QgsOptions::saveOptions()
   mSettings->setEnumValue( QStringLiteral( "/qgis/digitizing/offset_join_style" ), mOffsetJoinStyleComboBox->currentData().value<QgsGeometry::JoinStyle>() );
   mSettings->setValue( QStringLiteral( "/qgis/digitizing/offset_quad_seg" ), mOffsetQuadSegSpinBox->value() );
   mSettings->setValue( QStringLiteral( "/qgis/digitizing/offset_miter_limit" ), mCurveOffsetMiterLimitComboBox->value() );
+
+  mSettings->setValue( QStringLiteral( "/qgis/digitizing/convert_to_curve" ), mTracingConvertToCurveCheckBox->isChecked() );
 
   // default scale list
   QString myPaths;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2129,6 +2129,13 @@ QgsGeometry QgsGeometry::densifyByDistance( double distance ) const
   return engine.densifyByDistance( distance );
 }
 
+QgsGeometry QgsGeometry::convertToCurves( double distanceTolerance, double angleTolerance ) const
+{
+  QgsInternalGeometryEngine engine( *this );
+
+  return engine.convertToCurves( distanceTolerance, angleTolerance );
+}
+
 QgsGeometry QgsGeometry::centroid() const
 {
   if ( !d->geometry )

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1244,6 +1244,21 @@ class CORE_EXPORT QgsGeometry
     QgsGeometry densifyByDistance( double distance ) const;
 
     /**
+     * Attempts to convert a non-curved geometry into a curved geometry type (e.g.
+     * LineString to CompoundCurve, Polygon to CurvePolygon).
+     *
+     * The \a distanceTolerance specifies the maximum deviation allowed between the original location
+     * of vertices and where they would fall on the candidate curved geometry.
+     *
+     * This method only consider a segments as suitable for replacing with an arc if the points are all
+     * regularly spaced on the candidate arc. The \a pointSpacingAngleTolerance parameter specifies the maximum
+     * angular deviation (in radians) allowed when testing for regular point spacing.
+     *
+     * \since QGIS 3.2
+     */
+    QgsGeometry convertToCurves( double distanceTolerance = 1e-8, double angleTolerance = 1e-8 ) const;
+
+    /**
      * Returns the center of mass of a geometry.
      *
      * If the input is a NULL geometry, the output will also be a NULL geometry.

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1254,6 +1254,8 @@ class CORE_EXPORT QgsGeometry
      * regularly spaced on the candidate arc. The \a pointSpacingAngleTolerance parameter specifies the maximum
      * angular deviation (in radians) allowed when testing for regular point spacing.
      *
+     * \note The API is considered EXPERIMENTAL and can be changed without a notice
+     *
      * \since QGIS 3.14
      */
     QgsGeometry convertToCurves( double distanceTolerance = 1e-8, double angleTolerance = 1e-8 ) const;

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1254,7 +1254,7 @@ class CORE_EXPORT QgsGeometry
      * regularly spaced on the candidate arc. The \a pointSpacingAngleTolerance parameter specifies the maximum
      * angular deviation (in radians) allowed when testing for regular point spacing.
      *
-     * \since QGIS 3.2
+     * \since QGIS 3.14
      */
     QgsGeometry convertToCurves( double distanceTolerance = 1e-8, double angleTolerance = 1e-8 ) const;
 

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -262,7 +262,7 @@ class CORE_EXPORT QgsGeometryUtils
     static QVector<SelfIntersection> selfIntersections( const QgsAbstractGeometry *geom, int part, int ring, double tolerance ) SIP_SKIP;
 
     /**
-     * Returns a value < 0 if the point (\a x, \a y) is left of the line from (\a x1, \a y1) -> ( \a x2, \a y2).
+     * Returns a value < 0 if the point (\a x, \a y) is left of the line from (\a x1, \a y1) -> (\a x2, \a y2).
      * A positive return value indicates the point is to the right of the line.
      *
      * If the return value is 0, then the test was unsuccessful (e.g. due to testing a point exactly
@@ -371,6 +371,22 @@ class CORE_EXPORT QgsGeometryUtils
                                QgsPointSequence SIP_PYALTERNATIVETYPE( QVector<QgsPoint> ) &points SIP_OUT, double tolerance = M_PI_2 / 90,
                                QgsAbstractGeometry::SegmentationToleranceType toleranceType = QgsAbstractGeometry::MaximumAngle,
                                bool hasZ = false, bool hasM = false );
+
+    /**
+     * Returns true if point \a b is on the arc formed by points \a a1, \a a2, and \a a3, but not within
+     * that arc portion already described by \a a1, \a a2 and \a a3.
+     *
+     * The \a distanceTolerance specifies the maximum deviation allowed between the original location
+     * of point \b and where it would fall on the candidate arc.
+     *
+     * This method only consider a segments as continuing an arc if the points are all regularly spaced
+     * on the candidate arc. The \a pointSpacingAngleTolerance parameter specifies the maximum
+     * angular deviation (in radians) allowed when testing for regular point spacing.
+     *
+     * \since QGIS 3.2
+     */
+    static bool pointContinuesArc( const QgsPoint &a1, const QgsPoint &a2, const QgsPoint &a3, const QgsPoint &b, double distanceTolerance,
+                                   double pointSpacingAngleTolerance );
 
     /**
      * For line defined by points pt1 and pt3, find out on which side of the line is point pt3.

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -383,7 +383,7 @@ class CORE_EXPORT QgsGeometryUtils
      * on the candidate arc. The \a pointSpacingAngleTolerance parameter specifies the maximum
      * angular deviation (in radians) allowed when testing for regular point spacing.
      *
-     * \since QGIS 3.2
+     * \since QGIS 3.14
      */
     static bool pointContinuesArc( const QgsPoint &a1, const QgsPoint &a2, const QgsPoint &a3, const QgsPoint &b, double distanceTolerance,
                                    double pointSpacingAngleTolerance );

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -383,6 +383,8 @@ class CORE_EXPORT QgsGeometryUtils
      * on the candidate arc. The \a pointSpacingAngleTolerance parameter specifies the maximum
      * angular deviation (in radians) allowed when testing for regular point spacing.
      *
+     * \note The API is considered EXPERIMENTAL and can be changed without a notice
+     *
      * \since QGIS 3.14
      */
     static bool pointContinuesArc( const QgsPoint &a1, const QgsPoint &a2, const QgsPoint &a3, const QgsPoint &b, double distanceTolerance,

--- a/src/core/geometry/qgsinternalgeometryengine.cpp
+++ b/src/core/geometry/qgsinternalgeometryengine.cpp
@@ -20,6 +20,7 @@
 #include "qgsmultipolygon.h"
 #include "qgspolygon.h"
 #include "qgsmulticurve.h"
+#include "qgscircularstring.h"
 #include "qgsgeometry.h"
 #include "qgsgeometryutils.h"
 #include "qgslinesegment.h"
@@ -1166,4 +1167,257 @@ QVector<QgsPointXY> QgsInternalGeometryEngine::randomPointsInPolygon( const QgsG
     }
   }
   return result;
+}
+
+// ported from PostGIS' lwgeom pta_unstroke
+
+std::unique_ptr< QgsCompoundCurve > lineToCurve( const QgsLineString *lineString, double distanceTolerance,
+    double pointSpacingAngleTolerance )
+{
+  std::unique_ptr< QgsCompoundCurve > out = qgis::make_unique< QgsCompoundCurve >();
+
+  /* Minimum number of edges, per quadrant, required to define an arc */
+  const unsigned int minQuadEdges = 2;
+
+  /* Die on null input */
+  if ( !lineString )
+    return nullptr;
+
+  /* Null on empty input? */
+  if ( lineString->nCoordinates() == 0 )
+    return nullptr;
+
+  /* We can't desegmentize anything shorter than four points */
+  if ( lineString->nCoordinates() < 4 )
+  {
+    out->addCurve( lineString->clone() );
+    return out;
+  }
+
+  /* Allocate our result array of vertices that are part of arcs */
+  int numEdges = lineString->nCoordinates() - 1;
+  QVector< int > edgesInArcs( numEdges + 1, 0 );
+
+  auto arcAngle = []( const QgsPoint & a, const QgsPoint & b, const QgsPoint & c )->double
+  {
+    double abX = b.x() - a.x();
+    double abY = b.y() - a.y();
+
+    double cbX = b.x() - c.x();
+    double cbY = b.y() - c.y();
+
+    double dot = ( abX * cbX + abY * cbY ); /* dot product */
+    double cross = ( abX * cbY - abY * cbX ); /* cross product */
+
+    double alpha = std::atan2( cross, dot );
+
+    return alpha;
+  };
+
+  /* We make a candidate arc of the first two edges, */
+  /* And then see if the next edge follows it */
+  int i = 0;
+  int j = 0;
+  int k = 0;
+  int currentArc = 1;
+  QgsPoint a1;
+  QgsPoint a2;
+  QgsPoint a3;
+  QgsPoint b;
+  double centerX = 0.0;
+  double centerY = 0.0;
+  double radius = 0;
+
+  while ( i < numEdges - 2 )
+  {
+    unsigned int arcEdges = 0;
+    double numQuadrants = 0;
+    double angle;
+
+    bool foundArc = false;
+    /* Make candidate arc */
+    a1 = lineString->pointN( i );
+    a2 = lineString->pointN( i + 1 );
+    a3 = lineString->pointN( i + 2 );
+    QgsPoint first = a1;
+
+    for ( j = i + 3; j < numEdges + 1; j++ )
+    {
+      b = lineString->pointN( j );
+
+      /* Does this point fall on our candidate arc? */
+      if ( QgsGeometryUtils::pointContinuesArc( a1, a2, a3, b, distanceTolerance, pointSpacingAngleTolerance ) )
+      {
+        /* Yes. Mark this edge and the two preceding it as arc components */
+        foundArc = true;
+        for ( k = j - 1; k > j - 4; k-- )
+          edgesInArcs[k] = currentArc;
+      }
+      else
+      {
+        /* No. So we're done with this candidate arc */
+        currentArc++;
+        break;
+      }
+
+      a1 = a2;
+      a2 = a3;
+      a3 = b;
+    }
+    /* Jump past all the edges that were added to the arc */
+    if ( foundArc )
+    {
+      /* Check if an arc was composed by enough edges to be
+       * really considered an arc
+       * See http://trac.osgeo.org/postgis/ticket/2420
+       */
+      arcEdges = j - 1 - i;
+      if ( first.x() == b.x() && first.y() == b.y() )
+      {
+        numQuadrants = 4;
+      }
+      else
+      {
+        QgsGeometryUtils::circleCenterRadius( first, b, a1, radius, centerX, centerY );
+
+        angle = arcAngle( first, QgsPoint( centerX, centerY ), b );
+        int p2Side = QgsGeometryUtils::leftOfLine( b.x(), b.y(), first.x(), first.y(), a1.x(), a1.y() );
+        if ( p2Side >= 0 )
+          angle = -angle;
+
+        if ( angle < 0 )
+          angle = 2 * M_PI + angle;
+        numQuadrants = ( 4 * angle ) / ( 2 * M_PI );
+      }
+      /* a1 is first point, b is last point */
+      if ( arcEdges < minQuadEdges * numQuadrants )
+      {
+        // LWDEBUGF( 4, "Not enough edges for a %g quadrants arc, %g needed", num_quadrants, min_quad_edges * num_quadrants );
+        for ( k = j - 1; k >= i; k-- )
+          edgesInArcs[k] = 0;
+      }
+
+      i = j - 1;
+    }
+    else
+    {
+      /* Mark this edge as a linear edge */
+      edgesInArcs[i] = 0;
+      i = i + 1;
+    }
+  }
+
+  int start = 0;
+  int end = 0;
+  /* non-zero if edge is part of an arc */
+  int edgeType = edgesInArcs[0];
+
+  auto addPointsToCurve = [ lineString, &out ]( int start, int end, int type )
+  {
+    if ( type == 0 )
+    {
+      // straight segment
+      QVector< QgsPoint > points;
+      for ( int j = start; j < end + 2; ++ j )
+      {
+        points.append( lineString->pointN( j ) );
+      }
+      std::unique_ptr< QgsCurve > straightSegment = qgis::make_unique< QgsLineString >( points );
+      out->addCurve( straightSegment.release() );
+    }
+    else
+    {
+      // curved segment
+      QVector< QgsPoint > points;
+      points.append( lineString->pointN( start ) );
+      points.append( lineString->pointN( ( start + end + 1 ) / 2 ) );
+      points.append( lineString->pointN( end + 1 ) );
+      std::unique_ptr< QgsCircularString > curvedSegment = qgis::make_unique< QgsCircularString >();
+      curvedSegment->setPoints( points );
+      out->addCurve( curvedSegment.release() );
+    }
+  };
+
+  for ( int i = 1; i < numEdges; i++ )
+  {
+    if ( edgeType != edgesInArcs[i] )
+    {
+      end = i - 1;
+      addPointsToCurve( start, end, edgeType );
+      start = i;
+      edgeType = edgesInArcs[i];
+    }
+  }
+
+  /* Roll out last item */
+  end = numEdges - 1;
+  addPointsToCurve( start, end, edgeType );
+
+  return out;
+}
+
+std::unique_ptr< QgsAbstractGeometry > convertGeometryToCurves( const QgsAbstractGeometry *geom, double distanceTolerance, double angleTolerance )
+{
+  if ( QgsWkbTypes::geometryType( geom->wkbType() ) == QgsWkbTypes::LineGeometry )
+  {
+    return lineToCurve( static_cast< const QgsLineString * >( geom ), distanceTolerance, angleTolerance );
+  }
+  else
+  {
+    // polygon
+    const QgsPolygon *polygon = static_cast< const QgsPolygon * >( geom );
+    std::unique_ptr< QgsCurvePolygon > result = qgis::make_unique< QgsCurvePolygon>();
+
+    result->setExteriorRing( lineToCurve( static_cast< const QgsLineString * >( polygon->exteriorRing() ),
+                                          distanceTolerance, angleTolerance ).release() );
+    for ( int i = 0; i < polygon->numInteriorRings(); ++i )
+    {
+      result->addInteriorRing( lineToCurve( static_cast< const QgsLineString * >( polygon->interiorRing( i ) ),
+                                            distanceTolerance, angleTolerance ).release() );
+    }
+
+    return result;
+  }
+}
+
+QgsGeometry QgsInternalGeometryEngine::convertToCurves( double distanceTolerance, double angleTolerance ) const
+{
+  if ( !mGeometry )
+  {
+    return QgsGeometry();
+  }
+
+  if ( QgsWkbTypes::geometryType( mGeometry->wkbType() ) == QgsWkbTypes::PointGeometry )
+  {
+    return QgsGeometry( mGeometry->clone() ); // point geometry, nothing to do
+  }
+
+  if ( QgsWkbTypes::isCurvedType( mGeometry->wkbType() ) )
+  {
+    // already curved. In future we may want to allow this, and convert additional candidate segments
+    // in an already curved geometry to curves
+    return QgsGeometry( mGeometry->clone() );
+  }
+
+  if ( const QgsGeometryCollection *gc = qgsgeometry_cast< const QgsGeometryCollection *>( mGeometry ) )
+  {
+    int numGeom = gc->numGeometries();
+    QVector< QgsAbstractGeometry * > geometryList;
+    geometryList.reserve( numGeom );
+    for ( int i = 0; i < numGeom; ++i )
+    {
+      geometryList << convertGeometryToCurves( gc->geometryN( i ), distanceTolerance, angleTolerance ).release();
+    }
+
+    QgsGeometry first = QgsGeometry( geometryList.takeAt( 0 ) );
+    for ( QgsAbstractGeometry *g : qgis::as_const( geometryList ) )
+    {
+      first.addPart( g );
+    }
+    return first;
+  }
+  else
+  {
+    return QgsGeometry( convertGeometryToCurves( mGeometry, distanceTolerance, angleTolerance ) );
+  }
 }

--- a/src/core/geometry/qgsinternalgeometryengine.h
+++ b/src/core/geometry/qgsinternalgeometryengine.h
@@ -166,6 +166,21 @@ class QgsInternalGeometryEngine
     static QVector< QgsPointXY > randomPointsInPolygon( const QgsGeometry &polygon, int count,
         const std::function< bool( const QgsPointXY & ) > &acceptPoint, unsigned long seed = 0, QgsFeedback *feedback = nullptr );
 
+    /**
+     * Attempts to convert a non-curved geometry into a curved geometry type (e.g.
+     * LineString to CompoundCurve, Polygon to CurvePolygon).
+     *
+     * The \a distanceTolerance specifies the maximum deviation allowed between the original location
+     * of vertices and where they would fall on the candidate curved geometry.
+     *
+     * This method only consider a segments as suitable for replacing with an arc if the points are all
+     * regularly spaced on the candidate arc. The \a pointSpacingAngleTolerance parameter specifies the maximum
+     * angular deviation (in radians) allowed when testing for regular point spacing.
+     *
+     * \since QGIS 3.2
+     */
+    QgsGeometry convertToCurves( double distanceTolerance, double angleTolerance ) const;
+
   private:
     const QgsAbstractGeometry *mGeometry = nullptr;
 };

--- a/src/core/geometry/qgsinternalgeometryengine.h
+++ b/src/core/geometry/qgsinternalgeometryengine.h
@@ -177,6 +177,8 @@ class QgsInternalGeometryEngine
      * regularly spaced on the candidate arc. The \a pointSpacingAngleTolerance parameter specifies the maximum
      * angular deviation (in radians) allowed when testing for regular point spacing.
      *
+     * \note The API is considered EXPERIMENTAL and can be changed without a notice
+     *
      * \since QGIS 3.14
      */
     QgsGeometry convertToCurves( double distanceTolerance, double angleTolerance ) const;

--- a/src/core/geometry/qgsinternalgeometryengine.h
+++ b/src/core/geometry/qgsinternalgeometryengine.h
@@ -177,7 +177,7 @@ class QgsInternalGeometryEngine
      * regularly spaced on the candidate arc. The \a pointSpacingAngleTolerance parameter specifies the maximum
      * angular deviation (in radians) allowed when testing for regular point spacing.
      *
-     * \since QGIS 3.2
+     * \since QGIS 3.14
      */
     QgsGeometry convertToCurves( double distanceTolerance, double angleTolerance ) const;
 

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -290,8 +290,9 @@ bool QgsMapToolCapture::tracingAddVertex( const QgsPointXY &point )
   }
 
   // If the layer supports curves, we de-approximate curves
+  QgsSettings settings;
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mCanvas->currentLayer() );
-  if ( vlayer->dataProvider()->capabilities().testFlag( QgsVectorDataProvider::Capability::CircularGeometries ) )
+  if ( vlayer->dataProvider()->capabilities().testFlag( QgsVectorDataProvider::Capability::CircularGeometries ) && settings.value( QStringLiteral( "/qgis/digitizing/convert_to_curve" ), false ).toBool() )
   {
     QgsGeometry linear = QgsGeometry( mCaptureCurve.segmentize() );
     QgsGeometry curved = linear.convertToCurves();

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -13,8 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <ogr_api.h>
-#include <ogr_geometry.h>
+#include "ogr_srs_api.h"
 
 #include "qgsmaptoolcapture.h"
 #include "qgsexception.h"
@@ -26,6 +25,7 @@
 #include "qgsmapcanvas.h"
 #include "qgsmapcanvastracer.h"
 #include "qgsmapmouseevent.h"
+#include "qgsogrutils.h"
 #include "qgspolygon.h"
 #include "qgsrubberband.h"
 #include "qgssnapindicator.h"
@@ -296,34 +296,22 @@ bool QgsMapToolCapture::tracingAddVertex( const QgsPointXY &point )
   if ( vlayer->dataProvider()->capabilities().testFlag( QgsVectorDataProvider::Capability::CircularGeometries ) )
   {
     // We convert the capture curve to OGR geometry
-    OGRGeometry *ogrCaptureCurve;
-    OGRGeometryFactory::createFromWkt( mCaptureCurve.asWkt().toLocal8Bit().data(), nullptr, &ogrCaptureCurve );
+    QByteArray wkb = mCaptureCurve.asWkb();
+    OGRGeometryH ogrCaptureCurve;
+    OGR_G_CreateFromWkb( ( unsigned char *) wkb.constData(), nullptr, &ogrCaptureCurve, wkb.size() );
 
     // We de-approximate the curves using OGR (the geometry must be forced to linear first, as a mCaptureCurve is a CompoundCurve)
-    OGRGeometry *ogrLinestring = ogrCaptureCurve->getLinearGeometry(); // it must be forced to linear, as captuecurve is a compound curve
-    OGRGeometry *ogrRecurved = ogrLinestring->getCurveGeometry();
+    OGRGeometryH ogrLinestring = OGR_G_GetLinearGeometry( ogrCaptureCurve, 0, nullptr );
+    OGRGeometryH ogrRecurved = OGR_G_GetCurveGeometry( ogrLinestring, nullptr );
 
     // We save back to mCaptureCurve
-    mCaptureCurve.clear();
-    mCaptureCurve.fromWkt( QString::fromStdString( ogrRecurved->exportToWkt() ) );
+    mCaptureCurve = *qgsgeometry_cast<QgsCompoundCurve *>( QgsOgrUtils::ogrGeometryToQgsGeometry( ogrRecurved ).constGet() );
   }
 
   tracer->reportError( QgsTracer::ErrNone, true ); // clear messagebar if there was any error
   return true;
 }
 
-// Required to avoid this (took values from https://github.com/OSGeo/gdal/blob/master/gdal/ogr/ogrgeometry.cpp):
-// qgsmaptoolcapture.cpp.obj : error LNK2019: unresolved external symbol "private: static int __cdecl OGRWktOptions::getDefaultPrecision(void)" (?getDefaultPrecision@OGRWktOptions@@CAHXZ) referenced in function "public: __cdecl OGRWktOptions::OGRWktOptions(void)" (??0OGRWktOptions@@QEAA@XZ)
-// qgsmaptoolcapture.cpp.obj : error LNK2019: unresolved external symbol "private: static bool __cdecl OGRWktOptions::getDefaultRound(void)" (?getDefaultRound@OGRWktOptions@@CA_NXZ) referenced in function "public: __cdecl OGRWktOptions::OGRWktOptions(void)" (??0OGRWktOptions@@QEAA@XZ)
-// output\bin\qgis_gui.dll : fatal error LNK1120: 2 unresolved externals
-int OGRWktOptions::getDefaultPrecision( void )
-{
-  return 15;
-}
-bool OGRWktOptions::getDefaultRound( void )
-{
-  return true;
-}
 
 QgsRubberBand *QgsMapToolCapture::takeRubberBand()
 {

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -23,7 +23,6 @@
 #include "qgsmapcanvas.h"
 #include "qgsmapcanvastracer.h"
 #include "qgsmapmouseevent.h"
-#include "qgsogrutils.h"
 #include "qgspolygon.h"
 #include "qgsrubberband.h"
 #include "qgssnapindicator.h"

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -52,10 +52,23 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
       CapturePolygon  //!< Capture polygons
     };
 
+    enum Capability
+    {
+      NoCapabilities = 0,       //!< Tool has no capabilities
+      SupportsCurves = 1,       //!< Supports curved geometries input;
+    };
+
+    Q_DECLARE_FLAGS( Capabilities, Capability )
+
     //! constructor
     QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode );
 
     ~QgsMapToolCapture() override;
+
+    /**
+     * Returns flags containing the supported capabilities
+     */
+    virtual QgsMapToolCapture::Capabilities capabilities() const;
 
     void activate() override;
     void deactivate() override;
@@ -313,5 +326,7 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     friend class TestQgsMapToolReshape;
 
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsMapToolCapture::Capabilities )
 
 #endif

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -52,10 +52,11 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
       CapturePolygon  //!< Capture polygons
     };
 
+    //! Specific capbilities of the tool
     enum Capability
     {
-      NoCapabilities = 0,       //!< Tool has no capabilities
-      SupportsCurves = 1,       //!< Supports curved geometries input;
+      NoCapabilities = 0,       //!< No specific capabilities
+      SupportsCurves = 1,       //!< Supports curved geometries input
     };
 
     Q_DECLARE_FLAGS( Capabilities, Capability )

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -52,7 +52,7 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
       CapturePolygon  //!< Capture polygons
     };
 
-    //! Specific capbilities of the tool
+    //! Specific capabilities of the tool
     enum Capability
     {
       NoCapabilities = 0,       //!< No specific capabilities

--- a/src/gui/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/qgsmaptooldigitizefeature.cpp
@@ -43,6 +43,11 @@ QgsMapToolDigitizeFeature::QgsMapToolDigitizeFeature( QgsMapCanvas *canvas, QgsA
   connect( QgsProject::instance(), &QgsProject::readProject, this, &QgsMapToolDigitizeFeature::stopCapturing );
 }
 
+QgsMapToolCapture::Capabilities QgsMapToolDigitizeFeature::capabilities() const
+{
+  return QgsMapToolCapture::SupportsCurves;
+}
+
 void QgsMapToolDigitizeFeature::digitized( const QgsFeature &f )
 {
   emit digitizingCompleted( f );

--- a/src/gui/qgsmaptooldigitizefeature.h
+++ b/src/gui/qgsmaptooldigitizefeature.h
@@ -42,6 +42,8 @@ class GUI_EXPORT QgsMapToolDigitizeFeature : public QgsMapToolCapture
      */
     QgsMapToolDigitizeFeature( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode = QgsMapToolCapture::CaptureNone );
 
+    QgsMapToolCapture::Capabilities capabilities() const override;
+
     void cadCanvasReleaseEvent( QgsMapMouseEvent *e ) override;
 
     /**

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -4515,7 +4515,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                   <item row="0" column="0" colspan="3">
                    <widget class="QCheckBox" name="mTracingConvertToCurveCheckBox">
                     <property name="text">
-                     <string>Convert tracing to curve</string>
+                     <string>Convert tracing to curve (this feature is experimental)</string>
                     </property>
                    </widget>
                   </item>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -4507,6 +4507,22 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                 </widget>
                </item>
                <item>
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_30">
+                 <property name="title">
+                  <string>Tracing</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout">
+                  <item row="0" column="0" colspan="3">
+                   <widget class="QCheckBox" name="mTracingConvertToCurveCheckBox">
+                    <property name="text">
+                     <string>Convert tracing to curve</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
                 <spacer name="verticalSpacer_4">
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>
@@ -5836,6 +5852,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>mOffsetJoinStyleComboBox</tabstop>
   <tabstop>mOffsetQuadSegSpinBox</tabstop>
   <tabstop>mCurveOffsetMiterLimitComboBox</tabstop>
+  <tabstop>mTracingConvertToCurveCheckBox</tabstop>
   <tabstop>mOptionsScrollArea_12</tabstop>
   <tabstop>mComposerFontComboBox</tabstop>
   <tabstop>mGridStyleComboBox</tabstop>

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -324,8 +324,8 @@ void TestQgsMapToolAddFeatureLine::testTracingWithConvertToCurves()
   QgsFeatureId newFid1 = utils.newFeatureId( oldFids );
 
   const QgsAbstractGeometry *g = mLayerLineCurved->getFeature( newFid1 ).geometry().constGet();
-  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPointXY( 6, 1 ) );
-  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, g->vertexCount() - 1 ) ), QgsPointXY( 7, 1 ) );
+  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 6, 1 ) );
+  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, g->vertexCount() - 1 ) ), QgsPoint( 7, 1 ) );
   QVERIFY( g->vertexCount() > 3 );  // a segmentized arc has (much) more than 3 points
 
   mLayerLineCurved->undoStack()->undo();
@@ -341,8 +341,8 @@ void TestQgsMapToolAddFeatureLine::testTracingWithConvertToCurves()
   QgsFeatureId newFid2 = utils.newFeatureId( oldFids );
 
   g = mLayerLineCurved->getFeature( newFid2 ).geometry().constGet();
-  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPointXY( 6, 1 ) );
-  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, g->vertexCount() - 1 ) ), QgsPointXY( 7, 1 ) );
+  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 6, 1 ) );
+  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, g->vertexCount() - 1 ) ), QgsPoint( 7, 1 ) );
   QVERIFY( g->vertexCount() == 3 );  // a true arc is composed of 3 vertices
 
   mLayerLineCurved->undoStack()->undo();

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -65,8 +65,8 @@ class TestQgsMapToolAddFeatureLine : public QObject
 
     void testNoTracing();
     void testTracing();
-    void testTracingWithConvertToCurves();
     void testTracingWithOffset();
+    void testTracingWithConvertToCurves();
     void testZ();
     void testZMSnapping();
     void testTopologicalEditingZ();
@@ -303,57 +303,6 @@ void TestQgsMapToolAddFeatureLine::testTracing()
 }
 
 
-void TestQgsMapToolAddFeatureLine::testTracingWithConvertToCurves()
-{
-  TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
-
-  mCanvas->setCurrentLayer( mLayerLineCurved );
-
-  // enable snapping and tracing
-  mEnableTracingAction->setChecked( true );
-
-  QSet<QgsFeatureId> oldFids = utils.existingFeatureIds();
-
-  // tracing enabled - without converting to curves
-  QgsSettings().setValue( QStringLiteral( "/qgis/digitizing/convert_to_curve" ), false );
-
-  utils.mouseClick( 6, 1, Qt::LeftButton );
-  utils.mouseClick( 7, 1, Qt::LeftButton );
-  utils.mouseClick( 7, 1, Qt::RightButton );
-
-  QgsFeatureId newFid1 = utils.newFeatureId( oldFids );
-
-  const QgsAbstractGeometry *g = mLayerLineCurved->getFeature( newFid1 ).geometry().constGet();
-  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 6, 1 ) );
-  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, g->vertexCount() - 1 ) ), QgsPoint( 7, 1 ) );
-  QVERIFY( g->vertexCount() > 3 );  // a segmentized arc has (much) more than 3 points
-
-  mLayerLineCurved->undoStack()->undo();
-
-  // we redo the same with convert to curves enabled
-  QgsSettings().setValue( QStringLiteral( "/qgis/digitizing/convert_to_curve" ), true );
-
-  // tracing enabled - without converting to curves
-  utils.mouseClick( 6, 1, Qt::LeftButton );
-  utils.mouseClick( 7, 1, Qt::LeftButton );
-  utils.mouseClick( 7, 1, Qt::RightButton );
-
-  QgsFeatureId newFid2 = utils.newFeatureId( oldFids );
-
-  g = mLayerLineCurved->getFeature( newFid2 ).geometry().constGet();
-  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 6, 1 ) );
-  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, g->vertexCount() - 1 ) ), QgsPoint( 7, 1 ) );
-  QVERIFY( g->vertexCount() == 3 );  // a true arc is composed of 3 vertices
-
-  mLayerLineCurved->undoStack()->undo();
-
-  // no other unexpected changes happened
-  QCOMPARE( mLayerLineCurved->undoStack()->index(), 1 );
-
-  mEnableTracingAction->setChecked( false );
-}
-
-
 void TestQgsMapToolAddFeatureLine::testTracingWithOffset()
 {
   TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
@@ -431,6 +380,58 @@ void TestQgsMapToolAddFeatureLine::testTracingWithOffset()
 
   mEnableTracingAction->setChecked( false );
 }
+
+
+void TestQgsMapToolAddFeatureLine::testTracingWithConvertToCurves()
+{
+  TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
+
+  mCanvas->setCurrentLayer( mLayerLineCurved );
+
+  // enable snapping and tracing
+  mEnableTracingAction->setChecked( true );
+
+  QSet<QgsFeatureId> oldFids = utils.existingFeatureIds();
+
+  // tracing enabled - without converting to curves
+  QgsSettings().setValue( QStringLiteral( "/qgis/digitizing/convert_to_curve" ), false );
+
+  utils.mouseClick( 6, 1, Qt::LeftButton );
+  utils.mouseClick( 7, 1, Qt::LeftButton );
+  utils.mouseClick( 7, 1, Qt::RightButton );
+
+  QgsFeatureId newFid1 = utils.newFeatureId( oldFids );
+
+  const QgsAbstractGeometry *g = mLayerLineCurved->getFeature( newFid1 ).geometry().constGet();
+  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPointXY( 6, 1 ) );
+  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, g->vertexCount() - 1 ) ), QgsPointXY( 7, 1 ) );
+  QVERIFY( g->vertexCount() > 3 );  // a segmentized arc has (much) more than 3 points
+
+  mLayerLineCurved->undoStack()->undo();
+
+  // we redo the same with convert to curves enabled
+  QgsSettings().setValue( QStringLiteral( "/qgis/digitizing/convert_to_curve" ), true );
+
+  // tracing enabled - without converting to curves
+  utils.mouseClick( 6, 1, Qt::LeftButton );
+  utils.mouseClick( 7, 1, Qt::LeftButton );
+  utils.mouseClick( 7, 1, Qt::RightButton );
+
+  QgsFeatureId newFid2 = utils.newFeatureId( oldFids );
+
+  g = mLayerLineCurved->getFeature( newFid2 ).geometry().constGet();
+  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPointXY( 6, 1 ) );
+  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, g->vertexCount() - 1 ) ), QgsPointXY( 7, 1 ) );
+  QVERIFY( g->vertexCount() == 3 );  // a true arc is composed of 3 vertices
+
+  mLayerLineCurved->undoStack()->undo();
+
+  // no other unexpected changes happened
+  QCOMPARE( mLayerLineCurved->undoStack()->index(), 1 );
+
+  mEnableTracingAction->setChecked( false );
+}
+
 
 void TestQgsMapToolAddFeatureLine::testZ()
 {

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -302,7 +302,6 @@ void TestQgsMapToolAddFeatureLine::testTracing()
   mEnableTracingAction->setChecked( false );
 }
 
-
 void TestQgsMapToolAddFeatureLine::testTracingWithOffset()
 {
   TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
@@ -381,7 +380,6 @@ void TestQgsMapToolAddFeatureLine::testTracingWithOffset()
   mEnableTracingAction->setChecked( false );
 }
 
-
 void TestQgsMapToolAddFeatureLine::testTracingWithConvertToCurves()
 {
   TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
@@ -403,8 +401,8 @@ void TestQgsMapToolAddFeatureLine::testTracingWithConvertToCurves()
   QgsFeatureId newFid1 = utils.newFeatureId( oldFids );
 
   const QgsAbstractGeometry *g = mLayerLineCurved->getFeature( newFid1 ).geometry().constGet();
-  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPointXY( 6, 1 ) );
-  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, g->vertexCount() - 1 ) ), QgsPointXY( 7, 1 ) );
+  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 6, 1 ) );
+  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, g->vertexCount() - 1 ) ), QgsPoint( 7, 1 ) );
   QVERIFY( g->vertexCount() > 3 );  // a segmentized arc has (much) more than 3 points
 
   mLayerLineCurved->undoStack()->undo();
@@ -420,8 +418,8 @@ void TestQgsMapToolAddFeatureLine::testTracingWithConvertToCurves()
   QgsFeatureId newFid2 = utils.newFeatureId( oldFids );
 
   g = mLayerLineCurved->getFeature( newFid2 ).geometry().constGet();
-  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPointXY( 6, 1 ) );
-  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, g->vertexCount() - 1 ) ), QgsPointXY( 7, 1 ) );
+  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 6, 1 ) );
+  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, g->vertexCount() - 1 ) ), QgsPoint( 7, 1 ) );
   QVERIFY( g->vertexCount() == 3 );  // a true arc is composed of 3 vertices
 
   mLayerLineCurved->undoStack()->undo();
@@ -431,7 +429,6 @@ void TestQgsMapToolAddFeatureLine::testTracingWithConvertToCurves()
 
   mEnableTracingAction->setChecked( false );
 }
-
 
 void TestQgsMapToolAddFeatureLine::testZ()
 {

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -378,6 +378,7 @@ void TestQgsMapToolAddFeatureLine::testTracingWithOffset()
 
 
   mEnableTracingAction->setChecked( false );
+  mTracer->setOffset( 0 );
 }
 
 void TestQgsMapToolAddFeatureLine::testTracingWithConvertToCurves()

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -26,6 +26,7 @@
 #include "qgsproject.h"
 #include "qgssettings.h"
 #include "qgsvectorlayer.h"
+#include "qgswkbtypes.h"
 #include "qgsmapmouseevent.h"
 #include "testqgsmaptoolutils.h"
 
@@ -64,6 +65,7 @@ class TestQgsMapToolAddFeatureLine : public QObject
 
     void testNoTracing();
     void testTracing();
+    void testTracingWithConvertToCurves();
     void testTracingWithOffset();
     void testZ();
     void testZMSnapping();
@@ -77,12 +79,14 @@ class TestQgsMapToolAddFeatureLine : public QObject
     QAction *mEnableTracingAction = nullptr;
     QgsMapToolAddFeature *mCaptureTool = nullptr;
     QgsVectorLayer *mLayerLine = nullptr;
+    QgsVectorLayer *mLayerLineCurved = nullptr;
     QgsVectorLayer *mLayerLineZ = nullptr;
     QgsVectorLayer *mLayerPointZM = nullptr;
     QgsVectorLayer *mLayerTopoZ = nullptr;
     QgsVectorLayer *mLayerLine2D = nullptr;
     QgsVectorLayer *mLayerCloseLine = nullptr;
     QgsFeatureId mFidLineF1 = 0;
+    QgsFeatureId mFidCurvedF1 = 0;
 };
 
 TestQgsMapToolAddFeatureLine::TestQgsMapToolAddFeatureLine() = default;
@@ -124,6 +128,22 @@ void TestQgsMapToolAddFeatureLine::initTestCase()
 
   // just one added feature
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
+
+  // make testing layers
+  mLayerLineCurved = new QgsVectorLayer( QStringLiteral( "LineString?crs=EPSG:27700" ), QStringLiteral( "curved layer line" ), QStringLiteral( "memory" ) );
+  QVERIFY( mLayerLineCurved->isValid() );
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mLayerLineCurved );
+
+  QgsFeature curveF1;
+  curveF1.setGeometry( QgsGeometry::fromWkt( "CIRCULARSTRING(6 1, 6.5 1.5, 7 1)" ) );
+
+  mLayerLineCurved->startEditing();
+  mLayerLineCurved->addFeature( curveF1 );
+  mFidCurvedF1 = curveF1.id();
+  QCOMPARE( mLayerLineCurved->featureCount(), ( long )1 );
+
+  // just one added feature
+  QCOMPARE( mLayerLineCurved->undoStack()->index(), 1 );
 
   // make testing layers
   mLayerLineZ = new QgsVectorLayer( QStringLiteral( "LineStringZ?crs=EPSG:27700" ), QStringLiteral( "layer line Z" ), QStringLiteral( "memory" ) );
@@ -188,7 +208,7 @@ void TestQgsMapToolAddFeatureLine::initTestCase()
 
   mLayerLine2D->addFeature( lineString2DF );
   QCOMPARE( mLayerLine2D->featureCount(), ( long )1 );
-  mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerLine << mLayerLineZ << mLayerPointZM << mLayerTopoZ << mLayerLine2D );
+  mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerLine << mLayerLineCurved << mLayerLineZ << mLayerPointZM << mLayerTopoZ << mLayerLine2D );
 
   mCanvas->setSnappingUtils( new QgsMapCanvasSnappingUtils( mCanvas, this ) );
 
@@ -281,6 +301,58 @@ void TestQgsMapToolAddFeatureLine::testTracing()
 
   mEnableTracingAction->setChecked( false );
 }
+
+
+void TestQgsMapToolAddFeatureLine::testTracingWithConvertToCurves()
+{
+  TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
+
+  mCanvas->setCurrentLayer( mLayerLineCurved );
+
+  // enable snapping and tracing
+  mEnableTracingAction->setChecked( true );
+
+  QSet<QgsFeatureId> oldFids = utils.existingFeatureIds();
+
+  // tracing enabled - without converting to curves
+  QgsSettings().setValue( QStringLiteral( "/qgis/digitizing/convert_to_curve" ), false );
+
+  utils.mouseClick( 6, 1, Qt::LeftButton );
+  utils.mouseClick( 7, 1, Qt::LeftButton );
+  utils.mouseClick( 7, 1, Qt::RightButton );
+
+  QgsFeatureId newFid1 = utils.newFeatureId( oldFids );
+
+  const QgsAbstractGeometry *g = mLayerLineCurved->getFeature( newFid1 ).geometry().constGet();
+  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPointXY( 6, 1 ) );
+  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, g->vertexCount() - 1 ) ), QgsPointXY( 7, 1 ) );
+  QVERIFY( g->vertexCount() > 3 );  // a segmentized arc has (much) more than 3 points
+
+  mLayerLineCurved->undoStack()->undo();
+
+  // we redo the same with convert to curves enabled
+  QgsSettings().setValue( QStringLiteral( "/qgis/digitizing/convert_to_curve" ), true );
+
+  // tracing enabled - without converting to curves
+  utils.mouseClick( 6, 1, Qt::LeftButton );
+  utils.mouseClick( 7, 1, Qt::LeftButton );
+  utils.mouseClick( 7, 1, Qt::RightButton );
+
+  QgsFeatureId newFid2 = utils.newFeatureId( oldFids );
+
+  g = mLayerLineCurved->getFeature( newFid2 ).geometry().constGet();
+  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPointXY( 6, 1 ) );
+  QCOMPARE( g->vertexAt( QgsVertexId( 0, 0, g->vertexCount() - 1 ) ), QgsPointXY( 7, 1 ) );
+  QVERIFY( g->vertexCount() == 3 );  // a true arc is composed of 3 vertices
+
+  mLayerLineCurved->undoStack()->undo();
+
+  // no other unexpected changes happened
+  QCOMPARE( mLayerLineCurved->undoStack()->index(), 1 );
+
+  mEnableTracingAction->setChecked( false );
+}
+
 
 void TestQgsMapToolAddFeatureLine::testTracingWithOffset()
 {

--- a/tests/src/core/testqgsgeometryutils.cpp
+++ b/tests/src/core/testqgsgeometryutils.cpp
@@ -80,6 +80,7 @@ class TestQgsGeometryUtils: public QObject
     void testTriangleArea();
     void testWeightedPointInTriangle_data();
     void testWeightedPointInTriangle();
+    void testPointContinuesArc();
 };
 
 
@@ -1468,6 +1469,32 @@ void TestQgsGeometryUtils::testWeightedPointInTriangle()
   QgsGeometryUtils::weightedPointInTriangle( aX, aY, bX, bY, cX, cY, weightB, weightC, x, y );
   QGSCOMPARENEAR( x, expectedX, 0.0000001 );
   QGSCOMPARENEAR( y, expectedY, 0.0000001 );
+}
+
+void TestQgsGeometryUtils::testPointContinuesArc()
+{
+  // normal arcs
+  QVERIFY( QgsGeometryUtils::pointContinuesArc( QgsPoint( 0, 0 ), QgsPoint( 1, 1 ), QgsPoint( 2, 0 ), QgsPoint( 1, -1 ), 0.000000001, 0.000001 ) );
+  QVERIFY( QgsGeometryUtils::pointContinuesArc( QgsPoint( 2, 0 ), QgsPoint( 1, 1 ), QgsPoint( 0, 0 ), QgsPoint( 1, -1 ), 0.000000001, 0.000001 ) );
+  QVERIFY( !QgsGeometryUtils::pointContinuesArc( QgsPoint( 0, 0 ), QgsPoint( 1, 1 ), QgsPoint( 2, 0 ), QgsPoint( 3, 0 ), 0.000000001, 0.000001 ) );
+  QVERIFY( QgsGeometryUtils::pointContinuesArc( QgsPoint( 0, 0 ), QgsPoint( 0.29289321881, 0.707106781 ), QgsPoint( 1, 1 ), QgsPoint( 1.707106781, 0.707106781 ), 0.00001, 0.00001 ) );
+
+  // irregular spacing
+  QVERIFY( !QgsGeometryUtils::pointContinuesArc( QgsPoint( 0, 0 ), QgsPoint( 0.29289321881, 0.707106781 ), QgsPoint( 1, 1 ), QgsPoint( 1, -1 ), 0.00001, 0.00001 ) );
+
+  // inside current arc
+  QVERIFY( !QgsGeometryUtils::pointContinuesArc( QgsPoint( 0, 0 ), QgsPoint( 0.29289321881, 0.707106781 ), QgsPoint( 1, 1 ), QgsPoint( 0.29289321881, 0.707106781 ), 0.00001, 0.00001 ) );
+  QVERIFY( !QgsGeometryUtils::pointContinuesArc( QgsPoint( 0, 0 ), QgsPoint( 0.29289321881, 0.707106781 ), QgsPoint( 1, 1 ), QgsPoint( 1, 1 ), 0.00001, 0.00001 ) );
+  QVERIFY( !QgsGeometryUtils::pointContinuesArc( QgsPoint( 0, 0 ), QgsPoint( 0.29289321881, 0.707106781 ), QgsPoint( 1, 1 ), QgsPoint( 0, 0 ), 0.00001, 0.00001 ) );
+
+  // colinear points
+  QVERIFY( !QgsGeometryUtils::pointContinuesArc( QgsPoint( 0, 0 ), QgsPoint( 0.5, 0.5 ), QgsPoint( 1, 1 ), QgsPoint( 1.5, 1.5 ), 0.00001, 0.00001 ) );
+
+  // with a bit more tolerance
+  QVERIFY( !QgsGeometryUtils::pointContinuesArc( QgsPoint( 0, 0 ), QgsPoint( 1, 1 ), QgsPoint( 2, 0 ), QgsPoint( 1.01, -1 ), 0.000000001, 0.05 ) );
+  QVERIFY( QgsGeometryUtils::pointContinuesArc( QgsPoint( 0, 0 ), QgsPoint( 1, 1 ), QgsPoint( 2, 0 ), QgsPoint( 1.01, -1 ), 0.1, 0.05 ) );
+  QVERIFY( !QgsGeometryUtils::pointContinuesArc( QgsPoint( 0, 0 ), QgsPoint( 1, 1 ), QgsPoint( 2, 0 ), QgsPoint( 1.01, -1 ), 0.1, 0.000001 ) );
+  QVERIFY( !QgsGeometryUtils::pointContinuesArc( QgsPoint( 0, 0 ), QgsPoint( 1, 1 ), QgsPoint( 2, 0 ), QgsPoint( 1.01, -1 ), 0.000000001, 0.05 ) );
 }
 
 QGSTEST_MAIN( TestQgsGeometryUtils )

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -5183,6 +5183,32 @@ class TestQgsGeometry(unittest.TestCase):
             self.assertAlmostEqual(o, exp, 5,
                                    "mismatch for {} to {}, expected:\n{}\nGot:\n{}\n".format(t[0], t[1], exp, o))
 
+    def testConvertToCurves(self):
+        tests = [
+            ["LINESTRING Z (3 3 3,2.4142135623731 1.58578643762691 3,1 1 3,-0.414213562373092 1.5857864376269 3,-1 2.99999999999999 3,-0.414213562373101 4.41421356237309 3,0.999999999999991 5 3,2.41421356237309 4.4142135623731 3,3 3 3)",
+             "CompoundCurveZ (CircularStringZ (3 3 3, -1 2.99999999999998979 3, 3 3 3))", 0.00000001, 0.0000001],
+            ["LINESTRING(0 0,10 0,10 10,0 10,0 0)", "CompoundCurve((0 0,10 0,10 10,0 10,0 0))", 0.00000001, 0.00000001],
+            ["LINESTRING(0 0,10 0,10 10,0 10)", "CompoundCurve((0 0,10 0,10 10,0 10))", 0.00000001, 0.00000001],
+            ["LINESTRING(10 10,0 10,0 0,10 0)", "CompoundCurve((10 10,0 10,0 0,10 0))", 0.0000001, 0.00000001],
+            ["LINESTRING(0 0, 1 1)", "CompoundCurve((0 0, 1 1))", 0.00000001, 0.00000001],
+            ["GEOMETRYCOLLECTION(LINESTRING(10 10,10 11),LINESTRING(10 11,11 11),LINESTRING(11 11,10 10))",
+             "MultiCurve (CompoundCurve ((10 10, 10 11)),CompoundCurve ((10 11, 11 11)),CompoundCurve ((11 11, 10 10)))", 0.000001, 0.000001],
+            ["GEOMETRYCOLLECTION(LINESTRING(4 4,4 8),CIRCULARSTRING(4 8,6 10,8 8),LINESTRING(8 8,8 4))",
+             "MultiCurve (CompoundCurve ((4 4, 4 8)),CompoundCurve (CircularString (4 8, 6 10, 8 8)),CompoundCurve ((8 8, 8 4)))", 0.0000001, 0.0000001],
+            ["LINESTRING(-13151357.927248 3913656.64539871,-13151419.0845266 3913664.12016378,-13151441.323537 3913666.61175286,-13151456.8908442 3913666.61175286,-13151476.9059536 3913666.61175286,-13151496.921063 3913666.61175287,-13151521.3839744 3913666.61175287,-13151591.4368571 3913665.36595828)",
+             "CompoundCurve ((-13151357.92724799923598766 3913656.64539870992302895, -13151419.08452660031616688 3913664.12016378017142415, -13151441.32353699952363968 3913666.61175285978242755, -13151456.8908441998064518 3913666.61175285978242755, -13151476.90595359914004803 3913666.61175285978242755, -13151496.92106300033628941 3913666.61175287002697587, -13151521.38397439941763878 3913666.61175287002697587, -13151591.43685710057616234 3913665.36595827993005514))", 0.000001, 0.0000001],
+            ["Point( 1 2 )", "Point( 1 2 )", 0.00001, 0.00001],
+            ["MultiPoint( 1 2, 3 4 )", "MultiPoint( (1 2 ), (3 4 ))", 0.00001, 0.00001]
+
+        ]
+        for t in tests:
+            g1 = QgsGeometry.fromWkt(t[0])
+            distance_tolerance = t[2]
+            angle_tolerance = t[3]
+            o = g1.convertToCurves(distance_tolerance, angle_tolerance)
+            self.assertTrue(compareWkt(o.asWkt(), t[1], 0.00001),
+                            "clipped: mismatch Expected:\n{}\nGot:\n{}\n".format(t[1], o.asWkt()))
+
     def testBoundingBoxIntersects(self):
         tests = [
             ["LINESTRING (0 0, 100 100)", "LINESTRING (90 0, 100 0)", True],


### PR DESCRIPTION
This PR adds curved geometries support for the trace tool. Currently, when tracing existing curved geometries, the results are segmentized. This PR fixes this by "de-segmentizing" traced curves when working on a layer that supports geometries.

![pr](https://user-images.githubusercontent.com/1894106/79769829-e3b04080-832c-11ea-9029-981e3a3ecf1b.gif)

The de-segmentation is made by `OGRGeometry->getCurveGeometry()`.

The whole tracing logic is left unchanged, so it still makes use of segmentized geometries, as currently there's no support for true curves intersection in the libraries we use. This means there's a small approximation if snapping on curved intersections, but this was the case before already.

Note this other PR https://github.com/qgis/QGIS/pull/35877 which fixes multi-geometries not being correctly cast to linear, preventing the trace tool from working on MultiCurves (with or without this PR).

As commented in the code, I had to declare  `int OGRWktOptions::getDefaultPrecision(void)` and `bool OGRWktOptions::getDefaultRound(void)` to fix linking errors... Not familiar with OGR at all, but it doesn't look exactly right to have this there... Any idea on how to better avoid this issue ?