### PR TITLE
Add expression variables for layout item position and size.

### DIFF
--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -748,6 +748,9 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts()->insert( QStringLiteral( "item_top" ), QCoreApplication::translate( "variable_help", "Top position of layout item (in mm)." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "item_width" ), QCoreApplication::translate( "variable_help", "Width of layout item (in mm)." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "item_height" ), QCoreApplication::translate( "variable_help", "Height of layout item (in mm)." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "item_x" ), QCoreApplication::translate( "variable_help", "Horizontal position of reference point of layout item (in mm)." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "item_y" ), QCoreApplication::translate( "variable_help", "Vertical position of reference point of layout item (in mm)." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "item_reference_point" ), QCoreApplication::translate( "variable_help", "Reference point of layout item. 0: upper left; 1: upper center; 2: upper right; 3: middle left; 4: center; 5: middle right; 6: lower left; 7: lower center; 8: lower right" ) );
 
   //map settings item variables
   sVariableHelpTexts()->insert( QStringLiteral( "map_id" ), QCoreApplication::translate( "variable_help", "ID of current map destination. This will be 'canvas' for canvas renders, and the item ID for layout map renders." ) );

--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -633,6 +633,14 @@ QgsExpressionContextScope *QgsExpressionContextUtils::layoutItemScope( const Qgs
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "item_id" ), item->id(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "item_uuid" ), item->uuid(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layout_page" ), item->page() + 1, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "item_reference_point" ), item->referencePoint(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "item_left" ), item->x(), true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "item_top" ), item->y(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "item_width" ), item->rect().width(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "item_height" ), item->rect().height(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "item_x" ), item->pagePos().x(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "item_y" ), item->pagePos().y(), true ) );
+
 
   if ( item->layout() )
   {


### PR DESCRIPTION
Closes #25768

## Description

Add the following expression variables:

* `item_left`: horizontal position of left edge of item
* `item_top`: horizontal position of top edge of item
* `item_width`: width of item
* `item_height`: height of item
* `item_x`: horizontal position of item reference point
* `item_y`: vertical position of item reference point
* `item_reference_point`: integer representing item reference point

