### PR TITLE
Only list layers with styling options in styling panel

### DIFF
--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -101,6 +101,12 @@ QgsLayerStylingWidget::QgsLayerStylingWidget( QgsMapCanvas *canvas, QgsMessageBa
   connect( mLayerCombo, &QgsMapLayerComboBox::layerChanged, this, &QgsLayerStylingWidget::setLayer );
   connect( mLiveApplyCheck, &QAbstractButton::toggled, this, &QgsLayerStylingWidget::liveApplyToggled );
 
+  mLayerCombo->setFilters( QgsMapLayerProxyModel::Filter::HasGeometry
+                           | QgsMapLayerProxyModel::Filter::RasterLayer
+                           | QgsMapLayerProxyModel::Filter::PluginLayer
+                           | QgsMapLayerProxyModel::Filter::MeshLayer
+                           | QgsMapLayerProxyModel::Filter::VectorTileLayer );
+
   mStackedWidget->setCurrentIndex( 0 );
 }
 
@@ -245,8 +251,7 @@ void QgsLayerStylingWidget::setLayer( QgsMapLayer *layer )
       break;
   }
 
-  const auto constMPageFactories = mPageFactories;
-  for ( QgsMapLayerConfigWidgetFactory *factory : constMPageFactories )
+  for ( QgsMapLayerConfigWidgetFactory *factory : qgis::as_const( mPageFactories ) )
   {
     if ( factory->supportsStyleDock() && factory->supportsLayer( layer ) )
     {


### PR DESCRIPTION
## Description

The layer combobox on top of the styling panel up to now also listed ordinary "tables". These are not meaningful in the styling panel. And if chosen, they will make the styling panel itself deactivate.

# Now

![image](https://user-images.githubusercontent.com/588407/89705243-05751800-d95c-11ea-9332-ed6b5695aea6.png)


# Before

![Peek 2020-08-08 09-45](https://user-images.githubusercontent.com/588407/89705238-f55d3880-d95b-11ea-8369-04d1e204f323.gif)
