### PR TITLE
[authentication manager] Avoid crossing mutex wires when checking for master password

### DIFF
--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -99,6 +99,7 @@ QgsAuthManager *QgsAuthManager::instance()
 QgsAuthManager::QgsAuthManager()
 {
   mMutex = new QMutex( QMutex::Recursive );
+  mMasterPasswordMutex = new QMutex( QMutex::Recursive );
   connect( this, &QgsAuthManager::messageOut,
            this, &QgsAuthManager::writeToConsole );
 }
@@ -487,7 +488,7 @@ const QString QgsAuthManager::disabledMessage() const
 
 bool QgsAuthManager::setMasterPassword( bool verify )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( mMasterPasswordMutex );
   if ( isDisabled() )
     return false;
 
@@ -497,13 +498,11 @@ bool QgsAuthManager::setMasterPassword( bool verify )
   if ( mMasterPass.isEmpty() )
   {
     QgsDebugMsg( QStringLiteral( "Master password is not yet set by user" ) );
-    locker.unlock();
     if ( !masterPasswordInput() )
     {
       QgsDebugMsg( QStringLiteral( "Master password input canceled by user" ) );
       return false;
     }
-    locker.relock();
   }
   else
   {

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -497,11 +497,13 @@ bool QgsAuthManager::setMasterPassword( bool verify )
   if ( mMasterPass.isEmpty() )
   {
     QgsDebugMsg( QStringLiteral( "Master password is not yet set by user" ) );
+    locker.unlock();
     if ( !masterPasswordInput() )
     {
       QgsDebugMsg( QStringLiteral( "Master password input canceled by user" ) );
       return false;
     }
+    locker.relock();
   }
   else
   {
@@ -1200,12 +1202,13 @@ bool QgsAuthManager::updateAuthenticationConfig( const QgsAuthMethodConfig &conf
 
 bool QgsAuthManager::loadAuthenticationConfig( const QString &authcfg, QgsAuthMethodConfig &mconfig, bool full )
 {
-  QMutexLocker locker( mMutex );
   if ( isDisabled() )
     return false;
 
   if ( full && !setMasterPassword( true ) )
     return false;
+
+  QMutexLocker locker( mMutex );
 
   QSqlQuery query( authDatabaseConnection() );
   if ( full )

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -863,6 +863,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
     bool mScheduledDbEraseRequestEmitted = false;
     int mScheduledDbEraseRequestCount = 0;
     QMutex *mMutex = nullptr;
+    QMutex *mMasterPasswordMutex = nullptr;
 
 #ifndef QT_NO_SSL
     // mapping of sha1 digest and cert source and cert


### PR DESCRIPTION
## Description

This PR fixes issue #35993 . We were both locking the authentication manager's mutex in a function while trying to reach another function locked by the same mutex.

@nyalldawson , I'm really not that intimidate with the code, review much appreciated.

This likely created all sorts of problem for people with master passwords that were not locked in the system's keyring/wallet.