### PR TITLE
allow editing of links in file widget

### DIFF
--- a/src/gui/qgsfilewidget.h
+++ b/src/gui/qgsfilewidget.h
@@ -200,12 +200,17 @@ class GUI_EXPORT QgsFileWidget : public QWidget
   private slots:
     void openFileDialog();
     void textEdited( const QString &path );
+    void editLink();
 
   private:
+    void updateLayout();
+
     QString mFilePath;
     bool mButtonVisible = true;
     bool mUseLink = false;
     bool mFullUrl = false;
+    bool mReadOnly = false;
+    bool mIsLinkEdited = false;
     QString mDialogTitle;
     QString mFilter;
     QString mSelectedFilter;
@@ -216,6 +221,7 @@ class GUI_EXPORT QgsFileWidget : public QWidget
 
     QLabel *mLinkLabel = nullptr;
     QgsFileDropEdit *mLineEdit = nullptr;
+    QToolButton *mLinkEditButton = nullptr;
     QToolButton *mFileWidgetButton = nullptr;
     QHBoxLayout *mLayout = nullptr;
 


### PR DESCRIPTION
In a form, links can now be edited (when widget is not readonly) in the file widget.

![ezgif-6-c4737ab9cb1f](https://user-images.githubusercontent.com/127259/81038564-bcb64a80-8ea6-11ea-8289-46340dee9a88.gif)


Sponsored by the QGIS Swiss user group