### PR TITLE
[FEATURE][layout] Expose temporal UI for map items

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutobject.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutobject.sip.in
@@ -164,6 +164,8 @@ A base class for objects which belong to a layout.
       //table item
       AttributeTableSourceLayer,
       MapCrs,
+      StartDateTime,
+      EndDateTime,
     };
 
     enum PropertyValueType

--- a/python/core/auto_generated/qgsproperty.sip.in
+++ b/python/core/auto_generated/qgsproperty.sip.in
@@ -55,6 +55,7 @@ commonly used property types, such as colors and blend modes.
       VerticalAnchor,
       SvgPath,
       Offset,
+      DateTime,
       Custom,
     };
 
@@ -349,6 +350,29 @@ Calculates the current value of the property, including any transforms which are
 .. seealso:: :py:func:`valueAsBool`
 %End
 
+    QDateTime valueAsDateTime( const QgsExpressionContext &context, const QDateTime &defaultDateTime = QDateTime(), bool *ok /Out/ = 0 ) const;
+%Docstring
+Calculates the current value of the property and interprets it as a datetime.
+
+:param context: QgsExpressionContext to evaluate the property for.
+:param defaultDateTime: default datetime to return if the property cannot be calculated as a datetime
+
+:return: - value parsed to datetime
+         - ok: will be set to ``True`` if conversion was successful
+
+.. seealso:: :py:func:`value`
+
+.. seealso:: :py:func:`valueAsString`
+
+.. seealso:: :py:func:`valueAsColor`
+
+.. seealso:: :py:func:`valueAsDouble`
+
+.. seealso:: :py:func:`valueAsInt`
+
+.. seealso:: :py:func:`valueAsBool`
+%End
+
     QString valueAsString( const QgsExpressionContext &context, const QString &defaultString = QString(), bool *ok /Out/ = 0 ) const;
 %Docstring
 Calculates the current value of the property and interprets it as a string.
@@ -360,6 +384,8 @@ Calculates the current value of the property and interprets it as a string.
          - ok: will be set to ``True`` if conversion was successful
 
 .. seealso:: :py:func:`value`
+
+.. seealso:: :py:func:`valueAsDateTime`
 
 .. seealso:: :py:func:`valueAsColor`
 
@@ -382,6 +408,8 @@ Calculates the current value of the property and interprets it as a color.
 
 .. seealso:: :py:func:`value`
 
+.. seealso:: :py:func:`valueAsDateTime`
+
 .. seealso:: :py:func:`valueAsString`
 
 .. seealso:: :py:func:`valueAsDouble`
@@ -402,6 +430,8 @@ Calculates the current value of the property and interprets it as a double.
          - ok: will be set to ``True`` if conversion was successful
 
 .. seealso:: :py:func:`value`
+
+.. seealso:: :py:func:`valueAsDateTime`
 
 .. seealso:: :py:func:`valueAsString`
 
@@ -424,6 +454,8 @@ Calculates the current value of the property and interprets it as an integer.
 
 .. seealso:: :py:func:`value`
 
+.. seealso:: :py:func:`valueAsDateTime`
+
 .. seealso:: :py:func:`valueAsString`
 
 .. seealso:: :py:func:`valueAsColor`
@@ -444,6 +476,8 @@ Calculates the current value of the property and interprets it as an boolean.
          - ok: will be set to ``True`` if conversion was successful
 
 .. seealso:: :py:func:`value`
+
+.. seealso:: :py:func:`valueAsDateTime`
 
 .. seealso:: :py:func:`valueAsString`
 

--- a/python/core/auto_generated/qgsproperty.sip.in
+++ b/python/core/auto_generated/qgsproperty.sip.in
@@ -371,6 +371,8 @@ Calculates the current value of the property and interprets it as a datetime.
 .. seealso:: :py:func:`valueAsInt`
 
 .. seealso:: :py:func:`valueAsBool`
+
+.. versionadded:: 3.14
 %End
 
     QString valueAsString( const QgsExpressionContext &context, const QString &defaultString = QString(), bool *ok /Out/ = 0 ) const;

--- a/python/core/auto_generated/qgspropertycollection.sip.in
+++ b/python/core/auto_generated/qgspropertycollection.sip.in
@@ -8,6 +8,7 @@
 
 
 
+
 typedef QMap< int, QgsPropertyDefinition > QgsPropertiesDefinition;
 
 
@@ -111,6 +112,31 @@ valueAs* variants) refer to the property() and :py:func:`QgsProperty.value()`
 .. seealso:: :py:func:`valueAsBool`
 %End
 
