### PR TITLE
Avoid long loading in attribute table on model change

### DIFF
--- a/python/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
@@ -94,6 +94,16 @@ Set the filter mode the filter will use.
 :param filterMode: Sets the current mode of the filter
 %End
 
+    void disconnectFilterModeConnections();
+%Docstring
+Disconnect the connections set for the current filterMode
+%End
+
+    void connectFilterModeConnections( FilterMode filterMode );
+%Docstring
+Disconnect the connections set for the new ``filterMode``
+%End
+
     FilterMode filterMode();
 %Docstring
 The current filterModel

--- a/python/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
@@ -216,6 +216,16 @@ Emitted whenever the sort column is changed
 :param order: The sort order
 %End
 
+    void featuresFiltered();
+%Docstring
+Emitted when the filtering of the features has been done
+%End
+
+    void visibleReloaded();
+%Docstring
+Emitted when the the visible features on extend are reloaded (the list is created)
+%End
+
   protected:
 
     virtual bool filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const;

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -318,25 +318,37 @@ void QgsAttributeTableFilterModel::setFilterMode( FilterMode filterMode )
 {
   if ( filterMode != mFilterMode )
   {
-    if ( filterMode == ShowVisible )
+    // cleanup existing connections
+    switch ( mFilterMode )
     {
-      connect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
-      connect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
-      generateListOfVisibleFeatures();
-    }
-    else
-    {
-      disconnect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
-      disconnect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
+      case ShowVisible:
+        disconnect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
+        disconnect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
+        break;
+      case ShowAll:
+      case ShowEdited:
+      case ShowSelected:
+        break;
+      case ShowFilteredList:
+        disconnect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::filterFeatures );
+        break;
     }
 
-    if ( filterMode == ShowFilteredList )
+    // setup new connections
+    switch ( filterMode )
     {
-      connect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::filterFeatures );
-    }
-    else
-    {
-      disconnect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::filterFeatures );
+      case ShowVisible:
+        connect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
+        connect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
+        generateListOfVisibleFeatures();
+        break;
+      case ShowAll:
+      case ShowEdited:
+      case ShowSelected:
+        break;
+      case ShowFilteredList:
+        connect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::filterFeatures );
+        break;
     }
 
     mFilterMode = filterMode;

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -323,14 +323,18 @@ void QgsAttributeTableFilterModel::setFilterMode( FilterMode filterMode )
     {
       case ShowVisible:
         disconnect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
-        disconnect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
+        disconnect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::reloadVisible );
+        disconnect( layer(), &QgsVectorLayer::geometryChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
+        disconnect( mTableModel, &QgsAttributeTableModel::finished, this, &QgsAttributeTableFilterModel::reloadVisible );
         break;
       case ShowAll:
       case ShowEdited:
       case ShowSelected:
         break;
       case ShowFilteredList:
-        disconnect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::filterFeatures );
+        disconnect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::filterFeatures );
+        disconnect( layer(), &QgsVectorLayer::attributeValueChanged, this, &QgsAttributeTableFilterModel::filterFeatures );
+        disconnect( mTableModel, &QgsAttributeTableModel::finished, this, &QgsAttributeTableFilterModel::filterFeatures );
         break;
     }
 
