### PR TITLE
Expose 3d algorithms provider to Python 

### DIFF
--- a/python/3d/3d_auto.sip
+++ b/python/3d/3d_auto.sip
@@ -1,4 +1,5 @@
 // Include auto-generated SIP files
+%Include auto_generated/processing/qgs3dalgorithms.sip
 %Include auto_generated/qgs3dmapsettings.sip
 %Include auto_generated/qgs3dtypes.sip
 %Include auto_generated/qgsabstractvectorlayer3drenderer.sip

--- a/python/3d/auto_generated/processing/qgs3dalgorithms.sip.in
+++ b/python/3d/auto_generated/processing/qgs3dalgorithms.sip.in
@@ -1,0 +1,58 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/3d/processing/qgs3dalgorithms.h                                  *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class Qgs3DAlgorithms: QgsProcessingProvider
+{
+%Docstring
+QGIS 3D processing algorithm provider.
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgs3dalgorithms.h"
+%End
+  public:
+
+    Qgs3DAlgorithms( QObject *parent = 0 );
+%Docstring
+Constructor for Qgs3DAlgorithms.
+%End
+
+    virtual QIcon icon() const;
+
+    virtual QString svgIconPath() const;
+
+    virtual QString id() const;
+
+    virtual QString helpId() const;
+
+    virtual QString name() const;
+
+    virtual bool supportsNonFileBasedOutput() const;
+
+
+  protected:
+
+    virtual void loadAlgorithms();
+
+
+};
+
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/3d/processing/qgs3dalgorithms.h                                  *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -247,6 +247,7 @@ IF (WITH_3D)
   INCLUDE_DIRECTORIES(
     ${CMAKE_SOURCE_DIR}/src/3d
     ${CMAKE_SOURCE_DIR}/src/3d/chunks
+    ${CMAKE_SOURCE_DIR}/src/3d/processing
     ${CMAKE_SOURCE_DIR}/src/3d/symbols
     ${CMAKE_SOURCE_DIR}/src/3d/terrain
     ${CMAKE_BINARY_DIR}/src/3d

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -36,7 +36,8 @@ from qgis.core import QgsApplication, QgsSettings, Qgis
 from .ui_console_history_dlg import Ui_HistoryDialogPythonConsole
 
 _init_commands = ["import sys", "import os", "import re", "import math", "from qgis.core import *",
-                  "from qgis.gui import *", "from qgis.analysis import *", "import processing", "import qgis.utils",
+                  "from qgis.gui import *", "from qgis.analysis import *", "from qgis._3d import *",
+                  "import processing", "import qgis.utils",
                   "from qgis.utils import iface", "from qgis.PyQt.QtCore import *", "from qgis.PyQt.QtGui import *",
                   "from qgis.PyQt.QtWidgets import *",
                   "from qgis.PyQt.QtNetwork import *", "from qgis.PyQt.QtXml import *"]

--- a/scripts/sip_include.sh
+++ b/scripts/sip_include.sh
@@ -34,7 +34,7 @@ fi
 if [[ -n $1 ]]; then
   modules=("$1")
 else
-  modules=(core gui analysis server)
+  modules=(core gui analysis server 3d)
 fi
 sources=(HDRS MOC_HDRS SRCS)
 

--- a/src/3d/chunks/qgschunkboundsentity_p.h
+++ b/src/3d/chunks/qgschunkboundsentity_p.h
@@ -36,10 +36,13 @@
 class QgsAABB;
 class AABBMesh;
 
+#define SIP_NO_FILE
+
 
 /**
  * \ingroup 3d
  * Draws bounds of axis aligned bounding boxes
+ * \note Not available in Python bindings
  * \since QGIS 3.0
  */
 class QgsChunkBoundsEntity : public Qt3DCore::QEntity

--- a/src/3d/chunks/qgschunkedentity_p.h
+++ b/src/3d/chunks/qgschunkedentity_p.h
@@ -29,6 +29,8 @@
 
 #include <Qt3DCore/QEntity>
 
+#define SIP_NO_FILE
+
 class QgsAABB;
 class QgsChunkNode;
 class QgsChunkList;

--- a/src/3d/chunks/qgschunklist_p.h
+++ b/src/3d/chunks/qgschunklist_p.h
@@ -27,11 +27,16 @@
 // version without notice, or even be removed.
 //
 
+#define SIP_NO_FILE
+
 class QgsChunkNode;
 
 /**
  * \ingroup 3d
  * Element of a double-linked list
+ *
+ * \note Not available in Python bindings
+ *
  * \since QGIS 3.0
  */
 struct QgsChunkListEntry

--- a/src/3d/chunks/qgschunkloader_p.h
+++ b/src/3d/chunks/qgschunkloader_p.h
@@ -29,9 +29,14 @@
 
 #include "qgschunkqueuejob_p.h"
 
+#define SIP_NO_FILE
+
 /**
  * \ingroup 3d
  * Base class for jobs that load chunks
+ *
+ * \note Not available in Python bindings
+ *
  * \since QGIS 3.0
  */
 class QgsChunkLoader : public QgsChunkQueueJob

--- a/src/3d/chunks/qgschunknode_p.h
+++ b/src/3d/chunks/qgschunknode_p.h
@@ -31,6 +31,8 @@
 
 #include <QTime>
 
+#define SIP_NO_FILE
+
 namespace Qt3DCore
 {
   class QEntity;

--- a/src/3d/chunks/qgschunkqueuejob_p.h
+++ b/src/3d/chunks/qgschunkqueuejob_p.h
@@ -34,6 +34,8 @@ namespace Qt3DCore
   class QEntity;
 }
 
+#define SIP_NO_FILE
+
 #include <QObject>
 
 /**

--- a/src/3d/mesh/qgsmesh3dentity_p.h
+++ b/src/3d/mesh/qgsmesh3dentity_p.h
@@ -36,6 +36,8 @@
 // version without notice, or even be removed.
 //
 
+#define SIP_NO_FILE
+
 class Qgs3DMapSettings;
 class QgsTessellatedPolygonGeometry;
 class QgsMesh3DSymbol;

--- a/src/3d/mesh/qgsmesh3dgeometry_p.h
+++ b/src/3d/mesh/qgsmesh3dgeometry_p.h
@@ -40,6 +40,8 @@
 // version without notice, or even be removed.
 //
 
+#define SIP_NO_FILE
+
 namespace Qt3DRender
 {
   class QAttribute;

--- a/src/3d/mesh/qgsmesh3dmaterial_p.h
+++ b/src/3d/mesh/qgsmesh3dmaterial_p.h
@@ -38,6 +38,8 @@
 // version without notice, or even be removed.
 //
 
+#define SIP_NO_FILE
+
 class QgsMeshLayer;
 
 /**

--- a/src/3d/qgs3danimationsettings.h
+++ b/src/3d/qgs3danimationsettings.h
@@ -26,10 +26,13 @@ class QDomDocument;
 class QDomElement;
 class QgsReadWriteContext;
 
+#define SIP_NO_FILE
+
 /**
  * \ingroup 3d
  * Class that holds information about animation in 3D view. The animation is defined
  * as a series of keyframes
+ * \note Not available in Python bindings
  * \since QGIS 3.8
  */
 class _3D_EXPORT Qgs3DAnimationSettings

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -49,10 +49,12 @@ class Qgs3DMapSettings;
 class QgsTerrainEntity;
 class QgsChunkedEntity;
 
+#define SIP_NO_FILE
 
 /**
  * \ingroup 3d
  * Entity that encapsulates our 3D scene - contains all other entities (such as terrain) as children.
+ * \note Not available in Python bindings
  * \since QGIS 3.0
  */
 class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -38,11 +38,12 @@ namespace Qt3DExtras
 
 #include <memory>
 
-#ifndef SIP_RUN
+#define SIP_NO_FILE
 
 /**
  * \ingroup 3d
  * Miscellaneous utility functions used from 3D code.
+ * \note Not available in Python bindings
  * \since QGIS 3.0
  */
 class _3D_EXPORT Qgs3DUtils
@@ -177,7 +178,5 @@ class _3D_EXPORT Qgs3DUtils
     //! Returns phong material object based on the material settings
     static Qt3DExtras::QPhongMaterial *phongMaterial( const QgsPhongMaterialSettings &settings );
 };
