### PR TITLE
Fix placement of message bar 'clear all' menu arrow on hidpi screens

### DIFF
--- a/src/gui/qgsmessagebar.cpp
+++ b/src/gui/qgsmessagebar.cpp
@@ -81,7 +81,7 @@ QgsMessageBar::QgsMessageBar( QWidget *parent )
   mCloseBtn = new QToolButton( this );
   mCloseMenu->setObjectName( QStringLiteral( "mCloseMenu" ) );
   mCloseBtn->setToolTip( tr( "Close" ) );
-  mCloseBtn->setMinimumWidth( 40 );
+  mCloseBtn->setMinimumWidth( QgsGuiUtils::scaleIconSize( 44 ) );
   mCloseBtn->setStyleSheet(
     "QToolButton { border:none; background-color: rgba(0, 0, 0, 0); }"
     "QToolButton::menu-button { border:none; background-color: rgba(0, 0, 0, 0); }" );


### PR DESCRIPTION
Previously the arrow would sit right over the icon on hidpi screens