### PR TITLE
Gps interaction fixes

### DIFF
--- a/python/gui/auto_additions/qgsmapcanvasinteractionblocker.py
+++ b/python/gui/auto_additions/qgsmapcanvasinteractionblocker.py
@@ -1,0 +1,5 @@
+# The following has been generated automatically from src/gui/qgsmapcanvasinteractionblocker.h
+# monkey patching scoped based enum
+QgsMapCanvasInteractionBlocker.Interaction.MapPanOnSingleClick.__doc__ = "A map pan interaction caused by a single click and release on the map canvas"
+QgsMapCanvasInteractionBlocker.Interaction.__doc__ = '\n\n' + '* ``MapPanOnSingleClick``: ' + QgsMapCanvasInteractionBlocker.Interaction.MapPanOnSingleClick.__doc__
+# --

--- a/python/gui/auto_additions/qgsmapcanvasinteractionblocker.py
+++ b/python/gui/auto_additions/qgsmapcanvasinteractionblocker.py
@@ -1,5 +1,5 @@
 # The following has been generated automatically from src/gui/qgsmapcanvasinteractionblocker.h
 # monkey patching scoped based enum
 QgsMapCanvasInteractionBlocker.Interaction.MapPanOnSingleClick.__doc__ = "A map pan interaction caused by a single click and release on the map canvas"
-QgsMapCanvasInteractionBlocker.Interaction.__doc__ = '\n\n' + '* ``MapPanOnSingleClick``: ' + QgsMapCanvasInteractionBlocker.Interaction.MapPanOnSingleClick.__doc__
+QgsMapCanvasInteractionBlocker.Interaction.__doc__ = 'Available interactions to block.\n\n' + '* ``MapPanOnSingleClick``: ' + QgsMapCanvasInteractionBlocker.Interaction.MapPanOnSingleClick.__doc__
 # --

--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -19,6 +19,7 @@
 
 
 
