### PR TITLE
show line numbers in the query are of the virtual layer dialog (fix #23185)

### DIFF
--- a/src/providers/virtual/qgsvirtuallayersourceselect.cpp
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.cpp
@@ -43,6 +43,9 @@ QgsVirtualLayerSourceSelect::QgsVirtualLayerSourceSelect( QWidget *parent, Qt::W
   setupUi( this );
   setupButtons( buttonBox );
 
+  mQueryEdit->setMarginWidth( 1, QStringLiteral( "000" ) );
+  mQueryEdit->setMarginLineNumbers( 1, true );
+
   connect( mTestButton, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::testQuery );
   connect( mBrowseCRSBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::browseCRS );
   connect( mAddLayerBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::addLayer );


### PR DESCRIPTION
## Description
Adds line numbers to the query text edit in the "Add virtual layer" dialog. This improves UX a bit, especially when query has errors and corresponding message indicates line with error.

Fixes #23185.