### PR TITLE
Remove restrictive length limitations on created fields

### DIFF
--- a/src/analysis/processing/qgsalgorithmmergevector.cpp
+++ b/src/analysis/processing/qgsalgorithmmergevector.cpp
@@ -167,13 +167,13 @@ QVariantMap QgsMergeVectorAlgorithm::processAlgorithm( const QVariantMap &parame
   bool addLayerField = false;
   if ( outputFields.lookupField( QStringLiteral( "layer" ) ) < 0 )
   {
-    outputFields.append( QgsField( QStringLiteral( "layer" ), QVariant::String, QString(), 100 ) );
+    outputFields.append( QgsField( QStringLiteral( "layer" ), QVariant::String, QString() ) );
     addLayerField = true;
   }
   bool addPathField = false;
   if ( outputFields.lookupField( QStringLiteral( "path" ) ) < 0 )
   {
-    outputFields.append( QgsField( QStringLiteral( "path" ), QVariant::String, QString(), 200 ) );
+    outputFields.append( QgsField( QStringLiteral( "path" ), QVariant::String, QString() ) );
     addPathField = true;
   }
 


### PR DESCRIPTION
Otherwise the algorithm can fail to add features if the path/layername is too long 