### PR TITLE
createUserProfile: ensure qgis.db file is user writable

### DIFF
--- a/src/core/qgsuserprofilemanager.cpp
+++ b/src/core/qgsuserprofilemanager.cpp
@@ -156,6 +156,17 @@ QgsError QgsUserProfileManager::createUserProfile( const QString &name )
 
     //now copy the master file into the users .qgis dir
     masterFile.copy( qgisPrivateDbFile.fileName() );
+
+    // In some packaging systems, the master can be read-only. Make sure to make
+    // the copy user writable.
+    const QFile::Permissions perms = QFile( qgisPrivateDbFile.fileName() ).permissions();
+    if ( !( perms & QFile::WriteOwner ) )
+    {
+      if ( !qgisPrivateDbFile.setPermissions( perms | QFile::WriteOwner ) )
+      {
+        error.append( tr( "Can not make '%1' user writable" ).arg( qgisPrivateDbFile.fileName() ) );
+      }
+    }
   }
 
   if ( error.isEmpty() )


### PR DESCRIPTION
## Description

In some package managers (such as NIX[1], used in NixOS[2]), packaged
data is installed read-only.

When creating a new user profile, QGis copies the `qgis.db` file from
the packages and the user ends having a read-only `qgis.db` database.

This commit ensures that once copied when creating a ne profile, the
`qgis.db` file is made user writable.

Since we are running QGIS LTS in nixpkgs (currently QGIS-3.10.7), it would be greatly appreciated if this could be back ported.

[1] https://nixos.org/nix/
[2] https://nixos.org/

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
