### PR TITLE
[VirtualLayer] Remove useless qWarning message

### DIFF
--- a/src/providers/virtual/qgsvirtuallayerqueryparser.cpp
+++ b/src/providers/virtual/qgsvirtuallayerqueryparser.cpp
@@ -212,7 +212,6 @@ namespace QgsVirtualLayerQueryParser
           qs += QLatin1String( ", " );
       }
       qs += QLatin1String( " FROM _tview LIMIT 1" );
-      qWarning() << qs;
 
       Sqlite::Query q( db, qs );
       if ( q.step() == SQLITE_ROW )


### PR DESCRIPTION
## Description

Remove _qWarning_ from virtual layer provider. The debugging message ends up appearing in a red banner in QGIS.