### PR TITLE
Remove extra bracket from stdev statistic option in Zonal Statistics GUI

### DIFF
--- a/src/analysis/vector/qgszonalstatistics.cpp
+++ b/src/analysis/vector/qgszonalstatistics.cpp
@@ -423,7 +423,7 @@ QString QgsZonalStatistics::displayName( QgsZonalStatistics::Statistic statistic
     case Median:
       return QObject::tr( "Median" );
     case StDev:
-      return QObject::tr( "St dev)" );
+      return QObject::tr( "St dev" );
     case Min:
       return QObject::tr( "Minimum" );
     case Max:


### PR DESCRIPTION
This commit removes an extra bracket in the Zonal Statistics tool. In the Statistics to calculate sub-menu, the St dev option appears as St dev).
![Screenshot_20200731_151221](https://user-images.githubusercontent.com/1714080/89068961-3cd23c00-d340-11ea-9fbe-5439e09e0293.png)