@@ -339,7 +343,9 @@ void QgsAttributeTableFilterModel::setFilterMode( FilterMode filterMode )
     {
       case ShowVisible:
         connect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
-        connect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
+        connect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::reloadVisible );
+        connect( layer(), &QgsVectorLayer::geometryChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
+        connect( mTableModel, &QgsAttributeTableModel::finished, this, &QgsAttributeTableFilterModel::reloadVisible );
         generateListOfVisibleFeatures();
         break;
       case ShowAll:
@@ -347,7 +353,9 @@ void QgsAttributeTableFilterModel::setFilterMode( FilterMode filterMode )
       case ShowSelected:
         break;
       case ShowFilteredList:
-        connect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::filterFeatures );
+        connect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::filterFeatures );
+        connect( layer(), &QgsVectorLayer::attributeValueChanged, this, &QgsAttributeTableFilterModel::filterFeatures );
+        connect( mTableModel, &QgsAttributeTableModel::finished, this, &QgsAttributeTableFilterModel::filterFeatures );
         break;
     }
 

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -323,51 +323,55 @@ void QgsAttributeTableFilterModel::setFilterMode( FilterMode filterMode )
 {
   if ( filterMode != mFilterMode )
   {
-    // cleanup existing connections
-    switch ( mFilterMode )
-    {
-      case ShowVisible:
-        disconnect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsAttributeTableFilterModel::startTimedReloadVisible );
-        disconnect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::startTimedReloadVisible );
-        disconnect( layer(), &QgsVectorLayer::geometryChanged, this, &QgsAttributeTableFilterModel::startTimedReloadVisible );
-        disconnect( mTableModel, &QgsAttributeTableModel::finished, this, &QgsAttributeTableFilterModel::startTimedReloadVisible );
-        break;
-      case ShowAll:
-      case ShowEdited:
-      case ShowSelected:
-        break;
-      case ShowFilteredList:
-        disconnect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::startTimedFilterFeatures );
-        disconnect( mTableModel, &QgsAttributeTableModel::finished, this, &QgsAttributeTableFilterModel::startTimedFilterFeatures );
-        disconnect( layer(), &QgsVectorLayer::attributeValueChanged, this, &QgsAttributeTableFilterModel::onAttributeValueChanged );
-        disconnect( layer(), &QgsVectorLayer::geometryChanged, this, &QgsAttributeTableFilterModel::onGeometryChanged );
-        break;
-    }
-
-    // setup new connections
-    switch ( filterMode )
-    {
-      case ShowVisible:
-        connect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsAttributeTableFilterModel::startTimedReloadVisible );
-        connect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::startTimedReloadVisible );
-        connect( layer(), &QgsVectorLayer::geometryChanged, this, &QgsAttributeTableFilterModel::startTimedReloadVisible );
-        connect( mTableModel, &QgsAttributeTableModel::finished, this, &QgsAttributeTableFilterModel::startTimedReloadVisible );
-        generateListOfVisibleFeatures();
-        break;
-      case ShowAll:
-      case ShowEdited:
-      case ShowSelected:
-        break;
-      case ShowFilteredList:
-        connect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::startTimedFilterFeatures );
-        connect( mTableModel, &QgsAttributeTableModel::finished, this, &QgsAttributeTableFilterModel::startTimedFilterFeatures );
-        connect( layer(), &QgsVectorLayer::attributeValueChanged, this, &QgsAttributeTableFilterModel::onAttributeValueChanged );
-        connect( layer(), &QgsVectorLayer::geometryChanged, this, &QgsAttributeTableFilterModel::onGeometryChanged );
-        break;
-    }
-
+    disconnectFilterModeConnections();
+    connectFilterModeConnections( filterMode );
     mFilterMode = filterMode;
     invalidateFilter();
