### PR TITLE
3.10 backport of fixing dropping pgsql materialized views

### DIFF
--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -65,7 +65,7 @@ bool QgsPostgresUtils::deleteLayer( const QString &uri, QString &errCause )
   QString type = resViewCheck.PQgetvalue( 0, 0 );
   if ( type == QLatin1String( "v" ) || type == QLatin1String( "m" ) )
   {
-    QString sql = QString( "DROP %1VIEW %2" ).arg( type == QLatin1String( "m" ) ? "MATERIALIZED " : QString(), schemaTableName );
+    QString sql = QStringLiteral( "DROP %1VIEW %2" ).arg( type == QLatin1String( "m" ) ? QStringLiteral( "MATERIALIZED " ) : QString(), schemaTableName );
     QgsPostgresResult result( conn->PQexec( sql ) );
     if ( result.PQresultStatus() != PGRES_COMMAND_OK )
     {

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -65,7 +65,7 @@ bool QgsPostgresUtils::deleteLayer( const QString &uri, QString &errCause )
   QString type = resViewCheck.PQgetvalue( 0, 0 );
   if ( type == QLatin1String( "v" ) || type == QLatin1String( "m" ) )
   {
-    QString sql = QString( "DROP VIEW %1" ).arg( schemaTableName );
+    QString sql = QString( "DROP %1VIEW %2" ).arg( type == QLatin1String( "m" ) ? "MATERIALIZED " : QString(), schemaTableName );
     QgsPostgresResult result( conn->PQexec( sql ) );
     if ( result.PQresultStatus() != PGRES_COMMAND_OK )
     {


### PR DESCRIPTION
Manual backport of #36226 to the release-3_10 branch , which the github bot could not automatically merge (botched #36274).

This was created by cherry-picking 9bc7d4c90cf3072b7f7ab3683cb4cdde8c9ddf5c and 
66760b46eadb726d6f90f74f2d4407af96331953 onto the latest release-3_10 branch.