### PR TITLE
Add API to retrieve QGIS version used to save a QgsProject

### DIFF
--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -127,6 +127,13 @@ Returns the date and time when the project was last saved.
 .. versionadded:: 3.14
 %End
 
+    QgsProjectVersion lastSaveVersion() const;
+%Docstring
+Returns the QGIS version which the project was last saved using.
+
+.. versionadded:: 3.14
+%End
+
     bool isDirty() const;
 %Docstring
 Returns ``True`` if the project has been modified since the last :py:func:`~QgsProject.write`

--- a/python/core/auto_generated/qgsprojectversion.sip.in
+++ b/python/core/auto_generated/qgsprojectversion.sip.in
@@ -9,7 +9,6 @@
 
 
 
-
 class QgsProjectVersion
 {
 %Docstring
@@ -28,12 +27,35 @@ of QGIS is greater than the one used to create a project file.
 Creates a new NULL version
 %End
 
-    QgsProjectVersion( int major, int minor, int sub, const QString &name = "" );
+    QgsProjectVersion( int major, int minor, int sub, const QString &name = QString() );
+%Docstring
+Constructor for QgsProjectVersion, with the specified ``major``, ``minor`` and ``sub`` version numbers.
+%End
+
     QgsProjectVersion( const QString &string );
-    int majorVersion();
-    int minorVersion();
-    int subVersion();
-    QString text();
+%Docstring
+Constructor for QgsProjectVersion, which parses the version number from a ``string``.
+%End
+
+    int majorVersion() const;
+%Docstring
+Returns the major version number.
+%End
+
+    int minorVersion() const;
+%Docstring
+Returns the minor version number.
+%End
+
+    int subVersion() const;
+%Docstring
+Returns the sub version number.
+%End
+
+    QString text() const;
+%Docstring
+Returns a string representation of the version.
+%End
 
     bool isNull() const;
 %Docstring
@@ -49,7 +71,6 @@ Returns ``True`` if this is a NULL project version.
     bool operator>( const QgsProjectVersion &other ) const;
 
 };
-
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -496,6 +496,11 @@ QDateTime QgsProject::lastSaveDateTime() const
   return mSaveDateTime;
 }
 
