### PR TITLE
[expression] Compile make_{datetime,date,time} for sqlite

### DIFF
--- a/src/core/qgssqlexpressioncompiler.cpp
+++ b/src/core/qgssqlexpressioncompiler.cpp
@@ -372,7 +372,7 @@ QgsSqlExpressionCompiler::Result QgsSqlExpressionCompiler::compileNode( const Qg
       // get sql function to compile node expression
       QString nd = sqlFunctionFromFunctionName( fd->name() );
       // if no sql function the node can't be compiled
-      if ( nd.isEmpty() )
+      if ( nd.isNull() )
         return Fail;
 
       // compile arguments
@@ -397,7 +397,7 @@ QgsSqlExpressionCompiler::Result QgsSqlExpressionCompiler::compileNode( const Qg
       args = sqlArgumentsFromFunctionName( fd->name(), args );
 
       // build result
-      result = QStringLiteral( "%1(%2)" ).arg( nd, args.join( ',' ) );
+      result = !nd.isEmpty() ? QStringLiteral( "%1(%2)" ).arg( nd, args.join( ',' ) ) : QStringLiteral( "%1" ).arg( args.join( ',' ) );
       return inResult == Partial ? Partial : Complete;
     }
 

--- a/src/core/qgssqliteexpressioncompiler.cpp
+++ b/src/core/qgssqliteexpressioncompiler.cpp
@@ -17,7 +17,9 @@
 
 #include "qgssqliteexpressioncompiler.h"
 #include "qgssqlexpressioncompiler.h"
+#include "qgsexpressionfunction.h"
 #include "qgsexpressionnodeimpl.h"
+#include "qgsexpression.h"
 #include "qgssqliteutils.h"
 
 QgsSQLiteExpressionCompiler::QgsSQLiteExpressionCompiler( const QgsFields &fields )
@@ -61,6 +63,24 @@ QgsSqlExpressionCompiler::Result QgsSQLiteExpressionCompiler::compileNode( const
       }
     }
 
+    case QgsExpressionNode::ntFunction:
+    {
+      const QgsExpressionNodeFunction *n = static_cast<const QgsExpressionNodeFunction *>( node );
+      QgsExpressionFunction *fd = QgsExpression::Functions()[n->fnIndex()];
+
+      if ( fd->name() == QLatin1String( "make_datetime" ) || fd->name() == QLatin1String( "make_date" ) || fd->name() == QLatin1String( "make_time" ) )
+      {
+        const auto constList = n->args()->list();
+        for ( const QgsExpressionNode *ln : constList )
+        {
+          if ( ln->nodeType() != QgsExpressionNode::ntLiteral )
+            return Fail;
+        }
+      }
+
+      return QgsSqlExpressionCompiler::compileNode( node, result );
+    }
+
     default:
       break;
   }
@@ -90,9 +110,39 @@ QString QgsSQLiteExpressionCompiler::sqlFunctionFromFunctionName( const QString 
     { "round", "round" },
     { "trim", "trim" },
     { "upper", "upper" },
+    { "make_datetime", "" },
+    { "make_date", "" },
+    { "make_time", "" },
   };
 
   return FN_NAMES.value( fnName, QString() );
+}
+
+QStringList QgsSQLiteExpressionCompiler::sqlArgumentsFromFunctionName( const QString &fnName, const QStringList &fnArgs ) const
+{
+  QStringList args( fnArgs );
+  if ( fnName == QLatin1String( "make_datetime" ) )
+  {
+    args = QStringList( QStringLiteral( "'%1-%2-%3T%4:%5:%6Z'" ).arg( args[0].rightJustified( 4, '0' ) )
+                        .arg( args[1].rightJustified( 2, '0' ) )
+                        .arg( args[2].rightJustified( 2, '0' ) )
+                        .arg( args[3].rightJustified( 2, '0' ) )
+                        .arg( args[4].rightJustified( 2, '0' ) )
+                        .arg( args[5].rightJustified( 2, '0' ) ) );
+  }
+  else if ( fnName == QLatin1String( "make_date" ) )
+  {
+    args = QStringList( QStringLiteral( "'%1-%2-%3'" ).arg( args[0].rightJustified( 4, '0' ) )
+                        .arg( args[1].rightJustified( 2, '0' ) )
+                        .arg( args[2].rightJustified( 2, '0' ) ) );
+  }
+  else if ( fnName == QLatin1String( "make_time" ) )
+  {
+    args = QStringList( QStringLiteral( "'%1:%2:%3'" ).arg( args[0].rightJustified( 2, '0' ) )
+                        .arg( args[1].rightJustified( 2, '0' ) )
+                        .arg( args[2].rightJustified( 2, '0' ) ) );
+  }
+  return args;
 }
 
 QString QgsSQLiteExpressionCompiler::castToReal( const QString &value ) const

