### PR TITLE
show current layer CRS in the layer context menu and allow to change it using recent CRSs

### DIFF
--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -346,7 +346,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           {
             QAction *action = menuSetCRS->addAction( tr( "Set to %1" ).arg( crs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ) ) );
             action->setProperty( "layerId", layer->id() );
-            action->setProperty( "crs", crs.toWkt() );
+            action->setProperty( "crs", crs.toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ) );
             i++;
             if ( i == 2 )
               break;

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -328,15 +328,38 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         if ( !layer->isInScaleRange( mCanvas->scale() ) )
           menu->addAction( tr( "Zoom to &Visible Scale" ), QgisApp::instance(), &QgisApp::zoomToLayerScale );
 
-        QMenu *menuSetCRS = new QMenu( tr( "Set CRS" ), menu );
-        // set layer crs
-        QAction *actionSetLayerCrs = new QAction( tr( "Set Layer CRS…" ), menuSetCRS );
-        connect( actionSetLayerCrs, &QAction::triggered, QgisApp::instance(), &QgisApp::setLayerCrs );
-        menuSetCRS->addAction( actionSetLayerCrs );
+        QMenu *menuSetCRS = new QMenu( tr( "Layer CRS" ), menu );
+        QAction *actionCurrentCrs = new QAction( layer->crs().authid(), menuSetCRS );
+        actionCurrentCrs->setEnabled( false );
+        menuSetCRS->addAction( actionCurrentCrs );
         // assign layer crs to project
         QAction *actionSetProjectCrs = new QAction( tr( "Set &Project CRS from Layer" ), menuSetCRS );
         connect( actionSetProjectCrs, &QAction::triggered, QgisApp::instance(), &QgisApp::setProjectCrsFromLayer );
         menuSetCRS->addAction( actionSetProjectCrs );
+
+        const QList< QgsCoordinateReferenceSystem> recentProjections = QgsCoordinateReferenceSystem::recentCoordinateReferenceSystems();
+        if ( !recentProjections.isEmpty() )
+        {
+          menuSetCRS->addSeparator();
+          int i = 0;
+          for ( const QgsCoordinateReferenceSystem &crs : recentProjections )
+          {
+            QAction *action = menuSetCRS->addAction( crs.authid() );
+            action->setProperty( "layerId", layer->id() );
+            action->setProperty( "crs", crs.authid() );
+            i++;
+            if ( i == 2 )
+              break;
+          }
+        }
+        // Connect once for the entire submenu.
+        connect( menuSetCRS, &QMenu::triggered, this, &QgsAppLayerTreeViewMenuProvider::setLayerCrs );
+
+        // set layer crs
+        menuSetCRS->addSeparator();
+        QAction *actionSetLayerCrs = new QAction( tr( "Set Layer CRS…" ), menuSetCRS );
+        connect( actionSetLayerCrs, &QAction::triggered, QgisApp::instance(), &QgisApp::setLayerCrs );
+        menuSetCRS->addAction( actionSetLayerCrs );
 
         menu->addMenu( menuSetCRS );
       }
@@ -996,4 +1019,16 @@ bool QgsAppLayerTreeViewMenuProvider::removeActionEnabled()
       return false;
   }
   return true;
+}
+
+void QgsAppLayerTreeViewMenuProvider::setLayerCrs( QAction *action )
+{
+  QString layerId = action->property( "layerId" ).toString();
+  QgsMapLayer *layer = QgsProject::instance()->mapLayer( layerId );
+  if ( !layer )
+    return;
+
+  QString authid = action->property( "crs" ).toString();
+  layer->setCrs( QgsCoordinateReferenceSystem( authid ), true );
+  layer->triggerRepaint();
 }

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -329,7 +329,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           menu->addAction( tr( "Zoom to &Visible Scale" ), QgisApp::instance(), &QgisApp::zoomToLayerScale );
 
         QMenu *menuSetCRS = new QMenu( tr( "Layer CRS" ), menu );
-        QAction *actionCurrentCrs = new QAction( layer->crs().authid(), menuSetCRS );
+        QAction *actionCurrentCrs = new QAction( layer->crs().userFriendlyIdentifier(), menuSetCRS );
         actionCurrentCrs->setEnabled( false );
         menuSetCRS->addAction( actionCurrentCrs );
         // assign layer crs to project
@@ -344,9 +344,9 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           int i = 0;
           for ( const QgsCoordinateReferenceSystem &crs : recentProjections )
           {
-            QAction *action = menuSetCRS->addAction( crs.userFriendlyIdentifier() );
+            QAction *action = menuSetCRS->addAction( tr( "Set to %1" ).arg( crs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ) ) );
             action->setProperty( "layerId", layer->id() );
-            action->setProperty( "crs", crs.authid() );
+            action->setProperty( "crs", crs.toWkt() );
             i++;
             if ( i == 2 )
               break;
@@ -1028,7 +1028,7 @@ void QgsAppLayerTreeViewMenuProvider::setLayerCrs( QAction *action )
   if ( !layer )
     return;
 
-  QString authid = action->property( "crs" ).toString();
-  layer->setCrs( QgsCoordinateReferenceSystem( authid ), true );
+  QString wkt = action->property( "crs" ).toString();
+  layer->setCrs( QgsCoordinateReferenceSystem( wkt ), true );
   layer->triggerRepaint();
 }

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -344,7 +344,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           int i = 0;
           for ( const QgsCoordinateReferenceSystem &crs : recentProjections )
           {
-            QAction *action = menuSetCRS->addAction( crs.authid() );
+            QAction *action = menuSetCRS->addAction( crs.userFriendlyIdentifier() );
             action->setProperty( "layerId", layer->id() );
             action->setProperty( "crs", crs.authid() );
             i++;

--- a/src/app/qgsapplayertreeviewmenuprovider.h
+++ b/src/app/qgsapplayertreeviewmenuprovider.h
@@ -71,7 +71,8 @@ class QgsAppLayerTreeViewMenuProvider : public QObject, public QgsLayerTreeViewM
     void copySymbolLegendNodeSymbol( const QString &layerId, const QString &ruleKey );
     void pasteSymbolLegendNodeSymbol( const QString &layerId, const QString &ruleKey );
     void setSymbolLegendNodeColor( const QColor &color );
-
+    // Set layer CRS corresponding to the text of the given action
+    void setLayerCrs( QAction *action );
   private:
     bool removeActionEnabled();
 };


### PR DESCRIPTION
## Description
Adds current layer CRS directly to the layer's context menu so it can be easily discoverable. Also allows to quickly set layer CRS to one of the three recently used CRSs without opening CRS selector.

![crs](https://user-images.githubusercontent.com/776954/89046994-6d24d500-d356-11ea-861a-93ac67f7d2b1.png)

Fixes #13882.