### PR TITLE
Correctly utilise expression contexts for attribute form container visibility

### DIFF
--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
@@ -48,6 +48,11 @@ QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *i
   connect( mShowAsGroupBoxCheckBox, &QCheckBox::stateChanged, mShowLabelCheckBox, &QCheckBox::setEnabled );
 }
 
+void QgsAttributeFormContainerEdit::registerExpressionContextGenerator( QgsExpressionContextGenerator *generator )
+{
+  mVisibilityExpressionWidget->registerExpressionContextGenerator( generator );
+}
+
 void QgsAttributeFormContainerEdit::updateItemData()
 {
   QgsAttributesFormProperties::DnDTreeItemData itemData = mTreeItem->data( 0, QgsAttributesFormProperties::DnDTreeRole ).value<QgsAttributesFormProperties::DnDTreeItemData>();

--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.h
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.h
@@ -38,12 +38,17 @@ class GUI_EXPORT QgsAttributeFormContainerEdit: public QWidget, private Ui_QgsAt
   public:
     explicit QgsAttributeFormContainerEdit( QTreeWidgetItem *item, QWidget *parent = nullptr );
 
+    /**
+     * Register an expression context generator class that will be used to retrieve
+     * an expression context for the widget when required.
+     * \since QGIS 3.14
+     */
+    void registerExpressionContextGenerator( QgsExpressionContextGenerator *generator );
 
     void updateItemData();
 
-
   private:
-    QTreeWidgetItem *mTreeItem;
+    QTreeWidgetItem *mTreeItem = nullptr;
 };
 
 #endif // QGSATTRIBUTEFORMCONTAINEREDIT_H

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -306,7 +306,6 @@ void QgsAttributeForm::setFeature( const QgsFeature &feature )
     }
   }
   mIsSettingFeature = false;
-  mExpressionContext.setFeature( feature );
 }
 
 bool QgsAttributeForm::saveEdits()
@@ -951,28 +950,32 @@ void QgsAttributeForm::updateConstraints( QgsEditorWidgetWrapper *eww )
     // sync OK button status
     synchronizeEnabledState();
 
