### PR TITLE
 Display generated fields as read-only in editors 

### DIFF
--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -373,6 +373,22 @@ by manual field configuration.
 :return: the value
 %End
 
+    void setReadOnly( bool readOnly );
+%Docstring
+Make field read-only if ``readOnly`` is set to true. This is the case for
+providers which support generated fields for instance.
+
+.. versionadded:: 3.18
+%End
+
+    bool isReadOnly() const;
+%Docstring
+Returns ``True`` if this field is a read-only field. This is the case for
+providers which support generated fields for instance.
+
+.. versionadded:: 3.18
+%End
+
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsField: %1 (%2)>" ).arg( sipCpp->name() ).arg( sipCpp->typeName() );

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -561,6 +561,17 @@ QgsEditorWidgetSetup QgsField::editorWidgetSetup() const
   return d->editorWidgetSetup;
 }
 
+void QgsField::setReadOnly( bool readOnly )
+{
+  d->isReadOnly = readOnly;
+}
+
+bool QgsField::isReadOnly() const
+{
+  return d->isReadOnly;
+}
+
+
 /***************************************************************************
  * This class is considered CRITICAL and any change MUST be accompanied with
  * full unit tests in testqgsfield.cpp.

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -433,6 +433,20 @@ class CORE_EXPORT QgsField
      */
     QgsEditorWidgetSetup editorWidgetSetup() const;
 
+    /**
+     * Make field read-only if \a readOnly is set to true. This is the case for
+     * providers which support generated fields for instance.
+     * \since QGIS 3.18
+     */
+    void setReadOnly( bool readOnly );
+
+    /**
+     * Returns TRUE if this field is a read-only field. This is the case for
+     * providers which support generated fields for instance.
+     * \since QGIS 3.18
+     */
+    bool isReadOnly() const;
+
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();
     % MethodCode

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -61,6 +61,7 @@ class CORE_EXPORT QgsField
     Q_PROPERTY( QgsDefaultValue defaultValueDefinition READ defaultValueDefinition WRITE setDefaultValueDefinition )
     Q_PROPERTY( QgsFieldConstraints constraints READ constraints WRITE setConstraints )
     Q_PROPERTY( ConfigurationFlags configurationFlags READ configurationFlags WRITE setConfigurationFlags )
+    Q_PROPERTY( bool isReadOnly READ isReadOnly WRITE setReadOnly )
 
 
   public:

--- a/src/core/qgsfield_p.h
+++ b/src/core/qgsfield_p.h
@@ -78,6 +78,7 @@ class QgsFieldPrivate : public QSharedData
       , flags( other.flags )
       , defaultValueDefinition( other.defaultValueDefinition )
       , constraints( other.constraints )
+      , isReadOnly( other.isReadOnly )
     {
     }
 
@@ -88,7 +89,8 @@ class QgsFieldPrivate : public QSharedData
       return ( ( name == other.name ) && ( type == other.type ) && ( subType == other.subType )
                && ( length == other.length ) && ( precision == other.precision )
                && ( alias == other.alias ) && ( defaultValueDefinition == other.defaultValueDefinition )
-               && ( constraints == other.constraints )  && ( flags == other.flags ) );
+               && ( constraints == other.constraints )  && ( flags == other.flags )
+               && ( isReadOnly == other.isReadOnly ) );
     }
 
     //! Name
@@ -125,6 +127,9 @@ class QgsFieldPrivate : public QSharedData
     QgsFieldConstraints constraints;
 
     QgsEditorWidgetSetup editorWidgetSetup;
+
+    //! Read-only
+    bool isReadOnly = false;
 
   private:
     QgsFieldPrivate &operator=( const QgsFieldPrivate & ) = delete;

