### PR TITLE
[decorations] Fix hardcoded black color for the grid decoration

### DIFF
--- a/src/app/decorations/qgsdecorationgrid.cpp
+++ b/src/app/decorations/qgsdecorationgrid.cpp
@@ -23,16 +23,17 @@
 #include "qgslogger.h"
 #include "qgsmaplayer.h"
 #include "qgsrasterlayer.h"
+#include "qgsmapcanvas.h"
 #include "qgsmaptopixel.h"
 #include "qgspathresolver.h"
 #include "qgspointxy.h"
 #include "qgsproject.h"
-#include "qgssymbollayerutils.h" //for pointOnLineWithDistance
-#include "qgssymbol.h" //for symbology
+#include "qgssymbollayerutils.h"
+#include "qgssymbol.h"
 #include "qgsmarkersymbollayer.h"
 #include "qgsreadwritecontext.h"
 #include "qgsrendercontext.h"
-#include "qgsmapcanvas.h"
+#include "qgstextrenderer.h"
 
 #include <QPainter>
 #include <QAction>
@@ -50,9 +51,6 @@
 
 //non qt includes
 #include <cmath>
-
-
-#define FONT_WORKAROUND_SCALE 10 //scale factor for upscaling fontsize and downscaling painter
 
 
 QgsDecorationGrid::QgsDecorationGrid( QObject *parent )
@@ -101,30 +99,26 @@ void QgsDecorationGrid::projectRead()
   mGridIntervalY = QgsProject::instance()->readDoubleEntry( mConfigurationName, QStringLiteral( "/IntervalY" ), 10 );
   mGridOffsetX = QgsProject::instance()->readDoubleEntry( mConfigurationName, QStringLiteral( "/OffsetX" ), 0 );
   mGridOffsetY = QgsProject::instance()->readDoubleEntry( mConfigurationName, QStringLiteral( "/OffsetY" ), 0 );
-  // mCrossLength = QgsProject::instance()->readDoubleEntry( mConfigurationName, "/CrossLength", 3 );
   mShowGridAnnotation = QgsProject::instance()->readBoolEntry( mConfigurationName, QStringLiteral( "/ShowAnnotation" ), false );
-  // mGridAnnotationPosition = ( GridAnnotationPosition ) QgsProject::instance()->readNumEntry( mConfigurationName,
-  //                           "/AnnotationPosition", 0 );
-  mGridAnnotationPosition = InsideMapFrame; // don't allow outside frame, doesn't make sense
   mGridAnnotationDirection = static_cast< GridAnnotationDirection >( QgsProject::instance()->readNumEntry( mConfigurationName,
                              QStringLiteral( "/AnnotationDirection" ), 0 ) );
-  QString fontStr = QgsProject::instance()->readEntry( mConfigurationName, QStringLiteral( "/AnnotationFont" ), QString() );
-  if ( !fontStr.isEmpty() )
+
+  QDomDocument doc;
+  QDomElement elem;
+  QString textXml = QgsProject::instance()->readEntry( mConfigurationName, QStringLiteral( "/Font" ) );
+  if ( !textXml.isEmpty() )
   {
-    mGridAnnotationFont.fromString( fontStr );
+    doc.setContent( textXml );
+    elem = doc.documentElement();
+    QgsReadWriteContext rwContext;
+    rwContext.setPathResolver( QgsProject::instance()->pathResolver() );
+    mTextFormat.readXml( elem, rwContext );
   }
-  else
-  {
-    mGridAnnotationFont = QFont();
-    // TODO fix font scaling problem - put a slightly large font for now
-    mGridAnnotationFont.setPointSize( 16 );
-  }
+
   mAnnotationFrameDistance = QgsProject::instance()->readDoubleEntry( mConfigurationName, QStringLiteral( "/AnnotationFrameDistance" ), 0 );
   mGridAnnotationPrecision = QgsProject::instance()->readNumEntry( mConfigurationName, QStringLiteral( "/AnnotationPrecision" ), 0 );
 
   // read symbol info from xml
-  QDomDocument doc;
-  QDomElement elem;
   QString xml;
   QgsReadWriteContext rwContext;
   rwContext.setPathResolver( QgsProject::instance()->pathResolver() );
