### PR TITLE
Set focus to name field when saving or editing attribute table advanced filter expressions

### DIFF
--- a/src/gui/attributetable/qgsfeaturefilterwidget.cpp
+++ b/src/gui/attributetable/qgsfeaturefilterwidget.cpp
@@ -345,6 +345,7 @@ void QgsFeatureFilterWidget::saveAsStoredFilterExpression()
   QLineEdit *nameEdit = new QLineEdit( dlg );
   layout->addWidget( nameLabel );
   layout->addWidget( nameEdit );
+  nameEdit->setFocus();
 
   if ( dlg->exec() == QDialog::Accepted )
   {
@@ -372,6 +373,7 @@ void QgsFeatureFilterWidget::editStoredFilterExpression()
   layout->addWidget( nameEdit );
   layout->addWidget( expressionLabel );
   layout->addWidget( expressionEdit );
+  nameEdit->setFocus();
 
   if ( dlg->exec() == QDialog::Accepted )
   {


### PR DESCRIPTION
## Description
When saving or editing attribute table advanced filter expressions, focus was set to the OK button by default.
Now focus goes to the name field so one can start typing a name at once.

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
