### PR TITLE
debian/rules: Fix invalid sed expression syntax to calculate PYTHON_LIBRARY

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -74,9 +74,9 @@ TESTMAKE=ninja $(NINJA_OPTS)
 endif
 
 ifeq (,$(findstring $(DISTRIBUTION),"focal sid"))
-PYTHON_LIBRARY=$(shell python3-config --ldflags | sed -e 's\#-L\(.*\) -L/usr/lib -l\([^ ]*\) .*$$\#\1/lib\2.so\#')
+PYTHON_LIBRARY=$(shell python3-config --ldflags | sed -e 's#-L\(.*\) -L/usr/lib -l\([^ ]*\) .*$$#\1/lib\2.so#')
 else
-PYTHON_LIBRARY=$(shell python3-config --ldflags --embed | sed -e 's\#-L\(.*\) -L/usr/lib -l\([^ ]*\) .*$$\#\1/lib\2.so\#')
+PYTHON_LIBRARY=$(shell python3-config --ldflags --embed | sed -e 's#-L\(.*\) -L/usr/lib -l\([^ ]*\) .*$$#\1/lib\2.so#')
 endif
 
 CMAKE_OPTS := \


### PR DESCRIPTION
debian/rules contains sed invocation for calculation of PYTHON_LIBRARY
path. At debian sid, sed fails here with message:

  sed: -e expression #1, char 11: unknown option to `s'

This causes by invalid escaping of '#' symbol in sed expression
(expression is defined in quotes, not in double-quotes):

```sh
PYTHON_LIBRARY=$(shell python3-config --ldflags --embed | sed -e 's\#-L\(.*\) -L/usr/lib -l\([^ ]*\) .*$$\#\1/lib\2.so\#')
```

Removing of escape symbols before '#' fixes this. Maybe this solution should be
checked with older versions of 'make'.