### PR TITLE
Add modeler algorithm to set a project expression variable

### DIFF
--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -148,6 +148,7 @@ SET(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmserviceareafrompoint.cpp
   processing/qgsalgorithmsetlayerencoding.cpp
   processing/qgsalgorithmsetmvalue.cpp
+  processing/qgsalgorithmsetvariable.cpp
   processing/qgsalgorithmsetzvalue.cpp
   processing/qgsalgorithmshortestpathlayertopoint.cpp
   processing/qgsalgorithmshortestpathpointtolayer.cpp

--- a/src/analysis/processing/qgsalgorithmsetvariable.cpp
+++ b/src/analysis/processing/qgsalgorithmsetvariable.cpp
@@ -1,0 +1,94 @@
+/***************************************************************************
+                         qgsalgorithmsetvariable.cpp
+                         ---------------------
+    begin                : June 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmsetvariable.h"
+#include "qgsexpressioncontextutils.h"
+
+///@cond PRIVATE
+
+QString QgsSetProjectVariableAlgorithm::name() const
+{
+  return QStringLiteral( "setprojectvariable" );
+}
+
+QgsProcessingAlgorithm::Flags QgsSetProjectVariableAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::FlagHideFromToolbox | QgsProcessingAlgorithm::FlagSkipGenericModelLogging;
+}
+
+QString QgsSetProjectVariableAlgorithm::displayName() const
+{
+  return QObject::tr( "Set project variable" );
+}
+
+QStringList QgsSetProjectVariableAlgorithm::tags() const
+{
+  return QObject::tr( "expression" ).split( ',' );
+}
+
+QString QgsSetProjectVariableAlgorithm::group() const
+{
+  return QObject::tr( "Modeler tools" );
+}
+
+QString QgsSetProjectVariableAlgorithm::groupId() const
+{
+  return QStringLiteral( "modelertools" );
+}
+
+QString QgsSetProjectVariableAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Sets an expression variable for the current project" );
+}
+
+QString QgsSetProjectVariableAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm sets an expression variable for the current project." );
+}
+
+QgsSetProjectVariableAlgorithm *QgsSetProjectVariableAlgorithm::createInstance() const
+{
+  return new QgsSetProjectVariableAlgorithm();
+}
+
+bool QgsSetProjectVariableAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  // this is all nice and quick, we can (and should) do it in the main thread without issue
+  const QString name = parameterAsString( parameters, QStringLiteral( "NAME" ), context );
+  const QString value = parameterAsString( parameters, QStringLiteral( "VALUE" ), context );
+
+  if ( name.isEmpty() )
+    throw QgsProcessingException( QObject::tr( "Variable name cannot be empty" ) );
+
+  QgsExpressionContextUtils::setProjectVariable( context.project(), name, value );
+  feedback->pushInfo( QObject::tr( "Set variable \'%1\' to \'%2\'" ).arg( name, value ) );
+
+  return true;
+}
+
+void QgsSetProjectVariableAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "NAME" ), QObject::tr( "Variable name" ) ) );
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "VALUE" ), QObject::tr( "Variable value" ) ) );
+}
+
+QVariantMap QgsSetProjectVariableAlgorithm::processAlgorithm( const QVariantMap &, QgsProcessingContext &, QgsProcessingFeedback * )
+{
+  return QVariantMap();
+}
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmsetvariable.h
+++ b/src/analysis/processing/qgsalgorithmsetvariable.h
@@ -1,0 +1,56 @@
+/***************************************************************************
+                         qgsalgorithmsetvariable.h
+                         ---------------------
+    begin                : June 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMSETVARIABLE_H
+#define QGSALGORITHMSETVARIABLE_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+
+///@cond PRIVATE
+
+/**
+ * Native rename layer algorithm.
+ */
+class QgsSetProjectVariableAlgorithm : public QgsProcessingAlgorithm
+{
+  public:
+    QgsSetProjectVariableAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    Flags flags() const override;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QgsSetProjectVariableAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback * ) override;
+
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMSETVARIABLE_H

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -143,6 +143,7 @@
 #include "qgsalgorithmserviceareafrompoint.h"
 #include "qgsalgorithmsetlayerencoding.h"
 #include "qgsalgorithmsetmvalue.h"
+#include "qgsalgorithmsetvariable.h"
 #include "qgsalgorithmsetzvalue.h"
 #include "qgsalgorithmshortestpathlayertopoint.h"
 #include "qgsalgorithmshortestpathpointtolayer.h"
@@ -373,6 +374,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsServiceAreaFromPointAlgorithm() );
   addAlgorithm( new QgsSetLayerEncodingAlgorithm() );
   addAlgorithm( new QgsSetMValueAlgorithm() );
+  addAlgorithm( new QgsSetProjectVariableAlgorithm() );
   addAlgorithm( new QgsSetZValueAlgorithm() );
   addAlgorithm( new QgsShapefileEncodingInfoAlgorithm() );
   addAlgorithm( new QgsShortestPathLayerToPointAlgorithm() );


### PR DESCRIPTION
Allows a model to set Project-level expression variables during execution. Especially
useful with the new Export Print Layout algorithms from #36916  to allow models which dynamically set variables used in a layout prior to export.

Ported from https://gis.stackexchange.com/questions/359386/is-there-a-way-to-edit-project-variables-with-modeller-in-qgis/363208#363208
