### PR TITLE
[Oracle] Force multi geometry type at layer level

### DIFF
--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -78,6 +78,10 @@ QgsOracleProvider::QgsOracleProvider( QString const &uri, const ProviderOptions 
   mSqlWhereClause = mUri.sql();
   mSrid = mUri.srid().toInt();
   mRequestedGeomType = mUri.wkbType();
+  if ( QgsWkbTypes::isSingleType( mRequestedGeomType ) && QgsWkbTypes::geometryType( mRequestedGeomType ) != QgsWkbTypes::PointGeometry )
+  {
+    mRequestedGeomType = QgsWkbTypes::multiType( mRequestedGeomType );
+  }
   mUseEstimatedMetadata = mUri.useEstimatedMetadata();
   mIncludeGeoAttributes = mUri.hasParam( "includegeoattributes" ) ? mUri.param( "includegeoattributes" ) == "true" : false;
 


### PR DESCRIPTION
Oracle DBMS can mix single and multi geometry type like ESRI ShapeFile.
So the geometry type has to be multi geometry type for requested one.
