### PR TITLE
include missed WFS connection settings into XML exchange file (fix #35866)

### DIFF
--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -475,7 +475,7 @@ QDomDocument QgsManageConnectionsDialog::saveWfsConnections( const QStringList &
 {
   QDomDocument doc( QStringLiteral( "connections" ) );
   QDomElement root = doc.createElement( QStringLiteral( "qgsWFSConnections" ) );
-  root.setAttribute( QStringLiteral( "version" ), QStringLiteral( "1.0" ) );
+  root.setAttribute( QStringLiteral( "version" ), QStringLiteral( "1.1" ) );
   doc.appendChild( root );
 
   QgsSettings settings;
@@ -487,7 +487,12 @@ QDomDocument QgsManageConnectionsDialog::saveWfsConnections( const QStringList &
     el.setAttribute( QStringLiteral( "name" ), connections[ i ] );
     el.setAttribute( QStringLiteral( "url" ), settings.value( path + connections[ i ] + "/url", "" ).toString() );
 
-    el.setAttribute( QStringLiteral( "referer" ), settings.value( path + connections[ i ] + "/referer", "" ).toString() );
+    el.setAttribute( QStringLiteral( "version" ), settings.value( path + connections[ i ] + "/version", "" ).toString() );
+    el.setAttribute( QStringLiteral( "maxnumfeatures" ), settings.value( path + connections[ i ] + "/maxnumfeatures", "" ).toString() );
+    el.setAttribute( QStringLiteral( "pagesize" ), settings.value( path + connections[ i ] + "/pagesize", "" ).toString() );
+    el.setAttribute( QStringLiteral( "pagingenabled" ), settings.value( path + connections[ i ] + "/pagingenabled", false ).toString() );
+    el.setAttribute( QStringLiteral( "ignoreAxisOrientation" ), settings.value( path + connections[ i ] + "/ignoreAxisOrientation", false ).toString() );
+    el.setAttribute( QStringLiteral( "invertAxisOrientation" ), settings.value( path + connections[ i ] + "/invertAxisOrientation", false ).toString() );
 
     path = QStringLiteral( "/qgis/WFS/" );
     el.setAttribute( QStringLiteral( "username" ), settings.value( path + connections[ i ] + "/username", "" ).toString() );
@@ -926,6 +931,13 @@ void QgsManageConnectionsDialog::loadWfsConnections( const QDomDocument &doc, co
     // no dups detected or overwrite is allowed
     settings.beginGroup( QStringLiteral( "/qgis/connections-wfs" ) );
     settings.setValue( QString( '/' + connectionName + "/url" ), child.attribute( QStringLiteral( "url" ) ) );
+
+    settings.setValue( QString( '/' + connectionName + "/version" ), child.attribute( QStringLiteral( "version" ) ) );
+    settings.setValue( QString( '/' + connectionName + "/maxnumfeatures" ), child.attribute( QStringLiteral( "maxnumfeatures" ) ) );
+    settings.setValue( QString( '/' + connectionName + "/pagesize" ), child.attribute( QStringLiteral( "pagesize" ) ) );
+    settings.setValue( QString( '/' + connectionName + "/pagingenabled" ), child.attribute( QStringLiteral( "pagingenabled" ) ) );
+    settings.setValue( QString( '/' + connectionName + "/ignoreAxisOrientation" ), child.attribute( QStringLiteral( "ignoreAxisOrientation" ) ) );
+    settings.setValue( QString( '/' + connectionName + "/invertAxisOrientation" ), child.attribute( QStringLiteral( "invertAxisOrientation" ) ) );
     settings.endGroup();
 
     if ( !child.attribute( QStringLiteral( "username" ) ).isEmpty() )

--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -449,7 +449,7 @@ QDomDocument QgsManageConnectionsDialog::saveOWSConnections( const QStringList &
     path = "/qgis/connections-" + service.toLower() + '/';
     QDomElement el = doc.createElement( service.toLower() );
     el.setAttribute( QStringLiteral( "name" ), connections[ i ] );
-    el.setAttribute( QStringLiteral( "url" ), settings.value( path + connections[ i ] + "/url", "" ).toString() );
+    el.setAttribute( QStringLiteral( "url" ), settings.value( path + connections[ i ] + "/url" ).toString() );
 
     if ( service == QLatin1String( "WMS" ) )
     {
@@ -457,14 +457,14 @@ QDomDocument QgsManageConnectionsDialog::saveOWSConnections( const QStringList &
       el.setAttribute( QStringLiteral( "ignoreGetFeatureInfoURI" ), settings.value( path + connections[i] + "/ignoreGetFeatureInfoURI", false ).toBool() ? "true" : "false" );
       el.setAttribute( QStringLiteral( "ignoreAxisOrientation" ), settings.value( path + connections[i] + "/ignoreAxisOrientation", false ).toBool() ? "true" : "false" );
       el.setAttribute( QStringLiteral( "invertAxisOrientation" ), settings.value( path + connections[i] + "/invertAxisOrientation", false ).toBool() ? "true" : "false" );
-      el.setAttribute( QStringLiteral( "referer" ), settings.value( path + connections[ i ] + "/referer", "" ).toString() );
+      el.setAttribute( QStringLiteral( "referer" ), settings.value( path + connections[ i ] + "/referer" ).toString() );
       el.setAttribute( QStringLiteral( "smoothPixmapTransform" ), settings.value( path + connections[i] + "/smoothPixmapTransform", false ).toBool() ? "true" : "false" );
       el.setAttribute( QStringLiteral( "dpiMode" ), settings.value( path + connections[i] + "/dpiMode", "7" ).toInt() );
     }
 
     path = "/qgis/" + service.toUpper() + '/';
-    el.setAttribute( QStringLiteral( "username" ), settings.value( path + connections[ i ] + "/username", "" ).toString() );
-    el.setAttribute( QStringLiteral( "password" ), settings.value( path + connections[ i ] + "/password", "" ).toString() );
+    el.setAttribute( QStringLiteral( "username" ), settings.value( path + connections[ i ] + "/username" ).toString() );
+    el.setAttribute( QStringLiteral( "password" ), settings.value( path + connections[ i ] + "/password" ).toString() );
     root.appendChild( el );
   }
 
@@ -485,18 +485,18 @@ QDomDocument QgsManageConnectionsDialog::saveWfsConnections( const QStringList &
     path = QStringLiteral( "/qgis/connections-wfs/" );
     QDomElement el = doc.createElement( QStringLiteral( "wfs" ) );
     el.setAttribute( QStringLiteral( "name" ), connections[ i ] );
-    el.setAttribute( QStringLiteral( "url" ), settings.value( path + connections[ i ] + "/url", "" ).toString() );
+    el.setAttribute( QStringLiteral( "url" ), settings.value( path + connections[ i ] + "/url" ).toString() );
 
-    el.setAttribute( QStringLiteral( "version" ), settings.value( path + connections[ i ] + "/version", "" ).toString() );
-    el.setAttribute( QStringLiteral( "maxnumfeatures" ), settings.value( path + connections[ i ] + "/maxnumfeatures", "" ).toString() );
-    el.setAttribute( QStringLiteral( "pagesize" ), settings.value( path + connections[ i ] + "/pagesize", "" ).toString() );
+    el.setAttribute( QStringLiteral( "version" ), settings.value( path + connections[ i ] + "/version" ).toString() );
+    el.setAttribute( QStringLiteral( "maxnumfeatures" ), settings.value( path + connections[ i ] + "/maxnumfeatures" ).toString() );
+    el.setAttribute( QStringLiteral( "pagesize" ), settings.value( path + connections[ i ] + "/pagesize" ).toString() );
     el.setAttribute( QStringLiteral( "pagingenabled" ), settings.value( path + connections[ i ] + "/pagingenabled", false ).toString() );
     el.setAttribute( QStringLiteral( "ignoreAxisOrientation" ), settings.value( path + connections[ i ] + "/ignoreAxisOrientation", false ).toString() );
     el.setAttribute( QStringLiteral( "invertAxisOrientation" ), settings.value( path + connections[ i ] + "/invertAxisOrientation", false ).toString() );
 
     path = QStringLiteral( "/qgis/WFS/" );
-    el.setAttribute( QStringLiteral( "username" ), settings.value( path + connections[ i ] + "/username", "" ).toString() );
-    el.setAttribute( QStringLiteral( "password" ), settings.value( path + connections[ i ] + "/password", "" ).toString() );
+    el.setAttribute( QStringLiteral( "username" ), settings.value( path + connections[ i ] + "/username" ).toString() );
+    el.setAttribute( QStringLiteral( "password" ), settings.value( path + connections[ i ] + "/password" ).toString() );
     root.appendChild( el );
   }
 
@@ -517,10 +517,10 @@ QDomDocument QgsManageConnectionsDialog::savePgConnections( const QStringList &c
     path = "/PostgreSQL/connections/" + connections[ i ];
     QDomElement el = doc.createElement( QStringLiteral( "postgis" ) );
     el.setAttribute( QStringLiteral( "name" ), connections[ i ] );
-    el.setAttribute( QStringLiteral( "host" ), settings.value( path + "/host", "" ).toString() );
-    el.setAttribute( QStringLiteral( "port" ), settings.value( path + "/port", "" ).toString() );
-    el.setAttribute( QStringLiteral( "database" ), settings.value( path + "/database", "" ).toString() );
-    el.setAttribute( QStringLiteral( "service" ), settings.value( path + "/service", "" ).toString() );
+    el.setAttribute( QStringLiteral( "host" ), settings.value( path + "/host" ).toString() );
+    el.setAttribute( QStringLiteral( "port" ), settings.value( path + "/port" ).toString() );
+    el.setAttribute( QStringLiteral( "database" ), settings.value( path + "/database" ).toString() );
+    el.setAttribute( QStringLiteral( "service" ), settings.value( path + "/service" ).toString() );
     el.setAttribute( QStringLiteral( "sslmode" ), settings.value( path + "/sslmode", "1" ).toString() );
     el.setAttribute( QStringLiteral( "estimatedMetadata" ), settings.value( path + "/estimatedMetadata", "0" ).toString() );
 
@@ -528,14 +528,14 @@ QDomDocument QgsManageConnectionsDialog::savePgConnections( const QStringList &c
 
     if ( settings.value( path + "/saveUsername", "false" ).toString() == QLatin1String( "true" ) )
     {
-      el.setAttribute( QStringLiteral( "username" ), settings.value( path + "/username", "" ).toString() );
+      el.setAttribute( QStringLiteral( "username" ), settings.value( path + "/username" ).toString() );
     }
 
     el.setAttribute( QStringLiteral( "savePassword" ), settings.value( path + "/savePassword", "false" ).toString() );
 
     if ( settings.value( path + "/savePassword", "false" ).toString() == QLatin1String( "true" ) )
     {
-      el.setAttribute( QStringLiteral( "password" ), settings.value( path + "/password", "" ).toString() );
+      el.setAttribute( QStringLiteral( "password" ), settings.value( path + "/password" ).toString() );
     }
 
     root.appendChild( el );
@@ -558,10 +558,10 @@ QDomDocument QgsManageConnectionsDialog::saveMssqlConnections( const QStringList
     path = "/MSSQL/connections/" + connections[ i ];
     QDomElement el = doc.createElement( QStringLiteral( "mssql" ) );
     el.setAttribute( QStringLiteral( "name" ), connections[ i ] );
-    el.setAttribute( QStringLiteral( "host" ), settings.value( path + "/host", "" ).toString() );
-    el.setAttribute( QStringLiteral( "port" ), settings.value( path + "/port", "" ).toString() );
-    el.setAttribute( QStringLiteral( "database" ), settings.value( path + "/database", "" ).toString() );
-    el.setAttribute( QStringLiteral( "service" ), settings.value( path + "/service", "" ).toString() );
+    el.setAttribute( QStringLiteral( "host" ), settings.value( path + "/host" ).toString() );
+    el.setAttribute( QStringLiteral( "port" ), settings.value( path + "/port" ).toString() );
+    el.setAttribute( QStringLiteral( "database" ), settings.value( path + "/database" ).toString() );
+    el.setAttribute( QStringLiteral( "service" ), settings.value( path + "/service" ).toString() );
     el.setAttribute( QStringLiteral( "sslmode" ), settings.value( path + "/sslmode", "1" ).toString() );
     el.setAttribute( QStringLiteral( "estimatedMetadata" ), settings.value( path + "/estimatedMetadata", "0" ).toString() );
 
@@ -569,14 +569,14 @@ QDomDocument QgsManageConnectionsDialog::saveMssqlConnections( const QStringList
 
     if ( settings.value( path + "/saveUsername", "false" ).toString() == QLatin1String( "true" ) )
     {
-      el.setAttribute( QStringLiteral( "username" ), settings.value( path + "/username", "" ).toString() );
+      el.setAttribute( QStringLiteral( "username" ), settings.value( path + "/username" ).toString() );
     }
 
     el.setAttribute( QStringLiteral( "savePassword" ), settings.value( path + "/savePassword", "false" ).toString() );
 
     if ( settings.value( path + "/savePassword", "false" ).toString() == QLatin1String( "true" ) )
     {
-      el.setAttribute( QStringLiteral( "password" ), settings.value( path + "/password", "" ).toString() );
+      el.setAttribute( QStringLiteral( "password" ), settings.value( path + "/password" ).toString() );
     }
 
     root.appendChild( el );
@@ -599,12 +599,12 @@ QDomDocument QgsManageConnectionsDialog::saveOracleConnections( const QStringLis
     path = "/Oracle/connections/" + connections[ i ];
     QDomElement el = doc.createElement( QStringLiteral( "oracle" ) );
     el.setAttribute( QStringLiteral( "name" ), connections[ i ] );
-    el.setAttribute( QStringLiteral( "host" ), settings.value( path + "/host", "" ).toString() );
-    el.setAttribute( QStringLiteral( "port" ), settings.value( path + "/port", "" ).toString() );
-    el.setAttribute( QStringLiteral( "database" ), settings.value( path + "/database", "" ).toString() );
-    el.setAttribute( QStringLiteral( "dboptions" ), settings.value( path + "/dboptions", "" ).toString() );
-    el.setAttribute( QStringLiteral( "dbworkspace" ), settings.value( path + "/dbworkspace", "" ).toString() );
-    el.setAttribute( QStringLiteral( "schema" ), settings.value( path + "/schema", QString() ).toString() );
+    el.setAttribute( QStringLiteral( "host" ), settings.value( path + "/host" ).toString() );
+    el.setAttribute( QStringLiteral( "port" ), settings.value( path + "/port" ).toString() );
+    el.setAttribute( QStringLiteral( "database" ), settings.value( path + "/database" ).toString() );
+    el.setAttribute( QStringLiteral( "dboptions" ), settings.value( path + "/dboptions" ).toString() );
+    el.setAttribute( QStringLiteral( "dbworkspace" ), settings.value( path + "/dbworkspace" ).toString() );
+    el.setAttribute( QStringLiteral( "schema" ), settings.value( path + "/schema" ).toString() );
     el.setAttribute( QStringLiteral( "estimatedMetadata" ), settings.value( path + "/estimatedMetadata", "0" ).toString() );
     el.setAttribute( QStringLiteral( "userTablesOnly" ), settings.value( path + "/userTablesOnly", "0" ).toString() );
     el.setAttribute( QStringLiteral( "geometryColumnsOnly" ), settings.value( path + "/geometryColumnsOnly", "0" ).toString() );
@@ -614,14 +614,14 @@ QDomDocument QgsManageConnectionsDialog::saveOracleConnections( const QStringLis
 
     if ( settings.value( path + "/saveUsername", "false" ).toString() == QLatin1String( "true" ) )
     {
-      el.setAttribute( QStringLiteral( "username" ), settings.value( path + "/username", "" ).toString() );
+      el.setAttribute( QStringLiteral( "username" ), settings.value( path + "/username" ).toString() );
     }
 
     el.setAttribute( QStringLiteral( "savePassword" ), settings.value( path + "/savePassword", "false" ).toString() );
 
     if ( settings.value( path + "/savePassword", "false" ).toString() == QLatin1String( "true" ) )
     {
-      el.setAttribute( QStringLiteral( "password" ), settings.value( path + "/password", "" ).toString() );
+      el.setAttribute( QStringLiteral( "password" ), settings.value( path + "/password" ).toString() );
     }
 
     root.appendChild( el );
@@ -644,10 +644,10 @@ QDomDocument QgsManageConnectionsDialog::saveDb2Connections( const QStringList &
     path = "/DB2/connections/" + connections[ i ];
     QDomElement el = doc.createElement( QStringLiteral( "db2" ) );
     el.setAttribute( QStringLiteral( "name" ), connections[ i ] );
-    el.setAttribute( QStringLiteral( "host" ), settings.value( path + "/host", "" ).toString() );
-    el.setAttribute( QStringLiteral( "port" ), settings.value( path + "/port", "" ).toString() );
-    el.setAttribute( QStringLiteral( "database" ), settings.value( path + "/database", "" ).toString() );
-    el.setAttribute( QStringLiteral( "service" ), settings.value( path + "/service", "" ).toString() );
+    el.setAttribute( QStringLiteral( "host" ), settings.value( path + "/host" ).toString() );
+    el.setAttribute( QStringLiteral( "port" ), settings.value( path + "/port" ).toString() );
+    el.setAttribute( QStringLiteral( "database" ), settings.value( path + "/database" ).toString() );
+    el.setAttribute( QStringLiteral( "service" ), settings.value( path + "/service" ).toString() );
     el.setAttribute( QStringLiteral( "sslmode" ), settings.value( path + "/sslmode", "1" ).toString() );
     el.setAttribute( QStringLiteral( "estimatedMetadata" ), settings.value( path + "/estimatedMetadata", "0" ).toString() );
 
@@ -655,14 +655,14 @@ QDomDocument QgsManageConnectionsDialog::saveDb2Connections( const QStringList &
 
     if ( settings.value( path + "/saveUsername", "false" ).toString() == QLatin1String( "true" ) )
     {
-      el.setAttribute( QStringLiteral( "username" ), settings.value( path + "/username", "" ).toString() );
+      el.setAttribute( QStringLiteral( "username" ), settings.value( path + "/username" ).toString() );
     }
 
     el.setAttribute( QStringLiteral( "savePassword" ), settings.value( path + "/savePassword", "false" ).toString() );
 
     if ( settings.value( path + "/savePassword", "false" ).toString() == QLatin1String( "true" ) )
     {
-      el.setAttribute( QStringLiteral( "password" ), settings.value( path + "/password", "" ).toString() );
+      el.setAttribute( QStringLiteral( "password" ), settings.value( path + "/password" ).toString() );
     }
 
     root.appendChild( el );
@@ -685,11 +685,11 @@ QDomDocument QgsManageConnectionsDialog::saveGeonodeConnections( const QStringLi
     path = QStringLiteral( "/qgis/connections-geonode/" );
     QDomElement el = doc.createElement( QStringLiteral( "geonode" ) );
     el.setAttribute( QStringLiteral( "name" ), connections[ i ] );
-    el.setAttribute( QStringLiteral( "url" ), settings.value( path + connections[ i ] + "/url", "" ).toString() );
+    el.setAttribute( QStringLiteral( "url" ), settings.value( path + connections[ i ] + "/url" ).toString() );
 
     path = QStringLiteral( "/qgis/GeoNode/" );
-    el.setAttribute( QStringLiteral( "username" ), settings.value( path + connections[ i ] + "/username", "" ).toString() );
-    el.setAttribute( QStringLiteral( "password" ), settings.value( path + connections[ i ] + "/password", "" ).toString() );
+    el.setAttribute( QStringLiteral( "username" ), settings.value( path + connections[ i ] + "/username" ).toString() );
+    el.setAttribute( QStringLiteral( "password" ), settings.value( path + connections[ i ] + "/password" ).toString() );
     root.appendChild( el );
   }
 
@@ -711,13 +711,13 @@ QDomDocument QgsManageConnectionsDialog::saveXyzTilesConnections( const QStringL
     QDomElement el = doc.createElement( QStringLiteral( "xyztiles" ) );
 
     el.setAttribute( QStringLiteral( "name" ), connections[ i ] );
-    el.setAttribute( QStringLiteral( "url" ), settings.value( path + "/url", "" ).toString() );
+    el.setAttribute( QStringLiteral( "url" ), settings.value( path + "/url" ).toString() );
     el.setAttribute( QStringLiteral( "zmin" ), settings.value( path + "/zmin", -1 ).toInt() );
     el.setAttribute( QStringLiteral( "zmax" ), settings.value( path + "/zmax", -1 ).toInt() );
-    el.setAttribute( QStringLiteral( "authcfg" ), settings.value( path + "/authcfg", "" ).toString() );
-    el.setAttribute( QStringLiteral( "username" ), settings.value( path + "/username", "" ).toString() );
-    el.setAttribute( QStringLiteral( "password" ), settings.value( path + "/password", "" ).toString() );
-    el.setAttribute( QStringLiteral( "referer" ), settings.value( path + "/referer", "" ).toString() );
+    el.setAttribute( QStringLiteral( "authcfg" ), settings.value( path + "/authcfg" ).toString() );
+    el.setAttribute( QStringLiteral( "username" ), settings.value( path + "/username" ).toString() );
+    el.setAttribute( QStringLiteral( "password" ), settings.value( path + "/password" ).toString() );
+    el.setAttribute( QStringLiteral( "referer" ), settings.value( path + "/referer" ).toString() );
 
     root.appendChild( el );
   }
@@ -739,13 +739,13 @@ QDomDocument QgsManageConnectionsDialog::saveArcgisConnections( const QStringLis
     path = "/qgis/connections-" + service.toLower() + '/';
     QDomElement el = doc.createElement( service.toLower() );
     el.setAttribute( QStringLiteral( "name" ), connections[ i ] );
-    el.setAttribute( QStringLiteral( "url" ), settings.value( path + connections[ i ] + "/url", "" ).toString() );
-    el.setAttribute( QStringLiteral( "referer" ), settings.value( path + connections[ i ] + "/referer", "" ).toString() );
+    el.setAttribute( QStringLiteral( "url" ), settings.value( path + connections[ i ] + "/url" ).toString() );
+    el.setAttribute( QStringLiteral( "referer" ), settings.value( path + connections[ i ] + "/referer" ).toString() );
 
     path = "/qgis/" + service.toUpper() + '/';
-    el.setAttribute( QStringLiteral( "username" ), settings.value( path + connections[ i ] + "/username", "" ).toString() );
-    el.setAttribute( QStringLiteral( "password" ), settings.value( path + connections[ i ] + "/password", "" ).toString() );
-    el.setAttribute( QStringLiteral( "authcfg" ), settings.value( path + connections[ i ] + "/authcfg", "" ).toString() );
+    el.setAttribute( QStringLiteral( "username" ), settings.value( path + connections[ i ] + "/username" ).toString() );
+    el.setAttribute( QStringLiteral( "password" ), settings.value( path + connections[ i ] + "/password" ).toString() );
+    el.setAttribute( QStringLiteral( "authcfg" ), settings.value( path + connections[ i ] + "/authcfg" ).toString() );
     root.appendChild( el );
   }
 
@@ -767,7 +767,7 @@ QDomDocument QgsManageConnectionsDialog::saveVectorTileConnections( const QStrin
     QDomElement el = doc.createElement( QStringLiteral( "vectortile" ) );
 
     el.setAttribute( QStringLiteral( "name" ), connections[ i ] );
-    el.setAttribute( QStringLiteral( "url" ), settings.value( path + "/url", "" ).toString() );
+    el.setAttribute( QStringLiteral( "url" ), settings.value( path + "/url" ).toString() );
     el.setAttribute( QStringLiteral( "zmin" ), settings.value( path + "/zmin", -1 ).toInt() );
     el.setAttribute( QStringLiteral( "zmax" ), settings.value( path + "/zmax", -1 ).toInt() );
 


### PR DESCRIPTION
## Description
WFS connection settings now have much more information then just connection name and URL: WFS version, axis orientation settings, pagination etc. All these are missed from the XML exchange file when connections are exported for sharing.

This PR adds these missed WFS settings to the exchange file. Fixes #35866