### PR TITLE
Various UX fixes

### DIFF
--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -51,7 +51,7 @@ from processing.gui.AlgorithmLocatorFilter import (AlgorithmLocatorFilter,
                                                    InPlaceAlgorithmLocatorFilter)
 from processing.modeler.ModelerDialog import ModelerDialog
 from processing.tools.system import tempHelpFolder
-from processing.gui.menus import removeMenus, initializeMenus, createMenus
+from processing.gui.menus import removeMenus, initializeMenus, createMenus, createButtons, removeButtons
 from processing.core.ProcessingResults import resultsList
 
 pluginPath = os.path.dirname(__file__)
@@ -271,6 +271,7 @@ class ProcessingPlugin:
 
         initializeMenus()
         createMenus()
+        createButtons()
 
         # In-place editing button state sync
         self.iface.currentLayerChanged.connect(self.sync_in_place_button_state)
@@ -322,6 +323,7 @@ class ProcessingPlugin:
         self.iface.unregisterCustomDropHandler(self.drop_handler)
         QgsApplication.dataItemProviderRegistry().removeProvider(self.item_provider)
 
+        removeButtons()
         removeMenus()
         Processing.deinitialize()
 

--- a/python/plugins/processing/gui/menus.py
+++ b/python/plugins/processing/gui/menus.py
@@ -291,8 +291,7 @@ def findAction(actions, alg):
 def addToolBarButton(algId, toolbar, icon=None, tooltip=None):
     alg = QgsApplication.processingRegistry().algorithmById(algId)
     if alg is None or alg.id() != algId:
-        QgsMessageLog.logMessage(Processing.tr('Invalid algorithm ID for button: {}').format(algId), Processing.tr('Processing'))
-        return
+        assert False, algId
 
     if tooltip is None:
         if (QgsGui.higFlags() & QgsGui.HigMenuTextIsTitleCase) and not (alg.flags() & QgsProcessingAlgorithm.FlagDisplayNameIsLiteral):

--- a/python/plugins/processing/gui/menus.py
+++ b/python/plugins/processing/gui/menus.py
@@ -42,7 +42,7 @@ algorithmsToolbar = None
 menusSettingsGroup = 'Menus'
 
 defaultMenuEntries = {}
