### PR TITLE
WMS Server: display visibilityChecked property of a layer in GetProjectSettings

### DIFF
--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -913,6 +913,7 @@ namespace QgsWms
         if ( projectSettings )
         {
           layerElem.setAttribute( QStringLiteral( "visible" ), treeNode->isVisible() );
+          layerElem.setAttribute( QStringLiteral( "visibilityChecked" ), treeNode->itemVisibilityChecked() );
           layerElem.setAttribute( QStringLiteral( "expanded" ), treeNode->isExpanded() );
         }
 

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -141,7 +141,7 @@ Content-Type: text/xml; charset=utf-8
    <BoundingBox maxy="5606043.446" maxx="913283.462" miny="5605986.581" CRS="EPSG:3857" minx="913170.942"/>
    <BoundingBox maxy="8.204165" maxx="44.901599" miny="8.203154" CRS="EPSG:4326" minx="44.901236"/>
    <TreeName>QGIS Test Project</TreeName>
-   <Layer geometryType="Point" queryable="1" displayField="id" visible="1" opacity="1" expanded="1">
+   <Layer geometryType="Point" queryable="1" displayField="id" visible="1" visibilityChecked="1" opacity="1" expanded="1">
     <Name>layer_with_short_name</Name>
     <Title>A Layer with a short name</Title>
     <Abstract>A Layer with an abstract</Abstract>
@@ -171,7 +171,7 @@ Content-Type: text/xml; charset=utf-8
      <Attribute precision="0" type="QString" editType="TextEdit" typeName="String" name="utf8nameè" comment="" length="13"/>
     </Attributes>
    </Layer>
-   <Layer queryable="1" visible="1" opacity="1" expanded="0">
+   <Layer queryable="1" visible="1" visibilityChecked="1" opacity="1" expanded="0">
     <Name>landsat</Name>
     <Title>landsat</Title>
     <CRS>CRS:84</CRS>
@@ -195,7 +195,7 @@ Content-Type: text/xml; charset=utf-8
     </Style>
     <TreeName>landsat</TreeName>
    </Layer>
-   <Layer geometryType="Point" queryable="1" displayField="name" visible="1" opacity="1" expanded="1">
+   <Layer geometryType="Point" queryable="1" displayField="name" visible="1" visibilityChecked="1" opacity="1" expanded="1">
     <Name>testlayer èé</Name>
     <Title>A test vector layer</Title>
     <Abstract>A test vector layer with unicode òà</Abstract>
@@ -225,7 +225,7 @@ Content-Type: text/xml; charset=utf-8
      <Attribute precision="0" type="QString" editType="TextEdit" typeName="String" name="utf8nameè" comment="" length="13"/>
     </Attributes>
    </Layer>
-   <Layer geometryType="Point" queryable="1" displayField="alias_name" visible="1" opacity="1" expanded="1">
+   <Layer geometryType="Point" queryable="1" displayField="alias_name" visible="1" visibilityChecked="1" opacity="1" expanded="1">
     <Name>fields_alias</Name>
     <Title>A test vector layer</Title>
     <Abstract>A test vector layer with unicode òà</Abstract>
@@ -255,7 +255,7 @@ Content-Type: text/xml; charset=utf-8
      <Attribute precision="0" type="QString" editType="TextEdit" typeName="String" name="utf8nameè" comment="" length="13"/>
     </Attributes>
    </Layer>
-   <Layer geometryType="Point" queryable="1" displayField="name" visible="1" opacity="1" expanded="1">
+   <Layer geometryType="Point" queryable="1" displayField="name" visible="1" visibilityChecked="1" opacity="1" expanded="1">
     <Name>exclude_attribute</Name>
     <Title>A test vector layer</Title>
     <Abstract>A test vector layer with unicode òà</Abstract>
@@ -284,7 +284,7 @@ Content-Type: text/xml; charset=utf-8
      <Attribute precision="0" type="QString" editType="TextEdit" typeName="String" name="utf8nameè" comment="" length="13"/>
     </Attributes>
    </Layer>
