### PR TITLE
Add project load profile times to debugging tools dock

### DIFF
--- a/python/core/auto_generated/qgsruntimeprofiler.sip.in
+++ b/python/core/auto_generated/qgsruntimeprofiler.sip.in
@@ -36,6 +36,7 @@ Constructor to create a new runtime profiler.
    QgsRuntimeProfiler is not usually instantied manually, but rather accessed
    through :py:func:`QgsApplication.profiler()`.
 %End
+    ~QgsRuntimeProfiler();
 
  void beginGroup( const QString &name ) /Deprecated/;
 %Docstring

--- a/python/core/auto_generated/qgsruntimeprofiler.sip.in
+++ b/python/core/auto_generated/qgsruntimeprofiler.sip.in
@@ -100,6 +100,14 @@ The current total time collected in the profiler.
 Returns the set of known groups.
 %End
 
+    bool groupIsActive( const QString &group ) const;
+%Docstring
+Returns ``True`` if the specified ``group`` is currently being logged,
+i.e. it has a entry which has started and not yet stopped.
+
+.. versionadded:: 3.14
+%End
+
     static QString translateGroupName( const QString &group );
 %Docstring
 Returns the translated name of a standard profile ``group``.

--- a/python/core/auto_generated/qgsruntimeprofiler.sip.in
+++ b/python/core/auto_generated/qgsruntimeprofiler.sip.in
@@ -151,7 +151,7 @@ Python scripts should not use QgsScopedRuntimeProfile directly. Instead, use :py
 %End
   public:
 
-    QgsScopedRuntimeProfile( const QString &name );
+    QgsScopedRuntimeProfile( const QString &name, const QString &group = "startup" );
 %Docstring
 Constructor for QgsScopedRuntimeProfile.
 

--- a/python/core/auto_generated/qgsruntimeprofiler.sip.in
+++ b/python/core/auto_generated/qgsruntimeprofiler.sip.in
@@ -161,6 +161,16 @@ and starts recording the run time of the operation.
 
     ~QgsScopedRuntimeProfile();
 
+    void switchTask( const QString &name );
+%Docstring
+Switches the current task managed by the scoped profile to a new task with the given ``name``.
+The current task will be finalised before switching.
+
+This is useful for reusing an existing scoped runtime profiler with multi-step processes.
+
+.. versionadded:: 3.14
+%End
+
 };
 
 

--- a/python/core/auto_generated/qgsruntimeprofiler.sip.in
+++ b/python/core/auto_generated/qgsruntimeprofiler.sip.in
@@ -8,8 +8,19 @@
 
 
 
-class QgsRuntimeProfiler
+class QgsRuntimeProfiler : QAbstractItemModel
 {
+%Docstring
+
+Provides a method of recording run time profiles of operations, allowing
+easy recording of their overall run time.
+
+QgsRuntimeProfiler is not usually instantied manually, but rather accessed
+through :py:func:`QgsApplication.profiler()`.
+
+This class is thread-safe only if accessed through :py:func:`QgsApplication.profiler()`.
+If accessed in this way, operations can be profiled from non-main threads.
+%End
 
 %TypeHeaderCode
 #include "qgsruntimeprofiler.h"
@@ -19,6 +30,11 @@ class QgsRuntimeProfiler
     QgsRuntimeProfiler();
 %Docstring
 Constructor to create a new runtime profiler.
+
+.. warning::
+
+   QgsRuntimeProfiler is not usually instantied manually, but rather accessed
+   through :py:func:`QgsApplication.profiler()`.
 %End
 
  void beginGroup( const QString &name ) /Deprecated/;
@@ -40,14 +56,14 @@ End the current active group.
    use end() instead
 %End
 
-    QStringList childGroups( const QString &parent = QString() ) const;
+    QStringList childGroups( const QString &parent = QString(), const QString &group = "startup" ) const;
 %Docstring
 Returns a list of all child groups with the specified ``parent``.
 
 .. versionadded:: 3.14
 %End
 
-    void start( const QString &name );
+    void start( const QString &name, const QString &group = "startup" );
 %Docstring
 Start a profile event with the given name.
 
@@ -55,28 +71,58 @@ Start a profile event with the given name.
              the active group appended after ending.
 %End
 
-    void end();
+    void end( const QString &group = "startup" );
 %Docstring
 End the current profile event.
 %End
 
-    double profileTime( const QString &name ) const;
+    double profileTime( const QString &name, const QString &group = "startup" ) const;
 %Docstring
 Returns the profile time for the specified ``name``.
 
 .. versionadded:: 3.14
 %End
 
-    void clear();
+    void clear( const QString &group = "startup" );
 %Docstring
 clear Clear all profile data.
 %End
 
-    double totalTime();
+    double totalTime( const QString &group = "startup" );
 %Docstring
 The current total time collected in the profiler.
 
 :return: The current total time collected in the profiler.
+%End
+
+    QSet< QString > groups() const;
+%Docstring
+Returns the set of known groups.
+%End
+
+    static QString translateGroupName( const QString &group );
+%Docstring
+Returns the translated name of a standard profile ``group``.
+%End
+
+
+    virtual int rowCount( const QModelIndex &parent = QModelIndex() ) const;
+
+    virtual int columnCount( const QModelIndex &parent = QModelIndex() ) const;
+
+    virtual QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const;
+
+    virtual QModelIndex parent( const QModelIndex &child ) const;
+
+    virtual QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const;
+
+    virtual QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const;
+
+
+
+    void groupAdded( const QString &group );
+%Docstring
+Emitted when a new group has started being profiled.
 %End
 
 };

--- a/src/app/devtools/profiler/qgsprofilerpanelwidget.cpp
+++ b/src/app/devtools/profiler/qgsprofilerpanelwidget.cpp
@@ -16,6 +16,7 @@
 #include "qgsprofilerpanelwidget.h"
 #include "qgsruntimeprofiler.h"
 #include "qgslogger.h"
+#include "qgis.h"
 #include <QPainter>
 #include <cmath>
 
@@ -29,35 +30,64 @@ QgsProfilerPanelWidget::QgsProfilerPanelWidget( QgsRuntimeProfiler *profiler, QW
 {
   setupUi( this );
 
-  mTreeWidget->setColumnCount( 2 );
-  mTreeWidget->setHeaderLabels( QStringList() << tr( "Task" ) << tr( "Time (seconds)" ) );
-  mTreeWidget->setSortingEnabled( true );
+  mProxyModel = new QgsProfilerProxyModel( profiler, this );
 
-  std::function< void( const QString &topLevel, QTreeWidgetItem *parentItem, double parentCost ) > addGroup;
-  addGroup = [&]( const QString & topLevel, QTreeWidgetItem * parentItem, double parentCost )
+  mTreeView->setModel( mProxyModel );
+  mTreeView->setSortingEnabled( true );
+
+  mTreeView->resizeColumnToContents( 0 );
+  mTreeView->resizeColumnToContents( 1 );
+
+  mTreeView->setItemDelegateForColumn( 1, new CostDelegate( QgsRuntimeProfilerNode::Elapsed, QgsRuntimeProfilerNode::ParentElapsed ) );
+
+  connect( mProfiler, &QgsRuntimeProfiler::groupAdded, this, [ = ]( const QString & group )
   {
-    const QStringList children = mProfiler->childGroups( topLevel );
-    for ( const QString &child : children )
+    mCategoryComboBox->addItem( QgsRuntimeProfiler::translateGroupName( group ).isEmpty() ? group : QgsRuntimeProfiler::translateGroupName( group ), group );
+    if ( mCategoryComboBox->count() == 1 )
     {
-      double profileTime = mProfiler->profileTime( topLevel.isEmpty() ? child : topLevel + '/' + child );
-      QTreeWidgetItem *item = new QTreeWidgetItem( QStringList() << child << QString::number( profileTime ) );
-      item->setData( 1, Qt::UserRole + 1, parentCost * 1000 );
-      item->setData( 1, Qt::InitialSortOrderRole, profileTime * 1000 );
-      if ( !parentItem )
-        mTreeWidget->addTopLevelItem( item );
-      else
-        parentItem->addChild( item );
-
-      addGroup( topLevel.isEmpty() ? child : topLevel + '/' + child, item, profileTime );
+      mCategoryComboBox->setCurrentIndex( 0 );
+      mProxyModel->setGroup( mCategoryComboBox->currentData().toString() );
     }
-  };
-  const double totalTime = mProfiler->profileTime( QString() );
-  addGroup( QString(), nullptr, totalTime );
+  } );
 
-  mTreeWidget->resizeColumnToContents( 0 );
-  mTreeWidget->resizeColumnToContents( 1 );
+  connect( mCategoryComboBox, qgis::overload< int >::of( &QComboBox::currentIndexChanged ), this, [ = ]( int )
+  {
+    mProxyModel->setGroup( mCategoryComboBox->currentData().toString() );
+  } );
 
-  mTreeWidget->setItemDelegateForColumn( 1, new CostDelegate( Qt::InitialSortOrderRole, Qt::UserRole + 1 ) );
+  const QSet<QString> groups = mProfiler->groups();
+  for ( const QString &group : groups )
+  {
+    mCategoryComboBox->addItem( QgsRuntimeProfiler::translateGroupName( group ).isEmpty() ? group : QgsRuntimeProfiler::translateGroupName( group ), group );
+  }
+
+  if ( mCategoryComboBox->count() > 0 )
+  {
+    mCategoryComboBox->setCurrentIndex( 0 );
+    mProxyModel->setGroup( mCategoryComboBox->currentData().toString() );
+  }
+}
+
+//
+// QgsProfilerProxyModel
+//
+
+QgsProfilerProxyModel::QgsProfilerProxyModel( QgsRuntimeProfiler *profiler, QObject *parent )
+  : QSortFilterProxyModel( parent )
+{
+  setSourceModel( profiler );
+}
+
+void QgsProfilerProxyModel::setGroup( const QString &group )
+{
+  mGroup = group;
+  invalidateFilter();
+}
+
+bool QgsProfilerProxyModel::filterAcceptsRow( int row, const QModelIndex &source_parent ) const
+{
+  QModelIndex index = sourceModel()->index( row, 0, source_parent );
+  return sourceModel()->data( index, QgsRuntimeProfilerNode::Group ).toString() == mGroup;
 }
 
 
