### PR TITLE
Add mechanism for algorithms to alter their core behavior when run in-place mode

### DIFF
--- a/python/plugins/processing/algs/qgis/Climb.py
+++ b/python/plugins/processing/algs/qgis/Climb.py
@@ -60,7 +60,7 @@ class Climb(QgisAlgorithm):
         return 'climbalongline'
 
     def displayName(self):
-        return self.tr('Climb Along Line')
+        return self.tr('Climb along line')
 
     def group(self):
         return self.tr('Vector analysis')

--- a/python/plugins/processing/gui/AlgorithmExecutor.py
+++ b/python/plugins/processing/gui/AlgorithmExecutor.py
@@ -153,7 +153,7 @@ def execute_in_place_run(alg, parameters, context=None, feedback=None, raise_exc
         if hasattr(alg, 'processFeature'):  # in-place feature editing
             # Make a clone or it will crash the second time the dialog
             # is opened and run
-            alg = alg.create()
+            alg = alg.create({'IN_PLACE': True})
             if not alg.prepare(parameters, context, feedback):
                 raise QgsProcessingException(tr("Could not prepare selected algorithm."))
             # Check again for compatibility after prepare
@@ -218,7 +218,7 @@ def execute_in_place_run(alg, parameters, context=None, feedback=None, raise_exc
             else:
                 selected_ids = []
 
-            results, ok = alg.run(parameters, context, feedback)
+            results, ok = alg.run(parameters, context, feedback, configuration={'IN_PLACE': True})
 
             if ok:
                 result_layer = QgsProcessingUtils.mapLayerFromString(results['OUTPUT'], context)

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -233,7 +233,10 @@ class ProcessingToolbox(QgsDockWidget, WIDGET):
             dlg.exec_()
 
     def executeAlgorithm(self):
-        alg = self.algorithmTree.selectedAlgorithm().create() if self.algorithmTree.selectedAlgorithm() is not None else None
+        config = {}
+        if self.in_place_mode:
+            config['IN_PLACE'] = True
+        alg = self.algorithmTree.selectedAlgorithm().create(config) if self.algorithmTree.selectedAlgorithm() is not None else None
         if alg is not None:
             ok, message = alg.canExecute()
             if not ok:

--- a/src/analysis/processing/qgsalgorithmaddxyfields.h
+++ b/src/analysis/processing/qgsalgorithmaddxyfields.h
@@ -58,11 +58,16 @@ class QgsAddXYFieldsAlgorithm : public QgsProcessingFeatureBasedAlgorithm
 
   private:
 
+    bool mIsInPlace = false;
     QString mPrefix;
     mutable QgsCoordinateReferenceSystem mSourceCrs;
     QgsCoordinateReferenceSystem mCrs;
     QgsCoordinateTransform mTransform;
     bool mTransformNeedsInitialization = true;
+    QString mInPlaceXField;
+    QString mInPlaceYField;
+    mutable int mInPlaceXFieldIndex = -1;
+    mutable int mInPlaceYFieldIndex = -1;
 
 };
 

--- a/src/analysis/processing/qgsalgorithmangletonearest.h
+++ b/src/analysis/processing/qgsalgorithmangletonearest.h
@@ -37,6 +37,7 @@ class QgsAngleToNearestAlgorithm : public QgsProcessingAlgorithm
     QgsAngleToNearestAlgorithm() = default;
     ~QgsAngleToNearestAlgorithm() override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;
@@ -45,6 +46,7 @@ class QgsAngleToNearestAlgorithm : public QgsProcessingAlgorithm
     QString shortHelpString() const override;
     QString shortDescription() const override;
     QgsAngleToNearestAlgorithm *createInstance() const override SIP_FACTORY;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   protected:
 
@@ -53,6 +55,7 @@ class QgsAngleToNearestAlgorithm : public QgsProcessingAlgorithm
                                   QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
   private:
+    bool mIsInPlace = false;
     std::unique_ptr< QgsFeatureRenderer > mSourceRenderer;
 
 };


### PR DESCRIPTION
This allows algorithms to dynamically adapt their behavior to make them compatible
with in-place mode. Previously, some useful algorithms could not be
run in-place because they alter a layer's structure (e.g. adding new
fields).

Now, these algorithms have a means to detect that they are being
run in-place and change their input parameters accordingly. E.g.
an algorithm which usually adds new fields to store calculated
values (such as "add xy fields to layer") could instead expose
field parameter choices to ask the user to pick from existing
fields in which to store the calculated values, thereby avoiding
the need to change the table structure and making them eligable
for running in-place mode.

Note that this needs to be handled algorithm-by-algorithm, it's
not automatic! It's just the raw api to allow this... Here I've just updated the newly added "Align points to features" algorithm to add support for in place mode, as a bit of an demonstration of how an algorithm can be adapted.

![Peek 2020-07-27 13-46](https://user-images.githubusercontent.com/1829991/88502070-c1574e80-d010-11ea-82bc-3bf943320215.gif)
