### PR TITLE
Allow clipping layout maps to non-rectangular sizes

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutmodel.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutmodel.sip.in
@@ -180,6 +180,28 @@ Returns ``True`` if the model includes the empty item choice.
 .. versionadded:: 3.8
 %End
 
+    void setItemFlags( QgsLayoutItem::Flags flags );
+%Docstring
+Sets layout item flags to use for filtering the available items.
+
+Set ``flags`` to ``None`` to clear the flag based filtering.
+
+.. seealso:: :py:func:`itemFlags`
+
+.. versionadded:: 3.16
+%End
+
+    QgsLayoutItem::Flags itemFlags() const;
+%Docstring
+Returns the layout item flags used for filtering the available items.
+
+Returns ``None`` if no flag based filtering is occurring.
+
+.. seealso:: :py:func:`setItemFlags`
+
+.. versionadded:: 3.16
+%End
+
   protected:
     virtual bool filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const;
 

--- a/python/gui/auto_generated/layout/qgslayoutitemcombobox.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutitemcombobox.sip.in
@@ -94,6 +94,28 @@ Returns ``True`` if the model includes the empty item choice.
 .. versionadded:: 3.8
 %End
 
+    void setItemFlags( QgsLayoutItem::Flags flags );
+%Docstring
+Sets layout item flags to use for filtering the available items.
+
+Set ``flags`` to ``None`` to clear the flag based filtering.
+
+.. seealso:: :py:func:`itemFlags`
+
+.. versionadded:: 3.16
+%End
+
+    QgsLayoutItem::Flags itemFlags() const;
+%Docstring
+Returns the layout item flags used for filtering the available items.
+
+Returns ``None`` if no flag based filtering is occurring.
+
+.. seealso:: :py:func:`setItemFlags`
+
+.. versionadded:: 3.16
+%End
+
     QgsLayoutItem *item( int index ) const;
 %Docstring
 Returns the item currently shown at the specified ``index`` within the combo box.

--- a/src/core/layout/qgslayoutmodel.cpp
+++ b/src/core/layout/qgslayoutmodel.cpp
@@ -1000,6 +1000,17 @@ bool QgsLayoutProxyModel::allowEmptyItem() const
   return mAllowEmpty;
 }
 
+void QgsLayoutProxyModel::setItemFlags( QgsLayoutItem::Flags flags )
+{
+  mItemFlags = flags;
+  invalidateFilter();
+}
+
+QgsLayoutItem::Flags QgsLayoutProxyModel::itemFlags() const
+{
+  return mItemFlags;
+}
+
 void QgsLayoutProxyModel::setFilterType( QgsLayoutItemRegistry::ItemType filter )
 {
   mItemTypeFilter = filter;
@@ -1031,6 +1042,11 @@ bool QgsLayoutProxyModel::filterAcceptsRow( int sourceRow, const QModelIndex &so
   // filter by type
   if ( mItemTypeFilter != QgsLayoutItemRegistry::LayoutItem && item->type() != mItemTypeFilter )
     return false;
+
+  if ( mItemFlags && !( item->itemFlags() & mItemFlags ) )
+  {
+    return false;
+  }
 
   return true;
 }

--- a/src/core/layout/qgslayoutmodel.h
+++ b/src/core/layout/qgslayoutmodel.h
@@ -372,6 +372,26 @@ class CORE_EXPORT QgsLayoutProxyModel: public QSortFilterProxyModel
      */
     bool allowEmptyItem() const;
 
+    /**
+     * Sets layout item flags to use for filtering the available items.
+     *
+     * Set \a flags to NULLPTR to clear the flag based filtering.
+     *
+     * \see itemFlags()
+     * \since QGIS 3.16
+     */
+    void setItemFlags( QgsLayoutItem::Flags flags );
+
+    /**
+     * Returns the layout item flags used for filtering the available items.
+     *
+     * Returns NULLPTR if no flag based filtering is occurring.
+     *
+     * \see setItemFlags()
+     * \since QGIS 3.16
+     */
+    QgsLayoutItem::Flags itemFlags() const;
+
   protected:
     bool filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const override;
     bool lessThan( const QModelIndex &left, const QModelIndex &right ) const override;
@@ -381,6 +401,7 @@ class CORE_EXPORT QgsLayoutProxyModel: public QSortFilterProxyModel
     QgsLayoutItemRegistry::ItemType mItemTypeFilter;
     QList< QgsLayoutItem * > mExceptedList;
     bool mAllowEmpty = false;
+    QgsLayoutItem::Flags mItemFlags = nullptr;
 
 };
 

--- a/src/gui/layout/qgslayoutitemcombobox.cpp
+++ b/src/gui/layout/qgslayoutitemcombobox.cpp
@@ -121,6 +121,16 @@ bool QgsLayoutItemComboBox::allowEmptyItem() const
   return mProxyModel->allowEmptyItem();
 }
 
