### PR TITLE
[QgsQuick] Photo panel path fix

### DIFF
--- a/src/quickgui/plugin/qgsquickphotopanel.qml
+++ b/src/quickgui/plugin/qgsquickphotopanel.qml
@@ -211,8 +211,7 @@ Drawer {
           onClicked: {
             captureItem.saveImage = true
             photoPanel.visible = false
-            photoPanel.lastPhotoName = QgsQuick.Utils.getRelativePath(camera.imageCapture.capturedImagePath, photoPanel.prefixToRelativePath)
-            confirmButtonClicked(photoPanel.prefixToRelativePath, photoPanel.lastPhotoName)
+            confirmButtonClicked(photoPanel.prefixToRelativePath, camera.imageCapture.capturedImagePath)
           }
         }
 


### PR DESCRIPTION
Relative path should be handled in external resource handler. Photo panel should provide full path to taken image.