### PR TITLE
WFS server: use exact intersection if there is a bbox parameter

### DIFF
--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -767,7 +767,7 @@ namespace QgsWfs
       for ( ; qIt != request.queries.end(); ++qIt )
       {
         getFeatureQuery &query = *qIt;
-        query.featureRequest.setFilterRect( extent );
+        query.featureRequest.setFilterRect( extent ).setFlags( query.featureRequest.flags() | QgsFeatureRequest::ExactIntersect );
       }
       return request;
     }


### PR DESCRIPTION
If there is a bbox-Parameter in a WFS GetFeature request, the ExactIntersect - Flag has not  been set to the feature request object. Therefore it sometimes returned more features than it should.