### PR TITLE
[processing] Fix python error when attempting to re-open generate XYZ tiles algorithm from the history dialog

### DIFF
--- a/python/plugins/processing/gui/HistoryDialog.py
+++ b/python/plugins/processing/gui/HistoryDialog.py
@@ -121,6 +121,7 @@ class HistoryDialog(BASE, WIDGET):
             if item.isAlg:
                 script = 'import processing\n'
                 script += 'from qgis.core import QgsProcessingOutputLayerDefinition, QgsProcessingFeatureSourceDefinition, QgsProperty, QgsCoordinateReferenceSystem, QgsFeatureRequest\n'
+                script += 'from qgis.PyQt.QtGui import QColor\n'
                 script += item.entry.text.replace('processing.run(', 'processing.execAlgorithmDialog(')
                 self.close()
                 exec(script)


### PR DESCRIPTION
## Description

The generate XYZ tiles algorithm needs a QColor object as one of its parameters, make sure the history dialog's executeAlgorithm imports it.