### PR TITLE
Some fixes relating to Triangle geometry handling

### DIFF
--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -189,9 +189,18 @@ Sets the geometry from a WKT string.
 %End
 
 
-    virtual QByteArray asWkb() const = 0;
+    enum WkbFlag
+    {
+      FlagExportTrianglesAsPolygons,
+    };
+    typedef QFlags<QgsAbstractGeometry::WkbFlag> WkbFlags;
+
+
+    virtual QByteArray asWkb( WkbFlags flags = 0 ) const = 0;
 %Docstring
 Returns a WKB representation of the geometry.
+
+The optional ``flags`` argument specifies flags controlling WKB export behavior (since QGIS 3.14).
 
 .. seealso:: :py:func:`asWkt`
 
@@ -990,6 +999,9 @@ Returns next part of the geometry (undefined behavior if hasNext() returns ``Fal
 %End
 
 };
+
+QFlags<QgsAbstractGeometry::WkbFlag> operator|(QgsAbstractGeometry::WkbFlag f1, QFlags<QgsAbstractGeometry::WkbFlag> f2);
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -71,7 +71,7 @@ to ``p2`` will be used (i.e. winding the other way around the circle).
     virtual bool fromWkt( const QString &wkt );
 
 
-    virtual QByteArray asWkb() const;
+    virtual QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = 0 ) const;
 
     virtual QString asWkt( int precision = 17 ) const;
 

--- a/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
@@ -42,7 +42,7 @@ Compound curve geometry type
     virtual bool fromWkt( const QString &wkt );
 
 
-    virtual QByteArray asWkb() const;
+    virtual QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = 0 ) const;
 
     virtual QString asWkt( int precision = 17 ) const;
 

--- a/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -46,7 +46,7 @@ Curve polygon geometry type
     virtual bool fromWkt( const QString &wkt );
 
 
-    virtual QByteArray asWkb() const;
+    virtual QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = 0 ) const;
 
     virtual QString asWkt( int precision = 17 ) const;
 

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1522,9 +1522,11 @@ is null, a ValueError will be raised.
 
 
 
-    QByteArray asWkb() const;
+    QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = 0 ) const;
 %Docstring
 Export the geometry to WKB
+
+The optional ``flags`` argument specifies flags controlling WKB export behavior (since QGIS 3.14).
 
 .. versionadded:: 3.0
 %End

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -154,7 +154,7 @@ An IndexError will be raised if no geometry with the specified index exists.
 
     virtual bool fromWkt( const QString &wkt );
 
-    virtual QByteArray asWkb() const;
+    virtual QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = 0 ) const;
 
     virtual QString asWkt( int precision = 17 ) const;
 

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -424,7 +424,7 @@ segment in the line.
     virtual bool fromWkt( const QString &wkt );
 
 
-    virtual QByteArray asWkb() const;
+    virtual QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = 0 ) const;
 
     virtual QString asWkt( int precision = 17 ) const;
 

--- a/python/core/auto_generated/geometry/qgspoint.sip.in
+++ b/python/core/auto_generated/geometry/qgspoint.sip.in
@@ -367,7 +367,7 @@ M value is preserved.
 
     virtual bool fromWkt( const QString &wkt );
 
-    virtual QByteArray asWkb() const;
+    virtual QByteArray asWkb( QgsAbstractGeometry::WkbFlags = 0 ) const;
 
     virtual QString asWkt( int precision = 17 ) const;
 

--- a/python/core/auto_generated/geometry/qgspolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgspolygon.sip.in
@@ -41,7 +41,7 @@ Ownership of ``exterior`` and ``rings`` is transferred to the polygon.
 
     virtual bool fromWkb( QgsConstWkbPtr &wkb );
 
-    virtual QByteArray asWkb() const;
+    virtual QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = 0 ) const;
 
     virtual QgsPolygon *surfaceToPolygon() const /Factory/;
 

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -239,14 +239,27 @@ class CORE_EXPORT QgsAbstractGeometry
     //export
 
     /**
+     * WKB export flags.
+     * \since QGIS 3.14
+     */
+    enum WkbFlag
+    {
+      FlagExportTrianglesAsPolygons = 1 << 0, //!< Triangles should be exported as polygon geometries
+    };
+    Q_DECLARE_FLAGS( WkbFlags, WkbFlag )
+
+    /**
      * Returns a WKB representation of the geometry.
+     *
+     * The optional \a flags argument specifies flags controlling WKB export behavior (since QGIS 3.14).
+     *
      * \see asWkt
      * \see asGml2
      * \see asGml3
      * \see asJson()
      * \since QGIS 3.0
      */
