### PR TITLE
Fixed fetching NULL bigint pgsql attributes. Fixes #36011

### DIFF
--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -859,7 +859,14 @@ void QgsPostgresFeatureIterator::getFeatureAttribute( int idx, QgsPostgresResult
     }
     case QVariant::LongLong:
     {
-      v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), QString::number( mConn->getBinaryInt( queryResult, row, col ) ), fld.typeName() );
+      if ( ::PQgetisnull( queryResult.result(), row, col ) )
+      {
+        v = QVariant( QVariant::LongLong );
+      }
+      else
+      {
+        v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), QString::number( mConn->getBinaryInt( queryResult, row, col ) ), fld.typeName() );
+      }
       break;
     }
     default:

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -441,6 +441,10 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         bigint_with_default_idx = vl.fields().lookupField('bigint_attribute_def')
         self.assertEqual(f.attributes()[bigint_with_default_idx], 42)
 
+        # check if NULL values are correctly read
+        bigint_def_null_idx = vl.fields().lookupField('bigint_attribute')
+        self.assertEqual(f.attributes()[bigint_def_null_idx], NULL)
+
         # check if we can overwrite a default value
         vl.startEditing()
         vl.changeAttributeValue(f.id(), bigint_with_default_idx, 43)


### PR DESCRIPTION
This fixes an omission from handling bigint fields in PostgreSQL, related to PRs #35162 (backported to QGIS 3.12 with PR #35832) and #36040 (backported to QGIS 3.12 via PR #36063). I've added a new check in the tests for this fix.

@m-kuhn , may you please take a look? This really needs to be backported to 3.12. Thank you very much.

 @tudorbarascu , the fix is simple, really, maybe you can try it in your local repo to see if there are any omissions. Also pinging @gioman . Thank you all for reporting, and I'm very sorry to have missed this.

