### PR TITLE
Improvements to the security warning on plugin install dialog

### DIFF
--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -178,7 +178,7 @@ class ShellOutputScintilla(QsciScintilla):
         txtInit = QCoreApplication.translate("PythonConsole",
                                              "Python Console\n"
                                              "Use iface to access QGIS API interface or Type help(iface) for more info\n"
-                                             "Security warning: typing commands from an untrusted source can lead to data loss and/or leak")
+                                             "Security warning: typing commands from an untrusted source can harm your computer")
 
         # some translation string for the console header ends without '\n'
         # and the first command in console will be appended at the header text.

--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -1522,7 +1522,8 @@ void QgsPluginManager::buttonInstallFromZip_clicked()
   QMessageBox msgbox;
   if ( showInstallFromZipWarning )
   {
-    msgbox.setText( tr( "Security warning: installing a plugin from an untrusted source can lead to data loss and/or leak. Continue?" ) );
+    msgbox.setWindowTitle( tr( "Security warning" ) );
+    msgbox.setText( tr( "Installing a plugin from an untrusted source can harm your computer. Only continue if you received the plugin from a source you trust. Continue?" ) );
     msgbox.setIcon( QMessageBox::Icon::Warning );
     msgbox.addButton( QMessageBox::Yes );
     msgbox.addButton( QMessageBox::No );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7330,7 +7330,8 @@ void QgisApp::runScript( const QString &filePath )
   QMessageBox msgbox;
   if ( showScriptWarning )
   {
-    msgbox.setText( tr( "Security warning: executing a script from an untrusted source can lead to data loss and/or leak. Continue?" ) );
+    msgbox.setWindowTitle( tr( "Security warning" ) );
+    msgbox.setText( tr( "Executing a script from an untrusted source can harm your computer. Only continue if you trust the source of the script. Continue?" ) );
     msgbox.setIcon( QMessageBox::Icon::Warning );
     msgbox.addButton( QMessageBox::Yes );
     msgbox.addButton( QMessageBox::No );


### PR DESCRIPTION
## Description

- Add window title
- Switch to a more generic statement (as there is much more that can be done than data loss / leak)
- Give an advice (so they really think about the *source* of the plugin and not the *way of installation* as a problem)