### PR TITLE
Pass time step and time step unit into QgsTemporalNavigationObject

### DIFF
--- a/python/core/auto_generated/qgstemporalnavigationobject.sip.in
+++ b/python/core/auto_generated/qgstemporalnavigationobject.sip.in
@@ -118,7 +118,7 @@ the temporal length of each frame in the animation.
 
    Calling this will reset the :py:func:`~QgsTemporalNavigationObject.currentFrameNumber` to the first frame.
 
-.. seealso:: :py:func:`frameFrameTimeStep`
+.. seealso:: :py:func:`frameTimeStep`
 %End
 
     void setFrameTimeStepUnit( QgsUnitTypes::TemporalUnit timeStepUnit );

--- a/python/core/auto_generated/qgstemporalnavigationobject.sip.in
+++ b/python/core/auto_generated/qgstemporalnavigationobject.sip.in
@@ -109,22 +109,44 @@ Returns the current frame number.
 .. seealso:: :py:func:`setCurrentFrameNumber`
 %End
 
-    void setFrameDuration( QgsInterval duration );
+    void setFrameTimeStep( double timeStep );
 %Docstring
-Sets the frame ``duration``, which dictates the temporal length of each frame in the animation.
+Sets the frame ``timestep``, which together with the frame timestep unit dictates
+the temporal length of each frame in the animation.
 
 .. note::
 
    Calling this will reset the :py:func:`~QgsTemporalNavigationObject.currentFrameNumber` to the first frame.
 
-.. seealso:: :py:func:`frameDuration`
+.. seealso:: :py:func:`frameFrameTimeStep`
 %End
 
-    QgsInterval frameDuration() const;
+    void setFrameTimeStepUnit( QgsUnitTypes::TemporalUnit timeStepUnit );
 %Docstring
-Returns the current set frame duration, which dictates the temporal length of each frame in the animation.
+Sets the frame ``timestep`` unit, which together with the frame time step dictates
+the temporal length of each frame in the animation.
 
-.. seealso:: :py:func:`setFrameDuration`
+.. note::
+
+   Calling this will reset the :py:func:`~QgsTemporalNavigationObject.currentFrameNumber` to the first frame.
+
+.. seealso:: :py:func:`frameTimeStepUnit`
+%End
+
+    double frameTimeStep() const;
+%Docstring
+Returns the current set frame timestep, which together with frame timestep unit
+dictates the temporal length of each frame in the animation.
+
+.. seealso:: :py:func:`setFrameTimeStep`
+%End
+
+    QgsUnitTypes::TemporalUnit frameTimeStepUnit() const;
+%Docstring
+Returns the current set frame timestep unit, which together with frame timestep
+dictates the temporal length of each frame in the animation.
+
+.. seealso:: :py:func:`setFrameTimeStepUnit`
 %End
 
     QgsDateTimeRange dateTimeRangeForFrameNumber( long long frame ) const;

--- a/python/core/auto_generated/qgstemporalutils.sip.in
+++ b/python/core/auto_generated/qgstemporalutils.sip.in
@@ -35,7 +35,9 @@ returns the maximal combined temporal extent of these layers.
     {
       QgsDateTimeRange animationRange;
 
-      QgsInterval frameDuration;
+      double frameTimeStep;
+
+      QgsUnitTypes::TemporalUnit frameTimeStepUnit;
 
       QString outputDirectory;
 

--- a/python/core/auto_generated/qgstemporalutils.sip.in
+++ b/python/core/auto_generated/qgstemporalutils.sip.in
@@ -63,6 +63,25 @@ support.
 :return: - ``True`` if the export was successful.
          - error: will be set to a descriptive error message if the export fails
 %End
+
+    static QDateTime calculateFrameTime( const QDateTime &start, const long long frame, double timeStep, QgsUnitTypes::TemporalUnit timeStepUnit );
+%Docstring
+Calculates the frame time for an animation.
+
+If mFrameTimeStep is fractional, then QgsInterval is used to determine the
+duration of the frame. This uses average durations for months and years.
+Otherwise, we use QDateTime to advance by the exact duration of the current
+month or year. So a time step of 1.5 months will result in a duration of 45
+days, but a time step of 1 month will result in a duration that depends upon
+the number of days in the current month.
+
+:param start: the start time of the animation.
+:param frame: the frame number
+:param timeStep: the time step for the animation
+:param timeStepUnit: the time step unit for the animation
+
+:return: The calculated datetime for the frame.
+%End
 };
 
 

