### PR TITLE
Avoid long loading in attributetable on model change

### DIFF
--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -321,22 +321,22 @@ void QgsAttributeTableFilterModel::setFilterMode( FilterMode filterMode )
     if ( filterMode == ShowVisible )
     {
       connect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
-      connect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
+      connect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::reloadVisible );
       generateListOfVisibleFeatures();
     }
     else
     {
       disconnect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
-      disconnect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
+      disconnect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::reloadVisible );
     }
 
     if ( filterMode == ShowFilteredList )
     {
-      connect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::filterFeatures );
+      connect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::filterFeatures );
     }
     else
     {
-      disconnect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::filterFeatures );
+      disconnect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::filterFeatures );
     }
 
     mFilterMode = filterMode;

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -322,6 +322,7 @@ void QgsAttributeTableFilterModel::setFilterMode( FilterMode filterMode )
     {
       connect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
       connect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::reloadVisible );
+      //featureDeleted is handled over selectionChanged
       generateListOfVisibleFeatures();
     }
     else
@@ -333,6 +334,7 @@ void QgsAttributeTableFilterModel::setFilterMode( FilterMode filterMode )
     if ( filterMode == ShowFilteredList )
     {
       connect( layer(), &QgsVectorLayer::featureAdded, this, &QgsAttributeTableFilterModel::filterFeatures );
+      //featureDeleted is handled over selectionChanged
     }
     else
     {


### PR DESCRIPTION
This is a minimal changeset to fix #35927 on the backport branches.

The connection from `dataChanged` to `reloadVisible` and `filterFeatures` leaded to very long loading times. It's improved in this master PR #36188.

This here replaces the signal for `reloadVisible` and `filterFeatures` with `featureAdded` of the vector layer. The implementation, that leaded to issues (connecting `dataChanged`) has been implemented for this case of `featureAdded`. So this fix should still cover the requirement for this change.