### PR TITLE
rename QgsProject::layer(s)WillBeRemoved to aboutToRemoveLayer(s)

### DIFF
--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -1580,17 +1580,23 @@ Emitted when one or more layers are about to be removed from the registry.
 .. seealso:: :py:func:`layerWillBeRemoved`
 
 .. seealso:: :py:func:`layersRemoved`
+
+.. seealso:: :py:func:`aboutToRemoveLayers`
 %End
 
-    void layersWillBeRemoved( const QList<QgsMapLayer *> &layers );
+    void aboutToRemoveLayers( const QList<QgsMapLayer *> &layers );
 %Docstring
 Emitted when one or more layers are about to be removed from the registry.
 
 :param layers: A list of layers which are to be removed.
 
-.. seealso:: :py:func:`layerWillBeRemoved`
+.. seealso:: :py:func:`layersWillBeRemoved`
 
 .. seealso:: :py:func:`layersRemoved`
+
+.. seealso:: :py:func:`aboutToRemoveLayer`
+
+.. versionadded:: 3.16
 %End
 
     void layerWillBeRemoved( const QString &layerId );
@@ -1606,9 +1612,11 @@ Emitted when a layer is about to be removed from the registry.
 .. seealso:: :py:func:`layersWillBeRemoved`
 
 .. seealso:: :py:func:`layerRemoved`
+
+.. seealso:: :py:func:`aboutToRemoveLayer`
 %End
 
-    void layerWillBeRemoved( QgsMapLayer *layer );
+    void aboutToRemoveLayer( QgsMapLayer *layer );
 %Docstring
 Emitted when a layer is about to be removed from the registry.
 
@@ -1621,6 +1629,10 @@ Emitted when a layer is about to be removed from the registry.
 .. seealso:: :py:func:`layersWillBeRemoved`
 
 .. seealso:: :py:func:`layerRemoved`
+
+.. seealso:: :py:func:`aboutToRemoveLayers`
+
+.. versionadded:: 3.16
 %End
 
     void layersRemoved( const QStringList &layerIds );

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -1084,7 +1084,7 @@ void QgsGeoreferencerMainWindow::setupConnections()
   connect( mCanvas, &QgsMapCanvas::zoomLastStatusChanged, mActionZoomLast, &QAction::setEnabled );
   connect( mCanvas, &QgsMapCanvas::zoomNextStatusChanged, mActionZoomNext, &QAction::setEnabled );
   // Connect when one Layer is removed - Case where change the Projetct in QGIS
-  connect( QgsProject::instance(), static_cast<void ( QgsProject::* )( const QString & )>( &QgsProject::layerWillBeRemoved ), this, &QgsGeoreferencerMainWindow::layerWillBeRemoved );
+  connect( QgsProject::instance(), &QgsProject::layerWillBeRemoved, this, &QgsGeoreferencerMainWindow::layerWillBeRemoved );
 
   // Connect extents changed - Use for need add again Raster
   connect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsGeoreferencerMainWindow::extentsChanged );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4156,15 +4156,11 @@ void QgisApp::setupConnections()
   } );
 
   // connect map layer registry
-  connect( QgsProject::instance(), &QgsProject::layersAdded,
-           this, &QgisApp::layersWereAdded );
-  connect( QgsProject::instance(),
-           static_cast < void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ),
-           this, &QgisApp::removingLayers );
+  connect( QgsProject::instance(), &QgsProject::layersAdded, this, &QgisApp::layersWereAdded );
+  connect( QgsProject::instance(), &QgsProject::layersWillBeRemoved, this, &QgisApp::removingLayers );
 
   // connect initialization signal
