### PR TITLE
Fix crash when masking widget is not initialized

### DIFF
--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -615,7 +615,8 @@ void QgsVectorLayerProperties::apply()
   mMetadataFilled = false;
 
   // save masking settings
-  mMaskingWidget->apply();
+  if ( mMaskingWidget )
+    mMaskingWidget->apply();
 
   //
   // Set up sql subset query if applicable


### PR DESCRIPTION
## Description

Follows #36366

There is no masking widget for non spatial data.