### PR TITLE
re-allow circular dependencies

### DIFF
--- a/python/gui/auto_generated/vector/qgsvectorlayerproperties.sip.in
+++ b/python/gui/auto_generated/vector/qgsvectorlayerproperties.sip.in
@@ -42,7 +42,6 @@ Adds a properties page factory to the vector layer properties dialog.
 
 
 
-      public:
 };
 
 

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -388,7 +388,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
       dependencySources << layer;
   }
 
-  mLayersDependenciesTreeModel = new DependenciesLayerTreeModel( mLayer, this );
+  mLayersDependenciesTreeModel = new QgsLayerTreeFilterProxyModel( this );
   mLayersDependenciesTreeModel->setLayerTreeModel( new QgsLayerTreeModel( QgsProject::instance()->layerTreeRoot(), mLayersDependenciesTreeModel ) );
   mLayersDependenciesTreeModel->setCheckedLayers( dependencySources );
   connect( QgsProject::instance(), &QObject::destroyed, this, [ = ] {mLayersDependenciesTreeView->setModel( nullptr );} );

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -160,19 +160,6 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
   private:
 
-    class DependenciesLayerTreeModel : public QgsLayerTreeFilterProxyModel
-    {
-      public:
-        DependenciesLayerTreeModel( QgsVectorLayer *mainLayer, QObject *parent = nullptr )
-          : QgsLayerTreeFilterProxyModel( parent )
-          , mMainLayer( mainLayer )
-        {}
-
-      private:
-        QgsVectorLayer *mMainLayer = nullptr;
-        bool layerShown( QgsMapLayer *layer ) const override {return layer != mMainLayer;}
-    };
-
     enum PropertyType
     {
       Style = 0,
@@ -241,7 +228,7 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
     QgsExpressionContext createExpressionContext() const override;
 
-    DependenciesLayerTreeModel *mLayersDependenciesTreeModel;
+    QgsLayerTreeFilterProxyModel *mLayersDependenciesTreeModel;
 
     void showHelp();
 


### PR DESCRIPTION
see #30947

When replacing the layer tree model, I assumed you could not do this.
I just discovered you can.