### PR TITLE
enhance sorting capabilities in attribute table list/form view

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -675,6 +675,7 @@
         <file>themes/default/multieditSameValues.svg</file>
         <file>themes/default/locked_repeating.svg</file>
         <file>themes/default/sort.svg</file>
+        <file>themes/default/sort-reverse.svg</file>
         <file>themes/default/styleicons/multibandcolor.svg</file>
         <file>themes/default/styleicons/paletted.svg</file>
         <file>themes/default/styleicons/singlebandgray.svg</file>

--- a/images/themes/default/sort-reverse.svg
+++ b/images/themes/default/sort-reverse.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   sodipodi:docname="sort-reverse.svg"
+   id="svg839"
+   version="1.1"
+   width="16"
+   viewBox="0 0 4.2333333 4.2333335"
+   height="16">
+  <metadata
+     id="metadata845">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs843" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg839"
+     inkscape:window-maximized="0"
+     inkscape:window-y="23"
+     inkscape:window-x="0"
+     inkscape:cy="8"
+     inkscape:cx="8"
+     inkscape:zoom="44.5"
+     showgrid="false"
+     id="namedview841"
+     inkscape:window-height="1012"
+     inkscape:window-width="1759"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path833"
+     style="fill:#6d97c4;fill-rule:evenodd;stroke:#415a75;stroke-width:0.198438;stroke-linecap:round;stroke-linejoin:round"
+     d="M 2.9088665,0.40079901 1.8293909,1.6410334 H 2.602776 L 2.8915153,3.7628679 3.2054438,1.6410334 h 0.7828981 z" />
+  <path
+     id="path835"
+     stroke-width=".19843751"
+     stroke-linejoin="round"
+     stroke-linecap="round"
+     stroke="#a40000"
+     fill="#f79191"
+     d="m1.2400171 1.4925339h-.54129826l-.0854208.2668105h-.3479775l.49723917-1.46451483h.41271749l.4972392 1.46451483h-.3479775l-.084522-.2668105m-.45497826-.271715h.36775916l-.1834298-.58266702-.18432916.58266702" />
+  <path
+     id="path837"
+     stroke-width=".19843751"
+     stroke-linejoin="round"
+     stroke-linecap="round"
+     stroke="#0044a4"
+     fill="#91bbf7"
+     d="m .40469133 2.2147734h1.12845407v.2285545l-.72023241.9505123h.74091331v.285448h-1.16981581v-.2285546l.72023251-.9505123h-.69955167z" />
+</svg>

--- a/python/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
@@ -63,6 +63,10 @@ If ``True`` is specified, a NULL value will be injected
 :param injectNull: state of null value injection
 
 .. versionadded:: 2.9
+
+.. note::
+
+   If set to ``True``, the sort by display expression cannot be used
 %End
 
     bool injectNull();
@@ -139,7 +143,7 @@ Sort this model by its display expression.
 .. versionadded:: 3.2
 %End
 
-    void setSortByDisplayExpression( bool sortByDisplayExpression );
+    void setSortByDisplayExpression( bool sortByDisplayExpression, Qt::SortOrder order = Qt::AscendingOrder );
 %Docstring
 Sort this model by its display expression.
 

--- a/python/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
@@ -62,11 +62,11 @@ If ``True`` is specified, a NULL value will be injected
 
 :param injectNull: state of null value injection
 
-.. versionadded:: 2.9
-
 .. note::
 
    If set to ``True``, the sort by display expression cannot be used
+
+.. versionadded:: 2.9
 %End
 
     bool injectNull();

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -209,9 +209,31 @@ void QgsDualView::columnBoxInit()
     }
   }
 