-    virtual QByteArray asWkb() const = 0;
+    virtual QByteArray asWkb( WkbFlags flags = nullptr ) const = 0;
 
     /**
      * Returns a WKT representation of the geometry.
@@ -1233,5 +1246,7 @@ class CORE_EXPORT QgsGeometryConstPartIterator
     QgsAbstractGeometry::const_part_iterator i, n;
 
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsAbstractGeometry::WkbFlags )
 
 #endif //QGSABSTRACTGEOMETRYV2

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -321,7 +321,7 @@ bool QgsCircularString::fromWkt( const QString &wkt )
   return true;
 }
 
-QByteArray QgsCircularString::asWkb() const
+QByteArray QgsCircularString::asWkb( WkbFlags ) const
 {
   int binarySize = sizeof( char ) + sizeof( quint32 ) + sizeof( quint32 );
   binarySize += numPoints() * ( 2 + is3D() + isMeasure() ) * sizeof( double );

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -75,7 +75,7 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
     bool fromWkb( QgsConstWkbPtr &wkb ) override;
     bool fromWkt( const QString &wkt ) override;
 
-    QByteArray asWkb() const override;
+    QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = nullptr ) const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -224,14 +224,14 @@ bool QgsCompoundCurve::fromWkt( const QString &wkt )
   return true;
 }
 
-QByteArray QgsCompoundCurve::asWkb() const
+QByteArray QgsCompoundCurve::asWkb( WkbFlags flags ) const
 {
   int binarySize = sizeof( char ) + sizeof( quint32 ) + sizeof( quint32 );
   QVector<QByteArray> wkbForCurves;
   wkbForCurves.reserve( mCurves.size() );
   for ( const QgsCurve *curve : mCurves )
   {
-    QByteArray wkbForCurve = curve->asWkb();
+    QByteArray wkbForCurve = curve->asWkb( flags );
     binarySize += wkbForCurve.length();
     wkbForCurves << wkbForCurve;
   }

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -46,7 +46,7 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
     bool fromWkb( QgsConstWkbPtr &wkb ) override;
     bool fromWkt( const QString &wkt ) override;
 
-    QByteArray asWkb() const override;
+    QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = nullptr ) const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -285,20 +285,20 @@ QgsRectangle QgsCurvePolygon::calculateBoundingBox() const
   return QgsRectangle();
 }
 
-QByteArray QgsCurvePolygon::asWkb() const
+QByteArray QgsCurvePolygon::asWkb( WkbFlags flags ) const
 {
   int binarySize = sizeof( char ) + sizeof( quint32 ) + sizeof( quint32 );
   QVector<QByteArray> wkbForRings;
   wkbForRings.reserve( 1 + mInteriorRings.size() );
   if ( mExteriorRing )
   {
-    QByteArray wkb( mExteriorRing->asWkb() );
+    QByteArray wkb( mExteriorRing->asWkb( flags ) );
     binarySize += wkb.length();
     wkbForRings << wkb;
   }
   for ( const QgsCurve *curve : mInteriorRings )
   {
-    QByteArray wkb( curve->asWkb() );
+    QByteArray wkb( curve->asWkb( flags ) );
     binarySize += wkb.length();
     wkbForRings << wkb;
   }

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -51,7 +51,7 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     bool fromWkb( QgsConstWkbPtr &wkb ) override;
     bool fromWkt( const QString &wkt ) override;
 
-    QByteArray asWkb() const override;
+    QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = nullptr ) const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2507,9 +2507,9 @@ QVector<QgsPointXY> QgsGeometry::randomPointsInPolygon( int count, unsigned long
 }
 ///@endcond
 
-QByteArray QgsGeometry::asWkb() const
+QByteArray QgsGeometry::asWkb( QgsAbstractGeometry::WkbFlags flags ) const
 {
-  return d->geometry ? d->geometry->asWkb() : QByteArray();
+  return d->geometry ? d->geometry->asWkb( flags ) : QByteArray();
 }
 
 QVector<QgsGeometry> QgsGeometry::asGeometryCollection() const

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1544,9 +1544,12 @@ class CORE_EXPORT QgsGeometry
 
     /**
      * Export the geometry to WKB
+     *
+     * The optional \a flags argument specifies flags controlling WKB export behavior (since QGIS 3.14).
+     *
      * \since QGIS 3.0
      */