+    QDateTime valueAsDateTime( int key, const QgsExpressionContext &context, const QDateTime &defaultDateTime = QDateTime(), bool *ok /Out/ = 0 ) const;
+%Docstring
+Calculates the current value of the property with the specified key and interprets it as a string.
+
+:param key: integer key for property to return. The intended use case is that a context specific enum is cast to
+            int and used for the key value.
+:param context: QgsExpressionContext to evaluate the property for.
+:param defaultString: default string to return if the property cannot be calculated as a string
+
+:return: - value parsed to string
+         - ok: will be set to ``True`` if conversion was successful
+
+.. seealso:: :py:func:`value`
+
+.. seealso:: :py:func:`valueAsString`
+
+.. seealso:: :py:func:`valueAsColor`
+
+.. seealso:: :py:func:`valueAsDouble`
+
+.. seealso:: :py:func:`valueAsInt`
+
+.. seealso:: :py:func:`valueAsBool`
+%End
+
     QString valueAsString( int key, const QgsExpressionContext &context, const QString &defaultString = QString(), bool *ok /Out/ = 0 ) const;
 %Docstring
 Calculates the current value of the property with the specified key and interprets it as a string.
@@ -124,6 +150,8 @@ Calculates the current value of the property with the specified key and interpre
          - ok: will be set to ``True`` if conversion was successful
 
 .. seealso:: :py:func:`value`
+
+.. seealso:: :py:func:`valueAsDateTime`
 
 .. seealso:: :py:func:`valueAsColor`
 
@@ -148,6 +176,8 @@ Calculates the current value of the property with the specified key and interpre
 
 .. seealso:: :py:func:`value`
 
+.. seealso:: :py:func:`valueAsDateTime`
+
 .. seealso:: :py:func:`valueAsString`
 
 .. seealso:: :py:func:`valueAsDouble`
@@ -170,6 +200,8 @@ Calculates the current value of the property with the specified key and interpre
          - ok: will be set to ``True`` if conversion was successful
 
 .. seealso:: :py:func:`value`
+
+.. seealso:: :py:func:`valueAsDateTime`
 
 .. seealso:: :py:func:`valueAsString`
 
@@ -194,6 +226,8 @@ Calculates the current value of the property with the specified key and interpre
 
 .. seealso:: :py:func:`value`
 
+.. seealso:: :py:func:`valueAsDateTime`
+
 .. seealso:: :py:func:`valueAsString`
 
 .. seealso:: :py:func:`valueAsColor`
@@ -216,6 +250,8 @@ Calculates the current value of the property with the specified key and interpre
          - ok: will be set to ``True`` if conversion was successful
 
 .. seealso:: :py:func:`value`
+
+.. seealso:: :py:func:`valueAsDateTime`
 
 .. seealso:: :py:func:`valueAsString`
 

--- a/python/core/auto_generated/qgspropertycollection.sip.in
+++ b/python/core/auto_generated/qgspropertycollection.sip.in
@@ -114,14 +114,14 @@ valueAs* variants) refer to the property() and :py:func:`QgsProperty.value()`
 
     QDateTime valueAsDateTime( int key, const QgsExpressionContext &context, const QDateTime &defaultDateTime = QDateTime(), bool *ok /Out/ = 0 ) const;
 %Docstring
-Calculates the current value of the property with the specified key and interprets it as a string.
+Calculates the current value of the property with the specified key and interprets it as a datetime.
 
 :param key: integer key for property to return. The intended use case is that a context specific enum is cast to
             int and used for the key value.
 :param context: QgsExpressionContext to evaluate the property for.
-:param defaultString: default string to return if the property cannot be calculated as a string
+:param defaultDateTime: default datetime to return if the property cannot be calculated as a datetime
 
-:return: - value parsed to string
+:return: - value parsed to datetime
          - ok: will be set to ``True`` if conversion was successful
 
 .. seealso:: :py:func:`value`
@@ -135,6 +135,8 @@ Calculates the current value of the property with the specified key and interpre
 .. seealso:: :py:func:`valueAsInt`
 
 .. seealso:: :py:func:`valueAsBool`
