### PR TITLE
Add additional temporal modes for vector layers

### DIFF
--- a/python/core/auto_generated/qgsvectorlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/qgsvectorlayertemporalproperties.sip.in
@@ -142,6 +142,11 @@ contains the duration of the event.
 
 Units are specified by durationUnits()
 
+.. warning::
+
+   This setting is only effective when mode() is
+   QgsVectorLayerTemporalProperties.ModeFeatureDateTimeStartAndDurationFromFields
+
 .. seealso:: :py:func:`setDurationField`
 
 .. seealso:: :py:func:`durationUnits`
@@ -153,6 +158,11 @@ Sets the name of the duration ``field``, which
 contains the duration of the event.
 
 Units are specified by setDurationUnits()
+
+.. warning::
+
+   This setting is only effective when mode() is
+   QgsVectorLayerTemporalProperties.ModeFeatureDateTimeStartAndDurationFromFields
 
 .. seealso:: :py:func:`durationField`
 
@@ -171,6 +181,38 @@ Returns the units of the event's duration.
 Sets the ``units`` of the event's duration.
 
 .. seealso:: :py:func:`durationUnits`
+%End
+
+    double fixedDuration() const;
+%Docstring
+Returns the fixed duration length, which contains the duration of the event.
+
+Units are specified by durationUnits()
+
+.. warning::
+
+   This setting is only effective when mode() is
+   QgsVectorLayerTemporalProperties.ModeFeatureDateTimeInstantFromField
+
+.. seealso:: :py:func:`setFixedDuration`
+
+.. seealso:: :py:func:`durationUnits`
+%End
+
+    void setFixedDuration( double duration );
+%Docstring
+Sets the fixed event ``duration``, which contains the duration of the event.
+
+Units are specified by setDurationUnits()
+
+.. warning::
+
+   This setting is only effective when mode() is
+   QgsVectorLayerTemporalProperties.ModeFeatureDateTimeInstantFromField
+
+.. seealso:: :py:func:`fixedDuration`
+
+.. seealso:: :py:func:`setDurationUnits`
 %End
 
     QString createFilterString( QgsVectorLayer *layer, const QgsDateTimeRange &range ) const;

--- a/python/core/auto_generated/qgsvectorlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/qgsvectorlayertemporalproperties.sip.in
@@ -39,6 +39,7 @@ The ``enabled`` argument specifies whether the temporal properties are initially
       ModeFixedTemporalRange,
       ModeFeatureDateTimeInstantFromField,
       ModeFeatureDateTimeStartAndEndFromFields,
+      ModeFeatureDateTimeStartAndDurationFromFields,
       ModeRedrawLayerOnly,
     };
 
@@ -132,6 +133,44 @@ contains the end time for the feature's time spans.
 .. seealso:: :py:func:`endField`
 
 .. seealso:: :py:func:`setStartField`
+%End
+
+    QString durationField() const;
+%Docstring
+Returns the name of the duration field, which
+contains the duration of the event.
+
+Units are specified by durationUnits()
+
+.. seealso:: :py:func:`setDurationField`
+
+.. seealso:: :py:func:`durationUnits`
+%End
+
+    void setDurationField( const QString &field );
+%Docstring
+Sets the name of the duration ``field``, which
+contains the duration of the event.
+
+Units are specified by setDurationUnits()
+
+.. seealso:: :py:func:`durationField`
+
+.. seealso:: :py:func:`setDurationUnits`
+%End
+
+    QgsUnitTypes::TemporalUnit durationUnits() const;
+%Docstring
+Returns the units of the event's duration.
+
+.. seealso:: :py:func:`setDurationUnits`
+%End
+
+    void setDurationUnits( QgsUnitTypes::TemporalUnit units );
+%Docstring
+Sets the ``units`` of the event's duration.
+
+.. seealso:: :py:func:`durationUnits`
 %End
 
     QString createFilterString( QgsVectorLayer *layer, const QgsDateTimeRange &range ) const;

--- a/python/core/auto_generated/qgsvectorlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/qgsvectorlayertemporalproperties.sip.in
@@ -40,6 +40,7 @@ The ``enabled`` argument specifies whether the temporal properties are initially
       ModeFeatureDateTimeInstantFromField,
       ModeFeatureDateTimeStartAndEndFromFields,
       ModeFeatureDateTimeStartAndDurationFromFields,
+      ModeFeatureDateTimeStartAndEndFromExpressions,
       ModeRedrawLayerOnly,
     };
 
@@ -133,6 +134,62 @@ contains the end time for the feature's time spans.
 .. seealso:: :py:func:`endField`
 
 .. seealso:: :py:func:`setStartField`
