### PR TITLE
Add a iface method to directly set a specific GPS connection to connect to in the GPS Information panel

### DIFF
--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -1397,6 +1397,16 @@ creating a new browser model for every use.
 .. versionadded:: 3.4
 %End
 
+    virtual void setGpsPanelConnection( QgsGpsConnection *connection ) = 0;
+%Docstring
+Sets a GPS ``connection`` to use within the GPS Panel widget.
+
+Any existing GPS connection used by the widget will be disconnect and replaced with this connection. The connection
+is automatically registered within the :py:func:`QgsApplication.gpsConnectionRegistry()`.
+
+.. versionadded:: 3.16
+%End
+
   signals:
 
     void currentLayerChanged( QgsMapLayer *layer );

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -528,6 +528,11 @@ bool QgsGpsInformationWidget::blockCanvasInteraction( QgsMapCanvasInteractionBlo
   return false;
 }
 
+void QgsGpsInformationWidget::setConnection( QgsGpsConnection *connection )
+{
+  connected( connection );
+}
+
 void QgsGpsInformationWidget::mSpinTrackWidth_valueChanged( int value )
 {
   if ( mRubberBand )

--- a/src/app/gps/qgsgpsinformationwidget.h
+++ b/src/app/gps/qgsgpsinformationwidget.h
@@ -58,6 +58,14 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, public QgsMapCa
 
     bool blockCanvasInteraction( Interaction interaction ) const override;
 
+    /**
+     * Sets a GPS \a connection to use within the GPS Panel widget.
+     *
+     * Any existing GPS connection used by the widget will be disconnect and replaced with this connection. The connection
+     * is automatically registered within the QgsApplication::gpsConnectionRegistry().
+     */
+    void setConnection( QgsGpsConnection *connection );
+
   public slots:
     void tapAndHold( const QgsPointXY &mapPoint, QTapAndHoldGesture *gesture );
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4813,6 +4813,11 @@ QgsLayerTreeRegistryBridge::InsertionPoint QgisApp::layerTreeInsertionPoint() co
   return QgsLayerTreeRegistryBridge::InsertionPoint( insertGroup, index );
 }
 
+void QgisApp::setGpsPanelConnection( QgsGpsConnection *connection )
+{
+  mpGpsWidget->setConnection( connection );
+}
+
 void QgisApp::autoSelectAddedLayer( QList<QgsMapLayer *> layers )
 {
   if ( !layers.isEmpty() )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -110,6 +110,7 @@ class QgsUserProfileManagerWidgetFactory;
 class Qgs3DMapCanvasDockWidget;
 class QgsHandleBadLayersHandler;
 class QgsNetworkAccessManager;
+class QgsGpsConnection;
 
 class QDomDocument;
 class QNetworkReply;
@@ -801,6 +802,14 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void takeAppScreenShots( const QString &saveDirectory, const int categories = 0 );
 
     QgsLayerTreeRegistryBridge::InsertionPoint layerTreeInsertionPoint() const;
+
+    /**
+     * Sets a GPS \a connection to use within the GPS Panel widget.
+     *
+     * Any existing GPS connection used by the widget will be disconnect and replaced with this connection. The connection
+     * is automatically registered within the QgsApplication::gpsConnectionRegistry().
+     */
+    void setGpsPanelConnection( QgsGpsConnection *connection );
 
   public slots:
     //! save current vector layer

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -860,3 +860,8 @@ QgsLayerTreeRegistryBridge::InsertionPoint QgisAppInterface::layerTreeInsertionP
 {
   return qgis->layerTreeInsertionPoint();
 }
+
+void QgisAppInterface::setGpsPanelConnection( QgsGpsConnection *connection )
+{
+  qgis->setGpsPanelConnection( connection );
+}

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -309,7 +309,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     void takeAppScreenShots( const QString &saveDirectory, const int categories = 0 ) override;
     QgsBrowserGuiModel *browserModel() override;
     QgsLayerTreeRegistryBridge::InsertionPoint layerTreeInsertionPoint() override;
-
+    void setGpsPanelConnection( QgsGpsConnection *connection ) override;
 
   private slots:
 

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -64,6 +64,7 @@ class QgsStatusBar;
 class QgsMeshLayer;
 class QgsBrowserGuiModel;
 class QgsDevToolWidgetFactory;
+class QgsGpsConnection;
 
 
 /**
@@ -1156,6 +1157,16 @@ class GUI_EXPORT QgisInterface : public QObject
      * \since QGIS 3.4
      */
     virtual QgsBrowserGuiModel *browserModel() = 0;
+
+    /**
+     * Sets a GPS \a connection to use within the GPS Panel widget.
+     *
+     * Any existing GPS connection used by the widget will be disconnect and replaced with this connection. The connection
+     * is automatically registered within the QgsApplication::gpsConnectionRegistry().
+     *
+     * \since QGIS 3.16
+     */
+    virtual void setGpsPanelConnection( QgsGpsConnection *connection ) = 0;
 
   signals:
 


### PR DESCRIPTION
Allows for plugins to create subclasses of QgsGpsConnection and then hook these into the existing GPS panel widget
