### PR TITLE
Fix subset string is ignored for vector layers when running GDAL algorithms

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalAlgorithm.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithm.py
@@ -99,7 +99,8 @@ class GdalAlgorithm(QgsProcessingAlgorithm):
                 ogr_data_path = 'path_to_data_file'
                 ogr_layer_name = 'layer_name'
         elif input_layer.dataProvider().name() == 'ogr':
-            if executing and isinstance(parameters[parameter_name], QgsProcessingFeatureSourceDefinition) and parameters[parameter_name].selectedFeaturesOnly:
+            if executing and (isinstance(parameters[parameter_name], QgsProcessingFeatureSourceDefinition) and parameters[parameter_name].selectedFeaturesOnly) \
+                    or input_layer.subsetString():
                 # parameter is a vector layer, with OGR data provider
                 # so extract selection if required
                 ogr_data_path = self.parameterAsCompatibleSourceLayerPath(parameters, parameter_name, context,

--- a/python/plugins/processing/tests/GdalAlgorithmsGeneralTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsGeneralTest.py
@@ -164,6 +164,18 @@ class TestGdalAlgorithms(unittest.TestCase):
         path, layer = alg.getOgrCompatibleSource('INPUT', parameters, context, feedback, False)
         self.assertEqual(path, source)
 
+        # with subset string
+        vl.setSubsetString('x')
+        path, layer = alg.getOgrCompatibleSource('INPUT', parameters, context, feedback, False)
+        self.assertEqual(path, source)
+        # subset of layer must be exported
+        path, layer = alg.getOgrCompatibleSource('INPUT', parameters, context, feedback, True)
+        self.assertNotEqual(path, source)
+        self.assertTrue(path)
+        self.assertTrue(path.endswith('.gpkg'))
+        self.assertTrue(os.path.exists(path))
+        self.assertTrue(layer)
+
         # geopackage with layer
         source = os.path.join(testDataPath, 'custom', 'circular_strings.gpkg')
         vl2 = QgsVectorLayer(source + '|layername=circular_strings')


### PR DESCRIPTION
If a subset string is set, we must export the subset of the layer
for use by the GDAL command*

Fixes #35981

* well, we probably **should** just build the gdal command to include
the SQL definition of the subset filter, but that's non-trivial, so
this fix is a good simple solution for now

