### PR TITLE
Fix SIP QgsHighlight class declaration

### DIFF
--- a/python/gui/auto_generated/qgshighlight.sip.in
+++ b/python/gui/auto_generated/qgshighlight.sip.in
@@ -13,7 +13,7 @@
 #include <qgshighlight.h>
 %End
 
-class QgsHighlight: QObject, QgsMapCanvasItem
+class QgsHighlight : QgsMapCanvasItem
 {
 %Docstring
 A class for highlight features on the map.

--- a/src/gui/qgshighlight.h
+++ b/src/gui/qgshighlight.h
@@ -53,8 +53,14 @@ class QgsSymbol;
  *   highlight.show()
  * \endcode
  */
+#ifndef SIP_RUN
 class GUI_EXPORT QgsHighlight: public QObject, public QgsMapCanvasItem
 {
+#else
+class GUI_EXPORT QgsHighlight : public QgsMapCanvasItem
+{
+#endif
+
     Q_OBJECT
 
 #ifdef SIP_RUN


### PR DESCRIPTION
Fixes  #34457 : missing SIP_RUN class specific declaration

SIP doesn't like double inheritance. Same as #36240, #32755 