### PR TITLE
Add processing algorithms to export a print layout as PDF/image

### DIFF
--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -88,6 +88,8 @@ SET(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmjoinbynearest.cpp
   processing/qgsalgorithmjoinwithlines.cpp
   processing/qgsalgorithmkmeansclustering.cpp
+  processing/qgsalgorithmlayouttoimage.cpp
+  processing/qgsalgorithmlayouttopdf.cpp
   processing/qgsalgorithmlinedensity.cpp
   processing/qgsalgorithmlineintersection.cpp
   processing/qgsalgorithmlinesubstring.cpp
@@ -409,6 +411,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core/labeling
   ${CMAKE_SOURCE_DIR}/src/core/processing
   ${CMAKE_SOURCE_DIR}/src/core/raster
+  ${CMAKE_SOURCE_DIR}/src/core/layout
   ${CMAKE_SOURCE_DIR}/src/core/mesh
   ${CMAKE_SOURCE_DIR}/src/core/providers/meshmemory
   ${CMAKE_SOURCE_DIR}/src/core/symbology

--- a/src/analysis/processing/qgsalgorithmlayouttoimage.cpp
+++ b/src/analysis/processing/qgsalgorithmlayouttoimage.cpp
@@ -1,0 +1,168 @@
+/***************************************************************************
+                         qgsalgorithmlayouttoimage.cpp
+                         ---------------------
+    begin                : June 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmlayouttoimage.h"
+#include "qgslayout.h"
+#include "qgsprintlayout.h"
+#include "qgsprocessingoutputs.h"
+#include "qgslayoutexporter.h"
+#include <QImageWriter>
+
+///@cond PRIVATE
+
+QString QgsLayoutToImageAlgorithm::name() const
+{
+  return QStringLiteral( "printlayouttoimage" );
+}
+
+QString QgsLayoutToImageAlgorithm::displayName() const
+{
+  return QObject::tr( "Export print layout as image" );
+}
+
+QStringList QgsLayoutToImageAlgorithm::tags() const
+{
+  return QObject::tr( "layout,composer,composition,save,png,jpeg,jpg" ).split( ',' );
+}
+
+QString QgsLayoutToImageAlgorithm::group() const
+{
+  return QObject::tr( "Cartography" );
+}
+
+QString QgsLayoutToImageAlgorithm::groupId() const
+{
+  return QStringLiteral( "cartography" );
+}
+
+QString QgsLayoutToImageAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Exports a print layout as an image." );
+}
+
+QString QgsLayoutToImageAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm outputs a print layout as an image file (e.g. PNG or JPEG images)." );
+}
+
+void QgsLayoutToImageAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterLayout( QStringLiteral( "LAYOUT" ), QObject::tr( "Print layout" ) ) );
+
+  std::unique_ptr< QgsProcessingParameterNumber > dpiParam = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "DPI" ), QObject::tr( "DPI (leave blank for default layout DPI)" ), QgsProcessingParameterNumber::Double, QVariant(), true, 0 );
+  dpiParam->setFlags( dpiParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( dpiParam.release() );
+
+  std::unique_ptr< QgsProcessingParameterBoolean > appendGeorefParam = qgis::make_unique< QgsProcessingParameterBoolean >( QStringLiteral( "GEOREFERENCE" ), QObject::tr( "Generate world file" ), true );
+  appendGeorefParam->setFlags( appendGeorefParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( appendGeorefParam.release() );
+
+  std::unique_ptr< QgsProcessingParameterBoolean > exportRDFParam = qgis::make_unique< QgsProcessingParameterBoolean >( QStringLiteral( "INCLUDE_METADATA" ), QObject::tr( "Export RDF metadata (title, author, etc.)" ), true );
+  exportRDFParam->setFlags( exportRDFParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( exportRDFParam.release() );
+
+  std::unique_ptr< QgsProcessingParameterBoolean > antialias = qgis::make_unique< QgsProcessingParameterBoolean >( QStringLiteral( "ANTIALIAS" ), QObject::tr( "Enable antialiasing" ), true );
+  antialias->setFlags( antialias->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( antialias.release() );
+
+  QStringList imageFilters;
+  const auto supportedImageFormats { QImageWriter::supportedImageFormats() };
+  for ( const QByteArray &format : supportedImageFormats )
+  {
+    if ( format == "svg" )
+      continue;
+
+    QString longName = format.toUpper() + QObject::tr( " format" );
+    QString glob = "*." + format;
+
+    if ( format == "png" && !imageFilters.empty() )
+      imageFilters.insert( 0, QStringLiteral( "%1 (%2 %3)" ).arg( longName, glob.toLower(), glob.toUpper() ) );
+    else
+      imageFilters.append( QStringLiteral( "%1 (%2 %3)" ).arg( longName, glob.toLower(), glob.toUpper() ) );
+  }
+
+  addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Image file" ), imageFilters.join( QStringLiteral( ";;" ) ) ) );
+}
+
+QgsProcessingAlgorithm::Flags QgsLayoutToImageAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | FlagNoThreading;
+}
+
+QgsLayoutToImageAlgorithm *QgsLayoutToImageAlgorithm::createInstance() const
+{
+  return new QgsLayoutToImageAlgorithm();
+}
+
+QVariantMap QgsLayoutToImageAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  // this needs to be done in main thread, layouts are not thread safe
+  QgsPrintLayout *layout = parameterAsLayout( parameters, QStringLiteral( "LAYOUT" ), context );
+  if ( !layout )
+    throw QgsProcessingException( QObject::tr( "Cannot find layout with name \"%1\"" ).arg( parameters.value( QStringLiteral( "LAYOUT" ) ).toString() ) );
+
+  const QString dest = parameterAsFileOutput( parameters, QStringLiteral( "OUTPUT" ), context );
+
+  QgsLayoutExporter exporter( layout );
+  QgsLayoutExporter::ImageExportSettings settings;
+
+  if ( parameters.value( QStringLiteral( "DPI" ) ).isValid() )
+  {
+    settings.dpi = parameterAsDouble( parameters, QStringLiteral( "DPI" ), context );
+  }
+
+  settings.exportMetadata = parameterAsBool( parameters, QStringLiteral( "INCLUDE_METADATA" ), context );
+  settings.generateWorldFile = parameterAsBool( parameters, QStringLiteral( "GEOREFERENCE" ), context );
+
+  if ( parameterAsBool( parameters, QStringLiteral( "ANTIALIAS" ), context ) )
+    settings.flags = settings.flags | QgsLayoutRenderContext::FlagAntialiasing;
+  else
+    settings.flags = settings.flags & ~QgsLayoutRenderContext::FlagAntialiasing;
+
+  switch ( exporter.exportToImage( dest, settings ) )
+  {
+    case QgsLayoutExporter::Success:
+    {
+      feedback->pushInfo( QObject::tr( "Successfully exported layout to %1" ).arg( QDir::toNativeSeparators( dest ) ) );
+      break;
+    }
+
+    case QgsLayoutExporter::FileError:
+      throw QgsProcessingException( QObject::tr( "Cannot write to %1.\n\nThis file may be open in another application." ).arg( QDir::toNativeSeparators( dest ) ) );
+
+    case QgsLayoutExporter::MemoryError:
+      throw QgsProcessingException( QObject::tr( "Trying to create the image "
+                                    "resulted in a memory overflow.\n\n"
+                                    "Please try a lower resolution or a smaller paper size." ) );
+
+    case QgsLayoutExporter::SvgLayerError:
+    case QgsLayoutExporter::IteratorError:
+    case QgsLayoutExporter::Canceled:
+    case QgsLayoutExporter::PrintError:
+      // no meaning for imageexports, will not be encountered
+      break;
+  }
+
+  feedback->setProgress( 100 );
+
+  QVariantMap outputs;
+  outputs.insert( QStringLiteral( "OUTPUT" ), dest );
+  return outputs;
+}
+
+///@endcond
+

--- a/src/analysis/processing/qgsalgorithmlayouttoimage.h
+++ b/src/analysis/processing/qgsalgorithmlayouttoimage.h
@@ -1,0 +1,60 @@
+/***************************************************************************
+                         qgsalgorithmlayouttoimage.h
+                         ---------------------
+    begin                : June 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMLAYOUTTOIMAGE_H
+#define QGSALGORITHMLAYOUTTOIMAGE_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+
+///@cond PRIVATE
+
+/**
+ * Native export layout to image algorithm.
+ */
+class QgsLayoutToImageAlgorithm : public QgsProcessingAlgorithm
+{
+
+  public:
+
+    QgsLayoutToImageAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    Flags flags() const override;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortDescription() const override;
+    QString shortHelpString() const override;
+    QgsLayoutToImageAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMLAYOUTTOIMAGE_H
+
+

--- a/src/analysis/processing/qgsalgorithmlayouttopdf.cpp
+++ b/src/analysis/processing/qgsalgorithmlayouttopdf.cpp
@@ -88,7 +88,7 @@ void QgsLayoutToPdfAlgorithm::initAlgorithm( const QVariantMap & )
 
   QStringList textExportOptions
   {
-    QObject::tr( "Always Export Text as Paths (Recommended" ),
+    QObject::tr( "Always Export Text as Paths (Recommended)" ),
     QObject::tr( "Always Export Text as Text Objects" )
   };
 

--- a/src/analysis/processing/qgsalgorithmlayouttopdf.cpp
+++ b/src/analysis/processing/qgsalgorithmlayouttopdf.cpp
@@ -1,0 +1,175 @@
+/***************************************************************************
+                         qgsalgorithmlayouttopdf.cpp
+                         ---------------------
+    begin                : June 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmlayouttopdf.h"
+#include "qgslayout.h"
+#include "qgsprintlayout.h"
+#include "qgsprocessingoutputs.h"
+#include "qgslayoutexporter.h"
+
+///@cond PRIVATE
+
+QString QgsLayoutToPdfAlgorithm::name() const
+{
+  return QStringLiteral( "printlayouttopdf" );
+}
+
+QString QgsLayoutToPdfAlgorithm::displayName() const
+{
+  return QObject::tr( "Export print layout as PDF" );
+}
+
+QStringList QgsLayoutToPdfAlgorithm::tags() const
+{
+  return QObject::tr( "layout,composer,composition,save" ).split( ',' );
+}
+
+QString QgsLayoutToPdfAlgorithm::group() const
+{
+  return QObject::tr( "Cartography" );
+}
+
+QString QgsLayoutToPdfAlgorithm::groupId() const
+{
+  return QStringLiteral( "cartography" );
+}
+
+QString QgsLayoutToPdfAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Exports a print layout as a PDF." );
+}
+
+QString QgsLayoutToPdfAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm outputs a print layout as a PDF file." );
+}
+
+void QgsLayoutToPdfAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterLayout( QStringLiteral( "LAYOUT" ), QObject::tr( "Print layout" ) ) );
+
+  std::unique_ptr< QgsProcessingParameterNumber > dpiParam = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "DPI" ), QObject::tr( "DPI (leave blank for default layout DPI)" ), QgsProcessingParameterNumber::Double, QVariant(), true, 0 );
+  dpiParam->setFlags( dpiParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( dpiParam.release() );
+
+  std::unique_ptr< QgsProcessingParameterBoolean > forceVectorParam = qgis::make_unique< QgsProcessingParameterBoolean >( QStringLiteral( "FORCE_VECTOR" ), QObject::tr( "Always export as vectors" ), false );
+  forceVectorParam->setFlags( forceVectorParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( forceVectorParam.release() );
+
+  std::unique_ptr< QgsProcessingParameterBoolean > appendGeorefParam = qgis::make_unique< QgsProcessingParameterBoolean >( QStringLiteral( "GEOREFERENCE" ), QObject::tr( "Append georeference information" ), true );
+  appendGeorefParam->setFlags( appendGeorefParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( appendGeorefParam.release() );
+
+  std::unique_ptr< QgsProcessingParameterBoolean > exportRDFParam = qgis::make_unique< QgsProcessingParameterBoolean >( QStringLiteral( "INCLUDE_METADATA" ), QObject::tr( "Export RDF metadata (title, author, etc.)" ), true );
+  exportRDFParam->setFlags( exportRDFParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( exportRDFParam.release() );
+
+  std::unique_ptr< QgsProcessingParameterBoolean > disableTiled = qgis::make_unique< QgsProcessingParameterBoolean >( QStringLiteral( "DISABLE_TILED" ), QObject::tr( "Disable tiled raster layer exports" ), false );
+  disableTiled->setFlags( disableTiled->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( disableTiled.release() );
+
+  std::unique_ptr< QgsProcessingParameterBoolean > simplify = qgis::make_unique< QgsProcessingParameterBoolean >( QStringLiteral( "SIMPLIFY" ), QObject::tr( "Simplify geometries to reduce output file size" ), true );
+  simplify->setFlags( simplify->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( simplify.release() );
+
+  QStringList textExportOptions
+  {
+    QObject::tr( "Always Export Text as Paths (Recommended" ),
+    QObject::tr( "Always Export Text as Text Objects" )
+  };
+
+  std::unique_ptr< QgsProcessingParameterEnum > textFormat = qgis::make_unique< QgsProcessingParameterEnum >( QStringLiteral( "TEXT_FORMAT" ), QObject::tr( "Text export" ), textExportOptions, false, 0 );
+  textFormat->setFlags( textFormat->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( textFormat.release() );
+
+  addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "PDF file" ), QObject::tr( "PDF Format" ) + " (*.pdf *.PDF)" ) );
+}
+
+QgsProcessingAlgorithm::Flags QgsLayoutToPdfAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | FlagNoThreading;
+}
+
+QgsLayoutToPdfAlgorithm *QgsLayoutToPdfAlgorithm::createInstance() const
+{
+  return new QgsLayoutToPdfAlgorithm();
+}
+
+QVariantMap QgsLayoutToPdfAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  // this needs to be done in main thread, layouts are not thread safe
+  QgsPrintLayout *layout = parameterAsLayout( parameters, QStringLiteral( "LAYOUT" ), context );
+  if ( !layout )
+    throw QgsProcessingException( QObject::tr( "Cannot find layout with name \"%1\"" ).arg( parameters.value( QStringLiteral( "LAYOUT" ) ).toString() ) );
+
+  const QString dest = parameterAsFileOutput( parameters, QStringLiteral( "OUTPUT" ), context );
+
+  QgsLayoutExporter exporter( layout );
+  QgsLayoutExporter::PdfExportSettings settings;
+
+  if ( parameters.value( QStringLiteral( "DPI" ) ).isValid() )
+  {
+    settings.dpi = parameterAsDouble( parameters, QStringLiteral( "DPI" ), context );
+  }
+
+  settings.forceVectorOutput = parameterAsBool( parameters, QStringLiteral( "FORCE_VECTOR" ), context );
+  settings.appendGeoreference = parameterAsBool( parameters, QStringLiteral( "GEOREFERENCE" ), context );
+  settings.exportMetadata = parameterAsBool( parameters, QStringLiteral( "INCLUDE_METADATA" ), context );
+  settings.exportMetadata = parameterAsBool( parameters, QStringLiteral( "INCLUDE_METADATA" ), context );
+  settings.simplifyGeometries = parameterAsBool( parameters, QStringLiteral( "SIMPLIFY" ), context );
+  settings.textRenderFormat = parameterAsEnum( parameters, QStringLiteral( "TEXT_FORMAT" ), context ) == 0 ? QgsRenderContext::TextFormatAlwaysOutlines : QgsRenderContext::TextFormatAlwaysText;
+
+  if ( parameterAsBool( parameters, QStringLiteral( "DISABLE_TILED" ), context ) )
+    settings.flags = settings.flags | QgsLayoutRenderContext::FlagDisableTiledRasterLayerRenders;
+  else
+    settings.flags = settings.flags & ~QgsLayoutRenderContext::FlagDisableTiledRasterLayerRenders;
+
+  switch ( exporter.exportToPdf( dest, settings ) )
+  {
+    case QgsLayoutExporter::Success:
+    {
+      feedback->pushInfo( QObject::tr( "Successfully exported layout to %1" ).arg( QDir::toNativeSeparators( dest ) ) );
+      break;
+    }
+
+    case QgsLayoutExporter::FileError:
+      throw QgsProcessingException( QObject::tr( "Cannot write to %1.\n\nThis file may be open in another application." ).arg( QDir::toNativeSeparators( dest ) ) );
+
+    case QgsLayoutExporter::PrintError:
+      throw QgsProcessingException( QObject::tr( "Could not create print device." ) );
+
+    case QgsLayoutExporter::MemoryError:
+      throw QgsProcessingException( QObject::tr( "Exporting the PDF "
+                                    "resulted in a memory overflow.\n\n"
+                                    "Please try a lower resolution or a smaller paper size." ) );
+
+    case QgsLayoutExporter::SvgLayerError:
+    case QgsLayoutExporter::IteratorError:
+    case QgsLayoutExporter::Canceled:
+      // no meaning for PDF exports, will not be encountered
+      break;
+  }
+
+  feedback->setProgress( 100 );
+
+  QVariantMap outputs;
+  outputs.insert( QStringLiteral( "OUTPUT" ), dest );
+  return outputs;
+}
+
+///@endcond
+

--- a/src/analysis/processing/qgsalgorithmlayouttopdf.cpp
+++ b/src/analysis/processing/qgsalgorithmlayouttopdf.cpp
@@ -96,6 +96,10 @@ void QgsLayoutToPdfAlgorithm::initAlgorithm( const QVariantMap & )
   textFormat->setFlags( textFormat->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
   addParameter( textFormat.release() );
 
+  std::unique_ptr< QgsProcessingParameterBoolean > layeredExport = qgis::make_unique< QgsProcessingParameterBoolean >( QStringLiteral( "SEPARATE_LAYERS" ), QObject::tr( "Export layers as separate PDF files" ), false );
+  layeredExport->setFlags( layeredExport->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( layeredExport.release() );
+
   addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "PDF file" ), QObject::tr( "PDF Format" ) + " (*.pdf *.PDF)" ) );
 }
 
@@ -132,6 +136,7 @@ QVariantMap QgsLayoutToPdfAlgorithm::processAlgorithm( const QVariantMap &parame
   settings.exportMetadata = parameterAsBool( parameters, QStringLiteral( "INCLUDE_METADATA" ), context );
   settings.simplifyGeometries = parameterAsBool( parameters, QStringLiteral( "SIMPLIFY" ), context );
   settings.textRenderFormat = parameterAsEnum( parameters, QStringLiteral( "TEXT_FORMAT" ), context ) == 0 ? QgsRenderContext::TextFormatAlwaysOutlines : QgsRenderContext::TextFormatAlwaysText;
+  settings.exportLayersAsSeperateFiles = parameterAsBool( parameters, QStringLiteral( "SEPARATE_LAYERS" ), context );
 
   if ( parameterAsBool( parameters, QStringLiteral( "DISABLE_TILED" ), context ) )
     settings.flags = settings.flags | QgsLayoutRenderContext::FlagDisableTiledRasterLayerRenders;

--- a/src/analysis/processing/qgsalgorithmlayouttopdf.h
+++ b/src/analysis/processing/qgsalgorithmlayouttopdf.h
@@ -1,0 +1,60 @@
+/***************************************************************************
+                         qgsalgorithmlayouttopdf.h
+                         ---------------------
+    begin                : June 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMLAYOUTTOPDF_H
+#define QGSALGORITHMLAYOUTTOPDF_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+
+///@cond PRIVATE
+
+/**
+ * Native export layout to PDF algorithm.
+ */
+class QgsLayoutToPdfAlgorithm : public QgsProcessingAlgorithm
+{
+
+  public:
+
+    QgsLayoutToPdfAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    Flags flags() const override;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortDescription() const override;
+    QString shortHelpString() const override;
+    QgsLayoutToPdfAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMLAYOUTTOPDF_H
+
+

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -84,6 +84,8 @@
 #include "qgsalgorithminterpolatepoint.h"
 #include "qgsalgorithmintersection.h"
 #include "qgsalgorithmkmeansclustering.h"
+#include "qgsalgorithmlayouttoimage.h"
+#include "qgsalgorithmlayouttopdf.h"
 #include "qgsalgorithmlinedensity.h"
 #include "qgsalgorithmlineintersection.h"
 #include "qgsalgorithmlinesubstring.h"
@@ -301,6 +303,8 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsKMeansClusteringAlgorithm() );
   addAlgorithm( new QgsLayerToBookmarksAlgorithm() );
   addAlgorithm( new QgsLayoutMapExtentToLayerAlgorithm() );
+  addAlgorithm( new QgsLayoutToImageAlgorithm() );
+  addAlgorithm( new QgsLayoutToPdfAlgorithm() );
   addAlgorithm( new QgsLineDensityAlgorithm() );
   addAlgorithm( new QgsLineIntersectionAlgorithm() );
   addAlgorithm( new QgsLineSubstringAlgorithm() );

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -2510,13 +2510,21 @@ QWidget *QgsProcessingLayoutWidgetWrapper::createWidget()
 
     case QgsProcessingGui::Modeler:
     {
-      mLineEdit = new QLineEdit();
-      mLineEdit->setToolTip( tr( "Name of an existing print layout" ) );
-      connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & )
+      mPlainComboBox = new QComboBox();
+      mPlainComboBox->setEditable( true );
+      mPlainComboBox->setToolTip( tr( "Name of an existing print layout" ) );
+      if ( widgetContext().project() )
+      {
+        const QList< QgsPrintLayout * > layouts = widgetContext().project()->layoutManager()->printLayouts();
+        for ( const QgsPrintLayout *layout : layouts )
+          mPlainComboBox->addItem( layout->name() );
+      }
+
+      connect( mPlainComboBox, &QComboBox::currentTextChanged, this, [ = ]( const QString & )
       {
         emit widgetValueHasChanged( this );
       } );
-      return mLineEdit;
+      return mPlainComboBox;
     }
   }
   return nullptr;
