### PR TITLE
[quick] Fix unhandled exception in QgsQuickPositionKit

### DIFF
--- a/src/quickgui/qgsquickpositionkit.cpp
+++ b/src/quickgui/qgsquickpositionkit.cpp
@@ -139,11 +139,19 @@ void QgsQuickPositionKit::updateProjectedPosition()
     return;
 
   QgsPointXY srcPoint = QgsPointXY( mPosition.x(), mPosition.y() );
-  QgsPointXY projectedPositionXY = QgsQuickUtils::transformPoint(
-                                     positionCRS(),
-                                     mMapSettings->destinationCrs(),
-                                     mMapSettings->transformContext(),
-                                     srcPoint );
+  QgsPointXY projectedPositionXY = srcPoint;
+  try
+  {
+    projectedPositionXY = QgsQuickUtils::transformPoint(
+                            positionCRS(),
+                            mMapSettings->destinationCrs(),
+                            mMapSettings->transformContext(),
+                            srcPoint );
+  }
+  catch ( const QgsCsException & )
+  {
+    QgsDebugMsg( QStringLiteral( "Failed to transform GPS position: " ) + srcPoint.toString() );
+  }
 
   QgsPoint projectedPosition( projectedPositionXY );
   projectedPosition.addZValue( mPosition.z() );


### PR DESCRIPTION
If transformation of GPS position to project CRS fails, the unhandled exception would cause a crash.