### PR TITLE
[Backport release-3_10] oracle identity field #33683 #34546

### DIFF
--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -1182,7 +1182,43 @@ bool QgsOracleProvider::isValid() const
 
 QVariant QgsOracleProvider::defaultValue( int fieldId ) const
 {
-  return mDefaultValues.value( fieldId, QVariant() );
+  QString defVal = mDefaultValues.value( fieldId, QString() ).toString();
+
+  if ( providerProperty( EvaluateDefaultValues, false ).toBool() && !defVal.isEmpty() )
+  {
+    QgsField fld = field( fieldId );
+    return evaluateDefaultExpression( defVal, fld.type() );
+  }
+
+  return defVal;
+}
+
+QString QgsOracleProvider::defaultValueClause( int fieldId ) const
+{
+  QString defVal = mDefaultValues.value( fieldId, QString() ).toString();
+
+  if ( !providerProperty( EvaluateDefaultValues, false ).toBool() && !defVal.isEmpty() )
+  {
+    return defVal;
+  }
+
+  return QString();
+}
+
+
+bool QgsOracleProvider::skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint constraint, const QVariant &value ) const
+{
+  Q_UNUSED( constraint );
+  if ( providerProperty( EvaluateDefaultValues, false ).toBool() )
+  {
+    return !mDefaultValues.value( fieldIndex ).toString().isEmpty();
+  }
+  else
+  {
+    // stricter check - if we are evaluating default values only on commit then we can only bypass the check
+    // if the attribute values matches the original default clause
+    return mDefaultValues.value( fieldIndex ) == value.toString() && !value.isNull();
+  }
 }
 
 QVariant QgsOracleProvider::evaluateDefaultExpression( const QString &value, const QVariant::Type &fieldType ) const