@@ -2536,10 +2544,10 @@ void QgsProcessingLayoutWidgetWrapper::setWidgetValue( const QVariant &value, Qg
         mComboBox->setCurrentLayout( nullptr );
     }
   }
-  else if ( mLineEdit )
+  else if ( mPlainComboBox )
   {
     const QString v = QgsProcessingParameters::parameterAsString( parameterDefinition(), value, context );
-    mLineEdit->setText( v );
+    mPlainComboBox->setCurrentText( v );
   }
 }
 
@@ -2550,10 +2558,21 @@ QVariant QgsProcessingLayoutWidgetWrapper::widgetValue() const
     const QgsMasterLayoutInterface *l = mComboBox->currentLayout();
     return l ? l->name() : QVariant();
   }
-  else if ( mLineEdit )
-    return mLineEdit->text().isEmpty() ? QVariant() : mLineEdit->text();
+  else if ( mPlainComboBox )
+    return mPlainComboBox->currentText().isEmpty() ? QVariant() : mPlainComboBox->currentText();
   else
     return QVariant();
+}
+
+void QgsProcessingLayoutWidgetWrapper::setWidgetContext( const QgsProcessingParameterWidgetContext &context )
+{
+  QgsAbstractProcessingParameterWidgetWrapper::setWidgetContext( context );
+  if ( mPlainComboBox && context.project() )
+  {
+    const QList< QgsPrintLayout * > layouts = widgetContext().project()->layoutManager()->printLayouts();
+    for ( const QgsPrintLayout *layout : layouts )
+      mPlainComboBox->addItem( layout->name() );
+  }
 }
 
 QStringList QgsProcessingLayoutWidgetWrapper::compatibleParameterTypes() const

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -825,6 +825,7 @@ class GUI_EXPORT QgsProcessingLayoutWidgetWrapper : public QgsAbstractProcessing
 
     void setWidgetValue( const QVariant &value, QgsProcessingContext &context ) override;
     QVariant widgetValue() const override;
