### PR TITLE
Avoid proj 'object is not a concatenated operation' warnings

### DIFF
--- a/src/core/qgsdatumtransform.cpp
+++ b/src/core/qgsdatumtransform.cpp
@@ -377,24 +377,42 @@ QgsDatumTransform::TransformDetails QgsDatumTransform::transformDetailsFromPj( P
     details.grids.append( gridDetails );
   }
 
-  for ( int j = 0; j < proj_concatoperation_get_step_count( pjContext, op ); ++j )
+  if ( proj_get_type( op ) == PJ_TYPE_CONCATENATED_OPERATION )
   {
-    QgsProjUtils::proj_pj_unique_ptr step( proj_concatoperation_get_step( pjContext, op, j ) );
-    if ( step )
+    for ( int j = 0; j < proj_concatoperation_get_step_count( pjContext, op ); ++j )
     {
-      SingleOperationDetails singleOpDetails;
-      singleOpDetails.remarks = QString( proj_get_remarks( step.get() ) );
-      singleOpDetails.scope = QString( proj_get_scope( step.get() ) );
-      singleOpDetails.authority = QString( proj_get_id_auth_name( step.get(), 0 ) );
-      singleOpDetails.code = QString( proj_get_id_code( step.get(), 0 ) );
-
-      const char *areaOfUseName = nullptr;
-      if ( proj_get_area_of_use( pjContext, step.get(), nullptr, nullptr, nullptr, nullptr, &areaOfUseName ) )
+      QgsProjUtils::proj_pj_unique_ptr step( proj_concatoperation_get_step( pjContext, op, j ) );
+      if ( step )
       {
-        singleOpDetails.areaOfUse = QString( areaOfUseName );
+        SingleOperationDetails singleOpDetails;
+        singleOpDetails.remarks = QString( proj_get_remarks( step.get() ) );
+        singleOpDetails.scope = QString( proj_get_scope( step.get() ) );
+        singleOpDetails.authority = QString( proj_get_id_auth_name( step.get(), 0 ) );
+        singleOpDetails.code = QString( proj_get_id_code( step.get(), 0 ) );
+
+        const char *areaOfUseName = nullptr;
+        if ( proj_get_area_of_use( pjContext, step.get(), nullptr, nullptr, nullptr, nullptr, &areaOfUseName ) )
+        {
+          singleOpDetails.areaOfUse = QString( areaOfUseName );
+        }
+        details.operationDetails.append( singleOpDetails );
       }
-      details.operationDetails.append( singleOpDetails );
     }
+  }
+  else
+  {
+    SingleOperationDetails singleOpDetails;
+    singleOpDetails.remarks = QString( proj_get_remarks( op ) );
+    singleOpDetails.scope = QString( proj_get_scope( op ) );
+    singleOpDetails.authority = QString( proj_get_id_auth_name( op, 0 ) );
+    singleOpDetails.code = QString( proj_get_id_code( op, 0 ) );
+
+    const char *areaOfUseName = nullptr;
+    if ( proj_get_area_of_use( pjContext, op, nullptr, nullptr, nullptr, nullptr, &areaOfUseName ) )
+    {
+      singleOpDetails.areaOfUse = QString( areaOfUseName );
+    }
+    details.operationDetails.append( singleOpDetails );
   }
 
   return details;


### PR DESCRIPTION
Ultimately harmless, but may cause warnings raised by real issues to be ignored