### PR TITLE
[layout] allow sorting attribute table by field not listed in the table

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitemattributetable.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemattributetable.sip.in
@@ -270,7 +270,6 @@ Sets the attributes to display in the table.
                 to accommodate the new displayed feature attributes.
 %End
 
-
     void setWrapString( const QString &wrapString );
 %Docstring
 Sets a string to wrap the contents of the table cells by. Occurrences of this string will

--- a/python/core/auto_generated/layout/qgslayouttable.sip.in
+++ b/python/core/auto_generated/layout/qgslayouttable.sip.in
@@ -15,9 +15,9 @@ typedef QVector< QVariant > QgsLayoutTableRow;
 typedef QVector< QVector< QVariant > > QgsLayoutTableContents;
 
 
-typedef QVector< QgsLayoutTableColumn * > QgsLayoutTableColumns;
+typedef QVector<QgsLayoutTableColumn> QgsLayoutTableColumns;
 
-typedef QVector< QgsLayoutTableColumn * > QgsLayoutTableSortColumns;
+typedef QVector<QgsLayoutTableColumn> QgsLayoutTableSortColumns;
 
 
 

--- a/python/core/auto_generated/layout/qgslayouttable.sip.in
+++ b/python/core/auto_generated/layout/qgslayouttable.sip.in
@@ -17,6 +17,9 @@ typedef QVector< QVector< QVariant > > QgsLayoutTableContents;
 
 typedef QVector< QgsLayoutTableColumn * > QgsLayoutTableColumns;
 
+typedef QVector< QgsLayoutTableSortColumn * > QgsLayoutTableSortColumns;
+
+
 
 
 class QgsLayoutTableStyle
@@ -475,6 +478,26 @@ Replaces the columns in the table with a specified list of QgsLayoutTableColumns
 .. seealso:: :py:func:`columns`
 %End
 
+    QgsLayoutTableSortColumns &sortColumns();
+%Docstring
+Returns a reference to the list of QgsLayoutTableSortColumns shown in the table
+
+.. seealso:: :py:func:`setSortColumns`
+
+.. versionadded:: 3.14
+%End
+
+    void setSortColumns( const QgsLayoutTableSortColumns &sortColumns );
+%Docstring
+Replaces the sorting columns in the table with a specified list of QgsLayoutTableSortColumns.
+
+:param columns: list of QgsLayoutTableColumns used to sort the table.
+
+.. seealso:: :py:func:`sortColumns`
+
+.. versionadded:: 3.14
+%End
+
     void setCellStyle( CellStyleGroup group, const QgsLayoutTableStyle &style );
 %Docstring
 Sets the cell ``style`` for a cell ``group``.
@@ -541,6 +564,7 @@ new data.
 
 
   protected:
+
 
 
 

--- a/python/core/auto_generated/layout/qgslayouttable.sip.in
+++ b/python/core/auto_generated/layout/qgslayouttable.sip.in
@@ -491,7 +491,7 @@ Returns a reference to the list of QgsLayoutTableSortColumns shown in the table
 %Docstring
 Replaces the sorting columns in the table with a specified list of QgsLayoutTableSortColumns.
 
-:param columns: list of QgsLayoutTableColumns used to sort the table.
+:param sortColumns: list of QgsLayoutTableColumns used to sort the table.
 
 .. seealso:: :py:func:`sortColumns`
 

--- a/python/core/auto_generated/layout/qgslayouttable.sip.in
+++ b/python/core/auto_generated/layout/qgslayouttable.sip.in
@@ -17,7 +17,7 @@ typedef QVector< QVector< QVariant > > QgsLayoutTableContents;
 
 typedef QVector< QgsLayoutTableColumn * > QgsLayoutTableColumns;
 
-typedef QVector< QgsLayoutTableSortColumn * > QgsLayoutTableSortColumns;
+typedef QVector< QgsLayoutTableColumn * > QgsLayoutTableSortColumns;
 
 
 

--- a/python/core/auto_generated/layout/qgslayouttablecolumn.sip.in
+++ b/python/core/auto_generated/layout/qgslayouttablecolumn.sip.in
@@ -10,7 +10,7 @@
 
 
 
