### PR TITLE
[Bug fix] load 3D view symbol configuration automatically in layer properties

### DIFF
--- a/src/app/3d/qgsvectorlayer3drendererwidget.cpp
+++ b/src/app/3d/qgsvectorlayer3drendererwidget.cpp
@@ -100,6 +100,8 @@ QgsVectorLayer3DRendererWidget::QgsVectorLayer3DRendererWidget( QgsMapLayer *lay
   connect( widgetRuleBasedRenderer, &QgsRuleBased3DRendererWidget::widgetChanged, this, &QgsVectorLayer3DRendererWidget::widgetChanged );
   connect( widgetRuleBasedRenderer, &QgsRuleBased3DRendererWidget::showPanel, this, &QgsPanelWidget::openPanel );
   connect( widgetBaseProperties, &QgsVectorLayer3DPropertiesWidget::changed, this, &QgsVectorLayer3DRendererWidget::widgetChanged );
+
+  syncToLayer( layer );
 }
 
 


### PR DESCRIPTION
Hi,
I am Belgacem Nedjima, one of this year's Google Summer of Code project student.
This month we started the community bonding period and was tasked to try to fix issues I find in QGIS,
I accidentally found this small bug that doesn't seem to appear in any issue.
## Bug description
### Before:
In the layer properties window by default the 3D view doesn't show that a symbol is in use.
![Screenshot_20200515_080528](https://user-images.githubusercontent.com/29183781/82021736-4aeab780-9683-11ea-8520-35fd1aa43b30.png)
### After:
The symbol configuration widget is loaded according to its type (No symbol / Single Symbol / Rule-based)
![Screenshot_20200515_080556](https://user-images.githubusercontent.com/29183781/82021750-4f16d500-9683-11ea-98fe-fc42050f3b0a.png)

