### PR TITLE
quote project file path when passing it to the crash handler (fix #25532)

### DIFF
--- a/src/app/qgscrashhandler.cpp
+++ b/src/app/qgscrashhandler.cpp
@@ -62,7 +62,7 @@ LONG WINAPI QgsCrashHandler::handle( LPEXCEPTION_POINTERS exception )
   QString projectFile = QgsProject::instance()->fileName();
   if ( !projectFile.isEmpty() )
     // quote project file path to avoid issues if it has spaces
-    arguments << '"' << projectFile << '"';
+    arguments << QStringLiteral( "\"%1\"" ).arg( projectFile );
   else
     arguments << projectFile;
 

--- a/src/app/qgscrashhandler.cpp
+++ b/src/app/qgscrashhandler.cpp
@@ -59,7 +59,12 @@ LONG WINAPI QgsCrashHandler::handle( LPEXCEPTION_POINTERS exception )
   arguments = QCoreApplication::arguments();
   // TODO In future this needs to be moved out into a "session state" file because we can't trust this is valid in
   // a crash.
-  arguments << QgsProject::instance()->fileName();
+  QString projectFile = QgsProject::instance()->fileName();
+  if ( !projectFile.isEmpty() )
+    // quote project file path to avoid issues if it has spaces
+    arguments << '"' << projectFile << '"';
+  else
+    arguments << projectFile;
 
   QStringList reportData;
   reportData.append( QStringLiteral( "QGIS Version: %1" ).arg( Qgis::version() ) );

--- a/src/app/qgscrashhandler.cpp
+++ b/src/app/qgscrashhandler.cpp
@@ -63,8 +63,6 @@ LONG WINAPI QgsCrashHandler::handle( LPEXCEPTION_POINTERS exception )
   if ( !projectFile.isEmpty() )
     // quote project file path to avoid issues if it has spaces
     arguments << QStringLiteral( "\"%1\"" ).arg( projectFile );
-  else
-    arguments << projectFile;
 
   QStringList reportData;
   reportData.append( QStringLiteral( "QGIS Version: %1" ).arg( Qgis::version() ) );


### PR DESCRIPTION
## Description
If project saved in the path with spaces and QGIS crashed, crash handler fails to reload project as unquoted path with spaces considered as multiple command-line arguments.

Fixes #25532.