### PR TITLE
Cache snapping results in feature dialog for subsequent recalculation

### DIFF
--- a/python/gui/auto_generated/qgsattributedialog.sip.in
+++ b/python/gui/auto_generated/qgsattributedialog.sip.in
@@ -77,7 +77,7 @@ Intercept window activate/deactivate events to show/hide the highlighted feature
 
     void setExtraContextScope( QgsExpressionContextScope *extraScope /Transfer/ );
 %Docstring
-Sets an additional expression context scope to be used
+Sets ``extraScope`` as an additional expression context scope to be used
 for calculations in this form.
 
 .. versionadded:: 3.16

--- a/python/gui/auto_generated/qgsattributedialog.sip.in
+++ b/python/gui/auto_generated/qgsattributedialog.sip.in
@@ -75,6 +75,14 @@ Intercept window activate/deactivate events to show/hide the highlighted feature
 :return: The same as the parent QDialog
 %End
 
+    void setExtraContextScope( QgsExpressionContextScope *extraScope /Transfer/ );
+%Docstring
+Sets an additional expression context scope to be used
+for calculations in this form.
+
+.. versionadded:: 3.16
+%End
+
   public slots:
     virtual void accept();
 

--- a/python/gui/auto_generated/qgsattributeform.sip.in
+++ b/python/gui/auto_generated/qgsattributeform.sip.in
@@ -169,6 +169,14 @@ on all attribute widgets.
 .. versionadded:: 3.0
 %End
 
+    void setExtraContextScope( QgsExpressionContextScope *extraScope /Transfer/ );
+%Docstring
+Sets an additional expression context scope to be used
+for calculations in this form.
+
+.. versionadded:: 3.16
+%End
+
   signals:
 
  void attributeChanged( const QString &attribute, const QVariant &value ) /Deprecated/;

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -65,6 +65,9 @@ QgsAttributeDialog *QgsFeatureAction::newDialog( bool cloneFeature )
 
   QgsAttributeDialog *dialog = new QgsAttributeDialog( mLayer, f, cloneFeature, parentWidget(), true, context );
   dialog->setWindowFlags( dialog->windowFlags() | Qt::Tool );
+  if ( scope )
+    dialog->setExtraContextScope( new QgsExpressionContextScope( *scope ) );
+
 
   dialog->setObjectName( QStringLiteral( "featureactiondlg:%1:%2" ).arg( mLayer->id() ).arg( f->id() ) );
 
@@ -255,6 +258,8 @@ bool QgsFeatureAction::addFeature( const QgsAttributeMap &defaultAttributes, boo
     dialog->setAttribute( Qt::WA_DeleteOnClose );
     dialog->setMode( QgsAttributeEditorContext::AddFeatureMode );
     dialog->setEditCommandMessage( text() );
+    if ( scope )
+      dialog->setExtraContextScope( new QgsExpressionContextScope( *scope ) );
 
     connect( dialog->attributeForm(), &QgsAttributeForm::featureSaved, this, &QgsFeatureAction::onFeatureSaved );
 

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -65,9 +65,6 @@ QgsAttributeDialog *QgsFeatureAction::newDialog( bool cloneFeature )
 
   QgsAttributeDialog *dialog = new QgsAttributeDialog( mLayer, f, cloneFeature, parentWidget(), true, context );
   dialog->setWindowFlags( dialog->windowFlags() | Qt::Tool );
-  if ( scope )
-    dialog->setExtraContextScope( new QgsExpressionContextScope( *scope ) );
-
 
   dialog->setObjectName( QStringLiteral( "featureactiondlg:%1:%2" ).arg( mLayer->id() ).arg( f->id() ) );
 

--- a/src/gui/qgsattributedialog.cpp
+++ b/src/gui/qgsattributedialog.cpp
@@ -148,3 +148,8 @@ bool QgsAttributeDialog::event( QEvent *e )
 
   return QDialog::event( e );
 }
+
+void QgsAttributeDialog::setExtraContextScope( QgsExpressionContextScope *extraScope )
+{
+  mAttributeForm->setExtraContextScope( extraScope );
+}

--- a/src/gui/qgsattributedialog.h
+++ b/src/gui/qgsattributedialog.h
@@ -95,6 +95,14 @@ class GUI_EXPORT QgsAttributeDialog : public QDialog
      */
     bool event( QEvent *e ) override;
 
+    /**
+     * Sets an additional expression context scope to be used
+     * for calculations in this form.
+     *
+     * \since QGIS 3.16
+     */
+    void setExtraContextScope( QgsExpressionContextScope *extraScope SIP_TRANSFER );
+
   public slots:
     void accept() override;
     void reject() override;

--- a/src/gui/qgsattributedialog.h
+++ b/src/gui/qgsattributedialog.h
@@ -96,7 +96,7 @@ class GUI_EXPORT QgsAttributeDialog : public QDialog
     bool event( QEvent *e ) override;
 
     /**
-     * Sets an additional expression context scope to be used
+     * Sets \a extraScope as an additional expression context scope to be used
      * for calculations in this form.
      *
      * \since QGIS 3.16

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -183,6 +183,14 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
      */
     QString aggregateFilter() const;
 
+    /**
+     * Sets an additional expression context scope to be used
+     * for calculations in this form.
+     *
+     * \since QGIS 3.16
+     */
+    void setExtraContextScope( QgsExpressionContextScope *extraScope SIP_TRANSFER );
+
   signals:
 
     /**
@@ -387,6 +395,8 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
 
     QString createFilterExpression() const;
 
+    QgsExpressionContext createExpressionContext( const QgsFeature &feature ) const;
+
     //! constraints management
     void updateAllConstraints();
     void updateConstraints( QgsEditorWidgetWrapper *w );
@@ -407,6 +417,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     QgsMessageBarItem *mMultiEditMessageBarItem = nullptr;
     QList<QgsWidgetWrapper *> mWidgets;
     QgsAttributeEditorContext mContext;
+    std::unique_ptr<QgsExpressionContextScope> mExtraContextScope;
     QDialogButtonBox *mButtonBox = nullptr;
     QWidget *mSearchButtonBox = nullptr;
     QList<QgsAttributeFormInterface *> mInterfaces;


### PR DESCRIPTION
Snapping results are used for initial calculation of default values on an attribute form.

If a default value has to be recalculated (because it depends on another attribute) the snapping results are no longer available.

Fixes #37359
