### PR TITLE
Apply proxy settings both in ogr and gdal providers

### DIFF
--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -160,6 +160,10 @@ QgsGdalProvider::QgsGdalProvider( const QString &uri, const ProviderOptions &opt
 
   QgsGdalProviderBase::registerGdalDrivers();
 
+#ifndef QT_NO_NETWORKPROXY
+  QgsGdalUtils::setupProxy();
+#endif
+
   if ( !CPLGetConfigOption( "AAIGRID_DATATYPE", nullptr ) )
   {
     // GDAL tends to open AAIGrid as Float32 which results in lost precision

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -19,6 +19,7 @@ email                : sherman at mrcc.com
 ///@cond PRIVATE
 
 #include "qgscplerrorhandler.h"
+#include "qgsgdalutils.h"
 #include "qgsogrfeatureiterator.h"
 #include "qgslogger.h"
 #include "qgsmessagelog.h"
@@ -493,7 +494,7 @@ QgsOgrProvider::QgsOgrProvider( QString const &uri, const ProviderOptions &optio
   CPLSetConfigOption( "SHAPE_ENCODING", "" );
 
 #ifndef QT_NO_NETWORKPROXY
-  setupProxy();
+  QgsGdalUtils::setupProxy();
 #endif
 
   // make connection to the data source
@@ -2604,56 +2605,6 @@ bool QgsOgrProvider::doInitialActionsForEdition()
 
   return true;
 }
-
-#ifndef QT_NO_NETWORKPROXY
-void QgsOgrProvider::setupProxy()
-{
-  // Check proxy configuration, they are application level but
-  // instead of adding an API and complex signal/slot connections
-  // given the limited cost of checking them on every provider instantiation
-  // we can do it here so that new settings are applied whenever a new layer
-  // is created.
-  QgsSettings settings;
-  // Check that proxy is enabled
-  if ( settings.value( QStringLiteral( "proxy/proxyEnabled" ), false ).toBool() )
-  {
-    // Get the first configured proxy
-    QList<QNetworkProxy> proxyes( QgsNetworkAccessManager::instance()->proxyFactory()->queryProxy( ) );
-    if ( ! proxyes.isEmpty() )
-    {
-      QNetworkProxy proxy( proxyes.first() );
-      // TODO/FIXME: check excludes (the GDAL config options are global, we need a per-connection config option)
-      //QStringList excludes;
-      //excludes = settings.value( QStringLiteral( "proxy/proxyExcludedUrls" ), "" ).toStringList();
-
-      QString proxyHost( proxy.hostName() );
-      qint16 proxyPort( proxy.port() );
-
-      QString proxyUser( proxy.user() );
-      QString proxyPassword( proxy.password() );
-
-      if ( ! proxyHost.isEmpty() )
-      {
-        QString connection( proxyHost );
-        if ( proxyPort )
-        {
-          connection += ':' +  QString::number( proxyPort );
-        }
-        CPLSetConfigOption( "GDAL_HTTP_PROXY", connection.toUtf8() );
-        if ( !  proxyUser.isEmpty( ) )
-        {
-          QString credentials( proxyUser );
-          if ( !  proxyPassword.isEmpty( ) )
-          {
-            credentials += ':' + proxyPassword;
-          }
-          CPLSetConfigOption( "GDAL_HTTP_PROXYUSERPWD", credentials.toUtf8() );
-        }
-      }
-    }
-  }
-}
-#endif
 
 QgsVectorDataProvider::Capabilities QgsOgrProvider::capabilities() const
 {

--- a/src/core/providers/ogr/qgsogrprovider.h
+++ b/src/core/providers/ogr/qgsogrprovider.h
@@ -321,10 +321,6 @@ class QgsOgrProvider final: public QgsVectorDataProvider
 
     bool addAttributeOGRLevel( const QgsField &field, bool &ignoreErrorOut );
 
-#ifndef QT_NO_NETWORKPROXY
-    void setupProxy();
-#endif
-
     QgsOgrTransaction *mTransaction = nullptr;
 
     void setTransaction( QgsTransaction *transaction ) override;

--- a/src/core/qgsgdalutils.cpp
+++ b/src/core/qgsgdalutils.cpp
@@ -503,10 +503,10 @@ void QgsGdalUtils::setupProxy()
   if ( settings.value( QStringLiteral( "proxy/proxyEnabled" ), false ).toBool() )
   {
     // Get the first configured proxy
-    QList<QNetworkProxy> proxyes( QgsNetworkAccessManager::instance()->proxyFactory()->queryProxy( ) );
-    if ( ! proxyes.isEmpty() )
+    QList<QNetworkProxy> proxies( QgsNetworkAccessManager::instance()->proxyFactory()->queryProxy( ) );
+    if ( ! proxies.isEmpty() )
     {
-      QNetworkProxy proxy( proxyes.first() );
+      QNetworkProxy proxy( proxies.first() );
       // TODO/FIXME: check excludes (the GDAL config options are global, we need a per-connection config option)
       //QStringList excludes;
       //excludes = settings.value( QStringLiteral( "proxy/proxyExcludedUrls" ), "" ).toStringList();

--- a/src/core/qgsgdalutils.h
+++ b/src/core/qgsgdalutils.h
@@ -116,6 +116,11 @@ class CORE_EXPORT QgsGdalUtils
       double dfMaxError,
       const GDALWarpOptions *psOptionsIn );
 
+#ifndef QT_NO_NETWORKPROXY
+    //! Sets the gdal proxy variables
+    static void setupProxy();
+#endif
+
     friend class TestQgsGdalUtils;
 };
 


### PR DESCRIPTION
Currently, the OGR provider reads the QGIS proxy settings and applies it to GDAL. However the GDAL provider does not yet do it.
This PR moves the function which sets the GDAL proxy to QgsGdalUtils and calls it from both OGR and GDAL providers.
