### PR TITLE
Only use distance area calculator in expression preview results when it has been initialized correctly

### DIFF
--- a/src/gui/qgsexpressionpreviewwidget.cpp
+++ b/src/gui/qgsexpressionpreviewwidget.cpp
@@ -55,6 +55,7 @@ void QgsExpressionPreviewWidget::setCurrentFeature( const QgsFeature &feature )
 void QgsExpressionPreviewWidget::setGeomCalculator( const QgsDistanceArea &da )
 {
   mDa = da;
+  mUseGeomCalculator = true;
 }
 
 void QgsExpressionPreviewWidget::setExpressionContext( const QgsExpressionContext &context )
@@ -78,10 +79,10 @@ void QgsExpressionPreviewWidget::refreshPreview()
   {
     mExpression = QgsExpression( mExpressionText );
 
-    if ( mLayer )
+    if ( mUseGeomCalculator )
     {
-      // TODO: is this OK?
-      // Only set calculator if we have layer, else use default.
+      // only set an explicit geometry calculator if a call to setGeomCalculator was made. If not,
+      // let the expression context handle this correctly
       mExpression.setGeomCalculator( &mDa );
     }
 

--- a/src/gui/qgsexpressionpreviewwidget.h
+++ b/src/gui/qgsexpressionpreviewwidget.h
@@ -123,6 +123,7 @@ class GUI_EXPORT QgsExpressionPreviewWidget : public QWidget, private Ui::QgsExp
     QgsVectorLayer *mLayer = nullptr;
     QgsExpressionContext mExpressionContext;
     QgsDistanceArea mDa;
+    bool mUseGeomCalculator = false;
     QString mToolTip;
     bool mEvalError = true;
     bool mParserError = true;


### PR DESCRIPTION
Fixes #35628
