### PR TITLE
Fix running script algorithm from editor dialog

### DIFF
--- a/python/plugins/processing/script/ScriptEditorDialog.py
+++ b/python/plugins/processing/script/ScriptEditorDialog.py
@@ -27,7 +27,7 @@ import inspect
 import traceback
 import warnings
 
-from qgis.PyQt import uic
+from qgis.PyQt import uic, sip
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QCursor
 from qgis.PyQt.QtWidgets import (QMessageBox,
@@ -113,6 +113,7 @@ class ScriptEditorDialog(BASE, WIDGET):
         self.btnFind.clicked.connect(self.find)
         self.btnReplace.clicked.connect(self.replace)
         self.lastSearch = None
+        self.run_dialog = None
 
         self.filePath = None
         if filePath is not None:
@@ -219,6 +220,10 @@ class ScriptEditorDialog(BASE, WIDGET):
         self.update_dialog_title()
 
     def runAlgorithm(self):
+        if self.run_dialog and not sip.isdeleted(self.run_dialog):
+            self.run_dialog.close()
+            self.run_dialog = None
+
         _locals = {}
         try:
             exec(self.editor.text(), _locals)
@@ -248,14 +253,14 @@ class ScriptEditorDialog(BASE, WIDGET):
         alg.setProvider(QgsApplication.processingRegistry().providerById("script"))
         alg.initAlgorithm()
 
-        dlg = alg.createCustomParametersWidget(iface.mainWindow())
-        if not dlg:
-            dlg = AlgorithmDialog(alg, parent=iface.mainWindow())
+        self.run_dialog = alg.createCustomParametersWidget(self)
+        if not self.run_dialog:
+            self.run_dialog = AlgorithmDialog(alg, parent=self)
 
         canvas = iface.mapCanvas()
         prevMapTool = canvas.mapTool()
 
-        dlg.show()
+        self.run_dialog.show()
 
         if canvas.mapTool() != prevMapTool:
             try:


### PR DESCRIPTION
We have to keep a local reference to the dialog, otherwise sip suddenly
"forgets" about the python subclass and treats the dialog as just
the parent c++ class. Really weird, thanks sip.

3.14 only.

Fixes #36436
