### PR TITLE
[canvas] Insure a refreshed canvas due to temporal range changes reflects the last provided range

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayertemporalproperties.sip.in
@@ -49,6 +49,7 @@ Constructor for QgsMeshLayerTemporalProperties
 %End
 
   public:
+
     virtual QDomElement writeXml( QDomElement &element, QDomDocument &doc, const QgsReadWriteContext &context );
 
     virtual bool readXml( const QDomElement &element, const QgsReadWriteContext &context );

--- a/python/core/auto_generated/qgstemporalproperty.sip.in
+++ b/python/core/auto_generated/qgstemporalproperty.sip.in
@@ -24,6 +24,7 @@ Base class for temporal property.
 #include "qgstemporalproperty.h"
 %End
   public:
+
     enum Flag
     {
       NoFlags,

--- a/python/core/auto_generated/qgstemporalproperty.sip.in
+++ b/python/core/auto_generated/qgstemporalproperty.sip.in
@@ -24,6 +24,13 @@ Base class for temporal property.
 #include "qgstemporalproperty.h"
 %End
   public:
+    enum Flag
+    {
+      NoFlags,
+      FlagDontInvalidateCachedRendersWhenRangeChanges
+    };
+    typedef QFlags<QgsTemporalProperty::Flag> Flags;
+
 
     QgsTemporalProperty( QObject *parent /TransferThis/ = 0, bool enabled = false );
 %Docstring
@@ -44,6 +51,11 @@ Sets whether the temporal property is ``active``.
 Returns ``True`` if the temporal property is active.
 
 .. seealso:: :py:func:`setIsActive`
+%End
+
+    virtual const QgsTemporalProperty::Flags flags() const;
+%Docstring
+Returns flags associated to the temporal property.
 %End
 
   signals:

--- a/python/core/auto_generated/qgstemporalproperty.sip.in
+++ b/python/core/auto_generated/qgstemporalproperty.sip.in
@@ -27,7 +27,6 @@ Base class for temporal property.
 
     enum Flag
     {
-      NoFlags,
       FlagDontInvalidateCachedRendersWhenRangeChanges
     };
     typedef QFlags<QgsTemporalProperty::Flag> Flags;
@@ -54,7 +53,7 @@ Returns ``True`` if the temporal property is active.
 .. seealso:: :py:func:`setIsActive`
 %End
 
-    virtual const QgsTemporalProperty::Flags flags() const;
+    virtual QgsTemporalProperty::Flags flags() const;
 %Docstring
 Returns flags associated to the temporal property.
 %End

--- a/python/core/auto_generated/qgsvectorlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/qgsvectorlayertemporalproperties.sip.in
@@ -55,7 +55,7 @@ Sets the temporal properties ``mode``.
 .. seealso:: :py:func:`mode`
 %End
 
-    virtual const QgsTemporalProperty::Flags flags() const;
+    virtual QgsTemporalProperty::Flags flags() const;
 
 %Docstring
 Returns flags associated to the temporal property.

--- a/python/core/auto_generated/qgsvectorlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/qgsvectorlayertemporalproperties.sip.in
@@ -55,6 +55,12 @@ Sets the temporal properties ``mode``.
 .. seealso:: :py:func:`mode`
 %End
 
+    virtual const QgsTemporalProperty::Flags flags() const;
+
+%Docstring
+Returns flags associated to the temporal property.
+%End
+
     void setFixedTemporalRange( const QgsDateTimeRange &range );
 %Docstring
 Sets a temporal ``range`` to apply to the whole layer. All features from

--- a/python/core/auto_generated/raster/qgsrasterlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayertemporalproperties.sip.in
@@ -53,7 +53,7 @@ Sets the temporal properties ``mode``.
 .. seealso:: :py:func:`mode`
 %End
 
-    virtual const QgsTemporalProperty::Flags flags() const;
+    virtual QgsTemporalProperty::Flags flags() const;
 
 %Docstring
 Returns flags associated to the temporal property.

--- a/python/core/auto_generated/raster/qgsrasterlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayertemporalproperties.sip.in
@@ -53,6 +53,12 @@ Sets the temporal properties ``mode``.
 .. seealso:: :py:func:`mode`
 %End
 
+    virtual const QgsTemporalProperty::Flags flags() const;
+
+%Docstring
+Returns flags associated to the temporal property.
+%End
+
     QgsRasterDataProviderTemporalCapabilities::IntervalHandlingMethod intervalHandlingMethod() const;
 %Docstring
 Returns the desired method to use when resolving a temporal interval to matching

--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -131,13 +131,6 @@ Make sure to remove any rendered images from cache (does nothing if cache is not
 .. versionadded:: 2.4
 %End
 
-    void clearTemporalCache();
-%Docstring
-Make sure to remove any rendered images of temporal-enabled layers from cache (does nothing if cache is not enabled)
-
-.. versionadded:: 3.14
-%End
-
     void waitWhileRendering();
 %Docstring
 Blocks until the rendering job has finished.

--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -131,6 +131,13 @@ Make sure to remove any rendered images from cache (does nothing if cache is not
 .. versionadded:: 2.4
 %End
 
+    void clearTemporalCache();
+%Docstring
+Make sure to remove any rendered images of temporal-enabled layers from cache (does nothing if cache is not enabled)
+
+.. versionadded:: 3.14
+%End
+
     void waitWhileRendering();
 %Docstring
 Blocks until the rendering job has finished.

--- a/src/core/mesh/qgsmeshlayertemporalproperties.h
+++ b/src/core/mesh/qgsmeshlayertemporalproperties.h
@@ -61,6 +61,7 @@ class CORE_EXPORT QgsMeshLayerTemporalProperties : public QgsMapLayerTemporalPro
     QgsMeshLayerTemporalProperties( QObject *parent SIP_TRANSFERTHIS = nullptr, bool enabled = true );
 
   public:
+
     QDomElement writeXml( QDomElement &element, QDomDocument &doc, const QgsReadWriteContext &context ) override;
     bool readXml( const QDomElement &element, const QgsReadWriteContext &context ) override;
     void setDefaultsFromDataProviderTemporalCapabilities( const QgsDataProviderTemporalCapabilities *capabilities ) override;

--- a/src/core/qgstemporalproperty.h
+++ b/src/core/qgstemporalproperty.h
@@ -37,10 +37,14 @@ class CORE_EXPORT QgsTemporalProperty : public QObject
     Q_OBJECT
 
   public:
+
+    /**
+     * Flags attached to the temporal property.
+     */
     enum Flag
     {
       NoFlags                                         = 0,
-      FlagDontInvalidateCachedRendersWhenRangeChanges = 1  //!< Any cached rendering will not be invalidated when temporal range context is modified
+      FlagDontInvalidateCachedRendersWhenRangeChanges = 1  //!< Any cached rendering will not be invalidated when temporal range context is modified.
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 

--- a/src/core/qgstemporalproperty.h
+++ b/src/core/qgstemporalproperty.h
@@ -43,7 +43,6 @@ class CORE_EXPORT QgsTemporalProperty : public QObject
      */
     enum Flag
     {
-      NoFlags                                         = 0,
       FlagDontInvalidateCachedRendersWhenRangeChanges = 1  //!< Any cached rendering will not be invalidated when temporal range context is modified.
     };
     Q_DECLARE_FLAGS( Flags, Flag )
@@ -72,7 +71,7 @@ class CORE_EXPORT QgsTemporalProperty : public QObject
     /**
      * Returns flags associated to the temporal property.
      */
-    virtual const QgsTemporalProperty::Flags flags() const { return QgsTemporalProperty::NoFlags; }
+    virtual QgsTemporalProperty::Flags flags() const { return nullptr; }
 
   signals:
 

--- a/src/core/qgstemporalproperty.h
+++ b/src/core/qgstemporalproperty.h
@@ -37,6 +37,12 @@ class CORE_EXPORT QgsTemporalProperty : public QObject
     Q_OBJECT
 
   public:
+    enum Flag
+    {
+      NoFlags                                         = 0,
+      FlagDontInvalidateCachedRendersWhenRangeChanges = 1  //!< Any cached rendering will not be invalidated when temporal range context is modified
+    };
+    Q_DECLARE_FLAGS( Flags, Flag )
 
     /**
      * Constructor for QgsTemporalProperty, with the specified \a parent object.
@@ -58,6 +64,11 @@ class CORE_EXPORT QgsTemporalProperty : public QObject
      * \see setIsActive()
     */
     bool isActive() const;
+
+    /**
+     * Returns flags associated to the temporal property.
+     */
+    virtual const QgsTemporalProperty::Flags flags() const { return QgsTemporalProperty::NoFlags; }
 
   signals:
 

--- a/src/core/qgsvectorlayertemporalproperties.cpp
+++ b/src/core/qgsvectorlayertemporalproperties.cpp
@@ -53,6 +53,11 @@ void QgsVectorLayerTemporalProperties::setMode( QgsVectorLayerTemporalProperties
   mMode = mode;
 }
 
+const QgsTemporalProperty::Flags QgsVectorLayerTemporalProperties::flags() const
+{
+  return mode() == ModeFixedTemporalRange ? QgsTemporalProperty::FlagDontInvalidateCachedRendersWhenRangeChanges : QgsTemporalProperty::NoFlags;
+}
+
 void  QgsVectorLayerTemporalProperties::setFixedTemporalRange( const QgsDateTimeRange &range )
 {
   mFixedRange = range;

--- a/src/core/qgsvectorlayertemporalproperties.cpp
+++ b/src/core/qgsvectorlayertemporalproperties.cpp
@@ -53,9 +53,9 @@ void QgsVectorLayerTemporalProperties::setMode( QgsVectorLayerTemporalProperties
   mMode = mode;
 }
 
-const QgsTemporalProperty::Flags QgsVectorLayerTemporalProperties::flags() const
+QgsTemporalProperty::Flags QgsVectorLayerTemporalProperties::flags() const
 {
-  return mode() == ModeFixedTemporalRange ? QgsTemporalProperty::FlagDontInvalidateCachedRendersWhenRangeChanges : QgsTemporalProperty::NoFlags;
+  return mode() == ModeFixedTemporalRange ? QgsTemporalProperty::FlagDontInvalidateCachedRendersWhenRangeChanges : QgsTemporalProperty::Flags( nullptr );
 }
 
 void  QgsVectorLayerTemporalProperties::setFixedTemporalRange( const QgsDateTimeRange &range )

--- a/src/core/qgsvectorlayertemporalproperties.h
+++ b/src/core/qgsvectorlayertemporalproperties.h
@@ -74,6 +74,11 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
     void setMode( TemporalMode mode );
 
     /**
+     * Returns flags associated to the temporal property.
+     */
+    const QgsTemporalProperty::Flags flags() const override;
+
+    /**
      * Sets a temporal \a range to apply to the whole layer. All features from
      * the layer will be rendered whenever the current datetime range of
      * a render context intersects the specified \a range.

--- a/src/core/qgsvectorlayertemporalproperties.h
+++ b/src/core/qgsvectorlayertemporalproperties.h
@@ -76,7 +76,7 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
     /**
      * Returns flags associated to the temporal property.
      */
-    const QgsTemporalProperty::Flags flags() const override;
+    QgsTemporalProperty::Flags flags() const override;
 
     /**
      * Sets a temporal \a range to apply to the whole layer. All features from

--- a/src/core/raster/qgsrasterlayertemporalproperties.cpp
+++ b/src/core/raster/qgsrasterlayertemporalproperties.cpp
@@ -51,6 +51,11 @@ void QgsRasterLayerTemporalProperties::setMode( QgsRasterLayerTemporalProperties
   mMode = mode;
 }
 
+const QgsTemporalProperty::Flags QgsRasterLayerTemporalProperties::flags() const
+{
+  return mode() == ModeFixedTemporalRange ? QgsTemporalProperty::FlagDontInvalidateCachedRendersWhenRangeChanges : QgsTemporalProperty::NoFlags;
+}
+
 QgsRasterDataProviderTemporalCapabilities::IntervalHandlingMethod QgsRasterLayerTemporalProperties::intervalHandlingMethod() const
 {
   return mIntervalHandlingMethod;

--- a/src/core/raster/qgsrasterlayertemporalproperties.cpp
+++ b/src/core/raster/qgsrasterlayertemporalproperties.cpp
@@ -51,9 +51,9 @@ void QgsRasterLayerTemporalProperties::setMode( QgsRasterLayerTemporalProperties
   mMode = mode;
 }
 
-const QgsTemporalProperty::Flags QgsRasterLayerTemporalProperties::flags() const
+QgsTemporalProperty::Flags QgsRasterLayerTemporalProperties::flags() const
 {
-  return mode() == ModeFixedTemporalRange ? QgsTemporalProperty::FlagDontInvalidateCachedRendersWhenRangeChanges : QgsTemporalProperty::NoFlags;
+  return mode() == ModeFixedTemporalRange ? QgsTemporalProperty::FlagDontInvalidateCachedRendersWhenRangeChanges : QgsTemporalProperty::Flags( nullptr );
 }
 
 QgsRasterDataProviderTemporalCapabilities::IntervalHandlingMethod QgsRasterLayerTemporalProperties::intervalHandlingMethod() const

--- a/src/core/raster/qgsrasterlayertemporalproperties.h
+++ b/src/core/raster/qgsrasterlayertemporalproperties.h
@@ -71,6 +71,11 @@ class CORE_EXPORT QgsRasterLayerTemporalProperties : public QgsMapLayerTemporalP
     void setMode( TemporalMode mode );
 
     /**
+     * Returns flags associated to the temporal property.
+     */
+    const QgsTemporalProperty::Flags flags() const override;
+
+    /**
      * Returns the desired method to use when resolving a temporal interval to matching
      * layers or bands in the data provider.
      *

--- a/src/core/raster/qgsrasterlayertemporalproperties.h
+++ b/src/core/raster/qgsrasterlayertemporalproperties.h
@@ -73,7 +73,7 @@ class CORE_EXPORT QgsRasterLayerTemporalProperties : public QgsMapLayerTemporalP
     /**
      * Returns flags associated to the temporal property.
      */
-    const QgsTemporalProperty::Flags flags() const override;
+    QgsTemporalProperty::Flags flags() const override;
 
     /**
      * Returns the desired method to use when resolving a temporal interval to matching

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -76,6 +76,8 @@ email                : sherman at mrcc.com
 #include "qgsreferencedgeometry.h"
 #include "qgsprojectviewsettings.h"
 #include "qgsmaplayertemporalproperties.h"
+#include "qgsrasterlayertemporalproperties.h"
+#include "qgsvectorlayertemporalproperties.h"
 #include "qgstemporalcontroller.h"
 
 /**
@@ -776,7 +778,12 @@ void QgsMapCanvas::clearTemporalCache()
     for ( QgsMapLayer *layer : layerList )
     {
       if ( layer->temporalProperties() && layer->temporalProperties()->isActive() )
+      {
+        if ( layer->temporalProperties()->flags() & QgsTemporalProperty::FlagDontInvalidateCachedRendersWhenRangeChanges )
+          continue;
+
         mCache->invalidateCacheForLayer( layer );
+      }
     }
   }
 }

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -692,8 +692,12 @@ void QgsMapCanvas::rendererJobFinished()
     {
       mLastLayerRenderTime.insert( it.key()->id(), it.value() );
     }
-    if ( mUsePreviewJobs )
+    if ( mUsePreviewJobs && !mTemporalRefreshAfterJob )
       startPreviewJobs();
+  }
+  else
+  {
+    mTemporalRefreshAfterJob = false;
   }
 
   // now we are in a slot called from mJob - do not delete it immediately
@@ -702,6 +706,13 @@ void QgsMapCanvas::rendererJobFinished()
   mJob = nullptr;
 
   emit mapCanvasRefreshed();
+
+  if ( mTemporalRefreshAfterJob )
+  {
+    mTemporalRefreshAfterJob = false;
+    clearTemporalCache();
+    refresh();
+  }
 }
 
 void QgsMapCanvas::previewJobFinished()
@@ -757,17 +768,10 @@ void QgsMapCanvas::setCustomDropHandlers( const QVector<QPointer<QgsCustomDropHa
   mDropHandlers = handlers;
 }
 
-void QgsMapCanvas::setTemporalRange( const QgsDateTimeRange &dateTimeRange )
+void QgsMapCanvas::clearTemporalCache()
 {
-  if ( temporalRange() == dateTimeRange )
-    return;
-
-  mSettings.setTemporalRange( dateTimeRange );
-
   if ( mCache )
   {
-    // we need to discard any previously cached images which have temporal properties enabled, so that these will be updated when
-    // the canvas is redrawn
     const QList<QgsMapLayer *> layerList = mapSettings().layers();
     for ( QgsMapLayer *layer : layerList )
     {
@@ -775,10 +779,28 @@ void QgsMapCanvas::setTemporalRange( const QgsDateTimeRange &dateTimeRange )
         mCache->invalidateCacheForLayer( layer );
     }
   }
+}
+
+void QgsMapCanvas::setTemporalRange( const QgsDateTimeRange &dateTimeRange )
+{
+  if ( temporalRange() == dateTimeRange )
+    return;
+
+  mSettings.setTemporalRange( dateTimeRange );
 
   emit temporalRangeChanged();
 
-  autoRefreshTriggered();
+  if ( !mJob )
+  {
+    // we need to discard any previously cached images which have temporal properties enabled, so that these will be updated when
+    // the canvas is redrawn
+    clearTemporalCache();
+    autoRefreshTriggered();
+  }
+  else
+  {
+    mTemporalRefreshAfterJob = true;
+  }
 }
 
 const QgsDateTimeRange &QgsMapCanvas::temporalRange() const

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -178,12 +178,6 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     void clearCache();
 
     /**
-     * Make sure to remove any rendered images of temporal-enabled layers from cache (does nothing if cache is not enabled)
-     * \since QGIS 3.14
-     */
-    void clearTemporalCache();
-
-    /**
      * Blocks until the rendering job has finished.
      *
      * In almost all cases you do NOT want to call this, as it will hang the UI
@@ -1205,6 +1199,12 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     int nextZoomLevel( const QList<double> &resolutions, bool zoomIn = true ) const;
     double zoomInFactor() const;
     double zoomOutFactor() const;
+
+    /**
+     * Make sure to remove any rendered images of temporal-enabled layers from cache (does nothing if cache is not enabled)
+     * \since QGIS 3.14
+     */
+    void clearTemporalCache();
 
     friend class TestQgsMapCanvas;
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -178,6 +178,12 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     void clearCache();
 
     /**
+     * Make sure to remove any rendered images of temporal-enabled layers from cache (does nothing if cache is not enabled)
+     * \since QGIS 3.14
+     */
+    void clearTemporalCache();
+
+    /**
      * Blocks until the rendering job has finished.
      *
      * In almost all cases you do NOT want to call this, as it will hang the UI
@@ -1056,6 +1062,9 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     //! Flag that allows squashing multiple refresh() calls into just one delayed rendering job
     bool mRefreshScheduled = false;
+
+    //! Flag that triggers a refresh after an ongoing rendering job finishes and clear cache for temporal-enabled layers
+    bool mTemporalRefreshAfterJob = false;
 
     //! determines whether user has requested to suppress rendering
     bool mRenderFlag = true;

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -1063,8 +1063,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! Flag that allows squashing multiple refresh() calls into just one delayed rendering job
     bool mRefreshScheduled = false;
 
-    //! Flag that triggers a refresh after an ongoing rendering job finishes and clear cache for temporal-enabled layers
-    bool mTemporalRefreshAfterJob = false;
+    //! Flag that triggers a refresh after an ongoing rendering job triggered by autoRefresh
+    bool mRefreshAfterJob = false;
 
     //! determines whether user has requested to suppress rendering
     bool mRenderFlag = true;


### PR DESCRIPTION
## Description

This PR aims at improving the temporal controller's interaction with the canvas by insuring that the canvas always reflects the last selected datetime via the controller's slider.

Background: to make sure the UI isn't blocked, changing the current datetime via the controller's slider does _not_ abort an ongoing rendering (good). However, it does mean the user can end up settling on a datetime with the slider and unknowingly have a rendered canvas that does not reflect that user-picked datetime.

To fix that, a refresh is automatically triggered after a job is rendered if the temporal range changes while a rendering job is taking place. 