### PR TITLE
avoid 3D crash if terrain layer is null

### DIFF
--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -402,8 +402,7 @@ void QgsChunkedEntity::startJobs()
     delete entry;
 
     QgsChunkQueueJob *job = startJob( node );
-    if ( job )
-      mActiveJobs.append( job );
+    mActiveJobs.append( job );
   }
 }
 
@@ -415,8 +414,6 @@ QgsChunkQueueJob *QgsChunkedEntity::startJob( QgsChunkNode *node )
     QgsEventTracing::addEvent( QgsEventTracing::AsyncBegin, QStringLiteral( "3D" ), QStringLiteral( "Load " ) + node->tileId().text(), node->tileId().text() );
 
     QgsChunkLoader *loader = mChunkLoaderFactory->createChunkLoader( node );
-    if ( !loader )
-      return nullptr;
     connect( loader, &QgsChunkQueueJob::finished, this, &QgsChunkedEntity::onActiveJobFinished );
     node->setLoading( loader );
     return loader;

--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -123,6 +123,9 @@ QgsChunkedEntity::~QgsChunkedEntity()
 
 void QgsChunkedEntity::update( const SceneState &state )
 {
+  if ( !mIsValid )
+    return;
+
   QElapsedTimer t;
   t.start();
 
@@ -399,7 +402,8 @@ void QgsChunkedEntity::startJobs()
     delete entry;
 
     QgsChunkQueueJob *job = startJob( node );
-    mActiveJobs.append( job );
+    if ( job )
+      mActiveJobs.append( job );
   }
 }
 
@@ -411,6 +415,8 @@ QgsChunkQueueJob *QgsChunkedEntity::startJob( QgsChunkNode *node )
     QgsEventTracing::addEvent( QgsEventTracing::AsyncBegin, QStringLiteral( "3D" ), QStringLiteral( "Load " ) + node->tileId().text(), node->tileId().text() );
 
     QgsChunkLoader *loader = mChunkLoaderFactory->createChunkLoader( node );
+    if ( !loader )
+      return nullptr;
     connect( loader, &QgsChunkQueueJob::finished, this, &QgsChunkedEntity::onActiveJobFinished );
     node->setLoading( loader );
     return loader;

--- a/src/3d/chunks/qgschunkedentity_p.h
+++ b/src/3d/chunks/qgschunkedentity_p.h
@@ -172,6 +172,8 @@ class QgsChunkedEntity : public Qt3DCore::QEntity
 
     //! If picking is enabled, QObjectPicker objects will be assigned to chunks and pickedObject() signals fired on mouse click
     bool mPickingEnabled = false;
+
+    bool mIsValid = true;
 };
 
 /// @endcond

--- a/src/3d/mesh/qgsmeshterraingenerator.cpp
+++ b/src/3d/mesh/qgsmeshterraingenerator.cpp
@@ -99,6 +99,7 @@ void QgsMeshTerrainGenerator::resolveReferences( const QgsProject &project )
 void QgsMeshTerrainGenerator::setLayer( QgsMeshLayer *layer )
 {
   mLayer = QgsMapLayerRef( layer );
+  mIsValid = layer != nullptr;
 }
 
 QgsMeshLayer *QgsMeshTerrainGenerator::meshLayer() const

--- a/src/3d/mesh/qgsmeshterraingenerator.cpp
+++ b/src/3d/mesh/qgsmeshterraingenerator.cpp
@@ -54,8 +54,7 @@ Qt3DCore::QEntity *QgsMeshTerrainTileLoader::createEntity( Qt3DCore::QEntity *pa
 
 QgsChunkLoader *QgsMeshTerrainGenerator::createChunkLoader( QgsChunkNode *node ) const
 {
-  if ( !mLayer )
-    return nullptr;
+  Q_ASSERT( meshLayer() );
 
   return new QgsMeshTerrainTileLoader( mTerrain, node, meshLayer(), symbol() );
 }

--- a/src/3d/terrain/qgsdemterraingenerator.cpp
+++ b/src/3d/terrain/qgsdemterraingenerator.cpp
@@ -113,11 +113,13 @@ void QgsDemTerrainGenerator::updateGenerator()
     mTerrainTilingScheme = QgsTilingScheme( te, mCrs );
     delete mHeightMapGenerator;
     mHeightMapGenerator = new QgsDemHeightMapGenerator( dem, mTerrainTilingScheme, mResolution, mTransformContext );
+    mIsValid = true;
   }
   else
   {
     mTerrainTilingScheme = QgsTilingScheme();
     delete mHeightMapGenerator;
     mHeightMapGenerator = nullptr;
+    mIsValid = false;
   }
 }

--- a/src/3d/terrain/qgsterrainentity_p.cpp
+++ b/src/3d/terrain/qgsterrainentity_p.cpp
@@ -64,6 +64,7 @@ QgsTerrainEntity::QgsTerrainEntity( int maxLevel, const Qgs3DMapSettings &map, Q
   , mMap( map )
 {
   map.terrainGenerator()->setTerrain( this );
+  mIsValid = map.terrainGenerator()->isValid();
 
   connect( &map, &Qgs3DMapSettings::showTerrainBoundingBoxesChanged, this, &QgsTerrainEntity::onShowBoundingBoxesChanged );
   connect( &map, &Qgs3DMapSettings::showTerrainTilesInfoChanged, this, &QgsTerrainEntity::invalidateMapImages );

--- a/src/3d/terrain/qgsterraingenerator.cpp
+++ b/src/3d/terrain/qgsterraingenerator.cpp
@@ -71,3 +71,8 @@ QString QgsTerrainGenerator::typeToString( QgsTerrainGenerator::Type type )
   }
   return QString();
 }
+
+bool QgsTerrainGenerator::isValid() const
+{
+  return mIsValid;
+}

--- a/src/3d/terrain/qgsterraingenerator.h
+++ b/src/3d/terrain/qgsterraingenerator.h
@@ -99,9 +99,14 @@ class _3D_EXPORT QgsTerrainGenerator : public QgsChunkLoaderFactory
     //! Returns CRS of the terrain
     QgsCoordinateReferenceSystem crs() const { return mTerrainTilingScheme.crs(); }
 
+    //! Returns whether the terrain generator is valid
+    bool isValid() const;
+
   protected:
     QgsTilingScheme mTerrainTilingScheme;   //!< Tiling scheme of the terrain
     QgsTerrainEntity *mTerrain = nullptr;
+
+    bool mIsValid = true;
 };
 
 


### PR DESCRIPTION
On 3D map settings, when no layer is chosen for terrain (mesh or DEM), QGIS can crash when the settings are applied.
This PR fix this issue.