### PR TITLE
fix calculating raster size in the TIN and IDW algorithms to maintain accurate pixel size (fix #31970)

### DIFF
--- a/python/plugins/processing/algs/qgis/IdwInterpolation.py
+++ b/python/plugins/processing/algs/qgis/IdwInterpolation.py
@@ -22,6 +22,7 @@ __date__ = 'October 2016'
 __copyright__ = '(C) 2016, Alexander Bruy'
 
 import os
+import math
 
 from qgis.PyQt.QtGui import QIcon
 
@@ -114,9 +115,9 @@ class IdwInterpolation(QgisAlgorithm):
         columns = self.parameterAsInt(parameters, self.COLUMNS, context)
         rows = self.parameterAsInt(parameters, self.ROWS, context)
         if columns == 0:
-            columns = max(round(bbox.width() / pixel_size) + 1, 1)
+            columns = max(math.ceil(bbox.width() / pixel_size), 1)
         if rows == 0:
-            rows = max(round(bbox.height() / pixel_size) + 1, 1)
+            rows = max(math.ceil(bbox.height() / pixel_size), 1)
 
         if interpolationData is None:
             raise QgsProcessingException(

--- a/python/plugins/processing/algs/qgis/TinInterpolation.py
+++ b/python/plugins/processing/algs/qgis/TinInterpolation.py
@@ -22,6 +22,7 @@ __date__ = 'October 2016'
 __copyright__ = '(C) 2016, Alexander Bruy'
 
 import os
+import math
 
 from qgis.PyQt.QtGui import QIcon
 
@@ -130,9 +131,9 @@ class TinInterpolation(QgisAlgorithm):
         columns = self.parameterAsInt(parameters, self.COLUMNS, context)
         rows = self.parameterAsInt(parameters, self.ROWS, context)
         if columns == 0:
-            columns = max(round(bbox.width() / pixel_size) + 1, 1)
+            columns = max(math.ceil(bbox.width() / pixel_size), 1)
         if rows == 0:
-            rows = max(round(bbox.height() / pixel_size) + 1, 1)
+            rows = max(math.ceil(bbox.height() / pixel_size), 1)
 
         if interpolationData is None:
             raise QgsProcessingException(

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests2.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests2.yaml
@@ -2,185 +2,202 @@
 
 tests:
 
+  - algorithm: qgis:tininterpolation
+    name: TIN interpolation using attribute
+    params:
+      EXTENT: 0.000000000,8.000000000,-5.000000000,3.000000000 [EPSG:4326]
+      INTERPOLATION_DATA:
+        name: pointsz.gml::~::0::~::1::~::0
+        type: interpolation
+      METHOD: 0
+      PIXEL_SIZE: 0.1
+    results:
+      OUTPUT:
+        hash:
+          - bfb3616a73065c0cb41eb1c5c1e9e8812fe1c63019a6177adb1dfe3e
+          - 19bbd79d15b0ba7dbde05665d559e9806fdb1cd579df9222f9cc4d92
+        type: rasterhash
+
+  - algorithm: qgis:tininterpolation
+    name: TIN interpolation using Z value
+    params:
+      EXTENT: 0.000000000,8.000000000,-5.000000000,3.000000000 [EPSG:4326]
+      INTERPOLATION_DATA:
+        name: pointsz.gml::~::1::~::-1::~::0
+        type: interpolation
+      METHOD: 0
+      PIXEL_SIZE: 0.1
+    results:
+      OUTPUT:
+        hash:
+          - bfb3616a73065c0cb41eb1c5c1e9e8812fe1c63019a6177adb1dfe3e
+          - 19bbd79d15b0ba7dbde05665d559e9806fdb1cd579df9222f9cc4d92
+        type: rasterhash
+
+  - algorithm: qgis:tininterpolation
+    name: TIN interpolation with breaklines
+    params:
+      EXTENT: 0.000000000,8.000000000,-5.000000000,3.000000000 [EPSG:4326]
+      INTERPOLATION_DATA:
+        name: pointsz.gml::~::1::~::-1::~::0::|::breaklines.gml::~::0::~::1::~::2
+        type: interpolation
+      METHOD: 0
+      PIXEL_SIZE: 0.1
+    results:
+      OUTPUT:
+        hash:
+          - b8e49813c507b73cb39a5ad904b2d302ccb25c591a2e577b6405f982
+          - 19bbd79d15b0ba7dbde05665d559e9806fdb1cd579df9222f9cc4d92
+        type: rasterhash
+
+  - algorithm: qgis:tininterpolation
+    name: TIN interpolation using attribute (old parameters)
+    params:
+      EXTENT: 0.000000000,8.000000000,-5.000000000,3.000000000 [EPSG:4326]
+      INTERPOLATION_DATA:
+        name: pointsz.gml::~::0::~::1::~::0
+        type: interpolation
+      METHOD: 0
+      COLUMNS: 80
+      ROWS: 80
+    results:
+      OUTPUT:
+        hash:
+          - bfb3616a73065c0cb41eb1c5c1e9e8812fe1c63019a6177adb1dfe3e
+          - 19bbd79d15b0ba7dbde05665d559e9806fdb1cd579df9222f9cc4d92
+        type: rasterhash
+
+  - algorithm: qgis:tininterpolation
+    name: TIN interpolation using Z value (old parameters)
+    params:
+      EXTENT: 0.000000000,8.000000000,-5.000000000,3.000000000 [EPSG:4326]
+      INTERPOLATION_DATA:
+        name: pointsz.gml::~::1::~::-1::~::0
+        type: interpolation
+      METHOD: 0
+      COLUMNS: 80
+      ROWS: 80
+    results:
+      OUTPUT:
+        hash:
+          - bfb3616a73065c0cb41eb1c5c1e9e8812fe1c63019a6177adb1dfe3e
+          - 19bbd79d15b0ba7dbde05665d559e9806fdb1cd579df9222f9cc4d92
+        type: rasterhash
+
+  - algorithm: qgis:tininterpolation
+    name: TIN interpolation with breaklines (old parameters)
+    params:
+      EXTENT: 0.000000000,8.000000000,-5.000000000,3.000000000 [EPSG:4326]
+      INTERPOLATION_DATA:
+        name: pointsz.gml::~::1::~::-1::~::0::|::breaklines.gml::~::0::~::1::~::2
+        type: interpolation
+      METHOD: 0
+      COLUMNS: 80
+      ROWS: 80
+    results:
+      OUTPUT:
+        hash:
+          - b8e49813c507b73cb39a5ad904b2d302ccb25c591a2e577b6405f982
+          - 19bbd79d15b0ba7dbde05665d559e9806fdb1cd579df9222f9cc4d92
+        type: rasterhash
+
   - algorithm: qgis:idwinterpolation
     name: IDW interpolation using attribute
     params:
       DISTANCE_COEFFICIENT: 2.0
-      EXTENT: 0.0,8.0,-5.0,3.0 [EPSG:4326]
+      EXTENT: 0.000000000,8.000000000,-5.000000000,3.000000000 [EPSG:4326]
       INTERPOLATION_DATA:
         name: pointsz.gml::~::0::~::1::~::0
         type: interpolation
-      PIXEL_SIZE: 0.026667
+      PIXEL_SIZE: 0.1
     results:
       OUTPUT:
         hash:
-          - 76d59e1a9905e97fde7da598022d50ec7de15994e61a59e2b6dc952f
-          - 6d2da87e58dfe8fdfb3a1b66543bc68870f7e3292a9ca2674ea3a523
+          - 55dfd0e0e5ea300d2314785ab6aa1f4d941a4506e63d0d9e2b84e959
+          - b5fc06549f1b0ce3261f9fb8868bb6d082edcbfe409c89a82e2b7e7a
         type: rasterhash
 
   - algorithm: qgis:idwinterpolation
     name: IDW interpolation using Z value
     params:
       DISTANCE_COEFFICIENT: 2.0
-      EXTENT: 0.0,8.0,-5.0,3.0 [EPSG:4326]
-      INTERPOLATION_DATA:
-        name: pointsz.gml::~::1::~::1::~::0
-        type: interpolation
-      PIXEL_SIZE: 0.026667
-    results:
-      OUTPUT:
-        hash:
-          - 76d59e1a9905e97fde7da598022d50ec7de15994e61a59e2b6dc952f
-          - 6d2da87e58dfe8fdfb3a1b66543bc68870f7e3292a9ca2674ea3a523
-        type: rasterhash
-
-  - algorithm: qgis:tininterpolation
-    name: TIN interpolation using attribute
-    params:
-      EXTENT: 0.0,8.0,-5.0,3.0 [EPSG:4326]
-      INTERPOLATION_DATA:
-        name: pointsz.gml::~::0::~::1::~::0
-        type: interpolation
-      METHOD: 0
-      PIXEL_SIZE: 0.026667
-    results:
-      OUTPUT:
-        hash:
-          - 1e07ea5c90a16f87df812042d3e89dd5b1216defa7714921f306de94
-          - 6e533a4c2c2e8ef5ca62814a7ad6dd29cb0f0f6eea85baf2a2802870
-        type: rasterhash
-      #TRIANGULATION_FILE:
-      #  name: expected/triangulation.gml
-      #  type: vector
-
-  - algorithm: qgis:tininterpolation
-    name: TIN interpolation using Z value
-    params:
-      EXTENT: 0.0,8.0,-5.0,3.0 [EPSG:4326]
+      EXTENT: 0.000000000,8.000000000,-5.000000000,3.000000000 [EPSG:4326]
       INTERPOLATION_DATA:
         name: pointsz.gml::~::1::~::-1::~::0
         type: interpolation
-      METHOD: 0
-      PIXEL_SIZE: 0.026667
-    results:
-      OUTPUT:
-        hash:
-          - 1e07ea5c90a16f87df812042d3e89dd5b1216defa7714921f306de94
-          - 6d2da87e58dfe8fdfb3a1b66543bc68870f7e3292a9ca2674ea3a523
-          - 6e533a4c2c2e8ef5ca62814a7ad6dd29cb0f0f6eea85baf2a2802870
-        type: rasterhash
-      #TRIANULATION_FILE:
-      #  name: expected/triangulation.gml
-      #  type: vector
-
-  - algorithm: qgis:tininterpolation
-    name: TIN interpolation with breaklines
-    params:
-      EXTENT: -0.4450000000000012,8.445,-5.2,3.2 [EPSG:4326]
-      INTERPOLATION_DATA:
-        name: pointsz.gml::~::1::~::-1::~::0::|::breaklines.gml::~::0::~::1::~::2
-        type: interpolation
-      METHOD: 0
       PIXEL_SIZE: 0.1
     results:
       OUTPUT:
         hash:
-        - 34ebe51b4ff75e2eb80746571ac4b72709d200f5d36a1d367d7b0b32
-        - d2529829631d5b816dba56305736ed7e6961bc63f224f351be719c78
+          - 55dfd0e0e5ea300d2314785ab6aa1f4d941a4506e63d0d9e2b84e959
+          - b5fc06549f1b0ce3261f9fb8868bb6d082edcbfe409c89a82e2b7e7a
+        type: rasterhash
+
+  - algorithm: qgis:idwinterpolation
+    name: IDW interpolation with breaklines
+    params:
+      DISTANCE_COEFFICIENT: 2.0
+      EXTENT: 0.000000000,8.000000000,-5.000000000,3.000000000 [EPSG:4326]
+      INTERPOLATION_DATA:
+        name: pointsz.gml::~::1::~::-1::~::0::|::breaklines.gml::~::0::~::1::~::2
+        type: interpolation
+      PIXEL_SIZE: 0.1
+    results:
+      OUTPUT:
+        hash:
+          - d53cd7327d53bd4b8fb2de8b206e5aa0a1366963f2b63f58c2b7926e
+          - b5fc06549f1b0ce3261f9fb8868bb6d082edcbfe409c89a82e2b7e7a
         type: rasterhash
 
   - algorithm: qgis:idwinterpolation
     name: IDW interpolation using attribute (old parameters)
     params:
-      COLUMNS: 300
       DISTANCE_COEFFICIENT: 2.0
-      EXTENT: 0, 8, -5, 3
+      EXTENT: 0.000000000,8.000000000,-5.000000000,3.000000000 [EPSG:4326]
       INTERPOLATION_DATA:
         name: pointsz.gml::~::0::~::1::~::0
         type: interpolation
-      ROWS: 300
+      COLUMNS: 80
+      ROWS: 80
     results:
       OUTPUT:
         hash:
-          - 56d2671d50444f8571affba3f9e585830b82af5e380394178f521065
-          - 2ae62aca803e6864ac75e47b4357292b0637d811cb510ed19471f422
-          - 3851b5d5f4030513003883150a64c83ec5d63709a6a5866867440309
+          - 55dfd0e0e5ea300d2314785ab6aa1f4d941a4506e63d0d9e2b84e959
+          - b5fc06549f1b0ce3261f9fb8868bb6d082edcbfe409c89a82e2b7e7a
         type: rasterhash
 
   - algorithm: qgis:idwinterpolation
     name: IDW interpolation using Z value (old parameters)
     params:
-      COLUMNS: 300
       DISTANCE_COEFFICIENT: 2.0
-      EXTENT: 0, 8, -5, 3
+      EXTENT: 0.000000000,8.000000000,-5.000000000,3.000000000 [EPSG:4326]
       INTERPOLATION_DATA:
         name: pointsz.gml::~::1::~::-1::~::0
         type: interpolation
-      ROWS: 300
+      COLUMNS: 80
+      ROWS: 80
     results:
       OUTPUT:
         hash:
-          - 56d2671d50444f8571affba3f9e585830b82af5e380394178f521065
-          - 2ae62aca803e6864ac75e47b4357292b0637d811cb510ed19471f422
-          - 3851b5d5f4030513003883150a64c83ec5d63709a6a5866867440309
+          - 55dfd0e0e5ea300d2314785ab6aa1f4d941a4506e63d0d9e2b84e959
+          - b5fc06549f1b0ce3261f9fb8868bb6d082edcbfe409c89a82e2b7e7a
         type: rasterhash
-
-  - algorithm: qgis:tininterpolation
-    name: TIN interpolation using attribute (old parameters)
-    params:
-      COLUMNS: 300
-      EXTENT: 0, 8, -5, 3
-      INTERPOLATION_DATA:
-        name: pointsz.gml::~::0::~::1::~::0
-        type: interpolation
-      METHOD: '0'
-      ROWS: 300
-    results:
-      OUTPUT:
-        hash:
-          - 87f40be6ec08f3fcbb5707762de71f6be35bb265c61f594335562a26
-          - a31f0faf918ebe0902e5c9c5c8cf606d30f52eb4094bf24e4f8ac67a
-          - de8de3914164770865c0045b19cb9bd68531d74e7ceb9794a5f4989d
-        type: rasterhash
-      #TRIANGULATION_FILE:
-      #  name: expected/triangulation.gml
-      #  type: vector
-
-  - algorithm: qgis:tininterpolation
-    name: TIN interpolation using Z value (old parameters)
-    params:
-      COLUMNS: 300
-      EXTENT: 0, 8, -5, 3
-      INTERPOLATION_DATA:
-        name: pointsz.gml::~::1::~::-1::~::0
-        type: interpolation
-      METHOD: '1'
-      ROWS: 300
-    results:
-      OUTPUT:
-        hash:
-          - 5e14dd0b879884b8b8da56c082947dad681feb4e9f1137f5cda126f8
-          - b8389559d6a85e7a672d72254228473fae71af2d89e5a5dd73d1b0d7
-          - caeb23e86e710ab0e5555eb8508e9b07b162706bda7fa4faeb94cd7b
-        type: rasterhash
-      #TRIANULATION_FILE:
-      #  name: expected/triangulation.gml
-      #  type: vector
 
   - algorithm: qgis:idwinterpolation
-    name: IDW interpolation with breakline
+    name: IDW interpolation with breaklines (old parameters)
     params:
       DISTANCE_COEFFICIENT: 2.0
-      EXTENT: -0.4450000000000012,8.445,-5.2,3.2 [EPSG:4326]
+      EXTENT: 0.000000000,8.000000000,-5.000000000,3.000000000 [EPSG:4326]
       INTERPOLATION_DATA:
         name: pointsz.gml::~::1::~::-1::~::0::|::breaklines.gml::~::0::~::1::~::2
         type: interpolation
-      PIXEL_SIZE: 0.1
+      COLUMNS: 80
+      ROWS: 80
     results:
       OUTPUT:
         hash:
-        - 56ecc53f6c66a21dd0379170a833c87337932160767cdf9cc47695a8
-        - f096ffa048892c87eae61ddd4253501f1236ad785a9b084a2badf051
+          - d53cd7327d53bd4b8fb2de8b206e5aa0a1366963f2b63f58c2b7926e
+          - b5fc06549f1b0ce3261f9fb8868bb6d082edcbfe409c89a82e2b7e7a
         type: rasterhash
 
   - algorithm: native:removenullgeometries


### PR DESCRIPTION
## Description
TIN and IDW interpolation algorithms produce outputs with slightly different (smaller) pixel size than requested. Proposed PR fixes rounding issue so result has more accurate pixel size.

Fixes #31970.