### PR TITLE
[postgres] Fix superslow layer instantiation in huge databases by only fetching type info of used fields.

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -909,7 +909,7 @@ bool QgsPostgresProvider::loadFields()
       {
         attroidsList.append( QString::number( attroid ) );
       }
-      attroidsFilter = QStringLiteral( "WHERE oid in (" ) + attroidsList.join( QStringLiteral( "," ) ) + QStringLiteral( ")" );
+      attroidsFilter = QStringLiteral( "WHERE oid in (%1)" ).arg( attroidsList.join( ',' ) );
     }
   }
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -796,14 +796,9 @@ bool QgsPostgresProvider::loadFields()
   {
     QgsDebugMsgLevel( QStringLiteral( "Loading fields for table %1" ).arg( mTableName ), 2 );
 
-    // Get the relation oid for use in later queries
-    sql = QStringLiteral( "SELECT regclass(%1)::oid" ).arg( quotedValue( mQuery ) );
-    QgsPostgresResult tresult( connectionRO()->PQexec( sql ) );
-    QString tableoid = tresult.PQgetvalue( 0, 0 );
-
     // Get the table description
-    sql = QStringLiteral( "SELECT description FROM pg_description WHERE objoid=%1 AND objsubid=0" ).arg( tableoid );
-    tresult = connectionRO()->PQexec( sql );
+    sql = QStringLiteral( "SELECT description FROM pg_description WHERE objoid=regclass(%1)::oid AND objsubid=0" ).arg( quotedValue( mQuery ) );
+    QgsPostgresResult tresult( connectionRO()->PQexec( sql ) );
     if ( tresult.PQntuples() > 0 )
     {
       mDataComment = tresult.PQgetvalue( 0, 0 );

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -904,8 +904,7 @@ bool QgsPostgresProvider::loadFields()
     if ( !attroids.isEmpty() )
     {
       QStringList attroidsList;
-      const auto constAttroids = attroids;
-      for ( Oid attroid : constAttroids )
+      for ( Oid attroid : qgis::as_const( attroids ) )
       {
         attroidsList.append( QString::number( attroid ) );
       }


### PR DESCRIPTION
If a postgresql database contains hundreds of thousands tables, instantiating any layer becomes madly slow, because QgsPostgresProvider::loadFields fetches type info for all those tables, instead of just columns of source table(s). See bug #38114.

This PR adds a filter to only fetch used columns, speeding up project opening in my case from over one hour (!) to a couple of seconds.

Supersedes #38115.