### PR TITLE
Fix styles are not copied in offline editing

### DIFF
--- a/python/core/auto_generated/qgsmaplayerstylemanager.sip.in
+++ b/python/core/auto_generated/qgsmaplayerstylemanager.sip.in
@@ -143,6 +143,14 @@ Returns ``True`` if this is the default style
 .. versionadded:: 3.0
 %End
 
+    void copyStylesFrom( QgsMapLayerStyleManager *other );
+%Docstring
+Copies all styles from ``other``.
+In case there is already a style with the same name it will be overwritten.
+
+.. versionadded:: 3.14
+%End
+
   signals:
     void styleAdded( const QString &name );
 %Docstring

--- a/src/core/qgsmaplayerstylemanager.cpp
+++ b/src/core/qgsmaplayerstylemanager.cpp
@@ -230,3 +230,14 @@ bool QgsMapLayerStyleManager::isDefault( const QString &styleName ) const
 {
   return styleName == defaultStyleName();
 }
+
+void QgsMapLayerStyleManager::copyStylesFrom( QgsMapLayerStyleManager *other )
+{
+  const QStringList styleNames = other->mStyles.keys();
+
+  for ( const QString &styleName : styleNames )
+  {
+    mStyles.remove( styleName );
+    addStyle( styleName, other->style( styleName ) );
+  }
+}

--- a/src/core/qgsmaplayerstylemanager.h
+++ b/src/core/qgsmaplayerstylemanager.h
@@ -136,6 +136,14 @@ class CORE_EXPORT QgsMapLayerStyleManager : public QObject
      */
     bool isDefault( const QString &styleName ) const;
 
+    /**
+     * Copies all styles from \a other.
+     * In case there is already a style with the same name it will be overwritten.
+     *
+     * \since QGIS 3.14
+     */
+    void copyStylesFrom( QgsMapLayerStyleManager *other );
+
   signals:
     //! Emitted when a new style has been added
     void styleAdded( const QString &name );

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -40,6 +40,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsproviderregistry.h"
 #include "qgsprovidermetadata.h"
+#include "qgsmaplayerstylemanager.h"
 
 #include <QDir>
 #include <QDomDocument>
@@ -1096,6 +1097,14 @@ void QgsOfflineEditing::updateFidLookup( QgsVectorLayer *remoteLayer, sqlite3 *d
 
 void QgsOfflineEditing::copySymbology( QgsVectorLayer *sourceLayer, QgsVectorLayer *targetLayer )
 {
+  const QMap<QString, QgsMapLayerStyle> styles = sourceLayer->styleManager()->mapLayerStyles();
+  const QStringList styleNames = styles.keys();
+
+  for ( const QString &styleName : styleNames )
+  {
+    targetLayer->styleManager()->addStyle( styleName, styles.value( styleName ) );
+  }
+
   QString error;
   QDomDocument doc;
   QgsReadWriteContext context;

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -1097,13 +1097,7 @@ void QgsOfflineEditing::updateFidLookup( QgsVectorLayer *remoteLayer, sqlite3 *d
 
 void QgsOfflineEditing::copySymbology( QgsVectorLayer *sourceLayer, QgsVectorLayer *targetLayer )
 {
-  const QMap<QString, QgsMapLayerStyle> styles = sourceLayer->styleManager()->mapLayerStyles();
-  const QStringList styleNames = styles.keys();
-
-  for ( const QString &styleName : styleNames )
-  {
-    targetLayer->styleManager()->addStyle( styleName, styles.value( styleName ) );
-  }
+  targetLayer->styleManager()->copyStylesFrom( sourceLayer->styleManager() );
 
   QString error;
   QDomDocument doc;

--- a/tests/src/core/testqgsmaplayerstylemanager.cpp
+++ b/tests/src/core/testqgsmaplayerstylemanager.cpp
@@ -39,6 +39,7 @@ class TestQgsMapLayerStyleManager : public QObject
     void testStyle();
     void testReadWrite();
     void testSwitchingStyles();
+    void testCopyStyles();
 
   private:
     QgsVectorLayer *mVL = nullptr;
@@ -198,6 +199,25 @@ void TestQgsMapLayerStyleManager::testSwitchingStyles()
 
   mVL->styleManager()->setCurrentStyle( QStringLiteral( "s1" ) );
   QCOMPARE( _getVLColor( mVL ), QColor( Qt::blue ) );
+}
+
+void TestQgsMapLayerStyleManager::testCopyStyles()
+{
+  std::unique_ptr<QgsVectorLayer> lines = qgis::make_unique<QgsVectorLayer>( QStringLiteral( "LineString" ), QStringLiteral( "Line Layer" ), QStringLiteral( "memory" ) );
+  std::unique_ptr<QgsVectorLayer> lines2 = qgis::make_unique<QgsVectorLayer>( QStringLiteral( "LineString" ), QStringLiteral( "Line Layer" ), QStringLiteral( "memory" ) );
+
+  QgsMapLayerStyleManager *sm = lines->styleManager();
+
+  sm->addStyleFromLayer( QStringLiteral( "style2" ) );
+
+  QgsMapLayerStyleManager *sm2 = lines2->styleManager();
+
+  sm2->copyStylesFrom( sm );
+  sm2->addStyleFromLayer( "style3" );
+
+  QVERIFY( sm2->styles().contains( "style2" ) );
+  QVERIFY( sm2->styles().contains( "style3" ) );
+  QVERIFY( sm2->styles().contains( "default" ) );
 }
 
 

--- a/tests/src/core/testqgsofflineediting.cpp
+++ b/tests/src/core/testqgsofflineediting.cpp
@@ -26,6 +26,7 @@
 #include "qgstest.h"
 #include "qgsvectorlayerref.h"
 #include "qgslayertree.h"
+#include "qgsmaplayerstylemanager.h"
 
 /**
  * \ingroup UnitTests
@@ -164,6 +165,10 @@ void TestQgsOfflineEditing::createGeopackageAndSynchronizeBack()
   QgsLayerTreeLayer *layerTreelayer = QgsProject::instance()->layerTreeRoot()->findLayer( mpLayer->id() );
   layerTreelayer->setCustomProperty( QStringLiteral( "showFeatureCount" ), 1 );
   layerTreelayer->setItemVisibilityChecked( false );
+  QgsMapLayerStyle style;
+  style.readFromLayer( mpLayer );
+
+  mpLayer->styleManager()->addStyle( QStringLiteral( "testStyle" ), style );
 
   //convert
   mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, QgsOfflineEditing::GPKG );
@@ -177,6 +182,7 @@ void TestQgsOfflineEditing::createGeopackageAndSynchronizeBack()
   layerTreelayer = QgsProject::instance()->layerTreeRoot()->findLayer( mpLayer->id() );
   QCOMPARE( layerTreelayer->customProperty( QStringLiteral( "showFeatureCount" ), 0 ).toInt(), 1 );
   QCOMPARE( layerTreelayer->isVisible(), false );
+  QVERIFY( mpLayer->styleManager()->styles().contains( QStringLiteral( "testStyle" ) ) );
 
   QgsFeature firstFeatureInAction;
   it = mpLayer->getFeatures();


### PR DESCRIPTION
## Description

When an offline version of a layer is created, the styles are lost. This fixes this issue.

Fixes https://github.com/opengisch/qfieldsync/issues/111