### PR TITLE
Fix connection slot

### DIFF
--- a/src/ui/qgsvectorlayersaveasdialogbase.ui
+++ b/src/ui/qgsvectorlayersaveasdialogbase.ui
@@ -516,7 +516,7 @@
  <resources/>
  <connections>
   <connection>
-   <sender>buttonBox</sender>
+   <sender>mButtonBox</sender>
    <signal>accepted()</signal>
    <receiver>QgsVectorLayerSaveAsDialogBase</receiver>
    <slot>accept()</slot>
@@ -532,7 +532,7 @@
    </hints>
   </connection>
   <connection>
-   <sender>buttonBox</sender>
+   <sender>mButtonBox</sender>
    <signal>rejected()</signal>
    <receiver>QgsVectorLayerSaveAsDialogBase</receiver>
    <slot>reject()</slot>


### PR DESCRIPTION
I suppose... due to https://github.com/qgis/QGIS/pull/37771/checks?check_run_id=867287292#step:6:707
> /Users/runner/work/QGIS/QGIS/src/ui/qgsvectorlayersaveasdialogbase.ui: Warning: Invalid signal/slot connection: "buttonBox" -> "QgsVectorLayerSaveAsDialogBase".
/Users/runner/work/QGIS/QGIS/src/ui/qgsvectorlayersaveasdialogbase.ui: Warning: Invalid signal/slot connection: "buttonBox" -> "QgsVectorLayerSaveAsDialogBase".