### PR TITLE
New algorithm "Align points to features" 

### DIFF
--- a/python/core/auto_generated/symbology/qgsstyle.sip.in
+++ b/python/core/auto_generated/symbology/qgsstyle.sip.in
@@ -1108,7 +1108,7 @@ A symbol entity for QgsStyle databases.
 %End
   public:
 
-    QgsStyleSymbolEntity( const QgsSymbol *symbol );
+    QgsStyleSymbolEntity( QgsSymbol *symbol );
 %Docstring
 Constructor for QgsStyleSymbolEntity, with the specified ``symbol``.
 
@@ -1118,7 +1118,7 @@ Ownership of ``symbol`` is NOT transferred.
     virtual QgsStyle::StyleEntity type() const;
 
 
-    const QgsSymbol *symbol() const;
+    QgsSymbol *symbol() const;
 %Docstring
 Returns the entity's symbol.
 %End
@@ -1138,7 +1138,7 @@ A color ramp entity for QgsStyle databases.
 %End
   public:
 
-    QgsStyleColorRampEntity( const QgsColorRamp *ramp );
+    QgsStyleColorRampEntity( QgsColorRamp *ramp );
 %Docstring
 Constructor for QgsStyleColorRampEntity, with the specified color ``ramp``.
 
@@ -1148,7 +1148,7 @@ Ownership of ``ramp`` is NOT transferred.
     virtual QgsStyle::StyleEntity type() const;
 
 
-    const QgsColorRamp *ramp() const;
+    QgsColorRamp *ramp() const;
 %Docstring
 Returns the entity's color ramp.
 %End

--- a/python/plugins/processing/tests/testdata/expected/rotated_points_max.gml
+++ b/python/plugins/processing/tests/testdata/expected/rotated_points_max.gml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ rotated_points_max.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                               
+  <gml:featureMember>
+    <ogr:rotated_points_max fid="points.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>1</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:angle>85.3649325292524</ogr:angle>
+    </ogr:rotated_points_max>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:rotated_points_max fid="points.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>2</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:angle xsi:nil="true"/>
+    </ogr:rotated_points_max>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:rotated_points_max fid="points.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>3</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:angle>6.7420642833774</ogr:angle>
+    </ogr:rotated_points_max>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:rotated_points_max fid="points.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>4</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:angle xsi:nil="true"/>
+    </ogr:rotated_points_max>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:rotated_points_max fid="points.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>5</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:angle xsi:nil="true"/>
+    </ogr:rotated_points_max>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:rotated_points_max fid="points.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>6</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:angle xsi:nil="true"/>
+    </ogr:rotated_points_max>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:rotated_points_max fid="points.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>7</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:angle>124.307787844716</ogr:angle>
+    </ogr:rotated_points_max>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:rotated_points_max fid="points.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>8</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:angle>147.639207132861</ogr:angle>
+    </ogr:rotated_points_max>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:rotated_points_max fid="points.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>9</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:angle>180</ogr:angle>
+    </ogr:rotated_points_max>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/rotated_points_max.xsd
+++ b/python/plugins/processing/tests/testdata/expected/rotated_points_max.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="rotated_points_max" type="ogr:rotated_points_max_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="rotated_points_max_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="angle" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/rotated_points_no_max.gml
+++ b/python/plugins/processing/tests/testdata/expected/rotated_points_no_max.gml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ rotated_points_no_max.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                               
+  <gml:featureMember>
+    <ogr:rotated_points_no_max fid="points.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>1</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:rotation>85.3649325292524</ogr:rotation>
+    </ogr:rotated_points_no_max>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:rotated_points_no_max fid="points.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>2</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:rotation>-165.374165295877</ogr:rotation>
+    </ogr:rotated_points_no_max>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:rotated_points_no_max fid="points.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>3</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:rotation>6.7420642833774</ogr:rotation>
+    </ogr:rotated_points_no_max>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:rotated_points_no_max fid="points.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>4</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:rotation>72.7061456490137</ogr:rotation>
+    </ogr:rotated_points_no_max>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:rotated_points_no_max fid="points.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>5</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:rotation>-41.558194492138</ogr:rotation>
+    </ogr:rotated_points_no_max>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:rotated_points_no_max fid="points.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>6</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:rotation>90</ogr:rotation>
+    </ogr:rotated_points_no_max>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:rotated_points_no_max fid="points.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>7</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:rotation>124.307787844716</ogr:rotation>
+    </ogr:rotated_points_no_max>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:rotated_points_no_max fid="points.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>8</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:rotation>147.639207132861</ogr:rotation>
+    </ogr:rotated_points_no_max>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:rotated_points_no_max fid="points.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>9</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:rotation>180</ogr:rotation>
+    </ogr:rotated_points_no_max>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/rotated_points_no_max.xsd
+++ b/python/plugins/processing/tests/testdata/expected/rotated_points_no_max.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="rotated_points_no_max" type="ogr:rotated_points_no_max_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="rotated_points_no_max_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="rotation" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
@@ -2501,5 +2501,46 @@ tests:
         hash: 63610fb1f7ec3d6530591b1eb479355b52cedfebf6331cec77f2b35c
         type: rasterhash
 
