### PR TITLE
Improve native item_id variable_help

### DIFF
--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -750,7 +750,7 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts()->insert( QStringLiteral( "atlas_geometry" ), QCoreApplication::translate( "variable_help", "Current atlas feature geometry." ) );
 
   //layout item variables
-  sVariableHelpTexts()->insert( QStringLiteral( "item_id" ), QCoreApplication::translate( "variable_help", "Layout item user ID (not necessarily unique)." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "item_id" ), QCoreApplication::translate( "variable_help", "Layout item user-assigned ID (not necessarily unique)." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "item_uuid" ), QCoreApplication::translate( "variable_help", "layout item unique ID." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "item_left" ), QCoreApplication::translate( "variable_help", "Left position of layout item (in mm)." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "item_top" ), QCoreApplication::translate( "variable_help", "Top position of layout item (in mm)." ) );


### PR DESCRIPTION
## Description

This is a small PR, just to improve the readability of the `item_id` native help, used on layout expressions.

I've found out that the Portuguese translation uses the literal "user ID" translation. The `item_id` has nothing to do with the usual `userid` meaning.

I think the translations can be improved if we use `user-assigned ID` instead of `user ID`, _but I'm not a native English speaker_.

If the native speakers are comfortable with the current description, I'll just improve the translation. 

### Note for Portuguese speakers

I think the translation should be:
- ID atribuído pelo utilizador ao item da composição (não necessariamente único).

instead of:
- ID do utilizador do item da composição (não necessariamente único).