### PR TITLE
Avoid startup warnings caused by trying to create a CRS from a '0' string

### DIFF
--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -271,6 +271,9 @@ bool QgsCoordinateReferenceSystem::createFromId( const long id, CrsType type )
 
 bool QgsCoordinateReferenceSystem::createFromString( const QString &definition )
 {
+  if ( definition.isEmpty() )
+    return false;
+
   QgsReadWriteLocker locker( *sCrsStringLock(), QgsReadWriteLocker::Read );
   if ( !sDisableStringCache )
   {
@@ -336,6 +339,9 @@ bool QgsCoordinateReferenceSystem::createFromString( const QString &definition )
 
 bool QgsCoordinateReferenceSystem::createFromUserInput( const QString &definition )
 {
+  if ( definition.isEmpty() )
+    return false;
+
   QString userWkt;
   OGRSpatialReferenceH crs = OSRNewSpatialReference( nullptr );
 
@@ -381,6 +387,9 @@ void QgsCoordinateReferenceSystem::setupESRIWktFix()
 
 bool QgsCoordinateReferenceSystem::createFromOgcWmsCrs( const QString &crs )
 {
+  if ( crs.isEmpty() )
+    return false;
+
   QgsReadWriteLocker locker( *sOgcLock(), QgsReadWriteLocker::Read );
   if ( !sDisableOgcCache )
   {
@@ -829,6 +838,9 @@ bool QgsCoordinateReferenceSystem::hasAxisInverted() const
 
 bool QgsCoordinateReferenceSystem::createFromWkt( const QString &wkt )
 {
+  if ( wkt.isEmpty() )
+    return false;
+
   d.detach();
 
   QgsReadWriteLocker locker( *sCRSWktLock(), QgsReadWriteLocker::Read );
@@ -899,6 +911,9 @@ bool QgsCoordinateReferenceSystem::createFromProj4( const QString &proj4String )
 
 bool QgsCoordinateReferenceSystem::createFromProj( const QString &projString, const bool identify )
 {
+  if ( projString.isEmpty() )
+    return false;
+
   d.detach();
 
   if ( projString.trimmed().isEmpty() )

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -53,7 +53,7 @@ QgsMapToolCapture::QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizin
 
   QgsVectorLayer::LayerOptions layerOptions;
   layerOptions.skipCrsValidation = true;
-  mExtraSnapLayer = new QgsVectorLayer( QStringLiteral( "LineString?crs=0" ), QStringLiteral( "extra snap" ), QStringLiteral( "memory" ), layerOptions );
+  mExtraSnapLayer = new QgsVectorLayer( QStringLiteral( "LineString?crs=" ), QStringLiteral( "extra snap" ), QStringLiteral( "memory" ), layerOptions );
   mExtraSnapLayer->startEditing();
   QgsFeature f;
   mExtraSnapLayer->addFeature( f );


### PR DESCRIPTION
And instead just shortcut and don't try to create the CRS