### PR TITLE
Fix leak of network replies when network content is fetched in a thread which is destroyed soon after

### DIFF
--- a/src/core/qgsnetworkcontentfetcher.cpp
+++ b/src/core/qgsnetworkcontentfetcher.cpp
@@ -31,10 +31,7 @@ QgsNetworkContentFetcher::~QgsNetworkContentFetcher()
     //cancel running request
     mReply->abort();
   }
-  if ( mReply )
-  {
-    mReply->deleteLater();
-  }
+  delete mReply;
 }
 
 void QgsNetworkContentFetcher::fetchContent( const QUrl &url, const QString &authcfg )


### PR DESCRIPTION
Because the thread is destroyed, the event loops never executes and
deleteLater is never called, resulting the a leak of the network reply

(Moderately risky!)