### PR TITLE
In georeferencer, allow to move and delete GCPs without perfect aiming

### DIFF
--- a/src/app/georeferencer/qgsgeorefconfigdialog.cpp
+++ b/src/app/georeferencer/qgsgeorefconfigdialog.cpp
@@ -88,6 +88,8 @@ void QgsGeorefConfigDialog::readSettings()
   mShowIDsCheckBox->setChecked( s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/ShowId" ) ).toBool() );
   mShowCoordsCheckBox->setChecked( s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/ShowCoords" ) ).toBool() );
   mShowDockedCheckBox->setChecked( s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/ShowDocked" ) ).toBool() );
+  mPointSelectionDistanceSpinBox->setValue( s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/PointSelectionDistance" ), "10" ).toInt() );
+  mPointSelectionDistanceSpinBox->setClearValue( 10 );
 
   if ( s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/ResidualUnits" ) ).toString() == QLatin1String( "mapUnits" ) )
   {
@@ -123,6 +125,7 @@ void QgsGeorefConfigDialog::writeSettings()
   QgsSettings s;
   s.setValue( QStringLiteral( "/Plugin-GeoReferencer/Config/ShowId" ), mShowIDsCheckBox->isChecked() );
   s.setValue( QStringLiteral( "/Plugin-GeoReferencer/Config/ShowCoords" ), mShowCoordsCheckBox->isChecked() );
+  s.setValue( QStringLiteral( "/Plugin-GeoReferencer/Config/PointSelectionDistance" ), mPointSelectionDistanceSpinBox->value() );
   s.setValue( QStringLiteral( "/Plugin-GeoReferencer/Config/ShowDocked" ), mShowDockedCheckBox->isChecked() );
   if ( mPixelsButton->isChecked() )
   {

--- a/src/app/georeferencer/qgsgeorefdatapoint.cpp
+++ b/src/app/georeferencer/qgsgeorefdatapoint.cpp
@@ -139,7 +139,7 @@ bool QgsGeorefDataPoint::contains( QPoint p, bool isMapPlugin )
 qreal QgsGeorefDataPoint::distance( QPoint p, bool isMapPlugin )
 {
   QPointF pnt = isMapPlugin ? mGCPSourceItem->mapFromScene( p ) : mGCPDestinationItem->mapFromScene( p );
-  return pnt.manhattanLength();
+  return std::sqrt( pnt.x() * pnt.x() + pnt.y() * pnt.y() );
 }
 
 void QgsGeorefDataPoint::moveTo( QPoint p, bool isMapPlugin )

--- a/src/app/georeferencer/qgsgeorefdatapoint.cpp
+++ b/src/app/georeferencer/qgsgeorefdatapoint.cpp
@@ -136,6 +136,12 @@ bool QgsGeorefDataPoint::contains( QPoint p, bool isMapPlugin )
   }
 }
 
+qreal QgsGeorefDataPoint::distance( QPoint p, bool isMapPlugin )
+{
+  QPointF pnt = isMapPlugin ? mGCPSourceItem->mapFromScene( p ) : mGCPDestinationItem->mapFromScene( p );
+  return pnt.manhattanLength();
+}
+
 void QgsGeorefDataPoint::moveTo( QPoint p, bool isMapPlugin )
 {
   if ( isMapPlugin )

--- a/src/app/georeferencer/qgsgeorefdatapoint.h
+++ b/src/app/georeferencer/qgsgeorefdatapoint.h
@@ -46,6 +46,7 @@ class QgsGeorefDataPoint : public QObject
     void setId( int id );
 
     bool contains( QPoint p, bool isMapPlugin );
+    qreal distance( QPoint p, bool isMapPlugin );
 
     QgsMapCanvas *srcCanvas() const { return mSrcCanvas; }
     QgsMapCanvas *dstCanvas() const { return mDstCanvas; }

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -519,7 +519,7 @@ void QgsGeoreferencerMainWindow::deleteDataPoint( QPoint coords )
   // This is the manhattan length from mouse cursor point to GCP
   // We will use this distance to pick the closest GCP to the cursor
   // GCPs farther than the initial minDistance are too far and are ignored
-  qreal minDistance = 10;
+  qreal minDistance = mCanvas->physicalDpiX() / 10;
   for ( QgsGCPList::iterator it = mPoints.begin(); it != mPoints.end(); ++it )
   {
     qreal distance = ( *it )->distance( coords, true );
@@ -555,7 +555,7 @@ void QgsGeoreferencerMainWindow::selectPoint( QPoint p )
   // This is the manhattan length from mouse cursor point to GCP
   // We will use this distance to pick the closest GCP to the cursor
   // GCPs farther than the initial minDistance are too far and are ignored
-  qreal minDistance = 10;
+  qreal minDistance = mCanvas->physicalDpiX() / 10;
   for ( QgsGCPList::const_iterator it = mPoints.constBegin(); it != mPoints.constEnd(); ++it )
   {
     qreal distance = ( *it )->distance( p, isMapPlugin );

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -117,6 +117,7 @@ QgsGeoreferencerMainWindow::QgsGeoreferencerMainWindow( QWidget *parent, Qt::Win
   {
     dockThisWindow( true );
   }
+  mPointSelectionDistance = settings.value( QStringLiteral( "/Plugin-GeoReferencer/Config/PointSelectionDistance" ), "10" ).toInt();
 }
 
 void QgsGeoreferencerMainWindow::dockThisWindow( bool dock )
@@ -519,7 +520,7 @@ void QgsGeoreferencerMainWindow::deleteDataPoint( QPoint coords )
   // This is the manhattan length from mouse cursor point to GCP
   // We will use this distance to pick the closest GCP to the cursor
   // GCPs farther than the initial minDistance are too far and are ignored
-  qreal minDistance = mCanvas->physicalDpiX() / 10;
+  qreal minDistance = mPointSelectionDistance * mCanvas->devicePixelRatioF();
   for ( QgsGCPList::iterator it = mPoints.begin(); it != mPoints.end(); ++it )
   {
     qreal distance = ( *it )->distance( coords, true );
@@ -555,7 +556,7 @@ void QgsGeoreferencerMainWindow::selectPoint( QPoint p )
   // This is the manhattan length from mouse cursor point to GCP
   // We will use this distance to pick the closest GCP to the cursor
   // GCPs farther than the initial minDistance are too far and are ignored
-  qreal minDistance = mCanvas->physicalDpiX() / 10;
+  qreal minDistance = mPointSelectionDistance * mCanvas->devicePixelRatioF();
   for ( QgsGCPList::const_iterator it = mPoints.constBegin(); it != mPoints.constEnd(); ++it )
   {
     qreal distance = ( *it )->distance( p, isMapPlugin );
@@ -668,6 +669,7 @@ void QgsGeoreferencerMainWindow::showGeorefConfigDialog()
     mCanvas->refresh();
     QgisApp::instance()->mapCanvas()->refresh();
     QgsSettings s;
+    mPointSelectionDistance = s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/PointSelectionDistance" ) ).toInt();
     //update dock state
     bool dock = s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/ShowDocked" ) ).toBool();
     if ( dock && !mDock )

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -223,6 +223,7 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     QString mTranslatedRasterFileName;
     QString mGCPpointsFileName;
     QgsCoordinateReferenceSystem mProjection;
+    int mPointSelectionDistance;
     QString mPdfOutputFile;
     QString mPdfOutputMapFile;
     QString mSaveGcp;

--- a/src/ui/georeferencer/qgsgeorefconfigdialogbase.ui
+++ b/src/ui/georeferencer/qgsgeorefconfigdialogbase.ui
@@ -28,9 +28,9 @@
     </spacer>
    </item>
    <item row="0" column="0">
-    <widget class="QGroupBox" name="mPointTipGroupBox">
+    <widget class="QGroupBox" name="mPointsGroupBox">
      <property name="title">
-      <string>Point Tip</string>
+      <string>Points</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
@@ -46,6 +46,33 @@
          <string>Show coordinates</string>
         </property>
        </widget>
+      </item>
+      <item row="2" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_7">
+        <item>
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Point selection distance</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsSpinBox" name="mPointSelectionDistanceSpinBox">
+          <property name="suffix">
+           <string>px</string>
+          </property>
+          <property name="minimum">
+           <number>4</number>
+          </property>
+          <property name="maximum">
+           <number>9999</number>
+          </property>
+          <property name="value">
+           <number>10</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -175,10 +202,16 @@
    <extends>QDoubleSpinBox</extends>
    <header location="global">qgsdoublespinbox.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header location="global">qgsspinbox.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mShowIDsCheckBox</tabstop>
   <tabstop>mShowCoordsCheckBox</tabstop>
+  <tabstop>mPointSelectionDistanceSpinBox</tabstop>
   <tabstop>mPixelsButton</tabstop>
   <tabstop>mMapUnitsButton</tabstop>
   <tabstop>mLeftMarginSpinBox</tabstop>

--- a/src/ui/georeferencer/qgsgeorefpluginguibase.ui
+++ b/src/ui/georeferencer/qgsgeorefpluginguibase.ui
@@ -355,6 +355,9 @@
    <property name="statusTip">
     <string>Move GCP point</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+E</string>
+   </property>
   </action>
   <action name="mActionZoomNext">
    <property name="text">


### PR DESCRIPTION
## Description
In the georeferencer, one has to aim frustratingly good in order to use the *Delete GCP* and *Move GCP point* tool.
This PR fixes this by allowing a manhattan distance of 10 between the mouse cursor and the actual GCP, similarly to the way the *vertex tool* works.

`QgsGeorefDataPoint::contains` is no longer used; should I remove it?

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