--- a/src/app/qgsanimationexportdialog.cpp
+++ b/src/app/qgsanimationexportdialog.cpp
@@ -222,9 +222,14 @@ QgsDateTimeRange QgsAnimationExportDialog::animationRange() const
   return QgsDateTimeRange( mStartDateTime->dateTime(), mEndDateTime->dateTime() );
 }
 
-QgsInterval QgsAnimationExportDialog::frameInterval() const
+double QgsAnimationExportDialog::frameTimeStep() const
 {
-  return QgsInterval( mFrameDurationSpinBox->value(), static_cast< QgsUnitTypes::TemporalUnit>( mTimeStepsComboBox->currentData().toInt() ) );
+  return mFrameDurationSpinBox->value();
+}
+
+QgsUnitTypes::TemporalUnit QgsAnimationExportDialog::frameTimeStepUnit() const
+{
+  return static_cast< QgsUnitTypes::TemporalUnit>( mTimeStepsComboBox->currentData().toInt() );
 }
 
 void QgsAnimationExportDialog::applyMapSettings( QgsMapSettings &mapSettings )

--- a/src/app/qgsanimationexportdialog.h
+++ b/src/app/qgsanimationexportdialog.h
@@ -63,8 +63,11 @@ class APP_EXPORT QgsAnimationExportDialog: public QDialog, private Ui::QgsAnimat
     //! Returns the overall animation range
     QgsDateTimeRange animationRange() const;
 
-    //! Returns the duration of each individual frame
-    QgsInterval frameInterval() const;
+    //! Returns the time step of each individual frame
+    double frameTimeStep() const;
+
+    //! Returns the time step unit of each individual frame
+    QgsUnitTypes::TemporalUnit frameTimeStepUnit() const;
 
     //! configure a map settings object
     void applyMapSettings( QgsMapSettings &mapSettings );

--- a/src/app/qgstemporalcontrollerdockwidget.cpp
+++ b/src/app/qgstemporalcontrollerdockwidget.cpp
@@ -60,7 +60,8 @@ void QgsTemporalControllerDockWidget::exportAnimation()
     dlg->applyMapSettings( s );
 
     const QgsDateTimeRange animationRange = dlg->animationRange();
-    const QgsInterval frameDuration = dlg->frameInterval();
+    const double frameTimeStep = dlg->frameTimeStep();
+    const QgsUnitTypes::TemporalUnit frameTimeStepUnit = dlg->frameTimeStepUnit();
     const QString outputDir = dlg->outputDirectory();
     const QString fileNameExpression = dlg->fileNameExpression();
 
@@ -89,7 +90,8 @@ void QgsTemporalControllerDockWidget::exportAnimation()
       decorations = QgisApp::instance()->activeDecorations();
 
     QgsTemporalUtils::AnimationExportSettings animationSettings;
-    animationSettings.frameDuration = frameDuration;
+    animationSettings.frameTimeStep = frameTimeStep;
+    animationSettings.frameTimeStepUnit = frameTimeStepUnit;
     animationSettings.animationRange = animationRange;
     animationSettings.outputDirectory = outputDir;
     animationSettings.fileNameTemplate = fileNameExpression;

--- a/src/core/qgstemporalnavigationobject.h
+++ b/src/core/qgstemporalnavigationobject.h
@@ -127,20 +127,40 @@ class CORE_EXPORT QgsTemporalNavigationObject : public QgsTemporalController, pu
     long long currentFrameNumber() const;
 
     /**
-     * Sets the frame \a duration, which dictates the temporal length of each frame in the animation.
+     * Sets the frame \a timestep, which together with the frame timestep unit dictates
+     * the temporal length of each frame in the animation.
      *
      * \note Calling this will reset the currentFrameNumber() to the first frame.
      *
-     * \see frameDuration()
+     * \see frameFrameTimeStep()
      */
-    void setFrameDuration( QgsInterval duration );
+    void setFrameTimeStep( double timeStep );
 
     /**
-     * Returns the current set frame duration, which dictates the temporal length of each frame in the animation.
+     * Sets the frame \a timestep unit, which together with the frame time step dictates
+     * the temporal length of each frame in the animation.
      *
-     * \see setFrameDuration()
+     * \note Calling this will reset the currentFrameNumber() to the first frame.
+     *
+     * \see frameTimeStepUnit()
      */