+%End
+
+    QString startExpression() const;
+%Docstring
+Returns the expression for the start time for the feature's time spans.
+
+.. warning::
+
+   This setting is only effective when mode() is
+   QgsVectorLayerTemporalProperties.ModeFeatureDateTimeStartAndEndFromExpressions
+
+.. seealso:: :py:func:`setStartExpression`
+
+.. seealso:: :py:func:`endExpression`
+%End
+
+    void setStartExpression( const QString &expression );
+%Docstring
+Sets the ``expression`` to use for the start time for the feature's time spans.
+
+.. warning::
+
+   This setting is only effective when mode() is
+   QgsVectorLayerTemporalProperties.ModeFeatureDateTimeStartAndEndFromExpressions
+
+.. seealso:: :py:func:`startExpression`
+
+.. seealso:: :py:func:`setEndExpression`
+%End
+
+    QString endExpression() const;
+%Docstring
+Returns the expression for the end time for the feature's time spans.
+
+.. warning::
+
+   This setting is only effective when mode() is
+   QgsVectorLayerTemporalProperties.ModeFeatureDateTimeStartAndEndFromExpressions
+
+.. seealso:: :py:func:`setEndExpression`
+
+.. seealso:: :py:func:`startExpression`
+%End
+
+    void setEndExpression( const QString &endExpression );
+%Docstring
+Sets the ``expression`` to use for the end time for the feature's time spans.
+
+.. warning::
+
+   This setting is only effective when mode() is
+   QgsVectorLayerTemporalProperties.ModeFeatureDateTimeStartAndEndFromExpressions
+
+.. seealso:: :py:func:`endExpression`
+
+.. seealso:: :py:func:`setStartExpression`
 %End
 
     QString durationField() const;

--- a/python/core/auto_generated/qgsvectorlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/qgsvectorlayertemporalproperties.sip.in
@@ -215,6 +215,32 @@ Units are specified by setDurationUnits()
 .. seealso:: :py:func:`setDurationUnits`
 %End
 
