### PR TITLE
Swap display_expression parameters order

### DIFF
--- a/resources/function_help/json/display_expression
+++ b/resources/function_help/json/display_expression
@@ -2,39 +2,36 @@
   "name": "display_expression",
   "type": "function",
   "groups": ["Record and Attributes"],
-  "description": "Returns the display expression for a given feature in a layer. If called with no parameters, it evaluates the current feature. The expression is evaluated by default.",
-  "arguments": [
+  "description": "Returns the display expression for a given feature in a layer. The expression is evaluated by default. Can be used with zero, one or more arguments, see below for details.",
+  "variants": [
     {
-      "arg": "layer",
-      "optional": true,
-      "default": "current layer",
-      "description": "The layer (or its id or name)."
+      "variant": "No parameters",
+      "variant_description": "If called with no parameters, the function will evaluate the display expression of the current feature in the current layer.",
+      "arguments": [],
+      "examples": [ { "expression": "display_expression()", "returns" : "The display expression of the current feature in the current layer." } ]
     },
     {
-      "arg": "feature",
-      "optional": true,
-      "default": "current feature",
-      "description": "The feature which should be evaluated."
+      "variant": "One 'feature' parameter",
+      "variant_description": "If called with a 'feature' parameter only, the function will evaluate the specified feature from the current layer.",
+      "arguments": [ { "arg": "feature", "description": "The feature which should be evaluated." } ],
+      "examples": [ { "expression": "display_expression(@atlas_feature)", "returns": "The display expression of the current atlas feature." } ]
     },
     {
-      "arg": "evaluate",
-      "description": "If the expression must be evaluated. If false, the expression will be returned as a string literal only (which could potentially be later evaluated using the 'eval' function).",
-      "optional": true,
-      "default": "true"
-    }
-  ],
-  "examples": [
-    {
-      "expression": "display_expression()",
-      "returns": "The display expression of the current feature."
-    },
-    {
-      "expression": "display_expression('streets', get_feature_by_id('streets', 1))",
-      "returns": "The display expression of the feature with the ID 1 on the layer 'streets'."
-    },
-    {
-      "expression": "display_expression('a_layer_id', $currentfeature, 'False')",
-      "returns": "The display expression of the given feature not evaluated."
+      "variant" : "Layer and feature parameters",
+      "variant_description": "If the function is called with both a layer and a feature, it will evaluate the specified feature from the specified layer.",
+      "arguments": [
+        { "arg": "layer", "description": "The layer (or its ID or name)" },
+        { "arg": "feature", "description": "The feature which should be evaluated." },
+        { "arg": "evaluate", "description": "If the expression must be evaluated. If false, the expression will be returned as a string literal only (which could potentially be later evaluated using the 'eval' function).", "optional": true, "default": "true" }
+      ],
+      "examples": [
+        { "expression": "display_expression( 'streets', get_feature_by_id('streets', 1))",
+          "returns": "The display expression of the feature with the ID 1 on the layer 'streets'."
+        },
+        { "expression": "display_expression('a_layer_id', $currentfeature, 'False')",
+          "returns": "The display expression of the given feature not evaluated."
+        }
+      ]
     }
   ]
 }

--- a/resources/function_help/json/display_expression
+++ b/resources/function_help/json/display_expression
@@ -5,16 +5,16 @@
   "description": "Returns the display expression for a given feature in a layer. If called with no parameters, it evaluates the current feature. The expression is evaluated by default.",
   "arguments": [
     {
-      "arg": "feature",
-      "optional": true,
-      "default": "current feature",
-      "description": "The feature which should be evaluated."
-    },
-    {
       "arg": "layer",
       "optional": true,
       "default": "current layer",
       "description": "The layer (or its id or name)."
+    },
+    {
+      "arg": "feature",
+      "optional": true,
+      "default": "current feature",
+      "description": "The feature which should be evaluated."
     },
     {
       "arg": "evaluate",
@@ -29,7 +29,7 @@
       "returns": "The display expression of the current feature."
     },
     {
-      "expression": "display_expression(get_feature_by_id('streets', 1), 'streets')",
+      "expression": "display_expression('streets', get_feature_by_id('streets', 1))",
       "returns": "The display expression of the feature with the ID 1 on the layer 'streets'."
     },
     {

--- a/resources/function_help/json/maptip
+++ b/resources/function_help/json/maptip
@@ -2,39 +2,36 @@
   "name": "maptip",
   "type": "function",
   "groups": ["Record and Attributes"],
-  "description": "Returns the maptip for a given feature in a layer. If called with no parameters, it evaluates the current feature. The maptip is evaluated by default.",
-  "arguments": [
+  "description": "Returns the maptip for a given feature in a layer. The expression is evaluated by default. Can be used with zero, one or more arguments, see below for details.",
+  "variants": [
     {
-      "arg": "feature",
-      "optional": true,
-      "default": "current feature",
-      "description": "The feature which should be evaluated."
+      "variant": "No parameters",
+      "variant_description": "If called with no parameters, the function will evaluate the maptip of the current feature in the current layer.",
+      "arguments": [],
+      "examples": [ { "expression": "maptip()", "returns" : "The maptip of the current feature in the current layer." } ]
     },
     {
-      "arg": "layer",
-      "optional": true,
-      "default": "current layer",
-      "description": "The layer (or its id or name)."
+      "variant": "One 'feature' parameter",
+      "variant_description": "If called with a 'feature' parameter only, the function will evaluate the specified feature from the current layer.",
+      "arguments": [ { "arg": "feature", "description": "The feature which should be evaluated." } ],
+      "examples": [ { "expression": "maptip(@atlas_feature)", "returns": "The maptip of the current atlas feature." } ]
     },
     {
-      "arg": "evaluate",
-      "description": "If the expression must be evaluated. If false, the expression will be returned as a string literal only (which could potentially be later evaluated using the 'eval_template' function).",
-      "optional": true,
-      "default": "true"
-    }
-  ],
-  "examples": [
-    {
-      "expression": "maptip()",
-      "returns": "The maptip of the current feature."
-    },
-    {
-      "expression": "maptip(get_feature('streets', 1), 'streets')",
-      "returns": "The maptip of the feature with the ID 1 on the layer 'streets'."
-    },
-    {
-      "expression": "maptip('a_layer_id', $currentfeature, 'False')",
-      "returns": "The maptip of the given feature not evaluated."
+      "variant" : "Layer and feature parameters",
+      "variant_description": "If the function is called with both a layer and a feature, it will evaluate the specified feature from the specified layer.",
+      "arguments": [
+        { "arg": "layer", "description": "The layer (or its ID or name)" },
+        { "arg": "feature", "description": "The feature which should be evaluated." },
+        { "arg": "evaluate", "description": "If the expression must be evaluated. If false, the expression will be returned as a string literal only (which could potentially be later evaluated using the 'eval_template' function).", "optional": true, "default": "true" }
+      ],
+      "examples": [
+        { "expression": "maptip('streets', get_feature_by_id('streets', 1))",
+          "returns": "The maptip of the feature with the ID 1 on the layer 'streets'."
+        },
+        { "expression": "maptip('a_layer_id', $currentfeature, 'False')",
+          "returns": "The maptip of the given feature not evaluated."
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Because the commented expression below instead works
![image](https://user-images.githubusercontent.com/7983394/87243006-56afeb80-c432-11ea-8805-297068670e5d.png)
