### PR TITLE
[FEATURE][3d] Enable embedded and remote 3D models for 3D point symbols

### DIFF
--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -697,6 +697,13 @@ Returns the application's image cache, used for caching resampled versions of ra
 .. versionadded:: 3.6
 %End
 
+    static QgsSourceCache *sourceCache();
+%Docstring
+Returns the application's source cache, used for caching embedded and remote source strings as local files
+
+.. versionadded:: 3.16
+%End
+
     static QgsNetworkContentFetcherRegistry *networkContentFetcherRegistry() /KeepReference/;
 %Docstring
 Returns the application's network content registry used for fetching temporary files during QGIS session

--- a/python/core/auto_generated/qgssourcecache.sip.in
+++ b/python/core/auto_generated/qgssourcecache.sip.in
@@ -1,0 +1,56 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgssourcecache.h                                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsSourceCache : QgsAbstractContentCacheBase
+{
+%Docstring
+A cache for source strings that returns a local file path containing the source content.
+
+QgsSourceCache is not usually directly created, but rather accessed through
+:py:func:`QgsApplication.sourceCache()`.
+
+.. versionadded:: 3.16
+%End
+
+%TypeHeaderCode
+#include "qgssourcecache.h"
+%End
+  public:
+
+    QgsSourceCache( QObject *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsSourceCache, with the specified ``parent`` object.
+%End
+
+    QString localFilePath( const QString &path, bool blocking = false );
+%Docstring
+Returns a local file path reflecting the content of a specified source ``path``
+
+``path`` may be a local file, remote (HTTP) url, or a base 64 encoded string (with a "base64:" prefix).
+%End
+
+  signals:
+
+    void remoteSourceFetched( const QString &url );
+%Docstring
+Emitted when the cache has finished retrieving a 3D model from a remote ``url``.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgssourcecache.h                                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -194,6 +194,7 @@
 %Include auto_generated/qgssimplifymethod.sip
 %Include auto_generated/qgssnappingconfig.sip
 %Include auto_generated/qgssnappingutils.sip
+%Include auto_generated/qgssourcecache.sip
 %Include auto_generated/qgsspatialindex.sip
 %Include auto_generated/qgsspatialindexkdbush.sip
 %Include auto_generated/qgsspatialindexkdbushdata.sip

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -194,10 +194,10 @@
 %Include auto_generated/qgssimplifymethod.sip
 %Include auto_generated/qgssnappingconfig.sip
 %Include auto_generated/qgssnappingutils.sip
-%Include auto_generated/qgssourcecache.sip
 %Include auto_generated/qgsspatialindex.sip
 %Include auto_generated/qgsspatialindexkdbush.sip
 %Include auto_generated/qgsspatialindexkdbushdata.sip
+%Include auto_generated/qgssourcecache.sip
 %Include auto_generated/qgssqliteutils.sip
 %Include auto_generated/qgssqlstatement.sip
 %Include auto_generated/qgsstatisticalsummary.sip

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -164,6 +164,7 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     QList<Qt3DCore::QEntity *> mLightEntities;
     //! List of light origins in the scene
     QList<Qt3DCore::QEntity *> mLightOriginEntities;
+    QList<QgsMapLayer *> mModelVectorLayers;
 };
 
 #endif // QGS3DMAPSCENE_H

--- a/src/app/3d/qgs3dmodelsourcelineedit.cpp
+++ b/src/app/3d/qgs3dmodelsourcelineedit.cpp
@@ -1,0 +1,59 @@
+/***************************************************************************
+ qgs3dmodelsourcelineedit.cpp
+ -----------------------
+ begin                : July 2020
+ copyright            : (C) 2020 by Mathieu Pellerin
+ email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgs3dmodelsourcelineedit.h"
+
+//
+// Qgs3DModelSourceLineEdit
+//
+
+///@cond PRIVATE
+
+QString Qgs3DModelSourceLineEdit::fileFilter() const
+{
+  return tr( "All files" ) + " (*.*)";
+}
+
+QString Qgs3DModelSourceLineEdit::selectFileTitle() const
+{
+  return tr( "Select 3D Model File" );
+}
+
+QString Qgs3DModelSourceLineEdit::fileFromUrlTitle() const
+{
+  return tr( "3D Model From URL" );
+}
+
+QString Qgs3DModelSourceLineEdit::fileFromUrlText() const
+{
+  return tr( "Enter 3D Model URL" );
+}
+
+QString Qgs3DModelSourceLineEdit::embedFileTitle() const
+{
+  return tr( "Embed 3D Model File" );
+}
+
+QString Qgs3DModelSourceLineEdit::extractFileTitle() const
+{
+  return tr( "Extract 3D Model File" );
+}
+
+QString Qgs3DModelSourceLineEdit::defaultSettingsKey() const
+{
+  return QStringLiteral( "/UI/last3DModelDir" );
+}
+
+///@endcond

--- a/src/app/3d/qgs3dmodelsourcelineedit.h
+++ b/src/app/3d/qgs3dmodelsourcelineedit.h
@@ -1,0 +1,57 @@
+/***************************************************************************
+ qgs3dmodelsourcelineedit.h
+ ---------------------
+ begin                : July 2020
+ copyright            : (C) 2020 by Mathieu Pellerin
+ email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGS3DMODELSOURCELINEEDIT_H
+#define QGS3DMODELSOURCELINEEDIT_H
+
+#include "qgsfilecontentsourcelineedit.h"
+
+#include <QString>
+
+/**
+ * \class Qgs3DModelSourceLineEdit
+ * A line edit widget with toolbutton for setting a 3D model source path.
+ *
+ * Designed for use with QgsSourceCache.
+ *
+ * \since QGIS 3.16
+ */
+class Qgs3DModelSourceLineEdit : public QgsAbstractFileContentSourceLineEdit
+{
+    Q_OBJECT
+  public:
+
+    /**
+     * Constructor for Qgs3DModelSourceLineEdit, with the specified \a parent widget.
+     */
+    Qgs3DModelSourceLineEdit( QWidget *parent SIP_TRANSFERTHIS = nullptr )
+      : QgsAbstractFileContentSourceLineEdit( parent )
+    {}
+
+  private:
+#ifndef SIP_RUN
+///@cond PRIVATE
+    QString fileFilter() const override;
+    QString selectFileTitle() const override;
+    QString fileFromUrlTitle() const override;
+    QString fileFromUrlText() const override;
+    QString embedFileTitle() const override;
+    QString extractFileTitle() const override;
+    QString defaultSettingsKey() const override;
+///@endcond
+#endif
+};
+
+#endif // QGS3DMODELSOURCELINEEDIT_H

--- a/src/app/3d/qgspoint3dsymbolwidget.h
+++ b/src/app/3d/qgspoint3dsymbolwidget.h
@@ -37,7 +37,6 @@ class QgsPoint3DSymbolWidget : public QWidget, private Ui::Point3DSymbolWidget
 
   private slots:
     void onShapeChanged();
-    void onChooseModelClicked( bool checked = false );
     void onOverwriteMaterialChecked( int state );
 };
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -268,6 +268,7 @@ IF (WITH_3D)
     3d/qgs3dmaptoolidentify.cpp
     3d/qgs3dmaptoolmeasureline.cpp
     3d/qgs3dmeasuredialog.cpp