+  - algorithm: native:angletonearest
+    name: Align points to nearest line, no max distance
+    params:
+      APPLY_SYMBOLOGY: true
+      FIELD_NAME: rotation
+      INPUT:
+        name: points.gml|layername=points
+        type: vector
+      REFERENCE_LAYER:
+        name: custom/snap_lines_3857.gml|layername=snap_lines_3857
+        type: vector
+    results:
+      OUTPUT:
+        name: expected/rotated_points_no_max.gml
+        type: vector
+        compare:
+          fields:
+            rotation:
+              precision: 2
+
+  - algorithm: native:angletonearest
+    name: Align points to nearest line, max distance
+    params:
+      APPLY_SYMBOLOGY: true
+      FIELD_NAME: angle
+      INPUT:
+        name: points.gml|layername=points
+        type: vector
+      MAX_DISTANCE: 1.0
+      REFERENCE_LAYER:
+        name: custom/snap_lines_3857.gml|layername=snap_lines_3857
+        type: vector
+    results:
+      OUTPUT:
+        name: expected/rotated_points_max.gml
+        type: vector
+        compare:
+          fields:
+            angle:
+              precision: 2
+
 
 # See ../README.md for a description of the file format

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -26,6 +26,7 @@ SET(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmaddxyfields.cpp
   processing/qgsalgorithmaffinetransform.cpp
   processing/qgsalgorithmaggregate.cpp
+  processing/qgsalgorithmangletonearest.cpp
   processing/qgsalgorithmapplylayerstyle.cpp
   processing/qgsalgorithmarraytranslatedfeatures.cpp
   processing/qgsalgorithmaspect.cpp

--- a/src/analysis/processing/qgsalgorithmangletonearest.cpp
+++ b/src/analysis/processing/qgsalgorithmangletonearest.cpp
@@ -1,0 +1,258 @@
+/***************************************************************************
+                         qgsalgorithmangletonearest.cpp
+                         ---------------------
+    begin                : July 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmangletonearest.h"
+#include "qgsprocessingoutputs.h"
+#include "qgslinestring.h"
+#include "qgsvectorlayer.h"
+#include "qgsrenderer.h"
+#include "qgsstyleentityvisitor.h"
+
+///@cond PRIVATE
+
+class SetMarkerRotationVisitor : public QgsStyleEntityVisitorInterface
+{
+  public:
+
+    SetMarkerRotationVisitor( const QString &rotationField )
+      : mRotationField( rotationField )
+    {}
+
+    bool visit( const QgsStyleEntityVisitorInterface::StyleLeaf &entity )
+    {
+      if ( const QgsStyleSymbolEntity *symbolEntity = dynamic_cast< const QgsStyleSymbolEntity * >( entity.entity ) )
+      {
+        if ( QgsMarkerSymbol *marker = dynamic_cast< QgsMarkerSymbol * >( symbolEntity->symbol() ) )
+        {
+          marker->setDataDefinedAngle( QgsProperty::fromField( mRotationField ) );
+        }
+      }
+      return true;
+    }
+
+  private:
+    QString mRotationField;
+
+};
+
+class SetMarkerRotationPostProcessor : public QgsProcessingLayerPostProcessorInterface
+{
+  public:
+
+    SetMarkerRotationPostProcessor( std::unique_ptr< QgsFeatureRenderer > renderer, const QString &rotationField )
+      : mRenderer( std::move( renderer ) )
+      , mRotationField( rotationField )
+    {}
+
+    void postProcessLayer( QgsMapLayer *layer, QgsProcessingContext &, QgsProcessingFeedback * ) override
+    {
+      if ( QgsVectorLayer *vl = qobject_cast< QgsVectorLayer * >( layer ) )
+      {
+        SetMarkerRotationVisitor visitor( mRotationField );
+        mRenderer->accept( &visitor );
+        vl->setRenderer( mRenderer.release() );
+        vl->triggerRepaint();
+      }
+    }
+
+  private:
+
+    std::unique_ptr<QgsFeatureRenderer> mRenderer;
+    QString mRotationField;
+};
+
+QString QgsAngleToNearestAlgorithm::name() const
+{
+  return QStringLiteral( "angletonearest" );
+}
+
+QString QgsAngleToNearestAlgorithm::displayName() const
+{
+  return QObject::tr( "Align points to features" );
+}
+
+QStringList QgsAngleToNearestAlgorithm::tags() const
+{
+  return QObject::tr( "align,marker,stroke,fill,orient,points,lines,angles,rotation,rotate" ).split( ',' );
+}
+
+QString QgsAngleToNearestAlgorithm::group() const
+{
+  return QObject::tr( "Cartography" );
+}
+
+QString QgsAngleToNearestAlgorithm::groupId() const
+{
+  return QStringLiteral( "cartography" );
+}
+
+QgsAngleToNearestAlgorithm::~QgsAngleToNearestAlgorithm() = default;
+
+void QgsAngleToNearestAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ),
+                QObject::tr( "Input layer" ), QList< int >() << QgsProcessing::TypeVectorPoint ) );
+  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "REFERENCE_LAYER" ),
+                QObject::tr( "Reference layer" ) ) );
+
+  addParameter( new QgsProcessingParameterDistance( QStringLiteral( "MAX_DISTANCE" ),
+                QObject::tr( "Maximum distance to consider" ), QVariant(), QStringLiteral( "INPUT" ), true, 0 ) );
+
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "FIELD_NAME" ), QObject::tr( "Angle field name" ), QStringLiteral( "rotation" ) ) );
+
+  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "APPLY_SYMBOLOGY" ), QObject::tr( "Automatically apply symbology" ), true ) );
+
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Aligned layer" ), QgsProcessing::TypeVectorPoint ) );
+}
+
+QString QgsAngleToNearestAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm calculates the rotation required to align point features with their nearest "
+                      "feature from another reference layer. A new field is added to the output layer which is filled with the angle "
+                      "(in degrees, clockwise) to the nearest reference feature.\n\n"
+                      "Optionally, the output layer's symbology can be set to automatically use the calculated rotation "
+                      "field to rotate marker symbols.\n\n"
+                      "If desired, a maximum distance to use when aligning points can be set, to avoid aligning isolated points "
+                      "to distant features." );
+}
+
+QString QgsAngleToNearestAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Rotates point features to align them to nearby features." );
+}
+
+QgsAngleToNearestAlgorithm *QgsAngleToNearestAlgorithm::createInstance() const
+{
+  return new QgsAngleToNearestAlgorithm();
+}
+
+bool QgsAngleToNearestAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  if ( QgsVectorLayer *sourceLayer = parameterAsVectorLayer( parameters, QStringLiteral( "INPUT" ), context ) )
+  {
+    mSourceRenderer.reset( sourceLayer->renderer()->clone() );
+  }
+
+  return true;
+}
+
+QVariantMap QgsAngleToNearestAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  const double maxDistance = parameters.value( QStringLiteral( "MAX_DISTANCE" ) ).isValid() ? parameterAsDouble( parameters, QStringLiteral( "MAX_DISTANCE" ), context ) : std::numeric_limits< double >::quiet_NaN();
+  std::unique_ptr< QgsProcessingFeatureSource > input( parameterAsSource( parameters, QStringLiteral( "INPUT" ), context ) );
+  if ( !input )
+    throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "INPUT" ) ) );
+
+  std::unique_ptr< QgsProcessingFeatureSource > referenceSource( parameterAsSource( parameters, QStringLiteral( "REFERENCE_LAYER" ), context ) );
+  if ( !referenceSource )
+    throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "REFERENCE_LAYER" ) ) );
+
+  const QString fieldName = parameterAsString( parameters, QStringLiteral( "FIELD_NAME" ), context );
+
+  QgsFields outFields = input->fields();
+  outFields.append( QgsField( fieldName, QVariant::Double ) );
+
+  QString dest;
+  std::unique_ptr< QgsFeatureSink > sink( parameterAsSink( parameters, QStringLiteral( "OUTPUT" ), context, dest, outFields,
+                                          input->wkbType(), input->sourceCrs() ) );
+  if ( parameters.value( QStringLiteral( "OUTPUT" ) ).isValid() && !sink )
+    throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "OUTPUT" ) ) );
+
+  // make spatial index
+  QgsFeatureIterator f2 = referenceSource->getFeatures( QgsFeatureRequest().setDestinationCrs( input->sourceCrs(), context.transformContext() ).setNoAttributes() );
+  double step = referenceSource->featureCount() > 0 ? 50.0 / referenceSource->featureCount() : 1;
+  int i = 0;
+  QgsSpatialIndex index( f2, [&]( const QgsFeature & )->bool
+  {
+    i++;
+    if ( feedback->isCanceled() )
+      return false;
+
+    feedback->setProgress( i * step );
+
+    return true;
+  }, QgsSpatialIndex::FlagStoreFeatureGeometries );
+
+  QgsFeature f;
+
+  // Create output vector layer with additional attributes
+  step = input->featureCount() > 0 ? 50.0 / input->featureCount() : 1;
+  QgsFeatureIterator features = input->getFeatures();
+  i = 0;
+  while ( features.nextFeature( f ) )
+  {
+    i++;
+    if ( feedback->isCanceled() )
+    {
+      break;
+    }
+
+    feedback->setProgress( 50 + i * step );
+
+    QgsAttributes attributes = f.attributes();
+
+    if ( !f.hasGeometry() )
+    {
+      attributes.append( QVariant() );
+      f.setAttributes( attributes );
+      sink->addFeature( f, QgsFeatureSink::FastInsert );
+    }
+    else
+    {
+      const QList< QgsFeatureId > nearest = index.nearestNeighbor( f.geometry(), 1, std::isnan( maxDistance ) ? 0 : maxDistance );
+      if ( nearest.empty() )
+      {
+        feedback->pushInfo( QObject::tr( "No matching features found within search distance" ) );
+        attributes.append( QVariant() );
+        f.setAttributes( attributes );
+        sink->addFeature( f, QgsFeatureSink::FastInsert );
+      }
+      else
+      {
+        if ( nearest.count() > 1 )
+        {
+          feedback->pushInfo( QObject::tr( "Multiple matching features found at same distance from search feature, found %1 features" ).arg( nearest.count() ) );
+        }
+
+        const QgsGeometry joinLine = f.geometry().shortestLine( index.geometry( nearest.at( 0 ) ) );
+        if ( const QgsLineString *line = qgsgeometry_cast< const QgsLineString * >( joinLine.constGet() ) )
+        {
+          attributes.append( line->startPoint().azimuth( line->endPoint() ) );
+        }
+        else
+        {
+          attributes.append( QVariant() );
+        }
+        f.setAttributes( attributes );
+        sink->addFeature( f, QgsFeatureSink::FastInsert );
+      }
+    }
+  }
+
+  const bool applySymbology = parameterAsBool( parameters, QStringLiteral( "APPLY_SYMBOLOGY" ), context );
+  if ( applySymbology && mSourceRenderer && context.willLoadLayerOnCompletion( dest ) )
+  {
+    context.layerToLoadOnCompletionDetails( dest ).setPostProcessor( new SetMarkerRotationPostProcessor( std::move( mSourceRenderer ), fieldName ) );
+  }
+
+  QVariantMap outputs;
+  outputs.insert( QStringLiteral( "OUTPUT" ), dest );
+  return outputs;
+}
+
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmangletonearest.h
+++ b/src/analysis/processing/qgsalgorithmangletonearest.h
@@ -1,0 +1,64 @@
+/***************************************************************************
+                         qgsalgorithmangletonearest.h
+                         ---------------------
+    begin                : July 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMANGLETONEAREST_H
+#define QGSALGORITHMANGLETONEAREST_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+#include "qgsrenderer.h"
+
+///@cond PRIVATE
+
+/**
+ * Native angle to nearest feature algorithm.
+ */
+class QgsAngleToNearestAlgorithm : public QgsProcessingAlgorithm
+{
+
+  public:
+
+    QgsAngleToNearestAlgorithm() = default;
+    ~QgsAngleToNearestAlgorithm() override;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QgsAngleToNearestAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+  private:
+    std::unique_ptr< QgsFeatureRenderer > mSourceRenderer;
+
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMANGLETONEAREST_H
+
+

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -22,6 +22,7 @@
 #include "qgsalgorithmaddxyfields.h"
 #include "qgsalgorithmaffinetransform.h"
 #include "qgsalgorithmaggregate.h"
+#include "qgsalgorithmangletonearest.h"
 #include "qgsalgorithmapplylayerstyle.h"
 #include "qgsalgorithmarraytranslatedfeatures.h"
 #include "qgsalgorithmaspect.h"
@@ -235,6 +236,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsAddUniqueValueIndexAlgorithm() );
   addAlgorithm( new QgsAffineTransformationAlgorithm() );
   addAlgorithm( new QgsAggregateAlgorithm() );
+  addAlgorithm( new QgsAngleToNearestAlgorithm() );
   addAlgorithm( new QgsApplyLayerStyleAlgorithm() );
   addAlgorithm( new QgsArrayTranslatedFeaturesAlgorithm() );
   addAlgorithm( new QgsAspectAlgorithm() );

--- a/src/core/layout/qgslayoutitempage.cpp
+++ b/src/core/layout/qgslayoutitempage.cpp
@@ -211,7 +211,7 @@ QgsLayoutItem::ExportLayerBehavior QgsLayoutItemPage::exportLayerBehavior() cons
 
 bool QgsLayoutItemPage::accept( QgsStyleEntityVisitorInterface *visitor ) const
 {
-  QgsStyleSymbolEntity entity( pageStyleSymbol() );
+  QgsStyleSymbolEntity entity( mPageStyleSymbol.get() );
   if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity, QStringLiteral( "page" ), QObject::tr( "Page" ) ) ) )
     return false;
   return true;

