### PR TITLE
Multi identify for mesh layer

### DIFF
--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -1087,7 +1087,9 @@ void QgsIdentifyResultsDialog::addFeature( QgsMeshLayer *layer,
       QgsFeature(),
       layer->crs(),
       QStringList() << label << QString() );
+
   layItem->addChild( featItem );
+  featItem->setExpanded( true );
 
   // attributes
   for ( QMap<QString, QString>::const_iterator it = attributes.begin(); it != attributes.end(); ++it )

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -28,6 +28,7 @@
 #include "qgsmaptopixel.h"
 #include "qgsmessageviewer.h"
 #include "qgsmeshlayer.h"
+#include "qgsmeshlayertemporalproperties.h"
 #include "qgsmaplayer.h"
 #include "qgsrasterdataprovider.h"
 #include "qgsrasterlayer.h"
@@ -252,7 +253,7 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
     return false;
 
   double searchRadius = mOverrideCanvasSearchRadius < 0 ? searchRadiusMU( mCanvas ) : mOverrideCanvasSearchRadius;
-  bool isTemporal = mCanvas->mapSettings().isTemporal();
+  bool isTemporal = mCanvas->mapSettings().isTemporal() && layer->temporalProperties()->isActive();
 
   QList<QgsMeshDatasetIndex> datasetIndexList;
   int activeScalarGroup = layer->rendererSettings().activeScalarDatasetGroup();
@@ -263,7 +264,7 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
     const QgsDateTimeRange &time = mCanvas->mapSettings().temporalRange();
     if ( activeScalarGroup >= 0 )
       datasetIndexList.append( layer->activeScalarDatasetAtTime( time ) );
-    if ( activeVectorGroup >= 0 )
+    if ( activeVectorGroup >= 0 && activeVectorGroup != activeScalarGroup )
       datasetIndexList.append( layer->activeVectorDatasetAtTime( time ) );
 
     const QList<int> allGroup = layer->datasetGroupsIndexes();
@@ -277,7 +278,7 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
   {
     if ( activeScalarGroup >= 0 )
       datasetIndexList.append( layer->staticScalarDatasetIndex() );
-    if ( activeVectorGroup >= 0 )
+    if ( activeVectorGroup >= 0 && activeVectorGroup != activeScalarGroup )
       datasetIndexList.append( layer->staticVectorDatasetIndex() );
   }
 
@@ -295,7 +296,7 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
     {
       const QgsMeshDatasetValue scalarValue = layer->datasetValue( index, point, searchRadius );
       const double scalar = scalarValue.scalar();
-      attribute.insert( tr( "Scalar value" ), std::isnan( scalar ) ? tr( "no data" ) : QString::number( scalar ) );
+      attribute.insert( tr( "Scalar Value" ), std::isnan( scalar ) ? tr( "no data" ) : QString::number( scalar ) );
     }
 
     if ( groupMeta.isVector() )
@@ -304,7 +305,7 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
       const double vectorX = vectorValue.x();
       const double vectorY = vectorValue.y();
       if ( std::isnan( vectorX ) || std::isnan( vectorY ) )
