### PR TITLE
Fix raster calculator parser/lexer

### DIFF
--- a/src/analysis/raster/qgsrastercalclexer.ll
+++ b/src/analysis/raster/qgsrastercalclexer.ll
@@ -63,8 +63,8 @@ raster_band_ref_quoted  \"(\\.|[^"])*\"
 "ln" { rasterlval.op = QgsRasterCalcNode::opLOG; return FUNCTION;}
 "log10" { rasterlval.op = QgsRasterCalcNode::opLOG10; return FUNCTION;}
 "abs" { rasterlval.op = QgsRasterCalcNode::opABS; return FUNCTION;}
-"min" { rasterlval.op = QgsRasterCalcNode::opMIN; return FUNCTION;}
-"max" { rasterlval.op = QgsRasterCalcNode::opMAX; return FUNCTION;}
+"min" { rasterlval.op = QgsRasterCalcNode::opMIN; return FUNCTION_2_ARGS;}
+"max" { rasterlval.op = QgsRasterCalcNode::opMAX; return FUNCTION_2_ARGS;}
 
 "AND" { return AND; }
 "OR" { return OR; }

--- a/src/analysis/raster/qgsrastercalcparser.yy
+++ b/src/analysis/raster/qgsrastercalcparser.yy
@@ -56,6 +56,7 @@
 %token RASTER_BAND_REF
 %token<number> NUMBER
 %token<op> FUNCTION
+%token<op> FUNCTION_2_ARGS
 
 %type <node> root
 %type <node> raster_exp
@@ -79,7 +80,7 @@ root: raster_exp{}
 
 raster_exp:
   FUNCTION '(' raster_exp ')'   { $$ = new QgsRasterCalcNode($1, $3, 0); joinTmpNodes($$, $3, 0);}
-  | FUNCTION '(' raster_exp ',' raster_exp ')' { $$ = new QgsRasterCalcNode($1, $3, $5); joinTmpNodes($$, $3, $5);}
+  | FUNCTION_2_ARGS '(' raster_exp ',' raster_exp ')' { $$ = new QgsRasterCalcNode($1, $3, $5); joinTmpNodes($$, $3, $5);}
   | raster_exp AND raster_exp   { $$ = new QgsRasterCalcNode( QgsRasterCalcNode::opAND, $1, $3 ); joinTmpNodes($$,$1,$3); }
   | raster_exp OR raster_exp   { $$ = new QgsRasterCalcNode( QgsRasterCalcNode::opOR, $1, $3 ); joinTmpNodes($$,$1,$3); }
   | raster_exp '=' raster_exp   { $$ = new QgsRasterCalcNode( QgsRasterCalcNode::opEQ, $1, $3 ); joinTmpNodes($$,$1,$3); }

--- a/tests/src/analysis/testqgsrastercalculator.cpp
+++ b/tests/src/analysis/testqgsrastercalculator.cpp
@@ -589,7 +589,6 @@ void TestQgsRasterCalculator::findNodes()
   node = QgsRasterCalcNode::parseRasterCalcString( QStringLiteral( "max(-1,1)" ), errorString );
   QVERIFY( node );
   QVERIFY( errorString.isEmpty() );
-
 }
 
 void TestQgsRasterCalculator::testRasterEntries()
@@ -743,6 +742,12 @@ void TestQgsRasterCalculator::toString()
   // Test regression #32477
   QCOMPARE( _test( QStringLiteral( R"raw(("r@1"<100.09)*0.1)raw" ), true ),
             QString( R"raw(( float ) ( ( float ) "r@1" < ( float ) 100.09 ) * ( float ) 0.1)raw" ) );
+
+  QString error;
+  std::unique_ptr< QgsRasterCalcNode > calcNode( QgsRasterCalcNode::parseRasterCalcString( QStringLiteral( "min( \"raster@1\" )" ), error ) );
+  QVERIFY( calcNode == nullptr );
+  calcNode.reset( QgsRasterCalcNode::parseRasterCalcString( QStringLiteral( "max( \"raster@1\" )" ), error ) );
+  QVERIFY( calcNode == nullptr );
 }
 
 void TestQgsRasterCalculator::calcFormulasWithReprojectedLayers()


### PR DESCRIPTION
## Description

In this [issue](https://github.com/qgis/QGIS/issues/35583), a segfault is happening in raster calculator as soon as we use `min` or `max` functions with only 1 parameter. For example: `min ( "slope@1" ) `.

Actually, `min` and `max` functions need two parameters to work, but the parser and lexer are faulty, leading to a valid expression in the raster calculator dialog even if only 1 parameter is indicated.

Due to this PR, the `min ( "slope@1" ) ` expression is invalid and a user cannot click on the `OK` button to run the computation (so no segfault).