### PR TITLE
Be more lenient on accepted "beta" SAGA versions

### DIFF
--- a/python/plugins/processing/algs/saga/SagaAlgorithmProvider.py
+++ b/python/plugins/processing/algs/saga/SagaAlgorithmProvider.py
@@ -41,7 +41,7 @@ pluginPath = os.path.normpath(os.path.join(
     os.path.split(os.path.dirname(__file__))[0], os.pardir))
 
 REQUIRED_VERSION = '2.3.'
-BETA_SUPPORT_VERSION = '7.3.'
+BETA_SUPPORT_VERSION = '7.'
 
 
 class SagaAlgorithmProvider(QgsProcessingProvider):


### PR DESCRIPTION
Even though SAGA explicitly does't follow semver conventions, there are
advances, and not all changes on their part break the API. Since the
user is already warned in big letters that versions different from 2.3
are unsupported, in beta status, we've changed the requirement for SAGA
"beta" from 7.3 to everything in version 7.

I've tested locally with SAGA 7.3.0 and 7.6.3, by issuing:

`ctest -V -R ProcessingSagaAlgorithmsTest`

and rebuilding QGIS (but not reconfiguring) after installing each version of SAGA.

If it helps, these are the last few lines of the ctest output:

For SAGA 7.3.0:

```
<...> snip
22: ----------------------------------------------------------------------
22: Ran 43 tests in 75.032s
22: 
22: FAILED (failures=30)
22: CMake Error at ProcessingSagaAlgorithmsTest.cmake:15 (MESSAGE):
22:   Test failed: Segmentation fault
22: 
22: 
1/1 Test #22: ProcessingSagaAlgorithmsTest .....***Failed   86.42 sec
```

For SAGA 7.6.3:

```
<...> snip
22: Ran 43 tests in 39.600s
22: 
22: FAILED (failures=28)
22: CMake Error at ProcessingSagaAlgorithmsTest.cmake:15 (MESSAGE):
22:   Test failed: Segmentation fault
22: 
22: 
1/1 Test #22: ProcessingSagaAlgorithmsTest .....***Failed   48.68 sec
```

If needed, I have the full stdout log of both test runs.