### PR TITLE
Vector tile layer - part 7 (writing to MBTiles)

### DIFF
--- a/python/core/auto_generated/qgstiles.sip.in
+++ b/python/core/auto_generated/qgstiles.sip.in
@@ -113,6 +113,16 @@ Please note that we follow the XYZ convention of X/Y axes, i.e. top-left tile ha
 Returns a tile matrix for the usual web mercator
 %End
 
+    int matrixWidth() const;
+%Docstring
+Returns number of columns of the tile matrix
+%End
+
+    int matrixHeight() const;
+%Docstring
+Returns number of rows of the tile matrix
+%End
+
     QgsRectangle tileExtent( QgsTileXYZ id ) const;
 %Docstring
 Returns extent of the given tile in this matrix

--- a/python/core/auto_generated/vectortile/qgsvectortilewriter.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilewriter.sip.in
@@ -26,8 +26,8 @@ the "url" key is normally the path. Currently supported types:
 - "xyz" - tile data written as local files, using a template where {x},{y},{z}
 are replaced by the actual tile column, row and zoom level numbers, e.g.:
 file:///home/qgis/tiles/{z}/{x}/{y}.pbf
-
-(More types such as "mbtiles" or "gpkg" may be added later.)
+- "mbtiles" - tile data written to a new MBTiles file, the "url" key should
+be ordinary file system path, e.g.: /home/qgis/output.mbtiles
 
 Currently the writer only support MVT encoding of data.
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -261,7 +261,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsmapoverviewcanvas.h"
 #include "qgsmapsettings.h"
 #include "qgsmaptip.h"
-#include "qgsmbtilesreader.h"
+#include "qgsmbtiles.h"
 #include "qgsmenuheader.h"
 #include "qgsmergeattributesdialog.h"
 #include "qgsmessageviewer.h"
