### PR TITLE
Server external wms several layers

### DIFF
--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1885,7 +1885,7 @@ namespace QgsWms
     for ( ; paramIt != paramMap.constEnd(); ++paramIt )
     {
       QString paramName = paramIt.key().toLower();
-      if ( paramName == "layers" || paramName == "styles" )
+      if ( paramName == QLatin1String( "layers" ) || paramName == QLatin1String( "styles" ) )
       {
         QStringList values = paramIt.value().split( "," );
         QStringList::const_iterator valuesIt = values.constBegin();

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1887,7 +1887,7 @@ namespace QgsWms
       QString paramName = paramIt.key().toLower();
       if ( paramName == QLatin1String( "layers" ) || paramName == QLatin1String( "styles" ) )
       {
-        QStringList values = paramIt.value().split( ',' );
+        const QStringList values = paramIt.value().split( ',' );
         for ( const QString &value : values )
           wmsUri.setParam( paramName, value );
       }

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1884,7 +1884,20 @@ namespace QgsWms
     QMap<QString, QString>::const_iterator paramIt = paramMap.constBegin();
     for ( ; paramIt != paramMap.constEnd(); ++paramIt )
     {
-      wmsUri.setParam( paramIt.key().toLower(), paramIt.value() );
+      QString paramName = paramIt.key().toLower();
+      if ( paramName == "layers" || paramName == "styles" )
+      {
+        QStringList values = paramIt.value().split( "," );
+        QStringList::const_iterator valuesIt = values.constBegin();
+        for ( ; valuesIt != values.constEnd(); ++valuesIt )
+        {
+          wmsUri.setParam( paramName, *valuesIt );
+        }
+      }
+      else
+      {
+        wmsUri.setParam( paramName, paramIt.value() );
+      }
     }
     return wmsUri.encodedUri();
   }

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1887,12 +1887,9 @@ namespace QgsWms
       QString paramName = paramIt.key().toLower();
       if ( paramName == QLatin1String( "layers" ) || paramName == QLatin1String( "styles" ) )
       {
-        QStringList values = paramIt.value().split( "," );
-        QStringList::const_iterator valuesIt = values.constBegin();
-        for ( ; valuesIt != values.constEnd(); ++valuesIt )
-        {
-          wmsUri.setParam( paramName, *valuesIt );
-        }
+        QStringList values = paramIt.value().split( ',' );
+        for ( const QString &value : values )
+          wmsUri.setParam( paramName, value );
       }
       else
       {


### PR DESCRIPTION
An external WMS layer can sometimes request several WMS layers and styles. Up to know, the server passed this as parameter to the WMS client uri. However it seems that it only works if the layers and styles are set one-by-one with wmsUri.setParam. It needs several layers-Parameter with one layer instead one with all the layers (e.g. layers=A&layers=B instead of layers=A,B).