### PR TITLE
 Fix int64 literals parsing in QgsExpression

### DIFF
--- a/src/core/qgsexpressionlexer.ll
+++ b/src/core/qgsexpressionlexer.ll
@@ -209,6 +209,10 @@ string      "'"{str_char}*"'"
 	if( ok )
 		return NUMBER_INT;
 
+  yylval->numberInt64 = cLocale()->toLongLong( QString::fromLatin1(yytext), &ok );
+  if( ok )
+    return NUMBER_INT64;
+
 	yylval->numberFloat = cLocale()->toDouble( QString::fromLatin1(yytext), &ok );
 	if( ok )
 		return NUMBER_FLOAT;

--- a/src/core/qgsexpressionparser.yy
+++ b/src/core/qgsexpressionparser.yy
@@ -97,6 +97,7 @@ void addParserLocation(YYLTYPE* yyloc, QgsExpressionNode *node)
   QgsExpressionNode::NamedNode* namednode;
   double numberFloat;
   int    numberInt;
+  qlonglong numberInt64;
   bool   boolVal;
   QString* text;
   QgsExpressionNodeBinaryOperator::BinaryOperator b_op;
@@ -120,6 +121,7 @@ void addParserLocation(YYLTYPE* yyloc, QgsExpressionNode *node)
 // literals
 %token <numberFloat> NUMBER_FLOAT
 %token <numberInt> NUMBER_INT
+%token <numberInt64> NUMBER_INT64
 %token <boolVal> BOOLEAN
 %token NULLVALUE
 
@@ -326,6 +328,7 @@ expression:
     //  literals
     | NUMBER_FLOAT                { $$ = new QgsExpressionNodeLiteral( QVariant($1) ); }
     | NUMBER_INT                  { $$ = new QgsExpressionNodeLiteral( QVariant($1) ); }
+    | NUMBER_INT64                { $$ = new QgsExpressionNodeLiteral( QVariant($1) ); }
     | BOOLEAN                     { $$ = new QgsExpressionNodeLiteral( QVariant($1) ); }
     | STRING                      { $$ = new QgsExpressionNodeLiteral( QVariant(*$1) ); delete $1; }
     | NULLVALUE                   { $$ = new QgsExpressionNodeLiteral( QVariant() ); }

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -556,6 +556,7 @@ class TestQgsExpression: public QObject
       // literal evaluation
       QTest::newRow( "literal null" ) << "NULL" << false << QVariant();
       QTest::newRow( "literal int" ) << "123" << false << QVariant( 123 );
+      QTest::newRow( "literal int64" ) << "1234567890123456789" << false << QVariant( qlonglong( 1234567890123456789 ) );
       QTest::newRow( "literal double" ) << "1.2" << false << QVariant( 1.2 );
       QTest::newRow( "literal text" ) << "'hello'" << false << QVariant( "hello" );
       QTest::newRow( "literal double" ) << ".000001" << false << QVariant( 0.000001 );


### PR DESCRIPTION
## Description

Int64 literals are incorrectly parsed as double in expressions (Field Calculator / Expression builder), so their vaule is incorrect in calculations and when stored in int64 fileds.

This patch let the exression parser correcty handle int64 literals as the sql statement parser do.

Fixes #34262 (for the field calculator issue, except for shapefile int64 field issue which probably should be fixed at provider level)


<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
