### PR TITLE
[Backport 3.12] qgswmsrenderer.cpp: avoid confusing aliasing of 'layer' variable name

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -615,15 +615,15 @@ namespace QgsWms
             {
               QList<QgsMapLayer *> layersFromGroup;
 
-              for ( QgsMapLayer *layer : mContext.layersFromGroup( layer.mNickname ) )
+              for ( QgsMapLayer *layerFromGroup : mContext.layersFromGroup( layer.mNickname ) )
               {
 
-                if ( ! layer )
+                if ( ! layerFromGroup )
                 {
                   continue;
                 }
 
-                layersFromGroup.push_front( layer );
+                layersFromGroup.push_front( layerFromGroup );
               }
 
               if ( !layersFromGroup.isEmpty() )


### PR DESCRIPTION
which caused gcc 5.5 to fail

Backport of master commit https://github.com/qgis/QGIS/commit/3d3477e0fd3ba0a24af69009daa9c39a31f061ba