+    bool accumulateFeatures() const;
+%Docstring
+Returns ``True`` if features will be accumulated over time (i.e. all features which
+occur before or within the map's temporal range should be rendered).
+
+.. warning::
+
+   This setting is only effective when mode() is
+   QgsVectorLayerTemporalProperties.ModeFeatureDateTimeInstantFromField
+
+.. seealso:: :py:func:`setAccumulateFeatures`
+%End
+
+    void setAccumulateFeatures( bool accumulate );
+%Docstring
+Sets whether features will be accumulated over time (i.e. all features which
+occur before or within the map's temporal range should be rendered).
+
+.. warning::
+
+   This setting is only effective when mode() is
+   QgsVectorLayerTemporalProperties.ModeFeatureDateTimeInstantFromField
+
+.. seealso:: :py:func:`accumulateFeatures`
+%End
+
     QString createFilterString( QgsVectorLayer *layer, const QgsDateTimeRange &range ) const;
 %Docstring
 Creates a QGIS expression filter string for filtering features from ``layer``

--- a/python/gui/auto_generated/qgsvectorlayertemporalpropertieswidget.sip.in
+++ b/python/gui/auto_generated/qgsvectorlayertemporalpropertieswidget.sip.in
@@ -10,7 +10,7 @@
 
 
 
-class QgsVectorLayerTemporalPropertiesWidget : QWidget
+class QgsVectorLayerTemporalPropertiesWidget : QWidget, QgsExpressionContextGenerator
 {
 %Docstring
 A widget for configuring the temporal properties for a vector layer.
@@ -32,6 +32,9 @@ Constructor for QgsVectorLayerTemporalPropertiesWidget.
 %Docstring
 Save widget temporal properties inputs.
 %End
+
+    virtual QgsExpressionContext createExpressionContext() const;
+
 
 };
 /************************************************************************

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1159,12 +1159,12 @@ static QVariant fcnMakeDateTime( const QVariantList &values, const QgsExpression
 
 static QVariant fcnMakeInterval( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  const int years = QgsExpressionUtils::getIntValue( values.at( 0 ), parent );
-  const int months = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
-  const int weeks = QgsExpressionUtils::getIntValue( values.at( 2 ), parent );
-  const int days = QgsExpressionUtils::getIntValue( values.at( 3 ), parent );
-  const int hours = QgsExpressionUtils::getIntValue( values.at( 4 ), parent );
-  const int minutes = QgsExpressionUtils::getIntValue( values.at( 5 ), parent );
+  const double years = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
+  const double months = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
+  const double weeks = QgsExpressionUtils::getDoubleValue( values.at( 2 ), parent );
+  const double days = QgsExpressionUtils::getDoubleValue( values.at( 3 ), parent );
+  const double hours = QgsExpressionUtils::getDoubleValue( values.at( 4 ), parent );
+  const double minutes = QgsExpressionUtils::getDoubleValue( values.at( 5 ), parent );
   const double seconds = QgsExpressionUtils::getDoubleValue( values.at( 6 ), parent );
 
   return QVariant::fromValue( QgsInterval( years, months, weeks, days, hours, minutes, seconds ) );

--- a/src/core/qgsinterval.cpp
+++ b/src/core/qgsinterval.cpp
@@ -141,7 +141,7 @@ QgsInterval operator-( const QDateTime &dt1, const QDateTime &dt2 )
   return QgsInterval( mSeconds / 1000.0 );
 }
 
-QDateTime operator+( const QDateTime &start, QgsInterval interval )
+QDateTime operator+( const QDateTime &start, const QgsInterval &interval )
 {
   return start.addMSecs( static_cast<qint64>( interval.seconds() * 1000.0 ) );
 }

--- a/src/core/qgsvectorlayertemporalproperties.h
+++ b/src/core/qgsvectorlayertemporalproperties.h
@@ -61,6 +61,7 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
       ModeFeatureDateTimeInstantFromField, //!< Mode when features have a datetime instant taken from a single field
       ModeFeatureDateTimeStartAndEndFromFields, //!< Mode when features have separate fields for start and end times
       ModeFeatureDateTimeStartAndDurationFromFields, //!< Mode when features have a field for start time and a field for event duration
+      ModeFeatureDateTimeStartAndEndFromExpressions, //!< Mode when features use expressions for start and end times
       ModeRedrawLayerOnly, //!< Redraw the layer when temporal range changes, but don't apply any filtering. Useful when symbology or rule based renderer expressions depend on the time range.
     };
 
@@ -146,6 +147,50 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
      * \see setStartField()
      */
     void setEndField( const QString &field );
+
+    /**
+     * Returns the expression for the start time for the feature's time spans.
+     *
+     * \warning This setting is only effective when mode() is
+     * QgsVectorLayerTemporalProperties::ModeFeatureDateTimeStartAndEndFromExpressions
+     *
+     * \see setStartExpression()
+     * \see endExpression()
+     */
+    QString startExpression() const;
+
+    /**
+     * Sets the \a expression to use for the start time for the feature's time spans.
+     *
+     * \warning This setting is only effective when mode() is
+     * QgsVectorLayerTemporalProperties::ModeFeatureDateTimeStartAndEndFromExpressions
+     *
+     * \see startExpression()
+     * \see setEndExpression()
+     */
+    void setStartExpression( const QString &expression );
+
+    /**
+     * Returns the expression for the end time for the feature's time spans.
+     *
+     * \warning This setting is only effective when mode() is
+     * QgsVectorLayerTemporalProperties::ModeFeatureDateTimeStartAndEndFromExpressions
+     *
+     * \see setEndExpression()
+     * \see startExpression()
+     */
+    QString endExpression() const;
+
+    /**
+     * Sets the \a expression to use for the end time for the feature's time spans.
+     *
+     * \warning This setting is only effective when mode() is
+     * QgsVectorLayerTemporalProperties::ModeFeatureDateTimeStartAndEndFromExpressions
+     *
+     * \see endExpression()
+     * \see setStartExpression()
+     */
+    void setEndExpression( const QString &endExpression );
 
     /**
      * Returns the name of the duration field, which
@@ -277,6 +322,9 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
     double mFixedDuration = 0;
 
     bool mAccumulateFeatures = false;
+
+    QString mStartExpression;
+    QString mEndExpression;
 
 };
 

--- a/src/core/qgsvectorlayertemporalproperties.h
+++ b/src/core/qgsvectorlayertemporalproperties.h
@@ -24,6 +24,7 @@
 #include "qgsrange.h"
 #include "qgsmaplayertemporalproperties.h"
 #include "qgsrasterdataprovidertemporalcapabilities.h"
+#include "qgsunittypes.h"
 
 class QgsVectorLayer;
 class QgsFields;
@@ -59,6 +60,7 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
       ModeFixedTemporalRange = 0, //!< Mode when temporal properties have fixed start and end datetimes.
       ModeFeatureDateTimeInstantFromField, //!< Mode when features have a datetime instant taken from a single field
       ModeFeatureDateTimeStartAndEndFromFields, //!< Mode when features have separate fields for start and end times
+      ModeFeatureDateTimeStartAndDurationFromFields, //!< Mode when features have a field for start time and a field for event duration
       ModeRedrawLayerOnly, //!< Redraw the layer when temporal range changes, but don't apply any filtering. Useful when symbology or rule based renderer expressions depend on the time range.
     };
 
@@ -146,6 +148,42 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
     void setEndField( const QString &field );
 
     /**
+     * Returns the name of the duration field, which
+     * contains the duration of the event.
+     *
+     * Units are specified by durationUnits()
+     *
+     * \see setDurationField()
+     * \see durationUnits()
+     */
+    QString durationField() const;
+
+    /**
+     * Sets the name of the duration \a field, which
+     * contains the duration of the event.
+     *
+     * Units are specified by setDurationUnits()
+     *
+     * \see durationField()
+     * \see setDurationUnits()
+     */
+    void setDurationField( const QString &field );
+
+    /**
+     * Returns the units of the event's duration.
+     *
+     * \see setDurationUnits()
+     */
+    QgsUnitTypes::TemporalUnit durationUnits() const;
+
+    /**
+     * Sets the \a units of the event's duration.
+     *
+     * \see durationUnits()
+     */
+    void setDurationUnits( QgsUnitTypes::TemporalUnit units );
+
+    /**
      * Creates a QGIS expression filter string for filtering features from \a layer
      * to those within the specified time \a range.
      *
@@ -179,6 +217,8 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
 
     QString mStartFieldName;
     QString mEndFieldName;
+    QString mDurationFieldName;
+    QgsUnitTypes::TemporalUnit mDurationUnit = QgsUnitTypes::TemporalMinutes;
 
 };
 

--- a/src/core/qgsvectorlayertemporalproperties.h
+++ b/src/core/qgsvectorlayertemporalproperties.h
@@ -216,6 +216,28 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
     void setFixedDuration( double duration );
 
     /**
+     * Returns TRUE if features will be accumulated over time (i.e. all features which
+     * occur before or within the map's temporal range should be rendered).
+     *
+     * \warning This setting is only effective when mode() is
+     * QgsVectorLayerTemporalProperties::ModeFeatureDateTimeInstantFromField
+     *
+     * \see setAccumulateFeatures()
+     */
+    bool accumulateFeatures() const;
+
+    /**
+     * Sets whether features will be accumulated over time (i.e. all features which
+     * occur before or within the map's temporal range should be rendered).
+     *
+     * \warning This setting is only effective when mode() is
+     * QgsVectorLayerTemporalProperties::ModeFeatureDateTimeInstantFromField
+     *
+     * \see accumulateFeatures()
+     */
+    void setAccumulateFeatures( bool accumulate );
+
+    /**
      * Creates a QGIS expression filter string for filtering features from \a layer
      * to those within the specified time \a range.
      *
@@ -253,6 +275,8 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
     QgsUnitTypes::TemporalUnit mDurationUnit = QgsUnitTypes::TemporalMinutes;
 
     double mFixedDuration = 0;
+
+    bool mAccumulateFeatures = false;
 
 };
 

--- a/src/core/qgsvectorlayertemporalproperties.h
+++ b/src/core/qgsvectorlayertemporalproperties.h
@@ -153,6 +153,9 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
      *
      * Units are specified by durationUnits()
      *
+     * \warning This setting is only effective when mode() is
+     * QgsVectorLayerTemporalProperties::ModeFeatureDateTimeStartAndDurationFromFields
+     *
      * \see setDurationField()
      * \see durationUnits()
      */
@@ -163,6 +166,9 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
      * contains the duration of the event.
      *
      * Units are specified by setDurationUnits()
+     *
+     * \warning This setting is only effective when mode() is
+     * QgsVectorLayerTemporalProperties::ModeFeatureDateTimeStartAndDurationFromFields
      *
      * \see durationField()
      * \see setDurationUnits()
@@ -182,6 +188,32 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
      * \see durationUnits()
      */
     void setDurationUnits( QgsUnitTypes::TemporalUnit units );
+
+    /**
+     * Returns the fixed duration length, which contains the duration of the event.
+     *
+     * Units are specified by durationUnits()
+     *
+     * \warning This setting is only effective when mode() is
+     * QgsVectorLayerTemporalProperties::ModeFeatureDateTimeInstantFromField
+     *
+     * \see setFixedDuration()
+     * \see durationUnits()
+     */
+    double fixedDuration() const;
+
+    /**
+     * Sets the fixed event \a duration, which contains the duration of the event.
+     *
+     * Units are specified by setDurationUnits()
+     *
+     * \warning This setting is only effective when mode() is
+     * QgsVectorLayerTemporalProperties::ModeFeatureDateTimeInstantFromField
+     *
+     * \see fixedDuration()
+     * \see setDurationUnits()
+     */
+    void setFixedDuration( double duration );
 
     /**
      * Creates a QGIS expression filter string for filtering features from \a layer
@@ -219,6 +251,8 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
     QString mEndFieldName;
     QString mDurationFieldName;
     QgsUnitTypes::TemporalUnit mDurationUnit = QgsUnitTypes::TemporalMinutes;
+
+    double mFixedDuration = 0;
 
 };
 

--- a/src/gui/qgsvectorlayertemporalpropertieswidget.cpp
+++ b/src/gui/qgsvectorlayertemporalpropertieswidget.cpp
@@ -34,6 +34,7 @@ QgsVectorLayerTemporalPropertiesWidget::QgsVectorLayerTemporalPropertiesWidget( 
   mModeComboBox->addItem( tr( "Fixed Time Range" ), QgsVectorLayerTemporalProperties::ModeFixedTemporalRange );
   mModeComboBox->addItem( tr( "Single Field with Date/Time" ), QgsVectorLayerTemporalProperties::ModeFeatureDateTimeInstantFromField );
   mModeComboBox->addItem( tr( "Separate Fields for Start and End Date/Time" ), QgsVectorLayerTemporalProperties::ModeFeatureDateTimeStartAndEndFromFields );
+  mModeComboBox->addItem( tr( "Separate Fields for Start and Event Duration" ), QgsVectorLayerTemporalProperties::ModeFeatureDateTimeStartAndDurationFromFields );
   mModeComboBox->addItem( tr( "Redraw Layer Only" ), QgsVectorLayerTemporalProperties::ModeRedrawLayerOnly );
 
   const QgsVectorLayerTemporalProperties *properties = qobject_cast< QgsVectorLayerTemporalProperties * >( layer->temporalProperties() );
@@ -54,21 +55,45 @@ QgsVectorLayerTemporalPropertiesWidget::QgsVectorLayerTemporalPropertiesWidget( 
   mSingleFieldComboBox->setLayer( layer );
   mStartFieldComboBox->setLayer( layer );
   mEndFieldComboBox->setLayer( layer );
+  mDurationStartFieldComboBox->setLayer( layer );
+  mDurationFieldComboBox->setLayer( layer );
   mSingleFieldComboBox->setFilters( QgsFieldProxyModel::DateTime | QgsFieldProxyModel::Date );
   mStartFieldComboBox->setFilters( QgsFieldProxyModel::DateTime | QgsFieldProxyModel::Date );
   mStartFieldComboBox->setAllowEmptyFieldName( true );
   mEndFieldComboBox->setFilters( QgsFieldProxyModel::DateTime | QgsFieldProxyModel::Date );
   mEndFieldComboBox->setAllowEmptyFieldName( true );
+  mDurationStartFieldComboBox->setFilters( QgsFieldProxyModel::DateTime | QgsFieldProxyModel::Date );
+  mDurationFieldComboBox->setFilters( QgsFieldProxyModel::Numeric );
+
+  for ( QgsUnitTypes::TemporalUnit u :
+        {
+          QgsUnitTypes::TemporalMilliseconds,
+          QgsUnitTypes::TemporalSeconds,
+          QgsUnitTypes::TemporalMinutes,
+          QgsUnitTypes::TemporalHours,
+          QgsUnitTypes::TemporalDays,
+          QgsUnitTypes::TemporalWeeks,
+          QgsUnitTypes::TemporalMonths,
+          QgsUnitTypes::TemporalYears,
+          QgsUnitTypes::TemporalDecades,
+          QgsUnitTypes::TemporalCenturies
+        } )
+  {
+    mDurationUnitsComboBox->addItem( QgsUnitTypes::toString( u ), u );
+  }
 
   if ( !properties->startField().isEmpty() )
   {
     mSingleFieldComboBox->setField( properties->startField() );
     mStartFieldComboBox->setField( properties->startField() );
+    mDurationStartFieldComboBox->setField( properties->startField() );
   }
   if ( !properties->endField().isEmpty() )
   {
     mEndFieldComboBox->setField( properties->endField() );
   }
+  mDurationFieldComboBox->setField( properties->durationField() );
+  mDurationUnitsComboBox->setCurrentIndex( mDurationUnitsComboBox->findData( properties->durationUnits() ) );
 }
 
 void QgsVectorLayerTemporalPropertiesWidget::saveTemporalProperties()
@@ -94,7 +119,13 @@ void QgsVectorLayerTemporalPropertiesWidget::saveTemporalProperties()
     case QgsVectorLayerTemporalProperties::ModeFeatureDateTimeStartAndEndFromFields:
       properties->setStartField( mStartFieldComboBox->currentField() );
       break;
+
+    case QgsVectorLayerTemporalProperties::ModeFeatureDateTimeStartAndDurationFromFields:
+      properties->setStartField( mDurationStartFieldComboBox->currentField() );
+      break;
   }
 
   properties->setEndField( mEndFieldComboBox->currentField() );
+  properties->setDurationField( mDurationFieldComboBox->currentField() );
+  properties->setDurationUnits( static_cast< QgsUnitTypes::TemporalUnit >( mDurationUnitsComboBox->currentData().toInt() ) );
 }

--- a/src/gui/qgsvectorlayertemporalpropertieswidget.cpp
+++ b/src/gui/qgsvectorlayertemporalpropertieswidget.cpp
@@ -102,6 +102,15 @@ QgsVectorLayerTemporalPropertiesWidget::QgsVectorLayerTemporalPropertiesWidget( 
   mDurationFieldComboBox->setField( properties->durationField() );
   mDurationUnitsComboBox->setCurrentIndex( mDurationUnitsComboBox->findData( properties->durationUnits() ) );
   mFixedDurationUnitsComboBox->setCurrentIndex( mDurationUnitsComboBox->findData( properties->durationUnits() ) );
+
+  mAccumulateCheckBox->setChecked( properties->accumulateFeatures() );
+  mFixedDurationUnitsComboBox->setEnabled( !mAccumulateCheckBox->isChecked() );
+  mFixedDurationSpinBox->setEnabled( !mAccumulateCheckBox->isChecked() );
+  connect( mAccumulateCheckBox, &QCheckBox::toggled, this, [ = ]( bool checked )
+  {
+    mFixedDurationUnitsComboBox->setEnabled( !checked );
+    mFixedDurationSpinBox->setEnabled( !checked );
+  } );
 }
 
 void QgsVectorLayerTemporalPropertiesWidget::saveTemporalProperties()
@@ -139,4 +148,5 @@ void QgsVectorLayerTemporalPropertiesWidget::saveTemporalProperties()
   properties->setEndField( mEndFieldComboBox->currentField() );
   properties->setDurationField( mDurationFieldComboBox->currentField() );
   properties->setFixedDuration( mFixedDurationSpinBox->value() );
+  properties->setAccumulateFeatures( mAccumulateCheckBox->isChecked() );
 }

--- a/src/gui/qgsvectorlayertemporalpropertieswidget.h
+++ b/src/gui/qgsvectorlayertemporalpropertieswidget.h
@@ -19,6 +19,7 @@
 #define QGSVECTORLAYERTEMPORALPROPERTIESWIDGET_H
 
 #include "ui_qgsvectorlayertemporalpropertieswidgetbase.h"
+#include "qgsexpressioncontextgenerator.h"
 #include "qgis_gui.h"
 
 class QgsVectorLayer;
@@ -30,7 +31,7 @@ class QgsVectorLayer;
  *
  * \since QGIS 3.14
  */
-class GUI_EXPORT QgsVectorLayerTemporalPropertiesWidget : public QWidget, private Ui::QgsVectorLayerTemporalPropertiesWidgetBase
+class GUI_EXPORT QgsVectorLayerTemporalPropertiesWidget : public QWidget, public QgsExpressionContextGenerator, private Ui::QgsVectorLayerTemporalPropertiesWidgetBase
 {
     Q_OBJECT
   public:
@@ -44,6 +45,8 @@ class GUI_EXPORT QgsVectorLayerTemporalPropertiesWidget : public QWidget, privat
      * Save widget temporal properties inputs.
      */
     void saveTemporalProperties();
+
+    QgsExpressionContext createExpressionContext() const override;
 
   private:
 

--- a/src/ui/qgsvectorlayertemporalpropertieswidgetbase.ui
+++ b/src/ui/qgsvectorlayertemporalpropertieswidgetbase.ui
@@ -94,45 +94,11 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
           <item row="1" column="0" colspan="2">
            <widget class="QStackedWidget" name="mStackedWidget">
             <property name="currentIndex">
-             <number>0</number>
+             <number>1</number>
             </property>
             <widget class="QWidget" name="page_3">
              <layout class="QGridLayout" name="gridLayout_6">
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_5">
-                <property name="text">
-                 <string>End date</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QgsDateTimeEdit" name="mEndTemporalDateTimeEdit">
-                <property name="displayFormat">
-                 <string>M/d/yyyy h:mm AP</string>
-                </property>
-                <property name="timeSpec">
-                 <enum>Qt::UTC</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_6">
-                <property name="text">
-                 <string>Start date</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QgsDateTimeEdit" name="mStartTemporalDateTimeEdit">
-                <property name="displayFormat">
-                 <string>M/d/yyyy h:mm AP</string>
-                </property>
-                <property name="timeSpec">
-                 <enum>Qt::UTC</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
+              <item row="3" column="0">
                <spacer name="verticalSpacer_3">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>
@@ -145,21 +111,75 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
                 </property>
                </spacer>
               </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_6">
+                <property name="text">
+                 <string>Start date</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QgsDateTimeEdit" name="mStartTemporalDateTimeEdit">
+                <property name="displayFormat">
+                 <string>M/d/yyyy h:mm AP</string>
+                </property>
+                <property name="timeSpec">
+                 <enum>Qt::UTC</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QgsDateTimeEdit" name="mEndTemporalDateTimeEdit">
+                <property name="displayFormat">
+                 <string>M/d/yyyy h:mm AP</string>
+                </property>
+                <property name="timeSpec">
+                 <enum>Qt::UTC</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_5">
+                <property name="text">
+                 <string>End date</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0" colspan="2">
+               <widget class="QLabel" name="label_14">
+                <property name="text">
+                 <string>&lt;p&gt;&lt;b&gt;&lt;i&gt;All&lt;/i&gt; features from the layer will be rendered whenever the map's temporal range overlaps the range defined below.&lt;/b&gt;&lt;/p&gt;</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
              </layout>
             </widget>
             <widget class="QWidget" name="page">
-             <layout class="QGridLayout" name="gridLayout_4">
-              <item row="0" column="0">
+             <layout class="QGridLayout" name="gridLayout_4" columnstretch="0,0,0">
+              <item row="2" column="2">
+               <widget class="QComboBox" name="mFixedDurationUnitsComboBox"/>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_11">
+                <property name="text">
+                 <string>Event duration</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
                <widget class="QLabel" name="label_2">
                 <property name="text">
                  <string>Field</string>
                 </property>
                </widget>
               </item>
-              <item row="0" column="1">
+              <item row="1" column="1" colspan="2">
                <widget class="QgsFieldComboBox" name="mSingleFieldComboBox"/>
               </item>
-              <item row="1" column="0">
+              <item row="5" column="0">
                <spacer name="verticalSpacer">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>
@@ -172,31 +192,58 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
                 </property>
                </spacer>
               </item>
+              <item row="2" column="1">
+               <widget class="QgsDoubleSpinBox" name="mFixedDurationSpinBox">
+                <property name="maximum">
+                 <double>9999999999.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0" colspan="3">
+               <widget class="QLabel" name="label_13">
+                <property name="text">
+                 <string>&lt;p&gt;Event durations in &lt;i&gt;Months&lt;/i&gt; assume a fixed 30-day month length, and durations in &lt;i&gt;Years&lt;/i&gt;, &lt;i&gt;Decades&lt;/i&gt; or &lt;i&gt;Centuries&lt;/i&gt; assume a 365.25-day year length.&lt;/p&gt;</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0" colspan="3">
+               <widget class="QLabel" name="label_28">
+                <property name="text">
+                 <string>&lt;p&gt;&lt;b&gt;Individual features from the layer will be rendered if the field's value falls within the map's temporal range.&lt;/b&gt;&lt;/p&gt;</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
              </layout>
             </widget>
             <widget class="QWidget" name="page_2">
              <layout class="QGridLayout" name="gridLayout_5">
-              <item row="0" column="0">
+              <item row="2" column="1">
+               <widget class="QgsFieldComboBox" name="mEndFieldComboBox"/>
+              </item>
+              <item row="1" column="1">
+               <widget class="QgsFieldComboBox" name="mStartFieldComboBox"/>
+              </item>
+              <item row="1" column="0">
                <widget class="QLabel" name="label_3">
                 <property name="text">
                  <string>Start field</string>
                 </property>
                </widget>
               </item>
-              <item row="0" column="1">
-               <widget class="QgsFieldComboBox" name="mStartFieldComboBox"/>
-              </item>
-              <item row="1" column="1">
-               <widget class="QgsFieldComboBox" name="mEndFieldComboBox"/>
-              </item>
-              <item row="1" column="0">
+              <item row="2" column="0">
                <widget class="QLabel" name="label_4">
                 <property name="text">
                  <string>End field</string>
                 </property>
                </widget>
               </item>
-              <item row="2" column="0">
+              <item row="3" column="0">
                <spacer name="verticalSpacer_2">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>
@@ -209,21 +256,47 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
                 </property>
                </spacer>
               </item>
+              <item row="0" column="0" colspan="2">
+               <widget class="QLabel" name="label_29">
+                <property name="text">
+                 <string>&lt;p&gt;&lt;b&gt;Individual features from the layer will be rendered if the range specified by the &lt;i&gt;Start&lt;/i&gt; and &lt;i&gt;End&lt;/i&gt; fields overlaps the map's temporal range.&lt;/b&gt;&lt;/p&gt;</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
              </layout>
             </widget>
             <widget class="QWidget" name="page_5">
              <layout class="QGridLayout" name="gridLayout_7">
+              <item row="2" column="1">
+               <widget class="QgsFieldComboBox" name="mDurationFieldComboBox"/>
+              </item>
               <item row="1" column="0">
-               <widget class="QLabel" name="label_9">
+               <widget class="QLabel" name="label_8">
                 <property name="text">
-                 <string>Event duration field</string>
+                 <string>Start field</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0" colspan="2">
+               <widget class="QLabel" name="label_12">
+                <property name="text">
+                 <string>&lt;p&gt;Event durations in &lt;i&gt;Months&lt;/i&gt; assume a fixed 30-day month length, and durations in &lt;i&gt;Years&lt;/i&gt;, &lt;i&gt;Decades&lt;/i&gt; or &lt;i&gt;Centuries&lt;/i&gt; assume a 365.25-day year length.&lt;/p&gt;</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
                 </property>
                </widget>
               </item>
               <item row="1" column="1">
-               <widget class="QgsFieldComboBox" name="mDurationFieldComboBox"/>
+               <widget class="QgsFieldComboBox" name="mDurationStartFieldComboBox"/>
               </item>
-              <item row="3" column="0">
+              <item row="3" column="1">
+               <widget class="QComboBox" name="mDurationUnitsComboBox"/>
+              </item>
+              <item row="5" column="0">
                <spacer name="verticalSpacer_5">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>
@@ -236,25 +309,29 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
                 </property>
                </spacer>
               </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_8">
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_9">
                 <property name="text">
-                 <string>Start field</string>
+                 <string>Event duration field</string>
                 </property>
                </widget>
               </item>
-              <item row="0" column="1">
-               <widget class="QgsFieldComboBox" name="mDurationStartFieldComboBox"/>
-              </item>
-              <item row="2" column="0">
+              <item row="3" column="0">
                <widget class="QLabel" name="label_10">
                 <property name="text">
                  <string>Event duration units</string>
                 </property>
                </widget>
               </item>
-              <item row="2" column="1">
-               <widget class="QComboBox" name="mDurationUnitsComboBox"/>
+              <item row="0" column="0" colspan="2">
+               <widget class="QLabel" name="label_30">
+                <property name="text">
+                 <string>&lt;p&gt;&lt;b&gt;Individual features from the layer will be rendered if the temporal range defined by the &lt;i&gt;Start&lt;/i&gt; and &lt;i&gt;Event Duration&lt;/i&gt; fields overlaps the map's temporal range.&lt;/b&gt;&lt;/p&gt;</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
               </item>
              </layout>
             </widget>
@@ -336,6 +413,11 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
    <class>QgsFieldComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsfieldcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsvectorlayertemporalpropertieswidgetbase.ui
+++ b/src/ui/qgsvectorlayertemporalpropertieswidgetbase.ui
@@ -94,7 +94,7 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
           <item row="1" column="0" colspan="2">
            <widget class="QStackedWidget" name="mStackedWidget">
             <property name="currentIndex">
-             <number>1</number>
+             <number>4</number>
             </property>
             <widget class="QWidget" name="page_3">
              <layout class="QGridLayout" name="gridLayout_6">
@@ -269,7 +269,8 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
               <item row="0" column="0" colspan="2">
                <widget class="QLabel" name="label_29">
                 <property name="text">
-                 <string>&lt;p&gt;&lt;b&gt;Individual features from the layer will be rendered if the range specified by the &lt;i&gt;Start&lt;/i&gt; and &lt;i&gt;End&lt;/i&gt; fields overlaps the map's temporal range.&lt;/b&gt;&lt;/p&gt;</string>
+                 <string>&lt;p&gt;&lt;b&gt;Individual features from the layer will be rendered if the range specified by the &lt;i&gt;Start&lt;/i&gt; and &lt;i&gt;End&lt;/i&gt; fields overlaps the map's temporal range.&lt;/b&gt;&lt;/p&gt;
+&lt;p&gt;If the &lt;i&gt;Start&lt;/i&gt; field choice is empty, then features will be treated as having no start date. Similarly if the &lt;i&gt;End&lt;/i&gt; field choice is empty, then features will be treated as having no end date.&lt;/p&gt;</string>
                 </property>
                 <property name="wordWrap">
                  <bool>true</bool>
@@ -342,6 +343,55 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
                  <bool>true</bool>
                 </property>
                </widget>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="page_11">
+             <layout class="QGridLayout" name="gridLayout_12" columnstretch="0,1" columnminimumwidth="0,0">
+              <item row="0" column="0" colspan="2">
+               <widget class="QLabel" name="label_33">
+                <property name="text">
+                 <string>&lt;p&gt;&lt;b&gt;Individual features from the layer will be rendered if the range specified by the &lt;i&gt;Start&lt;/i&gt; and &lt;i&gt;End&lt;/i&gt; expressions overlaps the map's temporal range.&lt;/b&gt;&lt;/p&gt;
+&lt;p&gt;If the &lt;i&gt;Start&lt;/i&gt; expression choice is empty, then features will be treated as having no start date. Similarly if the &lt;i&gt;End&lt;/i&gt; expression choice is empty, then features will be treated as having no end date.&lt;/p&gt;
+&lt;p&gt;The &lt;i&gt;Start&lt;/i&gt; and &lt;i&gt;End&lt;/i&gt; expressions must return date or datetime values.&lt;/p&gt;</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_31">
+                <property name="text">
+                 <string>End expression</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_32">
+                <property name="text">
+                 <string>Start expression</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <spacer name="verticalSpacer_11">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="1" column="1">
+               <widget class="QgsFieldExpressionWidget" name="mStartExpressionWidget" native="true"/>
+              </item>
+              <item row="2" column="1">
+               <widget class="QgsFieldExpressionWidget" name="mEndExpressionWidget" native="true"/>
               </item>
              </layout>
             </widget>
@@ -428,6 +478,12 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFieldExpressionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfieldexpressionwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsvectorlayertemporalpropertieswidgetbase.ui
+++ b/src/ui/qgsvectorlayertemporalpropertieswidgetbase.ui
@@ -211,6 +211,53 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
               </item>
              </layout>
             </widget>
+            <widget class="QWidget" name="page_5">
+             <layout class="QGridLayout" name="gridLayout_7">
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_9">
+                <property name="text">
+                 <string>Event duration field</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QgsFieldComboBox" name="mDurationFieldComboBox"/>
+              </item>
+              <item row="3" column="0">
+               <spacer name="verticalSpacer_5">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_8">
+                <property name="text">
+                 <string>Start field</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QgsFieldComboBox" name="mDurationStartFieldComboBox"/>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_10">
+                <property name="text">
+                 <string>Event duration units</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QComboBox" name="mDurationUnitsComboBox"/>
+              </item>
+             </layout>
+            </widget>
             <widget class="QWidget" name="page_4">
              <layout class="QVBoxLayout" name="verticalLayout">
               <item>

--- a/src/ui/qgsvectorlayertemporalpropertieswidgetbase.ui
+++ b/src/ui/qgsvectorlayertemporalpropertieswidgetbase.ui
@@ -219,6 +219,16 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
                 </property>
                </widget>
               </item>
+              <item row="4" column="0" colspan="3">
+               <widget class="QCheckBox" name="mAccumulateCheckBox">
+                <property name="toolTip">
+                 <string>If checked, then features will be shown whenever their defined temporal value falls within or before the map's temporal range</string>
+                </property>
+                <property name="text">
+                 <string>Accumulate features over time</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </widget>
             <widget class="QWidget" name="page_2">

--- a/tests/src/python/test_qgsvectorlayertemporalproperties.py
+++ b/tests/src/python/test_qgsvectorlayertemporalproperties.py
@@ -38,6 +38,7 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         props.setEndField('end')
         props.setDurationField('duration')
         props.setDurationUnits(QgsUnitTypes.TemporalWeeks)
+        props.setFixedDuration(5.6)
 
         # save to xml
         doc = QDomDocument("testdoc")
@@ -54,6 +55,7 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         self.assertEqual(props2.endField(), props.endField())
         self.assertEqual(props2.durationField(), props.durationField())
         self.assertEqual(props2.durationUnits(), props.durationUnits())
+        self.assertEqual(props2.fixedDuration(), props.fixedDuration())
 
     def testModeFromProvider(self):
         caps = QgsVectorDataProviderTemporalCapabilities()
@@ -158,6 +160,23 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
 
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeEnd=False)
         self.assertEqual(props.createFilterString(layer, range), '("start_field" >= make_datetime(2019,3,4,11,12,13) AND "start_field" < make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
+
+        # with fixed duration
+        props.setFixedDuration(3)
+        props.setDurationUnits(QgsUnitTypes.TemporalDays)
+        range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)))
+        self.assertEqual(props.createFilterString(layer, range), '("start_field" >= make_datetime(2019,3,1,11,12,13) AND "start_field" <= make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
+
+        range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeBeginning=False)
+        self.assertEqual(props.createFilterString(layer, range), '("start_field" > make_datetime(2019,3,1,11,12,13) AND "start_field" <= make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
+
+        range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeEnd=False)
+        self.assertEqual(props.createFilterString(layer, range), '("start_field" >= make_datetime(2019,3,1,11,12,13) AND "start_field" < make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
+
+        props.setDurationUnits(QgsUnitTypes.TemporalMinutes)
+        range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)))
+        self.assertEqual(props.createFilterString(layer, range),
+                         '("start_field" >= make_datetime(2019,3,4,11,9,13) AND "start_field" <= make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
 
     def testDualFieldMode(self):
         layer = QgsVectorLayer("Point?field=fldtxt:string&field=fldint:integer&field=start_field:datetime&field=end_field:datetime", "test", "memory")


### PR DESCRIPTION
Allows temporal filtering of layers which store a start time in one
field and a duration in a different numeric field. Users are given
a choice of temporal units for the duration (e.g. seconds, days, etc)
