### PR TITLE
Fixes OGC API Features certification

### DIFF
--- a/resources/server/api/ogc/schema.json
+++ b/resources/server/api/ogc/schema.json
@@ -389,7 +389,7 @@
         "description" : "Sort results in descending order, field name must be specified with 'sortby' parameter",
         "required" : false,
         "schema" : {
-          "type" : "bool"
+          "type" : "boolean"
         }
       },
       "relations" : {

--- a/resources/server/api/ogc/schema.json
+++ b/resources/server/api/ogc/schema.json
@@ -376,7 +376,7 @@
       },
       "sortby" : {
         "name" : "sortby",
-        "in" : "path",
+        "in" : "query",
         "description" : "Sort results by the specified field name",
         "required" : false,
         "schema" : {
@@ -385,7 +385,7 @@
       },
       "sortdesc" : {
         "name" : "sortdesc",
-        "in" : "path",
+        "in" : "query",
         "description" : "Sort results in descending order, field name must be specified with 'sortby' parameter",
         "required" : false,
         "schema" : {

--- a/tests/testdata/qgis_server/api/test_wfs3_api_project.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_api_project.json
@@ -135,7 +135,7 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       },
       "sortby": {
         "description": "Sort results by the specified field name",
-        "in": "path",
+        "in": "query",
         "name": "sortby",
         "required": false,
         "schema": {
@@ -144,11 +144,11 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       },
       "sortdesc": {
         "description": "Sort results in descending order, field name must be specified with 'sortby' parameter",
-        "in": "path",
+        "in": "query",
         "name": "sortdesc",
         "required": false,
         "schema": {
-          "type": "bool"
+          "type": "boolean"
         }
       }
     },


### PR DESCRIPTION
## Description

This PR is a follow-up to https://github.com/qgis/QGIS/pull/37429 because OGC API Features certification tests are failing since the merge (cf http://test.qgis.org/ogc_cite/ogcapif/2020_07_06_05_00/report.html):

- [X] ERROR: Value 'bool' does not match required pattern 'boolean|object|array|number|integer|string'
- [x] ERROR: Path param 'sortby' must have 'required' property set true 
- [x] ERROR: Path param 'sortdesc' must have 'required' property set true 

The first issue is fixed but I still have to take a look to others (according to https://apisecurity.io/encyclopedia/content/oasv3/oasconformance/structure/v3-validation-parameter-path-required.htm, a path parameter has to have its property 'required' set to 'true').

