### PR TITLE
Save features into PostgreSQL 12+ tables with GENERATED columns.

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -920,7 +920,7 @@ bool QgsPostgresProvider::loadFields()
         notNullMap[attrelid][attnum] = attNotNull;
         uniqueMap[attrelid][attnum] = uniqueConstraint;
         identityMap[attrelid][attnum] = attIdentity.isEmpty() ? " " : attIdentity;
-        generatedMap[attrelid][attnum] = attGenerated == "s" ? defVal : "";
+        generatedMap[attrelid][attnum] = attGenerated.isEmpty() ? "" : defVal;
       }
     }
   }

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2341,7 +2341,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
 
       if ( !mGeneratedValues.value( idx, QString() ).isEmpty() )
       {
-        QgsDebugMsg( QStringLiteral( "Skipping field %1 (idx %2) which is GENERATED." ).arg( fieldname, idx ) );
+        QgsDebugMsg( QStringLiteral( "Skipping field %1 (idx %2) which is GENERATED." ).arg( fieldname, QString::number( idx ) ) );
         continue;
       }
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2339,7 +2339,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
 
       QString fieldname = mAttributeFields.at( idx ).name();
 
-      if ( mGeneratedValues.contains( idx ) && !mGeneratedValues.value( idx, QString() ).isEmpty() )
+      if ( !mGeneratedValues.value( idx, QString() ).isEmpty() )
       {
         QgsDebugMsg( QStringLiteral( "Skipping field %1 (idx %2) which is GENERATED." ).arg( fieldname, idx ) );
         continue;
@@ -2371,12 +2371,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
 
       if ( i == flist.size() )
       {
-        // generated values override everything.
-        if ( !mGeneratedValues[idx].isEmpty() )
-        {
-          values += delim + defVal;
-        }
-        else if ( qgsVariantEqual( v, defVal ) )
+        if ( qgsVariantEqual( v, defVal ) )
         {
           if ( defVal.isNull() )
           {

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -889,9 +889,9 @@ bool QgsPostgresProvider::loadFields()
               " LEFT OUTER JOIN ( SELECT DISTINCT indrelid, indkey, indisunique FROM pg_index WHERE indisunique ) uniq ON attrelid=indrelid AND attnum::text=indkey::text "
 
               " WHERE attrelid IN %3"
-            ).arg( connectionRO()->pgVersion() >= 100000 ? QStringLiteral( ", attidentity" ) : QString() )
-            .arg( connectionRO()->pgVersion() >= 120000 ? QStringLiteral( ", attgenerated" ) : QString() )
-            .arg( tableoidsFilter );
+            ).arg( connectionRO()->pgVersion() >= 100000 ? QStringLiteral( ", attidentity" ) : QString(),
+                   connectionRO()->pgVersion() >= 120000 ? QStringLiteral( ", attgenerated" ) : QString(),
+                   tableoidsFilter );
 
       QgsPostgresResult fmtFieldTypeResult( connectionRO()->PQexec( sql ) );
       for ( int i = 0; i < fmtFieldTypeResult.PQntuples(); ++i )
@@ -2341,7 +2341,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
 
       if ( !mGeneratedValues.value( idx, QString() ).isEmpty() )
       {
-        QgsDebugMsg( QStringLiteral( "Skipping field %1 (idx %2) which is GENERATED." ).arg( fieldname, idx ) );
+        QgsLogger::warning( tr( "Skipping field %1 which is GENERATED." ).arg( fieldname ) );
         continue;
       }
 
@@ -2954,7 +2954,7 @@ bool QgsPostgresProvider::changeAttributeValues( const QgsChangedAttributesMap &
 
           if ( mGeneratedValues.contains( siter.key() ) && !mGeneratedValues.value( siter.key(), QString() ).isEmpty() )
           {
-            pushError( tr( "Changing the value of GENERATED field %1 is not allowed." ).arg( fld.name() ) );
+            QgsLogger::warning( tr( "Changing the value of GENERATED field %1 is not allowed." ).arg( fld.name() ) );
             continue;
           }
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -908,7 +908,14 @@ bool QgsPostgresProvider::loadFields()
         QString attGenerated = connectionRO()->pgVersion() >= 120000 ? fmtFieldTypeResult.PQgetvalue( i, 9 ) : " ";
         fmtFieldTypeMap[attrelid][attnum] = formatType;
         descrMap[attrelid][attnum] = descr;
-        defValMap[attrelid][attnum] = attGenerated.isEmpty() ? defVal : "DEFAULT";
+        if ( connectionRO()->pgVersion() >= 120000 )
+        {
+          defValMap[attrelid][attnum] = attGenerated.isEmpty() ? defVal : "DEFAULT";
+        }
+        else
+        {
+          defValMap[attrelid][attnum] = defVal;
+        }
         attTypeIdMap[attrelid][attnum] = attType;
         notNullMap[attrelid][attnum] = attNotNull;
         uniqueMap[attrelid][attnum] = uniqueConstraint;

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2341,7 +2341,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
 
       if ( !mGeneratedValues.value( idx, QString() ).isEmpty() )
       {
-        QgsLogger::warning( tr( "Skipping field %1 which is GENERATED." ).arg( fieldname ) );
+        QgsDebugMsg( QStringLiteral( "Skipping field %1 (idx %2) which is GENERATED." ).arg( fieldname, idx ) );
         continue;
       }
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -912,22 +912,15 @@ bool QgsPostgresProvider::loadFields()
         // generated values, which might make possible to have values other than "s" on pg_attribute.attgenerated,
         // which should be unimportant for QGIS if the user still won't be able to overwrite the column value.
         // See https://www.postgresql.org/docs/12/ddl-generated-columns.html
-        QString attGenerated = connectionRO()->pgVersion() >= 120000 ? fmtFieldTypeResult.PQgetvalue( i, 9 ) : " ";
+        QString attGenerated = connectionRO()->pgVersion() >= 120000 ? fmtFieldTypeResult.PQgetvalue( i, 9 ) : "";
         fmtFieldTypeMap[attrelid][attnum] = formatType;
         descrMap[attrelid][attnum] = descr;
-        if ( connectionRO()->pgVersion() >= 120000 )
-        {
-          defValMap[attrelid][attnum] = attGenerated.isEmpty() ? defVal : "DEFAULT";
-        }
-        else
-        {
-          defValMap[attrelid][attnum] = defVal;
-        }
+        defValMap[attrelid][attnum] = defVal;
         attTypeIdMap[attrelid][attnum] = attType;
         notNullMap[attrelid][attnum] = attNotNull;
         uniqueMap[attrelid][attnum] = uniqueConstraint;
         identityMap[attrelid][attnum] = attIdentity.isEmpty() ? " " : attIdentity;
-        generatedMap[attrelid][attnum] = attGenerated.isEmpty() ? QString() : attGenerated;
+        generatedMap[attrelid][attnum] = attGenerated;
       }
     }
   }

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -905,6 +905,13 @@ bool QgsPostgresProvider::loadFields()
         bool attNotNull = fmtFieldTypeResult.PQgetvalue( i, 6 ).toInt();
         bool uniqueConstraint = fmtFieldTypeResult.PQgetvalue( i, 7 ).toInt();
         QString attIdentity = connectionRO()->pgVersion() >= 100000 ? fmtFieldTypeResult.PQgetvalue( i, 8 ) : " ";
