### PR TITLE
[MESH] fix #36463 : display last dataset at the end of the time extent

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshdataprovidertemporalcapabilities.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovidertemporalcapabilities.sip.in
@@ -23,22 +23,37 @@ Class for handling properties relating to a mesh data provider's temporal capabi
 %End
   public:
 
+    enum MatchingTemporalDatasetMethod
+    {
+      FindClosestDatasetBeforeStartRangeTime,
+      FindClosestDatasetFromStartRangeTime
+    };
+
     QgsMeshDataProviderTemporalCapabilities();
 %Docstring
 Constructor for QgsMeshDataProviderTemporalCapabilities
 %End
 
-    QgsMeshDatasetIndex datasetIndexFromRelativeTimeRange( int group, qint64 startTimeSinceGlobalReference, qint64 endTimeSinceGlobalReference ) const;
+    QgsMeshDatasetIndex datasetIndexClosestBeforeRelativeTime( int group, qint64 timeSinceGlobalReference ) const;
 %Docstring
-Returns the first dataset that are include in the range [``startTimeSinceGlobalReference``,``endTimeSinceGlobalReference``[ (in milliseconds)
-from the dataset ``group``. If no dataset is present in this range return the last dataset before this range if it not the last one
-of whole the dataset group
+Returns the last dataset whith time less than or equal to ``timeSinceGlobalReference``
 
-Returns invalid dataset index if there is no data set in the range
+Returns invalid dataset index if ``timeSinceGlobalReference`` is outside the time extent of the dataset group
 
 .. note::
 
-   for non temporal dataset group, the range is not used and the unique dataset is returned
+   for non temporal dataset group, ``timeSinceGlobalReference`` is not used and the unique dataset is returned
+%End
+
+    QgsMeshDatasetIndex datasetIndexClosestFromRelativeTime( int group, qint64 timeSinceGlobalReference ) const;
+%Docstring
+Returns the closest dataset index from the ``timeSinceGlobalReference``
+
+Returns invalid dataset index if ``timeSinceGlobalReference`` is outside the time extent of the dataset group
+
+.. note::
+
+   for non temporal dataset group, ``timeSinceGlobalReference`` is not used and the unique dataset is returned
 %End
 
 

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -292,6 +292,11 @@ If the temporal properties is not active, return the static dataset
 
 :return: dataset index
 
+.. note::
+
+   the returned dataset index depends on the matching method, see setTemporalMatchingMethod()
+
+
 .. versionadded:: 3.14
 %End
 
@@ -303,6 +308,11 @@ If the temporal properties is not active, return the static dataset
 :param timeRange: the time range
 
 :return: dataset index
+
+.. note::
+
+   the returned dataset index depends on the matching method, see setTemporalMatchingMethod()
+
 
 .. versionadded:: 3.14
 %End
@@ -328,6 +338,15 @@ Returns the static vector dataset index that is rendered if the temporal propert
 Sets the reference time of the layer
 
 :param referenceTime: the reference time
+
+.. versionadded:: 3.14
+%End
+
+    void setTemporalMatchingMethod( const QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod &matchingMethod );
+%Docstring
+Sets the method used to match the temporal dataset from a requested time, see activeVectorDatasetAtTime()
+
+:param matchingMethod: the matching method
 
 .. versionadded:: 3.14
 %End

--- a/python/core/auto_generated/mesh/qgsmeshlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayertemporalproperties.sip.in
@@ -76,6 +76,18 @@ if the temporal capabilities is null, set a void time extent (reference time to 
 :param capabilities: the temporal capabilities of the data provider
 %End
 
+    QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod matchingMethod() const;
+%Docstring
+Returns the method used to match dataset from temporal capabilities
+%End
+
+    void setMatchingMethod( const QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod &matchingMethod );
+%Docstring
+Sets the method used to match dataset from temporal capabilities
+
+:param matchingMethod: the matching method
+%End
+
 };
 
 /************************************************************************

--- a/python/gui/auto_additions/qgssublayersdialog.py
+++ b/python/gui/auto_additions/qgssublayersdialog.py
@@ -1,0 +1,2 @@
+# The following has been generated automatically from src/gui/qgssublayersdialog.h
+QgsSublayersDialog.PromptMode.baseClass = QgsSublayersDialog

--- a/src/app/mesh/qgsmeshlayerproperties.cpp
+++ b/src/app/mesh/qgsmeshlayerproperties.cpp
@@ -95,9 +95,9 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   delete mOptsPage_3DView;  // removes both the "3d view" list item and its page
 #endif
 
-  mComboBoxTemporalDatasetMatchingMethod->addItem( tr( "Find closest dataset before requested time" ),
+  mComboBoxTemporalDatasetMatchingMethod->addItem( tr( "Find Closest Dataset Before Requested Time" ),
       QgsMeshDataProviderTemporalCapabilities::FindClosestDatasetBeforeStartRangeTime );
-  mComboBoxTemporalDatasetMatchingMethod->addItem( tr( "Find closest dataset from requested time (after or before)" ),
+  mComboBoxTemporalDatasetMatchingMethod->addItem( tr( "Find Closest Dataset From Requested Time (After or Before)" ),
       QgsMeshDataProviderTemporalCapabilities::FindClosestDatasetFromStartRangeTime );
 
   // update based on lyr's current state

--- a/src/app/mesh/qgsmeshlayerproperties.cpp
+++ b/src/app/mesh/qgsmeshlayerproperties.cpp
@@ -95,6 +95,11 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   delete mOptsPage_3DView;  // removes both the "3d view" list item and its page
 #endif
 
+  mComboBoxTemporalDatasetMatchingMethod->addItem( tr( "Find closest dataset before requested time" ),
+      QgsMeshDataProviderTemporalCapabilities::FindClosestDatasetBeforeStartRangeTime );
+  mComboBoxTemporalDatasetMatchingMethod->addItem( tr( "Find closest dataset from requested time (after or before)" ),
+      QgsMeshDataProviderTemporalCapabilities::FindClosestDatasetFromStartRangeTime );
+
   // update based on lyr's current state
   syncToLayer();
 
@@ -209,6 +214,8 @@ void QgsMeshLayerProperties::syncToLayer()
     mTemporalProviderTimeUnitComboBox->setCurrentIndex(
       mTemporalProviderTimeUnitComboBox->findData( mMeshLayer->dataProvider()->temporalCapabilities()->temporalUnit() ) );
   }
+  mComboBoxTemporalDatasetMatchingMethod->setCurrentIndex(
+    mComboBoxTemporalDatasetMatchingMethod->findData( temporalProperties->matchingMethod() ) );
 
   mStaticScalarWidget->syncToLayer();
   mStaticScalarWidget->setVisible( !mMeshLayer->temporalProperties()->isActive() );
@@ -371,6 +378,8 @@ void QgsMeshLayerProperties::apply()
   mStaticScalarWidget->apply();
   bool needEmitRendererChanged = mMeshLayer->temporalProperties()->isActive() == mTemporalStaticDatasetCheckBox->isChecked();
   mMeshLayer->temporalProperties()->setIsActive( !mTemporalStaticDatasetCheckBox->isChecked() );
+  mMeshLayer->setTemporalMatchingMethod( static_cast<QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod>(
+      mComboBoxTemporalDatasetMatchingMethod->currentData().toInt() ) );
 
   if ( needMeshUpdating )
     mMeshLayer->reload();

--- a/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.cpp
+++ b/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.cpp
@@ -33,7 +33,10 @@ QgsMeshDatasetIndex QgsMeshDataProviderTemporalCapabilities::datasetIndexFromRel
   const qint64 endTimeSinceGroupReference =
     endTimeSinceGlobalReference - mGlobalReferenceDateTime.msecsTo( groupReference );
 
-  if ( startTimeSinceGroupReference >= datasetTimes.last() )
+  if ( startTimeSinceGroupReference > datasetTimes.last() )
+    return QgsMeshDatasetIndex();
+
+  if ( endTimeSinceGroupReference < datasetTimes.first() )
     return QgsMeshDatasetIndex();
 
   for ( int i = 0; i < datasetTimes.count(); ++i )
@@ -41,10 +44,10 @@ QgsMeshDatasetIndex QgsMeshDataProviderTemporalCapabilities::datasetIndexFromRel
     qint64 time = datasetTimes.at( i );
     if ( startTimeSinceGroupReference <= time )
     {
-      if ( endTimeSinceGroupReference <= time )
-        return QgsMeshDatasetIndex( group, i - 1 ); // invalid if i=0
+      if ( endTimeSinceGroupReference < time ) // Start and end of range are before the current time step
+        return QgsMeshDatasetIndex( group, i - 1 ); // --> return the previous time step, invalid if i=0
       else
-        return QgsMeshDatasetIndex( group, i );
+        return QgsMeshDatasetIndex( group, i ); // current time step are included in [start,end] --> return current
     }
   }
 

--- a/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.cpp
+++ b/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.cpp
@@ -21,38 +21,58 @@
 QgsMeshDataProviderTemporalCapabilities::QgsMeshDataProviderTemporalCapabilities(): QgsDataProviderTemporalCapabilities()
 {}
 
-QgsMeshDatasetIndex QgsMeshDataProviderTemporalCapabilities::datasetIndexFromRelativeTimeRange( int group, qint64 startTimeSinceGlobalReference, qint64 endTimeSinceGlobalReference ) const
+QgsMeshDatasetIndex QgsMeshDataProviderTemporalCapabilities::datasetIndexClosestFromRelativeTime( int group, qint64 timeSinceGlobalReference ) const
 {
   // No time --> non temporal dataset, so return the dataset that has to be the only one
   const QList<qint64> &datasetTimes = mDatasetTimeSinceGroupReference[group];
   if ( datasetTimes.isEmpty() )
     return QgsMeshDatasetIndex( group, 0 );
   const QDateTime groupReference = mGroupsReferenceDateTime[group];
-  const qint64 startTimeSinceGroupReference =
-    startTimeSinceGlobalReference - mGlobalReferenceDateTime.msecsTo( groupReference );
-  const qint64 endTimeSinceGroupReference =
-    endTimeSinceGlobalReference - mGlobalReferenceDateTime.msecsTo( groupReference );
+  const qint64 timeSinceGroupReference =
+    timeSinceGlobalReference - mGlobalReferenceDateTime.msecsTo( groupReference );
 
-  if ( startTimeSinceGroupReference > datasetTimes.last() )
+  if ( timeSinceGroupReference > datasetTimes.last() // after last time
+       || timeSinceGroupReference < datasetTimes.first() ) // before first time
     return QgsMeshDatasetIndex();
 
-  if ( endTimeSinceGroupReference < datasetTimes.first() )
-    return QgsMeshDatasetIndex();
-
-  for ( int i = 0; i < datasetTimes.count(); ++i )
+  for ( int i = 1 ; i < datasetTimes.count(); ++i )
   {
-    qint64 time = datasetTimes.at( i );
-    if ( startTimeSinceGroupReference <= time )
+    qint64 time1 = datasetTimes.at( i - 1 );
+    qint64 time2 = datasetTimes.at( i );
+    if ( time1 <= timeSinceGroupReference && timeSinceGroupReference <= time2 )
     {
-      if ( endTimeSinceGroupReference < time ) // Start and end of range are before the current time step
-        return QgsMeshDatasetIndex( group, i - 1 ); // --> return the previous time step, invalid if i=0
+      if ( abs( timeSinceGroupReference - time2 ) < abs( timeSinceGroupReference - time1 ) )
+        return QgsMeshDatasetIndex( group, i );
       else
-        return QgsMeshDatasetIndex( group, i ); // current time step are included in [start,end] --> return current
+        return QgsMeshDatasetIndex( group, i - 1 );
     }
   }
 
-  // if we are here (normally, this could no happen), return invalid dataset index
-  return QgsMeshDatasetIndex();
+  return QgsMeshDatasetIndex( QgsMeshDatasetIndex( group, datasetTimes.count() - 1 ) );
+}
+
+QgsMeshDatasetIndex QgsMeshDataProviderTemporalCapabilities::datasetIndexClosestBeforeRelativeTime( int group, qint64 timeSinceGlobalReference ) const
+{
+  // No time --> non temporal dataset, so return the dataset that has to be the only one
+  const QList<qint64> &datasetTimes = mDatasetTimeSinceGroupReference[group];
+  if ( datasetTimes.isEmpty() )
+    return QgsMeshDatasetIndex( group, 0 );
+  const QDateTime groupReference = mGroupsReferenceDateTime[group];
+  const qint64 timeSinceGroupReference =
+    timeSinceGlobalReference - mGlobalReferenceDateTime.msecsTo( groupReference );
+
+  if ( timeSinceGroupReference > datasetTimes.last() // after last time
+       || timeSinceGroupReference < datasetTimes.first() ) // before first time
+    return QgsMeshDatasetIndex();
+
+  for ( int i = 1; i < datasetTimes.count(); ++i )
+  {
+    qint64 time = datasetTimes.at( i );
+    if ( timeSinceGroupReference < time )
+      return QgsMeshDatasetIndex( group, i - 1 );
+  }
+
+  return QgsMeshDatasetIndex( QgsMeshDatasetIndex( group, datasetTimes.count() - 1 ) );
 }
 
 void QgsMeshDataProviderTemporalCapabilities::addGroupReferenceDateTime( int group, const QDateTime &reference )

--- a/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.h
+++ b/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.h
@@ -35,20 +35,36 @@ class CORE_EXPORT QgsMeshDataProviderTemporalCapabilities: public QgsDataProvide
   public:
 
     /**
+     * Method to use when requesting a tempral dataset from a time
+     **/
+    enum MatchingTemporalDatasetMethod
+    {
+      FindClosestDatasetBeforeStartRangeTime, //! Find the closest dataset which have its time before the requested start range time
+      FindClosestDatasetFromStartRangeTime //! Find the closest dataset before or after the requested start range time
+    };
+
+    /**
      * Constructor for QgsMeshDataProviderTemporalCapabilities
      */
     QgsMeshDataProviderTemporalCapabilities();
 
     /**
-     * Returns the first dataset that are include in the range [\a startTimeSinceGlobalReference,\a endTimeSinceGlobalReference[ (in milliseconds)
-     * from the dataset \a group. If no dataset is present in this range return the last dataset before this range if it not the last one
-     * of whole the dataset group
+     * Returns the last dataset whith time less than or equal to \a timeSinceGlobalReference
      *
-     * Returns invalid dataset index if there is no data set in the range
+     * Returns invalid dataset index if \a timeSinceGlobalReference is outside the time extent of the dataset group
      *
-     * \note for non temporal dataset group, the range is not used and the unique dataset is returned
+     * \note for non temporal dataset group, \a timeSinceGlobalReference is not used and the unique dataset is returned
      */
-    QgsMeshDatasetIndex datasetIndexFromRelativeTimeRange( int group, qint64 startTimeSinceGlobalReference, qint64 endTimeSinceGlobalReference ) const;
+    QgsMeshDatasetIndex datasetIndexClosestBeforeRelativeTime( int group, qint64 timeSinceGlobalReference ) const;
+
+    /**
+     * Returns the closest dataset index from the \a timeSinceGlobalReference
+     *
+     *Returns invalid dataset index if \a timeSinceGlobalReference is outside the time extent of the dataset group
+     *
+     * \note for non temporal dataset group, \a timeSinceGlobalReference is not used and the unique dataset is returned
+     */
+    QgsMeshDatasetIndex datasetIndexClosestFromRelativeTime( int group, qint64 timeSinceGlobalReference ) const;
 
     /**
      * Adds a \a reference date/time from a dataset \a group

--- a/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.h
+++ b/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.h
@@ -35,12 +35,12 @@ class CORE_EXPORT QgsMeshDataProviderTemporalCapabilities: public QgsDataProvide
   public:
 
     /**
-     * Method to use when requesting a tempral dataset from a time
+     * Method for selection of temporal mesh dataset from a range time
      **/
     enum MatchingTemporalDatasetMethod
     {
-      FindClosestDatasetBeforeStartRangeTime, //! Find the closest dataset which have its time before the requested start range time
-      FindClosestDatasetFromStartRangeTime //! Find the closest dataset before or after the requested start range time
+      FindClosestDatasetBeforeStartRangeTime, //! Finds the closest dataset which have its time before the requested start range time
+      FindClosestDatasetFromStartRangeTime //! Finds the closest dataset before or after the requested start range time
     };
 
     /**

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -332,6 +332,8 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
       * \param timeRange the time range
       * \returns dataset index
       *
+      * \note the returned dataset index depends on the matching method, see setTemporalMatchingMethod()
+      *
       * \since QGIS 3.14
       */
     QgsMeshDatasetIndex activeScalarDatasetAtTime( const QgsDateTimeRange &timeRange ) const;
@@ -342,6 +344,8 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
       *
       * \param timeRange the time range
       * \returns dataset index
+      *
+      * \note the returned dataset index depends on the matching method, see setTemporalMatchingMethod()
       *
       * \since QGIS 3.14
       */
@@ -387,6 +391,15 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
       * \since QGIS 3.14
       */
     void setReferenceTime( const QDateTime &referenceTime );
+
+    /**
+      * Sets the method used to match the temporal dataset from a requested time, see activeVectorDatasetAtTime()
+      *
+      * \param matchingMethod the matching method
+      *
+      * \since QGIS 3.14
+      */
+    void setTemporalMatchingMethod( const QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod &matchingMethod );
 
     /**
       * Returns the position of the snapped point on the mesh element closest to \a point intersecting with

--- a/src/core/mesh/qgsmeshlayertemporalproperties.cpp
+++ b/src/core/mesh/qgsmeshlayertemporalproperties.cpp
@@ -33,6 +33,7 @@ QDomElement QgsMeshLayerTemporalProperties::writeXml( QDomElement &element, QDom
   temporalElement.setAttribute( QStringLiteral( "reference-time" ), mReferenceTime.toTimeSpec( Qt::UTC ).toString( Qt::ISODate ) );
   temporalElement.setAttribute( QStringLiteral( "start-time-extent" ), mTimeExtent.begin().toTimeSpec( Qt::UTC ).toString( Qt::ISODate ) );
   temporalElement.setAttribute( QStringLiteral( "end-time-extent" ), mTimeExtent.end().toTimeSpec( Qt::UTC ).toString( Qt::ISODate ) );
+  temporalElement.setAttribute( QStringLiteral( "matching-method" ), mMatchingMethod );
 
   element.appendChild( temporalElement );
 
@@ -56,6 +57,9 @@ bool QgsMeshLayerTemporalProperties::readXml( const QDomElement &element, const 
     QDateTime end = QDateTime::fromString( temporalElement.attribute( QStringLiteral( "end-time-extent" ) ), Qt::ISODate );
     mTimeExtent = QgsDateTimeRange( start, end );
   }
+
+  mMatchingMethod = static_cast<QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod>(
+                      temporalElement.attribute( QStringLiteral( "matching-method" ) ).toInt() );
 
   return true;
 }
@@ -97,4 +101,14 @@ void QgsMeshLayerTemporalProperties::setReferenceTime( const QDateTime &referenc
   }
   else
     mTimeExtent = QgsDateTimeRange( referenceTime, referenceTime );
+}
+
+QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod QgsMeshLayerTemporalProperties::matchingMethod() const
+{
+  return mMatchingMethod;
+}
+
+void QgsMeshLayerTemporalProperties::setMatchingMethod( const QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod &matchingMethod )
+{
+  mMatchingMethod = matchingMethod;
 }

--- a/src/core/mesh/qgsmeshlayertemporalproperties.h
+++ b/src/core/mesh/qgsmeshlayertemporalproperties.h
@@ -19,6 +19,7 @@
 #define QGSMESHLAYERTEMPORALPROPERTIES_H
 
 #include "qgsmaplayertemporalproperties.h"
+#include "qgsmeshdataprovidertemporalcapabilities.h"
 
 
 /**
@@ -86,9 +87,23 @@ class CORE_EXPORT QgsMeshLayerTemporalProperties : public QgsMapLayerTemporalPro
      */
     void setReferenceTime( const QDateTime &referenceTime, const QgsDataProviderTemporalCapabilities *capabilities );
 
+    /**
+     * Returns the method used to match dataset from temporal capabilities
+     */
+    QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod matchingMethod() const;
+
+    /**
+     * Sets the method used to match dataset from temporal capabilities
+     *
+     * \param matchingMethod the matching method
+     */
+    void setMatchingMethod( const QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod &matchingMethod );
+
   private:
     QDateTime mReferenceTime;
     QgsDateTimeRange mTimeExtent;
+    QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod mMatchingMethod =
+      QgsMeshDataProviderTemporalCapabilities::FindClosestDatasetBeforeStartRangeTime;
 };
 
 #endif // QGSMESHLAYERTEMPORALPROPERTIES_H

--- a/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
+++ b/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
@@ -532,21 +532,18 @@ border-radius: 2px;</string>
            <property name="bottomMargin">
             <number>0</number>
            </property>
-           <item row="1" column="3">
-            <widget class="QDateTimeEdit" name="mTemporalDateTimeStart">
-             <property name="enabled">
-              <bool>false</bool>
+           <item row="4" column="2">
+            <spacer name="verticalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
              </property>
-             <property name="alignment">
-              <set>Qt::AlignCenter</set>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
              </property>
-             <property name="readOnly">
-              <bool>true</bool>
-             </property>
-             <property name="buttonSymbols">
-              <enum>QAbstractSpinBox::NoButtons</enum>
-             </property>
-            </widget>
+            </spacer>
            </item>
            <item row="0" column="4">
             <widget class="QPushButton" name="mTemporalReloadButton">
@@ -568,45 +565,6 @@ border-radius: 2px;</string>
              </property>
             </widget>
            </item>
-           <item row="0" column="2">
-            <widget class="QLabel" name="label_3">
-             <property name="text">
-              <string>Layer Time Reference</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="2" colspan="7">
-            <widget class="QGroupBox" name="groupBox_2">
-             <property name="title">
-              <string>Provider Time Settings</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_5">
-              <item row="0" column="2">
-               <spacer name="horizontalSpacer_4">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_12">
-                <property name="text">
-                 <string>Time unit</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QComboBox" name="mTemporalProviderTimeUnitComboBox"/>
-              </item>
-             </layout>
-            </widget>
-           </item>
            <item row="0" column="3">
             <widget class="QDateTimeEdit" name="mTemporalDateTimeReference">
              <property name="alignment">
@@ -617,6 +575,22 @@ border-radius: 2px;</string>
              </property>
              <property name="timeSpec">
               <enum>Qt::UTC</enum>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="3">
+            <widget class="QDateTimeEdit" name="mTemporalDateTimeStart">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+             <property name="readOnly">
+              <bool>true</bool>
+             </property>
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
              </property>
             </widget>
            </item>
@@ -633,11 +607,43 @@ border-radius: 2px;</string>
              </property>
             </spacer>
            </item>
-           <item row="1" column="4" colspan="2">
-            <widget class="QLabel" name="label_4">
+           <item row="1" column="2">
+            <widget class="QLabel" name="label_6">
              <property name="text">
-              <string>Layer End Time</string>
+              <string>Layer Start Time</string>
              </property>
+            </widget>
+           </item>
+           <item row="3" column="2" colspan="7">
+            <widget class="QGroupBox" name="groupBox_2">
+             <property name="title">
+              <string>Provider Time Settings</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_5">
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_12">
+                <property name="text">
+                 <string>Time unit</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2">
+               <spacer name="horizontalSpacer_4">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="1" column="1">
+               <widget class="QComboBox" name="mTemporalProviderTimeUnitComboBox"/>
+              </item>
+             </layout>
             </widget>
            </item>
            <item row="1" column="6">
@@ -671,25 +677,29 @@ border-radius: 2px;</string>
              </property>
             </widget>
            </item>
-           <item row="3" column="2">
-            <spacer name="verticalSpacer_2">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>40</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item row="1" column="2">
-            <widget class="QLabel" name="label_6">
+           <item row="0" column="2">
+            <widget class="QLabel" name="label_3">
              <property name="text">
-              <string>Layer Start Time</string>
+              <string>Layer Time Reference</string>
              </property>
             </widget>
+           </item>
+           <item row="1" column="4" colspan="2">
+            <widget class="QLabel" name="label_4">
+             <property name="text">
+              <string>Layer End Time</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="2">
+            <widget class="QLabel" name="label_10">
+             <property name="text">
+              <string>Matching dataset Method</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="3" colspan="3">
+            <widget class="QComboBox" name="mComboBoxTemporalDatasetMatchingMethod"/>
            </item>
           </layout>
          </widget>

--- a/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
+++ b/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
@@ -200,7 +200,7 @@
           <enum>QFrame::Plain</enum>
          </property>
          <property name="currentIndex">
-          <number>1</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="mOptsPage_Information">
           <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -567,6 +567,9 @@ border-radius: 2px;</string>
            </item>
            <item row="0" column="3">
             <widget class="QDateTimeEdit" name="mTemporalDateTimeReference">
+             <property name="toolTip">
+              <string>Reference time used to render mesh dataset when using temporal range or temporal animation</string>
+             </property>
              <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
@@ -623,7 +626,7 @@ border-radius: 2px;</string>
               <item row="1" column="0">
                <widget class="QLabel" name="label_12">
                 <property name="text">
-                 <string>Time unit</string>
+                 <string>Time Unit</string>
                 </property>
                </widget>
               </item>
@@ -641,7 +644,11 @@ border-radius: 2px;</string>
                </spacer>
               </item>
               <item row="1" column="1">
-               <widget class="QComboBox" name="mTemporalProviderTimeUnitComboBox"/>
+               <widget class="QComboBox" name="mTemporalProviderTimeUnitComboBox">
+                <property name="toolTip">
+                 <string>Default time unit of mesh data provider is hour, change to override the time unit</string>
+                </property>
+               </widget>
               </item>
              </layout>
             </widget>
@@ -680,7 +687,7 @@ border-radius: 2px;</string>
            <item row="0" column="2">
             <widget class="QLabel" name="label_3">
              <property name="text">
-              <string>Layer Time Reference</string>
+              <string>Layer Reference Time</string>
              </property>
             </widget>
            </item>
@@ -694,12 +701,16 @@ border-radius: 2px;</string>
            <item row="2" column="2">
             <widget class="QLabel" name="label_10">
              <property name="text">
-              <string>Matching dataset Method</string>
+              <string>Dataset Matching Method</string>
              </property>
             </widget>
            </item>
-           <item row="2" column="3" colspan="3">
-            <widget class="QComboBox" name="mComboBoxTemporalDatasetMatchingMethod"/>
+           <item row="2" column="3" colspan="4">
+            <widget class="QComboBox" name="mComboBoxTemporalDatasetMatchingMethod">
+             <property name="toolTip">
+              <string>Method for selection of temporal mesh dataset from a range time</string>
+             </property>
+            </widget>
            </item>
           </layout>
          </widget>

--- a/tests/src/core/testqgsmeshlayer.cpp
+++ b/tests/src/core/testqgsmeshlayer.cpp
@@ -1123,40 +1123,50 @@ void TestQgsMeshLayer::test_temporal()
 {
   qint64 relativeTime_0 = -1000;
   qint64 relativeTime_1 = 0;
-  qint64 relativeTime_2 = 1000 * 60 * 60 * 0.3;
-  qint64 relativeTime_3 = 1000 * 60 * 60 * 0.5;
-  qint64 relativeTime_4 = 1000 * 60 * 60 * 1.5;
-  qint64 relativeTime_5 = 1000 * 60 * 60 * 2;
+  qint64 relativeTime_2 = 1000 * 60 * 60 * 0.6;
+  qint64 relativeTime_3 = 1000 * 60 * 60 * 1;
+  qint64 relativeTime_4 = 1000 * 60 * 60 * 2;
   // Mesh memory provider
   QgsMeshDataProviderTemporalCapabilities *tempCap = mMemoryLayer->dataProvider()->temporalCapabilities();
   // Static dataset
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 0, relativeTime_0, relativeTime_1 ).dataset(), 0 );
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 0, relativeTime_1, relativeTime_2 ).dataset(), 0 );
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 0, relativeTime_2, relativeTime_3 ).dataset(), 0 );
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 0, relativeTime_3, relativeTime_4 ).dataset(), 0 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 0, relativeTime_0 ).dataset(), 0 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 0, relativeTime_1 ).dataset(), 0 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 0, relativeTime_2 ).dataset(), 0 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 0, relativeTime_3 ).dataset(), 0 );
   // Temporal dataset
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 1, relativeTime_0, relativeTime_1 ).dataset(), -1 );
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 1, relativeTime_1, relativeTime_2 ).dataset(), 0 );
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 1, relativeTime_2, relativeTime_3 ).dataset(), 0 );
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 1, relativeTime_3, relativeTime_4 ).dataset(), 1 );
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 1, relativeTime_4, relativeTime_5 ).dataset(), -1 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 1, relativeTime_0 ).dataset(), -1 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 1, relativeTime_1 ).dataset(), 0 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 1, relativeTime_2 ).dataset(), 0 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 1, relativeTime_3 ).dataset(), 1 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 1, relativeTime_4 ).dataset(), -1 );
+  QCOMPARE( tempCap->datasetIndexClosestFromRelativeTime( 1, relativeTime_0 ).dataset(), -1 );
+  QCOMPARE( tempCap->datasetIndexClosestFromRelativeTime( 1, relativeTime_1 ).dataset(), 0 );
+  QCOMPARE( tempCap->datasetIndexClosestFromRelativeTime( 1, relativeTime_2 ).dataset(), 1 );
+  QCOMPARE( tempCap->datasetIndexClosestFromRelativeTime( 1, relativeTime_3 ).dataset(), 1 );
+  QCOMPARE( tempCap->datasetIndexClosestFromRelativeTime( 1, relativeTime_4 ).dataset(), -1 );
+
 
   // Mesh MDAL provider with internal dataset
   tempCap = mMdalLayer->dataProvider()->temporalCapabilities();
   // Static dataset
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 0, relativeTime_0, relativeTime_1 ).dataset(), 0 );
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 0, relativeTime_1, relativeTime_2 ).dataset(), 0 );
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 0, relativeTime_2, relativeTime_3 ).dataset(), 0 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 0, relativeTime_0 ).dataset(), 0 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 0, relativeTime_1 ).dataset(), 0 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 0, relativeTime_2 ).dataset(), 0 );
   // Temporal dataset
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 1, relativeTime_0, relativeTime_1 ).dataset(), -1 );
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 1, relativeTime_1, relativeTime_2 ).dataset(), 0 );
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 1, relativeTime_2, relativeTime_3 ).dataset(), 0 );
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 1, relativeTime_3, relativeTime_4 ).dataset(), 1 );
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 1, relativeTime_4, relativeTime_5 ).dataset(), -1 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 1, relativeTime_0 ).dataset(), -1 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 1, relativeTime_1 ).dataset(), 0 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 1, relativeTime_2 ).dataset(), 0 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 1, relativeTime_3 ).dataset(), 1 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 1, relativeTime_4 ).dataset(), -1 );
+  QCOMPARE( tempCap->datasetIndexClosestFromRelativeTime( 1, relativeTime_0 ).dataset(), -1 );
+  QCOMPARE( tempCap->datasetIndexClosestFromRelativeTime( 1, relativeTime_1 ).dataset(), 0 );
+  QCOMPARE( tempCap->datasetIndexClosestFromRelativeTime( 1, relativeTime_2 ).dataset(), 1 );
+  QCOMPARE( tempCap->datasetIndexClosestFromRelativeTime( 1, relativeTime_3 ).dataset(), 1 );
+  QCOMPARE( tempCap->datasetIndexClosestFromRelativeTime( 1, relativeTime_4 ).dataset(), -1 );
 
   //Mesh MDAL provider with reference time
   tempCap = mMdal3DLayer->dataProvider()->temporalCapabilities();
