### PR TITLE
Vector tile layer - part 9 (labeling gui)

### DIFF
--- a/python/core/auto_generated/vectortile/qgsvectortilebasiclabeling.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilebasiclabeling.sip.in
@@ -146,6 +146,14 @@ Sets list of styles of the renderer
 %Docstring
 Returns list of styles of the renderer
 %End
+    void setStyle( int index, const QgsVectorTileBasicLabelingStyle &style );
+%Docstring
+Updates style definition at the paricular index of the list (the index must be in interval [0,N-1] otherwise this function does nothing)
+%End
+    QgsVectorTileBasicLabelingStyle style( int index ) const;
+%Docstring
+Returns style definition at the particular index
+%End
 
 };
 

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -36,6 +36,7 @@
 #include "qgsstyle.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectortilelayer.h"
+#include "qgsvectortilebasiclabelingwidget.h"
 #include "qgsvectortilebasicrendererwidget.h"
 #include "qgsmeshlayer.h"
 #include "qgsproject.h"
@@ -233,7 +234,10 @@ void QgsLayerStylingWidget::setLayer( QgsMapLayer *layer )
       symbolItem->setData( Qt::UserRole, Symbology );
       symbolItem->setToolTip( tr( "Symbology" ) );
       mOptionsListWidget->addItem( symbolItem );
-
+      QListWidgetItem *labelItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "labelingSingle.svg" ) ), QString() );
+      labelItem->setData( Qt::UserRole, VectorLabeling );
+      labelItem->setToolTip( tr( "Labels" ) );
+      mOptionsListWidget->addItem( labelItem );
       break;
     }
 
