### PR TITLE
[feature] Snapping also snaps to the currently digitised feature

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -700,6 +700,7 @@
         <file>themes/default/mIconSnappingMiddle.svg</file>
         <file>themes/default/mIconSnappingOnScale.svg</file>
         <file>themes/default/mIconSnappingVertex.svg</file>
+        <file>themes/default/mIconSnappingSelf.svg</file>
         <file>themes/default/mIconSnappingSegment.svg</file>
         <file>themes/default/mIconTopologicalEditing.svg</file>
         <file>themes/default/mIconSnappingIntersection.svg</file>

--- a/images/themes/default/mIconSnappingSelf.svg
+++ b/images/themes/default/mIconSnappingSelf.svg
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="mIconSnappingSelf.svg"
+   id="svg68"
+   version="1.1"
+   width="24"
+   viewBox="0 0 24 24"
+   height="24">
+  <metadata
+     id="metadata74">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs72" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg68"
+     inkscape:window-maximized="0"
+     inkscape:window-y="120"
+     inkscape:window-x="351"
+     inkscape:cy="15.032678"
+     inkscape:cx="21.715662"
+     inkscape:zoom="14.849242"
+     showgrid="false"
+     id="namedview70"
+     inkscape:window-height="1163"
+     inkscape:window-width="1445"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <g
+     id="g66"
+     transform="translate(0.04085775,-7.9316355)"
+     stroke-linecap="round">
+    <path
+       sodipodi:nodetypes="cccc"
+       id="path60"
+       stroke-width="2"
+       stroke-linejoin="round"
+       stroke="#8cbe8c"
+       fill="none"
+       d="M 20.566062,23.218131 4.4877133,14.977485 9.0817013,27.060272 2,30" />
+    <ellipse
+       id="ellipse62"
+       stroke-width="2"
+       stroke="#ffffff"
+       ry="2.5"
+       rx="0.75"
+       fill="#322825"
+       cy="14"
+       cx="-14.75" />
+    <circle
+       id="circle64"
+       stroke-width="1.031"
+       stroke="#8c8c8c"
+       r="2.034729"
+       fill="#bebebe"
+       cy="26.858242"
+       cx="8.6102972" />
+    <circle
+       cx="4.4877133"
+       cy="15.179515"
+       fill="#bebebe"
+       r="2.034729"
+       stroke="#8c8c8c"
+       stroke-width="1.031"
+       id="circle64-5" />
+  </g>
+  <g
+     transform="matrix(1.2651778,0,0,1.2651778,-4.6265242,-0.70591315)"
+     id="g1921">
+    <path
+       sodipodi:nodetypes="cccc"
+       id="path1853"
+       stroke-width="0.35534"
+       stroke-linecap="round"
+       stroke="#505050"
+       overflow="visible"
+       fill="#505050"
+       d="m 19.461512,9.2175166 -2.259422,1.3635194 2.663548,1.925751 z" />
+    <path
+       id="path1855"
+       stroke-width="0.35534"
+       stroke-linecap="round"
+       stroke="#8b7617"
+       overflow="visible"
+       fill="#fce94f"
+       d="M 15.362026,1.9819405 12.900159,3.4032995 16.927342,10.37859 19.38921,8.9572295 15.362026,1.9819405" />
+    <path
+       id="path1861"
+       style="overflow:visible;opacity:0.5;fill:#fce94f;stroke:#8b7617;stroke-width:0.35534;stroke-linecap:round"
+       d="m 13.957675,3.3398245 3.79029,6.564978" />
+    <path
+       id="path1863"
+       stroke-width="0.236893"
+       stroke-linecap="square"
+       stroke="#969696"
+       overflow="visible"
+       fill="#969696"
+       d="M 19.369733,12.033342 17.379211,10.47792 18.198585,10.004853 Z" />
+    <path
+       id="path1865"
+       style="overflow:visible;opacity:0.5;fill:#fce94f;stroke:#8b7617;stroke-width:0.35534;stroke-linecap:round"
+       d="m 14.983453,2.7475915 3.790289,6.564978" />
+    <path
+       id="path1867"
+       stroke-width="0.236893"
+       stroke-linecap="round"
+       stroke="#969696"
+       overflow="visible"
+       fill="#e6e6e6"
+       d="m 15.192412,1.4694895 -2.651241,1.530695 0.516222,0.894122 2.65124,-1.530695 z" />
+    <path
+       id="path1869"
+       stroke-width="0.236893"
+       stroke-linecap="square"
+       stroke="#e6e6e6"
+       overflow="visible"
+       fill="#e6e6e6"
+       d="M 19.70856,11.92433 19.319283,9.3578195 18.499909,9.8308845 Z" />
+  </g>
+</svg>