+
+        // On PostgreSQL 12, the field pg_attribute.attgenerated is always filled with "s" if the field is generated,
+        // with the possibility of other values in future releases. This indicates "STORED" generated fields.
+        // The documentation for version 12 indicates that there is a future possibility of supporting virtual
+        // generated values, which might make possible to have values other than "s" on pg_attribute.attgenerated,
+        // which should be unimportant for QGIS if the user still won't be able to overwrite the column value.
+        // See https://www.postgresql.org/docs/12/ddl-generated-columns.html
         QString attGenerated = connectionRO()->pgVersion() >= 120000 ? fmtFieldTypeResult.PQgetvalue( i, 9 ) : " ";
         fmtFieldTypeMap[attrelid][attnum] = formatType;
         descrMap[attrelid][attnum] = descr;
@@ -920,7 +927,7 @@ bool QgsPostgresProvider::loadFields()
         notNullMap[attrelid][attnum] = attNotNull;
         uniqueMap[attrelid][attnum] = uniqueConstraint;
         identityMap[attrelid][attnum] = attIdentity.isEmpty() ? " " : attIdentity;
-        generatedMap[attrelid][attnum] = attGenerated.isEmpty() ? " " : attGenerated;
+        generatedMap[attrelid][attnum] = attGenerated.isEmpty() ? QString() : attGenerated;
       }
     }
   }
