### PR TITLE
Fix incorrect "layer could not be generated" message after running gdal warp algorithm

### DIFF
--- a/python/plugins/processing/algs/gdal/warp.py
+++ b/python/plugins/processing/algs/gdal/warp.py
@@ -175,8 +175,6 @@ class warp(GdalAlgorithm):
         if inLayer is None:
             raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT))
 
-        out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
-        self.setOutputValue(self.OUTPUT, out)
         sourceCrs = self.parameterAsCrs(parameters, self.SOURCE_CRS, context)
         targetCrs = self.parameterAsCrs(parameters, self.TARGET_CRS, context)
         if self.NODATA in parameters and parameters[self.NODATA] is not None:

--- a/python/plugins/processing/gui/Postprocessing.py
+++ b/python/plugins/processing/gui/Postprocessing.py
@@ -111,7 +111,7 @@ def handleAlgorithmResults(alg, context, feedback=None, showResults=True, parame
 
     if wrongLayers:
         msg = QCoreApplication.translate('Postprocessing', "The following layers were not correctly generated.")
-        msg += "<ul>" + "".join(["<li>%s</li>" % lay for lay in wrongLayers]) + "</ul>"
+        msg += "\n" + "\n".join(["• {}".format(lay) for lay in wrongLayers]) + '\n'
         msg += QCoreApplication.translate('Postprocessing',
                                           "You can check the 'Log Messages Panel' in QGIS main window to find more information about the execution of the algorithm.")
         feedback.reportError(msg)


### PR DESCRIPTION
Double evalution of the output layer name causes an incorrect warning about layer not being generated to appear after running the algorithm

Fixes #30095