### PR TITLE
[backport] Fix image size ignored in image widget

### DIFF
--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
@@ -185,6 +185,14 @@ void QgsExternalResourceWidgetWrapper::initWidget( QWidget *editor )
     {
       mQgsWidget->fileWidget()->setFilter( cfg.value( QStringLiteral( "FileWidgetFilter" ) ).toString() );
     }
+    if ( cfg.contains( QStringLiteral( "DocumentViewerHeight" ) ) )
+    {
+      mQgsWidget->setDocumentViewerHeight( cfg.value( QStringLiteral( "DocumentViewerHeight" ) ).toInt( ) );
+    }
+    if ( cfg.contains( QStringLiteral( "DocumentViewerWidth" ) ) )
+    {
+      mQgsWidget->setDocumentViewerWidth( cfg.value( QStringLiteral( "DocumentViewerWidth" ) ).toInt( ) );
+    }
   }
 
   if ( mLineEdit )


### PR DESCRIPTION
Fixes #33682  (maybe)

Cherry-pick from master commit 72c0ae73ba6822cec66
