### PR TITLE
allow to copy all line measurements at once (fix #20498)

### DIFF
--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -27,6 +27,7 @@
 #include "qgssettings.h"
 #include "qgsgui.h"
 
+#include <QClipboard>
 #include <QCloseEvent>
 #include <QLocale>
 #include <QPushButton>
@@ -54,6 +55,13 @@ QgsMeasureDialog::QgsMeasureDialog( QgsMeasureTool *tool, Qt::WindowFlags f )
   QPushButton *cb = new QPushButton( tr( "&Configuration" ) );
   buttonBox->addButton( cb, QDialogButtonBox::ActionRole );
   connect( cb, &QAbstractButton::clicked, this, &QgsMeasureDialog::openConfigTab );
+
+  if ( !mMeasureArea )
+  {
+    QPushButton *cpb = new QPushButton( tr( "Copy &All" ) );
+    buttonBox->addButton( cpb, QDialogButtonBox::ActionRole );
+    connect( cpb, &QAbstractButton::clicked, this, &QgsMeasureDialog::copyMeasurements );
+  }
 
   repopulateComboBoxUnits( mMeasureArea );
   if ( mMeasureArea )
@@ -646,6 +654,18 @@ double QgsMeasureDialog::convertArea( double area, QgsUnitTypes::AreaUnit toUnit
   return mDa.convertAreaMeasurement( area, toUnit );
 }
 
+void QgsMeasureDialog::copyMeasurements()
+{
+  QClipboard *clipboard = QApplication::clipboard();
+  QString text;
+  QTreeWidgetItemIterator it( mTable );
+  while ( *it )
+  {
+    text += ( *it )->text( 0 ) + QStringLiteral( "\n" );
+    it++;
+  }
+  clipboard->setText( text );
+}
 
 void QgsMeasureDialog::reject()
 {

--- a/src/app/qgsmeasuredialog.h
+++ b/src/app/qgsmeasuredialog.h
@@ -70,6 +70,9 @@ class APP_EXPORT QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
     //! Open configuration tab
     void openConfigTab();
 
+    //! Copy measurements to the clipboard
+    void copyMeasurements();
+
     void crsChanged();
 
     void projChanged();


### PR DESCRIPTION
## Description
When measuring line one can copy selected segment measurement, but there is no way to copy all measurements as once. This PR adds "Copy All" button to the Measure Distance dialog allowing to copy all segments measurements at once.

![measure](https://user-images.githubusercontent.com/776954/88926519-c7526700-d27e-11ea-8f61-e3339b361447.png)

Fixes #20498.