### PR TITLE
Fix pasting features - only a single insert operation, no unnecessary (failing) updates

### DIFF
--- a/python/gui/auto_generated/qgsattributeeditorcontext.sip.in
+++ b/python/gui/auto_generated/qgsattributeeditorcontext.sip.in
@@ -31,6 +31,7 @@ showing an embedded form due to relations)
     {
       SingleEditMode,
       AddFeatureMode,
+      FixAttributeMode,
       MultiEditMode,
       SearchMode,
       AggregateSearchMode,

--- a/src/app/qgsfixattributedialog.cpp
+++ b/src/app/qgsfixattributedialog.cpp
@@ -52,7 +52,7 @@ void QgsFixAttributeDialog::init( QgsVectorLayer *layer, const QgsAttributeEdito
   infoLayout->addWidget( mProgressBar );
   QgsFeature feature;
   mAttributeForm = new QgsAttributeForm( layer, *mCurrentFeature, context, this );
-  mAttributeForm->setMode( QgsAttributeEditorContext::SingleEditMode );
+  mAttributeForm->setMode( QgsAttributeEditorContext::FixAttributeMode );
   mAttributeForm->disconnectButtonBox();
   layout()->addWidget( mAttributeForm );
 

--- a/src/core/qgsfeatureid.h
+++ b/src/core/qgsfeatureid.h
@@ -21,7 +21,10 @@ email                : matthias@opengis.ch
 
 // feature id (currently 64 bit)
 
-// 64 bit feature ids
+/**
+ * 64 bit feature ids
+ * negative numbers are used for uncommitted/newly added features
+ **/
 typedef qint64 QgsFeatureId SIP_SKIP;
 #define FID_NULL            std::numeric_limits<QgsFeatureId>::min()
 #define FID_IS_NULL(fid)    ( fid == std::numeric_limits<QgsFeatureId>::min() )

--- a/src/gui/qgsattributeeditorcontext.h
+++ b/src/gui/qgsattributeeditorcontext.h
@@ -49,6 +49,7 @@ class GUI_EXPORT QgsAttributeEditorContext
       SingleEditMode, //!< Single edit mode, for editing a single feature
       AddFeatureMode, /*!< Add feature mode, for setting attributes for a new feature. In this mode the dialog will be editable even with an invalid feature and
       will add a new feature when the form is accepted. */
+      FixAttributeMode, //!< Fix feature mode, for modifying the feature attributes without saving. The updated feature is available via `feature()` after `save()`
       MultiEditMode, //!< Multi edit mode, for editing fields of multiple features at once
       SearchMode, //!< Form values are used for searching/filtering the layer
       AggregateSearchMode, //!< Form is in aggregate search mode, show each widget in this mode \since QGIS 3.0

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -173,6 +173,10 @@ void QgsAttributeForm::setMode( QgsAttributeEditorContext::Mode mode )
         w->setMode( QgsAttributeFormWidget::DefaultMode );
         break;
 
+      case QgsAttributeEditorContext::FixAttributeMode:
+        w->setMode( QgsAttributeFormWidget::DefaultMode );
+        break;
+
       case QgsAttributeEditorContext::MultiEditMode:
         w->setMode( QgsAttributeFormWidget::MultiEditMode );
         break;
@@ -212,6 +216,11 @@ void QgsAttributeForm::setMode( QgsAttributeEditorContext::Mode mode )
       break;
 
     case QgsAttributeEditorContext::AddFeatureMode:
+      synchronizeEnabledState();
+      mSearchButtonBox->setVisible( false );
+      break;
+
+    case QgsAttributeEditorContext::FixAttributeMode:
       synchronizeEnabledState();
       mSearchButtonBox->setVisible( false );
       break;
@@ -278,6 +287,7 @@ void QgsAttributeForm::setFeature( const QgsFeature &feature )
     case QgsAttributeEditorContext::SingleEditMode:
     case QgsAttributeEditorContext::IdentifyMode:
     case QgsAttributeEditorContext::AddFeatureMode:
+    case QgsAttributeEditorContext::FixAttributeMode:
     {
       resetValues();
 
@@ -320,7 +330,7 @@ bool QgsAttributeForm::saveEdits()
 
     // An add dialog should perform an action by default
     // and not only if attributes have "changed"
-    if ( mMode == QgsAttributeEditorContext::AddFeatureMode )
+    if ( mMode == QgsAttributeEditorContext::AddFeatureMode || mMode == QgsAttributeEditorContext::FixAttributeMode )
       doUpdate = true;
 
     QgsAttributes src = mFeature.attributes();
@@ -379,7 +389,11 @@ bool QgsAttributeForm::saveEdits()
 
     if ( doUpdate )
     {
-      if ( mMode == QgsAttributeEditorContext::AddFeatureMode )
+      if ( mMode == QgsAttributeEditorContext::FixAttributeMode )
+      {
+        mFeature = updatedFeature;
+      }
+      else if ( mMode == QgsAttributeEditorContext::AddFeatureMode )
       {
         mFeature.setValid( true );
         mLayer->beginEditCommand( mEditCommandMessage );
@@ -735,6 +749,7 @@ bool QgsAttributeForm::save()
   {
     case QgsAttributeEditorContext::SingleEditMode:
     case QgsAttributeEditorContext::IdentifyMode:
+    case QgsAttributeEditorContext::FixAttributeMode:
     case QgsAttributeEditorContext::MultiEditMode:
       if ( !mDirty )
         return true;
@@ -761,6 +776,7 @@ bool QgsAttributeForm::save()
     case QgsAttributeEditorContext::SingleEditMode:
     case QgsAttributeEditorContext::IdentifyMode:
     case QgsAttributeEditorContext::AddFeatureMode:
+    case QgsAttributeEditorContext::FixAttributeMode:
     case QgsAttributeEditorContext::SearchMode:
     case QgsAttributeEditorContext::AggregateSearchMode:
       success = saveEdits();
@@ -848,6 +864,7 @@ void QgsAttributeForm::onAttributeChanged( const QVariant &value, const QVariant
     case QgsAttributeEditorContext::SingleEditMode:
     case QgsAttributeEditorContext::IdentifyMode:
     case QgsAttributeEditorContext::AddFeatureMode:
+    case QgsAttributeEditorContext::FixAttributeMode:
     {
       Q_NOWARN_DEPRECATED_PUSH
       emit attributeChanged( eww->field().name(), value );
@@ -2264,6 +2281,7 @@ void QgsAttributeForm::layerSelectionChanged()
     case QgsAttributeEditorContext::SingleEditMode:
     case QgsAttributeEditorContext::IdentifyMode:
     case QgsAttributeEditorContext::AddFeatureMode:
+    case QgsAttributeEditorContext::FixAttributeMode:
     case QgsAttributeEditorContext::SearchMode:
     case QgsAttributeEditorContext::AggregateSearchMode:
       break;


### PR DESCRIPTION
When pasting features from another layer, the current implementation calls both `QgsVectorLayer::addFeatures` and `QgsVectorLayer::changeAttributeValue`. This results in both `INSERT` and `UPDATE` operations, but the latter is unnecessary, especially updating a feature with not yet known feature id. 

The error has not been caught yet, because in case of invalid feature ID for `UPDATE`, it results in a query `UPDATE ... WHERE fid = 0`, which is executes and does nothing (unless someone is unlucky enough). However, the error was caught with the PostGIS provider and `int64` id column, because the `WHERE` clause remains empty string, which causes a SQL error.

I am currently investigating the possibility to have a test case, but I am done with the fix itself.