### PR TITLE
silence debug information from delimited text provider (fix #35552)

### DIFF
--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
@@ -34,7 +34,7 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
 {
 
   // Determine mode to use based on request...
-  QgsDebugMsg( QStringLiteral( "Setting up QgsDelimitedTextIterator" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Setting up QgsDelimitedTextIterator" ), 4 );
 
   // Does the layer have geometry - will revise later to determine if we actually need to
   // load it.
@@ -57,7 +57,7 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
 
   if ( !mFilterRect.isNull() && hasGeometry )
   {
-    QgsDebugMsg( QStringLiteral( "Configuring for rectangle select" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Configuring for rectangle select" ), 4 );
     mTestGeometry = true;
     // Exact intersection test only applies for WKT geometries
     mTestGeometryExact = mRequest.flags() & QgsFeatureRequest::ExactIntersect
@@ -66,7 +66,7 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
     // If request doesn't overlap extents, then nothing to return
     if ( ! mFilterRect.intersects( mSource->mExtent ) && !mTestSubset )
     {
-      QgsDebugMsg( QStringLiteral( "Rectangle outside layer extents - no features to return" ) );
+      QgsDebugMsgLevel( QStringLiteral( "Rectangle outside layer extents - no features to return" ), 4 );
       mMode = FeatureIds;
     }
     // If the request extents include the entire layer, then revert to
@@ -74,7 +74,7 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
 
     else if ( mFilterRect.contains( mSource->mExtent ) && !mTestSubset )
     {
-      QgsDebugMsg( QStringLiteral( "Rectangle contains layer extents - bypass spatial filter" ) );
+      QgsDebugMsgLevel( QStringLiteral( "Rectangle contains layer extents - bypass spatial filter" ), 4 );
       mTestGeometry = false;
     }
 
@@ -87,7 +87,7 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
       mFeatureIds = mSource->mSpatialIndex->intersects( mFilterRect );
       // Sort for efficient sequential retrieval
       std::sort( mFeatureIds.begin(), mFeatureIds.end() );
-      QgsDebugMsg( QStringLiteral( "Layer has spatial index - selected %1 features from index" ).arg( mFeatureIds.size() ) );
+      QgsDebugMsgLevel( QStringLiteral( "Layer has spatial index - selected %1 features from index" ).arg( mFeatureIds.size() ), 4 );
       mMode = FeatureIds;
       mTestSubset = false;
       mTestGeometry = mTestGeometryExact;
@@ -96,7 +96,7 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
 
   if ( request.filterType() == QgsFeatureRequest::FilterFid )
   {
-    QgsDebugMsg( QStringLiteral( "Configuring for returning single id" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Configuring for returning single id" ), 4 );
     if ( mFilterRect.isNull() || mFeatureIds.contains( request.filterFid() ) )
     {
       mFeatureIds = QList<QgsFeatureId>() << request.filterFid();
@@ -116,7 +116,7 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
     // If we have a subset index then use it..
     if ( mMode == FileScan && mSource->mUseSubsetIndex )
     {
-      QgsDebugMsg( QStringLiteral( "Layer has subset index - use %1 items from subset index" ).arg( mSource->mSubsetIndex.size() ) );
+      QgsDebugMsgLevel( QStringLiteral( "Layer has subset index - use %1 items from subset index" ).arg( mSource->mSubsetIndex.size() ), 4 );
       mTestSubset = false;
       mMode = SubsetIndex;
     }
@@ -124,7 +124,7 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
   // Otherwise just have to scan the file
   if ( mMode == FileScan )
   {
-    QgsDebugMsg( QStringLiteral( "File will be scanned for desired features" ) );
+    QgsDebugMsgLevel( QStringLiteral( "File will be scanned for desired features" ), 4 );
   }
 
   // If the layer has geometry, do we really need to load it?
@@ -170,10 +170,10 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
     mRequest.setSubsetOfAttributes( attrs );
   }
 
-  QgsDebugMsg( QStringLiteral( "Iterator is scanning file: " ) + ( mMode == FileScan ? "Yes" : "No" ) );
-  QgsDebugMsg( QStringLiteral( "Iterator is loading geometries: " ) + ( mLoadGeometry ? "Yes" : "No" ) );
-  QgsDebugMsg( QStringLiteral( "Iterator is testing geometries: " ) + ( mTestGeometry ? "Yes" : "No" ) );
-  QgsDebugMsg( QStringLiteral( "Iterator is testing subset: " ) + ( mTestSubset ? "Yes" : "No" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Iterator is scanning file: " ) + ( mMode == FileScan ? "Yes" : "No" ), 4 );
+  QgsDebugMsgLevel( QStringLiteral( "Iterator is loading geometries: " ) + ( mLoadGeometry ? "Yes" : "No" ), 4 );
+  QgsDebugMsgLevel( QStringLiteral( "Iterator is testing geometries: " ) + ( mTestGeometry ? "Yes" : "No" ), 4 );
+  QgsDebugMsgLevel( QStringLiteral( "Iterator is testing subset: " ) + ( mTestSubset ? "Yes" : "No" ), 4 );
 
   rewind();
 }

--- a/src/providers/delimitedtext/qgsdelimitedtextfile.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfile.cpp
@@ -79,7 +79,7 @@ bool QgsDelimitedTextFile::open()
     mFile = new QFile( mFileName );
     if ( ! mFile->open( QIODevice::ReadOnly ) )
     {
-      QgsDebugMsg( "Data file " + mFileName + " could not be opened" );
+      QgsDebugMsgLevel( "Data file " + mFileName + " could not be opened", 2 );
       delete mFile;
       mFile = nullptr;
     }
@@ -211,17 +211,17 @@ bool QgsDelimitedTextFile::setFromUrl( const QUrl &url )
     mMaxFields = query.queryItemValue( QStringLiteral( "maxFields" ) ).toInt();
   }
 
-  QgsDebugMsg( "Delimited text file is: " + mFileName );
-  QgsDebugMsg( "Encoding is: " + mEncoding );
-  QgsDebugMsg( "Delimited file type is: " + type );
-  QgsDebugMsg( "Delimiter is: [" + delimiter + ']' );
-  QgsDebugMsg( "Quote character is: [" + quote + ']' );
-  QgsDebugMsg( "Escape character is: [" + escape + ']' );
-  QgsDebugMsg( "Skip lines: " + QString::number( mSkipLines ) );
-  QgsDebugMsg( "Maximum number of fields in record: " + QString::number( mMaxFields ) );
-  QgsDebugMsg( "Use headers: " + QString( mUseHeader ? "Yes" : "No" ) );
-  QgsDebugMsg( "Discard empty fields: " + QString( mDiscardEmptyFields ? "Yes" : "No" ) );
-  QgsDebugMsg( "Trim fields: " + QString( mTrimFields ? "Yes" : "No" ) );
+  QgsDebugMsgLevel( "Delimited text file is: " + mFileName, 2 );
+  QgsDebugMsgLevel( "Encoding is: " + mEncoding, 2 );
+  QgsDebugMsgLevel( "Delimited file type is: " + type, 2 );
+  QgsDebugMsgLevel( "Delimiter is: [" + delimiter + ']', 2 );
+  QgsDebugMsgLevel( "Quote character is: [" + quote + ']', 2 );
+  QgsDebugMsgLevel( "Escape character is: [" + escape + ']', 2 );
+  QgsDebugMsgLevel( "Skip lines: " + QString::number( mSkipLines ), 2 );
+  QgsDebugMsgLevel( "Maximum number of fields in record: " + QString::number( mMaxFields ), 2 );
+  QgsDebugMsgLevel( "Use headers: " + QString( mUseHeader ? "Yes" : "No" ), 2 );
+  QgsDebugMsgLevel( "Discard empty fields: " + QString( mDiscardEmptyFields ? "Yes" : "No" ), 2 );
+  QgsDebugMsgLevel( "Trim fields: " + QString( mTrimFields ? "Yes" : "No" ), 2 );
 
   // Support for previous version of plain characters
   if ( type == QLatin1String( "csv" ) || type == QLatin1String( "plain" ) )
@@ -335,12 +335,12 @@ void QgsDelimitedTextFile::setTypeRegexp( const QString &regexp )
   mDefinitionValid = !regexp.isEmpty() && mDelimRegexp.isValid();
   if ( ! mDefinitionValid )
   {
-    QgsDebugMsg( "Invalid regular expression in delimited text file delimiter: " + regexp );
+    QgsDebugMsgLevel( "Invalid regular expression in delimited text file delimiter: " + regexp, 2 );
   }
   else if ( mAnchoredRegexp && mDelimRegexp.captureCount() == 0 )
   {
     mDefinitionValid = false;
-    QgsDebugMsg( "Invalid anchored regular expression - must have capture groups: " + regexp );
+    QgsDebugMsgLevel( "Invalid anchored regular expression - must have capture groups: " + regexp, 2 );
   }
 }
 
@@ -367,7 +367,7 @@ void QgsDelimitedTextFile::setTypeCSV( const QString &delim, const QString &quot
   mDefinitionValid = !mDelimChars.isEmpty();
   if ( ! mDefinitionValid )
   {
-    QgsDebugMsg( QStringLiteral( "Invalid empty delimiter defined for text file delimiter" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Invalid empty delimiter defined for text file delimiter" ), 2 );
   }
 }
 

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -70,7 +70,7 @@ QgsDelimitedTextProvider::QgsDelimitedTextProvider( const QString &uri, const Pr
                   << QgsVectorDataProvider::NativeType( tr( "Text, unlimited length (text)" ), QStringLiteral( "text" ), QVariant::String, -1, -1, -1, -1 )
                 );
 
-  QgsDebugMsg( "Delimited text file uri is " + uri );
+  QgsDebugMsgLevel( "Delimited text file uri is " + uri, 2 );
 
   const QUrl url = QUrl::fromEncoded( uri.toLatin1() );
   mFile = qgis::make_unique< QgsDelimitedTextFile >();
@@ -94,7 +94,7 @@ QgsDelimitedTextProvider::QgsDelimitedTextProvider( const QString &uri, const Pr
     {
       mWktFieldName = query.queryItemValue( QStringLiteral( "wktField" ) );
       mGeomRep = GeomAsWkt;
-      QgsDebugMsg( "wktField is: " + mWktFieldName );
+      QgsDebugMsgLevel( "wktField is: " + mWktFieldName, 2 );
     }
     else if ( query.hasQueryItem( QStringLiteral( "xField" ) ) && query.hasQueryItem( QStringLiteral( "yField" ) ) )
     {
@@ -106,10 +106,10 @@ QgsDelimitedTextProvider::QgsDelimitedTextProvider( const QString &uri, const Pr
         mZFieldName = query.queryItemValue( QStringLiteral( "zField" ) );
       if ( query.hasQueryItem( QStringLiteral( "mField" ) ) )
         mMFieldName = query.queryItemValue( QStringLiteral( "mField" ) );
-      QgsDebugMsg( "xField is: " + mXFieldName );
-      QgsDebugMsg( "yField is: " + mYFieldName );
-      QgsDebugMsg( "zField is: " + mZFieldName );
-      QgsDebugMsg( "mField is: " + mMFieldName );
+      QgsDebugMsgLevel( "xField is: " + mXFieldName, 2 );
+      QgsDebugMsgLevel( "yField is: " + mYFieldName, 2 );
+      QgsDebugMsgLevel( "zField is: " + mZFieldName, 2 );
+      QgsDebugMsgLevel( "mField is: " + mMFieldName, 2 );
 
       if ( query.hasQueryItem( QStringLiteral( "xyDms" ) ) )
       {
@@ -146,7 +146,7 @@ QgsDelimitedTextProvider::QgsDelimitedTextProvider( const QString &uri, const Pr
   {
     // We need to specify FullyDecoded so that %25 is decoded as %
     subset = query.queryItemValue( QStringLiteral( "subset" ), QUrl::FullyDecoded );
-    QgsDebugMsg( "subset is: " + subset );
+    QgsDebugMsgLevel( "subset is: " + subset, 2 );
   }
 
   if ( query.hasQueryItem( QStringLiteral( "quiet" ) ) ) mShowInvalidLines = false;
@@ -226,16 +226,15 @@ QStringList QgsDelimitedTextProvider::readCsvtFieldTypes( const QString &filenam
   }
 
   // All good, so pull out the types from the string.  Currently only returning integer, real, and string types
-
-  QgsDebugMsg( QStringLiteral( "Reading field types from %1" ).arg( csvtInfo.fileName() ) );
-  QgsDebugMsg( QStringLiteral( "Field type string: %1" ).arg( strTypeList ) );
+  QgsDebugMsgLevel( QStringLiteral( "Reading field types from %1" ).arg( csvtInfo.fileName() ), 2 );
+  QgsDebugMsgLevel( QStringLiteral( "Field type string: %1" ).arg( strTypeList ), 2 );
 
   int pos = 0;
   QRegExp reType( "(integer|real|double|string|date|datetime|time)" );
 
   while ( ( pos = reType.indexIn( strTypeList, pos ) ) != -1 )
   {
-    QgsDebugMsg( QStringLiteral( "Found type: %1" ).arg( reType.cap( 1 ) ) );
+    QgsDebugMsgLevel( QStringLiteral( "Found type: %1" ).arg( reType.cap( 1 ) ), 2 );
     types << reType.cap( 1 );
     pos += reType.matchedLength();
   }
@@ -326,7 +325,7 @@ void QgsDelimitedTextProvider::scanFile( bool buildIndexes )
 
     messages.append( tr( "File cannot be opened or delimiter parameters are not valid" ) );
     reportErrors( messages );
-    QgsDebugMsg( QStringLiteral( "Delimited text source invalid - filename or delimiter parameters" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Delimited text source invalid - filename or delimiter parameters" ), 2 );
     return;
   }
 
@@ -374,7 +373,7 @@ void QgsDelimitedTextProvider::scanFile( bool buildIndexes )
   if ( !messages.isEmpty() )
   {
     reportErrors( messages );
-    QgsDebugMsg( QStringLiteral( "Delimited text source invalid - missing geometry fields" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Delimited text source invalid - missing geometry fields" ), 2 );
     return;
   }
 
@@ -681,10 +680,9 @@ void QgsDelimitedTextProvider::scanFile( bool buildIndexes )
     attributeFields.append( QgsField( fieldNames[i], fieldType, typeName ) );
   }
 
-
-  QgsDebugMsg( "Field count for the delimited text file is " + QString::number( attributeFields.size() ) );
-  QgsDebugMsg( "geometry type is: " + QString::number( mWkbType ) );
-  QgsDebugMsg( "feature count is: " + QString::number( mNumberFeatures ) );
+  QgsDebugMsgLevel( "Field count for the delimited text file is " + QString::number( attributeFields.size() ), 2 );
+  QgsDebugMsgLevel( "geometry type is: " + QString::number( mWkbType ), 2 );
+  QgsDebugMsgLevel( "feature count is: " + QString::number( mNumberFeatures ), 2 );
 
   QStringList warnings;
   if ( ! csvtMessage.isEmpty() )
@@ -769,7 +767,7 @@ void QgsDelimitedTextProvider::rescanFile() const
   if ( !messages.isEmpty() )
   {
     reportErrors( messages );
-    QgsDebugMsg( QStringLiteral( "Delimited text source invalid on rescan - missing geometry fields" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Delimited text source invalid on rescan - missing geometry fields" ), 2 );
     mValid = false;
     return;
   }
@@ -1091,14 +1089,14 @@ bool QgsDelimitedTextProvider::setSubsetString( const QString &subset, bool upda
     {
       if ( ! mCachedSubsetString.isNull() && mSubsetString == mCachedSubsetString )
       {
-        QgsDebugMsg( QStringLiteral( "DelimitedText: Resetting cached subset string %1" ).arg( mSubsetString ) );
+        QgsDebugMsgLevel( QStringLiteral( "DelimitedText: Resetting cached subset string %1" ).arg( mSubsetString ), 3 );
         mUseSpatialIndex = mCachedUseSpatialIndex;
         mUseSubsetIndex = mCachedUseSubsetIndex;
         resetCachedSubset();
       }
       else
       {
-        QgsDebugMsg( QStringLiteral( "DelimitedText: Setting new subset string %1" ).arg( mSubsetString ) );
+        QgsDebugMsgLevel( QStringLiteral( "DelimitedText: Setting new subset string %1" ).arg( mSubsetString ), 3 );
         // Reset the subset index
         rescanFile();
         // Encode the subset string into the data source URI.
@@ -1108,10 +1106,10 @@ bool QgsDelimitedTextProvider::setSubsetString( const QString &subset, bool upda
     else
     {
       // If not already using temporary subset, then cache the current subset
-      QgsDebugMsg( QStringLiteral( "DelimitedText: Setting temporary subset string %1" ).arg( mSubsetString ) );
+      QgsDebugMsgLevel( QStringLiteral( "DelimitedText: Setting temporary subset string %1" ).arg( mSubsetString ), 3 );
       if ( mCachedSubsetString.isNull() )
       {
-        QgsDebugMsg( QStringLiteral( "DelimitedText: Caching previous subset %1" ).arg( previousSubset ) );
+        QgsDebugMsgLevel( QStringLiteral( "DelimitedText: Caching previous subset %1" ).arg( previousSubset ), 3 );
         mCachedSubsetString = previousSubset;
         mCachedUseSpatialIndex = mUseSpatialIndex;
         mCachedUseSubsetIndex = mUseSubsetIndex;


### PR DESCRIPTION
## Description
Delimited text provider prints a lot of duplicated debug info on every interaction with layer. This PR replaces `QgsDebugMsg` calls with `QgsDebugMsgLevel` to silence most of these messages.

Fixes #35552.