### PR TITLE
[Bugfix][Server] WFS DescribeFeatureType: add MultiCurve and MultiSurface in SCHEMA

### DIFF
--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -243,6 +243,9 @@ namespace QgsWfs
         case QgsWkbTypes::MultiLineString:
           geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:MultiLineStringPropertyType" ) );
           break;
+        case QgsWkbTypes::MultiSurface:
+          geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:MultiSurfaceType" ) );
+          break;
         case QgsWkbTypes::MultiPolygon25D:
         case QgsWkbTypes::MultiPolygon:
           geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:MultiPolygonPropertyType" ) );

--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -236,6 +236,9 @@ namespace QgsWfs
         case QgsWkbTypes::MultiPoint:
           geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:MultiPointPropertyType" ) );
           break;
+        case QgsWkbTypes::MultiCurve:
+          geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:MultiCurveType" ) );
+          break;
         case QgsWkbTypes::MultiLineString25D:
         case QgsWkbTypes::MultiLineString:
           geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:MultiLineStringPropertyType" ) );


### PR DESCRIPTION
## Description

[In the GML provided by QGIS Server, MultiCurve and MultiSurface elements could be used to describe geometry. The SCHEMA provided by WFS DescribeFeatureType did not include this geometry element.