### PR TITLE
fix deprecated QList::toSet in Qt 5.14+

### DIFF
--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -457,6 +457,16 @@ namespace qgis
       return pmf;
     }
   };
+
+  template<class T>
+  QSet<T> listToSet( const QList<T> &list )
+  {
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    return list.toSet();
+#else
+    return QSet<T>( list.begin(), list.end() );
+#endif
+  }
 }
 ///@endcond
 #endif

--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -67,11 +67,7 @@ void QgsFeatureFilterModel::requestToReloadCurrentFeature( QgsFeatureRequest &re
 
 QSet<QString> QgsFeatureFilterModel::requestedAttributes() const
 {
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-  return mIdentifierFields.toSet();
-#else
-  return QSet<QString>( mIdentifierFields.begin(), mIdentifierFields.end() );
-#endif
+  return qgis::listToSet( mIdentifierFields );
 }
 
 QVariant QgsFeatureFilterModel::entryIdentifier( const QgsFeatureExpressionValuesGatherer::Entry &entry ) const

--- a/src/core/qgsstringstatisticalsummary.h
+++ b/src/core/qgsstringstatisticalsummary.h
@@ -20,6 +20,7 @@
 #include <QVariantList>
 
 #include "qgis_core.h"
+#include "qgis.h"
 
 /***************************************************************************
  * This class is considered CRITICAL and any change MUST be accompanied with
@@ -164,7 +165,7 @@ class CORE_EXPORT QgsStringStatisticalSummary
      * Returns the set of distinct string values.
      * \see countDistinct()
      */
-    QSet< QString > distinctValues() const { return QSet<QString>::fromList( mValues.keys() ); }
+    QSet< QString > distinctValues() const { return qgis::listToSet( mValues.keys() ); }
 
     /**
      * Returns the number of missing (null) string values.

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -76,7 +76,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
       public:
         SetOption( const QString &docString, const QStringList &values, const QString &defaultValue, bool allowNone = false )
           : Option( docString, Set )
-          , values( values.toSet() )
+          , values( qgis::listToSet( values ) )
           , defaultValue( defaultValue )
           , allowNone( allowNone )
         {}

--- a/src/core/qgsvectorlayercache.h
+++ b/src/core/qgsvectorlayercache.h
@@ -231,7 +231,7 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
      * \see isFidCached()
      * \since QGIS 3.0
      */
-    QgsFeatureIds cachedFeatureIds() const { return mCache.keys().toSet(); }
+    QgsFeatureIds cachedFeatureIds() const { return qgis::listToSet( mCache.keys() ); }
 
     /**
      * Gets the feature at the given feature id. Considers the changed, added, deleted and permanent features


### PR DESCRIPTION
add an helper in qgis.h to avoid overwhelming the code