-  QAction *sortByPreviewExpression = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "sort.svg" ) ), tr( "Sort by preview expression" ), this );
-  connect( sortByPreviewExpression, &QAction::triggered, this, &QgsDualView::sortByPreviewExpression );
-  mFeatureListPreviewButton->addAction( sortByPreviewExpression );
+  QMenu *sortMenu = new QMenu( this );
+  QAction *sortMenuAction = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "sort.svg" ) ), tr( "Sort…" ), this );
+  sortMenuAction->setMenu( sortMenu );
+
+  QAction *sortByPreviewExpressionAsc = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "sort.svg" ) ), tr( "by preview expression (asc)" ), this );
+  connect( sortByPreviewExpressionAsc, &QAction::triggered, this, [ = ]()
+  {
+    mFeatureListModel->setSortByDisplayExpression( true, Qt::AscendingOrder );
+  } );
+  sortMenu->addAction( sortByPreviewExpressionAsc );
+  QAction *sortByPreviewExpressionDesc = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "sort-reverse.svg" ) ), tr( "by preview expression (desc)" ), this );
+  connect( sortByPreviewExpressionDesc, &QAction::triggered, this, [ = ]()
+  {
+    mFeatureListModel->setSortByDisplayExpression( true, Qt::DescendingOrder );
+  } );
+  sortMenu->addAction( sortByPreviewExpressionDesc );
+  QAction *sortByPreviewExpressionCustom = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "mIconExpressionPreview.svg" ) ), tr( "by custom expression" ), this );
+  connect( sortByPreviewExpressionCustom, &QAction::triggered, this, [ = ]()
+  {
+    if ( modifySort() )
+      mFeatureListModel->setSortByDisplayExpression( false );
+  } );
+  sortMenu->addAction( sortByPreviewExpressionCustom );
+
+  mFeatureListPreviewButton->addAction( sortMenuAction );
 
   QAction *separator = new QAction( mFeatureListPreviewButton );
   separator->setSeparator( true );
@@ -820,7 +842,7 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
   connect( organize, &QAction::triggered, this, &QgsDualView::organizeColumns );
   mHorizontalHeaderMenu->addAction( organize );
   QAction *sort = new QAction( tr( "&Sort…" ), mHorizontalHeaderMenu );
-  connect( sort, &QAction::triggered, this, &QgsDualView::modifySort );
+  connect( sort, &QAction::triggered, this, [ = ]() {modifySort();} );
   mHorizontalHeaderMenu->addAction( sort );
 
   mHorizontalHeaderMenu->popup( mTableView->horizontalHeader()->mapToGlobal( point ) );
@@ -895,10 +917,10 @@ void QgsDualView::autosizeColumn()
   mTableView->resizeColumnToContents( col );
 }
 
-void QgsDualView::modifySort()
+bool QgsDualView::modifySort()
 {
   if ( !mLayer )
-    return;
+    return false;
 
   QgsAttributeTableConfig config = mConfig;
 
@@ -946,7 +968,13 @@ void QgsDualView::modifySort()
     }
 
     setAttributeTableConfig( config );
+    return true;
   }
+  else
+  {
+    return false;
+  }
+
 }
 
 void QgsDualView::zoomToCurrentFeature()
@@ -1023,16 +1051,6 @@ void QgsDualView::onSortColumnChanged()
     cfg.setSortOrder( mFilterModel->sortOrder() );
     setAttributeTableConfig( cfg );
   }
-}
-
-void QgsDualView::sortByPreviewExpression()
-{
-  Qt::SortOrder sortOrder = Qt::AscendingOrder;
-  if ( mFeatureListView->displayExpression() == sortExpression() )
-  {
-    sortOrder = mConfig.sortOrder() == Qt::AscendingOrder ? Qt::DescendingOrder : Qt::AscendingOrder;
-  }
-  setSortExpression( mFeatureListView->displayExpression(), sortOrder );
 }
 
 void QgsDualView::updateSelectedFeatures()

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -213,19 +213,19 @@ void QgsDualView::columnBoxInit()
   QAction *sortMenuAction = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "sort.svg" ) ), tr( "Sort…" ), this );
   sortMenuAction->setMenu( sortMenu );
 
-  QAction *sortByPreviewExpressionAsc = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "sort.svg" ) ), tr( "by preview expression (asc)" ), this );
+  QAction *sortByPreviewExpressionAsc = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "sort.svg" ) ), tr( "By Preview Expression (ascending)" ), this );
   connect( sortByPreviewExpressionAsc, &QAction::triggered, this, [ = ]()
   {
     mFeatureListModel->setSortByDisplayExpression( true, Qt::AscendingOrder );
   } );
   sortMenu->addAction( sortByPreviewExpressionAsc );
-  QAction *sortByPreviewExpressionDesc = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "sort-reverse.svg" ) ), tr( "by preview expression (desc)" ), this );
+  QAction *sortByPreviewExpressionDesc = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "sort-reverse.svg" ) ), tr( "By Preview Expression (descending)" ), this );
   connect( sortByPreviewExpressionDesc, &QAction::triggered, this, [ = ]()
   {
     mFeatureListModel->setSortByDisplayExpression( true, Qt::DescendingOrder );
   } );
   sortMenu->addAction( sortByPreviewExpressionDesc );
