### PR TITLE
Add a broader restorer mechanism for WMS 

### DIFF
--- a/src/server/services/wms/CMakeLists.txt
+++ b/src/server/services/wms/CMakeLists.txt
@@ -19,7 +19,7 @@ SET (WMS_SRCS
   qgsmediancut.cpp
   qgswmsrenderer.cpp
   qgswmsparameters.cpp
-  qgslayerrestorer.cpp
+  qgswmsrestorer.cpp
   qgswmsrendercontext.cpp
 )
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -58,7 +58,7 @@
 #include "qgsvectorlayerlabeling.h"
 #include "qgsvectorlayerfeaturecounter.h"
 #include "qgspallabeling.h"
-#include "qgslayerrestorer.h"
+#include "qgswmsrestorer.h"
 #include "qgsdxfexport.h"
 #include "qgssymbollayerutils.h"
 #include "qgsserverexception.h"

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -112,8 +112,8 @@ namespace QgsWms
   QImage *QgsRenderer::getLegendGraphics( QgsLayerTreeModel &model )
   {
     // get layers
-    std::unique_ptr<QgsLayerRestorer> restorer;
-    restorer.reset( new QgsLayerRestorer( mContext.layers() ) );
+    std::unique_ptr<QgsWmsRestorer> restorer;
+    restorer.reset( new QgsWmsRestorer( mContext ) );
 
     // configure layers
     QList<QgsMapLayer *> layers = mContext.layersToRender();
@@ -151,8 +151,8 @@ namespace QgsWms
   QImage *QgsRenderer::getLegendGraphics( QgsLayerTreeModelLegendNode &nodeModel )
   {
     // get layers
-    std::unique_ptr<QgsLayerRestorer> restorer;
-    restorer.reset( new QgsLayerRestorer( mContext.layers() ) );
+    std::unique_ptr<QgsWmsRestorer> restorer;
+    restorer.reset( new QgsWmsRestorer( mContext ) );
 
     // configure layers
     QList<QgsMapLayer *> layers = mContext.layersToRender();
@@ -182,8 +182,8 @@ namespace QgsWms
   QJsonObject QgsRenderer::getLegendGraphicsAsJson( QgsLayerTreeModel &model )
   {
     // get layers
-    std::unique_ptr<QgsLayerRestorer> restorer;
-    restorer.reset( new QgsLayerRestorer( mContext.layers() ) );
+    std::unique_ptr<QgsWmsRestorer> restorer;
+    restorer.reset( new QgsWmsRestorer( mContext ) );
 
     // configure layers
     QList<QgsMapLayer *> layers = mContext.layersToRender();
@@ -259,8 +259,8 @@ namespace QgsWms
     }
 
     // init layer restorer before doing anything
-    std::unique_ptr<QgsLayerRestorer> restorer;
-    restorer.reset( new QgsLayerRestorer( mContext.layers() ) );
+    std::unique_ptr<QgsWmsRestorer> restorer;
+    restorer.reset( new QgsWmsRestorer( mContext ) );
 
     // configure layers
     QgsMapSettings mapSettings;
@@ -288,8 +288,8 @@ namespace QgsWms
   QByteArray QgsRenderer::getPrint()
   {
     // init layer restorer before doing anything
-    std::unique_ptr<QgsLayerRestorer> restorer;
-    restorer.reset( new QgsLayerRestorer( mContext.layers() ) );
+    std::unique_ptr<QgsWmsRestorer> restorer;
+    restorer.reset( new QgsWmsRestorer( mContext ) );
 
     // GetPrint request needs a template parameter
     const QString templateName = mWmsParameters.composerTemplate();
@@ -795,8 +795,8 @@ namespace QgsWms
     }
 
     // init layer restorer before doing anything
-    std::unique_ptr<QgsLayerRestorer> restorer;
-    restorer.reset( new QgsLayerRestorer( mContext.layers() ) );
+    std::unique_ptr<QgsWmsRestorer> restorer;
+    restorer.reset( new QgsWmsRestorer( mContext ) );
 
     // configure layers
     QList<QgsMapLayer *> layers = mContext.layersToRender();
@@ -836,8 +836,8 @@ namespace QgsWms
   std::unique_ptr<QgsDxfExport> QgsRenderer::getDxf()
   {
     // init layer restorer before doing anything
-    std::unique_ptr<QgsLayerRestorer> restorer;
-    restorer.reset( new QgsLayerRestorer( mContext.layers() ) );
+    std::unique_ptr<QgsWmsRestorer> restorer;
+    restorer.reset( new QgsWmsRestorer( mContext ) );
 
     // configure layers
     QList<QgsMapLayer *> layers = mContext.layersToRender();
@@ -949,8 +949,8 @@ namespace QgsWms
     std::unique_ptr<QImage> outputImage( createImage( mContext.mapSize() ) );
 
     // init layer restorer before doing anything
-    std::unique_ptr<QgsLayerRestorer> restorer;
-    restorer.reset( new QgsLayerRestorer( mContext.layers() ) );
+    std::unique_ptr<QgsWmsRestorer> restorer;
+    restorer.reset( new QgsWmsRestorer( mContext ) );
 
     // The CRS parameter is considered as mandatory in configureMapSettings
     // but in the case of filter parameter, CRS parameter has not to be mandatory

--- a/src/server/services/wms/qgswmsrestorer.cpp
+++ b/src/server/services/wms/qgswmsrestorer.cpp
@@ -136,9 +136,10 @@ QgsLayerRestorer::~QgsLayerRestorer()
   }
 }
 
-namespace QgsWms {
+namespace QgsWms
+{
   QgsWmsRestorer::QgsWmsRestorer( const QgsWmsRenderContext &context )
+    : mLayerRestorer( context.layers() )
   {
-    mLayerRestorer.reset( new QgsLayerRestorer( context.layers()) );
   }
 }

--- a/src/server/services/wms/qgswmsrestorer.cpp
+++ b/src/server/services/wms/qgswmsrestorer.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
-                              qgslayerrestorer.cpp
-                              --------------------
+                              qgswmsrestorer.cpp
+                              ------------------
   begin                : April 24, 2017
   copyright            : (C) 2017 by Paul Blottiere
   email                : paul.blottiere@oslandia.com
@@ -15,7 +15,7 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgslayerrestorer.h"
+#include "qgswmsrestorer.h"
 #include "qgsmessagelog.h"
 #include "qgsmaplayer.h"
 #include "qgsvectorlayer.h"
@@ -133,5 +133,12 @@ QgsLayerRestorer::~QgsLayerRestorer()
       case QgsMapLayerType::PluginLayer:
         break;
     }
+  }
+}
+
+namespace QgsWms {
+  QgsWmsRestorer::QgsWmsRestorer( const QgsWmsRenderContext &context )
+  {
+    mLayerRestorer.reset( new QgsLayerRestorer( context.layers()) );
   }
 }