+
 class QgsMapCanvas : QGraphicsView
 {
 %Docstring
@@ -75,7 +76,7 @@ Gets access to properties used for map rendering
 
     void setTemporalController( QgsTemporalController *controller );
 %Docstring
-Sets the temporal controller, this controller will be used to
+Sets the temporal controller, tQgsMapCanvasInteractionBlockerhis controller will be used to
 update the canvas temporal range.
 
 .. versionadded:: 3.14
@@ -783,6 +784,39 @@ The temporalRangeChanged() signal will be emitted if the temporal range has been
 Returns map canvas datetime range.
 
 .. seealso:: :py:func:`setTemporalRange`
+
+.. versionadded:: 3.14
+%End
+
+    void installInteractionBlocker( QgsMapCanvasInteractionBlocker *blocker );
+%Docstring
+Installs an interaction ``blocker`` onto the canvas, which may prevent certain map canvas
+interactions from occurring.
+
+The caller retains ownership of ``blocker``, and must correctly call removeInteractionBlocker()
+before deleting the object.
+
+.. seealso:: :py:func:`allowInteraction`
+
+.. seealso:: :py:func:`removeInteractionBlocker`
+
+.. versionadded:: 3.14
+%End
+
+    void removeInteractionBlocker( QgsMapCanvasInteractionBlocker *blocker );
+%Docstring
+Removes an interaction ``blocker`` from the canvas.
+
+.. seealso:: :py:func:`allowInteraction`
+
+.. seealso:: :py:func:`installInteractionBlocker`
+
+.. versionadded:: 3.14
+%End
+
+    bool allowInteraction( QgsMapCanvasInteractionBlocker::Interaction interaction ) const;
+%Docstring
+Returns ``True`` if the specified ``interaction`` is currently permitted on the canvas.
 
 .. versionadded:: 3.14
 %End

--- a/python/gui/auto_generated/qgsmapcanvasinteractionblocker.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvasinteractionblocker.sip.in
@@ -1,0 +1,45 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsmapcanvasinteractionblocker.h                             *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsMapCanvasInteractionBlocker
+{
+%Docstring
+An interface for objects which block interactions with a QgsMapCanvas.
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgsmapcanvasinteractionblocker.h"
+%End
+  public:
+
+    enum class Interaction
+    {
+      MapPanOnSingleClick,
+    };
+
+    virtual ~QgsMapCanvasInteractionBlocker();
+
+    virtual bool blockCanvasInteraction( Interaction interaction ) const = 0;
+%Docstring
+Returns ``True`` if the specified ``interaction`` should be blocked.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsmapcanvasinteractionblocker.h                             *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -119,6 +119,7 @@
 %Include auto_generated/qgsmanageconnectionsdialog.sip
 %Include auto_generated/qgsmapcanvas.sip
 %Include auto_generated/qgsmapcanvasannotationitem.sip
+%Include auto_generated/qgsmapcanvasinteractionblocker.sip
 %Include auto_generated/qgsmapcanvasitem.sip
 %Include auto_generated/qgsmapcanvassnappingutils.sip
 %Include auto_generated/qgsmapcanvastracer.sip

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -319,6 +319,17 @@ QgsGpsInformationWidget::QgsGpsInformationWidget( QgsMapCanvas *mapCanvas, QWidg
   mRotateMapCheckBox->setChecked( mySettings.value( QStringLiteral( "gps/rotateMap" ), false ).toBool() );
   mSpinMapRotateInterval->setValue( mySettings.value( QStringLiteral( "gps/rotateMapInterval" ), 0 ).toInt() );
   mShowBearingLineCheck->setChecked( mySettings.value( QStringLiteral( "gps/showBearingLine" ), false ).toBool() );
+  connect( mShowBearingLineCheck, &QgsCollapsibleGroupBox::toggled, this, [ = ]( bool checked )
+  {
+    if ( !checked )
+    {
+      if ( mMapBearingItem )
+      {
+        delete mMapBearingItem;
+        mMapBearingItem = nullptr;
+      }
+    }
+  } );
 
   mBtnDebug->setVisible( mySettings.value( QStringLiteral( "gps/showDebug" ), "false" ).toBool() );  // use a registry setting to control - power users/devs could set it
 
@@ -984,7 +995,7 @@ void QgsGpsInformationWidget::displayGPSInformation( const QgsGpsInformation &in
       mLastRotateTimer.restart();
     }
 
-    if ( mShowBearingLineCheck )
+    if ( mShowBearingLineCheck->isChecked() )
     {
       if ( ! mMapBearingItem )
       {

--- a/src/app/gps/qgsgpsinformationwidget.h
+++ b/src/app/gps/qgsgpsinformationwidget.h
@@ -25,6 +25,7 @@
 #include "qgsgpsmarker.h"
 #include "qgsmaptoolcapture.h"
 #include "qgspanelwidget.h"
+#include "qgsmapcanvasinteractionblocker.h"
 #include <qwt_plot_curve.h>
 #ifdef WITH_QWTPOLAR
 #include <qwt_polar_plot.h>
@@ -48,12 +49,14 @@ class QColor;
  * A dock widget that displays information from a GPS device and
  * allows the user to capture features using gps readings to
  * specify the geometry.*/
-class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, private Ui::QgsGpsInformationWidgetBase
+class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, public QgsMapCanvasInteractionBlocker, private Ui::QgsGpsInformationWidgetBase
 {
     Q_OBJECT
   public:
     QgsGpsInformationWidget( QgsMapCanvas *mapCanvas, QWidget *parent = nullptr );
     ~QgsGpsInformationWidget() override;
+
+    bool blockCanvasInteraction( Interaction interaction ) const override;
 
   public slots:
     void tapAndHold( const QgsPointXY &mapPoint, QTapAndHoldGesture *gesture );
@@ -111,7 +114,7 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, private Ui::Qgs
     void updateTimeZones();
     QVariant timestamp( QgsVectorLayer *vlayer, int idx );
     QgsGpsConnection *mNmea = nullptr;
-    QgsMapCanvas *mMapCanvas = nullptr;
+    QPointer< QgsMapCanvas > mMapCanvas;
     QgsGpsMarker *mMapMarker = nullptr;
     QgsGpsBearingItem *mMapBearingItem = nullptr;
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -674,6 +674,7 @@ SET(QGIS_GUI_HDRS
   qgsmanageconnectionsdialog.h
   qgsmapcanvas.h
   qgsmapcanvasannotationitem.h
+  qgsmapcanvasinteractionblocker.h
   qgsmapcanvasitem.h
   qgsmapcanvasmap.h
   qgsmapcanvassnappingutils.h

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -818,6 +818,26 @@ const QgsDateTimeRange &QgsMapCanvas::temporalRange() const
   return mSettings.temporalRange();
 }
 
+void QgsMapCanvas::installInteractionBlocker( QgsMapCanvasInteractionBlocker *blocker )
+{
+  mInteractionBlockers.append( blocker );
+}
+
+void QgsMapCanvas::removeInteractionBlocker( QgsMapCanvasInteractionBlocker *blocker )
+{
+  mInteractionBlockers.removeAll( blocker );
+}
+
+bool QgsMapCanvas::allowInteraction( QgsMapCanvasInteractionBlocker::Interaction interaction ) const
+{
+  for ( const QgsMapCanvasInteractionBlocker *block : mInteractionBlockers )
+  {
+    if ( block->blockCanvasInteraction( interaction ) )
+      return false;
+  }
+  return true;
+}
+
 void QgsMapCanvas::mapUpdateTimeout()
 {
   if ( mJob )

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -27,6 +27,7 @@
 #include "qgsgeometry.h"
 #include "qgscustomdrophandler.h"
 #include "qgstemporalrangeobject.h"
+#include "qgsmapcanvasinteractionblocker.h"
 
 #include <QDomDocument>
 #include <QGraphicsView>
@@ -69,6 +70,7 @@ class QgsMapCanvasAnnotationItem;
 class QgsReferencedRectangle;
 
 class QgsTemporalController;
+
 
 /**
  * \ingroup gui
@@ -126,7 +128,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     const QgsMapSettings &mapSettings() const SIP_KEEPREFERENCE;
 
     /**
-     * Sets the temporal controller, this controller will be used to
+     * Sets the temporal controller, tQgsMapCanvasInteractionBlockerhis controller will be used to
      * update the canvas temporal range.
      *
      * \since QGIS 3.14
@@ -723,6 +725,35 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     */
     const QgsDateTimeRange &temporalRange() const;
 
+    /**
+     * Installs an interaction \a blocker onto the canvas, which may prevent certain map canvas
+     * interactions from occurring.
+     *
+     * The caller retains ownership of \a blocker, and must correctly call removeInteractionBlocker()
+     * before deleting the object.
+     *
+     * \see allowInteraction()
+     * \see removeInteractionBlocker()
+     * \since QGIS 3.14
+     */
+    void installInteractionBlocker( QgsMapCanvasInteractionBlocker *blocker );
+
+    /**
+     * Removes an interaction \a blocker from the canvas.
+     *
+     * \see allowInteraction()
+     * \see installInteractionBlocker()
+     * \since QGIS 3.14
+     */
+    void removeInteractionBlocker( QgsMapCanvasInteractionBlocker *blocker );
+
+    /**
+     * Returns TRUE if the specified \a interaction is currently permitted on the canvas.
+     *
+     * \since QGIS 3.14
+     */
+    bool allowInteraction( QgsMapCanvasInteractionBlocker::Interaction interaction ) const;
+
   public slots:
 
     //! Repaints the canvas map
@@ -1149,6 +1180,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     QgsDistanceArea mDa;
     QList<double> mZoomResolutions;
+
+    QList< QgsMapCanvasInteractionBlocker * > mInteractionBlockers;
 
     /**
      * Returns the last cursor position on the canvas in geographical coordinates

--- a/src/gui/qgsmapcanvasinteractionblocker.h
+++ b/src/gui/qgsmapcanvasinteractionblocker.h
@@ -1,0 +1,47 @@
+/***************************************************************************
+                              qgsmapcanvasinteractionblocker.h
+                              --------------------------------
+  begin                : May 2020
+  copyright            : (C) 2020 by Nyall Dawson
+  email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPCANVASINTERACTIONBLOCKER_H
+#define QGSMAPCANVASINTERACTIONBLOCKER_H
+
+#include "qgis_gui.h"
+
+/**
+ * \class QgsMapCanvasInteractionBlocker
+ * \ingroup gui
+ * An interface for objects which block interactions with a QgsMapCanvas.
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsMapCanvasInteractionBlocker
+{
+  public:
+
+    enum class Interaction : int
+    {
+      MapPanOnSingleClick = 1 << 0, //!< A map pan interaction caused by a single click and release on the map canvas
+    };
+
+    virtual ~QgsMapCanvasInteractionBlocker() = default;
+
+    /**
+     * Returns TRUE if the specified \a interaction should be blocked.
+     */
+    virtual bool blockCanvasInteraction( Interaction interaction ) const = 0;
+
+};
+
+#endif // QGSMAPCANVASINTERACTIONBLOCKER_H

--- a/src/gui/qgsmapcanvasinteractionblocker.h
+++ b/src/gui/qgsmapcanvasinteractionblocker.h
@@ -30,6 +30,9 @@ class GUI_EXPORT QgsMapCanvasInteractionBlocker
 {
   public:
 
+    /**
+     * Available interactions to block.
+     */
     enum class Interaction : int
     {
       MapPanOnSingleClick = 1 << 0, //!< A map pan interaction caused by a single click and release on the map canvas

--- a/src/gui/qgsmaptoolpan.cpp
+++ b/src/gui/qgsmaptoolpan.cpp
@@ -86,16 +86,19 @@ void QgsMapToolPan::canvasReleaseEvent( QgsMapMouseEvent *e )
       }
       else // add pan to mouse cursor
       {
-        // transform the mouse pos to map coordinates
-        const QgsPointXY prevCenter = mCanvas->center();
-        QgsPointXY center = mCanvas->getCoordinateTransform()->toMapCoordinates( e->x(), e->y() );
-        mCanvas->setCenter( center );
-        mCanvas->refresh();
+        if ( mCanvas->allowInteraction( QgsMapCanvasInteractionBlocker::Interaction::MapPanOnSingleClick ) )
+        {
+          // transform the mouse pos to map coordinates
+          const QgsPointXY prevCenter = mCanvas->center();
+          QgsPointXY center = mCanvas->getCoordinateTransform()->toMapCoordinates( e->x(), e->y() );
+          mCanvas->setCenter( center );
+          mCanvas->refresh();
 
-        QgsDistanceArea da;
-        da.setEllipsoid( QgsProject::instance()->ellipsoid() );
-        da.setSourceCrs( mCanvas->mapSettings().destinationCrs(), QgsProject::instance()->transformContext() );
-        emit panDistanceBearingChanged( da.measureLine( center, prevCenter ), da.lengthUnits(), da.bearing( center, prevCenter ) * 180 / M_PI );
+          QgsDistanceArea da;
+          da.setEllipsoid( QgsProject::instance()->ellipsoid() );
+          da.setSourceCrs( mCanvas->mapSettings().destinationCrs(), QgsProject::instance()->transformContext() );
+          emit panDistanceBearingChanged( da.measureLine( center, prevCenter ), da.lengthUnits(), da.bearing( center, prevCenter ) * 180 / M_PI );
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes a UI bug where the bearing line can't be cleared, and also prevents the single-click-to-pan canvas behavior when a GPS device is connected and the canvas is set to follow the GPS location.