+    void setWidgetContext( const QgsProcessingParameterWidgetContext &context ) override;
 
     QStringList compatibleParameterTypes() const override;
 
@@ -834,7 +835,7 @@ class GUI_EXPORT QgsProcessingLayoutWidgetWrapper : public QgsAbstractProcessing
   private:
 
     QgsLayoutComboBox *mComboBox = nullptr;
-    QLineEdit *mLineEdit = nullptr;
+    QComboBox *mPlainComboBox = nullptr;
 
     friend class TestProcessingGui;
 };

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -4139,7 +4139,7 @@ void TestProcessingGui::testLayoutWrapper()
     }
     else
     {
-      QCOMPARE( static_cast< QLineEdit * >( wrapper.wrappedWidget() )->text(), QStringLiteral( "l2" ) );
+      QCOMPARE( static_cast< QComboBox * >( wrapper.wrappedWidget() )->currentText(), QStringLiteral( "l2" ) );
     }
     wrapper.setWidgetValue( "l1", context );
     QCOMPARE( spy.count(), 2 );
@@ -4151,7 +4151,7 @@ void TestProcessingGui::testLayoutWrapper()
     }
     else
     {
-      QCOMPARE( static_cast< QLineEdit * >( wrapper.wrappedWidget() )->text(), QStringLiteral( "l1" ) );
+      QCOMPARE( static_cast< QComboBox * >( wrapper.wrappedWidget() )->currentText(), QStringLiteral( "l1" ) );
     }
 
     QLabel *l = wrapper.createWrappedLabel();
