### PR TITLE
Another batch of cppcheck fixes

### DIFF
--- a/python/analysis/auto_generated/network/qgsgraphbuilder.sip.in
+++ b/python/analysis/auto_generated/network/qgsgraphbuilder.sip.in
@@ -11,7 +11,7 @@
 
 
 
-class QgsGraphBuilder : QgsGraphBuilderInterface
+class QgsGraphBuilder : QgsGraphBuilderInterface /NoDefaultCtors/
 {
 %Docstring
 This class used for making the QgsGraph object

--- a/src/3d/symbols/qgsmesh3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsmesh3dsymbol_p.cpp
@@ -115,7 +115,7 @@ Qt3DRender::QGeometryRenderer *QgsMesh3DSymbolEntityNode::renderer( const Qgs3DM
   }
 
   const QgsTriangularMesh *mesh = layer->triangularMesh();
-  if ( layer && mesh )
+  if ( mesh )
   {
     const QVector<QgsMeshFace> &triangles = mesh->triangles();
     const QVector<QgsMeshVertex> &vertices = mesh->vertices();

--- a/src/analysis/interpolation/NormVecDecorator.h
+++ b/src/analysis/interpolation/NormVecDecorator.h
@@ -80,6 +80,10 @@ class ANALYSIS_EXPORT NormVecDecorator: public TriDecorator
     QVector<PointState> *mPointState;
     //! Sets the state (BreakLine, Normal, EndPoint) of a point
     void setState( int pointno, PointState s );
+
+  private:
+    NormVecDecorator( const NormVecDecorator & ) = delete;
+    NormVecDecorator &operator=( const NormVecDecorator & ) = delete;
 };
 
 #ifndef SIP_RUN

--- a/src/analysis/network/qgsgraphbuilder.h
+++ b/src/analysis/network/qgsgraphbuilder.h
@@ -32,7 +32,7 @@ class QgsGraph;
 * \brief This class used for making the QgsGraph object
 */
 
-class ANALYSIS_EXPORT QgsGraphBuilder : public QgsGraphBuilderInterface
+class ANALYSIS_EXPORT QgsGraphBuilder : public QgsGraphBuilderInterface SIP_NODEFAULTCTORS
 {
   public:
 
@@ -58,6 +58,9 @@ class ANALYSIS_EXPORT QgsGraphBuilder : public QgsGraphBuilderInterface
   private:
 
     QgsGraph *mGraph = nullptr;
+
+    QgsGraphBuilder( const QgsGraphBuilder & ) = delete;
+    QgsGraphBuilder &operator=( const QgsGraphBuilder & ) = delete;
 };
 
 // clazy:excludeall=qstring-allocations

--- a/src/analysis/processing/qgsalgorithmjoinwithlines.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinwithlines.cpp
@@ -116,7 +116,7 @@ QVariantMap QgsJoinWithLinesAlgorithm::processAlgorithm( const QVariantMap &para
     throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "HUBS" ) ) );
 
   std::unique_ptr< QgsProcessingFeatureSource > spokeSource( parameterAsSource( parameters, QStringLiteral( "SPOKES" ), context ) );
-  if ( !hubSource || !spokeSource )
+  if ( !spokeSource )
     throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "SPOKES" ) ) );
 
   QString fieldHubName = parameterAsString( parameters, QStringLiteral( "HUB_FIELD" ), context );

--- a/src/analysis/vector/geometry_checker/qgsgeometryfollowboundariescheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryfollowboundariescheck.h
@@ -47,6 +47,9 @@ class ANALYSIS_EXPORT QgsGeometryFollowBoundariesCheck : public QgsGeometryCheck
     enum ResolutionMethod { NoChange };
     QgsVectorLayer *mCheckLayer;
     QgsSpatialIndex *mIndex = nullptr;
+
+    QgsGeometryFollowBoundariesCheck( const QgsGeometryFollowBoundariesCheck & ) = delete;
+    QgsGeometryFollowBoundariesCheck &operator=( const QgsGeometryFollowBoundariesCheck & ) = delete;
 };
 
 #endif // QGSGEOMETRYFOLLOWBOUNDARIESCHECK_H

--- a/src/app/qgsvariantdelegate.cpp
+++ b/src/app/qgsvariantdelegate.cpp
@@ -361,12 +361,12 @@ QVariant::Type QgsVariantDelegate::type( const QVariant &value )
 
     // is this an int?
     // perhaps we should treat as double for more flexibility
-    str.toInt( &ok );
+    ( void ) str.toInt( &ok );
     if ( ok )
       return QVariant::Int;
 
     // is this a double?