-        attribute.insert( tr( "Vector value" ), tr( "no data" ) );
+        attribute.insert( tr( "Vector Value" ), tr( "no data" ) );
       else
       {
         attribute.insert( tr( "Vector Magnitude" ), QString::number( vectorValue.scalar() ) );
@@ -316,7 +317,7 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
     const QgsMeshDatasetMetadata &meta = layer->datasetMetadata( index );
 
     if ( groupMeta.isTemporal() )
-      derivedAttributes.insert( tr( "Time step" ), layer->formatTime( meta.time() ) );
+      derivedAttributes.insert( tr( "Time Step" ), layer->formatTime( meta.time() ) );
     derivedAttributes.insert( tr( "Source" ), groupMeta.uri() );
 
     QString resultName = groupMeta.name();
@@ -336,22 +337,22 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
   QgsPointXY vertexPoint = layer->snapOnElement( QgsMesh::Vertex, point, searchRadius );
   if ( !vertexPoint.isEmpty() )
   {
-    derivedGeometry.insert( tr( "Snapped Vertex position X" ), QString::number( vertexPoint.x() ) );
-    derivedGeometry.insert( tr( "Snapped Vertex position Y" ), QString::number( vertexPoint.y() ) );
+    derivedGeometry.insert( tr( "Snapped Vertex Position X" ), QString::number( vertexPoint.x() ) );
+    derivedGeometry.insert( tr( "Snapped Vertex Position Y" ), QString::number( vertexPoint.y() ) );
   }
 
   QgsPointXY faceCentroid = layer->snapOnElement( QgsMesh::Face, point, searchRadius );
   if ( !faceCentroid.isEmpty() )
   {
-    derivedGeometry.insert( tr( "Face centroid X" ), QString::number( faceCentroid.x() ) );
-    derivedGeometry.insert( tr( "Face centroid Y" ), QString::number( faceCentroid.y() ) );
+    derivedGeometry.insert( tr( "Face Centroid X" ), QString::number( faceCentroid.x() ) );
+    derivedGeometry.insert( tr( "Face Centroid Y" ), QString::number( faceCentroid.y() ) );
   }
 
   QgsPointXY pointOnEdge = layer->snapOnElement( QgsMesh::Edge, point, searchRadius );
   if ( !pointOnEdge.isEmpty() )
   {
-    derivedGeometry.insert( tr( "Point on edge X" ), QString::number( pointOnEdge.x() ) );
-    derivedGeometry.insert( tr( "Point on edge Y" ), QString::number( pointOnEdge.y() ) );
+    derivedGeometry.insert( tr( "Point on Edge X" ), QString::number( pointOnEdge.x() ) );
+    derivedGeometry.insert( tr( "Point on Edge Y" ), QString::number( pointOnEdge.y() ) );
   }
 
   const IdentifyResult result( qobject_cast<QgsMapLayer *>( layer ),

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -251,76 +251,116 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
   if ( !layer )
     return false;
 
-  const QgsMeshRendererSettings rendererSettings = layer->rendererSettings();
-  const QgsMeshDatasetIndex scalarDatasetIndex = layer->activeScalarDatasetAtTime( mCanvas->temporalRange() );
-  const QgsMeshDatasetIndex vectorDatasetIndex = layer->activeVectorDatasetAtTime( mCanvas->temporalRange() );
-  if ( ! scalarDatasetIndex.isValid() && ! vectorDatasetIndex.isValid() )
-    return false;
-
-  QMap< QString, QString > scalarAttributes, vectorAttributes, raw3dAttributes;
-
   double searchRadius = mOverrideCanvasSearchRadius < 0 ? searchRadiusMU( mCanvas ) : mOverrideCanvasSearchRadius;
+  bool isTemporal = mCanvas->mapSettings().isTemporal();
 
-  QString scalarGroup;
-  if ( scalarDatasetIndex.isValid() )
+  QList<QgsMeshDatasetIndex> datasetIndexList;
+  int activeScalarGroup = layer->rendererSettings().activeScalarDatasetGroup();
+  int activeVectorGroup = layer->rendererSettings().activeVectorDatasetGroup();
+
+  if ( isTemporal ) //non active dataset group value are only accesible if temporal is active
   {
-    scalarGroup = layer->datasetGroupMetadata( scalarDatasetIndex.group() ).name();
+    const QgsDateTimeRange &time = mCanvas->mapSettings().temporalRange();
+    if ( activeScalarGroup >= 0 )
+      datasetIndexList.append( layer->activeScalarDatasetAtTime( time ) );
+    if ( activeVectorGroup >= 0 )
+      datasetIndexList.append( layer->activeVectorDatasetAtTime( time ) );
 
-    const QgsMeshDatasetValue scalarValue = layer->datasetValue( scalarDatasetIndex, point, searchRadius );
-    const double scalar = scalarValue.scalar();
-    if ( std::isnan( scalar ) )
-      scalarAttributes.insert( tr( "Scalar Value" ), tr( "no data" ) );
-    else
-      scalarAttributes.insert( tr( "Scalar Value" ), QString::number( scalar ) );
-  }
-
-  QString vectorGroup;
-  if ( vectorDatasetIndex.isValid() )
-  {
-    vectorGroup = layer->datasetGroupMetadata( vectorDatasetIndex.group() ).name();
-
-    const QgsMeshDatasetValue vectorValue = layer->datasetValue( vectorDatasetIndex, point, searchRadius );
-    const double vectorX = vectorValue.x();
-    const double vectorY = vectorValue.y();
-
-    if ( std::isnan( vectorX ) || std::isnan( vectorY ) )
-      vectorAttributes.insert( tr( "Vector Value" ), tr( "no data" ) );
-    else
+    const QList<int> allGroup = layer->datasetGroupsIndexes();
+    for ( int groupIndex : allGroup )
     {
-      vectorAttributes.insert( tr( "Vector Magnitude" ), QString::number( vectorValue.scalar() ) );
-      vectorAttributes.insert( tr( "Vector x-component" ), QString::number( vectorY ) );
-      vectorAttributes.insert( tr( "Vector y-component" ), QString::number( vectorX ) );
+      if ( groupIndex != activeScalarGroup && groupIndex != activeVectorGroup )
+        datasetIndexList.append( layer->datasetIndexAtTime( time, groupIndex ) );
     }
-  }
-
-  const QMap< QString, QString > derivedAttributes = derivedAttributesForPoint( QgsPoint( point ) );
-  if ( scalarGroup == vectorGroup )
-  {
-    const IdentifyResult result( qobject_cast<QgsMapLayer *>( layer ),
-                                 scalarGroup,
-                                 vectorAttributes,
-                                 derivedAttributes );
-    results->append( result );
   }
   else
   {
-    if ( !scalarGroup.isEmpty() )
-    {
-      const IdentifyResult result( qobject_cast<QgsMapLayer *>( layer ),
-                                   scalarGroup,
-                                   scalarAttributes,
-                                   derivedAttributes );
-      results->append( result );
-    }
-    if ( !vectorGroup.isEmpty() )
-    {
-      const IdentifyResult result( qobject_cast<QgsMapLayer *>( layer ),
-                                   vectorGroup,
-                                   vectorAttributes,
-                                   derivedAttributes );
-      results->append( result );
-    }
+    if ( activeScalarGroup >= 0 )
+      datasetIndexList.append( layer->staticScalarDatasetIndex() );
+    if ( activeVectorGroup >= 0 )
+      datasetIndexList.append( layer->staticVectorDatasetIndex() );
   }
+
+  //create results
+  for ( const QgsMeshDatasetIndex &index : datasetIndexList )
+  {
+    if ( !index.isValid() )
+      continue;
+
+    const QgsMeshDatasetGroupMetadata &groupMeta = layer->datasetGroupMetadata( index );
+    QMap< QString, QString > derivedAttributes;
+
+    QMap<QString, QString> attribute;
+    if ( groupMeta.isScalar() )
+    {
+      const QgsMeshDatasetValue scalarValue = layer->datasetValue( index, point, searchRadius );
+      const double scalar = scalarValue.scalar();
+      attribute.insert( tr( "Scalar value" ), std::isnan( scalar ) ? tr( "no data" ) : QString::number( scalar ) );
+    }
+
+    if ( groupMeta.isVector() )
+    {
+      const QgsMeshDatasetValue vectorValue = layer->datasetValue( index, point, searchRadius );
+      const double vectorX = vectorValue.x();
+      const double vectorY = vectorValue.y();
+      if ( std::isnan( vectorX ) || std::isnan( vectorY ) )
+        attribute.insert( tr( "Vector value" ), tr( "no data" ) );
+      else
+      {
+        attribute.insert( tr( "Vector Magnitude" ), QString::number( vectorValue.scalar() ) );
+        derivedAttributes.insert( tr( "Vector x-component" ), QString::number( vectorY ) );
+        derivedAttributes.insert( tr( "Vector y-component" ), QString::number( vectorX ) );
+      }
+    }
+
+    const QgsMeshDatasetMetadata &meta = layer->datasetMetadata( index );
+
+    if ( groupMeta.isTemporal() )
+      derivedAttributes.insert( tr( "Time step" ), layer->formatTime( meta.time() ) );
+    derivedAttributes.insert( tr( "Source" ), groupMeta.uri() );
+
+    QString resultName = groupMeta.name();
+    if ( isTemporal && ( index.group() == activeScalarGroup  || index.group() == activeVectorGroup ) )
+      resultName.append( tr( " (active)" ) );
+
+    const IdentifyResult result( qobject_cast<QgsMapLayer *>( layer ),
+                                 resultName,
+                                 attribute,
+                                 derivedAttributes );
+
+    results->append( result );
+  }
+
+  QMap<QString, QString> derivedGeometry;
+
+  QgsPointXY vertexPoint = layer->snapOnElement( QgsMesh::Vertex, point, searchRadius );
+  if ( !vertexPoint.isEmpty() )
+  {
+    derivedGeometry.insert( tr( "Snapped Vertex position X" ), QString::number( vertexPoint.x() ) );
+    derivedGeometry.insert( tr( "Snapped Vertex position Y" ), QString::number( vertexPoint.y() ) );
+  }
+
+  QgsPointXY faceCentroid = layer->snapOnElement( QgsMesh::Face, point, searchRadius );
+  if ( !faceCentroid.isEmpty() )
+  {
+    derivedGeometry.insert( tr( "Face centroid X" ), QString::number( faceCentroid.x() ) );
+    derivedGeometry.insert( tr( "Face centroid Y" ), QString::number( faceCentroid.y() ) );
+  }
+
+  QgsPointXY pointOnEdge = layer->snapOnElement( QgsMesh::Edge, point, searchRadius );
+  if ( !pointOnEdge.isEmpty() )
+  {
+    derivedGeometry.insert( tr( "Point on edge X" ), QString::number( pointOnEdge.x() ) );
+    derivedGeometry.insert( tr( "Point on edge Y" ), QString::number( pointOnEdge.y() ) );
+  }
+
+  const IdentifyResult result( qobject_cast<QgsMapLayer *>( layer ),
+                               tr( "Geometry" ),
+                               derivedAttributesForPoint( QgsPoint( point ) ),
+                               derivedGeometry );
+
+  results->append( result );
+
   return true;
 }
 

--- a/tests/src/app/testqgsmaptoolidentifyaction.cpp
+++ b/tests/src/app/testqgsmaptoolidentifyaction.cpp
@@ -36,6 +36,7 @@
 #include "qgsidentifyresultsdialog.h"
 #include "qgsmapmouseevent.h"
 #include "qgsmaplayertemporalproperties.h"
+#include "qgsmeshlayertemporalproperties.h"
 
 #include <QTimer>
 
@@ -621,6 +622,9 @@ void TestQgsMapToolIdentifyAction::identifyMesh()
   QVERIFY( tempLayer->isValid() );
   const QString vectorDs = QStringLiteral( TEST_DATA_DIR ) + "/mesh/quad_and_triangle_vertex_vector.dat";
   tempLayer->dataProvider()->addDataset( vectorDs );
+  static_cast<QgsMeshLayerTemporalProperties *>(
+    tempLayer->temporalProperties() )->setReferenceTime(
+      QDateTime( QDate( 1950, 01, 01 ), QTime( 0, 0, 0, Qt::UTC ), Qt::UTC ), tempLayer->dataProvider()->temporalCapabilities() );
 
   // we need to setup renderer otherwise triangular mesh
   // will not be populated and identify will not work
@@ -639,42 +643,78 @@ void TestQgsMapToolIdentifyAction::identifyMesh()
   QList<QgsMapToolIdentify::IdentifyResult> results;
 
   results = testIdentifyMesh( tempLayer, 500, 500 );
-  QCOMPARE( results.size(), 1 );
+  QCOMPARE( results.size(), 2 );
   QCOMPARE( results[0].mAttributes[ QStringLiteral( "Scalar Value" )], QStringLiteral( "no data" ) );
+  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "Source" )], mesh );
+  QCOMPARE( results[1].mLabel, QStringLiteral( "Geometry" ) );
   results = testIdentifyMesh( tempLayer, 2400, 2400 );