+
+.. versionadded:: 3.14
 %End
 
     QString valueAsString( int key, const QgsExpressionContext &context, const QString &defaultString = QString(), bool *ok /Out/ = 0 ) const;

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -818,7 +818,7 @@ bool QgsLayoutItemMap::readPropertiesFromElement( const QDomElement &itemElem, c
   if ( isTemporal() )
   {
     QDateTime begin = QDateTime::fromString( itemElem.attribute( QStringLiteral( "temporalRangeBegin" ) ), Qt::ISODate );
-    QDateTime end = QDateTime::fromString( itemElem.attribute( QStringLiteral( "temporalRangeBegin" ) ), Qt::ISODate );
+    QDateTime end = QDateTime::fromString( itemElem.attribute( QStringLiteral( "temporalRangeEnd" ) ), Qt::ISODate );
     setTemporalRange( QgsDateTimeRange( begin, end ) );
   }
 
@@ -1764,6 +1764,19 @@ void QgsLayoutItemMap::refreshDataDefinedProperty( const QgsLayoutObject::DataDe
     mLastEvaluatedThemeName = mDataDefinedProperties.valueAsString( QgsLayoutObject::MapStylePreset, context, mFollowVisibilityPresetName );
     if ( mLastEvaluatedThemeName != previousTheme )
       emit themeChanged( mLastEvaluatedThemeName );
+  }
+
+  if ( isTemporal() && ( property == QgsLayoutObject::StartDateTime || property == QgsLayoutObject::EndDateTime || property == QgsLayoutObject::AllProperties ) )
+  {
+    QDateTime begin = temporalRange().begin();
+    QDateTime end = temporalRange().end();
+
+    if ( property == QgsLayoutObject::StartDateTime || property == QgsLayoutObject::AllProperties )
+      begin = mDataDefinedProperties.valueAsDateTime( QgsLayoutObject::StartDateTime, context, temporalRange().begin() );
+    if ( property == QgsLayoutObject::EndDateTime || property == QgsLayoutObject::AllProperties )
+      end = mDataDefinedProperties.valueAsDateTime( QgsLayoutObject::EndDateTime, context, temporalRange().end() );
+
+    setTemporalRange( QgsDateTimeRange( begin, end ) );
   }
 
   //force redraw

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1561,10 +1561,9 @@ QgsExpressionContext QgsLayoutItemMap::createExpressionContext() const
 
   scope->addFunction( QStringLiteral( "is_layer_visible" ), new QgsExpressionContextUtils::GetLayerVisibility( layersInMap, scale() ) );
 
-  // maybe one day we'll populate these with real values!
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_start_time" ), QVariant(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_end_time" ), QVariant(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_interval" ), QVariant(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_start_time" ), isTemporal() ? temporalRange().begin() : QVariant(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_end_time" ), isTemporal() ? temporalRange().end() : QVariant(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_interval" ), isTemporal() ? ( temporalRange().end() - temporalRange().begin() ) : QVariant(), true ) );
 
   return context;
 }

--- a/src/core/layout/qgslayoutobject.cpp
+++ b/src/core/layout/qgslayoutobject.cpp
@@ -91,6 +91,8 @@ void QgsLayoutObject::initPropertyDefinitions()
     { QgsLayoutObject::ScalebarLineWidth, QgsPropertyDefinition( "dataDefinedScalebarLineWidth", QObject::tr( "Line width" ), QgsPropertyDefinition::StrokeWidth ) },
     { QgsLayoutObject::AttributeTableSourceLayer, QgsPropertyDefinition( "dataDefinedAttributeTableSourceLayer", QObject::tr( "Table source layer" ), QgsPropertyDefinition::String ) },
     { QgsLayoutObject::MapCrs, QgsPropertyDefinition( "dataDefinedCrs", QgsPropertyDefinition::DataTypeString, QObject::tr( "Map CRS" ), QObject::tr( "string representing a CRS, either an authority/id pair (e.g. \"EPSG:4326\"), a proj string prefixes by \"PROJ:\" (e.g. \"PROJ: +proj=...\") or a WKT string prefixed by \"WKT:\" (e.g. \"WKT:GEOGCS[\"WGS 84\"...)" ) ) },
+    { QgsLayoutObject::StartDateTime, QgsPropertyDefinition( "dataDefinedStartDateTime", QObject::tr( "Temporal range start date / time" ), QgsPropertyDefinition::DateTime ) },
+    { QgsLayoutObject::EndDateTime, QgsPropertyDefinition( "dataDefinedEndDateTime", QObject::tr( "Temporal range end date / time" ), QgsPropertyDefinition::DateTime ) },
   };
 }
 

--- a/src/core/layout/qgslayoutobject.h
+++ b/src/core/layout/qgslayoutobject.h
@@ -192,6 +192,8 @@ class CORE_EXPORT QgsLayoutObject: public QObject, public QgsExpressionContextGe
       //table item
       AttributeTableSourceLayer, //!< Attribute table source layer
       MapCrs, //!< Map CRS
