### PR TITLE
[QgsQuick] Fix overlaped variable name with QT widget's variable

### DIFF
--- a/src/quickgui/plugin/editor/qgsquickvaluemap.qml
+++ b/src/quickgui/plugin/editor/qgsquickvaluemap.qml
@@ -38,7 +38,7 @@ Item {
   QgsQuick.EditorWidgetComboBox {
     // Reversed to model's key-value map. It is used to find index according current value
     property var reverseConfig: ({})
-    property var currentValue: value
+    property var currentEditorValue: value
 
     comboStyle: customStyle.fields
     textRole: 'display'
@@ -81,7 +81,7 @@ Item {
     }
 
     // Workaround to get a signal when the value has changed
-    onCurrentValueChanged: {
+    onCurrentEditorValueChanged: {
       currentIndex = find(reverseConfig[value])
     }
 

--- a/src/quickgui/plugin/editor/qgsquickvaluerelation.qml
+++ b/src/quickgui/plugin/editor/qgsquickvaluerelation.qml
@@ -37,7 +37,7 @@ Item {
 
   QgsQuick.EditorWidgetComboBox {
 
-    property var currentValue: value
+    property var currentEditorValue: value
 
     comboStyle: customStyle.fields
     textRole: 'display'
@@ -58,7 +58,7 @@ Item {
     }
 
     // Called when the same form is used for a different feature
-    onCurrentValueChanged: {
+    onCurrentEditorValueChanged: {
         currentIndex = vrModel.rowForKey(value);
     }
 


### PR DESCRIPTION
Qt 5.14 introduced currentValue variable for combobox widget which clashes with QgsQuick variable. Note that EditorWidgetComboBox is extended Combobox from QtQuick.
ref: https://doc.qt.io/qt-5/qml-qtquick-controls2-combobox.html#currentValue-prop

