### PR TITLE
Commit changes from read only fields on the attribute form

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -356,7 +356,7 @@ bool QgsAttributeForm::saveEdits()
         for ( int i = 0; i < dstVars.count(); i++ )
         {
 
-          if ( !qgsVariantEqual( dstVars[i], srcVars[i] ) && srcVars[i].isValid() && fieldIsEditable( fieldIndexes[i] ) )
+          if ( !qgsVariantEqual( dstVars[i], srcVars[i] ) && srcVars[i].isValid() )
           {
             dst[fieldIndexes[i]] = srcVars[i];
 


### PR DESCRIPTION
Read only fields can be calculated from default value expressions and in this case should be committed too.

Fixes #36360

Does someone know why we should *not* do this - and why this check was in place?
Read only fields are not user editable, I assume this is the main thing to make a field read only, the read only configuration comes from the attribute form configuration.
I would prefer not to backport this commit, it makes me uneasy to remove a check that looks like it has been put there on purpose. But I just can't find a good reason for it.