### PR TITLE
Fix QgsGeometry::closestVertex() to return empty point

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -556,7 +556,7 @@ and the indices of the vertices before and after the closest vertex.
                     not present.
 :param sqrDist: will be set to the square distance between the closest vertex and the specified point
 
-:return: - closest point in geometry. If not found (empty geometry), returns null point nad sqrDist is negative.
+:return: - closest point in geometry. If not found (empty geometry), returns null point and sqrDist is negative.
          - atVertex: will be set to the vertex index of the closest found vertex
 %End
 
@@ -669,7 +669,7 @@ Returns coordinates of a vertex.
 
 :param atVertex: index of the vertex
 
-:return: Coordinates of the vertex or QgsPoint(0,0) on error
+:return: Coordinates of the vertex or empty :py:class:`QgsPoint`() on error
 %End
 
     double sqrDistToVertexAt( QgsPointXY &point /In/, int atVertex ) const;

--- a/python/core/auto_generated/geometry/qgstriangle.sip.in
+++ b/python/core/auto_generated/geometry/qgstriangle.sip.in
@@ -107,7 +107,7 @@ Returns coordinates of a vertex.
 
 :param atVertex: index of the vertex
 
-:return: Coordinates of the vertex or QgsPoint(0,0) on error (``atVertex`` < 0 or > 3).
+:return: Coordinates of the vertex or empty :py:class:`QgsPoint`() on error (``atVertex`` < 0 or > 3).
 %End
 
     QVector<double> lengths() const;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -388,7 +388,7 @@ QgsPointXY QgsGeometry::closestVertex( const QgsPointXY &point, int &atVertex, i
     return QgsPointXY();
   }
 
-  QgsPoint pt( point.x(), point.y() );
+  QgsPoint pt( point );
   QgsVertexId id;
 
   QgsPoint vp = QgsGeometryUtils::closestVertex( *( d->geometry ), pt, id );
@@ -630,7 +630,7 @@ double QgsGeometry::closestVertexWithContext( const QgsPointXY &point, int &atVe
   }
 
   QgsVertexId vId;
