### PR TITLE
Use zero to represent not applicable precision

### DIFF
--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -1646,22 +1646,22 @@ bool QgsDb2Provider::convertField( QgsField &field )
 
     case QVariant::DateTime:
       fieldType = QStringLiteral( "TIMESTAMP" );
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
     case QVariant::Date:
       fieldType = QStringLiteral( "DATE" );
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
     case QVariant::Time:
       fieldType = QStringLiteral( "TIME" );
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
     case QVariant::String:
       fieldType = QStringLiteral( "VARCHAR" );
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
     case QVariant::Int:
@@ -1675,7 +1675,7 @@ bool QgsDb2Provider::convertField( QgsField &field )
       {
         fieldType = QStringLiteral( "DOUBLE" );
         fieldSize = -1;
-        fieldPrec = -1;
+        fieldPrec = 0;
       }
       else
       {

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -1667,22 +1667,22 @@ bool QgsMssqlProvider::convertField( QgsField &field )
 
     case QVariant::DateTime:
       fieldType = QStringLiteral( "datetime" );
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
     case QVariant::Date:
       fieldType = QStringLiteral( "date" );
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
     case QVariant::Time:
       fieldType = QStringLiteral( "time" );
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
     case QVariant::String:
       fieldType = QStringLiteral( "nvarchar(max)" );
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
     case QVariant::Int:
@@ -1696,7 +1696,7 @@ bool QgsMssqlProvider::convertField( QgsField &field )
       {
         fieldType = QStringLiteral( "float" );
         fieldSize = -1;
-        fieldPrec = -1;
+        fieldPrec = 0;
       }
       else
       {

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -2873,19 +2873,19 @@ bool QgsOracleProvider::convertField( QgsField &field )
 
     case QVariant::DateTime:
       fieldType = "TIMESTAMP";
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
 
     case QVariant::Time:
     case QVariant::String:
       fieldType = "VARCHAR2(2047)";
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
     case QVariant::Date:
       fieldType = "DATE";
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
     case QVariant::Int:
@@ -2899,7 +2899,7 @@ bool QgsOracleProvider::convertField( QgsField &field )
       {
         fieldType = "BINARY_DOUBLE";
         fieldSize = -1;
-        fieldPrec = -1;
+        fieldPrec = 0;
       }
       else
       {

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -935,7 +935,7 @@ bool QgsPostgresProvider::loadFields()
 
     Oid fldtyp = result.PQftype( i );
     int fldMod = result.PQfmod( i );
-    int fieldPrec = -1;
+    int fieldPrec = 0;
     Oid tableoid = result.PQftable( i );
     int attnum = result.PQftablecol( i );
     Oid atttypid = attTypeIdMap[tableoid][attnum];
@@ -990,7 +990,7 @@ bool QgsPostgresProvider::loadFields()
       {
         fieldType = QVariant::Double;
         fieldSize = -1;
-        fieldPrec = -1;
+        fieldPrec = 0;
       }
       else if ( fieldTypeName == QLatin1String( "numeric" ) )
       {
@@ -999,7 +999,7 @@ bool QgsPostgresProvider::loadFields()
         if ( formattedFieldType == QLatin1String( "numeric" ) || formattedFieldType.isEmpty() )
         {
           fieldSize = -1;
-          fieldPrec = -1;
+          fieldPrec = 0;
         }
         else
         {
@@ -1016,7 +1016,7 @@ bool QgsPostgresProvider::loadFields()
                                              fieldName ),
                                        tr( "PostGIS" ) );
             fieldSize = -1;
-            fieldPrec = -1;
+            fieldPrec = 0;
           }
         }
       }
@@ -1086,7 +1086,7 @@ bool QgsPostgresProvider::loadFields()
                        .arg( formattedFieldType,
                              fieldName ) );
           fieldSize = -1;
-          fieldPrec = -1;
+          fieldPrec = 0;
         }
       }
       else if ( fieldTypeName == QLatin1String( "char" ) )
@@ -1104,7 +1104,7 @@ bool QgsPostgresProvider::loadFields()
                                      .arg( formattedFieldType,
                                            fieldName ) );
           fieldSize = -1;
-          fieldPrec = -1;
+          fieldPrec = 0;
         }
       }
       else if ( fieldTypeName == QLatin1String( "hstore" ) ||  fieldTypeName == QLatin1String( "json" ) || fieldTypeName == QLatin1String( "jsonb" ) )
@@ -2752,7 +2752,7 @@ bool QgsPostgresProvider::addAttributes( const QList<QgsField> &attributes )
       }
       else if ( type == QLatin1String( "numeric" ) || type == QLatin1String( "decimal" ) )
       {
-        if ( iter->length() > 0 && iter->precision() >= 0 )
+        if ( iter->length() > 0 && iter->precision() > 0 )
           type = QStringLiteral( "%1(%2,%3)" ).arg( type ).arg( iter->length() ).arg( iter->precision() );
       }
       sql.append( QStringLiteral( "%1ADD COLUMN %2 %3" ).arg( delim, quotedIdentifier( iter->name() ), type ) );
