### PR TITLE
Remove unecessary update in the qgsmasksourceselectionwidget constructor

### DIFF
--- a/src/gui/qgsmaskingwidget.cpp
+++ b/src/gui/qgsmaskingwidget.cpp
@@ -332,3 +332,8 @@ void QgsMaskingWidget::apply()
     layer->triggerRepaint();
   }
 }
+
+bool QgsMaskingWidget::hasBeenPopulated()
+{
+  return mMustPopulate == false;
+}

--- a/src/gui/qgsmaskingwidget.cpp
+++ b/src/gui/qgsmaskingwidget.cpp
@@ -335,5 +335,5 @@ void QgsMaskingWidget::apply()
 
 bool QgsMaskingWidget::hasBeenPopulated()
 {
-  return mMustPopulate == false;
+  return !mMustPopulate;
 }

--- a/src/gui/qgsmaskingwidget.h
+++ b/src/gui/qgsmaskingwidget.h
@@ -47,6 +47,7 @@ class GUI_EXPORT QgsMaskingWidget: public QgsPanelWidget, private Ui::QgsMasking
     //! Applies the changes
     void apply();
 
+    //! Widget has been populated or not
     bool hasBeenPopulated();
 
   signals:

--- a/src/gui/qgsmaskingwidget.h
+++ b/src/gui/qgsmaskingwidget.h
@@ -47,6 +47,8 @@ class GUI_EXPORT QgsMaskingWidget: public QgsPanelWidget, private Ui::QgsMasking
     //! Applies the changes
     void apply();
 
+    bool hasBeenPopulated();
+
   signals:
     //! Emitted when a change is performed
     void widgetChanged();

--- a/src/gui/qgsmasksourceselectionwidget.cpp
+++ b/src/gui/qgsmasksourceselectionwidget.cpp
@@ -67,8 +67,6 @@ QgsMaskSourceSelectionWidget::QgsMaskSourceSelectionWidget( QWidget *parent )
   vbox->addWidget( mTree );
 
   setLayout( vbox );
-
-  update();
 }
 
 void QgsMaskSourceSelectionWidget::update()

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -607,7 +607,7 @@ void QgsVectorLayerProperties::apply()
   mMetadataFilled = false;
 
   // save masking settings
-  if ( mMaskingWidget )
+  if ( mMaskingWidget && mMaskingWidget->hasBeenPopulated() )
     mMaskingWidget->apply();
 
   //


### PR DESCRIPTION

Remove unecessary update in the qgsmasksourceselectionwidget constructor. Update is done automatically when the mask widget is opened. Should fix #34942.

It seems the latest changes introduced by [PR 36366](https://github.com/qgis/QGIS/pull/36366) removed the check box "Edit mask settings" and changed the behavior to an automatic update of the masking symbol when the "mask" widget is opened within the property view.
But the "update" function was still called when QgsMaskSourceSelectionWidget is constructed at the opening of the layer property view. 

This update call is causing the delay and is unnecessary because the update is now done automatically when the mask view is opened.