### PR TITLE
Map decoration cleanup, simplify code

### DIFF
--- a/python/core/auto_generated/qgsmapdecoration.sip.in
+++ b/python/core/auto_generated/qgsmapdecoration.sip.in
@@ -35,10 +35,20 @@ Renders a map decoration.
 %End
 
     QString name() const;
+%Docstring
+Returns the map decoration name.
+
+.. versionadded:: 3.14
+%End
 
   protected:
 
     virtual void setName( const QString &name );
+%Docstring
+Sets the map decoration ``name``.
+
+.. versionadded:: 3.14
+%End
 
 };
 

--- a/python/core/auto_generated/qgsmapdecoration.sip.in
+++ b/python/core/auto_generated/qgsmapdecoration.sip.in
@@ -34,6 +34,12 @@ Constructor for QgsMapDecoration.
 Renders a map decoration.
 %End
 
+    QString name() const;
+
+  protected:
+
+    virtual void setName( const QString &name );
+
 };
 
 /************************************************************************

--- a/src/app/decorations/qgsdecorationitem.cpp
+++ b/src/app/decorations/qgsdecorationitem.cpp
@@ -69,11 +69,11 @@ void QgsDecorationItem::saveToProject()
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginUnit" ), QgsUnitTypes::encodeUnit( mMarginUnit ) );
 }
 
-void QgsDecorationItem::setName( const char *name )
+void QgsDecorationItem::setName( const QString &name )
 {
-  mName = name;
+  QgsMapDecoration::setName( name );
+
   mNameConfig = name;
   mNameConfig.remove( ' ' );
-  mNameTranslated = tr( name );
-  QgsDebugMsgLevel( QStringLiteral( "name=%1 nameconfig=%2 nametrans=%3" ).arg( mName, mNameConfig, mNameTranslated ), 3 );
+  QgsDebugMsgLevel( QStringLiteral( "name=%1 nameconfig=%2" ).arg( name, mNameConfig ), 3 );
 }

--- a/src/app/decorations/qgsdecorationitem.h
+++ b/src/app/decorations/qgsdecorationitem.h
@@ -63,8 +63,6 @@ class APP_EXPORT QgsDecorationItem : public QObject, public QgsMapDecoration
      */
     void setPlacement( Placement placement ) { mPlacement = placement; }
 
-    QString name() const { return mName; }
-
   signals:
     void toggled( bool t );
 
@@ -82,7 +80,7 @@ class APP_EXPORT QgsDecorationItem : public QObject, public QgsMapDecoration
 
   protected:
 
-    void setName( const char *name );
+    void setName( const QString &name ) override;
 
     //! True if decoration item has to be displayed
     bool mEnabled = false;
@@ -92,9 +90,7 @@ class APP_EXPORT QgsDecorationItem : public QObject, public QgsMapDecoration
     //! Units used for the decoration placement margin
     QgsUnitTypes::RenderUnit mMarginUnit = QgsUnitTypes::RenderMillimeters;
 
-    QString mName;
     QString mNameConfig;
-    QString mNameTranslated;
 };
 
 #endif

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7524,9 +7524,9 @@ void QgisApp::updateFilterLegend()
   }
 }
 