@@ -624,6 +628,14 @@ void QgsLayerStylingWidget::updateCurrentWidgetLayer()
             mVectorTileStyleWidget->setDockMode( true );
             connect( mVectorTileStyleWidget, &QgsPanelWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
             mWidgetStack->setMainPanel( mVectorTileStyleWidget );
+            break;
+          }
+          case 1: // Labeling
+          {
+            mVectorTileLabelingWidget = new QgsVectorTileBasicLabelingWidget( vtLayer, mMapCanvas, mMessageBar, mWidgetStack );
+            mVectorTileLabelingWidget->setDockMode( true );
+            connect( mVectorTileLabelingWidget, &QgsPanelWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
+            mWidgetStack->setMainPanel( mVectorTileLabelingWidget );
             break;
           }
           default:

--- a/src/app/qgslayerstylingwidget.h
+++ b/src/app/qgslayerstylingwidget.h
@@ -45,6 +45,7 @@ class QgsVectorLayer3DRendererWidget;
 class QgsMeshLayer3DRendererWidget;
 class QgsMessageBar;
 class QgsVectorTileBasicRendererWidget;
+class QgsVectorTileBasicLabelingWidget;
 
 class APP_EXPORT QgsLayerStyleManagerWidgetFactory : public QgsMapLayerConfigWidgetFactory
 {
@@ -151,6 +152,7 @@ class APP_EXPORT QgsLayerStylingWidget : public QWidget, private Ui::QgsLayerSty
     QgsRendererRasterPropertiesWidget *mRasterStyleWidget = nullptr;
     QgsRendererMeshPropertiesWidget *mMeshStyleWidget = nullptr;
     QgsVectorTileBasicRendererWidget *mVectorTileStyleWidget = nullptr;
+    QgsVectorTileBasicLabelingWidget *mVectorTileLabelingWidget = nullptr;
     QList<QgsMapLayerConfigWidgetFactory *> mPageFactories;
     QMap<int, QgsMapLayerConfigWidgetFactory *> mUserPages;
     QgsLayerStyleManagerWidgetFactory *mStyleManagerFactory = nullptr;

--- a/src/core/vectortile/qgsvectortilebasiclabeling.h
+++ b/src/core/vectortile/qgsvectortilebasiclabeling.h
@@ -119,6 +119,10 @@ class CORE_EXPORT QgsVectorTileBasicLabeling : public QgsVectorTileLabeling
     void setStyles( const QList<QgsVectorTileBasicLabelingStyle> &styles ) { mStyles = styles; }
     //! Returns list of styles of the renderer
     QList<QgsVectorTileBasicLabelingStyle> styles() const { return mStyles; }
+    //! Updates style definition at the paricular index of the list (the index must be in interval [0,N-1] otherwise this function does nothing)
+    void setStyle( int index, const QgsVectorTileBasicLabelingStyle &style ) { mStyles[index] = style; }
+    //! Returns style definition at the particular index
+    QgsVectorTileBasicLabelingStyle style( int index ) const { return mStyles[index]; }
 
   private:
     //! List of rendering styles

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -323,6 +323,7 @@ SET(QGIS_GUI_SRCS
   tableeditor/qgstableeditorformattingwidget.cpp
   tableeditor/qgstableeditorwidget.cpp
 
+  vectortile/qgsvectortilebasiclabelingwidget.cpp
   vectortile/qgsvectortilebasicrendererwidget.cpp
   vectortile/qgsvectortileconnectiondialog.cpp
   vectortile/qgsvectortiledataitemguiprovider.cpp
@@ -1107,6 +1108,7 @@ SET(QGIS_GUI_HDRS
   tableeditor/qgstableeditorformattingwidget.h
   tableeditor/qgstableeditorwidget.h
 
+  vectortile/qgsvectortilebasiclabelingwidget.h
   vectortile/qgsvectortilebasicrendererwidget.h
   vectortile/qgsvectortileconnectiondialog.h
   vectortile/qgsvectortiledataitemguiprovider.h

--- a/src/gui/vectortile/qgsvectortilebasiclabelingwidget.cpp
+++ b/src/gui/vectortile/qgsvectortilebasiclabelingwidget.cpp
@@ -1,0 +1,458 @@
+/***************************************************************************
+  qgsvectortilebasiclabelingwidget.cpp
+  --------------------------------------
+  Date                 : May 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvectortilebasiclabelingwidget.h"
+
+#include "qgsvectortilebasiclabeling.h"
+#include "qgsvectortilelayer.h"
+
+#include "qgslabelinggui.h"
+
+#include <QMenu>
+
+///@cond PRIVATE
+
+
+class QgsVectorTileBasicLabelingListModel : public QAbstractListModel
+{
+  public:
+    QgsVectorTileBasicLabelingListModel( QgsVectorTileBasicLabeling *r, QObject *parent = nullptr );
+
+    int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
+    int columnCount( const QModelIndex &parent = QModelIndex() ) const override;
+    QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
+    QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const override;
+    Qt::ItemFlags flags( const QModelIndex &index ) const override;
+    bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
+
+    bool removeRows( int row, int count, const QModelIndex &parent = QModelIndex() ) override;
+
+    void insertStyle( int row, const QgsVectorTileBasicLabelingStyle &style );
+
+    // drag'n'drop support
+    Qt::DropActions supportedDropActions() const override;
+    QStringList mimeTypes() const override;
+    QMimeData *mimeData( const QModelIndexList &indexes ) const override;
+    bool dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent ) override;
+
+  private:
+    QgsVectorTileBasicLabeling *mLabeling = nullptr;
+};
+
+
+QgsVectorTileBasicLabelingListModel::QgsVectorTileBasicLabelingListModel( QgsVectorTileBasicLabeling *l, QObject *parent )
+  : QAbstractListModel( parent )
+  , mLabeling( l )
+{
+}
+
+int QgsVectorTileBasicLabelingListModel::rowCount( const QModelIndex &parent ) const
+{
+  if ( parent.isValid() )
+    return 0;
+
+  return mLabeling->styles().count();
+}
+
+int QgsVectorTileBasicLabelingListModel::columnCount( const QModelIndex & ) const
+{
+  return 5;
+}
+
+QVariant QgsVectorTileBasicLabelingListModel::data( const QModelIndex &index, int role ) const
+{
+  if ( index.row() < 0 || index.row() >= mLabeling->styles().count() )
+    return QVariant();
+
+  const QList<QgsVectorTileBasicLabelingStyle> styles = mLabeling->styles();
+  const QgsVectorTileBasicLabelingStyle &style = styles[index.row()];
+
+  switch ( role )
+  {
+    case Qt::DisplayRole:
+    {
+      if ( index.column() == 0 )
+        return style.styleName();
+      else if ( index.column() == 1 )
+        return style.layerName().isEmpty() ? tr( "(all layers)" ) : style.layerName();
+      else if ( index.column() == 2 )
+        return style.minZoomLevel() >= 0 ? style.minZoomLevel() : QVariant();
+      else if ( index.column() == 3 )
+        return style.maxZoomLevel() >= 0 ? style.maxZoomLevel() : QVariant();
+      else if ( index.column() == 4 )
+        return style.filterExpression().isEmpty() ? tr( "(no filter)" ) : style.filterExpression();
+
+      break;
+    }
+
+    case Qt::EditRole:
+    {
+      if ( index.column() == 0 )
+        return style.styleName();
+      else if ( index.column() == 1 )
+        return style.layerName();
+      else if ( index.column() == 2 )
+        return style.minZoomLevel();
+      else if ( index.column() == 3 )
+        return style.maxZoomLevel();
+      else if ( index.column() == 4 )
+        return style.filterExpression();
+
+      break;
+    }
+
+    case Qt::CheckStateRole:
+    {
+      if ( index.column() != 0 )
+        return QVariant();
+      return style.isEnabled() ? Qt::Checked : Qt::Unchecked;
+    }
+
+  }
+  return QVariant();
+}
+
+QVariant QgsVectorTileBasicLabelingListModel::headerData( int section, Qt::Orientation orientation, int role ) const
+{
+  if ( orientation == Qt::Horizontal && role == Qt::DisplayRole && section >= 0 && section < 5 )
+  {
+    QStringList lst;
+    lst << tr( "Label" ) << tr( "Layer" ) << tr( "Min. zoom" ) << tr( "Max. zoom" ) << tr( "Filter" );
+    return lst[section];
+  }
+
+  return QVariant();
+}
+
+Qt::ItemFlags QgsVectorTileBasicLabelingListModel::flags( const QModelIndex &index ) const
+{
+  if ( !index.isValid() )
+    return Qt::ItemIsDropEnabled;
+
+  Qt::ItemFlag checkable = ( index.column() == 0 ? Qt::ItemIsUserCheckable : Qt::NoItemFlags );
+
+  return Qt::ItemIsEnabled | Qt::ItemIsSelectable |
+         Qt::ItemIsEditable | checkable |
+         Qt::ItemIsDragEnabled;
+}
+
+bool QgsVectorTileBasicLabelingListModel::setData( const QModelIndex &index, const QVariant &value, int role )
+{
+  if ( !index.isValid() )
+    return false;
+
+  QgsVectorTileBasicLabelingStyle style = mLabeling->style( index.row() );
+
+  if ( role == Qt::CheckStateRole )
+  {
+    style.setEnabled( value.toInt() == Qt::Checked );
+    mLabeling->setStyle( index.row(), style );
+    emit dataChanged( index, index );
+    return true;
+  }
+
+  if ( role == Qt::EditRole )
+  {
+    if ( index.column() == 0 )
+      style.setStyleName( value.toString() );
+    else if ( index.column() == 1 )
+      style.setLayerName( value.toString() );
+    else if ( index.column() == 2 )
+      style.setMinZoomLevel( value.toInt() );
+    else if ( index.column() == 3 )
+      style.setMaxZoomLevel( value.toInt() );
+    else if ( index.column() == 4 )
+      style.setFilterExpression( value.toString() );
+
+    mLabeling->setStyle( index.row(), style );
+    emit dataChanged( index, index );
+    return true;
+  }
+
+  return false;
+}
+
+bool QgsVectorTileBasicLabelingListModel::removeRows( int row, int count, const QModelIndex &parent )
+{
+  QList<QgsVectorTileBasicLabelingStyle> styles = mLabeling->styles();
+
+  if ( row < 0 || row >= styles.count() )
+    return false;
+
+  beginRemoveRows( parent, row, row + count - 1 );
+
+  for ( int i = 0; i < count; i++ )
+  {
+    if ( row < styles.count() )
+    {
+      styles.removeAt( row );
+    }
+  }
+
+  mLabeling->setStyles( styles );
+
+  endRemoveRows();
+  return true;
+}
+
+void QgsVectorTileBasicLabelingListModel::insertStyle( int row, const QgsVectorTileBasicLabelingStyle &style )
+{
+  beginInsertRows( QModelIndex(), row, row );
+
+  QList<QgsVectorTileBasicLabelingStyle> styles = mLabeling->styles();
+  styles.insert( row, style );
+  mLabeling->setStyles( styles );
+
+  endInsertRows();
+}
+
+Qt::DropActions QgsVectorTileBasicLabelingListModel::supportedDropActions() const
+{
+  return Qt::MoveAction;
+}
+
+QStringList QgsVectorTileBasicLabelingListModel::mimeTypes() const
+{
+  QStringList types;
+  types << QStringLiteral( "application/vnd.text.list" );
+  return types;
+}
+
+QMimeData *QgsVectorTileBasicLabelingListModel::mimeData( const QModelIndexList &indexes ) const
+{
+  QMimeData *mimeData = new QMimeData();
+  QByteArray encodedData;
+
+  QDataStream stream( &encodedData, QIODevice::WriteOnly );
+
+  const auto constIndexes = indexes;
+  for ( const QModelIndex &index : constIndexes )
+  {
+    // each item consists of several columns - let's add it with just first one
+    if ( !index.isValid() || index.column() != 0 )
+      continue;
+
+    QgsVectorTileBasicLabelingStyle style = mLabeling->style( index.row() );
+
+    QDomDocument doc;
+    QDomElement rootElem = doc.createElement( QStringLiteral( "vector_tile_basic_labeling_style_mime" ) );
+    style.writeXml( rootElem, QgsReadWriteContext() );
+    doc.appendChild( rootElem );
+
+    stream << doc.toString( -1 );
+  }
+
+  mimeData->setData( QStringLiteral( "application/vnd.text.list" ), encodedData );
+  return mimeData;
+}
+
+bool QgsVectorTileBasicLabelingListModel::dropMimeData( const QMimeData *data,
+    Qt::DropAction action, int row, int column, const QModelIndex &parent )
+{
+  Q_UNUSED( column )
+
+  if ( action == Qt::IgnoreAction )
+    return true;
+
+  if ( !data->hasFormat( QStringLiteral( "application/vnd.text.list" ) ) )
+    return false;
+
+  if ( parent.column() > 0 )
+    return false;
+
+  QByteArray encodedData = data->data( QStringLiteral( "application/vnd.text.list" ) );
+  QDataStream stream( &encodedData, QIODevice::ReadOnly );
+  int rows = 0;
+
+  if ( row == -1 )
+  {
+    // the item was dropped at a parent - we may decide where to put the items - let's append them
+    row = rowCount( parent );
+  }
+
+  while ( !stream.atEnd() )
+  {
+    QString text;
+    stream >> text;
+
+    QDomDocument doc;
+    if ( !doc.setContent( text ) )
+      continue;
+    QDomElement rootElem = doc.documentElement();
+    if ( rootElem.tagName() != QLatin1String( "vector_tile_basic_labeling_style_mime" ) )
+      continue;
+
+    QgsVectorTileBasicLabelingStyle style;
+    style.readXml( rootElem, QgsReadWriteContext() );
+
+    insertStyle( row + rows, style );
+    ++rows;
+  }
+  return true;
+}
+
+
+//
+
+
+QgsVectorTileBasicLabelingWidget::QgsVectorTileBasicLabelingWidget( QgsVectorTileLayer *layer, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent )
+  : QgsMapLayerConfigWidget( layer, canvas, parent )
+  , mVTLayer( layer )
+  , mMessageBar( messageBar )
+{
+
+  setupUi( this );
+  layout()->setContentsMargins( 0, 0, 0, 0 );
+
+  if ( layer->labeling() && layer->labeling()->type() == QStringLiteral( "basic" ) )
+  {
+    mLabeling.reset( static_cast<QgsVectorTileBasicLabeling *>( layer->labeling()->clone() ) );
+  }
+  else
+  {
+    mLabeling.reset( new QgsVectorTileBasicLabeling() );
+  }
+
+  mModel = new QgsVectorTileBasicLabelingListModel( mLabeling.get(), viewStyles );
+  viewStyles->setModel( mModel );
+
+  QMenu *menuAddRule = new QMenu( btnAddRule );
+  menuAddRule->addAction( tr( "Marker" ), this, [this] { addStyle( QgsWkbTypes::PointGeometry ); } );
+  menuAddRule->addAction( tr( "Line" ), this, [this] { addStyle( QgsWkbTypes::LineGeometry ); } );
+  menuAddRule->addAction( tr( "Fill" ), this, [this] { addStyle( QgsWkbTypes::PolygonGeometry ); } );
+  btnAddRule->setMenu( menuAddRule );
+
+  //connect( btnAddRule, &QPushButton::clicked, this, &QgsVectorTileBasicLabelingWidget::addStyle );
+  connect( btnEditRule, &QPushButton::clicked, this, &QgsVectorTileBasicLabelingWidget::editStyle );
+  connect( btnRemoveRule, &QAbstractButton::clicked, this, &QgsVectorTileBasicLabelingWidget::removeStyle );
+
+  connect( viewStyles, &QAbstractItemView::doubleClicked, this, &QgsVectorTileBasicLabelingWidget::editStyleAtIndex );
+
+  connect( mModel, &QAbstractItemModel::dataChanged, this, &QgsPanelWidget::widgetChanged );
+  connect( mModel, &QAbstractItemModel::rowsInserted, this, &QgsPanelWidget::widgetChanged );
+  connect( mModel, &QAbstractItemModel::rowsRemoved, this, &QgsPanelWidget::widgetChanged );
+}
+
+QgsVectorTileBasicLabelingWidget::~QgsVectorTileBasicLabelingWidget() = default;
+
+void QgsVectorTileBasicLabelingWidget::apply()
+{
+  mVTLayer->setLabeling( mLabeling->clone() );
+}
+
+void QgsVectorTileBasicLabelingWidget::addStyle( QgsWkbTypes::GeometryType geomType )
+{
+  QgsVectorTileBasicLabelingStyle style;
+  style.setGeometryType( geomType );
+
+  int rows = mModel->rowCount();
+  mModel->insertStyle( rows, style );
+  viewStyles->selectionModel()->setCurrentIndex( mModel->index( rows, 0 ), QItemSelectionModel::ClearAndSelect );
+}
+
+void QgsVectorTileBasicLabelingWidget::editStyle()
+{
+  editStyleAtIndex( viewStyles->selectionModel()->currentIndex() );
+}
+
+void QgsVectorTileBasicLabelingWidget::editStyleAtIndex( const QModelIndex &index )
+{
+  QgsVectorTileBasicLabelingStyle style = mLabeling->style( index.row() );
+
+  QgsPalLayerSettings labelSettings = style.labelSettings();
+  if ( labelSettings.layerType == QgsWkbTypes::UnknownGeometry )
+    labelSettings.layerType = style.geometryType();
+
+  QgsSymbolWidgetContext context;
+  context.setMapCanvas( mMapCanvas );
+  context.setMessageBar( mMessageBar );
+
+  QgsVectorLayer *vectorLayer = nullptr;  // TODO: have a temporary vector layer with sub-layer's fields?
+
+  QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
+  if ( panel && panel->dockMode() )
+  {
+    QgsLabelingPanelWidget *widget = new QgsLabelingPanelWidget( labelSettings, vectorLayer, mMapCanvas, panel );
+    widget->setContext( context );
+    widget->setPanelTitle( style.styleName() );
+    connect( widget, &QgsPanelWidget::widgetChanged, this, &QgsVectorTileBasicLabelingWidget::updateLabelingFromWidget );
+    openPanel( widget );
+  }
+  else
+  {
+    // TODO: implement when adding support for vector tile layer properties dialog
+  }
+}
+
+void QgsVectorTileBasicLabelingWidget::updateLabelingFromWidget()
+{
+  int index = viewStyles->selectionModel()->currentIndex().row();
+  QgsVectorTileBasicLabelingStyle style = mLabeling->style( index );
+
+  QgsLabelingPanelWidget *widget = qobject_cast<QgsLabelingPanelWidget *>( sender() );
+  style.setLabelSettings( widget->labelSettings() );
+
+  mLabeling->setStyle( index, style );
+  emit widgetChanged();
+}
+
+void QgsVectorTileBasicLabelingWidget::removeStyle()
+{
+  QItemSelection sel = viewStyles->selectionModel()->selection();
+  const auto constSel = sel;
+  for ( const QItemSelectionRange &range : constSel )
+  {
+    if ( range.isValid() )
+      mModel->removeRows( range.top(), range.bottom() - range.top() + 1, range.parent() );
+  }
+  // make sure that the selection is gone
+  viewStyles->selectionModel()->clear();
+}
+
+
+//
+
+
+QgsLabelingPanelWidget::QgsLabelingPanelWidget( const QgsPalLayerSettings &labelSettings, QgsVectorLayer *vectorLayer, QgsMapCanvas *mapCanvas, QWidget *parent )
+  : QgsPanelWidget( parent )
+{
+  mLabelingGui = new QgsLabelingGui( vectorLayer, mapCanvas, labelSettings, this, labelSettings.layerType );
+  mLabelingGui->setLabelMode( QgsLabelingGui::Labels );
+
+  mLabelingGui->layout()->setContentsMargins( 0, 0, 0, 0 );
+  QVBoxLayout *l = new QVBoxLayout;
+  l->addWidget( mLabelingGui );
+  setLayout( l );
+
+  connect( mLabelingGui, &QgsTextFormatWidget::widgetChanged, this, &QgsLabelingPanelWidget::widgetChanged );
+}
+
+void QgsLabelingPanelWidget::setDockMode( bool dockMode )
+{
+  QgsPanelWidget::setDockMode( dockMode );
+  mLabelingGui->setDockMode( dockMode );
+}
+
+void QgsLabelingPanelWidget::setContext( const QgsSymbolWidgetContext &context )
+{
+  mLabelingGui->setContext( context );
+}
+
+QgsPalLayerSettings QgsLabelingPanelWidget::labelSettings()
+{
+  return mLabelingGui->layerSettings();
+}
+
+///@endcond

--- a/src/gui/vectortile/qgsvectortilebasiclabelingwidget.cpp
+++ b/src/gui/vectortile/qgsvectortilebasiclabelingwidget.cpp
@@ -25,33 +25,6 @@
 ///@cond PRIVATE
 
 
-class QgsVectorTileBasicLabelingListModel : public QAbstractListModel
-{
-  public:
-    QgsVectorTileBasicLabelingListModel( QgsVectorTileBasicLabeling *r, QObject *parent = nullptr );
-
-    int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
-    int columnCount( const QModelIndex &parent = QModelIndex() ) const override;
-    QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
-    QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const override;
-    Qt::ItemFlags flags( const QModelIndex &index ) const override;
-    bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
-
-    bool removeRows( int row, int count, const QModelIndex &parent = QModelIndex() ) override;
-
-    void insertStyle( int row, const QgsVectorTileBasicLabelingStyle &style );
-
-    // drag'n'drop support
-    Qt::DropActions supportedDropActions() const override;
-    QStringList mimeTypes() const override;
-    QMimeData *mimeData( const QModelIndexList &indexes ) const override;
-    bool dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent ) override;
-
-  private:
-    QgsVectorTileBasicLabeling *mLabeling = nullptr;
-};
-
-
 QgsVectorTileBasicLabelingListModel::QgsVectorTileBasicLabelingListModel( QgsVectorTileBasicLabeling *l, QObject *parent )
   : QAbstractListModel( parent )
   , mLabeling( l )

--- a/src/gui/vectortile/qgsvectortilebasiclabelingwidget.h
+++ b/src/gui/vectortile/qgsvectortilebasiclabelingwidget.h
@@ -93,6 +93,36 @@ class QgsLabelingPanelWidget : public QgsPanelWidget
     QgsLabelingGui *mLabelingGui = nullptr;
 };
 
+
+class QgsVectorTileBasicLabelingStyle;
+
+class QgsVectorTileBasicLabelingListModel : public QAbstractListModel
+{
+    Q_OBJECT
+  public:
+    QgsVectorTileBasicLabelingListModel( QgsVectorTileBasicLabeling *r, QObject *parent = nullptr );
+
+    int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
+    int columnCount( const QModelIndex &parent = QModelIndex() ) const override;
+    QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
+    QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const override;
+    Qt::ItemFlags flags( const QModelIndex &index ) const override;
+    bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
+
+    bool removeRows( int row, int count, const QModelIndex &parent = QModelIndex() ) override;
+
+    void insertStyle( int row, const QgsVectorTileBasicLabelingStyle &style );
+
+    // drag'n'drop support
+    Qt::DropActions supportedDropActions() const override;
+    QStringList mimeTypes() const override;
+    QMimeData *mimeData( const QModelIndexList &indexes ) const override;
+    bool dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent ) override;
+
+  private:
+    QgsVectorTileBasicLabeling *mLabeling = nullptr;
+};
+
 ///@endcond
 
 #endif // QGSVECTORTILEBASICLABELINGWIDGET_H

--- a/src/gui/vectortile/qgsvectortilebasiclabelingwidget.h
+++ b/src/gui/vectortile/qgsvectortilebasiclabelingwidget.h
@@ -1,0 +1,98 @@
+/***************************************************************************
+  qgsvectortilebasiclabelingwidget.h
+  --------------------------------------
+  Date                 : May 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSVECTORTILEBASICLABELINGWIDGET_H
+#define QGSVECTORTILEBASICLABELINGWIDGET_H
+
+#include "qgsmaplayerconfigwidget.h"
+
+#include "ui_qgsvectortilebasiclabelingwidget.h"
+
+#include "qgswkbtypes.h"
+
+#include <memory>
+
+///@cond PRIVATE
+#define SIP_NO_FILE
+
+class QgsVectorTileBasicLabeling;
+class QgsVectorTileBasicLabelingListModel;
+class QgsVectorTileLayer;
+class QgsMapCanvas;
+class QgsMessageBar;
+
+/**
+ * \ingroup gui
+ * Styling widget for basic labling of vector tile layer
+ *
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsVectorTileBasicLabelingWidget : public QgsMapLayerConfigWidget, private Ui::QgsVectorTileBasicLabelingWidget
+{
+    Q_OBJECT
+  public:
+    QgsVectorTileBasicLabelingWidget( QgsVectorTileLayer *layer, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent = nullptr );
+    ~QgsVectorTileBasicLabelingWidget() override;
+
+  public slots:
+    //! Applies the settings made in the dialog
+    void apply() override;
+
+  private slots:
+    void addStyle( QgsWkbTypes::GeometryType geomType );
+    //void addStyle();
+    void editStyle();
+    void editStyleAtIndex( const QModelIndex &index );
+    void removeStyle();
+
+    void updateLabelingFromWidget();
+
+  private:
+    QgsVectorTileLayer *mVTLayer = nullptr;
+    std::unique_ptr<QgsVectorTileBasicLabeling> mLabeling;
+    QgsVectorTileBasicLabelingListModel *mModel = nullptr;
+    QgsMessageBar *mMessageBar = nullptr;
+};
+
+
+class QgsPalLayerSettings;
+class QgsVectorLayer;
+class QgsSymbolWidgetContext;
+class QgsLabelingGui;
+
+/**
+ * \ingroup gui
+ * Helper widget class that wraps QgsLabelingGui into a QgsPanelWidget
+ *
+ * \since QGIS 3.14
+ */
+class QgsLabelingPanelWidget : public QgsPanelWidget
+{
+    Q_OBJECT
+  public:
+    QgsLabelingPanelWidget( const QgsPalLayerSettings &labelSettings, QgsVectorLayer *vectorLayer, QgsMapCanvas *mapCanvas, QWidget *parent = nullptr );
+
+    void setDockMode( bool dockMode ) override;
+
+    void setContext( const QgsSymbolWidgetContext &context );
+    QgsPalLayerSettings labelSettings();
+
+  private:
+    QgsLabelingGui *mLabelingGui = nullptr;
+};
+
+///@endcond
+
+#endif // QGSVECTORTILEBASICLABELINGWIDGET_H

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
@@ -29,32 +29,6 @@
 
 ///@cond PRIVATE
 
-class QgsVectorTileBasicRendererListModel : public QAbstractListModel
-{
-  public:
-    QgsVectorTileBasicRendererListModel( QgsVectorTileBasicRenderer *r, QObject *parent = nullptr );
-
-    int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
-    int columnCount( const QModelIndex &parent = QModelIndex() ) const override;
-    QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
-    QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const override;
-    Qt::ItemFlags flags( const QModelIndex &index ) const override;
-    bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
-
-    bool removeRows( int row, int count, const QModelIndex &parent = QModelIndex() ) override;
-
-    void insertStyle( int row, const QgsVectorTileBasicRendererStyle &style );
-
-    // drag'n'drop support
-    Qt::DropActions supportedDropActions() const override;
-    QStringList mimeTypes() const override;
-    QMimeData *mimeData( const QModelIndexList &indexes ) const override;
-    bool dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent ) override;
-
-  private:
-    QgsVectorTileBasicRenderer *mRenderer = nullptr;
-};
-
 
 QgsVectorTileBasicRendererListModel::QgsVectorTileBasicRendererListModel( QgsVectorTileBasicRenderer *r, QObject *parent )
   : QAbstractListModel( parent )

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
@@ -66,6 +66,36 @@ class GUI_EXPORT QgsVectorTileBasicRendererWidget : public QgsMapLayerConfigWidg
     QgsMessageBar *mMessageBar = nullptr;
 };
 
+
+class QgsVectorTileBasicRendererStyle;
+
+class QgsVectorTileBasicRendererListModel : public QAbstractListModel
+{
+    Q_OBJECT
+  public:
+    QgsVectorTileBasicRendererListModel( QgsVectorTileBasicRenderer *r, QObject *parent = nullptr );
+
+    int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
+    int columnCount( const QModelIndex &parent = QModelIndex() ) const override;
+    QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
+    QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const override;
+    Qt::ItemFlags flags( const QModelIndex &index ) const override;
+    bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
+
+    bool removeRows( int row, int count, const QModelIndex &parent = QModelIndex() ) override;
+
+    void insertStyle( int row, const QgsVectorTileBasicRendererStyle &style );
+
+    // drag'n'drop support
+    Qt::DropActions supportedDropActions() const override;
+    QStringList mimeTypes() const override;
+    QMimeData *mimeData( const QModelIndexList &indexes ) const override;
+    bool dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent ) override;
+
+  private:
+    QgsVectorTileBasicRenderer *mRenderer = nullptr;
+};
+
 ///@endcond
 
 #endif // QGSVECTORTILEBASICRENDERERWIDGET_H

--- a/src/ui/qgsvectortilebasiclabelingwidget.ui
+++ b/src/ui/qgsvectortilebasiclabelingwidget.ui
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsVectorTileBasicLabelingWidget</class>
+ <widget class="QWidget" name="QgsVectorTileBasicLabelingWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>557</width>
+    <height>424</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTreeView" name="viewStyles">
+     <property name="acceptDrops">
+      <bool>true</bool>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
+     </property>
+     <property name="dragEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="dragDropMode">
+      <enum>QAbstractItemView::InternalMove</enum>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+     <property name="rootIsDecorated">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QToolButton" name="btnAddRule">
+       <property name="toolTip">
+        <string>Add rule</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+       </property>
+       <property name="popupMode">
+        <enum>QToolButton::InstantPopup</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnRemoveRule">
+       <property name="toolTip">
+        <string>Remove selected rules</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnEditRule">
+       <property name="toolTip">
+        <string>Edit current rule</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/symbologyEdit.svg</normaloff>:/images/themes/default/symbologyEdit.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
+ <connections/>
+</ui>


### PR DESCRIPTION
This adds a new tab in the layer styling dock widget for vector tile layers.

The new QgsVectorTileBasicLabelingWidget class is based on the code used for QgsVectorTileBasicRendererWidget

See the QEP: qgis/QGIS-Enhancement-Proposals#162

![image](https://user-images.githubusercontent.com/193367/81866605-b93e5580-956f-11ea-8139-1640ad506b3d.png)

## Thanks

Huge thanks to all funders who have contributed to the crowdfunding and made this possible :clap: :clap: :clap:
https://www.lutraconsulting.co.uk/blog/2020/04/02/vectortiles-donors/