@@ -4097,7 +4097,7 @@ bool QgsPostgresProvider::convertField( QgsField &field, const QMap<QString, QVa
 
     case QVariant::String:
       fieldType = stringFieldType;
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
     case QVariant::Int:
@@ -4114,12 +4114,12 @@ bool QgsPostgresProvider::convertField( QgsField &field, const QMap<QString, QVa
       fieldType = field.typeName();
       if ( fieldType.isEmpty() )
         fieldType = QStringLiteral( "hstore" );
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
     case QVariant::StringList:
       fieldType = QStringLiteral( "_text" );
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
     case QVariant::List:
@@ -4127,7 +4127,7 @@ bool QgsPostgresProvider::convertField( QgsField &field, const QMap<QString, QVa
       QgsField sub( QString(), field.subType(), QString(), fieldSize, fieldPrec );
       if ( !convertField( sub, nullptr ) ) return false;
       fieldType = "_" + sub.typeName();
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
     }
 
@@ -4141,18 +4141,18 @@ bool QgsPostgresProvider::convertField( QgsField &field, const QMap<QString, QVa
       {
         fieldType = QStringLiteral( "float8" );
       }
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
     case QVariant::Bool:
       fieldType = QStringLiteral( "bool" );
-      fieldPrec = -1;
-      fieldSize = -1;
+      fieldPrec = 0;
+      fieldSize = 0;
       break;
 
     case QVariant::ByteArray:
       fieldType = QStringLiteral( "bytea" );
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
     default:

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -4147,7 +4147,7 @@ bool QgsPostgresProvider::convertField( QgsField &field, const QMap<QString, QVa
     case QVariant::Bool:
       fieldType = QStringLiteral( "bool" );
       fieldPrec = 0;
-      fieldSize = 0;
+      fieldSize = -1;
       break;
 
     case QVariant::ByteArray:

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
@@ -1583,7 +1583,7 @@ bool QgsPostgresRasterProvider::loadFields()
 
     Oid fldtyp = result.PQftype( i );
     int fldMod = result.PQfmod( i );
-    int fieldPrec = -1;
+    int fieldPrec = 0;
     Oid tableoid = result.PQftable( i );
     int attnum = result.PQftablecol( i );
     Oid atttypid = attTypeIdMap[tableoid][attnum];
@@ -1638,7 +1638,7 @@ bool QgsPostgresRasterProvider::loadFields()
       {
         fieldType = QVariant::Double;
         fieldSize = -1;
-        fieldPrec = -1;
+        fieldPrec = 0;
       }
       else if ( fieldTypeName == QLatin1String( "numeric" ) )
       {
@@ -1647,7 +1647,7 @@ bool QgsPostgresRasterProvider::loadFields()
         if ( formattedFieldType == QLatin1String( "numeric" ) || formattedFieldType.isEmpty() )
         {
           fieldSize = -1;
-          fieldPrec = -1;
+          fieldPrec = 0;
         }
         else
         {
@@ -1664,7 +1664,7 @@ bool QgsPostgresRasterProvider::loadFields()
                                              fieldName ),
                                        tr( "PostGIS" ) );
             fieldSize = -1;
-            fieldPrec = -1;
+            fieldPrec = 0;
           }
         }
       }
@@ -1734,7 +1734,7 @@ bool QgsPostgresRasterProvider::loadFields()
                        .arg( formattedFieldType,
                              fieldName ) );
           fieldSize = -1;
-          fieldPrec = -1;
+          fieldPrec = 0;
         }
       }
       else if ( fieldTypeName == QLatin1String( "char" ) )
@@ -1752,7 +1752,7 @@ bool QgsPostgresRasterProvider::loadFields()
                                      .arg( formattedFieldType,
                                            fieldName ) );
           fieldSize = -1;
-          fieldPrec = -1;
+          fieldPrec = 0;
         }
       }
       else if ( fieldTypeName == QLatin1String( "hstore" ) ||  fieldTypeName == QLatin1String( "json" ) || fieldTypeName == QLatin1String( "jsonb" ) )

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -79,7 +79,7 @@ bool QgsSpatiaLiteProvider::convertField( QgsField &field )
     case QVariant::Time:
     case QVariant::String:
       fieldType = QStringLiteral( "TEXT" );
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
     case QVariant::Int:
@@ -93,7 +93,7 @@ bool QgsSpatiaLiteProvider::convertField( QgsField &field )
       {
         fieldType = QStringLiteral( "REAL" );
         fieldSize = -1;
-        fieldPrec = -1;
+        fieldPrec = 0;
       }
       else
       {
@@ -117,7 +117,7 @@ bool QgsSpatiaLiteProvider::convertField( QgsField &field )
     case QVariant::ByteArray:
       fieldType = QStringLiteral( "BLOB" );
       fieldSize = -1;
-      fieldPrec = -1;
+      fieldPrec = 0;
       break;
 
     default:


### PR DESCRIPTION
The documentation for QgsField states that zero should be used for
an unset precision, but the database providers use -1 in some places
for that purpose.

Fixes #38360

## Description

It would have been less work to change the field editor to use -1 for unset values, but the documentation for QgsField is clear that 0 represents an unset value. I tested these changes manually using the field editor and spatialite and postgis, but I don't have access to DB2, MSSQL or Oracle to test the changes there.