### PR TITLE
Improve temporal controller frame count

### DIFF
--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -191,7 +191,7 @@ void QgsTemporalNavigationObject::skipToEnd()
 long long QgsTemporalNavigationObject::totalFrameCount()
 {
   QgsInterval totalAnimationLength = mTemporalExtents.end() - mTemporalExtents.begin();
-  return std::ceil( totalAnimationLength.seconds() / mFrameDuration.seconds() ) + 1;
+  return std::floor( totalAnimationLength.seconds() / mFrameDuration.seconds() ) + 1;
 }
 
 void QgsTemporalNavigationObject::setAnimationState( AnimationState mode )

--- a/tests/src/core/testqgstemporalnavigationobject.cpp
+++ b/tests/src/core/testqgstemporalnavigationobject.cpp
@@ -113,7 +113,7 @@ void TestQgsTemporalNavigationObject::animationState()
   QCOMPARE( navigationObject->currentFrameNumber(), 0 );
 
   navigationObject->skipToEnd();
-  QCOMPARE( navigationObject->currentFrameNumber(), 10 );
+  QCOMPARE( navigationObject->currentFrameNumber(), 9 );
 
   navigationObject->rewindToStart();
   QCOMPARE( navigationObject->currentFrameNumber(), 0 );


### PR DESCRIPTION
Improves logic for calculating frame count in temporal controller.

Currently if the start and end times are (date) 12:00 hrs to (date) 14:00 hrs with 1.5 hrs time step the temporal controller will generate following frames,

1st frame  12:00 hrs - 13:30 hrs
2nd frame 13:30 hrs - 14:00 hrs
**3rd(last) frame 15:00 hrs - 14:00 hrs**

The 3rd frame should haven't been generated, this PR provides fix for this issue, the resulting frames will be 
1st frame 12:00 hrs - 13:30 hrs
2nd(last) frame 13:30 hrs - 14:00 hrs
