### PR TITLE
Allow cells in manual text tables to have expression based contents

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitemattributetable.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemattributetable.sip.in
@@ -291,6 +291,8 @@ be replaced by a line break.
 
     virtual QgsConditionalStyle conditionalCellStyle( int row, int column ) const;
 
+    virtual QgsExpressionContextScope *scopeForCell( int row, int column ) const /Factory/;
+
 
     virtual QgsExpressionContext createExpressionContext() const;
 

--- a/python/core/auto_generated/layout/qgslayouttable.sip.in
+++ b/python/core/auto_generated/layout/qgslayouttable.sip.in
@@ -597,6 +597,13 @@ Returns the conditional style to use for the cell at ``row``, ``column``.
 .. versionadded:: 3.12
 %End
 
+    virtual QgsExpressionContextScope *scopeForCell( int row, int column ) const /Factory/;
+%Docstring
+Creates a new QgsExpressionContextScope for the cell at ``row``, ``column``.
+
+.. versionadded:: 3.16
+%End
+
     QgsLayoutTableContents &contents();
 %Docstring
 Returns the current contents of the table. Excludes header cells.

--- a/python/gui/auto_generated/tableeditor/qgstableeditordialog.sip.in
+++ b/python/gui/auto_generated/tableeditor/qgstableeditordialog.sip.in
@@ -118,6 +118,14 @@ Sets the table ``headers``.
 .. seealso:: :py:func:`tableHeaders`
 %End
 
+    void registerExpressionContextGenerator( QgsExpressionContextGenerator *generator );
+%Docstring
+Register an expression context generator class that will be used to retrieve
+an expression context for the editor when required.
+
+.. versionadded:: 3.16
+%End
+
   signals:
 
     void tableChanged();

--- a/python/gui/auto_generated/tableeditor/qgstableeditorwidget.sip.in
+++ b/python/gui/auto_generated/tableeditor/qgstableeditorwidget.sip.in
@@ -127,6 +127,16 @@ the selected cells have a mix of different vertical alignments.
 .. seealso:: :py:func:`selectionVerticalAlignment`
 %End
 
+    QgsProperty selectionCellProperty();
+%Docstring
+Returns the QgsProperty used for the contents of the currently selected cells.
+
+If the returned value is a default constructed :py:class:`QgsProperty`, then the selected
+cells have a mix of different properties.
+
+.. versionadded:: 3.16
+%End
+
     QgsTextFormat selectionTextFormat();
 %Docstring
 Returns the text format for the currently selected cells.
@@ -316,6 +326,13 @@ Sets the vertical alignment for the currently selected cells.
 .. seealso:: :py:func:`selectionVerticalAlignment`
 
 .. seealso:: :py:func:`setSelectionHorizontalAlignment`
+
+.. versionadded:: 3.16
+%End
+
+    void setSelectionCellProperty( const QgsProperty &property );
+%Docstring
+Sets the cell contents QgsProperty for the currently selected cells.
 
 .. versionadded:: 3.16
 %End

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -793,6 +793,7 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts()->insert( QStringLiteral( "row_number" ), QCoreApplication::translate( "variable_help", "Stores the number of the current row." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "grid_number" ), QCoreApplication::translate( "variable_help", "Current grid annotation value." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "grid_axis" ), QCoreApplication::translate( "variable_help", "Current grid annotation axis (e.g., 'x' for longitude, 'y' for latitude)." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "column_number" ), QCoreApplication::translate( "variable_help", "Stores the number of the current column." ) );
 
   // map canvas item variables
   sVariableHelpTexts()->insert( QStringLiteral( "canvas_cursor_point" ), QCoreApplication::translate( "variable_help", "Last cursor position on the canvas in the project's geographical coordinates." ) );

--- a/src/core/layout/qgslayoutitemattributetable.h
+++ b/src/core/layout/qgslayoutitemattributetable.h
@@ -280,6 +280,7 @@ class CORE_EXPORT QgsLayoutItemAttributeTable: public QgsLayoutTable
     bool getTableContents( QgsLayoutTableContents &contents ) override SIP_SKIP;
 
     QgsConditionalStyle conditionalCellStyle( int row, int column ) const override;
+    QgsExpressionContextScope *scopeForCell( int row, int column ) const override SIP_FACTORY;
 
     QgsExpressionContext createExpressionContext() const override;
     void finalizeRestoreFromXml() override;
