### PR TITLE
allow adding attributes in the New Scratch Layer dialog (fix #24397)

### DIFF
--- a/python/gui/auto_generated/qgsnewmemorylayerdialog.sip.in
+++ b/python/gui/auto_generated/qgsnewmemorylayerdialog.sip.in
@@ -58,6 +58,13 @@ Returns the selected CRS for the new layer.
 Returns the layer name
 %End
 
+    QgsFields fields() const;
+%Docstring
+Returns attributes for the new layer.
+
+.. versionadded:: 3.14
+%End
+
 };
 
 /************************************************************************

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -64,9 +64,11 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
   mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPointLayer.svg" ) ), tr( "MultiPoint" ), QgsWkbTypes::MultiPoint );
   mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconLineLayer.svg" ) ), tr( "MultiLineString / MultiCurve" ), QgsWkbTypes::MultiLineString );
   mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPolygonLayer.svg" ) ), tr( "MultiPolygon / MultiSurface" ), QgsWkbTypes::MultiPolygon );
+  mGeometryTypeBox->setCurrentIndex( -1 );
 
   mGeometryWithZCheckBox->setEnabled( false );
   mGeometryWithMCheckBox->setEnabled( false );
+  mCrsSelector->setEnabled( false );
 
   mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldText.svg" ) ), tr( "Text" ), "string" );
   mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), tr( "Whole number" ), "integer" );
@@ -79,13 +81,16 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
   mWidth->setValidator( new QIntValidator( 1, 255, this ) );
   mPrecision->setValidator( new QIntValidator( 0, 15, this ) );
 
+  mOkButton = mButtonBox->button( QDialogButtonBox::Ok );
+  mOkButton->setEnabled( false );
+
   connect( mGeometryTypeBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsNewMemoryLayerDialog::geometryTypeChanged );
   connect( mFieldNameEdit, &QLineEdit::textChanged, this, &QgsNewMemoryLayerDialog::fieldNameChanged );
   connect( mAttributeView, &QTreeWidget::itemSelectionChanged, this, &QgsNewMemoryLayerDialog::selectionChanged );
   connect( mAddAttributeButton, &QToolButton::clicked, this, &QgsNewMemoryLayerDialog::mAddAttributeButton_clicked );
   connect( mRemoveAttributeButton, &QToolButton::clicked, this, &QgsNewMemoryLayerDialog::mRemoveAttributeButton_clicked );
   connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsNewMemoryLayerDialog::showHelp );
-  geometryTypeChanged( mGeometryTypeBox->currentIndex() );
+  //geometryTypeChanged( mGeometryTypeBox->currentIndex() );
 }
 
 QgsWkbTypes::Type QgsNewMemoryLayerDialog::selectedType() const
@@ -114,6 +119,9 @@ void QgsNewMemoryLayerDialog::geometryTypeChanged( int )
   mGeometryWithZCheckBox->setEnabled( isSpatial );
   mGeometryWithMCheckBox->setEnabled( isSpatial );
   mCrsSelector->setEnabled( isSpatial );
+
+  bool ok = ( !mNameLineEdit->text().isEmpty() && mGeometryTypeBox->currentIndex() != -1 );
+  mOkButton->setEnabled( ok );
 }
 
 void QgsNewMemoryLayerDialog::setCrs( const QgsCoordinateReferenceSystem &crs )

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -22,6 +22,8 @@
 #include "qgsproviderregistry.h"
 #include "qgsvectordataprovider.h"
 #include "qgsvectorlayer.h"
+#include "qgsfield.h"
+#include "qgsfields.h"
 #include "qgssettings.h"
 #include "qgsmemoryproviderutils.h"
 #include "qgsgui.h"
@@ -41,8 +43,9 @@ QgsVectorLayer *QgsNewMemoryLayerDialog::runAndCreateLayer( QWidget *parent, con
   }
 
   QgsWkbTypes::Type geometrytype = dialog.selectedType();
+  QgsFields fields = dialog.fields();
   QString name = dialog.layerName().isEmpty() ? tr( "New scratch layer" ) : dialog.layerName();
-  QgsVectorLayer *newLayer = QgsMemoryProviderUtils::createMemoryLayer( name, QgsFields(), geometrytype, dialog.crs() );
+  QgsVectorLayer *newLayer = QgsMemoryProviderUtils::createMemoryLayer( name, fields, geometrytype, dialog.crs() );
   return newLayer;
 }
 
@@ -51,6 +54,8 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
 {
   setupUi( this );
   QgsGui::enableAutoGeometryRestore( this );
+
+  mNameLineEdit->setText( tr( "New scratch layer" ) );
 
   mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconTableLayer.svg" ) ), tr( "No geometry" ), QgsWkbTypes::NoGeometry );
   mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPointLayer.svg" ) ), tr( "Point" ), QgsWkbTypes::Point );
@@ -63,9 +68,22 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
   mGeometryWithZCheckBox->setEnabled( false );
   mGeometryWithMCheckBox->setEnabled( false );
 
-  mNameLineEdit->setText( tr( "New scratch layer" ) );
+  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldText.svg" ) ), tr( "Text" ), "string" );
+  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), tr( "Whole number" ), "integer" );
+  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldFloat.svg" ) ), tr( "Decimal number" ), "double" );
+  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldBool.svg" ) ), tr( "Boolean" ), "bool" );
+  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDate.svg" ) ), tr( "Date" ), "date" );
+  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldTime.svg" ) ), tr( "Time" ), "time" );
+  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDateTime.svg" ) ), tr( "Date & time" ), "datetime" );
+
+  mWidth->setValidator( new QIntValidator( 1, 255, this ) );
+  mPrecision->setValidator( new QIntValidator( 0, 15, this ) );
 
   connect( mGeometryTypeBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsNewMemoryLayerDialog::geometryTypeChanged );
+  connect( mFieldNameEdit, &QLineEdit::textChanged, this, &QgsNewMemoryLayerDialog::fieldNameChanged );
+  connect( mAttributeView, &QTreeWidget::itemSelectionChanged, this, &QgsNewMemoryLayerDialog::selectionChanged );
+  connect( mAddAttributeButton, &QToolButton::clicked, this, &QgsNewMemoryLayerDialog::mAddAttributeButton_clicked );
+  connect( mRemoveAttributeButton, &QToolButton::clicked, this, &QgsNewMemoryLayerDialog::mRemoveAttributeButton_clicked );
   connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsNewMemoryLayerDialog::showHelp );
   geometryTypeChanged( mGeometryTypeBox->currentIndex() );
 }
@@ -111,6 +129,70 @@ QgsCoordinateReferenceSystem QgsNewMemoryLayerDialog::crs() const
 QString QgsNewMemoryLayerDialog::layerName() const
 {
   return mNameLineEdit->text();
+}
+
+void QgsNewMemoryLayerDialog::fieldNameChanged( const QString &name )
+{
+  mAddAttributeButton->setDisabled( name.isEmpty() || ! mAttributeView->findItems( name, Qt::MatchExactly ).isEmpty() );
+}
+
+void QgsNewMemoryLayerDialog::selectionChanged()
+{
+  mRemoveAttributeButton->setDisabled( mAttributeView->selectedItems().isEmpty() );
+}
+
+QgsFields QgsNewMemoryLayerDialog::fields() const
+{
+  QgsFields fields = QgsFields();
+
+  QTreeWidgetItemIterator it( mAttributeView );
+  while ( *it )
+  {
+    QString name( ( *it )->text( 0 ) );
+    QString typeName( ( *it )->text( 1 ) );
+    int width = ( *it )->text( 2 ).toInt();
+    int precision = ( *it )->text( 3 ).toInt();
+    QVariant::Type fieldType = QVariant::Invalid;
+    if ( typeName == QLatin1String( "string" ) )
+      fieldType = QVariant::String;
+    else if ( typeName == QLatin1String( "integer" ) )
+      fieldType = QVariant::Int;
+    else if ( typeName == QLatin1String( "double" ) )
+      fieldType = QVariant::Double;
+    else if ( typeName == QLatin1String( "bool" ) )
+      fieldType = QVariant::Bool;
+    else if ( typeName == QLatin1String( "date" ) )
+      fieldType = QVariant::Date;
+    else if ( typeName == QLatin1String( "time" ) )
+      fieldType = QVariant::Time;
+    else if ( typeName == QLatin1String( "datetime" ) )
+      fieldType = QVariant::DateTime;
+
+    QgsField field = QgsField( name, fieldType, typeName, width, precision );
+    fields.append( field );
+    ++it;
+  }
+
+  return fields;
+}
+
+void QgsNewMemoryLayerDialog::mAddAttributeButton_clicked()
+{
+  if ( !mFieldNameEdit->text().isEmpty() )
+  {
+    QString fieldName = mFieldNameEdit->text();
+    QString fieldType = mTypeBox->currentData( Qt::UserRole ).toString();
+    QString width = mWidth->text();
+    QString precision = mPrecision->text();
+    mAttributeView->addTopLevelItem( new QTreeWidgetItem( QStringList() << fieldName << fieldType << width << precision ) );
+
+    mFieldNameEdit->clear();
+  }
+}
+
+void QgsNewMemoryLayerDialog::mRemoveAttributeButton_clicked()
+{
+  delete mAttributeView->currentItem();
 }
 
 void QgsNewMemoryLayerDialog::showHelp()

--- a/src/gui/qgsnewmemorylayerdialog.h
+++ b/src/gui/qgsnewmemorylayerdialog.h
@@ -77,6 +77,7 @@ class GUI_EXPORT QgsNewMemoryLayerDialog: public QDialog, private Ui::QgsNewMemo
   private:
 
     QString mCrsId;
+    QPushButton *mOkButton = nullptr;
 
   private slots:
 

--- a/src/gui/qgsnewmemorylayerdialog.h
+++ b/src/gui/qgsnewmemorylayerdialog.h
@@ -23,6 +23,7 @@
 #include "qgshelp.h"
 #include "qgis_gui.h"
 
+class QgsFields;
 class QgsVectorLayer;
 
 /**
@@ -67,6 +68,12 @@ class GUI_EXPORT QgsNewMemoryLayerDialog: public QDialog, private Ui::QgsNewMemo
     //! Returns the layer name
     QString layerName() const;
 
+    /**
+     * Returns attributes for the new layer.
+     * \since QGIS 3.14
+     */
+    QgsFields fields() const;
+
   private:
 
     QString mCrsId;