-  QCOMPARE( tempCap->datasetIndexFromRelativeTimeRange( 0, relativeTime_0, relativeTime_1 ).dataset(), 0 );
+  QCOMPARE( tempCap->datasetIndexClosestBeforeRelativeTime( 0, relativeTime_0 ).dataset(), 0 );
   QDateTime begin = QDateTime( QDate( 1990, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC );
   QDateTime end = QDateTime( QDate( 1990, 1, 1 ), QTime( 6, 0, 1, 938 ), Qt::UTC );
   QCOMPARE( tempCap->timeExtent(), QgsDateTimeRange( begin, end ) );
@@ -1174,10 +1184,15 @@ void TestQgsMeshLayer::test_temporal()
   // Temporal dataset
   settings.setActiveScalarDatasetGroup( 1 );
   mMdal3DLayer->setRendererSettings( settings );
+  mMdal3DLayer->setTemporalMatchingMethod( QgsMeshDataProviderTemporalCapabilities::FindClosestDatasetBeforeStartRangeTime );
+  QCOMPARE( mMdal3DLayer->activeScalarDatasetAtTime( QgsDateTimeRange( time_1, time_2 ) ).dataset(), 17 );
+  mMdal3DLayer->setTemporalMatchingMethod( QgsMeshDataProviderTemporalCapabilities::FindClosestDatasetFromStartRangeTime );
   QCOMPARE( mMdal3DLayer->activeScalarDatasetAtTime( QgsDateTimeRange( time_1, time_2 ) ).dataset(), 18 );
   // Next dataset
+  mMdal3DLayer->setTemporalMatchingMethod( QgsMeshDataProviderTemporalCapabilities::FindClosestDatasetBeforeStartRangeTime );
+  QCOMPARE( mMdal3DLayer->activeScalarDatasetAtTime( QgsDateTimeRange( time_1.addSecs( 400 ), time_2.addSecs( 400 ) ) ).dataset(), 18 );
+  mMdal3DLayer->setTemporalMatchingMethod( QgsMeshDataProviderTemporalCapabilities::FindClosestDatasetFromStartRangeTime );
   QCOMPARE( mMdal3DLayer->activeScalarDatasetAtTime( QgsDateTimeRange( time_1.addSecs( 400 ), time_2.addSecs( 400 ) ) ).dataset(), 19 );
-
   mMdal3DLayer->temporalProperties();
 }
 


### PR DESCRIPTION
fix #36463 (point 2)
Depending of datasets, when the temporal  slider is at the end of the time extent, no datasets was displayed, and the last datasets could never be displayed.
This PR fix this issue.