### PR TITLE
Disable project time usage in WMS-T if the project temporal range is invalid

### DIFF
--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -1374,6 +1374,17 @@ void QgsRasterLayerProperties::setSourceStaticTimeState()
       mWmstOptionsLabel->setText( tr( "The static temporal options below are disabled because the layer "
                                       "temporal properties are active, to enable them disable temporal properties "
                                       "in the temporal tab. " ) );
+    QgsDateTimeRange range;
+    if ( QgsProject::instance()->timeSettings() )
+      range = QgsProject::instance()->timeSettings()->temporalRange();
+
+    if ( !range.begin().isValid() || !range.end().isValid() )
+    {
+      mProjectTemporalRange->setEnabled( false );
+      mProjectTemporalRangeLabel->setText( tr( "The option below is disabled because the project temporal range "
+                                           "is not valid, update the project temporal range in the project properties "
+                                           "with valid values in order to use it here." ) );
+    }
 
     mWmstGroup->setChecked( uri.contains( QStringLiteral( "allowTemporalUpdates" ) ) &&
                             uri.value( QStringLiteral( "allowTemporalUpdates" ), true ).toBool() );

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -1371,9 +1371,9 @@ void QgsRasterLayerProperties::setSourceStaticTimeState()
     mWmstOptions->setEnabled( !mRasterLayer->temporalProperties()->isActive() );
 
     if ( mRasterLayer->temporalProperties()->isActive() )
-      mWmstOptionsLabel->setText( "The static temporal options below are disabled because the layer "
-                                  "temporal properties are active, to enable them disable temporal properties "
-                                  "in the temporal tab. " );
+      mWmstOptionsLabel->setText( tr( "The static temporal options below are disabled because the layer "
+                                      "temporal properties are active, to enable them disable temporal properties "
+                                      "in the temporal tab. " ) );
 
     mWmstGroup->setChecked( uri.contains( QStringLiteral( "allowTemporalUpdates" ) ) &&
                             uri.value( QStringLiteral( "allowTemporalUpdates" ), true ).toBool() );
@@ -1411,9 +1411,9 @@ void QgsRasterLayerProperties::temporalPropertiesChange()
   mWmstOptions->setEnabled( !mRasterLayer->temporalProperties()->isActive() );
 
   if ( mRasterLayer->temporalProperties()->isActive() )
-    mWmstOptionsLabel->setText( "The static temporal options below are disabled because the layer "
-                                "temporal properties are active, to enable them disable temporal properties "
-                                "in the temporal tab. " );
+    mWmstOptionsLabel->setText( tr( "The static temporal options below are disabled because the layer "
+                                    "temporal properties are active, to enable them disable temporal properties "
+                                    "in the temporal tab. " ) );
   else
     mWmstOptionsLabel->clear();
 }

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -1274,17 +1274,17 @@ void QgsRasterLayerProperties::updateSourceStaticTime()
           uri[ QStringLiteral( "temporalSource" ) ] = QLatin1String( "project" );
         }
       }
+    }
 
-      if ( mReferenceTime->isChecked() )
-      {
-        QString referenceTime = mReferenceDateTimeEdit->dateTime().toString( Qt::ISODateWithMs );
-        uri[ QStringLiteral( "referenceTime" ) ] = referenceTime;
-      }
-      else
-      {
-        if ( uri.contains( QStringLiteral( "referenceTime" ) ) )
-          uri.remove( QStringLiteral( "referenceTime" ) );
-      }
+    if ( mReferenceTime->isChecked() )
+    {
+      QString referenceTime = mReferenceDateTimeEdit->dateTime().toString( Qt::ISODateWithMs );
+      uri[ QStringLiteral( "referenceTime" ) ] = referenceTime;
+    }
+    else
+    {
+      if ( uri.contains( QStringLiteral( "referenceTime" ) ) )
+        uri.remove( QStringLiteral( "referenceTime" ) );
     }
   }
 

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -113,6 +113,9 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     //! \brief slot executed when user "Static time range" radio button on time options in source page.
     void staticTemporalRange_toggled( bool checked );
 
