### PR TITLE
[rastercalc] enable Ok button only when expression and output are set (fix #30420)

### DIFF
--- a/src/app/qgsrastercalcdialog.cpp
+++ b/src/app/qgsrastercalcdialog.cpp
@@ -81,6 +81,8 @@ QgsRasterCalcDialog::QgsRasterCalcDialog( QgsRasterLayer *rasterLayer, QWidget *
     mCrsSelector->setCrs( rasterLayer->crs() );
   }
 
+  mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
+
   //add supported output formats
   insertAvailableOutputFormats();
   insertAvailableRasterBands();


### PR DESCRIPTION
## Description
Improve native Raster Calculator UI by enabling OK button only when expression is valid and output file is set. Fixes #30420.

Actually all code was already here, the only missed bit - OK button is not disabled on start.