+  }
+}
+
+void QgsAttributeTableFilterModel::disconnectFilterModeConnections()
+{
+  // cleanup existing connections
+  switch ( mFilterMode )
+  {
+    case ShowVisible:
+      disconnect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsAttributeTableFilterModel::startTimedReloadVisible );
+      disconnect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::startTimedReloadVisible );
+      disconnect( layer(), &QgsVectorLayer::geometryChanged, this, &QgsAttributeTableFilterModel::startTimedReloadVisible );
+      break;
+    case ShowAll:
+    case ShowEdited:
+    case ShowSelected:
+      break;
+    case ShowFilteredList:
+      disconnect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::startTimedFilterFeatures );
+      disconnect( layer(), &QgsVectorLayer::attributeValueChanged, this, &QgsAttributeTableFilterModel::onAttributeValueChanged );
+      disconnect( layer(), &QgsVectorLayer::geometryChanged, this, &QgsAttributeTableFilterModel::onGeometryChanged );
+      break;
+  }
+}
+
+void QgsAttributeTableFilterModel::connectFilterModeConnections( QgsAttributeTableFilterModel::FilterMode filterMode )
+{
+  // setup new connections
+  switch ( filterMode )
+  {
+    case ShowVisible:
+      connect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsAttributeTableFilterModel::startTimedReloadVisible );
+      connect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::startTimedReloadVisible );
+      connect( layer(), &QgsVectorLayer::geometryChanged, this, &QgsAttributeTableFilterModel::startTimedReloadVisible );
+      generateListOfVisibleFeatures();
+      break;
+    case ShowAll:
+    case ShowEdited:
+    case ShowSelected:
+      break;
+    case ShowFilteredList:
+      connect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::startTimedFilterFeatures );
+      connect( layer(), &QgsVectorLayer::attributeValueChanged, this, &QgsAttributeTableFilterModel::onAttributeValueChanged );
+      connect( layer(), &QgsVectorLayer::geometryChanged, this, &QgsAttributeTableFilterModel::onGeometryChanged );
+      break;
   }
 }
 

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -333,7 +333,8 @@ void QgsAttributeTableFilterModel::setFilterMode( FilterMode filterMode )
         break;
       case ShowFilteredList:
         disconnect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::filterFeatures );
-        disconnect( layer(), &QgsVectorLayer::attributeValueChanged, this, &QgsAttributeTableFilterModel::filterFeatures );
+        disconnect( layer(), &QgsVectorLayer::attributeValueChanged, this, &QgsAttributeTableFilterModel::onAttributeValueChanged );
+        disconnect( layer(), &QgsVectorLayer::geometryChanged, this, &QgsAttributeTableFilterModel::onGeometryChanged );
         disconnect( mTableModel, &QgsAttributeTableModel::finished, this, &QgsAttributeTableFilterModel::filterFeatures );
         break;
     }
@@ -354,7 +355,8 @@ void QgsAttributeTableFilterModel::setFilterMode( FilterMode filterMode )
         break;
       case ShowFilteredList:
         connect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::filterFeatures );
-        connect( layer(), &QgsVectorLayer::attributeValueChanged, this, &QgsAttributeTableFilterModel::filterFeatures );
+        connect( layer(), &QgsVectorLayer::attributeValueChanged, this, &QgsAttributeTableFilterModel::onAttributeValueChanged );
+        connect( layer(), &QgsVectorLayer::geometryChanged, this, &QgsAttributeTableFilterModel::onGeometryChanged );
         connect( mTableModel, &QgsAttributeTableModel::finished, this, &QgsAttributeTableFilterModel::filterFeatures );
         break;
     }
@@ -418,6 +420,25 @@ void QgsAttributeTableFilterModel::reloadVisible()
 {
   generateListOfVisibleFeatures();
   invalidateFilter();
+}
+
+void QgsAttributeTableFilterModel::onAttributeValueChanged( QgsFeatureId fid, int idx, const QVariant &value )
+{
+  Q_UNUSED( fid );
+  Q_UNUSED( value );
+
+  if ( mFilterExpression.referencedAttributeIndexes( layer()->fields() ).contains( idx ) )
+  {
+    filterFeatures();
+  }
+}
+
+void QgsAttributeTableFilterModel::onGeometryChanged()
+{
+  if ( mFilterExpression.needsGeometry() )
+  {
+    filterFeatures();
+  }
 }
 
 void QgsAttributeTableFilterModel::filterFeatures()

--- a/src/gui/attributetable/qgsattributetablefiltermodel.h
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.h
@@ -282,6 +282,8 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
     void selectionChanged();
     void onColumnsChanged();
     void reloadVisible();
+    void onAttributeValueChanged( QgsFeatureId fid, int idx, const QVariant &value );
+    void onGeometryChanged();
 
   private:
     QgsFeatureIds mFilteredFeatures;

