### PR TITLE
Fix message bar slows qgis down when many messages are present

### DIFF
--- a/python/gui/auto_generated/qgsmessagebar.sip.in
+++ b/python/gui/auto_generated/qgsmessagebar.sip.in
@@ -15,6 +15,21 @@ class QgsMessageBar: QFrame
 {
 %Docstring
 A bar for displaying non-blocking messages to the user.
+
+QgsMessageBar is a reusable widget which allows for providing feedback to users in
+a non-intrusive way. Messages are shown in a horizontal bar widget, which is styled
+automatically to reflect the severity ("message level") of the displayed message (e.g.
+warning messages are styled in an orange color scheme, critical errors are shown in
+red, etc).
+
+The message bar supports automatic stacking of multiple messages, so that
+only the most recent message is shown to users. Users can then manually dismiss
+individual messages to remove them from the stack, causing the next-most-recent
+message to be shown. If no messages are available to show then the message bar
+automatically hides.
+
+The class also supports pushing custom widgets to the notification stack via
+the pushWidget() method.
 %End
 
 %TypeHeaderCode
@@ -29,93 +44,140 @@ Constructor for QgsMessageBar
 
     void pushItem( QgsMessageBarItem *item /Transfer/ );
 %Docstring
-Display a message item on the bar after hiding the currently visible one
+Display a message ``item`` on the bar, after hiding the currently visible one
 and putting it in a stack.
-The message bar will take ownership of the item.
 
-:param item: Item to display
+The message bar will take ownership of ``item``.
 %End
 
     QgsMessageBarItem *pushWidget( QWidget *widget /Transfer/, Qgis::MessageLevel level = Qgis::Info, int duration = 0 );
 %Docstring
-Display a widget as a message on the bar after hiding the currently visible one
+Display a ``widget`` as a message on the bar, after hiding the currently visible one
 and putting it in a stack.
 
 :param widget: message widget to display
 :param level: is Qgis.Info, Warning, Critical or Success
-:param duration: timeout duration of message in seconds, 0 value indicates no timeout
+:param duration: timeout duration of message in seconds, 0 value indicates no timeout (i.e.
+                 the message must be manually cleared by the user).
 %End
 
     bool popWidget( QgsMessageBarItem *item );
 %Docstring
-Remove the passed widget from the bar (if previously added),
-then display the next one in the stack if any or hide the bar
+Remove the specified ``item`` from the bar, and display the next most recent one in the stack.
+If no messages remain in the stack, then the bar will be hidden.
 
-:param item: item to remove
+:param item: previously added item to remove.
 
-:return: ``True`` if the widget was removed, ``False`` otherwise
+:return: ``True`` if ``item`` was removed, ``False`` otherwise
 %End
 
     static QgsMessageBarItem *createMessage( const QString &text, QWidget *parent = 0 ) /Factory/;
 %Docstring
-make out a widget containing a message to be displayed on the bar
+Creates message bar item widget containing a message ``text`` to be displayed on the bar.
+
+The caller takes ownership of the returned item.
+
+.. note::
+
+   This is a low-level API call. Users are recommended to use the high-level pushMessage() API call
+   instead.
 %End
+
     static QgsMessageBarItem *createMessage( const QString &title, const QString &text, QWidget *parent = 0 ) /Factory/;
 %Docstring
-make out a widget containing title and message to be displayed on the bar
+Creates message bar item widget containing a ``title`` and message ``text`` to be displayed on the bar.
+
+The caller takes ownership of the returned item.
+
+.. note::
+
+   This is a low-level API call. Users are recommended to use the high-level pushMessage() API call
+   instead.
 %End
+
     static QgsMessageBarItem *createMessage( QWidget *widget, QWidget *parent = 0 ) /Factory/;
 %Docstring
-make out a widget containing title and message to be displayed on the bar
+Creates message bar item widget containing a custom ``widget`` to be displayed on the bar.
+
+The caller takes ownership of the returned item.
+
+.. note::
+
+   This is a low-level API call. Users are recommended to use the high-level pushWidget() API call
+   instead.
 %End
 
     void pushMessage( const QString &text, Qgis::MessageLevel level = Qgis::Info, int duration = 5 );
 %Docstring
-convenience method for pushing a message to the bar
+A convenience method for pushing a message with the specified ``text`` to the bar.
+
+The ``level`` argument specifies the desired message level (severity) of the message, which controls
+how the message bar is styled.
+
+The optional ``duration`` argument can be used to specify the message timeout in seconds. If ``duration``
+is set to 0, then the message must be manually dismissed by the user.
 %End
+
     void pushMessage( const QString &title, const QString &text, Qgis::MessageLevel level = Qgis::Info, int duration = 5 );
 %Docstring
-convenience method for pushing a message with title to the bar
+A convenience method for pushing a message with the specified ``title`` and ``text`` to the bar.
+
+The ``level`` argument specifies the desired message level (severity) of the message, which controls
+how the message bar is styled.
+
+The optional ``duration`` argument can be used to specify the message timeout in seconds. If ``duration``
+is set to 0, then the message must be manually dismissed by the user.
 %End
 
     void pushMessage( const QString &title, const QString &text, const QString &showMore, Qgis::MessageLevel level = Qgis::Info, int duration = 5 );
 %Docstring
-convenience method for pushing a message to the bar with a detail text which be shown when pressing a "more" button
+A convenience method for pushing a message with the specified ``title`` and ``text`` to the bar. Additional
+message content specified via ``showMore`` will be shown when the user presses a "more" button.
+
+The ``level`` argument specifies the desired message level (severity) of the message, which controls
+how the message bar is styled.
+
+The optional ``duration`` argument can be used to specify the message timeout in seconds. If ``duration``
+is set to 0, then the message must be manually dismissed by the user.
 %End
 
     QgsMessageBarItem *currentItem();
+%Docstring
+Returns the current visible item, or ``None`` if no item is shown.
+%End
 
   signals:
+
     void widgetAdded( QgsMessageBarItem *item );
 %Docstring
-emitted when a message widget is added to the bar
+Emitted whenever an ``item`` is added to the bar.
 %End
 
     void widgetRemoved( QgsMessageBarItem *item );
 %Docstring
-emitted when a message widget was removed from the bar
+Emitted whenever an ``item`` was removed from the bar.
 %End
 
   public slots:
 
     bool popWidget();
 %Docstring
-Remove the currently displayed widget from the bar and
-display the next in the stack if any or hide the bar.
+Remove the currently displayed item from the bar and display the next item
+in the stack. If no remaining items are present, the bar will be hidden.
 
 :return: ``True`` if the widget was removed, ``False`` otherwise
 %End
 
     bool clearWidgets();
 %Docstring
-Remove all items from the bar's widget list
+Removes all items from the bar.
 
 :return: ``True`` if all items were removed, ``False`` otherwise
 %End
 
     void pushSuccess( const QString &title, const QString &message );
 %Docstring
-Pushes a success message with default timeout to the message bar
+Pushes a success ``message`` with default timeout to the message bar.
 
 :param title: title string for message
 :param message: The message to be displayed
@@ -125,7 +187,7 @@ Pushes a success message with default timeout to the message bar
 
     void pushInfo( const QString &title, const QString &message );
 %Docstring
-Pushes a information message with default timeout to the message bar
+Pushes a information ``message`` with default timeout to the message bar.
 
 :param title: title string for message
 :param message: The message to be displayed
@@ -135,7 +197,7 @@ Pushes a information message with default timeout to the message bar
 
     void pushWarning( const QString &title, const QString &message );
 %Docstring
-Pushes a warning with default timeout to the message bar
+Pushes a warning ``message`` with default timeout to the message bar.
 
 :param title: title string for message
 :param message: The message to be displayed
@@ -145,7 +207,7 @@ Pushes a warning with default timeout to the message bar
 
     void pushCritical( const QString &title, const QString &message );
 %Docstring
-Pushes a critical warning with default timeout to the message bar
+Pushes a critical warning ``message`` with default timeout to the message bar.
 
 :param title: title string for message
 :param message: The message to be displayed

--- a/python/gui/auto_generated/qgsmessagebar.sip.in
+++ b/python/gui/auto_generated/qgsmessagebar.sip.in
@@ -146,6 +146,13 @@ is set to 0, then the message must be manually dismissed by the user.
 Returns the current visible item, or ``None`` if no item is shown.
 %End
 
+    QList<QgsMessageBarItem *> items();
+%Docstring
+Returns a list of all items currently visible or queued for the bar.
+
+.. versionadded:: 3.14
+%End
+
   signals:
 
     void widgetAdded( QgsMessageBarItem *item );

--- a/python/gui/auto_generated/qgsmessagebaritem.sip.in
+++ b/python/gui/auto_generated/qgsmessagebaritem.sip.in
@@ -12,76 +12,155 @@
 
 class QgsMessageBarItem : QWidget
 {
+%Docstring
+Represents an item shown within a QgsMessageBar widget.
+
+QgsMessageBarItem represents a single item (or message) which can be shown in a QgsMessageBar widget.
+%End
 
 %TypeHeaderCode
 #include "qgsmessagebaritem.h"
 %End
   public:
+
     QgsMessageBarItem( const QString &text, Qgis::MessageLevel level = Qgis::Info, int duration = 0, QWidget *parent /TransferThis/ = 0 );
 %Docstring
-make out a widget containing a message to be displayed on the bar
+Constructor for QgsMessageBarItem, containing a message with the specified ``text`` to be displayed on the bar.
+
+The ``level`` argument specifies the desired message level (severity) of the message, which controls
+how the message bar is styled when the item is displayed.
+
+The optional ``duration`` argument can be used to specify the message timeout in seconds. If ``duration``
+is set to 0, then the message must be manually dismissed by the user.
 %End
 
     QgsMessageBarItem( const QString &title, const QString &text, Qgis::MessageLevel level = Qgis::Info, int duration = 0, QWidget *parent /TransferThis/ = 0 );
 %Docstring
-make out a widget containing title and message to be displayed on the bar
+Constructor for QgsMessageBarItem, containing a ``title`` and message with the specified ``text`` to be displayed on the bar.
+
+The ``level`` argument specifies the desired message level (severity) of the message, which controls
+how the message bar is styled when the item is displayed.
+
+The optional ``duration`` argument can be used to specify the message timeout in seconds. If ``duration``
+is set to 0, then the message must be manually dismissed by the user.
 %End
 
     QgsMessageBarItem( const QString &title, const QString &text, QWidget *widget, Qgis::MessageLevel level = Qgis::Info, int duration = 0, QWidget *parent /TransferThis/ = 0 );
 %Docstring
-make out a widget containing title, message and widget to be displayed on the bar
+Constructor for QgsMessageBarItem, containing a \title, message with the specified ``text``, and a custom ``widget`` to be displayed on the bar.
+
+The ``level`` argument specifies the desired message level (severity) of the message, which controls
+how the message bar is styled when the item is displayed.
+
+The optional ``duration`` argument can be used to specify the message timeout in seconds. If ``duration``
+is set to 0, then the message must be manually dismissed by the user.
 %End
 
     QgsMessageBarItem( QWidget *widget, Qgis::MessageLevel level = Qgis::Info, int duration = 0, QWidget *parent /TransferThis/ = 0 );
 %Docstring
-make out a widget containing a widget to be displayed on the bar
+Constructor for QgsMessageBarItem, containing a custom ``widget`` to be displayed on the bar.
+
+The ``level`` argument specifies the desired message level (severity) of the message, which controls
+how the message bar is styled when the item is displayed.
+
+The optional ``duration`` argument can be used to specify the message timeout in seconds. If ``duration``
+is set to 0, then the message must be manually dismissed by the user.
 %End
 
     QgsMessageBarItem *setText( const QString &text );
+%Docstring
+Sets the message ``text`` to show in the item.
+
+.. seealso:: :py:func:`text`
+%End
 
     QString text() const;
 %Docstring
 Returns the text for the message.
+
+.. seealso:: :py:func:`setText`
 %End
 
     QgsMessageBarItem *setTitle( const QString &title );
+%Docstring
+Sets the ``title`` for in the item.
+
+.. seealso:: :py:func:`title`
+%End
 
     QString title() const;
 %Docstring
 Returns the title for the message.
+
+.. seealso:: :py:func:`setTitle`
 %End
 
     QgsMessageBarItem *setLevel( Qgis::MessageLevel level );
+%Docstring
+Sets the message ``level`` for the item, which controls how the message bar is styled
+when the item is displayed.
+
+.. seealso:: :py:func:`level`
+%End
 
     Qgis::MessageLevel level() const;
 %Docstring
 Returns the message level for the message.
+
+.. seealso:: :py:func:`setLevel`
 %End
 
     QgsMessageBarItem *setWidget( QWidget *widget );
+%Docstring
+Sets a custom ``widget`` to show in the item.
+
+.. seealso:: :py:func:`widget`
+%End
 
     QWidget *widget() const;
 %Docstring
 Returns the widget for the message.
+
+.. seealso:: :py:func:`setWidget`
 %End
 
     QgsMessageBarItem *setIcon( const QIcon &icon );
+%Docstring
+Sets the ``icon`` associated with the message.
+
+.. seealso:: :py:func:`icon`
+%End
 
     QIcon icon() const;
 %Docstring
 Returns the icon for the message.
+
+.. seealso:: :py:func:`setIcon`
 %End
 
     QgsMessageBarItem *setDuration( int duration );
+%Docstring
+Sets the ``duration`` (in seconds) to show the message for. If ``duration``
+is 0 then the message will not automatically timeout and instead must be
+manually dismissed by the user.
+
+.. seealso:: :py:func:`duration`
+%End
 
     int duration() const;
 %Docstring
-returns the duration in second of the message
+Returns the duration (in seconds) of the message.
+
+If the duration is 0 then the message will not automatically timeout and instead must be
+manually dismissed by the user.
+
+.. seealso:: :py:func:`setDuration`
 %End
 
     QString getStyleSheet();
 %Docstring
-returns the styleSheet
+Returns the styleSheet which should be used to style a QgsMessageBar object when
+this item is displayed.
 %End
 
   public slots:
@@ -99,7 +178,8 @@ has no effect.
 
     void styleChanged( const QString &styleSheet );
 %Docstring
-emitted when the message level has changed
+Emitted when the item's message level has changed and the message bar style
+will need to be updated as a result.
 %End
 
 };

--- a/python/gui/auto_generated/qgsmessagebaritem.sip.in
+++ b/python/gui/auto_generated/qgsmessagebaritem.sip.in
@@ -96,6 +96,7 @@ has no effect.
 %End
 
   signals:
+
     void styleChanged( const QString &styleSheet );
 %Docstring
 emitted when the message level has changed

--- a/src/gui/qgsmessagebar.cpp
+++ b/src/gui/qgsmessagebar.cpp
@@ -260,7 +260,13 @@ void QgsMessageBar::showItem( QgsMessageBarItem *item )
   }
 
   connect( mCurrentItem, &QgsMessageBarItem::styleChanged, this, &QWidget::setStyleSheet );
