### PR TITLE
Fix crash in QgsWmsProvider::htmlMetadata if layer is invalid

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2386,15 +2386,15 @@ QString QgsWmsProvider::htmlMetadata()
         metadata += QStringLiteral( "%1:%2<br>" ).arg( it.key(), it.value() );
       }
       metadata += QStringLiteral( "</td></tr>" );
-    }
 
-    // GetFeatureInfo Request Formats
-    metadata += QStringLiteral( "<tr><td>" ) %
-                tr( "Identify Formats" ) %
-                QStringLiteral( "</td>"
-                                "<td>" ) %
-                mTileLayer->infoFormats.join( QStringLiteral( "<br />" ) ) %
-                QStringLiteral( "</td></tr>" );
+      // GetFeatureInfo Request Formats
+      metadata += QStringLiteral( "<tr><td>" ) %
+                  tr( "Identify Formats" ) %
+                  QStringLiteral( "</td>"
+                                  "<td>" ) %
+                  mTileLayer->infoFormats.join( QStringLiteral( "<br />" ) ) %
+                  QStringLiteral( "</td></tr>" );
+    }
   }
   else
   {


### PR DESCRIPTION
Forward ported from https://github.com/kadas-albireo/QGIS/commit/32d39d68fffa431b40b92f13d64501f972d5c654