--- a/src/core/symbology/qgsstyle.h
+++ b/src/core/symbology/qgsstyle.h
@@ -1140,7 +1140,7 @@ class CORE_EXPORT QgsStyleSymbolEntity : public QgsStyleEntityInterface
      *
      * Ownership of \a symbol is NOT transferred.
      */
-    QgsStyleSymbolEntity( const QgsSymbol *symbol )
+    QgsStyleSymbolEntity( QgsSymbol *symbol )
       : mSymbol( symbol )
     {}
 
@@ -1149,11 +1149,11 @@ class CORE_EXPORT QgsStyleSymbolEntity : public QgsStyleEntityInterface
     /**
      * Returns the entity's symbol.
      */
-    const QgsSymbol *symbol() const { return mSymbol; }
+    QgsSymbol *symbol() const { return mSymbol; }
 
   private:
 
-    const QgsSymbol *mSymbol = nullptr;
+    QgsSymbol *mSymbol = nullptr;
 
 };
 
@@ -1172,7 +1172,7 @@ class CORE_EXPORT QgsStyleColorRampEntity : public QgsStyleEntityInterface
      *
      * Ownership of \a ramp is NOT transferred.
      */
-    QgsStyleColorRampEntity( const QgsColorRamp *ramp )
+    QgsStyleColorRampEntity( QgsColorRamp *ramp )
       : mRamp( ramp )
     {}
 
@@ -1181,11 +1181,11 @@ class CORE_EXPORT QgsStyleColorRampEntity : public QgsStyleEntityInterface
     /**
      * Returns the entity's color ramp.
      */
-    const QgsColorRamp *ramp() const { return mRamp; }
+    QgsColorRamp *ramp() const { return mRamp; }
 
   private:
 
-    const QgsColorRamp *mRamp = nullptr;
+    QgsColorRamp *mRamp = nullptr;
 };
 
 /**


### PR DESCRIPTION
This algorithm calculates the rotation required to align point features
with their nearest feature from another reference layer. A new field is
added to the output layer which is filled with the angle (in degrees,
clockwise) to the nearest reference feature.

Optionally, the output layer's symbology can be set to automatically
use the calculated rotation field to rotate marker symbols.

If desired, a maximum distance to use when aligning points can be set,
to avoid aligning isolated points to distant features.

Designed for use cases like aligning building point symbols to follow
the nearest road direction!