-QList< QgsDecorationItem * > QgisApp::activeDecorationItems()
+QList< QgsMapDecoration * > QgisApp::activeDecorations()
 {
-  QList< QgsDecorationItem * > decorations;
+  QList< QgsMapDecoration * > decorations;
   const auto constMDecorationItems = mDecorationItems;
   for ( QgsDecorationItem *decoration : constMDecorationItems )
   {
@@ -7539,14 +7539,14 @@ QList< QgsDecorationItem * > QgisApp::activeDecorationItems()
 }
 void QgisApp::saveMapAsImage()
 {
-  QgsMapSaveDialog *dlg = new QgsMapSaveDialog( this, mMapCanvas, activeDecorationItems(), QgsProject::instance()->annotationManager()->annotations() );
+  QgsMapSaveDialog *dlg = new QgsMapSaveDialog( this, mMapCanvas, activeDecorations(), QgsProject::instance()->annotationManager()->annotations() );
   dlg->setAttribute( Qt::WA_DeleteOnClose );
   dlg->show();
 } // saveMapAsImage
 
 void QgisApp::saveMapAsPdf()
 {
-  QgsMapSaveDialog *dlg = new QgsMapSaveDialog( this, mMapCanvas, activeDecorationItems(), QgsProject::instance()->annotationManager()->annotations(), QgsMapSaveDialog::Pdf );
+  QgsMapSaveDialog *dlg = new QgsMapSaveDialog( this, mMapCanvas, activeDecorations(), QgsProject::instance()->annotationManager()->annotations(), QgsMapSaveDialog::Pdf );
   dlg->setAttribute( Qt::WA_DeleteOnClose );
   dlg->show();
 } // saveMapAsPdf

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -123,6 +123,7 @@ class QgsStatisticalSummaryDockWidget;
 class QgsMapCanvasTracer;
 class QgsTemporalControllerDockWidget;
 
+class QgsMapDecoration;
 class QgsDecorationItem;
 class QgsMessageLogViewer;
 class QgsMessageBar;
@@ -695,8 +696,16 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     void emitCustomCrsValidation( QgsCoordinateReferenceSystem &crs );
 
-    QList<QgsDecorationItem *> activeDecorationItems();
+    /**
+     * Returns a list of active map decorations
+     * \since QGIS 3.14
+     */
+    QList<QgsMapDecoration *> activeDecorations();
+
+    //! Returns a list of registered map decoration items
     QList<QgsDecorationItem *> decorationItems() { return mDecorationItems; }
+
+    //! A a map decoration \a item
     void addDecorationItem( QgsDecorationItem *item ) { mDecorationItems.append( item ); }
 
     //! \since QGIS 2.1

--- a/src/app/qgsanimationexportdialog.cpp
+++ b/src/app/qgsanimationexportdialog.cpp
@@ -25,7 +25,7 @@
 
 Q_GUI_EXPORT extern int qt_defaultDpiX();
 
-QgsAnimationExportDialog::QgsAnimationExportDialog( QWidget *parent, QgsMapCanvas *mapCanvas, const QList< QgsDecorationItem * > &decorations )
+QgsAnimationExportDialog::QgsAnimationExportDialog( QWidget *parent, QgsMapCanvas *mapCanvas, const QList< QgsMapDecoration * > &decorations )
   : QDialog( parent )
   , mMapCanvas( mapCanvas )
 {
@@ -47,7 +47,7 @@ QgsAnimationExportDialog::QgsAnimationExportDialog( QWidget *parent, QgsMapCanva
 
   QString activeDecorations;
   const auto constDecorations = decorations;
-  for ( QgsDecorationItem *decoration : constDecorations )
+  for ( QgsMapDecoration *decoration : constDecorations )
   {
     if ( activeDecorations.isEmpty() )
       activeDecorations = decoration->name().toLower();

--- a/src/app/qgsanimationexportdialog.h
+++ b/src/app/qgsanimationexportdialog.h
@@ -46,7 +46,7 @@ class APP_EXPORT QgsAnimationExportDialog: public QDialog, private Ui::QgsAnimat
      */
     QgsAnimationExportDialog( QWidget *parent = nullptr,
                               QgsMapCanvas *mapCanvas = nullptr,
-                              const QList< QgsDecorationItem * > &decorations = QList< QgsDecorationItem * >() );
+                              const QList< QgsMapDecoration * > &decorations = QList< QgsMapDecoration * >() );
 
     //! Returns extent rectangle
     QgsRectangle extent() const;

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -48,10 +48,11 @@
 
 Q_GUI_EXPORT extern int qt_defaultDpiX();
 
-QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, const QList<QgsDecorationItem *> &decorations, const QList< QgsAnnotation *> &annotations, DialogType type )
+QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, const QList<QgsMapDecoration *> &decorations, const QList< QgsAnnotation *> &annotations, DialogType type )
   : QDialog( parent )
   , mDialogType( type )
   , mMapCanvas( mapCanvas )
+  , mDecorations( decorations )
   , mAnnotations( annotations )
 {
   setupUi( this );
@@ -75,10 +76,9 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
   mScaleWidget->setShowCurrentScaleButton( true );
 
   QString activeDecorations;
-  const auto constDecorations = decorations;
-  for ( QgsDecorationItem *decoration : constDecorations )
+  const auto constDecorations = mDecorations;
+  for ( QgsMapDecoration *decoration : constDecorations )
   {
-    mDecorations << decoration;
     if ( activeDecorations.isEmpty() )
       activeDecorations = decoration->name().toLower();
     else

--- a/src/app/qgsmapsavedialog.h
+++ b/src/app/qgsmapsavedialog.h
@@ -52,7 +52,7 @@ class APP_EXPORT QgsMapSaveDialog: public QDialog, private Ui::QgsMapSaveDialog
      * Constructor for QgsMapSaveDialog
      */
     QgsMapSaveDialog( QWidget *parent = nullptr, QgsMapCanvas *mapCanvas = nullptr,
-                      const QList< QgsDecorationItem * > &decorations = QList< QgsDecorationItem * >(),
+                      const QList< QgsMapDecoration * > &decorations = QList< QgsMapDecoration * >(),
                       const QList<QgsAnnotation *> &annotations = QList< QgsAnnotation * >(),
                       DialogType type = Image );
 

--- a/src/app/qgstemporalcontrollerdockwidget.cpp
+++ b/src/app/qgstemporalcontrollerdockwidget.cpp
@@ -53,7 +53,7 @@ QgsTemporalController *QgsTemporalControllerDockWidget::temporalController()
 
 void QgsTemporalControllerDockWidget::exportAnimation()
 {
-  QgsAnimationExportDialog *dlg = new QgsAnimationExportDialog( this, QgisApp::instance()->mapCanvas(), QgisApp::instance()->activeDecorationItems() );
+  QgsAnimationExportDialog *dlg = new QgsAnimationExportDialog( this, QgisApp::instance()->mapCanvas(), QgisApp::instance()->activeDecorations() );
   connect( dlg, &QgsAnimationExportDialog::startExport, this, [ = ]
   {
     QgsMapSettings s = QgisApp::instance()->mapCanvas()->mapSettings();
@@ -86,13 +86,7 @@ void QgsTemporalControllerDockWidget::exportAnimation()
 
     QList<QgsMapDecoration *> decorations;
     if ( dlg->drawDecorations() )
-    {
-      const QList<QgsDecorationItem *> decorationItems = QgisApp::instance()->activeDecorationItems();
-      for ( QgsMapDecoration *decoration : decorationItems )
-      {
-        decorations << decoration;
-      }
-    }
+      decorations = QgisApp::instance()->activeDecorations();
 
     QgsTemporalUtils::AnimationExportSettings animationSettings;
     animationSettings.frameDuration = frameDuration;

--- a/src/core/qgsmapdecoration.h
+++ b/src/core/qgsmapdecoration.h
@@ -46,6 +46,16 @@ class CORE_EXPORT QgsMapDecoration
      */
     virtual void render( const QgsMapSettings &mapSettings, QgsRenderContext &context ) = 0;
 
+    QString name() const { return mName; }
+
+  protected:
+
+    virtual void setName( const QString &name ) { mName = name; }
+
+  private:
+
+    QString mName;
+
 };
 
 #endif //QGSMAPDECORATION_H

--- a/src/core/qgsmapdecoration.h
+++ b/src/core/qgsmapdecoration.h
@@ -46,10 +46,18 @@ class CORE_EXPORT QgsMapDecoration
      */
     virtual void render( const QgsMapSettings &mapSettings, QgsRenderContext &context ) = 0;
 
+    /**
+     * Returns the map decoration name.
+     * \since QGIS 3.14
+     */
     QString name() const { return mName; }
 
   protected:
 
+    /**
+     * Sets the map decoration \a name.
+     * \since QGIS 3.14
+     */
     virtual void setName( const QString &name ) { mName = name; }
 
   private:


### PR DESCRIPTION
## Description

@nyalldawson , small map decoration cleanup. Moving the name() function away from QgsDecorationItem into QgsMapDecoration allows us to avoid passing on a list of QgsDecorationItem (src/app) and maintain a parallel list of QgsMapDecoration (src/core).

I've also removed the mTranslatedName stuff since it's not used anywhere, and drop `const char *` in favor of `const QString &`.