### PR TITLE
Fix default value expression on double field

### DIFF
--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -252,6 +252,13 @@ QString QgsField::displayString( const QVariant &v ) const
   // Special treatment for numeric types if group separator is set or decimalPoint is not a dot
   if ( d->type == QVariant::Double )
   {
+    // if value doesn't contain a double (a default value expression for instance),
+    // apply no transformation
+    bool ok;
+    v.toDouble( &ok );
+    if ( !ok )
+      return v.toString();
+
     // Locales with decimal point != '.' or that require group separator: use QLocale
     if ( QLocale().decimalPoint() != '.' ||
          !( QLocale().numberOptions() & QLocale::NumberOption::OmitGroupSeparator ) )

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -370,6 +370,9 @@ void TestQgsField::displayString()
   QCOMPARE( QLocale().numberOptions() & QLocale::NumberOption::OmitGroupSeparator, QLocale::NumberOption::DefaultNumberOptions );
   QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599,999,898,999" ) );
 
+  // no conversion when this is default value expression
+  QCOMPARE( doubleFieldNoPrec.displayString( ( "(1+2)" ) ), QString( "(1+2)" ) );
+
   //test NULL double
   QVariant nullDouble = QVariant( QVariant::Double );
   QCOMPARE( doubleField.displayString( nullDouble ), QString( "TEST NULL" ) );


### PR DESCRIPTION
## Description

When a default value expression is defined on provider side (Postgres or Oracle  for instance) for a double field, the value always default to 0 and the expression is lost when you create a feature 

For instance, on Postgres
```sql
create table test_double( id serial primary key, mydouble double precision DEFAULT 6+3, geom geometry(Point,4326)
```
And Oracle
```sql
CREATE TABLE QGIS.POINT_DATA_IDENTITY ( "pk" NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, GEOM SDO_GEOMETRY)
```
Both *pk* and *mydouble* always defaults to 0