### PR TITLE
Correctly handle bigint PostgreSQL values

### DIFF
--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -857,6 +857,11 @@ void QgsPostgresFeatureIterator::getFeatureAttribute( int idx, QgsPostgresResult
       }
       break;
     }
+    case QVariant::LongLong:
+    {
+      v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), QString::number( mConn->getBinaryInt( queryResult, row, col ) ), fld.typeName() );
+      break;
+    }
     default:
     {
       v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), queryResult.PQgetvalue( row, col ), fld.typeName() );

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1768,14 +1768,7 @@ QVariant QgsPostgresProvider::minimumValue( int index ) const
     sql = QStringLiteral( "SELECT %1 FROM (%2) foo" ).arg( connectionRO()->fieldExpression( fld ), sql );
 
     QgsPostgresResult rmin( connectionRO()->PQexec( sql ) );
-    if ( fld.type() == QVariant::LongLong )
-    {
-      return convertValue( fld.type(), fld.subType(), QString::number( connectionRO()->getBinaryInt( rmin, 0, 0 ) ), fld.typeName() );
-    }
-    else
-    {
-      return convertValue( fld.type(), fld.subType(), rmin.PQgetvalue( 0, 0 ), fld.typeName() );
-    }
+    return convertValue( fld.type(), fld.subType(), rmin.PQgetvalue( 0, 0 ), fld.typeName() );
   }
   catch ( PGFieldNotFound )
   {
@@ -2040,14 +2033,7 @@ QVariant QgsPostgresProvider::maximumValue( int index ) const
 
     QgsPostgresResult rmax( connectionRO()->PQexec( sql ) );
 
-    if ( fld.type() == QVariant::LongLong )
-    {
-      return convertValue( fld.type(), fld.subType(), QString::number( connectionRO()->getBinaryInt( rmax, 0, 0 ) ), fld.typeName() );
-    }
-    else
-    {
-      return convertValue( fld.type(), fld.subType(), rmax.PQgetvalue( 0, 0 ), fld.typeName() );
-    }
+    return convertValue( fld.type(), fld.subType(), rmax.PQgetvalue( 0, 0 ), fld.typeName() );
   }
   catch ( PGFieldNotFound )
   {

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1768,7 +1768,14 @@ QVariant QgsPostgresProvider::minimumValue( int index ) const
     sql = QStringLiteral( "SELECT %1 FROM (%2) foo" ).arg( connectionRO()->fieldExpression( fld ), sql );
 
     QgsPostgresResult rmin( connectionRO()->PQexec( sql ) );
-    return convertValue( fld.type(), fld.subType(), rmin.PQgetvalue( 0, 0 ), fld.typeName() );
+    if ( fld.type() == QVariant::LongLong )
+    {
+      return convertValue( fld.type(), fld.subType(), QString::number( connectionRO()->getBinaryInt( rmin, 0, 0 ) ), fld.typeName() );
+    }
+    else
+    {
+      return convertValue( fld.type(), fld.subType(), rmin.PQgetvalue( 0, 0 ), fld.typeName() );
+    }
   }
   catch ( PGFieldNotFound )
   {
@@ -2033,7 +2040,14 @@ QVariant QgsPostgresProvider::maximumValue( int index ) const
 
     QgsPostgresResult rmax( connectionRO()->PQexec( sql ) );
 
-    return convertValue( fld.type(), fld.subType(), rmax.PQgetvalue( 0, 0 ), fld.typeName() );
+    if ( fld.type() == QVariant::LongLong )
+    {
+      return convertValue( fld.type(), fld.subType(), QString::number( connectionRO()->getBinaryInt( rmax, 0, 0 ) ), fld.typeName() );
+    }
+    else
+    {
+      return convertValue( fld.type(), fld.subType(), rmax.PQgetvalue( 0, 0 ), fld.typeName() );
+    }
   }
   catch ( PGFieldNotFound )
   {
@@ -2070,7 +2084,16 @@ QVariant QgsPostgresProvider::defaultValue( int fieldId ) const
     QgsPostgresResult res( connectionRO()->PQexec( QStringLiteral( "SELECT %1" ).arg( defVal ) ) );
 
     if ( res.result() )
-      return convertValue( fld.type(), fld.subType(), res.PQgetvalue( 0, 0 ), fld.typeName() );
+    {
+      if ( fld.type() == QVariant::LongLong )
+      {
+        return convertValue( fld.type(), fld.subType(), QString::number( connectionRO()->getBinaryInt( res, 0, 0 ) ), fld.typeName() );
+      }
+      else
+      {
+        return convertValue( fld.type(), fld.subType(), res.PQgetvalue( 0, 0 ), fld.typeName() );
+      }
+    }
     else
     {
       pushError( tr( "Could not execute query" ) );

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2071,14 +2071,7 @@ QVariant QgsPostgresProvider::defaultValue( int fieldId ) const
 
     if ( res.result() )
     {
-      if ( fld.type() == QVariant::LongLong )
-      {
-        return convertValue( fld.type(), fld.subType(), QString::number( connectionRO()->getBinaryInt( res, 0, 0 ) ), fld.typeName() );
-      }
-      else
-      {
-        return convertValue( fld.type(), fld.subType(), res.PQgetvalue( 0, 0 ), fld.typeName() );
-      }
+      return convertValue( fld.type(), fld.subType(), res.PQgetvalue( 0, 0 ), fld.typeName() );
     }
     else
     {

--- a/tests/testdata/provider/testdata_pg_bigint_pk.sql
+++ b/tests/testdata/provider/testdata_pg_bigint_pk.sql
@@ -3,6 +3,8 @@ DROP TABLE IF EXISTS qgis_test.bigint_pk;
 CREATE TABLE qgis_test.bigint_pk (
   pk bigserial NOT NULL PRIMARY KEY,
   value varchar(16),
+  bigint_attribute bigint,
+  bigint_attribute_def bigint DEFAULT 42,
   geom geometry(Point, 4326)
 );
 


### PR DESCRIPTION
Fixes #36011

When changing the way QGIS handles bigint PostgreSQL values, we stopped quoting/converting them as texts; however, on the last PR (#35162), we only handled primary keys; ordinary fields were left unchanged, leading to conflicts on the attribute tables and other parts of the code. This PR fixes that issue, by fetching bigint values as binary and internally converting them to text.

Please backport this to 3.12 as well, because #35832 also had this bug. @m-kuhn , can you please take a look? Thank you very much.