### PR TITLE
Save correctly selective masking parameters

### DIFF
--- a/src/gui/qgsmaskingwidget.cpp
+++ b/src/gui/qgsmaskingwidget.cpp
@@ -28,29 +28,54 @@
 #include "qgsvectorlayerutils.h"
 #include "qgsmasksymbollayer.h"
 #include "qgsvectorlayerlabeling.h"
+#include "qgsmessagebaritem.h"
 
 QgsMaskingWidget::QgsMaskingWidget( QWidget *parent ) :
   QgsPanelWidget( parent )
 {
   setupUi( this );
+}
 
-  connect( mMaskTargetsWidget, &QgsSymbolLayerSelectionWidget::changed, this, [&]()
-  {
-    mMaskSourcesWidget->setEnabled( ! mMaskTargetsWidget->selection().isEmpty() );
-    emit widgetChanged();
-  } );
-  connect( mMaskSourcesWidget, &QgsMaskSourceSelectionWidget::changed, this, [&]()
-  {
-    emit widgetChanged();
-  } );
+void QgsMaskingWidget::onSelectionChanged()
+{
+  // display message if configuration is not consistent
+  bool printMessage =
+    ( mMaskTargetsWidget->selection().empty() && !mMaskSourcesWidget->selection().empty() )
+    || ( !mMaskTargetsWidget->selection().empty() && mMaskSourcesWidget->selection().empty() );
 
-  connect( mEditMaskSettingsGroup, &QGroupBox::toggled, this, [&]( bool on )
+  if ( mMessageBarItem && !printMessage )
   {
-    if ( on && mLayer )
-    {
-      populate();
-    }
-  } );
+    mMessageBar->popWidget( mMessageBarItem );
+    delete mMessageBarItem;
+    mMessageBarItem = nullptr;
+  }
+  else if ( !mMessageBarItem && printMessage )
+  {
+    mMessageBarItem = new QgsMessageBarItem( tr( "You need to select both mask sources and masked symbol layers. If not, all configuration will be lost" ), Qgis::Warning, 0, this );
+    mMessageBar->pushItem( mMessageBarItem );
+  }
+
+  emit widgetChanged();
+}
+
+void QgsMaskingWidget::showEvent( QShowEvent *event )
+{
+  Q_UNUSED( event );
+
+  // populate is quite long, so we delay it when the widget is first shown
+  if ( _mustPopulate )
+  {
+    disconnect( mMaskTargetsWidget, &QgsSymbolLayerSelectionWidget::changed, this, &QgsMaskingWidget::onSelectionChanged );
+    disconnect( mMaskSourcesWidget, &QgsMaskSourceSelectionWidget::changed, this, &QgsMaskingWidget::onSelectionChanged );
+
+    _mustPopulate = false;
+    populate();
+
+    connect( mMaskTargetsWidget, &QgsSymbolLayerSelectionWidget::changed, this, &QgsMaskingWidget::onSelectionChanged );
+    connect( mMaskSourcesWidget, &QgsMaskSourceSelectionWidget::changed, this, &QgsMaskingWidget::onSelectionChanged );
+
+    onSelectionChanged();
+  }
 }
 
 /**
@@ -141,10 +166,10 @@ QList<QPair<QgsSymbolLayerId, QList<QgsSymbolLayerReference>>> symbolLayerMasks(
 
 void QgsMaskingWidget::setLayer( QgsVectorLayer *layer )
 {
-  mLayer = layer;
-  if ( mEditMaskSettingsGroup->isChecked() )
+  if ( mLayer != layer )
   {
-    populate();
+    mLayer = layer;
+    _mustPopulate = true;
   }
 }
 

--- a/src/gui/qgsmaskingwidget.cpp
+++ b/src/gui/qgsmaskingwidget.cpp
@@ -39,15 +39,12 @@ QgsMaskingWidget::QgsMaskingWidget( QWidget *parent ) :
 void QgsMaskingWidget::onSelectionChanged()
 {
   // display message if configuration is not consistent
-  bool printMessage =
-    ( mMaskTargetsWidget->selection().empty() && !mMaskSourcesWidget->selection().empty() )
-    || ( !mMaskTargetsWidget->selection().empty() && mMaskSourcesWidget->selection().empty() );
+  bool printMessage = mMaskTargetsWidget->selection().empty() != mMaskSourcesWidget->selection().empty();
 
   if ( mMessageBarItem && !printMessage )
   {
     mMessageBar->popWidget( mMessageBarItem );
     delete mMessageBarItem;
-    mMessageBarItem = nullptr;
   }
   else if ( !mMessageBarItem && printMessage )
   {

--- a/src/gui/qgsmaskingwidget.cpp
+++ b/src/gui/qgsmaskingwidget.cpp
@@ -51,7 +51,7 @@ void QgsMaskingWidget::onSelectionChanged()
   }
   else if ( !mMessageBarItem && printMessage )
   {
-    mMessageBarItem = new QgsMessageBarItem( tr( "You need to select both mask sources and masked symbol layers. If not, all configuration will be lost" ), Qgis::Warning, 0, this );
+    mMessageBarItem = new QgsMessageBarItem( tr( "Select both sources and symbol layers or your configuration will be lost" ), Qgis::Warning, 0, this );
     mMessageBar->pushItem( mMessageBarItem );
   }
 
@@ -63,12 +63,12 @@ void QgsMaskingWidget::showEvent( QShowEvent *event )
   Q_UNUSED( event );
 
   // populate is quite long, so we delay it when the widget is first shown
-  if ( _mustPopulate )
+  if ( mMustPopulate )
   {
     disconnect( mMaskTargetsWidget, &QgsSymbolLayerSelectionWidget::changed, this, &QgsMaskingWidget::onSelectionChanged );
     disconnect( mMaskSourcesWidget, &QgsMaskSourceSelectionWidget::changed, this, &QgsMaskingWidget::onSelectionChanged );
 
-    _mustPopulate = false;
+    mMustPopulate = false;
     populate();
 
     connect( mMaskTargetsWidget, &QgsSymbolLayerSelectionWidget::changed, this, &QgsMaskingWidget::onSelectionChanged );
@@ -169,7 +169,7 @@ void QgsMaskingWidget::setLayer( QgsVectorLayer *layer )
   if ( mLayer != layer )
   {
     mLayer = layer;
-    _mustPopulate = true;
+    mMustPopulate = true;
   }
 }
 

--- a/src/gui/qgsmaskingwidget.h
+++ b/src/gui/qgsmaskingwidget.h
@@ -23,6 +23,8 @@
 #include "qgis_sip.h"
 #include "qgis_gui.h"
 
+class QgsMessageBarItem;
+
 /**
  * \ingroup gui
  * Main widget for the configuration of mask sources and targets.
@@ -47,10 +49,21 @@ class GUI_EXPORT QgsMaskingWidget: public QgsPanelWidget, private Ui::QgsMasking
     //! Emitted when a change is performed
     void widgetChanged();
 
+  protected:
+
+    void showEvent( QShowEvent * ) override;
+
+  protected slots:
+
+    void onSelectionChanged();
+
   private:
     QgsVectorLayer *mLayer = nullptr;
     //! Populate the mask source and target widgets
     void populate();
+
+    QgsMessageBarItem *mMessageBarItem = nullptr;
+    bool _mustPopulate = false;
 };
 
 #endif

--- a/src/gui/qgsmaskingwidget.h
+++ b/src/gui/qgsmaskingwidget.h
@@ -18,6 +18,8 @@
 // We don't want to expose this in the public API
 #define SIP_NO_FILE
 
+#include <QPointer>
+
 #include "qgspanelwidget.h"
 #include "ui_qgsmaskingwidgetbase.h"
 #include "qgis_sip.h"
@@ -53,7 +55,7 @@ class GUI_EXPORT QgsMaskingWidget: public QgsPanelWidget, private Ui::QgsMasking
 
     void showEvent( QShowEvent * ) override;
 
-  protected slots:
+  private slots:
 
     /**
      * Called whenever mask sources or targets selection has changed
@@ -65,7 +67,7 @@ class GUI_EXPORT QgsMaskingWidget: public QgsPanelWidget, private Ui::QgsMasking
     //! Populate the mask source and target widgets
     void populate();
 
-    QgsMessageBarItem *mMessageBarItem = nullptr;
+    QPointer<QgsMessageBarItem> mMessageBarItem;
     bool mMustPopulate = false;
 };
 

--- a/src/gui/qgsmaskingwidget.h
+++ b/src/gui/qgsmaskingwidget.h
@@ -55,6 +55,9 @@ class GUI_EXPORT QgsMaskingWidget: public QgsPanelWidget, private Ui::QgsMasking
 
   protected slots:
 
+    /**
+     * Called whenever mask sources or targets selection has changed
+     */
     void onSelectionChanged();
 
   private:

