### PR TITLE
Fix memory layers lose CRS definition if it does not have an authority associated with it

### DIFF
--- a/src/core/providers/memory/qgsmemoryproviderutils.cpp
+++ b/src/core/providers/memory/qgsmemoryproviderutils.cpp
@@ -65,7 +65,10 @@ QgsVectorLayer *QgsMemoryProviderUtils::createMemoryLayer( const QString &name, 
   QStringList parts;
   if ( crs.isValid() )
   {
-    parts << QStringLiteral( "crs=" ) + crs.authid();
+    if ( !crs.authid().isEmpty() )
+      parts << QStringLiteral( "crs=%1" ).arg( crs.authid() );
+    else
+      parts << QStringLiteral( "crs=wkt:%1" ).arg( crs.toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ) );
   }
   for ( const auto &field : fields )
   {

--- a/tests/src/python/test_provider_memory.py
+++ b/tests/src/python/test_provider_memory.py
@@ -28,7 +28,8 @@ from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsRectangle,
     QgsTestUtils,
-    QgsFeatureSource
+    QgsFeatureSource,
+    QgsProjUtils
 )
 
 from qgis.testing import (
@@ -442,6 +443,19 @@ class TestPyQgsMemoryProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(layer.wkbType(), QgsWkbTypes.PolygonZM)
         self.assertTrue(layer.crs().isValid())
         self.assertEqual(layer.crs().authid(), 'EPSG:3111')
+
+        # custom CRS
+        if QgsProjUtils.projVersionMajor() >= 6:
+            crs = QgsCoordinateReferenceSystem.fromProj('+proj=qsc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs')
+            layer = QgsMemoryProviderUtils.createMemoryLayer('my name', QgsFields(), QgsWkbTypes.PolygonZM, crs)
+            self.assertTrue(layer.isValid())
+            self.assertTrue(layer.crs().isValid())
+            self.assertEqual(layer.crs().toProj(), '+proj=qsc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs +type=crs')
+
+            # clone it, just to check
+            layer2 = layer.clone()
+            self.assertEqual(layer2.crs().toProj(),
+                             '+proj=qsc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs +type=crs')
 
         # fields
         fields = QgsFields()


### PR DESCRIPTION
Fixes #36241