--- a/src/gui/attributetable/qgsattributetablefiltermodel.h
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.h
@@ -128,6 +128,16 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
     void setFilterMode( FilterMode filterMode );
 
     /**
+     * Disconnect the connections set for the current filterMode
+     */
+    void disconnectFilterModeConnections();
+
+    /**
+     * Disconnect the connections set for the new \a filterMode
+     */
+    void connectFilterModeConnections( FilterMode filterMode );
+
+    /**
      * The current filterModel
      */
     FilterMode filterMode() { return mFilterMode; }

--- a/src/gui/attributetable/qgsattributetablefiltermodel.h
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.h
@@ -238,6 +238,16 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
      */
     void sortColumnChanged( int column, Qt::SortOrder order );
 
+    /**
+     * Emitted when the filtering of the features has been done
+     */
+    void featuresFiltered();
+
+    /**
+     * Emitted when the the visible features on extend are reloaded (the list is created)
+     */
+    void visibleReloaded();
+
   protected:
 
     /**
@@ -300,6 +310,10 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
     int mapColumnToSource( int column ) const;
     int mapColumnFromSource( int column ) const;
 
+    QTimer mReloadVisibleTimer;
+    QTimer mFilterFeaturesTimer;
+    void startTimedReloadVisible();
+    void startTimedFilterFeatures();
 };
 
 #endif

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -248,11 +248,13 @@ void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filter
   {
     case QgsAttributeTableFilterModel::ShowVisible:
       disconnect( mFilterModel->mapCanvas(), &QgsMapCanvas::extentsChanged, this, &QgsDualView::extentChanged );
+      disconnect( mFilterModel, &QgsAttributeTableFilterModel::visibleReloaded, this, &QgsDualView::filterChanged );
       break;
 
     case QgsAttributeTableFilterModel::ShowAll:
     case QgsAttributeTableFilterModel::ShowEdited:
     case QgsAttributeTableFilterModel::ShowFilteredList:
+      disconnect( mFilterModel, &QgsAttributeTableFilterModel::featuresFiltered, this, &QgsDualView::filterChanged );
       break;
 
     case QgsAttributeTableFilterModel::ShowSelected:
@@ -285,11 +287,13 @@ void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filter
         QgsRectangle rect = mFilterModel->mapCanvas()->mapSettings().mapToLayerCoordinates( mLayer, mFilterModel->mapCanvas()->extent() );
         r.setFilterRect( rect );
       }
+      connect( mFilterModel, &QgsAttributeTableFilterModel::visibleReloaded, this, &QgsDualView::filterChanged );
       break;
 
     case QgsAttributeTableFilterModel::ShowAll:
     case QgsAttributeTableFilterModel::ShowEdited:
     case QgsAttributeTableFilterModel::ShowFilteredList:
+      disconnect( mFilterModel, &QgsAttributeTableFilterModel::featuresFiltered, this, &QgsDualView::filterChanged );
       break;
 
     case QgsAttributeTableFilterModel::ShowSelected:

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -298,14 +298,6 @@ void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filter
       break;
   }
 
-  if ( requiresTableReload )
-  {
-    mMasterModel->setRequest( r );
-    whileBlocking( mLayerCache )->setCacheGeometry( needsGeometry );
-    mMasterModel->loadLayer();
-  }
-
-
   // disable the browsing auto pan/scale if the list only shows visible items
   switch ( filterMode )
   {
@@ -323,6 +315,14 @@ void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filter
 
   //update filter model
   mFilterModel->setFilterMode( filterMode );
+
+  if ( requiresTableReload )
+  {
+    mMasterModel->setRequest( r );
+    whileBlocking( mLayerCache )->setCacheGeometry( needsGeometry );
+    mMasterModel->loadLayer();
+  }
+
   emit filterChanged();
 }
 

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -293,7 +293,7 @@ void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filter
     case QgsAttributeTableFilterModel::ShowAll:
     case QgsAttributeTableFilterModel::ShowEdited:
     case QgsAttributeTableFilterModel::ShowFilteredList:
-      disconnect( mFilterModel, &QgsAttributeTableFilterModel::featuresFiltered, this, &QgsDualView::filterChanged );
+      connect( mFilterModel, &QgsAttributeTableFilterModel::featuresFiltered, this, &QgsDualView::filterChanged );
       break;
 
     case QgsAttributeTableFilterModel::ShowSelected:
@@ -317,16 +317,18 @@ void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filter
       break;
   }
 
-  //update filter model
-  mFilterModel->setFilterMode( filterMode );
-
   if ( requiresTableReload )
   {
+    //disconnect the connections of the current (old) filtermode before reload
+    mFilterModel->disconnectFilterModeConnections();
+
     mMasterModel->setRequest( r );
     whileBlocking( mLayerCache )->setCacheGeometry( needsGeometry );
     mMasterModel->loadLayer();
   }
 
+  //update filter model
+  mFilterModel->setFilterMode( filterMode );
   emit filterChanged();
 }
 

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -428,6 +428,9 @@ void TestQgsAttributeTable::testFilteredFeatures()
 
   std::unique_ptr< QgsAttributeTableDialog > dlg( new QgsAttributeTableDialog( tempLayer.get(), QgsAttributeTableFilterModel::ShowAll ) );
 
+  QEventLoop loop;
+  connect( qobject_cast<QgsAttributeTableFilterModel *>( dlg->mMainView->mFilterModel ), &QgsAttributeTableFilterModel::featuresFiltered, &loop, &QEventLoop::quit );
+
   // show all (three features)
   dlg->mFeatureFilterWidget->filterShowAll();
   QCOMPARE( dlg->mMainView->featureCount(), 3 );
@@ -463,7 +466,7 @@ void TestQgsAttributeTable::testFilteredFeatures()
   f6.setAttribute( 1, 12 );
   QVERIFY( tempLayer->addFeatures( QgsFeatureList() << f5 << f6 ) );
   tempLayer->commitChanges();
-
+  loop.exec();
   //no filter change -> now two of six features
   QCOMPARE( dlg->mMainView->featureCount(), 6 );
   QCOMPARE( dlg->mMainView->filteredFeatureCount(), 2 );

--- a/tests/src/gui/testqgsdualview.cpp
+++ b/tests/src/gui/testqgsdualview.cpp
@@ -164,14 +164,19 @@ void TestQgsDualView::testFilterSelected()
 
 void TestQgsDualView::testSelectAll()
 {
+
+  QEventLoop loop;
+  connect( qobject_cast<QgsAttributeTableFilterModel *>( mDualView->mFilterModel ), &QgsAttributeTableFilterModel::visibleReloaded, &loop, &QEventLoop::quit );
   mDualView->setFilterMode( QgsAttributeTableFilterModel::ShowVisible );
   // Only show parts of the canvas, so only one selected feature is visible
   mCanvas->setExtent( QgsRectangle( -139, 23, -100, 48 ) );
+  loop.exec();
   mDualView->mTableView->selectAll();
   QCOMPARE( mPointsLayer->selectedFeatureCount(), 10 );
 
   mPointsLayer->selectByIds( QgsFeatureIds() );
   mCanvas->setExtent( QgsRectangle( -110, 40, -100, 48 ) );
+  loop.exec();
   mDualView->mTableView->selectAll();
   QCOMPARE( mPointsLayer->selectedFeatureCount(), 1 );
 }


### PR DESCRIPTION
The filtered features in the attribute table have been reloaded when the model changed, to be able to display added features etc. in the filter mode as well. Same for only-show-visible-on-map.

Since the reload listened on the models signal `dataChanged` this leaded to very long reloads since on a complete model reload the signal was fired multiple times.

This PR fixes #35927 because the filter model is reloaded now on `featureAdded` etc. signals on the layer instead on the signal `dataChanged` of the main model (and on the `finished` signal of the model, what is called when the complete main model finished reloading).

Additionally there is a short timer to avoid long reloading times e.g. when a huge amount of features are added at the same time. 

And there has been some ugly connect/disconnect logic I improved (first commit) as well.
