### PR TITLE
Make relation reference in filter work again

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
@@ -143,7 +143,7 @@ void QgsRelationReferenceSearchWidgetWrapper::onValueChanged( const QVariant &va
 
 void QgsRelationReferenceSearchWidgetWrapper::onValuesChanged( const QVariantList &values )
 {
-  if ( !values.isEmpty() )
+  if ( values.isEmpty() )
   {
     clearExpression();
     emit valueCleared();


### PR DESCRIPTION
I think it has been a typo negating the check for empty value.
 
Now it clears expression only on empty value and sets expression when there is a changed value.

This fixes #37843

Still we can think about a better Relation Reference Search Widget more looking like the Value Relation Search Widget with having as the default set value an invalid value "Please Select", but not as part of t his fix.