### PR TITLE
[image cache] Avoid creating an invalid image and painting onto it

### DIFF
--- a/src/core/qgsimagecache.cpp
+++ b/src/core/qgsimagecache.cpp
@@ -208,6 +208,10 @@ QImage QgsImageCache::renderImage( const QString &path, QSize size, const bool k
     {
       isBroken = true;
 
+      // if the size parameter is not valid, skip drawing of missing image symbol
+      if ( !size.isValid() )
+        return im;
+
       // if image size is set to respect aspect ratio, correct for broken image aspect ratio
       if ( size.width() == 0 )
         size.setWidth( size.height() );


### PR DESCRIPTION
## Description

@nyalldawson , this PR fixes a set of qt errors in qgsimagecache whenever pathAsImage() is called with an invalid size (for e.g., https://github.com/qgis/QGIS/blob/master/src/core/layout/qgslayoutitempicture.cpp#L464 )

If you want to replicate the dozen+ qt error thrown when the code tries to paint an SVG onto an invalid image, load this file in a debug-enabled QGIS build:
[advanced_bee_farming.zip](https://github.com/qgis/QGIS/files/4578602/advanced_bee_farming.zip)
