### PR TITLE
Fix QGIS server getPrint when highlight is requested over a map following a theme

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -622,31 +622,32 @@ namespace QgsWms
             renderLayers = c->project()->mapThemeCollection()->masterVisibleLayers();
 
           // get highlight layers, if any
-          bool has_highlight_layer = false;
-          for ( auto layer : mapSettings.layers() )
+          bool hasHighlightLayer = false;
+          const QList<QgsMapLayer *> layers = mapSettings.layers();
+          for ( QgsMapLayer *layer : layers )
           {
 
             if ( RE_HIGHLIGHT_LAYER.match( layer->name() ).hasMatch() )
             {
-              has_highlight_layer = true;
+              hasHighlightLayer = true;
               auxHighlightLayers << layer;
               c->project()->layerTreeRoot()->insertLayer( 0, layer );
             }
 
           }
 
-          if ( has_highlight_layer )
+          if ( hasHighlightLayer )
           {
 
             // create a new theme with all layers
             QgsMapThemeCollection::MapThemeRecord rec;
             // layers from the theme
-            for ( auto layer : renderLayers )
+            for ( QgsMapLayer *layer : qgis::as_const( renderLayers ) )
             {
               rec.addLayerRecord( QgsMapThemeCollection::MapThemeLayerRecord( layer ) );
             }
             // highlight layers
-            for ( auto layer : auxHighlightLayers )
+            for ( QgsMapLayer *layer : qgis::as_const( auxHighlightLayers ) )
             {
               rec.addLayerRecord( QgsMapThemeCollection::MapThemeLayerRecord( layer ) );
             }

--- a/src/server/services/wms/qgswmsrestorer.cpp
+++ b/src/server/services/wms/qgswmsrestorer.cpp
@@ -23,6 +23,8 @@
 #include "qgsrasterrenderer.h"
 #include "qgsmaplayerstylemanager.h"
 #include "qgsreadwritecontext.h"
+#include "qgsmapthemecollection.h"
+
 
 QgsLayerRestorer::QgsLayerRestorer( const QList<QgsMapLayer *> &layers )
 {
@@ -138,10 +140,33 @@ QgsLayerRestorer::~QgsLayerRestorer()
   }
 }
 
+QgsProjectRestorer::QgsProjectRestorer( const QgsProject *project )
+{
+  mThemeCollection = const_cast<QgsProject *>( project )->mapThemeCollection( );
+}
+
+QgsProjectRestorer::~QgsProjectRestorer()
+{
+
+  QStringList themes = mThemeCollection->mapThemes();
+
+  static const QRegularExpression RE_THEME_WITH_HIGHLIGHT_LAYER = QRegularExpression( ".*__highlight$" );
+
+  for ( int i = 0 ; i < themes.length() ; i++ )
+  {
+    if ( RE_THEME_WITH_HIGHLIGHT_LAYER.match( themes.at( i ) ).hasMatch() )
+    {
+      mThemeCollection->removeMapTheme( themes.at( i ) );
+    }
+  }
+
+}
+
 namespace QgsWms
 {
   QgsWmsRestorer::QgsWmsRestorer( const QgsWmsRenderContext &context )
-    : mLayerRestorer( context.layers() )
+    : mLayerRestorer( context.layers() ),
+      mProjectRestorer( context.project() )
   {
   }
 }

--- a/src/server/services/wms/qgswmsrestorer.cpp
+++ b/src/server/services/wms/qgswmsrestorer.cpp
@@ -140,9 +140,9 @@ QgsLayerRestorer::~QgsLayerRestorer()
   }
 }
 
-QgsProjectRestorer::QgsProjectRestorer( const QgsProject *project )
+QgsProjectRestorer::QgsProjectRestorer( QgsProject *project )
+  : mThemeCollection( project->mapThemeCollection() )
 {
-  mThemeCollection = const_cast<QgsProject *>( project )->mapThemeCollection( );
 }
 
 QgsProjectRestorer::~QgsProjectRestorer()
@@ -166,7 +166,7 @@ namespace QgsWms
 {
   QgsWmsRestorer::QgsWmsRestorer( const QgsWmsRenderContext &context )
     : mLayerRestorer( context.layers() ),
-      mProjectRestorer( context.project() )
+      mProjectRestorer( const_cast<QgsProject *>( context.project() ) )
   {
   }
 }

--- a/src/server/services/wms/qgswmsrestorer.h
+++ b/src/server/services/wms/qgswmsrestorer.h
@@ -31,7 +31,7 @@ class QgsMapLayer;
  * \ingroup server
  * RAII class to restore layer configuration on destruction (opacity,
  * filters, ...)
- * \since QGIS 3.0
+ * \since QGIS 3.14
  */
 class QgsLayerRestorer
 {
@@ -69,7 +69,7 @@ class QgsLayerRestorer
 /**
  * \ingroup server
  * RAII class to restore project configuration on destruction
- * \since QGIS 3.0
+ * \since QGIS 3.16
  */
 class QgsProjectRestorer
 {
@@ -77,9 +77,8 @@ class QgsProjectRestorer
 
     /**
      * Constructor for QgsProjectRestorer.
-     * \param project
      */
-    QgsProjectRestorer( const QgsProject *project );
+    QgsProjectRestorer( QgsProject *project );
 
     /**
      * Destructor.

--- a/src/server/services/wms/qgswmsrestorer.h
+++ b/src/server/services/wms/qgswmsrestorer.h
@@ -63,6 +63,35 @@ class QgsLayerRestorer
     };
 
     QMap<QgsMapLayer *, QgsLayerSettings> mLayerSettings;
+
+};
+
+/**
+ * \ingroup server
+ * RAII class to restore project configuration on destruction
+ * \since QGIS 3.0
+ */
+class QgsProjectRestorer
+{
+  public:
+
+    /**
+     * Constructor for QgsProjectRestorer.
+     * \param project
+     */
+    QgsProjectRestorer( const QgsProject *project );
+
+    /**
+     * Destructor.
+     *
+     * Restore project to its initial state.
+     */
+    ~QgsProjectRestorer();
+
+  private:
+
+    QgsMapThemeCollection *mThemeCollection;
+
 };
 
 namespace QgsWms
@@ -91,6 +120,9 @@ namespace QgsWms
     private:
 
       QgsLayerRestorer mLayerRestorer;
+
+      QgsProjectRestorer mProjectRestorer;
+
   };
 };
 


### PR DESCRIPTION
## Description

Fix #34178

To be able to print with a highlight geometry and a map following a theme, this PR creates a temporary theme.

The temporary theme is removed by `QgsWmsRestorer`. I've added a very simple `QgsProjectRestorer` class to QgsWmsRestorer. This class can be expanded later to make sure other properties of the project are preserved, if they are changed during a specific request.

This PR replaces the former #36007.

This fix was only possible with @pblottiere guidance.