### PR TITLE
Improvements in QgsPostgresProvider::changeFeatures

### DIFF
--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -1123,8 +1123,21 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
             {'a': 123, 'b': 123.34, 'c': 'a string', 'd': [
                 1, 2, 3], 'e': {'a': 123, 'b': 123.45}}
         )
+        attrs2 = (
+            246,
+            2466.91,
+            None,
+            True,
+            False,
+            r"Yet another string literal with \"quotes\" 'and' other funny chars: π []{};#/èé*",
+            [2, 4, 3.14159, None],
+            [True, False],
+            {'a': 246, 'b': 246.68, 'c': 'a rounded area: π × r²', 'd': [
+                1, 2, 3], 'e': {'a': 246, 'b': 246.91}}
+        )
         json_idx = vl.fields().lookupField('jvalue')
         jsonb_idx = vl.fields().lookupField('jbvalue')
+
         for attr in attrs:
             # Add a new feature
             vl2 = QgsVectorLayer('%s table="qgis_test"."json" sql=' % (
@@ -1149,6 +1162,21 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
                 fid, {json_idx: attr, jsonb_idx: attr}))
             self.assertTrue(vl2.commitChanges())
             # Read back
+            vl2 = QgsVectorLayer('%s table="qgis_test"."json" sql=' % (
+                self.dbconn), "testjson", "postgres")
+            f = vl2.getFeature(fid)
+            self.assertEqual(f.attributes(), [fid, attr, attr])
+
+        # Let's check changeFeatures:
+        for attr in attrs2:
+            vl2 = QgsVectorLayer('%s table="qgis_test"."json" sql=' % (
+                self.dbconn), "testjson", "postgres")
+            fid = [f.id() for f in vl2.getFeatures()][-1]
+            self.assertTrue(vl2.startEditing())
+            self.assertTrue(vl2.dataProvider().changeFeatures({fid: {json_idx: attr, jsonb_idx: attr}}, {}))
+            self.assertTrue(vl2.commitChanges())
+
+            # Read back again
             vl2 = QgsVectorLayer('%s table="qgis_test"."json" sql=' % (
                 self.dbconn), "testjson", "postgres")
             f = vl2.getFeature(fid)
@@ -2215,6 +2243,67 @@ class TestPyQgsPostgresProviderCompoundKey(unittest.TestCase, ProviderTestCase):
             self.assertFalse(self.vl.dataProvider().fieldConstraints(
                 idx) & QgsFieldConstraints.ConstraintUnique)
 