-  QAction *sortByPreviewExpressionCustom = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "mIconExpressionPreview.svg" ) ), tr( "by custom expression" ), this );
+  QAction *sortByPreviewExpressionCustom = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "mIconExpressionPreview.svg" ) ), tr( "By Custom Expression" ), this );
   connect( sortByPreviewExpressionCustom, &QAction::triggered, this, [ = ]()
   {
     if ( modifySort() )

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -346,13 +346,9 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
 
     void autosizeColumn();
 
-    void modifySort();
-
     void previewExpressionChanged( const QString &expression );
 
     void onSortColumnChanged();
-
-    void sortByPreviewExpression();
 
     void updateSelectedFeatures();
 
@@ -408,6 +404,10 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     void panOrZoomToFeature( const QgsFeatureIds &featureset );
     //! disable/enable the buttons of the browsing toolbar (feature list view)
     void setBrowsingAutoPanScaleAllowed( bool allowed );
+
+    //! Returns TRUE if the expression dialog has been accepted
+    bool modifySort();
+
 
     QgsFieldConditionalFormatWidget *mConditionalFormatWidget = nullptr;
     QgsAttributeEditorContext mEditorContext;

--- a/src/gui/attributetable/qgsfeaturelistmodel.cpp
+++ b/src/gui/attributetable/qgsfeaturelistmodel.cpp
@@ -281,17 +281,17 @@ bool QgsFeatureListModel::sortByDisplayExpression() const
   return mSortByDisplayExpression;
 }
 
-void QgsFeatureListModel::setSortByDisplayExpression( bool sortByDisplayExpression )
+void QgsFeatureListModel::setSortByDisplayExpression( bool sortByDisplayExpression, Qt::SortOrder order )
 {
   mSortByDisplayExpression = sortByDisplayExpression;
 
   // If we are sorting by display expression, we do not support injected null
-  if ( sortByDisplayExpression )
+  if ( mSortByDisplayExpression )
     setInjectNull( false );
 
   setSortRole( QgsAttributeTableModel::SortRole + 1 );
   setDynamicSortFilter( mSortByDisplayExpression );
-  sort( 0 );
+  sort( 0, order );
 }
 
 QModelIndex QgsFeatureListModel::mapToMaster( const QModelIndex &proxyIndex ) const

--- a/src/gui/attributetable/qgsfeaturelistmodel.h
+++ b/src/gui/attributetable/qgsfeaturelistmodel.h
@@ -80,8 +80,8 @@ class GUI_EXPORT QgsFeatureListModel : public QSortFilterProxyModel, public QgsF
     /**
      * \brief If TRUE is specified, a NULL value will be injected
      * \param injectNull state of null value injection
-     * \since QGIS 2.9
      * \note If set to TRUE, the sort by display expression cannot be used
+     * \since QGIS 2.9
      */
     void setInjectNull( bool injectNull );
 

--- a/src/gui/attributetable/qgsfeaturelistmodel.h
+++ b/src/gui/attributetable/qgsfeaturelistmodel.h
@@ -81,6 +81,7 @@ class GUI_EXPORT QgsFeatureListModel : public QSortFilterProxyModel, public QgsF
      * \brief If TRUE is specified, a NULL value will be injected
      * \param injectNull state of null value injection
      * \since QGIS 2.9
+     * \note If set to TRUE, the sort by display expression cannot be used
      */
     void setInjectNull( bool injectNull );
 
@@ -153,7 +154,7 @@ class GUI_EXPORT QgsFeatureListModel : public QSortFilterProxyModel, public QgsF
      *
      * \since QGIS 3.2
      */
-    void setSortByDisplayExpression( bool sortByDisplayExpression );
+    void setSortByDisplayExpression( bool sortByDisplayExpression, Qt::SortOrder order = Qt::AscendingOrder );
 
   public slots:
 


### PR DESCRIPTION
This improves the possibilities to sort the list of features in the attribute table in form/list mode.
Sorting can now 
* be done in both direction (asc and desc) using the display expression (by using the dynamic filtering of the sort filter proxy model)
* use a custom expression (it actually uses the same sorting than the table mode).

![image](https://user-images.githubusercontent.com/127259/81067121-7977ce00-8ede-11ea-80a6-4081bae81c09.png)

Sponsored by the QGIS Swiss User Group