### PR TITLE
Respect text field width specification

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -1886,7 +1886,8 @@ bool QgsOgrProvider::addAttributeOGRLevel( const QgsField &field, bool &ignoreEr
 
   gdal::ogr_field_def_unique_ptr fielddefn( OGR_Fld_Create( textEncoding()->fromUnicode( field.name() ).constData(), type ) );
   int width = field.length();
-  if ( field.precision() )
+  // precision is only meaningful for OFTReal, don't alter the specified width for other types
+  if ( type == OFTReal && field.precision() )
     width += 1;
   OGR_Fld_SetWidth( fielddefn.get(), width );
   OGR_Fld_SetPrecision( fielddefn.get(), field.precision() );

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -1886,7 +1886,7 @@ bool QgsOgrProvider::addAttributeOGRLevel( const QgsField &field, bool &ignoreEr
 
   gdal::ogr_field_def_unique_ptr fielddefn( OGR_Fld_Create( textEncoding()->fromUnicode( field.name() ).constData(), type ) );
   int width = field.length();
-  // precision is only meaningful for OFTReal, don't alter the specified width for other types
+  // Increase width by 1 for OFTReal to make room for the decimal point
   if ( type == OFTReal && field.precision() )
     width += 1;
   OGR_Fld_SetWidth( fielddefn.get(), width );


### PR DESCRIPTION
Since 231a2df2dd86a5ffe8e97a7da937007a9c7d2475 all field types for OGR providers are saved with a width that is one greater than the width specified in the "New field" dialog.

In 231a2df2dd86a5ffe8e97a7da937007a9c7d2475, a default value of `3` was introduced for the "precision" field. This value cannot be altered for column types other than "real" because the field is hidden. The default value then gets passed to [qgsogrprovider.cpp](https://github.com/qgis/QGIS/blob/a835cdfd1b62d23ee78f6bc20f54d5e86af4797d/src/core/providers/ogr/qgsogrprovider.cpp#L1890-L1891), where the non-zero precision triggers incrementing the `width` field by 1. This increment was introduced to address https://issues.qgis.org/issues/11755 (making room for the decimal point), which is only relevant for reals.

This PR checks whether we're dealing with a real before applying the width correction.

Fixes #37254