### PR TITLE
Sensible default field precision for new fields

### DIFF
--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -50,15 +50,6 @@ QgsNewSpatialiteLayerDialog::QgsNewSpatialiteLayerDialog( QWidget *parent, Qt::W
   setupUi( this );
   QgsGui::enableAutoGeometryRestore( this );
 
-  connect( mAddAttributeButton, &QToolButton::clicked, this, &QgsNewSpatialiteLayerDialog::mAddAttributeButton_clicked );
-  connect( mRemoveAttributeButton, &QToolButton::clicked, this, &QgsNewSpatialiteLayerDialog::mRemoveAttributeButton_clicked );
-  connect( mGeometryTypeBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsNewSpatialiteLayerDialog::mGeometryTypeBox_currentIndexChanged );
-  connect( mTypeBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsNewSpatialiteLayerDialog::mTypeBox_currentIndexChanged );
-  connect( pbnFindSRID, &QPushButton::clicked, this, &QgsNewSpatialiteLayerDialog::pbnFindSRID_clicked );
-  connect( toolButtonNewDatabase, &QToolButton::clicked, this, &QgsNewSpatialiteLayerDialog::createDb );
-  connect( buttonBox, &QDialogButtonBox::accepted, this, &QgsNewSpatialiteLayerDialog::buttonBox_accepted );
-  connect( buttonBox, &QDialogButtonBox::rejected, this, &QgsNewSpatialiteLayerDialog::buttonBox_rejected );
-
   mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconTableLayer.svg" ) ), tr( "No geometry" ), QString() );
   mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPointLayer.svg" ) ), tr( "Point" ), QStringLiteral( "POINT" ) );
   mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconLineLayer.svg" ) ), tr( "Line" ), QStringLiteral( "LINESTRING" ) );
@@ -66,6 +57,7 @@ QgsNewSpatialiteLayerDialog::QgsNewSpatialiteLayerDialog( QWidget *parent, Qt::W
   mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPointLayer.svg" ) ), tr( "MultiPoint" ), QStringLiteral( "MULTIPOINT" ) );
   mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconLineLayer.svg" ) ), tr( "MultiLine" ), QStringLiteral( "MULTILINESTRING" ) );
   mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPolygonLayer.svg" ) ), tr( "MultiPolygon" ), QStringLiteral( "MULTIPOLYGON" ) );
+  mGeometryTypeBox->setCurrentIndex( -1 );
 
   pbnFindSRID->setEnabled( false );
   mGeometryWithZCheckBox->setEnabled( false );
@@ -94,12 +86,19 @@ QgsNewSpatialiteLayerDialog::QgsNewSpatialiteLayerDialog( QWidget *parent, Qt::W
   connect( mAttributeView, &QTreeWidget::itemSelectionChanged, this, &QgsNewSpatialiteLayerDialog::selectionChanged );
   connect( leLayerName, &QLineEdit::textChanged, this, &QgsNewSpatialiteLayerDialog::checkOk );
   connect( checkBoxPrimaryKey, &QAbstractButton::clicked, this, &QgsNewSpatialiteLayerDialog::checkOk );
+  connect( mAddAttributeButton, &QToolButton::clicked, this, &QgsNewSpatialiteLayerDialog::mAddAttributeButton_clicked );
+  connect( mRemoveAttributeButton, &QToolButton::clicked, this, &QgsNewSpatialiteLayerDialog::mRemoveAttributeButton_clicked );
+  connect( mGeometryTypeBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsNewSpatialiteLayerDialog::mGeometryTypeBox_currentIndexChanged );
+  connect( mTypeBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsNewSpatialiteLayerDialog::mTypeBox_currentIndexChanged );
+  connect( pbnFindSRID, &QPushButton::clicked, this, &QgsNewSpatialiteLayerDialog::pbnFindSRID_clicked );
+  connect( toolButtonNewDatabase, &QToolButton::clicked, this, &QgsNewSpatialiteLayerDialog::createDb );
+  connect( buttonBox, &QDialogButtonBox::accepted, this, &QgsNewSpatialiteLayerDialog::buttonBox_accepted );
+  connect( buttonBox, &QDialogButtonBox::rejected, this, &QgsNewSpatialiteLayerDialog::buttonBox_rejected );
 
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsNewSpatialiteLayerDialog::showHelp );
 
   mAddAttributeButton->setEnabled( false );
   mRemoveAttributeButton->setEnabled( false );
-
 }
 
 void QgsNewSpatialiteLayerDialog::mGeometryTypeBox_currentIndexChanged( int index )
@@ -108,6 +107,8 @@ void QgsNewSpatialiteLayerDialog::mGeometryTypeBox_currentIndexChanged( int inde
   mGeometryWithZCheckBox->setEnabled( index != 0 );
   mGeometryWithMCheckBox->setEnabled( index != 0 );
   leGeometryColumn->setEnabled( index != 0 );
+
+  checkOk();
 }
 
 void QgsNewSpatialiteLayerDialog::mTypeBox_currentIndexChanged( int index )
@@ -148,7 +149,7 @@ QString QgsNewSpatialiteLayerDialog::selectedZM() const
 
 void QgsNewSpatialiteLayerDialog::checkOk()
 {
-  bool created  = !leLayerName->text().isEmpty() &&
+  bool created  = !leLayerName->text().isEmpty() && mGeometryTypeBox->currentIndex() != -1 &&
                   ( checkBoxPrimaryKey->isChecked() || mAttributeView->topLevelItemCount() > 0 );
   mOkButton->setEnabled( created );
 }

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -90,7 +90,6 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
   connect( mAddAttributeButton, &QToolButton::clicked, this, &QgsNewMemoryLayerDialog::mAddAttributeButton_clicked );
   connect( mRemoveAttributeButton, &QToolButton::clicked, this, &QgsNewMemoryLayerDialog::mRemoveAttributeButton_clicked );
   connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsNewMemoryLayerDialog::showHelp );
