### PR TITLE
[Server] Expression override for online resource in service capabilities

### DIFF
--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -406,6 +406,18 @@ a hierarchy of keys and corresponding values
    The key string must be valid xml tag names in order to be saved to the file.
 %End
 
+    bool writeEntry( const QString &scope, const QString &key, const QgsProperty &value );
+%Docstring
+Write a QgsProperty entry to the project file.
+
+Keys are '/'-delimited entries, implying
+a hierarchy of keys and corresponding values
+
+.. note::
+
+   The key string must be valid xml tag names in order to be saved to the file.
+%End
+
     QStringList readListEntry( const QString &scope, const QString &key, const QStringList &def = QStringList(), bool *ok = 0 ) const;
 %Docstring
 Key value accessors
@@ -418,6 +430,7 @@ implying a hierarchy of keys and corresponding values
     int readNumEntry( const QString &scope, const QString &key, int def = 0, bool *ok = 0 ) const;
     double readDoubleEntry( const QString &scope, const QString &key, double def = 0, bool *ok = 0 ) const;
     bool readBoolEntry( const QString &scope, const QString &key, bool def = false, bool *ok = 0 ) const;
+    QgsProperty readPropertyEntry( const QString &scope, const QString &key, QgsProperty def = QgsProperty(), bool *ok = 0 ) const;
 
 
     bool removeEntry( const QString &scope, const QString &key );

--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -430,7 +430,7 @@ implying a hierarchy of keys and corresponding values
     int readNumEntry( const QString &scope, const QString &key, int def = 0, bool *ok = 0 ) const;
     double readDoubleEntry( const QString &scope, const QString &key, double def = 0, bool *ok = 0 ) const;
     bool readBoolEntry( const QString &scope, const QString &key, bool def = false, bool *ok = 0 ) const;
-    QgsProperty readPropertyEntry( const QString &scope, const QString &key, QgsProperty def = QgsProperty(), bool *ok = 0 ) const;
+    QgsProperty readPropertyEntry( const QString &scope, const QString &key, const QgsProperty &def = QgsProperty(), bool *ok = 0 ) const;
 
 
     bool removeEntry( const QString &scope, const QString &key );

--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -55,6 +55,13 @@ open within the main QGIS application.
       AvoidIntersectionsLayers,
     };
 
+    enum DataDefinedServerProperty
+    {
+      NoProperty,
+      AllProperties,
+      WMSOnlineResource,
+    };
+
     static QgsProject *instance();
 %Docstring
 Returns the QgsProject singleton instance
@@ -406,18 +413,6 @@ a hierarchy of keys and corresponding values
    The key string must be valid xml tag names in order to be saved to the file.
 %End
 
-    bool writeEntry( const QString &scope, const QString &key, const QgsProperty &value );
-%Docstring
-Write a QgsProperty entry to the project file.
-
-Keys are '/'-delimited entries, implying
-a hierarchy of keys and corresponding values
-
-.. note::
-
-   The key string must be valid xml tag names in order to be saved to the file.
-%End
-
     QStringList readListEntry( const QString &scope, const QString &key, const QStringList &def = QStringList(), bool *ok = 0 ) const;
 %Docstring
 Key value accessors
@@ -430,8 +425,6 @@ implying a hierarchy of keys and corresponding values
     int readNumEntry( const QString &scope, const QString &key, int def = 0, bool *ok = 0 ) const;
     double readDoubleEntry( const QString &scope, const QString &key, double def = 0, bool *ok = 0 ) const;
     bool readBoolEntry( const QString &scope, const QString &key, bool def = false, bool *ok = 0 ) const;
-    QgsProperty readPropertyEntry( const QString &scope, const QString &key, const QgsProperty &def = QgsProperty(), bool *ok = 0 ) const;
-
 
     bool removeEntry( const QString &scope, const QString &key );
 %Docstring
@@ -1729,6 +1722,22 @@ Registers the objects that require translation into the ``translationContext``.
 So there can be created a ts file with these values.
 
 .. versionadded:: 3.4
+%End
+
+    void setDataDefinedServerProperties( const QgsPropertyCollection &properties );
+%Docstring
+Sets the data defined properties used for overrides in user defined server
+parameters to ``properties``
+
+.. versionadded:: 3.14
+%End
+
+    QgsPropertyCollection dataDefinedServerProperties() const;
+%Docstring
+Returns the data defined properties used for overrides in user defined server
+parameters
+
+.. versionadded:: 3.14
 %End
 
 };

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -446,6 +446,8 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   mWMSUrlLineEdit->setText( QgsProject::instance()->readEntry( QStringLiteral( "WMSUrl" ), QStringLiteral( "/" ), QString() ) );
   mWMSKeywordList->setText( QgsProject::instance()->readListEntry( QStringLiteral( "WMSKeywordList" ), QStringLiteral( "/" ) ).join( QStringLiteral( ", " ) ) );
 
+  mWMSOnlineResourceExpressionButton->registerExpressionContextGenerator( this );
+
   // WMS Name validator
   QValidator *shortNameValidator = new QRegExpValidator( QgsApplication::shortNameRegExp(), this );
   mWMSName->setValidator( shortNameValidator );
@@ -993,6 +995,16 @@ void QgsProjectProperties::setSelectedCrs( const QgsCoordinateReferenceSystem &c
   projectionSelector->setCrs( crs );
   mBlockCrsUpdates = false;
   crsChanged( projectionSelector->crs() );
+}
+
+QgsExpressionContext QgsProjectProperties::createExpressionContext() const
+{
+  QgsExpressionContext context;
+  context
+      << QgsExpressionContextUtils::globalScope()
+      << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
+
+  return context;
 }
 
 void QgsProjectProperties::apply()

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -442,11 +442,11 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   mWMSContactPhone->setText( QgsProject::instance()->readEntry( QStringLiteral( "WMSContactPhone" ), QStringLiteral( "/" ), QString() ) );
   mWMSAbstract->setPlainText( QgsProject::instance()->readEntry( QStringLiteral( "WMSServiceAbstract" ), QStringLiteral( "/" ), QString() ) );
   mWMSOnlineResourceLineEdit->setText( QgsProject::instance()->readEntry( QStringLiteral( "WMSOnlineResource" ), QStringLiteral( "/" ), QString() ) );
-  mWMSOnlineResourceExpressionButton->setToProperty( QgsProject::instance()->readPropertyEntry( "WMSOnlineResourceExpression", "/" ) );
   mWMSUrlLineEdit->setText( QgsProject::instance()->readEntry( QStringLiteral( "WMSUrl" ), QStringLiteral( "/" ), QString() ) );
   mWMSKeywordList->setText( QgsProject::instance()->readListEntry( QStringLiteral( "WMSKeywordList" ), QStringLiteral( "/" ) ).join( QStringLiteral( ", " ) ) );
 
   mWMSOnlineResourceExpressionButton->registerExpressionContextGenerator( this );
