### PR TITLE
Add safety check

### DIFF
--- a/src/core/qgsvectorlayerjoininfo.cpp
+++ b/src/core/qgsvectorlayerjoininfo.cpp
@@ -100,11 +100,15 @@ QStringList QgsVectorLayerJoinInfo::joinFieldNamesSubset( const QgsVectorLayerJo
     }
     else
     {
-      for ( const QgsField &f : info.joinLayer()->fields() )
+      if ( info.joinLayer() )
       {
-        if ( !info.joinFieldNamesBlockList().contains( f.name() )
-             && f.name() != info.joinFieldName() )
-          fieldNames.append( f.name() );
+        const QgsFields fields { info.joinLayer()->fields() };
+        for ( const QgsField &f : fields )
+        {
+          if ( !info.joinFieldNamesBlockList().contains( f.name() )
+               && f.name() != info.joinFieldName() )
+            fieldNames.append( f.name() );
+        }
       }
     }
   }


### PR DESCRIPTION
... or QGIS crashes when offline editing layers with auxiliary storage attached

Fixes an unreported crasher