### PR TITLE
fix scientific notation in scale notation, fix #36859

### DIFF
--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -387,7 +387,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   {
     for ( double scale : projectScales )
     {
-      addScaleToScaleList( QStringLiteral( "1:%1" ).arg( scale ) );
+      addScaleToScaleList( QStringLiteral( "1:%1" ).arg( QLocale().toString( scale, 'f', 0 ) ) );
     }
   }
   connect( lstScales, &QListWidget::itemChanged, this, &QgsProjectProperties::scaleItemChanged );

--- a/src/app/qgsstatusbarscalewidget.cpp
+++ b/src/app/qgsstatusbarscalewidget.cpp
@@ -98,7 +98,7 @@ void QgsStatusBarScaleWidget::updateScales()
     QStringList textScales;
     textScales.reserve( scales.size() );
     for ( double scale : scales )
-      textScales << QStringLiteral( "1:%1" ).arg( scale );
+      textScales << QStringLiteral( "1:%1" ).arg( QLocale().toString( scale, 'f', 0 ) );
     mScale->updateScales( textScales );
   }
   else

--- a/src/gui/qgsscalecombobox.cpp
+++ b/src/gui/qgsscalecombobox.cpp
@@ -216,7 +216,7 @@ QString QgsScaleComboBox::toString( double scale )
   }
   else
   {
-    return QStringLiteral( "1:%1" ).arg( QLocale().toString( static_cast< int >( std::round( scale ) ) ) );
+    return QStringLiteral( "1:%1" ).arg( QLocale().toString( static_cast< float >( std::round( scale ) ), 'f', 0 ) );
   }
 }
 

--- a/tests/src/gui/testqgsscalecombobox.cpp
+++ b/tests/src/gui/testqgsscalecombobox.cpp
@@ -41,6 +41,7 @@ class TestQgsScaleComboBox : public QObject
     void toString();
     void toDouble();
     void allowNull();
+    void testLocale();
 
   private:
     void enterScale( const QString &scale );
@@ -254,6 +255,34 @@ void TestQgsScaleComboBox::enterScale( double scale )
 void TestQgsScaleComboBox::cleanup()
 {
   delete s;
+}
+
+void TestQgsScaleComboBox::testLocale()
+{
+  QLocale::setDefault( QLocale::English );
+  QCOMPARE( s->toString( 1e8 ), QString( "1:100,000,000" ) );
+  QLocale customEnglish( QLocale::English );
+  customEnglish.setNumberOptions( QLocale::NumberOption::OmitGroupSeparator );
+  QLocale::setDefault( customEnglish );
+  QCOMPARE( s->toString( 1e8 ), QString( "1:100000000" ) );
+
+  QLocale::setDefault( QLocale::French );
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 12, 0 )
+  QCOMPARE( s->toString( 1e8 ), QString( "1:100 000 000" ) );
+#else
+  QCOMPARE( s->toString( 1e8 ), QString( "1:100\u00A0000\u00A0000" ) );
+#endif
+  QLocale customFrench( QLocale::French );
+  customFrench.setNumberOptions( QLocale::NumberOption::OmitGroupSeparator );
+  QLocale::setDefault( customFrench );
+  QCOMPARE( s->toString( 1e8 ), QString( "1:100000000" ) );
+
+  QLocale::setDefault( QLocale::German );
+  QCOMPARE( s->toString( 1e8 ), QString( "1:100.000.000" ) );
+  QLocale customGerman( QLocale::German );
+  customFrench.setNumberOptions( QLocale::NumberOption::OmitGroupSeparator );
+  QLocale::setDefault( customFrench );
+  QCOMPARE( s->toString( 1e8 ), QString( "1:100000000" ) );
 }
 
 QGSTEST_MAIN( TestQgsScaleComboBox )


### PR DESCRIPTION

## Description

This PR fixes bugs with project predefined scales. Using this feature, smal scale are displayed with scientific notation (see #36859). It break the use of the QgsScaleComboBox, and alter the use of the Predefined scales configuration in Project properties.

 Internationalization was not fully used which causes troubles to convert int to string and vice versa.