@@ -74,6 +81,10 @@ class GUI_EXPORT QgsNewMemoryLayerDialog: public QDialog, private Ui::QgsNewMemo
   private slots:
 
     void geometryTypeChanged( int index );
+    void fieldNameChanged( const QString & );
+    void mAddAttributeButton_clicked();
+    void mRemoveAttributeButton_clicked();
+    void selectionChanged();
     void showHelp();
 };
 

--- a/src/ui/qgsnewmemorylayerdialogbase.ui
+++ b/src/ui/qgsnewmemorylayerdialogbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>444</width>
-    <height>246</height>
+    <height>596</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -22,53 +22,194 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="2" column="2">
-      <widget class="QCheckBox" name="mGeometryWithMCheckBox">
-       <property name="text">
-        <string>Include M values</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Geometry type</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Layer name</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QCheckBox" name="mGeometryWithZCheckBox">
-       <property name="text">
-        <string>Include Z dimension</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1" colspan="2">
-      <widget class="QComboBox" name="mGeometryTypeBox"/>
-     </item>
-     <item row="0" column="1" colspan="2">
-      <widget class="QLineEdit" name="mNameLineEdit"/>
-     </item>
-     <item row="3" column="1" colspan="2">
-      <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
-       <property name="focusPolicy">
-        <enum>Qt::StrongFocus</enum>
-       </property>
-      </widget>
-     </item>
-    </layout>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Layer name</string>
+     </property>
+    </widget>
    </item>