--- a/src/server/services/wms/qgswmsrestorer.h
+++ b/src/server/services/wms/qgswmsrestorer.h
@@ -65,12 +65,27 @@ class QgsLayerRestorer
     QMap<QgsMapLayer *, QgsLayerSettings> mLayerSettings;
 };
 
-namespace QgsWms {
+namespace QgsWms
+{
+  /**
+   * \ingroup server
+   * RAII class to restore the rendering context configuration on destruction
+   * \since QGIS 3.14
+   */
   class QgsWmsRestorer
   {
     public:
 
+      /**
+       * Constructor for QgsWmsRestorer.
+       * \param context The rendering context to restore in its initial state
+       */
       QgsWmsRestorer( const QgsWmsRenderContext &context );
+
+      /**
+       * Default destructor.
+       */
+      ~QgsWmsRestorer() = default;
 
     private:
 

--- a/src/server/services/wms/qgswmsrestorer.h
+++ b/src/server/services/wms/qgswmsrestorer.h
@@ -1,6 +1,6 @@
 /***************************************************************************
-                              qgslayerrestorer.h
-                              -------------------
+                              qgswmsrestorer.h
+                              ----------------
   begin                : April 24, 2017
   copyright            : (C) 2017 by Paul Blottiere
   email                : paul.blottiere@oslandia.com
@@ -15,14 +15,15 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef QGSLAYERRESTORER_H
-#define QGSLAYERRESTORER_H
+#ifndef QGSWMSRESTORER_H
+#define QGSWMSRESTORER_H
 
 #include <QList>
 #include <QDomDocument>
 #include <QMap>
 
 #include "qgsfeatureid.h"
+#include "qgswmsrendercontext.h"
 
 class QgsMapLayer;
 
@@ -62,6 +63,19 @@ class QgsLayerRestorer
     };
 
     QMap<QgsMapLayer *, QgsLayerSettings> mLayerSettings;
+};
+
+namespace QgsWms {
+  class QgsWmsRestorer
+  {
+    public:
+
+      QgsWmsRestorer( const QgsWmsRenderContext &context );
+
+    private:
+
+      std::unique_ptr<QgsLayerRestorer> mLayerRestorer;
+  };
 };
 
 #endif

--- a/src/server/services/wms/qgswmsrestorer.h
+++ b/src/server/services/wms/qgswmsrestorer.h
@@ -67,6 +67,7 @@ class QgsLayerRestorer
 
 namespace QgsWms
 {
+
   /**
    * \ingroup server
    * RAII class to restore the rendering context configuration on destruction
@@ -89,7 +90,7 @@ namespace QgsWms
 
     private:
 
-      std::unique_ptr<QgsLayerRestorer> mLayerRestorer;
+      QgsLayerRestorer mLayerRestorer;
   };
 };
 

--- a/tests/src/server/wms/CMakeLists.txt
+++ b/tests/src/server/wms/CMakeLists.txt
@@ -38,7 +38,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}
 #See: http://www.cmake.org/Wiki/CMake_RPATH_handling#No_relinking_and_full_RPATH_for_the_install_tree
 SET(MODULE_WMS_SRCS
   ${CMAKE_SOURCE_DIR}/src/server/services/wms/qgswmsrenderer.cpp
-  ${CMAKE_SOURCE_DIR}/src/server/services/wms/qgslayerrestorer.cpp
+  ${CMAKE_SOURCE_DIR}/src/server/services/wms/qgswmsrestorer.cpp
   ${CMAKE_SOURCE_DIR}/src/server/services/wms/qgsmaprendererjobproxy.cpp
   ${CMAKE_SOURCE_DIR}/src/server/services/wms/qgswmsparameters.cpp
   ${CMAKE_SOURCE_DIR}/src/server/services/wms/qgswmsrendercontext.cpp

--- a/tests/src/server/wms/CMakeLists.txt
+++ b/tests/src/server/wms/CMakeLists.txt
@@ -76,6 +76,7 @@ ENDMACRO (ADD_QGIS_TEST)
 
 SET(TESTS
   test_qgsserver_wms_dxf.cpp
+  test_qgsserver_wms_restorer.cpp
   test_qgsserver_wms_exceptions.cpp
 )
 

--- a/tests/src/server/wms/test_qgsserver_wms_restorer.cpp
+++ b/tests/src/server/wms/test_qgsserver_wms_restorer.cpp
@@ -71,18 +71,18 @@ void TestQgsServerWmsRestorer::restorer_layer()
   QgsVectorLayer *vl = nullptr;
   for ( QgsMapLayer *l : context.layers() )
   {
-    if ( l->name().compare(name) == 0 )
+    if ( l->name().compare( name ) == 0 )
       vl = qobject_cast<QgsVectorLayer *>( l );
   }
 
   QCOMPARE( vl->name(), name );
-  const int opacity = vl->opacity();
+  const double opacity = vl->opacity();
 
   // call restorer
   {
     // destructor is called once out of scope
     std::unique_ptr<QgsWms::QgsWmsRestorer> restorer;
-    restorer.reset( new QgsWms::QgsWmsRestorer(context) );
+    restorer.reset( new QgsWms::QgsWmsRestorer( context ) );
 
     const QString new_name = "new_name";
     vl->setName( new_name );

--- a/tests/src/server/wms/test_qgsserver_wms_restorer.cpp
+++ b/tests/src/server/wms/test_qgsserver_wms_restorer.cpp
@@ -1,0 +1,101 @@
+/***************************************************************************
+     test_qgsserver_wms_restorer.cpp
+     -------------------------------
+    Date                 : 01 May 2020
+    Copyright            : (C) 2020 by Paul Blottiere
+    Email                : blottiere.paul@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+#include "qgsvectorlayer.h"
+
+#include "qgswmsrestorer.h"
+#include "qgsserverinterfaceimpl.h"
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test for the WMS restorer class
+ */
+class TestQgsServerWmsRestorer : public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();
+    void cleanupTestCase();
+
+    void restorer_layer();
+};
+
+void TestQgsServerWmsRestorer::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+}
+
+void TestQgsServerWmsRestorer::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsServerWmsRestorer::restorer_layer()
+{
+  // read project
+  const QString filename = QString( "%1/qgis_server/test_project.qgs" ).arg( TEST_DATA_DIR );
+  QgsProject project;
+  project.read( filename );
+
+  // init wms parameters
+  QUrlQuery query;
+  QgsWms::QgsWmsParameters parameters( query );
+
+  // init context
+  QgsCapabilitiesCache cache;
+  QgsServiceRegistry registry;
+  QgsServerSettings settings;
+  QgsServerInterfaceImpl interface( &cache, &registry, &settings );
+
+  QgsWms::QgsWmsRenderContext context( &project, &interface );
+  context.setFlag( QgsWms::QgsWmsRenderContext::UseOpacity );
+  context.setParameters( parameters );
+
+  // retrieve a specific vector layer
+  const QString name = "testlayer";
+  QgsVectorLayer *vl = nullptr;
+  for ( QgsMapLayer *l : context.layers() )
+  {
+    if ( l->name().compare(name) == 0 )
+      vl = qobject_cast<QgsVectorLayer *>( l );
+  }
+
+  QCOMPARE( vl->name(), name );
+  const int opacity = vl->opacity();
+
+  // call restorer
+  {
+    // destructor is called once out of scope
+    std::unique_ptr<QgsWms::QgsWmsRestorer> restorer;
+    restorer.reset( new QgsWms::QgsWmsRestorer(context) );
+
+    const QString new_name = "new_name";
+    vl->setName( new_name );
+    QCOMPARE( vl->name(), new_name );
+
+    vl->setOpacity( opacity + 10 );
+    QCOMPARE( vl->opacity(), opacity + 10 );
+  }
+
+  // check that initial values are well restored
+  QCOMPARE( vl->name(), name );
+  QCOMPARE( vl->opacity(), opacity );
+}
+
+QGSTEST_MAIN( TestQgsServerWmsRestorer )
+#include "test_qgsserver_wms_restorer.moc"


### PR DESCRIPTION
## Description

This PR adds a broader restorer mechanism for the WMS service (cf the discussion on https://github.com/qgis/QGIS/pull/36007).

This way we can easily add specific restorers without updating the renderer itself.