@@ -7325,7 +7325,7 @@ bool QgisApp::openLayer( const QString &fileName, bool allowInteractive )
 
   if ( fileName.endsWith( QStringLiteral( ".mbtiles" ), Qt::CaseInsensitive ) )
   {
-    QgsMBTilesReader reader( fileName );
+    QgsMbTiles reader( fileName );
     if ( reader.open() )
     {
       if ( reader.metadataValue( "format" ) == QStringLiteral( "pbf" ) )

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -315,7 +315,7 @@ SET(QGIS_CORE_SRCS
   qgsmapunitscale.cpp
   qgsmargins.cpp
   qgsmaskidprovider.cpp
-  qgsmbtilesreader.cpp
+  qgsmbtiles.cpp
   qgsmessagelog.cpp
   qgsmessageoutput.cpp
   qgsmimedatautils.cpp
@@ -861,7 +861,7 @@ SET(QGIS_CORE_HDRS
   qgsmapunitscale.h
   qgsmargins.h
   qgsmaskidprovider.h
-  qgsmbtilesreader.h
+  qgsmbtiles.h
   qgsmessagelog.h
   qgsmessageoutput.h
   qgsmimedatautils.h
@@ -1487,7 +1487,6 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/external/poly2tri
   ${CMAKE_SOURCE_DIR}/external/rtree/include
   ${CMAKE_SOURCE_DIR}/external/meshOptimizer
-  ${CMAKE_SOURCE_DIR}/external/mapbox-vector-tile
 )
 
 INCLUDE_DIRECTORIES(SYSTEM

--- a/src/core/providers/gdal/qgsgdaldataitems.cpp
+++ b/src/core/providers/gdal/qgsgdaldataitems.cpp
@@ -18,7 +18,7 @@
 ///@cond PRIVATE
 #include "qgsgdalprovider.h"
 #include "qgslogger.h"
-#include "qgsmbtilesreader.h"
+#include "qgsmbtiles.h"
 #include "qgssettings.h"
 #include "qgsogrutils.h"
 #include "qgsproject.h"
@@ -265,7 +265,7 @@ QgsDataItem *QgsGdalDataItemProvider::createDataItem( const QString &pathIn, Qgs
 
   if ( suffix == QStringLiteral( "mbtiles" ) )
   {
-    QgsMBTilesReader reader( path );
+    QgsMbTiles reader( path );
     if ( reader.open() )
     {
       if ( reader.metadataValue( "format" ) == QStringLiteral( "pbf" ) )

--- a/src/core/qgsmbtiles.cpp
+++ b/src/core/qgsmbtiles.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-  qgsmbtilesreader.cpp
+  qgsmbtiles.cpp
   --------------------------------------
   Date                 : January 2020
   Copyright            : (C) 2020 by Martin Dobias
@@ -13,7 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsmbtilesreader.h"
+#include "qgsmbtiles.h"
 
 #include "qgslogger.h"
 #include "qgsrectangle.h"
@@ -24,12 +24,12 @@
 #include <zlib.h>
 
 
-QgsMBTilesReader::QgsMBTilesReader( const QString &filename )
+QgsMbTiles::QgsMbTiles( const QString &filename )
   : mFilename( filename )
 {
 }
 
-bool QgsMBTilesReader::open()
+bool QgsMbTiles::open()
 {
   if ( mDatabase )
     return true;  // already opened
@@ -44,12 +44,12 @@ bool QgsMBTilesReader::open()
   return true;
 }
 
-bool QgsMBTilesReader::isOpen() const
+bool QgsMbTiles::isOpen() const
 {
   return bool( mDatabase );
 }
 
-bool QgsMBTilesReader::create()
+bool QgsMbTiles::create()
 {
   if ( mDatabase )
     return false;
@@ -80,7 +80,7 @@ bool QgsMBTilesReader::create()
   return true;
 }
 
-QString QgsMBTilesReader::metadataValue( const QString &key )
+QString QgsMbTiles::metadataValue( const QString &key )
 {
   if ( !mDatabase )
   {
@@ -106,7 +106,7 @@ QString QgsMBTilesReader::metadataValue( const QString &key )
   return preparedStatement.columnAsText( 0 );
 }
 
-void QgsMBTilesReader::setMetadataValue( const QString &key, const QString &value )
+void QgsMbTiles::setMetadataValue( const QString &key, const QString &value )
 {
   if ( !mDatabase )
   {
@@ -130,7 +130,7 @@ void QgsMBTilesReader::setMetadataValue( const QString &key, const QString &valu
   }
 }
 
-QgsRectangle QgsMBTilesReader::extent()
+QgsRectangle QgsMbTiles::extent()
 {
   QString boundsStr = metadataValue( "bounds" );
   if ( boundsStr.isEmpty() )
@@ -143,7 +143,7 @@ QgsRectangle QgsMBTilesReader::extent()
                        boundsArray[2].toDouble(), boundsArray[3].toDouble() );
 }
 
-QByteArray QgsMBTilesReader::tileData( int z, int x, int y )
+QByteArray QgsMbTiles::tileData( int z, int x, int y )
 {
   if ( !mDatabase )
   {
@@ -169,7 +169,7 @@ QByteArray QgsMBTilesReader::tileData( int z, int x, int y )
   return preparedStatement.columnAsBlob( 0 );
 }
 
-QImage QgsMBTilesReader::tileDataAsImage( int z, int x, int y )
+QImage QgsMbTiles::tileDataAsImage( int z, int x, int y )
 {
   QImage tileImage;
   QByteArray tileBlob = tileData( z, x, y );
@@ -181,7 +181,7 @@ QImage QgsMBTilesReader::tileDataAsImage( int z, int x, int y )
   return tileImage;
 }
 
-void QgsMBTilesReader::setTileData( int z, int x, int y, const QByteArray &data )
+void QgsMbTiles::setTileData( int z, int x, int y, const QByteArray &data )
 {
   if ( !mDatabase )
   {
@@ -207,7 +207,7 @@ void QgsMBTilesReader::setTileData( int z, int x, int y, const QByteArray &data 
   }
 }
 
-bool QgsMBTilesReader::decodeGzip( const QByteArray &bytesIn, QByteArray &bytesOut )
+bool QgsMbTiles::decodeGzip( const QByteArray &bytesIn, QByteArray &bytesOut )
 {
   unsigned char *bytesInPtr = reinterpret_cast<unsigned char *>( const_cast<char *>( bytesIn.constData() ) );
   uint bytesInLeft = static_cast<uint>( bytesIn.count() );
@@ -263,7 +263,7 @@ bool QgsMBTilesReader::decodeGzip( const QByteArray &bytesIn, QByteArray &bytesO
 }
 
 
-bool QgsMBTilesReader::encodeGzip( const QByteArray &bytesIn, QByteArray &bytesOut )
+bool QgsMbTiles::encodeGzip( const QByteArray &bytesIn, QByteArray &bytesOut )
 {
   unsigned char *bytesInPtr = reinterpret_cast<unsigned char *>( const_cast<char *>( bytesIn.constData() ) );
   uint bytesInLeft = static_cast<uint>( bytesIn.count() );

--- a/src/core/qgsmbtiles.h
+++ b/src/core/qgsmbtiles.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-  qgsmbtilesreader.h
+  qgsmbtiles.h
   --------------------------------------
   Date                 : January 2020
   Copyright            : (C) 2020 by Martin Dobias
@@ -13,8 +13,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef QGSMBTILESREADER_H
-#define QGSMBTILESREADER_H
+#ifndef QGSMBTILES_H
+#define QGSMBTILES_H
 
 #include "qgis_core.h"
 
@@ -28,15 +28,18 @@ class QgsRectangle;
 
 /**
  * \ingroup core
- * Utility class for reading MBTiles files (which are SQLite3 databases).
+ * Utility class for reading and writing MBTiles files (which are SQLite3 databases).
+ *
+ * See the specification for more details:
+ * https://github.com/mapbox/mbtiles-spec/blob/master/1.3/spec.md
  *
  * \since QGIS 3.14
  */
-class CORE_EXPORT QgsMBTilesReader
+class CORE_EXPORT QgsMbTiles
 {
   public:
     //! Constructs MBTiles reader (but it does not open the file yet)
-    explicit QgsMBTilesReader( const QString &filename );
+    explicit QgsMbTiles( const QString &filename );
 
     //! Tries to open the file, returns true on success
     bool open();
@@ -86,4 +89,4 @@ class CORE_EXPORT QgsMBTilesReader
 };
 
 
-#endif // QGSMBTILESREADER_H
+#endif // QGSMBTILES_H

--- a/src/core/qgsmbtilesreader.cpp
+++ b/src/core/qgsmbtilesreader.cpp
@@ -18,7 +18,10 @@
 #include "qgslogger.h"
 #include "qgsrectangle.h"
 
+#include <QFile>
 #include <QImage>
+
+#include <zlib.h>
 
 
 QgsMBTilesReader::QgsMBTilesReader( const QString &filename )
@@ -46,6 +49,37 @@ bool QgsMBTilesReader::isOpen() const
   return bool( mDatabase );
 }
 
+bool QgsMBTilesReader::create()
+{
+  if ( mDatabase )
+    return false;
+
+  if ( QFile::exists( mFilename ) )
+    return false;
+
+  sqlite3_database_unique_ptr database;
+  int result = mDatabase.open_v2( mFilename, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr );
+  if ( result != SQLITE_OK )
+  {
+    QgsDebugMsg( QStringLiteral( "Can't create MBTiles database: %1" ).arg( database.errorMessage() ) );
+    return false;
+  }
+
+  QString sql = \
+                "CREATE TABLE metadata (name text, value text);" \
+                "CREATE TABLE tiles (zoom_level integer, tile_column integer, tile_row integer, tile_data blob);" \
+                "CREATE UNIQUE INDEX tile_index on tiles (zoom_level, tile_column, tile_row);";
+  QString errorMessage;
+  result = mDatabase.exec( sql, errorMessage );
+  if ( result != SQLITE_OK )
+  {
+    QgsDebugMsg( QStringLiteral( "Failed to initialize MBTiles database: " ) + errorMessage );
+    return false;
+  }
+
+  return true;
+}
+
 QString QgsMBTilesReader::metadataValue( const QString &key )
 {
   if ( !mDatabase )
@@ -70,6 +104,30 @@ QString QgsMBTilesReader::metadataValue( const QString &key )
   }
 
   return preparedStatement.columnAsText( 0 );
+}
+
+void QgsMBTilesReader::setMetadataValue( const QString &key, const QString &value )
+{
+  if ( !mDatabase )
+  {
+    QgsDebugMsg( QStringLiteral( "MBTiles database not open: " ) + mFilename );
+    return;
+  }
+
+  int result;
+  QString sql = QStringLiteral( "insert into metadata values (%1, %2)" ).arg( QgsSqliteUtils::quotedValue( key ), QgsSqliteUtils::quotedValue( value ) );
+  sqlite3_statement_unique_ptr preparedStatement = mDatabase.prepare( sql, result );
+  if ( result != SQLITE_OK )
+  {
+    QgsDebugMsg( QStringLiteral( "MBTile failed to prepare statement: " ) + sql );
+    return;
+  }
+
+  if ( preparedStatement.step() != SQLITE_DONE )
+  {
+    QgsDebugMsg( QStringLiteral( "MBTile metadata value failed to be set: " ) + key );
+    return;
+  }
 }
 
 QgsRectangle QgsMBTilesReader::extent()
@@ -121,4 +179,128 @@ QImage QgsMBTilesReader::tileDataAsImage( int z, int x, int y )
     return QImage();
   }
   return tileImage;
+}
+
+void QgsMBTilesReader::setTileData( int z, int x, int y, const QByteArray &data )
+{
+  if ( !mDatabase )
+  {
+    QgsDebugMsg( QStringLiteral( "MBTiles database not open: " ) + mFilename );
+    return;
+  }
+
+  int result;
+  QString sql = QStringLiteral( "insert into tiles values (%1, %2, %3, ?)" ).arg( z ).arg( x ).arg( y );
+  sqlite3_statement_unique_ptr preparedStatement = mDatabase.prepare( sql, result );
+  if ( result != SQLITE_OK )
+  {
+    QgsDebugMsg( QStringLiteral( "MBTile failed to prepare statement: " ) + sql );
+    return;
+  }
+
+  sqlite3_bind_blob( preparedStatement.get(), 1, data.constData(), data.size(), SQLITE_TRANSIENT );
+
+  if ( preparedStatement.step() != SQLITE_DONE )
+  {
+    QgsDebugMsg( QStringLiteral( "MBTile tile failed to be set: %1,%2,%3" ).arg( z ).arg( x ).arg( y ) );
+    return;
+  }
+}
+
+bool QgsMBTilesReader::decodeGzip( const QByteArray &bytesIn, QByteArray &bytesOut )
+{
+  unsigned char *bytesInPtr = reinterpret_cast<unsigned char *>( const_cast<char *>( bytesIn.constData() ) );
+  uint bytesInLeft = static_cast<uint>( bytesIn.count() );
+
+  const uint CHUNK = 16384;
+  unsigned char out[CHUNK];
+  const int DEC_MAGIC_NUM_FOR_GZIP = 16;
+
+  // allocate inflate state
+  z_stream strm;
+  strm.zalloc = Z_NULL;
+  strm.zfree = Z_NULL;
+  strm.opaque = Z_NULL;
+  strm.avail_in = 0;
+  strm.next_in = Z_NULL;
+
+  int ret = inflateInit2( &strm, MAX_WBITS + DEC_MAGIC_NUM_FOR_GZIP );
+  if ( ret != Z_OK )
+    return false;
+
+  while ( ret != Z_STREAM_END ) // done when inflate() says it's done
+  {
+    // prepare next chunk
+    uint bytesToProcess = std::min( CHUNK, bytesInLeft );
+    strm.next_in = bytesInPtr;
+    strm.avail_in = bytesToProcess;
+    bytesInPtr += bytesToProcess;
+    bytesInLeft -= bytesToProcess;
+
+    if ( bytesToProcess == 0 )
+      break;  // we end with an error - no more data but inflate() wants more data
+
+    // run inflate() on input until output buffer not full
+    do
+    {
+      strm.avail_out = CHUNK;
+      strm.next_out = out;
+      ret = inflate( &strm, Z_NO_FLUSH );
+      Q_ASSERT( ret != Z_STREAM_ERROR ); // state not clobbered
+      if ( ret == Z_NEED_DICT || ret == Z_DATA_ERROR || ret == Z_MEM_ERROR )
+      {
+        inflateEnd( &strm );
+        return false;
+      }
+      unsigned have = CHUNK - strm.avail_out;
+      bytesOut.append( QByteArray::fromRawData( reinterpret_cast<const char *>( out ), static_cast<int>( have ) ) );
+    }
+    while ( strm.avail_out == 0 );
+  }
+
+  inflateEnd( &strm );
+  return ret == Z_STREAM_END;
+}
+
+
+bool QgsMBTilesReader::encodeGzip( const QByteArray &bytesIn, QByteArray &bytesOut )
+{
+  unsigned char *bytesInPtr = reinterpret_cast<unsigned char *>( const_cast<char *>( bytesIn.constData() ) );
+  uint bytesInLeft = static_cast<uint>( bytesIn.count() );
+
+  const uint CHUNK = 16384;
+  unsigned char out[CHUNK];
+  const int DEC_MAGIC_NUM_FOR_GZIP = 16;
+
+  // allocate deflate state
+  z_stream strm;
+  strm.zalloc = Z_NULL;
+  strm.zfree = Z_NULL;
+  strm.opaque = Z_NULL;
+
+  int ret = deflateInit2( &strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, MAX_WBITS + DEC_MAGIC_NUM_FOR_GZIP, 8, Z_DEFAULT_STRATEGY );
+  if ( ret != Z_OK )
+    return false;
+
+  strm.avail_in = bytesInLeft;
+  strm.next_in = bytesInPtr;
+
+  // run deflate() on input until output buffer not full, finish
+  // compression if all of source has been read in
+  do
+  {
+    strm.avail_out = CHUNK;
+    strm.next_out = out;
+    ret = deflate( &strm, Z_FINISH );  // no bad return value
+    Q_ASSERT( ret != Z_STREAM_ERROR ); // state not clobbered
+
+    unsigned have = CHUNK - strm.avail_out;
+    bytesOut.append( QByteArray::fromRawData( reinterpret_cast<const char *>( out ), static_cast<int>( have ) ) );
+  }
+  while ( strm.avail_out == 0 );
+  Q_ASSERT( ret == Z_STREAM_END );      // stream will be complete
+
+  // clean up and return
+  deflateEnd( &strm );
+  return true;
 }

--- a/src/core/qgsmbtilesreader.h
+++ b/src/core/qgsmbtilesreader.h
@@ -44,8 +44,21 @@ class CORE_EXPORT QgsMBTilesReader
     //! Returns whether the MBTiles file is currently opened
     bool isOpen() const;
 
+    /**
+     * Creates a new MBTiles file and initializes it with metadata and tiles tables.
+     * It is up to the caller to set appropriate metadata entries and add tiles afterwards.
+     * Returns true on success. If the file exists already, returns false.
+     */
+    bool create();
+
     //! Requests metadata value for the given key
     QString metadataValue( const QString &key );
+
+    /**
+     * Sets metadata value for the given key. Does not overwrite existing entries.
+     * \note the database has to be opened in read-write mode (currently only when opened with create()
+     */
+    void setMetadataValue( const QString &key, const QString &value );
 
     //! Returns bounding box from metadata, given in WGS 84 (if available)
     QgsRectangle extent();
@@ -55,6 +68,17 @@ class CORE_EXPORT QgsMBTilesReader
 
     //! Returns tile decoded as a raster image (if stored in a known format like JPG or PNG)
     QImage tileDataAsImage( int z, int x, int y );
+
+    /**
+     * Adds tile data for the given tile coordinates. Does not overwrite existing entries.
+     * \note the database has to be opened in read-write mode (currently only when opened with create()
+     */
+    void setTileData( int z, int x, int y, const QByteArray &data );
+
+    //! Decodes gzip byte stream, returns true on success. Useful for reading vector tiles.
+    static bool decodeGzip( const QByteArray &bytesIn, QByteArray &bytesOut );
+    //! Encodes gzip byte stream, returns true on success. Useful for writing vector tiles.
+    static bool encodeGzip( const QByteArray &bytesIn, QByteArray &bytesOut );
 
   private:
     QString mFilename;

--- a/src/core/qgsmbtilesreader.h
+++ b/src/core/qgsmbtilesreader.h
@@ -35,7 +35,7 @@ class QgsRectangle;
 class CORE_EXPORT QgsMBTilesReader
 {
   public:
-    //! Contructs MBTiles reader (but it does not open the file yet)
+    //! Constructs MBTiles reader (but it does not open the file yet)
     explicit QgsMBTilesReader( const QString &filename );
 
     //! Tries to open the file, returns true on success

--- a/src/core/qgstiles.h
+++ b/src/core/qgstiles.h
@@ -106,6 +106,12 @@ class CORE_EXPORT QgsTileMatrix
     //! Returns a tile matrix for the usual web mercator
     static QgsTileMatrix fromWebMercator( int mZoomLevel );
 
+    //! Returns number of columns of the tile matrix
+    int matrixWidth() const { return mMatrixWidth; }
+
+    //! Returns number of rows of the tile matrix
+    int matrixHeight() const { return mMatrixHeight; }
+
     //! Returns extent of the given tile in this matrix
     QgsRectangle tileExtent( QgsTileXYZ id ) const;
 

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -68,6 +68,13 @@ bool QgsVectorTileLayer::loadDataSource()
       return false;
     }
 
+    QString format = reader.metadataValue( QStringLiteral( "format" ) );
+    if ( format != QStringLiteral( "pbf" ) )
+    {
+      QgsDebugMsg( QStringLiteral( "Cannot open MBTiles for vector tiles. Format = " ) + format );
+      return false;
+    }
+
     QgsDebugMsgLevel( QStringLiteral( "name: " ) + reader.metadataValue( QStringLiteral( "name" ) ), 2 );
     bool minZoomOk, maxZoomOk;
     int minZoom = reader.metadataValue( QStringLiteral( "minzoom" ) ).toInt( &minZoomOk );

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -17,7 +17,7 @@
 
 #include "qgslogger.h"
 #include "qgsvectortilelayerrenderer.h"
-#include "qgsmbtilesreader.h"
+#include "qgsmbtiles.h"
 #include "qgsvectortilebasiclabeling.h"
 #include "qgsvectortilebasicrenderer.h"
 #include "qgsvectortilelabeling.h"
@@ -61,7 +61,7 @@ bool QgsVectorTileLayer::loadDataSource()
   }
   else if ( mSourceType == QStringLiteral( "mbtiles" ) )
   {
-    QgsMBTilesReader reader( mSourcePath );
+    QgsMbTiles reader( mSourcePath );
     if ( !reader.open() )
     {
       QgsDebugMsg( QStringLiteral( "failed to open MBTiles file: " ) + mSourcePath );

--- a/src/core/vectortile/qgsvectortileloader.cpp
+++ b/src/core/vectortile/qgsvectortileloader.cpp
@@ -19,7 +19,7 @@
 
 #include "qgsblockingnetworkrequest.h"
 #include "qgslogger.h"
-#include "qgsmbtilesreader.h"
+#include "qgsmbtiles.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgsvectortileutils.h"
 
@@ -147,7 +147,7 @@ QList<QgsVectorTileRawData> QgsVectorTileLoader::blockingFetchTileRawData( const
 {
   QList<QgsVectorTileRawData> rawTiles;
 
-  QgsMBTilesReader mbReader( sourcePath );
+  QgsMbTiles mbReader( sourcePath );
   bool isUrl = ( sourceType == QStringLiteral( "xyz" ) );
   if ( !isUrl )
   {
@@ -187,7 +187,7 @@ QByteArray QgsVectorTileLoader::loadFromNetwork( const QgsTileXYZ &id, const QSt
 }
 
 
-QByteArray QgsVectorTileLoader::loadFromMBTiles( const QgsTileXYZ &id, QgsMBTilesReader &mbTileReader )
+QByteArray QgsVectorTileLoader::loadFromMBTiles( const QgsTileXYZ &id, QgsMbTiles &mbTileReader )
 {
   // MBTiles uses TMS specs with Y starting at the bottom while XYZ uses Y starting at the top
   int rowTMS = pow( 2, id.zoomLevel() ) - id.row() - 1;
@@ -199,7 +199,7 @@ QByteArray QgsVectorTileLoader::loadFromMBTiles( const QgsTileXYZ &id, QgsMBTile
   }
 
   QByteArray data;
-  if ( !QgsMBTilesReader::decodeGzip( gzippedTileData, data ) )
+  if ( !QgsMbTiles::decodeGzip( gzippedTileData, data ) )
   {
     QgsDebugMsg( QStringLiteral( "Failed to decompress tile " ) + id.toString() );
     return QByteArray();

--- a/src/core/vectortile/qgsvectortileloader.cpp
+++ b/src/core/vectortile/qgsvectortileloader.cpp
@@ -17,8 +17,6 @@
 
 #include <QEventLoop>
 
-#include <zlib.h>
-
 #include "qgsblockingnetworkrequest.h"
 #include "qgslogger.h"
 #include "qgsmbtilesreader.h"
@@ -200,10 +198,8 @@ QByteArray QgsVectorTileLoader::loadFromMBTiles( const QgsTileXYZ &id, QgsMBTile
     return QByteArray();
   }
 
-  // TODO: check format is "pbf"
-
   QByteArray data;
-  if ( !decodeGzip( gzippedTileData, data ) )
+  if ( !QgsMBTilesReader::decodeGzip( gzippedTileData, data ) )
   {
     QgsDebugMsg( QStringLiteral( "Failed to decompress tile " ) + id.toString() );
     return QByteArray();
@@ -211,60 +207,4 @@ QByteArray QgsVectorTileLoader::loadFromMBTiles( const QgsTileXYZ &id, QgsMBTile
 
   QgsDebugMsgLevel( QStringLiteral( "Tile blob size %1 -> uncompressed size %2" ).arg( gzippedTileData.size() ).arg( data.size() ), 2 );
   return data;
-}
-
-
-bool QgsVectorTileLoader::decodeGzip( const QByteArray &bytesIn, QByteArray &bytesOut )
-{
-  unsigned char *bytesInPtr = reinterpret_cast<unsigned char *>( const_cast<char *>( bytesIn.constData() ) );
-  uint bytesInLeft = static_cast<uint>( bytesIn.count() );
-
-  const uint CHUNK = 16384;
-  unsigned char out[CHUNK];
-  const int DEC_MAGIC_NUM_FOR_GZIP = 16;
-
-  // allocate inflate state
-  z_stream strm;
-  strm.zalloc = Z_NULL;
-  strm.zfree = Z_NULL;
-  strm.opaque = Z_NULL;
-  strm.avail_in = 0;
-  strm.next_in = Z_NULL;
-
-  int ret = inflateInit2( &strm, MAX_WBITS + DEC_MAGIC_NUM_FOR_GZIP );
-  if ( ret != Z_OK )
-    return false;
-
-  while ( ret != Z_STREAM_END ) // done when inflate() says it's done
-  {
-    // prepare next chunk
-    uint bytesToProcess = std::min( CHUNK, bytesInLeft );
-    strm.next_in = bytesInPtr;
-    strm.avail_in = bytesToProcess;
-    bytesInPtr += bytesToProcess;
-    bytesInLeft -= bytesToProcess;
-
-    if ( bytesToProcess == 0 )
-      break;  // we end with an error - no more data but inflate() wants more data
-
-    // run inflate() on input until output buffer not full
-    do
-    {
-      strm.avail_out = CHUNK;
-      strm.next_out = out;
-      ret = inflate( &strm, Z_NO_FLUSH );
-      Q_ASSERT( ret != Z_STREAM_ERROR ); // state not clobbered
-      if ( ret == Z_NEED_DICT || ret == Z_DATA_ERROR || ret == Z_MEM_ERROR )
-      {
-        inflateEnd( &strm );
-        return false;
-      }
-      unsigned have = CHUNK - strm.avail_out;
-      bytesOut.append( QByteArray::fromRawData( reinterpret_cast<const char *>( out ), static_cast<int>( have ) ) );
-    }
-    while ( strm.avail_out == 0 );
-  }
-
-  inflateEnd( &strm );
-  return ret == Z_STREAM_END;
 }

--- a/src/core/vectortile/qgsvectortileloader.h
+++ b/src/core/vectortile/qgsvectortileloader.h
@@ -45,7 +45,7 @@ class QgsVectorTileRawData
 class QNetworkReply;
 class QEventLoop;
 
-class QgsMBTilesReader;
+class QgsMbTiles;
 
 /**
  * \ingroup core
@@ -64,7 +64,7 @@ class QgsVectorTileLoader : public QObject
     //! Returns raw tile data for a single tile, doing a HTTP request. Block the caller until tile data are downloaded.
     static QByteArray loadFromNetwork( const QgsTileXYZ &id, const QString &requestUrl );
     //! Returns raw tile data for a single tile loaded from MBTiles file
-    static QByteArray loadFromMBTiles( const QgsTileXYZ &id, QgsMBTilesReader &mbTileReader );
+    static QByteArray loadFromMBTiles( const QgsTileXYZ &id, QgsMbTiles &mbTileReader );
 
     //
     // non-static stuff

--- a/src/core/vectortile/qgsvectortileloader.h
+++ b/src/core/vectortile/qgsvectortileloader.h
@@ -65,8 +65,6 @@ class QgsVectorTileLoader : public QObject
     static QByteArray loadFromNetwork( const QgsTileXYZ &id, const QString &requestUrl );
     //! Returns raw tile data for a single tile loaded from MBTiles file
     static QByteArray loadFromMBTiles( const QgsTileXYZ &id, QgsMBTilesReader &mbTileReader );
-    //! Decodes gzip byte stream, returns true on success
-    static bool decodeGzip( const QByteArray &bytesIn, QByteArray &bytesOut );
 
     //
     // non-static stuff

--- a/src/core/vectortile/qgsvectortilewriter.cpp
+++ b/src/core/vectortile/qgsvectortilewriter.cpp
@@ -18,7 +18,7 @@
 #include "qgsdatasourceuri.h"
 #include "qgsfeedback.h"
 #include "qgsjsonutils.h"
-#include "qgsmbtilesreader.h"
+#include "qgsmbtiles.h"
 #include "qgstiles.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectortilemvtencoder.h"
@@ -51,7 +51,7 @@ bool QgsVectorTileWriter::writeTiles( QgsFeedback *feedback )
     return false;
   }
 
-  std::unique_ptr<QgsMBTilesReader> mbtiles;
+  std::unique_ptr<QgsMbTiles> mbtiles;
 
   QgsDataSourceUri dsUri;
   dsUri.setEncodedUri( mDestinationUri );
@@ -65,7 +65,7 @@ bool QgsVectorTileWriter::writeTiles( QgsFeedback *feedback )
   }
   else if ( sourceType == QStringLiteral( "mbtiles" ) )
   {
-    mbtiles.reset( new QgsMBTilesReader( sourcePath ) );
+    mbtiles.reset( new QgsMbTiles( sourcePath ) );
   }
   else
   {
@@ -158,7 +158,7 @@ bool QgsVectorTileWriter::writeTiles( QgsFeedback *feedback )
         else  // mbtiles
         {
           QByteArray gzipTileData;
-          QgsMBTilesReader::encodeGzip( tileData, gzipTileData );
+          QgsMbTiles::encodeGzip( tileData, gzipTileData );
           int rowTMS = pow( 2, tileID.zoomLevel() ) - tileID.row() - 1;
           mbtiles->setTileData( tileID.zoomLevel(), tileID.column(), rowTMS, gzipTileData );
         }

--- a/src/core/vectortile/qgsvectortilewriter.h
+++ b/src/core/vectortile/qgsvectortilewriter.h
@@ -20,6 +20,7 @@
 #include "qgsrectangle.h"
 
 class QgsFeedback;
+class QgsTileXYZ;
 class QgsVectorLayer;
 
 
@@ -38,8 +39,8 @@ class QgsVectorLayer;
  * - "xyz" - tile data written as local files, using a template where {x},{y},{z}
  *   are replaced by the actual tile column, row and zoom level numbers, e.g.:
  *   file:///home/qgis/tiles/{z}/{x}/{y}.pbf
- *
- * (More types such as "mbtiles" or "gpkg" may be added later.)
+ * - "mbtiles" - tile data written to a new MBTiles file, the "url" key should
+ *   be ordinary file system path, e.g.: /home/qgis/output.mbtiles
  *
  * Currently the writer only support MVT encoding of data.
  *
@@ -109,6 +110,10 @@ class CORE_EXPORT QgsVectorTileWriter
      * an empty string if writing was successful.
      */
     QString errorMessage() const { return mErrorMessage; }
+
+  private:
+    bool writeTileFileXYZ( const QString &sourcePath, QgsTileXYZ tileID, const QByteArray &tileData );
+    QString mbtilesJsonSchema();
 
   private:
     QgsRectangle mExtent;

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -37,7 +37,7 @@
 #include "qgsrectangle.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsmapsettings.h"
-#include "qgsmbtilesreader.h"
+#include "qgsmbtiles.h"
 #include "qgsmessageoutput.h"
 #include "qgsmessagelog.h"
 #include "qgsnetworkaccessmanager.h"
@@ -821,10 +821,10 @@ QImage *QgsWmsProvider::draw( QgsRectangle const &viewExtent, int pixelWidth, in
     QList<TileImage> tileImages;  // in the correct resolution
     QList<QRectF> missing;  // rectangles (in map coords) of missing tiles for this view
 
-    std::unique_ptr<QgsMBTilesReader> mbtilesReader;
+    std::unique_ptr<QgsMbTiles> mbtilesReader;
     if ( mSettings.mIsMBTiles )
     {
-      mbtilesReader.reset( new QgsMBTilesReader( QUrl( mSettings.mBaseUrl ).path() ) );
+      mbtilesReader.reset( new QgsMbTiles( QUrl( mSettings.mBaseUrl ).path() ) );
       mbtilesReader->open();
     }
 
@@ -1460,7 +1460,7 @@ void QgsWmsProvider::setupXyzCapabilities( const QString &uri, const QgsRectangl
 bool QgsWmsProvider::setupMBTilesCapabilities( const QString &uri )
 {
   // if it is MBTiles source, let's prepare the reader to get some metadata
-  QgsMBTilesReader mbtilesReader( QUrl( mSettings.mBaseUrl ).path() );
+  QgsMbTiles mbtilesReader( QUrl( mSettings.mBaseUrl ).path() );
   if ( !mbtilesReader.open() )
     return false;
 


### PR DESCRIPTION
Continued work on vector tile layer implementation.

See the QEP: qgis/QGIS-Enhancement-Proposals#162

Added support to write vector tiles to MBTiles files. These are convenient because it is just a single file with all tiles stored as gzipped blobs in SQLite database.

Sample code to generate vector tiles to MBTiles:

```
uri = QgsDataSourceUri()
uri.setParam("type", "mbtiles")
uri.setParam("url", "/home/qgis/output.mbtiles")
lyr = QgsVectorTileWriter.Layer(iface.activeLayer())
writer = QgsVectorTileWriter()
writer.setDestinationUri(bytes(uri.encodedUri()).decode('utf-8'))
writer.setLayers([lyr])
writer.setMinZoom(0)
writer.setMaxZoom(3)
# writer.setExtent(QgsRectangle(...))
writer.writeTiles()
```

## Thanks

Huge thanks to all funders who have contributed to the crowdfunding and made this possible :clap: :clap: :clap:
https://www.lutraconsulting.co.uk/blog/2020/04/02/vectortiles-donors/