-   <Layer mutuallyExclusive="0" visible="1" queryable="1" expanded="1">
+   <Layer mutuallyExclusive="0" visible="1" visibilityChecked="1" queryable="1" expanded="1">
     <Name>group_name</Name>
     <Title>Group title</Title>
     <Abstract>Group abstract</Abstract>
@@ -300,7 +300,7 @@ Content-Type: text/xml; charset=utf-8
     <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
     <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
     <TreeName>groupwithshortname</TreeName>
-    <Layer geometryType="Point" queryable="1" displayField="id" visible="1" opacity="1" expanded="1">
+    <Layer geometryType="Point" queryable="1" displayField="id" visible="1" visibilityChecked="1" opacity="1" expanded="1">
      <Name>testlayer2</Name>
      <Title>testlayer2</Title>
      <CRS>CRS:84</CRS>
@@ -330,7 +330,7 @@ Content-Type: text/xml; charset=utf-8
      </Attributes>
     </Layer>
    </Layer>
-   <Layer mutuallyExclusive="0" queryable="0" visible="1" expanded="1">
+   <Layer mutuallyExclusive="0" queryable="0" visible="1" visibilityChecked="1" expanded="1">
     <Name>groupwithoutshortname</Name>
     <Title>groupwithoutshortname</Title>
     <CRS>CRS:84</CRS>
@@ -345,7 +345,7 @@ Content-Type: text/xml; charset=utf-8
     <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
     <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
     <TreeName>groupwithoutshortname</TreeName>
-    <Layer geometryType="Point" queryable="0" displayField="name" visible="1" opacity="1" expanded="1">
+    <Layer geometryType="Point" queryable="0" displayField="name" visible="1" visibilityChecked="1" opacity="1" expanded="1">
      <Name>testlayer3</Name>
      <Title>testlayer3</Title>
      <CRS>CRS:84</CRS>

--- a/tests/testdata/qgis_server/getprojectsettings_opacity.txt
+++ b/tests/testdata/qgis_server/getprojectsettings_opacity.txt
@@ -141,7 +141,7 @@ Content-Type: text/xml; charset=utf-8
    <BoundingBox maxy="5606043.446" maxx="913283.462" miny="5605986.581" CRS="EPSG:3857" minx="913170.942"/>
    <BoundingBox maxy="8.204165" maxx="44.901599" miny="8.203154" CRS="EPSG:4326" minx="44.901236"/>
    <TreeName>QGIS Test Project</TreeName>
-   <Layer geometryType="Point" queryable="1" displayField="id" visible="1" opacity="1" expanded="1">
+   <Layer geometryType="Point" queryable="1" displayField="id" visible="1" visibilityChecked="1" opacity="1" expanded="1">
     <Name>layer_with_short_name</Name>
     <Title>A Layer with a short name</Title>
     <Abstract>A Layer with an abstract</Abstract>
@@ -171,7 +171,7 @@ Content-Type: text/xml; charset=utf-8
      <Attribute precision="0" type="QString" editType="TextEdit" typeName="String" name="utf8nameè" comment="" length="13"/>
     </Attributes>
    </Layer>
-   <Layer queryable="1" visible="1" opacity="1" expanded="0">
+   <Layer queryable="1" visible="1" visibilityChecked="1" opacity="1" expanded="0">
     <Name>landsat</Name>
     <Title>landsat</Title>
     <CRS>CRS:84</CRS>
@@ -195,7 +195,7 @@ Content-Type: text/xml; charset=utf-8
     </Style>
     <TreeName>landsat</TreeName>
    </Layer>
-   <Layer geometryType="Point" queryable="1" displayField="name" visible="1" opacity="0.5" expanded="1">
+   <Layer geometryType="Point" queryable="1" displayField="name" visible="1" visibilityChecked="1" opacity="0.5" expanded="1">
     <Name>testlayer èé</Name>
     <Title>A test vector layer</Title>
     <Abstract>A test vector layer with unicode òà</Abstract>