--- a/python/core/auto_generated/qgscadutils.sip.in
+++ b/python/core/auto_generated/qgscadutils.sip.in
@@ -53,6 +53,8 @@ The QgsCadUtils class provides routines for CAD editing.
 
       QgsPointXY finalMapPoint;
 
+      QgsPointLocator::Match snapMatch;
+
       QgsPointLocator::Match edgeMatch;
 
       double softLockCommonAngle;

--- a/python/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/core/auto_generated/qgssnappingconfig.sip.in
@@ -345,6 +345,20 @@ Returns if the snapping on intersection is enabled
 Sets if the snapping on intersection is enabled
 %End
 
+    bool selfSnapping() const;
+%Docstring
+Returns if self snapping (snapping to the currently digitised feature) is enabled
+
+.. versionadded:: 3.14
+%End
+
+    void setSelfSnapping( bool enabled );
+%Docstring
+Sets if self snapping (snapping to the currently digitised feature) is enabled
+
+.. versionadded:: 3.14
+%End
+
     SIP_PYDICT individualLayerSettings() const;
 %Docstring
 Returns individual snapping settings for all layers

--- a/python/core/auto_generated/qgssnappingutils.sip.in
+++ b/python/core/auto_generated/qgssnappingutils.sip.in
@@ -166,6 +166,42 @@ Set if invisible features must be snapped or not.
 .. versionadded:: 3.2
 %End
 
+    void addExtraSnapLayer( QgsVectorLayer *vl );
+%Docstring
+Supply an extra snapping layer (typically a memory layer).
+This is can be used by map tools to provide additionnal
+snappings points.
+
+.. seealso:: :py:func:`removeExtraSnapLayer`
+
+.. seealso:: :py:func:`getExtraSnapLayers`
+
+.. versionadded:: 3.14
+%End
+
+    void removeExtraSnapLayer( QgsVectorLayer *vl );
+%Docstring
+Removes an extra snapping layer
+
+.. seealso:: :py:func:`addExtraSnapLayer`
+
+.. seealso:: :py:func:`getExtraSnapLayers`
+
+.. versionadded:: 3.14
+%End
+
+    QSet<QgsVectorLayer *> getExtraSnapLayers();
+%Docstring
+Returns the list of extra snapping layers
+
+.. seealso:: :py:func:`addExtraSnapLayer`
+
+.. seealso:: :py:func:`removeExtraSnapLayer`
+
+.. versionadded:: 3.14
+%End
+
+
   public slots:
 
     void setConfig( const QgsSnappingConfig &snappingConfig );

--- a/python/core/auto_generated/qgssnappingutils.sip.in
+++ b/python/core/auto_generated/qgssnappingutils.sip.in
@@ -169,7 +169,7 @@ Set if invisible features must be snapped or not.
     void addExtraSnapLayer( QgsVectorLayer *vl );
 %Docstring
 Supply an extra snapping layer (typically a memory layer).
-This is can be used by map tools to provide additionnal
+This can be used by map tools to provide additionnal
 snappings points.
 
 .. seealso:: :py:func:`removeExtraSnapLayer`

--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -291,7 +291,7 @@ QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas,
   mSelfSnappingAction = new QAction( tr( "Self-snapping" ), this );
   mSelfSnappingAction->setCheckable( true );
   mSelfSnappingAction->setIcon( QIcon( QgsApplication::getThemeIcon( "/mIconSnappingSelf.svg" ) ) );
