### PR TITLE
Avoid divide by zero number error 

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -335,6 +335,9 @@ QDateTime QgsWmsSettings::findLeastClosestDateTime( QDateTime dateTime, bool dat
       break;
 
     long long resolutionSeconds = pair.resolution.interval();
+
+    if ( resolutionSeconds <= 0 )
+      continue;
     long long step = std::floor( ( seconds - startSeconds ) / resolutionSeconds );
     long long resultSeconds = startSeconds + ( step * resolutionSeconds );
 


### PR DESCRIPTION
Removes the possibly of divide by zero error in one of WMS-T temporal range match modes logic.