### PR TITLE
WIP Context menu 'Search selected in PyQGIS docs' in Console input and output

### DIFF
--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -19,8 +19,8 @@ email                : lrssvtml (at) gmail (dot) com
 Some portions of code were taken from https://code.google.com/p/pydee/
 """
 
-from qgis.PyQt.QtCore import Qt, QCoreApplication, QThread, QMetaObject, Q_RETURN_ARG, Q_ARG, QObject, pyqtSlot
-from qgis.PyQt.QtGui import QColor, QFont, QKeySequence, QFontDatabase
+from qgis.PyQt.QtCore import Qt, QCoreApplication, QThread, QMetaObject, Q_RETURN_ARG, Q_ARG, QObject, pyqtSlot, QUrl
+from qgis.PyQt.QtGui import QColor, QFont, QKeySequence, QFontDatabase, QDesktopServices
 from qgis.PyQt.QtWidgets import QGridLayout, QSpacerItem, QSizePolicy, QShortcut, QMenu, QApplication
 from qgis.PyQt.Qsci import QsciScintilla, QsciLexerPython
 from qgis.core import Qgis, QgsApplication, QgsSettings
@@ -265,6 +265,7 @@ class ShellOutputScintilla(QsciScintilla):
         iconClear = QgsApplication.getThemeIcon("console/iconClearConsole.svg")
         iconHideTool = QgsApplication.getThemeIcon("console/iconHideToolConsole.svg")
         iconSettings = QgsApplication.getThemeIcon("console/iconSettingsConsole.svg")
+        iconPyQGISHelp = QgsApplication.getThemeIcon("console/iconHelpConsole.svg")
         menu.addAction(iconHideTool,
                        QCoreApplication.translate("PythonConsole", "Hide/Show Toolbar"),
                        self.hideToolBar)
@@ -280,6 +281,9 @@ class ShellOutputScintilla(QsciScintilla):
         clearAction = menu.addAction(iconClear,
                                      QCoreApplication.translate("PythonConsole", "Clear Console"),
                                      self.clearConsole)
+        pyQGISHelpAction = menu.addAction(iconPyQGISHelp,
+                                     QCoreApplication.translate("PythonConsole", "Search Selected in PyQGIS docs"),
+                                     self.searchPyQGIS)
         menu.addSeparator()
         copyAction = menu.addAction(
             QCoreApplication.translate("PythonConsole", "Copy"),
@@ -294,11 +298,13 @@ class ShellOutputScintilla(QsciScintilla):
         runAction.setEnabled(False)
         clearAction.setEnabled(False)
         copyAction.setEnabled(False)
+        pyQGISHelpAction.setEnabled(False)
         selectAllAction.setEnabled(False)
         showEditorAction.setEnabled(True)
         if self.hasSelectedText():
             runAction.setEnabled(True)
             copyAction.setEnabled(True)
+            pyQGISHelpAction.setEnabled(True)
         if not self.text(3) == '':
             selectAllAction.setEnabled(True)
             clearAction.setEnabled(True)
@@ -331,6 +337,13 @@ class ShellOutputScintilla(QsciScintilla):
         cmd = self.selectedText()
         self.shell.insertFromDropPaste(cmd)
         self.shell.entered()
+
+    def searchPyQGIS(self):
+        if self.hasSelectedText():
+            text = self.selectedText()
+            text = text.replace('>>> ', '').replace('... ', '').strip()  # removing prompts
+            version = '.'.join(Qgis.QGIS_VERSION.split('.')[0:2])
+            QDesktopServices.openUrl( QUrl('https://qgis.org/pyqgis/'+version+'/search.html?q='+text) )
 
     def keyPressEvent(self, e):
         # empty text indicates possible shortcut key sequence so stay in output

--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -282,8 +282,8 @@ class ShellOutputScintilla(QsciScintilla):
                                      QCoreApplication.translate("PythonConsole", "Clear Console"),
                                      self.clearConsole)
         pyQGISHelpAction = menu.addAction(iconPyQGISHelp,
-                                     QCoreApplication.translate("PythonConsole", "Search Selected in PyQGIS docs"),
-                                     self.searchPyQGIS)
+                                          QCoreApplication.translate("PythonConsole", "Search Selected in PyQGIS docs"),
+                                          self.searchPyQGIS)
         menu.addSeparator()
         copyAction = menu.addAction(
             QCoreApplication.translate("PythonConsole", "Copy"),
@@ -343,7 +343,7 @@ class ShellOutputScintilla(QsciScintilla):
             text = self.selectedText()
             text = text.replace('>>> ', '').replace('... ', '').strip()  # removing prompts
             version = '.'.join(Qgis.QGIS_VERSION.split('.')[0:2])
-            QDesktopServices.openUrl( QUrl('https://qgis.org/pyqgis/'+version+'/search.html?q='+text) )
+            QDesktopServices.openUrl(QUrl('https://qgis.org/pyqgis/' + version + '/search.html?q=' + text))
 
     def keyPressEvent(self, e):
         # empty text indicates possible shortcut key sequence so stay in output

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -196,7 +196,7 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
             text = self.selectedText()
             text = text.replace('>>> ', '').replace('... ', '').strip()  # removing prompts
             version = '.'.join(Qgis.QGIS_VERSION.split('.')[0:2])
-            QDesktopServices.openUrl( QUrl('https://qgis.org/pyqgis/'+version+'/search.html?q='+text) )
+            QDesktopServices.openUrl(QUrl('https://qgis.org/pyqgis/' + version + '/search.html?q=' + text))
 
     def autoCompleteKeyBinding(self):
         radioButtonSource = self.settings.value("pythonConsole/autoCompleteSource", 'fromAPI')

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -19,10 +19,10 @@ email                : lrssvtml (at) gmail (dot) com
 Some portions of code were taken from https://code.google.com/p/pydee/
 """
 