+void QgsLayoutItemComboBox::setItemFlags( QgsLayoutItem::Flags flags )
+{
+  mProxyModel->setItemFlags( flags );
+}
+
+QgsLayoutItem::Flags QgsLayoutItemComboBox::itemFlags() const
+{
+  return mProxyModel->itemFlags();
+}
+
 QgsLayoutItem *QgsLayoutItemComboBox::item( int index ) const
 {
   const QModelIndex proxyIndex = mProxyModel->index( index, 0 );

--- a/src/gui/layout/qgslayoutitemcombobox.h
+++ b/src/gui/layout/qgslayoutitemcombobox.h
@@ -100,6 +100,26 @@ class GUI_EXPORT QgsLayoutItemComboBox : public QComboBox
     bool allowEmptyItem() const;
 
     /**
+     * Sets layout item flags to use for filtering the available items.
+     *
+     * Set \a flags to NULLPTR to clear the flag based filtering.
+     *
+     * \see itemFlags()
+     * \since QGIS 3.16
+     */
+    void setItemFlags( QgsLayoutItem::Flags flags );
+
+    /**
+     * Returns the layout item flags used for filtering the available items.
+     *
+     * Returns NULLPTR if no flag based filtering is occurring.
+     *
+     * \see setItemFlags()
+     * \since QGIS 3.16
+     */
+    QgsLayoutItem::Flags itemFlags() const;
+
+    /**
      * Returns the item currently shown at the specified \a index within the combo box.
      * \see currentItem()
      */

--- a/src/ui/layout/qgslayoutmapclippingwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapclippingwidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>318</width>
-    <height>408</height>
+    <height>619</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -99,6 +99,51 @@
     </widget>
    </item>
    <item>
+    <widget class="QgsCollapsibleGroupBox" name="mClipToItemCheckBox">
+     <property name="title">
+      <string>Clip to item</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>The clipping mode determines how features from vector layers will be clipped.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="mClipToAtlasLabel_2">
+        <property name="text">
+         <string>&lt;b&gt;When enabled, the map will be automatically clipped to the selected shape.&lt;/b&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QComboBox" name="mItemClippingTypeComboBox"/>
+      </item>
+      <item row="4" column="0">
+       <widget class="QCheckBox" name="mForceLabelsInsideItemCheckBox">
+        <property name="text">
+         <string>Force labels inside clipping shape</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QgsLayoutItemComboBox" name="mClipItemComboBox"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -120,6 +165,11 @@
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsLayoutItemComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgslayoutitemcombobox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/ui/layout/qgslayoutmapclippingwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapclippingwidgetbase.ui
@@ -118,7 +118,7 @@
        </widget>
       </item>
       <item row="0" column="0">
-       <widget class="QLabel" name="mClipToAtlasLabel_2">
+       <widget class="QLabel" name="mClipToItemLabel">
         <property name="text">
          <string>&lt;b&gt;When enabled, the map will be automatically clipped to the selected shape.&lt;/b&gt;</string>
         </property>

--- a/tests/src/core/testqgslayoutmodel.cpp
+++ b/tests/src/core/testqgslayoutmodel.cpp
@@ -23,6 +23,7 @@
 #include "qgsproject.h"
 #include "qgslayoutitemlabel.h"
 #include "qgslayoutitemgroup.h"
+#include "qgslayoutitemshape.h"
 #include <QObject>
 #include "qgstest.h"
 #include <QList>
@@ -967,17 +968,27 @@ void TestQgsLayoutModel::proxy()
   QgsLayoutItemLabel *item3 = new QgsLayoutItemLabel( layout );
   item3->setId( QStringLiteral( "a" ) );
   layout->addLayoutItem( item3 );
-  QCOMPARE( proxy->rowCount( QModelIndex() ), 3 );
+  QgsLayoutItemShape *item4 = new QgsLayoutItemShape( layout );
+  item4->setId( QStringLiteral( "d" ) );
+  layout->addLayoutItem( item4 );
+  QgsLayoutItemShape *item5 = new QgsLayoutItemShape( layout );
+  item5->setId( QStringLiteral( "e" ) );
+  layout->addLayoutItem( item5 );
+  QCOMPARE( proxy->rowCount( QModelIndex() ), 5 );
   QCOMPARE( proxy->data( proxy->index( 0, 2, QModelIndex() ) ).toString(), QStringLiteral( "a" ) );
   QCOMPARE( proxy->data( proxy->index( 1, 2, QModelIndex() ) ).toString(), QStringLiteral( "b" ) );
   QCOMPARE( proxy->data( proxy->index( 2, 2, QModelIndex() ) ).toString(), QStringLiteral( "c" ) );
+  QCOMPARE( proxy->data( proxy->index( 3, 2, QModelIndex() ) ).toString(), QStringLiteral( "d" ) );
+  QCOMPARE( proxy->data( proxy->index( 4, 2, QModelIndex() ) ).toString(), QStringLiteral( "e" ) );
 
   proxy->setAllowEmptyItem( true );
-  QCOMPARE( proxy->rowCount( QModelIndex() ), 4 );
+  QCOMPARE( proxy->rowCount( QModelIndex() ), 6 );
   QCOMPARE( proxy->data( proxy->index( 0, 2, QModelIndex() ) ).toString(), QString() );
   QCOMPARE( proxy->data( proxy->index( 1, 2, QModelIndex() ) ).toString(), QStringLiteral( "a" ) );
   QCOMPARE( proxy->data( proxy->index( 2, 2, QModelIndex() ) ).toString(), QStringLiteral( "b" ) );
   QCOMPARE( proxy->data( proxy->index( 3, 2, QModelIndex() ) ).toString(), QStringLiteral( "c" ) );
+  QCOMPARE( proxy->data( proxy->index( 4, 2, QModelIndex() ) ).toString(), QStringLiteral( "d" ) );
+  QCOMPARE( proxy->data( proxy->index( 5, 2, QModelIndex() ) ).toString(), QStringLiteral( "e" ) );
 
   proxy->setFilterType( QgsLayoutItemRegistry::LayoutMap );
   QCOMPARE( proxy->rowCount( QModelIndex() ), 3 );
@@ -993,6 +1004,16 @@ void TestQgsLayoutModel::proxy()
   proxy->setFilterType( QgsLayoutItemRegistry::LayoutScaleBar );
   QCOMPARE( proxy->rowCount( QModelIndex() ), 1 );
   QCOMPARE( proxy->data( proxy->index( 0, 2, QModelIndex() ) ).toString(), QString() );
+
+  proxy->setAllowEmptyItem( false );
+  proxy->setFilterType( QgsLayoutItemRegistry::LayoutItem );
+  QCOMPARE( proxy->rowCount( QModelIndex() ), 5 );
+  proxy->setItemFlags( QgsLayoutItem::FlagProvidesClipPath );
+  QCOMPARE( proxy->rowCount( QModelIndex() ), 2 );
+  QCOMPARE( proxy->data( proxy->index( 0, 2, QModelIndex() ) ).toString(), QStringLiteral( "d" ) );
+  QCOMPARE( proxy->data( proxy->index( 1, 2, QModelIndex() ) ).toString(), QStringLiteral( "e" ) );
+  proxy->setItemFlags( nullptr );
+  QCOMPARE( proxy->rowCount( QModelIndex() ), 5 );
 }
 
 void TestQgsLayoutModel::proxyCrash()

