### PR TITLE
Server standalone: read hostname and port from HOST header (if any)

### DIFF
--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -322,15 +322,6 @@ int main( int argc, char *argv[] )
             throw HttpException( QStringLiteral( "HTTP error unsupported method: %1" ).arg( methodString ) );
           }
 
-          // Build URL from env ...
-          QString url { qgetenv( "REQUEST_URI" ) };
-          // ... or from server ip/port and request path
-          if ( url.isEmpty() )
-          {
-            const QString path { firstLinePieces.at( 1 )};
-            url = QStringLiteral( "http://%1:%2%3" ).arg( ipAddress ).arg( port ).arg( path );
-          }
-
           const QString protocol { firstLinePieces.at( 2 )};
           if ( protocol != QStringLiteral( "HTTP/1.0" ) && protocol != QStringLiteral( "HTTP/1.1" ) )
           {
@@ -354,6 +345,23 @@ int main( int argc, char *argv[] )
             if ( headerColonPos > 0 )
             {
               headers.insert( headerLine.left( headerColonPos ), headerLine.mid( headerColonPos + 2 ) );
+            }
+          }
+
+          // Build URL from env ...
+          QString url { qgetenv( "REQUEST_URI" ) };
+          // ... or from server ip/port and request path
+          if ( url.isEmpty() )
+          {
+            const QString path { firstLinePieces.at( 1 )};
+            // Take Host header if defined
+            if ( headers.contains( QStringLiteral( "Host" ) ) )
+            {
+              url = QStringLiteral( "http://%1%2" ).arg( headers.value( QStringLiteral( "Host" ) ) ).arg( path );
+            }
+            else
+            {
+              url = QStringLiteral( "http://%2:%3%4" ).arg( ipAddress ).arg( port ).arg( path );
             }
           }
 

--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -361,7 +361,7 @@ int main( int argc, char *argv[] )
             }
             else
             {
-              url = QStringLiteral( "http://%2:%3%4" ).arg( ipAddress ).arg( port ).arg( path );
+              url = QStringLiteral( "http://%1:%2%3" ).arg( ipAddress ).arg( port ).arg( path );
             }
           }
 


### PR DESCRIPTION
A tiny change: use the default hostname and port from the incoming request HOST header (if defined).