### PR TITLE
Snap on mesh elements

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -322,18 +322,28 @@ Sets the reference time of the layer
 
     QgsPointXY snapOnElement( QgsMesh::ElementType elementType, const QgsPointXY &point, double searchRadius );
 %Docstring
-Returns the position of the snapped point on the closest mesh element
+Returns the position of the snapped point on the mesh element closest to ``point`` intersecting with
+the searching area defined by ``point`` and ``searchRadius``
 
 For vertex, the snapped position is the vertex position
 For edge, the snapped position is the projected point on the edge, extremity of edge if outside the edge
-For face, the snapped position is the centroïd of the face
-The returned position is in map coordinates
+For face, the snapped position is the centroid of the face
+The returned position is in map coordinates.
+
+.. note::
+
+   It uses previously cached and indexed triangular mesh
+   and so if the layer has not been rendered previously
+   (e.g. when used in a script) it returns empty :py:class:`QgsPointXY`
+
+.. seealso:: :py:func:`updateTriangularMesh`
 
 :param elementType: the type of element to snap
 :param point: the center of the search area in map coordinates
 :param searchRadius: the radius of the search area in map units
 
-:return: the position of the snapped point on the closest element, empty if no element of type ``elementType``
+:return: the position of the snapped point on the closest element, empty QgsPointXY if no element of type ``elementType``
+
 
 .. versionadded:: 3.14
 %End

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -326,7 +326,7 @@ Returns the position of the snapped point on the closest mesh element
 
 For vertex, the snapped position is the vertex position
 For edge, the snapped position is the projected point on the edge, extremity of edge if outside the edge
-For faces, the snapped position is the centroïd of the face
+For face, the snapped position is the centroïd of the face
 The returned position is in map coordinates
 
 :param elementType: the type of element to snap

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -320,6 +320,24 @@ Sets the reference time of the layer
 .. versionadded:: 3.14
 %End
 
+    QgsPointXY snapOnElement( QgsMesh::ElementType elementType, const QgsPointXY &point, double searchRadius );
+%Docstring
+Returns the position of the snapped point on the closest mesh element
+
+For vertex, the snapped position is the vertex position
+For edge, the snapped position is the projected point on the edge, extremity of edge if outside the edge
+For faces, the snapped position is the centroïd of the face
+The returned position is in map coordinates
+
+:param elementType: the type of element to snap
+:param point: the center of the search area in map coordinates
+:param searchRadius: the radius of the search area in map units
+
+:return: the position of the snapped point on the closest element, empty if no element of type ``elementType``
+
+.. versionadded:: 3.14
+%End
+
   public slots:
 
     virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext );

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -377,6 +377,23 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
       */
     void setReferenceTime( const QDateTime &referenceTime );
 
+    /**
+      * Returns the position of the snapped point on the closest mesh element
+      *
+      * For vertex, the snapped position is the vertex position
+      * For edge, the snapped position is the projected point on the edge, extremity of edge if outside the edge
+      * For faces, the snapped position is the centroïd of the face
+      * The returned position is in map coordinates
+      *
+      * \param elementType the type of element to snap
+      * \param point the center of the search area in map coordinates
+      * \param searchRadius the radius of the search area in map units
+      * \return the position of the snapped point on the closest element, empty if no element of type \a elementType
+      *
+      * \since QGIS 3.14
+      */
+    QgsPointXY snapOnElement( QgsMesh::ElementType elementType, const QgsPointXY &point, double searchRadius );
+
   public slots:
 
     /**
@@ -467,6 +484,17 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
 
     QgsMeshDatasetIndex mStaticScalarDatasetIndex;
     QgsMeshDatasetIndex mStaticVectorDatasetIndex;
+
+    int closestEdge( const QgsPointXY &point, double searchRadius, QgsPointXY &projectedPoint ) const;
+
+    //! Returns the exact position in map coordinates of the closest vertex in the search area
+    QgsPointXY snapOnVertex( const QgsPointXY &point, double searchRadius );
+
+    //!Returns the postion of the projected point on the closest edge in the search area
+    QgsPointXY snapOnEdge( const QgsPointXY &point, double searchRadius );
+
+    //!Returns the postion of the centroid point on the closest face in the search area
+    QgsPointXY snapOnFace( const QgsPointXY &point, double searchRadius );
 };
 
 #endif //QGSMESHLAYER_H

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -382,7 +382,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
       *
       * For vertex, the snapped position is the vertex position
       * For edge, the snapped position is the projected point on the edge, extremity of edge if outside the edge
-      * For faces, the snapped position is the centroïd of the face
+      * For face, the snapped position is the centroïd of the face
       * The returned position is in map coordinates
       *
       * \param elementType the type of element to snap
@@ -490,10 +490,10 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     //! Returns the exact position in map coordinates of the closest vertex in the search area
     QgsPointXY snapOnVertex( const QgsPointXY &point, double searchRadius );
 
-    //!Returns the postion of the projected point on the closest edge in the search area
+    //!Returns the position of the projected point on the closest edge in the search area
     QgsPointXY snapOnEdge( const QgsPointXY &point, double searchRadius );
 
-    //!Returns the postion of the centroid point on the closest face in the search area
+    //!Returns the position of the centroid point on the closest face in the search area
     QgsPointXY snapOnFace( const QgsPointXY &point, double searchRadius );
 };
 

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -378,17 +378,23 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     void setReferenceTime( const QDateTime &referenceTime );
 
     /**
-      * Returns the position of the snapped point on the closest mesh element
+      * Returns the position of the snapped point on the mesh element closest to \a point intersecting with
+      * the searching area defined by \a point and \a searchRadius
       *
       * For vertex, the snapped position is the vertex position
       * For edge, the snapped position is the projected point on the edge, extremity of edge if outside the edge
-      * For face, the snapped position is the centroïd of the face
-      * The returned position is in map coordinates
+      * For face, the snapped position is the centroid of the face
+      * The returned position is in map coordinates.
+      *
+      * \note It uses previously cached and indexed triangular mesh
+      * and so if the layer has not been rendered previously
+      * (e.g. when used in a script) it returns empty QgsPointXY
+      * \see updateTriangularMesh
       *
       * \param elementType the type of element to snap
       * \param point the center of the search area in map coordinates
       * \param searchRadius the radius of the search area in map units
-      * \return the position of the snapped point on the closest element, empty if no element of type \a elementType
+      * \return the position of the snapped point on the closest element, empty QgsPointXY if no element of type \a elementType
       *
       * \since QGIS 3.14
       */