-  QCOMPARE( results.size(), 1 );
+  QCOMPARE( results.size(), 2 );
   QCOMPARE( results[0].mAttributes[ QStringLiteral( "Scalar Value" )], QStringLiteral( "42" ) );
+  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "Source" )], mesh );
+  QCOMPARE( results[1].mLabel, QStringLiteral( "Geometry" ) );
+  QCOMPARE( results[1].mDerivedAttributes[QStringLiteral( "Face Centroid X" )], QStringLiteral( "2333.33" ) );
+  QCOMPARE( results[1].mDerivedAttributes[QStringLiteral( "Face Centroid Y" )], QStringLiteral( "2333.33" ) );
+  results = testIdentifyMesh( tempLayer, 1999, 2999 );
+  QCOMPARE( results[1].mDerivedAttributes[QStringLiteral( "Snapped Vertex Position X" )], QStringLiteral( "2000" ) );
+  QCOMPARE( results[1].mDerivedAttributes[QStringLiteral( "Snapped Vertex Position Y" )], QStringLiteral( "3000" ) );
+
+  canvas->setTemporalRange( QgsDateTimeRange( QDateTime( QDate( 1950, 01, 01 ), QTime( 0, 0, 0, Qt::UTC ), Qt::UTC ),
+                            QDateTime( QDate( 1950, 01, 01 ), QTime( 1, 0, 0, Qt::UTC ), Qt::UTC ) ) );
+
+  tempLayer->temporalProperties()->setIsActive( true );
+  results = testIdentifyMesh( tempLayer, 2400, 2400 );
+  QCOMPARE( results.size(), 3 );
+  QCOMPARE( results[0].mLabel, QStringLiteral( "Bed Elevation (active)" ) );
+  QCOMPARE( results[0].mAttributes[ QStringLiteral( "Scalar Value" )], QStringLiteral( "42" ) );
+  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "Source" )], mesh );
+
+  QCOMPARE( results[1].mDerivedAttributes[ QStringLiteral( "Time Step" )], QStringLiteral( "01.01.1950 00:00:00" ) );
+
+  QCOMPARE( results[1].mLabel, QStringLiteral( "VertexVectorDataset" ) );
+  QCOMPARE( results[1].mDerivedAttributes[QStringLiteral( "Source" )], vectorDs );
+  QCOMPARE( results[1].mAttributes[ QStringLiteral( "Vector Magnitude" )], QStringLiteral( "3" ) );
+  QCOMPARE( results[1].mDerivedAttributes[ QStringLiteral( "Vector x-component" )], QStringLiteral( "1.8" ) );
+  QCOMPARE( results[1].mDerivedAttributes[ QStringLiteral( "Vector y-component" )], QStringLiteral( "2.4" ) );
+
+  QCOMPARE( results[2].mLabel, QStringLiteral( "Geometry" ) );
+  QCOMPARE( results[2].mDerivedAttributes[QStringLiteral( "Face Centroid X" )], QStringLiteral( "2333.33" ) );
+  QCOMPARE( results[2].mDerivedAttributes[QStringLiteral( "Face Centroid Y" )], QStringLiteral( "2333.33" ) );
+  results = testIdentifyMesh( tempLayer, 1999, 2999 );
+  QCOMPARE( results[2].mDerivedAttributes[QStringLiteral( "Snapped Vertex Position X" )], QStringLiteral( "2000" ) );
+  QCOMPARE( results[2].mDerivedAttributes[QStringLiteral( "Snapped Vertex Position Y" )], QStringLiteral( "3000" ) );
+
+  tempLayer->temporalProperties()->setIsActive( false );
 
   // scalar + vector same
   tempLayer->setStaticScalarDatasetIndex( QgsMeshDatasetIndex( 1, 0 ) );
   tempLayer->setStaticVectorDatasetIndex( QgsMeshDatasetIndex( 1, 0 ) );
   results = testIdentifyMesh( tempLayer, 500, 500 );
