### PR TITLE
Use a filter proxy model for the dependencies layer tree

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreefilterproxymodel.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreefilterproxymodel.sip.in
@@ -1,0 +1,109 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/layertree/qgslayertreefilterproxymodel.h                    *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsLayerTreeFilterProxyModel : QSortFilterProxyModel
+{
+%Docstring
+QgsLayerTreeFilterProxyModel is a sort filter proxy model to easily reproduce the legend/layer tree in a tree view.
+Layers are checkable by default.
+Symbology nodes will not be shown.
+
+This model can be re-implemented to add more columns.
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgslayertreefilterproxymodel.h"
+%End
+  public:
+    QgsLayerTreeFilterProxyModel( QObject *parent = 0 );
+
+    void setCheckedLayers( const QList<QgsMapLayer *> layers );
+%Docstring
+Initialize the list of checked layers.
+
+.. note::
+
+   If the model is re-implemented, this method might become useless
+%End
+
+    QList<QgsMapLayer *> checkedLayers() const;
+%Docstring
+Returns the checked layers
+%End
+
+    QgsMapLayer *mapLayer( const QModelIndex &idx ) const;
+%Docstring
+Returns the map layer at a given index
+%End
+
+    QgsLayerTreeModel *layerTreeModel() const;
+%Docstring
+Rerturns the layer tree model
+%End
+    void setLayerTreeModel( QgsLayerTreeModel *layerTreeModel );
+%Docstring
+Sets the layer tree model
+%End
+
+    void resetLayerTreeModel();
+%Docstring
+This will refresh the model
+%End
+
+    void setMapLayerTypeFilter( const QList<QgsMapLayerType> &types = QList<QgsMapLayerType>() );
+%Docstring
+Defines the type layers (vector, raster, etc) shown in the tree
+If the list is empty, all types are shown.
+%End
+
+    virtual int columnCount( const QModelIndex &parent ) const;
+    virtual Qt::ItemFlags flags( const QModelIndex &idx ) const;
+    virtual QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const;
+
+    virtual QModelIndex parent( const QModelIndex &child ) const;
+
+    virtual QModelIndex sibling( int row, int column, const QModelIndex &idx ) const;
+
+    virtual QVariant data( const QModelIndex &index, int role ) const;
+    virtual bool setData( const QModelIndex &index, const QVariant &value, int role );
+
+  public slots:
+    virtual void setFilterText( const QString &filterText = QString() );
+%Docstring
+Sets the filter text to search for a layer in the tree
+%End
+
+  protected:
+    virtual bool isLayerChecked( QgsMapLayer *layer ) const;
+%Docstring
+Returns if the layer is checked or not
+%End
+
+    virtual void setLayerChecked( QgsMapLayer *layer, bool checked );
+%Docstring
+This will set if the layer is checked or not
+%End
+
+    virtual bool filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const;
+
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/layertree/qgslayertreefilterproxymodel.h                    *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/layertree/qgslayertreefilterproxymodel.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreefilterproxymodel.sip.in
@@ -60,11 +60,6 @@ Rerturns the layer tree model
 Sets the layer tree model
 %End
 
-    void resetLayerTreeModel();
-%Docstring
-This will refresh the model
-%End
-
     void setFilters( const QgsMapLayerProxyModel::Filters &filters );
 %Docstring
 Defines the type layers (vector, raster, etc) shown in the tree

--- a/python/core/auto_generated/layertree/qgslayertreefilterproxymodel.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreefilterproxymodel.sip.in
@@ -65,7 +65,7 @@ Sets the layer tree model
 This will refresh the model
 %End
 
-    void setMapLayerTypeFilter( const QList<QgsMapLayerType> &types = QList<QgsMapLayerType>() );
+    void setFilters( const QgsMapLayerProxyModel::Filters &filters );
 %Docstring
 Defines the type layers (vector, raster, etc) shown in the tree
 If the list is empty, all types are shown.

--- a/python/core/auto_generated/layertree/qgslayertreefilterproxymodel.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreefilterproxymodel.sip.in
@@ -16,8 +16,9 @@ class QgsLayerTreeFilterProxyModel : QSortFilterProxyModel
 QgsLayerTreeFilterProxyModel is a sort filter proxy model to easily reproduce the legend/layer tree in a tree view.
 Layers are checkable by default.
 Symbology nodes will not be shown.
+Layers can be fitlered by their type.
 
-This model can be re-implemented to add more columns.
+For more complex use-cases, the model can be re-implemented to allow a different interaction or to add more columns.
 
 .. versionadded:: 3.14
 %End
@@ -27,6 +28,9 @@ This model can be re-implemented to add more columns.
 %End
   public:
     QgsLayerTreeFilterProxyModel( QObject *parent = 0 );
+%Docstring
+Constructor
+%End
 
     void setCheckedLayers( const QList<QgsMapLayer *> layers );
 %Docstring

--- a/python/core/auto_generated/qgsmaplayerproxymodel.sip.in
+++ b/python/core/auto_generated/qgsmaplayerproxymodel.sip.in
@@ -69,6 +69,13 @@ Returns the filter flags which affect how layers are filtered within the model.
 .. versionadded:: 2.3
 %End
 
+    static bool layerMatchesFilters( const QgsMapLayer *layer, const Filters &filters );
+%Docstring
+Returns if the ``layer`` matches the given ``filters``
+
+.. versionadded:: 3.14
+%End
+
     void setLayerWhitelist( const QList<QgsMapLayer *> &layers );
 %Docstring
 Sets a whitelist of ``layers`` to include within the model. Only layers

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -348,6 +348,7 @@
 %Include auto_generated/layertree/qgslayertreemodellegendnode.sip
 %Include auto_generated/layertree/qgslayertreenode.sip
 %Include auto_generated/layertree/qgslayertreeregistrybridge.sip
+%Include auto_generated/layertree/qgslayertreefilterproxymodel.sip
 %Include auto_generated/layertree/qgslayertreeutils.sip
 %Include auto_generated/layertree/qgslegendpatchshape.sip
 %Include auto_generated/layout/qgsabstractlayoutiterator.sip

--- a/python/gui/auto_generated/vector/qgsvectorlayerproperties.sip.in
+++ b/python/gui/auto_generated/vector/qgsvectorlayerproperties.sip.in
@@ -42,6 +42,7 @@ Adds a properties page factory to the vector layer properties dialog.
 
 
 
+      public:
 };
 
 

