### PR TITLE
[gps] Don't correct for true north by default, and add manual bearing offset option

### DIFF
--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -86,6 +86,16 @@ projections\newProjectCrsBehavior=UseCrsOfFirstLayerAdded
 # "UseDefaultCrs" - use the default layer CRS set via QGIS options
 projections\unknownCrsBehavior=NoAction
 
+# Specifies a manual bearing correction to apply to bearings reported by a GPS
+# device, for use when a map canvas is set to match rotation to the GPS bearing
+# or when showing the GPS bearing line
+gps\bearingAdjustment=0
+
+# Set to "true" to automatically correct GPS reported bearings for true north
+# when a map canvas is set to match rotation to the GPS bearing
+# or when showing the GPS bearing line
+gps\correctForTrueNorth=false
+
 [core]
 
 # Desired flow control mode for serial port GPS connections


### PR DESCRIPTION
This change adds two new advanced settings keys for gps:

app\gps\bearingAdjustment: allows for specifying a manual adjustment
factor to apply to bearings obtained from the GPS, in the case that
the GPS reports offset bearings

app\gps\correctForTrueNorth: whether to apply a correction for
true north to bearings obtained from the GPS (now defaults to off)
