### PR TITLE
add the possibility to use absolute value for varying line of 1D mesh

### DIFF
--- a/python/core/auto_generated/symbology/qgsinterpolatedlinerenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsinterpolatedlinerenderer.sip.in
@@ -148,6 +148,15 @@ Returns whether the variable width ignores out of range value
 Sets whether the variable width ignores out of range value
 %End
 
+    bool useAbsoluteValue() const;
+%Docstring
+Returns whether absolute value are used as input
+%End
+    void setUseAbsoluteValue( bool useAbsoluteValue );
+%Docstring
+Sets whether absolute value are used as input
+%End
+
     bool isVariableWidth() const;
 %Docstring
 Returns whether the width is variable

--- a/src/app/mesh/qgsmeshvariablestrokewidthwidget.cpp
+++ b/src/app/mesh/qgsmeshvariablestrokewidthwidget.cpp
@@ -44,6 +44,8 @@ QgsMeshVariableStrokeWidthWidget::QgsMeshVariableStrokeWidthWidget(
            this, &QgsMeshVariableStrokeWidthWidget::widgetChanged );
   connect( mIgnoreOutOfRangecheckBox, &QCheckBox::toggled,
            this, &QgsMeshVariableStrokeWidthWidget::widgetChanged );
+  connect( mUseAbsoluteValueCheckBox, &QCheckBox::toggled,
+           this, &QgsMeshVariableStrokeWidthWidget::widgetChanged );
 }
 
 void QgsMeshVariableStrokeWidthWidget::setVariableStrokeWidth( const QgsInterpolatedLineWidth &variableStrokeWidth )
@@ -53,6 +55,7 @@ void QgsMeshVariableStrokeWidthWidget::setVariableStrokeWidth( const QgsInterpol
   whileBlocking( mWidthMinimumSpinBox )->setValue( variableStrokeWidth.minimumWidth() );
   whileBlocking( mWidthMaximumSpinBox )->setValue( variableStrokeWidth.maximumWidth() );
   whileBlocking( mIgnoreOutOfRangecheckBox )->setChecked( variableStrokeWidth.ignoreOutOfRange() );
+  whileBlocking( mUseAbsoluteValueCheckBox )->setChecked( variableStrokeWidth.useAbsoluteValue() );
 }
 
 void QgsMeshVariableStrokeWidthButton::setDefaultMinMaxValue( double minimum, double maximum )
@@ -69,7 +72,7 @@ QgsInterpolatedLineWidth QgsMeshVariableStrokeWidthWidget::variableStrokeWidth()
   strokeWidth.setMinimumWidth( mWidthMinimumSpinBox->value() );
   strokeWidth.setMaximumWidth( mWidthMaximumSpinBox->value() );
   strokeWidth.setIgnoreOutOfRange( mIgnoreOutOfRangecheckBox->isChecked() );
-
+  strokeWidth.setUseAbsoluteValue( mUseAbsoluteValueCheckBox->isChecked() );
   return strokeWidth;
 }
 

--- a/src/core/symbology/qgsinterpolatedlinerenderer.cpp
+++ b/src/core/symbology/qgsinterpolatedlinerenderer.cpp
@@ -277,6 +277,9 @@ double QgsInterpolatedLineWidth::strokeWidth( double value ) const
     if ( mNeedUpdateFormula )
       updateLinearFormula();
 
