### PR TITLE
Update vertex tool to base its snapping parameters on global ones 

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -780,6 +780,9 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
         {
           layerSettings = existingSettings.value();
           layerSettings.setEnabled( vlayer == currentVlayer );
+          layerSettings.setTolerance( tol );
+          layerSettings.setTypeFlag( static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ) );
+          layerSettings.setUnits( QgsTolerance::ProjectUnits );
         }
         else
         {
@@ -819,12 +822,15 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
       {
         layerSettings = existingSettings.value();
         layerSettings.setEnabled( vlayer->isEditable() );
+        layerSettings.setTolerance( tol );
+        layerSettings.setTypeFlag( static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ) );
+        layerSettings.setUnits( QgsTolerance::ProjectUnits );
       }
       else
       {
-        config.setIndividualLayerSettings( vlayer, QgsSnappingConfig::IndividualLayerSettings(
-                                             vlayer->isEditable(), static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits, 0.0, 0.0 ) );
+        layerSettings = QgsSnappingConfig::IndividualLayerSettings( vlayer->isEditable(), static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits, 0.0, 0.0 );
       }
+      config.setIndividualLayerSettings( vlayer, layerSettings );
     }
 
     snapUtils->setConfig( config );

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -748,17 +748,14 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
   QgsPointXY mapPoint = toMapCoordinates( e->pos() );
   double tol = QgsTolerance::vertexSearchRadius( canvas()->mapSettings() );
 
-  QgsSnappingConfig config;
+  QgsSnappingConfig config = oldConfig;
   config.setEnabled( true );
   config.setMode( QgsSnappingConfig::AdvancedConfiguration );
   config.setIntersectionSnapping( false );  // only snap to layers
-  config.setScaleDependencyMode( oldConfig.scaleDependencyMode() );
-  config.setMinimumScale( oldConfig.minimumScale() );
-  config.setMaximumScale( oldConfig.maximumScale() );
+  config.individualLayerSettings().clear();
 
   typedef QHash<QgsVectorLayer *, QgsSnappingConfig::IndividualLayerSettings> SettingsHashMap;
   SettingsHashMap oldLayerSettings = oldConfig.individualLayerSettings();
-  Q_ASSERT( config.individualLayerSettings().isEmpty() );
 
   // if there is a current layer, it should have priority over other layers
   // because sometimes there may be match from multiple layers at one location

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -94,7 +94,7 @@ bool QgsSnappingUtils::isIndexPrepared( QgsPointLocator *loc, const QgsRectangle
   if ( mStrategy == IndexAlwaysFull && loc->hasIndex() )
     return true;
 
-  if ( mStrategy == IndexExtent && loc->hasIndex() && loc->extent()->intersects( areaOfInterest ) )
+  if ( mStrategy == IndexExtent && loc->hasIndex() && ( !loc->extent() || loc->extent()->intersects( areaOfInterest ) ) )
     return true;
 
   QgsRectangle aoi( areaOfInterest );


### PR DESCRIPTION
Update vertex tool to not override some of the global snapping parameters (especially snapping enabled on a scale range).

Keep some of the specific behavior of enabling snapping in priority on an active layer (ie creation of a specific layer settings, now based an existing one if present).

Should fix #36229