### PR TITLE
Better error reporting when features fail to be added to an output

### DIFF
--- a/python/core/auto_generated/qgsfeaturesink.sip.in
+++ b/python/core/auto_generated/qgsfeaturesink.sip.in
@@ -73,6 +73,13 @@ Flushes any internal buffer which may exist in the sink, causing any buffered fe
 
 :return: ``False`` if any buffered features could not be added to the sink.
 %End
+
+    virtual QString lastError() const;
+%Docstring
+Returns the most recent error encountered by the sink, e.g. when a call to :py:func:`~QgsFeatureSink.addFeatures` returns ``False``.
+
+.. versionadded:: 3.16
+%End
 };
 
 QFlags<QgsFeatureSink::Flag> operator|(QgsFeatureSink::Flag f1, QFlags<QgsFeatureSink::Flag> f2);

--- a/python/core/auto_generated/qgsproxyfeaturesink.sip.in
+++ b/python/core/auto_generated/qgsproxyfeaturesink.sip.in
@@ -36,6 +36,7 @@ Constructs a new QgsProxyFeatureSink which forwards features onto a destination 
     virtual bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() );
     virtual bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() );
     virtual bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() );
+    virtual QString lastError() const;
 
     QgsFeatureSink *destinationSink();
 %Docstring

--- a/python/core/auto_generated/qgsremappingproxyfeaturesink.sip.in
+++ b/python/core/auto_generated/qgsremappingproxyfeaturesink.sip.in
@@ -192,6 +192,8 @@ Remaps a ``feature`` to a set of features compatible with the destination sink.
 
     virtual bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() );
 
+    virtual QString lastError() const;
+
 
     QgsFeatureSink *destinationSink();
 %Docstring

--- a/python/core/auto_generated/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/qgsvectordataprovider.sip.in
@@ -234,6 +234,8 @@ or if the given attribute is not an enum type.
 
     virtual bool addFeatures( QgsFeatureList &flist /In,Out/, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() );
 
+    virtual QString lastError() const;
+
 
     virtual bool deleteFeatures( const QgsFeatureIds &id );
 %Docstring

--- a/python/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -572,6 +572,8 @@ Retrieves error message
 
     virtual bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() );
 
+    virtual QString lastError() const;
+
 
     bool addFeatureWithStyle( QgsFeature &feature, QgsFeatureRenderer *renderer, QgsUnitTypes::DistanceUnit outputUnit = QgsUnitTypes::DistanceMeters );
 %Docstring

--- a/python/core/auto_generated/qgsvectorlayerexporter.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerexporter.sip.in
@@ -124,6 +124,8 @@ Returns the number of error messages encountered during the export.
 
     virtual bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() );
 
+    virtual QString lastError() const;
+
 
     ~QgsVectorLayerExporter();
 

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -1377,7 +1377,13 @@ bool QgsProcessingFeatureSink::addFeature( QgsFeature &feature, QgsFeatureSink::
 {
   bool result = QgsProxyFeatureSink::addFeature( feature, flags );
   if ( !result && mContext.feedback() )
-    mContext.feedback()->reportError( QObject::tr( "Feature could not be written to %1" ).arg( mSinkName ) );
+  {
+    const QString error = lastError();
+    if ( !error.isEmpty() )
+      mContext.feedback()->reportError( QObject::tr( "Feature could not be written to %1: %2" ).arg( mSinkName, error ) );
+    else
+      mContext.feedback()->reportError( QObject::tr( "Feature could not be written to %1" ).arg( mSinkName ) );
+  }
   return result;
 }
 
@@ -1385,7 +1391,13 @@ bool QgsProcessingFeatureSink::addFeatures( QgsFeatureList &features, QgsFeature
 {
   bool result = QgsProxyFeatureSink::addFeatures( features, flags );
   if ( !result && mContext.feedback() )
-    mContext.feedback()->reportError( QObject::tr( "%1 feature(s) could not be written to %2" ).arg( features.count() ).arg( mSinkName ) );
+  {
+    const QString error = lastError();
+    if ( !error.isEmpty() )
+      mContext.feedback()->reportError( QObject::tr( "%1 feature(s) could not be written to %2: %3" ).arg( features.count() ).arg( mSinkName, error ) );
+    else
+      mContext.feedback()->reportError( QObject::tr( "%1 feature(s) could not be written to %2" ).arg( features.count() ).arg( mSinkName ) );
+  }
   return result;
 }
 
@@ -1393,6 +1405,12 @@ bool QgsProcessingFeatureSink::addFeatures( QgsFeatureIterator &iterator, QgsFea
 {
   bool result = QgsProxyFeatureSink::addFeatures( iterator, flags );
   if ( !result && mContext.feedback() )
-    mContext.feedback()->reportError( QObject::tr( "Features could not be written to %1" ).arg( mSinkName ) );
+  {
+    const QString error = lastError();
+    if ( !error.isEmpty() )
+      mContext.feedback()->reportError( QObject::tr( "Features could not be written to %1: %2" ).arg( mSinkName, error ) );
+    else
+      mContext.feedback()->reportError( QObject::tr( "Features could not be written to %1" ).arg( mSinkName ) );
+  }
   return result;
 }

--- a/src/core/qgsfeaturesink.h
+++ b/src/core/qgsfeaturesink.h
@@ -106,6 +106,13 @@ class CORE_EXPORT QgsFeatureSink
      * \returns FALSE if any buffered features could not be added to the sink.
      */
     virtual bool flushBuffer() { return true; }
+
+    /**
+     * Returns the most recent error encountered by the sink, e.g. when a call to addFeatures() returns FALSE.
+     *
+     * \since QGIS 3.16
+     */
+    virtual QString lastError() const { return QString(); }
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsFeatureSink::Flags )

--- a/src/core/qgsproxyfeaturesink.h
+++ b/src/core/qgsproxyfeaturesink.h
@@ -47,6 +47,7 @@ class CORE_EXPORT QgsProxyFeatureSink : public QgsFeatureSink
     bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) override { return mSink->addFeature( feature, flags ); }
     bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) override { return mSink->addFeatures( features, flags ); }
     bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) override { return mSink->addFeatures( iterator, flags ); }
