### PR TITLE
when adding new field apply precision only when field type supports it

### DIFF
--- a/src/gui/qgsaddattrdialog.cpp
+++ b/src/gui/qgsaddattrdialog.cpp
@@ -90,6 +90,7 @@ void QgsAddAttrDialog::setPrecisionMinMax()
   int minPrecType = mTypeBox->itemData( idx, Qt::UserRole + 4 ).toInt();
   int maxPrecType = mTypeBox->itemData( idx, Qt::UserRole + 5 ).toInt();
   bool precisionIsEnabled = minPrecType < maxPrecType;
+  mPrec->setEnabled( precisionIsEnabled );
   mPrec->setVisible( precisionIsEnabled );
   mPrecLabel->setVisible( precisionIsEnabled );
 
@@ -138,7 +139,7 @@ QgsField QgsAddAttrDialog::field() const
            ( QVariant::Type ) mTypeBox->currentData( Qt::UserRole ).toInt(),
            mTypeBox->currentData( Qt::UserRole + 1 ).toString(),
            mLength->value(),
-           mPrec->isVisible() ? mPrec->value() : 0,
+           mPrec->isEnabled() ? mPrec->value() : 0,
            mCommentEdit->text(),
            static_cast<QVariant::Type>( mTypeBox->currentData( Qt::UserRole ).toInt() ) == QVariant::Map ? QVariant::String : QVariant::Invalid
          );

--- a/src/gui/qgsaddattrdialog.cpp
+++ b/src/gui/qgsaddattrdialog.cpp
@@ -138,7 +138,7 @@ QgsField QgsAddAttrDialog::field() const
            ( QVariant::Type ) mTypeBox->currentData( Qt::UserRole ).toInt(),
            mTypeBox->currentData( Qt::UserRole + 1 ).toString(),
            mLength->value(),
-           mPrec->value(),
+           mPrec->isVisible() ? mPrec->value() : 0,
            mCommentEdit->text(),
            static_cast<QVariant::Type>( mTypeBox->currentData( Qt::UserRole ).toInt() ) == QVariant::Map ? QVariant::String : QVariant::Invalid
          );


### PR DESCRIPTION
## Description
Fixes [regression](https://github.com/qgis/QGIS/pull/36524#issuecomment-655614909) in the add attribute dialog (field precision is used when adding field even if field type does not support precision) which prevents user from leaving editing session.
