### PR TITLE
New QGIS Server setting environement to disable GetPrint and do not load layouts

### DIFF
--- a/python/server/auto_generated/qgsserversettings.sip.in
+++ b/python/server/auto_generated/qgsserversettings.sip.in
@@ -196,12 +196,13 @@ variable QGIS_SERVER_TRUST_LAYER_METADATA.
 .. versionadded:: 3.16
 %End
 
-    bool dontLoadLayouts() const;
+    bool getPrintDisabled() const;
 %Docstring
-Returns ``True`` if the reading flag don't load layouts is activated.
+Returns ``True`` if WMS GetPrint request is disabled and the project's
+reading flag DONT_LOAD_LAYOUTS is activated.
 
 The default value is ``False``, this value can be changed by setting the environment
-variable QGIS_SERVER_DONT_LOAD_LAYOUTS.
+variable QGIS_SERVER_DISABLE_GETPRINT.
 
 .. versionadded:: 3.16
 %End

--- a/python/server/auto_generated/qgsserversettings.sip.in
+++ b/python/server/auto_generated/qgsserversettings.sip.in
@@ -196,6 +196,16 @@ variable QGIS_SERVER_TRUST_LAYER_METADATA.
 .. versionadded:: 3.16
 %End
 
+    bool dontLoadLayouts() const;
+%Docstring
+Returns ``True`` if the reading flag don't load layouts is activated.
+
+The default value is ``False``, this value can be changed by setting the environment
+variable QGIS_SERVER_DONT_LOAD_LAYOUTS.
+
+.. versionadded:: 3.16
+%End
+
 };
 
 /************************************************************************

--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -57,7 +57,7 @@ const QgsProject *QgsConfigCache::project( const QString &path, QgsServerSetting
         readFlags |= QgsProject::ReadFlag::FlagTrustLayerMetadata;
       }
       // Activate don't load layouts flag
-      else if ( settings->dontLoadLayouts() )
+      if ( settings->getPrintDisabled() )
       {
         readFlags |= QgsProject::ReadFlag::FlagDontLoadLayouts;
       }

--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -49,7 +49,7 @@ const QgsProject *QgsConfigCache::project( const QString &path, QgsServerSetting
     prj->setBadLayerHandler( badLayerHandler );
 
     QgsProject::ReadFlags readFlags = QgsProject::ReadFlag();
-    if ( ! settings || ! settings->trustLayerMetadata() )
+    if ( settings && settings->trustLayerMetadata() )
     {
       readFlags |= QgsProject::ReadFlag::FlagTrustLayerMetadata;
     }

--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -49,9 +49,18 @@ const QgsProject *QgsConfigCache::project( const QString &path, QgsServerSetting
     prj->setBadLayerHandler( badLayerHandler );
 
     QgsProject::ReadFlags readFlags = QgsProject::ReadFlag();
-    if ( settings && settings->trustLayerMetadata() )
+    if ( settings )
     {
-      readFlags |= QgsProject::ReadFlag::FlagTrustLayerMetadata;
+      // Activate trust layer metadata flag
+      if ( settings->trustLayerMetadata() )
+      {
+        readFlags |= QgsProject::ReadFlag::FlagTrustLayerMetadata;
+      }
+      // Activate don't load layouts flag
+      else if ( settings->dontLoadLayouts() )
+      {
+        readFlags |= QgsProject::ReadFlag::FlagDontLoadLayouts;
+      }
     }
 
     if ( prj->read( path, readFlags ) )

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -174,6 +174,17 @@ void QgsServerSettings::initSettings()
                                       };
   mSettings[ sTrustLayerMetadata.envVar ] = sTrustLayerMetadata;
 
+  // don't load layouts
+  const Setting sDontLoadLayouts = { QgsServerSettingsEnv::QGIS_SERVER_DONT_LOAD_LAYOUTS,
+                                     QgsServerSettingsEnv::DEFAULT_VALUE,
+                                     QStringLiteral( "Don't load layouts" ),
+                                     QString(),
+                                     QVariant::Bool,
+                                     QVariant( false ),
+                                     QVariant()
+                                   };
+  mSettings[ sDontLoadLayouts.envVar ] = sDontLoadLayouts;
+
   // show group separator
   const Setting sShowGroupSeparator = { QgsServerSettingsEnv::QGIS_SERVER_SHOW_GROUP_SEPARATOR,
                                         QgsServerSettingsEnv::DEFAULT_VALUE,
@@ -449,4 +460,9 @@ bool QgsServerSettings::ignoreBadLayers() const
 bool QgsServerSettings::trustLayerMetadata() const
 {
   return value( QgsServerSettingsEnv::QGIS_SERVER_TRUST_LAYER_METADATA ).toBool();
+}
+
+bool QgsServerSettings::dontLoadLayouts() const
+{
+  return value( QgsServerSettingsEnv::QGIS_SERVER_DONT_LOAD_LAYOUTS ).toBool();
 }

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -175,7 +175,7 @@ void QgsServerSettings::initSettings()
   mSettings[ sTrustLayerMetadata.envVar ] = sTrustLayerMetadata;
 
   // don't load layouts
-  const Setting sDontLoadLayouts = { QgsServerSettingsEnv::QGIS_SERVER_DONT_LOAD_LAYOUTS,
+  const Setting sDontLoadLayouts = { QgsServerSettingsEnv::QGIS_SERVER_DISABLE_GETPRINT,
                                      QgsServerSettingsEnv::DEFAULT_VALUE,
                                      QStringLiteral( "Don't load layouts" ),
                                      QString(),
@@ -462,7 +462,7 @@ bool QgsServerSettings::trustLayerMetadata() const
   return value( QgsServerSettingsEnv::QGIS_SERVER_TRUST_LAYER_METADATA ).toBool();
 }
 
-bool QgsServerSettings::dontLoadLayouts() const
+bool QgsServerSettings::getPrintDisabled() const
 {
-  return value( QgsServerSettingsEnv::QGIS_SERVER_DONT_LOAD_LAYOUTS ).toBool();
+  return value( QgsServerSettingsEnv::QGIS_SERVER_DISABLE_GETPRINT ).toBool();
 }

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -68,8 +68,8 @@ class SERVER_EXPORT QgsServerSettingsEnv : public QObject
       QGIS_SERVER_WMS_MAX_WIDTH, //!< Maximum width for a WMS request. The most conservative between this and the project one is used (since QGIS 3.6.2)
       QGIS_SERVER_API_RESOURCES_DIRECTORY, //!< Base directory where HTML templates and static assets (e.g. images, js and css files) are searched for (since QGIS 3.10).
       QGIS_SERVER_API_WFS3_MAX_LIMIT, //!< Maximum value for "limit" in a features request, defaults to 10000 (since QGIS 3.10).
-      QGIS_SERVER_TRUST_LAYER_METADATA, //!< Trust layer metadata (since QGIS 3.16).
-      QGIS_SERVER_DONT_LOAD_LAYOUTS //!< Don't load layouts, this deactivated GetPrint capabilities (since QGIS 3.16).
+      QGIS_SERVER_TRUST_LAYER_METADATA, //!< Trust layer metadata. Improves project read time. (since QGIS 3.16).
+      QGIS_SERVER_DISABLE_GETPRINT //!< Disabled WMS GetPrint request and don't load layouts. Improves project read time. (since QGIS 3.16).
     };
     Q_ENUM( EnvVar )
 };
@@ -247,14 +247,15 @@ class SERVER_EXPORT QgsServerSettings
     bool trustLayerMetadata() const;
 
     /**
-     * Returns TRUE if the reading flag don't load layouts is activated.
+     * Returns TRUE if WMS GetPrint request is disabled and the project's
+     * reading flag DONT_LOAD_LAYOUTS is activated.
      *
      * The default value is FALSE, this value can be changed by setting the environment
-     * variable QGIS_SERVER_DONT_LOAD_LAYOUTS.
+     * variable QGIS_SERVER_DISABLE_GETPRINT.
      *
      * \since QGIS 3.16
      */