@@ -79,14 +109,14 @@ CostDelegate::~CostDelegate() = default;
 void CostDelegate::paint( QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index ) const
 {
   // TODO: handle negative values
-  const auto cost = index.data( m_sortRole ).toULongLong();
+  const auto cost = index.data( m_sortRole ).toDouble();
   if ( cost == 0 )
   {
     QStyledItemDelegate::paint( painter, option, index );
     return;
   }
 
-  const auto totalCost = index.data( m_totalCostRole ).toULongLong();
+  const auto totalCost = index.data( m_totalCostRole ).toDouble();
   const auto fraction = std::abs( float( cost ) / totalCost );
 
   auto rect = option.rect;
@@ -123,3 +153,4 @@ void CostDelegate::paint( QPainter *painter, const QStyleOptionViewItem &option,
     QStyledItemDelegate::paint( painter, option, index );
   }
 }
+

--- a/src/app/devtools/profiler/qgsprofilerpanelwidget.cpp
+++ b/src/app/devtools/profiler/qgsprofilerpanelwidget.cpp
@@ -35,8 +35,8 @@ QgsProfilerPanelWidget::QgsProfilerPanelWidget( QgsRuntimeProfiler *profiler, QW
   mTreeView->setModel( mProxyModel );
   mTreeView->setSortingEnabled( true );
 
-  mTreeView->resizeColumnToContents( 0 );
-  mTreeView->resizeColumnToContents( 1 );
+  //mTreeView->resizeColumnToContents( 0 );
+  //mTreeView->resizeColumnToContents( 1 );
 
   mTreeView->setItemDelegateForColumn( 1, new CostDelegate( QgsRuntimeProfilerNode::Elapsed, QgsRuntimeProfilerNode::ParentElapsed ) );
 

--- a/src/app/devtools/profiler/qgsprofilerpanelwidget.h
+++ b/src/app/devtools/profiler/qgsprofilerpanelwidget.h
@@ -19,8 +19,30 @@
 #include "ui_qgsprofilerpanelbase.h"
 #include <QTreeView>
 #include <QStyledItemDelegate>
+#include <QSortFilterProxyModel>
 
 class QgsRuntimeProfiler;
+
+class QgsProfilerProxyModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProfilerProxyModel( QgsRuntimeProfiler *profiler, QObject *parent );
+
+    void setGroup( const QString &group );
+
+  protected:
+    bool filterAcceptsRow( int row, const QModelIndex &source_parent ) const override;
+
+  private:
+
+    QString mGroup;
+
+
+
+};
 
 /**
  * \ingroup app
@@ -43,6 +65,7 @@ class QgsProfilerPanelWidget : public QgsDevToolWidget, private Ui::QgsProfilerP
   private:
 
     QgsRuntimeProfiler *mProfiler = nullptr;
+    QgsProfilerProxyModel *mProxyModel = nullptr;
 
 };
 

--- a/src/app/devtools/profiler/qgsprofilerwidgetfactory.cpp
+++ b/src/app/devtools/profiler/qgsprofilerwidgetfactory.cpp
@@ -18,7 +18,7 @@
 #include "qgsapplication.h"
 
 QgsProfilerWidgetFactory::QgsProfilerWidgetFactory( QgsRuntimeProfiler *profiler )
-  : QgsDevToolWidgetFactory( QObject::tr( "Startup Profiler" ), QgsApplication::getThemeIcon( QStringLiteral( "mIconStopwatch.svg" ) ) )
+  : QgsDevToolWidgetFactory( QObject::tr( "Profiler" ), QgsApplication::getThemeIcon( QStringLiteral( "mIconStopwatch.svg" ) ) )
   , mProfiler( profiler )
 {
 }

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -460,7 +460,7 @@ bool QgsApplication::notify( QObject *receiver, QEvent *event )
 
 QgsRuntimeProfiler *QgsApplication::profiler()
 {
-  return members()->mProfiler;
+  return QgsRuntimeProfiler::threadLocalInstance();
 }
 
 void QgsApplication::setFileOpenEventReceiver( QObject *receiver )
@@ -2247,134 +2247,134 @@ QgsApplication::ApplicationMembers::ApplicationMembers()
   // will need to be careful with the order of creation/destruction
   mLocalizedDataPathRegistry = new QgsLocalizedDataPathRegistry();
   mMessageLog = new QgsMessageLog();
-  mProfiler = new QgsRuntimeProfiler();
+  QgsRuntimeProfiler *profiler = QgsRuntimeProfiler::threadLocalInstance();
 
   {
-    mProfiler->start( tr( "Create connection registry" ) );
+    profiler->start( tr( "Create connection registry" ) );
     mConnectionRegistry = new QgsConnectionRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup task manager" ) );
+    profiler->start( tr( "Setup task manager" ) );
     mTaskManager = new QgsTaskManager();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup action scope registry" ) );
+    profiler->start( tr( "Setup action scope registry" ) );
     mActionScopeRegistry = new QgsActionScopeRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup numeric formats" ) );
+    profiler->start( tr( "Setup numeric formats" ) );
     mNumericFormatRegistry = new QgsNumericFormatRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup field formats" ) );
+    profiler->start( tr( "Setup field formats" ) );
     mFieldFormatterRegistry = new QgsFieldFormatterRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup SVG cache" ) );
+    profiler->start( tr( "Setup SVG cache" ) );
     mSvgCache = new QgsSvgCache();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup image cache" ) );
+    profiler->start( tr( "Setup image cache" ) );
     mImageCache = new QgsImageCache();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup color scheme registry" ) );
+    profiler->start( tr( "Setup color scheme registry" ) );
     mColorSchemeRegistry = new QgsColorSchemeRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup paint effect" ) );
+    profiler->start( tr( "Setup paint effect" ) );
     mPaintEffectRegistry = new QgsPaintEffectRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup symbol layer registry" ) );
+    profiler->start( tr( "Setup symbol layer registry" ) );
     mSymbolLayerRegistry = new QgsSymbolLayerRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup callout registry" ) );
+    profiler->start( tr( "Setup callout registry" ) );
     mCalloutRegistry = new QgsCalloutRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup renderer registry" ) );
+    profiler->start( tr( "Setup renderer registry" ) );
     mRendererRegistry = new QgsRendererRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup raster renderer registry" ) );
+    profiler->start( tr( "Setup raster renderer registry" ) );
     mRasterRendererRegistry = new QgsRasterRendererRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup GPS registry" ) );
+    profiler->start( tr( "Setup GPS registry" ) );
     mGpsConnectionRegistry = new QgsGpsConnectionRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup plugin layer registry" ) );
+    profiler->start( tr( "Setup plugin layer registry" ) );
     mPluginLayerRegistry = new QgsPluginLayerRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup Processing registry" ) );
+    profiler->start( tr( "Setup Processing registry" ) );
     mProcessingRegistry = new QgsProcessingRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   mPageSizeRegistry = new QgsPageSizeRegistry();
   {
-    mProfiler->start( tr( "Setup layout item registry" ) );
+    profiler->start( tr( "Setup layout item registry" ) );
     mLayoutItemRegistry = new QgsLayoutItemRegistry();
     mLayoutItemRegistry->populate();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup annotation registry" ) );
+    profiler->start( tr( "Setup annotation registry" ) );
     mAnnotationRegistry = new QgsAnnotationRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup 3D renderer registry" ) );
+    profiler->start( tr( "Setup 3D renderer registry" ) );
     m3DRendererRegistry = new Qgs3DRendererRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup project storage registry" ) );
+    profiler->start( tr( "Setup project storage registry" ) );
     mProjectStorageRegistry = new QgsProjectStorageRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup network content cache" ) );
+    profiler->start( tr( "Setup network content cache" ) );
     mNetworkContentFetcherRegistry = new QgsNetworkContentFetcherRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup layout check registry" ) );
+    profiler->start( tr( "Setup layout check registry" ) );
     mValidityCheckRegistry = new QgsValidityCheckRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup classification registry" ) );
+    profiler->start( tr( "Setup classification registry" ) );
     mClassificationMethodRegistry = new QgsClassificationMethodRegistry();
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup bookmark manager" ) );
+    profiler->start( tr( "Setup bookmark manager" ) );
     mBookmarkManager = new QgsBookmarkManager( nullptr );
-    mProfiler->end();
+    profiler->end();
   }
   {
-    mProfiler->start( tr( "Setup scalebar registry" ) );
+    profiler->start( tr( "Setup scalebar registry" ) );
     mScaleBarRendererRegistry = new QgsScaleBarRendererRegistry();
-    mProfiler->end();
+    profiler->end();
   }
 }
 
@@ -2396,7 +2396,6 @@ QgsApplication::ApplicationMembers::~ApplicationMembers()
   delete mProjectStorageRegistry;
   delete mPageSizeRegistry;
   delete mLayoutItemRegistry;
-  delete mProfiler;
   delete mRasterRendererRegistry;
   delete mRendererRegistry;
   delete mSvgCache;

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -940,7 +940,6 @@ class CORE_EXPORT QgsApplication : public QApplication
       QgsPageSizeRegistry *mPageSizeRegistry = nullptr;
       QgsRasterRendererRegistry *mRasterRendererRegistry = nullptr;
       QgsRendererRegistry *mRendererRegistry = nullptr;
-      QgsRuntimeProfiler *mProfiler = nullptr;
       QgsSvgCache *mSvgCache = nullptr;
       QgsImageCache *mImageCache = nullptr;
       QgsSymbolLayerRegistry *mSymbolLayerRegistry = nullptr;

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1162,6 +1162,8 @@ bool QgsProject::addLayer( const QDomElement &layerElem, QList<QDomNode> &broken
 
   profile.switchTask( tr( "Load layer source" ) );
   bool layerIsValid = mapLayer->readLayerXml( layerElem, context, layerFlags ) && mapLayer->isValid();
+
+  profile.switchTask( tr( "Add layer to project" ) );
   QList<QgsMapLayer *> newLayers;
   newLayers << mapLayer.get();
   if ( layerIsValid || flags & QgsProject::ReadFlag::FlagDontResolveLayers )

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -61,6 +61,7 @@
 #include "qgsprojectdisplaysettings.h"
 #include "qgsprojecttimesettings.h"
 #include "qgsvectortilelayer.h"
+#include "qgsruntimeprofiler.h"
 
 #include <algorithm>
 #include <QApplication>
@@ -1059,6 +1060,7 @@ bool QgsProject::_getMapLayers( const QDomDocument &doc, QList<QDomNode> &broken
   emit layerLoaded( 0, nl.count() );
 
   // order layers based on their dependencies
+  QgsScopedRuntimeProfile profile( tr( "Sorting layers" ), QStringLiteral( "projectload" ) );
   QgsLayerDefinition::DependencySorter depSorter( doc );
   if ( depSorter.hasCycle() || depSorter.hasMissingDependency() )
     return false;
@@ -1074,6 +1076,8 @@ bool QgsProject::_getMapLayers( const QDomDocument &doc, QList<QDomNode> &broken
     const QString name = translate( QStringLiteral( "project:layers:%1" ).arg( node.namedItem( QStringLiteral( "id" ) ).toElement().text() ), node.namedItem( QStringLiteral( "layername" ) ).toElement().text() );
     if ( !name.isNull() )
       emit loadingLayer( tr( "Loading layer %1" ).arg( name ) );
+
+    profile.switchTask( name );
 
     if ( element.attribute( QStringLiteral( "embedded" ) ) == QLatin1String( "1" ) )
     {
@@ -1109,6 +1113,7 @@ bool QgsProject::addLayer( const QDomElement &layerElem, QList<QDomNode> &broken
   QgsDebugMsgLevel( "Layer type is " + type, 4 );
   std::unique_ptr<QgsMapLayer> mapLayer;
 
+  QgsScopedRuntimeProfile profile( tr( "Create layer" ), QStringLiteral( "projectload" ) );
   if ( type == QLatin1String( "vector" ) )
   {
     mapLayer = qgis::make_unique<QgsVectorLayer>();
@@ -1154,6 +1159,8 @@ bool QgsProject::addLayer( const QDomElement &layerElem, QList<QDomNode> &broken
   QgsMapLayer::ReadFlags layerFlags = QgsMapLayer::ReadFlags();
   if ( flags & QgsProject::ReadFlag::FlagDontResolveLayers )
     layerFlags |= QgsMapLayer::FlagDontResolveLayers;
+
+  profile.switchTask( tr( "Load layer source" ) );
   bool layerIsValid = mapLayer->readLayerXml( layerElem, context, layerFlags ) && mapLayer->isValid();
   QList<QgsMapLayer *> newLayers;
   newLayers << mapLayer.get();
@@ -1251,6 +1258,9 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
   QFile projectFile( filename );
   clearError();
 
+  QgsApplication::profiler()->clear( QStringLiteral( "projectload" ) );
+  QgsScopedRuntimeProfile profile( tr( "Setting up translations" ), QStringLiteral( "projectload" ) );
+
   QgsSettings settings;
 
   QString localeFileName = QStringLiteral( "%1_%2" ).arg( QFileInfo( projectFile.fileName() ).baseName(), settings.value( QStringLiteral( "locale/userLocale" ), QString() ).toString() );
@@ -1261,6 +1271,7 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
     mTranslator->load( localeFileName, QFileInfo( projectFile.fileName() ).absolutePath() );
   }
 
+  profile.switchTask( tr( "Reading project file" ) );
   std::unique_ptr<QDomDocument> doc( new QDomDocument( QStringLiteral( "qgis" ) ) );
 
   if ( !projectFile.open( QIODevice::ReadOnly | QIODevice::Text ) )
@@ -1304,6 +1315,7 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
   QgsProjectVersion fileVersion = getVersion( *doc );
   const QgsProjectVersion thisVersion( Qgis::version() );
 
+  profile.switchTask( tr( "Updating project file" ) );
   if ( thisVersion > fileVersion )
   {
     QgsLogger::warning( "Loading a file that was saved with an older "
@@ -1320,6 +1332,7 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
   }
 
   // start new project, just keep the file name and auxiliary storage
+  profile.switchTask( tr( "Creating auxiliary storage" ) );
   QString fileName = mFile.fileName();
   std::unique_ptr<QgsAuxiliaryStorage> aStorage = std::move( mAuxiliaryStorage );
   clear();
@@ -1330,6 +1343,7 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
   mSaveVersion = fileVersion;
 
   // now get any properties
+  profile.switchTask( tr( "Reading properties" ) );
   _getProperties( *doc, mProperties );
 
   // now get the data defined server properties
@@ -1485,7 +1499,7 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
   }
 
   // read the layer tree from project file
-
+  profile.switchTask( tr( "Loading layer tree" ) );
   mRootGroup->setCustomProperty( QStringLiteral( "loading" ), 1 );
 
   QDomElement layerTreeElem = doc->documentElement().firstChildElement( QStringLiteral( "layer-tree-group" ) );
@@ -1501,6 +1515,8 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
   mLayerTreeRegistryBridge->setEnabled( false );
 
   // get the map layers
+  profile.switchTask( tr( "Reading map layers" ) );
+
   QList<QDomNode> brokenNodes;
   bool clean = _getMapLayers( *doc, brokenNodes, flags );
 
@@ -1521,6 +1537,7 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
 
   // Resolve references to other layers
   // Needs to be done here once all dependent layers are loaded
+  profile.switchTask( tr( "Resolving layer references" ) );
   QMap<QString, QgsMapLayer *> layers = mLayerStore->mapLayers();
   for ( QMap<QString, QgsMapLayer *>::iterator it = layers.begin(); it != layers.end(); ++it )
   {
@@ -1530,11 +1547,12 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
   mLayerTreeRegistryBridge->setEnabled( true );
 
   // load embedded groups and layers
+  profile.switchTask( tr( "Loading embedded layers" ) );
   loadEmbeddedNodes( mRootGroup, flags );
 
   // now that layers are loaded, we can resolve layer tree's references to the layers
+  profile.switchTask( tr( "Resolving references" ) );
   mRootGroup->resolveReferences( this );
-
 
   if ( !layerTreeElem.isNull() )
   {
@@ -1576,16 +1594,23 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
 
   mRootGroup->removeCustomProperty( QStringLiteral( "loading" ) );
 
+  profile.switchTask( tr( "Loading map themes" ) );
   mMapThemeCollection.reset( new QgsMapThemeCollection( this ) );
   emit mapThemeCollectionChanged();
   mMapThemeCollection->readXml( *doc );
 
+  profile.switchTask( tr( "Loading label settings" ) );
   mLabelingEngineSettings->readSettingsFromProject( this );
   emit labelingEngineSettingsChanged();
 
+  profile.switchTask( tr( "Loading annotations" ) );
   mAnnotationManager->readXml( doc->documentElement(), context );
   if ( !( flags & QgsProject::ReadFlag::FlagDontLoadLayouts ) )
+  {
+    profile.switchTask( tr( "Loading layouts" ) );
     mLayoutManager->readXml( doc->documentElement(), *doc );
+  }
+  profile.switchTask( tr( "Loading bookmarks" ) );
   mBookmarkManager->readXml( doc->documentElement(), *doc );
 
   // reassign change dependencies now that all layers are loaded
@@ -1595,9 +1620,11 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
     it.value()->setDependencies( it.value()->dependencies() );
   }
 
+  profile.switchTask( tr( "Loading snapping settings" ) );
   mSnappingConfig.readProject( *doc );
   mAvoidIntersectionsMode = static_cast<AvoidIntersectionsMode>( readNumEntry( QStringLiteral( "Digitizing" ), QStringLiteral( "/AvoidIntersectionsMode" ), static_cast<int>( AvoidIntersectionsMode::AvoidIntersectionsLayers ) ) );
 
+  profile.switchTask( tr( "Loading view settings" ) );
   // restore older project scales settings
   mViewSettings->setUseProjectScales( readBoolEntry( QStringLiteral( "Scales" ), QStringLiteral( "/useProjectScales" ) ) );
   const QStringList scales = readListEntry( QStringLiteral( "Scales" ), QStringLiteral( "/ScalesList" ) );
@@ -1621,21 +1648,28 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
     mViewSettings->readXml( viewSettingsElement, context );
 
   // restore time settings
+  profile.switchTask( tr( "Loading temporal settings" ) );
   QDomElement timeSettingsElement = doc->documentElement().firstChildElement( QStringLiteral( "ProjectTimeSettings" ) );
   if ( !timeSettingsElement.isNull() )
     mTimeSettings->readXml( timeSettingsElement, context );
 
+  profile.switchTask( tr( "Loading display settings" ) );
   QDomElement displaySettingsElement = doc->documentElement().firstChildElement( QStringLiteral( "ProjectDisplaySettings" ) );
   if ( !displaySettingsElement.isNull() )
     mDisplaySettings->readXml( displaySettingsElement, context );
 
+  profile.switchTask( tr( "Updating variables" ) );
   emit customVariablesChanged();
+  profile.switchTask( tr( "Updating CRS" ) );
   emit crsChanged();
   emit ellipsoidChanged( ellipsoid() );
 
   // read the project: used by map canvas and legend
+  profile.switchTask( tr( "Reading external settings" ) );
   emit readProject( *doc );
   emit readProjectWithContext( *doc, context );
+
+  profile.switchTask( tr( "Updating interface" ) );
   emit snappingConfigChanged( mSnappingConfig );
   emit avoidIntersectionsModeChanged();
   emit topologicalEditingChanged();

--- a/src/core/qgsruntimeprofiler.cpp
+++ b/src/core/qgsruntimeprofiler.cpp
@@ -92,11 +92,11 @@ int QgsRuntimeProfilerNode::indexOf( QgsRuntimeProfilerNode *child ) const
   return -1;
 }
 
-QgsRuntimeProfilerNode *QgsRuntimeProfilerNode::child( const QString &group, const QString &path )
+QgsRuntimeProfilerNode *QgsRuntimeProfilerNode::child( const QString &group, const QString &name )
 {
   for ( auto &it : mChildren )
   {
-    if ( it->data( Group ).toString() == group &&  it->data( Name ).toString() == path )
+    if ( it->data( Group ).toString() == group &&  it->data( Name ).toString() == name )
       return it.get();
   }
   return nullptr;
@@ -507,10 +507,13 @@ void QgsRuntimeProfiler::setupConnections()
 
 QgsRuntimeProfilerNode *QgsRuntimeProfiler::pathToNode( const QString &group, const QString &path ) const
 {
-  QStringList parts = path.split( '/', Qt::SkipEmptyParts );
+  QStringList parts = path.split( '/' );
   QgsRuntimeProfilerNode *res = mRootNode.get();
   for ( const QString &part : parts )
   {
+    if ( part.isEmpty() )
+      continue;
+
     res = res->child( group, part );
     if ( !res )
       break;

--- a/src/core/qgsruntimeprofiler.cpp
+++ b/src/core/qgsruntimeprofiler.cpp
@@ -197,7 +197,8 @@ QStringList QgsRuntimeProfiler::childGroups( const QString &parent, const QStrin
   for ( int i = 0; i < parentNode->childCount(); ++i )
   {
     QgsRuntimeProfilerNode *child = parentNode->childAt( i );
-    res << child->data( QgsRuntimeProfilerNode::Name ).toString();
+    if ( child->data( QgsRuntimeProfilerNode::Group ).toString() == group )
+      res << child->data( QgsRuntimeProfilerNode::Name ).toString();
   }
   return res;
 }

--- a/src/core/qgsruntimeprofiler.cpp
+++ b/src/core/qgsruntimeprofiler.cpp
@@ -33,6 +33,8 @@ QgsRuntimeProfilerNode::QgsRuntimeProfilerNode( const QString &group, const QStr
 
 }
 
+QgsRuntimeProfilerNode::~QgsRuntimeProfilerNode() = default;
+
 QStringList QgsRuntimeProfilerNode::fullParentPath() const
 {
   QStringList res;
@@ -45,8 +47,6 @@ QStringList QgsRuntimeProfilerNode::fullParentPath() const
   }
   return res;
 }
-
-QgsRuntimeProfilerNode::~QgsRuntimeProfilerNode() = default;
 
 QVariant QgsRuntimeProfilerNode::data( int role ) const
 {
@@ -159,6 +159,8 @@ QgsRuntimeProfiler::QgsRuntimeProfiler()
 {
 
 }
+
+QgsRuntimeProfiler::~QgsRuntimeProfiler() = default;
 
 QgsRuntimeProfiler *QgsRuntimeProfiler::threadLocalInstance()
 {

--- a/src/core/qgsruntimeprofiler.cpp
+++ b/src/core/qgsruntimeprofiler.cpp
@@ -167,7 +167,7 @@ QgsRuntimeProfiler *QgsRuntimeProfiler::threadLocalInstance()
   static QThreadStorage<QgsRuntimeProfiler> sInstances;
   QgsRuntimeProfiler *profiler = &sInstances.localData();
 
-  if ( profiler->thread() == qApp->thread() )
+  if ( !qApp || profiler->thread() == qApp->thread() )
     sMainProfiler = profiler;
 
   if ( !profiler->mInitialized )

--- a/src/core/qgsruntimeprofiler.cpp
+++ b/src/core/qgsruntimeprofiler.cpp
@@ -288,6 +288,11 @@ double QgsRuntimeProfiler::totalTime( const QString &group )
   return 0;
 }
 
+bool QgsRuntimeProfiler::groupIsActive( const QString &group ) const
+{
+  return !mCurrentStack.value( group ).empty();
+}
+
 QString QgsRuntimeProfiler::translateGroupName( const QString &group )
 {
   if ( group == QLatin1String( "startup" ) )

--- a/src/core/qgsruntimeprofiler.cpp
+++ b/src/core/qgsruntimeprofiler.cpp
@@ -570,11 +570,18 @@ QgsRuntimeProfilerNode *QgsRuntimeProfiler::index2node( const QModelIndex &index
 //
 
 QgsScopedRuntimeProfile::QgsScopedRuntimeProfile( const QString &name, const QString &group )
+  : mGroup( group )
 {
-  QgsApplication::profiler()->start( name, group );
+  QgsApplication::profiler()->start( name, mGroup );
 }
 
 QgsScopedRuntimeProfile::~QgsScopedRuntimeProfile()
 {
-  QgsApplication::profiler()->end();
+  QgsApplication::profiler()->end( mGroup );
+}
+
+void QgsScopedRuntimeProfile::switchTask( const QString &name )
+{
+  QgsApplication::profiler()->end( mGroup );
+  QgsApplication::profiler()->start( name, mGroup );
 }

--- a/src/core/qgsruntimeprofiler.cpp
+++ b/src/core/qgsruntimeprofiler.cpp
@@ -17,6 +17,156 @@
 #include "qgis.h"
 #include "qgsapplication.h"
 #include <QSet>
+#include <QThreadStorage>
+
+QgsRuntimeProfiler *QgsRuntimeProfiler::sMainProfiler = nullptr;
+
+
+//
+// QgsRuntimeProfilerNode
+//
+
+QgsRuntimeProfilerNode::QgsRuntimeProfilerNode( const QString &group, const QString &name )
+  : mName( name )
+  , mGroup( group )
+{
+
+}
+
+QStringList QgsRuntimeProfilerNode::fullParentPath() const
+{
+  QStringList res;
+  if ( mParent )
+  {
+    res = mParent->fullParentPath();
+    const QString parentName = mParent->data( Name ).toString();
+    if ( !parentName.isEmpty() )
+      res << parentName;
+  }
+  return res;
+}
+
+QgsRuntimeProfilerNode::~QgsRuntimeProfilerNode() = default;
+
+QVariant QgsRuntimeProfilerNode::data( int role ) const
+{
+  switch ( role )
+  {
+    case Qt::DisplayRole:
+    case Qt::ToolTipRole:
+    case Name:
+      return mName;
+
+    case Group:
+      return mGroup;
+
+    case Elapsed:
+      return mElapsed;
+
+    case ParentElapsed:
+      return mParent ? ( mParent->elapsed() > 0 ? mParent->elapsed() : mParent->totalElapsedTimeForChildren( mGroup ) ) : 0;
+  }
+  return QVariant();
+}
+
+void QgsRuntimeProfilerNode::addChild( std::unique_ptr<QgsRuntimeProfilerNode> child )
+{
+  if ( !child )
+    return;
+
+  Q_ASSERT( !child->mParent );
+  child->mParent = this;
+
+  mChildren.emplace_back( std::move( child ) );
+}
+
+int QgsRuntimeProfilerNode::indexOf( QgsRuntimeProfilerNode *child ) const
+{
+  Q_ASSERT( child->mParent == this );
+  auto it = std::find_if( mChildren.begin(), mChildren.end(), [&]( const std::unique_ptr<QgsRuntimeProfilerNode> &p )
+  {
+    return p.get() == child;
+  } );
+  if ( it != mChildren.end() )
+    return std::distance( mChildren.begin(), it );
+  return -1;
+}
+
+QgsRuntimeProfilerNode *QgsRuntimeProfilerNode::child( const QString &group, const QString &path )
+{
+  for ( auto &it : mChildren )
+  {
+    if ( it->data( Group ).toString() == group &&  it->data( Name ).toString() == path )
+      return it.get();
+  }
+  return nullptr;
+}
+
+QgsRuntimeProfilerNode *QgsRuntimeProfilerNode::childAt( int index )
+{
+  Q_ASSERT( static_cast< std::size_t >( index ) < mChildren.size() );
+  return mChildren[ index ].get();
+}
+
+void QgsRuntimeProfilerNode::clear()
+{
+  mChildren.clear();
+}
+
+void QgsRuntimeProfilerNode::start()
+{
+  mProfileTime.restart();
+}
+
+void QgsRuntimeProfilerNode::stop()
+{
+  mElapsed = mProfileTime.elapsed() / 1000.0;
+}
+
+void QgsRuntimeProfilerNode::setElapsed( double time )
+{
+  mElapsed = time;
+}
+
+double QgsRuntimeProfilerNode::elapsed() const
+{
+  return mElapsed;
+}
+
+double QgsRuntimeProfilerNode::totalElapsedTimeForChildren( const QString &group ) const
+{
+  double total = 0;
+  for ( auto &it : mChildren )
+  {
+    if ( it->data( Group ).toString() == group )
+      total += it->elapsed();
+  }
+  return total;
+}
+
+//
+// QgsRuntimeProfiler
+//
+
+QgsRuntimeProfiler::QgsRuntimeProfiler()
+  : mRootNode( qgis::make_unique< QgsRuntimeProfilerNode >( QString(), QString() ) )
+{
+
+}
+
+QgsRuntimeProfiler *QgsRuntimeProfiler::threadLocalInstance()
+{
+  static QThreadStorage<QgsRuntimeProfiler> sInstances;
+  QgsRuntimeProfiler *profiler = &sInstances.localData();
+
+  if ( profiler->thread() == qApp->thread() )
+    sMainProfiler = profiler;
+
+  if ( !profiler->mInitialized )
+    profiler->setupConnections();
+
+  return profiler;
+}
 
 void QgsRuntimeProfiler::beginGroup( const QString &name )
 {
@@ -28,95 +178,383 @@ void QgsRuntimeProfiler::endGroup()
   end();
 }
 
-QStringList QgsRuntimeProfiler::childGroups( const QString &parent ) const
+QStringList QgsRuntimeProfiler::childGroups( const QString &parent, const QString &group ) const
 {
+  QgsRuntimeProfilerNode *parentNode = pathToNode( group, parent );
+  if ( !parentNode )
+    return QStringList();
+
   QStringList res;
-  const int parentDepth = parent.split( '/' ).length();
-  for ( auto it = mProfileTimes.constBegin(); it != mProfileTimes.constEnd(); ++it )
+  res.reserve( parentNode->childCount() );
+  for ( int i = 0; i < parentNode->childCount(); ++i )
   {
-    if ( !parent.isEmpty() && !it->first.startsWith( parent + '/' ) )
-      continue;
-
-    if ( it->first.isEmpty() )
-      continue;
-
-    const QStringList groups = it->first.split( '/' );
-    if ( parent.isEmpty() )
-    {
-      if ( !res.contains( groups.at( 0 ) ) )
-        res << groups.at( 0 );
-    }
-    else
-    {
-      if ( !res.contains( groups.at( parentDepth ) ) )
-        res << groups.at( parentDepth );
-    }
+    QgsRuntimeProfilerNode *child = parentNode->childAt( i );
+    res << child->data( QgsRuntimeProfilerNode::Name ).toString();
   }
   return res;
 }
 
-void QgsRuntimeProfiler::start( const QString &name )
+void QgsRuntimeProfiler::start( const QString &name, const QString &group )
 {
-  mProfileTime.push( QElapsedTimer() );
-  mProfileTime.top().restart();
-  QString cleanedName = name;
-  cleanedName.replace( '/', '_' );
-  mCurrentName.push( cleanedName );
-}
+  std::unique_ptr< QgsRuntimeProfilerNode > node = qgis::make_unique< QgsRuntimeProfilerNode >( group, name );
+  node->start();
 
-void QgsRuntimeProfiler::end()
-{
-  QString name;
-  for ( const QString &group : qgis::as_const( mCurrentName ) )
+  QgsRuntimeProfilerNode *child = node.get();
+  if ( !mCurrentStack[ group ].empty() )
   {
-    name += name.isEmpty() || name.right( 1 ) == '/' ? group : '/' + group;
-  }
-  mCurrentName.pop();
+    QgsRuntimeProfilerNode *parent = mCurrentStack[group ].top();
 
-  double timing = mProfileTime.top().elapsed() / 1000.0;
-  mProfileTime.pop();
-
-  mProfileTimes << qMakePair( name, timing );
-  QgsDebugMsgLevel( QStringLiteral( "PROFILE: %1 - %2" ).arg( name ).arg( timing ), 2 );
-}
-
-double QgsRuntimeProfiler::profileTime( const QString &name ) const
-{
-  if ( !name.isEmpty() )
-  {
-    for ( auto it = mProfileTimes.constBegin(); it != mProfileTimes.constEnd(); ++it )
-    {
-      if ( it->first == name )
-        return it->second;
-    }
-    return -1;
+    const QModelIndex parentIndex = node2index( parent );
+    beginInsertRows( parentIndex, parent->childCount(), parent->childCount() );
+    parent->addChild( std::move( node ) );
+    endInsertRows();
   }
   else
   {
-    // collect total time for top level items
-    double totalTime = 0;
-    for ( auto it = mProfileTimes.constBegin(); it != mProfileTimes.constEnd(); ++it )
-    {
-      if ( it->first.count( '/' ) == 0 )
-        totalTime += it->second;
-    }
-    return totalTime;
+    beginInsertRows( QModelIndex(), mRootNode->childCount(), mRootNode->childCount() );
+    mRootNode->addChild( std::move( node ) );
+    endInsertRows();
   }
-}
 
-void QgsRuntimeProfiler::clear()
-{
-  mProfileTimes.clear();
-}
+  mCurrentStack[group].push( child );
+  emit started( group, child->fullParentPath(), name );
 
-double QgsRuntimeProfiler::totalTime()
-{
-  double total = 0;
-  for ( auto it = mProfileTimes.constBegin(); it != mProfileTimes.constEnd(); ++it )
+  if ( !mGroups.contains( group ) )
   {
-    total += it->second;
+    mGroups.insert( group );
+    emit groupAdded( group );
   }
-  return total;
+}
+
+void QgsRuntimeProfiler::end( const QString &group )
+{
+  if ( mCurrentStack[group].empty() )
+    return;
+
+  QgsRuntimeProfilerNode *node = mCurrentStack[group].top();
+  mCurrentStack[group].pop();
+  node->stop();
+
+  const QModelIndex nodeIndex = node2index( node );
+  const QModelIndex col2Index = index( nodeIndex.row(), 1, nodeIndex.parent() );
+  emit dataChanged( nodeIndex, nodeIndex );
+  emit dataChanged( col2Index, col2Index );
+  // parent item has data changed too, cos the overall time elapsed will have changed!
+  QModelIndex parentIndex = nodeIndex.parent();
+  while ( parentIndex.isValid() )
+  {
+    const QModelIndex parentCol2Index = index( parentIndex.row(), 1, parentIndex.parent() );
+    emit dataChanged( parentIndex, parentIndex );
+    emit dataChanged( parentCol2Index, parentCol2Index );
+    parentIndex = parentIndex.parent();
+  }
+
+  emit ended( group, node->fullParentPath(), node->data( QgsRuntimeProfilerNode::Name ).toString(), node->data( QgsRuntimeProfilerNode::Elapsed ).toDouble() );
+}
+
+double QgsRuntimeProfiler::profileTime( const QString &name, const QString &group ) const
+{
+  QgsRuntimeProfilerNode *node = pathToNode( group, name );
+  if ( !node )
+    return 0;
+
+  return node->data( QgsRuntimeProfilerNode::Elapsed ).toDouble();
+}
+
+void QgsRuntimeProfiler::clear( const QString &group )
+{
+  if ( QgsRuntimeProfilerNode *node = pathToNode( group, QString() ) )
+  {
+    // FIX!!!
+    const QModelIndex index = node2index( node );
+    beginRemoveRows( index, 0, node->childCount() - 1 );
+    node->clear();
+    endRemoveRows();
+  }
+}
+
+double QgsRuntimeProfiler::totalTime( const QString &group )
+{
+  if ( QgsRuntimeProfilerNode *node = pathToNode( group, QString() ) )
+    return node->elapsed();
+
+  return 0;
+}
+
+QString QgsRuntimeProfiler::translateGroupName( const QString &group )
+{
+  if ( group == QLatin1String( "startup" ) )
+    return tr( "Startup" );
+  else if ( group == QLatin1String( "projectload" ) )
+    return tr( "Project Load" );
+  else if ( group == QLatin1String( "render" ) )
+    return tr( "Map Render" );
+  return QString();
+}
+
+int QgsRuntimeProfiler::rowCount( const QModelIndex &parent ) const
+{
+  QgsRuntimeProfilerNode *n = index2node( parent );
+  if ( !n )
+    return 0;
+
+  return n->childCount();
+}
+
+int QgsRuntimeProfiler::columnCount( const QModelIndex &parent ) const
+{
+  Q_UNUSED( parent )
+  return 2;
+}
+
+QModelIndex QgsRuntimeProfiler::index( int row, int column, const QModelIndex &parent ) const
+{
+  if ( column < 0 || column >= columnCount( parent ) ||
+       row < 0 || row >= rowCount( parent ) )
+    return QModelIndex();
+
+  QgsRuntimeProfilerNode *n = index2node( parent );
+  if ( !n )
+    return QModelIndex(); // have no children
+
+  return createIndex( row, column, n->childAt( row ) );
+}
+
+QModelIndex QgsRuntimeProfiler::parent( const QModelIndex &child ) const
+{
+  if ( !child.isValid() )
+    return QModelIndex();
+
+  if ( QgsRuntimeProfilerNode *n = index2node( child ) )
+  {
+    return indexOfParentNode( n->parent() ); // must not be null
+  }
+  else
+  {
+    Q_ASSERT( false );
+    return QModelIndex();
+  }
+}
+
+QVariant QgsRuntimeProfiler::data( const QModelIndex &index, int role ) const
+{
+  if ( !index.isValid() || index.column() > 2 )
+    return QVariant();
+
+  QgsRuntimeProfilerNode *node = index2node( index );
+  if ( !node )
+    return QVariant();
+
+  switch ( index.column() )
+  {
+    case 0:
+      return node->data( role );
+
+    case 1:
+    {
+      switch ( role )
+      {
+        case Qt::DisplayRole:
+        case Qt::InitialSortOrderRole:
+          return node->data( QgsRuntimeProfilerNode::Elapsed );
+
+        default:
+          break;
+      }
+      return node->data( role );
+    }
+  }
+  return QVariant();
+}
+
+QVariant QgsRuntimeProfiler::headerData( int section, Qt::Orientation orientation, int role ) const
+{
+  switch ( role )
+  {
+    case Qt::DisplayRole:
+    {
+      if ( orientation == Qt::Horizontal )
+      {
+        switch ( section )
+        {
+          case 0:
+            return tr( "Task" );
+          case 1:
+            return tr( "Time (seconds)" );
+          default:
+            return QVariant();
+        }
+      }
+      else
+      {
+        return QVariant();
+      }
+    }
+
+    default:
+      return QAbstractItemModel::headerData( section, orientation, role );
+  }
+}
+
+void QgsRuntimeProfiler::otherProfilerStarted( const QString &group, const QStringList &path, const QString &name )
+{
+  QgsRuntimeProfilerNode *parentNode = mRootNode.get();
+  for ( const QString &part : path )
+  {
+    QgsRuntimeProfilerNode *child = parentNode->child( group, part );
+    if ( !child )
+    {
+      std::unique_ptr< QgsRuntimeProfilerNode > newChild = qgis::make_unique< QgsRuntimeProfilerNode >( group, part );
+
+      const QModelIndex parentIndex = node2index( parentNode );
+      beginInsertRows( parentIndex, parentNode->childCount(), parentNode->childCount() );
+      QgsRuntimeProfilerNode *next = newChild.get();
+      parentNode->addChild( std::move( newChild ) );
+      endInsertRows();
+      parentNode = next;
+    }
+    else
+    {
+      parentNode = child;
+    }
+  }
+
+  if ( parentNode->child( group, name ) )
+    return;
+
+  const QModelIndex parentIndex = node2index( parentNode );
+  beginInsertRows( parentIndex, parentNode->childCount(), parentNode->childCount() );
+  parentNode->addChild( qgis::make_unique< QgsRuntimeProfilerNode >( group, name ) );
+  endInsertRows();
+
+  if ( !mGroups.contains( group ) )
+  {
+    mGroups.insert( group );
+    emit groupAdded( group );
+  }
+}
+
+void QgsRuntimeProfiler::otherProfilerEnded( const QString &group, const QStringList &path, const QString &name, double elapsed )
+{
+  QgsRuntimeProfilerNode *parentNode = mRootNode.get();
+  for ( const QString &part : path )
+  {
+    QgsRuntimeProfilerNode *child = parentNode->child( group, part );
+    if ( !child )
+    {
+      std::unique_ptr< QgsRuntimeProfilerNode > newChild = qgis::make_unique< QgsRuntimeProfilerNode >( group, part );
+
+      const QModelIndex parentIndex = node2index( parentNode );
+      beginInsertRows( parentIndex, parentNode->childCount(), parentNode->childCount() );
+      QgsRuntimeProfilerNode *next = newChild.get();
+      parentNode->addChild( std::move( newChild ) );
+      endInsertRows();
+      parentNode = next;
+    }
+    else
+    {
+      parentNode = child;
+    }
+  }
+
+  QgsRuntimeProfilerNode *destNode = parentNode->child( group, name );
+  if ( !destNode )
+  {
+    std::unique_ptr< QgsRuntimeProfilerNode > node = qgis::make_unique< QgsRuntimeProfilerNode >( group, name );
+    destNode = node.get();
+    const QModelIndex parentIndex = node2index( parentNode );
+    beginInsertRows( parentIndex, parentNode->childCount(), parentNode->childCount() );
+    parentNode->addChild( std::move( node ) );
+    endInsertRows();
+  }
+
+  destNode->setElapsed( elapsed );
+
+  const QModelIndex nodeIndex = node2index( destNode );
+  const QModelIndex col2Index = index( nodeIndex.row(), 1, nodeIndex.parent() );
+  emit dataChanged( nodeIndex, nodeIndex );
+  emit dataChanged( col2Index, col2Index );
+  // parent item has data changed too, cos the overall time elapsed will have changed!
+  QModelIndex parentIndex = nodeIndex.parent();
+  while ( parentIndex.isValid() )
+  {
+    const QModelIndex parentCol2Index = index( parentIndex.row(), 1, parentIndex.parent() );
+    emit dataChanged( parentIndex, parentIndex );
+    emit dataChanged( parentCol2Index, parentCol2Index );
+    parentIndex = parentIndex.parent();
+  }
+}
+
+void QgsRuntimeProfiler::setupConnections()
+{
+  mInitialized = true;
+
+  Q_ASSERT( sMainProfiler );
+
+  if ( sMainProfiler != this )
+  {
+    connect( this, &QgsRuntimeProfiler::started, sMainProfiler, &QgsRuntimeProfiler::otherProfilerStarted );
+    connect( this, &QgsRuntimeProfiler::ended, sMainProfiler, &QgsRuntimeProfiler::otherProfilerEnded );
+  }
+}
+
+QgsRuntimeProfilerNode *QgsRuntimeProfiler::pathToNode( const QString &group, const QString &path ) const
+{
+  QStringList parts = path.split( '/', Qt::SkipEmptyParts );
+  QgsRuntimeProfilerNode *res = mRootNode.get();
+  for ( const QString &part : parts )
+  {
+    res = res->child( group, part );
+    if ( !res )
+      break;
+  }
+  return res;
+}
+
+QgsRuntimeProfilerNode *QgsRuntimeProfiler::pathToNode( const QString &group, const QStringList &path ) const
+{
+  QgsRuntimeProfilerNode *res = mRootNode.get();
+  for ( const QString &part : path )
+  {
+    res = res->child( group, part );
+    if ( !res )
+      break;
+  }
+  return res;
+}
+
+QModelIndex QgsRuntimeProfiler::node2index( QgsRuntimeProfilerNode *node ) const
+{
+  if ( !node || !node->parent() )
+    return QModelIndex(); // this is the only root item -> invalid index
+
+  QModelIndex parentIndex = node2index( node->parent() );
+
+  int row = node->parent()->indexOf( node );
+  Q_ASSERT( row >= 0 );
+  return index( row, 0, parentIndex );
+}
+
+QModelIndex QgsRuntimeProfiler::indexOfParentNode( QgsRuntimeProfilerNode *parentNode ) const
+{
+  Q_ASSERT( parentNode );
+
+  QgsRuntimeProfilerNode *grandParentNode = parentNode->parent();
+  if ( !grandParentNode )
+    return QModelIndex();  // root node -> invalid index
+
+  int row = grandParentNode->indexOf( parentNode );
+  Q_ASSERT( row >= 0 );
+
+  return createIndex( row, 0, parentNode );
+}
+
+QgsRuntimeProfilerNode *QgsRuntimeProfiler::index2node( const QModelIndex &index ) const
+{
+  if ( !index.isValid() )
+    return mRootNode.get();
+
+  return reinterpret_cast<QgsRuntimeProfilerNode *>( index.internalPointer() );
 }
 
 

--- a/src/core/qgsruntimeprofiler.h
+++ b/src/core/qgsruntimeprofiler.h
@@ -90,7 +90,11 @@ class CORE_EXPORT QgsRuntimeProfilerNode
      */
     int indexOf( QgsRuntimeProfilerNode *child ) const;
 
