### PR TITLE
[decorations] Fix scale bar color not applied to division ticks

### DIFF
--- a/src/app/decorations/qgsdecorationscalebar.cpp
+++ b/src/app/decorations/qgsdecorationscalebar.cpp
@@ -168,7 +168,8 @@ void QgsDecorationScaleBar::setupScaleBar()
       lineSymbol->setColor( mColor ); // Compatibility with pre 3.2 configuration
       lineSymbol->setWidth( 0.3 );
       lineSymbol->setOutputUnit( QgsUnitTypes::RenderMillimeters );
-      mSettings.setLineSymbol( lineSymbol.release() );
+      mSettings.setLineSymbol( lineSymbol->clone() );
+      mSettings.setDivisionLineSymbol( lineSymbol.release() );
       mSettings.setHeight( 2.2 );
       break;
     }


### PR DESCRIPTION
## Description

Before vs. PR:
![image](https://user-images.githubusercontent.com/1728657/88252577-f6923280-ccd8-11ea-8d4c-1ec0e4d4dca7.png)

