### PR TITLE
digitizing and splitting feature with curves

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -284,6 +284,7 @@
         <file>themes/default/mActionDeleteTable.svg</file>
         <file>themes/default/mActionDeselectAll.svg</file>
         <file>themes/default/mActionDeselectActiveLayer.svg</file>
+        <file>themes/default/mActionDigitizeWithCurve.svg</file>
         <file>themes/default/mActionDuplicateLayer.svg</file>
         <file>themes/default/mActionDuplicateComposer.svg</file>
         <file>themes/default/mActionEditCopy.svg</file>

--- a/images/themes/default/mActionDigitizeWithCurve.svg
+++ b/images/themes/default/mActionDigitizeWithCurve.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   viewBox="0 0 24 24"
+   width="24"
+   version="1.1"
+   id="svg3811"
+   sodipodi:docname="mActionDigitizeWithCurve.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata3817">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3815" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1051"
+     id="namedview3813"
+     showgrid="false"
+     inkscape:zoom="20.108349"
+     inkscape:cx="-0.57970588"
+     inkscape:cy="12.518898"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3811" />
+  <path
+     style="fill:none;stroke:#8cbe8c;stroke-width:1.4;stroke-miterlimit:4;stroke-dasharray:2.8,1.4;stroke-dashoffset:0"
+     inkscape:connector-curvature="0"
+     id="path3787"
+     d="m 4.5166046,21.5 c -6.5,-13.5 3.5,-23.5 16.9999994,-16.999999" />
+  <g
+     style="fill:#bebebe;stroke:#8c8c8c"
+     id="g3805"
+     transform="translate(0,-8)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path3799"
+       d="m 18.5,10.5 h 3 v 3 h -3 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3801"
+       d="m 4.5,11.5 h 3 v 3 h -3 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3803"
+       d="m 2.5,27.5 h 3 v 3 h -3 z" />
+  </g>
+</svg>

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -884,6 +884,21 @@ Example:
       > LineStringZ (2749549.12 1262908.38 125.14, 2749557.82 1262920.06 200)
 %End
 
+    OperationResult splitGeometry( const QgsCurve *curve,  QVector<QgsGeometry> &newGeometries /Out/, bool preserveCircular, bool topological, QgsPointSequence &topologyTestPoints /Out/, bool splitFeature = true );
+%Docstring
+Splits this geometry according to a given curve.
+
+:param curve: the curve that splits the geometry
+\param[out] newGeometries list of new geometries that have been created with the ``splitLine``. If the geometry is 3D, a linear interpolation of the z value is performed on the geometry at split points, see example.
+:param preserveCircular: whether if circular strings are preserved after splitting
+:param topological: ``True`` if topological editing is enabled
+\param[out] topologyTestPoints points that need to be tested for topological completeness in the dataset
+:param splitFeature: Set to True if you want to split a feature, otherwise set to False to split parts
+                     fix this bug?
+
+:return: OperationResult a result code: success or reason of failure
+%End
+
     OperationResult reshapeGeometry( const QgsLineString &reshapeLineString );
 %Docstring
 Replaces a part of this geometry with another line

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -894,7 +894,6 @@ Splits this geometry according to a given curve.
 :param topological: ``True`` if topological editing is enabled
 \param[out] topologyTestPoints points that need to be tested for topological completeness in the dataset
 :param splitFeature: Set to True if you want to split a feature, otherwise set to False to split parts
-                     fix this bug?
 
 :return: OperationResult a result code: success or reason of failure
 

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -897,6 +897,8 @@ Splits this geometry according to a given curve.
                      fix this bug?
 
 :return: OperationResult a result code: success or reason of failure
+
+.. versionadded:: 3.16
 %End
 
     OperationResult reshapeGeometry( const QgsLineString &reshapeLineString );

--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -526,6 +526,13 @@ transform point coordinates from layer's CRS to output CRS
 :return: the transformed point
 %End
 
+    QgsPoint layerToMapCoordinates( const QgsMapLayer *layer, QgsPoint point ) const;
+%Docstring
+transform point coordinates from layer's CRS to output CRS
+
+:return: the transformed point
+%End
+
     QgsRectangle layerToMapCoordinates( const QgsMapLayer *layer, QgsRectangle rect ) const;
 %Docstring
 transform rectangle from layer's CRS to output CRS
@@ -536,6 +543,13 @@ transform rectangle from layer's CRS to output CRS
 %End
 
     QgsPointXY mapToLayerCoordinates( const QgsMapLayer *layer, QgsPointXY point ) const;
+%Docstring
+transform point coordinates from output CRS to layer's CRS
+
+:return: the transformed point
+%End
+
+    QgsPoint mapToLayerCoordinates( const QgsMapLayer *layer, QgsPoint point ) const;
 %Docstring
 transform point coordinates from output CRS to layer's CRS
 

--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -531,6 +531,8 @@ transform point coordinates from layer's CRS to output CRS
 transform point coordinates from layer's CRS to output CRS
 
 :return: the transformed point
+
+.. versionadded:: 3.16
 %End
 
     QgsRectangle layerToMapCoordinates( const QgsMapLayer *layer, QgsRectangle rect ) const;
@@ -554,6 +556,8 @@ transform point coordinates from output CRS to layer's CRS
 transform point coordinates from output CRS to layer's CRS
 
 :return: the transformed point
+
+.. versionadded:: 3.16
 %End
 
     QgsRectangle mapToLayerCoordinates( const QgsMapLayer *layer, QgsRectangle rect ) const;

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -1603,6 +1603,32 @@ Splits features cut by the given line
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
 %End
 
+    QgsGeometry::OperationResult splitFeatures( const QgsCurve *curve, bool preserveCircular = false, bool topologicalEditing = false );
+%Docstring
+Splits features cut by the given curve
+
+:param curve: curve that splits the layer features
+:param preserveCircular: whether if circular strings are preserved after splitting
+:param topologicalEditing: ``True`` if topological editing is enabled
+
+:return: QgsGeometry.OperationResult
+
+         - Success
+         - NothingHappened
+         - LayerNotEditable
+         - InvalidInputGeometryType
+         - InvalidBaseGeometry
+         - GeometryEngineError
+         - SplitCannotSplitPoint
+
+.. note::
+
+   Calls to :py:func:`~QgsVectorLayer.splitFeatures` are only valid for layers in which edits have been enabled
+   by a call to :py:func:`~QgsVectorLayer.startEditing`. Changes made to features using this method are not committed
+   to the underlying data provider until a :py:func:`~QgsVectorLayer.commitChanges` call is made. Any uncommitted
+   changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
+%End
+
     int addTopologicalPoints( const QgsGeometry &geom );
 %Docstring
 Adds topological points for every vertex of the geometry.

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -1627,6 +1627,8 @@ Splits features cut by the given curve
    by a call to :py:func:`~QgsVectorLayer.startEditing`. Changes made to features using this method are not committed
    to the underlying data provider until a :py:func:`~QgsVectorLayer.commitChanges` call is made. Any uncommitted
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
+
+.. versionadded:: 3.16
 %End
 
     int addTopologicalPoints( const QgsGeometry &geom );

--- a/python/core/auto_generated/qgsvectorlayereditutils.sip.in
+++ b/python/core/auto_generated/qgsvectorlayereditutils.sip.in
@@ -233,6 +233,8 @@ Splits features cut by the given curve
 
 :return: 0 in case of success,
          4 if there is a selection but no feature split
+
+.. versionadded:: 3.16
 %End
 
     int addTopologicalPoints( const QgsGeometry &geom );

--- a/python/core/auto_generated/qgsvectorlayereditutils.sip.in
+++ b/python/core/auto_generated/qgsvectorlayereditutils.sip.in
@@ -223,6 +223,18 @@ Splits features cut by the given line
          4 if there is a selection but no feature split
 %End
 
+    QgsGeometry::OperationResult splitFeatures( const QgsCurve *curve, bool preserveCircular = false, bool topologicalEditing = false );
+%Docstring
+Splits features cut by the given curve
+
+:param curve: line that splits the layer features
+:param preserveCircular: whether if circular strings are preserved after splitting
+:param topologicalEditing: ``True`` if topological editing is enabled
+
+:return: 0 in case of success,
+         4 if there is a selection but no feature split
+%End
+
     int addTopologicalPoints( const QgsGeometry &geom );
 %Docstring
 Adds topological points for every vertex of the geometry.

--- a/python/gui/auto_generated/qgsgeometryrubberband.sip.in
+++ b/python/gui/auto_generated/qgsgeometryrubberband.sip.in
@@ -101,6 +101,11 @@ Sets whether the vertices are drawn
 Returns which geometry is handled by the rubber band, polygon or line
 %End
 
+    void setGeometryType( const QgsWkbTypes::GeometryType &geometryType );
+%Docstring
+Sets which geometry is handled by the rubber band, polygon or line
+%End
+
 };
 
 

--- a/python/gui/auto_generated/qgsgeometryrubberband.sip.in
+++ b/python/gui/auto_generated/qgsgeometryrubberband.sip.in
@@ -87,7 +87,7 @@ Sets brush style
 %Docstring
 Sets vertex marker icon type
 %End
