### PR TITLE
Relation reference: Update user interface when adding new entry

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -1001,7 +1001,7 @@ void QgsRelationReferenceWidget::entryAdded( const QgsFeature &feat )
     for ( const QString &fieldName : qgis::as_const( mReferencedFields ) )
       attrs << f.attribute( fieldName );
 
-    mComboBox->setIdentifierValues( attrs );
+    setForeignKeys( attrs );
 
     mAddEntryButton->setEnabled( false );
   }


### PR DESCRIPTION
Fixes #38303

Use the proper internal setter method when adding a new entry in the relation reference widget.
Besides the directly visible fix of #38303 it will also update embedded form and make sure all signals are emitted as expected.