-    QgsInterval frameDuration() const;
+    void setFrameTimeStepUnit( QgsUnitTypes::TemporalUnit timeStepUnit );
+
+    /**
+     * Returns the current set frame timestep, which together with frame timestep unit
+     * dictates the temporal length of each frame in the animation.
+     *
+     * \see setFrameTimeStep()
+     */
+    double frameTimeStep() const;
+
+    /**
+     * Returns the current set frame timestep unit, which together with frame timestep
+     * dictates the temporal length of each frame in the animation.
+     *
+     * \see setFrameTimeStepUnit()
+     */
+    QgsUnitTypes::TemporalUnit frameTimeStepUnit() const;
 
     /**
      * Calculates the temporal range associated with a particular animation \a frame.
@@ -288,7 +308,9 @@ class CORE_EXPORT QgsTemporalNavigationObject : public QgsTemporalController, pu
     long long mCurrentFrameNumber = 0;
 
     //! Frame duration
-    QgsInterval mFrameDuration;
+    double mFrameTimeStep;
+    bool mFrameTimeStepIsFractional;
+    QgsUnitTypes::TemporalUnit mFrameTimeStepUnit;
 
     //! Member for frame rate
     double mFramesPerSecond = 1;

--- a/src/core/qgstemporalnavigationobject.h
+++ b/src/core/qgstemporalnavigationobject.h
@@ -132,7 +132,7 @@ class CORE_EXPORT QgsTemporalNavigationObject : public QgsTemporalController, pu
      *
      * \note Calling this will reset the currentFrameNumber() to the first frame.
      *
-     * \see frameFrameTimeStep()
+     * \see frameTimeStep()
      */
     void setFrameTimeStep( double timeStep );
 

--- a/src/core/qgstemporalnavigationobject.h
+++ b/src/core/qgstemporalnavigationobject.h
@@ -308,8 +308,8 @@ class CORE_EXPORT QgsTemporalNavigationObject : public QgsTemporalController, pu
     long long mCurrentFrameNumber = 0;
 
     //! Frame duration
-    double mFrameTimeStep;
-    QgsUnitTypes::TemporalUnit mFrameTimeStepUnit;
+    double mFrameTimeStep = 1.0;
+    QgsUnitTypes::TemporalUnit mFrameTimeStepUnit = QgsUnitTypes::TemporalUnit::TemporalHours;
 
     //! Member for frame rate
     double mFramesPerSecond = 1;

--- a/src/core/qgstemporalnavigationobject.h
+++ b/src/core/qgstemporalnavigationobject.h
@@ -309,7 +309,6 @@ class CORE_EXPORT QgsTemporalNavigationObject : public QgsTemporalController, pu
 
     //! Frame duration
     double mFrameTimeStep;
-    bool mFrameTimeStepIsFractional;
     QgsUnitTypes::TemporalUnit mFrameTimeStepUnit;
 
     //! Member for frame rate

