### PR TITLE
restore missed "save query" functionality in the Query builder

### DIFF
--- a/python/gui/auto_generated/qgsquerybuilder.sip.in
+++ b/python/gui/auto_generated/qgsquerybuilder.sip.in
@@ -56,6 +56,20 @@ The test uses a "select count(*) from ..." query to test the SQL
 statement.
 %End
 
+    void saveQuery();
+%Docstring
+Save query to the XML file
+
+.. versionadded:: 3.16
+%End
+
+    void loadQuery();
+%Docstring
+Load query from the XML file
+
+.. versionadded:: 3.16
+%End
+
     void setDatasourceDescription( const QString &uri );
 
 };

--- a/python/gui/auto_generated/qgssearchquerybuilder.sip.in
+++ b/python/gui/auto_generated/qgssearchquerybuilder.sip.in
@@ -14,6 +14,9 @@ class QgsSearchQueryBuilder : QDialog
 {
 %Docstring
 Query Builder for search strings
+
+.. deprecated::
+   Will be removed in QGIS 4
 %End
 
 %TypeHeaderCode

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -74,12 +74,12 @@ QgsQueryBuilder::QgsQueryBuilder( QgsVectorLayer *layer,
 
   pbn = new QPushButton( tr( "&Save…" ) );
   buttonBox->addButton( pbn, QDialogButtonBox::ActionRole );
-  pbn->setToolTip( tr( "Save query to an xml file" ) );
+  pbn->setToolTip( tr( "Save query to QQF file" ) );
   connect( pbn, &QAbstractButton::clicked, this, &QgsQueryBuilder::saveQuery );
 
   pbn = new QPushButton( tr( "&Load…" ) );
   buttonBox->addButton( pbn, QDialogButtonBox::ActionRole );
-  pbn->setToolTip( tr( "Load query from xml file" ) );
+  pbn->setToolTip( tr( "Load query from QQF file" ) );
   connect( pbn, &QAbstractButton::clicked, this, &QgsQueryBuilder::loadQuery );
 
   setupGuiViews();
@@ -530,58 +530,6 @@ void QgsQueryBuilder::loadQuery()
     return;
   }
 
-  QString newQueryText = query;
-
-#if 0
-  // TODO: implement with visitor pattern in QgsExpression
-
-  QStringList attributes = searchTree->referencedColumns();
-  QMap< QString, QString> attributesToReplace;
-  QStringList existingAttributes;
-
-  //get all existing fields
-  QMap<QString, int>::const_iterator fieldIt = mFieldMap.constBegin();
-  for ( ; fieldIt != mFieldMap.constEnd(); ++fieldIt )
-  {
-    existingAttributes.push_back( fieldIt.key() );
-  }
-
-  //if a field does not exist, ask what field should be used instead
-  QStringList::const_iterator attIt = attributes.constBegin();
-  for ( ; attIt != attributes.constEnd(); ++attIt )
-  {
-    //test if attribute is there
-    if ( !mFieldMap.contains( attIt ) )
-    {
-      bool ok;
-      QString replaceAttribute = QInputDialog::getItem( 0, tr( "Select Attribute" ), tr( "There is no attribute '%1' in the current vector layer. Please select an existing attribute." ).arg( *attIt ),
-                                 existingAttributes, 0, false, &ok );
-      if ( !ok || replaceAttribute.isEmpty() )
-      {
-        return;
-      }
-      attributesToReplace.insert( *attIt, replaceAttribute );
-    }
-  }
-
-  //Now replace all the string in the query
-  QList<QgsSearchTreeNode *> columnRefList = searchTree->columnRefNodes();
-  QList<QgsSearchTreeNode *>::iterator columnIt = columnRefList.begin();
-  for ( ; columnIt != columnRefList.end(); ++columnIt )
-  {
-    QMap< QString, QString>::const_iterator replaceIt = attributesToReplace.find( ( *columnIt )->columnRef() );
-    if ( replaceIt != attributesToReplace.constEnd() )
-    {
-      ( *columnIt )->setColumnRef( replaceIt.value() );
-    }
-  }
-
-  if ( attributesToReplace.size() > 0 )
-  {
-    newQueryText = query;
-  }
-#endif
-
   txtSQL->clear();
-  txtSQL->insertText( newQueryText );
+  txtSQL->insertText( query );
 }

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -458,7 +458,7 @@ void QgsQueryBuilder::saveQuery()
   QgsSettings s;
   QString lastQueryFileDir = s.value( QStringLiteral( "/UI/lastQueryFileDir" ), QDir::homePath() ).toString();
   //save as qqf (QGIS query file)
