### PR TITLE
Don't require all parameter values to be specified via qgis_process command line tool

### DIFF
--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -440,13 +440,17 @@ int QgsProcessingExec::execute( const QString &id, const QVariantMap &params )
     std::cout << it.key().toLocal8Bit().constData() << ":\t" << it.value().toString().toLocal8Bit().constData() << '\n';
   }
 
+  QgsProcessingContext context;
   const QgsProcessingParameterDefinitions defs = alg->parameterDefinitions();
   QList< const QgsProcessingParameterDefinition * > missingParams;
   for ( const QgsProcessingParameterDefinition *p : defs )
   {
-    if ( !( p->flags() & QgsProcessingParameterDefinition::FlagOptional ) && !params.contains( p->name() ) )
+    if ( !p->checkValueIsAcceptable( params.value( p->name() ), &context ) )
     {
-      missingParams << p;
+      if ( !( p->flags() & QgsProcessingParameterDefinition::FlagOptional ) && !params.contains( p->name() ) )
+      {
+        missingParams << p;
+      }
     }
   }
 
@@ -461,7 +465,14 @@ int QgsProcessingExec::execute( const QString &id, const QVariantMap &params )
     return 1;
   }
 
-  QgsProcessingContext context;
+  QString message;
+  if ( !alg->checkParameterValues( params, context, &message ) )
+  {
+    std::cerr << QStringLiteral( "ERROR:\tAn error was encountered while checking parameter values\n" ).toLocal8Bit().constData();
+    std::cerr << QStringLiteral( "\t%1\n" ).arg( message ).toLocal8Bit().constData();
+    return 1;
+  }
+
   ConsoleFeedback feedback;
 
 #if defined(Q_OS_UNIX) and !defined(Q_OS_ANDROID)

--- a/tests/src/python/test_qgsprocessexecutable.py
+++ b/tests/src/python/test_qgsprocessexecutable.py
@@ -111,7 +111,7 @@ class TestQgsProcessExecutable(unittest.TestCase):
 
     def testAlgorithmRun(self):
         output_file = self.TMP_DIR + '/polygon_centroid.shp'
-        rc, output, err = self.run_process(['run', 'native:centroids', '--INPUT={}'.format(TEST_DATA_DIR + '/polys.shp'), '--ALL_PARTS=false', '--OUTPUT={}'.format(output_file)])
+        rc, output, err = self.run_process(['run', 'native:centroids', '--INPUT={}'.format(TEST_DATA_DIR + '/polys.shp'), '--OUTPUT={}'.format(output_file)])
         if os.environ.get('TRAVIS', '') != 'true':
             # Travis DOES have errors, due to QStandardPaths: XDG_RUNTIME_DIR not set warnings raised by Qt
             self.assertFalse(err)


### PR DESCRIPTION
Instead use the proper value validity check to test whether it's ok to leave them unspecified

Fixes #37692