### PR TITLE
Add cumulative temporal range setting in temporal controller

### DIFF
--- a/python/core/auto_generated/qgsprojecttimesettings.sip.in
+++ b/python/core/auto_generated/qgsprojecttimesettings.sip.in
@@ -137,6 +137,20 @@ Returns the project's default animation frame rate, in frames per second.
 .. seealso:: :py:func:`setFramesPerSecond`
 %End
 
+    void setIsTemporalRangeCumulative( bool state );
+%Docstring
+Sets the project's temporal range as cumulative in animation settings.
+
+.. seealso:: :py:func:`isTemporalRangeCumulative`
+%End
+
+    bool isTemporalRangeCumulative() const;
+%Docstring
+Returns the value of cumulative temporal range in animation settings.
+
+.. seealso:: :py:func:`setIsTemporalRangeCumulative`
+%End
+
   signals:
 
     void temporalRangeChanged();

--- a/python/core/auto_generated/qgstemporalnavigationobject.sip.in
+++ b/python/core/auto_generated/qgstemporalnavigationobject.sip.in
@@ -134,6 +134,20 @@ a playing animation will advance to the next frame.
 .. seealso:: :py:func:`setFramesPerSecond`
 %End
 
+    void setTemporalRangeCumulative( bool state );
+%Docstring
+Sets the animation temporal range as cumulative.
+
+.. seealso:: :py:func:`temporalRangeCumulative`
+%End
+
+    bool temporalRangeCumulative() const;
+%Docstring
+Returns the animation temporal range cumulative settings.
+
+.. seealso:: :py:func:`setTemporalRangeCumulative`
+%End
+
     long long totalFrameCount();
 %Docstring
 Returns the total number of frames for the navigation.

--- a/src/core/qgsprojecttimesettings.cpp
+++ b/src/core/qgsprojecttimesettings.cpp
@@ -63,7 +63,7 @@ bool QgsProjectTimeSettings::readXml( const QDomElement &element, const QgsReadW
   mTimeStepUnit = QgsUnitTypes::decodeTemporalUnit( element.attribute( QStringLiteral( "timeStepUnit" ), QgsUnitTypes::encodeUnit( QgsUnitTypes::TemporalHours ) ) );
   mTimeStep = element.attribute( QStringLiteral( "timeStep" ), "1" ).toDouble();
   mFrameRate = element.attribute( QStringLiteral( "frameRate" ), "1" ).toDouble();
-  mCumulativeTemporalRange = element.attribute( QStringLiteral( "cumulativeTemporalRange" ), "0" ).toInt() == 1 ? true : false;
+  mCumulativeTemporalRange = element.attribute( QStringLiteral( "cumulativeTemporalRange" ), "0" ).toInt();
 
   return true;
 }

--- a/src/core/qgsprojecttimesettings.cpp
+++ b/src/core/qgsprojecttimesettings.cpp
@@ -63,6 +63,7 @@ bool QgsProjectTimeSettings::readXml( const QDomElement &element, const QgsReadW
   mTimeStepUnit = QgsUnitTypes::decodeTemporalUnit( element.attribute( QStringLiteral( "timeStepUnit" ), QgsUnitTypes::encodeUnit( QgsUnitTypes::TemporalHours ) ) );
   mTimeStep = element.attribute( QStringLiteral( "timeStep" ), "1" ).toDouble();
   mFrameRate = element.attribute( QStringLiteral( "frameRate" ), "1" ).toDouble();
+  mCumulativeTemporalRange = element.attribute( QStringLiteral( "cumulativeTemporalRange" ), "0" ).toInt() == 1 ? true : false;
 
   return true;
 }
@@ -92,6 +93,7 @@ QDomElement QgsProjectTimeSettings::writeXml( QDomDocument &document, const QgsR
   element.setAttribute( QStringLiteral( "timeStepUnit" ), QgsUnitTypes::encodeUnit( mTimeStepUnit ) );
   element.setAttribute( QStringLiteral( "timeStep" ), qgsDoubleToString( mTimeStep ) );
   element.setAttribute( QStringLiteral( "frameRate" ), qgsDoubleToString( mFrameRate ) );
+  element.setAttribute( QStringLiteral( "cumulativeTemporalRange" ),  mCumulativeTemporalRange ? 1 : 0 );
 
   return element;
 }
