### PR TITLE
Fix misalignment of rasters with RPC (fixes #35796)

### DIFF
--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -2666,9 +2666,18 @@ void QgsGdalProvider::initBaseDataset()
   {
     QgsLogger::warning( QStringLiteral( "Creating Warped VRT." ) );
 
-    mGdalDataset =
-      GDALAutoCreateWarpedVRT( mGdalBaseDataset, nullptr, nullptr,
-                               GRA_NearestNeighbour, 0.2, nullptr );
+    if ( GDALGetMetadata( mGdalBaseDataset, "RPC" ) )
+    {
+      mGdalDataset =
+        QgsGdalUtils::rpcAwareAutoCreateWarpedVrt( mGdalBaseDataset, nullptr, nullptr,
+            GRA_NearestNeighbour, 0.2, nullptr );
+    }
+    else
+    {
+      mGdalDataset =
+        GDALAutoCreateWarpedVRT( mGdalBaseDataset, nullptr, nullptr,
+                                 GRA_NearestNeighbour, 0.2, nullptr );
+    }
 
     if ( !mGdalDataset )
     {

--- a/src/core/qgsgdalutils.h
+++ b/src/core/qgsgdalutils.h
@@ -100,6 +100,22 @@ class CORE_EXPORT QgsGdalUtils
      */
     static gdal::dataset_unique_ptr imageToMemoryDataset( const QImage &image );
 
+    /**
+     * This is a copy of GDALAutoCreateWarpedVRT optimized for imagery using RPC georeferencing
+     * that also sets RPC_HEIGHT in GDALCreateGenImgProjTransformer2 based on HEIGHT_OFF.
+     * By default GDAL would assume that the imagery has zero elevation - if that is not the case,
+     * the image would not be shown in the correct location.
+     *
+     * \since QGIS 3.14
+     */
+    static GDALDatasetH rpcAwareAutoCreateWarpedVrt(
+      GDALDatasetH hSrcDS,
+      const char *pszSrcWKT,
+      const char *pszDstWKT,
+      GDALResampleAlg eResampleAlg,
+      double dfMaxError,
+      const GDALWarpOptions *psOptionsIn );
+
     friend class TestQgsGdalUtils;
 };
 


### PR DESCRIPTION
By default GDAL would assume that the imagery has zero elevation - if that is not the case, the image would not be shown in the correct location. Fortunately we can pass RPC_HEIGHT to GDAL to use given value as the fixed elevation for the whole image.

We try to use HEIGHT_OFF coefficient ("Geodetic Height Offset") as an estimate for elevation (it seems that ENVI software does that as well). In the future we may want to use also RPC_DEM for an even more precise georeferencing.

https://gdal.org/development/rfc/rfc22_rpc.html

@rouault Would you mind having a look at this?

- I have not found a way how to pass RPC_HEIGHT to GDALAutoCreateWarpedVRT so I ended up creating a RPC-aware copy of it within QGIS code
- I do not have much experience with RPC-based rasters - I am only fixing code where QGIS does not behave correctly according to user's expectations on some sample data I got. Is it "safe" to always use HEIGHT_OFF for RPC_HEIGHT? Or do we need some way for users to manually override RPC_HEIGHT? (I am now ignoring the possibility to have DEM specified for even better accuracy)