### PR TITLE
[Server] WMTS Use WMS tile_buffer by using TILED param

### DIFF
--- a/src/server/services/wmts/qgswmtsparameters.h
+++ b/src/server/services/wmts/qgswmtsparameters.h
@@ -52,6 +52,7 @@ namespace QgsWmts
         FORMAT,
         TRANSPARENT,
         DPI,
+        TILED,
         QUERY_LAYERS,
         I,
         J,

--- a/src/server/services/wmts/qgswmtsutils.cpp
+++ b/src/server/services/wmts/qgswmtsutils.cpp
@@ -802,6 +802,7 @@ namespace QgsWmts
       query.addQueryItem( QgsWmsParameterForWmts::name( QgsWmsParameterForWmts::TRANSPARENT ), QStringLiteral( "true" ) );
     }
     query.addQueryItem( QgsWmsParameterForWmts::name( QgsWmsParameterForWmts::DPI ), QStringLiteral( "96" ) );
+    query.addQueryItem( QgsWmsParameterForWmts::name( QgsWmsParameterForWmts::TILED ), QStringLiteral( "true" ) );
 
     return query;
   }


### PR DESCRIPTION
## Description

A new parameter in the WMS OWS Server project properties has been added to avoid cut symbols when WMS GetMap is used as tiled.

But this parameter was not used in Web Map Tiled Service.

Linked to #30071