### PR TITLE
Vector tile writer: skip geometries too short/small (fixes #36939)

### DIFF
--- a/src/core/vectortile/qgsvectortilemvtencoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtencoder.cpp
@@ -231,6 +231,21 @@ void QgsVectorTileMVTEncoder::addLayer( QgsVectorLayer *layer, QgsFeedback *feed
 
 void QgsVectorTileMVTEncoder::addFeature( vector_tile::Tile_Layer *tileLayer, const QgsFeature &f )
 {
+  QgsGeometry g = f.geometry();
+  QgsWkbTypes::GeometryType geomType = g.type();
+  double onePixel = mTileExtent.width() / mResolution;
+
+  if ( geomType == QgsWkbTypes::LineGeometry )
+  {
+    if ( g.length() < onePixel )
+      return; // too short
+  }
+  else if ( geomType == QgsWkbTypes::PolygonGeometry )
+  {
+    if ( g.area() < onePixel * onePixel )
+      return; // too small
+  }
+
   vector_tile::Tile_Feature *feature = tileLayer->add_features();
 
   feature->set_id( static_cast<quint64>( f.id() ) );
@@ -275,8 +290,6 @@ void QgsVectorTileMVTEncoder::addFeature( vector_tile::Tile_Layer *tileLayer, co
   // encode geometry
   //
 
-  QgsGeometry g = f.geometry();
-  QgsWkbTypes::GeometryType geomType = g.type();
   vector_tile::Tile_GeomType mvtGeomType = vector_tile::Tile_GeomType_UNKNOWN;
   if ( geomType == QgsWkbTypes::PointGeometry )
     mvtGeomType = vector_tile::Tile_GeomType_POINT;


### PR DESCRIPTION
The tile encoder would include even linestrings/polygons that were shorter that 1px / smaller that 1px^2. Now we skip those, greatly reducing tile size on lower zoom levels.

(actually the resolution of each tile is normally set as 4096x4096, so 1px in fact is much smaller than "true" pixel on a screen)

The exported file size as reported in #36939 went down from 11MB to < 0.2MB. The export speed is a bit better, but it's probably caused mainly by slow reading of GeoJSON.