--- a/src/core/qgstemporalutils.cpp
+++ b/src/core/qgstemporalutils.cpp
@@ -80,8 +80,8 @@ bool QgsTemporalUtils::exportAnimation( const QgsMapSettings &mapSettings, const
 
   QgsTemporalNavigationObject navigator;
   navigator.setTemporalExtents( settings.animationRange );
-  navigator.setFrameTimeStep( settings.frameDuration.seconds() );
-  navigator.setFrameTimeStepUnit( QgsUnitTypes::TemporalUnit::TemporalSeconds );
+  navigator.setFrameTimeStep( settings.frameTimeStep );
+  navigator.setFrameTimeStepUnit( settings.frameTimeStepUnit );
   QgsMapSettings ms = mapSettings;
   const QgsExpressionContext context = ms.expressionContext();
 

--- a/src/core/qgstemporalutils.cpp
+++ b/src/core/qgstemporalutils.cpp
@@ -80,7 +80,8 @@ bool QgsTemporalUtils::exportAnimation( const QgsMapSettings &mapSettings, const
 
   QgsTemporalNavigationObject navigator;
   navigator.setTemporalExtents( settings.animationRange );
-  navigator.setFrameDuration( settings.frameDuration );
+  navigator.setFrameTimeStep( settings.frameDuration.seconds() );
+  navigator.setFrameTimeStepUnit( QgsUnitTypes::TemporalUnit::TemporalSeconds );
   QgsMapSettings ms = mapSettings;
   const QgsExpressionContext context = ms.expressionContext();
 

--- a/src/core/qgstemporalutils.cpp
+++ b/src/core/qgstemporalutils.cpp
@@ -142,3 +142,58 @@ bool QgsTemporalUtils::exportAnimation( const QgsMapSettings &mapSettings, const
 
   return true;
 }
+
+
+QDateTime QgsTemporalUtils::calculateFrameTime( const QDateTime &start, const long long frame, const double timeStep, const QgsUnitTypes::TemporalUnit timeStepUnit )
+{
+
+  double unused;
+  bool isFractional = fabs( modf( timeStep, &unused ) ) > 0.00001;
+
+  if ( isFractional )
+  {
+    double duration = QgsInterval( timeStep, timeStepUnit ).seconds();
+    return start.addSecs( frame * duration );
+  }
+  else
+  {
+    switch ( timeStepUnit )
+    {
+      case QgsUnitTypes::TemporalUnit::TemporalMilliseconds:
+        return start.addMSecs( frame * timeStep );
+        break;
+      case QgsUnitTypes::TemporalUnit::TemporalSeconds:
+        return start.addSecs( frame * timeStep );
+        break;
+      case QgsUnitTypes::TemporalUnit::TemporalMinutes:
+        return start.addSecs( 60 * frame * timeStep );
+        break;
+      case QgsUnitTypes::TemporalUnit::TemporalHours:
+        return start.addSecs( 3600 * frame * timeStep );
+        break;
+      case QgsUnitTypes::TemporalUnit::TemporalDays:
+        return start.addDays( frame * timeStep );
+        break;
+      case QgsUnitTypes::TemporalUnit::TemporalWeeks:
+        return start.addDays( 7 * frame * timeStep );
+        break;
+      case QgsUnitTypes::TemporalUnit::TemporalMonths:
+        return start.addMonths( frame * timeStep );
+        break;
+      case QgsUnitTypes::TemporalUnit::TemporalYears:
+        return start.addYears( frame * timeStep );
+        break;
+      case QgsUnitTypes::TemporalUnit::TemporalDecades:
+        return start.addYears( 10 * frame * timeStep );
+        break;
+      case QgsUnitTypes::TemporalUnit::TemporalCenturies:
+        return start.addYears( 100 * frame * timeStep );
+        break;
+      case QgsUnitTypes::TemporalUnit::TemporalUnknownUnit:
+        Q_ASSERT( false );
+        return start;
+        break;
+    }
+  }
+}
+

--- a/src/core/qgstemporalutils.h
+++ b/src/core/qgstemporalutils.h
@@ -51,8 +51,11 @@ class CORE_EXPORT QgsTemporalUtils
       //! Dictates the overall temporal range of the animation.
       QgsDateTimeRange animationRange;
 
-      //! Duration of individual export frames
-      QgsInterval frameDuration;
+      //! Time step of individual export frames
+      double frameTimeStep;
+
+      //! Time step unit of individual export frames
+      QgsUnitTypes::TemporalUnit frameTimeStepUnit;
 
       //! Destination directory for created image files.
       QString outputDirectory;

--- a/src/core/qgstemporalutils.h
+++ b/src/core/qgstemporalutils.h
@@ -89,6 +89,25 @@ class CORE_EXPORT QgsTemporalUtils
      * \returns TRUE if the export was successful.
      */
     static bool exportAnimation( const QgsMapSettings &mapSettings, const AnimationExportSettings &settings, QString &error SIP_OUT, QgsFeedback *feedback = nullptr );
+
+    /**
+     * Calculates the frame time for an animation.
+     *
+     * If mFrameTimeStep is fractional, then QgsInterval is used to determine the
+     * duration of the frame. This uses average durations for months and years.
+     * Otherwise, we use QDateTime to advance by the exact duration of the current
+     * month or year. So a time step of 1.5 months will result in a duration of 45
+     * days, but a time step of 1 month will result in a duration that depends upon
+     * the number of days in the current month.
+     *
+     * \param start the start time of the animation.
+     * \param frame the frame number
+     * \param timeStep the time step for the animation
+     * \param timeStepUnit the time step unit for the animation
+     *
+     * \returns The calculated datetime for the frame.
+     */
+    static QDateTime calculateFrameTime( const QDateTime &start, const long long frame, double timeStep, QgsUnitTypes::TemporalUnit timeStepUnit );
 };
 
 

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -285,8 +285,8 @@ void QgsTemporalControllerWidget::updateFrameDuration()
   QgsProject::instance()->timeSettings()->setTimeStepUnit( static_cast< QgsUnitTypes::TemporalUnit>( mTimeStepsComboBox->currentData().toInt() ) );
   QgsProject::instance()->timeSettings()->setTimeStep( mStepSpinBox->value() );
 
-  mNavigationObject->setFrameDuration( QgsInterval( QgsProject::instance()->timeSettings()->timeStep(),
-                                       QgsProject::instance()->timeSettings()->timeStepUnit() ) );
+  mNavigationObject->setFrameTimeStep( QgsProject::instance()->timeSettings()->timeStep() );
+  mNavigationObject->setFrameTimeStepUnit( QgsProject::instance()->timeSettings()->timeStepUnit() );
   mSlider->setRange( 0, mNavigationObject->totalFrameCount() - 1 );
 }
 