-    QByteArray asWkb() const;
+    QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = nullptr ) const;
 
     /**
      * Exports the geometry to WKT

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -357,7 +357,7 @@ bool QgsGeometryCollection::fromWkt( const QString &wkt )
                             << new QgsMultiCurve << new QgsMultiSurface, QStringLiteral( "GeometryCollection" ) );
 }
 
-QByteArray QgsGeometryCollection::asWkb() const
+QByteArray QgsGeometryCollection::asWkb( WkbFlags flags ) const
 {
   int binarySize = sizeof( char ) + sizeof( quint32 ) + sizeof( quint32 );
   QVector<QByteArray> wkbForGeometries;
@@ -365,7 +365,7 @@ QByteArray QgsGeometryCollection::asWkb() const
   {
     if ( geom )
     {
-      QByteArray wkb( geom->asWkb() );
+      QByteArray wkb( geom->asWkb( flags ) );
       binarySize += wkb.length();
       wkbForGeometries << wkb;
     }

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -179,7 +179,7 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
 
     bool fromWkb( QgsConstWkbPtr &wkb ) override;
     bool fromWkt( const QString &wkt ) override;
-    QByteArray asWkb() const override;
+    QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = nullptr ) const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;

--- a/src/core/geometry/qgsgeometryeditutils.cpp
+++ b/src/core/geometry/qgsgeometryeditutils.cpp
@@ -138,6 +138,7 @@ QgsGeometry::OperationResult QgsGeometryEditUtils::addPart( QgsAbstractGeometry 
       added = geomCollection->addGeometry( poly.release() );
     }
     else if ( QgsWkbTypes::flatType( part->wkbType() ) == QgsWkbTypes::Polygon
+              || QgsWkbTypes::flatType( part->wkbType() ) == QgsWkbTypes::Triangle
               || QgsWkbTypes::flatType( part->wkbType() ) == QgsWkbTypes::CurvePolygon )
     {
       added = geomCollection->addGeometry( part.release() );

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -441,7 +441,7 @@ bool QgsLineString::fromWkt( const QString &wkt )
   return true;
 }
 
-QByteArray QgsLineString::asWkb() const
+QByteArray QgsLineString::asWkb( WkbFlags ) const
 {
   int binarySize = sizeof( char ) + sizeof( quint32 ) + sizeof( quint32 );
   binarySize += numPoints() * ( 2 + is3D() + isMeasure() ) * sizeof( double );

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -588,7 +588,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     bool fromWkb( QgsConstWkbPtr &wkb ) override;
     bool fromWkt( const QString &wkt ) override;
 
-    QByteArray asWkb() const override;
+    QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = nullptr ) const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -209,7 +209,7 @@ bool QgsPoint::fromWkt( const QString &wkt )
  * See details in QEP #17
  ****************************************************************************/
 
-QByteArray QgsPoint::asWkb() const
+QByteArray QgsPoint::asWkb( WkbFlags ) const
 {
   int binarySize = sizeof( char ) + sizeof( quint32 );
   binarySize += ( 2 + is3D() + isMeasure() ) * sizeof( double );

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -489,7 +489,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
     void clear() override;
     bool fromWkb( QgsConstWkbPtr &wkb ) override;
     bool fromWkt( const QString &wkt ) override;
-    QByteArray asWkb() const override;
+    QByteArray asWkb( QgsAbstractGeometry::WkbFlags = nullptr ) const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;

--- a/src/core/geometry/qgspolygon.cpp
+++ b/src/core/geometry/qgspolygon.cpp
@@ -121,7 +121,7 @@ bool QgsPolygon::fromWkb( QgsConstWkbPtr &wkbPtr )
   return true;
 }
 
