### PR TITLE
Teach the AlgorithmExecutor to count up to 100

### DIFF
--- a/python/plugins/processing/gui/AlgorithmExecutor.py
+++ b/python/plugins/processing/gui/AlgorithmExecutor.py
@@ -172,7 +172,6 @@ def execute_in_place_run(alg, parameters, context=None, feedback=None, raise_exc
             feature_iterator = active_layer.getFeatures(iterator_req)
             step = 100 / len(active_layer.selectedFeatureIds()) if active_layer.selectedFeatureIds() else 1
             for current, f in enumerate(feature_iterator):
-                feedback.setProgress(current * step)
                 if feedback.isCanceled():
                     break
 
@@ -205,6 +204,8 @@ def execute_in_place_run(alg, parameters, context=None, feedback=None, raise_exc
                         raise QgsProcessingException(tr("Error adding processed features back into the layer."))
                     new_ids = set([f.id() for f in active_layer.getFeatures(req)])
                     new_feature_ids += list(new_ids - old_ids)
+
+                feedback.setProgress(int((current + 1) * step))
 
             results, ok = {}, True
 
@@ -314,7 +315,7 @@ def executeIterating(alg, parameters, paramToIter, context, feedback):
     if iter_source.featureCount() == 0:
         return False
 
-    total = 100.0 / iter_source.featureCount()
+    step = 100.0 / iter_source.featureCount()
     for current, feat in enumerate(iter_source.getFeatures()):
         if feedback.isCanceled():
             return False
@@ -324,7 +325,7 @@ def executeIterating(alg, parameters, paramToIter, context, feedback):
         sink.addFeature(feat, QgsFeatureSink.FastInsert)
         del sink
 
-        feedback.setProgress(int(current * total))
+        feedback.setProgress(int((current + 1) * step))
 
     # store output values to use them later as basenames for all outputs
     outputs = {}
@@ -345,7 +346,7 @@ def executeIterating(alg, parameters, paramToIter, context, feedback):
             o = outputs[out.name()]
             parameters[out.name()] = QgsProcessingUtils.generateIteratingDestination(o, i, context)
         feedback.setProgressText(QCoreApplication.translate('AlgorithmExecutor', 'Executing iteration {0}/{1}…').format(i + 1, len(sink_list)))
-        feedback.setProgress(i * 100 / len(sink_list))
+        feedback.setProgress(int((i + 1) * 100 / len(sink_list)))
         ret, results = execute(alg, parameters, context, feedback)
         if not ret:
             return False


### PR DESCRIPTION
## Description
Progress was counted off by one.
This was mostly visible when running in-place algorithms from the locator widget where the progress bar does not dissappear on completion.


<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
