### PR TITLE
allow to customize convertToCurves parameters for tracing curves

### DIFF
--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -318,7 +318,10 @@ bool QgsMapToolCapture::tracingAddVertex( const QgsPointXY &point )
     if ( capabilities().testFlag( QgsMapToolCapture::Capability::SupportsCurves ) && vlayer->dataProvider()->capabilities().testFlag( QgsVectorDataProvider::Capability::CircularGeometries ) )
     {
       QgsGeometry linear = QgsGeometry( mCaptureCurve.segmentize() );
-      QgsGeometry curved = linear.convertToCurves();
+      QgsGeometry curved = linear.convertToCurves(
+                             settings.value( QStringLiteral( "/qgis/digitizing/convert_to_curve_angle_tolerance" ), 1e-6 ).toDouble(),
+                             settings.value( QStringLiteral( "/qgis/digitizing/convert_to_curve_distance_tolerance" ), 1e-6 ).toDouble()
+                           );
       mCaptureCurve = *qgsgeometry_cast<QgsCompoundCurve *>( curved.constGet() );
     }
   }


### PR DESCRIPTION
## Description

This mitigates an issue with the new (3.14) tracing curves feature, where the default tolerance is too low for curves to be correctly detected (especially when working far from the origin).

This PR sets the default angle/distance tolerance to 1e-6 when tracing curves (this matches the default of the processing algorithm, the default of `QgsGeometry.convertToCurves()` being 1e-8).

Of course there's no one value fits all when it comes to tolerance, so it is now customizable via a QgsSettings.

Open questions :
- do we want to these settings to the configuration panel (under Digitizing/Tracing), or is it too technical ?
- would it make sense to change the defaults of `QgsGeometry.convertToCurves()` to 1e-6 too ?

Cheers !

