### PR TITLE
[Backport release-3_12] Fix issues when content cache is used in blocking mode

### DIFF
--- a/src/core/qgsabstractcontentcache.h
+++ b/src/core/qgsabstractcontentcache.h
@@ -447,7 +447,7 @@ class CORE_EXPORT QgsAbstractContentCache : public QgsAbstractContentCacheBase
     }
 
     /**
-     * Blocks the current thread until the \a task finishes or an arbitrary setting maximum wait to 5 seconds
+     * Blocks the current thread until the \a task finishes (or user's preset network timeout expires)
      *
      * \warning this method must NEVER be used from GUI based applications (like the main QGIS application)
      * or crashes will result. Only for use in external scripts or QGIS server.
@@ -458,8 +458,8 @@ class CORE_EXPORT QgsAbstractContentCache : public QgsAbstractContentCacheBase
      */
     bool waitForTaskFinished( QgsNetworkContentFetcherTask *task ) const
     {
-      // Second step, wait 5 seconds for task finished
-      if ( task->waitForFinished( 5000 ) )
+      // Wait up to timeout seconds for task finished
+      if ( task->waitForFinished( QgsNetworkAccessManager::timeout() ) )
       {
         // The wait did not time out
         // Third step, check status as complete

--- a/src/core/qgsabstractcontentcache.h
+++ b/src/core/qgsabstractcontentcache.h
@@ -458,15 +458,6 @@ class CORE_EXPORT QgsAbstractContentCache : public QgsAbstractContentCacheBase
      */
     bool waitForTaskFinished( QgsNetworkContentFetcherTask *task ) const
     {
-      // First step, waiting for task running
-      if ( task->status() != QgsTask::Running )
-      {
-        QEventLoop loop;
-        connect( task, &QgsNetworkContentFetcherTask::begun, &loop, &QEventLoop::quit );
-        if ( task->status() != QgsTask::Running )
-          loop.exec();
-      }
-
       // Second step, wait 5 seconds for task finished
       if ( task->waitForFinished( 5000 ) )
       {


### PR DESCRIPTION
## Description

Manually backport #35158

Fixes numerous issues when the content cache is used in blocking mode, ultimately resulting in null entries being stored in the cache for remote requests