### PR TITLE
Python console improvements

### DIFF
--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -152,7 +152,6 @@ class ShellOutputScintilla(QsciScintilla):
         self.setMarginWidth(0, 0)
         self.setMarginWidth(1, 0)
         self.setMarginWidth(2, 0)
-        # fm = QFontMetrics(font)
         self.setMarginsFont(font)
         self.setMarginWidth(1, "00000")
         self.setMarginLineNumbers(1, True)


### PR DESCRIPTION
## Description

How many times per week are you finding yourself swearing at the console after a failed copy to or pasting from clipboard after selecting all text via the ctrl+a shortcut? Swear no more.

This PR fixes _a bunch of_ issues with the console input area by moving the >>> prompt characters _into the margin_ instead of appending it into the text input area. This simplifies the code a lot and makes a bunch of keyboard shortcuts behave as you'd expect (hitting the home key, copy/pasting, etc.)

I've also taken the time to transform the help button into a help menu that provides shortcuts to the python console documentation, the pyqgis API, and the pyqgis cookbook.

PR selfie:
![image](https://user-images.githubusercontent.com/1728657/83593325-aa532d80-a586-11ea-9034-926c3303f546.png)
