### PR TITLE
Use string representation for Color functions example output

### DIFF
--- a/resources/function_help/json/color_cmyk
+++ b/resources/function_help/json/color_cmyk
@@ -7,5 +7,5 @@
                  {"arg":"magenta","description":"magenta component of the color, as a percentage integer value from 0 to 100"},
                  {"arg":"yellow","description":"yellow component of the color, as a percentage integer value from 0 to 100"},
                  {"arg":"black","description":"black component of the color, as a percentage integer value from 0 to 100"}],
-  "examples": [ { "expression":"color_cmyk(100,50,0,10)", "returns":"0,115,230"}]
+  "examples": [ { "expression":"color_cmyk(100,50,0,10)", "returns":"'0,115,230'"}]
 }

--- a/resources/function_help/json/color_cmyka
+++ b/resources/function_help/json/color_cmyka
@@ -8,5 +8,5 @@
                  {"arg":"yellow","description":"yellow component of the color, as a percentage integer value from 0 to 100"},
                  {"arg":"black","description":"black component of the color, as a percentage integer value from 0 to 100"},
                  {"arg":"alpha","description":"alpha component as an integer value from 0 (completely transparent) to 255 (opaque)."}],
-  "examples": [ { "expression":"color_cmyk(100,50,0,10,200)", "returns":"0,115,230,200"}]
+  "examples": [ { "expression":"color_cmyk(100,50,0,10,200)", "returns":"'0,115,230,200'"}]
 }

--- a/resources/function_help/json/color_grayscale_average
+++ b/resources/function_help/json/color_grayscale_average
@@ -6,5 +6,5 @@
   "arguments": [
                {"arg":"color", "description":"a color string"}
 	          ],
-  "examples": [ { "expression":"color_grayscale_average('255,100,50')", "returns":"127,127,127,255"}]
+  "examples": [ { "expression":"color_grayscale_average('255,100,50')", "returns":"'135,135,135,255'"}]
 }

--- a/resources/function_help/json/color_hsl
+++ b/resources/function_help/json/color_hsl
@@ -6,5 +6,5 @@
   "arguments": [ {"arg":"hue","description":"hue of the color, as an integer value from 0 to 360"},
                  {"arg":"saturation","description":"saturation percentage of the color as an integer value from 0 to 100"},
                  {"arg":"lightness","description":"lightness percentage of the color as an integer value from 0 to 100"}],
-  "examples": [ { "expression":"color_hsl(100,50,70)", "returns":"166,217,140"}]
+  "examples": [ { "expression":"color_hsl(100,50,70)", "returns":"'166,217,140'"}]
 }

--- a/resources/function_help/json/color_hsla
+++ b/resources/function_help/json/color_hsla
@@ -7,5 +7,5 @@
                  {"arg":"saturation","description":"saturation percentage of the color as an integer value from 0 to 100"},
                  {"arg":"lightness","description":"lightness percentage of the color as an integer value from 0 to 100"},
                  {"arg":"alpha","description":"alpha component as an integer value from 0 (completely transparent) to 255 (opaque)."}],
-  "examples": [ { "expression":"color_hsla(100,50,70,200)", "returns":"166,217,140,200"}]
+  "examples": [ { "expression":"color_hsla(100,50,70,200)", "returns":"'166,217,140,200'"}]
 }

--- a/resources/function_help/json/color_hsv
+++ b/resources/function_help/json/color_hsv
@@ -6,5 +6,5 @@
   "arguments": [ {"arg":"hue","description":"hue of the color, as an integer value from 0 to 360"},
                  {"arg":"saturation","description":"saturation percentage of the color as an integer value from 0 to 100"},
                  {"arg":"value","description":"value percentage of the color as an integer from 0 to 100"}],
-  "examples": [ { "expression":"color_hsv(40,100,100)", "returns":"255,170,0"}]
+  "examples": [ { "expression":"color_hsv(40,100,100)", "returns":"'255,170,0'"}]
 }

--- a/resources/function_help/json/color_hsva
+++ b/resources/function_help/json/color_hsva
@@ -7,6 +7,6 @@
                  {"arg":"saturation","description":"saturation percentage of the color as an integer value from 0 to 100"},
                  {"arg":"value","description":"value percentage of the color as an integer from 0 to 100"},
                  {"arg":"alpha","description":"alpha component as an integer value from 0 (completely transparent) to 255 (opaque)"}],
-  "examples": [ { "expression":"color_hsva(40,100,100,200)", "returns":"255,170,0,200"}]
+  "examples": [ { "expression":"color_hsva(40,100,100,200)", "returns":"'255,170,0,200'"}]
 }
 

--- a/resources/function_help/json/color_mix_rgb
+++ b/resources/function_help/json/color_mix_rgb
@@ -8,5 +8,5 @@
                {"arg":"color2", "description":"a color string"},
                {"arg":"ratio", "description":"a ratio"}
 	          ],
-  "examples": [ { "expression":"color_mix_rgb('0,0,0','255,255,255',0.5)", "returns":"127,127,127,255"}]
+  "examples": [ { "expression":"color_mix_rgb('0,0,0','255,255,255',0.5)", "returns":"'127,127,127,255'"}]
 }

--- a/resources/function_help/json/color_rgb
+++ b/resources/function_help/json/color_rgb
@@ -6,6 +6,6 @@
   "arguments": [ {"arg":"red","description":"red component as an integer value from 0 to 255"},
                  {"arg":"green","description":"green component as an integer value from 0 to 255"},
                  {"arg":"blue","description":"blue component as an integer value from 0 to 255"}],
