### PR TITLE
Improving the "Add/Discover relation" dialogs

### DIFF
--- a/src/app/qgsdiscoverrelationsdialog.cpp
+++ b/src/app/qgsdiscoverrelationsdialog.cpp
@@ -15,6 +15,7 @@
 #include "qgsdiscoverrelationsdialog.h"
 #include "qgsvectorlayer.h"
 #include "qgsrelationmanager.h"
+#include "qgshelp.h"
 
 #include <QPushButton>
 
@@ -25,6 +26,11 @@ QgsDiscoverRelationsDialog::QgsDiscoverRelationsDialog( const QList<QgsRelation>
   setupUi( this );
 
   mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
+  mButtonBox->addButton( QDialogButtonBox::Help );
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, [ = ]
+  {
+    QgsHelp::openHelp( QStringLiteral( "working_with_vector/attribute_table.html#defining-1-n-relation" ) );
+  } );
   connect( mRelationsTable->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsDiscoverRelationsDialog::onSelectionChanged );
 
   mFoundRelations = QgsRelationManager::discoverRelations( existingRelations, layers );

--- a/src/app/qgsrelationadddlg.cpp
+++ b/src/app/qgsrelationadddlg.cpp
@@ -44,7 +44,7 @@ QgsFieldPairWidget::QgsFieldPairWidget( int index, QWidget *parent )
   mAddButton = new QToolButton( this );
   mAddButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/symbologyAdd.svg" ) ) );
   mAddButton->setMinimumWidth( 30 );
-  mAddButton->setToolTip( "Add new fields to pair" );
+  mAddButton->setToolTip( "Add new field pair as part of a composite foreign key" );
   mLayout->addWidget( mAddButton, 0, Qt::AlignLeft );
 
   mRemoveButton = new QToolButton( this );

--- a/src/app/qgsrelationadddlg.cpp
+++ b/src/app/qgsrelationadddlg.cpp
@@ -29,6 +29,7 @@
 #include "qgsfieldcombobox.h"
 #include "qgsmaplayerproxymodel.h"
 #include "qgsapplication.h"
+#include "qgshelp.h"
 
 
 
@@ -43,11 +44,13 @@ QgsFieldPairWidget::QgsFieldPairWidget( int index, QWidget *parent )
   mAddButton = new QToolButton( this );
   mAddButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/symbologyAdd.svg" ) ) );
   mAddButton->setMinimumWidth( 30 );
+  mAddButton->setToolTip( "Add new fields to pair" );
   mLayout->addWidget( mAddButton, 0, Qt::AlignLeft );
 
   mRemoveButton = new QToolButton( this );
   mRemoveButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/symbologyRemove.svg" ) ) );
   mRemoveButton->setMinimumWidth( 30 );
+  mRemoveButton->setToolTip( "Remove the last pair of fields" );
   mLayout->addWidget( mRemoveButton, 0, Qt::AlignLeft );
 
   mSpacerItem = new QSpacerItem( 30, 30, QSizePolicy::Minimum, QSizePolicy::Maximum );
@@ -120,7 +123,8 @@ void QgsFieldPairWidget::changeEnable()
 QgsRelationAddDlg::QgsRelationAddDlg( QWidget *parent )
   : QDialog( parent )
 {
-  QGridLayout *layout = new QGridLayout(); // column 0 is kept free for alignmenent purpose
+  setWindowTitle( "Add New Relation" );
+  QGridLayout *layout = new QGridLayout(); // column 0 is kept free for alignment purpose
 
   // row 0: name
   // col 1
@@ -176,9 +180,13 @@ QgsRelationAddDlg::QgsRelationAddDlg( QWidget *parent )
   // row 6: button box
   mButtonBox = new QDialogButtonBox( this );
   mButtonBox->setOrientation( Qt::Horizontal );
-  mButtonBox->setStandardButtons( QDialogButtonBox::Cancel | QDialogButtonBox::Ok );
+  mButtonBox->setStandardButtons( QDialogButtonBox::Cancel | QDialogButtonBox::Help | QDialogButtonBox::Ok );
   connect( mButtonBox, &QDialogButtonBox::accepted, this, &QgsRelationAddDlg::accept );
   connect( mButtonBox, &QDialogButtonBox::rejected, this, &QgsRelationAddDlg::reject );
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, [ = ]
+  {
+    QgsHelp::openHelp( QStringLiteral( "working_with_vector/attribute_table.html#defining-1-n-relations" ) );
+  } );
   layout->addWidget( mButtonBox, 7, 1, 1, 2 );
 
   // set layout


### PR DESCRIPTION
adding title, tooltips and help button to documentation
![image](https://user-images.githubusercontent.com/7983394/88492254-a4d3fb80-cfa9-11ea-91be-78f36f168184.png)
Question: should we left align the Help button with the + button or with the others (as done currently)?