### PR TITLE
New expression function "make_interval" 

### DIFF
--- a/python/core/auto_generated/qgsinterval.sip.in
+++ b/python/core/auto_generated/qgsinterval.sip.in
@@ -49,6 +49,22 @@ Constructor for QgsInterval.
 Constructor for QgsInterval, using the specified ``duration`` and ``units``.
 %End
 
+    QgsInterval( double years, double months, double weeks, double days, double hours, double minutes, double seconds );
+%Docstring
+Constructor for QgsInterval, using the specified ``years``, ``months``,
+``weeks``, ``days``, ``hours``, ``minutes`` and ``seconds``.
+
+.. note::
+
+   Month units assumes a 30 day month length.
+
+.. note::
+
+   Year units assumes a 365.25 day year length.
+
+.. versionadded:: 3.14
+%End
+
     double years() const;
 %Docstring
 Returns the interval duration in years (based on an average year length)

--- a/resources/function_help/json/make_interval
+++ b/resources/function_help/json/make_interval
@@ -1,0 +1,18 @@
+{
+  "name": "make_interval",
+  "type": "function",
+  "description": "Creates an interval value from year, month, weeks, days, hours, minute and seconds values.",
+  "arguments": [
+    {"arg":"years","description":"Number of years (assumes a 365.25 day year length).", "optional": true, "default": "0"},
+    {"arg":"months","description":"Number of months (assumes a 30 day month length)", "optional": true, "default": "0"},
+    {"arg":"weeks","description":"Number of weeks", "optional": true, "default": "0"},
+    {"arg":"days","description":"Number of days", "optional": true, "default": "0"},
+    {"arg":"hours","description":"Number of hours", "optional": true, "default": "0"},
+    {"arg":"minutes","description":"Number of minutes", "optional": true, "default": "0"},
+    {"arg":"seconds","description":"Number of seconds", "optional": true, "default": "0"}
+  ],
+  "examples": [
+    { "expression":"make_interval(hours:=3)", "returns":"3 hour interval"},
+    { "expression":"make_interval(days:=2, hours:=3)", "returns":"2 day, 3 hour interval"}
+  ]
+}

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1157,6 +1157,19 @@ static QVariant fcnMakeDateTime( const QVariantList &values, const QgsExpression
   return QVariant( QDateTime( date, time ) );
 }
 
+static QVariant fcnMakeInterval( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  const int years = QgsExpressionUtils::getIntValue( values.at( 0 ), parent );
+  const int months = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
+  const int weeks = QgsExpressionUtils::getIntValue( values.at( 2 ), parent );
+  const int days = QgsExpressionUtils::getIntValue( values.at( 3 ), parent );
+  const int hours = QgsExpressionUtils::getIntValue( values.at( 4 ), parent );
+  const int minutes = QgsExpressionUtils::getIntValue( values.at( 5 ), parent );
+  const double seconds = QgsExpressionUtils::getDoubleValue( values.at( 6 ), parent );
+
+  return QVariant::fromValue( QgsInterval( years, months, weeks, days, hours, minutes, seconds ) );
+}
+
 static QVariant fcnCoalesce( const QVariantList &values, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * )
 {
   for ( const QVariant &value : values )
@@ -5807,6 +5820,14 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "minute" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "second" ) ),
                                             fcnMakeDateTime, QStringLiteral( "Date and Time" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "make_interval" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "years" ), true, 0 )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "months" ), true, 0 )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "weeks" ), true, 0 )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "days" ), true, 0 )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "hours" ), true, 0 )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "minutes" ), true, 0 )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "seconds" ), true, 0 ),
+                                            fcnMakeInterval, QStringLiteral( "Date and Time" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "lower" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "string" ) ), fcnLower, QStringLiteral( "String" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "upper" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "string" ) ), fcnUpper, QStringLiteral( "String" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "title" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "string" ) ), fcnTitle, QStringLiteral( "String" ) )

--- a/src/core/qgsinterval.cpp
+++ b/src/core/qgsinterval.cpp
@@ -40,6 +40,19 @@ QgsInterval::QgsInterval( double duration, QgsUnitTypes::TemporalUnit unit )
 
 }
 
