### PR TITLE
[processing] When removing a parameter registered as an output, remove it from outputs list

### DIFF
--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -329,6 +329,12 @@ void QgsProcessingAlgorithm::removeParameter( const QString &name )
     delete def;
     mParameters.removeAll( def );
   }
+  const QgsProcessingOutputDefinition *outputDef = outputDefinition( name );
+  if ( outputDef )
+  {
+    delete outputDef;
+    mOutputs.removeAll( outputDef );
+  }
 }
 
 bool QgsProcessingAlgorithm::addOutput( QgsProcessingOutputDefinition *definition )


### PR DESCRIPTION
## Description

Until now, when removing a processing parameter that's also registered as an output, the parameter definition was removed but its linked output was not. This PR fixes that.

Practically, the PR also gets rid of the following warning thrown every time QGIS is launched:
`WARNING    Duplicate output OUTPUT registered for alg contour_polygon`
