### PR TITLE
Correctly store temporal settings in QML files and copy when duplicating layers

### DIFF
--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -96,6 +96,7 @@ This is the base class for all map layer types (vector, raster).
       CustomProperties,
       GeometryOptions,
       Relations,
+      Temporal,
       AllStyleCategories
     };
     typedef QFlags<QgsMapLayer::StyleCategory> StyleCategories;

--- a/python/gui/auto_generated/qgsvectorlayertemporalpropertieswidget.sip.in
+++ b/python/gui/auto_generated/qgsvectorlayertemporalpropertieswidget.sip.in
@@ -36,6 +36,11 @@ Save widget temporal properties inputs.
     virtual QgsExpressionContext createExpressionContext() const;
 
 
+    void syncToLayer();
+%Docstring
+Updates the widget state to match the current layer state.
+%End
+
 };
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/gui/auto_generated/raster/qgsrasterlayertemporalpropertieswidget.sip.in
+++ b/python/gui/auto_generated/raster/qgsrasterlayertemporalpropertieswidget.sip.in
@@ -34,6 +34,11 @@ Constructor for QgsRasterLayerTemporalPropertiesWidget.
 Save widget temporal properties inputs.
 %End
 
+    void syncToLayer();
+%Docstring
+Updates the widget state to match the current layer state.
+%End
+
 };
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -1033,8 +1033,6 @@ bool QgsMeshLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &con
   QString errorMsg;
   readSymbology( layer_node, errorMsg, context );
 
-  // read temporal
-  temporalProperties()->readXml( layer_node.toElement(), context );
   if ( !mTemporalProperties->timeExtent().begin().isValid() )
     temporalProperties()->setDefaultsFromDataProviderTemporalCapabilities( dataProvider()->temporalCapabilities() );
 
@@ -1089,8 +1087,6 @@ bool QgsMeshLayer::writeXml( QDomNode &layer_node, QDomDocument &document, const
     }
     layer_node.appendChild( elemExtraDatasets );
   }
-  // write temporal
-  mTemporalProperties->writeXml( mapLayerNode, document, context );
 
   QDomElement elemStaticDataset = document.createElement( QStringLiteral( "static-active-dataset" ) );
   if ( mStaticScalarDatasetIndex.isValid() )

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -53,6 +53,7 @@
 #include "qgsvectordataprovider.h"
 #include "qgsxmlutils.h"
 #include "qgsstringutils.h"
+#include "qgsmaplayertemporalproperties.h"
 
 QString QgsMapLayer::extensionPropertyType( QgsMapLayer::PropertyType type )
 {
@@ -577,6 +578,11 @@ void QgsMapLayer::writeCommonStyle( QDomElement &layerElement, QDomDocument &doc
       layerFlagsElem.appendChild( flagElem );
     }
     layerElement.appendChild( layerFlagsElem );
+  }
+
+  if ( categories.testFlag( Temporal ) && const_cast< QgsMapLayer * >( this )->temporalProperties() )
+  {
+    const_cast< QgsMapLayer * >( this )->temporalProperties()->writeXml( layerElement, document, context );
   }
 
   // custom properties
@@ -1671,6 +1677,11 @@ void QgsMapLayer::readCommonStyle( const QDomElement &layerElement, const QgsRea
         flags |= it.key();
     }
     setFlags( flags );
+  }
+
+  if ( categories.testFlag( Temporal ) && temporalProperties() )
+  {
+    temporalProperties()->readXml( layerElement.toElement(), context );
   }
 }
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -167,8 +167,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
       CustomProperties   = 1 << 11, //!< Custom properties (by plugins for instance)
       GeometryOptions    = 1 << 12, //!< Geometry validation configuration
       Relations          = 1 << 13, //!< Relations
+      Temporal           = 1 << 14, //!< Temporal properties
       AllStyleCategories = LayerConfiguration | Symbology | Symbology3D | Labeling | Fields | Forms | Actions |
