### PR TITLE
[vector file writer] LIBKML driver also requires coordinates to be in wgs84

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -419,7 +419,7 @@ void QgsVectorFileWriter::init( QString vectorFileName,
   }
 
   // consider spatial reference system of the layer
-  if ( driverName == QLatin1String( "KML" ) || driverName == QLatin1String( "GPX" ) )
+  if ( driverName == QLatin1String( "KML" ) || driverName == QLatin1String( "LIBKML" ) || driverName == QLatin1String( "GPX" ) )
   {
     if ( srs.authid() != QStringLiteral( "EPSG:4326" ) )
     {


### PR DESCRIPTION
## Description

While we do not use the LIBKML driver in our save vector as file dialog, calling QgsVectorFileWriter::driverForExtension( "kml" ) will return LIBKML. We need to make sure this driver also forces coordinates to be in wgs84 to produce a valid output.

@rouault , out of curiosity, in 2020, would you recommend that QGIS relies on the KML driver or the LIBKML driver to write kml files? 