### PR TITLE
Do not add SplitFeatures to undo stack if no features are split

### DIFF
--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -95,7 +95,14 @@ void QgsMapToolSplitFeatures::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     int topologicalEditing = QgsProject::instance()->topologicalEditing();
     vlayer->beginEditCommand( tr( "Features split" ) );
     QgsGeometry::OperationResult returnCode = vlayer->splitFeatures( captureCurve(), true, topologicalEditing );
-    vlayer->endEditCommand();
+    if ( returnCode == QgsGeometry::OperationResult::Success )
+    {
+      vlayer->endEditCommand();
+    }
+    else
+    {
+      vlayer->destroyEditCommand();
+    }
     if ( returnCode == QgsGeometry::OperationResult::NothingHappened )
     {
       QgisApp::instance()->messageBar()->pushMessage(

--- a/src/core/qgsvectorlayereditutils.cpp
+++ b/src/core/qgsvectorlayereditutils.cpp
@@ -391,10 +391,8 @@ QgsGeometry::OperationResult QgsVectorLayerEditUtils::splitFeatures( const QgsCu
     }
   }
 
-  if ( numberOfSplitFeatures == 0 && !selectedIds.isEmpty() )
+  if ( numberOfSplitFeatures == 0 )
   {
-    //There is a selection but no feature has been split.
-    //Maybe user forgot that only the selected features are split
     returnCode = QgsGeometry::OperationResult::NothingHappened;
   }
 


### PR DESCRIPTION
This changes QgsVectorLayerEditUtils::splitFeatures to always return
NothingHappened if no features are split. The current code only does this when
there is an active selection, but this misses the case where the curve drawn by
the user does not intersect any features.

This also changes QgsMapToolSplitFeatures::cadCanvasReleaseEvent to call
QgsVectorLayer::destroyEditCommand if the splitFeatures command fails.
Currently, we always call QgsVectorLayer::endEditCommand, which will cause
the command to be added to the undo stack even if it fails.

Fixes #38287