### PR TITLE
[Backport release-3_14]  Return on shortcut paste when layer not editable

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10251,19 +10251,25 @@ void QgisApp::pasteFromClipboard( QgsMapLayer *destinationLayer )
 
 void QgisApp::pasteFeatures( QgsVectorLayer *pasteVectorLayer, int invalidGeometriesCount, int nTotalFeatures, QgsFeatureList &features )
 {
-  pasteVectorLayer->addFeatures( features );
-  QgsFeatureIds newIds;
-  newIds.reserve( features.size() );
-  for ( const QgsFeature &f : qgis::as_const( features ) )
+  int nCopiedFeatures = features.count();
+  if ( pasteVectorLayer->addFeatures( features ) )
   {
-    newIds << f.id();
-  }
+    QgsFeatureIds newIds;
+    newIds.reserve( features.size() );
+    for ( const QgsFeature &f : qgis::as_const( features ) )
+    {
+      newIds << f.id();
+    }
 
-  pasteVectorLayer->selectByIds( newIds );
+    pasteVectorLayer->selectByIds( newIds );
+  }
+  else
+  {
+    nCopiedFeatures = 0;
+  }
   pasteVectorLayer->endEditCommand();
   pasteVectorLayer->updateExtents();
 
-  int nCopiedFeatures = features.count();
   Qgis::MessageLevel level = ( nCopiedFeatures == 0 || invalidGeometriesCount > 0 ) ? Qgis::Warning : Qgis::Info;
   QString message;
   if ( nCopiedFeatures == 0 )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10081,6 +10081,14 @@ void QgisApp::cutSelectionToClipboard( QgsMapLayer *layerContainingSelection )
   if ( !selectionVectorLayer )
     return;
 
+  if ( !selectionVectorLayer->isEditable() )
+  {
+    visibleMessageBar()->pushMessage( tr( "Layer not editable" ),
+                                      tr( "The current layer is not editable. Choose 'Start editing' in the digitizing toolbar." ),
+                                      Qgis::Info, messageTimeout() );
+    return;
+  }
+
   clipboard()->replaceWithCopyOf( selectionVectorLayer );
 
   selectionVectorLayer->beginEditCommand( tr( "Features cut" ) );
@@ -10108,6 +10116,14 @@ void QgisApp::pasteFromClipboard( QgsMapLayer *destinationLayer )
   QgsVectorLayer *pasteVectorLayer = qobject_cast<QgsVectorLayer *>( destinationLayer ? destinationLayer : activeLayer() );
   if ( !pasteVectorLayer )
     return;
+
+  if ( !pasteVectorLayer->isEditable() )
+  {
+    visibleMessageBar()->pushMessage( tr( "Layer not editable" ),
+                                      tr( "The current layer is not editable. Choose 'Start editing' in the digitizing toolbar." ),
+                                      Qgis::Info, messageTimeout() );
+    return;
+  }
 
   pasteVectorLayer->beginEditCommand( tr( "Features pasted" ) );
   QgsFeatureList features = clipboard()->transformedCopyOf( pasteVectorLayer->crs(), pasteVectorLayer->fields() );


### PR DESCRIPTION
Manual backport from #37672 without feedback texts with translation

On Copy / Paste pasting with the shortcut (Ctrl-V) to a layer that is not editable, it did nothing but give the message "x features pasted" as feedback. Now on shortcut paste (and on shortcut cut (Ctrl-X)) we give the feedback that the layer is not editable (like on shortcut delete).

This issue has been mentioned here #37617 (comment) but is not directly related to the the attribute-fix implementation.

Additionally I improved some feedback messages.
