### PR TITLE
Immediately liberate connection of expression value gatherer

### DIFF
--- a/src/core/qgsfeatureexpressionvaluesgatherer.h
+++ b/src/core/qgsfeatureexpressionvaluesgatherer.h
@@ -91,7 +91,7 @@ class QgsFeatureExpressionValuesGatherer: public QThread
     {
       mWasCanceled = false;
 
-      mIterator = mSource->getFeatures( mRequest );
+      QgsFeatureIterator iterator = mSource->getFeatures( mRequest );
 
       mDisplayExpression.prepare( &mExpressionContext );
 
@@ -100,7 +100,7 @@ class QgsFeatureExpressionValuesGatherer: public QThread
       for ( const QString &fieldName : qgis::as_const( mIdentifierFields ) )
         attributeIndexes << mSource->fields().indexOf( fieldName );
 
-      while ( mIterator.nextFeature( feature ) )
+      while ( iterator.nextFeature( feature ) )
       {
         mExpressionContext.setFeature( feature );
         QVariantList attributes;
@@ -165,7 +165,6 @@ class QgsFeatureExpressionValuesGatherer: public QThread
     QgsExpression mDisplayExpression;
     QgsExpressionContext mExpressionContext;
     QgsFeatureRequest mRequest;
-    QgsFeatureIterator mIterator;
     bool mWasCanceled = false;
     mutable QMutex mCancelMutex;
     QStringList mIdentifierFields;


### PR DESCRIPTION
This fixes a deadlock when opening attribute forms with many relation reference widgets (with remote databases / long roundtrips).

The iterator as a member as previously implemented kept connections
occupied for as long as the gatherer existed. This could lead to a
situation, where all connections have been reserved from finished
gatherers which were waiting to be deleted (through deleteLater),
but deleteLater would never happen if the main thread was
also busy waiting for a connection to become available.

Fixes https://github.com/qgis/QGIS/issues/37496
