### PR TITLE
Use a proper ellipsoidal length calculation when calculating the size of the scalebar decoration

### DIFF
--- a/src/app/decorations/qgsdecorationscalebar.h
+++ b/src/app/decorations/qgsdecorationscalebar.h
@@ -76,6 +76,8 @@ class APP_EXPORT QgsDecorationScaleBar: public QgsDecorationItem
     int mMarginHorizontal = 0;
     int mMarginVertical = 0;
 
+    double mapWidth( const QgsMapSettings &settings ) const;
+
     friend class QgsDecorationScaleBarDialog;
 };
 


### PR DESCRIPTION
Avoids a misleading Cartesian-based scalebar (unless project is
set to always use cartesian measurements, that is!)

Fixes #28407