-class QgsLayoutTableColumn : QObject
+class QgsLayoutTableColumn
 {
 %Docstring
 Stores properties of a column for a QgsLayoutTable.
@@ -218,12 +218,17 @@ If the sort ``rank`` is <= 0 then the column is not being sorted.
    the order is now hold in a dedicated model
 %End
 
-    QgsLayoutTableColumn *clone() /Factory/;
+ QgsLayoutTableColumn *clone() /Deprecated,Factory/;
 %Docstring
 Creates a duplicate column which is a deep copy of this column.
 
 :return: a new QgsLayoutTableColumn with same properties as this column.
+
+.. deprecated:: QGIS 3.14
+   use a copy instead
 %End
+
+    bool operator==( const QgsLayoutTableColumn &other );
 
 };
 /************************************************************************

--- a/python/core/auto_generated/layout/qgslayouttablecolumn.sip.in
+++ b/python/core/auto_generated/layout/qgslayouttablecolumn.sip.in
@@ -147,155 +147,6 @@ is only used when the column is part of a :py:class:`QgsLayoutItemAttributeTable
 .. seealso:: :py:func:`attribute`
 %End
 
- Qt::SortOrder sortOrder() const /Deprecated/;
-%Docstring
-Returns the sort order for the column. This property is only used when the column
-is part of a QgsLayoutItemAttributeTable and when sortByRank is > 0.
-
-.. note::
-
-   only applicable when used in a :py:class:`QgsLayoutItemAttributeTable`
-
-.. seealso:: :py:func:`setSortOrder`
-
-.. seealso:: :py:func:`sortByRank`
-
-.. deprecated:: QGIS 3.14
-   the order is now hold in a distinct model
-%End
-
- void setSortOrder( Qt::SortOrder order ) /Deprecated/;
-%Docstring
-Sets the sort ``order`` for the column. This property is only used when the column
-is part of a QgsLayoutItemAttributeTable and when sortByRank() is > 0.
-
-.. note::
-
-   only applicable when used in a :py:class:`QgsLayoutItemAttributeTable`
-
-.. seealso:: :py:func:`sortOrder`
-
-.. seealso:: :py:func:`setSortByRank`
-
-.. deprecated:: QGIS 3.14
-   the order is now hold in a distinct model
-%End
-
- int sortByRank() const /Deprecated/;
-%Docstring
-Returns the sort rank for the column. If the sort rank is > 0 then the column
-will be sorted in the table. The sort rank specifies the priority given to the
-column when the table is sorted by multiple columns, with lower sort ranks
-having higher priority. This property is only used when the column
-is part of a :py:class:`QgsLayoutItemAttributeTable`.
-
-If sort rank is <= 0 then the column is not being sorted.
-
-.. note::
-
-   only applicable when used in a :py:class:`QgsLayoutItemAttributeTable`
-
-.. seealso:: :py:func:`setSortByRank`
-
-.. seealso:: :py:func:`sortOrder`
-
-.. deprecated:: QGIS 3.14
-   the order is now hold in a distinct model
-%End
-
- void setSortByRank( int rank ) /Deprecated/;
-%Docstring
-Sets the sort ``rank`` for the column. If the sort rank is > 0 then the column
-will be sorted in the table. The sort rank specifies the priority given to the
-column when the table is sorted by multiple columns, with lower sort ranks
-having higher priority. This property is only used when the column
-is part of a :py:class:`QgsLayoutItemAttributeTable`.
-If the sort ``rank`` is <= 0 then the column is not being sorted.
-
-.. note::
-
-   only applicable when used in a :py:class:`QgsLayoutItemAttributeTable`
-
-.. seealso:: :py:func:`sortByRank`
-
-.. seealso:: :py:func:`setSortOrder`
-
-.. deprecated:: QGIS 3.14
-   the order is now hold in a distinct model
-%End
-
-    QgsLayoutTableColumn *clone() /Factory/;
-%Docstring
-Creates a duplicate column which is a deep copy of this column.
-
-:return: a new QgsLayoutTableColumn with same properties as this column.
-%End
-
-};
-
-class QgsLayoutTableSortColumn : QObject
-{
-%Docstring
-Stores properties of a column for the sorting of a :py:class:`QgsLayoutTable`.
-
-.. versionadded:: 3.14
-%End
-
-%TypeHeaderCode
-#include "qgslayouttablecolumn.h"
-%End
-  public:
-
-    QgsLayoutTableSortColumn();
-%Docstring
-Constructor for :py:class:`QgsLayoutTableColumn`.
-
-:param heading: column heading
-%End
-
-    bool writeXml( QDomElement &columnElem, QDomDocument &doc ) const;
-%Docstring
-Writes the column's properties to xml for storage.
-
-:param columnElem: an existing QDomElement in which to store the column's properties.
-:param doc: QDomDocument for the destination xml.
-
-.. seealso:: :py:func:`readXml`
-%End
-
-    bool readXml( const QDomElement &columnElem );
-%Docstring
-Reads the column's properties from xml.
-
-:param columnElem: a QDomElement holding the column's desired properties.
-
-.. seealso:: :py:func:`writeXml`
-%End
-
-    QString attribute() const;
-%Docstring
-Returns the attribute name or expression used for the column's values. This property
-is only used when the column is part of a :py:class:`QgsLayoutItemAttributeTable`.
-
-.. note::
-
-   only applicable when used in a :py:class:`QgsLayoutItemAttributeTable`
-
-.. seealso:: :py:func:`setAttribute`
-%End
-
-    void setAttribute( const QString &attribute );
-%Docstring
-Sets the ``attribute`` name or expression used for the column's values. This property
-is only used when the column is part of a :py:class:`QgsLayoutItemAttributeTable`.
-
-.. note::
-
-   only applicable when used in a :py:class:`QgsLayoutItemAttributeTable`
-
-.. seealso:: :py:func:`attribute`
-%End
-
     Qt::SortOrder sortOrder() const;
 %Docstring
 Returns the sort order for the column. This property is only used when the column
@@ -324,15 +175,57 @@ is part of a QgsLayoutItemAttributeTable and when sortByRank() is > 0.
 .. seealso:: :py:func:`setSortByRank`
 %End
 
-    QgsLayoutTableSortColumn *clone() /Factory/;
+ int sortByRank() const /Deprecated/;
+%Docstring
+Returns the sort rank for the column. If the sort rank is > 0 then the column
+will be sorted in the table. The sort rank specifies the priority given to the
+column when the table is sorted by multiple columns, with lower sort ranks
+having higher priority. This property is only used when the column
+is part of a :py:class:`QgsLayoutItemAttributeTable`.
+
+If sort rank is <= 0 then the column is not being sorted.
+
+.. note::
+
+   only applicable when used in a :py:class:`QgsLayoutItemAttributeTable`
+
+.. seealso:: :py:func:`setSortByRank`
+
+.. seealso:: :py:func:`sortOrder`
+
+.. deprecated:: QGIS 3.14
+   the order is now hold in a dedicated model
+%End
+
+ void setSortByRank( int rank ) /Deprecated/;
+%Docstring
+Sets the sort ``rank`` for the column. If the sort rank is > 0 then the column
+will be sorted in the table. The sort rank specifies the priority given to the
+column when the table is sorted by multiple columns, with lower sort ranks
+having higher priority. This property is only used when the column
+is part of a :py:class:`QgsLayoutItemAttributeTable`.
+If the sort ``rank`` is <= 0 then the column is not being sorted.
+
+.. note::
+
+   only applicable when used in a :py:class:`QgsLayoutItemAttributeTable`
+
+.. seealso:: :py:func:`sortByRank`
+
+.. seealso:: :py:func:`setSortOrder`
+
+.. deprecated:: QGIS 3.14
+   the order is now hold in a dedicated model
+%End
+
+    QgsLayoutTableColumn *clone() /Factory/;
 %Docstring
 Creates a duplicate column which is a deep copy of this column.
 
-:return: a new QgsLayoutTableSortColumn with same properties as this column.
+:return: a new QgsLayoutTableColumn with same properties as this column.
 %End
 
 };
-
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/core/auto_generated/layout/qgslayouttablecolumn.sip.in
+++ b/python/core/auto_generated/layout/qgslayouttablecolumn.sip.in
@@ -13,9 +13,10 @@
 class QgsLayoutTableColumn : QObject
 {
 %Docstring
-Stores properties of a column for a QgsLayoutTable. Some properties of aQgsLayoutTableColumn
-are applicable only in certain contexts. For instance, the attribute and setAttribute methods only
-have an effect for QgsLayoutItemAttributeTables, and have no effect for QgsLayoutItemTextTables.
+Stores properties of a column for a QgsLayoutTable.
+Some properties of a QgsLayoutTableColumn are applicable only in certain contexts.
+For instance, the attribute and setAttribute methods only have an effect
+for QgsLayoutItemAttributeTables, and have no effect for QgsLayoutItemTextTables.
 
 .. versionadded:: 3.0
 %End
@@ -146,6 +147,155 @@ is only used when the column is part of a :py:class:`QgsLayoutItemAttributeTable
 .. seealso:: :py:func:`attribute`
 %End
 
+ Qt::SortOrder sortOrder() const /Deprecated/;
+%Docstring
+Returns the sort order for the column. This property is only used when the column
+is part of a QgsLayoutItemAttributeTable and when sortByRank is > 0.
+
+.. note::
+
+   only applicable when used in a :py:class:`QgsLayoutItemAttributeTable`
+
+.. seealso:: :py:func:`setSortOrder`
+
+.. seealso:: :py:func:`sortByRank`
+
+.. deprecated:: QGIS 3.14
+   the order is now hold in a distinct model
+%End
+
+ void setSortOrder( Qt::SortOrder order ) /Deprecated/;
+%Docstring
+Sets the sort ``order`` for the column. This property is only used when the column
+is part of a QgsLayoutItemAttributeTable and when sortByRank() is > 0.
+
+.. note::
+
+   only applicable when used in a :py:class:`QgsLayoutItemAttributeTable`
+
+.. seealso:: :py:func:`sortOrder`
+
+.. seealso:: :py:func:`setSortByRank`
+
+.. deprecated:: QGIS 3.14
+   the order is now hold in a distinct model
+%End
+
+ int sortByRank() const /Deprecated/;
+%Docstring
+Returns the sort rank for the column. If the sort rank is > 0 then the column
+will be sorted in the table. The sort rank specifies the priority given to the
+column when the table is sorted by multiple columns, with lower sort ranks
+having higher priority. This property is only used when the column
+is part of a :py:class:`QgsLayoutItemAttributeTable`.
+
+If sort rank is <= 0 then the column is not being sorted.
+
+.. note::
+
+   only applicable when used in a :py:class:`QgsLayoutItemAttributeTable`
+
+.. seealso:: :py:func:`setSortByRank`
+
+.. seealso:: :py:func:`sortOrder`
+
+.. deprecated:: QGIS 3.14
+   the order is now hold in a distinct model
+%End
+
+ void setSortByRank( int rank ) /Deprecated/;
+%Docstring
+Sets the sort ``rank`` for the column. If the sort rank is > 0 then the column
+will be sorted in the table. The sort rank specifies the priority given to the
+column when the table is sorted by multiple columns, with lower sort ranks
+having higher priority. This property is only used when the column
+is part of a :py:class:`QgsLayoutItemAttributeTable`.
+If the sort ``rank`` is <= 0 then the column is not being sorted.
+
+.. note::
+
+   only applicable when used in a :py:class:`QgsLayoutItemAttributeTable`
+
+.. seealso:: :py:func:`sortByRank`
+
+.. seealso:: :py:func:`setSortOrder`
+
+.. deprecated:: QGIS 3.14
+   the order is now hold in a distinct model
+%End
+
+    QgsLayoutTableColumn *clone() /Factory/;
+%Docstring
+Creates a duplicate column which is a deep copy of this column.
+
+:return: a new QgsLayoutTableColumn with same properties as this column.
+%End
+
+};
+
+class QgsLayoutTableSortColumn : QObject
+{
+%Docstring
+Stores properties of a column for the sorting of a :py:class:`QgsLayoutTable`.
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgslayouttablecolumn.h"
+%End
+  public:
+
+    QgsLayoutTableSortColumn();
+%Docstring
+Constructor for :py:class:`QgsLayoutTableColumn`.
+
+:param heading: column heading
+%End
+
+    bool writeXml( QDomElement &columnElem, QDomDocument &doc ) const;
+%Docstring
+Writes the column's properties to xml for storage.
+
+:param columnElem: an existing QDomElement in which to store the column's properties.
+:param doc: QDomDocument for the destination xml.
+
+.. seealso:: :py:func:`readXml`
+%End
+
+    bool readXml( const QDomElement &columnElem );
+%Docstring
+Reads the column's properties from xml.
+
+:param columnElem: a QDomElement holding the column's desired properties.
+
+.. seealso:: :py:func:`writeXml`
+%End
+
+    QString attribute() const;
+%Docstring
+Returns the attribute name or expression used for the column's values. This property
+is only used when the column is part of a :py:class:`QgsLayoutItemAttributeTable`.
+
+.. note::
+
+   only applicable when used in a :py:class:`QgsLayoutItemAttributeTable`
+
+.. seealso:: :py:func:`setAttribute`
+%End
+
+    void setAttribute( const QString &attribute );
+%Docstring
+Sets the ``attribute`` name or expression used for the column's values. This property
+is only used when the column is part of a :py:class:`QgsLayoutItemAttributeTable`.
+
+.. note::
+
+   only applicable when used in a :py:class:`QgsLayoutItemAttributeTable`
+
+.. seealso:: :py:func:`attribute`
+%End
+
     Qt::SortOrder sortOrder() const;
 %Docstring
 Returns the sort order for the column. This property is only used when the column
@@ -174,48 +324,11 @@ is part of a QgsLayoutItemAttributeTable and when sortByRank() is > 0.
 .. seealso:: :py:func:`setSortByRank`
 %End
 
-    int sortByRank() const;
-%Docstring
-Returns the sort rank for the column. If the sort rank is > 0 then the column
-will be sorted in the table. The sort rank specifies the priority given to the
-column when the table is sorted by multiple columns, with lower sort ranks
-having higher priority. This property is only used when the column
-is part of a :py:class:`QgsLayoutItemAttributeTable`.
-
-If sort rank is <= 0 then the column is not being sorted.
-
-.. note::
-
-   only applicable when used in a :py:class:`QgsLayoutItemAttributeTable`
-
-.. seealso:: :py:func:`setSortByRank`
-
-.. seealso:: :py:func:`sortOrder`
-%End
-
-    void setSortByRank( int rank );
-%Docstring
-Sets the sort ``rank`` for the column. If the sort rank is > 0 then the column
-will be sorted in the table. The sort rank specifies the priority given to the
-column when the table is sorted by multiple columns, with lower sort ranks
-having higher priority. This property is only used when the column
-is part of a :py:class:`QgsLayoutItemAttributeTable`.
-If the sort ``rank`` is <= 0 then the column is not being sorted.
-
-.. note::
-
-   only applicable when used in a :py:class:`QgsLayoutItemAttributeTable`
-
-.. seealso:: :py:func:`sortByRank`
-
-.. seealso:: :py:func:`setSortOrder`
-%End
-
-    QgsLayoutTableColumn *clone() /Factory/;
+    QgsLayoutTableSortColumn *clone() /Factory/;
 %Docstring
 Creates a duplicate column which is a deep copy of this column.
 
-:return: a new QgsLayoutTableColumn with same properties as this column.
+:return: a new QgsLayoutTableSortColumn with same properties as this column.
 %End
 
 };

--- a/src/core/layout/qgscompositionconverter.cpp
+++ b/src/core/layout/qgscompositionconverter.cpp
@@ -1469,7 +1469,9 @@ bool QgsCompositionConverter::readTableXml( QgsLayoutItemAttributeTable *layoutI
 
       // sorting columns are now (QGIS 3.14+) handled in a dedicated list
       Q_NOWARN_DEPRECATED_PUSH
-      std::copy_if( layoutItem->mColumns.begin(), layoutItem->mColumns.end(), std::back_inserter( layoutItem->mSortColumns ), []( QgsLayoutTableColumn * col ) {return col->sortByRank() > 0;} );
+      for ( QgsLayoutTableColumn *col : qgis::as_const( layoutItem->mColumns ) )
+        if ( col->sortByRank() > 0 )
+          layoutItem->mSortColumns.append( col->clone() );
       std::sort( layoutItem->mSortColumns.begin(), layoutItem->mSortColumns.end(), []( QgsLayoutTableColumn * a, QgsLayoutTableColumn * b ) {return a->sortByRank() < b->sortByRank();} );
       Q_NOWARN_DEPRECATED_POP
     }

--- a/src/core/layout/qgscompositionconverter.cpp
+++ b/src/core/layout/qgscompositionconverter.cpp
@@ -1466,10 +1466,9 @@ bool QgsCompositionConverter::readTableXml( QgsLayoutItemAttributeTable *layoutI
       layoutItem->mColumns.append( column );
 
       // sorting columns are now (QGIS 3.14+) handled in a dedicated list
+      // copy the display columns if sortByRank > 0 and then, sort them by rank
       Q_NOWARN_DEPRECATED_PUSH
-      for ( const QgsLayoutTableColumn &col : qgis::as_const( layoutItem->mColumns ) )
-        if ( col.sortByRank() > 0 )
-          layoutItem->mSortColumns.append( col );
+      std::copy_if( layoutItem->mColumns.begin(), layoutItem->mColumns.end(), std::back_inserter( layoutItem->mSortColumns ), []( const QgsLayoutTableColumn & col ) {return col.sortByRank() > 0;} );
       std::sort( layoutItem->mSortColumns.begin(), layoutItem->mSortColumns.end(), []( const QgsLayoutTableColumn & a, const QgsLayoutTableColumn & b ) {return a.sortByRank() < b.sortByRank();} );
       Q_NOWARN_DEPRECATED_POP
     }

--- a/src/core/layout/qgscompositionconverter.cpp
+++ b/src/core/layout/qgscompositionconverter.cpp
@@ -1428,7 +1428,11 @@ bool QgsCompositionConverter::readTableXml( QgsLayoutItemAttributeTable *layoutI
   layoutItem->setWrapBehavior( static_cast<QgsLayoutTable::WrapBehavior>( itemElem.attribute( QStringLiteral( "wrapBehavior" ), QStringLiteral( "0" ) ).toInt() ) );
 
   //restore column specifications
+  qDeleteAll( layoutItem->mColumns );
   layoutItem->mColumns.clear();
+  qDeleteAll( layoutItem->mSortColumns );
+  layoutItem->mSortColumns.clear();
+
   QDomNodeList columnsList = itemElem.elementsByTagName( QStringLiteral( "displayColumns" ) );
   if ( !columnsList.isEmpty() )
   {
@@ -1464,12 +1468,10 @@ bool QgsCompositionConverter::readTableXml( QgsLayoutItemAttributeTable *layoutI
       layoutItem->mColumns.append( column );
 
       // sorting columns are now (QGIS 3.14+) handled in a dedicated list
-      QVector<QgsLayoutTableColumn *> sortColumns;
       Q_NOWARN_DEPRECATED_PUSH
-      std::copy_if( layoutItem->mColumns.begin(), layoutItem->mColumns.end(), std::back_inserter( sortColumns ), []( QgsLayoutTableColumn * col ) {return col->sortByRank() > 0;} );
-      std::sort( sortColumns.begin(), sortColumns.end(), []( QgsLayoutTableColumn * a, QgsLayoutTableColumn * b ) {return a->sortByRank() < b->sortByRank();} );
+      std::copy_if( layoutItem->mColumns.begin(), layoutItem->mColumns.end(), std::back_inserter( layoutItem->mSortColumns ), []( QgsLayoutTableColumn * col ) {return col->sortByRank() > 0;} );
+      std::sort( layoutItem->mSortColumns.begin(), layoutItem->mSortColumns.end(), []( QgsLayoutTableColumn * a, QgsLayoutTableColumn * b ) {return a->sortByRank() < b->sortByRank();} );
       Q_NOWARN_DEPRECATED_POP
-      // TODO remove comment: layoutItem->mSortColumns = sortColumns;
     }
   }
 

--- a/src/core/layout/qgscompositionconverter.cpp
+++ b/src/core/layout/qgscompositionconverter.cpp
@@ -1462,6 +1462,14 @@ bool QgsCompositionConverter::readTableXml( QgsLayoutItemAttributeTable *layoutI
         }
       }
       layoutItem->mColumns.append( column );
+
+      // sorting columns are now (QGIS 3.14+) handled in a dedicated list
+      QVector<QgsLayoutTableColumn *> sortColumns;
+      Q_NOWARN_DEPRECATED_PUSH
+      std::copy_if( layoutItem->mColumns.begin(), layoutItem->mColumns.end(), std::back_inserter( sortColumns ), []( QgsLayoutTableColumn * col ) {return col->sortByRank() > 0;} );
+      std::sort( sortColumns.begin(), sortColumns.end(), []( QgsLayoutTableColumn * a, QgsLayoutTableColumn * b ) {return a->sortByRank() < b->sortByRank();} );
+      Q_NOWARN_DEPRECATED_POP
+      // TODO remove comment: layoutItem->mSortColumns = sortColumns;
     }
   }
 

--- a/src/core/layout/qgscompositionconverter.cpp
+++ b/src/core/layout/qgscompositionconverter.cpp
@@ -1428,9 +1428,7 @@ bool QgsCompositionConverter::readTableXml( QgsLayoutItemAttributeTable *layoutI
   layoutItem->setWrapBehavior( static_cast<QgsLayoutTable::WrapBehavior>( itemElem.attribute( QStringLiteral( "wrapBehavior" ), QStringLiteral( "0" ) ).toInt() ) );
 
   //restore column specifications
-  qDeleteAll( layoutItem->mColumns );
   layoutItem->mColumns.clear();
-  qDeleteAll( layoutItem->mSortColumns );
   layoutItem->mSortColumns.clear();
 
   QDomNodeList columnsList = itemElem.elementsByTagName( QStringLiteral( "displayColumns" ) );
@@ -1441,14 +1439,14 @@ bool QgsCompositionConverter::readTableXml( QgsLayoutItemAttributeTable *layoutI
     for ( int i = 0; i < columnEntryList.size(); ++i )
     {
       QDomElement columnElem = columnEntryList.at( i ).toElement();
-      QgsLayoutTableColumn *column = new QgsLayoutTableColumn;
-      column->mHAlignment = static_cast< Qt::AlignmentFlag >( columnElem.attribute( QStringLiteral( "hAlignment" ), QString::number( Qt::AlignLeft ) ).toInt() );
-      column->mVAlignment = static_cast< Qt::AlignmentFlag >( columnElem.attribute( QStringLiteral( "vAlignment" ), QString::number( Qt::AlignVCenter ) ).toInt() );
-      column->mHeading = columnElem.attribute( QStringLiteral( "heading" ), QString() );
-      column->mAttribute = columnElem.attribute( QStringLiteral( "attribute" ), QString() );
-      column->mSortByRank = columnElem.attribute( QStringLiteral( "sortByRank" ), QStringLiteral( "0" ) ).toInt();
-      column->mSortOrder = static_cast< Qt::SortOrder >( columnElem.attribute( QStringLiteral( "sortOrder" ), QString::number( Qt::AscendingOrder ) ).toInt() );
-      column->mWidth = columnElem.attribute( QStringLiteral( "width" ), QStringLiteral( "0.0" ) ).toDouble();
+      QgsLayoutTableColumn column;
+      column.mHAlignment = static_cast< Qt::AlignmentFlag >( columnElem.attribute( QStringLiteral( "hAlignment" ), QString::number( Qt::AlignLeft ) ).toInt() );
+      column.mVAlignment = static_cast< Qt::AlignmentFlag >( columnElem.attribute( QStringLiteral( "vAlignment" ), QString::number( Qt::AlignVCenter ) ).toInt() );
+      column.mHeading = columnElem.attribute( QStringLiteral( "heading" ), QString() );
+      column.mAttribute = columnElem.attribute( QStringLiteral( "attribute" ), QString() );
+      column.mSortByRank = columnElem.attribute( QStringLiteral( "sortByRank" ), QStringLiteral( "0" ) ).toInt();
+      column.mSortOrder = static_cast< Qt::SortOrder >( columnElem.attribute( QStringLiteral( "sortOrder" ), QString::number( Qt::AscendingOrder ) ).toInt() );
+      column.mWidth = columnElem.attribute( QStringLiteral( "width" ), QStringLiteral( "0.0" ) ).toDouble();
 
       QDomNodeList bgColorList = columnElem.elementsByTagName( QStringLiteral( "backgroundColor" ) );
       if ( !bgColorList.isEmpty() )
@@ -1462,17 +1460,17 @@ bool QgsCompositionConverter::readTableXml( QgsLayoutItemAttributeTable *layoutI
         bgAlpha = bgColorElem.attribute( QStringLiteral( "alpha" ) ).toDouble( &alphaOk );
         if ( redOk && greenOk && blueOk && alphaOk )
         {
-          column->mBackgroundColor = QColor( bgRed, bgGreen, bgBlue, bgAlpha );
+          column.mBackgroundColor = QColor( bgRed, bgGreen, bgBlue, bgAlpha );
         }
       }
       layoutItem->mColumns.append( column );
 
       // sorting columns are now (QGIS 3.14+) handled in a dedicated list
       Q_NOWARN_DEPRECATED_PUSH
-      for ( QgsLayoutTableColumn *col : qgis::as_const( layoutItem->mColumns ) )
-        if ( col->sortByRank() > 0 )
-          layoutItem->mSortColumns.append( col->clone() );
-      std::sort( layoutItem->mSortColumns.begin(), layoutItem->mSortColumns.end(), []( QgsLayoutTableColumn * a, QgsLayoutTableColumn * b ) {return a->sortByRank() < b->sortByRank();} );
+      for ( const QgsLayoutTableColumn &col : qgis::as_const( layoutItem->mColumns ) )
+        if ( col.sortByRank() > 0 )
+          layoutItem->mSortColumns.append( col );
+      std::sort( layoutItem->mSortColumns.begin(), layoutItem->mSortColumns.end(), []( const QgsLayoutTableColumn & a, const QgsLayoutTableColumn & b ) {return a.sortByRank() < b.sortByRank();} );
       Q_NOWARN_DEPRECATED_POP
     }
   }

--- a/src/core/layout/qgslayoutitemattributetable.cpp
+++ b/src/core/layout/qgslayoutitemattributetable.cpp
@@ -482,7 +482,7 @@ bool QgsLayoutItemAttributeTable::getTableContents( QgsLayoutTableContents &cont
     req.setFilterFid( atlasFeature.id() );
   }
 
-  for ( const QgsLayoutTableSortColumn *column : qgis::as_const( mSortColumns ) )
+  for ( const QgsLayoutTableColumn *column : qgis::as_const( mSortColumns ) )
   {
     req = req.addOrderBy( column->attribute(), column->sortOrder() == Qt::AscendingOrder );
   }

--- a/src/core/layout/qgslayoutitemattributetable.cpp
+++ b/src/core/layout/qgslayoutitemattributetable.cpp
@@ -367,16 +367,16 @@ void QgsLayoutItemAttributeTable::restoreFieldAliasMap( const QMap<int, QString>
     return;
   }
 
-  for ( QgsLayoutTableColumn &column : mColumns )
+  for ( int i = 0; i < mColumns.count(); i++ )
   {
-    int attrIdx = source->fields().lookupField( column.attribute() );
+    int attrIdx = source->fields().lookupField( mColumns[i].attribute() );
     if ( map.contains( attrIdx ) )
     {
-      column.setHeading( map.value( attrIdx ) );
+      mColumns[i].setHeading( map.value( attrIdx ) );
     }
     else
     {
-      column.setHeading( source->attributeDisplayName( attrIdx ) );
+      mColumns[i].setHeading( source->attributeDisplayName( attrIdx ) );
     }
   }
 }

--- a/src/core/layout/qgslayoutitemattributetable.cpp
+++ b/src/core/layout/qgslayoutitemattributetable.cpp
@@ -170,9 +170,7 @@ void QgsLayoutItemAttributeTable::resetColumns()
   }
 
   //remove existing columns
-  qDeleteAll( mColumns );
   mColumns.clear();
-  qDeleteAll( mSortColumns );
   mSortColumns.clear();
 
   //rebuild columns list from vector layer fields
@@ -181,10 +179,10 @@ void QgsLayoutItemAttributeTable::resetColumns()
   for ( const auto &field : sourceFields )
   {
     QString currentAlias = source->attributeDisplayName( idx );
-    std::unique_ptr< QgsLayoutTableColumn > col = qgis::make_unique< QgsLayoutTableColumn >();
-    col->setAttribute( field.name() );
-    col->setHeading( currentAlias );
-    mColumns.append( col.release() );
+    QgsLayoutTableColumn col;
+    col.setAttribute( field.name() );
+    col.setHeading( currentAlias );
+    mColumns.append( col );
     idx++;
   }
 }
@@ -321,7 +319,6 @@ void QgsLayoutItemAttributeTable::setDisplayedFields( const QStringList &fields,
   }
 
   //rebuild columns list, taking only fields contained in supplied list
-  qDeleteAll( mColumns );
   mColumns.clear();
 
   const QgsFields layerFields = source->fields();
@@ -335,10 +332,10 @@ void QgsLayoutItemAttributeTable::setDisplayedFields( const QStringList &fields,
         continue;
 
       QString currentAlias = source->attributeDisplayName( attrIdx );
-      std::unique_ptr< QgsLayoutTableColumn > col = qgis::make_unique< QgsLayoutTableColumn >();
-      col->setAttribute( layerFields.at( attrIdx ).name() );
-      col->setHeading( currentAlias );
-      mColumns.append( col.release() );
+      QgsLayoutTableColumn col;
+      col.setAttribute( layerFields.at( attrIdx ).name() );
+      col.setHeading( currentAlias );
+      mColumns.append( col );
     }
   }
   else
@@ -348,10 +345,10 @@ void QgsLayoutItemAttributeTable::setDisplayedFields( const QStringList &fields,
     for ( const QgsField &field : layerFields )
     {
       QString currentAlias = source->attributeDisplayName( idx );
-      std::unique_ptr< QgsLayoutTableColumn > col = qgis::make_unique< QgsLayoutTableColumn >();
-      col->setAttribute( field.name() );
-      col->setHeading( currentAlias );
-      mColumns.append( col.release() );
+      QgsLayoutTableColumn col;
+      col.setAttribute( field.name() );
+      col.setHeading( currentAlias );
+      mColumns.append( col );
       idx++;
     }
   }
@@ -370,16 +367,16 @@ void QgsLayoutItemAttributeTable::restoreFieldAliasMap( const QMap<int, QString>
     return;
   }
 
-  for ( QgsLayoutTableColumn *column : qgis::as_const( mColumns ) )
+  for ( QgsLayoutTableColumn &column : mColumns )
   {
-    int attrIdx = source->fields().lookupField( column->attribute() );
+    int attrIdx = source->fields().lookupField( column.attribute() );
     if ( map.contains( attrIdx ) )
     {
-      column->setHeading( map.value( attrIdx ) );
+      column.setHeading( map.value( attrIdx ) );
     }
     else
     {
-      column->setHeading( source->attributeDisplayName( attrIdx ) );
+      column.setHeading( source->attributeDisplayName( attrIdx ) );
     }
   }
 }
@@ -482,9 +479,9 @@ bool QgsLayoutItemAttributeTable::getTableContents( QgsLayoutTableContents &cont
     req.setFilterFid( atlasFeature.id() );
   }
 
-  for ( const QgsLayoutTableColumn *column : qgis::as_const( mSortColumns ) )
+  for ( const QgsLayoutTableColumn &column : qgis::as_const( mSortColumns ) )
   {
-    req = req.addOrderBy( column->attribute(), column->sortOrder() == Qt::AscendingOrder );
+    req = req.addOrderBy( column.attribute(), column.sortOrder() == Qt::AscendingOrder );
   }
 
   QgsFeature f;
@@ -550,9 +547,9 @@ bool QgsLayoutItemAttributeTable::getTableContents( QgsLayoutTableContents &cont
     QgsLayoutTableRow rowContents;
     rowContents.reserve( mColumns.count() );
 
-    for ( QgsLayoutTableColumn *column : qgis::as_const( mColumns ) )
+    for ( const QgsLayoutTableColumn &column : qgis::as_const( mColumns ) )
     {
-      int idx = layer->fields().lookupField( column->attribute() );
+      int idx = layer->fields().lookupField( column.attribute() );
 
       QgsConditionalStyle style;
 
@@ -575,7 +572,7 @@ bool QgsLayoutItemAttributeTable::getTableContents( QgsLayoutTableContents &cont
       else
       {
         // Lets assume it's an expression
-        std::unique_ptr< QgsExpression > expression = qgis::make_unique< QgsExpression >( column->attribute() );
+        std::unique_ptr< QgsExpression > expression = qgis::make_unique< QgsExpression >( column.attribute() );
         context.lastScope()->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "row_number" ), counter + 1, true ) );
         expression->prepare( &context );
         QVariant value = expression->evaluate( &context );
@@ -717,7 +714,6 @@ void QgsLayoutItemAttributeTable::removeLayer( const QString &layerId )
     {
       mVectorLayer.setLayer( nullptr );
       //remove existing columns
-      qDeleteAll( mColumns );
       mColumns.clear();
     }
   }

--- a/src/core/layout/qgslayoutitemattributetable.h
+++ b/src/core/layout/qgslayoutitemattributetable.h
@@ -257,15 +257,6 @@ class CORE_EXPORT QgsLayoutItemAttributeTable: public QgsLayoutTable
     void setDisplayedFields( const QStringList &fields, bool refresh = true );
 
     /**
-     * Returns the attributes used to sort the table's features.
-     * \returns a QList of integer/bool pairs, where the integer refers to the attribute index and
-     * the bool to the sort order for the attribute. If TRUE the attribute is sorted ascending,
-     * if FALSE, the attribute is sorted in descending order.
-     * \note not available in Python bindings
-     */
-    QVector< QPair<int, bool> > sortAttributes() const SIP_SKIP;
-
-    /**
      * Sets a string to wrap the contents of the table cells by. Occurrences of this string will
      * be replaced by a line break.
      * \param wrapString string to replace with line break

--- a/src/core/layout/qgslayouttable.cpp
+++ b/src/core/layout/qgslayouttable.cpp
@@ -107,7 +107,7 @@ bool QgsLayoutTable::writePropertiesToElement( QDomElement &elem, QDomDocument &
   elem.appendChild( displayColumnsElem );
   // sort columns
   QDomElement sortColumnsElem = doc.createElement( QStringLiteral( "sortColumns" ) );
-  for ( QgsLayoutTableSortColumn *column : qgis::as_const( mSortColumns ) )
+  for ( QgsLayoutTableColumn *column : qgis::as_const( mSortColumns ) )
   {
     QDomElement columnElem = doc.createElement( QStringLiteral( "column" ) );
     column->writeXml( columnElem, doc );
@@ -187,7 +187,7 @@ bool QgsLayoutTable::readPropertiesFromElement( const QDomElement &itemElem, con
     for ( int i = 0; i < columnEntryList.size(); ++i )
     {
       QDomElement columnElem = columnEntryList.at( i ).toElement();
-      QgsLayoutTableSortColumn *column = new QgsLayoutTableSortColumn;
+      QgsLayoutTableColumn *column = new QgsLayoutTableColumn;
       column->readXml( columnElem );
       mSortColumns.append( column );
     }

--- a/src/core/layout/qgslayouttable.cpp
+++ b/src/core/layout/qgslayouttable.cpp
@@ -196,7 +196,9 @@ bool QgsLayoutTable::readPropertiesFromElement( const QDomElement &itemElem, con
   {
     // backward compatibility for QGIS < 3.14
     Q_NOWARN_DEPRECATED_PUSH
-    std::copy_if( mColumns.begin(), mColumns.end(), std::back_inserter( mSortColumns ), []( QgsLayoutTableColumn * col ) {return col->sortByRank() > 0;} );
+    for ( QgsLayoutTableColumn *col : qgis::as_const( mColumns ) )
+      if ( col->sortByRank() > 0 )
+        mSortColumns.append( col->clone() );
     std::sort( mSortColumns.begin(), mSortColumns.end(), []( QgsLayoutTableColumn * a, QgsLayoutTableColumn * b ) {return a->sortByRank() < b->sortByRank();} );
     Q_NOWARN_DEPRECATED_POP
   }

--- a/src/core/layout/qgslayouttable.cpp
+++ b/src/core/layout/qgslayouttable.cpp
@@ -180,9 +180,9 @@ bool QgsLayoutTable::readPropertiesFromElement( const QDomElement &itemElem, con
   qDeleteAll( mSortColumns );
   mSortColumns.clear();
   QDomNodeList sortColumnsList = itemElem.elementsByTagName( QStringLiteral( "sortColumns" ) );
-  if ( !columnsList.isEmpty() )
+  if ( !sortColumnsList.isEmpty() )
   {
-    QDomElement columnsElem = columnsList.at( 0 ).toElement();
+    QDomElement columnsElem = sortColumnsList.at( 0 ).toElement();
     QDomNodeList columnEntryList = columnsElem.elementsByTagName( QStringLiteral( "column" ) );
     for ( int i = 0; i < columnEntryList.size(); ++i )
     {
@@ -195,12 +195,10 @@ bool QgsLayoutTable::readPropertiesFromElement( const QDomElement &itemElem, con
   else
   {
     // backward compatibility for QGIS < 3.14
-    QVector<QgsLayoutTableColumn *> sortColumns;
     Q_NOWARN_DEPRECATED_PUSH
-    std::copy_if( mColumns.begin(), mColumns.end(), std::back_inserter( sortColumns ), []( QgsLayoutTableColumn * col ) {return col->sortByRank() > 0;} );
-    std::sort( sortColumns.begin(), sortColumns.end(), []( QgsLayoutTableColumn * a, QgsLayoutTableColumn * b ) {return a->sortByRank() < b->sortByRank();} );
+    std::copy_if( mColumns.begin(), mColumns.end(), std::back_inserter( mSortColumns ), []( QgsLayoutTableColumn * col ) {return col->sortByRank() > 0;} );
+    std::sort( mSortColumns.begin(), mSortColumns.end(), []( QgsLayoutTableColumn * a, QgsLayoutTableColumn * b ) {return a->sortByRank() < b->sortByRank();} );
     Q_NOWARN_DEPRECATED_POP
-    // TODO remove comment: mSortColumns = sortColumns;
   }
 
   //restore cell styles

--- a/src/core/layout/qgslayouttable.h
+++ b/src/core/layout/qgslayouttable.h
@@ -27,7 +27,6 @@
 #include <QPair>
 
 class QgsLayoutTableColumn;
-class QgsLayoutTableColumn;
 
 /**
  * \ingroup core

--- a/src/core/layout/qgslayouttable.h
+++ b/src/core/layout/qgslayouttable.h
@@ -27,6 +27,7 @@
 #include <QPair>
 
 class QgsLayoutTableColumn;
+class QgsLayoutTableSortColumn;
 
 /**
  * \ingroup core
@@ -55,6 +56,14 @@ typedef QVector< QVector< QVariant > > QgsLayoutTableContents;
  * \since QGIS 3.0
 */
 typedef QVector< QgsLayoutTableColumn * > QgsLayoutTableColumns;