-  connect( this, &QgisApp::initializationCompleted,
-           this, &QgisApp::fileOpenAfterLaunch );
+  connect( this, &QgisApp::initializationCompleted, this, &QgisApp::fileOpenAfterLaunch );
 
   // Connect warning dialog from project reading
   connect( QgsProject::instance(), &QgsProject::oldProjectVersionWarning,

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -73,7 +73,7 @@ QgsLayerStylingWidget::QgsLayerStylingWidget( QgsMapCanvas *canvas, QgsMessageBa
   mOptionsListWidget->setIconSize( QgisApp::instance()->iconSize( false ) );
   mOptionsListWidget->setMaximumWidth( static_cast< int >( mOptionsListWidget->iconSize().width() * 1.18 ) );
 
-  connect( QgsProject::instance(), static_cast < void ( QgsProject::* )( QgsMapLayer * ) > ( &QgsProject::layerWillBeRemoved ), this, &QgsLayerStylingWidget::layerAboutToBeRemoved );
+  connect( QgsProject::instance(), &QgsProject::aboutToRemoveLayer, this, &QgsLayerStylingWidget::layerAboutToBeRemoved );
 
   QgsSettings settings;
   mLiveApplyCheck->setChecked( settings.value( QStringLiteral( "UI/autoApplyStyling" ), true ).toBool() );

--- a/src/app/qgsstatisticalsummarydockwidget.cpp
+++ b/src/app/qgsstatisticalsummarydockwidget.cpp
@@ -74,7 +74,7 @@ QgsStatisticalSummaryDockWidget::QgsStatisticalSummaryDockWidget( QWidget *paren
   connect( mSelectedOnlyCheckBox, &QAbstractButton::toggled, this, &QgsStatisticalSummaryDockWidget::refreshStatistics );
   connect( mButtonCopy, &QAbstractButton::clicked, this, &QgsStatisticalSummaryDockWidget::copyStatistics );
   connect( mButtonRefresh, &QAbstractButton::clicked, this, &QgsStatisticalSummaryDockWidget::refreshStatistics );
-  connect( QgsProject::instance(), static_cast<void ( QgsProject::* )( const QStringList & )>( &QgsProject::layersWillBeRemoved ), this, &QgsStatisticalSummaryDockWidget::layersRemoved );
+  connect( QgsProject::instance(), &QgsProject::layersWillBeRemoved, this, &QgsStatisticalSummaryDockWidget::layersRemoved );
 
   mStatisticsMenu = new QMenu( mOptionsToolButton );
   mOptionsToolButton->setMenu( mStatisticsMenu );

--- a/src/core/layertree/qgslayertreeregistrybridge.cpp
+++ b/src/core/layertree/qgslayertreeregistrybridge.cpp
@@ -30,7 +30,7 @@ QgsLayerTreeRegistryBridge::QgsLayerTreeRegistryBridge( QgsLayerTreeGroup *root,
   , mInsertionPoint( root, 0 )
 {
   connect( mProject, &QgsProject::legendLayersAdded, this, &QgsLayerTreeRegistryBridge::layersAdded );
-  connect( mProject, static_cast < void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsLayerTreeRegistryBridge::layersWillBeRemoved );
+  connect( mProject, &QgsProject::layersWillBeRemoved, this, &QgsLayerTreeRegistryBridge::layersWillBeRemoved );
 
   connect( mRoot, &QgsLayerTreeNode::willRemoveChildren, this, &QgsLayerTreeRegistryBridge::groupWillRemoveChildren );
   connect( mRoot, &QgsLayerTreeNode::removedChildren, this, &QgsLayerTreeRegistryBridge::groupRemovedChildren );

--- a/src/core/layout/qgslayoutatlas.cpp
+++ b/src/core/layout/qgslayoutatlas.cpp
@@ -33,7 +33,7 @@ QgsLayoutAtlas::QgsLayoutAtlas( QgsLayout *layout )
 {
 
   //listen out for layer removal
-  connect( mLayout->project(), static_cast < void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsLayoutAtlas::removeLayers );
+  connect( mLayout->project(), &QgsProject::layersWillBeRemoved, this, &QgsLayoutAtlas::removeLayers );
 }
 
 QString QgsLayoutAtlas::stringType() const

--- a/src/core/layout/qgslayoutitemattributetable.cpp
+++ b/src/core/layout/qgslayoutitemattributetable.cpp
@@ -41,7 +41,7 @@ QgsLayoutItemAttributeTable::QgsLayoutItemAttributeTable( QgsLayout *layout )
 {
   if ( mLayout )
   {
-    connect( mLayout->project(), static_cast < void ( QgsProject::* )( const QString & ) >( &QgsProject::layerWillBeRemoved ), this, &QgsLayoutItemAttributeTable::removeLayer );
+    connect( mLayout->project(), &QgsProject::layerWillBeRemoved, this, &QgsLayoutItemAttributeTable::removeLayer );
 
     //coverage layer change = regenerate columns
     connect( &mLayout->reportContext(), &QgsLayoutReportContext::layerChanged, this, &QgsLayoutItemAttributeTable::atlasLayerChanged );

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1854,8 +1854,7 @@ void QgsLayoutItemMap::connectUpdateSlot()
   if ( project )
   {
     // handles updating the stored layer state BEFORE the layers are removed
-    connect( project, static_cast < void ( QgsProject::* )( const QList<QgsMapLayer *>& layers ) > ( &QgsProject::layersWillBeRemoved ),
-             this, &QgsLayoutItemMap::layersAboutToBeRemoved );
+    connect( project, &QgsProject::aboutToRemoveLayers, this, &QgsLayoutItemMap::layersAboutToBeRemoved );
     // redraws the map AFTER layers are removed
     connect( project->layerTreeRoot(), &QgsLayerTree::layerOrderChanged, this, [ = ]
     {

--- a/src/core/qgsmaplayermodel.cpp
+++ b/src/core/qgsmaplayermodel.cpp
@@ -25,7 +25,7 @@ QgsMapLayerModel::QgsMapLayerModel( const QList<QgsMapLayer *> &layers, QObject 
   : QAbstractItemModel( parent )
   , mProject( project ? project : QgsProject::instance() )
 {
-  connect( mProject, static_cast < void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsMapLayerModel::removeLayers );
+  connect( mProject, &QgsProject::layersWillBeRemoved, this, &QgsMapLayerModel::removeLayers );
   addLayers( layers );
 }
 
@@ -34,7 +34,7 @@ QgsMapLayerModel::QgsMapLayerModel( QObject *parent, QgsProject *project )
   , mProject( project ? project : QgsProject::instance() )
 {
   connect( mProject, &QgsProject::layersAdded, this, &QgsMapLayerModel::addLayers );
-  connect( mProject, static_cast < void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsMapLayerModel::removeLayers );
+  connect( mProject, &QgsProject::layersWillBeRemoved, this, &QgsMapLayerModel::removeLayers );
   addLayers( mProject->mapLayers().values() );
 }
 

--- a/src/core/qgsmapthemecollection.cpp
+++ b/src/core/qgsmapthemecollection.cpp
@@ -29,7 +29,7 @@
 QgsMapThemeCollection::QgsMapThemeCollection( QgsProject *project )
   : mProject( project )
 {
-  connect( project, static_cast<void ( QgsProject::* )( const QStringList & )>( &QgsProject::layersWillBeRemoved ), this, &QgsMapThemeCollection::registryLayersRemoved );
+  connect( project, &QgsProject::layersWillBeRemoved, this, &QgsMapThemeCollection::registryLayersRemoved );
 }
 
 QgsMapThemeCollection::MapThemeLayerRecord QgsMapThemeCollection::createThemeLayerRecord( QgsLayerTreeLayer *nodeLayer, QgsLayerTreeModel *model )
@@ -218,9 +218,9 @@ void QgsMapThemeCollection::setProject( QgsProject *project )
   if ( project == mProject )
     return;
 
-  disconnect( mProject, static_cast<void ( QgsProject::* )( const QStringList & )>( &QgsProject::layersWillBeRemoved ), this, &QgsMapThemeCollection::registryLayersRemoved );
+  disconnect( mProject, &QgsProject::layersWillBeRemoved, this, &QgsMapThemeCollection::registryLayersRemoved );
   mProject = project;
-  connect( mProject, static_cast<void ( QgsProject::* )( const QStringList & )>( &QgsProject::layersWillBeRemoved ), this, &QgsMapThemeCollection::registryLayersRemoved );
+  connect( mProject, &QgsProject::layersWillBeRemoved, this, &QgsMapThemeCollection::registryLayersRemoved );
   emit projectChanged();
 }
 

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -383,17 +383,17 @@ QgsProject::QgsProject( QObject *parent )
   mLayerTreeRegistryBridge = new QgsLayerTreeRegistryBridge( mRootGroup, this, this );
   connect( this, &QgsProject::layersAdded, this, &QgsProject::onMapLayersAdded );
   connect( this, &QgsProject::layersRemoved, this, [ = ] { cleanTransactionGroups(); } );
-  connect( this, qgis::overload< const QList<QgsMapLayer *> & >::of( &QgsProject::layersWillBeRemoved ), this, &QgsProject::onMapLayersRemoved );
+  connect( this, &QgsProject::aboutToRemoveLayers, this, &QgsProject::onMapLayersRemoved );
 
   // proxy map layer store signals to this
   connect( mLayerStore.get(), qgis::overload<const QStringList &>::of( &QgsMapLayerStore::layersWillBeRemoved ),
   this, [ = ]( const QStringList & layers ) { mProjectScope.reset(); emit layersWillBeRemoved( layers ); } );
   connect( mLayerStore.get(), qgis::overload< const QList<QgsMapLayer *> & >::of( &QgsMapLayerStore::layersWillBeRemoved ),
-  this, [ = ]( const QList<QgsMapLayer *> &layers ) { mProjectScope.reset(); emit layersWillBeRemoved( layers ); } );
+  this, [ = ]( const QList<QgsMapLayer *> &layers ) { mProjectScope.reset(); emit aboutToRemoveLayers( layers ); } );
   connect( mLayerStore.get(), qgis::overload< const QString & >::of( &QgsMapLayerStore::layerWillBeRemoved ),
   this, [ = ]( const QString & layer ) { mProjectScope.reset(); emit layerWillBeRemoved( layer ); } );
   connect( mLayerStore.get(), qgis::overload< QgsMapLayer * >::of( &QgsMapLayerStore::layerWillBeRemoved ),
-  this, [ = ]( QgsMapLayer * layer ) { mProjectScope.reset(); emit layerWillBeRemoved( layer ); } );
+  this, [ = ]( QgsMapLayer * layer ) { mProjectScope.reset(); emit aboutToRemoveLayer( layer ); } );
   connect( mLayerStore.get(), qgis::overload<const QStringList & >::of( &QgsMapLayerStore::layersRemoved ), this,
   [ = ]( const QStringList & layers ) { mProjectScope.reset(); emit layersRemoved( layers ); } );
   connect( mLayerStore.get(), &QgsMapLayerStore::layerRemoved, this,

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -1621,6 +1621,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \param layerIds A list of IDs for the layers which are to be removed.
      * \see layerWillBeRemoved()
      * \see layersRemoved()
+     * \see aboutToRemoveLayers()
      */
     void layersWillBeRemoved( const QStringList &layerIds );
 
@@ -1628,10 +1629,12 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * Emitted when one or more layers are about to be removed from the registry.
      *
      * \param layers A list of layers which are to be removed.
-     * \see layerWillBeRemoved()
+     * \see layersWillBeRemoved()
      * \see layersRemoved()
+     * \see aboutToRemoveLayer()
+     * \since QGIS 3.16
      */
-    void layersWillBeRemoved( const QList<QgsMapLayer *> &layers );
+    void aboutToRemoveLayers( const QList<QgsMapLayer *> &layers );
 
     /**
      * Emitted when a layer is about to be removed from the registry.
@@ -1641,6 +1644,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \note Consider using layersWillBeRemoved() instead
      * \see layersWillBeRemoved()
      * \see layerRemoved()
+     * \see aboutToRemoveLayer()
      */
     void layerWillBeRemoved( const QString &layerId );
 
@@ -1652,8 +1656,10 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \note Consider using layersWillBeRemoved() instead
      * \see layersWillBeRemoved()
      * \see layerRemoved()
+     * \see aboutToRemoveLayers()
+     * \since QGIS 3.16
      */
-    void layerWillBeRemoved( QgsMapLayer *layer );
+    void aboutToRemoveLayer( QgsMapLayer *layer );
 
     /**
      * Emitted after one or more layers were removed from the registry.

--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -437,8 +437,7 @@ long QgsTaskManager::addTaskPrivate( QgsTask *task, QgsTaskList dependencies, bo
     mInitialized = true;
     // defer connection to project until we actually need it -- we don't want to connect to the project instance in the constructor,
     // cos that forces early creation of QgsProject
-    connect( QgsProject::instance(), static_cast < void ( QgsProject::* )( const QList< QgsMapLayer * >& ) > ( &QgsProject::layersWillBeRemoved ),
-             this, &QgsTaskManager::layersWillBeRemoved );
+    connect( QgsProject::instance(), &QgsProject::aboutToRemoveLayers, this, &QgsTaskManager::layersWillBeRemoved );
   }
 
   long taskId = mNextTaskId++;

--- a/src/gui/raster/qgspalettedrendererwidget.cpp
+++ b/src/gui/raster/qgspalettedrendererwidget.cpp
@@ -117,7 +117,7 @@ QgsPalettedRendererWidget::QgsPalettedRendererWidget( QgsRasterLayer *layer, con
     mLoadFromLayerAction->setEnabled( false );
   }
 
-  connect( QgsProject::instance(), static_cast < void ( QgsProject::* )( QgsMapLayer * ) >( &QgsProject::layerWillBeRemoved ), this, &QgsPalettedRendererWidget::layerWillBeRemoved );
+  connect( QgsProject::instance(), &QgsProject::aboutToRemoveLayer, this, &QgsPalettedRendererWidget::layerWillBeRemoved );
   connect( mBandComboBox, &QgsRasterBandComboBox::bandChanged, this, &QgsPalettedRendererWidget::bandChanged );
 }
 

--- a/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
@@ -84,7 +84,7 @@ QgsGeometryCheckerResultTab::QgsGeometryCheckerResultTab( QgisInterface *iface, 
   connect( ui.pushButtonFixWithPrompt, &QAbstractButton::clicked, this, &QgsGeometryCheckerResultTab::fixErrorsWithPrompt );
   connect( ui.pushButtonErrorResolutionSettings, &QAbstractButton::clicked, this, &QgsGeometryCheckerResultTab::setDefaultResolutionMethods );
   connect( ui.checkBoxHighlight, &QAbstractButton::clicked, this, &QgsGeometryCheckerResultTab::highlightErrors );
-  connect( QgsProject::instance(), static_cast<void ( QgsProject::* )( const QStringList & )>( &QgsProject::layersWillBeRemoved ), this, &QgsGeometryCheckerResultTab::checkRemovedLayer );
+  connect( QgsProject::instance(), &QgsProject::layersWillBeRemoved, this, &QgsGeometryCheckerResultTab::checkRemovedLayer );
   connect( ui.pushButtonExport, &QAbstractButton::clicked, this, &QgsGeometryCheckerResultTab::exportErrors );
 
   bool allLayersEditable = true;

--- a/src/plugins/offline_editing/offline_editing_plugin.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin.cpp
@@ -84,7 +84,7 @@ void QgsOfflineEditingPlugin::initGui()
   connect( mQGisIface, &QgisInterface::newProjectCreated, this, &QgsOfflineEditingPlugin::updateActions );
   connect( QgsProject::instance(), &QgsProject::writeProject, this, &QgsOfflineEditingPlugin::updateActions );
   connect( QgsProject::instance(), &QgsProject::layerWasAdded, this, &QgsOfflineEditingPlugin::updateActions );
-  connect( QgsProject::instance(), static_cast < void ( QgsProject::* )( const QString & ) >( &QgsProject::layerWillBeRemoved ), this, &QgsOfflineEditingPlugin::updateActions );
+  connect( QgsProject::instance(), &QgsProject::layerWillBeRemoved, this, &QgsOfflineEditingPlugin::updateActions );
   updateActions();
 }
 

--- a/src/plugins/topology/checkDock.cpp
+++ b/src/plugins/topology/checkDock.cpp
@@ -89,7 +89,7 @@ checkDock::checkDock( QgisInterface *qIface, QWidget *parent )
   connect( mFixButton, &QAbstractButton::clicked, this, &checkDock::fix );
   connect( mErrorTableView, &QAbstractItemView::clicked, this, &checkDock::errorListClicked );
 
-  connect( QgsProject::instance(), static_cast < void ( QgsProject::* )( const QString & ) >( &QgsProject::layerWillBeRemoved ), this, &checkDock::parseErrorListByLayer );
+  connect( QgsProject::instance(), &QgsProject::layerWillBeRemoved, this, &checkDock::parseErrorListByLayer );
 
   connect( this, &QDockWidget::visibilityChanged, this, &checkDock::updateRubberBands );
   connect( qgsInterface, &QgisInterface::newProjectCreated, mConfigureDialog, &rulesDialog::clearRules );


### PR DESCRIPTION
the overloading was not used in Python bindings
renaming is preferred since it avoids the usage of overloads

supersedes #37353