@@ -124,5 +126,14 @@ void QgsProjectTimeSettings::setFramesPerSecond( double rate )
 double QgsProjectTimeSettings::framesPerSecond() const
 {
   return mFrameRate;
+}
+
+void QgsProjectTimeSettings::setIsTemporalRangeCumulative( bool state )
+{
+  mCumulativeTemporalRange = state;
+}
+bool QgsProjectTimeSettings::isTemporalRangeCumulative() const
+{
+  return mCumulativeTemporalRange;
 }
 

--- a/src/core/qgsprojecttimesettings.h
+++ b/src/core/qgsprojecttimesettings.h
@@ -141,6 +141,20 @@ class CORE_EXPORT QgsProjectTimeSettings : public QObject
      */
     double framesPerSecond() const;
 
+    /**
+     * Sets the project's temporal range as cumulative in animation settings.
+     *
+     * \see isTemporalRangeCumulative()
+     */
+    void setIsTemporalRangeCumulative( bool state );
+
+    /**
+     * Returns the value of cumulative temporal range in animation settings.
+     *
+     * \see setIsTemporalRangeCumulative()
+     */
+    bool isTemporalRangeCumulative() const;
+
   signals:
 
     /**
@@ -157,6 +171,7 @@ class CORE_EXPORT QgsProjectTimeSettings : public QObject
     QgsUnitTypes::TemporalUnit mTimeStepUnit = QgsUnitTypes::TemporalHours;
     double mTimeStep = 1;
     double mFrameRate = 1;
+    bool mCumulativeTemporalRange = false;
 };
 
 

--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -90,6 +90,9 @@ QgsDateTimeRange QgsTemporalNavigationObject::dateTimeRangeForFrameNumber( long 
   const QDateTime begin = start.addSecs( frame * mFrameDuration.seconds() );
   const QDateTime end = start.addSecs( nextFrame * mFrameDuration.seconds() );
 
+  if ( mCumulativeTemporalRange )
+    return QgsDateTimeRange( start, begin, true, false );
+
   if ( end <= mTemporalExtents.end() )
     return QgsDateTimeRange( begin, end, true, false );
 
@@ -151,6 +154,16 @@ void QgsTemporalNavigationObject::setFramesPerSecond( double framesPerSeconds )
 double QgsTemporalNavigationObject::framesPerSecond() const
 {
   return mFramesPerSecond;
+}
+
+void QgsTemporalNavigationObject::setTemporalRangeCumulative( bool state )
+{
+  mCumulativeTemporalRange = state;
+}
+
+bool QgsTemporalNavigationObject::temporalRangeCumulative() const
+{
+  return mCumulativeTemporalRange;
 }
 
 void QgsTemporalNavigationObject::play()

--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -90,13 +90,15 @@ QgsDateTimeRange QgsTemporalNavigationObject::dateTimeRangeForFrameNumber( long 
   const QDateTime begin = start.addSecs( frame * mFrameDuration.seconds() );
   const QDateTime end = start.addSecs( nextFrame * mFrameDuration.seconds() );
 
+  QDateTime frameStart = begin;
+
   if ( mCumulativeTemporalRange )
-    return QgsDateTimeRange( start, begin, true, false );
+    frameStart = start;
 
   if ( end <= mTemporalExtents.end() )
-    return QgsDateTimeRange( begin, end, true, false );
+    return QgsDateTimeRange( frameStart, end, true, false );
 
-  return QgsDateTimeRange( begin, mTemporalExtents.end(), true, false );
+  return QgsDateTimeRange( frameStart, mTemporalExtents.end(), true, false );
 }
 
 void QgsTemporalNavigationObject::setTemporalExtents( const QgsDateTimeRange &temporalExtents )

--- a/src/core/qgstemporalnavigationobject.h
+++ b/src/core/qgstemporalnavigationobject.h
@@ -149,6 +149,20 @@ class CORE_EXPORT QgsTemporalNavigationObject : public QgsTemporalController, pu
     double framesPerSecond() const;
 
     /**
+     * Sets the animation temporal range as cumulative.
+     *
+     * \see temporalRangeCumulative()
+     */
+    void setTemporalRangeCumulative( bool state );
+
+    /**
+     * Returns the animation temporal range cumulative settings.
+     *
+     * \see setTemporalRangeCumulative()
+     */
+    bool temporalRangeCumulative() const;
+
+    /**
      * Returns the total number of frames for the navigation.
      */
     long long totalFrameCount();