+
+/**
+ * \ingroup core
+ * List of column definitions for sorting a QgsLayoutTable
+ * \since QGIS 3.14
+*/
+typedef QVector< QgsLayoutTableSortColumn * > QgsLayoutTableSortColumns;
+
 
 
 /**
@@ -440,6 +449,21 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
     void setColumns( const QgsLayoutTableColumns &columns );
 
     /**
+     * Returns a reference to the list of QgsLayoutTableSortColumns shown in the table
+     * \see setSortColumns()
+     * \since QGIS 3.14
+     */
+    QgsLayoutTableSortColumns &sortColumns() { return mSortColumns; }
+
+    /**
+     * Replaces the sorting columns in the table with a specified list of QgsLayoutTableSortColumns.
+     * \param columns list of QgsLayoutTableColumns used to sort the table.
+     * \see sortColumns()
+     * \since QGIS 3.14
+     */
+    void setSortColumns( const QgsLayoutTableSortColumns &sortColumns );
+
+    /**
      * Sets the cell \a style for a cell \a group.
      * \see cellStyle()
      */
@@ -550,6 +574,9 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
 
     //! Columns to show in table
     QgsLayoutTableColumns mColumns;
+
+    //! Columns to sort the table
+    QgsLayoutTableSortColumns mSortColumns;
 
     //! Contents to show in table
     QgsLayoutTableContents mTableContents;

