### PR TITLE
[eVis] Display the icons in the dialog

### DIFF
--- a/src/plugins/evis/databaseconnection/evisdatabaseconnectiongui.cpp
+++ b/src/plugins/evis/databaseconnection/evisdatabaseconnectiongui.cpp
@@ -84,10 +84,9 @@ eVisDatabaseConnectionGui::eVisDatabaseConnectionGui( QList<QTemporaryFile *> *t
   cboxPredefinedQueryList->insertItem( 0, tr( "No predefined queries loaded" ) );
 
   //set icons
-  QString myThemePath = QgsApplication::activeThemePath();
-  pbtnOpenFile->setIcon( QIcon( QPixmap( myThemePath + "/mActionFolder.svg" ) ) );
+  pbtnOpenFile->setIcon( QIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionFolder.svg" ) ) ) );
   pbtnOpenFile->setToolTip( tr( "Open File" ) );
-  pbtnLoadPredefinedQueries->setIcon( QIcon( QPixmap( myThemePath + "/mActionFolder.svg" ) ) );
+  pbtnLoadPredefinedQueries->setIcon( QIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionFolder.svg" ) ) ) );
   pbtnLoadPredefinedQueries->setToolTip( tr( "Open File" ) );
 }
 


### PR DESCRIPTION
To move from 
![image](https://user-images.githubusercontent.com/7983394/82140833-e9b51680-9831-11ea-8270-2badc9885ff6.png)
to 
![image](https://user-images.githubusercontent.com/7983394/82140874-4dd7da80-9832-11ea-8fc6-89cd578ceb64.png)

I think that for consistency with other parts of QGIS (fwiw regarding eVis), we should instead use [mActionFileOpen](https://github.com/qgis/QGIS/blob/master/images/themes/default/mActionFileOpen.svg) to open file. Right?