### PR TITLE
Clear ongoing drawing on map canvas when closing layer's edit session

### DIFF
--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -339,6 +339,21 @@ You don't have to call it manually, QgsMapTool takes care of it.
 Returns the currently active tool
 %End
 
+    void setProject( QgsProject *project );
+%Docstring
+Sets the ``project`` linked to this canvas.
+
+.. versionadded:: 3.14
+%End
+
+    QgsProject *project();
+%Docstring
+Returns the project linked to this canvas.
+The returned value may be ``None``.
+
+.. versionadded:: 3.14
+%End
+
     void setCanvasColor( const QColor &_newVal );
 %Docstring
 Write property of QColor bgColor.

--- a/python/gui/auto_generated/qgsmaptooledit.sip.in
+++ b/python/gui/auto_generated/qgsmaptooledit.sip.in
@@ -93,6 +93,7 @@ Display a timed message bar noting the active layer is not vector.
 %Docstring
 Display a timed message bar noting the active vector layer is not editable.
 %End
+
 };
 
 /************************************************************************

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -940,6 +940,9 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   int myGreen = settings.value( QStringLiteral( "qgis/default_canvas_color_green" ), 255 ).toInt();
   int myBlue = settings.value( QStringLiteral( "qgis/default_canvas_color_blue" ), 255 ).toInt();
   mMapCanvas->setCanvasColor( QColor( myRed, myGreen, myBlue ) );
+
+  // set project linked to main canvas
+  mMapCanvas->setProject( QgsProject::instance() );
   endProfile();
 
   // what type of project to auto-open
@@ -4482,6 +4485,7 @@ QgsMapCanvasDockWidget *QgisApp::createNewMapCanvasDock( const QString &name )
   QgsMapCanvas *mapCanvas = mapCanvasWidget->mapCanvas();
   mapCanvas->freeze( true );
   mapCanvas->setObjectName( name );
+  mapCanvas->setProject( QgsProject::instance() );
   connect( mapCanvas, &QgsMapCanvas::messageEmitted, this, &QgisApp::displayMessage );
   connect( mLayerTreeCanvasBridge, &QgsLayerTreeMapCanvasBridge::canvasLayersChanged, mapCanvas, &QgsMapCanvas::setLayers );
 

--- a/src/app/qgsmaptooladdcircle.cpp
+++ b/src/app/qgsmaptooladdcircle.cpp
@@ -29,6 +29,8 @@ QgsMapToolAddCircle::QgsMapToolAddCircle( QgsMapToolCapture *parentTool, QgsMapC
   , mParentTool( parentTool )
   , mSnapIndicator( qgis::make_unique< QgsSnapIndicator>( canvas ) )
 {
+  mToolName = tr( "Add circle" );
+
   clean();
   connect( QgisApp::instance(), &QgisApp::newProject, this, &QgsMapToolAddCircle::stopCapturing );
   connect( QgisApp::instance(), &QgisApp::projectRead, this, &QgsMapToolAddCircle::stopCapturing );

--- a/src/app/qgsmaptooladdcircularstring.cpp
+++ b/src/app/qgsmaptooladdcircularstring.cpp
@@ -58,12 +58,7 @@ void QgsMapToolAddCircularString::keyPressEvent( QKeyEvent *e )
 
   if ( ( e && e->key() == Qt::Key_Escape ) || ( ( e && e->key() == Qt::Key_Backspace ) && ( mPoints.size() == 1 ) ) )
   {
-    mPoints.clear();
-    delete mRubberBand;
-    mRubberBand = nullptr;
-    delete mTempRubberBand;
-    mTempRubberBand = nullptr;
-    removeCenterPointRubberBand();
+    clean();
     if ( mParentTool )
       mParentTool->keyPressEvent( e );
   }
@@ -125,12 +120,7 @@ void QgsMapToolAddCircularString::deactivate()
   QgsCircularString *c = new QgsCircularString();
   c->setPoints( mPoints );
   mParentTool->addCurve( c );
-  mPoints.clear();
-  delete mRubberBand;
-  mRubberBand = nullptr;
-  delete mTempRubberBand;
-  mTempRubberBand = nullptr;
-  removeCenterPointRubberBand();
+  clean();
   QgsMapToolCapture::deactivate();
 }
 
@@ -252,4 +242,14 @@ void QgsMapToolAddCircularString::release( QgsMapMouseEvent *e )
     mParentTool->canvasReleaseEvent( e );
   }
   activate();
+}
+
+void QgsMapToolAddCircularString::clean()
+{
+  mPoints.clear();
+  delete mRubberBand;
+  mRubberBand = nullptr;
+  delete mTempRubberBand;
+  mTempRubberBand = nullptr;
+  removeCenterPointRubberBand();
 }

--- a/src/app/qgsmaptooladdcircularstring.cpp
+++ b/src/app/qgsmaptooladdcircularstring.cpp
@@ -31,6 +31,7 @@ QgsMapToolAddCircularString::QgsMapToolAddCircularString( QgsMapToolCapture *par
   , mShowCenterPointRubberBand( false )
   , mSnapIndicator( qgis::make_unique< QgsSnapIndicator>( canvas ) )
 {
+  mToolName = tr( "Add circular string" );
   connect( QgisApp::instance(), &QgisApp::newProject, this, &QgsMapToolAddCircularString::stopCapturing );
   connect( QgisApp::instance(), &QgisApp::projectRead, this, &QgsMapToolAddCircularString::stopCapturing );
 }

--- a/src/app/qgsmaptooladdcircularstring.h
+++ b/src/app/qgsmaptooladdcircularstring.h
@@ -36,6 +36,9 @@ class APP_EXPORT QgsMapToolAddCircularString: public QgsMapToolCapture
 
     void activate() override;
 
+    //! Clean drawings on map canvas
+    void clean() override;
+
     /*private slots:
       void setParentTool( QgsMapTool *newTool, QgsMapTool *oldTool );*/
 

