### PR TITLE
Tests to check correctness of WHERE clauses for PostgreSQL

### DIFF
--- a/tests/src/providers/testqgspostgresprovider.cpp
+++ b/tests/src/providers/testqgspostgresprovider.cpp
@@ -199,7 +199,8 @@ void TestQgsPostgresProvider::testQuotedValueBigInt()
   QgsFields fields;
   QList<int> pkAttrs;
   QVariantList vlst;
-  QgsPostgresSharedData *sdata;
+
+  std::shared_ptr< QgsPostgresSharedData > sdata( new QgsPostgresSharedData() );
 
   QgsField f0, f1, f2, f3;
 
@@ -208,15 +209,10 @@ void TestQgsPostgresProvider::testQuotedValueBigInt()
   f0.setType( QVariant::Int );
   f0.setTypeName( "int" );
 
-  fields.clear();
-  pkAttrs.clear();
-  vlst.clear();
-
   fields.append( f0 );
   pkAttrs.append( 0 );
   vlst.append( 42 );
 
-  sdata = new QgsPostgresSharedData;
   // for positive integers, fid  == the value, there is no map.
   sdata->insertFid( 42, vlst );
 
@@ -235,7 +231,7 @@ void TestQgsPostgresProvider::testQuotedValueBigInt()
   pkAttrs.append( 0 );
   vlst.append( -9223372036854775800LL ); // way outside int4 range
 
-  sdata = new QgsPostgresSharedData;
+  sdata->clear();
   sdata->insertFid( 1LL, vlst );
 
   QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktInt64, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_bigint\"=-9223372036854775800" ) );
@@ -253,7 +249,7 @@ void TestQgsPostgresProvider::testQuotedValueBigInt()
   pkAttrs.append( 0 );
   vlst.append( 3.141592741 );
 
-  sdata = new QgsPostgresSharedData;
+  sdata->clear();
   sdata->insertFid( 1LL, vlst );
 
   QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_double\"=3.141592741" ) );
@@ -271,7 +267,7 @@ void TestQgsPostgresProvider::testQuotedValueBigInt()
   pkAttrs.append( 0 );
   vlst.append( QString( "QGIS 'Rocks'!" ) );
 
-  sdata = new QgsPostgresSharedData;
+  sdata->clear();
   sdata->insertFid( 1LL, vlst );
 
   QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_text\"::text='QGIS ''Rocks''!'" ) );
@@ -293,7 +289,7 @@ void TestQgsPostgresProvider::testQuotedValueBigInt()
   fields.append( f3 );
   fields.append( f0 );
 
-  sdata = new QgsPostgresSharedData;
+  sdata->clear();
   sdata->insertFid( 1LL, vlst );
 
   // TODO: FIXME: in tables with composite PKs, integer fields are cast to text, but their values are not.

--- a/tests/src/providers/testqgspostgresprovider.cpp
+++ b/tests/src/providers/testqgspostgresprovider.cpp
@@ -16,6 +16,9 @@
 #include <QObject>
 
 #include <qgspostgresprovider.h>
+#include <qgspostgresconn.h>
+#include <qgsfields.h>
+
 
 class TestQgsPostgresProvider: public QObject
 {
@@ -34,6 +37,7 @@ class TestQgsPostgresProvider: public QObject
     void decodeJsonMap();
     void decodeJsonbMap();
     void testDecodeDateTimes();
+    void testQuotedValueBigInt();
 };
 
 
@@ -188,6 +192,113 @@ void TestQgsPostgresProvider::testDecodeDateTimes()
   decoded = QgsPostgresProvider::convertValue( QVariant::Time, QVariant::Invalid, QStringLiteral( "18:29:27.569401" ), QStringLiteral( "time" ) );
   QCOMPARE( decoded.type(), QVariant::Time );
 