-
-#endif
 
 #endif // QGS3DUTILS_H

--- a/src/3d/qgsaabb.h
+++ b/src/3d/qgsaabb.h
@@ -22,9 +22,12 @@
 #include <QList>
 #include <QVector3D>
 
+#define SIP_NO_FILE
+
 /**
  * \ingroup 3d
  * Axis-aligned bounding box - in world coords.
+ * \note Not available in Python bindings
  * \since QGIS 3.0
  */
 class _3D_EXPORT QgsAABB

--- a/src/3d/qgsabstract3dengine.h
+++ b/src/3d/qgsabstract3dengine.h
@@ -20,6 +20,8 @@
 
 #include <QObject>
 
+#define SIP_NO_FILE
+
 class QColor;
 class QRect;
 class QSurface;
@@ -46,6 +48,7 @@ namespace Qt3DRender
  * - QgsWindow3DEngine - used for rendering on display (has a QWindow that can be embedded into QWidget)
  * - QgsOffscreen3DEngine - renders scene to images
  *
+ * \note Not available in Python bindings
  * \since QGIS 3.4
  */
 class _3D_EXPORT QgsAbstract3DEngine : public QObject

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -48,9 +48,12 @@ class QgsCameraPose;
 class QgsTerrainEntity;
 class QgsVector3D;
 
