### PR TITLE
Add some helpful scoped RAII classes for use with QgsRenderContext

### DIFF
--- a/python/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/core/auto_generated/qgsrendercontext.sip.in
@@ -793,6 +793,7 @@ Clears the specified custom rendering flag.
 QFlags<QgsRenderContext::Flag> operator|(QgsRenderContext::Flag f1, QFlags<QgsRenderContext::Flag> f2);
 
 
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *


### PR DESCRIPTION
- QgsScopedRenderContextPainterSwap: allows for temporarily swapping the destination painter object for a QgsRenderContext for the lifetime of the object

- QgsScopedRenderContextScaleToMm: temporarily rescales a render context destination painter device to use millimeter based units for the lifetime of the object

- QgsScopedRenderContextScaleToPixels: temporarily rescales a render context (which has been scaled to millimeter based units) back to pixel based units, for the lifetime of the object
