### PR TITLE
DB Connections API: add fields method -> column info

### DIFF
--- a/python/core/auto_generated/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/qgsabstractdatabaseproviderconnection.sip.in
@@ -475,9 +475,16 @@ Raises a QgsProviderConnectionException if any errors are encountered.
    the default implementation creates a temporary vector layer, providers may
    choose to override this method for a greater efficiency.
 
-.. versionadded:: 3.18
+.. versionadded:: 3.16
 
 :raises :: py:class:`QgsProviderConnectionException`
+%End
+
+    QString providerKey() const;
+%Docstring
+Returns the provider key
+
+.. versionadded:: 3.16
 %End
 
   protected:

--- a/python/core/auto_generated/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/qgsabstractdatabaseproviderconnection.sip.in
@@ -234,6 +234,8 @@ This information is calculated from the geometry columns types.
       CreateSpatialIndex,
       SpatialIndexExists,
       DeleteSpatialIndex,
+      DeleteField,
+      CreateField,
     };
 
     typedef QFlags<QgsAbstractDatabaseProviderConnection::Capability> Capabilities;
@@ -459,6 +461,21 @@ Raises a QgsProviderConnectionException if any errors are encountered.
 %Docstring
 Returns information about the existing schemas.
 Raises a QgsProviderConnectionException if any errors are encountered.
