### PR TITLE
Add ability to export animation frames

### DIFF
--- a/python/core/auto_generated/qgstemporalutils.sip.in
+++ b/python/core/auto_generated/qgstemporalutils.sip.in
@@ -31,6 +31,28 @@ This method considers the temporal range available from layers contained within 
 returns the maximal combined temporal extent of these layers.
 %End
 
+    static bool exportAnimation( const QgsMapSettings &mapSettings,
+                                 const QgsDateTimeRange &animationRange,
+                                 QgsInterval frameDuration,
+                                 const QString &outputDirectory,
+                                 const QString &fileNameTemplate,
+                                 QString &error /Out/,
+                                 QgsFeedback *feedback );
+%Docstring
+Exports animation frames by rendering the map to multiple destination images.
+
+The ``mapSettings`` argument dictates the overall map settings such as extent
+and size.
+
+The ``animationRange`` argument specifies the overall temporal range of the animation.
+Temporal duration of individual frames is given by ``frameDuration``.
+
+An ``outputDirectory`` must be set, which controls where the created image files are
+stored. ``fileNameTemplate`` gives the template for exporting the frames.
+This must be in format prefix####.format, where number of
+# represents how many 0 should be left-padded to the frame number
+e.g. my###.jpg will create frames my001.jpg, my002.jpg, etc
+%End
 };
 
 

--- a/python/gui/auto_generated/qgstemporalcontrollerwidget.sip.in
+++ b/python/gui/auto_generated/qgstemporalcontrollerwidget.sip.in
@@ -36,6 +36,7 @@ Returns the temporal controller object used by this object in navigation.
 The dock widget retains ownership of the returned object.
 %End
 
