### PR TITLE
Fix WMS-T static temporal ui state in layer properties

### DIFF
--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -302,6 +302,7 @@ QString QgsWMSItemBase::createUri()
   if ( mDataSourceUri.param( QLatin1String( "type" ) ) == QLatin1String( "wmst" ) )
   {
     mDataSourceUri.setParam( QLatin1String( "temporalSource" ), QLatin1String( "provider" ) );
+    mDataSourceUri.setParam( QLatin1String( "allowTemporalUpdates" ), QLatin1String( "true" ) );
   }
 
   QString format;

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -1056,6 +1056,7 @@ void QgsWMSSourceSelect::collectDimensions( QStringList &layers, QgsDataSourceUr
       if ( uri.param( QLatin1String( "type" ) ) == QLatin1String( "wmst" ) )
       {
         uri.setParam( QLatin1String( "temporalSource" ), QLatin1String( "provider" ) );
+        uri.setParam( QLatin1String( "allowTemporalUpdates" ), QLatin1String( "true" ) );
       }
 
     }


### PR DESCRIPTION
Currently the static temporal settings are unchecked in the UI while they are used in the temporal updates(they should be checked by default). This PR enables loading static temporal settings by default, hence the static temporal settings will be checked in the raster layer properties.

Current default state
![current_default_wmst_settings](https://user-images.githubusercontent.com/2663775/82316909-30437600-99d6-11ea-989c-9c0c27ec3a25.png)

New default state
![new_use_dates_only_position](https://user-images.githubusercontent.com/2663775/82316929-376a8400-99d6-11ea-986b-d2b1f627fbe0.png)