-    QgsRuntimeProfilerNode *child( const QString &group, const QString &path );
+    /**
+     * Finds the child with matching \a group and \a name. Returns NULLPTR if
+     * a matching child was not found.
+     */
+    QgsRuntimeProfilerNode *child( const QString &group, const QString &name );
 
     /**
      * Returns the child at the specified \a index.

--- a/src/core/qgsruntimeprofiler.h
+++ b/src/core/qgsruntimeprofiler.h
@@ -178,6 +178,7 @@ class CORE_EXPORT QgsRuntimeProfiler : public QAbstractItemModel
      * through QgsApplication::profiler().
      */
     QgsRuntimeProfiler();
+    ~QgsRuntimeProfiler() override;
 
     /**
      * \brief Begin the group for the profiler. Groups will append {GroupName}/ to the

--- a/src/core/qgsruntimeprofiler.h
+++ b/src/core/qgsruntimeprofiler.h
@@ -103,6 +103,11 @@ class CORE_EXPORT QgsRuntimeProfilerNode
     void clear();
 
     /**
+     * Removes and deletes the child at the specified \a index.
+     */
+    void removeChildAt( int index );
+
+    /**
      * Starts the node timer.
      * \see stop()
      */
@@ -311,7 +316,7 @@ class CORE_EXPORT QgsScopedRuntimeProfile
      * Automatically registers the operation in the QgsApplication::profiler() instance
      * and starts recording the run time of the operation.
      */