-  //geometryTypeChanged( mGeometryTypeBox->currentIndex() );
 }
 
 QgsWkbTypes::Type QgsNewMemoryLayerDialog::selectedType() const

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -77,15 +77,21 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
   mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDate.svg" ) ), tr( "Date" ), "date" );
   mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldTime.svg" ) ), tr( "Time" ), "time" );
   mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDateTime.svg" ) ), tr( "Date & time" ), "datetime" );
+  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldBinary.svg" ) ), tr( "Binary (BLOB)" ), "binary" );
+  mTypeBox_currentIndexChanged( 1 );
 
   mWidth->setValidator( new QIntValidator( 1, 255, this ) );
-  mPrecision->setValidator( new QIntValidator( 0, 15, this ) );
+  mPrecision->setValidator( new QIntValidator( 0, 30, this ) );
+
+  mAddAttributeButton->setEnabled( false );
+  mRemoveAttributeButton->setEnabled( false );
 
   mOkButton = mButtonBox->button( QDialogButtonBox::Ok );
   mOkButton->setEnabled( false );
 
   connect( mGeometryTypeBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsNewMemoryLayerDialog::geometryTypeChanged );
   connect( mFieldNameEdit, &QLineEdit::textChanged, this, &QgsNewMemoryLayerDialog::fieldNameChanged );
+  connect( mTypeBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsNewMemoryLayerDialog::mTypeBox_currentIndexChanged );
   connect( mAttributeView, &QTreeWidget::itemSelectionChanged, this, &QgsNewMemoryLayerDialog::selectionChanged );
   connect( mAddAttributeButton, &QToolButton::clicked, this, &QgsNewMemoryLayerDialog::mAddAttributeButton_clicked );
   connect( mRemoveAttributeButton, &QToolButton::clicked, this, &QgsNewMemoryLayerDialog::mRemoveAttributeButton_clicked );
@@ -121,6 +127,69 @@ void QgsNewMemoryLayerDialog::geometryTypeChanged( int )
 
   bool ok = ( !mNameLineEdit->text().isEmpty() && mGeometryTypeBox->currentIndex() != -1 );
   mOkButton->setEnabled( ok );
