### PR TITLE
[ui] Reduce visual attention grab of the authentication settings wiget's warning label

### DIFF
--- a/src/gui/auth/qgsauthsettingswidget.cpp
+++ b/src/gui/auth/qgsauthsettingswidget.cpp
@@ -104,7 +104,7 @@ const QString QgsAuthSettingsWidget::dataprovider() const
 
 const QString QgsAuthSettingsWidget::formattedWarning( WarningType warning )
 {
-  QString out = tr( "<div>Warning: credentials stored as plain text in %1.</div>" );
+  QString out = tr( "Warning: credentials stored as plain text in %1." );
   switch ( warning )
   {
     case ProjectFile:

--- a/src/ui/auth/qgsauthsettingswidget.ui
+++ b/src/ui/auth/qgsauthsettingswidget.ui
@@ -173,21 +173,35 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0" colspan="3">
-        <widget class="QLabel" name="lblWarning">
-         <property name="styleSheet">
-          <string notr="true">QLabel{color: rgb(255, 0, 0);font-weight: bold;}</string>
-         </property>
-         <property name="text">
-          <string>Warning text!</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
+       <item row="3" column="1" colspan="2">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+           <widget class="QLabel" name="lblWarningIcon">
+           <property name="pixmap">
+            <pixmap>:/images/themes/default/mIconWarning.svg</pixmap>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="lblWarning">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string></string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item row="1" column="1">
         <widget class="QLineEdit" name="txtUserName">

--- a/src/ui/auth/qgsauthsettingswidget.ui
+++ b/src/ui/auth/qgsauthsettingswidget.ui
@@ -196,9 +196,6 @@
            <property name="wordWrap">
             <bool>true</bool>
            </property>
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
           </widget>
          </item>
         </layout>


### PR DESCRIPTION
## Description

This PR addresses the UI issue #37070 .

Before vs. PR:
![image](https://user-images.githubusercontent.com/1728657/84344801-e49b7b00-abd5-11ea-87de-1776299dacaf.png)

![image](https://user-images.githubusercontent.com/1728657/84344810-e8c79880-abd5-11ea-900a-797bec659407.png)
