### PR TITLE
Delete cascade on composition relations

### DIFF
--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -374,6 +374,18 @@ Constructor for LayerOptions.
 
     };
 
+    struct DeleteContext
+    {
+
+      explicit DeleteContext( bool cascade = false );
+%Docstring
+Constructor for DeleteContext.
+%End
+
+      QMap<QgsVectorLayer *, QgsFeatureIds> handledFeatures;
+      bool cascade;
+    };
+
     explicit QgsVectorLayer( const QString &path = QString(), const QString &baseName = QString(),
                              const QString &providerLib = "ogr", const QgsVectorLayer::LayerOptions &options = QgsVectorLayer::LayerOptions() );
 %Docstring
@@ -1259,7 +1271,7 @@ Deletes a vertex from a feature.
 .. versionadded:: 2.14
 %End
 
-    bool deleteSelectedFeatures( int *deletedCount = 0, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = 0 );
+    bool deleteSelectedFeatures( int *deletedCount = 0, DeleteContext *context = 0 );
 %Docstring
 Deletes the selected features
 
@@ -1944,7 +1956,7 @@ Deletes a list of attribute fields (but does not commit it)
     virtual bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = 0 ) ${SIP_FINAL};
 
 
-    bool deleteFeature( QgsFeatureId fid, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = 0 );
+    bool deleteFeature( QgsFeatureId fid, DeleteContext *context = 0 );
 %Docstring
 Deletes a feature from the layer (but does not commit it).
 
@@ -1959,7 +1971,7 @@ Deletes a feature from the layer (but does not commit it).
    changes can be discarded by calling rollBack().
 %End
 
-    bool deleteFeatures( const QgsFeatureIds &fids, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = 0 );
+    bool deleteFeatures( const QgsFeatureIds &fids, DeleteContext *context = 0 );
 %Docstring
 Deletes a set of features from the layer (but does not commit it)
 

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -1971,7 +1971,7 @@ Deletes a feature from the layer (but does not commit it).
    changes can be discarded by calling rollBack().
 %End
 
-    bool deleteFeatures( const QgsFeatureIds &fids, DeleteContext *context = 0 );
+    bool deleteFeatures( const QgsFeatureIds fids, DeleteContext *context = 0 );
 %Docstring
 Deletes a set of features from the layer (but does not commit it)
 

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -1259,9 +1259,12 @@ Deletes a vertex from a feature.
 .. versionadded:: 2.14
 %End
 
-    bool deleteSelectedFeatures( int *deletedCount = 0 );
+    bool deleteSelectedFeatures( int *deletedCount = 0, const bool cascade = false );
 %Docstring
 Deletes the selected features
+
+:param deleteCount: The number of successfully deleted features
+:param cascade: If the decendants of the feature should be deleted as well
 
 :return: ``True`` in case of success and ``False`` otherwise
 %End
@@ -1941,9 +1944,12 @@ Deletes a list of attribute fields (but does not commit it)
     virtual bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = 0 ) ${SIP_FINAL};
 
 
-    bool deleteFeature( QgsFeatureId fid );
+    bool deleteFeature( QgsFeatureId fid, const bool cascade = false );
 %Docstring
 Deletes a feature from the layer (but does not commit it).
+
+:param fid: The feature id to delete
+:param cascade: If the decendants of the feature should be deleted as well
 
 .. note::
 
@@ -1953,11 +1959,12 @@ Deletes a feature from the layer (but does not commit it).
    changes can be discarded by calling rollBack().
 %End
 
-    bool deleteFeatures( const QgsFeatureIds &fids );
+    bool deleteFeatures( const QgsFeatureIds &fids, const bool cascade = false );
 %Docstring
 Deletes a set of features from the layer (but does not commit it)
 
 :param fids: The feature ids to delete
+:param cascade: If the decendants of the feature should be deleted as well
 
 :return: ``False`` if the layer is not in edit mode or does not support deleting
          in case of an active transaction depends on the provider implementation

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -1974,7 +1974,7 @@ Deletes a feature from the layer (but does not commit it).
    changes can be discarded by calling rollBack().
 %End
 
-    bool deleteFeatures( const QgsFeatureIds fids, DeleteContext *context = 0 );
+    bool deleteFeatures( const QgsFeatureIds &fids, DeleteContext *context = 0 );
 %Docstring
 Deletes a set of features from the layer (but does not commit it)
 

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -374,7 +374,7 @@ Constructor for LayerOptions.
 
     };
 
-    struct  DeleteContext
+    struct DeleteContext
     {
 
       explicit DeleteContext( bool cascade = false );

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -382,10 +382,8 @@ Constructor for LayerOptions.
 Constructor for DeleteContext.
 %End
 
-      QMap<QgsVectorLayer *, QgsFeatureIds> handledFeatures();
-%Docstring
-Returns all the layers on which features have been deleted
-%End
+      QList<QgsVectorLayer *> handledLayers() const;
+      QgsFeatureIds handledFeatures( QgsVectorLayer *layer ) const;
 
       bool cascade;
     };

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -1275,7 +1275,7 @@ Deletes a vertex from a feature.
 %Docstring
 Deletes the selected features
 
-:param deleteCount: The number of successfully deleted features
+:param deletedCount: The number of successfully deleted features
 :param context: The chain of features who will be deleted for feedback and to avoid endless recursions
 
 :return: ``True`` in case of success and ``False`` otherwise

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -377,7 +377,7 @@ Constructor for LayerOptions.
     struct DeleteContext
     {
 
-      explicit DeleteContext( bool cascade = false );
+      explicit DeleteContext( bool cascade = false, QgsProject *project = 0 );
 %Docstring
 Constructor for DeleteContext.
 %End
@@ -386,6 +386,7 @@ Constructor for DeleteContext.
       QgsFeatureIds handledFeatures( QgsVectorLayer *layer ) const;
 
       bool cascade;
+      QgsProject *project;
     };
 
     explicit QgsVectorLayer( const QString &path = QString(), const QString &baseName = QString(),

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -1276,7 +1276,7 @@ Deletes a vertex from a feature.
 Deletes the selected features
 
 :param deleteCount: The number of successfully deleted features
-:param cascade: If the decendants of the feature should be deleted as well
+:param context: The chain of features who will be deleted for feedback and to avoid endless recursions
 
 :return: ``True`` in case of success and ``False`` otherwise
 %End
@@ -1961,7 +1961,7 @@ Deletes a list of attribute fields (but does not commit it)
 Deletes a feature from the layer (but does not commit it).
 
 :param fid: The feature id to delete
-:param cascade: If the decendants of the feature should be deleted as well
+:param context: The chain of features who will be deleted for feedback and to avoid endless recursions
 
 .. note::
 
@@ -1976,7 +1976,7 @@ Deletes a feature from the layer (but does not commit it).
 Deletes a set of features from the layer (but does not commit it)
 
 :param fids: The feature ids to delete
-:param cascade: If the decendants of the feature should be deleted as well
+:param context: The chain of features who will be deleted for feedback and to avoid endless recursions
 
 :return: ``False`` if the layer is not in edit mode or does not support deleting
          in case of an active transaction depends on the provider implementation

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -374,7 +374,7 @@ Constructor for LayerOptions.
 
     };
 
-    struct DeleteContext
+    struct  DeleteContext
     {
 
       explicit DeleteContext( bool cascade = false );
@@ -382,7 +382,11 @@ Constructor for LayerOptions.
 Constructor for DeleteContext.
 %End
 
-      QMap<QgsVectorLayer *, QgsFeatureIds> handledFeatures;
+      QMap<QgsVectorLayer *, QgsFeatureIds> handledFeatures();
+%Docstring
+Returns all the layers on which features have been deleted
+%End
+
       bool cascade;
     };
 

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -1259,7 +1259,7 @@ Deletes a vertex from a feature.
 .. versionadded:: 2.14
 %End
 
-    bool deleteSelectedFeatures( int *deletedCount = 0, const bool cascade = false );
+    bool deleteSelectedFeatures( int *deletedCount = 0, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = 0 );
 %Docstring
 Deletes the selected features
 
@@ -1944,7 +1944,7 @@ Deletes a list of attribute fields (but does not commit it)
     virtual bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = 0 ) ${SIP_FINAL};
 
 
-    bool deleteFeature( QgsFeatureId fid, const bool cascade = false );
+    bool deleteFeature( QgsFeatureId fid, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = 0 );
 %Docstring
 Deletes a feature from the layer (but does not commit it).
 
@@ -1959,7 +1959,7 @@ Deletes a feature from the layer (but does not commit it).
    changes can be discarded by calling rollBack().
 %End
 
-    bool deleteFeatures( const QgsFeatureIds &fids, const bool cascade = false );
+    bool deleteFeatures( const QgsFeatureIds &fids, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = 0 );
 %Docstring
 Deletes a set of features from the layer (but does not commit it)
 

--- a/python/core/auto_generated/qgsvectorlayerjoinbuffer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerjoinbuffer.sip.in
@@ -213,7 +213,7 @@ Deletes a feature from joined layers. The feature id given in
 parameter is the one coming from the target layer.
 
 :param fid: The feature id from the target layer to delete
-:param context: The chain of features who will be deleted for feedback and to avoid endless recursions
+:param context: The chain of features which will be deleted for feedback and to avoid infinite recursions. Can be ``None``.
 
 :return: ``False`` if an error happened, ``True`` otherwise
 
@@ -227,7 +227,7 @@ Deletes a list of features from joined layers. Feature ids given
 in a parameter are those coming from the target layer.
 
 :param fids: Feature ids from the target layer to delete
-:param context: The chain of features who will be deleted for feedback and to avoid endless recursions
+:param context: The chain of features who will be deleted for feedback and to avoid infinite recursions. Can be ``None``.
 
 :return: ``False`` if an error happened, ``True`` otherwise
 

--- a/python/core/auto_generated/qgsvectorlayerjoinbuffer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerjoinbuffer.sip.in
@@ -207,7 +207,7 @@ created if its fields are not empty.
 .. versionadded:: 3.0
 %End
 
-    bool deleteFeature( QgsFeatureId fid ) const;
+    bool deleteFeature( QgsFeatureId fid, const bool cascade = false ) const;
 %Docstring
 Deletes a feature from joined layers. The feature id given in
 parameter is the one coming from the target layer.
@@ -220,7 +220,7 @@ parameter is the one coming from the target layer.
 .. versionadded:: 3.0
 %End
 
