### PR TITLE
disable transparency for QgsInterpolatedLineRenderer

### DIFF
--- a/python/core/auto_generated/symbology/qgsinterpolatedlinerenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsinterpolatedlinerenderer.sip.in
@@ -209,11 +209,6 @@ Sets the unit of the stroke width
 Sets the stroke color used to plot
 %End
 
-    void setOpacity( double opacity );
-%Docstring
-Sets the opacity used to plot
-%End
-
     void render( double value1, double value2, QgsPointXY point1, QgsPointXY point2, QgsRenderContext &context ) const;
 %Docstring
 Render a line in the ``context`` between ``point1`` and ``point2``

--- a/src/app/mesh/qgsmeshrendererscalarsettingswidget.cpp
+++ b/src/app/mesh/qgsmeshrendererscalarsettingswidget.cpp
@@ -137,6 +137,8 @@ void QgsMeshRendererScalarSettingsWidget::syncToLayer( )
     whileBlocking( mScalarEdgeStrokeWidthSpinBox )->setValue( edgeStrokeWidth.fixedStrokeWidth() );
     whileBlocking( mScalarEdgeStrokeWidthVariableRadioButton )->setChecked( edgeStrokeWidth.isVariableWidth() );
     whileBlocking( mScalarEdgeStrokeWidthUnitSelectionWidget )->setUnit( settings.edgeStrokeWidthUnit() );
+    if ( !hasFaces )
+      mOpacityContainerWidget->setVisible( false );
 
     const QgsMeshDatasetGroupMetadata metadata = mMeshLayer->dataProvider()->datasetGroupMetadata( mActiveDatasetGroup );
     double min = metadata.minimum();

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -466,7 +466,6 @@ void QgsMeshLayerRenderer::renderScalarDatasetOnEdges( const QgsMeshRendererScal
   edgePlotter.setInterpolatedColor( QgsInterpolatedLineColor( scalarSettings.colorRampShader() ) );
   edgePlotter.setInterpolatedWidth( QgsInterpolatedLineWidth( scalarSettings.edgeStrokeWidth() ) );
   edgePlotter.setWidthUnit( scalarSettings.edgeStrokeWidthUnit() );
-  edgePlotter.setOpacity( scalarSettings.opacity() );
 
   for ( const int i : egdesInExtent )
   {

--- a/src/core/symbology/qgsinterpolatedlinerenderer.cpp
+++ b/src/core/symbology/qgsinterpolatedlinerenderer.cpp
@@ -39,7 +39,6 @@ void QgsInterpolatedLineRenderer::render( double value1, double value2, QgsPoint
   painter->save();
   if ( context.flags() & QgsRenderContext::Antialiasing )
     painter->setRenderHint( QPainter::Antialiasing, true );
-  painter->setOpacity( mOpacity );
 
   const QgsMapToPixel &mapToPixel = context.mapToPixel();
 
@@ -225,12 +224,6 @@ void QgsInterpolatedLineRenderer::adjustLine( const double &value, const double 
     adjusting = fabs( ( value - mStrokeWidth.minimumValue() ) / ( value2 - value1 ) );
     width = mStrokeWidth.minimumWidth();
   }
-}
-
-
-void QgsInterpolatedLineRenderer::setOpacity( double opacity )
-{
-  mOpacity = opacity;
 }
 
 double QgsInterpolatedLineWidth::minimumValue() const

--- a/src/core/symbology/qgsinterpolatedlinerenderer.h
+++ b/src/core/symbology/qgsinterpolatedlinerenderer.h
@@ -186,9 +186,6 @@ class CORE_EXPORT QgsInterpolatedLineRenderer
     //! Sets the stroke color used to plot
     void setInterpolatedColor( const QgsInterpolatedLineColor &strokeColoring );
 
-    //! Sets the opacity used to plot
-    void setOpacity( double opacity );
-
     /**
      * Render a line in the \a context between \a point1 and \a point2
      * with color and width that vary depending on \a value1 and \a value2
@@ -199,7 +196,6 @@ class CORE_EXPORT QgsInterpolatedLineRenderer
     QgsInterpolatedLineWidth mStrokeWidth;
     QgsInterpolatedLineColor mStrokeColoring;
     QgsUnitTypes::RenderUnit mStrokeWidthUnit = QgsUnitTypes::RenderMillimeters;
-    double mOpacity;
 
     QPolygonF varyingWidthLine( double value1, double value2, QPointF point1, QPointF point2, QgsRenderContext &context ) const;
     void adjustLine( const double &value, const double &value1, const double &value2, double &width, double &adjusting ) const;

--- a/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>378</width>
-    <height>237</height>
+    <height>206</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,22 +27,42 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="mOpacityLabel">
-       <property name="text">
-        <string>Opacity</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
-       <property name="focusPolicy">
-        <enum>Qt::StrongFocus</enum>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QWidget" name="mOpacityContainerWidget" native="true">
+     <layout class="QFormLayout" name="formLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="mOpacityLabel">
+        <property name="text">
+         <string>Opacity</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>14</height>
+         </size>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <widget class="QGroupBox" name="mEdgeWidthGroupBox">


### PR DESCRIPTION
The new `QgsInterpolatedLineRenderer` class had the possibility to set the opacity of the rendered line. But when there is some transparency, the rendering has some issue (overlapped border or very thin line between two color classes).
I didn't find proper way to fix that so I propose to simply remove the possibility of setting the opacity of  this line renderer at its level.
**EDIT :**
![image](https://user-images.githubusercontent.com/7416892/80971626-0d686d80-8deb-11ea-8c36-94bb8e8df82c.png)

The issue comes from anti-aliasing that creates a little overlap between each line stroke. If the anti-aliasing is disabled, there is no issue.

A solution could be to paint the line in a QImage then apply this image on the painter, but I don't find this solution very proper, so for now I propose to disabeling the opacity settings.
