### PR TITLE
Fix build errors for txt2tags on macos

### DIFF
--- a/doc/INSTALL.t2t
+++ b/doc/INSTALL.t2t
@@ -4,7 +4,7 @@ Building QGIS from source - step by step
 
 %! target       : html
 %! style        : style.css
-%! Options      : --toc --toc-level 2 --enum-title
+%! Options      : --enum-title
 %! preproc      : TUT_URL   https://qgis.org
 %! PostProc(html): '(?i)(<pre>)' '<div class="code">\1'
 %! PostProc(html): '(?i)(</pre>)' '\1</div>'

--- a/doc/NEWS.t2t
+++ b/doc/NEWS.t2t
@@ -4,7 +4,7 @@ Change history for the QGIS Project
 
 %! target       : html
 %! style        : style.css
-%! Options      : --toc --toc-level 1 --enum-title
+%! Options      : --enum-title
 %! preproc      : TUT_URL   https://qgis.org
 %! PostProc(html): '(?i)(<pre>)' '<div class="code">\1'
 %! PostProc(html): '(?i)(</pre>)' '\1</div>'


### PR DESCRIPTION
## Description

On macOS brew, we only get txt2tags 3.7 which deprecates the ``--toc-level`` option for txt2tags

This PR fixes the doc build though I think creates some small formatting issues in the generated HTML. Similar issue to https://github.com/qgis/QGIS/issues/33516