-  "examples": [ { "expression":"color_rgb(255,127,0)", "returns":"255,127,0"}]
+  "examples": [ { "expression":"color_rgb(255,127,0)", "returns":"'255,127,0'"}]
 }
 

--- a/resources/function_help/json/color_rgba
+++ b/resources/function_help/json/color_rgba
@@ -7,5 +7,5 @@
                  {"arg":"green","description":"green component as an integer value from 0 to 255"},
                  {"arg":"blue","description":"blue component as an integer value from 0 to 255"},
                  {"arg":"alpha","description":"alpha component as an integer value from 0 (completely transparent) to 255 (opaque)."}],
-  "examples": [ { "expression":"color_rgba(255,127,0,200)", "returns":"255,127,0,200"}]
+  "examples": [ { "expression":"color_rgba(255,127,0,200)", "returns":"'255,127,0,200'"}]
 }

--- a/resources/function_help/json/create_ramp
+++ b/resources/function_help/json/create_ramp
@@ -4,6 +4,6 @@
   "groups": ["Color"],
   "description": "Returns a gradient ramp from a map of color strings and steps.",
   "arguments": [ {"arg":"map","description":"a map of color strings and steps"},
-                 {"arg":"discrete","optional":true,"description":"declare whether the color ramp is discrete"}],
+                 {"arg":"discrete","optional":true,"default":"false","description":"set this parameter to true to create a discrete color ramp"}],
   "examples": [ { "expression":"ramp_color(create_ramp(map(0,'0,0,0',1,'255,0,0')),1)", "returns":"'255,0,0,255'"} ]
 }

--- a/resources/function_help/json/create_ramp
+++ b/resources/function_help/json/create_ramp
@@ -5,5 +5,5 @@
   "description": "Returns a gradient ramp from a map of color strings and steps.",
   "arguments": [ {"arg":"map","description":"a map of color strings and steps"},
                  {"arg":"discrete","optional":true,"description":"declare whether the color ramp is discrete"}],
-  "examples": [ { "expression":"ramp_color(create_array(map(0,'0,0,0',1,'255,0,0')),1)", "returns":"'255,0,0,255'"} ]
+  "examples": [ { "expression":"ramp_color(create_ramp(map(0,'0,0,0',1,'255,0,0')),1)", "returns":"'255,0,0,255'"} ]
 }

--- a/resources/function_help/json/project_color
+++ b/resources/function_help/json/project_color
@@ -4,6 +4,6 @@
   "groups": ["Color"],
   "description": "Returns a color from the project's color scheme.",
   "arguments": [ {"arg":"name","description":"a color name"}],
-  "examples": [ { "expression":"project_color('Logo color')", "returns":"20,140,50"}
+  "examples": [ { "expression":"project_color('Logo color')", "returns":"'20,140,50'"}
   ]
 }

--- a/resources/function_help/json/set_color_part
+++ b/resources/function_help/json/set_color_part
@@ -8,5 +8,5 @@
 	{"arg":"component", "description":"a string corresponding to the color component to set. Valid options are:<br /><ul><li>red: RGB red component (0-255)</li><li>green: RGB green component (0-255)</li><li>blue: RGB blue component (0-255)</li><li>alpha: alpha (transparency) value (0-255)</li><li>hue: HSV hue (0-360)</li><li>saturation: HSV saturation (0-100)</li><li>value: HSV value (0-100)</li><li>hsl_hue: HSL hue (0-360)</li><li>hsl_saturation: HSL saturation (0-100)</li><li>lightness: HSL lightness (0-100)</li><li>cyan: CMYK cyan component (0-100)</li><li>magenta: CMYK magenta component (0-100)</li><li>yellow: CMYK yellow component (0-100)</li> <li>black: CMYK black component (0-100)</li></ul>"},
 	{"arg":"value", "description":"new value for color component, respecting the ranges listed above"}
 	          ],
-  "examples": [ { "expression":"set_color_part('200,10,30','green',50)", "returns":"'200,50,30'"}]
+  "examples": [ { "expression":"set_color_part('200,10,30','green',50)", "returns":"'200,50,30,255'"}]
 }

--- a/resources/function_help/json/set_color_part
+++ b/resources/function_help/json/set_color_part
@@ -8,5 +8,5 @@
 	{"arg":"component", "description":"a string corresponding to the color component to set. Valid options are:<br /><ul><li>red: RGB red component (0-255)</li><li>green: RGB green component (0-255)</li><li>blue: RGB blue component (0-255)</li><li>alpha: alpha (transparency) value (0-255)</li><li>hue: HSV hue (0-360)</li><li>saturation: HSV saturation (0-100)</li><li>value: HSV value (0-100)</li><li>hsl_hue: HSL hue (0-360)</li><li>hsl_saturation: HSL saturation (0-100)</li><li>lightness: HSL lightness (0-100)</li><li>cyan: CMYK cyan component (0-100)</li><li>magenta: CMYK magenta component (0-100)</li><li>yellow: CMYK yellow component (0-100)</li> <li>black: CMYK black component (0-100)</li></ul>"},
 	{"arg":"value", "description":"new value for color component, respecting the ranges listed above"}
 	          ],
-  "examples": [ { "expression":"set_color_part('200,10,30','green',50)", "returns":"200,50,30"}]
+  "examples": [ { "expression":"set_color_part('200,10,30','green',50)", "returns":"'200,50,30'"}]
 }


### PR DESCRIPTION
instead of comma separated integers