+#define SIP_NO_FILE
+
 /**
  * \ingroup 3d
  * Object that controls camera movement based on user input
+ * \note Not available in Python bindings
  * \since QGIS 3.0
  */
 class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity

--- a/src/3d/qgsfeature3dhandler_p.h
+++ b/src/3d/qgsfeature3dhandler_p.h
@@ -36,10 +36,14 @@ class QgsFeature;
 
 class Qgs3DMapSettings;
 
+#define SIP_NO_FILE
+
 
 /**
  * \ingroup 3d
  * Rendering context for preparation of 3D entities.
+ *
+ * \note Not available in Python bindings
  */
 class Qgs3DRenderContext
 {

--- a/src/3d/qgsmeshlayer3drenderer.h
+++ b/src/3d/qgsmeshlayer3drenderer.h
@@ -27,6 +27,8 @@
 
 #include <QObject>
 
+#define SIP_NO_FILE
+
 class QgsMeshLayer;
 
 
@@ -36,6 +38,7 @@ class QgsMeshLayer;
  *
  * \warning This is not considered stable API, and may change in future QGIS releases
  *
+ * \note Not available in Python bindings
  * \since QGIS 3.6
  */
 class _3D_EXPORT QgsMeshLayer3DRendererMetadata : public Qgs3DRendererAbstractMetadata

--- a/src/3d/qgsoffscreen3dengine.h
+++ b/src/3d/qgsoffscreen3dengine.h
@@ -48,6 +48,7 @@ namespace Qt3DLogic
   class QLogicAspect;
 }
 
+#define SIP_NO_FILE
 
 /**
  * \ingroup 3d
@@ -55,6 +56,8 @@ namespace Qt3DLogic
  *
  * \note While the on-screen 3D engine also allows capturing of images, its limitation is that
  * the captured images are of the size of the on-screen window.
+ *
+ * \note Not available in Python bindings
  *
  * \since QGIS 3.4
  */

--- a/src/3d/qgsraycastingutils_p.h
+++ b/src/3d/qgsraycastingutils_p.h
@@ -29,6 +29,8 @@
 
 #include <QVector3D>
 
+#define SIP_NO_FILE
+
 class QgsAABB;
 
 namespace Qt3DRender

--- a/src/3d/qgsrulebasedchunkloader_p.h
+++ b/src/3d/qgsrulebasedchunkloader_p.h
@@ -32,6 +32,8 @@
 #include "qgschunkedentity_p.h"
 #include "qgsrulebased3drenderer.h"
 
