### PR TITLE
Re-center the map when zooming with active scale lock

### DIFF
--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -157,11 +157,12 @@ Default value is 96
 Sets DPI used for conversion between real world units (e.g. mm) and pixels
 %End
 
-    void setMagnificationFactor( double factor );
+    void setMagnificationFactor( double factor, const QgsPointXY *center = 0 );
 %Docstring
 Set the magnification factor.
 
 :param factor: the factor of magnification
+:param center: optional point to re-center the map
 
 .. seealso:: :py:func:`magnificationFactor`
 

--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -863,11 +863,14 @@ called to read map canvas settings from project
 called to write map canvas settings to project
 %End
 
-    void setMagnificationFactor( double factor );
+    void setMagnificationFactor( double factor, const QgsPointXY *center = 0 );
 %Docstring
 Sets the factor of magnification to apply to the map canvas. Indeed, we
 increase/decrease the DPI of the map settings according to this factor
 in order to render marker point, labels, ... bigger.
+
+:param factor: The factor of magnification
+:param center: Optional point to re-center the map
 
 .. versionadded:: 2.16
 %End

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3683,7 +3683,7 @@ void QgisApp::createStatusBar()
   mMagnifierWidget->setObjectName( QStringLiteral( "mMagnifierWidget" ) );
   mMagnifierWidget->setFont( statusBarFont );
   connect( mMapCanvas, &QgsMapCanvas::magnificationChanged, mMagnifierWidget, &QgsStatusBarMagnifierWidget::updateMagnification );
-  connect( mMagnifierWidget, &QgsStatusBarMagnifierWidget::magnificationChanged, mMapCanvas, &QgsMapCanvas::setMagnificationFactor );
+  connect( mMagnifierWidget, &QgsStatusBarMagnifierWidget::magnificationChanged, mMapCanvas, [ = ]( double factor ) { mMapCanvas->setMagnificationFactor( factor ); } );
   connect( mMagnifierWidget, &QgsStatusBarMagnifierWidget::scaleLockChanged, mMapCanvas, &QgsMapCanvas::setScaleLocked );
   connect( mMagnifierWidget, &QgsStatusBarMagnifierWidget::scaleLockChanged, mScaleWidget, &QgsStatusBarScaleWidget::setLocked );
   mMagnifierWidget->updateMagnification( QSettings().value( QStringLiteral( "/qgis/magnifier_factor_default" ), 1.0 ).toDouble() );

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -45,7 +45,7 @@ QgsMapSettings::QgsMapSettings()
   updateDerived();
 }
 
-void QgsMapSettings::setMagnificationFactor( double factor )
+void QgsMapSettings::setMagnificationFactor( double factor, const QgsPointXY *center )
 {
   double ratio = mMagnificationFactor / factor;
 
@@ -55,7 +55,7 @@ void QgsMapSettings::setMagnificationFactor( double factor )
   setRotation( 0.0 );
 
   QgsRectangle ext = visibleExtent();
-  ext.scale( ratio );
+  ext.scale( ratio, center );
 
   mRotation = rot;
   mExtent = ext;

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -172,10 +172,11 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
     /**
      * Set the magnification factor.
      * \param factor the factor of magnification
+     * \param center optional point to re-center the map
      * \see magnificationFactor()
      * \since QGIS 2.16
      */
-    void setMagnificationFactor( double factor );
+    void setMagnificationFactor( double factor, const QgsPointXY *center = nullptr );
 
     /**
      * Returns the magnification factor.

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -261,7 +261,7 @@ QgsMapCanvas::~QgsMapCanvas()
   delete mLabelingResults;
 }
 
-void QgsMapCanvas::setMagnificationFactor( double factor )
+void QgsMapCanvas::setMagnificationFactor( double factor, const QgsPointXY *center )
 {
   // do not go higher or lower than min max magnification ratio
   double magnifierMin = QgsGuiUtils::CANVAS_MAGNIFICATION_MIN;
@@ -271,7 +271,7 @@ void QgsMapCanvas::setMagnificationFactor( double factor )
   // the magnifier widget is in integer percent
   if ( !qgsDoubleNear( factor, mSettings.magnificationFactor(), 0.01 ) )
   {
-    mSettings.setMagnificationFactor( factor );
+    mSettings.setMagnificationFactor( factor, center );
     refresh();
     emit magnificationChanged( factor );
   }
@@ -1749,14 +1749,15 @@ void QgsMapCanvas::zoomWithCenter( int x, int y, bool zoomIn )
 {
   double scaleFactor = ( zoomIn ? zoomInFactor() : zoomOutFactor() );
 
+  // transform the mouse pos to map coordinates
+  QgsPointXY center  = getCoordinateTransform()->toMapCoordinates( x, y );
+
   if ( mScaleLocked )
   {
-    setMagnificationFactor( mapSettings().magnificationFactor() / scaleFactor );
+    setMagnificationFactor( mapSettings().magnificationFactor() / scaleFactor, &center );
   }
   else
   {
-    // transform the mouse pos to map coordinates
-    QgsPointXY center  = getCoordinateTransform()->toMapCoordinates( x, y );
     QgsRectangle r = mapSettings().visibleExtent();
     r.scale( scaleFactor, &center );
     setExtent( r, true );
@@ -2326,7 +2327,7 @@ void QgsMapCanvas::zoomByFactor( double scaleFactor, const QgsPointXY *center, b
   if ( mScaleLocked && !ignoreScaleLock )
   {
     // zoom map to mouse cursor by magnifying
-    setMagnificationFactor( mapSettings().magnificationFactor() / scaleFactor );
+    setMagnificationFactor( mapSettings().magnificationFactor() / scaleFactor, center );
   }
   else
   {

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -783,9 +783,11 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
      * Sets the factor of magnification to apply to the map canvas. Indeed, we
      * increase/decrease the DPI of the map settings according to this factor
      * in order to render marker point, labels, ... bigger.
+     * \param factor The factor of magnification
+     * \param center Optional point to re-center the map
      * \since QGIS 2.16
      */
-    void setMagnificationFactor( double factor );
+    void setMagnificationFactor( double factor, const QgsPointXY *center = nullptr );
 
     /**
      * Lock the scale, so zooming can be performed using magnication


### PR DESCRIPTION
## Description

When zooming with the mouse wheel or the Zoom map tool while the scale is locked the zoom is not relative to the mouse / zoom box position, but relative to the center of the screen (see #30023).

This PR fixes this behavior by adding a new optional `center` argument to the 
`QgsMapSettings::setMagnificationFactor` and `QgsMapCanvas::setMagnificationFactor` functions, which is then used to scale the extent rectangle.
