### PR TITLE
Add option to disable ssl verification in the Metasearch plugin

### DIFF
--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -97,7 +97,7 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
         self.startfrom = 0
         self.maxrecords = 10
         self.timeout = 10
-        self.disable_ssl = False
+        self.disable_ssl_verification = False
         self.constraints = []
 
         # Servers tab
@@ -448,9 +448,6 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
 
         # set timeout
         self.timeout = self.spnTimeout.value()
-
-        # ssl mode
-        self.disable_ssl = self.disableSSL.isChecked()
 
         # bbox
         # CRS is WGS84 with axis order longitude, latitude
@@ -831,10 +828,12 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
 
         identifier = get_item_data(item, 'identifier')
 
+        self.disable_ssl_verification = self.disableSSLVerification.isChecked()
+
         try:
             with OverrideCursor(Qt.WaitCursor):
                 auth = None
-                if self.disable_ssl:
+                if self.disable_ssl_verification:
                     auth = Authentication(verify=False)
                 cat = CatalogueServiceWeb(self.catalog_url, timeout=self.timeout,  # spellok
                                           username=self.catalog_username,
@@ -914,10 +913,12 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
     def _get_csw(self):
         """convenience function to init owslib.csw.CatalogueServiceWeb"""  # spellok
 
+        self.disable_ssl_verification = self.disableSSLVerification.isChecked()
+
         # connect to the server
         with OverrideCursor(Qt.WaitCursor):
             auth = None
-            if self.disable_ssl:
+            if self.disable_ssl_verification:
                 auth = Authentication(verify=False)
             try:
                 self.catalog = CatalogueServiceWeb(self.catalog_url,  # spellok

--- a/python/plugins/MetaSearch/ui/maindialog.ui
+++ b/python/plugins/MetaSearch/ui/maindialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>656</width>
+    <width>658</width>
     <height>550</height>
    </rect>
   </property>
@@ -488,20 +488,41 @@
        <item>
         <widget class="QGroupBox" name="groupBox_4">
          <property name="title">
-          <string>Server Timeout</string>
+          <string>Server</string>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="0" column="2">
            <widget class="QSpinBox" name="spnTimeout">
             <property name="value">
              <number>10</number>
             </property>
            </widget>
           </item>
-          <item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_11">
+            <property name="text">
+             <string>Disable SSL</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QCheckBox" name="disableSSL">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
            <widget class="QLabel" name="label_9">
             <property name="text">
              <string>seconds</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>Timeout</string>
             </property>
            </widget>
           </item>

--- a/python/plugins/MetaSearch/ui/maindialog.ui
+++ b/python/plugins/MetaSearch/ui/maindialog.ui
@@ -501,12 +501,12 @@
           <item row="1" column="0">
            <widget class="QLabel" name="label_11">
             <property name="text">
-             <string>Disable SSL</string>
+             <string>Disable SSL verification</string>
             </property>
            </widget>
           </item>
           <item row="1" column="2">
-           <widget class="QCheckBox" name="disableSSL">
+           <widget class="QCheckBox" name="disableSSLVerification">
             <property name="text">
              <string/>
             </property>


### PR DESCRIPTION
The latest owslib which is used by Metasearch plugin has an option to switch off ssl verification (see https://github.com/geopython/OWSLib/pull/685), this work expose that option to the Metasearch plugin user.

Fixes https://github.com/qgis/QGIS/issues/35476

Screenshot
![metasearch_ssl_fix](https://user-images.githubusercontent.com/2663775/83645448-2e270d00-a5bb-11ea-9a62-c047c80e7dce.gif)

cc @gubuntu
cc @tomkralidis