### PR TITLE
refresh attribute form editor when layer fields are changed (fix #26350)

### DIFF
--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -232,6 +232,8 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   mAttributesFormFrame->layout()->setContentsMargins( 0, 0, 0, 0 );
   mAttributesFormFrame->layout()->addWidget( mAttributesFormPropertiesDialog );
 
+  connect( mLayer, &QgsVectorLayer::updatedFields, mAttributesFormPropertiesDialog, &QgsAttributesFormProperties::init );
+
   // Metadata tab, before the syncToLayer
   QVBoxLayout *metadataLayout = new QVBoxLayout( metadataFrame );
   metadataLayout->setContentsMargins( 0, 0, 0, 0 );

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -232,7 +232,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   mAttributesFormFrame->layout()->setContentsMargins( 0, 0, 0, 0 );
   mAttributesFormFrame->layout()->addWidget( mAttributesFormPropertiesDialog );
 
-  connect( mLayer, &QgsVectorLayer::updatedFields, mAttributesFormPropertiesDialog, &QgsAttributesFormProperties::init );
+  connect( mLayer, &QgsVectorLayer::updatedFields, mAttributesFormPropertiesDialog, &QgsAttributesFormProperties::initAvailableWidgetsTree );
 
   // Metadata tab, before the syncToLayer
   QVBoxLayout *metadataLayout = new QVBoxLayout( metadataFrame );


### PR DESCRIPTION
## Description
Refresh attribute form editor when fields added/removed in the "Source Fields" tab, otherwise changed in the layer fields are not reflected until closing and re-openining layer properties.

Fixes #26350.