### PR TITLE
postgres: correct timestamp comparison in where clause (fix #24163)

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1212,7 +1212,6 @@ QString QgsPostgresConn::quotedValue( const QVariant &value )
   {
     case QVariant::Int:
     case QVariant::LongLong:
-    case QVariant::ULongLong:
     case QVariant::Double:
       return value.toString();
 
@@ -1624,7 +1623,7 @@ QString QgsPostgresConn::fieldExpressionForWhereClause( const QgsField &fld, QVa
   {
     out = expr.arg( quotedIdentifier( fld.name() ) );
     // if field and value havev incompatible types, rollback to text cast
-    if ( valueType !=  QVariant::LastType && valueType != QVariant::Int && valueType != QVariant::LongLong && valueType != QVariant::ULongLong && valueType != QVariant::Double )
+    if ( valueType !=  QVariant::LastType && valueType != QVariant::Int && valueType != QVariant::LongLong && valueType != QVariant::Double )
     {
       out = out + "::text";
     }

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1216,6 +1216,9 @@ QString QgsPostgresConn::quotedValue( const QVariant &value )
     case QVariant::Double:
       return value.toString();
 
+    case QVariant::DateTime:
+      return quotedString( value.toDateTime().toString( Qt::ISODateWithMs ) );
+
     case QVariant::Bool:
       return value.toBool() ? "TRUE" : "FALSE";
 

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -339,6 +339,8 @@ class QgsPostgresConn : public QObject
 
     qint64 getBinaryInt( QgsPostgresResult &queryResult, int row, int col );
 
+    QString fieldExpressionForWhereClause( const QgsField &fld, QVariant::Type valueType = QVariant::LastType, QString expr = "%1" );
+
     QString fieldExpression( const QgsField &fld, QString expr = "%1" );
 
     QString connInfo() const { return mConnInfo; }

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -469,7 +469,7 @@ QString QgsPostgresProvider::pkParamWhereClause( int offset, const char *alias )
         int idx = mPrimaryKeyAttrs[i];
         QgsField fld = field( idx );
 
-        whereClause += delim + QStringLiteral( "%3%1=$%2" ).arg( connectionRO()->fieldExpression( fld ) ).arg( offset++ ).arg( aliased );
+        whereClause += delim + QStringLiteral( "%3%1=$%2" ).arg( connectionRO()->fieldExpressionForWhereClause( fld ) ).arg( offset++ ).arg( aliased );
         delim = QStringLiteral( " AND " );
       }
     }
@@ -599,11 +599,11 @@ QString QgsPostgresUtils::whereClause( QgsFeatureId featureId, const QgsFields &
           int idx = pkAttrs[i];
           QgsField fld = fields.at( idx );
 
-          whereClause += delim + conn->fieldExpression( fld );
+          whereClause += delim + conn->fieldExpressionForWhereClause( fld, pkVals[i].type() );
           if ( pkVals[i].isNull() )
             whereClause += QLatin1String( " IS NULL" );
           else
-            whereClause += '=' + QgsPostgresConn::quotedValue( pkVals[i].toString() );
+            whereClause += '=' + QgsPostgresConn::quotedValue( pkVals[i] ); // remove toString as it must be handled by quotedValue function
 
           delim = QStringLiteral( " AND " );
         }

--- a/tests/src/providers/testqgspostgresconn.cpp
+++ b/tests/src/providers/testqgspostgresconn.cpp
@@ -52,7 +52,7 @@ class TestQgsPostgresConn: public QObject
       fields.append( f );
       QgsField f2;
       f2.setName( "pk" );
-      f2.setType( QVariant::ULongLong );
+      f2.setType( QVariant::LongLong );
       f2.setTypeName( "serial8" );
       fields.append( f2 );
 

--- a/tests/src/providers/testqgspostgresconn.cpp
+++ b/tests/src/providers/testqgspostgresconn.cpp
@@ -63,7 +63,7 @@ class TestQgsPostgresConn: public QObject
       QgsPostgresSharedData *shared = new QgsPostgresSharedData;
       QVariantList qvlist;
       qvlist.append( QDateTime::fromString( "2020-05-07 17:56:00", "yyyy-MM-dd HH:mm:ss" ) );
-      qvlist.append( 123ULL );
+      qvlist.append( 123LL );
       shared->insertFid( 1LL, qvlist );
 
       QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( shared ) ), QString( "\"ts\"='2020-05-07T17:56:00.000' AND \"pk\"=123" ) );

