### PR TITLE
Re-allow creation of postgres connections with ONLY a database name entered

### DIFF
--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -250,6 +250,6 @@ void QgsPgNewConnection::updateOkButtonState()
 {
   bool enabled = !txtName->text().isEmpty() && (
                    !txtService->text().isEmpty() ||
-                   ( !txtHost->text().isEmpty() && !txtPort->text().isEmpty() && !txtDatabase->text().isEmpty() ) );
+                   !txtDatabase->text().isEmpty() );
   buttonBox->button( QDialogButtonBox::Ok )->setEnabled( enabled );
 }


### PR DESCRIPTION
Followup https://github.com/qgis/QGIS/pull/36129 - this configuration works and was previously supported
