### PR TITLE
accord static dataset group to rendering setting dataset group

### DIFF
--- a/src/app/mesh/qgsmeshstaticdatasetwidget.cpp
+++ b/src/app/mesh/qgsmeshstaticdatasetwidget.cpp
@@ -34,7 +34,7 @@ void QgsMeshStaticDatasetWidget::setLayer( QgsMeshLayer *layer )
 
 void QgsMeshStaticDatasetWidget::syncToLayer()
 {
-  if ( !mLayer && !mLayer->dataProvider() )
+  if ( !mLayer || !mLayer->dataProvider() )
     return;
 
   mScalarDatasetGroup = mLayer->rendererSettings().activeScalarDatasetGroup();

--- a/src/app/mesh/qgsmeshstaticdatasetwidget.cpp
+++ b/src/app/mesh/qgsmeshstaticdatasetwidget.cpp
@@ -34,7 +34,7 @@ void QgsMeshStaticDatasetWidget::setLayer( QgsMeshLayer *layer )
 
 void QgsMeshStaticDatasetWidget::syncToLayer()
 {
-  if ( !mLayer )
+  if ( !mLayer && !mLayer->dataProvider() )
     return;
 
   mScalarDatasetGroup = mLayer->rendererSettings().activeScalarDatasetGroup();
@@ -44,8 +44,18 @@ void QgsMeshStaticDatasetWidget::syncToLayer()
   mDatasetVectorModel->setMeshLayer( mLayer );
   mDatasetVectorModel->setDatasetGroup( mVectorDatasetGroup );
 
-  mScalarDatasetComboBox->setCurrentIndex( mLayer->staticScalarDatasetIndex().dataset() + 1 );
-  mVectorDatasetComboBox->setCurrentIndex( mLayer->staticVectorDatasetIndex().dataset() + 1 );
+  QgsMeshDatasetIndex scalarStaticIndex = mLayer->staticScalarDatasetIndex();
+  QgsMeshDatasetIndex vectorStaticIndex = mLayer->staticScalarDatasetIndex();
+
+  if ( scalarStaticIndex.dataset() < mLayer->dataProvider()->datasetCount( scalarStaticIndex.group() ) )
+    mScalarDatasetComboBox->setCurrentIndex( scalarStaticIndex.dataset() + 1 );
+  else
+    mScalarDatasetComboBox->setCurrentIndex( 0 );
+
+  if ( vectorStaticIndex.dataset() < mLayer->dataProvider()->datasetCount( vectorStaticIndex.group() ) )
+    mVectorDatasetComboBox->setCurrentIndex( vectorStaticIndex.dataset() + 1 );
+  else
+    mVectorDatasetComboBox->setCurrentIndex( 0 );
 }
 
 void QgsMeshStaticDatasetWidget::apply()

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -81,8 +81,6 @@ void QgsMeshLayer::setDefaultRendererSettings()
     if ( meta.maximum() == std::numeric_limits<double>::quiet_NaN() &&
          meta.minimum() == std::numeric_limits<double>::quiet_NaN() )
       meshSettings.setEnabled( true );
-
-    setStaticScalarDatasetIndex( QgsMeshDatasetIndex( 0, 0 ) );
   }
   else
   {
@@ -539,7 +537,7 @@ QgsMeshDatasetIndex QgsMeshLayer::activeScalarDatasetAtTime( const QgsDateTimeRa
   if ( mTemporalProperties->isActive() )
     return datasetIndexAtTime( timeRange, mRendererSettings.activeScalarDatasetGroup() );
   else
-    return mStaticScalarDatasetIndex;
+    return QgsMeshDatasetIndex( mRendererSettings.activeScalarDatasetGroup(), mStaticScalarDatasetIndex );
 }
 
 QgsMeshDatasetIndex QgsMeshLayer::activeVectorDatasetAtTime( const QgsDateTimeRange &timeRange ) const
@@ -547,7 +545,7 @@ QgsMeshDatasetIndex QgsMeshLayer::activeVectorDatasetAtTime( const QgsDateTimeRa
   if ( mTemporalProperties->isActive() )
     return datasetIndexAtTime( timeRange, mRendererSettings.activeVectorDatasetGroup() );
   else
-    return mStaticVectorDatasetIndex;
+    return QgsMeshDatasetIndex( mRendererSettings.activeVectorDatasetGroup(), mStaticVectorDatasetIndex );
 }
 
 void QgsMeshLayer::fillNativeMesh()
@@ -629,7 +627,7 @@ int QgsMeshLayer::closestEdge( const QgsPointXY &point, double searchRadius, Qgs
 
 QgsMeshDatasetIndex QgsMeshLayer::staticVectorDatasetIndex() const
 {
-  return mStaticVectorDatasetIndex;
+  return QgsMeshDatasetIndex( mRendererSettings.activeVectorDatasetGroup(), mStaticVectorDatasetIndex );
 }
 
 void QgsMeshLayer::setReferenceTime( const QDateTime &referenceTime )
@@ -801,21 +799,19 @@ QgsPointXY QgsMeshLayer::snapOnElement( QgsMesh::ElementType elementType, const 
 
 QgsMeshDatasetIndex QgsMeshLayer::staticScalarDatasetIndex() const
 {
-  return mStaticScalarDatasetIndex;
+  return QgsMeshDatasetIndex( mRendererSettings.activeScalarDatasetGroup(), mStaticScalarDatasetIndex );
 }
 
 void QgsMeshLayer::setStaticVectorDatasetIndex( const QgsMeshDatasetIndex &staticVectorDatasetIndex )
 {
-  mStaticVectorDatasetIndex = staticVectorDatasetIndex;
-  if ( !temporalProperties()->isActive() )
-    mRendererSettings.setActiveVectorDatasetGroup( staticVectorDatasetIndex.group() );
+  mStaticVectorDatasetIndex = staticVectorDatasetIndex.dataset();
+  mRendererSettings.setActiveVectorDatasetGroup( staticVectorDatasetIndex.group() );
 }
 
 void QgsMeshLayer::setStaticScalarDatasetIndex( const QgsMeshDatasetIndex &staticScalarDatasetIndex )
 {
-  mStaticScalarDatasetIndex = staticScalarDatasetIndex;
-  if ( !temporalProperties()->isActive() )
-    mRendererSettings.setActiveScalarDatasetGroup( staticScalarDatasetIndex.group() );
+  mStaticScalarDatasetIndex = staticScalarDatasetIndex.dataset();
+  mRendererSettings.setActiveScalarDatasetGroup( staticScalarDatasetIndex.group() );
 }
 
 QgsMeshSimplificationSettings QgsMeshLayer::meshSimplificationSettings() const
@@ -1048,15 +1044,11 @@ bool QgsMeshLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &con
   QDomElement elemStaticDataset = layer_node.firstChildElement( QStringLiteral( "static-active-dataset" ) );
   if ( elemStaticDataset.hasAttribute( QStringLiteral( "scalar" ) ) )
   {
-    QStringList lst = elemStaticDataset.attribute( QStringLiteral( "scalar" ) ).split( QChar( ',' ) );
-    if ( lst.count() == 2 )
-      mStaticScalarDatasetIndex = QgsMeshDatasetIndex( lst[0].toInt(), lst[1].toInt() );
+    mStaticScalarDatasetIndex = elemStaticDataset.attribute( QStringLiteral( "scalar" ) ).toInt();
   }
   if ( elemStaticDataset.hasAttribute( QStringLiteral( "vector" ) ) )
   {
-    QStringList lst = elemStaticDataset.attribute( QStringLiteral( "vector" ) ).split( QChar( ',' ) );
-    if ( lst.count() == 2 )
-      mStaticVectorDatasetIndex = QgsMeshDatasetIndex( lst[0].toInt(), lst[1].toInt() );
+    mStaticVectorDatasetIndex = elemStaticDataset.attribute( QStringLiteral( "vector" ) ).toInt();
   }
 
   return mValid; // should be true if read successfully
@@ -1097,10 +1089,8 @@ bool QgsMeshLayer::writeXml( QDomNode &layer_node, QDomDocument &document, const
   }
 
   QDomElement elemStaticDataset = document.createElement( QStringLiteral( "static-active-dataset" ) );
-  if ( mStaticScalarDatasetIndex.isValid() )
-    elemStaticDataset.setAttribute( QStringLiteral( "scalar" ), QStringLiteral( "%1,%2" ).arg( mStaticScalarDatasetIndex.group() ).arg( mStaticScalarDatasetIndex.dataset() ) );
-  if ( mStaticVectorDatasetIndex.isValid() )
-    elemStaticDataset.setAttribute( QStringLiteral( "vector" ), QStringLiteral( "%1,%2" ).arg( mStaticVectorDatasetIndex.group() ).arg( mStaticVectorDatasetIndex.dataset() ) );
+  elemStaticDataset.setAttribute( QStringLiteral( "scalar" ), mStaticScalarDatasetIndex );
+  elemStaticDataset.setAttribute( QStringLiteral( "vector" ), mStaticVectorDatasetIndex );
   layer_node.appendChild( elemStaticDataset );
 
   // write dataset group tree items

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -545,8 +545,8 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
 
     QgsMeshLayerTemporalProperties *mTemporalProperties;
 
-    QgsMeshDatasetIndex mStaticScalarDatasetIndex;
-    QgsMeshDatasetIndex mStaticVectorDatasetIndex;
+    int mStaticScalarDatasetIndex = 0;
+    int mStaticVectorDatasetIndex = 0;
 
     std::unique_ptr<QgsMeshDatasetGroupTreeItem> mDatasetGroupTreeRootItem;
 


### PR DESCRIPTION
Temporal frameworks led to the concept of static dataset, that is dataset that is rendered when the temporal navigation is turned off or the mesh layer is forced to be static.
Before this PR the static dataset was stored in an QgsMeshDatasetIndex value in the mesh layer, storing index of the dataset group  and the index of the dataset in the group. As the dataset group rendered is also storing in the renderings settings, that leads to inconsistent behavior when passing from static to temporal mode. 
This PR fixes those issues using only the dataset group index in the renderings settings while the index of the static dataset is stored  directly in the layer and not exposed with the rendering settings.