### PR TITLE
PostgreSQL composite PK with bigint component

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1212,7 +1212,6 @@ QString QgsPostgresConn::quotedValue( const QVariant &value )
   {
     case QVariant::Int:
     case QVariant::LongLong:
-    case QVariant::Double:
       return value.toString();
 
     case QVariant::DateTime:
@@ -1228,6 +1227,8 @@ QString QgsPostgresConn::quotedValue( const QVariant &value )
     case QVariant::List:
       return quotedList( value.toList() );
 
+    // we need to pass floating point values quoted to the DBMS
+    case QVariant::Double:
     case QVariant::String:
     default:
       return quotedString( value.toString() );

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1212,6 +1212,7 @@ QString QgsPostgresConn::quotedValue( const QVariant &value )
   {
     case QVariant::Int:
     case QVariant::LongLong:
+    case QVariant::Double:
       return value.toString();
 
     case QVariant::DateTime:
@@ -1227,8 +1228,6 @@ QString QgsPostgresConn::quotedValue( const QVariant &value )
     case QVariant::List:
       return quotedList( value.toList() );
 
-    // we need to pass floating point values quoted to the DBMS
-    case QVariant::Double:
     case QVariant::String:
     default:
       return quotedString( value.toString() );

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -783,8 +783,16 @@ bool QgsPostgresFeatureIterator::getFeature( QgsPostgresResult &queryResult, int
       Q_FOREACH ( int idx, mSource->mPrimaryKeyAttrs )
       {
         QgsField fld = mSource->mFields.at( idx );
+        QVariant v;
 
-        QVariant v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), queryResult.PQgetvalue( row, col ), fld.typeName() );
+        if ( fld.type() == QVariant::LongLong )
+        {
+          v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), QString::number( mConn->getBinaryInt( queryResult, row, col ) ), fld.typeName() );
+        }
+        else
+        {
+          v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), queryResult.PQgetvalue( row, col ), fld.typeName() );
+        }
         primaryKeyVals << v;
 
         if ( !subsetOfAttributes || fetchAttributes.contains( idx ) )

--- a/tests/src/providers/testqgspostgresprovider.cpp
+++ b/tests/src/providers/testqgspostgresprovider.cpp
@@ -252,7 +252,7 @@ void TestQgsPostgresProvider::testQuotedValueBigInt()
   sdata->clear();
   sdata->insertFid( 1LL, vlst );
 
-  QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_double\"=3.141592741" ) );
+  QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_double\"='3.141592741'" ) );
 
   // text
   f3.setName( "fld_text" );

--- a/tests/src/providers/testqgspostgresprovider.cpp
+++ b/tests/src/providers/testqgspostgresprovider.cpp
@@ -252,7 +252,7 @@ void TestQgsPostgresProvider::testQuotedValueBigInt()
   sdata->clear();
   sdata->insertFid( 1LL, vlst );
 
-  QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_double\"='3.141592741'" ) );
+  QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_double\"=3.141592741" ) );
 
   // text
   f3.setName( "fld_text" );

--- a/tests/src/providers/testqgspostgresprovider.cpp
+++ b/tests/src/providers/testqgspostgresprovider.cpp
@@ -207,7 +207,7 @@ void TestQgsPostgresProvider::testQuotedValueBigInt()
   // 4 byte integer
   f0.setName( "fld_integer" );
   f0.setType( QVariant::Int );
-  f0.setTypeName( "int" );
+  f0.setTypeName( "int4" );
 
   fields.append( f0 );
   pkAttrs.append( 0 );
@@ -292,9 +292,7 @@ void TestQgsPostgresProvider::testQuotedValueBigInt()
   sdata->clear();
   sdata->insertFid( 1LL, vlst );
 
-  // TODO: FIXME: in tables with composite PKs, integer fields are cast to text, but their values are not.
-  // It hurts the database performance badly.
-  QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_bigint\"=-9223372036854775800 AND \"fld_text\"::text='QGIS ''Rocks''!' AND \"fld_integer\"::text=42" ) );
+  QCOMPARE( QgsPostgresUtils::whereClause( 1LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ), QString( "\"fld_bigint\"=-9223372036854775800 AND \"fld_text\"::text='QGIS ''Rocks''!' AND \"fld_integer\"=42" ) );
 }
 
 QGSTEST_MAIN( TestQgsPostgresProvider )

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -786,7 +786,9 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(f.isValid())
         self.assertEqual(f['pk1'], 1)
         self.assertEqual(f['pk2'], 2)
