### PR TITLE
Force reload when a user clicks the "Reload all repositories" button

### DIFF
--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -119,7 +119,7 @@ class QgsPluginInstaller(QObject):
 
         for key in repositories.allEnabled():
             if reloadMode or repositories.all()[key]["state"] == 3:  # if state = 3 (error or not fetched yet), try to fetch once again
-                repositories.requestFetching(key)
+                repositories.requestFetching(key, force_reload=reloadMode)
 
         if repositories.fetchingInProgress():
             fetchDlg = QgsPluginInstallerFetchingDialog(iface.mainWindow())

--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -316,7 +316,7 @@ class Repositories(QObject):
         settings.endGroup()
 
     # ----------------------------------------- #
-    def requestFetching(self, key, url=None, redirectionCounter=0):
+    def requestFetching(self, key, url=None, redirectionCounter=0, force_reload=False):
         """ start fetching the repository given by key """
         self.mRepositories[key]["state"] = 1
         if not url:
@@ -327,6 +327,8 @@ class Repositories(QObject):
         self.mRepositories[key]["QRequest"] = QNetworkRequest(url)
         self.mRepositories[key]["QRequest"].setAttribute(QNetworkRequest.Attribute(QgsNetworkRequestParameters.AttributeInitiatorClass), "Relay")
         self.mRepositories[key]["QRequest"].setAttribute(QNetworkRequest.FollowRedirectsAttribute, True)
+        if force_reload:
+            self.mRepositories[key]["QRequest"].setAttribute(QNetworkRequest.CacheLoadControlAttribute, QNetworkRequest.AlwaysNetwork)
         authcfg = self.mRepositories[key]["authcfg"]
         if authcfg and isinstance(authcfg, str):
             if not QgsApplication.authManager().updateNetworkRequest(


### PR DESCRIPTION
When a user manually presses "Reload all Repositories" in the plugin manager, then force a reload of the repositories and don't rely on cached copies of the repo manifest

Otherwise it's not possible to force a refresh on certain types of
plugin repositories where it's not possible to modify the Cache-Control
attribute of the repo

Note that to avoid unnecessary server load, we still use cached
copies during startup and by default. It's only when a user explicitly
hits the "Reload all repositories" button that we force a non-cached
fetch.

Fixes #34351
