### PR TITLE
never hide mesh static dataset widget

### DIFF
--- a/src/app/mesh/qgsmeshlayerproperties.cpp
+++ b/src/app/mesh/qgsmeshlayerproperties.cpp
@@ -80,7 +80,6 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
 
   connect( mTemporalReloadButton, &QPushButton::clicked, this, &QgsMeshLayerProperties::reloadTemporalProperties );
   connect( mTemporalDateTimeReference, &QDateTimeEdit::dateTimeChanged, this, &QgsMeshLayerProperties::onTimeReferenceChange );
-  connect( mTemporalStaticDatasetCheckBox, &QCheckBox::toggled, this, &QgsMeshLayerProperties::onStaticDatasetCheckBoxChanged );
   connect( mMeshLayer, &QgsMeshLayer::activeScalarDatasetGroupChanged, mStaticScalarWidget, &QgsMeshStaticDatasetWidget::setScalarDatasetGroup );
   connect( mMeshLayer, &QgsMeshLayer::activeVectorDatasetGroupChanged, mStaticScalarWidget, &QgsMeshStaticDatasetWidget::setVectorDatasetGroup );
 
@@ -218,7 +217,6 @@ void QgsMeshLayerProperties::syncToLayer()
     mComboBoxTemporalDatasetMatchingMethod->findData( temporalProperties->matchingMethod() ) );
 
   mStaticScalarWidget->syncToLayer();
-  mStaticScalarWidget->setVisible( !mMeshLayer->temporalProperties()->isActive() );
   mTemporalStaticDatasetCheckBox->setChecked( !mMeshLayer->temporalProperties()->isActive() );
 }
 
@@ -462,9 +460,4 @@ void QgsMeshLayerProperties::onTimeReferenceChange()
   const QgsDateTimeRange &timeExtent = mMeshLayer->dataProvider()->temporalCapabilities()->timeExtent( mTemporalDateTimeReference->dateTime() );
   mTemporalDateTimeStart->setDateTime( timeExtent.begin() );
   mTemporalDateTimeEnd->setDateTime( timeExtent.end() );
-}
-
-void QgsMeshLayerProperties::onStaticDatasetCheckBoxChanged()
-{
-  mStaticScalarWidget->setVisible( mTemporalStaticDatasetCheckBox->isChecked() );
 }

--- a/src/app/mesh/qgsmeshlayerproperties.cpp
+++ b/src/app/mesh/qgsmeshlayerproperties.cpp
@@ -393,6 +393,10 @@ void QgsMeshLayerProperties::apply()
 
   // notify the project we've made a change
   QgsProject::instance()->setDirty( true );
+
+  // Resync what have to be resync (widget that can be changed by other properties part)
+  mStaticDatasetWidget->syncToLayer();
+  mRendererMeshPropertiesWidget->syncToLayer();
 }
 
 void QgsMeshLayerProperties::changeCrs( const QgsCoordinateReferenceSystem &crs )

--- a/src/app/mesh/qgsmeshlayerproperties.h
+++ b/src/app/mesh/qgsmeshlayerproperties.h
@@ -74,7 +74,6 @@ class APP_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
 
     void onTimeReferenceChange();
 
-    void onStaticDatasetCheckBoxChanged();
   private:
     //! Pointer to the mesh styling widget
     QgsRendererMeshPropertiesWidget *mRendererMeshPropertiesWidget = nullptr;

--- a/src/app/mesh/qgsmeshlayerproperties.h
+++ b/src/app/mesh/qgsmeshlayerproperties.h
@@ -74,6 +74,7 @@ class APP_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
 
     void onTimeReferenceChange();
 
+    void onStaticDatasetCheckBoxChanged();
   private:
     //! Pointer to the mesh styling widget
     QgsRendererMeshPropertiesWidget *mRendererMeshPropertiesWidget = nullptr;
@@ -88,6 +89,8 @@ class APP_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
      * Previous layer style. Used to reset style to previous state if new style
      * was loaded but dialog is canceled */
     QgsMapLayerStyle mOldStyle;
+
+    bool mIsMapSettingsTemporal = false;
 
     friend class TestQgsMeshLayerPropertiesDialog;
 

