### PR TITLE
Compiling error in Visual Studio: Error E0484 invalid explicit instantiation declaration

### DIFF
--- a/src/core/qgsoptionalexpression.h
+++ b/src/core/qgsoptionalexpression.h
@@ -79,7 +79,7 @@ class CORE_EXPORT QgsOptionalExpression : public QgsOptional<QgsExpression>
 
 #if defined(_MSC_VER)
 #ifndef SIP_RUN
-template CORE_EXPORT QgsOptional<QgsExpression>;
+template class CORE_EXPORT QgsOptional<QgsExpression>;
 #endif
 #endif
 


### PR DESCRIPTION
With no "class" keyword on line 82 there is Error E0484 invalid explicit instantiation declaration.
See "[General Rules and Limitations](https://docs.microsoft.com/en-us/cpp/cpp/general-rules-and-limitations?view=vs-2019)" on MS.