### PR TITLE
Fix incorrect label placement after moving an 'unplaced' label

### DIFF
--- a/src/app/labeling/qgsmaptoollabel.cpp
+++ b/src/app/labeling/qgsmaptoollabel.cpp
@@ -512,11 +512,19 @@ bool QgsMapToolLabel::currentLabelDataDefinedPosition( double &x, bool &xSuccess
     return false;
   }
 
-  QgsAttributes attributes = f.attributes();
-  if ( !attributes.at( xCol ).isNull() )
-    x = attributes.at( xCol ).toDouble( &xSuccess );
-  if ( !attributes.at( yCol ).isNull() )
-    y = attributes.at( yCol ).toDouble( &ySuccess );
+  if ( mCurrentLabel.pos.isUnplaced )
+  {
+    xSuccess = false;
+    ySuccess = false;
+  }
+  else
+  {
+    QgsAttributes attributes = f.attributes();
+    if ( !attributes.at( xCol ).isNull() )
+      x = attributes.at( xCol ).toDouble( &xSuccess );
+    if ( !attributes.at( yCol ).isNull() )
+      y = attributes.at( yCol ).toDouble( &ySuccess );
+  }
 
   return true;
 }


### PR DESCRIPTION
For unplaced labels, we can't calculate the new position relative to
the original stored label placement, because we're not actually
showing the 'unplaced' label at the stored position...