--- a/src/app/mesh/qgsmeshstaticdatasetwidget.cpp
+++ b/src/app/mesh/qgsmeshstaticdatasetwidget.cpp
@@ -37,25 +37,10 @@ void QgsMeshStaticDatasetWidget::syncToLayer()
   if ( !mLayer || !mLayer->dataProvider() )
     return;
 
-  mScalarDatasetGroup = mLayer->rendererSettings().activeScalarDatasetGroup();
-  mVectorDatasetGroup = mLayer->rendererSettings().activeVectorDatasetGroup();
   mDatasetScalarModel->setMeshLayer( mLayer );
-  mDatasetScalarModel->setDatasetGroup( mScalarDatasetGroup );
   mDatasetVectorModel->setMeshLayer( mLayer );
-  mDatasetVectorModel->setDatasetGroup( mVectorDatasetGroup );
-
-  QgsMeshDatasetIndex scalarStaticIndex = mLayer->staticScalarDatasetIndex();
-  QgsMeshDatasetIndex vectorStaticIndex = mLayer->staticScalarDatasetIndex();
-
-  if ( scalarStaticIndex.dataset() < mLayer->dataProvider()->datasetCount( scalarStaticIndex.group() ) )
-    mScalarDatasetComboBox->setCurrentIndex( scalarStaticIndex.dataset() + 1 );
-  else
-    mScalarDatasetComboBox->setCurrentIndex( 0 );
-
-  if ( vectorStaticIndex.dataset() < mLayer->dataProvider()->datasetCount( vectorStaticIndex.group() ) )
-    mVectorDatasetComboBox->setCurrentIndex( vectorStaticIndex.dataset() + 1 );
-  else
-    mVectorDatasetComboBox->setCurrentIndex( 0 );
+  setScalarDatasetGroup( mLayer->rendererSettings().activeScalarDatasetGroup() );
+  setVectorDatasetGroup( mLayer->rendererSettings().activeVectorDatasetGroup() );
 }
 
 void QgsMeshStaticDatasetWidget::apply()
@@ -71,16 +56,40 @@ void QgsMeshStaticDatasetWidget::setScalarDatasetGroup( int index )
 {
   mScalarDatasetGroup = index;
   mDatasetScalarModel->setDatasetGroup( index );
+  mScalarDatasetComboBox->setEnabled( mScalarDatasetGroup >= 0 );
   if ( mLayer && mLayer->dataProvider() )
+  {
     mScalarName->setText( mLayer->dataProvider()->datasetGroupMetadata( index ).name() );
+    setScalarDatasetIndex( mLayer->staticScalarDatasetIndex().dataset() );
+  }
 }
 
 void QgsMeshStaticDatasetWidget::setVectorDatasetGroup( int index )
 {
   mVectorDatasetGroup = index;
   mDatasetVectorModel->setDatasetGroup( index );
+  mVectorDatasetComboBox->setEnabled( mVectorDatasetGroup >= 0 );
   if ( mLayer && mLayer->dataProvider() )
+  {
     mVectorName->setText( mLayer->dataProvider()->datasetGroupMetadata( index ).name() );
+    setVectorDatasetIndex( mLayer->staticVectorDatasetIndex().dataset() );
+  }
+}
+
+void QgsMeshStaticDatasetWidget::setScalarDatasetIndex( int index )
+{
+  if ( index < mLayer->dataProvider()->datasetCount( mScalarDatasetGroup ) )
+    mScalarDatasetComboBox->setCurrentIndex( index + 1 );
+  else
+    mScalarDatasetComboBox->setCurrentIndex( 0 );
+}
+
+void QgsMeshStaticDatasetWidget::setVectorDatasetIndex( int index )
+{
+  if ( index < mLayer->dataProvider()->datasetCount( mVectorDatasetGroup ) )
+    mVectorDatasetComboBox->setCurrentIndex( index + 1 );
+  else
+    mVectorDatasetComboBox->setCurrentIndex( 0 );
 }
 
 QgsMeshDatasetListModel::QgsMeshDatasetListModel( QObject *parent ): QAbstractListModel( parent )

--- a/src/app/mesh/qgsmeshstaticdatasetwidget.h
+++ b/src/app/mesh/qgsmeshstaticdatasetwidget.h
@@ -74,6 +74,9 @@ class APP_NO_EXPORT QgsMeshStaticDatasetWidget  : public QWidget, private Ui::Qg
     void setVectorDatasetGroup( int index );
 
   private:
