### PR TITLE
Add a new "Redraw Layer Only" mode for temporal vector layers

### DIFF
--- a/python/core/auto_generated/qgsvectorlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/qgsvectorlayertemporalproperties.sip.in
@@ -39,6 +39,7 @@ The ``enabled`` argument specifies whether the temporal properties are initially
       ModeFixedTemporalRange,
       ModeFeatureDateTimeInstantFromField,
       ModeFeatureDateTimeStartAndEndFromFields,
+      ModeRedrawLayerOnly,
     };
 
     TemporalMode mode() const;

--- a/src/core/qgstemporalutils.cpp
+++ b/src/core/qgstemporalutils.cpp
@@ -101,6 +101,9 @@ QgsDateTimeRange QgsTemporalUtils::calculateTemporalRangeForProject( QgsProject 
             }
             break;
           }
+
+          case QgsVectorLayerTemporalProperties::ModeRedrawLayerOnly:
+            break;
         }
         break;
       }

--- a/src/core/qgsvectorlayertemporalproperties.cpp
+++ b/src/core/qgsvectorlayertemporalproperties.cpp
@@ -36,6 +36,7 @@ bool QgsVectorLayerTemporalProperties::isVisibleInTemporalRange( const QgsDateTi
 
     case ModeFeatureDateTimeInstantFromField:
     case ModeFeatureDateTimeStartAndEndFromFields:
+    case ModeRedrawLayerOnly:
       return true;
   }
   return true;
@@ -183,6 +184,7 @@ QString QgsVectorLayerTemporalProperties::createFilterString( QgsVectorLayer *, 
   switch ( mMode )
   {
     case ModeFixedTemporalRange:
+    case ModeRedrawLayerOnly:
       return QString();
 
     case ModeFeatureDateTimeInstantFromField:

--- a/src/core/qgsvectorlayertemporalproperties.h
+++ b/src/core/qgsvectorlayertemporalproperties.h
@@ -57,6 +57,7 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
       ModeFixedTemporalRange = 0, //!< Mode when temporal properties have fixed start and end datetimes.
       ModeFeatureDateTimeInstantFromField, //!< Mode when features have a datetime instant taken from a single field
       ModeFeatureDateTimeStartAndEndFromFields, //!< Mode when features have separate fields for start and end times
+      ModeRedrawLayerOnly, //!< Redraw the layer when temporal range changes, but don't apply any filtering. Useful when symbology or rule based renderer expressions depend on the time range.
     };
 
     /**

--- a/src/gui/qgsvectorlayertemporalpropertieswidget.cpp
+++ b/src/gui/qgsvectorlayertemporalpropertieswidget.cpp
@@ -34,6 +34,7 @@ QgsVectorLayerTemporalPropertiesWidget::QgsVectorLayerTemporalPropertiesWidget( 
   mModeComboBox->addItem( tr( "Fixed Time Range" ), QgsVectorLayerTemporalProperties::ModeFixedTemporalRange );
   mModeComboBox->addItem( tr( "Single Field with Date/Time" ), QgsVectorLayerTemporalProperties::ModeFeatureDateTimeInstantFromField );
   mModeComboBox->addItem( tr( "Separate Fields for Start and End Date/Time" ), QgsVectorLayerTemporalProperties::ModeFeatureDateTimeStartAndEndFromFields );
+  mModeComboBox->addItem( tr( "Redraw Layer Only" ), QgsVectorLayerTemporalProperties::ModeRedrawLayerOnly );
 
   const QgsVectorLayerTemporalProperties *properties = qobject_cast< QgsVectorLayerTemporalProperties * >( layer->temporalProperties() );
   mTemporalGroupBox->setChecked( properties->isActive() );
@@ -86,6 +87,7 @@ void QgsVectorLayerTemporalPropertiesWidget::saveTemporalProperties()
   {
     case QgsVectorLayerTemporalProperties::ModeFeatureDateTimeInstantFromField:
     case QgsVectorLayerTemporalProperties::ModeFixedTemporalRange:
+    case QgsVectorLayerTemporalProperties::ModeRedrawLayerOnly:
       properties->setStartField( mSingleFieldComboBox->currentField() );
       break;
 

--- a/src/ui/qgsvectorlayertemporalpropertieswidgetbase.ui
+++ b/src/ui/qgsvectorlayertemporalpropertieswidgetbase.ui
@@ -94,7 +94,7 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
           <item row="1" column="0" colspan="2">
            <widget class="QStackedWidget" name="mStackedWidget">
             <property name="currentIndex">
-             <number>1</number>
+             <number>0</number>
             </property>
             <widget class="QWidget" name="page_3">
              <layout class="QGridLayout" name="gridLayout_6">
@@ -198,6 +198,33 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
               </item>
               <item row="2" column="0">
                <spacer name="verticalSpacer_2">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="page_4">
+             <layout class="QVBoxLayout" name="verticalLayout">
+              <item>
+               <widget class="QLabel" name="label_7">
+                <property name="text">
+                 <string>&lt;p&gt;&lt;b&gt;The layer will automatically be redrawn whenever the temporal range is changed, but no time based filtering will be applied to the features.&lt;b&gt;&lt;/p&gt;&lt;p&gt;This configuration is useful when the layer has symbology settings which vary based on the temporal range. For instance, when it is using time-dependent rule-based renderer expressions or data-defined symbology expressions.&lt;/p&gt;</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_4">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>
                 </property>


### PR DESCRIPTION
When set to this mode, the layer will automatically be redrawn whenever the temporal range is changed, but no time based filtering will be applied to the features.

This configuration is useful when the layer has symbology settings which vary based on the temporal range. For instance, when a layer is using time-dependent rule-based renderer expressions or data-defined symbology expressions.
