### PR TITLE
improve geopackage support when opened through networks drives

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -4047,7 +4047,7 @@ static bool IsLocalFile( const QString &path )
   // Start with the OS specific methods since the QT >= 5.4 method just
   // return a string and not an enumerated type.
 #if defined(Q_OS_WIN)
-  if ( dirName.startsWith( "\\\\" ) )
+  if ( dirName.startsWith( "\\\\" ) || dirName.startsWith( "//" ) )
     return false;
   if ( dirName.length() >= 3 && dirName[1] == ':' &&
        ( dirName[2] == '\\' || dirName[2] == '/' ) )


### PR DESCRIPTION
This PR aims to improve support of geopackages when accessed from network drives (esp. windows shares).

Initial testing seems to fix the deadlock when exiting QGIS with two clients (readonly), fixing https://github.com/qgis/QGIS/issues/32034. It may also help with https://github.com/qgis/QGIS/issues/27899.

- [x] 1. fix detection of network paths 
- [x] 2. explicitly set journal_mode=delete if journal_mode=wal is unwanted
~~- [ ] 3. deal with local/remote setup~~
~~- [ ] 4. what about spatialite ?~~

1. `QFileInfo::absolutePath()` is [documented ](https://doc.qt.io/qt-5/qfileinfo.html#absolutePath)to return forward slashes on Windows too. I still left the detection for backwards slashes as I guess it must have worked on some setups at some point ?

2. `journal_mode=wal` is persisted in the database, which means we have to set `journal_model=delete` explicitly if wal is unwanted (as it's enough for a file to have been opened once with wal enabled to stay this way). Worth noting that QGIS tries to restore `journal_mode=delete` on closing the datasource, but this isn't executed in case of a crash.

3. I guess one user working on a local file (in a shared folder) with another user accessing the same file over the network is common. In such a case, in one case it's a local database (and wal will be used), in the other it's a network file (and wal won't be used). We could try to detect such cases (by checking if a `-wal` sidecar exists while the database was supposed to be openeded without wal) and show a warning and open the dataset in readonly mode to reduce risk of corruption. I guess this would only work in one way (the when the local user opens the file before the remote user), so it's definitely not fail proof... but maybe better than nothing ?

4. In the code, the logic seems to apply only for `.gpkg` files, but I guess this all also applies to `.sqlite`, right ?