+
 };
 
 /************************************************************************

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -18,6 +18,7 @@ SET(QGIS_APP_SRCS
   qgsapplayertreeviewmenuprovider.cpp
   qgsappwindowmanager.cpp
   qgsappscreenshots.cpp
+  qgsanimationexportdialog.cpp
   qgsannotationwidget.cpp
   qgsappsslerrorhandler.cpp
   qgsattributetabledialog.cpp

--- a/src/app/qgsanimationexportdialog.cpp
+++ b/src/app/qgsanimationexportdialog.cpp
@@ -1,0 +1,277 @@
+/***************************************************************************
+                         qgsanimationexportdialog.cpp
+                         -------------------------------------
+    begin                : May 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsanimationexportdialog.h"
+#include "qgsmapcanvas.h"
+#include "qgsexpressioncontextutils.h"
+#include "qgstemporalnavigationobject.h"
+#include "qgsprojecttimesettings.h"
+#include "qgstemporalutils.h"
+
+Q_GUI_EXPORT extern int qt_defaultDpiX();
+
+QgsAnimationExportDialog::QgsAnimationExportDialog( QWidget *parent, QgsMapCanvas *mapCanvas )
+  : QDialog( parent )
+  , mMapCanvas( mapCanvas )
+{
+  setupUi( this );
+
+  // Use unrotated visible extent to insure output size and scale matches canvas
+  QgsMapSettings ms = mMapCanvas->mapSettings();
+  ms.setRotation( 0 );
+  mExtent = ms.visibleExtent();
+  mSize = ms.outputSize();
+
+  mExtentGroupBox->setOutputCrs( ms.destinationCrs() );
+  mExtentGroupBox->setCurrentExtent( mExtent, ms.destinationCrs() );
+  mExtentGroupBox->setOutputExtentFromCurrent();
+  mExtentGroupBox->setMapCanvas( mapCanvas );
+
+  mStartDateTime->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
+  mEndDateTime->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
+
+  QgsSettings settings;
+
+  const QString templateText = settings.value( QStringLiteral( "ExportAnimation/fileNameTemplate" ),
+                               QStringLiteral( "%1####.png" ).arg( QgsProject::instance()->baseName() )
+                               , QgsSettings::App ).toString();
+  mTemplateLineEdit->setText( templateText );
+  QRegExp rx( QStringLiteral( "\\w+#+\\.{1}\\w+" ) ); //e.g. anyprefix#####.png
+  QValidator *validator = new QRegExpValidator( rx, this );
+  mTemplateLineEdit->setValidator( validator );
+
+  connect( mTemplateLineEdit, &QLineEdit::textChanged, this, [ = ]
+  {
+    QgsSettings settings;
+    settings.setValue( QStringLiteral( "ExportAnimation/fileNameTemplate" ), mTemplateLineEdit->text() );
+  } );
+
+  mOutputDirFileWidget->setStorageMode( QgsFileWidget::GetDirectory );
+  mOutputDirFileWidget->setDialogTitle( tr( "Select Directory for Animation Frames" ) );
+  mOutputDirFileWidget->lineEdit()->setShowClearButton( false );
+  mOutputDirFileWidget->setDefaultRoot( settings.value( QStringLiteral( "ExportAnimation/lastDir" ), QString(), QgsSettings::App ).toString() );
+  mOutputDirFileWidget->setFilePath( settings.value( QStringLiteral( "ExportAnimation/lastDir" ), QString(), QgsSettings::App ).toString() );
+
+  connect( mOutputDirFileWidget, &QgsFileWidget::fileChanged, this, [ = ]
+  {
+    QgsSettings settings;
+    settings.setValue( QStringLiteral( "ExportAnimation/lastDir" ), mOutputDirFileWidget->filePath(), QgsSettings::App );
+  } );
+
+  for ( QgsUnitTypes::TemporalUnit u :
+        {
+          QgsUnitTypes::TemporalMilliseconds,
+          QgsUnitTypes::TemporalSeconds,
+          QgsUnitTypes::TemporalMinutes,
+          QgsUnitTypes::TemporalHours,
+          QgsUnitTypes::TemporalDays,
+          QgsUnitTypes::TemporalWeeks,
+          QgsUnitTypes::TemporalMonths,
+          QgsUnitTypes::TemporalYears,
+          QgsUnitTypes::TemporalDecades,
+          QgsUnitTypes::TemporalCenturies
+        } )
+  {
+    mTimeStepsComboBox->addItem( QgsUnitTypes::toString( u ), u );
+  }
+
+  if ( const QgsTemporalNavigationObject *controller = qobject_cast< const QgsTemporalNavigationObject * >( mMapCanvas->temporalController() ) )
+  {
+    mStartDateTime->setDateTime( controller->temporalExtents().begin() );
+    mEndDateTime->setDateTime( controller->temporalExtents().end() );
+  }
+  mFrameDurationSpinBox->setClearValue( 1 );
+  mFrameDurationSpinBox->setValue( QgsProject::instance()->timeSettings()->timeStep() );
+  mTimeStepsComboBox->setCurrentIndex( QgsProject::instance()->timeSettings()->timeStepUnit() );
+
+  connect( mOutputWidthSpinBox, &QSpinBox::editingFinished, this, [ = ] { updateOutputWidth( mOutputWidthSpinBox->value() );} );
+  connect( mOutputHeightSpinBox, &QSpinBox::editingFinished, this, [ = ] { updateOutputHeight( mOutputHeightSpinBox->value() );} );
+  connect( mExtentGroupBox, &QgsExtentGroupBox::extentChanged, this, &QgsAnimationExportDialog::updateExtent );
+  connect( mLockAspectRatio, &QgsRatioLockButton::lockChanged, this, &QgsAnimationExportDialog::lockChanged );
+
+  connect( mSetToProjectTimeButton, &QPushButton::clicked, this, &QgsAnimationExportDialog::setToProjectTime );
+
+  connect( buttonBox, &QDialogButtonBox::accepted, this, [ = ]
+  {
+    emit startExport();
+    accept();
+  } );
+
+  updateOutputSize();
+}
+
+void QgsAnimationExportDialog::updateOutputWidth( int width )
+{
+  double scale = static_cast<double>( width ) / mSize.width();
+  double adjustment = ( ( mExtent.width() * scale ) - mExtent.width() ) / 2;
+
+  mSize.setWidth( width );
+
+  mExtent.setXMinimum( mExtent.xMinimum() - adjustment );
+  mExtent.setXMaximum( mExtent.xMaximum() + adjustment );
+
+  if ( mLockAspectRatio->locked() )
+  {
+    int height = width * mExtentGroupBox->ratio().height() / mExtentGroupBox->ratio().width();
+    double scale = static_cast<double>( height ) / mSize.height();
+    double adjustment = ( ( mExtent.height() * scale ) - mExtent.height() ) / 2;
+
+    whileBlocking( mOutputHeightSpinBox )->setValue( height );
+    mSize.setHeight( height );
+
+    mExtent.setYMinimum( mExtent.yMinimum() - adjustment );
+    mExtent.setYMaximum( mExtent.yMaximum() + adjustment );
+  }
+
+  whileBlocking( mExtentGroupBox )->setOutputExtentFromUser( mExtent, mExtentGroupBox->currentCrs() );
+}
+
+void QgsAnimationExportDialog::updateOutputHeight( int height )
+{
+  double scale = static_cast<double>( height ) / mSize.height();
+  double adjustment = ( ( mExtent.height() * scale ) - mExtent.height() ) / 2;
+
+  mSize.setHeight( height );
+
+  mExtent.setYMinimum( mExtent.yMinimum() - adjustment );
+  mExtent.setYMaximum( mExtent.yMaximum() + adjustment );
+
+  if ( mLockAspectRatio->locked() )
+  {
+    int width = height * mExtentGroupBox->ratio().width() / mExtentGroupBox->ratio().height();
+    double scale = static_cast<double>( width ) / mSize.width();
+    double adjustment = ( ( mExtent.width() * scale ) - mExtent.width() ) / 2;
+
+    whileBlocking( mOutputWidthSpinBox )->setValue( width );
+    mSize.setWidth( width );
+
+    mExtent.setXMinimum( mExtent.xMinimum() - adjustment );
+    mExtent.setXMaximum( mExtent.xMaximum() + adjustment );
+  }
+
+  whileBlocking( mExtentGroupBox )->setOutputExtentFromUser( mExtent, mExtentGroupBox->currentCrs() );
+}
+
+void QgsAnimationExportDialog::updateExtent( const QgsRectangle &extent )
+{
+  // leave width as is, update height
+  mSize.setHeight( mSize.width() * extent.height() / extent.width() );
+  updateOutputSize();
+
+  mExtent = extent;
+  if ( mLockAspectRatio->locked() )
+  {
+    mExtentGroupBox->setRatio( QSize( mSize.width(), mSize.height() ) );
+  }
+}
+
+void QgsAnimationExportDialog::updateOutputSize()
+{
+  whileBlocking( mOutputWidthSpinBox )->setValue( mSize.width() );
+  whileBlocking( mOutputHeightSpinBox )->setValue( mSize.height() );
+}
+
+QgsRectangle QgsAnimationExportDialog::extent() const
+{
+  return mExtentGroupBox->outputExtent();
+}
+
+QSize QgsAnimationExportDialog::size() const
+{
+  return mSize;
+}
+
+QString QgsAnimationExportDialog::outputDirectory() const
+{
+  return mOutputDirFileWidget->filePath();
+}
+
+QString QgsAnimationExportDialog::fileNameExpression() const
+{
+  return mTemplateLineEdit->text();
+}
+
+QgsDateTimeRange QgsAnimationExportDialog::animationRange() const
+{
+  return QgsDateTimeRange( mStartDateTime->dateTime(), mEndDateTime->dateTime() );
+}
+
+QgsInterval QgsAnimationExportDialog::frameInterval() const
+{
+  return QgsInterval( mFrameDurationSpinBox->value(), static_cast< QgsUnitTypes::TemporalUnit>( mTimeStepsComboBox->currentData().toInt() ) );
+}
+
+void QgsAnimationExportDialog::applyMapSettings( QgsMapSettings &mapSettings )
+{
+  QgsSettings settings;
+
+  mapSettings.setFlag( QgsMapSettings::Antialiasing, settings.value( QStringLiteral( "qgis/enable_anti_aliasing" ), true ).toBool() );
+  mapSettings.setFlag( QgsMapSettings::DrawEditingInfo, false );
+  mapSettings.setFlag( QgsMapSettings::DrawSelection, false );
+  mapSettings.setSelectionColor( mMapCanvas->mapSettings().selectionColor() );
+  mapSettings.setDestinationCrs( mMapCanvas->mapSettings().destinationCrs() );
+  mapSettings.setExtent( extent() );
+  mapSettings.setOutputSize( size() );
+  mapSettings.setBackgroundColor( mMapCanvas->canvasColor() );
+  mapSettings.setRotation( mMapCanvas->rotation() );
+  mapSettings.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  mapSettings.setLayers( mMapCanvas->layers() );
+  mapSettings.setLabelingEngineSettings( mMapCanvas->mapSettings().labelingEngineSettings() );
+  mapSettings.setTransformContext( QgsProject::instance()->transformContext() );
+  mapSettings.setPathResolver( QgsProject::instance()->pathResolver() );
+
+  //build the expression context
+  QgsExpressionContext expressionContext;
+  expressionContext << QgsExpressionContextUtils::globalScope()
+                    << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+                    << QgsExpressionContextUtils::mapSettingsScope( mapSettings );
+
+  mapSettings.setExpressionContext( expressionContext );
+}
+
+void QgsAnimationExportDialog::setToProjectTime()
+{
+  QgsDateTimeRange range;
+
+  // by default try taking the project's fixed temporal extent
+  if ( QgsProject::instance()->timeSettings() )
+    range = QgsProject::instance()->timeSettings()->temporalRange();
+
+  // if that's not set, calculate the extent from the project's layers
+  if ( !range.begin().isValid() || !range.end().isValid() )
+  {
+    range = QgsTemporalUtils::calculateTemporalRangeForProject( QgsProject::instance() );
+  }
+
+  if ( range.begin().isValid() && range.end().isValid() )
+  {
+    whileBlocking( mStartDateTime )->setDateTime( range.begin() );
+    whileBlocking( mEndDateTime )->setDateTime( range.end() );
+  }
+}
+
+void QgsAnimationExportDialog::lockChanged( const bool locked )
+{
+  if ( locked )
+  {
+    mExtentGroupBox->setRatio( QSize( mOutputWidthSpinBox->value(), mOutputHeightSpinBox->value() ) );
+  }
+  else
+  {
+    mExtentGroupBox->setRatio( QSize( 0, 0 ) );
+  }
+}

--- a/src/app/qgsanimationexportdialog.h
+++ b/src/app/qgsanimationexportdialog.h
@@ -1,0 +1,96 @@
+/***************************************************************************
+                         qgsanimationexportdialog.h
+                         -------------------------------------
+    begin                : May 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSANIMATIONEXPORTDIALOG_H
+#define QGSANIMATIONEXPORTDIALOG_H
+
+#include "ui_qgsanimationexportdialogbase.h"
+
+#include "qgisapp.h"
+#include "qgsrectangle.h"
+#include "qgshelp.h"
+
+#include <QDialog>
+#include <QSize>
+
+class QgsMapCanvas;
+
+
+/**
+ * \ingroup app
+ * \brief A dialog for specifying map animation export settings.
+ * \since QGIS 3.14
+*/
+class APP_EXPORT QgsAnimationExportDialog: public QDialog, private Ui::QgsAnimationExportDialogBase
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsAnimationExportDialog
+     */
+    QgsAnimationExportDialog( QWidget *parent = nullptr, QgsMapCanvas *mapCanvas = nullptr );
+
+    //! Returns extent rectangle
+    QgsRectangle extent() const;
+
+    //! Returns the output size
+    QSize size() const;
+
+    //! Returns output directory for frames
+    QString outputDirectory( ) const;
+
+    //! Returns filename template for frames
+    QString fileNameExpression( ) const;
+
+    //! Returns the overall animation range
+    QgsDateTimeRange animationRange() const;
+
+    //! Returns the duration of each individual frame
+    QgsInterval frameInterval() const;
+
+    //! configure a map settings object
+    void applyMapSettings( QgsMapSettings &mapSettings );
+
+  signals:
+
+    void startExport();
+
+  private slots:
+
+    void setToProjectTime();
+
+  private:
+
+    void lockChanged( bool locked );
+
+    void updateOutputWidth( int width );
+    void updateOutputHeight( int height );
+    void updateExtent( const QgsRectangle &extent );
+    void updateOutputSize();
+
+    QgsMapCanvas *mMapCanvas = nullptr;
+
+    QgsRectangle mExtent;
+    QSize mSize;
+
+    QString mInfoDetails;
+
+};
+
+#endif // QGSANIMATIONEXPORTDIALOG_H

