### PR TITLE
Fix georeferencer help button

### DIFF
--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -681,12 +681,6 @@ void QgsGeoreferencerMainWindow::localHistogramStretch()
   mCanvas->refresh();
 }
 
-// Info slots
-void QgsGeoreferencerMainWindow::showHelp()
-{
-  QgsHelp::openHelp( QStringLiteral( "plugins/core_plugins/plugins_georeferencer.html#defining-the-transformation-settings" ) );
-}
-
 // Comfort slots
 void QgsGeoreferencerMainWindow::jumpToGCP( uint theGCPIndex )
 {
@@ -904,10 +898,6 @@ void QgsGeoreferencerMainWindow::createActions()
   mActionFullHistogramStretch->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionFullHistogramStretch.svg" ) ) );
   connect( mActionFullHistogramStretch, &QAction::triggered, this, &QgsGeoreferencerMainWindow::fullHistogramStretch );
   mActionFullHistogramStretch->setEnabled( false );
-
-  // Help actions
-  mActionHelp = new QAction( tr( "Help" ), this );
-  connect( mActionHelp, &QAction::triggered, this, &QgsGeoreferencerMainWindow::showHelp );
 
   mActionQuit->setShortcuts( QList<QKeySequence>() << QKeySequence( Qt::CTRL + Qt::Key_Q )
                              << QKeySequence( Qt::Key_Escape ) );

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -101,9 +101,6 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     void showRasterPropertiesDialog();
     void showGeorefConfigDialog();
 
-    // plugin info
-    void showHelp();
-
     // comfort
     void jumpToGCP( uint theGCPIndex );
     void extentsChangedGeorefCanvas();
@@ -204,8 +201,6 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     QgsMessageBar *mMessageBar = nullptr;
     QMenu *mPanelMenu = nullptr;
     QMenu *mToolbarMenu = nullptr;
-
-    QAction *mActionHelp = nullptr;
 
     QgsGCPListWidget *mGCPListWidget = nullptr;
     QLineEdit *mScaleEdit = nullptr;

--- a/src/app/georeferencer/qgstransformsettingsdialog.cpp
+++ b/src/app/georeferencer/qgstransformsettingsdialog.cpp
@@ -25,6 +25,7 @@
 #include "qgstransformsettingsdialog.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsgui.h"
+#include "qgshelp.h"
 
 QgsTransformSettingsDialog::QgsTransformSettingsDialog( const QString &raster, const QString &output,
     int countGCPpoints, QWidget *parent )
@@ -124,6 +125,7 @@ QgsTransformSettingsDialog::QgsTransformSettingsDialog( const QString &raster, c
   cbxLoadInQgisWhenDone->setChecked( settings.value( QStringLiteral( "/Plugin-GeoReferencer/loadinqgis" ), false ).toBool() );
   saveGcpCheckBox->setChecked( settings.value( QStringLiteral( "/Plugin-GeoReferencer/save_gcp_points" ), false ).toBool() );
 
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsTransformSettingsDialog::showHelp );
 }
 
 void QgsTransformSettingsDialog::getTransformSettings( QgsGeorefTransform::TransformParametrisation &tp,
@@ -309,4 +311,9 @@ QIcon QgsTransformSettingsDialog::getThemeIcon( const QString &name )
       return QIcon( ":/icons/default" + name );
     }
   }
+}
+
+void QgsTransformSettingsDialog::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "working_with_raster/georeferencer.html#defining-the-transformation-settings" ) );
 }

--- a/src/app/georeferencer/qgstransformsettingsdialog.h
+++ b/src/app/georeferencer/qgstransformsettingsdialog.h
@@ -44,6 +44,7 @@ class QgsTransformSettingsDialog : public QDialog, private Ui::QgsTransformSetti
     void cmbTransformType_currentIndexChanged( const QString &text );
     void mWorldFileCheckBox_stateChanged( int state );
     QIcon getThemeIcon( const QString &name );
+    void showHelp();
 
   private:
     bool checkGCPpoints( int count, int &minGCPpoints );


### PR DESCRIPTION
## Description
The slot method on `QgsGeoreferencerMainWindow` was pointing to the old plugin help page, and the help button on the transformation settings page was disconnected!

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
