### PR TITLE
Some tweaks to the "Export 3d scene" dialog

### DIFF
--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -263,7 +263,7 @@ void Qgs3DMapCanvasDockWidget::configure()
   QDialogButtonBox *buttons = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel | QDialogButtonBox::Help, &dlg );
   connect( buttons, &QDialogButtonBox::accepted, &dlg, &QDialog::accept );
   connect( buttons, &QDialogButtonBox::rejected, &dlg, &QDialog::reject );
-  connect( buttons, &QDialogButtonBox::helpRequested, w, []() { QgsHelp::openHelp( QStringLiteral( "introduction/qgis_gui.html#d-map-view" ) ); } );
+  connect( buttons, &QDialogButtonBox::helpRequested, w, []() { QgsHelp::openHelp( QStringLiteral( "introduction/qgis_gui.html#scene-configuration" ) ); } );
 
   QVBoxLayout *layout = new QVBoxLayout( &dlg );
   layout->addWidget( w, 1 );
@@ -302,16 +302,16 @@ void Qgs3DMapCanvasDockWidget::exportScene()
   QDialog dlg;
   dlg.setWindowTitle( tr( "Export 3D Scene" ) );
   dlg.setObjectName( QStringLiteral( "3DSceneExportDialog" ) );
-  dlg.setMinimumSize( 380, 460 );
-//  QgsGui::instance()->enableAutoGeometryRestore( &dlg );
+  QgsGui::instance()->enableAutoGeometryRestore( &dlg );
 
   Qgs3DMapExportSettings exportSettings;
   QgsMap3DExportWidget w( mCanvas->scene(), &exportSettings );
 
-  QDialogButtonBox *buttons = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dlg );
+  QDialogButtonBox *buttons = new QDialogButtonBox( QDialogButtonBox::Cancel | QDialogButtonBox::Help | QDialogButtonBox::Ok, &dlg );
 
   connect( buttons, &QDialogButtonBox::accepted, &dlg, &QDialog::accept );
   connect( buttons, &QDialogButtonBox::rejected, &dlg, &QDialog::reject );
+  connect( buttons, &QDialogButtonBox::helpRequested, &dlg, [ = ] { QgsHelp::openHelp( QStringLiteral( "introduction/qgis_gui.html#d-map-view" ) ); } );
 
   QVBoxLayout *layout = new QVBoxLayout( &dlg );
   layout->addWidget( &w, 1 );

--- a/src/ui/3d/map3dexportwidget.ui
+++ b/src/ui/3d/map3dexportwidget.ui
@@ -7,10 +7,22 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>251</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
      <item row="3" column="1" colspan="2">
@@ -29,7 +41,7 @@
      <item row="5" column="0" colspan="3">
       <widget class="QCheckBox" name="smoothEdgesCheckBox">
        <property name="text">
-        <string>Smooth Edges</string>
+        <string>Smooth edges</string>
        </property>
       </widget>
      </item>
@@ -93,7 +105,7 @@
      <item row="6" column="0" colspan="3">
       <widget class="QCheckBox" name="exportNormalsCheckBox">
        <property name="text">
-        <string>Export Normals</string>
+        <string>Export normals</string>
        </property>
        <property name="checked">
         <bool>true</bool>
@@ -145,6 +157,15 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>sceneNameLineEdit</tabstop>
+  <tabstop>terrainResolutionSpinBox</tabstop>
+  <tabstop>terrainTextureResolutionSpinBox</tabstop>
+  <tabstop>scaleSpinBox</tabstop>
+  <tabstop>smoothEdgesCheckBox</tabstop>
+  <tabstop>exportNormalsCheckBox</tabstop>
+  <tabstop>exportTexturesCheckBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
reduce dialog minimal size and margins, fix tab order and add help button
![3dexp](https://user-images.githubusercontent.com/7983394/89476154-3d2c6600-d78a-11ea-89d9-abda949f7a22.png)
