### PR TITLE
Unittest for wfs with SRSname

### DIFF
--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -285,6 +285,34 @@ class TestQgsServerWFS(QgsServerTestBase):
 """
         tests.append(('within4326FilterTemplate_post', within4326FilterTemplate.format("")))
 
+        # Check get feature within linear ring with srsName=EPSG:3857 (different from the project/layer)
+        # The coordinates are converted from the one in 4326
+        within3857FilterTemplate = """<?xml version="1.0" encoding="UTF-8"?>
+<wfs:GetFeature service="WFS" version="1.0.0" {} xmlns:wfs="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+  <wfs:Query typeName="testlayer" srsName="EPSG:3857" xmlns:feature="http://www.qgis.org/gml">
+    <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+      <Within>
+        <PropertyName>geometry</PropertyName>
+        <Polygon xmlns="http://www.opengis.net/gml" srsName="EPSG:3857">
+          <exterior>
+            <LinearRing srsName="EPSG:3857">
+              <posList srsDimension="2">
+                890555.93 5465442.18
+                1001875.42, 5465442.18
+                1001875.42, 5621521.49
+                890555.93, 5621521.49
+                890555.93 5465442.18
+              </posList>
+            </LinearRing>
+          </exterior>
+        </Polygon>
+      </Within>
+    </ogc:Filter>
+  </wfs:Query>
+</wfs:GetFeature>
+"""
+        tests.append(('within3857FilterTemplate_post', within3857FilterTemplate.format("")))
+
         srsTwoLayersTemplate = """<?xml version="1.0" encoding="UTF-8"?>
 <wfs:GetFeature service="WFS" version="1.0.0" {} xmlns:wfs="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
   <wfs:Query typeName="testlayer" srsName="EPSG:3857" xmlns:feature="http://www.qgis.org/gml">

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -268,7 +268,7 @@ class TestQgsServerWFS(QgsServerTestBase):
         <PropertyName>geometry</PropertyName>
         <Polygon xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
           <exterior>
-            <LinearRing srsName="EPSG:4326">
+            <LinearRing>
               <posList srsDimension="2">
                 8 44
                 9 44
@@ -296,7 +296,7 @@ class TestQgsServerWFS(QgsServerTestBase):
         <PropertyName>geometry</PropertyName>
         <Polygon xmlns="http://www.opengis.net/gml" srsName="EPSG:3857">
           <exterior>
-            <LinearRing srsName="EPSG:3857">
+            <LinearRing>
               <posList srsDimension="2">
                 890555.93 5465442.18
                 1001875.42 5465442.18

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -257,6 +257,34 @@ class TestQgsServerWFS(QgsServerTestBase):
 """
         tests.append(('srsname_post', srsTemplate.format("")))
 
+        # Issue https://github.com/qgis/QGIS/issues/36398
+        # Check get feature within linear ring with srsName=EPSG:4326 (same as the project/layer)
+        within4326FilterTemplate = """<?xml version="1.0" encoding="UTF-8"?>
+<wfs:GetFeature service="WFS" version="1.0.0" {} xmlns:wfs="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+  <wfs:Query typeName="testlayer" srsName="EPSG:4326" xmlns:feature="http://www.qgis.org/gml">
+    <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+      <Within>
+        <PropertyName>geometry</PropertyName>
+        <Polygon xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+          <exterior>
+            <LinearRing srsName="EPSG:4326">
+              <posList srsDimension="2">
+                8 44
+                9 44
+                9 45
+                8 45
+                8 44
+              </posList>
+            </LinearRing>
+          </exterior>
+        </Polygon>
+      </Within>
+    </ogc:Filter>
+  </wfs:Query>
+</wfs:GetFeature>
+"""
+        tests.append(('within4326FilterTemplate_post', within4326FilterTemplate.format("")))
+
         srsTwoLayersTemplate = """<?xml version="1.0" encoding="UTF-8"?>
 <wfs:GetFeature service="WFS" version="1.0.0" {} xmlns:wfs="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
   <wfs:Query typeName="testlayer" srsName="EPSG:3857" xmlns:feature="http://www.qgis.org/gml">

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -259,7 +259,7 @@ class TestQgsServerWFS(QgsServerTestBase):
         tests.append(('srsname_post', srsTemplate.format("")))
 
         # Issue https://github.com/qgis/QGIS/issues/36398