--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -863,7 +863,9 @@ bool _fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFea
 {
   return layer->isEditable() &&
          !layer->editFormConfig().readOnly( fieldIndex ) &&
-         ( ( layer->dataProvider() && layer->dataProvider()->capabilities() & QgsVectorDataProvider::ChangeAttributeValues ) || FID_IS_NEW( feature.id() ) );
+         layer->dataProvider() &&
+         ( ( layer->dataProvider()->capabilities() & QgsVectorDataProvider::ChangeAttributeValues ) || FID_IS_NEW( feature.id() ) ) &&
+         !layer->fields().at( fieldIndex ).isReadOnly();
 }
 
 bool QgsVectorLayerUtils::fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature )

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -773,6 +773,7 @@ bool QgsOracleProvider::loadFields()
 
     QVariant::Type type = field.type();
     QgsField newField( field.name(), type, types.value( field.name() ), field.length(), field.precision(), comments.value( field.name() ) );
+    newField.setReadOnly( alwaysGenerated.value( field.name(), false ) );
 
     QgsFieldConstraints constraints;
     if ( mPrimaryKeyAttrs.contains( i ) )
@@ -1220,7 +1221,6 @@ QString QgsOracleProvider::defaultValueClause( int fieldId ) const
 
   return QString();
 }
-
 
 bool QgsOracleProvider::skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint constraint, const QVariant &value ) const
 {

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -87,6 +87,7 @@ void TestQgsField::create()
   QCOMPARE( field->length(), 5 );
   QCOMPARE( field->precision(), 2 );
   QCOMPARE( field->comment(), QString( "comment" ) );
+  QCOMPARE( field->isReadOnly(), false );
 }
 
 void TestQgsField::copy()
@@ -97,6 +98,7 @@ void TestQgsField::copy()
   constraints.setConstraintExpression( QStringLiteral( "constraint expression" ), QStringLiteral( "description" ) );
   constraints.setConstraintStrength( QgsFieldConstraints::ConstraintExpression, QgsFieldConstraints::ConstraintStrengthSoft );
   original.setConstraints( constraints );
+  original.setReadOnly( true );
   QgsField copy( original );
   QVERIFY( copy == original );
 
@@ -113,6 +115,7 @@ void TestQgsField::assignment()
   constraints.setConstraintExpression( QStringLiteral( "constraint expression" ), QStringLiteral( "description" ) );
   constraints.setConstraintStrength( QgsFieldConstraints::ConstraintExpression, QgsFieldConstraints::ConstraintStrengthSoft );
   original.setConstraints( constraints );
+  original.setReadOnly( true );
   QgsField copy;
   copy = original;
   QVERIFY( copy == original );
@@ -177,6 +180,9 @@ void TestQgsField::gettersSetters()
   constraints.setConstraintStrength( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintStrengthSoft );
   field.setConstraints( constraints );
   QCOMPARE( field.constraints().constraintStrength( QgsFieldConstraints::ConstraintUnique ), QgsFieldConstraints::ConstraintStrengthSoft );
+
+  field.setReadOnly( true );
+  QCOMPARE( field.isReadOnly(), true );
 }
 
 void TestQgsField::isNumeric()
@@ -275,6 +281,10 @@ void TestQgsField::equality()
   QVERIFY( !( field1 == field2 ) );
   QVERIFY( field1 != field2 );
   field2.setAlias( QString() );
+  field2.setReadOnly( true );
+  QVERIFY( !( field1 == field2 ) );
+  QVERIFY( field1 != field2 );
+  field2.setReadOnly( false );
   field2.setDefaultValueDefinition( QgsDefaultValue( QStringLiteral( "1+2" ) ) );
   QVERIFY( !( field1 == field2 ) );
   QVERIFY( field1 != field2 );

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -30,6 +30,7 @@ from qgis.core import (
     QgsTestUtils,
     QgsFeatureSource,
     QgsFieldConstraints,
+    QgsVectorLayerUtils,
     NULL
 )
 from qgis.PyQt.QtCore import QDate, QTime, QDateTime, QVariant
