### PR TITLE
disabled contour/vector checkbox when rendered type is disabled

### DIFF
--- a/src/app/mesh/qgsrenderermeshpropertieswidget.cpp
+++ b/src/app/mesh/qgsrenderermeshpropertieswidget.cpp
@@ -168,7 +168,6 @@ void QgsRendererMeshPropertiesWidget::onActiveScalarGroupChanged( int groupIndex
   mMeshRendererScalarSettingsWidget->setActiveDatasetGroup( groupIndex );
   mMeshRendererScalarSettingsWidget->syncToLayer();
   mContoursGroupBox->setChecked( groupIndex >= 0 );
-  mContoursGroupBox->setEnabled( groupIndex >= 0 );
   emit mMeshLayer->activeScalarDatasetGroupChanged( groupIndex );
 }
 
@@ -180,6 +179,5 @@ void QgsRendererMeshPropertiesWidget::onActiveVectorGroupChanged( int groupIndex
   mMeshRendererVectorSettingsWidget->setActiveDatasetGroup( groupIndex );
   mMeshRendererVectorSettingsWidget->syncToLayer();
   mVectorsGroupBox->setChecked( groupIndex >= 0 );
-  mVectorsGroupBox->setEnabled( groupIndex >= 0 );
   emit mMeshLayer->activeVectorDatasetGroupChanged( groupIndex );
 }


### PR DESCRIPTION
For mesh layer, when contour or vector rendering are disabled, in the styling dialog, entire group boxes are disabled (event the check box to enable/disable). With this PR, only inside the group box is disabled.