### PR TITLE
Test to isolate the unit test causing the segfault in WMS GetPrint

### DIFF
--- a/.ci/travis/linux/scripts/test_blacklist.txt
+++ b/.ci/travis/linux/scripts/test_blacklist.txt
@@ -25,4 +25,4 @@ qgis_layerdefinition
 PyQgsProviderConnectionMssql
 
 # Broken - segfaults on Travis, likely due to a real issue in the server code
-PyQgsServerWMSGetPrint
+# PyQgsServerWMSGetPrint

--- a/tests/src/python/test_qgsserver_wms_getprint.py
+++ b/tests/src/python/test_qgsserver_wms_getprint.py
@@ -35,7 +35,7 @@ import base64
 import subprocess
 
 from test_qgsserver import QgsServerTestBase
-from qgis.core import QgsProject, QgsRenderChecker, QgsMultiRenderChecker, Qt
+from qgis.core import QgsProject, QgsRenderChecker, QgsMultiRenderChecker
 from qgis.server import QgsServerRequest
 from utilities import getExecutablePath, unitTestDataPath
 
@@ -639,56 +639,56 @@ class TestQgsServerWMSGetPrint(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self._img_diff_error(r, h, "WMS_GetPrint_TwoMaps")
 
-    def test_wms_getprint_atlas(self):
-        qs = "?" + "&".join(["%s=%s" % i for i in list({
-            "MAP": urllib.parse.quote(self.projectPath),
-            "SERVICE": "WMS",
-            "VERSION": "1.3.0",
-            "REQUEST": "GetPrint",
-            "TEMPLATE": "layoutA4",
-            "FORMAT": "png",
-            "CRS": "EPSG:3857",
-            "ATLAS_PK": "3",
-            "map0:LAYERS": "Country,Hello",
-        }.items())])
-        r, h = self._result(self._execute_request(qs))
-        self._img_diff_error(r, h, "WMS_GetPrint_Atlas")
+    # def test_wms_getprint_atlas(self):
+    #     qs = "?" + "&".join(["%s=%s" % i for i in list({
+    #         "MAP": urllib.parse.quote(self.projectPath),
+    #         "SERVICE": "WMS",
+    #         "VERSION": "1.3.0",
+    #         "REQUEST": "GetPrint",
+    #         "TEMPLATE": "layoutA4",
+    #         "FORMAT": "png",
+    #         "CRS": "EPSG:3857",
+    #         "ATLAS_PK": "3",
+    #         "map0:LAYERS": "Country,Hello",
+    #     }.items())])
+    #     r, h = self._result(self._execute_request(qs))
+    #     self._img_diff_error(r, h, "WMS_GetPrint_Atlas")
 
-    def test_wms_getprint_atlas_getProjectSettings(self):
-        qs = "?" + "&".join(["%s=%s" % i for i in list({
-            "MAP": urllib.parse.quote(self.projectPath),
-            "SERVICE": "WMS",
-            "VERSION": "1.3.0",
-            "REQUEST": "GetProjectSettings",
-        }.items())])
-        r, h = self._result(self._execute_request(qs))
-        self.assertTrue('atlasEnabled="1"' in str(r))
-        self.assertTrue('<PrimaryKeyAttribute>' in str(r))
+    # def test_wms_getprint_atlas_getProjectSettings(self):
+    #     qs = "?" + "&".join(["%s=%s" % i for i in list({
+    #         "MAP": urllib.parse.quote(self.projectPath),
+    #         "SERVICE": "WMS",
+    #         "VERSION": "1.3.0",
+    #         "REQUEST": "GetProjectSettings",
+    #     }.items())])
+    #     r, h = self._result(self._execute_request(qs))
+    #     self.assertTrue('atlasEnabled="1"' in str(r))
+    #     self.assertTrue('<PrimaryKeyAttribute>' in str(r))
 
-    @unittest.skipIf(os.environ.get('TRAVIS', '') == 'true',
-                     'Can\'t rely on external resources for continuous integration')
-    def test_wms_getprint_external(self):
-        qs = "?" + "&".join(["%s=%s" % i for i in list({
-            "MAP": urllib.parse.quote(self.projectPath),
-            "SERVICE": "WMS",
-            "VERSION": "1.1.1",
-            "REQUEST": "GetPrint",
-            "TEMPLATE": "layoutA4",
-            "map0:EXTENT": "-90,-180,90,180",
-            "map0:LAYERS": "EXTERNAL_WMS:landsat",
-            "landsat:layers": "GEBCO_LATEST",
-            "landsat:dpiMode": "7",
-            "landsat:url": "https://www.gebco.net/data_and_products/gebco_web_services/web_map_service/mapserv",
-            "landsat:crs": "EPSG:4326",
-            "landsat:styles": "default",
-            "landsat:format": "image/jpeg",
-            "landsat:bbox": "-90,-180,90,180",
-            "landsat:version": "1.3.0",
-            "CRS": "EPSG:4326"
-        }.items())])
+    # @unittest.skipIf(os.environ.get('TRAVIS', '') == 'true',
+    #                  'Can\'t rely on external resources for continuous integration')
+    # def test_wms_getprint_external(self):
+    #     qs = "?" + "&".join(["%s=%s" % i for i in list({
+    #         "MAP": urllib.parse.quote(self.projectPath),
+    #         "SERVICE": "WMS",
+    #         "VERSION": "1.1.1",
+    #         "REQUEST": "GetPrint",
+    #         "TEMPLATE": "layoutA4",
+    #         "map0:EXTENT": "-90,-180,90,180",
+    #         "map0:LAYERS": "EXTERNAL_WMS:landsat",
+    #         "landsat:layers": "GEBCO_LATEST",
+    #         "landsat:dpiMode": "7",
+    #         "landsat:url": "https://www.gebco.net/data_and_products/gebco_web_services/web_map_service/mapserv",
+    #         "landsat:crs": "EPSG:4326",
+    #         "landsat:styles": "default",
+    #         "landsat:format": "image/jpeg",
+    #         "landsat:bbox": "-90,-180,90,180",
+    #         "landsat:version": "1.3.0",
+    #         "CRS": "EPSG:4326"
+    #     }.items())])
 
-        r, h = self._result(self._execute_request(qs))
-        self._img_diff_error(r, h, "WMS_GetPrint_External")
+    #     r, h = self._result(self._execute_request(qs))
+    #     self._img_diff_error(r, h, "WMS_GetPrint_External")
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsserver_wms_getprint.py
+++ b/tests/src/python/test_qgsserver_wms_getprint.py
@@ -619,6 +619,7 @@ class TestQgsServerWMSGetPrint(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self._img_diff_error(r, h, "WMS_GetPrint_LabelRemoved")
 
+    @unittest.skipIf(os.environ.get('TRAVIS', '') == 'true', 'Flaky test')
     def test_wms_getprint_two_maps(self):
         """Test map0 and map1 apply to the correct maps"""
         qs = "?" + "&".join(["%s=%s" % i for i in list({
@@ -639,56 +640,58 @@ class TestQgsServerWMSGetPrint(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self._img_diff_error(r, h, "WMS_GetPrint_TwoMaps")
 
-    # def test_wms_getprint_atlas(self):
-    #     qs = "?" + "&".join(["%s=%s" % i for i in list({
-    #         "MAP": urllib.parse.quote(self.projectPath),
-    #         "SERVICE": "WMS",
-    #         "VERSION": "1.3.0",
-    #         "REQUEST": "GetPrint",
-    #         "TEMPLATE": "layoutA4",
-    #         "FORMAT": "png",
-    #         "CRS": "EPSG:3857",
-    #         "ATLAS_PK": "3",
-    #         "map0:LAYERS": "Country,Hello",
-    #     }.items())])
-    #     r, h = self._result(self._execute_request(qs))
-    #     self._img_diff_error(r, h, "WMS_GetPrint_Atlas")
+    @unittest.skipIf(os.environ.get('TRAVIS', '') == 'true', 'Flaky test')
+    def test_wms_getprint_atlas(self):
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WMS",
+            "VERSION": "1.3.0",
+            "REQUEST": "GetPrint",
+            "TEMPLATE": "layoutA4",
+            "FORMAT": "png",
+            "CRS": "EPSG:3857",
+            "ATLAS_PK": "3",
+            "map0:LAYERS": "Country,Hello",
+        }.items())])
+        r, h = self._result(self._execute_request(qs))
+        self._img_diff_error(r, h, "WMS_GetPrint_Atlas")
 
-    # def test_wms_getprint_atlas_getProjectSettings(self):
-    #     qs = "?" + "&".join(["%s=%s" % i for i in list({
-    #         "MAP": urllib.parse.quote(self.projectPath),
-    #         "SERVICE": "WMS",
-    #         "VERSION": "1.3.0",
-    #         "REQUEST": "GetProjectSettings",
-    #     }.items())])
-    #     r, h = self._result(self._execute_request(qs))
-    #     self.assertTrue('atlasEnabled="1"' in str(r))
-    #     self.assertTrue('<PrimaryKeyAttribute>' in str(r))
+    @unittest.skipIf(os.environ.get('TRAVIS', '') == 'true', 'Flaky test')
+    def test_wms_getprint_atlas_getProjectSettings(self):
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WMS",
+            "VERSION": "1.3.0",
+            "REQUEST": "GetProjectSettings",
+        }.items())])
+        r, h = self._result(self._execute_request(qs))
+        self.assertTrue('atlasEnabled="1"' in str(r))
+        self.assertTrue('<PrimaryKeyAttribute>' in str(r))
 
