### PR TITLE
Missing options for r.neighbors in processing

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.neighbors.txt
+++ b/python/plugins/processing/algs/grass7/description/r.neighbors.txt
@@ -3,7 +3,7 @@ Makes each cell category value a function of the category values assigned to the
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Input raster layer|None|False
 QgsProcessingParameterRasterLayer|selection|Raster layer to select the cells which should be processed|None|True
-QgsProcessingParameterEnum|method|Neighborhood operation|average;median;mode;minimum;maximum;stddev;sum;variance;diversity;interspersion|False|0|True
+QgsProcessingParameterEnum|method|Neighborhood operation|average;median;mode;minimum;maximum;range;stddev;sum;count;variance;diversity;interspersion;quart1;quart3;perc90;quantile|False|0|True
 QgsProcessingParameterNumber|size|Neighborhood size|QgsProcessingParameterNumber.Integer|3|True|1|None
 QgsProcessingParameterNumber|gauss|Sigma (in cells) for Gaussian filter|QgsProcessingParameterNumber.Integer|None|True|0|None
 QgsProcessingParameterString|quantile|Quantile to calculate for method=quantile|None|False|True


### PR DESCRIPTION
All options added to r.neighbors processing alg: https://grass.osgeo.org/grass78/manuals/r.neighbors.html

Fix https://github.com/qgis/QGIS/issues/37699




