### PR TITLE
add Y page offset expression

### DIFF
--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -736,6 +736,7 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts()->insert( QStringLiteral( "layout_page" ), QCoreApplication::translate( "variable_help", "Current page number in composition." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "layout_pageheight" ), QCoreApplication::translate( "variable_help", "Composition page height in mm." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "layout_pagewidth" ), QCoreApplication::translate( "variable_help", "Composition page width in mm." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "layout_pageoffsets" ), QCoreApplication::translate( "variable_help", "Array of Y coordinate of the top of each page." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "layout_dpi" ), QCoreApplication::translate( "variable_help", "Composition resolution (DPI)." ) );
 
   //atlas variables

--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -510,6 +510,15 @@ QgsExpressionContextScope *QgsExpressionContextUtils::layoutScope( const QgsLayo
     scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layout_pageheight" ), s.height(), true ) );
     scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layout_pagewidth" ), s.width(), true ) );
   }
+
+  QVariantList offsets;
+  for ( int i = 0; i < layout->pageCollection()->pageCount(); i++ )
+  {
+    QPointF p = layout->pageCollection()->pagePositionToLayoutPosition( i, QgsLayoutPoint( 0, 0 ) );
+    offsets << p.y();
+  }
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layout_pageoffsets" ), offsets, true ) );
+
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layout_dpi" ), layout->renderContext().dpi(), true ) );
 
   scope->addFunction( QStringLiteral( "item_variables" ), new GetLayoutItemVariables( layout ) );

--- a/tests/src/core/testqgslayoutlabel.cpp
+++ b/tests/src/core/testqgslayoutlabel.cpp
@@ -50,6 +50,7 @@ class TestQgsLayoutLabel : public QObject
     void featureEvaluationUsingContext();
     // test page expressions
     void pageEvaluation();
+    void pageSizeEvaluation();
     void marginMethods(); //tests getting/setting margins
     void render();
     void renderAsHtml();
@@ -232,6 +233,34 @@ void TestQgsLayoutLabel::pageEvaluation()
     // move to the second page and re-evaluate
     label->attemptMove( QgsLayoutPoint( 0, 320 ) );
     QCOMPARE( label->currentText(), QString( "2/2" ) );
+  }
+}
+
+void TestQgsLayoutLabel::pageSizeEvaluation()
+{
+  QgsLayout l( QgsProject::instance() );
+  l.initializeDefaults();
+
+  QgsLayoutItemLabel *label = new QgsLayoutItemLabel( &l );
+  label->setMargin( 1 );
+  label->setText( QStringLiteral( "[%array_to_string(@layout_pageoffsets)%]" ) );
+  l.addLayoutItem( label );
+
+  {
+    QString evaluated = label->currentText();
+    QString expected = QStringLiteral( "0" );
+    QCOMPARE( evaluated, expected );
+  }
+
+  // add a page and re-evaluate
+  QgsLayoutItemPage *page2 = new QgsLayoutItemPage( &l );
+  page2->setPageSize( "A4", QgsLayoutItemPage::Landscape );
+  l.pageCollection()->addPage( page2 );
+
+  {
+    QString evaluated = label->currentText();
+    QString expected = QStringLiteral( "0,220" );
+    QCOMPARE( evaluated, expected );
   }
 }
 


### PR DESCRIPTION
# Description

This PR adds the `layout_pageoffsets` expression, to be used in the layout composer. The expression returns an array of Y coordinates of the top of each page in the layout, allowing to dynamically position items on pages in a context where page sizes may change.

Example to set an item at 2.5mm from the top of page 2 (for the data-defined position Y of a map item) :
```
@layout_pageoffsets[1] + 2.5
```

This constitutes a workaround for https://github.com/qgis/QGIS/issues/37567

