### PR TITLE
Allow QgsDateTimeEdit to support dates since Jan 1st 1 CE (instead of 100 CE) and avoid QDate and QDateTime field value triple conversion

### DIFF
--- a/src/core/fieldformatter/qgsdatetimefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsdatetimefieldformatter.cpp
@@ -51,13 +51,20 @@ QString QgsDateTimeFieldFormatter::representValue( QgsVectorLayer *layer, int fi
   const QString displayFormat = config.value( QStringLiteral( "display_format" ), defaultFormat( field.type() ) ).toString();
 
   QDateTime date;
-  if ( fieldIsoFormat )
+  if ( static_cast<QMetaType::Type>( value.type() ) == QMetaType::QDate || static_cast<QMetaType::Type>( value.type() ) == QMetaType::QDateTime )
   {
-    date = QDateTime::fromString( value.toString(), Qt::ISODate );
+    date = value.toDateTime();
   }
   else
   {
-    date = QDateTime::fromString( value.toString(), fieldFormat );
+    if ( fieldIsoFormat )
+    {
+      date = QDateTime::fromString( value.toString(), Qt::ISODate );
+    }
+    else
+    {
+      date = QDateTime::fromString( value.toString(), fieldFormat );
+    }
   }
 
   if ( date.isValid() )

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -188,19 +188,17 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
     void resetBeforeChange( int delta );
 
     /**
-     * Set the lowest Date that can be displayed with the Qt::ISODate format
-     *  - uses QDateTimeEdit::setMinimumDateTime (since Qt 4.4)
+     * Set the lowest Date that can be stored in a Shapefile or Geopackage Date field
+     *  - uses QDateTimeEdit::setDateTimeRange (since Qt 4.4)
      * \note
      *  - QDate and QDateTime does not support minus years for the Qt::ISODate format
      *  -> returns empty (toString) or invalid (fromString) values
-     *  - QDateTimeEdit::setMinimumDateTime does not support dates < '0100-01-01'
-     *  -> it is not for us to wonder why [defined in qdatetimeparser_p.h]
     * \note not available in Python bindings
     * \since QGIS 3.0
     */
     void setMinimumEditDateTime()
     {
-      setMinimumDateTime( QDateTime::fromString( QStringLiteral( "0100-01-01" ), Qt::ISODate ) );
+      setDateTimeRange( QDateTime( QDate( 1, 1, 1 ) ), maximumDateTime() );
     }
 
     friend class TestQgsDateTimeEdit;

--- a/tests/src/gui/testqgsdatetimeedit.cpp
+++ b/tests/src/gui/testqgsdatetimeedit.cpp
@@ -40,6 +40,7 @@ class TestQgsDateTimeEdit: public QObject
     std::unique_ptr<QgsDateTimeEditWrapper> widget3; // For field 2
     std::unique_ptr<QgsDateTimeEditWrapper> widget4; // For field 3
     std::unique_ptr<QgsDateTimeEditWrapper> widget5; // For field 4
+    std::unique_ptr<QgsDateTimeEditWrapper> widget6; // For field 5
     std::unique_ptr<QgsVectorLayer> vl;
 
 };
@@ -65,7 +66,8 @@ void TestQgsDateTimeEdit::init()
   fields.append( QgsField( "date2", QVariant::Date ) );
   fields.append( QgsField( "date3", QVariant::Date ) );
   fields.append( QgsField( "time", QVariant::Time ) );
-  fields.append( QgsField( "datetime", QVariant::DateTime ) );
+  fields.append( QgsField( "datetime1", QVariant::DateTime ) );
+  fields.append( QgsField( "datetime2", QVariant::DateTime ) );
   vl->dataProvider()->addAttributes( fields );
   vl->updateFields();
   QVERIFY( vl.get() );
@@ -76,11 +78,13 @@ void TestQgsDateTimeEdit::init()
   widget3 = qgis::make_unique<QgsDateTimeEditWrapper>( vl.get(), 2, nullptr, nullptr );
   widget4 = qgis::make_unique<QgsDateTimeEditWrapper>( vl.get(), 3, nullptr, nullptr );
   widget5 = qgis::make_unique<QgsDateTimeEditWrapper>( vl.get(), 4, nullptr, nullptr );
+  widget6 = qgis::make_unique<QgsDateTimeEditWrapper>( vl.get(), 5, nullptr, nullptr );
   QVERIFY( widget1.get() );
   QVERIFY( widget2.get() );
   QVERIFY( widget3.get() );
   QVERIFY( widget4.get() );
   QVERIFY( widget5.get() );
+  QVERIFY( widget6.get() );
 }
 
 void TestQgsDateTimeEdit::cleanup()
@@ -307,6 +311,14 @@ void TestQgsDateTimeEdit::testDateTime()
   widget5->setValue( QDate( 1966, 11, 25 ) );
   QDate value5 { widget5->value().toDate() };
   QCOMPARE( value5, QDate( 1966, 11, 25 ) );
+
+  widget6->setConfig( cfg );
+  QgsDateTimeEdit *dateedit6 = qobject_cast<QgsDateTimeEdit *>( widget6->createWidget( &w ) );
+  QVERIFY( dateedit6 );
+  widget6->initWidget( dateedit6 );
+  widget6->setValue( QDate( 1, 1, 1 ) );
+  QDate value6 { widget6->value().toDate() };
+  QCOMPARE( value6, QDate( 1, 1, 1 ) );
 }
 
 QGSTEST_MAIN( TestQgsDateTimeEdit )


### PR DESCRIPTION
## Description

With PR #4842 the lower limit for values that can be entered in a field using the Date/Time widget was set to Jan 1st 100 CE (previously it was not possible to enter dates prior to Sep 14th 1752 CE).

The date of Jan 1st 100 CE was used only because QDateTimeEdit::setMinimumDateTime() doesn't support dates earlier than that.
https://github.com/qgis/QGIS/blob/d73eaa1d58ca6e7429d338ef42bcd16dcae6742a/src/gui/editorwidgets/qgsdatetimeedit.h#L196-L204

This limitation doesn't affect QDateTimeEdit::setDateTimeRange(), so it is possible to use it to allow entering dates also from 1 CE to 99 CE which previously where not allowed***.
```
    void setMinimumEditDateTime()
    {
      setDateTimeRange( QDateTime( QDate( 1, 1, 1 ) ), maximumDateTime() );
    }
```

Fixes #35574 (as far as possible).

This PR also avoids a triple conversion of QDate and QDateTime field value in QgsDateTimeFieldFormatter::representValue():
- QVariant-[toString]->QString
- QString-[fromString(format)]->QDateTime
- QDateTime-[toString(format)]->QString

while 
- QVariant-(toDateTime)->QDateTime
- QDateTime-[toString(format()]->QString

is enough for QDate and QDateTime fields.

#    
***It could be possible to go further and allow dates with negative years since they are supported by setDateTimeRange() and by QDate and QDateTime type fields for memory layers, but it seems they are not allowed in Date/Time field by some providers (e.g. Shapefile and GeoPackage).

![Video_2020-05-23_234612](https://user-images.githubusercontent.com/16253859/82741448-2ca34c80-9d52-11ea-8aa5-9cb74fa27e9b.gif)

Dates with negative years could also be stored in text fields but they are not properly handled by the Date/Time widget until [QTBUG-84334](https://bugreports.qt.io/browse/QTBUG-84334) is fixed (QDateTime::toString() handles negative years while QDateTime::fromString() cannot parse them).
<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
