### PR TITLE
Fix crash on "Open Directory" entry of contextual menu of recent projects

### DIFF
--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -18,6 +18,7 @@
 #include "qgisapp.h"
 #include "qgsversioninfo.h"
 #include "qgsapplication.h"
+#include "qgsfocuskeeper.h"
 #include "qgssettings.h"
 #include "qgsgui.h"
 #include "qgsnative.h"
@@ -291,6 +292,7 @@ void QgsWelcomePage::showContextMenuForProjects( QPoint point )
       QAction *openFolderAction = new QAction( tr( "Open Directory…" ), menu );
       connect( openFolderAction, &QAction::triggered, this, [path]
       {
+        QgsFocusKeeper focusKeeper;
         QgsGui::instance()->nativePlatformInterface()->openFileExplorerAndSelectFile( path );
       } );
       menu->addAction( openFolderAction );


### PR DESCRIPTION
Fixes #31630

I couldn't reproduce a crash on my platform (Linux, Ubuntu 16.04, gnome classic),
but this smells pretty much like the issue of #30210 fixed per PR #30210

So using QgsFocusKeeper hoping that it would solve the issue for people affected
