### PR TITLE
 [FEATURE][expression] Add a to_decimal() function to convert degree/minute/second strings

### DIFF
--- a/resources/function_help/json/to_decimal
+++ b/resources/function_help/json/to_decimal
@@ -1,0 +1,12 @@
+{
+  "name": "to_decimal",
+  "type": "function",
+  "groups": ["Conversions"],
+  "description": "Converts a degree, minute, second coordinate to its decimal equivalent.",
+  "arguments": [
+    {"arg":"value","description":"A degree, minute, second string."}
+  ],
+    "examples": [
+    { "expression":"to_decimal('6°21\\'16.445')", "returns":"6.3545680555"}
+  ]
+}

--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -734,6 +734,7 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
   bool okY = false;
   double posX = 0.0;
   double posY = 0.0;
+  bool posIsDms = false;
   QLocale locale;
 
   // Coordinates such as 106.8468,-6.3804
@@ -752,58 +753,67 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
     // Digit detection using user locale failed, use default C decimal separators
     separatorRx = QRegularExpression( QStringLiteral( "^([0-9\\-\\.]*)[\\s\\,]*([0-9\\-\\.]*)$" ) );
     match = separatorRx.match( string.trimmed() );
-  }
-
-  if ( match.hasMatch() )
-  {
-    if ( !okX || !okY )
+    if ( match.hasMatch() )
     {
       posX = match.captured( 1 ).toDouble( &okX );
       posY = match.captured( 2 ).toDouble( &okY );
     }
+  }
 
-    if ( okX && okY )
+  if ( !match.hasMatch() )
+  {
+    // Check if the string is a pair of degree minute second
+    separatorRx = QRegularExpression( QStringLiteral( "^((?:([-+nsew])\\s*)?\\d{1,3}(?:[^0-9.]+[0-5]?\\d)?[^0-9.]+[0-5]?\\d(?:\\.\\d+)?[^0-9.]*[-+nsew]?)\\s+((?:([-+nsew])\\s*)?\\d{1,3}(?:[^0-9.]+[0-5]?\\d)?[^0-9.]+[0-5]?\\d(?:\\.\\d+)?[^0-9.]*[-+nsew]?)$" ) );
+    match = separatorRx.match( string.trimmed() );
+    if ( match.hasMatch() )
     {
-      QVariantMap data;
-      QgsPointXY point( posX, posY );
-      data.insert( QStringLiteral( "point" ), point );
+      posIsDms = true;
+      posX = QgsCoordinateUtils::dmsToDecimal( match.captured( 1 ), &okX );
+      posY = QgsCoordinateUtils::dmsToDecimal( match.captured( 3 ), &okY );
+    }
+  }
 