-  mSelfSnappingAction->setToolTip( tr( "Enable Self-snapping" ) );
+  mSelfSnappingAction->setToolTip( tr( "If self snapping is enabled, snapping will also take the current state of the digitized feature into consideration." ) );
   mSelfSnappingAction->setObjectName( QStringLiteral( "SelfSnappingAction" ) );
   connect( mSelfSnappingAction, &QAction::toggled, this, &QgsSnappingWidget::enableSelfSnapping );
 

--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -287,6 +287,14 @@ QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas,
   tracingMenu->addAction( widgetAction );
   mEnableTracingAction->setMenu( tracingMenu );
 
+  // self-snapping button
+  mSelfSnappingAction = new QAction( tr( "Self-snapping" ), this );
+  mSelfSnappingAction->setCheckable( true );
+  mSelfSnappingAction->setIcon( QIcon( QgsApplication::getThemeIcon( "/mIconSnappingSelf.svg" ) ) );
+  mSelfSnappingAction->setToolTip( tr( "Enable Self-snapping" ) );
+  mSelfSnappingAction->setObjectName( QStringLiteral( "SelfSnappingAction" ) );
+  connect( mSelfSnappingAction, &QAction::toggled, this, &QgsSnappingWidget::enableSelfSnapping );
+
   // layout
   if ( mDisplayMode == ToolBar )
   {
@@ -316,6 +324,7 @@ QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas,
     mAvoidIntersectionsModeAction = tb->addWidget( mAvoidIntersectionsModeButton );
     tb->addAction( mIntersectionSnappingAction );
     tb->addAction( mEnableTracingAction );
+    tb->addAction( mSelfSnappingAction );
   }
   else
   {
@@ -349,6 +358,12 @@ QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas,
     interButton->setDefaultAction( mIntersectionSnappingAction );
     interButton->setToolButtonStyle( Qt::ToolButtonTextBesideIcon );
     layout->addWidget( interButton );
+
+    QToolButton *selfsnapButton = new QToolButton();
+    selfsnapButton->addAction( mSelfSnappingAction );
+    selfsnapButton->setDefaultAction( mSelfSnappingAction );
+    selfsnapButton->setToolButtonStyle( Qt::ToolButtonTextBesideIcon );
+    layout->addWidget( selfsnapButton );
 
     layout->setContentsMargins( 0, 0, 0, 0 );
     layout->setAlignment( Qt::AlignRight );
@@ -488,6 +503,11 @@ void QgsSnappingWidget::projectSnapSettingsChanged()
     mIntersectionSnappingAction->setChecked( config.intersectionSnapping() );
   }
 
+  if ( config.selfSnapping() != mSelfSnappingAction->isChecked() )
+  {
+    mSelfSnappingAction->setChecked( config.selfSnapping() );
+  }
+
   toggleSnappingWidgets( config.enabled() );
 
 }
@@ -552,6 +572,7 @@ void QgsSnappingWidget::toggleSnappingWidgets( bool enabled )
     mAdvancedConfigWidget->setEnabled( enabled );
   }
   mIntersectionSnappingAction->setEnabled( enabled );
+  mSelfSnappingAction->setEnabled( enabled );
   mEnableTracingAction->setEnabled( enabled );
 }
 
@@ -590,6 +611,12 @@ void QgsSnappingWidget::enableTopologicalEditing( bool enabled )
 void QgsSnappingWidget::enableIntersectionSnapping( bool enabled )
 {
   mConfig.setIntersectionSnapping( enabled );
+  mProject->setSnappingConfig( mConfig );
+}
+
+void QgsSnappingWidget::enableSelfSnapping( bool enabled )
+{
+  mConfig.setSelfSnapping( enabled );
   mProject->setSnappingConfig( mConfig );
 }
 

--- a/src/app/qgssnappingwidget.h
+++ b/src/app/qgssnappingwidget.h
@@ -114,6 +114,8 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
 
     void enableIntersectionSnapping( bool enabled );
 
+    void enableSelfSnapping( bool enabled );
+
     void modeButtonTriggered( QAction *action );
     void avoidIntersectionsModeButtonTriggered( QAction *action );
     void typeButtonTriggered( QAction *action );
@@ -172,6 +174,7 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
     QAction *mIntersectionSnappingAction = nullptr;
     QAction *mEnableTracingAction = nullptr;
     QgsDoubleSpinBox *mTracingOffsetSpinBox = nullptr;