-from qgis.PyQt.QtCore import Qt, QByteArray, QCoreApplication, QFile, QSize
+from qgis.PyQt.QtCore import Qt, QByteArray, QCoreApplication, QFile, QSize, QUrl
 from qgis.PyQt.QtWidgets import QDialog, QMenu, QShortcut, QApplication
 from qgis.PyQt.QtGui import QColor, QKeySequence, QFont, QFontMetrics, QStandardItemModel, QStandardItem, QClipboard, \
-    QFontDatabase
+    QFontDatabase, QDesktopServices
 from qgis.PyQt.Qsci import QsciScintilla, QsciLexerPython, QsciAPIs
 
 import sys
@@ -190,6 +190,13 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
             self.historyDlg.show()
         self.historyDlg._reloadHistory()
         self.historyDlg.activateWindow()
+
+    def searchPyQGIS(self):
+        if self.hasSelectedText():
+            text = self.selectedText()
+            text = text.replace('>>> ', '').replace('... ', '').strip()  # removing prompts
+            version = '.'.join(Qgis.QGIS_VERSION.split('.')[0:2])
+            QDesktopServices.openUrl( QUrl('https://qgis.org/pyqgis/'+version+'/search.html?q='+text) )
 
     def autoCompleteKeyBinding(self):
         radioButtonSource = self.settings.value("pythonConsole/autoCompleteSource", 'fromAPI')
@@ -542,10 +549,15 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
         pasteAction = menu.addAction(
             QCoreApplication.translate("PythonConsole", "Paste"),
             self.paste, QKeySequence.Paste)
+        pyQGISHelpAction = menu.addAction(
+            QCoreApplication.translate("PythonConsole", "Search Selected in PyQGIS docs"),
+            self.searchPyQGIS)
         copyAction.setEnabled(False)
         pasteAction.setEnabled(False)
+        pyQGISHelpAction.setEnabled(False)
         if self.hasSelectedText():
             copyAction.setEnabled(True)
+            pyQGISHelpAction.setEnabled(True)
         if QApplication.clipboard().text():
             pasteAction.setEnabled(True)
         menu.exec_(self.mapToGlobal(e.pos()))


### PR DESCRIPTION
Was trying out some things in the python console recently and was 'missing' the context help to search for the docs of a certain class or term in qgis.org/pyqgis..

This PR add a 'Search selected in PyQGIS docs' context menu, both in the input and output pane of the Python Console

The selected term (for example 'qgsMapCanvas') will sent you to:

https://qgis.org/pyqgis/master/search.html?q=

So in this case:

https://qgis.org/pyqgis/master/search.html?q=qgsMapCanvas

I started with the output pane (see below) which has an icon in the context menu:

![Screenshot-20200703201050-587x296](https://user-images.githubusercontent.com/731673/86490978-90fdf680-bd69-11ea-89f5-f180b3473f41.png)

Then I did the input pane, which nowhere has icons, so skipped it there also:

![Screenshot-20200703201005-474x230](https://user-images.githubusercontent.com/731673/86490976-8f343300-bd69-11ea-9cac-86b584133ab9.png)

Thinking about adding it in the 'Editor' pane too, IF others are positive about this idea.

This is a quick hack so feel free to discuss or throw away the idea :-)