### PR TITLE
Add option to set the ellipsoid to use for calculations with qgis_process tool

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -49,6 +49,7 @@ Abstract base class for processing algorithms.
       FlagCustomException,
       FlagPruneModelBranchesBasedOnAlgorithmResults,
       FlagSkipGenericModelLogging,
+      FlagNotAvailableInStandaloneTool,
       FlagDeprecated,
     };
     typedef QFlags<QgsProcessingAlgorithm::Flag> Flags;

--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -50,6 +50,7 @@ Abstract base class for processing algorithms.
       FlagPruneModelBranchesBasedOnAlgorithmResults,
       FlagSkipGenericModelLogging,
       FlagNotAvailableInStandaloneTool,
+      FlagRequiresProject,
       FlagDeprecated,
     };
     typedef QFlags<QgsProcessingAlgorithm::Flag> Flags;

--- a/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -73,8 +73,8 @@ Returns the project in which the algorithm is being executed.
 %Docstring
 Sets the ``project`` in which the algorithm will be executed.
 
-This also automatically sets the :py:func:`~QgsProcessingContext.transformContext` to match
-the project's transform context.
+This also automatically sets the :py:func:`~QgsProcessingContext.transformContext`, :py:func:`~QgsProcessingContext.ellipsoid`, :py:func:`~QgsProcessingContext.distanceUnit` and
+:py:func:`~QgsProcessingContext.areaUnit` to match the project's settings.
 
 .. seealso:: :py:func:`project`
 %End
@@ -105,6 +105,74 @@ Note that setting a project for the context will automatically set the coordinat
 context.
 
 .. seealso:: :py:func:`transformContext`
+%End
+
+    QString ellipsoid() const;
+%Docstring
+Returns the ellipsoid to use for distance and area calculations.
+
+.. seealso:: :py:func:`setEllipsoid`
+
+.. versionadded:: 3.16
+%End
+
+    void setEllipsoid( const QString &ellipsoid );
+%Docstring
+Sets a specified ``ellipsoid`` to use for distance and area calculations.
+
+If not explicitly set, the ellipsoid will default to the :py:func:`~QgsProcessingContext.project`'s ellipsoid setting.
+
+.. seealso:: :py:func:`ellipsoid`
+
+.. versionadded:: 3.16
+%End
+
+    QgsUnitTypes::DistanceUnit distanceUnit() const;
+%Docstring
+Returns the distance unit to use for distance calculations.
+
+.. seealso:: :py:func:`setDistanceUnit`
+
+.. seealso:: :py:func:`areaUnit`
+
+.. versionadded:: 3.16
+%End
+
+    void setDistanceUnit( QgsUnitTypes::DistanceUnit unit );
+%Docstring
+Sets the ``unit`` to use for distance calculations.
+
+If not explicitly set, the unit will default to the :py:func:`~QgsProcessingContext.project`'s distance unit setting.
+
+.. seealso:: :py:func:`distanceUnit`
+
+.. seealso:: :py:func:`setAreaUnit`
+
+.. versionadded:: 3.16
+%End
+
+    QgsUnitTypes::AreaUnit areaUnit() const;
+%Docstring
+Returns the area unit to use for area calculations.
+
+.. seealso:: :py:func:`setAreaUnit`
+
+.. seealso:: :py:func:`distanceUnit`
+
+.. versionadded:: 3.16
+%End
+
+    void setAreaUnit( QgsUnitTypes::AreaUnit areaUnit );
+%Docstring
+Sets the ``unit`` to use for area calculations.
+
+If not explicitly set, the unit will default to the :py:func:`~QgsProcessingContext.project`'s area unit setting.
+
+.. seealso:: :py:func:`areaUnit`
+
+.. seealso:: :py:func:`setDistanceUnit`
+
+.. versionadded:: 3.16
 %End
 
     QgsMapLayerStore *temporaryLayerStore();

--- a/python/plugins/processing/algs/qgis/EliminateSelection.py
+++ b/python/plugins/processing/algs/qgis/EliminateSelection.py
@@ -68,7 +68,7 @@ class EliminateSelection(QgisAlgorithm):
         super().__init__()
 
     def flags(self):
