### PR TITLE
Fix #36983 arguments of is_selected are flipped

### DIFF
--- a/resources/function_help/json/is_selected
+++ b/resources/function_help/json/is_selected
@@ -7,7 +7,7 @@
             "variant": "No parameters",
             "variant_description": "If called with no parameters, the function will return true if the current feature in the current layer is selected.",
             "arguments": [ { "arg": "", "description": "No parameters" } ],
-            "examples": [ { "expression": "is_selected()", "returns" : "True if the current feature in current layer is selected." } ]
+            "examples": [ { "expression": "is_selected()", "returns" : "True if the current feature in the current layer is selected." } ]
         },
         {
             "variant": "One 'feature' parameter",
@@ -23,5 +23,4 @@
         }
   ]
  }
-
 

--- a/resources/function_help/json/is_selected
+++ b/resources/function_help/json/is_selected
@@ -19,7 +19,7 @@
             "variant" : "Two parameters",
             "variant_description": "If the function is called with both a layer and a feature, it will return true if the specified feature from the specified layer is selected.",
             "arguments": [ { "arg": "layer", "description": "The layer (or its ID or name) on which the selection will be checked." }, { "arg": "feature", "description": "The feature which should be checked for selection." } ],
-            "examples": [ { "expression": "is_selected( 'streets', get_feature('streets', 'name', \"street_name\"))", "returns": "True if the current building's street is selected." } ]
+            "examples": [ { "expression": "is_selected( 'streets', get_feature('streets', 'name', \"street_name\"))", "returns": "True if the current building's street is selected (assuming the building layer has a field named 'street_name' and the 'streets' layer has a field called 'name')." } ]
         }
   ]
  }

--- a/resources/function_help/json/is_selected
+++ b/resources/function_help/json/is_selected
@@ -5,7 +5,7 @@
   "variants": [
         {
             "variant": "No parameters",
-            "variant_description": "If called with no parameters, it checks if current feature in current layer is selected.",
+            "variant_description": "If called with no parameters, the function will return true if the current feature in the current layer is selected.",
             "arguments": [ { "arg": "", "description": "No parameters" } ],
             "examples": [ { "expression": "is_selected()", "returns" : "True if the current feature in current layer is selected." } ]
         },
@@ -23,6 +23,5 @@
         }
   ]
  }
-
 
 

--- a/resources/function_help/json/is_selected
+++ b/resources/function_help/json/is_selected
@@ -1,23 +1,29 @@
 {
   "name": "is_selected",
   "type": "function",
-  "description": "Returns True if a feature is selected. If called with no parameters checks the current feature.",
-  "arguments": [
+  "description": "Returns True if a feature is selected. Can be used with zero, one or two parameters, see below for different variants.",
+  "variants": [
         {
-          "arg": "layer",
-          "optional": true,
-          "default": "current layer",
-          "description": "The layer (or its id or name) on which the selection will be checked."
+            "variant": "No parameters",
+            "variant_description": "If called with no parameters, it checks if current feature in current layer is selected.",
+            "arguments": [ { "arg": "", "description": "No parameters" } ],
+            "examples": [ { "expression": "is_selected()", "returns" : "True if the current feature in current layer is selected." } ]
         },
         {
-          "arg":"feature",
-          "optional": true,
-          "default": "current feature",
-          "description":"The feature which should be checked for selection."
+            "variant": "One 'feature' parameter",
+            "variant_description": "If called with a 'feature' parameter, it returns True if that feature is selected.",
+            "arguments": [ { "arg": "feature", "description": "The feature which should be checked for selection." } ],
+            "examples": [ { "expression": "is_selected( get_feature('streets', 'name', \"street_name\")) )", "returns": "True if that feature is selected." } ]
+        },
+        {
+            "variant" : "Two parameters",
+            "variant_description": "If called with a layer and a feature, it checks if that feature in that layer is selected.",
+            "arguments": [ { "arg": "layer", "description": "The layer (or its id or name) on which the selection will be checked." }, { "arg": "feature", "description": "The feature which should be checked for selection." } ],
+            "examples": [ { "expression": "is_selected( 'streets', get_feature('streets', 'name', \"street_name\"))", "returns": "True if the current building's street is selected." } ]
         }
-  ],
-  "examples": [
-        { "expression":"is_selected()", "returns" : "True if the current feature is selected."},
-        { "expression":"is_selected('streets', get_feature('streets', 'name', \"street_name\"))", "returns":"True if the current building's street is selected."}
   ]
-}
+ }
+
+
+
+

--- a/resources/function_help/json/is_selected
+++ b/resources/function_help/json/is_selected
@@ -6,7 +6,7 @@
         {
             "variant": "No parameters",
             "variant_description": "If called with no parameters, the function will return true if the current feature in the current layer is selected.",
-            "arguments": [ { "arg": "", "description": "No parameters" } ],
+            "arguments": [],
             "examples": [ { "expression": "is_selected()", "returns" : "True if the current feature in the current layer is selected." } ]
         },
         {

--- a/resources/function_help/json/is_selected
+++ b/resources/function_help/json/is_selected
@@ -17,7 +17,7 @@
         },
         {
             "variant" : "Two parameters",
-            "variant_description": "If called with a layer and a feature, it checks if that feature in that layer is selected.",
+            "variant_description": "If the function is called with both a layer and a feature, it will return true if the specified feature from the specified layer is selected.",
             "arguments": [ { "arg": "layer", "description": "The layer (or its id or name) on which the selection will be checked." }, { "arg": "feature", "description": "The feature which should be checked for selection." } ],
             "examples": [ { "expression": "is_selected( 'streets', get_feature('streets', 'name', \"street_name\"))", "returns": "True if the current building's street is selected." } ]
         }