-    str.toDouble( &ok );
+    ( void ) str.toDouble( &ok );
     if ( ok )
       return QVariant::Double;
 

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2418,6 +2418,7 @@ void QgsVertexTool::setHighlightedVertices( const QList<Vertex> &listVertices, H
     for ( const Vertex &vertex : qgis::as_const( mSelectedVertices ) )
     {
       // we should never be able to select vertices that are not from the locked feature
+      // cppcheck-suppress assertWithSideEffect
       Q_ASSERT( mLockedFeature->featureId() == vertex.fid && mLockedFeature->layer() == vertex.layer );
       mLockedFeature->selectVertex( vertex.vertexId );
     }

--- a/src/auth/basic/qgsauthbasicmethod.cpp
+++ b/src/auth/basic/qgsauthbasicmethod.cpp
@@ -154,13 +154,8 @@ bool QgsAuthBasicMethod::updateDataSourceUriItems( QStringList &connectionItems,
             uri.chop( 1 );
             chopped = true;
           }
-          if ( !username.isEmpty() )
-          {
-            uri += QStringLiteral( " user='%1'" ).arg( username );
-
-            if ( !password.isEmpty() )
-              uri += QStringLiteral( " password='%1'" ).arg( password );
-          }
+          uri += QStringLiteral( " user='%1'" ).arg( username );
+          uri += QStringLiteral( " password='%1'" ).arg( password );
           // add extra CAs
           if ( ! caparam.isEmpty() )
           {
@@ -182,30 +177,25 @@ bool QgsAuthBasicMethod::updateDataSourceUriItems( QStringList &connectionItems,
             chopped = true;
           }
           uri += QStringLiteral( " user=%1" ).arg( username );
-          if ( !password.isEmpty() )
-            uri += QStringLiteral( " pass=%1" ).arg( password );
+          uri += QStringLiteral( " pass=%1" ).arg( password );
           if ( chopped )
             uri += '"';
         }
         else if ( uri.startsWith( QLatin1String( "@driver=ingres" ) ) )
         {
           uri += QStringLiteral( ",userid=%1" ).arg( username );
-          if ( !password.isEmpty() )
-            uri += QStringLiteral( ",password=%1" ).arg( password );
+          uri += QStringLiteral( ",password=%1" ).arg( password );
         }
         else if ( uri.startsWith( QLatin1String( "MySQL:" ) ) )
         {
           uri += QStringLiteral( ",user=%1" ).arg( username );
-          if ( !password.isEmpty() )
-            uri += QStringLiteral( ",password=%1" ).arg( password );
+          uri += QStringLiteral( ",password=%1" ).arg( password );
         }
         else if ( uri.startsWith( QLatin1String( "MSSQL:" ) ) )
         {
           uri += QStringLiteral( ";uid=%1" ).arg( username );
           uri = uri.replace( QLatin1String( ";trusted_connection=yes" ), QString() );
-
-          if ( !password.isEmpty() )
-            uri += QStringLiteral( ";pwd=%1" ).arg( password );
+          uri += QStringLiteral( ";pwd=%1" ).arg( password );
         }
         else if ( uri.startsWith( QLatin1String( "OCI:" ) ) )
         {
@@ -214,14 +204,7 @@ bool QgsAuthBasicMethod::updateDataSourceUriItems( QStringList &connectionItems,
         }
         else if ( uri.startsWith( QLatin1String( "ODBC:" ) ) )
         {
-          if ( password.isEmpty() )
-          {
-            uri = uri.replace( QRegExp( "^ODBC:@?" ),  "ODBC:" + username + '@' );
-          }
-          else
-          {
-            uri = uri.replace( QRegExp( "^ODBC:@?" ), "ODBC:" + username + '/' + password + '@' );
-          }
+          uri = uri.replace( QRegExp( "^ODBC:@?" ), "ODBC:" + username + '/' + password + '@' );
         }
         else if ( uri.startsWith( QLatin1String( "couchdb" ) )
                   || uri.startsWith( QLatin1String( "DODS" ) )

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -84,6 +84,10 @@ const QString QgsAuthManager::AUTH_PASSWORD_HELPER_DISPLAY_NAME( "Password Manag
 
 QgsAuthManager *QgsAuthManager::instance()
 {
+  // NOTE cppcheck complains about identicalInnerCondition. Pedantically
+  // the below construct is not totally thread-safe.
+  // See https://preshing.com/20130930/double-checked-locking-is-fixed-in-cpp11/
+  // regarding double-checked locking pattern (DCLP)
   if ( !sInstance )
   {
     static QMutex sMutex;

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -84,18 +84,11 @@ const QString QgsAuthManager::AUTH_PASSWORD_HELPER_DISPLAY_NAME( "Password Manag
 
 QgsAuthManager *QgsAuthManager::instance()
 {
-  // NOTE cppcheck complains about identicalInnerCondition. Pedantically
-  // the below construct is not totally thread-safe.
-  // See https://preshing.com/20130930/double-checked-locking-is-fixed-in-cpp11/
-  // regarding double-checked locking pattern (DCLP)
+  static QMutex sMutex;
+  QMutexLocker locker( &sMutex );
   if ( !sInstance )
   {
-    static QMutex sMutex;
-    QMutexLocker locker( &sMutex );
-    if ( !sInstance )
-    {
-      sInstance = new QgsAuthManager( );
-    }
+    sInstance = new QgsAuthManager( );
   }
   return sInstance;
 }

--- a/src/core/dxf/qgsdxfexport_p.h
+++ b/src/core/dxf/qgsdxfexport_p.h
@@ -103,6 +103,10 @@ struct DxfLayerJob
     QString splitLayerAttribute;
     QString layerTitle;
     QSet<QString> attributes;
+
+  private:
+    DxfLayerJob( const DxfLayerJob & ) = delete;
+    DxfLayerJob &operator=( const DxfLayerJob & ) = delete;
 };
 
 // dxf color palette

--- a/src/core/dxf/qgsdxfexport_p.h
+++ b/src/core/dxf/qgsdxfexport_p.h
@@ -30,79 +30,79 @@
  */
 struct DxfLayerJob
 {
-  DxfLayerJob( QgsVectorLayer *vl, const QString &layerStyleOverride, QgsRenderContext &renderContext, QgsDxfExport *dxfExport, const QString &splitLayerAttribute )
-    : renderContext( renderContext )
-    , styleOverride( vl )
-    , featureSource( vl )
-    , dxfExport( dxfExport )
-    , crs( vl->crs() )
-    , layerName( vl->name() )
-    , splitLayerAttribute( splitLayerAttribute )
-    , layerTitle( vl->title().isEmpty() ? vl->name() : vl->title() )
-  {
-    fields = vl->fields();
-    renderer.reset( vl->renderer()->clone() );
-    renderContext.expressionContext().appendScope( QgsExpressionContextUtils::layerScope( vl ) );
-
-    if ( !layerStyleOverride.isNull() )
+    DxfLayerJob( QgsVectorLayer *vl, const QString &layerStyleOverride, QgsRenderContext &renderContext, QgsDxfExport *dxfExport, const QString &splitLayerAttribute )
+      : renderContext( renderContext )
+      , styleOverride( vl )
+      , featureSource( vl )
+      , dxfExport( dxfExport )
+      , crs( vl->crs() )
+      , layerName( vl->name() )
+      , splitLayerAttribute( splitLayerAttribute )
+      , layerTitle( vl->title().isEmpty() ? vl->name() : vl->title() )
     {
-      styleOverride.setOverrideStyle( layerStyleOverride );
-    }
+      fields = vl->fields();
+      renderer.reset( vl->renderer()->clone() );
+      renderContext.expressionContext().appendScope( QgsExpressionContextUtils::layerScope( vl ) );
 
-    labeling.reset( vl->labelsEnabled() ? vl->labeling()->clone() : nullptr );
-
-    attributes = renderer->usedAttributes( renderContext );
-    if ( !splitLayerAttribute.isNull() )
-    {
-      attributes << splitLayerAttribute;
-    }
-
-    if ( labeling )
-    {
-      QgsLabelingEngine *labelingEngine = renderContext.labelingEngine();
-      if ( const QgsRuleBasedLabeling *rbl = dynamic_cast<const QgsRuleBasedLabeling *>( labeling.get() ) )
+      if ( !layerStyleOverride.isNull() )
       {
-        ruleBasedLabelProvider = new QgsRuleBasedLabelSinkProvider( *rbl, vl, dxfExport );
-        labelingEngine->addProvider( ruleBasedLabelProvider );
+        styleOverride.setOverrideStyle( layerStyleOverride );
+      }
 
-        if ( !ruleBasedLabelProvider->prepare( renderContext, attributes ) )
+      labeling.reset( vl->labelsEnabled() ? vl->labeling()->clone() : nullptr );
+
+      attributes = renderer->usedAttributes( renderContext );
+      if ( !splitLayerAttribute.isNull() )
+      {
+        attributes << splitLayerAttribute;
+      }
+
+      if ( labeling )
+      {
+        QgsLabelingEngine *labelingEngine = renderContext.labelingEngine();
+        if ( const QgsRuleBasedLabeling *rbl = dynamic_cast<const QgsRuleBasedLabeling *>( labeling.get() ) )
         {
-          labelingEngine->removeProvider( ruleBasedLabelProvider );
-          ruleBasedLabelProvider = nullptr;
+          ruleBasedLabelProvider = new QgsRuleBasedLabelSinkProvider( *rbl, vl, dxfExport );
+          labelingEngine->addProvider( ruleBasedLabelProvider );
+
+          if ( !ruleBasedLabelProvider->prepare( renderContext, attributes ) )
+          {
+            labelingEngine->removeProvider( ruleBasedLabelProvider );
+            ruleBasedLabelProvider = nullptr;
+          }
+        }
+        else
+        {
+          QgsPalLayerSettings settings = labeling->settings();
+          labelProvider = new QgsLabelSinkProvider( vl, QString(), dxfExport, &settings );
+          labelingEngine->addProvider( labelProvider );
+
+          if ( !labelProvider->prepare( renderContext, attributes ) )
+          {
+            labelingEngine->removeProvider( labelProvider );
+            labelProvider = nullptr;
+          }
         }
       }
-      else
-      {
-        QgsPalLayerSettings settings = labeling->settings();
-        labelProvider = new QgsLabelSinkProvider( vl, QString(), dxfExport, &settings );
-        labelingEngine->addProvider( labelProvider );
 
-        if ( !labelProvider->prepare( renderContext, attributes ) )
-        {
-          labelingEngine->removeProvider( labelProvider );
-          labelProvider = nullptr;
-        }
-      }
-    }
+      // This will need to be started in a separate thread, if threaded somewhere else to
+      renderer->startRender( renderContext, fields );
+    };
 
-    // This will need to be started in a separate thread, if threaded somewhere else to
-    renderer->startRender( renderContext, fields );
-  };
-
-  QgsRenderContext renderContext;
-  QgsFields fields;
-  QgsMapLayerStyleOverride styleOverride;
-  QgsVectorLayerFeatureSource featureSource;
-  std::unique_ptr< QgsFeatureRenderer > renderer;
-  std::unique_ptr<QgsAbstractVectorLayerLabeling> labeling;
-  QgsDxfExport *dxfExport = nullptr;
-  QgsCoordinateReferenceSystem crs;
-  QString layerName;
-  QgsLabelSinkProvider *labelProvider = nullptr;
-  QgsRuleBasedLabelSinkProvider *ruleBasedLabelProvider = nullptr;
-  QString splitLayerAttribute;
-  QString layerTitle;
-  QSet<QString> attributes;
+    QgsRenderContext renderContext;
+    QgsFields fields;
+    QgsMapLayerStyleOverride styleOverride;
+    QgsVectorLayerFeatureSource featureSource;
+    std::unique_ptr< QgsFeatureRenderer > renderer;
+    std::unique_ptr<QgsAbstractVectorLayerLabeling> labeling;
+    QgsDxfExport *dxfExport = nullptr;
+    QgsCoordinateReferenceSystem crs;
+    QString layerName;
+    QgsLabelSinkProvider *labelProvider = nullptr;
+    QgsRuleBasedLabelSinkProvider *ruleBasedLabelProvider = nullptr;
+    QString splitLayerAttribute;
+    QString layerTitle;
+    QSet<QString> attributes;
 };
 
 // dxf color palette

--- a/src/core/dxf/qgsdxfexport_p.h
+++ b/src/core/dxf/qgsdxfexport_p.h
@@ -110,7 +110,7 @@ struct DxfLayerJob
 };
 
 // dxf color palette
-static int sDxfColors[][3] =
+static const int sDxfColors[][3] =
 {
   { 255, 255, 255 },
   { 255, 0, 0 },

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -81,8 +81,8 @@ QgsGeometry::QgsGeometry( std::unique_ptr<QgsAbstractGeometry> geom )
 }
 
 QgsGeometry::QgsGeometry( const QgsGeometry &other )
+  : d( other.d )
 {
-  d = other.d;
   mLastError = other.mLastError;
   d->ref.ref();
 }

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -372,23 +372,23 @@ bool QgsGeometryUtils::lineCircleIntersection( const QgsPointXY &center, const d
 
 // based on public domain work by 3/26/2005 Tim Voght
 // see http://paulbourke.net/geometry/circlesphere/tvoght.c
-int QgsGeometryUtils::circleCircleIntersections( QgsPointXY center0, const double r0, QgsPointXY center1, const double r1, QgsPointXY &intersection1, QgsPointXY &intersection2 )
+int QgsGeometryUtils::circleCircleIntersections( QgsPointXY center1, const double r1, QgsPointXY center2, const double r2, QgsPointXY &intersection1, QgsPointXY &intersection2 )
 {
   // determine the straight-line distance between the centers
-  const double d = center0.distance( center1 );
+  const double d = center1.distance( center2 );
 
   // check for solvability
-  if ( d > ( r0 + r1 ) )
+  if ( d > ( r1 + r2 ) )
   {
     // no solution. circles do not intersect.
     return 0;
   }
-  else if ( d < std::fabs( r0 - r1 ) )
+  else if ( d < std::fabs( r1 - r2 ) )
   {
     // no solution. one circle is contained in the other
     return 0;
   }
-  else if ( qgsDoubleNear( d, 0 ) && ( qgsDoubleNear( r0, r1 ) ) )
+  else if ( qgsDoubleNear( d, 0 ) && ( qgsDoubleNear( r1, r2 ) ) )
   {
     // no solutions, the circles coincide
     return 0;
@@ -400,22 +400,22 @@ int QgsGeometryUtils::circleCircleIntersections( QgsPointXY center0, const doubl
   */
 
   // Determine the distance from point 0 to point 2.
-  const double a = ( ( r0 * r0 ) - ( r1 * r1 ) + ( d * d ) ) / ( 2.0 * d ) ;
+  const double a = ( ( r1 * r1 ) - ( r2 * r2 ) + ( d * d ) ) / ( 2.0 * d ) ;
 
   /* dx and dy are the vertical and horizontal distances between
    * the circle centers.
    */
-  const double dx = center1.x() - center0.x();
-  const double dy = center1.y() - center0.y();
+  const double dx = center2.x() - center1.x();
+  const double dy = center2.y() - center1.y();
 
   // Determine the coordinates of point 2.
-  const double x2 = center0.x() + ( dx * a / d );
-  const double y2 = center0.y() + ( dy * a / d );
+  const double x2 = center1.x() + ( dx * a / d );
+  const double y2 = center1.y() + ( dy * a / d );
 
   /* Determine the distance from point 2 to either of the
    * intersection points.
    */
-  const double h = std::sqrt( ( r0 * r0 ) - ( a * a ) );
+  const double h = std::sqrt( ( r1 * r1 ) - ( a * a ) );
 
   /* Now determine the offsets of the intersection points from
    * point 2.
@@ -428,7 +428,7 @@ int QgsGeometryUtils::circleCircleIntersections( QgsPointXY center0, const doubl
   intersection2 = QgsPointXY( x2 - rx, y2 +  ry );
 
   // see if we have 1 or 2 solutions
-  if ( qgsDoubleNear( d, r0 + r1 ) )
+  if ( qgsDoubleNear( d, r1 + r2 ) )
     return 1;
 
   return 2;

--- a/src/core/layout/qgslayout.h
+++ b/src/core/layout/qgslayout.h
@@ -754,6 +754,9 @@ class CORE_EXPORT QgsLayout : public QGraphicsScene, public QgsExpressionContext
     //! Calculates the item minimum position from an XML element
     QPointF minPointFromXml( const QDomElement &elem ) const;
 
+    QgsLayout( const QgsLayout & ) = delete;
+    QgsLayout &operator=( const QgsLayout & ) = delete;
+
     friend class QgsLayoutItemAddItemCommand;
     friend class QgsLayoutItemDeleteUndoCommand;
     friend class QgsLayoutItemUndoCommand;

--- a/src/core/layout/qgslayoutitemhtml.h
+++ b/src/core/layout/qgslayoutitemhtml.h
@@ -273,6 +273,9 @@ class CORE_EXPORT QgsLayoutItemHtml: public QgsLayoutMultiFrame
     double maxFrameWidth() const;
 
     void refreshExpressionContext();
+
+    QgsLayoutItemHtml( const QgsLayoutItemHtml & ) = delete;
+    QgsLayoutItemHtml &operator=( const QgsLayoutItemHtml & ) = delete;
 };
 
 ///@cond PRIVATE

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1878,6 +1878,9 @@ void QgsLayoutItemMap::connectUpdateSlot()
     {
       invalidateCache();
     } );
+
+    connect( project->mapThemeCollection(), &QgsMapThemeCollection::mapThemeChanged, this, &QgsLayoutItemMap::mapThemeChanged );
+    connect( project->mapThemeCollection(), &QgsMapThemeCollection::mapThemeRenamed, this, &QgsLayoutItemMap::currentMapThemeRenamed );
   }
   connect( mLayout, &QgsLayout::refreshed, this, &QgsLayoutItemMap::invalidateCache );
   connect( &mLayout->renderContext(), &QgsLayoutRenderContext::predefinedScalesChanged, this, [ = ]
@@ -1885,9 +1888,6 @@ void QgsLayoutItemMap::connectUpdateSlot()
     if ( mAtlasScalingMode == Predefined )
       updateAtlasFeature();
   } );
-
-  connect( project->mapThemeCollection(), &QgsMapThemeCollection::mapThemeChanged, this, &QgsLayoutItemMap::mapThemeChanged );
-  connect( project->mapThemeCollection(), &QgsMapThemeCollection::mapThemeRenamed, this, &QgsLayoutItemMap::currentMapThemeRenamed );
 }
 
 QTransform QgsLayoutItemMap::layoutToMapCoordsTransform() const

--- a/src/core/layout/qgslayoutitemmarker.h
+++ b/src/core/layout/qgslayoutitemmarker.h
@@ -159,6 +159,9 @@ class CORE_EXPORT QgsLayoutItemMarker : public QgsLayoutItem
     QString mRotationMapUuid;
     QgsLayoutNorthArrowHandler *mNorthArrowHandler = nullptr;
     double mNorthArrowRotation = 0;
+
+    QgsLayoutItemMarker( const QgsLayoutItemMarker & ) = delete;
+    QgsLayoutItemMarker &operator=( const QgsLayoutItemMarker & ) = delete;
 };
 
 

--- a/src/core/layout/qgslayoutitempicture.h
+++ b/src/core/layout/qgslayoutitempicture.h
@@ -367,6 +367,9 @@ class CORE_EXPORT QgsLayoutItemPicture: public QgsLayoutItem
 
     void loadPictureUsingCache( const QString &path );
 
+    QgsLayoutItemPicture( const QgsLayoutItemPicture & ) = delete;
+    QgsLayoutItemPicture &operator=( const QgsLayoutItemPicture & ) = delete;
+
   private slots:
 
     void updateNorthArrowRotation( double rotation );

--- a/src/core/layout/qgsprintlayout.h
+++ b/src/core/layout/qgsprintlayout.h
@@ -76,6 +76,8 @@ class CORE_EXPORT QgsPrintLayout : public QgsLayout, public QgsMasterLayoutInter
     QString mName;
     QgsLayoutAtlas *mAtlas = nullptr;
 
+    QgsPrintLayout( const QgsPrintLayout & ) = delete;
+    QgsPrintLayout &operator=( const QgsPrintLayout & ) = delete;
 };
 
 #endif //QGSPRINTLAYOUT_H

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -603,8 +603,7 @@ int QgsMeshLayer::closestEdge( const QgsPointXY &point, double searchRadius, Qgs
   // search for the closest edge in search area from point
   const QList<int> edgeIndexes = mesh->edgeIndexesForRectangle( searchRectangle );
   int selectedIndex = -1;
-  if ( mesh &&
-       mesh->contains( QgsMesh::Edge ) &&
+  if ( mesh->contains( QgsMesh::Edge ) &&
        mDataProvider->isValid() )
   {
     double sqrMaxDistFromPoint = pow( searchRadius, 2 );

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -48,9 +48,13 @@ QgsMeshLayerRenderer::QgsMeshLayerRenderer(
   , mRendererSettings( layer->rendererSettings() )
 {
   // make copies for mesh data
+  // cppcheck-suppress assertWithSideEffect
   Q_ASSERT( layer->nativeMesh() );
+  // cppcheck-suppress assertWithSideEffect
   Q_ASSERT( layer->triangularMesh() );
+  // cppcheck-suppress assertWithSideEffect
   Q_ASSERT( layer->rendererCache() );
+  // cppcheck-suppress assertWithSideEffect
   Q_ASSERT( layer->dataProvider() );
 
   // copy native mesh

--- a/src/core/mesh/qgsmeshtracerenderer.cpp
+++ b/src/core/mesh/qgsmeshtracerenderer.cpp
@@ -784,6 +784,7 @@ QgsMeshStreamField &QgsMeshStreamField::operator=( const QgsMeshStreamField &oth
   mPen = other.mPen;
   mTraceImage = other.mTraceImage ;
   mMapToFieldPixel = other.mMapToFieldPixel ;
+  mVectorColoring = other.mVectorColoring;
   mPixelFillingCount = other.mPixelFillingCount ;
   mMaxPixelFillingCount = other.mMaxPixelFillingCount ;
   mLayerExtent = other.mLayerExtent ;

--- a/src/core/processing/qgsprocessingcontext.h
+++ b/src/core/processing/qgsprocessingcontext.h
@@ -420,6 +420,7 @@ class CORE_EXPORT QgsProcessingContext
      */
     void pushToThread( QThread *thread )
     {
+      // cppcheck-suppress assertWithSideEffect
       Q_ASSERT_X( QThread::currentThread() == QgsProcessingContext::thread(), "QgsProcessingContext::pushToThread", "Cannot push context to another thread unless the current thread matches the existing context thread affinity" );
       tempLayerStore.moveToThread( thread );
     }

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -216,6 +216,7 @@ QgsGdalProvider::QgsGdalProvider( const QgsGdalProvider &other )
   if ( forceUseSameDataset )
   {
     ++ ( *other.mpRefCounter );
+    // cppcheck-suppress copyCtorPointerCopying
     mpRefCounter = other.mpRefCounter;
     mpMutex = other.mpMutex;
     mpLightRefCounter = new QAtomicInt( 1 );

--- a/src/core/providers/gdal/qgsgdalprovider.h
+++ b/src/core/providers/gdal/qgsgdalprovider.h
@@ -207,6 +207,7 @@ class QgsGdalProvider final: public QgsRasterDataProvider, QgsGdalProviderBase
 
   private:
     QgsGdalProvider( const QgsGdalProvider &other );
+    QgsGdalProvider &operator=( const QgsGdalProvider & ) = delete;
 
     //! Whether mGdalDataset and mGdalBaseDataset have been attempted to be set
     bool mHasInit = false;

--- a/src/core/qgsgmlschema.cpp
+++ b/src/core/qgsgmlschema.cpp
@@ -514,7 +514,7 @@ void QgsGmlSchema::addAttribute( const QString &name, const QString &value )
 {
   // It is not geometry attribute -> analyze value
   bool ok;
-  value.toInt( &ok );
+  ( void ) value.toInt( &ok );
   QVariant::Type type = QVariant::String;
   if ( ok )
   {
@@ -522,7 +522,7 @@ void QgsGmlSchema::addAttribute( const QString &name, const QString &value )
   }
   else
   {
-    value.toDouble( &ok );
+    ( void ) value.toDouble( &ok );
     if ( ok )
     {
       type = QVariant::Double;

--- a/src/core/qgsspatialindexkdbush.cpp
+++ b/src/core/qgsspatialindexkdbush.cpp
@@ -32,9 +32,8 @@ QgsSpatialIndexKDBush::QgsSpatialIndexKDBush( const QgsFeatureSource &source, Qg
 {
 }
 
-QgsSpatialIndexKDBush::QgsSpatialIndexKDBush( const QgsSpatialIndexKDBush &other )
+QgsSpatialIndexKDBush::QgsSpatialIndexKDBush( const QgsSpatialIndexKDBush &other ): d( other.d )
 {
-  d = other.d;
   d->ref.ref();
 }
 

--- a/src/core/qgstemporalnavigationobject.h
+++ b/src/core/qgstemporalnavigationobject.h
@@ -303,6 +303,8 @@ class CORE_EXPORT QgsTemporalNavigationObject : public QgsTemporalController, pu
 
     bool mCumulativeTemporalRange = false;
 
+    QgsTemporalNavigationObject( const QgsTemporalNavigationObject & ) = delete;
+    QgsTemporalNavigationObject &operator= ( const QgsTemporalNavigationObject & ) = delete;
 };
 
 #endif // QGSTEMPORALNAVIGATIONOBJECT_H

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -432,9 +432,9 @@ QString QgsRasterLayer::htmlMetadata() const
                 QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "Band count" ) % QStringLiteral( "</td><td>" ) % QString::number( bandCount() ) % QStringLiteral( "</td></tr>\n" );
 
   // Band table
-  QStringLiteral( "</table>\n<br><table width=\"100%\" class=\"tabular-view\">\n" ) %
-  QStringLiteral( "<tr><th>" ) % tr( "Number" ) % QStringLiteral( "</th><th>" ) % tr( "Band" ) % QStringLiteral( "</th><th>" ) % tr( "No-Data" ) % QStringLiteral( "</th><th>" ) %
-  tr( "Min" ) % QStringLiteral( "</th><th>" ) % tr( "Max" ) % QStringLiteral( "</th></tr>\n" );
+  myMetadata += QStringLiteral( "</table>\n<br><table width=\"100%\" class=\"tabular-view\">\n" ) %
+                QStringLiteral( "<tr><th>" ) % tr( "Number" ) % QStringLiteral( "</th><th>" ) % tr( "Band" ) % QStringLiteral( "</th><th>" ) % tr( "No-Data" ) % QStringLiteral( "</th><th>" ) %
+                tr( "Min" ) % QStringLiteral( "</th><th>" ) % tr( "Max" ) % QStringLiteral( "</th></tr>\n" );
 
   QgsRasterDataProvider *provider = const_cast< QgsRasterDataProvider * >( mDataProvider );
   for ( int i = 1; i <= bandCount(); i++ )

--- a/src/core/vectortile/qgsvectortilemvtencoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtencoder.cpp
@@ -67,8 +67,10 @@ struct MVTGeometryWriter
     qint32 vx = pt.x() - cursor.x();
     qint32 vy = pt.y() - cursor.y();
 
-    feature->add_geometry( ( vx << 1 ) ^ ( vx >> 31 ) );
-    feature->add_geometry( ( vy << 1 ) ^ ( vy >> 31 ) );
+    // (quint32)(-(qint32)((quint32)vx >> 31)) is a C/C++ compliant way
+    // of doing vx >> 31, which is undefined behaviour since vx is signed
+    feature->add_geometry( ( ( quint32 )vx << 1 ) ^ ( ( quint32 )( -( qint32 )( ( quint32 )vx >> 31 ) ) ) );
+    feature->add_geometry( ( ( quint32 )vy << 1 ) ^ ( ( quint32 )( -( qint32 )( ( quint32 )vy >> 31 ) ) ) );
 
     cursor = pt;
   }

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -212,6 +212,7 @@ void QgsFeatureListView::setEditSelection( const QModelIndex &index, QItemSelect
   bool ok = true;
   emit aboutToChangeEditSelection( ok );
 
+  // cppcheck-suppress assertWithSideEffect
   Q_ASSERT( index.model() == mModel->masterModel() || !index.isValid() );
 
   if ( ok )

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -208,6 +208,7 @@ void QgsProcessingLayerOutputDestinationWidget::registerProcessingParametersGene
 
 void QgsProcessingLayerOutputDestinationWidget::addOpenAfterRunningOption()
 {
+  Q_ASSERT( mOpenAfterRunningCheck == nullptr );
   mOpenAfterRunningCheck = new QCheckBox( tr( "Open output file after running algorithm" ) );
   mOpenAfterRunningCheck->setChecked( !outputIsSkipped() );
   mOpenAfterRunningCheck->setEnabled( !outputIsSkipped() );

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -200,8 +200,7 @@ QString QgsMapTip::fetchFeature( QgsMapLayer *layer, QgsPointXY &mapPosition, Qg
   r = mapCanvas->mapSettings().mapToLayerCoordinates( layer, r );
 
   QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( vlayer ) );
-  if ( mapCanvas )
-    context.appendScope( QgsExpressionContextUtils::mapSettingsScope( mapCanvas->mapSettings() ) );
+  context.appendScope( QgsExpressionContextUtils::mapSettingsScope( mapCanvas->mapSettings() ) );
 
   QString mapTip = vlayer->mapTipTemplate();
   QString tipString;

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -852,7 +852,7 @@ double QgsRasterLayerSaveAsDialog::noDataCellValue( int row, int column ) const
   QLineEdit *lineEdit = dynamic_cast<QLineEdit *>( mNoDataTableWidget->cellWidget( row, column ) );
   if ( !lineEdit || lineEdit->text().isEmpty() )
   {
-    std::numeric_limits<double>::quiet_NaN();
+    return std::numeric_limits<double>::quiet_NaN();
   }
   return lineEdit->text().toDouble();
 }

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -1669,7 +1669,7 @@ double QgsRasterLayerProperties::transparencyCellValue( int row, int column )
   QLineEdit *lineEdit = dynamic_cast<QLineEdit *>( tableTransparency->cellWidget( row, column ) );
   if ( !lineEdit || lineEdit->text().isEmpty() )
   {
-    std::numeric_limits<double>::quiet_NaN();
+    return std::numeric_limits<double>::quiet_NaN();
   }
   return lineEdit->text().toDouble();
 }

--- a/src/gui/raster/qgsrastertransparencywidget.cpp
+++ b/src/gui/raster/qgsrastertransparencywidget.cpp
@@ -688,7 +688,7 @@ double QgsRasterTransparencyWidget::transparencyCellValue( int row, int column )
   QLineEdit *lineEdit = dynamic_cast<QLineEdit *>( tableTransparency->cellWidget( row, column ) );
   if ( !lineEdit || lineEdit->text().isEmpty() )
   {
-    std::numeric_limits<double>::quiet_NaN();
+    return std::numeric_limits<double>::quiet_NaN();
   }
   return lineEdit->text().toDouble();
 

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -976,7 +976,7 @@ QList<QgsSymbol *> QgsCategorizedSymbolRendererWidget::selectedSymbols()
   QItemSelectionModel *m = viewCategories->selectionModel();
   QModelIndexList selectedIndexes = m->selectedRows( 1 );
 
-  if ( m && !selectedIndexes.isEmpty() )
+  if ( !selectedIndexes.isEmpty() )
   {
     const QgsCategoryList &categories = mRenderer->categories();
     QModelIndexList::const_iterator indexIt = selectedIndexes.constBegin();
@@ -1000,7 +1000,7 @@ QgsCategoryList QgsCategorizedSymbolRendererWidget::selectedCategoryList()
   QItemSelectionModel *m = viewCategories->selectionModel();
   QModelIndexList selectedIndexes = m->selectedRows( 1 );
 
-  if ( m && !selectedIndexes.isEmpty() )
+  if ( !selectedIndexes.isEmpty() )
   {
     QModelIndexList::const_iterator indexIt = selectedIndexes.constBegin();
     for ( ; indexIt != selectedIndexes.constEnd(); ++indexIt )
@@ -1151,7 +1151,7 @@ void QgsCategorizedSymbolRendererWidget::applyChangeToSymbol()
   QItemSelectionModel *m = viewCategories->selectionModel();
   QModelIndexList i = m->selectedRows();
 
-  if ( m && !i.isEmpty() )
+  if ( !i.isEmpty() )
   {
     QList<int> selectedCats = selectedCategories();
 

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -935,7 +935,7 @@ void QgsGraduatedSymbolRendererWidget::applyChangeToSymbol()
 
   QItemSelectionModel *m = viewGraduated->selectionModel();
   QModelIndexList selectedIndexes = m->selectedRows( 1 );
-  if ( m && !selectedIndexes.isEmpty() )
+  if ( !selectedIndexes.isEmpty() )
   {
     const auto constSelectedIndexes = selectedIndexes;
     for ( const QModelIndex &idx : constSelectedIndexes )
@@ -1026,7 +1026,7 @@ void QgsGraduatedSymbolRendererWidget::classifyGraduated()
 
   // If complexity >= oN^2, warn for big dataset (more than 50k records)
   // and give the user the chance to cancel
-  if ( method && method->codeComplexity() > 1 && mLayer->featureCount() > 50000 )
+  if ( method->codeComplexity() > 1 && mLayer->featureCount() > 50000 )
   {
     if ( QMessageBox::Cancel == QMessageBox::question( this, tr( "Apply Classification" ), tr( "Natural break classification (Jenks) is O(n2) complexity, your classification may take a long time.\nPress cancel to abort breaks calculation or OK to continue." ), QMessageBox::Cancel, QMessageBox::Ok ) )
     {
@@ -1304,7 +1304,7 @@ QList<QgsSymbol *> QgsGraduatedSymbolRendererWidget::selectedSymbols()
 
   QItemSelectionModel *m = viewGraduated->selectionModel();
   QModelIndexList selectedIndexes = m->selectedRows( 1 );
-  if ( m && !selectedIndexes.isEmpty() )
+  if ( !selectedIndexes.isEmpty() )
   {
     const QgsRangeList &ranges = mRenderer->ranges();
     QModelIndexList::const_iterator indexIt = selectedIndexes.constBegin();

--- a/src/plugins/grass/qgsgrassmapcalc.h
+++ b/src/plugins/grass/qgsgrassmapcalc.h
@@ -198,6 +198,9 @@ class QgsGrassMapcalc: public QMainWindow, private Ui::QgsGrassMapcalcBase,
     QAction *mActionLoad = nullptr;
     QAction *mActionSave = nullptr;
     QAction *mActionSaveAs = nullptr;
+
+    QgsGrassMapcalc( const QgsGrassMapcalc & ) = delete;
+    QgsGrassMapcalc &operator = ( const QgsGrassMapcalc & ) = delete;
 };
 
 /*

--- a/src/plugins/grass/qgsgrassmoduleinput.h
+++ b/src/plugins/grass/qgsgrassmoduleinput.h
@@ -87,6 +87,8 @@ class QgsGrassModuleInputModel : public QStandardItemModel
     QStringList locationDirNames();
     QFileSystemWatcher *mWatcher = nullptr;
 
+    QgsGrassModuleInputModel( const QgsGrassModuleInputModel & ) = delete;
+    QgsGrassModuleInputModel &operator = ( const QgsGrassModuleInputModel & ) = delete;
 };
 
 // Filter maps by type
@@ -350,6 +352,9 @@ class QgsGrassModuleInput : public QgsGrassModuleGroupBoxItem
 
     //! Required field
     bool mRequired;
+
+    QgsGrassModuleInput( const QgsGrassModuleInput & ) = delete;
+    QgsGrassModuleInput &operator = ( const QgsGrassModuleInput & ) = delete;
 };
 
 

--- a/src/plugins/grass/qgsgrassmoduleparam.h
+++ b/src/plugins/grass/qgsgrassmoduleparam.h
@@ -228,6 +228,9 @@ class QgsGrassModuleMultiParam : public QgsGrassModuleGroupBoxItem
 
     // Parameters layout
     QVBoxLayout *mButtonsLayout = nullptr;
+
+    QgsGrassModuleMultiParam( const QgsGrassModuleMultiParam & ) = delete;
+    QgsGrassModuleMultiParam &operator=( const QgsGrassModuleMultiParam & ) = delete;
 };
 
 /****************** QgsGrassModuleOption ************************/
@@ -572,6 +575,9 @@ class QgsGrassModuleSelection : public QgsGrassModuleGroupBoxItem
 
     // selection mode
     QComboBox *mModeComboBox = nullptr;
+
+    QgsGrassModuleSelection( const QgsGrassModuleSelection & ) = delete;
+    QgsGrassModuleSelection &operator = ( const QgsGrassModuleSelection & ) = delete;
 };
 
 /*********************** QgsGrassModuleFile **********************/
@@ -623,6 +629,9 @@ class QgsGrassModuleFile : public QgsGrassModuleGroupBoxItem
 
     //! File filters
     QString mFilters;
+
+    QgsGrassModuleFile( const QgsGrassModuleFile & ) = delete;
+    QgsGrassModuleFile &operator = ( const QgsGrassModuleFile & ) = delete;
 };
 
 #endif // QGSGRASSMODULEPARAM_H

--- a/src/plugins/grass/qtermwidget/Filter.h
+++ b/src/plugins/grass/qtermwidget/Filter.h
@@ -283,6 +283,9 @@ public:
         UrlType urlType() const;
 
         FilterObject* _urlObject;
+
+        HotSpot( const HotSpot& ) = delete;
+        HotSpot& operator= ( const HotSpot& ) = delete;
     };
 
     UrlFilter();

--- a/src/plugins/grass/qtermwidget/KeyboardTranslator.h
+++ b/src/plugins/grass/qtermwidget/KeyboardTranslator.h
@@ -413,6 +413,9 @@ private:
     QString _description;
     KeyboardTranslator::Entry _nextEntry;
     bool _hasNext;
+
+    KeyboardTranslatorReader(const KeyboardTranslatorReader&) = delete;
+    KeyboardTranslatorReader& operator=(const KeyboardTranslatorReader&) = delete;
 };
 
 /** Writes a keyboard translation to disk. */
@@ -437,6 +440,9 @@ public:
 private:
     QIODevice* _destination;
     QTextStream* _writer;
+
+    KeyboardTranslatorWriter(const KeyboardTranslatorWriter&) = delete;
+    KeyboardTranslatorWriter& operator=(const KeyboardTranslatorWriter&) = delete;
 };
 
 /**

--- a/src/plugins/grass/qtermwidget/Screen.cpp
+++ b/src/plugins/grass/qtermwidget/Screen.cpp
@@ -403,6 +403,7 @@ void Screen::updateEffectiveRendition()
 
 void Screen::copyFromHistory(Character* dest, int startLine, int count) const
 {
+    // cppcheck-suppress assertWithSideEffect
     Q_ASSERT( startLine >= 0 && count > 0 && startLine + count <= history->getLines() );
 
     for (int line = startLine; line < startLine + count; line++)
@@ -456,6 +457,7 @@ void Screen::copyFromScreen(Character* dest , int startLine , int count) const
 void Screen::getImage( Character* dest, int size, int startLine, int endLine ) const
 {
     Q_ASSERT( startLine >= 0 );
+    // cppcheck-suppress assertWithSideEffect
     Q_ASSERT( endLine >= startLine && endLine < history->getLines() + lines );
 
     const int mergedLines = endLine - startLine + 1;
@@ -492,6 +494,7 @@ void Screen::getImage( Character* dest, int size, int startLine, int endLine ) c
 QVector<LineProperty> Screen::getLineProperties( int startLine , int endLine ) const
 {
     Q_ASSERT( startLine >= 0 );
+    // cppcheck-suppress assertWithSideEffect
     Q_ASSERT( endLine >= startLine && endLine < history->getLines() + lines );
 
     const int mergedLines = endLine-startLine+1;
@@ -1204,6 +1207,7 @@ int Screen::copyLineToStream(int line ,
         // safety checks
         assert( start >= 0 );
         assert( count >= 0 );
+        // cppcheck-suppress assertWithSideEffect
         assert( (start+count) <= history->getLineLen(line) );
 
         history->getCells(line,start,count,characterBuffer);

--- a/src/plugins/grass/qtermwidget/Screen.h
+++ b/src/plugins/grass/qtermwidget/Screen.h
@@ -668,6 +668,9 @@ private:
     int lastPos;
 
     static Character defaultChar;
+
+    Screen (const Screen&) = delete;
+    Screen& operator= (const Screen&) = delete;
 };
 
 }

--- a/src/plugins/grass/qtermwidget/kpty.h
+++ b/src/plugins/grass/qtermwidget/kpty.h
@@ -185,6 +185,9 @@ class KPty {
 
   private:
     Q_DECLARE_PRIVATE(KPty)
+
+    KPty( const KPty& ) = delete;
+    KPty& operator= ( const KPty& ) = delete;
 };
 
 #endif

--- a/src/providers/db2/qgsdb2tablemodel.cpp
+++ b/src/providers/db2/qgsdb2tablemodel.cpp
@@ -371,7 +371,7 @@ QString QgsDb2TableModel::layerURI( const QModelIndex &index, const QString &con
 
     srid = index.sibling( index.row(), DbtmSrid ).data( Qt::DisplayRole ).toString();
     bool ok;
-    srid.toInt( &ok );
+    ( void )srid.toInt( &ok );
     if ( !ok )
       return QString();
   }

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -601,12 +601,12 @@ void QgsDelimitedTextProvider::scanFile( bool buildIndexes )
 
       if ( couldBeInt[i] )
       {
-        value.toInt( &couldBeInt[i] );
+        ( void )value.toInt( &couldBeInt[i] );
       }
 
       if ( couldBeLongLong[i] && ! couldBeInt[i] )
       {
-        value.toLongLong( &couldBeLongLong[i] );
+        ( void )value.toLongLong( &couldBeLongLong[i] );
       }
 
       if ( couldBeDouble[i] && ! couldBeLongLong[i] )
@@ -615,7 +615,7 @@ void QgsDelimitedTextProvider::scanFile( bool buildIndexes )
         {
           value.replace( mDecimalPoint, QLatin1String( "." ) );
         }
-        value.toDouble( &couldBeDouble[i] );
+        ( void )value.toDouble( &couldBeDouble[i] );
       }
     }
   }

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -509,7 +509,7 @@ void QgsDelimitedTextSourceSelect::updateFieldLists()
           }
           else
           {
-            value.toDouble( &ok );
+            ( void )value.toDouble( &ok );
           }
           isValidCoordinate[i] = ok;
         }

--- a/src/providers/grass/qgsgrass.cpp
+++ b/src/providers/grass/qgsgrass.cpp
@@ -2867,7 +2867,6 @@ void QgsGrass::vectDestroyMapStruct( struct Map_info *map )
   // call G_fatal_error, otherwise check and remove use of vectDestroyMapStruct from G_CATCH blocks
   QgsDebugMsg( QString( "free map = %1" ).arg( ( quint64 )map ) );
   qgsFree( map );
-  map = nullptr;
 }
 
 void QgsGrass::sleep( int ms )

--- a/src/providers/grass/qgsgrassprovider.cpp
+++ b/src/providers/grass/qgsgrassprovider.cpp
@@ -2042,7 +2042,9 @@ QgsGrassVectorMapLayer *QgsGrassProvider::openLayer() const
 struct Map_info *QgsGrassProvider::map() const
 {
   Q_ASSERT( mLayer );
+  // cppcheck-suppress assertWithSideEffect
   Q_ASSERT( mLayer->map() );
+  // cppcheck-suppress assertWithSideEffect
   Q_ASSERT( mLayer->map()->map() );
   return mLayer->map()->map();
 }

--- a/src/providers/grass/qgsgrassprovidermodule.h
+++ b/src/providers/grass/qgsgrassprovidermodule.h
@@ -91,6 +91,9 @@ class QgsGrassLocationItem : public QgsDirectoryItem, public QgsGrassObjectItemB
 
   private:
     QgsGrassItemActions *mActions = nullptr;
+
+    QgsGrassLocationItem( const QgsGrassLocationItem & ) = delete;
+    QgsGrassLocationItem &operator=( const QgsGrassLocationItem & ) = delete;
 };
 
 class QgsGrassMapsetItem : public QgsDirectoryItem, public QgsGrassObjectItemBase
@@ -123,6 +126,9 @@ class QgsGrassMapsetItem : public QgsDirectoryItem, public QgsGrassObjectItemBas
     bool mRefreshLater;
     // running imports
     static QList<QgsGrassImport *> sImports;
+
+    QgsGrassMapsetItem( const QgsGrassMapsetItem & ) = delete;
+    QgsGrassMapsetItem &operator=( const QgsGrassMapsetItem & ) = delete;
 };
 
 class QgsGrassObjectItem : public QgsLayerItem, public QgsGrassObjectItemBase
@@ -141,6 +147,8 @@ class QgsGrassObjectItem : public QgsLayerItem, public QgsGrassObjectItemBase
   protected:
     QgsGrassItemActions *mActions = nullptr;
 
+    QgsGrassObjectItem( const QgsGrassObjectItem & ) = delete;
+    QgsGrassObjectItem &operator=( const QgsGrassObjectItem & ) = delete;
 };
 
 // Vector is collection of layers
@@ -164,6 +172,9 @@ class QgsGrassVectorItem : public QgsDataCollectionItem, public QgsGrassObjectIt
     bool mValid;
     QgsGrassItemActions *mActions = nullptr;
     QFileSystemWatcher *mWatcher = nullptr;
+
+    QgsGrassVectorItem( const QgsGrassVectorItem & ) = delete;
+    QgsGrassVectorItem &operator= ( const QgsGrassVectorItem & ) = delete;
 };
 
 class QgsGrassVectorLayerItem : public QgsGrassObjectItem

--- a/src/providers/mssql/qgsmssqltablemodel.cpp
+++ b/src/providers/mssql/qgsmssqltablemodel.cpp
@@ -371,7 +371,7 @@ QString QgsMssqlTableModel::layerURI( const QModelIndex &index, const QString &c
 
     srid = index.sibling( index.row(), DbtmSrid ).data( Qt::DisplayRole ).toString();
     bool ok;
-    srid.toInt( &ok );
+    ( void )srid.toInt( &ok );
     if ( !ok )
       return QString();
   }

--- a/src/providers/oracle/qgsoraclesourceselect.cpp
+++ b/src/providers/oracle/qgsoraclesourceselect.cpp
@@ -124,7 +124,7 @@ void QgsOracleSourceSelectDelegate::setEditorData( QWidget *editor, const QModel
   if ( le )
   {
     bool ok;
-    value.toInt( &ok );
+    ( void )value.toInt( &ok );
     if ( index.column() == QgsOracleTableModel::DbtmSrid && !ok )
       value.clear();
 

--- a/src/providers/oracle/qgsoracletablemodel.cpp
+++ b/src/providers/oracle/qgsoracletablemodel.cpp
@@ -334,7 +334,7 @@ QString QgsOracleTableModel::layerURI( const QModelIndex &index, const QgsDataSo
 
     srid = index.sibling( index.row(), DbtmSrid ).data( Qt::DisplayRole ).toString();
     bool ok;
-    srid.toInt( &ok );
+    ( void )srid.toInt( &ok );
     if ( !ok )
     {
       QgsDebugMsg( QStringLiteral( "srid not numeric" ) );

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -145,7 +145,7 @@ void QgsPgSourceSelectDelegate::setEditorData( QWidget *editor, const QModelInde
   if ( le )
   {
     bool ok;
-    value.toInt( &ok );
+    ( void )value.toInt( &ok );
     if ( index.column() == QgsPgTableModel::DbtmSrid && !ok )
       value.clear();
 

--- a/src/providers/postgres/qgspgtablemodel.cpp
+++ b/src/providers/postgres/qgspgtablemodel.cpp
@@ -450,7 +450,7 @@ QString QgsPgTableModel::layerURI( const QModelIndex &index, const QString &conn
 
     srid = index.sibling( index.row(), DbtmSrid ).data( Qt::DisplayRole ).toString();
     bool ok;
-    srid.toInt( &ok );
+    ( void )srid.toInt( &ok );
     if ( !ok )
     {
       QgsDebugMsg( QStringLiteral( "srid not numeric" ) );

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -882,7 +882,7 @@ bool QgsWcsProvider::readBlock( int bandNo, int xBlock, int yBlock, void *block 
 // This could be shared with GDAL provider
 Qgis::DataType QgsWcsProvider::sourceDataType( int bandNo ) const
 {
-  if ( bandNo < 0 || bandNo > mSrcGdalDataType.size() )
+  if ( bandNo <= 0 || bandNo > mSrcGdalDataType.size() )
   {
     return Qgis::UnknownDataType;
   }
@@ -892,7 +892,7 @@ Qgis::DataType QgsWcsProvider::sourceDataType( int bandNo ) const
 
 Qgis::DataType QgsWcsProvider::dataType( int bandNo ) const
 {
-  if ( bandNo < 0 || bandNo > mGdalDataType.size() )
+  if ( bandNo <= 0 || bandNo > mGdalDataType.size() )
   {
     return Qgis::UnknownDataType;
   }

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2005,64 +2005,64 @@ QString QgsWmsProvider::layerMetadata( QgsWmsLayerProperty &layer )
     tr( "Title" ) %
     QStringLiteral( "</td>"
                     "<td>" ) %
-    layer.title;
-  QStringLiteral( "</td></tr>"
+    layer.title %
+    QStringLiteral( "</td></tr>"
 
-                  // Layer Abstract
-                  "<tr><td>" ) %
-  tr( "Abstract" ) %
-  QStringLiteral( "</td>"
-                  "<td>" ) %
-  layer.abstract;
-  QStringLiteral( "</td></tr>"
+                    // Layer Abstract
+                    "<tr><td>" ) %
+    tr( "Abstract" ) %
+    QStringLiteral( "</td>"
+                    "<td>" ) %
+    layer.abstract %
+    QStringLiteral( "</td></tr>"
 
-                  // Layer Queryability
-                  "<tr><td>" ) %
-  tr( "Can Identify" ) %
-  QStringLiteral( "</td>"
-                  "<td>" ) %
-  ( layer.queryable ? tr( "Yes" ) : tr( "No" ) ) %
-  QStringLiteral( "</td></tr>"
+                    // Layer Queryability
+                    "<tr><td>" ) %
+    tr( "Can Identify" ) %
+    QStringLiteral( "</td>"
+                    "<td>" ) %
+    ( layer.queryable ? tr( "Yes" ) : tr( "No" ) ) %
+    QStringLiteral( "</td></tr>"
 
-                  // Layer Opacity
-                  "<tr><td>" ) %
-  tr( "Can be Transparent" ) %
-  QStringLiteral( "</td>"
-                  "<td>" ) %
-  ( layer.opaque ? tr( "No" ) : tr( "Yes" ) ) %
-  QStringLiteral( "</td></tr>"
+                    // Layer Opacity
+                    "<tr><td>" ) %
+    tr( "Can be Transparent" ) %
+    QStringLiteral( "</td>"
+                    "<td>" ) %
+    ( layer.opaque ? tr( "No" ) : tr( "Yes" ) ) %
+    QStringLiteral( "</td></tr>"
 
-                  // Layer Subsetability
-                  "<tr><td>" ) %
-  tr( "Can Zoom In" ) %
-  QStringLiteral( "</td>"
-                  "<td>" ) %
-  ( layer.noSubsets ? tr( "No" ) : tr( "Yes" ) ) %
-  QStringLiteral( "</td></tr>"
+                    // Layer Subsetability
+                    "<tr><td>" ) %
+    tr( "Can Zoom In" ) %
+    QStringLiteral( "</td>"
+                    "<td>" ) %
+    ( layer.noSubsets ? tr( "No" ) : tr( "Yes" ) ) %
+    QStringLiteral( "</td></tr>"
 
-                  // Layer Server Cascade Count
-                  "<tr><td>" ) %
-  tr( "Cascade Count" ) %
-  QStringLiteral( "</td>"
-                  "<td>" ) %
-  QString::number( layer.cascaded );
-  QStringLiteral( "</td></tr>"
+                    // Layer Server Cascade Count
+                    "<tr><td>" ) %
+    tr( "Cascade Count" ) %
+    QStringLiteral( "</td>"
+                    "<td>" ) %
+    QString::number( layer.cascaded ) %
+    QStringLiteral( "</td></tr>"
 
-                  // Layer Fixed Width
-                  "<tr><td>" ) %
-  tr( "Fixed Width" ) %
-  QStringLiteral( "</td>"
-                  "<td>" ) %
-  QString::number( layer.fixedWidth );
-  QStringLiteral( "</td></tr>"
+                    // Layer Fixed Width
+                    "<tr><td>" ) %
+    tr( "Fixed Width" ) %
+    QStringLiteral( "</td>"
+                    "<td>" ) %
+    QString::number( layer.fixedWidth ) %
+    QStringLiteral( "</td></tr>"
 
-                  // Layer Fixed Height
-                  "<tr><td>" ) %
-  tr( "Fixed Height" ) %
-  QStringLiteral( "</td>"
-                  "<td>" ) %
-  QString::number( layer.fixedHeight ) %
-  QStringLiteral( "</td></tr>" );
+                    // Layer Fixed Height
+                    "<tr><td>" ) %
+    tr( "Fixed Height" ) %
+    QStringLiteral( "</td>"
+                    "<td>" ) %
+    QString::number( layer.fixedHeight ) %
+    QStringLiteral( "</td></tr>" );
 
   // Dimensions
   if ( !layer.dimensions.isEmpty() )

--- a/src/server/services/wfs/qgswfsparameters.h
+++ b/src/server/services/wfs/qgswfsparameters.h
@@ -291,7 +291,7 @@ namespace QgsWfs
       QString geometryNameAsString() const;
 
     private:
-      bool loadParameter( const QString &name, const QString &key ) override;
+      bool loadParameter( const QString &key, const QString &value ) override;
       void save( const QgsWfsParameter &parameter );
 
       void log( const QString &msg ) const;

--- a/src/server/services/wfs/qgswfstransaction.cpp
+++ b/src/server/services/wfs/qgswfstransaction.cpp
@@ -522,11 +522,11 @@ namespace QgsWfs
           }
         }
       }
-#endif
       if ( action.error )
       {
         continue;
       }
+#endif
 
       // Commit the changes of the update elements
       if ( !vlayer->commitChanges() )

--- a/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
+++ b/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
@@ -498,11 +498,11 @@ namespace QgsWfs
             }
           }
         }
-#endif
         if ( action.error )
         {
           continue;
         }
+#endif
 
         // Commit the changes of the update elements
         if ( !vlayer->commitChanges() )

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -141,6 +141,7 @@ namespace QgsWms
       }
 #endif
 
+      // cppcheck-suppress identicalInnerCondition
       if ( !capabilitiesDocument )
       {
         capabilitiesCache->insertCapabilitiesDocument( configFilePath, cacheKey, &doc );

--- a/src/server/services/wmts/qgswmtsparameters.h
+++ b/src/server/services/wmts/qgswmtsparameters.h
@@ -313,7 +313,7 @@ namespace QgsWmts
       int jAsInt() const;
 
     private:
-      bool loadParameter( const QString &name, const QString &key ) override;
+      bool loadParameter( const QString &key, const QString &value ) override;
       void save( const QgsWmtsParameter &parameter );
 
       void log( const QString &msg ) const;


### PR DESCRIPTION
A number of the "declare deleted copy constructor and assignment operators as the class has pointer member variables" are not strictly needed, as they are for classes that derived from QObject that deletes those operators, but cppcheck isn't smart enough to detect that.