--- a/src/core/layout/qgslayouttable.h
+++ b/src/core/layout/qgslayouttable.h
@@ -55,14 +55,14 @@ typedef QVector< QVector< QVariant > > QgsLayoutTableContents;
  * List of column definitions for a QgsLayoutTable
  * \since QGIS 3.0
 */
-typedef QVector< QgsLayoutTableColumn * > QgsLayoutTableColumns;
+typedef QVector<QgsLayoutTableColumn> QgsLayoutTableColumns;
 
 /**
  * \ingroup core
  * List of column definitions for sorting a QgsLayoutTable
  * \since QGIS 3.14
 */
-typedef QVector< QgsLayoutTableColumn * > QgsLayoutTableSortColumns;
+typedef QVector<QgsLayoutTableColumn> QgsLayoutTableSortColumns;
 
 
 

--- a/src/core/layout/qgslayouttable.h
+++ b/src/core/layout/qgslayouttable.h
@@ -456,7 +456,7 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
 
     /**
      * Replaces the sorting columns in the table with a specified list of QgsLayoutTableSortColumns.
-     * \param columns list of QgsLayoutTableColumns used to sort the table.
+     * \param sortColumns list of QgsLayoutTableColumns used to sort the table.
      * \see sortColumns()
      * \since QGIS 3.14
      */

--- a/src/core/layout/qgslayouttable.h
+++ b/src/core/layout/qgslayouttable.h
@@ -27,7 +27,7 @@
 #include <QPair>
 
 class QgsLayoutTableColumn;
-class QgsLayoutTableSortColumn;
+class QgsLayoutTableColumn;
 
 /**
  * \ingroup core
@@ -62,7 +62,7 @@ typedef QVector< QgsLayoutTableColumn * > QgsLayoutTableColumns;
  * List of column definitions for sorting a QgsLayoutTable
  * \since QGIS 3.14
 */
-typedef QVector< QgsLayoutTableSortColumn * > QgsLayoutTableSortColumns;
+typedef QVector< QgsLayoutTableColumn * > QgsLayoutTableSortColumns;
 
 
 

--- a/src/core/layout/qgslayouttablecolumn.cpp
+++ b/src/core/layout/qgslayouttablecolumn.cpp
@@ -85,35 +85,8 @@ QgsLayoutTableColumn *QgsLayoutTableColumn::clone()
   newColumn->setVAlignment( mVAlignment );
   Q_NOWARN_DEPRECATED_PUSH
   newColumn->setSortByRank( mSortByRank );
