### PR TITLE
Fix OGC utils filter srsName

### DIFF
--- a/python/core/auto_generated/qgsogcutils.sip.in
+++ b/python/core/auto_generated/qgsogcutils.sip.in
@@ -43,7 +43,7 @@ Constructs a Context from ``layer`` and ``transformContext``
       GML_3_2_1,
     };
 
-    static QgsGeometry geometryFromGML( const QString &xmlString, const Context &context = Context() );
+    static QgsGeometry geometryFromGML( const QString &xmlString, const QgsOgcUtils::Context &context = QgsOgcUtils::Context() );
 %Docstring
 Static method that creates geometry from GML
 
@@ -53,7 +53,7 @@ Static method that creates geometry from GML
 :param context: QgsOgcUtils context
 %End
 
-    static QgsGeometry geometryFromGML( const QDomNode &geometryNode, const Context &context = Context() );
+    static QgsGeometry geometryFromGML( const QDomNode &geometryNode, const QgsOgcUtils::Context &context = QgsOgcUtils::Context() );
 %Docstring
 Static method that creates geometry from GML
 %End

--- a/python/core/auto_generated/qgsogcutils.sip.in
+++ b/python/core/auto_generated/qgsogcutils.sip.in
@@ -25,6 +25,17 @@ Currently supported standards:
 %End
   public:
 
+    struct Context
+    {
+
+      Context( const QgsMapLayer *layer = 0, const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext() );
+%Docstring
+Constructs a Context from ``layer`` and ``transformContext``
+%End
+      const QgsMapLayer *layer;
+      QgsCoordinateTransformContext transformContext;
+    };
+
     enum GMLVersion
     {
       GML_2_1_2,
@@ -32,16 +43,17 @@ Currently supported standards:
       GML_3_2_1,
     };
 