+#define SIP_NO_FILE
+
 class Qgs3DMapSettings;
 class QgsVectorLayer;
 class QgsVectorLayerFeatureSource;

--- a/src/3d/qgstessellatedpolygongeometry.h
+++ b/src/3d/qgstessellatedpolygongeometry.h
@@ -26,12 +26,16 @@ namespace Qt3DRender
   class QBuffer;
 }
 
+#define SIP_NO_FILE
+
 /**
  * \ingroup 3d
  * Class derived from Qt3DRender::QGeometry that represents polygons tessellated into 3D geometry.
  *
  * Takes a list of polygons as input, internally it does tessellation and writes output to the internal
  * vertex buffer. Optionally it can add "walls" if the extrusion height is non-zero.
+ *
+ * \note Not available in Python bindings
  *
  * \since QGIS 3.0
  */

--- a/src/3d/qgstilingscheme.h
+++ b/src/3d/qgstilingscheme.h
@@ -23,10 +23,13 @@
 
 class QgsRectangle;
 
+#define SIP_NO_FILE
+
 /**
  * \ingroup 3d
  * The class encapsulates tiling scheme (just like with WMTS / TMS / XYZ layers).
  * The origin (tile [0,0]) is in bottom-left corner.
+ * \note Not available in Python bindings
  * \since QGIS 3.0
  */
 class _3D_EXPORT QgsTilingScheme

--- a/src/3d/qgsvectorlayerchunkloader_p.h
+++ b/src/3d/qgsvectorlayerchunkloader_p.h
@@ -31,6 +31,8 @@
 #include "qgsfeature3dhandler_p.h"
 #include "qgschunkedentity_p.h"
 
+#define SIP_NO_FILE
+
 class Qgs3DMapSettings;
 class QgsVectorLayer;
 class QgsVectorLayer3DTilingSettings;

--- a/src/3d/qgswindow3dengine.h
+++ b/src/3d/qgswindow3dengine.h
@@ -32,10 +32,14 @@ namespace Qt3DExtras
 class QWindow;
 
 
+#define SIP_NO_FILE
+
 /**
  * \ingroup 3d
  * On-screen 3D engine: it creates OpenGL window (QWindow) and displays rendered 3D scene there.
  * The window can be embedded into a QWidget-based application with QWidget::createWindowContainer().
+ *
+ * \note Not available in Python bindings
  *
  * \since QGIS 3.4
  */

--- a/src/3d/symbols/qgsbillboardgeometry.h
+++ b/src/3d/symbols/qgsbillboardgeometry.h
@@ -21,10 +21,13 @@
 #include <Qt3DRender/QBuffer>
 #include <Qt3DRender/QAttribute>
 
+#define SIP_NO_FILE
 
 /**
  * \ingroup 3d
  * Geometry of the billboard rendering for points in 3D map view.
+ *
+ * \note Not available in Python bindings
  *
  * \since QGIS 3.10
  */

--- a/src/3d/symbols/qgsline3dsymbol_p.h
+++ b/src/3d/symbols/qgsline3dsymbol_p.h
@@ -27,6 +27,7 @@
 // version without notice, or even be removed.
 //
 
+#define SIP_NO_FILE
 
 #include "qgsfeature3dhandler_p.h"
 

--- a/src/3d/symbols/qgslinematerial_p.h
+++ b/src/3d/symbols/qgslinematerial_p.h
@@ -29,6 +29,8 @@
 
 #include <Qt3DRender/QMaterial>
 
