### PR TITLE
Fix registerMapLayerConfigWidgetFactory docs

### DIFF
--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -1126,7 +1126,7 @@ Unregister a previously registered action. (e.g. when plugin is going to be unlo
 
     virtual void registerMapLayerConfigWidgetFactory( QgsMapLayerConfigWidgetFactory *factory ) = 0;
 %Docstring
-Register a new tab in the vector layer properties dialog.
+Register a new tab in the map layer properties dialog.
 
 .. note::
 
@@ -1142,7 +1142,7 @@ Register a new tab in the vector layer properties dialog.
 
     virtual void unregisterMapLayerConfigWidgetFactory( QgsMapLayerConfigWidgetFactory *factory ) = 0;
 %Docstring
-Unregister a previously registered tab in the vector layer properties dialog.
+Unregister a previously registered tab in the map layer properties dialog.
 
 .. seealso:: :py:class:`QgsMapLayerConfigWidgetFactory`
 

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -948,7 +948,7 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual bool unregisterMainWindowAction( QAction *action ) = 0;
 
     /**
-     * Register a new tab in the vector layer properties dialog.
+     * Register a new tab in the map layer properties dialog.
      * \note Ownership of the factory is not transferred, and the factory must
      *       be unregistered when plugin is unloaded.
      * \see QgsMapLayerConfigWidgetFactory
@@ -958,7 +958,7 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual void registerMapLayerConfigWidgetFactory( QgsMapLayerConfigWidgetFactory *factory ) = 0;
 
     /**
-     * Unregister a previously registered tab in the vector layer properties dialog.
+     * Unregister a previously registered tab in the map layer properties dialog.
      * \see QgsMapLayerConfigWidgetFactory
      * \see registerMapLayerConfigWidgetFactory()
      * \since QGIS 2.16


### PR DESCRIPTION
`QgsInterface::registerMapLayerConfigWidgetFactory` and `QgsInterface::registerMapLayerConfigWidget` work on any type of layer, not only vector layers.