### PR TITLE
Fix various issues with application of raster styles from QML-files

### DIFF
--- a/src/gui/raster/qgscolorrampshaderwidget.cpp
+++ b/src/gui/raster/qgscolorrampshaderwidget.cpp
@@ -376,6 +376,18 @@ void QgsColorRampShaderWidget::applyColorRamp()
   int topLevelItemCount = mColormapTreeWidget->topLevelItemCount();
   if ( topLevelItemCount > 0 )
   {
+    // We need to have valid min/max values here. If we haven't, load from colormap
+    double min, max;
+    if ( isnan( mMin ) || isnan( mMax ) )
+    {
+      colormapMinMax( min, max );
+    }
+    else
+    {
+      min = mMin;
+      max = mMax;
+    }
+
     // if the list values has been customized, maintain pre-existing values
     QTreeWidgetItem *currentItem = nullptr;
     for ( int i = 0; i < topLevelItemCount; ++i )
@@ -387,7 +399,7 @@ void QgsColorRampShaderWidget::applyColorRamp()
       }
 
       double value = QLocale().toDouble( currentItem->text( ValueColumn ) );
-      double position = ( value - mMin ) / ( mMax - mMin );
+      double position = ( value - min ) / ( max - min );
       whileBlocking( static_cast<QgsTreeWidgetItemObject *>( currentItem ) )->setData( ColorColumn, Qt::EditRole, ramp->color( position ) );
     }
 
@@ -727,9 +739,7 @@ double QgsColorRampShaderWidget::maximum() const
   return mMax;
 }
 
-
-
-void QgsColorRampShaderWidget::loadMinimumMaximumFromTree()
+void QgsColorRampShaderWidget::colormapMinMax( double &min, double &max )
 {
   QTreeWidgetItem *item = mColormapTreeWidget->topLevelItem( 0 );
   if ( !item )
@@ -737,9 +747,15 @@ void QgsColorRampShaderWidget::loadMinimumMaximumFromTree()
     return;
   }
 
-  double min = QLocale().toDouble( item->text( ValueColumn ) );
+  min = QLocale().toDouble( item->text( ValueColumn ) );
   item = mColormapTreeWidget->topLevelItem( mColormapTreeWidget->topLevelItemCount() - 1 );
