### PR TITLE
 QgsDelimitedTextFile: fix parsing of files with CR end of line 

### DIFF
--- a/src/providers/delimitedtext/qgsdelimitedtextfile.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextfile.h
@@ -428,6 +428,9 @@ class QgsDelimitedTextFile : public QObject
     long mLineNumber = -1;
     long mRecordLineNumber = -1;
     long mRecordNumber = -1;
+    QString mBuffer;
+    int mPosInBuffer = 0;
+    int mMaxBufferSize = 0;
     QStringList mCurrentRecord;
     bool mHoldCurrentRecord = false;
     // Maximum number of record (ie maximum record number visited)

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -98,6 +98,7 @@ QgsDelimitedTextSourceSelect::QgsDelimitedTextSourceSelect( QWidget *parent, Qt:
   mFileWidget->setDialogTitle( tr( "Choose a Delimited Text File to Open" ) );
   mFileWidget->setFilter( tr( "Text files" ) + QStringLiteral( " (*.txt *.csv *.dat *.wkt);;" ) + tr( "All files" ) + QStringLiteral( " (* *.*)" ) );
   mFileWidget->setSelectedFilter( settings.value( mSettingsKey + QStringLiteral( "/file_filter" ), QString() ).toString() );
+  mMaxFields = settings.value( mSettingsKey + QStringLiteral( "/max_fields" ), DEFAULT_MAX_FIELDS ).toInt();
   connect( mFileWidget, &QgsFileWidget::fileChanged, this, &QgsDelimitedTextSourceSelect::updateFileName );
 }
 
@@ -403,6 +404,7 @@ bool QgsDelimitedTextSourceSelect::loadDelimitedFileDefinition()
   mFile->setUseHeader( cbxUseHeader->isChecked() );
   mFile->setDiscardEmptyFields( cbxSkipEmptyFields->isChecked() );
   mFile->setTrimFields( cbxTrimFields->isChecked() );
+  mFile->setMaxFields( mMaxFields );
   return mFile->isValid();
 }
 

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
@@ -50,6 +50,8 @@ class QgsDelimitedTextSourceSelect : public QgsAbstractDataSourceWidget, private
     std::unique_ptr<QgsDelimitedTextFile> mFile;
     int mExampleRowCount = 20;
     int mBadRowCount = 0;
+    static constexpr int DEFAULT_MAX_FIELDS = 10000;
+    int mMaxFields = DEFAULT_MAX_FIELDS; // to avoid Denial Of Service (at least in source select). Configurable through /max_fields settings sub-key.
     QString mSettingsKey;
     QString mLastFileType;
     QButtonGroup *bgFileFormat = nullptr;

--- a/tests/src/python/test_qgsdelimitedtextprovider.py
+++ b/tests/src/python/test_qgsdelimitedtextprovider.py
@@ -933,6 +933,62 @@ class TestQgsDelimitedTextProviderOther(unittest.TestCase):
         uri = registry.encodeUri('delimitedtext', parts)
         self.assertEqual(uri, 'file://' + filename)
 
+    def testCREndOfLineAndWorkingBuffer(self):
+        # Test CSV file with \r (CR) endings
+        # Test also that the logic to refill the buffer works properly
+        os.environ['QGIS_DELIMITED_TEXT_FILE_BUFFER_SIZE'] = '17'
+        try:
+            basetestfile = os.path.join(unitTestDataPath("delimitedtext"), 'test_cr_end_of_line.csv')
+
+            url = MyUrl.fromLocalFile(basetestfile)
+            url.addQueryItem("type", "csv")
+            url.addQueryItem("geomType", "none")
+
+            vl = QgsVectorLayer(url.toString(), 'test', 'delimitedtext')
+            assert vl.isValid(), "{} is invalid".format(basetestfile)
+
+            fields = vl.fields()
+            self.assertEqual(len(fields), 2)
+            self.assertEqual(fields[0].name(), 'col0')
+            self.assertEqual(fields[1].name(), 'col1')
+
+            features = [f for f in vl.getFeatures()]
+            self.assertEqual(len(features), 2)
+            self.assertEqual(features[0]['col0'], 'value00')
+            self.assertEqual(features[0]['col1'], 'value01')
+            self.assertEqual(features[1]['col0'], 'value10')
+            self.assertEqual(features[1]['col1'], 'value11')
+
+        finally:
+            del os.environ['QGIS_DELIMITED_TEXT_FILE_BUFFER_SIZE']
+
+    def testSaturationOfWorkingBuffer(self):
+        # 10 bytes is sufficient to detect the header line, but not enough for the
+        # first record
+        os.environ['QGIS_DELIMITED_TEXT_FILE_BUFFER_SIZE'] = '10'
+        try:
+            basetestfile = os.path.join(unitTestDataPath("delimitedtext"), 'test_cr_end_of_line.csv')
+
+            url = MyUrl.fromLocalFile(basetestfile)
+            url.addQueryItem("type", "csv")
+            url.addQueryItem("geomType", "none")
+
+            vl = QgsVectorLayer(url.toString(), 'test', 'delimitedtext')
+            assert vl.isValid(), "{} is invalid".format(basetestfile)
+
+            fields = vl.fields()
+            self.assertEqual(len(fields), 2)
+            self.assertEqual(fields[0].name(), 'col0')
+            self.assertEqual(fields[1].name(), 'col1')
+
+            features = [f for f in vl.getFeatures()]
+            self.assertEqual(len(features), 1)
+            self.assertEqual(features[0]['col0'], 'value00')
+            self.assertEqual(features[0]['col1'], 'va')  # truncated
+
+        finally:
+            del os.environ['QGIS_DELIMITED_TEXT_FILE_BUFFER_SIZE']
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/testdata/delimitedtext/test_cr_end_of_line.csv
+++ b/tests/testdata/delimitedtext/test_cr_end_of_line.csv
@@ -1,0 +1,1 @@
+col0,col1value00,value01value10,value11


### PR DESCRIPTION
*  QgsDelimitedTextFile: fix parsing of files with CR end of line 

Fixes #36392
Fixes #21976 
Fixes #17190

We are obliged to do 'at hand' parsing due to QT not handling CR-only
end of lines.
As we are at it, also limit each line to 1 MB to avoid potential denial
of service (which was what close to what happened here before the CR-only
parsing fix)

Add tests for parsing CR-only end of lines, and exercising the at-hand
buffering logic

*  QgsDelimitedTextSourceSelect: add a limitation to the number of fields
9d85148

Set to 10000 by default. Can be overriden through settings.

This is only for the preview in the source select dialog. (Attribute
table performs badly for much less columns)

---------------------

While being a bug fix, I'm not completely sure this is material for 3.10. At least not without being exercised a bit in master. The logic to parse lines at hand isn't completely trivial.
