### PR TITLE
[feature] ability to remove custom functions (fix #27513)

### DIFF
--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -425,6 +425,11 @@ void QgsExpressionBuilderWidget::btnNewFile_pressed()
 
 void QgsExpressionBuilderWidget::btnRemoveFile_pressed()
 {
+  if ( QMessageBox::question( this, tr( "Remove File" ),
+                              tr( "Are you sure you want to remove current functions file?" ),
+                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) == QMessageBox::No )
+    return;
+
   int currentRow = cmbFileNames->currentRow();
   QString fileName = cmbFileNames->currentItem()->text();
   if ( QFile::remove( mFunctionsPath + QDir::separator() + fileName.append( ".py" ) ) )

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -29,7 +29,6 @@
 #include <QJsonArray>
 #include <QFileDialog>
 #include <QMenu>
-#include <QSignalBlocker>
 
 #include "qgsexpressionbuilderwidget.h"
 #include "qgslogger.h"
@@ -431,8 +430,7 @@ void QgsExpressionBuilderWidget::btnRemoveFile_pressed()
   if ( QFile::remove( mFunctionsPath + QDir::separator() + fileName.append( ".py" ) ) )
   {
     {
-      const QSignalBlocker blocker( cmbFileNames );
-      QListWidgetItem *itemToRemove = cmbFileNames->takeItem( currentRow );
+      QListWidgetItem *itemToRemove = whileBlocking( cmbFileNames )->takeItem( currentRow );
       delete itemToRemove;
     }
 

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -29,6 +29,7 @@
 #include <QJsonArray>
 #include <QFileDialog>
 #include <QMenu>
+#include <QSignalBlocker>
 
 #include "qgsexpressionbuilderwidget.h"
 #include "qgslogger.h"
@@ -425,14 +426,15 @@ void QgsExpressionBuilderWidget::btnNewFile_pressed()
 
 void QgsExpressionBuilderWidget::btnRemoveFile_pressed()
 {
+  int currentRow = cmbFileNames->currentRow();
   QString fileName = cmbFileNames->currentItem()->text();
   if ( QFile::remove( mFunctionsPath + QDir::separator() + fileName.append( ".py" ) ) )
   {
-    cmbFileNames->blockSignals( true );
-    int currentRow = cmbFileNames->currentRow();
-    QListWidgetItem *itemToRemove = cmbFileNames->takeItem( currentRow );
-    delete itemToRemove;
-    cmbFileNames->blockSignals( false );
+    {
+      const QSignalBlocker blocker( cmbFileNames );
+      QListWidgetItem *itemToRemove = cmbFileNames->takeItem( currentRow );
+      delete itemToRemove;
+    }
 
     if ( cmbFileNames->count() > 0 )
     {

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -340,6 +340,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void operatorButtonClicked();
     void btnRun_pressed();
     void btnNewFile_pressed();
+    void btnRemoveFile_pressed();
 
     /**
      * Display a file dialog to choose where to store the exported expressions JSON file

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -35,7 +35,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="documentMode">
       <bool>true</bool>
@@ -835,7 +835,27 @@ Change the name of the script and save to allow QGIS to auto load on startup.</s
                </property>
                <property name="icon">
                 <iconset resource="../../images/images.qrc">
-                 <normaloff>:/images/themes/default/console/iconNewTabEditorConsole.svg</normaloff>:/images/themes/default/console/iconNewTabEditorConsole.svg</iconset>
+                 <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+               </property>
+               <property name="iconSize">
+                <size>
+                 <width>24</width>
+                 <height>24</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnRemoveFile">
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove selected functions file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="icon">
+                <iconset resource="../../images/images.qrc">
+                 <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
                </property>
                <property name="iconSize">
                 <size>


### PR DESCRIPTION
## Description
Add remove button to the Functions Editor tab in the Expression builder dialog to allow removing user functions from QGIS without need to navigate to user profile directory.

Fixes #27513.