-    mExpressionContext.setFeature( ft );
-
-    mExpressionContext << QgsExpressionContextUtils::formScope( ft, mContext.attributeFormModeString() );
+    QgsExpressionContext context;
+    context.appendScopes( QgsExpressionContextUtils::globalProjectLayerScopes( mLayer ) );
+    context.appendScope( QgsExpressionContextUtils::formScope( ft, mContext.attributeFormModeString() ) );
+    context.setFeature( ft );
 
     // Recheck visibility for all containers which are controlled by this value
     const QVector<ContainerInformation *> infos = mContainerInformationDependency.value( eww->field().name() );
     for ( ContainerInformation *info : infos )
     {
-      info->apply( &mExpressionContext );
+      info->apply( &context );
     }
   }
 }
 
 void QgsAttributeForm::updateContainersVisibility()
 {
-  mExpressionContext << QgsExpressionContextUtils::formScope( QgsFeature( mFeature ), mContext.attributeFormModeString() );
+  QgsExpressionContext context;
+  context.appendScopes( QgsExpressionContextUtils::globalProjectLayerScopes( mLayer ) );
+  context.appendScope( QgsExpressionContextUtils::formScope( mFeature, mContext.attributeFormModeString() ) );
+  context.setFeature( mFeature );
 
   const QVector<ContainerInformation *> infos = mContainerVisibilityInformation;
 
   for ( ContainerInformation *info : infos )
   {
-    info->apply( &mExpressionContext );
+    info->apply( &context );
   }
 
   //and update the constraints
@@ -1014,13 +1017,16 @@ void QgsAttributeForm::updateLabels()
     QgsFeature currentFeature;
     if ( currentFormFeature( currentFeature ) )
     {
-      mExpressionContext << QgsExpressionContextUtils::formScope( currentFeature, mContext.attributeFormModeString() );
-      mExpressionContext.setFields( mLayer->fields() );
+      QgsExpressionContext context;
+      context.appendScopes( QgsExpressionContextUtils::globalProjectLayerScopes( mLayer ) );
+      context.appendScope( QgsExpressionContextUtils::formScope( currentFeature, mContext.attributeFormModeString() ) );
+      context.setFeature( currentFeature );
+
       for ( auto it = mLabelDataDefinedProperties.constBegin() ; it != mLabelDataDefinedProperties.constEnd(); ++it )
       {
         QLabel *label { it.key() };
         bool ok;
-        const QString value { it->valueAsString( mExpressionContext, QString(), &ok ) };
+        const QString value { it->valueAsString( context, QString(), &ok ) };
         if ( ok && ! value.isEmpty() )
         {
           label->setText( value );

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -412,7 +412,6 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     QList<QgsAttributeFormInterface *> mInterfaces;
     QMap< int, QgsAttributeFormEditorWidget * > mFormEditorWidgets;
     QList< QgsAttributeFormWidget *> mFormWidgets;
-    QgsExpressionContext mExpressionContext;
     QMap<const QgsVectorLayerJoinInfo *, QgsFeature> mJoinedFeatures;
     QMap<QLabel *, QgsProperty> mLabelDataDefinedProperties;
     bool mValuesInitialized = false;

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -26,6 +26,7 @@
 #include "qgsapplication.h"
 #include "qgscolorbutton.h"
 #include "qgscodeeditorhtml.h"
+#include "qgsexpressioncontextutils.h"
 
 
 QgsAttributesFormProperties::QgsAttributesFormProperties( QgsVectorLayer *layer, QWidget *parent )
@@ -183,9 +184,15 @@ void QgsAttributesFormProperties::initSuppressCombo()
   mFormSuppressCmbBx->addItem( tr( "Show form on add feature" ) );
 
   mFormSuppressCmbBx->setCurrentIndex( mLayer->editFormConfig().suppress() );
-
-
 }
+
+QgsExpressionContext QgsAttributesFormProperties::createExpressionContext() const
+{
+  QgsExpressionContext context;
+  context.appendScopes( QgsExpressionContextUtils::globalProjectLayerScopes( mLayer ) );
+  return context;
+}
+
 void QgsAttributesFormProperties::initLayoutConfig()
 {
   mEditorLayoutComboBox->setCurrentIndex( mEditorLayoutComboBox->findData( mLayer->editFormConfig().layout() ) );
@@ -432,6 +439,7 @@ void QgsAttributesFormProperties::loadAttributeContainerEdit()
 
   QTreeWidgetItem *currentItem = mFormLayoutTree->selectedItems().at( 0 );
   mAttributeContainerEdit = new QgsAttributeFormContainerEdit( currentItem, this );
+  mAttributeContainerEdit->registerExpressionContextGenerator( this );
   mAttributeContainerEdit->layout()->setContentsMargins( 0, 0, 0, 0 );
   mAttributeTypeFrame->layout()->setContentsMargins( 0, 0, 0, 0 );
   mAttributeTypeFrame->layout()->addWidget( mAttributeContainerEdit );

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -53,7 +53,7 @@ class QgsAttributeTypeDialog;
 class QgsAttributeRelationEdit;
 class QgsAttributeWidgetEdit;
 
-class GUI_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAttributesFormProperties
+class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpressionContextGenerator, private Ui_QgsAttributesFormProperties
 {
     Q_OBJECT
 
@@ -214,6 +214,8 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAtt
     void initLayoutConfig();
     void initInitPython();
     void initSuppressCombo();
+
+    QgsExpressionContext createExpressionContext() const override;
 
   protected:
     void updateButtons();


### PR DESCRIPTION
-  we shouldn't use a single member instance of the context here, because continually adding new scopes to that single instance will eventually cause the context to become massive and slow
- correctly populate the context with the global/project/layer scopes

Fixes #35558