### PR TITLE
Fixed dropping PostgreSQL materialized views.

### DIFF
--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -59,7 +59,7 @@ bool QgsPostgresUtils::deleteLayer( const QString &uri, QString &errCause )
   QString type = resViewCheck.PQgetvalue( 0, 0 );
   if ( type == QLatin1String( "v" ) || type == QLatin1String( "m" ) )
   {
-    QString sql = QString( "DROP VIEW %1" ).arg( schemaTableName );
+    QString sql = QString( "DROP %1VIEW %2" ).arg( type == QLatin1String( "m" ) ? "MATERIALIZED " : QString(), schemaTableName );
     QgsPostgresResult result( conn->PQexec( sql ) );
     if ( result.PQresultStatus() != PGRES_COMMAND_OK )
     {

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -59,7 +59,7 @@ bool QgsPostgresUtils::deleteLayer( const QString &uri, QString &errCause )
   QString type = resViewCheck.PQgetvalue( 0, 0 );
   if ( type == QLatin1String( "v" ) || type == QLatin1String( "m" ) )
   {
-    QString sql = QString( "DROP %1VIEW %2" ).arg( type == QLatin1String( "m" ) ? "MATERIALIZED " : QString(), schemaTableName );
+    QString sql = QStringLiteral( "DROP %1VIEW %2" ).arg( type == QLatin1String( "m" ) ? QStringLiteral( "MATERIALIZED " ) : QString(), schemaTableName );
     QgsPostgresResult result( conn->PQexec( sql ) );
     if ( result.PQresultStatus() != PGRES_COMMAND_OK )
     {


### PR DESCRIPTION
By default, the PostgreSQL provider allows the user to drop database
objects from the Browser tree; however, the PostgreSQL syntax for
dropping materialized views is different from dropping ordinary views.
This fixes it, and adds the keyword "MATERIALIZED" accordingly.

Fixes #36164

There is no unit test, as this is a purely interactive action by the user:
![image](https://user-images.githubusercontent.com/25933044/81135482-c2f00980-8f2e-11ea-96fb-4eaa2a806971.png)

It will be great if this is backported to 3.12 and 3.10.