@@ -170,19 +164,22 @@ void QgsDecorationGrid::saveToProject()
   QgsProject::instance()->writeEntry( mConfigurationName, QStringLiteral( "/IntervalY" ), mGridIntervalY );
   QgsProject::instance()->writeEntry( mConfigurationName, QStringLiteral( "/OffsetX" ), mGridOffsetX );
   QgsProject::instance()->writeEntry( mConfigurationName, QStringLiteral( "/OffsetY" ), mGridOffsetY );
-  // QgsProject::instance()->writeEntry( mConfigurationName, "/CrossLength", mCrossLength );
-  // missing mGridPen, but should use styles anyway
   QgsProject::instance()->writeEntry( mConfigurationName, QStringLiteral( "/ShowAnnotation" ), mShowGridAnnotation );
-  // QgsProject::instance()->writeEntry( mConfigurationName, "/AnnotationPosition", ( int ) mGridAnnotationPosition );
   QgsProject::instance()->writeEntry( mConfigurationName, QStringLiteral( "/AnnotationDirection" ), static_cast< int >( mGridAnnotationDirection ) );
   QgsProject::instance()->writeEntry( mConfigurationName, QStringLiteral( "/AnnotationFont" ), mGridAnnotationFont.toString() );
   QgsProject::instance()->writeEntry( mConfigurationName, QStringLiteral( "/AnnotationFrameDistance" ), mAnnotationFrameDistance );
   QgsProject::instance()->writeEntry( mConfigurationName, QStringLiteral( "/AnnotationPrecision" ), mGridAnnotationPrecision );
 
+  QDomDocument textDoc;
+  QgsReadWriteContext rwContext;
+  rwContext.setPathResolver( QgsProject::instance()->pathResolver() );
+  QDomElement textElem = mTextFormat.writeXml( textDoc, rwContext );
+  textDoc.appendChild( textElem );
+  QgsProject::instance()->writeEntry( mConfigurationName, QStringLiteral( "/Font" ), textDoc.toString() );
+
   // write symbol info to xml
   QDomDocument doc;
   QDomElement elem;
