### PR TITLE
Don't report legend filter by expression as enabled if the expression is empty

### DIFF
--- a/src/core/layertree/qgslayertreeutils.cpp
+++ b/src/core/layertree/qgslayertreeutils.cpp
@@ -429,14 +429,15 @@ void QgsLayerTreeUtils::updateEmbeddedGroupsProjectPath( QgsLayerTreeGroup *grou
 void QgsLayerTreeUtils::setLegendFilterByExpression( QgsLayerTreeLayer &layer, const QString &expr, bool enabled )
 {
   layer.setCustomProperty( QStringLiteral( "legend/expressionFilter" ), expr );
-  layer.setCustomProperty( QStringLiteral( "legend/expressionFilterEnabled" ), enabled );
+  layer.setCustomProperty( QStringLiteral( "legend/expressionFilterEnabled" ), enabled && !expr.isEmpty() );
 }
 
 QString QgsLayerTreeUtils::legendFilterByExpression( const QgsLayerTreeLayer &layer, bool *enabled )
 {
+  const QString expression = layer.customProperty( QStringLiteral( "legend/expressionFilter" ), QString() ).toString();
   if ( enabled )
-    *enabled = layer.customProperty( QStringLiteral( "legend/expressionFilterEnabled" ), "" ).toBool();
-  return layer.customProperty( QStringLiteral( "legend/expressionFilter" ), "" ).toString();
+    *enabled = !expression.isEmpty() && layer.customProperty( QStringLiteral( "legend/expressionFilterEnabled" ), QString() ).toBool();
+  return expression;
 }
 
 bool QgsLayerTreeUtils::hasLegendFilterExpression( const QgsLayerTreeGroup &group )

--- a/src/gui/qgslegendfilterbutton.cpp
+++ b/src/gui/qgslegendfilterbutton.cpp
@@ -92,12 +92,12 @@ void QgsLegendFilterButton::updateMenu()
   if ( !mExpression.isEmpty() )
   {
     mClearExpressionAction->setEnabled( true );
-    mSetExpressionAction->setText( QString( tr( "Edit filter expression (current: %1)" ) ).arg( mExpression ) );
+    mSetExpressionAction->setText( tr( "Edit Filter Expression (current: %1)" ).arg( mExpression ) );
   }
   else
   {
     mClearExpressionAction->setEnabled( false );
-    mSetExpressionAction->setText( tr( "Edit filter expression" ) );
+    mSetExpressionAction->setText( tr( "Edit Filter Expression" ) );
   }
 }
 


### PR DESCRIPTION
Can cause issues when opening very old projects, where the legend expression
builder will automatically open immediately upon selecting a layer