+    QAction *mSelfSnappingAction = nullptr;
     QTreeView *mLayerTreeView = nullptr;
     QWidget *mAdvancedConfigWidget = nullptr;
     QgsFloatingWidget *mAdvancedConfigContainer = nullptr;

--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -42,16 +42,19 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
 
   // try to snap to anything
   QgsPointLocator::Match snapMatch = ctx.snappingUtils->snapToMap( originalMapPoint, nullptr, true );
+  res.snapMatch = snapMatch;
   QgsPointXY point = snapMatch.isValid() ? snapMatch.point() : originalMapPoint;
-
-  // try to snap explicitly to a segment - useful for some constraints
   QgsPointXY edgePt0, edgePt1;
-  EdgesOnlyFilter edgesOnlyFilter;
-  QgsPointLocator::Match edgeMatch = ctx.snappingUtils->snapToMap( originalMapPoint, &edgesOnlyFilter, true );
-  if ( edgeMatch.hasEdge() )
-    edgeMatch.edgePoints( edgePt0, edgePt1 );
-
-  res.edgeMatch = edgeMatch;
+  if ( snapMatch.hasEdge() )
+  {
+    snapMatch.edgePoints( edgePt0, edgePt1 );
+    // note : res.edgeMatch should be removed, as we can just check snapMatch.hasEdge()
+    res.edgeMatch = snapMatch;
+  }
+  else
+  {
+    res.edgeMatch = QgsPointLocator::Match();
+  }
 
   QgsPointXY previousPt, penultimatePt;
   if ( ctx.cadPointList.count() >= 2 )
@@ -71,7 +74,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
     {
       point.setX( previousPt.x() + ctx.xConstraint.value );
     }
-    if ( edgeMatch.hasEdge() && !ctx.yConstraint.locked )
+    if ( snapMatch.hasEdge() && !ctx.yConstraint.locked )
     {
       // intersect with snapped segment line at X coordinate
       const double dx = edgePt1.x() - edgePt0.x();
@@ -99,7 +102,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
     {
       point.setY( previousPt.y() + ctx.yConstraint.value );
     }
-    if ( edgeMatch.hasEdge() && !ctx.xConstraint.locked )
+    if ( snapMatch.hasEdge() && !ctx.xConstraint.locked )
     {
       // intersect with snapped segment line at Y coordinate
       const double dy = edgePt1.y() - edgePt0.y();
@@ -224,7 +227,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
       point.setY( previousPt.y() + sina * v );
     }
 
-    if ( edgeMatch.hasEdge() && !ctx.distanceConstraint.locked )
+    if ( snapMatch.hasEdge() && !ctx.distanceConstraint.locked )
     {
       // magnetize to the intersection of the snapped segment and the lockedAngle
 
@@ -287,7 +290,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
                    previousPt.y() + ( point.y() - previousPt.y() ) * vP );
       }
 
-      if ( edgeMatch.hasEdge() && !ctx.angleConstraint.locked )
+      if ( snapMatch.hasEdge() && !ctx.angleConstraint.locked )
       {
         // we will magnietize to the intersection of that segment and the lockedDistance !
         res.valid &= QgsGeometryUtils::lineCircleIntersection( previousPt, ctx.distanceConstraint.value, edgePt0, edgePt1, point );

--- a/src/core/qgscadutils.h
+++ b/src/core/qgscadutils.h
@@ -92,7 +92,10 @@ class CORE_EXPORT QgsCadUtils
       //! map point aligned according to the constraints
       QgsPointXY finalMapPoint;
 
-      //! Snapped point - only valid if actually used for something
+      /**
+       * Snapped point - only valid if actually used for something
+       * \since QGIS 3.14
+       */
       QgsPointLocator::Match snapMatch;
 
       /**

--- a/src/core/qgscadutils.h
+++ b/src/core/qgscadutils.h
@@ -92,7 +92,13 @@ class CORE_EXPORT QgsCadUtils
       //! map point aligned according to the constraints
       QgsPointXY finalMapPoint;
 
-      //! Snapped segment - only valid if actually used for something
+      //! Snapped point - only valid if actually used for something
+      QgsPointLocator::Match snapMatch;
+
+      /**
+       * Snapped segment - only valid if actually used for something
+       * \deprecated will be removed in QGIS 4.0 - use snapMatch instead
+       */
       QgsPointLocator::Match edgeMatch;
 
       //! Angle (in degrees) to which we have soft-locked ourselves (if not set it is -1)

--- a/src/core/qgssnappingconfig.cpp
+++ b/src/core/qgssnappingconfig.cpp
@@ -179,6 +179,7 @@ bool QgsSnappingConfig::operator==( const QgsSnappingConfig &other ) const
          && mTolerance == other.mTolerance
          && mUnits == other.mUnits
          && mIntersectionSnapping == other.mIntersectionSnapping
+         && mSelfSnapping == other.mSelfSnapping
          && mIndividualLayerSettings == other.mIndividualLayerSettings
          && mScaleDependencyMode == other.mScaleDependencyMode
          && mMinimumScale == other.mMinimumScale
@@ -218,6 +219,7 @@ void QgsSnappingConfig::reset()
     mUnits = units;
   }
   mIntersectionSnapping = false;
