### PR TITLE
Enables Postgresql service based connections without database name

### DIFF
--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -249,7 +249,7 @@ void QgsPgNewConnection::showHelp()
 void QgsPgNewConnection::updateOkButtonState()
 {
   bool enabled = !txtName->text().isEmpty() && (
-                   ( !txtService->text().isEmpty() && txtDatabase->text().isEmpty() ) ||
+                   !txtService->text().isEmpty() ||
                    ( !txtHost->text().isEmpty() && !txtPort->text().isEmpty() && !txtDatabase->text().isEmpty() ) );
   buttonBox->button( QDialogButtonBox::Ok )->setEnabled( enabled );
 }

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -249,7 +249,7 @@ void QgsPgNewConnection::showHelp()
 void QgsPgNewConnection::updateOkButtonState()
 {
   bool enabled = !txtName->text().isEmpty() && (
-                   ( !txtService->text().isEmpty() && !txtDatabase->text().isEmpty() ) ||
+                   ( !txtService->text().isEmpty() && txtDatabase->text().isEmpty() ) ||
                    ( !txtHost->text().isEmpty() && !txtPort->text().isEmpty() && !txtDatabase->text().isEmpty() ) );
   buttonBox->button( QDialogButtonBox::Ok )->setEnabled( enabled );
 }

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -345,6 +345,7 @@ void QgsPgSourceSelect::btnLoad_clicked()
 void QgsPgSourceSelect::btnEdit_clicked()
 {
   QgsPgNewConnection *nc = new QgsPgNewConnection( this, cmbConnections->currentText() );
+  nc->setWindowTitle( tr( "Edit PostGIS Connection" ) );
   if ( nc->exec() )
   {
     populateConnectionList();

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -185,6 +185,7 @@ void QgsPostgresDataItemGuiProvider::newConnection( QgsDataItem *item )
 void QgsPostgresDataItemGuiProvider::editConnection( QgsDataItem *item )
 {
   QgsPgNewConnection nc( nullptr, item->name() );
+  nc.setWindowTitle( tr( "Edit PostGIS Connection" ) );
   if ( nc.exec() )
   {
     // the parent should be updated


### PR DESCRIPTION
## Description

Postgresql service based connections can have an empty database name, if a service name is provided. 

Fix #36127

### Additional tiny UX improvement

When the user edits the connection, the dialogue title is set accordingly. The connection can be changed from the **Browser** or from the **Data Source Manager**.

Dialogue title when editing:

![improved_connection_title](https://user-images.githubusercontent.com/163681/80829428-010fc500-8bdf-11ea-8415-41d426158440.png)