-                           MapTips | Diagrams | AttributeTable | Rendering | CustomProperties | GeometryOptions | Relations,
+                           MapTips | Diagrams | AttributeTable | Rendering | CustomProperties | GeometryOptions | Relations | Temporal,
     };
     Q_ENUM( StyleCategory )
     Q_DECLARE_FLAGS( StyleCategories, StyleCategory )

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1561,8 +1561,6 @@ bool QgsVectorLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
     return false;
   }
 
-  mTemporalProperties->readXml( layer_node.toElement(), context );
-
   readStyleManager( layer_node );
 
   QDomNode depsNode = layer_node.namedItem( QStringLiteral( "dataDependencies" ) );
@@ -1876,9 +1874,6 @@ bool QgsVectorLayer::writeXml( QDomNode &layer_node,
 
   // save expression fields
   mExpressionFieldBuffer->writeXml( layer_node, document );
-
-  // write temporal properties
-  mTemporalProperties->writeXml( mapLayerNode, document, context );
 
   writeStyleManager( layer_node, document );
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -1965,8 +1965,6 @@ bool QgsRasterLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
     }
   }
 
-  mTemporalProperties->readXml( layer_node.toElement(), context );
-
   readStyleManager( layer_node );
 
   return res;
@@ -2068,9 +2066,6 @@ bool QgsRasterLayer::writeXml( QDomNode &layer_node,
   {
     layer_node.appendChild( noData );
   }
-
-  // write temporal properties
-  mTemporalProperties->writeXml( mapLayerNode, document, context );
 
   writeStyleManager( layer_node, document );
 

--- a/src/gui/qgsmaplayerstylecategoriesmodel.cpp
+++ b/src/gui/qgsmaplayerstylecategoriesmodel.cpp
@@ -231,6 +231,19 @@ QVariant QgsMapLayerStyleCategoriesModel::data( const QModelIndex &index, int ro
           return QgsApplication::getThemeIcon( QStringLiteral( "/propertyicons/relations.svg" ) );
       }
       break;
+
+    case QgsMapLayer::StyleCategory::Temporal:
+      switch ( role )
+      {
+        case Qt::DisplayRole:
+          return tr( "Temporal Properties" );
+        case Qt::ToolTipRole:
+          return tr( "Temporal properties" );
+        case Qt::DecorationRole:
+          return QgsApplication::getThemeIcon( QStringLiteral( "/propertyicons/temporal.svg" ) );
+      }
+      break;
+
     case QgsMapLayer::StyleCategory::AllStyleCategories:
       switch ( role )
       {

--- a/src/gui/qgsvectorlayertemporalpropertieswidget.h
+++ b/src/gui/qgsvectorlayertemporalpropertieswidget.h
@@ -48,6 +48,11 @@ class GUI_EXPORT QgsVectorLayerTemporalPropertiesWidget : public QWidget, public
 
     QgsExpressionContext createExpressionContext() const override;
 
+    /**
+     * Updates the widget state to match the current layer state.
+     */
+    void syncToLayer();
+
   private:
 
     /**

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -938,18 +938,11 @@ void QgsRasterLayerProperties::sync()
   QVariant wmsBackgroundLayer = mRasterLayer->customProperty( QStringLiteral( "WMSBackgroundLayer" ), false );
   mBackgroundLayerCheckBox->setChecked( wmsBackgroundLayer.toBool() );
 
-  /*
-   * Legend Tab
-   */
   mLegendConfigEmbeddedWidget->setLayer( mRasterLayer );
 
-} // QgsRasterLayerProperties::sync()
+  mTemporalWidget->syncToLayer();
+}
 
