### PR TITLE
Safename for scope variable shouldn't contain ".". Fixes #36377

### DIFF
--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -826,7 +826,7 @@ QMap<QString, QgsProcessingModelAlgorithm::VariableDefinition> QgsProcessingMode
   auto safeName = []( const QString & name )->QString
   {
     QString s = name;
-    return s.replace( QRegularExpression( QStringLiteral( "[\\s'\"\\(\\):.]" ) ), QStringLiteral( "_" ) );
+    return s.replace( QRegularExpression( QStringLiteral( "[\\s'\"\\(\\):\\.]" ) ), QStringLiteral( "_" ) );
   };
 
   // "static"/single value sources

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -826,7 +826,7 @@ QMap<QString, QgsProcessingModelAlgorithm::VariableDefinition> QgsProcessingMode
   auto safeName = []( const QString & name )->QString
   {
     QString s = name;
-    return s.replace( QRegularExpression( QStringLiteral( "[\\s'\"\\(\\):]" ) ), QStringLiteral( "_" ) );
+    return s.replace( QRegularExpression( QStringLiteral( "[\\s'\"\\(\\):.]" ) ), QStringLiteral( "_" ) );
   };
 
   // "static"/single value sources

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -9455,14 +9455,14 @@ void TestQgsProcessing::modelExecution()
   // name of the variable is get from childDescription or childId. To avoid using grass provider
   // is simpler to use native algorithm and change it's description.
   // test to check fix https://github.com/qgis/QGIS/issues/36377
-  QgsProcessingModelChildAlgorithm& cx1 = model2.childAlgorithm("cx1");
+  QgsProcessingModelChildAlgorithm& cx1 = model2.childAlgorithm( "cx1" );
   QString oldDescription = cx1.description();
-  cx1.setDescription("cx '():.1");
+  cx1.setDescription( "cx '():.1" );
   variables = model2.variablesForChildAlgorithm( "cx3", context );
   QVERIFY( !variables.contains( "cx1_OUTPUT" ) );
   QVERIFY( !variables.contains( "cx '():.1_OUTPUT" ) );
   QVERIFY( variables.contains( "cx______1_OUTPUT" ) );
-  cx1.setDescription(oldDescription); // set descrin back to avoid fail of following tests
+  cx1.setDescription( oldDescription ); // set descrin back to avoid fail of following tests
 
   // test to python convertion
   model2.setName( QStringLiteral( "2my model" ) );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -9455,7 +9455,7 @@ void TestQgsProcessing::modelExecution()
   // name of the variable is get from childDescription or childId. To avoid using grass provider
   // is simpler to use native algorithm and change it's description.
   // test to check fix https://github.com/qgis/QGIS/issues/36377
-  QgsProcessingModelChildAlgorithm& cx1 = model2.childAlgorithm( "cx1" );
+  QgsProcessingModelChildAlgorithm &cx1 = model2.childAlgorithm( "cx1" );
   QString oldDescription = cx1.description();
   cx1.setDescription( "cx '():.1" );
   variables = model2.variablesForChildAlgorithm( "cx3", context );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -9462,7 +9462,7 @@ void TestQgsProcessing::modelExecution()
   QVERIFY( variables.contains( "cx______1_OUTPUT" ) );
   cx1.setDescription( oldDescription ); // set descrin back to avoid fail of following tests
 
-  // test to python convertion
+  // test model to python conversion
   model2.setName( QStringLiteral( "2my model" ) );
   model2.childAlgorithm( "cx1" ).modelOutput( QStringLiteral( "MODEL_OUT_LAYER" ) ).setDescription( "my model output" );
   model2.updateDestinationParameters();

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -9452,9 +9452,7 @@ void TestQgsProcessing::modelExecution()
   // test safe name of the child alg parameter as source to another algoritmn
   // parameter name should have [\s ' ( ) : .] chars changed to "_" (regexp [\\s'\"\\(\\):\.])
   // this case is esecially important in case of grass algs where name algorithm contains "."
-  // name of the variable is get from childDescription or childId. To avoid using grass provider
-  // is simpler to use native algorithm and change it's description.
-  // test to check fix https://github.com/qgis/QGIS/issues/36377
+  // name of the variable is get from childDescription or childId. Refs https://github.com/qgis/QGIS/issues/36377
   QgsProcessingModelChildAlgorithm &cx1 = model2.childAlgorithm( "cx1" );
   QString oldDescription = cx1.description();
   cx1.setDescription( "cx '():.1" );


### PR DESCRIPTION
## Description

output variable names added in the algorithm sope are build from command name, and if the command is a grass command it contains "." generating error in expression parsing.
This PR add "." as sanitised character to the other chars already sanitised in the QgsProcessingModelAlgorithm::variablesForChildAlgorithm call

micro fix sponsored by GaliciaSustentable (https://fgsustentable.org/)