### PR TITLE
restore last used attribute table view when exiting multi-edit mode (fix #25099)

### DIFF
--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -630,7 +630,12 @@ void QgsDualView::openConditionalStyles()
 void QgsDualView::setMultiEditEnabled( bool enabled )
 {
   if ( enabled )
+  {
+    mPreviousView = view();
     setView( AttributeEditor );
+  }
+  else
+    setView( mPreviousView );
 
   mAttributeForm->setMode( enabled ? QgsAttributeEditorContext::MultiEditMode : QgsAttributeEditorContext::SingleEditMode );
 }

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -431,7 +431,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     QgsFeature mTempAttributeFormFeature;
     QgsFeatureIds mLastFeatureSet;
     bool mBrowsingAutoPanScaleAllowed = true;
-    ViewMode mPreviousView;
+    ViewMode mPreviousView = AttributeTable;
 
     friend class TestQgsDualView;
     friend class TestQgsAttributeTable;

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -431,6 +431,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     QgsFeature mTempAttributeFormFeature;
     QgsFeatureIds mLastFeatureSet;
     bool mBrowsingAutoPanScaleAllowed = true;
+    ViewMode mPreviousView;
 
     friend class TestQgsDualView;
     friend class TestQgsAttributeTable;


### PR DESCRIPTION
## Description
When attribute table is in table mode and user starts multi-edit session, turning multi-edit mode off does not return into table view, instead a Form view is used.

Fixes #25099.