+    if ( mUseAbsoluteValue )
+      value = std::fabs( value );
+
     if ( value > mMaximumValue )
     {
       if ( mIgnoreOutOfRange )
@@ -312,6 +315,7 @@ QDomElement QgsInterpolatedLineWidth::writeXml( QDomDocument &doc, const QgsRead
   elem.setAttribute( QStringLiteral( "minimum-width" ), mMinimumWidth );
   elem.setAttribute( QStringLiteral( "maximum-width" ), mMaximumWidth );
   elem.setAttribute( QStringLiteral( "ignore-out-of-range" ), mIgnoreOutOfRange ? 1 : 0 );
+  elem.setAttribute( QStringLiteral( "use-absolute-value" ), mUseAbsoluteValue ? 1 : 0 );
 
   return elem;
 }
@@ -327,6 +331,17 @@ void QgsInterpolatedLineWidth::readXml( const QDomElement &elem, const QgsReadWr
   mMinimumWidth = elem.attribute( QStringLiteral( "minimum-width" ) ).toDouble();
   mMaximumWidth = elem.attribute( QStringLiteral( "maximum-width" ) ).toDouble();
   mIgnoreOutOfRange = elem.attribute( QStringLiteral( "ignore-out-of-range" ) ).toInt();
+  mUseAbsoluteValue = elem.attribute( QStringLiteral( "use-absolute-value" ) ).toInt();
+}
+
+bool QgsInterpolatedLineWidth::useAbsoluteValue() const
+{
+  return mUseAbsoluteValue;
+}
+
+void QgsInterpolatedLineWidth::setUseAbsoluteValue( bool useAbsoluteValue )
+{
+  mUseAbsoluteValue = useAbsoluteValue;
 }
 
 double QgsInterpolatedLineWidth::fixedStrokeWidth() const

--- a/src/core/symbology/qgsinterpolatedlinerenderer.h
+++ b/src/core/symbology/qgsinterpolatedlinerenderer.h
@@ -134,6 +134,11 @@ class CORE_EXPORT QgsInterpolatedLineWidth
     //! Sets whether the variable width ignores out of range value
     void setIgnoreOutOfRange( bool ignoreOutOfRange );
 
+    //! Returns whether absolute value are used as input
+    bool useAbsoluteValue() const;
+    //! Sets whether absolute value are used as input
+    void setUseAbsoluteValue( bool useAbsoluteValue );
+
     //! Returns whether the width is variable
     bool isVariableWidth() const;
     //! Returns whether the width is variable
@@ -162,6 +167,7 @@ class CORE_EXPORT QgsInterpolatedLineWidth
     double mMinimumWidth = DEFAULT_LINE_WIDTH;
     double mMaximumWidth = 3;
     bool mIgnoreOutOfRange = false;
+    bool mUseAbsoluteValue = false;
 
     mutable double mLinearCoef = 1;
     mutable bool mNeedUpdateFormula = true;

--- a/src/ui/mesh/qgsmeshvariablestrokewidthwidgetbase.ui
+++ b/src/ui/mesh/qgsmeshvariablestrokewidthwidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>268</width>
+    <width>340</width>
     <height>220</height>
    </rect>
   </property>
@@ -14,7 +14,24 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="8" column="0">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Input Values</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QgsDoubleSpinBox" name="mWidthMinimumSpinBox">
+     <property name="value">
+      <double>1.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="mValueMinimumLineEdit"/>
+   </item>
+   <item row="9" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -26,6 +43,9 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="mValueMaximumLineEdit"/>
    </item>
    <item row="1" column="2" rowspan="2">
     <widget class="QPushButton" name="mDefaultMinMaxButton">
@@ -50,14 +70,21 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_4">
+   <item row="7" column="0">
+    <widget class="QLabel" name="label">
      <property name="text">
-      <string>Min value</string>
+      <string>Min Width</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="3">
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Max Width</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="3">
     <widget class="Line" name="line">
      <property name="minimumSize">
       <size>
@@ -70,60 +97,47 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="label_2">
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>Max width</string>
+      <string>Max Value</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Min Value</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
     <widget class="QgsDoubleSpinBox" name="mWidthMaximumSpinBox">
      <property name="value">
       <double>5.000000000000000</double>
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Input values</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Min width</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Max value</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QgsDoubleSpinBox" name="mWidthMinimumSpinBox">
-     <property name="value">
-      <double>1.000000000000000</double>
-     </property>
-    </widget>
-   </item>
    <item row="3" column="0" colspan="3">
-    <widget class="QCheckBox" name="mIgnoreOutOfRangecheckBox">
-     <property name="text">
-      <string>Ignore out of range values</string>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="bottomMargin">
+      <number>0</number>
      </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="mValueMinimumLineEdit"/>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="mValueMaximumLineEdit"/>
+     <item>
+      <widget class="QCheckBox" name="mIgnoreOutOfRangecheckBox">
+       <property name="text">
+        <string>Ignore Out of Range Values</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="mUseAbsoluteValueCheckBox">
+       <property name="text">
+        <string>Use Absolute Value</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
@@ -138,7 +152,6 @@
   <tabstop>mValueMinimumLineEdit</tabstop>
   <tabstop>mValueMaximumLineEdit</tabstop>
   <tabstop>mDefaultMinMaxButton</tabstop>
-  <tabstop>mIgnoreOutOfRangecheckBox</tabstop>
   <tabstop>mWidthMinimumSpinBox</tabstop>
   <tabstop>mWidthMaximumSpinBox</tabstop>
  </tabstops>


### PR DESCRIPTION
With the new width varying 1D mesh, when scalar value are negative, this could leads to inconsistent displaying depending on user data.
This PR introduce the possibility to use absolute value.

![image](https://user-images.githubusercontent.com/7416892/83513479-d9db3a80-a49f-11ea-8843-ab064b8e1596.png)

fix #36858