-/*
- *
- * PUBLIC AND PRIVATE SLOTS
- *
- */
 void QgsRasterLayerProperties::apply()
 {
 

--- a/src/gui/raster/qgsrasterlayertemporalpropertieswidget.cpp
+++ b/src/gui/raster/qgsrasterlayertemporalpropertieswidget.cpp
@@ -31,28 +31,9 @@ QgsRasterLayerTemporalPropertiesWidget::QgsRasterLayerTemporalPropertiesWidget( 
   setupUi( this );
 
   connect( mModeFixedRangeRadio, &QRadioButton::toggled, mFixedTimeRangeFrame, &QWidget::setEnabled );
-  init();
-}
 
-void QgsRasterLayerTemporalPropertiesWidget::init()
-{
   mStartTemporalDateTimeEdit->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
-
   mEndTemporalDateTimeEdit->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
-
-  const QgsRasterLayerTemporalProperties *temporalProperties = qobject_cast< const QgsRasterLayerTemporalProperties * >( mLayer->temporalProperties() );
-  switch ( temporalProperties->mode() )
-  {
-    case QgsRasterLayerTemporalProperties::ModeTemporalRangeFromDataProvider:
-      mModeAutomaticRadio->setChecked( true );
-      break;
-    case QgsRasterLayerTemporalProperties::ModeFixedTemporalRange:
-      mModeFixedRangeRadio->setChecked( true );
-      break;
-  }
-
-  mStartTemporalDateTimeEdit->setDateTime( temporalProperties->fixedTemporalRange().begin() );
-  mEndTemporalDateTimeEdit->setDateTime( temporalProperties->fixedTemporalRange().end() );
 
   if ( !mLayer->dataProvider() || !mLayer->dataProvider()->temporalCapabilities()->hasTemporalCapabilities() )
   {
@@ -61,7 +42,7 @@ void QgsRasterLayerTemporalPropertiesWidget::init()
     mModeFixedRangeRadio->setChecked( true );
   }
 
-  mTemporalGroupBox->setChecked( temporalProperties->isActive() );
+  syncToLayer();
 }
 
 void QgsRasterLayerTemporalPropertiesWidget::saveTemporalProperties()
@@ -78,4 +59,23 @@ void QgsRasterLayerTemporalPropertiesWidget::saveTemporalProperties()
   else if ( mModeFixedRangeRadio->isChecked() )
     temporalProperties->setMode( QgsRasterLayerTemporalProperties::ModeFixedTemporalRange );
   temporalProperties->setFixedTemporalRange( normalRange );
+}
+
+void QgsRasterLayerTemporalPropertiesWidget::syncToLayer()
+{
+  const QgsRasterLayerTemporalProperties *temporalProperties = qobject_cast< const QgsRasterLayerTemporalProperties * >( mLayer->temporalProperties() );
+  switch ( temporalProperties->mode() )
+  {
+    case QgsRasterLayerTemporalProperties::ModeTemporalRangeFromDataProvider:
+      mModeAutomaticRadio->setChecked( true );
+      break;
+    case QgsRasterLayerTemporalProperties::ModeFixedTemporalRange:
+      mModeFixedRangeRadio->setChecked( true );
+      break;
+  }
+
+  mStartTemporalDateTimeEdit->setDateTime( temporalProperties->fixedTemporalRange().begin() );
+  mEndTemporalDateTimeEdit->setDateTime( temporalProperties->fixedTemporalRange().end() );
+
+  mTemporalGroupBox->setChecked( temporalProperties->isActive() );
 }

--- a/src/gui/raster/qgsrasterlayertemporalpropertieswidget.h
+++ b/src/gui/raster/qgsrasterlayertemporalpropertieswidget.h
@@ -46,12 +46,12 @@ class GUI_EXPORT QgsRasterLayerTemporalPropertiesWidget : public QWidget, privat
      */
     void saveTemporalProperties();
 
-  private:
-
     /**
-     * Initialize the widget with default state.
+     * Updates the widget state to match the current layer state.
      */
-    void init();
+    void syncToLayer();
+
+  private:
 
     /**
      * The corresponding map layer with temporal attributes

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -597,6 +597,8 @@ void QgsVectorLayerProperties::syncToLayer()
 
   mMetadataWidget->setMetadata( &mLayer->metadata() );
 
+  mTemporalWidget->syncToLayer();
+
 } // syncToLayer()
 
 void QgsVectorLayerProperties::apply()


### PR DESCRIPTION
Fixes #36531, fixes #36530