--- a/tests/src/core/testqgstemporalnavigationobject.cpp
+++ b/tests/src/core/testqgstemporalnavigationobject.cpp
@@ -198,9 +198,8 @@ void TestQgsTemporalNavigationObject::frameSettings()
 
   navigationObject->setFrameTimeStep( 1 );
   navigationObject->setFrameTimeStepUnit( QgsUnitTypes::TemporalHours );
-  QCOMPARE( navigationObject->frameTimeStep(), 1 );
-  QCOMPARE( static_cast<int>( navigationObject->frameTimeStepUnit() ),
-            static_cast<int>( QgsUnitTypes::TemporalHours ) );
+  QCOMPARE( navigationObject->frameTimeStep(), 1.0 );
+  QCOMPARE( navigationObject->frameTimeStepUnit(), QgsUnitTypes::TemporalHours );
 
   QCOMPARE( navigationObject->currentFrameNumber(), 0 );
   QCOMPARE( navigationObject->totalFrameCount(), 5 );
@@ -234,7 +233,7 @@ void TestQgsTemporalNavigationObject::expressionContext()
   std::unique_ptr< QgsExpressionContextScope > scope( object.createExpressionContextScope() );
   QCOMPARE( scope->variable( QStringLiteral( "frame_rate" ) ).toDouble(), 30.0 );
   QCOMPARE( scope->variable( QStringLiteral( "frame_timestep" ) ).value< double >(), 1.0 );
-  QCOMPARE( scope->variable( QStringLiteral( "frame_timestepunit" ) ).value< QgsUnitTypes::TemporalUnit >(), QgsUnitTypes::TemporalUnit::TemporalHours );
+  QCOMPARE( scope->variable( QStringLiteral( "frame_timestep_unit" ) ).value< QgsUnitTypes::TemporalUnit >(), QgsUnitTypes::TemporalUnit::TemporalHours );
   QCOMPARE( scope->variable( QStringLiteral( "frame_number" ) ).toInt(), 1 );
   QCOMPARE( scope->variable( QStringLiteral( "animation_start_time" ) ).toDateTime(), range.begin() );
   QCOMPARE( scope->variable( QStringLiteral( "animation_end_time" ) ).toDateTime(), range.end() );

--- a/tests/src/core/testqgstemporalnavigationobject.cpp
+++ b/tests/src/core/testqgstemporalnavigationobject.cpp
@@ -86,7 +86,8 @@ void TestQgsTemporalNavigationObject::animationState()
                            );
   navigationObject->setTemporalExtents( range );
 
-  navigationObject->setFrameDuration( QgsInterval( 1, QgsUnitTypes::TemporalMonths ) );
+  navigationObject->setFrameTimeStep( 1 );
+  navigationObject->setFrameTimeStepUnit( QgsUnitTypes::TemporalMonths );
 
   qRegisterMetaType<QgsTemporalNavigationObject::AnimationState>( "AnimationState" );
   QSignalSpy stateSignal( navigationObject, &QgsTemporalNavigationObject::stateChanged );