-  QgsReadWriteContext rwContext;
   rwContext.setPathResolver( QgsProject::instance()->pathResolver() );
   if ( mLineSymbol )
   {
@@ -217,13 +214,10 @@ void QgsDecorationGrid::render( const QgsMapSettings &mapSettings, QgsRenderCont
   if ( ! mEnabled )
     return;
 
-  // p->setPen( mGridPen );
-
   QList< QPair< qreal, QLineF > > verticalLines;
   yGridLines( mapSettings, verticalLines );
   QList< QPair< qreal, QLineF > > horizontalLines;
   xGridLines( mapSettings, horizontalLines );
-  //QgsDebugMsg( QStringLiteral("grid has %1 vertical and %2 horizontal lines").arg( verticalLines.size() ).arg( horizontalLines.size() ) );
 
   QList< QPair< qreal, QLineF > >::const_iterator vIt = verticalLines.constBegin();
   QList< QPair< qreal, QLineF > >::const_iterator hIt = horizontalLines.constBegin();
@@ -328,187 +322,105 @@ void QgsDecorationGrid::render( const QgsMapSettings &mapSettings, QgsRenderCont
     mMarkerSymbol->stopRender( context );
   }
 
-  // p->setClipRect( thisPaintRect, Qt::NoClip );
-
   if ( mShowGridAnnotation )
   {
-    drawCoordinateAnnotations( context.painter(), horizontalLines, verticalLines );
+    drawCoordinateAnnotations( context, horizontalLines, verticalLines );
   }
 }
 
-void QgsDecorationGrid::drawCoordinateAnnotations( QPainter *p, const QList< QPair< qreal, QLineF > > &hLines, const QList< QPair< qreal, QLineF > > &vLines )
+void QgsDecorationGrid::drawCoordinateAnnotations( QgsRenderContext &context, const QList< QPair< qreal, QLineF > > &hLines, const QList< QPair< qreal, QLineF > > &vLines )
 {
-  if ( !p )
-  {
-    return;
-  }
-
   QString currentAnnotationString;
   QList< QPair< qreal, QLineF > >::const_iterator it = hLines.constBegin();
   for ( ; it != hLines.constEnd(); ++it )
   {
     currentAnnotationString = QString::number( it->first, 'f', mGridAnnotationPrecision );
-    drawCoordinateAnnotation( p, it->second.p1(), currentAnnotationString );
-    drawCoordinateAnnotation( p, it->second.p2(), currentAnnotationString );
+    drawCoordinateAnnotation( context, it->second.p1(), currentAnnotationString );
+    drawCoordinateAnnotation( context, it->second.p2(), currentAnnotationString );
   }
 
   it = vLines.constBegin();
   for ( ; it != vLines.constEnd(); ++it )
   {
     currentAnnotationString = QString::number( it->first, 'f', mGridAnnotationPrecision );
-    drawCoordinateAnnotation( p, it->second.p1(), currentAnnotationString );
-    drawCoordinateAnnotation( p, it->second.p2(), currentAnnotationString );
+    drawCoordinateAnnotation( context, it->second.p1(), currentAnnotationString );
+    drawCoordinateAnnotation( context, it->second.p2(), currentAnnotationString );
   }
 }
 
-void QgsDecorationGrid::drawCoordinateAnnotation( QPainter *p, QPointF pos, const QString &annotationString )
+void QgsDecorationGrid::drawCoordinateAnnotation( QgsRenderContext &context, QPointF pos, const QString &annotationString )
 {
-  Border frameBorder = borderForLineCoord( pos, p );
-  double textWidth = textWidthMillimeters( mGridAnnotationFont, annotationString );
-  //relevant for annotations is the height of digits
-  double textHeight = fontHeightCharacterMM( mGridAnnotationFont, QChar( '0' ) );
+  Border frameBorder = borderForLineCoord( pos, context.painter() );
+  const QStringList annotationStringList = QStringList() << annotationString;
+
+  QFontMetricsF textMetrics = QgsTextRenderer::fontMetrics( context, mTextFormat );
+  double textDescent = textMetrics.descent();
+  double textWidth = QgsTextRenderer::textWidth( context, mTextFormat, annotationStringList );
+  double textHeight = QgsTextRenderer::textHeight( context, mTextFormat, annotationStringList, QgsTextRenderer::Point );
+
   double xpos = pos.x();
   double ypos = pos.y();
-  int rotation = 0;
+  double rotation = 0;
 
-  if ( frameBorder == Left )
+  switch ( frameBorder )
   {
-
-    if ( mGridAnnotationPosition == InsideMapFrame )
-    {
+    case Left:
       if ( mGridAnnotationDirection == Vertical || mGridAnnotationDirection == BoundaryDirection )
       {
-        xpos += textHeight + mAnnotationFrameDistance;
-        ypos += textWidth / 2.0;
-        rotation = 270;
-      }
-      else
-      {
-        xpos += mAnnotationFrameDistance;
-        ypos += textHeight / 2.0;
-      }
-    }
-    else //Outside map frame
-    {
-      if ( mGridAnnotationDirection == Vertical || mGridAnnotationDirection == BoundaryDirection )
-      {
-        xpos -= mAnnotationFrameDistance;
-        ypos += textWidth / 2.0;
-        rotation = 270;
-      }
-      else
-      {
-        xpos -= textWidth + mAnnotationFrameDistance;
-        ypos += textHeight / 2.0;
-      }
-    }
-
-  }
-  else if ( frameBorder == Right )
-  {
-    if ( mGridAnnotationPosition == InsideMapFrame )
-    {
-      if ( mGridAnnotationDirection == Vertical || mGridAnnotationDirection == BoundaryDirection )
-      {
-        xpos -= mAnnotationFrameDistance;
-        ypos += textWidth / 2.0;
-        rotation = 270;
-      }
-      else //Horizontal
-      {
-        xpos -= textWidth + mAnnotationFrameDistance;
-        ypos += textHeight / 2.0;
-      }
-    }
-    else //OutsideMapFrame
-    {
-      if ( mGridAnnotationDirection == Vertical || mGridAnnotationDirection == BoundaryDirection )
-      {
-        xpos += textHeight + mAnnotationFrameDistance;
-        ypos += textWidth / 2.0;
-        rotation = 270;
+        xpos += mAnnotationFrameDistance + textDescent;
+        ypos -= textWidth / 2;
+        rotation = 4.71239;
       }
       else //Horizontal
       {
         xpos += mAnnotationFrameDistance;
-        ypos += textHeight / 2.0;
+        ypos += textHeight / 2.0 - textDescent;
       }
-    }
-  }
-  else if ( frameBorder == Bottom )
-  {
-    if ( mGridAnnotationPosition == InsideMapFrame )
-    {
+      break;
+
+    case Right:
+      if ( mGridAnnotationDirection == Vertical || mGridAnnotationDirection == BoundaryDirection )
+      {
+        xpos -= textHeight - textDescent + mAnnotationFrameDistance;
+        ypos -= textWidth / 2;
+        rotation = 4.71239;
+      }
+      else //Horizontal
+      {
+        xpos -= textWidth + mAnnotationFrameDistance;
+        ypos += textHeight / 2.0 - textDescent;
+      }
+      break;
+
+    case Bottom:
       if ( mGridAnnotationDirection == Horizontal || mGridAnnotationDirection == BoundaryDirection )
       {
-        ypos -= mAnnotationFrameDistance;
+        ypos -= mAnnotationFrameDistance + textDescent;
         xpos -= textWidth / 2.0;
       }
       else //Vertical
       {
-        xpos += textHeight / 2.0;
-        ypos -= mAnnotationFrameDistance;
-        rotation = 270;
+        xpos -= textDescent;
+        ypos -= textWidth - mAnnotationFrameDistance;
+        rotation = 4.71239;
       }
-    }
-    else //OutsideMapFrame
-    {
-      if ( mGridAnnotationDirection == Horizontal || mGridAnnotationDirection == BoundaryDirection )
-      {
-        ypos += mAnnotationFrameDistance + textHeight;
-        xpos -= textWidth / 2.0;
-      }
-      else //Vertical
-      {
-        xpos += textHeight / 2.0;
-        ypos += textWidth + mAnnotationFrameDistance;
-        rotation = 270;
-      }
-    }
-  }
-  else //Top
-  {
-    if ( mGridAnnotationPosition == InsideMapFrame )
-    {
+      break;
+
+    case Top:
       if ( mGridAnnotationDirection == Horizontal || mGridAnnotationDirection == BoundaryDirection )
       {
         xpos -= textWidth / 2.0;
-        ypos += textHeight + mAnnotationFrameDistance;
+        ypos += textHeight - textDescent + mAnnotationFrameDistance;
       }
       else //Vertical
       {
-        xpos += textHeight / 2.0;
-        ypos += textWidth + mAnnotationFrameDistance;
-        rotation = 270;
+        xpos -= textDescent;
+        ypos += mAnnotationFrameDistance;
+        rotation = 4.71239;
       }
-    }
-    else //OutsideMapFrame
-    {
-      if ( mGridAnnotationDirection == Horizontal || mGridAnnotationDirection == BoundaryDirection )
-      {
-        xpos -= textWidth / 2.0;
-        ypos -= mAnnotationFrameDistance;
-      }
-      else //Vertical
-      {
-        xpos += textHeight / 2.0;
-        ypos -= mAnnotationFrameDistance;
-        rotation = 270;
-      }
-    }
   }
 
-  drawAnnotation( p, QPointF( xpos, ypos ), rotation, annotationString );
-}
-
-void QgsDecorationGrid::drawAnnotation( QPainter *p, QPointF pos, int rotation, const QString &annotationText )
-{
-  p->save();
-  p->translate( pos );
-  p->rotate( rotation );
-  p->setPen( QColor( 0, 0, 0 ) );
-  drawText( p, 0, 0, annotationText, mGridAnnotationFont );
-  p->restore();
+  QgsTextRenderer::drawText( QPointF( xpos, ypos ), rotation, QgsTextRenderer::AlignLeft, annotationStringList, context, mTextFormat );
 }
 
 QPolygonF canvasPolygon( const QgsMapSettings &mapSettings )
@@ -663,70 +575,6 @@ QgsDecorationGrid::Border QgsDecorationGrid::borderForLineCoord( QPointF point, 
   {
     return Bottom;
   }
-}
-
-void QgsDecorationGrid::drawText( QPainter *p, double x, double y, const QString &text, const QFont &font ) const
-{
-  QFont textFont = scaledFontPixelSize( font );
-
-  p->save();
-  p->setFont( textFont );
-  p->setPen( QColor( 0, 0, 0 ) ); //draw text always in black
-  double scaleFactor = 1.0 / FONT_WORKAROUND_SCALE;
-  p->scale( scaleFactor, scaleFactor );
-  p->drawText( QPointF( x * FONT_WORKAROUND_SCALE, y * FONT_WORKAROUND_SCALE ), text );
-  p->restore();
-}
-
-void QgsDecorationGrid::drawText( QPainter *p, const QRectF &rect, const QString &text, const QFont &font, Qt::AlignmentFlag halignment, Qt::AlignmentFlag valignment ) const
-{
-  QFont textFont = scaledFontPixelSize( font );
-
-  QRectF scaledRect( rect.x() * FONT_WORKAROUND_SCALE, rect.y() * FONT_WORKAROUND_SCALE,
-                     rect.width() * FONT_WORKAROUND_SCALE, rect.height() * FONT_WORKAROUND_SCALE );
-
-  p->save();
-  p->setFont( textFont );
-  double scaleFactor = 1.0 / FONT_WORKAROUND_SCALE;
-  p->scale( scaleFactor, scaleFactor );
-  p->drawText( scaledRect, halignment | valignment | Qt::TextWordWrap, text );
-  p->restore();
-}
-
-double QgsDecorationGrid::textWidthMillimeters( const QFont &font, const QString &text ) const
-{
-  QFont metricsFont = scaledFontPixelSize( font );
-  QFontMetrics fontMetrics( metricsFont );
-  return ( fontMetrics.boundingRect( text ).width() / FONT_WORKAROUND_SCALE );
-}
-
-double QgsDecorationGrid::fontHeightCharacterMM( const QFont &font, QChar c ) const
-{
-  QFont metricsFont = scaledFontPixelSize( font );
-  QFontMetricsF fontMetrics( metricsFont );
-  return ( fontMetrics.boundingRect( c ).height() / FONT_WORKAROUND_SCALE );
-}
-
-double QgsDecorationGrid::fontAscentMillimeters( const QFont &font ) const
-{
-  QFont metricsFont = scaledFontPixelSize( font );
-  QFontMetricsF fontMetrics( metricsFont );
-  return ( fontMetrics.ascent() / FONT_WORKAROUND_SCALE );
-}
-
-double QgsDecorationGrid::pixelFontSize( double pointSize ) const
-{
-  // return ( pointSize * 0.3527 );
-  // TODO fix font scaling problem - this seems to help, but text seems still a bit too small (about 5/6)
-  return pointSize;
-}
-
-QFont QgsDecorationGrid::scaledFontPixelSize( const QFont &font ) const
-{
-  QFont scaledFont = font;
-  double pixelSize = pixelFontSize( font.pointSizeF() ) * FONT_WORKAROUND_SCALE + 0.5;
-  scaledFont.setPixelSize( pixelSize );
-  return scaledFont;
 }
 
 void QgsDecorationGrid::checkMapUnitsChanged()

--- a/src/app/decorations/qgsdecorationgrid.h
+++ b/src/app/decorations/qgsdecorationgrid.h
@@ -19,6 +19,7 @@
 #define QGSDECORATIONGRID_H
 
 #include "qgsdecorationitem.h"
+#include "qgstextformat.h"
 
 class QPainter;
 class QgsLineSymbol;
@@ -31,23 +32,18 @@ class QgsMarkerSymbol;
 
 class APP_EXPORT QgsDecorationGrid: public QgsDecorationItem
 {
-    Q_OBJECT
-  public:
-    //! Constructor
-    QgsDecorationGrid( QObject *parent = nullptr );
 
+    Q_OBJECT
+
+  public:
+
+    QgsDecorationGrid( QObject *parent = nullptr );
     ~ QgsDecorationGrid() override;
 
     enum GridStyle
     {
       Line = 0, // lines
       Marker //markers
-    };
-
-    enum GridAnnotationPosition
-    {
-      InsideMapFrame = 0,
-      OutsideMapFrame
     };
 
     enum GridAnnotationDirection
@@ -57,6 +53,20 @@ class APP_EXPORT QgsDecorationGrid: public QgsDecorationItem
       HorizontalAndVertical,
       BoundaryDirection
     };
+
+    /**
+     * Returns the title text format.
+     * \see setTextFormat()
+     * \see labelExtents()
+     */
+    QgsTextFormat textFormat() const { return mTextFormat; }
+
+    /**
+     * Sets the title text \a format.
+     * \see textFormat()
+     * \see setLabelExtents()
+     */
+    void setTextFormat( const QgsTextFormat &format ) { mTextFormat = format; }
 
     //! Sets coordinate grid style.
     void setGridStyle( GridStyle style ) {mGridStyle = style;}
@@ -98,10 +108,6 @@ class APP_EXPORT QgsDecorationGrid: public QgsDecorationItem
     void setShowGridAnnotation( bool show ) {mShowGridAnnotation = show;}
     bool showGridAnnotation() const {return mShowGridAnnotation;}
 
-    //! Sets position of grid annotations. Possibilities are inside or outside of the map frame
-    void setGridAnnotationPosition( GridAnnotationPosition p ) {mGridAnnotationPosition = p;}
-    GridAnnotationPosition gridAnnotationPosition() const {return mGridAnnotationPosition;}
-
     //! Sets distance between map frame and annotations
     void setAnnotationFrameDistance( double d ) {mAnnotationFrameDistance = d;}
     double annotationFrameDistance() const {return mAnnotationFrameDistance;}
@@ -109,10 +115,6 @@ class APP_EXPORT QgsDecorationGrid: public QgsDecorationItem
     //! Sets grid annotation direction. Can be horizontal, vertical, direction of axis and horizontal and vertical
     void setGridAnnotationDirection( GridAnnotationDirection d ) {mGridAnnotationDirection = d;}
     GridAnnotationDirection gridAnnotationDirection() const {return mGridAnnotationDirection;}
-
-    //! Sets length of the cross segments (if grid style is cross)
-    /* void setCrossLength( double l ) {mCrossLength = l;} */
-    /* double crossLength() {return mCrossLength;} */
 
     //! Sets symbol that is used to draw grid lines. Takes ownership
     void setLineSymbol( QgsLineSymbol *symbol );
@@ -180,14 +182,10 @@ class APP_EXPORT QgsDecorationGrid: public QgsDecorationItem
     int mGridAnnotationPrecision;
     //! True if coordinate values should be drawn
     bool mShowGridAnnotation;
-    //! Annotation position inside or outside of map frame
-    GridAnnotationPosition mGridAnnotationPosition;
     //! Distance between map frame and annotation
     double mAnnotationFrameDistance;
     //! Annotation can be horizontal / vertical or different for axes
     GridAnnotationDirection mGridAnnotationDirection;
-    //! The length of the cross sides for mGridStyle Cross
-    /* double mCrossLength; */
 
     QgsLineSymbol *mLineSymbol = nullptr;
     QgsMarkerSymbol *mMarkerSymbol = nullptr;
@@ -196,51 +194,29 @@ class APP_EXPORT QgsDecorationGrid: public QgsDecorationItem
 
     /**
      * Draw coordinates for mGridAnnotationType Coordinate
-        \param p drawing painter
-    \param hLines horizontal coordinate lines in item coordinates
-        \param vLines vertical coordinate lines in item coordinates*/
-    void drawCoordinateAnnotations( QPainter *p, const QList< QPair< qreal, QLineF > > &hLines, const QList< QPair< qreal, QLineF > > &vLines );
-    void drawCoordinateAnnotation( QPainter *p, QPointF pos, const QString &annotationString );
-
-    /**
-     * Draws a single annotation
-        \param p drawing painter
-        \param pos item coordinates where to draw
-        \param rotation text rotation
-        \param annotationText the text to draw*/
-    void drawAnnotation( QPainter *p, QPointF pos, int rotation, const QString &annotationText );
+     * \param p drawing painter
+     * \param hLines horizontal coordinate lines in item coordinates
+     * \param vLines vertical coordinate lines in item coordinates
+     */
+    void drawCoordinateAnnotations( QgsRenderContext &context, const QList< QPair< qreal, QLineF > > &hLines, const QList< QPair< qreal, QLineF > > &vLines );
+    void drawCoordinateAnnotation( QgsRenderContext &context, QPointF pos, const QString &annotationString );
 
     /**
      * Returns the grid lines with associated coordinate value
-        \returns 0 in case of success*/
+     * \returns 0 in case of success
+     */
     int xGridLines( const QgsMapSettings &mapSettings, QList< QPair< qreal, QLineF > > &lines ) const;
 
     /**
      * Returns the grid lines for the y-coordinates. Not vertical in case of rotation
-        \returns 0 in case of success*/
+     * \returns 0 in case of success
+     */
     int yGridLines( const QgsMapSettings &mapSettings, QList< QPair< qreal, QLineF > > &lines ) const;
 
     //! Returns the item border of a point (in item coordinates)
     Border borderForLineCoord( QPointF point, QPainter *p ) const;
 
-    /**
-     * Draws Text. Takes care about all the composer specific issues (calculation to pixel, scaling of font and painter
-     to work around the Qt font bug)*/
-    void drawText( QPainter *p, double x, double y, const QString &text, const QFont &font ) const;
-    //! Like the above, but with a rectangle for multiline text
-    void drawText( QPainter *p, const QRectF &rect, const QString &text, const QFont &font, Qt::AlignmentFlag halignment = Qt::AlignLeft, Qt::AlignmentFlag valignment = Qt::AlignTop ) const;
-    //! Returns the font width in millimeters (considers upscaling and downscaling with FONT_WORKAROUND_SCALE
-    double textWidthMillimeters( const QFont &font, const QString &text ) const;
-    //! Returns the font height of a character in millimeters.
-    double fontHeightCharacterMM( const QFont &font, QChar c ) const;
-    //! Returns the font ascent in Millimeters (considers upscaling and downscaling with FONT_WORKAROUND_SCALE
-    double fontAscentMillimeters( const QFont &font ) const;
-    //! Calculates font to from point size to pixel size
-    double pixelFontSize( double pointSize ) const;
-    //! Returns a font where size is in pixel and font size is upscaled with FONT_WORKAROUND_SCALE
-    QFont scaledFontPixelSize( const QFont &font ) const;
-
-    /* friend class QgsDecorationGridDialog; */
+    QgsTextFormat mTextFormat;
 };
 
 #endif

