### PR TITLE
Warn user when raster or vector renderere does not have any classes defined (fix #21075)  

### DIFF
--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -82,7 +82,9 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
   private slots:
 
     //! \brief Applies the settings made in the dialog without closing the box
-    void apply();
+    bool apply();
+    //! \brief Called when OK button is pressed
+    void onAccept();
     //! \brief Called when cancel button is pressed
     void onCancel();
     //! \brief Slot to update layer display name as original is edited.

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -87,7 +87,10 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     void mLayerOrigNameLineEdit_textEdited( const QString &text );
 
     //! Called when apply button is pressed or dialog is accepted
-    void apply();
+    bool apply();
+
+    //! Called when OK button is pressed
+    void onAccept();
 
     //! Called when cancel button is pressed
     void onCancel();


### PR DESCRIPTION
## Description
If graduated/categorized/rule-based vector renderer does not have any classes defined (e.g. user removed all classes or never pressed "Classify" button) layer won't be rendered on the canvas and labels won't be drawn. Same happens with paletted/pseudocolor raster renderers.

Prosed PR adds a warning before closing dialog/applying changes, so user can either refine settings or continue without classes.

Fixes #21075.