@@ -225,7 +225,7 @@ Content-Type: text/xml; charset=utf-8
      <Attribute precision="0" type="QString" editType="TextEdit" typeName="String" name="utf8nameè" comment="" length="13"/>
     </Attributes>
    </Layer>
-   <Layer geometryType="Point" queryable="1" displayField="alias_name" visible="1" opacity="1" expanded="1">
+   <Layer geometryType="Point" queryable="1" displayField="alias_name" visible="1" visibilityChecked="1" opacity="1" expanded="1">
     <Name>fields_alias</Name>
     <Title>A test vector layer</Title>
     <Abstract>A test vector layer with unicode òà</Abstract>
@@ -255,7 +255,7 @@ Content-Type: text/xml; charset=utf-8
      <Attribute precision="0" type="QString" editType="TextEdit" typeName="String" name="utf8nameè" comment="" length="13"/>
     </Attributes>
    </Layer>
-   <Layer geometryType="Point" queryable="1" displayField="name" visible="1" opacity="1" expanded="1">
+   <Layer geometryType="Point" queryable="1" displayField="name" visible="1" visibilityChecked="1" opacity="1" expanded="1">
     <Name>exclude_attribute</Name>
     <Title>A test vector layer</Title>
     <Abstract>A test vector layer with unicode òà</Abstract>
@@ -284,7 +284,7 @@ Content-Type: text/xml; charset=utf-8
      <Attribute precision="0" type="QString" editType="TextEdit" typeName="String" name="utf8nameè" comment="" length="13"/>
     </Attributes>
    </Layer>
-   <Layer mutuallyExclusive="0" visible="1" queryable="1" expanded="1">
+   <Layer mutuallyExclusive="0" visible="1" visibilityChecked="1" queryable="1" expanded="1">
     <Name>group_name</Name>
     <Title>Group title</Title>
     <Abstract>Group abstract</Abstract>
@@ -300,7 +300,7 @@ Content-Type: text/xml; charset=utf-8
     <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
     <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
     <TreeName>groupwithshortname</TreeName>
-    <Layer geometryType="Point" queryable="1" displayField="id" visible="1" opacity="1" expanded="1">
+    <Layer geometryType="Point" queryable="1" displayField="id" visible="1" visibilityChecked="1" opacity="1" expanded="1">
      <Name>testlayer2</Name>
      <Title>testlayer2</Title>
      <CRS>CRS:84</CRS>
@@ -330,7 +330,7 @@ Content-Type: text/xml; charset=utf-8
      </Attributes>
     </Layer>
    </Layer>
-   <Layer mutuallyExclusive="0" queryable="0" visible="1" expanded="1">
+   <Layer mutuallyExclusive="0" queryable="0" visible="1" visibilityChecked="1" expanded="1">
     <Name>groupwithoutshortname</Name>
     <Title>groupwithoutshortname</Title>
     <CRS>CRS:84</CRS>
@@ -345,7 +345,7 @@ Content-Type: text/xml; charset=utf-8
     <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
     <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
     <TreeName>groupwithoutshortname</TreeName>
-    <Layer geometryType="Point" queryable="0" displayField="name" visible="1" opacity="0.8" expanded="1">
+    <Layer geometryType="Point" queryable="0" displayField="name" visible="1" visibilityChecked="1" opacity="0.8" expanded="1">
      <Name>testlayer3</Name>
      <Title>testlayer3</Title>
      <CRS>CRS:84</CRS>


### PR DESCRIPTION
In QGIS, a layer can be checked but still invisible if the parent group is not visible (the layer is then kind of greyed out). To allow the webclient mimic this behaviour, it needs additional information in the GetProjectSettings response. This PR adds 'visiilityChecked' in addition to 'visible'.