-    bool dontLoadLayouts() const;
+    bool getPrintDisabled() const;
 
   private:
     void initSettings();

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -68,7 +68,8 @@ class SERVER_EXPORT QgsServerSettingsEnv : public QObject
       QGIS_SERVER_WMS_MAX_WIDTH, //!< Maximum width for a WMS request. The most conservative between this and the project one is used (since QGIS 3.6.2)
       QGIS_SERVER_API_RESOURCES_DIRECTORY, //!< Base directory where HTML templates and static assets (e.g. images, js and css files) are searched for (since QGIS 3.10).
       QGIS_SERVER_API_WFS3_MAX_LIMIT, //!< Maximum value for "limit" in a features request, defaults to 10000 (since QGIS 3.10).
-      QGIS_SERVER_TRUST_LAYER_METADATA //!< Trust layer metadata (since QGIS 3.16).
+      QGIS_SERVER_TRUST_LAYER_METADATA, //!< Trust layer metadata (since QGIS 3.16).
+      QGIS_SERVER_DONT_LOAD_LAYOUTS //!< Don't load layouts, this deactivated GetPrint capabilities (since QGIS 3.16).
     };
     Q_ENUM( EnvVar )
 };
@@ -244,6 +245,16 @@ class SERVER_EXPORT QgsServerSettings
      * \since QGIS 3.16
      */
     bool trustLayerMetadata() const;
