### PR TITLE
Extend .qgz mime type support

### DIFF
--- a/debian/qgis.mime
+++ b/debian/qgis.mime
@@ -7,6 +7,7 @@ application/x-raster-mrsid; qgis '%s'; description="MrSID raster data"; test=tes
 application/x-raster-mif; qgis '%s'; description="MapInfo file"; test=test -n "$DISPLAY"; nametemplate=%s.mif; priority=2
 application/x-esri-shape; qgis '%s'; description="ESRI shape file"; test=test -n "$DISPLAY"; nametemplate=%s.shp; priority=2
 application/x-qgis-project; qgis '%s'; description="QGIS Project"; test=test -n "$DISPLAY"; nametemplate=%s.qgs
+application/x-qgis-project-container; qgis '%s'; description="QGIS Project"; test=test -n "$DISPLAY"; nametemplate=%s.qgz
 application/x-qgis-layer-settings; qgis '%s'; description="QGIS Layer Settings"; test=test -n "$DISPLAY"; nametemplate=%s.qml
 application/x-qgis-layer-definition; qgis '%s'; description="QGIS Layer Definition"; test=test -n "$DISPLAY"; nametemplate=%s.qlr
 application/x-qgis-composer-template; qgis '%s'; description="QGIS Composer Template"; test=test -n "$DISPLAY"; nametemplate=%s.qpt

--- a/debian/qgis.xml
+++ b/debian/qgis.xml
@@ -13,6 +13,19 @@
       </match>
     </magic>
     <glob pattern="*.qgs"/>
+  </mime-type>
+  
+  <mime-type type="application/x-qgis-project-container">
+    <comment>QGIS Project</comment>
+    <comment xml:lang="de">QGIS-Projekt</comment>
+    <sub-class-of type="application/zip"/>
+    <alias type="application/x-qgis"/>
+    <icon name="qgis-qgs"/>
+    <magic priority="50">
+      <match type="string" offset="0" value="&lt;!DOCTYPE qgis">
+        <match type="string" offset="0:256" value="&lt;qgis projectname"/>
+      </match>
+    </magic>
     <glob pattern="*.qgz"/>
   </mime-type>
 

--- a/linux/org.qgis.qgis.desktop.in
+++ b/linux/org.qgis.qgis.desktop.in
@@ -8,6 +8,6 @@ Exec=qgis %F
 Terminal=false
 StartupNotify=false
 Categories=Qt;Education;Science;Geography;
-MimeType=application/x-qgis-project;application/x-qgis-layer-settings;application/x-qgis-layer-definition;application/x-qgis-composer-template;image/tiff;image/jpeg;image/jp2;application/x-raster-aig;application/x-raster-ecw;application/x-raster-mrsid;application/x-mapinfo-mif;application/x-esri-shape;
+MimeType=application/x-qgis-project;application/x-qgis-project-container;application/x-qgis-layer-settings;application/x-qgis-layer-definition;application/x-qgis-composer-template;image/tiff;image/jpeg;image/jp2;application/x-raster-aig;application/x-raster-ecw;application/x-raster-mrsid;application/x-mapinfo-mif;application/x-esri-shape;
 Keywords=map;globe;postgis;wms;wfs;ogc;osgeo;
 StartupWMClass=QGIS3

--- a/rpm/sources/qgis-mime.xml
+++ b/rpm/sources/qgis-mime.xml
@@ -14,6 +14,20 @@
     </magic>
     <glob pattern="*.qgs"/>
   </mime-type>
+  
+  <mime-type type="application/x-qgis-project-container">
+    <comment>QGIS Project</comment>
+    <comment xml:lang="de">QGIS-Projekt</comment>
+    <sub-class-of type="application/zip"/>
+    <alias type="application/x-qgis"/>
+    <icon name="qgis-qgs"/>
+    <magic priority="50">
+      <match type="string" offset="0" value="&lt;!DOCTYPE qgis">
+        <match type="string" offset="0:256" value="&lt;qgis projectname"/>
+      </match>
+    </magic>
+    <glob pattern="*.qgz"/>
+  </mime-type>
 
   <mime-type type="application/x-qgis-layer-settings">
     <comment>QGIS layer settings</comment>


### PR DESCRIPTION
## Description

This simply adds a new mime type `application/x-qgis-project-container` for `.qgz` files, inheriting from `application/zip`. There was already some support for `.qgz` in the Debian mime type file, but it inherited from `application/xml`, meaning that some programs would incorrectly assume that `.qgz` were text files. The KDE file manager Dolphin, for example, would try to preview the binary `.qgz` in text mode.

The RPM version of the mime type file did not support `.qgz` at all, but now does.

The PR also adds support for `application/x-qgis-project-container` in the `.desktop` file so the new mime type is handled by QGIS.