### PR TITLE
Vector tile layer - part 10 (properties dialog)

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -114,6 +114,8 @@ SET(QGIS_APP_SRCS
   decorations/qgsdecorationgrid.cpp
   decorations/qgsdecorationgriddialog.cpp
 
+  vectortile/qgsvectortilelayerproperties.cpp
+
   vertextool/qgslockedfeature.cpp
   vertextool/qgsvertexeditor.cpp
   vertextool/qgsvertextool.cpp
@@ -383,6 +385,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/app/dwg
   ${CMAKE_SOURCE_DIR}/src/app/mesh
   ${CMAKE_SOURCE_DIR}/src/app/locator
+  ${CMAKE_SOURCE_DIR}/src/app/vectortile
   ${CMAKE_SOURCE_DIR}/src/analysis
   ${CMAKE_SOURCE_DIR}/src/analysis/raster
   ${CMAKE_SOURCE_DIR}/src/analysis/mesh

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -342,6 +342,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsvectorlayerproperties.h"
 #include "qgsvectorlayerdigitizingproperties.h"
 #include "qgsvectortilelayer.h"
+#include "qgsvectortilelayerproperties.h"
 #include "qgsmapthemes.h"
 #include "qgsmessagelogviewer.h"
 #include "qgsdataitem.h"
@@ -15453,7 +15454,17 @@ void QgisApp::showLayerProperties( QgsMapLayer *mapLayer, const QString &page )
 
     case QgsMapLayerType::VectorTileLayer:
     {
-      // TODO
+      QgsVectorTileLayerProperties vectorTileLayerPropertiesDialog( qobject_cast<QgsVectorTileLayer *>( mapLayer ), mMapCanvas, visibleMessageBar(), this );
+      if ( !page.isEmpty() )
+        vectorTileLayerPropertiesDialog.setCurrentPage( page );
+
+      mMapStyleWidget->blockUpdates( true );
+      if ( vectorTileLayerPropertiesDialog.exec() )
+      {
+        activateDeactivateLayerRelatedActions( mapLayer );
+        mMapStyleWidget->updateCurrentWidgetLayer();
+      }
+      mMapStyleWidget->blockUpdates( false ); // delete since dialog cannot be reused without updating code
       break;
     }
 

--- a/src/app/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/app/vectortile/qgsvectortilelayerproperties.cpp
@@ -1,0 +1,236 @@
+/***************************************************************************
+  qgsvectortilelayerproperties.cpp
+  --------------------------------------
+  Date                 : May 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvectortilelayerproperties.h"
+
+#include "qgsfileutils.h"
+#include "qgshelp.h"
+#include "qgsmaplayerstylemanager.h"
+#include "qgsmaplayerstyleguiutils.h"
+#include "qgsvectortilebasicrendererwidget.h"
+#include "qgsvectortilebasiclabelingwidget.h"
+#include "qgsvectortilelayer.h"
+
+#include <QFileDialog>
+#include <QMenu>
+#include <QMessageBox>
+
+
+QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *lyr, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent, Qt::WindowFlags flags )
+  : QgsOptionsDialogBase( QStringLiteral( "VectorTileLayerProperties" ), parent, flags )
+  , mLayer( lyr )
+{
+  setupUi( this );
+
+  mRendererWidget = new QgsVectorTileBasicRendererWidget( nullptr, canvas, messageBar, this );
+  mOptsPage_Style->layout()->addWidget( mRendererWidget );
+
+  mLabelingWidget = new QgsVectorTileBasicLabelingWidget( nullptr, canvas, messageBar, this );
+  mOptsPage_Labeling->layout()->addWidget( mLabelingWidget );
+
+  connect( this, &QDialog::accepted, this, &QgsVectorTileLayerProperties::apply );
+  connect( buttonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsVectorTileLayerProperties::apply );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsVectorTileLayerProperties::showHelp );
+
+  // QgsOptionsDialogBase handles saving/restoring of geometry, splitter and current tab states,
+  // switching vertical tabs between icon/text to icon-only modes (splitter collapsed to left),
+  // and connecting QDialogButtonBox's accepted/rejected signals to dialog's accept/reject slots
+  initOptionsBase( false );
+
+  // update based on lyr's current state
+  syncToLayer();
+
+  QgsSettings settings;
+  // if dialog hasn't been opened/closed yet, default to Styles tab, which is used most often
+  // this will be read by restoreOptionsBaseUi()
+  if ( !settings.contains( QStringLiteral( "/Windows/VectorTileLayerProperties/tab" ) ) )
+  {
+    settings.setValue( QStringLiteral( "Windows/VectorTileLayerProperties/tab" ),
+                       mOptStackedWidget->indexOf( mOptsPage_Style ) );
+  }
+
+  QString title = QString( tr( "Layer Properties - %1" ) ).arg( mLayer->name() );
+
+  if ( !mLayer->styleManager()->isDefault( mLayer->styleManager()->currentStyle() ) )
+    title += QStringLiteral( " (%1)" ).arg( mLayer->styleManager()->currentStyle() );
+  restoreOptionsBaseUi( title );
+
+  QPushButton *btnStyle = new QPushButton( tr( "Style" ) );
+  QMenu *menuStyle = new QMenu( this );
+  menuStyle->addAction( tr( "Load Style…" ), this, &QgsVectorTileLayerProperties::loadStyle );
+  menuStyle->addAction( tr( "Save Style…" ), this, &QgsVectorTileLayerProperties::saveStyleAs );
+  menuStyle->addSeparator();
+  menuStyle->addAction( tr( "Save as Default" ), this, &QgsVectorTileLayerProperties::saveDefaultStyle );
+  menuStyle->addAction( tr( "Restore Default" ), this, &QgsVectorTileLayerProperties::loadDefaultStyle );
+  btnStyle->setMenu( menuStyle );
+  connect( menuStyle, &QMenu::aboutToShow, this, &QgsVectorTileLayerProperties::aboutToShowStyleMenu );
+
+  buttonBox->addButton( btnStyle, QDialogButtonBox::ResetRole );
+}
+
+void QgsVectorTileLayerProperties::apply()
+{
+  mRendererWidget->apply();
+  mLabelingWidget->apply();
+}
+
+void QgsVectorTileLayerProperties::syncToLayer()
+{
+  /*
+   * Information Tab
+   */
+  QString info;
+  info += QStringLiteral( "<table>" );
+  info += QStringLiteral( "<tr><td>%1: </td><td>%2</td><tr>" ).arg( tr( "Uri" ) ).arg( mLayer->source() );
+  info += QStringLiteral( "<tr><td>%1: </td><td>%2</td><tr>" ).arg( tr( "Source Type" ) ).arg( mLayer->sourceType() );
+  info += QStringLiteral( "<tr><td>%1: </td><td>%2</td><tr>" ).arg( tr( "Source Path" ) ).arg( mLayer->sourcePath() );
+  info += QStringLiteral( "<tr><td>%1: </td><td>%2 - %3</td><tr>" ).arg( tr( "Zoom Levels" ) ).arg( mLayer->sourceMinZoom() ).arg( mLayer->sourceMaxZoom() );
+  info += QStringLiteral( "</table>" );
+  mInformationTextBrowser->setText( info );
+
+  /*
+   * Symbology Tab
+   */
+  mRendererWidget->setLayer( mLayer );
+
+  /*
+   * Labels Tab
+   */
+  mLabelingWidget->setLayer( mLayer );
+}
+
+
+void QgsVectorTileLayerProperties::loadDefaultStyle()
+{
+  bool defaultLoadedFlag = false;
+  QString myMessage = mLayer->loadDefaultStyle( defaultLoadedFlag );
+  // reset if the default style was loaded OK only
+  if ( defaultLoadedFlag )
+  {
+    syncToLayer();
+  }
+  else
+  {
+    // otherwise let the user know what went wrong
+    QMessageBox::information( this,
+                              tr( "Default Style" ),
+                              myMessage
+                            );
+  }
+}
+
+void QgsVectorTileLayerProperties::saveDefaultStyle()
+{
+  apply(); // make sure the style to save is up-to-date
+
+  // a flag passed by reference
+  bool defaultSavedFlag = false;
+  // after calling this the above flag will be set true for success
+  // or false if the save operation failed
+  QString myMessage = mLayer->saveDefaultStyle( defaultSavedFlag );
+  if ( !defaultSavedFlag )
+  {
+    // let the user know what went wrong
+    QMessageBox::information( this,
+                              tr( "Default Style" ),
+                              myMessage
+                            );
+  }
+}
+
+void QgsVectorTileLayerProperties::loadStyle()
+{
+  QgsSettings settings;
+  QString lastUsedDir = settings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
+
+  QString fileName = QFileDialog::getOpenFileName(
+                       this,
+                       tr( "Load rendering setting from style file" ),
+                       lastUsedDir,
+                       tr( "QGIS Layer Style File" ) + " (*.qml)" );
+  if ( fileName.isEmpty() )
+    return;
+
+  // ensure the user never omits the extension from the file name
+  if ( !fileName.endsWith( QLatin1String( ".qml" ), Qt::CaseInsensitive ) )
+    fileName += QLatin1String( ".qml" );
+
+  bool defaultLoadedFlag = false;
+  QString message = mLayer->loadNamedStyle( fileName, defaultLoadedFlag );
+  if ( defaultLoadedFlag )
+  {
+    settings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( fileName ).absolutePath() );
+    syncToLayer();
+  }
+  else
+  {
+    QMessageBox::information( this, tr( "Load Style" ), message );
+  }
+}
+
+void QgsVectorTileLayerProperties::saveStyleAs()
+{
+  QgsSettings settings;
+  QString lastUsedDir = settings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
+
+  QString outputFileName = QFileDialog::getSaveFileName(
+                             this,
+                             tr( "Save layer properties as style file" ),
+                             lastUsedDir,
+                             tr( "QGIS Layer Style File" ) + " (*.qml)" );
+  if ( outputFileName.isEmpty() )
+    return;
+
+  // ensure the user never omits the extension from the file name
+  outputFileName = QgsFileUtils::ensureFileNameHasExtension( outputFileName, QStringList() << QStringLiteral( "qml" ) );
+
+  apply(); // make sure the style to save is up-to-date
+
+  // then export style
+  bool defaultLoadedFlag = false;
+  QString message;
+  message = mLayer->saveNamedStyle( outputFileName, defaultLoadedFlag );
+
+  if ( defaultLoadedFlag )
+  {
+    settings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( outputFileName ).absolutePath() );
+  }
+  else
+    QMessageBox::information( this, tr( "Save Style" ), message );
+}
+
+void QgsVectorTileLayerProperties::aboutToShowStyleMenu()
+{
+  QMenu *m = qobject_cast<QMenu *>( sender() );
+
+  QgsMapLayerStyleGuiUtils::instance()->removesExtraMenuSeparators( m );
+  // re-add style manager actions!
+  m->addSeparator();
+  QgsMapLayerStyleGuiUtils::instance()->addStyleManagerActions( m, mLayer );
+}
+
+void QgsVectorTileLayerProperties::showHelp()
+{
+  const QVariant helpPage = mOptionsStackedWidget->currentWidget()->property( "helpPage" );
+
+  if ( helpPage.isValid() )
+  {
+    QgsHelp::openHelp( helpPage.toString() );
+  }
+  else
+  {
+    QgsHelp::openHelp( QStringLiteral( "working_with_vector_tiles/vector_tiles_properties.html" ) );
+  }
+}

