### PR TITLE
Check for dimensions when comparing WMS layer properties

### DIFF
--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -204,6 +204,15 @@ struct QgsWmsDimensionProperty
 
     return QgsDateTimeRange();
   }
+
+  bool operator== ( const QgsWmsDimensionProperty &other ) const
+  {
+    return name == other.name && units == other.units &&
+           unitSymbol == other.unitSymbol && defaultValue == other.defaultValue &&
+           extent == other.extent && multipleValues == other.multipleValues &&
+           nearestValue == other.nearestValue && current == other.current;
+  }
+
 };
 
 //! Logo URL Property structure
@@ -346,6 +355,8 @@ struct QgsWmsLayerProperty
     if ( !( title == layerProperty.title ) )
       return false;
     if ( !( abstract == layerProperty.abstract ) )
+      return false;
+    if ( !( dimensions == layerProperty.dimensions ) )
       return false;
 
     return true;

--- a/tests/src/providers/testqgswmscapabilities.cpp
+++ b/tests/src/providers/testqgswmscapabilities.cpp
@@ -249,6 +249,164 @@ class TestQgsWmsCapabilities: public QObject
       QCOMPARE( dimensionProperty.extent, extent );
     }
 
+    void wmsLayerProperty_data()
+    {
+      QTest::addColumn<QString>( "firstLayer" );
+      QTest::addColumn<QString>( "secondLayer" );
+      QTest::addColumn<bool>( "result" );
+
+      QTest::newRow( "equal properties" ) << R"""(<Layer queryable="0" opaque="0" cascaded="0">
+                                             <Name>Test</Name>
+                                             <Title>Test</Title>
+                                             <Abstract>Test</Abstract>
+                                             <SRS>EPSG:4326</SRS>
+                                             <LatLonBoundingBox minx="-180" miny="-90" maxx="180" maxy="90" />
+                                             <BoundingBox SRS="EPSG:4326"
+                                                         minx="-180" miny="-90" maxx="180" maxy="90" />
+                                             <Dimension name="time" units="ISO8601">
+                                             2020-01-01
+                                             </Dimension>
+                                             </Layer>)"""
+                                          << R"""(<Layer queryable="0" opaque="0" cascaded="0">
+                                             <Name>Test</Name>
+                                             <Title>Test</Title>
+                                             <Abstract>Test</Abstract>
+                                             <SRS>EPSG:4326</SRS>
+                                             <LatLonBoundingBox minx="-180" miny="-90" maxx="180" maxy="90" />
+                                             <BoundingBox SRS="EPSG:4326"
+                                                         minx="-180" miny="-90" maxx="180" maxy="90" />
+                                             <Dimension name="time" units="ISO8601">
+                                             2020-01-01
+                                             </Dimension>
+                                             </Layer>)"""
+                                          << true;
+
+      QTest::newRow( "different names" ) << R"""(<Layer queryable="0" opaque="0" cascaded="0">
+                                            <Name>Test</Name>
+                                            <Title>Test</Title>
+                                            <Abstract>Test</Abstract>
+                                            <SRS>EPSG:4326</SRS>
+                                            <LatLonBoundingBox minx="-180" miny="-90" maxx="180" maxy="90" />
+                                            <BoundingBox SRS="EPSG:4326"
+                                                        minx="-180" miny="-90" maxx="180" maxy="90" />
+                                            <Dimension name="time" units="ISO8601">
+                                            2020-01-01
+                                            </Dimension>
+                                            </Layer>)"""
+                                         << R"""(<Layer queryable="0" opaque="0" cascaded="0">
+                                            <Name>Test2</Name>
+                                            <Title>Test</Title>
+                                            <Abstract>Test</Abstract>
+                                            <SRS>EPSG:4326</SRS>
+                                            <LatLonBoundingBox minx="-180" miny="-90" maxx="180" maxy="90" />
+                                            <BoundingBox SRS="EPSG:4326"
+                                                        minx="-180" miny="-90" maxx="180" maxy="90" />
+                                            <Dimension name="time" units="ISO8601">
+                                            2020-01-01
+                                            </Dimension>
+                                            </Layer>)"""
+                                         << false;
+
+      QTest::newRow( "different titles" ) << R"""(<Layer queryable="0" opaque="0" cascaded="0">
+                                             <Name>Test</Name>
+                                             <Title>Test</Title>
+                                             <SRS>EPSG:4326</SRS>
+                                             <LatLonBoundingBox minx="-180" miny="-90" maxx="180" maxy="90" />
+                                             <BoundingBox SRS="EPSG:4326"
+                                                         minx="-180" miny="-90" maxx="180" maxy="90" />
+                                             <Dimension name="time" units="ISO8601">
+                                             2020-01-01
+                                             </Dimension>
+                                             </Layer>)"""
+                                          << R"""(<Layer queryable="0" opaque="0" cascaded="0">
+                                             <Name>Test</Name>
+                                             <Title>Test2</Title>
+                                             <SRS>EPSG:4326</SRS>
+                                             <LatLonBoundingBox minx="-180" miny="-90" maxx="180" maxy="90" />
+                                             <BoundingBox SRS="EPSG:4326"
+                                                         minx="-180" miny="-90" maxx="180" maxy="90" />
+                                             <Dimension name="time" units="ISO8601">
+                                             2020-01-01
+                                             </Dimension>
+                                             </Layer>)"""
+                                          << false;
+
+      QTest::newRow( "different abstract" ) << R"""(<Layer queryable="0" opaque="0" cascaded="0">
+                                             <Name>Test</Name>
+                                             <Title>Test</Title>
+                                             <Abstract>Test</Abstract>
+                                             <SRS>EPSG:4326</SRS>
+                                             <LatLonBoundingBox minx="-180" miny="-90" maxx="180" maxy="90" />
+                                             <BoundingBox SRS="EPSG:4326"
+                                                         minx="-180" miny="-90" maxx="180" maxy="90" />
+                                             <Dimension name="time" units="ISO8601">
+                                             2020-01-01
+                                             </Dimension>
+                                             </Layer>)"""
+                                            << R"""(<Layer queryable="0" opaque="0" cascaded="0">
+                                             <Name>Test</Name>
+                                             <Title>Test2</Title>
+                                             <Abstract>Test2</Abstract>
+                                             <SRS>EPSG:4326</SRS>
+                                             <LatLonBoundingBox minx="-180" miny="-90" maxx="180" maxy="90" />
+                                             <BoundingBox SRS="EPSG:4326"
+                                                         minx="-180" miny="-90" maxx="180" maxy="90" />
+                                             <Dimension name="time" units="ISO8601">
+                                             2020-01-01
+                                             </Dimension>
+                                             </Layer>)"""
+                                            << false;
+
+      QTest::newRow( "different dimension extent" ) << R"""(<Layer queryable="0" opaque="0" cascaded="0">
+                                                       <Name>Test</Name>
+                                                       <Title>Test</Title>
+                                                       <Abstract>Test</Abstract>
+                                                       <SRS>EPSG:4326</SRS>
+                                                       <LatLonBoundingBox minx="-180" miny="-90" maxx="180" maxy="90" />
+                                                       <BoundingBox SRS="EPSG:4326"
+                                                                   minx="-180" miny="-90" maxx="180" maxy="90" />
+                                                       <Dimension name="time" units="ISO8601">
+                                                       2020-01-01
+                                                       </Dimension>
+                                                       </Layer>)"""
+          << R"""(<Layer queryable="0" opaque="0" cascaded="0">
+                                                       <Name>Test</Name>
+                                                       <Title>Test</Title>
+                                                       <Abstract>Test</Abstract>
+                                                       <SRS>EPSG:4326</SRS>
+                                                       <LatLonBoundingBox minx="-180" miny="-90" maxx="180" maxy="90" />
+                                                       <BoundingBox SRS="EPSG:4326"
+                                                                   minx="-180" miny="-90" maxx="180" maxy="90" />
+                                                       <Dimension name="time" units="ISO8601">
+                                                       2020-01-01/2020-12-31/P1M
+                                                       </Dimension>
+                                                       </Layer>)"""
+          << false;
+    }
+
+    void wmsLayerProperty()
+    {
+      QFETCH( QString, firstLayer );
+      QFETCH( QString, secondLayer );
+      QFETCH( bool, result );
+
+      QDomDocument doc;
+      doc.setContent( firstLayer );
+
+      QDomDocument doc2;
+      doc2.setContent( secondLayer );
+
+      QgsWmsCapabilities cap;
+      QgsWmsLayerProperty firstLayerProp;
+      QgsWmsLayerProperty secondLayerProp;
+
+      cap.parseLayer( doc.documentElement(), firstLayerProp );
+      cap.parseLayer( doc2.documentElement(), secondLayerProp );
+
+      QCOMPARE( firstLayerProp.equal( secondLayerProp ), result );
+
+    }
+
 };
 
 QGSTEST_MAIN( TestQgsWmsCapabilities )


### PR DESCRIPTION
## Description
Currently when a WMS server capabilities has updated layer's dimensions, refreshing the WMS connection item does not update the corresponding layer items dimensions in the browser.

This PR adds a check for WMS dimensions when comparing WMS layer properties. This will cause WMS layer items in the browser to update to when there are new dimensions and user refreshes the WMS connection item.

cc @tomkralidis 