@@ -195,8 +196,10 @@ void TestQgsTemporalNavigationObject::frameSettings()
   navigationObject->setTemporalExtents( range );
   QCOMPARE( temporalRangeSignal.count(), 1 );
 
-  navigationObject->setFrameDuration( QgsInterval( 1, QgsUnitTypes::TemporalHours ) );
-  QCOMPARE( navigationObject->frameDuration(), QgsInterval( 1, QgsUnitTypes::TemporalHours ) );
+  navigationObject->setFrameTimeStep( 1 );
+  navigationObject->setFrameTimeStepUnit( QgsUnitTypes::TemporalHours );
+  QCOMPARE( navigationObject->frameTimeStep(), 1 );
+  QCOMPARE( navigationObject->frameTimeStepUnit(), QgsUnitTypes::TemporalHours );
 
   QCOMPARE( navigationObject->currentFrameNumber(), 0 );
   QCOMPARE( navigationObject->totalFrameCount(), 5 );
@@ -222,13 +225,15 @@ void TestQgsTemporalNavigationObject::expressionContext()
                              QDateTime( QDate( 2020, 1, 1 ), QTime( 12, 0, 0 ) )
                            );
   object.setTemporalExtents( range );
-  object.setFrameDuration( QgsInterval( 1, QgsUnitTypes::TemporalHours ) );
+  object.setFrameTimeStep( 1 );
+  object.setFrameTimeStepUnit( QgsUnitTypes::TemporalHours );
   object.setCurrentFrameNumber( 1 );
   object.setFramesPerSecond( 30 );
 
   std::unique_ptr< QgsExpressionContextScope > scope( object.createExpressionContextScope() );
   QCOMPARE( scope->variable( QStringLiteral( "frame_rate" ) ).toDouble(), 30.0 );
-  QCOMPARE( scope->variable( QStringLiteral( "frame_duration" ) ).value< QgsInterval >().seconds(), 3600.0 );
+  QCOMPARE( scope->variable( QStringLiteral( "frame_timestep" ) ).value< double >(), 1.0 );
+  QCOMPARE( scope->variable( QStringLiteral( "frame_timestepunit" ) ).value< QgsUnitTypes::TemporalUnit >(), QgsUnitTypes::TemporalUnit::TemporalHours );
   QCOMPARE( scope->variable( QStringLiteral( "frame_number" ) ).toInt(), 1 );
   QCOMPARE( scope->variable( QStringLiteral( "animation_start_time" ) ).toDateTime(), range.begin() );
   QCOMPARE( scope->variable( QStringLiteral( "animation_end_time" ) ).toDateTime(), range.end() );

--- a/tests/src/core/testqgstemporalnavigationobject.cpp
+++ b/tests/src/core/testqgstemporalnavigationobject.cpp
@@ -199,7 +199,8 @@ void TestQgsTemporalNavigationObject::frameSettings()
   navigationObject->setFrameTimeStep( 1 );
   navigationObject->setFrameTimeStepUnit( QgsUnitTypes::TemporalHours );
   QCOMPARE( navigationObject->frameTimeStep(), 1 );
-  QCOMPARE( navigationObject->frameTimeStepUnit(), QgsUnitTypes::TemporalHours );
+  QCOMPARE( static_cast<int>( navigationObject->frameTimeStepUnit() ),
+            static_cast<int>( QgsUnitTypes::TemporalHours ) );
 
   QCOMPARE( navigationObject->currentFrameNumber(), 0 );
   QCOMPARE( navigationObject->totalFrameCount(), 5 );


### PR DESCRIPTION
Currently, we pass the frame duration as a QgsInterval and use the average
duration of a month or year during the animation, for instance, 30 days
rather than a month. This makes it impossible to have an animation that
displays on a particular day each month, as the day in the next month will
change depending on the number of days in the previous month.

This changes QgsTemporalNavigationObject to take the time step and time
step unit as separate arguments. The settings in
QgsTemporalUtils::exportAnimation are left unchanged, because in this case
the user interface is already set up to use an interval.

If the time step has a fractional value, the frame duration is calculated
using a QgsInterval as before. If it has an integer value, the calculation
uses QDateTime to advance by the specified time step instead. So a value of
1.5 months results in a frame duration of 45 days, but a value of 1 month
will result in a duration that depends on the length of the current month.

Fixes #37829.