### PR TITLE
[python console] Improve key up/down press for multiline command string

### DIFF
--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -94,6 +94,7 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
         self.setMarginsFont(font)
         self.setMarginWidth(1, "00000")
         self.setMarginType(1, 5)
+        self.setCaretLineVisible(False)
 
         self.buffer = []
 
@@ -179,8 +180,7 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
                                                                        QColor(self.MATCHED_BRACE_BACKGROUND_COLOR))))
         self.setMatchedBraceForegroundColor(QColor(self.settings.value("pythonConsole/matchedBraceForegroundColor",
                                                                        QColor(self.MATCHED_BRACE_FOREGROUND_COLOR))))
-        self.setMarginsBackgroundColor(
-            QColor(self.settings.value("pythonConsole/marginBackgroundColor", QColor(self.MARGIN_BACKGROUND_COLOR))))
+        self.setMarginsBackgroundColor(QColor(self.settings.value("pythonConsole/paperBackgroundColor", QColor(self.BACKGROUND_COLOR))))
 
         # Sets minimum height for input area based of font metric
         self._setMinimumHeight()
@@ -314,6 +314,7 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
         self.setCursorPosition(0, 0)
         self.ensureCursorVisible()
         self.ensureLineVisible(0)
+        self.displayPrompt(False)
 
     def move_cursor_to_end(self):
         """Move cursor to end of text"""
@@ -321,6 +322,7 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
         self.setCursorPosition(line, index)
         self.ensureCursorVisible()
         self.ensureLineVisible(line)
+        self.displayPrompt(False)
 
     def is_cursor_on_last_line(self):
         """Return True if cursor is on the last line"""

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -299,10 +299,21 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
         line = self.lines() - 1
         return line, len(self.text(line))
 
+    def is_cursor_at_start(self):
+        """Return True if cursor is at the end of text"""
+        cline, cindex = self.getCursorPosition()
+        return cline == 0 and cindex == 0
+
     def is_cursor_at_end(self):
         """Return True if cursor is at the end of text"""
         cline, cindex = self.getCursorPosition()
         return (cline, cindex) == self.get_end_pos()
+
+    def move_cursor_to_start(self):
+        """Move cursor to start of text"""
+        self.setCursorPosition(0, 0)
+        self.ensureCursorVisible()
+        self.ensureLineVisible(0)
 
     def move_cursor_to_end(self):
         """Move cursor to end of text"""
@@ -405,7 +416,7 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
                 self.setText("")
             else:
                 self.setText(self.history[self.historyIndex])
-            self.move_cursor_to_end()
+            self.move_cursor_to_start()
             # self.SendScintilla(QsciScintilla.SCI_DELETEBACK)
 
     def keyPressEvent(self, e):
@@ -458,9 +469,17 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
             e.accept()
 
         elif e.key() == Qt.Key_Down and not self.isListActive():
-            self.showPrevious()
+            if self.is_cursor_at_end():
+                self.showPrevious()
+            else:
+                QsciScintilla.keyPressEvent(self, e)
+
         elif e.key() == Qt.Key_Up and not self.isListActive():
-            self.showNext()
+            if self.is_cursor_at_start():
+                self.showNext()
+            else:
+                QsciScintilla.keyPressEvent(self, e)
+
         # TODO: press event for auto-completion file directory
         else:
             t = e.text()


### PR DESCRIPTION
## Description

Another console behavior that drives most crazy: pressing up or down on a long, multiline string overwrites that string with the previous/next entry in the commands history.

The PR fixes this broken UX by using the following logic:

- if you are pressing key up, it'll *only* jump to previous command if your cursor's location is at the very beginning of the line, otherwise it'll allow navigating through the string (which eventually gets you to the beginning of the line, upon which you'd then go to previous command)

- if you are pressing key down, same improved behavior applies, except it's when the cursor is at the very end of the string.