+QgsProjectVersion QgsProject::lastSaveVersion() const
+{
+  return mSaveVersion;
+}
+
 bool QgsProject::isDirty() const
 {
   return mDirty;
@@ -771,6 +776,7 @@ void QgsProject::clear()
   mSaveUser.clear();
   mSaveUserFull.clear();
   mSaveDateTime = QDateTime();
+  mSaveVersion = QgsProjectVersion();
   mHomePath.clear();
   mCachedHomePath.clear();
   mAutoTransaction = false;
@@ -1296,7 +1302,7 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
 
   // get project version string, if any
   QgsProjectVersion fileVersion = getVersion( *doc );
-  QgsProjectVersion thisVersion( Qgis::version() );
+  const QgsProjectVersion thisVersion( Qgis::version() );
 
   if ( thisVersion > fileVersion )
   {
@@ -1321,6 +1327,7 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
   mFile.setFileName( fileName );
   mCachedHomePath.clear();
   mProjectScope.reset();
+  mSaveVersion = fileVersion;
 
   // now get any properties
   _getProperties( *doc, mProperties );
@@ -1542,7 +1549,7 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
   }
 
   // Convert pre 3.4 to create layers flags
-  if ( QgsProjectVersion( 3, 4, 0 ) > fileVersion )
+  if ( QgsProjectVersion( 3, 4, 0 ) > mSaveVersion )
   {
     const QStringList requiredLayerIds = readListEntry( QStringLiteral( "RequiredLayers" ), QStringLiteral( "Layers" ) );
     for ( const QString &layerId : requiredLayerIds )
@@ -2114,6 +2121,7 @@ bool QgsProject::writeProjectFile( const QString &filename )
     mSaveDateTime = QDateTime();
   }
   doc->appendChild( qgisNode );
+  mSaveVersion = QgsProjectVersion( Qgis::version() );
 
   QDomElement homePathNode = doc->createElement( QStringLiteral( "homePath" ) );
   homePathNode.setAttribute( QStringLiteral( "path" ), mHomePath );

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -216,6 +216,13 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     QDateTime lastSaveDateTime() const;
 
     /**
+     * Returns the QGIS version which the project was last saved using.
+     *
+     * \since QGIS 3.14
+     */
+    QgsProjectVersion lastSaveVersion() const;
+
+    /**
      * Returns TRUE if the project has been modified since the last write()
      */
     bool isDirty() const;
@@ -1939,6 +1946,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     QString mSaveUser;              // last saved user.
     QString mSaveUserFull;          // last saved user full name.
     QDateTime mSaveDateTime;
+    QgsProjectVersion mSaveVersion;
 
     /**
      * Manual override for project home path - if empty, home path is automatically

--- a/src/core/qgsprojectversion.cpp
+++ b/src/core/qgsprojectversion.cpp
@@ -22,32 +22,28 @@
 #include "qgsprojectversion.h"
 
 QgsProjectVersion::QgsProjectVersion( int major, int minor, int sub, const QString &name )
+  : mMajor( major )
+  , mMinor( minor )
+  , mSub( sub )
+  , mName( name )
 {
-  mMajor = major;
-  mMinor = minor;
-  mSub   = sub;
-  mName  = name;
 }
 
 QgsProjectVersion::QgsProjectVersion( const QString &string )
 {
-  QString pre = string.section( '-', 0, 0 );
+  const QString pre = string.section( '-', 0, 0 );
+  const QStringList fileVersionParts = pre.section( '-', 0 ).split( '.' );
 
-  QStringList fileVersionParts = pre.section( '-', 0 ).split( '.' );
-
-  mMinor = 0;
-  mSub   = 0;
   mMajor = fileVersionParts.at( 0 ).toInt();
-
   if ( fileVersionParts.size() > 1 )
   {
     mMinor = fileVersionParts.at( 1 ).toInt();
   }
   if ( fileVersionParts.size() > 2 )
   {
-    mSub   = fileVersionParts.at( 2 ).toInt();
+    mSub = fileVersionParts.at( 2 ).toInt();
   }
-  mName  = string.section( '-', 1 );
+  mName = string.section( '-', 1 );
 
   QgsDebugMsgLevel( QStringLiteral( "Version is set to " ) + text(), 4 );
 }
@@ -78,7 +74,7 @@ bool QgsProjectVersion::operator>( const QgsProjectVersion &other ) const
            ( ( mMajor == other.mMajor ) && ( mMinor == other.mMinor ) && ( mSub > other.mSub ) ) );
 }
 
-QString QgsProjectVersion::text()
+QString QgsProjectVersion::text() const
 {
   if ( mName.isEmpty() )
   {

--- a/src/core/qgsprojectversion.h
+++ b/src/core/qgsprojectversion.h
@@ -28,7 +28,6 @@
  * Used in places where you need to check if the current version
  * of QGIS is greater than the one used to create a project file.
  */
-
 class CORE_EXPORT QgsProjectVersion
 {
 
@@ -39,12 +38,35 @@ class CORE_EXPORT QgsProjectVersion
      */
     QgsProjectVersion() = default;
 
-    QgsProjectVersion( int major, int minor, int sub, const QString &name = "" );
+    /**
+     * Constructor for QgsProjectVersion, with the specified \a major, \a minor and \a sub version numbers.
+     */
+    QgsProjectVersion( int major, int minor, int sub, const QString &name = QString() );
+
+    /**
+     * Constructor for QgsProjectVersion, which parses the version number from a \a string.
+     */
     QgsProjectVersion( const QString &string );
-    int majorVersion() { return mMajor;}
-    int minorVersion() { return mMinor;}
-    int subVersion()   { return mSub;}
-    QString text();
+
+    /**
+     * Returns the major version number.
+     */
+    int majorVersion() const { return mMajor;}
+
+    /**
+     * Returns the minor version number.
+     */
+    int minorVersion() const { return mMinor;}
+
+    /**
+     * Returns the sub version number.
+     */
+    int subVersion() const { return mSub;}
+
+    /**
+     * Returns a string representation of the version.
+     */
+    QString text() const;
 
     /**
      * Returns TRUE if this is a NULL project version.
@@ -77,7 +99,5 @@ class CORE_EXPORT QgsProjectVersion
     int mSub = 0;
     QString mName;
 };
-
-// clazy:excludeall=qstring-allocations
 
 #endif // QGSPROJECTVERSION_H

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -517,6 +517,7 @@ void TestQgsProject::projectSaveUser()
   QCOMPARE( p.saveUser(), QgsApplication::userLoginName() );
   QCOMPARE( p.saveUserFullName(), QgsApplication::userFullName() );
   QCOMPARE( p.lastSaveDateTime().date(), QDateTime::currentDateTime().date() );
+  QCOMPARE( p.lastSaveVersion().text(), QgsProjectVersion( Qgis::version() ).text() );
 
   QgsSettings s;
   s.setValue( QStringLiteral( "projects/anonymize_saved_projects" ), true, QgsSettings::Core );
@@ -533,6 +534,12 @@ void TestQgsProject::projectSaveUser()
   QCOMPARE( p.saveUser(), QgsApplication::userLoginName() );
   QCOMPARE( p.saveUserFullName(), QgsApplication::userFullName() );
   QCOMPARE( p.lastSaveDateTime().date(), QDateTime::currentDateTime().date() );
+
+  QgsProject p2;
+  QVERIFY( p2.read( QString( TEST_DATA_DIR ) + QStringLiteral( "/embedded_groups/project1.qgs" ) ) );
+  QCOMPARE( p2.lastSaveVersion().text(), QStringLiteral( "2.99.0-Master" ) );
+  p2.clear();
+  QVERIFY( p2.lastSaveVersion().isNull() );
 }
 
 void TestQgsProject::testSetGetCrs()


### PR DESCRIPTION
  
  project.lastSaveVersion()

now returns the version number used to save the project.
Also cleanup QgsProjectVersion code

Fixes #37288