@@ -356,6 +357,18 @@ class CORE_EXPORT QgsLayoutItemAttributeTable: public QgsLayoutTable
     bool mUseConditionalStyling = false;
 
     QList< QList< QgsConditionalStyle > > mConditionalStyles;
+    QList< QgsFeature > mFeatures;
+
+    struct Cell
+    {
+      Cell( const QVariant &content, const QgsConditionalStyle &style, const QgsFeature &feature )
+        : content( content )
+        , style( style )
+        , feature( feature ) {}
+      QVariant content;
+      QgsConditionalStyle style;
+      QgsFeature feature;
+    };
 
     /**
      * Returns a list of attribute indices corresponding to displayed fields in the table.

--- a/src/core/layout/qgslayoutitemattributetable.h
+++ b/src/core/layout/qgslayoutitemattributetable.h
@@ -361,6 +361,8 @@ class CORE_EXPORT QgsLayoutItemAttributeTable: public QgsLayoutTable
 
     struct Cell
     {
+      Cell() = default;
+
       Cell( const QVariant &content, const QgsConditionalStyle &style, const QgsFeature &feature )
         : content( content )
         , style( style )

--- a/src/core/layout/qgslayouttable.cpp
+++ b/src/core/layout/qgslayouttable.cpp
@@ -989,6 +989,14 @@ QMap<int, QString> QgsLayoutTable::headerLabels() const
   return headers;
 }
 
+QgsExpressionContextScope *QgsLayoutTable::scopeForCell( int row, int column ) const
+{
+  std::unique_ptr< QgsExpressionContextScope > cellScope = qgis::make_unique< QgsExpressionContextScope >();
+  cellScope->setVariable( QStringLiteral( "table_row" ), row + 1, true );
+  cellScope->setVariable( QStringLiteral( "table_column" ), column + 1, true );
+  return cellScope.release();
+}
+
 QgsConditionalStyle QgsLayoutTable::conditionalCellStyle( int, int ) const
 {
   return QgsConditionalStyle();

--- a/src/core/layout/qgslayouttable.cpp
+++ b/src/core/layout/qgslayouttable.cpp
@@ -992,8 +992,8 @@ QMap<int, QString> QgsLayoutTable::headerLabels() const
 QgsExpressionContextScope *QgsLayoutTable::scopeForCell( int row, int column ) const
 {
   std::unique_ptr< QgsExpressionContextScope > cellScope = qgis::make_unique< QgsExpressionContextScope >();
-  cellScope->setVariable( QStringLiteral( "table_row" ), row + 1, true );
-  cellScope->setVariable( QStringLiteral( "table_column" ), column + 1, true );
+  cellScope->setVariable( QStringLiteral( "row_number" ), row + 1, true );
+  cellScope->setVariable( QStringLiteral( "column_number" ), column + 1, true );
   return cellScope.release();
 }
 

--- a/src/core/layout/qgslayouttable.h
+++ b/src/core/layout/qgslayouttable.h
@@ -538,6 +538,13 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
     virtual QgsConditionalStyle conditionalCellStyle( int row, int column ) const;
 
     /**
+     * Creates a new QgsExpressionContextScope for the cell at \a row, \a column.
+     *
+     * \since QGIS 3.16
+     */
+    virtual QgsExpressionContextScope *scopeForCell( int row, int column ) const SIP_FACTORY;
+
+    /**
      * Returns the current contents of the table. Excludes header cells.
      */
     QgsLayoutTableContents &contents() { return mTableContents; }

