### PR TITLE
[TEMPORAL] set mesh layer visible when animated mode is off

### DIFF
--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -82,9 +82,7 @@ void QgsMeshLayer::setDefaultRendererSettings()
          meta.minimum() == std::numeric_limits<double>::quiet_NaN() )
       meshSettings.setEnabled( true );
 
-    // If the mesh is non temporal, set the static scalar dataset
-    if ( !mDataProvider->temporalCapabilities()->hasTemporalCapabilities() )
-      setStaticScalarDatasetIndex( QgsMeshDatasetIndex( 0, 0 ) );
+    setStaticScalarDatasetIndex( QgsMeshDatasetIndex( 0, 0 ) );
   }
   else
   {

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -82,7 +82,9 @@ void QgsMeshLayer::setDefaultRendererSettings()
          meta.minimum() == std::numeric_limits<double>::quiet_NaN() )
       meshSettings.setEnabled( true );
 
-    setStaticScalarDatasetIndex( QgsMeshDatasetIndex( 0, 0 ) );
+    // If the mesh is non temporal, set the static scalar dataset
+    if ( !mDataProvider->temporalCapabilities()->hasTemporalCapabilities() )
+      setStaticScalarDatasetIndex( QgsMeshDatasetIndex( 0, 0 ) );
   }
   else
   {

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -243,13 +243,11 @@ void QgsTemporalControllerWidget::onLayersAdded( const QList<QgsMapLayer *> &lay
 {
   if ( !mHasTemporalLayersLoaded )
   {
-    bool temporalMeshLayerPresent = false;
     for ( QgsMapLayer *layer : layers )
     {
       if ( layer->temporalProperties() )
       {
         mHasTemporalLayersLoaded |= layer->temporalProperties()->isActive();
-        temporalMeshLayerPresent = mHasTemporalLayersLoaded && layer->type() == QgsMapLayerType::MeshLayer;
 
         if ( !mHasTemporalLayersLoaded )
         {
@@ -260,8 +258,6 @@ void QgsTemporalControllerWidget::onLayersAdded( const QList<QgsMapLayer *> &lay
               mHasTemporalLayersLoaded = true;
               // if we are moving from zero temporal layers to non-zero temporal layers, let's set temporal extent
               this->setDatesToProjectTime();
-              if ( layer->type() == QgsMapLayerType::MeshLayer )
-                setNavigationMode( QgsTemporalNavigationObject::Animated );
             }
           } );
         }
@@ -269,11 +265,7 @@ void QgsTemporalControllerWidget::onLayersAdded( const QList<QgsMapLayer *> &lay
     }
 
     if ( mHasTemporalLayersLoaded )
-    {
       setDatesToProjectTime();
-      if ( temporalMeshLayerPresent )
-        setNavigationMode( QgsTemporalNavigationObject::Animated );
-    }
   }
 }
 

--- a/src/gui/qgstemporalcontrollerwidget.h
+++ b/src/gui/qgstemporalcontrollerwidget.h
@@ -125,6 +125,7 @@ class GUI_EXPORT QgsTemporalControllerWidget : public QgsPanelWidget, private Ui
     void mNavigationOff_clicked();
     void mNavigationFixedRange_clicked();
     void mNavigationAnimated_clicked();
+    void setNavigationMode( const QgsTemporalNavigationObject::NavigationMode mode, bool writeEntry = false );
     void setWidgetStateFromNavigationMode( const QgsTemporalNavigationObject::NavigationMode mode );
 
     void onLayersAdded( const QList<QgsMapLayer *> &layers );


### PR DESCRIPTION
With #36426, the default temporal mode is "navigation off". 
But with this mode when mesh has only temporal datasets the mesh is not visible after loading it, and that could be disturbing for user.
With this new PR, when a temporal layer is loaded for the first time, if it is a mesh layer the temporal mode is set to "animated".
As I don't know very well how other layer type work with different navigation mode, this behavior is only for mesh layer, maybe it could be too for other types.

Some refactoring is also done.