### PR TITLE
Fix QgsGeometry constParts() example code

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -481,17 +481,17 @@ iteration only is required.
 
        # print the WKT representation of each part in a multi-point geometry
        geometry = QgsGeometry.fromWkt( 'MultiPoint( 0 0, 1 1, 2 2)' )
-       for part in geometry.parts():
+       for part in geometry.constParts():
            print(part.asWkt())
 
        # single part geometries only have one part - this loop will iterate once only
        geometry = QgsGeometry.fromWkt( 'LineString( 0 0, 10 10 )' )
-       for part in geometry.parts():
+       for part in geometry.constParts():
            print(part.asWkt())
 
        # part iteration can also be combined with vertex iteration
        geometry = QgsGeometry.fromWkt( 'MultiPolygon((( 0 0, 0 10, 10 10, 10 0, 0 0 ),( 5 5, 5 6, 6 6, 6 5, 5 5)),((20 2, 22 2, 22 4, 20 4, 20 2)))' )
-       for part in geometry.parts():
+       for part in geometry.constParts():
            for v in part.vertices():
                print(v.x(), v.y())
 

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -559,17 +559,17 @@ class CORE_EXPORT QgsGeometry
      * \code{.py}
      *   # print the WKT representation of each part in a multi-point geometry
      *   geometry = QgsGeometry.fromWkt( 'MultiPoint( 0 0, 1 1, 2 2)' )
-     *   for part in geometry.parts():
+     *   for part in geometry.constParts():
      *       print(part.asWkt())
      *
      *   # single part geometries only have one part - this loop will iterate once only
      *   geometry = QgsGeometry.fromWkt( 'LineString( 0 0, 10 10 )' )
-     *   for part in geometry.parts():
+     *   for part in geometry.constParts():
      *       print(part.asWkt())
      *
      *   # part iteration can also be combined with vertex iteration
      *   geometry = QgsGeometry.fromWkt( 'MultiPolygon((( 0 0, 0 10, 10 10, 10 0, 0 0 ),( 5 5, 5 6, 6 6, 6 5, 5 5)),((20 2, 22 2, 22 4, 20 4, 20 2)))' )
-     *   for part in geometry.parts():
+     *   for part in geometry.constParts():
      *       for v in part.vertices():
      *           print(v.x(), v.y())
      *


### PR DESCRIPTION
## Description

The sample code for QgsGeometry constParts() wrongly refers to parts() instead of constParts().

Also in 3.10 branch.

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
