### PR TITLE
Reload the data source when a dependency layer is changed

### DIFF
--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -2663,6 +2663,13 @@ Emitted before changes are committed to the data provider.
 Emitted before changes are rolled back.
 %End
 
+    void afterCommitChanges();
+%Docstring
+Emitted after changes are commited to the data provider.
+
+.. versionadded:: 3.16
+%End
+
     void afterRollBack();
 %Docstring
 Emitted after changes are rolled back.

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -5325,13 +5325,8 @@ void QgsVectorLayer::emitDataChanged()
 
 void QgsVectorLayer::onAfterCommitChangesDependency()
 {
-  // Refreshing the data provider right away causes problems on a layer dependent on itself.
-  // In that case two `dataChanged` signals are expected to be emitted when deleting or creating
-  // a feature, but as the layer is reloaded, the second `dataChanged` is not emitted.
-  QTimer::singleShot( 0, this, [ = ]()
-  {
-    reload();
-  } );
+  mDataChangedFired = true;
+  reload();
 }
 
 bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -5323,6 +5323,17 @@ void QgsVectorLayer::emitDataChanged()
   mDataChangedFired = false;
 }
 
+void QgsVectorLayer::onAfterCommitChangesDependency()
+{
+  // Refreshing the data provider right away causes problems on a layer dependent on itself.
+  // In that case two `dataChanged` signals are expected to be emitted when deleting or creating
+  // a feature, but as the layer is reloaded, the second `dataChanged` is not emitted.
+  QTimer::singleShot( 0, this, [ = ]()
+  {
+    reload();
+  } );
+}
+
 bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
 {
   QSet<QgsMapLayerDependency> deps;
@@ -5346,7 +5357,7 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
     disconnect( lyr, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayer::emitDataChanged );
     disconnect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::emitDataChanged );
     disconnect( lyr, &QgsVectorLayer::repaintRequested, this, &QgsVectorLayer::triggerRepaint );
-    disconnect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::reload );
+    disconnect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::onAfterCommitChangesDependency );
   }
 
   // assign new dependencies
@@ -5367,7 +5378,7 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
     connect( lyr, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayer::emitDataChanged );
     connect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::emitDataChanged );
     connect( lyr, &QgsVectorLayer::repaintRequested, this, &QgsVectorLayer::triggerRepaint );
-    connect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::reload );
+    connect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::onAfterCommitChangesDependency );
   }
 
   // if new layers are present, emit a data change

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -5323,11 +5323,6 @@ void QgsVectorLayer::emitDataChanged()
   mDataChangedFired = false;
 }
 
-void QgsVectorLayer::onAfterCommitDependency()
-{
-  mDataProvider->reloadData();
-}
-
 bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
 {
   QSet<QgsMapLayerDependency> deps;
@@ -5351,7 +5346,7 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
     disconnect( lyr, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayer::emitDataChanged );
     disconnect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::emitDataChanged );
     disconnect( lyr, &QgsVectorLayer::repaintRequested, this, &QgsVectorLayer::triggerRepaint );
-    disconnect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::onAfterCommitDependency );
+    disconnect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::reload );
   }
 
   // assign new dependencies
@@ -5372,7 +5367,7 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
     connect( lyr, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayer::emitDataChanged );
     connect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::emitDataChanged );
     connect( lyr, &QgsVectorLayer::repaintRequested, this, &QgsVectorLayer::triggerRepaint );
-    connect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::onAfterCommitDependency );
+    connect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::reload );
   }
 
   // if new layers are present, emit a data change

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -3354,6 +3354,7 @@ bool QgsVectorLayer::commitChanges()
     delete mEditBuffer;
     mEditBuffer = nullptr;
     undoStack()->clear();
+    emit afterCommitChanges();
     emit editingStopped();
   }
   else
@@ -5322,6 +5323,11 @@ void QgsVectorLayer::emitDataChanged()
   mDataChangedFired = false;
 }
 
+void QgsVectorLayer::onAfterCommitDependency()
+{
+  mDataProvider->reloadData();
+}
+
 bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
 {
   QSet<QgsMapLayerDependency> deps;
@@ -5345,6 +5351,7 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
     disconnect( lyr, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayer::emitDataChanged );
     disconnect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::emitDataChanged );
     disconnect( lyr, &QgsVectorLayer::repaintRequested, this, &QgsVectorLayer::triggerRepaint );
+    disconnect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::onAfterCommitDependency );
   }
 
   // assign new dependencies
@@ -5365,6 +5372,7 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
     connect( lyr, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayer::emitDataChanged );
     connect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::emitDataChanged );
     connect( lyr, &QgsVectorLayer::repaintRequested, this, &QgsVectorLayer::triggerRepaint );
+    connect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::onAfterCommitDependency );
   }
 
   // if new layers are present, emit a data change

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2715,7 +2715,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void onSymbolsCounted();
     void onDirtyTransaction( const QString &sql, const QString &name );
     void emitDataChanged();
-    void onAfterCommitDependency();
 
   private:
     void updateDefaultValues( QgsFeatureId fid, QgsFeature feature = QgsFeature() );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2715,6 +2715,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void onSymbolsCounted();
     void onDirtyTransaction( const QString &sql, const QString &name );
     void emitDataChanged();
+    void onAfterCommitChangesDependency();
 
   private:
     void updateDefaultValues( QgsFeatureId fid, QgsFeature feature = QgsFeature() );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2483,6 +2483,12 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void beforeRollBack();
 
     /**
+     * Emitted after changes are commited to the data provider.
+     * \since QGIS 3.16
+     */
+    void afterCommitChanges();
+
+    /**
      * Emitted after changes are rolled back.
      * \since QGIS 3.4
      */
@@ -2709,6 +2715,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void onSymbolsCounted();
     void onDirtyTransaction( const QString &sql, const QString &name );
     void emitDataChanged();
+    void onAfterCommitDependency();
 
   private:
     void updateDefaultValues( QgsFeatureId fid, QgsFeature feature = QgsFeature() );

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -872,6 +872,8 @@ void QgsRelationEditorWidget::toggleEditing( bool state )
     if ( mNmRelation.isValid() )
       mEditorContext.vectorLayerTools()->stopEditing( mNmRelation.referencedLayer() );
   }
+
+  updateButtons();
 }
 
 void QgsRelationEditorWidget::saveEdits()


### PR DESCRIPTION
Given layers A and B:
- A is a view from layer B
- A is dependent on layer B

Without the fix, whenever one edits layer B, layer A does not get it's cache invalidated. Because A is a view from B, it means one can modify/create/delete a feature in layer B, but it will not appear in layer A.

Bonus fix:
the toggle edit button on relation editor widget easily get's unsyncronized with the rest of the buttons. If you click on the button when there are changes in the relation and then choose `Cancel` on the dialog, the button wrongly toggles its state, while the rest of the buttons remain enabled.  E.g. toggle edit is toggled to false, but the button "Add new row" is enabled, or vice versa. 

