### PR TITLE
[ui] Make temporal controller's forward, backward and pause buttons behave as animation state toggle.

### DIFF
--- a/python/gui/auto_generated/qgstemporalcontrollerwidget.sip.in
+++ b/python/gui/auto_generated/qgstemporalcontrollerwidget.sip.in
@@ -37,6 +37,11 @@ The dock widget retains ownership of the returned object.
 %End
 
 
+  protected:
+
+    virtual void keyPressEvent( QKeyEvent *e );
+
+
 };
 
 /************************************************************************

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -142,6 +142,7 @@ void QgsTemporalControllerWidget::keyPressEvent( QKeyEvent *e )
   {
     togglePause();
   }
+  QWidget::keyPressEvent( e );
 }
 
 void QgsTemporalControllerWidget::togglePlayForward()

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -30,11 +30,11 @@ QgsTemporalControllerWidget::QgsTemporalControllerWidget( QWidget *parent )
 
   mNavigationObject = new QgsTemporalNavigationObject( this );
 
-  connect( mForwardButton, &QPushButton::clicked, mNavigationObject, &QgsTemporalNavigationObject::playForward );
-  connect( mBackButton, &QPushButton::clicked, mNavigationObject, &QgsTemporalNavigationObject::playBackward );
+  connect( mForwardButton, &QPushButton::clicked, this, &QgsTemporalControllerWidget::togglePlayForward );
+  connect( mBackButton, &QPushButton::clicked, this, &QgsTemporalControllerWidget::togglePlayBackward );
+  connect( mStopButton, &QPushButton::clicked, this, &QgsTemporalControllerWidget::togglePause );
   connect( mNextButton, &QPushButton::clicked, mNavigationObject, &QgsTemporalNavigationObject::next );
   connect( mPreviousButton, &QPushButton::clicked, mNavigationObject, &QgsTemporalNavigationObject::previous );
-  connect( mStopButton, &QPushButton::clicked, mNavigationObject, &QgsTemporalNavigationObject::pause );
   connect( mFastForwardButton, &QPushButton::clicked, mNavigationObject, &QgsTemporalNavigationObject::skipToEnd );
   connect( mRewindButton, &QPushButton::clicked, mNavigationObject, &QgsTemporalNavigationObject::rewindToStart );
   connect( mLoopingCheckBox, &QCheckBox::toggled, this, [ = ]( bool state ) { mNavigationObject->setLooping( state ); } );
@@ -134,6 +134,76 @@ QgsTemporalControllerWidget::QgsTemporalControllerWidget( QWidget *parent )
   connect( QgsProject::instance(), &QgsProject::readProject, this, &QgsTemporalControllerWidget::setWidgetStateFromProject );
   connect( QgsProject::instance(), &QgsProject::layersAdded, this, &QgsTemporalControllerWidget::onLayersAdded );
   connect( QgsProject::instance(), &QgsProject::cleared, this, &QgsTemporalControllerWidget::onProjectCleared );
+}
+
+void QgsTemporalControllerWidget::keyPressEvent( QKeyEvent *e )
+{
+  if ( mSlider->hasFocus() && e->key() == Qt::Key_Space )
+  {
+    togglePause();
+  }
+}
+
+void QgsTemporalControllerWidget::togglePlayForward()
+{
+  mPlayingForward = true;
+
+  if ( mNavigationObject->animationState() != QgsTemporalNavigationObject::Forward )
+  {
+    mStopButton->setChecked( false );
+    mBackButton->setChecked( false );
+    mForwardButton->setChecked( true );
+    mNavigationObject->playForward();
+  }
+  else
+  {
+    mBackButton->setChecked( true );
+    mForwardButton->setChecked( false );
+    mNavigationObject->pause();
+  }
+}
+
+void QgsTemporalControllerWidget::togglePlayBackward()
+{
+  mPlayingForward = false;
+
+  if ( mNavigationObject->animationState() != QgsTemporalNavigationObject::Reverse )
+  {
+    mStopButton->setChecked( false );
+    mBackButton->setChecked( true );
+    mForwardButton->setChecked( false );
+    mNavigationObject->playBackward();
+  }
+  else
+  {
+    mBackButton->setChecked( true );
+    mBackButton->setChecked( false );
+    mNavigationObject->pause();
+  }
+}
+
+void QgsTemporalControllerWidget::togglePause()
+{
+  if ( mNavigationObject->animationState() != QgsTemporalNavigationObject::Idle )
+  {
+    mStopButton->setChecked( true );
+    mBackButton->setChecked( false );
+    mForwardButton->setChecked( false );
+    mNavigationObject->pause();
+  }
+  else
+  {
+    mBackButton->setChecked( mPlayingForward ? false : true );
+    mForwardButton->setChecked( mPlayingForward ? false : true );
+    if ( mPlayingForward )
+    {
+      mNavigationObject->playForward();
+    }
+    else
+    {
+      mNavigationObject->playBackward();
+    }
+  }
 }
 
 void QgsTemporalControllerWidget::updateTemporalExtent()

--- a/src/gui/qgstemporalcontrollerwidget.h
+++ b/src/gui/qgstemporalcontrollerwidget.h
@@ -63,6 +63,10 @@ class GUI_EXPORT QgsTemporalControllerWidget : public QgsPanelWidget, private Ui
 
 #endif
 
+  protected:
+
+    void keyPressEvent( QKeyEvent *e ) override;
+
   private:
 
     /**
@@ -81,6 +85,11 @@ class GUI_EXPORT QgsTemporalControllerWidget : public QgsPanelWidget, private Ui
     int mBlockSettingUpdates = 0;
 
     bool mHasTemporalLayersLoaded = false;
+
+    void togglePlayForward();
+    void togglePlayBackward();
+    void togglePause();
+    bool mPlayingForward = true;
 
   private slots:
 


### PR DESCRIPTION
This PR improves the animation UI/UX of the temporal controller panel by having the play forward, play backward, and pause buttons act as toggles. I.e., if you hit play while the temporal animation is playing, it'll pause the animation, and vice versa. 

It's quite useful to be able to quickly toggle the animation state (via keyboard or mouse).

The PR also makes a space bar key press event starts / pauses the animation state when the user has the slider focused. This means users can pause the animation, move through temporal frames via the arrow left and right keys, and resume the animation easily:

![Peek 2020-05-22 16-14](https://user-images.githubusercontent.com/1728657/82652292-971b9600-9c47-11ea-9652-782ee8cb99ab.gif)

