### PR TITLE
Don't modify project when snapping utils config is modified

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1062,7 +1062,6 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   mMapCanvas->setSnappingUtils( mSnappingUtils );
   connect( QgsProject::instance(), &QgsProject::snappingConfigChanged, mSnappingUtils, &QgsSnappingUtils::setConfig );
   connect( QgsProject::instance(), &QgsProject::collectAttachedFiles, this, &QgisApp::generateProjectAttachedFiles );
-  connect( mSnappingUtils, &QgsSnappingUtils::configChanged, QgsProject::instance(), &QgsProject::setSnappingConfig );
 
   endProfile();
 


### PR DESCRIPTION
Fixes #36796

QgsSnappingUtils configuration is modified from [snapToEditableLayer](https://github.com/qgis/QGIS/blob/master/src/app/vertextool/qgsvertextool.cpp#L775) and so fire _configChanged_ signal which modifies the project. 

I remove the signal connection which was added in 5176ecf597a510cb5f32973fa3723532cbbc52fe

The shortcut for toggle snapping seems to not exist anymore and modifying project snapping configuration should be done thanks to QgsProject method _setSnappingConfig_, not from QgsSnappingUtils.