-  QgsPoint pt( point.x(), point.y() );
+  QgsPoint pt( point );
   QgsPoint closestPoint = QgsGeometryUtils::closestVertex( *( d->geometry ), pt, vId );
   if ( !vId.isValid() )
     return -1;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -385,7 +385,7 @@ QgsPointXY QgsGeometry::closestVertex( const QgsPointXY &point, int &atVertex, i
   if ( !d->geometry )
   {
     sqrDist = -1;
-    return QgsPointXY( 0, 0 );
+    return QgsPointXY();
   }
 
   QgsPoint pt( point.x(), point.y() );
@@ -395,7 +395,7 @@ QgsPointXY QgsGeometry::closestVertex( const QgsPointXY &point, int &atVertex, i
   if ( !id.isValid() )
   {
     sqrDist = -1;
-    return QgsPointXY( 0, 0 );
+    return QgsPointXY();
   }
   sqrDist = QgsGeometryUtils::sqrDistance2D( pt, vp );
 

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -632,7 +632,7 @@ class CORE_EXPORT QgsGeometry
      * \param afterVertex will be set to the vertex index of the next vertex after the closest one. Will be set to -1 if
      * not present.
      * \param sqrDist will be set to the square distance between the closest vertex and the specified point
-     * \returns closest point in geometry. If not found (empty geometry), returns null point nad sqrDist is negative.
+     * \returns closest point in geometry. If not found (empty geometry), returns null point and sqrDist is negative.
      */
     QgsPointXY closestVertex( const QgsPointXY &point, int &atVertex SIP_OUT, int &beforeVertex SIP_OUT, int &afterVertex SIP_OUT, double &sqrDist SIP_OUT ) const;
 
@@ -731,7 +731,7 @@ class CORE_EXPORT QgsGeometry
     /**
      * Returns coordinates of a vertex.
      * \param atVertex index of the vertex
-     * \returns Coordinates of the vertex or QgsPoint(0,0) on error
+     * \returns Coordinates of the vertex or empty QgsPoint() on error
      */
     QgsPoint vertexAt( int atVertex ) const;
 
@@ -1630,7 +1630,7 @@ class CORE_EXPORT QgsGeometry
      *
      * Any z or m values present in the geometry will be discarded.
      *
-     * \warning If the geometry is not a single-point type, a QgsPoint( 0, 0 ) will be returned.
+     * \warning If the geometry is not a single-point type, an empty QgsPointXY() will be returned.
      */
     QgsPointXY asPoint() const;
 #else

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -71,6 +71,9 @@ QgsPoint QgsGeometryUtils::closestVertex( const QgsAbstractGeometry &geom, const
   QgsPoint minDistPoint;
   id = QgsVertexId(); // set as invalid
 
+  if ( geom.isEmpty() || pt.isEmpty() )
+    return minDistPoint;
+
   QgsVertexId vertexId;
   QgsPoint vertex;
   while ( geom.nextVertex( vertexId, vertex ) )

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -67,6 +67,11 @@ QgsPoint::QgsPoint( const QgsPointXY &p )
   , mM( std::numeric_limits<double>::quiet_NaN() )
 {
   mWkbType = QgsWkbTypes::Point;
+  if ( p.isEmpty() )
+  {
+    mX = std::numeric_limits<double>::quiet_NaN();
+    mY = std::numeric_limits<double>::quiet_NaN();
+  }
 }
 
 QgsPoint::QgsPoint( QPointF p )

--- a/src/core/geometry/qgstriangle.h
+++ b/src/core/geometry/qgstriangle.h
@@ -101,7 +101,7 @@ class CORE_EXPORT QgsTriangle : public QgsPolygon
     /**
      *  Returns coordinates of a vertex.
      *  \param atVertex index of the vertex
-     *  \returns Coordinates of the vertex or QgsPoint(0,0) on error (\a atVertex < 0 or > 3).
+     *  \returns Coordinates of the vertex or empty QgsPoint() on error (\a atVertex < 0 or > 3).
      */
     QgsPoint vertexAt( int atVertex ) const;
 

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -1193,6 +1193,9 @@ class TestQgsGeometry(unittest.TestCase):
         assert abs(dist - exp) < 0.00001, "Expected: %f; Got:%f" % (exp, dist)
         self.assertEqual(leftOf, -1)
 
+        (point, atVertex, beforeVertex, afterVertex, dist) = QgsGeometry().closestVertex(QgsPointXY(42, 42))
+        self.assertTrue(point.isEmpty())
+
     def testAdjacentVertex(self):
         # 2-+-+-+-+-3
         # |         |

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -1193,6 +1193,10 @@ class TestQgsGeometry(unittest.TestCase):
         assert abs(dist - exp) < 0.00001, "Expected: %f; Got:%f" % (exp, dist)
         self.assertEqual(leftOf, -1)
 
+        (point, atVertex, beforeVertex, afterVertex, dist) = polygon.closestVertex(QgsPointXY())
+        self.assertTrue(point.isEmpty())
+        self.assertEqual(dist, -1)
+
         (point, atVertex, beforeVertex, afterVertex, dist) = QgsGeometry().closestVertex(QgsPointXY(42, 42))
         self.assertTrue(point.isEmpty())
 

--- a/tests/src/python/test_qgspoint.py
+++ b/tests/src/python/test_qgspoint.py
@@ -86,6 +86,10 @@ class TestQgsPointXY(unittest.TestCase):
         p = QgsPoint(1, 2, m=4, z=3)
         assert p.wkbType() == QgsWkbTypes.PointZM and p.x() == 1 and p.y() == 2 and p.z() == 3 and p.m() == 4
 
+    def test_empty_QgsPointXY(self):
+        p = QgsPoint(QgsPointXY())
+        assert p.isEmpty()
+
 
 class TestQgsPoint(unittest.TestCase):
 


### PR DESCRIPTION
## Description
`QgsGeometry::closestVertex()` returns `QgsPointXY( 0, 0 )` instead of an empty point when there is no closest vertex. This was probably a leftover from before the introduction of `QgsPointXY::isEmpty`.
Also fixed a couple of docstrings with the same issue.

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
