### PR TITLE
[quick] Fix missing images in qgis_quick library

### DIFF
--- a/src/quickgui/CMakeLists.txt
+++ b/src/quickgui/CMakeLists.txt
@@ -89,6 +89,8 @@ INCLUDE_DIRECTORIES(SYSTEM
   ${QTKEYCHAIN_INCLUDE_DIR}
 )
 
+SET(QGIS_QUICK_GUI_IMAGE_RCCS ./images/images.qrc)
+
 ############################################################
 # qgis_quick shared library
 QT5_WRAP_CPP(QGIS_QUICK_GUI_MOC_SRCS ${QGIS_QUICK_GUI_MOC_HDRS})
@@ -99,6 +101,7 @@ ELSE(MSVC)
 ENDIF(MSVC)
 
 ADD_LIBRARY(qgis_quick ${LIBRARY_TYPE}
+    ${QGIS_QUICK_GUI_IMAGE_RCCS}
     ${QGIS_QUICK_GUI_SRC}
     ${QGIS_QUICK_GUI_MOC_HDRS}
     ${QGIS_QUICK_GUI_MOC_SRCS}


### PR DESCRIPTION
They were removed by mistake in 19edc99 when cleaning up .qrc handling