### PR TITLE
Fix long reload of filter change in attribute table by revert bad commit

### DIFF
--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -162,11 +162,7 @@ void QgsFeatureListView::editSelectionChanged( const QItemSelection &deselected,
     QItemSelection localSelected = mModel->mapSelectionFromMaster( selected );
     viewport()->update( visualRegionForSelection( localDeselected ) | visualRegionForSelection( localSelected ) );
   }
-  updateEditSelectionDependencies();
-}
 
-void QgsFeatureListView::updateEditSelectionDependencies()
-{
   QItemSelection currentSelection = mCurrentEditSelectionModel->selection();
   if ( currentSelection.size() == 1 )
   {
@@ -468,7 +464,6 @@ void QgsFeatureListView::ensureEditSelection( bool inSelection )
     }
     mUpdateEditSelectionTimer.start();
   }
-  updateEditSelectionDependencies();
 }
 
 void QgsFeatureListView::setFeatureSelectionManager( QgsIFeatureSelectionManager *featureSelectionManager )

--- a/src/gui/attributetable/qgsfeaturelistview.h
+++ b/src/gui/attributetable/qgsfeaturelistview.h
@@ -215,11 +215,6 @@ class GUI_EXPORT QgsFeatureListView : public QListView
     void editSelectionChanged( const QItemSelection &deselected, const QItemSelection &selected );
 
     /**
-     * Emits the signal for the feature and the selection information
-     */
-    void updateEditSelectionDependencies();
-
-    /**
      * Make sure, there is an edit selection. If there is none, choose the first item.
      * If \a inSelection is set to TRUE, the edit selection is done in selected entries if
      * there is a selected entry visible.


### PR DESCRIPTION
Revert of commit d409c65de9c31266ae00a16d1004b4856dc1f5b4 leading to long reload time of the attribute table after `setFilterMode`.

This bad commit has been a fix on the minor bug, that the counter on form view mode of the attribute table has not been updated after adding or removing a feature that did not affect the edit selection.

This PR is an alternative to the ugly fix with timer here #38111

I suggest to merge that to have #38018 fixed, and backport it to 3.10 and 3.14.
And then we go for a new and proper fix for the counter reset for the master with calling the ensure-edit-selection part after the model has populated (instead of on every add-/remove row).