### PR TITLE
[wms] When a legend graphic fetch fails, don't show the error in the layer tree, but instead just log it to the message log

### DIFF
--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -1034,8 +1034,7 @@ QImage QgsWmsLegendNode::getLegendGraphic() const
       connect( mFetcher.get(), &QgsImageFetcher::error, this, &QgsWmsLegendNode::getLegendGraphicErrored );
       connect( mFetcher.get(), &QgsImageFetcher::progress, this, &QgsWmsLegendNode::getLegendGraphicProgress );
       mFetcher->start();
-    } // else QgsDebugMsg("XXX No legend supported?");
-
+    }
   }
 
   return mImage;
@@ -1043,8 +1042,6 @@ QImage QgsWmsLegendNode::getLegendGraphic() const
 
 QVariant QgsWmsLegendNode::data( int role ) const
 {
-  //QgsDebugMsg( QStringLiteral("XXX data called with role %1 -- mImage size is %2x%3").arg(role).arg(mImage.width()).arg(mImage.height()) );
-
   if ( role == Qt::DecorationRole )
   {
     return QPixmap::fromImage( getLegendGraphic() );
@@ -1099,7 +1096,6 @@ QJsonObject QgsWmsLegendNode::exportSymbolToJson( const QgsLegendSettings &, con
   return json;
 }
 
-/* private */
 QImage QgsWmsLegendNode::renderMessage( const QString &msg ) const
 {
   const int fontHeight = 10;
@@ -1123,38 +1119,33 @@ QImage QgsWmsLegendNode::renderMessage( const QString &msg ) const
 void QgsWmsLegendNode::getLegendGraphicProgress( qint64 cur, qint64 tot )
 {
   QString msg = QStringLiteral( "Downloading... %1/%2" ).arg( cur ).arg( tot );
-  //QgsDebugMsg ( QString("XXX %1").arg(msg) );
   mImage = renderMessage( msg );
   emit dataChanged();
 }
 
-void QgsWmsLegendNode::getLegendGraphicErrored( const QString &msg )
+void QgsWmsLegendNode::getLegendGraphicErrored( const QString & )
 {
-  if ( ! mFetcher ) return; // must be coming after finish
+  if ( ! mFetcher )
+    return; // must be coming after finish
 
-  mImage = renderMessage( msg );
-  //QgsDebugMsg( QStringLiteral("XXX emitting dataChanged after writing an image of %1x%2").arg(mImage.width()).arg(mImage.height()) );
-
+  mImage = QImage();
   emit dataChanged();
 
   mFetcher.reset();
 
   mValid = true; // we consider it valid anyway
-  // ... but remove validity after 5 seconds
-  //QTimer::singleShot(5000, this, SLOT(invalidateMapBasedData()));
 }
 
 void QgsWmsLegendNode::getLegendGraphicFinished( const QImage &image )
 {
-  if ( ! mFetcher ) return; // must be coming after error
+  if ( ! mFetcher )
+    return; // must be coming after error
 
-  //QgsDebugMsg( QStringLiteral("XXX legend graphic finished, image is %1x%2").arg(theImage.width()).arg(theImage.height()) );
   if ( ! image.isNull() )
   {
     if ( image != mImage )
     {
       mImage = image;
-      //QgsDebugMsg( QStringLiteral("XXX emitting dataChanged") );
       emit dataChanged();
     }
     mValid = true; // only if not null I guess
@@ -1164,7 +1155,6 @@ void QgsWmsLegendNode::getLegendGraphicFinished( const QImage &image )
 
 void QgsWmsLegendNode::invalidateMapBasedData()
 {
-  //QgsDebugMsg( QStringLiteral("XXX invalidateMapBasedData called") );
   // TODO: do this only if this extent != prev extent ?
   mValid = false;
   emit dataChanged();

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -123,7 +123,7 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
 
   mHttpUri = uri.param( QStringLiteral( "url" ) );
   mBaseUrl = QgsWmsProvider::prepareUri( mHttpUri ); // must set here, setImageCrs is using that
-  QgsDebugMsg( "mBaseUrl = " + mBaseUrl );
+  QgsDebugMsgLevel( "mBaseUrl = " + mBaseUrl, 2 );
 
   mIgnoreGetMapUrl = uri.hasParam( QStringLiteral( "IgnoreGetMapUrl" ) );
   mIgnoreGetFeatureInfoUrl = uri.hasParam( QStringLiteral( "IgnoreGetFeatureInfoUrl" ) );
@@ -136,10 +136,10 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
 
   mActiveSubLayers = uri.params( QStringLiteral( "layers" ) );
   mActiveSubStyles = uri.params( QStringLiteral( "styles" ) );
-  QgsDebugMsg( "Entering: layers:" + mActiveSubLayers.join( ", " ) + ", styles:" + mActiveSubStyles.join( ", " ) );
+  QgsDebugMsgLevel( "Entering: layers:" + mActiveSubLayers.join( ", " ) + ", styles:" + mActiveSubStyles.join( ", " ), 2 );
 
   mImageMimeType = uri.param( QStringLiteral( "format" ) );
-  QgsDebugMsg( "Setting image encoding to " + mImageMimeType + '.' );
+  QgsDebugMsgLevel( "Setting image encoding to " + mImageMimeType + '.', 2 );
 
   mMaxWidth = 0;
   mMaxHeight = 0;
@@ -182,7 +182,7 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
       }
       else
       {
-        QgsDebugMsg( QStringLiteral( "skipped dimension %1" ).arg( param ) );
+        QgsDebugMsgLevel( QStringLiteral( "skipped dimension %1" ).arg( param ), 2 );
       }
     }
   }
@@ -190,7 +190,7 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
   mCrsId = uri.param( QStringLiteral( "crs" ) );
 
   mEnableContextualLegend = uri.param( QStringLiteral( "contextualWMSLegend" ) ).toInt();
-  QgsDebugMsg( QStringLiteral( "Contextual legend: %1" ).arg( mEnableContextualLegend ) );
+  QgsDebugMsgLevel( QStringLiteral( "Contextual legend: %1" ).arg( mEnableContextualLegend ), 2 );
 
   mFeatureCount = uri.param( QStringLiteral( "featureCount" ) ).toInt(); // default to 0
 
@@ -485,7 +485,7 @@ bool QgsWmsCapabilities::parseResponse( const QByteArray &response, QgsWmsParser
   }
 
 
-  QgsDebugMsg( QStringLiteral( "Converting to Dom." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Converting to Dom." ), 2 );
 
   bool domOK;
   domOK = parseCapabilitiesDom( response, mCapabilities );
@@ -506,7 +506,7 @@ bool QgsWmsCapabilities::parseResponse( const QByteArray &response, QgsWmsParser
   for ( const QString &f : qgis::as_const( mCapabilities.capability.request.getFeatureInfo.format ) )
   {
     // Don't use mSupportedGetFeatureFormats, there are too many possibilities
-    QgsDebugMsg( "supported format = " + f );
+    QgsDebugMsgLevel( "supported format = " + f, 2 );
     // 1.0: MIME - server shall choose format, we presume it to be plain text
     //      GML.1, GML.2, or GML.3
     // 1.1.0, 1.3.0 - mime types, GML should use application/vnd.ogc.gml
@@ -572,7 +572,7 @@ bool QgsWmsCapabilities::parseCapabilitiesDom( const QByteArray &xml, QgsWmsCapa
   QDomElement docElement = capabilitiesDom.documentElement();
 
   // Assert that the DTD is what we expected (i.e. a WMS Capabilities document)
-  QgsDebugMsg( "testing tagName " + docElement.tagName() );
+  QgsDebugMsgLevel( "testing tagName " + docElement.tagName(), 2 );
 
   if (
     docElement.tagName() != QLatin1String( "WMS_Capabilities" )  && // (1.3 vintage)
@@ -603,21 +603,21 @@ bool QgsWmsCapabilities::parseCapabilitiesDom( const QByteArray &xml, QgsWmsCapa
     QDomElement element = node.toElement();
     if ( !element.isNull() )
     {
-      QgsDebugMsg( element.tagName() ); // the node really is an element.
+      QgsDebugMsgLevel( element.tagName(), 2 ); // the node really is an element.
 
       if ( element.tagName() == QLatin1String( "Service" ) || element.tagName() == QLatin1String( "ows:ServiceProvider" ) || element.tagName() == QLatin1String( "ows:ServiceIdentification" ) )
       {
-        QgsDebugMsg( QStringLiteral( "  Service." ) );
+        QgsDebugMsgLevel( QStringLiteral( "  Service." ), 2 );
         parseService( element, capabilitiesProperty.service );
       }
       else if ( element.tagName() == QLatin1String( "Capability" ) || element.tagName() == QLatin1String( "ows:OperationsMetadata" ) )
       {
-        QgsDebugMsg( QStringLiteral( "  Capability." ) );
+        QgsDebugMsgLevel( QStringLiteral( "  Capability." ), 2 );
         parseCapability( element, capabilitiesProperty.capability );
       }
       else if ( element.tagName() == QLatin1String( "Contents" ) )
       {
-        QgsDebugMsg( QStringLiteral( "  Contents." ) );
+        QgsDebugMsgLevel( QStringLiteral( "  Contents." ), 2 );
         parseWMTSContents( element );
       }
     }
@@ -637,7 +637,6 @@ void QgsWmsCapabilities::parseService( const QDomElement &element, QgsWmsService
     QDomElement nodeElement = node.toElement();
     if ( !nodeElement.isNull() )
     {
-      // QgsDebugMsg( "  "  + e1.tagName() ); // the node really is an element.
       QString tagName = nodeElement.tagName();
       if ( tagName.startsWith( QLatin1String( "wms:" ) ) )
         tagName = tagName.mid( 4 );
@@ -719,7 +718,7 @@ void QgsWmsCapabilities::parseKeywordList( const QDomElement &element, QStringLi
 
       if ( tagName == QLatin1String( "Keyword" ) )
       {
-        QgsDebugMsg( QStringLiteral( "      Keyword." ) );
+        QgsDebugMsgLevel( QStringLiteral( "      Keyword." ), 2 );
         keywordListProperty += nodeElement.text();
       }
     }
@@ -873,7 +872,7 @@ void QgsWmsCapabilities::parseCapability( const QDomElement &element, QgsWmsCapa
     if ( tagName.startsWith( QLatin1String( "wms:" ) ) )
       tagName = tagName.mid( 4 );
 
-    QgsDebugMsg( "  "  + nodeElement.tagName() ); // the node really is an element.
+    QgsDebugMsgLevel( "  "  + nodeElement.tagName(), 2 ); // the node really is an element.
 
     if ( tagName == QLatin1String( "Request" ) )
     {
@@ -1007,17 +1006,17 @@ void QgsWmsCapabilities::parseRequest( const QDomElement &element, QgsWmsRequest
 
       if ( operation == QLatin1String( "GetMap" ) )
       {
-        QgsDebugMsg( QStringLiteral( "      GetMap." ) );
+        QgsDebugMsgLevel( QStringLiteral( "      GetMap." ), 2 );
         parseOperationType( nodeElement, requestProperty.getMap );
       }
       else if ( operation == QLatin1String( "GetFeatureInfo" ) )
       {
-        QgsDebugMsg( QStringLiteral( "      GetFeatureInfo." ) );
+        QgsDebugMsgLevel( QStringLiteral( "      GetFeatureInfo." ), 2 );
         parseOperationType( nodeElement, requestProperty.getFeatureInfo );
       }
       else if ( operation == QLatin1String( "GetLegendGraphic" ) || operation == QLatin1String( "sld:GetLegendGraphic" ) )
       {
-        QgsDebugMsg( QStringLiteral( "      GetLegendGraphic." ) );
+        QgsDebugMsgLevel( QStringLiteral( "      GetLegendGraphic." ), 2 );
         parseOperationType( nodeElement, requestProperty.getLegendGraphic );
       }
     }
@@ -1171,16 +1170,12 @@ void QgsWmsCapabilities::parseLayer( const QDomElement &element, QgsWmsLayerProp
     QDomElement nodeElement = node.toElement();
     if ( !nodeElement.isNull() )
     {
-      //QgsDebugMsg( "    "  + nodeElement.tagName() ); // the node really is an element.
-
       QString tagName = nodeElement.tagName();
       if ( tagName.startsWith( QLatin1String( "wms:" ) ) )
         tagName = tagName.mid( 4 );
 
       if ( tagName == QLatin1String( "Layer" ) )
       {
-        //QgsDebugMsg( QStringLiteral( "      Nested layer." ) );
-
         QgsWmsLayerProperty subLayerProperty;
 
         // Inherit things into the sublayer
@@ -1472,12 +1467,12 @@ void QgsWmsCapabilities::parseOperationType( const QDomElement &element, QgsWmsO
 
       if ( tagName == QLatin1String( "Format" ) )
       {
-        QgsDebugMsg( QStringLiteral( "      Format." ) );
+        QgsDebugMsgLevel( QStringLiteral( "      Format." ), 2 );
         operationType.format += nodeElement.text();
       }
       else if ( tagName == QLatin1String( "DCPType" ) )
       {
-        QgsDebugMsg( QStringLiteral( "      DCPType." ) );
+        QgsDebugMsgLevel( QStringLiteral( "      DCPType." ), 2 );
         QgsWmsDcpTypeProperty dcp;
         parseDcpType( nodeElement, dcp );
         operationType.dcpType.push_back( dcp );
@@ -1499,7 +1494,7 @@ void QgsWmsCapabilities::parseDcpType( const QDomElement &element, QgsWmsDcpType
     {
       if ( nodeElement.tagName() == QLatin1String( "HTTP" ) )
       {
-        QgsDebugMsg( QStringLiteral( "      HTTP." ) );
+        QgsDebugMsgLevel( QStringLiteral( "      HTTP." ), 2 );
         parseHttp( nodeElement, dcpType.http );
       }
     }
@@ -1522,12 +1517,12 @@ void QgsWmsCapabilities::parseHttp( const QDomElement &element, QgsWmsHttpProper
 
       if ( tagName == QLatin1String( "Get" ) )
       {
-        QgsDebugMsg( QStringLiteral( "      Get." ) );
+        QgsDebugMsgLevel( QStringLiteral( "      Get." ), 2 );
         parseGet( nodeElement, httpProperty.get );
       }
       else if ( tagName == QLatin1String( "Post" ) )
       {
-        QgsDebugMsg( QStringLiteral( "      Post." ) );
+        QgsDebugMsgLevel( QStringLiteral( "      Post." ), 2 );
         parsePost( nodeElement, httpProperty.post );
       }
     }
@@ -1550,7 +1545,7 @@ void QgsWmsCapabilities::parseGet( const QDomElement &element, QgsWmsGetProperty
 
       if ( tagName == QLatin1String( "OnlineResource" ) )
       {
-        QgsDebugMsg( QStringLiteral( "      OnlineResource." ) );
+        QgsDebugMsgLevel( QStringLiteral( "      OnlineResource." ), 2 );
         parseOnlineResource( nodeElement, getProperty.onlineResource );
       }
     }
@@ -1573,7 +1568,7 @@ void QgsWmsCapabilities::parsePost( const QDomElement &element, QgsWmsPostProper
 
       if ( tagName == QLatin1String( "OnlineResource" ) )
       {
-        QgsDebugMsg( QStringLiteral( "      OnlineResource." ) );
+        QgsDebugMsgLevel( QStringLiteral( "      OnlineResource." ), 2 );
         parseOnlineResource( nodeElement, postProperty.onlineResource );
       }
     }
@@ -1596,7 +1591,7 @@ void QgsWmsCapabilities::parseTileSetProfile( const QDomElement &element )
   {
     QDomElement nodeElement = node.toElement();
     {
-      QgsDebugMsg( "    "  + nodeElement.tagName() ); // the node really is an element.
+      QgsDebugMsgLevel( "    "  + nodeElement.tagName(), 2 ); // the node really is an element.
 
       QString tagName = nodeElement.tagName();
       if ( tagName.startsWith( QLatin1String( "wms:" ) ) )
@@ -1731,13 +1726,13 @@ void QgsWmsCapabilities::parseWMTSContents( const QDomElement &element )
     if ( mParserSettings.invertAxisOrientation )
       invert = !invert;
 
-    QgsDebugMsg( QStringLiteral( "tilematrix set: %1 (supportedCRS:%2 crs:%3; metersPerUnit:%4 axisInverted:%5)" )
-                 .arg( set.identifier,
-                       supportedCRS,
-                       set.crs )
-                 .arg( metersPerUnit, 0, 'f' )
-                 .arg( invert ? "yes" : "no" )
-               );
+    QgsDebugMsgLevel( QStringLiteral( "tilematrix set: %1 (supportedCRS:%2 crs:%3; metersPerUnit:%4 axisInverted:%5)" )
+                      .arg( set.identifier,
+                            supportedCRS,
+                            set.crs )
+                      .arg( metersPerUnit, 0, 'f' )
+                      .arg( invert ? "yes" : "no" ), 2
+                    );
 
     for ( QDomElement secondChildElement = childElement.firstChildElement( QStringLiteral( "TileMatrix" ) );
           !secondChildElement.isNull();
@@ -1779,13 +1774,13 @@ void QgsWmsCapabilities::parseWMTSContents( const QDomElement &element )
       // in WMTS (and WMS 1.3) standard, being 0.28 pixel
       tileMatrix.tres = tileMatrix.scaleDenom * 0.00028 / metersPerUnit;
 
-      QgsDebugMsg( QStringLiteral( " %1: scale=%2 res=%3 tile=%4x%5 matrix=%6x%7 topLeft=%8" )
-                   .arg( tileMatrix.identifier )
-                   .arg( tileMatrix.scaleDenom ).arg( tileMatrix.tres )
-                   .arg( tileMatrix.tileWidth ).arg( tileMatrix.tileHeight )
-                   .arg( tileMatrix.matrixWidth ).arg( tileMatrix.matrixHeight )
-                   .arg( tileMatrix.topLeft.toString() )
-                 );
+      QgsDebugMsgLevel( QStringLiteral( " %1: scale=%2 res=%3 tile=%4x%5 matrix=%6x%7 topLeft=%8" )
+                        .arg( tileMatrix.identifier )
+                        .arg( tileMatrix.scaleDenom ).arg( tileMatrix.tres )
+                        .arg( tileMatrix.tileWidth ).arg( tileMatrix.tileHeight )
+                        .arg( tileMatrix.matrixWidth ).arg( tileMatrix.matrixHeight )
+                        .arg( tileMatrix.topLeft.toString() ), 2
+                      );
 
       set.tileMatrices.insert( tileMatrix.tres, tileMatrix );
     }
@@ -1804,7 +1799,7 @@ void QgsWmsCapabilities::parseWMTSContents( const QDomElement &element )
   {
 #ifdef QGISDEBUG
     QString id = childElement.firstChildElement( QStringLiteral( "ows:Identifier" ) ).text();  // clazy:exclude=unused-non-trivial-variable
-    QgsDebugMsg( QStringLiteral( "Layer %1" ).arg( id ) );
+    QgsDebugMsgLevel( QStringLiteral( "Layer %1" ).arg( id ), 2 );
 #endif
 
     QgsWmtsTileLayer tileLayer;
@@ -1947,7 +1942,7 @@ void QgsWmsCapabilities::parseWMTSContents( const QDomElement &element )
 
       QgsRaster::IdentifyFormat fmt = QgsRaster::IdentifyFormatUndefined;
 
-      QgsDebugMsg( QStringLiteral( "format=%1" ).arg( format ) );
+      QgsDebugMsgLevel( QStringLiteral( "format=%1" ).arg( format ), 2 );
 
       if ( format == QLatin1String( "MIME" ) )
         fmt = QgsRaster::IdentifyFormatText; // 1.0
@@ -1969,7 +1964,7 @@ void QgsWmsCapabilities::parseWMTSContents( const QDomElement &element )
         continue;
       }
 
-      QgsDebugMsg( QStringLiteral( "fmt=%1" ).arg( fmt ) );
+      QgsDebugMsgLevel( QStringLiteral( "fmt=%1" ).arg( fmt ), 2 );
       mIdentifyFormats.insert( fmt, format );
     }
 
@@ -2055,13 +2050,13 @@ void QgsWmsCapabilities::parseWMTSContents( const QDomElement &element )
             QgsDebugMsg( QStringLiteral( "   TileMatrix id:%1 not found." ).arg( id ) );
           }
 
-          QgsDebugMsg( QStringLiteral( "   TileMatrixLimit id:%1 row:%2-%3 col:%4-%5 matrix:%6x%7 %8" )
-                       .arg( id )
-                       .arg( limit.minTileRow ).arg( limit.maxTileRow )
-                       .arg( limit.minTileCol ).arg( limit.maxTileCol )
-                       .arg( matrixWidth ).arg( matrixHeight )
-                       .arg( isValid ? "valid" : "INVALID" )
-                     );
+          QgsDebugMsgLevel( QStringLiteral( "   TileMatrixLimit id:%1 row:%2-%3 col:%4-%5 matrix:%6x%7 %8" )
+                            .arg( id )
+                            .arg( limit.minTileRow ).arg( limit.maxTileRow )
+                            .arg( limit.minTileCol ).arg( limit.maxTileCol )
+                            .arg( matrixWidth ).arg( matrixHeight )
+                            .arg( isValid ? "valid" : "INVALID" ), 2
+                          );
 
           if ( isValid )
           {
@@ -2081,10 +2076,10 @@ void QgsWmsCapabilities::parseWMTSContents( const QDomElement &element )
 
       if ( format.isEmpty() || resourceType.isEmpty() || tmpl.isEmpty() )
       {
-        QgsDebugMsg( QStringLiteral( "SKIPPING ResourceURL format=%1 resourceType=%2 template=%3" )
-                     .arg( format,
-                           resourceType,
-                           tmpl ) );
+        QgsDebugMsgLevel( QStringLiteral( "SKIPPING ResourceURL format=%1 resourceType=%2 template=%3" )
+                          .arg( format,
+                                resourceType,
+                                tmpl ), 2 );
         continue;
       }
 
@@ -2098,7 +2093,7 @@ void QgsWmsCapabilities::parseWMTSContents( const QDomElement &element )
 
         QgsRaster::IdentifyFormat fmt = QgsRaster::IdentifyFormatUndefined;
 
-        QgsDebugMsg( QStringLiteral( "format=%1" ).arg( format ) );
+        QgsDebugMsgLevel( QStringLiteral( "format=%1" ).arg( format ), 2 );
 
         if ( format == QLatin1String( "MIME" ) )
           fmt = QgsRaster::IdentifyFormatText; // 1.0
@@ -2120,7 +2115,7 @@ void QgsWmsCapabilities::parseWMTSContents( const QDomElement &element )
           continue;
         }
 
-        QgsDebugMsg( QStringLiteral( "fmt=%1" ).arg( fmt ) );
+        QgsDebugMsgLevel( QStringLiteral( "fmt=%1" ).arg( fmt ), 2 );
         mIdentifyFormats.insert( fmt, format );
       }
       else
@@ -2132,7 +2127,7 @@ void QgsWmsCapabilities::parseWMTSContents( const QDomElement &element )
       }
     }
 
-    QgsDebugMsg( QStringLiteral( "add layer %1" ).arg( id ) );
+    QgsDebugMsgLevel( QStringLiteral( "add layer %1" ).arg( id ), 2 );
     mTileLayersSupported << tileLayer;
   }
 
@@ -2254,8 +2249,8 @@ bool QgsWmsCapabilities::detectTileLayerBoundingBox( QgsWmtsTileLayer &tileLayer
   QgsPointXY bottomRight( tm.topLeft.x() + res * tm.tileWidth * tm.matrixWidth,
                           tm.topLeft.y() - res * tm.tileHeight * tm.matrixHeight );
 
-  QgsDebugMsg( QStringLiteral( "detecting WMTS layer bounding box: tileset %1 matrix %2 crs %3 res %4" )
-               .arg( tmsIt->identifier, tm.identifier, tmsIt->crs ).arg( res ) );
+  QgsDebugMsgLevel( QStringLiteral( "detecting WMTS layer bounding box: tileset %1 matrix %2 crs %3 res %4" )
+                    .arg( tmsIt->identifier, tm.identifier, tmsIt->crs ).arg( res ), 2 );
 
   QgsRectangle extent( tm.topLeft, bottomRight );
   extent.normalize();
@@ -2401,7 +2396,7 @@ void QgsWmsCapabilitiesDownload::abort()
 void QgsWmsCapabilitiesDownload::capabilitiesReplyProgress( qint64 bytesReceived, qint64 bytesTotal )
 {
   QString message = tr( "%1 of %2 bytes of capabilities downloaded." ).arg( bytesReceived ).arg( bytesTotal < 0 ? QStringLiteral( "unknown number of" ) : QString::number( bytesTotal ) );
-  QgsDebugMsg( message );
+  QgsDebugMsgLevel( message, 2 );
   emit statusChanged( message );
 }
 
@@ -2411,7 +2406,7 @@ void QgsWmsCapabilitiesDownload::capabilitiesReplyFinished()
   {
     if ( mCapabilitiesReply->error() == QNetworkReply::NoError )
     {
-      QgsDebugMsg( QStringLiteral( "reply OK" ) );
+      QgsDebugMsgLevel( QStringLiteral( "reply OK" ), 2 );
       QVariant redirect = mCapabilitiesReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
       if ( !redirect.isNull() )
       {
@@ -2443,7 +2438,7 @@ void QgsWmsCapabilitiesDownload::capabilitiesReplyFinished()
           mCapabilitiesReply->deleteLater();
           mCapabilitiesReply = nullptr;
 
-          QgsDebugMsg( QStringLiteral( "redirected getcapabilities: %1 forceRefresh=%2" ).arg( redirect.toString() ).arg( mForceRefresh ) );
+          QgsDebugMsgLevel( QStringLiteral( "redirected getcapabilities: %1 forceRefresh=%2" ).arg( redirect.toString() ).arg( mForceRefresh ), 2 );
           mCapabilitiesReply = QgsNetworkAccessManager::instance()->get( request );
 
           if ( !mAuth.setAuthorizationReply( mCapabilitiesReply ) )
@@ -2479,7 +2474,7 @@ void QgsWmsCapabilitiesDownload::capabilitiesReplyFinished()
           }
           cmd.setRawHeaders( hl );
 
-          QgsDebugMsg( QStringLiteral( "expirationDate:%1" ).arg( cmd.expirationDate().toString() ) );
+          QgsDebugMsgLevel( QStringLiteral( "expirationDate:%1" ).arg( cmd.expirationDate().toString() ), 2 );
           if ( cmd.expirationDate().isNull() )
           {
             QgsSettings s;
@@ -2490,12 +2485,12 @@ void QgsWmsCapabilitiesDownload::capabilitiesReplyFinished()
         }
         else
         {
-          QgsDebugMsg( QStringLiteral( "No cache for capabilities!" ) );
+          QgsDebugMsgLevel( QStringLiteral( "No cache for capabilities!" ), 2 );
         }
 
 #ifdef QGISDEBUG
         bool fromCache = mCapabilitiesReply->attribute( QNetworkRequest::SourceIsFromCacheAttribute ).toBool();
-        QgsDebugMsg( QStringLiteral( "Capabilities reply was cached: %1" ).arg( fromCache ) );
+        QgsDebugMsgLevel( QStringLiteral( "Capabilities reply was cached: %1" ).arg( fromCache ), 2 );
 #endif
 
         mHttpCapabilitiesResponse = mCapabilitiesReply->readAll();
@@ -2557,10 +2552,6 @@ void QgsWmtsTileMatrix::viewExtentIntersection( const QgsRectangle &viewExtent, 
     maxTileCol = tml->maxTileCol;
     minTileRow = tml->minTileRow;
     maxTileRow = tml->maxTileRow;
-    //QgsDebugMsg( QStringLiteral( "%1 %2: TileMatrixLimits col %3-%4 row %5-%6" )
-    //             .arg( tileMatrixSet->identifier, identifier )
-    //             .arg( minTileCol ).arg( maxTileCol )
-    //             .arg( minTileRow ).arg( maxTileRow ) );
   }
 
   col0 = qBound( minTileCol, ( int ) std::floor( ( viewExtent.xMinimum() - topLeft.x() ) / twMap ), maxTileCol );
@@ -2574,7 +2565,6 @@ const QgsWmtsTileMatrix *QgsWmtsTileMatrixSet::findNearestResolution( double vre
   QMap<double, QgsWmtsTileMatrix>::const_iterator prev, it = tileMatrices.constBegin();
   while ( it != tileMatrices.constEnd() && it.key() < vres )
   {
-    //QgsDebugMsg( QStringLiteral( "res:%1 >= %2" ).arg( it.key() ).arg( vres ) );
     prev = it;
     ++it;
   }
@@ -2582,7 +2572,6 @@ const QgsWmtsTileMatrix *QgsWmtsTileMatrixSet::findNearestResolution( double vre
   if ( it == tileMatrices.constEnd() ||
        ( it != tileMatrices.constBegin() && vres - prev.key() < it.key() - vres ) )
   {
-    //QgsDebugMsg( QStringLiteral( "back to previous res" ) );
     it = prev;
   }
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -4509,7 +4509,7 @@ void QgsWmsLegendDownloadHandler::startUrl( const QUrl &url )
 
 void QgsWmsLegendDownloadHandler::sendError( const QString &msg )
 {
-  QgsDebugMsgLevel( QStringLiteral( "emitting error: %1" ).arg( msg ), 2 );
+  QgsMessageLog::logMessage( msg, tr( "WMS" ) );
   Q_ASSERT( mReply );
   mReply->deleteLater();
   mReply = nullptr;

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -419,8 +419,6 @@ void QgsWmsProvider::setConnectionName( QString const &connName )
 
 void QgsWmsProvider::setLayerOrder( QStringList const &layers )
 {
-  QgsDebugMsg( QStringLiteral( "Entering." ) );
-
   if ( layers.size() != mSettings.mActiveSubLayers.size() )
   {
     QgsDebugMsg( QStringLiteral( "Invalid layer list length" ) );
@@ -448,8 +446,6 @@ void QgsWmsProvider::setLayerOrder( QStringList const &layers )
   {
     mSettings.mActiveSubStyles.append( styleMap[ layers[i] ] );
   }
-
-  QgsDebugMsg( QStringLiteral( "Exiting." ) );
 }
 
 
@@ -1037,8 +1033,8 @@ QUrl QgsWmsProvider::createRequestUrlWMS( const QgsRectangle &viewExtent, int pi
 
   bool changeXY = mCaps.shouldInvertAxisOrientation( mImageCrs );
 
-  QgsDebugMsg( "Active layer list of "  + mSettings.mActiveSubLayers.join( ", " )
-               + " and style list of "  + mSettings.mActiveSubStyles.join( ", " ) );
+  QgsDebugMsgLevel( "Active layer list of "  + mSettings.mActiveSubLayers.join( ", " )
+                    + " and style list of "  + mSettings.mActiveSubStyles.join( ", " ), 2 );
 
   QStringList visibleLayers = QStringList();
   QStringList visibleStyles = QStringList();
@@ -1063,7 +1059,7 @@ QUrl QgsWmsProvider::createRequestUrlWMS( const QgsRectangle &viewExtent, int pi
   QString styles = visibleStyles.join( ',' );
   styles = styles.isNull() ? QString() : styles;
 
-  QgsDebugMsg( "Visible layer list of " + layers + " and style list of " + styles );
+  QgsDebugMsgLevel( "Visible layer list of " + layers + " and style list of " + styles, 2 );
 
   QString bbox = toParamValue( viewExtent, changeXY );
 
@@ -1108,7 +1104,7 @@ QUrl QgsWmsProvider::createRequestUrlWMS( const QgsRectangle &viewExtent, int pi
 
   url.setQuery( query );
 
-  QgsDebugMsg( QStringLiteral( "getmap: %1" ).arg( url.toString() ) );
+  QgsDebugMsgLevel( QStringLiteral( "getmap: %1" ).arg( url.toString() ), 2 );
   return url;
 }
 
@@ -1258,7 +1254,7 @@ void QgsWmsProvider::createTileRequestsWMSC( const QgsWmtsTileMatrix *tm, const 
                   qgsDoubleToString( bbox.xMaximum() ),
                   qgsDoubleToString( bbox.yMaximum() ) );
 
-    QgsDebugMsg( QStringLiteral( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i ).arg( tiles.count() ).arg( tile.row ).arg( tile.col ).arg( turl ) );
+    QgsDebugMsgLevel( QStringLiteral( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i ).arg( tiles.count() ).arg( tile.row ).arg( tile.col ).arg( turl ), 2 );
     requests << TileRequest( turl, tm->tileRect( tile.col, tile.row ), i );
     ++i;
   }
@@ -1300,7 +1296,7 @@ void QgsWmsProvider::createTileRequestsWMTS( const QgsWmtsTileMatrix *tm, const 
       turl += url.toString();
       turl += QStringLiteral( "&TILEROW=%1&TILECOL=%2" ).arg( tile.row ).arg( tile.col );
 
-      QgsDebugMsg( QStringLiteral( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i ).arg( tiles.count() ).arg( tile.row ).arg( tile.col ).arg( turl ) );
+      QgsDebugMsgLevel( QStringLiteral( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i ).arg( tiles.count() ).arg( tile.row ).arg( tile.col ).arg( turl ), 2 );
       requests << TileRequest( turl, tm->tileRect( tile.col, tile.row ), i );
       ++i;
     }
@@ -1389,8 +1385,6 @@ void QgsWmsProvider::createTileRequestsXYZ( const QgsWmtsTileMatrix *tm, const Q
 
 bool QgsWmsProvider::retrieveServerCapabilities( bool forceRefresh )
 {
-  QgsDebugMsg( QStringLiteral( "entering: forceRefresh=%1" ).arg( forceRefresh ) );
-
   if ( !mCaps.isValid() )
   {
     QgsWmsCapabilitiesDownload downloadCaps( mSettings.baseUrl(), mSettings.authorization(), forceRefresh );
@@ -1413,8 +1407,6 @@ bool QgsWmsProvider::retrieveServerCapabilities( bool forceRefresh )
   }
 
   Q_ASSERT( mCaps.isValid() );
-
-  QgsDebugMsg( QStringLiteral( "exiting." ) );
 
   return true;
 }
@@ -1637,7 +1629,7 @@ bool QgsWmsProvider::extentForNonTiledLayer( const QString &layerName, const QSt
 
   QgsCoordinateTransform xform( wgs, dst, transformContext() );
 
-  QgsDebugMsg( QStringLiteral( "transforming layer extent %1" ).arg( extent.toString( true ) ) );
+  QgsDebugMsgLevel( QStringLiteral( "transforming layer extent %1" ).arg( extent.toString( true ) ), 2 );
   try
   {
     extent = xform.transformBoundingBox( extent );
@@ -1647,7 +1639,7 @@ bool QgsWmsProvider::extentForNonTiledLayer( const QString &layerName, const QSt
     Q_UNUSED( cse )
     return false;
   }
-  QgsDebugMsg( QStringLiteral( "transformed layer extent %1" ).arg( extent.toString( true ) ) );
+  QgsDebugMsgLevel( QStringLiteral( "transformed layer extent %1" ).arg( extent.toString( true ) ), 2 );
 
   //make sure extent does not contain 'inf' or 'nan'
   if ( !extent.isFinite() )
@@ -1665,7 +1657,7 @@ bool QgsWmsProvider::parseServiceExceptionReportDom( QByteArray const &xml, QStr
 #ifdef QGISDEBUG
   //test the content of the QByteArray
   QString responsestring( xml );
-  QgsDebugMsg( "received the following data: " + responsestring );
+  QgsDebugMsgLevel( "received the following data: " + responsestring, 2 );
 #endif
 
   // Convert completed document into a Dom
@@ -1703,7 +1695,7 @@ bool QgsWmsProvider::parseServiceExceptionReportDom( QByteArray const &xml, QStr
     QDomElement e = n.toElement(); // try to convert the node to an element.
     if ( !e.isNull() )
     {
-      QgsDebugMsg( e.tagName() ); // the node really is an element.
+      QgsDebugMsgLevel( e.tagName(), 2 ); // the node really is an element.
 
       QString tagName = e.tagName();
       if ( tagName.startsWith( QLatin1String( "wms:" ) ) ||
@@ -1719,8 +1711,6 @@ bool QgsWmsProvider::parseServiceExceptionReportDom( QByteArray const &xml, QStr
     }
     n = n.nextSibling();
   }
-
-  QgsDebugMsg( QStringLiteral( "exiting." ) );
 
   return true;
 }
@@ -1809,7 +1799,7 @@ void QgsWmsProvider::parseServiceException( QDomElement const &e, QString &error
 
   // TODO = e.attribute("locator");
 
-  QgsDebugMsg( QStringLiteral( "exiting with composed error message '%1'." ).arg( errorText ) );
+  QgsDebugMsgLevel( QStringLiteral( "exiting with composed error message '%1'." ).arg( errorText ), 2 );
 }
 
 QgsRectangle QgsWmsProvider::extent() const
@@ -1859,7 +1849,9 @@ bool QgsWmsProvider::calculateExtent() const
     {
       int i;
       for ( i = 0; i < mTileLayer->boundingBoxes.size() && mTileLayer->boundingBoxes[i].crs != mImageCrs; i++ )
-        QgsDebugMsg( QStringLiteral( "Skip %1 [%2]" ).arg( mTileLayer->boundingBoxes.at( i ).crs, mImageCrs ) );
+      {
+        QgsDebugMsgLevel( QStringLiteral( "Skip %1 [%2]" ).arg( mTileLayer->boundingBoxes.at( i ).crs, mImageCrs ), 2 );
+      }
 
       if ( i < mTileLayer->boundingBoxes.size() )
       {
@@ -1876,7 +1868,7 @@ bool QgsWmsProvider::calculateExtent() const
 
           QgsCoordinateTransform ct( qgisSrsSource, qgisSrsDest, transformContext() );
 
-          QgsDebugMsg( QStringLiteral( "ct: %1 => %2" ).arg( mTileLayer->boundingBoxes.at( i ).crs, mImageCrs ) );
+          QgsDebugMsgLevel( QStringLiteral( "ct: %1 => %2" ).arg( mTileLayer->boundingBoxes.at( i ).crs, mImageCrs ), 2 );
 
           try
           {
@@ -1901,7 +1893,7 @@ bool QgsWmsProvider::calculateExtent() const
       return true;
     }
 
-    QgsDebugMsg( QStringLiteral( "no extent returned" ) );
+    QgsDebugMsgLevel( QStringLiteral( "no extent returned" ), 2 );
     return false;
   }
   else
@@ -1911,16 +1903,16 @@ bool QgsWmsProvider::calculateExtent() const
           it != mSettings.mActiveSubLayers.constEnd();
           ++it )
     {
-      QgsDebugMsg( "Sublayer iterator: " + *it );
+      QgsDebugMsgLevel( "Sublayer iterator: " + *it, 2 );
 
       QgsRectangle extent;
       if ( !extentForNonTiledLayer( *it, mImageCrs, extent ) )
       {
-        QgsDebugMsg( "extent for " + *it + " is invalid! (ignoring)" );
+        QgsDebugMsgLevel( "extent for " + *it + " is invalid! (ignoring)", 2 );
         continue;
       }
 
-      QgsDebugMsg( "extent for " + *it  + " is " + extent.toString( 3 )  + '.' );
+      QgsDebugMsgLevel( "extent for " + *it  + " is " + extent.toString( 3 )  + '.', 2 );
 
       // add to the combined extent of all the active sublayers
       if ( firstLayer )
@@ -1934,12 +1926,12 @@ bool QgsWmsProvider::calculateExtent() const
 
       firstLayer = false;
 
-      QgsDebugMsg( "combined extent is '"  + mLayerExtent.toString()
-                   + "' after '"  + ( *it ) + "'." );
+      QgsDebugMsgLevel( "combined extent is '"  + mLayerExtent.toString()
+                        + "' after '"  + ( *it ) + "'.", 2 );
 
     }
 
-    QgsDebugMsg( "exiting with '"  + mLayerExtent.toString() + "'." );
+    QgsDebugMsgLevel( "exiting with '"  + mLayerExtent.toString() + "'.", 2 );
     return true;
   }
 }
@@ -1969,7 +1961,7 @@ int QgsWmsProvider::capabilities() const
         // Is sublayer queryable?
         if ( mCaps.mQueryableForLayer.find( *it ).value() )
         {
-          QgsDebugMsg( '\''  + ( *it )  + "' is queryable." );
+          QgsDebugMsgLevel( '\''  + ( *it )  + "' is queryable.", 2 );
           canIdentify = true;
         }
       }
@@ -2756,7 +2748,7 @@ QString QgsWmsProvider::htmlMetadata()
 
 QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRaster::IdentifyFormat format, const QgsRectangle &boundingBox, int width, int height, int /*dpi*/ )
 {
-  QgsDebugMsg( QStringLiteral( "format = %1" ).arg( format ) );
+  QgsDebugMsgLevel( QStringLiteral( "format = %1" ).arg( format ), 2 );
 
   QString formatStr;
   formatStr = mCaps.mIdentifyFormats.value( format );
@@ -2765,7 +2757,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
     return QgsRasterIdentifyResult( QGS_ERROR( tr( "Format not supported" ) ) );
   }
 
-  QgsDebugMsg( QStringLiteral( "format = %1 format = %2" ).arg( format ).arg( formatStr ) );
+  QgsDebugMsgLevel( QStringLiteral( "format = %1 format = %2" ).arg( format ).arg( formatStr ), 2 );
 
   QMap<int, QVariant> results;
   if ( !extent().contains( point ) )
@@ -2849,17 +2841,17 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
     myExtent.setYMaximum( myExtent.yMaximum() + yRes );
   }
 
-  QgsDebugMsg( "myExtent = " + myExtent.toString() );
-  QgsDebugMsg( QStringLiteral( "theWidth = %1 height = %2" ).arg( width ).arg( height ) );
-  QgsDebugMsg( QStringLiteral( "xRes = %1 yRes = %2" ).arg( xRes ).arg( yRes ) );
+  QgsDebugMsgLevel( "myExtent = " + myExtent.toString(), 2 );
+  QgsDebugMsgLevel( QStringLiteral( "theWidth = %1 height = %2" ).arg( width ).arg( height ), 2 );
+  QgsDebugMsgLevel( QStringLiteral( "xRes = %1 yRes = %2" ).arg( xRes ).arg( yRes ), 2 );
 
   QgsPointXY finalPoint;
   finalPoint.setX( std::floor( ( point.x() - myExtent.xMinimum() ) / xRes ) );
   finalPoint.setY( std::floor( ( myExtent.yMaximum() - point.y() ) / yRes ) );
 
-  QgsDebugMsg( QStringLiteral( "point = %1 %2" ).arg( finalPoint.x() ).arg( finalPoint.y() ) );
+  QgsDebugMsgLevel( QStringLiteral( "point = %1 %2" ).arg( finalPoint.x() ).arg( finalPoint.y() ), 2 );
 
-  QgsDebugMsg( QStringLiteral( "recalculated orig point (corner) = %1 %2" ).arg( myExtent.xMinimum() + finalPoint.x()*xRes ).arg( myExtent.yMaximum() - finalPoint.y()*yRes ) );
+  QgsDebugMsgLevel( QStringLiteral( "recalculated orig point (corner) = %1 %2" ).arg( myExtent.xMinimum() + finalPoint.x()*xRes ).arg( myExtent.yMaximum() - finalPoint.y()*yRes ), 2 );
 
   // Collect which layers to query on
   //according to the WMS spec for 1.3, the order of x - and y - coordinates is inverted for geographical CRS
@@ -2910,7 +2902,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
         continue;
       }
 
-      QgsDebugMsg( "Layer '" + *layers + "' is queryable." );
+      QgsDebugMsgLevel( "Layer '" + *layers + "' is queryable.", 2 );
 
       QUrl requestUrl( mSettings.mIgnoreGetFeatureInfoUrl ? mSettings.mBaseUrl : getFeatureInfoUrl() );
       QUrlQuery query( requestUrl );
@@ -2973,7 +2965,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
     QMap<double, QgsWmtsTileMatrix>::const_iterator prev, it = m.constBegin();
     while ( it != m.constEnd() && it.key() < vres )
     {
-      QgsDebugMsg( QStringLiteral( "res:%1 >= %2" ).arg( it.key() ).arg( vres ) );
+      QgsDebugMsgLevel( QStringLiteral( "res:%1 >= %2" ).arg( it.key() ).arg( vres ), 2 );
       prev = it;
       ++it;
     }
@@ -2981,43 +2973,43 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
     if ( it == m.constEnd() ||
          ( it != m.constBegin() && vres - prev.key() < it.key() - vres ) )
     {
-      QgsDebugMsg( QStringLiteral( "back to previous res" ) );
+      QgsDebugMsgLevel( QStringLiteral( "back to previous res" ), 2 );
       it = prev;
     }
 
     tres = it.key();
     tm = &it.value();
 
-    QgsDebugMsg( QStringLiteral( "layer extent: %1,%2,%3,%4 %5x%6" )
-                 .arg( qgsDoubleToString( mLayerExtent.xMinimum() ),
-                       qgsDoubleToString( mLayerExtent.yMinimum() ) )
-                 .arg( qgsDoubleToString( mLayerExtent.xMaximum() ),
-                       qgsDoubleToString( mLayerExtent.yMaximum() ) )
-                 .arg( mLayerExtent.width() )
-                 .arg( mLayerExtent.height() )
-               );
+    QgsDebugMsgLevel( QStringLiteral( "layer extent: %1,%2,%3,%4 %5x%6" )
+                      .arg( qgsDoubleToString( mLayerExtent.xMinimum() ),
+                            qgsDoubleToString( mLayerExtent.yMinimum() ) )
+                      .arg( qgsDoubleToString( mLayerExtent.xMaximum() ),
+                            qgsDoubleToString( mLayerExtent.yMaximum() ) )
+                      .arg( mLayerExtent.width() )
+                      .arg( mLayerExtent.height() ), 2
+                    );
 
-    QgsDebugMsg( QStringLiteral( "view extent: %1,%2,%3,%4 %5x%6  res:%7" )
-                 .arg( qgsDoubleToString( boundingBox.xMinimum() ),
-                       qgsDoubleToString( boundingBox.yMinimum() ) )
-                 .arg( qgsDoubleToString( boundingBox.xMaximum() ),
-                       qgsDoubleToString( boundingBox.yMaximum() ) )
-                 .arg( boundingBox.width() )
-                 .arg( boundingBox.height() )
-                 .arg( vres, 0, 'f' )
-               );
+    QgsDebugMsgLevel( QStringLiteral( "view extent: %1,%2,%3,%4 %5x%6  res:%7" )
+                      .arg( qgsDoubleToString( boundingBox.xMinimum() ),
+                            qgsDoubleToString( boundingBox.yMinimum() ) )
+                      .arg( qgsDoubleToString( boundingBox.xMaximum() ),
+                            qgsDoubleToString( boundingBox.yMaximum() ) )
+                      .arg( boundingBox.width() )
+                      .arg( boundingBox.height() )
+                      .arg( vres, 0, 'f' ), 2
+                    );
 
-    QgsDebugMsg( QStringLiteral( "tile matrix %1,%2 res:%3 tilesize:%4x%5 matrixsize:%6x%7 id:%8" )
-                 .arg( tm->topLeft.x() ).arg( tm->topLeft.y() ).arg( tres )
-                 .arg( tm->tileWidth ).arg( tm->tileHeight )
-                 .arg( tm->matrixWidth ).arg( tm->matrixHeight )
-                 .arg( tm->identifier )
-               );
+    QgsDebugMsgLevel( QStringLiteral( "tile matrix %1,%2 res:%3 tilesize:%4x%5 matrixsize:%6x%7 id:%8" )
+                      .arg( tm->topLeft.x() ).arg( tm->topLeft.y() ).arg( tres )
+                      .arg( tm->tileWidth ).arg( tm->tileHeight )
+                      .arg( tm->matrixWidth ).arg( tm->matrixHeight )
+                      .arg( tm->identifier ), 2
+                    );
 
     // calculate tile coordinates
     double twMap = tm->tileWidth * tres;
     double thMap = tm->tileHeight * tres;
-    QgsDebugMsg( QStringLiteral( "tile map size: %1,%2" ).arg( qgsDoubleToString( twMap ), qgsDoubleToString( thMap ) ) );
+    QgsDebugMsgLevel( QStringLiteral( "tile map size: %1,%2" ).arg( qgsDoubleToString( twMap ), qgsDoubleToString( thMap ) ), 2 );
 
     int col = ( int ) std::floor( ( point.x() - tm->topLeft.x() ) / twMap );
     int row = ( int ) std::floor( ( tm->topLeft.y() - point.y() ) / thMap );
@@ -3026,7 +3018,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
     int i   = ( point.x() - tx ) / tres;
     int j   = ( ty - point.y() ) / tres;
 
-    QgsDebugMsg( QStringLiteral( "col=%1 row=%2 i=%3 j=%4 tx=%5 ty=%6" ).arg( col ).arg( row ).arg( i ).arg( j ).arg( tx, 0, 'f', 1 ).arg( ty, 0, 'f', 1 ) );
+    QgsDebugMsgLevel( QStringLiteral( "col=%1 row=%2 i=%3 j=%4 tx=%5 ty=%6" ).arg( col ).arg( row ).arg( i ).arg( j ).arg( tx, 0, 'f', 1 ).arg( ty, 0, 'f', 1 ), 2 );
 
     if ( mTileLayer->getFeatureInfoURLs.contains( formatStr ) )
     {
@@ -3090,7 +3082,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
   {
     const QUrl &requestUrl = urls[count];
 
-    QgsDebugMsg( QStringLiteral( "getfeatureinfo: %1" ).arg( requestUrl.toString() ) );
+    QgsDebugMsgLevel( QStringLiteral( "getfeatureinfo: %1" ).arg( requestUrl.toString() ), 2 );
     QNetworkRequest request( requestUrl );
     QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWmsProvider" ) );
     QgsSetRequestInitiatorId( request, QStringLiteral( "identify %1,%2" ).arg( point.x() ).arg( point.y() ) );
@@ -3215,12 +3207,12 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
           xsdPart = 1;
         }
       }
-      QgsDebugMsg( QStringLiteral( "jsonPart = %1 gmlPart = %2 xsdPart = %3" ).arg( jsonPart ).arg( gmlPart ).arg( xsdPart ) );
+      QgsDebugMsgLevel( QStringLiteral( "jsonPart = %1 gmlPart = %2 xsdPart = %3" ).arg( jsonPart ).arg( gmlPart ).arg( xsdPart ), 2 );
 
       if ( gmlPart >= 0 )
       {
         QByteArray gmlByteArray = mIdentifyResultBodies.value( gmlPart );
-        QgsDebugMsg( "GML (first 2000 bytes):\n" + gmlByteArray.left( 2000 ) );
+        QgsDebugMsgLevel( "GML (first 2000 bytes):\n" + gmlByteArray.left( 2000 ), 2 );
 
         // QgsGmlSchema.guessSchema() and QgsGml::getFeatures() are using Expat
         // which only accepts UTF-8, UTF-16, ISO-8859-1
@@ -3232,14 +3224,14 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
         stream.setCodec( QTextCodec::codecForName( "UTF-8" ) );
         dom.save( stream, 4, QDomNode::EncodingFromTextStream );
 
-        QgsDebugMsg( "GML UTF-8 (first 2000 bytes):\n" + gmlByteArray.left( 2000 ) );
+        QgsDebugMsgLevel( "GML UTF-8 (first 2000 bytes):\n" + gmlByteArray.left( 2000 ), 2 );
 
         QgsWkbTypes::Type wkbType;
         QgsGmlSchema gmlSchema;
 
         if ( xsdPart >= 0 )  // XSD available
         {
-          QgsDebugMsg( "GML XSD (first 4000 bytes):\n" + QString::fromUtf8( mIdentifyResultBodies.value( xsdPart ).left( 4000 ) ) );
+          QgsDebugMsgLevel( "GML XSD (first 4000 bytes):\n" + QString::fromUtf8( mIdentifyResultBodies.value( xsdPart ).left( 4000 ) ), 2 );
           gmlSchema.parseXSD( mIdentifyResultBodies.value( xsdPart ) );
         }
         else
@@ -3256,7 +3248,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
         }
 
         QStringList featureTypeNames = gmlSchema.typeNames();
-        QgsDebugMsg( QStringLiteral( "%1 featureTypeNames found" ).arg( featureTypeNames.size() ) );
+        QgsDebugMsgLevel( QStringLiteral( "%1 featureTypeNames found" ).arg( featureTypeNames.size() ), 2 );
 
         // Each sublayer may have more features of different types, for example
         // if GROUP of multiple vector layers is used with UMN MapServer
@@ -3270,11 +3262,11 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
         const auto constFeatureTypeNames = featureTypeNames;
         for ( const QString &featureTypeName : constFeatureTypeNames )
         {
-          QgsDebugMsg( QStringLiteral( "featureTypeName = %1" ).arg( featureTypeName ) );
+          QgsDebugMsgLevel( QStringLiteral( "featureTypeName = %1" ).arg( featureTypeName ), 2 );
 
           QString geometryAttribute = gmlSchema.geometryAttributes( featureTypeName ).value( 0 );
           QList<QgsField> fieldList = gmlSchema.fields( featureTypeName );
-          QgsDebugMsg( QStringLiteral( "%1 fields found" ).arg( fieldList.size() ) );
+          QgsDebugMsgLevel( QStringLiteral( "%1 fields found" ).arg( fieldList.size() ), 2 );
           QgsFields fields;
           for ( int i = 0; i < fieldList.size(); i++ )
           {
@@ -3284,7 +3276,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
           // TODO: avoid converting to string and back
           int ret = gml.getFeatures( gmlByteArray, &wkbType );
 #ifdef QGISDEBUG
-          QgsDebugMsg( QStringLiteral( "parsing result = %1" ).arg( ret ) );
+          QgsDebugMsgLevel( QStringLiteral( "parsing result = %1" ).arg( ret ), 2 );
 #else
           Q_UNUSED( ret )
 #endif
@@ -3293,7 +3285,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
           // for results -> verify CRS and reprojects if necessary
           QMap<QgsFeatureId, QgsFeature * > features = gml.featuresMap();
           QgsCoordinateReferenceSystem featuresCrs = gml.crs();
-          QgsDebugMsg( QStringLiteral( "%1 features read, crs: %2" ).arg( features.size() ).arg( featuresCrs.userFriendlyIdentifier() ) );
+          QgsDebugMsgLevel( QStringLiteral( "%1 features read, crs: %2" ).arg( features.size() ).arg( featuresCrs.userFriendlyIdentifier() ), 2 );
           QgsCoordinateTransform coordinateTransform;
           if ( featuresCrs.isValid() && featuresCrs != crs() )
           {
@@ -3310,7 +3302,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
           {
             QgsFeature *feature = featIt.value();
 
-            QgsDebugMsg( QStringLiteral( "feature id = %1 : %2 attributes" ).arg( featIt.key() ).arg( feature->attributes().size() ) );
+            QgsDebugMsgLevel( QStringLiteral( "feature id = %1 : %2 attributes" ).arg( featIt.key() ).arg( feature->attributes().size() ), 2 );
 
             if ( coordinateTransform.isValid() && feature->hasGeometry() )
             {
@@ -3391,7 +3383,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
             const QJsonValue props = f.value( QLatin1String( "properties" ) );
             if ( !props.isObject() )
             {
-              QgsDebugMsg( QStringLiteral( "no properties found" ) );
+              QgsDebugMsgLevel( QStringLiteral( "no properties found" ), 2 );
               continue;
             }
 
@@ -3480,12 +3472,12 @@ void QgsWmsProvider::identifyReplyFinished()
     QVariant redirect = mIdentifyReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
     if ( !redirect.isNull() )
     {
-      QgsDebugMsg( QStringLiteral( "identify request redirected to %1" ).arg( redirect.toString() ) );
+      QgsDebugMsgLevel( QStringLiteral( "identify request redirected to %1" ).arg( redirect.toString() ), 2 );
       emit statusChanged( tr( "identify request redirected." ) );
 
       mIdentifyReply->deleteLater();
 
-      QgsDebugMsg( QStringLiteral( "redirected getfeatureinfo: %1" ).arg( redirect.toString() ) );
+      QgsDebugMsgLevel( QStringLiteral( "redirected getfeatureinfo: %1" ).arg( redirect.toString() ), 2 );
       mIdentifyReply = QgsNetworkAccessManager::instance()->get( QNetworkRequest( redirect.toUrl() ) );
       mSettings.authorization().setAuthorizationReply( mIdentifyReply );
       mIdentifyReply->setProperty( "eventLoop", QVariant::fromValue( qobject_cast<QObject *>( loop ) ) );
@@ -3513,7 +3505,7 @@ void QgsWmsProvider::identifyReplyFinished()
     else
     {
       // TODO: check headers, xsd ...
-      QgsDebugMsg( QStringLiteral( "%1 parts" ).arg( parser.parts() ) );
+      QgsDebugMsgLevel( QStringLiteral( "%1 parts" ).arg( parser.parts() ), 2 );
       mIdentifyResultBodies = parser.bodies();
       mIdentifyResultHeaders = parser.headers();
     }
@@ -3548,7 +3540,6 @@ QString QgsWmsProvider::lastErrorTitle()
 
 QString QgsWmsProvider::lastError()
 {
-  QgsDebugMsg( "returning '" + mError  + "'." );
   return mError;
 }
 
@@ -3679,18 +3670,18 @@ QUrl QgsWmsProvider::getLegendGraphicFullURL( double scale, const QgsRectangle &
 
   if ( lurl.isEmpty() )
   {
-    QgsDebugMsg( QStringLiteral( "getLegendGraphic url is empty" ) );
+    QgsDebugMsgLevel( QStringLiteral( "getLegendGraphic url is empty" ), 2 );
     return QUrl();
   }
 
-  QgsDebugMsg( QStringLiteral( "visibleExtent is %1" ).arg( visibleExtent.toString() ) );
+  QgsDebugMsgLevel( QStringLiteral( "visibleExtent is %1" ).arg( visibleExtent.toString() ), 2 );
 
   QUrl url( lurl );
   QUrlQuery query( url );
 
   if ( isUrlForWMTS( dataSourceUri() ) )
   {
-    QgsDebugMsg( QString( "getlegendgraphicrequest: %1" ).arg( url.toString() ) );
+    QgsDebugMsgLevel( QString( "getlegendgraphicrequest: %1" ).arg( url.toString() ), 2 );
     return url;
   }
 
@@ -3721,7 +3712,7 @@ QUrl QgsWmsProvider::getLegendGraphicFullURL( double scale, const QgsRectangle &
   // add config parameter related to resolution
   QgsSettings s;
   int defaultLegendGraphicResolution = s.value( QStringLiteral( "qgis/defaultLegendGraphicResolution" ), 0 ).toInt();
-  QgsDebugMsg( QStringLiteral( "defaultLegendGraphicResolution: %1" ).arg( defaultLegendGraphicResolution ) );
+  QgsDebugMsgLevel( QStringLiteral( "defaultLegendGraphicResolution: %1" ).arg( defaultLegendGraphicResolution ), 2 );
   if ( defaultLegendGraphicResolution )
   {
     if ( mSettings.mDpiMode & DpiQGIS )
@@ -3746,7 +3737,7 @@ QUrl QgsWmsProvider::getLegendGraphicFullURL( double scale, const QgsRectangle &
   }
   url.setQuery( query );
 
-  QgsDebugMsg( QStringLiteral( "getlegendgraphicrequest: %1" ).arg( url.toString() ) );
+  QgsDebugMsgLevel( QStringLiteral( "getlegendgraphicrequest: %1" ).arg( url.toString() ), 2 );
   return QUrl( url );
 }
 
@@ -3760,7 +3751,7 @@ QImage QgsWmsProvider::getLegendGraphic( double scale, bool forceRefresh, const 
 
   if ( lurl.isEmpty() )
   {
-    QgsDebugMsg( QStringLiteral( "getLegendGraphic url is empty" ) );
+    QgsDebugMsgLevel( QStringLiteral( "getLegendGraphic url is empty" ), 2 );
     return QImage();
   }
 
@@ -3793,8 +3784,6 @@ QImage QgsWmsProvider::getLegendGraphic( double scale, bool forceRefresh, const 
   mLegendGraphicFetcher->setProperty( "legendScale", QVariant::fromValue( scale ) );
   mLegendGraphicFetcher->setProperty( "legendExtent", QVariant::fromValue( mapExtent.toRectF() ) );
   loop.exec( QEventLoop::ExcludeUserInputEvents );
-
-  QgsDebugMsg( QStringLiteral( "exiting." ) );
 
   return mGetLegendGraphicImage;
 }
@@ -3837,7 +3826,7 @@ QgsImageFetcher *QgsWmsProvider::getLegendGraphicFetcher( const QgsMapSettings *
        scale == mGetLegendGraphicScale &&
        !mGetLegendGraphicImage.isNull() )
   {
-    QgsDebugMsg( QStringLiteral( "Emitting cached image fetcher" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Emitting cached image fetcher" ), 2 );
     // return a cached image, skipping the load
     return new QgsCachedImageFetcher( mGetLegendGraphicImage );
   }
@@ -3862,10 +3851,10 @@ void QgsWmsProvider::getLegendGraphicReplyFinished( const QImage &img )
     mGetLegendGraphicExtent = QgsRectangle( reply->property( "legendExtent" ).toRectF() );
     mGetLegendGraphicScale = reply->property( "legendScale" ).value<double>();
 
-#ifdef QGISDEBUG
+#if 0
     QString filename = QDir::tempPath() + "/GetLegendGraphic.png";
     mGetLegendGraphicImage.save( filename );
-    QgsDebugMsg( "saved GetLegendGraphic result in debug file: " + filename );
+    QgsDebugMsgLevel( "saved GetLegendGraphic result in debug file: " + filename, 2 );
 #endif
   }
 
@@ -3881,7 +3870,7 @@ void QgsWmsProvider::getLegendGraphicReplyFinished( const QImage &img )
 void QgsWmsProvider::getLegendGraphicReplyErrored( const QString &message )
 {
   Q_UNUSED( message )
-  QgsDebugMsg( QStringLiteral( "get legend failed: %1" ).arg( message ) );
+  QgsDebugMsgLevel( QStringLiteral( "get legend failed: %1" ).arg( message ), 2 );
 
   QObject *reply = sender();
 
@@ -3897,7 +3886,7 @@ void QgsWmsProvider::getLegendGraphicReplyErrored( const QString &message )
 void QgsWmsProvider::getLegendGraphicReplyProgress( qint64 bytesReceived, qint64 bytesTotal )
 {
   QString msg = tr( "%1 of %2 bytes of GetLegendGraphic downloaded." ).arg( bytesReceived ).arg( bytesTotal < 0 ? QStringLiteral( "unknown number of" ) : QString::number( bytesTotal ) );
-  QgsDebugMsg( msg );
+  QgsDebugMsgLevel( msg, 2 );
   emit statusChanged( msg );
 }
 
@@ -3967,7 +3956,7 @@ void QgsWmsImageDownloadHandler::cacheReplyFinished()
     {
       mCacheReply->deleteLater();
 
-      QgsDebugMsg( QStringLiteral( "redirected getmap: %1" ).arg( redirect.toString() ) );
+      QgsDebugMsgLevel( QStringLiteral( "redirected getmap: %1" ).arg( redirect.toString() ), 2 );
       mCacheReply = QgsNetworkAccessManager::instance()->get( QNetworkRequest( redirect.toUrl() ) );
       connect( mCacheReply, &QNetworkReply::finished, this, &QgsWmsImageDownloadHandler::cacheReplyFinished );
       return;
@@ -3991,7 +3980,7 @@ void QgsWmsImageDownloadHandler::cacheReplyFinished()
     }
 
     QString contentType = mCacheReply->header( QNetworkRequest::ContentTypeHeader ).toString();
-    QgsDebugMsg( "contentType: " + contentType );
+    QgsDebugMsgLevel( "contentType: " + contentType, 2 );
     QByteArray text = mCacheReply->readAll();
     QImage myLocalImage = QImage::fromData( text );
     if ( !myLocalImage.isNull() )
@@ -4064,16 +4053,16 @@ void QgsWmsImageDownloadHandler::cacheReplyProgress( qint64 bytesReceived, qint6
 {
   Q_UNUSED( bytesReceived )
   Q_UNUSED( bytesTotal )
-  QgsDebugMsg( QStringLiteral( "%1 of %2 bytes of map downloaded." ).arg( bytesReceived ).arg( bytesTotal < 0 ? QString( "unknown number of" ) : QString::number( bytesTotal ) ) );
+  QgsDebugMsgLevel( QStringLiteral( "%1 of %2 bytes of map downloaded." ).arg( bytesReceived ).arg( bytesTotal < 0 ? QString( "unknown number of" ) : QString::number( bytesTotal ) ), 2 );
 }
 
 void QgsWmsImageDownloadHandler::canceled()
 {
-  QgsDebugMsg( QStringLiteral( "Caught canceled() signal" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Caught canceled() signal" ), 2 );
   if ( mCacheReply )
   {
     // abort the reply if it is still active
-    QgsDebugMsg( QStringLiteral( "Aborting WMS network request" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Aborting WMS network request" ), 2 );
     mCacheReply->abort();
   }
 }
@@ -4219,7 +4208,7 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
       mReplies.removeOne( reply );
       reply->deleteLater();
 
-      QgsDebugMsg( QStringLiteral( "redirected gettile: %1" ).arg( redirect.toString() ) );
+      QgsDebugMsgLevel( QStringLiteral( "redirected gettile: %1" ).arg( redirect.toString() ), 2 );
       reply = QgsNetworkAccessManager::instance()->get( request );
       mReplies << reply;
 
@@ -4329,7 +4318,7 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
     }
     else
     {
-      QgsDebugMsg( QStringLiteral( "Reply too late [%1]" ).arg( reply->url().toString() ) );
+      QgsDebugMsgLevel( QStringLiteral( "Reply too late [%1]" ).arg( reply->url().toString() ), 2 );
     }
 
     mReplies.removeOne( reply );
@@ -4420,7 +4409,7 @@ void QgsWmsTiledImageDownloadHandler::repeatTileRequest( QNetworkRequest const &
     QgsMessageLog::logMessage( tr( "repeat tileRequest %1 tile %2(retry %3)" )
                                .arg( tileReqNo ).arg( tileNo ).arg( retry ), tr( "WMS" ), Qgis::Info );
   }
-  QgsDebugMsg( QStringLiteral( "repeat tileRequest %1 %2(retry %3) for url: %4" ).arg( tileReqNo ).arg( tileNo ).arg( retry ).arg( url ) );
+  QgsDebugMsgLevel( QStringLiteral( "repeat tileRequest %1 %2(retry %3) for url: %4" ).arg( tileReqNo ).arg( tileNo ).arg( retry ).arg( url ), 2 );
   request.setAttribute( static_cast<QNetworkRequest::Attribute>( TileRetry ), retry );
 
   QNetworkReply *reply = QgsNetworkAccessManager::instance()->get( request );
@@ -4477,23 +4466,19 @@ QgsWmsLegendDownloadHandler::~QgsWmsLegendDownloadHandler()
   if ( mReply )
   {
     // Send finished if not done yet ?
-    QgsDebugMsg( QStringLiteral( "WMSLegendDownloader destroyed while still processing reply" ) );
+    QgsDebugMsgLevel( QStringLiteral( "WMSLegendDownloader destroyed while still processing reply" ), 2 );
     mReply->deleteLater();
   }
   mReply = nullptr;
 }
 
-/* public */
-void
-QgsWmsLegendDownloadHandler::start()
+void QgsWmsLegendDownloadHandler::start()
 {
   Q_ASSERT( mVisitedUrls.empty() );
   startUrl( mInitialUrl );
 }
 
-/* private */
-void
-QgsWmsLegendDownloadHandler::startUrl( const QUrl &url )
+void QgsWmsLegendDownloadHandler::startUrl( const QUrl &url )
 {
   Q_ASSERT( !mReply );  // don't call me twice from outside !
   Q_ASSERT( url.isValid() );
@@ -4507,7 +4492,7 @@ QgsWmsLegendDownloadHandler::startUrl( const QUrl &url )
   }
   mVisitedUrls.insert( url );
 
-  QgsDebugMsg( QStringLiteral( "legend url: %1" ).arg( url.toString() ) );
+  QgsDebugMsgLevel( QStringLiteral( "legend url: %1" ).arg( url.toString() ), 2 );
 
   QNetworkRequest request( url );
   QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWmsLegendDownloadHandler" ) );
@@ -4522,28 +4507,25 @@ QgsWmsLegendDownloadHandler::startUrl( const QUrl &url )
   connect( mReply, &QNetworkReply::downloadProgress, this, &QgsWmsLegendDownloadHandler::progressed );
 }
 
-void
-QgsWmsLegendDownloadHandler::sendError( const QString &msg )
+void QgsWmsLegendDownloadHandler::sendError( const QString &msg )
 {
-  QgsDebugMsg( QStringLiteral( "emitting error: %1" ).arg( msg ) );
+  QgsDebugMsgLevel( QStringLiteral( "emitting error: %1" ).arg( msg ), 2 );
   Q_ASSERT( mReply );
   mReply->deleteLater();
   mReply = nullptr;
   emit error( msg );
 }
 
-void
-QgsWmsLegendDownloadHandler::sendSuccess( const QImage &img )
+void QgsWmsLegendDownloadHandler::sendSuccess( const QImage &img )
 {
-  QgsDebugMsg( QStringLiteral( "emitting finish: %1x%2 image" ).arg( img.width() ).arg( img.height() ) );
+  QgsDebugMsgLevel( QStringLiteral( "emitting finish: %1x%2 image" ).arg( img.width() ).arg( img.height() ), 2 );
   Q_ASSERT( mReply );
   mReply->deleteLater();
   mReply = nullptr;
   emit finish( img );
 }
 
-void
-QgsWmsLegendDownloadHandler::errored( QNetworkReply::NetworkError /* code */ )
+void QgsWmsLegendDownloadHandler::errored( QNetworkReply::NetworkError )
 {
   if ( !mReply )
     return;
@@ -4551,8 +4533,7 @@ QgsWmsLegendDownloadHandler::errored( QNetworkReply::NetworkError /* code */ )
   sendError( mReply->errorString() );
 }
 
-void
-QgsWmsLegendDownloadHandler::finished()
+void QgsWmsLegendDownloadHandler::finished()
 {
   if ( !mReply )
     return;
@@ -4560,7 +4541,7 @@ QgsWmsLegendDownloadHandler::finished()
   // or ::errored() should have been called before ::finished
   Q_ASSERT( mReply->error() == QNetworkReply::NoError );
 
-  QgsDebugMsg( QStringLiteral( "reply OK" ) );
+  QgsDebugMsgLevel( QStringLiteral( "reply OK" ), 2 );
   QVariant redirect = mReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
   if ( !redirect.isNull() )
   {
@@ -4593,8 +4574,7 @@ QgsWmsLegendDownloadHandler::finished()
   sendSuccess( myLocalImage );
 }
 
-void
-QgsWmsLegendDownloadHandler::progressed( qint64 recv, qint64 tot )
+void QgsWmsLegendDownloadHandler::progressed( qint64 recv, qint64 tot )
 {
   emit progress( recv, tot );
 }

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -416,6 +416,9 @@ class QgsWmsProvider final: public QgsRasterDataProvider
 
     std::unique_ptr<QgsImageFetcher> mLegendGraphicFetcher;
 
+    //! TRUE if an error was encountered while fetching a legend graphic
+    bool mLegendGraphicFetchErrored = false;
+
     /**
      * Visibility status of the given active sublayer
      */

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -152,7 +152,7 @@ QgsWMSSourceSelect::QgsWMSSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
 void QgsWMSSourceSelect::refresh()
 {
   // Reload WMS connections and update the GUI
-  QgsDebugMsg( QStringLiteral( "Refreshing WMS connections ..." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Refreshing WMS connections ..." ), 2 );
   populateConnectionList();
 }
 
@@ -337,7 +337,7 @@ bool QgsWMSSourceSelect::populateLayerList( const QgsWmsCapabilities &capabiliti
     // Layer Styles
     for ( const QgsWmsStyleProperty &property : layer.style )
     {
-      QgsDebugMsg( QStringLiteral( "got style name %1 and title '%2'." ).arg( property.name, property.title ) );
+      QgsDebugMsgLevel( QStringLiteral( "got style name %1 and title '%2'." ).arg( property.name, property.title ), 2 );
 
       QgsTreeWidgetItem *lItem2 = new QgsTreeWidgetItem( lItem );
       lItem2->setText( 0, QString::number( ++layerAndStyleCount ) );
@@ -585,7 +585,7 @@ void QgsWMSSourceSelect::addButtonClicked()
   uri.setParam( QStringLiteral( "styles" ), styles );
   uri.setParam( QStringLiteral( "format" ), format );
   uri.setParam( QStringLiteral( "crs" ), crs );
-  QgsDebugMsg( QStringLiteral( "crs=%2 " ).arg( crs ) );
+  QgsDebugMsgLevel( QStringLiteral( "crs=%2 " ).arg( crs ), 2 );
 
   if ( mFeatureCount->text().toInt() > 0 )
   {
@@ -901,7 +901,7 @@ void QgsWMSSourceSelect::lstTilesets_itemClicked( QTableWidgetItem *item )
   lstTilesets->clearSelection();
   if ( !wasSelected )
   {
-    QgsDebugMsg( QStringLiteral( "selecting current row %1" ).arg( lstTilesets->currentRow() ) );
+    QgsDebugMsgLevel( QStringLiteral( "selecting current row %1" ).arg( lstTilesets->currentRow() ), 2 );
     lstTilesets->selectRow( lstTilesets->currentRow() );
     mCurrentTileset = rowItem;
   }


### PR DESCRIPTION
This error indicates an issue on the server configuration and isn't
anything that a user can resolve. Showing it in the layer tree incorrectly
indicates that there's a problem with the layer rendering, which isn't
really true. Better to be more forgiving of misconfigured legend
services (there seems to be a lot!) and don't show this warning
right in the user's face...

