### PR TITLE
warn with 0 or negative values when using log scale in graduated renderer

### DIFF
--- a/src/core/classification/qgsclassificationlogarithmic.cpp
+++ b/src/core/classification/qgsclassificationlogarithmic.cpp
@@ -110,9 +110,20 @@ QList<double> QgsClassificationLogarithmic::calculateBreaks( double &minimum, do
 QString QgsClassificationLogarithmic::valueToLabel( double value ) const
 {
   if ( value <= 0 )
+  {
     return QString( QStringLiteral( "%1" ) ).arg( value );
+  }
   else
-    return QString( QStringLiteral( "10^%1" ) ).arg( std::log10( value ) );
+  {
+    if ( isnan( value ) )
+    {
+      return QObject::tr( "invalid (0 or negative values in the data)" );
+    }
+    else
+    {
+      return QString( QStringLiteral( "10^%1" ) ).arg( std::log10( value ) );
+    }
+  }
 }
 
 QString QgsClassificationLogarithmic::labelForRange( double lowerValue, double upperValue, QgsClassificationMethod::ClassPosition position ) const

--- a/src/core/classification/qgsclassificationlogarithmic.cpp
+++ b/src/core/classification/qgsclassificationlogarithmic.cpp
@@ -115,7 +115,7 @@ QString QgsClassificationLogarithmic::valueToLabel( double value ) const
   }
   else
   {
-    if ( isnan( value ) )
+    if ( std::isnan( value ) )
     {
       return QObject::tr( "invalid (0 or negative values in the data)" );
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/127259/89262080-6dabbd00-d62f-11ea-84a4-39c9182a58fd.png)