+
+    /**
+     * Returns TRUE if the reading flag don't load layouts is activated.
+     *
+     * The default value is FALSE, this value can be changed by setting the environment
+     * variable QGIS_SERVER_DONT_LOAD_LAYOUTS.
+     *
+     * \since QGIS 3.16
+     */
+    bool dontLoadLayouts() const;
 
   private:
     void initSettings();

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -143,6 +143,13 @@ namespace QgsWms
         }
         else if ( QSTR_COMPARE( req, "GetPrint" ) )
         {
+          if ( mServerIface->serverSettings() && mServerIface->serverSettings()->getPrintDisabled() )
+          {
+            // GetPrint has been disabled
+            QgsDebugMsg( QStringLiteral( "WMS GetPrint request called, but it has been disabled." ) );
+            throw QgsServiceException( QgsServiceException::OGC_OperationNotSupported,
+                                       QStringLiteral( "Request %1 is not supported" ).arg( req ), 501 );
+          }
           writeGetPrint( mServerIface, project, version, request, response );
         }
         else

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -230,7 +230,7 @@ namespace QgsWms
     wmsCapabilitiesElement.appendChild( getServiceElement( doc, project, version, request ) );
 
     //wms:Capability element
-    QDomElement capabilityElement = getCapabilityElement( doc, project, version, request, projectSettings );
+    QDomElement capabilityElement = getCapabilityElement( doc, project, version, request, projectSettings, serverIface );
     wmsCapabilitiesElement.appendChild( capabilityElement );
 
     if ( projectSettings )
@@ -431,7 +431,7 @@ namespace QgsWms
 
   QDomElement getCapabilityElement( QDomDocument &doc, const QgsProject *project,
                                     const QString &version, const QgsServerRequest &request,
-                                    bool projectSettings )
+                                    bool projectSettings, QgsServerInterface *serverIface )
   {
     QgsServerRequest::Parameters parameters = request.parameters();
 
@@ -534,7 +534,8 @@ namespace QgsWms
     elem.appendChild( dcpTypeElem.cloneNode().toElement() ); //this is the same as for 'GetCapabilities'
     requestElem.appendChild( elem );
 
-    if ( projectSettings ) //remove composer templates from GetCapabilities in the long term
+    if ( ( !serverIface->serverSettings() || !serverIface->serverSettings()->getPrintDisabled() ) &&
+         projectSettings ) //remove composer templates from GetCapabilities in the long term
     {
       //wms:GetPrint
       elem = doc.createElement( QStringLiteral( "GetPrint" ) /*wms:GetPrint*/ );

--- a/src/server/services/wms/qgswmsgetcapabilities.h
+++ b/src/server/services/wms/qgswmsgetcapabilities.h
@@ -55,7 +55,8 @@ namespace QgsWms
    * Create Capability element for get capabilities document
    */
   QDomElement getCapabilityElement( QDomDocument &doc, const QgsProject *project, const QString &version,
-                                    const QgsServerRequest &request, bool projectSettings );
+                                    const QgsServerRequest &request, bool projectSettings,
+                                    QgsServerInterface *serverIface );
 
   /**
    * Create Service element for get capabilities document

--- a/tests/src/python/test_qgsserver_settings.py
+++ b/tests/src/python/test_qgsserver_settings.py
@@ -146,6 +146,21 @@ class TestQgsServerSettings(unittest.TestCase):
         self.assertFalse(self.settings.trustLayerMetadata())
         os.environ.pop(env)
 
+    def test_env_dont_load_layouts(self):
+        env = "QGIS_SERVER_DONT_LOAD_LAYOUTS"
+
+        self.assertFalse(self.settings.dontLoadLayouts())
+
+        os.environ[env] = "1"
+        self.settings.load()
+        self.assertTrue(self.settings.dontLoadLayouts())
+        os.environ.pop(env)
+
+        os.environ[env] = "0"
+        self.settings.load()
+        self.assertFalse(self.settings.dontLoadLayouts())
+        os.environ.pop(env)
+
     def test_priority(self):
         env = "QGIS_OPTIONS_PATH"
         dpath = "conf0"

--- a/tests/src/python/test_qgsserver_settings.py
+++ b/tests/src/python/test_qgsserver_settings.py
@@ -147,18 +147,18 @@ class TestQgsServerSettings(unittest.TestCase):
         os.environ.pop(env)
 
     def test_env_dont_load_layouts(self):
-        env = "QGIS_SERVER_DONT_LOAD_LAYOUTS"
+        env = "QGIS_SERVER_DISABLE_GETPRINT"
 
-        self.assertFalse(self.settings.dontLoadLayouts())
+        self.assertFalse(self.settings.getPrintDisabled())
 
         os.environ[env] = "1"
         self.settings.load()
-        self.assertTrue(self.settings.dontLoadLayouts())
+        self.assertTrue(self.settings.getPrintDisabled())
         os.environ.pop(env)
 
         os.environ[env] = "0"
         self.settings.load()
-        self.assertFalse(self.settings.dontLoadLayouts())
+        self.assertFalse(self.settings.getPrintDisabled())
         os.environ.pop(env)
 
     def test_priority(self):


### PR DESCRIPTION
## Description

Defined a new QGIS Server setting environnement `QGIS_SERVER_DISABLE_GETPRINT` to do not load layouts when QGIS Server reads projects and disable WMS GetPrint request.

This improves projects read time.

Funded by [Ifremer](https://wwz.ifremer.fr/)