+    def testCompoundPkChanges(self):
+        """ Check if fields with compound primary keys can be changed """
+        vl = self.vl
+
+        self.assertTrue(vl.isValid())
+        idx_key1 = vl.fields().lookupField('key1')
+        idx_key2 = vl.fields().lookupField('key2')
+        # the name "pk" for this datasource is misleading;
+        # the primary key is actually composed by the fields key1 and key2
+        idx_pk = vl.fields().lookupField('pk')
+        idx_name = vl.fields().lookupField('name')
+        idx_name2 = vl.fields().lookupField('name2')
+
+        geomwkt = 'Point(-47.945 -15.812)'
+
+        # start editing ordinary attribute.
+        ft1 = next(vl.getFeatures(QgsFeatureRequest().setFilterExpression("key1 = 2 AND key2 = 2")))
+        self.assertTrue(ft1.isValid())
+        original_geometry = ft1.geometry().asWkt()
+
+        vl.startEditing()
+        self.assertTrue(vl.changeAttributeValues(ft1.id(), {idx_name: 'Rose'}))
+        self.assertTrue(vl.commitChanges())
+
+        # check change
+        ft2 = next(vl.getFeatures(QgsFeatureRequest().setFilterExpression("key1 = 2 AND key2 = 2")))
+        self.assertEqual(ft2['name'], 'Rose')
+        self.assertEqual(ft2['name2'], 'Apple')
+        self.assertEqual(ft2['pk'], 2)
+
+        # now, start editing one of the PK field components
+        vl.startEditing()
+
+        self.assertTrue(vl.dataProvider().changeFeatures({ft2.id(): {idx_key2: 42, idx_name: 'Orchid', idx_name2: 'Daisy'}}, {ft2.id(): QgsGeometry.fromWkt(geomwkt)}))
+        self.assertTrue(vl.commitChanges())
+
+        # let's check if we still have the same fid...
+        ft2 = next(vl.getFeatures(QgsFeatureRequest().setFilterFid(ft2.id())))
+        self.assertEqual(ft2['key2'], 42)
+        self.assertEqual(ft2['name'], 'Orchid')
+        self.assertEqual(ft2['name2'], 'Daisy')
+        self.assertTrue(vl.startEditing())
+        vl.changeAttributeValues(ft2.id(), {idx_key1: 21, idx_name2: 'Hibiscus'})
+        self.assertTrue(vl.commitChanges())
+        ft2 = next(vl.getFeatures(QgsFeatureRequest().setFilterFid(ft2.id())))
+        self.assertEqual(ft2['key1'], 21)
+        self.assertEqual(ft2['name2'], 'Hibiscus')
+
+        # lets get a brand new feature and check how it went...
+        ft3 = next(vl.getFeatures(QgsFeatureRequest().setFilterExpression('pk = 2')))
+        self.assertEqual(ft3['name'], 'Orchid')
+        self.assertEqual(ft3['key1'], 21)
+        self.assertEqual(ft3['key2'], 42)
+
+        assert compareWkt(ft3.geometry().asWkt(), geomwkt), "Geometry mismatch. Expected: {} Got: {}\n".format(ft3.geometry().asWkt(), geomwkt)
+
+        # Now, we leave the record as we found it, so further tests can proceed
+        vl.startEditing()
+        self.assertTrue(vl.dataProvider().changeFeatures({ft3.id(): {idx_key1: 2, idx_key2: 2, idx_pk: 2, idx_name: 'Apple', idx_name2: 'Apple'}}, {ft3.id(): QgsGeometry.fromWkt(original_geometry)}))
+        self.assertTrue(vl.commitChanges())
+
 
 class TestPyQgsPostgresProviderBigintSinglePk(unittest.TestCase, ProviderTestCase):
 
@@ -2493,6 +2582,28 @@ class TestPyQgsPostgresProviderBigintSinglePk(unittest.TestCase, ProviderTestCas
             # expect fail
             self.assertFalse(l.dataProvider().addFeatures([f1, f2]),
                              'Provider reported no AddFeatures capability, but returned true to addFeatures')
+
+    def testModifyPk(self):
+        """ Check if we can modify a primary key value. Since this PK is bigint, we also exercise the mapping between fid and values """
+
+        vl = self.getEditableLayer()
+        self.assertTrue(vl.isValid())
+        geomwkt = 'Point(-47.945 -15.812)'
+
+        feature = next(vl.getFeatures(QgsFeatureRequest().setFilterExpression('pk = 4')))
+        self.assertTrue(feature.isValid())
+
+        self.assertTrue(vl.startEditing())
+        idxpk = vl.fields().lookupField('pk')
+
+        self.assertTrue(vl.dataProvider().changeFeatures({feature.id(): {idxpk: 42}}, {feature.id(): QgsGeometry.fromWkt(geomwkt)}))
+        self.assertTrue(vl.commitChanges())
+
+        # read back
+        ft = next(vl.getFeatures(QgsFeatureRequest().setFilterExpression('pk = 42')))
+        self.assertTrue(ft.isValid())
+        self.assertEqual(ft['name'], 'Honey')
+        assert compareWkt(ft.geometry().asWkt(), geomwkt), "Geometry mismatch. Expected: {} Got: {}\n".format(ft.geometry().asWkt(), geomwkt)
 
     def testDuplicatedFieldNamesInQueryLayers(self):
         """Test regresssion GH #36205"""


### PR DESCRIPTION
Included support for json/jsonb in this method, as there already exists
for QgsPostgresProvider::changeAttributeValues; fixed how the provider
deals with bigint primary keys in this case; added a few tests that
exercise changing of attributes, geometries, and primary keys of
features.