@@ -4174,7 +4174,7 @@ void TestProcessingGui::testLayoutWrapper()
     }
     else
     {
-      static_cast< QLineEdit * >( wrapper.wrappedWidget() )->setText( QStringLiteral( "aaaa" ) );
+      static_cast< QComboBox * >( wrapper.wrappedWidget() )->setCurrentText( QStringLiteral( "aaaa" ) );
     }
     QCOMPARE( spy.count(), 3 );
 
@@ -4199,7 +4199,7 @@ void TestProcessingGui::testLayoutWrapper()
     }
     else
     {
-      QCOMPARE( static_cast< QLineEdit * >( wrapper2.wrappedWidget() )->text(), QStringLiteral( "l2" ) );
+      QCOMPARE( static_cast< QComboBox * >( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "l2" ) );
     }
     wrapper2.setWidgetValue( "l1", context );
     QCOMPARE( spy2.count(), 2 );
@@ -4211,7 +4211,7 @@ void TestProcessingGui::testLayoutWrapper()
     }
     else
     {
-      QCOMPARE( static_cast< QLineEdit * >( wrapper2.wrappedWidget() )->text(), QStringLiteral( "l1" ) );
+      QCOMPARE( static_cast< QComboBox * >( wrapper2.wrappedWidget() )->currentText(), QStringLiteral( "l1" ) );
     }
     wrapper2.setWidgetValue( QVariant(), context );
     QCOMPARE( spy2.count(), 3 );
