### PR TITLE
[delimitedtext] Don't use an out of range index while reading string buffer (fixes a Qt warning)

### DIFF
--- a/src/providers/delimitedtext/qgsdelimitedtextfile.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfile.cpp
@@ -764,11 +764,8 @@ QgsDelimitedTextFile::Status QgsDelimitedTextFile::parseQuoted( QString &buffer,
 
   while ( true )
   {
-    QChar c = buffer[cp];
-    cp++;
-
     // If end of line then if escaped or buffered then try to get more...
-    if ( cp > cpmax )
+    if ( cp >= cpmax )
     {
       if ( quoted || escaped )
       {
@@ -786,6 +783,9 @@ QgsDelimitedTextFile::Status QgsDelimitedTextFile::parseQuoted( QString &buffer,
       }
       break;
     }
+
+    QChar c = buffer[cp];
+    cp++;
 
     // If escaped, then just append the character
     if ( escaped )


### PR DESCRIPTION
## Description

Qt warning this PR fixes:

`Warning: Using QCharRef with an index pointing outside the valid range of a QString. The corresponding behavior is deprecated, and will be changed in a future version of Qt.`