-        self.assertEqual(f['pk3'], 3.1415927)
+
+        # round() needed to make sure Python older than 3.8 do the right thing.
+        self.assertEqual(round(f['pk3'], 5), round(3.1415927, 5))
         self.assertEqual(f['value'], 'test 2')
 
         # can we edit a field?
@@ -801,7 +803,8 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(f2.isValid())
 
         # just making sure we have the correct feature
-        self.assertEqual(f2['pk3'], 3.1415927)
+        # round() needed to make sure Python older than 3.8 do the right thing.
+        self.assertEqual(round(f2['pk3'], 5), round(3.1415927, 5))
 
         # Then, making sure we really did change our value.
         self.assertEqual(f2['value'], 'Edited Test 2')
@@ -821,7 +824,9 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         f4 = next(vl2.getFeatures(QgsFeatureRequest().setFilterExpression('pk2 = -9223372036854775800')))
 
         self.assertTrue(f4.isValid())
-        expected_attrs = [4, -9223372036854775800, 7.29154, 'other test']
+        # round() needed to make sure Python older than 3.8 do the right thing.
+        expected_attrs = [4, -9223372036854775800, round(7.29154, 5), 'other test']
+        gotten_attrs = [f4['pk1'], f4['pk2'], round(f4['pk3'], 5), f4['value']]
         self.assertEqual(f4.attributes(), expected_attrs)
 
         # Finally, let's delete one of the features.
@@ -851,7 +856,9 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         fields = vl.fields()
         f = next(vl.getFeatures(QgsFeatureRequest().setFilterExpression('pk = 3.141592741')))
         self.assertTrue(f.isValid())
-        self.assertEqual(f['pk'], 3.1415927)
+
+        # round() needed to make sure Python older than 3.8 do the right thing.
+        self.assertEqual(round(f['pk'], 5), round(3.1415927, 5))
         self.assertEqual(f['value'], 'first test')
 
         # editing

