### PR TITLE
Limit scope of Ctrl+C shortcut 

### DIFF
--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -171,6 +171,7 @@ class ShellOutputScintilla(QsciScintilla):
         self.copyShortcut.setContext(Qt.WidgetWithChildrenShortcut)
         self.copyShortcut.activated.connect(self.copy)
         self.selectAllShortcut = QShortcut(QKeySequence.SelectAll, self)
+        self.selectAllShortcut.setContext(Qt.WidgetWithChildrenShortcut)
         self.selectAllShortcut.activated.connect(self.selectAll)
 
     def insertInitText(self):

--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -168,6 +168,7 @@ class ShellOutputScintilla(QsciScintilla):
         self.runScut.activated.connect(self.enteredSelected)
         # Reimplemented copy action to prevent paste prompt (>>>,...) in command view
         self.copyShortcut = QShortcut(QKeySequence.Copy, self)
+        self.copyShortcut.setContext(Qt.WidgetWithChildrenShortcut)
         self.copyShortcut.activated.connect(self.copy)
         self.selectAllShortcut = QShortcut(QKeySequence.SelectAll, self)
         self.selectAllShortcut.activated.connect(self.selectAll)

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2816,10 +2816,14 @@ void QgisApp::createActions()
 
   connect( mActionDiagramProperties, &QAction::triggered, this, &QgisApp::diagramProperties );
 
-  // we can't set the shortcut on the copy action, because we need to restrict it's context to the canvas and it's children..
+  // we can't set the shortcut these actions, because we need to restrict their context to the canvas and it's children..
   QShortcut *copyShortcut = new QShortcut( QKeySequence::Copy, mMapCanvas );
   copyShortcut->setContext( Qt::WidgetWithChildrenShortcut );
   connect( copyShortcut, &QShortcut::activated, this, [ = ] { copySelectionToClipboard(); } );
+
+  QShortcut *selectAllShortcut = new QShortcut( QKeySequence::SelectAll, mMapCanvas );
+  selectAllShortcut->setContext( Qt::WidgetWithChildrenShortcut );
+  connect( selectAllShortcut, &QShortcut::activated, this, &QgisApp::selectAll );
 
 #ifndef HAVE_POSTGRESQL
   delete mActionAddPgLayer;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2816,6 +2816,11 @@ void QgisApp::createActions()
 
   connect( mActionDiagramProperties, &QAction::triggered, this, &QgisApp::diagramProperties );
 
+  // we can't set the shortcut on the copy action, because we need to restrict it's context to the canvas and it's children..
+  QShortcut *copyShortcut = new QShortcut( QKeySequence::Copy, mMapCanvas );
+  copyShortcut->setContext( Qt::WidgetWithChildrenShortcut );
+  connect( copyShortcut, &QShortcut::activated, this, [ = ] { copySelectionToClipboard(); } );
+
 #ifndef HAVE_POSTGRESQL
   delete mActionAddPgLayer;
   mActionAddPgLayer = 0;

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -894,9 +894,6 @@
    <property name="text">
     <string>Copy Features</string>
    </property>
-   <property name="shortcut">
-    <string>Ctrl+C</string>
-   </property>
   </action>
   <action name="mActionPasteFeatures">
    <property name="icon">

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1253,9 +1253,6 @@
    <property name="toolTip">
     <string>Select All Features</string>
    </property>
-   <property name="shortcut">
-    <string>Ctrl+A</string>
-   </property>
   </action>
   <action name="mActionInvertSelection">
    <property name="icon">


### PR DESCRIPTION
for copy features to canvas 
and for python console to console widget

Avoids ambiguous shortcut warnings/unexpected behavior when pressing Ctrl+C

Fixes #27035
Fixes #31918
Fixes #31914
Fixes #31392
