### PR TITLE
fix processing tool box `BarPlot.py` translate text spell error

### DIFF
--- a/python/plugins/processing/algs/qgis/BarPlot.py
+++ b/python/plugins/processing/algs/qgis/BarPlot.py
@@ -41,7 +41,7 @@ class BarPlot(QgisAlgorithm):
     VALUE_FIELD = 'VALUE_FIELD'
 
     def group(self):
-        return self.tr('Plots}')
+        return self.tr('Plots')
 
     def groupId(self):
         return 'plots'


### PR DESCRIPTION
I found that BarPlot.py translate text maybe spell error when I translate the text to chinese.
I have checked the [BoxPlot.py](https://github.com/qgis/QGIS/blob/master/python/plugins/processing/algs/qgis/BoxPlot.py#L46) , [PolarPlot.py](https://github.com/qgis/QGIS/blob/master/python/plugins/processing/algs/qgis/PolarPlot.py#L43) and the other plots tools. Each of them is `plots` but the **[BarPlot.py](https://github.com/qgis/QGIS/blob/master/python/plugins/processing/algs/qgis/BarPlot.py#L44)** is `plots}`.

I think is should be `plots` not `plots}`. If I am wrong, forget it.

BTW, should we upgrade the `plotly` from version 3.7x to 4.x .