--- a/tests/testdata/provider/testdata_pg_bigint_pk.sql
+++ b/tests/testdata/provider/testdata_pg_bigint_pk.sql
@@ -104,20 +104,29 @@ INSERT INTO qgis_test.provider_bigint_nonfirst_pk  (zeroth_field, key1, key2, pr
 (1, 2, 3, 4,  400, 'Honey', 'Honey', '4', TIMESTAMP '2021-05-04 13:13:14', '2021-05-04', '13:13:14', '0101000020E610000014AE47E17A5450C03333333333935340')
 ;
 
-/* -- PostgreSQL 12 or later
+CREATE TABLE qgis_test.tb_test_compound_pk
+(
+    pk1 INTEGER,
+    pk2 BIGINT,
+    pk3 REAL,
+    value VARCHAR(16),
+    geom geometry(Point, 4326),
+    PRIMARY KEY (pk1, pk2, pk3)
+);
 
-DROP TABLE IF EXISTS qgis_test.bigint_partitioned;
+INSERT INTO qgis_test.tb_test_compound_pk (pk1, pk2, pk3, value, geom) VALUES
+    (1, 1, 1.0, 'test 1', ST_SetSRID(ST_Point(-47.930, -15.818), 4326)),
+    (1, 2, 3.141592741, 'test 2', ST_SetSRID(ST_Point(-47.887, -15.864), 4326)),
+    (2, 2, 2.718281828, 'test 3', ST_SetSRID(ST_Point(-47.902, -15.763), 4326)),
+    (2, 2, 1.0, 'test 4', ST_SetSRID(ST_Point(-47.952, -15.781), 4326));
 
-CREATE TABLE qgis_test.bigint_partitioned (
-  pk BIGSERIAL NOT NULL,
-  value varchar(8),
-  geom geometry(Point, 4326)
-) PARTITION BY RANGE(pk);
+CREATE TABLE qgis_test.tb_test_float_pk
+(
+    pk REAL PRIMARY KEY,
+    value VARCHAR(16),
+    geom geometry(Point, 4326)
+);
 
-CREATE TABLE qgis_test.bigint_partitioned_positive PARTITION OF qgis_test.bigint_partitioned
-  FOR VALUES FROM 1 TO 1000;
-CREATE TABLE qgis_test.bigint_partitioned_nonpositive PARTITION OF qgis_test.bigint_partitioned
-  FOR VALUES FROM -1 TO 0;
-
-ALTER TABLE qgis_test.bigint_partitioned ADD PRIMARY KEY(pk);
-*/
+INSERT INTO qgis_test.tb_test_float_pk (pk, value, geom) VALUES
+    (3.141592741, 'first test', ST_SetSRID(ST_Point(-47.887, -15.864), 4326)),
+    (2.718281828, 'second test', ST_SetSRID(ST_Point(-47.902, -15.763), 4326));

--- a/tests/testdata/provider/testdata_pg_bigint_pk.sql
+++ b/tests/testdata/provider/testdata_pg_bigint_pk.sql
@@ -108,17 +108,16 @@ CREATE TABLE qgis_test.tb_test_compound_pk
 (
     pk1 INTEGER,
     pk2 BIGINT,
-    pk3 REAL,
     value VARCHAR(16),
     geom geometry(Point, 4326),
-    PRIMARY KEY (pk1, pk2, pk3)
+    PRIMARY KEY (pk1, pk2)
 );
 
-INSERT INTO qgis_test.tb_test_compound_pk (pk1, pk2, pk3, value, geom) VALUES
-    (1, 1, 1.0, 'test 1', ST_SetSRID(ST_Point(-47.930, -15.818), 4326)),
-    (1, 2, 3.14159, 'test 2', ST_SetSRID(ST_Point(-47.887, -15.864), 4326)),
-    (2, 2, 2.718281828, 'test 3', ST_SetSRID(ST_Point(-47.902, -15.763), 4326)),
-    (2, 2, 1.0, 'test 4', ST_SetSRID(ST_Point(-47.952, -15.781), 4326));
+INSERT INTO qgis_test.tb_test_compound_pk (pk1, pk2, value, geom) VALUES
+    (1, 1, 'test 1', ST_SetSRID(ST_Point(-47.930, -15.818), 4326)),
+    (1, 2, 'test 2', ST_SetSRID(ST_Point(-47.887, -15.864), 4326)),
+    (2, 1, 'test 3', ST_SetSRID(ST_Point(-47.902, -15.763), 4326)),
+    (2, 2, 'test 4', ST_SetSRID(ST_Point(-47.952, -15.781), 4326));
 
 CREATE TABLE qgis_test.tb_test_float_pk
 (
@@ -128,5 +127,5 @@ CREATE TABLE qgis_test.tb_test_float_pk
 );
 
 INSERT INTO qgis_test.tb_test_float_pk (pk, value, geom) VALUES
-    (3.14159, 'first test', ST_SetSRID(ST_Point(-47.887, -15.864), 4326)),
+    (3.14159, 'first test',  ST_SetSRID(ST_Point(-47.887, -15.864), 4326)),
     (2.71828, 'second test', ST_SetSRID(ST_Point(-47.902, -15.763), 4326));

--- a/tests/testdata/provider/testdata_pg_bigint_pk.sql
+++ b/tests/testdata/provider/testdata_pg_bigint_pk.sql
@@ -116,7 +116,7 @@ CREATE TABLE qgis_test.tb_test_compound_pk
 
 INSERT INTO qgis_test.tb_test_compound_pk (pk1, pk2, pk3, value, geom) VALUES
     (1, 1, 1.0, 'test 1', ST_SetSRID(ST_Point(-47.930, -15.818), 4326)),
-    (1, 2, 3.141592741, 'test 2', ST_SetSRID(ST_Point(-47.887, -15.864), 4326)),
+    (1, 2, 3.14159, 'test 2', ST_SetSRID(ST_Point(-47.887, -15.864), 4326)),
     (2, 2, 2.718281828, 'test 3', ST_SetSRID(ST_Point(-47.902, -15.763), 4326)),
     (2, 2, 1.0, 'test 4', ST_SetSRID(ST_Point(-47.952, -15.781), 4326));
 
@@ -128,5 +128,5 @@ CREATE TABLE qgis_test.tb_test_float_pk
 );
 
 INSERT INTO qgis_test.tb_test_float_pk (pk, value, geom) VALUES
-    (3.141592741, 'first test', ST_SetSRID(ST_Point(-47.887, -15.864), 4326)),
-    (2.718281828, 'second test', ST_SetSRID(ST_Point(-47.902, -15.763), 4326));
+    (3.14159, 'first test', ST_SetSRID(ST_Point(-47.887, -15.864), 4326)),
+    (2.71828, 'second test', ST_SetSRID(ST_Point(-47.902, -15.763), 4326));


### PR DESCRIPTION
Bigint PostgreSQL fields are handled correctly if they are part of a
composite primary key. As a bonus, we always pass double values as
quoted to the DBMS (but not cast to text). With this one can work with
tables with real/double primary keys without the penalty of casting
these values to text. Fixes #37126.

Also added test cases for working with tables with composite primary keys, and tables whose primary key is of a floating point type.