-  newColumn->setSortOrder( mSortOrder );
   Q_NOWARN_DEPRECATED_POP
-  newColumn->setWidth( mWidth );
-  return newColumn.release();
-}
-
-QgsLayoutTableSortColumn::QgsLayoutTableSortColumn()
-{}
-
-bool QgsLayoutTableSortColumn::writeXml( QDomElement &columnElem, QDomDocument &doc ) const
-{
-  //background color
-  QDomElement bgColorElem = doc.createElement( QStringLiteral( "backgroundColor" ) );
-  columnElem.setAttribute( QStringLiteral( "attribute" ), mAttribute );
-  columnElem.setAttribute( QStringLiteral( "sortOrder" ), QString::number( mSortOrder ) );
-  return true;
-}
-
-bool QgsLayoutTableSortColumn::readXml( const QDomElement &columnElem )
-{
-  mAttribute = columnElem.attribute( QStringLiteral( "attribute" ), QString() );
-  mSortOrder = static_cast< Qt::SortOrder >( columnElem.attribute( QStringLiteral( "sortOrder" ), QString::number( Qt::AscendingOrder ) ).toInt() );
-  return true;
-}
-
-QgsLayoutTableSortColumn *QgsLayoutTableSortColumn::clone()
-{
-  std::unique_ptr< QgsLayoutTableSortColumn > newColumn = qgis::make_unique< QgsLayoutTableSortColumn >();
-  newColumn->setAttribute( mAttribute );
   newColumn->setSortOrder( mSortOrder );
+  newColumn->setWidth( mWidth );
   return newColumn.release();
 }

--- a/src/core/layout/qgslayouttablecolumn.cpp
+++ b/src/core/layout/qgslayouttablecolumn.cpp
@@ -83,8 +83,37 @@ QgsLayoutTableColumn *QgsLayoutTableColumn::clone()
   newColumn->setHeading( mHeading );
   newColumn->setHAlignment( mHAlignment );
   newColumn->setVAlignment( mVAlignment );
+  Q_NOWARN_DEPRECATED_PUSH
   newColumn->setSortByRank( mSortByRank );
   newColumn->setSortOrder( mSortOrder );
+  Q_NOWARN_DEPRECATED_POP
   newColumn->setWidth( mWidth );
+  return newColumn.release();
+}
+
+QgsLayoutTableSortColumn::QgsLayoutTableSortColumn()
+{}
+
+bool QgsLayoutTableSortColumn::writeXml( QDomElement &columnElem, QDomDocument &doc ) const
+{
+  //background color
+  QDomElement bgColorElem = doc.createElement( QStringLiteral( "backgroundColor" ) );
+  columnElem.setAttribute( QStringLiteral( "attribute" ), mAttribute );
+  columnElem.setAttribute( QStringLiteral( "sortOrder" ), QString::number( mSortOrder ) );
+  return true;
+}
+
+bool QgsLayoutTableSortColumn::readXml( const QDomElement &columnElem )
+{
+  mAttribute = columnElem.attribute( QStringLiteral( "attribute" ), QString() );
+  mSortOrder = static_cast< Qt::SortOrder >( columnElem.attribute( QStringLiteral( "sortOrder" ), QString::number( Qt::AscendingOrder ) ).toInt() );
+  return true;
+}
+
+QgsLayoutTableSortColumn *QgsLayoutTableSortColumn::clone()
+{
+  std::unique_ptr< QgsLayoutTableSortColumn > newColumn = qgis::make_unique< QgsLayoutTableSortColumn >();
+  newColumn->setAttribute( mAttribute );
+  newColumn->setSortOrder( mSortOrder );
   return newColumn.release();
 }

--- a/src/core/layout/qgslayouttablecolumn.cpp
+++ b/src/core/layout/qgslayouttablecolumn.cpp
@@ -75,18 +75,3 @@ bool QgsLayoutTableColumn::readXml( const QDomElement &columnElem )
 
   return true;
 }
-
-QgsLayoutTableColumn *QgsLayoutTableColumn::clone()
-{
-  std::unique_ptr< QgsLayoutTableColumn > newColumn = qgis::make_unique< QgsLayoutTableColumn >();
-  newColumn->setAttribute( mAttribute );
-  newColumn->setHeading( mHeading );
-  newColumn->setHAlignment( mHAlignment );
-  newColumn->setVAlignment( mVAlignment );
-  Q_NOWARN_DEPRECATED_PUSH
-  newColumn->setSortByRank( mSortByRank );
-  Q_NOWARN_DEPRECATED_POP
-  newColumn->setSortOrder( mSortOrder );
-  newColumn->setWidth( mWidth );
-  return newColumn.release();
-}

--- a/src/core/layout/qgslayouttablecolumn.h
+++ b/src/core/layout/qgslayouttablecolumn.h
@@ -28,9 +28,10 @@
 
 /**
  * \ingroup core
- * Stores properties of a column for a QgsLayoutTable. Some properties of aQgsLayoutTableColumn
- * are applicable only in certain contexts. For instance, the attribute and setAttribute methods only
- * have an effect for QgsLayoutItemAttributeTables, and have no effect for QgsLayoutItemTextTables.
+ * Stores properties of a column for a QgsLayoutTable.
+ * Some properties of a QgsLayoutTableColumn are applicable only in certain contexts.
+ * For instance, the attribute and setAttribute methods only have an effect
+ * for QgsLayoutItemAttributeTables, and have no effect for QgsLayoutItemTextTables.
  * \since QGIS 3.0
 */
 class CORE_EXPORT QgsLayoutTableColumn : public QObject
@@ -141,8 +142,9 @@ class CORE_EXPORT QgsLayoutTableColumn : public QObject
      * \note only applicable when used in a QgsLayoutItemAttributeTable
      * \see setSortOrder()
      * \see sortByRank()
+     * \deprecated since QGIS 3.14 the order is now hold in a distinct model
      */
-    Qt::SortOrder sortOrder() const { return mSortOrder; }
+    Q_DECL_DEPRECATED Qt::SortOrder sortOrder() const SIP_DEPRECATED { return mSortOrder; }
 
     /**
      * Sets the sort \a order for the column. This property is only used when the column
@@ -150,8 +152,9 @@ class CORE_EXPORT QgsLayoutTableColumn : public QObject
      * \note only applicable when used in a QgsLayoutItemAttributeTable
      * \see sortOrder()
      * \see setSortByRank()
+     * \deprecated since QGIS 3.14 the order is now hold in a distinct model
      */
-    void setSortOrder( Qt::SortOrder order ) { mSortOrder = order; }
+    Q_DECL_DEPRECATED void setSortOrder( Qt::SortOrder order ) SIP_DEPRECATED { mSortOrder = order; }
 
     /**
      * Returns the sort rank for the column. If the sort rank is > 0 then the column
@@ -165,8 +168,9 @@ class CORE_EXPORT QgsLayoutTableColumn : public QObject
      * \note only applicable when used in a QgsLayoutItemAttributeTable
      * \see setSortByRank()
      * \see sortOrder()
+     * \deprecated since QGIS 3.14 the order is now hold in a distinct model
      */
-    int sortByRank() const { return mSortByRank; }
+    Q_DECL_DEPRECATED int sortByRank() const SIP_DEPRECATED { return mSortByRank; }
 
     /**
      * Sets the sort \a rank for the column. If the sort rank is > 0 then the column
@@ -179,8 +183,9 @@ class CORE_EXPORT QgsLayoutTableColumn : public QObject
      * \note only applicable when used in a QgsLayoutItemAttributeTable
      * \see sortByRank()
      * \see setSortOrder()
+     * \deprecated since QGIS 3.14 the order is now hold in a distinct model
      */
-    void setSortByRank( int rank ) { mSortByRank = rank; }
+    Q_DECL_DEPRECATED void setSortByRank( int rank ) SIP_DEPRECATED { mSortByRank = rank; }
 
     /**
      * Creates a duplicate column which is a deep copy of this column.
@@ -201,6 +206,84 @@ class CORE_EXPORT QgsLayoutTableColumn : public QObject
 
     friend class QgsCompositionConverter;
 
+};
+
+/**
+ * \ingroup core
+ * Stores properties of a column for the sorting of a QgsLayoutTable.
+ * \since QGIS 3.14
+*/
+class CORE_EXPORT QgsLayoutTableSortColumn : public QObject
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsLayoutTableColumn.
+     * \param heading column heading
+     */
+    QgsLayoutTableSortColumn();
+
+    /**
+     * Writes the column's properties to xml for storage.
+     * \param columnElem an existing QDomElement in which to store the column's properties.
+     * \param doc QDomDocument for the destination xml.
+     * \see readXml()
+     */
+    bool writeXml( QDomElement &columnElem, QDomDocument &doc ) const;
+
+    /**
+     * Reads the column's properties from xml.
+     * \param columnElem a QDomElement holding the column's desired properties.
+     * \see writeXml()
+     */
+    bool readXml( const QDomElement &columnElem );
+
+    /**
+     * Returns the attribute name or expression used for the column's values. This property
+     * is only used when the column is part of a QgsLayoutItemAttributeTable.
+     * \note only applicable when used in a QgsLayoutItemAttributeTable
+     * \see setAttribute()
+     */
+    QString attribute() const { return mAttribute; }
+
+    /**
+     * Sets the \a attribute name or expression used for the column's values. This property
+     * is only used when the column is part of a QgsLayoutItemAttributeTable.
+     * \note only applicable when used in a QgsLayoutItemAttributeTable
+     * \see attribute()
+     */
+    void setAttribute( const QString &attribute ) { mAttribute = attribute; }
+
+    /**
+     * Returns the sort order for the column. This property is only used when the column
+     * is part of a QgsLayoutItemAttributeTable and when sortByRank is > 0.
+     * \note only applicable when used in a QgsLayoutItemAttributeTable
+     * \see setSortOrder()
+     * \see sortByRank()
+     */
+    Qt::SortOrder sortOrder() const { return mSortOrder; }
+
+    /**
+     * Sets the sort \a order for the column. This property is only used when the column
+     * is part of a QgsLayoutItemAttributeTable and when sortByRank() is > 0.
+     * \note only applicable when used in a QgsLayoutItemAttributeTable
+     * \see sortOrder()
+     * \see setSortByRank()
+     */
+    void setSortOrder( Qt::SortOrder order ) { mSortOrder = order; }
+
+    /**
+     * Creates a duplicate column which is a deep copy of this column.
+     * \returns a new QgsLayoutTableSortColumn with same properties as this column.
+     */
+    QgsLayoutTableSortColumn *clone() SIP_FACTORY;
+
+  private:
+
+    QString mAttribute;
+    Qt::SortOrder mSortOrder = Qt::AscendingOrder;
 };
 
 #endif //QGSLAYOUTTABLECOLUMN_H

--- a/src/core/layout/qgslayouttablecolumn.h
+++ b/src/core/layout/qgslayouttablecolumn.h
@@ -18,7 +18,6 @@
 #ifndef QGSLAYOUTTABLECOLUMN_H
 #define QGSLAYOUTTABLECOLUMN_H
 
-#include <QObject>
 #include <QDomDocument>
 #include <QDomElement>
 #include <QColor>
@@ -34,10 +33,8 @@
  * for QgsLayoutItemAttributeTables, and have no effect for QgsLayoutItemTextTables.
  * \since QGIS 3.0
 */