-  QString saveFileName = QFileDialog::getSaveFileName( nullptr, tr( "Save Query to File" ), lastQueryFileDir, QStringLiteral( "*.qqf" ) );
+  QString saveFileName = QFileDialog::getSaveFileName( nullptr, tr( "Save Query to File" ), lastQueryFileDir, tr( "Query files (*.qqf *.QQF)" ) );
   if ( saveFileName.isNull() )
   {
     return;

--- a/src/gui/qgsquerybuilder.h
+++ b/src/gui/qgsquerybuilder.h
@@ -72,6 +72,18 @@ class GUI_EXPORT QgsQueryBuilder : public QDialog, private Ui::QgsQueryBuilderBa
      */
     void test();
 
+    /**
+     * Save query to the XML file
+     * \since QGIS 3.16
+     */
+    void saveQuery();
+
+    /**
+     * Load query from the XML file
+     * \since QGIS 3.16
+     */
+    void loadQuery();
+
     void setDatasourceDescription( const QString &uri );
 
   private slots:

--- a/src/gui/qgssearchquerybuilder.cpp
+++ b/src/gui/qgssearchquerybuilder.cpp
@@ -382,7 +382,7 @@ void QgsSearchQueryBuilder::saveQuery()
   QgsSettings s;
   QString lastQueryFileDir = s.value( QStringLiteral( "/UI/lastQueryFileDir" ), QDir::homePath() ).toString();
   //save as qqt (QGIS query file)
-  QString saveFileName = QFileDialog::getSaveFileName( nullptr, tr( "Save Query to File" ), lastQueryFileDir, QStringLiteral( "*.qqf" ) );
+  QString saveFileName = QFileDialog::getSaveFileName( nullptr, tr( "Save Query to File" ), lastQueryFileDir, tr( "Query files (*.qqf *.QQF)" ) );
   if ( saveFileName.isNull() )
   {
     return;
@@ -418,7 +418,7 @@ void QgsSearchQueryBuilder::loadQuery()
   QgsSettings s;
   QString lastQueryFileDir = s.value( QStringLiteral( "/UI/lastQueryFileDir" ), QDir::homePath() ).toString();
 
-  QString queryFileName = QFileDialog::getOpenFileName( nullptr, tr( "Load Query from File" ), lastQueryFileDir, tr( "Query files" ) + " (*.qqf);;" + tr( "All files" ) + " (*)" );
+  QString queryFileName = QFileDialog::getOpenFileName( nullptr, tr( "Load Query from File" ), lastQueryFileDir, tr( "Query files" ) + " (*.qqf *.QQF);;" + tr( "All files" ) + " (*)" );
   if ( queryFileName.isNull() )
   {
     return;

--- a/src/gui/qgssearchquerybuilder.h
+++ b/src/gui/qgssearchquerybuilder.h
@@ -32,6 +32,7 @@ class QgsVectorLayer;
  * \ingroup gui
  * \class QgsSearchQueryBuilder
  * \brief Query Builder for search strings
+ * \deprecated Will be removed in QGIS 4
  */
 class GUI_EXPORT QgsSearchQueryBuilder : public QDialog, private Ui::QgsQueryBuilderBase
 {


### PR DESCRIPTION
## Description

In previous QGIS versions it was possible to save queries used in the Search Query Builder in the *.qqf files, but at some point when Search Query Builder was replaced by Query Builder class this functionality was missed. This PR restores functionality for saving/loading queries.

FIxes #18550 and #12827.