--- a/tests/src/providers/testqgspostgresconn.cpp
+++ b/tests/src/providers/testqgspostgresconn.cpp
@@ -16,6 +16,8 @@
 #include <QObject>
 
 #include <qgspostgresconn.h>
+#include <qgsfields.h>
+#include <qgspostgresprovider.h>
 
 class TestQgsPostgresConn: public QObject
 {
@@ -36,6 +38,35 @@ class TestQgsPostgresConn: public QObject
       QCOMPARE( QgsPostgresConn::quotedValue( "b" ), QString( "'b'" ) );
       QCOMPARE( QgsPostgresConn::quotedValue( "b's" ), QString( "'b''s'" ) );
       QCOMPARE( QgsPostgresConn::quotedValue( "b \"c' \\x" ), QString( "E'b \"c'' \\\\x'" ) );
+    }
+
+    void quotedValueDatetime()
+    {
+      QCOMPARE( QgsPostgresConn::quotedValue( QDateTime::fromString( "2020-05-07 17:56:00", "yyyy-MM-dd HH:mm:ss" ) ), QString( "'2020-05-07T17:56:00.000'" ) );
+
+      QgsFields fields;
+      QgsField f;
+      f.setName( "ts" );
+      f.setType( QVariant::DateTime );
+      f.setTypeName( "timestamp" );
+      fields.append( f );
+      QgsField f2;
+      f2.setName( "pk" );
+      f2.setType( QVariant::ULongLong );
+      f2.setTypeName( "serial8" );
+      fields.append( f2 );
+
+      QList<int> pkAttrs;
+      pkAttrs.append( 0 );
+      pkAttrs.append( 1 );
+
+      QgsPostgresSharedData *shared = new QgsPostgresSharedData;
+      QVariantList qvlist;
+      qvlist.append( QDateTime::fromString( "2020-05-07 17:56:00", "yyyy-MM-dd HH:mm:ss" ) );
+      qvlist.append( 123ULL );
+      shared->insertFid( 1LL, qvlist );
+
+      QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( shared ) ), QString( "\"ts\"='2020-05-07T17:56:00.000' AND \"pk\"=123" ) );
     }
 
     void quotedValueStringArray()


### PR DESCRIPTION
Hi,
My name is Benoit De Mezzo and I'm a new member of Oslandia. I hope I could contribute to the Qgis project in a more broadly way. All tips are welcome !

## Description

The issue #24163 was due to sql casting to **::text** for unmanaged datatype as timestamp. The main problem was in the differents ways Qt and postgresql cast timestamp to string. Qt QDateTime cast to ISO 8601 (```yyyy-MM-ddTHH:mm:ss```) but postgresql cast to this format ```yyyy-MM-dd HH:mm:ss```. The generated sql was: 
```... WHERE ("time"::text='2017-02-20T13:41:47.000' OR ...``` 
ie. 
```... WHERE ('2017-02-20 13:41:47'='2017-02-20T13:41:47.000' OR ...``` 
so they cannot be compared as **::text**.

I solved this by forcing **QDatetime** in **quotedValue** to ISO 8601 and by adding a dedicated function **fieldExpressionForWhereClause** to avoid the cast to **::text**.

This PR could be backported to release-3_10 (I have tested it).

## Issue

Fixes #24163