-class CORE_EXPORT QgsLayoutTableColumn : public QObject
+class CORE_EXPORT QgsLayoutTableColumn
 {
-    Q_OBJECT
-
   public:
 
     /**
@@ -188,19 +185,31 @@ class CORE_EXPORT QgsLayoutTableColumn : public QObject
     /**
      * Creates a duplicate column which is a deep copy of this column.
      * \returns a new QgsLayoutTableColumn with same properties as this column.
+     * \deprecated since QGIS 3.14 use a copy instead
      */
-    QgsLayoutTableColumn *clone() SIP_FACTORY;
+    Q_DECL_DEPRECATED QgsLayoutTableColumn *clone() SIP_DEPRECATED SIP_FACTORY {return new QgsLayoutTableColumn( *this );}
+
+    bool operator==( const QgsLayoutTableColumn &other )
+    {
+      return mHeading == other.mHeading
+             && mAttribute == other.mAttribute
+             && mSortByRank == other.mSortByRank
+             && mSortOrder == other.mSortOrder
+             && mWidth == other.mWidth
+             && mHAlignment == other.mHAlignment
+             && mVAlignment == other.mVAlignment;
+    }
 
   private:
 
-    QColor mBackgroundColor = Qt::transparent; //currently unused
-    Qt::AlignmentFlag mHAlignment = Qt::AlignLeft;
-    Qt::AlignmentFlag mVAlignment = Qt::AlignVCenter;
     QString mHeading;
     QString mAttribute;
     int mSortByRank = 0;
     Qt::SortOrder mSortOrder = Qt::AscendingOrder;
     double mWidth = 0.0;
+    QColor mBackgroundColor = Qt::transparent; //currently unused
+    Qt::AlignmentFlag mHAlignment = Qt::AlignLeft;
+    Qt::AlignmentFlag mVAlignment = Qt::AlignVCenter;
 
     friend class QgsCompositionConverter;
 

--- a/src/core/layout/qgslayouttablecolumn.h
+++ b/src/core/layout/qgslayouttablecolumn.h
@@ -142,9 +142,8 @@ class CORE_EXPORT QgsLayoutTableColumn : public QObject
      * \note only applicable when used in a QgsLayoutItemAttributeTable
      * \see setSortOrder()
      * \see sortByRank()
-     * \deprecated since QGIS 3.14 the order is now hold in a distinct model
      */
-    Q_DECL_DEPRECATED Qt::SortOrder sortOrder() const SIP_DEPRECATED { return mSortOrder; }
+    Qt::SortOrder sortOrder() const { return mSortOrder; }
 
     /**
      * Sets the sort \a order for the column. This property is only used when the column
@@ -152,9 +151,8 @@ class CORE_EXPORT QgsLayoutTableColumn : public QObject
      * \note only applicable when used in a QgsLayoutItemAttributeTable
      * \see sortOrder()
      * \see setSortByRank()
-     * \deprecated since QGIS 3.14 the order is now hold in a distinct model
      */
-    Q_DECL_DEPRECATED void setSortOrder( Qt::SortOrder order ) SIP_DEPRECATED { mSortOrder = order; }
+    void setSortOrder( Qt::SortOrder order ) { mSortOrder = order; }
 
     /**
      * Returns the sort rank for the column. If the sort rank is > 0 then the column
@@ -168,7 +166,7 @@ class CORE_EXPORT QgsLayoutTableColumn : public QObject
      * \note only applicable when used in a QgsLayoutItemAttributeTable
      * \see setSortByRank()
      * \see sortOrder()
-     * \deprecated since QGIS 3.14 the order is now hold in a distinct model
+     * \deprecated since QGIS 3.14 the order is now hold in a dedicated model
      */
     Q_DECL_DEPRECATED int sortByRank() const SIP_DEPRECATED { return mSortByRank; }
 
@@ -183,7 +181,7 @@ class CORE_EXPORT QgsLayoutTableColumn : public QObject
      * \note only applicable when used in a QgsLayoutItemAttributeTable
      * \see sortByRank()
      * \see setSortOrder()
-     * \deprecated since QGIS 3.14 the order is now hold in a distinct model
+     * \deprecated since QGIS 3.14 the order is now hold in a dedicated model
      */
     Q_DECL_DEPRECATED void setSortByRank( int rank ) SIP_DEPRECATED { mSortByRank = rank; }
 
@@ -207,83 +205,4 @@ class CORE_EXPORT QgsLayoutTableColumn : public QObject
     friend class QgsCompositionConverter;
 
 };
-
-/**
- * \ingroup core
- * Stores properties of a column for the sorting of a QgsLayoutTable.
- * \since QGIS 3.14
-*/
-class CORE_EXPORT QgsLayoutTableSortColumn : public QObject
-{
-    Q_OBJECT
-
-  public:
-
-    /**
-     * Constructor for QgsLayoutTableColumn.
-     * \param heading column heading
-     */
-    QgsLayoutTableSortColumn();
-
-    /**
-     * Writes the column's properties to xml for storage.
-     * \param columnElem an existing QDomElement in which to store the column's properties.
-     * \param doc QDomDocument for the destination xml.
-     * \see readXml()
-     */
-    bool writeXml( QDomElement &columnElem, QDomDocument &doc ) const;
-
-    /**
-     * Reads the column's properties from xml.
-     * \param columnElem a QDomElement holding the column's desired properties.
-     * \see writeXml()
-     */
-    bool readXml( const QDomElement &columnElem );
-
-    /**
-     * Returns the attribute name or expression used for the column's values. This property
-     * is only used when the column is part of a QgsLayoutItemAttributeTable.
-     * \note only applicable when used in a QgsLayoutItemAttributeTable
-     * \see setAttribute()
-     */
-    QString attribute() const { return mAttribute; }
-
-    /**
-     * Sets the \a attribute name or expression used for the column's values. This property
-     * is only used when the column is part of a QgsLayoutItemAttributeTable.
-     * \note only applicable when used in a QgsLayoutItemAttributeTable
-     * \see attribute()
-     */
-    void setAttribute( const QString &attribute ) { mAttribute = attribute; }
-
-    /**
-     * Returns the sort order for the column. This property is only used when the column
-     * is part of a QgsLayoutItemAttributeTable and when sortByRank is > 0.
-     * \note only applicable when used in a QgsLayoutItemAttributeTable
-     * \see setSortOrder()
-     * \see sortByRank()
-     */
-    Qt::SortOrder sortOrder() const { return mSortOrder; }
-
-    /**
-     * Sets the sort \a order for the column. This property is only used when the column
-     * is part of a QgsLayoutItemAttributeTable and when sortByRank() is > 0.
-     * \note only applicable when used in a QgsLayoutItemAttributeTable
-     * \see sortOrder()
-     * \see setSortByRank()
-     */
-    void setSortOrder( Qt::SortOrder order ) { mSortOrder = order; }
-
-    /**
-     * Creates a duplicate column which is a deep copy of this column.
-     * \returns a new QgsLayoutTableSortColumn with same properties as this column.
-     */
-    QgsLayoutTableSortColumn *clone() SIP_FACTORY;
-
-  private:
-
-    QString mAttribute;
-    Qt::SortOrder mSortOrder = Qt::AscendingOrder;
-};
-
 #endif //QGSLAYOUTTABLECOLUMN_H

--- a/src/gui/layout/qgslayoutattributeselectiondialog.cpp
+++ b/src/gui/layout/qgslayoutattributeselectiondialog.cpp
@@ -231,38 +231,40 @@ bool QgsLayoutAttributeTableColumnModelBase::setData( const QModelIndex &index, 
   if ( index.column() > displayedColumns().count() )
     return false;
 
+  QgsLayoutTableColumn &colToUpdate = columns()[index.row()];
+
   Column col = displayedColumns()[index.column()];
   switch ( col )
   {
     case Attribute:
       // also update column's heading, if it hasn't been customized
-      if ( columns()[index.row()].heading().isEmpty() || ( columns()[index.row()].heading() == columns()[index.row()].attribute() ) )
+      if ( colToUpdate.heading().isEmpty() || ( colToUpdate.heading() == colToUpdate.attribute() ) )
       {
-        columns()[index.row()].setHeading( value.toString() );
+        colToUpdate.setHeading( value.toString() );
         emit dataChanged( createIndex( index.row(), 1 ), createIndex( index.row(), 1 ) );
       }
-      columns()[index.row()].setAttribute( value.toString() );
+      colToUpdate.setAttribute( value.toString() );
       emit dataChanged( index, index );
       return true;
 
     case Heading:
-      columns()[index.row()].setHeading( value.toString() );
+      colToUpdate.setHeading( value.toString() );
       emit dataChanged( index, index );
       return true;
 
     case Alignment:
-      columns()[index.row()].setHAlignment( Qt::AlignmentFlag( value.toInt() & Qt::AlignHorizontal_Mask ) );
-      columns()[index.row()].setVAlignment( Qt::AlignmentFlag( value.toInt() & Qt::AlignVertical_Mask ) );
+      colToUpdate.setHAlignment( Qt::AlignmentFlag( value.toInt() & Qt::AlignHorizontal_Mask ) );
+      colToUpdate.setVAlignment( Qt::AlignmentFlag( value.toInt() & Qt::AlignVertical_Mask ) );
       emit dataChanged( index, index );
       return true;
 
     case Width:
-      columns()[index.row()].setWidth( value.toDouble() );
+      colToUpdate.setWidth( value.toDouble() );
       emit dataChanged( index, index );
       return true;
 
     case SortOrder:
-      mTable->sortColumns()[index.row()].setSortOrder( static_cast< Qt::SortOrder >( value.toInt() ) );
+      colToUpdate.setSortOrder( static_cast< Qt::SortOrder >( value.toInt() ) );
       emit dataChanged( index, index );
       return true;
   }

--- a/src/gui/layout/qgslayoutattributeselectiondialog.cpp
+++ b/src/gui/layout/qgslayoutattributeselectiondialog.cpp
@@ -418,7 +418,7 @@ QVariant QgsLayoutTableSortModel::data( const QModelIndex &index, int role ) con
   }
 
   //get column for index