-    bool deleteFeatures( const QgsFeatureIds &fids ) const;
+    bool deleteFeatures( const QgsFeatureIds &fids, const bool cascade = false ) const;
 %Docstring
 Deletes a list of features from joined layers. Feature ids given
 in a parameter are those coming from the target layer.

--- a/python/core/auto_generated/qgsvectorlayerjoinbuffer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerjoinbuffer.sip.in
@@ -213,6 +213,7 @@ Deletes a feature from joined layers. The feature id given in
 parameter is the one coming from the target layer.
 
 :param fid: The feature id from the target layer to delete
+:param context: The chain of features who will be deleted for feedback and to avoid endless recursions
 
 :return: ``False`` if an error happened, ``True`` otherwise
 
@@ -226,6 +227,7 @@ Deletes a list of features from joined layers. Feature ids given
 in a parameter are those coming from the target layer.
 
 :param fids: Feature ids from the target layer to delete
+:param context: The chain of features who will be deleted for feedback and to avoid endless recursions
 
 :return: ``False`` if an error happened, ``True`` otherwise
 

--- a/python/core/auto_generated/qgsvectorlayerjoinbuffer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerjoinbuffer.sip.in
@@ -207,7 +207,7 @@ created if its fields are not empty.
 .. versionadded:: 3.0
 %End
 
-    bool deleteFeature( QgsFeatureId fid, const bool cascade = false ) const;
+    bool deleteFeature( QgsFeatureId fid, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = 0 ) const;
 %Docstring
 Deletes a feature from joined layers. The feature id given in
 parameter is the one coming from the target layer.
@@ -220,7 +220,7 @@ parameter is the one coming from the target layer.
 .. versionadded:: 3.0
 %End
 
-    bool deleteFeatures( const QgsFeatureIds &fids, const bool cascade = false ) const;
+    bool deleteFeatures( const QgsFeatureIds &fids, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = 0 ) const;
 %Docstring
 Deletes a list of features from joined layers. Feature ids given
 in a parameter are those coming from the target layer.

--- a/python/core/auto_generated/qgsvectorlayerjoinbuffer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerjoinbuffer.sip.in
@@ -207,7 +207,7 @@ created if its fields are not empty.
 .. versionadded:: 3.0
 %End
 
-    bool deleteFeature( QgsFeatureId fid, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = 0 ) const;
+    bool deleteFeature( QgsFeatureId fid, QgsVectorLayer::DeleteContext *context = 0 ) const;
 %Docstring
 Deletes a feature from joined layers. The feature id given in
 parameter is the one coming from the target layer.
@@ -220,7 +220,7 @@ parameter is the one coming from the target layer.
 .. versionadded:: 3.0
 %End
 
-    bool deleteFeatures( const QgsFeatureIds &fids, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = 0 ) const;
+    bool deleteFeatures( const QgsFeatureIds &fids, QgsVectorLayer::DeleteContext *context = 0 ) const;
 %Docstring
 Deletes a list of features from joined layers. Feature ids given
 in a parameter are those coming from the target layer.

--- a/python/core/auto_generated/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerutils.sip.in
@@ -297,7 +297,7 @@ The following operations will be performed to convert the input features:
 .. versionadded:: 3.12
 %End
 
-    static bool impactsCascadeFeatures( const QgsVectorLayer *layer, const QgsProject *project );
+    static bool impactsCascadeFeatures( const QgsVectorLayer *layer, const QgsFeatureIds &fids, const QgsProject *project, QgsDuplicateFeatureContext &context );
 %Docstring
 
 :return: true if the ``is`` connected as parent in at least one composition relation of the ``project``

--- a/python/core/auto_generated/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerutils.sip.in
@@ -300,9 +300,9 @@ The following operations will be performed to convert the input features:
     static bool impactsCascadeFeatures( const QgsVectorLayer *layer, const QgsFeatureIds &fids, const QgsProject *project, QgsDuplicateFeatureContext &context /Out/ );
 %Docstring
 
-:return: true if at least one feature of the ``fids`` on ``layer`` is connected as parent in at
+:return: ``True`` if at least one feature of the ``fids`` on ``layer`` is connected as parent in at
          least one composition relation of the ``project`` or contains joins, where cascade delete is set.
-         The ``context`` is used to get more details.
+         Details about cascading effects will be written to ``context``.
 
 .. versionadded:: 3.14
 %End

--- a/python/core/auto_generated/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerutils.sip.in
@@ -300,8 +300,9 @@ The following operations will be performed to convert the input features:
     static bool impactsCascadeFeatures( const QgsVectorLayer *layer, const QgsFeatureIds &fids, const QgsProject *project, QgsDuplicateFeatureContext &context );
 %Docstring
 
-:return: true if the ``is`` connected as parent in at least one composition relation of the ``project``
-         or contains joins, where cascade delete is set.
+:return: true if at least one feature of the ``fids`` on ``layer`` is connected as parent in at
+         least one composition relation of the ``project`` or contains joins, where cascade delete is set.
+         The ``context`` is used to get more details.
 
 .. versionadded:: 3.14
 %End

--- a/python/core/auto_generated/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerutils.sip.in
@@ -296,6 +296,16 @@ The following operations will be performed to convert the input features:
 
 .. versionadded:: 3.12
 %End
+
+    static bool impactsCascadeFeatures( const QgsVectorLayer *layer, const QgsProject *project );
+%Docstring
+
+:return: true if the ``is`` connected as parent in at least one composition relation of the ``project``
+         or contains joins, where cascade delete is set.
+
+.. versionadded:: 3.14
+%End
+
 };
 
 

--- a/python/core/auto_generated/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerutils.sip.in
@@ -297,7 +297,7 @@ The following operations will be performed to convert the input features:
 .. versionadded:: 3.12
 %End
 
-    static bool impactsCascadeFeatures( const QgsVectorLayer *layer, const QgsFeatureIds &fids, const QgsProject *project, QgsDuplicateFeatureContext &context );
+    static bool impactsCascadeFeatures( const QgsVectorLayer *layer, const QgsFeatureIds &fids, const QgsProject *project, QgsDuplicateFeatureContext &context /Out/ );
 %Docstring
 
 :return: true if at least one feature of the ``fids`` on ``layer`` is connected as parent in at

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9003,7 +9003,8 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *parent, bool checkFea
 
   vlayer->beginEditCommand( tr( "Features deleted" ) );
   int deletedCount = 0;
-  if ( !vlayer->deleteSelectedFeatures( &deletedCount, true ) )
+  QgsVectorLayer::DeleteContext context { true };
+  if ( !vlayer->deleteSelectedFeatures( &deletedCount, &context ) )
   {
     visibleMessageBar()->pushMessage( tr( "Problem deleting features" ),
                                       tr( "A problem occurred during deletion from layer \"%1\". %n feature(s) not deleted.", nullptr, numberOfSelectedFeatures - deletedCount ).arg( vlayer->name() ),

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9001,10 +9001,10 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *parent, bool checkFea
     }
   }
 
