### PR TITLE
Disable distance settings when opening polygon's diagram dialog

### DIFF
--- a/src/gui/vector/qgsdiagramproperties.cpp
+++ b/src/gui/vector/qgsdiagramproperties.cpp
@@ -298,6 +298,9 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer *layer, QWidget *pare
 
       case QgsWkbTypes::PolygonGeometry:
         radOverCentroid->setChecked( true );
+        mDiagramDistanceLabel->setEnabled( false );
+        mDiagramDistanceSpinBox->setEnabled( false );
+        mDistanceDDBtn->setEnabled( false );
         break;
 
       case QgsWkbTypes::UnknownGeometry:


### PR DESCRIPTION
The default "over centroid" setting is not compatible with distances