### PR TITLE
Oracle - Wrong default value FIX #34482

### DIFF
--- a/src/providers/oracle/ocispatial/qsql_ocispatial.cpp
+++ b/src/providers/oracle/ocispatial/qsql_ocispatial.cpp
@@ -3432,7 +3432,10 @@ bool QOCISpatialResult::gotoNext( QSqlCachedResult::ValueCache &values, int inde
 
   // need to read piecewise before assigning values
   if ( r == OCI_SUCCESS && piecewise )
+  {
+    values.clear();
     r = d->cols->readPiecewise( values, index );
+  }
 
   if ( r == OCI_SUCCESS )
     d->cols->getValues( values, index );

--- a/tests/src/python/test_provider_oracle.py
+++ b/tests/src/python/test_provider_oracle.py
@@ -234,6 +234,7 @@ class TestPyQgsOracleProvider(unittest.TestCase, ProviderTestCase):
     def testDefaultValue(self):
         self.assertEqual(self.source.defaultValue(1), NULL)
         self.assertEqual(self.source.defaultValue(2), "'qgis'")
+        self.assertEqual(self.source.defaultValue(3), "'qgis'")
 
     def testPoints(self):
         vl = QgsVectorLayer('%s table="QGIS"."POINT_DATA" (GEOM) srid=4326 type=POINT sql=' %


### PR DESCRIPTION
FIX #34482
FIX #32401

## Description

Default values are misreaded from `all_tab_columns` table.

Default values are retrieving from the `data_default` field in `all_tab_columns` table (see [here](https://github.com/qgis/QGIS/blob/master/src/providers/oracle/qgsoracleprovider.cpp#L604)).

And long story short : 
- `data_default` is a long type column
- long is a type that can contains a lot of data, so data is readed in a "piecewise" mode (see [qsql_ocispatial.cpp](https://github.com/qgis/QGIS/blob/master/src/providers/oracle/ocispatial/qsql_ocispatial.cpp#L1535) and [oracle documentation](https://docs.oracle.com/database/121/HETER/GUID-9F828F0D-60ED-4F7D-92D5-0F3DFE1C9AA7.htm#HETER4069))
- piecewise read mode concatenates the value piece by piece (for a single row), but after the first row the value is not cleared, so it concatenates the current default value with the previous one, etc

The solution is to clear values if piecewise mode is used.

We already test default values in [test_provider_oracle.py](https://github.com/qgis/QGIS/blob/master/tests/src/python/test_provider_oracle.py#L234) :

```python
    def testDefaultValue(self):
        self.assertEqual(self.source.defaultValue(1), NULL)
        self.assertEqual(self.source.defaultValue(2), "'qgis'")
```

I add `self.assertEqual(self.source.defaultValue(3), "'qgis'")` that is not tested yet. Without the PR changes, `self.source.defaultValue(3)` is equal to "qgisqgis" and not "qgis"

No backport before backporting #36654