@@ -1171,38 +1172,45 @@ class ProviderTestCase(FeatureSourceTestCase):
         vl.startEditing()
 
         feature = next(vl.getFeatures())
-        # to be fixed
-        # self.assertEqual(QgsVectorLayerUtils.fieldIsEditable(vl, 1, feature), editable)
+        self.assertFalse(QgsVectorLayerUtils.fieldIsEditable(vl, 1, feature))
+        self.assertTrue(QgsVectorLayerUtils.fieldIsEditable(vl, 0, feature))
 
         # same test on a new inserted feature
         feature = QgsFeature(vl.fields())
         feature.setAttribute(0, 2)
         vl.addFeature(feature)
         self.assertTrue(feature.id() < 0)
-        # to be fixed
-        # self.assertEqual(QgsVectorLayerUtils.fieldIsEditable(vl, 1, feature), editable)
+        self.assertFalse(QgsVectorLayerUtils.fieldIsEditable(vl, 1, feature))
+        self.assertTrue(QgsVectorLayerUtils.fieldIsEditable(vl, 0, feature))
         vl.commitChanges()
 
         feature = vl.getFeature(2)
         self.assertTrue(feature.isValid())
         self.assertEqual(feature.attribute(1), "test:2")
-
-        # to be fixed
-        # self.assertEqual(QgsVectorLayerUtils.fieldIsEditable(vl, 1, feature), editable)
+        self.assertFalse(QgsVectorLayerUtils.fieldIsEditable(vl, 1, feature))
+        self.assertFalse(QgsVectorLayerUtils.fieldIsEditable(vl, 0, feature))
 
         # test update id and commit
         vl.startEditing()
+        self.assertFalse(QgsVectorLayerUtils.fieldIsEditable(vl, 1, feature))
+        self.assertTrue(QgsVectorLayerUtils.fieldIsEditable(vl, 0, feature))
         self.assertTrue(vl.changeAttributeValue(2, 0, 10))
         self.assertTrue(vl.commitChanges())
         feature = vl.getFeature(10)
         self.assertTrue(feature.isValid())
         self.assertEqual(feature.attribute(0), 10)
         self.assertEqual(feature.attribute(1), "test:10")
+        self.assertFalse(QgsVectorLayerUtils.fieldIsEditable(vl, 1, feature))
+        self.assertFalse(QgsVectorLayerUtils.fieldIsEditable(vl, 0, feature))
 
         # test update the_field and commit (the value is not changed because the field is generated)
         vl.startEditing()
+        self.assertFalse(QgsVectorLayerUtils.fieldIsEditable(vl, 1, feature))
+        self.assertTrue(QgsVectorLayerUtils.fieldIsEditable(vl, 0, feature))
         self.assertTrue(vl.changeAttributeValue(10, 1, "new value"))
         self.assertTrue(vl.commitChanges())
         feature = vl.getFeature(10)
         self.assertTrue(feature.isValid())
         self.assertEqual(feature.attribute(1), "test:10")
+        self.assertFalse(QgsVectorLayerUtils.fieldIsEditable(vl, 1, feature))
+        self.assertFalse(QgsVectorLayerUtils.fieldIsEditable(vl, 0, feature))


### PR DESCRIPTION
## Description

Generated columns are now supported since #35995 for Postgres and almost in Oracle #38026 but they are editable in editors while they should not. 

This PR adds an API methods to know from the provider if a field is readonly. It includes the #38026 because it reuses the test method. So the PR is not for merge until this last is not merged.

@espinafre  You may want to take a look on my modifications on postgres provider, I [changed](https://github.com/qgis/QGIS/compare/master...troopa81:feat_gen_field_readonly?expand=1#diff-374a3d3ebe5430cec252d7f2c7d5f457R1163) the way the map *mGeneratedValues* was managed to not store fields not generated.

I check on local and all postgres tests work with a Postgres 12 database, but I think it would be better to upgrade Postgres version in CI.
