### PR TITLE
Implement spatial index detection for OGR provider

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3863,6 +3863,16 @@ QStringList QgsOgrProvider::uniqueStringsMatching( int index, const QString &sub
   return results;
 }
 
+QgsFeatureSource::SpatialIndexPresence QgsOgrProvider::hasSpatialIndex() const
+{
+  if ( mOgrLayer && mOgrLayer->TestCapability( OLCFastSpatialFilter ) )
+    return QgsFeatureSource::SpatialIndexPresent;
+  else if ( mOgrLayer )
+    return QgsFeatureSource::SpatialIndexNotPresent;
+  else
+    return QgsFeatureSource::SpatialIndexUnknown;
+}
+
 QVariant QgsOgrProvider::minimumValue( int index ) const
 {
   if ( !mValid || index < 0 || index >= mAttributeFields.count() )

--- a/src/core/providers/ogr/qgsogrprovider.h
+++ b/src/core/providers/ogr/qgsogrprovider.h
@@ -144,6 +144,7 @@ class QgsOgrProvider final: public QgsVectorDataProvider
     QSet< QVariant > uniqueValues( int index, int limit = -1 ) const override;
     QStringList uniqueStringsMatching( int index, const QString &substring, int limit = -1,
                                        QgsFeedback *feedback = nullptr ) const override;
+    QgsFeatureSource::SpatialIndexPresence hasSpatialIndex() const override;
 
     QString name() const override;
     static QString providerKey();


### PR DESCRIPTION
Provides warnings in Processing algorithms when running on layers which don't have a spatial index present (e.g. geojson files) and where performance will be severely hurt as a result

Fixes #30530