### PR TITLE
fix non temporal calculated mesh dataset

### DIFF
--- a/src/providers/mdal/qgsmdalprovider.cpp
+++ b/src/providers/mdal/qgsmdalprovider.cpp
@@ -306,8 +306,13 @@ bool QgsMdalProvider::persistDatasetGroup(
 
   MDAL_G_closeEditMode( g );
 
-  emit datasetGroupsAdded( 1 );
-  emit dataChanged();
+  if ( MDAL_LastStatus() == 0 )
+  {
+    mExtraDatasetUris << outputFilePath;
+    addGroupToTemporalCapabilities( datasetGroupCount() - 1 );
+    emit datasetGroupsAdded( 1 );
+    emit dataChanged();
+  }
 
   return false;
 }
@@ -587,7 +592,7 @@ QgsMeshDatasetGroupMetadata QgsMdalProvider::datasetGroupMetadata( int groupInde
   QString referenceTimeString( MDAL_G_referenceTime( group ) );
   QDateTime referenceTime = QDateTime::fromString( referenceTimeString, Qt::ISODate );
 
-  bool isTemporal = MDAL_G_datasetCount( group ) > 1;
+  bool isTemporal = MDAL_G_isTemporal( group );
 
   QgsMeshDatasetGroupMetadata meta(
     name,


### PR DESCRIPTION
When mesh dataset group was calculated with mesh calculator, the resulted dataset group is not temporal and was not saved as part of the mesh layer when the project is save.
This PR solves those issues.
