### PR TITLE
When reading scalebar from XML re-apply stored size after changing style

### DIFF
--- a/src/core/layout/qgslayoutitemscalebar.cpp
+++ b/src/core/layout/qgslayoutitemscalebar.cpp
@@ -577,7 +577,11 @@ void QgsLayoutItemScaleBar::update()
 void QgsLayoutItemScaleBar::updateScale()
 {
   refreshSegmentMillimeters();
-  resizeToMinimumWidth();
+  //Don't adjust box size for numeric scale bars:
+  if ( mStyle && mStyle->id() != QLatin1String( "Numeric" ) )
+  {
+    resizeToMinimumWidth();
+  }
   update();
 }
 
@@ -1062,6 +1066,9 @@ bool QgsLayoutItemScaleBar::readPropertiesFromElement( const QDomElement &itemEl
 
   //style
   setStyle( itemElem.attribute( QStringLiteral( "style" ), QString() ) );
+
+  //call attemptResize after setStyle to ensure the appropriate size limitations are applied
+  attemptResize( QgsLayoutSize::decodeSize( itemElem.attribute( QStringLiteral( "size" ) ) ) );
 
   if ( itemElem.attribute( QStringLiteral( "unitType" ) ).isEmpty() )
   {


### PR DESCRIPTION
## Description

This PR fixes the issue that when restoring a numeric scale bar layout item from an XML (such as when opening a saved project or pasting a copied item) the height of the scale bar layout item is set to a value larger than the one stored in the XML (see #26931 and #32379).

The issue arises from the fact that restoring a scale bar layout item initially creates a `QgsLayoutItemScaleBar` with the default style of `Single Box`, which has larger minimum dimensions as calculated by `calculateBoxSize`. The call to `attemptResize` in `QgsLayoutItem::readXml`, which tries to apply the dimensions stored in the XML, cannot set the dimensions of the scale bar layout item to be smaller than these minimum dimensions, so the dimensions are only applied correctly if they happen to be larger.

To fix this issue, this PR re-applies the stored size by calling `attemptResize` in `QgsLayoutItemScaleBar::readPropertiesFromElement` after the scale bar style has been set.

Additionally, the width of the numeric scale bar was not restored correctly because `QgsLayoutItemScaleBar::finalizeRestoreFromXml` calls `QgsLayoutItemScaleBar::updateScale`, which calls `resizeToMinimumWidth()`. This PR adds a check to skip `resizeToMinimumWidth` when the style is `Numeric`.

Fixes #26931, fixes #32379