### PR TITLE
Allow automatic naming when duplicating/renaming a layout

### DIFF
--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -1880,7 +1880,7 @@ void QgsLayoutDesignerDialog::addItemsFromTemplate()
 void QgsLayoutDesignerDialog::duplicate()
 {
   QString newTitle;
-  if ( !QgisApp::instance()->uniqueLayoutTitle( this, newTitle, false, masterLayout()->layoutType(), tr( "%1 copy" ).arg( masterLayout()->name() ) ) )
+  if ( !QgisApp::instance()->uniqueLayoutTitle( this, newTitle, true, masterLayout()->layoutType(), tr( "%1 copy" ).arg( masterLayout()->name() ) ) )
   {
     return;
   }
@@ -1943,7 +1943,7 @@ void QgsLayoutDesignerDialog::renameLayout()
 {
   QString currentTitle = masterLayout()->name();
   QString newTitle;
-  if ( !QgisApp::instance()->uniqueLayoutTitle( this, newTitle, false, masterLayout()->layoutType(), currentTitle ) )
+  if ( !QgisApp::instance()->uniqueLayoutTitle( this, newTitle, true, masterLayout()->layoutType(), currentTitle ) )
   {
     return;
   }

--- a/src/app/layout/qgslayoutmanagerdialog.cpp
+++ b/src/app/layout/qgslayoutmanagerdialog.cpp
@@ -448,7 +448,7 @@ void QgsLayoutManagerDialog::duplicateClicked()
   QString currentTitle = currentLayout->name();
 
   QString newTitle;
-  if ( !QgisApp::instance()->uniqueLayoutTitle( this, newTitle, false, currentLayout->layoutType(), tr( "%1 copy" ).arg( currentTitle ) ) )
+  if ( !QgisApp::instance()->uniqueLayoutTitle( this, newTitle, true, currentLayout->layoutType(), tr( "%1 copy" ).arg( currentTitle ) ) )
   {
     return;
   }
@@ -488,7 +488,7 @@ void QgsLayoutManagerDialog::renameClicked()
 
   QString currentTitle = currentLayout->name();
   QString newTitle;
-  if ( !QgisApp::instance()->uniqueLayoutTitle( this, newTitle, false, currentLayout->layoutType(), currentTitle ) )
+  if ( !QgisApp::instance()->uniqueLayoutTitle( this, newTitle, true, currentLayout->layoutType(), currentTitle ) )
   {
     return;
   }


### PR DESCRIPTION
and the naming widget is set empty
When you create a layout, keeping the widget empty will generate the layout name. But when duplicating or renaming a layout, the dialog can't be left empty, you necessary need to enter something (different from existing ones, of course).
This PR proposes to remove that limitation and autogenerate the layout name if the widget is cleared.