-    void setIsVerticesDrawn( bool isVerticesDrawn );
+    void setVertexDrawingEnabled( bool isVerticesDrawn );
 %Docstring
 Sets whether the vertices are drawn
 %End

--- a/python/gui/auto_generated/qgsgeometryrubberband.sip.in
+++ b/python/gui/auto_generated/qgsgeometryrubberband.sip.in
@@ -49,7 +49,7 @@ A rubberband class for QgsAbstractGeometry (considering curved geometries)*
     };
 
     QgsGeometryRubberBand( QgsMapCanvas *mapCanvas, QgsWkbTypes::GeometryType geomType = QgsWkbTypes::LineGeometry );
-    virtual ~QgsGeometryRubberBand();
+    ~QgsGeometryRubberBand();
 
     virtual void setGeometry( QgsAbstractGeometry *geom /Transfer/ );
 %Docstring
@@ -95,7 +95,11 @@ Sets whether the vertices are drawn
   protected:
     virtual void paint( QPainter *painter );
 
+
     QgsWkbTypes::GeometryType geometryType() const;
+%Docstring
+Returns which geometry is handled by the rubber band, polygon or line
+%End
 
 };
 

--- a/python/gui/auto_generated/qgsgeometryrubberband.sip.in
+++ b/python/gui/auto_generated/qgsgeometryrubberband.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 %ModuleHeaderCode
 // For ConvertToSubClassCode.
 #include <qgsgeometryrubberband.h>
@@ -48,9 +49,9 @@ A rubberband class for QgsAbstractGeometry (considering curved geometries)*
     };
 
     QgsGeometryRubberBand( QgsMapCanvas *mapCanvas, QgsWkbTypes::GeometryType geomType = QgsWkbTypes::LineGeometry );
-    ~QgsGeometryRubberBand();
+    virtual ~QgsGeometryRubberBand();
 
-    void setGeometry( QgsAbstractGeometry *geom /Transfer/ );
+    virtual void setGeometry( QgsAbstractGeometry *geom /Transfer/ );
 %Docstring
 Sets geometry (takes ownership). Geometry is expected to be in map coordinates
 %End
@@ -86,12 +87,18 @@ Sets brush style
 %Docstring
 Sets vertex marker icon type
 %End
+    void setIsVerticesDrawn( bool isVerticesDrawn );
+%Docstring
+Sets whether the vertices are drawn
+%End
 
   protected:
     virtual void paint( QPainter *painter );
 
+    QgsWkbTypes::GeometryType geometryType() const;
 
 };
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/gui/auto_generated/qgsmaptool.sip.in
+++ b/python/gui/auto_generated/qgsmaptool.sip.in
@@ -255,6 +255,11 @@ transformation from screen coordinates to layer's coordinates
 transformation from map coordinates to layer's coordinates
 %End
 
+    QgsPoint toLayerCoordinates( const QgsMapLayer *layer, const QgsPoint &point );
+%Docstring
+transformation from map coordinates to layer's coordinates
+%End
+
     QgsPointXY toMapCoordinates( const QgsMapLayer *layer, const QgsPointXY &point );
 %Docstring
 transformation from layer's coordinates to map coordinates (which is different in case reprojection is used)

--- a/python/gui/auto_generated/qgsmaptool.sip.in
+++ b/python/gui/auto_generated/qgsmaptool.sip.in
@@ -255,11 +255,6 @@ transformation from screen coordinates to layer's coordinates
 transformation from map coordinates to layer's coordinates
 %End
 
-    QgsPoint toLayerCoordinates( const QgsMapLayer *layer, const QgsPoint &point );
-%Docstring
-transformation from map coordinates to layer's coordinates
-%End
-
     QgsPointXY toMapCoordinates( const QgsMapLayer *layer, const QgsPointXY &point );
 %Docstring
 transformation from layer's coordinates to map coordinates (which is different in case reprojection is used)

--- a/python/gui/auto_generated/qgsmaptoolcapture.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolcapture.sip.in
@@ -119,9 +119,9 @@ transfers ownership to the caller.
 %End
 
   public slots:
-    void toggleLinearCircularDigitizing();
+    void setCircularDigitizingEnable( bool enable );
 %Docstring
-Changes the digitizing shape to linear or circular
+Enable the digitizing with curve
 %End
 
   protected:

--- a/python/gui/auto_generated/qgsmaptoolcapture.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolcapture.sip.in
@@ -119,7 +119,7 @@ transfers ownership to the caller.
 %End
 
   public slots:
-    void setCircularDigitizingEnable( bool enable );
+    void setCircularDigitizingEnabled( bool enable );
 %Docstring
 Enable the digitizing with curve
 %End

