### PR TITLE
[server] Preserve DPI for all image output formats

### DIFF
--- a/src/server/services/wms/qgswmsutils.cpp
+++ b/src/server/services/wms/qgswmsutils.cpp
@@ -152,6 +152,10 @@ namespace QgsWms
         break;
     }
 
+    // Preserve DPI, some conversions, in particular the one for 8bit will drop this information
+    result.setDotsPerMeterX( img.dotsPerMeterX() );
+    result.setDotsPerMeterY( img.dotsPerMeterY() );
+
     if ( outputFormat != UNKN )
     {
       response.setHeader( "Content-Type", contentType );

--- a/tests/src/python/test_qgsserver_wms_getmap.py
+++ b/tests/src/python/test_qgsserver_wms_getmap.py
@@ -241,8 +241,8 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self._img_diff_error(r, h, "WMS_GetMap_Basic5")
         img = QImage.fromData(r, "PNG")
-        self.assertEqual(img.dotsPerMeterX(), 4409)
-        self.assertEqual(img.dotsPerMeterY(), 4409)
+        self.assertEqual(round(img.dotsPerMeterX() / 39.37, 1), 112.5)
+        self.assertEqual(round(img.dotsPerMeterY() / 39.37, 1), 112.5)
 
     def test_wms_getmap_dpi_png_8bit(self):
         qs = "?" + "&".join(["%s=%s" % i for i in list({
@@ -252,7 +252,7 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
             "REQUEST": "GetMap",
             "LAYERS": "Country",
             "STYLES": "",
-            "FORMAT": "image/png",
+            "FORMAT": "image/png; mode=8bit",
             "BBOX": "-16817707,-4710778,5696513,14587125",
             "HEIGHT": "500",
             "WIDTH": "500",
@@ -262,8 +262,8 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
 
         r, h = self._result(self._execute_request(qs))
         img = QImage.fromData(r, "PNG")
-        self.assertEqual(img.dotsPerMeterX(), 4409)
-        self.assertEqual(img.dotsPerMeterY(), 4409)
+        self.assertEqual(round(img.dotsPerMeterX() / 39.37, 1), 112.5)
+        self.assertEqual(round(img.dotsPerMeterY() / 39.37, 1), 112.5)
 
     def test_wms_getmap_invalid_parameters(self):
         # invalid format

--- a/tests/src/python/test_qgsserver_wms_getmap.py
+++ b/tests/src/python/test_qgsserver_wms_getmap.py
@@ -26,6 +26,7 @@ import urllib.error
 
 from qgis.testing import unittest
 from qgis.PyQt.QtCore import QSize
+from qgis.PyQt.QtGui import QImage
 
 import osgeo.gdal  # NOQA
 
@@ -239,6 +240,30 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
 
         r, h = self._result(self._execute_request(qs))
         self._img_diff_error(r, h, "WMS_GetMap_Basic5")
+        img = QImage.fromData(r, "PNG")
+        self.assertEqual(img.dotsPerMeterX(), 4409)
+        self.assertEqual(img.dotsPerMeterY(), 4409)
+
+    def test_wms_getmap_dpi_png_8bit(self):
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WMS",
+            "VERSION": "1.1.1",
+            "REQUEST": "GetMap",
+            "LAYERS": "Country",
+            "STYLES": "",
+            "FORMAT": "image/png",
+            "BBOX": "-16817707,-4710778,5696513,14587125",
+            "HEIGHT": "500",
+            "WIDTH": "500",
+            "CRS": "EPSG:3857",
+            "DPI": "112.5"
+        }.items())])
+
+        r, h = self._result(self._execute_request(qs))
+        img = QImage.fromData(r, "PNG")
+        self.assertEqual(img.dotsPerMeterX(), 4409)
+        self.assertEqual(img.dotsPerMeterY(), 4409)
 
     def test_wms_getmap_invalid_parameters(self):
         # invalid format


### PR DESCRIPTION
In particular for image/png;mode=8bit

Followup https://github.com/qgis/QGIS/pull/36302