### PR TITLE
[win dev] Make build directory of package-nightly.cmd configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,7 @@ ms-windows/osgeo4w/binary-*
 ms-windows/osgeo4w/nsis/
 ms-windows/osgeo4w/packages-x86/
 ms-windows/osgeo4w/packages-x86_64/
-ms-windows/osgeo4w/build-qgis-test-x86/
-ms-windows/osgeo4w/build-qgis-test-x86_64/
+ms-windows/osgeo4w/build-*
 ms-windows/osgeo4w/unpacked/
 ms-windows/osgeo4w/untgz/
 ms-windows/packages/

--- a/ms-windows/osgeo4w/package-nightly.cmd
+++ b/ms-windows/osgeo4w/package-nightly.cmd
@@ -31,7 +31,7 @@ if "%SITE%"=="" set SITE=qgis.org
 if "%TARGET%"=="" set TARGET=Nightly
 if "%BUILDNAME%"=="" set BUILDNAME=%PACKAGENAME%-%VERSION%%SHA%-%TARGET%-VC14-%ARCH%
 
-set BUILDDIR=%CD%\build-%PACKAGENAME%-%ARCH%
+if "%BUILDDIR%"=="" set BUILDDIR=%CD%\build-%PACKAGENAME%-%ARCH%
 if not exist "%BUILDDIR%" mkdir %BUILDDIR%
 if not exist "%BUILDDIR%" (echo could not create build directory %BUILDDIR% & goto error)
 


### PR DESCRIPTION
`package-nightly.cmd` is the easiest and most up to date way to make a build on Windows, but currently it hard codes the build directory to `%CD%\build-%PACKAGENAME%-%ARCH%`.

This has a few issues :
- if the QGIS source is a bit deep in the folder hierarchy, one can get a `The specified path, file name, or both are too long. [...]` error (even with long paths enabled in Windows it seems).
- the build output is very deep in the hierarchy
- the build directory is not .gitignored

This PR adds the ability to provide a BUILDDIR env var, to customize it. If unset, behaviour is unchanged. By the way, the PR also .gitignores the default build dir.

I know this script's main use if for packaging, and not for developing, but it's a reasonably simple modification :-) Following this I'll try to propose some other commits to improve dev experience on Windows (looking at you, prepare-commit.sh).
