### PR TITLE
[FEATURE][MESH] Identify tool for 1d mesh

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -158,6 +158,8 @@ Returns the provider type for this layer
 Gets native mesh and updates (creates if it doesn't exist) the base triangular mesh
 
 :param transform: Transformation from layer CRS to destination (e.g. map) CRS. With invalid transform, it keeps the native mesh CRS
+
+.. versionadded:: 3.14
 %End
 
 
@@ -197,9 +199,11 @@ Returns (date) time in hours formatted to human readable form
 .. versionadded:: 3.8
 %End
 
-    QgsMeshDatasetValue datasetValue( const QgsMeshDatasetIndex &index, const QgsPointXY &point ) const;
+    QgsMeshDatasetValue datasetValue( const QgsMeshDatasetIndex &index, const QgsPointXY &point, double searchRadius = 0 ) const;
 %Docstring
 Interpolates the value on the given point from given dataset.
+For 3D datasets, it uses #dataset3dValue \n
+For 1D datasets, it uses #dataset1dValue with ``searchRadius``
 
 .. note::
 
@@ -207,8 +211,11 @@ Interpolates the value on the given point from given dataset.
    and so if the layer has not been rendered previously
    (e.g. when used in a script) it returns NaN value
 
+.. seealso:: :py:func:`updateTriangularMesh`
+
 :param index: dataset index specifying group and dataset to extract value from
 :param point: point to query in map coordinates
+:param searchRadius: the radius of the search area in map unit
 
 :return: interpolated value at the point. Returns NaN values for values
          outside the mesh layer, nodata values and in case triangular mesh was not
@@ -228,6 +235,8 @@ Returns the 3d values of stacked 3d mesh defined by the given point
    and so if the layer has not been rendered previously
    (e.g. when used in a script) it returns NaN value
 
+.. seealso:: :py:func:`updateTriangularMesh`
+
 :param index: dataset index specifying group and dataset to extract value from
 :param point: point to query in map coordinates
 
@@ -237,6 +246,29 @@ Returns the 3d values of stacked 3d mesh defined by the given point
 
 
 .. versionadded:: 3.12
+%End
+
+    QgsMeshDatasetValue dataset1dValue( const QgsMeshDatasetIndex &index, const QgsPointXY &point, double searchRadius ) const;
+%Docstring
+Returns the value of 1D mesh dataset defined on edge that are in the search area defined by point ans searchRadius
+
+.. note::
+
+   It uses previously cached and indexed triangular mesh
+   and so if the layer has not been rendered previously
+   (e.g. when used in a script) it returns NaN value
+
+.. seealso:: :py:func:`updateTriangularMesh`
+
+:param index: dataset index specifying group and dataset to extract value from
+:param point: the center point of the search area
+:param searchRadius: the radius of the searc area in map unit
+
+:return: interpolated value at the projected point. Returns NaN values for values
+         outside the mesh layer and in case triangular mesh was not previously used for rendering
+
+
+.. versionadded:: 3.14
 %End
 
     QgsMeshDatasetIndex activeScalarDatasetAtTime( const QgsDateTimeRange &timeRange ) const;

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -202,8 +202,8 @@ Returns (date) time in hours formatted to human readable form
     QgsMeshDatasetValue datasetValue( const QgsMeshDatasetIndex &index, const QgsPointXY &point, double searchRadius = 0 ) const;
 %Docstring
 Interpolates the value on the given point from given dataset.
-For 3D datasets, it uses #dataset3dValue \n
-For 1D datasets, it uses #dataset1dValue with ``searchRadius``
+For 3D datasets, it uses dataset3dValue(), \n
+For 1D datasets, it uses dataset1dValue() with ``searchRadius``
 
 .. note::
 

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -259,8 +259,8 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
 
     /**
       * Interpolates the value on the given point from given dataset.
-      * For 3D datasets, it uses #dataset3dValue \n
-      * For 1D datasets, it uses #dataset1dValue with \a searchRadius
+      * For 3D datasets, it uses dataset3dValue(), \n
+      * For 1D datasets, it uses dataset1dValue() with \a searchRadius
       *
       * \note It uses previously cached and indexed triangular mesh
       * and so if the layer has not been rendered previously

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -204,6 +204,8 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
      * Gets native mesh and updates (creates if it doesn't exist) the base triangular mesh
      *
      * \param transform Transformation from layer CRS to destination (e.g. map) CRS. With invalid transform, it keeps the native mesh CRS
+     *
+     * \since QGIS 3.14
      */
     void updateTriangularMesh( const QgsCoordinateTransform &transform = QgsCoordinateTransform() );
 
@@ -257,20 +259,24 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
 
     /**
       * Interpolates the value on the given point from given dataset.
+      * For 3D datasets, it uses #dataset3dValue \n
+      * For 1D datasets, it uses #dataset1dValue with \a searchRadius
       *
       * \note It uses previously cached and indexed triangular mesh
       * and so if the layer has not been rendered previously
       * (e.g. when used in a script) it returns NaN value
+      * \see updateTriangularMesh
       *
       * \param index dataset index specifying group and dataset to extract value from
       * \param point point to query in map coordinates
+      * \param searchRadius the radius of the search area in map unit
       * \returns interpolated value at the point. Returns NaN values for values
       * outside the mesh layer, nodata values and in case triangular mesh was not
       * previously used for rendering
       *
       * \since QGIS 3.4
       */
-    QgsMeshDatasetValue datasetValue( const QgsMeshDatasetIndex &index, const QgsPointXY &point ) const;
+    QgsMeshDatasetValue datasetValue( const QgsMeshDatasetIndex &index, const QgsPointXY &point, double searchRadius = 0 ) const;
 
     /**
       * Returns the 3d values of stacked 3d mesh defined by the given point
@@ -278,6 +284,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
       * \note It uses previously cached and indexed triangular mesh
       * and so if the layer has not been rendered previously
       * (e.g. when used in a script) it returns NaN value
+      * \see updateTriangularMesh
       *
       * \param index dataset index specifying group and dataset to extract value from
       * \param point point to query in map coordinates
@@ -288,6 +295,24 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
       * \since QGIS 3.12
       */
     QgsMesh3dDataBlock dataset3dValue( const QgsMeshDatasetIndex &index, const QgsPointXY &point ) const;
+
+    /**
+      * Returns the value of 1D mesh dataset defined on edge that are in the search area defined by point ans searchRadius
+      *
+      * \note It uses previously cached and indexed triangular mesh
+      * and so if the layer has not been rendered previously
+      * (e.g. when used in a script) it returns NaN value
+      * \see updateTriangularMesh
+      *
+      * \param index dataset index specifying group and dataset to extract value from
+      * \param point the center point of the search area
+      * \param searchRadius the radius of the searc area in map unit
+      * \returns interpolated value at the projected point. Returns NaN values for values
+      * outside the mesh layer and in case triangular mesh was not previously used for rendering
+      *
+      * \since QGIS 3.14
+      */
+    QgsMeshDatasetValue dataset1dValue( const QgsMeshDatasetIndex &index, const QgsPointXY &point, double searchRadius ) const;
 
     /**
       * Returns dataset index from active scalar group depending on the time range.

--- a/src/core/mesh/qgsmeshlayerutils.cpp
+++ b/src/core/mesh/qgsmeshlayerutils.cpp
@@ -269,6 +269,12 @@ double QgsMeshLayerUtils::interpolateFromVerticesData( double fraction, double v
   return val1 + ( val2 - val1 ) * fraction;
 }
 
+QgsMeshDatasetValue QgsMeshLayerUtils::interpolateFromVerticesData( double fraction, const QgsMeshDatasetValue &val1, const QgsMeshDatasetValue &val2 )
+{
+  return QgsMeshDatasetValue( interpolateFromVerticesData( fraction, val1.x(), val2.x() ),
+                              interpolateFromVerticesData( fraction, val1.y(), val2.y() ) );
+}
+
 
 QgsVector QgsMeshLayerUtils::interpolateVectorFromVerticesData( const QgsPointXY &p1, const QgsPointXY &p2, const QgsPointXY &p3, QgsVector vect1, QgsVector vect2, QgsVector vect3, const QgsPointXY &pt )
 {

--- a/src/core/mesh/qgsmeshlayerutils.h
+++ b/src/core/mesh/qgsmeshlayerutils.h
@@ -138,6 +138,16 @@ class CORE_EXPORT QgsMeshLayerUtils
     );
 
     /**
+    * Interpolates value based on known values on the vertices of a edge
+    * \returns value on the point pt a or NaN
+    *
+    * \since QGIS 3.14
+    */
+    static QgsMeshDatasetValue interpolateFromVerticesData( double fraction,
+        const QgsMeshDatasetValue &val1, const QgsMeshDatasetValue &val2
+                                                          );
+
+    /**
     * Interpolates value based on known values on the vertices of a triangle
     * \param p1 first vertex of the triangle
     * \param p2 second vertex of the triangle

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -259,12 +259,14 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
 
   QMap< QString, QString > scalarAttributes, vectorAttributes, raw3dAttributes;
 
+  double searchRadius = mOverrideCanvasSearchRadius < 0 ? searchRadiusMU( mCanvas ) : mOverrideCanvasSearchRadius;
+
   QString scalarGroup;
   if ( scalarDatasetIndex.isValid() )
   {
     scalarGroup = layer->dataProvider()->datasetGroupMetadata( scalarDatasetIndex.group() ).name();
 
-    const QgsMeshDatasetValue scalarValue = layer->datasetValue( scalarDatasetIndex, point );
+    const QgsMeshDatasetValue scalarValue = layer->datasetValue( scalarDatasetIndex, point, searchRadius );
     const double scalar = scalarValue.scalar();
     if ( std::isnan( scalar ) )
       scalarAttributes.insert( tr( "Scalar Value" ), tr( "no data" ) );
@@ -277,7 +279,7 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
   {
     vectorGroup = layer->dataProvider()->datasetGroupMetadata( vectorDatasetIndex.group() ).name();
 
-    const QgsMeshDatasetValue vectorValue = layer->datasetValue( vectorDatasetIndex, point );
+    const QgsMeshDatasetValue vectorValue = layer->datasetValue( vectorDatasetIndex, point, searchRadius );
     const double vectorX = vectorValue.x();
     const double vectorY = vectorValue.y();
 

--- a/tests/src/core/testqgsmeshlayer.cpp
+++ b/tests/src/core/testqgsmeshlayer.cpp
@@ -82,6 +82,8 @@ class TestQgsMeshLayer : public QObject
     void test_reload_extra_dataset();
 
     void test_mesh_simplification();
+
+    void test_dataset_value_from_layer();
 };
 
 QString TestQgsMeshLayer::readFile( const QString &fname ) const
@@ -907,6 +909,38 @@ void TestQgsMeshLayer::test_mesh_simplification()
   // Delete simplified meshes
   for ( QgsTriangularMesh *m : simplifiedMeshes )
     delete m;
+}
+
+void TestQgsMeshLayer::test_dataset_value_from_layer()
+{
+  QgsMeshDatasetValue value;
+
+  //1D mesh
+  mMdal1DLayer->updateTriangularMesh();
+  value = mMdal1DLayer->datasetValue( QgsMeshDatasetIndex( 0, 0 ), QgsPointXY( 1500, 2009 ), 10 );
+  QCOMPARE( QgsMeshDatasetValue( 25 ), value );
+  value = mMdal1DLayer->datasetValue( QgsMeshDatasetIndex( 1, 0 ), QgsPointXY( 2500, 1991 ), 10 );
+  QCOMPARE( QgsMeshDatasetValue( 2.5 ), value );
+  value = mMdal1DLayer->datasetValue( QgsMeshDatasetIndex( 2, 0 ), QgsPointXY( 2500, 2500 ), 10 );
+  QCOMPARE( QgsMeshDatasetValue( 2.5, 2 ), value );
+  value = mMdal1DLayer->datasetValue( QgsMeshDatasetIndex( 3, 1 ), QgsPointXY( 2495, 2000 ), 10 );
+  QCOMPARE( QgsMeshDatasetValue( 3 ), value );
+  value = mMdal1DLayer->datasetValue( QgsMeshDatasetIndex( 4, 1 ), QgsPointXY( 2500, 2495 ), 10 );
+  QCOMPARE( QgsMeshDatasetValue( 4, 4 ), value );
+
+  //2D mesh
+  mMdalLayer->updateTriangularMesh();
+  value = mMdalLayer->datasetValue( QgsMeshDatasetIndex( 0, 0 ), QgsPointXY( 1750, 2250 ) );
+  QCOMPARE( QgsMeshDatasetValue( 32.5 ), value );
+  value = mMdalLayer->datasetValue( QgsMeshDatasetIndex( 1, 0 ), QgsPointXY( 1750, 2250 ) );
+  QCOMPARE( QgsMeshDatasetValue( 1.75 ), value );
+  value = mMdalLayer->datasetValue( QgsMeshDatasetIndex( 2, 0 ), QgsPointXY( 1750, 2250 ) );
+  QCOMPARE( QgsMeshDatasetValue( 1.75, 1.25 ), value );
+  value = mMdalLayer->datasetValue( QgsMeshDatasetIndex( 3, 1 ), QgsPointXY( 1750, 2250 ) );
+  QCOMPARE( QgsMeshDatasetValue( 2 ), value );
+  value = mMdalLayer->datasetValue( QgsMeshDatasetIndex( 4, 1 ), QgsPointXY( 1750, 2250 ) );
+  QCOMPARE( QgsMeshDatasetValue( 2, 2 ), value );
+
 }
 
 void TestQgsMeshLayer::test_temporal()


### PR DESCRIPTION
This PR enables the identify tool for 1D mesh.
The identify tool displays dataset scalar and vector values on the edge the closest of the clicked point.
For dataset on vertex, the dataset are interpolated depending on the projected clicked point on the edge.

![identifyTool1D](https://user-images.githubusercontent.com/7416892/80411974-19a87400-889b-11ea-8d9d-823c00b8f91c.gif)