+    //! \brief slot executed when temporal properties status change.
+    void temporalPropertiesChange();
+
     /**
      * \brief slot executed when the single band radio button is pressed.
      * \brief slot executed when the reset null value to file default icon is selected

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -430,7 +430,7 @@ border-radius: 2px;</string>
                       <widget class="QgsDateTimeEdit" name="mReferenceDateTimeEdit">
                        <property name="dateTime">
                         <datetime>
-                         <hour>13</hour>
+                         <hour>12</hour>
                          <minute>20</minute>
                          <second>36</second>
                          <year>2020</year>
@@ -560,7 +560,7 @@ border-radius: 2px;</string>
                          <widget class="QgsDateTimeEdit" name="mStartStaticDateTimeEdit">
                           <property name="dateTime">
                            <datetime>
-                            <hour>20</hour>
+                            <hour>18</hour>
                             <minute>3</minute>
                             <second>57</second>
                             <year>2020</year>
@@ -589,6 +589,16 @@ border-radius: 2px;</string>
                       <widget class="QLabel" name="label_10">
                        <property name="text">
                         <string>Note:  If the capabilities of this layer move out of this time range, the range will be reset to layer's advertised  default layer time range.</string>
+                       </property>
+                       <property name="wordWrap">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="mProjectTemporalRangeLabel">
+                       <property name="text">
+                        <string/>
                        </property>
                        <property name="wordWrap">
                         <bool>true</bool>

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -303,7 +303,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>629</width>
-                <height>814</height>
+                <height>843</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -377,95 +377,24 @@ border-radius: 2px;</string>
                   <bool>true</bool>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_15">
-                  <item row="6" column="0" colspan="3">
-                   <widget class="QLabel" name="label_10">
+                  <item row="0" column="0" colspan="3">
+                   <widget class="QLabel" name="mLabel">
                     <property name="text">
-                     <string>Note:  If the capabilities of this layer move out of this time range, the range will be reset to layer's advertised  default layer time range.</string>
+                     <string/>
                     </property>
                     <property name="wordWrap">
                      <bool>true</bool>
                     </property>
                    </widget>
                   </item>
-                  <item row="5" column="0" colspan="3">
-                   <widget class="QFrame" name="mStaticWmstFrame">
-                    <property name="enabled">
-                     <bool>false</bool>
+                  <item row="1" column="1" rowspan="2" colspan="2">
+                   <widget class="QComboBox" name="mFetchModeComboBox"/>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QCheckBox" name="mDisableTime">
+                    <property name="text">
+                     <string>Use dates only</string>
                     </property>
-                    <property name="frameShape">
-                     <enum>QFrame::NoFrame</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Raised</enum>
-                    </property>
-                    <layout class="QGridLayout" name="gridLayout_16">
-                     <property name="topMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="bottomMargin">
-                      <number>0</number>
-                     </property>
-                     <item row="2" column="1" colspan="2">
-                      <widget class="QPushButton" name="mSetEndAsStartStaticButton">
-                       <property name="text">
-                        <string>Set end same as start</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="0">
-                      <widget class="QLabel" name="label_13">
-                       <property name="text">
-                        <string>Start date</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="1" colspan="2">
-                      <widget class="QgsDateTimeEdit" name="mEndStaticDateTimeEdit">
-                       <property name="displayFormat">
-                        <string>M/d/yyyy H:mm:ss AP</string>
-                       </property>
-                       <property name="timeSpec">
-                        <enum>Qt::UTC</enum>
-                       </property>
-                       <property name="allowNull" stdset="0">
-                        <bool>false</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="0">
-                      <widget class="QLabel" name="label_4">
-                       <property name="text">
-                        <string>End date</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="1" colspan="2">
-                      <widget class="QgsDateTimeEdit" name="mStartStaticDateTimeEdit">
-                       <property name="dateTime">
-                        <datetime>
-                         <hour>0</hour>
-                         <minute>3</minute>
-                         <second>57</second>
-                         <year>2020</year>
-                         <month>4</month>
-                         <day>30</day>
-                        </datetime>
-                       </property>
-                       <property name="currentSection">
-                        <enum>QDateTimeEdit::MonthSection</enum>
-                       </property>
-                       <property name="displayFormat">
-                        <string>M/d/yyyy H:mm:ss AP</string>
-                       </property>
-                       <property name="timeSpec">
-                        <enum>Qt::UTC</enum>
-                       </property>
-                       <property name="allowNull" stdset="0">
-                        <bool>false</bool>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
                    </widget>
                   </item>
                   <item row="1" column="0">
@@ -475,7 +404,7 @@ border-radius: 2px;</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="10" column="0">
+                  <item row="8" column="0">
                    <widget class="QFrame" name="mWmstReferenceTimeFrame">
                     <property name="enabled">
                      <bool>false</bool>
@@ -490,11 +419,18 @@ border-radius: 2px;</string>
                      <property name="topMargin">
                       <number>0</number>
                      </property>
+                     <item row="1" column="0">
+                      <widget class="QLabel" name="mReferenceTimeLabel">
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
                      <item row="0" column="0">
                       <widget class="QgsDateTimeEdit" name="mReferenceDateTimeEdit">
                        <property name="dateTime">
                         <datetime>
-                         <hour>15</hour>
+                         <hour>13</hour>
                          <minute>20</minute>
                          <second>36</second>
                          <year>2020</year>
@@ -526,18 +462,11 @@ border-radius: 2px;</string>
                        </property>
                       </widget>
                      </item>
-                     <item row="1" column="0">
-                      <widget class="QLabel" name="mReferenceTimeLabel">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
                     </layout>
                    </widget>
                   </item>
-                  <item row="0" column="0" colspan="3">
-                   <widget class="QLabel" name="mLabel">
+                  <item row="4" column="0" colspan="3">
+                   <widget class="QLabel" name="mWmstOptionsLabel">
                     <property name="text">
                      <string/>
                     </property>
@@ -546,35 +475,134 @@ border-radius: 2px;</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="1" rowspan="2" colspan="2">
-                   <widget class="QComboBox" name="mFetchModeComboBox"/>
-                  </item>
-                  <item row="4" column="0" colspan="3">
-                   <widget class="QRadioButton" name="mStaticTemporalRange">
-                    <property name="text">
-                     <string>Use static WMS-T temporal range</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="7" column="0" colspan="3">
-                   <widget class="QRadioButton" name="mProjectTemporalRange">
-                    <property name="text">
-                     <string>Pass project temporal range to provider</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="9" column="0" colspan="3">
+                  <item row="7" column="0">
                    <widget class="QCheckBox" name="mReferenceTime">
                     <property name="text">
                      <string>Reference time</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="8" column="0">
-                   <widget class="QCheckBox" name="mDisableTime">
-                    <property name="text">
-                     <string>Use dates only</string>
+                  <item row="5" column="0" colspan="3">
+                   <widget class="QFrame" name="mWmstOptions">
+                    <property name="frameShape">
+                     <enum>QFrame::NoFrame</enum>
                     </property>
+                    <property name="frameShadow">
+                     <enum>QFrame::Raised</enum>
+                    </property>
+                    <layout class="QVBoxLayout" name="verticalLayout_22">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QRadioButton" name="mStaticTemporalRange">
+                       <property name="text">
+                        <string>Use static WMS-T temporal range</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QFrame" name="mStaticWmstFrame">
+                       <property name="enabled">
+                        <bool>false</bool>
+                       </property>
+                       <property name="frameShape">
+                        <enum>QFrame::NoFrame</enum>
+                       </property>
+                       <property name="frameShadow">
+                        <enum>QFrame::Raised</enum>
+                       </property>
+                       <layout class="QGridLayout" name="gridLayout_16">
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
+                         <number>0</number>
+                        </property>
+                        <item row="2" column="1" colspan="2">
+                         <widget class="QPushButton" name="mSetEndAsStartStaticButton">
+                          <property name="text">
+                           <string>Set end same as start</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="0">
+                         <widget class="QLabel" name="label_13">
+                          <property name="text">
+                           <string>Start date</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="1" colspan="2">
+                         <widget class="QgsDateTimeEdit" name="mEndStaticDateTimeEdit">
+                          <property name="displayFormat">
+                           <string>M/d/yyyy H:mm:ss AP</string>
+                          </property>
+                          <property name="timeSpec">
+                           <enum>Qt::UTC</enum>
+                          </property>
+                          <property name="allowNull" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="0">
+                         <widget class="QLabel" name="label_4">
+                          <property name="text">
+                           <string>End date</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="1" colspan="2">
+                         <widget class="QgsDateTimeEdit" name="mStartStaticDateTimeEdit">
+                          <property name="dateTime">
+                           <datetime>
+                            <hour>20</hour>
+                            <minute>3</minute>
+                            <second>57</second>
+                            <year>2020</year>
+                            <month>4</month>
+                            <day>29</day>
+                           </datetime>
+                          </property>
+                          <property name="currentSection">
+                           <enum>QDateTimeEdit::MonthSection</enum>
+                          </property>
+                          <property name="displayFormat">
+                           <string>M/d/yyyy H:mm:ss AP</string>
+                          </property>
+                          <property name="timeSpec">
+                           <enum>Qt::UTC</enum>
+                          </property>
+                          <property name="allowNull" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                         </widget>
+                        </item>
+                       </layout>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="label_10">
+                       <property name="text">
+                        <string>Note:  If the capabilities of this layer move out of this time range, the range will be reset to layer's advertised  default layer time range.</string>
+                       </property>
+                       <property name="wordWrap">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QRadioButton" name="mProjectTemporalRange">
+                       <property name="text">
+                        <string>Pass project temporal range to provider</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
                    </widget>
                   </item>
                  </layout>


### PR DESCRIPTION
Includes updates from https://github.com/qgis/QGIS/pull/37199,
The static temporal options enables usage of project temporal range in setting layer static temporal range, when the project temporal range is invalid the option to use the project temporal range should be disabled, and notify user to update the project temporal range first before using it in the WMS-T option.

Screenshot
![update_project_time_to_use_it](https://user-images.githubusercontent.com/2663775/84591589-74486000-ae48-11ea-83f9-87eff69ab493.gif)

