### PR TITLE
Do not show error message if user cancels save as dialog

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -16023,10 +16023,6 @@ void QgisApp::populateProjectStorageMenu( QMenu *menu, const bool saving )
         {
           addProject( uri );
         }
-        else
-        {
-          messageBar()->pushCritical( tr( "Project load failed" ), tr( "The project could not be loaded because the project storage URI is empty." ) );
-        }
       } );
     }
   }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -16012,10 +16012,6 @@ void QgisApp::populateProjectStorageMenu( QMenu *menu, const bool saving )
         {
           saveProjectToProjectStorage( uri );
         }
-        else
-        {
-          messageBar()->pushCritical( tr( "Project save failed" ), tr( "The project could not be saved because the project storage URI is empty." ) );
-        }
       } );
     }
     else


### PR DESCRIPTION
The save to database providers return an null QString() if the dialog is cancelled,
as documented in qgsprojectstorageprovider.h.
No reason to show an error message for cancelling this dialog.

Old behavior:
![Peek 2020-05-13 15-01](https://user-images.githubusercontent.com/588407/81815730-a48b9e80-952a-11ea-8f0f-3891bacda51d.gif)
