### PR TITLE
Add explicit include to qgspoint.cpp for Qt 5.15

### DIFF
--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -25,6 +25,7 @@
 
 #include <cmath>
 #include <QPainter>
+#include <QPainterPath>
 #include <QRegularExpression>
 #include <QJsonObject>
 #include <QJsonArray>


### PR DESCRIPTION
This adds explicit include of QPainterPath to
src/core/geometry/qgspoint.cpp so QGIS may be built against Qt 5.15.0.
This is a followup to PR #37548.

Without this include, QGIS won't build against Qt 5.15.0 on Gentoo Linux; it fails with the following snippet:

```
<... snip ...>
/home/jose/sw/qgis/QGIS/src/core/geometry/qgspoint.cpp:324:41: error: return type ‘class QPainterPath’ is incomplete
  324 | QPainterPath QgsPoint::asQPainterPath() const
      |                                         ^~~~~
/home/jose/sw/qgis/QGIS/src/core/geometry/qgspoint.cpp: In member function ‘virtual void QgsPoint::asQPainterPath() const’:
/home/jose/sw/qgis/QGIS/src/core/geometry/qgspoint.cpp:326:23: error: invalid use of incomplete type ‘class QPainterPath’
  326 |   return QPainterPath();
      |                       ^
In file included from /home/jose/sw/qgis/QGIS/src/core/geometry/qgspoint.h:23,
                 from /home/jose/sw/qgis/QGIS/src/core/geometry/qgspoint.cpp:19:
/home/jose/sw/qgis/QGIS/src/core/geometry/qgsabstractgeometry.h:45:7: note: forward declaration of ‘class QPainterPath’
   45 | class QPainterPath;
      |       ^~~~~~~~~~~~
make[2]: *** [src/core/CMakeFiles/qgis_core.dir/build.make:9252: src/core/CMakeFiles/qgis_core.dir/geometry/qgspoint.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
<... snip ...>
```

I understand this header file also exists on Qt 5.12, so this should do no harm. @nyalldawson , since you submitted/merged #37548 , can you take a look? Thanks.