### PR TITLE
Fix batch panel uses layer ids when auto populating output names based on a layer parameter

### DIFF
--- a/python/plugins/processing/gui/BatchOutputSelectionPanel.py
+++ b/python/plugins/processing/gui/BatchOutputSelectionPanel.py
@@ -33,6 +33,7 @@ from qgis.core import (QgsMapLayer,
                        QgsProcessingParameterMultipleLayers,
                        QgsProcessingParameterBoolean,
                        QgsProcessingParameterEnum,
+                       QgsProject,
                        QgsProcessingParameterMatrix)
 from qgis.PyQt.QtWidgets import QWidget, QPushButton, QLineEdit, QHBoxLayout, QSizePolicy, QFileDialog
 
@@ -108,8 +109,19 @@ class BatchOutputSelectionPanel(QWidget):
                             if isinstance(v, QgsMapLayer):
                                 s = v.name()
                             else:
-                                s = os.path.basename(v)
-                                s = os.path.splitext(s)[0]
+                                if v in QgsProject.instance().mapLayers():
+                                    layer = QgsProject.instance().mapLayer(v)
+                                    # value is a layer ID, but we'd prefer to show a layer name if it's unique in the project
+                                    if len([l for _, l in QgsProject.instance().mapLayers().items() if l.name().lower() == layer.name().lower()]) == 1:
+                                        s = layer.name()
+                                    else:
+                                        # otherwise fall back to layer id
+                                        s = v
+                                else:
+                                    # else try to use file base name
+                                    # TODO: this is bad for database sources!!
+                                    s = os.path.basename(v)
+                                    s = os.path.splitext(s)[0]
                         elif isinstance(param, QgsProcessingParameterBoolean):
                             s = 'true' if v else 'false'
                         elif isinstance(param, QgsProcessingParameterEnum):

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -304,14 +304,6 @@ class BatchPanelFillWidget(QToolButton):
         dlg = MultipleInputDialog([layer.name() for layer in layers])
         dlg.exec_()
 
-        def generate_layer_id(layer):
-            # prefer layer name if unique
-            if len([l for l in layers if l.name().lower() == layer.name().lower()]) == 1:
-                return layer.name()
-            else:
-                # otherwise fall back to layer id
-                return layer.id()
-
         if not dlg.selectedoptions:
             return
 
@@ -321,8 +313,7 @@ class BatchPanelFillWidget(QToolButton):
 
         first_row = self.panel.batchRowCount() if self.panel.batchRowCount() > 1 else 0
         for row, selected_idx in enumerate(selected):
-            layer = layers[selected_idx]
-            value = generate_layer_id(layer)
+            value = layers[selected_idx].id()
             self.setRowValue(first_row + row, value, context)
 
     def calculateByExpression(self):


### PR DESCRIPTION
Fixes #37554