@@ -1198,6 +1205,7 @@ bool QgsPostgresProvider::loadFields()
     }
 
     mDefaultValues.insert( mAttributeFields.size(), defValMap[tableoid][attnum] );
+    mGeneratedValues.insert( mAttributeFields.size(), generatedMap[tableoid][attnum] );
 
     QgsField newField = QgsField( fieldName, fieldType, fieldTypeName, fieldSize, fieldPrec, fieldComment, fieldSubType );
 
@@ -2072,6 +2080,15 @@ bool QgsPostgresProvider::isValid() const
 QString QgsPostgresProvider::defaultValueClause( int fieldId ) const
 {
   QString defVal = mDefaultValues.value( fieldId, QString() );
+  QString genVal = mGeneratedValues.value( fieldId, QString() );
+
+  // with generated columns (PostgreSQL 12+), the provider will ALWAYS evaluate the default values.
+  // The only acceptable value for such columns on INSERT or UPDATE clauses is the keyword "DEFAULT".
+  // See https://www.postgresql.org/docs/12/ddl-generated-columns.html
+  if ( !genVal.isEmpty() )
+  {
+    return "DEFAULT";
+  }
 
   if ( !providerProperty( EvaluateDefaultValues, false ).toBool() && !defVal.isEmpty() )
   {
@@ -2350,7 +2367,12 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
 
       if ( i == flist.size() )
       {
-        if ( qgsVariantEqual( v, defVal ) )
+        // generated values override everything.
+        if ( !mGeneratedValues[idx].isEmpty() )
+        {
+          values += delim + defVal;
+        }
+        else if ( qgsVariantEqual( v, defVal ) )
         {
           if ( defVal.isNull() )
           {

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -473,6 +473,10 @@ class QgsPostgresProvider final: public QgsVectorDataProvider
 
     QHash<int, QString> mDefaultValues;
 
+    // for handling generated columns, available in PostgreSQL 12+
+    // See https://www.postgresql.org/docs/12/ddl-generated-columns.html
+    QHash<int, QString> mGeneratedValues;
+
     bool mCheckPrimaryKeyUnicity = true;
 
     QgsLayerMetadata mLayerMetadata;

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -566,7 +566,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         # reading back
         vl2 = QgsVectorLayer('{} table="qgis_test"."{}" (geom) srid=4326 type=POLYGON key="id" sql='.format(self.dbconn, "test_gen_col"), "test_gen_col", "postgres")
         f2 = next(vl2.getFeatures(QgsFeatureRequest()))
-        self.assertEqual(f2['poly_area'], expected_area) # this, and not 42
+        self.assertEqual(f2['poly_area'], expected_area)
 
         # now, getting a brand new QgsVectorLayer to check if changes (UPDATE) in the geometry are reflected in the generated fields
         vl = QgsVectorLayer('{} table="qgis_test"."{}" (geom) srid=4326 type=POLYGON key="id" sql='.format(self.dbconn, "test_gen_col"), "test_gen_col", "postgres")
@@ -590,7 +590,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(f2['poly_area'], expected_area)
         self.assertEqual(f2['name'], 'New')
 
-        ### Geography columns
+        # Geography columns
         vl3 = QgsVectorLayer('{} table="qgis_test"."{}" (geog) srid=4326 type=POLYGON key="id" sql='.format(self.dbconn, "test_gen_geog_col"), "test_gen_geog_col", "postgres")
         self.assertTrue(vl3.isValid())
 

--- a/tests/testdata/provider/testdata_pg.sh
+++ b/tests/testdata/provider/testdata_pg.sh
@@ -17,12 +17,24 @@ SCRIPTS="
   tests/testdata/provider/testdata_pg_bigint_pk.sql
 "
 
+SCRIPTS12="
+  tests/testdata/provider/testdata_pg_12_generated.sql
+"
+
 dropdb --if-exists $DB
 createdb $DB -E UTF8 -T template0 || exit 1
 for f in ${SCRIPTS}; do
   echo "Restoring $f"
   psql -q --echo-errors -c "SET client_min_messages TO WARNING;" -f $f $DB -v ON_ERROR_STOP=1 || exit 1
 done
+
+PGSERVERVERSION=$(psql -XtA -c 'SHOW server_version_num' $DB)
+if test $PGSERVERVERSION -gt 120000; then
+  for f in ${SCRIPTS12}; do
+    echo "Restoring $f"
+    psql -q --echo-errors -c "SET client_min_messages TO WARNING;" -f $f $DB -v ON_ERROR_STOP=1 || exit 1
+  done
+fi
 
 # Test existence of qgis_test service, and recommend how to set it up
 # otherwise

--- a/tests/testdata/provider/testdata_pg_12_generated.sql
+++ b/tests/testdata/provider/testdata_pg_12_generated.sql
@@ -4,5 +4,14 @@
 CREATE TABLE qgis_test.test_gen_col (
   id SERIAL PRIMARY KEY,
   geom GEOMETRY('Polygon', 4326) NOT NULL,
-  cent GEOMETRY('Point') GENERATED ALWAYS AS ( st_centroid(geom) ) STORED
+  cent GEOMETRY('Point', 4326) NOT NULL GENERATED ALWAYS AS ( st_centroid(geom) ) STORED,
+  poly_area FLOAT NOT NULL GENERATED ALWAYS AS ( st_area(st_transform(geom, 31979)) ) STORED
 );
+
+CREATE TABLE qgis_test.test_gen_geog_col (
+  id SERIAL PRIMARY KEY,
+  geog GEOGRAPHY('Polygon', 4326) NOT NULL,
+  cent GEOGRAPHY('Point', 4326) NOT NULL GENERATED ALWAYS AS ( st_centroid(geog) ) STORED,
+  poly_area FLOAT NOT NULL GENERATED ALWAYS AS ( st_area(geog) ) STORED
+);
+

--- a/tests/testdata/provider/testdata_pg_12_generated.sql
+++ b/tests/testdata/provider/testdata_pg_12_generated.sql
@@ -1,0 +1,8 @@
+-- valid only for PostgreSQL 12 and newer, because we are testing features
+-- available only on this version.
+
+CREATE TABLE qgis_test.test_gen_col (
+  id SERIAL PRIMARY KEY,
+  geom GEOMETRY('Polygon', 4326) NOT NULL,
+  cent GEOMETRY('Point') GENERATED ALWAYS AS ( st_centroid(geom) ) STORED
+);

--- a/tests/testdata/provider/testdata_pg_12_generated.sql
+++ b/tests/testdata/provider/testdata_pg_12_generated.sql
@@ -3,6 +3,7 @@
 
 CREATE TABLE qgis_test.test_gen_col (
   id SERIAL PRIMARY KEY,
+  name varchar(32),
   geom GEOMETRY('Polygon', 4326) NOT NULL,
   cent GEOMETRY('Point', 4326) NOT NULL GENERATED ALWAYS AS ( st_centroid(geom) ) STORED,
   poly_area FLOAT NOT NULL GENERATED ALWAYS AS ( st_area(st_transform(geom, 31979)) ) STORED


### PR DESCRIPTION
Fixes #32898 . GENERATED columns is a feature introduced by PostgreSQL
12, which allows column values to be generated from other columns in the
same table; this replaces the creation of triggers to, for instance,
populate a column of centroids for the stored polygons.

Quoting the PostgreSQL 12 [documentation](https://www.postgresql.org/docs/12/ddl-generated-columns.html), "A generated column cannot be written to directly. In INSERT or UPDATE commands, a value cannot be specified for a generated column, but the keyword DEFAULT may be specified."

With this commit, QGIS would use the keyword "DEFAULT". The minor drawback that I see is that users will see the string "DEFAULT" on the form field for GENERATED columns when inserting/editing a new feature, instead of the expression used to generate the table; maybe a TODO? The original expression is certainly fetched by the current code.

I've used the same table as the original reporter of the issue to test this fix; it works for me:

```sql
CREATE TABLE test_gen_col (
  id SERIAL PRIMARY KEY,
  geom GEOMETRY('Polygon', 4326) NOT NULL,
  cent GEOMETRY('Point') GENERATED ALWAYS AS ( st_centroid(geom) ) STORED
);
```

Should this be backported to 3.12 and 3.10?