### PR TITLE
Improving mesh symbology dialogs (part 1)

### DIFF
--- a/src/ui/mesh/qgsmeshrenderer3daveragingwidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrenderer3daveragingwidgetbase.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>852</width>
-    <height>552</height>
+    <width>454</width>
+    <height>179</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_7">
+  <layout class="QGridLayout" name="gridLayout_7">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -26,75 +26,7 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLabel" name="mAveragingMethodLabel">
-       <property name="text">
-        <string>Method</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="mAveragingMethodComboBox">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <item>
-        <property name="text">
-         <string>Single Vertical Level (from top)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Single Vertical Level (from bottom)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Multi Vertical Level (from top)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Multi Vertical Level (from bottom)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Sigma</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Depth (relative to surface)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Height (relative to bed level)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Elevation (absolute to model's datum)</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item>
+   <item row="1" column="0" colspan="2">
     <widget class="QStackedWidget" name="mAveragingMethodStackedWidget">
      <property name="currentIndex">
       <number>0</number>
@@ -106,7 +38,7 @@
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
+      <layout class="QGridLayout" name="gridLayout_3">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -119,95 +51,66 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item>
-        <widget class="QWidget" name="widget" native="true">
-         <layout class="QVBoxLayout" name="verticalLayout_18">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="mAveragingMethodLabel_2">
+         <property name="text">
+          <string>Vertical layer index</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QgsSpinBox" name="mSingleVerticalLayerIndexTopSpinBox">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>999</number>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="2">
+        <widget class="QGroupBox" name="mSingleTopGroup">
+         <property name="title">
+          <string>Example: Value of top vertical layer</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-             <widget class="QLabel" name="mAveragingMethodLabel_2">
-              <property name="text">
-               <string>Vertical layer index</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsSpinBox" name="mSingleVerticalLayerIndexTopSpinBox">
-              <property name="minimum">
-               <number>1</number>
-              </property>
-              <property name="maximum">
-               <number>999</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="mSingleTopGroup">
-            <property name="title">
-             <string>Example: Value of top vertical layer</string>
+           <widget class="QLabel" name="mSingleTopPngLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
-            <layout class="QVBoxLayout" name="verticalLayout_2">
-             <item>
-              <widget class="QLabel" name="mSingleTopPngLabel">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>png</string>
-               </property>
-               <property name="scaledContents">
-                <bool>false</bool>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="mSingleTopDescLabel">
-               <property name="text">
-                <string>Display the value from a vertical layer from the top (surface). The level is truncated to the maximum number of vertical layers for particular face.</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <property name="text">
+             <string>png</string>
+            </property>
+            <property name="scaledContents">
+             <bool>false</bool>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
            </widget>
           </item>
           <item>
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
+           <widget class="QLabel" name="mSingleTopDescLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
+            <property name="text">
+             <string>Display the value from a vertical layer from the top (surface). The level is truncated to the maximum number of vertical layers for particular face.</string>
             </property>
-           </spacer>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -215,7 +118,7 @@
       </layout>
      </widget>
      <widget class="QWidget" name="mAveragingMethodSingleLevelBottomPage">
-      <layout class="QVBoxLayout" name="verticalLayout_17">
+      <layout class="QGridLayout" name="gridLayout_17">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -228,89 +131,54 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item>
-        <widget class="QWidget" name="widget_8" native="true">
-         <layout class="QVBoxLayout" name="verticalLayout_19">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="mAveragingMethodLabel_11">
+         <property name="text">
+          <string>Vertical layer index</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QgsSpinBox" name="mSingleVerticalLayerIndexBottomSpinBox">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>999</number>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="2">
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Example: Value of bottom vertical layer</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_16">
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_15">
-            <item>
-             <widget class="QLabel" name="mAveragingMethodLabel_11">
-              <property name="text">
-               <string>Vertical layer index</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsSpinBox" name="mSingleVerticalLayerIndexBottomSpinBox">
-              <property name="minimum">
-               <number>1</number>
-              </property>
-              <property name="maximum">
-               <number>999</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="groupBox">
-            <property name="title">
-             <string>Example: Value of bottom vertical layer</string>
+           <widget class="QLabel" name="mSingleBottomPngLabel">
+            <property name="text">
+             <string>..png...</string>
             </property>
-            <layout class="QVBoxLayout" name="verticalLayout_16">
-             <item>
-              <widget class="QLabel" name="mSingleBottomPngLabel">
-               <property name="text">
-                <string>..png...</string>
-               </property>
-               <property name="scaledContents">
-                <bool>false</bool>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="mSingleBottomDescLabel">
-               <property name="text">
-                <string>Display the value from a vertical layer from the bottom (bed). The level is truncated to the maximum number of vertical layers for particular face.</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <property name="scaledContents">
+             <bool>false</bool>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
            </widget>
           </item>
           <item>
-           <spacer name="verticalSpacer_8">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
+           <widget class="QLabel" name="mSingleBottomDescLabel">
+            <property name="text">
+             <string>Display the value from a vertical layer from the bottom (bed). The level is truncated to the maximum number of vertical layers for particular face.</string>
             </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>291</height>
-             </size>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
             </property>
-           </spacer>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -318,7 +186,7 @@
       </layout>
      </widget>
      <widget class="QWidget" name="mAveragingMethodMultiTopPage">
-      <layout class="QVBoxLayout" name="verticalLayout_20">
+      <layout class="QGridLayout" name="gridLayout_20">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -331,67 +199,41 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item>
-        <widget class="QWidget" name="widget_2" native="true">
-         <layout class="QVBoxLayout" name="verticalLayout_4">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
-            <item>
-             <widget class="QLabel" name="mAveragingMethodLabel_3">
-              <property name="text">
-               <string>Start vertical layer index</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsSpinBox" name="mMultiTopVerticalLayerStartIndexSpinBox">
-              <property name="minimum">
-               <number>1</number>
-              </property>
-              <property name="maximum">
-               <number>999</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
-            <item>
-             <widget class="QLabel" name="mAveragingMethodLabel_5">
-              <property name="text">
-               <string>End vertical layer index</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsSpinBox" name="mMultiTopVerticalLayerEndIndexSpinBox">
-              <property name="minimum">
-               <number>1</number>
-              </property>
-              <property name="maximum">
-               <number>999</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
+       <item row="0" column="0">
+        <widget class="QLabel" name="mAveragingMethodLabel_3">
+         <property name="text">
+          <string>Start vertical layer index</string>
+         </property>
         </widget>
        </item>
-       <item>
+       <item row="0" column="1">
+        <widget class="QgsSpinBox" name="mMultiTopVerticalLayerStartIndexSpinBox">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>999</number>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="mAveragingMethodLabel_5">
+         <property name="text">
+          <string>End vertical layer index</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QgsSpinBox" name="mMultiTopVerticalLayerEndIndexSpinBox">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>999</number>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
         <widget class="QGroupBox" name="groupBox_2">
          <property name="title">
           <string>Example: first 2 vertical levels </string>
@@ -426,23 +268,10 @@
          </layout>
         </widget>
        </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>258</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="mAveragingMethodMultiBottomPage">
-      <layout class="QVBoxLayout" name="verticalLayout_21">
+      <layout class="QGridLayout" name="gridLayout_21">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -455,67 +284,41 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item>
-        <widget class="QWidget" name="widget_3" native="true">
-         <layout class="QVBoxLayout" name="verticalLayout_6">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
-            <item>
-             <widget class="QLabel" name="mAveragingMethodLabel_4">
-              <property name="text">
-               <string>Start vertical layer index</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsSpinBox" name="mMultiBottomVerticalLayerStartIndexSpinBox">
-              <property name="minimum">
-               <number>1</number>
-              </property>
-              <property name="maximum">
-               <number>999</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_6">
-            <item>
-             <widget class="QLabel" name="mAveragingMethodLabel_6">
-              <property name="text">
-               <string>End vertical layer index</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsSpinBox" name="mMultiBottomVerticalLayerEndIndexSpinBox">
-              <property name="minimum">
-               <number>1</number>
-              </property>
-              <property name="maximum">
-               <number>999</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
+       <item row="0" column="0">
+        <widget class="QLabel" name="mAveragingMethodLabel_4">
+         <property name="text">
+          <string>Start vertical layer index</string>
+         </property>
         </widget>
        </item>
-       <item>
+       <item row="0" column="1">
+        <widget class="QgsSpinBox" name="mMultiBottomVerticalLayerStartIndexSpinBox">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>999</number>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="mAveragingMethodLabel_6">
+         <property name="text">
+          <string>End vertical layer index</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QgsSpinBox" name="mMultiBottomVerticalLayerEndIndexSpinBox">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>999</number>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
         <widget class="QGroupBox" name="groupBox_3">
          <property name="title">
           <string>Example: last 2 vertical levels</string>
@@ -550,23 +353,10 @@
          </layout>
         </widget>
        </item>
-       <item>
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="mAveragingMethodSigmaPage">
-      <layout class="QVBoxLayout" name="verticalLayout_12">
+      <layout class="QGridLayout" name="gridLayout_12">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -579,116 +369,77 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item>
-        <widget class="QWidget" name="widget_4" native="true">
-         <layout class="QVBoxLayout" name="verticalLayout_22">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="mAveragingMethodLabel_7">
+         <property name="text">
+          <string>Start fraction </string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QgsDoubleSpinBox" name="mSigmaStartFractionSpinBox">
+         <property name="maximum">
+          <double>1.000000000000000</double>
+         </property>
+         <property name="singleStep">
+          <double>0.100000000000000</double>
+         </property>
+         <property name="value">
+          <double>0.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>End fraction</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QgsDoubleSpinBox" name="mSigmaEndFractionSpinBox">
+         <property name="maximum">
+          <double>1.000000000000000</double>
+         </property>
+         <property name="singleStep">
+          <double>0.100000000000000</double>
+         </property>
+         <property name="value">
+          <double>1.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <widget class="QGroupBox" name="groupBox_4">
+         <property name="title">
+          <string>Example: Sigma range 0.25 - 0.75 </string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_8">
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_7">
-            <item>
-             <widget class="QLabel" name="mAveragingMethodLabel_7">
-              <property name="text">
-               <string>Start fraction </string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsDoubleSpinBox" name="mSigmaStartFractionSpinBox">
-              <property name="maximum">
-               <double>1.000000000000000</double>
-              </property>
-              <property name="singleStep">
-               <double>0.100000000000000</double>
-              </property>
-              <property name="value">
-               <double>0.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_8">
-            <item>
-             <widget class="QLabel" name="label">
-              <property name="text">
-               <string>End fraction</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsDoubleSpinBox" name="mSigmaEndFractionSpinBox">
-              <property name="maximum">
-               <double>1.000000000000000</double>
-              </property>
-              <property name="singleStep">
-               <double>0.100000000000000</double>
-              </property>
-              <property name="value">
-               <double>1.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="groupBox_4">
-            <property name="title">
-             <string>Example: Sigma range 0.25 - 0.75 </string>
+           <widget class="QLabel" name="mSigmaPngLabel">
+            <property name="text">
+             <string>..png...</string>
             </property>
-            <layout class="QVBoxLayout" name="verticalLayout_8">
-             <item>
-              <widget class="QLabel" name="mSigmaPngLabel">
-               <property name="text">
-                <string>..png...</string>
-               </property>
-               <property name="scaledContents">
-                <bool>false</bool>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="mSigmaDescLabel">
-               <property name="text">
-                <string>Sigma averages over the values between 0 (bed level) and 1 (surface).</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <property name="scaledContents">
+             <bool>false</bool>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
            </widget>
           </item>
           <item>
-           <spacer name="verticalSpacer_4">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
+           <widget class="QLabel" name="mSigmaDescLabel">
+            <property name="text">
+             <string>Sigma averages over the values between 0 (bed level) and 1 (surface).</string>
             </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
             </property>
-           </spacer>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -696,7 +447,7 @@
       </layout>
      </widget>
      <widget class="QWidget" name="mAveragingMethodDepthPage">
-      <layout class="QVBoxLayout" name="verticalLayout_13">
+      <layout class="QGridLayout" name="gridLayout_13">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -709,107 +460,68 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item>
-        <widget class="QWidget" name="widget_5" native="true">
-         <layout class="QVBoxLayout" name="verticalLayout_23">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="mAveragingMethodLabel_8">
+         <property name="text">
+          <string>Start depth</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QgsDoubleSpinBox" name="mDepthStartSpinBox">
+         <property name="maximum">
+          <double>99999.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="lab2">
+         <property name="text">
+          <string>End depth</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QgsDoubleSpinBox" name="mDepthEndSpinBox">
+         <property name="maximum">
+          <double>99999.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>100.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <widget class="QGroupBox" name="groupBox_5">
+         <property name="title">
+          <string>Example: Depth 0.5 to 1.7</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_9">
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_9">
-            <item>
-             <widget class="QLabel" name="mAveragingMethodLabel_8">
-              <property name="text">
-               <string>Start depth</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsDoubleSpinBox" name="mDepthStartSpinBox">
-              <property name="maximum">
-               <double>99999.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_10">
-            <item>
-             <widget class="QLabel" name="lab2">
-              <property name="text">
-               <string>End depth</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsDoubleSpinBox" name="mDepthEndSpinBox">
-              <property name="maximum">
-               <double>99999.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>100.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="groupBox_5">
-            <property name="title">
-             <string>Example: Depth 0.5 to 1.7</string>
+           <widget class="QLabel" name="mDepthPngLabel">
+            <property name="text">
+             <string>..png...</string>
             </property>
-            <layout class="QVBoxLayout" name="verticalLayout_9">
-             <item>
-              <widget class="QLabel" name="mDepthPngLabel">
-               <property name="text">
-                <string>..png...</string>
-               </property>
-               <property name="scaledContents">
-                <bool>false</bool>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="mDepthDescLabel">
-               <property name="text">
-                <string>Depth averaging method averages the values based on range defined relative to surface. The range is defined in the same length units as defined by model (e.g. meters)</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <property name="scaledContents">
+             <bool>false</bool>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
            </widget>
           </item>
           <item>
-           <spacer name="verticalSpacer_5">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
+           <widget class="QLabel" name="mDepthDescLabel">
+            <property name="text">
+             <string>Depth averaging method averages the values based on range defined relative to surface. The range is defined in the same length units as defined by model (e.g. meters)</string>
             </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
             </property>
-           </spacer>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -817,7 +529,7 @@
       </layout>
      </widget>
      <widget class="QWidget" name="mAveragingMethodHeightPage">
-      <layout class="QVBoxLayout" name="verticalLayout_24">
+      <layout class="QGridLayout" name="gridLayout_24">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -830,64 +542,38 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item>
-        <widget class="QWidget" name="widget_6" native="true">
-         <layout class="QVBoxLayout" name="verticalLayout_10">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_11">
-            <item>
-             <widget class="QLabel" name="mAveragingMethodLabel_9">
-              <property name="text">
-               <string>Start height</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsDoubleSpinBox" name="mHeightStartSpinBox">
-              <property name="maximum">
-               <double>99999.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_12">
-            <item>
-             <widget class="QLabel" name="labl">
-              <property name="text">
-               <string>End height</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsDoubleSpinBox" name="mHeightEndSpinBox">
-              <property name="maximum">
-               <double>99999.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>100.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
+       <item row="0" column="0">
+        <widget class="QLabel" name="mAveragingMethodLabel_9">
+         <property name="text">
+          <string>Start height</string>
+         </property>
         </widget>
        </item>
-       <item>
+       <item row="0" column="1">
+        <widget class="QgsDoubleSpinBox" name="mHeightStartSpinBox">
+         <property name="maximum">
+          <double>99999.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="labl">
+         <property name="text">
+          <string>End height</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QgsDoubleSpinBox" name="mHeightEndSpinBox">
+         <property name="maximum">
+          <double>99999.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>100.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
         <widget class="QGroupBox" name="groupBox_6">
          <property name="title">
           <string>Example: Height 0-1.5m</string>
@@ -922,23 +608,10 @@
          </layout>
         </widget>
        </item>
-       <item>
-        <spacer name="verticalSpacer_6">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="mAveragingMethodElevationPage">
-      <layout class="QVBoxLayout" name="verticalLayout_15">
+      <layout class="QGridLayout" name="gridLayout_15">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -951,116 +624,77 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item>
-        <widget class="QWidget" name="widget_7" native="true">
-         <layout class="QVBoxLayout" name="verticalLayout_25">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="mAveragingMethodLabel_10">
+         <property name="text">
+          <string>Start elevation</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QgsDoubleSpinBox" name="mElevationStartSpinBox">
+         <property name="minimum">
+          <double>-999999.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="singleStep">
+          <double>1.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>End elevation</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QgsDoubleSpinBox" name="mElevationEndSpinBox">
+         <property name="minimum">
+          <double>-999999.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>-100.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <widget class="QGroupBox" name="groupBox_7">
+         <property name="title">
+          <string>Example: Elevation -0.5 to -2.5</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_11">
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_13">
-            <item>
-             <widget class="QLabel" name="mAveragingMethodLabel_10">
-              <property name="text">
-               <string>Start elevation</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsDoubleSpinBox" name="mElevationStartSpinBox">
-              <property name="minimum">
-               <double>-999999.000000000000000</double>
-              </property>
-              <property name="maximum">
-               <double>0.000000000000000</double>
-              </property>
-              <property name="singleStep">
-               <double>1.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_14">
-            <item>
-             <widget class="QLabel" name="label_2">
-              <property name="text">
-               <string>End elevation</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsDoubleSpinBox" name="mElevationEndSpinBox">
-              <property name="minimum">
-               <double>-999999.000000000000000</double>
-              </property>
-              <property name="maximum">
-               <double>0.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>-100.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="groupBox_7">
-            <property name="title">
-             <string>Example: Elevation -0.5 to -2.5</string>
+           <widget class="QLabel" name="mElevationPngLabel">
+            <property name="text">
+             <string>..png...</string>
             </property>
-            <layout class="QVBoxLayout" name="verticalLayout_11">
-             <item>
-              <widget class="QLabel" name="mElevationPngLabel">
-               <property name="text">
-                <string>..png...</string>
-               </property>
-               <property name="scaledContents">
-                <bool>false</bool>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="mElevationDescLabel">
-               <property name="text">
-                <string> Elevation averaging method averages the values based on range defined absolute value to the model's datum. The range is defined in the same length units as defined by model (e.g. meters). The elevation will be truncated at the surface and bed levels.</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <property name="scaledContents">
+             <bool>false</bool>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
            </widget>
           </item>
           <item>
-           <spacer name="verticalSpacer_7">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
+           <widget class="QLabel" name="mElevationDescLabel">
+            <property name="text">
+             <string> Elevation averaging method averages the values based on range defined absolute value to the model's datum. The range is defined in the same length units as defined by model (e.g. meters). The elevation will be truncated at the surface and bed levels.</string>
             </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
             </property>
-           </spacer>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -1069,18 +703,88 @@
      </widget>
     </widget>
    </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="mAveragingMethodLabel">
+     <property name="text">
+      <string>Method</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="mAveragingMethodComboBox">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <item>
+      <property name="text">
+       <string>Single Vertical Level (from top)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Single Vertical Level (from bottom)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Multi Vertical Level (from top)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Multi Vertical Level (from bottom)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Sigma</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Depth (relative to surface)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Height (relative to bed level)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Elevation (absolute to model's datum)</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/ui/mesh/qgsmeshrenderermeshsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrenderermeshsettingswidgetbase.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>144</width>
-    <height>163</height>
+    <width>327</width>
+    <height>67</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -19,7 +19,7 @@
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_2">
+  <layout class="QGridLayout" name="gridLayout_2">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -32,42 +32,53 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item>
-    <widget class="QGroupBox" name="groupBox">
+   <item row="0" column="2">
+    <widget class="QgsUnitSelectionWidget" name="mLineUnitsComboBox"/>
+   </item>
+   <item row="0" column="1">
+    <widget class="QgsDoubleSpinBox" name="mLineWidthSpinBox">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="title">
-      <string>Line Width and Color</string>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QgsColorButton" name="mColorWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QgsUnitSelectionWidget" name="mLineUnitsComboBox"/>
-      </item>
-      <item>
-       <widget class="QgsDoubleSpinBox" name="mLineWidthSpinBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QgsColorButton" name="mColorWidget">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-     </layout>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="mLineWidthLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Line width</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Line color</string>
+     </property>
     </widget>
    </item>
   </layout>
@@ -88,8 +99,14 @@
    <class>QgsUnitSelectionWidget</class>
    <extends>QComboBox</extends>
    <header>qgsunitselectionwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mLineWidthSpinBox</tabstop>
+  <tabstop>mLineUnitsComboBox</tabstop>
+  <tabstop>mColorWidget</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
@@ -7,13 +7,25 @@
     <x>0</x>
     <y>0</y>
     <width>378</width>
-    <height>449</height>
+    <height>237</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -136,6 +148,18 @@
    <item>
     <widget class="QWidget" name="mScalarResamplingWidget" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
        <widget class="QLabel" name="mLabelDataInterpolation">
         <property name="text">

--- a/src/ui/mesh/qgsmeshstaticdatasetwidgetbase.ui
+++ b/src/ui/mesh/qgsmeshstaticdatasetwidgetbase.ui
@@ -76,6 +76,10 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>mScalarDatasetComboBox</tabstop>
+  <tabstop>mVectorDatasetComboBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/mesh/qgsmeshvariablestrokewidthwidgetbase.ui
+++ b/src/ui/mesh/qgsmeshvariablestrokewidthwidgetbase.ui
@@ -134,6 +134,14 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mValueMinimumLineEdit</tabstop>
+  <tabstop>mValueMaximumLineEdit</tabstop>
+  <tabstop>mDefaultMinMaxButton</tabstop>
+  <tabstop>mIgnoreOutOfRangecheckBox</tabstop>
+  <tabstop>mWidthMinimumSpinBox</tabstop>
+  <tabstop>mWidthMaximumSpinBox</tabstop>
+ </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>
  </resources>

--- a/src/ui/mesh/qgsrenderermeshpropswidgetbase.ui
+++ b/src/ui/mesh/qgsrenderermeshpropswidgetbase.ui
@@ -123,7 +123,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>0</height>
           </size>
          </property>
         </spacer>
@@ -171,7 +171,7 @@
             <property name="sizeHint" stdset="0">
              <size>
               <width>20</width>
-              <height>40</height>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -229,7 +229,7 @@
             <property name="sizeHint" stdset="0">
              <size>
               <width>20</width>
-              <height>40</height>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -370,7 +370,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>0</height>
           </size>
          </property>
         </spacer>
@@ -415,7 +415,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>454</height>
+           <height>0</height>
           </size>
          </property>
         </spacer>

--- a/src/ui/qgscolorrampshaderwidgetbase.ui
+++ b/src/ui/qgscolorrampshaderwidgetbase.ui
@@ -257,8 +257,10 @@
    <item row="2" column="0">
     <widget class="QLabel" name="mUnitLabel">
      <property name="text">
-      <string>Label unit
-suffix</string>
+      <string>Label unit suffix</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Trying to fix some issues in the mesh layer properties and make them look like other dialogs:
* Use gridLayout instead of combination of horizontal + vertical layouts with no particular setting
* Reduce vertical spacer size and margins to remove unnecessary scrollbar/space, fix alignment
* Add label to widgets to mimic other others in QGIS
* Add tabstops

![meshaveragemixed](https://user-images.githubusercontent.com/7983394/80574988-1c25dd80-8a03-11ea-9434-7f0fd8523a7d.png)
![meshcontoursmixed](https://user-images.githubusercontent.com/7983394/80574996-1e883780-8a03-11ea-959e-27bc550bb4e5.png)
![meshgridmixed](https://user-images.githubusercontent.com/7983394/80575052-33fd6180-8a03-11ea-8725-be1f2f6b9881.png)

I think we can get rid of the bold text on top of the tabs being a groupbox label. It can simply be a label/checkbox (as in labels dialog), more coherent with other dialogs with advantages of giving back more spacing for actual widgets. Opinion?
Btw other suggestions welcome. I did not tackle the vector tab, yet.