### PR TITLE
warn if there is no style associated with a rule (fix #23048)

### DIFF
--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -13,7 +13,6 @@
  *                                                                         *
  ***************************************************************************/
 #include <QClipboard>
-#include <QMessageBox>
 
 #include "qgsapplayertreeviewmenuprovider.h"
 
@@ -43,6 +42,7 @@
 #include "qgsmaplayerstylecategoriesmodel.h"
 #include "qgssymbollayerutils.h"
 #include "qgsxmlutils.h"
+#include "qgsmessagebar.h"
 
 
 QgsAppLayerTreeViewMenuProvider::QgsAppLayerTreeViewMenuProvider( QgsLayerTreeView *view, QgsMapCanvas *canvas )
@@ -897,7 +897,7 @@ void QgsAppLayerTreeViewMenuProvider::editSymbolLegendNodeSymbol( const QString 
   const QgsSymbol *originalSymbol = node->symbol();
   if ( !originalSymbol )
   {
-    QMessageBox::information( nullptr, tr( "No Symbol" ), tr( "There is no symbol associated with the rule." ) );
+    QgisApp::instance()->messageBar()->pushWarning( tr( "No Symbol" ), tr( "There is no symbol associated with the rule." ) );
     return;
   }
 

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 #include <QClipboard>
+#include <QMessageBox>
 
 #include "qgsapplayertreeviewmenuprovider.h"
 
@@ -44,13 +45,11 @@
 #include "qgsxmlutils.h"
 
 
-
 QgsAppLayerTreeViewMenuProvider::QgsAppLayerTreeViewMenuProvider( QgsLayerTreeView *view, QgsMapCanvas *canvas )
   : mView( view )
   , mCanvas( canvas )
 {
 }
-
 
 QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 {
@@ -897,7 +896,10 @@ void QgsAppLayerTreeViewMenuProvider::editSymbolLegendNodeSymbol( const QString 
 
   const QgsSymbol *originalSymbol = node->symbol();
   if ( !originalSymbol )
+  {
+    QMessageBox::information( nullptr, tr( "No Symbol" ), tr( "There is no symbol associated with the rule." ) );
     return;
+  }
 
   std::unique_ptr< QgsSymbol > symbol( originalSymbol->clone() );
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( node->layerNode()->layer() );


### PR DESCRIPTION
## Description
If layer styled with rule-based renderer and some rules have no symbol associated with them user still have "Edit Symbol" entry in the legend entry context menu. Clicking on "Edit Symbol" in this case does nothing (which is correct as there is no symbol) and can be confusing.

Proposed PR adds a popup message explaining that corresponding rule does not have any symbol associated with it. Fixes #23048.

Probably can be backported to 3.10.