--- a/src/app/qgstemporalcontrollerdockwidget.cpp
+++ b/src/app/qgstemporalcontrollerdockwidget.cpp
@@ -18,6 +18,16 @@
 #include "qgstemporalcontrollerdockwidget.h"
 #include "qgstemporalcontrollerwidget.h"
 #include "qgspanelwidgetstack.h"
+#include "qgsanimationexportdialog.h"
+#include "qgsmapcanvas.h"
+
+#include "qgstemporalutils.h"
+#include "qgstaskmanager.h"
+#include "qgsproxyprogresstask.h"
+
+#include <QProgressDialog>
+#include <QMessageBox>
+
 
 QgsTemporalControllerDockWidget::QgsTemporalControllerDockWidget( const QString &name, QWidget *parent )
   : QgsDockWidget( parent )
@@ -29,9 +39,63 @@ QgsTemporalControllerDockWidget::QgsTemporalControllerDockWidget( const QString 
   QgsPanelWidgetStack *stack = new QgsPanelWidgetStack();
   stack->setMainPanel( mControllerWidget );
   setWidget( stack );
+
+  connect( mControllerWidget, &QgsTemporalControllerWidget::exportAnimation, this, &QgsTemporalControllerDockWidget::exportAnimation );
 }
 
 QgsTemporalController *QgsTemporalControllerDockWidget::temporalController()
 {
   return mControllerWidget->temporalController();
+}
+
+void QgsTemporalControllerDockWidget::exportAnimation()
+{
+  QgsAnimationExportDialog *dlg = new QgsAnimationExportDialog( this, QgisApp::instance()->mapCanvas() );
+  connect( dlg, &QgsAnimationExportDialog::startExport, this, [ = ]
+  {
+    QgsMapSettings s = QgisApp::instance()->mapCanvas()->mapSettings();
+    dlg->applyMapSettings( s );
+
+    const QgsDateTimeRange animationRange = dlg->animationRange();
+    const QgsInterval frameDuration = dlg->frameInterval();
+    const QString outputDir = dlg->outputDirectory();
+    const QString fileNameExpression = dlg->fileNameExpression();
+
+    dlg->hide();
+
+    QgsFeedback progressFeedback;
+    QgsScopedProxyProgressTask task( tr( "Exporting animation" ) );
+
+    QProgressDialog progressDialog( tr( "Exporting animation…" ), tr( "Abort" ), 0, 100, this );
+    progressDialog.setWindowTitle( tr( "Exporting Animation" ) );
+    progressDialog.setWindowModality( Qt::WindowModal );
+    QString error;
+
+    connect( &progressFeedback, &QgsFeedback::progressChanged, this,
+             [&progressDialog, &progressFeedback, &task]
+    {
+      progressDialog.setValue( static_cast<int>( progressFeedback.progress() ) );
+      task.setProgress( progressFeedback.progress() );
+      QCoreApplication::processEvents();
+    } );
+
+    connect( &progressDialog, &QProgressDialog::canceled, &progressFeedback, &QgsFeedback::cancel );
+
+    bool success = QgsTemporalUtils::exportAnimation(
+      s,
+      animationRange,
+      frameDuration,
+      outputDir,
+      fileNameExpression,
+      error,
+      &progressFeedback );
+
+    progressDialog.hide();
+    if ( !success )
+    {
+      QMessageBox::warning( this, tr( "Export Animation" ), error );
+    }
+  } );
+  dlg->setAttribute( Qt::WA_DeleteOnClose );
+  dlg->show();
 }