--- a/src/core/qgssqliteexpressioncompiler.h
+++ b/src/core/qgssqliteexpressioncompiler.h
@@ -50,6 +50,7 @@ class CORE_EXPORT QgsSQLiteExpressionCompiler : public QgsSqlExpressionCompiler
     QString quotedIdentifier( const QString &identifier ) override;
     QString quotedValue( const QVariant &value, bool &ok ) override;
     QString sqlFunctionFromFunctionName( const QString &fnName ) const override;
+    QStringList sqlArgumentsFromFunctionName( const QString &fnName, const QStringList &fnArgs ) const override;
     QString castToReal( const QString &value ) const override;
     QString castToInt( const QString &value ) const override;
     QString castToText( const QString &value ) const override;

--- a/tests/src/python/test_provider_gpkg.py
+++ b/tests/src/python/test_provider_gpkg.py
@@ -154,11 +154,7 @@ class TestPyQgsGpkgProvider(unittest.TestCase, ProviderTestCase):
                     'overlaps(buffer($geometry,1),geom_from_wkt( \'Polygon ((-75.1 76.1, -75.1 81.6, -68.8 81.6, -68.8 76.1, -75.1 76.1))\'))',
                     'intersects(centroid($geometry),geom_from_wkt( \'Polygon ((-74.4 78.2, -74.4 79.1, -66.8 79.1, -66.8 78.2, -74.4 78.2))\'))',
                     'intersects(point_on_surface($geometry),geom_from_wkt( \'Polygon ((-74.4 78.2, -74.4 79.1, -66.8 79.1, -66.8 78.2, -74.4 78.2))\'))',
-                    '"dt" <= make_datetime(2020, 5, 4, 12, 13, 14)',
-                    '"dt" < make_date(2020, 5, 4)',
                     '"dt" = to_datetime(\'000www14ww13ww12www4ww5ww2020\',\'zzzwwwsswwmmwwhhwwwdwwMwwyyyy\')',
-                    '"date" <= make_datetime(2020, 5, 4, 12, 13, 14)',
-                    '"date" >= make_date(2020, 5, 4)',
                     'to_time("time") >= make_time(12, 14, 14)',
                     'to_time("time") = to_time(\'000www14ww13ww12www\',\'zzzwwwsswwmmwwhhwww\')',
                     '"date" = to_date(\'www4ww5ww2020\',\'wwwdwwMwwyyyy\')'

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -361,8 +361,6 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
                     '"dt" <= format_date(make_datetime(2020, 5, 4, 12, 13, 14), \'yyyy-MM-dd hh:mm:ss\')',
                     '"dt" < format_date(make_date(2020, 5, 4), \'yyyy-MM-dd hh:mm:ss\')',
                     '"dt" = format_date(to_datetime(\'000www14ww13ww12www4ww5ww2020\',\'zzzwwwsswwmmwwhhwwwdwwMwwyyyy\'),\'yyyy-MM-dd hh:mm:ss\')',
-                    '"date" <= make_datetime(2020, 5, 4, 12, 13, 14)',
-                    '"date" >= make_date(2020, 5, 4)',
                     'to_time("time") >= make_time(12, 14, 14)',
                     'to_time("time") = to_time(\'000www14ww13ww12www\',\'zzzwwwsswwmmwwhhwww\')',
                     '"date" = to_date(\'www4ww5ww2020\',\'wwwdwwMwwyyyy\')'


### PR DESCRIPTION
## Description

This PR implements expression compilation of make_{datetime,date,time} for sqlite-based datasets (geopackage and spatialite). This unlocks blazingly fast temporal navigation over large file-based datasets.

Before:
![Peek 2020-05-11 09-53](https://user-images.githubusercontent.com/1728657/81520309-21254e00-936e-11ea-971e-3a3baf8c5ba2.gif)

After:
![Peek 2020-05-11 09-52](https://user-images.githubusercontent.com/1728657/81520315-25ea0200-936e-11ea-8691-771370df5ea8.gif)
