### PR TITLE
[locator] Add user locale handling to the goto locator

### DIFF
--- a/tests/src/app/testqgsapplocatorfilters.cpp
+++ b/tests/src/app/testqgsapplocatorfilters.cpp
@@ -277,13 +277,19 @@ void TestQgsAppLocatorFilters::testGoto()
 {
   QgsGotoLocatorFilter filter;
 
-  // goto X,Y
+  // simple goto
   QList< QgsLocatorResult > results = gatherResults( &filter, QStringLiteral( "4 5" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 2 );
   QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 4 5 (Map CRS, )" ) );
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 4, 5 ) );
   QCOMPARE( results.at( 1 ).displayString, QObject::tr( "Go to 4° 5° (EPSG:4326 - WGS 84)" ) );
   QCOMPARE( results.at( 1 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 4, 5 ) );
+
+  // locale-specific goto
+  results = gatherResults( &filter, QStringLiteral( "1,234.56 789.012" ), QgsLocatorContext() );
+  QCOMPARE( results.count(), 1 );
+  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 1,234.56 789.012 (Map CRS, )" ) );
+  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 1234.56, 789.012 ) );
 
   // OSM/Leaflet/OpenLayers
   results = gatherResults( &filter, QStringLiteral( "https://www.openstreetmap.org/#map=15/44.5546/6.4936" ), QgsLocatorContext() );


### PR DESCRIPTION
## Description

This allows users to type in coordinate using their locale's decimal separator. E.g., for French Canadian, the following lon lat string will now work: `104,1234 11,1234`.

Locale awareness also means coordinates with a comma as thousand separator will work too. For e.g., this UTM coordinate would work just fine: `456,789.1 1,234,567.2`.