### PR TITLE
[BUGFIX] Prepare for Qt5.15

### DIFF
--- a/src/core/dxf/qgsdxfpaintengine.h
+++ b/src/core/dxf/qgsdxfpaintengine.h
@@ -22,6 +22,7 @@
 
 #include "qgis_core.h"
 #include <QPaintEngine>
+#include <QPainterPath>
 #include "qgsabstractgeometry.h"
 
 class QgsPoint;

--- a/src/core/geometry/qgscurve.h
+++ b/src/core/geometry/qgscurve.h
@@ -22,9 +22,9 @@
 #include "qgis_sip.h"
 #include "qgsabstractgeometry.h"
 #include "qgsrectangle.h"
+#include <QPainterPath>
 
 class QgsLineString;
-class QPainterPath;
 
 /**
  * \ingroup core

--- a/src/core/symbology/qgssymbollayer.h
+++ b/src/core/symbology/qgssymbollayer.h
@@ -26,6 +26,7 @@
 #include <QSet>
 #include <QDomDocument>
 #include <QDomElement>
+#include <QPainterPath>
 
 #include "qgssymbol.h"
 #include "qgsfields.h"

--- a/src/gui/qgsmapoverviewcanvas.cpp
+++ b/src/gui/qgsmapoverviewcanvas.cpp
@@ -24,6 +24,7 @@
 #include "qgsmaptopixel.h"
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QPaintEvent>
 #include <QResizeEvent>
 #include <QMouseEvent>


### PR DESCRIPTION
## Description

Apart from the deprecated warnings, one of the big changes in Qt5.15 will be the need to include QPainterPath so as not to break the build.

Tested on QGIS 3.10 and 3.12 (and master) on FreeBSD with Qt 5.14 and 5.15.

cc @rhurlin