### PR TITLE
Minor typo corrected

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1765,7 +1765,7 @@ void QgsWmsProvider::parseServiceException( QDomElement const &e, QString &error
     if ( locator == QLatin1String( "time" ) )
       errorText = tr( "Request contains a time value that does not match any available layer in the server." );
     else
-      errorText = tr( "Request contains some parameter value that does not match any available layer in the server" );
+      errorText = tr( "Request contains some parameter values that does not match any available layer in the server" );
   }
   else if ( seCode.isEmpty() )
   {

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1765,7 +1765,7 @@ void QgsWmsProvider::parseServiceException( QDomElement const &e, QString &error
     if ( locator == QLatin1String( "time" ) )
       errorText = tr( "Request contains a time value that does not match any available layer in the server." );
     else
-      errorText = tr( "Request contains some parameter values that does not match any available layer in the server" );
+      errorText = tr( "Request contains some parameter values that do not match any available layer in the server" );
   }
   else if ( seCode.isEmpty() )
   {


### PR DESCRIPTION
## Description

Line 1768 : "some parameter value" should probably be plural: "some parameter values", otherwise better to change "some"with "a"

Should probably be backported to 3.10. Not sure though

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
