### PR TITLE
Remove groupUuid when copying grouped layout items

### DIFF
--- a/src/gui/layout/qgslayoutview.cpp
+++ b/src/gui/layout/qgslayoutview.cpp
@@ -364,6 +364,7 @@ void QgsLayoutView::copyItems( const QList<QgsLayoutItem *> &items, QgsLayoutVie
     if ( itemNode.isElement() )
     {
       itemNode.toElement().removeAttribute( QStringLiteral( "uuid" ) );
+      itemNode.toElement().removeAttribute( QStringLiteral( "groupUuid" ) );
     }
   }
   QDomNodeList multiFrameNodes = doc.elementsByTagName( QStringLiteral( "LayoutMultiFrame" ) );


### PR DESCRIPTION
## Description

At the moment, when copying grouped layout items, the new items still reference the old group in their `groupUuid` property, leading to strange behaviour when interacting with the original and the copied group:

![2020-04-24_21-43-37](https://user-images.githubusercontent.com/2399255/80252110-0026e280-8677-11ea-8008-d2ccddf118ed.gif)

Removing the `groupUuid` property from the grouped items when copying fixes this error:

![2020-04-24_21-51-14](https://user-images.githubusercontent.com/2399255/80252230-33697180-8677-11ea-9dc5-abbe3995bfcb.gif)