### PR TITLE
assign correct geometry calculator to expression builder widget in the Select by Expression dialog (fix #35628)

### DIFF
--- a/src/gui/qgsexpressionselectiondialog.cpp
+++ b/src/gui/qgsexpressionselectiondialog.cpp
@@ -59,6 +59,11 @@ QgsExpressionSelectionDialog::QgsExpressionSelectionDialog( QgsVectorLayer *laye
   mExpressionBuilder->initWithLayer( layer, context, QStringLiteral( "selection" ) );
   mExpressionBuilder->setExpressionText( startText );
 
+  QgsDistanceArea da;
+  da.setSourceCrs( layer->crs(), QgsProject::instance()->transformContext() );
+  da.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  mExpressionBuilder->setGeomCalculator( da );
+
   // by default, zoom to features is hidden, shown only if canvas is set
   mButtonZoomToFeatures->setVisible( false );
 


### PR DESCRIPTION
## Description
When projected CRS is used preview for `$perimeter` and `$area` expressions gives wrong results, although selection itself works fine. At the same time preview for same layer/expression in the Field Calculator is correct. Fixes #35628.