-QByteArray QgsPolygon::asWkb() const
+QByteArray QgsPolygon::asWkb( QgsAbstractGeometry::WkbFlags flags ) const
 {
   int binarySize = sizeof( char ) + sizeof( quint32 ) + sizeof( quint32 );
 
@@ -139,7 +139,30 @@ QByteArray QgsPolygon::asWkb() const
   wkbArray.resize( binarySize );
   QgsWkbPtr wkb( wkbArray );
   wkb << static_cast<char>( QgsApplication::endian() );
-  wkb << static_cast<quint32>( wkbType() );
+
+  QgsWkbTypes::Type type = wkbType();
+  if ( flags & FlagExportTrianglesAsPolygons )
+  {
+    switch ( type )
+    {
+      case QgsWkbTypes::Triangle:
+        type = QgsWkbTypes::Polygon;
+        break;
+      case QgsWkbTypes::TriangleZ:
+        type = QgsWkbTypes::PolygonZ;
+        break;
+      case QgsWkbTypes::TriangleM:
+        type = QgsWkbTypes::PolygonM;
+        break;
+      case QgsWkbTypes::TriangleZM:
+        type = QgsWkbTypes::PolygonZM;
+        break;
+      default:
+        break;
+    }
+  }
+  wkb << static_cast<quint32>( type );
+
   wkb << static_cast<quint32>( ( nullptr != mExteriorRing ) + mInteriorRings.size() );
   if ( mExteriorRing )
   {

--- a/src/core/geometry/qgspolygon.h
+++ b/src/core/geometry/qgspolygon.h
@@ -48,7 +48,7 @@ class CORE_EXPORT QgsPolygon: public QgsCurvePolygon
     QgsPolygon *clone() const override SIP_FACTORY;
     void clear() override;
     bool fromWkb( QgsConstWkbPtr &wkb ) override;
-    QByteArray asWkb() const override;
+    QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = nullptr ) const override;
     QgsPolygon *surfaceToPolygon() const override SIP_FACTORY;
 
     /**

--- a/src/core/geometry/qgswkbtypes.h
+++ b/src/core/geometry/qgswkbtypes.h
@@ -303,11 +303,20 @@ class CORE_EXPORT QgsWkbTypes
       switch ( type )
       {
         case Unknown:
-        case Triangle:
-        case TriangleZ:
-        case TriangleM:
-        case TriangleZM:
           return Unknown;
+
+        // until we support TIN types, use multipolygon
+        case Triangle:
+          return MultiPolygon;
+
+        case TriangleZ:
+          return MultiPolygonZ;
+
+        case TriangleM:
+          return MultiPolygonM;
+
+        case TriangleZM:
+          return MultiPolygonZM;
 
         case GeometryCollection:
           return GeometryCollection;

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2622,7 +2622,7 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
       }
       else // wkb type matches
       {
-        QByteArray wkb( geom.asWkb() );
+        QByteArray wkb( geom.asWkb( QgsAbstractGeometry::FlagExportTrianglesAsPolygons ) );
         OGRGeometryH ogrGeom = createEmptyGeometry( mWkbType );
         OGRErr err = OGR_G_ImportFromWkb( ogrGeom, reinterpret_cast<unsigned char *>( const_cast<char *>( wkb.constData() ) ), wkb.length() );
         if ( err != OGRERR_NONE )

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -34,6 +34,7 @@ from qgis.core import (
     QgsCoordinateTransform,
     QgsRectangle,
     QgsWkbTypes,
+    QgsTriangle,
     QgsRenderChecker,
     QgsCoordinateReferenceSystem,
     QgsProject
@@ -2104,6 +2105,13 @@ class TestQgsGeometry(unittest.TestCase):
                       QgsGeometry.fromWkt('Polygon((100 100, 101 100, 101 101, 100 100))')]
         geometry = QgsGeometry.collectGeometry(geometries)
         expwkt = "MultiPolygon (((0 0, 1 0, 1 1, 0 1, 0 0)),((2 0, 3 0, 3 1, 2 1, 2 0)),((100 100, 101 100, 101 101, 100 100)))"
+        wkt = geometry.asWkt()
+        assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
+
+        geometries = [QgsGeometry(QgsTriangle(QgsPoint(0, 0, 5), QgsPoint(1, 0, 6), QgsPoint(1, 1, 7))),
+                      QgsGeometry(QgsTriangle(QgsPoint(100, 100, 9), QgsPoint(101, 100, -1), QgsPoint(101, 101, 4)))]
+        geometry = QgsGeometry.collectGeometry(geometries)
+        expwkt = "MultiPolygonZ (((0 0 5, 1 0 6, 1 1 7, 0 0 5)),((100 100 9, 101 100 -1, 101 101 4, 100 100 9)))"
         wkt = geometry.asWkt()
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
 

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -2911,6 +2911,11 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertEqual(QgsWkbTypes.multiType(QgsWkbTypes.MultiPoint25D), QgsWkbTypes.MultiPoint25D)
         self.assertEqual(QgsWkbTypes.multiType(QgsWkbTypes.MultiLineString25D), QgsWkbTypes.MultiLineString25D)
         self.assertEqual(QgsWkbTypes.multiType(QgsWkbTypes.MultiPolygon25D), QgsWkbTypes.MultiPolygon25D)
+        # until we have tin types, these should return multipolygons
+        self.assertEqual(QgsWkbTypes.multiType(QgsWkbTypes.Triangle), QgsWkbTypes.MultiPolygon)
+        self.assertEqual(QgsWkbTypes.multiType(QgsWkbTypes.TriangleZ), QgsWkbTypes.MultiPolygonZ)
+        self.assertEqual(QgsWkbTypes.multiType(QgsWkbTypes.TriangleM), QgsWkbTypes.MultiPolygonM)
+        self.assertEqual(QgsWkbTypes.multiType(QgsWkbTypes.TriangleZM), QgsWkbTypes.MultiPolygonZM)
 
         # test curveType method
         self.assertEqual(QgsWkbTypes.curveType(QgsWkbTypes.Unknown), QgsWkbTypes.Unknown)

--- a/tests/src/python/test_qgsvectorfilewriter.py
+++ b/tests/src/python/test_qgsvectorfilewriter.py
@@ -26,7 +26,10 @@ from qgis.core import (QgsVectorLayer,
                        QgsProject,
                        QgsWkbTypes,
                        QgsRectangle,
-                       QgsCoordinateTransform
+                       QgsCoordinateTransform,
+                       QgsMultiPolygon,
+                       QgsTriangle,
+                       QgsPoint
                        )
 from qgis.PyQt.QtCore import QDate, QTime, QDateTime, QVariant, QDir, QByteArray
 import os
@@ -1201,6 +1204,38 @@ class TestQgsVectorFileWriter(unittest.TestCase):
         self.assertEqual(f.geometry().asWkt(), 'Point (2 49)')
         self.assertEqual(f.attributes(), [123, 'text1'])
         self.assertEqual(f.id(), 123)
+
+    def testWriteTriangle(self):
+        """Check we can write geometries with triangle types."""
+        layer = QgsVectorLayer(
+            ('MultiPolygonZ?crs=epsg:4326&field=name:string(20)'),
+            'test',
+            'memory')
+
+        ft = QgsFeature()
+        geom = QgsMultiPolygon()
+        geom.addGeometry(QgsTriangle(QgsPoint(1, 2, 3), QgsPoint(2, 2, 4), QgsPoint(2, 3, 4)))
+        ft.setGeometry(geom)
+        ft.setAttributes(['Johny'])
+        myResult, myFeatures = layer.dataProvider().addFeatures([ft])
+        self.assertTrue(myResult)
+        self.assertTrue(myFeatures)
+
+        dest_file_name = os.path.join(str(QDir.tempPath()), 'testWriteTriangle.gpkg')
+        write_result, error_message = QgsVectorFileWriter.writeAsVectorFormat(
+            layer,
+            dest_file_name,
+            'utf-8',
+            layer.crs(),
+            'GPKG')
+        self.assertEqual(write_result, QgsVectorFileWriter.NoError, error_message)
+
+        # Open result and check
+        created_layer = QgsVectorLayer(dest_file_name, 'test', 'ogr')
+        self.assertTrue(created_layer.isValid())
+        f = next(created_layer.getFeatures(QgsFeatureRequest()))
+        self.assertEqual(f.geometry().asWkt(), 'MultiPolygonZ (((1 2 3, 2 2 4, 2 3 4, 1 2 3)))')
+        self.assertEqual(f.attributes(), [1, 'Johny'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
These are workarounds due to lack of a proper TIN geometry type -- in the absence of this, we need to ensure that triangles are treated as polygons when they are part of a multipolygon geometry.