### PR TITLE
Server little cleanup (class documentation)

### DIFF
--- a/python/server/auto_generated/qgsserverapiutils.sip.in
+++ b/python/server/auto_generated/qgsserverapiutils.sip.in
@@ -114,8 +114,11 @@ This method takes into account the ACL restrictions provided by QGIS Server Acce
 
     static QString sanitizedFieldValue( const QString &value );
 %Docstring
-Sanitizes the input ``value`` by removing URL encoding and checking for malicious content.
-In case of failure returns an empty string.
+Sanitizes the input ``value`` by removing URL encoding.
+
+.. note::
+
+   the returned value is meant to become part of a QgsExpression filter
 %End
 
     static QStringList publishedCrsList( const QgsProject *project );

--- a/src/server/qgsserverapiutils.cpp
+++ b/src/server/qgsserverapiutils.cpp
@@ -569,11 +569,6 @@ const QVector<QgsVectorLayer *> QgsServerApiUtils::publishedWfsLayers( const Qgs
 QString QgsServerApiUtils::sanitizedFieldValue( const QString &value )
 {
   QString result { QUrl( value ).toString() };
-  static const QRegularExpression re( R"raw(;.*(DROP|DELETE|INSERT|UPDATE|CREATE|INTO))raw" );
-  if ( re.match( result.toUpper() ).hasMatch() )
-  {
-    result = QString();
-  }
   return result.replace( '\'', QStringLiteral( "\'" ) );
 }
 

--- a/src/server/qgsserverapiutils.h
+++ b/src/server/qgsserverapiutils.h
@@ -203,8 +203,8 @@ class SERVER_EXPORT QgsServerApiUtils
 
 
     /**
-     * Sanitizes the input \a value by removing URL encoding and checking for malicious content.
-     * In case of failure returns an empty string.
+     * Sanitizes the input \a value by removing URL encoding.
+     * \note the returned value is meant to become part of a QgsExpression filter
      */
     static QString sanitizedFieldValue( const QString &value );
 

--- a/src/server/services/wfs3/qgswfs3handlers.h
+++ b/src/server/services/wfs3/qgswfs3handlers.h
@@ -111,7 +111,9 @@ class QgsWfs3StaticHandler: public QgsServerOgcApiHandler
 
 };
 
-
+/**
+ * The QgsWfs3LandingPageHandler is the landing page handler.
+ */
 class QgsWfs3LandingPageHandler: public QgsServerOgcApiHandler
 {
   public:
@@ -138,7 +140,9 @@ class QgsWfs3LandingPageHandler: public QgsServerOgcApiHandler
     json schema( const QgsServerApiContext &context ) const override;
 };
 
-
+/**
+ * The QgsWfs3ConformanceHandler class shows the conformance links.
+ */
 class QgsWfs3ConformanceHandler: public QgsServerOgcApiHandler
 {
   public:

--- a/tests/src/python/test_qgsserver_api.py
+++ b/tests/src/python/test_qgsserver_api.py
@@ -81,6 +81,8 @@ class QgsServerAPIUtilsTest(QgsServerTestBase):
 
         crs = QgsServerApiUtils.parseCrs('http://www.opengis.net/def/crs/OGC/1.3/CRS84')
         self.assertTrue(crs.isValid())
+
+        crs = QgsServerApiUtils.parseCrs('http://www.opengis.net/def/crs/EPSG/9.6.2/4326')
         self.assertEquals(crs.postgisSrid(), 4326)
 
         crs = QgsServerApiUtils.parseCrs('http://www.opengis.net/def/crs/EPSG/9.6.2/3857')


### PR DESCRIPTION
Plus removed sql injection protection from
sanitize because:

1. it was not required: the value goes into a QgsExpression and it's
never sent to a provider directly
2. it could have been misused with the wrong assumption that
it was robust implementation (it wasn't)
