### PR TITLE
Reactivate (some) WMS GetPrint unit tests

### DIFF
--- a/.ci/travis/linux/scripts/test_blocklist.txt
+++ b/.ci/travis/linux/scripts/test_blocklist.txt
@@ -23,6 +23,3 @@ qgis_layerdefinition
 
 # MSSQL requires the MSSQL docker
 PyQgsProviderConnectionMssql
-
-# Broken - segfaults on Travis, likely due to a real issue in the server code
-PyQgsServerWMSGetPrint

--- a/tests/src/python/test_qgsserver_wms_getprint.py
+++ b/tests/src/python/test_qgsserver_wms_getprint.py
@@ -35,7 +35,7 @@ import base64
 import subprocess
 
 from test_qgsserver import QgsServerTestBase
-from qgis.core import QgsProject, QgsRenderChecker, QgsMultiRenderChecker, Qt
+from qgis.core import QgsProject, QgsRenderChecker, QgsMultiRenderChecker
 from qgis.server import QgsServerRequest
 from utilities import getExecutablePath, unitTestDataPath
 

--- a/tests/src/python/test_qgsserver_wms_getprint.py
+++ b/tests/src/python/test_qgsserver_wms_getprint.py
@@ -25,7 +25,7 @@ import urllib.parse
 import urllib.error
 
 from qgis.testing import unittest
-from qgis.PyQt.QtCore import QSize
+from qgis.PyQt.QtCore import QSize, Qt
 from qgis.PyQt.QtGui import QImage, QPainter
 from qgis.PyQt.QtSvg import QSvgRenderer, QSvgGenerator
 

--- a/tests/src/python/test_qgsserver_wms_getprint.py
+++ b/tests/src/python/test_qgsserver_wms_getprint.py
@@ -619,6 +619,7 @@ class TestQgsServerWMSGetPrint(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self._img_diff_error(r, h, "WMS_GetPrint_LabelRemoved")
 
+    @unittest.skipIf(os.environ.get('TRAVIS', '') == 'true', 'Flaky test')
     def test_wms_getprint_two_maps(self):
         """Test map0 and map1 apply to the correct maps"""
         qs = "?" + "&".join(["%s=%s" % i for i in list({
@@ -639,6 +640,7 @@ class TestQgsServerWMSGetPrint(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self._img_diff_error(r, h, "WMS_GetPrint_TwoMaps")
 
+    @unittest.skipIf(os.environ.get('TRAVIS', '') == 'true', 'Flaky test')
     def test_wms_getprint_atlas(self):
         qs = "?" + "&".join(["%s=%s" % i for i in list({
             "MAP": urllib.parse.quote(self.projectPath),
@@ -654,6 +656,7 @@ class TestQgsServerWMSGetPrint(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self._img_diff_error(r, h, "WMS_GetPrint_Atlas")
 
+    @unittest.skipIf(os.environ.get('TRAVIS', '') == 'true', 'Flaky test')
     def test_wms_getprint_atlas_getProjectSettings(self):
         qs = "?" + "&".join(["%s=%s" % i for i in list({
             "MAP": urllib.parse.quote(self.projectPath),


### PR DESCRIPTION
## Description

After some experimentation with Travis, it seems that 3 tests are actually flaky and cause a segfault:

- `test_wms_getprint_atlas_getProjectSettings`
- `test_wms_getprint_atlas`
- `test_wms_getprint_two_maps`

However, segfault doesn't seem to be happening when these tests are executed alone. I didn't find the origin of the segfault but I'd like to reactivate all the other tests to have a basic test coverage for the WMS `GetPrint` request.