--- a/src/app/qgsmaptooladdellipse.cpp
+++ b/src/app/qgsmaptooladdellipse.cpp
@@ -29,6 +29,8 @@ QgsMapToolAddEllipse::QgsMapToolAddEllipse( QgsMapToolCapture *parentTool, QgsMa
   , mParentTool( parentTool )
   , mSnapIndicator( qgis::make_unique< QgsSnapIndicator>( canvas ) )
 {
+  mToolName = tr( "Add ellipse" );
+
   clean();
   connect( QgisApp::instance(), &QgisApp::newProject, this, &QgsMapToolAddEllipse::stopCapturing );
   connect( QgisApp::instance(), &QgisApp::projectRead, this, &QgsMapToolAddEllipse::stopCapturing );

--- a/src/app/qgsmaptooladdrectangle.cpp
+++ b/src/app/qgsmaptooladdrectangle.cpp
@@ -30,6 +30,8 @@ QgsMapToolAddRectangle::QgsMapToolAddRectangle( QgsMapToolCapture *parentTool, Q
   , mParentTool( parentTool )
   , mSnapIndicator( qgis::make_unique< QgsSnapIndicator>( canvas ) )
 {
+  mToolName = tr( "Add rectangle" );
+
   clean();
   connect( QgisApp::instance(), &QgisApp::newProject, this, &QgsMapToolAddRectangle::stopCapturing );
   connect( QgisApp::instance(), &QgisApp::projectRead, this, &QgsMapToolAddRectangle::stopCapturing );

--- a/src/app/qgsmaptooladdregularpolygon.cpp
+++ b/src/app/qgsmaptooladdregularpolygon.cpp
@@ -29,6 +29,8 @@ QgsMapToolAddRegularPolygon::QgsMapToolAddRegularPolygon( QgsMapToolCapture *par
   , mParentTool( parentTool )
   , mSnapIndicator( qgis::make_unique< QgsSnapIndicator>( canvas ) )
 {
+  mToolName = tr( "Add regular polygon" );
+
   clean();
   connect( QgisApp::instance(), &QgisApp::newProject, this, &QgsMapToolAddRegularPolygon::stopCapturing );
   connect( QgisApp::instance(), &QgisApp::projectRead, this, &QgsMapToolAddRegularPolygon::stopCapturing );

--- a/src/app/qgsmaptoolcircle2points.cpp
+++ b/src/app/qgsmaptoolcircle2points.cpp
@@ -26,6 +26,7 @@ QgsMapToolCircle2Points::QgsMapToolCircle2Points( QgsMapToolCapture *parentTool,
     QgsMapCanvas *canvas, CaptureMode mode )
   : QgsMapToolAddCircle( parentTool, canvas, mode )
 {
+  mToolName = tr( "Add circle from 2 points" );
 }
 
 void QgsMapToolCircle2Points::cadCanvasReleaseEvent( QgsMapMouseEvent *e )

--- a/src/app/qgsmaptoolcircle2tangentspoint.cpp
+++ b/src/app/qgsmaptoolcircle2tangentspoint.cpp
@@ -35,6 +35,7 @@ QgsMapToolCircle2TangentsPoint::QgsMapToolCircle2TangentsPoint( QgsMapToolCaptur
     QgsMapCanvas *canvas, CaptureMode mode )
   : QgsMapToolAddCircle( parentTool, canvas, mode )
 {
+  mToolName = tr( "Add circle from 2 tangents and a point" );
 }
 
 QgsMapToolCircle2TangentsPoint::~QgsMapToolCircle2TangentsPoint()

--- a/src/app/qgsmaptoolcircle3points.cpp
+++ b/src/app/qgsmaptoolcircle3points.cpp
@@ -26,6 +26,7 @@ QgsMapToolCircle3Points::QgsMapToolCircle3Points( QgsMapToolCapture *parentTool,
     QgsMapCanvas *canvas, CaptureMode mode )
   : QgsMapToolAddCircle( parentTool, canvas, mode )
 {
+  mToolName = tr( "Add circle from 3 points" );
 }
 
 void QgsMapToolCircle3Points::cadCanvasReleaseEvent( QgsMapMouseEvent *e )

--- a/src/app/qgsmaptoolcircle3tangents.cpp
+++ b/src/app/qgsmaptoolcircle3tangents.cpp
@@ -31,6 +31,7 @@ QgsMapToolCircle3Tangents::QgsMapToolCircle3Tangents( QgsMapToolCapture *parentT
     QgsMapCanvas *canvas, CaptureMode mode )
   : QgsMapToolAddCircle( parentTool, canvas, mode )
 {
+  mToolName = tr( "Add circle from 3 tangents" );
 }
 
 void QgsMapToolCircle3Tangents::cadCanvasReleaseEvent( QgsMapMouseEvent *e )

--- a/src/app/qgsmaptoolcirclecenterpoint.cpp
+++ b/src/app/qgsmaptoolcirclecenterpoint.cpp
@@ -26,6 +26,7 @@ QgsMapToolCircleCenterPoint::QgsMapToolCircleCenterPoint( QgsMapToolCapture *par
     QgsMapCanvas *canvas, CaptureMode mode )
   : QgsMapToolAddCircle( parentTool, canvas, mode )
 {
+  mToolName = tr( "Add circle by a center point and another point" );
 }
 
 void QgsMapToolCircleCenterPoint::cadCanvasReleaseEvent( QgsMapMouseEvent *e )

--- a/src/app/qgsmaptoolcircularstringcurvepoint.cpp
+++ b/src/app/qgsmaptoolcircularstringcurvepoint.cpp
@@ -26,7 +26,7 @@ QgsMapToolCircularStringCurvePoint::QgsMapToolCircularStringCurvePoint( QgsMapTo
     QgsMapCanvas *canvas, CaptureMode mode )
   : QgsMapToolAddCircularString( parentTool, canvas, mode )
 {
-
+  mToolName = tr( "Add circular string curve point" );
 }
 
 void QgsMapToolCircularStringCurvePoint::cadCanvasReleaseEvent( QgsMapMouseEvent *e )

--- a/src/app/qgsmaptoolcircularstringradius.cpp
+++ b/src/app/qgsmaptoolcircularstringradius.cpp
@@ -33,7 +33,7 @@ QgsMapToolCircularStringRadius::QgsMapToolCircularStringRadius( QgsMapToolCaptur
   , mRadius( 0.0 )
 
 {
-
+  mToolName = tr( "Add circular string by radius" );
 }
 
 void QgsMapToolCircularStringRadius::deactivate()

--- a/src/app/qgsmaptoolfillring.cpp
+++ b/src/app/qgsmaptoolfillring.cpp
@@ -30,6 +30,7 @@
 QgsMapToolFillRing::QgsMapToolFillRing( QgsMapCanvas *canvas )
   : QgsMapToolCapture( canvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CapturePolygon )
 {
+  mToolName = tr( "Fill ring" );
 }
 
 void QgsMapToolFillRing::cadCanvasReleaseEvent( QgsMapMouseEvent *e )

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -36,7 +36,9 @@
 QgsMapToolOffsetCurve::QgsMapToolOffsetCurve( QgsMapCanvas *canvas )
   : QgsMapToolEdit( canvas )
   , mSnapIndicator( qgis::make_unique< QgsSnapIndicator >( canvas ) )
-{}
+{
+  mToolName = tr( "Map tool offset curve" );
+}
 
 QgsMapToolOffsetCurve::~QgsMapToolOffsetCurve()
 {

--- a/src/app/qgsmaptooloffsetpointsymbol.cpp
+++ b/src/app/qgsmaptooloffsetpointsymbol.cpp
@@ -33,7 +33,9 @@ QgsMapToolOffsetPointSymbol::QgsMapToolOffsetPointSymbol( QgsMapCanvas *canvas )
   : QgsMapToolPointSymbol( canvas )
   , mOffsetting( false )
   , mSymbolRotation( 0.0 )
-{}
+{
+  mToolName = tr( "Map tool offset point symbol" );
+}
 
 QgsMapToolOffsetPointSymbol::~QgsMapToolOffsetPointSymbol()
 {

--- a/src/app/qgsmaptoolpointsymbol.cpp
+++ b/src/app/qgsmaptoolpointsymbol.cpp
@@ -26,7 +26,9 @@
 QgsMapToolPointSymbol::QgsMapToolPointSymbol( QgsMapCanvas *canvas )
   : QgsMapToolEdit( canvas )
   , mFeatureNumber( -1 )
-{}
+{
+  mToolName = tr( "Map tool point symbol" );
+}
 
 void QgsMapToolPointSymbol::canvasPressEvent( QgsMapMouseEvent *e )
 {

--- a/src/app/qgsmaptoolrectangle3points.cpp
+++ b/src/app/qgsmaptoolrectangle3points.cpp
@@ -29,6 +29,7 @@ QgsMapToolRectangle3Points::QgsMapToolRectangle3Points( QgsMapToolCapture *paren
   : QgsMapToolAddRectangle( parentTool, canvas, mode ),
     mCreateMode( createMode )
 {
+  mToolName = tr( "Add rectangle from 3 points" );
 }
 
 void QgsMapToolRectangle3Points::cadCanvasReleaseEvent( QgsMapMouseEvent *e )

--- a/src/app/qgsmaptoolrectanglecenter.cpp
+++ b/src/app/qgsmaptoolrectanglecenter.cpp
@@ -30,6 +30,7 @@ QgsMapToolRectangleCenter::QgsMapToolRectangleCenter( QgsMapToolCapture *parentT
     QgsMapCanvas *canvas, CaptureMode mode )
   : QgsMapToolAddRectangle( parentTool, canvas, mode )
 {
+  mToolName = tr( "Add rectangle from center and a point" );
 }
 
 void QgsMapToolRectangleCenter::cadCanvasReleaseEvent( QgsMapMouseEvent *e )

--- a/src/app/qgsmaptoolrectangleextent.cpp
+++ b/src/app/qgsmaptoolrectangleextent.cpp
@@ -28,6 +28,7 @@ QgsMapToolRectangleExtent::QgsMapToolRectangleExtent( QgsMapToolCapture *parentT
     QgsMapCanvas *canvas, CaptureMode mode )
   : QgsMapToolAddRectangle( parentTool, canvas, mode )
 {
+  mToolName = tr( "Add rectangle from extent" );
 }
 
 void QgsMapToolRectangleExtent::cadCanvasReleaseEvent( QgsMapMouseEvent *e )

--- a/src/app/qgsmaptoolregularpolygon2points.cpp
+++ b/src/app/qgsmaptoolregularpolygon2points.cpp
@@ -25,6 +25,7 @@ QgsMapToolRegularPolygon2Points::QgsMapToolRegularPolygon2Points( QgsMapToolCapt
     QgsMapCanvas *canvas, CaptureMode mode )
   : QgsMapToolAddRegularPolygon( parentTool, canvas, mode )
 {
+  mToolName = tr( "Add regular polygon from 2 points" );
 }
 
 QgsMapToolRegularPolygon2Points::~QgsMapToolRegularPolygon2Points()

--- a/src/app/qgsmaptoolregularpolygoncentercorner.cpp
+++ b/src/app/qgsmaptoolregularpolygoncentercorner.cpp
@@ -26,6 +26,7 @@ QgsMapToolRegularPolygonCenterCorner::QgsMapToolRegularPolygonCenterCorner( QgsM
     QgsMapCanvas *canvas, CaptureMode mode )
   : QgsMapToolAddRegularPolygon( parentTool, canvas, mode )
 {
+  mToolName = tr( "Add regular polygon from center and a corner" );
 }
 
 QgsMapToolRegularPolygonCenterCorner::~QgsMapToolRegularPolygonCenterCorner()

--- a/src/app/qgsmaptoolregularpolygoncenterpoint.cpp
+++ b/src/app/qgsmaptoolregularpolygoncenterpoint.cpp
@@ -25,6 +25,7 @@ QgsMapToolRegularPolygonCenterPoint::QgsMapToolRegularPolygonCenterPoint( QgsMap
     QgsMapCanvas *canvas, CaptureMode mode )
   : QgsMapToolAddRegularPolygon( parentTool, canvas, mode )
 {
+  mToolName = tr( "Add regular polygon from center and a point " );
 }
 
 QgsMapToolRegularPolygonCenterPoint::~QgsMapToolRegularPolygonCenterPoint()

--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -27,6 +27,7 @@
 QgsMapToolReshape::QgsMapToolReshape( QgsMapCanvas *canvas )
   : QgsMapToolCapture( canvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CaptureLine )
 {
+  mToolName = tr( "Reshape features" );
 }
 
 void QgsMapToolReshape::cadCanvasReleaseEvent( QgsMapMouseEvent *e )

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2861,3 +2861,16 @@ void QgsVertexTool::cleanEditor( QgsFeatureId id )
     cleanupVertexEditor();
   };
 }
+
+void QgsVertexTool::clean()
+{
+  if ( mDraggingVertex || mDraggingEdge )
+  {
+    stopDragging();
+  }
+  if ( mSelectionRubberBand )
+  {
+    stopSelectionRubberBand();
+    mSelectionRubberBandStartPos.reset();
+  }
+}

--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -91,6 +91,9 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
 
     void deactivate() override;
 
+    //! Clean drawings on map canvas
+    void clean() override;
+
     void keyPressEvent( QKeyEvent *e ) override;
 
     QgsGeometry cachedGeometry( const QgsVectorLayer *layer, QgsFeatureId fid );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2030,6 +2030,11 @@ void QgsMapCanvas::unsetMapTool( QgsMapTool *tool )
   }
 }
 
+void QgsMapCanvas::setProject( QgsProject *project )
+{
+  mProject = project;
+}
+
 void QgsMapCanvas::setCanvasColor( const QColor &color )
 {
   if ( canvasColor() == color )
@@ -2245,6 +2250,11 @@ void QgsMapCanvas::projectThemesChanged()
 QgsMapTool *QgsMapCanvas::mapTool()
 {
   return mMapTool;
+}
+
+QgsProject *QgsMapCanvas::project()
+{
+  return mProject;
 }
 
 void QgsMapCanvas::panActionEnd( QPoint releasePoint )

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -28,6 +28,7 @@
 #include "qgscustomdrophandler.h"
 #include "qgstemporalrangeobject.h"
 #include "qgsmapcanvasinteractionblocker.h"
+#include "qgsproject.h"
 
 #include <QDomDocument>
 #include <QGraphicsView>
@@ -354,6 +355,21 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     //! Returns the currently active tool
     QgsMapTool *mapTool();
+
+    /**
+     * Sets the \a project linked to this canvas.
+     *
+     * \since QGIS 3.14
+     */
+    void setProject( QgsProject *project );
+
+    /**
+     * Returns the project linked to this canvas.
+     * The returned value may be NULLPTR.
+     *
+     * \since QGIS 3.14
+     */
+    QgsProject *project();
 
     //! Write property of QColor bgColor.
     void setCanvasColor( const QColor &_newVal );
@@ -1110,6 +1126,9 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     //! previous tool if current is for zooming/panning
     QgsMapTool *mLastNonZoomMapTool = nullptr;
+
+    //! Pointer to project linked to this canvas
+    QgsProject *mProject = nullptr;
 
     //! Context menu
     QMenu *mMenu = nullptr;

--- a/src/gui/qgsmaptooledit.h
+++ b/src/gui/qgsmaptooledit.h
@@ -44,6 +44,16 @@ class GUI_EXPORT QgsMapToolEdit: public QgsMapTool
      */
     double defaultZValue() const;
 
+  private slots:
+    //! Vector layers' editingStopped SIGNAL will eventually trigger a clean
+    void connectLayers( const QList<QgsMapLayer *> &layers );
+
+    /**
+     * Makes sure rubber bands are removed if there
+     * is no editable layer left in the project
+     */
+    void cleanCanvas();
+
   protected:
 
     //! Returns stroke color for rubber bands (from global settings)
@@ -93,6 +103,10 @@ class GUI_EXPORT QgsMapToolEdit: public QgsMapTool
     void notifyNotVectorLayer();
     //! Display a timed message bar noting the active vector layer is not editable.
     void notifyNotEditableLayer();
+
+  private:
+    //! Returns a list of layers filtered to just editable spatial vector layers
+    QList<QgsVectorLayer *> editableVectorLayers();
 };
 
 #endif


### PR DESCRIPTION
When a layer goes to non-edit mode, call `clean()` methods for map tools that could have temporary drawings on the map canvas.

Before: 
![](https://user-images.githubusercontent.com/652785/81415988-be824700-910e-11ea-9699-7100ca4021ba.gif)

After: 
![solution_for_incomplete_digitized_feature](https://user-images.githubusercontent.com/652785/81460716-bc4ed580-916c-11ea-8a65-85b5b089486f.gif)


Fix #36292