### PR TITLE
Load processing results to layer group (optional)

### DIFF
--- a/python/plugins/processing/core/ProcessingConfig.py
+++ b/python/plugins/processing/core/ProcessingConfig.py
@@ -62,6 +62,7 @@ class ProcessingConfig:
     DEFAULT_OUTPUT_RASTER_LAYER_EXT = 'DefaultOutputRasterLayerExt'
     DEFAULT_OUTPUT_VECTOR_LAYER_EXT = 'DefaultOutputVectorLayerExt'
     TEMP_PATH = 'TEMP_PATH2'
+    RESULTS_GROUP_NAME = 'RESULTS_GROUP_NAME'
 
     settings = {}
     settingIcons = {}
@@ -172,6 +173,13 @@ class ProcessingConfig:
             ProcessingConfig.TEMP_PATH,
             ProcessingConfig.tr('Override temporary output folder path (leave blank for default)'), None,
             valuetype=Setting.FOLDER))
+
+        ProcessingConfig.addSetting(Setting(
+            ProcessingConfig.tr('General'),
+            ProcessingConfig.RESULTS_GROUP_NAME,
+            ProcessingConfig.tr("Results group name"),
+            "",
+            valuetype=Setting.STRING))
 
     @staticmethod
     def setGroupIcon(group, icon):

--- a/python/plugins/processing/core/ProcessingConfig.py
+++ b/python/plugins/processing/core/ProcessingConfig.py
@@ -171,15 +171,18 @@ class ProcessingConfig:
         ProcessingConfig.addSetting(Setting(
             ProcessingConfig.tr('General'),
             ProcessingConfig.TEMP_PATH,
-            ProcessingConfig.tr('Override temporary output folder path (leave blank for default)'), None,
-            valuetype=Setting.FOLDER))
+            ProcessingConfig.tr('Override temporary output folder path'), None,
+            valuetype=Setting.FOLDER,
+            placeholder=ProcessingConfig.tr('Leave blank for default')))
 
         ProcessingConfig.addSetting(Setting(
             ProcessingConfig.tr('General'),
             ProcessingConfig.RESULTS_GROUP_NAME,
             ProcessingConfig.tr("Results group name"),
             "",
-            valuetype=Setting.STRING))
+            valuetype=Setting.STRING,
+            placeholder=ProcessingConfig.tr("Leave blank to avoid loading results in a predetermined group")
+        ))
 
     @staticmethod
     def setGroupIcon(group, icon):
@@ -266,7 +269,7 @@ class Setting:
     MULTIPLE_FOLDERS = 6
 
     def __init__(self, group, name, description, default, hidden=False, valuetype=None,
-                 validator=None, options=None):
+                 validator=None, options=None, placeholder=""):
         self.group = group
         self.name = name
         self.qname = "Processing/Configuration/" + self.name
@@ -275,6 +278,7 @@ class Setting:
         self.hidden = hidden
         self.valuetype = valuetype
         self.options = options
+        self.placeholder = placeholder
 
         if self.valuetype is None:
             if isinstance(default, int):

--- a/python/plugins/processing/gui/ConfigDialog.py
+++ b/python/plugins/processing/gui/ConfigDialog.py
@@ -366,15 +366,15 @@ class SettingDelegate(QStyledItemDelegate):
     def createEditor(self, parent, options, index):
         setting = index.model().data(index, Qt.UserRole)
         if setting.valuetype == Setting.FOLDER:
-            return FileDirectorySelector(parent)
+            return FileDirectorySelector(parent, placeholder=setting.placeholder)
         elif setting.valuetype == Setting.FILE:
-            return FileDirectorySelector(parent, True)
+            return FileDirectorySelector(parent, True, setting.placeholder)
         elif setting.valuetype == Setting.SELECTION:
             combo = QComboBox(parent)
             combo.addItems(setting.options)
             return combo
         elif setting.valuetype == Setting.MULTIPLE_FOLDERS:
-            return MultipleDirectorySelector(parent)
+            return MultipleDirectorySelector(parent, setting.placeholder)
         else:
             value = self.convertValue(index.model().data(index, Qt.EditRole))
             if isinstance(value, int):
@@ -387,7 +387,9 @@ class SettingDelegate(QStyledItemDelegate):
                 spnBox.setDecimals(6)
                 return spnBox
             elif isinstance(value, str):
-                return QLineEdit(parent)
+                lineEdit = QLineEdit(parent)
+                lineEdit.setPlaceholderText(setting.placeholder)
+                return lineEdit
 
     def setEditorData(self, editor, index):
         value = self.convertValue(index.model().data(index, Qt.EditRole))
@@ -433,13 +435,14 @@ class SettingDelegate(QStyledItemDelegate):
 
 class FileDirectorySelector(QWidget):
 
-    def __init__(self, parent=None, selectFile=False):
+    def __init__(self, parent=None, selectFile=False, placeholder=""):
         QWidget.__init__(self, parent)
 
         # create gui
         self.btnSelect = QToolButton()
         self.btnSelect.setText('…')
         self.lineEdit = QLineEdit()
+        self.lineEdit.setPlaceholderText(placeholder)
         self.hbl = QHBoxLayout()
         self.hbl.setMargin(0)
         self.hbl.setSpacing(0)
@@ -480,13 +483,14 @@ class FileDirectorySelector(QWidget):
 
 class MultipleDirectorySelector(QWidget):
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, placeholder=""):
         QWidget.__init__(self, parent)
 
         # create gui
         self.btnSelect = QToolButton()
         self.btnSelect.setText('…')
         self.lineEdit = QLineEdit()
+        self.lineEdit.setPlaceholderText(placeholder)
         self.hbl = QHBoxLayout()
         self.hbl.setMargin(0)
         self.hbl.setSpacing(0)

--- a/python/plugins/processing/gui/Postprocessing.py
+++ b/python/plugins/processing/gui/Postprocessing.py
@@ -93,7 +93,18 @@ def handleAlgorithmResults(alg, context, feedback=None, showResults=True, parame
                 if style:
                     layer.loadNamedStyle(style)
 
-                details.project.addMapLayer(context.temporaryLayerStore().takeMapLayer(layer))
+                # Load layer to layer tree root or to a specific group
+                mapLayer = context.temporaryLayerStore().takeMapLayer(layer)
+                group_name = ProcessingConfig.getSetting(ProcessingConfig.RESULTS_GROUP_NAME)
+                if group_name:
+                    group = details.project.layerTreeRoot().findGroup(group_name)
+                    if not group:
+                        group = details.project.layerTreeRoot().insertGroup(0, group_name)
+
+                    details.project.addMapLayer(mapLayer, False)
+                    group.addLayer(mapLayer)
+                else:
+                    details.project.addMapLayer(mapLayer)
 
                 if details.postProcessor():
                     details.postProcessor().postProcessLayer(layer, context, feedback)


### PR DESCRIPTION
## Description

When running several Processing algorithms (with `Open output file after running algorithm` checked), it is common to end up with an untidy QGIS project. Manual re-arrangement of layers is then required to preserve the original layer tree configuration, which may take some time depending on user expertise.

This PR adds the possibility to set a group name in Processing options to contain all Processing result layers, so that they can be easily located in the layer tree and then turned on/off, removed, exported, among others. 

Screencast:

![processing_results2](https://user-images.githubusercontent.com/652785/95942494-e1ddac00-0da8-11eb-9efe-269b990f8f2c.gif)