-    QgsScopedRuntimeProfile( const QString &name );
+    QgsScopedRuntimeProfile( const QString &name, const QString &group = "startup" );
 
     /**
      * Records the final runtime of the operation in the profiler instance.

--- a/src/core/qgsruntimeprofiler.h
+++ b/src/core/qgsruntimeprofiler.h
@@ -21,21 +21,154 @@
 #include <QPair>
 #include <QStack>
 #include <QList>
-
+#include <QAbstractItemModel>
+#include <memory>
+#include <deque>
+#include <QSet>
 #include "qgis_core.h"
+
+#ifndef SIP_RUN
+
+/**
+ * \ingroup core
+ * \class QgsRuntimeProfilerNode
+ * A node representing an entry in a QgsRuntimeProfiler.
+ *
+ * \since QGIS 3.16
+ */
+class CORE_EXPORT QgsRuntimeProfilerNode
+{
+  public:
+
+    //! Custom node data roles
+    enum Roles
+    {
+      Name = Qt::UserRole + 1, //!< Profile item name
+      Group, //!< Node group
+      Elapsed, //!< Node elapsed time
+      ParentElapsed, //!< Total elapsed time for node's parent
+    };
+
+    /**
+     * Constructor for QgsRuntimeProfilerNode, with the specified \a group and \a name.
+     */
+    QgsRuntimeProfilerNode( const QString &group, const QString &name );
+
+    ~QgsRuntimeProfilerNode();
+
+    /**
+     * Returns the node's parent node.
+     *
+     * If parent is NULLPTR, the node is a root node
+     */
+    QgsRuntimeProfilerNode *parent() { return mParent; }
+
+    /**
+     * Returns the full path to the node's parent.
+     */
+    QStringList fullParentPath() const;
+
+    /**
+     * Returns the node's data for the specified model \a role.
+     */
+    QVariant data( int role = Qt::DisplayRole ) const;
+
+    /**
+     * Returns the number of child nodes owned by this node.
+     */
+    int childCount() const { return mChildren.size(); }
+
+    /**
+     * Adds a \a child node to this node.
+     */
+    void addChild( std::unique_ptr< QgsRuntimeProfilerNode > child );
+
+    /**
+     * Returns the index of the specified \a child node.
+     *
+     * \warning \a child must be a valid child of this node.
+     */
+    int indexOf( QgsRuntimeProfilerNode *child ) const;
+
+    QgsRuntimeProfilerNode *child( const QString &group, const QString &path );
+
+    /**
+     * Returns the child at the specified \a index.
+     */
+    QgsRuntimeProfilerNode *childAt( int index );
+
+    /**
+     * Clears the node, removing all its children.
+     */
+    void clear();
+
+    /**
+     * Starts the node timer.
+     * \see stop()
+     */
+    void start();
+
+    /**
+     * Stops the node's timer, recording the elapsed time automatically.
+     */
+    void stop();
+
+    /**
+     * Manually sets the node's elapsed \a time, in seconds.
+     */
+    void setElapsed( double time );
+
+    /**
+     * Returns the node's elapsed time, in seconds.
+     *
+     * If the node is still running then 0 will be returned.
+     */
+    double elapsed() const;
+
+    /**
+     * Returns the total elapsed time in seconds for all children
+     * of this node with matching \a group.
+     */
+    double totalElapsedTimeForChildren( const QString &group ) const;
+
+  private:
+    std::deque< std::unique_ptr< QgsRuntimeProfilerNode > > mChildren;
+    QgsRuntimeProfilerNode *mParent = nullptr;
+    QElapsedTimer mProfileTime;
+    double mElapsed = 0;
+
+    QString mName;
+    QString mGroup;
+
+};
+#endif
 
 /**
  * \ingroup core
  * \class QgsRuntimeProfiler
+ *
+ * Provides a method of recording run time profiles of operations, allowing
+ * easy recording of their overall run time.
+ *
+ * QgsRuntimeProfiler is not usually instantied manually, but rather accessed
+ * through QgsApplication::profiler().
+ *
+ * This class is thread-safe only if accessed through QgsApplication::profiler().
+ * If accessed in this way, operations can be profiled from non-main threads.
  */
