### PR TITLE
Fix expression description HTML

### DIFF
--- a/python/gui/auto_generated/qgsexpressionstoredialog.sip.in
+++ b/python/gui/auto_generated/qgsexpressionstoredialog.sip.in
@@ -44,7 +44,7 @@ Returns the expression text
 Returns the label text
 %End
 
-    QString helpText();
+    QString helpText() const;
 %Docstring
 Returns the help text
 %End

--- a/src/gui/qgsexpressionstoredialog.cpp
+++ b/src/gui/qgsexpressionstoredialog.cpp
@@ -59,3 +59,10 @@ QgsExpressionStoreDialog::QgsExpressionStoreDialog( const QString &label, const 
   mLabel->setText( labelFixed );
 }
 
+QString QgsExpressionStoreDialog::helpText()
+{
+  // remove meta qrichtext instruction from html. It fails rendering
+  // when mixing with other html content
+  // see issue https://github.com/qgis/QGIS/issues/36191
+  return mHelpText->toHtml().replace( "<meta name=\"qrichtext\" content=\"1\" />", QString() );
+}

--- a/src/gui/qgsexpressionstoredialog.cpp
+++ b/src/gui/qgsexpressionstoredialog.cpp
@@ -59,7 +59,7 @@ QgsExpressionStoreDialog::QgsExpressionStoreDialog( const QString &label, const 
   mLabel->setText( labelFixed );
 }
 
-QString QgsExpressionStoreDialog::helpText()
+QString QgsExpressionStoreDialog::helpText() const
 {
   // remove meta qrichtext instruction from html. It fails rendering
   // when mixing with other html content

--- a/src/gui/qgsexpressionstoredialog.h
+++ b/src/gui/qgsexpressionstoredialog.h
@@ -55,7 +55,7 @@ class GUI_EXPORT QgsExpressionStoreDialog : public QDialog, private Ui::QgsExpre
     /**
      * Returns the help text
      */
-    QString helpText() { return  mHelpText->toHtml(); }
+    QString helpText();
 
   private:
 

--- a/src/gui/qgsexpressionstoredialog.h
+++ b/src/gui/qgsexpressionstoredialog.h
@@ -55,7 +55,7 @@ class GUI_EXPORT QgsExpressionStoreDialog : public QDialog, private Ui::QgsExpre
     /**
      * Returns the help text
      */
-    QString helpText();
+    QString helpText() const;
 
   private:
 


### PR DESCRIPTION
## Description

Fixes #36191

When mixed with other html content, expression description HTML makes the rendering of carriage return in `<pre>` fails because of the following line in HTML

```html
<meta name="qrichtext" content="1" />
```
This PR proposes to remove this line from the returned HTML.