--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -266,6 +266,7 @@ QgsSnappingLayerTreeModel::QgsSnappingLayerTreeModel( QgsProject *project, QgsMa
 {
   connect( project, &QgsProject::snappingConfigChanged, this, &QgsSnappingLayerTreeModel::onSnappingSettingsChanged );
   connect( project, &QgsProject::avoidIntersectionsLayersChanged, this, &QgsSnappingLayerTreeModel::onSnappingSettingsChanged );
+  connect( project, &QgsProject::readProject, this, [ = ] {resetLayerTreeModel();} );
 }
 
 int QgsSnappingLayerTreeModel::columnCount( const QModelIndex &parent ) const

--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -92,7 +92,6 @@ QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas,
   connect( model, &QgsSnappingLayerTreeModel::rowsInserted, this, &QgsSnappingWidget::onSnappingTreeLayersChanged );
   connect( model, &QgsSnappingLayerTreeModel::modelReset, this, &QgsSnappingWidget::onSnappingTreeLayersChanged );
   connect( model, &QgsSnappingLayerTreeModel::rowsRemoved, this, &QgsSnappingWidget::onSnappingTreeLayersChanged );
-  connect( mProject, &QgsProject::readProject, this, [ = ] {model->resetLayerTreeModel();} );
   connect( mProject, &QObject::destroyed, this, [ = ] {mLayerTreeView->setModel( nullptr );} );
   // model->setFlags( 0 );
   mLayerTreeView->setModel( model );

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -96,6 +96,7 @@ SET(QGIS_CORE_SRCS
   layertree/qgslayertreemodellegendnode.cpp
   layertree/qgslayertreenode.cpp
   layertree/qgslayertreeregistrybridge.cpp
+  layertree/qgslayertreefilterproxymodel.cpp
   layertree/qgslayertreeutils.cpp
   layertree/qgslayertree.cpp
   layertree/qgslegendpatchshape.cpp
@@ -1152,6 +1153,7 @@ SET(QGIS_CORE_HDRS
   layertree/qgslayertreemodellegendnode.h
   layertree/qgslayertreenode.h
   layertree/qgslayertreeregistrybridge.h
+  layertree/qgslayertreefilterproxymodel.h
   layertree/qgslayertreeutils.h
   layertree/qgslegendpatchshape.h
 

--- a/src/core/layertree/qgslayertreefilterproxymodel.cpp
+++ b/src/core/layertree/qgslayertreefilterproxymodel.cpp
@@ -22,6 +22,7 @@
 QgsLayerTreeFilterProxyModel::QgsLayerTreeFilterProxyModel( QObject *parent )
   : QSortFilterProxyModel( parent )
 {
+  connect( QgsProject::instance(), &QgsProject::readProject, this, [ = ] {resetLayerTreeModel();} );
 }
 
 void QgsLayerTreeFilterProxyModel::setCheckedLayers( const QList<QgsMapLayer *> layers )

--- a/src/core/layertree/qgslayertreefilterproxymodel.cpp
+++ b/src/core/layertree/qgslayertreefilterproxymodel.cpp
@@ -1,0 +1,296 @@
+/***************************************************************************
+  qgslayertreefilterproxymodel.cpp
+
+ ---------------------
+ begin                : 05.06.2020
+ copyright            : (C) 2020 by Denis Rouzaud
+ email                : denis@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslayertreefilterproxymodel.h"
+
+#include "qgslayertree.h"
+#include "qgslayertreemodel.h"
+
+QgsLayerTreeFilterProxyModel::QgsLayerTreeFilterProxyModel( QObject *parent )
+  : QSortFilterProxyModel( parent )
+{
+}
+
+void QgsLayerTreeFilterProxyModel::setCheckedLayers( const QList<QgsMapLayer *> layers )
+{
+  beginResetModel();
+  mCheckedLayers = layers;
+  endResetModel();
+}
+
+int QgsLayerTreeFilterProxyModel::columnCount( const QModelIndex &parent ) const
+{
+  Q_UNUSED( parent )
+  return 1;
+}
+
+Qt::ItemFlags QgsLayerTreeFilterProxyModel::flags( const QModelIndex &idx ) const
+{
+  if ( idx.column() == 0 )
+  {
+    return Qt::ItemIsEnabled | Qt::ItemIsUserCheckable;
+  }
+  return Qt::NoItemFlags;
+}
+
+QModelIndex QgsLayerTreeFilterProxyModel::index( int row, int column, const QModelIndex &parent ) const
+{
+  QModelIndex newIndex = QSortFilterProxyModel::index( row, 0, parent );
+  if ( column == 0 )
+    return newIndex;
+
+  return createIndex( row, column, newIndex.internalId() );
+}
+
+QModelIndex QgsLayerTreeFilterProxyModel::parent( const QModelIndex &child ) const
+{
+  return QSortFilterProxyModel::parent( createIndex( child.row(), 0, child.internalId() ) );
+}
+
+QModelIndex QgsLayerTreeFilterProxyModel::sibling( int row, int column, const QModelIndex &idx ) const
+{
+  QModelIndex parent = idx.parent();
+  return index( row, column, parent );
+}
+
+QgsMapLayer *QgsLayerTreeFilterProxyModel::mapLayer( const QModelIndex &idx ) const
+{
+  QgsLayerTreeNode *node = nullptr;
+  if ( idx.column() == 0 )
+  {
+    node = mLayerTreeModel->index2node( mapToSource( idx ) );
+  }
+
+  if ( !node || !QgsLayerTree::isLayer( node ) )
+    return nullptr;
+
+  return QgsLayerTree::toLayer( node )->layer();
+}
+
+void QgsLayerTreeFilterProxyModel::setFilterText( const QString &filterText )
+{
+  if ( filterText == mFilterText )
+    return;
+
+  mFilterText = filterText;
+  invalidateFilter();
+}
+
+QgsLayerTreeModel *QgsLayerTreeFilterProxyModel::layerTreeModel() const
+{
+  return mLayerTreeModel;
+}
+
+void QgsLayerTreeFilterProxyModel::setLayerTreeModel( QgsLayerTreeModel *layerTreeModel )
+{
+  mLayerTreeModel = layerTreeModel;
+  QSortFilterProxyModel::setSourceModel( layerTreeModel );
+}
+
+void QgsLayerTreeFilterProxyModel::resetLayerTreeModel()
+{
+  beginResetModel();
+  endResetModel();
+}
+
+void QgsLayerTreeFilterProxyModel::setMapLayerTypeFilter( const QList<QgsMapLayerType> &types )
+{
+  beginResetModel();
+  mLayerTypeFilter = types;
+  endResetModel();
+}
+
+bool QgsLayerTreeFilterProxyModel::filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const
+{
+  QgsLayerTreeNode *node = mLayerTreeModel->index2node( mLayerTreeModel->index( sourceRow, 0, sourceParent ) );
+  return nodeShown( node );
+}
+
+bool QgsLayerTreeFilterProxyModel::isLayerChecked( QgsMapLayer *layer ) const
+{
+  return mCheckedLayers.contains( layer );
+}
+
+void QgsLayerTreeFilterProxyModel::setLayerChecked( QgsMapLayer *layer, bool checked )
+{
+  if ( checked )
+  {
+    mCheckedLayers << layer;
+  }
+  else
+  {
+    mCheckedLayers.removeAll( layer );
+  }
+}
+
+void QgsLayerTreeFilterProxyModel::setLayerCheckedPrivate( QgsMapLayer *layer, bool checked )
+{
+  if ( checked && isLayerChecked( layer ) )
+    return;
+  if ( !checked && !isLayerChecked( layer ) )
+    return;
+
+  QgsLayerTreeNode *node = mLayerTreeModel->rootGroup()->findLayer( layer );
+  QModelIndex index = mapFromSource( mLayerTreeModel->node2index( node ) );
+
+  setLayerChecked( layer, checked );
+
+  emit dataChanged( index, index );
+}
+
+bool QgsLayerTreeFilterProxyModel::layerShown( QgsMapLayer *layer ) const
+{
+  Q_UNUSED( layer )
+  return true;
+}
+
+bool QgsLayerTreeFilterProxyModel::nodeShown( QgsLayerTreeNode *node ) const
+{
+  if ( !node )
+    return false;
+  if ( node->nodeType() == QgsLayerTreeNode::NodeGroup )
+  {
+    const auto constChildren = node->children();
+    for ( QgsLayerTreeNode *child : constChildren )
+    {
+      if ( nodeShown( child ) )
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+  else
+  {
+    QgsMapLayer *layer = QgsLayerTree::toLayer( node )->layer();
+    if ( !layer )
+      return false;
+    if ( !mFilterText.isEmpty() && !layer->name().contains( mFilterText, Qt::CaseInsensitive ) )
+      return false;
+    if ( !mLayerTypeFilter.isEmpty() && !mLayerTypeFilter.contains( layer->type() ) )
+      return false;
+
+    return layerShown( layer );
+  }
+}
+
+QVariant QgsLayerTreeFilterProxyModel::data( const QModelIndex &idx, int role ) const
+{
+  if ( idx.column() == 0 )
+  {
+    if ( role == Qt::CheckStateRole )
+    {
+      QgsMapLayer *layer = mapLayer( idx );
+      if ( layer )
+      {
+        if ( isLayerChecked( layer ) )
+        {
+          return Qt::Checked;
+        }
+        else
+        {
+          return Qt::Unchecked;
+        }
+      }
+      else
+      {
+        // i.e. this is a group, analyze its children
+        bool hasChecked = false, hasUnchecked = false;
+        int n;
+        for ( n = 0; !hasChecked || !hasUnchecked; n++ )
+        {
+          QVariant v = data( index( n, 0, idx ), role );
+          if ( !v.isValid() )
+            break;
+
+          switch ( v.toInt() )
+          {
+            case Qt::PartiallyChecked:
+              // parent of partially checked child shared state
+              return Qt::PartiallyChecked;
+
+            case Qt::Checked:
+              hasChecked = true;
+              break;
+
+            case Qt::Unchecked:
+              hasUnchecked = true;
+              break;
+          }
+        }
+
+        // unchecked leaf
+        if ( n == 0 )
+          return Qt::Unchecked;
+
+        // both
+        if ( hasChecked &&  hasUnchecked )
+          return Qt::PartiallyChecked;
+
+        if ( hasChecked )
+          return Qt::Checked;
+
+        Q_ASSERT( hasUnchecked );
+        return Qt::Unchecked;
+      }
+    }
+    else
+    {
+      return mLayerTreeModel->data( mapToSource( idx ), role );
+    }
+  }
+  return QVariant();
+}
+
+bool QgsLayerTreeFilterProxyModel::setData( const QModelIndex &index, const QVariant &value, int role )
+{
+  if ( index.column() == 0 )
+  {
+    if ( role == Qt::CheckStateRole )
+    {
+      int i = 0;
+      for ( i = 0; ; i++ )
+      {
+        QModelIndex child = QgsLayerTreeFilterProxyModel::index( i, 0, index );
+        if ( !child.isValid() )
+          break;
+
+        setData( child, value, role );
+      }
+
+      if ( i == 0 )
+      {
+        QgsMapLayer *layer = mapLayer( index );
+        if ( !layer )
+        {
+          return false;
+        }
+        if ( value.toInt() == Qt::Checked )
+          setLayerChecked( layer, true );
+        else if ( value.toInt() == Qt::Unchecked )
+          setLayerChecked( layer, false );
+        else
+          Q_ASSERT( false ); // expected checked or unchecked
+      }
+      emit dataChanged( index, index );
+      return true;
+    }
+
+    return mLayerTreeModel->setData( mapToSource( index ), value, role );
+  }
+
+  return false;
+}

--- a/src/core/layertree/qgslayertreefilterproxymodel.cpp
+++ b/src/core/layertree/qgslayertreefilterproxymodel.cpp
@@ -22,11 +22,16 @@
 QgsLayerTreeFilterProxyModel::QgsLayerTreeFilterProxyModel( QObject *parent )
   : QSortFilterProxyModel( parent )
 {
-  connect( QgsProject::instance(), &QgsProject::readProject, this, [ = ] {resetLayerTreeModel();} );
+  connect( QgsProject::instance(), &QgsProject::readProject, this, [ = ]
+  {
+    beginResetModel();
+    endResetModel();
+  } );
 }
 
 void QgsLayerTreeFilterProxyModel::setCheckedLayers( const QList<QgsMapLayer *> layers )
 {
+  // do not use invalidate() since it's not the filter which changes but the data
   beginResetModel();
   mCheckedLayers = layers;
   endResetModel();
@@ -101,17 +106,10 @@ void QgsLayerTreeFilterProxyModel::setLayerTreeModel( QgsLayerTreeModel *layerTr
   QSortFilterProxyModel::setSourceModel( layerTreeModel );
 }
 
-void QgsLayerTreeFilterProxyModel::resetLayerTreeModel()
-{
-  beginResetModel();
-  endResetModel();
-}
-
 void QgsLayerTreeFilterProxyModel::setFilters( const QgsMapLayerProxyModel::Filters &filters )
 {
-  beginResetModel();
   mFilters = filters;
-  endResetModel();
+  invalidateFilter();
 }
 
 bool QgsLayerTreeFilterProxyModel::filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const
@@ -280,9 +278,9 @@ bool QgsLayerTreeFilterProxyModel::setData( const QModelIndex &index, const QVar
           return false;
         }
         if ( value.toInt() == Qt::Checked )
-          setLayerChecked( layer, true );
+          setLayerCheckedPrivate( layer, true );
         else if ( value.toInt() == Qt::Unchecked )
-          setLayerChecked( layer, false );
+          setLayerCheckedPrivate( layer, false );
         else
           Q_ASSERT( false ); // expected checked or unchecked
       }

--- a/src/core/layertree/qgslayertreefilterproxymodel.cpp
+++ b/src/core/layertree/qgslayertreefilterproxymodel.cpp
@@ -107,10 +107,10 @@ void QgsLayerTreeFilterProxyModel::resetLayerTreeModel()
   endResetModel();
 }
 
-void QgsLayerTreeFilterProxyModel::setMapLayerTypeFilter( const QList<QgsMapLayerType> &types )
+void QgsLayerTreeFilterProxyModel::setFilters( const QgsMapLayerProxyModel::Filters &filters )
 {
   beginResetModel();
-  mLayerTypeFilter = types;
+  mFilters = filters;
   endResetModel();
 }
 
@@ -181,7 +181,7 @@ bool QgsLayerTreeFilterProxyModel::nodeShown( QgsLayerTreeNode *node ) const
       return false;
     if ( !mFilterText.isEmpty() && !layer->name().contains( mFilterText, Qt::CaseInsensitive ) )
       return false;
-    if ( !mLayerTypeFilter.isEmpty() && !mLayerTypeFilter.contains( layer->type() ) )
+    if ( !QgsMapLayerProxyModel::layerMatchesFilters( layer, mFilters ) )
       return false;
 
     return layerShown( layer );

--- a/src/core/layertree/qgslayertreefilterproxymodel.h
+++ b/src/core/layertree/qgslayertreefilterproxymodel.h
@@ -61,9 +61,6 @@ class CORE_EXPORT QgsLayerTreeFilterProxyModel : public QSortFilterProxyModel
     //! Sets the layer tree model
     void setLayerTreeModel( QgsLayerTreeModel *layerTreeModel );
 
-    //! This will refresh the model
-    void resetLayerTreeModel();
-
     /**
      * Defines the type layers (vector, raster, etc) shown in the tree
      * If the list is empty, all types are shown.

--- a/src/core/layertree/qgslayertreefilterproxymodel.h
+++ b/src/core/layertree/qgslayertreefilterproxymodel.h
@@ -40,6 +40,7 @@ class CORE_EXPORT QgsLayerTreeFilterProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
   public:
+    //! Constructor
     QgsLayerTreeFilterProxyModel( QObject *parent = nullptr );
 
     /**

--- a/src/core/layertree/qgslayertreefilterproxymodel.h
+++ b/src/core/layertree/qgslayertreefilterproxymodel.h
@@ -1,0 +1,111 @@
+/***************************************************************************
+  qgslayertreefilterproxymodel.h
+
+ ---------------------
+ begin                : 05.06.2020
+ copyright            : (C) 2020 by Denis Rouzaud
+ email                : denis@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSLAYERTREEFILTERPROXYMODEL_H
+#define QGSLAYERTREEFILTERPROXYMODEL_H
+
+#include <QSortFilterProxyModel>
+
+#include "qgis_core.h"
+#include "qgsmaplayer.h"
+
+class QgsLayerTreeModel;
+class QgsLayerTreeNode;
+
+/**
+ * \ingroup core
+ * QgsLayerTreeFilterProxyModel is a sort filter proxy model to easily reproduce the legend/layer tree in a tree view.
+ * Layers are checkable by default.
+ * Symbology nodes will not be shown.
+ * Layers can be fitlered by their type.
+ *
+ * For more complex use-cases, the model can be re-implemented to allow a different interaction or to add more columns.
+ *
+ * \since QGIS 3.14
+ */
+class CORE_EXPORT QgsLayerTreeFilterProxyModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+  public:
+    QgsLayerTreeFilterProxyModel( QObject *parent = nullptr );
+
+    /**
+     * Initialize the list of checked layers.
+     * \note If the model is re-implemented, this method might become useless
+     */
+    void setCheckedLayers( const QList<QgsMapLayer *> layers );
+
+    //! Returns the checked layers
+    QList<QgsMapLayer *> checkedLayers() const {return mCheckedLayers;}
+
+    //! Returns the map layer at a given index
+    QgsMapLayer *mapLayer( const QModelIndex &idx ) const;
+
+    //! Rerturns the layer tree model
+    QgsLayerTreeModel *layerTreeModel() const;
+    //! Sets the layer tree model
+    void setLayerTreeModel( QgsLayerTreeModel *layerTreeModel );
+
+    //! This will refresh the model
+    void resetLayerTreeModel();
+
+    /**
+     * Defines the type layers (vector, raster, etc) shown in the tree
+     * If the list is empty, all types are shown.
+     */
+    void setMapLayerTypeFilter( const QList<QgsMapLayerType> &types = QList<QgsMapLayerType>() );
+
+    virtual int columnCount( const QModelIndex &parent ) const override;
+    virtual Qt::ItemFlags flags( const QModelIndex &idx ) const override;
+    QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const override;
+    QModelIndex parent( const QModelIndex &child ) const override;
+    QModelIndex sibling( int row, int column, const QModelIndex &idx ) const override;
+    virtual QVariant data( const QModelIndex &index, int role ) const override;
+    virtual bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
+
+  public slots:
+    //! Sets the filter text to search for a layer in the tree
+    virtual void setFilterText( const QString &filterText = QString() );
+
+  protected:
+    //! Returns if the layer is checked or not
+    virtual bool isLayerChecked( QgsMapLayer *layer ) const;
+
+    //! This will set if the layer is checked or not
+    virtual void setLayerChecked( QgsMapLayer *layer, bool checked );
+
+    bool filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const override;
+
+  private:
+
+    /**
+     * Reimplement to determine which layer are shown in the model
+     * \note even when reimplemented, the layer type filter and the filter text will respected.
+     */
+    virtual bool layerShown( QgsMapLayer *layer ) const;
+
+    bool nodeShown( QgsLayerTreeNode *node ) const;
+
+    //! This will call the virtual method and takes care of emitting dataChanged signal
+    void setLayerCheckedPrivate( QgsMapLayer *layer, bool checked );
+
+    QgsLayerTreeModel *mLayerTreeModel = nullptr;
+    QList<QgsMapLayer *> mCheckedLayers;
+    QString mFilterText;
+    QList<QgsMapLayerType> mLayerTypeFilter;
+};
+
+#endif // QGSLAYERTREEFILTERPROXYMODEL_H

--- a/src/core/layertree/qgslayertreefilterproxymodel.h
+++ b/src/core/layertree/qgslayertreefilterproxymodel.h
@@ -21,6 +21,7 @@
 
 #include "qgis_core.h"
 #include "qgsmaplayer.h"
+#include "qgsmaplayerproxymodel.h"
 
 class QgsLayerTreeModel;
 class QgsLayerTreeNode;
@@ -67,7 +68,7 @@ class CORE_EXPORT QgsLayerTreeFilterProxyModel : public QSortFilterProxyModel
      * Defines the type layers (vector, raster, etc) shown in the tree
      * If the list is empty, all types are shown.
      */
-    void setMapLayerTypeFilter( const QList<QgsMapLayerType> &types = QList<QgsMapLayerType>() );
+    void setFilters( const QgsMapLayerProxyModel::Filters &filters );
 
     virtual int columnCount( const QModelIndex &parent ) const override;
     virtual Qt::ItemFlags flags( const QModelIndex &idx ) const override;
@@ -106,7 +107,7 @@ class CORE_EXPORT QgsLayerTreeFilterProxyModel : public QSortFilterProxyModel
     QgsLayerTreeModel *mLayerTreeModel = nullptr;
     QList<QgsMapLayer *> mCheckedLayers;
     QString mFilterText;
-    QList<QgsMapLayerType> mLayerTypeFilter;
+    QgsMapLayerProxyModel::Filters mFilters = QgsMapLayerProxyModel::All;
 };
 
 #endif // QGSLAYERTREEFILTERPROXYMODEL_H

--- a/src/core/qgsmaplayerproxymodel.cpp
+++ b/src/core/qgsmaplayerproxymodel.cpp
@@ -45,6 +45,9 @@ QgsMapLayerProxyModel *QgsMapLayerProxyModel::setFilters( Filters filters )
 
 bool QgsMapLayerProxyModel::layerMatchesFilters( const QgsMapLayer *layer, const Filters &filters )
 {
+  if ( filters.testFlag( All ) )
+    return true;
+
   // layer type
   if ( ( filters.testFlag( RasterLayer ) && layer->type() == QgsMapLayerType::RasterLayer ) ||
        ( filters.testFlag( VectorLayer ) && layer->type() == QgsMapLayerType::VectorLayer ) ||
@@ -61,7 +64,7 @@ bool QgsMapLayerProxyModel::layerMatchesFilters( const QgsMapLayer *layer, const
                         filters.testFlag( HasGeometry );
   if ( detectGeometry && layer->type() == QgsMapLayerType::VectorLayer )
   {
-    if ( QgsVectorLayer *vl = qobject_cast< QgsVectorLayer *>( layer ) )
+    if ( const QgsVectorLayer *vl = qobject_cast<const QgsVectorLayer *>( layer ) )
     {
       if ( filters.testFlag( HasGeometry ) && vl->isSpatial() )
         return true;

--- a/src/core/qgsmaplayerproxymodel.h
+++ b/src/core/qgsmaplayerproxymodel.h
@@ -87,6 +87,12 @@ class CORE_EXPORT QgsMapLayerProxyModel : public QSortFilterProxyModel
     const Filters &filters() const { return mFilters; }
 
     /**
+     * Returns if the \a layer matches the given \a filters
+     * \since QGIS 3.14
+     */
+    static bool layerMatchesFilters( const QgsMapLayer *layer, const Filters &filters );
+
+    /**
      * Sets a whitelist of \a layers to include within the model. Only layers
      * from this list will be shown.
      *

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -28,6 +28,7 @@
 #include "qgsvectorlayerserverproperties.h"
 #include "qgslayertree.h"
 #include "qgslayertreemodel.h"
+#include "qgslayertreefilterproxymodel.h"
 
 class QgsMapLayer;
 
@@ -159,6 +160,19 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
   private:
 
+    class DependenciesLayerTreeModel : public QgsLayerTreeFilterProxyModel
+    {
+      public:
+        DependenciesLayerTreeModel( QgsVectorLayer *mainLayer, QObject *parent = nullptr )
+          : QgsLayerTreeFilterProxyModel( parent )
+          , mMainLayer( mainLayer )
+        {}
+
+      private:
+        QgsVectorLayer *mMainLayer = nullptr;
+        bool layerShown( QgsMapLayer *layer ) const override {return layer != mMainLayer;}
+    };
+
     enum PropertyType
     {
       Style = 0,
@@ -227,8 +241,7 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
     QgsExpressionContext createExpressionContext() const override;
 
-    std::unique_ptr<QgsLayerTree> mLayersDependenciesTreeGroup;
-    std::unique_ptr<QgsLayerTreeModel> mLayersDependenciesTreeModel;
+    DependenciesLayerTreeModel *mLayersDependenciesTreeModel;
 
     void showHelp();
 

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -363,7 +363,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>18</number>
          </property>
          <widget class="QWidget" name="mOptsPage_Information">
           <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -439,8 +439,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>653</width>
-                <height>679</height>
+                <width>644</width>
+                <height>664</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -727,8 +727,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>653</width>
-                <height>679</height>
+                <width>100</width>
+                <height>30</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_18">
@@ -944,8 +944,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>653</width>
-                <height>679</height>
+                <width>199</width>
+                <height>119</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -1339,8 +1339,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>653</width>
-                <height>679</height>
+                <width>100</width>
+                <height>30</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -1541,8 +1541,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>673</width>
-                <height>665</height>
+                <width>652</width>
+                <height>368</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -1954,7 +1954,7 @@ border-radius: 2px;</string>
                </widget>
               </item>
               <item>
-               <widget class="QgsLayerTreeView" name="mLayersDependenciesTreeView">
+               <widget class="QTreeView" name="mLayersDependenciesTreeView">
                 <property name="enabled">
                  <bool>true</bool>
                 </property>
@@ -2033,8 +2033,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>639</width>
-                <height>797</height>
+                <width>644</width>
+                <height>808</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -2586,12 +2586,6 @@ border-radius: 2px;</string>
    <class>QgsFieldExpressionWidget</class>
    <extends>QWidget</extends>
    <header>qgsfieldexpressionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsLayerTreeView</class>
-   <extends>QTreeView</extends>
-   <header>qgslayertreeview.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>


### PR DESCRIPTION
The layer tree for dependencies (in vector layer properties) was showing symbols and also the main layer.
This fixes this by using a layer tree filter proxy model (similarly to the snapping and data sources).

I have create a re-usable base class `QgsLayerTreeFilterProxyModel` which makes this easy.
Next step (after release I guess), would be to use the same base class in other places (snapping, data sources, DXF export, …)