### PR TITLE
allow users to unhide paths directly from browser (fix #22290)

### DIFF
--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -177,6 +177,7 @@ void QgsAppDirectoryItemGuiProvider::populateContextMenu( QgsDataItem *item, QMe
   QMenu *hiddenMenu = new QMenu( tr( "Hidden Items" ), menu );
   int count = 0;
   const QStringList hiddenPathList = settings.value( QStringLiteral( "/browser/hiddenPaths" ) ).toStringList();
+  static int MAX_HIDDEN_ENTRIES = 5;
   for ( const QString &path : hiddenPathList )
   {
     QAction *action = new QAction( QDir::toNativeSeparators( path ), hiddenMenu );
@@ -202,17 +203,23 @@ void QgsAppDirectoryItemGuiProvider::populateContextMenu( QgsDataItem *item, QMe
     } );
     hiddenMenu->addAction( action );
     count += 1;
-    if ( count == 5 )
+    if ( count == MAX_HIDDEN_ENTRIES )
     {
       break;
     }
   }
-  QAction *moreAction = new QAction( tr( "Show More…" ), hiddenMenu );
-  connect( moreAction, &QAction::triggered, this, [ = ]
+
+  if ( hiddenPathList.size() > MAX_HIDDEN_ENTRIES )
   {
-    QgisApp::instance()->showOptionsDialog( QgisApp::instance(), QStringLiteral( "mOptionsPageDataSources" ) );
-  } );
-  hiddenMenu->addAction( moreAction );
+    hiddenMenu->addSeparator();
+
+    QAction *moreAction = new QAction( tr( "Show More…" ), hiddenMenu );
+    connect( moreAction, &QAction::triggered, this, [ = ]
+    {
+      QgisApp::instance()->showOptionsDialog( QgisApp::instance(), QStringLiteral( "mOptionsPageDataSources" ) );
+    } );
+    hiddenMenu->addAction( moreAction );
+  }
   if ( count > 0 )
   {
     menu->addMenu( hiddenMenu );

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -179,7 +179,7 @@ void QgsAppDirectoryItemGuiProvider::populateContextMenu( QgsDataItem *item, QMe
   const QStringList hiddenPathList = settings.value( QStringLiteral( "/browser/hiddenPaths" ) ).toStringList();
   for ( const QString &path : hiddenPathList )
   {
-    QAction *action = new QAction( path, hiddenMenu );
+    QAction *action = new QAction( QDir::toNativeSeparators( path ), hiddenMenu );
     connect( action, &QAction::triggered, this, [ = ]
     {
       QgsSettings s;

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -174,6 +174,51 @@ void QgsAppDirectoryItemGuiProvider::populateContextMenu( QgsDataItem *item, QMe
   } );
   menu->addAction( hideAction );
 
+  QMenu *hiddenMenu = new QMenu( tr( "Hidden items" ), menu );
+  int count = 0;
+  const QStringList hiddenPathList = settings.value( QStringLiteral( "/browser/hiddenPaths" ) ).toStringList();
+  for ( const QString &path : hiddenPathList )
+  {
+    QAction *action = new QAction( path, hiddenMenu );
+    connect( action, &QAction::triggered, this, [ = ]
+    {
+      QString path = qobject_cast<QAction *>( sender() )->text();
+      QgsSettings s;
+      QStringList pathsList = s.value( QStringLiteral( "/browser/hiddenPaths" ) ).toStringList();
+      pathsList.removeAll( path );
+      s.setValue( QStringLiteral( "/browser/hiddenPaths" ), pathsList );
+
+      // get parent path and refresh corresponding node
+      int idx = path.lastIndexOf( QStringLiteral( "/" ) );
+      if ( idx != -1 && path.count( QStringLiteral( "/" ) ) > 1 )
+      {
+        path = path.left( idx );
+        QgisApp::instance()->browserModel()->refresh( path );
+      }
+      else
+      {
+        // top-level (drive or root) node
+        QgisApp::instance()->browserModel()->refreshDrives();
+      }
+    } );
+    hiddenMenu->addAction( action );
+    count += 1;
+    if ( count == 5 )
+    {
+      break;
+    }
+  }
+  QAction *moreAction = new QAction( tr( "Show More…" ), hiddenMenu );
+  connect( moreAction, &QAction::triggered, this, [ = ]
+  {
+    QgisApp::instance()->showOptionsDialog( QgisApp::instance(), QStringLiteral( "mOptionsPageDataSources" ) );
+  } );
+  hiddenMenu->addAction( moreAction );
+  if ( count > 0 )
+  {
+    menu->addMenu( hiddenMenu );
+  }
+
   QAction *fastScanAction = new QAction( tr( "Fast Scan this Directory" ), menu );
   connect( fastScanAction, &QAction::triggered, this, [ = ]
   {

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -174,7 +174,7 @@ void QgsAppDirectoryItemGuiProvider::populateContextMenu( QgsDataItem *item, QMe
   } );
   menu->addAction( hideAction );
 
-  QMenu *hiddenMenu = new QMenu( tr( "Hidden items" ), menu );
+  QMenu *hiddenMenu = new QMenu( tr( "Hidden Items" ), menu );
   int count = 0;
   const QStringList hiddenPathList = settings.value( QStringLiteral( "/browser/hiddenPaths" ) ).toStringList();
   for ( const QString &path : hiddenPathList )
@@ -182,7 +182,6 @@ void QgsAppDirectoryItemGuiProvider::populateContextMenu( QgsDataItem *item, QMe
     QAction *action = new QAction( path, hiddenMenu );
     connect( action, &QAction::triggered, this, [ = ]
     {
-      QString path = qobject_cast<QAction *>( sender() )->text();
       QgsSettings s;
       QStringList pathsList = s.value( QStringLiteral( "/browser/hiddenPaths" ) ).toStringList();
       pathsList.removeAll( path );
@@ -192,8 +191,8 @@ void QgsAppDirectoryItemGuiProvider::populateContextMenu( QgsDataItem *item, QMe
       int idx = path.lastIndexOf( QStringLiteral( "/" ) );
       if ( idx != -1 && path.count( QStringLiteral( "/" ) ) > 1 )
       {
-        path = path.left( idx );
-        QgisApp::instance()->browserModel()->refresh( path );
+        QString parentPath = path.left( idx );
+        QgisApp::instance()->browserModel()->refresh( parentPath );
       }
       else
       {


### PR DESCRIPTION
## Description

Currently the only way to unhide previously hidden path in Browser is to go to the Settings→ Options → Data sources and remove them from the list. Some users find this difficult and confusing as hidding path done directly from the browser. Proposed PR allows to unhide paths directly from the Browser to make this functionality more visible and accessible for users.

If there are hidden paths user will have new "Hidden items" submenu in the browser context menu with first 5 hidden path in it and "Show More…" entry. Clicking at the hidden path in this menu will unhide it, clicking at the "Show More…" entry will open QGIS settings dialog with "Data Sources" tab selected where user can review/unhide all hidden path.

![browser](https://user-images.githubusercontent.com/776954/90490728-a2e3ff00-e147-11ea-992b-b2db230e9850.gif)

Fixes #22290.