### PR TITLE
disable inappropriate vector settings when 1D mesh

### DIFF
--- a/src/app/mesh/qgsmeshrenderervectorsettingswidget.cpp
+++ b/src/app/mesh/qgsmeshrenderervectorsettingswidget.cpp
@@ -181,16 +181,20 @@ QgsMeshRendererVectorSettings QgsMeshRendererVectorSettingsWidget::settings() co
 
 void QgsMeshRendererVectorSettingsWidget::syncToLayer( )
 {
-  if ( !mMeshLayer )
+  if ( !mMeshLayer && !mMeshLayer->dataProvider() )
     return;
 
   if ( mActiveDatasetGroup < 0 )
     return;
 
+  bool hasFaces = ( mMeshLayer->dataProvider() &&
+                    mMeshLayer->dataProvider()->contains( QgsMesh::ElementType::Face ) );
+
   const QgsMeshRendererSettings rendererSettings = mMeshLayer->rendererSettings();
   const QgsMeshRendererVectorSettings settings = rendererSettings.vectorSettings( mActiveDatasetGroup );
 
-  mSymbologyVectorComboBox->setCurrentIndex( settings.symbology() );
+  mSymbologyGroupBox->setVisible( hasFaces );
+  mSymbologyVectorComboBox->setCurrentIndex( hasFaces ? settings.symbology() : 0 );
 
   // Arrow settings
   const QgsMeshRendererVectorArrowSettings arrowSettings = settings.arrowSettings();
@@ -218,7 +222,8 @@ void QgsMeshRendererVectorSettingsWidget::syncToLayer( )
   mHeadLengthLineEdit->setText( QString::number( arrowSettings.arrowHeadLengthRatio() * 100.0 ) );
 
   // user grid
-  mDisplayVectorsOnGridGroupBox->setChecked( settings.isOnUserDefinedGrid() );
+  mDisplayVectorsOnGridGroupBox->setVisible( hasFaces );
+  mDisplayVectorsOnGridGroupBox->setChecked( settings.isOnUserDefinedGrid() && hasFaces );
   mXSpacingSpinBox->setValue( settings.userGridCellWidth() );
   mYSpacingSpinBox->setValue( settings.userGridCellHeight() );
 

--- a/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
@@ -27,7 +27,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="mSymbologyGroupBox">
      <property name="title">
       <string>Symbology</string>
      </property>


### PR DESCRIPTION
fix #36460
All vector settings for mesh layer are appropriate when mesh is 1D. This PR disable these settings when the mesh is 1D.