### PR TITLE
renaming and cleaning of Triangulation class and export to QgsMesh

### DIFF
--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -10,14 +10,14 @@ SET(QGIS_ANALYSIS_SRCS
   interpolation/qgstininterpolator.cpp
   interpolation/Bezier3D.cpp
   interpolation/CloughTocherInterpolator.cpp
-  interpolation/DualEdgeTriangulation.cpp
+  interpolation/qgsdualedgetriangulation.cpp
   interpolation/HalfEdge.cpp
   interpolation/LinTriangleInterpolator.cpp
   interpolation/MathUtils.cpp
   interpolation/NormVecDecorator.cpp
   interpolation/ParametricLine.cpp
   interpolation/TriangleInterpolator.cpp
-  interpolation/Triangulation.cpp
+  interpolation/qgstriangulation.cpp
   interpolation/TriDecorator.cpp
   interpolation/Vector3D.cpp
 
@@ -273,7 +273,7 @@ SET(QGIS_ANALYSIS_HDRS
 
   interpolation/Bezier3D.h
   interpolation/CloughTocherInterpolator.h
-  interpolation/DualEdgeTriangulation.h
+  interpolation/qgsdualedgetriangulation.h
   interpolation/HalfEdge.h
   interpolation/LinTriangleInterpolator.h
   interpolation/MathUtils.h
@@ -281,7 +281,7 @@ SET(QGIS_ANALYSIS_HDRS
   interpolation/ParametricLine.h
   interpolation/TriDecorator.h
   interpolation/TriangleInterpolator.h
-  interpolation/Triangulation.h
+  interpolation/qgstriangulation.h
   interpolation/Vector3D.h
   interpolation/qgsgridfilewriter.h
   interpolation/qgsidwinterpolator.h

--- a/src/analysis/interpolation/CloughTocherInterpolator.cpp
+++ b/src/analysis/interpolation/CloughTocherInterpolator.cpp
@@ -42,9 +42,20 @@ double CloughTocherInterpolator::calcBernsteinPoly( int n, int i, int j, int k, 
   return result;
 }
 
-bool CloughTocherInterpolator::calcNormVec( double x, double y, Vector3D *result )
+static void normalize( QgsPoint &point )
 {
-  if ( result )
+  double length = sqrt( pow( point.x(), 2 ) + pow( point.y(), 2 ) + pow( point.z(), 2 ) );
+  if ( length > 0 )
+  {
+    point.setX( point.x() / length );
+    point.setY( point.y() / length );
+    point.setZ( point.z() / length );
+  }
+}
+
+bool CloughTocherInterpolator::calcNormVec( double x, double y, QgsPoint &result )
+{
+  if ( !result.isEmpty() )
   {
     init( x, y );
     QgsPoint barycoord( 0, 0, 0 );//barycentric coordinates of (x,y) with respect to the triangle
@@ -66,10 +77,10 @@ bool CloughTocherInterpolator::calcNormVec( double x, double y, Vector3D *result
       endpointVXY.setZ( 3 * ( zv - zw ) );
       Vector3D v1( endpointUXY.x() - x, endpointUXY.y() - y, endpointUXY.z() );
       Vector3D v2( endpointVXY.x() - x, endpointVXY.y() - y, endpointVXY.z() );
-      result->setX( v1.getY()*v2.getZ() - v1.getZ()*v2.getY() );
-      result->setY( v1.getZ()*v2.getX() - v1.getX()*v2.getZ() );
-      result->setZ( v1.getX()*v2.getY() - v1.getY()*v2.getX() );
-      result->standardise();
+      result.setX( v1.getY()*v2.getZ() - v1.getZ()*v2.getY() );
+      result.setY( v1.getZ()*v2.getX() - v1.getX()*v2.getZ() );
+      result.setZ( v1.getX()*v2.getY() - v1.getY()*v2.getX() );
+      normalize( result );
       return true;
     }
     //is the point in the second subtriangle (point2,point3,cp10)?
@@ -85,10 +96,10 @@ bool CloughTocherInterpolator::calcNormVec( double x, double y, Vector3D *result
       endpointVXY.setZ( 3 * ( zv - zw ) );
       Vector3D v1( endpointUXY.x() - x, endpointUXY.y() - y, endpointUXY.z() );
       Vector3D v2( endpointVXY.x() - x, endpointVXY.y() - y, endpointVXY.z() );
-      result->setX( v1.getY()*v2.getZ() - v1.getZ()*v2.getY() );
-      result->setY( v1.getZ()*v2.getX() - v1.getX()*v2.getZ() );
-      result->setZ( v1.getX()*v2.getY() - v1.getY()*v2.getX() );
-      result->standardise();
+      result.setX( v1.getY()*v2.getZ() - v1.getZ()*v2.getY() );
+      result.setY( v1.getZ()*v2.getX() - v1.getX()*v2.getZ() );
+      result.setZ( v1.getX()*v2.getY() - v1.getY()*v2.getX() );
+      normalize( result );
       return true;
 
     }
@@ -105,42 +116,39 @@ bool CloughTocherInterpolator::calcNormVec( double x, double y, Vector3D *result
       endpointVXY.setZ( 3 * ( zv - zw ) );
       Vector3D v1( endpointUXY.x() - x, endpointUXY.y() - y, endpointUXY.z() );
       Vector3D v2( endpointVXY.x() - x, endpointVXY.y() - y, endpointVXY.z() );
-      result->setX( v1.getY()*v2.getZ() - v1.getZ()*v2.getY() );
-      result->setY( v1.getZ()*v2.getX() - v1.getX()*v2.getZ() );
-      result->setZ( v1.getX()*v2.getY() - v1.getY()*v2.getX() );
-      result->standardise();
+      result.setX( v1.getY()*v2.getZ() - v1.getZ()*v2.getY() );
+      result.setY( v1.getZ()*v2.getX() - v1.getX()*v2.getZ() );
+      result.setZ( v1.getX()*v2.getY() - v1.getY()*v2.getX() );
+      normalize( result );
       return true;
     }
 
     //the point is in none of the subtriangles, test if point has the same position as one of the vertices
     if ( x == point1.x() && y == point1.y() )
     {
-      result->setX( -der1X );
-      result->setY( -der1Y );
-      result->setZ( 1 );
-      result->standardise();
+      result.setX( -der1X );
+      result.setY( -der1Y );
+      result.setZ( 1 ); normalize( result );
       return true;
     }
     else if ( x == point2.x() && y == point2.y() )
     {
-      result->setX( -der2X );
-      result->setY( -der2Y );
-      result->setZ( 1 );
-      result->standardise();
+      result.setX( -der2X );
+      result.setY( -der2Y );
+      result.setZ( 1 ); normalize( result );
       return true;
     }
     else if ( x == point3.x() && y == point3.y() )
     {
-      result->setX( -der3X );
-      result->setY( -der3Y );
-      result->setZ( 1 );
-      result->standardise();
+      result.setX( -der3X );
+      result.setY( -der3Y );
+      result.setZ( 1 ); normalize( result );
       return true;
     }
 
-    result->setX( 0 );//return a vertical normal if failed
-    result->setY( 0 );
-    result->setZ( 1 );
+    result.setX( 0 );//return a vertical normal if failed
+    result.setY( 0 );
+    result.setZ( 1 );
     return false;
 
   }

--- a/src/analysis/interpolation/CloughTocherInterpolator.h
+++ b/src/analysis/interpolation/CloughTocherInterpolator.h
@@ -106,7 +106,7 @@ class ANALYSIS_EXPORT CloughTocherInterpolator : public TriangleInterpolator
     CloughTocherInterpolator( NormVecDecorator *tin );
 
     //! Calculates the normal vector and assigns it to vec (not implemented at the moment)
-    bool calcNormVec( double x, double y, Vector3D *result SIP_OUT ) override;
+    bool calcNormVec( double x, double y, QgsPoint &result SIP_OUT ) override;
     bool calcPoint( double x, double y, QgsPoint &result SIP_OUT ) override;
     virtual void setTriangulation( NormVecDecorator *tin );
 };

--- a/src/analysis/interpolation/LinTriangleInterpolator.cpp
+++ b/src/analysis/interpolation/LinTriangleInterpolator.cpp
@@ -26,7 +26,7 @@ bool LinTriangleInterpolator::calcFirstDerX( double x, double y, Vector3D *vec )
     QgsPoint pt2( 0, 0, 0 );
     QgsPoint pt3( 0, 0, 0 );
 
-    if ( !mTIN->getTriangle( x, y, pt1, pt2, pt3 ) )
+    if ( !mTIN->triangleVertices( x, y, pt1, pt2, pt3 ) )
     {
       return false;//point outside the convex hull or numerical problems
     }
@@ -52,7 +52,7 @@ bool LinTriangleInterpolator::calcFirstDerY( double x, double y, Vector3D *vec )
     QgsPoint pt2( 0, 0, 0 );
     QgsPoint pt3( 0, 0, 0 );
 
-    if ( !mTIN->getTriangle( x, y, pt1, pt2, pt3 ) )
+    if ( !mTIN->triangleVertices( x, y, pt1, pt2, pt3 ) )
     {
       return false;
     }
@@ -70,10 +70,10 @@ bool LinTriangleInterpolator::calcFirstDerY( double x, double y, Vector3D *vec )
   }
 }
 
-bool LinTriangleInterpolator::calcNormVec( double x, double y, Vector3D *vec )
+bool LinTriangleInterpolator::calcNormVec( double x, double y, QgsPoint &vec )
 {
 //calculate vector product of the two derivative vectors in x- and y-direction and set the length to 1
-  if ( vec && mTIN )
+  if ( mTIN )
   {
     Vector3D vec1;
     Vector3D vec2;
@@ -83,9 +83,9 @@ bool LinTriangleInterpolator::calcNormVec( double x, double y, Vector3D *vec )
     {return false;}
     Vector3D vec3( vec1.getY()*vec2.getZ() - vec1.getZ()*vec2.getY(), vec1.getZ()*vec2.getX() - vec1.getX()*vec2.getZ(), vec1.getX()*vec2.getY() - vec1.getY()*vec2.getX() );//calculate vector product
     double absvec3 = std::sqrt( vec3.getX() * vec3.getX() + vec3.getY() * vec3.getY() + vec3.getZ() * vec3.getZ() );//length of vec3
-    vec->setX( vec3.getX() / absvec3 );//standardize vec3 and assign it to vec
-    vec->setY( vec3.getY() / absvec3 );
-    vec->setZ( vec3.getZ() / absvec3 );
+    vec.setX( vec3.getX() / absvec3 );//standardize vec3 and assign it to vec
+    vec.setY( vec3.getY() / absvec3 );
+    vec.setZ( vec3.getZ() / absvec3 );
     return true;
   }
 
@@ -105,7 +105,7 @@ bool LinTriangleInterpolator::calcPoint( double x, double y, QgsPoint &point )
     QgsPoint pt2( 0, 0, 0 );
     QgsPoint pt3( 0, 0, 0 );
 
-    if ( !mTIN->getTriangle( x, y, pt1, pt2, pt3 ) )
+    if ( !mTIN->triangleVertices( x, y, pt1, pt2, pt3 ) )
     {
       return false;//point is outside the convex hull or numerical problems
     }

--- a/src/analysis/interpolation/LinTriangleInterpolator.h
+++ b/src/analysis/interpolation/LinTriangleInterpolator.h
@@ -18,7 +18,7 @@
 #define LINTRIANGLEINTERPOLATOR_H
 
 #include "TriangleInterpolator.h"
-#include "DualEdgeTriangulation.h"
+#include "qgsdualedgetriangulation.h"
 #include "qgis_analysis.h"
 
 #define SIP_NO_FILE
@@ -34,18 +34,18 @@ class ANALYSIS_EXPORT LinTriangleInterpolator : public TriangleInterpolator
     //! Default constructor
     LinTriangleInterpolator() = default;
     //! Constructor with reference to a DualEdgeTriangulation object
-    LinTriangleInterpolator( DualEdgeTriangulation *tin );
+    LinTriangleInterpolator( QgsDualEdgeTriangulation *tin );
     //! Calculates the normal vector and assigns it to vec
-    bool calcNormVec( double x, double y, Vector3D *result SIP_OUT ) override;
+    bool calcNormVec( double x, double y, QgsPoint &result SIP_OUT ) override;
     bool calcPoint( double x, double y, QgsPoint &result SIP_OUT ) override;
     //! Returns a pointer to the current Triangulation object
-    virtual DualEdgeTriangulation *getTriangulation() const;
+    virtual QgsDualEdgeTriangulation *getTriangulation() const;
     //! Sets a Triangulation
-    virtual void setTriangulation( DualEdgeTriangulation *tin );
+    virtual void setTriangulation( QgsDualEdgeTriangulation *tin );
 
 
   protected:
-    DualEdgeTriangulation *mTIN = nullptr;
+    QgsDualEdgeTriangulation *mTIN = nullptr;
     //! Calculates the first derivative with respect to x for a linear surface and assigns it to vec
     virtual bool calcFirstDerX( double x, double y, Vector3D *result SIP_OUT );
     //! Calculates the first derivative with respect to y for a linear surface and assigns it to vec
@@ -54,17 +54,17 @@ class ANALYSIS_EXPORT LinTriangleInterpolator : public TriangleInterpolator
 
 #ifndef SIP_RUN
 
-inline LinTriangleInterpolator::LinTriangleInterpolator( DualEdgeTriangulation *tin ): mTIN( tin )
+inline LinTriangleInterpolator::LinTriangleInterpolator( QgsDualEdgeTriangulation *tin ): mTIN( tin )
 {
 
 }
 
-inline DualEdgeTriangulation *LinTriangleInterpolator::getTriangulation() const
+inline QgsDualEdgeTriangulation *LinTriangleInterpolator::getTriangulation() const
 {
   return mTIN;
 }
 
-inline void LinTriangleInterpolator::setTriangulation( DualEdgeTriangulation *tin )
+inline void LinTriangleInterpolator::setTriangulation( QgsDualEdgeTriangulation *tin )
 {
   mTIN = tin;
 }

--- a/src/analysis/interpolation/NormVecDecorator.cpp
+++ b/src/analysis/interpolation/NormVecDecorator.cpp
@@ -58,7 +58,7 @@ int NormVecDecorator::addPoint( const QgsPoint &p )
     {
       estimateFirstDerivative( pointno );
       //update also the neighbours of the new point
-      const QList<int> list = mTIN->getSurroundingTriangles( pointno );
+      const QList<int> list = mTIN->surroundingTriangles( pointno );
       auto it = list.constBegin();//iterate through the list and analyze it
       while ( it != list.constEnd() )
       {
@@ -80,7 +80,7 @@ int NormVecDecorator::addPoint( const QgsPoint &p )
   return -1;
 }
 
-bool NormVecDecorator::calcNormal( double x, double y, Vector3D *result )
+bool NormVecDecorator::calcNormal( double x, double y, QgsPoint &result )
 {
   if ( !alreadyestimated )
   {
@@ -100,7 +100,7 @@ bool NormVecDecorator::calcNormal( double x, double y, Vector3D *result )
   }
 }
 
-bool NormVecDecorator::calcNormalForPoint( double x, double y, int point, Vector3D *result )
+bool NormVecDecorator::calcNormalForPoint( double x, double y, int pointIndex, Vector3D *result )
 {
   if ( !alreadyestimated )
   {
@@ -121,7 +121,7 @@ bool NormVecDecorator::calcNormalForPoint( double x, double y, int point, Vector
     result->setY( 0 );
     result->setZ( 0 );
 
-    const QList<int> vlist = getSurroundingTriangles( point );//get the value list
+    const QList<int> vlist = surroundingTriangles( pointIndex );//get the value list
     if ( vlist.empty() )//an error occurred in 'getSurroundingTriangles'
     {
       return false;
@@ -162,13 +162,13 @@ bool NormVecDecorator::calcNormalForPoint( double x, double y, int point, Vector
 
         if ( p1 != -1 && p2 != -1 && p3 != -1 )
         {
-          if ( MathUtils::pointInsideTriangle( x, y, getPoint( p1 ), getPoint( p2 ), getPoint( p3 ) ) )
+          if ( MathUtils::pointInsideTriangle( x, y, point( p1 ), point( p2 ), point( p3 ) ) )
           {
             pointfound = true;
           }
 
           Vector3D addvec( 0, 0, 0 );
-          MathUtils::normalFromPoints( getPoint( p1 ), getPoint( p2 ), getPoint( p3 ), &addvec );
+          MathUtils::normalFromPoints( point( p1 ), point( p2 ), point( p3 ), &addvec );
           result->setX( result->getX() + addvec.getX() );
           result->setY( result->getY() + addvec.getY() );
           result->setZ( result->getZ() + addvec.getZ() );
@@ -254,7 +254,7 @@ bool NormVecDecorator::getTriangle( double x, double y, QgsPoint &p1, Vector3D *
     int nr2 = 0;
     int nr3 = 0;
 
-    if ( TriDecorator::getTriangle( x, y, p1, nr1, p2, nr2, p3, nr3 ) )//everything alright
+    if ( TriDecorator::triangleVertices( x, y, p1, nr1, p2, nr2, p3, nr3 ) )//everything alright
     {
       if ( ( *mNormVec )[ nr1 ] && ( *mNormVec )[ nr2 ] && ( *mNormVec )[ nr3 ] )
       {
@@ -308,7 +308,7 @@ bool NormVecDecorator::getTriangle( double x, double y, QgsPoint &p1, int &ptn1,
 {
   if ( v1 && v2 && v3 && state1 && state2 && state3 )
   {
-    if ( TriDecorator::getTriangle( x, y, p1, ptn1, p2, ptn2, p3, ptn3 ) )//everything alright
+    if ( TriDecorator::triangleVertices( x, y, p1, ptn1, p2, ptn2, p3, ptn3 ) )//everything alright
     {
       v1->setX( ( *mNormVec )[( ptn1 )]->getX() );
       v1->setY( ( *mNormVec )[( ptn1 )]->getY() );
@@ -360,7 +360,7 @@ bool NormVecDecorator::estimateFirstDerivative( int pointno )
   double currentweight = 0;//current weight
   PointState status;
 
-  const QList<int> vlist = getSurroundingTriangles( pointno );//get the value list
+  const QList<int> vlist = surroundingTriangles( pointno );//get the value list
 
   if ( vlist.empty() )
   {
@@ -418,11 +418,11 @@ bool NormVecDecorator::estimateFirstDerivative( int pointno )
 
     if ( p1 != -1 && p2 != -1 && p3 != -1 )//don't calculate normal, if a point is a virtual point
     {
-      MathUtils::normalFromPoints( getPoint( p1 ), getPoint( p2 ), getPoint( p3 ), &part );
-      double dist1 = getPoint( p3 )->distance3D( *getPoint( p1 ) );
-      double dist2 = getPoint( p3 )->distance3D( *getPoint( p2 ) );
+      MathUtils::normalFromPoints( point( p1 ), point( p2 ), point( p3 ), &part );
+      double dist1 = point( p3 )->distance3D( *point( p1 ) );
+      double dist2 = point( p3 )->distance3D( *point( p2 ) );
       //don't add the normal if the triangle is horizontal
-      if ( ( getPoint( p1 )->z() != getPoint( p2 )->z() ) || ( getPoint( p1 )->z() != getPoint( p3 )->z() ) )
+      if ( ( point( p1 )->z() != point( p2 )->z() ) || ( point( p1 )->z() != point( p3 )->z() ) )
       {
         currentweight = 1 / ( dist1 * dist1 * dist2 * dist2 );
         total.setX( total.getX() + part.getX()*currentweight );
@@ -493,7 +493,7 @@ bool NormVecDecorator::estimateFirstDerivative( int pointno )
 //weighted method of little
 bool NormVecDecorator::estimateFirstDerivatives( QgsFeedback *feedback )
 {
-  int numberPoints = getNumberOfPoints();
+  int numberPoints = pointsCount();
   for ( int i = 0; i < numberPoints; i++ )
   {
     if ( feedback )
@@ -545,16 +545,14 @@ bool NormVecDecorator::swapEdge( double x, double y )
     bool b = false;
     if ( alreadyestimated )
     {
-      QList<int> *list = getPointsAroundEdge( x, y );
-      if ( list )
+      const QList<int> list = pointsAroundEdge( x, y );
+      if ( !list.empty() )
       {
         b = mTIN->swapEdge( x, y );
-        QList<int>::iterator it;
-        for ( it = list->begin(); it != list->end(); ++it )
+        for ( int i : list )
         {
-          estimateFirstDerivative( ( *it ) );
+          estimateFirstDerivative( i );
         }
-        delete list;
       }
     }
     else
@@ -577,5 +575,14 @@ bool NormVecDecorator::saveTriangulation( QgsFeatureSink *sink, QgsFeedback *fee
     return false;
   }
   return mTIN->saveTriangulation( sink, feedback );
+}
+
+QgsMesh NormVecDecorator::triangulationToMesh() const
+{
+  if ( !mTIN )
+  {
+    return QgsMesh();
+  }
+  return mTIN->triangulationToMesh();
 }
 

--- a/src/analysis/interpolation/NormVecDecorator.h
+++ b/src/analysis/interpolation/NormVecDecorator.h
@@ -39,6 +39,7 @@ class ANALYSIS_EXPORT NormVecDecorator: public TriDecorator
     //! Enumeration for the state of a point. Normal means, that the point is not on a BreakLine, BreakLine means that the point is on a breakline (but not an end point of it) and EndPoint means, that it is an endpoint of a breakline.
     enum PointState {Normal, BreakLine, EndPoint};
     NormVecDecorator();
+    //! Constructor for TriDecorator with an existing triangulation
     NormVecDecorator( QgsTriangulation *tin );
     ~NormVecDecorator() override;
     int addPoint( const QgsPoint &p ) override;

--- a/src/analysis/interpolation/NormVecDecorator.h
+++ b/src/analysis/interpolation/NormVecDecorator.h
@@ -39,13 +39,13 @@ class ANALYSIS_EXPORT NormVecDecorator: public TriDecorator
     //! Enumeration for the state of a point. Normal means, that the point is not on a BreakLine, BreakLine means that the point is on a breakline (but not an end point of it) and EndPoint means, that it is an endpoint of a breakline.
     enum PointState {Normal, BreakLine, EndPoint};
     NormVecDecorator();
-    NormVecDecorator( Triangulation *tin );
+    NormVecDecorator( QgsTriangulation *tin );
     ~NormVecDecorator() override;
     int addPoint( const QgsPoint &p ) override;
     //! Calculates the normal at a point on the surface and assigns it to 'result'. Returns TRUE in case of success and FALSE in case of failure
-    bool calcNormal( double x, double y, Vector3D *result SIP_OUT ) override;
+    bool calcNormal( double x, double y, QgsPoint &result SIP_OUT ) override;
     //! Calculates the normal of a triangle-point for the point with coordinates x and y. This is needed, if a point is on a break line and there is no unique normal stored in 'mNormVec'. Returns FALSE, it something went wrong and TRUE otherwise
-    bool calcNormalForPoint( double x, double y, int point, Vector3D *result SIP_OUT );
+    bool calcNormalForPoint( double x, double y, int pointIndex, Vector3D *result SIP_OUT );
     bool calcPoint( double x, double y, QgsPoint &result SIP_OUT ) override;
     //! Eliminates the horizontal triangles by swapping or by insertion of new points. If alreadyestimated is TRUE, a re-estimation of the normals will be done
     void eliminateHorizontalTriangles() override;
@@ -67,6 +67,8 @@ class ANALYSIS_EXPORT NormVecDecorator: public TriDecorator
     bool swapEdge( double x, double y ) override;
 
     bool saveTriangulation( QgsFeatureSink *sink, QgsFeedback *feedback = nullptr ) const override;
+
+    QgsMesh triangulationToMesh() const override;
 
   protected:
     //! Is TRUE, if the normals already have been estimated
@@ -95,7 +97,7 @@ inline NormVecDecorator::NormVecDecorator()
   alreadyestimated = false;
 }
 
-inline NormVecDecorator::NormVecDecorator( Triangulation *tin )
+inline NormVecDecorator::NormVecDecorator( QgsTriangulation *tin )
   : TriDecorator( tin )
   , mNormVec( new QVector<Vector3D*>( DEFAULT_STORAGE_FOR_NORMALS ) )
   , mPointState( new QVector<PointState>( DEFAULT_STORAGE_FOR_NORMALS ) )

--- a/src/analysis/interpolation/TriDecorator.cpp
+++ b/src/analysis/interpolation/TriDecorator.cpp
@@ -55,7 +55,7 @@ void TriDecorator::performConsistencyTest()
   }
 }
 
-bool TriDecorator::calcNormal( double x, double y, Vector3D *result )
+bool TriDecorator::calcNormal( double x, double y, QgsPoint &result )
 {
   if ( mTIN )
   {
@@ -83,11 +83,11 @@ bool TriDecorator::calcPoint( double x, double y, QgsPoint &result )
   }
 }
 
-QgsPoint *TriDecorator::getPoint( int i ) const
+QgsPoint *TriDecorator::point( int i ) const
 {
   if ( mTIN )
   {
-    QgsPoint *p = mTIN->getPoint( i );
+    QgsPoint *p = mTIN->point( i );
     return p;
   }
   else
@@ -97,11 +97,11 @@ QgsPoint *TriDecorator::getPoint( int i ) const
   }
 }
 
-bool TriDecorator::getTriangle( double x, double y, QgsPoint &p1, int &n1, QgsPoint &p2, int &n2, QgsPoint &p3, int &n3 )
+bool TriDecorator::triangleVertices( double x, double y, QgsPoint &p1, int &n1, QgsPoint &p2, int &n2, QgsPoint &p3, int &n3 )
 {
   if ( mTIN )
   {
-    bool b = mTIN->getTriangle( x, y, p1, n1, p2, n2, p3, n3 );
+    bool b = mTIN->triangleVertices( x, y, p1, n1, p2, n2, p3, n3 );
     return b;
   }
   else
@@ -111,11 +111,11 @@ bool TriDecorator::getTriangle( double x, double y, QgsPoint &p1, int &n1, QgsPo
   }
 }
 
-bool TriDecorator::getTriangle( double x, double y, QgsPoint &p1, QgsPoint &p2, QgsPoint &p3 )
+bool TriDecorator::triangleVertices( double x, double y, QgsPoint &p1, QgsPoint &p2, QgsPoint &p3 )
 {
   if ( mTIN )
   {
-    bool b = mTIN->getTriangle( x, y, p1, p2, p3 );
+    bool b = mTIN->triangleVertices( x, y, p1, p2, p3 );
     return b;
   }
   else
@@ -125,11 +125,11 @@ bool TriDecorator::getTriangle( double x, double y, QgsPoint &p1, QgsPoint &p2, 
   }
 }
 
-int TriDecorator::getNumberOfPoints() const
+int TriDecorator::pointsCount() const
 {
   if ( mTIN )
   {
-    return ( mTIN->getNumberOfPoints() );
+    return ( mTIN->pointsCount() );
   }
   else
   {
@@ -138,11 +138,11 @@ int TriDecorator::getNumberOfPoints() const
   }
 }
 
-int TriDecorator::getOppositePoint( int p1, int p2 )
+int TriDecorator::oppositePoint( int p1, int p2 )
 {
   if ( mTIN )
   {
-    int i = mTIN->getOppositePoint( p1, p2 );
+    int i = mTIN->oppositePoint( p1, p2 );
     return i;
   }
   else
@@ -152,11 +152,11 @@ int TriDecorator::getOppositePoint( int p1, int p2 )
   }
 }
 
-QList<int> TriDecorator::getSurroundingTriangles( int pointno )
+QList<int> TriDecorator::surroundingTriangles( int pointno )
 {
   if ( mTIN )
   {
-    return mTIN->getSurroundingTriangles( pointno );
+    return mTIN->surroundingTriangles( pointno );
   }
   else
   {
@@ -164,11 +164,11 @@ QList<int> TriDecorator::getSurroundingTriangles( int pointno )
   }
 }
 
-double TriDecorator::getXMax() const
+double TriDecorator::xMax() const
 {
   if ( mTIN )
   {
-    double d = mTIN->getXMax();
+    double d = mTIN->xMax();
     return d;
   }
   else
@@ -178,11 +178,11 @@ double TriDecorator::getXMax() const
   }
 }
 
-double TriDecorator::getXMin() const
+double TriDecorator::xMin() const
 {
   if ( mTIN )
   {
-    double d = mTIN->getXMin();
+    double d = mTIN->xMin();
     return d;
   }
   else
@@ -191,25 +191,11 @@ double TriDecorator::getXMin() const
     return 0;
   }
 }
-double TriDecorator::getYMax() const
+double TriDecorator::yMax() const
 {
   if ( mTIN )
   {
-    double d = mTIN->getYMax();
-    return d;
-  }
-  else
-  {
-    QgsDebugMsg( QStringLiteral( "warning, null pointer" ) );
-    return 0;
-  }
-}
-
-double TriDecorator::getYMin() const
-{
-  if ( mTIN )
-  {
-    double d = mTIN->getYMin();
+    double d = mTIN->yMax();
     return d;
   }
   else
@@ -219,47 +205,25 @@ double TriDecorator::getYMin() const
   }
 }
 
-void TriDecorator::setForcedCrossBehavior( Triangulation::ForcedCrossBehavior b )
+double TriDecorator::yMin() const
+{
+  if ( mTIN )
+  {
+    double d = mTIN->yMin();
+    return d;
+  }
+  else
+  {
+    QgsDebugMsg( QStringLiteral( "warning, null pointer" ) );
+    return 0;
+  }
+}
+
+void TriDecorator::setForcedCrossBehavior( QgsTriangulation::ForcedCrossBehavior b )
 {
   if ( mTIN )
   {
     mTIN->setForcedCrossBehavior( b );
-  }
-  else
-  {
-    QgsDebugMsg( QStringLiteral( "warning, null pointer" ) );
-  }
-}
-
-void TriDecorator::setEdgeColor( int r, int g, int b )
-{
-  if ( mTIN )
-  {
-    mTIN->setEdgeColor( r, g, b );
-  }
-  else
-  {
-    QgsDebugMsg( QStringLiteral( "warning, null pointer" ) );
-  }
-}
-
-void TriDecorator::setForcedEdgeColor( int r, int g, int b )
-{
-  if ( mTIN )
-  {
-    mTIN->setForcedEdgeColor( r, g, b );
-  }
-  else
-  {
-    QgsDebugMsg( QStringLiteral( "warning, null pointer" ) );
-  }
-}
-
-void TriDecorator::setBreakEdgeColor( int r, int g, int b )
-{
-  if ( mTIN )
-  {
-    mTIN->setBreakEdgeColor( r, g, b );
   }
   else
   {
@@ -331,15 +295,15 @@ bool TriDecorator::swapEdge( double x, double y )
   }
 }
 
-QList<int> *TriDecorator::getPointsAroundEdge( double x, double y )
+QList<int> TriDecorator::pointsAroundEdge( double x, double y )
 {
   if ( mTIN )
   {
-    return mTIN->getPointsAroundEdge( x, y );
+    return mTIN->pointsAroundEdge( x, y );
   }
   else
   {
     QgsDebugMsg( QStringLiteral( "warning, null pointer" ) );
-    return nullptr;
+    return QList<int>();
   }
 }

--- a/src/analysis/interpolation/TriDecorator.h
+++ b/src/analysis/interpolation/TriDecorator.h
@@ -33,6 +33,7 @@ class ANALYSIS_EXPORT TriDecorator : public QgsTriangulation
   public:
     //! Constructor for TriDecorator
     TriDecorator() = default;
+    //! Constructor for TriDecorator with an existing triangulation
     explicit TriDecorator( QgsTriangulation *t );
     void addLine( const QVector< QgsPoint> &points, QgsInterpolator::SourceType lineType ) override;
     int addPoint( const QgsPoint &p ) override;

--- a/src/analysis/interpolation/TriDecorator.h
+++ b/src/analysis/interpolation/TriDecorator.h
@@ -17,7 +17,7 @@
 #ifndef TRIDECORATOR_H
 #define TRIDECORATOR_H
 
-#include "Triangulation.h"
+#include "qgstriangulation.h"
 #include "qgis_sip.h"
 #include "qgis_analysis.h"
 
@@ -28,54 +28,51 @@
  * Decorator class for Triangulations (s. Decorator pattern in Gamma et al.).
  * \note Not available in Python bindings.
 */
-class ANALYSIS_EXPORT TriDecorator : public Triangulation
+class ANALYSIS_EXPORT TriDecorator : public QgsTriangulation
 {
   public:
     //! Constructor for TriDecorator
     TriDecorator() = default;
-    explicit TriDecorator( Triangulation *t );
+    explicit TriDecorator( QgsTriangulation *t );
     void addLine( const QVector< QgsPoint> &points, QgsInterpolator::SourceType lineType ) override;
     int addPoint( const QgsPoint &p ) override;
     //! Adds an association to a triangulation
-    virtual void addTriangulation( Triangulation *t );
+    virtual void addTriangulation( QgsTriangulation *t );
     //! Performs a consistency check, remove this later
     void performConsistencyTest() override;
-    bool calcNormal( double x, double y, Vector3D *result SIP_OUT ) override;
+    bool calcNormal( double x, double y, QgsPoint &result SIP_OUT ) override;
     bool calcPoint( double x, double y, QgsPoint &result SIP_OUT ) override;
-    QgsPoint *getPoint( int i ) const override;
-    int getNumberOfPoints() const override;
-    bool getTriangle( double x, double y, QgsPoint &p1 SIP_OUT, int &n1 SIP_OUT, QgsPoint &p2 SIP_OUT, int &n2 SIP_OUT, QgsPoint &p3 SIP_OUT, int &n3 SIP_OUT )  SIP_PYNAME( getTriangleVertices ) override;
-    bool getTriangle( double x, double y, QgsPoint &p1 SIP_OUT, QgsPoint &p2 SIP_OUT, QgsPoint &p3 SIP_OUT ) override;
-    int getOppositePoint( int p1, int p2 ) override;
-    QList<int> getSurroundingTriangles( int pointno ) override;
-    double getXMax() const override;
-    double getXMin() const override;
-    double getYMax() const override;
-    double getYMin() const override;
-    void setForcedCrossBehavior( Triangulation::ForcedCrossBehavior b ) override;
-    void setEdgeColor( int r, int g, int b ) override;
-    void setForcedEdgeColor( int r, int g, int b ) override;
-    void setBreakEdgeColor( int r, int g, int b ) override;
+    QgsPoint *point( int i ) const override;
+    int pointsCount() const override;
+    bool triangleVertices( double x, double y, QgsPoint &p1 SIP_OUT, int &n1 SIP_OUT, QgsPoint &p2 SIP_OUT, int &n2 SIP_OUT, QgsPoint &p3 SIP_OUT, int &n3 SIP_OUT ) override;
+    bool triangleVertices( double x, double y, QgsPoint &p1 SIP_OUT, QgsPoint &p2 SIP_OUT, QgsPoint &p3 SIP_OUT ) override;
+    int oppositePoint( int p1, int p2 ) override;
+    QList<int> surroundingTriangles( int pointno ) override;
+    double xMax() const override;
+    double xMin() const override;
+    double yMax() const override;
+    double yMin() const override;
+    void setForcedCrossBehavior( QgsTriangulation::ForcedCrossBehavior b ) override;
     void setTriangleInterpolator( TriangleInterpolator *interpolator ) override;
     void eliminateHorizontalTriangles() override;
     void ruppertRefinement() override;
     bool pointInside( double x, double y ) override;
     bool swapEdge( double x, double y ) override;
-    QList<int> *getPointsAroundEdge( double x, double y ) override;
+    QList<int> pointsAroundEdge( double x, double y ) override;
   protected:
     //! Association with a Triangulation object
-    Triangulation *mTIN = nullptr;
+    QgsTriangulation *mTIN = nullptr;
 };
 
 #ifndef SIP_RUN
 
-inline TriDecorator::TriDecorator( Triangulation *t )
+inline TriDecorator::TriDecorator( QgsTriangulation *t )
   : mTIN( t )
 {
 
 }
 
-inline void TriDecorator::addTriangulation( Triangulation *t )
+inline void TriDecorator::addTriangulation( QgsTriangulation *t )
 {
   mTIN = t;
 }

--- a/src/analysis/interpolation/TriangleInterpolator.h
+++ b/src/analysis/interpolation/TriangleInterpolator.h
@@ -36,7 +36,7 @@ class ANALYSIS_EXPORT TriangleInterpolator
   public:
     virtual ~TriangleInterpolator() = default;
     //! Calculates the normal vector and assigns it to vec
-    virtual bool calcNormVec( double x, double y, Vector3D *result SIP_OUT ) = 0;
+    virtual bool calcNormVec( double x, double y, QgsPoint &result SIP_OUT ) = 0;
     //! Performs a linear interpolation in a triangle and assigns the x-,y- and z-coordinates to point
     virtual bool calcPoint( double x, double y, QgsPoint &result SIP_OUT ) = 0;
 };

--- a/src/analysis/interpolation/qgsdualedgetriangulation.cpp
+++ b/src/analysis/interpolation/qgsdualedgetriangulation.cpp
@@ -15,7 +15,7 @@
  ***************************************************************************/
 
 
-#include "DualEdgeTriangulation.h"
+#include "qgsdualedgetriangulation.h"
 #include <map>
 #include "MathUtils.h"
 #include "qgsgeometry.h"
@@ -25,7 +25,7 @@
 
 double leftOfTresh = 0.00000001;
 
-DualEdgeTriangulation::~DualEdgeTriangulation()
+QgsDualEdgeTriangulation::~QgsDualEdgeTriangulation()
 {
   //remove all the points
   if ( !mPointVector.isEmpty() )
@@ -46,7 +46,7 @@ DualEdgeTriangulation::~DualEdgeTriangulation()
   }
 }
 
-void DualEdgeTriangulation::performConsistencyTest()
+void QgsDualEdgeTriangulation::performConsistencyTest()
 {
   QgsDebugMsg( QStringLiteral( "performing consistency test" ) );
 
@@ -66,7 +66,7 @@ void DualEdgeTriangulation::performConsistencyTest()
   QgsDebugMsg( QStringLiteral( "consistency test finished" ) );
 }
 
-void DualEdgeTriangulation::addLine( const QVector<QgsPoint> &points, QgsInterpolator::SourceType lineType )
+void QgsDualEdgeTriangulation::addLine( const QVector<QgsPoint> &points, QgsInterpolator::SourceType lineType )
 {
   int actpoint = -10;//number of the last point, which has been inserted from the line
   int currentpoint = -10;//number of the point, which is currently inserted from the line
@@ -98,22 +98,22 @@ void DualEdgeTriangulation::addLine( const QVector<QgsPoint> &points, QgsInterpo
   }
 }
 
-int DualEdgeTriangulation::addPoint( const QgsPoint &p )
+int QgsDualEdgeTriangulation::addPoint( const QgsPoint &p )
 {
   //first update the bounding box
   if ( mPointVector.isEmpty() )//update bounding box when the first point is inserted
   {
-    xMin = p.x();
-    yMin = p.y();
-    xMax = p.x();
-    yMax = p.y();
+    mXMin = p.x();
+    mYMin = p.y();
+    mXMax = p.x();
+    mYMax = p.y();
   }
   else //update bounding box else
   {
-    xMin = std::min( p.x(), xMin );
-    xMax = std::max( p.x(), xMax );
-    yMin = std::min( p.y(), yMin );
-    yMax = std::max( p.y(), yMax );
+    mXMin = std::min( p.x(), mXMin );
+    mXMax = std::max( p.x(), mXMax );
+    mYMin = std::min( p.y(), mYMin );
+    mYMax = std::max( p.y(), mYMax );
   }
 
   //then update mPointVector
@@ -369,7 +369,7 @@ int DualEdgeTriangulation::addPoint( const QgsPoint &p )
   return ( mPointVector.count() - 1 );
 }
 
-int DualEdgeTriangulation::baseEdgeOfPoint( int point )
+int QgsDualEdgeTriangulation::baseEdgeOfPoint( int point )
 {
   unsigned int actedge = mEdgeInside;//starting edge
 
@@ -441,7 +441,7 @@ int DualEdgeTriangulation::baseEdgeOfPoint( int point )
   }
 }
 
-int DualEdgeTriangulation::baseEdgeOfTriangle( const QgsPoint &point )
+int QgsDualEdgeTriangulation::baseEdgeOfTriangle( const QgsPoint &point )
 {
   unsigned int actedge = mEdgeInside;//start with an edge which does not point to the virtual point (usually number 3)
   int counter = 0;//number of consecutive successful left-of-tests
@@ -618,9 +618,9 @@ int DualEdgeTriangulation::baseEdgeOfTriangle( const QgsPoint &point )
   return -100;//this means a bug happened
 }
 
-bool DualEdgeTriangulation::calcNormal( double x, double y, Vector3D *result )
+bool QgsDualEdgeTriangulation::calcNormal( double x, double y, QgsPoint &result )
 {
-  if ( result && mTriangleInterpolator )
+  if ( mTriangleInterpolator )
   {
     return mTriangleInterpolator->calcNormVec( x, y, result );
   }
@@ -631,7 +631,7 @@ bool DualEdgeTriangulation::calcNormal( double x, double y, Vector3D *result )
   }
 }
 
-bool DualEdgeTriangulation::calcPoint( double x, double y, QgsPoint &result )
+bool QgsDualEdgeTriangulation::calcPoint( double x, double y, QgsPoint &result )
 {
   if ( mTriangleInterpolator )
   {
@@ -644,7 +644,7 @@ bool DualEdgeTriangulation::calcPoint( double x, double y, QgsPoint &result )
   }
 }
 
-bool DualEdgeTriangulation::checkSwap( unsigned int edge, unsigned int recursiveDeep )
+bool QgsDualEdgeTriangulation::checkSwap( unsigned int edge, unsigned int recursiveDeep )
 {
   if ( swapPossible( edge ) )
   {
@@ -661,7 +661,7 @@ bool DualEdgeTriangulation::checkSwap( unsigned int edge, unsigned int recursive
   return false;
 }
 
-void DualEdgeTriangulation::doOnlySwap( unsigned int edge )
+void QgsDualEdgeTriangulation::doOnlySwap( unsigned int edge )
 {
   unsigned int edge1 = edge;
   unsigned int edge2 = mHalfEdge[edge]->getDual();
@@ -679,7 +679,7 @@ void DualEdgeTriangulation::doOnlySwap( unsigned int edge )
   mHalfEdge[edge2]->setPoint( mHalfEdge[edge5]->getPoint() );
 }
 
-void DualEdgeTriangulation::doSwap( unsigned int edge, unsigned int recursiveDeep )
+void QgsDualEdgeTriangulation::doSwap( unsigned int edge, unsigned int recursiveDeep )
 {
   unsigned int edge1 = edge;
   unsigned int edge2 = mHalfEdge[edge]->getDual();
@@ -853,7 +853,7 @@ void DualEdgeTriangulation::draw( QPainter *p, double xlowleft, double ylowleft,
 }
 #endif
 
-int DualEdgeTriangulation::getOppositePoint( int p1, int p2 )
+int QgsDualEdgeTriangulation::oppositePoint( int p1, int p2 )
 {
 
   //first find a half edge which points to p2
@@ -887,7 +887,7 @@ int DualEdgeTriangulation::getOppositePoint( int p1, int p2 )
 
 }
 
-QList<int> DualEdgeTriangulation::getSurroundingTriangles( int pointno )
+QList<int> QgsDualEdgeTriangulation::surroundingTriangles( int pointno )
 {
   int firstedge = baseEdgeOfPoint( pointno );
 
@@ -923,7 +923,7 @@ QList<int> DualEdgeTriangulation::getSurroundingTriangles( int pointno )
 
 }
 
-bool DualEdgeTriangulation::getTriangle( double x, double y, QgsPoint &p1, int &n1, QgsPoint &p2, int &n2, QgsPoint &p3, int &n3 )
+bool QgsDualEdgeTriangulation::triangleVertices( double x, double y, QgsPoint &p1, int &n1, QgsPoint &p2, int &n2, QgsPoint &p3, int &n3 )
 {
   if ( mPointVector.size() < 3 )
   {
@@ -1031,7 +1031,7 @@ bool DualEdgeTriangulation::getTriangle( double x, double y, QgsPoint &p1, int &
   }
 }
 
-bool DualEdgeTriangulation::getTriangle( double x, double y, QgsPoint &p1, QgsPoint &p2, QgsPoint &p3 )
+bool QgsDualEdgeTriangulation::triangleVertices( double x, double y, QgsPoint &p1, QgsPoint &p2, QgsPoint &p3 )
 {
   if ( mPointVector.size() < 3 )
   {
@@ -1129,7 +1129,7 @@ bool DualEdgeTriangulation::getTriangle( double x, double y, QgsPoint &p1, QgsPo
   }
 }
 
-unsigned int DualEdgeTriangulation::insertEdge( int dual, int next, int point, bool mbreak, bool forced )
+unsigned int QgsDualEdgeTriangulation::insertEdge( int dual, int next, int point, bool mbreak, bool forced )
 {
   HalfEdge *edge = new HalfEdge( dual, next, point, mbreak, forced );
   mHalfEdge.append( edge );
@@ -1137,7 +1137,7 @@ unsigned int DualEdgeTriangulation::insertEdge( int dual, int next, int point, b
 
 }
 
-int DualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolator::SourceType segmentType )
+int QgsDualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolator::SourceType segmentType )
 {
   if ( p1 == p2 )
   {
@@ -1207,7 +1207,7 @@ int DualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolator:
     }
     else if ( MathUtils::lineIntersection( mPointVector[p1], mPointVector[p2], mPointVector[mHalfEdge[mHalfEdge[actedge]->getNext()]->getPoint()], mPointVector[mHalfEdge[mHalfEdge[mHalfEdge[actedge]->getNext()]->getDual()]->getPoint()] ) )
     {
-      if ( mHalfEdge[mHalfEdge[actedge]->getNext()]->getForced() && mForcedCrossBehavior == Triangulation::SnappingTypeVertex )//if the crossed edge is a forced edge, we have to snap the forced line to the next node
+      if ( mHalfEdge[mHalfEdge[actedge]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::SnappingTypeVertex )//if the crossed edge is a forced edge, we have to snap the forced line to the next node
       {
         QgsPoint crosspoint( 0, 0, 0 );
         int p3, p4;
@@ -1229,7 +1229,7 @@ int DualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolator:
           return e;
         }
       }
-      else if ( mHalfEdge[mHalfEdge[actedge]->getNext()]->getForced() && mForcedCrossBehavior == Triangulation::InsertVertex )//if the crossed edge is a forced edge, we have to insert a new vertice on this edge
+      else if ( mHalfEdge[mHalfEdge[actedge]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::InsertVertex )//if the crossed edge is a forced edge, we have to insert a new vertice on this edge
       {
         QgsPoint crosspoint( 0, 0, 0 );
         int p3, p4;
@@ -1295,7 +1295,7 @@ int DualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolator:
   {
     if ( MathUtils::lineIntersection( mPointVector[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getPoint()], mPointVector[mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getPoint()], mPointVector[p1], mPointVector[p2] ) )
     {
-      if ( mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getForced() && mForcedCrossBehavior == Triangulation::SnappingTypeVertex )//if the crossed edge is a forced edge and mForcedCrossBehavior is SnappingType_VERTICE, we have to snap the forced line to the next node
+      if ( mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::SnappingTypeVertex )//if the crossed edge is a forced edge and mForcedCrossBehavior is SnappingType_VERTICE, we have to snap the forced line to the next node
       {
         QgsPoint crosspoint( 0, 0, 0 );
         int p3, p4;
@@ -1317,7 +1317,7 @@ int DualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolator:
           return e;
         }
       }
-      else if ( mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getForced() && mForcedCrossBehavior == Triangulation::InsertVertex )//if the crossed edge is a forced edge, we have to insert a new vertice on this edge
+      else if ( mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::InsertVertex )//if the crossed edge is a forced edge, we have to insert a new vertice on this edge
       {
         QgsPoint crosspoint( 0, 0, 0 );
         int p3, p4;
@@ -1342,7 +1342,7 @@ int DualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolator:
     }
     else if ( MathUtils::lineIntersection( mPointVector[mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getPoint()], mPointVector[mHalfEdge[mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getNext()]->getPoint()], mPointVector[p1], mPointVector[p2] ) )
     {
-      if ( mHalfEdge[mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getNext()]->getForced() && mForcedCrossBehavior == Triangulation::SnappingTypeVertex )//if the crossed edge is a forced edge and mForcedCrossBehavior is SnappingType_VERTICE, we have to snap the forced line to the next node
+      if ( mHalfEdge[mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::SnappingTypeVertex )//if the crossed edge is a forced edge and mForcedCrossBehavior is SnappingType_VERTICE, we have to snap the forced line to the next node
       {
         QgsPoint crosspoint( 0, 0, 0 );
         int p3, p4;
@@ -1364,7 +1364,7 @@ int DualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolator:
           return e;
         }
       }
-      else if ( mHalfEdge[mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getNext()]->getForced() && mForcedCrossBehavior == Triangulation::InsertVertex )//if the crossed edge is a forced edge, we have to insert a new vertice on this edge
+      else if ( mHalfEdge[mHalfEdge[mHalfEdge[mHalfEdge[crossedEdges.last()]->getDual()]->getNext()]->getNext()]->getForced() && mForcedCrossBehavior == QgsTriangulation::InsertVertex )//if the crossed edge is a forced edge, we have to insert a new vertice on this edge
       {
         QgsPoint crosspoint( 0, 0, 0 );
         int p3, p4;
@@ -1507,32 +1507,17 @@ int DualEdgeTriangulation::insertForcedSegment( int p1, int p2, QgsInterpolator:
   return leftPolygon.first();
 }
 
-void DualEdgeTriangulation::setForcedCrossBehavior( Triangulation::ForcedCrossBehavior b )
+void QgsDualEdgeTriangulation::setForcedCrossBehavior( QgsTriangulation::ForcedCrossBehavior b )
 {
   mForcedCrossBehavior = b;
 }
 
-void DualEdgeTriangulation::setEdgeColor( int r, int g, int b )
-{
-  mEdgeColor.setRgb( r, g, b );
-}
-
-void DualEdgeTriangulation::setForcedEdgeColor( int r, int g, int b )
-{
-  mForcedEdgeColor.setRgb( r, g, b );
-}
-
-void DualEdgeTriangulation::setBreakEdgeColor( int r, int g, int b )
-{
-  mBreakEdgeColor.setRgb( r, g, b );
-}
-
-void DualEdgeTriangulation::setTriangleInterpolator( TriangleInterpolator *interpolator )
+void QgsDualEdgeTriangulation::setTriangleInterpolator( TriangleInterpolator *interpolator )
 {
   mTriangleInterpolator = interpolator;
 }
 
-void DualEdgeTriangulation::eliminateHorizontalTriangles()
+void QgsDualEdgeTriangulation::eliminateHorizontalTriangles()
 {
   QgsDebugMsg( QStringLiteral( "am in eliminateHorizontalTriangles" ) );
   double minangle = 0;//minimum angle for swapped triangles. If triangles generated by a swap would have a minimum angle (in degrees) below that value, the swap will not be done.
@@ -1621,7 +1606,7 @@ void DualEdgeTriangulation::eliminateHorizontalTriangles()
   QgsDebugMsg( QStringLiteral( "end of method" ) );
 }
 
-void DualEdgeTriangulation::ruppertRefinement()
+void QgsDualEdgeTriangulation::ruppertRefinement()
 {
   //minimum angle
   double mintol = 17;//refinement stops after the minimum angle reached this tolerance
@@ -2311,7 +2296,7 @@ void DualEdgeTriangulation::ruppertRefinement()
 }
 
 
-bool DualEdgeTriangulation::swapPossible( unsigned int edge )
+bool QgsDualEdgeTriangulation::swapPossible( unsigned int edge )
 {
   //test, if edge belongs to a forced edge
   if ( mHalfEdge[edge]->getForced() )
@@ -2348,7 +2333,7 @@ bool DualEdgeTriangulation::swapPossible( unsigned int edge )
   return true;
 }
 
-void DualEdgeTriangulation::triangulatePolygon( QList<int> *poly, QList<int> *free, int mainedge )
+void QgsDualEdgeTriangulation::triangulatePolygon( QList<int> *poly, QList<int> *free, int mainedge )
 {
   if ( poly && free )
   {
@@ -2485,7 +2470,7 @@ void DualEdgeTriangulation::triangulatePolygon( QList<int> *poly, QList<int> *fr
 
 }
 
-bool DualEdgeTriangulation::pointInside( double x, double y )
+bool QgsDualEdgeTriangulation::pointInside( double x, double y )
 {
   QgsPoint point( x, y, 0 );
   unsigned int actedge = mEdgeInside;//start with an edge which does not point to the virtual point
@@ -2851,7 +2836,7 @@ bool DualEdgeTriangulation::saveToTAFF( QString filename ) const
 }
 #endif //0
 
-bool DualEdgeTriangulation::swapEdge( double x, double y )
+bool QgsDualEdgeTriangulation::swapEdge( double x, double y )
 {
   QgsPoint p( x, y, 0 );
   int edge1 = baseEdgeOfTriangle( p );
@@ -2863,9 +2848,9 @@ bool DualEdgeTriangulation::swapEdge( double x, double y )
     QgsPoint *point3 = nullptr;
     edge2 = mHalfEdge[edge1]->getNext();
     edge3 = mHalfEdge[edge2]->getNext();
-    point1 = getPoint( mHalfEdge[edge1]->getPoint() );
-    point2 = getPoint( mHalfEdge[edge2]->getPoint() );
-    point3 = getPoint( mHalfEdge[edge3]->getPoint() );
+    point1 = point( mHalfEdge[edge1]->getPoint() );
+    point2 = point( mHalfEdge[edge2]->getPoint() );
+    point3 = point( mHalfEdge[edge3]->getPoint() );
     if ( point1 && point2 && point3 )
     {
       //find out the closest edge to the point and swap this edge
@@ -2912,17 +2897,18 @@ bool DualEdgeTriangulation::swapEdge( double x, double y )
   }
 }
 
-QList<int> *DualEdgeTriangulation::getPointsAroundEdge( double x, double y )
+QList<int> QgsDualEdgeTriangulation::pointsAroundEdge( double x, double y )
 {
   QgsPoint p( x, y, 0 );
+  QList<int> list;
   const int edge1 = baseEdgeOfTriangle( p );
   if ( edge1 >= 0 )
   {
     const int edge2 = mHalfEdge[edge1]->getNext();
     const int edge3 = mHalfEdge[edge2]->getNext();
-    QgsPoint *point1 = getPoint( mHalfEdge[edge1]->getPoint() );
-    QgsPoint *point2 = getPoint( mHalfEdge[edge2]->getPoint() );
-    QgsPoint *point3 = getPoint( mHalfEdge[edge3]->getPoint() );
+    QgsPoint *point1 = point( mHalfEdge[edge1]->getPoint() );
+    QgsPoint *point2 = point( mHalfEdge[edge2]->getPoint() );
+    QgsPoint *point3 = point( mHalfEdge[edge3]->getPoint() );
     if ( point1 && point2 && point3 )
     {
       int p1, p2, p3, p4;
@@ -2950,27 +2936,26 @@ QList<int> *DualEdgeTriangulation::getPointsAroundEdge( double x, double y )
         p3 = mHalfEdge[mHalfEdge[edge3]->getDual()]->getPoint();
         p4 = mHalfEdge[mHalfEdge[mHalfEdge[edge3]->getDual()]->getNext()]->getPoint();
       }
-      QList<int> *list = new QList<int>();
-      list->append( p1 );
-      list->append( p2 );
-      list->append( p3 );
-      list->append( p4 );
-      return list;
+
+
+      list.append( p1 );
+      list.append( p2 );
+      list.append( p3 );
+      list.append( p4 );
     }
     else
     {
       QgsDebugMsg( QStringLiteral( "warning: null pointer" ) );
-      return nullptr;
     }
   }
   else
   {
     QgsDebugMsg( QStringLiteral( "Edge number negative" ) );
-    return nullptr;
   }
+  return list;
 }
 
-bool DualEdgeTriangulation::saveTriangulation( QgsFeatureSink *sink, QgsFeedback *feedback ) const
+bool QgsDualEdgeTriangulation::saveTriangulation( QgsFeatureSink *sink, QgsFeedback *feedback ) const
 {
   if ( !sink )
   {
@@ -3033,12 +3018,55 @@ bool DualEdgeTriangulation::saveTriangulation( QgsFeatureSink *sink, QgsFeedback
   return !feedback || !feedback->isCanceled();
 }
 
-double DualEdgeTriangulation::swapMinAngle( int edge ) const
+QgsMesh QgsDualEdgeTriangulation::triangulationToMesh() const
 {
-  QgsPoint *p1 = getPoint( mHalfEdge[edge]->getPoint() );
-  QgsPoint *p2 = getPoint( mHalfEdge[mHalfEdge[edge]->getNext()]->getPoint() );
-  QgsPoint *p3 = getPoint( mHalfEdge[mHalfEdge[edge]->getDual()]->getPoint() );
-  QgsPoint *p4 = getPoint( mHalfEdge[mHalfEdge[mHalfEdge[edge]->getDual()]->getNext()]->getPoint() );
+  QVector<bool> alreadyVisitedEdges( mHalfEdge.count(), false );
+
+  //QSet<HalfEdge *> edgeToTreat = QSet<HalfEdge *>::fromList( mHalfEdge.toList() );
+  QVector< bool> edgeToTreat( mHalfEdge.count(), true );
+  QHash<HalfEdge *, int > edgesHash;
+  for ( int i = 0; i < mHalfEdge.count(); ++i )
+  {
+    edgesHash.insert( mHalfEdge[i], i );
+  }
+
+  QgsMesh mesh;
+
+  for ( int i = 0 ; i < edgeToTreat.count(); ++i )
+  {
+    bool containVirtualPoint = false;
+    if ( edgeToTreat[i] )
+    {
+      HalfEdge *currentEdge = mHalfEdge[i];
+      HalfEdge *firstEdge = currentEdge;
+      QgsMeshFace face;
+      do
+      {
+        edgeToTreat[edgesHash.value( currentEdge )] = false;
+        face.append( currentEdge->getPoint() );
+        containVirtualPoint |= currentEdge->getPoint() == -1;
+        currentEdge = mHalfEdge.at( currentEdge->getNext() );
+      }
+      while ( currentEdge != firstEdge );
+      if ( !containVirtualPoint )
+        mesh.faces.append( face );
+    }
+  }
+
+  for ( const QgsPoint *point : mPointVector )
+  {
+    mesh.vertices.append( *point );
+  }
+
+  return mesh;
+}
+
+double QgsDualEdgeTriangulation::swapMinAngle( int edge ) const
+{
+  QgsPoint *p1 = point( mHalfEdge[edge]->getPoint() );
+  QgsPoint *p2 = point( mHalfEdge[mHalfEdge[edge]->getNext()]->getPoint() );
+  QgsPoint *p3 = point( mHalfEdge[mHalfEdge[edge]->getDual()]->getPoint() );
+  QgsPoint *p4 = point( mHalfEdge[mHalfEdge[mHalfEdge[edge]->getDual()]->getNext()]->getPoint() );
 
   //search for the minimum angle (it is important, which directions the lines have!)
   double minangle;
@@ -3073,7 +3101,7 @@ double DualEdgeTriangulation::swapMinAngle( int edge ) const
   return minangle;
 }
 
-int DualEdgeTriangulation::splitHalfEdge( int edge, float position )
+int QgsDualEdgeTriangulation::splitHalfEdge( int edge, float position )
 {
   //just a short test if position is between 0 and 1
   if ( position < 0 || position > 1 )
@@ -3128,12 +3156,12 @@ int DualEdgeTriangulation::splitHalfEdge( int edge, float position )
   return mPointVector.count() - 1;
 }
 
-bool DualEdgeTriangulation::edgeOnConvexHull( int edge )
+bool QgsDualEdgeTriangulation::edgeOnConvexHull( int edge )
 {
   return ( mHalfEdge[mHalfEdge[edge]->getNext()]->getPoint() == -1 || mHalfEdge[mHalfEdge[mHalfEdge[edge]->getDual()]->getNext()]->getPoint() == -1 );
 }
 
-void DualEdgeTriangulation::evaluateInfluenceRegion( QgsPoint *point, int edge, QSet<int> &set )
+void QgsDualEdgeTriangulation::evaluateInfluenceRegion( QgsPoint *point, int edge, QSet<int> &set )
 {
   if ( set.find( edge ) == set.end() )
   {

--- a/src/analysis/interpolation/qgsdualedgetriangulation.cpp
+++ b/src/analysis/interpolation/qgsdualedgetriangulation.cpp
@@ -74,7 +74,7 @@ void QgsDualEdgeTriangulation::addLine( const QVector<QgsPoint> &points, QgsInte
   int i = 0;
   for ( const QgsPoint &point : points )
   {
-    actpoint = mDecorator->addPoint( point );
+    actpoint = addPoint( point );
     i++;
     if ( actpoint != -100 )
     {
@@ -89,7 +89,7 @@ void QgsDualEdgeTriangulation::addLine( const QVector<QgsPoint> &points, QgsInte
 
   for ( ; i < points.size(); ++i )
   {
-    currentpoint = mDecorator->addPoint( points.at( i ) );
+    currentpoint = addPoint( points.at( i ) );
     if ( currentpoint != -100 && actpoint != -100 && currentpoint != actpoint )//-100 is the return value if the point could not be not inserted
     {
       insertForcedSegment( actpoint, currentpoint, lineType );
@@ -2102,8 +2102,8 @@ void QgsDualEdgeTriangulation::ruppertRefinement()
     /*******otherwise, try to add the circumcenter to the triangulation************************************************************************************************/
 
     QgsPoint p( 0, 0, 0 );
-    mDecorator->calcPoint( circumcenter.x(), circumcenter.y(), p );
-    int pointno = mDecorator->addPoint( p );
+    calcPoint( circumcenter.x(), circumcenter.y(), p );
+    int pointno = addPoint( p );
 
     if ( pointno == -100 || pointno == mTwiceInsPoint )
     {
@@ -3022,7 +3022,6 @@ QgsMesh QgsDualEdgeTriangulation::triangulationToMesh() const
 {
   QVector<bool> alreadyVisitedEdges( mHalfEdge.count(), false );
 
-  //QSet<HalfEdge *> edgeToTreat = QSet<HalfEdge *>::fromList( mHalfEdge.toList() );
   QVector< bool> edgeToTreat( mHalfEdge.count(), true );
   QHash<HalfEdge *, int > edgesHash;
   for ( int i = 0; i < mHalfEdge.count(); ++i )
@@ -3114,7 +3113,7 @@ int QgsDualEdgeTriangulation::splitHalfEdge( int edge, float position )
 
   //calculate the z-value of the point to insert
   QgsPoint zvaluepoint( 0, 0, 0 );
-  mDecorator->calcPoint( p->x(), p->y(), zvaluepoint );
+  calcPoint( p->x(), p->y(), zvaluepoint );
   p->setZ( zvaluepoint.z() );
 
   //insert p into mPointVector
@@ -3151,7 +3150,7 @@ int QgsDualEdgeTriangulation::splitHalfEdge( int edge, float position )
   checkSwap( mHalfEdge[dualedge]->getNext(), 0 );
   checkSwap( mHalfEdge[edge3]->getNext(), 0 );
 
-  mDecorator->addPoint( QgsPoint( p->x(), p->y(), 0 ) );//dirty hack to enforce update of decorators
+  addPoint( QgsPoint( p->x(), p->y(), 0 ) );//dirty hack to enforce update of decorators
 
   return mPointVector.count() - 1;
 }

--- a/src/analysis/interpolation/qgsdualedgetriangulation.h
+++ b/src/analysis/interpolation/qgsdualedgetriangulation.h
@@ -43,14 +43,16 @@
  * \ingroup analysis
  * DualEdgeTriangulation is an implementation of a triangulation class based on the dual edge data structure.
  * \note Not available in Python bindings.
+ *
+ * \since QGIS 3.16
 */
 class ANALYSIS_EXPORT QgsDualEdgeTriangulation: public QgsTriangulation
 {
   public:
     QgsDualEdgeTriangulation();
-    QgsDualEdgeTriangulation( int nop, QgsTriangulation *decorator );
+    //! Constructor with a number of points to reserve
+    QgsDualEdgeTriangulation( int nop );
     ~QgsDualEdgeTriangulation() override;
-    void setDecorator( QgsTriangulation *d ) {mDecorator = d;}
     void addLine( const QVector< QgsPoint > &points, QgsInterpolator::SourceType lineType ) override;
     int addPoint( const QgsPoint &p ) override;
     //! Performs a consistency check, remove this later
@@ -116,8 +118,6 @@ class ANALYSIS_EXPORT QgsDualEdgeTriangulation: public QgsTriangulation
     TriangleInterpolator *mTriangleInterpolator = nullptr;
     //! Member to store the behavior in case of crossing forced segments
     QgsTriangulation::ForcedCrossBehavior mForcedCrossBehavior = QgsTriangulation::DeleteFirst;
-    //! Pointer to the decorator using this triangulation. It it is used directly, mDecorator equals this
-    QgsTriangulation *mDecorator = nullptr;
     //! Inserts an edge and makes sure, everything is OK with the storage of the edge. The number of the HalfEdge is returned
     unsigned int insertEdge( int dual, int next, int point, bool mbreak, bool forced );
     //! Inserts a forced segment between the points with the numbers p1 and p2 into the triangulation and returns the number of a HalfEdge belonging to this forced edge or -100 in case of failure
@@ -167,14 +167,12 @@ class ANALYSIS_EXPORT QgsDualEdgeTriangulation: public QgsTriangulation
 #ifndef SIP_RUN
 
 inline QgsDualEdgeTriangulation::QgsDualEdgeTriangulation()
-  : mDecorator( this )
 {
   mPointVector.reserve( DEFAULT_STORAGE_FOR_POINTS );
   mHalfEdge.reserve( DEFAULT_STORAGE_FOR_HALF_EDGES );
 }
 
-inline QgsDualEdgeTriangulation::QgsDualEdgeTriangulation( int nop, QgsTriangulation *decorator )
-  : mDecorator( decorator ? decorator : this )
+inline QgsDualEdgeTriangulation::QgsDualEdgeTriangulation( int nop )
 {
   mPointVector.reserve( nop );
   mHalfEdge.reserve( nop );

--- a/src/analysis/interpolation/qgstininterpolator.cpp
+++ b/src/analysis/interpolation/qgstininterpolator.cpp
@@ -79,7 +79,7 @@ void QgsTinInterpolator::setTriangulationSink( QgsFeatureSink *sink )
 
 void QgsTinInterpolator::initialize()
 {
-  QgsDualEdgeTriangulation *dualEdgeTriangulation = new QgsDualEdgeTriangulation( 100000, nullptr );
+  QgsDualEdgeTriangulation *dualEdgeTriangulation = new QgsDualEdgeTriangulation( 100000 );
   if ( mInterpolation == CloughTocher )
   {
     NormVecDecorator *dec = new NormVecDecorator();

--- a/src/analysis/interpolation/qgstininterpolator.cpp
+++ b/src/analysis/interpolation/qgstininterpolator.cpp
@@ -18,7 +18,7 @@
 #include "qgstininterpolator.h"
 #include "qgsfeatureiterator.h"
 #include "CloughTocherInterpolator.h"
-#include "DualEdgeTriangulation.h"
+#include "qgsdualedgetriangulation.h"
 #include "NormVecDecorator.h"
 #include "LinTriangleInterpolator.h"
 #include "qgspoint.h"
@@ -69,7 +69,7 @@ int QgsTinInterpolator::interpolatePoint( double x, double y, double &result, Qg
 
 QgsFields QgsTinInterpolator::triangulationFields()
 {
-  return Triangulation::triangulationFields();
+  return QgsTriangulation::triangulationFields();
 }
 
 void QgsTinInterpolator::setTriangulationSink( QgsFeatureSink *sink )
@@ -79,7 +79,7 @@ void QgsTinInterpolator::setTriangulationSink( QgsFeatureSink *sink )
 
 void QgsTinInterpolator::initialize()
 {
-  DualEdgeTriangulation *dualEdgeTriangulation = new DualEdgeTriangulation( 100000, nullptr );
+  QgsDualEdgeTriangulation *dualEdgeTriangulation = new QgsDualEdgeTriangulation( 100000, nullptr );
   if ( mInterpolation == CloughTocher )
   {
     NormVecDecorator *dec = new NormVecDecorator();

--- a/src/analysis/interpolation/qgstininterpolator.h
+++ b/src/analysis/interpolation/qgstininterpolator.h
@@ -23,7 +23,7 @@
 #include "qgis_analysis.h"
 
 class QgsFeatureSink;
-class Triangulation;
+class QgsTriangulation;
 class TriangleInterpolator;
 class QgsFeature;
 class QgsFeedback;
@@ -76,7 +76,7 @@ class ANALYSIS_EXPORT QgsTinInterpolator: public QgsInterpolator
     void setTriangulationSink( QgsFeatureSink *sink );
 
   private:
-    Triangulation *mTriangulation = nullptr;
+    QgsTriangulation *mTriangulation = nullptr;
     TriangleInterpolator *mTriangleInterpolator = nullptr;
     bool mIsInitialized;
     QgsFeedback *mFeedback = nullptr;

--- a/src/analysis/interpolation/qgstriangulation.cpp
+++ b/src/analysis/interpolation/qgstriangulation.cpp
@@ -12,10 +12,10 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-#include "Triangulation.h"
+#include "qgstriangulation.h"
 #include "qgsfields.h"
 
-QgsFields Triangulation::triangulationFields()
+QgsFields QgsTriangulation::triangulationFields()
 {
   QgsFields fields;
   fields.append( QgsField( QStringLiteral( "type" ), QVariant::String, QStringLiteral( "String" ) ) );

--- a/src/analysis/interpolation/qgstriangulation.h
+++ b/src/analysis/interpolation/qgstriangulation.h
@@ -35,6 +35,8 @@ class QgsFeedback;
  * \ingroup analysis
  * Interface for Triangulation classes.
  * \note Not available in Python bindings.
+ *
+ * \since QGIS 3.16
 */
 class ANALYSIS_EXPORT QgsTriangulation
 {

--- a/src/analysis/interpolation/qgstriangulation.h
+++ b/src/analysis/interpolation/qgstriangulation.h
@@ -23,6 +23,7 @@
 #include "TriangleInterpolator.h"
 #include "qgis_analysis.h"
 #include "qgsinterpolator.h"
+#include "qgsmeshdataprovider.h"
 
 class QgsFeatureSink;
 class QgsFields;
@@ -35,7 +36,7 @@ class QgsFeedback;
  * Interface for Triangulation classes.
  * \note Not available in Python bindings.
 */
-class ANALYSIS_EXPORT Triangulation
+class ANALYSIS_EXPORT QgsTriangulation
 {
   public:
     //! Enumeration describing the behavior, if two forced lines cross.
@@ -45,13 +46,13 @@ class ANALYSIS_EXPORT Triangulation
       DeleteFirst,        //!< The status of the first inserted forced line is reset to that of a normal edge (so that the second inserted forced line remain and the first not)
       InsertVertex
     };
-    virtual ~Triangulation() = default;
+    virtual ~QgsTriangulation() = default;
 
     /**
      * Adds a line (e.g. a break-, structure- or an isoline) to the triangulation, by specifying
      * a list of source \a points.
      */
-    virtual void addLine( const QVector< QgsPoint > &points, QgsInterpolator::SourceType lineType ) = 0;
+    virtual void addLine( const QgsPointSequence &points, QgsInterpolator::SourceType lineType ) = 0;
 
     /**
      * Adds a \a point to the triangulation.
@@ -64,7 +65,7 @@ class ANALYSIS_EXPORT Triangulation
      * Calculates the normal at a point on the surface and assigns it to 'result'.
      * \returns TRUE in case of success and FALSE in case of failure
      */
-    virtual bool calcNormal( double x, double y, Vector3D *result SIP_OUT ) = 0;
+    virtual bool calcNormal( double x, double y, QgsPoint &result SIP_OUT ) = 0;
 
     //! Performs a consistency check, remove this later
     virtual void performConsistencyTest() = 0;
@@ -75,17 +76,17 @@ class ANALYSIS_EXPORT Triangulation
      */
     virtual bool calcPoint( double x, double y, QgsPoint &result SIP_OUT ) = 0;
 
-    //! Returns a pointer to the point with number i. Any virtual points must have the number -1
-    virtual QgsPoint *getPoint( int i ) const = 0;
+    //! Returns a pointer to the point with number i.
+    virtual QgsPoint *point( int i ) const = 0;
 
     /**
      * Finds out in which triangle the point with coordinates x and y is and
      * assigns the numbers of the vertices to 'n1', 'n2' and 'n3' and the vertices to 'p1', 'p2' and 'p3'
      */
-    virtual bool getTriangle( double x, double y, QgsPoint &p1 SIP_OUT, int &n1 SIP_OUT, QgsPoint &p2 SIP_OUT, int &n2 SIP_OUT, QgsPoint &p3 SIP_OUT, int &n3 SIP_OUT ) = 0 SIP_PYNAME( getTriangleVertices );
+    virtual bool triangleVertices( double x, double y, QgsPoint &p1 SIP_OUT, int &n1 SIP_OUT, QgsPoint &p2 SIP_OUT, int &n2 SIP_OUT, QgsPoint &p3 SIP_OUT, int &n3 SIP_OUT ) = 0;
 
     //! Finds out, in which triangle the point with coordinates x and y is and assigns the  points at the vertices to 'p1', 'p2' and 'p3
-    virtual bool getTriangle( double x, double y, QgsPoint &p1 SIP_OUT, QgsPoint &p2 SIP_OUT, QgsPoint &p3 SIP_OUT ) = 0;
+    virtual bool triangleVertices( double x, double y, QgsPoint &p1 SIP_OUT, QgsPoint &p2 SIP_OUT, QgsPoint &p3 SIP_OUT ) = 0;
 
     /**
      * Returns the number of the point opposite to the triangle points p1, p2 (which have to be on a halfedge).
@@ -93,30 +94,30 @@ class ANALYSIS_EXPORT Triangulation
      * Returns -1 if point is a virtual point.
      * Returns -10 if point crosses over edges.
      */
-    virtual int getOppositePoint( int p1, int p2 ) = 0;
+    virtual int oppositePoint( int p1, int p2 ) = 0;
 
     //! Returns the largest x-coordinate value of the bounding box
-    virtual double getXMax() const = 0;
+    virtual double xMax() const = 0;
 
     //! Returns the smallest x-coordinate value of the bounding box
-    virtual double getXMin() const = 0;
+    virtual double xMin() const = 0;
 
     //! Returns the largest y-coordinate value of the bounding box
-    virtual double getYMax() const = 0;
+    virtual double yMax() const = 0;
 
     //! Returns the smallest x-coordinate value of the bounding box
-    virtual double getYMin() const = 0;
+    virtual double yMin() const = 0;
 
     //! Returns the number of points
-    virtual int getNumberOfPoints() const = 0;
+    virtual int pointsCount() const = 0;
 
     /**
-     * Returns a pointer to a value list with the information of the triangles surrounding (counterclockwise) a point.
+     * Returns a value list with the information of the triangles surrounding (counterclockwise) a point.
      * Four integer values describe a triangle, the first three are the number of the half edges of the triangle
      * and the fourth is -10, if the third (and most counterclockwise) edge is a breakline, and -20 otherwise.
      * Any virtual point needs to have the number -1
      */
-    virtual QList<int> getSurroundingTriangles( int pointno ) = 0;
+    virtual QList<int> surroundingTriangles( int pointno ) = 0;
 
     /**
      * Returns a value list with the numbers of the four points, which would be affected by an edge swap.
@@ -124,22 +125,13 @@ class ANALYSIS_EXPORT Triangulation
      * for which the normals have to be recalculated.
      * The list has to be deleted by the code which calls this method
      */
-    virtual QList<int> *getPointsAroundEdge( double x, double y ) = 0;
+    virtual QList<int> pointsAroundEdge( double x, double y ) = 0;
 
     //! Draws the points, edges and the forced lines
     //virtual void draw(QPainter* p, double xlowleft, double ylowleft, double xupright, double yupright, double width, double height) const=0;
 
     //! Sets the behavior of the triangulation in case of crossing forced lines
-    virtual void setForcedCrossBehavior( Triangulation::ForcedCrossBehavior b ) = 0;
-
-    //! Sets the color of the normal edges
-    virtual void setEdgeColor( int r, int g, int b ) = 0;
-
-    //! Sets the color of the forced edges
-    virtual void setForcedEdgeColor( int r, int g, int b ) = 0;
-
-    //! Sets the color of the breaklines
-    virtual void setBreakEdgeColor( int r, int g, int b ) = 0;
+    virtual void setForcedCrossBehavior( QgsTriangulation::ForcedCrossBehavior b ) = 0;
 
     //! Sets an interpolator object
     virtual void setTriangleInterpolator( TriangleInterpolator *interpolator ) = 0;
@@ -183,6 +175,13 @@ class ANALYSIS_EXPORT Triangulation
      *  \since QGIS 3.0
      */
     virtual bool saveTriangulation( QgsFeatureSink *sink, QgsFeedback *feedback = nullptr ) const = 0;
+
+    /**
+     * Returns a QgsMesh corresponding to the triangulation
+     *
+     * \since QGIS 3.16
+     */
+    virtual QgsMesh triangulationToMesh() const = 0;
 };
 
 #endif

--- a/tests/src/analysis/testqgsinterpolator.cpp
+++ b/tests/src/analysis/testqgsinterpolator.cpp
@@ -15,7 +15,7 @@ Email                : nyall dot dawson at gmail dot com
 #include "qgstest.h"
 
 #include "qgsapplication.h"
-#include "DualEdgeTriangulation.h"
+#include "qgsdualedgetriangulation.h"
 
 class TestQgsInterpolator : public QObject
 {
@@ -56,22 +56,22 @@ void TestQgsInterpolator::cleanup()
 
 void TestQgsInterpolator::dualEdge()
 {
-  DualEdgeTriangulation tri;
-  QVERIFY( !tri.getPoint( 0 ) );
-  QVERIFY( !tri.getPoint( 1 ) );
-  QCOMPARE( tri.getNumberOfPoints(), 0 );
+  QgsDualEdgeTriangulation tri;
+  QVERIFY( !tri.point( 0 ) );
+  QVERIFY( !tri.point( 1 ) );
+  QCOMPARE( tri.pointsCount(), 0 );
 
   tri.addPoint( QgsPoint( 1, 2, 3 ) );
-  QCOMPARE( *tri.getPoint( 0 ), QgsPoint( 1, 2, 3 ) );
-  QCOMPARE( tri.getNumberOfPoints(), 1 );
+  QCOMPARE( *tri.point( 0 ), QgsPoint( 1, 2, 3 ) );
+  QCOMPARE( tri.pointsCount(), 1 );
 
   tri.addPoint( QgsPoint( 3, 0, 4 ) );
-  QCOMPARE( *tri.getPoint( 1 ), QgsPoint( 3, 0, 4 ) );
-  QCOMPARE( tri.getNumberOfPoints(), 2 );
+  QCOMPARE( *tri.point( 1 ), QgsPoint( 3, 0, 4 ) );
+  QCOMPARE( tri.pointsCount(), 2 );
 
   tri.addPoint( QgsPoint( 4, 4, 5 ) );
-  QCOMPARE( *tri.getPoint( 2 ), QgsPoint( 4, 4, 5 ) );
-  QCOMPARE( tri.getNumberOfPoints(), 3 );
+  QCOMPARE( *tri.point( 2 ), QgsPoint( 4, 4, 5 ) );
+  QCOMPARE( tri.pointsCount(), 3 );
 
   QgsPoint p1( 0, 0, 0 );
   QgsPoint p2( 0, 0, 0 );
@@ -80,26 +80,26 @@ void TestQgsInterpolator::dualEdge()
   int n2 = 0;
   int n3 = 0;
   QVERIFY( !tri.pointInside( 0, 1 ) );
-  QVERIFY( !tri.getTriangle( 0, 1, p1, p2, p3 ) );
-  QVERIFY( !tri.getTriangle( 0, 1, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( !tri.triangleVertices( 0, 1, p1, p2, p3 ) );
+  QVERIFY( !tri.triangleVertices( 0, 1, p1, n1, p2, n2, p3, n3 ) );
   QVERIFY( !tri.pointInside( 1, 1 ) );
-  QVERIFY( !tri.getTriangle( 1, 1, p1, p2, p3 ) );
-  QVERIFY( !tri.getTriangle( 1, 1, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( !tri.triangleVertices( 1, 1, p1, p2, p3 ) );
+  QVERIFY( !tri.triangleVertices( 1, 1, p1, n1, p2, n2, p3, n3 ) );
   QVERIFY( !tri.pointInside( 4, 1 ) );
-  QVERIFY( !tri.getTriangle( 4, 1, p1, p2, p3 ) );
-  QVERIFY( !tri.getTriangle( 4, 1, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( !tri.triangleVertices( 4, 1, p1, p2, p3 ) );
+  QVERIFY( !tri.triangleVertices( 4, 1, p1, n1, p2, n2, p3, n3 ) );
   QVERIFY( !tri.pointInside( 2, 4 ) );
-  QVERIFY( !tri.getTriangle( 2, 4, p1, p2, p3 ) );
-  QVERIFY( !tri.getTriangle( 2, 4, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( !tri.triangleVertices( 2, 4, p1, p2, p3 ) );
+  QVERIFY( !tri.triangleVertices( 2, 4, p1, n1, p2, n2, p3, n3 ) );
   QVERIFY( !tri.pointInside( 3, -1 ) );
-  QVERIFY( !tri.getTriangle( 3, -1, p1, p2, p3 ) );
-  QVERIFY( !tri.getTriangle( 3, -1, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( !tri.triangleVertices( 3, -1, p1, p2, p3 ) );
+  QVERIFY( !tri.triangleVertices( 3, -1, p1, n1, p2, n2, p3, n3 ) );
   QVERIFY( tri.pointInside( 2, 2 ) );
-  QVERIFY( tri.getTriangle( 2, 2, p1, p2, p3 ) );
+  QVERIFY( tri.triangleVertices( 2, 2, p1, p2, p3 ) );
   QCOMPARE( p1, QgsPoint( 1, 2, 3 ) );
   QCOMPARE( p2, QgsPoint( 3, 0, 4 ) );
   QCOMPARE( p3, QgsPoint( 4, 4, 5 ) );
-  QVERIFY( tri.getTriangle( 2, 2, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( tri.triangleVertices( 2, 2, p1, n1, p2, n2, p3, n3 ) );
   QCOMPARE( p1, QgsPoint( 1, 2, 3 ) );
   QCOMPARE( p2, QgsPoint( 3, 0, 4 ) );
   QCOMPARE( p3, QgsPoint( 4, 4, 5 ) );
@@ -107,11 +107,11 @@ void TestQgsInterpolator::dualEdge()
   QCOMPARE( n2, 1 );
   QCOMPARE( n3, 2 );
   QVERIFY( tri.pointInside( 3, 1 ) );
-  QVERIFY( tri.getTriangle( 3, 1, p1, p2, p3 ) );
+  QVERIFY( tri.triangleVertices( 3, 1, p1, p2, p3 ) );
   QCOMPARE( p1, QgsPoint( 1, 2, 3 ) );
   QCOMPARE( p2, QgsPoint( 3, 0, 4 ) );
   QCOMPARE( p3, QgsPoint( 4, 4, 5 ) );
-  QVERIFY( tri.getTriangle( 3, 1, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( tri.triangleVertices( 3, 1, p1, n1, p2, n2, p3, n3 ) );
   QCOMPARE( p1, QgsPoint( 1, 2, 3 ) );
   QCOMPARE( p2, QgsPoint( 3, 0, 4 ) );
   QCOMPARE( p3, QgsPoint( 4, 4, 5 ) );
@@ -119,11 +119,11 @@ void TestQgsInterpolator::dualEdge()
   QCOMPARE( n2, 1 );
   QCOMPARE( n3, 2 );
   QVERIFY( tri.pointInside( 3.5, 3.5 ) );
-  QVERIFY( tri.getTriangle( 3.5, 3.5, p1, p2, p3 ) );
+  QVERIFY( tri.triangleVertices( 3.5, 3.5, p1, p2, p3 ) );
   QCOMPARE( p1, QgsPoint( 1, 2, 3 ) );
   QCOMPARE( p2, QgsPoint( 3, 0, 4 ) );
   QCOMPARE( p3, QgsPoint( 4, 4, 5 ) );
-  QVERIFY( tri.getTriangle( 3.5, 3.5, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( tri.triangleVertices( 3.5, 3.5, p1, n1, p2, n2, p3, n3 ) );
   QCOMPARE( p1, QgsPoint( 1, 2, 3 ) );
   QCOMPARE( p2, QgsPoint( 3, 0, 4 ) );
   QCOMPARE( p3, QgsPoint( 4, 4, 5 ) );
@@ -131,36 +131,36 @@ void TestQgsInterpolator::dualEdge()
   QCOMPARE( n2, 1 );
   QCOMPARE( n3, 2 );
 
-  QCOMPARE( tri.getOppositePoint( 0, 1 ), -1 );
-  QCOMPARE( tri.getOppositePoint( 0, 2 ), 1 );
-  QCOMPARE( tri.getOppositePoint( 1, 0 ), 2 );
-  QCOMPARE( tri.getOppositePoint( 1, 2 ), -1 );
-  QCOMPARE( tri.getOppositePoint( 2, 0 ), -1 );
-  QCOMPARE( tri.getOppositePoint( 2, 1 ), 0 );
+  QCOMPARE( tri.oppositePoint( 0, 1 ), -1 );
+  QCOMPARE( tri.oppositePoint( 0, 2 ), 1 );
+  QCOMPARE( tri.oppositePoint( 1, 0 ), 2 );
+  QCOMPARE( tri.oppositePoint( 1, 2 ), -1 );
+  QCOMPARE( tri.oppositePoint( 2, 0 ), -1 );
+  QCOMPARE( tri.oppositePoint( 2, 1 ), 0 );
 
   // add another point
   tri.addPoint( QgsPoint( 2, 4, 6 ) );
-  QCOMPARE( *tri.getPoint( 3 ), QgsPoint( 2, 4, 6 ) );
-  QCOMPARE( tri.getNumberOfPoints(), 4 );
+  QCOMPARE( *tri.point( 3 ), QgsPoint( 2, 4, 6 ) );
+  QCOMPARE( tri.pointsCount(), 4 );
   QVERIFY( !tri.pointInside( 2, 4.5 ) );
-  QVERIFY( !tri.getTriangle( 2, 4.5, p1, p2, p3 ) );
-  QVERIFY( !tri.getTriangle( 2, 4.5, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( !tri.triangleVertices( 2, 4.5, p1, p2, p3 ) );
+  QVERIFY( !tri.triangleVertices( 2, 4.5, p1, n1, p2, n2, p3, n3 ) );
   QVERIFY( !tri.pointInside( 1, 4 ) );
-  QVERIFY( !tri.getTriangle( 1, 4, p1, p2, p3 ) );
-  QVERIFY( !tri.getTriangle( 1, 4, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( !tri.triangleVertices( 1, 4, p1, p2, p3 ) );
+  QVERIFY( !tri.triangleVertices( 1, 4, p1, n1, p2, n2, p3, n3 ) );
   QVERIFY( tri.pointInside( 2, 3.5 ) );
-  QVERIFY( tri.getTriangle( 2, 3.5, p1, p2, p3 ) );
+  QVERIFY( tri.triangleVertices( 2, 3.5, p1, p2, p3 ) );
   QCOMPARE( p1, QgsPoint( 1, 2, 3 ) );
   QCOMPARE( p2, QgsPoint( 4, 4, 5 ) );
   QCOMPARE( p3, QgsPoint( 2, 4, 6 ) );
-  QVERIFY( tri.getTriangle( 2, 3.5, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( tri.triangleVertices( 2, 3.5, p1, n1, p2, n2, p3, n3 ) );
   QCOMPARE( p1, QgsPoint( 1, 2, 3 ) );
   QCOMPARE( p2, QgsPoint( 4, 4, 5 ) );
   QCOMPARE( p3, QgsPoint( 2, 4, 6 ) );
   QCOMPARE( n1, 0 );
   QCOMPARE( n2, 2 );
   QCOMPARE( n3, 3 );
-  QVERIFY( tri.getTriangle( 2, 2, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( tri.triangleVertices( 2, 2, p1, n1, p2, n2, p3, n3 ) );
   QCOMPARE( p1, QgsPoint( 1, 2, 3 ) );
   QCOMPARE( p2, QgsPoint( 3, 0, 4 ) );
   QCOMPARE( p3, QgsPoint( 4, 4, 5 ) );
@@ -168,36 +168,36 @@ void TestQgsInterpolator::dualEdge()
   QCOMPARE( n2, 1 );
   QCOMPARE( n3, 2 );
 
-  QCOMPARE( tri.getOppositePoint( 0, 1 ), -1 );
-  QCOMPARE( tri.getOppositePoint( 0, 2 ), 1 );
-  QCOMPARE( tri.getOppositePoint( 0, 3 ), 2 );
-  QCOMPARE( tri.getOppositePoint( 1, 0 ), 2 );
-  QCOMPARE( tri.getOppositePoint( 1, 2 ), -1 );
-  QCOMPARE( tri.getOppositePoint( 1, 3 ), -10 );
-  QCOMPARE( tri.getOppositePoint( 2, 0 ), 3 );
-  QCOMPARE( tri.getOppositePoint( 2, 1 ), 0 );
-  QCOMPARE( tri.getOppositePoint( 2, 3 ), -1 );
-  QCOMPARE( tri.getOppositePoint( 3, 0 ), -1 );
-  QCOMPARE( tri.getOppositePoint( 3, 1 ), -10 );
-  QCOMPARE( tri.getOppositePoint( 3, 2 ), 0 );
+  QCOMPARE( tri.oppositePoint( 0, 1 ), -1 );
+  QCOMPARE( tri.oppositePoint( 0, 2 ), 1 );
+  QCOMPARE( tri.oppositePoint( 0, 3 ), 2 );
+  QCOMPARE( tri.oppositePoint( 1, 0 ), 2 );
+  QCOMPARE( tri.oppositePoint( 1, 2 ), -1 );
+  QCOMPARE( tri.oppositePoint( 1, 3 ), -10 );
+  QCOMPARE( tri.oppositePoint( 2, 0 ), 3 );
+  QCOMPARE( tri.oppositePoint( 2, 1 ), 0 );
+  QCOMPARE( tri.oppositePoint( 2, 3 ), -1 );
+  QCOMPARE( tri.oppositePoint( 3, 0 ), -1 );
+  QCOMPARE( tri.oppositePoint( 3, 1 ), -10 );
+  QCOMPARE( tri.oppositePoint( 3, 2 ), 0 );
 
 
   // add another point
   tri.addPoint( QgsPoint( 2, 2, 7 ) );
-  QCOMPARE( *tri.getPoint( 4 ), QgsPoint( 2, 2, 7 ) );
-  QCOMPARE( tri.getNumberOfPoints(), 5 );
+  QCOMPARE( *tri.point( 4 ), QgsPoint( 2, 2, 7 ) );
+  QCOMPARE( tri.pointsCount(), 5 );
   QVERIFY( !tri.pointInside( 2, 4.5 ) );
-  QVERIFY( !tri.getTriangle( 2, 4.5, p1, p2, p3 ) );
-  QVERIFY( !tri.getTriangle( 2, 4.5, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( !tri.triangleVertices( 2, 4.5, p1, p2, p3 ) );
+  QVERIFY( !tri.triangleVertices( 2, 4.5, p1, n1, p2, n2, p3, n3 ) );
   QVERIFY( !tri.pointInside( 1, 4 ) );
-  QVERIFY( !tri.getTriangle( 1, 4, p1, p2, p3 ) );
-  QVERIFY( !tri.getTriangle( 1, 4, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( !tri.triangleVertices( 1, 4, p1, p2, p3 ) );
+  QVERIFY( !tri.triangleVertices( 1, 4, p1, n1, p2, n2, p3, n3 ) );
   QVERIFY( tri.pointInside( 2, 3.5 ) );
-  QVERIFY( tri.getTriangle( 2, 3.5, p1, p2, p3 ) );
+  QVERIFY( tri.triangleVertices( 2, 3.5, p1, p2, p3 ) );
   QCOMPARE( p1, QgsPoint( 2, 4, 6 ) );
   QCOMPARE( p2, QgsPoint( 1, 2, 3 ) );
   QCOMPARE( p3, QgsPoint( 2, 2, 7 ) );
-  QVERIFY( tri.getTriangle( 2, 3.5, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( tri.triangleVertices( 2, 3.5, p1, n1, p2, n2, p3, n3 ) );
   QCOMPARE( p1, QgsPoint( 2, 4, 6 ) );
   QCOMPARE( p2, QgsPoint( 1, 2, 3 ) );
   QCOMPARE( p3, QgsPoint( 2, 2, 7 ) );
@@ -205,11 +205,11 @@ void TestQgsInterpolator::dualEdge()
   QCOMPARE( n2, 0 );
   QCOMPARE( n3, 4 );
   QVERIFY( tri.pointInside( 2, 1.5 ) );
-  QVERIFY( tri.getTriangle( 2, 1.5, p1, p2, p3 ) );
+  QVERIFY( tri.triangleVertices( 2, 1.5, p1, p2, p3 ) );
   QCOMPARE( p1, QgsPoint( 1, 2, 3 ) );
   QCOMPARE( p2, QgsPoint( 3, 0, 4 ) );
   QCOMPARE( p3, QgsPoint( 2, 2, 7 ) );
-  QVERIFY( tri.getTriangle( 2, 1.5, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( tri.triangleVertices( 2, 1.5, p1, n1, p2, n2, p3, n3 ) );
   QCOMPARE( p1, QgsPoint( 1, 2, 3 ) );
   QCOMPARE( p2, QgsPoint( 3, 0, 4 ) );
   QCOMPARE( p3, QgsPoint( 2, 2, 7 ) );
@@ -217,11 +217,11 @@ void TestQgsInterpolator::dualEdge()
   QCOMPARE( n2, 1 );
   QCOMPARE( n3, 4 );
   QVERIFY( tri.pointInside( 3.1, 1 ) );
-  QVERIFY( tri.getTriangle( 3.1, 1, p1, p2, p3 ) );
+  QVERIFY( tri.triangleVertices( 3.1, 1, p1, p2, p3 ) );
   QCOMPARE( p1, QgsPoint( 2, 2, 7 ) );
   QCOMPARE( p2, QgsPoint( 3, 0, 4 ) );
   QCOMPARE( p3, QgsPoint( 4, 4, 5 ) );
-  QVERIFY( tri.getTriangle( 3.1, 1, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( tri.triangleVertices( 3.1, 1, p1, n1, p2, n2, p3, n3 ) );
   QCOMPARE( p1, QgsPoint( 2, 2, 7 ) );
   QCOMPARE( p2, QgsPoint( 3, 0, 4 ) );
   QCOMPARE( p3, QgsPoint( 4, 4, 5 ) );
@@ -229,11 +229,11 @@ void TestQgsInterpolator::dualEdge()
   QCOMPARE( n2, 1 );
   QCOMPARE( n3, 2 );
   QVERIFY( tri.pointInside( 2.5, 3.5 ) );
-  QVERIFY( tri.getTriangle( 2.5, 3.5, p1, p2, p3 ) );
+  QVERIFY( tri.triangleVertices( 2.5, 3.5, p1, p2, p3 ) );
   QCOMPARE( p1, QgsPoint( 2, 2, 7 ) );
   QCOMPARE( p2, QgsPoint( 4, 4, 5 ) );
   QCOMPARE( p3, QgsPoint( 2, 4, 6 ) );
-  QVERIFY( tri.getTriangle( 2.5, 3.5, p1, n1, p2, n2, p3, n3 ) );
+  QVERIFY( tri.triangleVertices( 2.5, 3.5, p1, n1, p2, n2, p3, n3 ) );
   QCOMPARE( p1, QgsPoint( 2, 2, 7 ) );
   QCOMPARE( p2, QgsPoint( 4, 4, 5 ) );
   QCOMPARE( p3, QgsPoint( 2, 4, 6 ) );
@@ -241,28 +241,43 @@ void TestQgsInterpolator::dualEdge()
   QCOMPARE( n2, 2 );
   QCOMPARE( n3, 3 );
 
-  QCOMPARE( tri.getOppositePoint( 0, 1 ), -1 );
-  QCOMPARE( tri.getOppositePoint( 0, 2 ), -10 );
-  QCOMPARE( tri.getOppositePoint( 0, 3 ), 4 );
-  QCOMPARE( tri.getOppositePoint( 0, 4 ), 1 );
-  QCOMPARE( tri.getOppositePoint( 1, 0 ), 4 );
-  QCOMPARE( tri.getOppositePoint( 1, 2 ), -1 );
-  QCOMPARE( tri.getOppositePoint( 1, 3 ), -10 );
-  QCOMPARE( tri.getOppositePoint( 1, 4 ), 2 );
-  QCOMPARE( tri.getOppositePoint( 2, 0 ), -10 );
-  QCOMPARE( tri.getOppositePoint( 2, 1 ), 4 );
-  QCOMPARE( tri.getOppositePoint( 2, 3 ), -1 );
-  QCOMPARE( tri.getOppositePoint( 2, 4 ), 3 );
-  QCOMPARE( tri.getOppositePoint( 3, 0 ), -1 );
-  QCOMPARE( tri.getOppositePoint( 3, 1 ), -10 );
-  QCOMPARE( tri.getOppositePoint( 3, 2 ), 4 );
-  QCOMPARE( tri.getOppositePoint( 3, 4 ), 0 );
-  QCOMPARE( tri.getOppositePoint( 4, 0 ), 3 );
-  QCOMPARE( tri.getOppositePoint( 4, 1 ), 0 );
-  QCOMPARE( tri.getOppositePoint( 4, 2 ), 1 );
-  QCOMPARE( tri.getOppositePoint( 4, 3 ), 2 );
+  QCOMPARE( tri.oppositePoint( 0, 1 ), -1 );
+  QCOMPARE( tri.oppositePoint( 0, 2 ), -10 );
+  QCOMPARE( tri.oppositePoint( 0, 3 ), 4 );
+  QCOMPARE( tri.oppositePoint( 0, 4 ), 1 );
+  QCOMPARE( tri.oppositePoint( 1, 0 ), 4 );
+  QCOMPARE( tri.oppositePoint( 1, 2 ), -1 );
+  QCOMPARE( tri.oppositePoint( 1, 3 ), -10 );
+  QCOMPARE( tri.oppositePoint( 1, 4 ), 2 );
+  QCOMPARE( tri.oppositePoint( 2, 0 ), -10 );
+  QCOMPARE( tri.oppositePoint( 2, 1 ), 4 );
+  QCOMPARE( tri.oppositePoint( 2, 3 ), -1 );
+  QCOMPARE( tri.oppositePoint( 2, 4 ), 3 );
+  QCOMPARE( tri.oppositePoint( 3, 0 ), -1 );
+  QCOMPARE( tri.oppositePoint( 3, 1 ), -10 );
+  QCOMPARE( tri.oppositePoint( 3, 2 ), 4 );
+  QCOMPARE( tri.oppositePoint( 3, 4 ), 0 );
+  QCOMPARE( tri.oppositePoint( 4, 0 ), 3 );
+  QCOMPARE( tri.oppositePoint( 4, 1 ), 0 );
+  QCOMPARE( tri.oppositePoint( 4, 2 ), 1 );
+  QCOMPARE( tri.oppositePoint( 4, 3 ), 2 );
 
 //  QVERIFY( tri.getSurroundingTriangles( 0 ).empty() );
+
+  QgsMesh mesh = tri.triangulationToMesh();
+  QCOMPARE( mesh.faceCount(), 4 );
+  QCOMPARE( mesh.vertexCount(), 5 );
+
+  QCOMPARE( mesh.vertex( 0 ), QgsMeshVertex( 1.0, 2.0, 3.0 ) );
+  QCOMPARE( mesh.vertex( 1 ), QgsMeshVertex( 3.0, 0.0, 4.0 ) );
+  QCOMPARE( mesh.vertex( 2 ), QgsMeshVertex( 4.0, 4.0, 5.0 ) );
+  QCOMPARE( mesh.vertex( 3 ), QgsMeshVertex( 2.0, 4.0, 6.0 ) );
+  QCOMPARE( mesh.vertex( 4 ), QgsMeshVertex( 2.0, 2.0, 7.0 ) );
+
+  QCOMPARE( mesh.face( 0 ), QgsMeshFace( {0, 4, 3} ) );
+  QCOMPARE( mesh.face( 1 ), QgsMeshFace( {1, 4, 0} ) );
+  QCOMPARE( mesh.face( 2 ), QgsMeshFace( {2, 4, 1} ) );
+  QCOMPARE( mesh.face( 3 ), QgsMeshFace( {4, 2, 3} ) );
 }
 
 QGSTEST_MAIN( TestQgsInterpolator )


### PR DESCRIPTION
In this PR :
- renaming and cleaning of the Triangulation class and DualEdgeTriangulation class to make them more consistent with QGIS code
- add a method to export the triangulation to a QgsMesh instance

The aim of this PR is to add the possibility to construct mesh layer with triangulation from existing points and lines. This first step allows to obtain a QgsMesh that is the base of mesh layers.