### PR TITLE
Fix build

### DIFF
--- a/src/app/devtools/profiler/qgsprofilerpanelwidget.cpp
+++ b/src/app/devtools/profiler/qgsprofilerpanelwidget.cpp
@@ -17,6 +17,7 @@
 #include "qgsruntimeprofiler.h"
 #include "qgslogger.h"
 #include <QPainter>
+#include <cmath>
 
 //
 // QgsProfilerPanelWidget


### PR DESCRIPTION
## Description

include cmath to fix this error:
```
/home/lbartoletti/QGIS/src/app/devtools/profiler/qgsprofilerpanelwidget.cpp:89:25: error: call to 'abs' is ambiguous
  const auto fraction = std::abs( float( cost ) / totalCost );
                        ^~~~~~~~
/usr/include/stdlib.h:87:6: note: candidate function
int      abs(int) __pure2;
         ^
/usr/include/c++/v1/stdlib.h:111:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long      abs(     long __x) _NOEXCEPT {return  labs(__x);}
                                           ^
/usr/include/c++/v1/stdlib.h:113:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long long abs(long long __x) _NOEXCEPT {return llabs(__x);}
                                           ^
1 error generated.
```