### PR TITLE
Vertex tool, fix escape to stop dragging edge

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -1236,38 +1236,52 @@ void QgsVertexTool::updateFeatureBand( const QgsPointLocator::Match &m )
 
 void QgsVertexTool::keyPressEvent( QKeyEvent *e )
 {
-  if ( !mDraggingVertex && !mDraggingEdge && e->key() == Qt::Key_R && e->modifiers() & Qt::ShiftModifier )
+  switch ( e->key() )
   {
-    startRangeVertexSelection();
-    return;
+    case Qt::Key_Escape:
+    {
+      if ( mSelectionMethod == SelectionRange )
+        stopRangeVertexSelection();
+      if ( mDraggingVertex || mDraggingEdge )
+        stopDragging();
+      break;
+    }
+    case Qt::Key_Delete:
+    case Qt::Key_Backspace:
+    {
+      if ( mDraggingVertex || ( !mDraggingEdge && !mSelectedVertices.isEmpty() ) )
+      {
+        e->ignore();  // Override default shortcut management
+        deleteVertex();
+      }
+      break;
+    }
+    case Qt::Key_R:
+    {
+      if ( e->modifiers() & Qt::ShiftModifier && !mDraggingVertex && !mDraggingEdge )
+        startRangeVertexSelection();
+      break;
+    }
+    case Qt::Key_Less:
+    case Qt::Key_Comma:
+    {
+      if ( !mDraggingVertex && !mDraggingEdge )
+        highlightAdjacentVertex( -1 );
+      break;
+    }
+    case Qt::Key_Greater:
+    case Qt::Key_Period:
+    {
+      if ( !mDraggingVertex && !mDraggingEdge )
+        highlightAdjacentVertex( + 1 );
+      break;
+    }
+    default:
+    {
+      return;
+    }
   }
-  if ( mSelectionMethod == SelectionRange && e->key() == Qt::Key_Escape )
-  {
-    stopRangeVertexSelection();
-    return;
-  }
-
-  if ( !mDraggingVertex && !mDraggingEdge && mSelectedVertices.count() == 0 )
-    return;
-
-  if ( e->key() == Qt::Key_Delete || e->key() == Qt::Key_Backspace )
-  {
-    e->ignore();  // Override default shortcut management
-    deleteVertex();
-  }
-  else if ( e->key() == Qt::Key_Escape )
-  {
-    if ( mDraggingVertex || mDraggingEdge )
-      stopDragging();
-  }
-  else if ( e->key() == Qt::Key_Less || e->key() == Qt::Key_Comma )
-  {
-    highlightAdjacentVertex( -1 );
-  }
-  else if ( e->key() == Qt::Key_Greater || e->key() == Qt::Key_Period )
-  {
-    highlightAdjacentVertex( + 1 );
-  }
+  return;
 }
 
 QgsGeometry QgsVertexTool::cachedGeometry( const QgsVectorLayer *layer, QgsFeatureId fid )

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -1247,7 +1247,7 @@ void QgsVertexTool::keyPressEvent( QKeyEvent *e )
     return;
   }
 
-  if ( !mDraggingVertex && mSelectedVertices.count() == 0 )
+  if ( !mDraggingVertex && !mDraggingEdge && mSelectedVertices.count() == 0 )
     return;
 
   if ( e->key() == Qt::Key_Delete || e->key() == Qt::Key_Backspace )
@@ -1257,7 +1257,7 @@ void QgsVertexTool::keyPressEvent( QKeyEvent *e )
   }
   else if ( e->key() == Qt::Key_Escape )
   {
-    if ( mDraggingVertex )
+    if ( mDraggingVertex || mDraggingEdge )
       stopDragging();
   }
   else if ( e->key() == Qt::Key_Less || e->key() == Qt::Key_Comma )


### PR DESCRIPTION
## Description
In vertex tool, dragging a vertex can be stopped by pressing Escape, but dragging an edge cannot. This PR fixes that, so escape can stop both dragging a vertex or an edge.

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