-vectorMenu = QApplication.translate('MainWindow', 'Vect&or')
+vectorMenu = iface.vectorMenu().title()
 analysisToolsMenu = vectorMenu + "/" + Processing.tr('&Analysis Tools')
 defaultMenuEntries.update({'qgis:distancematrix': analysisToolsMenu,
                            'native:sumlinelengths': analysisToolsMenu,
@@ -64,7 +64,6 @@ defaultMenuEntries.update({'native:creategrid': researchToolsMenu,
                            'qgis:regularpoints': researchToolsMenu,
                            'native:selectbylocation': researchToolsMenu,
                            'native:polygonfromlayerextent': researchToolsMenu})
-
 geoprocessingToolsMenu = vectorMenu + "/" + Processing.tr('&Geoprocessing Tools')
 defaultMenuEntries.update({'native:buffer': geoprocessingToolsMenu,
                            'native:convexhull': geoprocessingToolsMenu,
@@ -95,7 +94,7 @@ defaultMenuEntries.update({'native:reprojectlayer': managementToolsMenu,
                            'native:mergevectorlayers': managementToolsMenu,
                            'native:createspatialindex': managementToolsMenu})
 
-rasterMenu = QApplication.translate('MainWindow', '&Raster')
+rasterMenu = iface.rasterMenu().title()
 projectionsMenu = rasterMenu + "/" + Processing.tr('Projections')
 defaultMenuEntries.update({'gdal:warpreproject': projectionsMenu,
                            'gdal:extractprojection': projectionsMenu,

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1285,7 +1285,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
 
   mLogDock = new QgsDockWidget( tr( "Log Messages" ), this );
   mLogDock->setObjectName( QStringLiteral( "MessageLog" ) );
-  mLogDock->setAllowedAreas( Qt::BottomDockWidgetArea | Qt::TopDockWidgetArea );
+  mLogDock->setAllowedAreas( Qt::AllDockWidgetAreas );
   addDockWidget( Qt::BottomDockWidgetArea, mLogDock );
   mLogDock->setWidget( mLogViewer );
   mLogDock->hide();

--- a/src/gui/vector/qgsfieldcalculator.cpp
+++ b/src/gui/vector/qgsfieldcalculator.cpp
@@ -349,6 +349,8 @@ void QgsFieldCalculator::populateOutputFieldTypes()
     return;
   }
 
+  int oldDataType = mOutputFieldTypeComboBox->currentData( Qt::UserRole + FTC_TYPE_ROLE_IDX ).toInt();
+
   mOutputFieldTypeComboBox->blockSignals( true );
 
   // Standard subset of fields in case of virtual
@@ -382,8 +384,18 @@ void QgsFieldCalculator::populateOutputFieldTypes()
     mOutputFieldTypeComboBox->setItemData( i, static_cast<int>( typelist[i].mSubType ), Qt::UserRole + FTC_SUBTYPE_IDX );
   }
   mOutputFieldTypeComboBox->blockSignals( false );
-  mOutputFieldTypeComboBox->setCurrentIndex( 0 );
-  mOutputFieldTypeComboBox_activated( 0 );
+
+  int idx = mOutputFieldTypeComboBox->findData( oldDataType, Qt::UserRole + FTC_TYPE_ROLE_IDX );
+  if ( idx != -1 )
+  {
+    mOutputFieldTypeComboBox->setCurrentIndex( idx );
+    mOutputFieldTypeComboBox_activated( idx );
+  }
+  else
+  {
+    mOutputFieldTypeComboBox->setCurrentIndex( 0 );
+    mOutputFieldTypeComboBox_activated( 0 );
+  }
 }
 
 void QgsFieldCalculator::mNewFieldGroupBox_toggled( bool on )

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -345,6 +345,15 @@
      <addaction name="mActionRegularPolygonCenterCorner"/>
      <addaction name="mActionRegularPolygon2Points"/>
     </widget>
+    <widget class="QMenu" name="mMenuAnnotation">
+     <property name="title">
+      <string>Add Annotation</string>
+     </property>
+     <addaction name="mActionTextAnnotation"/>
+     <addaction name="mActionFormAnnotation"/>
+     <addaction name="mActionHtmlAnnotation"/>
+     <addaction name="mActionSvgAnnotation"/>
+    </widget>
     <addaction name="mActionUndo"/>
     <addaction name="mActionRedo"/>
     <addaction name="separator"/>
@@ -361,6 +370,7 @@
     <addaction name="mMenuRectangle"/>
     <addaction name="mMenuRegularPolygon"/>
     <addaction name="mMenuEllipse"/>
+    <addaction name="mMenuAnnotation"/>
     <addaction name="mActionMoveFeature"/>
     <addaction name="mActionMoveFeatureCopy"/>
     <addaction name="mActionDeleteSelected"/>

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -540,6 +540,7 @@
    <addaction name="mActionZoomLast"/>
    <addaction name="mActionZoomNext"/>
    <addaction name="mActionNewMapCanvas"/>
+   <addaction name="mActionNew3DMapCanvas"/>
    <addaction name="mActionNewBookmark"/>
    <addaction name="mActionShowBookmarks"/>
    <addaction name="mActionTemporalController"/>


### PR DESCRIPTION
## Description
Fix some UX issues:

- in Processing get Vector and Raster menu names from the QGIS main window instead using hardcoded values (fix #35028 and #28474)
- allow docking Message Log to the left and right areas to help users with smal screens preserve some vertical space (fix #29463)
- add annotation actions to the Edit menu. These actions were accessible only from toolbar which is not consistent with the rest of tools (fix #27748)
- add 3D map view button to the Map Navigation toolbar (fix #25440)
- add Select By Location button to the Selection toolbar (fix #20350)
- keep selected data type when toggling "Create virtual field" checkbox in the field calculator to avoid loosing user settings (fix #36679)