### PR TITLE
Do not show crs validation dialog for extra snapping layer

### DIFF
--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -51,7 +51,9 @@ QgsMapToolCapture::QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizin
   connect( canvas, &QgsMapCanvas::currentLayerChanged,
            this, &QgsMapToolCapture::currentLayerChanged );
 
-  mExtraSnapLayer = new QgsVectorLayer( "LineString?crs=0", "extra snap", "memory" );
+  QgsVectorLayer::LayerOptions layerOptions;
+  layerOptions.skipCrsValidation = true;
+  mExtraSnapLayer = new QgsVectorLayer( "LineString?crs=0", "extra snap", "memory", layerOptions );
   mExtraSnapLayer->startEditing();
   QgsFeature f;
   mExtraSnapLayer->addFeature( f );

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -53,7 +53,7 @@ QgsMapToolCapture::QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizin
 
   QgsVectorLayer::LayerOptions layerOptions;
   layerOptions.skipCrsValidation = true;
-  mExtraSnapLayer = new QgsVectorLayer( "LineString?crs=0", "extra snap", "memory", layerOptions );
+  mExtraSnapLayer = new QgsVectorLayer( QStringLiteral( "LineString?crs=0" ), QStringLiteral( "extra snap" ), QStringLiteral( "memory" ), layerOptions );
   mExtraSnapLayer->startEditing();
   QgsFeature f;
   mExtraSnapLayer->addFeature( f );


### PR DESCRIPTION
It is set to an invalid CRS (== map canvas CRS) on purpose

Fixes #37045
