### PR TITLE
allow to export favorite symbols from style manager (fix #27315)

### DIFF
--- a/python/gui/auto_generated/symbology/qgsstyleexportimportdialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgsstyleexportimportdialog.sip.in
@@ -73,6 +73,20 @@ selectAll selects all symbols
 clearSelection deselects all symbols
 %End
 
+    void selectFavorites();
+%Docstring
+Selects favorite symbols
+
+.. versionadded:: 3.14
+%End
+
+    void deselectFavorites();
+%Docstring
+Deselects favorite symbols
+
+.. versionadded:: 3.14
+%End
+
     void selectTag( const QString &tagName );
 %Docstring
 Select the symbols belonging to the given tag

--- a/python/gui/auto_generated/symbology/qgsstylegroupselectiondialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgsstylegroupselectiondialog.sip.in
@@ -49,6 +49,20 @@ all deselected
 all selected
 %End
 
+    void favoritesDeselected();
+%Docstring
+Favorites has been deselected
+
+.. versionadded:: 3.14
+%End
+
+    void favoritesSelected();
+%Docstring
+Favorites has need selected
+
+.. versionadded:: 3.14
+%End
+
 };
 
 /************************************************************************

--- a/src/gui/symbology/qgsstyleexportimportdialog.cpp
+++ b/src/gui/symbology/qgsstyleexportimportdialog.cpp
@@ -258,6 +258,18 @@ void QgsStyleExportImportDialog::clearSelection()
   listItems->clearSelection();
 }
 
+void QgsStyleExportImportDialog::selectFavorites()
+{
+  QStringList symbolNames = mStyle->symbolsOfFavorite( QgsStyle::SymbolEntity );
+  selectSymbols( symbolNames );
+}
+
+void QgsStyleExportImportDialog::deselectFavorites()
+{
+  QStringList symbolNames = mStyle->symbolsOfFavorite( QgsStyle::SymbolEntity );
+  deselectSymbols( symbolNames );
+}
+
 void QgsStyleExportImportDialog::selectSymbols( const QStringList &symbolNames )
 {
   const auto constSymbolNames = symbolNames;
@@ -329,6 +341,8 @@ void QgsStyleExportImportDialog::selectByGroup()
     connect( mGroupSelectionDlg, &QgsStyleGroupSelectionDialog::tagDeselected, this, &QgsStyleExportImportDialog::deselectTag );
     connect( mGroupSelectionDlg, &QgsStyleGroupSelectionDialog::allSelected, this, &QgsStyleExportImportDialog::selectAll );
     connect( mGroupSelectionDlg, &QgsStyleGroupSelectionDialog::allDeselected, this, &QgsStyleExportImportDialog::clearSelection );
+    connect( mGroupSelectionDlg, &QgsStyleGroupSelectionDialog::favoritesSelected, this, &QgsStyleExportImportDialog::selectFavorites );
+    connect( mGroupSelectionDlg, &QgsStyleGroupSelectionDialog::favoritesDeselected, this, &QgsStyleExportImportDialog::deselectFavorites );
     connect( mGroupSelectionDlg, &QgsStyleGroupSelectionDialog::smartgroupSelected, this, &QgsStyleExportImportDialog::selectSmartgroup );
     connect( mGroupSelectionDlg, &QgsStyleGroupSelectionDialog::smartgroupDeselected, this, &QgsStyleExportImportDialog::deselectSmartgroup );
   }

--- a/src/gui/symbology/qgsstyleexportimportdialog.h
+++ b/src/gui/symbology/qgsstyleexportimportdialog.h
@@ -97,13 +97,13 @@ class GUI_EXPORT QgsStyleExportImportDialog : public QDialog, private Ui::QgsSty
     void clearSelection();
 
     /**
-     * \brief selectFavorites selects favorite symbols
+     * Selects favorite symbols
      * \since QGIS 3.14
      */
     void selectFavorites();
 
     /**
-     * \brief deselectFavorites deselects favorite symbols
+     * Deselects favorite symbols
      * \since QGIS 3.14
      */
     void deselectFavorites();

--- a/src/gui/symbology/qgsstyleexportimportdialog.h
+++ b/src/gui/symbology/qgsstyleexportimportdialog.h
@@ -97,6 +97,18 @@ class GUI_EXPORT QgsStyleExportImportDialog : public QDialog, private Ui::QgsSty
     void clearSelection();
 
     /**
+     * \brief selectFavorites selects favorite symbols
+     * \since QGIS 3.14
+     */
+    void selectFavorites();
+
+    /**
+     * \brief deselectFavorites deselects favorite symbols
+     * \since QGIS 3.14
+     */
+    void deselectFavorites();
+
+    /**
      * Select the symbols belonging to the given tag
      * \param tagName the name of the group to be selected
      */

