### PR TITLE
Add invalid state to QgsTextFormat, and improve UX for setting manual table text format overrides

### DIFF
--- a/python/core/auto_generated/qgspropertycollection.sip.in
+++ b/python/core/auto_generated/qgspropertycollection.sip.in
@@ -389,6 +389,9 @@ Copy constructor.
 %End
 
 
+    bool operator==( const QgsPropertyCollection &other ) const;
+    bool operator!=( const QgsPropertyCollection &other ) const;
+
     int count() const;
 %Docstring
 Returns the number of properties contained within the collection.

--- a/python/core/auto_generated/qgstablecell.sip.in
+++ b/python/core/auto_generated/qgstablecell.sip.in
@@ -106,28 +106,6 @@ Sets the cell's text ``format``.
 .. versionadded:: 3.16
 %End
 
-    bool hasTextFormat() const;
-%Docstring
-Returns ``True`` if the cell has a specific text format which should be applied.
-
-.. seealso:: :py:func:`textFormat`
-
-.. seealso:: :py:func:`setHasTextFormat`
-
-.. versionadded:: 3.16
-%End
-
-    void setHasTextFormat( bool hasTextFormat );
-%Docstring
-Sets whether the cell has a specific text format which should be applied.
-
-.. seealso:: :py:func:`setTextFormat`
-
-.. seealso:: :py:func:`hasTextFormat`
-
-.. versionadded:: 3.16
-%End
-
     const QgsNumericFormat *numericFormat() const;
 %Docstring
 Returns the numeric format used for numbers in the cell, or ``None`` if no format is set.

--- a/python/core/auto_generated/textrenderer/qgstextbackgroundsettings.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextbackgroundsettings.sip.in
@@ -63,6 +63,9 @@ Copy constructor.
 
     ~QgsTextBackgroundSettings();
 
+    bool operator==( const QgsTextBackgroundSettings &other ) const;
+    bool operator!=( const QgsTextBackgroundSettings &other ) const;
+
     bool enabled() const;
 %Docstring
 Returns whether the background is enabled.

--- a/python/core/auto_generated/textrenderer/qgstextbuffersettings.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextbuffersettings.sip.in
@@ -39,6 +39,9 @@ Copy constructor.
 
     ~QgsTextBufferSettings();
 
+    bool operator==( const QgsTextBufferSettings &other ) const;
+    bool operator!=( const QgsTextBufferSettings &other ) const;
+
     bool enabled() const;
 %Docstring
 Returns whether the buffer is enabled.

--- a/python/core/auto_generated/textrenderer/qgstextformat.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextformat.sip.in
@@ -50,6 +50,9 @@ Copy constructor.
 
     ~QgsTextFormat();
 
+    bool operator==( const QgsTextFormat &other ) const;
+    bool operator!=( const QgsTextFormat &other ) const;
+
     bool isValid() const;
 %Docstring
 Returns ``True`` if the format is valid.

--- a/python/core/auto_generated/textrenderer/qgstextformat.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextformat.sip.in
@@ -35,6 +35,10 @@ Container for all settings relating to text rendering.
     };
 
     QgsTextFormat();
+%Docstring
+Default constructor for QgsTextFormat. Creates a text format initially
+set to an invalid state (see :py:func:`~QgsTextFormat.isValid`).
+%End
 
     QgsTextFormat( const QgsTextFormat &other );
 %Docstring
@@ -45,6 +49,32 @@ Copy constructor.
 
 
     ~QgsTextFormat();
+
+    bool isValid() const;
+%Docstring
+Returns ``True`` if the format is valid.
+
+A default constructed QgsTextFormat is invalid, until at least one or more properties
+have been set on the format. An invalid state can be used as a representation of a "not set"
+text format, e.g. for indicating that a default text format should be used.
+
+.. note::
+
+   Calling any setter on a QgsTextFormat object will automatically set the format as valid.
+
+.. seealso:: :py:func:`setValid`
+
+.. versionadded:: 3.16
+%End
+
+    void setValid();
+%Docstring
+Sets the format to a valid state, without changing any of the default format settings.
+
+.. seealso:: :py:func:`isValid`
+
+.. versionadded:: 3.16
+%End
 
     QgsTextBufferSettings &buffer();
 %Docstring

--- a/python/core/auto_generated/textrenderer/qgstextmasksettings.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextmasksettings.sip.in
@@ -46,6 +46,9 @@ Copy constructor.
 
     ~QgsTextMaskSettings();
 
+    bool operator==( const QgsTextMaskSettings &other ) const;
+    bool operator!=( const QgsTextMaskSettings &other ) const;
+
     bool enabled() const;
 %Docstring
 Returns whether the mask is enabled.

--- a/python/core/auto_generated/textrenderer/qgstextshadowsettings.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextshadowsettings.sip.in
@@ -47,6 +47,9 @@ Copy constructor.
 
     ~QgsTextShadowSettings();
 
+    bool operator==( const QgsTextShadowSettings &other ) const;
+    bool operator!=( const QgsTextShadowSettings &other ) const;
+
     bool enabled() const;
 %Docstring
 Returns whether the shadow is enabled.

--- a/python/gui/auto_generated/qgsfontbutton.sip.in
+++ b/python/gui/auto_generated/qgsfontbutton.sip.in
@@ -159,6 +159,51 @@ an expression context for the button when required.
 .. versionadded:: 3.10
 %End
 
+    void setShowNullFormat( const bool show );
+%Docstring
+Sets whether the "null format" option should be shown in the button's drop-down menu. This option
+is only used for buttons set to the ModeTextRenderer :py:func:`~QgsFontButton.mode`.
+
+If selected, the "null format" option sets the button's format to an invalid :py:class:`QgsTextFormat`. This
+can be used to represent a "use default format" state for the button.
+
+By default this option is not shown.
+
+.. seealso:: :py:func:`setNoFormatString`
+
+.. seealso:: :py:func:`showNullFormat`
+
+.. versionadded:: 3.16
+%End
+
+    void setNoFormatString( const QString &string );
+%Docstring
+Sets the ``string`` to use for the "null format" option in the button's drop-down menu.
+
+.. note::
+
+   The "null format" option is only shown if :py:func:`~QgsFontButton.showNullFormat` is ``True``.
+
+.. seealso:: :py:func:`setShowNullFormat`
+
+.. versionadded:: 3.16
+%End
+
+    bool showNullFormat() const;
+%Docstring
+Returns whether the "null format" option will be shown in the button's drop-down menu. This option
+is only used for buttons set to the ModeTextRenderer :py:func:`~QgsFontButton.mode`.
+
+If selected, the "null format" option sets the button's format to an invalid :py:class:`QgsTextFormat`. This
+can be used to represent a "use default format" state for the button.
+
+By default this option is not shown.
+
+.. seealso:: :py:func:`setShowNullFormat`
+
+.. versionadded:: 3.16
+%End
+
   public slots:
 
     void setTextFormat( const QgsTextFormat &format );
@@ -167,6 +212,15 @@ Sets the current text ``format`` to show in the widget.
 This is only used when :py:func:`~QgsFontButton.mode` is ModeTextRenderer.
 
 .. seealso:: :py:func:`textFormat`
+%End
+
+    void setToNullFormat();
+%Docstring
+Sets the text format to a null (invalid) :py:class:`QgsTextFormat`.
+
+This is only used when :py:func:`~QgsFontButton.mode` is ModeTextRenderer.
+
+.. versionadded:: 3.16
 %End
 
     void setCurrentFont( const QFont &font );

--- a/python/gui/auto_generated/tableeditor/qgstableeditorwidget.sip.in
+++ b/python/gui/auto_generated/tableeditor/qgstableeditorwidget.sip.in
@@ -76,13 +76,6 @@ Returns ``True`` if the current selection has a mix of numeric formats.
 .. seealso:: :py:func:`selectionNumericFormat`
 %End
 
-    bool hasMixedSelectionHasTextFormat();
-%Docstring
-Returns ``True`` if the current selection has a mix of text format override state.
-
-.. versionadded:: 3.16
-%End
-
     QColor selectionForegroundColor();
 %Docstring
 Returns the foreground color for the currently selected cells.
@@ -131,12 +124,7 @@ the selected cells have a mix of different vertical alignments.
 %Docstring
 Returns the text format for the currently selected cells.
 
-.. versionadded:: 3.16
-%End
-
-    bool selectionHasTextFormat();
-%Docstring
-Returns whether the currently selected cells have the text format override option set.
+Returns an invalid QgsTextFormat if the selection has mixed text format.
 
 .. versionadded:: 3.16
 %End
@@ -323,13 +311,6 @@ Sets the vertical alignment for the currently selected cells.
     void setSelectionTextFormat( const QgsTextFormat &format );
 %Docstring
 Sets the text ``format`` for the selected cells.
-
-.. versionadded:: 3.16
-%End
-
-    void setSelectionHasTextFormat( bool hasFormat );
-%Docstring
-Sets whether the selected cells have the text format override option set.
 
 .. versionadded:: 3.16
 %End

