### PR TITLE
QgsVectorLayerSaveAsDialog: make it work with custom CRS

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8874,7 +8874,7 @@ QString QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbology
     QgsWkbTypes::Type forcedGeometryType = dialog->geometryType();
 
     QgsCoordinateTransform ct;
-    destCRS = QgsCoordinateReferenceSystem::fromSrsId( dialog->crs() );
+    destCRS = dialog->crsObject();
 
     if ( destCRS.isValid() )
     {

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -39,7 +39,7 @@ static const int COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE = 2;
 
 QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( long srsid, QWidget *parent, Qt::WindowFlags fl )
   : QDialog( parent, fl )
-  , mCRS( srsid )
+  , mSelectedCrs( QgsCoordinateReferenceSystem::fromSrsId( srsid ) )
   , mAttributeTableItemChangedSlotEnabled( true )
   , mReplaceRawFieldValuesStateChangedSlotEnabled( true )
   , mActionOnExistingFile( QgsVectorFileWriter::CreateOrOverwriteFile )
@@ -57,7 +57,7 @@ QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( QgsVectorLayer *layer, i
 {
   if ( layer )
   {
-    mCRS = layer->crs().srsid();
+    mSelectedCrs = layer->crs();
     mLayerExtent = layer->extent();
   }
   setup();
@@ -149,9 +149,8 @@ void QgsVectorLayerSaveAsDialog::setup()
     idx = 0;
   }
 
-  QgsCoordinateReferenceSystem srs = QgsCoordinateReferenceSystem::fromSrsId( mCRS );
-  mCrsSelector->setCrs( srs );
-  mCrsSelector->setLayerCrs( srs );
+  mCrsSelector->setCrs( mSelectedCrs );
+  mCrsSelector->setLayerCrs( mSelectedCrs );
   mCrsSelector->setMessage( tr( "Select the coordinate reference system for the vector file. "
                                 "The data points will be transformed from the layer coordinate reference system." ) );
 
@@ -165,8 +164,8 @@ void QgsVectorLayerSaveAsDialog::setup()
   mSymbologyExportComboBox_currentIndexChanged( mSymbologyExportComboBox->currentText() );
 
   // extent group box
-  mExtentGroupBox->setOutputCrs( srs );
-  mExtentGroupBox->setOriginalExtent( mLayerExtent, srs );
+  mExtentGroupBox->setOutputCrs( mSelectedCrs );
+  mExtentGroupBox->setOriginalExtent( mLayerExtent, mSelectedCrs );
   mExtentGroupBox->setOutputExtentFromOriginal();
   mExtentGroupBox->setCheckable( true );
   mExtentGroupBox->setChecked( false );
@@ -726,8 +725,8 @@ void QgsVectorLayerSaveAsDialog::mAttributeTable_itemChanged( QTableWidgetItem *
 
 void QgsVectorLayerSaveAsDialog::mCrsSelector_crsChanged( const QgsCoordinateReferenceSystem &crs )
 {
-  mCRS = crs.srsid();
-  mExtentGroupBox->setOutputCrs( crs );
+  mSelectedCrs = crs;
+  mExtentGroupBox->setOutputCrs( mSelectedCrs );
 }
 
 QString QgsVectorLayerSaveAsDialog::filename() const
@@ -752,7 +751,12 @@ QString QgsVectorLayerSaveAsDialog::format() const
 
 long QgsVectorLayerSaveAsDialog::crs() const
 {
-  return mCRS;
+  return mSelectedCrs.srsid();
+}
+
+QgsCoordinateReferenceSystem QgsVectorLayerSaveAsDialog::crsObject() const
+{
+  return mSelectedCrs;
 }
 
 QStringList QgsVectorLayerSaveAsDialog::datasourceOptions() const

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.h
@@ -56,8 +56,10 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
 
     /**
      * Construct a new QgsVectorLayerSaveAsDialog
+     *
+     * \deprecated since QGIS 3.14 - will be removed in QGIS 4.0
      */
-    QgsVectorLayerSaveAsDialog( long srsid, QWidget *parent = nullptr, Qt::WindowFlags fl = nullptr );
+    Q_DECL_DEPRECATED QgsVectorLayerSaveAsDialog( long srsid, QWidget *parent = nullptr, Qt::WindowFlags fl = nullptr );
 
     /**
      * Construct a new QgsVectorLayerSaveAsDialog
@@ -100,8 +102,15 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     /**
      * Returns the internal CRS ID.
      * \see QgsCoordinateReferenceSystem::srsid()
+     * \deprecated since QGIS 3.14 - will be removed in QGIS 4.0. Use crsObject() instead.
      */
-    long crs() const;
+    Q_DECL_DEPRECATED long crs() const;
+
+    /**
+     * Returns the CRS chosen for export
+     * \since QGIS 3.14
+     */
+    QgsCoordinateReferenceSystem crsObject() const;
 
     /**
      * Returns a list of attributes which are selected for saving.
@@ -221,7 +230,7 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     void setup();
     QList< QPair< QLabel *, QWidget * > > createControls( const QMap<QString, QgsVectorFileWriter::Option *> &options );
 
-    long mCRS;
+    QgsCoordinateReferenceSystem mSelectedCrs;
 
     QgsRectangle mLayerExtent;
     QgsCoordinateReferenceSystem mLayerCrs;

--- a/tests/src/app/testqgsvectorlayersaveasdialog.cpp
+++ b/tests/src/app/testqgsvectorlayersaveasdialog.cpp
@@ -72,6 +72,11 @@ void TestQgsVectorLayerSaveAsDialog::testAttributesAsDisplayedValues()
   std::unique_ptr< QgsVectorLayer> tempLayer( new QgsVectorLayer( QStringLiteral( "none?field=code:int&field=regular:string" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
   QVERIFY( tempLayer->isValid() );
 
+  // Assign a custom CRS to the layer
+  QgsCoordinateReferenceSystem crs;
+  crs.createFromString( "PROJ:+proj=merc +a=1" );
+  tempLayer->setCrs( crs );
+
   // Set a widget
   tempLayer->setEditorWidgetSetup( 0, QgsEditorWidgetSetup( QStringLiteral( "ValueRelation" ), QVariantMap() ) );
 
@@ -127,6 +132,9 @@ void TestQgsVectorLayerSaveAsDialog::testAttributesAsDisplayedValues()
   mAttributeTable->item( 0, 0 )->setCheckState( Qt::Unchecked );
   QCOMPARE( mAttributeTable->item( 0, 2 )->checkState(), Qt::Unchecked );
   QCOMPARE( mAttributeTable->item( 0, 2 )->flags(), Qt::ItemIsUserCheckable );
+
+  // Check that we can get a custom CRS with crsObject()
+  QCOMPARE( d.crsObject(), crs ) ;
 
   //d.exec();
 }


### PR DESCRIPTION
The current approach was based on a srsid, that that might be unset for custom
CRS. So store a full QgsCoordinateReferenceSystem object internally and use
that for exchanges with QgsProjectionSelectionWidget

Consequence: we need to deprecate the "long crs()" method, and replace it
by a "QgsCoordinateReferenceSystem crsObject()" one. I'm not particularly
happy with the name but the existing one was not very well named...

Mark also the QgsVectorLayerSaveAsDialog( long srsid, ... ) constructor as
deprecated.

Fixes the use case of https://github.com/qgis/QGIS/issues/34471#issuecomment-586181977
