### PR TITLE
Add safety check

### DIFF
--- a/src/core/pal/layer.cpp
+++ b/src/core/pal/layer.cpp
@@ -203,7 +203,7 @@ bool Layer::registerFeature( QgsLabelFeature *lf )
       geos::unique_ptr geom = QgsGeos::asGeos( *it );
 
       // ignore invalid geometries (e.g. polygons with self-intersecting rings)
-      if ( GEOSisValid_r( geosctxt, geom.get() ) != 1 ) // 0=invalid, 1=valid, 2=exception
+      if ( !geom.get() || GEOSisValid_r( geosctxt, geom.get() ) != 1 ) // 0=invalid, 1=valid, 2=exception
       {
         continue;
       }


### PR DESCRIPTION
Fixes #36346

## Description

Please note, zooming out still triggers an assert in RTree. By nature this will only be observable on debug builds and I assume it's a different issue.