### PR TITLE
Add askToSaveMemoryLayers to ini file template so it has a default an…

### DIFF
--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -47,6 +47,11 @@ stylesheet\toolbarSpacing=
 
 [app]
 
+# Whether the user should be asked to save a layer in case of one or more MemoryLayers
+# when a project is closed.
+# Default to true, set to false to disable this dialog/question.
+askToSaveMemoryLayers=true
+
 # Maximum number of recent projects to show on the welcome page
 maxRecentProjects=20
 


### PR DESCRIPTION
…d is searchable

See https://github.com/qgis/QGIS/issues/36763

With this setting in place in your ini file you can search for 'memory' or 'save' and find this setting which in the advanced settings then you can set to false.

Seeing the Advanced Settings Editor below, I was wondering what the trick would be to add a Description there, as if I am right a QSetting just does not have one?

![Screenshot-20200527123006-943x430](https://user-images.githubusercontent.com/731673/83008668-cfd7b880-a015-11ea-9989-629ca6cbd563.png)

