### PR TITLE
[Expression] Do not transform NULL integer as 0 when concat

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1923,7 +1923,8 @@ static QVariant fcnConcat( const QVariantList &values, const QgsExpressionContex
   QString concat;
   for ( const QVariant &value : values )
   {
-    concat += QgsExpressionUtils::getStringValue( value, parent );
+    if ( !value.isNull() )
+      concat += QgsExpressionUtils::getStringValue( value, parent );
   }
   return concat;
 }

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -3893,7 +3893,7 @@ class TestQgsExpression: public QObject
 
     void testConcatNULLAttributeValue()
     {
-      // Test that null integer values comming from provider are not transformed as 0
+      // Test that null integer values coming from provider are not transformed as 0
       // https://github.com/qgis/QGIS/issues/36112
 
       QgsFields fields;
@@ -3904,11 +3904,16 @@ class TestQgsExpression: public QObject
       f.setAttribute( 0, QVariant( QVariant::Int ) );
 
       QgsExpressionContext context = QgsExpressionContextUtils::createFeatureBasedContext( f, fields );
-
       QgsExpression exp( QStringLiteral( "concat('test', foo)" ) );
       QVariant res = exp.evaluate( &context );
       QCOMPARE( res.type(), QVariant::String );
-      QCOMPARE( res.toString(), "test" );
+      QCOMPARE( res.toString(), QStringLiteral( "test" ) );
+
+      f.setAttribute( 0, QVariant() );
+      context = QgsExpressionContextUtils::createFeatureBasedContext( f, fields );
+      res = exp.evaluate( &context );
+      QCOMPARE( res.type(), QVariant::String );
+      QCOMPARE( res.toString(), QStringLiteral( "test" ) );
     }
 
 };

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -3891,6 +3891,26 @@ class TestQgsExpression: public QObject
       QCOMPARE( QgsExpression::replaceExpressionText( input, &context ), expected );
     }
 
+    void testConcatNULLAttributeValue()
+    {
+      // Test that null integer values comming from provider are not transformed as 0
+      // https://github.com/qgis/QGIS/issues/36112
+
+      QgsFields fields;
+      fields.append( QgsField( QStringLiteral( "foo" ), QVariant::Int ) );
+
+      QgsFeature f;
+      f.initAttributes( 1 );
+      f.setAttribute( 0, QVariant( QVariant::Int ) );
+
+      QgsExpressionContext context = QgsExpressionContextUtils::createFeatureBasedContext( f, fields );
+
+      QgsExpression exp( QStringLiteral( "concat('test', foo)" ) );
+      QVariant res = exp.evaluate( &context );
+      QCOMPARE( res.type(), QVariant::String );
+      QCOMPARE( res.toString(), "test" );
+    }
+
 };
 
 QGSTEST_MAIN( TestQgsExpression )


### PR DESCRIPTION
## Description

Fixes #36112

Providers returns QVariant ( QVariant::Int ) for null integer, which converts to "0" as a string. This PR proposes to not concat null values. 

The issue doesn't occured for OGR data (GPKG for instance) because this provider [returns a null QString](https://github.com/qgis/QGIS/blob/master/src/core/qgsogrutils.cpp#L318) for any null values while others provider don't ([spatialite](https://github.com/qgis/QGIS/blob/master/src/providers/spatialite/qgsspatialitefeatureiterator.cpp#L609), [postgres](https://github.com/qgis/QGIS/blob/master/src/providers/postgres/qgspostgresprovider.cpp#L4679), [delimitedtext](https://github.com/qgis/QGIS/blob/master/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp#L476))