--- a/src/app/qgstemporalcontrollerdockwidget.h
+++ b/src/app/qgstemporalcontrollerdockwidget.h
@@ -47,6 +47,10 @@ class APP_EXPORT QgsTemporalControllerDockWidget : public QgsDockWidget
      */
     QgsTemporalController *temporalController();
 
+  private slots:
+
+    void exportAnimation();
+
   private:
 
     QgsTemporalControllerWidget *mControllerWidget = nullptr;

--- a/src/core/qgstemporalutils.cpp
+++ b/src/core/qgstemporalutils.cpp
@@ -22,6 +22,10 @@
 #include "qgsvectorlayertemporalproperties.h"
 #include "qgsrasterlayertemporalproperties.h"
 #include "qgsmeshlayertemporalproperties.h"
+#include "qgstemporalnavigationobject.h"
+#include "qgsmapsettings.h"
+#include "qgsmaprenderercustompainterjob.h"
+#include "qgsexpressioncontextutils.h"
 
 QgsDateTimeRange QgsTemporalUtils::calculateTemporalRangeForProject( QgsProject *project )
 {
@@ -46,4 +50,78 @@ QgsDateTimeRange QgsTemporalUtils::calculateTemporalRangeForProject( QgsProject 
   }
 
   return QgsDateTimeRange( minDate, maxDate );
+}
+
+bool QgsTemporalUtils::exportAnimation( const QgsMapSettings &mapSettings, const QgsDateTimeRange &animationRange, QgsInterval frameDuration, const QString &outputDirectory, const QString &fileNameTemplate, QString &error, QgsFeedback *feedback )
+{
+  if ( fileNameTemplate.isEmpty() )
+  {
+    error = QObject::tr( "Filename template is empty" );
+    return false;
+  }
+  int numberOfDigits = fileNameTemplate.count( QLatin1Char( '#' ) );
+  if ( numberOfDigits < 0 )
+  {
+    error = QObject::tr( "Wrong filename template format (must contain #)" );
+    return false;
+  }
+  const QString token( numberOfDigits, QLatin1Char( '#' ) );
+  if ( !fileNameTemplate.contains( token ) )
+  {
+    error = QObject::tr( "Filename template must contain all # placeholders in one continuous group." );
+    return false;
+  }
+
+  QgsTemporalNavigationObject navigator;
+  navigator.setTemporalExtents( animationRange );
+  navigator.setFrameDuration( frameDuration );
+  QgsMapSettings settings = mapSettings;
+  const QgsExpressionContext context = settings.expressionContext();
+
+  const long long totalFrames = navigator.totalFrameCount();
+  long long currentFrame = 0;
+
+  while ( currentFrame < totalFrames )
+  {
+    if ( feedback )
+    {
+      if ( feedback->isCanceled() )
+      {
+        error = QObject::tr( "Export canceled" );
+        return false;
+      }
+      feedback->setProgress( currentFrame / static_cast<double>( totalFrames ) * 100 );
+    }
+    ++currentFrame;
+
+    navigator.setCurrentFrameNumber( currentFrame );
+
+    settings.setIsTemporal( true );
+    settings.setTemporalRange( navigator.dateTimeRangeForFrameNumber( currentFrame ) );
+
+    QgsExpressionContext frameContext = context;
+    frameContext.appendScope( navigator.createExpressionContextScope() );
+    frameContext.appendScope( QgsExpressionContextUtils::mapSettingsScope( settings ) );
+    settings.setExpressionContext( frameContext );
+
+    QString fileName( fileNameTemplate );
+    const QString frameNoPaddedLeft( QStringLiteral( "%1" ).arg( currentFrame, numberOfDigits, 10, QChar( '0' ) ) ); // e.g. 0001
+    fileName.replace( token, frameNoPaddedLeft );
+    const QString path = QDir( outputDirectory ).filePath( fileName );
+
+    QImage img = QImage( settings.outputSize(), settings.outputImageFormat() );
+    img.setDotsPerMeterX( 1000 * settings.outputDpi() / 25.4 );
+    img.setDotsPerMeterY( 1000 * settings.outputDpi() / 25.4 );
+    img.fill( settings.backgroundColor().rgb() );
+
+    QPainter p( &img );
+    QgsMapRendererCustomPainterJob job( settings, &p );
+    job.start();
+    job.waitForFinished();
+    p.end();
+
+    img.save( path );
+  }
+
+  return true;
 }