-    static QgsGeometry geometryFromGML( const QString &xmlString );
+    static QgsGeometry geometryFromGML( const QString &xmlString, const Context &context = Context() );
 %Docstring
 Static method that creates geometry from GML
 
 :param xmlString: xml representation of the geometry. GML elements are expected to be
                   in default namespace (\verbatim {<Point>...</Point> \endverbatim) or in
                   "gml" namespace (\verbatim <gml:Point>...</gml:Point> \endverbatim)
+:param context: QgsOgcUtils context
 %End
 
-    static QgsGeometry geometryFromGML( const QDomNode &geometryNode );
+    static QgsGeometry geometryFromGML( const QDomNode &geometryNode, const Context &context = Context() );
 %Docstring
 Static method that creates geometry from GML
 %End

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -3122,10 +3122,20 @@ static QVariant fcnGeomFromWKB( const QVariantList &values, const QgsExpressionC
   return !geom.isNull() ? QVariant::fromValue( geom ) : QVariant();
 }
 
-static QVariant fcnGeomFromGML( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnGeomFromGML( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString gml = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
-  QgsGeometry geom = QgsOgcUtils::geometryFromGML( gml );
+  QgsOgcUtils::Context ogcContext;
+  if ( context )
+  {
+    QgsWeakMapLayerPointer mapLayerPtr {context->variable( QStringLiteral( "layer" ) ).value<QgsWeakMapLayerPointer>() };
+    if ( mapLayerPtr )
+    {
+      ogcContext.layer = mapLayerPtr.data();
+      ogcContext.transformContext = context->variable( QStringLiteral( "_project_transform_context" ) ).value<QgsCoordinateTransformContext>();
+    }
+  }
+  QgsGeometry geom = QgsOgcUtils::geometryFromGML( gml, ogcContext );
   QVariant result = !geom.isNull() ? QVariant::fromValue( geom ) : QVariant();
   return result;
 }

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -51,6 +51,25 @@ class CORE_EXPORT QgsOgcUtils
   public:
 
     /**
+     * The Context struct stores the current layer and coordinate transform context.
+     * \since QGIS 3.14
+     */
+    struct Context
+    {
+
+      /**
+       * Constructs a Context from \a layer and \a transformContext
+       */
+      Context( const QgsMapLayer *layer = nullptr, const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext() )
+        : layer( layer )
+        , transformContext( transformContext )
+      {
+      }
+      const QgsMapLayer *layer = nullptr;
+      QgsCoordinateTransformContext transformContext;
+    };
+
+    /**
      *GML version
      */
     enum GMLVersion
@@ -62,16 +81,17 @@ class CORE_EXPORT QgsOgcUtils
 
     /**
      * Static method that creates geometry from GML
-     \param xmlString xml representation of the geometry. GML elements are expected to be
-       in default namespace (\verbatim {<Point>...</Point> \endverbatim) or in
-       "gml" namespace (\verbatim <gml:Point>...</gml:Point> \endverbatim)
+     * \param xmlString xml representation of the geometry. GML elements are expected to be
+     *  in default namespace (\verbatim {<Point>...</Point> \endverbatim) or in
+     *  "gml" namespace (\verbatim <gml:Point>...</gml:Point> \endverbatim)
+     * \param context QgsOgcUtils context
      */
-    static QgsGeometry geometryFromGML( const QString &xmlString );
+    static QgsGeometry geometryFromGML( const QString &xmlString, const Context &context = Context() );
 
     /**
      * Static method that creates geometry from GML
       */
-    static QgsGeometry geometryFromGML( const QDomNode &geometryNode );
+    static QgsGeometry geometryFromGML( const QDomNode &geometryNode, const Context &context = Context() );
 
     //! Read rectangle from GML2 Box
     static QgsRectangle rectangleFromGMLBox( const QDomNode &boxNode );
@@ -279,7 +299,8 @@ class CORE_EXPORT QgsOgcUtils
      * Reads the \verbatim <gml:coordinates> \endverbatim element and extracts the coordinates as points
        \param coords list where the found coordinates are appended
        \param elem the \verbatim <gml:coordinates> \endverbatim element
-       \returns boolean for success*/
+       \returns boolean FALSE on success
+    */
     static bool readGMLCoordinates( QgsPolylineXY &coords, const QDomElement &elem );
 
     /**
@@ -288,7 +309,8 @@ class CORE_EXPORT QgsOgcUtils
        \param coords list where the found coordinates are appended
        \param elem the \verbatim <gml:pos> \endverbatim or
                     \verbatim <gml:posList> \endverbatim element
-       \returns boolean for success*/
+       \returns boolean FALSE on success
+     */
     static bool readGMLPositions( QgsPolylineXY &coords, const QDomElement &elem );
 
 

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -86,12 +86,12 @@ class CORE_EXPORT QgsOgcUtils
      *  "gml" namespace (\verbatim <gml:Point>...</gml:Point> \endverbatim)
      * \param context QgsOgcUtils context
      */
-    static QgsGeometry geometryFromGML( const QString &xmlString, const Context &context = Context() );
+    static QgsGeometry geometryFromGML( const QString &xmlString, const QgsOgcUtils::Context &context = QgsOgcUtils::Context() );
 
     /**
      * Static method that creates geometry from GML
       */
-    static QgsGeometry geometryFromGML( const QDomNode &geometryNode, const Context &context = Context() );
+    static QgsGeometry geometryFromGML( const QDomNode &geometryNode, const QgsOgcUtils::Context &context = QgsOgcUtils::Context() );
 
     //! Read rectangle from GML2 Box
     static QgsRectangle rectangleFromGMLBox( const QDomNode &boxNode );

--- a/src/server/services/wfs/qgswfsutils.cpp
+++ b/src/server/services/wfs/qgswfsutils.cpp
@@ -100,14 +100,14 @@ namespace QgsWfs
     return nullptr;
   }
 
-  QgsFeatureRequest parseFilterElement( const QString &typeName, QDomElement &filterElem, const QgsProject *project )
+  QgsFeatureRequest parseFilterElement( const QString &typeName, QDomElement &filterElem, QgsProject *project )
   {
     // Get the server feature ids in filter element
     QStringList collectedServerFids;
     return parseFilterElement( typeName, filterElem, collectedServerFids, project );
   }
 
-  QgsFeatureRequest parseFilterElement( const QString &typeName, QDomElement &filterElem, QStringList &serverFids, const QgsProject *project )
+  QgsFeatureRequest parseFilterElement( const QString &typeName, QDomElement &filterElem, QStringList &serverFids, const QgsProject *project, const QgsMapLayer *layer )
   {
     QgsFeatureRequest request;
 
@@ -147,7 +147,7 @@ namespace QgsWfs
     }
     else if ( !goidNodes.isEmpty() )
     {
-      // Get the server feature idsin filter element
+      // Get the server feature ids in filter element
       QStringList collectedServerFids;
       QDomElement goidElem;
       for ( int f = 0; f < goidNodes.size(); f++ )
@@ -192,7 +192,8 @@ namespace QgsWfs
         }
         else if ( childElem.tagName() != QLatin1String( "PropertyName" ) )
         {
-          QgsGeometry geom = QgsOgcUtils::geometryFromGML( childElem );
+          QgsOgcUtils::Context ctx { layer, project ? project->transformContext() : QgsCoordinateTransformContext() };
+          QgsGeometry geom = QgsOgcUtils::geometryFromGML( childElem, ctx );
           request.setFilterRect( geom.boundingBox() );
         }
         childElem = childElem.nextSiblingElement();

--- a/src/server/services/wfs/qgswfsutils.h
+++ b/src/server/services/wfs/qgswfsutils.h
@@ -60,12 +60,12 @@ namespace QgsWfs
   /**
    * Transform a Filter element to a feature request
    */
-  QgsFeatureRequest parseFilterElement( const QString &typeName, QDomElement &filterElem, const QgsProject *project = nullptr );
+  QgsFeatureRequest parseFilterElement( const QString &typeName, QDomElement &filterElem, QgsProject *project = nullptr );
 
   /**
    * Transform a Filter element to a feature request and update server feature ids
    */
-  QgsFeatureRequest parseFilterElement( const QString &typeName, QDomElement &filterElem, QStringList &serverFids, const QgsProject *project = nullptr );
+  QgsFeatureRequest parseFilterElement( const QString &typeName, QDomElement &filterElem, QStringList &serverFids, const QgsProject *project = nullptr, const QgsMapLayer *layer = nullptr );
 
   // Define namespaces used in WFS documents
   const QString WFS_NAMESPACE = QStringLiteral( "http://www.opengis.net/wfs" );

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -257,6 +257,62 @@ class TestQgsServerWFS(QgsServerTestBase):
 """
         tests.append(('srsname_post', srsTemplate.format("")))
 
+        # Issue https://github.com/qgis/QGIS/issues/36398
+        # Check get feature within polygon having srsName=EPSG:4326 (same as the project/layer)
+        within4326FilterTemplate = """<?xml version="1.0" encoding="UTF-8"?>
+<wfs:GetFeature service="WFS" version="1.0.0" {} xmlns:wfs="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+  <wfs:Query typeName="testlayer" srsName="EPSG:4326" xmlns:feature="http://www.qgis.org/gml">
+    <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+      <Within>
+        <PropertyName>geometry</PropertyName>
+        <Polygon xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+          <exterior>
+            <LinearRing>
+              <posList srsDimension="2">
+                8.20344131 44.90137909
+                8.20347748 44.90137909
+                8.20347748 44.90141005
+                8.20344131 44.90141005
+                8.20344131 44.90137909
+              </posList>
+            </LinearRing>
+          </exterior>
+        </Polygon>
+      </Within>
+    </ogc:Filter>
+  </wfs:Query>
+</wfs:GetFeature>
+"""
+        tests.append(('within4326FilterTemplate_post', within4326FilterTemplate.format("")))
+
+        # Check get feature within polygon having srsName=EPSG:3857 (different from the project/layer)
+        # The coordinates are converted from the one in 4326
+        within3857FilterTemplate = """<?xml version="1.0" encoding="UTF-8"?>
+<wfs:GetFeature service="WFS" version="1.0.0" {} xmlns:wfs="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+  <wfs:Query typeName="testlayer" srsName="EPSG:3857" xmlns:feature="http://www.qgis.org/gml">
+    <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+      <Within>
+        <PropertyName>geometry</PropertyName>
+        <Polygon xmlns="http://www.opengis.net/gml" srsName="EPSG:3857">
+          <exterior>
+            <LinearRing>
+              <posList srsDimension="2">
+              913202.90938171 5606008.98136456
+              913206.93580769 5606008.98136456
+              913206.93580769 5606013.84701639
+              913202.90938171 5606013.84701639
+              913202.90938171 5606008.98136456
+              </posList>
+            </LinearRing>
+          </exterior>
+        </Polygon>
+      </Within>
+    </ogc:Filter>
+  </wfs:Query>
+</wfs:GetFeature>
+"""
+        tests.append(('within3857FilterTemplate_post', within3857FilterTemplate.format("")))
+
         srsTwoLayersTemplate = """<?xml version="1.0" encoding="UTF-8"?>
 <wfs:GetFeature service="WFS" version="1.0.0" {} xmlns:wfs="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
   <wfs:Query typeName="testlayer" srsName="EPSG:3857" xmlns:feature="http://www.qgis.org/gml">

--- a/tests/testdata/qgis_server/wfs_getfeature_within3857FilterTemplate_post.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_within3857FilterTemplate_post.txt
@@ -1,0 +1,26 @@
+Content-Type: text/xml; subtype=gml/2.1.2; charset=utf-8
+
+<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd http://www.qgis.org/gml ?">
+<gml:boundedBy>
+ <gml:Box srsName="EPSG:4326">
+  <gml:coordinates cs="," ts=" ">8.20345931,44.90139484 8.20354699,44.90148253</gml:coordinates>
+ </gml:Box>
+</gml:boundedBy>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.2">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:3857">
+    <gml:coordinates cs="," ts=" ">913204.91280263,5606011.45647302 913204.91280263,5606011.45647302</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:3857">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">913204.91280263,5606011.45647302</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>3</qgs:id>
+  <qgs:name>three</qgs:name>
+  <qgs:utf8nameè>three èé↓</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+</wfs:FeatureCollection>

--- a/tests/testdata/qgis_server/wfs_getfeature_within4326FilterTemplate_post.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_within4326FilterTemplate_post.txt
@@ -1,0 +1,26 @@
+Content-Type: text/xml; subtype=gml/2.1.2; charset=utf-8
+
+<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd http://www.qgis.org/gml ?">
+<gml:boundedBy>
+ <gml:Box srsName="EPSG:4326">
+  <gml:coordinates cs="," ts=" ">8.20345931,44.90139484 8.20354699,44.90148253</gml:coordinates>
+ </gml:Box>
+</gml:boundedBy>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.2">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:4326">
+    <gml:coordinates cs="," ts=" ">8.20345931,44.90139484 8.20345931,44.90139484</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20345931,44.90139484</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>3</qgs:id>
+  <qgs:name>three</qgs:name>
+  <qgs:utf8nameè>three èé↓</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+</wfs:FeatureCollection>


### PR DESCRIPTION
Adds a layer + coordinateTransform context to pass
to the ogc utils functions that read the GML geometry
so that it can be transformed to layer's CRS when
constructing the feature filter.

Fixes #36398

@ismailsunni : thank you for the test!
See: https://github.com/qgis/QGIS/pull/37035

Side note: in the server code there are other places (`Envelope`?) where a GML geometry transformation could be used but they require a QgsMapLayer instance that it is only determined from the `typename` at a later stage, implementation requires a bit of refactoring that is out of scope for a bugfix.
