### PR TITLE
perform rounding either if field type is numeric or if value was casted to the number

### DIFF
--- a/python/testing/__init__.py
+++ b/python/testing/__init__.py
@@ -269,19 +269,22 @@ class TestCase(_TestCase):
             field_result = [fld for fld in fields_expected.toList() if fld.name() == field_expected.name()][0]
 
             # Cast field to a given type
+            isNumber = False
             if 'cast' in cmp:
                 if cmp['cast'] == 'int':
                     attr_expected = int(attr_expected) if attr_expected else None
                     attr_result = int(attr_result) if attr_result else None
+                    isNumber = True
                 if cmp['cast'] == 'float':
                     attr_expected = float(attr_expected) if attr_expected else None
                     attr_result = float(attr_result) if attr_result else None
+                    isNumber = True
                 if cmp['cast'] == 'str':
                     attr_expected = str(attr_expected) if attr_expected else None
                     attr_result = str(attr_result) if attr_result else None
 
             # Round field (only numeric so it works with __all__)
-            if 'precision' in cmp and field_expected.type() in [QVariant.Int, QVariant.Double, QVariant.LongLong]:
+            if 'precision' in cmp and (field_expected.type() in [QVariant.Int, QVariant.Double, QVariant.LongLong] or isNumber):
                 if not attr_expected == NULL:
                     attr_expected = round(attr_expected, cmp['precision'])
                 if not attr_result == NULL:


### PR DESCRIPTION
## Description
QGIS Processing testing framework allows to customize layer comparison. Among options are casting field values to some data type and setting values precision before comparison. But precision can be applied it only if expected field has numeric data type, so if fields have string data type (for example, if test result and expected result saved as CSV) and were casted to int or float setting precision for them won't take any effect.

This was found when investigating test failures in #37039.

Proposed PR allows to apply precision restriction also for fields which were casted to numeric data type. Another option will be to update failing tests and use more robust output format for problematic tests.