+QgsInterval::QgsInterval( double years, double months, double weeks, double days, double hours, double minutes, double seconds )
+  : mSeconds( years * QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalYears, QgsUnitTypes::TemporalSeconds )
+              + months * QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalMonths, QgsUnitTypes::TemporalSeconds )
+              + weeks * QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalWeeks, QgsUnitTypes::TemporalSeconds )
+              + days * QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalDays, QgsUnitTypes::TemporalSeconds )
+              + hours * QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalHours, QgsUnitTypes::TemporalSeconds )
+              + minutes * QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalMinutes, QgsUnitTypes::TemporalSeconds )
+              + seconds )
+  , mValid( true )
+{
+
+}
+
 bool QgsInterval::operator==( QgsInterval other ) const
 {
   if ( !mValid && !other.mValid )

--- a/src/core/qgsinterval.h
+++ b/src/core/qgsinterval.h
@@ -73,6 +73,17 @@ class CORE_EXPORT QgsInterval
     QgsInterval( double duration, QgsUnitTypes::TemporalUnit unit );
 
     /**
+     * Constructor for QgsInterval, using the specified \a years, \a months,
+     * \a weeks, \a days, \a hours, \a minutes and \a seconds.
+     *
+     * \note Month units assumes a 30 day month length.
+     * \note Year units assumes a 365.25 day year length.
+     *
+     * \since QGIS 3.14
+     */
+    QgsInterval( double years, double months, double weeks, double days, double hours, double minutes, double seconds );
+
+    /**
      * Returns the interval duration in years (based on an average year length)
      * \see setYears()
      */

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1345,6 +1345,14 @@ class TestQgsExpression: public QObject
       QTest::newRow( "make datetime with ms" ) << "make_datetime(2012,7,8,13,6,28.5)" << false << QVariant( QDateTime( QDate( 2012, 7, 8 ), QTime( 13, 6, 28, 500 ) ) );
       QTest::newRow( "make datetime invalid" ) << "make_datetime(2012,7,8,'a',6,28)" << true << QVariant();
       QTest::newRow( "make datetime invalid 2" ) << "make_datetime(2012,7,8,2012,16,28)" << true << QVariant();
+      QTest::newRow( "make interval years" ) << "second(make_interval(years:=2))" << false << QVariant( 63115200.0 );
+      QTest::newRow( "make interval months" ) << "second(make_interval(months:=2))" << false << QVariant( 5184000.0 );
+      QTest::newRow( "make interval weeks" ) << "second(make_interval(weeks:=2))" << false << QVariant( 1209600.0 );
+      QTest::newRow( "make interval days" ) << "second(make_interval(days:=2))" << false << QVariant( 172800.0 );
+      QTest::newRow( "make interval hours" ) << "second(make_interval(hours:=2))" << false << QVariant( 7200.0 );
+      QTest::newRow( "make interval minutes" ) << "second(make_interval(minutes:=2))" << false << QVariant( 120.0 );
+      QTest::newRow( "make interval seconds" ) << "second(make_interval(seconds:=2))" << false << QVariant( 2.0 );
+      QTest::newRow( "make interval mixed" ) << "second(make_interval(2,3,4,5,6,7,8))" << false << QVariant( 73764428.0 );
       QTest::newRow( "to date" ) << "todate('2012-06-28')" << false << QVariant( QDate( 2012, 6, 28 ) );
       QTest::newRow( "to interval" ) << "tointerval('1 Year 1 Month 1 Week 1 Hour 1 Minute')" << false << QVariant::fromValue( QgsInterval( 34758060 ) );
       QTest::newRow( "day with date" ) << "day('2012-06-28')" << false << QVariant( 28 );

--- a/tests/src/python/test_qgsinterval.py
+++ b/tests/src/python/test_qgsinterval.py
@@ -166,6 +166,24 @@ class TestQgsInterval(unittest.TestCase):
         i = QgsInterval.fromString('bad')
         self.assertFalse(i.isValid())
 
+    def testFromUnits(self):
+        i = QgsInterval(2, 0, 0, 0, 0, 0, 0)
+        self.assertEqual(i.seconds(), 63115200.0)
+        i = QgsInterval(0, 2, 0, 0, 0, 0, 0)
+        self.assertEqual(i.seconds(), 5184000.0)
+        i = QgsInterval(0, 0, 2, 0, 0, 0, 0)
+        self.assertEqual(i.seconds(), 1209600.0)
+        i = QgsInterval(0, 0, 0, 2, 0, 0, 0)
+        self.assertEqual(i.seconds(), 172800.0)
+        i = QgsInterval(0, 0, 0, 0, 2, 0, 0)
+        self.assertEqual(i.seconds(), 7200.0)
+        i = QgsInterval(0, 0, 0, 0, 0, 2, 0)
+        self.assertEqual(i.seconds(), 120.0)
+        i = QgsInterval(0, 0, 0, 0, 0, 0, 2)
+        self.assertEqual(i.seconds(), 2)
+        i = QgsInterval(1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 2)
+        self.assertEqual(i.seconds(), 56342192.0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Allows direct construction of interval values from years/months/weeks/
days/hours/minutes/second values, without having to construct
a string representation of the interval first