-      bool withinWgs84 = wgs84Crs.bounds().contains( point );
+  if ( okX && okY )
+  {
+    QVariantMap data;
+    QgsPointXY point( posX, posY );
+    data.insert( QStringLiteral( "point" ), point );
+
+    bool withinWgs84 = wgs84Crs.bounds().contains( point );
+    if ( !posIsDms && currentCrs != wgs84Crs )
+    {
+      QgsLocatorResult result;
+      result.filter = this;
+      result.displayString = tr( "Go to %1 %2 (Map CRS, %3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), currentCrs.userFriendlyIdentifier() );
+      result.userData = data;
+      result.score = 0.9;
+      emit resultFetched( result );
+    }
+
+    if ( withinWgs84 )
+    {
       if ( currentCrs != wgs84Crs )
       {
-        QgsLocatorResult result;
-        result.filter = this;
-        result.displayString = tr( "Go to %1 %2 (Map CRS, %3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), currentCrs.userFriendlyIdentifier() );
-        result.userData = data;
-        result.score = 0.9;
-        emit resultFetched( result );
-      }
-
-      if ( withinWgs84 )
-      {
-        if ( currentCrs != wgs84Crs )
+        QgsCoordinateTransform transform( wgs84Crs, currentCrs, QgsProject::instance()->transformContext() );
+        QgsPointXY transformedPoint;
+        try
         {
-          QgsCoordinateTransform transform( wgs84Crs, currentCrs, QgsProject::instance()->transformContext() );
-          QgsPointXY transformedPoint;
-          try
-          {
-            transformedPoint = transform.transform( point );
-          }
-          catch ( const QgsException &e )
-          {
-            Q_UNUSED( e )
-            return;
-          }
-          data[QStringLiteral( "point" )] = transformedPoint;
+          transformedPoint = transform.transform( point );
         }
-
-        QgsLocatorResult result;
-        result.filter = this;
-        result.displayString = tr( "Go to %1° %2° (%3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), wgs84Crs.userFriendlyIdentifier() );
-        result.userData = data;
-        result.score = 1.0;
-        emit resultFetched( result );
+        catch ( const QgsException &e )
+        {
+          Q_UNUSED( e )
+          return;
+        }
+        data[QStringLiteral( "point" )] = transformedPoint;
       }
+
+      QgsLocatorResult result;
+      result.filter = this;
+      result.displayString = tr( "Go to %1° %2° (%3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), wgs84Crs.userFriendlyIdentifier() );
+      result.userData = data;
+      result.score = 1.0;
+      emit resultFetched( result );
     }
     return;
   }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -17,6 +17,7 @@
 #include <random>
 
 #include "qgscoordinateformatter.h"
+#include "qgscoordinateutils.h"
 #include "qgsexpressionfunction.h"
 #include "qgsexpressionutils.h"
 #include "qgsexpressionnodeimpl.h"
@@ -2098,6 +2099,15 @@ static QVariant fcnToDegreeMinute( const QVariantList &values, const QgsExpressi
 {
   QgsCoordinateFormatter::Format format = QgsCoordinateFormatter::FormatDegreesMinutes;
   return floatToDegreeFormat( format, values, context, parent, node );
+}
+
+static QVariant fcnToDecimal( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  double value = 0.0;
+  bool ok = false;
+  value = QgsCoordinateUtils::dmsToDecimal( QgsExpressionUtils::getStringValue( values.at( 0 ), parent ), &ok );
+
+  return ok ? QVariant( value ) : QVariant();
 }
 
 static QVariant fcnToDegreeMinuteSecond( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction *node )
@@ -5737,6 +5747,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "to_interval" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ), fcnToInterval, QStringList() << QStringLiteral( "Conversions" ) << QStringLiteral( "Date and Time" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "tointerval" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "to_dm" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "axis" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "precision" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "formatting" ), true ), fcnToDegreeMinute, QStringLiteral( "Conversions" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "todm" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "to_dms" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "axis" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "precision" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "formatting" ), true ), fcnToDegreeMinuteSecond, QStringLiteral( "Conversions" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "todms" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "to_decimal" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ), fcnToDecimal, QStringLiteral( "Conversions" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "todecimal" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "coalesce" ), -1, fcnCoalesce, QStringLiteral( "Conditionals" ), QString(), false, QSet<QString>(), false, QStringList(), true )
         << new QgsStaticExpressionFunction( QStringLiteral( "nullif" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "value1" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "value2" ) ), fcnNullIf, QStringLiteral( "Conditionals" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "if" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "condition" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "result_when_true" ) )  << QgsExpressionFunction::Parameter( QStringLiteral( "result_when_false" ) ), fcnIf, QStringLiteral( "Conditionals" ), QString(), false, QSet<QString>(), true )

--- a/src/core/qgscoordinateutils.cpp
+++ b/src/core/qgscoordinateutils.cpp
@@ -106,4 +106,60 @@ QString QgsCoordinateUtils::formatCoordinateForProject( QgsProject *project, con
   }
 }
 
+double QgsCoordinateUtils::dmsToDecimal( const QString &string, bool *ok )
+{
+  const QString negative( QStringLiteral( "swSW-" ) );
+  double value = 0.0;
+  bool okValue = false;
+
+  if ( ok )
+  {
+    *ok = false;
+  }
+  else
+  {
+    ok = &okValue;
+  }
+
+  QRegularExpression dms( "^\\s*(?:([-+nsew])\\s*)?(\\d{1,3})(?:[^0-9.]+([0-5]?\\d))?[^0-9.]+([0-5]?\\d(?:\\.\\d+)?)[^0-9.]*?([-+nsew])?\\s*$", QRegularExpression::CaseInsensitiveOption );
+  QRegularExpressionMatch match = dms.match( string.trimmed() );
+  if ( match.hasMatch() )
+  {
+    QString dms1 = match.captured( 2 );
+    QString dms2 = match.captured( 3 );
+    QString dms3 = match.captured( 4 );
+
+    double v = dms3.toDouble( ok );
+    if ( *ok == false )
+      return value;
+    // Allow for Degrees/minutes format as well as DMS
+    if ( !dms2.isEmpty() )
+    {
+      v = dms2.toInt( ok ) + v / 60.0;
+      if ( *ok == false )
+        return value;
+    }
+    v = dms1.toInt( ok ) + v / 60.0;
+    if ( *ok == false )
+      return value;
+
+    QString sign1 = match.captured( 1 );
+    QString sign2 = match.captured( 5 );
+
+    if ( sign1.isEmpty() )
+    {
+      value = !sign2.isEmpty() && negative.contains( sign2 ) ? -v : v;
+    }
+    else if ( sign2.isEmpty() )
+    {
+      value = !sign1.isEmpty() && negative.contains( sign1 ) ? -v : v;
+    }
+    else
+    {
+      *ok = false;
+    }
+  }
+  return value;
+}
+
 ///@endcond

