### PR TITLE
Handle CONSTRAINT TRIGGER on DB Manager/PostgreSQL.

### DIFF
--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -657,7 +657,7 @@ class PostGisDBConnector(DBConnector):
                   LEFT JOIN pg_class t ON c.conrelid = t.oid
                         LEFT JOIN pg_class t2 ON c.confrelid = t2.oid
                         JOIN pg_namespace nsp ON t.relnamespace = nsp.oid
-                        WHERE t.relname = %s %s """ % (con_col_name, self.quoteString(tablename), schema_where)
+                        WHERE c.contype <> 't' AND t.relname = %s %s """ % (con_col_name, self.quoteString(tablename), schema_where)
 
         c = self._execute(None, sql)
         res = self._fetchall(c)

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -652,6 +652,9 @@ class PostGisDBConnector(DBConnector):
         version_number = int(self.getInfo()[0].split(' ')[1].split('.')[0])
         con_col_name = 'consrc' if version_number < 12 else 'conbin'
 
+        # In the query below, we exclude rows where pg_constraint.contype whose values are equal to 't'
+        # because 't' describes a CONSTRAINT TRIGGER, which is not really a constraint in the traditional
+        # sense, but a special type of trigger, and an extension to the SQL standard.
         sql = u"""SELECT c.conname, c.contype, c.condeferrable, c.condeferred, array_to_string(c.conkey, ' '), c.%s,
                          t2.relname, c.confupdtype, c.confdeltype, c.confmatchtype, array_to_string(c.confkey, ' ') FROM pg_constraint c
                   LEFT JOIN pg_class t ON c.conrelid = t.oid


### PR DESCRIPTION
Fixes #35967

Despite appearing as constraints on the catalog pg_constraint, they are not really constraints, but rather a special kind of trigger, as seen here: https://www.postgresql.org/docs/12/catalog-pg-constraint.html and here: https://www.postgresql.org/docs/12/sql-createtrigger.html .

The following table/trigger shows the issue:

```sql
CREATE FUNCTION hi_trigger() RETURNS TRIGGER AS $$ BEGIN RAISE NOTICE 'Hello world'; RETURN NEW; END; $$ LANGUAGE plpgsql;
CREATE TABLE test_trigger(id SERIAL NOT NULL PRIMARY KEY, value varchar(32));
CREATE CONSTRAINT TRIGGER tg_test AFTER INSERT ON test_trigger DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE PROCEDURE hi_trigger();
```
All the other constraint types that might appear on the catalog pg_constraint according to the PostgreSQL documentation are handled by DB Manager: https://github.com/qgis/QGIS/blob/2e7bebcf201d095b74b47c7f56406dab640d27e5/python/plugins/db_manager/db_plugins/plugin.py#L1284

Those are SQL standard, the CONSTRAINT TRIGGER is a PostgreSQL extension (according to the PostgreSQL docs), and I think it is not really a constraint in the traditional sense.

I believe this should be backported to 3.12 and 3.10.