### PR TITLE
use attribute value in the output file name for Split vector layer algorithm (fix #37296)

### DIFF
--- a/src/analysis/processing/qgsalgorithmsplitvectorlayer.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitvectorlayer.cpp
@@ -119,7 +119,7 @@ QVariantMap QgsSplitVectorLayerAlgorithm::processAlgorithm( const QVariantMap &p
     if ( feedback->isCanceled() )
       break;
 
-    QString fileName = QStringLiteral( "%1_%2.%3" ).arg( baseName ).arg( current ).arg( outputFormat );
+    QString fileName = QStringLiteral( "%1_%2.%3" ).arg( baseName ).arg( ( *it ).toString() ).arg( outputFormat );
     feedback->pushInfo( QObject::tr( "Creating layer: %1" ).arg( fileName ) );
 
     sink.reset( QgsProcessingUtils::createFeatureSink( fileName, context, fields, geometryType, crs ) );


### PR DESCRIPTION
## Description
Split vector layer creates files with names containing field name + index, while it should create files with name containing field name + unique attribute value.

Fixes #37296. Master only.