### PR TITLE
[MESH] fix streamlines and traces renderer when vector is null

### DIFF
--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -550,6 +550,9 @@ void QgsMeshLayerRenderer::renderVectorDataset()
   if ( std::isnan( mVectorDatasetMagMinimum ) || std::isnan( mVectorDatasetMagMaximum ) )
     return; // only NODATA values
 
+  if ( !( mVectorDatasetMagMaximum > 0 ) )
+    return; //all vector are null vector
+
   std::unique_ptr<QgsMeshVectorRenderer> renderer( QgsMeshVectorRenderer::makeVectorRenderer(
         mTriangularMesh,
         mVectorDatasetValues,

--- a/src/core/mesh/qgsmeshtracerenderer.cpp
+++ b/src/core/mesh/qgsmeshtracerenderer.cpp
@@ -371,8 +371,10 @@ void QgsMeshStreamField::addTrace( QgsPointXY startPoint )
 
 void QgsMeshStreamField::addRandomTraces()
 {
-  while ( mPixelFillingCount < mMaxPixelFillingCount && !mRenderContext.renderingStopped() )
-    addRandomTrace();
+  if ( mMaximumMagnitude > 0 )
+    while ( mPixelFillingCount < mMaxPixelFillingCount && !mRenderContext.renderingStopped() )
+      addRandomTrace();
+}
 }
 
 void QgsMeshStreamField::addRandomTrace()
@@ -427,6 +429,9 @@ void QgsMeshStreamField::addTrace( QPoint startPixel )
     return;
 
   if ( !mVectorValueInterpolator )
+    return;
+
+  if ( !( mMaximumMagnitude > 0 ) )
     return;
 
   mPainter->setPen( mPen );
@@ -909,7 +914,6 @@ QgsMeshVectorStreamlineRenderer::QgsMeshVectorStreamlineRenderer(
                                   QgsUnitTypes::RenderUnit::RenderMillimeters ) ) ;
   mStreamlineField->setColor( settings.color() );
   mStreamlineField->setFilter( settings.filterMin(), settings.filterMax() );
-
 
   switch ( settings.streamLinesSettings().seedingMethod() )
   {

--- a/src/core/mesh/qgsmeshtracerenderer.cpp
+++ b/src/core/mesh/qgsmeshtracerenderer.cpp
@@ -375,7 +375,6 @@ void QgsMeshStreamField::addRandomTraces()
     while ( mPixelFillingCount < mMaxPixelFillingCount && !mRenderContext.renderingStopped() )
       addRandomTrace();
 }
-}
 
 void QgsMeshStreamField::addRandomTrace()
 {


### PR DESCRIPTION
In mesh rendering, the streamlines and the trace renderers didn't stop when vector magnitude was null.
This PR fix this issue