--- a/tests/src/python/test_qgslayoutitemcombobox.py
+++ b/tests/src/python/test_qgslayoutitemcombobox.py
@@ -16,7 +16,9 @@ from qgis.core import (QgsProject,
                        QgsPrintLayout,
                        QgsLayoutItemMap,
                        QgsLayoutItemLabel,
-                       QgsLayoutItemRegistry)
+                       QgsLayoutItemRegistry,
+                       QgsLayoutItemShape,
+                       QgsLayoutItem)
 from qgis.gui import QgsLayoutItemComboBox
 from qgis.PyQt.QtCore import Qt, QModelIndex
 from qgis.testing import start_app, unittest
@@ -241,6 +243,23 @@ class TestQgsLayoutItemComboBox(unittest.TestCase):
         self.assertEqual(combo.count(), 0)
         self.assertIsNone(combo.currentItem())
         self.assertEqual(combo.currentIndex(), -1)
+
+        combo.setItemType(QgsLayoutItemRegistry.LayoutItem)
+        self.assertEqual(combo.count(), 2)
+        combo.setItemFlags(QgsLayoutItem.FlagProvidesClipPath)
+        self.assertEqual(combo.count(), 0)
+        shape = QgsLayoutItemShape(layout)
+        shape.setId('shape 1')
+        layout.addLayoutItem(shape)
+        self.assertEqual(combo.count(), 1)
+        shape2 = QgsLayoutItemShape(layout)
+        shape2.setId('shape 2')
+        layout.addLayoutItem(shape2)
+        self.assertEqual(combo.count(), 2)
+        self.assertEqual(combo.itemText(0), 'shape 1')
+        self.assertEqual(combo.itemText(1), 'shape 2')
+        combo.setItemFlags(QgsLayoutItem.Flags())
+        self.assertEqual(combo.count(), 4)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Allows users to clip a map item to a shape or polygon item from their layout, allowing for non-rectangular maps in the layout

![Peek 2020-07-29 15-39](https://user-images.githubusercontent.com/1829991/88761088-c1428480-d1b1-11ea-90c0-a391d00b084d.gif)
