### PR TITLE
Fix QgsGeometry nearestPoint and minimalEnclosingCircle when the geometry is empty

### DIFF
--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -606,6 +606,10 @@ double QgsGeometry::sqrDistToVertexAt( QgsPointXY &point, int atVertex ) const
 
 QgsGeometry QgsGeometry::nearestPoint( const QgsGeometry &other ) const
 {
+  if ( isEmpty() )
+  {
+    return QgsGeometry();
+  }
   QgsGeos geos( d->geometry.get() );
   mLastError.clear();
   QgsGeometry result = geos.closestPoint( other );
@@ -1072,7 +1076,7 @@ QgsGeometry QgsGeometry::minimalEnclosingCircle( QgsPointXY &center, double &rad
   center = QgsPointXY();
   radius = 0;
 
-  if ( !d->geometry )
+  if ( isEmpty() )
   {
     return QgsGeometry();
   }

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -606,10 +606,6 @@ double QgsGeometry::sqrDistToVertexAt( QgsPointXY &point, int atVertex ) const
 
 QgsGeometry QgsGeometry::nearestPoint( const QgsGeometry &other ) const
 {
-  if ( isEmpty() )
-  {
-    return QgsGeometry();
-  }
   QgsGeos geos( d->geometry.get() );
   mLastError.clear();
   QgsGeometry result = geos.closestPoint( other );

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -2213,7 +2213,7 @@ QgsGeometry QgsGeos::mergeLines( QString *errorMsg ) const
 
 QgsGeometry QgsGeos::closestPoint( const QgsGeometry &other, QString *errorMsg ) const
 {
-  if ( !mGeos || other.isNull() )
+  if ( !mGeos || isEmpty() || other.isNull() )
   {
     return QgsGeometry();
   }


### PR DESCRIPTION
* In QgsGeometry nearestPoint method : exit early if the geometry is empty to avoid creating an invalid GEOSNearestPoints_r.

* In QgsGeometry minimalEnclosingCircle method : return a default QgsGeometry instead of a default 36 segments polygon with NaN value if the geometry is empty.

fix #36142