-  QgsLayoutTableSortColumn *column = columnFromIndex( index );
+  QgsLayoutTableColumn *column = columnFromIndex( index );
   if ( !column )
   {
     return QVariant();
@@ -504,7 +504,7 @@ bool QgsLayoutTableSortModel::setData( const QModelIndex &index, const QVariant 
   }
 
   //get column for index
-  QgsLayoutTableSortColumn *column = columnFromIndex( index );
+  QgsLayoutTableColumn *column = columnFromIndex( index );
   if ( !column )
   {
     return false;
@@ -564,7 +564,7 @@ bool QgsLayoutTableSortModel::insertRows( int row, int count, const QModelIndex 
   //create new QgsComposerTableColumns for each inserted row
   for ( int i = row; i < row + count; ++i )
   {
-    QgsLayoutTableSortColumn *col = new QgsLayoutTableSortColumn;
+    QgsLayoutTableColumn *col = new QgsLayoutTableColumn;
     mTable->sortColumns().insert( i, col );
   }
   endInsertRows();
@@ -585,7 +585,7 @@ bool QgsLayoutTableSortModel::moveRow( int row, ShiftDirection direction )
 
   //remove row
   beginRemoveRows( QModelIndex(), swapWithRow, swapWithRow );
-  QgsLayoutTableSortColumn *temp = mTable->sortColumns().takeAt( swapWithRow );
+  QgsLayoutTableColumn *temp = mTable->sortColumns().takeAt( swapWithRow );
   endRemoveRows();
 
   //insert row
@@ -596,13 +596,13 @@ bool QgsLayoutTableSortModel::moveRow( int row, ShiftDirection direction )
   return true;
 }
 
-QgsLayoutTableSortColumn *QgsLayoutTableSortModel::columnFromIndex( const QModelIndex &index ) const
+QgsLayoutTableColumn *QgsLayoutTableSortModel::columnFromIndex( const QModelIndex &index ) const
 {
-  QgsLayoutTableSortColumn *column = static_cast<QgsLayoutTableSortColumn *>( index.internalPointer() );
+  QgsLayoutTableColumn *column = static_cast<QgsLayoutTableColumn *>( index.internalPointer() );
   return column;
 }
 
-QModelIndex QgsLayoutTableSortModel::indexFromColumn( QgsLayoutTableSortColumn *column )
+QModelIndex QgsLayoutTableSortModel::indexFromColumn( QgsLayoutTableColumn *column )
 {
   if ( !mTable )
   {

--- a/src/gui/layout/qgslayoutattributeselectiondialog.h
+++ b/src/gui/layout/qgslayoutattributeselectiondialog.h
@@ -65,13 +65,16 @@ class GUI_EXPORT QgsLayoutAttributeTableColumnModelBase: public QAbstractTableMo
       ShiftDown //!< Shift the row/column down
     };
 
+    /**
+     * Available columns for the configuration table to be used by the model
+     */
     enum Column
     {
-      Attribute,
-      Heading,
-      Alignment,
-      Width,
-      SortOrder
+      Attribute, //!< Attribute for a field or an expression
+      Heading, //!< Defines the title of the column
+      Alignment, //!< Defines the alignment of the column
+      Width, //!< Defines the width of the column
+      SortOrder //!< Defines the sort order
     };
 
     /**

--- a/src/gui/layout/qgslayoutattributeselectiondialog.h
+++ b/src/gui/layout/qgslayoutattributeselectiondialog.h
@@ -100,15 +100,8 @@ class GUI_EXPORT QgsLayoutAttributeTableColumnModel: public QAbstractTableModel
 
     /**
      * Returns the QgsLayoutTableColumn corresponding to an index in the model.
-     * \see indexFromColumn()
      */
-    QgsLayoutTableColumn *columnFromIndex( const QModelIndex &index ) const;
-
-    /**
-     * Returns a QModelIndex corresponding to a QgsLayoutTableColumn in the model.
-     * \see columnFromIndex()
-     */
-    QModelIndex indexFromColumn( QgsLayoutTableColumn *column );
+    QgsLayoutTableColumn columnFromIndex( const QModelIndex &index ) const;
 
   private:
     QgsLayoutItemAttributeTable *mTable = nullptr;
@@ -167,15 +160,8 @@ class GUI_EXPORT QgsLayoutTableSortModel: public QAbstractTableModel
 
     /**
      * Returns the QgsLayoutTableSortColumn corresponding to an index in the model.
-     * \see indexFromColumn()
      */
-    QgsLayoutTableColumn *columnFromIndex( const QModelIndex &index ) const;
-
-    /**
-     * Returns a QModelIndex corresponding to a QgsLayoutTableSortColumn in the model.
-     * \see columnFromIndex()
-     */
-    QModelIndex indexFromColumn( QgsLayoutTableColumn *column );
+    QgsLayoutTableColumn columnFromIndex( const QModelIndex &index ) const;
 
   private:
     QgsLayoutItemAttributeTable *mTable = nullptr;

--- a/src/gui/layout/qgslayoutattributeselectiondialog.h
+++ b/src/gui/layout/qgslayoutattributeselectiondialog.h
@@ -41,7 +41,7 @@ class QgsLayoutTableSortModel;
 class QgsLayoutTableAvailableSortProxyModel;
 class QgsLayoutObject;
 class QgsLayoutTableColumn;
-class QgsLayoutTableSortColumn;
+class QgsLayoutTableColumn;
 
 /**
  * \ingroup gui
@@ -169,13 +169,13 @@ class GUI_EXPORT QgsLayoutTableSortModel: public QAbstractTableModel
      * Returns the QgsLayoutTableSortColumn corresponding to an index in the model.
      * \see indexFromColumn()
      */
-    QgsLayoutTableSortColumn *columnFromIndex( const QModelIndex &index ) const;
+    QgsLayoutTableColumn *columnFromIndex( const QModelIndex &index ) const;
 
     /**
      * Returns a QModelIndex corresponding to a QgsLayoutTableSortColumn in the model.
      * \see columnFromIndex()
      */
-    QModelIndex indexFromColumn( QgsLayoutTableSortColumn *column );
+    QModelIndex indexFromColumn( QgsLayoutTableColumn *column );
 
   private:
     QgsLayoutItemAttributeTable *mTable = nullptr;

--- a/src/gui/layout/qgslayoutattributetablewidget.cpp
+++ b/src/gui/layout/qgslayoutattributetablewidget.cpp
@@ -234,6 +234,14 @@ void QgsLayoutAttributeTableWidget::mAttributesPushButton_clicked()
     currentColumns.append( copy );
   }
 
+  QVector<QgsLayoutTableSortColumn *> currentSortColumns;
+  auto sit = mTable->sortColumns().constBegin();
+  for ( ; sit != mTable->sortColumns().constEnd() ; ++sit )
+  {
+    QgsLayoutTableSortColumn *copy = ( *sit )->clone();
+    currentSortColumns.append( copy );
+  }
+
   mTable->beginCommand( tr( "Change Table Attributes" ) );
 
   //temporarily block updates for the window, to stop table trying to repaint under windows (#11462)
@@ -251,11 +259,14 @@ void QgsLayoutAttributeTableWidget::mAttributesPushButton_clicked()
     //clear currentColumns to free memory
     qDeleteAll( currentColumns );
     currentColumns.clear();
+    qDeleteAll( currentSortColumns );
+    currentSortColumns.clear();
   }
   else
   {
     //undo changes
     mTable->setColumns( currentColumns );
+    mTable->setSortColumns( currentSortColumns );
     window()->setUpdatesEnabled( true );
     mTable->cancelCommand();
   }

--- a/src/gui/layout/qgslayoutattributetablewidget.cpp
+++ b/src/gui/layout/qgslayoutattributetablewidget.cpp
@@ -226,21 +226,8 @@ void QgsLayoutAttributeTableWidget::mAttributesPushButton_clicked()
   }
 
   //make deep copy of current columns, so we can restore them in case of cancellation
-  QVector<QgsLayoutTableColumn *> currentColumns;
-  auto it = mTable->columns().constBegin();
-  for ( ; it != mTable->columns().constEnd() ; ++it )
-  {
-    QgsLayoutTableColumn *copy = ( *it )->clone();
-    currentColumns.append( copy );
-  }
-
-  QVector<QgsLayoutTableColumn *> currentSortColumns;
-  auto sit = mTable->sortColumns().constBegin();
-  for ( ; sit != mTable->sortColumns().constEnd() ; ++sit )
-  {
-    QgsLayoutTableColumn *copy = ( *sit )->clone();
-    currentSortColumns.append( copy );
-  }
+  QVector<QgsLayoutTableColumn> currentColumns = mTable->columns();
+  QVector<QgsLayoutTableColumn> currentSortColumns = mTable->sortColumns();
 
   mTable->beginCommand( tr( "Change Table Attributes" ) );
 
@@ -257,9 +244,7 @@ void QgsLayoutAttributeTableWidget::mAttributesPushButton_clicked()
     mTable->endCommand();
 
     //clear currentColumns to free memory
-    qDeleteAll( currentColumns );
     currentColumns.clear();
-    qDeleteAll( currentSortColumns );
     currentSortColumns.clear();
   }
   else

--- a/src/gui/layout/qgslayoutattributetablewidget.cpp
+++ b/src/gui/layout/qgslayoutattributetablewidget.cpp
@@ -234,11 +234,11 @@ void QgsLayoutAttributeTableWidget::mAttributesPushButton_clicked()
     currentColumns.append( copy );
   }
 
-  QVector<QgsLayoutTableSortColumn *> currentSortColumns;
+  QVector<QgsLayoutTableColumn *> currentSortColumns;
   auto sit = mTable->sortColumns().constBegin();
   for ( ; sit != mTable->sortColumns().constEnd() ; ++sit )
   {
-    QgsLayoutTableSortColumn *copy = ( *sit )->clone();
+    QgsLayoutTableColumn *copy = ( *sit )->clone();
     currentSortColumns.append( copy );
   }
 

--- a/src/gui/layout/qgslayoutmanualtablewidget.cpp
+++ b/src/gui/layout/qgslayoutmanualtablewidget.cpp
@@ -188,7 +188,7 @@ void QgsLayoutManualTableWidget::setTableContents()
     for ( double width : columnWidths )
     {
       mEditorDialog->setTableColumnWidth( col, width );
-      headers << ( mTable->headers().size() > col ? mTable->headers().value( col )->heading() : QVariant() );
+      headers << ( col < mTable->headers().count() ? mTable->headers().value( col ).heading() : QVariant() );
       col++;
     }
     mEditorDialog->setTableHeaders( headers );
@@ -206,7 +206,7 @@ void QgsLayoutManualTableWidget::setTableContents()
           QgsLayoutTableColumns headers;
           for ( const QVariant &h : headerText )
           {
-            headers << new QgsLayoutTableColumn( h.toString() );
+            headers << QgsLayoutTableColumn( h.toString() );
           }
           mTable->setHeaders( headers );
         }