+
+:raises :: py:class:`QgsProviderConnectionException`
+%End
+
+    virtual QgsFields fields( const QString &schema, const QString &table ) const throw( QgsProviderConnectionException );
+%Docstring
+Returns the fields of a ``table`` and ``schema``.
+Raises a QgsProviderConnectionException if any errors are encountered.
+
+.. note::
+
+   the default implementation creates a temporary vector layer, providers may
+   choose to override this method for a greater efficiency.
+
+.. versionadded:: 3.18
 
 :raises :: py:class:`QgsProviderConnectionException`
 %End

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -24,6 +24,7 @@
 QgsGeoPackageProviderConnection::QgsGeoPackageProviderConnection( const QString &name )
   : QgsAbstractDatabaseProviderConnection( name )
 {
+  mProviderKey = QStringLiteral( "ogr" );
   setDefaultCapabilities();
   QgsSettings settings;
   settings.beginGroup( QStringLiteral( "ogr" ), QgsSettings::Section::Providers );
@@ -36,6 +37,7 @@ QgsGeoPackageProviderConnection::QgsGeoPackageProviderConnection( const QString 
 QgsGeoPackageProviderConnection::QgsGeoPackageProviderConnection( const QString &uri, const QVariantMap &configuration ):
   QgsAbstractDatabaseProviderConnection( uri, configuration )
 {
+  mProviderKey = QStringLiteral( "ogr" );
   // Cleanup the URI in case it contains other information other than the file path
   if ( uri.contains( '|' ) )
   {

--- a/src/core/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/qgsabstractdatabaseproviderconnection.cpp
@@ -52,6 +52,11 @@ void QgsAbstractDatabaseProviderConnection::checkCapability( QgsAbstractDatabase
     throw QgsProviderConnectionException( QObject::tr( "Operation '%1' is not supported for this connection" ).arg( capName ) );
   }
 }
+
+QString QgsAbstractDatabaseProviderConnection::providerKey() const
+{
+  return mProviderKey;
+}
 ///@endcond
 
 void QgsAbstractDatabaseProviderConnection::createVectorTable( const QString &schema,
@@ -215,7 +220,9 @@ QList<QgsAbstractDatabaseProviderConnection::TableProperty::GeometryColumnType> 
 
 QgsFields QgsAbstractDatabaseProviderConnection::fields( const QString &schema, const QString &tableName ) const
 {
-  QgsVectorLayer vl { tableUri( schema, tableName ), QStringLiteral( "temp_layer" ), mProviderKey };
+  QgsVectorLayer::LayerOptions options { true, true };
+  options.skipCrsValidation = true;
+  QgsVectorLayer vl { tableUri( schema, tableName ), QStringLiteral( "temp_layer" ), mProviderKey, options };
   if ( vl.isValid() )
   {
     return vl.fields();

--- a/src/core/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/qgsabstractdatabaseproviderconnection.cpp
@@ -14,6 +14,7 @@
  *                                                                         *
  ***************************************************************************/
 #include "qgsabstractdatabaseproviderconnection.h"
+#include "qgsvectorlayer.h"
 #include "qgsexception.h"
 #include <QVariant>
 #include <QObject>
@@ -212,6 +213,18 @@ QList<QgsAbstractDatabaseProviderConnection::TableProperty::GeometryColumnType> 
   return mGeometryColumnTypes;
 }
 
+QgsFields QgsAbstractDatabaseProviderConnection::fields( const QString &schema, const QString &tableName ) const
+{
+  QgsVectorLayer vl { tableUri( schema, tableName ), QStringLiteral( "temp_layer" ), mProviderKey };
+  if ( vl.isValid() )
+  {
+    return vl.fields();
+  }
+  else
+  {
+    throw QgsProviderConnectionException( QObject::tr( "Error retrieving fields information for uri: %1" ).arg( vl.publicSource() ) );
+  }
+}
 
 QString QgsAbstractDatabaseProviderConnection::TableProperty::defaultName() const
 {

--- a/src/core/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/qgsabstractdatabaseproviderconnection.h
@@ -501,10 +501,16 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
      * Raises a QgsProviderConnectionException if any errors are encountered.
      * \note the default implementation creates a temporary vector layer, providers may
      * choose to override this method for a greater efficiency.
-     * \since QGIS 3.18
+     * \since QGIS 3.16
      * \throws QgsProviderConnectionException
      */
     virtual QgsFields fields( const QString &schema, const QString &table ) const SIP_THROW( QgsProviderConnectionException );
+
+    /**
+     * Returns the provider key
+     * \since QGIS 3.16
+     */
+    QString providerKey() const;
 
   protected:
 

--- a/src/core/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/qgsabstractdatabaseproviderconnection.h
@@ -293,6 +293,8 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
       CreateSpatialIndex = 1 << 16, //!< The connection can create spatial indices
       SpatialIndexExists = 1 << 17, //!< The connection can determine if a spatial index exists
       DeleteSpatialIndex = 1 << 18, //!< The connection can delete spatial indices for tables
+      DeleteField = 1 << 19,        //!< Can delete an existing field
+      CreateField = 1 << 20,        //!< Can add a new field
     };
 
     Q_ENUM( Capability )
@@ -494,6 +496,16 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
      */
     virtual QStringList schemas() const SIP_THROW( QgsProviderConnectionException );
 
+    /**
+     * Returns the fields of a \a table and \a schema.
+     * Raises a QgsProviderConnectionException if any errors are encountered.
+     * \note the default implementation creates a temporary vector layer, providers may
+     * choose to override this method for a greater efficiency.
+     * \since QGIS 3.18
+     * \throws QgsProviderConnectionException
+     */
+    virtual QgsFields fields( const QString &schema, const QString &table ) const SIP_THROW( QgsProviderConnectionException );
+
   protected:
 
 ///@cond PRIVATE
@@ -506,6 +518,7 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
 ///@endcond
 
     Capabilities mCapabilities = nullptr SIP_SKIP;
+    QString mProviderKey;
 
 };
 

--- a/src/providers/mssql/qgsmssqlproviderconnection.cpp
+++ b/src/providers/mssql/qgsmssqlproviderconnection.cpp
@@ -37,6 +37,7 @@ const QStringList QgsMssqlProviderConnection::EXTRA_CONNECTION_PARAMETERS
 QgsMssqlProviderConnection::QgsMssqlProviderConnection( const QString &name )
   : QgsAbstractDatabaseProviderConnection( name )
 {
+  mProviderKey = QStringLiteral( "mssql" );
   // Remove the sql and table empty parts
   setUri( QgsMssqlConnection::connUri( name ).uri() );
   setDefaultCapabilities();
@@ -45,6 +46,7 @@ QgsMssqlProviderConnection::QgsMssqlProviderConnection( const QString &name )
 QgsMssqlProviderConnection::QgsMssqlProviderConnection( const QString &uri, const QVariantMap &configuration ):
   QgsAbstractDatabaseProviderConnection( QString(), configuration )
 {
+  mProviderKey = QStringLiteral( "mssql" );
   // Additional connection information
   const QgsDataSourceUri inputUri( uri );
   QgsDataSourceUri currentUri { QgsDataSourceUri( uri ).connectionInfo( false ) };

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -29,6 +29,7 @@ extern "C"
 QgsPostgresProviderConnection::QgsPostgresProviderConnection( const QString &name )
   : QgsAbstractDatabaseProviderConnection( name )
 {
+  mProviderKey = QStringLiteral( "postgres" );
   // Remove the sql and table empty parts
   const QRegularExpression removePartsRe { R"raw(\s*sql=\s*|\s*table=""\s*)raw" };
   setUri( QgsPostgresConn::connUri( name ).uri().replace( removePartsRe, QString() ) );
@@ -38,6 +39,7 @@ QgsPostgresProviderConnection::QgsPostgresProviderConnection( const QString &nam
 QgsPostgresProviderConnection::QgsPostgresProviderConnection( const QString &uri, const QVariantMap &configuration ):
   QgsAbstractDatabaseProviderConnection( QgsDataSourceUri( uri ).connectionInfo( false ), configuration )
 {
+  mProviderKey = QStringLiteral( "postgres" );
   setDefaultCapabilities();
 }
 

--- a/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
@@ -25,6 +25,7 @@
 QgsSpatiaLiteProviderConnection::QgsSpatiaLiteProviderConnection( const QString &name )
   : QgsAbstractDatabaseProviderConnection( name )
 {
+  mProviderKey = QStringLiteral( "spatialite" );
   setDefaultCapabilities();
   // TODO: QGIS 4: move into QgsSettings::Section::Providers group
   QgsSettings settings;
@@ -39,6 +40,7 @@ QgsSpatiaLiteProviderConnection::QgsSpatiaLiteProviderConnection( const QString 
 QgsSpatiaLiteProviderConnection::QgsSpatiaLiteProviderConnection( const QString &uri, const QVariantMap &configuration ):
   QgsAbstractDatabaseProviderConnection( uri, configuration )
 {
+  mProviderKey = QStringLiteral( "spatialite" );
   const QRegularExpression removePartsRe { R"raw(\s*sql=\s*|\s*table=""\s*|\([^\)]+\))raw" };
   // Cleanup the URI in case it contains other information other than the file path
   setUri( QString( uri ).replace( removePartsRe, QString() ) );

--- a/tests/src/python/test_qgsproviderconnection_mssql.py
+++ b/tests/src/python/test_qgsproviderconnection_mssql.py
@@ -101,6 +101,14 @@ class TestPyQgsProviderConnectionMssql(unittest.TestCase, TestPyQgsProviderConne
         vl = QgsVectorLayer(conn.tableUri('qgis_test', 'someData'), 'my', 'mssql')
         self.assertTrue(vl.isValid())
 
+    def test_gpkg_fields(self):
+        """Test fields"""
+
+        md = QgsProviderRegistry.instance().providerMetadata('mssql')
+        conn = md.createConnection(self.uri, {})
+        fields = conn.fields('qgis_test', 'someData')
+        self.assertEqual(fields.names(), ['pk', 'cnt', 'name', 'name2', 'num_char'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
+++ b/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
@@ -118,6 +118,14 @@ class TestPyQgsProviderConnectionGpkg(unittest.TestCase, TestPyQgsProviderConnec
         self.assertFalse('myNewTable' in table_names)
         self.assertTrue('myNewAspatialTable' in table_names)
 
+    def test_gpkg_fields(self):
+        """Test fields"""
+
+        md = QgsProviderRegistry.instance().providerMetadata('ogr')
+        conn = md.createConnection(self.uri, {})
+        fields = conn.fields('', 'cdb_lines')
+        self.assertEqual(fields.names(), ['fid', 'id', 'typ', 'name', 'ortsrat', 'id_long'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -317,6 +317,14 @@ IMPORT FOREIGN SCHEMA qgis_test LIMIT TO ( "someData" )
         conn.executeSql(foreign_table_definition)
         self.assertEquals(conn.tables('foreign_schema', QgsAbstractDatabaseProviderConnection.Foreign)[0].tableName(), 'someData')
 
+    def test_fields(self):
+        """Test fields"""
+
+        md = QgsProviderRegistry.instance().providerMetadata('postgres')
+        conn = md.createConnection(self.uri, {})
+        fields = conn.fields('qgis_test', 'someData')
+        self.assertEqual(fields.names(), ['pk', 'cnt', 'name', 'name2', 'num_char', 'dt', 'date', 'time', 'geom'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsproviderconnection_spatialite.py
+++ b/tests/src/python/test_qgsproviderconnection_spatialite.py
@@ -110,6 +110,14 @@ class TestPyQgsProviderConnectionSpatialite(unittest.TestCase, TestPyQgsProvider
         self.assertFalse('myNewTable' in table_names)
         self.assertTrue('myNewAspatialTable' in table_names)
 
+    def test_gpkg_fields(self):
+        """Test fields"""
+
+        md = QgsProviderRegistry.instance().providerMetadata('spatialite')
+        conn = md.createConnection(self.uri, {})
+        fields = conn.fields('', 'cdb_lines')
+        self.assertEqual(fields.names(), ['pk', 'geom', 'fid', 'id', 'typ', 'name', 'ortsrat', 'id_long'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds to the DB connections API a method to retrieve columns information as `QgsFields`.

I though about implementing a separate struct to hold column information but I think `QgsFields` have all the information we need to implement `alter table` instructions. 
I'm not too worried about the "hidden" columns because they are most of the times not modifiable anyway (geometry, PK etc.).

```python
md = QgsProviderRegistry.instance().providerMetadata('mssql')
conn = md.createConnection(self.uri, {})
fields = conn.fields('qgis_test', 'someData')
self.assertEqual(fields.names(), ['pk', 'cnt', 'name', 'name2', 'num_char'])
```

