### PR TITLE
fix georeferencer sticky move gcp button

### DIFF
--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -401,16 +401,22 @@ void QgsGeoreferencerMainWindow::generateGDALScript()
 void QgsGeoreferencerMainWindow::setAddPointTool()
 {
   mCanvas->setMapTool( mToolAddPoint );
+  QgisApp::instance()->mapCanvas()->setMapTool( mPrevQgisMapTool );
 }
 
 void QgsGeoreferencerMainWindow::setDeletePointTool()
 {
   mCanvas->setMapTool( mToolDeletePoint );
+  QgisApp::instance()->mapCanvas()->setMapTool( mPrevQgisMapTool );
 }
 
 void QgsGeoreferencerMainWindow::setMovePointTool()
 {
   mCanvas->setMapTool( mToolMovePoint );
+  QgsMapTool *activeQgisMapTool = QgisApp::instance()->mapCanvas()->mapTool();
+  if ( activeQgisMapTool == mToolMovePointQgis )
+    return;
+  mPrevQgisMapTool = activeQgisMapTool;
   QgisApp::instance()->mapCanvas()->setMapTool( mToolMovePointQgis );
 }
 

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -401,14 +401,16 @@ void QgsGeoreferencerMainWindow::generateGDALScript()
 void QgsGeoreferencerMainWindow::setAddPointTool()
 {
   mCanvas->setMapTool( mToolAddPoint );
-  if ( mPrevQgisMapTool )
+  QgsMapTool *activeQgisMapTool = QgisApp::instance()->mapCanvas()->mapTool();
+  if ( activeQgisMapTool == mToolMovePointQgis )
     QgisApp::instance()->mapCanvas()->setMapTool( mPrevQgisMapTool );
 }
 
 void QgsGeoreferencerMainWindow::setDeletePointTool()
 {
   mCanvas->setMapTool( mToolDeletePoint );
-  if ( mPrevQgisMapTool )
+  QgsMapTool *activeQgisMapTool = QgisApp::instance()->mapCanvas()->mapTool();
+  if ( activeQgisMapTool == mToolMovePointQgis )
     QgisApp::instance()->mapCanvas()->setMapTool( mPrevQgisMapTool );
 }
 

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -401,13 +401,15 @@ void QgsGeoreferencerMainWindow::generateGDALScript()
 void QgsGeoreferencerMainWindow::setAddPointTool()
 {
   mCanvas->setMapTool( mToolAddPoint );
-  QgisApp::instance()->mapCanvas()->setMapTool( mPrevQgisMapTool );
+  if ( mPrevQgisMapTool )
+    QgisApp::instance()->mapCanvas()->setMapTool( mPrevQgisMapTool );
 }
 
 void QgsGeoreferencerMainWindow::setDeletePointTool()
 {
   mCanvas->setMapTool( mToolDeletePoint );
-  QgisApp::instance()->mapCanvas()->setMapTool( mPrevQgisMapTool );
+  if ( mPrevQgisMapTool )
+    QgisApp::instance()->mapCanvas()->setMapTool( mPrevQgisMapTool );
 }
 
 void QgsGeoreferencerMainWindow::setMovePointTool()

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -240,6 +240,7 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     QgsMapTool *mToolZoomIn = nullptr;
     QgsMapTool *mToolZoomOut = nullptr;
     QgsMapTool *mToolPan = nullptr;
+    QgsMapTool *mPrevQgisMapTool = nullptr;
     QgsGeorefToolAddPoint *mToolAddPoint = nullptr;
     QgsGeorefToolDeletePoint *mToolDeletePoint = nullptr;
     QgsGeorefToolMovePoint *mToolMovePoint = nullptr;


### PR DESCRIPTION
## Description
Store a pointer to the active map tool so the georeferencer does not stick with the move GCP tool

Fixes #37248 

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
