### PR TITLE
Replace the "Edit user expression" button icon

### DIFF
--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -114,7 +114,7 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
 
   // Set icons for tool buttons
   btnSaveExpression->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionFileSave.svg" ) ) );
-  btnEditExpression->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionToggleEditing.svg" ) ) );
+  btnEditExpression->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "symbologyEdit.svg" ) ) );
   btnRemoveExpression->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionDeleteSelected.svg" ) ) );
   btnExportExpressions->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionSharingExport.svg" ) ) );
   btnImportExpressions->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionSharingImport.svg" ) ) );


### PR DESCRIPTION
Moving from (mActionToggleEditing)
![image](https://user-images.githubusercontent.com/7983394/80898163-922a8d00-8d00-11ea-8edb-327af809c06f.png)

to (symbologyEdit)
![image](https://user-images.githubusercontent.com/7983394/80896112-2853b880-8ceb-11ea-945c-db1b67ba37fb.png)

The symbologyEdit icon is used in different places (authentication, style manager, project & layer properties, settings...) when it comes to edit a symbol, a rule, a color... whereas the mActionToggleEditing is mainly used when it's about feature edit and other few places I wonder if it should (datum transformation, authentication config). I think we should keep the latter solely for features edit.

About the import/export icons, there are many GUIs in which we import/export items (style manager, project or global settings of scales or colors...) and the tools have filesave and folder like icons instead of the ones above. it might be worth harmonizing the icons?