### PR TITLE
Fix generating negative random values

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -434,6 +434,17 @@ static QVariant fcnRnd( const QVariantList &values, const QgsExpressionContext *
     generator.seed( seed );
   }
 
+  qint64 randomInteger = min + ( generator() % ( max - min + 1 ) );
+  if ( randomInteger  > std::numeric_limits<int>::max() || randomInteger < -std::numeric_limits<int>::max() )
+  {
+    return QVariant( randomInteger );
+  }
+  else
+  {
+    // Prevent wrong conversion of QVariant. See #36412
+    return QVariant( int( randomInteger ) );
+  }
+
   // Return a random integer in the range [min, max] (inclusive)
   return QVariant( min + ( generator() % ( max - min + 1 ) ) );
 }

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -550,6 +550,16 @@ void TestQgsField::convertCompatible()
   QVERIFY( intField.convertCompatible( smallLonglong ) );
   QCOMPARE( smallLonglong.type(), QVariant::Int );
   QCOMPARE( smallLonglong, QVariant( 99 ) );
+  // negative longlong to int
+  QVariant negativeLonglong( -99999999999999999LL );
+  QVERIFY( !intField.convertCompatible( negativeLonglong ) );
+  QCOMPARE( negativeLonglong.type(), QVariant::Int );
+  QVERIFY( negativeLonglong.isNull() );
+  // small negative longlong to int
+  QVariant smallNegativeLonglong( -99LL );
+  QVERIFY( intField.convertCompatible( smallNegativeLonglong ) );
+  QCOMPARE( smallNegativeLonglong.type(), QVariant::Int );
+  QCOMPARE( smallNegativeLonglong, QVariant( -99 ) );
 
   //string representation of an int
   QVariant stringInt( "123456" );


### PR DESCRIPTION
## Description

Prevent QVariant's conversion to int64 if int is enough.

![rand_int](https://user-images.githubusercontent.com/1421861/81980974-e5b9a680-962f-11ea-9407-ddabfed7049d.gif)

Fixes #36412


<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
