### PR TITLE
 Move the "Discourage diagrams from covering features" setting

### DIFF
--- a/src/ui/qgsdiagrampropertiesbase.ui
+++ b/src/ui/qgsdiagrampropertiesbase.ui
@@ -968,37 +968,6 @@
                          </item>
                         </layout>
                        </item>
-                       <item row="4" column="0" colspan="3">
-                        <layout class="QHBoxLayout" name="horizontalLayout_12">
-                         <item>
-                          <widget class="QLabel" name="label_8">
-                           <property name="text">
-                            <string>Discourage diagrams and labels from covering features</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <widget class="QgsPropertyOverrideButton" name="mIsObstacleDDBtn">
-                           <property name="text">
-                            <string>…</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <spacer name="horizontalSpacer">
-                           <property name="orientation">
-                            <enum>Qt::Horizontal</enum>
-                           </property>
-                           <property name="sizeHint" stdset="0">
-                            <size>
-                             <width>40</width>
-                             <height>20</height>
-                            </size>
-                           </property>
-                          </spacer>
-                         </item>
-                        </layout>
-                       </item>
                        <item row="3" column="0" colspan="3">
                         <widget class="QgsCollapsibleGroupBox" name="mScaleVisibilityGroupBox">
                          <property name="title">
@@ -1615,6 +1584,51 @@
                         <string>…</string>
                        </property>
                       </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item row="8" column="0">
+                   <widget class="QgsCollapsibleGroupBox" name="mObstaclesGrpBox">
+                    <property name="title">
+                     <string>Obstacles</string>
+                    </property>
+                    <property name="syncGroup" stdset="0">
+                     <string notr="true">labelplacementgroup</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_12">
+                     <property name="leftMargin">
+                      <number>8</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>8</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="label_8">
+                       <property name="text">
+                         <string>Discourage diagrams and labels from covering features</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QgsPropertyOverrideButton" name="mIsObstacleDDBtn">
+                       <property name="text">
+                        <string>…</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
                      </item>
                     </layout>
                    </widget>
@@ -2312,7 +2326,6 @@
   <tabstop>mScaleVisibilityGroupBox</tabstop>
   <tabstop>mShowDiagramDDBtn</tabstop>
   <tabstop>mAlwaysShowDDBtn</tabstop>
-  <tabstop>mIsObstacleDDBtn</tabstop>
   <tabstop>scrollArea_5</tabstop>
   <tabstop>mDiagramUnitComboBox</tabstop>
   <tabstop>mFixedSizeRadio</tabstop>
@@ -2343,6 +2356,7 @@
   <tabstop>mCoordYDDBtn</tabstop>
   <tabstop>mPrioritySlider</tabstop>
   <tabstop>mPriorityDDBtn</tabstop>
+  <tabstop>mIsObstacleDDBtn</tabstop>
   <tabstop>scrollArea_7</tabstop>
   <tabstop>mOrientationUpButton</tabstop>
   <tabstop>mOrientationDownButton</tabstop>

--- a/src/ui/qgsdiagrampropertiesbase.ui
+++ b/src/ui/qgsdiagrampropertiesbase.ui
@@ -853,14 +853,6 @@
                     <property name="syncGroup" stdset="0">
                      <string notr="true">labelrenderinggroup</string>
                     </property>
-                    <layout class="QHBoxLayout" name="horizontalLayout_91">
-                     <property name="leftMargin">
-                      <number>6</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>6</number>
-                     </property>
-                     <item>
                       <layout class="QGridLayout" name="gridLayout_3">
                        <item row="0" column="2">
                         <widget class="QgsPropertyOverrideButton" name="mZOrderDDBtn">
@@ -1003,8 +995,6 @@
                         </widget>
                        </item>
                       </layout>
-                     </item>
-                    </layout>
                    </widget>
                   </item>
                   <item>
@@ -1136,7 +1126,7 @@
                     </property>
                    </spacer>
                   </item>
-                  <item row="3" column="0" colspan="3">
+                  <item row="3" column="0" colspan="2">
                    <widget class="QFrame" name="mLinearScaleFrame">
                     <property name="frameShape">
                      <enum>QFrame::NoFrame</enum>
@@ -1443,7 +1433,7 @@
                     </layout>
                    </widget>
                   </item>
-                  <item row="8" column="0">
+                  <item row="9" column="0">
                    <spacer name="verticalSpacer_4">
                     <property name="orientation">
                      <enum>Qt::Vertical</enum>
@@ -1456,7 +1446,7 @@
                     </property>
                    </spacer>
                   </item>
-                  <item row="3" column="0" colspan="2">
+                  <item row="3" column="0">
                    <widget class="QFrame" name="mLinePlacementFrame">
                     <property name="frameShape">
                      <enum>QFrame::NoFrame</enum>
@@ -1527,7 +1517,7 @@
                     </layout>
                    </widget>
                   </item>
-                  <item row="7" column="0" colspan="2">
+                  <item row="7" column="0">
                    <widget class="QgsCollapsibleGroupBox" name="mPriorityGrpBox">
                     <property name="title">
                      <string>Priority</string>
@@ -2323,9 +2313,9 @@
   <tabstop>mZIndexSpinBox</tabstop>
   <tabstop>mZOrderDDBtn</tabstop>
   <tabstop>mShowAllCheckBox</tabstop>
-  <tabstop>mScaleVisibilityGroupBox</tabstop>
   <tabstop>mShowDiagramDDBtn</tabstop>
   <tabstop>mAlwaysShowDDBtn</tabstop>
+  <tabstop>mScaleVisibilityGroupBox</tabstop>
   <tabstop>scrollArea_5</tabstop>
   <tabstop>mDiagramUnitComboBox</tabstop>
   <tabstop>mFixedSizeRadio</tabstop>
@@ -2367,29 +2357,6 @@
   <tabstop>mButtonSizeLegendSettings</tabstop>
  </tabstops>
  <resources>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>


### PR DESCRIPTION
from Rendering tab to Placement tab.
Makes it inline with labels dialog, and next to the related priority rank setting

![image](https://user-images.githubusercontent.com/7983394/87481793-5a10c600-c630-11ea-8fe1-649ecb119e89.png)