+    QString lastError() const override { return mSink->lastError(); }
 
     /**
      * Returns the destination QgsFeatureSink which the proxy will forward features to.

--- a/src/core/qgsremappingproxyfeaturesink.cpp
+++ b/src/core/qgsremappingproxyfeaturesink.cpp
@@ -130,6 +130,11 @@ bool QgsRemappingProxyFeatureSink::addFeatures( QgsFeatureIterator &iterator, Qg
   return res;
 }
 
+QString QgsRemappingProxyFeatureSink::lastError() const
+{
+  return mSink->lastError();
+}
+
 QVariant QgsRemappingSinkDefinition::toVariant() const
 {
   QVariantMap map;

--- a/src/core/qgsremappingproxyfeaturesink.h
+++ b/src/core/qgsremappingproxyfeaturesink.h
@@ -219,6 +219,7 @@ class CORE_EXPORT QgsRemappingProxyFeatureSink : public QgsFeatureSink
     bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) override;
     bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) override;
     bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) override;
+    QString lastError() const override;
 
     /**
      * Returns the destination QgsFeatureSink which the proxy will forward features to.

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -89,6 +89,11 @@ bool QgsVectorDataProvider::addFeatures( QgsFeatureList &flist, Flags flags )
   return false;
 }
 
+QString QgsVectorDataProvider::lastError() const
+{
+  return mErrors.last();
+}
+
 bool QgsVectorDataProvider::deleteFeatures( const QgsFeatureIds &ids )
 {
   Q_UNUSED( ids )

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -260,6 +260,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
     virtual void enumValues( int index, QStringList &enumList SIP_OUT ) const { Q_UNUSED( index ) enumList.clear(); }
 
     bool addFeatures( QgsFeatureList &flist SIP_INOUT, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) override;
+    QString lastError() const override;
 
     /**
      * Deletes one or more features from the provider. This requires the DeleteFeatures capability.

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2296,6 +2296,11 @@ bool QgsVectorFileWriter::addFeatures( QgsFeatureList &features, QgsFeatureSink:
   return result;
 }
 
+QString QgsVectorFileWriter::lastError() const
+{
+  return mErrorMessage;
+}
+
 bool QgsVectorFileWriter::addFeatureWithStyle( QgsFeature &feature, QgsFeatureRenderer *renderer, QgsUnitTypes::DistanceUnit outputUnit )
 {
   // create the feature

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -762,6 +762,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
 
     bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) override;
     bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) override;
+    QString lastError() const override;
 
     /**
      * Adds a \a feature to the currently opened data source, using the style from a specified \a renderer.

--- a/src/core/qgsvectorlayerexporter.cpp
+++ b/src/core/qgsvectorlayerexporter.cpp
@@ -188,6 +188,11 @@ bool QgsVectorLayerExporter::addFeature( QgsFeature &feat, Flags )
   return true;
 }
 
+QString QgsVectorLayerExporter::lastError() const
+{
+  return mErrorMessage;
+}
+
 bool QgsVectorLayerExporter::flushBuffer()
 {
   if ( mFeatureBuffer.count() <= 0 )

--- a/src/core/qgsvectorlayerexporter.h
+++ b/src/core/qgsvectorlayerexporter.h
@@ -136,6 +136,7 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
 
     bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) override;
     bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) override;
+    QString lastError() const override;
 
     /**
      * Finalizes the export and closes the new created layer.


### PR DESCRIPTION
Use a descriptive error message which explains why the feature addition failed, instead of a generic error message