### PR TITLE
Treat mdb files as a database source in browser

### DIFF
--- a/src/core/providers/ogr/qgsogrdataitems.cpp
+++ b/src/core/providers/ogr/qgsogrdataitems.cpp
@@ -604,10 +604,12 @@ QgsDataItem *QgsOgrDataItemProvider::createDataItem( const QString &pathIn, QgsD
       QStringLiteral( "gdb" ),
       QStringLiteral( "kml" ),
       QStringLiteral( "osm" ),
+      QStringLiteral( "mdb" ),
       QStringLiteral( "pbf" ) };
   static QStringList sOgrSupportedDbDriverNames { QStringLiteral( "GPKG" ),
       QStringLiteral( "db" ),
-      QStringLiteral( "gdb" ) };
+      QStringLiteral( "gdb" ),
+      QStringLiteral( "pgdb" )};
 
   // these extensions are trivial to read, so there's no need to rely on
   // the extension only scan here -- avoiding it always gives us the correct data type


### PR DESCRIPTION
Allows these to be expanded so that particular layers can be loaded, notably allowing projects with broken mdb layer paths to be repaired by allowing users to pick the correct target layer from an mdb file.