-    # @unittest.skipIf(os.environ.get('TRAVIS', '') == 'true',
-    #                  'Can\'t rely on external resources for continuous integration')
-    # def test_wms_getprint_external(self):
-    #     qs = "?" + "&".join(["%s=%s" % i for i in list({
-    #         "MAP": urllib.parse.quote(self.projectPath),
-    #         "SERVICE": "WMS",
-    #         "VERSION": "1.1.1",
-    #         "REQUEST": "GetPrint",
-    #         "TEMPLATE": "layoutA4",
-    #         "map0:EXTENT": "-90,-180,90,180",
-    #         "map0:LAYERS": "EXTERNAL_WMS:landsat",
-    #         "landsat:layers": "GEBCO_LATEST",
-    #         "landsat:dpiMode": "7",
-    #         "landsat:url": "https://www.gebco.net/data_and_products/gebco_web_services/web_map_service/mapserv",
-    #         "landsat:crs": "EPSG:4326",
-    #         "landsat:styles": "default",
-    #         "landsat:format": "image/jpeg",
-    #         "landsat:bbox": "-90,-180,90,180",
-    #         "landsat:version": "1.3.0",
-    #         "CRS": "EPSG:4326"
-    #     }.items())])
+    @unittest.skipIf(os.environ.get('TRAVIS', '') == 'true',
+                     'Can\'t rely on external resources for continuous integration')
+    def test_wms_getprint_external(self):
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WMS",
+            "VERSION": "1.1.1",
+            "REQUEST": "GetPrint",
+            "TEMPLATE": "layoutA4",
+            "map0:EXTENT": "-90,-180,90,180",
+            "map0:LAYERS": "EXTERNAL_WMS:landsat",
+            "landsat:layers": "GEBCO_LATEST",
+            "landsat:dpiMode": "7",
+            "landsat:url": "https://www.gebco.net/data_and_products/gebco_web_services/web_map_service/mapserv",
+            "landsat:crs": "EPSG:4326",
+            "landsat:styles": "default",
+            "landsat:format": "image/jpeg",
+            "landsat:bbox": "-90,-180,90,180",
+            "landsat:version": "1.3.0",
+            "CRS": "EPSG:4326"
+        }.items())])
 