@@ -1230,7 +1266,7 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flag
 
   try
   {
-    QSqlQuery ins( db ), getfid( db );
+    QSqlQuery ins( db ), getfid( db ), identitytype( db );
 
     if ( !conn->begin( db ) )
     {
@@ -1244,12 +1280,30 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flag
 
     QStringList defaultValues;
     QList<int> fieldId;
+    QList<int> alwaysGenerated;
 
     if ( !mGeometryColumn.isNull() )
     {
       insert += quotedIdentifier( mGeometryColumn );
       values += '?';
       delim = ',';
+    }
+    QString sql = QStringLiteral( "SELECT a.column_name "
+                                  "FROM all_tab_identity_cols a "
+                                  "WHERE a.owner = '%1' "
+                                  "AND a.table_name = '%2' "
+                                  "AND a.generation_type = 'ALWAYS'" ).arg( mOwnerName ).arg( mTableName );
+    identitytype.prepare( sql );
+
+    if ( identitytype.exec() )
+    {
+      while ( identitytype.next() )
+      {
+        if ( flist[0].fields().names().contains( identitytype.value( 0 ).toString() ) )
+        {
+          alwaysGenerated.append( flist[0].fields().indexOf( identitytype.value( 0 ).toString() ) );
+        }
+      }
     }
 
     if ( mPrimaryKeyType == PktInt || mPrimaryKeyType == PktFidMap )
@@ -1260,8 +1314,10 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flag
       for ( int idx : constMPrimaryKeyAttrs )
       {
         QgsField fld = field( idx );
-        insert += delim + quotedIdentifier( fld.name() );
         keys += kdelim + quotedIdentifier( fld.name() );
+        if ( alwaysGenerated.contains( idx ) )
+          continue;
+        insert += delim + quotedIdentifier( fld.name() );
         values += delim + '?';
         delim = ',';
         kdelim = ',';
@@ -1282,6 +1338,8 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flag
     for ( int idx = 0; idx < std::min( attributevec.size(), mAttributeFields.size() ); ++idx )
     {
       QVariant v = attributevec[idx];
+      if ( alwaysGenerated.contains( idx ) )
+        continue;
       if ( !v.isValid() )
         continue;
 

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -139,6 +139,14 @@ QgsOracleProvider::QgsOracleProvider( QString const &uri, const ProviderOptions 
 
   mLayerExtent.setMinimal();
 
+  // get always generated key
+  if ( !determineAlwaysGeneratedKeys() )
+  {
+    mValid = false;
+    disconnectDb();
+    return;
+  }
+
   // set the primary key
   if ( !determinePrimaryKey() )
   {
@@ -1008,6 +1016,46 @@ bool QgsOracleProvider::determinePrimaryKey()
   return mValid;
 }
 
+bool QgsOracleProvider::determineAlwaysGeneratedKeys()
+{
+  if ( !loadFields() )
+  {
+    return false;
+  }
+
+  // check to see if there is an unique index on the relation, which
+  // can be used as a key into the table. Primary keys are always
+  // unique indices, so we catch them as well.
+  QgsOracleConn *conn = connectionRO();
+  QSqlQuery qry( *conn );
+
+  QString sql = QStringLiteral( "SELECT a.column_name "
+                                "FROM all_tab_identity_cols a "
+                                "WHERE a.owner = '%1' "
+                                "AND a.table_name = '%2' "
+                                "AND a.generation_type = 'ALWAYS'" ).arg( mOwnerName ).arg( mTableName );
+
+  if ( exec( qry, sql, QVariantList() ) )
+  {
+    while ( qry.next() )
+    {
+      if ( mAttributeFields.names().contains( qry.value( 0 ).toString() ) )
+      {
+        mAlwaysGeneratedKeyAttrs.append( mAttributeFields.indexOf( qry.value( 0 ).toString() ) );
+      }
+    }
+    mValid = true;
+  }
+  else
+  {
+    QgsMessageLog::logMessage( tr( "Unable to execute the query.\nThe error message from the database was:\n%1.\nSQL: %2" )
+                               .arg( qry.lastError().text() )
+                               .arg( qry.lastQuery() ), tr( "Oracle" ) );
+    mValid = false;
+  }
+  return mValid;
+}
+
 bool QgsOracleProvider::uniqueData( QString query, QString colName )
 {
   Q_UNUSED( query )
@@ -1280,34 +1328,12 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flag
 
     QStringList defaultValues;
     QList<int> fieldId;
-    QList<int> alwaysGenerated;
 
     if ( !mGeometryColumn.isNull() )
     {
       insert += quotedIdentifier( mGeometryColumn );
       values += '?';
       delim = ',';
-    }
-    QString sql = QStringLiteral( "SELECT a.column_name "
-                                  "FROM all_tab_identity_cols a "
-                                  "WHERE a.owner = '%1' "
-                                  "AND a.table_name = '%2' "
-                                  "AND a.generation_type = 'ALWAYS'" ).arg( mOwnerName ).arg( mTableName );
-    identitytype.prepare( sql );
-
-    if ( exec( identitytype, sql, QVariantList() ) )
-    {
-      while ( identitytype.next() )
-      {
-        if ( flist[0].fields().names().contains( identitytype.value( 0 ).toString() ) )
-        {
-          alwaysGenerated.append( flist[0].fields().indexOf( identitytype.value( 0 ).toString() ) );
-        }
-      }
-    }
-    else
-    {
-      throw OracleException( tr( "Could not check if table has identity field" ), identitytype );
     }
 
     if ( mPrimaryKeyType == PktInt || mPrimaryKeyType == PktFidMap )
@@ -1319,7 +1345,7 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flag
       {
         QgsField fld = field( idx );
         keys += kdelim + quotedIdentifier( fld.name() );
-        if ( alwaysGenerated.contains( idx ) )
+        if ( mAlwaysGeneratedKeyAttrs.contains( idx ) )
           continue;
         insert += delim + quotedIdentifier( fld.name() );
         values += delim + '?';
@@ -1342,7 +1368,7 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flag
     for ( int idx = 0; idx < std::min( attributevec.size(), mAttributeFields.size() ); ++idx )
     {
       QVariant v = attributevec[idx];
-      if ( alwaysGenerated.contains( idx ) )
+      if ( mAlwaysGeneratedKeyAttrs.contains( idx ) )
         continue;
       if ( !v.isValid() )
         continue;

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -1295,7 +1295,7 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flag
                                   "AND a.generation_type = 'ALWAYS'" ).arg( mOwnerName ).arg( mTableName );
     identitytype.prepare( sql );
 
-    if ( identitytype.exec() )
+    if ( exec( identitytype, sql, QVariantList() ) )
     {
       while ( identitytype.next() )
       {
@@ -1304,6 +1304,10 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flag
           alwaysGenerated.append( flist[0].fields().indexOf( identitytype.value( 0 ).toString() ) );
         }
       }
+    }
+    else
+    {
+      throw OracleException( tr( "Could not check if table has identity field" ), identitytype );
     }
 
     if ( mPrimaryKeyType == PktInt || mPrimaryKeyType == PktFidMap )

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -1023,28 +1023,43 @@ bool QgsOracleProvider::determineAlwaysGeneratedKeys()
     return false;
   }
 
+  mValid = true;
   // check to see if there is an unique index on the relation, which
   // can be used as a key into the table. Primary keys are always
   // unique indices, so we catch them as well.
   QgsOracleConn *conn = connectionRO();
   QSqlQuery qry( *conn );
-
-  QString sql = QStringLiteral( "SELECT a.column_name "
-                                "FROM all_tab_identity_cols a "
-                                "WHERE a.owner = '%1' "
-                                "AND a.table_name = '%2' "
-                                "AND a.generation_type = 'ALWAYS'" ).arg( mOwnerName ).arg( mTableName );
-
-  if ( exec( qry, sql, QVariantList() ) )
+  QString sql = QStringLiteral( "SELECT VERSION FROM PRODUCT_COMPONENT_VERSION" );
+  if ( exec( qry, sql, QVariantList() ) && qry.next() )
   {
-    while ( qry.next() )
+    // Identity type is a feature since Oracle 12 version, otherwise all_tab_identity_cols table doesn't exist
+    if ( qry.value( 0 ).toString().split( '.' ).at( 0 ).toInt() >= 12 )
     {
-      if ( mAttributeFields.names().contains( qry.value( 0 ).toString() ) )
+      QgsDebugMsg( QStringLiteral( "Oracle version : %1" ).arg( qry.value( 0 ).toString().split( '.' ).at( 0 ) ) );
+      QString sql = QStringLiteral( "SELECT a.column_name "
+                                    "FROM all_tab_identity_cols a "
+                                    "WHERE a.owner = '%1' "
+                                    "AND a.table_name = '%2' "
+                                    "AND a.generation_type = 'ALWAYS'" ).arg( mOwnerName ).arg( mTableName );
+
+      if ( exec( qry, sql, QVariantList() ) )
       {
-        mAlwaysGeneratedKeyAttrs.append( mAttributeFields.indexOf( qry.value( 0 ).toString() ) );
+        while ( qry.next() )
+        {
+          if ( mAttributeFields.names().contains( qry.value( 0 ).toString() ) )
+          {
+            mAlwaysGeneratedKeyAttrs.append( mAttributeFields.indexOf( qry.value( 0 ).toString() ) );
+          }
+        }
+      }
+      else
+      {
+        QgsMessageLog::logMessage( tr( "Unable to execute the query.\nThe error message from the database was:\n%1.\nSQL: %2" )
+                                   .arg( qry.lastError().text() )
+                                   .arg( qry.lastQuery() ), tr( "Oracle" ) );
+        mValid = false;
       }
     }
-    mValid = true;
   }
   else
   {

--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -127,6 +127,11 @@ class QgsOracleProvider : public QgsVectorDataProvider
      */
     bool determinePrimaryKey();
 
+    /**
+     * Determine the always generated identity fields
+     */
+    bool determineAlwaysGeneratedKeys();
+
     QgsFields fields() const override;
     QString dataComment() const override;
 
@@ -250,6 +255,11 @@ class QgsOracleProvider : public QgsVectorDataProvider
      */
     QList<int> mPrimaryKeyAttrs;
     QString mPrimaryKeyDefault;
+
+    /**
+     * List of always generated key attributes
+     */
+    QList<int> mAlwaysGeneratedKeyAttrs;
 
     QString mGeometryColumn;           //!< Name of the geometry column
     mutable QgsRectangle mLayerExtent; //!< Rectangle that contains the extent (bounding box) of the layer

--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -142,6 +142,8 @@ class QgsOracleProvider : public QgsVectorDataProvider
     QgsAttributeList pkAttributeIndexes() const override { return mPrimaryKeyAttrs; }
     QVariant defaultValue( QString fieldName, QString tableName = QString(), QString schemaName = QString() );
     QVariant defaultValue( int fieldId ) const override;
+    QString defaultValueClause( int fieldId ) const override;
+    bool skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint constraint, const QVariant &value = QVariant() ) const override;
     bool addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flags flags = nullptr ) override;
     bool deleteFeatures( const QgsFeatureIds &id ) override;
     bool addAttributes( const QList<QgsField> &attributes ) override;

--- a/tests/src/python/test_provider_oracle.py
+++ b/tests/src/python/test_provider_oracle.py
@@ -389,7 +389,7 @@ class TestPyQgsOracleProvider(unittest.TestCase, ProviderTestCase):
         vl.rollBack()
 
     def testTransactionTuple(self):
-        # create a vector layer based on postgres
+        # create a vector layer based on oracle
         vl = QgsVectorLayer(
             self.dbconn + ' sslmode=disable key=\'pk\' srid=4326 type=POLYGON table="QGIS"."SOME_POLY_DATA" (GEOM) sql=',
             'test', 'oracle')
@@ -435,6 +435,25 @@ class TestPyQgsOracleProvider(unittest.TestCase, ProviderTestCase):
 
         feature = vl.getFeature(2)
         self.assertTrue(feature.isValid())
+
+    def testIdentityCommit(self):
+        # create a vector layer based on oracle
+        vl = QgsVectorLayer(
+            self.dbconn + ' sslmode=disable key=\'pk\' srid=4326 type=POINT table="QGIS"."POINT_DATA_IDENTITY" (GEOM) sql=',
+            'test', 'oracle')
+        self.assertTrue(vl.isValid())
+
+        features = [f for f in vl.getFeatures()]
+
+        # add a new feature
+        newf = QgsFeature(features[0].fields())
+        success, featureAdded = vl.dataProvider().addFeatures([newf])
+        self.assertTrue(success)
+
+        # clean up
+        features = [f for f in vl.getFeatures()]
+        vl.dataProvider().deleteFeatures([features[-1].id()])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/testdata/provider/testdata_oracle.sql
+++ b/tests/testdata/provider/testdata_oracle.sql
@@ -70,13 +70,6 @@ INSERT INTO QGIS.DATE_TIMES ("id", "date_field", "datetime_field" ) VALUES (1, D
 
 CREATE TABLE QGIS.POINT_DATA_IDENTITY ( "pk" NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, GEOM SDO_GEOMETRY);
 INSERT INTO QGIS.POINT_DATA_IDENTITY (GEOM)
- SELECT SDO_GEOMETRY( 2001,4326,SDO_POINT_TYPE(1, 2, NULL), NULL, NULL) from dual
-  UNION ALL SELECT SDO_GEOMETRY( 3001,4326,SDO_POINT_TYPE(1, 2, 3), NULL, NULL) from dual
-  UNION ALL SELECT SDO_GEOMETRY( 3005,4326,NULL, sdo_elem_info_array (1,1,1, 4,1,1), sdo_ordinate_array (1,2,3, 4,5,6)) from dual
-  UNION ALL SELECT SDO_GEOMETRY( 2005,4326,NULL, sdo_elem_info_array (1,1,1, 3,1,1), sdo_ordinate_array (1,2, 3,4)) from dual
-  UNION ALL SELECT SDO_GEOMETRY( 3005,4326,NULL, sdo_elem_info_array (1,1,2), sdo_ordinate_array (1,2,3, 4,5,6)) from dual
-  UNION ALL SELECT SDO_GEOMETRY( 2001,4326,NULL, sdo_elem_info_array (1,1,1), sdo_ordinate_array (1,2)) from dual
-  UNION ALL SELECT SDO_GEOMETRY( 2001,4326, SDO_POINT_TYPE(3, 4, NULL), NULL, NULL) from dual
-  UNION ALL SELECT SDO_GEOMETRY( 2001,4326,NULL, sdo_elem_info_array (1,1,1), sdo_ordinate_array (5,6)) from dual;
+ SELECT SDO_GEOMETRY( 2001,4326,SDO_POINT_TYPE(1, 2, NULL), NULL, NULL) from dual;
 
 COMMIT;

--- a/tests/testdata/provider/testdata_oracle.sql
+++ b/tests/testdata/provider/testdata_oracle.sql
@@ -68,4 +68,15 @@ CREATE TABLE QGIS.DATE_TIMES ( "id" INTEGER PRIMARY KEY, "date_field" DATE, "dat
 
 INSERT INTO QGIS.DATE_TIMES ("id", "date_field", "datetime_field" ) VALUES (1, DATE '2004-03-04', TIMESTAMP '2004-03-04 13:41:52' );
 
+CREATE TABLE QGIS.POINT_DATA_IDENTITY ( "pk" NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, GEOM SDO_GEOMETRY);
+INSERT INTO QGIS.POINT_DATA_IDENTITY (GEOM)
+ SELECT SDO_GEOMETRY( 2001,4326,SDO_POINT_TYPE(1, 2, NULL), NULL, NULL) from dual
+  UNION ALL SELECT SDO_GEOMETRY( 3001,4326,SDO_POINT_TYPE(1, 2, 3), NULL, NULL) from dual
+  UNION ALL SELECT SDO_GEOMETRY( 3005,4326,NULL, sdo_elem_info_array (1,1,1, 4,1,1), sdo_ordinate_array (1,2,3, 4,5,6)) from dual
+  UNION ALL SELECT SDO_GEOMETRY( 2005,4326,NULL, sdo_elem_info_array (1,1,1, 3,1,1), sdo_ordinate_array (1,2, 3,4)) from dual
+  UNION ALL SELECT SDO_GEOMETRY( 3005,4326,NULL, sdo_elem_info_array (1,1,2), sdo_ordinate_array (1,2,3, 4,5,6)) from dual
+  UNION ALL SELECT SDO_GEOMETRY( 2001,4326,NULL, sdo_elem_info_array (1,1,1), sdo_ordinate_array (1,2)) from dual
+  UNION ALL SELECT SDO_GEOMETRY( 2001,4326, SDO_POINT_TYPE(3, 4, NULL), NULL, NULL) from dual
+  UNION ALL SELECT SDO_GEOMETRY( 2001,4326,NULL, sdo_elem_info_array (1,1,1), sdo_ordinate_array (5,6)) from dual;
+
 COMMIT;


### PR DESCRIPTION
## Description

It is a backport of PR #33683 and #34546 (that fixes an exception in the previous one). It fixes the use of identity field in Oracle DB.

The first attempt to backport #33683 didn't work due to a merge conflict (see #34260 ) so I rebase it.