### PR TITLE
Get rid of SIP deprecated functions

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1533,7 +1533,7 @@ is null, a ValueError will be raised.
     }
     else
     {
-      const sipMappedType *qvector_type = sipFindMappedType( "QVector<QgsPointXY>" );
+      const sipTypeDef *qvector_type = sipFindType( "QVector<QgsPointXY>" );
       sipRes = sipConvertFromNewType( new QVector< QgsPointXY >( sipCpp->randomPointsInPolygon( a0, a1 ) ), qvector_type, Py_None );
     }
 %End
@@ -1681,7 +1681,7 @@ will be raised.
     }
     else
     {
-      const sipMappedType *qvector_type = sipFindMappedType( "QVector< QgsPointXY >" );
+      const sipTypeDef *qvector_type = sipFindType( "QVector< QgsPointXY >" );
       sipRes = sipConvertFromNewType( new QgsPolylineXY( sipCpp->asPolyline() ), qvector_type, Py_None );
     }
 %End
@@ -1712,7 +1712,7 @@ will be raised.
     }
     else
     {
-      const sipMappedType *qvector_type = sipFindMappedType( "QVector<QVector<QgsPointXY>>" );
+      const sipTypeDef *qvector_type = sipFindType( "QVector<QVector<QgsPointXY>>" );
       sipRes = sipConvertFromNewType( new QgsPolygonXY( sipCpp->asPolygon() ), qvector_type, Py_None );
     }
 %End
@@ -1742,7 +1742,7 @@ will be raised.
     }
     else
     {
-      const sipMappedType *qvector_type = sipFindMappedType( "QVector< QgsPointXY >" );
+      const sipTypeDef *qvector_type = sipFindType( "QVector< QgsPointXY >" );
       sipRes = sipConvertFromNewType( new QgsPolylineXY( sipCpp->asMultiPoint() ), qvector_type, Py_None );
     }
 %End
@@ -1773,7 +1773,7 @@ will be raised.
     }
     else
     {
-      const sipMappedType *qvector_type = sipFindMappedType( "QVector<QVector<QgsPointXY>>" );
+      const sipTypeDef *qvector_type = sipFindType( "QVector<QVector<QgsPointXY>>" );
       sipRes = sipConvertFromNewType( new QgsMultiPolylineXY( sipCpp->asMultiPolyline() ), qvector_type, Py_None );
     }
 %End
@@ -1804,7 +1804,7 @@ will be raised.
     }
     else
     {
-      const sipMappedType *qvector_type = sipFindMappedType( "QVector<QVector<QVector<QgsPointXY>>>" );
+      const sipTypeDef *qvector_type = sipFindType( "QVector<QVector<QVector<QgsPointXY>>>" );
       sipRes = sipConvertFromNewType( new QgsMultiPolygonXY( sipCpp->asMultiPolygon() ), qvector_type, Py_None );
     }
 %End

--- a/python/core/auto_generated/geometry/qgspoint.sip.in
+++ b/python/core/auto_generated/geometry/qgspoint.sip.in
@@ -88,8 +88,7 @@ based on the following rules:
       ( a0 == Py_None || PyFloat_AsDouble( a0 ) != -1.0 || !PyErr_Occurred() ) &&
       ( a1 == Py_None || PyFloat_AsDouble( a1 ) != -1.0 || !PyErr_Occurred() ) &&
       ( a2 == Py_None || PyFloat_AsDouble( a2 ) != -1.0 || !PyErr_Occurred() ) &&
-      ( a3 == Py_None || PyFloat_AsDouble( a3 ) != -1.0 || !PyErr_Occurred() ) &&
-      ( a4 == Py_None || sipCanConvertToEnum( a4, sipType_QgsWkbTypes_Type ) ) )
+      ( a3 == Py_None || PyFloat_AsDouble( a3 ) != -1.0 || !PyErr_Occurred() ) )
     {
       double x = a0 == Py_None ? std::numeric_limits<double>::quiet_NaN() : PyFloat_AsDouble( a0 );
       double y = a1 == Py_None ? std::numeric_limits<double>::quiet_NaN() : PyFloat_AsDouble( a1 );

--- a/python/core/auto_generated/raster/qgsrasterpipe.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterpipe.sip.in
@@ -54,7 +54,7 @@ if connection would fail, the interface is not inserted and ``False`` is returne
       // if insertion failed transfer ownership back to python
       PyObject *o = sipGetPyObject( a1, sipType_QgsRasterInterface );
       if ( o )
-        sipTransferBreak( o );
+        sipTransferTo( o, NULL );
     }
 %End
 

--- a/python/core/conversions.sip
+++ b/python/core/conversions.sip
@@ -41,7 +41,7 @@ template <TYPE>
   if ((l = PyList_New(sipCpp->size())) == NULL)
     return NULL;
 
