### PR TITLE
Allow adding new features via attribute form

### DIFF
--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -171,6 +171,8 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
      * add feature
      */
     void mActionAddFeature_triggered();
+    void mActionAddFeatureViaAttributeTable_triggered();
+    void mActionAddFeatureViaAttributeForm_triggered();
 
     void mActionExpressionSelect_triggered();
 

--- a/src/ui/qgsattributetabledialog.ui
+++ b/src/ui/qgsattributetabledialog.ui
@@ -532,6 +532,27 @@
     <string>Organize Columns</string>
    </property>
   </action>
+  <action name="mActionAddFeatureViaAttributeTable">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionNewTableRow.svg</normaloff>:/images/themes/default/mActionNewTableRow.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Add feature via attribute table</string>
+   </property>
+  </action>
+  <action name="mActionAddFeatureViaAttributeForm">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mIconFormSelect.svg</normaloff>:/images/themes/default/mIconFormSelect.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Add feature via attribute form</string>
+   </property>
+   <property name="toolTip">
+    <string>Add feature via attribute form</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>


### PR DESCRIPTION
Addresses to fix #37846. See also the proposed 

The attribute table is already a complex enough, so a possible solution changing there is hard enough. Also little to no change for backporting. Note the behaviour in the described bug is only present when in "Project properties" the checkbox "Automatically create transaction groups where possible" is checked.

The proposed solution is:
> Make the current "Add feature" button to have a little arrow with two actions: "Add feature via attribute form" and "Add feature via attribute table". By default we have the latter, but when transaction mode is enabled, it is disabled and only the "Add feature via attribute form" is enabled. This will be minimal and backportable code and UI layout change which will overcome the attribute table limitations, as well as adding the convinience of using the attribute form when desired. As a bonus, the button remembers the last selection of action - add via form or via table.

![Peek 2020-08-20 10-46](https://user-images.githubusercontent.com/2820439/90732068-34cc4300-e2d3-11ea-82db-ed408785a142.gif)

Even though it might feel as a duplication of form view in the attribute table, it is a change that touches the least amount of code and allows using the attribute table to add new features when they don't match the constraint. Which also makes the solution backportable.