--- a/resources/function_help/json/is_selected
+++ b/resources/function_help/json/is_selected
@@ -13,7 +13,7 @@
             "variant": "One 'feature' parameter",
             "variant_description": "If called with a 'feature' parameter, it returns True if that feature is selected.",
             "arguments": [ { "arg": "feature", "description": "The feature which should be checked for selection." } ],
-            "examples": [ { "expression": "is_selected( get_feature('streets', 'name', \"street_name\")) )", "returns": "True if that feature is selected." } ]
+            "examples": [ { "expression": "is_selected(@atlas_feature)", "returns": "True if the current atlas feature is selected." } ]
         },
         {
             "variant" : "Two parameters",
@@ -23,4 +23,3 @@
         }
   ]
  }
-

--- a/resources/function_help/json/is_selected
+++ b/resources/function_help/json/is_selected
@@ -11,7 +11,7 @@
         },
         {
             "variant": "One 'feature' parameter",
-            "variant_description": "If called with a 'feature' parameter, it returns True if that feature is selected.",
+            "variant_description": "If called with a 'feature' parameter only, the function returns true if the specified feature from the current layer is selected.",
             "arguments": [ { "arg": "feature", "description": "The feature which should be checked for selection." } ],
             "examples": [ { "expression": "is_selected(@atlas_feature)", "returns": "True if the current atlas feature is selected." } ]
         },

--- a/resources/function_help/json/is_selected
+++ b/resources/function_help/json/is_selected
@@ -1,23 +1,23 @@
 {
   "name": "is_selected",
   "type": "function",
-  "description": "Returns if a feature is selected. If called with no parameters checks the current feature.",
+  "description": "Returns True if a feature is selected. If called with no parameters checks the current feature.",
   "arguments": [
-        {
-          "arg":"feature",
-          "optional": true,
-          "default": "current feature",
-          "description":"The feature which should be checked for selection."
-        },
         {
           "arg": "layer",
           "optional": true,
           "default": "current layer",
           "description": "The layer (or its id or name) on which the selection will be checked."
+        },
+        {
+          "arg":"feature",
+          "optional": true,
+          "default": "current feature",
+          "description":"The feature which should be checked for selection."
         }
   ],
   "examples": [
-	{ "expression":"is_selected()", "returns" : "True if the current feature is selected."},
-	{ "expression":"is_selected(get_feature('streets', 'name', \"street_name\"), 'streets')", "returns":"True if the current building's street is selected."}
+        { "expression":"is_selected()", "returns" : "True if the current feature is selected."},
+        { "expression":"is_selected('streets', get_feature('streets', 'name', \"street_name\"))", "returns":"True if the current building's street is selected."}
   ]
 }

--- a/resources/function_help/json/is_selected
+++ b/resources/function_help/json/is_selected
@@ -18,7 +18,7 @@
         {
             "variant" : "Two parameters",
             "variant_description": "If the function is called with both a layer and a feature, it will return true if the specified feature from the specified layer is selected.",
-            "arguments": [ { "arg": "layer", "description": "The layer (or its id or name) on which the selection will be checked." }, { "arg": "feature", "description": "The feature which should be checked for selection." } ],
+            "arguments": [ { "arg": "layer", "description": "The layer (or its ID or name) on which the selection will be checked." }, { "arg": "feature", "description": "The feature which should be checked for selection." } ],
             "examples": [ { "expression": "is_selected( 'streets', get_feature('streets', 'name', \"street_name\"))", "returns": "True if the current building's street is selected." } ]
         }
   ]

--- a/resources/function_help/json/is_selected
+++ b/resources/function_help/json/is_selected
@@ -1,7 +1,7 @@
 {
   "name": "is_selected",
   "type": "function",
-  "description": "Returns True if a feature is selected. Can be used with zero, one or two parameters, see below for different variants.",
+  "description": "Returns True if a feature is selected. Can be used with zero, one or two arguments, see below for details.",
   "variants": [
         {
             "variant": "No parameters",
@@ -23,7 +23,6 @@
         }
   ]
  }
-
 
 
 


### PR DESCRIPTION
Fixes https://github.com/qgis/QGIS/issues/36983

I think this could be backported to 3.12 and 3.10 too?

In the help text the arguments for the is_selected function were flipped. I checked, also the example as shown was not working.

Also added a 'True' in the description, which I think was missing.

Old situation:

![oldsituation](https://user-images.githubusercontent.com/731673/83979964-55ab0c00-a912-11ea-9ec0-38e5d711728d.png)

New situation:

![newsituation](https://user-images.githubusercontent.com/731673/83979972-5e034700-a912-11ea-8793-b1a3cb70aa24.png)