@@ -257,6 +271,8 @@ class CORE_EXPORT QgsTemporalNavigationObject : public QgsTemporalController, pu
     AnimationState mPlayBackMode = Idle;
 
     bool mLoopAnimation = false;
+
+    bool mCumulativeTemporalRange = false;
 
 };
 

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -151,6 +151,7 @@ void QgsTemporalControllerWidget::setWidgetStateFromProject()
   updateFrameDuration();
 
   mNavigationObject->setFramesPerSecond( QgsProject::instance()->timeSettings()->framesPerSecond() );
+  mNavigationObject->setTemporalRangeCumulative( QgsProject::instance()->timeSettings()->isTemporalRangeCumulative() );
 }
 
 void QgsTemporalControllerWidget::onLayersAdded()
@@ -214,12 +215,20 @@ void QgsTemporalControllerWidget::settings_clicked()
 {
   QgsTemporalMapSettingsWidget *settingsWidget = new QgsTemporalMapSettingsWidget( this );
   settingsWidget->setFrameRateValue( mNavigationObject->framesPerSecond() );
+  settingsWidget->setIsTemporalRangeCumulative( mNavigationObject->temporalRangeCumulative() );
 
   connect( settingsWidget, &QgsTemporalMapSettingsWidget::frameRateChanged, this, [ = ]( double rate )
   {
     // save new settings into project
     QgsProject::instance()->timeSettings()->setFramesPerSecond( rate );
     mNavigationObject->setFramesPerSecond( rate );
+  } );
+
+  connect( settingsWidget, &QgsTemporalMapSettingsWidget::temporalRangeCumulativeChanged, this, [ = ]( bool state )
+  {
+    // save new settings into project
+    QgsProject::instance()->timeSettings()->setIsTemporalRangeCumulative( state );
+    mNavigationObject->setTemporalRangeCumulative( state );
   } );
   openPanel( settingsWidget );
 }

--- a/src/gui/qgstemporalmapsettingswidget.cpp
+++ b/src/gui/qgstemporalmapsettingswidget.cpp
@@ -29,6 +29,7 @@ QgsTemporalMapSettingsWidget::QgsTemporalMapSettingsWidget( QWidget *parent )
   mFrameSpinBox->setClearValue( 1 );
 
   connect( mFrameSpinBox,  qgis::overload<double>::of( &QDoubleSpinBox::valueChanged ), this, &QgsTemporalMapSettingsWidget::frameRateChanged );
+  connect( mCumulativeTemporalRange, &QCheckBox::toggled, this, &QgsTemporalMapSettingsWidget::temporalRangeCumulativeChanged );
 }
 
 double QgsTemporalMapSettingsWidget::frameRateValue()
@@ -39,6 +40,16 @@ double QgsTemporalMapSettingsWidget::frameRateValue()
 void QgsTemporalMapSettingsWidget::setFrameRateValue( double value )
 {
   mFrameSpinBox->setValue( value );
+}
+
+void QgsTemporalMapSettingsWidget::setIsTemporalRangeCumulative( bool state )
+{
+  mCumulativeTemporalRange->setChecked( state );
+}
+
+bool QgsTemporalMapSettingsWidget::isTemporalRangeCumulative()
+{
+  return mCumulativeTemporalRange->isChecked();
 }
 
 ///@endcond

--- a/src/gui/qgstemporalmapsettingswidget.h
+++ b/src/gui/qgstemporalmapsettingswidget.h
@@ -47,12 +47,28 @@ class GUI_EXPORT QgsTemporalMapSettingsWidget : public QgsPanelWidget, private U
      */
     void setFrameRateValue( double value );
 
+    /**
+     * Returns the cumulative range option state from vcr widget.
+     *
+     * \see setIsTemporalRangeCumulative()
+     */
+    bool isTemporalRangeCumulative();
+
+    /**
+     * Sets the cumulative range option state from vcr widget.
+     *
+     * \see isTemporalRangeCumulative(
+     */
+    void setIsTemporalRangeCumulative( bool state );
+
   signals:
 
     /**
      * Emitted when frame \a rate value on the spin box has changed.
      */
     void frameRateChanged( double rate );
