### PR TITLE
Fix incorrect behaviors of Date/Time widget config

### DIFF
--- a/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
@@ -453,7 +453,14 @@ void QgsDateTimeEditConfig::displayFormatChanged( int idx )
   }
   if ( !custom )
   {
-    mDisplayFormatEdit->setText( mFieldFormatEdit->text() );
+    if ( mFieldFormatComboBox->currentData() == QgsDateTimeFieldFormatter::QT_ISO_FORMAT )
+    {
+      mDisplayFormatEdit->setText( QgsDateTimeFieldFormatter::DISPLAY_FOR_ISO_FORMAT );
+    }
+    else
+    {
+      mDisplayFormatEdit->setText( mFieldFormatEdit->text() );
+    }
   }
 }
 

--- a/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
@@ -415,6 +415,10 @@ void QgsDateTimeEditConfig::updateFieldFormat( int idx )
   {
     mFieldFormatEdit->setText( format );
   }
+  else if ( mFieldFormatEdit->text() == QgsDateTimeFieldFormatter::QT_ISO_FORMAT )
+  {
+    mFieldFormatEdit->setText( QgsDateTimeFieldFormatter::DISPLAY_FOR_ISO_FORMAT );
+  }
 
   mFieldFormatEdit->setEnabled( custom );
   mFieldHelpToolButton->setVisible( custom );


### PR DESCRIPTION
## Description

 In the Date/Time widget config window:

- when the Field Format combo box is set to "ISO Date Time" and the Widget Display combo box to "Default", then the display format string is correctly set to "yyyy-MM-dd HH:mm:ss+t".
Changing the Widget Display combo box to "Custom" and then again to "Default", the display format string will be incorrectly set to the invalid format string "Qt ISO Date" (QgsDateTimeFieldFormatter::QT_ISO_FORMAT)
In this case, the patch properly sets the display format string to the corresponding valid format string "yyyy-MM-dd HH:mm:ss+t" (QgsDateTimeFieldFormatter::DISPLAY_FOR_ISO_FORMAT).

before
<img src="https://user-images.githubusercontent.com/16253859/82511506-d0e88180-9b0d-11ea-9df7-6dd735618ceb.gif" width="450">
after
<img src="https://user-images.githubusercontent.com/16253859/82511538-e3fb5180-9b0d-11ea-810d-95e33839532c.gif" width="450">


- when the Field Format combo box is set to "ISO Date Time" and after that it is switched to "Custom", then the field format string is incorrectly set to the invalid format string "Qt ISO Date" (QgsDateTimeFieldFormatter::QT_ISO_FORMAT)
Also in this case, the patch properly sets the field format string to the corresponding valid format string "yyyy-MM-dd HH:mm:ss+t" (QgsDateTimeFieldFormatter::DISPLAY_FOR_ISO_FORMAT).

before
<img src="https://user-images.githubusercontent.com/16253859/82511945-eb6f2a80-9b0e-11ea-9b77-7b3c3c184fb7.gif" width="450">
after
<img src="https://user-images.githubusercontent.com/16253859/82511964-f2963880-9b0e-11ea-916f-700b1eaa21ae.gif" width="450">

These incorrect behaviors also affect 3.10 branch.

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
