### PR TITLE
emit mesh dataset group changed after it effectively changed

### DIFF
--- a/src/app/mesh/qgsrenderermeshpropertieswidget.cpp
+++ b/src/app/mesh/qgsrenderermeshpropertieswidget.cpp
@@ -169,7 +169,6 @@ void QgsRendererMeshPropertiesWidget::onActiveScalarGroupChanged( int groupIndex
   mMeshRendererScalarSettingsWidget->syncToLayer();
   mContoursGroupBox->setChecked( groupIndex >= 0 );
   mContoursGroupBox->setEnabled( groupIndex >= 0 );
-  emit mMeshLayer->activeScalarDatasetGroupChanged( groupIndex );
 }
 
 void QgsRendererMeshPropertiesWidget::onActiveVectorGroupChanged( int groupIndex )
@@ -181,5 +180,4 @@ void QgsRendererMeshPropertiesWidget::onActiveVectorGroupChanged( int groupIndex
   mMeshRendererVectorSettingsWidget->syncToLayer();
   mVectorsGroupBox->setChecked( groupIndex >= 0 );
   mVectorsGroupBox->setEnabled( groupIndex >= 0 );
-  emit mMeshLayer->activeVectorDatasetGroupChanged( groupIndex );
 }

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -267,7 +267,16 @@ QgsMeshRendererSettings QgsMeshLayer::rendererSettings() const
 
 void QgsMeshLayer::setRendererSettings( const QgsMeshRendererSettings &settings )
 {
+  int oldActiveScalar = mRendererSettings.activeScalarDatasetGroup();
+  int oldActiveVector = mRendererSettings.activeVectorDatasetGroup();
   mRendererSettings = settings;
+
+  if ( oldActiveScalar != mRendererSettings.activeScalarDatasetGroup() )
+    emit activeScalarDatasetGroupChanged( mRendererSettings.activeScalarDatasetGroup() );
+
+  if ( oldActiveVector != mRendererSettings.activeVectorDatasetGroup() )
+    emit activeVectorDatasetGroupChanged( mRendererSettings.activeScalarDatasetGroup() );
+
   emit rendererChanged();
   triggerRepaint();
 }
@@ -817,14 +826,24 @@ QgsMeshDatasetIndex QgsMeshLayer::staticScalarDatasetIndex() const
 
 void QgsMeshLayer::setStaticVectorDatasetIndex( const QgsMeshDatasetIndex &staticVectorDatasetIndex )
 {
+  int oldActiveVector = mRendererSettings.activeVectorDatasetGroup();
+
   mStaticVectorDatasetIndex = staticVectorDatasetIndex.dataset();
   mRendererSettings.setActiveVectorDatasetGroup( staticVectorDatasetIndex.group() );
+
+  if ( oldActiveVector != mRendererSettings.activeVectorDatasetGroup() )
+    emit activeVectorDatasetGroupChanged( mRendererSettings.activeScalarDatasetGroup() );
 }
 
 void QgsMeshLayer::setStaticScalarDatasetIndex( const QgsMeshDatasetIndex &staticScalarDatasetIndex )
 {
+  int oldActiveScalar = mRendererSettings.activeScalarDatasetGroup();
+
   mStaticScalarDatasetIndex = staticScalarDatasetIndex.dataset();
   mRendererSettings.setActiveScalarDatasetGroup( staticScalarDatasetIndex.group() );
+
+  if ( oldActiveScalar != mRendererSettings.activeScalarDatasetGroup() )
+    emit activeScalarDatasetGroupChanged( mRendererSettings.activeScalarDatasetGroup() );
 }
 
 QgsMeshSimplificationSettings QgsMeshLayer::meshSimplificationSettings() const


### PR DESCRIPTION
The mesh layer emits signal when active dataset group changed. Before this PR, the signal was emitted just before it effectively changed and outside layers method. 
That's could lead to unwanted behavior, especially with plugins that listen to this change.
This PR fix this issue.
