### PR TITLE
Remove email address from Processing metadata

### DIFF
--- a/python/plugins/processing/metadata.txt
+++ b/python/plugins/processing/metadata.txt
@@ -7,7 +7,6 @@ version=2.12.99
 qgisMinimumVersion=3.0
 
 author=Victor Olaya
-email=volayaf@gmail.com
 
 icon=:/images/themes/default/processingAlgorithm.svg
 


### PR DESCRIPTION
I would ike to have my email removed from the Processing metadata. Reason for this is that people tend to go to the plugin description in the Plugin Manager to look for the contact person when they have issues, and I end up receiving quite a few emails with bug reports or questions. Most of the time I redirect people to the mailing list, some time i just ignore those emails since I do not have much time lately. This is not the optimal situation.

Processing being a core plugin, I believe it is better to have a qgis email address in there, or no address at all, since I guess I am not anymore the person to contact for this (and probably no person should take that place, instead it should be handled through the mailing lists)

Email adresses are mandatory when uploading to the QGIS Plugins Server, but plugins are loaded without issues if there is no email defined, so I guess there should be no problem with this.