### PR TITLE
Default the expression builder dialog to the functions list page

### DIFF
--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -35,7 +35,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <property name="documentMode">
       <bool>true</bool>
@@ -837,12 +837,6 @@ Change the name of the script and save to allow QGIS to auto load on startup.</s
                 <iconset resource="../../images/images.qrc">
                  <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
                </property>
-               <property name="iconSize">
-                <size>
-                 <width>24</width>
-                 <height>24</height>
-                </size>
-               </property>
               </widget>
              </item>
              <item>
@@ -856,12 +850,6 @@ Change the name of the script and save to allow QGIS to auto load on startup.</s
                <property name="icon">
                 <iconset resource="../../images/images.qrc">
                  <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
-               </property>
-               <property name="iconSize">
-                <size>
-                 <width>24</width>
-                 <height>24</height>
-                </size>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
instead of the function editor, and do not force icon size (they look bigger than other windows' here)