### PR TITLE
Workaround GDAL reporting that shapefiles support DateTime

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -564,6 +564,15 @@ QgsOgrProvider::QgsOgrProvider( QString const &uri, const ProviderOptions &optio
     CSLDestroy( papszTokens );
   }
 
+  // Older versions of GDAL incorrectly report that shapefiles support
+  // DateTime.
+#if GDAL_VERSION_NUM <= GDAL_COMPUTE_VERSION(3,1,2)
+  if ( mGDALDriverName == QLatin1String( "ESRI Shapefile" ) )
+  {
+    supportsDateTime = false;
+  }
+#endif
+
   if ( supportsDate )
   {
     nativeTypes

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -566,7 +566,7 @@ QgsOgrProvider::QgsOgrProvider( QString const &uri, const ProviderOptions &optio
 
   // Older versions of GDAL incorrectly report that shapefiles support
   // DateTime.
-#if GDAL_VERSION_NUM <= GDAL_COMPUTE_VERSION(3,1,2)
+#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3,2,0)
   if ( mGDALDriverName == QLatin1String( "ESRI Shapefile" ) )
   {
     supportsDateTime = false;


### PR DESCRIPTION
This was fixed in OSGeo/gdal#2821 but we probably want to add a workaround in QGIS until we update to a version of GDAL that includes that fix.

Fixes #38011 