### PR TITLE
Constrain the expression feature preview widget size and avoid it expanding

### DIFF
--- a/src/core/qgsproperty.cpp
+++ b/src/core/qgsproperty.cpp
@@ -88,7 +88,7 @@ QgsPropertyDefinition::QgsPropertyDefinition( const QString &name, const QString
 
     case ColorWithAlpha:
       mTypes = DataTypeString;
-      mHelpText = QObject::tr( "string [<b>r,g,b,a</b>] as int 0-255 or #<b>AARRGGBB</b> as hex or <b>color</b> as color's name" );
+      mHelpText = QObject::tr( "string [<b>r,g,b,a</b>] as int 0-255 or #<b>RRGGBBAA</b> as hex or <b>color</b> as color's name" );
       break;
 
     case ColorNoAlpha:

--- a/src/gui/qgsfeaturepickerwidget.cpp
+++ b/src/gui/qgsfeaturepickerwidget.cpp
@@ -42,6 +42,7 @@ QgsFeaturePickerWidget::QgsFeaturePickerWidget( QWidget *parent )
   mNextButton->setEnabled( false );
   mNextButton->setVisible( mShowBrowserButtons );
   layout->addWidget( mNextButton );
+  layout->setContentsMargins( 0, 0, 0, 0 );
 
   setLayout( layout );
 

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -438,9 +438,6 @@
                        <verstretch>0</verstretch>
                       </sizepolicy>
                      </property>
-                     <property name="toolTip">
-                      <string>Output preview is generated &lt;br&gt; using the first feature from the layer.</string>
-                     </property>
                      <property name="text">
                       <string>Expected format:</string>
                      </property>
@@ -448,9 +445,6 @@
                    </item>
                    <item>
                     <widget class="QLabel" name="lblExpected">
-                     <property name="toolTip">
-                      <string>Output preview is generated &lt;br&gt; using the first feature from the layer.</string>
-                     </property>
                      <property name="text">
                       <string>Help text</string>
                      </property>

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -99,7 +99,7 @@
                <height>0</height>
               </size>
              </property>
-             <layout class="QVBoxLayout" name="verticalLayout_6" stretch="0,1,0,1">
+             <layout class="QVBoxLayout" name="verticalLayout_6" stretch="0,1,0,0">
               <item>
                <layout class="QHBoxLayout" name="horizontalLayout_10" stretch="0">
                 <item>
@@ -412,21 +412,12 @@
               </item>
               <item>
                <layout class="QGridLayout" name="gridLayout">
-                <property name="sizeConstraint">
-                 <enum>QLayout::SetMinAndMaxSize</enum>
-                </property>
                 <property name="topMargin">
-                 <number>0</number>
+                 <number>3</number>
                 </property>
                 <item row="0" column="0">
                  <widget class="QFrame" name="mExpectedOutputFrame">
                   <layout class="QHBoxLayout" name="horizontalLayout_7">
-                   <property name="spacing">
-                    <number>3</number>
-                   </property>
-                   <property name="sizeConstraint">
-                    <enum>QLayout::SetMinAndMaxSize</enum>
-                   </property>
                    <property name="leftMargin">
                     <number>0</number>
                    </property>
@@ -442,7 +433,7 @@
                    <item>
                     <widget class="QLabel" name="label_3">
                      <property name="sizePolicy">
-                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
                        <horstretch>0</horstretch>
                        <verstretch>0</verstretch>
                       </sizepolicy>
@@ -451,41 +442,17 @@
                       <string>Output preview is generated &lt;br&gt; using the first feature from the layer.</string>
                      </property>
                      <property name="text">
-                      <string>Expected Format:</string>
+                      <string>Expected format:</string>
                      </property>
                     </widget>
                    </item>
                    <item>
                     <widget class="QLabel" name="lblExpected">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
                      <property name="toolTip">
                       <string>Output preview is generated &lt;br&gt; using the first feature from the layer.</string>
                      </property>
-                     <property name="frameShape">
-                      <enum>QFrame::NoFrame</enum>
-                     </property>
-                     <property name="frameShadow">
-                      <enum>QFrame::Sunken</enum>
-                     </property>
-                     <property name="lineWidth">
-                      <number>0</number>
-                     </property>
-                     <property name="midLineWidth">
-                      <number>0</number>
-                     </property>
                      <property name="text">
-                      <string>string [r,g,b,a] as int 0-255 or #RRGGBBAA as hex or color as color's name</string>
-                     </property>
-                     <property name="textFormat">
-                      <enum>Qt::RichText</enum>
-                     </property>
-                     <property name="scaledContents">
-                      <bool>false</bool>
+                      <string>Help text</string>
                      </property>
                      <property name="wordWrap">
                       <bool>true</bool>

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -499,7 +499,14 @@
                  </widget>
                 </item>
                 <item row="1" column="0">
-                 <widget class="QgsExpressionPreviewWidget" name="mExpressionPreviewWidget" native="true"/>
+                 <widget class="QgsExpressionPreviewWidget" name="mExpressionPreviewWidget" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                 </widget>
                 </item>
                </layout>
               </item>

--- a/src/ui/qgsexpressionpreviewbase.ui
+++ b/src/ui/qgsexpressionpreviewbase.ui
@@ -7,17 +7,29 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>67</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item row="1" column="0">
     <widget class="QLabel" name="label">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -26,14 +38,14 @@
       <string>Preview:</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
    <item row="1" column="1">
     <widget class="QLabel" name="mPreviewLabel">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -42,7 +54,7 @@
       <string>TextLabel</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -57,7 +69,7 @@
      <item>
       <widget class="QLabel" name="label_2">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>

--- a/src/ui/qgsexpressionpreviewbase.ui
+++ b/src/ui/qgsexpressionpreviewbase.ui
@@ -74,6 +74,9 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="toolTip">
+        <string>Select the feature to use for the output preview</string>
+       </property>
        <property name="text">
         <string>Feature</string>
        </property>


### PR DESCRIPTION
moving from
![image](https://user-images.githubusercontent.com/7983394/80898136-48da3d80-8d00-11ea-958e-b5da4d137491.png)

to 
![image](https://user-images.githubusercontent.com/7983394/80896671-170daa80-8cf1-11ea-97a8-ca1554da2f4b.png)
