### PR TITLE
hide mesh 3D arrow settings for terrain settings

### DIFF
--- a/src/app/3d/qgsmesh3dsymbolwidget.cpp
+++ b/src/app/3d/qgsmesh3dsymbolwidget.cpp
@@ -96,6 +96,7 @@ void QgsMesh3dSymbolWidget::configureForTerrain()
 {
   mComboBoxTextureType->addItem( tr( "Color Ramp Shader" ), QgsMesh3DSymbol::ColorRamp );
   enableVerticalSetting( false );
+  enableArrowSettings( false );
 }
 
 void QgsMesh3dSymbolWidget::configureForDataset()
@@ -103,6 +104,7 @@ void QgsMesh3dSymbolWidget::configureForDataset()
   mComboBoxTextureType->addItem( tr( "2D Contour Color Ramp Shader" ), QgsMesh3DSymbol::ColorRamp2DRendering );
   mGroupBoxColorRampShader->hide();
   enableVerticalSetting( true );
+  enableArrowSettings( true );
 }
 
 void QgsMesh3dSymbolWidget::setLayer( QgsMeshLayer *meshLayer, bool updateSymbol )
@@ -213,6 +215,11 @@ void QgsMesh3dSymbolWidget::setColorRampMinMax( double min, double max )
 void QgsMesh3dSymbolWidget::enableVerticalSetting( bool isEnable )
 {
   mGroupBoxVerticaleSettings->setVisible( isEnable );
+}
+
+void QgsMesh3dSymbolWidget::enableArrowSettings( bool isEnable )
+{
+  mGroupBoxArrowsSettings->setVisible( isEnable );
 }
 
 

--- a/src/app/3d/qgsmesh3dsymbolwidget.h
+++ b/src/app/3d/qgsmesh3dsymbolwidget.h
@@ -44,6 +44,7 @@ class QgsMesh3dSymbolWidget : public QWidget, private Ui::QgsMesh3dPropsWidget
   public slots:
     void reloadColorRampShaderMinMax();
     void enableVerticalSetting( bool isEnable );
+    void enableArrowSettings( bool isEnable );
 
   signals:
     void changed();


### PR DESCRIPTION
When a mesh is set for terrain in the 3D configuration widget, arrows settings are visible in the mesh terrain settings, that is a non sens for terrain.
This PR hides the arrows settings in the 3D configuration widget.