--- a/src/core/qgstemporalutils.h
+++ b/src/core/qgstemporalutils.h
@@ -18,8 +18,11 @@
 
 #include "qgis_core.h"
 #include "qgsrange.h"
+#include "qgsinterval.h"
 
 class QgsProject;
+class QgsMapSettings;
+class QgsFeedback;
 
 /**
  * \ingroup core
@@ -41,6 +44,28 @@ class CORE_EXPORT QgsTemporalUtils
      */
     static QgsDateTimeRange calculateTemporalRangeForProject( QgsProject *project );
 
+    /**
+     * Exports animation frames by rendering the map to multiple destination images.
+     *
+     * The \a mapSettings argument dictates the overall map settings such as extent
+     * and size.
+     *
+     * The \a animationRange argument specifies the overall temporal range of the animation.
+     * Temporal duration of individual frames is given by \a frameDuration.
+     *
+     * An \a outputDirectory must be set, which controls where the created image files are
+     * stored. \a fileNameTemplate gives the template for exporting the frames.
+     * This must be in format prefix####.format, where number of
+     * # represents how many 0 should be left-padded to the frame number
+     * e.g. my###.jpg will create frames my001.jpg, my002.jpg, etc
+     */
+    static bool exportAnimation( const QgsMapSettings &mapSettings,
+                                 const QgsDateTimeRange &animationRange,
+                                 QgsInterval frameDuration,
+                                 const QString &outputDirectory,
+                                 const QString &fileNameTemplate,
+                                 QString &error SIP_OUT,
+                                 QgsFeedback *feedback );
 };
 
 

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -60,6 +60,8 @@ QgsTemporalControllerWidget::QgsTemporalControllerWidget( QWidget *parent )
   connect( mSettings, &QPushButton::clicked, this, &QgsTemporalControllerWidget::settings_clicked );
   connect( mSetToProjectTimeButton, &QPushButton::clicked, this, &QgsTemporalControllerWidget::mSetToProjectTimeButton_clicked );
 