+  mSelfSnapping = false;
 
   // set advanced config
   if ( mProject )
@@ -343,6 +345,16 @@ void QgsSnappingConfig::setIntersectionSnapping( bool enabled )
   mIntersectionSnapping = enabled;
 }
 
+bool QgsSnappingConfig::selfSnapping() const
+{
+  return mSelfSnapping;
+}
+
+void QgsSnappingConfig::setSelfSnapping( bool enabled )
+{
+  mSelfSnapping = enabled;
+}
+
 QHash<QgsVectorLayer *, QgsSnappingConfig::IndividualLayerSettings> QgsSnappingConfig::individualLayerSettings() const
 {
   return mIndividualLayerSettings;
@@ -459,6 +471,9 @@ void QgsSnappingConfig::readProject( const QDomDocument &doc )
   if ( snapSettingsElem.hasAttribute( QStringLiteral( "intersection-snapping" ) ) )
     mIntersectionSnapping = snapSettingsElem.attribute( QStringLiteral( "intersection-snapping" ) ) == QLatin1String( "1" );
 
+  if ( snapSettingsElem.hasAttribute( QStringLiteral( "self-snapping" ) ) )
+    mSelfSnapping = snapSettingsElem.attribute( QStringLiteral( "self-snapping" ) ) == QLatin1String( "1" );
+
   // do not clear the settings as they must be automatically synchronized with current layers
   QDomNodeList nodes = snapSettingsElem.elementsByTagName( QStringLiteral( "individual-layer-settings" ) );
   if ( nodes.count() )
@@ -504,6 +519,7 @@ void QgsSnappingConfig::writeProject( QDomDocument &doc )
   snapSettingsElem.setAttribute( QStringLiteral( "tolerance" ), mTolerance );
   snapSettingsElem.setAttribute( QStringLiteral( "unit" ), static_cast<int>( mUnits ) );
   snapSettingsElem.setAttribute( QStringLiteral( "intersection-snapping" ), QString::number( mIntersectionSnapping ) );
+  snapSettingsElem.setAttribute( QStringLiteral( "self-snapping" ), QString::number( mSelfSnapping ) );
   snapSettingsElem.setAttribute( QStringLiteral( "scaleDependencyMode" ), QString::number( mScaleDependencyMode ) );
   snapSettingsElem.setAttribute( QStringLiteral( "minScale" ), mMinimumScale );
   snapSettingsElem.setAttribute( QStringLiteral( "maxScale" ), mMaximumScale );

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -335,6 +335,20 @@ class CORE_EXPORT QgsSnappingConfig
     //! Sets if the snapping on intersection is enabled
     void setIntersectionSnapping( bool enabled );
 
+    /**
+     * Returns if self snapping (snapping to the currently digitised feature) is enabled
+     *
+     * \since QGIS 3.14
+     */
+    bool selfSnapping() const;
+
+    /**
+     * Sets if self snapping (snapping to the currently digitised feature) is enabled
+     *
+     * \since QGIS 3.14
+     */
+    void setSelfSnapping( bool enabled );
+
     //! Returns individual snapping settings for all layers
 #ifndef SIP_RUN
     QHash<QgsVectorLayer *, QgsSnappingConfig::IndividualLayerSettings> individualLayerSettings() const;
@@ -458,6 +472,7 @@ class CORE_EXPORT QgsSnappingConfig
     double mMaximumScale = 0.0;
     QgsTolerance::UnitType mUnits = QgsTolerance::ProjectUnits;
     bool mIntersectionSnapping = false;
+    bool mSelfSnapping = false;
 
     QHash<QgsVectorLayer *, IndividualLayerSettings> mIndividualLayerSettings;
 

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -187,7 +187,7 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
 
     /**
      * Supply an extra snapping layer (typically a memory layer).
-     * This is can be used by map tools to provide additionnal
+     * This can be used by map tools to provide additionnal
      * snappings points.
      *
      * \see removeExtraSnapLayer()

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -185,6 +185,48 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
      */
     void setEnableSnappingForInvisibleFeature( bool enable );
 
+    /**
+     * Supply an extra snapping layer (typically a memory layer).
+     * This is can be used by map tools to provide additionnal
+     * snappings points.
+     *
+     * \see removeExtraSnapLayer()
+     * \see getExtraSnapLayers()
+     *
+     * \since QGIS 3.14
+     */
+    void addExtraSnapLayer( QgsVectorLayer *vl )
+    {
+      mExtraSnapLayers.insert( vl );
+    }
+
+    /**
+     * Removes an extra snapping layer
+     *
+     * \see addExtraSnapLayer()
+     * \see getExtraSnapLayers()
+     *
+     * \since QGIS 3.14
+     */
+    void removeExtraSnapLayer( QgsVectorLayer *vl )
+    {
+      mExtraSnapLayers.remove( vl );
+    }
+
+    /**
+     * Returns the list of extra snapping layers
+     *
+     * \see addExtraSnapLayer()
+     * \see removeExtraSnapLayer()
+     *
+     * \since QGIS 3.14
+     */
+    QSet<QgsVectorLayer *> getExtraSnapLayers()
+    {
+      return mExtraSnapLayers;
+    }
+
+
   public slots:
 
     /**
@@ -257,6 +299,8 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
     LocatorsMap mTemporaryLocators;
     //! list of layer IDs that are too large to be indexed (hybrid strategy will use temporary locators for those)
     QSet<QString> mHybridNonindexableLayers;
+    //! list of additionnal snapping layers
+    QSet<QgsVectorLayer *> mExtraSnapLayers;
 
     /**
      * a record for each layer seen:

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -648,10 +648,10 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
   bool res = output.valid;
   QgsPointXY point = output.finalMapPoint;
   mSnappedSegment.clear();
-  if ( output.edgeMatch.hasEdge() )
+  if ( output.snapMatch.hasEdge() )
   {
     QgsPointXY edgePt0, edgePt1;
-    output.edgeMatch.edgePoints( edgePt0, edgePt1 );
+    output.snapMatch.edgePoints( edgePt0, edgePt1 );
     mSnappedSegment << edgePt0 << edgePt1;
   }
   if ( mAngleConstraint->lockMode() != CadConstraint::HardLock )

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -667,14 +667,9 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
     }
   }
 
-  // set the point coordinates in the map event
-  e->setMapPoint( point );
-
-  mSnapMatch = context.snappingUtils->snapToMap( point, nullptr, true );
-
-  if ( mSnapMatch.isValid() )
+  if ( output.snapMatch.isValid() )
   {
-    mSnapIndicator->setMatch( mSnapMatch );
+    mSnapIndicator->setMatch( output.snapMatch );
     mSnapIndicator->setVisible( true );
   }
   else
@@ -690,6 +685,8 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
    * when the snapped point corresponds to the constrained point or on an edge
    * if the topological editing is activated.
    */
+  e->setMapPoint( point );
+  mSnapMatch = context.snappingUtils->snapToMap( point, nullptr, true );
   if ( ( mSnapMatch.hasVertex() && ( point == mSnapMatch.point() ) ) || ( mSnapMatch.hasEdge() && QgsProject::instance()->topologicalEditing() ) )
   {
     e->snapPoint();

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -72,6 +72,7 @@ QgsMapToolCapture::~QgsMapToolCapture()
     mValidator->deleteLater();
     mValidator = nullptr;
   }
+  mCanvas->snappingUtils()->removeExtraSnapLayer( mExtraSnapLayer );
   mExtraSnapLayer->deleteLater();
   mExtraSnapLayer = nullptr;
 }

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -51,6 +51,15 @@ QgsMapToolCapture::QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizin
   connect( canvas, &QgsMapCanvas::currentLayerChanged,
            this, &QgsMapToolCapture::currentLayerChanged );
 
