### PR TITLE
Fix for container "show as group box" setting is lost when closing layer properties dialog

### DIFF
--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
@@ -32,6 +32,7 @@ QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *i
     // only top level items can be tabs
     // i.e. it's always a group box if it's a nested container
     mShowAsGroupBoxCheckBox->hide();
+    mShowAsGroupBoxCheckBox->setEnabled( false );
   }
 
   mTitleLineEdit->setText( itemData.name() );
@@ -59,7 +60,7 @@ void QgsAttributeFormContainerEdit::updateItemData()
   QgsAttributesFormProperties::DnDTreeItemData itemData = mTreeItem->data( 0, QgsAttributesFormProperties::DnDTreeRole ).value<QgsAttributesFormProperties::DnDTreeItemData>();
 
   itemData.setColumnCount( mColumnCountSpinBox->value() );
-  itemData.setShowAsGroupBox( mShowAsGroupBoxCheckBox->isVisible() ? mShowAsGroupBoxCheckBox->isChecked() : false );
+  itemData.setShowAsGroupBox( mShowAsGroupBoxCheckBox->isEnabled() ? mShowAsGroupBoxCheckBox->isChecked() : false );
   itemData.setName( mTitleLineEdit->text() );
   itemData.setShowLabel( mShowLabelCheckBox->isChecked() );
   itemData.setBackgroundColor( mBackgroundColorButton->color() );


### PR DESCRIPTION
We can't use the checkbox visibility to determine whether it applies,
as the checkbox will ALWAYS be invisible when applying the settings
as a result of clicking "OK" (since the form is already closed and
all child widgets are not visible at that stage)

Fixes #37205