-  QCOMPARE( results.size(), 1 );
+  QCOMPARE( results.size(), 2 );
   QCOMPARE( results[0].mAttributes[ QStringLiteral( "Vector Value" )], QStringLiteral( "no data" ) );
   results = testIdentifyMesh( tempLayer, 2400, 2400 );
-  QCOMPARE( results.size(), 1 );
+  QCOMPARE( results.size(), 2 );
   QCOMPARE( results[0].mAttributes[ QStringLiteral( "Vector Magnitude" )], QStringLiteral( "3" ) );
-  QCOMPARE( results[0].mAttributes[ QStringLiteral( "Vector x-component" )], QStringLiteral( "1.8" ) );
-  QCOMPARE( results[0].mAttributes[ QStringLiteral( "Vector y-component" )], QStringLiteral( "2.4" ) );
+  QCOMPARE( results[0].mDerivedAttributes[ QStringLiteral( "Vector x-component" )], QStringLiteral( "1.8" ) );
+  QCOMPARE( results[0].mDerivedAttributes[ QStringLiteral( "Vector y-component" )], QStringLiteral( "2.4" ) );
 
   // scalar + vector different
   tempLayer->setStaticScalarDatasetIndex( QgsMeshDatasetIndex( 0, 0 ) );
   tempLayer->setStaticVectorDatasetIndex( QgsMeshDatasetIndex( 1, 0 ) );
   results = testIdentifyMesh( tempLayer, 2400, 2400 );