+  mExtraSnapLayer = new QgsVectorLayer( "LineString?crs=0", "extra snap", "memory" );
+  mExtraSnapLayer->startEditing();
+  QgsFeature f;
+  mExtraSnapLayer->addFeature( f );
+  mExtraSnapFeatureId = f.id();
+
+  connect( QgsProject::instance(), &QgsProject::snappingConfigChanged,
+           this, &QgsMapToolCapture::updateExtraSnapLayer );
+
   currentLayerChanged( canvas->currentLayer() );
 }
 
@@ -63,6 +72,8 @@ QgsMapToolCapture::~QgsMapToolCapture()
     mValidator->deleteLater();
     mValidator = nullptr;
   }
+  mExtraSnapLayer->deleteLater();
+  mExtraSnapLayer = nullptr;
 }
 
 QgsMapToolCapture::Capabilities QgsMapToolCapture::capabilities() const
@@ -75,6 +86,7 @@ void QgsMapToolCapture::activate()
   if ( mTempRubberBand )
     mTempRubberBand->show();
 
+  mCanvas->snappingUtils()->addExtraSnapLayer( mExtraSnapLayer );
   QgsMapToolAdvancedDigitizing::activate();
 }
 
@@ -85,6 +97,7 @@ void QgsMapToolCapture::deactivate()
 
   mSnapIndicator->setMatch( QgsPointLocator::Match() );
 
