### PR TITLE
[QgsQuick] Reset feature layer pair after deleting a feature.

### DIFF
--- a/src/quickgui/attributes/qgsquickattributemodel.cpp
+++ b/src/quickgui/attributes/qgsquickattributemodel.cpp
@@ -200,12 +200,18 @@ bool QgsQuickAttributeModel::deleteFeature()
     rv = false;
   }
 
-  if ( !mFeatureLayerPair.layer()->deleteFeature( mFeatureLayerPair.feature().id() ) )
+  bool isDeleted = mFeatureLayerPair.layer()->deleteFeature( mFeatureLayerPair.feature().id() );
+  rv = commit();
+
+  if ( !isDeleted )
     QgsMessageLog::logMessage( tr( "Cannot delete feature" ),
                                QStringLiteral( "QgsQuick" ),
                                Qgis::Warning );
-
-  rv = commit();
+  else
+  {
+    mFeatureLayerPair = QgsQuickFeatureLayerPair();
+    emit featureLayerPairChanged();
+  }
 
   return rv;
 }


### PR DESCRIPTION
Improvement of QgsQuickAttributeModel: when a delete feature is called, a reference to featureLayerPair is still set and therefore outdated. This fix sets the pair to empty pair after a removal is committed to the layer data. It is basically cleaning reference after feature is deleted.