### PR TITLE
Fix attributes on copy paste while QGIS stays responsive

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10217,9 +10217,6 @@ void QgisApp::pasteFromClipboard( QgsMapLayer *destinationLayer )
       QgsAttributeEditorContext context( createAttributeEditorContext() );
       context.setAllowCustomUi( false );
       context.setFormMode( QgsAttributeEditorContext::StandaloneDialog );
-      context.setVectorLayerTools( mVectorLayerTools );
-      context.setCadDockWidget( mAdvancedDigitizingDockWidget );
-      context.setMapCanvas( mMapCanvas );
 
       QgsFixAttributeDialog *dialog = new QgsFixAttributeDialog( pasteVectorLayer, invalidFeatures, this, context );
 
@@ -10238,6 +10235,7 @@ void QgisApp::pasteFromClipboard( QgsMapLayer *destinationLayer )
             break;
         }
         pasteFeatures( pasteVectorLayer, invalidGeometriesCount, nTotalFeatures, features );
+        dialog->deleteLater();
       } );
       dialog->show();
       return;
@@ -10247,12 +10245,12 @@ void QgisApp::pasteFromClipboard( QgsMapLayer *destinationLayer )
   pasteFeatures( pasteVectorLayer, invalidGeometriesCount, nTotalFeatures, newFeatures );
 }
 
