### PR TITLE
[ui] Fix SVG marker widget not properly restoring colors

### DIFF
--- a/python/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
@@ -452,7 +452,15 @@ Creates a new QgsSvgMarkerSymbolLayerWidget.
   protected:
 
     void populateList();
+
     void setGuiForSvg( const QgsSvgMarkerSymbolLayer *layer, bool skipDefaultColors = false );
+%Docstring
+Updates the GUI to reflect the SVG marker symbol ``layer``.
+
+:param layer: SVG marker symbol layer
+:param skipDefaultColors: if ``True``, the default fill and outline colors of the SVG file will not overwrite
+                          the ones from the symbol layer
+%End
 
 
 };

--- a/python/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
@@ -452,7 +452,7 @@ Creates a new QgsSvgMarkerSymbolLayerWidget.
   protected:
 
     void populateList();
-    void setGuiForSvg( const QgsSvgMarkerSymbolLayer *layer );
+    void setGuiForSvg( const QgsSvgMarkerSymbolLayer *layer, bool skipDefaultColors = false );
 
 
 };

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -2423,14 +2423,12 @@ void QgsSvgMarkerSymbolLayerWidget::setGuiForSvg( const QgsSvgMarkerSymbolLayer 
   mChangeStrokeColorButton->setAllowOpacity( hasStrokeOpacityParam );
   mStrokeWidthSpinBox->setEnabled( hasStrokeWidthParam );
 
-  qDebug() << ( hasFillParam ? "true" : "false" );
   if ( hasFillParam )
   {
     QColor fill = layer->fillColor();
     double existingOpacity = hasFillOpacityParam ? fill.alphaF() : 1.0;
     if ( hasDefaultFillColor && !skipDefaultColors )
     {
-      qDebug() << ( hasFillParam ? "true" : "false" );
       fill = defaultFill;
     }
     fill.setAlphaF( hasDefaultFillOpacity ? defaultFillOpacity : existingOpacity );

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -2400,7 +2400,7 @@ void QgsSvgMarkerSymbolLayerWidget::populateIcons( const QModelIndex &idx )
   connect( viewImages->selectionModel(), &QItemSelectionModel::currentChanged, this, &QgsSvgMarkerSymbolLayerWidget::setName );
 }
 
-void QgsSvgMarkerSymbolLayerWidget::setGuiForSvg( const QgsSvgMarkerSymbolLayer *layer )
+void QgsSvgMarkerSymbolLayerWidget::setGuiForSvg( const QgsSvgMarkerSymbolLayer *layer, bool skipDefaultColors )
 {
   if ( !layer )
   {
@@ -2423,12 +2423,14 @@ void QgsSvgMarkerSymbolLayerWidget::setGuiForSvg( const QgsSvgMarkerSymbolLayer 
   mChangeStrokeColorButton->setAllowOpacity( hasStrokeOpacityParam );
   mStrokeWidthSpinBox->setEnabled( hasStrokeWidthParam );
 
+  qDebug() << ( hasFillParam ? "true" : "false" );
   if ( hasFillParam )
   {
     QColor fill = layer->fillColor();
     double existingOpacity = hasFillOpacityParam ? fill.alphaF() : 1.0;
-    if ( hasDefaultFillColor )
+    if ( hasDefaultFillColor && !skipDefaultColors )
     {
+      qDebug() << ( hasFillParam ? "true" : "false" );
       fill = defaultFill;
     }
     fill.setAlphaF( hasDefaultFillOpacity ? defaultFillOpacity : existingOpacity );
@@ -2438,7 +2440,7 @@ void QgsSvgMarkerSymbolLayerWidget::setGuiForSvg( const QgsSvgMarkerSymbolLayer 
   {
     QColor stroke = layer->strokeColor();
     double existingOpacity = hasStrokeOpacityParam ? stroke.alphaF() : 1.0;
-    if ( hasDefaultStrokeColor )
+    if ( hasDefaultStrokeColor && !skipDefaultColors )
     {
       stroke = defaultStroke;
     }
@@ -2545,7 +2547,7 @@ void QgsSvgMarkerSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer *layer )
   mHorizontalAnchorComboBox->blockSignals( false );
   mVerticalAnchorComboBox->blockSignals( false );
 
-  setGuiForSvg( mLayer );
+  setGuiForSvg( mLayer, true );
 
   registerDataDefinedButton( mWidthDDBtn, QgsSymbolLayer::PropertyWidth );
   registerDataDefinedButton( mHeightDDBtn, QgsSymbolLayer::PropertyHeight );

--- a/src/gui/symbology/qgssymbollayerwidget.h
+++ b/src/gui/symbology/qgssymbollayerwidget.h
@@ -601,7 +601,13 @@ class GUI_EXPORT QgsSvgMarkerSymbolLayerWidget : public QgsSymbolLayerWidget, pr
   protected:
 
     void populateList();
-    //update gui for svg file (insert new path, update activation of gui elements for svg params)
+
+    /**
+     * Updates the GUI to reflect the SVG marker symbol \a layer.
+     * \param layer SVG marker symbol layer
+     * \param skipDefaultColors if TRUE, the default fill and outline colors of the SVG file will not overwrite
+     * the ones from the symbol layer
+     */
     void setGuiForSvg( const QgsSvgMarkerSymbolLayer *layer, bool skipDefaultColors = false );
 
     QgsSvgMarkerSymbolLayer *mLayer = nullptr;

--- a/src/gui/symbology/qgssymbollayerwidget.h
+++ b/src/gui/symbology/qgssymbollayerwidget.h
@@ -602,7 +602,7 @@ class GUI_EXPORT QgsSvgMarkerSymbolLayerWidget : public QgsSymbolLayerWidget, pr
 
     void populateList();
     //update gui for svg file (insert new path, update activation of gui elements for svg params)
-    void setGuiForSvg( const QgsSvgMarkerSymbolLayer *layer );
+    void setGuiForSvg( const QgsSvgMarkerSymbolLayer *layer, bool skipDefaultColors = false );
 
     QgsSvgMarkerSymbolLayer *mLayer = nullptr;
 


### PR DESCRIPTION
## Description

This PR fixes the SVG marker widget unable to restore fill and outline colors when accessing a preexisting SVG marker layer.  