### PR TITLE
Skip geometry checks in "Boundary" alg

### DIFF
--- a/src/analysis/processing/qgsalgorithmboundary.cpp
+++ b/src/analysis/processing/qgsalgorithmboundary.cpp
@@ -73,6 +73,11 @@ QgsBoundaryAlgorithm *QgsBoundaryAlgorithm::createInstance() const
   return new QgsBoundaryAlgorithm();
 }
 
+QgsProcessingFeatureSource::Flag QgsBoundaryAlgorithm::sourceFlags() const
+{
+  return QgsProcessingFeatureSource::FlagSkipGeometryValidityChecks;
+}
+
 QgsWkbTypes::Type QgsBoundaryAlgorithm::outputWkbType( QgsWkbTypes::Type inputWkbType ) const
 {
   QgsWkbTypes::Type outputWkb = QgsWkbTypes::Unknown;

--- a/src/analysis/processing/qgsalgorithmboundary.h
+++ b/src/analysis/processing/qgsalgorithmboundary.h
@@ -43,6 +43,7 @@ class QgsBoundaryAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QList<int> inputLayerTypes() const override;
     bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
     QgsBoundaryAlgorithm *createInstance() const override SIP_FACTORY;
+    QgsProcessingFeatureSource::Flag sourceFlags() const override;
 
   protected:
 


### PR DESCRIPTION
The boundary algorithm isn't suspectible to invalid geometries, so skip the checks for it
