### PR TITLE
[BUGFIX][GPS] Fix error when vector layer has Z

### DIFF
--- a/src/app/devtools/profiler/qgsprofilerpanelwidget.cpp
+++ b/src/app/devtools/profiler/qgsprofilerpanelwidget.cpp
@@ -17,6 +17,7 @@
 #include "qgsruntimeprofiler.h"
 #include "qgslogger.h"
 #include <QPainter>
+#include <cmath>
 
 //
 // QgsProfilerPanelWidget

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -46,6 +46,7 @@
 #include "qgslocaldefaultsettings.h"
 #include "qgsprojectdisplaysettings.h"
 #include "qgsbearingnumericformat.h"
+#include "qgspolygon.h"
 
 // QWT Charting widget
 
@@ -833,17 +834,20 @@ void QgsGpsInformationWidget::displayGPSInformation( const QgsGpsInformation &in
   QgsPointXY myNewCenter;
   nmeaPOS newNmeaPosition;
   nmeaTIME newNmeaTime;
+  double newAlt = 0.0;
   if ( validFlag )
   {
     myNewCenter = QgsPointXY( info.longitude, info.latitude );
     newNmeaPosition.lat = nmea_degree2radian( info.latitude );
     newNmeaPosition.lon = nmea_degree2radian( info.longitude );
+    newAlt = info.elevation;
     nmea_time_now( &newNmeaTime );
   }
   else
   {
     myNewCenter = mLastGpsPosition;
     newNmeaPosition = mLastNmeaPosition;
+    newAlt = mLastElevation;
   }
   if ( !mAcquisitionEnabled || ( nmea_distance( &newNmeaPosition, &mLastNmeaPosition ) < mDistanceThreshold ) )
   {
@@ -925,6 +929,7 @@ void QgsGpsInformationWidget::displayGPSInformation( const QgsGpsInformation &in
     mLastGpsPosition = myNewCenter;
     mLastNmeaPosition = newNmeaPosition;
     mLastNmeaTime = newNmeaTime;
+    mLastElevation = newAlt;
     // Pan based on user specified behavior
     if ( radRecenterMap->isChecked() || radRecenterWhenNeeded->isChecked() )
     {
@@ -1042,7 +1047,9 @@ void QgsGpsInformationWidget::addVertex()
 
   // we store the capture list in wgs84 and then transform to layer crs when
   // calling close feature
-  mCaptureList.push_back( mLastGpsPosition );
+  QgsPoint point = QgsPoint( mLastGpsPosition.x(), mLastGpsPosition.y(), mLastElevation );
+  mCaptureList.push_back( point );
+
 
   // we store the rubber band points in map canvas CRS so transform to map crs
   // potential problem with transform errors and wrong coordinates if map CRS is changed after points are stored - SLM
@@ -1100,6 +1107,7 @@ void QgsGpsInformationWidget::mBtnCloseFeature_clicked()
   }
 
   QgsCoordinateTransform t( mWgs84CRS, vlayer->crs(), QgsProject::instance() );
+  bool is3D = QgsWkbTypes::hasZ( vlayer->wkbType() );
   switch ( vlayer->geometryType() )
   {
     case QgsWkbTypes::PointGeometry:
@@ -1107,7 +1115,14 @@ void QgsGpsInformationWidget::mBtnCloseFeature_clicked()
       QgsFeature f;
       try
       {
-        QgsGeometry g = QgsGeometry::fromPointXY( t.transform( mLastGpsPosition ) );
+        QgsPointXY pointXY = t.transform( mLastGpsPosition );
+
+        QgsGeometry g;
+        if ( is3D )
+          g = QgsGeometry( new QgsPoint( pointXY.x(), pointXY.y(), mLastElevation ) );
+        else
+          g = QgsGeometry::fromPointXY( pointXY );
+
         if ( QgsWkbTypes::isMultiType( vlayer->wkbType() ) )
           g.convertToMultiType();
 
@@ -1153,7 +1168,7 @@ void QgsGpsInformationWidget::mBtnCloseFeature_clicked()
 
       if ( vlayer->geometryType() == QgsWkbTypes::LineGeometry )
       {
-        g = QgsGeometry::fromPolylineXY( mCaptureList );
+        g = QgsGeometry( new QgsLineString( mCaptureList ) );
         try
         {
           g.transform( t );
@@ -1169,13 +1184,12 @@ void QgsGpsInformationWidget::mBtnCloseFeature_clicked()
       }
       else if ( vlayer->geometryType() == QgsWkbTypes::PolygonGeometry )
       {
-        QVector< QgsPointXY > line = mCaptureList;
+        std::unique_ptr<QgsLineString> ring( new QgsLineString( mCaptureList ) );
+        ring->close();
+        std::unique_ptr<QgsPolygon> polygon( new QgsPolygon() );
+        polygon->setExteriorRing( ring.release() );
 
-        // close ring if required
-        if ( line.constFirst() != line.constLast() )
-          line << line.constFirst();
-
-        g = QgsGeometry::fromPolygonXY( QVector< QgsPolylineXY > () << line );
+        g = QgsGeometry( polygon.release() );
         try
         {
           g.transform( t );

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -1166,9 +1166,14 @@ void QgsGpsInformationWidget::mBtnCloseFeature_clicked()
       QgsFeature f;
       QgsGeometry g;
 
+      std::unique_ptr<QgsLineString> ring( new QgsLineString( mCaptureList ) );
+      if ( ! is3D )
+        ring->dropZValue();
+
       if ( vlayer->geometryType() == QgsWkbTypes::LineGeometry )
       {
-        g = QgsGeometry( new QgsLineString( mCaptureList ) );
+
+        g = QgsGeometry( ring.release() );
         try
         {
           g.transform( t );
@@ -1184,7 +1189,6 @@ void QgsGpsInformationWidget::mBtnCloseFeature_clicked()
       }
       else if ( vlayer->geometryType() == QgsWkbTypes::PolygonGeometry )
       {
-        std::unique_ptr<QgsLineString> ring( new QgsLineString( mCaptureList ) );
         ring->close();
         std::unique_ptr<QgsPolygon> polygon( new QgsPolygon() );
         polygon->setExteriorRing( ring.release() );

--- a/src/app/gps/qgsgpsinformationwidget.h
+++ b/src/app/gps/qgsgpsinformationwidget.h
@@ -133,7 +133,8 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, private Ui::Qgs
 // not used    QPointF gpsToPixelPosition( const QgsPoint& point );
     QgsRubberBand *mRubberBand = nullptr;
     QgsPointXY mLastGpsPosition;
-    QVector<QgsPointXY> mCaptureList;
+    QVector<QgsPoint> mCaptureList;
+    double mLastElevation = 0.0;
     FixStatus mLastFixStatus;
     QString mDateTimeFormat; // user specified format string in registry (no UI presented)
     QPointer< QgsVectorLayer > mLastLayer;

--- a/tests/src/app/testqgsgpsinformationwidget.cpp
+++ b/tests/src/app/testqgsgpsinformationwidget.cpp
@@ -270,14 +270,14 @@ void TestQgsGpsInformationWidget::testTimestampWrite()
   QCOMPARE( _testWrite( tempLayerString, widget.get(), QStringLiteral( "stringf" ),  Qt::TimeSpec::TimeZone ).toString( Qt::DateFormat::ISODate ),  tzTime.toString( Qt::DateFormat::ISODate ) );
 
   // Test write on line string field
-  widget->mCaptureList.push_back( QgsPointXY( 1, 2 ) );
-  widget->mCaptureList.push_back( QgsPointXY( 3, 4 ) );
+  widget->mCaptureList.push_back( QgsPoint( 1, 2 ) );
+  widget->mCaptureList.push_back( QgsPoint( 3, 4 ) );
   QCOMPARE( _testWrite( tempLayerLineString, widget.get(), QStringLiteral( "stringf" ),  Qt::TimeSpec::UTC ).toString( Qt::DateFormat::ISODate ), dateTime.toString( Qt::DateFormat::ISODate ) );
-  widget->mCaptureList.push_back( QgsPointXY( 1, 2 ) );
-  widget->mCaptureList.push_back( QgsPointXY( 3, 4 ) );
+  widget->mCaptureList.push_back( QgsPoint( 1, 2 ) );
+  widget->mCaptureList.push_back( QgsPoint( 3, 4 ) );
   QCOMPARE( _testWrite( tempLayerLineString, widget.get(), QStringLiteral( "stringf" ),  Qt::TimeSpec::LocalTime ).toString( Qt::DateFormat::ISODate ), localTime.toString( Qt::DateFormat::ISODate ) );
-  widget->mCaptureList.push_back( QgsPointXY( 1, 2 ) );
-  widget->mCaptureList.push_back( QgsPointXY( 3, 4 ) );
+  widget->mCaptureList.push_back( QgsPoint( 1, 2 ) );
+  widget->mCaptureList.push_back( QgsPoint( 3, 4 ) );
   QCOMPARE( _testWrite( tempLayerLineString, widget.get(), QStringLiteral( "stringf" ),  Qt::TimeSpec::TimeZone ).toString( Qt::DateFormat::ISODate ),  tzTime.toString( Qt::DateFormat::ISODate ) );
 
   // Write on GPKG


### PR DESCRIPTION
## Description

GPS module doesn't save information about "elevation/altitude" and can cause problem as described in #32016 .

I suggest to use QgsPoint instead of QgsPointXY and take "Z" from info.elevation.

@nyalldawson do you agree with that? Thanks.

[Video](https://github.com/lbartoletti/lbartoletti.github.io/blob/master/gps3D.mp4)