-    #     r, h = self._result(self._execute_request(qs))
-    #     self._img_diff_error(r, h, "WMS_GetPrint_External")
+        r, h = self._result(self._execute_request(qs))
+        self._img_diff_error(r, h, "WMS_GetPrint_External")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

Since I cannot replicate the segfault locally, I'd like to find which specific test is causing the segmentation fault before investigating more.

It seems to be related to `test_wms_getprint_two_maps` but I'd like to be sure.

- `basic` and `style`: 5x
- `basic`, `style`, `group` and `legend`: 5x 
- `basic`, `style`, `group`, `legend`, `srs`, `scale`, `grid` and `rotation`: 5x
- `basic`, `style`, `group`, `legend`, `srs`, `scale`, `grid`, `rotation`, `opacity`, `selection`, `opacity_post` and `hilight`: 5x
- `basic`, `style`, `group`, `legend`, `srs`, `scale`, `grid`, `rotation`, `opacity`, `selection`, `opacity_post`, `hilight`, `label`: 5x
- `basic`, `style`, `group`, `legend`, `srs`, `scale`, `grid`, `rotation`, `opacity`, `selection`, `opacity_post`, `hilight`, `label` and `atlas`: 5x success and  5x fail
- `basic`, `style`, `group`, `legend`, `srs`, `scale`, `grid`, `rotation`, `opacity`, `selection`, `opacity_post`, `hilight`, `label`, `atlas` and `two_maps`: 

Suspicious tests:

`atlas`: 5x (no fail when no other tests)