+}
+
+void TestQgsPostgresProvider::testQuotedValueBigInt()
+{
+  QgsFields fields;
+  QList<int> pkAttrs;
+  QVariantList vlst;
+  QgsPostgresSharedData *sdata;
+
+  QgsField f0, f1, f2, f3;
+
+  // 4 byte integer
+  f0.setName( "fld_integer" );
+  f0.setType( QVariant::Int );
+  f0.setTypeName( "int" );
+
+  fields.clear();
+  pkAttrs.clear();
+  vlst.clear();
+
+  fields.append( f0 );
+  pkAttrs.append( 0 );
+  vlst.append( 42 );
+
+  sdata = new QgsPostgresSharedData;
+  // for positive integers, fid  == the value, there is no map.
+  sdata->insertFid( 42, vlst );
+
+  QCOMPARE( QgsPostgresUtils::whereClause( 42, fields, NULL, QgsPostgresPrimaryKeyType::PktInt, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_integer\"=42" ) );
+
+  // 8 byte integer
+  f1.setName( "fld_bigint" );
+  f1.setType( QVariant::LongLong );
+  f1.setTypeName( "int8" );
+
+  fields.clear();
+  pkAttrs.clear();
+  vlst.clear();
+
+  fields.append( f1 );
+  pkAttrs.append( 0 );
+  vlst.append( -9223372036854775800LL ); // way outside int4 range
+
+  sdata = new QgsPostgresSharedData;
+  sdata->insertFid( 1LL, vlst );
+
+  QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktInt64, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_bigint\"=-9223372036854775800" ) );
+
+  // double
+  f2.setName( "fld_double" );
+  f2.setType( QVariant::Double );
+  f2.setTypeName( "float8" );
+
+  fields.clear();
+  pkAttrs.clear();
+  vlst.clear();
+
+  fields.append( f2 );
+  pkAttrs.append( 0 );
+  vlst.append( 3.141592741 );
+
+  sdata = new QgsPostgresSharedData;
+  sdata->insertFid( 1LL, vlst );
+
+  QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_double\"::text='3.141592741'" ) );
+
+  // text
+  f3.setName( "fld_text" );
+  f3.setType( QVariant::String );
+  f3.setTypeName( "text" );
+
+  fields.clear();
+  pkAttrs.clear();
+  vlst.clear();
+
+  fields.append( f3 );
+  pkAttrs.append( 0 );
+  vlst.append( QString( "QGIS 'Rocks'!" ) );
+
+  sdata = new QgsPostgresSharedData;
+  sdata->insertFid( 1LL, vlst );
+
+  QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_text\"::text='QGIS ''Rocks''!'" ) );
+
+  // Composite bigint + text + int
+  pkAttrs.clear();
+
+  pkAttrs.append( 0 );
+  pkAttrs.append( 1 );
+  pkAttrs.append( 2 );
+
+  vlst.clear();
+  vlst.append( -9223372036854775800LL );
+  vlst.append( QString( "QGIS 'Rocks'!" ) );
+  vlst.append( 42 );
+
+  fields.clear();
+  fields.append( f1 );
+  fields.append( f3 );
+  fields.append( f0 );
+
+  sdata = new QgsPostgresSharedData;
+  sdata->insertFid( 1LL, vlst );
+
+  // TODO: FIXME: Please don't cast integer primary key types to text if they are part of a FidMap!
+  // It hurts the database performance badly.
+  QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_bigint\"='-9223372036854775800' AND \"fld_text\"::text='QGIS ''Rocks''!' AND \"fld_integer\"::text='42'" ) );
 }
 
 QGSTEST_MAIN( TestQgsPostgresProvider )

--- a/tests/src/providers/testqgspostgresprovider.cpp
+++ b/tests/src/providers/testqgspostgresprovider.cpp
@@ -256,7 +256,7 @@ void TestQgsPostgresProvider::testQuotedValueBigInt()
   sdata = new QgsPostgresSharedData;
   sdata->insertFid( 1LL, vlst );
 
-  QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_double\"::text='3.141592741'" ) );
+  QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_double\"=3.141592741" ) );
 
   // text
   f3.setName( "fld_text" );
@@ -296,9 +296,9 @@ void TestQgsPostgresProvider::testQuotedValueBigInt()
   sdata = new QgsPostgresSharedData;
   sdata->insertFid( 1LL, vlst );
 
-  // TODO: FIXME: Please don't cast integer primary key types to text if they are part of a FidMap!
+  // TODO: FIXME: in tables with composite PKs, integer fields are cast to text, but their values are not.
   // It hurts the database performance badly.
-  QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_bigint\"='-9223372036854775800' AND \"fld_text\"::text='QGIS ''Rocks''!' AND \"fld_integer\"::text='42'" ) );
+  QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_bigint\"=-9223372036854775800 AND \"fld_text\"::text='QGIS ''Rocks''!' AND \"fld_integer\"::text=42" ) );
 }
 
 QGSTEST_MAIN( TestQgsPostgresProvider )


### PR DESCRIPTION
When I submitted the improvement for handling PostgreSQL bigint/bigserial primary keys, preventing QGIS from casting those to text (PR #35162) I wrote some functional testcases in Python. Those tests only assured that my changes didn't break anything, but they didn't prove that the changes really worked as intended. I've checked that by looking at debug logs and the database logs. I didn't know then a way to formally check the generated SQL queries from inside the testing framework.

Now, while reviewing #36266, I saw that @benoitdm-oslandia came up with the idea of calling the QgsPostgresUtils::whereClause() method directly, while using an instance of QgsPostgresSharedData to pass the fields to the provider.

So, I stole his idea and wrote these tests, and I've gained some more insights about the QGIS provider in the process. For instance, I've found that in the case of compound keys, the original problem of QGIS casting integers to text persist; that's not a common use case, but still, I think it is worth a shot (thats what the FIXME comment on the last test is for).

Also, with these tests we cases we may rest more assured that there won't be regressions in this case.

