### PR TITLE
add "All supported" filter to the open vector and raster dialogs (fix #13239)

### DIFF
--- a/python/gui/auto_generated/qgsfilewidget.sip.in
+++ b/python/gui/auto_generated/qgsfilewidget.sip.in
@@ -98,6 +98,20 @@ setFilter sets the filter used by the model to filters. The filter is used to sp
 :param filter: Only files that match the given filter are shown, it may be an empty string. If you want multiple filters, separate them with ';;',
 %End
 
+    QFileDialog::Options options() const;
+%Docstring
+Returns additional options used for QFileDialog
+
+.. versionadded:: 3.14
+%End
+
+    void setOptions( QFileDialog::Options options );
+%Docstring
+setOptions sets additional options used for QFileDialog. These options affect the look and feel of the QFileDialog
+
+.. versionadded:: 3.14
+%End
+
     void setSelectedFilter( const QString &selectedFilter );
 %Docstring
 Sets the selected filter when the file dialog opens.

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -2286,6 +2286,12 @@ void buildSupportedRasterFileFilterAndExtensions( QString &fileFiltersString, QS
     extensions << QStringLiteral( "zip" ) << QStringLiteral( "gz" ) << QStringLiteral( "tar" ) << QStringLiteral( "tar.gz" ) << QStringLiteral( "tgz" );
   }
 
+  // can't forget the all supported case
+  QStringList exts;
+  for ( const QString &ext : qgis::as_const( extensions ) )
+    exts << QStringLiteral( "*.%1 *.%2" ).arg( ext, ext.toUpper() );
+  fileFiltersString.prepend( QObject::tr( "All supported files" ) + QStringLiteral( " (%1);;" ).arg( exts.join( QStringLiteral( " " ) ) ) );
+
   // can't forget the default case - first
   fileFiltersString.prepend( QObject::tr( "All files" ) + " (*);;" );
 

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3306,11 +3306,17 @@ QString createFilters( const QString &type )
     {
       sFileFilters.prepend( createFileFilter_( QObject::tr( "GDAL/OGR VSIFileHandler" ), QStringLiteral( "*.zip *.gz *.tar *.tar.gz *.tgz" ) ) );
       sExtensions << QStringLiteral( "zip" ) << QStringLiteral( "gz" ) << QStringLiteral( "tar" ) << QStringLiteral( "tar.gz" ) << QStringLiteral( "tgz" );
-
     }
+
+    // can't forget the all supported case
+    QStringList exts;
+    for ( const QString &ext : qgis::as_const( sExtensions ) )
+      exts << QStringLiteral( "*.%1 *.%2" ).arg( ext, ext.toUpper() );
+    sFileFilters.prepend( QObject::tr( "All supported files" ) + QStringLiteral( " (%1);;" ).arg( exts.join( QStringLiteral( " " ) ) ) );
 
     // can't forget the default case - first
     sFileFilters.prepend( QObject::tr( "All files" ) + " (*);;" );
+
 
     // cleanup
     if ( sFileFilters.endsWith( QLatin1String( ";;" ) ) ) sFileFilters.chop( 2 );

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -70,6 +70,7 @@ QgsGdalSourceSelect::QgsGdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
   mFileWidget->setDialogTitle( tr( "Open GDAL Supported Raster Dataset(s)" ) );
   mFileWidget->setFilter( QgsProviderRegistry::instance()->fileRasterFilters() );
   mFileWidget->setStorageMode( QgsFileWidget::GetMultipleFiles );
+  mFileWidget->setOptions( QFileDialog::HideNameFilterDetails );
   connect( mFileWidget, &QgsFileWidget::fileChanged, this, [ = ]( const QString & path )
   {
     mRasterPath = path;

--- a/src/gui/providers/ogr/qgsogrsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrsourceselect.cpp
@@ -111,6 +111,7 @@ QgsOgrSourceSelect::QgsOgrSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
   mFileWidget->setDialogTitle( tr( "Open OGR Supported Vector Dataset(s)" ) );
   mFileWidget->setFilter( mVectorFileFilter );
   mFileWidget->setStorageMode( QgsFileWidget::GetMultipleFiles );
+  mFileWidget->setOptions( QFileDialog::HideNameFilterDetails );
 
   connect( mFileWidget, &QgsFileWidget::fileChanged, this, [ = ]( const QString & path )
   {

--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -19,7 +19,6 @@
 #include <QLineEdit>
 #include <QToolButton>
 #include <QLabel>
-#include <QFileDialog>
 #include <QGridLayout>
 #include <QUrl>
 #include <QDropEvent>
@@ -130,6 +129,16 @@ void QgsFileWidget::setFilter( const QString &filters )
 {
   mFilter = filters;
   mLineEdit->setFilters( filters );
+}
+
+QFileDialog::Options QgsFileWidget::options() const
+{
+  return mOptions;
+}
+
+void QgsFileWidget::setOptions( QFileDialog::Options options )
+{
+  mOptions = options;
 }
 
 bool QgsFileWidget::fileWidgetButtonVisible() const
@@ -305,26 +314,26 @@ void QgsFileWidget::openFileDialog()
   {
     case GetFile:
       title = !mDialogTitle.isEmpty() ? mDialogTitle : tr( "Select a file" );
-      fileName = QFileDialog::getOpenFileName( this, title, QFileInfo( oldPath ).absoluteFilePath(), mFilter, &mSelectedFilter );
+      fileName = QFileDialog::getOpenFileName( this, title, QFileInfo( oldPath ).absoluteFilePath(), mFilter, &mSelectedFilter, mOptions );
       break;
     case GetMultipleFiles:
       title = !mDialogTitle.isEmpty() ? mDialogTitle : tr( "Select one or more files" );
-      fileNames = QFileDialog::getOpenFileNames( this, title, QFileInfo( oldPath ).absoluteFilePath(), mFilter, &mSelectedFilter );
+      fileNames = QFileDialog::getOpenFileNames( this, title, QFileInfo( oldPath ).absoluteFilePath(), mFilter, &mSelectedFilter, mOptions );
       break;
     case GetDirectory:
       title = !mDialogTitle.isEmpty() ? mDialogTitle : tr( "Select a directory" );
-      fileName = QFileDialog::getExistingDirectory( this, title, QFileInfo( oldPath ).absoluteFilePath(),  QFileDialog::ShowDirsOnly );
+      fileName = QFileDialog::getExistingDirectory( this, title, QFileInfo( oldPath ).absoluteFilePath(), mOptions | QFileDialog::ShowDirsOnly );
       break;
     case SaveFile:
     {
       title = !mDialogTitle.isEmpty() ? mDialogTitle : tr( "Create or select a file" );
       if ( !confirmOverwrite() )
       {
-        fileName = QFileDialog::getSaveFileName( this, title, QFileInfo( oldPath ).absoluteFilePath(), mFilter, &mSelectedFilter, QFileDialog::DontConfirmOverwrite );
+        fileName = QFileDialog::getSaveFileName( this, title, QFileInfo( oldPath ).absoluteFilePath(), mFilter, &mSelectedFilter, mOptions | QFileDialog::DontConfirmOverwrite );
       }
       else
       {
-        fileName = QFileDialog::getSaveFileName( this, title, QFileInfo( oldPath ).absoluteFilePath(), mFilter, &mSelectedFilter );
+        fileName = QFileDialog::getSaveFileName( this, title, QFileInfo( oldPath ).absoluteFilePath(), mFilter, &mSelectedFilter, mOptions );
       }
 
       // make sure filename ends with filter. This isn't automatically done by

--- a/src/gui/qgsfilewidget.h
+++ b/src/gui/qgsfilewidget.h
@@ -23,6 +23,7 @@ class QVariant;
 class QgsFileDropEdit;
 class QHBoxLayout;
 #include <QWidget>
+#include <QFileDialog>
 
 #include "qgis_gui.h"
 #include "qgis_sip.h"
@@ -44,7 +45,6 @@ class GUI_EXPORT QgsFileWidget : public QWidget
     SIP_END
 #endif
 
-
     Q_OBJECT
     Q_PROPERTY( bool fileWidgetButtonVisible READ fileWidgetButtonVisible WRITE setFileWidgetButtonVisible )
     Q_PROPERTY( bool useLink READ useLink WRITE setUseLink )
@@ -54,6 +54,7 @@ class GUI_EXPORT QgsFileWidget : public QWidget
     Q_PROPERTY( QString defaultRoot READ defaultRoot WRITE setDefaultRoot )
     Q_PROPERTY( StorageMode storageMode READ storageMode WRITE setStorageMode )
     Q_PROPERTY( RelativeStorage relativeStorage READ relativeStorage WRITE setRelativeStorage )
+    Q_PROPERTY( QFileDialog::Options options READ options WRITE setOptions )
 
   public:
 
@@ -122,6 +123,18 @@ class GUI_EXPORT QgsFileWidget : public QWidget
      * \param filter Only files that match the given filter are shown, it may be an empty string. If you want multiple filters, separate them with ';;',
      */
     void setFilter( const QString &filter );
+
+    /**
+     * Returns additional options used for QFileDialog
+     * \since QGIS 3.14
+     */
+    QFileDialog::Options options() const;
+
+    /**
+     * \brief setOptions sets additional options used for QFileDialog. These options affect the look and feel of the QFileDialog
+     * \since QGIS 3.14
+     */
+    void setOptions( QFileDialog::Options options );
 
     /**
      * Sets the selected filter when the file dialog opens.
@@ -218,6 +231,7 @@ class GUI_EXPORT QgsFileWidget : public QWidget
     bool mConfirmOverwrite = true;
     StorageMode mStorageMode = GetFile;
     RelativeStorage mRelativeStorage = Absolute;
+    QFileDialog::Options mOptions = QFileDialog::Options();
 
     QLabel *mLinkLabel = nullptr;
     QgsFileDropEdit *mLineEdit = nullptr;
@@ -234,9 +248,9 @@ class GUI_EXPORT QgsFileWidget : public QWidget
     friend class TestQgsFileWidget;
 };
 
-
-
 ///@cond PRIVATE
+
+
 
 #ifndef SIP_RUN
 

--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -244,7 +244,7 @@ void QgsGeorefPluginGui::openRaster()
   QString filters = QgsProviderRegistry::instance()->fileRasterFilters();
   filters.prepend( otherFiles + ";;" );
   filters.chop( otherFiles.size() + 2 );
-  mRasterFileName = QFileDialog::getOpenFileName( this, tr( "Open Raster" ), dir, filters, &lastUsedFilter );
+  mRasterFileName = QFileDialog::getOpenFileName( this, tr( "Open Raster" ), dir, filters, &lastUsedFilter, QFileDialog::HideNameFilterDetails );
   mModifiedRasterFileName.clear();
 
   if ( mRasterFileName.isEmpty() )


### PR DESCRIPTION
## Description
Currently in file selectors we have "All files" filter as well as individual file type filters. Using individual filters to open layer can be inconvenient when different file types are located in the same directory. On other hand using "All files" also not very convenient as lot of unnecessary files (.shx, prj, etc) are visible too
![all-files](https://user-images.githubusercontent.com/776954/81279563-fbdbcb80-905f-11ea-8f21-3992f77f49c8.png)

Proposed PR adds new "All supported" entry to the filter list, which includes all supported file types making file selection a bit easier
![all-supported](https://user-images.githubusercontent.com/776954/81279922-6ee54200-9060-11ea-8ce8-c46b41b3bb89.png)

Also this PR adds new `options` and `setOptions` methods to `QgsFileWidget` allowing to pass additional options to the underlying QFileDialog. One of use-cases is to hide file extensions from the file filter as long filter string leads to expanding of the dropdown list as below
![with-details](https://user-images.githubusercontent.com/776954/81280290-eb782080-9060-11ea-9d69-91e78825a3ec.png)
and without these details
![no-details](https://user-images.githubusercontent.com/776954/81280313-f3d05b80-9060-11ea-8325-15b2c2a2d807.png)

Fixes #13239.