-class CORE_EXPORT QgsRuntimeProfiler
+class CORE_EXPORT QgsRuntimeProfiler : public QAbstractItemModel
 {
+    Q_OBJECT
+
   public:
 
     /**
      * Constructor to create a new runtime profiler.
+     *
+     * \warning QgsRuntimeProfiler is not usually instantied manually, but rather accessed
+     * through QgsApplication::profiler().
      */
-    QgsRuntimeProfiler() = default;
+    QgsRuntimeProfiler();
 
     /**
      * \brief Begin the group for the profiler. Groups will append {GroupName}/ to the
@@ -57,42 +190,98 @@ class CORE_EXPORT QgsRuntimeProfiler
      * Returns a list of all child groups with the specified \a parent.
      * \since QGIS 3.14
      */
-    QStringList childGroups( const QString &parent = QString() ) const;
+    QStringList childGroups( const QString &parent = QString(), const QString &group = "startup" ) const;
 
     /**
      * \brief Start a profile event with the given name.
      * \param name The name of the profile event. Will have the name of
      * the active group appended after ending.
      */
-    void start( const QString &name );
+    void start( const QString &name, const QString &group = "startup" );
 
     /**
      * \brief End the current profile event.
      */
-    void end();
+    void end( const QString &group = "startup" );
 
     /**
      * Returns the profile time for the specified \a name.
      * \since QGIS 3.14
      */
-    double profileTime( const QString &name ) const;
+    double profileTime( const QString &name, const QString &group = "startup" ) const;
 
     /**
      * \brief clear Clear all profile data.
      */
-    void clear();
+    void clear( const QString &group = "startup" );
 
     /**
      * \brief The current total time collected in the profiler.
      * \returns The current total time collected in the profiler.
      */
-    double totalTime();
+    double totalTime( const QString &group = "startup" );
+
+    /**
+     * Returns the set of known groups.
+     */
+    QSet< QString > groups() const { return mGroups; }
+
+    /**
+     * Returns the translated name of a standard profile \a group.
+     */
+    static QString translateGroupName( const QString &group );
+
+    // Implementation of virtual functions from QAbstractItemModel
+
+    int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
+    int columnCount( const QModelIndex &parent = QModelIndex() ) const override;
+    QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const override;
+    QModelIndex parent( const QModelIndex &child ) const override;
+    QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
+    QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const override;
+
+#ifndef SIP_RUN
+    ///@cond PRIVATE
+  signals:
+
+    void started( const QString &group, const QStringList &path, const QString &name );
+    void ended( const QString &group, const QStringList &path, const QString &name, double elapsed );
+///@endcond
+#endif
+
+    /**
+     * Emitted when a new group has started being profiled.
+     */
+    void groupAdded( const QString &group );
+
+  private slots:
+
+    void otherProfilerStarted( const QString &group, const QStringList &path, const QString &name );
+    void otherProfilerEnded( const QString &group, const QStringList &path, const QString &name, double elapsed );
 
   private:
 
-    QStack< QElapsedTimer > mProfileTime;
-    QStack< QString > mCurrentName;
-    QList< QPair< QString, double > > mProfileTimes;
+    static QgsRuntimeProfiler *threadLocalInstance();
+    static QgsRuntimeProfiler *sMainProfiler;
+    bool mInitialized = false;
+    void setupConnections();
+
+    QgsRuntimeProfilerNode *pathToNode( const QString &group, const QString &path ) const;
+    QgsRuntimeProfilerNode *pathToNode( const QString &group, const QStringList &path ) const;
+    QModelIndex node2index( QgsRuntimeProfilerNode *node ) const;
+    QModelIndex indexOfParentNode( QgsRuntimeProfilerNode *parentNode ) const;
+
+    /**
+     * Returns node for given index. Returns root node for invalid index.
+     */
+    QgsRuntimeProfilerNode *index2node( const QModelIndex &index ) const;
+
+    QMap< QString, QStack< QgsRuntimeProfilerNode * > > mCurrentStack;
+    std::unique_ptr< QgsRuntimeProfilerNode > mRootNode;
+
+    QSet< QString > mGroups;
+
+    friend class QgsApplication;
 };
 
 