--- a/src/gui/qgsmaskingwidget.h
+++ b/src/gui/qgsmaskingwidget.h
@@ -63,7 +63,7 @@ class GUI_EXPORT QgsMaskingWidget: public QgsPanelWidget, private Ui::QgsMasking
     void populate();
 
     QgsMessageBarItem *mMessageBarItem = nullptr;
-    bool _mustPopulate = false;
+    bool mMustPopulate = false;
 };
 
 #endif

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -614,6 +614,9 @@ void QgsVectorLayerProperties::apply()
   mMetadataWidget->acceptMetadata();
   mMetadataFilled = false;
 
+  // save masking settings
+  mMaskingWidget->apply();
+
   //
   // Set up sql subset query if applicable
   //

--- a/src/ui/qgsmaskingwidgetbase.ui
+++ b/src/ui/qgsmaskingwidgetbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>863</width>
-    <height>461</height>
+    <width>812</width>
+    <height>538</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,46 +15,34 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <widget class="QGroupBox" name="mEditMaskSettingsGroup">
-     <property name="title">
-      <string>Edit mask settings</string>
+    <widget class="QgsMessageBar" name="mMessageBar">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
      </property>
-     <property name="checkable">
-      <bool>true</bool>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
      </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <property name="leftMargin">
-       <number>9</number>
-      </property>
-      <item>
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Masked symbol layers</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QgsSymbolLayerSelectionWidget" name="mMaskTargetsWidget" native="true"/>
-      </item>
-      <item>
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Mask sources</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QgsMaskSourceSelectionWidget" name="mMaskSourcesWidget" native="true">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
     </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Masked symbol layers</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QgsSymbolLayerSelectionWidget" name="mMaskTargetsWidget" native="true"/>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Mask sources</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QgsMaskSourceSelectionWidget" name="mMaskSourcesWidget" native="true"/>
    </item>
   </layout>
  </widget>
@@ -69,6 +57,12 @@
    <class>QgsSymbolLayerSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgssymbollayerselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMessageBar</class>
+   <extends>QFrame</extends>
+   <header>qgsmessagebar.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
## Description

This PR fixes #33277. It fixes several things:

- It applies masking widget settings from the vector properties

- The edit mask settings were not serialized in the project and so need to be unchecked every time we display the widget. This checkbox was used to defer widget populate which takes time #35557. I propose to delay the populate when the widget is first shown. 

- If user selects a masked symbol layer but no mask source (or vice versa) the configuration is not saved because data model associates sources with layers. I propose to display a warning message when the configuration is not consistent.

![msgSelectiveMasking](https://user-images.githubusercontent.com/14358135/81657201-facbe500-9437-11ea-89b0-bb0a35ac77aa.gif)

