### PR TITLE
[postgres] Compile make_date, make_datetime, make_time functions

### DIFF
--- a/src/providers/postgres/qgspostgresexpressioncompiler.cpp
+++ b/src/providers/postgres/qgspostgresexpressioncompiler.cpp
@@ -104,6 +104,9 @@ static const QMap<QString, QString> FUNCTION_NAMES_SQL_FUNCTIONS_MAP
   { "lower", "lower" },
   { "trim", "trim" },
   { "upper", "upper" },
+  { "make_date", "make_date" },
+  { "make_time", "make_time" },
+  { "make_datetime", "make_timestamp" },
 };
 
 QString QgsPostgresExpressionCompiler::sqlFunctionFromFunctionName( const QString &fnName ) const

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -122,13 +122,8 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         QgsSettings().setValue('/qgis/compileExpressions', False)
 
     def uncompiledFilters(self):
-        return set(['"dt" <= make_datetime(2020, 5, 4, 12, 13, 14)',
-                    '"dt" < make_date(2020, 5, 4)',
-                    '"dt" = to_datetime(\'000www14ww13ww12www4ww5ww2020\',\'zzzwwwsswwmmwwhhwwwdwwMwwyyyy\')',
-                    '"date" <= make_datetime(2020, 5, 4, 12, 13, 14)',
-                    '"date" >= make_date(2020, 5, 4)',
+        return set(['"dt" = to_datetime(\'000www14ww13ww12www4ww5ww2020\',\'zzzwwwsswwmmwwhhwwwdwwMwwyyyy\')',
                     '"date" = to_date(\'www4ww5ww2020\',\'wwwdwwMwwyyyy\')',
-                    '"time" >= make_time(12, 14, 14)',
                     '"time" = to_time(\'000www14ww13ww12www\',\'zzzwwwsswwmmwwhhwww\')'])
 
     def partiallyCompiledFilters(self):
@@ -1986,13 +1981,8 @@ class TestPyQgsPostgresProviderBigintSinglePk(unittest.TestCase, ProviderTestCas
         QgsSettings().setValue('/qgis/compileExpressions', False)
 
     def uncompiledFilters(self):
-        return set(['"dt" <= make_datetime(2020, 5, 4, 12, 13, 14)',
-                    '"dt" < make_date(2020, 5, 4)',
-                    '"dt" = to_datetime(\'000www14ww13ww12www4ww5ww2020\',\'zzzwwwsswwmmwwhhwwwdwwMwwyyyy\')',
-                    '"date" <= make_datetime(2020, 5, 4, 12, 13, 14)',
-                    '"date" >= make_date(2020, 5, 4)',
+        return set(['"dt" = to_datetime(\'000www14ww13ww12www4ww5ww2020\',\'zzzwwwsswwmmwwhhwwwdwwMwwyyyy\')',
                     '"date" = to_date(\'www4ww5ww2020\',\'wwwdwwMwwyyyy\')',
-                    '"time" >= make_time(12, 14, 14)',
                     '"time" = to_time(\'000www14ww13ww12www\',\'zzzwwwsswwmmwwhhwww\')'])
 
     def partiallyCompiledFilters(self):

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -1916,13 +1916,8 @@ class TestPyQgsPostgresProviderCompoundKey(unittest.TestCase, ProviderTestCase):
         QgsSettings().setValue('/qgis/compileExpressions', False)
 
     def uncompiledFilters(self):
-        return set(['"dt" <= make_datetime(2020, 5, 4, 12, 13, 14)',
-                    '"dt" < make_date(2020, 5, 4)',
-                    '"dt" = to_datetime(\'000www14ww13ww12www4ww5ww2020\',\'zzzwwwsswwmmwwhhwwwdwwMwwyyyy\')',
-                    '"date" <= make_datetime(2020, 5, 4, 12, 13, 14)',
-                    '"date" >= make_date(2020, 5, 4)',
+        return set(['"dt" = to_datetime(\'000www14ww13ww12www4ww5ww2020\',\'zzzwwwsswwmmwwhhwwwdwwMwwyyyy\')',
                     '"date" = to_date(\'www4ww5ww2020\',\'wwwdwwMwwyyyy\')',
-                    '"time" >= make_time(12, 14, 14)',
                     '"time" = to_time(\'000www14ww13ww12www\',\'zzzwwwsswwmmwwhhwww\')'])
 
     def partiallyCompiledFilters(self):


### PR DESCRIPTION
Allows (most) vector temporal filters to be performed server-side,
utilising indexes on the temporal fields. Ultimately makes it possible
to animate huge postgres tables using the new temporal framework.