--- a/tests/src/core/testqgsmeshlayer.cpp
+++ b/tests/src/core/testqgsmeshlayer.cpp
@@ -83,6 +83,7 @@ class TestQgsMeshLayer : public QObject
 
     void test_mesh_simplification();
 
+    void test_snap_on_mesh();
     void test_dataset_value_from_layer();
 };
 
@@ -909,6 +910,51 @@ void TestQgsMeshLayer::test_mesh_simplification()
   // Delete simplified meshes
   for ( QgsTriangularMesh *m : simplifiedMeshes )
     delete m;
+}
+
+void TestQgsMeshLayer::test_snap_on_mesh()
+{
+  //1D mesh
+  mMdal1DLayer->updateTriangularMesh();
+  double searchRadius = 10;
+
+  QgsPointXY snappedPoint;
+
+  //1D mesh
+  snappedPoint = mMdal1DLayer->snapOnElement( QgsMesh::Vertex, QgsPointXY(), searchRadius );
+  QCOMPARE( snappedPoint, QgsPointXY() );
+  snappedPoint = mMdal1DLayer->snapOnElement( QgsMesh::Vertex, QgsPointXY( 1002, 2005 ), searchRadius );
+  QCOMPARE( snappedPoint, QgsPointXY( 1000, 2000 ) );
+  snappedPoint = mMdal1DLayer->snapOnElement( QgsMesh::Edge, QgsPointXY( 1002, 2005 ), searchRadius );
+  QCOMPARE( snappedPoint, QgsPointXY( 1002, 2000 ) );
+  snappedPoint = mMdal1DLayer->snapOnElement( QgsMesh::Edge, QgsPointXY( 998, 2005 ), searchRadius );
+  QCOMPARE( snappedPoint, QgsPointXY( 1000, 2000 ) );
+  snappedPoint = mMdal1DLayer->snapOnElement( QgsMesh::Edge, QgsPointXY( 990, 2010 ), searchRadius );
+  QCOMPARE( snappedPoint, QgsPointXY() );
+  snappedPoint = mMdal1DLayer->snapOnElement( QgsMesh::Vertex, QgsPointXY( 2002, 2998 ), searchRadius );
+  QCOMPARE( snappedPoint, QgsPointXY( 2000, 3000 ) );
+
+
+  //2D mesh
+  mMdalLayer->updateTriangularMesh();
+  snappedPoint = mMdalLayer->snapOnElement( QgsMesh::Vertex, QgsPointXY(), searchRadius );
+  QCOMPARE( snappedPoint, QgsPointXY() );
+  snappedPoint = mMdalLayer->snapOnElement( QgsMesh::Vertex, QgsPointXY(), searchRadius );
+  QCOMPARE( snappedPoint, QgsPointXY() );
+  snappedPoint = mMdalLayer->snapOnElement( QgsMesh::Vertex, QgsPointXY( 1002, 2005 ), searchRadius );
+  QCOMPARE( snappedPoint, QgsPointXY( 1000, 2000 ) );
+  snappedPoint = mMdalLayer->snapOnElement( QgsMesh::Vertex, QgsPointXY( 2002, 2998 ), searchRadius );
+  QCOMPARE( snappedPoint, QgsPointXY( 2000, 3000 ) );
+  snappedPoint = mMdalLayer->snapOnElement( QgsMesh::Face, QgsPointXY( 998, 1998 ), searchRadius );
+  QCOMPARE( snappedPoint, QgsPointXY( 1500, 2500 ) );
+  snappedPoint = mMdalLayer->snapOnElement( QgsMesh::Face, QgsPointXY( 1002, 2001 ), searchRadius );
+  QCOMPARE( snappedPoint, QgsPointXY( 1500, 2500 ) );
+  snappedPoint = mMdalLayer->snapOnElement( QgsMesh::Face, QgsPointXY( 1998, 2998 ), searchRadius );
+  QCOMPARE( snappedPoint, QgsPointXY( 1500, 2500 ) );
+  snappedPoint = mMdalLayer->snapOnElement( QgsMesh::Face, QgsPointXY( 2002, 1998 ), searchRadius );
+  QCOMPARE( snappedPoint, QgsPointXY( 2333.33333333, 2333.333333333 ) );
+  snappedPoint = mMdalLayer->snapOnElement( QgsMesh::Face, QgsPointXY( 500, 500 ), searchRadius );
+  QCOMPARE( snappedPoint, QgsPointXY() );
 }
 
 void TestQgsMeshLayer::test_dataset_value_from_layer()


### PR DESCRIPTION
Add a method in API to snap on mesh elements. 
The method returns the position of the snapped point on the closest mesh element :
- For vertex, the snapped position is the vertex position
- For edge, the snapped position is the projected point on the edge, extremity of edge if outside the edge
- For face, the snapped position is the centroïd of the face

The returned position is in map coordinates