@@ -4223,14 +4223,14 @@ void TestProcessingGui::testLayoutWrapper()
     }
     else
     {
-      QVERIFY( static_cast< QLineEdit * >( wrapper2.wrappedWidget() )->text().isEmpty() );
+      QVERIFY( static_cast< QComboBox * >( wrapper2.wrappedWidget() )->currentText().isEmpty() );
     }
 
     // check signal
     if ( type != QgsProcessingGui::Modeler )
       static_cast< QComboBox * >( wrapper2.wrappedWidget() )->setCurrentIndex( 2 );
     else
-      static_cast< QLineEdit * >( wrapper2.wrappedWidget() )->setText( QStringLiteral( "aaa" ) );
+      static_cast< QComboBox * >( wrapper2.wrappedWidget() )->setCurrentText( QStringLiteral( "aaa" ) );
     QCOMPARE( spy2.count(), 4 );
 
     delete w;


### PR DESCRIPTION
This allows for models which export print layouts from the current project. One
use case for this is allowing users to create an in-project model which exports
a particular set of layouts from the project to certain folders, so that they
can easily re-export the current project in a single operation instead of
having to manually open multiple layouts and export one-by-one.

Additionally, with the new capabilities to have expression based output files
inside models, you can automatically export the layouts to a folder with
the current date tag and include this in the exported file names!