### PR TITLE
[themes] Style checked style of push buttons

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -265,6 +265,11 @@ QPushButton:pressed, QToolButton:pressed, QTabWidget::top-bar QToolButton:presse
     background-color: @darkalternativegradient;
 }
 
+QPushButton:open {
+    background-color: @darkalternativegradient;
+    border: 1px solid @selection;
+}
+
 /* ==================================================================================== */
 /* COMBO BOX                                                                            */
 /* ==================================================================================== */

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -275,6 +275,11 @@ QPushButton:pressed, QToolButton:pressed {
     background-color: @darkalternativegradient;
 }
 
+QPushButton:open {
+    background-color: @darkalternativegradient;
+    border: 1px solid @focus;
+}
+
 /* ==================================================================================== */
 /* COMBO BOX                                                                            */
 /* ==================================================================================== */


### PR DESCRIPTION
## Description

Needed so we can enjoy our temporal canvas playbacks:
![Screenshot from 2020-05-07 16-23-12](https://user-images.githubusercontent.com/1728657/81277896-36089580-907f-11ea-8ce1-b7053525d82f.png)

Without this fix, checked/active push buttons aren't styled so it's impossible to know whether the play forward/backward button is active or not.