+      StartDateTime, //!< Temporal range's start DateTime
+      EndDateTime, //!< Temporal range's end DateTime
     };
 
     /**

--- a/src/core/qgsproperty.cpp
+++ b/src/core/qgsproperty.cpp
@@ -167,6 +167,11 @@ QgsPropertyDefinition::QgsPropertyDefinition( const QString &name, const QString
       mHelpText = QObject::tr( "string of doubles '<b>x,y</b>' or array of doubles <b>[x, y]</b>" );
       break;
 
+    case DateTime:
+      mTypes = DataTypeString;
+      mHelpText = QObject::tr( "DateTime or string representation of a DateTime" );
+      break;
+
     case Custom:
       mTypes = DataTypeString;
   }
@@ -532,6 +537,34 @@ QVariant QgsProperty::value( const QgsExpressionContext &context, const QVariant
     *ok = true;
 
   return val;
+}
+
+QDateTime QgsProperty::valueAsDateTime( const QgsExpressionContext &context, const QDateTime &defaultDateTime, bool *ok ) const
+{
+  bool valOk = false;
+  QVariant val = value( context, defaultDateTime, &valOk );
+
+  if ( !valOk || !val.isValid() )
+    return defaultDateTime;
+
+  QDateTime dateTime;
+  if ( val.type() == QVariant::DateTime )
+  {
+    dateTime = val.value<QDateTime>();
+  }
+  else
+  {
+    dateTime = val.toDateTime();
+  }
+
+  if ( !dateTime.isValid() )
+    return defaultDateTime;
+  else
+  {
+    if ( ok )
+      *ok = true;
+    return dateTime;
+  }
 }
 
 QString QgsProperty::valueAsString( const QgsExpressionContext &context, const QString &defaultString, bool *ok ) const

--- a/src/core/qgsproperty.h
+++ b/src/core/qgsproperty.h
@@ -77,7 +77,7 @@ class CORE_EXPORT QgsPropertyDefinition
       VerticalAnchor, //!< Vertical anchor point
       SvgPath, //!< Path to an SVG file
       Offset, //!< 2D offset
-      DateTime, //!< 2D offset
+      DateTime, //!< DateTime value
       Custom = 3000, //!< Custom property types
     };
 
@@ -392,6 +392,7 @@ class CORE_EXPORT QgsProperty
      * \see valueAsDouble()
      * \see valueAsInt()
      * \see valueAsBool()
+     * \since QGIS 3.14
      */
     QDateTime valueAsDateTime( const QgsExpressionContext &context, const QDateTime &defaultDateTime = QDateTime(), bool *ok SIP_OUT = nullptr ) const;
 

--- a/src/core/qgsproperty.h
+++ b/src/core/qgsproperty.h
@@ -28,6 +28,7 @@
 #include <QDomElement>
 #include <QDomDocument>
 #include <QColor>
+#include <QDateTime>
 
 class QgsPropertyTransformer;
 class QgsPropertyPrivate;
@@ -76,6 +77,7 @@ class CORE_EXPORT QgsPropertyDefinition
       VerticalAnchor, //!< Vertical anchor point
       SvgPath, //!< Path to an SVG file
       Offset, //!< 2D offset
+      DateTime, //!< 2D offset
       Custom = 3000, //!< Custom property types
     };
 