-        # Check get feature within linear ring with srsName=EPSG:4326 (same as the project/layer)
+        # Check get feature within polygon having srsName=EPSG:4326 (same as the project/layer)
         within4326FilterTemplate = """<?xml version="1.0" encoding="UTF-8"?>
 <wfs:GetFeature service="WFS" version="1.0.0" {} xmlns:wfs="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
   <wfs:Query typeName="testlayer" srsName="EPSG:4326" xmlns:feature="http://www.qgis.org/gml">

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -212,11 +212,11 @@ class TestQgsServerWFS(QgsServerTestBase):
 
         self.result_compare(
             'wfs_getfeature_{}.txt'.format(requestid),
-            "GetFeature in POST for '{}' failed.".format(requestid),
+            "GetFeature in POST for '{}' failed.\n\n {}".format(requestid, body.decode('utf-8')),
             header, body,
         )
 
-    @unittest.expectedFailure("Issue #36398: QGIS Server: WFS Request does not use SrsName on the geometry")
+    # @unittest.expectedFailure("Issue #36398: QGIS Server: WFS Request does not use SrsName on the geometry")
     def test_getfeature_post(self):
         tests = []
 
@@ -270,11 +270,11 @@ class TestQgsServerWFS(QgsServerTestBase):
           <exterior>
             <LinearRing>
               <posList srsDimension="2">
-                8 44
-                9 44
-                9 45
-                8 45
-                8 44
+                8.20344131 44.90137909
+                8.20347748 44.90137909
+                8.20347748 44.90141005
+                8.20344131 44.90141005
+                8.20344131 44.90137909
               </posList>
             </LinearRing>
           </exterior>
@@ -312,7 +312,7 @@ class TestQgsServerWFS(QgsServerTestBase):
   </wfs:Query>
 </wfs:GetFeature>
 """
-        tests.append(('within3857FilterTemplate_post', within3857FilterTemplate.format("")))
+        # tests.append(('within3857FilterTemplate_post', within3857FilterTemplate.format("")))
 
         srsTwoLayersTemplate = """<?xml version="1.0" encoding="UTF-8"?>
 <wfs:GetFeature service="WFS" version="1.0.0" {} xmlns:wfs="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -212,11 +212,11 @@ class TestQgsServerWFS(QgsServerTestBase):
 
         self.result_compare(
             'wfs_getfeature_{}.txt'.format(requestid),
-            "GetFeature in POST for '{}' failed.\n\n {}".format(requestid, body.decode('utf-8')),
+            "GetFeature in POST for '{}' failed.".format(requestid),
             header, body,
         )
 
-    # @unittest.expectedFailure("Issue #36398: QGIS Server: WFS Request does not use SrsName on the geometry")
+    @unittest.expectedFailure("Issue #36398: QGIS Server: WFS Request does not use SrsName on the geometry")
     def test_getfeature_post(self):
         tests = []
 
@@ -298,11 +298,11 @@ class TestQgsServerWFS(QgsServerTestBase):
           <exterior>
             <LinearRing>
               <posList srsDimension="2">
-                890555.93 5465442.18
-                1001875.42 5465442.18
-                1001875.42 5621521.49
-                890555.93 5621521.49
-                890555.93 5465442.18
+              913202.90938171 5606008.98136456
+              913206.93580769 5606008.98136456
+              913206.93580769 5606013.84701639
+              913202.90938171 5606013.84701639
+              913202.90938171 5606008.98136456
               </posList>
             </LinearRing>
           </exterior>
@@ -312,7 +312,7 @@ class TestQgsServerWFS(QgsServerTestBase):
   </wfs:Query>
 </wfs:GetFeature>
 """
