### PR TITLE
Group postgres DELETE statements to a single query

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2536,6 +2536,9 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
 
 bool QgsPostgresProvider::deleteFeatures( const QgsFeatureIds &ids )
 {
+  if ( ids.isEmpty() )
+    return true;
+
   bool returnvalue = true;
 
   if ( mIsQuery )

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2558,8 +2558,8 @@ bool QgsPostgresProvider::deleteFeatures( const QgsFeatureIds &ids )
   {
     conn->begin();
 
-    QString sql = QStringLiteral( "DELETE FROM %1 WHERE %2" )
-                  .arg( mQuery, whereClause( ids ) );
+    const QString sql = QStringLiteral( "DELETE FROM %1 WHERE %2" )
+                        .arg( mQuery, whereClause( ids ) );
     QgsDebugMsgLevel( "delete sql: " + sql, 2 );
 
     //send DELETE statement and do error handling


### PR DESCRIPTION
...instead of one for each deleted feature
Deleting lots of features over remote connections should be faster.
Is there a query length limitation we should consider? I successfully ~~test deleted 10m features.~~ realized I'm tired... I tested with 1k though.

Fixes #35381