### PR TITLE
[wms] Fix broken WMS layers from servers using relative OnlineResource paths

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -452,8 +452,9 @@ QDateTime QgsWmsSettings::parseWmstDateTimes( QString item )
 // ----------------------
 
 
-QgsWmsCapabilities::QgsWmsCapabilities( const QgsCoordinateTransformContext &coordinateTransformContext ):
-  mCoordinateTransformContext( coordinateTransformContext )
+QgsWmsCapabilities::QgsWmsCapabilities( const QgsCoordinateTransformContext &coordinateTransformContext, const QString &baseUrl ):
+  mCoordinateTransformContext( coordinateTransformContext ),
+  mBaseUrl( baseUrl )
 {
 
 }
@@ -691,8 +692,13 @@ void QgsWmsCapabilities::parseService( const QDomElement &element, QgsWmsService
 
 void QgsWmsCapabilities::parseOnlineResource( const QDomElement &element, QgsWmsOnlineResourceAttribute &onlineResourceAttribute )
 {
-
-  onlineResourceAttribute.xlinkHref = QUrl::fromEncoded( element.attribute( QStringLiteral( "xlink:href" ) ).toUtf8() ).toString();
+  QUrl url = QUrl::fromEncoded( element.attribute( QStringLiteral( "xlink:href" ) ).toUtf8() );
+  if ( url.isRelative() )
+  {
+    QUrl baseUrl = QUrl( mBaseUrl );
+    url = baseUrl.resolved( url );
+  }
+  onlineResourceAttribute.xlinkHref = url.toString();
 }
 
 

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -695,7 +695,7 @@ void QgsWmsCapabilities::parseOnlineResource( const QDomElement &element, QgsWms
   QUrl url = QUrl::fromEncoded( element.attribute( QStringLiteral( "xlink:href" ) ).toUtf8() );
   if ( url.isRelative() )
   {
-    QUrl baseUrl = QUrl( mBaseUrl );
+    const QUrl baseUrl = QUrl( mBaseUrl );
     url = baseUrl.resolved( url );
   }
   onlineResourceAttribute.xlinkHref = url.toString();

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -933,7 +933,7 @@ class QgsWmsCapabilities
     /**
      * Constructs a QgsWmsCapabilities object with the given \a coordinateTransformContext
      */
-    QgsWmsCapabilities( const QgsCoordinateTransformContext &coordinateTransformContext = QgsCoordinateTransformContext() );
+    QgsWmsCapabilities( const QgsCoordinateTransformContext &coordinateTransformContext = QgsCoordinateTransformContext(), const QString &baseUrl = QString() );
 
     bool isValid() const { return mValid; }
 
@@ -1072,6 +1072,7 @@ class QgsWmsCapabilities
   private:
 
     QgsCoordinateTransformContext mCoordinateTransformContext;
+    QString mBaseUrl;
 
     friend class QgsWmsProvider;
     friend class TestQgsWmsCapabilities;

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1373,7 +1373,7 @@ bool QgsWmsProvider::retrieveServerCapabilities( bool forceRefresh )
       return false;
     }
 
-    QgsWmsCapabilities caps( transformContext() );
+    QgsWmsCapabilities caps( transformContext(), mSettings.baseUrl() );
     if ( !caps.parseResponse( downloadCaps.response(), mSettings.parserSettings() ) )
     {
       mErrorFormat = caps.lastErrorFormat();


### PR DESCRIPTION
## Description

WMS servers in the wild can server OnlineResource as relative paths ( e.g. https://data.opendevelopmentcambodia.net/geoserver/ODCambodia/wms? ). QGIS' WMS provider would produce broken layers for those servers.

This PR fixes the provider by checking whether a given path is relative, and if so resolve it.

_Note: I'm not familiar with the WMS spec, I suspect relative paths might be an explicit or implicit breach of the spec. That said, it's in the wild already and it costs us nothing to be tolerant here._