### PR TITLE
fix long reload of filter change in attribute table

### DIFF
--- a/src/gui/attributetable/qgsfeaturelistview.h
+++ b/src/gui/attributetable/qgsfeaturelistview.h
@@ -215,7 +215,7 @@ class GUI_EXPORT QgsFeatureListView : public QListView
     void editSelectionChanged( const QItemSelection &deselected, const QItemSelection &selected );
 
     /**
-     * Emits the signal for the feature and the selection information
+     * Emits the signal to change the information for position and count
      */
     void updateEditSelectionDependencies();
 
@@ -252,6 +252,7 @@ class GUI_EXPORT QgsFeatureListView : public QListView
     QItemSelectionModel::SelectionFlags mCtrlDragSelectionFlag;
 
     QTimer mUpdateEditSelectionTimer;
+    QTimer mUpdateEditSelectionDependenciesTimer;
 
     friend class QgsDualView;
 };


### PR DESCRIPTION
Avoid to call the slot updateEditSelectionDependencies on every insertRow / removeRow of the model by having a timer.

this fixes #38018

Additionally do not emit the currentEditSelectionChanged when no selection has been changed in updateEditSelectionDependencies. Only emit the signal to achieve an update of e.g. the count of features in the attribute table form view.

The code to get the index is now in editSelectionChanged and updateEditSelectionDependencies  but the code gets better readable like this.