### PR TITLE
look for qgis_global_settings.ini also in the AppDataLocation (fix #31288)

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -896,10 +896,20 @@ int main( int argc, char *argv[] )
   // Set up the QgsSettings Global Settings:
   // - use the path specified with --globalsettingsfile path,
   // - use the environment if not found
+  // - use the AppDataLocation ($HOME/.local/share/QGIS/QGIS3 on Linux, roaming path on Windows)
   // - use a default location as a fallback
   if ( globalsettingsfile.isEmpty() )
   {
     globalsettingsfile = getenv( "QGIS_GLOBAL_SETTINGS_FILE" );
+  }
+
+  if ( globalsettingsfile.isEmpty() )
+  {
+    QStringList startupPaths = QStandardPaths::locateAll( QStandardPaths::AppDataLocation, QStringLiteral( "qgis_global_settings.ini" ) );
+    if ( !startupPaths.isEmpty() )
+    {
+      globalsettingsfile = startupPaths.at( 0 );
+    }
   }
 
   if ( globalsettingsfile.isEmpty() )


### PR DESCRIPTION
## Description
Allow to put global settings file also in the default location managed by the user or system administrator which is not touched by installer and does not require any additional setup like passing commandline parameters or settings environment variable. Only first found file will be used. On Linux AppData location usually is `$HOME/.local/share/QGIS/QGIS3`, on Windows `%AppData%\Roaming\QGIS\QGIS3`.

With this PR QGIS will look for global settins file (`qgis_global_settings.ini`) in the following places

1. path specified by commandline parameter
2. path defined by environment variable
3. AppData location (see [QStandardPaths](https://doc.qt.io/qt-5/qstandardpaths.html))
4. installation directory

