### PR TITLE
Ensure text format previews are antialiased

### DIFF
--- a/src/core/textrenderer/qgstextformat.cpp
+++ b/src/core/textrenderer/qgstextformat.cpp
@@ -821,6 +821,7 @@ QPixmap QgsTextFormat::textFormatPreviewPixmap( const QgsTextFormat &format, QSi
 
   context.setScaleFactor( QgsApplication::desktop()->logicalDpiX() / 25.4 );
   context.setUseAdvancedEffects( true );
+  context.setFlag( QgsRenderContext::Antialiasing, true );
   context.setPainter( &painter );
 
   // slightly inset text to account for buffer/background

--- a/src/gui/qgsfontbutton.cpp
+++ b/src/gui/qgsfontbutton.cpp
@@ -867,6 +867,7 @@ void QgsFontButton::updatePreview( const QColor &color, QgsTextFormat *format, Q
 
       context.setScaleFactor( QgsApplication::desktop()->logicalDpiX() / 25.4 );
       context.setUseAdvancedEffects( true );
+      context.setFlag( QgsRenderContext::Antialiasing, true );
       context.setPainter( &p );
 
       // slightly inset text to account for buffer/background

--- a/src/gui/qgstextpreview.cpp
+++ b/src/gui/qgstextpreview.cpp
@@ -30,6 +30,8 @@ QgsTextPreview::QgsTextPreview( QWidget *parent )
   mContext.setScaleFactor( QgsApplication::desktop()->logicalDpiX() / 25.4 );
   mContext.setUseAdvancedEffects( true );
 
+  mContext.setFlag( QgsRenderContext::Antialiasing, true );
+
   mContext.setIsGuiPreview( true );
 }
 


### PR DESCRIPTION
Fixes a regression where all text format previews are not antialiased (master only).