### PR TITLE
Fix QgsFieldExpressionWidget generates an invalid expression when a field name has a space and the expression button is clicked

### DIFF
--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -230,7 +230,7 @@ void QgsFieldExpressionWidget::setExpression( const QString &expression )
 
 void QgsFieldExpressionWidget::editExpression()
 {
-  QString currentExpression = currentText();
+  QString currentExpression = asExpression();
   QgsVectorLayer *vl = layer();
 
   QgsExpressionContext context = mExpressionContextGenerator ? mExpressionContextGenerator->createExpressionContext() : mExpressionContext;


### PR DESCRIPTION
Fix QgsFieldExpressionWidget generates an invalid expression if a field name with a space is selected from the dropdown list and then the expression editor button is clicked

Previously, the expression editor would open with an unquoted field name, which was broken for field names containing spaces. Now, we always ensure that the editor opens with a valid expression
