### PR TITLE
Close 3D measurement on 3D canvas close

### DIFF
--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -58,10 +58,11 @@ Qgs3DMapCanvas::Qgs3DMapCanvas( QWidget *parent )
 
 Qgs3DMapCanvas::~Qgs3DMapCanvas()
 {
+  if ( mMapTool )
+    mMapTool->deactivate();
   // make sure the scene is deleted while map settings object is still alive
   delete mScene;
   mScene = nullptr;
-
   delete mMap;
   mMap = nullptr;
 }

--- a/src/app/3d/qgs3dmaptoolmeasureline.cpp
+++ b/src/app/3d/qgs3dmaptoolmeasureline.cpp
@@ -57,6 +57,8 @@ Qgs3DMapToolMeasureLine::Qgs3DMapToolMeasureLine( Qgs3DMapCanvas *canvas )
   mDialog->setWindowFlags( mDialog->windowFlags() | Qt::Tool );
   mDialog->restorePosition();
 
+  // Update scale if the terrain vertical scale changed
+  connect( mCanvas->map(), &Qgs3DMapSettings::terrainVerticalScaleChanged, this, &Qgs3DMapToolMeasureLine::updateMeasurementLayer );
   connect( canvas, &Qgs3DMapCanvas::mapSettingsChanged, this, &Qgs3DMapToolMeasureLine::onMapSettingsChanged );
 }
 
@@ -97,7 +99,6 @@ void Qgs3DMapToolMeasureLine::activate()
     updateSettings();
     mIsAlreadyActivated = true;
   }
-
   // Show dialog
   mDialog->updateSettings();
   mDialog->show();
@@ -281,3 +282,4 @@ QVector<QgsPoint> Qgs3DMapToolMeasureLine::points() const
 {
   return mPoints;
 }
+

--- a/src/app/3d/qgs3dmaptoolmeasureline.cpp
+++ b/src/app/3d/qgs3dmaptoolmeasureline.cpp
@@ -58,7 +58,6 @@ Qgs3DMapToolMeasureLine::Qgs3DMapToolMeasureLine( Qgs3DMapCanvas *canvas )
   mDialog->restorePosition();
 
   // Update scale if the terrain vertical scale changed
-  connect( mCanvas->map(), &Qgs3DMapSettings::terrainVerticalScaleChanged, this, &Qgs3DMapToolMeasureLine::updateMeasurementLayer );
   connect( canvas, &Qgs3DMapCanvas::mapSettingsChanged, this, &Qgs3DMapToolMeasureLine::onMapSettingsChanged );
 }
 
@@ -282,4 +281,3 @@ QVector<QgsPoint> Qgs3DMapToolMeasureLine::points() const
 {
   return mPoints;
 }
-

--- a/src/app/3d/qgs3dmaptoolmeasureline.h
+++ b/src/app/3d/qgs3dmaptoolmeasureline.h
@@ -73,6 +73,9 @@ class Qgs3DMapToolMeasureLine : public Qgs3DMapTool
     void handleClick( Qt3DRender::QPickEvent *event, const QgsVector3D &worldIntersection );
     void onMapSettingsChanged() override;
 
+  signals:
+    void closingTool();
+
   private:
     std::unique_ptr<Qgs3DMapToolMeasureLinePickHandler> mPickHandler;
 
@@ -92,6 +95,8 @@ class Qgs3DMapToolMeasureLine : public Qgs3DMapTool
 
     //! Dialog
     Qgs3DMeasureDialog *mDialog = nullptr;
+
+    bool mCanvasClosed = false;
 };
 
 #endif // QGS3DMAPTOOLMEASURELINE_H

--- a/src/app/3d/qgs3dmaptoolmeasureline.h
+++ b/src/app/3d/qgs3dmaptoolmeasureline.h
@@ -73,9 +73,6 @@ class Qgs3DMapToolMeasureLine : public Qgs3DMapTool
     void handleClick( Qt3DRender::QPickEvent *event, const QgsVector3D &worldIntersection );
     void onMapSettingsChanged() override;
 
-  signals:
-    void closingTool();
-
   private:
     std::unique_ptr<Qgs3DMapToolMeasureLinePickHandler> mPickHandler;
 
@@ -96,7 +93,6 @@ class Qgs3DMapToolMeasureLine : public Qgs3DMapTool
     //! Dialog
     Qgs3DMeasureDialog *mDialog = nullptr;
 
-    bool mCanvasClosed = false;
 };
 
 #endif // QGS3DMAPTOOLMEASURELINE_H


### PR DESCRIPTION
## Description

Proposal to Fix #34632 

This changes ensure that the measurement dialog is closed when the 3D canvas is also closed to prevent crash and other inconsistencies.