-  if ( QgsVectorLayerUtils::impactsCascadeFeatures(vlayer, QgsProject::instance() ) )
+  if ( QgsVectorLayerUtils::impactsCascadeFeatures( vlayer, QgsProject::instance() ) )
   {
     // for extra safety to make sure we know that the delete can have impact on children and joins
-    int res = QMessageBox::warning( mMapCanvas, tr( "Possible impact on descendants of layer \"%1\"").arg( vlayer->name() ),
+    int res = QMessageBox::warning( mMapCanvas, tr( "Possible impact on descendants of layer \"%1\"" ).arg( vlayer->name() ),
                                     tr( "A delete on this layer could have an impact on referencing or joined layers and their descendants. Would you still like to continue?" ),
                                     QMessageBox::Yes | QMessageBox::No );
     if ( res != QMessageBox::Yes )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9040,7 +9040,7 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *parent, bool checkFea
       QString feedbackMessage;
       for ( QgsVectorLayer *contextLayer : contextLayers )
       {
-        feedbackMessage += tr( " %1 on layer %2." ).arg( context.handledFeatures( contextLayer ).size() ).arg( contextLayer->name() );
+        feedbackMessage += tr( "%1 on layer %2. " ).arg( context.handledFeatures( contextLayer ).size() ).arg( contextLayer->name() );
         deletedCount += context.handledFeatures( contextLayer ).size();
       }
       visibleMessageBar()->pushMessage( tr( "%1 features deleted: %2" ).arg( deletedCount ).arg( feedbackMessage ), Qgis::Success );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9023,7 +9023,7 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *parent, bool checkFea
 
   vlayer->beginEditCommand( tr( "Features deleted" ) );
   int deletedCount = 0;
-  QgsVectorLayer::DeleteContext context { true };
+  QgsVectorLayer::DeleteContext context( true, QgsProject::instance() );
   if ( !vlayer->deleteSelectedFeatures( &deletedCount, &context ) )
   {
     visibleMessageBar()->pushMessage( tr( "Problem deleting features" ),

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9033,12 +9033,12 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *parent, bool checkFea
   else
   {
     //if it effected more than one layer, print feedback for all descendants
-    if ( context.handledFeatures().size() > 1 )
+    if ( context.mHandledFeatures.size() > 1 )
     {
       deletedCount = 0;
       QString feedbackMessage;
       QMap<QgsVectorLayer *, QgsFeatureIds>::const_iterator i;
-      for ( i = context.handledFeatures().begin(); i != context.handledFeatures().end(); ++i )
+      for ( i = context.mHandledFeatures.begin(); i != context.mHandledFeatures.end(); ++i )
       {
         feedbackMessage += tr( " %1 on layer %2." ).arg( i.value().size() ).arg( i.key()->name() );
         deletedCount += i.value().size();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9012,7 +9012,21 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *parent, bool checkFea
   }
   else
   {
-    showStatusMessage( tr( "%n feature(s) deleted.", "number of features deleted", numberOfSelectedFeatures ) );
+    //if it effected more than one layer, print feedback for all descendants
+    if ( context.handledFeatures.count() > 1 )
+    {
+      deletedCount = 0;
+      QString feedbackMessage;
+      QMap<QgsVectorLayer *, QgsFeatureIds>::const_iterator i;
+      for ( i = context.handledFeatures.begin(); i != context.handledFeatures.end(); ++i )
+      {
+        feedbackMessage += tr( " %1 on layer %2." ).arg( i.value().count() ).arg( i.key()->name() );
+        deletedCount += i.value().count();
+      }
+      visibleMessageBar()->pushMessage( tr( "%1 features deleted: %2" ).arg( deletedCount ).arg( feedbackMessage ), Qgis::Success );
+    }
+
+    showStatusMessage( tr( "%n feature(s) deleted.", "number of features deleted", deletedCount ) );
   }
 
   vlayer->endEditCommand();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9003,7 +9003,7 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *parent, bool checkFea
 
   vlayer->beginEditCommand( tr( "Features deleted" ) );
   int deletedCount = 0;
-  if ( !vlayer->deleteSelectedFeatures( &deletedCount ) )
+  if ( !vlayer->deleteSelectedFeatures( &deletedCount, true ) )
   {
     visibleMessageBar()->pushMessage( tr( "Problem deleting features" ),
                                       tr( "A problem occurred during deletion from layer \"%1\". %n feature(s) not deleted.", nullptr, numberOfSelectedFeatures - deletedCount ).arg( vlayer->name() ),

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9032,16 +9032,16 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *parent, bool checkFea
   }
   else
   {
+    const auto contextLayers = context.handledLayers();
     //if it effected more than one layer, print feedback for all descendants
-    if ( context.mHandledFeatures.size() > 1 )
+    if ( contextLayers.size() > 1 )
     {
       deletedCount = 0;
       QString feedbackMessage;
-      QMap<QgsVectorLayer *, QgsFeatureIds>::const_iterator i;
-      for ( i = context.mHandledFeatures.begin(); i != context.mHandledFeatures.end(); ++i )
+      for ( QgsVectorLayer *contextLayer : contextLayers )
       {
-        feedbackMessage += tr( " %1 on layer %2." ).arg( i.value().size() ).arg( i.key()->name() );
-        deletedCount += i.value().size();
+        feedbackMessage += tr( " %1 on layer %2." ).arg( context.handledFeatures( contextLayer ).size() ).arg( contextLayer->name() );
+        deletedCount += context.handledFeatures( contextLayer ).size();
       }
       visibleMessageBar()->pushMessage( tr( "%1 features deleted: %2" ).arg( deletedCount ).arg( feedbackMessage ), Qgis::Success );
     }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9001,6 +9001,16 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *parent, bool checkFea
     }
   }
 
+  if ( QgsVectorLayerUtils::impactsCascadeFeatures(vlayer, QgsProject::instance() ) )
+  {
+    // for extra safety to make sure we know that the delete can have impact on children and joins
+    int res = QMessageBox::warning( mMapCanvas, tr( "Possible impact on descendants of layer \"%1\"").arg( vlayer->name() ),
+                                    tr( "A delete on this layer could have an impact on referencing or joined layers and their descendants. Would you still like to continue?" ),
+                                    QMessageBox::Yes | QMessageBox::No );
+    if ( res != QMessageBox::Yes )
+      return;
+  }
+
   vlayer->beginEditCommand( tr( "Features deleted" ) );
   int deletedCount = 0;
   QgsVectorLayer::DeleteContext context { true };

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9001,11 +9001,21 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *parent, bool checkFea
     }
   }
 
-  if ( QgsVectorLayerUtils::impactsCascadeFeatures( vlayer, QgsProject::instance() ) )
+  QgsVectorLayerUtils::QgsDuplicateFeatureContext infoContext;
+  if ( QgsVectorLayerUtils::impactsCascadeFeatures( vlayer, vlayer->selectedFeatureIds(), QgsProject::instance(), infoContext ) )
   {
+    QString childrenInfo;
+    int childrenCount = 0;
+    const auto infoContextLayers = infoContext.layers();
+    for ( QgsVectorLayer *chl : infoContextLayers )
+    {
+      childrenCount += infoContext.duplicatedFeatures( chl ).size();
+      childrenInfo += ( tr( "%1 feature(s) on layer \"%2\", " ).arg( infoContext.duplicatedFeatures( chl ).size() ).arg( chl->name() ) );
+    }
+
     // for extra safety to make sure we know that the delete can have impact on children and joins
-    int res = QMessageBox::question( mMapCanvas, tr( "Possible impact on descendants of layer \"%1\"" ).arg( vlayer->name() ),
-                                     tr( "A delete on this layer could have an impact on referencing or joined layers and their descendants. Would you still like to continue?" ),
+    int res = QMessageBox::question( mMapCanvas, tr( "Delete at least %3 feature(s) on other layer(s)" ).arg( childrenCount ),
+                                     tr( "Delete %1 feature(s) on layer \"%2\" and %3as well.\nAnd all the further descendants of them.\nDelete these features?" ).arg( numberOfSelectedFeatures ).arg( vlayer->name() ).arg( childrenInfo ),
                                      QMessageBox::Yes | QMessageBox::No );
     if ( res != QMessageBox::Yes )
       return;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9004,9 +9004,9 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *parent, bool checkFea
   if ( QgsVectorLayerUtils::impactsCascadeFeatures( vlayer, QgsProject::instance() ) )
   {
     // for extra safety to make sure we know that the delete can have impact on children and joins
-    int res = QMessageBox::warning( mMapCanvas, tr( "Possible impact on descendants of layer \"%1\"" ).arg( vlayer->name() ),
-                                    tr( "A delete on this layer could have an impact on referencing or joined layers and their descendants. Would you still like to continue?" ),
-                                    QMessageBox::Yes | QMessageBox::No );
+    int res = QMessageBox::question( mMapCanvas, tr( "Possible impact on descendants of layer \"%1\"" ).arg( vlayer->name() ),
+                                     tr( "A delete on this layer could have an impact on referencing or joined layers and their descendants. Would you still like to continue?" ),
+                                     QMessageBox::Yes | QMessageBox::No );
     if ( res != QMessageBox::Yes )
       return;
   }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9033,7 +9033,7 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *parent, bool checkFea
   else
   {
     const auto contextLayers = context.handledLayers();
-    //if it effected more than one layer, print feedback for all descendants
+    // if it affects more than one layer, print feedback for all descendants
     if ( contextLayers.size() > 1 )
     {
       deletedCount = 0;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9033,15 +9033,15 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *parent, bool checkFea
   else
   {
     //if it effected more than one layer, print feedback for all descendants
-    if ( context.handledFeatures.count() > 1 )
+    if ( context.handledFeatures().size() > 1 )
     {
       deletedCount = 0;
       QString feedbackMessage;
       QMap<QgsVectorLayer *, QgsFeatureIds>::const_iterator i;
-      for ( i = context.handledFeatures.begin(); i != context.handledFeatures.end(); ++i )
+      for ( i = context.handledFeatures().begin(); i != context.handledFeatures().end(); ++i )
       {
-        feedbackMessage += tr( " %1 on layer %2." ).arg( i.value().count() ).arg( i.key()->name() );
-        deletedCount += i.value().count();
+        feedbackMessage += tr( " %1 on layer %2." ).arg( i.value().size() ).arg( i.key()->name() );
+        deletedCount += i.value().size();
       }
       visibleMessageBar()->pushMessage( tr( "%1 features deleted: %2" ).arg( deletedCount ).arg( feedbackMessage ), Qgis::Success );
     }

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -888,12 +888,12 @@ void QgsAttributeTableDialog::deleteFeature( const QgsFeatureId fid )
   QgsVectorLayer::DeleteContext context { true };
   mLayer->deleteFeature( fid, &context );
   //if it effected more than one layer, print feedback for all descendants
-  if ( context.handledFeatures().size() > 1 )
+  if ( context.mHandledFeatures.size() > 1 )
   {
     int deletedCount = 0;
     QString feedbackMessage;
     QMap<QgsVectorLayer *, QgsFeatureIds>::const_iterator i;
-    for ( i = context.handledFeatures().begin(); i != context.handledFeatures().end(); ++i )
+    for ( i = context.mHandledFeatures.begin(); i != context.mHandledFeatures.end(); ++i )
     {
       feedbackMessage += tr( " %1 on layer %2." ).arg( i.value().size() ).arg( i.key()->name() );
       deletedCount += i.value().size();

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -864,10 +864,10 @@ void QgsAttributeTableDialog::setFilterExpression( const QString &filterString, 
 void QgsAttributeTableDialog::deleteFeature( const QgsFeatureId fid )
 {
   QgsDebugMsg( QStringLiteral( "Delete %1" ).arg( fid ) );
-  if ( QgsVectorLayerUtils::impactsCascadeFeatures(mLayer, QgsProject::instance() ) )
+  if ( QgsVectorLayerUtils::impactsCascadeFeatures( mLayer, QgsProject::instance() ) )
   {
     // for extra safety to make sure we know that the delete can have impact on children and joins
-    int res = QMessageBox::warning( this, tr( "Possible impact on descendants of layer \"%1\"").arg( mLayer->name() ),
+    int res = QMessageBox::warning( this, tr( "Possible impact on descendants of layer \"%1\"" ).arg( mLayer->name() ),
                                     tr( "A delete on this layer could have an impact on referencing or joined layers and their descendants. Would you still like to continue?" ),
                                     QMessageBox::Yes | QMessageBox::No );
     if ( res != QMessageBox::Yes )

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -864,7 +864,7 @@ void QgsAttributeTableDialog::setFilterExpression( const QString &filterString, 
 void QgsAttributeTableDialog::deleteFeature( const QgsFeatureId fid )
 {
   QgsDebugMsg( QStringLiteral( "Delete %1" ).arg( fid ) );
-  mLayer->deleteFeature( fid );
+  mLayer->deleteFeature( fid, true );
 }
 
 void QgsAttributeTableDialog::showContextMenu( QgsActionMenu *menu, const QgsFeatureId fid )

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -866,6 +866,19 @@ void QgsAttributeTableDialog::deleteFeature( const QgsFeatureId fid )
   QgsDebugMsg( QStringLiteral( "Delete %1" ).arg( fid ) );
   QgsVectorLayer::DeleteContext context { true };
   mLayer->deleteFeature( fid, &context );
+  //if it effected more than one layer, print feedback for all descendants
+  if ( context.handledFeatures.count() > 1 )
+  {
+    int deletedCount = 0;
+    QString feedbackMessage;
+    QMap<QgsVectorLayer *, QgsFeatureIds>::const_iterator i;
+    for ( i = context.handledFeatures.begin(); i != context.handledFeatures.end(); ++i )
+    {
+      feedbackMessage += tr( " %1 on layer %2." ).arg( i.value().count() ).arg( i.key()->name() );
+      deletedCount += i.value().count();
+    }
+    QgisApp::instance()->messageBar()->pushMessage( tr( "%1 features deleted: %2" ).arg( deletedCount ).arg( feedbackMessage ), Qgis::Success );
+  }
 }
 
 void QgsAttributeTableDialog::showContextMenu( QgsActionMenu *menu, const QgsFeatureId fid )

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -896,7 +896,7 @@ void QgsAttributeTableDialog::deleteFeature( const QgsFeatureId fid )
     QString feedbackMessage;
     for ( QgsVectorLayer *contextLayer : contextLayers )
     {
-      feedbackMessage += tr( " %1 on layer %2." ).arg( context.handledFeatures( contextLayer ).size() ).arg( contextLayer->name() );
+      feedbackMessage += tr( "%1 on layer %2. " ).arg( context.handledFeatures( contextLayer ).size() ).arg( contextLayer->name() );
       deletedCount += context.handledFeatures( contextLayer ).size();
     }
     QgisApp::instance()->messageBar()->pushMessage( tr( "%1 features deleted: %2" ).arg( deletedCount ).arg( feedbackMessage ), Qgis::Success );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -864,7 +864,8 @@ void QgsAttributeTableDialog::setFilterExpression( const QString &filterString, 
 void QgsAttributeTableDialog::deleteFeature( const QgsFeatureId fid )
 {
   QgsDebugMsg( QStringLiteral( "Delete %1" ).arg( fid ) );
-  mLayer->deleteFeature( fid, true );
+  QgsVectorLayer::DeleteContext context { true };
+  mLayer->deleteFeature( fid, &context );
 }
 
 void QgsAttributeTableDialog::showContextMenu( QgsActionMenu *menu, const QgsFeatureId fid )

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -867,9 +867,9 @@ void QgsAttributeTableDialog::deleteFeature( const QgsFeatureId fid )
   if ( QgsVectorLayerUtils::impactsCascadeFeatures( mLayer, QgsProject::instance() ) )
   {
     // for extra safety to make sure we know that the delete can have impact on children and joins
-    int res = QMessageBox::warning( this, tr( "Possible impact on descendants of layer \"%1\"" ).arg( mLayer->name() ),
-                                    tr( "A delete on this layer could have an impact on referencing or joined layers and their descendants. Would you still like to continue?" ),
-                                    QMessageBox::Yes | QMessageBox::No );
+    int res = QMessageBox::question( this, tr( "Possible impact on descendants of layer \"%1\"" ).arg( mLayer->name() ),
+                                     tr( "A delete on this layer could have an impact on referencing or joined layers and their descendants. Would you still like to continue?" ),
+                                     QMessageBox::Yes | QMessageBox::No );
     if ( res != QMessageBox::Yes )
       return;
   }

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -888,15 +888,15 @@ void QgsAttributeTableDialog::deleteFeature( const QgsFeatureId fid )
   QgsVectorLayer::DeleteContext context { true };
   mLayer->deleteFeature( fid, &context );
   //if it effected more than one layer, print feedback for all descendants
-  if ( context.handledFeatures.count() > 1 )
+  if ( context.handledFeatures().size() > 1 )
   {
     int deletedCount = 0;
     QString feedbackMessage;
     QMap<QgsVectorLayer *, QgsFeatureIds>::const_iterator i;
-    for ( i = context.handledFeatures.begin(); i != context.handledFeatures.end(); ++i )
+    for ( i = context.handledFeatures().begin(); i != context.handledFeatures().end(); ++i )
     {
-      feedbackMessage += tr( " %1 on layer %2." ).arg( i.value().count() ).arg( i.key()->name() );
-      deletedCount += i.value().count();
+      feedbackMessage += tr( " %1 on layer %2." ).arg( i.value().size() ).arg( i.key()->name() );
+      deletedCount += i.value().size();
     }
     QgisApp::instance()->messageBar()->pushMessage( tr( "%1 features deleted: %2" ).arg( deletedCount ).arg( feedbackMessage ), Qgis::Success );
   }

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -887,16 +887,17 @@ void QgsAttributeTableDialog::deleteFeature( const QgsFeatureId fid )
 
   QgsVectorLayer::DeleteContext context { true };
   mLayer->deleteFeature( fid, &context );
+
+  const auto contextLayers = context.handledLayers();
   //if it effected more than one layer, print feedback for all descendants
-  if ( context.mHandledFeatures.size() > 1 )
+  if ( contextLayers.size() > 1 )
   {
     int deletedCount = 0;
     QString feedbackMessage;
-    QMap<QgsVectorLayer *, QgsFeatureIds>::const_iterator i;
-    for ( i = context.mHandledFeatures.begin(); i != context.mHandledFeatures.end(); ++i )
+    for ( QgsVectorLayer *contextLayer : contextLayers )
     {
-      feedbackMessage += tr( " %1 on layer %2." ).arg( i.value().size() ).arg( i.key()->name() );
-      deletedCount += i.value().size();
+      feedbackMessage += tr( " %1 on layer %2." ).arg( context.handledFeatures( contextLayer ).size() ).arg( contextLayer->name() );
+      deletedCount += context.handledFeatures( contextLayer ).size();
     }
     QgisApp::instance()->messageBar()->pushMessage( tr( "%1 features deleted: %2" ).arg( deletedCount ).arg( feedbackMessage ), Qgis::Success );
   }

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -864,6 +864,16 @@ void QgsAttributeTableDialog::setFilterExpression( const QString &filterString, 
 void QgsAttributeTableDialog::deleteFeature( const QgsFeatureId fid )
 {
   QgsDebugMsg( QStringLiteral( "Delete %1" ).arg( fid ) );
+  if ( QgsVectorLayerUtils::impactsCascadeFeatures(mLayer, QgsProject::instance() ) )
+  {
+    // for extra safety to make sure we know that the delete can have impact on children and joins
+    int res = QMessageBox::warning( this, tr( "Possible impact on descendants of layer \"%1\"").arg( mLayer->name() ),
+                                    tr( "A delete on this layer could have an impact on referencing or joined layers and their descendants. Would you still like to continue?" ),
+                                    QMessageBox::Yes | QMessageBox::No );
+    if ( res != QMessageBox::Yes )
+      return;
+  }
+
   QgsVectorLayer::DeleteContext context { true };
   mLayer->deleteFeature( fid, &context );
   //if it effected more than one layer, print feedback for all descendants

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -885,9 +885,8 @@ void QgsAttributeTableDialog::deleteFeature( const QgsFeatureId fid )
       return;
   }
 
-  QgsVectorLayer::DeleteContext context { true };
+  QgsVectorLayer::DeleteContext context( true, QgsProject::instance() );
   mLayer->deleteFeature( fid, &context );
-
   const auto contextLayers = context.handledLayers();
   //if it effected more than one layer, print feedback for all descendants
   if ( contextLayers.size() > 1 )

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -3171,9 +3171,9 @@ bool QgsVectorLayer::deleteFeatureCascade( QgsFeatureId fid, QgsVectorLayer::Del
 
   if ( context && context->cascade )
   {
-    if ( context->handledFeatures.contains( this ) )
+    if ( context->mHandledFeatures.contains( this ) )
     {
-      QgsFeatureIds handledFeatureIds = context->handledFeatures.value( this );
+      QgsFeatureIds handledFeatureIds = context->mHandledFeatures.value( this );
       if ( handledFeatureIds.contains( fid ) )
       {
         // avoid endless recursion
@@ -3183,13 +3183,13 @@ bool QgsVectorLayer::deleteFeatureCascade( QgsFeatureId fid, QgsVectorLayer::Del
       {
         // add feature id
         handledFeatureIds << fid;
-        context->handledFeatures.insert( this, handledFeatureIds );
+        context->mHandledFeatures.insert( this, handledFeatureIds );
       }
     }
     else
     {
       // add layer and feature id
-      context->handledFeatures.insert( this, QgsFeatureIds() << fid );
+      context->mHandledFeatures.insert( this, QgsFeatureIds() << fid );
     }
 
     const QList<QgsRelation> relations = QgsProject::instance()->relationManager()->referencedRelations( this );

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -3215,7 +3215,7 @@ bool QgsVectorLayer::deleteFeatureCascade( QgsFeatureId fid, const bool cascade,
   }
 
   if ( mJoinBuffer->containsJoins() )
-    mJoinBuffer->deleteFeature( fid, cascade );
+    mJoinBuffer->deleteFeature( fid, cascade, handledFeatures );
 
   bool res = mEditBuffer->deleteFeature( fid );
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -3192,7 +3192,7 @@ bool QgsVectorLayer::deleteFeatureCascade( QgsFeatureId fid, QgsVectorLayer::Del
       context->mHandledFeatures.insert( this, QgsFeatureIds() << fid );
     }
 
-    const QList<QgsRelation> relations = QgsProject::instance()->relationManager()->referencedRelations( this );
+    const QList<QgsRelation> relations = context->project->relationManager()->referencedRelations( this );
 
     for ( const QgsRelation &relation : relations )
     {

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -5529,3 +5529,17 @@ void QgsVectorLayer::onDirtyTransaction( const QString &sql, const QString &name
     qobject_cast<QgsVectorLayerEditPassthrough *>( mEditBuffer )->update( tr, sql, name );
   }
 }
+
+QList<QgsVectorLayer *> QgsVectorLayer::DeleteContext::handledLayers() const
+{
+  QList<QgsVectorLayer *> layers;
+  QMap<QgsVectorLayer *, QgsFeatureIds>::const_iterator i;
+  for ( i = mHandledFeatures.begin(); i != mHandledFeatures.end(); ++i )
+    layers.append( i.key() );
+  return layers;
+}
+
+QgsFeatureIds QgsVectorLayer::DeleteContext::handledFeatures( QgsVectorLayer *layer ) const
+{
+  return mHandledFeatures[layer];
+}

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -3240,7 +3240,7 @@ bool QgsVectorLayer::deleteFeature( QgsFeatureId fid, QgsVectorLayer::DeleteCont
   return res;
 }
 
-bool QgsVectorLayer::deleteFeatures( const QgsFeatureIds &fids, QgsVectorLayer::DeleteContext *context )
+bool QgsVectorLayer::deleteFeatures( const QgsFeatureIds fids, QgsVectorLayer::DeleteContext *context )
 {
   bool res = true;
   const auto constFids = fids;

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -3176,7 +3176,7 @@ bool QgsVectorLayer::deleteFeatureCascade( QgsFeatureId fid, QgsVectorLayer::Del
       QgsFeatureIds handledFeatureIds = context->handledFeatures.value( this );
       if ( handledFeatureIds.contains( fid ) )
       {
-        // break recursion
+        // avoid endless recursion
         return false;
       }
       else

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -3207,9 +3207,11 @@ bool QgsVectorLayer::deleteFeatureCascade( QgsFeatureId fid, QgsVectorLayer::Del
         {
           childFeatureIds.insert( childFeature.id() );
         }
-
-        relation.referencingLayer()->startEditing();
-        relation.referencingLayer()->deleteFeatures( childFeatureIds, context );
+        if ( childFeatureIds.count() > 0 )
+        {
+          relation.referencingLayer()->startEditing();
+          relation.referencingLayer()->deleteFeatures( childFeatureIds, context );
+        }
       }
     }
   }

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -3240,7 +3240,7 @@ bool QgsVectorLayer::deleteFeature( QgsFeatureId fid, QgsVectorLayer::DeleteCont
   return res;
 }
 
-bool QgsVectorLayer::deleteFeatures( const QgsFeatureIds fids, QgsVectorLayer::DeleteContext *context )
+bool QgsVectorLayer::deleteFeatures( const QgsFeatureIds &fids, QgsVectorLayer::DeleteContext *context )
 {
   bool res = true;
   const auto constFids = fids;

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -516,10 +516,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
        */
       explicit DeleteContext( bool cascade = false ): cascade( cascade ) {}
 
-      /**
-       * Returns all the layers on which features have been deleted
-       */
-      QMap<QgsVectorLayer *, QgsFeatureIds> handledFeatures() { return mHandledFeatures; }
+      QList<QgsVectorLayer *> handledLayers() const;
+      QgsFeatureIds handledFeatures( QgsVectorLayer *layer ) const;
 
       QMap<QgsVectorLayer *, QgsFeatureIds> mHandledFeatures SIP_SKIP;
       bool cascade;

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1294,7 +1294,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     /**
      * Deletes the selected features
-     * \param deleteCount The number of successfully deleted features
+     * \param deletedCount The number of successfully deleted features
      * \param context The chain of features who will be deleted for feedback and to avoid endless recursions
      *
      * \returns TRUE in case of success and FALSE otherwise

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -508,7 +508,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * Context for deleting features
      * \since QGIS 3.14
      */
-    struct DeleteContext
+    struct  DeleteContext
     {
 
       /**
@@ -516,8 +516,13 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
        */
       explicit DeleteContext( bool cascade = false ): cascade( cascade ) {}
 
-      QMap<QgsVectorLayer *, QgsFeatureIds> handledFeatures;
-      bool cascade ;
+      /**
+       * Returns all the layers on which features have been deleted
+       */
+      QMap<QgsVectorLayer *, QgsFeatureIds> handledFeatures() { return mHandledFeatures; }
+
+      QMap<QgsVectorLayer *, QgsFeatureIds> mHandledFeatures SIP_SKIP;
+      bool cascade;
     };
 
     /**

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1283,7 +1283,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      *
      * \returns TRUE in case of success and FALSE otherwise
      */
-    Q_INVOKABLE bool deleteSelectedFeatures( int *deletedCount = nullptr, const bool cascade = false );
+    Q_INVOKABLE bool deleteSelectedFeatures( int *deletedCount = nullptr, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = nullptr );
 
     /**
      * Adds a ring to polygon/multipolygon features
@@ -1823,7 +1823,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * to the underlying data provider until a commitChanges() call is made. Any uncommitted
      * changes can be discarded by calling rollBack().
      */
-    bool deleteFeature( QgsFeatureId fid, const bool cascade = false );
+    bool deleteFeature( QgsFeatureId fid, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = nullptr );
 
     /**
      * Deletes a set of features from the layer (but does not commit it)
@@ -1838,7 +1838,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * to the underlying data provider until a commitChanges() call is made. Any uncommitted
      * changes can be discarded by calling rollBack().
      */
-    bool deleteFeatures( const QgsFeatureIds &fids, const bool cascade = false );
+    bool deleteFeatures( const QgsFeatureIds &fids, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = nullptr );
 
     /**
      * Attempts to commit to the underlying data provider any buffered changes made since the
@@ -2695,7 +2695,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     //! Read simple labeling from layer's custom properties (QGIS 2.x projects)
     QgsAbstractVectorLayerLabeling *readLabelingFromCustomProperties();
 
-    bool deleteFeatureWithDependencies( QgsFeatureId fid, const bool cascade = false );
+    bool deleteFeatureCascade( QgsFeatureId fid, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = nullptr );
 
 #ifdef SIP_RUN
     QgsVectorLayer( const QgsVectorLayer &rhs );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1295,7 +1295,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     /**
      * Deletes the selected features
      * \param deleteCount The number of successfully deleted features
-     * \param cascade If the decendants of the feature should be deleted as well
+     * \param context The chain of features who will be deleted for feedback and to avoid endless recursions
      *
      * \returns TRUE in case of success and FALSE otherwise
      */
@@ -1832,7 +1832,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     /**
      * Deletes a feature from the layer (but does not commit it).
      * \param fid The feature id to delete
-     * \param cascade If the decendants of the feature should be deleted as well
+     * \param context The chain of features who will be deleted for feedback and to avoid endless recursions
      *
      * \note Calls to deleteFeature() are only valid for layers in which edits have been enabled
      * by a call to startEditing(). Changes made to features using this method are not committed
@@ -1844,7 +1844,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     /**
      * Deletes a set of features from the layer (but does not commit it)
      * \param fids The feature ids to delete
-     * \param cascade If the decendants of the feature should be deleted as well
+     * \param context The chain of features who will be deleted for feedback and to avoid endless recursions
      *
      * \returns FALSE if the layer is not in edit mode or does not support deleting
      *         in case of an active transaction depends on the provider implementation

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -514,13 +514,14 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
       /**
        * Constructor for DeleteContext.
        */
-      explicit DeleteContext( bool cascade = false ): cascade( cascade ) {}
+      explicit DeleteContext( bool cascade = false, QgsProject *project = nullptr ): cascade( cascade ), project( project ) {}
 
       QList<QgsVectorLayer *> handledLayers() const;
       QgsFeatureIds handledFeatures( QgsVectorLayer *layer ) const;
 
       QMap<QgsVectorLayer *, QgsFeatureIds> mHandledFeatures SIP_SKIP;
       bool cascade;
+      QgsProject *project;
     };
 
     /**

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2689,6 +2689,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     //! Read simple labeling from layer's custom properties (QGIS 2.x projects)
     QgsAbstractVectorLayerLabeling *readLabelingFromCustomProperties();
 
+    bool deleteFeatureWithDependencies( QgsFeatureId fid );
+
 #ifdef SIP_RUN
     QgsVectorLayer( const QgsVectorLayer &rhs );
 #endif

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1278,9 +1278,12 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     /**
      * Deletes the selected features
-     *  \returns TRUE in case of success and FALSE otherwise
+     * \param deleteCount The number of successfully deleted features
+     * \param cascade If the decendants of the feature should be deleted as well
+     *
+     * \returns TRUE in case of success and FALSE otherwise
      */
-    Q_INVOKABLE bool deleteSelectedFeatures( int *deletedCount = nullptr );
+    Q_INVOKABLE bool deleteSelectedFeatures( int *deletedCount = nullptr, const bool cascade = false );
 
     /**
      * Adds a ring to polygon/multipolygon features
@@ -1812,17 +1815,20 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     /**
      * Deletes a feature from the layer (but does not commit it).
+     * \param fid The feature id to delete
+     * \param cascade If the decendants of the feature should be deleted as well
      *
      * \note Calls to deleteFeature() are only valid for layers in which edits have been enabled
      * by a call to startEditing(). Changes made to features using this method are not committed
      * to the underlying data provider until a commitChanges() call is made. Any uncommitted
      * changes can be discarded by calling rollBack().
      */
-    bool deleteFeature( QgsFeatureId fid );
+    bool deleteFeature( QgsFeatureId fid, const bool cascade = false );
 
     /**
      * Deletes a set of features from the layer (but does not commit it)
      * \param fids The feature ids to delete
+     * \param cascade If the decendants of the feature should be deleted as well
      *
      * \returns FALSE if the layer is not in edit mode or does not support deleting
      *         in case of an active transaction depends on the provider implementation
@@ -1832,7 +1838,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * to the underlying data provider until a commitChanges() call is made. Any uncommitted
      * changes can be discarded by calling rollBack().
      */
-    bool deleteFeatures( const QgsFeatureIds &fids );
+    bool deleteFeatures( const QgsFeatureIds &fids, const bool cascade = false );
 
     /**
      * Attempts to commit to the underlying data provider any buffered changes made since the
@@ -2689,7 +2695,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     //! Read simple labeling from layer's custom properties (QGIS 2.x projects)
     QgsAbstractVectorLayerLabeling *readLabelingFromCustomProperties();
 
-    bool deleteFeatureWithDependencies( QgsFeatureId fid );
+    bool deleteFeatureWithDependencies( QgsFeatureId fid, const bool cascade = false );
 
 #ifdef SIP_RUN
     QgsVectorLayer( const QgsVectorLayer &rhs );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1854,7 +1854,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * to the underlying data provider until a commitChanges() call is made. Any uncommitted
      * changes can be discarded by calling rollBack().
      */
-    bool deleteFeatures( const QgsFeatureIds &fids, DeleteContext *context = nullptr );
+    bool deleteFeatures( const QgsFeatureIds fids, DeleteContext *context = nullptr );
 
     /**
      * Attempts to commit to the underlying data provider any buffered changes made since the

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -508,7 +508,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * Context for deleting features
      * \since QGIS 3.14
      */
-    struct  DeleteContext
+    struct CORE_EXPORT DeleteContext
     {
 
       /**

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -505,6 +505,22 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     };
 
     /**
+     * Context for deleting features
+     * \since QGIS 3.14
+     */
+    struct DeleteContext
+    {
+
+      /**
+       * Constructor for DeleteContext.
+       */
+      explicit DeleteContext( bool cascade = false ): cascade( cascade ) {}
+
+      QMap<QgsVectorLayer *, QgsFeatureIds> handledFeatures;
+      bool cascade ;
+    };
+
+    /**
      * Constructor - creates a vector layer
      *
      * The QgsVectorLayer is constructed by instantiating a data provider.  The provider
@@ -1283,7 +1299,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      *
      * \returns TRUE in case of success and FALSE otherwise
      */
-    Q_INVOKABLE bool deleteSelectedFeatures( int *deletedCount = nullptr, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = nullptr );
+    Q_INVOKABLE bool deleteSelectedFeatures( int *deletedCount = nullptr, DeleteContext *context = nullptr );
 
     /**
      * Adds a ring to polygon/multipolygon features
@@ -1823,7 +1839,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * to the underlying data provider until a commitChanges() call is made. Any uncommitted
      * changes can be discarded by calling rollBack().
      */
-    bool deleteFeature( QgsFeatureId fid, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = nullptr );
+    bool deleteFeature( QgsFeatureId fid, DeleteContext *context = nullptr );
 
     /**
      * Deletes a set of features from the layer (but does not commit it)
@@ -1838,7 +1854,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * to the underlying data provider until a commitChanges() call is made. Any uncommitted
      * changes can be discarded by calling rollBack().
      */
-    bool deleteFeatures( const QgsFeatureIds &fids, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = nullptr );
+    bool deleteFeatures( const QgsFeatureIds &fids, DeleteContext *context = nullptr );
 
     /**
      * Attempts to commit to the underlying data provider any buffered changes made since the
@@ -2695,7 +2711,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     //! Read simple labeling from layer's custom properties (QGIS 2.x projects)
     QgsAbstractVectorLayerLabeling *readLabelingFromCustomProperties();
 
-    bool deleteFeatureCascade( QgsFeatureId fid, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = nullptr );
+    bool deleteFeatureCascade( QgsFeatureId fid, DeleteContext *context = nullptr );
 
 #ifdef SIP_RUN
     QgsVectorLayer( const QgsVectorLayer &rhs );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -505,7 +505,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     };
 
     /**
-     * Context for deleting features
+     * Context for cascade delete features
      * \since QGIS 3.14
      */
     struct CORE_EXPORT DeleteContext

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1858,7 +1858,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * to the underlying data provider until a commitChanges() call is made. Any uncommitted
      * changes can be discarded by calling rollBack().
      */
-    bool deleteFeatures( const QgsFeatureIds fids, DeleteContext *context = nullptr );
+    bool deleteFeatures( const QgsFeatureIds &fids, DeleteContext *context = nullptr );
 
     /**
      * Attempts to commit to the underlying data provider any buffered changes made since the

--- a/src/core/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/qgsvectorlayerjoinbuffer.cpp
@@ -663,12 +663,12 @@ bool QgsVectorLayerJoinBuffer::changeAttributeValues( QgsFeatureId fid, const Qg
   return success;
 }
 
-bool QgsVectorLayerJoinBuffer::deleteFeature( QgsFeatureId fid, const bool cascade ) const
+bool QgsVectorLayerJoinBuffer::deleteFeature( QgsFeatureId fid, const bool cascade, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures ) const
 {
-  return deleteFeatures( QgsFeatureIds() << fid, cascade );
+  return deleteFeatures( QgsFeatureIds() << fid, cascade, handledFeatures );
 }
 
-bool QgsVectorLayerJoinBuffer::deleteFeatures( const QgsFeatureIds &fids, const bool cascade ) const
+bool QgsVectorLayerJoinBuffer::deleteFeatures( const QgsFeatureIds &fids, const bool cascade, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures ) const
 {
   if ( !containsJoins() )
     return false;
@@ -683,7 +683,7 @@ bool QgsVectorLayerJoinBuffer::deleteFeatures( const QgsFeatureIds &fids, const 
       {
         const QgsFeature joinFeature = joinedFeatureOf( &info, mLayer->getFeature( fid ) );
         if ( joinFeature.isValid() )
-          info.joinLayer()->deleteFeature( joinFeature.id(), cascade );
+          info.joinLayer()->deleteFeature( joinFeature.id(), cascade, handledFeatures );
       }
     }
   }

--- a/src/core/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/qgsvectorlayerjoinbuffer.cpp
@@ -663,12 +663,12 @@ bool QgsVectorLayerJoinBuffer::changeAttributeValues( QgsFeatureId fid, const Qg
   return success;
 }
 
-bool QgsVectorLayerJoinBuffer::deleteFeature( QgsFeatureId fid, const bool cascade, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures ) const
+bool QgsVectorLayerJoinBuffer::deleteFeature( QgsFeatureId fid, QgsVectorLayer::DeleteContext *context ) const
 {
-  return deleteFeatures( QgsFeatureIds() << fid, cascade, handledFeatures );
+  return deleteFeatures( QgsFeatureIds() << fid, context );
 }
 
-bool QgsVectorLayerJoinBuffer::deleteFeatures( const QgsFeatureIds &fids, const bool cascade, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures ) const
+bool QgsVectorLayerJoinBuffer::deleteFeatures( const QgsFeatureIds &fids, QgsVectorLayer::DeleteContext *context ) const
 {
   if ( !containsJoins() )
     return false;
@@ -683,7 +683,7 @@ bool QgsVectorLayerJoinBuffer::deleteFeatures( const QgsFeatureIds &fids, const 
       {
         const QgsFeature joinFeature = joinedFeatureOf( &info, mLayer->getFeature( fid ) );
         if ( joinFeature.isValid() )
-          info.joinLayer()->deleteFeature( joinFeature.id(), cascade, handledFeatures );
+          info.joinLayer()->deleteFeature( joinFeature.id(), context );
       }
     }
   }

--- a/src/core/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/qgsvectorlayerjoinbuffer.cpp
@@ -663,12 +663,12 @@ bool QgsVectorLayerJoinBuffer::changeAttributeValues( QgsFeatureId fid, const Qg
   return success;
 }
 
-bool QgsVectorLayerJoinBuffer::deleteFeature( QgsFeatureId fid ) const
+bool QgsVectorLayerJoinBuffer::deleteFeature( QgsFeatureId fid, const bool cascade ) const
 {
-  return deleteFeatures( QgsFeatureIds() << fid );
+  return deleteFeatures( QgsFeatureIds() << fid, cascade );
 }
 
-bool QgsVectorLayerJoinBuffer::deleteFeatures( const QgsFeatureIds &fids ) const
+bool QgsVectorLayerJoinBuffer::deleteFeatures( const QgsFeatureIds &fids, const bool cascade ) const
 {
   if ( !containsJoins() )
     return false;
@@ -683,7 +683,7 @@ bool QgsVectorLayerJoinBuffer::deleteFeatures( const QgsFeatureIds &fids ) const
       {
         const QgsFeature joinFeature = joinedFeatureOf( &info, mLayer->getFeature( fid ) );
         if ( joinFeature.isValid() )
-          info.joinLayer()->deleteFeature( joinFeature.id() );
+          info.joinLayer()->deleteFeature( joinFeature.id(), cascade );
       }
     }
   }

--- a/src/core/qgsvectorlayerjoinbuffer.h
+++ b/src/core/qgsvectorlayerjoinbuffer.h
@@ -202,7 +202,7 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer : public QObject, public QgsFeatureSi
      *
      * \since QGIS 3.0
      */
-    bool deleteFeature( QgsFeatureId fid, const bool cascade = false ) const;
+    bool deleteFeature( QgsFeatureId fid, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = nullptr ) const;
 
     /**
      * Deletes a list of features from joined layers. Feature ids given
@@ -214,7 +214,7 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer : public QObject, public QgsFeatureSi
      *
      * \since QGIS 3.0
      */
-    bool deleteFeatures( const QgsFeatureIds &fids, const bool cascade = false ) const;
+    bool deleteFeatures( const QgsFeatureIds &fids, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = nullptr ) const;
 
   signals:
 

--- a/src/core/qgsvectorlayerjoinbuffer.h
+++ b/src/core/qgsvectorlayerjoinbuffer.h
@@ -210,7 +210,7 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer : public QObject, public QgsFeatureSi
      * in a parameter are those coming from the target layer.
      *
      * \param fids Feature ids from the target layer to delete
-     * \param context The chain of features who will be deleted for feedback and to avoid endless recursions
+     * \param context The chain of features who will be deleted for feedback and to avoid infinite recursions. Can be NULLPTR.
      *
      * \returns FALSE if an error happened, TRUE otherwise
      *

--- a/src/core/qgsvectorlayerjoinbuffer.h
+++ b/src/core/qgsvectorlayerjoinbuffer.h
@@ -197,7 +197,7 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer : public QObject, public QgsFeatureSi
      * parameter is the one coming from the target layer.
      *
      * \param fid The feature id from the target layer to delete
-     * \param context The chain of features who will be deleted for feedback and to avoid endless recursions
+     * \param context The chain of features which will be deleted for feedback and to avoid infinite recursions. Can be NULLPTR.
      *
      * \returns FALSE if an error happened, TRUE otherwise
      *

--- a/src/core/qgsvectorlayerjoinbuffer.h
+++ b/src/core/qgsvectorlayerjoinbuffer.h
@@ -202,7 +202,7 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer : public QObject, public QgsFeatureSi
      *
      * \since QGIS 3.0
      */
-    bool deleteFeature( QgsFeatureId fid, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = nullptr ) const;
+    bool deleteFeature( QgsFeatureId fid, QgsVectorLayer::DeleteContext *context = nullptr ) const;
 
     /**
      * Deletes a list of features from joined layers. Feature ids given
@@ -214,7 +214,7 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer : public QObject, public QgsFeatureSi
      *
      * \since QGIS 3.0
      */
-    bool deleteFeatures( const QgsFeatureIds &fids, const bool cascade = false, QMap<QgsVectorLayer *, QgsFeatureIds> *handledFeatures = nullptr ) const;
+    bool deleteFeatures( const QgsFeatureIds &fids, QgsVectorLayer::DeleteContext *context = nullptr ) const;
 
   signals:
 

--- a/src/core/qgsvectorlayerjoinbuffer.h
+++ b/src/core/qgsvectorlayerjoinbuffer.h
@@ -202,7 +202,7 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer : public QObject, public QgsFeatureSi
      *
      * \since QGIS 3.0
      */
-    bool deleteFeature( QgsFeatureId fid ) const;
+    bool deleteFeature( QgsFeatureId fid, const bool cascade = false ) const;
 
     /**
      * Deletes a list of features from joined layers. Feature ids given
@@ -214,7 +214,7 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer : public QObject, public QgsFeatureSi
      *
      * \since QGIS 3.0
      */
-    bool deleteFeatures( const QgsFeatureIds &fids ) const;
+    bool deleteFeatures( const QgsFeatureIds &fids, const bool cascade = false ) const;
 
   signals:
 

--- a/src/core/qgsvectorlayerjoinbuffer.h
+++ b/src/core/qgsvectorlayerjoinbuffer.h
@@ -197,6 +197,7 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer : public QObject, public QgsFeatureSi
      * parameter is the one coming from the target layer.
      *
      * \param fid The feature id from the target layer to delete
+     * \param context The chain of features who will be deleted for feedback and to avoid endless recursions
      *
      * \returns FALSE if an error happened, TRUE otherwise
      *
@@ -209,6 +210,7 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer : public QObject, public QgsFeatureSi
      * in a parameter are those coming from the target layer.
      *
      * \param fids Feature ids from the target layer to delete
+     * \param context The chain of features who will be deleted for feedback and to avoid endless recursions
      *
      * \returns FALSE if an error happened, TRUE otherwise
      *

--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -934,3 +934,30 @@ QString QgsVectorLayerUtils::getFeatureDisplayString( const QgsVectorLayer *laye
 
   return displayString;
 }
+
+bool QgsVectorLayerUtils::impactsCascadeFeatures(const QgsVectorLayer *layer, const QgsProject *project)
+{
+  if ( !layer )
+    return false;
+
+  const QList<QgsRelation> relations = project->relationManager()->referencedRelations( layer );
+  for ( const QgsRelation &relation : relations )
+  {
+    if ( relation.strength() == QgsRelation::Composition )
+    {
+      return true;
+    }
+  }
+
+  layer->joinBuffer()->containsJoins();
+  const auto constVectorJoins = layer->joinBuffer()->vectorJoins();
+  for ( const QgsVectorLayerJoinInfo &info : constVectorJoins )
+  {
+    if ( info.isEditable() && info.hasCascadedDelete() )
+    {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -935,7 +935,7 @@ QString QgsVectorLayerUtils::getFeatureDisplayString( const QgsVectorLayer *laye
   return displayString;
 }
 
-bool QgsVectorLayerUtils::impactsCascadeFeatures(const QgsVectorLayer *layer, const QgsProject *project)
+bool QgsVectorLayerUtils::impactsCascadeFeatures( const QgsVectorLayer *layer, const QgsProject *project )
 {
   if ( !layer )
     return false;

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -327,7 +327,7 @@ class CORE_EXPORT QgsVectorLayerUtils
      *
      * \since QGIS 3.14
      */
-    static bool impactsCascadeFeatures( const QgsVectorLayer *layer, const QgsFeatureIds &fids, const QgsProject *project, QgsDuplicateFeatureContext &context );
+    static bool impactsCascadeFeatures( const QgsVectorLayer *layer, const QgsFeatureIds &fids, const QgsProject *project, QgsDuplicateFeatureContext &context SIP_OUT );
 
 };
 

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -321,8 +321,9 @@ class CORE_EXPORT QgsVectorLayerUtils
     static QString getFeatureDisplayString( const QgsVectorLayer *layer, const QgsFeature &feature );
 
     /**
-     * \returns true if the \a is connected as parent in at least one composition relation of the \a project
-     * or contains joins, where cascade delete is set.
+     * \returns true if at least one feature of the \a fids on \a layer is connected as parent in at
+     * least one composition relation of the \a project or contains joins, where cascade delete is set.
+     * The \a context is used to get more details.
      *
      * \since QGIS 3.14
      */

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -326,7 +326,7 @@ class CORE_EXPORT QgsVectorLayerUtils
      *
      * \since QGIS 3.14
      */
-    static bool impactsCascadeFeatures(const QgsVectorLayer *layer, const QgsProject *project);
+    static bool impactsCascadeFeatures( const QgsVectorLayer *layer, const QgsProject *project );
 
 };
 

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -323,7 +323,7 @@ class CORE_EXPORT QgsVectorLayerUtils
     /**
      * \returns TRUE if at least one feature of the \a fids on \a layer is connected as parent in at
      * least one composition relation of the \a project or contains joins, where cascade delete is set.
-     * The \a context is used to get more details.
+     * Details about cascading effects will be written to \a context.
      *
      * \since QGIS 3.14
      */

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -319,6 +319,15 @@ class CORE_EXPORT QgsVectorLayerUtils
      * \since QGIS 3.12
      */
     static QString getFeatureDisplayString( const QgsVectorLayer *layer, const QgsFeature &feature );
+
+    /**
+     * \returns true if the \a is connected as parent in at least one composition relation of the \a project
+     * or contains joins, where cascade delete is set.
+     *
+     * \since QGIS 3.14
+     */
+    static bool impactsCascadeFeatures(const QgsVectorLayer *layer, const QgsProject *project);
+
 };
 
 

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -326,7 +326,7 @@ class CORE_EXPORT QgsVectorLayerUtils
      *
      * \since QGIS 3.14
      */
-    static bool impactsCascadeFeatures( const QgsVectorLayer *layer, const QgsProject *project );
+    static bool impactsCascadeFeatures( const QgsVectorLayer *layer, const QgsFeatureIds &fids, const QgsProject *project, QgsDuplicateFeatureContext &context );
 
 };
 

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -324,7 +324,6 @@ class CORE_EXPORT QgsVectorLayerUtils
      * \returns TRUE if at least one feature of the \a fids on \a layer is connected as parent in at
      * least one composition relation of the \a project or contains joins, where cascade delete is set.
      * Details about cascading effects will be written to \a context.
-     *
      * \since QGIS 3.14
      */
     static bool impactsCascadeFeatures( const QgsVectorLayer *layer, const QgsFeatureIds &fids, const QgsProject *project, QgsDuplicateFeatureContext &context SIP_OUT );

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -321,7 +321,7 @@ class CORE_EXPORT QgsVectorLayerUtils
     static QString getFeatureDisplayString( const QgsVectorLayer *layer, const QgsFeature &feature );
 
     /**
-     * \returns true if at least one feature of the \a fids on \a layer is connected as parent in at
+     * \returns TRUE if at least one feature of the \a fids on \a layer is connected as parent in at
      * least one composition relation of the \a project or contains joins, where cascade delete is set.
      * The \a context is used to get more details.
      *

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -731,9 +731,9 @@ void QgsRelationEditorWidget::deleteFeatures( const QgsFeatureIds &featureids )
   if ( QgsVectorLayerUtils::impactsCascadeFeatures( layer, QgsProject::instance() ) )
   {
     // for extra safety to make sure we know that the delete can have impact on children and joins
-    int res = QMessageBox::warning( this, tr( "Possible impact on descendants of layer \"%1\"" ).arg( layer->name() ),
-                                    tr( "A delete on this layer could have an impact on referencing or joined layers and their descendants. Would you still like to continue?" ),
-                                    QMessageBox::Yes | QMessageBox::No );
+    int res = QMessageBox::question( this, tr( "Possible impact on descendants of layer \"%1\"" ).arg( layer->name() ),
+                                     tr( "A delete on this layer could have an impact on referencing or joined layers and their descendants. Would you still like to continue?" ),
+                                     QMessageBox::Yes | QMessageBox::No );
     if ( res == QMessageBox::No )
       deleteFeatures = false;
   }

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -752,18 +752,19 @@ void QgsRelationEditorWidget::deleteFeatures( const QgsFeatureIds &featureids )
   {
     QgsVectorLayer::DeleteContext context { true };
     layer->deleteFeatures( featureids, &context );
-    if ( context.mHandledFeatures.size() > 1 )
+    const auto contextLayers = context.handledLayers();
+    if ( contextLayers.size() > 1 )
     {
       int deletedCount = 0;
       QString feedbackMessage;
-      QMap<QgsVectorLayer *, QgsFeatureIds>::const_iterator i;
-      for ( i = context.mHandledFeatures.begin(); i != context.mHandledFeatures.end(); ++i )
+      for ( QgsVectorLayer *contextLayer : contextLayers )
       {
-        feedbackMessage += tr( " %1 on layer %2." ).arg( i.value().size() ).arg( i.key()->name() );
-        deletedCount += i.value().size();
+        feedbackMessage += tr( " %1 on layer %2." ).arg( context.handledFeatures( contextLayer ).size() ).arg( contextLayer->name() );
+        deletedCount += context.handledFeatures( contextLayer ).size();
       }
       mEditorContext.mainMessageBar()->pushMessage( tr( "%1 features deleted: %2" ).arg( deletedCount ).arg( feedbackMessage ), Qgis::Success );
     }
+
     updateUi();
   }
 }

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -762,7 +762,7 @@ void QgsRelationEditorWidget::deleteFeatures( const QgsFeatureIds &featureids )
         feedbackMessage += tr( " %1 on layer %2." ).arg( context.handledFeatures( contextLayer ).size() ).arg( contextLayer->name() );
         deletedCount += context.handledFeatures( contextLayer ).size();
       }
-      mEditorContext.mainMessageBar()->pushMessage( tr( "%1 features deleted: %2" ).arg( deletedCount ).arg( feedbackMessage ), Qgis::Success );
+      mEditorContext.mainMessageBar()->pushMessage( tr( "%1 features deleted:%2" ).arg( deletedCount ).arg( feedbackMessage ), Qgis::Success );
     }
 
     updateUi();

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -667,10 +667,8 @@ void QgsRelationEditorWidget::deleteFeatures( const QgsFeatureIds &featureids )
     // When deleting a linked feature within an N:M relation,
     // check if the feature is linked to more than just one feature.
     // In case it is linked more than just once, ask the user for confirmation
-    // as it is likely he was not aware of the implications and might either
-    // leave the dataset in a corrupted state (referential integrity) or if
-    // the fk constraint is ON CASCADE DELETE, there may be several linking
-    // entries deleted along.
+    // as it is likely he was not aware of the implications and might delete
+    // there may be several linking entries deleted along.
 
     QgsFeatureRequest deletedFeaturesRequest;
     deletedFeaturesRequest.setFilterFids( featureids );
@@ -732,7 +730,7 @@ void QgsRelationEditorWidget::deleteFeatures( const QgsFeatureIds &featureids )
 
   if ( deleteFeatures )
   {
-    layer->deleteFeatures( featureids );
+    layer->deleteFeatures( featureids, true );
     updateUi();
   }
 }
@@ -793,7 +791,7 @@ void QgsRelationEditorWidget::unlinkFeatures( const QgsFeatureIds &featureids )
       QgsDebugMsgLevel( FID_TO_STRING( f.id() ), 4 );
     }
 
-    mRelation.referencingLayer()->deleteFeatures( fids );
+    mRelation.referencingLayer()->deleteFeatures( fids, false );
 
     updateUi();
   }

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -728,10 +728,10 @@ void QgsRelationEditorWidget::deleteFeatures( const QgsFeatureIds &featureids )
     layer = mRelation.referencingLayer();
   }
 
-  if ( QgsVectorLayerUtils::impactsCascadeFeatures(layer, QgsProject::instance() ) )
+  if ( QgsVectorLayerUtils::impactsCascadeFeatures( layer, QgsProject::instance() ) )
   {
     // for extra safety to make sure we know that the delete can have impact on children and joins
-    int res = QMessageBox::warning( this, tr( "Possible impact on descendants of layer \"%1\"").arg( layer->name() ),
+    int res = QMessageBox::warning( this, tr( "Possible impact on descendants of layer \"%1\"" ).arg( layer->name() ),
                                     tr( "A delete on this layer could have an impact on referencing or joined layers and their descendants. Would you still like to continue?" ),
                                     QMessageBox::Yes | QMessageBox::No );
     if ( res == QMessageBox::No )

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -652,7 +652,8 @@ void QgsRelationEditorWidget::deleteFeature( const QgsFeatureId featureid )
 
 void QgsRelationEditorWidget::deleteSelectedFeatures()
 {
-  deleteFeatures( mFeatureSelectionMgr->selectedFeatureIds() );
+  QgsFeatureIds selectedFids = mFeatureSelectionMgr->selectedFeatureIds();
+  deleteFeatures( selectedFids );
 }
 
 void QgsRelationEditorWidget::deleteFeatures( const QgsFeatureIds &featureids )

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -728,6 +728,16 @@ void QgsRelationEditorWidget::deleteFeatures( const QgsFeatureIds &featureids )
     layer = mRelation.referencingLayer();
   }
 
+  if ( QgsVectorLayerUtils::impactsCascadeFeatures(layer, QgsProject::instance() ) )
+  {
+    // for extra safety to make sure we know that the delete can have impact on children and joins
+    int res = QMessageBox::warning( this, tr( "Possible impact on descendants of layer \"%1\"").arg( layer->name() ),
+                                    tr( "A delete on this layer could have an impact on referencing or joined layers and their descendants. Would you still like to continue?" ),
+                                    QMessageBox::Yes | QMessageBox::No );
+    if ( res == QMessageBox::No )
+      deleteFeatures = false;
+  }
+
   if ( deleteFeatures )
   {
     QgsVectorLayer::DeleteContext context { true };

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -741,7 +741,7 @@ void QgsRelationEditorWidget::deleteFeatures( const QgsFeatureIds &featureids )
     }
 
     // for extra safety to make sure we know that the delete can have impact on children and joins
-    int res = QMessageBox::question( this, tr( "Delete at least %3 feature(s) on other layer(s)" ).arg( childrenCount ),
+    int res = QMessageBox::question( this, tr( "Delete at least %1 feature(s) on other layer(s)" ).arg( childrenCount ),
                                      tr( "Delete %1 feature(s) on layer \"%2\" and %3as well.\nAnd all the further descendants of them.\nDelete these features?" ).arg( featureids.count() ).arg( layer->name() ).arg( childrenInfo ),
                                      QMessageBox::Yes | QMessageBox::No );
     if ( res != QMessageBox::Yes )
@@ -759,10 +759,10 @@ void QgsRelationEditorWidget::deleteFeatures( const QgsFeatureIds &featureids )
       QString feedbackMessage;
       for ( QgsVectorLayer *contextLayer : contextLayers )
       {
-        feedbackMessage += tr( " %1 on layer %2." ).arg( context.handledFeatures( contextLayer ).size() ).arg( contextLayer->name() );
+        feedbackMessage += tr( "%1 on layer %2. " ).arg( context.handledFeatures( contextLayer ).size() ).arg( contextLayer->name() );
         deletedCount += context.handledFeatures( contextLayer ).size();
       }
-      mEditorContext.mainMessageBar()->pushMessage( tr( "%1 features deleted:%2" ).arg( deletedCount ).arg( feedbackMessage ), Qgis::Success );
+      mEditorContext.mainMessageBar()->pushMessage( tr( "%1 features deleted: %2" ).arg( deletedCount ).arg( feedbackMessage ), Qgis::Success );
     }
 
     updateUi();

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -752,15 +752,15 @@ void QgsRelationEditorWidget::deleteFeatures( const QgsFeatureIds &featureids )
   {
     QgsVectorLayer::DeleteContext context { true };
     layer->deleteFeatures( featureids, &context );
-    if ( context.handledFeatures.count() > 1 )
+    if ( context.handledFeatures().size() > 1 )
     {
       int deletedCount = 0;
       QString feedbackMessage;
       QMap<QgsVectorLayer *, QgsFeatureIds>::const_iterator i;
-      for ( i = context.handledFeatures.begin(); i != context.handledFeatures.end(); ++i )
+      for ( i = context.handledFeatures().begin(); i != context.handledFeatures().end(); ++i )
       {
-        feedbackMessage += tr( " %1 on layer %2." ).arg( i.value().count() ).arg( i.key()->name() );
-        deletedCount += i.value().count();
+        feedbackMessage += tr( " %1 on layer %2." ).arg( i.value().size() ).arg( i.key()->name() );
+        deletedCount += i.value().size();
       }
       mEditorContext.mainMessageBar()->pushMessage( tr( "%1 features deleted: %2" ).arg( deletedCount ).arg( feedbackMessage ), Qgis::Success );
     }

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -730,7 +730,8 @@ void QgsRelationEditorWidget::deleteFeatures( const QgsFeatureIds &featureids )
 
   if ( deleteFeatures )
   {
-    layer->deleteFeatures( featureids, true );
+    QgsVectorLayer::DeleteContext context { true };
+    layer->deleteFeatures( featureids, &context );
     updateUi();
   }
 }
@@ -791,7 +792,7 @@ void QgsRelationEditorWidget::unlinkFeatures( const QgsFeatureIds &featureids )
       QgsDebugMsgLevel( FID_TO_STRING( f.id() ), 4 );
     }
 
-    mRelation.referencingLayer()->deleteFeatures( fids, false );
+    mRelation.referencingLayer()->deleteFeatures( fids );
 
     updateUi();
   }

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -750,7 +750,7 @@ void QgsRelationEditorWidget::deleteFeatures( const QgsFeatureIds &featureids )
 
   if ( deleteFeatures )
   {
-    QgsVectorLayer::DeleteContext context { true };
+    QgsVectorLayer::DeleteContext context( true, QgsProject::instance() );
     layer->deleteFeatures( featureids, &context );
     const auto contextLayers = context.handledLayers();
     if ( contextLayers.size() > 1 )

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -752,12 +752,12 @@ void QgsRelationEditorWidget::deleteFeatures( const QgsFeatureIds &featureids )
   {
     QgsVectorLayer::DeleteContext context { true };
     layer->deleteFeatures( featureids, &context );
-    if ( context.handledFeatures().size() > 1 )
+    if ( context.mHandledFeatures.size() > 1 )
     {
       int deletedCount = 0;
       QString feedbackMessage;
       QMap<QgsVectorLayer *, QgsFeatureIds>::const_iterator i;
-      for ( i = context.handledFeatures().begin(); i != context.handledFeatures().end(); ++i )
+      for ( i = context.mHandledFeatures.begin(); i != context.mHandledFeatures.end(); ++i )
       {
         feedbackMessage += tr( " %1 on layer %2." ).arg( i.value().size() ).arg( i.key()->name() );
         deletedCount += i.value().size();

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -732,6 +732,18 @@ void QgsRelationEditorWidget::deleteFeatures( const QgsFeatureIds &featureids )
   {
     QgsVectorLayer::DeleteContext context { true };
     layer->deleteFeatures( featureids, &context );
+    if ( context.handledFeatures.count() > 1 )
+    {
+      int deletedCount = 0;
+      QString feedbackMessage;
+      QMap<QgsVectorLayer *, QgsFeatureIds>::const_iterator i;
+      for ( i = context.handledFeatures.begin(); i != context.handledFeatures.end(); ++i )
+      {
+        feedbackMessage += tr( " %1 on layer %2." ).arg( i.value().count() ).arg( i.key()->name() );
+        deletedCount += i.value().count();
+      }
+      mEditorContext.mainMessageBar()->pushMessage( tr( "%1 features deleted: %2" ).arg( deletedCount ).arg( feedbackMessage ), Qgis::Success );
+    }
     updateUi();
   }
 }


### PR DESCRIPTION
## Description
On deleting a feature having children defined by a relation with the strength `composition` (especially used for a reference table on many-to-many relations), the children are deleted as well.

- It's cascade over all levels - means childrenchildren and childrenchildrenchildren are deleted as well. But an endless loop is avoided.
- When the child-layer is not editable, editable is triggered.
- Message reporting how many features on what layers are deleted
- Warning on delete for layers with composition relations and joins (joined features are deleted on cascade delete - this is an existing implementation)

## Looks like this
One parent-child relation (forest to tree) and one many-to-many creating a recursion on the same feature.

![image](https://user-images.githubusercontent.com/28384354/81377236-59762380-9105-11ea-862b-2778c3c6d65c.png)

Warning message:
![cascade1](https://user-images.githubusercontent.com/28384354/81391546-8df5d980-911d-11ea-85aa-92be691d5ca8.png)

Feedback message:
![cascade2](https://user-images.githubusercontent.com/28384354/81391547-8fbf9d00-911d-11ea-9f59-01088fd33310.png)


## Technical details
The main part is implemented in the `QgsVectorLayer`. I thought about it to have everything in `QgsVectorLayerUtils` but since there are several methods affected, needing to call each other (like e.g. `deleteFeature` on `QgsVectorLayerJoinBuffer`), this would have lead to a lot of duplicate code.

Not every call of `deleteFeature` / `deleteFeatures` / `deleteSelectedFeatures` makes a cascade delete:

Doing cascade delete:
- `QgsAttributeTableDialog::deleteFeature`
- `QgisApp::deleteSelected`
- `QgsRelationEditorWidget::deleteFeatures`

Not doing cascade delete:
- `QgisApp::mergeSelectedFeatures`
- `QgsOfflineEditing::applyFeaturesRemoved`
- `QgsRelationEditorWidget::unlinkFeatures`
- `TopolError::fixUnion`
- `TopolError::deleteFirst`
- `TopolError::deleteSecond`
- `QgsAuxiliaryLayer::clear`
- `QgisApp::cutSelectionToClipboard`
- `QgsTrackedVectorLayerTools::rollback`
- `performTransaction` in `QgsWfs`
