### PR TITLE
fix transform Polygon to CurvePolygon when splitting

### DIFF
--- a/src/core/qgsvectorlayereditutils.cpp
+++ b/src/core/qgsvectorlayereditutils.cpp
@@ -313,6 +313,9 @@ QgsGeometry::OperationResult QgsVectorLayerEditUtils::splitFeatures( const QgsCu
   QgsFeatureIterator features;
   const QgsFeatureIds selectedIds = mLayer->selectedFeatureIds();
 
+  // deactivate preserving circular if the curve contains only straight segments to avoid transforming Polygon to CurvePolygon
+  preserveCircular &= curve->hasCurvedSegments();
+
   if ( !selectedIds.isEmpty() ) //consider only the selected features if there is a selection
   {
     features = mLayer->getSelectedFeatures();


### PR DESCRIPTION
When splitting with curve, resulting split features are transform to CurvePolygon to preserving curved element.
This PR deactivates this preserving when the curve does not contained curved element, so there is no transform to CurvePolygon if there are only straight segments.