--- a/src/core/layout/qgslayoutitemmanualtable.cpp
+++ b/src/core/layout/qgslayoutitemmanualtable.cpp
@@ -312,7 +312,7 @@ QgsTextFormat QgsLayoutItemManualTable::textFormatForHeader( int column ) const
 
 QgsTextFormat QgsLayoutItemManualTable::textFormatForCell( int row, int column ) const
 {
-  if ( mContents.value( row ).value( column ).hasTextFormat() )
+  if ( mContents.value( row ).value( column ).textFormat().isValid() )
     return mContents.value( row ).value( column ).textFormat();
 
   return QgsLayoutTable::textFormatForCell( row, column );

--- a/src/core/qgspropertycollection.cpp
+++ b/src/core/qgspropertycollection.cpp
@@ -144,6 +144,16 @@ QgsPropertyCollection &QgsPropertyCollection::operator=( const QgsPropertyCollec
   return *this;
 }
 
+bool QgsPropertyCollection::operator==( const QgsPropertyCollection &other ) const
+{
+  return mProperties == other.mProperties;
+}
+
+bool QgsPropertyCollection::operator!=( const QgsPropertyCollection &other ) const
+{
+  return !( *this == other );
+}
+
 int QgsPropertyCollection::count() const
 {
   if ( !mDirty )

--- a/src/core/qgspropertycollection.h
+++ b/src/core/qgspropertycollection.h
@@ -332,6 +332,9 @@ class CORE_EXPORT QgsPropertyCollection : public QgsAbstractPropertyCollection
 
     QgsPropertyCollection &operator=( const QgsPropertyCollection &other );
 
+    bool operator==( const QgsPropertyCollection &other ) const;
+    bool operator!=( const QgsPropertyCollection &other ) const;
+
     /**
      * Returns the number of properties contained within the collection.
      */

--- a/src/core/qgstablecell.cpp
+++ b/src/core/qgstablecell.cpp
@@ -27,7 +27,6 @@ QgsTableCell::QgsTableCell( const QgsTableCell &other )
   : mContent( other.mContent )
   , mBackgroundColor( other.mBackgroundColor )
   , mForegroundColor( other.mForegroundColor )
-  , mHasTextFormat( other.mHasTextFormat )
   , mTextFormat( other.mTextFormat )
   , mFormat( other.mFormat ? other.mFormat->clone() : nullptr )
   , mHAlign( other.mHAlign )
@@ -41,7 +40,6 @@ QgsTableCell &QgsTableCell::operator=( const QgsTableCell &other )
   mContent = other.mContent;
   mBackgroundColor = other.mBackgroundColor;
   mForegroundColor = other.mForegroundColor;
-  mHasTextFormat = other.mHasTextFormat;
   mTextFormat = other.mTextFormat;
   mFormat.reset( other.mFormat ? other.mFormat->clone() : nullptr );
   mHAlign = other.mHAlign;
@@ -71,11 +69,13 @@ QVariantMap QgsTableCell::properties( const QgsReadWriteContext &context ) const
     res.insert( QStringLiteral( "format" ), mFormat->configuration( context ) );
   }
 
-  res.insert( QStringLiteral( "has_text_format" ), mHasTextFormat );
-  QDomDocument textDoc;
-  QDomElement textElem = mTextFormat.writeXml( textDoc, context );
-  textDoc.appendChild( textElem );
-  res.insert( QStringLiteral( "text_format" ), textDoc.toString() );
+  if ( mTextFormat.isValid() )
+  {
+    QDomDocument textDoc;
+    QDomElement textElem = mTextFormat.writeXml( textDoc, context );
+    textDoc.appendChild( textElem );
+    res.insert( QStringLiteral( "text_format" ), textDoc.toString() );
+  }
 
   res.insert( QStringLiteral( "halign" ), static_cast< int >( mHAlign ) );
   res.insert( QStringLiteral( "valign" ), static_cast< int >( mVAlign ) );
@@ -98,7 +98,10 @@ void QgsTableCell::setProperties( const QVariantMap &properties, const QgsReadWr
     elem = doc.documentElement();
     mTextFormat.readXml( elem, context );
   }
-  mHasTextFormat = properties.value( QStringLiteral( "has_text_format" ) ).toBool();
+  else
+  {
+    mTextFormat = QgsTextFormat();
+  }
 
   if ( properties.contains( QStringLiteral( "format_type" ) ) )
   {

--- a/src/core/qgstablecell.h
+++ b/src/core/qgstablecell.h
@@ -116,24 +116,6 @@ class CORE_EXPORT QgsTableCell
     void setTextFormat( const QgsTextFormat &format ) { mTextFormat = format; }
 
     /**
-     * Returns TRUE if the cell has a specific text format which should be applied.
-     *
-     * \see textFormat()
-     * \see setHasTextFormat()
-     * \since QGIS 3.16
-     */
-    bool hasTextFormat() const { return mHasTextFormat; }
-
-    /**
-     * Sets whether the cell has a specific text format which should be applied.
-     *
-     * \see setTextFormat()
-     * \see hasTextFormat()
-     * \since QGIS 3.16
-     */
-    void setHasTextFormat( bool hasTextFormat ) { mHasTextFormat = hasTextFormat; }
-
-    /**
      * Returns the numeric format used for numbers in the cell, or NULLPTR if no format is set.
      *
      * \see setNumericFormat()
@@ -213,7 +195,6 @@ class CORE_EXPORT QgsTableCell
     QVariant mContent;
     QColor mBackgroundColor;
     QColor mForegroundColor;
-    bool mHasTextFormat = false;
     QgsTextFormat mTextFormat;
     std::unique_ptr< QgsNumericFormat > mFormat;
 

--- a/src/core/textrenderer/qgstextbackgroundsettings.cpp
+++ b/src/core/textrenderer/qgstextbackgroundsettings.cpp
@@ -44,6 +44,49 @@ QgsTextBackgroundSettings::~QgsTextBackgroundSettings() //NOLINT
 
 }
 
+bool QgsTextBackgroundSettings::operator==( const QgsTextBackgroundSettings &other ) const
+{
+  if ( !d->enabled == other.enabled()
+       || d->type != other.type()
+       || d->svgFile != other.svgFile()
+       || d->sizeType != other.sizeType()
+       || d->size != other.size()
+       || d->sizeUnits != other.sizeUnit()
+       || d->sizeMapUnitScale != other.sizeMapUnitScale()
+       || d->rotationType != other.rotationType()
+       || d->rotation != other.rotation()
+       || d->offset != other.offset()
+       || d->offsetUnits != other.offsetUnit()
+       || d->offsetMapUnitScale != other.offsetMapUnitScale()
+       || d->radii != other.radii()
+       || d->radiiUnits != other.radiiUnit()
+       || d->radiiMapUnitScale != other.radiiMapUnitScale()
+       || d->blendMode != other.blendMode()
+       || d->fillColor != other.fillColor()
+       || d->strokeColor != other.strokeColor()
+       || d->opacity != other.opacity()
+       || d->strokeWidth != other.strokeWidth()
+       || d->strokeWidthUnits != other.strokeWidthUnit()
+       || d->strokeWidthMapUnitScale != other.strokeWidthMapUnitScale()
+       || d->joinStyle != other.joinStyle() )
+    return false;
+
+  if ( static_cast< bool >( d->paintEffect ) != static_cast< bool >( other.paintEffect() )
+       || ( d->paintEffect && d->paintEffect->properties() != other.paintEffect()->properties() ) )
+    return false;
+
+  if ( static_cast< bool >( d->markerSymbol ) != static_cast< bool >( other.markerSymbol() )
+       || ( d->markerSymbol && QgsSymbolLayerUtils::symbolProperties( d->markerSymbol.get() ) != QgsSymbolLayerUtils::symbolProperties( other.markerSymbol() ) ) )
+    return false;
+
+  return true;
+}
+
+bool QgsTextBackgroundSettings::operator!=( const QgsTextBackgroundSettings &other ) const
+{
+  return !( *this == other );
+}
+
 bool QgsTextBackgroundSettings::enabled() const
 {
   return d->enabled;

--- a/src/core/textrenderer/qgstextbackgroundsettings.h
+++ b/src/core/textrenderer/qgstextbackgroundsettings.h
@@ -91,6 +91,9 @@ class CORE_EXPORT QgsTextBackgroundSettings
 
     ~QgsTextBackgroundSettings();
 
+    bool operator==( const QgsTextBackgroundSettings &other ) const;
+    bool operator!=( const QgsTextBackgroundSettings &other ) const;
+
     /**
      * Returns whether the background is enabled.
      * \see setEnabled()

--- a/src/core/textrenderer/qgstextbuffersettings.cpp
+++ b/src/core/textrenderer/qgstextbuffersettings.cpp
@@ -44,6 +44,31 @@ QgsTextBufferSettings::~QgsTextBufferSettings() //NOLINT
 
 }
 
+bool QgsTextBufferSettings::operator==( const QgsTextBufferSettings &other ) const
+{
+  if ( d->enabled != other.enabled()
+       || d->size != other.size()
+       || d->sizeUnit != other.sizeUnit()
+       || d->sizeMapUnitScale != other.sizeMapUnitScale()
+       || d->color != other.color()
+       || d->opacity != other.opacity()
+       || d->fillBufferInterior != other.fillBufferInterior()
+       || d->joinStyle != other.joinStyle()
+       || d->blendMode != other.blendMode() )
+    return false;
+
+  if ( static_cast< bool >( d->paintEffect ) != static_cast< bool >( other.paintEffect() )
+       || ( d->paintEffect && d->paintEffect->properties() != other.paintEffect()->properties() ) )
+    return false;
+
+  return true;
+}
+
+bool QgsTextBufferSettings::operator!=( const QgsTextBufferSettings &other ) const
+{
+  return !( *this == other );
+}
+
 bool QgsTextBufferSettings::enabled() const
 {
   return d->enabled;

--- a/src/core/textrenderer/qgstextbuffersettings.h
+++ b/src/core/textrenderer/qgstextbuffersettings.h
@@ -59,6 +59,9 @@ class CORE_EXPORT QgsTextBufferSettings
 
     ~QgsTextBufferSettings();
 
+    bool operator==( const QgsTextBufferSettings &other ) const;
+    bool operator!=( const QgsTextBufferSettings &other ) const;
+
     /**
      * Returns whether the buffer is enabled.
      * \see setEnabled()

--- a/src/core/textrenderer/qgstextformat.cpp
+++ b/src/core/textrenderer/qgstextformat.cpp
@@ -59,6 +59,64 @@ QgsTextFormat::~QgsTextFormat() //NOLINT
 
 }
 
+bool QgsTextFormat::isValid() const
+{
+  return d->isValid;
+}
+
+void QgsTextFormat::setValid()
+{
+  d->isValid = true;
+}
+
+QgsTextBufferSettings &QgsTextFormat::buffer()
+{
+  d->isValid = true;
+  return mBufferSettings;
+}
+
+void QgsTextFormat::setBuffer( const QgsTextBufferSettings &bufferSettings )
+{
+  d->isValid = true;
+  mBufferSettings = bufferSettings;
+}
+
+QgsTextBackgroundSettings &QgsTextFormat::background()
+{
+  d->isValid = true;
+  return mBackgroundSettings;
+}
+
+void QgsTextFormat::setBackground( const QgsTextBackgroundSettings &backgroundSettings )
+{
+  d->isValid = true;
+  mBackgroundSettings = backgroundSettings;
+}
+
+QgsTextShadowSettings &QgsTextFormat::shadow()
+{
+  d->isValid = true;
+  return mShadowSettings;
+}
+
+void QgsTextFormat::setShadow( const QgsTextShadowSettings &shadowSettings )
+{
+  d->isValid = true;
+  mShadowSettings = shadowSettings;
+}
+
+QgsTextMaskSettings &QgsTextFormat::mask()
+{
+  d->isValid = true;
+  return mMaskSettings;
+}
+
+void QgsTextFormat::setMask( const QgsTextMaskSettings &maskSettings )
+{
+  d->isValid = true;
+  mMaskSettings = maskSettings;
+}
+
 QFont QgsTextFormat::font() const
 {
   return d->textFont;
@@ -87,6 +145,7 @@ QFont QgsTextFormat::scaledFont( const QgsRenderContext &context, double scaleFa
 
 void QgsTextFormat::setFont( const QFont &font )
 {
+  d->isValid = true;
   d->textFont = font;
 }
 
@@ -101,6 +160,7 @@ QString QgsTextFormat::namedStyle() const
 
 void QgsTextFormat::setNamedStyle( const QString &style )
 {
+  d->isValid = true;
   QgsFontUtils::updateFontViaStyle( d->textFont, style );
   d->textNamedStyle = style;
 }
@@ -112,6 +172,7 @@ QgsUnitTypes::RenderUnit QgsTextFormat::sizeUnit() const
 
 void QgsTextFormat::setSizeUnit( QgsUnitTypes::RenderUnit unit )
 {
+  d->isValid = true;
   d->fontSizeUnits = unit;
 }
 
@@ -122,6 +183,7 @@ QgsMapUnitScale QgsTextFormat::sizeMapUnitScale() const
 
 void QgsTextFormat::setSizeMapUnitScale( const QgsMapUnitScale &scale )
 {
+  d->isValid = true;
   d->fontSizeMapUnitScale = scale;
 }
 
@@ -132,6 +194,7 @@ double QgsTextFormat::size() const
 
 void QgsTextFormat::setSize( double size )
 {
+  d->isValid = true;
   d->fontSize = size;
 }
 
@@ -142,6 +205,7 @@ QColor QgsTextFormat::color() const
 
 void QgsTextFormat::setColor( const QColor &color )
 {
+  d->isValid = true;
   d->textColor = color;
 }
 
@@ -152,6 +216,7 @@ double QgsTextFormat::opacity() const
 
 void QgsTextFormat::setOpacity( double opacity )
 {
+  d->isValid = true;
   d->opacity = opacity;
 }
 
@@ -162,6 +227,7 @@ QPainter::CompositionMode QgsTextFormat::blendMode() const
 
 void QgsTextFormat::setBlendMode( QPainter::CompositionMode mode )
 {
+  d->isValid = true;
   d->blendMode = mode;
 }
 
@@ -172,6 +238,7 @@ double QgsTextFormat::lineHeight() const
 
 void QgsTextFormat::setLineHeight( double height )
 {
+  d->isValid = true;
   d->multilineHeight = height;
 }
 
@@ -182,6 +249,7 @@ QgsTextFormat::TextOrientation QgsTextFormat::orientation() const
 
 void QgsTextFormat::setOrientation( TextOrientation orientation )
 {
+  d->isValid = true;
   d->orientation = orientation;
 }
 
@@ -192,6 +260,7 @@ bool QgsTextFormat::allowHtmlFormatting() const
 
 void QgsTextFormat::setAllowHtmlFormatting( bool allow )
 {
+  d->isValid = true;
   d->allowHtmlFormatting = allow;
 }
 
@@ -202,11 +271,13 @@ QColor QgsTextFormat::previewBackgroundColor() const
 
 void QgsTextFormat::setPreviewBackgroundColor( const QColor &color )
 {
+  d->isValid = true;
   d->previewBackgroundColor = color;
 }
 
 void QgsTextFormat::readFromLayer( QgsVectorLayer *layer )
 {
+  d->isValid = true;
   QFont appFont = QApplication::font();
   mTextFontFamily = layer->customProperty( QStringLiteral( "labeling/fontFamily" ), QVariant( appFont.family() ) ).toString();
   QString fontFamily = mTextFontFamily;
@@ -290,6 +361,7 @@ void QgsTextFormat::readFromLayer( QgsVectorLayer *layer )
 
 void QgsTextFormat::readXml( const QDomElement &elem, const QgsReadWriteContext &context )
 {
+  d->isValid = true;
   QDomElement textStyleElem;
   if ( elem.nodeName() == QStringLiteral( "text-style" ) )
     textStyleElem = elem;
@@ -580,6 +652,7 @@ bool QgsTextFormat::containsAdvancedEffects() const
 
 QgsPropertyCollection &QgsTextFormat::dataDefinedProperties()
 {
+  d->isValid = true;
   return d->mDataDefinedProperties;
 }
 
@@ -600,11 +673,13 @@ QSet<QString> QgsTextFormat::referencedFields( const QgsRenderContext &context )
 
 void QgsTextFormat::setDataDefinedProperties( const QgsPropertyCollection &collection )
 {
+  d->isValid = true;
   d->mDataDefinedProperties = collection;
 }
 
 void QgsTextFormat::updateDataDefinedProperties( QgsRenderContext &context )
 {
+  d->isValid = true;
   if ( !d->mDataDefinedProperties.hasActiveProperties() )
     return;
 

--- a/src/core/textrenderer/qgstextformat.cpp
+++ b/src/core/textrenderer/qgstextformat.cpp
@@ -59,6 +59,36 @@ QgsTextFormat::~QgsTextFormat() //NOLINT
 
 }
 
+bool QgsTextFormat::operator==( const QgsTextFormat &other ) const
+{
+  if ( d->isValid != other.isValid()
+       || d->textFont != other.font()
+       || d->textNamedStyle != other.namedStyle()
+       || d->fontSizeUnits != other.sizeUnit()
+       || d->fontSizeMapUnitScale != other.sizeMapUnitScale()
+       || d->fontSize != other.size()
+       || d->textColor != other.color()
+       || d->opacity != other.opacity()
+       || d->blendMode != other.blendMode()
+       || d->multilineHeight != other.lineHeight()
+       || d->orientation != other.orientation()
+       || d->previewBackgroundColor != other.previewBackgroundColor()
+       || d->allowHtmlFormatting != other.allowHtmlFormatting()
+       || mBufferSettings != other.mBufferSettings
+       || mBackgroundSettings != other.mBackgroundSettings
+       || mShadowSettings != other.mShadowSettings
+       || mMaskSettings != other.mMaskSettings
+       || d->mDataDefinedProperties != other.dataDefinedProperties() )
+    return false;
+
+  return true;
+}
+
+bool QgsTextFormat::operator!=( const QgsTextFormat &other ) const
+{
+  return !( *this == other );
+}
+
 bool QgsTextFormat::isValid() const
 {
   return d->isValid;

--- a/src/core/textrenderer/qgstextformat.cpp
+++ b/src/core/textrenderer/qgstextformat.cpp
@@ -63,7 +63,7 @@ bool QgsTextFormat::operator==( const QgsTextFormat &other ) const
 {
   if ( d->isValid != other.isValid()
        || d->textFont != other.font()
-       || d->textNamedStyle != other.namedStyle()
+       || namedStyle() != other.namedStyle()
        || d->fontSizeUnits != other.sizeUnit()
        || d->fontSizeMapUnitScale != other.sizeMapUnitScale()
        || d->fontSize != other.size()

--- a/src/core/textrenderer/qgstextformat.h
+++ b/src/core/textrenderer/qgstextformat.h
@@ -63,6 +63,9 @@ class CORE_EXPORT QgsTextFormat
 
     ~QgsTextFormat();
 
+    bool operator==( const QgsTextFormat &other ) const;
+    bool operator!=( const QgsTextFormat &other ) const;
+
     /**
      * Returns TRUE if the format is valid.
      *

--- a/src/core/textrenderer/qgstextformat.h
+++ b/src/core/textrenderer/qgstextformat.h
@@ -47,6 +47,10 @@ class CORE_EXPORT QgsTextFormat
       RotationBasedOrientation, //!< Horizontally or vertically oriented text based on rotation (only available for map labeling)
     };
 
+    /**
+     * Default constructor for QgsTextFormat. Creates a text format initially
+     * set to an invalid state (see isValid()).
+     */
     QgsTextFormat();
 
     /**
@@ -60,10 +64,32 @@ class CORE_EXPORT QgsTextFormat
     ~QgsTextFormat();
 
     /**
+     * Returns TRUE if the format is valid.
+     *
+     * A default constructed QgsTextFormat is invalid, until at least one or more properties
+     * have been set on the format. An invalid state can be used as a representation of a "not set"
+     * text format, e.g. for indicating that a default text format should be used.
+     *
+     * \note Calling any setter on a QgsTextFormat object will automatically set the format as valid.
+     *
+     * \see setValid()
+     * \since QGIS 3.16
+     */
+    bool isValid() const;
+
+    /**
+     * Sets the format to a valid state, without changing any of the default format settings.
+     *
+     * \see isValid()
+     * \since QGIS 3.16
+     */
+    void setValid();
+
+    /**
      * Returns a reference to the text buffer settings.
      * \see setBuffer()
      */
-    QgsTextBufferSettings &buffer() { return mBufferSettings; }
+    QgsTextBufferSettings &buffer();
 
     /**
      * Returns a reference to the text buffer settings.
@@ -76,13 +102,13 @@ class CORE_EXPORT QgsTextFormat
      * \param bufferSettings buffer settings
      * \see buffer()
      */
-    void setBuffer( const QgsTextBufferSettings &bufferSettings ) { mBufferSettings = bufferSettings; }
+    void setBuffer( const QgsTextBufferSettings &bufferSettings );
 
     /**
      * Returns a reference to the text background settings.
      * \see setBackground()
      */
-    QgsTextBackgroundSettings &background() { return mBackgroundSettings; }
+    QgsTextBackgroundSettings &background();
 
     /**
      * Returns a reference to the text background settings.
@@ -95,13 +121,13 @@ class CORE_EXPORT QgsTextFormat
      * \param backgroundSettings background settings
      * \see background()
      */
-    void setBackground( const QgsTextBackgroundSettings &backgroundSettings ) { mBackgroundSettings = backgroundSettings; }
+    void setBackground( const QgsTextBackgroundSettings &backgroundSettings );
 
     /**
      * Returns a reference to the text drop shadow settings.
      * \see setShadow()
      */
-    QgsTextShadowSettings &shadow() { return mShadowSettings; }
+    QgsTextShadowSettings &shadow();
 
     /**
      * Returns a reference to the text drop shadow settings.
@@ -114,13 +140,13 @@ class CORE_EXPORT QgsTextFormat
      * \param shadowSettings shadow settings
      * \see shadow()
      */
-    void setShadow( const QgsTextShadowSettings &shadowSettings ) { mShadowSettings = shadowSettings; }
+    void setShadow( const QgsTextShadowSettings &shadowSettings );
 
     /**
      * Returns a reference to the masking settings.
      * \see setMask()
      */
-    QgsTextMaskSettings &mask() { return mMaskSettings; }
+    QgsTextMaskSettings &mask();
 
     /**
      * Returns a reference to the masking settings.
@@ -137,7 +163,7 @@ class CORE_EXPORT QgsTextFormat
      * \see mask()
      * \since QGIS 3.12
      */
-    void setMask( const QgsTextMaskSettings &maskSettings ) { mMaskSettings = maskSettings; }
+    void setMask( const QgsTextMaskSettings &maskSettings );
 
     /**
      * Returns the font used for rendering text. Note that the size of the font

--- a/src/core/textrenderer/qgstextmasksettings.cpp
+++ b/src/core/textrenderer/qgstextmasksettings.cpp
@@ -37,6 +37,30 @@ QgsTextMaskSettings &QgsTextMaskSettings::operator=( const QgsTextMaskSettings &
   return *this;
 }
 
+bool QgsTextMaskSettings::operator==( const QgsTextMaskSettings &other ) const
+{
+  if ( d->enabled != other.enabled()
+       || d->type != other.type()
+       || d->size != other.size()
+       || d->sizeUnit != other.sizeUnit()
+       || d->sizeMapUnitScale != other.sizeMapUnitScale()
+       || d->joinStyle != other.joinStyle()
+       || d->opacity != other.opacity()
+       || d->maskedSymbolLayers != other.maskedSymbolLayers() )
+    return false;
+
+  if ( static_cast< bool >( d->paintEffect ) != static_cast< bool >( other.paintEffect() )
+       || ( d->paintEffect && d->paintEffect->properties() != other.paintEffect()->properties() ) )
+    return false;
+
+  return true;
+}
+
+bool QgsTextMaskSettings::operator!=( const QgsTextMaskSettings &other ) const
+{
+  return !( *this == other );
+}
+
 bool QgsTextMaskSettings::enabled() const
 {
   return d->enabled;

--- a/src/core/textrenderer/qgstextmasksettings.h
+++ b/src/core/textrenderer/qgstextmasksettings.h
@@ -66,6 +66,9 @@ class CORE_EXPORT QgsTextMaskSettings
 
     ~QgsTextMaskSettings();
 
+    bool operator==( const QgsTextMaskSettings &other ) const;
+    bool operator!=( const QgsTextMaskSettings &other ) const;
+
     /**
      * Returns whether the mask is enabled.
      */

--- a/src/core/textrenderer/qgstextrenderer_p.h
+++ b/src/core/textrenderer/qgstextrenderer_p.h
@@ -258,6 +258,7 @@ class QgsTextSettingsPrivate : public QSharedData
 
     QgsTextSettingsPrivate( const QgsTextSettingsPrivate &other )
       : QSharedData( other )
+      , isValid( other.isValid )
       , textFont( other.textFont )
       , textNamedStyle( other.textNamedStyle )
       , fontSizeUnits( other.fontSizeUnits )
@@ -274,6 +275,7 @@ class QgsTextSettingsPrivate : public QSharedData
     {
     }
 
+    bool isValid = false;
     QFont textFont;
     QString textNamedStyle;
     QgsUnitTypes::RenderUnit fontSizeUnits = QgsUnitTypes::RenderPoints;

--- a/src/core/textrenderer/qgstextshadowsettings.cpp
+++ b/src/core/textrenderer/qgstextshadowsettings.cpp
@@ -43,6 +43,33 @@ QgsTextShadowSettings::~QgsTextShadowSettings() //NOLINT
 
 }
 
+bool QgsTextShadowSettings::operator==( const QgsTextShadowSettings &other ) const
+{
+  if ( d->enabled != other.enabled()
+       || d->shadowUnder != other.shadowPlacement()
+       || d->offsetAngle != other.offsetAngle()
+       || d->offsetDist != other.offsetDistance()
+       || d->offsetUnits != other.offsetUnit()
+       || d->offsetMapUnitScale != other.offsetMapUnitScale()
+       || d->offsetGlobal != other.offsetGlobal()
+       || d->radius != other.blurRadius()
+       || d->radiusUnits != other.blurRadiusUnit()
+       || d->radiusMapUnitScale != other.blurRadiusMapUnitScale()
+       || d->radiusAlphaOnly != other.blurAlphaOnly()
+       || d->scale != other.scale()
+       || d->color != other.color()
+       || d->opacity != other.opacity()
+       || d->blendMode != other.blendMode() )
+    return false;
+
+  return true;
+}
+
+bool QgsTextShadowSettings::operator!=( const QgsTextShadowSettings &other ) const
+{
+  return !( *this == other );
+}
+
 bool QgsTextShadowSettings::enabled() const
 {
   return d->enabled;

--- a/src/core/textrenderer/qgstextshadowsettings.h
+++ b/src/core/textrenderer/qgstextshadowsettings.h
@@ -61,6 +61,9 @@ class CORE_EXPORT QgsTextShadowSettings
 
     ~QgsTextShadowSettings();
 
+    bool operator==( const QgsTextShadowSettings &other ) const;
+    bool operator!=( const QgsTextShadowSettings &other ) const;
+
     /**
      * Returns whether the shadow is enabled.
      * \see setEnabled()

--- a/src/gui/qgsfontbutton.cpp
+++ b/src/gui/qgsfontbutton.cpp
@@ -821,6 +821,12 @@ void QgsFontButton::resizeEvent( QResizeEvent *event )
 
 void QgsFontButton::updatePreview( const QColor &color, QgsTextFormat *format, QFont *font )
 {
+  if ( mShowNoFormat && !mFormat.isValid() )
+  {
+    setIcon( QPixmap() );
+    return;
+  }
+
   QgsTextFormat tempFormat;
   QFont tempFont;
 

--- a/src/gui/qgsfontbutton.h
+++ b/src/gui/qgsfontbutton.h
@@ -163,6 +163,45 @@ class GUI_EXPORT QgsFontButton : public QToolButton
      */
     void registerExpressionContextGenerator( QgsExpressionContextGenerator *generator );
 
+    /**
+     * Sets whether the "null format" option should be shown in the button's drop-down menu. This option
+     * is only used for buttons set to the ModeTextRenderer mode().
+     *
+     * If selected, the "null format" option sets the button's format to an invalid QgsTextFormat. This
+     * can be used to represent a "use default format" state for the button.
+     *
+     * By default this option is not shown.
+     *
+     * \see setNoFormatString()
+     * \see showNullFormat()
+     * \since QGIS 3.16
+     */
+    void setShowNullFormat( const bool show ) { mShowNoFormat = show; }
+
+    /**
+     * Sets the \a string to use for the "null format" option in the button's drop-down menu.
+     *
+     * \note The "null format" option is only shown if showNullFormat() is TRUE.
+     *
+     * \see setShowNullFormat()
+     * \since QGIS 3.16
+     */
+    void setNoFormatString( const QString &string ) { mNullFormatString = string; }
+
+    /**
+     * Returns whether the "null format" option will be shown in the button's drop-down menu. This option
+     * is only used for buttons set to the ModeTextRenderer mode().
+     *
+     * If selected, the "null format" option sets the button's format to an invalid QgsTextFormat. This
+     * can be used to represent a "use default format" state for the button.
+     *
+     * By default this option is not shown.
+     *
+     * \see setShowNullFormat()
+     * \since QGIS 3.16
+     */
+    bool showNullFormat() const { return mShowNoFormat; }
+
   public slots:
 
     /**
@@ -171,6 +210,15 @@ class GUI_EXPORT QgsFontButton : public QToolButton
      * \see textFormat()
      */
     void setTextFormat( const QgsTextFormat &format );
+
+    /**
+     * Sets the text format to a null (invalid) QgsTextFormat.
+     *
+     * This is only used when mode() is ModeTextRenderer.
+     *
+     * \since QGIS 3.16
+     */
+    void setToNullFormat();
 
     /**
      * Sets the current text \a font to show in the widget.
@@ -277,6 +325,10 @@ class GUI_EXPORT QgsFontButton : public QToolButton
     QSize mIconSize;
 
     QgsExpressionContextGenerator *mExpressionContextGenerator = nullptr;
+
+    bool mShowNoFormat = false;
+    QString mNullFormatString;
+    QPointer< QAction > mNullFormatAction;
 
     /**
      * Attempts to parse \a mimeData as a text format.

--- a/src/gui/tableeditor/qgstableeditordialog.cpp
+++ b/src/gui/tableeditor/qgstableeditordialog.cpp
@@ -86,10 +86,6 @@ QgsTableEditorDialog::QgsTableEditorDialog( QWidget *parent )
   {
     mTableWidget->setSelectionTextFormat( mFormattingWidget->textFormat() );
   } );
-  connect( mFormattingWidget, &QgsTableEditorFormattingWidget::hasTextFormatChanged, this, [ = ]
-  {
-    mTableWidget->setSelectionHasTextFormat( mFormattingWidget->textFormatSet() );
-  } );
 
   connect( mFormattingWidget, &QgsTableEditorFormattingWidget::numberFormatChanged, this, [ = ]
   {
@@ -105,7 +101,7 @@ QgsTableEditorDialog::QgsTableEditorDialog( QWidget *parent )
     mFormattingWidget->setNumericFormat( mTableWidget->selectionNumericFormat(), mTableWidget->hasMixedSelectionNumericFormat() );
     mFormattingWidget->setRowHeight( mTableWidget->selectionRowHeight() );
     mFormattingWidget->setColumnWidth( mTableWidget->selectionColumnWidth() );
-    mFormattingWidget->setTextFormat( mTableWidget->selectionTextFormat(), mTableWidget->selectionHasTextFormat(), mTableWidget->hasMixedSelectionHasTextFormat() );
+    mFormattingWidget->setTextFormat( mTableWidget->selectionTextFormat() );
     mFormattingWidget->setHorizontalAlignment( mTableWidget->selectionHorizontalAlignment() );
     mFormattingWidget->setVerticalAlignment( mTableWidget->selectionVerticalAlignment() );
 

--- a/src/gui/tableeditor/qgstableeditorformattingwidget.cpp
+++ b/src/gui/tableeditor/qgstableeditorformattingwidget.cpp
@@ -25,7 +25,9 @@ QgsTableEditorFormattingWidget::QgsTableEditorFormattingWidget( QWidget *parent 
   setPanelTitle( tr( "Formatting" ) );
 
   mFormatNumbersCheckBox->setTristate( false );
-  mTextFormatCheckBox->setTristate( false );
+
+  mFontButton->setShowNullFormat( true );
+  mFontButton->setNoFormatString( tr( "Clear Formatting" ) );
 
   mTextColorButton->setAllowOpacity( true );
   mTextColorButton->setColorDialogTitle( tr( "Text Color" ) );
@@ -70,15 +72,6 @@ QgsTableEditorFormattingWidget::QgsTableEditorFormattingWidget( QWidget *parent 
       mFormatNumbersCheckBox->setTristate( false );
     if ( !mBlockSignals )
       emit numberFormatChanged();
-  } );
-
-  connect( mTextFormatCheckBox, &QCheckBox::stateChanged, this, [ = ]( int state )
-  {
-    mFontButton->setEnabled( state == Qt::Checked );
-    if ( state != Qt::PartiallyChecked )
-      mTextFormatCheckBox->setTristate( false );
-    if ( !mBlockSignals )
-      emit hasTextFormatChanged();
   } );
 
   connect( mFontButton, &QgsFontButton::changed, this, [ = ]
@@ -154,11 +147,6 @@ QgsTextFormat QgsTableEditorFormattingWidget::textFormat() const
   return mFontButton->textFormat();
 }
 
-bool QgsTableEditorFormattingWidget::textFormatSet() const
-{
-  return mTextFormatCheckBox->checkState() == Qt::Checked;
-}
-
 void QgsTableEditorFormattingWidget::setForegroundColor( const QColor &color )
 {
   mBlockSignals++;
@@ -182,11 +170,9 @@ void QgsTableEditorFormattingWidget::setNumericFormat( QgsNumericFormat *format,
   mBlockSignals--;
 }
 
-void QgsTableEditorFormattingWidget::setTextFormat( const QgsTextFormat &format, bool isSet, bool isMixedFormat )
+void QgsTableEditorFormattingWidget::setTextFormat( const QgsTextFormat &format )
 {
   mBlockSignals++;
-  mTextFormatCheckBox->setTristate( isMixedFormat );
-  mTextFormatCheckBox->setCheckState( isMixedFormat ? Qt::PartiallyChecked : ( isSet ? Qt::Checked : Qt::Unchecked ) );
   mFontButton->setTextFormat( format );
   mBlockSignals--;
 }

--- a/src/gui/tableeditor/qgstableeditorformattingwidget.h
+++ b/src/gui/tableeditor/qgstableeditorformattingwidget.h
@@ -61,18 +61,9 @@ class GUI_EXPORT QgsTableEditorFormattingWidget : public QgsPanelWidget, private
      * Returns the current text format shown in the widget.
      *
      * \see setTextFormat()
-     * \see textFormatSet()
      * \since QGIS 3.16
      */
     QgsTextFormat textFormat() const;
-
-    /**
-     * Returns TRUE if a text format is set in the widget.
-     *
-     * \see textFormat()
-     * \since QGIS 3.16
-     */
-    bool textFormatSet() const;
 
     /**
      * Sets the cell foreground \a color to show in the widget.
@@ -102,12 +93,10 @@ class GUI_EXPORT QgsTableEditorFormattingWidget : public QgsPanelWidget, private
     /**
      * Sets the text \a format to show in the widget.
      *
-     * if \a isMixedFormat is TRUE then the widget will be set to indicate a "mixed format" setting.
-     *
      * \see textFormat()
      * \since QGIS 3.16
      */
-    void setTextFormat( const QgsTextFormat &format, bool isSet, bool isMixedFormat );
+    void setTextFormat( const QgsTextFormat &format );
 
     /**
      * Sets the row \a height to show in the widget, or 0 for automatic height.
@@ -172,13 +161,6 @@ class GUI_EXPORT QgsTableEditorFormattingWidget : public QgsPanelWidget, private
      * \since QGIS 3.16
      */
     void textFormatChanged();
-
-    /**
-     * Emitted whenever the apply text format option in the widget is changed.
-     *
-     * \since QGIS 3.16
-     */
-    void hasTextFormatChanged();
 
     /**
      * Emitted whenever the row \a height shown in the widget is changed.

--- a/src/gui/tableeditor/qgstableeditorwidget.h
+++ b/src/gui/tableeditor/qgstableeditorwidget.h
@@ -161,13 +161,6 @@ class GUI_EXPORT QgsTableEditorWidget : public QTableWidget
     bool hasMixedSelectionNumericFormat();
 
     /**
-     * Returns TRUE if the current selection has a mix of text format override state.
-     *
-     * \since QGIS 3.16
-     */
-    bool hasMixedSelectionHasTextFormat();
-
-    /**
      * Returns the foreground color for the currently selected cells.
      *
      * If the selected cells have a mix of different foreground colors then an
@@ -212,16 +205,11 @@ class GUI_EXPORT QgsTableEditorWidget : public QTableWidget
     /**
      * Returns the text format for the currently selected cells.
      *
-     * \since QGIS 3.16
-     */
-    QgsTextFormat selectionTextFormat();
-
-    /**
-     * Returns whether the currently selected cells have the text format override option set.
+     * Returns an invalid QgsTextFormat if the selection has mixed text format.
      *
      * \since QGIS 3.16
      */
-    bool selectionHasTextFormat();
+    QgsTextFormat selectionTextFormat();
 
     /**
      * Returns the height (in millimeters) of the rows associated with the current selection,
@@ -404,13 +392,6 @@ class GUI_EXPORT QgsTableEditorWidget : public QTableWidget
     void setSelectionTextFormat( const QgsTextFormat &format );
 
     /**
-     * Sets whether the selected cells have the text format override option set.
-     *
-     * \since QGIS 3.16
-     */
-    void setSelectionHasTextFormat( bool hasFormat );
-
-    /**
      * Sets the row \a height (in millimeters) for the currently selected rows, or 0 for automatic row height.
      *
      * \see setSelectionColumnWidth()
@@ -466,7 +447,6 @@ class GUI_EXPORT QgsTableEditorWidget : public QTableWidget
       RowHeight,
       ColumnWidth,
       CellContent,
-      HasTextFormat,
       TextFormat,
       HorizontalAlignment,
       VerticalAlignment

--- a/src/ui/qgstableeditorformattingwidgetbase.ui
+++ b/src/ui/qgstableeditorformattingwidgetbase.ui
@@ -152,13 +152,6 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="0">
-           <widget class="QCheckBox" name="mTextFormatCheckBox">
-            <property name="text">
-             <string>Override text format</string>
-            </property>
-           </widget>
-          </item>
           <item row="1" column="1">
            <widget class="QPushButton" name="mCustomizeFormatButton">
             <property name="text">
@@ -198,6 +191,13 @@
           </item>
           <item row="2" column="1">
            <widget class="QgsAlignmentComboBox" name="mHorizontalAlignComboBox"/>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Text format</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -307,7 +307,6 @@
   <tabstop>mTextColorButton</tabstop>
   <tabstop>mBackgroundColorButton</tabstop>
   <tabstop>groupBox_7</tabstop>
-  <tabstop>mTextFormatCheckBox</tabstop>
   <tabstop>mFontButton</tabstop>
   <tabstop>mFormatNumbersCheckBox</tabstop>
   <tabstop>mCustomizeFormatButton</tabstop>

--- a/tests/src/core/testqgslayoutmanualtable.cpp
+++ b/tests/src/core/testqgslayoutmanualtable.cpp
@@ -444,7 +444,6 @@ void TestQgsLayoutManualTable::cellTextFormat()
   f1.buffer().setColor( QColor( 100, 130, 150 ) );
   f1.buffer().setSize( 1 );
   c1.setTextFormat( f1 );
-  c1.setHasTextFormat( true );
 
   QgsTableCell c3( QStringLiteral( "Plane" ) );
   QgsTextFormat f2 = table->contentTextFormat();
@@ -453,7 +452,6 @@ void TestQgsLayoutManualTable::cellTextFormat()
   f2.buffer().setColor( QColor( 150, 110, 90 ) );
   f2.buffer().setSize( 1 );
   c3.setTextFormat( f2 );
-  c3.setHasTextFormat( true );
 
   QgsTableCell c5( QStringLiteral( "B" ) );
   QgsTextFormat f3 = table->contentTextFormat();
@@ -462,7 +460,6 @@ void TestQgsLayoutManualTable::cellTextFormat()
   f3.buffer().setColor( QColor( 200, 110, 90 ) );
   f3.buffer().setSize( 1 );
   c5.setTextFormat( f3 );
-  c5.setHasTextFormat( true );
 
   table->setTableContents( QgsTableContents() << ( QgsTableRow() << c1 << QgsTableCell( QStringLiteral( "Helicopter" ) ) << c3 )
                            << ( QgsTableRow() << QgsTableCell( QStringLiteral( "A" ) ) << c5 << QgsTableCell( QStringLiteral( "C" ) ) ) );

--- a/tests/src/core/testqgsproperty.cpp
+++ b/tests/src/core/testqgsproperty.cpp
@@ -1375,6 +1375,10 @@ void TestQgsProperty::propertyCollection()
   QVERIFY( !collection.hasDynamicProperties() );
   QVERIFY( !collection.hasActiveProperties() );
 
+  QgsPropertyCollection collection2;
+  QVERIFY( collection == collection2 );
+  QVERIFY( !( collection != collection2 ) );
+
   QgsProperty property = QgsProperty::fromValue( "value", true );
   collection.setProperty( Property1, property );
   QVERIFY( collection.hasProperty( Property1 ) );
@@ -1385,6 +1389,12 @@ void TestQgsProperty::propertyCollection()
   QVERIFY( collection.isActive( Property1 ) );
   QVERIFY( collection.hasActiveProperties() );
   QVERIFY( !collection.hasDynamicProperties() );
+
+  QVERIFY( collection != collection2 );
+  QVERIFY( !( collection == collection2 ) );
+  collection2.setProperty( Property1, property );
+  QVERIFY( collection == collection2 );
+  QVERIFY( !( collection != collection2 ) );
 
   //preparation
   QVERIFY( collection.prepare( context ) );
@@ -1403,6 +1413,8 @@ void TestQgsProperty::propertyCollection()
   QCOMPARE( collection.property( Property1 ).value( context ), property2.value( context ) );
   QVERIFY( collection.hasActiveProperties() );
   QVERIFY( !collection.hasDynamicProperties() );
+  QVERIFY( collection != collection2 );
+  QVERIFY( !( collection == collection2 ) );
 
   //implicit conversion
   collection.setProperty( Property3, 5 );
@@ -1431,6 +1443,13 @@ void TestQgsProperty::propertyCollection()
   collection.setProperty( Property3, QgsProperty::fromField( QStringLiteral( "field1" ), true ) );
   collection.setProperty( Property4, QgsProperty::fromExpression( QStringLiteral( "\"field1\" + \"field2\"" ), true ) );
   QCOMPARE( collection.count(), 4 );
+
+  collection2 = collection;
+  QVERIFY( collection == collection2 );
+  QVERIFY( !( collection != collection2 ) );
+  collection2.setProperty( Property3, QgsProperty() );
+  QVERIFY( collection != collection2 );
+  QVERIFY( !( collection == collection2 ) );
 
   // test referenced fields
   QCOMPARE( collection.referencedFields( context ).count(), 2 );
@@ -1466,7 +1485,7 @@ void TestQgsProperty::propertyCollection()
   QVERIFY( restoredCollection.hasDynamicProperties() );
 
   // copy constructor
-  QgsPropertyCollection collection2( collection );
+  collection2 = QgsPropertyCollection( collection );
   QCOMPARE( collection2.name(), QStringLiteral( "collection" ) );
   QCOMPARE( collection2.count(), 4 );
   QCOMPARE( collection2.property( Property1 ).propertyType(), QgsProperty::StaticProperty );

--- a/tests/src/gui/testqgstableeditor.cpp
+++ b/tests/src/gui/testqgstableeditor.cpp
@@ -87,7 +87,6 @@ void TestQgsTableEditor::testData()
   c2.setForegroundColor( QColor( 0, 255, 0 ) );
   QgsTextFormat textFormat;
   textFormat.setSize( 12.6 );
-  c2.setHasTextFormat( true );
   c2.setTextFormat( textFormat );
   c2.setHorizontalAlignment( Qt::AlignRight );
   c2.setVerticalAlignment( Qt::AlignTop );
@@ -99,7 +98,7 @@ void TestQgsTableEditor::testData()
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).backgroundColor().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).foregroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).hasTextFormat() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).horizontalAlignment(), Qt::AlignLeft );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).verticalAlignment(), Qt::AlignVCenter );
@@ -107,7 +106,7 @@ void TestQgsTableEditor::testData()
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).backgroundColor(), QColor( 255, 0, 0 ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).foregroundColor(), QColor( 0, 255, 0 ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 1 ).numericFormat() );
-  QVERIFY( w.tableContents().at( 0 ).at( 1 ).hasTextFormat() );
+  QVERIFY( w.tableContents().at( 0 ).at( 1 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).textFormat().size(), 12.6 );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).horizontalAlignment(), Qt::AlignRight );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).verticalAlignment(), Qt::AlignTop );
@@ -936,25 +935,23 @@ void TestQgsTableEditor::textFormat()
   QgsTextFormat format;
   format.setSize( 12.6 );
   c3.setTextFormat( format );
-  c3.setHasTextFormat( false );
   QgsTableCell c2( 76 );
   c2.setTextFormat( format );
-  c2.setHasTextFormat( true );
   w.setTableContents( QgsTableContents() << ( QgsTableRow() << QgsTableCell( QStringLiteral( "Jet" ) ) << c2 << c3 << QgsTableCell( QStringLiteral( "Jet3" ) ) ) );
   QCOMPARE( spy.count(), 1 );
 
   QCOMPARE( w.tableContents().size(), 1 );
   QCOMPARE( w.tableContents().at( 0 ).size(), 4 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).hasTextFormat() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().toString(), QStringLiteral( "76" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).textFormat().size(), 12.6 );
-  QVERIFY( w.tableContents().at( 0 ).at( 1 ).hasTextFormat() );
+  QVERIFY( w.tableContents().at( 0 ).at( 1 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QStringLiteral( "87" ) );
-  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).hasTextFormat() );
+  QVERIFY( w.tableContents().at( 0 ).at( 2 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).textFormat().size(), 12.6 );
   QCOMPARE( w.tableContents().at( 0 ).at( 3 ).content().toString(), QStringLiteral( "Jet3" ) );
-  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).hasTextFormat() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).textFormat().isValid() );
 
   w.selectionModel()->clearSelection();
   format.setSize( 21 );
@@ -971,6 +968,7 @@ void TestQgsTableEditor::textFormat()
   QVERIFY( w.selectionTextFormat().size() !=  21.0 );
   w.setSelectionTextFormat( format );
   QCOMPARE( spy.count(), 2 );
+  QVERIFY( w.selectionTextFormat().isValid() );
   QCOMPARE( w.selectionTextFormat().size(), 21.0 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).textFormat().size(), 21.0 );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).textFormat().size(), 21.0 );

--- a/tests/src/python/test_qgsfontbutton.py
+++ b/tests/src/python/test_qgsfontbutton.py
@@ -103,6 +103,21 @@ class TestQgsFontButton(unittest.TestCase):
         r = button.textFormat()
         self.assertEqual(r.color(), QColor(0, 255, 0))
 
+    def testNull(self):
+        button = QgsFontButton()
+        self.assertFalse(button.showNullFormat())
+        button.setShowNullFormat(True)
+        self.assertTrue(button.showNullFormat())
+
+        s = QgsTextFormat()
+        s.setFont(getTestFont())
+        button.setTextFormat(s)
+        self.assertTrue(button.textFormat().isValid())
+        button.setToNullFormat()
+        self.assertFalse(button.textFormat().isValid())
+        button.setTextFormat(s)
+        self.assertTrue(button.textFormat().isValid())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgstablecell.py
+++ b/tests/src/python/test_qgstablecell.py
@@ -36,7 +36,7 @@ class TestQgsTableCell(unittest.TestCase):
         self.assertFalse(c.backgroundColor().isValid())
         self.assertFalse(c.foregroundColor().isValid())
         self.assertFalse(c.numericFormat())
-        self.assertFalse(c.hasTextFormat())
+        self.assertFalse(c.textFormat().isValid())
 
         c.setBackgroundColor(QColor(255, 0, 0))
         c.setForegroundColor(QColor(255, 0, 255))
@@ -48,9 +48,8 @@ class TestQgsTableCell(unittest.TestCase):
         format = QgsTextFormat()
         format.setSize(16.8)
         c.setTextFormat(format)
-        c.setHasTextFormat(True)
         self.assertEqual(c.textFormat().size(), 16.8)
-        self.assertTrue(c.hasTextFormat())
+        self.assertTrue(c.textFormat().isValid())
 
     def testProperties(self):
         c = QgsTableCell('test')
@@ -64,7 +63,7 @@ class TestQgsTableCell(unittest.TestCase):
         self.assertFalse(c2.backgroundColor().isValid())
         self.assertFalse(c2.foregroundColor().isValid())
         self.assertFalse(c2.numericFormat())
-        self.assertFalse(c2.hasTextFormat())
+        self.assertFalse(c2.textFormat().isValid())
 
         c.setBackgroundColor(QColor(255, 0, 0))
         c.setForegroundColor(QColor(255, 0, 255))
@@ -74,7 +73,6 @@ class TestQgsTableCell(unittest.TestCase):
         text_format = QgsTextFormat()
         text_format.setSize(16.8)
         c.setTextFormat(text_format)
-        c.setHasTextFormat(True)
         props = c.properties(QgsReadWriteContext())
 
         c3 = QgsTableCell()
@@ -86,7 +84,7 @@ class TestQgsTableCell(unittest.TestCase):
         self.assertIsInstance(c3.numericFormat(), QgsBearingNumericFormat)
         self.assertTrue(c3.numericFormat().showPlusSign())
         self.assertEqual(c3.textFormat().size(), 16.8)
-        self.assertTrue(c3.hasTextFormat())
+        self.assertTrue(c3.textFormat().isValid())
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgstextrenderer.py
+++ b/tests/src/python/test_qgstextrenderer.py
@@ -277,6 +277,39 @@ class PyQgsTextRenderer(unittest.TestCase):
                                  QgsSymbolLayerReference("layerid2", QgsSymbolLayerId("symbol2", 2))])
         return s
 
+    def testMaskEquality(self):
+        s = self.createMaskSettings()
+        s2 = self.createMaskSettings()
+        self.assertEqual(s, s2)
+
+        s.setEnabled(False)
+        self.assertNotEqual(s, s2)
+        s = self.createMaskSettings()
+
+        s.setSize(15)
+        self.assertNotEqual(s, s2)
+        s = self.createMaskSettings()
+
+        s.setSizeUnit(QgsUnitTypes.RenderPixels)
+        self.assertNotEqual(s, s2)
+        s = self.createMaskSettings()
+
+        s.setSizeMapUnitScale(QgsMapUnitScale(11, 12))
+        self.assertNotEqual(s, s2)
+        s = self.createMaskSettings()
+
+        s.setOpacity(0.6)
+        self.assertNotEqual(s, s2)
+        s = self.createMaskSettings()
+
+        s.setJoinStyle(Qt.MiterJoin)
+        self.assertNotEqual(s, s2)
+        s = self.createMaskSettings()
+
+        s.setMaskedSymbolLayers([QgsSymbolLayerReference("layerid11", QgsSymbolLayerId("symbol", 1)),
+                                 QgsSymbolLayerReference("layerid21", QgsSymbolLayerId("symbol2", 2))])
+        self.assertNotEqual(s, s2)
+
     def checkMaskSettings(self, s):
         """ test QgsTextMaskSettings """
         self.assertTrue(s.enabled())

--- a/tests/src/python/test_qgstextrenderer.py
+++ b/tests/src/python/test_qgstextrenderer.py
@@ -307,6 +307,103 @@ class PyQgsTextRenderer(unittest.TestCase):
 
         return s
 
+    def testBackgroundEquality(self):
+        s = self.createBackgroundSettings()
+        s2 = self.createBackgroundSettings()
+        self.assertEqual(s, s2)
+
+        s.setEnabled(False)
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setType(QgsTextBackgroundSettings.ShapeRectangle)
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setSvgFile('svg2.svg')
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setSizeType(QgsTextBackgroundSettings.SizeFixed)
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setSize(QSizeF(1, 22))
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setSizeUnit(QgsUnitTypes.RenderPixels)
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setSizeMapUnitScale(QgsMapUnitScale(11, 22))
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setRotationType(QgsTextBackgroundSettings.RotationSync)
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setRotation(145)
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setOffset(QPointF(31, 41))
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setOffsetUnit(QgsUnitTypes.RenderPixels)
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setOffsetMapUnitScale(QgsMapUnitScale(15, 16))
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setRadii(QSizeF(111, 112))
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setRadiiUnit(QgsUnitTypes.RenderPoints)
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setRadiiMapUnitScale(QgsMapUnitScale(151, 161))
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setFillColor(QColor(255, 255, 0))
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setStrokeColor(QColor(0, 255, 255))
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setOpacity(0.6)
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setJoinStyle(Qt.MiterJoin)
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setBlendMode(QPainter.CompositionMode_Darken)
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setStrokeWidth(17)
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setStrokeWidthUnit(QgsUnitTypes.RenderPixels)
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
+        s.setStrokeWidthMapUnitScale(QgsMapUnitScale(QgsMapUnitScale(251, 261)))
+        self.assertNotEqual(s, s2)
+        s = self.createBackgroundSettings()
+
     def checkBackgroundSettings(self, s):
         """ test QgsTextBackgroundSettings """
         self.assertTrue(s.enabled())

--- a/tests/src/python/test_qgstextrenderer.py
+++ b/tests/src/python/test_qgstextrenderer.py
@@ -695,6 +695,96 @@ class PyQgsTextRenderer(unittest.TestCase):
         s.dataDefinedProperties().setProperty(QgsPalLayerSettings.Bold, QgsProperty.fromExpression('1>2'))
         return s
 
+    def testFormatEquality(self):
+        s = self.createFormatSettings()
+        s2 = self.createFormatSettings()
+        self.assertEqual(s, s2)
+
+        s.buffer().setEnabled(False)
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.buffer().setSize(12)
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.mask().setEnabled(False)
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.mask().setSize(12)
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.background().setEnabled(False)
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.background().setSvgFile('test2.svg')
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.shadow().setEnabled(False)
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.shadow().setOffsetAngle(123)
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        font = getTestFont()
+        font.setKerning(True)
+        s.setFont(font)
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.setNamedStyle('Bold')
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.setSize(15)
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.setSizeUnit(QgsUnitTypes.RenderPixels)
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.setSizeMapUnitScale(QgsMapUnitScale(11, 12))
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.setColor(QColor(255, 255, 0))
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.setOpacity(0.6)
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.setBlendMode(QPainter.CompositionMode_Darken)
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.setLineHeight(15)
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.setPreviewBackgroundColor(QColor(100, 250, 200))
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.setOrientation(QgsTextFormat.HorizontalOrientation)
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.setAllowHtmlFormatting(False)
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
+        s.dataDefinedProperties().setProperty(QgsPalLayerSettings.Bold, QgsProperty.fromExpression('1>3'))
+        self.assertNotEqual(s, s2)
+
     def checkTextFormat(self, s):
         """ test QgsTextFormat """
         self.assertTrue(s.buffer().enabled())

--- a/tests/src/python/test_qgstextrenderer.py
+++ b/tests/src/python/test_qgstextrenderer.py
@@ -550,6 +550,70 @@ class PyQgsTextRenderer(unittest.TestCase):
         s.setBlendMode(QPainter.CompositionMode_DestinationAtop)
         return s
 
+    def testShadowEquality(self):
+        s = self.createShadowSettings()
+        s2 = self.createShadowSettings()
+        self.assertEqual(s, s2)
+
+        s.setEnabled(False)
+        self.assertNotEqual(s, s2)
+        s = self.createShadowSettings()
+
+        s.setShadowPlacement(QgsTextShadowSettings.ShadowText)
+        self.assertNotEqual(s, s2)
+        s = self.createShadowSettings()
+
+        s.setOffsetAngle(145)
+        self.assertNotEqual(s, s2)
+        s = self.createShadowSettings()
+
+        s.setOffsetDistance(175)
+        self.assertNotEqual(s, s2)
+        s = self.createShadowSettings()
+
+        s.setOffsetUnit(QgsUnitTypes.RenderPixels)
+        self.assertNotEqual(s, s2)
+        s = self.createShadowSettings()
+
+        s.setOffsetMapUnitScale(QgsMapUnitScale(15, 16))
+        self.assertNotEqual(s, s2)
+        s = self.createShadowSettings()
+
+        s.setOffsetGlobal(False)
+        self.assertNotEqual(s, s2)
+        s = self.createShadowSettings()
+
+        s.setBlurRadius(21)
+        self.assertNotEqual(s, s2)
+        s = self.createShadowSettings()
+
+        s.setBlurRadiusUnit(QgsUnitTypes.RenderPoints)
+        self.assertNotEqual(s, s2)
+        s = self.createShadowSettings()
+
+        s.setBlurRadiusMapUnitScale(QgsMapUnitScale(115, 116))
+        self.assertNotEqual(s, s2)
+        s = self.createShadowSettings()
+
+        s.setBlurAlphaOnly(False)
+        self.assertNotEqual(s, s2)
+        s = self.createShadowSettings()
+
+        s.setColor(QColor(255, 255, 0))
+        self.assertNotEqual(s, s2)
+        s = self.createShadowSettings()
+
+        s.setOpacity(0.6)
+        self.assertNotEqual(s, s2)
+        s = self.createShadowSettings()
+
+        s.setScale(23)
+        self.assertNotEqual(s, s2)
+        s = self.createShadowSettings()
+
+        s.setBlendMode(QPainter.CompositionMode_Darken)
+        self.assertNotEqual(s, s2)
+
     def checkShadowSettings(self, s):
         """ test QgsTextShadowSettings """
         self.assertTrue(s.enabled())

--- a/tests/src/python/test_qgstextrenderer.py
+++ b/tests/src/python/test_qgstextrenderer.py
@@ -63,6 +63,96 @@ class PyQgsTextRenderer(unittest.TestCase):
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 
+    def testValid(self):
+        t = QgsTextFormat()
+        self.assertFalse(t.isValid())
+
+        tt = QgsTextFormat(t)
+        self.assertFalse(tt.isValid())
+
+        t.setValid()
+        self.assertTrue(t.isValid())
+        tt = QgsTextFormat(t)
+        self.assertTrue(tt.isValid())
+
+        doc = QDomDocument()
+        elem = t.writeXml(doc, QgsReadWriteContext())
+        parent = doc.createElement("settings")
+        parent.appendChild(elem)
+        t3 = QgsTextFormat()
+        t3.readXml(parent, QgsReadWriteContext())
+        self.assertTrue(t3.isValid())
+
+        t = QgsTextFormat()
+        t.buffer().setEnabled(True)
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.background().setEnabled(True)
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.shadow().setEnabled(True)
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.mask().setEnabled(True)
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.font()
+        self.assertFalse(t.isValid())
+        t.setFont(QFont())
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.setNamedStyle('Bold')
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.setSize(20)
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.setSizeUnit(QgsUnitTypes.RenderPixels)
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.setSizeMapUnitScale(QgsMapUnitScale(5, 10))
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.setColor(QColor(255, 0, 0))
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.setOpacity(0.2)
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.setBlendMode(QPainter.CompositionMode_Darken)
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.setLineHeight(20)
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.setOrientation(QgsTextFormat.VerticalOrientation)
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.setAllowHtmlFormatting(True)
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.setPreviewBackgroundColor(QColor(255, 0, 0))
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.dataDefinedProperties().setProperty(QgsPalLayerSettings.Bold, QgsProperty.fromValue(True))
+        self.assertTrue(t.isValid())
+
     def testAlignmentConversion(self):
         self.assertEqual(QgsTextRenderer.convertQtHAlignment(Qt.AlignLeft), QgsTextRenderer.AlignLeft)
         self.assertEqual(QgsTextRenderer.convertQtHAlignment(Qt.AlignRight), QgsTextRenderer.AlignRight)

--- a/tests/src/python/test_qgstextrenderer.py
+++ b/tests/src/python/test_qgstextrenderer.py
@@ -180,6 +180,46 @@ class PyQgsTextRenderer(unittest.TestCase):
         s.setBlendMode(QPainter.CompositionMode_DestinationAtop)
         return s
 
+    def testBufferEquality(self):
+        s = self.createBufferSettings()
+        s2 = self.createBufferSettings()
+        self.assertEqual(s, s2)
+
+        s.setEnabled(False)
+        self.assertNotEqual(s, s2)
+        s = self.createBufferSettings()
+
+        s.setSize(15)
+        self.assertNotEqual(s, s2)
+        s = self.createBufferSettings()
+
+        s.setSizeUnit(QgsUnitTypes.RenderPixels)
+        self.assertNotEqual(s, s2)
+        s = self.createBufferSettings()
+
+        s.setSizeMapUnitScale(QgsMapUnitScale(11, 12))
+        self.assertNotEqual(s, s2)
+        s = self.createBufferSettings()
+
+        s.setColor(QColor(255, 255, 0))
+        self.assertNotEqual(s, s2)
+        s = self.createBufferSettings()
+
+        s.setFillBufferInterior(False)
+        self.assertNotEqual(s, s2)
+        s = self.createBufferSettings()
+
+        s.setOpacity(0.6)
+        self.assertNotEqual(s, s2)
+        s = self.createBufferSettings()
+
+        s.setJoinStyle(Qt.MiterJoin)
+        self.assertNotEqual(s, s2)
+        s = self.createBufferSettings()
+
+        s.setBlendMode(QPainter.CompositionMode_Darken)
+        self.assertNotEqual(s, s2)
+
     def checkBufferSettings(self, s):
         """ test QgsTextBufferSettings """
         self.assertTrue(s.enabled())
@@ -402,7 +442,6 @@ class PyQgsTextRenderer(unittest.TestCase):
 
         s.setStrokeWidthMapUnitScale(QgsMapUnitScale(QgsMapUnitScale(251, 261)))
         self.assertNotEqual(s, s2)
-        s = self.createBackgroundSettings()
 
     def checkBackgroundSettings(self, s):
         """ test QgsTextBackgroundSettings """


### PR DESCRIPTION
Remove the checkbox for overridding text format and use the new "not set" state from the font button instead. Makes for a much nicer API and UX when setting format overrides for table cells.