-  const sipMappedType *qvector_type = sipFindMappedType("QVector<TYPE>");
+  const sipTypeDef *qvector_type = sipFindType("QVector<TYPE>");
 
   // Set the list elements.
   for (int i = 0; i < sipCpp->size(); ++i)
@@ -62,7 +62,7 @@ template <TYPE>
 %End
 
 %ConvertToTypeCode
-  const sipMappedType *qvector_type = sipFindMappedType("QVector<TYPE>");
+  const sipTypeDef *qvector_type = sipFindType("QVector<TYPE>");
 
   // Check the type if that is all that is required.
   if (sipIsErr == NULL)
@@ -71,7 +71,7 @@ template <TYPE>
       return 0;
 
     for (int i = 0; i < PyList_GET_SIZE(sipPy); ++i)
-      if (!sipCanConvertToMappedType(PyList_GET_ITEM(sipPy, i), qvector_type, SIP_NOT_NONE))
+      if (!sipCanConvertToType(PyList_GET_ITEM(sipPy, i), qvector_type, SIP_NOT_NONE))
         return 0;
 
     return 1;
@@ -84,16 +84,16 @@ template <TYPE>
   {
     int state;
     //TYPE *t = reinterpret_cast<TYPE *>(sipConvertToType(PyList_GET_ITEM(sipPy, i), sipType_TYPE, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
-    QVector<TYPE> *t = reinterpret_cast< QVector<TYPE> * >(sipConvertToMappedType(PyList_GET_ITEM(sipPy, i), qvector_type, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
+    QVector<TYPE> *t = reinterpret_cast< QVector<TYPE> * >(sipConvertToType(PyList_GET_ITEM(sipPy, i), qvector_type, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
 
     if (*sipIsErr)
     {
-      sipReleaseMappedType(t, qvector_type, state);
+      sipReleaseType(t, qvector_type, state);
       delete ql;
       return 0;
     }
     ql->append(*t);
-    sipReleaseMappedType(t, qvector_type, state);
+    sipReleaseType(t, qvector_type, state);
   }
 
   *sipCppPtr = ql;
@@ -118,7 +118,7 @@ template <TYPE>
   if ((l = PyList_New(sipCpp->size())) == NULL)
     return NULL;
 
-  const sipMappedType *qvector_type = sipFindMappedType("QVector<QVector<TYPE> >");
+  const sipTypeDef *qvector_type = sipFindType("QVector<QVector<TYPE> >");
 
   // Set the list elements.
   for (int i = 0; i < sipCpp->size(); ++i)
@@ -139,7 +139,7 @@ template <TYPE>
 
 %ConvertToTypeCode
 
-  const sipMappedType *qvector_type = sipFindMappedType("QVector<QVector<TYPE> >");
+  const sipTypeDef *qvector_type = sipFindType("QVector<QVector<TYPE> >");
 
   // Check the type if that is all that is required.
   if (sipIsErr == NULL)
@@ -148,7 +148,7 @@ template <TYPE>
       return 0;
 
     for (int i = 0; i < PyList_GET_SIZE(sipPy); ++i)
-      if (!sipCanConvertToMappedType(PyList_GET_ITEM(sipPy, i), qvector_type, SIP_NOT_NONE))
+      if (!sipCanConvertToType(PyList_GET_ITEM(sipPy, i), qvector_type, SIP_NOT_NONE))
         return 0;
 
     return 1;
@@ -161,16 +161,16 @@ template <TYPE>
   {
     int state;
     //TYPE *t = reinterpret_cast<TYPE *>(sipConvertToType(PyList_GET_ITEM(sipPy, i), sipType_TYPE, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
-    QVector<QVector<TYPE> > *t = reinterpret_cast< QVector< QVector<TYPE> > * >(sipConvertToMappedType(PyList_GET_ITEM(sipPy, i), qvector_type, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
+    QVector<QVector<TYPE> > *t = reinterpret_cast< QVector< QVector<TYPE> > * >(sipConvertToType(PyList_GET_ITEM(sipPy, i), qvector_type, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
 
     if (*sipIsErr)
     {
-      sipReleaseMappedType(t, qvector_type, state);
+      sipReleaseType(t, qvector_type, state);
       delete ql;
       return 0;
     }
     ql->append(*t);
-    sipReleaseMappedType(t, qvector_type, state);
+    sipReleaseType(t, qvector_type, state);
   }
 
   *sipCppPtr = ql;
@@ -194,7 +194,7 @@ template <TYPE>
   if ((l = PyList_New(sipCpp->size())) == NULL)
     return NULL;
 
-  const sipMappedType *qlist_type = sipFindMappedType("QList<TYPE>");
+  const sipTypeDef *qlist_type = sipFindType("QList<TYPE>");
 
   // Set the list elements.
   for (int i = 0; i < sipCpp->size(); ++i)
@@ -215,7 +215,7 @@ template <TYPE>
 %End
 
 %ConvertToTypeCode
-  const sipMappedType *qlist_type = sipFindMappedType("QList<TYPE>");
+  const sipTypeDef *qlist_type = sipFindType("QList<TYPE>");
 
   // Check the type if that is all that is required.
   if (sipIsErr == NULL)
@@ -224,7 +224,7 @@ template <TYPE>
       return 0;
 
     for (int i = 0; i < PyList_GET_SIZE(sipPy); ++i)
-      if (!sipCanConvertToMappedType(PyList_GET_ITEM(sipPy, i), qlist_type, SIP_NOT_NONE))
+      if (!sipCanConvertToType(PyList_GET_ITEM(sipPy, i), qlist_type, SIP_NOT_NONE))
         return 0;
 
     return 1;
@@ -237,16 +237,16 @@ template <TYPE>
   {
     int state;
     //TYPE *t = reinterpret_cast<TYPE *>(sipConvertToType(PyList_GET_ITEM(sipPy, i), sipType_TYPE, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
-    QList<TYPE> *t = reinterpret_cast< QList<TYPE> * >(sipConvertToMappedType(PyList_GET_ITEM(sipPy, i), qlist_type, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
+    QList<TYPE> *t = reinterpret_cast< QList<TYPE> * >(sipConvertToType(PyList_GET_ITEM(sipPy, i), qlist_type, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
 
     if (*sipIsErr)
     {
-      sipReleaseMappedType(t, qlist_type, state);
+      sipReleaseType(t, qlist_type, state);
       delete ql;
       return 0;
     }
     ql->append(*t);
-    sipReleaseMappedType(t, qlist_type, state);
+    sipReleaseType(t, qlist_type, state);
   }
 
   *sipCppPtr = ql;
@@ -462,7 +462,7 @@ template<TYPE>
   if ((d = PyDict_New()) == NULL)
     return NULL;
 
-  const sipMappedType *qmap2 = sipFindMappedType("QMap<int, TYPE>");
+  const sipTypeDef *qmap2 = sipFindType("QMap<int, TYPE>");
 
   // Set the list elements.
   for (QMap<qint64, QMap<int, TYPE> >::iterator it = sipCpp->begin(); it != sipCpp->end(); ++it)
@@ -531,7 +531,7 @@ template<TYPE>
   {
     qint64 k = PyLong_AsLongLong(kobj);
 
-    // using sipConvertToMappedType to convert directly to QMap<int, TYPE> doesn't work
+    // using sipConvertToType to convert directly to QMap<int, TYPE> doesn't work
     // and ends with a segfault
 
     QMap<int, TYPE> qm2;
@@ -1025,7 +1025,7 @@ template<TYPE2>
     Py_ssize_t i = 0;
 
 
-    const sipMappedType *qlist_type = sipFindMappedType("QList<TYPE2>");
+    const sipTypeDef *qlist_type = sipFindType("QList<TYPE2>");
 
 
     // Check the type if that is all that is required.
@@ -1051,7 +1051,7 @@ template<TYPE2>
 
         QString *t1 = reinterpret_cast<QString *>(sipConvertToType(t1obj, sipType_QString, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
 
-    QList<TYPE2> *t2 = reinterpret_cast< QList<TYPE2> * >(sipConvertToMappedType(t2obj, qlist_type, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
+    QList<TYPE2> *t2 = reinterpret_cast< QList<TYPE2> * >(sipConvertToType(t2obj, qlist_type, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
         if (*sipIsErr)
         {
             sipReleaseType(t2, sipType_TYPE2, state);

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1558,7 +1558,7 @@ class CORE_EXPORT QgsGeometry
     }
     else
     {
-      const sipMappedType *qvector_type = sipFindMappedType( "QVector<QgsPointXY>" );
+      const sipTypeDef *qvector_type = sipFindType( "QVector<QgsPointXY>" );
       sipRes = sipConvertFromNewType( new QVector< QgsPointXY >( sipCpp->randomPointsInPolygon( a0, a1 ) ), qvector_type, Py_None );
     }
     % End
@@ -1731,7 +1731,7 @@ class CORE_EXPORT QgsGeometry
     }
     else
     {
-      const sipMappedType *qvector_type = sipFindMappedType( "QVector< QgsPointXY >" );
+      const sipTypeDef *qvector_type = sipFindType( "QVector< QgsPointXY >" );
       sipRes = sipConvertFromNewType( new QgsPolylineXY( sipCpp->asPolyline() ), qvector_type, Py_None );
     }
     % End
@@ -1775,7 +1775,7 @@ class CORE_EXPORT QgsGeometry
     }
     else
     {
-      const sipMappedType *qvector_type = sipFindMappedType( "QVector<QVector<QgsPointXY>>" );
+      const sipTypeDef *qvector_type = sipFindType( "QVector<QVector<QgsPointXY>>" );
       sipRes = sipConvertFromNewType( new QgsPolygonXY( sipCpp->asPolygon() ), qvector_type, Py_None );
     }
     % End
@@ -1817,7 +1817,7 @@ class CORE_EXPORT QgsGeometry
     }
     else
     {
-      const sipMappedType *qvector_type = sipFindMappedType( "QVector< QgsPointXY >" );
+      const sipTypeDef *qvector_type = sipFindType( "QVector< QgsPointXY >" );
       sipRes = sipConvertFromNewType( new QgsPolylineXY( sipCpp->asMultiPoint() ), qvector_type, Py_None );
     }
     % End
@@ -1861,7 +1861,7 @@ class CORE_EXPORT QgsGeometry
     }
     else
     {
-      const sipMappedType *qvector_type = sipFindMappedType( "QVector<QVector<QgsPointXY>>" );
+      const sipTypeDef *qvector_type = sipFindType( "QVector<QVector<QgsPointXY>>" );
       sipRes = sipConvertFromNewType( new QgsMultiPolylineXY( sipCpp->asMultiPolyline() ), qvector_type, Py_None );
     }
     % End
@@ -1905,7 +1905,7 @@ class CORE_EXPORT QgsGeometry
     }
     else
     {
-      const sipMappedType *qvector_type = sipFindMappedType( "QVector<QVector<QVector<QgsPointXY>>>" );
+      const sipTypeDef *qvector_type = sipFindType( "QVector<QVector<QVector<QgsPointXY>>>" );
       sipRes = sipConvertFromNewType( new QgsMultiPolygonXY( sipCpp->asMultiPolygon() ), qvector_type, Py_None );
     }
     % End

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -110,8 +110,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
       ( a0 == Py_None || PyFloat_AsDouble( a0 ) != -1.0 || !PyErr_Occurred() ) &&
       ( a1 == Py_None || PyFloat_AsDouble( a1 ) != -1.0 || !PyErr_Occurred() ) &&
       ( a2 == Py_None || PyFloat_AsDouble( a2 ) != -1.0 || !PyErr_Occurred() ) &&
-      ( a3 == Py_None || PyFloat_AsDouble( a3 ) != -1.0 || !PyErr_Occurred() ) &&
-      ( a4 == Py_None || sipCanConvertToEnum( a4, sipType_QgsWkbTypes_Type ) ) )
+      ( a3 == Py_None || PyFloat_AsDouble( a3 ) != -1.0 || !PyErr_Occurred() ) )
     {
       double x = a0 == Py_None ? std::numeric_limits<double>::quiet_NaN() : PyFloat_AsDouble( a0 );
       double y = a1 == Py_None ? std::numeric_limits<double>::quiet_NaN() : PyFloat_AsDouble( a1 );

--- a/src/core/raster/qgsrasterpipe.h
+++ b/src/core/raster/qgsrasterpipe.h
@@ -83,7 +83,7 @@ class CORE_EXPORT QgsRasterPipe
       // if insertion failed transfer ownership back to python
       PyObject *o = sipGetPyObject( a1, sipType_QgsRasterInterface );
       if ( o )
-        sipTransferBreak( o );
+        sipTransferTo( o, NULL );
     }
     % End
 #endif


### PR DESCRIPTION
- `sipMappedType` struct was deprecated in SIP v4.8 in favour of `sipTypeDef`. The related functions should be changed as follows:
    - `sipFindMappedType` → `sipFindType`;
    - `sipCanConvertToMappedType` → `sipCanConvertToType`;
    - `sipConvertToMappedType` → `sipConvertToType`;
    - `sipReleaseMappedType` → `sipReleaseType`.

- `sipCanConvertToEnum` was deprecated in SIP v4.19.4. The documentation suggests to use `sipConvertToEnum` directly. In QGIS case, that function was used to raise a `TypeError` exception when the type does not match, however `sipConvertToEnum` [raises a `TypeError` itself][1] so that code is not needed.

- `sipTransferBreak` was deprecated in SIP v4.14. The documentation says to [use `sipTransferTo(obj, NULL);` instead][2] (available since v4.3), which is what I have done here.

All deprecated functions were removed in SIP v5.0, so this is needed in preparation for SIP v5 support (#37542). I plan to add actual support in the next pull request.

This does not change minimal SIP dependency. The code is already using `sipConvertToEnum` which means that SIP v4.19.4 is required. (In fact, `sipConvertToEnum` was added together with deprecating `sipCanConvertToEnum`.)

[1]: https://riverbankcomputing.com/hg/sip/file/853c4a8b4592/siplib/siplib.c#l7705
[2]: https://riverbankcomputing.com/hg/sip/file/853c4a8b4592/sphinx/c_api.rst#l2453