### PR TITLE
[processing] fix file filter for i.landsat.toar (fix #36290)

### DIFF
--- a/python/plugins/processing/algs/grass7/description/i.landsat.toar.txt
+++ b/python/plugins/processing/algs/grass7/description/i.landsat.toar.txt
@@ -2,7 +2,7 @@ i.landsat.toar
 Calculates top-of-atmosphere radiance or reflectance and temperature for Landsat MSS/TM/ETM+/OLI
 Imagery (i.*)
 QgsProcessingParameterMultipleLayers|rasters|Landsat input rasters|3|None|False
-QgsProcessingParameterFile|metfile|Name of Landsat metadata file (.met or MTL.txt)|QgsProcessingParameterFile.File|met|None|True
+QgsProcessingParameterFile|metfile|Name of Landsat metadata file (.met or MTL.txt)|QgsProcessingParameterFile.File|None|None|True|Landsat metadata (*.met *.MET *.txt *.TXT)
 QgsProcessingParameterEnum|sensor|Spacecraft sensor|mss1;mss2;mss3;mss4;mss5;tm4;tm5;tm7;oli8|False|7|True
 QgsProcessingParameterEnum|method|Atmospheric correction method|uncorrected;dos1;dos2;dos2b;dos3;dos4|False|0|True
 QgsProcessingParameterString|date|Image acquisition date (yyyy-mm-dd)|None|False|True


### PR DESCRIPTION
## Description
Improve file filter string for "Landsat metadata file" in `i.landsat.toar` Processing algorithm.

Fixes #36290.