--- a/src/app/decorations/qgsdecorationgriddialog.cpp
+++ b/src/app/decorations/qgsdecorationgriddialog.cpp
@@ -46,8 +46,6 @@ QgsDecorationGridDialog::QgsDecorationGridDialog( QgsDecorationGrid &deco, QWidg
   mMarkerSymbolButton->setSymbolType( QgsSymbol::Marker );
   mLineSymbolButton->setSymbolType( QgsSymbol::Line );
 
-  mAnnotationFontButton->setMode( QgsFontButton::ModeQFont );
-
   grpEnable->setChecked( mDeco.enabled() );
   connect( grpEnable, &QGroupBox::toggled, this, [ = ] { updateSymbolButtons(); } );
 
@@ -71,7 +69,11 @@ QgsDecorationGridDialog::QgsDecorationGridDialog( QgsDecorationGrid &deco, QWidg
   updateGuiElements();
 
   connect( buttonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsDecorationGridDialog::apply );
-  connect( mAnnotationFontButton, &QgsFontButton::changed, this, &QgsDecorationGridDialog::annotationFontChanged );
+
+  // font settings
+  mAnnotationFontButton->setDialogTitle( tr( "Annotation Text Format" ) );
+  mAnnotationFontButton->setMapCanvas( QgisApp::instance()->mapCanvas() );
+  mAnnotationFontButton->setTextFormat( mDeco.textFormat() );
 
   mMarkerSymbolButton->setMapCanvas( QgisApp::instance()->mapCanvas() );
   mMarkerSymbolButton->setMessageBar( QgisApp::instance()->messageBar() );
@@ -100,6 +102,8 @@ void QgsDecorationGridDialog::updateGuiElements()
   // mLineWidthSpinBox->setValue( gridPen.widthF() );
   // mLineColorButton->setColor( gridPen.color() );
 
+  mAnnotationFontButton->setTextFormat( mDeco.textFormat() );
+
   mLineSymbolButton->setSymbol( mDeco.lineSymbol()->clone() );
   mMarkerSymbolButton->setSymbol( mDeco.markerSymbol()->clone() );
 
@@ -120,17 +124,9 @@ void QgsDecorationGridDialog::updateDecoFromGui()
   mDeco.setGridOffsetX( mOffsetXEdit->text().toDouble() );
   mDeco.setGridOffsetY( mOffsetYEdit->text().toDouble() );
   mDeco.setGridStyle( static_cast< QgsDecorationGrid::GridStyle >( mGridTypeComboBox->currentData().toInt() ) );
+
+  mDeco.setTextFormat( mAnnotationFontButton->textFormat() );
   mDeco.setAnnotationFrameDistance( mDistanceToMapFrameSpinBox->value() );
-
-  // if ( mAnnotationPositionComboBox->currentText() == tr( "Inside frame" ) )
-  // {
-  //   mDeco.setGridAnnotationPosition( QgsDecorationGrid::InsideMapFrame );
-  // }
-  // else
-  // {
-  //   mDeco.setGridAnnotationPosition( QgsDecorationGrid::OutsideMapFrame );
-  // }
-
   mDeco.setShowGridAnnotation( mDrawAnnotationCheckBox->isChecked() );
   QString text = mAnnotationDirectionComboBox->currentText();
   if ( text == tr( "Horizontal" ) )
@@ -224,11 +220,6 @@ void QgsDecorationGridDialog::mPbtnUpdateFromLayer_clicked()
     else
       mCoordinatePrecisionSpinBox->setValue( 3 );
   }
-}
-
-void QgsDecorationGridDialog::annotationFontChanged()
-{
-  mDeco.setGridAnnotationFont( mAnnotationFontButton->currentFont() );
 }
 
 void QgsDecorationGridDialog::updateInterval( bool force )

