### PR TITLE
fix bad alloc when mesh's arrows of 3D rendering has too small spacing

### DIFF
--- a/src/3d/mesh/qgsmesh3dmaterial_p.cpp
+++ b/src/3d/mesh/qgsmesh3dmaterial_p.cpp
@@ -368,6 +368,9 @@ void QgsMesh3dMaterial::configureArrows( QgsMeshLayer *layer, const QgsDateTimeR
                 minCorner );
   }
 
+  if ( vectors.isEmpty() )
+    return;
+
   mTechnique->addParameter( arrowsEnabledParameter )  ;
 
   Qt3DRender::QTexture2D *arrowsGridTexture = new Qt3DRender::QTexture2D( this );

--- a/src/3d/mesh/qgsmesh3dmaterial_p.cpp
+++ b/src/3d/mesh/qgsmesh3dmaterial_p.cpp
@@ -366,10 +366,10 @@ void QgsMesh3dMaterial::configureArrows( QgsMeshLayer *layer, const QgsDateTimeR
                 ySpacing,
                 gridSize,
                 minCorner );
-  }
 
-  if ( vectors.isEmpty() )
-    return;
+    if ( vectors.isEmpty() )
+      return;
+  }
 
   mTechnique->addParameter( arrowsEnabledParameter )  ;
 

--- a/src/3d/symbols/qgsmesh3dsymbol.cpp
+++ b/src/3d/symbols/qgsmesh3dsymbol.cpp
@@ -93,7 +93,8 @@ void QgsMesh3DSymbol::readXml( const QDomElement &elem, const QgsReadWriteContex
   mColorRampShader.setMaximumValue( elemAdvancedSettings.attribute( QStringLiteral( "max-color-ramp-shader" ) ).toDouble() );
   mSingleColor = QgsSymbolLayerUtils::decodeColor( elemAdvancedSettings.attribute( QStringLiteral( "texture-single-color" ) ) );
   mArrowsEnabled = elemAdvancedSettings.attribute( QStringLiteral( "arrows-enabled" ) ).toInt();
-  mArrowsSpacing = elemAdvancedSettings.attribute( QStringLiteral( "arrows-spacing" ) ).toDouble();
+  if ( elemAdvancedSettings.hasAttribute( QStringLiteral( "arrows-spacing" ) ) )
+    mArrowsSpacing = elemAdvancedSettings.attribute( QStringLiteral( "arrows-spacing" ) ).toDouble();
   mArrowsFixedSize = elemAdvancedSettings.attribute( QStringLiteral( "arrows-fixed-size" ) ).toInt();
   QDomElement elemDDP = elem.firstChildElement( QStringLiteral( "data-defined-properties" ) );
   if ( !elemDDP.isNull() )

--- a/src/core/mesh/qgsmeshlayerutils.cpp
+++ b/src/core/mesh/qgsmeshlayerutils.cpp
@@ -136,7 +136,7 @@ QVector<QgsVector> QgsMeshLayerUtils::griddedVectorValues( const QgsMeshLayer *m
   }
   catch ( ... )
   {
-    QgsDebugMsgLevel( "Unable to store the arrow grid in memmory", 1 );
+    QgsDebugMsgLevel( "Unable to store the arrow grid in memory", 1 );
     return QVector<QgsVector>();
   }
 

--- a/src/core/mesh/qgsmeshlayerutils.cpp
+++ b/src/core/mesh/qgsmeshlayerutils.cpp
@@ -22,6 +22,7 @@
 #include "qgsmeshlayerutils.h"
 #include "qgsmeshtimesettings.h"
 #include "qgstriangularmesh.h"
+#include "qgslogger.h"
 #include "qgsmeshdataprovider.h"
 #include "qgsmesh3daveraging.h"
 #include "qgsmeshlayer.h"
@@ -129,7 +130,16 @@ QVector<QgsVector> QgsMeshLayerUtils::griddedVectorValues( const QgsMeshLayer *m
   if ( dataType == QgsMeshDatasetGroupMetadata::DataOnEdges )
     return vectors;
 
-  vectors.reserve( size.height()*size.width() );
+  try
+  {
+    vectors.reserve( size.height()*size.width() );
+  }
+  catch ( ... )
+  {
+    QgsDebugMsgLevel( "Unable to store the arrow grid in memmory", 1 );
+    return QVector<QgsVector>();
+  }
+
   for ( int iy = 0; iy < size.height(); ++iy )
   {
     double y = minCorner.y() + iy * ySpacing;


### PR DESCRIPTION
fix #37184 
When the arrow grids for 3D rendering has a spacing too small, the vector containing the grid is too big and that can lead to a bad alloc. This too small resolution appear when using a project that have been created before the new feature to render arrows with mesh in 3D view (3.14). 
This PR avoid this bad alloc with a try/catch and prevent to have such too small resolution.