+  mCanvas->snappingUtils()->removeExtraSnapLayer( mExtraSnapLayer );
   QgsMapToolAdvancedDigitizing::deactivate();
 }
 
@@ -513,6 +526,7 @@ int QgsMapToolCapture::addVertex( const QgsPointXY &point, const QgsPointLocator
     // ordinary digitizing
     mRubberBand->addPoint( point );
     mCaptureCurve.addVertex( layerPoint );
+    updateExtraSnapLayer();
     mSnappingMatches.append( match );
   }
 
@@ -574,6 +588,7 @@ int QgsMapToolCapture::addCurve( QgsCurve *c )
     c->transform( ct, QgsCoordinateTransform::ReverseTransform );
   }
   mCaptureCurve.addCurve( c );
+  updateExtraSnapLayer();
   for ( int i = 0; i < c->length(); ++i )
     mSnappingMatches.append( QgsPointLocator::Match() );
 
@@ -583,6 +598,7 @@ int QgsMapToolCapture::addCurve( QgsCurve *c )
 void QgsMapToolCapture::clearCurve()
 {
   mCaptureCurve.clear();
+  updateExtraSnapLayer();
 }
 
 QList<QgsPointLocator::Match> QgsMapToolCapture::snappingMatches() const
@@ -627,6 +643,7 @@ void QgsMapToolCapture::undo()
     vertexToRemove.vertex = size() - 1;
     mCaptureCurve.deleteVertex( vertexToRemove );
     mSnappingMatches.removeAt( vertexToRemove.vertex );
+    updateExtraSnapLayer();
 
     mCadDockWidget->removePreviousPoint();
 
@@ -676,6 +693,7 @@ void QgsMapToolCapture::stopCapturing()
 
   mCapturing = false;
   mCaptureCurve.clear();
+  updateExtraSnapLayer();
   mSnappingMatches.clear();
   if ( currentVectorLayer() )
     currentVectorLayer()->triggerRepaint();
@@ -695,6 +713,7 @@ void QgsMapToolCapture::clean()
 void QgsMapToolCapture::closePolygon()
 {
   mCaptureCurve.close();
+  updateExtraSnapLayer();
 }
 
 void QgsMapToolCapture::validateGeometry()
