### PR TITLE
[themes] Fix tab widget's panel missing border for non selected tabs

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -520,11 +520,15 @@ QTabWidget::pane {
     top:-1px;
 }
 
+QTabWidget[tabPosition="0"] QTabBar {
+    border-bottom: 1px solid @itemdarkbackground;
+}
+
 QTabBar::tab {
     color: @text;
     border: 1px solid @itemdarkbackground;
     border-bottom: none;
-    background-color: @background;
+    background-color: transparent;
     padding-left: 0.8em;
     padding-right: 0.8em;
     padding-top: 0.1em;
@@ -559,6 +563,7 @@ QTabBar::tab:!selected
 QTabBar::tab:selected
 {
     margin-bottom: 0px;
+    background-color: @background;
 }
 
 QTabBar::tab:bottom:!selected
@@ -570,6 +575,7 @@ QTabBar::tab:bottom:!selected
 QTabBar::tab:bottom:selected
 {
     margin-top: 0px;
+    background-color: @background;
 }
 
 QGroupBox::indicator:hover,

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -530,11 +530,15 @@ QTabWidget::pane {
     top:-1px;
 }
 
+QTabWidget[tabPosition="0"] QTabBar {
+    border-bottom: 1px solid @itemdarkbackground;
+}
+
 QTabBar::tab {
     color: @text;
     border: 1px solid @itemdarkbackground;
     border-bottom: none;
-    background-color: @background;
+    background-color: transparent;
     padding-left: 0.8em;
     padding-right: 0.8em;
     padding-top: 0.1em;
@@ -569,6 +573,7 @@ QTabBar::tab:!selected
 QTabBar::tab:selected
 {
     margin-bottom: 0px;
+    background-color: @background;
 }
 
 QTabBar::tab:bottom:!selected
@@ -580,6 +585,7 @@ QTabBar::tab:bottom:!selected
 QTabBar::tab:bottom:selected
 {
     margin-top: 0px;
+    background-color: @background;
 }
 
 QGroupBox::indicator:hover,


### PR DESCRIPTION
## Description

Another tiny themes fix.

Before vs. PR:
![image](https://user-images.githubusercontent.com/1728657/84345190-e6b20980-abd6-11ea-8d65-97c8154cae66.png)