--- a/src/core/qgscoordinateutils.h
+++ b/src/core/qgscoordinateutils.h
@@ -67,6 +67,14 @@ class CORE_EXPORT QgsCoordinateUtils
      */
     Q_INVOKABLE static QString formatCoordinateForProject( QgsProject *project, const QgsPointXY &point, const QgsCoordinateReferenceSystem &destCrs, int precision );
 
+    /**
+     * Converts a degree minute second coordinate string to its decimal equivalent.
+     * \param string degree minute second string to convert
+     * \returns Double decimal value
+     * \since QGIS 3.16
+     */
+    Q_INVOKABLE static double dmsToDecimal( const QString &string, bool *ok );
+
 };
 
 

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.h
@@ -156,7 +156,6 @@ class QgsDelimitedTextProvider final: public QgsVectorDataProvider
     static QgsGeometry geomFromWkt( QString &sWkt, bool wktHasPrefixRegexp );
     static bool pointFromXY( QString &sX, QString &sY, QgsPoint &point, const QString &decimalPoint, bool xyDms );
     static void appendZM( QString &sZ, QString &sM, QgsPoint &point, const QString &decimalPoint );
-    static double dmsStringToDouble( const QString &sX, bool *xOk );
 
     // mLayerValid defines whether the layer has been loaded as a valid layer
     bool mLayerValid = false;

--- a/tests/src/app/testqgsapplocatorfilters.cpp
+++ b/tests/src/app/testqgsapplocatorfilters.cpp
@@ -291,6 +291,12 @@ void TestQgsAppLocatorFilters::testGoto()
   QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 1,234.56 789.012 (Map CRS, )" ) );
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 1234.56, 789.012 ) );
 
+  // degree/minuste/second coordinates goto
+  results = gatherResults( &filter, QStringLiteral( "40deg 1' 0\" E 11deg  55' 0\" S" ), QgsLocatorContext() );
+  QCOMPARE( results.count(), 1 );
+  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 40.01666667° -11.91666667° (EPSG:4326 - WGS 84)" ) );
+  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 40.0166666667, -11.9166666667 ) );
+
   // OSM/Leaflet/OpenLayers
   results = gatherResults( &filter, QStringLiteral( "https://www.openstreetmap.org/#map=15/44.5546/6.4936" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -869,6 +869,8 @@ class TestQgsExpression: public QObject
       QTest::newRow( "Y coordinate to degree minute second with suffix" ) << "to_dms(6.3545681,'y',2,'suffix')" << false << QVariant( "6°21′16.45″N" );
       QTest::newRow( "Y coordinate to degree minute second without formatting" ) << "to_dms(6.3545681,'y',2,'')" << false << QVariant( "6°21′16.45″" );
       QTest::newRow( "Y coordinate to degree minute second" ) << "to_dms(6.3545681,'y',2)" << false << QVariant( "6°21′16.45″" );
+      QTest::newRow( "degree minute second string to decimal" ) << "to_decimal('6°21′16.45″N')" << false << QVariant( 6.35456944444 );
+      QTest::newRow( "wrong degree minute second string to decimal" ) << "to_decimal('qgis')" << false << QVariant();
 
       // geometry functions
       QTest::newRow( "geom_to_wkb" ) << "geom_to_wkt(geom_from_wkb(geom_to_wkb(make_point(4,5))))" << false << QVariant( "Point (4 5)" );


### PR DESCRIPTION
## Description

This PR adds a `QgsCoordinateUtils::dmsToDecimal` function to convert degree minute second to decimal degree coordinates alongside an expression `to_decimal` function.

The new function is also used to add degree minute second coordinates support to the goto locator.

_(FYI, the delimited text provider tests a fair amount of DMS strings, which now doubles as a good test for the QgsCoordinateUtils::dmsToDecimal() function)_