--- a/src/app/vectortile/qgsvectortilelayerproperties.h
+++ b/src/app/vectortile/qgsvectortilelayerproperties.h
@@ -1,0 +1,57 @@
+/***************************************************************************
+  qgsvectortilelayerproperties.h
+  --------------------------------------
+  Date                 : May 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSVECTORTILELAYERPROPERTIES_H
+#define QGSVECTORTILELAYERPROPERTIES_H
+
+#include "qgsoptionsdialogbase.h"
+
+#include "ui_qgsvectortilelayerpropertiesbase.h"
+
+class QgsMapLayer;
+class QgsMapCanvas;
+class QgsMessageBar;
+class QgsVectorTileBasicLabelingWidget;
+class QgsVectorTileBasicRendererWidget;
+class QgsVectorTileLayer;
+
+
+class QgsVectorTileLayerProperties : public QgsOptionsDialogBase, private Ui::QgsVectorTileLayerPropertiesBase
+{
+    Q_OBJECT
+  public:
+    QgsVectorTileLayerProperties( QgsVectorTileLayer *lyr, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent = nullptr, Qt::WindowFlags = QgsGuiUtils::ModalDialogFlags );
+
+  private slots:
+    void apply();
+
+    void loadDefaultStyle();
+    void saveDefaultStyle();
+    void loadStyle();
+    void saveStyleAs();
+    void aboutToShowStyleMenu();
+    void showHelp();
+
+  private:
+    void syncToLayer();
+
+  private:
+    QgsVectorTileLayer *mLayer = nullptr;
+
+    QgsVectorTileBasicRendererWidget *mRendererWidget = nullptr;
+    QgsVectorTileBasicLabelingWidget *mLabelingWidget = nullptr;
+};
+
+#endif // QGSVECTORTILELAYERPROPERTIES_H

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -293,6 +293,7 @@ QByteArray QgsVectorTileLayer::getRawTile( QgsTileXYZ tileID )
 void QgsVectorTileLayer::setRenderer( QgsVectorTileRenderer *r )
 {
   mRenderer.reset( r );
+  triggerRepaint();
 }
 
 QgsVectorTileRenderer *QgsVectorTileLayer::renderer() const
@@ -303,6 +304,7 @@ QgsVectorTileRenderer *QgsVectorTileLayer::renderer() const
 void QgsVectorTileLayer::setLabeling( QgsVectorTileLabeling *labeling )
 {
   mLabeling.reset( labeling );
+  triggerRepaint();
 }
 
 QgsVectorTileLabeling *QgsVectorTileLayer::labeling() const

--- a/src/gui/vectortile/qgsvectortilebasiclabelingwidget.cpp
+++ b/src/gui/vectortile/qgsvectortilebasiclabelingwidget.cpp
@@ -282,24 +282,11 @@ bool QgsVectorTileBasicLabelingListModel::dropMimeData( const QMimeData *data,
 
 QgsVectorTileBasicLabelingWidget::QgsVectorTileBasicLabelingWidget( QgsVectorTileLayer *layer, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent )
   : QgsMapLayerConfigWidget( layer, canvas, parent )
-  , mVTLayer( layer )
   , mMessageBar( messageBar )
 {
 
   setupUi( this );
   layout()->setContentsMargins( 0, 0, 0, 0 );
-
-  if ( layer->labeling() && layer->labeling()->type() == QStringLiteral( "basic" ) )
-  {
-    mLabeling.reset( static_cast<QgsVectorTileBasicLabeling *>( layer->labeling()->clone() ) );
-  }
-  else
-  {
-    mLabeling.reset( new QgsVectorTileBasicLabeling() );
-  }
-
-  mModel = new QgsVectorTileBasicLabelingListModel( mLabeling.get(), viewStyles );
-  viewStyles->setModel( mModel );
 
   QMenu *menuAddRule = new QMenu( btnAddRule );
   menuAddRule->addAction( tr( "Marker" ), this, [this] { addStyle( QgsWkbTypes::PointGeometry ); } );
@@ -312,6 +299,25 @@ QgsVectorTileBasicLabelingWidget::QgsVectorTileBasicLabelingWidget( QgsVectorTil
   connect( btnRemoveRule, &QAbstractButton::clicked, this, &QgsVectorTileBasicLabelingWidget::removeStyle );
 
   connect( viewStyles, &QAbstractItemView::doubleClicked, this, &QgsVectorTileBasicLabelingWidget::editStyleAtIndex );
+
+  setLayer( layer );
+}
+
+void QgsVectorTileBasicLabelingWidget::setLayer( QgsVectorTileLayer *layer )
+{
+  mVTLayer = layer;
+
+  if ( layer && layer->labeling() && layer->labeling()->type() == QStringLiteral( "basic" ) )
+  {
+    mLabeling.reset( static_cast<QgsVectorTileBasicLabeling *>( layer->labeling()->clone() ) );
+  }
+  else
+  {
+    mLabeling.reset( new QgsVectorTileBasicLabeling() );
+  }
+
+  mModel = new QgsVectorTileBasicLabelingListModel( mLabeling.get(), viewStyles );
+  viewStyles->setModel( mModel );
 
   connect( mModel, &QAbstractItemModel::dataChanged, this, &QgsPanelWidget::widgetChanged );
   connect( mModel, &QAbstractItemModel::rowsInserted, this, &QgsPanelWidget::widgetChanged );

--- a/src/gui/vectortile/qgsvectortilebasiclabelingwidget.h
+++ b/src/gui/vectortile/qgsvectortilebasiclabelingwidget.h
@@ -46,6 +46,8 @@ class GUI_EXPORT QgsVectorTileBasicLabelingWidget : public QgsMapLayerConfigWidg
     QgsVectorTileBasicLabelingWidget( QgsVectorTileLayer *layer, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent = nullptr );
     ~QgsVectorTileBasicLabelingWidget() override;
 
+    void setLayer( QgsVectorTileLayer *layer );
+
   public slots:
     //! Applies the settings made in the dialog
     void apply() override;

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
@@ -297,23 +297,10 @@ bool QgsVectorTileBasicRendererListModel::dropMimeData( const QMimeData *data,
 
 QgsVectorTileBasicRendererWidget::QgsVectorTileBasicRendererWidget( QgsVectorTileLayer *layer, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent )
   : QgsMapLayerConfigWidget( layer, canvas, parent )
-  , mVTLayer( layer )
   , mMessageBar( messageBar )
 {
   setupUi( this );
   layout()->setContentsMargins( 0, 0, 0, 0 );
-
-  if ( layer->renderer() && layer->renderer()->type() == QStringLiteral( "basic" ) )
-  {
-    mRenderer.reset( static_cast<QgsVectorTileBasicRenderer *>( layer->renderer()->clone() ) );
-  }
-  else
-  {
-    mRenderer.reset( new QgsVectorTileBasicRenderer() );
-  }
-
-  mModel = new QgsVectorTileBasicRendererListModel( mRenderer.get(), viewStyles );
-  viewStyles->setModel( mModel );
 
   QMenu *menuAddRule = new QMenu( btnAddRule );
   menuAddRule->addAction( tr( "Marker" ), this, [this] { addStyle( QgsWkbTypes::PointGeometry ); } );
@@ -325,6 +312,25 @@ QgsVectorTileBasicRendererWidget::QgsVectorTileBasicRendererWidget( QgsVectorTil
   connect( btnRemoveRule, &QAbstractButton::clicked, this, &QgsVectorTileBasicRendererWidget::removeStyle );
 
   connect( viewStyles, &QAbstractItemView::doubleClicked, this, &QgsVectorTileBasicRendererWidget::editStyleAtIndex );
+
+  setLayer( layer );
+}
+
+void QgsVectorTileBasicRendererWidget::setLayer( QgsVectorTileLayer *layer )
+{
+  mVTLayer = layer;
+
+  if ( layer && layer->renderer() && layer->renderer()->type() == QStringLiteral( "basic" ) )
+  {
+    mRenderer.reset( static_cast<QgsVectorTileBasicRenderer *>( layer->renderer()->clone() ) );
+  }
+  else
+  {
+    mRenderer.reset( new QgsVectorTileBasicRenderer() );
+  }
+
+  mModel = new QgsVectorTileBasicRendererListModel( mRenderer.get(), viewStyles );
+  viewStyles->setModel( mModel );
 
   connect( mModel, &QAbstractItemModel::dataChanged, this, &QgsPanelWidget::widgetChanged );
   connect( mModel, &QAbstractItemModel::rowsInserted, this, &QgsPanelWidget::widgetChanged );

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
@@ -46,6 +46,8 @@ class GUI_EXPORT QgsVectorTileBasicRendererWidget : public QgsMapLayerConfigWidg
     QgsVectorTileBasicRendererWidget( QgsVectorTileLayer *layer, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent = nullptr );
     ~QgsVectorTileBasicRendererWidget() override;
 
+    void setLayer( QgsVectorTileLayer *layer );
+
   public slots:
     //! Applies the settings made in the dialog
     void apply() override;

--- a/src/ui/qgsvectortilelayerpropertiesbase.ui
+++ b/src/ui/qgsvectortilelayerpropertiesbase.ui
@@ -1,0 +1,249 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsVectorTileLayerPropertiesBase</class>
+ <widget class="QDialog" name="QgsVectorTileLayerPropertiesBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>815</width>
+    <height>557</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>700</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Vector Tile Layer Properties</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QSplitter" name="mOptionsSplitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
+     <widget class="QFrame" name="mOptionsListFrame">
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QgsFilterLineEdit" name="mSearchLineEdit"/>
+       </item>
+       <item>
+        <widget class="QListWidget" name="mOptionsListWidget">
+         <property name="minimumSize">
+          <size>
+           <width>58</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>150</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>32</width>
+           <height>32</height>
+          </size>
+         </property>
+         <property name="textElideMode">
+          <enum>Qt::ElideNone</enum>
+         </property>
+         <property name="resizeMode">
+          <enum>QListView::Adjust</enum>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <item>
+          <property name="text">
+           <string>Information</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/propertyicons/metadata.svg</normaloff>:/images/themes/default/propertyicons/metadata.svg</iconset>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Symbology</string>
+          </property>
+          <property name="toolTip">
+           <string>Symbology</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/propertyicons/symbology.svg</normaloff>:/images/themes/default/propertyicons/symbology.svg</iconset>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Labels</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/propertyicons/labels.svg</normaloff>:/images/themes/default/propertyicons/labels.svg</iconset>
+          </property>
+         </item>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QFrame" name="mOptionsFrame">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <horstretch>1</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QStackedWidget" name="mOptionsStackedWidget">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Plain</enum>
+         </property>
+         <property name="currentIndex">
+          <number>2</number>
+         </property>
+         <widget class="QWidget" name="mOptsPage_Information">
+          <layout class="QVBoxLayout" name="verticalLayout_20">
+           <property name="margin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QTextBrowser" name="mInformationTextBrowser"/>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="mOptsPage_Style">
+          <layout class="QVBoxLayout" name="verticalLayout_14">
+           <property name="margin">
+            <number>0</number>
+           </property>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="mOptsPage_Labeling">
+          <layout class="QVBoxLayout" name="verticalLayout_4"/>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="mButtonBoxFrame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="margin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0" colspan="2">
+       <widget class="QDialogButtonBox" name="buttonBox">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="standardButtons">
+         <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>mSearchLineEdit</tabstop>
+  <tabstop>mOptionsListWidget</tabstop>
+  <tabstop>mInformationTextBrowser</tabstop>
+ </tabstops>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>mOptionsListWidget</sender>
+   <signal>currentRowChanged(int)</signal>
+   <receiver>mOptionsStackedWidget</receiver>
+   <slot>setCurrentIndex(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>86</x>
+     <y>325</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>794</x>
+     <y>14</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
Initial implementation with three tabs:
- Information - displaying very basic data source information for now
- Symbology - configuration of the renderer (same as in styling dock)
- Labels - configuration of labeling (same as in styling dock)

I think this should be the last missing piece that was necessary for a new layer type implementation...

See the QEP: qgis/QGIS-Enhancement-Proposals#162

![image](https://user-images.githubusercontent.com/193367/81976945-92dcf080-9629-11ea-8f12-f6129183a5cb.png)


## Thanks

Huge thanks to all funders who have contributed to the crowdfunding and made this possible :clap: :clap: :clap:
https://www.lutraconsulting.co.uk/blog/2020/04/02/vectortiles-donors/