### PR TITLE
Try to auto-populate reasonable initial choices for vector layer temporal settings

### DIFF
--- a/python/core/auto_generated/qgsvectorlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/qgsvectorlayertemporalproperties.sip.in
@@ -150,6 +150,12 @@ settings (such as startField()) when building the filter string.
    ModeFixedTemporalRange should ALL be filtered out.
 %End
 
+    void guessDefaultsFromFields( const QgsFields &fields );
+%Docstring
+Attempts to setup the temporal properties by scanning a set of ``fields``
+and looking for standard naming conventions (e.g. "begin_date").
+%End
+
     virtual QDomElement writeXml( QDomElement &element, QDomDocument &doc, const QgsReadWriteContext &context );
 
     virtual bool readXml( const QDomElement &element, const QgsReadWriteContext &context );

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -188,6 +188,12 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
   if ( mValid )
   {
     mTemporalProperties->setDefaultsFromDataProviderTemporalCapabilities( mDataProvider->temporalCapabilities() );
+    if ( !mTemporalProperties->isActive() )
+    {
+      // didn't populate temporal properties from provider metadata, so at least try to setup some initially nice
+      // selections
+      mTemporalProperties->guessDefaultsFromFields( mFields );
+    }
   }
 
   connect( this, &QgsVectorLayer::selectionChanged, this, [ = ] { triggerRepaint(); } );

--- a/src/core/qgsvectorlayertemporalproperties.h
+++ b/src/core/qgsvectorlayertemporalproperties.h
@@ -26,6 +26,7 @@
 #include "qgsrasterdataprovidertemporalcapabilities.h"
 
 class QgsVectorLayer;
+class QgsFields;
 
 /**
  * \class QgsVectorLayerTemporalProperties
@@ -157,6 +158,12 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
      * ModeFixedTemporalRange should ALL be filtered out.
      */
     QString createFilterString( QgsVectorLayer *layer, const QgsDateTimeRange &range ) const;
+
+    /**
+     * Attempts to setup the temporal properties by scanning a set of \a fields
+     * and looking for standard naming conventions (e.g. "begin_date").
+     */
+    void guessDefaultsFromFields( const QgsFields &fields );
 
     QDomElement writeXml( QDomElement &element, QDomDocument &doc, const QgsReadWriteContext &context ) override;
     bool readXml( const QDomElement &element, const QgsReadWriteContext &context ) override;


### PR DESCRIPTION
When a new vector layer is loaded, we scan through the fields for likely candidates for the start and end field choices. If found, we initially setup the temporal properties to these guessed fields, but we DON'T automatically enable temporal properties for the layer.

It's just a nice little shortcut, much like how we auto-guess the appropriate title field for a newly added layer