+  connect( mExportAnimationButton, &QPushButton::clicked, this, &QgsTemporalControllerWidget::exportAnimation );
+
   QgsDateTimeRange range;
 
   if ( QgsProject::instance()->timeSettings() )

--- a/src/gui/qgstemporalcontrollerwidget.h
+++ b/src/gui/qgstemporalcontrollerwidget.h
@@ -51,6 +51,17 @@ class GUI_EXPORT QgsTemporalControllerWidget : public QgsPanelWidget, private Ui
      */
     QgsTemporalController *temporalController();
 
+#ifndef SIP_RUN
+
+  signals:
+
+    /**
+     * Triggered when an animation should be exported
+     */
+    void exportAnimation();
+
+#endif
+
   private:
 
     /**

--- a/src/ui/3d/animationexport3ddialog.ui
+++ b/src/ui/3d/animationexport3ddialog.ui
@@ -23,7 +23,7 @@
    <item row="4" column="0">
     <widget class="QLabel" name="mHeightLabel">
      <property name="text">
-      <string>Output Height</string>
+      <string>Output height</string>
      </property>
      <property name="buddy">
       <cstring>mHeightSpinBox</cstring>
@@ -33,7 +33,7 @@
    <item row="2" column="0">
     <widget class="QLabel" name="mFpsLabel">
      <property name="text">
-      <string>Frames Per Second</string>
+      <string>Frames per second</string>
      </property>
     </widget>
    </item>
@@ -47,7 +47,7 @@
    <item row="1" column="0">
     <widget class="QLabel" name="mOutputDirLabel">
      <property name="text">
-      <string>Output Directory</string>
+      <string>Output directory</string>
      </property>
     </widget>
    </item>
@@ -74,7 +74,7 @@
    <item row="3" column="0">
     <widget class="QLabel" name="mWidthLabel">
      <property name="text">
-      <string>Output Width</string>
+      <string>Output width</string>
      </property>
      <property name="buddy">
       <cstring>mWidthSpinBox</cstring>

--- a/src/ui/qgsanimationexportdialogbase.ui
+++ b/src/ui/qgsanimationexportdialogbase.ui
@@ -1,0 +1,312 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsAnimationExportDialogBase</class>
+ <widget class="QDialog" name="QgsAnimationExportDialogBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>629</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Export Map Animation</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_5" columnstretch="0,0">
+   <item row="1" column="0">
+    <widget class="QLabel" name="mOutputDirLabel_2">
+     <property name="text">
+      <string>Output directory</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Temporal Settings</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Range</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="QDateTimeEdit" name="mEndDateTime">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="displayFormat">
+         <string>M/d/yyyy h:mm AP</string>
+        </property>
+        <property name="timeSpec">
+         <enum>Qt::UTC</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>to </string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QDateTimeEdit" name="mStartDateTime">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="displayFormat">
+         <string>M/d/yyyy h:mm AP</string>
+        </property>
+        <property name="timeSpec">
+         <enum>Qt::UTC</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5">
+       <widget class="QToolButton" name="mSetToProjectTimeButton">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset resource="../../images/images.qrc">
+          <normaloff>:/images/themes/default/mActionRefresh.svg</normaloff>:/images/themes/default/mActionRefresh.svg</iconset>
+        </property>
+        <property name="autoRaise">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Step (frame length)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QgsDoubleSpinBox" name="mFrameDurationSpinBox">
+        <property name="decimals">
+         <number>3</number>
+        </property>
+        <property name="maximum">
+         <double>9999999999.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3" colspan="3">
+       <widget class="QComboBox" name="mTimeStepsComboBox">
+        <property name="editable">
+         <bool>false</bool>
+        </property>
+        <property name="currentText">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="mTemplateLabel_2">
+     <property name="text">
+      <string>Template</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="mTemplateLineEdit">
+     <property name="toolTip">
+      <string>Number of # represents number of digits (e.g. frame###.png -&gt; frame001.png)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Map Settings</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Output width</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QgsSpinBox" name="mOutputHeightSpinBox">
+        <property name="suffix">
+         <string> px</string>
+        </property>
+        <property name="prefix">
+         <string/>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>99999</number>
+        </property>
+        <property name="showClearButton" stdset="0">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QgsSpinBox" name="mOutputWidthSpinBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="suffix">
+         <string> px</string>
+        </property>
+        <property name="prefix">
+         <string/>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>99999</number>
+        </property>
+        <property name="showClearButton" stdset="0">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2" rowspan="2">
+       <widget class="QgsRatioLockButton" name="mLockAspectRatio">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Lock aspect ratio (including while drawing extent onto canvas)</string>
+        </property>
+        <property name="leftMargin" stdset="0">
+         <number>13</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="3">
+       <widget class="QgsExtentGroupBox" name="mExtentGroupBox">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+        <property name="title">
+         <string>Extent</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Output height</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QgsFileWidget" name="mOutputDirFileWidget" native="true"/>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsExtentGroupBox</class>
+   <extends>QgsCollapsibleGroupBox</extends>
+   <header>qgsextentgroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsRatioLockButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsratiolockbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsAnimationExportDialogBase</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/qgstemporalcontrollerwidgetbase.ui
+++ b/src/ui/qgstemporalcontrollerwidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>747</width>
-    <height>93</height>
+    <height>100</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -284,6 +284,23 @@
        </property>
       </spacer>
      </item>
+     <item>
+      <widget class="QToolButton" name="mExportAnimationButton">
+       <property name="toolTip">
+        <string>Export Animation</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/mActionFileSave.svg</normaloff>:/images/themes/default/mActionFileSave.svg</iconset>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -315,8 +332,6 @@
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
Allows exporting of temporal animation frames to successive images,
for later stitching together in an external application.

Users have precise control over the image size and map extent.

There's LOTS of scope for improvements here, which range from simple UX tweaks (using the message bar instead of message boxes, showing links to exported images after export, better warning messages) through to enhancements (exporting in a background thread! multithreaded exports!!) 

But I thought it was important functionality to have for 3.14, so even in it's current unrefined state I would like to see it merged prior to freeze

 