### PR TITLE
set time step when first loading meshlayer

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshdataprovidertemporalcapabilities.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovidertemporalcapabilities.sip.in
@@ -103,6 +103,13 @@ Returns the relative time in milliseconds of the dataset
 Clears alls stored reference times and dataset times
 %End
 
+    qint64 firstTimeStepDuration( int group ) const;
+%Docstring
+Returns the duration of the first time step of the dataset group with index ``group``
+
+The value is -1 if the dataset group is not present or if it contains only one dataset (non temporal dataset)
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -409,6 +409,13 @@ Reset the dataset group tree item to default from provider
 .. versionadded:: 3.14
 %End
 
+    QgsInterval firstValidTimeStep() const;
+%Docstring
+Return the first valid time step of the dataset groups, invalid QgInterval if no time step is present
+
+.. versionadded:: 3.14
+%End
+
   public slots:
 
     virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext );

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -411,7 +411,7 @@ Reset the dataset group tree item to default from provider
 
     QgsInterval firstValidTimeStep() const;
 %Docstring
-Return the first valid time step of the dataset groups, invalid QgInterval if no time step is present
+Returns the first valid time step of the dataset groups, invalid QgInterval if no time step is present
 
 .. versionadded:: 3.14
 %End

--- a/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.cpp
+++ b/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.cpp
@@ -174,3 +174,15 @@ void QgsMeshDataProviderTemporalCapabilities::clear()
   mGroupsReferenceDateTime.clear();
   mDatasetTimeSinceGroupReference.clear();
 }
+
+qint64 QgsMeshDataProviderTemporalCapabilities::firstTimeStepDuration( int group ) const
+{
+  qint64 ret = -1;
+  if ( mDatasetTimeSinceGroupReference.contains( group ) )
+  {
+    const QList<qint64> times = mDatasetTimeSinceGroupReference[group];
+    if ( times.count() > 1 )
+      ret = times.at( 1 ) - times.at( 0 );
+  }
+  return ret;
+}

--- a/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.h
+++ b/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.h
@@ -133,6 +133,13 @@ class CORE_EXPORT QgsMeshDataProviderTemporalCapabilities: public QgsDataProvide
     */
     void clear();
 
+    /**
+    * Returns the duration of the first time step of the dataset group with index \a group
+    *
+    * The value is -1 if the dataset group is not present or if it contains only one dataset (non temporal dataset)
+    */
+    qint64 firstTimeStepDuration( int group ) const;
+
   private:
 
     //! Holds the global reference date/time value if exists (min of all groups), otherwise it is invalid

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -736,6 +736,21 @@ void QgsMeshLayer::resetDatasetGroupTreeItem()
   updateActiveDatasetGroups();
 }
 
+QgsInterval QgsMeshLayer::firstValidTimeStep() const
+{
+  if ( !mDataProvider )
+    return QgsInterval();
+  int groupCount = mDataProvider->datasetGroupCount();
+  for ( int i = 0; i < groupCount; ++i )
+  {
+    qint64 timeStep = mDataProvider->temporalCapabilities()->firstTimeStepDuration( i );
+    if ( timeStep > 0 )
+      return QgsInterval( timeStep, QgsUnitTypes::TemporalMilliseconds );
+  }
+
+  return QgsInterval();
+}
+
 void QgsMeshLayer::updateActiveDatasetGroups()
 {
   if ( !mDatasetGroupTreeRootItem )

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -21,6 +21,7 @@
 #include <memory>
 
 #include "qgis_core.h"
+#include "qgsinterval.h"
 #include "qgsmaplayer.h"
 #include "qgsmeshdataprovider.h"
 #include "qgsmeshrenderersettings.h"
@@ -453,6 +454,13 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
      * \since QGIS 3.14
      */
     void resetDatasetGroupTreeItem();
+
+    /**
+     * Return the first valid time step of the dataset groups, invalid QgInterval if no time step is present
+     *
+     * \since QGIS 3.14
+     */
+    QgsInterval firstValidTimeStep() const;
 
   public slots:
 

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -456,7 +456,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     void resetDatasetGroupTreeItem();
 
     /**
-     * Return the first valid time step of the dataset groups, invalid QgInterval if no time step is present
+     * Returns the first valid time step of the dataset groups, invalid QgInterval if no time step is present
      *
      * \since QGIS 3.14
      */

--- a/src/gui/qgstemporalcontrollerwidget.h
+++ b/src/gui/qgstemporalcontrollerwidget.h
@@ -89,6 +89,9 @@ class GUI_EXPORT QgsTemporalControllerWidget : public QgsPanelWidget, private Ui
     std::unique_ptr< QMenu > mRangeLayersSubMenu;
     QgsMapLayerModel *mMapLayerModel = nullptr;
 
+    void firstTemporalLayerLoaded( QgsMapLayer *layer );
+    void setTimeStep( const QgsInterval &timeStep );
+
   private slots:
 
     /**


### PR DESCRIPTION
Before the new temporal framework, when loading a mesh layer the user could navigate through time with a time step adapted to the dataset, which often has a constant time step.
Now with the new temporal framework, the default time step is 1 hour, that is very often not adapted to mesh dataset. So user can be confused when loading a mesh layer and navigating with the temporal controller. Furthermore, the user has to find a way to know the time step to set the temporal controller (the more straightforward way is to open mesh layer properties and look at the time related with dataset through the static dataset options...)
So this default time step independent from the mesh layer can be seen as a regression for mesh layer.
To fix that, this PR set the time step equal to the first time step of the mesh layer when this mesh layer is the first temporal layer loaded.