--- a/src/gui/symbology/qgsstylegroupselectiondialog.cpp
+++ b/src/gui/symbology/qgsstylegroupselectiondialog.cpp
@@ -34,6 +34,12 @@ QgsStyleGroupSelectionDialog::QgsStyleGroupSelectionDialog( QgsStyle *style, QWi
   QStandardItemModel *model = new QStandardItemModel( groupTree );
   groupTree->setModel( model );
 
+  QStandardItem *favSymbols = new QStandardItem( tr( "Favorites" ) );
+  favSymbols->setData( "favorites", Qt::UserRole + 2 );
+  favSymbols->setEditable( false );
+  setBold( favSymbols );
+  model->appendRow( favSymbols );
+
   QStandardItem *allSymbols = new QStandardItem( tr( "All" ) );
   allSymbols->setData( "all", Qt::UserRole + 2 );
   allSymbols->setEditable( false );
@@ -83,7 +89,6 @@ void QgsStyleGroupSelectionDialog::setBold( QStandardItem *item )
   item->setFont( font );
 }
 
-
 void QgsStyleGroupSelectionDialog::groupTreeSelectionChanged( const QItemSelection &selected, const QItemSelection &deselected )
 {
   const QModelIndexList selectedItems = selected.indexes();
@@ -94,6 +99,10 @@ void QgsStyleGroupSelectionDialog::groupTreeSelectionChanged( const QItemSelecti
     if ( index.data( Qt::UserRole + 2 ).toString() == QLatin1String( "tagssheader" ) )
     {
       // Ignore: it's the group header
+    }
+    else if ( index.data( Qt::UserRole + 2 ).toString() == QLatin1String( "favorites" ) )
+    {
+      emit favoritesDeselected();
     }
     else if ( index.data( Qt::UserRole + 2 ).toString() == QLatin1String( "all" ) )
     {
@@ -120,6 +129,10 @@ void QgsStyleGroupSelectionDialog::groupTreeSelectionChanged( const QItemSelecti
     {
       // Ignore: it's the group header
     }
+    else if ( index.data( Qt::UserRole + 2 ).toString() == QLatin1String( "favorites" ) )
+    {
+      emit favoritesSelected();
+    }
     else if ( index.data( Qt::UserRole + 2 ).toString() == QLatin1String( "all" ) )
     {
       emit allSelected();
@@ -140,7 +153,6 @@ void QgsStyleGroupSelectionDialog::groupTreeSelectionChanged( const QItemSelecti
   }
 }
 
-
 void QgsStyleGroupSelectionDialog::buildTagTree( QStandardItem *&parent )
 {
   QStringList tags = mStyle->tags();
@@ -155,4 +167,3 @@ void QgsStyleGroupSelectionDialog::buildTagTree( QStandardItem *&parent )
     parent->appendRow( item );
   }
 }
-

--- a/src/gui/symbology/qgsstylegroupselectiondialog.h
+++ b/src/gui/symbology/qgsstylegroupselectiondialog.h
@@ -51,6 +51,14 @@ class GUI_EXPORT QgsStyleGroupSelectionDialog : public QDialog, private Ui::Symb
     void allDeselected();
     //! all selected
     void allSelected();
+    /** favorites has been deselected
+     * \since QGIS 3.14
+     */
+    void favoritesDeselected();
+    /** favorites has need selected
+     * \since QGIS 3.14
+     */
+    void favoritesSelected();
 
   private slots:
     void groupTreeSelectionChanged( const QItemSelection &selected, const QItemSelection &deselected );

--- a/src/gui/symbology/qgsstylegroupselectiondialog.h
+++ b/src/gui/symbology/qgsstylegroupselectiondialog.h
@@ -51,11 +51,15 @@ class GUI_EXPORT QgsStyleGroupSelectionDialog : public QDialog, private Ui::Symb
     void allDeselected();
     //! all selected
     void allSelected();
-    /** favorites has been deselected
+
+    /**
+     * Favorites has been deselected
      * \since QGIS 3.14
      */
     void favoritesDeselected();
-    /** favorites has need selected
+
+    /**
+     * Favorites has need selected
      * \since QGIS 3.14
      */
     void favoritesSelected();


### PR DESCRIPTION
## Description
When exporting symbols from Style manager one can select symbols with mouse or using "Select by group" button. The latter allows to select symbols which belong to some smart group or tag but it is not possible to select favorite symbols.

Proposed PR adds "Favorites" group to the "Select by group" dialog to allow selecting favorite symbols and make it consistent with group selector in the Style manager itself.

Fixes #27315.

Not sure about backport to 3.10.