### PR TITLE
Adjust width of relation reference config widget

### DIFF
--- a/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
@@ -29,7 +29,11 @@
     </widget>
    </item>
    <item row="1" column="1">
-    <widget class="QComboBox" name="mComboRelation"/>
+    <widget class="QComboBox" name="mComboRelation">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
    </item>
    <item row="2" column="0" colspan="2">
     <widget class="QCheckBox" name="mCbxAllowNull">


### PR DESCRIPTION
Reduce minimum width of the combobox.
This has bugged me for ages. The widget configuration taking more horizontal space than required.

# Before (horizontal scroll bar visible)

![image](https://user-images.githubusercontent.com/588407/90314830-f7ecfe80-df16-11ea-83fb-ebda9eca6c0c.png)


# After (no horizontal scroll bar)

![image](https://user-images.githubusercontent.com/588407/90314835-02a79380-df17-11ea-88e9-05d501ef4a22.png)
