### PR TITLE
Adds José Assis (espinafre) to the contributor lists.

### DIFF
--- a/doc/CONTRIBUTORS
+++ b/doc/CONTRIBUTORS
@@ -49,6 +49,7 @@ James Shaeffer
 Jean-Denis Giguere
 Jeremy Palmer
 Jerrit Collord
+José de Paula R. N. Assis
 Luiz Motta
 Magnus Homann
 Marcel Dancak

--- a/resources/data/contributors.json
+++ b/resources/data/contributors.json
@@ -958,6 +958,23 @@
           -6.784386
         ]
       }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "José de Paula R. N. Assis",
+        "Committer": "No",
+        "First Commit Message": " Fixes empty tracebacks for user Python code",
+        "First Commit Date": "09-02-2020",
+        "GIT Nickname": "espinafre"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -47.94110,
+          -15.814729
+        ]
+      }
     }
   ]
 }

--- a/resources/data/contributors.json
+++ b/resources/data/contributors.json
@@ -964,7 +964,7 @@
       "properties": {
         "Name": "José de Paula R. N. Assis",
         "Committer": "No",
-        "First Commit Message": " Fixes empty tracebacks for user Python code",
+        "First Commit Message": "Fixes empty tracebacks for user Python code",
         "First Commit Date": "09-02-2020",
         "GIT Nickname": "espinafre"
       },


### PR DESCRIPTION
Adding José de Paula Rodrigues Neto Assis to the list of contributors, for work on: improving Python traceback reporting, improving handling of bigint datatype and adding support for generated columns on the PostgreSQL provider, and small fixes like allowing to drop MATERIALIZED views on the PostgreSQL provider and making the DB Manager understand CONSTRAINT TRIGGER.