### PR TITLE
[BUGFIX] Fix the absence of words in the advanced configuration widget

### DIFF
--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -573,7 +573,7 @@ QVariant QgsSnappingLayerTreeModel::data( const QModelIndex &idx, int role ) con
               }
               if ( activeTypes > 0 )
                 modes.append( tr( ", " ) );
-              modes.append( QgsSnappingConfig::snappingTypeFlagToString( ls.typeFlag() ) );
+              modes.append( QgsSnappingConfig::snappingTypeFlagToString( ls.typeFlag() & snappingTypeEnum.value( i ) ) );
               activeTypes++;
             }
           }


### PR DESCRIPTION
## Description

@nirvn noticed there's something wrong with the label in the advanced configuration widget's type column:
![image](https://user-images.githubusercontent.com/7521540/82192404-3fea8e00-98f4-11ea-8455-3466c03cd8e1.png)

[Context](https://github.com/qgis/QGIS/pull/35643#issuecomment-610215386)

Thanks to @nirvn and sorry for the very late response.

Now:
![image](https://user-images.githubusercontent.com/7521540/82192203-f26e2100-98f3-11ea-9557-51c66d1279cc.png)
