### PR TITLE
Lazily initialize QgsDistanceArea in expressions

### DIFF
--- a/src/core/expression/qgsexpression_p.h
+++ b/src/core/expression/qgsexpression_p.h
@@ -67,6 +67,10 @@ class QgsExpressionPrivate
 
     QString mExp;
 
+    QString mDaEllipsoid;
+    QgsCoordinateReferenceSystem mDaCrs;
+    QgsCoordinateTransformContext mDaTransformContext;
+
     std::shared_ptr<QgsDistanceArea> mCalc;
     QgsUnitTypes::DistanceUnit mDistanceUnit = QgsUnitTypes::DistanceUnknownUnit;
     QgsUnitTypes::AreaUnit mAreaUnit = QgsUnitTypes::AreaUnknownUnit;


### PR DESCRIPTION
This is barely ever used (only when the $perimeter, $length or $area functions are used in an expression), and is expensive to construct.

We've been merrily creating them EVERY time we prepare an expression resulting in a lot of wasted effort. By lazily creating it only if needed we save a bunch of wasted processing and ultimately get
MUCH faster expression preparation.

(especially noticable when animating vector layers using data defined symbol settings or categorized/graduated/rule based renderers, refs #36243 , but I've also seen this hotspot when profiling other slow rendering/processing operations)
