### PR TITLE
Normalize action scope checkbox labels

### DIFF
--- a/src/core/qgsactionscoperegistry.cpp
+++ b/src/core/qgsactionscoperegistry.cpp
@@ -32,9 +32,9 @@ QgsActionScopeRegistry::QgsActionScopeRegistry( QObject *parent )
   fieldScope.addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "field_name" ), "[field_name]", true ) );
   fieldScope.addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "field_value" ), "[field_value]", true ) );
 
-  mActionScopes.insert( QgsActionScope( QStringLiteral( "Field" ), tr( "Field Scope" ), tr( "Available for individual fields. For example in the attribute table." ), fieldScope ) );
-  mActionScopes.insert( QgsActionScope( QStringLiteral( "Feature" ), tr( "Feature Scope" ), tr( "Available for individual features. For example on feature forms or per row in the attribute table." ) ) );
-  mActionScopes.insert( QgsActionScope( QStringLiteral( "Layer" ), tr( "Layer Scope" ), tr( "Available as layer global action. For example on top of the attribute table." ) ) );
+  mActionScopes.insert( QgsActionScope( QStringLiteral( "Field" ), tr( "Field" ), tr( "Available for individual fields. For example in the attribute table." ), fieldScope ) );
+  mActionScopes.insert( QgsActionScope( QStringLiteral( "Feature" ), tr( "Feature" ), tr( "Available for individual features. For example on feature forms or per row in the attribute table." ) ) );
+  mActionScopes.insert( QgsActionScope( QStringLiteral( "Layer" ), tr( "Layer" ), tr( "Available as layer global action. For example on top of the attribute table." ) ) );
 }
 
 QSet<QgsActionScope> QgsActionScopeRegistry::actionScopes() const


### PR DESCRIPTION
Minor adjustment to go from this: 

![image](https://user-images.githubusercontent.com/652785/86081742-ab7b5b80-ba5b-11ea-8610-7b9730f650f0.png)


to this: 

![image](https://user-images.githubusercontent.com/652785/86081691-871f7f00-ba5b-11ea-81ab-e4babeb76017.png)

------------
Another option is to add the word _Scope_ to the canvas scope option, but since the title already includes the word _Scope_ I think it would be redundant.