+  mWMSOnlineResourceExpressionButton->setToProperty( QgsProject::instance()->dataDefinedServerProperties().property( QgsProject::DataDefinedServerProperty::WMSOnlineResource ) );
 
   // WMS Name validator
   QValidator *shortNameValidator = new QRegExpValidator( QgsApplication::shortNameRegExp(), this );
@@ -1183,8 +1183,11 @@ void QgsProjectProperties::apply()
   QgsProject::instance()->writeEntry( QStringLiteral( "WMSContactPhone" ), QStringLiteral( "/" ), mWMSContactPhone->text() );
   QgsProject::instance()->writeEntry( QStringLiteral( "WMSServiceAbstract" ), QStringLiteral( "/" ), mWMSAbstract->toPlainText() );
   QgsProject::instance()->writeEntry( QStringLiteral( "WMSOnlineResource" ), QStringLiteral( "/" ), mWMSOnlineResourceLineEdit->text() );
-  QgsProject::instance()->writeEntry( QStringLiteral( "WMSOnlineResourceExpression" ), QStringLiteral( "/" ), mWMSOnlineResourceExpressionButton->toProperty() );
   QgsProject::instance()->writeEntry( QStringLiteral( "WMSUrl" ), QStringLiteral( "/" ), mWMSUrlLineEdit->text() );
+
+  QgsPropertyCollection propertyCollection = QgsProject::instance()->dataDefinedServerProperties();
+  propertyCollection.setProperty( QgsProject::DataDefinedServerProperty::WMSOnlineResource, mWMSOnlineResourceExpressionButton->toProperty() );
+  QgsProject::instance()->setDataDefinedServerProperties( propertyCollection );
 
   // WMS Contact Position
   int contactPositionIndex = mWMSContactPositionCb->currentIndex();

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -442,6 +442,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   mWMSContactPhone->setText( QgsProject::instance()->readEntry( QStringLiteral( "WMSContactPhone" ), QStringLiteral( "/" ), QString() ) );
   mWMSAbstract->setPlainText( QgsProject::instance()->readEntry( QStringLiteral( "WMSServiceAbstract" ), QStringLiteral( "/" ), QString() ) );
   mWMSOnlineResourceLineEdit->setText( QgsProject::instance()->readEntry( QStringLiteral( "WMSOnlineResource" ), QStringLiteral( "/" ), QString() ) );
+  mWMSOnlineResourceExpressionButton->setToProperty( QgsProject::instance()->readPropertyEntry( "WMSOnlineResourceExpression", "/" ) );
   mWMSUrlLineEdit->setText( QgsProject::instance()->readEntry( QStringLiteral( "WMSUrl" ), QStringLiteral( "/" ), QString() ) );
   mWMSKeywordList->setText( QgsProject::instance()->readListEntry( QStringLiteral( "WMSKeywordList" ), QStringLiteral( "/" ) ).join( QStringLiteral( ", " ) ) );
 
@@ -1170,6 +1171,7 @@ void QgsProjectProperties::apply()
   QgsProject::instance()->writeEntry( QStringLiteral( "WMSContactPhone" ), QStringLiteral( "/" ), mWMSContactPhone->text() );
   QgsProject::instance()->writeEntry( QStringLiteral( "WMSServiceAbstract" ), QStringLiteral( "/" ), mWMSAbstract->toPlainText() );
   QgsProject::instance()->writeEntry( QStringLiteral( "WMSOnlineResource" ), QStringLiteral( "/" ), mWMSOnlineResourceLineEdit->text() );
+  QgsProject::instance()->writeEntry( QStringLiteral( "WMSOnlineResourceExpression" ), QStringLiteral( "/" ), mWMSOnlineResourceExpressionButton->toProperty() );
   QgsProject::instance()->writeEntry( QStringLiteral( "WMSUrl" ), QStringLiteral( "/" ), mWMSUrlLineEdit->text() );
 
   // WMS Contact Position

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -42,7 +42,7 @@ class QgsBearingNumericFormat;
   \note actual state is stored in QgsProject singleton instance
 
  */
