### PR TITLE
[processing] fix handling for stdout and file outputs in GRASS

### DIFF
--- a/python/plugins/processing/algs/grass7/Grass7Algorithm.py
+++ b/python/plugins/processing/algs/grass7/Grass7Algorithm.py
@@ -445,6 +445,9 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
             outName = out.name()
             if outName in parameters:
                 if outName in self.fileOutputs:
+                    print('ADD', outName)
+                    print('VAL', parameters[outName])
+                    print('VAL 2', self.fileOutputs[outName])
                     outputs[outName] = self.fileOutputs[outName]
                 else:
                     outputs[outName] = parameters[outName]

--- a/python/plugins/processing/algs/grass7/ext/i_cluster.py
+++ b/python/plugins/processing/algs/grass7/ext/i_cluster.py
@@ -41,6 +41,7 @@ def processCommand(alg, parameters, context, feedback):
 
     # Re-add signature files
     parameters['signaturefile'] = signatureFile
+    alg.fileOutputs['signaturefile'] = signatureFile
 
     # Export signature file
     exportSigFile(alg, group, subgroup, signatureFile)

--- a/python/plugins/processing/algs/grass7/ext/i_gensig.py
+++ b/python/plugins/processing/algs/grass7/ext/i_gensig.py
@@ -37,6 +37,7 @@ def processCommand(alg, parameters, context, feedback):
 
     # Re-add signature files
     parameters['signaturefile'] = signatureFile
+    alg.fileOutputs['signaturefile'] = signatureFile
 
     # Export signature file
     exportSigFile(alg, group, subgroup, signatureFile)

--- a/python/plugins/processing/algs/grass7/ext/i_gensigset.py
+++ b/python/plugins/processing/algs/grass7/ext/i_gensigset.py
@@ -37,6 +37,7 @@ def processCommand(alg, parameters, context, feedback):
 
     # Re-add signature files
     parameters['signaturefile'] = signatureFile
+    alg.fileOutputs['signaturefile'] = signatureFile
 
     # Export signature file
     exportSigFile(alg, group, subgroup, signatureFile, 'sigset')


### PR DESCRIPTION
## Description
Found this when working on another issue in Processing GRASS provider.

"Fake" (redirected from stdout) outputs in GRASS algorithms does not handled correctly if destination is temporary file. Algorithms just fail with Python error saying "File 'TEMPORARY_OUTPUT' does not exists". Normal file outputs works almost fine, except that in the log instead of valid output path we got also `TEMPORARY_OUTPUT` literal.

Proposed PR fixes this by maintaining mapping between output name and destination path. This mapping then used to produce results map and also for converting text outputs into HTML.