-        # tests.append(('within3857FilterTemplate_post', within3857FilterTemplate.format("")))
+        tests.append(('within3857FilterTemplate_post', within3857FilterTemplate.format("")))
 
         srsTwoLayersTemplate = """<?xml version="1.0" encoding="UTF-8"?>
 <wfs:GetFeature service="WFS" version="1.0.0" {} xmlns:wfs="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -298,9 +298,9 @@ class TestQgsServerWFS(QgsServerTestBase):
             <LinearRing srsName="EPSG:3857">
               <posList srsDimension="2">
                 890555.93 5465442.18
-                1001875.42, 5465442.18
-                1001875.42, 5621521.49
-                890555.93, 5621521.49
+                1001875.42 5465442.18
+                1001875.42 5621521.49
+                890555.93 5621521.49
                 890555.93 5465442.18
               </posList>
             </LinearRing>

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -286,7 +286,7 @@ class TestQgsServerWFS(QgsServerTestBase):
 """
         tests.append(('within4326FilterTemplate_post', within4326FilterTemplate.format("")))
 
-        # Check get feature within linear ring with srsName=EPSG:3857 (different from the project/layer)
+        # Check get feature within polygon having srsName=EPSG:3857 (different from the project/layer)
         # The coordinates are converted from the one in 4326
         within3857FilterTemplate = """<?xml version="1.0" encoding="UTF-8"?>
 <wfs:GetFeature service="WFS" version="1.0.0" {} xmlns:wfs="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -216,6 +216,7 @@ class TestQgsServerWFS(QgsServerTestBase):
             header, body,
         )
 
+    @unittest.expectedFailure("Issue #36398: QGIS Server: WFS Request does not use SrsName on the geometry")
     def test_getfeature_post(self):
         tests = []
 

--- a/tests/testdata/qgis_server/wfs_getfeature_within3857FilterTemplate_post.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_within3857FilterTemplate_post.txt
@@ -1,0 +1,60 @@
+Content-Type: text/xml; subtype=gml/2.1.2; charset=utf-8
+
+<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd http://www.qgis.org/gml ?MAP=/home/ale/dev/QGIS/tests/testdata/qgis_server/test_project_wfs.qgs&amp;SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=testlayer&amp;OUTPUTFORMAT=XMLSCHEMA">
+<gml:boundedBy>
+ <gml:Box srsName="EPSG:4326">
+  <gml:coordinates cs="," ts=" ">8.20345931,44.90139484 8.20354699,44.90148253</gml:coordinates>
+ </gml:Box>
+</gml:boundedBy>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.0">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:4326">
+    <gml:coordinates cs="," ts=" ">8.20349634,44.90148253 8.20349634,44.90148253</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20349634,44.90148253</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>1</qgs:id>
+  <qgs:name>one</qgs:name>
+  <qgs:utf8nameè>one èé</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.1">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:4326">
+    <gml:coordinates cs="," ts=" ">8.20354699,44.90143568 8.20354699,44.90143568</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20354699,44.90143568</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>2</qgs:id>
+  <qgs:name>two</qgs:name>
+  <qgs:utf8nameè>two àò</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.2">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:4326">
+    <gml:coordinates cs="," ts=" ">8.20345931,44.90139484 8.20345931,44.90139484</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20345931,44.90139484</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>3</qgs:id>
+  <qgs:name>three</qgs:name>
+  <qgs:utf8nameè>three èé↓</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+</wfs:FeatureCollection>

--- a/tests/testdata/qgis_server/wfs_getfeature_within3857FilterTemplate_post.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_within3857FilterTemplate_post.txt
@@ -1,55 +1,21 @@
 Content-Type: text/xml; subtype=gml/2.1.2; charset=utf-8
 
-<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd http://www.qgis.org/gml ?MAP=/home/ale/dev/QGIS/tests/testdata/qgis_server/test_project_wfs.qgs&amp;SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=testlayer&amp;OUTPUTFORMAT=XMLSCHEMA">
+<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd http://www.qgis.org/gml ?MAP=/home/ismailsunni/dev/cpp/QGIS/tests/testdata/qgis_server/test_project_wfs.qgs&amp;SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=testlayer&amp;OUTPUTFORMAT=XMLSCHEMA">
 <gml:boundedBy>
- <gml:Box srsName="EPSG:4326">
-  <gml:coordinates cs="," ts=" ">8.20345931,44.90139484 8.20354699,44.90148253</gml:coordinates>
+ <gml:Box srsName="EPSG:3857">
+  <gml:coordinates cs="," ts=" ">916341.08, 4998400.41 916350.94, 4998410.17</gml:coordinates>
  </gml:Box>
 </gml:boundedBy>
 <gml:featureMember>
- <qgs:testlayer fid="testlayer.0">
-  <gml:boundedBy>
-   <gml:Box srsName="EPSG:4326">
-    <gml:coordinates cs="," ts=" ">8.20349634,44.90148253 8.20349634,44.90148253</gml:coordinates>
-   </gml:Box>
-  </gml:boundedBy>
-  <qgs:geometry>
-   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
-    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20349634,44.90148253</coordinates>
-   </Point>
-  </qgs:geometry>
-  <qgs:id>1</qgs:id>
-  <qgs:name>one</qgs:name>
-  <qgs:utf8nameè>one èé</qgs:utf8nameè>
- </qgs:testlayer>
-</gml:featureMember>
-<gml:featureMember>
- <qgs:testlayer fid="testlayer.1">
-  <gml:boundedBy>
-   <gml:Box srsName="EPSG:4326">
-    <gml:coordinates cs="," ts=" ">8.20354699,44.90143568 8.20354699,44.90143568</gml:coordinates>
-   </gml:Box>
-  </gml:boundedBy>
-  <qgs:geometry>
-   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
-    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20354699,44.90143568</coordinates>
-   </Point>
-  </qgs:geometry>
-  <qgs:id>2</qgs:id>
-  <qgs:name>two</qgs:name>
-  <qgs:utf8nameè>two àò</qgs:utf8nameè>
- </qgs:testlayer>
-</gml:featureMember>
-<gml:featureMember>
  <qgs:testlayer fid="testlayer.2">
   <gml:boundedBy>
-   <gml:Box srsName="EPSG:4326">
-    <gml:coordinates cs="," ts=" ">8.20345931,44.90139484 8.20345931,44.90139484</gml:coordinates>
+   <gml:Box srsName="EPSG:3857">
+    <gml:coordinates cs="," ts=" ">916341.08, 4998400.41 916341.08, 4998400.41</gml:coordinates>
    </gml:Box>
   </gml:boundedBy>
   <qgs:geometry>
-   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
-    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20345931,44.90139484</coordinates>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:3857">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">916341.08, 4998400.41</coordinates>
    </Point>
   </qgs:geometry>
   <qgs:id>3</qgs:id>

--- a/tests/testdata/qgis_server/wfs_getfeature_within4326FilterTemplate_post.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_within4326FilterTemplate_post.txt
@@ -1,0 +1,60 @@
+Content-Type: text/xml; subtype=gml/2.1.2; charset=utf-8
+
+<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd http://www.qgis.org/gml ?MAP=/home/ale/dev/QGIS/tests/testdata/qgis_server/test_project_wfs.qgs&amp;SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=testlayer&amp;OUTPUTFORMAT=XMLSCHEMA">
+<gml:boundedBy>
+ <gml:Box srsName="EPSG:4326">
+  <gml:coordinates cs="," ts=" ">8.20345931,44.90139484 8.20354699,44.90148253</gml:coordinates>
+ </gml:Box>
+</gml:boundedBy>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.0">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:4326">
+    <gml:coordinates cs="," ts=" ">8.20349634,44.90148253 8.20349634,44.90148253</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20349634,44.90148253</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>1</qgs:id>
+  <qgs:name>one</qgs:name>
+  <qgs:utf8nameè>one èé</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.1">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:4326">
+    <gml:coordinates cs="," ts=" ">8.20354699,44.90143568 8.20354699,44.90143568</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20354699,44.90143568</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>2</qgs:id>
+  <qgs:name>two</qgs:name>
+  <qgs:utf8nameè>two àò</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.2">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:4326">
+    <gml:coordinates cs="," ts=" ">8.20345931,44.90139484 8.20345931,44.90139484</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20345931,44.90139484</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>3</qgs:id>
+  <qgs:name>three</qgs:name>
+  <qgs:utf8nameè>three èé↓</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+</wfs:FeatureCollection>

--- a/tests/testdata/qgis_server/wfs_getfeature_within4326FilterTemplate_post.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_within4326FilterTemplate_post.txt
@@ -1,45 +1,11 @@
 Content-Type: text/xml; subtype=gml/2.1.2; charset=utf-8
 
-<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd http://www.qgis.org/gml ?MAP=/home/ale/dev/QGIS/tests/testdata/qgis_server/test_project_wfs.qgs&amp;SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=testlayer&amp;OUTPUTFORMAT=XMLSCHEMA">
+<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd http://www.qgis.org/gml ?MAP=/home/ismailsunni/dev/cpp/QGIS/tests/testdata/qgis_server/test_project_wfs.qgs&amp;SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=testlayer&amp;OUTPUTFORMAT=XMLSCHEMA">
 <gml:boundedBy>
  <gml:Box srsName="EPSG:4326">
   <gml:coordinates cs="," ts=" ">8.20345931,44.90139484 8.20354699,44.90148253</gml:coordinates>
  </gml:Box>
 </gml:boundedBy>
-<gml:featureMember>
- <qgs:testlayer fid="testlayer.0">
-  <gml:boundedBy>
-   <gml:Box srsName="EPSG:4326">
-    <gml:coordinates cs="," ts=" ">8.20349634,44.90148253 8.20349634,44.90148253</gml:coordinates>
-   </gml:Box>
-  </gml:boundedBy>
-  <qgs:geometry>
-   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
-    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20349634,44.90148253</coordinates>
-   </Point>
-  </qgs:geometry>
-  <qgs:id>1</qgs:id>
-  <qgs:name>one</qgs:name>
-  <qgs:utf8nameè>one èé</qgs:utf8nameè>
- </qgs:testlayer>
-</gml:featureMember>
-<gml:featureMember>
- <qgs:testlayer fid="testlayer.1">
-  <gml:boundedBy>
-   <gml:Box srsName="EPSG:4326">
-    <gml:coordinates cs="," ts=" ">8.20354699,44.90143568 8.20354699,44.90143568</gml:coordinates>
-   </gml:Box>
-  </gml:boundedBy>
-  <qgs:geometry>
-   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
-    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20354699,44.90143568</coordinates>
-   </Point>
-  </qgs:geometry>
-  <qgs:id>2</qgs:id>
-  <qgs:name>two</qgs:name>
-  <qgs:utf8nameè>two àò</qgs:utf8nameè>
- </qgs:testlayer>
-</gml:featureMember>
 <gml:featureMember>
  <qgs:testlayer fid="testlayer.2">
   <gml:boundedBy>


### PR DESCRIPTION
## Description

This PR is addressing this discussion: https://github.com/qgis/QGIS/pull/36926#discussion_r435711557

There are two unit test added:
1. WFS request with the same SRSname as in the project (i.e. 4326)
    This unit test is used to make sure that the request is working fine.
2. WFS request with the different SRSname (3857) to 4326 project.
    This request doesn't return any feature, although the coordinates are converted/projected from the 4326's coordinates. The expected/reference files can be wrong since I am not sure what's is the correct format would be. I only know that it shouldn't be empty.

Note: I removed the previous unit test that uses 4326's coordinates but SRS 3857. I use it to show that the SRSname is not considered in the request and it still returns features although the coordinates do not make sense in 3857.

cc @elpaso 

I will add the expected error after Travis finished checking (to see the failed test first.)

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
