### PR TITLE
Some tweaks to the Obstacle Settings dialog

### DIFF
--- a/src/gui/labeling/qgslabelsettingswidgetbase.cpp
+++ b/src/gui/labeling/qgslabelsettingswidgetbase.cpp
@@ -21,6 +21,7 @@
 #include "qgspropertyoverridebutton.h"
 #include "qgsauxiliarystorage.h"
 #include "qgsgui.h"
+#include "qgshelp.h"
 
 
 QgsLabelSettingsWidgetBase::QgsLabelSettingsWidgetBase( QWidget *parent, QgsVectorLayer *vl )
@@ -162,9 +163,13 @@ QgsLabelSettingsWidgetDialog::QgsLabelSettingsWidgetDialog( QgsLabelSettingsWidg
   setWindowTitle( widget->windowTitle() );
   QVBoxLayout *vLayout = new QVBoxLayout();
   vLayout->addWidget( widget );
-  QDialogButtonBox *bbox = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal );
+  QDialogButtonBox *bbox = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel | QDialogButtonBox::Help, Qt::Horizontal );
   connect( bbox, &QDialogButtonBox::accepted, this, &QDialog::accept );
   connect( bbox, &QDialogButtonBox::rejected, this, &QDialog::reject );
+  connect( bbox, &QDialogButtonBox::helpRequested, this, [ = ]
+  {
+    QgsHelp::openHelp( QStringLiteral( "style_library/label_settings.html#obstacles" ) );
+  } );
   vLayout->addWidget( bbox );
   setLayout( vLayout );
 

--- a/src/ui/labeling/qgslabelobstaclesettingswidgetbase.ui
+++ b/src/ui/labeling/qgslabelobstaclesettingswidgetbase.ui
@@ -11,9 +11,21 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string notr="true">Form</string>
+   <string notr="true">Obstacle Settings</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item row="3" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
@@ -22,7 +34,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
+       <height>0</height>
       </size>
      </property>
     </spacer>
@@ -36,7 +48,7 @@
       <item>
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Setting a higher weight for obstacles means that labels are less likely to cover features in this layer.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Only labels with a higher priority then this obstacle weight will be placed over these obstacles.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Setting a higher weight for obstacles means that labels are less likely to cover features in this layer.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Only labels with a higher priority than this obstacle weight will be placed over these obstacles.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>


### PR DESCRIPTION
Add title, a help button and fix typo

![obstaclesSettinsg](https://user-images.githubusercontent.com/7983394/83213629-e8a1b480-a162-11ea-96d6-ebc4083a02af.png)
Not sure whether that was the most appropriate place to add the help button

Also I found that there's an issue in the dialog in that the second paragraph can be totally hidden whie resizing the dialog (not fixed here)