### PR TITLE
Typo corrected. Added one space

### DIFF
--- a/python/plugins/processing/algs/qgis/FieldPyculator.py
+++ b/python/plugins/processing/algs/qgis/FieldPyculator.py
@@ -117,7 +117,7 @@ class FieldsPyculator(QgisAlgorithm):
                 exec(bytecode, new_ns)
             except:
                 raise QgsProcessingException(
-                    self.tr("FieldPyculator code execute error.Global code block can't be executed!\n{0}\n{1}").format(
+                    self.tr("FieldPyculator code execute error. Global code block can't be executed!\n{0}\n{1}").format(
                         str(sys.exc_info()[0].__name__), str(sys.exc_info()[1])))
 
         # Replace all fields tags


### PR DESCRIPTION
Line 120 :  "FieldPyculator code execute error.Global code block can't be executed!\n{0}\n{1}" " should probably be
                  "FieldPyculator code execute error. Global code block can't be executed!\n{0}\n{1}" "
Added one space between "error." and "Gobal"

## Description

Goal : Display correct documentation.

Semantic is not right on these sentences. There should be a space after the dot (.) behind "error". Space added before "Global"

Not sure if this should be backported, I suspect it has to be.