+    3d/qgs3dmodelsourcelineedit.cpp
     3d/qgs3dnavigationwidget.cpp
     3d/qgslightswidget.cpp
     3d/qgsline3dsymbolwidget.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -409,6 +409,7 @@ SET(QGIS_CORE_SRCS
   qgssqliteexpressioncompiler.cpp
   qgssqlstatement.cpp
   qgssqliteutils.cpp
+  qgssourcecache.cpp
   qgsspatialiteutils.cpp
   qgsstatisticalsummary.cpp
   qgsstoredexpressionmanager.cpp
@@ -966,6 +967,7 @@ SET(QGIS_CORE_HDRS
   qgsspatialindexkdbush.h
   qgsspatialindexkdbushdata.h
   qgsspatialindexutils.h
+  qgssourcecache.h
   qgsspatialiteutils.h
   qgssqlexpressioncompiler.h
   qgssqliteutils.h

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -35,6 +35,7 @@
 #include "qgsscalebarrendererregistry.h"
 #include "qgssvgcache.h"
 #include "qgsimagecache.h"
+#include "qgssourcecache.h"
 #include "qgscolorschemeregistry.h"
 #include "qgspainteffectregistry.h"
 #include "qgsprojectstorageregistry.h"
@@ -2139,6 +2140,11 @@ QgsImageCache *QgsApplication::imageCache()
   return members()->mImageCache;
 }
 
+QgsSourceCache *QgsApplication::sourceCache()
+{
+  return members()->mSourceCache;
+}
+
 QgsNetworkContentFetcherRegistry *QgsApplication::networkContentFetcherRegistry()
 {
   return members()->mNetworkContentFetcherRegistry;
@@ -2285,6 +2291,11 @@ QgsApplication::ApplicationMembers::ApplicationMembers()
   {
     profiler->start( tr( "Setup image cache" ) );
     mImageCache = new QgsImageCache();
+    profiler->end();
+  }
+  {
+    profiler->start( tr( "Setup source cache" ) );
+    mSourceCache = new QgsSourceCache();
     profiler->end();
   }
   {

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -36,6 +36,7 @@ class QgsLocalizedDataPathRegistry;
 class QgsRendererRegistry;
 class QgsSvgCache;
 class QgsImageCache;
+class QgsSourceCache;
 class QgsSymbolLayerRegistry;
 class QgsRasterRendererRegistry;
 class QgsGpsConnectionRegistry;
@@ -644,6 +645,13 @@ class CORE_EXPORT QgsApplication : public QApplication
     static QgsImageCache *imageCache();
 
     /**
+     * Returns the application's source cache, used for caching embedded and remote source strings as local files
+     *
+     * \since QGIS 3.16
+     */
+    static QgsSourceCache *sourceCache();
+
+    /**
      * Returns the application's network content registry used for fetching temporary files during QGIS session
      * \since QGIS 3.2
      */
@@ -942,6 +950,7 @@ class CORE_EXPORT QgsApplication : public QApplication
       QgsRendererRegistry *mRendererRegistry = nullptr;
       QgsSvgCache *mSvgCache = nullptr;
       QgsImageCache *mImageCache = nullptr;
+      QgsSourceCache *mSourceCache = nullptr;
       QgsSymbolLayerRegistry *mSymbolLayerRegistry = nullptr;
       QgsCalloutRegistry *mCalloutRegistry = nullptr;
       QgsTaskManager *mTaskManager = nullptr;

--- a/src/core/qgssourcecache.cpp
+++ b/src/core/qgssourcecache.cpp
@@ -1,0 +1,116 @@
+/***************************************************************************
+                         qgssourcecache.cpp
+                         -----------------
+    begin                : July 2020
+    copyright            : (C) 2020 by Mathieu Pellerin
+    email                : nirvn dot asia at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgssourcecache.h"
+
+#include "qgis.h"
+#include "qgslogger.h"
+
+#include <QFile>
+#include <QBuffer>
+#include <QTemporaryDir>
+
+///@cond PRIVATE
+
+QgsSourceCacheEntry::QgsSourceCacheEntry( const QString &path )
+  : QgsAbstractContentCacheEntry( path )
+{
+}
+
+bool QgsSourceCacheEntry::isEqual( const QgsAbstractContentCacheEntry *other ) const
+{
+  const QgsSourceCacheEntry *otherSource = dynamic_cast< const QgsSourceCacheEntry * >( other );
+  // cheapest checks first!
+  if ( !otherSource || otherSource->filePath != filePath )
+    return false;
+
+  return true;
+}
+
+int QgsSourceCacheEntry::dataSize() const
+{
+  return filePath.size();
+}
+
+void QgsSourceCacheEntry::dump() const
+{
+  QgsDebugMsgLevel( QStringLiteral( "path: %1" ).arg( path ), 3 );
+}
+
+///@endcond
+
+QgsSourceCache::QgsSourceCache( QObject *parent )
+  : QgsAbstractContentCache< QgsSourceCacheEntry >( parent, QObject::tr( "Source" ) )
+{
+  temporaryDir.reset( new QTemporaryDir() );
+
+  connect( this, &QgsAbstractContentCacheBase::remoteContentFetched, this, &QgsSourceCache::remoteSourceFetched );
+}
+
+QString QgsSourceCache::localFilePath( const QString &path, bool blocking )
+{
+  const QString file = path.trimmed();
+  if ( file.isEmpty() )
+    return QString();
+
+  QMutexLocker locker( &mMutex );
+
+  QgsSourceCacheEntry *currentEntry = findExistingEntry( new QgsSourceCacheEntry( file ) );
+
+  //if current entry's temporary file is empty, create it
+  if ( currentEntry->filePath.isEmpty() )
+  {
+    bool isBroken;
+    QString filePath = fetchSource( file, isBroken, blocking );
+    currentEntry->filePath = filePath;
+  }
+
+  return currentEntry->filePath;
+}
+
+QString QgsSourceCache::fetchSource( const QString &path, bool &isBroken, bool blocking ) const
+{
+  QString filePath;
+
+  if ( !path.startsWith( QStringLiteral( "base64:" ) ) && QFile::exists( path ) )
+  {
+    filePath = path;
+  }
+  else
+  {
+    QByteArray ba = getContent( path, QByteArray( "broken" ), QByteArray( "fetching" ), blocking );
+
+    if ( ba == "broken" )
+    {
+      isBroken = true;
+    }
+    else
+    {
+      int id = 1;
+      filePath = temporaryDir->filePath( QString::number( id ) );
+      while ( QFile::exists( filePath ) )
+        filePath = temporaryDir->filePath( QString::number( ++id ) );
+
+      QFile file( filePath );
+      file.open( QIODevice::WriteOnly );
+      file.write( ba );
+      file.close();
+    }
+  }
+
+  return filePath;
+}

--- a/src/core/qgssourcecache.h
+++ b/src/core/qgssourcecache.h
@@ -1,0 +1,103 @@
+/***************************************************************************
+                         qgssourcecache.h
+                         ---------------
+    begin                : July 2020
+    copyright            : (C) 2020 by Mathieu Pellerin
+    email                : nirvn dot asia at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSOURCECACHE_H
+#define QGSSOURCECACHE_H
+
+#include "qgsabstractcontentcache.h"
+#include "qgis_sip.h"
+#include "qgis_core.h"
+
+#ifndef SIP_RUN
+
+///@cond PRIVATE
+
+/**
+ * \ingroup core
+ * \class QgsSourceCacheEntry
+ * An entry for a QgsSourceCache, representing a given source's file path
+ * \since QGIS 3.16
+ */
+class CORE_EXPORT QgsSourceCacheEntry : public QgsAbstractContentCacheEntry
+{
+  public:
+
+    /**
+     * Constructor for QgsSourceCacheEntry, corresponding to the specified \a path.
+     */
+    QgsSourceCacheEntry( const QString &path ) ;
+
+    //! The local file path of the source string
+    QString filePath;
+
+    int dataSize() const override;
+    void dump() const override;
+    bool isEqual( const QgsAbstractContentCacheEntry *other ) const override;
+
+};
+
+///@endcond
+#endif
+
+/**
+ * \class QgsSourceCache
+ * \ingroup core
+ * A cache for source strings that returns a local file path containing the source content.
+ *
+ * QgsSourceCache is not usually directly created, but rather accessed through
+ * QgsApplication::sourceCache().
+ *
+ * \since QGIS 3.16
+*/
+#ifdef SIP_RUN
+class CORE_EXPORT QgsSourceCache : public QgsAbstractContentCacheBase // for sip we skip to the base class and avoid the template difficulty
+{
+#else
+class CORE_EXPORT QgsSourceCache : public QgsAbstractContentCache< QgsSourceCacheEntry >
+{
+#endif
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsSourceCache, with the specified \a parent object.
+     */
+    QgsSourceCache( QObject *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
+     * Returns a local file path reflecting the content of a specified source \a path
+     *
+     * \a path may be a local file, remote (HTTP) url, or a base 64 encoded string (with a "base64:" prefix).
+     */
+    QString localFilePath( const QString &path, bool blocking = false );
+
+  signals:
+
+    /**
+     * Emitted when the cache has finished retrieving a 3D model from a remote \a url.
+     */
+    void remoteSourceFetched( const QString &url );
+
+  private:
+
+    QString fetchSource( const QString &path, bool &isBroken, bool blocking = false ) const;
+
+    std::unique_ptr< QTemporaryDir > temporaryDir;
+};
+
+#endif // QGSSOURCECACHE_H

--- a/src/ui/3d/point3dsymbolwidget.ui
+++ b/src/ui/3d/point3dsymbolwidget.ui
@@ -238,14 +238,7 @@
      <item row="7" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
-        <widget class="QLineEdit" name="lineEditModel"/>
-       </item>
-       <item>
-        <widget class="QToolButton" name="btnModel">
-         <property name="text">
-          <string>…</string>
-         </property>
-        </widget>
+        <widget class="Qgs3DModelSourceLineEdit" name="lineEditModel"/>
        </item>
        <item>
         <widget class="QCheckBox" name="cbOverwriteMaterial">
@@ -425,6 +418,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>Qgs3DModelSourceLineEdit</class>
+   <extends>QWidget</extends>
+   <header>qgs3dmodelsourcelineedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsPhongMaterialWidget</class>
    <extends>QWidget</extends>
    <header>qgsphongmaterialwidget.h</header>
@@ -456,7 +455,6 @@
   <tabstop>spinSize</tabstop>
   <tabstop>spinLength</tabstop>
   <tabstop>lineEditModel</tabstop>
-  <tabstop>btnModel</tabstop>
   <tabstop>cbOverwriteMaterial</tabstop>
   <tabstop>spinBillboardHeight</tabstop>
   <tabstop>btnChangeSymbol</tabstop>


### PR DESCRIPTION
## Description

This PR unlocks project-embedded and remote 3D models for 3D point symbols. 

Being able to embed 3D models in the project file can be super useful when sharing projects.

Obligatory screenshot (take note of the 'embedded file' in the 3D symbol configuration widget at the right):
![image](https://user-images.githubusercontent.com/1728657/87271906-cab7c580-c4fe-11ea-9dd1-eb5597cc511d.png)