-void QgisApp::pasteFeatures( QgsVectorLayer *pasteVectorLayer, int invalidGeometriesCount, int nTotalFeatures, QgsFeatureList &newFeatures )
+void QgisApp::pasteFeatures( QgsVectorLayer *pasteVectorLayer, int invalidGeometriesCount, int nTotalFeatures, QgsFeatureList &features )
 {
-  pasteVectorLayer->addFeatures( newFeatures );
+  pasteVectorLayer->addFeatures( features );
   QgsFeatureIds newIds;
-  newIds.reserve( newFeatures.size() );
-  for ( const QgsFeature &f : qgis::as_const( newFeatures ) )
+  newIds.reserve( features.size() );
+  for ( const QgsFeature &f : qgis::as_const( features ) )
   {
     newIds << f.id();
   }
@@ -10261,7 +10259,7 @@ void QgisApp::pasteFeatures( QgsVectorLayer *pasteVectorLayer, int invalidGeomet
   pasteVectorLayer->endEditCommand();
   pasteVectorLayer->updateExtents();
 
-  int nCopiedFeatures = newFeatures.count();
+  int nCopiedFeatures = features.count();
   Qgis::MessageLevel level = ( nCopiedFeatures == 0 || invalidGeometriesCount > 0 ) ? Qgis::Warning : Qgis::Info;
   QString message;
   if ( nCopiedFeatures == 0 )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10214,7 +10214,14 @@ void QgisApp::pasteFromClipboard( QgsMapLayer *destinationLayer )
     {
       newFeatures.clear();
 
-      QgsFixAttributeDialog *dialog = new QgsFixAttributeDialog( pasteVectorLayer, invalidFeatures, this );
+      QgsAttributeEditorContext context( createAttributeEditorContext() );
+      context.setAllowCustomUi( false );
+      context.setFormMode( QgsAttributeEditorContext::StandaloneDialog );
+      context.setVectorLayerTools( mVectorLayerTools );
+      context.setCadDockWidget( mAdvancedDigitizingDockWidget );
+      context.setMapCanvas( mMapCanvas );
+
+      QgsFixAttributeDialog *dialog = new QgsFixAttributeDialog( pasteVectorLayer, invalidFeatures, this, context );
       int feedback = dialog->exec();
 
       switch ( feedback )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -927,6 +927,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
                                 (defaults to the active layer on the legend)
      */
     void pasteFromClipboard( QgsMapLayer *destinationLayer = nullptr );
+
+    void pasteFeatures( QgsVectorLayer *pasteVectorLayer, int invalidGeometriesCount, int nTotalFeatures, QgsFeatureList &newFeatures );
+
     //! copies features on the clipboard to a new vector layer
     void pasteAsNewVector();
     //! copies features on the clipboard to a new memory vector layer

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -928,8 +928,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      */
     void pasteFromClipboard( QgsMapLayer *destinationLayer = nullptr );
 
-    void pasteFeatures( QgsVectorLayer *pasteVectorLayer, int invalidGeometriesCount, int nTotalFeatures, QgsFeatureList &newFeatures );
-
     //! copies features on the clipboard to a new vector layer
     void pasteAsNewVector();
     //! copies features on the clipboard to a new memory vector layer
@@ -2188,6 +2186,12 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * try to resolve and create the broken relations.
      */
     void resolveVectorLayerWeakRelations( QgsVectorLayer *vectorLayer );
+
+    /**
+     * Pastes the \a features to the \a pasteVectorLayer and gives feedback to the user
+     * according to \a invalidGeometryCount and \a nTotalFeatures
+     */
+    void pasteFeatures( QgsVectorLayer *pasteVectorLayer, int invalidGeometriesCount, int nTotalFeatures, QgsFeatureList &features );
 
 
     QgisAppStyleSheet *mStyleSheetBuilder = nullptr;

--- a/src/app/qgsfixattributedialog.cpp
+++ b/src/app/qgsfixattributedialog.cpp
@@ -20,21 +20,19 @@
 
 #include <QtWidgets/QPushButton>
 
-QgsFixAttributeDialog::QgsFixAttributeDialog( QgsVectorLayer *vl, QgsFeatureList &features, QWidget *parent )
+
+QgsFixAttributeDialog::QgsFixAttributeDialog( QgsVectorLayer *vl, QgsFeatureList &features, QWidget *parent, const QgsAttributeEditorContext &context )
   : QDialog( parent )
   , mFeatures( features )
 {
-  init( vl );
+  init( vl, context );
 }
 
-void QgsFixAttributeDialog::init( QgsVectorLayer *layer )
+void QgsFixAttributeDialog::init( QgsVectorLayer *layer, const QgsAttributeEditorContext &context )
 {
-  QgsAttributeEditorContext context;
   setWindowTitle( tr( "%1 - Fix Pasted Features" ).arg( layer->name() ) );
   setLayout( new QGridLayout() );
   layout()->setMargin( 0 );
-  context.setFormMode( QgsAttributeEditorContext::StandaloneDialog );
-  context.setVectorLayerTools( QgisApp::instance()->vectorLayerTools() );
 
   mUnfixedFeatures = mFeatures;
   mCurrentFeature = mFeatures.begin();

--- a/src/app/qgsfixattributedialog.h
+++ b/src/app/qgsfixattributedialog.h
@@ -52,7 +52,7 @@ class APP_EXPORT QgsFixAttributeDialog : public QDialog
     /**
      * Constructor for QgsFixAttributeDialog
      */
-    QgsFixAttributeDialog( QgsVectorLayer *vl, QgsFeatureList &features, QWidget *parent SIP_TRANSFERTHIS = nullptr );
+    QgsFixAttributeDialog( QgsVectorLayer *vl, QgsFeatureList &features, QWidget *parent SIP_TRANSFERTHIS = nullptr, const QgsAttributeEditorContext &context = QgsAttributeEditorContext() );
 
     /**
      * Returns fixed features
@@ -69,7 +69,7 @@ class APP_EXPORT QgsFixAttributeDialog : public QDialog
     void reject() override;
 
   private:
-    void init( QgsVectorLayer *layer );
+    void init( QgsVectorLayer *layer, const QgsAttributeEditorContext &context );
     QString descriptionText();
 
     QgsFeatureList mFeatures;


### PR DESCRIPTION
By using `show()` instead of `exec()` the `QgsFixAttributeDialog` to fix features on Copy/Paste if the constraints are not fulfilled, the user is able to do stuff meanwhile. Like e.g. create a feature on the parent layer by using the + in the Relation Reference Widget.

Since this fixes a behavior that is not nice I like to backport it as well.