### PR TITLE
Add a scrollbar to 3D Map view rendering settings

### DIFF
--- a/src/app/3d/qgsvectorlayer3drendererwidget.cpp
+++ b/src/app/3d/qgsvectorlayer3drendererwidget.cpp
@@ -25,6 +25,7 @@
 #include "qgsapplication.h"
 #include "qgs3dsymbolregistry.h"
 #include "qgsabstractmaterialsettings.h"
+#include "qgsvscrollarea.h"
 
 #include <QBoxLayout>
 #include <QCheckBox>
@@ -82,12 +83,15 @@ QgsVectorLayer3DRendererWidget::QgsVectorLayer3DRendererWidget( QgsMapLayer *lay
   cboRendererType->addItem( QgsApplication::getThemeIcon( QStringLiteral( "rendererNullSymbol.svg" ) ), tr( "No Symbols" ) );
   cboRendererType->addItem( QgsApplication::getThemeIcon( QStringLiteral( "rendererSingleSymbol.svg" ) ), tr( "Single Symbol" ) );
   cboRendererType->addItem( QgsApplication::getThemeIcon( QStringLiteral( "rendererRuleBasedSymbol.svg" ) ), tr( "Rule-based" ) );
-
-  widgetBaseProperties = new QgsVectorLayer3DPropertiesWidget( this );
+  layout->addWidget( cboRendererType );
 
   widgetRendererStack = new QStackedWidget( this );
-  layout->addWidget( cboRendererType );
-  layout->addWidget( widgetRendererStack );
+  QgsVScrollArea *scrollArea = new QgsVScrollArea( this );
+  scrollArea->setFrameShape( QFrame::NoFrame );
+  layout->addWidget( scrollArea );
+  scrollArea->setWidget( widgetRendererStack );
+
+  widgetBaseProperties = new QgsVectorLayer3DPropertiesWidget( this );
   layout->addWidget( widgetBaseProperties );
 
   widgetNoRenderer = new QLabel;

--- a/src/app/3d/qgsvectorlayer3drendererwidget.cpp
+++ b/src/app/3d/qgsvectorlayer3drendererwidget.cpp
@@ -76,22 +76,32 @@ QgsVectorLayer3DRendererWidget::QgsVectorLayer3DRendererWidget( QgsMapLayer *lay
 {
   setPanelTitle( tr( "3D View" ) );
 
-  QVBoxLayout *layout = new QVBoxLayout( this );
+  QWidget *wdgt = new QWidget( this );
+  QVBoxLayout *layout = new QVBoxLayout( wdgt );
+  wdgt->setLayout( layout );
   layout->setContentsMargins( 0, 0, 0, 0 );
+
+  QScrollArea *scrollArea = new QScrollArea( this );
+  scrollArea->setWidget( wdgt );
+  scrollArea->setWidgetResizable( true );
+  scrollArea->setFrameShape( QFrame::NoFrame );
+  scrollArea->setFrameShadow( QFrame::Plain );
+
+  QVBoxLayout *layout2 = new QVBoxLayout();
+  layout2->setContentsMargins( 0, 0, 0, 0 );
+  layout2->addWidget( scrollArea );
+  setLayout( layout2 );
 
   cboRendererType = new QComboBox( this );
   cboRendererType->addItem( QgsApplication::getThemeIcon( QStringLiteral( "rendererNullSymbol.svg" ) ), tr( "No Symbols" ) );
   cboRendererType->addItem( QgsApplication::getThemeIcon( QStringLiteral( "rendererSingleSymbol.svg" ) ), tr( "Single Symbol" ) );
   cboRendererType->addItem( QgsApplication::getThemeIcon( QStringLiteral( "rendererRuleBasedSymbol.svg" ) ), tr( "Rule-based" ) );
-  layout->addWidget( cboRendererType );
-
-  widgetRendererStack = new QStackedWidget( this );
-  QgsVScrollArea *scrollArea = new QgsVScrollArea( this );
-  scrollArea->setFrameShape( QFrame::NoFrame );
-  layout->addWidget( scrollArea );
-  scrollArea->setWidget( widgetRendererStack );
 
   widgetBaseProperties = new QgsVectorLayer3DPropertiesWidget( this );
+
+  widgetRendererStack = new QStackedWidget( this );
+  layout->addWidget( cboRendererType );
+  layout->addWidget( widgetRendererStack );
   layout->addWidget( widgetBaseProperties );
 
   widgetNoRenderer = new QLabel;


### PR DESCRIPTION
to allow resizing and avoid dialog getting big when enabled (should fix #38134 )
![3dscrolls](https://user-images.githubusercontent.com/7983394/90477171-36f39d80-e12b-11ea-8101-b55e8dd13d0b.png)


I'm however seeing an issue with the shading group for line and point features (not polygons), in that it shrinks if the dialog is reduced. If any hint where I should look...
![3dpointshrinks](https://user-images.githubusercontent.com/7983394/90477276-686c6900-e12b-11ea-8cfd-aacb28eec13a.png)