+    void setScalarDatasetIndex( int index );
+    void setVectorDatasetIndex( int index );
+
     int mScalarDatasetGroup = -1;
     int mVectorDatasetGroup = -1;
 

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -417,7 +417,6 @@ QgsMeshDatasetValue QgsMeshLayer::dataset1dValue( const QgsMeshDatasetIndex &ind
     }
   }
 
-
   return value;
 }
 

--- a/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
+++ b/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
@@ -342,20 +342,32 @@ border-radius: 2px;</string>
                 <widget class="QgsMeshDatasetGroupTreeWidget" name="mDatasetGroupTreeWidget" native="true"/>
                </item>
                <item>
-                <widget class="QCheckBox" name="mTemporalStaticDatasetCheckBox">
-                 <property name="text">
+                <widget class="QGroupBox" name="groupBox">
+                 <property name="title">
                   <string>Static Dataset</string>
                  </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QgsMeshStaticDatasetWidget" name="mStaticScalarWidget" native="true">
-                 <property name="minimumSize">
-                  <size>
-                   <width>0</width>
-                   <height>0</height>
-                  </size>
-                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_7">
+                  <item>
+                   <widget class="QgsMeshStaticDatasetWidget" name="mStaticScalarWidget" native="true">
+                    <property name="minimumSize">
+                     <size>
+                      <width>0</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="mTemporalStaticDatasetCheckBox">
+                    <property name="toolTip">
+                     <string>Static dataset even if the temporal navigation is on</string>
+                    </property>
+                    <property name="text">
+                     <string>Force Static Dataset with Temporal Navigation</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
                 </widget>
                </item>
                <item>

--- a/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
+++ b/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
@@ -342,28 +342,28 @@ border-radius: 2px;</string>
                 <widget class="QgsMeshDatasetGroupTreeWidget" name="mDatasetGroupTreeWidget" native="true"/>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupBox">
+                <widget class="QCheckBox" name="mTemporalStaticDatasetCheckBox">
+                 <property name="toolTip">
+                  <string>Static dataset even if the temporal navigation is on</string>
+                 </property>
+                 <property name="text">
+                  <string>Force Static Dataset with Temporal Navigation</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QgsCollapsibleGroupBoxBasic" name="mStaticDatasetGroupBox">
                  <property name="title">
                   <string>Static Dataset</string>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_7">
                   <item>
-                   <widget class="QgsMeshStaticDatasetWidget" name="mStaticScalarWidget" native="true">
+                   <widget class="QgsMeshStaticDatasetWidget" name="mStaticDatasetWidget" native="true">
                     <property name="minimumSize">
                      <size>
                       <width>0</width>
                       <height>0</height>
                      </size>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="mTemporalStaticDatasetCheckBox">
-                    <property name="toolTip">
-                     <string>Static dataset even if the temporal navigation is on</string>
-                    </property>
-                    <property name="text">
-                     <string>Force Static Dataset with Temporal Navigation</string>
                     </property>
                    </widget>
                   </item>
@@ -378,7 +378,7 @@ border-radius: 2px;</string>
                  <property name="sizeHint" stdset="0">
                   <size>
                    <width>20</width>
-                   <height>0</height>
+                   <height>40</height>
                   </size>
                  </property>
                 </spacer>
@@ -808,6 +808,12 @@ border-radius: 2px;</string>
    <class>QgsMeshDatasetGroupTreeWidget</class>
    <extends>QWidget</extends>
    <header>qgsmeshdatasetgrouptreewidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
The new temporal framework led to the concept of static dataset for mesh layer, that is the datasets that are displayed if the temporal navigation is off or if the mesh layer is set to "Static Dataset".

Before, the possibility to set the map canvas with temporal navigation off, the choice of the dataset (with comboboxes) was possible only if the checkbox "Static dataset" was checked in the mesh layer properties widget.
Furthermore, the default QGIS map canvas is set with temporal navigation off. So after creating a new document and loading a mesh layer, it is the static dataset that is displayed even if the mesh layer is not forced to be static.
So, now, hiding the static dataset comboboxes has fewer sens.
With this PR those comboboxes are not hidden anymore.

![image](https://user-images.githubusercontent.com/7416892/83517926-c0d68780-a4a7-11ea-99c2-ae1c9fe73076.png)