### PR TITLE
[ui] Make the obstacle checkbox label wrap to avoid overly large minimum width

### DIFF
--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -5920,6 +5920,13 @@ font-style: italic;</string>
                              <property name="enabled">
                               <bool>true</bool>
                              </property>
+                            </widget>
+                           </item>
+                           <item>
+                            <widget class="QLabel" name="mLblNoObstacle">
+                             <property name="wordWrap">
+                              <bool>true</bool>
+                             </property>
                              <property name="text">
                               <string>Discourage labels and diagrams from covering features</string>
                              </property>


### PR DESCRIPTION
## Description

This PR tweaks the labelling UI to avoid an long non-wrappable checkbox string which leads to an overly large layout minimum width.

Updated UI:
![Screenshot from 2020-07-31 10-57-20](https://user-images.githubusercontent.com/1728657/88998620-a93b4400-d31c-11ea-85b6-1ea1060cce10.png)