--- a/src/app/decorations/qgsdecorationgriddialog.h
+++ b/src/app/decorations/qgsdecorationgriddialog.h
@@ -43,10 +43,6 @@ class APP_EXPORT QgsDecorationGridDialog : public QDialog, private Ui::QgsDecora
     void mPbtnUpdateFromExtents_clicked();
     void mPbtnUpdateFromLayer_clicked();
 
-    // from composer map
-    /* void on_mLineColorButton_clicked(); */
-    void annotationFontChanged();
-
   private:
     QgsDecorationGrid &mDeco;
 

--- a/src/app/decorations/qgsdecorationtitle.h
+++ b/src/app/decorations/qgsdecorationtitle.h
@@ -49,14 +49,14 @@ class APP_EXPORT QgsDecorationTitle : public QgsDecorationItem
     void render( const QgsMapSettings &mapSettings, QgsRenderContext &context ) override;
 
     /**
-     * Returns the text format for extent labels.
+     * Returns the title text format.
      * \see setTextFormat()
      * \see labelExtents()
      */
     QgsTextFormat textFormat() const { return mTextFormat; }
 
     /**
-     * Sets the text \a format for extent labels.
+     * Sets the title text \a format.
      * \see textFormat()
      * \see setLabelExtents()
      */


### PR DESCRIPTION
## Description

This PR fixes an issue with the grid decoration (issue #37028) whereas the hardcoded black color used to render grid annotations made those unreadable when hovering dark parts of the canvas.

~~Before vs~~ PR:
![Screenshot from 2020-06-11 15-42-12](https://user-images.githubusercontent.com/1728657/84364749-b2504480-abfa-11ea-99b7-e6a315ea3483.png)

The fix involved using our QgsTextRenderer class, which as a collateral benefit allows us to get rid of a bunch of unmaintained code in the grid decoration class. Win-win.