-class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui::QgsProjectPropertiesBase
+class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui::QgsProjectPropertiesBase, public QgsExpressionContextGenerator
 {
     Q_OBJECT
 
@@ -65,6 +65,7 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
      */
     void setSelectedCrs( const QgsCoordinateReferenceSystem &crs );
 
+    QgsExpressionContext createExpressionContext() const override;
   public slots:
 
     /**

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -2488,20 +2488,20 @@ bool QgsProject::readBoolEntry( const QString &scope, const QString &key, bool d
   return def;
 }
 
-QgsProperty QgsProject::readPropertyEntry( const QString &scope, const QString &key, QgsProperty def, bool *ok ) const
+QgsProperty QgsProject::readPropertyEntry( const QString &scope, const QString &key, const QgsProperty &def, bool *ok ) const
 {
   QgsProjectProperty *property = findKey_( scope, key, mProperties );
 
   if ( property )
   {
-    QgsProperty qgsproperty;
+    QgsProperty propertyValue;
     QVariant value = property->value();
-    bool loaded = qgsproperty.loadVariant( value );
+    bool loaded = propertyValue.loadVariant( value );
     if ( ok )
       *ok = loaded;
 
     if ( loaded )
-      return qgsproperty;
+      return propertyValue;
   }
 
   return def;

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -2359,6 +2359,17 @@ bool QgsProject::writeEntry( const QString &scope, const QString &key, const QSt
   return success;
 }
 
+bool QgsProject::writeEntry( const QString &scope, const QString &key, const QgsProperty &value )
+{
+  bool propertiesModified;
+  bool success = addKey_( scope, key, &mProperties, value.toVariant(), propertiesModified );
+
+  if ( propertiesModified )
+    setDirty( true );
+
+  return success;
+}
+
 QStringList QgsProject::readListEntry( const QString &scope,
                                        const QString &key,
                                        const QStringList &def,
@@ -2472,6 +2483,25 @@ bool QgsProject::readBoolEntry( const QString &scope, const QString &key, bool d
 
     if ( valid )
       return value.toBool();
+  }
+
+  return def;
+}
+
+QgsProperty QgsProject::readPropertyEntry( const QString &scope, const QString &key, QgsProperty def, bool *ok ) const
+{
+  QgsProjectProperty *property = findKey_( scope, key, mProperties );
+
+  if ( property )
+  {
+    QgsProperty qgsproperty;
+    QVariant value = property->value();
+    bool loaded = qgsproperty.loadVariant( value );
+    if ( ok )
+      *ok = loaded;
+
+    if ( loaded )
+      return qgsproperty;
   }
 
   return def;

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -894,41 +894,24 @@ void _getProperties( const QDomDocument &doc, QgsProjectPropertyKey &project_pro
 }
 
 /**
-
-Restore the data defined server properties collection found in "doc" to "dataDefinedServerProperties".
-
-\code{.xml}
-<dataDefinedServerProperties>
-  <Option type="Map">
-    <Option name="name" type="QString" value=""></Option>
-    <Option name="properties" type="Map">
-      <Option name="WMSOnlineResource" type="Map">
-        <Option name="active" type="bool" value="true"></Option>
-        <Option name="expression" type="QString" value="'www.mayasbees.ch/'||@project_basename"></Option>
-        <Option name="type" type="int" value="3"></Option>
-      </Option>
-    </Option>
-    <Option name="type" type="QString" value="collection"></Option>
-  </Option>
-</dataDefinedServerProperties>
-\endcode
-
-\param doc xml document
-\param dataDefinedServerProperties property collection of the server overrides
-
-*/
-void _getDataDefinedServerProperties( const QDomDocument &doc, QgsPropertyCollection &dataDefinedServerProperties, const QgsPropertiesDefinition &dataDefinedServerPropertyDefinitions )
+  Returns the data defined server properties collection found in "doc" to "dataDefinedServerProperties".
+  \param doc xml document
+  \param dataDefinedServerProperties property collection of the server overrides
+  \since QGIS 3.14
+**/
+QgsPropertyCollection getDataDefinedServerProperties( const QDomDocument &doc, const QgsPropertiesDefinition &dataDefinedServerPropertyDefinitions )
 {
+  QgsPropertyCollection ddServerProperties;
   // Read data defined server properties
-  dataDefinedServerProperties.clear();
   QDomElement ddElem = doc.documentElement().firstChildElement( QStringLiteral( "dataDefinedServerProperties" ) );
   if ( !ddElem.isNull() )
   {
-    if ( !dataDefinedServerProperties.readXml( ddElem, dataDefinedServerPropertyDefinitions ) )
+    if ( !ddServerProperties.readXml( ddElem, dataDefinedServerPropertyDefinitions ) )
     {
       QgsDebugMsg( QStringLiteral( "dataDefinedServerProperties.readXml() failed" ) );
     }
   }
+  return ddServerProperties;
 }
 
 /**
@@ -1326,7 +1309,7 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
   _getProperties( *doc, mProperties );
 
   // now get the data defined server properties
-  _getDataDefinedServerProperties( *doc, mDataDefinedServerProperties, dataDefinedServerPropertyDefinitions() );
+  mDataDefinedServerProperties = getDataDefinedServerProperties( *doc, dataDefinedServerPropertyDefinitions() );
 
   QgsDebugMsgLevel( QString::number( mProperties.count() ) + " properties read", 2 );
 

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -920,16 +920,14 @@ Restore the data defined server properties collection found in "doc" to "dataDef
 void _getDataDefinedServerProperties( const QDomDocument &doc, QgsPropertyCollection &dataDefinedServerProperties, const QgsPropertiesDefinition &dataDefinedServerPropertyDefinitions )
 {
   // Read data defined server properties
+  dataDefinedServerProperties.clear();
   QDomElement ddElem = doc.documentElement().firstChildElement( QStringLiteral( "dataDefinedServerProperties" ) );
-
-  if ( ddElem.isNull() )  // no properties found, so we're done
+  if ( !ddElem.isNull() )
   {
-    return;
-  }
-
-  if ( ! dataDefinedServerProperties.readXml( ddElem, dataDefinedServerPropertyDefinitions ) )
-  {
-    QgsDebugMsg( QStringLiteral( "dataDefinedServerProperties.readXml() failed" ) );
+    if ( !dataDefinedServerProperties.readXml( ddElem, dataDefinedServerPropertyDefinitions ) )
+    {
+      QgsDebugMsg( QStringLiteral( "dataDefinedServerProperties.readXml() failed" ) );
+    }
   }
 }
 

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -144,6 +144,21 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     };
     Q_ENUM( AvoidIntersectionsMode )
 
+    /**
+     * Data defined properties.
+     * Overrides of user defined server parameters are stored in a
+     * property collection and they can be retrieved using the
+     * indexes specified in this enum.
+     *
+     * \since QGIS 3.14
+     */
+    enum DataDefinedServerProperty
+    {
+      NoProperty = 0, //!< No property
+      AllProperties = 1, //!< All properties for item
+      WMSOnlineResource = 2, //!< Alias
+    };
+
     //! Returns the QgsProject singleton instance
     static QgsProject *instance();
 
@@ -424,16 +439,6 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     bool writeEntry( const QString &scope, const QString &key, const QStringList &value );
 
     /**
-     * Write a QgsProperty entry to the project file.
-     *
-     * Keys are '/'-delimited entries, implying
-     * a hierarchy of keys and corresponding values
-     *
-     * \note The key string must be valid xml tag names in order to be saved to the file.
-     */
-    bool writeEntry( const QString &scope, const QString &key, const QgsProperty &value );
-
-    /**
      * Key value accessors
      *
      * keys would be the familiar QgsSettings-like '/' delimited entries,
@@ -445,8 +450,6 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     int readNumEntry( const QString &scope, const QString &key, int def = 0, bool *ok = nullptr ) const;
     double readDoubleEntry( const QString &scope, const QString &key, double def = 0, bool *ok = nullptr ) const;
     bool readBoolEntry( const QString &scope, const QString &key, bool def = false, bool *ok = nullptr ) const;
-    QgsProperty readPropertyEntry( const QString &scope, const QString &key, const QgsProperty &def = QgsProperty(), bool *ok = nullptr ) const;
-
 
     //! Remove the given key
     bool removeEntry( const QString &scope, const QString &key );
@@ -1753,6 +1756,22 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     */
     void registerTranslatableObjects( QgsTranslationContext *translationContext );
 
+    /**
+     * Sets the data defined properties used for overrides in user defined server
+     * parameters to \a properties
+     *
+     * \since QGIS 3.14
+     */
+    void setDataDefinedServerProperties( const QgsPropertyCollection &properties );
+
+    /**
+     * Returns the data defined properties used for overrides in user defined server
+     * parameters
+     *
+     * \since QGIS 3.14
+     */
+    QgsPropertyCollection dataDefinedServerProperties() const;
+
   private slots:
     void onMapLayersAdded( const QList<QgsMapLayer *> &layers );
     void onMapLayersRemoved( const QList<QgsMapLayer *> &layers );
@@ -1831,6 +1850,9 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     //! Save auxiliary storage to database
     bool saveAuxiliaryStorage( const QString &filename = QString() );
 
+    //! Returns the property definition used for a data defined server property
+    static QgsPropertiesDefinition &dataDefinedServerPropertyDefinitions();
+
     std::unique_ptr< QgsMapLayerStore > mLayerStore;
 
     QString mErrorMessage;
@@ -1899,6 +1921,8 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     bool mDirty = false;                 // project has been modified since it has been read or saved
     int mDirtyBlockCount = 0;
     bool mTrustLayerMetadata = false;
+
+    QgsPropertyCollection mDataDefinedServerProperties;
 
     QgsCoordinateTransformContext mTransformContext;
 

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -445,7 +445,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     int readNumEntry( const QString &scope, const QString &key, int def = 0, bool *ok = nullptr ) const;
     double readDoubleEntry( const QString &scope, const QString &key, double def = 0, bool *ok = nullptr ) const;
     bool readBoolEntry( const QString &scope, const QString &key, bool def = false, bool *ok = nullptr ) const;
-    QgsProperty readPropertyEntry( const QString &scope, const QString &key, QgsProperty def = QgsProperty(), bool *ok = nullptr ) const;
+    QgsProperty readPropertyEntry( const QString &scope, const QString &key, const QgsProperty &def = QgsProperty(), bool *ok = nullptr ) const;
 
 
     //! Remove the given key

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -424,6 +424,16 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     bool writeEntry( const QString &scope, const QString &key, const QStringList &value );
 
     /**
+     * Write a QgsProperty entry to the project file.
+     *
+     * Keys are '/'-delimited entries, implying
+     * a hierarchy of keys and corresponding values
+     *
+     * \note The key string must be valid xml tag names in order to be saved to the file.
+     */
+    bool writeEntry( const QString &scope, const QString &key, const QgsProperty &value );
+
+    /**
      * Key value accessors
      *
      * keys would be the familiar QgsSettings-like '/' delimited entries,
@@ -435,6 +445,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     int readNumEntry( const QString &scope, const QString &key, int def = 0, bool *ok = nullptr ) const;
     double readDoubleEntry( const QString &scope, const QString &key, double def = 0, bool *ok = nullptr ) const;
     bool readBoolEntry( const QString &scope, const QString &key, bool def = false, bool *ok = nullptr ) const;
+    QgsProperty readPropertyEntry( const QString &scope, const QString &key, QgsProperty def = QgsProperty(), bool *ok = nullptr ) const;
 
 
     //! Remove the given key

--- a/src/core/qgsprojectproperty.cpp
+++ b/src/core/qgsprojectproperty.cpp
@@ -19,6 +19,7 @@
 #include "qgslogger.h"
 #include "qgis.h"
 #include "qgsmessagelog.h"
+#include "qgsxmlutils.h"
 
 #include <QDomDocument>
 #include <QStringList>
@@ -87,8 +88,9 @@ bool QgsProjectPropertyValue::readXml( const QDomNode &keyNode )
       return false;
 
     case QVariant::Map:
-      QgsDebugMsg( QStringLiteral( "no support for QVariant::Map" ) );
-      return false;
+      //it's a property
+      mValue = QgsXmlUtils::readVariant( subkeyElement.firstChild().toElement() ).toMap();
+      break;
 
     case QVariant::List:
       QgsDebugMsg( QStringLiteral( "no support for QVariant::List" ) );
@@ -218,7 +220,6 @@ bool QgsProjectPropertyValue::readXml( const QDomNode &keyNode )
       value_ = QVariant( subkeyElement.text() ).toULongLong();
       break;
 #endif
-
     default :
       QgsDebugMsg( QStringLiteral( "unsupported value type %1 .. not properly translated to QVariant" ).arg( typeString ) );
   }
@@ -257,6 +258,11 @@ bool QgsProjectPropertyValue::writeXml( QString const &nodeName,
 
       valueElement.appendChild( stringListElement );
     }
+  }
+  else if ( QVariant::Map == mValue.type() )
+  {
+    QDomElement element = QgsXmlUtils::writeVariant( mValue, document );
+    valueElement.appendChild( element );
   }
   else                    // we just plop the value in as plain ole text
   {

--- a/src/core/qgsprojectproperty.cpp
+++ b/src/core/qgsprojectproperty.cpp
@@ -88,8 +88,8 @@ bool QgsProjectPropertyValue::readXml( const QDomNode &keyNode )
       return false;
 
     case QVariant::Map:
-      mValue = QgsXmlUtils::readVariant( subkeyElement.firstChild().toElement() ).toMap();
-      break;
+      QgsDebugMsg( QStringLiteral( "no support for QVariant::Map" ) );
+      return false;
 
     case QVariant::List:
       QgsDebugMsg( QStringLiteral( "no support for QVariant::List" ) );
@@ -257,11 +257,6 @@ bool QgsProjectPropertyValue::writeXml( QString const &nodeName,
 
       valueElement.appendChild( stringListElement );
     }
-  }
-  else if ( QVariant::Map == mValue.type() )
-  {
-    QDomElement element = QgsXmlUtils::writeVariant( mValue, document );
-    valueElement.appendChild( element );
   }
   else                    // we just plop the value in as plain ole text
   {

--- a/src/core/qgsprojectproperty.cpp
+++ b/src/core/qgsprojectproperty.cpp
@@ -19,7 +19,6 @@
 #include "qgslogger.h"
 #include "qgis.h"
 #include "qgsmessagelog.h"
-#include "qgsxmlutils.h"
 
 #include <QDomDocument>
 #include <QStringList>

--- a/src/core/qgsprojectproperty.cpp
+++ b/src/core/qgsprojectproperty.cpp
@@ -88,7 +88,6 @@ bool QgsProjectPropertyValue::readXml( const QDomNode &keyNode )
       return false;
 
     case QVariant::Map:
-      //it's a property
       mValue = QgsXmlUtils::readVariant( subkeyElement.firstChild().toElement() ).toMap();
       break;
 

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -67,10 +67,10 @@ QString QgsServerProjectUtils::owsServiceOnlineResource( const QgsProject &proje
 {
   QString wmsOnlineResource = project.readEntry( QStringLiteral( "WMSOnlineResource" ), QStringLiteral( "/" ) );
 
-  QgsProperty wmsOnlineResourceExpression = project.readPropertyEntry( QStringLiteral( "WMSOnlineResource" ), QStringLiteral( "/" ) );
+  QgsProperty wmsOnlineResourceExpression = project.readPropertyEntry( QStringLiteral( "WMSOnlineResourceExpression" ), QStringLiteral( "/" ) );
   if ( wmsOnlineResourceExpression.isActive() && ! wmsOnlineResourceExpression.expressionString().isEmpty() )
   {
-    QgsExpressionContext context;
+    QgsExpressionContext context = project.createExpressionContext();
     return wmsOnlineResourceExpression.valueAsString( context, wmsOnlineResource );
   }
 

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -65,7 +65,16 @@ QStringList QgsServerProjectUtils::owsServiceKeywords( const QgsProject &project
 
 QString QgsServerProjectUtils::owsServiceOnlineResource( const QgsProject &project )
 {
-  return project.readEntry( QStringLiteral( "WMSOnlineResource" ), QStringLiteral( "/" ) );
+  QString wmsOnlineResource = project.readEntry( QStringLiteral( "WMSOnlineResource" ), QStringLiteral( "/" ) );
+
+  QgsProperty wmsOnlineResourceExpression = project.readPropertyEntry( QStringLiteral( "WMSOnlineResource" ), QStringLiteral( "/" ) );
+  if ( wmsOnlineResourceExpression.isActive() && ! wmsOnlineResourceExpression.expressionString().isEmpty() )
+  {
+    QgsExpressionContext context;
+    return wmsOnlineResourceExpression.valueAsString( context, wmsOnlineResource );
+  }
+
+  return wmsOnlineResource;
 }
 
 QString QgsServerProjectUtils::owsServiceContactOrganization( const QgsProject &project )

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -67,11 +67,11 @@ QString QgsServerProjectUtils::owsServiceOnlineResource( const QgsProject &proje
 {
   QString wmsOnlineResource = project.readEntry( QStringLiteral( "WMSOnlineResource" ), QStringLiteral( "/" ) );
 
-  QgsProperty wmsOnlineResourceExpression = project.readPropertyEntry( QStringLiteral( "WMSOnlineResourceExpression" ), QStringLiteral( "/" ) );
-  if ( wmsOnlineResourceExpression.isActive() && ! wmsOnlineResourceExpression.expressionString().isEmpty() )
+  QgsProperty wmsOnlineResourceProperty = project.dataDefinedServerProperties().property( QgsProject::DataDefinedServerProperty::WMSOnlineResource );
+  if ( wmsOnlineResourceProperty.isActive() && ! wmsOnlineResourceProperty.expressionString().isEmpty() )
   {
     QgsExpressionContext context = project.createExpressionContext();
-    return wmsOnlineResourceExpression.valueAsString( context, wmsOnlineResource );
+    return wmsOnlineResourceProperty.valueAsString( context, wmsOnlineResource );
   }
 
   return wmsOnlineResource;

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -274,7 +274,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>671</width>
+                <width>590</width>
                 <height>828</height>
                </rect>
               </property>
@@ -897,8 +897,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>685</width>
-                <height>681</height>
+                <width>603</width>
+                <height>161</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -972,8 +972,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>685</width>
-                <height>681</height>
+                <width>290</width>
+                <height>543</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1611,7 +1611,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>671</width>
-                <height>2718</height>
+                <height>3090</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -1642,30 +1642,7 @@
                   <bool>true</bool>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_6">
-                  <item row="14" column="1">
-                   <widget class="QComboBox" name="mWMSAccessConstraintsCb">
-                    <property name="toolTip">
-                     <string>Access constraints applied to the service.</string>
-                    </property>
-                    <property name="editable">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="12" column="1">
-                   <widget class="QTextEdit" name="mWMSAbstract">
-                    <property name="toolTip">
-                     <string>The abstract is a descriptive narrative providing more information about the service.</string>
-                    </property>
-                    <property name="whatsThis">
-                     <string/>
-                    </property>
-                    <property name="documentTitle">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
+                  <item row="7" column="1">
                    <widget class="QLineEdit" name="mWMSName">
                     <property name="toolTip">
                      <string>A name used to identify the root layer. The short name is a text string used for machine-to-machine communication.</string>
@@ -1675,105 +1652,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="8" column="1">
-                   <widget class="QLineEdit" name="mWMSContactPerson">
-                    <property name="toolTip">
-                     <string>The contact person name for the service.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>The contact person name for the service.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="13" column="1">
-                   <widget class="QComboBox" name="mWMSFeesCb">
-                    <property name="toolTip">
-                     <string>Fees applied to the service.</string>
-                    </property>
-                    <property name="editable">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="QLineEdit" name="mWMSTitle">
-                    <property name="toolTip">
-                     <string>The title should be brief yet descriptive enough to identify this service.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>The title should be brief yet descriptive enough to identify this service.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="15" column="0">
-                   <widget class="QLabel" name="mWMSKeywordListLabel">
-                    <property name="text">
-                     <string>Keyword list</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="label_10">
-                    <property name="text">
-                     <string>Title</string>
-                    </property>
-                    <property name="buddy">
-                     <cstring>mWMSTitle</cstring>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="label_11">
-                    <property name="text">
-                     <string>Or&amp;ganization</string>
-                    </property>
-                    <property name="buddy">
-                     <cstring>mWMSContactOrganization</cstring>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="13" column="0">
-                   <widget class="QLabel" name="mWMSFeesLabel">
-                    <property name="text">
-                     <string>Fees</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="1">
-                   <widget class="QLineEdit" name="mWMSContactOrganization">
-                    <property name="toolTip">
-                     <string>The name of the service provider.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>The name of the service provider.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="9" column="0">
-                   <widget class="QLabel" name="label_20">
-                    <property name="text">
-                     <string>Position</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="11" column="0">
-                   <widget class="QLabel" name="label_12">
-                    <property name="text">
-                     <string>Phone</string>
-                    </property>
-                    <property name="buddy">
-                     <cstring>mWMSContactPhone</cstring>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="10" column="0">
-                   <widget class="QLabel" name="label_13">
-                    <property name="text">
-                     <string>E-Mail</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="9" column="1">
+                  <item row="16" column="1">
                    <widget class="QComboBox" name="mWMSContactPositionCb">
                     <property name="toolTip">
                      <string>The contact person position for the service.</string>
@@ -1786,71 +1665,27 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="15" column="1">
-                   <widget class="QLineEdit" name="mWMSKeywordList">
+                  <item row="21" column="1">
+                   <widget class="QComboBox" name="mWMSAccessConstraintsCb">
                     <property name="toolTip">
-                     <string>List of keywords separated by comma to help catalog searching.</string>
+                     <string>Access constraints applied to the service.</string>
+                    </property>
+                    <property name="editable">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="15" column="1">
+                   <widget class="QLineEdit" name="mWMSContactPerson">
+                    <property name="toolTip">
+                     <string>The contact person name for the service.</string>
                     </property>
                     <property name="placeholderText">
-                     <string>List of keywords separated by comma to help catalog searching.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="label_6">
-                    <property name="text">
-                     <string>Short name</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="12" column="0">
-                   <widget class="QLabel" name="label_15">
-                    <property name="text">
-                     <string>Abstract</string>
-                    </property>
-                    <property name="buddy">
-                     <cstring>mWMSAbstract</cstring>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="8" column="0">
-                   <widget class="QLabel" name="label_9">
-                    <property name="text">
-                     <string>&amp;Person</string>
-                    </property>
-                    <property name="buddy">
-                     <cstring>mWMSContactPerson</cstring>
+                     <string>The contact person name for the service.</string>
                     </property>
                    </widget>
                   </item>
                   <item row="11" column="1">
-                   <widget class="QLineEdit" name="mWMSContactPhone">
-                    <property name="toolTip">
-                     <string>The contact person phone for the service.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>The contact person phone for the service.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="10" column="1">
-                   <widget class="QLineEdit" name="mWMSContactMail">
-                    <property name="toolTip">
-                     <string>The contact person e-mail for the service.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>The contact person e-mail for the service.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="14" column="0">
-                   <widget class="QLabel" name="mWMSAccessConstraintsLabel">
-                    <property name="text">
-                     <string>Access constraints</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="4" column="1">
                    <layout class="QGridLayout" name="wmsOnlineResourceGrid">
                     <item row="0" column="0">
                      <widget class="QLineEdit" name="mWMSOnlineResourceLineEdit">
@@ -1863,18 +1698,235 @@
                      </widget>
                     </item>
                     <item row="0" column="1">
-                     <widget class="QgsPropertyOverrideButton" name="mWMSOnlineResourceExpressionButton">
-                      <property name="text">
+                     <widget class="QgsPropertyOverrideButton" name="mWMSOnlineResourceExpressionButton" native="true">
+                      <property name="text" stdset="0">
                        <string>...</string>
                       </property>
                      </widget>
                     </item>
                    </layout>
                   </item>
-                  <item row="4" column="0">
+                  <item row="16" column="0">
+                   <widget class="QLabel" name="label_20">
+                    <property name="text">
+                     <string>Position</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="8" column="1">
+                   <widget class="QLineEdit" name="mWMSTitle">
+                    <property name="toolTip">
+                     <string>The title should be brief yet descriptive enough to identify this service.</string>
+                    </property>
+                    <property name="placeholderText">
+                     <string>The title should be brief yet descriptive enough to identify this service.</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="20" column="1">
+                   <widget class="QComboBox" name="mWMSFeesCb">
+                    <property name="toolTip">
+                     <string>Fees applied to the service.</string>
+                    </property>
+                    <property name="editable">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="17" column="1">
+                   <widget class="QLineEdit" name="mWMSContactMail">
+                    <property name="toolTip">
+                     <string>The contact person e-mail for the service.</string>
+                    </property>
+                    <property name="placeholderText">
+                     <string>The contact person e-mail for the service.</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="19" column="1">
+                   <widget class="QTextEdit" name="mWMSAbstract">
+                    <property name="toolTip">
+                     <string>The abstract is a descriptive narrative providing more information about the service.</string>
+                    </property>
+                    <property name="whatsThis">
+                     <string/>
+                    </property>
+                    <property name="documentTitle">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="9" column="0">
+                   <widget class="QLabel" name="label_11">
+                    <property name="text">
+                     <string>Or&amp;ganization</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>mWMSContactOrganization</cstring>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="21" column="0">
+                   <widget class="QLabel" name="mWMSAccessConstraintsLabel">
+                    <property name="text">
+                     <string>Access constraints</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="18" column="0">
+                   <widget class="QLabel" name="label_12">
+                    <property name="text">
+                     <string>Phone</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>mWMSContactPhone</cstring>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="18" column="1">
+                   <widget class="QLineEdit" name="mWMSContactPhone">
+                    <property name="toolTip">
+                     <string>The contact person phone for the service.</string>
+                    </property>
+                    <property name="placeholderText">
+                     <string>The contact person phone for the service.</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="8" column="0">
+                   <widget class="QLabel" name="label_10">
+                    <property name="text">
+                     <string>Title</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>mWMSTitle</cstring>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0" colspan="2">
+                   <widget class="QFrame" name="wmsWarningBox">
+                    <property name="autoFillBackground">
+                     <bool>false</bool>
+                    </property>
+                    <property name="styleSheet">
+                     <string notr="true"/>
+                    </property>
+                    <property name="frameShape">
+                     <enum>QFrame::StyledPanel</enum>
+                    </property>
+                    <property name="frameShadow">
+                     <enum>QFrame::Raised</enum>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_23">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item row="0" column="0">
+                      <widget class="QLabel" name="warningLabel">
+                       <property name="styleSheet">
+                        <string notr="true">background-color: rgba(255,165,0,0.3);</string>
+                       </property>
+                       <property name="frameShape">
+                        <enum>QFrame::NoFrame</enum>
+                       </property>
+                       <property name="text">
+                        <string>These parameters are used to generate the GetCapabilities document and shall be chosen carefully to avoid interoperability and security issues.</string>
+                       </property>
+                       <property name="textFormat">
+                        <enum>Qt::AutoText</enum>
+                       </property>
+                       <property name="wordWrap">
+                        <bool>true</bool>
+                       </property>
+                       <property name="margin">
+                        <number>9</number>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item row="22" column="1">
+                   <widget class="QLineEdit" name="mWMSKeywordList">
+                    <property name="toolTip">
+                     <string>List of keywords separated by comma to help catalog searching.</string>
+                    </property>
+                    <property name="placeholderText">
+                     <string>List of keywords separated by comma to help catalog searching.</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="17" column="0">
+                   <widget class="QLabel" name="label_13">
+                    <property name="text">
+                     <string>E-Mail</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="19" column="0">
+                   <widget class="QLabel" name="label_15">
+                    <property name="text">
+                     <string>Abstract</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>mWMSAbstract</cstring>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="22" column="0">
+                   <widget class="QLabel" name="mWMSKeywordListLabel">
+                    <property name="text">
+                     <string>Keyword list</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="15" column="0">
+                   <widget class="QLabel" name="label_9">
+                    <property name="text">
+                     <string>&amp;Person</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>mWMSContactPerson</cstring>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="9" column="1">
+                   <widget class="QLineEdit" name="mWMSContactOrganization">
+                    <property name="toolTip">
+                     <string>The name of the service provider.</string>
+                    </property>
+                    <property name="placeholderText">
+                     <string>The name of the service provider.</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="20" column="0">
+                   <widget class="QLabel" name="mWMSFeesLabel">
+                    <property name="text">
+                     <string>Fees</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="11" column="0">
                    <widget class="QLabel" name="mWMSOnlineResourceLabel">
                     <property name="text">
                      <string>Online resource</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="7" column="0">
+                   <widget class="QLabel" name="label_6">
+                    <property name="text">
+                     <string>Short name</string>
                     </property>
                    </widget>
                   </item>
@@ -2139,16 +2191,6 @@
                      <bool>true</bool>
                     </property>
                     <layout class="QGridLayout" name="gridLayout_4">
-                     <item row="0" column="0">
-                      <widget class="QLabel" name="label_16">
-                       <property name="text">
-                        <string>Min. &amp;X</string>
-                       </property>
-                       <property name="buddy">
-                        <cstring>mWMSExtMinX</cstring>
-                       </property>
-                      </widget>
-                     </item>
                      <item row="0" column="1">
                       <widget class="QLineEdit" name="mWMSExtMinX">
                        <property name="text">
@@ -2163,6 +2205,29 @@
                        </property>
                        <property name="buddy">
                         <cstring>mWMSExtMinY</cstring>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="5" column="0" colspan="2">
+                      <spacer name="verticalSpacer_3">
+                       <property name="orientation">
+                        <enum>Qt::Vertical</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>20</width>
+                         <height>40</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item row="0" column="0">
+                      <widget class="QLabel" name="label_16">
+                       <property name="text">
+                        <string>Min. &amp;X</string>
+                       </property>
+                       <property name="buddy">
+                        <cstring>mWMSExtMinX</cstring>
                        </property>
                       </widget>
                      </item>
@@ -2183,10 +2248,10 @@
                        </property>
                       </widget>
                      </item>
-                     <item row="2" column="1">
-                      <widget class="QLineEdit" name="mWMSExtMaxX">
+                     <item row="4" column="0" colspan="2">
+                      <widget class="QPushButton" name="pbnWMSExtCanvas">
                        <property name="text">
-                        <string/>
+                        <string>Use Current Canvas Extent</string>
                        </property>
                       </widget>
                      </item>
@@ -2207,25 +2272,12 @@
                        </property>
                       </widget>
                      </item>
-                     <item row="4" column="0" colspan="2">
-                      <widget class="QPushButton" name="pbnWMSExtCanvas">
+                     <item row="2" column="1">
+                      <widget class="QLineEdit" name="mWMSExtMaxX">
                        <property name="text">
-                        <string>Use Current Canvas Extent</string>
+                        <string/>
                        </property>
                       </widget>
-                     </item>
-                     <item row="5" column="0" colspan="2">
-                      <spacer name="verticalSpacer_3">
-                       <property name="orientation">
-                        <enum>Qt::Vertical</enum>
-                       </property>
-                       <property name="sizeHint" stdset="0">
-                        <size>
-                         <width>20</width>
-                         <height>40</height>
-                        </size>
-                       </property>
-                      </spacer>
                      </item>
                     </layout>
                    </widget>
@@ -3064,6 +3116,11 @@
    <extends>QWidget</extends>
    <header>qgsprojectionselectiontreewidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QWidget</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -245,7 +245,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>8</number>
          </property>
          <widget class="QWidget" name="mProjOptsGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -275,7 +275,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>671</width>
-                <height>865</height>
+                <height>828</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout">
@@ -897,8 +897,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>587</width>
-                <height>167</height>
+                <width>685</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -972,8 +972,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>288</width>
-                <height>563</height>
+                <width>685</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1548,8 +1548,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>177</width>
-                <height>56</height>
+                <width>178</width>
+                <height>54</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_17">
@@ -1610,8 +1610,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>643</width>
-                <height>2818</height>
+                <width>671</width>
+                <height>2718</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -1642,185 +1642,7 @@
                   <bool>true</bool>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_6">
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="label_10">
-                    <property name="text">
-                     <string>Title</string>
-                    </property>
-                    <property name="buddy">
-                     <cstring>mWMSTitle</cstring>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="1">
-                   <widget class="QLineEdit" name="mWMSOnlineResourceLineEdit">
-                    <property name="toolTip">
-                     <string>The web site URL of the service provider.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>The web site URL of the service provider.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QLabel" name="mWMSOnlineResourceLabel">
-                    <property name="text">
-                     <string>Online resource</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="4" column="0">
-                   <widget class="QLabel" name="label_9">
-                    <property name="text">
-                     <string>&amp;Person</string>
-                    </property>
-                    <property name="buddy">
-                     <cstring>mWMSContactPerson</cstring>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="1">
-                   <widget class="QLineEdit" name="mWMSContactMail">
-                    <property name="toolTip">
-                     <string>The contact person e-mail for the service.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>The contact person e-mail for the service.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="4" column="1">
-                   <widget class="QLineEdit" name="mWMSContactPerson">
-                    <property name="toolTip">
-                     <string>The contact person name for the service.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>The contact person name for the service.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="0">
-                   <widget class="QLabel" name="label_13">
-                    <property name="text">
-                     <string>E-Mail</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="1">
-                   <widget class="QLineEdit" name="mWMSContactOrganization">
-                    <property name="toolTip">
-                     <string>The name of the service provider.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>The name of the service provider.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="7" column="0">
-                   <widget class="QLabel" name="label_12">
-                    <property name="text">
-                     <string>Phone</string>
-                    </property>
-                    <property name="buddy">
-                     <cstring>mWMSContactPhone</cstring>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="QLineEdit" name="mWMSTitle">
-                    <property name="toolTip">
-                     <string>The title should be brief yet descriptive enough to identify this service.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>The title should be brief yet descriptive enough to identify this service.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="8" column="0">
-                   <widget class="QLabel" name="label_15">
-                    <property name="text">
-                     <string>Abstract</string>
-                    </property>
-                    <property name="buddy">
-                     <cstring>mWMSAbstract</cstring>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="7" column="1">
-                   <widget class="QLineEdit" name="mWMSContactPhone">
-                    <property name="toolTip">
-                     <string>The contact person phone for the service.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>The contact person phone for the service.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="8" column="1">
-                   <widget class="QTextEdit" name="mWMSAbstract">
-                    <property name="toolTip">
-                     <string>The abstract is a descriptive narrative providing more information about the service.</string>
-                    </property>
-                    <property name="whatsThis">
-                     <string/>
-                    </property>
-                    <property name="documentTitle">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="11" column="0">
-                   <widget class="QLabel" name="mWMSKeywordListLabel">
-                    <property name="text">
-                     <string>Keyword list</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="11" column="1">
-                   <widget class="QLineEdit" name="mWMSKeywordList">
-                    <property name="toolTip">
-                     <string>List of keywords separated by comma to help catalog searching.</string>
-                    </property>
-                    <property name="placeholderText">
-                     <string>List of keywords separated by comma to help catalog searching.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="label_11">
-                    <property name="text">
-                     <string>Or&amp;ganization</string>
-                    </property>
-                    <property name="buddy">
-                     <cstring>mWMSContactOrganization</cstring>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="10" column="0">
-                   <widget class="QLabel" name="mWMSAccessConstraintsLabel">
-                    <property name="text">
-                     <string>Access constraints</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="9" column="0">
-                   <widget class="QLabel" name="mWMSFeesLabel">
-                    <property name="text">
-                     <string>Fees</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="9" column="1">
-                   <widget class="QComboBox" name="mWMSFeesCb">
-                    <property name="toolTip">
-                     <string>Fees applied to the service.</string>
-                    </property>
-                    <property name="editable">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="10" column="1">
+                  <item row="14" column="1">
                    <widget class="QComboBox" name="mWMSAccessConstraintsCb">
                     <property name="toolTip">
                      <string>Access constraints applied to the service.</string>
@@ -1830,23 +1652,16 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="5" column="0">
-                   <widget class="QLabel" name="label_20">
-                    <property name="text">
-                     <string>Position</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="1">
-                   <widget class="QComboBox" name="mWMSContactPositionCb">
+                  <item row="12" column="1">
+                   <widget class="QTextEdit" name="mWMSAbstract">
                     <property name="toolTip">
-                     <string>The contact person position for the service.</string>
+                     <string>The abstract is a descriptive narrative providing more information about the service.</string>
                     </property>
-                    <property name="accessibleDescription">
+                    <property name="whatsThis">
                      <string/>
                     </property>
-                    <property name="editable">
-                     <bool>true</bool>
+                    <property name="documentTitle">
+                     <string/>
                     </property>
                    </widget>
                   </item>
@@ -1860,10 +1675,206 @@
                     </property>
                    </widget>
                   </item>
+                  <item row="8" column="1">
+                   <widget class="QLineEdit" name="mWMSContactPerson">
+                    <property name="toolTip">
+                     <string>The contact person name for the service.</string>
+                    </property>
+                    <property name="placeholderText">
+                     <string>The contact person name for the service.</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="13" column="1">
+                   <widget class="QComboBox" name="mWMSFeesCb">
+                    <property name="toolTip">
+                     <string>Fees applied to the service.</string>
+                    </property>
+                    <property name="editable">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QLineEdit" name="mWMSTitle">
+                    <property name="toolTip">
+                     <string>The title should be brief yet descriptive enough to identify this service.</string>
+                    </property>
+                    <property name="placeholderText">
+                     <string>The title should be brief yet descriptive enough to identify this service.</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="15" column="0">
+                   <widget class="QLabel" name="mWMSKeywordListLabel">
+                    <property name="text">
+                     <string>Keyword list</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_10">
+                    <property name="text">
+                     <string>Title</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>mWMSTitle</cstring>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="label_11">
+                    <property name="text">
+                     <string>Or&amp;ganization</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>mWMSContactOrganization</cstring>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="13" column="0">
+                   <widget class="QLabel" name="mWMSFeesLabel">
+                    <property name="text">
+                     <string>Fees</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <widget class="QLineEdit" name="mWMSContactOrganization">
+                    <property name="toolTip">
+                     <string>The name of the service provider.</string>
+                    </property>
+                    <property name="placeholderText">
+                     <string>The name of the service provider.</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="9" column="0">
+                   <widget class="QLabel" name="label_20">
+                    <property name="text">
+                     <string>Position</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="11" column="0">
+                   <widget class="QLabel" name="label_12">
+                    <property name="text">
+                     <string>Phone</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>mWMSContactPhone</cstring>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="10" column="0">
+                   <widget class="QLabel" name="label_13">
+                    <property name="text">
+                     <string>E-Mail</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="9" column="1">
+                   <widget class="QComboBox" name="mWMSContactPositionCb">
+                    <property name="toolTip">
+                     <string>The contact person position for the service.</string>
+                    </property>
+                    <property name="accessibleDescription">
+                     <string/>
+                    </property>
+                    <property name="editable">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="15" column="1">
+                   <widget class="QLineEdit" name="mWMSKeywordList">
+                    <property name="toolTip">
+                     <string>List of keywords separated by comma to help catalog searching.</string>
+                    </property>
+                    <property name="placeholderText">
+                     <string>List of keywords separated by comma to help catalog searching.</string>
+                    </property>
+                   </widget>
+                  </item>
                   <item row="0" column="0">
                    <widget class="QLabel" name="label_6">
                     <property name="text">
                      <string>Short name</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="12" column="0">
+                   <widget class="QLabel" name="label_15">
+                    <property name="text">
+                     <string>Abstract</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>mWMSAbstract</cstring>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="8" column="0">
+                   <widget class="QLabel" name="label_9">
+                    <property name="text">
+                     <string>&amp;Person</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>mWMSContactPerson</cstring>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="11" column="1">
+                   <widget class="QLineEdit" name="mWMSContactPhone">
+                    <property name="toolTip">
+                     <string>The contact person phone for the service.</string>
+                    </property>
+                    <property name="placeholderText">
+                     <string>The contact person phone for the service.</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="10" column="1">
+                   <widget class="QLineEdit" name="mWMSContactMail">
+                    <property name="toolTip">
+                     <string>The contact person e-mail for the service.</string>
+                    </property>
+                    <property name="placeholderText">
+                     <string>The contact person e-mail for the service.</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="14" column="0">
+                   <widget class="QLabel" name="mWMSAccessConstraintsLabel">
+                    <property name="text">
+                     <string>Access constraints</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="1">
+                   <layout class="QGridLayout" name="wmsOnlineResourceGrid">
+                    <item row="0" column="0">
+                     <widget class="QLineEdit" name="mWMSOnlineResourceLineEdit">
+                      <property name="toolTip">
+                       <string>The web site URL of the service provider.</string>
+                      </property>
+                      <property name="placeholderText">
+                       <string>The web site URL of the service provider.</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="1">
+                     <widget class="QgsPropertyOverrideButton" name="mWMSOnlineResourceExpressionButton">
+                      <property name="text">
+                       <string>...</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="4" column="0">
+                   <widget class="QLabel" name="mWMSOnlineResourceLabel">
+                    <property name="text">
+                     <string>Online resource</string>
                     </property>
                    </widget>
                   </item>
@@ -2009,14 +2020,14 @@
                      <bool>true</bool>
                     </property>
                     <layout class="QGridLayout" name="gridLayout_5">
-                     <item row="1" column="0">
-                      <widget class="QToolButton" name="pbnWMSAddSRS">
+                     <item row="1" column="1">
+                      <widget class="QToolButton" name="pbnWMSRemoveSRS">
                        <property name="toolTip">
-                        <string>Add new CRS</string>
+                        <string>Remove selected CRS</string>
                        </property>
                        <property name="icon">
                         <iconset resource="../../images/images.qrc">
-                         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+                         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
                        </property>
                       </widget>
                      </item>
@@ -2033,14 +2044,14 @@
                        </property>
                       </widget>
                      </item>
-                     <item row="1" column="1">
-                      <widget class="QToolButton" name="pbnWMSRemoveSRS">
+                     <item row="1" column="0">
+                      <widget class="QToolButton" name="pbnWMSAddSRS">
                        <property name="toolTip">
-                        <string>Remove selected CRS</string>
+                        <string>Add new CRS</string>
                        </property>
                        <property name="icon">
                         <iconset resource="../../images/images.qrc">
-                         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+                         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
                        </property>
                       </widget>
                      </item>
@@ -2991,6 +3002,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsFilterLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qgsfilterlineedit.h</header>
@@ -3005,12 +3022,6 @@
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -3112,7 +3123,6 @@
   <tabstop>mWMSName</tabstop>
   <tabstop>mWMSTitle</tabstop>
   <tabstop>mWMSContactOrganization</tabstop>
-  <tabstop>mWMSOnlineResourceLineEdit</tabstop>
   <tabstop>mWMSContactPerson</tabstop>
   <tabstop>mWMSContactPositionCb</tabstop>
   <tabstop>mWMSContactMail</tabstop>
@@ -3171,8 +3181,6 @@
   <tabstop>teOWSChecker</tabstop>
  </tabstops>
  <resources>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>


### PR DESCRIPTION
In ***Project Properties > QGIS Server > Service Capabilities*** values can be defined that are send back on capabilities requests. One of them is ***Online resource*** and this can have an override expression with the global and the projet scope.

![BEES](https://user-images.githubusercontent.com/28384354/81914060-14546480-95d1-11ea-9705-b68127f495bb.png)


Returns on `...bees_in_ticino.qgs&SERVICE=WMS&REQUEST=GetCapabilities`
```
<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="www.mayasbees.ch/bees_in_ticino"/>
```

resolves #36425

## Additional ideas:
- Are there any inputs on what properties it would make sense to have an override as well in future?
- Maybe in future it would make sense to be able to use the input request properties as kind of `serverRequestContext` appended to the expression evaluation.