+#define SIP_NO_FILE
+
 namespace Qt3DRender
 {
   class QCamera;

--- a/src/3d/symbols/qgslinevertexdata_p.h
+++ b/src/3d/symbols/qgslinevertexdata_p.h
@@ -30,6 +30,8 @@
 #include <QVector>
 #include <QVector3D>
 
+#define SIP_NO_FILE
+
 #include "qgs3dtypes.h"
 
 namespace Qt3DCore

--- a/src/3d/symbols/qgsmesh3dsymbol.h
+++ b/src/3d/symbols/qgsmesh3dsymbol.h
@@ -26,12 +26,16 @@
 
 #include <Qt3DRender/QCullFace>
 
+#define SIP_NO_FILE
+
 /**
  * \ingroup 3d
  * 3D symbol that draws mesh geometry as planar triangles.
  *
  * \warning This is not considered stable API, and may change in future QGIS releases. It is
  * exposed to the Python bindings as a tech preview only.
+ *
+ * \note Not available in Python bindings
  *
  * \since QGIS 3.6
  */

--- a/src/3d/symbols/qgsmesh3dsymbol_p.h
+++ b/src/3d/symbols/qgsmesh3dsymbol_p.h
@@ -31,6 +31,8 @@
 #include <Qt3DExtras/QPhongMaterial>
 #include <Qt3DRender/QGeometryRenderer>
 
+#define SIP_NO_FILE
+
 class Qgs3DMapSettings;
 class QgsTessellatedPolygonGeometry;
 class QgsMesh3DSymbol;

--- a/src/3d/symbols/qgspoint3dbillboardmaterial.h
+++ b/src/3d/symbols/qgspoint3dbillboardmaterial.h
@@ -23,9 +23,13 @@
 #include "qgsmarkersymbollayer.h"
 #include "qgs3dmapsettings.h"
 
+#define SIP_NO_FILE
+
 /**
  * \ingroup 3d
  * Material of the billboard rendering for points in 3D map view.
+ *
+ * \note Not available in Python bindings
  *
  * \since QGIS 3.10
  */

--- a/src/3d/symbols/qgspoint3dsymbol_p.h
+++ b/src/3d/symbols/qgspoint3dsymbol_p.h
@@ -27,6 +27,7 @@
 // version without notice, or even be removed.
 //
 
+#define SIP_NO_FILE
 
 #include "qgsfeature3dhandler_p.h"
 

--- a/src/3d/symbols/qgspolygon3dsymbol_p.h
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.h
@@ -27,6 +27,7 @@
 // version without notice, or even be removed.
 //
 
+#define SIP_NO_FILE
 
 #include "qgsfeature3dhandler_p.h"
 

--- a/src/3d/terrain/qgsdemterraingenerator.h
+++ b/src/3d/terrain/qgsdemterraingenerator.h
@@ -28,9 +28,14 @@ class QgsDemHeightMapGenerator;
 
 #include "qgsmaplayerref.h"
 
+#define SIP_NO_FILE
+
 /**
  * \ingroup 3d
  * Implementation of terrain generator that uses a raster layer with DEM to build terrain.
+ *
+ * \note Not available in Python bindings
+ *
  * \since QGIS 3.0
  */
 class _3D_EXPORT QgsDemTerrainGenerator : public QgsTerrainGenerator

--- a/src/3d/terrain/qgsdemterraintilegeometry_p.h
+++ b/src/3d/terrain/qgsdemterraintilegeometry_p.h
@@ -27,6 +27,8 @@
 // version without notice, or even be removed.
 //
 
+#define SIP_NO_FILE
+
 #include <Qt3DExtras/qt3dextras_global.h>
 #include <Qt3DRender/qgeometry.h>
 #include <QSize>

--- a/src/3d/terrain/qgsdemterraintileloader_p.h
+++ b/src/3d/terrain/qgsdemterraintileloader_p.h
@@ -27,6 +27,8 @@
 // version without notice, or even be removed.
 //
 
+#define SIP_NO_FILE
+
 #include <QtConcurrent/QtConcurrentRun>
 #include <QFutureWatcher>
 #include <QElapsedTimer>

--- a/src/3d/terrain/qgsflatterraingenerator.h
+++ b/src/3d/terrain/qgsflatterraingenerator.h
@@ -23,6 +23,8 @@
 #include "qgsrectangle.h"
 #include <Qt3DExtras/QPlaneGeometry>
 
+#define SIP_NO_FILE
+
 ///@cond PRIVATE
 
 //! Chunk loader for flat terrain implementation

--- a/src/3d/terrain/qgsonlineterraingenerator.h
+++ b/src/3d/terrain/qgsonlineterraingenerator.h
@@ -24,9 +24,14 @@
 
 class QgsDemHeightMapGenerator;
 
+#define SIP_NO_FILE
+
 /**
  * \ingroup 3d
  * Implementation of terrain generator that uses online resources to download heightmaps.
+ *
+ * \note Not available in Python bindings
+ *
  * \since QGIS 3.8
  */
 class _3D_EXPORT QgsOnlineTerrainGenerator : public QgsTerrainGenerator

--- a/src/3d/terrain/qgsterraindownloader.h
+++ b/src/3d/terrain/qgsterraindownloader.h
@@ -29,6 +29,8 @@ class QgsCoordinateReferenceSystem;
 class QgsRasterLayer;
 class QgsCoordinateTransformContext;
 
+#define SIP_NO_FILE
+
 /**
  * \ingroup 3d
  * Takes care of downloading terrain data from a publicly available data source.
@@ -37,6 +39,8 @@ class QgsCoordinateTransformContext;
  * - data format: https://github.com/tilezen/joerd/blob/master/docs/formats.md
  * - data sources: https://github.com/tilezen/joerd/blob/master/docs/data-sources.md
  * - hosting: https://registry.opendata.aws/terrain-tiles/
+ *
+ * \note Not available in Python bindings
  *
  * \since QGIS 3.8
  */

--- a/src/3d/terrain/qgsterrainentity_p.h
+++ b/src/3d/terrain/qgsterrainentity_p.h
@@ -27,6 +27,8 @@
 // version without notice, or even be removed.
 //
 
+#define SIP_NO_FILE
+
 #include "qgschunkedentity_p.h"
 #include "qgschunkqueuejob_p.h"
 

--- a/src/3d/terrain/qgsterraingenerator.h
+++ b/src/3d/terrain/qgsterraingenerator.h
@@ -30,6 +30,8 @@ class QDomElement;
 class QDomDocument;
 class QgsProject;
 
+#define SIP_NO_FILE
+
 
 /**
  * \ingroup 3d
@@ -37,6 +39,9 @@ class QgsProject;
  * to support hierarchical level of detail. Tiling scheme of a generator is defined
  * by the generator itself. Terrain generators are asked to produce new terrain tiles
  * whenever that is deemed necessary by the terrain controller (that caches generated tiles).
+ *
+ * \note Not available in Python bindings
+ *
  * \since QGIS 3.0
  */
 class _3D_EXPORT QgsTerrainGenerator : public QgsChunkLoaderFactory

--- a/src/3d/terrain/qgsterraintexturegenerator_p.h
+++ b/src/3d/terrain/qgsterraintexturegenerator_p.h
@@ -27,6 +27,8 @@
 // version without notice, or even be removed.
 //
 
+#define SIP_NO_FILE
+
 class QgsMapRendererSequentialJob;
 class QgsMapSettings;
 class QgsProject;

--- a/src/3d/terrain/qgsterraintextureimage_p.h
+++ b/src/3d/terrain/qgsterraintextureimage_p.h
@@ -27,6 +27,8 @@
 // version without notice, or even be removed.
 //
 
+#define SIP_NO_FILE
+
 #include <Qt3DRender/QAbstractTextureImage>
 
 #include "qgsrectangle.h"

--- a/src/3d/terrain/qgsterraintileloader_p.h
+++ b/src/3d/terrain/qgsterraintileloader_p.h
@@ -27,10 +27,14 @@
 // version without notice, or even be removed.
 //
 
+#define SIP_NO_FILE
+
 #include "qgschunkloader_p.h"
 
 #include <QImage>
 #include "qgsrectangle.h"
+
+#define SIP_NO_FILE
 
 class QgsPhongMaterialSettings;
 class QgsTerrainEntity;


### PR DESCRIPTION
Otherwise this provider cannot be initialized from standalone Python
scripts

Fixes #36661

Also cleanup 3d sip generation by correctly defining SIP_NO_FILE
in headers we don't want to expose, so that the sip_include script
can do its magic