-  QCOMPARE( results.size(), 2 );
+  QCOMPARE( results.size(), 3 );
   QCOMPARE( results[0].mAttributes[ QStringLiteral( "Scalar Value" )], QStringLiteral( "42" ) );
   QCOMPARE( results[1].mAttributes[ QStringLiteral( "Vector Magnitude" )], QStringLiteral( "3" ) );
-  QCOMPARE( results[1].mAttributes[ QStringLiteral( "Vector x-component" )], QStringLiteral( "1.8" ) );
-  QCOMPARE( results[1].mAttributes[ QStringLiteral( "Vector y-component" )], QStringLiteral( "2.4" ) );
+  QCOMPARE( results[1].mDerivedAttributes[ QStringLiteral( "Vector x-component" )], QStringLiteral( "1.8" ) );
+  QCOMPARE( results[1].mDerivedAttributes[ QStringLiteral( "Vector y-component" )], QStringLiteral( "2.4" ) );
 
   // only vector
   tempLayer->setStaticScalarDatasetIndex( QgsMeshDatasetIndex() );
   tempLayer->setStaticVectorDatasetIndex( QgsMeshDatasetIndex( 1, 0 ) );
   results = testIdentifyMesh( tempLayer, 2400, 2400 );
-  QCOMPARE( results.size(), 1 );
+  QCOMPARE( results.size(), 2 );
   QCOMPARE( results[0].mAttributes[ QStringLiteral( "Vector Magnitude" )], QStringLiteral( "3" ) );
