### PR TITLE
Don't modify text format paint effects in place

### DIFF
--- a/python/core/auto_generated/qgstextrenderer.sip.in
+++ b/python/core/auto_generated/qgstextrenderer.sip.in
@@ -223,7 +223,7 @@ Write settings into a DOM element.
 .. seealso:: :py:func:`readXml`
 %End
 
-    QgsPaintEffect *paintEffect() const;
+    const QgsPaintEffect *paintEffect() const;
 %Docstring
 Returns the current paint effect for the buffer.
 
@@ -796,7 +796,7 @@ Sets the join style used for drawing the background shape.
 .. seealso:: :py:func:`joinStyle`
 %End
 
-    QgsPaintEffect *paintEffect() const;
+    const QgsPaintEffect *paintEffect() const;
 %Docstring
 Returns the current paint effect for the background shape.
 

--- a/src/core/qgstextrenderer.h
+++ b/src/core/qgstextrenderer.h
@@ -217,7 +217,7 @@ class CORE_EXPORT QgsTextBufferSettings
      * \returns paint effect
      * \see setPaintEffect()
      */
-    QgsPaintEffect *paintEffect() const;
+    const QgsPaintEffect *paintEffect() const;
 
     /**
      * Sets the current paint \a effect for the buffer.
@@ -679,7 +679,7 @@ class CORE_EXPORT QgsTextBackgroundSettings
      * \returns paint effect
      * \see setPaintEffect()
      */
-    QgsPaintEffect *paintEffect() const;
+    const QgsPaintEffect *paintEffect() const;
 
     /**
      * Sets the current paint \a effect for the background shape.


### PR DESCRIPTION
Avoids race conditions when multiple threads are rendering the same
text format which contains paint effects

Fixes #37938

cherry-picked from 51d8ad7