+
+    void temporalRangeCumulativeChanged( bool state );
 
 
 };

--- a/src/ui/qgstemporalmapsettingswidgetbase.ui
+++ b/src/ui/qgstemporalmapsettingswidgetbase.ui
@@ -7,25 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>409</width>
-    <height>63</height>
+    <height>82</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>0</number>
-   </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -40,6 +28,30 @@
      </item>
      <item>
       <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QCheckBox" name="mCumulativeTemporalRange">
+       <property name="text">
+        <string>Cumulative range</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -78,6 +90,7 @@
    <class>QgsPanelWidget</class>
    <extends>QWidget</extends>
    <header>qgspanelwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/tests/src/core/testqgstemporalnavigationobject.cpp
+++ b/tests/src/core/testqgstemporalnavigationobject.cpp
@@ -145,8 +145,16 @@ void TestQgsTemporalNavigationObject::frameSettings()
 
   QgsDateTimeRange range = QgsDateTimeRange(
                              QDateTime( QDate( 2020, 1, 1 ), QTime( 8, 0, 0 ) ),
-                             QDateTime( QDate( 2020, 1, 1 ), QTime( 12, 0, 0 ) )
+                             QDateTime( QDate( 2020, 1, 1 ), QTime( 12, 0, 0 ) ),
+                             true,
+                             false
                            );
+  QgsDateTimeRange lastRange = QgsDateTimeRange(
+                                 QDateTime( QDate( 2020, 1, 1 ), QTime( 12, 0, 0 ) ),
+                                 QDateTime( QDate( 2020, 1, 1 ), QTime( 12, 0, 0 ) ),
+                                 true,
+                                 false
+                               );
   navigationObject->setTemporalExtents( range );
   QCOMPARE( temporalRangeSignal.count(), 1 );
 
@@ -162,6 +170,11 @@ void TestQgsTemporalNavigationObject::frameSettings()
 
   navigationObject->setFramesPerSecond( 1 );
   QCOMPARE( navigationObject->framesPerSecond(), 1.0 );
+
+  QCOMPARE( navigationObject->dateTimeRangeForFrameNumber( 4 ), lastRange );
+
+  navigationObject->setTemporalRangeCumulative( true );
+  QCOMPARE( navigationObject->dateTimeRangeForFrameNumber( 4 ), range );
 
 }
 

--- a/tests/src/python/test_qgsprojecttimesettings.py
+++ b/tests/src/python/test_qgsprojecttimesettings.py
@@ -67,6 +67,8 @@ class TestQgsProjectTimeSettings(unittest.TestCase):
         self.assertEqual(p.timeStepUnit(), QgsUnitTypes.TemporalDecades)
         p.setFramesPerSecond(90)
         self.assertEqual(p.framesPerSecond(), 90)
+        p.setIsTemporalRangeCumulative(True)
+        self.assertTrue(p.isTemporalRangeCumulative())
 
     def testReadWrite(self):
         p = QgsProjectTimeSettings()
@@ -88,6 +90,7 @@ class TestQgsProjectTimeSettings(unittest.TestCase):
         p.setTimeStep(4.8)
         p.setTimeStepUnit(QgsUnitTypes.TemporalDecades)
         p.setFramesPerSecond(90)
+        p.setIsTemporalRangeCumulative(True)
         elem = p.writeXml(doc, QgsReadWriteContext())
 
         p2 = QgsProjectTimeSettings()
@@ -98,6 +101,7 @@ class TestQgsProjectTimeSettings(unittest.TestCase):
         self.assertEqual(p2.timeStep(), 4.8)
         self.assertEqual(p2.timeStepUnit(), QgsUnitTypes.TemporalDecades)
         self.assertEqual(p2.framesPerSecond(), 90)
+        self.assertTrue(p.isTemporalRangeCumulative())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds a setting in temporal controller to set the animation temporal range as cumulative, that is all animation frames will have the same start date time but different end date time when the temporal range is cumulative.

eg.
![cumulative_animation_range](https://user-images.githubusercontent.com/2663775/81475518-77cb4480-9215-11ea-96a6-78b93ca01a69.gif)
