### PR TITLE
fixes invalid relation in search form

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
@@ -207,6 +207,8 @@ void QgsRelationReferenceSearchWidgetWrapper::initWidget( QWidget *editor )
   }
 
   QgsRelation relation = QgsProject::instance()->relationManager()->relation( config( QStringLiteral( "Relation" ) ).toString() );
+  if ( !relation.isValid() && !layer()->referencingRelations( mFieldIdx ).isEmpty() )
+    relation = layer()->referencingRelations( mFieldIdx )[0];
   mWidget->setRelation( relation, false );
 
   mWidget->showIndeterminateState();

--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
@@ -207,7 +207,8 @@ void QgsRelationReferenceSearchWidgetWrapper::initWidget( QWidget *editor )
   }
 
   QgsRelation relation = QgsProject::instance()->relationManager()->relation( config( QStringLiteral( "Relation" ) ).toString() );
-  if ( !relation.isValid() && !layer()->referencingRelations( mFieldIdx ).isEmpty() )
+  // if no relation is given from the config, fetch one if there is only one available
+  if ( !relation.isValid() && !layer()->referencingRelations( mFieldIdx ).isEmpty() && layer()->referencingRelations( mFieldIdx ).count() == 1 )
     relation = layer()->referencingRelations( mFieldIdx )[0];
   mWidget->setRelation( relation, false );
 


### PR DESCRIPTION
fixes #34410

If the relation is not defined in the config, guess it from the layer.
The config is empty while we are initalizing the attribute form of the referencing layer for the search widget wrapper.
There might be a better (more correct) fix by correctly initializing the form but I could not easily find out.
This approach sounds reasonable to me.