### PR TITLE
Fixes DB manager queries with duplicated field names

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1149,7 +1149,11 @@ bool QgsPostgresProvider::loadFields()
     if ( fields.contains( fieldName ) )
     {
       QgsMessageLog::logMessage( tr( "Duplicate field %1 found\n" ).arg( fieldName ), tr( "PostGIS" ) );
-      return false;
+      // In case of read-only query layers we can safely ignore the issue
+      if ( ! mIsQuery )
+      {
+        return false;
+      }
     }
 
     fields << fieldName;

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2387,6 +2387,19 @@ class TestPyQgsPostgresProviderBigintSinglePk(unittest.TestCase, ProviderTestCas
             self.assertFalse(l.dataProvider().addFeatures([f1, f2]),
                              'Provider reported no AddFeatures capability, but returned true to addFeatures')
 
+    def testDuplicatedFieldNamesInQueryLayers(self):
+        """Test regresssion GH #36205"""
+
+        vl = QgsVectorLayer(self.dbconn + ' sslmode=disable key=\'__rid__\' table="(SELECT row_number() OVER () AS __rid__, * FROM (SELECT *  from qgis_test.some_poly_data a, qgis_test.some_poly_data b  where  ST_Intersects(a.geom,b.geom)) as foo)" sql=', 'test_36205', 'postgres')
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.featureCount(), 3)
+
+        # This fails because the "geom" field and "pk" fields are ambiguous
+        # There is no easy fix: all duplicated fields should be explicitly aliased
+        # and the query internally rewritten
+        #feature = next(vl.getFeatures())
+        #self.assertTrue(vl.isValid())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2397,8 +2397,8 @@ class TestPyQgsPostgresProviderBigintSinglePk(unittest.TestCase, ProviderTestCas
         # This fails because the "geom" field and "pk" fields are ambiguous
         # There is no easy fix: all duplicated fields should be explicitly aliased
         # and the query internally rewritten
-        #feature = next(vl.getFeatures())
-        #self.assertTrue(vl.isValid())
+        # feature = next(vl.getFeatures())
+        # self.assertTrue(vl.isValid())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is probably a missing API in the provider metadata, we should not use QgsVectorLayer just to extract the information about fields, but for now returning a valid **query** layer in these corner cases it's probably the best we can do, the layer is just used to extract fields information and thrown away.

Fixes #36205

