### PR TITLE
Change placement mode selection widget from radio buttons to combobox, rework UI

### DIFF
--- a/python/gui/auto_generated/qgstextformatwidget.sip.in
+++ b/python/gui/auto_generated/qgstextformatwidget.sip.in
@@ -155,6 +155,15 @@ Controls whether data defined alignment buttons are enabled.
     virtual QgsExpressionContext createExpressionContext() const;
 
 
+    QgsWkbTypes::GeometryType labelGeometryType() const;
+%Docstring
+Returns the geometry type which will be used by the labeling engine
+when registering labels for the labeling settings currently defined by the widget.
+
+.. versionadded:: 3.16
+%End
+
+
 
 
 

--- a/src/gui/labeling/qgslabelinggui.cpp
+++ b/src/gui/labeling/qgslabelinggui.cpp
@@ -320,6 +320,8 @@ void QgsLabelingGui::setLayer( QgsMapLayer *mapLayer )
 
   mGeometryGenerator->setText( mSettings.geometryGenerator );
   mGeometryGeneratorGroupBox->setChecked( mSettings.geometryGeneratorEnabled );
+  if ( !mSettings.geometryGeneratorEnabled )
+    mGeometryGeneratorGroupBox->setCollapsed( true );
   mGeometryGeneratorType->setCurrentIndex( mGeometryGeneratorType->findData( mSettings.geometryGeneratorType ) );
 
   updateWidgetForFormat( mSettings.format() );

--- a/src/gui/labeling/qgslabelinggui.h
+++ b/src/gui/labeling/qgslabelinggui.h
@@ -85,7 +85,6 @@ class GUI_EXPORT QgsLabelingGui : public QgsTextFormatWidget
 
   private:
 
-    QgsWkbTypes::GeometryType mGeomType = QgsWkbTypes::UnknownGeometry;
     QgsPalLayerSettings mSettings;
     LabelMode mMode;
     QgsFeature mPreviewFeature;

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -1408,7 +1408,7 @@ void QgsTextFormatWidget::updatePlacementWidgets()
         helperText = tr( "Label candidates are placed outside of the features, preferring placements which give greatest visual association between the label and the feature." );
       break;
   }
-  mPlacementModeDescriptionLabel->setText( helperText );
+  mPlacementModeDescriptionLabel->setText( QStringLiteral( "<i>%1</i>" ).arg( helperText ) );
 }
 
 void QgsTextFormatWidget::populateFontCapitalsComboBox()

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -1358,6 +1358,57 @@ void QgsTextFormatWidget::updatePlacementWidgets()
   mPlacementMaxCharAngleFrame->setVisible( showMaxCharAngleFrame );
 
   mMultiLinesFrame->setEnabled( enableMultiLinesFrame );
+
+
+  QString helperText;
+  switch ( currentPlacement )
+  {
+    case QgsPalLayerSettings::AroundPoint:
+      if ( currentGeometryType == QgsWkbTypes::PointGeometry )
+        helperText = tr( "Arranges label candidates in a clockwise circle around the feature, preferring placements to the top-right of the feature." );
+      else if ( currentGeometryType == QgsWkbTypes::PolygonGeometry )
+        helperText = tr( "Arranges label candidates in a cluster around the feature's centroid, preferring placements directly over the centroid." );
+      break;
+    case QgsPalLayerSettings::OverPoint:
+      if ( currentGeometryType == QgsWkbTypes::PointGeometry )
+        helperText = tr( "Arranges label candidates directly over the feature or at a preset offset from the feature." );
+      else if ( currentGeometryType == QgsWkbTypes::PolygonGeometry )
+        helperText = tr( "Arranges label candidates directly over the feature's centroid, or at a preset offset from the centroid." );
+      break;
+    case QgsPalLayerSettings::Line:
+      if ( currentGeometryType == QgsWkbTypes::LineGeometry )
+        helperText = tr( "Arranges label candidates parallel to a generalised line representing the feature. Placements which fall over straighter portions of the line are preferred." );
+      else if ( currentGeometryType == QgsWkbTypes::PolygonGeometry )
+        helperText = tr( "Arranges label candidates parallel to a generalised line representing the polygon's perimeter. Placements which fall over straighter portions of the perimeter are preferred." );
+      break;
+    case QgsPalLayerSettings::Curved:
+      if ( currentGeometryType == QgsWkbTypes::LineGeometry )
+        helperText = tr( "Arranges candidates following the curvature of a line feature. Placements which fall over straighter portions of the line are preferred." );
+      break;
+    case QgsPalLayerSettings::Horizontal:
+      if ( currentGeometryType == QgsWkbTypes::PolygonGeometry )
+        helperText = tr( "Arranges label candidates scattered throughout the polygon. Labels will always be placed horizontally, with placements further from the edges of the polygon preferred." );
+      else if ( currentGeometryType == QgsWkbTypes::LineGeometry )
+        helperText = tr( "Label candidates are arranged horizontally along the length of the feature." );
+      break;
+    case QgsPalLayerSettings::Free:
+      if ( currentGeometryType == QgsWkbTypes::PolygonGeometry )
+        helperText = tr( "Arranges label candidates scattered throughout the polygon. Labels are rotated to respect the polygon's orientation, with placements further from the edges of the polygon preferred." );
+      break;
+    case QgsPalLayerSettings::OrderedPositionsAroundPoint:
+      if ( currentGeometryType == QgsWkbTypes::PointGeometry )
+        helperText = tr( "Label candidates are placed in predefined positions around the features. Preference is given to positions with greatest cartographic appeal, e.g., top right and bottom right of the feature." );
+      break;
+    case QgsPalLayerSettings::PerimeterCurved:
+      if ( currentGeometryType == QgsWkbTypes::PolygonGeometry )
+        helperText = tr( "Arranges candidates following the curvature of the feature's perimeter. Placements which fall over straighter portions of the perimeter are preferred." );
+      break;
+    case QgsPalLayerSettings::OutsidePolygons:
+      if ( currentGeometryType == QgsWkbTypes::PolygonGeometry )
+        helperText = tr( "Label candidates are placed outside of the features, preferring placements which give greatest visual association between the label and the feature." );
+      break;
+  }
+  mPlacementModeDescriptionLabel->setText( helperText );
 }
 
 void QgsTextFormatWidget::populateFontCapitalsComboBox()

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -1353,7 +1353,7 @@ void QgsTextFormatWidget::updatePlacementWidgets()
   mPlacementRotationFrame->setVisible( showRotationFrame );
   mPlacementRepeatDistanceFrame->setVisible( currentGeometryType == QgsWkbTypes::LineGeometry || ( currentGeometryType == QgsWkbTypes::PolygonGeometry &&
       ( currentPlacement == QgsPalLayerSettings::Line || currentPlacement == QgsPalLayerSettings::PerimeterCurved ) ) );
