### PR TITLE
Improve state handling in temporal tab in raster layer properties dialog

### DIFF
--- a/src/gui/raster/qgsrasterlayertemporalpropertieswidget.cpp
+++ b/src/gui/raster/qgsrasterlayertemporalpropertieswidget.cpp
@@ -40,7 +40,6 @@ void QgsRasterLayerTemporalPropertiesWidget::init()
 
   mEndTemporalDateTimeEdit->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
 
-  mTemporalGroupBox->setChecked( mLayer->temporalProperties()->isActive() );
   switch ( mLayer->temporalProperties()->mode() )
   {
     case QgsRasterLayerTemporalProperties::ModeTemporalRangeFromDataProvider:
@@ -61,6 +60,7 @@ void QgsRasterLayerTemporalPropertiesWidget::init()
     mModeFixedRangeRadio->setChecked( true );
   }
 
+  mTemporalGroupBox->setChecked( mLayer->temporalProperties()->isActive() );
 }
 
 void QgsRasterLayerTemporalPropertiesWidget::saveTemporalProperties()


### PR DESCRIPTION
Current temporal tab components state could lead to a below UI issue
![temporal_tab_state_issue](https://user-images.githubusercontent.com/2663775/80848624-85346d80-8c1c-11ea-9ab9-8fd652ebd47b.png)

the datetimes input should have been disabled in the above dialog, this PR provides a fix for this issue.