### PR TITLE
QgsAttributeTableModel loadAttributes Fix #36790

### DIFF
--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -405,11 +405,11 @@ void QgsAttributeTableModel::loadAttributes()
   if ( mFieldCount + mExtraColumns < attributes.size() + mExtraColumns )
   {
     ins = true;
-	if (attributes.size() - 1 >= mFieldCount + mExtraColumns) {
-		beginInsertColumns( QModelIndex(), mFieldCount + mExtraColumns, attributes.size() - 1 );
-	} else {
-		beginInsertColumns( QModelIndex(), attributes.size() - 1, mFieldCount + mExtraColumns );
-	}
+	  if ( attributes.size() - 1 >= mFieldCount + mExtraColumns ) {
+		  beginInsertColumns( QModelIndex(), mFieldCount + mExtraColumns, attributes.size() - 1 );
+	  } else {
+		  beginInsertColumns( QModelIndex(), attributes.size() - 1, mFieldCount + mExtraColumns );
+	  }
   }
   else if ( attributes.size() + mExtraColumns < mFieldCount + mExtraColumns )
   {

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -405,7 +405,11 @@ void QgsAttributeTableModel::loadAttributes()
   if ( mFieldCount + mExtraColumns < attributes.size() + mExtraColumns )
   {
     ins = true;
-    beginInsertColumns( QModelIndex(), mFieldCount + mExtraColumns, attributes.size() - 1 );
+	if (attributes.size() - 1 >= mFieldCount + mExtraColumns) {
+		beginInsertColumns( QModelIndex(), mFieldCount + mExtraColumns, attributes.size() - 1 );
+	} else {
+		beginInsertColumns( QModelIndex(), attributes.size() - 1, mFieldCount + mExtraColumns );
+	}
   }
   else if ( attributes.size() + mExtraColumns < mFieldCount + mExtraColumns )
   {


### PR DESCRIPTION
## Description
Fixes #36790 
In debug mode, last row number less than first row number, so crashed when adding one field of vectorlayer