### PR TITLE
Limit scope of Ctrl+{A,X,C,V} shortcut for attribue table 

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2821,6 +2821,14 @@ void QgisApp::createActions()
   copyShortcut->setContext( Qt::WidgetWithChildrenShortcut );
   connect( copyShortcut, &QShortcut::activated, this, [ = ] { copySelectionToClipboard(); } );
 
+  QShortcut *cutShortcut = new QShortcut( QKeySequence::Cut, mMapCanvas );
+  cutShortcut->setContext( Qt::WidgetWithChildrenShortcut );
+  connect( cutShortcut, &QShortcut::activated, this, [ = ] { cutSelectionToClipboard(); } );
+
+  QShortcut *pasteShortcut = new QShortcut( QKeySequence::Paste, mMapCanvas );
+  pasteShortcut->setContext( Qt::WidgetWithChildrenShortcut );
+  connect( pasteShortcut, &QShortcut::activated, this, [ = ] { pasteFromClipboard(); } );
+
   QShortcut *selectAllShortcut = new QShortcut( QKeySequence::SelectAll, mMapCanvas );
   selectAllShortcut->setContext( Qt::WidgetWithChildrenShortcut );
   connect( selectAllShortcut, &QShortcut::activated, this, &QgisApp::selectAll );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -114,6 +114,15 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   connect( mActionExpressionSelect, &QAction::triggered, this, &QgsAttributeTableDialog::mActionExpressionSelect_triggered );
   connect( mMainView, &QgsDualView::showContextMenuExternally, this, &QgsAttributeTableDialog::showContextMenu );
 
+  mActionSelectAll->setShortcuts( QKeySequence::SelectAll );
+  mActionSelectAll->setShortcutContext( Qt::WidgetWithChildrenShortcut );
+  mActionCopySelectedRows->setShortcuts( QKeySequence::Copy );
+  mActionCopySelectedRows->setShortcutContext( Qt::WidgetWithChildrenShortcut );
+  mActionCutSelectedRows->setShortcuts( QKeySequence::Cut );
+  mActionCutSelectedRows->setShortcutContext( Qt::WidgetWithChildrenShortcut );
+  mActionPasteFeatures->setShortcuts( QKeySequence::Paste );
+  mActionPasteFeatures->setShortcutContext( Qt::WidgetWithChildrenShortcut );
+
   const QgsFields fields = mLayer->fields();
   for ( const QgsField &field : fields )
   {
@@ -933,12 +942,8 @@ void QgsAttributeTableDialog::toggleDockMode( bool docked )
 
     // To prevent "QAction::event: Ambiguous shortcut overload"
     QgsDebugMsgLevel( QStringLiteral( "Remove shortcuts from attribute table already defined in main window" ), 2 );
-    mActionCopySelectedRows->setShortcut( QKeySequence() );
-    mActionPasteFeatures->setShortcut( QKeySequence() );
-    mActionCutSelectedRows->setShortcut( QKeySequence() );
     mActionZoomMapToSelectedRows->setShortcut( QKeySequence() );
     mActionRemoveSelection->setShortcut( QKeySequence() );
-    mActionSelectAll->setShortcut( QKeySequence() );
     // duplicated on Main Window, with different semantics
     mActionPanMapToSelectedRows->setShortcut( QKeySequence() );
     mActionSearchForm->setShortcut( QKeySequence() );
@@ -974,12 +979,8 @@ void QgsAttributeTableDialog::toggleDockMode( bool docked )
     // restore attribute table shortcuts in window mode
     QgsDebugMsgLevel( QStringLiteral( "Restore attribute table dialog shortcuts in window mode" ), 2 );
     // duplicated on Main Window
-    mActionCopySelectedRows->setShortcut( QKeySequence( QKeySequence::Copy ) );
-    mActionPasteFeatures->setShortcut( QKeySequence( QKeySequence::Paste ) );
-    mActionCutSelectedRows->setShortcut( QKeySequence( QKeySequence::Cut ) );
     mActionZoomMapToSelectedRows->setShortcut( QStringLiteral( "Ctrl+J" ) );
     mActionRemoveSelection->setShortcut( QStringLiteral( "Ctrl+Shift+A" ) );
-    mActionSelectAll->setShortcut( QStringLiteral( "Ctrl+A" ) );
     // duplicated on Main Window, with different semantics
     mActionPanMapToSelectedRows->setShortcut( QStringLiteral( "Ctrl+P" ) );
     mActionSearchForm->setShortcut( QStringLiteral( "Ctrl+F" ) );

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -882,9 +882,6 @@
    <property name="text">
     <string>Cut Features</string>
    </property>
-   <property name="shortcut">
-    <string>Ctrl+X</string>
-   </property>
   </action>
   <action name="mActionCopyFeatures">
    <property name="icon">
@@ -902,9 +899,6 @@
    </property>
    <property name="text">
     <string>Paste Features</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+V</string>
    </property>
   </action>
   <action name="mActionAddFeature">

--- a/src/ui/qgsattributetabledialog.ui
+++ b/src/ui/qgsattributetabledialog.ui
@@ -339,9 +339,6 @@
    <property name="toolTip">
     <string>Select all (Ctrl+A)</string>
    </property>
-   <property name="shortcut">
-    <string>Ctrl+A</string>
-   </property>
   </action>
   <action name="mActionInvertSelection">
    <property name="icon">
@@ -429,9 +426,6 @@
    <property name="toolTip">
     <string>Cut selected rows to clipboard (Ctrl+X)</string>
    </property>
-   <property name="shortcut">
-    <string>Ctrl+X</string>
-   </property>
   </action>
   <action name="mActionCopySelectedRows">
    <property name="icon">
@@ -444,9 +438,6 @@
    <property name="toolTip">
     <string>Copy selected rows to clipboard (Ctrl+C)</string>
    </property>
-   <property name="shortcut">
-    <string>Ctrl+C</string>
-   </property>
   </action>
   <action name="mActionPasteFeatures">
    <property name="icon">
@@ -458,9 +449,6 @@
    </property>
    <property name="toolTip">
     <string>Paste features from clipboard (Ctrl+V)</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+V</string>
    </property>
   </action>
   <action name="mActionRemoveAttribute">


### PR DESCRIPTION
## Description

@nyalldawson , following up on our discussion and your commits, this adds scope limits of ctrl+{a,x,c,v} keyboard shortcuts for the attribute table panel/dialog.