### PR TITLE
Don't modify text format paint effects in place

### DIFF
--- a/python/core/auto_generated/textrenderer/qgstextbackgroundsettings.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextbackgroundsettings.sip.in
@@ -555,7 +555,7 @@ Sets the join style used for drawing the background shape.
 .. seealso:: :py:func:`joinStyle`
 %End
 
-    QgsPaintEffect *paintEffect() const;
+    const QgsPaintEffect *paintEffect() const;
 %Docstring
 Returns the current paint effect for the background shape.
 

--- a/python/core/auto_generated/textrenderer/qgstextbuffersettings.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextbuffersettings.sip.in
@@ -223,7 +223,7 @@ Write settings into a DOM element.
 .. seealso:: :py:func:`readXml`
 %End
 
-    QgsPaintEffect *paintEffect() const;
+    const QgsPaintEffect *paintEffect() const;
 %Docstring
 Returns the current paint effect for the buffer.
 

--- a/src/core/textrenderer/qgstextbackgroundsettings.cpp
+++ b/src/core/textrenderer/qgstextbackgroundsettings.cpp
@@ -284,7 +284,7 @@ void QgsTextBackgroundSettings::setJoinStyle( Qt::PenJoinStyle style )
   d->joinStyle = style;
 }
 
-QgsPaintEffect *QgsTextBackgroundSettings::paintEffect() const
+const QgsPaintEffect *QgsTextBackgroundSettings::paintEffect() const
 {
   return d->paintEffect.get();
 }

--- a/src/core/textrenderer/qgstextbackgroundsettings.h
+++ b/src/core/textrenderer/qgstextbackgroundsettings.h
@@ -475,7 +475,7 @@ class CORE_EXPORT QgsTextBackgroundSettings
      * \returns paint effect
      * \see setPaintEffect()
      */
-    QgsPaintEffect *paintEffect() const;
+    const QgsPaintEffect *paintEffect() const;
 
     /**
      * Sets the current paint \a effect for the background shape.

--- a/src/core/textrenderer/qgstextbuffersettings.cpp
+++ b/src/core/textrenderer/qgstextbuffersettings.cpp
@@ -134,7 +134,7 @@ void QgsTextBufferSettings::setBlendMode( QPainter::CompositionMode mode )
   d->blendMode = mode;
 }
 
-QgsPaintEffect *QgsTextBufferSettings::paintEffect() const
+const QgsPaintEffect *QgsTextBufferSettings::paintEffect() const
 {
   return d->paintEffect.get();
 }

--- a/src/core/textrenderer/qgstextbuffersettings.h
+++ b/src/core/textrenderer/qgstextbuffersettings.h
@@ -212,7 +212,7 @@ class CORE_EXPORT QgsTextBufferSettings
      * \returns paint effect
      * \see setPaintEffect()
      */
-    QgsPaintEffect *paintEffect() const;
+    const QgsPaintEffect *paintEffect() const;
 
     /**
      * Sets the current paint \a effect for the buffer.

--- a/src/core/textrenderer/qgstextrenderer.cpp
+++ b/src/core/textrenderer/qgstextrenderer.cpp
@@ -327,12 +327,13 @@ double QgsTextRenderer::drawBuffer( QgsRenderContext &context, const QgsTextRend
   if ( buffer.paintEffect() && buffer.paintEffect()->enabled() )
   {
     context.setPainter( &buffp );
+    std::unique_ptr< QgsPaintEffect > tmpEffect( buffer.paintEffect()->clone() );
 
-    buffer.paintEffect()->begin( context );
+    tmpEffect->begin( context );
     context.painter()->setPen( pen );
     context.painter()->setBrush( tmpColor );
     context.painter()->drawPath( path );
-    buffer.paintEffect()->end( context );
+    tmpEffect->end( context );
 
     context.setPainter( p );
   }
@@ -616,9 +617,11 @@ void QgsTextRenderer::drawBackground( QgsRenderContext &context, QgsTextRenderer
 
   QPainter *prevP = context.painter();
   QPainter *p = context.painter();
+  std::unique_ptr< QgsPaintEffect > tmpEffect;
   if ( background.paintEffect() && background.paintEffect()->enabled() )
   {
-    background.paintEffect()->begin( context );
+    tmpEffect.reset( background.paintEffect()->clone() );
+    tmpEffect->begin( context );
     p = context.painter();
   }
 
@@ -986,9 +989,9 @@ void QgsTextRenderer::drawBackground( QgsRenderContext &context, QgsTextRenderer
     }
   }
 
-  if ( background.paintEffect() && background.paintEffect()->enabled() )
+  if ( tmpEffect )
   {
-    background.paintEffect()->end( context );
+    tmpEffect->end( context );
     context.setPainter( prevP );
   }
 }


### PR DESCRIPTION
Avoids race conditions when multiple threads are rendering the same
text format which contains paint effects

Fixes #37938

(cherry picked from commit 51d8ad75c5808bd83444d03159d22e15219766ac)