### PR TITLE
[ui] Improve looks of variable editor widget on non-default themes

### DIFF
--- a/src/gui/qgsvariableeditorwidget.cpp
+++ b/src/gui/qgsvariableeditorwidget.cpp
@@ -485,16 +485,9 @@ void QgsVariableEditorTree::drawRow( QPainter *painter, const QStyleOptionViewIt
     QColor baseColor = item->data( 0, RowBaseColor ).value<QColor>();
     if ( index.row() % 2 == 1 )
     {
-      baseColor = baseColor.lighter( 110 );
+      baseColor.setAlpha( 59 );
     }
     painter->fillRect( option.rect, baseColor );
-
-    //declare custom text color since we've overwritten default background color
-    QPalette pal = opt.palette;
-    pal.setColor( QPalette::Active, QPalette::Text, Qt::black );
-    pal.setColor( QPalette::Inactive, QPalette::Text, Qt::black );
-    pal.setColor( QPalette::Disabled, QPalette::Text, Qt::gray );
-    opt.palette = pal;
   }
   QTreeWidget::drawRow( painter, opt, index );
   QColor color = static_cast<QRgb>( QApplication::style()->styleHint( QStyle::SH_Table_GridLineColor, &opt ) );
@@ -511,18 +504,18 @@ QColor QgsVariableEditorTree::rowColor( int index ) const
   switch ( colorIdx )
   {
     case 0:
-      return QColor( 255, 220, 167 );
+      return QColor( 255, 163, 0, 89 );
     case 1:
-      return QColor( 255, 255, 191 );
+      return QColor( 255, 255, 77, 89 );
     case 2:
-      return QColor( 191, 255, 191 );
+      return QColor( 0, 255, 77, 89 );
     case 3:
-      return QColor( 199, 255, 255 );
+      return QColor( 0, 255, 255, 89 );
     case 4:
-      return QColor( 234, 191, 255 );
+      return QColor( 196, 125, 255, 89 );
     case 5:
     default:
-      return QColor( 255, 191, 239 );
+      return QColor( 255, 125, 225, 89 );
   }
 }
 


### PR DESCRIPTION
## Description
This PR improves the looks of the variable editor widget for non-default themes (including OS X's dark theme).

Before vs. PR:
![image](https://user-images.githubusercontent.com/1728657/84562410-99709c00-ad7e-11ea-90e5-c1068354d492.png)

![image](https://user-images.githubusercontent.com/1728657/84562413-9c6b8c80-ad7e-11ea-9fa3-6e208676d2b3.png)

The improvement on non-default themes comes at no cost to the default theme:
![image](https://user-images.githubusercontent.com/1728657/84562420-ac836c00-ad7e-11ea-8f0b-74eb8823fc51.png)