@@ -379,12 +381,28 @@ class CORE_EXPORT QgsProperty
     QVariant value( const QgsExpressionContext &context, const QVariant &defaultValue = QVariant(), bool *ok SIP_OUT = nullptr ) const;
 
     /**
+     * Calculates the current value of the property and interprets it as a datetime.
+     * \param context QgsExpressionContext to evaluate the property for.
+     * \param defaultDateTime default datetime to return if the property cannot be calculated as a datetime
+     * \param ok if specified, will be set to TRUE if conversion was successful
+     * \returns value parsed to datetime
+     * \see value()
+     * \see valueAsString()
+     * \see valueAsColor()
+     * \see valueAsDouble()
+     * \see valueAsInt()
+     * \see valueAsBool()
+     */
+    QDateTime valueAsDateTime( const QgsExpressionContext &context, const QDateTime &defaultDateTime = QDateTime(), bool *ok SIP_OUT = nullptr ) const;
+
+    /**
      * Calculates the current value of the property and interprets it as a string.
      * \param context QgsExpressionContext to evaluate the property for.
      * \param defaultString default string to return if the property cannot be calculated as a string
      * \param ok if specified, will be set to TRUE if conversion was successful
      * \returns value parsed to string
      * \see value()
+     * \see valueAsDateTime()
      * \see valueAsColor()
      * \see valueAsDouble()
      * \see valueAsInt()
@@ -399,6 +417,7 @@ class CORE_EXPORT QgsProperty
      * \param ok if specified, will be set to TRUE if conversion was successful
      * \returns value parsed to color
      * \see value()
+     * \see valueAsDateTime()
      * \see valueAsString()
      * \see valueAsDouble()
      * \see valueAsInt()
@@ -413,6 +432,7 @@ class CORE_EXPORT QgsProperty
      * \param ok if specified, will be set to TRUE if conversion was successful
      * \returns value parsed to double
      * \see value()
+     * \see valueAsDateTime()
      * \see valueAsString()
      * \see valueAsColor()
      * \see valueAsInt()
@@ -427,6 +447,7 @@ class CORE_EXPORT QgsProperty
      * \param ok if specified, will be set to TRUE if conversion was successful
      * \returns value parsed to integer
      * \see value()
+     * \see valueAsDateTime()
      * \see valueAsString()
      * \see valueAsColor()
      * \see valueAsDouble()
@@ -441,6 +462,7 @@ class CORE_EXPORT QgsProperty
      * \param ok if specified, will be set to TRUE if conversion was successful
      * \returns value parsed to boolean
      * \see value()
+     * \see valueAsDateTime()
      * \see valueAsString()
      * \see valueAsColor()
      * \see valueAsDouble()

--- a/src/core/qgspropertycollection.cpp
+++ b/src/core/qgspropertycollection.cpp
@@ -27,6 +27,18 @@ QgsAbstractPropertyCollection::QgsAbstractPropertyCollection( const QString &nam
 
 }
 
+QDateTime QgsAbstractPropertyCollection::valueAsDateTime( int key, const QgsExpressionContext &context, const QDateTime &defaultDateTime, bool *ok ) const
+{
+  if ( ok )
+    *ok = false;
+
+  QgsProperty prop = property( key );
+  if ( !prop || !prop.isActive() )
+    return defaultDateTime;
+
+  return prop.valueAsDateTime( context, defaultDateTime, ok );
+}
+
 QString QgsAbstractPropertyCollection::valueAsString( int key, const QgsExpressionContext &context, const QString &defaultString, bool *ok ) const
 {
   if ( ok )

--- a/src/core/qgspropertycollection.h
+++ b/src/core/qgspropertycollection.h
@@ -120,19 +120,20 @@ class CORE_EXPORT QgsAbstractPropertyCollection
     virtual QVariant value( int key, const QgsExpressionContext &context, const QVariant &defaultValue = QVariant() ) const = 0;
 
     /**
-     * Calculates the current value of the property with the specified key and interprets it as a string.
+     * Calculates the current value of the property with the specified key and interprets it as a datetime.
      * \param key integer key for property to return. The intended use case is that a context specific enum is cast to
      * int and used for the key value.
      * \param context QgsExpressionContext to evaluate the property for.
-     * \param defaultString default string to return if the property cannot be calculated as a string
+     * \param defaultDateTime default datetime to return if the property cannot be calculated as a datetime
      * \param ok if specified, will be set to TRUE if conversion was successful
-     * \returns value parsed to string
+     * \returns value parsed to datetime
      * \see value()
      * \see valueAsString()
      * \see valueAsColor()
      * \see valueAsDouble()
      * \see valueAsInt()
      * \see valueAsBool()
+     * \since QGIS 3.14
      */
     QDateTime valueAsDateTime( int key, const QgsExpressionContext &context, const QDateTime &defaultDateTime = QDateTime(), bool *ok SIP_OUT = nullptr ) const;
 

--- a/src/core/qgspropertycollection.h
+++ b/src/core/qgspropertycollection.h
@@ -17,11 +17,13 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
+#include "qgsexpressioncontext.h"
+#include "qgsproperty.h"
+
 #include <QString>
 #include <QVariant>
 #include <QColor>
-#include "qgsexpressioncontext.h"
-#include "qgsproperty.h"
+#include <QDateTime>
 
 class QDomElement;
 class QDomDocument;
@@ -126,6 +128,24 @@ class CORE_EXPORT QgsAbstractPropertyCollection
      * \param ok if specified, will be set to TRUE if conversion was successful
      * \returns value parsed to string
      * \see value()
