### PR TITLE
[delimited text] Specify ISO formatting for string to time conversion

### DIFF
--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
@@ -513,7 +513,7 @@ void QgsDelimitedTextFeatureIterator::fetchAttribute( QgsFeature &feature, int f
     }
     case QVariant::Time:
     {
-      val = QVariant( QTime::fromString( value ) );
+      val = QVariant( QTime::fromString( value, Qt::ISODate ) );
       break;
     }
     default:

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -659,7 +659,7 @@ void QgsDelimitedTextProvider::scanFile( bool buildIndexes )
 
       if ( couldBeTime[i] && !couldBeDateTime[i] )
       {
-        QTime t = QTime::fromString( value );
+        QTime t = QTime::fromString( value, Qt::ISODate );
         couldBeTime[i] = t.isValid();
       }
     }


### PR DESCRIPTION
## Description

This likely fixes issue #38091. I can't reproduce the issue to begin with, but it might be a qt 5.14 vs 5.11 situation.