--- a/src/core/qgsruntimeprofiler.h
+++ b/src/core/qgsruntimeprofiler.h
@@ -236,6 +236,14 @@ class CORE_EXPORT QgsRuntimeProfiler : public QAbstractItemModel
     QSet< QString > groups() const { return mGroups; }
 
     /**
+     * Returns TRUE if the specified \a group is currently being logged,
+     * i.e. it has a entry which has started and not yet stopped.
+     *
+     * \since QGIS 3.14
+     */
+    bool groupIsActive( const QString &group ) const;
+
+    /**
      * Returns the translated name of a standard profile \a group.
      */
     static QString translateGroupName( const QString &group );

--- a/src/core/qgsruntimeprofiler.h
+++ b/src/core/qgsruntimeprofiler.h
@@ -54,7 +54,9 @@ class CORE_EXPORT QgsRuntimeProfilerNode
      */
     QgsRuntimeProfilerNode( const QString &group, const QString &name );
 
+    //! QgsRuntimeProfilerNode cannot be copied
     QgsRuntimeProfilerNode( const QgsRuntimeProfilerNode &other ) = delete;
+    //! QgsRuntimeProfilerNode cannot be copied
     QgsRuntimeProfilerNode &operator=( const QgsRuntimeProfilerNode &other ) = delete;
 
     ~QgsRuntimeProfilerNode();