-  setStyleSheet( item->getStyleSheet() );
+
+  if ( item->level() != mPrevLevel )
+  {
+    setStyleSheet( item->getStyleSheet() );
+    mPrevLevel = item->level();
+  }
+
   show();
 
   emit widgetAdded( item );

--- a/src/gui/qgsmessagebar.cpp
+++ b/src/gui/qgsmessagebar.cpp
@@ -355,6 +355,11 @@ QgsMessageBarItem *QgsMessageBar::currentItem()
   return mItems.value( 0 );
 }
 
+QList<QgsMessageBarItem *> QgsMessageBar::items()
+{
+  return mItems;
+}
+
 QgsMessageBarItem *QgsMessageBar::createMessage( const QString &text, QWidget *parent )
 {
   QgsMessageBarItem *item = new QgsMessageBarItem( text, Qgis::Info, 0, parent );

--- a/src/gui/qgsmessagebar.cpp
+++ b/src/gui/qgsmessagebar.cpp
@@ -350,6 +350,11 @@ void QgsMessageBar::pushMessage( const QString &title, const QString &text, cons
   pushItem( item );
 }
 
+QgsMessageBarItem *QgsMessageBar::currentItem()
+{
+  return mItems.value( 0 );
+}
+
 QgsMessageBarItem *QgsMessageBar::createMessage( const QString &text, QWidget *parent )
 {
   QgsMessageBarItem *item = new QgsMessageBarItem( text, Qgis::Info, 0, parent );
@@ -364,6 +369,11 @@ QgsMessageBarItem *QgsMessageBar::createMessage( const QString &title, const QSt
 QgsMessageBarItem *QgsMessageBar::createMessage( QWidget *widget, QWidget *parent )
 {
   return new QgsMessageBarItem( widget, Qgis::Info, 0, parent );
+}
+
+void QgsMessageBar::pushMessage( const QString &text, Qgis::MessageLevel level, int duration )
+{
+  pushMessage( QString(), text, level, duration );
 }
 
 void QgsMessageBar::updateCountdown()

--- a/src/gui/qgsmessagebar.h
+++ b/src/gui/qgsmessagebar.h
@@ -163,6 +163,13 @@ class GUI_EXPORT QgsMessageBar: public QFrame
      */
     QgsMessageBarItem *currentItem();
 
+    /**
+     * Returns a list of all items currently visible or queued for the bar.
+     *
+     * \since QGIS 3.14
+     */
+    QList<QgsMessageBarItem *> items();
+
   signals:
 
     /**

--- a/src/gui/qgsmessagebar.h
+++ b/src/gui/qgsmessagebar.h
@@ -268,6 +268,8 @@ class GUI_EXPORT QgsMessageBar: public QFrame
     //! updates the countdown for widgets that have a timeout duration
     void updateCountdown();
     void resetCountdown();
+
+    friend class TestQgsMessageBar;
 };
 
 #endif

--- a/src/gui/qgsmessagebar.h
+++ b/src/gui/qgsmessagebar.h
@@ -92,7 +92,7 @@ class GUI_EXPORT QgsMessageBar: public QFrame
     //! convenience method for pushing a message to the bar with a detail text which be shown when pressing a "more" button
     void pushMessage( const QString &title, const QString &text, const QString &showMore, Qgis::MessageLevel level = Qgis::Info, int duration = 5 );
 
-    QgsMessageBarItem *currentItem() { return mCurrentItem; }
+    QgsMessageBarItem *currentItem() { return mItems.value( 0 ); }
 
   signals:
     //! emitted when a message widget is added to the bar
@@ -165,6 +165,10 @@ class GUI_EXPORT QgsMessageBar: public QFrame
     QProgressBar *mCountProgress = nullptr;
     QString mCountStyleSheet;
     Qgis::MessageLevel mPrevLevel = Qgis::MessageLevel::None;
+
+    static constexpr int MAX_ITEMS = 100;
+
+    void removeLowestPriorityOldestItem();
 
   private slots:
     //! updates count of items in widget list

--- a/src/gui/qgsmessagebar.h
+++ b/src/gui/qgsmessagebar.h
@@ -41,6 +41,21 @@ class QgsMessageBarItem;
 /**
  * \ingroup gui
  * A bar for displaying non-blocking messages to the user.
+ *
+ * QgsMessageBar is a reusable widget which allows for providing feedback to users in
+ * a non-intrusive way. Messages are shown in a horizontal bar widget, which is styled
+ * automatically to reflect the severity ("message level") of the displayed message (e.g.
+ * warning messages are styled in an orange color scheme, critical errors are shown in
+ * red, etc).
+ *
+ * The message bar supports automatic stacking of multiple messages, so that
+ * only the most recent message is shown to users. Users can then manually dismiss
+ * individual messages to remove them from the stack, causing the next-most-recent
+ * message to be shown. If no messages are available to show then the message bar
+ * automatically hides.
+ *
+ * The class also supports pushing custom widgets to the notification stack via
+ * the pushWidget() method.
  */
 class GUI_EXPORT QgsMessageBar: public QFrame
 {
@@ -52,98 +67,167 @@ class GUI_EXPORT QgsMessageBar: public QFrame
     QgsMessageBar( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
     /**
-     * Display a message item on the bar after hiding the currently visible one
+     * Display a message \a item on the bar, after hiding the currently visible one
      * and putting it in a stack.
-     * The message bar will take ownership of the item.
      *
-     * \param item Item to display
+     * The message bar will take ownership of \a item.
      */
     void pushItem( QgsMessageBarItem *item SIP_TRANSFER );
 
     /**
-     * Display a widget as a message on the bar after hiding the currently visible one
-     *  and putting it in a stack.
+     * Display a \a widget as a message on the bar, after hiding the currently visible one
+     * and putting it in a stack.
+     *
      * \param widget message widget to display
      * \param level is Qgis::Info, Warning, Critical or Success
-     * \param duration timeout duration of message in seconds, 0 value indicates no timeout
+     * \param duration timeout duration of message in seconds, 0 value indicates no timeout (i.e.
+     * the message must be manually cleared by the user).
      */
     QgsMessageBarItem *pushWidget( QWidget *widget SIP_TRANSFER, Qgis::MessageLevel level = Qgis::Info, int duration = 0 );
 
     /**
-     * Remove the passed widget from the bar (if previously added),
-     *  then display the next one in the stack if any or hide the bar
-     *  \param item item to remove
-     *  \returns TRUE if the widget was removed, FALSE otherwise
+     * Remove the specified \a item from the bar, and display the next most recent one in the stack.
+     * If no messages remain in the stack, then the bar will be hidden.
+     *
+     * \param item previously added item to remove.
+     * \returns TRUE if \a item was removed, FALSE otherwise
      */
     bool popWidget( QgsMessageBarItem *item );
 
-    //! make out a widget containing a message to be displayed on the bar
+    /**
+     * Creates message bar item widget containing a message \a text to be displayed on the bar.
+     *
+     * The caller takes ownership of the returned item.
+     *
+     * \note This is a low-level API call. Users are recommended to use the high-level pushMessage() API call
+     * instead.
+     */
     static QgsMessageBarItem *createMessage( const QString &text, QWidget *parent = nullptr ) SIP_FACTORY;
-    //! make out a widget containing title and message to be displayed on the bar
+
+    /**
+     * Creates message bar item widget containing a \a title and message \a text to be displayed on the bar.
+     *
+     * The caller takes ownership of the returned item.
+     *
+     * \note This is a low-level API call. Users are recommended to use the high-level pushMessage() API call
+     * instead.
+     */
     static QgsMessageBarItem *createMessage( const QString &title, const QString &text, QWidget *parent = nullptr ) SIP_FACTORY;
-    //! make out a widget containing title and message to be displayed on the bar
+
+    /**
+     * Creates message bar item widget containing a custom \a widget to be displayed on the bar.
+     *
+     * The caller takes ownership of the returned item.
+     *
+     * \note This is a low-level API call. Users are recommended to use the high-level pushWidget() API call
+     * instead.
+     */
     static QgsMessageBarItem *createMessage( QWidget *widget, QWidget *parent = nullptr ) SIP_FACTORY;
 
-    //! convenience method for pushing a message to the bar
-    void pushMessage( const QString &text, Qgis::MessageLevel level = Qgis::Info, int duration = 5 ) { pushMessage( QString(), text, level, duration ); }
-    //! convenience method for pushing a message with title to the bar
+    /**
+     * A convenience method for pushing a message with the specified \a text to the bar.
+     *
+     * The \a level argument specifies the desired message level (severity) of the message, which controls
+     * how the message bar is styled.
+     *
+     * The optional \a duration argument can be used to specify the message timeout in seconds. If \a duration
+     * is set to 0, then the message must be manually dismissed by the user.
+     */
+    void pushMessage( const QString &text, Qgis::MessageLevel level = Qgis::Info, int duration = 5 );
+
+    /**
+     * A convenience method for pushing a message with the specified \a title and \a text to the bar.
+     *
+     * The \a level argument specifies the desired message level (severity) of the message, which controls
+     * how the message bar is styled.
+     *
+     * The optional \a duration argument can be used to specify the message timeout in seconds. If \a duration
+     * is set to 0, then the message must be manually dismissed by the user.
+     */
     void pushMessage( const QString &title, const QString &text, Qgis::MessageLevel level = Qgis::Info, int duration = 5 );
 
-    //! convenience method for pushing a message to the bar with a detail text which be shown when pressing a "more" button
+    /**
+     * A convenience method for pushing a message with the specified \a title and \a text to the bar. Additional
+     * message content specified via \a showMore will be shown when the user presses a "more" button.
+     *
+     * The \a level argument specifies the desired message level (severity) of the message, which controls
+     * how the message bar is styled.
+     *
+     * The optional \a duration argument can be used to specify the message timeout in seconds. If \a duration
+     * is set to 0, then the message must be manually dismissed by the user.
+     */
     void pushMessage( const QString &title, const QString &text, const QString &showMore, Qgis::MessageLevel level = Qgis::Info, int duration = 5 );
 
-    QgsMessageBarItem *currentItem() { return mItems.value( 0 ); }
+    /**
+     * Returns the current visible item, or NULLPTR if no item is shown.
+     */
+    QgsMessageBarItem *currentItem();
 
   signals:
-    //! emitted when a message widget is added to the bar
+
+    /**
+     * Emitted whenever an \a item is added to the bar.
+     */
     void widgetAdded( QgsMessageBarItem *item );
 
-    //! emitted when a message widget was removed from the bar
+    /**
+     * Emitted whenever an \a item was removed from the bar.
+     */
     void widgetRemoved( QgsMessageBarItem *item );
 
   public slots:
 
     /**
-     * Remove the currently displayed widget from the bar and
-     *  display the next in the stack if any or hide the bar.
-     *  \returns TRUE if the widget was removed, FALSE otherwise
+     * Remove the currently displayed item from the bar and display the next item
+     * in the stack. If no remaining items are present, the bar will be hidden.
+     *
+     * \returns TRUE if the widget was removed, FALSE otherwise
      */
     bool popWidget();
 
     /**
-     * Remove all items from the bar's widget list
-     *  \returns TRUE if all items were removed, FALSE otherwise
+     * Removes all items from the bar.
+     *
+     * \returns TRUE if all items were removed, FALSE otherwise
      */
     bool clearWidgets();
 
     /**
-     * Pushes a success message with default timeout to the message bar
+     * Pushes a success \a message with default timeout to the message bar.
+     *
      * \param title title string for message
      * \param message The message to be displayed
+     *
      * \since QGIS 2.8
      */
     void pushSuccess( const QString &title, const QString &message );
 
     /**
-     * Pushes a information message with default timeout to the message bar
+     * Pushes a information \a message with default timeout to the message bar.
+     *
      * \param title title string for message
      * \param message The message to be displayed
+     *
      * \since QGIS 2.8
      */
     void pushInfo( const QString &title, const QString &message );
 
     /**
-     * Pushes a warning with default timeout to the message bar
+     * Pushes a warning \a message with default timeout to the message bar.
+     *
      * \param title title string for message
      * \param message The message to be displayed
+     *
      * \since QGIS 2.8
      */
     void pushWarning( const QString &title, const QString &message );
 
     /**
-     * Pushes a critical warning with default timeout to the message bar
+     * Pushes a critical warning \a message with default timeout to the message bar.
+     *
      * \param title title string for message
      * \param message The message to be displayed
+     *
      * \since QGIS 2.8
      */
     void pushCritical( const QString &title, const QString &message );

--- a/src/gui/qgsmessagebar.h
+++ b/src/gui/qgsmessagebar.h
@@ -164,6 +164,7 @@ class GUI_EXPORT QgsMessageBar: public QFrame
     QTimer *mCountdownTimer = nullptr;
     QProgressBar *mCountProgress = nullptr;
     QString mCountStyleSheet;
+    Qgis::MessageLevel mPrevLevel = Qgis::MessageLevel::None;
 
   private slots:
     //! updates count of items in widget list

--- a/src/gui/qgsmessagebaritem.cpp
+++ b/src/gui/qgsmessagebaritem.cpp
@@ -220,9 +220,13 @@ QString QgsMessageBarItem::title() const
 
 QgsMessageBarItem *QgsMessageBarItem::setLevel( Qgis::MessageLevel level )
 {
-  mLevel = level;
-  writeContent();
-  emit styleChanged( mStyleSheet );
+  if ( level != mLevel )
+  {
+    mLevel = level;
+    writeContent();
+    emit styleChanged( mStyleSheet );
+  }
+
   return this;
 }
 

--- a/src/gui/qgsmessagebaritem.h
+++ b/src/gui/qgsmessagebaritem.h
@@ -14,10 +14,9 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-#ifndef qgsmessagebaritem_H
-#define qgsmessagebaritem_H
+#ifndef QGSMESSAGEBARITEM_H
+#define QGSMESSAGEBARITEM_H
 
-#include "qgsmessagebaritem.h"
 #include "qgis.h"
 
 #include <QWidget>
@@ -32,64 +31,153 @@ class QgsMessageBar;
 /**
  * \ingroup gui
  * \class QgsMessageBarItem
+ * Represents an item shown within a QgsMessageBar widget.
+ *
+ * QgsMessageBarItem represents a single item (or message) which can be shown in a QgsMessageBar widget.
  */
 class GUI_EXPORT QgsMessageBarItem : public QWidget
 {
     Q_OBJECT
   public:
-    //! make out a widget containing a message to be displayed on the bar
+
+    /**
+     * Constructor for QgsMessageBarItem, containing a message with the specified \a text to be displayed on the bar.
+     *
+     * The \a level argument specifies the desired message level (severity) of the message, which controls
+     * how the message bar is styled when the item is displayed.
+     *
+     * The optional \a duration argument can be used to specify the message timeout in seconds. If \a duration
+     * is set to 0, then the message must be manually dismissed by the user.
+     */
     QgsMessageBarItem( const QString &text, Qgis::MessageLevel level = Qgis::Info, int duration = 0, QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
-    //! make out a widget containing title and message to be displayed on the bar
+    /**
+     * Constructor for QgsMessageBarItem, containing a \a title and message with the specified \a text to be displayed on the bar.
+     *
+     * The \a level argument specifies the desired message level (severity) of the message, which controls
+     * how the message bar is styled when the item is displayed.
+     *
+     * The optional \a duration argument can be used to specify the message timeout in seconds. If \a duration
+     * is set to 0, then the message must be manually dismissed by the user.
+     */
     QgsMessageBarItem( const QString &title, const QString &text, Qgis::MessageLevel level = Qgis::Info, int duration = 0, QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
-    //! make out a widget containing title, message and widget to be displayed on the bar
+    /**
+     * Constructor for QgsMessageBarItem, containing a \title, message with the specified \a text, and a custom \a widget to be displayed on the bar.
+     *
+     * The \a level argument specifies the desired message level (severity) of the message, which controls
+     * how the message bar is styled when the item is displayed.
+     *
+     * The optional \a duration argument can be used to specify the message timeout in seconds. If \a duration
+     * is set to 0, then the message must be manually dismissed by the user.
+     */
     QgsMessageBarItem( const QString &title, const QString &text, QWidget *widget, Qgis::MessageLevel level = Qgis::Info, int duration = 0, QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
-    //! make out a widget containing a widget to be displayed on the bar
+    /**
+     * Constructor for QgsMessageBarItem, containing a custom \a widget to be displayed on the bar.
+     *
+     * The \a level argument specifies the desired message level (severity) of the message, which controls
+     * how the message bar is styled when the item is displayed.
+     *
+     * The optional \a duration argument can be used to specify the message timeout in seconds. If \a duration
+     * is set to 0, then the message must be manually dismissed by the user.
+     */
     QgsMessageBarItem( QWidget *widget, Qgis::MessageLevel level = Qgis::Info, int duration = 0, QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
+    /**
+     * Sets the message \a text to show in the item.
+     *
+     * \see text()
+     */
     QgsMessageBarItem *setText( const QString &text );
 
     /**
      * Returns the text for the message.
+     *
+     * \see setText()
      */
     QString text() const;
 
+    /**
+     * Sets the \a title for in the item.
+     *
+     * \see title()
+     */
     QgsMessageBarItem *setTitle( const QString &title );
 
     /**
      * Returns the title for the message.
+     *
+     * \see setTitle()
      */
     QString title() const;
 
+    /**
+     * Sets the message \a level for the item, which controls how the message bar is styled
+     * when the item is displayed.
+     *
+     * \see level()
+     */
     QgsMessageBarItem *setLevel( Qgis::MessageLevel level );
 
     /**
      * Returns the message level for the message.
+     *
+     * \see setLevel()
      */
     Qgis::MessageLevel level() const;
 
+    /**
+     * Sets a custom \a widget to show in the item.
+     *
+     * \see widget()
+     */
     QgsMessageBarItem *setWidget( QWidget *widget );
 
     /**
      * Returns the widget for the message.
+     *
+     * \see setWidget()
      */
     QWidget *widget() const;
 
+    /**
+     * Sets the \a icon associated with the message.
+     *
+     * \see icon()
+     */
     QgsMessageBarItem *setIcon( const QIcon &icon );
 
     /**
      * Returns the icon for the message.
+     *
+     * \see setIcon()
      */
     QIcon icon() const;
 
+    /**
+     * Sets the \a duration (in seconds) to show the message for. If \a duration
+     * is 0 then the message will not automatically timeout and instead must be
+     * manually dismissed by the user.
+     *
+     * \see duration()
+     */
     QgsMessageBarItem *setDuration( int duration );
 
-    //! returns the duration in second of the message
+    /**
+     * Returns the duration (in seconds) of the message.
+     *
+     * If the duration is 0 then the message will not automatically timeout and instead must be
+     * manually dismissed by the user.
+     *
+     * \see setDuration()
+     */
     int duration() const { return mDuration; }
 
-    //! returns the styleSheet
+    /**
+     * Returns the styleSheet which should be used to style a QgsMessageBar object when
+     * this item is displayed.
+     */
     QString getStyleSheet() { return mStyleSheet; }
 
   public slots:
@@ -106,7 +194,8 @@ class GUI_EXPORT QgsMessageBarItem : public QWidget
   signals:
 
     /**
-     * emitted when the message level has changed
+     * Emitted when the item's message level has changed and the message bar style
+     * will need to be updated as a result.
      */
     void styleChanged( const QString &styleSheet );
 
@@ -132,4 +221,4 @@ class GUI_EXPORT QgsMessageBarItem : public QWidget
     friend class QgsMessageBar;
 };
 
-#endif // qgsmessagebaritem_H
+#endif // QGSMESSAGEBARITEM_H

--- a/src/gui/qgsmessagebaritem.h
+++ b/src/gui/qgsmessagebaritem.h
@@ -104,7 +104,10 @@ class GUI_EXPORT QgsMessageBarItem : public QWidget
     void dismiss();
 
   signals:
-    //! emitted when the message level has changed
+
+    /**
+     * emitted when the message level has changed
+     */
     void styleChanged( const QString &styleSheet );
 
   private slots:

--- a/tests/src/gui/testqgsmessagebar.cpp
+++ b/tests/src/gui/testqgsmessagebar.cpp
@@ -30,6 +30,7 @@ class TestQgsMessageBar: public QObject
     void cleanup(); // will be called after every testfunction.
     void dismiss();
     void pushPop();
+    void autoDelete();
 
 };
 
@@ -142,6 +143,40 @@ void TestQgsMessageBar::pushPop()
   QVERIFY( !bar.popWidget() );
   QCOMPARE( bar.items().size(), 0 );
   QVERIFY( !bar.currentItem() );
+}
+
+void TestQgsMessageBar::autoDelete()
+{
+  // ensure that items are automatically deleted when queue grows too large
+  QgsMessageBar bar;
+  for ( int i = 0; i < bar.MAX_ITEMS; ++i )
+  {
+    bar.pushMessage( QString::number( i ), Qgis::Warning );
+  }
+  QCOMPARE( bar.items().size(), 100 );
+  QCOMPARE( bar.items().at( 0 )->text(), QStringLiteral( "99" ) );
+  QCOMPARE( bar.items().at( 99 )->text(), QStringLiteral( "0" ) );
+  QPointer< QgsMessageBarItem > oldest = bar.items().at( 99 );
+
+  // push one more item, oldest one should be auto-removed
+  bar.pushMessage( QStringLiteral( "100" ), Qgis::Warning );
+  QCOMPARE( bar.items().size(), 100 );
+  QCOMPARE( bar.items().at( 0 )->text(), QStringLiteral( "100" ) );
+  QCOMPARE( bar.items().at( 99 )->text(), QStringLiteral( "1" ) );
+  QgsApplication::sendPostedEvents( nullptr, QEvent::DeferredDelete );
+  QVERIFY( !oldest );
+
+  // but if we have a lower priority message we can pop, then do that instead
+  bar.pushMessage( QStringLiteral( "101" ), Qgis::Info );
+  QCOMPARE( bar.items().size(), 100 );
+  QCOMPARE( bar.items().at( 0 )->text(), QStringLiteral( "101" ) );
+  QCOMPARE( bar.items().at( 1 )->text(), QStringLiteral( "100" ) );
+  QCOMPARE( bar.items().at( 99 )->text(), QStringLiteral( "2" ) );
+  bar.pushMessage( QStringLiteral( "102" ), Qgis::Info );
+  QCOMPARE( bar.items().size(), 100 );
+  QCOMPARE( bar.items().at( 0 )->text(), QStringLiteral( "102" ) );
+  QCOMPARE( bar.items().at( 1 )->text(), QStringLiteral( "100" ) );
+  QCOMPARE( bar.items().at( 99 )->text(), QStringLiteral( "2" ) );
 }
 
 QGSTEST_MAIN( TestQgsMessageBar )

--- a/tests/src/gui/testqgsmessagebar.cpp
+++ b/tests/src/gui/testqgsmessagebar.cpp
@@ -29,6 +29,7 @@ class TestQgsMessageBar: public QObject
     void init(); // will be called before each testfunction is executed.
     void cleanup(); // will be called after every testfunction.
     void dismiss();
+    void pushPop();
 
 };
 
@@ -80,7 +81,68 @@ void TestQgsMessageBar::dismiss()
   QVERIFY( !pItem.data() );
 }
 
+void TestQgsMessageBar::pushPop()
+{
+  // test pushing/popping message logic
+  QgsMessageBar bar;
+  QCOMPARE( bar.items().size(), 0 );
+  QVERIFY( !bar.currentItem() );
+  bar.pushMessage( QStringLiteral( "1" ) );
+  QCOMPARE( bar.items().size(), 1 );
+  QCOMPARE( bar.items().at( 0 )->text(), QStringLiteral( "1" ) );
+  QCOMPARE( bar.currentItem()->text(), QStringLiteral( "1" ) );
+  QPointer< QgsMessageBarItem > item1 = bar.currentItem();
+  // make sure correct item is the visible one
+  QCOMPARE( qobject_cast< QgsMessageBarItem * >( dynamic_cast< QGridLayout * >( bar.layout() )->itemAt( 3 )->widget() )->text(), QStringLiteral( "1" ) );
 
+  bar.pushMessage( QStringLiteral( "2" ) );
+  QCOMPARE( bar.items().size(), 2 );
+  QCOMPARE( bar.items().at( 0 )->text(), QStringLiteral( "2" ) );
+  QCOMPARE( bar.items().at( 1 )->text(), QStringLiteral( "1" ) );
+  QCOMPARE( bar.currentItem()->text(), QStringLiteral( "2" ) );
+  QPointer< QgsMessageBarItem > item2 = bar.currentItem();
+  QCOMPARE( qobject_cast< QgsMessageBarItem * >( dynamic_cast< QGridLayout * >( bar.layout() )->itemAt( 3 )->widget() )->text(), QStringLiteral( "2" ) );
+
+  bar.pushMessage( QStringLiteral( "3" ) );
+  QCOMPARE( bar.items().size(), 3 );
+  QCOMPARE( bar.items().at( 0 )->text(), QStringLiteral( "3" ) );
+  QCOMPARE( bar.items().at( 1 )->text(), QStringLiteral( "2" ) );
+  QCOMPARE( bar.items().at( 2 )->text(), QStringLiteral( "1" ) );
+  QCOMPARE( bar.currentItem()->text(), QStringLiteral( "3" ) );
+  QPointer< QgsMessageBarItem > item3 = bar.currentItem();
+  QCOMPARE( qobject_cast< QgsMessageBarItem * >( dynamic_cast< QGridLayout * >( bar.layout() )->itemAt( 3 )->widget() )->text(), QStringLiteral( "3" ) );
+
+  const int childCount = bar.children().count();
+  QVERIFY( bar.popWidget() );
+  QCOMPARE( bar.items().size(), 2 );
+  QCOMPARE( bar.items().at( 0 )->text(), QStringLiteral( "2" ) );
+  QCOMPARE( bar.items().at( 1 )->text(), QStringLiteral( "1" ) );
+  QCOMPARE( bar.currentItem()->text(), QStringLiteral( "2" ) );
+  QCOMPARE( qobject_cast< QgsMessageBarItem * >( dynamic_cast< QGridLayout * >( bar.layout() )->itemAt( 3 )->widget() )->text(), QStringLiteral( "2" ) );
+  QgsApplication::sendPostedEvents( nullptr, QEvent::DeferredDelete );
+  QCOMPARE( bar.children().count(), childCount - 1 );
+  QVERIFY( !item3 );
+
+  QVERIFY( bar.popWidget() );
+  QCOMPARE( bar.items().size(), 1 );
+  QCOMPARE( bar.items().at( 0 )->text(), QStringLiteral( "1" ) );
+  QCOMPARE( bar.currentItem()->text(), QStringLiteral( "1" ) );
+  QCOMPARE( qobject_cast< QgsMessageBarItem * >( dynamic_cast< QGridLayout * >( bar.layout() )->itemAt( 3 )->widget() )->text(), QStringLiteral( "1" ) );
+  QgsApplication::sendPostedEvents( nullptr, QEvent::DeferredDelete );
+  QCOMPARE( bar.children().count(), childCount - 2 );
+  QVERIFY( !item2 );
+
+  QVERIFY( bar.popWidget() );
+  QCOMPARE( bar.items().size(), 0 );
+  QVERIFY( !bar.currentItem() );
+  QgsApplication::sendPostedEvents( nullptr, QEvent::DeferredDelete );
+  QCOMPARE( bar.children().count(), childCount - 3 );
+  QVERIFY( !item1 );
+
+  QVERIFY( !bar.popWidget() );
+  QCOMPARE( bar.items().size(), 0 );
+  QVERIFY( !bar.currentItem() );
+}
 
 QGSTEST_MAIN( TestQgsMessageBar )
 #include "testqgsmessagebar.moc"


### PR DESCRIPTION
The previous size limitation code was rather broken, and didn't apply to all messages.

Add a refined approach which automatically removes the oldest message, prioritising lower impact messages (i.e. a "success" message will always be removed before a "warning")

Also fixes a quasi leak where items could be added to the bar and never deleted.

Fixes #29698