### PR TITLE
Cleanup leftover rubberband in identify and select tools

### DIFF
--- a/src/app/qgsmaptoolselectionhandler.cpp
+++ b/src/app/qgsmaptoolselectionhandler.cpp
@@ -220,10 +220,9 @@ void QgsMapToolSelectionHandler::selectFeaturesReleaseEvent( QgsMapMouseEvent *e
   }
 
   if ( mSelectionRubberBand && mSelectionActive )
-  {
     setSelectedGeometry( mSelectionRubberBand->asGeometry(), e->modifiers() );
+  if ( mSelectionRubberBand )
     mSelectionRubberBand.reset();
-  }
 
   mSelectionActive = false;
 }


### PR DESCRIPTION
## Description
There is a case where a rubberband is left on the canvas when using the identify or select tools.
While dragging with the left button, if right button is clicked before left is released, the following happens:

![Peek 2020-05-20 20-04](https://user-images.githubusercontent.com/11358178/82475887-db872480-9ad5-11ea-9b0a-f0b70eae98dc.gif)

This PR fixes that.

<!--When dragging a rectangle with the 
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
