### PR TITLE
Better GeoPDF exported layer name fix

### DIFF
--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -606,6 +606,12 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( const QString &f
         details.keywords = mLayout->project()->metadata().keywords();
       }
 
+      const QList< QgsMapLayer * > layers = mLayout->project()->mapLayers().values();
+      for ( const QgsMapLayer *layer : layers )
+      {
+        details.layerIdToPdfLayerTreeNameMap.insert( layer->id(), layer->name() );
+      }
+
       if ( settings.appendGeoreference )
       {
         // setup georeferencing

--- a/src/core/qgsabstractgeopdfexporter.cpp
+++ b/src/core/qgsabstractgeopdfexporter.cpp
@@ -263,6 +263,7 @@ QString QgsAbstractGeoPdfExporter::createCompositionXml( const QList<ComponentLa
   QMap< QString, QSet< QString > > createdLayerIds;
   QMap< QString, QDomElement > groupLayerMap;
   QMap< QString, QString > customGroupNamesToIds;
+
   if ( details.includeFeatures )
   {
     for ( const VectorComponentDetail &component : qgis::as_const( mVectorComponents ) )
@@ -272,7 +273,7 @@ QString QgsAbstractGeoPdfExporter::createCompositionXml( const QList<ComponentLa
 
       QDomElement layer = doc.createElement( QStringLiteral( "Layer" ) );
       layer.setAttribute( QStringLiteral( "id" ), component.group.isEmpty() ? component.mapLayerId : QStringLiteral( "%1_%2" ).arg( component.group, component.mapLayerId ) );
-      layer.setAttribute( QStringLiteral( "name" ), component.name );
+      layer.setAttribute( QStringLiteral( "name" ), details.layerIdToPdfLayerTreeNameMap.contains( component.mapLayerId ) ? details.layerIdToPdfLayerTreeNameMap.value( component.mapLayerId ) : component.name );
       layer.setAttribute( QStringLiteral( "initiallyVisible" ), QStringLiteral( "true" ) );
 
       if ( !component.group.isEmpty() )
@@ -312,7 +313,7 @@ QString QgsAbstractGeoPdfExporter::createCompositionXml( const QList<ComponentLa
 
     QDomElement layer = doc.createElement( QStringLiteral( "Layer" ) );
     layer.setAttribute( QStringLiteral( "id" ), component.group.isEmpty() ? component.mapLayerId : QStringLiteral( "%1_%2" ).arg( component.group, component.mapLayerId ) );
-    layer.setAttribute( QStringLiteral( "name" ), component.name );
+    layer.setAttribute( QStringLiteral( "name" ), details.layerIdToPdfLayerTreeNameMap.contains( component.mapLayerId ) ? details.layerIdToPdfLayerTreeNameMap.value( component.mapLayerId ) : component.name );
     layer.setAttribute( QStringLiteral( "initiallyVisible" ), QStringLiteral( "true" ) );
 
     if ( !component.group.isEmpty() )

--- a/src/core/qgsabstractgeopdfexporter.h
+++ b/src/core/qgsabstractgeopdfexporter.h
@@ -252,6 +252,14 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
        */
       QMap< QString, QString > customLayerTreeGroups;
 
+
+      /**
+       * Optional map of map layer ID to custom layer tree name to show in the created PDF file.
+       *
+       * \since QGIS 3.14
+       */
+      QMap< QString, QString > layerIdToPdfLayerTreeNameMap;
+
     };
 
     /**
@@ -320,6 +328,7 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
 
     QString mErrorMessage;
     QTemporaryDir mTemporaryDir;
+
 
     bool saveTemporaryLayers();
 

--- a/src/core/qgsmaprenderertask.cpp
+++ b/src/core/qgsmaprenderertask.cpp
@@ -185,7 +185,7 @@ bool QgsMapRendererTask::run()
     {
       QgsAbstractGeoPdfExporter::ComponentLayerDetail component;
 
-      component.name = mLayerIdToLayerNameMap.value( job->currentLayerId(), QStringLiteral( "layer_%1" ).arg( outputLayer ) );
+      component.name = QStringLiteral( "layer_%1" ).arg( outputLayer );
       component.mapLayerId = job->currentLayerId();
       component.sourcePdfPath = mGeoPdfExporter->generateTemporaryFilepath( QStringLiteral( "layer_%1.pdf" ).arg( outputLayer ) );
       pdfComponents << component;
@@ -212,6 +212,8 @@ bool QgsMapRendererTask::run()
     const double pageHeightMM = mMapSettings.outputSize().height() * 25.4 / mMapSettings.outputDpi();
     exportDetails.pageSizeMm = QSizeF( pageWidthMM, pageHeightMM );
     exportDetails.dpi = mMapSettings.outputDpi();
+
+    exportDetails.layerIdToPdfLayerTreeNameMap = mLayerIdToLayerNameMap;
 
     if ( mSaveWorldFile )
     {

--- a/src/gui/layout/qgsgeopdflayertreemodel.cpp
+++ b/src/gui/layout/qgsgeopdflayertreemodel.cpp
@@ -195,6 +195,10 @@ bool QgsGeoPdfLayerFilteredTreeModel::filterAcceptsRow( int source_row, const QM
     // filter out non-vector layers
     if ( QgsLayerTree::isLayer( node ) && QgsLayerTree::toLayer( node ) && QgsLayerTree::toLayer( node )->layer() && QgsLayerTree::toLayer( node )->layer()->type() != QgsMapLayerType::VectorLayer )
       return false;
+
+    // also filter out non-spatial vector layers
+    if ( !qobject_cast< QgsVectorLayer * >( QgsLayerTree::toLayer( node )->layer() )->isSpatial() )
+      return false;
   }
   return true;
 }

--- a/tests/src/core/testqgsgeopdfexport.cpp
+++ b/tests/src/core/testqgsgeopdfexport.cpp
@@ -225,6 +225,7 @@ void TestQgsGeoPdfExport::testComposition()
   // test creation of the composition xml
   QList< QgsAbstractGeoPdfExporter::ComponentLayerDetail > renderedLayers; // no extra layers for now
   QgsAbstractGeoPdfExporter::ExportDetails details;
+  details.layerIdToPdfLayerTreeNameMap.insert( QStringLiteral( "layer1" ), QStringLiteral( "my first layer" ) );
   QString composition = geoPdfExporter.createCompositionXml( renderedLayers, details );
   QgsDebugMsg( composition );
   QDomDocument doc;
@@ -255,7 +256,7 @@ void TestQgsGeoPdfExport::testComposition()
   layer1Idx = layerTreeList.at( 0 ).toElement().attribute( QStringLiteral( "id" ) ) == QStringLiteral( "layer1" ) ? 0 : 1;
   layer2Idx = layer1Idx == 0 ? 1 : 0;
   QCOMPARE( layerTreeList.at( layer1Idx ).toElement().attribute( QStringLiteral( "id" ) ), QStringLiteral( "layer1" ) );
-  QCOMPARE( layerTreeList.at( layer1Idx ).toElement().attribute( QStringLiteral( "name" ) ), QStringLiteral( "name layer1" ) );
+  QCOMPARE( layerTreeList.at( layer1Idx ).toElement().attribute( QStringLiteral( "name" ) ), QStringLiteral( "my first layer" ) );
   QCOMPARE( layerTreeList.at( layer1Idx ).toElement().attribute( QStringLiteral( "initiallyVisible" ) ), QStringLiteral( "true" ) );
 
   QCOMPARE( layerTreeList.at( layer2Idx ).toElement().attribute( QStringLiteral( "id" ) ), QStringLiteral( "layer2" ) );


### PR DESCRIPTION
Followup d864dc8 - implement a better fix which also fixes exported layertree names from layout GeoPDF exports

Fixes #33306