-        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading | QgsProcessingAlgorithm.FlagNotAvailableInStandaloneTool
 
     def initAlgorithm(self, config=None):
         self.modes = [self.tr('Largest Area'),

--- a/python/plugins/processing/algs/qgis/ExecuteSQL.py
+++ b/python/plugins/processing/algs/qgis/ExecuteSQL.py
@@ -133,7 +133,7 @@ class ExecuteSQL(QgisAlgorithm):
             # access (thanks the QgsVirtualLayerProvider) to memory layer that
             # belongs to temporary QgsMapLayerStore, not project.
             # So, we write them to disk is this is the case.
-            if not context.project().mapLayer(layer.id()):
+            if context.project() and not context.project().mapLayer(layer.id()):
                 basename = "memorylayer." + QgsVectorFileWriter.supportedFormatExtensions()[0]
                 tmp_path = QgsProcessingUtils.generateTempFilename(basename)
                 QgsVectorFileWriter.writeAsVectorFormat(

--- a/python/plugins/processing/algs/qgis/ExportGeometryInfo.py
+++ b/python/plugins/processing/algs/qgis/ExportGeometryInfo.py
@@ -43,7 +43,6 @@ from qgis.core import (NULL,
                        QgsProcessingParameterFeatureSink)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
-from processing.tools import vector
 
 pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
 

--- a/python/plugins/processing/algs/qgis/ExportGeometryInfo.py
+++ b/python/plugins/processing/algs/qgis/ExportGeometryInfo.py
@@ -138,7 +138,7 @@ class ExportGeometryInfo(QgisAlgorithm):
         self.distance_area = QgsDistanceArea()
         if method == 2:
             self.distance_area.setSourceCrs(source.sourceCrs(), context.transformContext())
-            self.distance_area.setEllipsoid(context.project().ellipsoid())
+            self.distance_area.setEllipsoid(context.ellipsoid())
         elif method == 1:
             coordTransform = QgsCoordinateTransform(source.sourceCrs(), context.project().crs(), context.project())
 

--- a/python/plugins/processing/algs/qgis/ExportGeometryInfo.py
+++ b/python/plugins/processing/algs/qgis/ExportGeometryInfo.py
@@ -139,6 +139,8 @@ class ExportGeometryInfo(QgisAlgorithm):
             self.distance_area.setSourceCrs(source.sourceCrs(), context.transformContext())
             self.distance_area.setEllipsoid(context.ellipsoid())
         elif method == 1:
+            if not context.project():
+                raise QgsProcessingException(self.tr('No project is available in this context'))
             coordTransform = QgsCoordinateTransform(source.sourceCrs(), context.project().crs(), context.project())
 
         features = source.getFeatures()

--- a/python/plugins/processing/algs/qgis/FieldsCalculator.py
+++ b/python/plugins/processing/algs/qgis/FieldsCalculator.py
@@ -106,11 +106,11 @@ class FieldsCalculator(QgisAlgorithm):
         expression = QgsExpression(formula)
         da = QgsDistanceArea()
         da.setSourceCrs(source.sourceCrs(), context.transformContext())
-        da.setEllipsoid(context.project().ellipsoid())
+        da.setEllipsoid(context.ellipsoid())
         expression.setGeomCalculator(da)
 
-        expression.setDistanceUnits(context.project().distanceUnits())
-        expression.setAreaUnits(context.project().areaUnits())
+        expression.setDistanceUnits(context.distanceUnit())
+        expression.setAreaUnits(context.areaUnit())
 
         fields = source.fields()
         field_index = fields.lookupField(field_name)

--- a/python/plugins/processing/algs/qgis/HubDistanceLines.py
+++ b/python/plugins/processing/algs/qgis/HubDistanceLines.py
@@ -121,7 +121,7 @@ class HubDistanceLines(QgisAlgorithm):
 
         distance = QgsDistanceArea()
         distance.setSourceCrs(point_source.sourceCrs(), context.transformContext())
-        distance.setEllipsoid(context.project().ellipsoid())
+        distance.setEllipsoid(context.ellipsoid())
 
         # Scan source points, find nearest hub, and write to output file
         features = point_source.getFeatures()

--- a/python/plugins/processing/algs/qgis/HubDistancePoints.py
+++ b/python/plugins/processing/algs/qgis/HubDistancePoints.py
@@ -118,7 +118,7 @@ class HubDistancePoints(QgisAlgorithm):
 
         distance = QgsDistanceArea()
         distance.setSourceCrs(point_source.sourceCrs(), context.transformContext())
-        distance.setEllipsoid(context.project().ellipsoid())
+        distance.setEllipsoid(context.ellipsoid())
 
         # Scan source points, find nearest hub, and write to output file
         features = point_source.getFeatures()

--- a/python/plugins/processing/algs/qgis/PointDistance.py
+++ b/python/plugins/processing/algs/qgis/PointDistance.py
@@ -180,7 +180,7 @@ class PointDistance(QgisAlgorithm):
 
         distArea = QgsDistanceArea()
         distArea.setSourceCrs(source.sourceCrs(), context.transformContext())
-        distArea.setEllipsoid(context.project().ellipsoid())
+        distArea.setEllipsoid(context.ellipsoid())
 
         features = source.getFeatures(QgsFeatureRequest().setSubsetOfAttributes([inIdx]))
         total = 100.0 / source.featureCount() if source.featureCount() else 0
@@ -235,7 +235,7 @@ class PointDistance(QgisAlgorithm):
 
         distArea = QgsDistanceArea()
         distArea.setSourceCrs(source.sourceCrs(), context.transformContext())
-        distArea.setEllipsoid(context.project().ellipsoid())
+        distArea.setEllipsoid(context.ellipsoid())
 
         inIdx = source.fields().lookupField(inField)
         targetIdx = target_source.fields().lookupField(targetField)

--- a/python/plugins/processing/algs/qgis/PointsToPaths.py
+++ b/python/plugins/processing/algs/qgis/PointsToPaths.py
@@ -156,7 +156,7 @@ class PointsToPaths(QgisAlgorithm):
 
         da = QgsDistanceArea()
         da.setSourceCrs(source.sourceCrs(), context.transformContext())
-        da.setEllipsoid(context.project().ellipsoid())
+        da.setEllipsoid(context.ellipsoid())
 
         current = 0
         total = 100.0 / len(points) if points else 1

--- a/python/plugins/processing/algs/qgis/PostGISExecuteAndLoadSQL.py
+++ b/python/plugins/processing/algs/qgis/PostGISExecuteAndLoadSQL.py
@@ -55,7 +55,7 @@ class PostGISExecuteAndLoadSQL(QgisAlgorithm):
         super().__init__()
 
     def flags(self):
-        return super().flags() | QgsProcessingAlgorithm.FlagNotAvailableInStandaloneTool
+        return super().flags() | QgsProcessingAlgorithm.FlagNotAvailableInStandaloneTool | QgsProcessingAlgorithm.FlagRequiresProject
 
     def initAlgorithm(self, config=None):
         db_param = QgsProcessingParameterProviderConnection(

--- a/python/plugins/processing/algs/qgis/PostGISExecuteAndLoadSQL.py
+++ b/python/plugins/processing/algs/qgis/PostGISExecuteAndLoadSQL.py
@@ -32,7 +32,8 @@ from qgis.core import (QgsProcessingException,
                        QgsProcessingContext,
                        QgsProcessingParameterProviderConnection,
                        QgsProviderRegistry,
-                       QgsProviderConnectionException
+                       QgsProviderConnectionException,
+                       QgsProcessingAlgorithm
                        )
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
@@ -52,6 +53,9 @@ class PostGISExecuteAndLoadSQL(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def flags(self):
+        return super().flags() | QgsProcessingAlgorithm.FlagNotAvailableInStandaloneTool
 
     def initAlgorithm(self, config=None):
         db_param = QgsProcessingParameterProviderConnection(

--- a/python/plugins/processing/algs/qgis/RandomPointsAlongLines.py
+++ b/python/plugins/processing/algs/qgis/RandomPointsAlongLines.py
@@ -110,7 +110,7 @@ class RandomPointsAlongLines(QgisAlgorithm):
 
         da = QgsDistanceArea()
         da.setSourceCrs(source.sourceCrs(), context.transformContext())
-        da.setEllipsoid(context.project().ellipsoid())
+        da.setEllipsoid(context.ellipsoid())
 
         request = QgsFeatureRequest()
 

--- a/python/plugins/processing/algs/qgis/RandomPointsPolygons.py
+++ b/python/plugins/processing/algs/qgis/RandomPointsPolygons.py
@@ -157,7 +157,7 @@ class RandomPointsPolygons(QgisAlgorithm):
 
         da = QgsDistanceArea()
         da.setSourceCrs(source.sourceCrs(), context.transformContext())
-        da.setEllipsoid(context.project().ellipsoid())
+        da.setEllipsoid(context.ellipsoid())
 
         total = 100.0 / source.featureCount() if source.featureCount() else 0
         current_progress = 0

--- a/python/plugins/processing/algs/qgis/RandomSelection.py
+++ b/python/plugins/processing/algs/qgis/RandomSelection.py
@@ -60,7 +60,7 @@ class RandomSelection(QgisAlgorithm):
         return 'vectorselection'
 
     def flags(self):
-        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading | QgsProcessingAlgorithm.FlagNotAvailableInStandaloneTool
 
     def __init__(self):
         super().__init__()

--- a/python/plugins/processing/algs/qgis/RandomSelectionWithinSubsets.py
+++ b/python/plugins/processing/algs/qgis/RandomSelectionWithinSubsets.py
@@ -66,7 +66,7 @@ class RandomSelectionWithinSubsets(QgisAlgorithm):
         super().__init__()
 
     def flags(self):
-        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading | QgsProcessingAlgorithm.FlagNotAvailableInStandaloneTool
 
     def initAlgorithm(self, config=None):
         self.methods = [self.tr('Number of selected features'),

--- a/python/plugins/processing/algs/qgis/RasterCalculator.py
+++ b/python/plugins/processing/algs/qgis/RasterCalculator.py
@@ -144,8 +144,9 @@ class RasterCalculator(QgisAlgorithm):
             expression = self.mappedNameToLayer(lyr, expression, layersDict, context)
 
         # check for layers available in the project
-        for lyr in QgsProcessingUtils.compatibleRasterLayers(context.project()):
-            expression = self.mappedNameToLayer(lyr, expression, layersDict, context)
+        if context.project():
+            for lyr in QgsProcessingUtils.compatibleRasterLayers(context.project()):
+                expression = self.mappedNameToLayer(lyr, expression, layersDict, context)
 
         # create the list of layers to be passed as inputs to RasterCalculaltor
         # at this phase expression has been modified to match available layers

--- a/python/plugins/processing/algs/qgis/RasterCalculator.py
+++ b/python/plugins/processing/algs/qgis/RasterCalculator.py
@@ -118,7 +118,7 @@ class RasterCalculator(QgisAlgorithm):
         if not bbox.isNull():
             bboxCrs = self.parameterAsExtentCrs(parameters, self.EXTENT, context)
             if bboxCrs != crs:
-                transform = QgsCoordinateTransform(bboxCrs, crs, context.project())
+                transform = QgsCoordinateTransform(bboxCrs, crs, context.transformContext())
                 bbox = transform.transformBoundingBox(bbox)
 
         if bbox.isNull() and layers:
@@ -131,7 +131,7 @@ class RasterCalculator(QgisAlgorithm):
         def _cellsize(layer):
             ext = layer.extent()
             if layer.crs() != crs:
-                transform = QgsCoordinateTransform(layer.crs(), crs, context.project())
+                transform = QgsCoordinateTransform(layer.crs(), crs, context.transformContext())
                 ext = transform.transformBoundingBox(ext)
             return (ext.xMaximum() - ext.xMinimum()) / layer.width()
 

--- a/python/plugins/processing/algs/qgis/SelectByAttribute.py
+++ b/python/plugins/processing/algs/qgis/SelectByAttribute.py
@@ -72,7 +72,7 @@ class SelectByAttribute(QgisAlgorithm):
         super().__init__()
 
     def flags(self):
-        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading | QgsProcessingAlgorithm.FlagNotAvailableInStandaloneTool
 
     def initAlgorithm(self, config=None):
         self.operators = ['=',

--- a/python/plugins/processing/algs/qgis/SelectByExpression.py
+++ b/python/plugins/processing/algs/qgis/SelectByExpression.py
@@ -48,7 +48,7 @@ class SelectByExpression(QgisAlgorithm):
         super().__init__()
 
     def flags(self):
-        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading | QgsProcessingAlgorithm.FlagNotAvailableInStandaloneTool
 
     def initAlgorithm(self, config=None):
         self.methods = [self.tr('creating new selection'),

--- a/python/plugins/processing/algs/qgis/SetRasterStyle.py
+++ b/python/plugins/processing/algs/qgis/SetRasterStyle.py
@@ -47,7 +47,7 @@ class SetRasterStyle(QgisAlgorithm):
         super().__init__()
 
     def flags(self):
-        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading | QgsProcessingAlgorithm.FlagDeprecated
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading | QgsProcessingAlgorithm.FlagDeprecated | QgsProcessingAlgorithm.FlagNotAvailableInStandaloneTool
 
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterRasterLayer(self.INPUT,

--- a/python/plugins/processing/algs/qgis/SetVectorStyle.py
+++ b/python/plugins/processing/algs/qgis/SetVectorStyle.py
@@ -43,7 +43,7 @@ class SetVectorStyle(QgisAlgorithm):
         super().__init__()
 
     def flags(self):
-        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading | QgsProcessingAlgorithm.FlagDeprecated
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading | QgsProcessingAlgorithm.FlagDeprecated | QgsProcessingAlgorithm.FlagNotAvailableInStandaloneTool
 
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterVectorLayer(self.INPUT,

--- a/python/plugins/processing/algs/qgis/TilesXYZ.py
+++ b/python/plugins/processing/algs/qgis/TilesXYZ.py
@@ -49,7 +49,8 @@ from qgis.core import (QgsProcessingException,
                        QgsMapRendererCustomPainterJob,
                        QgsLabelingEngineSettings,
                        QgsApplication,
-                       QgsExpressionContextUtils)
+                       QgsExpressionContextUtils,
+                       QgsProcessingAlgorithm)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -439,6 +440,9 @@ class TilesXYZAlgorithmMBTiles(TilesXYZAlgorithmBase):
 
     def groupId(self):
         return 'rastertools'
+
+    def flags(self):
+        return super().flags() | QgsProcessingAlgorithm.FlagRequiresProject
 
     def processAlgorithm(self, parameters, context, feedback):
         output_file = self.parameterAsString(parameters, self.OUTPUT_FILE, context)

--- a/src/analysis/processing/qgsalgorithmaggregate.cpp
+++ b/src/analysis/processing/qgsalgorithmaggregate.cpp
@@ -77,7 +77,7 @@ bool QgsAggregateAlgorithm::prepareAlgorithm( const QVariantMap &parameters, Qgs
   mGroupBy = parameterAsExpression( parameters, QStringLiteral( "GROUP_BY" ), context );
 
   mDa.setSourceCrs( mSource->sourceCrs(), context.transformContext() );
-  mDa.setEllipsoid( context.project()->ellipsoid() );
+  mDa.setEllipsoid( context.ellipsoid() );
 
   mGroupByExpression = createExpression( mGroupBy, context );
   mGeometryExpression = createExpression( QStringLiteral( "collect($geometry, %1)" ).arg( mGroupBy ), context );
@@ -278,8 +278,8 @@ QgsExpression QgsAggregateAlgorithm::createExpression( const QString &expression
 {
   QgsExpression expr( expressionString );
   expr.setGeomCalculator( &mDa );
-  expr.setDistanceUnits( context.project()->distanceUnits() );
-  expr.setAreaUnits( context.project()->areaUnits() );
+  expr.setDistanceUnits( context.distanceUnit() );
+  expr.setAreaUnits( context.areaUnit() );
   if ( expr.hasParserError() )
   {
     throw QgsProcessingException(

--- a/src/analysis/processing/qgsalgorithmcalculateoverlaps.cpp
+++ b/src/analysis/processing/qgsalgorithmcalculateoverlaps.cpp
@@ -127,7 +127,7 @@ QVariantMap QgsCalculateVectorOverlapsAlgorithm::processAlgorithm( const QVarian
 
   QgsDistanceArea da;
   da.setSourceCrs( mCrs, context.transformContext() );
-  da.setEllipsoid( context.project()->ellipsoid() );
+  da.setEllipsoid( context.ellipsoid() );
 
   // loop through input
   double step = mInputCount > 0 ? 100.0 / mInputCount : 0;

--- a/src/analysis/processing/qgsalgorithmcategorizeusingstyle.cpp
+++ b/src/analysis/processing/qgsalgorithmcategorizeusingstyle.cpp
@@ -51,6 +51,13 @@ void QgsCategorizeUsingStyleAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( failSymbols.release() );
 }
 
+QgsProcessingAlgorithm::Flags QgsCategorizeUsingStyleAlgorithm::flags() const
+{
+  Flags f = QgsProcessingAlgorithm::flags();
+  f |= FlagNotAvailableInStandaloneTool;
+  return f;
+}
+
 QString QgsCategorizeUsingStyleAlgorithm::name() const
 {
   return QStringLiteral( "categorizeusingstyle" );

--- a/src/analysis/processing/qgsalgorithmcategorizeusingstyle.h
+++ b/src/analysis/processing/qgsalgorithmcategorizeusingstyle.h
@@ -38,6 +38,7 @@ class QgsCategorizeUsingStyleAlgorithm : public QgsProcessingAlgorithm
     QgsCategorizeUsingStyleAlgorithm();
     ~QgsCategorizeUsingStyleAlgorithm() override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmextractbylocation.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbylocation.cpp
@@ -369,7 +369,7 @@ QString QgsSelectByLocationAlgorithm::name() const
 
 QgsProcessingAlgorithm::Flags QgsSelectByLocationAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagNoThreading;
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagNoThreading | QgsProcessingAlgorithm::FlagNotAvailableInStandaloneTool;
 }
 
 QString QgsSelectByLocationAlgorithm::displayName() const

--- a/src/analysis/processing/qgsalgorithmjoinwithlines.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinwithlines.cpp
@@ -143,7 +143,7 @@ QVariantMap QgsJoinWithLinesAlgorithm::processAlgorithm( const QVariantMap &para
   const bool splitAntimeridian = parameterAsBoolean( parameters, QStringLiteral( "ANTIMERIDIAN_SPLIT" ), context );
   QgsDistanceArea da;
   da.setSourceCrs( hubSource->sourceCrs(), context.transformContext() );
-  da.setEllipsoid( context.project()->ellipsoid() );
+  da.setEllipsoid( context.ellipsoid() );
 
   QgsFields hubOutFields;
   QgsAttributeList hubFieldIndices;

--- a/src/analysis/processing/qgsalgorithmlinedensity.cpp
+++ b/src/analysis/processing/qgsalgorithmlinedensity.cpp
@@ -91,13 +91,8 @@ bool QgsLineDensityAlgorithm::prepareAlgorithm( const QVariantMap &parameters, Q
   mExtent = mSource->sourceExtent();
   mCrs = mSource->sourceCrs();
   mDa = QgsDistanceArea();
-
-  if ( context.project() )
-  {
-    mDa.setEllipsoid( context.project()->ellipsoid() );
-  }
+  mDa.setEllipsoid( context.ellipsoid() );
   mDa.setSourceCrs( mCrs, context.transformContext() );
-
 
   //get cell midpoint from top left cell
   QgsPoint firstCellMidpoint = QgsPoint( mExtent.xMinimum() + ( mPixelSize / 2 ), mExtent.yMaximum() - ( mPixelSize / 2 ) );

--- a/src/analysis/processing/qgsalgorithmloadlayer.cpp
+++ b/src/analysis/processing/qgsalgorithmloadlayer.cpp
@@ -26,7 +26,7 @@ QString QgsLoadLayerAlgorithm::name() const
 
 QgsProcessingAlgorithm::Flags QgsLoadLayerAlgorithm::flags() const
 {
-  return FlagHideFromToolbox;
+  return FlagHideFromToolbox | FlagNotAvailableInStandaloneTool;
 }
 
 QString QgsLoadLayerAlgorithm::displayName() const

--- a/src/analysis/processing/qgsalgorithmnearestneighbouranalysis.cpp
+++ b/src/analysis/processing/qgsalgorithmnearestneighbouranalysis.cpp
@@ -89,7 +89,7 @@ QVariantMap QgsNearestNeighbourAnalysisAlgorithm::processAlgorithm( const QVaria
   QgsSpatialIndex spatialIndex( *source, feedback, QgsSpatialIndex::FlagStoreFeatureGeometries );
   QgsDistanceArea da;
   da.setSourceCrs( source->sourceCrs(), context.transformContext() );
-  da.setEllipsoid( context.project()->ellipsoid() );
+  da.setEllipsoid( context.ellipsoid() );
 
   double step = source->featureCount() ? 100.0 / source->featureCount() : 1;
   QgsFeatureIterator it = source->getFeatures( QgsFeatureRequest().setSubsetOfAttributes( QList< int >() ) );

--- a/src/analysis/processing/qgsalgorithmnetworkanalysisbase.cpp
+++ b/src/analysis/processing/qgsalgorithmnetworkanalysisbase.cpp
@@ -37,6 +37,12 @@ QString QgsNetworkAnalysisAlgorithmBase::groupId() const
   return QStringLiteral( "networkanalysis" );
 }
 
+QgsProcessingAlgorithm::Flags QgsNetworkAnalysisAlgorithmBase::flags() const
+{
+  // TODO -- remove the dependancy on the project from these algorithms, it shouldn't be required
+  return QgsProcessingAlgorithm::flags() | FlagRequiresProject;
+}
+
 void QgsNetworkAnalysisAlgorithmBase::addCommonParams()
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Vector layer representing network" ), QList< int >() << QgsProcessing::TypeVectorLine ) );

--- a/src/analysis/processing/qgsalgorithmnetworkanalysisbase.h
+++ b/src/analysis/processing/qgsalgorithmnetworkanalysisbase.h
@@ -41,6 +41,7 @@ class QgsNetworkAnalysisAlgorithmBase : public QgsProcessingAlgorithm
     QString groupId() const final;
     QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/algorithms/mAlgorithmNetworkAnalysis.svg" ) ); }
     QString svgIconPath() const override { return QgsApplication::iconPath( QStringLiteral( "/algorithms/mAlgorithmNetworkAnalysis.svg" ) ); }
+    Flags flags() const override;
 
   protected:
 

--- a/src/analysis/processing/qgsalgorithmrasterize.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterize.cpp
@@ -49,6 +49,11 @@ QStringList QgsRasterizeAlgorithm::tags() const
   return QObject::tr( "layer,raster,convert,file,map themes,tiles,render" ).split( ',' );
 }
 
+QgsProcessingAlgorithm::Flags QgsRasterizeAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | FlagRequiresProject;
+}
+
 QString QgsRasterizeAlgorithm::group() const
 {
   return QObject::tr( "Raster tools" );

--- a/src/analysis/processing/qgsalgorithmrasterize.h
+++ b/src/analysis/processing/qgsalgorithmrasterize.h
@@ -43,6 +43,7 @@ class QgsRasterizeAlgorithm : public QgsProcessingAlgorithm
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;
+    Flags flags() const override;
     QString group() const override;
     QString groupId() const override;
     QString shortHelpString() const override;

--- a/src/analysis/processing/qgsalgorithmrefactorfields.cpp
+++ b/src/analysis/processing/qgsalgorithmrefactorfields.cpp
@@ -94,7 +94,7 @@ bool QgsRefactorFieldsAlgorithm::prepareAlgorithm( const QVariantMap &parameters
     throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "INPUT" ) ) );
 
   mDa.setSourceCrs( source->sourceCrs(), context.transformContext() );
-  mDa.setEllipsoid( context.project()->ellipsoid() );
+  mDa.setEllipsoid( context.ellipsoid() );
 
   mExpressionContext = createExpressionContext( parameters, context, source.get() );
 
@@ -118,11 +118,8 @@ bool QgsRefactorFieldsAlgorithm::prepareAlgorithm( const QVariantMap &parameters
     {
       QgsExpression expression( expressionString );
       expression.setGeomCalculator( &mDa );
-      if ( context.project() )
-      {
-        expression.setDistanceUnits( context.project()->distanceUnits() );
-        expression.setAreaUnits( context.project()->areaUnits() );
-      }
+      expression.setDistanceUnits( context.distanceUnit() );
+      expression.setAreaUnits( context.areaUnit() );
       if ( expression.hasParserError() )
       {
         throw QgsProcessingException( QObject::tr( "Parser error for field \"%1\" with expression \"%2\": %3" )

--- a/src/analysis/processing/qgsalgorithmsetvariable.cpp
+++ b/src/analysis/processing/qgsalgorithmsetvariable.cpp
@@ -27,7 +27,9 @@ QString QgsSetProjectVariableAlgorithm::name() const
 
 QgsProcessingAlgorithm::Flags QgsSetProjectVariableAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::FlagHideFromToolbox | QgsProcessingAlgorithm::FlagSkipGenericModelLogging;
+  return QgsProcessingAlgorithm::FlagHideFromToolbox
+         | QgsProcessingAlgorithm::FlagSkipGenericModelLogging
+         | QgsProcessingAlgorithm::FlagNotAvailableInStandaloneTool;
 }
 
 QString QgsSetProjectVariableAlgorithm::displayName() const

--- a/src/analysis/processing/qgsalgorithmsplitlineantimeridian.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitlineantimeridian.cpp
@@ -100,11 +100,7 @@ QgsCoordinateReferenceSystem QgsSplitGeometryAtAntimeridianAlgorithm::outputCrs(
 
 bool QgsSplitGeometryAtAntimeridianAlgorithm::prepareAlgorithm( const QVariantMap &, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
-  if ( context.project() )
-  {
-    mDa.setEllipsoid( context.project()->ellipsoid() );
-  }
-
+  mDa.setEllipsoid( context.ellipsoid() );
   mTransformContext = context.transformContext();
   return true;
 }

--- a/src/analysis/processing/qgsalgorithmsumlinelength.cpp
+++ b/src/analysis/processing/qgsalgorithmsumlinelength.cpp
@@ -128,10 +128,7 @@ bool QgsSumLineLengthAlgorithm::prepareAlgorithm( const QVariantMap &parameters,
   if ( mLinesSource->hasSpatialIndex() == QgsFeatureSource::SpatialIndexNotPresent )
     feedback->reportError( QObject::tr( "No spatial index exists for lines layer, performance will be severely degraded" ) );
 
-  if ( context.project() )
-  {
-    mDa.setEllipsoid( context.project()->ellipsoid() );
-  }
+  mDa.setEllipsoid( context.ellipsoid() );
   mTransformContext = context.transformContext();
 
   return true;

--- a/src/analysis/processing/qgsbookmarkalgorithms.cpp
+++ b/src/analysis/processing/qgsbookmarkalgorithms.cpp
@@ -93,7 +93,11 @@ bool QgsBookmarksToLayerAlgorithm::prepareAlgorithm( const QVariantMap &paramete
 {
   QList< int > sources = parameterAsEnums( parameters, QStringLiteral( "SOURCE" ), context );
   if ( sources.contains( 0 ) )
+  {
+    if ( !context.project() )
+      throw QgsProcessingException( QObject::tr( "No project is available for bookmark extraction" ) );
     mBookmarks.append( context.project()->bookmarkManager()->bookmarks() );
+  }
   if ( sources.contains( 1 ) )
     mBookmarks.append( QgsApplication::bookmarkManager()->bookmarks() );
 

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -79,6 +79,7 @@ class CORE_EXPORT QgsProcessingAlgorithm
       FlagCustomException = 1 << 10, //!< Algorithm raises custom exception notices, don't use the standard ones
       FlagPruneModelBranchesBasedOnAlgorithmResults = 1 << 11, //!< Algorithm results will cause remaining model branches to be pruned based on the results of running the algorithm
       FlagSkipGenericModelLogging = 1 << 12, //!< When running as part of a model, the generic algorithm setup and results logging should be skipped
+      FlagNotAvailableInStandaloneTool = 1 << 13, //!< Algorithm should not be available from the standalone "qgis_process" tool. Used to flag algorithms which make no sense outside of the QGIS application, such as "select by..." style algorithms.
       FlagDeprecated = FlagHideFromToolbox | FlagHideFromModeler, //!< Algorithm is deprecated
     };
     Q_DECLARE_FLAGS( Flags, Flag )

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -80,6 +80,7 @@ class CORE_EXPORT QgsProcessingAlgorithm
       FlagPruneModelBranchesBasedOnAlgorithmResults = 1 << 11, //!< Algorithm results will cause remaining model branches to be pruned based on the results of running the algorithm
       FlagSkipGenericModelLogging = 1 << 12, //!< When running as part of a model, the generic algorithm setup and results logging should be skipped
       FlagNotAvailableInStandaloneTool = 1 << 13, //!< Algorithm should not be available from the standalone "qgis_process" tool. Used to flag algorithms which make no sense outside of the QGIS application, such as "select by..." style algorithms.
+      FlagRequiresProject = 1 << 14, //!< The algorithm requires that a valid QgsProject is available from the processing context in order to execute
       FlagDeprecated = FlagHideFromToolbox | FlagHideFromModeler, //!< Algorithm is deprecated
     };
     Q_DECLARE_FLAGS( Flags, Flag )

--- a/src/core/processing/qgsprocessingcontext.cpp
+++ b/src/core/processing/qgsprocessingcontext.cpp
@@ -110,7 +110,35 @@ QgsMapLayer *QgsProcessingContext::takeResultLayer( const QString &id )
   return tempLayerStore.takeMapLayer( tempLayerStore.mapLayer( id ) );
 }
 
+QString QgsProcessingContext::ellipsoid() const
+{
+  return mEllipsoid;
+}
 
+void QgsProcessingContext::setEllipsoid( const QString &ellipsoid )
+{
+  mEllipsoid = ellipsoid;
+}
+
+QgsUnitTypes::DistanceUnit QgsProcessingContext::distanceUnit() const
+{
+  return mDistanceUnit;
+}
+
+void QgsProcessingContext::setDistanceUnit( QgsUnitTypes::DistanceUnit unit )
+{
+  mDistanceUnit = unit;
+}
+
+QgsUnitTypes::AreaUnit QgsProcessingContext::areaUnit() const
+{
+  return mAreaUnit;
+}
+
+void QgsProcessingContext::setAreaUnit( QgsUnitTypes::AreaUnit areaUnit )
+{
+  mAreaUnit = areaUnit;
+}
 
 QgsProcessingLayerPostProcessorInterface *QgsProcessingContext::LayerDetails::postProcessor() const
 {

--- a/src/core/processing/qgsprocessingcontext.h
+++ b/src/core/processing/qgsprocessingcontext.h
@@ -78,6 +78,11 @@ class CORE_EXPORT QgsProcessingContext
       mTransformErrorCallback = other.mTransformErrorCallback;
       mDefaultEncoding = other.mDefaultEncoding;
       mFeedback = other.mFeedback;
+      mPreferredVectorFormat = other.mPreferredVectorFormat;
+      mPreferredRasterFormat = other.mPreferredRasterFormat;
+      mEllipsoid = other.mEllipsoid;
+      mDistanceUnit = other.mDistanceUnit;
+      mAreaUnit = other.mAreaUnit;
     }
 
     /**
@@ -101,8 +106,8 @@ class CORE_EXPORT QgsProcessingContext
     /**
      * Sets the \a project in which the algorithm will be executed.
      *
-     * This also automatically sets the transformContext() to match
-     * the project's transform context.
+     * This also automatically sets the transformContext(), ellipsoid(), distanceUnit() and
+     * areaUnit() to match the project's settings.
      *
      * \see project()
      */
@@ -110,7 +115,15 @@ class CORE_EXPORT QgsProcessingContext
     {
       mProject = project;
       if ( mProject )
+      {
         mTransformContext = mProject->transformContext();
+        if ( mEllipsoid.isEmpty() )
+          mEllipsoid = mProject->ellipsoid();
+        if ( mDistanceUnit == QgsUnitTypes::DistanceUnknownUnit )
+          mDistanceUnit = mProject->distanceUnits();
+        if ( mAreaUnit == QgsUnitTypes::AreaUnknownUnit )
+          mAreaUnit = mProject->areaUnits();
+      }
     }
 
     /**
@@ -143,6 +156,64 @@ class CORE_EXPORT QgsProcessingContext
      * \see transformContext()
      */
     void setTransformContext( const QgsCoordinateTransformContext &context ) { mTransformContext = context; }
+
+    /**
+     * Returns the ellipsoid to use for distance and area calculations.
+     *
+     * \see setEllipsoid()
+     * \since QGIS 3.16
+     */
+    QString ellipsoid() const;
+
+    /**
+     * Sets a specified \a ellipsoid to use for distance and area calculations.
+     *
+     * If not explicitly set, the ellipsoid will default to the project()'s ellipsoid setting.
+     *
+     * \see ellipsoid()
+     * \since QGIS 3.16
+     */
+    void setEllipsoid( const QString &ellipsoid );
+
+    /**
+     * Returns the distance unit to use for distance calculations.
+     *
+     * \see setDistanceUnit()
+     * \see areaUnit()
+     * \since QGIS 3.16
+     */
+    QgsUnitTypes::DistanceUnit distanceUnit() const;
+
+    /**
+     * Sets the \a unit to use for distance calculations.
+     *
+     * If not explicitly set, the unit will default to the project()'s distance unit setting.
+     *
+     * \see distanceUnit()
+     * \see setAreaUnit()
+     * \since QGIS 3.16
+     */
+    void setDistanceUnit( QgsUnitTypes::DistanceUnit unit );
+
+    /**
+     * Returns the area unit to use for area calculations.
+     *
+     * \see setAreaUnit()
+     * \see distanceUnit()
+     * \since QGIS 3.16
+     */
+    QgsUnitTypes::AreaUnit areaUnit() const;
+
+    /**
+     * Sets the \a unit to use for area calculations.
+     *
+     * If not explicitly set, the unit will default to the project()'s area unit setting.
+     *
+     * \see areaUnit()
+     * \see setDistanceUnit()
+     * \since QGIS 3.16
+     */
+    void setAreaUnit( QgsUnitTypes::AreaUnit areaUnit );
 
     /**
      * Returns a reference to the layer store used for storing temporary layers during
@@ -535,6 +606,11 @@ class CORE_EXPORT QgsProcessingContext
     QgsProcessingContext::Flags mFlags = QgsProcessingContext::Flags();
     QPointer< QgsProject > mProject;
     QgsCoordinateTransformContext mTransformContext;
+
+    QString mEllipsoid;
+    QgsUnitTypes::DistanceUnit mDistanceUnit = QgsUnitTypes::DistanceUnknownUnit;
+    QgsUnitTypes::AreaUnit mAreaUnit = QgsUnitTypes::AreaUnknownUnit;
+
     //! Temporary project owned by the context, used for storing temporarily loaded map layers
     QgsMapLayerStore tempLayerStore;
     QgsExpressionContext mExpressionContext;

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -459,6 +459,20 @@ int QgsProcessingExec::execute( const QString &id, const QVariantMap &params, co
       std::cerr << QStringLiteral( "The \"%1\" algorithm is not available for use outside of the QGIS desktop application\n" ).arg( id ).toLocal8Bit().constData();
       return 1;
     }
+
+    if ( alg->flags() & QgsProcessingAlgorithm::FlagKnownIssues )
+    {
+      std::cout << "\n****************\n";
+      std::cout << "Warning: this algorithm contains known issues and the results may be unreliable!\n";
+      std::cout << "****************\n\n";
+    }
+
+    if ( alg->flags() & QgsProcessingAlgorithm::FlagDeprecated )
+    {
+      std::cout << "\n****************\n";
+      std::cout << "Warning: this algorithm is deprecated and may be removed in a future QGIS version!\n";
+      std::cout << "****************\n\n";
+    }
   }
 
   std::cout << "\n----------------\n";

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -26,6 +26,7 @@
 #include "qgsapplication.h"
 #include "qgsprocessingparametertype.h"
 #include "processing/models/qgsprocessingmodelalgorithm.h"
+#include "qgsproject.h"
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_ANDROID)
 #include "sigwatch.h"
@@ -219,6 +220,7 @@ int QgsProcessingExec::run( const QStringList &args )
     QString ellipsoid;
     QgsUnitTypes::DistanceUnit distanceUnit = QgsUnitTypes::DistanceUnknownUnit;
     QgsUnitTypes::AreaUnit areaUnit = QgsUnitTypes::AreaUnknownUnit;
+    QString projectPath;
     QVariantMap params;
     for ( int i = 3; i < args.count(); i++ )
     {
@@ -243,6 +245,10 @@ int QgsProcessingExec::run( const QStringList &args )
         {
           areaUnit = QgsUnitTypes::decodeAreaUnit( parts.mid( 1 ).join( '=' ) );
         }
+        else if ( name.compare( QLatin1String( "project_path" ), Qt::CaseInsensitive ) == 0 )
+        {
+          projectPath = parts.mid( 1 ).join( '=' );
+        }
         else
         {
           const QString value = parts.mid( 1 ).join( '=' );
@@ -256,7 +262,7 @@ int QgsProcessingExec::run( const QStringList &args )
       }
     }
 
-    return execute( algId, params, ellipsoid, distanceUnit, areaUnit );
+    return execute( algId, params, ellipsoid, distanceUnit, areaUnit, projectPath );
   }
   else
   {
@@ -276,8 +282,9 @@ void QgsProcessingExec::showUsage( const QString &appName )
       << "\tplugins\tlist available and active plugins\n"
       << "\tlist\tlist all available processing algorithms\n"
       << "\thelp\tshow help for an algorithm. The algorithm id or a path to a model file must be specified.\n"
-      << "\trun\truns an algorithm. The algorithm id or a path to a model file and parameter values must be specified. Parameter values are specified via the --PARAMETER=VALUE syntax. "
-      "If required, the ellipsoid to use for distance and area calculations can be specified via the \"--ELLIPSOID=name\" argument.\n";
+      << "\trun\truns an algorithm. The algorithm id or a path to a model file and parameter values must be specified. Parameter values are specified via the --PARAMETER=VALUE syntax.\n"
+      << "\t\tIf required, the ellipsoid to use for distance and area calculations can be specified via the \"--ELLIPSOID=name\" argument.\n"
+      << "\t\tIf required, an existing QGIS project to use during the algorithm execution can be specified via the \"--PROJECT_PATH=path\" argument.\n";
 
   std::cout << msg.join( QString() ).toLocal8Bit().constData();
 }
@@ -430,7 +437,7 @@ int QgsProcessingExec::showAlgorithmHelp( const QString &id )
   return 0;
 }
 
-int QgsProcessingExec::execute( const QString &id, const QVariantMap &params, const QString &ellipsoid, QgsUnitTypes::DistanceUnit distanceUnit, QgsUnitTypes::AreaUnit areaUnit )
+int QgsProcessingExec::execute( const QString &id, const QVariantMap &params, const QString &ellipsoid, QgsUnitTypes::DistanceUnit distanceUnit, QgsUnitTypes::AreaUnit areaUnit, const QString &projectPath )
 {
   std::unique_ptr< QgsProcessingModelAlgorithm > model;
   const QgsProcessingAlgorithm *alg = nullptr;
@@ -473,6 +480,23 @@ int QgsProcessingExec::execute( const QString &id, const QVariantMap &params, co
       std::cout << "Warning: this algorithm is deprecated and may be removed in a future QGIS version!\n";
       std::cout << "****************\n\n";
     }
+
+    if ( alg->flags() & QgsProcessingAlgorithm::FlagRequiresProject && projectPath.isEmpty() )
+    {
+      std::cerr << QStringLiteral( "The \"%1\" algorithm requires a QGIS project to execute. Specify a path to an existing project with the \"--PROJECT_PATH=xxx\" argument.\n" ).arg( id ).toLocal8Bit().constData();
+      return 1;
+    }
+  }
+
+  std::unique_ptr< QgsProject > project;
+  if ( !projectPath.isEmpty() )
+  {
+    project = qgis::make_unique< QgsProject >();
+    if ( !project->read( projectPath ) )
+    {
+      std::cerr << QStringLiteral( "Could not load the QGIS project \"%1\"\n" ).arg( projectPath ).toLocal8Bit().constData();
+      return 1;
+    }
   }
 
   std::cout << "\n----------------\n";
@@ -496,6 +520,7 @@ int QgsProcessingExec::execute( const QString &id, const QVariantMap &params, co
   context.setEllipsoid( ellipsoid );
   context.setDistanceUnit( distanceUnit );
   context.setAreaUnit( areaUnit );
+  context.setProject( project.get() );
 
   const QgsProcessingParameterDefinitions defs = alg->parameterDefinitions();
   QList< const QgsProcessingParameterDefinition * > missingParams;

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -314,6 +314,9 @@ void QgsProcessingExec::listAlgorithms()
     const QList<const QgsProcessingAlgorithm *> algorithms = provider->algorithms();
     for ( const QgsProcessingAlgorithm *algorithm : algorithms )
     {
+      if ( algorithm->flags() & QgsProcessingAlgorithm::FlagDeprecated || algorithm->flags() & QgsProcessingAlgorithm::FlagNotAvailableInStandaloneTool )
+        continue;
+
       std::cout << "\t" << algorithm->id().toLocal8Bit().constData() << "\t" << algorithm->displayName().toLocal8Bit().constData() << "\n";
     }
 
@@ -448,6 +451,12 @@ int QgsProcessingExec::execute( const QString &id, const QVariantMap &params, co
     if ( ! alg )
     {
       std::cerr << QStringLiteral( "Algorithm %1 not found!\n" ).arg( id ).toLocal8Bit().constData();
+      return 1;
+    }
+
+    if ( alg->flags() & QgsProcessingAlgorithm::FlagNotAvailableInStandaloneTool )
+    {
+      std::cerr << QStringLiteral( "The \"%1\" algorithm is not available for use outside of the QGIS desktop application\n" ).arg( id ).toLocal8Bit().constData();
       return 1;
     }
   }

--- a/src/process/qgsprocess.h
+++ b/src/process/qgsprocess.h
@@ -20,6 +20,7 @@
 #include "qgsprocessingfeedback.h"
 #include "qgspythonrunner.h"
 #include "qgspythonutils.h"
+#include "qgsunittypes.h"
 #include <QElapsedTimer>
 
 class QgsApplication;
@@ -68,7 +69,7 @@ class QgsProcessingExec
     void listAlgorithms();
     void listPlugins();
     int showAlgorithmHelp( const QString &id );
-    int execute( const QString &algId, const QVariantMap &parameters );
+    int execute( const QString &algId, const QVariantMap &parameters, const QString &ellipsoid, QgsUnitTypes::DistanceUnit distanceUnit, QgsUnitTypes::AreaUnit areaUnit );
 
     std::unique_ptr< QgsPythonUtils > mPythonUtils;
     std::unique_ptr<QgsPythonUtils> loadPythonSupport();

--- a/src/process/qgsprocess.h
+++ b/src/process/qgsprocess.h
@@ -69,7 +69,12 @@ class QgsProcessingExec
     void listAlgorithms();
     void listPlugins();
     int showAlgorithmHelp( const QString &id );
-    int execute( const QString &algId, const QVariantMap &parameters, const QString &ellipsoid, QgsUnitTypes::DistanceUnit distanceUnit, QgsUnitTypes::AreaUnit areaUnit );
+    int execute( const QString &algId,
+                 const QVariantMap &parameters,
+                 const QString &ellipsoid,
+                 QgsUnitTypes::DistanceUnit distanceUnit,
+                 QgsUnitTypes::AreaUnit areaUnit,
+                 const QString &projectPath = QString() );
 
     std::unique_ptr< QgsPythonUtils > mPythonUtils;
     std::unique_ptr<QgsPythonUtils> loadPythonSupport();

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -961,6 +961,7 @@ void TestQgsProcessing::context()
   QCOMPARE( context.areaUnit(), QgsUnitTypes::AreaUnknownUnit );
 
   QgsProject p;
+  p.setCrs( QgsCoordinateReferenceSystem( "EPSG:4536" ) );
   p.setEllipsoid( QStringLiteral( "WGS84" ) );
   p.setDistanceUnits( QgsUnitTypes::DistanceFeet );
   p.setAreaUnits( QgsUnitTypes::AreaHectares );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -956,9 +956,28 @@ void TestQgsProcessing::context()
   context.setFlags( QgsProcessingContext::Flags( nullptr ) );
   QCOMPARE( context.flags(), QgsProcessingContext::Flags( nullptr ) );
 
+  QCOMPARE( context.ellipsoid(), QString() );
+  QCOMPARE( context.distanceUnit(), QgsUnitTypes::DistanceUnknownUnit );
+  QCOMPARE( context.areaUnit(), QgsUnitTypes::AreaUnknownUnit );
+
   QgsProject p;
+  p.setEllipsoid( QStringLiteral( "WGS84" ) );
+  p.setDistanceUnits( QgsUnitTypes::DistanceFeet );
+  p.setAreaUnits( QgsUnitTypes::AreaHectares );
   context.setProject( &p );
   QCOMPARE( context.project(), &p );
+  QCOMPARE( context.ellipsoid(), QStringLiteral( "WGS84" ) );
+  QCOMPARE( context.distanceUnit(), QgsUnitTypes::DistanceFeet );
+  QCOMPARE( context.areaUnit(), QgsUnitTypes::AreaHectares );
+
+  // if context ellipsoid/units are already set then setting the project shouldn't overwrite them
+  p.setEllipsoid( QStringLiteral( "WGS84v2" ) );
+  p.setDistanceUnits( QgsUnitTypes::DistanceMiles );
+  p.setAreaUnits( QgsUnitTypes::AreaAcres );
+  context.setProject( &p );
+  QCOMPARE( context.ellipsoid(), QStringLiteral( "WGS84" ) );
+  QCOMPARE( context.distanceUnit(), QgsUnitTypes::DistanceFeet );
+  QCOMPARE( context.areaUnit(), QgsUnitTypes::AreaHectares );
 
   context.setInvalidGeometryCheck( QgsFeatureRequest::GeometrySkipInvalid );
   QCOMPARE( context.invalidGeometryCheck(), QgsFeatureRequest::GeometrySkipInvalid );


### PR DESCRIPTION
- Add explicit settings for ellipsoid/distance unit/area unit to QgsProcessingContext, and prefer to use these instead of trying to get the settings from a QgsProject (which isn't available from the standalone tool).
- Expose a new argument to allow users to specify "--ELLIPSOID=xxxx" when running algorithms via the qgis_process tool.
- Flags algorithms which make no sense to run outside of the GUI environment (such as "select by ..." algorithms), and hides/prevents them from running via qgis_process.
- Also warns when running deprecated or algorithms with known issues from qgis_process
- Flags algorithms which require a valid project to execute so that errors are raised when running these from qgis_process, unless the new "--PROJECT_PATH=xxxx" argument is specified and pointing to a valid project path.

Fixes #37988