### PR TITLE
Updates on WMS-T static temporal capabilities settings 

### DIFF
--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -1247,7 +1247,9 @@ void QgsRasterLayerProperties::updateSourceStaticTime()
   QgsProviderMetadata *metadata = QgsProviderRegistry::instance()->providerMetadata(
                                     mRasterLayer->providerType() );
   QVariantMap uri = metadata->decodeUri( mRasterLayer->dataProvider()->dataSourceUri() );
-  uri[ QStringLiteral( "allowTemporalUpdates" ) ] = mWmstGroup->isChecked() ;
+
+  if ( mWmstGroup->isVisible() )
+    uri[ QStringLiteral( "allowTemporalUpdates" ) ] = mWmstGroup->isChecked();
 
   if ( mWmstGroup->isEnabled() &&
        mRasterLayer->dataProvider() &&


### PR DESCRIPTION
Improvements on top of work from PR https://github.com/qgis/QGIS/pull/35741.
This PR updates the state handling and logic of changes in WMS-T static temporal capabilities, these include disabling updates on temporal capabilities if the WMS-T static temporal capabilities group in raster layer properties is not checked.

example
![updates_on_wmst_settings](https://user-images.githubusercontent.com/2663775/80321861-67849400-8829-11ea-8f17-c9f2a29153ff.gif)
