### PR TITLE
FIX virtual layers with CSV layers opened with "delimitedtext" provider

### DIFF
--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -61,6 +61,15 @@ QRegExp QgsDelimitedTextProvider::sCrdDmsRegexp( "^\\s*(?:([-+nsew])\\s*)?(\\d{1
 QgsDelimitedTextProvider::QgsDelimitedTextProvider( const QString &uri, const ProviderOptions &options )
   : QgsVectorDataProvider( uri, options )
 {
+  // uri should be in the form of "file:///path/to/file.csv?query=params", if not, enforce it in that format
+  // first read the already encoded url to get the query string
+  QUrl url = QUrl::fromEncoded( uri.toLatin1() );
+  // temporarily store the query string
+  const QString tmpUrlQuery = url.query();
+  // make sure that the url is actually prefixed with "file://". However, this breaks the query part ("?" char gets encoded), so discard the query string
+  url = QUrl::fromLocalFile( url.path() );
+  // finally restore the query part
+  url.setQuery( tmpUrlQuery );
 
   // Add supported types to enable creating expression fields in field calculator
   setNativeTypes( QList< NativeType >()
@@ -72,7 +81,6 @@ QgsDelimitedTextProvider::QgsDelimitedTextProvider( const QString &uri, const Pr
 
   QgsDebugMsgLevel( "Delimited text file uri is " + uri, 2 );
 
-  const QUrl url = QUrl::fromEncoded( uri.toLatin1() );
   mFile = qgis::make_unique< QgsDelimitedTextFile >();
   mFile->setFromUrl( url );
 

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -562,9 +562,11 @@ void QgsVirtualLayerProvider::updateStatistics() const
   Q_ASSERT( ! mTableName.isNull() );
 
   QString sql = QStringLiteral( "SELECT Count(*)%1 FROM %2%3" )
-                .arg( hasGeometry ? QStringLiteral( ",Min(MbrMinX(%1)),Min(MbrMinY(%1)),Max(MbrMaxX(%1)),Max(MbrMaxY(%1))" ).arg( quotedColumn( mDefinition.geometryField() ) ) : QString(),
-                      mTableName,
-                      subset );
+                .arg(
+                  hasGeometry ? QStringLiteral( ",Min(MbrMinX(%1)),Min(MbrMinY(%1)),Max(MbrMaxX(%1)),Max(MbrMaxY(%1))" ).arg( quotedColumn( mDefinition.geometryField() ) ) : QString(),
+                  mTableName,
+                  subset
+                );
   Sqlite::Query q( mSqlite.get(), sql );
   if ( q.step() == SQLITE_ROW )
   {

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -317,6 +317,7 @@ bool QgsVirtualLayerProvider::createIt()
       provider.replace( QLatin1String( "'" ), QLatin1String( "''" ) );
       QString source = mLayers.at( i ).source;
       source.replace( QLatin1String( "'" ), QLatin1String( "''" ) );
+      // the encoding might be an empty string, which breaks the SQL query below
       QString encoding = mLayers.at( i ).encoding.isEmpty()
                          ? QStringLiteral( "System" )
                          : mLayers.at( i ).encoding;
@@ -559,6 +560,7 @@ void QgsVirtualLayerProvider::updateStatistics() const
   bool hasGeometry = mDefinition.geometryWkbType() != QgsWkbTypes::NoGeometry;
   QString subset = mSubset.isEmpty() ? QString() : QStringLiteral( " WHERE %1" ).arg( mSubset );
 
+  // `mTableName` might be a null string if the layer creation failed. Assert such situations at least during development.
   Q_ASSERT( ! mTableName.isNull() );
 
   QString sql = QStringLiteral( "SELECT Count(*)%1 FROM %2%3" )

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -317,7 +317,9 @@ bool QgsVirtualLayerProvider::createIt()
       provider.replace( QLatin1String( "'" ), QLatin1String( "''" ) );
       QString source = mLayers.at( i ).source;
       source.replace( QLatin1String( "'" ), QLatin1String( "''" ) );
-      QString encoding = mLayers.at( i ).encoding;
+      QString encoding = mLayers.at( i ).encoding.isEmpty()
+                         ? QStringLiteral( "System" )
+                         : mLayers.at( i ).encoding;
       QString createStr = QStringLiteral( "DROP TABLE IF EXISTS \"%1\"; CREATE VIRTUAL TABLE \"%1\" USING QgsVLayer('%2','%4',%3)" )
                           .arg( vname,
                                 provider,
@@ -555,7 +557,10 @@ QgsRectangle QgsVirtualLayerProvider::extent() const
 void QgsVirtualLayerProvider::updateStatistics() const
 {
   bool hasGeometry = mDefinition.geometryWkbType() != QgsWkbTypes::NoGeometry;
-  QString subset = mSubset.isEmpty() ? QString() : " WHERE " + mSubset;
+  QString subset = mSubset.isEmpty() ? QString() : QStringLiteral( " WHERE %1" ).arg( mSubset );
+
+  Q_ASSERT( ! mTableName.isNull() );
+
   QString sql = QStringLiteral( "SELECT Count(*)%1 FROM %2%3" )
                 .arg( hasGeometry ? QStringLiteral( ",Min(MbrMinX(%1)),Min(MbrMinY(%1)),Max(MbrMaxX(%1)),Max(MbrMaxY(%1))" ).arg( quotedColumn( mDefinition.geometryField() ) ) : QString(),
                       mTableName,

--- a/tests/src/python/test_qgsdelimitedtextprovider.py
+++ b/tests/src/python/test_qgsdelimitedtextprovider.py
@@ -63,7 +63,7 @@ try:
     class MyUrl:
 
         def __init__(self, url):
-            self.url = url
+            self.url = QUrl(url)
             self.query = QUrlQuery()
 
         @classmethod
@@ -127,6 +127,29 @@ class MessageLogger(QObject):
 
     def messages(self):
         return self.log
+
+
+class TestQgsDelimitedTextProviderLoading(unittest.TestCase):
+
+    def test_open_filepath_with_file_prefix(self):
+        srcpath = os.path.join(TEST_DATA_DIR, 'provider')
+        basetestfile = os.path.join(srcpath, 'delimited_xy.csv')
+
+        url = MyUrl.fromLocalFile(basetestfile)
+        url.addQueryItem("type", "csv")
+
+        vl = QgsVectorLayer(url.toString(), 'test', 'delimitedtext')
+        assert vl.isValid(), "{} is invalid".format(basetestfile)
+
+    def test_treat_open_filepath_without_file_prefix(self):
+        srcpath = os.path.join(TEST_DATA_DIR, 'provider')
+        basetestfile = os.path.join(srcpath, 'delimited_xy.csv')
+
+        url = MyUrl(basetestfile)
+        url.addQueryItem("type", "csv")
+
+        vl = QgsVectorLayer(url.toString(), 'test', 'delimitedtext')
+        assert vl.isValid(), "{} is invalid".format(basetestfile)
 
 
 class TestQgsDelimitedTextProviderXY(unittest.TestCase, ProviderTestCase):


### PR DESCRIPTION
cWhen using a CSV layer opened via "delimitedtext" provider (e.g. the delimited text dialog) in virtual layer, everything work fine until the project is reloaded.

In that case, some weird behabiour is observed - the virtual layer becomes invalid, because the CSV file name is not prefixed with `file://` and this breaks the layer itself, the layer properties etc.

This PR makes sure that the "delimitedtext" provider is always working with paths, prefixed with `file://`, which prevents the odd behaviour of occuring and makes sure the project with virtual layers can be successfully re-opened.

Fixes #32259