### PR TITLE
Add interface API for geocoders

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -105,6 +105,7 @@ IF(WITH_APIDOC)
       ${CMAKE_SOURCE_DIR}/src/gui/vectortile
       ${CMAKE_SOURCE_DIR}/src/analysis
       ${CMAKE_SOURCE_DIR}/src/analysis/mesh
+      ${CMAKE_SOURCE_DIR}/src/analysis/geocoding
       ${CMAKE_SOURCE_DIR}/src/analysis/interpolation
       ${CMAKE_SOURCE_DIR}/src/analysis/network
       ${CMAKE_SOURCE_DIR}/src/analysis/processing

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -312,6 +312,7 @@ ENDIF (WITH_SERVER AND WITH_SERVER_PLUGINS)
 IF(WITH_ANALYSIS)
   INCLUDE_DIRECTORIES(BEFORE
     ${CMAKE_SOURCE_DIR}/src/analysis
+    ${CMAKE_SOURCE_DIR}/src/analysis/geocoding
     ${CMAKE_SOURCE_DIR}/src/analysis/processing
     ${CMAKE_SOURCE_DIR}/src/analysis/vector
     ${CMAKE_SOURCE_DIR}/src/analysis/vector/geometry_checker
@@ -319,7 +320,6 @@ IF(WITH_ANALYSIS)
     ${CMAKE_SOURCE_DIR}/src/analysis/raster
     ${CMAKE_SOURCE_DIR}/src/analysis/network
     ${CMAKE_SOURCE_DIR}/src/analysis/interpolation
-    ${CMAKE_SOURCE_DIR}/src/analysis/openstreetmap
 
     ${CMAKE_BINARY_DIR}/src/analysis/processing
     ${CMAKE_BINARY_DIR}/src/analysis/vector
@@ -327,7 +327,7 @@ IF(WITH_ANALYSIS)
     ${CMAKE_BINARY_DIR}/src/analysis/raster
     ${CMAKE_BINARY_DIR}/src/analysis/network
     ${CMAKE_BINARY_DIR}/src/analysis/interpolation
-    ${CMAKE_BINARY_DIR}/src/analysis/openstreetmap
+    ${CMAKE_BINARY_DIR}/src/analysis/geocoding
   )
 
   # analysis module

--- a/python/analysis/analysis_auto.sip
+++ b/python/analysis/analysis_auto.sip
@@ -1,5 +1,8 @@
 // Include auto-generated SIP files
 %Include auto_generated/qgsanalysis.sip
+%Include auto_generated/geocoding/qgsgeocoder.sip
+%Include auto_generated/geocoding/qgsgeocodercontext.sip
+%Include auto_generated/geocoding/qgsgeocoderresult.sip
 %Include auto_generated/interpolation/qgsgridfilewriter.sip
 %Include auto_generated/interpolation/qgsidwinterpolator.sip
 %Include auto_generated/interpolation/qgsinterpolator.sip

--- a/python/analysis/auto_additions/qgsgeocoder.py
+++ b/python/analysis/auto_additions/qgsgeocoder.py
@@ -1,0 +1,6 @@
+# The following has been generated automatically from src/analysis/geocoding/qgsgeocoder.h
+# monkey patching scoped based enum
+QgsGeocoderInterface.Flag.GeocodesStrings.__doc__ = "Can geocode string input values"
+QgsGeocoderInterface.Flag.GeocodesFeatures.__doc__ = "Can geocode QgsFeature input values"
+QgsGeocoderInterface.Flag.__doc__ = 'Capability flags for the geocoder.\n\n' + '* ``GeocodesStrings``: ' + QgsGeocoderInterface.Flag.GeocodesStrings.__doc__ + '\n' + '* ``GeocodesFeatures``: ' + QgsGeocoderInterface.Flag.GeocodesFeatures.__doc__
+# --

--- a/python/analysis/auto_generated/geocoding/qgsgeocoder.sip.in
+++ b/python/analysis/auto_generated/geocoding/qgsgeocoder.sip.in
@@ -17,7 +17,7 @@ Interface for geocoders.
 QgsGeocoderInterface implementations are able to take either a QgsFeature or a free-form string
 and calculate the corresponding geometry of the feature.
 
-.. versionadded:: 3.16
+.. versionadded:: 3.18
 %End
 
 %TypeHeaderCode

--- a/python/analysis/auto_generated/geocoding/qgsgeocoder.sip.in
+++ b/python/analysis/auto_generated/geocoding/qgsgeocoder.sip.in
@@ -46,7 +46,7 @@ Geocodes a ``feature``.
 
 If implemented by the geocoder (i.e. :py:func:`~QgsGeocoderInterface.flags` returns the QgsGeocoderInterface.Flag.GeocodesFeatures flag), a list of matching results will be returned.
 
