### PR TITLE
[temporal] Make the temporal controller's set range button more useable

### DIFF
--- a/src/gui/qgstemporalcontrollerwidget.h
+++ b/src/gui/qgstemporalcontrollerwidget.h
@@ -25,6 +25,7 @@
 #include "qgstemporalnavigationobject.h"
 
 class QgsMapLayer;
+class QgsMapLayerModel;
 class QgsTemporalNavigationObject;
 class QgsTemporalController;
 class QgsInterval;
@@ -69,17 +70,7 @@ class GUI_EXPORT QgsTemporalControllerWidget : public QgsPanelWidget, private Ui
 
   private:
 
-    /**
-     * Updates the controller widget navigation buttons enabled status.
-     */
-    void updateButtonsEnable( bool enabled );
-
-    /**
-     * Sets the enable status of the widget date time inputs.
-     **/
-    void setDateInputsEnable( bool enabled );
-
-    //! Handles all non gui navigation logic
+    //! Handles all non-GUI navigation logic
     QgsTemporalNavigationObject *mNavigationObject = nullptr;
 
     int mBlockSettingUpdates = 0;
@@ -91,42 +82,61 @@ class GUI_EXPORT QgsTemporalControllerWidget : public QgsPanelWidget, private Ui
     void togglePause();
     bool mPlayingForward = true;
 
+    std::unique_ptr< QMenu > mRangeMenu;
+    QAction *mRangeSetToProjectAction = nullptr;
+    QAction *mRangeSetToAllLayersAction = nullptr;
+
+    std::unique_ptr< QMenu > mRangeLayersSubMenu;
+    QgsMapLayerModel *mMapLayerModel = nullptr;
+
   private slots:
 
     /**
      * Handles the action to be done when the
      * time slider value has changed.
-     **/
+     */
     void timeSlider_valueChanged( int value );
 
     /**
      * Loads a temporal map settings dialog.
-     **/
+     */
     void settings_clicked();
 
     /**
-     * Updates the controller dates time inputs.
+     * Set date widgets to match the given \a range.
+     */
+    void setDates( const QgsDateTimeRange &range );
+
+    /**
+     * Updates the controller dates time inputs using the full range of all layers.
+     */
+    void setDatesToAllLayers();
+
+    /**
+     * Updates the controller dates time inputs from the preset project range. If
+     * that isn't defined, the range will fallback to the full range of all
+     * layers.
      */
     void setDatesToProjectTime();
 
     /**
      * Updates the value of the slider
-     **/
+     */
     void updateSlider( const QgsDateTimeRange &range );
 
     /**
      * Updates the current range label
-     **/
+     */
     void updateRangeLabel( const QgsDateTimeRange &range );
 
     /**
      * Updates the navigation temporal extent.
-     **/
+     */
     void updateTemporalExtent();
 
     /**
      * Updates the navigation frame duration.
-     **/
+     */
     void updateFrameDuration();
 
     void setWidgetStateFromProject();
@@ -141,7 +151,13 @@ class GUI_EXPORT QgsTemporalControllerWidget : public QgsPanelWidget, private Ui
 
     void startEndDateTime_changed();
     void fixedRangeStartEndDateTime_changed();
-    void mSetToProjectTimeButton_clicked();
+
+    void saveRangeToProject();
+
+    void aboutToShowRangeMenu();
+
+    void mRangeSetToProjectAction_triggered();
+    void mRangeSetToAllLayersAction_triggered();
 };
 
 #endif // QGSTEMPORALCONTROLLERWIDGET_H

--- a/src/ui/qgstemporalcontrollerwidgetbase.ui
+++ b/src/ui/qgstemporalcontrollerwidgetbase.ui
@@ -216,7 +216,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QToolButton" name="mFixedRangeSetToProjectTimeButton">
+          <widget class="QToolButton" name="mFixedRangeSetRangeButton">
            <property name="text">
             <string/>
            </property>
@@ -441,7 +441,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QToolButton" name="mSetToProjectTimeButton">
+          <widget class="QToolButton" name="mSetRangeButton">
            <property name="text">
             <string/>
            </property>


### PR DESCRIPTION
## Description

OK, this PR is the last temporal controller UI/UX corner I felt wasn't working super well: the set range to project "refresh" button. 

This PR improves the experience by splitting the "full [project layers] range" vs. the "preset project range" and offering those through a tool button drop down menu:
![image](https://user-images.githubusercontent.com/1728657/82720454-f4fabd00-9cdd-11ea-95d7-33cfa4f8bcec.png)
_Ignore the auto raised temporal mode buttons, this was just a test._