-  QCOMPARE( results[0].mAttributes[ QStringLiteral( "Vector x-component" )], QStringLiteral( "1.8" ) );
-  QCOMPARE( results[0].mAttributes[ QStringLiteral( "Vector y-component" )], QStringLiteral( "2.4" ) );
+  QCOMPARE( results[0].mDerivedAttributes[ QStringLiteral( "Vector x-component" )], QStringLiteral( "1.8" ) );
+  QCOMPARE( results[0].mDerivedAttributes[ QStringLiteral( "Vector y-component" )], QStringLiteral( "2.4" ) );
 }
 
 void TestQgsMapToolIdentifyAction::identifyVectorTile()


### PR DESCRIPTION
This PR changes the map tool identify for mesh layer with displaying the dataset value corresponding of the current time of the temporal controller for all dataset groups. The active dataset groups (scalar and eventually vector) are first displayed, then the other dataset groups.
There is also other information displayed:
- Source : where the dataset is stored
- Time step : the time step of the dataset that is displayed (can be different than the time of the temporal controller), nothing if the dataset group is non temporal
- centroid of the corresponding face
- coordinate of the snapped vertex (if one is snapped)
- center of the snapped edge (if one is snapped)

When the map canvas is non temporal (temporal navigation disabled), the identify results contain only information about the active dataset groups that are the only dataset groups that have static dataset defined in the mesh properties dialog. 

![image](https://user-images.githubusercontent.com/7416892/88171264-06344d00-cbed-11ea-85d6-0926f503598f.png)
