### PR TITLE
Add time parameter in WMS-T GetFeatureInfo

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2914,6 +2914,14 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
       {
         setQueryItem( query, QStringLiteral( "FEATURE_COUNT" ), QString::number( mSettings.mFeatureCount ) );
       }
+
+      // For WMS-T layers
+      if ( temporalCapabilities() &&
+           temporalCapabilities()->hasTemporalCapabilities() )
+      {
+        addWmstParameters( query );
+      }
+
       requestUrl.setQuery( query );
 
       layerList << *layers;


### PR DESCRIPTION
Fixes https://github.com/qgis/QGIS/issues/37191
Adds the time parameter to the GetFeatureInfo request of the WMS-T based layer. 

Screenshot
![getfeatureinfo](https://user-images.githubusercontent.com/2663775/84867808-697a0f00-b084-11ea-844b-bedea2810321.gif)

Note: This only adds the time parameter when the static temporal options are used and layer temporal properties are not active.