### PR TITLE
check return value from the QgsRelief and notify user about errors (fix #17452)

### DIFF
--- a/python/plugins/processing/algs/qgis/Relief.py
+++ b/python/plugins/processing/algs/qgis/Relief.py
@@ -156,6 +156,20 @@ class Relief(QgisAlgorithm):
         relief.setZFactor(zFactor)
         if frequencyDistribution:
             relief.exportFrequencyDistributionToCsv(frequencyDistribution)
-        relief.processRaster(feedback)
+        res = relief.processRaster(feedback)
+        if res == 1:
+            raise QgsProcessingException(self.tr('Can not open input file.'))
+        elif res == 2:
+            raise QgsProcessingException(self.tr('Can not get GDAL driver for output file.'))
+        elif res == 3:
+            raise QgsProcessingException(self.tr('Can not create output file.'))
+        elif res == 4:
+            raise QgsProcessingException(self.tr('Can not get input band.'))
+        elif res == 5:
+            raise QgsProcessingException(self.tr('Can not create output bands.'))
+        elif res == 6:
+            raise QgsProcessingException(self.tr('Output raster size is too small (at least 3 rows needed).'))
+        elif res == 7:
+            feedback.pushInfo(self.tr('Cancelled.'))
 
         return {self.OUTPUT: outputFile, self.FREQUENCY_DISTRIBUTION: frequencyDistribution}


### PR DESCRIPTION
## Description
Native Relief algorithm may fail for different reasons, but details are coded as integer return codes. This PR provides more desciptive error messages to user. Fixes #17452