-  mPlacementOverrunDistanceFrame->setVisible( currentGeometryType == QgsWkbTypes::LineGeometry );
+  mPlacementOverrunDistanceFrame->setVisible( currentGeometryType == QgsWkbTypes::LineGeometry && currentPlacement != QgsPalLayerSettings::Horizontal );
   mLineAnchorGroupBox->setVisible( currentGeometryType == QgsWkbTypes::LineGeometry );
   mPlacementMaxCharAngleFrame->setVisible( showMaxCharAngleFrame );
 

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -65,6 +65,9 @@ QgsTextFormatWidget::QgsTextFormatWidget( QgsMapCanvas *mapCanvas, QWidget *pare
 void QgsTextFormatWidget::initWidget()
 {
   setupUi( this );
+
+  mGeometryGeneratorGroupBox->setCollapsed( true );
+
   connect( mShapeSVGPathLineEdit, &QLineEdit::textChanged, this, &QgsTextFormatWidget::mShapeSVGPathLineEdit_textChanged );
   connect( mFontSizeSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsTextFormatWidget::mFontSizeSpinBox_valueChanged );
   connect( mFontCapitalsComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsTextFormatWidget::mFontCapitalsComboBox_currentIndexChanged );

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -1351,9 +1351,9 @@ void QgsTextFormatWidget::updatePlacementWidgets()
   mPlacementDistanceFrame->setVisible( showDistanceFrame );
   mPlacementOffsetTypeFrame->setVisible( showOffsetTypeFrame );
   mPlacementRotationFrame->setVisible( showRotationFrame );
-  mPlacementRepeatDistanceFrame->setVisible( currentGeometryType == QgsWkbTypes::LineGeometry || ( currentGeometryType == QgsWkbTypes::PolygonGeometry &&
-      ( currentPlacement == QgsPalLayerSettings::Line || currentPlacement == QgsPalLayerSettings::PerimeterCurved ) ) );
-  mPlacementOverrunDistanceFrame->setVisible( currentGeometryType == QgsWkbTypes::LineGeometry && currentPlacement != QgsPalLayerSettings::Horizontal );
+  mPlacementRepeatGroupBox->setVisible( currentGeometryType == QgsWkbTypes::LineGeometry || ( currentGeometryType == QgsWkbTypes::PolygonGeometry &&
+                                        ( currentPlacement == QgsPalLayerSettings::Line || currentPlacement == QgsPalLayerSettings::PerimeterCurved ) ) );
+  mPlacementOverrunGroupBox->setVisible( currentGeometryType == QgsWkbTypes::LineGeometry && currentPlacement != QgsPalLayerSettings::Horizontal );
   mLineAnchorGroupBox->setVisible( currentGeometryType == QgsWkbTypes::LineGeometry );
   mPlacementMaxCharAngleFrame->setVisible( showMaxCharAngleFrame );
 

--- a/src/gui/qgstextformatwidget.h
+++ b/src/gui/qgstextformatwidget.h
@@ -161,6 +161,14 @@ class GUI_EXPORT QgsTextFormatWidget : public QWidget, public QgsExpressionConte
 
     QgsExpressionContext createExpressionContext() const override;
 
+    /**
+     * Returns the geometry type which will be used by the labeling engine
+     * when registering labels for the labeling settings currently defined by the widget.
+     *
+     * \since QGIS 3.16
+     */
+    QgsWkbTypes::GeometryType labelGeometryType() const;
+
     //! Text substitution list
     QgsStringReplacementCollection mSubstitutions;
     //! Quadrant button group
@@ -169,12 +177,6 @@ class GUI_EXPORT QgsTextFormatWidget : public QWidget, public QgsExpressionConte
     QButtonGroup *mDirectSymbBtnGrp = nullptr;
     //! Upside down labels button group
     QButtonGroup *mUpsidedownBtnGrp = nullptr;
-    //! Point placement button group
-    QButtonGroup *mPlacePointBtnGrp = nullptr;
-    //! Line placement button group
-    QButtonGroup *mPlaceLineBtnGrp = nullptr;
-    //! Polygon placement button group
-    QButtonGroup *mPlacePolygonBtnGrp = nullptr;
     //! Pixel size font limit
     int mMinPixelLimit = 0;
 
@@ -191,6 +193,9 @@ class GUI_EXPORT QgsTextFormatWidget : public QWidget, public QgsExpressionConte
     QgsVectorLayer *mLayer = nullptr;
 
     QgsSymbolLayerReferenceList mMaskedSymbolLayers;
+
+    //! Geometry type for layer, if known
+    QgsWkbTypes::GeometryType mGeomType = QgsWkbTypes::UnknownGeometry;
 
   protected slots:
 

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -4126,9 +4126,9 @@ font-style: italic;</string>
                      <property name="geometry">
                       <rect>
                        <x>0</x>
-                       <y>-601</y>
+                       <y>0</y>
                        <width>471</width>
-                       <height>1459</height>
+                       <height>1352</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -4145,254 +4145,21 @@ font-style: italic;</string>
                        <number>0</number>
                       </property>
                       <item>
-                       <widget class="QFrame" name="mPlacementTypeFrame">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
+                       <layout class="QHBoxLayout" name="horizontalLayout_14" stretch="0,1">
+                        <property name="topMargin">
+                         <number>0</number>
                         </property>
-                        <property name="frameShape">
-                         <enum>QFrame::NoFrame</enum>
-                        </property>
-                        <property name="frameShadow">
-                         <enum>QFrame::Sunken</enum>
-                        </property>
-                        <layout class="QVBoxLayout" name="verticalLayout_9">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
-                         <item>
-                          <widget class="QStackedWidget" name="stackedPlacement">
-                           <property name="frameShape">
-                            <enum>QFrame::NoFrame</enum>
-                           </property>
-                           <property name="frameShadow">
-                            <enum>QFrame::Sunken</enum>
-                           </property>
-                           <property name="currentIndex">
-                            <number>2</number>
-                           </property>
-                           <widget class="QWidget" name="pagePoint">
-                            <layout class="QGridLayout" name="gridLayout_13" columnstretch="0,0,0,0">
-                             <property name="leftMargin">
-                              <number>0</number>
-                             </property>
-                             <property name="topMargin">
-                              <number>0</number>
-                             </property>
-                             <property name="rightMargin">
-                              <number>0</number>
-                             </property>
-                             <property name="bottomMargin">
-                              <number>0</number>
-                             </property>
-                             <item row="0" column="1">
-                              <widget class="QRadioButton" name="radAroundPoint">
-                               <property name="toolTip">
-                                <string>Labels are placed in an equal radius circle around point features.</string>
-                               </property>
-                               <property name="text">
-                                <string>Around point</string>
-                               </property>
-                               <property name="checked">
-                                <bool>true</bool>
-                               </property>
-                              </widget>
-                             </item>
-                             <item row="0" column="2">
-                              <widget class="QRadioButton" name="radOverPoint">
-                               <property name="toolTip">
-                                <string>Labels are placed at a fixed offset from the point.</string>
-                               </property>
-                               <property name="text">
-                                <string>Offset from point</string>
-                               </property>
-                              </widget>
-                             </item>
-                             <item row="0" column="0">
-                              <widget class="QRadioButton" name="radPredefinedOrder">
-                               <property name="toolTip">
-                                <string>Uses 'ideal' cartographic placements, prioritizing label placement with best visual relationship with the point feature</string>
-                               </property>
-                               <property name="text">
-                                <string>Cartographic</string>
-                               </property>
-                              </widget>
-                             </item>
-                             <item row="0" column="3">
-                              <spacer name="horizontalSpacer_25">
-                               <property name="orientation">
-                                <enum>Qt::Horizontal</enum>
-                               </property>
-                               <property name="sizeHint" stdset="0">
-                                <size>
-                                 <width>40</width>
-                                 <height>20</height>
-                                </size>
-                               </property>
-                              </spacer>
-                             </item>
-                            </layout>
-                           </widget>
-                           <widget class="QWidget" name="pageLine">
-                            <layout class="QGridLayout" name="gridLayout_14">
-                             <property name="leftMargin">
-                              <number>0</number>
-                             </property>
-                             <property name="topMargin">
-                              <number>0</number>
-                             </property>
-                             <property name="rightMargin">
-                              <number>0</number>
-                             </property>
-                             <property name="bottomMargin">
-                              <number>0</number>
-                             </property>
-                             <item row="0" column="1">
-                              <widget class="QRadioButton" name="radLineCurved">
-                               <property name="sizePolicy">
-                                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                                 <horstretch>0</horstretch>
-                                 <verstretch>0</verstretch>
-                                </sizepolicy>
-                               </property>
-                               <property name="text">
-                                <string>Curved</string>
-                               </property>
-                              </widget>
-                             </item>
-                             <item row="0" column="0">
-                              <widget class="QRadioButton" name="radLineParallel">
-                               <property name="sizePolicy">
-                                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                                 <horstretch>0</horstretch>
-                                 <verstretch>0</verstretch>
-                                </sizepolicy>
-                               </property>
-                               <property name="text">
-                                <string>Parallel</string>
-                               </property>
-                               <property name="checked">
-                                <bool>true</bool>
-                               </property>
-                              </widget>
-                             </item>
-                             <item row="0" column="2">
-                              <widget class="QRadioButton" name="radLineHorizontal">
-                               <property name="text">
-                                <string>Horizontal</string>
-                               </property>
-                              </widget>
-                             </item>
-                            </layout>
-                           </widget>
-                           <widget class="QWidget" name="pagePolygon">
-                            <layout class="QGridLayout" name="gridLayout_18">
-                             <item row="0" column="0">
-                              <widget class="QRadioButton" name="radOverCentroid">
-                               <property name="sizePolicy">
-                                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                                 <horstretch>0</horstretch>
-                                 <verstretch>0</verstretch>
-                                </sizepolicy>
-                               </property>
-                               <property name="text">
-                                <string>Offset from centroid</string>
-                               </property>
-                               <property name="checked">
-                                <bool>true</bool>
-                               </property>
-                              </widget>
-                             </item>
-                             <item row="0" column="1">
-                              <widget class="QRadioButton" name="radPolygonHorizontal">
-                               <property name="text">
-                                <string>Horizontal</string>
-                               </property>
-                              </widget>
-                             </item>
-                             <item row="1" column="1">
-                              <widget class="QRadioButton" name="radPolygonFree">
-                               <property name="text">
-                                <string>Free (angled)</string>
-                               </property>
-                              </widget>
-                             </item>
-                             <item row="1" column="0">
-                              <widget class="QRadioButton" name="radAroundCentroid">
-                               <property name="sizePolicy">
-                                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                                 <horstretch>0</horstretch>
-                                 <verstretch>0</verstretch>
-                                </sizepolicy>
-                               </property>
-                               <property name="text">
-                                <string>Around centroid</string>
-                               </property>
-                              </widget>
-                             </item>
-                             <item row="2" column="0">
-                              <widget class="QRadioButton" name="radPolygonPerimeter">
-                               <property name="sizePolicy">
-                                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                                 <horstretch>0</horstretch>
-                                 <verstretch>0</verstretch>
-                                </sizepolicy>
-                               </property>
-                               <property name="text">
-                                <string>Using perimeter</string>
-                               </property>
-                              </widget>
-                             </item>
-                             <item row="1" column="3">
-                              <spacer name="horizontalSpacer_26">
-                               <property name="orientation">
-                                <enum>Qt::Horizontal</enum>
-                               </property>
-                               <property name="sizeHint" stdset="0">
-                                <size>
-                                 <width>40</width>
-                                 <height>20</height>
-                                </size>
-                               </property>
-                              </spacer>
-                             </item>
-                             <item row="2" column="1">
-                              <widget class="QRadioButton" name="radPolygonPerimeterCurved">
-                               <property name="sizePolicy">
-                                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                                 <horstretch>0</horstretch>
-                                 <verstretch>0</verstretch>
-                                </sizepolicy>
-                               </property>
-                               <property name="text">
-                                <string>Using perimeter (curved)</string>
-                               </property>
-                              </widget>
-                             </item>
-                             <item row="3" column="0">
-                              <widget class="QRadioButton" name="radPolygonOutside">
-                               <property name="text">
-                                <string>Outside polygons</string>
-                               </property>
-                              </widget>
-                             </item>
-                            </layout>
-                           </widget>
-                          </widget>
-                         </item>
-                        </layout>
-                       </widget>
+                        <item>
+                         <widget class="QLabel" name="label_2">
+                          <property name="text">
+                           <string>Placement</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QComboBox" name="mPlacementModeComboBox"/>
+                        </item>
+                       </layout>
                       </item>
                       <item>
                        <widget class="QFrame" name="mPlacementLineFrame">
@@ -6053,7 +5820,7 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>430</width>
+                       <width>471</width>
                        <height>708</height>
                       </rect>
                      </property>
@@ -7047,19 +6814,7 @@ font-style: italic;</string>
   <tabstop>mShadowBlendCmbBx</tabstop>
   <tabstop>mShadowBlendDDBtn</tabstop>
   <tabstop>scrollArea_3</tabstop>
-  <tabstop>radOverCentroid</tabstop>
-  <tabstop>radPolygonHorizontal</tabstop>
-  <tabstop>radAroundCentroid</tabstop>
-  <tabstop>radPolygonFree</tabstop>
-  <tabstop>radPolygonPerimeter</tabstop>
-  <tabstop>radPolygonPerimeterCurved</tabstop>
-  <tabstop>radPolygonOutside</tabstop>
-  <tabstop>radPredefinedOrder</tabstop>
-  <tabstop>radAroundPoint</tabstop>
-  <tabstop>radOverPoint</tabstop>
-  <tabstop>radLineParallel</tabstop>
-  <tabstop>radLineCurved</tabstop>
-  <tabstop>radLineHorizontal</tabstop>
+  <tabstop>mPlacementModeComboBox</tabstop>
   <tabstop>chkLineAbove</tabstop>
   <tabstop>chkLineOn</tabstop>
   <tabstop>chkLineBelow</tabstop>
@@ -7174,6 +6929,7 @@ font-style: italic;</string>
   <tabstop>mChkNoObstacle</tabstop>
   <tabstop>mIsObstacleDDBtn</tabstop>
   <tabstop>mObstacleSettingsButton</tabstop>
+  <tabstop>mLineAnchorSettingsButton</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -4145,21 +4145,50 @@ font-style: italic;</string>
                        <number>0</number>
                       </property>
                       <item>
-                       <layout class="QHBoxLayout" name="horizontalLayout_14" stretch="0,1">
-                        <property name="topMargin">
-                         <number>0</number>
+                       <widget class="QgsCollapsibleGroupBox" name="groupBox">
+                        <property name="title">
+                         <string>General Settings</string>
                         </property>
-                        <item>
-                         <widget class="QLabel" name="label_2">
-                          <property name="text">
-                           <string>Placement</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item>
-                         <widget class="QComboBox" name="mPlacementModeComboBox"/>
-                        </item>
-                       </layout>
+                        <layout class="QGridLayout" name="gridLayout_13">
+                         <item row="1" column="0">
+                          <layout class="QHBoxLayout" name="horizontalLayout_14" stretch="0,1">
+                           <property name="topMargin">
+                            <number>0</number>
+                           </property>
+                           <item>
+                            <widget class="QLabel" name="label_2">
+                             <property name="text">
+                              <string>Mode</string>
+                             </property>
+                            </widget>
+                           </item>
+                           <item>
+                            <widget class="QComboBox" name="mPlacementModeComboBox"/>
+                           </item>
+                          </layout>
+                         </item>
+                         <item row="0" column="0">
+                          <widget class="QLabel" name="label_14">
+                           <property name="text">
+                            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;The Placement Mode option controls the overall placement of labels relative to their corresponding features.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                           </property>
+                           <property name="wordWrap">
+                            <bool>true</bool>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="2" column="0">
+                          <widget class="QLabel" name="mPlacementModeDescriptionLabel">
+                           <property name="text">
+                            <string>TextLabel</string>
+                           </property>
+                           <property name="wordWrap">
+                            <bool>true</bool>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
+                       </widget>
                       </item>
                       <item>
                        <widget class="QFrame" name="mPlacementLineFrame">
@@ -4191,16 +4220,10 @@ font-style: italic;</string>
                          <property name="bottomMargin">
                           <number>0</number>
                          </property>
-                         <item row="0" column="0">
-                          <widget class="QLabel" name="label_13">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
+                         <item row="1" column="1">
+                          <widget class="QCheckBox" name="chkLineOrientationDependent">
                            <property name="text">
-                            <string>Allowed positions</string>
+                            <string>Line orientation dependent position</string>
                            </property>
                           </widget>
                          </item>
@@ -4251,10 +4274,16 @@ font-style: italic;</string>
                            </item>
                           </layout>
                          </item>
-                         <item row="1" column="1">
-                          <widget class="QCheckBox" name="chkLineOrientationDependent">
+                         <item row="0" column="0">
+                          <widget class="QLabel" name="label_13">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
                            <property name="text">
-                            <string>Line orientation dependent position</string>
+                            <string>Allowed positions</string>
                            </property>
                           </widget>
                          </item>

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -4126,8 +4126,8 @@ font-style: italic;</string>
                      <property name="geometry">
                       <rect>
                        <x>0</x>
-                       <y>-515</y>
-                       <width>471</width>
+                       <y>-1130</y>
+                       <width>472</width>
                        <height>1686</height>
                       </rect>
                      </property>
@@ -4150,6 +4150,150 @@ font-style: italic;</string>
                          <string>General Settings</string>
                         </property>
                         <layout class="QGridLayout" name="gridLayout_13">
+                         <item row="4" column="0">
+                          <widget class="QFrame" name="mPlacementPolygonFrame">
+                           <property name="minimumSize">
+                            <size>
+                             <width>0</width>
+                             <height>0</height>
+                            </size>
+                           </property>
+                           <property name="toolTip">
+                            <string>Allowed label placement for lines. At least one position must be selected.</string>
+                           </property>
+                           <property name="frameShape">
+                            <enum>QFrame::NoFrame</enum>
+                           </property>
+                           <property name="frameShadow">
+                            <enum>QFrame::Raised</enum>
+                           </property>
+                           <layout class="QGridLayout" name="gridLayout_48">
+                            <property name="leftMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="rightMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                             <number>0</number>
+                            </property>
+                            <item row="0" column="0">
+                             <layout class="QHBoxLayout" name="horizontalLayout_11">
+                              <item>
+                               <widget class="QCheckBox" name="mCheckAllowLabelsOutsidePolygons">
+                                <property name="text">
+                                 <string>Allow placing labels outside of polygons</string>
+                                </property>
+                               </widget>
+                              </item>
+                              <item>
+                               <widget class="QgsPropertyOverrideButton" name="mAllowOutsidePolygonsDDBtn">
+                                <property name="text">
+                                 <string>…</string>
+                                </property>
+                               </widget>
+                              </item>
+                             </layout>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                         <item row="0" column="0">
+                          <widget class="QLabel" name="label_14">
+                           <property name="text">
+                            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;The Placement Mode option controls the overall placement of labels relative to their corresponding features.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                           </property>
+                           <property name="wordWrap">
+                            <bool>true</bool>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="5" column="0">
+                          <widget class="QFrame" name="mPlacementCentroidFrame">
+                           <property name="frameShape">
+                            <enum>QFrame::NoFrame</enum>
+                           </property>
+                           <property name="frameShadow">
+                            <enum>QFrame::Raised</enum>
+                           </property>
+                           <layout class="QGridLayout" name="gridLayout_25">
+                            <property name="leftMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="rightMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                             <number>0</number>
+                            </property>
+                            <item row="1" column="1">
+                             <widget class="QRadioButton" name="mCentroidRadioVisible">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="text">
+                               <string>visible polygon</string>
+                              </property>
+                              <property name="checked">
+                               <bool>true</bool>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="1" column="3">
+                             <widget class="QgsPropertyOverrideButton" name="mCentroidDDBtn">
+                              <property name="text">
+                               <string>…</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="1" column="2">
+                             <widget class="QRadioButton" name="mCentroidRadioWhole">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="text">
+                               <string>whole polygon</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="2" column="1" colspan="3">
+                             <widget class="QCheckBox" name="mCentroidInsideCheckBox">
+                              <property name="text">
+                               <string>Force point inside polygon</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="1" column="0">
+                             <widget class="QLabel" name="mCentroidLabel">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="text">
+                               <string>Centroid</string>
+                              </property>
+                              <property name="alignment">
+                               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                              </property>
+                             </widget>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
                          <item row="1" column="0">
                           <layout class="QHBoxLayout" name="horizontalLayout_14" stretch="0,1">
                            <property name="topMargin">
@@ -4167,14 +4311,715 @@ font-style: italic;</string>
                            </item>
                           </layout>
                          </item>
-                         <item row="0" column="0">
-                          <widget class="QLabel" name="label_14">
-                           <property name="text">
-                            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;The Placement Mode option controls the overall placement of labels relative to their corresponding features.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                         <item row="8" column="0">
+                          <widget class="QFrame" name="mPlacementQuadrantFrame">
+                           <layout class="QGridLayout" name="gridLayout_19">
+                            <property name="leftMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="rightMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                             <number>0</number>
+                            </property>
+                            <item row="0" column="2">
+                             <widget class="QgsPropertyOverrideButton" name="mPointQuadOffsetDDBtn">
+                              <property name="text">
+                               <string>…</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="0" column="1" rowspan="3">
+                             <widget class="QFrame" name="mPlacementFixedQuadrantFrame">
+                              <layout class="QGridLayout" name="gridLayout_3">
+                               <property name="leftMargin">
+                                <number>0</number>
+                               </property>
+                               <property name="topMargin">
+                                <number>0</number>
+                               </property>
+                               <property name="rightMargin">
+                                <number>0</number>
+                               </property>
+                               <property name="bottomMargin">
+                                <number>0</number>
+                               </property>
+                               <property name="spacing">
+                                <number>2</number>
+                               </property>
+                               <item row="1" column="1">
+                                <widget class="QToolButton" name="mPointOffsetOver">
+                                 <property name="text">
+                                  <string>…</string>
+                                 </property>
+                                 <property name="icon">
+                                  <iconset resource="../../images/images.qrc">
+                                   <normaloff>:/images/themes/default/mIconLabelQuadrantCenter.svg</normaloff>:/images/themes/default/mIconLabelQuadrantCenter.svg</iconset>
+                                 </property>
+                                 <property name="iconSize">
+                                  <size>
+                                   <width>32</width>
+                                   <height>18</height>
+                                  </size>
+                                 </property>
+                                 <property name="checkable">
+                                  <bool>true</bool>
+                                 </property>
+                                 <property name="checked">
+                                  <bool>true</bool>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="0" column="2">
+                                <widget class="QToolButton" name="mPointOffsetAboveRight">
+                                 <property name="text">
+                                  <string>abc</string>
+                                 </property>
+                                 <property name="icon">
+                                  <iconset resource="../../images/images.qrc">
+                                   <normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</iconset>
+                                 </property>
+                                 <property name="iconSize">
+                                  <size>
+                                   <width>32</width>
+                                   <height>18</height>
+                                  </size>
+                                 </property>
+                                 <property name="checkable">
+                                  <bool>true</bool>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="2" column="0">
+                                <widget class="QToolButton" name="mPointOffsetBelowLeft">
+                                 <property name="text">
+                                  <string>abc</string>
+                                 </property>
+                                 <property name="icon">
+                                  <iconset resource="../../images/images.qrc">
+                                   <normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</iconset>
+                                 </property>
+                                 <property name="iconSize">
+                                  <size>
+                                   <width>32</width>
+                                   <height>18</height>
+                                  </size>
+                                 </property>
+                                 <property name="checkable">
+                                  <bool>true</bool>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="1" column="0">
+                                <widget class="QToolButton" name="mPointOffsetLeft">
+                                 <property name="text">
+                                  <string>abc</string>
+                                 </property>
+                                 <property name="icon">
+                                  <iconset resource="../../images/images.qrc">
+                                   <normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</iconset>
+                                 </property>
+                                 <property name="iconSize">
+                                  <size>
+                                   <width>32</width>
+                                   <height>18</height>
+                                  </size>
+                                 </property>
+                                 <property name="checkable">
+                                  <bool>true</bool>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="0" column="0">
+                                <widget class="QToolButton" name="mPointOffsetAboveLeft">
+                                 <property name="text">
+                                  <string>abc</string>
+                                 </property>
+                                 <property name="icon">
+                                  <iconset resource="../../images/images.qrc">
+                                   <normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</iconset>
+                                 </property>
+                                 <property name="iconSize">
+                                  <size>
+                                   <width>32</width>
+                                   <height>18</height>
+                                  </size>
+                                 </property>
+                                 <property name="checkable">
+                                  <bool>true</bool>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="1" column="2">
+                                <widget class="QToolButton" name="mPointOffsetRight">
+                                 <property name="text">
+                                  <string>abc</string>
+                                 </property>
+                                 <property name="icon">
+                                  <iconset resource="../../images/images.qrc">
+                                   <normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</iconset>
+                                 </property>
+                                 <property name="iconSize">
+                                  <size>
+                                   <width>32</width>
+                                   <height>18</height>
+                                  </size>
+                                 </property>
+                                 <property name="checkable">
+                                  <bool>true</bool>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="2" column="1">
+                                <widget class="QToolButton" name="mPointOffsetBelow">
+                                 <property name="text">
+                                  <string>abc</string>
+                                 </property>
+                                 <property name="icon">
+                                  <iconset resource="../../images/images.qrc">
+                                   <normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</iconset>
+                                 </property>
+                                 <property name="iconSize">
+                                  <size>
+                                   <width>32</width>
+                                   <height>18</height>
+                                  </size>
+                                 </property>
+                                 <property name="checkable">
+                                  <bool>true</bool>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="2" column="2">
+                                <widget class="QToolButton" name="mPointOffsetBelowRight">
+                                 <property name="text">
+                                  <string>abc</string>
+                                 </property>
+                                 <property name="icon">
+                                  <iconset resource="../../images/images.qrc">
+                                   <normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</iconset>
+                                 </property>
+                                 <property name="iconSize">
+                                  <size>
+                                   <width>32</width>
+                                   <height>18</height>
+                                  </size>
+                                 </property>
+                                 <property name="checkable">
+                                  <bool>true</bool>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="0" column="1">
+                                <widget class="QToolButton" name="mPointOffsetAbove">
+                                 <property name="text">
+                                  <string>abc</string>
+                                 </property>
+                                 <property name="icon">
+                                  <iconset resource="../../images/images.qrc">
+                                   <normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</iconset>
+                                 </property>
+                                 <property name="iconSize">
+                                  <size>
+                                   <width>32</width>
+                                   <height>18</height>
+                                  </size>
+                                 </property>
+                                 <property name="checkable">
+                                  <bool>true</bool>
+                                 </property>
+                                </widget>
+                               </item>
+                              </layout>
+                             </widget>
+                            </item>
+                            <item row="0" column="0">
+                             <widget class="QLabel" name="label_6">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="text">
+                               <string>Quadrant</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="2" column="0">
+                             <spacer name="horizontalSpacer_18">
+                              <property name="orientation">
+                               <enum>Qt::Horizontal</enum>
+                              </property>
+                              <property name="sizeType">
+                               <enum>QSizePolicy::Fixed</enum>
+                              </property>
+                              <property name="sizeHint" stdset="0">
+                               <size>
+                                <width>12</width>
+                                <height>12</height>
+                               </size>
+                              </property>
+                             </spacer>
+                            </item>
+                            <item row="0" column="3">
+                             <spacer name="horizontalSpacer_16">
+                              <property name="orientation">
+                               <enum>Qt::Horizontal</enum>
+                              </property>
+                              <property name="sizeHint" stdset="0">
+                               <size>
+                                <width>0</width>
+                                <height>12</height>
+                               </size>
+                              </property>
+                             </spacer>
+                            </item>
+                            <item row="1" column="0">
+                             <spacer name="horizontalSpacer_17">
+                              <property name="orientation">
+                               <enum>Qt::Horizontal</enum>
+                              </property>
+                              <property name="sizeType">
+                               <enum>QSizePolicy::Fixed</enum>
+                              </property>
+                              <property name="sizeHint" stdset="0">
+                               <size>
+                                <width>12</width>
+                                <height>12</height>
+                               </size>
+                              </property>
+                             </spacer>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                         <item row="3" column="0">
+                          <widget class="QFrame" name="mPlacementLineFrame">
+                           <property name="minimumSize">
+                            <size>
+                             <width>0</width>
+                             <height>0</height>
+                            </size>
                            </property>
-                           <property name="wordWrap">
-                            <bool>true</bool>
+                           <property name="toolTip">
+                            <string>Allowed label placement for lines. At least one position must be selected.</string>
                            </property>
+                           <property name="frameShape">
+                            <enum>QFrame::NoFrame</enum>
+                           </property>
+                           <property name="frameShadow">
+                            <enum>QFrame::Raised</enum>
+                           </property>
+                           <layout class="QGridLayout" name="gridLayout_10">
+                            <property name="leftMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="rightMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                             <number>0</number>
+                            </property>
+                            <item row="1" column="1">
+                             <widget class="QCheckBox" name="chkLineOrientationDependent">
+                              <property name="text">
+                               <string>Line orientation dependent position</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="0" column="1">
+                             <layout class="QHBoxLayout" name="horizontalLayout">
+                              <item>
+                               <widget class="QCheckBox" name="chkLineAbove">
+                                <property name="sizePolicy">
+                                 <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                 </sizepolicy>
+                                </property>
+                                <property name="text">
+                                 <string>Above line</string>
+                                </property>
+                                <property name="checked">
+                                 <bool>true</bool>
+                                </property>
+                               </widget>
+                              </item>
+                              <item>
+                               <widget class="QCheckBox" name="chkLineOn">
+                                <property name="sizePolicy">
+                                 <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                 </sizepolicy>
+                                </property>
+                                <property name="text">
+                                 <string>On line</string>
+                                </property>
+                               </widget>
+                              </item>
+                              <item>
+                               <widget class="QCheckBox" name="chkLineBelow">
+                                <property name="text">
+                                 <string>Below line</string>
+                                </property>
+                               </widget>
+                              </item>
+                              <item>
+                               <widget class="QgsPropertyOverrideButton" name="mLinePlacementFlagsDDBtn">
+                                <property name="text">
+                                 <string>…</string>
+                                </property>
+                               </widget>
+                              </item>
+                             </layout>
+                            </item>
+                            <item row="0" column="0">
+                             <widget class="QLabel" name="label_13">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="text">
+                               <string>Allowed positions</string>
+                              </property>
+                             </widget>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                         <item row="7" column="0">
+                          <widget class="QFrame" name="mPlacementOffsetTypeFrame">
+                           <property name="minimumSize">
+                            <size>
+                             <width>0</width>
+                             <height>0</height>
+                            </size>
+                           </property>
+                           <property name="frameShape">
+                            <enum>QFrame::NoFrame</enum>
+                           </property>
+                           <property name="frameShadow">
+                            <enum>QFrame::Raised</enum>
+                           </property>
+                           <layout class="QGridLayout" name="gridLayout_40">
+                            <property name="leftMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="rightMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                             <number>0</number>
+                            </property>
+                            <item row="0" column="0">
+                             <widget class="QLabel" name="label_42">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="text">
+                               <string>Distance offset from</string>
+                              </property>
+                              <property name="alignment">
+                               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="0" column="1">
+                             <widget class="QComboBox" name="mOffsetTypeComboBox"/>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                         <item row="10" column="0">
+                          <widget class="QFrame" name="mPlacementOffsetFrame">
+                           <property name="minimumSize">
+                            <size>
+                             <width>0</width>
+                             <height>0</height>
+                            </size>
+                           </property>
+                           <property name="frameShape">
+                            <enum>QFrame::NoFrame</enum>
+                           </property>
+                           <property name="frameShadow">
+                            <enum>QFrame::Raised</enum>
+                           </property>
+                           <layout class="QGridLayout" name="gridLayout_15">
+                            <property name="leftMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="rightMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                             <number>0</number>
+                            </property>
+                            <item row="0" column="2">
+                             <widget class="QgsDoubleSpinBox" name="mPointOffsetYSpinBox">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="prefix">
+                               <string/>
+                              </property>
+                              <property name="suffix">
+                               <string/>
+                              </property>
+                              <property name="decimals">
+                               <number>4</number>
+                              </property>
+                              <property name="minimum">
+                               <double>-9999999.000000000000000</double>
+                              </property>
+                              <property name="maximum">
+                               <double>9999999.000000000000000</double>
+                              </property>
+                              <property name="singleStep">
+                               <double>0.100000000000000</double>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="0" column="3">
+                             <widget class="QgsPropertyOverrideButton" name="mPointOffsetDDBtn">
+                              <property name="text">
+                               <string>…</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="1" column="3">
+                             <widget class="QgsPropertyOverrideButton" name="mPointOffsetUnitsDDBtn">
+                              <property name="text">
+                               <string>…</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="0" column="1">
+                             <widget class="QgsDoubleSpinBox" name="mPointOffsetXSpinBox">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="prefix">
+                               <string/>
+                              </property>
+                              <property name="suffix">
+                               <string/>
+                              </property>
+                              <property name="decimals">
+                               <number>4</number>
+                              </property>
+                              <property name="minimum">
+                               <double>-9999999.000000000000000</double>
+                              </property>
+                              <property name="maximum">
+                               <double>9999999.000000000000000</double>
+                              </property>
+                              <property name="singleStep">
+                               <double>0.100000000000000</double>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="0" column="0">
+                             <widget class="QLabel" name="label_15">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="text">
+                               <string>Offset X,Y</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="1" column="1" colspan="2">
+                             <widget class="QgsUnitSelectionWidget" name="mPointOffsetUnitWidget" native="true">
+                              <property name="focusPolicy">
+                               <enum>Qt::StrongFocus</enum>
+                              </property>
+                             </widget>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                         <item row="6" column="0">
+                          <widget class="QFrame" name="mPlacementDistanceFrame">
+                           <property name="minimumSize">
+                            <size>
+                             <width>0</width>
+                             <height>0</height>
+                            </size>
+                           </property>
+                           <property name="frameShape">
+                            <enum>QFrame::NoFrame</enum>
+                           </property>
+                           <property name="frameShadow">
+                            <enum>QFrame::Raised</enum>
+                           </property>
+                           <layout class="QGridLayout" name="gridLayout_27">
+                            <property name="leftMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="rightMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                             <number>0</number>
+                            </property>
+                            <item row="0" column="1">
+                             <widget class="QgsDoubleSpinBox" name="mLineDistanceSpnBx">
+                              <property name="decimals">
+                               <number>4</number>
+                              </property>
+                              <property name="minimum">
+                               <double>-999999999.000000000000000</double>
+                              </property>
+                              <property name="maximum">
+                               <double>999999999.000000000000000</double>
+                              </property>
+                              <property name="singleStep">
+                               <double>0.100000000000000</double>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="0" column="0">
+                             <widget class="QLabel" name="label_26">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="text">
+                               <string>Distance</string>
+                              </property>
+                              <property name="alignment">
+                               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="0" column="2">
+                             <widget class="QgsPropertyOverrideButton" name="mLineDistanceDDBtn">
+                              <property name="text">
+                               <string>…</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="1" column="2">
+                             <widget class="QgsPropertyOverrideButton" name="mLineDistanceUnitDDBtn">
+                              <property name="text">
+                               <string>…</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="1" column="1">
+                             <widget class="QgsUnitSelectionWidget" name="mLineDistanceUnitWidget" native="true">
+                              <property name="focusPolicy">
+                               <enum>Qt::StrongFocus</enum>
+                              </property>
+                             </widget>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                         <item row="9" column="0">
+                          <widget class="QFrame" name="mPlacementCartographicFrame">
+                           <layout class="QGridLayout" name="gridLayout_39">
+                            <property name="leftMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="rightMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                             <number>0</number>
+                            </property>
+                            <item row="0" column="2">
+                             <widget class="QgsPropertyOverrideButton" name="mPointPositionOrderDDBtn">
+                              <property name="text">
+                               <string>…</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="0" column="1" rowspan="2">
+                             <widget class="QFrame" name="mPlacementFixedQuadrantFrame_2">
+                              <layout class="QGridLayout" name="gridLayout_11">
+                               <property name="leftMargin">
+                                <number>0</number>
+                               </property>
+                               <property name="topMargin">
+                                <number>0</number>
+                               </property>
+                               <property name="rightMargin">
+                                <number>0</number>
+                               </property>
+                               <property name="bottomMargin">
+                                <number>0</number>
+                               </property>
+                               <property name="spacing">
+                                <number>2</number>
+                               </property>
+                              </layout>
+                             </widget>
+                            </item>
+                            <item row="0" column="3">
+                             <spacer name="horizontalSpacer_27">
+                              <property name="orientation">
+                               <enum>Qt::Horizontal</enum>
+                              </property>
+                              <property name="sizeHint" stdset="0">
+                               <size>
+                                <width>0</width>
+                                <height>12</height>
+                               </size>
+                              </property>
+                             </spacer>
+                            </item>
+                            <item row="0" column="0">
+                             <widget class="QLabel" name="label_20">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="text">
+                               <string>Position priority</string>
+                              </property>
+                             </widget>
+                            </item>
+                           </layout>
                           </widget>
                          </item>
                          <item row="2" column="0">
@@ -4187,400 +5032,21 @@ font-style: italic;</string>
                            </property>
                           </widget>
                          </item>
-                        </layout>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QFrame" name="mPlacementLineFrame">
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>0</height>
-                         </size>
-                        </property>
-                        <property name="toolTip">
-                         <string>Allowed label placement for lines. At least one position must be selected.</string>
-                        </property>
-                        <property name="frameShape">
-                         <enum>QFrame::NoFrame</enum>
-                        </property>
-                        <property name="frameShadow">
-                         <enum>QFrame::Raised</enum>
-                        </property>
-                        <layout class="QGridLayout" name="gridLayout_10">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
-                         <item row="1" column="1">
-                          <widget class="QCheckBox" name="chkLineOrientationDependent">
-                           <property name="text">
-                            <string>Line orientation dependent position</string>
+                         <item row="11" column="0">
+                          <widget class="QFrame" name="mPlacementRotationFrame">
+                           <property name="minimumSize">
+                            <size>
+                             <width>0</width>
+                             <height>0</height>
+                            </size>
                            </property>
-                          </widget>
-                         </item>
-                         <item row="0" column="1">
-                          <layout class="QHBoxLayout" name="horizontalLayout">
-                           <item>
-                            <widget class="QCheckBox" name="chkLineAbove">
-                             <property name="sizePolicy">
-                              <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                               <horstretch>0</horstretch>
-                               <verstretch>0</verstretch>
-                              </sizepolicy>
-                             </property>
-                             <property name="text">
-                              <string>Above line</string>
-                             </property>
-                             <property name="checked">
-                              <bool>true</bool>
-                             </property>
-                            </widget>
-                           </item>
-                           <item>
-                            <widget class="QCheckBox" name="chkLineOn">
-                             <property name="sizePolicy">
-                              <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                               <horstretch>0</horstretch>
-                               <verstretch>0</verstretch>
-                              </sizepolicy>
-                             </property>
-                             <property name="text">
-                              <string>On line</string>
-                             </property>
-                            </widget>
-                           </item>
-                           <item>
-                            <widget class="QCheckBox" name="chkLineBelow">
-                             <property name="text">
-                              <string>Below line</string>
-                             </property>
-                            </widget>
-                           </item>
-                           <item>
-                            <widget class="QgsPropertyOverrideButton" name="mLinePlacementFlagsDDBtn">
-                             <property name="text">
-                              <string>…</string>
-                             </property>
-                            </widget>
-                           </item>
-                          </layout>
-                         </item>
-                         <item row="0" column="0">
-                          <widget class="QLabel" name="label_13">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
+                           <property name="frameShape">
+                            <enum>QFrame::NoFrame</enum>
                            </property>
-                           <property name="text">
-                            <string>Allowed positions</string>
+                           <property name="frameShadow">
+                            <enum>QFrame::Raised</enum>
                            </property>
-                          </widget>
-                         </item>
-                        </layout>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QFrame" name="mPlacementPolygonFrame">
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>0</height>
-                         </size>
-                        </property>
-                        <property name="toolTip">
-                         <string>Allowed label placement for lines. At least one position must be selected.</string>
-                        </property>
-                        <property name="frameShape">
-                         <enum>QFrame::NoFrame</enum>
-                        </property>
-                        <property name="frameShadow">
-                         <enum>QFrame::Raised</enum>
-                        </property>
-                        <layout class="QGridLayout" name="gridLayout_48">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
-                         <item row="0" column="0">
-                          <layout class="QHBoxLayout" name="horizontalLayout_11">
-                           <item>
-                            <widget class="QCheckBox" name="mCheckAllowLabelsOutsidePolygons">
-                             <property name="text">
-                              <string>Allow placing labels outside of polygons</string>
-                             </property>
-                            </widget>
-                           </item>
-                           <item>
-                            <widget class="QgsPropertyOverrideButton" name="mAllowOutsidePolygonsDDBtn">
-                             <property name="text">
-                              <string>…</string>
-                             </property>
-                            </widget>
-                           </item>
-                          </layout>
-                         </item>
-                        </layout>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QFrame" name="mPlacementCentroidFrame">
-                        <property name="frameShape">
-                         <enum>QFrame::NoFrame</enum>
-                        </property>
-                        <property name="frameShadow">
-                         <enum>QFrame::Raised</enum>
-                        </property>
-                        <layout class="QGridLayout" name="gridLayout_25">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
-                         <item row="1" column="1">
-                          <widget class="QRadioButton" name="mCentroidRadioVisible">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="text">
-                            <string>visible polygon</string>
-                           </property>
-                           <property name="checked">
-                            <bool>true</bool>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="1" column="3">
-                          <widget class="QgsPropertyOverrideButton" name="mCentroidDDBtn">
-                           <property name="text">
-                            <string>…</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="1" column="2">
-                          <widget class="QRadioButton" name="mCentroidRadioWhole">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="text">
-                            <string>whole polygon</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="2" column="1" colspan="3">
-                          <widget class="QCheckBox" name="mCentroidInsideCheckBox">
-                           <property name="text">
-                            <string>Force point inside polygon</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="1" column="0">
-                          <widget class="QLabel" name="mCentroidLabel">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="text">
-                            <string>Centroid</string>
-                           </property>
-                           <property name="alignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                           </property>
-                          </widget>
-                         </item>
-                        </layout>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QFrame" name="mPlacementDistanceFrame">
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>0</height>
-                         </size>
-                        </property>
-                        <property name="frameShape">
-                         <enum>QFrame::NoFrame</enum>
-                        </property>
-                        <property name="frameShadow">
-                         <enum>QFrame::Raised</enum>
-                        </property>
-                        <layout class="QGridLayout" name="gridLayout_27">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
-                         <item row="0" column="1">
-                          <widget class="QgsDoubleSpinBox" name="mLineDistanceSpnBx">
-                           <property name="decimals">
-                            <number>4</number>
-                           </property>
-                           <property name="minimum">
-                            <double>-999999999.000000000000000</double>
-                           </property>
-                           <property name="maximum">
-                            <double>999999999.000000000000000</double>
-                           </property>
-                           <property name="singleStep">
-                            <double>0.100000000000000</double>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="0" column="0">
-                          <widget class="QLabel" name="label_26">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="text">
-                            <string>Distance</string>
-                           </property>
-                           <property name="alignment">
-                            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="0" column="2">
-                          <widget class="QgsPropertyOverrideButton" name="mLineDistanceDDBtn">
-                           <property name="text">
-                            <string>…</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="1" column="2">
-                          <widget class="QgsPropertyOverrideButton" name="mLineDistanceUnitDDBtn">
-                           <property name="text">
-                            <string>…</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="1" column="1">
-                          <widget class="QgsUnitSelectionWidget" name="mLineDistanceUnitWidget" native="true">
-                           <property name="focusPolicy">
-                            <enum>Qt::StrongFocus</enum>
-                           </property>
-                          </widget>
-                         </item>
-                        </layout>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QFrame" name="mPlacementOffsetTypeFrame">
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>0</height>
-                         </size>
-                        </property>
-                        <property name="frameShape">
-                         <enum>QFrame::NoFrame</enum>
-                        </property>
-                        <property name="frameShadow">
-                         <enum>QFrame::Raised</enum>
-                        </property>
-                        <layout class="QGridLayout" name="gridLayout_40">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
-                         <item row="0" column="0">
-                          <widget class="QLabel" name="label_42">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="text">
-                            <string>Distance offset from</string>
-                           </property>
-                           <property name="alignment">
-                            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="0" column="1">
-                          <widget class="QComboBox" name="mOffsetTypeComboBox"/>
-                         </item>
-                        </layout>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QFrame" name="mPlacementQuadrantFrame">
-                        <layout class="QGridLayout" name="gridLayout_19">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
-                         <item row="0" column="2">
-                          <widget class="QgsPropertyOverrideButton" name="mPointQuadOffsetDDBtn">
-                           <property name="text">
-                            <string>…</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="0" column="1" rowspan="3">
-                          <widget class="QFrame" name="mPlacementFixedQuadrantFrame">
-                           <layout class="QGridLayout" name="gridLayout_3">
+                           <layout class="QGridLayout" name="gridLayout_26">
                             <property name="leftMargin">
                              <number>0</number>
                             </property>
@@ -4593,514 +5059,48 @@ font-style: italic;</string>
                             <property name="bottomMargin">
                              <number>0</number>
                             </property>
-                            <property name="spacing">
-                             <number>2</number>
-                            </property>
-                            <item row="1" column="1">
-                             <widget class="QToolButton" name="mPointOffsetOver">
-                              <property name="text">
-                               <string>…</string>
-                              </property>
-                              <property name="icon">
-                               <iconset resource="../../images/images.qrc">
-                                <normaloff>:/images/themes/default/mIconLabelQuadrantCenter.svg</normaloff>:/images/themes/default/mIconLabelQuadrantCenter.svg</iconset>
-                              </property>
-                              <property name="iconSize">
-                               <size>
-                                <width>32</width>
-                                <height>18</height>
-                               </size>
-                              </property>
-                              <property name="checkable">
-                               <bool>true</bool>
-                              </property>
-                              <property name="checked">
-                               <bool>true</bool>
-                              </property>
-                             </widget>
-                            </item>
-                            <item row="0" column="2">
-                             <widget class="QToolButton" name="mPointOffsetAboveRight">
-                              <property name="text">
-                               <string>abc</string>
-                              </property>
-                              <property name="icon">
-                               <iconset resource="../../images/images.qrc">
-                                <normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</iconset>
-                              </property>
-                              <property name="iconSize">
-                               <size>
-                                <width>32</width>
-                                <height>18</height>
-                               </size>
-                              </property>
-                              <property name="checkable">
-                               <bool>true</bool>
-                              </property>
-                             </widget>
-                            </item>
-                            <item row="2" column="0">
-                             <widget class="QToolButton" name="mPointOffsetBelowLeft">
-                              <property name="text">
-                               <string>abc</string>
-                              </property>
-                              <property name="icon">
-                               <iconset resource="../../images/images.qrc">
-                                <normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</iconset>
-                              </property>
-                              <property name="iconSize">
-                               <size>
-                                <width>32</width>
-                                <height>18</height>
-                               </size>
-                              </property>
-                              <property name="checkable">
-                               <bool>true</bool>
-                              </property>
-                             </widget>
-                            </item>
-                            <item row="1" column="0">
-                             <widget class="QToolButton" name="mPointOffsetLeft">
-                              <property name="text">
-                               <string>abc</string>
-                              </property>
-                              <property name="icon">
-                               <iconset resource="../../images/images.qrc">
-                                <normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</iconset>
-                              </property>
-                              <property name="iconSize">
-                               <size>
-                                <width>32</width>
-                                <height>18</height>
-                               </size>
-                              </property>
-                              <property name="checkable">
-                               <bool>true</bool>
-                              </property>
-                             </widget>
-                            </item>
                             <item row="0" column="0">
-                             <widget class="QToolButton" name="mPointOffsetAboveLeft">
+                             <widget class="QLabel" name="label_25">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
                               <property name="text">
-                               <string>abc</string>
+                               <string>Rotation</string>
                               </property>
-                              <property name="icon">
-                               <iconset resource="../../images/images.qrc">
-                                <normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</iconset>
-                              </property>
-                              <property name="iconSize">
-                               <size>
-                                <width>32</width>
-                                <height>18</height>
-                               </size>
-                              </property>
-                              <property name="checkable">
-                               <bool>true</bool>
-                              </property>
-                             </widget>
-                            </item>
-                            <item row="1" column="2">
-                             <widget class="QToolButton" name="mPointOffsetRight">
-                              <property name="text">
-                               <string>abc</string>
-                              </property>
-                              <property name="icon">
-                               <iconset resource="../../images/images.qrc">
-                                <normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</iconset>
-                              </property>
-                              <property name="iconSize">
-                               <size>
-                                <width>32</width>
-                                <height>18</height>
-                               </size>
-                              </property>
-                              <property name="checkable">
-                               <bool>true</bool>
-                              </property>
-                             </widget>
-                            </item>
-                            <item row="2" column="1">
-                             <widget class="QToolButton" name="mPointOffsetBelow">
-                              <property name="text">
-                               <string>abc</string>
-                              </property>
-                              <property name="icon">
-                               <iconset resource="../../images/images.qrc">
-                                <normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</iconset>
-                              </property>
-                              <property name="iconSize">
-                               <size>
-                                <width>32</width>
-                                <height>18</height>
-                               </size>
-                              </property>
-                              <property name="checkable">
-                               <bool>true</bool>
-                              </property>
-                             </widget>
-                            </item>
-                            <item row="2" column="2">
-                             <widget class="QToolButton" name="mPointOffsetBelowRight">
-                              <property name="text">
-                               <string>abc</string>
-                              </property>
-                              <property name="icon">
-                               <iconset resource="../../images/images.qrc">
-                                <normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</iconset>
-                              </property>
-                              <property name="iconSize">
-                               <size>
-                                <width>32</width>
-                                <height>18</height>
-                               </size>
-                              </property>
-                              <property name="checkable">
-                               <bool>true</bool>
+                              <property name="alignment">
+                               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
                               </property>
                              </widget>
                             </item>
                             <item row="0" column="1">
-                             <widget class="QToolButton" name="mPointOffsetAbove">
-                              <property name="text">
-                               <string>abc</string>
-                              </property>
-                              <property name="icon">
-                               <iconset resource="../../images/images.qrc">
-                                <normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</normaloff>:/images/themes/default/mIconLabelQuadrantOffset.svg</iconset>
-                              </property>
-                              <property name="iconSize">
-                               <size>
-                                <width>32</width>
-                                <height>18</height>
-                               </size>
-                              </property>
-                              <property name="checkable">
+                             <widget class="QgsDoubleSpinBox" name="mPointAngleSpinBox">
+                              <property name="enabled">
                                <bool>true</bool>
+                              </property>
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="wrapping">
+                               <bool>true</bool>
+                              </property>
+                              <property name="suffix">
+                               <string>˚</string>
+                              </property>
+                              <property name="minimum">
+                               <double>-360.000000000000000</double>
+                              </property>
+                              <property name="maximum">
+                               <double>360.000000000000000</double>
                               </property>
                              </widget>
                             </item>
                            </layout>
-                          </widget>
-                         </item>
-                         <item row="0" column="0">
-                          <widget class="QLabel" name="label_6">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="text">
-                            <string>Quadrant</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="2" column="0">
-                          <spacer name="horizontalSpacer_18">
-                           <property name="orientation">
-                            <enum>Qt::Horizontal</enum>
-                           </property>
-                           <property name="sizeType">
-                            <enum>QSizePolicy::Fixed</enum>
-                           </property>
-                           <property name="sizeHint" stdset="0">
-                            <size>
-                             <width>12</width>
-                             <height>12</height>
-                            </size>
-                           </property>
-                          </spacer>
-                         </item>
-                         <item row="0" column="3">
-                          <spacer name="horizontalSpacer_16">
-                           <property name="orientation">
-                            <enum>Qt::Horizontal</enum>
-                           </property>
-                           <property name="sizeHint" stdset="0">
-                            <size>
-                             <width>0</width>
-                             <height>12</height>
-                            </size>
-                           </property>
-                          </spacer>
-                         </item>
-                         <item row="1" column="0">
-                          <spacer name="horizontalSpacer_17">
-                           <property name="orientation">
-                            <enum>Qt::Horizontal</enum>
-                           </property>
-                           <property name="sizeType">
-                            <enum>QSizePolicy::Fixed</enum>
-                           </property>
-                           <property name="sizeHint" stdset="0">
-                            <size>
-                             <width>12</width>
-                             <height>12</height>
-                            </size>
-                           </property>
-                          </spacer>
-                         </item>
-                        </layout>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QFrame" name="mPlacementCartographicFrame">
-                        <layout class="QGridLayout" name="gridLayout_39">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
-                         <item row="0" column="2">
-                          <widget class="QgsPropertyOverrideButton" name="mPointPositionOrderDDBtn">
-                           <property name="text">
-                            <string>…</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="0" column="1" rowspan="2">
-                          <widget class="QFrame" name="mPlacementFixedQuadrantFrame_2">
-                           <layout class="QGridLayout" name="gridLayout_11">
-                            <property name="leftMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="topMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="rightMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="bottomMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="spacing">
-                             <number>2</number>
-                            </property>
-                           </layout>
-                          </widget>
-                         </item>
-                         <item row="0" column="3">
-                          <spacer name="horizontalSpacer_27">
-                           <property name="orientation">
-                            <enum>Qt::Horizontal</enum>
-                           </property>
-                           <property name="sizeHint" stdset="0">
-                            <size>
-                             <width>0</width>
-                             <height>12</height>
-                            </size>
-                           </property>
-                          </spacer>
-                         </item>
-                         <item row="0" column="0">
-                          <widget class="QLabel" name="label_20">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="text">
-                            <string>Position priority</string>
-                           </property>
-                          </widget>
-                         </item>
-                        </layout>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QFrame" name="mPlacementOffsetFrame">
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>0</height>
-                         </size>
-                        </property>
-                        <property name="frameShape">
-                         <enum>QFrame::NoFrame</enum>
-                        </property>
-                        <property name="frameShadow">
-                         <enum>QFrame::Raised</enum>
-                        </property>
-                        <layout class="QGridLayout" name="gridLayout_15">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
-                         <item row="0" column="2">
-                          <widget class="QgsDoubleSpinBox" name="mPointOffsetYSpinBox">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="prefix">
-                            <string/>
-                           </property>
-                           <property name="suffix">
-                            <string/>
-                           </property>
-                           <property name="decimals">
-                            <number>4</number>
-                           </property>
-                           <property name="minimum">
-                            <double>-9999999.000000000000000</double>
-                           </property>
-                           <property name="maximum">
-                            <double>9999999.000000000000000</double>
-                           </property>
-                           <property name="singleStep">
-                            <double>0.100000000000000</double>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="0" column="3">
-                          <widget class="QgsPropertyOverrideButton" name="mPointOffsetDDBtn">
-                           <property name="text">
-                            <string>…</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="1" column="3">
-                          <widget class="QgsPropertyOverrideButton" name="mPointOffsetUnitsDDBtn">
-                           <property name="text">
-                            <string>…</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="0" column="1">
-                          <widget class="QgsDoubleSpinBox" name="mPointOffsetXSpinBox">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="prefix">
-                            <string/>
-                           </property>
-                           <property name="suffix">
-                            <string/>
-                           </property>
-                           <property name="decimals">
-                            <number>4</number>
-                           </property>
-                           <property name="minimum">
-                            <double>-9999999.000000000000000</double>
-                           </property>
-                           <property name="maximum">
-                            <double>9999999.000000000000000</double>
-                           </property>
-                           <property name="singleStep">
-                            <double>0.100000000000000</double>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="0" column="0">
-                          <widget class="QLabel" name="label_15">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="text">
-                            <string>Offset X,Y</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="1" column="1" colspan="2">
-                          <widget class="QgsUnitSelectionWidget" name="mPointOffsetUnitWidget" native="true">
-                           <property name="focusPolicy">
-                            <enum>Qt::StrongFocus</enum>
-                           </property>
-                          </widget>
-                         </item>
-                        </layout>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QFrame" name="mPlacementRotationFrame">
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>0</height>
-                         </size>
-                        </property>
-                        <property name="frameShape">
-                         <enum>QFrame::NoFrame</enum>
-                        </property>
-                        <property name="frameShadow">
-                         <enum>QFrame::Raised</enum>
-                        </property>
-                        <layout class="QGridLayout" name="gridLayout_26">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
-                         <item row="0" column="0">
-                          <widget class="QLabel" name="label_25">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="text">
-                            <string>Rotation</string>
-                           </property>
-                           <property name="alignment">
-                            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="0" column="1">
-                          <widget class="QgsDoubleSpinBox" name="mPointAngleSpinBox">
-                           <property name="enabled">
-                            <bool>true</bool>
-                           </property>
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="wrapping">
-                            <bool>true</bool>
-                           </property>
-                           <property name="suffix">
-                            <string>˚</string>
-                           </property>
-                           <property name="minimum">
-                            <double>-360.000000000000000</double>
-                           </property>
-                           <property name="maximum">
-                            <double>360.000000000000000</double>
-                           </property>
                           </widget>
                          </item>
                         </layout>
@@ -5388,10 +5388,13 @@ font-style: italic;</string>
                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Generates or transforms the geometry to be used for labeling&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The expression will be applied to each feature while rendering and the label will be placed based on the expression result.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                         </property>
                         <property name="title">
-                         <string>Geometry generator</string>
+                         <string>Geometry Generator</string>
                         </property>
                         <property name="checkable">
                          <bool>true</bool>
+                        </property>
+                        <property name="checked">
+                         <bool>false</bool>
                         </property>
                         <layout class="QGridLayout" name="gridLayout_41">
                          <property name="leftMargin">

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -717,8 +717,8 @@
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>485</width>
-                       <height>429</height>
+                       <width>323</width>
+                       <height>317</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
@@ -1280,7 +1280,7 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>471</width>
+                       <width>373</width>
                        <height>708</height>
                       </rect>
                      </property>
@@ -2164,8 +2164,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>485</width>
-                       <height>429</height>
+                       <width>299</width>
+                       <height>308</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -2510,8 +2510,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>485</width>
-                       <height>429</height>
+                       <width>294</width>
+                       <height>291</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_121">
@@ -2788,7 +2788,7 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>471</width>
+                       <width>440</width>
                        <height>786</height>
                       </rect>
                      </property>
@@ -3549,7 +3549,7 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>471</width>
+                       <width>324</width>
                        <height>457</height>
                       </rect>
                      </property>
@@ -3977,8 +3977,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>485</width>
-                       <height>429</height>
+                       <width>159</width>
+                       <height>211</height>
                       </rect>
                      </property>
                      <layout class="QGridLayout" name="gridLayout_46">
@@ -4126,9 +4126,9 @@ font-style: italic;</string>
                      <property name="geometry">
                       <rect>
                        <x>0</x>
-                       <y>0</y>
+                       <y>-515</y>
                        <width>471</width>
-                       <height>1352</height>
+                       <height>1686</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -5107,34 +5107,12 @@ font-style: italic;</string>
                        </widget>
                       </item>
                       <item>
-                       <widget class="QFrame" name="mPlacementRepeatDistanceFrame">
-                        <property name="frameShape">
-                         <enum>QFrame::NoFrame</enum>
+                       <widget class="QgsCollapsibleGroupBox" name="mPlacementRepeatGroupBox">
+                        <property name="title">
+                         <string>Repeating Labels</string>
                         </property>
-                        <property name="frameShadow">
-                         <enum>QFrame::Raised</enum>
-                        </property>
-                        <layout class="QGridLayout" name="gridLayout_24">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
-                         <item row="0" column="0">
-                          <widget class="QLabel" name="label_7">
-                           <property name="text">
-                            <string>Repeat</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="0" column="1">
+                        <layout class="QGridLayout" name="gridLayout_18">
+                         <item row="1" column="1">
                           <widget class="QgsDoubleSpinBox" name="mRepeatDistanceSpinBox">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -5153,24 +5131,41 @@ font-style: italic;</string>
                            </property>
                           </widget>
                          </item>
-                         <item row="0" column="2">
+                         <item row="1" column="2">
                           <widget class="QgsPropertyOverrideButton" name="mRepeatDistanceDDBtn">
                            <property name="text">
                             <string>…</string>
                            </property>
                           </widget>
                          </item>
-                         <item row="1" column="1">
+                         <item row="1" column="0">
+                          <widget class="QLabel" name="label_7">
+                           <property name="text">
+                            <string>Distance</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="2" column="1">
                           <widget class="QgsUnitSelectionWidget" name="mRepeatDistanceUnitWidget" native="true">
                            <property name="focusPolicy">
                             <enum>Qt::StrongFocus</enum>
                            </property>
                           </widget>
                          </item>
-                         <item row="1" column="2">
+                         <item row="2" column="2">
                           <widget class="QgsPropertyOverrideButton" name="mRepeatDistanceUnitDDBtn">
                            <property name="text">
                             <string>…</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="0" column="0" colspan="3">
+                          <widget class="QLabel" name="label_41">
+                           <property name="text">
+                            <string>Setting a repeat distance allows labels to be repeated multiple times over the length of the feature. This distance is treated as a hint for label placement only, and the exact distance between repeating labels may vary depending on the shape of the feature and arrangement of nearby labels.</string>
+                           </property>
+                           <property name="wordWrap">
+                            <bool>true</bool>
                            </property>
                           </widget>
                          </item>
@@ -5178,34 +5173,26 @@ font-style: italic;</string>
                        </widget>
                       </item>
                       <item>
-                       <widget class="QFrame" name="mPlacementOverrunDistanceFrame">
-                        <property name="frameShape">
-                         <enum>QFrame::NoFrame</enum>
+                       <widget class="QgsCollapsibleGroupBox" name="mPlacementOverrunGroupBox">
+                        <property name="title">
+                         <string>Label Overrun</string>
                         </property>
-                        <property name="frameShadow">
-                         <enum>QFrame::Raised</enum>
-                        </property>
-                        <layout class="QGridLayout" name="gridLayout_44">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
-                         <item row="0" column="0">
-                          <widget class="QLabel" name="label_46">
-                           <property name="text">
-                            <string>Overrun feature</string>
+                        <layout class="QGridLayout" name="gridLayout_14">
+                         <item row="2" column="1">
+                          <widget class="QgsUnitSelectionWidget" name="mOverrunDistanceUnitWidget" native="true">
+                           <property name="focusPolicy">
+                            <enum>Qt::StrongFocus</enum>
                            </property>
                           </widget>
                          </item>
-                         <item row="0" column="1">
+                         <item row="1" column="0">
+                          <widget class="QLabel" name="label_46">
+                           <property name="text">
+                            <string>Overrun distance</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="1" column="1">
                           <widget class="QgsDoubleSpinBox" name="mOverrunDistanceSpinBox">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -5224,17 +5211,20 @@ font-style: italic;</string>
                            </property>
                           </widget>
                          </item>
-                         <item row="0" column="2">
+                         <item row="1" column="2">
                           <widget class="QgsPropertyOverrideButton" name="mOverrunDistanceDDBtn">
                            <property name="text">
                             <string>…</string>
                            </property>
                           </widget>
                          </item>
-                         <item row="1" column="1">
-                          <widget class="QgsUnitSelectionWidget" name="mOverrunDistanceUnitWidget" native="true">
-                           <property name="focusPolicy">
-                            <enum>Qt::StrongFocus</enum>
+                         <item row="0" column="0" colspan="3">
+                          <widget class="QLabel" name="label_40">
+                           <property name="text">
+                            <string>The overrun distance allows labels which extend past the start or end of line features. Increasing this distance can allow for labels to be shown for shorter line features.</string>
+                           </property>
+                           <property name="wordWrap">
+                            <bool>true</bool>
                            </property>
                           </widget>
                          </item>
@@ -5831,7 +5821,7 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>471</width>
+                       <width>430</width>
                        <height>708</height>
                       </rect>
                      </property>
@@ -6859,10 +6849,6 @@ font-style: italic;</string>
   <tabstop>mPointOffsetUnitWidget</tabstop>
   <tabstop>mPointOffsetUnitsDDBtn</tabstop>
   <tabstop>mPointAngleSpinBox</tabstop>
-  <tabstop>mRepeatDistanceSpinBox</tabstop>
-  <tabstop>mRepeatDistanceDDBtn</tabstop>
-  <tabstop>mRepeatDistanceUnitWidget</tabstop>
-  <tabstop>mRepeatDistanceUnitDDBtn</tabstop>
   <tabstop>mMaxCharAngleInDSpinBox</tabstop>
   <tabstop>mMaxCharAngleOutDSpinBox</tabstop>
   <tabstop>mMaxCharAngleDDBtn</tabstop>
@@ -6934,9 +6920,6 @@ font-style: italic;</string>
   <tabstop>mCalloutsDrawCheckBox</tabstop>
   <tabstop>mCalloutDrawDDBtn</tabstop>
   <tabstop>mCalloutStyleComboBox</tabstop>
-  <tabstop>mOverrunDistanceSpinBox</tabstop>
-  <tabstop>mOverrunDistanceDDBtn</tabstop>
-  <tabstop>mOverrunDistanceUnitWidget</tabstop>
   <tabstop>mChkNoObstacle</tabstop>
   <tabstop>mIsObstacleDDBtn</tabstop>
   <tabstop>mObstacleSettingsButton</tabstop>

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -4451,9 +4451,6 @@ font-style: italic;</string>
                          <property name="bottomMargin">
                           <number>0</number>
                          </property>
-                         <property name="verticalSpacing">
-                          <number>12</number>
-                         </property>
                          <item row="0" column="1">
                           <widget class="QgsDoubleSpinBox" name="mLineDistanceSpnBx">
                            <property name="decimals">
@@ -4536,9 +4533,6 @@ font-style: italic;</string>
                          </property>
                          <property name="bottomMargin">
                           <number>0</number>
-                         </property>
-                         <property name="verticalSpacing">
-                          <number>12</number>
                          </property>
                          <item row="0" column="0">
                           <widget class="QLabel" name="label_42">
@@ -4948,9 +4942,6 @@ font-style: italic;</string>
                          <property name="bottomMargin">
                           <number>0</number>
                          </property>
-                         <property name="verticalSpacing">
-                          <number>12</number>
-                         </property>
                          <item row="0" column="2">
                           <widget class="QgsDoubleSpinBox" name="mPointOffsetYSpinBox">
                            <property name="sizePolicy">
@@ -5136,9 +5127,6 @@ font-style: italic;</string>
                          <property name="bottomMargin">
                           <number>0</number>
                          </property>
-                         <property name="verticalSpacing">
-                          <number>12</number>
-                         </property>
                          <item row="0" column="0">
                           <widget class="QLabel" name="label_7">
                            <property name="text">
@@ -5209,9 +5197,6 @@ font-style: italic;</string>
                          </property>
                          <property name="bottomMargin">
                           <number>0</number>
-                         </property>
-                         <property name="verticalSpacing">
-                          <number>12</number>
                          </property>
                          <item row="0" column="0">
                           <widget class="QLabel" name="label_46">
@@ -5296,9 +5281,6 @@ font-style: italic;</string>
                          </property>
                          <property name="bottomMargin">
                           <number>0</number>
-                         </property>
-                         <property name="verticalSpacing">
-                          <number>12</number>
                          </property>
                          <item row="1" column="2">
                           <widget class="QgsDoubleSpinBox" name="mMaxCharAngleInDSpinBox">


### PR DESCRIPTION
This PR reworks the Label "Placement" tab. It's currently a very dense, widget heavy tab which is daunting for new users (and I suspect contains many options which aren't understood even by experienced users)

So in this PR I've:
- Changed the existing radio button selection for placement modes to a combo box. The combo box is more compact and avoids the messy oversized padding which is forced on the radio buttons for non-polygon layers. The more compact widget gives us space to add some nice explanatory text. Before and after screenshots below. (Some nice illustrative icons would be great to add to the combo box too!)

![image](https://user-images.githubusercontent.com/1829991/90459162-d58bf880-e143-11ea-8208-00fa9ba567c8.png)

![image](https://user-images.githubusercontent.com/1829991/90459170-dcb30680-e143-11ea-91b8-2a91494eb5b4.png)

Some other screenshots:

![image](https://user-images.githubusercontent.com/1829991/90459230-09671e00-e144-11ea-8048-70924a3e9a47.png)

![image](https://user-images.githubusercontent.com/1829991/90459233-0e2bd200-e144-11ea-99e9-ad97b621050f.png)

![image](https://user-images.githubusercontent.com/1829991/90459241-12f08600-e144-11ea-8ed7-877648459829.png)

![image](https://user-images.githubusercontent.com/1829991/90459249-18e66700-e144-11ea-8a9e-05b7f1956b50.png)

![image](https://user-images.githubusercontent.com/1829991/90459261-20a60b80-e144-11ea-9584-b68de844e040.png)

- I've also moved the "Repeating Labels" and "Label Overrun" settings to collapsible groups, with nice explanatory text. Before/after images below. (Again, I think some nice illustrations sitting to the left of the helper text would be great to add in future)

![image](https://user-images.githubusercontent.com/1829991/90459298-43382480-e144-11ea-9290-cfd639a05aa5.png)

![image](https://user-images.githubusercontent.com/1829991/90459309-49c69c00-e144-11ea-9dd7-031d6ddc656d.png)






