### PR TITLE
[code editor] Improve creation of monospace font by:

### DIFF
--- a/src/gui/qgscodeeditor.cpp
+++ b/src/gui/qgscodeeditor.cpp
@@ -19,8 +19,10 @@
 #include "qgssettings.h"
 #include "qgssymbollayerutils.h"
 
+#include <QLabel>
 #include <QWidget>
 #include <QFont>
+#include <QFontDatabase>
 #include <QDebug>
 #include <QFocusEvent>
 
@@ -102,6 +104,9 @@ void QgsCodeEditor::setSciWidget()
     }
   }
   QPalette pal = qApp->palette();
+
+  QFont font = getMonospaceFont();
+  setFont( font );
 
   setUtf8( true );
   setCaretLineVisible( true );
@@ -193,14 +198,16 @@ bool QgsCodeEditor::isFixedPitch( const QFont &font )
 
 QFont QgsCodeEditor::getMonospaceFont()
 {
+  QFont font = QFontDatabase::systemFont( QFontDatabase::FixedFont );
+#ifdef Q_OS_MAC
+  // The font size gotten from getMonospaceFont() is too small on Mac
+  font.setPointSize( QLabel().font().pointSize() );
+#else
   QgsSettings settings;
-  QString loadFont = settings.value( QStringLiteral( "pythonConsole/fontfamilytextEditor" ), "Monospace" ).toString();
-  int fontSize = settings.value( QStringLiteral( "pythonConsole/fontsizeEditor" ), 10 ).toInt();
-
-  QFont font( loadFont );
-  font.setFixedPitch( true );
+  int fontSize = settings.value( QStringLiteral( "qgis/stylesheet/fontPointSize" ), 10 ).toInt();
   font.setPointSize( fontSize );
-  font.setStyleHint( QFont::TypeWriter );
+#endif
   font.setBold( false );
+
   return font;
 }

--- a/src/gui/qgscodeeditorexpression.cpp
+++ b/src/gui/qgscodeeditorexpression.cpp
@@ -19,7 +19,6 @@
 
 #include <QString>
 #include <QFont>
-#include <QLabel>
 
 QgsCodeEditorExpression::QgsCodeEditorExpression( QWidget *parent )
   : QgsCodeEditor( parent )
@@ -113,10 +112,6 @@ void QgsCodeEditorExpression::initializeLexer()
   }
 
   QFont font = getMonospaceFont();
-#ifdef Q_OS_MAC
-  // The font size gotten from getMonospaceFont() is too small on Mac
-  font.setPointSize( QLabel().font().pointSize() );
-#endif
   QColor defaultColor = colors.value( QStringLiteral( "sql/defaultFontColor" ), Qt::black );
 
   mSqlLexer = new QgsLexerExpression( this );

--- a/src/gui/qgscodeeditorhtml.cpp
+++ b/src/gui/qgscodeeditorhtml.cpp
@@ -20,7 +20,6 @@
 #include <QWidget>
 #include <QString>
 #include <QFont>
-#include <QLabel>
 #include <Qsci/qscilexerhtml.h>
 
 
@@ -49,10 +48,6 @@ void QgsCodeEditorHTML::setSciLexerHTML()
   }
 
   QFont font = getMonospaceFont();
-#ifdef Q_OS_MAC
-  // The font size gotten from getMonospaceFont() is too small on Mac
-  font.setPointSize( QLabel().font().pointSize() );
-#endif
   QColor defaultColor = colors.value( QStringLiteral( "html/defaultFontColor" ), Qt::black );
 
   QsciLexerHTML *lexer = new QsciLexerHTML( this );

--- a/src/gui/qgscodeeditorsql.cpp
+++ b/src/gui/qgscodeeditorsql.cpp
@@ -20,7 +20,6 @@
 #include <QWidget>
 #include <QString>
 #include <QFont>
-#include <QLabel>
 
 
 QgsCodeEditorSQL::QgsCodeEditorSQL( QWidget *parent )
@@ -50,10 +49,6 @@ void QgsCodeEditorSQL::initializeLexer()
   }
 
   QFont font = getMonospaceFont();
-#ifdef Q_OS_MAC
-  // The font size gotten from getMonospaceFont() is too small on Mac
-  font.setPointSize( QLabel().font().pointSize() );
-#endif
   QColor defaultColor = colors.value( QStringLiteral( "sql/defaultFontColor" ), Qt::black );
 
   mSqlLexer = new QgsCaseInsensitiveLexerSQL( this );


### PR DESCRIPTION
This PR improves the creation of a monospace font for our code editor widgets by:
- Stop relying on the python console settings;
- Using modern way to retreive monospace font family;
- Using QGIS' font size;
- Increase likelihood of getting a monospace font on all platforms.

It might, *might* fix issue #36686 too. Either way, the improvements here are all sound and needed. 
