### PR TITLE
always return correct field-alias mapping from attributeAliases() call (fix #31870)

### DIFF
--- a/src/core/qgsfieldmodel.cpp
+++ b/src/core/qgsfieldmodel.cpp
@@ -36,7 +36,7 @@ QModelIndex QgsFieldModel::indexFromName( const QString &fieldName )
   // only non-empty names should be used here, as by default all fields
   // have no aliases set and calling key() fill return just first value
   // from the aliases map
-  if ( mLayer && !fldName.isNull() )
+  if ( mLayer && !fldName.isEmpty() )
   {
     // the name could be an alias
     // it would be better to have "display name" directly in QgsFields

--- a/src/core/qgsfieldmodel.cpp
+++ b/src/core/qgsfieldmodel.cpp
@@ -33,7 +33,10 @@ QModelIndex QgsFieldModel::indexFromName( const QString &fieldName )
 {
   QString fldName( fieldName ); // we may need a copy
 
-  if ( mLayer )
+  // only non-empty names should be used here, as by default all fields
+  // have no aliases set and calling key() fill return just first value
+  // from the aliases map
+  if ( mLayer && !fldName.isNull() )
   {
     // the name could be an alias
     // it would be better to have "display name" directly in QgsFields

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -178,6 +178,11 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
     setDataSource( vectorLayerPath, baseName, providerKey, providerOptions, options.loadDefaultStyle );
   }
 
+  for ( const QgsField &field : mFields )
+  {
+    mAttributeAliasMap.insert( field.name(), QString() );
+  }
+
   connect( this, &QgsVectorLayer::selectionChanged, this, [ = ] { triggerRepaint(); } );
   connect( QgsProject::instance()->relationManager(), &QgsRelationManager::relationsLoaded, this, &QgsVectorLayer::onRelationsLoaded );
 
@@ -190,7 +195,6 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
   mSimplifyMethod.setThreshold( settings.value( QStringLiteral( "qgis/simplifyDrawingTol" ), mSimplifyMethod.threshold() ).toFloat() );
   mSimplifyMethod.setForceLocalOptimization( settings.value( QStringLiteral( "qgis/simplifyLocal" ), mSimplifyMethod.forceLocalOptimization() ).toBool() );
   mSimplifyMethod.setMaximumScale( settings.value( QStringLiteral( "qgis/simplifyMaxScale" ), mSimplifyMethod.maximumScale() ).toFloat() );
-
 } // QgsVectorLayer ctor
 
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -178,7 +178,7 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
     setDataSource( vectorLayerPath, baseName, providerKey, providerOptions, options.loadDefaultStyle );
   }
 
-  for ( const QgsField &field : mFields )
+  for ( const QgsField &field : qgis::as_const( mFields ) )
   {
     mAttributeAliasMap.insert( field.name(), QString() );
   }
@@ -2627,7 +2627,7 @@ bool QgsVectorLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString 
     node.appendChild( fieldConfigurationElement );
 
     int index = 0;
-    for ( const QgsField &field : mFields )
+    for ( const QgsField &field : qgis::as_const( mFields ) )
     {
       QDomElement fieldElement = doc.createElement( QStringLiteral( "field" ) );
       fieldElement.setAttribute( QStringLiteral( "name" ), field.name() );
@@ -2651,7 +2651,7 @@ bool QgsVectorLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString 
 
     //attribute aliases
     QDomElement aliasElem = doc.createElement( QStringLiteral( "aliases" ) );
-    for ( const QgsField &field : mFields )
+    for ( const QgsField &field : qgis::as_const( mFields ) )
     {
       QDomElement aliasEntryElem = doc.createElement( QStringLiteral( "alias" ) );
       aliasEntryElem.setAttribute( QStringLiteral( "field" ), field.name() );
@@ -2687,7 +2687,7 @@ bool QgsVectorLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString 
 
     //default expressions
     QDomElement defaultsElem = doc.createElement( QStringLiteral( "defaults" ) );
-    for ( const QgsField &field : mFields )
+    for ( const QgsField &field : qgis::as_const( mFields ) )
     {
       QDomElement defaultElem = doc.createElement( QStringLiteral( "default" ) );
       defaultElem.setAttribute( QStringLiteral( "field" ), field.name() );
@@ -2699,7 +2699,7 @@ bool QgsVectorLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString 
 
     // constraints
     QDomElement constraintsElem = doc.createElement( QStringLiteral( "constraints" ) );
-    for ( const QgsField &field : mFields )
+    for ( const QgsField &field : qgis::as_const( mFields ) )
     {
       QDomElement constraintElem = doc.createElement( QStringLiteral( "constraint" ) );
       constraintElem.setAttribute( QStringLiteral( "field" ), field.name() );
@@ -2713,7 +2713,7 @@ bool QgsVectorLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString 
 
     // constraint expressions
     QDomElement constraintExpressionsElem = doc.createElement( QStringLiteral( "constraintExpressions" ) );
-    for ( const QgsField &field : mFields )
+    for ( const QgsField &field : qgis::as_const( mFields ) )
     {
       QDomElement constraintExpressionElem = doc.createElement( QStringLiteral( "constraint" ) );
       constraintExpressionElem.setAttribute( QStringLiteral( "field" ), field.name() );
@@ -3485,7 +3485,7 @@ QString QgsVectorLayer::displayExpression() const
                                     QStringLiteral( "id" )};
     for ( const QString &candidate : sCandidates )
     {
-      for ( const QgsField &field : mFields )
+      for ( const QgsField &field : qgis::as_const( mFields ) )
       {
         QString fldName = field.name();
         if ( fldName.indexOf( candidate, 0, Qt::CaseInsensitive ) > -1 )

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -2302,6 +2302,8 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         """ test getting and setting aliases """
         layer = createLayerWithOnePoint()
 
+        self.assertEqual(len(layer.attributeAliases()), 2)
+
         self.assertFalse(layer.attributeAlias(0))
         self.assertFalse(layer.attributeAlias(1))
         self.assertFalse(layer.attributeAlias(2))


### PR DESCRIPTION
## Description
Right after adding vector layer to the project calling `attributeAliases()` on this layer returns an empty dictionary instead of mapping field-alias. But if at least one alias was set via "Layer properties - Attributes form" then `attributeAliases()` returns non-empty dictionary. After clearing previously set alias `attributeAliases()` continues to return non-empty dictionary. This is a bit inconsistent and confusing.

Proposed PR fixes this by initializing field-alias mapping on layer construction. Fixes #31870.
