### PR TITLE
mesh layer expose datasetIndexAtTime()

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -287,6 +287,7 @@ Returns the value of 1D mesh dataset defined on edge that are in the search area
     QgsMeshDatasetIndex datasetIndexAtTime( const QgsDateTimeRange &timeRange, int datasetGroupIndex ) const;
 %Docstring
 Returns dataset index from datasets group depending on the time range.
+If the temporal properties is not active, returns invalid dataset index
 
 :param timeRange: the time range
 

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -283,6 +283,23 @@ Returns the value of 1D mesh dataset defined on edge that are in the search area
 .. versionadded:: 3.14
 %End
 
+
+    QgsMeshDatasetIndex datasetIndexAtTime( const QgsDateTimeRange &timeRange, int datasetGroupIndex ) const;
+%Docstring
+Returns dataset index from datasets group depending on the time range.
+
+:param timeRange: the time range
+
+:return: dataset index
+
+.. note::
+
+   the returned dataset index depends on the matching method, see setTemporalMatchingMethod()
+
+
+.. versionadded:: 3.14
+%End
+
     QgsMeshDatasetIndex activeScalarDatasetAtTime( const QgsDateTimeRange &timeRange ) const;
 %Docstring
 Returns dataset index from active scalar group depending on the time range.

--- a/src/3d/mesh/qgsmesh3dgeometry_p.cpp
+++ b/src/3d/mesh/qgsmesh3dgeometry_p.cpp
@@ -417,6 +417,7 @@ int QgsMeshDataset3dGeometry::extractDataset( QVector<double> &verticalMagnitude
     //if invalid (for example, static mode) use the scalar dataset index
     int vertDataSetIndex = scalarDatasetIndex.dataset();
     vertDataSetIndex = std::min( vertDataSetIndex, layer->dataProvider()->datasetCount( mVerticalGroupDatasetIndex ) - 1 );
+    verticalMagDatasetIndex = QgsMeshDatasetIndex( vertDataSetIndex, mVerticalGroupDatasetIndex );
   }
   //define the active face for vertical magnitude, the inactive faces will not be rendered
   // The active face flag values are defined based on the vertival magnitude dataset

--- a/src/3d/mesh/qgsmesh3dgeometry_p.cpp
+++ b/src/3d/mesh/qgsmesh3dgeometry_p.cpp
@@ -410,11 +410,14 @@ int QgsMeshDataset3dGeometry::extractDataset( QVector<double> &verticalMagnitude
 
   //extract the scalar dataset used to render vertical magnitude of geometry
   //define the vertical magnitude datasetIndex
-  int verticalDataSetIndexNumber = 0;
-  verticalDataSetIndexNumber = scalarDatasetIndex.dataset();
-  verticalDataSetIndexNumber = std::min( verticalDataSetIndexNumber, layer->dataProvider()->datasetCount( mVerticalGroupDatasetIndex ) - 1 );
-  QgsMeshDatasetIndex verticalMagDatasetIndex( mVerticalGroupDatasetIndex, verticalDataSetIndexNumber );
-
+  QgsMeshDatasetIndex verticalMagDatasetIndex;
+  verticalMagDatasetIndex = layer->datasetIndexAtTime( mTimeRange, mVerticalGroupDatasetIndex );
+  if ( !verticalMagDatasetIndex.isValid() )
+  {
+    //if invalid (for example, static mode) use the scalar dataset index
+    int vertDataSetIndex = scalarDatasetIndex.dataset();
+    vertDataSetIndex = std::min( vertDataSetIndex, layer->dataProvider()->datasetCount( mVerticalGroupDatasetIndex ) - 1 );
+  }
   //define the active face for vertical magnitude, the inactive faces will not be rendered
   // The active face flag values are defined based on the vertival magnitude dataset
   activeFaceFlagValues = layer->dataProvider()->areFacesActive( verticalMagDatasetIndex, 0, nativeMesh.faces.count() );

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -428,6 +428,9 @@ void QgsMeshLayer::setTransformContext( const QgsCoordinateTransformContext &tra
 
 QgsMeshDatasetIndex QgsMeshLayer::datasetIndexAtTime( const QgsDateTimeRange &timeRange, int datasetGroupIndex ) const
 {
+  if ( ! mTemporalProperties->isActive() )
+    return QgsMeshDatasetIndex( datasetGroupIndex, -1 );
+
   const QDateTime layerReferenceTime = mTemporalProperties->referenceTime();
   qint64 startTime = layerReferenceTime.msecsTo( timeRange.begin() );
 

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -329,6 +329,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
 
     /**
       * Returns dataset index from datasets group depending on the time range.
+      * If the temporal properties is not active, returns invalid dataset index
       *
       * \param timeRange the time range
       * \returns dataset index

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -326,6 +326,19 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
       */
     QgsMeshDatasetValue dataset1dValue( const QgsMeshDatasetIndex &index, const QgsPointXY &point, double searchRadius ) const;
 
+
+    /**
+      * Returns dataset index from datasets group depending on the time range.
+      *
+      * \param timeRange the time range
+      * \returns dataset index
+      *
+      * \note the returned dataset index depends on the matching method, see setTemporalMatchingMethod()
+      *
+      * \since QGIS 3.14
+      */
+    QgsMeshDatasetIndex datasetIndexAtTime( const QgsDateTimeRange &timeRange, int datasetGroupIndex ) const;
+
     /**
       * Returns dataset index from active scalar group depending on the time range.
       * If the temporal properties is not active, return the static dataset
@@ -521,8 +534,6 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     int levelsOfDetailsIndex( double partOfMeshInView ) const;
 
     bool hasSimplifiedMeshes() const;
-
-    QgsMeshDatasetIndex datasetIndexAtTime( const QgsDateTimeRange &timeRange, int datasetGroupIndex ) const;
 
     //! Changes scalar settings for classified scalar value (information about is in the metadata
     void applyClassificationOnScalarSettings( const QgsMeshDatasetGroupMetadata &meta, QgsMeshRendererScalarSettings &scalarSettings ) const;


### PR DESCRIPTION
The new temporal framework leads to change the approach to access to datasets linked to mesh layer. Two methods was created to access to active datasets from the current date/time of the map. But access to non active datasets was not exposed in the mesh layer class. So plugins that need to handle with non active datasets could not access to dataset related to the current map date/time and these plugins can have issues when using those datasets. Furthermore, for 3D rendering, QGIS used a workaround to access dataset index that control the vertical magnitude from active scalar group, workaround that was not rigorous.
To fix those issues this PR expose `QgsMeshLayer::datasetAtTime()`, method that was private, and adapt a bit code.