+     * \see valueAsString()
+     * \see valueAsColor()
+     * \see valueAsDouble()
+     * \see valueAsInt()
+     * \see valueAsBool()
+     */
+    QDateTime valueAsDateTime( int key, const QgsExpressionContext &context, const QDateTime &defaultDateTime = QDateTime(), bool *ok SIP_OUT = nullptr ) const;
+
+    /**
+     * Calculates the current value of the property with the specified key and interprets it as a string.
+     * \param key integer key for property to return. The intended use case is that a context specific enum is cast to
+     * int and used for the key value.
+     * \param context QgsExpressionContext to evaluate the property for.
+     * \param defaultString default string to return if the property cannot be calculated as a string
+     * \param ok if specified, will be set to TRUE if conversion was successful
+     * \returns value parsed to string
+     * \see value()
+     * \see valueAsDateTime()
      * \see valueAsColor()
      * \see valueAsDouble()
      * \see valueAsInt()
@@ -142,6 +162,7 @@ class CORE_EXPORT QgsAbstractPropertyCollection
      * \param ok if specified, will be set to TRUE if conversion was successful
      * \returns value parsed to color
      * \see value()
+     * \see valueAsDateTime()
      * \see valueAsString()
      * \see valueAsDouble()
      * \see valueAsInt()
@@ -158,6 +179,7 @@ class CORE_EXPORT QgsAbstractPropertyCollection
      * \param ok if specified, will be set to TRUE if conversion was successful
      * \returns value parsed to double
      * \see value()
+     * \see valueAsDateTime()
      * \see valueAsString()
      * \see valueAsColor()
      * \see valueAsInt()
@@ -174,6 +196,7 @@ class CORE_EXPORT QgsAbstractPropertyCollection
      * \param ok if specified, will be set to TRUE if conversion was successful
      * \returns value parsed to integer
      * \see value()
+     * \see valueAsDateTime()
      * \see valueAsString()
      * \see valueAsColor()
      * \see valueAsDouble()
@@ -190,6 +213,7 @@ class CORE_EXPORT QgsAbstractPropertyCollection
      * \param ok if specified, will be set to TRUE if conversion was successful
      * \returns value parsed to bool
      * \see value()
+     * \see valueAsDateTime()
      * \see valueAsString()
      * \see valueAsColor()
      * \see valueAsDouble()

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -85,6 +85,12 @@ QgsLayoutMapWidget::QgsLayoutMapWidget( QgsLayoutItemMap *item, QgsMapCanvas *ma
   connect( mOverviewListWidget, &QListWidget::currentItemChanged, this, &QgsLayoutMapWidget::mOverviewListWidget_currentItemChanged );
   connect( mOverviewListWidget, &QListWidget::itemChanged, this, &QgsLayoutMapWidget::mOverviewListWidget_itemChanged );
   connect( mActionLabelSettings, &QAction::triggered, this, &QgsLayoutMapWidget::showLabelSettings );
+  connect( mTemporalCheckBox, &QgsCollapsibleGroupBoxBasic::toggled, this, &QgsLayoutMapWidget::mTemporalCheckBox_toggled );
+  connect( mStartDateTime, &QDateTimeEdit::dateTimeChanged, this, &QgsLayoutMapWidget::updateTemporalExtent );
+  connect( mEndDateTime, &QDateTimeEdit::dateTimeChanged, this, &QgsLayoutMapWidget::updateTemporalExtent );
+
+  mStartDateTime->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
+  mEndDateTime->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
 
   connect( mActionMoveContent, &QAction::triggered, this, &QgsLayoutMapWidget::switchToMoveContentTool );
   setPanelTitle( tr( "Map Properties" ) );
@@ -177,6 +183,8 @@ QgsLayoutMapWidget::QgsLayoutMapWidget( QgsLayoutItemMap *item, QgsMapCanvas *ma
   registerDataDefinedButton( mStylePresetsDDBtn, QgsLayoutObject::MapStylePreset );
   registerDataDefinedButton( mLayersDDBtn, QgsLayoutObject::MapLayers );
   registerDataDefinedButton( mCRSDDBtn, QgsLayoutObject::MapCrs );
+  registerDataDefinedButton( mStartDateTimeDDBtn, QgsLayoutObject::StartDateTime );
+  registerDataDefinedButton( mEndDateTimeDDBtn, QgsLayoutObject::EndDateTime );
 
   updateGuiElements();
   loadGridEntries();
@@ -249,6 +257,8 @@ void QgsLayoutMapWidget::populateDataDefinedButtons()
   updateDataDefinedButton( mStylePresetsDDBtn );
   updateDataDefinedButton( mLayersDDBtn );
   updateDataDefinedButton( mCRSDDBtn );
+  updateDataDefinedButton( mStartDateTimeDDBtn );
+  updateDataDefinedButton( mEndDateTimeDDBtn );
 }
 
 void QgsLayoutMapWidget::compositionAtlasToggled( bool atlasEnabled )
@@ -475,6 +485,45 @@ void QgsLayoutMapWidget::aboutToShowBookmarkMenu()
     else
       mBookmarkMenu->addMenu( groupMenus.value( groupKeys.at( i ) ) );
   }
+}
+
+void QgsLayoutMapWidget::mTemporalCheckBox_toggled( bool checked )
+{
+  if ( !mMapItem )
+  {
+    return;
+  }
+
+  mStartDateTime->setEnabled( checked );
+  mEndDateTime->setEnabled( checked );
+
+  mMapItem->layout()->undoStack()->beginCommand( mMapItem, tr( "Toggle Temporal Range" ) );
+  mMapItem->setIsTemporal( checked );
+  mMapItem->layout()->undoStack()->endCommand();
+
+  if ( checked )
+  {
+    whileBlocking( mStartDateTime )->setDateTime( mMapItem->temporalRange().begin() );
+    whileBlocking( mEndDateTime )->setDateTime( mMapItem->temporalRange().end() );
+  }
+
+  updatePreview();
+}
+
+void QgsLayoutMapWidget::updateTemporalExtent()
+{
+  if ( !mMapItem )
+  {
+    return;
+  }
+
+  QgsDateTimeRange range = QgsDateTimeRange( mStartDateTime->dateTime(), mEndDateTime->dateTime() );
+
+  mMapItem->layout()->undoStack()->beginCommand( mMapItem, tr( "Set Temporal Range" ) );
+  mMapItem->setTemporalRange( range );
+  mMapItem->layout()->undoStack()->endCommand();
+
+  updatePreview();
 }
 
 void QgsLayoutMapWidget::mAtlasCheckBox_toggled( bool checked )
@@ -833,6 +882,16 @@ void QgsLayoutMapWidget::updateGuiElements()
     mAtlasPredefinedScaleRadio->setEnabled( false );
   }
 
+  mTemporalCheckBox->setChecked( mMapItem->isTemporal() );
+  mTemporalCheckBox->setCollapsed( !mMapItem->isTemporal() );
+  mStartDateTime->setEnabled( mMapItem->isTemporal() );
+  mEndDateTime->setEnabled( mMapItem->isTemporal() );
+  if ( mMapItem->isTemporal() )
+  {
+    mStartDateTime->setDateTime( mMapItem->temporalRange().begin() );
+    mEndDateTime->setDateTime( mMapItem->temporalRange().end() );
+  }
+
   populateDataDefinedButtons();
   loadGridEntries();
   loadOverviewEntries();
@@ -922,6 +981,8 @@ void QgsLayoutMapWidget::blockAllSignals( bool b )
   mKeepLayerStylesCheckBox->blockSignals( b );
   mActionSetToCanvasExtent->blockSignals( b );
   mActionUpdatePreview->blockSignals( b );
+  mStartDateTime->blockSignals( b );
+  mEndDateTime->blockSignals( b );
 
   blockOverviewItemsSignals( b );
 }

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -981,6 +981,7 @@ void QgsLayoutMapWidget::blockAllSignals( bool b )
   mKeepLayerStylesCheckBox->blockSignals( b );
   mActionSetToCanvasExtent->blockSignals( b );
   mActionUpdatePreview->blockSignals( b );
+  mTemporalCheckBox->blockSignals( b );
   mStartDateTime->blockSignals( b );
   mEndDateTime->blockSignals( b );
 

--- a/src/gui/layout/qgslayoutmapwidget.h
+++ b/src/gui/layout/qgslayoutmapwidget.h
@@ -105,6 +105,9 @@ class GUI_EXPORT QgsLayoutMapWidget: public QgsLayoutItemBaseWidget, private Ui:
     void setOverviewItems( QgsLayoutItemMapOverview *overview );
     void blockOverviewItemsSignals( bool block );
 
+    void mTemporalCheckBox_toggled( bool checked );
+    void updateTemporalExtent();
+
   protected:
     bool setNewItem( QgsLayoutItem *item ) override;
 

--- a/src/ui/layout/qgslayoutmapwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapwidgetbase.ui
@@ -425,6 +425,105 @@
         </widget>
        </item>
        <item>
+        <widget class="QgsCollapsibleGroupBoxBasic" name="mTemporalCheckBox">
+         <property name="title">
+          <string>Temporal Range</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <property name="collapsed" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="syncGroup" stdset="0">
+          <string notr="true">composeritem</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_5">
+          <item row="0" column="0">
+           <widget class="QLabel" name="mStartDateTimeLabel">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>Start</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+            <property name="buddy">
+             <cstring>mStartDateTime</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDateTimeEdit" name="mStartDateTime">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="displayFormat">
+             <string>M/d/yyyy h:mm AP</string>
+            </property>
+            <property name="timeSpec">
+             <enum>Qt::UTC</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QgsPropertyOverrideButton" name="mStartDateTimeDDBtn">
+            <property name="text">
+             <string>…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="mEndDateTimeLabel">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>End</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+            <property name="buddy">
+             <cstring>mEndDateTime</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QDateTimeEdit" name="mEndDateTime">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="displayFormat">
+             <string>M/d/yyyy h:mm AP</string>
+            </property>
+            <property name="timeSpec">
+             <enum>Qt::UTC</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QgsPropertyOverrideButton" name="mEndDateTimeDDBtn">
+            <property name="text">
+             <string>…</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QgsCollapsibleGroupBoxBasic" name="mAtlasCheckBox">
          <property name="title">
           <string>Controlled by Atlas</string>

--- a/tests/src/core/testqgsproperty.cpp
+++ b/tests/src/core/testqgsproperty.cpp
@@ -268,6 +268,10 @@ void TestQgsProperty::conversions()
   collection.property( 5 ).setStaticValue( dt2 ); //datetime in qvariant
   QCOMPARE( d1.valueAsDateTime( context, dt ), dt2 );
   QCOMPARE( collection.valueAsDateTime( 5, context,  dt ), dt2 );
+  d1.setStaticValue( "2010-01-01" ); //datetime as string
+  collection.property( 5 ).setStaticValue( "2010-01-01" ); //datetime as string
+  QCOMPARE( d1.valueAsDateTime( context, dt ), dt2 );
+  QCOMPARE( collection.valueAsDateTime( 5, context, dt ), dt2 );
   d1.setStaticValue( "i am not a datetime" ); //not a datetime, should return default value
   collection.property( 5 ).setStaticValue( "i am not a datetime" ); //not a double, should return default value
   QCOMPARE( d1.valueAsDateTime( context, dt ), dt );

--- a/tests/src/core/testqgsproperty.cpp
+++ b/tests/src/core/testqgsproperty.cpp
@@ -256,6 +256,22 @@ void TestQgsProperty::conversions()
   collection.property( 4 ).setStaticValue( "s" );
   QCOMPARE( s1.valueAsString( context, "n" ), QStringLiteral( "s" ) );
   QCOMPARE( collection.valueAsString( 4, context, "y" ), QStringLiteral( "s" ) );
+
+  // test datetime conversions
+  QDateTime dt = QDateTime( QDate( 2020, 1, 1 ) );
+  QDateTime dt2 = QDateTime( QDate( 2010, 1, 1 ) );
+  QgsProperty dt1 = QgsProperty::fromValue( QVariant(), true );
+  collection.setProperty( 5, dt1 );
+  QCOMPARE( d1.valueAsDateTime( context, dt ), dt );
+  QCOMPARE( collection.valueAsDateTime( 5, context, dt ), dt );
+  d1.setStaticValue( dt2 ); //datetime in qvariant
+  collection.property( 5 ).setStaticValue( dt2 ); //datetime in qvariant
+  QCOMPARE( d1.valueAsDateTime( context, dt ), dt2 );
+  QCOMPARE( collection.valueAsDateTime( 5, context,  dt ), dt2 );
+  d1.setStaticValue( "i am not a datetime" ); //not a datetime, should return default value
+  collection.property( 5 ).setStaticValue( "i am not a datetime" ); //not a double, should return default value
+  QCOMPARE( d1.valueAsDateTime( context, dt ), dt );
+  QCOMPARE( collection.valueAsDateTime( 5, context, dt ), dt );
 }
 
 void TestQgsProperty::invalid()


### PR DESCRIPTION
## Description

There was no way we'd ship _QGIS 3.14 "Temporal edition"_ without temporal support to layouts:
![Peek 2020-05-09 14-45](https://user-images.githubusercontent.com/1728657/81467639-3ed6a400-9204-11ea-9b06-713872a1c799.gif)

This PR adds UI to the layout map item widget to enable/disable temporal range, as well as defining the temporal range start and end.

The start and end datetime values can be data-defined. I.e., this PR unlocks temporal atlas export. :tada: