### PR TITLE
[processing] Use a feature source for the input of the extract by location alg

### DIFF
--- a/src/analysis/processing/qgsalgorithmextractbylocation.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbylocation.cpp
@@ -436,7 +436,8 @@ QVariantMap QgsSelectByLocationAlgorithm::processAlgorithm( const QVariantMap &p
 
 void QgsExtractByLocationAlgorithm::initAlgorithm( const QVariantMap & )
 {
-  addParameter( new QgsProcessingParameterVectorLayer( QStringLiteral( "INPUT" ), QObject::tr( "Extract features from" ),
+  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ),
+                QObject::tr( "Extract features from" ),
                 QList< int >() << QgsProcessing::TypeVectorAnyGeometry ) );
   addPredicateParameter();
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INTERSECT" ),


### PR DESCRIPTION
## Description

Because feature source > vector layer. This fixes the missing [x] selected features only checkbox for the extract by location's input layer.