@@ -795,6 +814,7 @@ void QgsMapToolCapture::setPoints( const QVector<QgsPointXY> &pointList )
   QgsLineString *line = new QgsLineString( pointList );
   mCaptureCurve.clear();
   mCaptureCurve.addCurve( line );
+  updateExtraSnapLayer();
   mSnappingMatches.clear();
   for ( int i = 0; i < line->length(); ++i )
     mSnappingMatches.append( QgsPointLocator::Match() );
@@ -805,6 +825,7 @@ void QgsMapToolCapture::setPoints( const QgsPointSequence &pointList )
   QgsLineString *line = new QgsLineString( pointList );
   mCaptureCurve.clear();
   mCaptureCurve.addCurve( line );
+  updateExtraSnapLayer();
   mSnappingMatches.clear();
   for ( int i = 0; i < line->length(); ++i )
     mSnappingMatches.append( QgsPointLocator::Match() );
@@ -867,4 +888,20 @@ QgsPoint QgsMapToolCapture::mapPoint( const QgsMapMouseEvent &e ) const
   }
 
   return newPoint;
+}
+
+void QgsMapToolCapture::updateExtraSnapLayer()
+{
+  if ( canvas()->snappingUtils()->config().selfSnapping() && mCanvas->currentLayer() )
+  {
+    // the current layer may have changed
+    mExtraSnapLayer->setCrs( mCanvas->currentLayer()->crs() );
+    QgsGeometry geom = QgsGeometry( mCaptureCurve.clone() );
+    mExtraSnapLayer->changeGeometry( mExtraSnapFeatureId, geom );
+  }
+  else
+  {
+    QgsGeometry geom;
+    mExtraSnapLayer->changeGeometry( mExtraSnapFeatureId, geom );
+  }
 }

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -22,6 +22,7 @@
 #include "qgscompoundcurve.h"
 #include "qgsgeometry.h"
 #include "qobjectuniqueptr.h"
+#include "qgssnappingutils.h"
 
 #include <QPoint>
 #include <QList>
@@ -132,6 +133,8 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
   private slots:
     void addError( const QgsGeometry::Error &error );
     void currentLayerChanged( QgsMapLayer *layer );
+    //! Update the extra snap layer, this should be called whenever the capturecurve changes
+    void updateExtraSnapLayer();
 
   protected:
 
@@ -311,6 +314,11 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     QgsGeometryValidator *mValidator = nullptr;
     QList< QgsGeometry::Error > mGeomErrors;
     QList< QgsVertexMarker * > mGeomErrorMarkers;
+
+    //! A layer containing the current capture curve to provide additionnal snapping
+    QgsVectorLayer *mExtraSnapLayer = nullptr;
+    //! The feature in that layer (for updating)
+    QgsFeatureId mExtraSnapFeatureId;
 
     bool mCaptureModeFromLayer = false;
 


### PR DESCRIPTION
Snapping now also snaps to the currently digitised feature (a.k.a. rubberband).

This opens some really nice cad-like editing abilities, such as closing features at 90° angle or precisely align segments inside a feature (for U or T shapes).  It's very efficient once one is used to the alt+a shortcut to lock the angle.

![pr_self-snapping](https://user-images.githubusercontent.com/1894106/81065380-a37bc100-8edb-11ea-8aed-6fd52d843a26.gif)

I implemented it in QgsMapCanvasSnappingUtils, where the new logic is triggered if the active map tool is a QgsMapToolCapture, so that it should work with all the advanced digitizing tools as well.

As with the other PR, I open this as a draft for feedback before going too far in a possibly wrong direction. I haven't looked into tests yet, will see how it's done for regular snapping.

UX question : currently, this is always enabled. Are there scenarios where self-snapping would be an annoyance ? It would be nice if we could avoid one more snap setting.

Implementation question : I'm not sure this is the best approach, as I had to re-implement some logic (e.g. snapping on segments, and priority of vertices over edges). But the existing classes (QgsPointLocator) seems to only work with a layer instance, which we don't have in this case. So any suggestion is welcome !

Cheers



