### PR TITLE
[layouts] Add explicit button to insert expressions in legend text

### DIFF
--- a/src/gui/layout/qgslayoutlegendwidget.h
+++ b/src/gui/layout/qgslayoutlegendwidget.h
@@ -185,8 +185,9 @@ class GUI_EXPORT QgsLayoutLegendNodeWidget: public QgsPanelWidget, private Ui::Q
 
   private slots:
 
-    void labelChanged( const QString &label );
+    void labelChanged();
     void patchChanged();
+    void insertExpression();
 
   private:
 

--- a/src/ui/layout/qgslayoutlegendnodewidgetbase.ui
+++ b/src/ui/layout/qgslayoutlegendnodewidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>282</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,17 +26,17 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Label</string>
+   <item row="0" column="1">
+    <widget class="QPlainTextEdit" name="mLabelEdit">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>150</height>
+      </size>
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="mLabelEdit"/>
-   </item>
-   <item row="2" column="1">
+   <item row="3" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -49,14 +49,14 @@
      </property>
     </spacer>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="mPatchShapeLabel">
+   <item row="1" column="1">
+    <widget class="QPushButton" name="mInsertExpressionButton">
      <property name="text">
-      <string>Patch shape</string>
+      <string>Insert an Expression…</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="2" column="1">
     <widget class="QgsLegendPatchShapeButton" name="mPatchShapeButton">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -66,6 +66,20 @@
      </property>
      <property name="text">
       <string>Customize</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="mPatchShapeLabel">
+     <property name="text">
+      <string>Patch shape</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Label</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
While this has been possible for a while by manually entering a "[% expression %]" string as part of a legend item's text, this is completely hidden from users and rather useless.

Now that we have a dedicated widget to allow configuration of individual legend items, we've got the capacity to show a dedicated "insert expression" button, just like we do for layout labels.

This makes it immediately clear to users that expressions CAN be used in legend item text, and also helps them construct valid expressions using the available expression context.

![Peek 2020-04-23 16-25](https://user-images.githubusercontent.com/1829991/80066335-15204a80-857f-11ea-8c8a-ec163541d6ae.gif)
