### PR TITLE
Fix capitalization/spacing in ArcGIS MapServer/FeatureServer strings

### DIFF
--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -401,7 +401,7 @@ bool QgsManageConnectionsDialog::populateConnections()
         if ( root.tagName() != QLatin1String( "qgsARCGISMAPSERVERConnections" ) )
         {
           QMessageBox::information( this, tr( "Loading Connections" ),
-                                    tr( "The file is not a ArcGIS MapServer connections exchange file." ) );
+                                    tr( "The file is not a ArcGIS Map Service connections exchange file." ) );
           return false;
         }
         break;
@@ -409,7 +409,7 @@ bool QgsManageConnectionsDialog::populateConnections()
         if ( root.tagName() != QLatin1String( "qgsARCGISFEATURESERVERConnections" ) )
         {
           QMessageBox::information( this, tr( "Loading Connections" ),
-                                    tr( "The file is not a ArcGIS FeatureServer connections exchange file." ) );
+                                    tr( "The file is not a ArcGIS Feature Service connections exchange file." ) );
           return false;
         }
         break;

--- a/src/providers/arcgisrest/qgsafsdataitemguiprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsdataitemguiprovider.cpp
@@ -96,7 +96,7 @@ void QgsAfsDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
 void QgsAfsDataItemGuiProvider::newConnection( QgsDataItem *item )
 {
   QgsNewHttpConnection nc( nullptr, QgsNewHttpConnection::ConnectionOther, QStringLiteral( "qgis/connections-arcgisfeatureserver/" ), QString(), QgsNewHttpConnection::FlagShowHttpSettings );
-  nc.setWindowTitle( tr( "Create a New ArcGIS Feature Server Connection" ) );
+  nc.setWindowTitle( tr( "Create a New ArcGIS Feature Service Connection" ) );
 
   if ( nc.exec() )
   {
@@ -107,7 +107,7 @@ void QgsAfsDataItemGuiProvider::newConnection( QgsDataItem *item )
 void QgsAfsDataItemGuiProvider::editConnection( QgsDataItem *item )
 {
   QgsNewHttpConnection nc( nullptr, QgsNewHttpConnection::ConnectionOther, QStringLiteral( "qgis/connections-arcgisfeatureserver/" ), item->name(), QgsNewHttpConnection::FlagShowHttpSettings );
-  nc.setWindowTitle( tr( "Modify ArcGIS Feature Server Connection" ) );
+  nc.setWindowTitle( tr( "Modify ArcGIS Feature Service Connection" ) );
 
   if ( nc.exec() )
   {

--- a/src/providers/arcgisrest/qgsafsdataitems.cpp
+++ b/src/providers/arcgisrest/qgsafsdataitems.cpp
@@ -309,7 +309,7 @@ QgsDataItem *QgsAfsDataItemProvider::createDataItem( const QString &path, QgsDat
 {
   if ( path.isEmpty() )
   {
-    return new QgsAfsRootItem( parentItem, QStringLiteral( "ArcGisFeatureServer" ), QStringLiteral( "arcgisfeatureserver:" ) );
+    return new QgsAfsRootItem( parentItem, QObject::tr( "ArcGIS Feature Service" ), QStringLiteral( "arcgisfeatureserver:" ) );
   }
 
   // path schema: afs:/connection name (used by OWS)

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -25,7 +25,7 @@
 #include "qgsapplication.h"
 
 const QString QgsAfsProvider::AFS_PROVIDER_KEY = QStringLiteral( "arcgisfeatureserver" );
-const QString QgsAfsProvider::AFS_PROVIDER_DESCRIPTION = QStringLiteral( "ArcGIS Feature Server data provider" );
+const QString QgsAfsProvider::AFS_PROVIDER_DESCRIPTION = QStringLiteral( "ArcGIS Feature Service data provider" );
 
 
 QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &options )

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -45,7 +45,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
 
     /* Inherited from QgsVectorDataProvider */
     QgsAbstractFeatureSource *featureSource() const override;
-    QString storageType() const override { return QStringLiteral( "ESRI ArcGIS Feature Server" ); }
+    QString storageType() const override { return QStringLiteral( "ArcGIS Feature Service" ); }
     QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() ) const override;
     QgsWkbTypes::Type wkbType() const override;
     long featureCount() const override;

--- a/src/providers/arcgisrest/qgsafsprovidergui.cpp
+++ b/src/providers/arcgisrest/qgsafsprovidergui.cpp
@@ -28,7 +28,7 @@ class QgsAfsSourceSelectProvider : public QgsSourceSelectProvider
   public:
 
     QString providerKey() const override { return QgsAfsProvider::AFS_PROVIDER_KEY; }
-    QString text() const override { return QObject::tr( "ArcGIS Feature Server" ); }
+    QString text() const override { return QObject::tr( "ArcGIS Feature Service" ); }
     int ordering() const override { return QgsSourceSelectProvider::OrderRemoteProvider + 150; }
     QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddAfsLayer.svg" ) ); }
     QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override

--- a/src/providers/arcgisrest/qgsamsdataitemguiprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsdataitemguiprovider.cpp
@@ -86,7 +86,7 @@ void QgsAmsDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
 void QgsAmsDataItemGuiProvider::newConnection( QgsDataItem *item )
 {
   QgsNewHttpConnection nc( nullptr, QgsNewHttpConnection::ConnectionOther, QStringLiteral( "qgis/connections-arcgismapserver/" ), QString(), QgsNewHttpConnection::FlagShowHttpSettings );
-  nc.setWindowTitle( tr( "Create a New ArcGIS Map Server Connection" ) );
+  nc.setWindowTitle( tr( "Create a New ArcGIS Map Service Connection" ) );
 
   if ( nc.exec() )
   {
@@ -97,7 +97,7 @@ void QgsAmsDataItemGuiProvider::newConnection( QgsDataItem *item )
 void QgsAmsDataItemGuiProvider::editConnection( QgsDataItem *item )
 {
   QgsNewHttpConnection nc( nullptr, QgsNewHttpConnection::ConnectionOther, QStringLiteral( "qgis/connections-arcgismapserver/" ), item->name(), QgsNewHttpConnection::FlagShowHttpSettings );
-  nc.setWindowTitle( tr( "Modify ArcGIS Map Server Connection" ) );
+  nc.setWindowTitle( tr( "Modify ArcGIS Map Service Connection" ) );
 
   if ( nc.exec() )
   {

--- a/src/providers/arcgisrest/qgsamsdataitems.cpp
+++ b/src/providers/arcgisrest/qgsamsdataitems.cpp
@@ -290,7 +290,7 @@ QgsDataItem *QgsAmsDataItemProvider::createDataItem( const QString &path, QgsDat
 {
   if ( path.isEmpty() )
   {
-    return new QgsAmsRootItem( parentItem, QStringLiteral( "ArcGisMapServer" ), QStringLiteral( "arcgismapserver:" ) );
+    return new QgsAmsRootItem( parentItem, QObject::tr( "ArcGIS Map Service" ), QStringLiteral( "arcgismapserver:" ) );
   }
 
   // path schema: ams:/connection name (used by OWS)

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -42,7 +42,7 @@
 #include <QNetworkCacheMetaData>
 
 const QString QgsAmsProvider::AMS_PROVIDER_KEY = QStringLiteral( "arcgismapserver" );
-const QString QgsAmsProvider::AMS_PROVIDER_DESCRIPTION = QStringLiteral( "ArcGIS MapServer data provider" );
+const QString QgsAmsProvider::AMS_PROVIDER_DESCRIPTION = QStringLiteral( "ArcGIS Map Service data provider" );
 
 
 //! a helper class for ordering tile requests according to the distance from view center

--- a/src/providers/arcgisrest/qgsamsprovidergui.cpp
+++ b/src/providers/arcgisrest/qgsamsprovidergui.cpp
@@ -28,7 +28,7 @@ class QgsAmsSourceSelectProvider : public QgsSourceSelectProvider
   public:
 
     QString providerKey() const override { return QStringLiteral( "arcgismapserver" ); }
-    QString text() const override { return QObject::tr( "ArcGIS Map Server" ); }
+    QString text() const override { return QObject::tr( "ArcGIS Map Service" ); }
     int ordering() const override { return QgsSourceSelectProvider::OrderRemoteProvider + 140; }
     QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddAmsLayer.svg" ) ); }
     QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>847</width>
+    <width>1064</width>
     <height>506</height>
    </rect>
   </property>
@@ -16,7 +16,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>847</width>
+     <width>1064</width>
      <height>24</height>
     </rect>
    </property>
@@ -2816,10 +2816,10 @@ Acts on the currently active layer only.</string>
      <normaloff>:/images/themes/default/mActionAddAmsLayer.svg</normaloff>:/images/themes/default/mActionAddAmsLayer.svg</iconset>
    </property>
    <property name="text">
-    <string>Add Arc&amp;GIS MapServer Layer…</string>
+    <string>Add Arc&amp;GIS Map Service Layer…</string>
    </property>
    <property name="toolTip">
-    <string>Add ArcGIS MapServer Layer</string>
+    <string>Add ArcGIS Map Service Layer</string>
    </property>
   </action>
   <action name="mActionAddAfsLayer">
@@ -2828,10 +2828,10 @@ Acts on the currently active layer only.</string>
      <normaloff>:/images/themes/default/mActionAddAfsLayer.svg</normaloff>:/images/themes/default/mActionAddAfsLayer.svg</iconset>
    </property>
    <property name="text">
-    <string>Add Ar&amp;cGIS FeatureServer Layer…</string>
+    <string>Add Ar&amp;cGIS Feature Service Layer…</string>
    </property>
    <property name="toolTip">
-    <string>Add ArcGIS FeatureServer Layer</string>
+    <string>Add ArcGIS Feature Service Layer</string>
    </property>
   </action>
   <action name="mActionSelectByForm">


### PR DESCRIPTION
This should be "MapServer"/"FeatureServer", not "Map Server"/"Feature Server"
