### PR TITLE
FIX #35196, layer was not set on QgsFieldExpressionWidget

### DIFF
--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
@@ -18,7 +18,7 @@
 #include "qgsattributesformproperties.h"
 
 
-QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *item, QWidget *parent )
+QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *item, QgsVectorLayer *layer, QWidget *parent )
   : QWidget( parent )
   , mTreeItem( item )
 {
@@ -40,6 +40,7 @@ QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *i
   mShowAsGroupBoxCheckBox->setChecked( itemData.showAsGroupBox() );
 
   mControlVisibilityGroupBox->setChecked( itemData.visibilityExpression().enabled() );
+  mVisibilityExpressionWidget->setLayer( layer );
   mVisibilityExpressionWidget->setExpression( itemData.visibilityExpression()->expression() );
   mColumnCountSpinBox->setValue( itemData.columnCount() );
   mBackgroundColorButton->setColor( itemData.backgroundColor() );

--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.h
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.h
@@ -36,7 +36,7 @@ class GUI_EXPORT QgsAttributeFormContainerEdit: public QWidget, private Ui_QgsAt
     Q_OBJECT
 
   public:
-    explicit QgsAttributeFormContainerEdit( QTreeWidgetItem *item, QWidget *parent = nullptr );
+    explicit QgsAttributeFormContainerEdit( QTreeWidgetItem *item, QgsVectorLayer *layer, QWidget *parent = nullptr );
 
     /**
      * Register an expression context generator class that will be used to retrieve

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -438,7 +438,7 @@ void QgsAttributesFormProperties::loadAttributeContainerEdit()
     return;
 
   QTreeWidgetItem *currentItem = mFormLayoutTree->selectedItems().at( 0 );
-  mAttributeContainerEdit = new QgsAttributeFormContainerEdit( currentItem, this );
+  mAttributeContainerEdit = new QgsAttributeFormContainerEdit( currentItem, mLayer, this );
   mAttributeContainerEdit->registerExpressionContextGenerator( this );
   mAttributeContainerEdit->layout()->setContentsMargins( 0, 0, 0, 0 );
   mAttributeTypeFrame->layout()->setContentsMargins( 0, 0, 0, 0 );


### PR DESCRIPTION
## Description

The PR fixes issue #35196 . As explained by @Gustry, the visibility expression filter for container is not populated with layer's fields in the attributes form configuration (Drag and Drop mode) :

![image](https://user-images.githubusercontent.com/18545440/83251235-9d5ec480-a1a9-11ea-910e-1e8a7a064f56.png)

![image](https://user-images.githubusercontent.com/18545440/83251310-be271a00-a1a9-11ea-829f-5e815d75e512.png)

Usually we set the reference layer to QgsFieldExpressionWidget, so it can use layer's fields in expression filter. But it  wasn't done for QgsAttributeFormContainerEdit.

Simple as this :) : 
![image](https://user-images.githubusercontent.com/18545440/83250793-f8dc8280-a1a8-11ea-9245-0e141f5634ad.png)

I don't know if there is a test to do for this. QgsFieldExpressionWidget is already tested