-   <item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Geometry type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QCheckBox" name="mGeometryWithZCheckBox">
+     <property name="text">
+      <string>Include Z dimension</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QCheckBox" name="mGeometryWithMCheckBox">
+     <property name="text">
+      <string>Include M values</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="3">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>New Field</string>
+     </property>
+     <layout class="QGridLayout" name="_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="textLabel1">
+        <property name="text">
+         <string>Name</string>
+        </property>
+        <property name="buddy">
+         <cstring>mFieldNameEdit</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="4">
+       <widget class="QLineEdit" name="mFieldNameEdit"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="textLabel2">
+        <property name="text">
+         <string>Type</string>
+        </property>
+        <property name="buddy">
+         <cstring>mTypeBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="4">
+       <widget class="QComboBox" name="mTypeBox"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Length</string>
+        </property>
+        <property name="buddy">
+         <cstring>mWidth</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1" colspan="2">
+       <widget class="QLineEdit" name="mWidth"/>
+      </item>
+      <item row="2" column="3">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Precision</string>
+        </property>
+        <property name="buddy">
+         <cstring>mPrecision</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="4">
+       <widget class="QLineEdit" name="mPrecision"/>
+      </item>
+      <item row="4" column="4">
+       <widget class="QToolButton" name="mAddAttributeButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Add field to list</string>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+        <property name="text">
+         <string>Add to Fields List</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../images/images.qrc">
+          <normaloff>:/images/themes/default/mActionNewAttribute.svg</normaloff>:/images/themes/default/mActionNewAttribute.svg</iconset>
+        </property>
+        <property name="toolButtonStyle">
+         <enum>Qt::ToolButtonTextBesideIcon</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="3">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Fields List</string>
+     </property>
+     <layout class="QGridLayout" name="_3">
+      <item row="2" column="0" colspan="3">
+       <widget class="QTreeWidget" name="mAttributeView">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="rootIsDecorated">
+         <bool>false</bool>
+        </property>
+        <property name="columnCount">
+         <number>4</number>
+        </property>
+        <column>
+         <property name="text">
+          <string>Name</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Type</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Length</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Precision</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QToolButton" name="mRemoveAttributeButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Delete selected field</string>
+        </property>
+        <property name="text">
+         <string>Remove Field</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../images/images.qrc">
+          <normaloff>:/images/themes/default/mActionDeleteAttribute.svg</normaloff>:/images/themes/default/mActionDeleteAttribute.svg</iconset>
+        </property>
+        <property name="toolButtonStyle">
+         <enum>Qt::ToolButtonTextBesideIcon</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="3">
     <widget class="QLabel" name="label_2">
      <property name="text">
       <string>&lt;i&gt;&lt;b&gt;Warning:&lt;/b&gt; Temporary scratch layers are not saved and will be discarded when QGIS is closed.&lt;/i&gt;</string>
@@ -81,20 +222,7 @@
      </property>
     </widget>
    </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
+   <item row="7" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -103,6 +231,19 @@
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
+   </item>
+   <item row="3" column="0" colspan="3">
+    <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="2">
+    <widget class="QComboBox" name="mGeometryTypeBox"/>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QLineEdit" name="mNameLineEdit"/>
    </item>
   </layout>
  </widget>
@@ -122,7 +263,9 @@
   <tabstop>mGeometryWithMCheckBox</tabstop>
   <tabstop>mCrsSelector</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>mButtonBox</sender>


### PR DESCRIPTION
## Description
Allows to add attributes directly in the New Scratch Layer dialog making it more consistent with other dialogs like New Shapefile/Geopackage.
![scratch](https://user-images.githubusercontent.com/776954/81394331-76711d80-912a-11ea-8b86-4f2789adff08.png)
Possibility to create scratch layer without any attributes is still here, just don't add any fields to the list.

Fixes #24397.