### PR TITLE
[backport-3_10] Immediately liberate connection of expression value gatherer

### DIFF
--- a/src/core/qgsfeaturefiltermodel_p.h
+++ b/src/core/qgsfeaturefiltermodel_p.h
@@ -52,7 +52,7 @@ class QgsFieldExpressionValuesGatherer: public QThread
     {
       mWasCanceled = false;
 
-      mIterator = mSource->getFeatures( mRequest );
+      QgsFeatureIterator iterator = mSource->getFeatures( mRequest );
 
       mDisplayExpression.prepare( &mExpressionContext );
 
@@ -61,7 +61,7 @@ class QgsFieldExpressionValuesGatherer: public QThread
       for ( const QString &fieldName : qgis::as_const( mIdentifierFields ) )
         attributeIndexes << mSource->fields().indexOf( fieldName );
 
-      while ( mIterator.nextFeature( feat ) )
+      while ( iterator.nextFeature( feat ) )
       {
         mExpressionContext.setFeature( feat );
         QVariantList attributes;
@@ -121,7 +121,6 @@ class QgsFieldExpressionValuesGatherer: public QThread
     QgsExpression mDisplayExpression;
     QgsExpressionContext mExpressionContext;
     QgsFeatureRequest mRequest;
-    QgsFeatureIterator mIterator;
     bool mWasCanceled = false;
     mutable QMutex mCancelMutex;
     QVector<QgsFeatureFilterModel::Entry> mEntries;


### PR DESCRIPTION
Backport of https://github.com/qgis/QGIS/pull/37526

This fixes a deadlock

The iterator as a member as previously implemented kept connections
occupied for as long as the gatherer existed. This could lead to a
situation, where all connections have been reserved from finished
gatherers which were waiting to be deleted (through deleteLater),
but deleteLater would never happen because the main thread was
waiting for a connection to become available.

Fixes #37496

## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
