### PR TITLE
Fix some labels incorrectly flagged as unplaced when they actually are placed

### DIFF
--- a/src/core/pal/problem.cpp
+++ b/src/core/pal/problem.cpp
@@ -672,8 +672,10 @@ QList<LabelPosition *> Problem::getSolution( bool returnInactive, QList<LabelPos
     }
     else if ( unlabeled )
     {
-      if ( mFeatStartId[i] < static_cast< int >( mLabelPositions.size() ) )
-        unlabeled->push_back( mLabelPositions[ mFeatStartId[i] ].get() );
+      const int startPos = mFeatStartId[i];
+      // need to be careful here -- if the next feature's start id is the same as this one, then this feature had no candidates!
+      if ( startPos < static_cast< int >( mLabelPositions.size() ) && ( i == mFeatureCount - 1 || startPos != mFeatStartId[i + 1] ) )
+        unlabeled->push_back( mLabelPositions[ startPos ].get() );
     }
   }
 


### PR DESCRIPTION
Included in https://github.com/qgis/QGIS/pull/36106