--- a/python/gui/auto_generated/qgsmaptoolcapture.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolcapture.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 class QgsMapToolCapture : QgsMapToolAdvancedDigitizing
 {
 
@@ -115,6 +116,9 @@ transfers ownership to the caller.
 
 .. versionadded:: 3.8
 %End
+
+  public slots:
+    void toggleLinearCircularDigitizing();
 
   protected:
 

--- a/python/gui/auto_generated/qgsmaptoolcapture.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolcapture.sip.in
@@ -12,6 +12,7 @@
 
 
 
+
 class QgsMapToolCapture : QgsMapToolAdvancedDigitizing
 {
 
@@ -119,6 +120,9 @@ transfers ownership to the caller.
 
   public slots:
     void toggleLinearCircularDigitizing();
+%Docstring
+Changes the digitizing shape to linear or circular
+%End
 
   protected:
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9926,9 +9926,8 @@ void QgisApp::snappingOptions()
 
 void QgisApp::enableDigitizeWithCurve( bool enable )
 {
-  mMapTools.mAddFeature->setCircularDigitizingEnable( enable );
-  static_cast<QgsMapToolCapture *>( mMapTools.mSplitFeatures )->setCircularDigitizingEnable( enable );
-  static_cast<QgsMapToolCapture *>( mMapTools.mReshapeFeatures )->setCircularDigitizingEnable( enable );
+  mMapTools.mAddFeature->setCircularDigitizingEnabled( enable );
+  static_cast<QgsMapToolCapture *>( mMapTools.mSplitFeatures )->setCircularDigitizingEnabled( enable );
   QgsSettings settings;
   settings.setValue( QStringLiteral( "UI/digitizeWithCurve" ), enable ? 1 : 0 );
 }
@@ -9941,7 +9940,6 @@ void QgisApp::enableDigitizeWithCurveAction( bool enable )
   if ( sender && sender != this )
     enable &= ( sender == mActionAddFeature && mMapTools.mAddFeature->mode() != QgsMapToolCapture::CapturePoint ) ||
               sender == mActionSplitFeatures;
-
   else
     enable &= ( mMapCanvas->mapTool() == mMapTools.mAddFeature && mMapTools.mAddFeature->mode() != QgsMapToolCapture::CapturePoint ) ||
               mMapCanvas->mapTool() == mMapTools.mSplitFeatures;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1571,6 +1571,11 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   QShortcut *shortcutTracing = new QShortcut( QKeySequence( tr( "Ctrl+Shift+." ) ), this );
   connect( shortcutTracing, &QShortcut::activated, this, &QgisApp::toggleEventTracing );
 
+  QShortcut *shortcutToggleLinearCircularDigitizing = new QShortcut( QKeySequence( tr( "Ctrl+Shift+G" ) ), this );
+  connect( shortcutToggleLinearCircularDigitizing, &QShortcut::activated, mMapTools.mAddFeature, &QgsMapToolCapture::toggleLinearCircularDigitizing );
+  connect( shortcutToggleLinearCircularDigitizing, &QShortcut::activated,
+           static_cast<QgsMapToolSplitFeatures *>( mMapTools.mSplitFeatures ), &QgsMapToolCapture::toggleLinearCircularDigitizing );
+
   if ( ! QTouchDevice::devices().isEmpty() )
   {
     //add reacting to long click in touch

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1855,6 +1855,18 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Enable or disable event tracing (for debugging)
     void toggleEventTracing();
 
+    /**
+     * Enables or disables digitizing with curve for map tool that support this capabilities
+     * \since QGIS 3.16
+     */
+    void enableDigitizeWithCurve( bool enable );
+
+    /**
+     * Enables the action that allows to enable or disable digitizing with curve
+     * \since QGIS 3.16
+     */
+    void enableDigitizeWithCurveAction( bool enable );
+
 #ifdef HAVE_GEOREFERENCER
     void showGeoreferencer();
 #endif

--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -94,7 +94,7 @@ void QgsMapToolSplitFeatures::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     //bring up dialog if a split was not possible (polygon) or only done once (line)
     int topologicalEditing = QgsProject::instance()->topologicalEditing();
     vlayer->beginEditCommand( tr( "Features split" ) );
-    QgsGeometry::OperationResult returnCode = vlayer->splitFeatures( pointsZM(), topologicalEditing );
+    QgsGeometry::OperationResult returnCode = vlayer->splitFeatures( captureCurve(), true, topologicalEditing );
     vlayer->endEditCommand();
     if ( returnCode == QgsGeometry::OperationResult::NothingHappened )
     {

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -881,6 +881,26 @@ QgsGeometry::OperationResult QgsGeometry::splitGeometry( const QgsPointSequence 
   return QgsGeometry::NothingHappened;
 }
 
+QgsGeometry::OperationResult QgsGeometry::splitGeometry( const QgsCurve *curve, QVector<QgsGeometry> &newGeometries, bool preserveCircular, bool topological, QgsPointSequence &topologyTestPoints, bool splitFeature )
+{
+  std::unique_ptr<QgsLineString> segmentizedLine( curve->curveToLine() );
+  QgsPointSequence points;
+  segmentizedLine->points( points );
+  QgsGeometry::OperationResult result = splitGeometry( points, newGeometries, topological, topologyTestPoints, splitFeature );
+
+  if ( result == QgsGeometry::Success )
+  {
+    if ( preserveCircular )
+    {
+      for ( int i = 0; i < newGeometries.count(); ++i )
+        newGeometries[i] = newGeometries[i].convertToCurves();
+      *this = convertToCurves();
+    }
+  }
+
+  return result;
+}
+
 QgsGeometry::OperationResult QgsGeometry::reshapeGeometry( const QgsLineString &reshapeLineString )
 {
   if ( !d->geometry )

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -47,6 +47,7 @@ class QgsMapToPixel;
 class QPainter;
 class QgsPolygon;
 class QgsLineString;
+class QgsCurve;
 class QgsFeedback;
 
 /**
@@ -910,6 +911,19 @@ class CORE_EXPORT QgsGeometry
      * \endcode
      */
     OperationResult splitGeometry( const QgsPointSequence &splitLine, QVector<QgsGeometry> &newGeometries SIP_OUT, bool topological, QgsPointSequence &topologyTestPoints SIP_OUT, bool splitFeature = true );
+
+    /**
+     * Splits this geometry according to a given curve.
+     * \param curve the curve that splits the geometry
+     * \param[out] newGeometries list of new geometries that have been created with the ``splitLine``. If the geometry is 3D, a linear interpolation of the z value is performed on the geometry at split points, see example.
+     * \param preserveCircular whether if circular strings are preserved after splitting
+     * \param topological TRUE if topological editing is enabled
+     * \param[out] topologyTestPoints points that need to be tested for topological completeness in the dataset
+     * \param splitFeature Set to True if you want to split a feature, otherwise set to False to split parts
+     * fix this bug?
+     * \returns OperationResult a result code: success or reason of failure
+     */
+    OperationResult splitGeometry( const QgsCurve *curve,  QVector<QgsGeometry> &newGeometries SIP_OUT, bool preserveCircular, bool topological, QgsPointSequence &topologyTestPoints SIP_OUT, bool splitFeature = true );
 
     /**
      * Replaces a part of this geometry with another line

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -920,7 +920,6 @@ class CORE_EXPORT QgsGeometry
      * \param topological TRUE if topological editing is enabled
      * \param[out] topologyTestPoints points that need to be tested for topological completeness in the dataset
      * \param splitFeature Set to True if you want to split a feature, otherwise set to False to split parts
-     * fix this bug?
      * \returns OperationResult a result code: success or reason of failure
      * \since QGIS 3.16
      */

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -922,6 +922,7 @@ class CORE_EXPORT QgsGeometry
      * \param splitFeature Set to True if you want to split a feature, otherwise set to False to split parts
      * fix this bug?
      * \returns OperationResult a result code: success or reason of failure
+     * \since QGIS 3.16
      */
     OperationResult splitGeometry( const QgsCurve *curve,  QVector<QgsGeometry> &newGeometries SIP_OUT, bool preserveCircular, bool topological, QgsPointSequence &topologyTestPoints SIP_OUT, bool splitFeature = true );
 

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -495,6 +495,26 @@ QgsPointXY QgsMapSettings::layerToMapCoordinates( const QgsMapLayer *layer, QgsP
   return point;
 }
 
+QgsPoint QgsMapSettings::layerToMapCoordinates( const QgsMapLayer *layer, QgsPoint point ) const
+{
+  double x = point.x();
+  double y = point.y();
+  double z = point.z();
+
+  try
+  {
+    QgsCoordinateTransform ct = layerTransform( layer );
+    if ( ct.isValid() )
+      ct.transformInPlace( x, y, z, QgsCoordinateTransform::ForwardTransform );
+  }
+  catch ( QgsCsException &cse )
+  {
+    QgsMessageLog::logMessage( QObject::tr( "Transform error caught: %1" ).arg( cse.what() ), QObject::tr( "CRS" ) );
+  }
+
+  return QgsPoint( x, y, z );
+}
+
 
 QgsRectangle QgsMapSettings::layerToMapCoordinates( const QgsMapLayer *layer, QgsRectangle rect ) const
 {
@@ -527,6 +547,26 @@ QgsPointXY QgsMapSettings::mapToLayerCoordinates( const QgsMapLayer *layer, QgsP
   }
 
   return point;
+}
+
+QgsPoint QgsMapSettings::mapToLayerCoordinates( const QgsMapLayer *layer, QgsPoint point ) const
+{
+  double x = point.x();
+  double y = point.y();
+  double z = point.z();
+
+  try
+  {
+    QgsCoordinateTransform ct = layerTransform( layer );
+    if ( ct.isValid() )
+      ct.transformInPlace( x, y, z, QgsCoordinateTransform::ReverseTransform );
+  }
+  catch ( QgsCsException &cse )
+  {
+    QgsMessageLog::logMessage( QObject::tr( "Transform error caught: %1" ).arg( cse.what() ), QObject::tr( "CRS" ) );
+  }
+
+  return QgsPoint( x, y, z );
 }
 
 

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -466,6 +466,7 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
     /**
      * \brief transform point coordinates from layer's CRS to output CRS
      * \returns the transformed point
+     * \since QGIS 3.16
      */
     QgsPoint layerToMapCoordinates( const QgsMapLayer *layer, QgsPoint point ) const;
 
@@ -485,6 +486,7 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
     /**
      * \brief transform point coordinates from output CRS to layer's CRS
      * \returns the transformed point
+     * \since QGIS 3.16
      */
     QgsPoint mapToLayerCoordinates( const QgsMapLayer *layer, QgsPoint point ) const;
 

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -464,6 +464,12 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
     QgsPointXY layerToMapCoordinates( const QgsMapLayer *layer, QgsPointXY point ) const;
 
     /**
+     * \brief transform point coordinates from layer's CRS to output CRS
+     * \returns the transformed point
+     */
+    QgsPoint layerToMapCoordinates( const QgsMapLayer *layer, QgsPoint point ) const;
+
+    /**
      * \brief transform rectangle from layer's CRS to output CRS
      * \see layerExtentToOutputExtent() if you want to transform a bounding box
      * \returns the transformed rectangle
@@ -475,6 +481,12 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
      * \returns the transformed point
      */
     QgsPointXY mapToLayerCoordinates( const QgsMapLayer *layer, QgsPointXY point ) const;
+
+    /**
+     * \brief transform point coordinates from output CRS to layer's CRS
+     * \returns the transformed point
+     */
+    QgsPoint mapToLayerCoordinates( const QgsMapLayer *layer, QgsPoint point ) const;
 
     /**
      * \brief transform rectangle from output CRS to layer's CRS

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1370,11 +1370,17 @@ QgsGeometry::OperationResult QgsVectorLayer::splitFeatures( const QVector<QgsPoi
 
 QgsGeometry::OperationResult QgsVectorLayer::splitFeatures( const QgsPointSequence &splitLine, bool topologicalEditing )
 {
+  QgsLineString splitLineString( splitLine );
+  return splitFeatures( &splitLineString, topologicalEditing );
+}
+
+QgsGeometry::OperationResult QgsVectorLayer::splitFeatures( const QgsCurve *curve, bool preserveCircular, bool topologicalEditing )
+{
   if ( !mValid || !mEditBuffer || !mDataProvider )
     return QgsGeometry::OperationResult::LayerNotEditable;
 
   QgsVectorLayerEditUtils utils( this );
-  return utils.splitFeatures( splitLine, topologicalEditing );
+  return utils.splitFeatures( curve, preserveCircular, topologicalEditing );
 }
 
 int QgsVectorLayer::addTopologicalPoints( const QgsGeometry &geom )

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1548,6 +1548,28 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     Q_INVOKABLE QgsGeometry::OperationResult splitFeatures( const QgsPointSequence &splitLine, bool topologicalEditing = false );
 
     /**
+     * Splits features cut by the given curve
+     * \param curve curve that splits the layer features
+     * \param preserveCircular whether if circular strings are preserved after splitting
+     * \param topologicalEditing TRUE if topological editing is enabled
+     * \returns QgsGeometry::OperationResult
+     *
+     * - Success
+     * - NothingHappened
+     * - LayerNotEditable
+     * - InvalidInputGeometryType
+     * - InvalidBaseGeometry
+     * - GeometryEngineError
+     * - SplitCannotSplitPoint
+     *
+     * \note Calls to splitFeatures() are only valid for layers in which edits have been enabled
+     * by a call to startEditing(). Changes made to features using this method are not committed
+     * to the underlying data provider until a commitChanges() call is made. Any uncommitted
+     * changes can be discarded by calling rollBack().
+     */
+    Q_INVOKABLE QgsGeometry::OperationResult splitFeatures( const QgsCurve *curve, bool preserveCircular = false, bool topologicalEditing = false );
+
+    /**
      * Adds topological points for every vertex of the geometry.
      * \param geom the geometry where each vertex is added to segments of other features
      * \returns 0 in case of success

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1566,6 +1566,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * by a call to startEditing(). Changes made to features using this method are not committed
      * to the underlying data provider until a commitChanges() call is made. Any uncommitted
      * changes can be discarded by calling rollBack().
+     * \since QGIS 3.16
      */
     Q_INVOKABLE QgsGeometry::OperationResult splitFeatures( const QgsCurve *curve, bool preserveCircular = false, bool topologicalEditing = false );
 

--- a/src/core/qgsvectorlayereditutils.cpp
+++ b/src/core/qgsvectorlayereditutils.cpp
@@ -296,10 +296,15 @@ QgsGeometry::OperationResult QgsVectorLayerEditUtils::splitFeatures( const QVect
 
 QgsGeometry::OperationResult QgsVectorLayerEditUtils::splitFeatures( const QgsPointSequence &splitLine, bool topologicalEditing )
 {
+  QgsLineString lineString( splitLine );
+  return splitFeatures( &lineString, false, topologicalEditing );
+}
+
+QgsGeometry::OperationResult QgsVectorLayerEditUtils::splitFeatures( const QgsCurve *curve, bool preserveCircular, bool topologicalEditing )
+{
   if ( !mLayer->isSpatial() )
     return QgsGeometry::InvalidBaseGeometry;
 
-  double xMin, yMin, xMax, yMax;
   QgsRectangle bBox; //bounding box of the split line
   QgsGeometry::OperationResult returnCode = QgsGeometry::OperationResult::Success;
   QgsGeometry::OperationResult splitFunctionReturn; //return code of QgsGeometry::splitGeometry
@@ -314,17 +319,8 @@ QgsGeometry::OperationResult QgsVectorLayerEditUtils::splitFeatures( const QgsPo
   }
   else //else consider all the feature that intersect the bounding box of the split line
   {
-    if ( boundingBoxFromPointList( splitLine, xMin, yMin, xMax, yMax ) )
-    {
-      bBox.setXMinimum( xMin );
-      bBox.setYMinimum( yMin );
-      bBox.setXMaximum( xMax );
-      bBox.setYMaximum( yMax );
-    }
-    else
-    {
-      return QgsGeometry::OperationResult::InvalidInputGeometryType;
-    }
+
+    bBox = curve->boundingBox();
 
     if ( bBox.isEmpty() )
     {
@@ -365,7 +361,7 @@ QgsGeometry::OperationResult QgsVectorLayerEditUtils::splitFeatures( const QgsPo
     QVector<QgsGeometry> newGeometries;
     QgsPointSequence topologyTestPoints;
     QgsGeometry featureGeom = feat.geometry();
-    splitFunctionReturn = featureGeom.splitGeometry( splitLine, newGeometries, topologicalEditing, topologyTestPoints );
+    splitFunctionReturn = featureGeom.splitGeometry( curve, newGeometries, preserveCircular, topologicalEditing, topologyTestPoints );
     if ( splitFunctionReturn == QgsGeometry::OperationResult::Success )
     {
       //change this geometry

--- a/src/core/qgsvectorlayereditutils.h
+++ b/src/core/qgsvectorlayereditutils.h
@@ -204,6 +204,16 @@ class CORE_EXPORT QgsVectorLayerEditUtils
     QgsGeometry::OperationResult splitFeatures( const QgsPointSequence &splitLine, bool topologicalEditing = false );
 
     /**
+     * Splits features cut by the given curve
+     * \param curve line that splits the layer features
+     * \param preserveCircular whether if circular strings are preserved after splitting
+     * \param topologicalEditing TRUE if topological editing is enabled
+     * \returns 0 in case of success,
+     *  4 if there is a selection but no feature split
+     */
+    QgsGeometry::OperationResult splitFeatures( const QgsCurve *curve, bool preserveCircular = false, bool topologicalEditing = false );
+
+    /**
      * Adds topological points for every vertex of the geometry.
      * \param geom the geometry where each vertex is added to segments of other features
      * \return 0 in case of success

--- a/src/core/qgsvectorlayereditutils.h
+++ b/src/core/qgsvectorlayereditutils.h
@@ -210,6 +210,7 @@ class CORE_EXPORT QgsVectorLayerEditUtils
      * \param topologicalEditing TRUE if topological editing is enabled
      * \returns 0 in case of success,
      *  4 if there is a selection but no feature split
+     * \since QGIS 3.16
      */
     QgsGeometry::OperationResult splitFeatures( const QgsCurve *curve, bool preserveCircular = false, bool topologicalEditing = false );
 

--- a/src/gui/qgsgeometryrubberband.cpp
+++ b/src/gui/qgsgeometryrubberband.cpp
@@ -160,7 +160,7 @@ void QgsGeometryRubberBand::setBrushStyle( Qt::BrushStyle brushStyle )
   mBrush.setStyle( brushStyle );
 }
 
-void QgsGeometryRubberBand::setIsVerticesDrawn( bool isVerticesDrawn )
+void QgsGeometryRubberBand::setVertexDrawingEnabled( bool isVerticesDrawn )
 {
   mDrawVertices = isVerticesDrawn;
 }

--- a/src/gui/qgsgeometryrubberband.cpp
+++ b/src/gui/qgsgeometryrubberband.cpp
@@ -75,6 +75,11 @@ QgsWkbTypes::GeometryType QgsGeometryRubberBand::geometryType() const
   return mGeometryType;
 }
 
+void QgsGeometryRubberBand::setGeometryType( const QgsWkbTypes::GeometryType &geometryType )
+{
+  mGeometryType = geometryType;
+}
+
 void QgsGeometryRubberBand::drawVertex( QPainter *p, double x, double y )
 {
   qreal s = ( mIconSize - 1 ) / 2.0;

--- a/src/gui/qgsgeometryrubberband.cpp
+++ b/src/gui/qgsgeometryrubberband.cpp
@@ -30,7 +30,6 @@ QgsGeometryRubberBand::QgsGeometryRubberBand( QgsMapCanvas *mapCanvas, QgsWkbTyp
 
 QgsGeometryRubberBand::~QgsGeometryRubberBand()
 {
-  delete mGeometry;
 }
 
 void QgsGeometryRubberBand::paint( QPainter *painter )
@@ -59,6 +58,9 @@ void QgsGeometryRubberBand::paint( QPainter *painter )
   paintGeom->transform( mMapCanvas->getCoordinateTransform()->transform() );
   paintGeom->draw( *painter );
 
+  if ( !mDrawVertices )
+    return;
+
   //draw vertices
   QgsVertexId vertexId;
   QgsPoint vertex;
@@ -66,6 +68,11 @@ void QgsGeometryRubberBand::paint( QPainter *painter )
   {
     drawVertex( painter, vertex.x(), vertex.y() );
   }
+}
+
+QgsWkbTypes::GeometryType QgsGeometryRubberBand::geometryType() const
+{
+  return mGeometryType;
 }
 
 void QgsGeometryRubberBand::drawVertex( QPainter *p, double x, double y )
@@ -106,8 +113,7 @@ void QgsGeometryRubberBand::drawVertex( QPainter *p, double x, double y )
 
 void QgsGeometryRubberBand::setGeometry( QgsAbstractGeometry *geom )
 {
-  delete mGeometry;
-  mGeometry = geom;
+  mGeometry.reset( geom );
 
   if ( mGeometry )
   {
@@ -147,6 +153,11 @@ void QgsGeometryRubberBand::setLineStyle( Qt::PenStyle penStyle )
 void QgsGeometryRubberBand::setBrushStyle( Qt::BrushStyle brushStyle )
 {
   mBrush.setStyle( brushStyle );
+}
+
+void QgsGeometryRubberBand::setIsVerticesDrawn( bool isVerticesDrawn )
+{
+  mDrawVertices = isVerticesDrawn;
 }
 
 QgsRectangle QgsGeometryRubberBand::rubberBandRectangle() const

--- a/src/gui/qgsgeometryrubberband.h
+++ b/src/gui/qgsgeometryrubberband.h
@@ -113,7 +113,7 @@ class GUI_EXPORT QgsGeometryRubberBand: public QgsMapCanvasItem
     //! Sets vertex marker icon type
     void setIconType( IconType iconType ) { mIconType = iconType; }
     //! Sets whether the vertices are drawn
-    void setIsVerticesDrawn( bool isVerticesDrawn );
+    void setVertexDrawingEnabled( bool isVerticesDrawn );
 
   protected:
     void paint( QPainter *painter ) override;

--- a/src/gui/qgsgeometryrubberband.h
+++ b/src/gui/qgsgeometryrubberband.h
@@ -117,6 +117,8 @@ class GUI_EXPORT QgsGeometryRubberBand: public QgsMapCanvasItem
 
   protected:
     void paint( QPainter *painter ) override;
+
+    //! Returns which geometry is handled by the rubber band, polygon or line
     QgsWkbTypes::GeometryType geometryType() const;
 
   private:

--- a/src/gui/qgsgeometryrubberband.h
+++ b/src/gui/qgsgeometryrubberband.h
@@ -24,6 +24,12 @@
 #include <QPen>
 #include "qgis_gui.h"
 
+#include "qgscompoundcurve.h"
+#include "qgscurvepolygon.h"
+#include "qgscircularstring.h"
+#include "qgslinestring.h"
+#include "qgspoint.h"
+
 #ifdef SIP_RUN
 % ModuleHeaderCode
 // For ConvertToSubClassCode.
@@ -86,12 +92,12 @@ class GUI_EXPORT QgsGeometryRubberBand: public QgsMapCanvasItem
     };
 
     QgsGeometryRubberBand( QgsMapCanvas *mapCanvas, QgsWkbTypes::GeometryType geomType = QgsWkbTypes::LineGeometry );
-    ~QgsGeometryRubberBand() override;
+    virtual ~QgsGeometryRubberBand() override;
 
     //! Sets geometry (takes ownership). Geometry is expected to be in map coordinates
-    void setGeometry( QgsAbstractGeometry *geom SIP_TRANSFER );
+    virtual void setGeometry( QgsAbstractGeometry *geom SIP_TRANSFER );
     //! Returns a pointer to the geometry
-    const QgsAbstractGeometry *geometry() { return mGeometry; }
+    const QgsAbstractGeometry *geometry() { return mGeometry.get(); }
     //! Moves vertex to new position (in map coordinates)
     void moveVertex( QgsVertexId id, const QgsPoint &newPos );
     //! Sets fill color for vertex markers
@@ -106,20 +112,25 @@ class GUI_EXPORT QgsGeometryRubberBand: public QgsMapCanvasItem
     void setBrushStyle( Qt::BrushStyle brushStyle );
     //! Sets vertex marker icon type
     void setIconType( IconType iconType ) { mIconType = iconType; }
+    //! Sets whether the vertices are drawn
+    void setIsVerticesDrawn( bool isVerticesDrawn );
 
   protected:
     void paint( QPainter *painter ) override;
+    QgsWkbTypes::GeometryType geometryType() const;
 
   private:
-    QgsAbstractGeometry *mGeometry = nullptr;
+    std::unique_ptr<QgsAbstractGeometry> mGeometry = nullptr;
     QBrush mBrush;
     QPen mPen;
     int mIconSize;
     IconType mIconType;
     QgsWkbTypes::GeometryType mGeometryType;
+    bool mDrawVertices = true;
 
     void drawVertex( QPainter *p, double x, double y );
     QgsRectangle rubberBandRectangle() const;
 };
+
 
 #endif // QGSGEOMETRYRUBBERBAND_H

--- a/src/gui/qgsgeometryrubberband.h
+++ b/src/gui/qgsgeometryrubberband.h
@@ -92,7 +92,7 @@ class GUI_EXPORT QgsGeometryRubberBand: public QgsMapCanvasItem
     };
 
     QgsGeometryRubberBand( QgsMapCanvas *mapCanvas, QgsWkbTypes::GeometryType geomType = QgsWkbTypes::LineGeometry );
-    virtual ~QgsGeometryRubberBand() override;
+    ~QgsGeometryRubberBand() override;
 
     //! Sets geometry (takes ownership). Geometry is expected to be in map coordinates
     virtual void setGeometry( QgsAbstractGeometry *geom SIP_TRANSFER );

--- a/src/gui/qgsgeometryrubberband.h
+++ b/src/gui/qgsgeometryrubberband.h
@@ -121,6 +121,9 @@ class GUI_EXPORT QgsGeometryRubberBand: public QgsMapCanvasItem
     //! Returns which geometry is handled by the rubber band, polygon or line
     QgsWkbTypes::GeometryType geometryType() const;
 
+    //! Sets which geometry is handled by the rubber band, polygon or line
+    void setGeometryType( const QgsWkbTypes::GeometryType &geometryType );
+
   private:
     std::unique_ptr<QgsAbstractGeometry> mGeometry = nullptr;
     QBrush mBrush;

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -59,11 +59,6 @@ QgsPointXY QgsMapTool::toLayerCoordinates( const QgsMapLayer *layer, const QgsPo
   return mCanvas->mapSettings().mapToLayerCoordinates( layer, point );
 }
 
-QgsPoint QgsMapTool::toLayerCoordinates( const QgsMapLayer *layer, const QgsPoint &point )
-{
-  return mCanvas->mapSettings().mapToLayerCoordinates( layer, point );
-}
-
 QgsPointXY QgsMapTool::toMapCoordinates( const QgsMapLayer *layer, const QgsPointXY &point )
 {
   return mCanvas->mapSettings().layerToMapCoordinates( layer, point );

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -38,7 +38,6 @@ QgsMapTool::~QgsMapTool()
     mCanvas->unsetMapTool( this );
 }
 
-
 QgsPointXY QgsMapTool::toMapCoordinates( QPoint point )
 {
   return mCanvas->getCoordinateTransform()->toMapCoordinates( point );
@@ -46,10 +45,8 @@ QgsPointXY QgsMapTool::toMapCoordinates( QPoint point )
 
 QgsPoint QgsMapTool::toMapCoordinates( const QgsMapLayer *layer, const QgsPoint &point )
 {
-  QgsPointXY result = mCanvas->mapSettings().layerToMapCoordinates( layer, QgsPointXY( point.x(), point.y() ) );
-  return QgsPoint( result );
+  return mCanvas->mapSettings().layerToMapCoordinates( layer, point );
 }
-
 
 QgsPointXY QgsMapTool::toLayerCoordinates( const QgsMapLayer *layer, QPoint point )
 {
@@ -58,6 +55,11 @@ QgsPointXY QgsMapTool::toLayerCoordinates( const QgsMapLayer *layer, QPoint poin
 }
 
 QgsPointXY QgsMapTool::toLayerCoordinates( const QgsMapLayer *layer, const QgsPointXY &point )
+{
+  return mCanvas->mapSettings().mapToLayerCoordinates( layer, point );
+}
+
+QgsPoint QgsMapTool::toLayerCoordinates( const QgsMapLayer *layer, const QgsPoint &point )
 {
   return mCanvas->mapSettings().mapToLayerCoordinates( layer, point );
 }

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -240,9 +240,6 @@ class GUI_EXPORT QgsMapTool : public QObject
     //! transformation from map coordinates to layer's coordinates
     QgsPointXY toLayerCoordinates( const QgsMapLayer *layer, const QgsPointXY &point );
 
-    //! transformation from map coordinates to layer's coordinates
-    QgsPoint toLayerCoordinates( const QgsMapLayer *layer, const QgsPoint &point );
-
     //!transformation from layer's coordinates to map coordinates (which is different in case reprojection is used)
     QgsPointXY toMapCoordinates( const QgsMapLayer *layer, const QgsPointXY &point );
 

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -240,6 +240,9 @@ class GUI_EXPORT QgsMapTool : public QObject
     //! transformation from map coordinates to layer's coordinates
     QgsPointXY toLayerCoordinates( const QgsMapLayer *layer, const QgsPointXY &point );
 
+    //! transformation from map coordinates to layer's coordinates
+    QgsPoint toLayerCoordinates( const QgsMapLayer *layer, const QgsPoint &point );
+
     //!transformation from layer's coordinates to map coordinates (which is different in case reprojection is used)
     QgsPointXY toMapCoordinates( const QgsMapLayer *layer, const QgsPointXY &point );
 

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -574,7 +574,17 @@ int QgsMapToolCapture::addVertex( const QgsPointXY &point, const QgsPointLocator
     {
       const QgsCurve *curve = mTempRubberBand->curve();
       if ( curve )
+      {
         addCurve( curve->clone() );
+        // add curve append only invalid match to mSnappingMatches,
+        // so we need to remove one and add the one from here if it is valid
+        if ( match.isValid() && mSnappingMatches.count() > 0 && !mSnappingMatches.last().isValid() )
+        {
+          mSnappingMatches.removeLast();
+          mSnappingMatches.append( match );
+        }
+      }
+
       mTempRubberBand->reset( mCaptureMode == CapturePolygon ? QgsWkbTypes::PolygonGeometry : QgsWkbTypes::LineGeometry );
       if ( mCaptureMode == CapturePolygon )
       {

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -349,13 +349,9 @@ QgsRubberBand *QgsMapToolCapture::takeRubberBand()
   return mRubberBand.release();
 }
 
-void QgsMapToolCapture::toggleLinearCircularDigitizing()
+void QgsMapToolCapture::setCircularDigitizingEnable( bool enable )
 {
-  if ( mDigitizingType == QgsWkbTypes::LineString )
-    mDigitizingType = QgsWkbTypes::CircularString ;
-  else
-    mDigitizingType = QgsWkbTypes::LineString;
-
+  mDigitizingType = enable ? QgsWkbTypes::CircularString : QgsWkbTypes::LineString;
   if ( mTempRubberBand )
     mTempRubberBand->setStringType( mDigitizingType );
 }
@@ -716,7 +712,8 @@ void QgsMapToolCapture::undo()
       mCaptureCurve.deleteVertex( vertexToRemove );
       int pointsCountAfter = mCaptureCurve.numPoints();
       for ( ; pointsCountAfter < pointsCountBefore; pointsCountAfter++ )
-        mSnappingMatches.removeLast();
+        if ( !mSnappingMatches.empty() )
+          mSnappingMatches.removeLast();
     }
 
     updateExtraSnapLayer();

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -151,21 +151,12 @@ bool QgsMapToolCapture::tracingEnabled()
 
 QgsPointXY QgsMapToolCapture::tracingStartPoint()
 {
-//There is already a try/catch in the toLayerCoordinate() method if transform fails. Can we remove this try/catch?
-  try
-  {
-    // if we have starting point from previous trace, then preferably use that one
-    // (useful when tracing with offset)
-    if ( mTracingStartPoint != QgsPointXY() )
-      return mTracingStartPoint;
+  // if we have starting point from previous trace, then preferably use that one
+  // (useful when tracing with offset)
+  if ( mTracingStartPoint != QgsPointXY() )
+    return mTracingStartPoint;
 
-    return lastCapturedMapPoint();
-  }
-  catch ( QgsCsException & )
-  {
-    QgsDebugMsg( QStringLiteral( "transformation to layer coordinate failed" ) );
-    return QgsPointXY();
-  }
+  return lastCapturedMapPoint();
 }
 
 
@@ -305,10 +296,10 @@ bool QgsMapToolCapture::tracingAddVertex( const QgsPointXY &point )
   return true;
 }
 
-QgsMapToolCaptureRubberband *QgsMapToolCapture::createCurveRubberBand() const
+QgsMapToolCaptureRubberBand *QgsMapToolCapture::createCurveRubberBand() const
 {
   QgsSettings settings;
-  QgsMapToolCaptureRubberband *rb = new QgsMapToolCaptureRubberband( mCanvas );
+  QgsMapToolCaptureRubberBand *rb = new QgsMapToolCaptureRubberBand( mCanvas );
   QColor color = digitizingStrokeColor();
 
   double alphaScale = settings.value( QStringLiteral( "qgis/digitizing/line_color_alpha_scale" ), 0.75 ).toDouble();
@@ -349,7 +340,7 @@ QgsRubberBand *QgsMapToolCapture::takeRubberBand()
   return mRubberBand.release();
 }
 
-void QgsMapToolCapture::setCircularDigitizingEnable( bool enable )
+void QgsMapToolCapture::setCircularDigitizingEnabled( bool enable )
 {
   mDigitizingType = enable ? QgsWkbTypes::CircularString : QgsWkbTypes::LineString;
   if ( mTempRubberBand )
@@ -995,13 +986,13 @@ void QgsMapToolCapture::updateExtraSnapLayer()
   }
 }
 
-QgsMapToolCaptureRubberband::QgsMapToolCaptureRubberband( QgsMapCanvas *mapCanvas, QgsWkbTypes::GeometryType geomType ):
+QgsMapToolCaptureRubberBand::QgsMapToolCaptureRubberBand( QgsMapCanvas *mapCanvas, QgsWkbTypes::GeometryType geomType ):
   QgsGeometryRubberBand( mapCanvas, geomType )
 {
-  setIsVerticesDrawn( false );
+  setVertexDrawingEnabled( false );
 }
 
-QgsCurve *QgsMapToolCaptureRubberband::curve()
+QgsCurve *QgsMapToolCaptureRubberBand::curve()
 {
   if ( mPoints.empty() )
     return nullptr;
@@ -1024,13 +1015,13 @@ QgsCurve *QgsMapToolCaptureRubberband::curve()
   }
 }
 
-bool QgsMapToolCaptureRubberband::curveIsComplete() const
+bool QgsMapToolCaptureRubberBand::curveIsComplete() const
 {
   return ( mStringType == QgsWkbTypes::LineString && mPoints.count() > 1 ) ||
          ( mStringType == QgsWkbTypes::CircularString && mPoints.count() > 2 );
 }
 
-void QgsMapToolCaptureRubberband::reset( QgsWkbTypes::GeometryType geomType, QgsWkbTypes::Type stringType,  const QgsPoint &firstPolygonPoint )
+void QgsMapToolCaptureRubberBand::reset( QgsWkbTypes::GeometryType geomType, QgsWkbTypes::Type stringType,  const QgsPoint &firstPolygonPoint )
 {
   if ( !( geomType == QgsWkbTypes::LineGeometry || geomType == QgsWkbTypes::PolygonGeometry ) )
     return;
@@ -1041,13 +1032,13 @@ void QgsMapToolCaptureRubberband::reset( QgsWkbTypes::GeometryType geomType, Qgs
   setRubberBandGeometryType( geomType );
 }
 
-void QgsMapToolCaptureRubberband::setRubberBandGeometryType( QgsWkbTypes::GeometryType geomType )
+void QgsMapToolCaptureRubberBand::setRubberBandGeometryType( QgsWkbTypes::GeometryType geomType )
 {
   QgsGeometryRubberBand::setGeometryType( geomType );
   updateCurve();
 }
 
-void QgsMapToolCaptureRubberband::addPoint( const QgsPoint &point, bool doUpdate )
+void QgsMapToolCaptureRubberBand::addPoint( const QgsPoint &point, bool doUpdate )
 {
   if ( mPoints.count() == 0 )
     mPoints.append( point );
@@ -1058,7 +1049,7 @@ void QgsMapToolCaptureRubberband::addPoint( const QgsPoint &point, bool doUpdate
     updateCurve();
 }
 
-void QgsMapToolCaptureRubberband::movePoint( const QgsPoint &point )
+void QgsMapToolCaptureRubberBand::movePoint( const QgsPoint &point )
 {
   if ( mPoints.count() > 0 )
     mPoints.last() = point ;
@@ -1066,7 +1057,7 @@ void QgsMapToolCaptureRubberband::movePoint( const QgsPoint &point )
   updateCurve();
 }
 
-void QgsMapToolCaptureRubberband::movePoint( int index, const QgsPoint &point )
+void QgsMapToolCaptureRubberBand::movePoint( int index, const QgsPoint &point )
 {
   if ( mPoints.count() > 0 && mPoints.size() > index )
     mPoints[index] = point;
@@ -1074,17 +1065,17 @@ void QgsMapToolCaptureRubberband::movePoint( int index, const QgsPoint &point )
   updateCurve();
 }
 
-int QgsMapToolCaptureRubberband::pointsCount()
+int QgsMapToolCaptureRubberBand::pointsCount()
 {
   return mPoints.size();
 }
 
-QgsWkbTypes::Type QgsMapToolCaptureRubberband::stringType() const
+QgsWkbTypes::Type QgsMapToolCaptureRubberBand::stringType() const
 {
   return mStringType;
 }
 
-void QgsMapToolCaptureRubberband::setStringType( const QgsWkbTypes::Type &type )
+void QgsMapToolCaptureRubberBand::setStringType( const QgsWkbTypes::Type &type )
 {
   if ( ( type != QgsWkbTypes::CircularString && type != QgsWkbTypes::LineString ) || type == mStringType )
     return;
@@ -1095,11 +1086,11 @@ void QgsMapToolCaptureRubberband::setStringType( const QgsWkbTypes::Type &type )
     mPoints.removeAt( 1 );
   }
 
-  setIsVerticesDrawn( type == QgsWkbTypes::CircularString );
+  setVertexDrawingEnabled( type == QgsWkbTypes::CircularString );
   updateCurve();
 }
 
-QgsPoint QgsMapToolCaptureRubberband::lastPoint() const
+QgsPoint QgsMapToolCaptureRubberBand::lastPoint() const
 {
   if ( mPoints.empty() )
     return QgsPoint();
@@ -1107,7 +1098,7 @@ QgsPoint QgsMapToolCaptureRubberband::lastPoint() const
   return mPoints.last();
 }
 
-QgsPoint QgsMapToolCaptureRubberband::pointFromEnd( int posFromEnd ) const
+QgsPoint QgsMapToolCaptureRubberBand::pointFromEnd( int posFromEnd ) const
 {
   if ( posFromEnd < mPoints.size() )
     return mPoints.at( mPoints.size() - 1 - posFromEnd );
@@ -1115,7 +1106,7 @@ QgsPoint QgsMapToolCaptureRubberband::pointFromEnd( int posFromEnd ) const
     return QgsPoint();
 }
 
-void QgsMapToolCaptureRubberband::removeLastPoint()
+void QgsMapToolCaptureRubberBand::removeLastPoint()
 {
   if ( mPoints.count() > 1 )
     mPoints.removeLast();
@@ -1123,12 +1114,12 @@ void QgsMapToolCaptureRubberband::removeLastPoint()
   updateCurve();
 }
 
-void QgsMapToolCaptureRubberband::setGeometry( QgsAbstractGeometry *geom )
+void QgsMapToolCaptureRubberBand::setGeometry( QgsAbstractGeometry *geom )
 {
   QgsGeometryRubberBand::setGeometry( geom );
 }
 
-void QgsMapToolCaptureRubberband::updateCurve()
+void QgsMapToolCaptureRubberBand::updateCurve()
 {
   std::unique_ptr<QgsCurve> curve;
   switch ( mStringType )
@@ -1156,7 +1147,7 @@ void QgsMapToolCaptureRubberband::updateCurve()
   }
 }
 
-QgsCurve *QgsMapToolCaptureRubberband::createLinearString()
+QgsCurve *QgsMapToolCaptureRubberBand::createLinearString()
 {
   std::unique_ptr<QgsLineString> curve( new QgsLineString );
   if ( geometryType() == QgsWkbTypes::PolygonGeometry )
@@ -1171,7 +1162,7 @@ QgsCurve *QgsMapToolCaptureRubberband::createLinearString()
   return curve.release();
 }
 
-QgsCurve *QgsMapToolCaptureRubberband::createCircularString()
+QgsCurve *QgsMapToolCaptureRubberBand::createCircularString()
 {
   std::unique_ptr<QgsCircularString> curve( new QgsCircularString );
   curve->setPoints( mPoints );

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -64,8 +64,12 @@ class QgsMapToolCaptureRubberband: public QgsGeometryRubberBand
     /**
      * Resets the rubber band with the specified geometry type
      * that must be line geometry or polygon geometry.
+     * \a firstPolygonPoint is the first point that will be used to render the polygon rubber band (if \a geomType is PolygonGeometry)
      */
-    void reset( QgsWkbTypes::GeometryType geomType = QgsWkbTypes::LineGeometry, QgsWkbTypes::Type stringType = QgsWkbTypes::LineString );
+    void reset( QgsWkbTypes::GeometryType geomType = QgsWkbTypes::LineGeometry, QgsWkbTypes::Type stringType = QgsWkbTypes::LineString, const QgsPoint &firstPolygonPoint = QgsPoint() );
+
+    //! Sets the geometry type of the rubberband without removing already existing points
+    void setRubberBandGeometryType( QgsWkbTypes::GeometryType geomType );
 
     //! Adds point to the rubber band
     void addPoint( const QgsPoint &point, bool doUpdate = true );
@@ -78,11 +82,6 @@ class QgsMapToolCaptureRubberband: public QgsGeometryRubberBand
 
     //! Returns the points count in the rubber band (except the first point if polygon)
     int pointsCount();
-
-    /**
-     * Sets the first point that serves to render polygon rubber band
-     */
-    void setFirstPolygonPoint( const QgsPoint &point );
 
     //! Returns the type of the curve (linear string or circular string)
     QgsWkbTypes::Type stringType() const;
@@ -379,11 +378,14 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     bool tracingAddVertex( const QgsPointXY &point );
 
     //! create a curve rubber band
-    QgsMapToolCaptureRubberband *createCurveRubberBand( QgsWkbTypes::GeometryType geometryType = QgsWkbTypes::LineGeometry, bool alternativeBand = false ) const;
+    QgsMapToolCaptureRubberband *createCurveRubberBand() const;
 
     //! Returns extemity point of the captured curve in map coordinates
-    QgsPoint firstCaptureMapPoint();
-    QgsPoint lastCaptureMapPoint();
+    QgsPoint firstCapturedMapPoint();
+    QgsPoint lastCapturedMapPoint();
+
+    //! Reset the
+    void resetRubberBand();
 
   private:
     //! The capture mode in which this tool operates

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -93,6 +93,9 @@ class QgsMapToolCaptureRubberband: public QgsGeometryRubberBand
     //! Returns the last point of the rubber band
     QgsPoint lastPoint() const;
 
+    //! Returns the point of the rubber band at position from end
+    QgsPoint pointFromEnd( int posFromEnd ) const;
+
     //! Removes the last point of the rrubber band
     void removeLastPoint();
 

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -36,6 +36,7 @@ class QgsMapLayer;
 class QgsGeometryValidator;
 class QgsMapToolCaptureRubberband;
 
+#ifndef SIP_RUN
 /**
  * Class that reprensents a rubber can that can be linear or circular.
  */
@@ -101,6 +102,8 @@ class QgsMapToolCaptureRubberband: public QgsGeometryRubberBand
     QgsPointSequence mPoints;
     QgsPoint mFirstPolygonPoint;
 };
+
+#endif //SIP_RUN
 
 /**
  * \ingroup gui

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -62,13 +62,13 @@ class QgsMapToolCaptureRubberband: public QgsGeometryRubberBand
     void reset( QgsWkbTypes::GeometryType geomType = QgsWkbTypes::LineGeometry );
 
     //! Adds point to the rubber band
-    void addPoint( const QgsPointXY &point, bool doUpdate = true );
+    void addPoint( const QgsPoint &point, bool doUpdate = true );
 
     //! Moves the last point to the \a point position
-    void movePoint( const QgsPointXY &point );
+    void movePoint( const QgsPoint &point );
 
     //! Moves the point with \a index to the \a point position
-    void movePoint( int index, const QgsPointXY &point );
+    void movePoint( int index, const QgsPoint &point );
 
     //! Returns the points count in the rubber band (except the first point if polygon)
     int pointsCount();
@@ -76,7 +76,7 @@ class QgsMapToolCaptureRubberband: public QgsGeometryRubberBand
     /**
      * Sets the first point that serves to render polygon rubber band
      */
-    void setFirstPolygonPoint( const QgsPointXY &point );
+    void setFirstPolygonPoint( const QgsPoint &point );
 
     //! Returns the type of the curve (linear string or circular string)
     QgsWkbTypes::Type stringType() const;
@@ -408,9 +408,6 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
      * again after every time a new trace with offset is created (to get new "anchor" point)
      */
     QgsPointXY mTracingStartPoint;
-
-    friend class TestQgsMapToolReshape;
-
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsMapToolCapture::Capabilities )

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -404,7 +404,8 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     QgsCompoundCurve mCaptureCurve;
 
     QList<QgsPointLocator::Match> mSnappingMatches;
-    QgsPointLocator::Match mCircularIntermediateMatch = QgsPointLocator::Match();
+    QgsPointLocator::Match mCircularIntermediateMatch;
+    QgsPoint mCircularItermediatePoint;
 
     void validateGeometry();
     QgsGeometryValidator *mValidator = nullptr;

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -65,7 +65,7 @@ class QgsMapToolCaptureRubberband: public QgsGeometryRubberBand
      * Resets the rubber band with the specified geometry type
      * that must be line geometry or polygon geometry.
      */
-    void reset( QgsWkbTypes::GeometryType geomType = QgsWkbTypes::LineGeometry );
+    void reset( QgsWkbTypes::GeometryType geomType = QgsWkbTypes::LineGeometry, QgsWkbTypes::Type stringType = QgsWkbTypes::LineString );
 
     //! Adds point to the rubber band
     void addPoint( const QgsPoint &point, bool doUpdate = true );
@@ -421,6 +421,9 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
      * again after every time a new trace with offset is created (to get new "anchor" point)
      */
     QgsPointXY mTracingStartPoint;
+
+    //! Used to store the state of digitizing type (linear or circular)
+    QgsWkbTypes::Type mDigitizingType = QgsWkbTypes::LineString;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsMapToolCapture::Capabilities )

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -404,6 +404,7 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     QgsCompoundCurve mCaptureCurve;
 
     QList<QgsPointLocator::Match> mSnappingMatches;
+    QgsPointLocator::Match mCircularIntermediateMatch = QgsPointLocator::Match();
 
     void validateGeometry();
     QgsGeometryValidator *mValidator = nullptr;

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -34,7 +34,7 @@ class QgsSnapIndicator;
 class QgsVertexMarker;
 class QgsMapLayer;
 class QgsGeometryValidator;
-class QgsMapToolCaptureRubberband;
+class QgsMapToolCaptureRubberBand;
 
 
 #ifndef SIP_RUN
@@ -42,15 +42,15 @@ class QgsMapToolCaptureRubberband;
 ///@cond PRIVATE
 
 /**
- * Class that reprensents a rubber can that can be linear or circular.
+ * Class that reprensents a rubber band that can be linear or circular.
  *
  * \since QGIS 3.16
  */
-class QgsMapToolCaptureRubberband: public QgsGeometryRubberBand
+class QgsMapToolCaptureRubberBand: public QgsGeometryRubberBand
 {
   public:
     //! Constructor
-    QgsMapToolCaptureRubberband( QgsMapCanvas *mapCanvas, QgsWkbTypes::GeometryType geomType = QgsWkbTypes::LineGeometry );
+    QgsMapToolCaptureRubberBand( QgsMapCanvas *mapCanvas, QgsWkbTypes::GeometryType geomType = QgsWkbTypes::LineGeometry );
 
     //! Returns the curve defined by the rubber band, the caller has to take the ownership, nullptr if no curve is defined.
     QgsCurve *curve();
@@ -213,7 +213,7 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
 
   public slots:
     //! Enable the digitizing with curve
-    void setCircularDigitizingEnable( bool enable );
+    void setCircularDigitizingEnabled( bool enable );
 
   private slots:
     void addError( const QgsGeometry::Error &error );
@@ -378,7 +378,7 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     bool tracingAddVertex( const QgsPointXY &point );
 
     //! create a curve rubber band
-    QgsMapToolCaptureRubberband *createCurveRubberBand() const;
+    QgsMapToolCaptureRubberBand *createCurveRubberBand() const;
 
     //! Returns extemity point of the captured curve in map coordinates
     QgsPoint firstCapturedMapPoint();
@@ -398,7 +398,7 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     QObjectUniquePtr<QgsRubberBand> mRubberBand;
 
     //! Temporary rubber band for polylines and polygons. this connects the last added point to the mouse cursor position
-    std::unique_ptr<QgsMapToolCaptureRubberband> mTempRubberBand;
+    std::unique_ptr<QgsMapToolCaptureRubberBand> mTempRubberBand;
 
     //! List to store the points of digitized lines and polygons (in layer coordinates)
     QgsCompoundCurve mCaptureCurve;

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -378,6 +378,10 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     //! create a curve rubber band
     QgsMapToolCaptureRubberband *createCurveRubberBand( QgsWkbTypes::GeometryType geometryType = QgsWkbTypes::LineGeometry, bool alternativeBand = false ) const;
 
+    //! Returns extemity point of the captured curve in map coordinates
+    QgsPoint firstCaptureMapPoint();
+    QgsPoint lastCaptureMapPoint();
+
   private:
     //! The capture mode in which this tool operates
     CaptureMode mCaptureMode;

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -36,9 +36,15 @@ class QgsMapLayer;
 class QgsGeometryValidator;
 class QgsMapToolCaptureRubberband;
 
+
 #ifndef SIP_RUN
+
+///@cond PRIVATE
+
 /**
  * Class that reprensents a rubber can that can be linear or circular.
+ *
+ * \since QGIS 3.16
  */
 class QgsMapToolCaptureRubberband: public QgsGeometryRubberBand
 {
@@ -102,6 +108,8 @@ class QgsMapToolCaptureRubberband: public QgsGeometryRubberBand
     QgsPointSequence mPoints;
     QgsPoint mFirstPolygonPoint;
 };
+
+/// @endcond
 
 #endif //SIP_RUN
 
@@ -202,6 +210,7 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     QgsRubberBand *takeRubberBand() SIP_FACTORY;
 
   public slots:
+    //! Changes the digitizing shape to linear or circular
     void toggleLinearCircularDigitizing();
 
   private slots:

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -212,8 +212,8 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     QgsRubberBand *takeRubberBand() SIP_FACTORY;
 
   public slots:
-    //! Changes the digitizing shape to linear or circular
-    void toggleLinearCircularDigitizing();
+    //! Enable the digitizing with curve
+    void setCircularDigitizingEnable( bool enable );
 
   private slots:
     void addError( const QgsGeometry::Error &error );

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -489,6 +489,7 @@
    <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
+   <addaction name="mActionDigitizeWithCurve"/>
    <addaction name="mActionRotateFeature"/>
    <addaction name="mActionSimplifyFeature"/>
    <addaction name="mActionAddRing"/>
@@ -3361,6 +3362,27 @@ Shows placeholders for labels which could not be placed, e.g. due to overlaps wi
    </property>
    <property name="toolTip">
     <string>Increase Gamma</string>
+   </property>
+  </action>
+  <action name="mActionDigitizeWithCurve">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionDigitizeWithCurve.svg</normaloff>:/images/themes/default/mActionDigitizeWithCurve.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Digitize with curve</string>
+   </property>
+   <property name="toolTip">
+    <string>Digitize with curve</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+G</string>
    </property>
   </action>
  </widget>

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -283,7 +283,7 @@ void TestQgsMapToolAddFeatureLine::testNoTracing()
   mLayerLine->undoStack()->undo();
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
 
-  mCaptureTool->setCircularDigitizingEnable( true );
+  mCaptureTool->setCircularDigitizingEnabled( true );
 
   utils.mouseClick( 1, 1, Qt::LeftButton );
   utils.mouseClick( 3, 2, Qt::LeftButton );
@@ -305,7 +305,7 @@ void TestQgsMapToolAddFeatureLine::testNoTracing()
 
   mLayerLine->undoStack()->undo();
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
-  mCaptureTool->setCircularDigitizingEnable( false );
+  mCaptureTool->setCircularDigitizingEnabled( false );
 }
 
 void TestQgsMapToolAddFeatureLine::testTracing()

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -282,6 +282,30 @@ void TestQgsMapToolAddFeatureLine::testNoTracing()
 
   mLayerLine->undoStack()->undo();
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
+
+  mCaptureTool->toggleLinearCircularDigitizing();
+
+  utils.mouseClick( 1, 1, Qt::LeftButton );
+  utils.mouseClick( 3, 2, Qt::LeftButton );
+  utils.mouseClick( 3, 2, Qt::RightButton );
+
+  // Cirular string need 3 points, so no feature created
+  QCOMPARE( mLayerLine->undoStack()->index(), 1 );
+  QCOMPARE( utils.existingFeatureIds().count(), 1 );
+
+  utils.mouseClick( 1, 1, Qt::LeftButton );
+  utils.mouseClick( 3, 2, Qt::LeftButton );
+  utils.mouseClick( 4, 2, Qt::LeftButton );
+  utils.mouseClick( 4, 2, Qt::RightButton );
+
+  newFid = utils.newFeatureId( oldFids );
+
+  QCOMPARE( mLayerLine->undoStack()->index(), 2 );
+  QCOMPARE( mLayerLine->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( "CIRCULARSTRING(1 1, 3 2, 4 2)" ) );
+
+  mLayerLine->undoStack()->undo();
+  QCOMPARE( mLayerLine->undoStack()->index(), 1 );
+  mCaptureTool->toggleLinearCircularDigitizing();
 }
 
 void TestQgsMapToolAddFeatureLine::testTracing()

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -283,7 +283,7 @@ void TestQgsMapToolAddFeatureLine::testNoTracing()
   mLayerLine->undoStack()->undo();
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
 
-  mCaptureTool->toggleLinearCircularDigitizing();
+  mCaptureTool->setCircularDigitizingEnable( true );
 
   utils.mouseClick( 1, 1, Qt::LeftButton );
   utils.mouseClick( 3, 2, Qt::LeftButton );
@@ -305,7 +305,7 @@ void TestQgsMapToolAddFeatureLine::testNoTracing()
 
   mLayerLine->undoStack()->undo();
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
-  mCaptureTool->toggleLinearCircularDigitizing();
+  mCaptureTool->setCircularDigitizingEnable( false );
 }
 
 void TestQgsMapToolAddFeatureLine::testTracing()

--- a/tests/src/app/testqgsmaptoolreshape.cpp
+++ b/tests/src/app/testqgsmaptoolreshape.cpp
@@ -285,7 +285,7 @@ void TestQgsMapToolReshape::reshapeWithBindingLine()
   QgsCompoundCurve curve0( *cl0.toCurveType() );
 
   QgsMapToolReshape tool0( mQgisApp->mapCanvas() );
-  tool0.mCaptureCurve = curve0;
+  tool0.addCurve( curve0.clone() );
 
   vl->startEditing();
   tool0.reshape( vl.get() );
@@ -305,7 +305,7 @@ void TestQgsMapToolReshape::reshapeWithBindingLine()
   QgsCompoundCurve curve1( *cl1.toCurveType() );
 
   QgsMapToolReshape tool1( mQgisApp->mapCanvas() );
-  tool1.mCaptureCurve = curve1;
+  tool1.addCurve( curve1.clone() );
 
   vl->startEditing();
   tool1.reshape( vl.get() );


### PR DESCRIPTION
This PR adds the possibility to switch between linear or circular string when digitizing a new vector layer feature or when splitting them.
The user can use the short cut Ctrl+Shift+G to switch between linear/circular.
For splitting features, new overloading methods have been added in the API.
When splitting, curves are preserved. For this, the curve is segmentized before splitting, and all the split feature are "de-segmentized" after splitting.

![circular](https://user-images.githubusercontent.com/7416892/86938423-6a93de80-c10e-11ea-8511-489d8b4f006f.gif)

![splitCurve](https://user-images.githubusercontent.com/7416892/86938444-7089bf80-c10e-11ea-8fd0-0f419f71b52e.gif)

**EDIT:**
Tool button added to switch between linear/circular:
![toolButton](https://user-images.githubusercontent.com/7416892/88101713-6505b200-cb6c-11ea-9feb-68a4130d6f52.gif)
