### PR TITLE
[3d] When showing edges, data defined polygon height was not accounted for

### DIFF
--- a/src/3d/symbols/qgslinevertexdata_p.cpp
+++ b/src/3d/symbols/qgslinevertexdata_p.cpp
@@ -129,7 +129,7 @@ void QgsLineVertexData::addLineString( const QgsLineString &lineString, float ex
 }
 
 
-void QgsLineVertexData::addVerticalLines( const QgsLineString &lineString, float verticalLength )
+void QgsLineVertexData::addVerticalLines( const QgsLineString &lineString, float verticalLength, float extraHeightOffset )
 {
   QgsPoint centroid;
   if ( altBinding == Qgs3DTypes::AltBindCentroid )
@@ -138,7 +138,7 @@ void QgsLineVertexData::addVerticalLines( const QgsLineString &lineString, float
   for ( int i = 0; i < lineString.vertexCount(); ++i )
   {
     QgsPoint p = lineString.pointN( i );
-    float z = Qgs3DUtils::clampAltitude( p, altClamping, altBinding, baseHeight, centroid, *mapSettings );
+    float z = Qgs3DUtils::clampAltitude( p, altClamping, altBinding, baseHeight + extraHeightOffset, centroid, *mapSettings );
     float z2 = z + verticalLength;
 
     if ( withAdjacency )

--- a/src/3d/symbols/qgslinevertexdata_p.h
+++ b/src/3d/symbols/qgslinevertexdata_p.h
@@ -81,7 +81,7 @@ struct QgsLineVertexData
   Qt3DRender::QGeometry *createGeometry( Qt3DCore::QNode *parent );
 
   void addLineString( const QgsLineString &lineString, float extraHeightOffset = 0 );
-  void addVerticalLines( const QgsLineString &lineString, float verticalLength );
+  void addVerticalLines( const QgsLineString &lineString, float verticalLength, float extraHeightOffset = 0 );
 };
 
 /// @endcond

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -93,21 +93,21 @@ void QgsPolygon3DSymbolHandler::processPolygon( QgsPolygon *polyClone, QgsFeatur
   if ( mSymbol.edgesEnabled() )
   {
     // add edges before the polygon gets the Z values modified because addLineString() does its own altitude handling
-    outEdges.addLineString( *static_cast<const QgsLineString *>( polyClone->exteriorRing() ) );
+    outEdges.addLineString( *static_cast<const QgsLineString *>( polyClone->exteriorRing() ), height );
     for ( int i = 0; i < polyClone->numInteriorRings(); ++i )
-      outEdges.addLineString( *static_cast<const QgsLineString *>( polyClone->interiorRing( i ) ) );
+      outEdges.addLineString( *static_cast<const QgsLineString *>( polyClone->interiorRing( i ) ), height );
 
     if ( extrusionHeight )
     {
       // add roof and wall edges
       const QgsLineString *exterior = static_cast<const QgsLineString *>( polyClone->exteriorRing() );
-      outEdges.addLineString( *exterior, extrusionHeight );
-      outEdges.addVerticalLines( *exterior, extrusionHeight );
+      outEdges.addLineString( *exterior, extrusionHeight + height );
+      outEdges.addVerticalLines( *exterior, extrusionHeight, height );
       for ( int i = 0; i < polyClone->numInteriorRings(); ++i )
       {
         const QgsLineString *interior = static_cast<const QgsLineString *>( polyClone->interiorRing( i ) );
-        outEdges.addLineString( *interior, extrusionHeight );
-        outEdges.addVerticalLines( *interior, extrusionHeight );
+        outEdges.addLineString( *interior, extrusionHeight + height );
+        outEdges.addVerticalLines( *interior, extrusionHeight, height );
       }
     }
   }


### PR DESCRIPTION
I'm not 100% confident this is the correct fix. But without it, the combination of data defined polygon height + showing edges results in this:

![image](https://user-images.githubusercontent.com/1829991/83990463-179efe00-a98d-11ea-856c-e93c9323b0ea.png)