--- a/src/core/qgsruntimeprofiler.h
+++ b/src/core/qgsruntimeprofiler.h
@@ -323,6 +323,20 @@ class CORE_EXPORT QgsScopedRuntimeProfile
      */
     ~QgsScopedRuntimeProfile();
 
+    /**
+     * Switches the current task managed by the scoped profile to a new task with the given \a name.
+     * The current task will be finalised before switching.
+     *
+     * This is useful for reusing an existing scoped runtime profiler with multi-step processes.
+     *
+     * \since QGIS 3.14
+     */
+    void switchTask( const QString &name );
+
+  private:
+
+    QString mGroup;
+
 };
 
 

--- a/src/core/qgsruntimeprofiler.h
+++ b/src/core/qgsruntimeprofiler.h
@@ -54,6 +54,9 @@ class CORE_EXPORT QgsRuntimeProfilerNode
      */
     QgsRuntimeProfilerNode( const QString &group, const QString &name );
 
+    QgsRuntimeProfilerNode( const QgsRuntimeProfilerNode &other ) = delete;
+    QgsRuntimeProfilerNode &operator=( const QgsRuntimeProfilerNode &other ) = delete;
+
     ~QgsRuntimeProfilerNode();
 
     /**

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -99,6 +99,7 @@
 #include "qgsauxiliarystorage.h"
 #include "qgsgeometryoptions.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsruntimeprofiler.h"
 
 #include "diagram/qgsdiagram.h"
 
@@ -1631,6 +1632,10 @@ void QgsVectorLayer::setDataSource( const QString &dataSource, const QString &ba
   // reset style if loading default style, style is missing, or geometry type is has changed (and layer is valid)
   if ( !renderer() || !legend() || ( mValid && geomType != geometryType() ) || loadDefaultStyleFlag )
   {
+    std::unique_ptr< QgsScopedRuntimeProfile > profile;
+    if ( QgsApplication::profiler()->groupIsActive( QStringLiteral( "projectload" ) ) )
+      profile = qgis::make_unique< QgsScopedRuntimeProfile >( tr( "Load layer style" ), QStringLiteral( "projectload" ) );
+
     bool defaultLoadedFlag = false;
 
     if ( loadDefaultStyleFlag && isSpatial() && mDataProvider->capabilities() & QgsVectorDataProvider::CreateRenderer )
@@ -1714,6 +1719,10 @@ bool QgsVectorLayer::setDataProvider( QString const &provider, const QgsDataProv
     }
   }
 
+  std::unique_ptr< QgsScopedRuntimeProfile > profile;
+  if ( QgsApplication::profiler()->groupIsActive( QStringLiteral( "projectload" ) ) )
+    profile = qgis::make_unique< QgsScopedRuntimeProfile >( tr( "Create %1 provider" ).arg( provider ), QStringLiteral( "projectload" ) );
+
   mDataProvider = qobject_cast<QgsVectorDataProvider *>( QgsProviderRegistry::instance()->createProvider( provider, mDataSource, options ) );
   if ( !mDataProvider )
   {
@@ -1734,6 +1743,8 @@ bool QgsVectorLayer::setDataProvider( QString const &provider, const QgsDataProv
     return false;
   }
 
+  if ( profile )
+    profile->switchTask( tr( "Read layer metadata" ) );
   if ( mDataProvider->capabilities() & QgsVectorDataProvider::ReadLayerMetadata )
   {
     setMetadata( mDataProvider->layerMetadata() );
@@ -1746,6 +1757,8 @@ bool QgsVectorLayer::setDataProvider( QString const &provider, const QgsDataProv
   // get and store the feature type
   mWkbType = mDataProvider->wkbType();
 
+  if ( profile )
+    profile->switchTask( tr( "Read layer fields" ) );
   updateFields();
 
   if ( mProviderKey == QLatin1String( "postgres" ) )

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -54,6 +54,7 @@ email                : tim at linfiniti.com
 #include "qgsbilinearrasterresampler.h"
 #include "qgscubicrasterresampler.h"
 #include "qgsrasterlayertemporalproperties.h"
+#include "qgsruntimeprofiler.h"
 
 #include <cmath>
 #include <cstdio>
@@ -621,6 +622,10 @@ void QgsRasterLayer::setDataProvider( QString const &provider, const QgsDataProv
   }
 
   //mBandCount = 0;
+
+  std::unique_ptr< QgsScopedRuntimeProfile > profile;
+  if ( QgsApplication::profiler()->groupIsActive( QStringLiteral( "projectload" ) ) )
+    profile = qgis::make_unique< QgsScopedRuntimeProfile >( tr( "Create %1 provider" ).arg( provider ), QStringLiteral( "projectload" ) );
 
   mDataProvider = qobject_cast< QgsRasterDataProvider * >( QgsProviderRegistry::instance()->createProvider( mProviderKey, mDataSource, options ) );
   if ( !mDataProvider )

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -50,6 +50,7 @@
 #include "qgssettings.h"
 #include "qgsogrutils.h"
 #include "qgsproviderregistry.h"
+#include "qgsruntimeprofiler.h"
 
 #include <QNetworkRequest>
 #include <QNetworkReply>
@@ -122,8 +123,13 @@ QgsWmsProvider::QgsWmsProvider( QString const &uri, const ProviderOptions &optio
   if ( !addLayers() )
     return;
 
+  std::unique_ptr< QgsScopedRuntimeProfile > profile;
+
   if ( mSettings.mIsMBTiles )
   {
+    if ( QgsApplication::profiler()->groupIsActive( QStringLiteral( "projectload" ) ) )
+      profile = qgis::make_unique< QgsScopedRuntimeProfile >( tr( "Setup tile capabilities" ), QStringLiteral( "projectload" ) );
+
     // we are dealing with a local MBTiles file
     if ( !setupMBTilesCapabilities( uri ) )
     {
@@ -133,6 +139,9 @@ QgsWmsProvider::QgsWmsProvider( QString const &uri, const ProviderOptions &optio
   }
   else if ( mSettings.mXyz )
   {
+    if ( QgsApplication::profiler()->groupIsActive( QStringLiteral( "projectload" ) ) )
+      profile = qgis::make_unique< QgsScopedRuntimeProfile >( tr( "Setup tile capabilities" ), QStringLiteral( "projectload" ) );
+
     // we are working with XYZ tiles
     // no need to get capabilities, the whole definition is in URI
     // so we just generate a dummy WMTS definition
@@ -145,6 +154,9 @@ QgsWmsProvider::QgsWmsProvider( QString const &uri, const ProviderOptions &optio
     // if there are already parsed capabilities, use them!
     if ( capabilities )
       mCaps = *capabilities;
+
+    if ( QgsApplication::profiler()->groupIsActive( QStringLiteral( "projectload" ) ) )
+      profile = qgis::make_unique< QgsScopedRuntimeProfile >( tr( "Retrieve server capabilities" ), QStringLiteral( "projectload" ) );
 
     // Make sure we have capabilities - other functions here may need them
     if ( !retrieveServerCapabilities() )
@@ -175,6 +187,9 @@ QgsWmsProvider::QgsWmsProvider( QString const &uri, const ProviderOptions &optio
     return;
   }
   mCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( mSettings.mCrsId );
+
+  if ( profile )
+    profile->switchTask( tr( "Calculate extent" ) );
 
   if ( !calculateExtent() || mLayerExtent.isEmpty() )
   {

--- a/src/ui/qgsprofilerpanelbase.ui
+++ b/src/ui/qgsprofilerpanelbase.ui
@@ -27,13 +27,24 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QTreeWidget" name="mTreeWidget">
-     <column>
-      <property name="text">
-       <string notr="true">1</string>
-      </property>
-     </column>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Category</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="mCategoryComboBox"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTreeView" name="mTreeView"/>
    </item>
   </layout>
   <action name="mActionClear">

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -218,6 +218,7 @@ SET(TESTS
  testqgsrelationreferencefieldformatter.cpp
  testqgsrenderers.cpp
  testqgsrulebasedrenderer.cpp
+ testqgsruntimeprofiler.cpp
  testqgssettings.cpp
  testqgsshapeburst.cpp
  testqgssimplemarker.cpp

--- a/tests/src/core/testqgsruntimeprofiler.cpp
+++ b/tests/src/core/testqgsruntimeprofiler.cpp
@@ -1,0 +1,92 @@
+/***************************************************************************
+  testqgsruntimeprofiler.cpp
+  --------------------------------------
+Date                 : June 2020
+Copyright            : (C) 2020 by Nyall Dawson
+Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstest.h"
+
+#include "qgsapplication.h"
+#include "qgsruntimeprofiler.h"
+
+#include <QSignalSpy>
+
+class TestQgsRuntimeProfiler: public QObject
+{
+    Q_OBJECT
+  private slots:
+    void initTestCase();
+    void cleanupTestCase();
+    void testGroups();
+
+};
+
+
+void TestQgsRuntimeProfiler::initTestCase()
+{
+  //
+  // Runs once before any tests are run
+  //
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+}
+
+void TestQgsRuntimeProfiler::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsRuntimeProfiler::testGroups()
+{
+  QgsRuntimeProfiler profiler;
+
+  QVERIFY( profiler.groups().isEmpty() );
+  QVERIFY( !profiler.groupIsActive( QStringLiteral( "xxx" ) ) );
+
+  QSignalSpy spy( &profiler, &QgsRuntimeProfiler::groupAdded );
+  profiler.start( QStringLiteral( "task 1" ), QStringLiteral( "group 1" ) );
+
+  QCOMPARE( profiler.groups().count(), 1 );
+  QVERIFY( profiler.groups().contains( QStringLiteral( "group 1" ) ) );
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.at( 0 ).at( 0 ).toString(), QStringLiteral( "group 1" ) );
+  QVERIFY( profiler.groupIsActive( QStringLiteral( "group 1" ) ) );
+
+  profiler.start( QStringLiteral( "task 2" ), QStringLiteral( "group 2" ) );
+
+  QCOMPARE( profiler.groups().count(), 2 );
+  QVERIFY( profiler.groups().contains( QStringLiteral( "group 1" ) ) );
+  QVERIFY( profiler.groups().contains( QStringLiteral( "group 2" ) ) );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( spy.at( 1 ).at( 0 ).toString(), QStringLiteral( "group 2" ) );
+  QVERIFY( profiler.groupIsActive( QStringLiteral( "group 2" ) ) );
+  QVERIFY( profiler.groupIsActive( QStringLiteral( "group 1" ) ) );
+
+  // sub task
+  profiler.start( QStringLiteral( "task 1a" ), QStringLiteral( "group 1" ) );
+  QCOMPARE( profiler.groups().count(), 2 );
+  QCOMPARE( spy.count(), 2 );
+
+  profiler.end( QStringLiteral( "group 1" ) );
+  QVERIFY( profiler.groupIsActive( QStringLiteral( "group 1" ) ) );
+  profiler.end( QStringLiteral( "group 2" ) );
+  QVERIFY( !profiler.groupIsActive( QStringLiteral( "group 2" ) ) );
+  profiler.end( QStringLiteral( "group 1" ) );
+  QVERIFY( !profiler.groupIsActive( QStringLiteral( "group 1" ) ) );
+
+  QCOMPARE( profiler.childGroups( QString(), QStringLiteral( "group 1" ) ), QStringList() << QStringLiteral( "task 1" ) );
+  QCOMPARE( profiler.childGroups( QStringLiteral( "task 1" ), QStringLiteral( "group 1" ) ), QStringList() << QStringLiteral( "task 1a" ) );
+  QCOMPARE( profiler.childGroups( QString(), QStringLiteral( "group 2" ) ), QStringList() << QStringLiteral( "task 2" ) );
+}
+
+QGSTEST_MAIN( TestQgsRuntimeProfiler )
+#include "testqgsruntimeprofiler.moc"


### PR DESCRIPTION
This PR reworks the QgsRuntimeProfiler class, to:
1. make the profiling thread safe, so that it's possible to record times across multiple threads
2. allows different profiling "groups"

The new groups api is used here to expose a breakdown of project load times in the debugging dock, alongside the existing QGIS startup profiling. Now it's possible to get a breakdown of the various stages of project load, in order to identify the causes of slow project load times.

TODO: in 99% of cases this will be caused by one or more layers, so it would be nice to further break down the individual layer load times, e.g. so that for a WFS layer we see the time taken for the initial server capabilities queries, etc...
For now, you just get the overall load time of each individual layer.

![image](https://user-images.githubusercontent.com/1829991/85852152-6228d300-b7f3-11ea-96f3-b174fca02f05.png)

![image](https://user-images.githubusercontent.com/1829991/85852208-7bca1a80-b7f3-11ea-8882-b3253622b1b6.png)

ALSO TODO: Add a group with profile times for map rendering, so you can see exactly which layers in your project are causing slow map redraw times...
