### PR TITLE
Don't load GRASS algs if GRASS is not installed

### DIFF
--- a/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
+++ b/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
@@ -128,6 +128,12 @@ class Grass7AlgorithmProvider(QgsProcessingProvider):
         return algs
 
     def loadAlgorithms(self):
+        version = Grass7Utils.installedVersion(True)
+        if version is None:
+            QgsMessageLog.logMessage(self.tr('Problem with GRASS installation: GRASS was not found or is not correctly installed'),
+                                     self.tr('Processing'), Qgis.Critical)
+            return
+
         self.algs = self.createAlgsList()
         for a in self.algs:
             self.addAlgorithm(a)


### PR DESCRIPTION
## Description

This patch prevents the `qgis_process list` command from listing the GRASS algorithms among the available processing algs when GRASS is not installed in the system.

See also the same logic used for SAGA algorithms
https://github.com/qgis/QGIS/blob/d0dda27afa2cda4c7a21e1ed89adbb427788b7a2/python/plugins/processing/algs/saga/SagaAlgorithmProvider.py#L95-L100

and a similar behavior for OTB algorithms
https://github.com/qgis/QGIS/blob/9fedd2c581e23b0eaac024a9b62530d2428f2f16/python/plugins/processing/algs/otb/OtbAlgorithmProvider.py#L128-L130

Ref: https://github.com/qgis/QGIS/pull/34617

Fixes https://github.com/qgis/QGIS/issues/37877