### PR TITLE
[Backport release-3_10] Fix Task manager waitforfinished

### DIFF
--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -313,6 +313,12 @@ class CORE_EXPORT QgsTask : public QObject
      */
     QMutex mNotFinishedMutex;
 
+    /**
+     * This semaphore remains locked from task creation until the task actually start,
+     * it's used in waitForFinished to actually wait the task to be started.
+     */
+    QSemaphore mNotStartedMutex;
+
     //! Progress of this (parent) task alone
     double mProgress = 0.0;
     //! Overall progress of this task and all subtasks

--- a/tests/src/python/test_qgslayoutlegend.py
+++ b/tests/src/python/test_qgslayoutlegend.py
@@ -442,10 +442,6 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
 
         counterTask = point_layer.countSymbolFeatures()
         counterTask.waitForFinished()
-        TM = QgsApplication.taskManager()
-        actask = TM.activeTasks()
-        print(TM.tasks(), actask)
-        count = actask[0]
         legend.model().refreshLayerLegend(legendlayer)
         legendnodes = legend.model().layerLegendNodes(legendlayer)
         legendnodes[0].setUserLabel('[% @symbol_id %]')
@@ -454,7 +450,6 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         label1 = legendnodes[0].evaluateLabel()
         label2 = legendnodes[1].evaluateLabel()
         label3 = legendnodes[2].evaluateLabel()
-        count.waitForFinished()
         self.assertEqual(label1, '0')
         #self.assertEqual(label2, '5')
         #self.assertEqual(label3, '12')
@@ -509,7 +504,7 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         group = legend.model().rootGroup().addGroup("Group [% 1 + 5 %] [% @layout_name %]")
         layer_tree_layer = group.addLayer(point_layer)
         counterTask = point_layer.countSymbolFeatures()
-        counterTask.waitForFinished() # does this even work?
+        counterTask.waitForFinished()
         layer_tree_layer.setCustomProperty("legend/title-label", 'bbbb [% 1+2 %] xx [% @layout_name %] [% @layer_name %]')
         QgsMapLayerLegendUtils.setLegendNodeUserLabel(layer_tree_layer, 0, 'xxxx')
         legend.model().refreshLayerLegend(layer_tree_layer)
@@ -521,11 +516,6 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         legend.setLinkedMap(map)
         legend.updateLegend()
         print(layer_tree_layer.labelExpression())
-        TM = QgsApplication.taskManager()
-        actask = TM.activeTasks()
-        print(TM.tasks(), actask)
-        count = actask[0]
-        count.waitForFinished()
         map.setExtent(QgsRectangle(-102.51, 41.16, -102.36, 41.30))
         checker = QgsLayoutChecker(
             'composer_legend_symbol_expression', layout)


### PR DESCRIPTION
## Description

Manually backport #32838 needed for #36624

This PR fixes Task::waitForFinished methods. The method doesn't wait the task to be finished if the task has not yet being started (because the task wait to start if there is no thread available for instance).

It could lead to crashes (If you access some shared memory data believing the task has finished to run)