### PR TITLE
Don't try to update raster min/max settings when a raster layer is set to Updated Canvas mode and is being rendered in a 3d map

### DIFF
--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -346,6 +346,7 @@ Gets color that is used for drawing of selected vector features
       RenderPreviewJob,
       RenderBlocking,
       LosslessImageRendering,
+      Render3DMap,
       // TODO: ignore scale-based visibility (overview)
     };
     typedef QFlags<QgsMapSettings::Flag> Flags;

--- a/python/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/core/auto_generated/qgsrendercontext.sip.in
@@ -46,6 +46,7 @@ to be rendered etc.
       RenderSymbolPreview,
       LosslessImageRendering,
       ApplyScalingWorkaroundForTextRendering,
+      Render3DMap,
     };
     typedef QFlags<QgsRenderContext::Flag> Flags;
 

--- a/src/3d/terrain/qgsterraintexturegenerator_p.cpp
+++ b/src/3d/terrain/qgsterraintexturegenerator_p.cpp
@@ -140,6 +140,7 @@ QgsMapSettings QgsTerrainTextureGenerator::baseMapSettings()
   mapSettings.setDestinationCrs( mMap.crs() );
   mapSettings.setBackgroundColor( mMap.backgroundColor() );
   mapSettings.setFlag( QgsMapSettings::DrawLabeling, mMap.showLabels() );
+  mapSettings.setFlag( QgsMapSettings::Render3DMap );
   mapSettings.setTransformContext( mMap.transformContext() );
   mapSettings.setPathResolver( mMap.pathResolver() );
 

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -313,6 +313,7 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
       RenderPreviewJob         = 0x400, //!< Render is a 'canvas preview' render, and shortcuts should be taken to ensure fast rendering
       RenderBlocking           = 0x800, //!< Render and load remote sources in the same thread to ensure rendering remote sources (svg and images). WARNING: this flag must NEVER be used from GUI based applications (like the main QGIS application) or crashes will result. Only for use in external scripts or QGIS server.
       LosslessImageRendering   = 0x1000, //!< Render images losslessly whenever possible, instead of the default lossy jpeg rendering used for some destination devices (e.g. PDF). This flag only works with builds based on Qt 5.13 or later.
+      Render3DMap              = 0x2000, //!< Render is for a 3D map
       // TODO: ignore scale-based visibility (overview)
     };
     Q_DECLARE_FLAGS( Flags, Flag )

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -216,6 +216,7 @@ QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings &mapSet
   ctx.setFlag( RenderPreviewJob, mapSettings.testFlag( QgsMapSettings::RenderPreviewJob ) );
   ctx.setFlag( RenderBlocking, mapSettings.testFlag( QgsMapSettings::RenderBlocking ) );
   ctx.setFlag( LosslessImageRendering, mapSettings.testFlag( QgsMapSettings::LosslessImageRendering ) );
+  ctx.setFlag( Render3DMap, mapSettings.testFlag( QgsMapSettings::Render3DMap ) );
   ctx.setScaleFactor( mapSettings.outputDpi() / 25.4 ); // = pixels per mm
   ctx.setRendererScale( mapSettings.scale() );
   ctx.setExpressionContext( mapSettings.expressionContext() );

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -83,6 +83,7 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
       RenderSymbolPreview      = 0x800, //!< The render is for a symbol preview only and map based properties may not be available, so care should be taken to handle map unit based sizes in an appropriate way.
       LosslessImageRendering   = 0x1000, //!< Render images losslessly whenever possible, instead of the default lossy jpeg rendering used for some destination devices (e.g. PDF). This flag only works with builds based on Qt 5.13 or later.
       ApplyScalingWorkaroundForTextRendering = 0x2000, //!< Whether a scaling workaround designed to stablise the rendering of small font sizes (or for painters scaled out by a large amount) when rendering text. Generally this is recommended, but it may incur some performance cost.
+      Render3DMap              = 0x4000, //!< Render is for a 3D map
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -228,7 +228,9 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   mPipe = new QgsRasterPipe( *layer->pipe() );
   QObject::connect( mPipe->provider(), &QgsRasterDataProvider::statusChanged, layer, &QgsRasterLayer::statusChanged );
   QgsRasterRenderer *rasterRenderer = mPipe->renderer();
-  if ( rasterRenderer && !( rendererContext.flags() & QgsRenderContext::RenderPreviewJob ) )
+  if ( rasterRenderer
+       && !( rendererContext.flags() & QgsRenderContext::RenderPreviewJob )
+       && !( rendererContext.flags() & QgsRenderContext::Render3DMap ) )
     layer->refreshRendererIfNeeded( rasterRenderer, rendererContext.extent() );
 
   const QgsRasterLayerTemporalProperties *temporalProperties = qobject_cast< const QgsRasterLayerTemporalProperties * >( layer->temporalProperties() );

--- a/tests/src/python/test_qgsrendercontext.py
+++ b/tests/src/python/test_qgsrendercontext.py
@@ -128,12 +128,14 @@ class TestQgsRenderContext(unittest.TestCase):
         ms.setExtent(QgsRectangle(10000, 20000, 30000, 40000))
         ms.setFlag(QgsMapSettings.Antialiasing, True)
         ms.setFlag(QgsMapSettings.LosslessImageRendering, True)
+        ms.setFlag(QgsMapSettings.Render3DMap, True)
 
         ms.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysText)
         rc = QgsRenderContext.fromMapSettings(ms)
         self.assertEqual(rc.textRenderFormat(), QgsRenderContext.TextFormatAlwaysText)
         self.assertTrue(rc.testFlag(QgsRenderContext.Antialiasing))
         self.assertTrue(rc.testFlag(QgsRenderContext.LosslessImageRendering))
+        self.assertTrue(rc.testFlag(QgsRenderContext.Render3DMap))
 
         ms.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysOutlines)
         rc = QgsRenderContext.fromMapSettings(ms)


### PR DESCRIPTION
It causes crashes, but even if it worked, its not going to give
usable results...