### PR TITLE
Turn off editing and dragging for "Current environment variables" table widget in System settings window

### DIFF
--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -254,8 +254,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
     for ( int i = 0; i < varStrItms.size(); ++i )
     {
       QTableWidgetItem *varNameItm = new QTableWidgetItem( varStrItms.at( i ) );
-      varNameItm->setFlags( Qt::ItemIsEnabled | Qt::ItemIsSelectable
-                            | Qt::ItemIsEditable | Qt::ItemIsDragEnabled );
+      varNameItm->setFlags( Qt::ItemIsEnabled | Qt::ItemIsSelectable );
       fItm = varNameItm->font();
       if ( !sysVarVal.isEmpty() )
       {

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -1481,15 +1481,6 @@
                          <height>120</height>
                         </size>
                        </property>
-                       <property name="editTriggers">
-                        <set>QAbstractItemView::AllEditTriggers</set>
-                       </property>
-                       <property name="dragEnabled">
-                        <bool>true</bool>
-                       </property>
-                       <property name="dragDropMode">
-                        <enum>QAbstractItemView::DragOnly</enum>
-                       </property>
                        <property name="selectionMode">
                         <enum>QAbstractItemView::SingleSelection</enum>
                        </property>


### PR DESCRIPTION
## Description

Edit triggers are wrongly set on for the Current environment variables table widget in Options | System settings window, while the variables values are read only in that table.

This affects also 3.10 branch.

The patch sets to QAbstractItemView::NoEditTriggers the editTriggers property of the mCurrentVariablesTable QTableWidget in order to make it not editable.


<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