-The optional ``feedback`` argument can be used to provider cancelation support.
+The optional ``feedback`` argument can be used to provider cancellation support.
 %End
 
     virtual QgsFields appendedFields() const;
@@ -73,7 +73,7 @@ Geocodes a ``string``.
 
 If implemented by the geocoder (i.e. :py:func:`~QgsGeocoderInterface.flags` returns the QgsGeocoderInterface.Flag.GeocodesStrings flag), a list of matching results will be returned.
 
-The optional ``feedback`` argument can be used to provider cancelation support.
+The optional ``feedback`` argument can be used to provider cancellation support.
 %End
 
 };

--- a/python/analysis/auto_generated/geocoding/qgsgeocoder.sip.in
+++ b/python/analysis/auto_generated/geocoding/qgsgeocoder.sip.in
@@ -1,0 +1,87 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/analysis/geocoding/qgsgeocoder.h                                 *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsGeocoderInterface
+{
+%Docstring
+Interface for geocoders.
+
+QgsGeocoderInterface implementations are able to take either a QgsFeature or a free-form string
+and calculate the corresponding geometry of the feature.
+
+.. versionadded:: 3.16
+%End
+
+%TypeHeaderCode
+#include "qgsgeocoder.h"
+%End
+  public:
+
+    enum class Flag
+    {
+      GeocodesStrings,
+      GeocodesFeatures,
+    };
+    typedef QFlags<QgsGeocoderInterface::Flag> Flags;
+
+
+    virtual ~QgsGeocoderInterface();
+
+    virtual Flags flags() const = 0;
+%Docstring
+Returns the geocoder's capability flags.
+%End
+
+    virtual QList< QgsGeocoderResult > geocodeFeature( const QgsFeature &feature, const QgsGeocoderContext &context, QgsFeedback *feedback = 0 ) const;
+%Docstring
+Geocodes a ``feature``.
+
+If implemented by the geocoder (i.e. :py:func:`~QgsGeocoderInterface.flags` returns the QgsGeocoderInterface.Flag.GeocodesFeatures flag), a list of matching results will be returned.
+
+The optional ``feedback`` argument can be used to provider cancelation support.
+%End
+
+    virtual QgsFields appendedFields() const;
+%Docstring
+Returns a set of newly created fields which will be appended to existing features during the geocode
+operation.
+
+These fields will include any extra content returned by the geocoder, such as fields for accuracy of the
+match or correct attribute values.
+%End
+
+    virtual QgsWkbTypes::Type wkbType() const;
+%Docstring
+Returns the WKB type of geometries returned by the geocoder.
+
+If this is not known in advance then QgsWkbTypes.Unknown should be returned (e.g.
+in the case that a geocoder may return different geometry types depending on the
+quality of the match).
+%End
+
+    virtual QList< QgsGeocoderResult > geocodeString( const QString &string, const QgsGeocoderContext &context, QgsFeedback *feedback = 0 ) const;
+%Docstring
+Geocodes a ``string``.
+
+If implemented by the geocoder (i.e. :py:func:`~QgsGeocoderInterface.flags` returns the QgsGeocoderInterface.Flag.GeocodesStrings flag), a list of matching results will be returned.
+
+The optional ``feedback`` argument can be used to provider cancelation support.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/analysis/geocoding/qgsgeocoder.h                                 *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/analysis/auto_generated/geocoding/qgsgeocodercontext.sip.in
+++ b/python/analysis/auto_generated/geocoding/qgsgeocodercontext.sip.in
@@ -1,0 +1,108 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/analysis/geocoding/qgsgeocodercontext.h                          *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsGeocoderContext
+{
+%Docstring
+Encapsulates the context of a geocoding operation.
+
+.. versionadded:: 3.16
+%End
+
+%TypeHeaderCode
+#include "qgsgeocodercontext.h"
+%End
+  public:
+
+    QgsGeocoderContext( const QgsCoordinateTransformContext &transformContext );
+%Docstring
+Constructor for QgsGeocoderContext, with the specified ``transformContext``.
+%End
+
+    QgsCoordinateTransformContext transformContext() const;
+%Docstring
+Returns the coordinate transform context, which should be used whenever the
+geocoder constructs a coordinate transform.
+
+.. seealso:: :py:func:`setTransformContext`
+%End
+
+    void setTransformContext( const QgsCoordinateTransformContext &context );
+%Docstring
+Sets the coordinate transform ``context``, which should be used whenever the
+geocoder constructs a coordinate transform.
+
+.. seealso:: :py:func:`transformContext`
+%End
+
+    QgsGeometry areaOfInterest() const;
+%Docstring
+Returns the optional area of interest, which can be used to indicate the desired
+geographic area where geocoding results are desired.
+
+The area of interest can be a polygon geometry, in which case it represents the extent
+to use for filtering candidate results, or a point geometry, in which case it represents
+a "target point" for prioritising closer results.
+
+The coordinate reference system for the area of interest can be retrieved via
+:py:func:`~QgsGeocoderContext.areaOfInterestCrs`.
+
+.. seealso:: :py:func:`setAreaOfInterest`
+
+.. seealso:: :py:func:`areaOfInterestCrs`
+%End
+
+    void setAreaOfInterest( const QgsGeometry &area );
+%Docstring
+Sets the optional ``area`` of interest, which can be used to indicate the desired
+geographic area where geocoding results are desired.
+
+The area of interest can be a polygon geometry, in which case it represents the extent
+to use for filtering candidate results, or a point geometry, in which case it represents
+a "target point" for prioritising closer results.
+
+The coordinate reference system for the area of interest can be set via
+:py:func:`~QgsGeocoderContext.setAreaOfInterestCrs`.
+
+.. seealso:: :py:func:`areaOfInterest`
+
+.. seealso:: :py:func:`setAreaOfInterestCrs`
+%End
+
+    QgsCoordinateReferenceSystem areaOfInterestCrs() const;
+%Docstring
+Returns the coordinate reference system for the area of interest, which can be used to indicate the desired
+geographic area where geocoding results are desired.
+
+.. seealso:: :py:func:`areaOfInterest`
+
+.. seealso:: :py:func:`setAreaOfInterestCrs`
+%End
+
+    void setAreaOfInterestCrs( const QgsCoordinateReferenceSystem &crs );
+%Docstring
+Sets the ``crs`` for the area of interest, which can be used to indicate the desired
+geographic area where geocoding results are desired.
+
+.. seealso:: :py:func:`areaOfInterestCrs`
+
+.. seealso:: :py:func:`setAreaOfInterest`
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/analysis/geocoding/qgsgeocodercontext.h                          *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/analysis/auto_generated/geocoding/qgsgeocodercontext.sip.in
+++ b/python/analysis/auto_generated/geocoding/qgsgeocodercontext.sip.in
@@ -14,7 +14,7 @@ class QgsGeocoderContext
 %Docstring
 Encapsulates the context of a geocoding operation.
 
-.. versionadded:: 3.16
+.. versionadded:: 3.18
 %End
 
 %TypeHeaderCode
@@ -50,7 +50,7 @@ geographic area where geocoding results are desired.
 
 The area of interest can be a polygon geometry, in which case it represents the extent
 to use for filtering candidate results, or a point geometry, in which case it represents
-a "target point" for prioritising closer results.
+a "target point" for prioritizing closer results.
 
 The coordinate reference system for the area of interest can be retrieved via
 :py:func:`~QgsGeocoderContext.areaOfInterestCrs`.
@@ -67,7 +67,7 @@ geographic area where geocoding results are desired.
 
 The area of interest can be a polygon geometry, in which case it represents the extent
 to use for filtering candidate results, or a point geometry, in which case it represents
-a "target point" for prioritising closer results.
+a "target point" for prioritizing closer results.
 
 The coordinate reference system for the area of interest can be set via
 :py:func:`~QgsGeocoderContext.setAreaOfInterestCrs`.

--- a/python/analysis/auto_generated/geocoding/qgsgeocoderresult.sip.in
+++ b/python/analysis/auto_generated/geocoding/qgsgeocoderresult.sip.in
@@ -24,7 +24,7 @@ Valid geocoding results will have a :py:func:`~geometry` and :py:func:`~crs`, al
 of optional :py:func:`~additionalAttributes` which may contain information such as the
 accuracy of the geocoding result.
 
-.. versionadded:: 3.16
+.. versionadded:: 3.18
 %End
 
 %TypeHeaderCode

--- a/python/analysis/auto_generated/geocoding/qgsgeocoderresult.sip.in
+++ b/python/analysis/auto_generated/geocoding/qgsgeocoderresult.sip.in
@@ -1,0 +1,123 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/analysis/geocoding/qgsgeocoderresult.h                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsGeocoderResult
+{
+%Docstring
+Represents a matching result from a geocoder search.
+
+QgsGeocoderResult objects may represent valid matches, or an invalid
+error result. This can be checked by testing :py:func:`~isValid`. An invalid
+result represents that an error was encountered while geocoding, in which case the
+error message can be retrieved by calling :py:func:`~error`.
+
+Valid geocoding results will have a :py:func:`~geometry` and :py:func:`~crs`, along with a set
+of optional :py:func:`~additionalAttributes` which may contain information such as the
+accuracy of the geocoding result.
+
+.. versionadded:: 3.16
+%End
+
+%TypeHeaderCode
+#include "qgsgeocoderresult.h"
+%End
+  public:
+
+    static QgsGeocoderResult errorResult( const QString &errorMessage );
+%Docstring
+Creates an invalid error result, with the specified ``errorMessage`` string.
+%End
+
+    QgsGeocoderResult( const QgsGeometry &geometry, const QgsCoordinateReferenceSystem &crs );
+%Docstring
+Constructor for a valid QgsGeocoderResult, with the specified ``geometry`` and ``crs``.
+%End
+
+    bool isValid() const;
+%Docstring
+Returns ``True`` if the result is a valid result.
+
+If the result is invalid, the error message can be retrieved by calling :py:func:`~QgsGeocoderResult.error`.
+%End
+
+    QString error() const;
+%Docstring
+Returns the error string, if the result is invalid.
+%End
+
+    QgsGeometry geometry() const;
+%Docstring
+Returns the resultant geometry resulting from the geocoding operation.
+
+The coordinate reference system for the geometry can be retrieved
+via :py:func:`~QgsGeocoderResult.crs`.
+
+.. seealso:: :py:func:`setGeometry`
+
+.. seealso:: :py:func:`crs`
+%End
+
+    void setGeometry( const QgsGeometry &geometry );
+%Docstring
+Sets the resultant ``geometry`` resulting from the geocoding operation.
+
+The coordinate reference system for the geometry should also be set
+via :py:func:`~QgsGeocoderResult.setCrs`.
+
+.. seealso:: :py:func:`geometry`
+
+.. seealso:: :py:func:`setCrs`
+%End
+
+    QgsCoordinateReferenceSystem crs() const;
+%Docstring
+Returns the coordinate reference system for the calculated :py:func:`~QgsGeocoderResult.geometry`.
+
+.. seealso:: :py:func:`setCrs`
+
+.. seealso:: :py:func:`geometry`
+%End
+
+    void setCrs( const QgsCoordinateReferenceSystem &crs );
+%Docstring
+Sets the coordinate reference system for the calculated :py:func:`~QgsGeocoderResult.geometry`.
+
+.. seealso:: :py:func:`crs`
+
+.. seealso:: :py:func:`geometry`
+%End
+
+    QVariantMap additionalAttributes() const;
+%Docstring
+Contains additional attributes generated during the geocode,
+which may be added to features being geocoded.
+
+.. seealso:: :py:func:`setAdditionalAttributes`
+%End
+
+    void setAdditionalAttributes( const QVariantMap &attributes );
+%Docstring
+Setss additional attributes generated during the geocode,
+which may be added to features being geocoded.
+
+.. seealso:: :py:func:`additionalAttributes`
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/analysis/geocoding/qgsgeocoderresult.h                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -4,6 +4,10 @@
 SET(QGIS_ANALYSIS_SRCS
   qgsanalysis.cpp
 
+  geocoding/qgsgeocoder.cpp
+  geocoding/qgsgeocodercontext.cpp
+  geocoding/qgsgeocoderresult.cpp
+
   interpolation/qgsgridfilewriter.cpp
   interpolation/qgsidwinterpolator.cpp
   interpolation/qgsinterpolator.cpp
@@ -280,6 +284,10 @@ SET(QGIS_ANALYSIS_SRCS
 SET(QGIS_ANALYSIS_HDRS
   qgsanalysis.h
 
+  geocoding/qgsgeocoder.h
+  geocoding/qgsgeocodercontext.h
+  geocoding/qgsgeocoderresult.h
+
   interpolation/Bezier3D.h
   interpolation/CloughTocherInterpolator.h
   interpolation/qgsdualedgetriangulation.h
@@ -434,6 +442,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_BINARY_DIR}/src/analysis
   interpolation
   network
+  geocoding
 )
 INCLUDE_DIRECTORIES(SYSTEM
   ${SPATIALINDEX_INCLUDE_DIR} # before GEOS for case-insensitive filesystems

--- a/src/analysis/geocoding/qgsgeocoder.cpp
+++ b/src/analysis/geocoding/qgsgeocoder.cpp
@@ -1,0 +1,34 @@
+/***************************************************************************
+  qgsgeocoder.cpp
+  ---------------
+  Date                 : August 2020
+  Copyright            : (C) 2020 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsgeocoder.h"
+
+QList<QgsGeocoderResult> QgsGeocoderInterface::geocodeFeature( const QgsFeature &feature, const QgsGeocoderContext &context, QgsFeedback * ) const
+{
+  Q_UNUSED( feature )
+  Q_UNUSED( context )
+  return QList< QgsGeocoderResult >();
+}
+
+QgsFields QgsGeocoderInterface::appendedFields() const { return QgsFields(); }
+
+QgsWkbTypes::Type QgsGeocoderInterface::wkbType() const { return QgsWkbTypes::Unknown; }
+
+QList<QgsGeocoderResult> QgsGeocoderInterface::geocodeString( const QString &string, const QgsGeocoderContext &context, QgsFeedback * ) const
+{
+  Q_UNUSED( string )
+  Q_UNUSED( context )
+  return QList< QgsGeocoderResult >();
+}

--- a/src/analysis/geocoding/qgsgeocoder.h
+++ b/src/analysis/geocoding/qgsgeocoder.h
@@ -31,7 +31,7 @@ class QgsGeocoderContext;
  * QgsGeocoderInterface implementations are able to take either a QgsFeature or a free-form string
  * and calculate the corresponding geometry of the feature.
  *
- * \since QGIS 3.16
+ * \since QGIS 3.18
 */
 class ANALYSIS_EXPORT QgsGeocoderInterface
 {

--- a/src/analysis/geocoding/qgsgeocoder.h
+++ b/src/analysis/geocoding/qgsgeocoder.h
@@ -1,0 +1,94 @@
+/***************************************************************************
+  qgsgeocoder.h
+  ---------------
+  Date                 : August 2020
+  Copyright            : (C) 2020 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSGEOCODER_H
+#define QGSGEOCODER_H
+
+#include "qgis_analysis.h"
+#include "qgsgeocoderresult.h"
+#include "qgsgeometry.h"
+#include "qgsfields.h"
+
+class QgsFeature;
+class QgsGeocoderContext;
+
+/**
+ * \ingroup analysis
+ * Interface for geocoders.
+ *
+ * QgsGeocoderInterface implementations are able to take either a QgsFeature or a free-form string
+ * and calculate the corresponding geometry of the feature.
+ *
+ * \since QGIS 3.16
+*/
+class ANALYSIS_EXPORT QgsGeocoderInterface
+{
+
+  public:
+
+    //! Capability flags for the geocoder.
+    enum class Flag
+    {
+      GeocodesStrings = 1 << 0, //!< Can geocode string input values
+      GeocodesFeatures = 1 << 1, //!< Can geocode QgsFeature input values
+    };
+    Q_DECLARE_FLAGS( Flags, Flag )
+
+    virtual ~QgsGeocoderInterface() = default;
+
+    /**
+     * Returns the geocoder's capability flags.
+     */
+    virtual Flags flags() const = 0;
+
+    /**
+     * Geocodes a \a feature.
+     *
+     * If implemented by the geocoder (i.e. flags() returns the QgsGeocoderInterface::Flag::GeocodesFeatures flag), a list of matching results will be returned.
+     *
+     * The optional \a feedback argument can be used to provider cancelation support.
+     */
+    virtual QList< QgsGeocoderResult > geocodeFeature( const QgsFeature &feature, const QgsGeocoderContext &context, QgsFeedback *feedback = nullptr ) const;
+
+    /**
+     * Returns a set of newly created fields which will be appended to existing features during the geocode
+     * operation.
+     *
+     * These fields will include any extra content returned by the geocoder, such as fields for accuracy of the
+     * match or correct attribute values.
+     */
+    virtual QgsFields appendedFields() const;
+
+    /**
+     * Returns the WKB type of geometries returned by the geocoder.
+     *
+     * If this is not known in advance then QgsWkbTypes::Unknown should be returned (e.g.
+     * in the case that a geocoder may return different geometry types depending on the
+     * quality of the match).
+     */
+    virtual QgsWkbTypes::Type wkbType() const;
+
+    /**
+     * Geocodes a \a string.
+     *
+     * If implemented by the geocoder (i.e. flags() returns the QgsGeocoderInterface::Flag::GeocodesStrings flag), a list of matching results will be returned.
+     *
+     * The optional \a feedback argument can be used to provider cancelation support.
+     */
+    virtual QList< QgsGeocoderResult > geocodeString( const QString &string, const QgsGeocoderContext &context, QgsFeedback *feedback = nullptr ) const;
+
+};
+
+#endif // QGSGEOCODER_H

--- a/src/analysis/geocoding/qgsgeocoder.h
+++ b/src/analysis/geocoding/qgsgeocoder.h
@@ -58,7 +58,7 @@ class ANALYSIS_EXPORT QgsGeocoderInterface
      *
      * If implemented by the geocoder (i.e. flags() returns the QgsGeocoderInterface::Flag::GeocodesFeatures flag), a list of matching results will be returned.
      *
-     * The optional \a feedback argument can be used to provider cancelation support.
+     * The optional \a feedback argument can be used to provider cancellation support.
      */
     virtual QList< QgsGeocoderResult > geocodeFeature( const QgsFeature &feature, const QgsGeocoderContext &context, QgsFeedback *feedback = nullptr ) const;
 
@@ -85,7 +85,7 @@ class ANALYSIS_EXPORT QgsGeocoderInterface
      *
      * If implemented by the geocoder (i.e. flags() returns the QgsGeocoderInterface::Flag::GeocodesStrings flag), a list of matching results will be returned.
      *
-     * The optional \a feedback argument can be used to provider cancelation support.
+     * The optional \a feedback argument can be used to provider cancellation support.
      */
     virtual QList< QgsGeocoderResult > geocodeString( const QString &string, const QgsGeocoderContext &context, QgsFeedback *feedback = nullptr ) const;
 

--- a/src/analysis/geocoding/qgsgeocodercontext.cpp
+++ b/src/analysis/geocoding/qgsgeocodercontext.cpp
@@ -1,0 +1,24 @@
+/***************************************************************************
+  qgsgeocodercontext.cpp
+  ---------------
+  Date                 : August 2020
+  Copyright            : (C) 2020 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsgeocodercontext.h"
+
+//
+// QgsGeocoderContext
+//
+
+QgsGeocoderContext::QgsGeocoderContext( const QgsCoordinateTransformContext &transformContext )
+  : mTransformContext( transformContext )
+{}

--- a/src/analysis/geocoding/qgsgeocodercontext.h
+++ b/src/analysis/geocoding/qgsgeocodercontext.h
@@ -1,0 +1,114 @@
+/***************************************************************************
+  qgsgeocodercontext.h
+  ---------------
+  Date                 : August 2020
+  Copyright            : (C) 2020 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSGEOCODERCONTEXT_H
+#define QGSGEOCODERCONTEXT_H
+
+#include "qgis_analysis.h"
+
+#include "qgscoordinatetransformcontext.h"
+#include "qgscoordinatereferencesystem.h"
+#include "qgsgeometry.h"
+
+/**
+ * \ingroup analysis
+ * Encapsulates the context of a geocoding operation.
+ *
+ * \since QGIS 3.16
+*/
+class ANALYSIS_EXPORT QgsGeocoderContext
+{
+
+  public:
+
+    /**
+     * Constructor for QgsGeocoderContext, with the specified \a transformContext.
+     */
+    QgsGeocoderContext( const QgsCoordinateTransformContext &transformContext );
+
+    /**
+     * Returns the coordinate transform context, which should be used whenever the
+     * geocoder constructs a coordinate transform.
+     *
+     * \see setTransformContext()
+     */
+    QgsCoordinateTransformContext transformContext() const { return mTransformContext; }
+
+    /**
+     * Sets the coordinate transform \a context, which should be used whenever the
+     * geocoder constructs a coordinate transform.
+     *
+     * \see transformContext()
+     */
+    void setTransformContext( const QgsCoordinateTransformContext &context ) { mTransformContext = context; }
+
+    /**
+     * Returns the optional area of interest, which can be used to indicate the desired
+     * geographic area where geocoding results are desired.
+     *
+     * The area of interest can be a polygon geometry, in which case it represents the extent
+     * to use for filtering candidate results, or a point geometry, in which case it represents
+     * a "target point" for prioritising closer results.
+     *
+     * The coordinate reference system for the area of interest can be retrieved via
+     * areaOfInterestCrs().
+     *
+     * \see setAreaOfInterest()
+     * \see areaOfInterestCrs()
+     */
+    QgsGeometry areaOfInterest() const { return mAreaOfInterest; }
+
+    /**
+     * Sets the optional \a area of interest, which can be used to indicate the desired
+     * geographic area where geocoding results are desired.
+     *
+     * The area of interest can be a polygon geometry, in which case it represents the extent
+     * to use for filtering candidate results, or a point geometry, in which case it represents
+     * a "target point" for prioritising closer results.
+     *
+     * The coordinate reference system for the area of interest can be set via
+     * setAreaOfInterestCrs().
+     *
+     * \see areaOfInterest()
+     * \see setAreaOfInterestCrs()
+     */
+    void setAreaOfInterest( const QgsGeometry &area ) { mAreaOfInterest = area; }
+
+    /**
+     * Returns the coordinate reference system for the area of interest, which can be used to indicate the desired
+     * geographic area where geocoding results are desired.
+     *
+     * \see areaOfInterest()
+     * \see setAreaOfInterestCrs()
+     */
+    QgsCoordinateReferenceSystem areaOfInterestCrs() const { return mAreaOfInterestCrs; }
+
+    /**
+     * Sets the \a crs for the area of interest, which can be used to indicate the desired
+     * geographic area where geocoding results are desired.
+     *
+     * \see areaOfInterestCrs()
+     * \see setAreaOfInterest()
+     */
+    void setAreaOfInterestCrs( const QgsCoordinateReferenceSystem &crs ) { mAreaOfInterestCrs = crs; }
+
+  private:
+
+    QgsCoordinateTransformContext mTransformContext;
+    QgsGeometry mAreaOfInterest;
+    QgsCoordinateReferenceSystem mAreaOfInterestCrs;
+};
+
+#endif // QGSGEOCODERCONTEXT_H

--- a/src/analysis/geocoding/qgsgeocodercontext.h
+++ b/src/analysis/geocoding/qgsgeocodercontext.h
@@ -26,7 +26,7 @@
  * \ingroup analysis
  * Encapsulates the context of a geocoding operation.
  *
- * \since QGIS 3.16
+ * \since QGIS 3.18
 */
 class ANALYSIS_EXPORT QgsGeocoderContext
 {
@@ -60,7 +60,7 @@ class ANALYSIS_EXPORT QgsGeocoderContext
      *
      * The area of interest can be a polygon geometry, in which case it represents the extent
      * to use for filtering candidate results, or a point geometry, in which case it represents
-     * a "target point" for prioritising closer results.
+     * a "target point" for prioritizing closer results.
      *
      * The coordinate reference system for the area of interest can be retrieved via
      * areaOfInterestCrs().
@@ -76,7 +76,7 @@ class ANALYSIS_EXPORT QgsGeocoderContext
      *
      * The area of interest can be a polygon geometry, in which case it represents the extent
      * to use for filtering candidate results, or a point geometry, in which case it represents
-     * a "target point" for prioritising closer results.
+     * a "target point" for prioritizing closer results.
      *
      * The coordinate reference system for the area of interest can be set via
      * setAreaOfInterestCrs().

--- a/src/analysis/geocoding/qgsgeocoderresult.cpp
+++ b/src/analysis/geocoding/qgsgeocoderresult.cpp
@@ -1,0 +1,30 @@
+/***************************************************************************
+  qgsgeocoderresult.cpp
+  ---------------
+  Date                 : August 2020
+  Copyright            : (C) 2020 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsgeocoderresult.h"
+
+QgsGeocoderResult QgsGeocoderResult::errorResult( const QString &errorMessage )
+{
+  QgsGeocoderResult result;
+  result.mIsValid = false;
+  result.mErrorString = errorMessage;
+  return result;
+}
+
+QgsGeocoderResult::QgsGeocoderResult( const QgsGeometry &geometry, const QgsCoordinateReferenceSystem &crs )
+  : mIsValid( true )
+  , mGeometry( geometry )
+  , mCrs( crs )
+{}

--- a/src/analysis/geocoding/qgsgeocoderresult.h
+++ b/src/analysis/geocoding/qgsgeocoderresult.h
@@ -35,7 +35,7 @@
  * of optional additionalAttributes() which may contain information such as the
  * accuracy of the geocoding result.
  *
- * \since QGIS 3.16
+ * \since QGIS 3.18
 */
 class ANALYSIS_EXPORT QgsGeocoderResult
 {

--- a/src/analysis/geocoding/qgsgeocoderresult.h
+++ b/src/analysis/geocoding/qgsgeocoderresult.h
@@ -1,0 +1,134 @@
+/***************************************************************************
+  qgsgeocoderresult.h
+  ---------------
+  Date                 : August 2020
+  Copyright            : (C) 2020 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSGEOCODERRESULT_H
+#define QGSGEOCODERRESULT_H
+
+#include "qgis_analysis.h"
+
+#include "qgscoordinatereferencesystem.h"
+#include "qgsgeometry.h"
+
+
+/**
+ * \ingroup analysis
+ * Represents a matching result from a geocoder search.
+ *
+ * QgsGeocoderResult objects may represent valid matches, or an invalid
+ * error result. This can be checked by testing isValid(). An invalid
+ * result represents that an error was encountered while geocoding, in which case the
+ * error message can be retrieved by calling error().
+ *
+ * Valid geocoding results will have a geometry() and crs(), along with a set
+ * of optional additionalAttributes() which may contain information such as the
+ * accuracy of the geocoding result.
+ *
+ * \since QGIS 3.16
+*/
+class ANALYSIS_EXPORT QgsGeocoderResult
+{
+
+  public:
+
+    /**
+     * Creates an invalid error result, with the specified \a errorMessage string.
+     */
+    static QgsGeocoderResult errorResult( const QString &errorMessage );
+
+    /**
+     * Constructor for a valid QgsGeocoderResult, with the specified \a geometry and \a crs.
+     */
+    QgsGeocoderResult( const QgsGeometry &geometry, const QgsCoordinateReferenceSystem &crs );
+
+    /**
+     * Returns TRUE if the result is a valid result.
+     *
+     * If the result is invalid, the error message can be retrieved by calling error().
+     */
+    bool isValid() const { return mIsValid; }
+
+    /**
+     * Returns the error string, if the result is invalid.
+     */
+    QString error() const { return mErrorString; }
+
+    /**
+     * Returns the resultant geometry resulting from the geocoding operation.
+     *
+     * The coordinate reference system for the geometry can be retrieved
+     * via crs().
+     *
+     * \see setGeometry()
+     * \see crs()
+     */
+    QgsGeometry geometry() const { return mGeometry; }
+
+    /**
+     * Sets the resultant \a geometry resulting from the geocoding operation.
+     *
+     * The coordinate reference system for the geometry should also be set
+     * via setCrs().
+     *
+     * \see geometry()
+     * \see setCrs()
+     */
+    void setGeometry( const QgsGeometry &geometry ) { mGeometry = geometry; }
+
+    /**
+     * Returns the coordinate reference system for the calculated geometry().
+     *
+     * \see setCrs()
+     * \see geometry()
+     */
+    QgsCoordinateReferenceSystem crs() const { return mCrs; }
+
+    /**
+     * Sets the coordinate reference system for the calculated geometry().
+     *
+     * \see crs()
+     * \see geometry()
+     */
+    void setCrs( const QgsCoordinateReferenceSystem &crs ) { mCrs = crs; }
+
+    /**
+     * Contains additional attributes generated during the geocode,
+     * which may be added to features being geocoded.
+     *
+     * \see setAdditionalAttributes()
+     */
+    QVariantMap additionalAttributes() const { return mAdditionalAttributes; }
+
+    /**
+     * Setss additional attributes generated during the geocode,
+     * which may be added to features being geocoded.
+     *
+     * \see additionalAttributes()
+     */
+    void setAdditionalAttributes( const QVariantMap &attributes ) { mAdditionalAttributes = attributes; }
+
+  private:
+
+    QgsGeocoderResult() = default;
+
+    bool mIsValid = false;
+    QString mErrorString;
+
+    QgsGeometry mGeometry;
+    QgsCoordinateReferenceSystem mCrs;
+    QVariantMap mAdditionalAttributes;
+
+};
+
+#endif // QGSGEOCODERRESULT_H


### PR DESCRIPTION
This PR adds a basic interface for geocoder classes and operations, to allow a standard API for these using services.

Currently we have tons of geocoder-ish plugins, all of which use their own approaches and interface. Some have updated to use the unified locator bar as their UI, but others have retained custom UI, and to date few (maybe none?) are exposed through processing for bulk geocoding operations.

Accordingly, this interface is designed to remedy this situation! The intention here is that a follow up PR will add adapter classes for easily exposing a QgsGeocoderInterface implementation as a Processing algorithm or locator bar filter, e.g. via

    alg = QgsGeocoderAlgorithm(GoogleGeocoder(api_key='xxxxx'))
    filter = QgsLocatorFilter(EsriLocationGeocoder(url='xxxxx'))

Possibly we code include some services out-of-the-box as processing algorithms!

Here's an example Google Maps geocoder which follows the interface:

```
class GoogleGeocoder(QgsGeocoderInterface):
   
    def __init__(self, api_key):
        super().__init__()
        self.api_key = api_key
        self.endpoint = "https://maps.googleapis.com/maps/api/geocode/json?"
        
    def flags(self):
        return QgsGeocoderInterface.Flag.GeocodesStrings
        
    def get_request_url(self, address):
        return self.endpoint + "sensor=false&address={}&key={}".format(urllib.parse.quote(address),self.api_key)
        
    def geocodeString(self, string, context, feedback=None):
        all_results = []
        
        request = QgsBlockingNetworkRequest()
        error_code = request.get(QNetworkRequest(QUrl(self.get_request_url(string))), feedback=feedback)
        
        if error_code != QgsBlockingNetworkRequest.NoError:            
            return [QgsGeocoderResult.errorResult(request.errorMessage())]
            
        json_array = json.loads(request.reply().content().data().decode("utf-8"))

        for result in json_array["results"]:
            latitude = float(result["geometry"]["location"]["lat"])
            longitude = float(result["geometry"]["location"]["lng"])
            
            geom = QgsGeometry.fromPointXY(QgsPointXY(longitude, latitude))
            res = QgsGeocoderResult(geom, QgsCoordinateReferenceSystem('EPSG:4326'))
            
            attributes = {}
            attributes['status'] = str(json_array["status"])
            
            if "formatted_address" in result:
                attributes['formatted_address'] = str(result["formatted_address"])

            if "place_id" in result:
                attributes['place_id'] = str(result["place_id"])
            
            if "location_type" in result["geometry"]:
                attributes['location_type'] = str(result["geometry"]["location_type"])
                
            res.setAdditionalAttributes(attributes)

            all_results.append(res)

        return all_results

coder = GoogleGeocoder(api_key='xxxxxx')

context = QgsGeocoderContext(QgsProject.instance().transformContext())
results = coder.geocodeString('some address', context)
```

