### PR TITLE
Set DPI of rendered images

### DIFF
--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -703,6 +703,8 @@ QImage QgsMapRendererJob::composeImage( const QgsMapSettings &settings, const La
 {
   QImage image( settings.deviceOutputSize(), settings.outputImageFormat() );
   image.setDevicePixelRatio( settings.devicePixelRatio() );
+  image.setDotsPerMeterX( static_cast<int>( settings.outputDpi() * 39.37 ) );
+  image.setDotsPerMeterY( static_cast<int>( settings.outputDpi() * 39.37 ) );
   image.fill( settings.backgroundColor().rgba() );
 
   QPainter painter( &image );


### PR DESCRIPTION
The DPI of rendered images has been hard set to 100 so far, regardless of MapSettings.

E.g. the following code

```
img = renderer.renderedImage()
img.save(buf, 'PNG')
```

would save the PNG with a DPI of 100.