### PR TITLE
Fix encoding of ellipsis in Windows hopefully #37174

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -889,7 +889,7 @@ void QgsMapCanvas::showContextMenu( QgsMapMouseEvent *event )
     }
   }
   copyCoordinateMenu->addSeparator();
-  QAction *setCustomCrsAction = new QAction( QStringLiteral( "Set Custom CRS…" ), mMenu );
+  QAction *setCustomCrsAction = new QAction( tr( "Set Custom CRS…" ), mMenu );
   connect( setCustomCrsAction, &QAction::triggered, this, [ = ]
   {
     QgsProjectionSelectionDialog selector( this );


### PR DESCRIPTION
See #37174, this will hopefull fix the encoding of the ellipsis in Windows. 

I'm myself not able to see if it works untill the nightly of Windows is build.

Also: I'm not sure if

`QString( "Set Custom CRS" ).append( QChar( 0x2026 )`

instead of

`QStringLiteral( "Set Custom CRS…" )`

is the proper way to do this (or if there are other better string concat options).

(The QStringLiteral (marco?) did not accept an inline concat of string+QChar)

Feel free to ignore or edit for better ways...

Fixes #37174