### PR TITLE
Functions for adding a variant of bool params in provider metadata

### DIFF
--- a/python/core/auto_generated/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/qgsprovidermetadata.sip.in
@@ -181,6 +181,23 @@ Class factory to return a pointer to a newly created QgsDataProvider object
 .. versionadded:: 3.10
 %End
 
+    static void setBoolParameter( QVariantMap &uri, const QString &parameter, const QVariant &value );
+%Docstring
+Sets the ``value`` into the ``uri`` ``parameter`` as a bool.
+eg. "yes" value will be saved as true, 0 will be saved as false
+
+.. versionadded:: 3.14
+%End
+
+    static bool boolParameter( const QVariantMap &uri, const QString &parameter, bool defaultValue = false );
+%Docstring
+Returns the ``parameter`` value in the ``uri`` as a bool.
+eg. "yes" value will be returned as true, 0 will be returned as false
+
+.. versionadded:: 3.14
+%End
+
+
 
     virtual QgsRasterDataProvider *createRasterDataProvider(
       const QString &uri,

--- a/src/core/qgsprovidermetadata.cpp
+++ b/src/core/qgsprovidermetadata.cpp
@@ -89,6 +89,40 @@ QgsDataProvider *QgsProviderMetadata::createProvider( const QString &uri, const 
   return nullptr;
 }
 
+void QgsProviderMetadata::setBoolParameter( QVariantMap &uri, const QString &parameter, const QVariant &value )
+{
+  if ( value.toString().compare( QStringLiteral( "yes" ), Qt::CaseInsensitive ) == 0 ||
+       value.toString().compare( QStringLiteral( "1" ), Qt::CaseInsensitive ) == 0 ||
+       value.toString().compare( QStringLiteral( "true" ), Qt::CaseInsensitive ) == 0 )
+  {
+    uri[ parameter ] = true;
+  }
+  else if ( value.toString().compare( QStringLiteral( "no" ), Qt::CaseInsensitive ) == 0 ||
+            value.toString().compare( QStringLiteral( "0" ), Qt::CaseInsensitive ) == 0 ||
+            value.toString().compare( QStringLiteral( "false" ), Qt::CaseInsensitive ) == 0 )
+  {
+    uri[ parameter ] = false;
+  }
+}
+
+bool QgsProviderMetadata::boolParameter( const QVariantMap &uri, const QString &parameter, bool defaultValue )
+{
+  if ( uri.value( parameter, QString() ).toString().compare( QStringLiteral( "yes" ), Qt::CaseInsensitive ) == 0 ||
+       uri.value( parameter, QString() ).toString().compare( QStringLiteral( "1" ), Qt::CaseInsensitive ) == 0 ||
+       uri.value( parameter, QString() ).toString().compare( QStringLiteral( "true" ), Qt::CaseInsensitive ) == 0 )
+  {
+    return true;
+  }
+  else if ( uri.value( parameter, QString() ).toString().compare( QStringLiteral( "no" ), Qt::CaseInsensitive ) == 0 ||
+            uri.value( parameter, QString() ).toString().compare( QStringLiteral( "0" ), Qt::CaseInsensitive ) == 0 ||
+            uri.value( parameter, QString() ).toString().compare( QStringLiteral( "false" ), Qt::CaseInsensitive ) == 0 )
+  {
+    return false;
+  }
+
+  return defaultValue;
+}
+
 QVariantMap QgsProviderMetadata::decodeUri( const QString & )
 {
   return QVariantMap();

--- a/src/core/qgsprovidermetadata.h
+++ b/src/core/qgsprovidermetadata.h
@@ -232,6 +232,23 @@ class CORE_EXPORT QgsProviderMetadata : public QObject
      */
     virtual QgsDataProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options ) SIP_FACTORY;
 
+    /**
+     * Sets the \a value into the \a uri \a parameter as a bool.
+     * eg. "yes" value will be saved as true, 0 will be saved as false
+     *
+     * \since QGIS 3.14
+     */
+    static void setBoolParameter( QVariantMap &uri, const QString &parameter, const QVariant &value );
+
+    /**
+     * Returns the \a parameter value in the \a uri as a bool.
+     * eg. "yes" value will be returned as true, 0 will be returned as false
+     *
+     * \since QGIS 3.14
+     */
+    static bool boolParameter( const QVariantMap &uri, const QString &parameter, bool defaultValue = false );
+
+
 #ifndef SIP_RUN
 
     /**

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -199,6 +199,7 @@ SET(TESTS
  testqgsprojectstorage.cpp
  testqgsprojutils.cpp
  testqgsproperty.cpp
+ testqgsprovidermetadata.cpp
  testqgis.cpp
  testqgsrasterfilewriter.cpp
  testqgsrasterfill.cpp

--- a/tests/src/core/testqgsprovidermetadata.cpp
+++ b/tests/src/core/testqgsprovidermetadata.cpp
@@ -1,0 +1,128 @@
+/***************************************************************************
+                         testqgsprovidermetadata.cpp
+                         ---------------
+    begin                : April 2020
+    copyright            : (C) 2020 by Samweli Mwakisambwe
+    email                : samweli at kartoza dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstest.h"
+#include <QObject>
+#include <qgsprovidermetadata.h>
+#include <qgsproviderregistry.h>
+
+class TestQgsProviderMetadata: public QObject
+{
+    Q_OBJECT
+
+  public:
+    TestQgsProviderMetadata() = default;
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init(); // will be called before each testfunction is executed.
+    void cleanup(); // will be called after every testfunction.
+
+    void checkBoolParameterSetting();
+
+  private:
+    QgsProviderMetadata *mMetadata = nullptr;
+};
+
+void TestQgsProviderMetadata::initTestCase()
+{
+  //
+  // Runs once before any tests are run
+  //
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  QgsApplication::showSettings();
+
+}
+
+void TestQgsProviderMetadata::init()
+{
+  //create some objects that will be used in all tests...
+  //create a temporal object that will be used in all tests...
+
+  mMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "raster" ) );
+}
+
+void TestQgsProviderMetadata::cleanup()
+{
+}
+
+void TestQgsProviderMetadata::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsProviderMetadata::checkBoolParameterSetting()
+{
+  QVariantMap uri;
+  mMetadata->setBoolParameter( uri, QStringLiteral( "testOne" ), QStringLiteral( "yes" ) );
+  mMetadata->setBoolParameter( uri, QStringLiteral( "testTwo" ), QStringLiteral( "1" ) );
+  mMetadata->setBoolParameter( uri, QStringLiteral( "testThree" ), 1 );
+  mMetadata->setBoolParameter( uri, QStringLiteral( "testFour" ), QStringLiteral( "true" ) );
+  mMetadata->setBoolParameter( uri, QStringLiteral( "testFive" ), true );
+
+  QVariantMap expected = { { QStringLiteral( "testOne" ), QVariant( true ) },
+    { QStringLiteral( "testTwo" ), QVariant( true ) },
+    { QStringLiteral( "testThree" ), QVariant( true ) },
+    { QStringLiteral( "testFour" ), QVariant( true ) },
+    { QStringLiteral( "testFive" ), QVariant( true ) }
+  };
+
+  QCOMPARE( uri, expected );
+
+  mMetadata->setBoolParameter( uri, QStringLiteral( "testOne" ), QStringLiteral( "YES" ) );
+  mMetadata->setBoolParameter( uri, QStringLiteral( "testFour" ), QStringLiteral( "TRUE" ) );
+
+  QCOMPARE( uri, expected );
+
+  mMetadata->setBoolParameter( uri, QStringLiteral( "testOne" ), QStringLiteral( "no" ) );
+  mMetadata->setBoolParameter( uri, QStringLiteral( "testTwo" ), QStringLiteral( "0" ) );
+  mMetadata->setBoolParameter( uri, QStringLiteral( "testThree" ), 0 );
+  mMetadata->setBoolParameter( uri, QStringLiteral( "testFour" ), QStringLiteral( "false" ) );
+  mMetadata->setBoolParameter( uri, QStringLiteral( "testFive" ), false );
+
+  expected = { { QStringLiteral( "testOne" ), QVariant( false ) },
+    { QStringLiteral( "testTwo" ), QVariant( false ) },
+    { QStringLiteral( "testThree" ), QVariant( false ) },
+    { QStringLiteral( "testFour" ), QVariant( false ) },
+    { QStringLiteral( "testFive" ), QVariant( false ) }
+  };
+  QCOMPARE( uri, expected );
+
+  mMetadata->setBoolParameter( uri, QStringLiteral( "testOne" ), QStringLiteral( "NO" ) );
+  mMetadata->setBoolParameter( uri, QStringLiteral( "testFour" ), QStringLiteral( "FALSE" ) );
+
+  QCOMPARE( uri, expected );
+
+  uri[ QStringLiteral( "testOne" ) ] = QStringLiteral( "yes" );
+  uri[ QStringLiteral( "testTwo" ) ] = QStringLiteral( "1" );
+  uri[ QStringLiteral( "testThree" ) ] = QStringLiteral( "true" );
+  uri[ QStringLiteral( "testFour" ) ] = 1;
+  uri[ QStringLiteral( "testFive" ) ] = true;
+  uri[ QStringLiteral( "testSix" ) ] = QStringLiteral( "otherValue" );
+
+  QVERIFY( mMetadata->boolParameter( uri, QStringLiteral( "testOne" ), false ) );
+  QVERIFY( mMetadata->boolParameter( uri, QStringLiteral( "testTwo" ), false ) );
+  QVERIFY( mMetadata->boolParameter( uri, QStringLiteral( "testThree" ), false ) );
+  QVERIFY( mMetadata->boolParameter( uri, QStringLiteral( "testFour" ), false ) );
+  QVERIFY( mMetadata->boolParameter( uri, QStringLiteral( "testFive" ), false ) );
+  QVERIFY( !mMetadata->boolParameter( uri, QStringLiteral( "testSix" ), false ) );
+}
+
+QGSTEST_MAIN( TestQgsProviderMetadata )
+#include "testqgsprovidermetadata.moc"


### PR DESCRIPTION
From this discussion https://github.com/qgis/QGIS/pull/35741#discussion_r416396465.

This PR adds a consistent way of handling bool values in providers uri parameters.