-  double max = QLocale().toDouble( item->text( ValueColumn ) );
+  max = QLocale().toDouble( item->text( ValueColumn ) );
+}
+
+void QgsColorRampShaderWidget::loadMinimumMaximumFromTree()
+{
+  double min = 0, max = 0;
+  colormapMinMax( min, max );
 
   if ( !qgsDoubleNear( mMin, min ) || !qgsDoubleNear( mMax, max ) )
   {

--- a/src/gui/raster/qgscolorrampshaderwidget.cpp
+++ b/src/gui/raster/qgscolorrampshaderwidget.cpp
@@ -644,8 +644,6 @@ void QgsColorRampShaderWidget::mColormapTreeWidget_itemEdited( QTreeWidgetItem *
 
 void QgsColorRampShaderWidget::setFromShader( const QgsColorRampShader &colorRampShader )
 {
-  populateColormapTreeWidget( colorRampShader.colorRampItemList() );
-
   // Those objects are connected to classify() the color ramp shader if they change, or call widget change
   // need to block them to avoid to classify and to alter the color ramp, or to call duplicate widget change
   whileBlocking( mClipCheckBox )->setChecked( colorRampShader.clip() );
@@ -665,6 +663,8 @@ void QgsColorRampShaderWidget::setFromShader( const QgsColorRampShader &colorRam
     QString defaultPalette = settings.value( QStringLiteral( "/Raster/defaultPalette" ), "Spectral" ).toString();
     btnColorRamp->setColorRampFromName( defaultPalette );
   }
+
+  populateColormapTreeWidget( colorRampShader.colorRampItemList() );
 
   emit widgetChanged();
 }

--- a/src/gui/raster/qgscolorrampshaderwidget.h
+++ b/src/gui/raster/qgscolorrampshaderwidget.h
@@ -102,6 +102,7 @@ class GUI_EXPORT QgsColorRampShaderWidget: public QWidget, protected Ui::QgsColo
   protected:
     //! Populates color ramp tree from ramp items
     void populateColormapTreeWidget( const QList<QgsColorRampShader::ColorRampItem> &colorRampItems );
+    //! Extracts the minimal and maximal value from the colormapTreeWidget
     void colormapMinMax( double &min, double &max ) SIP_SKIP;
 
   private:

--- a/src/gui/raster/qgscolorrampshaderwidget.h
+++ b/src/gui/raster/qgscolorrampshaderwidget.h
@@ -102,6 +102,7 @@ class GUI_EXPORT QgsColorRampShaderWidget: public QWidget, protected Ui::QgsColo
   protected:
     //! Populates color ramp tree from ramp items
     void populateColormapTreeWidget( const QList<QgsColorRampShader::ColorRampItem> &colorRampItems );
+    void colormapMinMax( double &min, double &max ) SIP_SKIP;
 
   private:
 

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
@@ -153,6 +153,12 @@ void QgsSingleBandPseudoColorRendererWidget::setFromRenderer( const QgsRasterRen
     mMinMaxWidget->setBands( QList< int >() << pr->band() );
     mColorRampShaderWidget->setRasterBand( pr->band() );
 
+    // need to set min/max properties here because if we use the raster shader below,
+    // we may set a new color ramp which needs to have min/max values defined.
+    setLineEditValue( mMinLineEdit, pr->classificationMin() );
+    setLineEditValue( mMaxLineEdit, pr->classificationMax() );
+    mMinMaxWidget->setFromMinMaxOrigin( pr->minMaxOrigin() );
+
     const QgsRasterShader *rasterShader = pr->shader();
     if ( rasterShader )
     {
@@ -162,10 +168,6 @@ void QgsSingleBandPseudoColorRendererWidget::setFromRenderer( const QgsRasterRen
         mColorRampShaderWidget->setFromShader( *colorRampShader );
       }
     }
-    setLineEditValue( mMinLineEdit, pr->classificationMin() );
-    setLineEditValue( mMaxLineEdit, pr->classificationMax() );
-
-    mMinMaxWidget->setFromMinMaxOrigin( pr->minMaxOrigin() );
   }
   else
   {


### PR DESCRIPTION
## Description

This PR fixes various issues with the application of styles from QML-files  to raster layers. The general behavior is that a style is loaded from a QML with a colormap. Then this style seems to be show up OK in the canvas, but the actual color map assignment is sometimes wrong, and when you hit apply a wrong style is actually applied or the color scheme reverts back to a default one.

An example of this behavior (using ESACCI-LC data from http://maps.elie.ucl.ac.be/CCI/viewer/download.php)

![rasterstyle_issue](https://user-images.githubusercontent.com/10474950/89099340-cb04fb80-d3ee-11ea-82d0-a288a711a7e8.gif)

This behavior is described in issues
* #29427
* #26701
* #28229
* #28926

Two major reasons for this behavior are probably the culprits:

### applying a color ramp overwrites an already set colormap

When the QgsColorRampShaderwidget is populated by data from a QgsColorRampShader, the colormapTreeWidget is filled first (containing specific value->color assignments). After that it is checked if the shader has a colorramp and if it has none the default colorramp is applied. The problem is that this in the end emits colorRampChanged() which in turn repopulates the colorrampTreeWidget with new colors from the set colorramp (in this case the default one) overwriting the ones from the applied shader. 

**Fix:** populate the colormap *after* the color ramp is applied. (7368e7f7ec)

### QgsColorRampShaderWidget::applyColorRamp() relies on valid mMin and mMax

A second problem is that the function QgsColorRampShaderWidget::applyColorRamp() assumes that the member variables mMin and mMax are already set when calculating new colors for the colormap. This is not necessarily the case as when a QgsSingleBandPseudoColorRendererWidget is populated by a QgsSingleBandPseudoColorRenderer the min/max form fields are set *after* the color ramp shader is applied. Then the colors for all the entries in the colormap are picked with a nan-value.

**Fix:**
  * populate the min/and max fields in QgsSingleBandPseudoColorRendererWidget before applying the color ramp (5b817145ca)
  * to prevent future problems with unset mMin/mMax in QgsColorRampShaderWidget, as a fallback the color map is created by the min and max values of the actual values in the color map if mMin or mMax are nan (914f719bd8)

This PR fixes #28229, #28926 and #29427 and may also fix #26701.
