### PR TITLE
[vector layer] Fix feature request order by not working against non-provider fields

### DIFF
--- a/src/core/qgsvectorlayerfeatureiterator.h
+++ b/src/core/qgsvectorlayerfeatureiterator.h
@@ -288,6 +288,8 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
      * Checks a feature's geometry for validity, if requested in feature request.
      */
     bool checkGeometryValidity( const QgsFeature &feature );
+
+    bool mDelegatedOrderByToProvider = false;
 };
 
 


### PR DESCRIPTION
## Description

This PR fixes issue #37336 , whereas a feature request's order by would not work if clause(s) would rely on non-provider fields.
