### PR TITLE
Name role in expression item to be stable on fields in the expression builder

### DIFF
--- a/python/gui/auto_generated/qgsexpressiontreeview.sip.in
+++ b/python/gui/auto_generated/qgsexpressiontreeview.sip.in
@@ -67,6 +67,7 @@ Gets the type of expression item, e.g., header, field, ExpressionNode.
     static const int CUSTOM_SORT_ROLE;
     static const int ITEM_TYPE_ROLE;
     static const int SEARCH_TAGS_ROLE;
+    static const int ITEM_NAME_ROLE;
 
 };
 

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -309,7 +309,7 @@ void QgsExpressionBuilderWidget::expressionTreeItemChanged( QgsExpressionItem *i
   {
     mValuesModel->clear();
 
-    cbxValuesInUse->setVisible( formatterCanProvideAvailableValues( mLayer, item->text() ) );
+    cbxValuesInUse->setVisible( formatterCanProvideAvailableValues( mLayer, item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString() ) );
     cbxValuesInUse->setChecked( false );
   }
   mValueGroupBox->setVisible( isField );
@@ -827,7 +827,7 @@ void QgsExpressionBuilderWidget::loadSampleValues()
     return;
 
   mValueGroupBox->show();
-  fillFieldValues( item->text(), 10 );
+  fillFieldValues( item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString(), 10 );
 }
 
 void QgsExpressionBuilderWidget::loadAllValues()
@@ -839,7 +839,7 @@ void QgsExpressionBuilderWidget::loadAllValues()
     return;
 
   mValueGroupBox->show();
-  fillFieldValues( item->text(), -1 );
+  fillFieldValues( item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString(), -1 );
 }
 
 void QgsExpressionBuilderWidget::loadSampleUsedValues()
@@ -851,7 +851,7 @@ void QgsExpressionBuilderWidget::loadSampleUsedValues()
     return;
 
   mValueGroupBox->show();
-  fillFieldValues( item->text(), 10, true );
+  fillFieldValues( item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString(), 10, true );
 }
 
 void QgsExpressionBuilderWidget::loadAllUsedValues()
@@ -863,7 +863,7 @@ void QgsExpressionBuilderWidget::loadAllUsedValues()
     return;
 
   mValueGroupBox->show();
-  fillFieldValues( item->text(), -1, true );
+  fillFieldValues( item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString(), -1, true );
 }
 
 void QgsExpressionBuilderWidget::txtPython_textChanged()
@@ -1113,7 +1113,7 @@ QMenu *QgsExpressionBuilderWidget::ExpressionTreeMenuProvider::createContextMenu
     menu->addAction( tr( "Load First 10 Unique Values" ), mExpressionBuilderWidget, &QgsExpressionBuilderWidget::loadSampleValues );
     menu->addAction( tr( "Load All Unique Values" ), mExpressionBuilderWidget, &QgsExpressionBuilderWidget::loadAllValues );
 
-    if ( formatterCanProvideAvailableValues( layer, item->text() ) )
+    if ( formatterCanProvideAvailableValues( layer, item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString() ) )
     {
       menu->addAction( tr( "Load First 10 Unique Used Values" ), mExpressionBuilderWidget, SLOT( loadSampleUsedValues() ) );
       menu->addAction( tr( "Load All Unique Used Values" ), mExpressionBuilderWidget, &QgsExpressionBuilderWidget::loadAllUsedValues );

--- a/src/gui/qgsexpressiontreeview.cpp
+++ b/src/gui/qgsexpressiontreeview.cpp
@@ -324,12 +324,13 @@ void QgsExpressionTreeView::registerItem( const QString &group,
     const QString &label,
     const QString &expressionText,
     const QString &helpText,
-    QgsExpressionItem::ItemType type, bool highlightedItem, int sortOrder, QIcon icon, const QStringList &tags )
+    QgsExpressionItem::ItemType type, bool highlightedItem, int sortOrder, QIcon icon, const QStringList &tags, const QString &name )
 {
   QgsExpressionItem *item = new QgsExpressionItem( label, expressionText, helpText, type );
   item->setData( label, Qt::UserRole );
   item->setData( sortOrder, QgsExpressionItem::CUSTOM_SORT_ROLE );
   item->setData( tags, QgsExpressionItem::SEARCH_TAGS_ROLE );
+  item->setData( name, QgsExpressionItem::ITEM_NAME_ROLE );
   item->setIcon( icon );
 
   // Look up the group and insert the new function.
@@ -420,7 +421,7 @@ void QgsExpressionTreeView::loadFieldNames( const QgsFields &fields )
     const QgsField field = fields.at( i );
     QIcon icon = fields.iconForField( i );
     registerItem( QStringLiteral( "Fields and Values" ), field.displayNameWithAlias(),
-                  " \"" + field.name() + "\" ", QString(), QgsExpressionItem::Field, false, i, icon );
+                  " \"" + field.name() + "\" ", QString(), QgsExpressionItem::Field, false, i, icon, QStringList(), field.name() );
   }
 }
 

--- a/src/gui/qgsexpressiontreeview.h
+++ b/src/gui/qgsexpressiontreeview.h
@@ -95,6 +95,8 @@ class GUI_EXPORT QgsExpressionItem : public QStandardItem
     static const int ITEM_TYPE_ROLE = Qt::UserRole + 2;
     //! Search tags role
     static const int SEARCH_TAGS_ROLE = Qt::UserRole + 3;
+    //! Item name role
+    static const int ITEM_NAME_ROLE = Qt::UserRole + 4;
 
   private:
     QString mExpressionText;
@@ -308,7 +310,8 @@ class GUI_EXPORT QgsExpressionTreeView : public QTreeView
                        QgsExpressionItem::ItemType type = QgsExpressionItem::ExpressionNode,
                        bool highlightedItem = false, int sortOrder = 1,
                        QIcon icon = QIcon(),
-                       const QStringList &tags = QStringList() );
+                       const QStringList &tags = QStringList(),
+                       const QString &name = QString() );
 
     /**
      * Registers a node item for the expression builder, adding multiple items when the function exists in multiple groups


### PR DESCRIPTION
Issue has been that on using alias for the fields the label of the expression item are `<name> (<alias>)` and this label has been used to get the values listed as examples. By introducing the new role `ITEM_NAME_ROLE` we work with the field name instead of the label. This role is currently only used for the expression items for the fields. But I think it's the proper way. Maybe it can be used for other expression items as well in future.