### PR TITLE
Avoid useless join fetches when joined table is empty

### DIFF
--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -1014,6 +1014,12 @@ void QgsVectorLayerFeatureIterator::FetchJoinInfo::addJoinedAttributesCached( Qg
 
 void QgsVectorLayerFeatureIterator::FetchJoinInfo::addJoinedAttributesDirect( QgsFeature &f, const QVariant &joinValue ) const
 {
+  // Shortcut
+  if ( joinLayer && joinLayer->featureCount() < 1 )
+  {
+    return;
+  }
+
   // no memory cache, query the joined values by setting substring
   QString subsetString;
 


### PR DESCRIPTION
Another **huge** speed improvement with joins in case the joined table is empty.

Related to https://github.com/qgis/QGIS/issues/36167
and (spotted while debugging) https://github.com/qgis/QGIS/issues/36934