### PR TITLE
Call saveSettings from QgsCompoundColorWidget::hideEvent

### DIFF
--- a/python/gui/auto_generated/qgscompoundcolorwidget.sip.in
+++ b/python/gui/auto_generated/qgscompoundcolorwidget.sip.in
@@ -133,6 +133,9 @@ Sets the color to show in an optional "previous color" section
 
   protected:
 
+    virtual void hideEvent( QHideEvent *e );
+
+
     virtual void mousePressEvent( QMouseEvent *e );
 
 

--- a/src/gui/qgscompoundcolorwidget.cpp
+++ b/src/gui/qgscompoundcolorwidget.cpp
@@ -292,7 +292,6 @@ QgsCompoundColorWidget::QgsCompoundColorWidget( QWidget *parent, const QColor &c
 
 QgsCompoundColorWidget::~QgsCompoundColorWidget()
 {
-  saveSettings();
   if ( !mDiscarded )
   {
     QgsRecentColorScheme::addRecentColor( color() );
@@ -739,6 +738,12 @@ void QgsCompoundColorWidget::setPreviousColor( const QColor &color )
 {
   mOldColorLabel->setVisible( color.isValid() );
   mColorPreview->setColor2( color );
+}
+
+void QgsCompoundColorWidget::hideEvent( QHideEvent *e )
+{
+  saveSettings();
+  QWidget::hideEvent( e );
 }
 
 void QgsCompoundColorWidget::mousePressEvent( QMouseEvent *e )

--- a/src/gui/qgscompoundcolorwidget.h
+++ b/src/gui/qgscompoundcolorwidget.h
@@ -136,6 +136,8 @@ class GUI_EXPORT QgsCompoundColorWidget : public QgsPanelWidget, private Ui::Qgs
 
   protected:
 
+    void hideEvent( QHideEvent *e ) override;
+
     void mousePressEvent( QMouseEvent *e ) override;
 
     void mouseMoveEvent( QMouseEvent *e ) override;


### PR DESCRIPTION
We currently call saveSettings from the QgsCompoundColorWidget destructor.
Since we restore the custom colors when the constructor runs, any changes made
will be lost if a second QgsCompoundColorWidget is created before the first is
destroyed. This adds a hideEvent handler, and saves the settings from there.

Fixes #37749.