### PR TITLE
Only show detailed logging messages when running a model through the designer dialog

### DIFF
--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -52,6 +52,8 @@ class ParametersPanel(QgsProcessingParametersWidget):
 
         self.wrappers = {}
 
+        self.extra_parameters = {}
+
         self.processing_context = createContext()
 
         class ContextGenerator(QgsProcessingContextGenerator):
@@ -189,6 +191,8 @@ class ParametersPanel(QgsProcessingParametersWidget):
 
     def createProcessingParameters(self):
         parameters = {}
+        for p, v in self.extra_parameters.items():
+            parameters[p] = v
 
         for param in self.algorithm().parameterDefinitions():
             if param.flags() & QgsProcessingParameterDefinition.FlagHidden:
@@ -251,8 +255,11 @@ class ParametersPanel(QgsProcessingParametersWidget):
         return self.algorithm().preprocessParameters(parameters)
 
     def setParameters(self, parameters):
+        self.extra_parameters = {}
         for param in self.algorithm().parameterDefinitions():
             if param.flags() & QgsProcessingParameterDefinition.FlagHidden:
+                if param.name() in parameters:
+                    self.extra_parameters[param.name()] = parameters[param.name()]
                 continue
 
             if not param.name() in parameters:

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -489,7 +489,7 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
      *
      * \since QGIS 3.14
      */
-    QVariantMap designerParameterValues() const { return mDesignerParameterValues; }
+    QVariantMap designerParameterValues() const;
 
     /**
      * Sets the parameter \a values to use as default values when running this model through the

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -8596,6 +8596,9 @@ void TestQgsProcessing::modelerAlgorithm()
   lastParams.insert( QStringLiteral( "a" ), 2 );
   lastParams.insert( QStringLiteral( "b" ), 4 );
   alg.setDesignerParameterValues( lastParams );
+
+  // we expect the result to add in some custom parameters -- namely the verbose log switch
+  lastParams.insert( QStringLiteral( "VERBOSE_LOG" ), true );
   QCOMPARE( alg.designerParameterValues(), lastParams );
 
   // child algorithms

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -355,6 +355,7 @@ void TestProcessingGui::testModelUndo()
   // the last used parameter values setting should not be affected by undo stack changes
   QVariantMap params;
   params.insert( QStringLiteral( "a" ), 1 );
+  params.insert( QStringLiteral( "VERBOSE_LOG" ), true );
   model.setDesignerParameterValues( params );
   command.undo();
   QCOMPARE( model.designerParameterValues(), params );


### PR DESCRIPTION
Only show detailed logging messages when running a model algorithm IF the model is being run through the model designer dialog.

If you run it from the toolbox (or as a sub-component in another model) then skip all the additional verbose debugging information that normally gets logged.

This avoids a whole lot of unnecessary log noise when running models, unless you're actively working on changing the model.