+}
+
+void QgsNewMemoryLayerDialog::mTypeBox_currentIndexChanged( int index )
+{
+  switch ( index )
+  {
+    case 0: // Text data
+      if ( mWidth->text().toInt() < 1 || mWidth->text().toInt() > 255 )
+        mWidth->setText( QStringLiteral( "255" ) );
+      mPrecision->clear();
+      mPrecision->setEnabled( false );
+      mWidth->setValidator( new QIntValidator( 1, 255, this ) );
+      break;
+    case 1: // Whole number
+      if ( mWidth->text().toInt() < 1 || mWidth->text().toInt() > 10 )
+        mWidth->setText( QStringLiteral( "10" ) );
+      mPrecision->clear();
+      mPrecision->setEnabled( false );
+      mWidth->setValidator( new QIntValidator( 1, 10, this ) );
+      break;
+    case 2: // Decimal number
+      if ( mWidth->text().toInt() < 1 || mWidth->text().toInt() > 30 )
+        mWidth->setText( QStringLiteral( "30" ) );
+      if ( mPrecision->text().toInt() < 1 || mPrecision->text().toInt() > 30 )
+        mPrecision->setText( QStringLiteral( "6" ) );
+      mPrecision->setEnabled( true );
+      mWidth->setValidator( new QIntValidator( 1, 20, this ) );
+      break;
+    case 3: // Boolean
+      mWidth->clear();
+      mWidth->setEnabled( false );
+      mPrecision->clear();
+      mPrecision->setEnabled( false );
+      break;
+    case 4: // Date
+      mWidth->clear();
+      mWidth->setEnabled( false );
+      mPrecision->clear();
+      mPrecision->setEnabled( false );
+      break;
+    case 5: // Time
+      mWidth->clear();
+      mWidth->setEnabled( false );
+      mPrecision->clear();
+      mPrecision->setEnabled( false );
+      break;
+    case 6: // Datetime
+      mWidth->clear();
+      mWidth->setEnabled( false );
+      mPrecision->clear();
+      mPrecision->setEnabled( false );
+      break;
+    case 7: // Binary
+      mWidth->clear();
+      mWidth->setEnabled( false );
+      mPrecision->clear();
+      mPrecision->setEnabled( false );
+      break;
+
+    default:
+      QgsDebugMsg( QStringLiteral( "unexpected index" ) );
+      break;
+  }
 }
 
 void QgsNewMemoryLayerDialog::setCrs( const QgsCoordinateReferenceSystem &crs )

--- a/src/gui/qgsnewmemorylayerdialog.h
+++ b/src/gui/qgsnewmemorylayerdialog.h
@@ -83,6 +83,7 @@ class GUI_EXPORT QgsNewMemoryLayerDialog: public QDialog, private Ui::QgsNewMemo
 
     void geometryTypeChanged( int index );
     void fieldNameChanged( const QString & );
+    void mTypeBox_currentIndexChanged( int index );
     void mAddAttributeButton_clicked();
     void mRemoveAttributeButton_clicked();
     void selectionChanged();

--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -168,7 +168,7 @@ void QgsNewVectorLayerDialog::mTypeBox_currentIndexChanged( int index )
       if ( mWidth->text().toInt() < 1 || mWidth->text().toInt() > 20 )
         mWidth->setText( QStringLiteral( "20" ) );
       if ( mPrecision->text().toInt() < 1 || mPrecision->text().toInt() > 15 )
-        mPrecision->setText( QStringLiteral( "6" ) )
+        mPrecision->setText( QStringLiteral( "6" ) );
 
       mPrecision->setEnabled( true );
       mWidth->setValidator( new QIntValidator( 1, 20, this ) );

--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -167,6 +167,9 @@ void QgsNewVectorLayerDialog::mTypeBox_currentIndexChanged( int index )
     case 2: // Decimal number
       if ( mWidth->text().toInt() < 1 || mWidth->text().toInt() > 20 )
         mWidth->setText( QStringLiteral( "20" ) );
+      if ( mPrecision->text().toInt() < 1 || mPrecision->text().toInt() > 15 )
+        mPrecision->setText( QStringLiteral( "6" ) )
+
       mPrecision->setEnabled( true );
       mWidth->setValidator( new QIntValidator( 1, 20, this ) );
       break;


### PR DESCRIPTION
## Description

Couple of UX fixes related to fields length and precision:
- don't pre-select default geometry type in the new SpatiaLite dialog (consistent with other new layer dialogs)
- field length and precision validators in the New Memory Layer dialog now respect native provider types
- sensible default field precision in the Add Field dialog (same as in Field Calculator, fixes #16581)
