### PR TITLE
Add tooltip and help button to properties of the layout legend item

### DIFF
--- a/src/gui/layout/qgslayoutlegendlayersdialog.cpp
+++ b/src/gui/layout/qgslayoutlegendlayersdialog.cpp
@@ -20,6 +20,7 @@
 #include "qgsmaplayerproxymodel.h"
 #include "qgssettings.h"
 #include "qgsgui.h"
+#include "qgshelp.h"
 
 QgsLayoutLegendLayersDialog::QgsLayoutLegendLayersDialog( QWidget *parent )
   : QDialog( parent )
@@ -39,6 +40,7 @@ QgsLayoutLegendLayersDialog::QgsLayoutLegendLayersDialog( QWidget *parent )
 
   connect( mFilterLineEdit, &QLineEdit::textChanged, mModel, &QgsMapLayerProxyModel::setFilterString );
   connect( mCheckBoxVisibleLayers, &QCheckBox::toggled, this, &QgsLayoutLegendLayersDialog::filterVisible );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsLayoutLegendLayersDialog::showHelp );
 
   mFilterLineEdit->setFocus();
 }
@@ -74,4 +76,9 @@ void QgsLayoutLegendLayersDialog::filterVisible( bool enabled )
     mModel->setLayerAllowlist( mVisibleLayers );
   else
     mModel->setLayerAllowlist( QList< QgsMapLayer * >() );
+}
+
+void QgsLayoutLegendLayersDialog::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "print_composer/composer_items/composer_legend.html#legend-items" ) );
 }

--- a/src/gui/layout/qgslayoutlegendlayersdialog.h
+++ b/src/gui/layout/qgslayoutlegendlayersdialog.h
@@ -50,6 +50,7 @@ class GUI_EXPORT QgsLayoutLegendLayersDialog: public QDialog, private Ui::QgsLay
   private slots:
 
     void filterVisible( bool enabled );
+    void showHelp();
 
   private:
 

--- a/src/ui/layout/qgslayoutlegendlayersdialogbase.ui
+++ b/src/ui/layout/qgslayoutlegendlayersdialogbase.ui
@@ -30,7 +30,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/ui/layout/qgslayoutlegendwidgetbase.ui
+++ b/src/ui/layout/qgslayoutlegendwidgetbase.ui
@@ -238,6 +238,9 @@
               <property name="text">
                <string/>
               </property>
+              <property name="toolTip">
+               <string>Move item down</string>
+              </property>
               <property name="icon">
                <iconset resource="../../../images/images.qrc">
                 <normaloff>:/images/themes/default/mActionArrowDown.svg</normaloff>:/images/themes/default/mActionArrowDown.svg</iconset>
@@ -254,6 +257,9 @@
              <widget class="QToolButton" name="mMoveUpToolButton">
               <property name="text">
                <string/>
+              </property>
+              <property name="toolTip">
+               <string>Move item up</string>
               </property>
               <property name="icon">
                <iconset resource="../../../images/images.qrc">
@@ -292,6 +298,9 @@
               <property name="text">
                <string/>
               </property>
+              <property name="toolTip">
+               <string>Add layer(s) to legend</string>
+              </property>
               <property name="icon">
                <iconset resource="../../../images/images.qrc">
                 <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
@@ -309,6 +318,9 @@
               <property name="text">
                <string/>
               </property>
+              <property name="toolTip">
+               <string>Remove selected item(s) from legend</string>
+              </property>
               <property name="icon">
                <iconset resource="../../../images/images.qrc">
                 <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
@@ -325,6 +337,9 @@
              <widget class="QToolButton" name="mEditPushButton">
               <property name="text">
                <string/>
+              </property>
+              <property name="toolTip">
+               <string>Edit selected item properties</string>
               </property>
               <property name="icon">
                <iconset resource="../../../images/images.qrc">
@@ -398,6 +413,9 @@
              <widget class="QgsLegendFilterButton" name="mExpressionFilterButton">
               <property name="text">
                <string/>
+              </property>
+              <property name="toolTip">
+               <string>Filter expression</string>
               </property>
               <property name="icon">
                <iconset resource="../../../images/images.qrc">
@@ -1391,8 +1409,6 @@
   <tabstop>mLayerExpressionButton</tabstop>
  </tabstops>
  <resources>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
In Layout legend item properties --> Legend items section, some of the tools have tooltips and others do not. This harmonize the situation.
Also enable a help button from within the "add layers to legend" dialog