--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -1687,12 +1687,12 @@ bool QgsGeorefPluginGui::writePDFReportFile( const QString &fileName, const QgsG
     parameterTable->setContentFont( tableContentFont );
 
     QgsLayoutTableColumns columns;
-    columns << new QgsLayoutTableColumn( tr( "Translation x" ) )
-            << new QgsLayoutTableColumn( tr( "Translation y" ) )
-            << new QgsLayoutTableColumn( tr( "Scale x" ) )
-            << new QgsLayoutTableColumn( tr( "Scale y" ) )
-            << new QgsLayoutTableColumn( tr( "Rotation [degrees]" ) )
-            << new QgsLayoutTableColumn( tr( "Mean error [%1]" ).arg( residualUnits ) );
+    columns << QgsLayoutTableColumn( tr( "Translation x" ) )
+            << QgsLayoutTableColumn( tr( "Translation y" ) )
+            << QgsLayoutTableColumn( tr( "Scale x" ) )
+            << QgsLayoutTableColumn( tr( "Scale y" ) )
+            << QgsLayoutTableColumn( tr( "Rotation [degrees]" ) )
+            << QgsLayoutTableColumn( tr( "Mean error [%1]" ).arg( residualUnits ) );
 
     parameterTable->setColumns( columns );
     QStringList row;
@@ -1730,15 +1730,15 @@ bool QgsGeorefPluginGui::writePDFReportFile( const QString &fileName, const QgsG
   gcpTable->setContentFont( tableContentFont );
   gcpTable->setHeaderMode( QgsLayoutTable::AllFrames );
   QgsLayoutTableColumns columns;
-  columns << new QgsLayoutTableColumn( tr( "ID" ) )
-          << new QgsLayoutTableColumn( tr( "Enabled" ) )
-          << new QgsLayoutTableColumn( tr( "Pixel X" ) )
-          << new QgsLayoutTableColumn( tr( "Pixel Y" ) )
-          << new QgsLayoutTableColumn( tr( "Map X" ) )
-          << new QgsLayoutTableColumn( tr( "Map Y" ) )
-          << new QgsLayoutTableColumn( tr( "Res X (%1)" ).arg( residualUnits ) )
-          << new QgsLayoutTableColumn( tr( "Res Y (%1)" ).arg( residualUnits ) )
-          << new QgsLayoutTableColumn( tr( "Res Total (%1)" ).arg( residualUnits ) );
+  columns << QgsLayoutTableColumn( tr( "ID" ) )
+          << QgsLayoutTableColumn( tr( "Enabled" ) )
+          << QgsLayoutTableColumn( tr( "Pixel X" ) )
+          << QgsLayoutTableColumn( tr( "Pixel Y" ) )
+          << QgsLayoutTableColumn( tr( "Map X" ) )
+          << QgsLayoutTableColumn( tr( "Map Y" ) )
+          << QgsLayoutTableColumn( tr( "Res X (%1)" ).arg( residualUnits ) )
+          << QgsLayoutTableColumn( tr( "Res Y (%1)" ).arg( residualUnits ) )
+          << QgsLayoutTableColumn( tr( "Res Total (%1)" ).arg( residualUnits ) );
 
   gcpTable->setColumns( columns );
 

--- a/src/ui/layout/qgslayoutattributeselectiondialogbase.ui
+++ b/src/ui/layout/qgslayoutattributeselectiondialogbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>517</width>
+    <width>533</width>
     <height>729</height>
    </rect>
   </property>
@@ -141,47 +141,19 @@
       </property>
       <layout class="QGridLayout" name="gridLayout_3">
        <item row="0" column="0">
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
-          <widget class="QComboBox" name="mSortColumnComboBox">
-           <property name="minimumSize">
-            <size>
-             <width>180</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="mOrderComboBox">
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="mAddSortColumnPushButton">
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="icon">
-            <iconset resource="../../../images/images.qrc">
-             <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-           </property>
-          </widget>
-         </item>
-        </layout>
+        <widget class="QTableView" name="mSortColumnTableView">
+         <property name="editTriggers">
+          <set>QAbstractItemView::AllEditTriggers</set>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::SingleSelection</enum>
+         </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectRows</enum>
+         </property>
+        </widget>
        </item>
-       <item row="2" column="0">
+       <item row="1" column="0">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="QPushButton" name="mSortColumnUpPushButton">
@@ -202,6 +174,23 @@
            <property name="icon">
             <iconset resource="../../../images/images.qrc">
              <normaloff>:/images/themes/default/mActionArrowDown.svg</normaloff>:/images/themes/default/mActionArrowDown.svg</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="mAddSortColumnPushButton">
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../images/images.qrc">
+             <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
            </property>
           </widget>
          </item>
@@ -231,19 +220,6 @@
          </item>
         </layout>
        </item>
-       <item row="1" column="0">
-        <widget class="QTableView" name="mSortColumnTableView">
-         <property name="editTriggers">
-          <set>QAbstractItemView::AllEditTriggers</set>
-         </property>
-         <property name="selectionMode">
-          <enum>QAbstractItemView::SingleSelection</enum>
-         </property>
-         <property name="selectionBehavior">
-          <enum>QAbstractItemView::SelectRows</enum>
-         </property>
-        </widget>
-       </item>
       </layout>
      </widget>
     </widget>
@@ -267,9 +243,6 @@
   <tabstop>mAddColumnPushButton</tabstop>
   <tabstop>mRemoveColumnPushButton</tabstop>
   <tabstop>mResetColumnsPushButton</tabstop>
-  <tabstop>mSortColumnComboBox</tabstop>
-  <tabstop>mOrderComboBox</tabstop>
-  <tabstop>mAddSortColumnPushButton</tabstop>
   <tabstop>mSortColumnTableView</tabstop>
   <tabstop>mSortColumnUpPushButton</tabstop>
   <tabstop>mSortColumnDownPushButton</tabstop>

--- a/tests/src/core/testqgslayoutmanualtable.cpp
+++ b/tests/src/core/testqgslayoutmanualtable.cpp
@@ -404,9 +404,9 @@ void TestQgsLayoutManualTable::headers()
   table->setTableContents( QgsTableContents() << ( QgsTableRow() << QgsTableCell( QStringLiteral( "Jet" ) ) << QgsTableCell( QStringLiteral( "Helicopter" ) ) << QgsTableCell( QStringLiteral( "Plane" ) ) )
                            << ( QgsTableRow() << QgsTableCell( QStringLiteral( "A" ) ) << QgsTableCell( QStringLiteral( "B" ) ) << QgsTableCell( QStringLiteral( "C" ) ) ) );
   table->setIncludeTableHeader( true );
-  table->setHeaders( QgsLayoutTableColumns() << new QgsLayoutTableColumn( QStringLiteral( "header1" ) )
-                     << new QgsLayoutTableColumn( QStringLiteral( "h2" ) )
-                     << new QgsLayoutTableColumn( QStringLiteral( "header 3" ) ) );
+  table->setHeaders( QgsLayoutTableColumns() << QgsLayoutTableColumn( QStringLiteral( "header1" ) )
+                     << QgsLayoutTableColumn( QStringLiteral( "h2" ) )
+                     << QgsLayoutTableColumn( QStringLiteral( "header 3" ) ) );
 
   QgsLayoutChecker checker( QStringLiteral( "manualtable_headers" ), &l );
   checker.setControlPathPrefix( QStringLiteral( "layout_manual_table" ) );

--- a/tests/src/core/testqgslayouttable.cpp
+++ b/tests/src/core/testqgslayouttable.cpp
@@ -469,7 +469,7 @@ void TestQgsLayoutTable::manualColumnWidth()
   table->setBackgroundColor( Qt::yellow );
 
   table->setMaximumNumberOfFeatures( 20 );
-  table->columns().at( 0 )->setWidth( 5 );
+  table->columns()[0].setWidth( 5 );
   QgsLayoutChecker checker( QStringLiteral( "composerattributetable_columnwidth" ), &l );
   checker.setControlPathPrefix( QStringLiteral( "composer_table" ) );
   bool result = checker.testLayout( mReport, 0 );
@@ -700,8 +700,8 @@ void TestQgsLayoutTable::attributeTableRestoreAtlasSource()
   QVERIFY( l->atlas()->coverageLayer()->isValid() );
   QCOMPARE( table->sourceLayer(), l->atlas()->coverageLayer() );
   QCOMPARE( table->columns().count(), 2 );
-  QCOMPARE( table->columns().at( 0 )->attribute(), QStringLiteral( "Heading" ) );
-  QCOMPARE( table->columns().at( 1 )->attribute(), QStringLiteral( "Staff" ) );
+  QCOMPARE( table->columns()[0].attribute(), QStringLiteral( "Heading" ) );
+  QCOMPARE( table->columns()[1].attribute(), QStringLiteral( "Staff" ) );
 }
 
 
@@ -870,10 +870,10 @@ void TestQgsLayoutTable::removeDuplicates()
 
   //check if removing attributes in unique mode works correctly (should result in duplicate rows,
   //which will be stripped out)
-  delete table->columns().takeLast();
+  table->columns().takeLast();
   table->refreshAttributes();
   QCOMPARE( table->contents().length(), 2 );
-  delete table->columns().takeLast();
+  table->columns().takeLast();
   table->refreshAttributes();
   QCOMPARE( table->contents().length(), 1 );
   table->setUniqueRowsOnly( false );
@@ -1093,12 +1093,12 @@ void TestQgsLayoutTable::align()
   table->setMaximumNumberOfFeatures( 20 );
   table->setVectorLayer( multiLineLayer );
 
-  table->columns().at( 0 )->setHAlignment( Qt::AlignLeft );
-  table->columns().at( 0 )->setVAlignment( Qt::AlignTop );
-  table->columns().at( 1 )->setHAlignment( Qt::AlignHCenter );
-  table->columns().at( 1 )->setVAlignment( Qt::AlignVCenter );
-  table->columns().at( 2 )->setHAlignment( Qt::AlignRight );
-  table->columns(). at( 2 )->setVAlignment( Qt::AlignBottom );
+  table->columns()[0].setHAlignment( Qt::AlignLeft );
+  table->columns()[0].setVAlignment( Qt::AlignTop );
+  table->columns()[1].setHAlignment( Qt::AlignHCenter );
+  table->columns()[1].setVAlignment( Qt::AlignVCenter );
+  table->columns()[2].setHAlignment( Qt::AlignRight );
+  table->columns()[2].setVAlignment( Qt::AlignBottom );
   QgsLayoutChecker checker( QStringLiteral( "composerattributetable_align" ), &l );
   checker.setControlPathPrefix( QStringLiteral( "composer_table" ) );
   bool result = checker.testLayout( mReport );
@@ -1186,8 +1186,8 @@ void TestQgsLayoutTable::autoWrap()
   table->setVectorLayer( multiLineLayer.get() );
   table->setWrapBehavior( QgsLayoutTable::WrapText );
 
-  table->columns().at( 0 )->setWidth( 25 );
-  table->columns().at( 1 )->setWidth( 25 );
+  table->columns()[0].setWidth( 25 );
+  table->columns()[1].setWidth( 25 );
   QgsLayoutChecker checker( QStringLiteral( "composerattributetable_autowrap" ), &l );
   checker.setControlPathPrefix( QStringLiteral( "composer_table" ) );
   bool result = checker.testLayout( mReport, 0 );
@@ -1593,8 +1593,8 @@ void TestQgsLayoutTable::testBaseSort()
   table->setVectorLayer( mVectorLayer );
   table->setDisplayOnlyVisibleFeatures( false );
   table->setMaximumNumberOfFeatures( 1 );
-  table->columns().at( 2 )->setSortByRank( 1 );
-  table->columns().at( 2 )->setSortOrder( Qt::DescendingOrder );
+  table->columns()[2].setSortByRank( 1 );
+  table->columns()[2].setSortOrder( Qt::DescendingOrder );
   table->refresh();
 
   QVector<QStringList> expectedRows;
@@ -1615,10 +1615,10 @@ void TestQgsLayoutTable::testExpressionSort()
   table->setVectorLayer( mVectorLayer );
   table->setDisplayOnlyVisibleFeatures( false );
   table->setMaximumNumberOfFeatures( 1 );
-  table->columns().at( 0 )->setAttribute( "Heading * -1" );
-  table->columns().at( 0 )->setHeading( "exp" );
-  table->columns().at( 0 )->setSortByRank( 1 );
-  table->columns().at( 0 )->setSortOrder( Qt::AscendingOrder );
+  table->columns()[0].setAttribute( "Heading * -1" );
+  table->columns()[0].setHeading( "exp" );
+  table->columns()[0].setSortByRank( 1 );
+  table->columns()[0].setSortOrder( Qt::AscendingOrder );
   table->refresh();
 
   QVector<QStringList> expectedRows;

--- a/tests/src/core/testqgslayouttable.cpp
+++ b/tests/src/core/testqgslayouttable.cpp
@@ -1593,8 +1593,10 @@ void TestQgsLayoutTable::testBaseSort()
   table->setVectorLayer( mVectorLayer );
   table->setDisplayOnlyVisibleFeatures( false );
   table->setMaximumNumberOfFeatures( 1 );
-  table->columns()[2].setSortByRank( 1 );
-  table->columns()[2].setSortOrder( Qt::DescendingOrder );
+  QgsLayoutTableColumn col;
+  col.setAttribute(table->columns()[2].attribute());
+  col.setSortOrder( Qt::DescendingOrder );
+  table->sortColumns() = {col};
   table->refresh();
 
   QVector<QStringList> expectedRows;
@@ -1615,10 +1617,12 @@ void TestQgsLayoutTable::testExpressionSort()
   table->setVectorLayer( mVectorLayer );
   table->setDisplayOnlyVisibleFeatures( false );
   table->setMaximumNumberOfFeatures( 1 );
-  table->columns()[0].setAttribute( "Heading * -1" );
-  table->columns()[0].setHeading( "exp" );
-  table->columns()[0].setSortByRank( 1 );
-  table->columns()[0].setSortOrder( Qt::AscendingOrder );
+  QgsLayoutTableColumn col;
+  col.setAttribute( "Heading * -1" );
+  col.setHeading( "exp" );
+  col.setSortOrder( Qt::AscendingOrder );
+  table->sortColumns() = {col};
+  table->columns()[0] = col;
   table->refresh();
 
   QVector<QStringList> expectedRows;

--- a/tests/src/core/testqgslayouttable.cpp
+++ b/tests/src/core/testqgslayouttable.cpp
@@ -1594,7 +1594,7 @@ void TestQgsLayoutTable::testBaseSort()
   table->setDisplayOnlyVisibleFeatures( false );
   table->setMaximumNumberOfFeatures( 1 );
   QgsLayoutTableColumn col;
-  col.setAttribute(table->columns()[2].attribute());
+  col.setAttribute( table->columns()[2].attribute() );
   col.setSortOrder( Qt::DescendingOrder );
   table->sortColumns() = {col};
   table->refresh();


### PR DESCRIPTION
instead of using the same data model for the displayed and the sorting columns, two data models are now used.
They use the same API / base class as they are very similar.
QgsLayoutTableColumn is no longer a QObject.

this fixes #25671

a new feature with less lines in the code base 💪 