--- a/src/gui/layout/qgslayoutmanualtablewidget.cpp
+++ b/src/gui/layout/qgslayoutmanualtablewidget.cpp
@@ -161,6 +161,7 @@ void QgsLayoutManualTableWidget::setTableContents()
   else
   {
     mEditorDialog = new QgsTableEditorDialog( this );
+    mEditorDialog->registerExpressionContextGenerator( mTable );
     connect( this, &QWidget::destroyed, mEditorDialog, &QMainWindow::close );
 
     mEditorDialog->setIncludeTableHeader( mTable->includeTableHeader() );

--- a/src/gui/tableeditor/qgstableeditordialog.cpp
+++ b/src/gui/tableeditor/qgstableeditordialog.cpp
@@ -64,7 +64,7 @@ QgsTableEditorDialog::QgsTableEditorDialog( QWidget *parent )
 
   int minDockWidth( fontMetrics().boundingRect( QStringLiteral( "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" ) ).width() );
 
-  mPropertiesDock = new QgsDockWidget( tr( "Formatting" ), this );
+  mPropertiesDock = new QgsDockWidget( tr( "Cell Contents" ), this );
   mPropertiesDock->setObjectName( QStringLiteral( "FormattingDock" ) );
   mPropertiesStack = new QgsPanelWidgetStack();
   mPropertiesDock->setWidget( mPropertiesStack );
@@ -81,6 +81,7 @@ QgsTableEditorDialog::QgsTableEditorDialog( QWidget *parent )
 
   connect( mFormattingWidget, &QgsTableEditorFormattingWidget::horizontalAlignmentChanged, mTableWidget, &QgsTableEditorWidget::setSelectionHorizontalAlignment );
   connect( mFormattingWidget, &QgsTableEditorFormattingWidget::verticalAlignmentChanged, mTableWidget, &QgsTableEditorWidget::setSelectionVerticalAlignment );
+  connect( mFormattingWidget, &QgsTableEditorFormattingWidget::cellPropertyChanged, mTableWidget, &QgsTableEditorWidget::setSelectionCellProperty );
 
   connect( mFormattingWidget, &QgsTableEditorFormattingWidget::textFormatChanged, this, [ = ]
   {
@@ -108,6 +109,7 @@ QgsTableEditorDialog::QgsTableEditorDialog( QWidget *parent )
     mFormattingWidget->setTextFormat( mTableWidget->selectionTextFormat(), mTableWidget->selectionHasTextFormat(), mTableWidget->hasMixedSelectionHasTextFormat() );
     mFormattingWidget->setHorizontalAlignment( mTableWidget->selectionHorizontalAlignment() );
     mFormattingWidget->setVerticalAlignment( mTableWidget->selectionVerticalAlignment() );
+    mFormattingWidget->setCellProperty( mTableWidget->selectionCellProperty() );
 
     updateActionNamesFromSelection();
 
@@ -227,6 +229,11 @@ QVariantList QgsTableEditorDialog::tableHeaders() const
 void QgsTableEditorDialog::setTableHeaders( const QVariantList &headers )
 {
   mTableWidget->setTableHeaders( headers );
+}
+
+void QgsTableEditorDialog::registerExpressionContextGenerator( QgsExpressionContextGenerator *generator )
+{
+  mFormattingWidget->registerExpressionContextGenerator( generator );
 }
 
 void QgsTableEditorDialog::updateActionNamesFromSelection()

--- a/src/gui/tableeditor/qgstableeditordialog.h
+++ b/src/gui/tableeditor/qgstableeditordialog.h
@@ -25,6 +25,7 @@ class QgsMessageBar;
 class QgsDockWidget;
 class QgsPanelWidgetStack;
 class QgsTableEditorFormattingWidget;
+class QgsExpressionContextGenerator;
 
 /**
  * \ingroup gui
@@ -133,6 +134,13 @@ class GUI_EXPORT QgsTableEditorDialog : public QMainWindow, private Ui::QgsTable
      * \see tableHeaders()
      */
     void setTableHeaders( const QVariantList &headers );
+
+    /**
+     * Register an expression context generator class that will be used to retrieve
+     * an expression context for the editor when required.
+     * \since QGIS 3.16
+     */
+    void registerExpressionContextGenerator( QgsExpressionContextGenerator *generator );
 
   signals:
 

--- a/src/gui/tableeditor/qgstableeditorformattingwidget.cpp
+++ b/src/gui/tableeditor/qgstableeditorformattingwidget.cpp
@@ -17,12 +17,13 @@
 #include "qgsnumericformatselectorwidget.h"
 #include "qgsnumericformat.h"
 #include "qgis.h"
+#include "qgsproperty.h"
 
 QgsTableEditorFormattingWidget::QgsTableEditorFormattingWidget( QWidget *parent )
   : QgsPanelWidget( parent )
 {
   setupUi( this );
-  setPanelTitle( tr( "Formatting" ) );
+  setPanelTitle( tr( "Cell Contents" ) );
 
   mFormatNumbersCheckBox->setTristate( false );
   mTextFormatCheckBox->setTristate( false );
@@ -139,6 +140,19 @@ QgsTableEditorFormattingWidget::QgsTableEditorFormattingWidget( QWidget *parent 
       emit verticalAlignmentChanged( mVerticalAlignComboBox->currentAlignment() );
     }
   } );
+
+  connect( mExpressionEdit, qgis::overload<const QString &>::of( &QgsFieldExpressionWidget::fieldChanged ), this, [ = ]( const QString & expression )
+  {
+    if ( !mBlockSignals )
+    {
+      emit cellPropertyChanged( expression.isEmpty() ? QgsProperty() : QgsProperty::fromExpression( expression ) );
+    }
+  } );
+
+  mExpressionEdit->setAllowEmptyFieldName( true );
+
+  mExpressionEdit->registerExpressionContextGenerator( this );
+  mFontButton->registerExpressionContextGenerator( this );
 }
 
 QgsNumericFormat *QgsTableEditorFormattingWidget::numericFormat()
@@ -231,6 +245,37 @@ void QgsTableEditorFormattingWidget::setVerticalAlignment( Qt::Alignment alignme
   else
     mVerticalAlignComboBox->setCurrentAlignment( alignment );
   mBlockSignals--;
+}
+
+void QgsTableEditorFormattingWidget::setCellProperty( const QgsProperty &property )
+{
+  mBlockSignals++;
+  if ( !property.isActive() )
+    mExpressionEdit->setExpression( QString() );
+  else
+    mExpressionEdit->setExpression( property.asExpression() );
+  mBlockSignals--;
+}
+
+void QgsTableEditorFormattingWidget::registerExpressionContextGenerator( QgsExpressionContextGenerator *generator )
+{
+  mContextGenerator = generator;
+}
+
+QgsExpressionContext QgsTableEditorFormattingWidget::createExpressionContext() const
+{
+  QgsExpressionContext context;
+  if ( mContextGenerator )
+    context = mContextGenerator->createExpressionContext();
+
+  QgsExpressionContextScope *cellScope = new QgsExpressionContextScope();
+  // TODO -- could set real row/column numbers here, in certain circumstances...
+  cellScope->setVariable( QStringLiteral( "row_number" ), 0 );
+  cellScope->setVariable( QStringLiteral( "column_number" ), 0 );
+  context.appendScope( cellScope );
+
+  context.setHighlightedVariables( QStringList() << QStringLiteral( "row_number" ) << QStringLiteral( "column_number" ) );
+  return context;
 }
 
 QgsTableEditorFormattingWidget::~QgsTableEditorFormattingWidget() = default;

--- a/src/gui/tableeditor/qgstableeditorformattingwidget.h
+++ b/src/gui/tableeditor/qgstableeditorformattingwidget.h
@@ -18,11 +18,13 @@
 #include "qgis_gui.h"
 #include "ui_qgstableeditorformattingwidgetbase.h"
 #include "qgspanelwidget.h"
+#include "qgsexpressioncontextgenerator.h"
 #include <memory>
 
 #define SIP_NO_FILE
 
 class QgsNumericFormat;
+class QgsProperty;
 
 /**
  * \ingroup gui
@@ -36,7 +38,7 @@ class QgsNumericFormat;
  *
  * \since QGIS 3.12
  */
-class GUI_EXPORT QgsTableEditorFormattingWidget : public QgsPanelWidget, private Ui::QgsTableEditorFormattingWidgetBase
+class GUI_EXPORT QgsTableEditorFormattingWidget : public QgsPanelWidget, public QgsExpressionContextGenerator, private Ui::QgsTableEditorFormattingWidgetBase
 {
     Q_OBJECT
   public:
@@ -145,6 +147,22 @@ class GUI_EXPORT QgsTableEditorFormattingWidget : public QgsPanelWidget, private
      */
     void setVerticalAlignment( Qt::Alignment alignment );
 
+    /**
+     * Sets the cell content's \a property to show in the widget.
+     *
+     * \since QGIS 3.16
+     */
+    void setCellProperty( const QgsProperty &property );
+
+    /**
+     * Register an expression context generator class that will be used to retrieve
+     * an expression context for the widget when required.
+     * \since QGIS 3.16
+     */
+    void registerExpressionContextGenerator( QgsExpressionContextGenerator *generator );
+
+    QgsExpressionContext createExpressionContext() const override;
+
   signals:
 
     /**
@@ -204,10 +222,18 @@ class GUI_EXPORT QgsTableEditorFormattingWidget : public QgsPanelWidget, private
      */
     void verticalAlignmentChanged( Qt::Alignment alignment );
 
+    /**
+     * Emitted when the cell contents \a property shown in the widget is changed.
+     *
+     * \since QGIS 3.16
+     */
+    void cellPropertyChanged( const QgsProperty &property );
+
   private:
 
     std::unique_ptr< QgsNumericFormat > mNumericFormat;
     int mBlockSignals = 0;
+    QgsExpressionContextGenerator *mContextGenerator = nullptr;
 
 };
 

--- a/src/gui/tableeditor/qgstableeditorwidget.cpp
+++ b/src/gui/tableeditor/qgstableeditorwidget.cpp
@@ -320,7 +320,7 @@ void QgsTableEditorWidget::setTableContents( const QgsTableContents &contents )
     int colNumber = 0;
     for ( const QgsTableCell &col : row )
     {
-      QTableWidgetItem *item = new QTableWidgetItem( col.content().toString() );
+      QTableWidgetItem *item = new QTableWidgetItem( col.content().value< QgsProperty >().isActive() ? col.content().value< QgsProperty >().asExpression() : col.content().toString() );
       item->setData( CellContent, col.content() ); // can't use EditRole, because Qt. (https://bugreports.qt.io/browse/QTBUG-11549)
       item->setData( Qt::BackgroundRole, col.backgroundColor().isValid() ? col.backgroundColor() : QColor( 255, 255, 255 ) );
       item->setData( PresetBackgroundColorRole, col.backgroundColor().isValid() ? col.backgroundColor() : QVariant() );
@@ -329,6 +329,11 @@ void QgsTableEditorWidget::setTableContents( const QgsTableContents &contents )
       item->setData( TextFormat, QVariant::fromValue( col.textFormat() ) );
       item->setData( HorizontalAlignment, static_cast< int >( col.horizontalAlignment() ) );
       item->setData( VerticalAlignment, static_cast< int >( col.verticalAlignment() ) );
+      item->setData( CellProperty, QVariant::fromValue( col.content().value< QgsProperty >() ) );
+
+      if ( col.content().value< QgsProperty >().isActive() )
+        item->setFlags( item->flags() & ( ~Qt::ItemIsEditable ) );
+
       if ( col.numericFormat() )
       {
         mNumericFormats.insert( item, col.numericFormat()->clone() );
@@ -366,7 +371,7 @@ QgsTableContents QgsTableEditorWidget::tableContents() const
       QgsTableCell cell;
       if ( QTableWidgetItem *i = item( r, c ) )
       {
-        cell.setContent( i->data( CellContent ) );
+        cell.setContent( i->data( CellProperty ).value< QgsProperty >().isActive() ? i->data( CellProperty ) : i->data( CellContent ) );
         cell.setBackgroundColor( i->data( PresetBackgroundColorRole ).value< QColor >() );
         cell.setForegroundColor( i->data( Qt::ForegroundRole ).value< QColor >() );
         cell.setHasTextFormat( i->data( HasTextFormat ).toBool() );
@@ -602,6 +607,29 @@ Qt::Alignment QgsTableEditorWidget::selectionVerticalAlignment()
     }
   }
   return alignment;
+}
+
+QgsProperty QgsTableEditorWidget::selectionCellProperty()
+{
+  QgsProperty property;
+  bool first = true;
+  const QModelIndexList selection = selectedIndexes();
+  for ( const QModelIndex &index : selection )
+  {
+    const QgsProperty cellProperty = model()->data( index, CellProperty ).value< QgsProperty >();
+    if ( first )
+    {
+      property = cellProperty;
+      first = false;
+    }
+    else if ( cellProperty == property )
+      continue;
+    else
+    {
+      return QgsProperty();
+    }
+  }
+  return property;
 }
 
 QgsTextFormat QgsTableEditorWidget::selectionTextFormat()
@@ -1069,6 +1097,57 @@ void QgsTableEditorWidget::setSelectionVerticalAlignment( Qt::Alignment alignmen
     emit tableChanged();
 }
 
+void QgsTableEditorWidget::setSelectionCellProperty( const QgsProperty &property )
+{
+  const QModelIndexList selection = selectedIndexes();
+  bool changed = false;
+  mBlockSignals++;
+  for ( const QModelIndex &index : selection )
+  {
+    if ( index.row() == 0 && mIncludeHeader )
+      continue;
+
+    if ( QTableWidgetItem *i = item( index.row(), index.column() ) )
+    {
+      if ( i->data( CellProperty ).value< QgsProperty >() != property )
+      {
+        if ( property.isActive() )
+        {
+          i->setData( CellProperty, QVariant::fromValue( property ) );
+          i->setText( property.asExpression() );
+          i->setFlags( i->flags() & ( ~Qt::ItemIsEditable ) );
+        }
+        else
+        {
+          i->setData( CellProperty, QVariant() );
+          i->setText( QString() );
+          i->setFlags( i->flags() | Qt::ItemIsEditable );
+        }
+        changed = true;
+      }
+    }
+    else
+    {
+      QTableWidgetItem *newItem = new QTableWidgetItem( property.asExpression() );
+      if ( property.isActive() )
+      {
+        newItem->setData( CellProperty,  QVariant::fromValue( property ) );
+        newItem->setFlags( newItem->flags() & ( ~Qt::ItemIsEditable ) );
+      }
+      else
+      {
+        newItem->setData( CellProperty, QVariant() );
+        newItem->setFlags( newItem->flags() | Qt::ItemIsEditable );
+      }
+      setItem( index.row(), index.column(), newItem );
+      changed = true;
+    }
+  }
+  mBlockSignals--;
+  if ( changed && !mBlockSignals )
+    emit tableChanged();
+}
+
 void QgsTableEditorWidget::setSelectionTextFormat( const QgsTextFormat &format )
 {
   const QModelIndexList selection = selectedIndexes();
@@ -1402,7 +1481,7 @@ void QgsTableEditorDelegate::setModelData( QWidget *editor, QAbstractItemModel *
   if ( QgsTableEditorTextEdit *lineEdit = qobject_cast<QgsTableEditorTextEdit * >( editor ) )
   {
     const QString text = lineEdit->toPlainText();
-    if ( text != model->data( index, QgsTableEditorWidget::CellContent ).toString() )
+    if ( text != model->data( index, QgsTableEditorWidget::CellContent ).toString() && !model->data( index, QgsTableEditorWidget::CellProperty ).value< QgsProperty >().isActive() )
     {
       model->setData( index, text, QgsTableEditorWidget::CellContent );
       model->setData( index, text, Qt::DisplayRole );

--- a/src/gui/tableeditor/qgstableeditorwidget.h
+++ b/src/gui/tableeditor/qgstableeditorwidget.h
@@ -20,6 +20,7 @@
 
 #include "qgis_gui.h"
 #include "qgstablecell.h"
+#include "qgsproperty.h"
 #include <QTableWidget>
 #include <QPlainTextEdit>
 #include <QStyledItemDelegate>
@@ -210,6 +211,16 @@ class GUI_EXPORT QgsTableEditorWidget : public QTableWidget
     Qt::Alignment selectionVerticalAlignment();
 
     /**
+     * Returns the QgsProperty used for the contents of the currently selected cells.
+     *
+     * If the returned value is a default constructed QgsProperty, then the selected
+     * cells have a mix of different properties.
+     *
+     * \since QGIS 3.16
+     */
+    QgsProperty selectionCellProperty();
+
+    /**
      * Returns the text format for the currently selected cells.
      *
      * \since QGIS 3.16
@@ -397,6 +408,13 @@ class GUI_EXPORT QgsTableEditorWidget : public QTableWidget
     void setSelectionVerticalAlignment( Qt::Alignment alignment );
 
     /**
+     * Sets the cell contents QgsProperty for the currently selected cells.
+     *
+     * \since QGIS 3.16
+     */
+    void setSelectionCellProperty( const QgsProperty &property );
+
+    /**
      * Sets the text \a format for the selected cells.
      *
      * \since QGIS 3.16
@@ -469,7 +487,8 @@ class GUI_EXPORT QgsTableEditorWidget : public QTableWidget
       HasTextFormat,
       TextFormat,
       HorizontalAlignment,
-      VerticalAlignment
+      VerticalAlignment,
+      CellProperty,
     };
 
     void updateHeaders();

--- a/src/ui/qgstableeditorformattingwidgetbase.ui
+++ b/src/ui/qgstableeditorformattingwidgetbase.ui
@@ -46,8 +46,28 @@
         <height>464</height>
        </rect>
       </property>
-      <layout class="QVBoxLayout" name="mainLayout">
-       <item>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="5" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_5">
+         <property name="text">
+          <string>Expression</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
         <widget class="QGroupBox" name="groupBox_6">
          <property name="focusPolicy">
           <enum>Qt::StrongFocus</enum>
@@ -130,7 +150,7 @@
          </layout>
         </widget>
        </item>
-       <item>
+       <item row="3" column="0" colspan="2">
         <widget class="QGroupBox" name="groupBox_7">
          <property name="focusPolicy">
           <enum>Qt::StrongFocus</enum>
@@ -202,7 +222,7 @@
          </layout>
         </widget>
        </item>
-       <item>
+       <item row="4" column="0" colspan="2">
         <widget class="QGroupBox" name="groupBox_8">
          <property name="focusPolicy">
           <enum>Qt::StrongFocus</enum>
@@ -254,18 +274,18 @@
          </layout>
         </widget>
        </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
+       <item row="0" column="1">
+        <widget class="QgsFieldExpressionWidget" name="mExpressionEdit" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>0</height>
-          </size>
+         <property name="focusPolicy">
+          <enum>Qt::StrongFocus</enum>
          </property>
-        </spacer>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -300,6 +320,12 @@
    <class>QgsAlignmentComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsalignmentcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFieldExpressionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfieldexpressionwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/tests/src/core/testqgslayoutmanualtable.cpp
+++ b/tests/src/core/testqgslayoutmanualtable.cpp
@@ -284,8 +284,8 @@ void TestQgsLayoutManualTable::scopeForCell()
   std::unique_ptr< QgsExpressionContextScope > scope( table->scopeForCell( 1, 2 ) );
 
   // variable values for row/col should start at 1, not 0!
-  QCOMPARE( scope->variable( QStringLiteral( "table_row" ) ).toInt(), 2 );
-  QCOMPARE( scope->variable( QStringLiteral( "table_column" ) ).toInt(), 3 );
+  QCOMPARE( scope->variable( QStringLiteral( "row_number" ) ).toInt(), 2 );
+  QCOMPARE( scope->variable( QStringLiteral( "column_number" ) ).toInt(), 3 );
 }
 
 void TestQgsLayoutManualTable::expressionContents()
@@ -307,7 +307,7 @@ void TestQgsLayoutManualTable::expressionContents()
   expectedRows.append( row );
 
   table->setTableContents(
-    QgsTableContents() << ( QgsTableRow() << QgsTableCell( QStringLiteral( "Jet" ) ) << QgsTableCell( QgsProperty::fromExpression( QStringLiteral( "@table_row  || ',' || @table_column" ) ) ) << QgsTableCell( QgsProperty::fromExpression( QStringLiteral( "@table_row  || ',' || @table_column" ) ) ) )
+    QgsTableContents() << ( QgsTableRow() << QgsTableCell( QStringLiteral( "Jet" ) ) << QgsTableCell( QgsProperty::fromExpression( QStringLiteral( "@row_number  || ',' || @column_number" ) ) ) << QgsTableCell( QgsProperty::fromExpression( QStringLiteral( "@row_number  || ',' || @column_number" ) ) ) )
     << ( QgsTableRow() << QgsTableCell( QgsProperty::fromExpression( QStringLiteral( "@layout_name" ) ) ) << QgsTableCell( QStringLiteral( "Helicopter" ) ) << QgsTableCell( QStringLiteral( "Plane" ) ) ) );
   compareTable( table, expectedRows );
 

--- a/tests/src/core/testqgslayouttable.cpp
+++ b/tests/src/core/testqgslayouttable.cpp
@@ -82,6 +82,7 @@ class TestQgsLayoutTable : public QObject
     void wrappedText();
     void testBaseSort();
     void testExpressionSort();
+    void testScopeForCell();
 
   private:
     QgsVectorLayer *mVectorLayer = nullptr;
@@ -1637,6 +1638,36 @@ void TestQgsLayoutTable::testExpressionSort()
 
   //retrieve rows and check
   compareTable( table, expectedRows );
+}
+
+void TestQgsLayoutTable::testScopeForCell()
+{
+  QgsLayout l( QgsProject::instance() );
+  l.initializeDefaults();
+  QgsLayoutItemAttributeTable *table = new QgsLayoutItemAttributeTable( &l );
+  table->setVectorLayer( mVectorLayer );
+  table->refresh();
+
+  std::unique_ptr< QgsExpressionContextScope > scope( table->scopeForCell( 0, 0 ) );
+
+  // variable values for row/col should start at 1, not 0!
+  QCOMPARE( scope->variable( QStringLiteral( "table_row" ) ).toInt(), 1 );
+  QCOMPARE( scope->variable( QStringLiteral( "table_column" ) ).toInt(), 1 );
+  QCOMPARE( scope->feature().attribute( 0 ).toString(), QStringLiteral( "Jet" ) );
+  scope.reset( table->scopeForCell( 0, 1 ) );
+  QCOMPARE( scope->variable( QStringLiteral( "table_row" ) ).toInt(), 1 );
+  QCOMPARE( scope->variable( QStringLiteral( "table_column" ) ).toInt(), 2 );
+  QCOMPARE( scope->feature().attribute( 0 ).toString(), QStringLiteral( "Jet" ) );
+  scope.reset( table->scopeForCell( 1, 2 ) );
+  QCOMPARE( scope->variable( QStringLiteral( "table_row" ) ).toInt(), 2 );
+  QCOMPARE( scope->variable( QStringLiteral( "table_column" ) ).toInt(), 3 );
+  QCOMPARE( scope->feature().attribute( 0 ).toString(), QStringLiteral( "Biplane" ) );
+
+  // make sure fields are set
+  QgsExpressionContext context;
+  context.appendScope( scope.release() );
+  QCOMPARE( context.fields().size(), 6 );
+  QCOMPARE( context.fields().at( 0 ).name(), QStringLiteral( "Class" ) );
 }
 
 QGSTEST_MAIN( TestQgsLayoutTable )

--- a/tests/src/core/testqgslayouttable.cpp
+++ b/tests/src/core/testqgslayouttable.cpp
@@ -1651,16 +1651,16 @@ void TestQgsLayoutTable::testScopeForCell()
   std::unique_ptr< QgsExpressionContextScope > scope( table->scopeForCell( 0, 0 ) );
 
   // variable values for row/col should start at 1, not 0!
-  QCOMPARE( scope->variable( QStringLiteral( "table_row" ) ).toInt(), 1 );
-  QCOMPARE( scope->variable( QStringLiteral( "table_column" ) ).toInt(), 1 );
+  QCOMPARE( scope->variable( QStringLiteral( "row_number" ) ).toInt(), 1 );
+  QCOMPARE( scope->variable( QStringLiteral( "column_number" ) ).toInt(), 1 );
   QCOMPARE( scope->feature().attribute( 0 ).toString(), QStringLiteral( "Jet" ) );
   scope.reset( table->scopeForCell( 0, 1 ) );
-  QCOMPARE( scope->variable( QStringLiteral( "table_row" ) ).toInt(), 1 );
-  QCOMPARE( scope->variable( QStringLiteral( "table_column" ) ).toInt(), 2 );
+  QCOMPARE( scope->variable( QStringLiteral( "row_number" ) ).toInt(), 1 );
+  QCOMPARE( scope->variable( QStringLiteral( "column_number" ) ).toInt(), 2 );
   QCOMPARE( scope->feature().attribute( 0 ).toString(), QStringLiteral( "Jet" ) );
   scope.reset( table->scopeForCell( 1, 2 ) );
-  QCOMPARE( scope->variable( QStringLiteral( "table_row" ) ).toInt(), 2 );
-  QCOMPARE( scope->variable( QStringLiteral( "table_column" ) ).toInt(), 3 );
+  QCOMPARE( scope->variable( QStringLiteral( "row_number" ) ).toInt(), 2 );
+  QCOMPARE( scope->variable( QStringLiteral( "column_number" ) ).toInt(), 3 );
   QCOMPARE( scope->feature().attribute( 0 ).toString(), QStringLiteral( "Biplane" ) );
 
   // make sure fields are set


### PR DESCRIPTION
Allows individual cells from a manual text table to take their contents
from a preset expression. Expressions have access to the full layout
item expression context, allowing cells to calculate and display
metadata style values or aggregate based calculations.

Sponsored by City of Canning