### PR TITLE
Make cmake output slightly better

### DIFF
--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -44,7 +44,7 @@ ADD_QGIS_RESOURCES("${CMAKE_CURRENT_SOURCE_DIR}" resources DEST_RESOURCE_FILES "
 
 # srs.db -- special handling because there is a switch and rename depending on proj version
 IF (PROJ_VERSION_MAJOR GREATER 5)
-  MESSAGE(STATUS "Using PROJ 6 srs database.")
+  MESSAGE(STATUS "Using PROJ >= 6 srs database.")
   SET(SRSDB srs6.db)
 ELSE (PROJ_VERSION_MAJOR GREATER 5)
   MESSAGE(STATUS "Using PROJ <6 srs database.")


### PR DESCRIPTION
Seeing the following output during compile:

```
$ ninja install
[0/1] Re-running CMake...
-- QGIS version: 3.13.0 Master (31300)
...
-- Found Proj: /usr/lib/x86_64-linux-gnu/libproj.so version 7 (7.0.0)
...
-- Using PROJ 6 srs database.
-- Configuring done
-- Generating done
```
I was wondering if I was maybe mixing up proj6 and proj7 stuff..
Even told me that "Using PROJ 6 srs database." should be read as "Using PROJ >= 6 srs database

See https://lists.osgeo.org/pipermail/qgis-developer/2020-April/061002.html

So I thought to actually make it output this, so other nitwitpickers like me will be silenced... :-)