### PR TITLE
Landing page settings

### DIFF
--- a/python/server/auto_additions/qgsserversettings.py
+++ b/python/server/auto_additions/qgsserversettings.py
@@ -1,0 +1,3 @@
+# The following has been generated automatically from src/server/qgsserversettings.h
+QgsServerSettingsEnv.Source.baseClass = QgsServerSettingsEnv
+QgsServerSettingsEnv.EnvVar.baseClass = QgsServerSettingsEnv

--- a/python/server/auto_generated/qgsserversettings.sip.in
+++ b/python/server/auto_generated/qgsserversettings.sip.in
@@ -11,6 +11,44 @@
 
 
 
+class QgsServerSettingsEnv : QObject
+{
+
+%TypeHeaderCode
+#include "qgsserversettings.h"
+%End
+  public:
+    enum Source
+    {
+      DEFAULT_VALUE,
+      ENVIRONMENT_VARIABLE,
+      INI_FILE
+    };
+
+    enum EnvVar
+    {
+      QGIS_OPTIONS_PATH,
+      QGIS_SERVER_PARALLEL_RENDERING,
+      QGIS_SERVER_MAX_THREADS,
+      QGIS_SERVER_LOG_LEVEL,
+      QGIS_SERVER_LOG_FILE,
+      QGIS_SERVER_LOG_STDERR,
+      QGIS_PROJECT_FILE,
+      MAX_CACHE_LAYERS,
+      QGIS_SERVER_IGNORE_BAD_LAYERS,
+      QGIS_SERVER_CACHE_DIRECTORY,
+      QGIS_SERVER_CACHE_SIZE,
+      QGIS_SERVER_SHOW_GROUP_SEPARATOR,
+      QGIS_SERVER_OVERRIDE_SYSTEM_LOCALE,
+      QGIS_SERVER_WMS_MAX_HEIGHT,
+      QGIS_SERVER_WMS_MAX_WIDTH,
+      QGIS_SERVER_API_RESOURCES_DIRECTORY,
+      QGIS_SERVER_API_WFS3_MAX_LIMIT,
+      QGIS_SERVER_TRUST_LAYER_METADATA,
+      QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES,
+      QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS
+    };
+};
 
 class QgsServerSettings
 {
@@ -155,7 +193,7 @@ Returns the server-wide max width of a WMS GetMap request. The lower one of this
 .. versionadded:: 3.6.2
 %End
 
-    QString projectsDirectories() const;
+    QString landingPageProjectsDirectories() const;
 %Docstring
 Returns the directories used by the landing page service to find .qgs
 and .qgz projects. Multiple directories can be specified by separating
@@ -164,7 +202,7 @@ them with '||'.
 .. versionadded:: 3.16
 %End
 
-    QString projectsPgConnections() const;
+    QString landingPageProjectsPgConnections() const;
 %Docstring
 Returns the PostgreSQL connection strings used by the landing page
 service to find projects. Multiple connections can be specified by

--- a/python/server/auto_generated/qgsserversettings.sip.in
+++ b/python/server/auto_generated/qgsserversettings.sip.in
@@ -157,16 +157,18 @@ Returns the server-wide max width of a WMS GetMap request. The lower one of this
 
     QString projectsDirectories() const;
 %Docstring
-Returns the directory used by the landing page service to find .qgs and
-.qgz projects.
+Returns the directories used by the landing page service to find .qgs
+and .qgz projects. Multiple directories can be specified by separating
+them with '||'.
 
 .. versionadded:: 3.16
 %End
 
     QString projectsPgConnections() const;
 %Docstring
-Returns the PostgreSQL connection string used by the landing page
-service to find projects.
+Returns the PostgreSQL connection strings used by the landing page
+service to find projects. Multiple connections can be specified by
+separating them with '||'.
 
 .. versionadded:: 3.16
 %End

--- a/python/server/auto_generated/qgsserversettings.sip.in
+++ b/python/server/auto_generated/qgsserversettings.sip.in
@@ -50,6 +50,7 @@ Provides some enum describing the environment currently supported for configurat
       QGIS_SERVER_API_RESOURCES_DIRECTORY,
       QGIS_SERVER_API_WFS3_MAX_LIMIT,
       QGIS_SERVER_TRUST_LAYER_METADATA,
+      QGIS_SERVER_DISABLE_GETPRINT,
       QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES,
       QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS
     };
@@ -257,7 +258,6 @@ variable QGIS_SERVER_TRUST_LAYER_METADATA.
 .. versionadded:: 3.16
 %End
 
-<<<<<<< HEAD
     bool getPrintDisabled() const;
 %Docstring
 Returns ``True`` if WMS GetPrint request is disabled and the project's
@@ -265,11 +265,13 @@ reading flag DONT_LOAD_LAYOUTS is activated.
 
 The default value is ``False``, this value can be changed by setting the environment
 variable QGIS_SERVER_DISABLE_GETPRINT.
-=======
+
+.. versionadded:: 3.16
+%End
+
     static QString name( QgsServerSettingsEnv::EnvVar env );
 %Docstring
 Returns the string representation of a setting.
->>>>>>> 63c64d45a6... Add name method
 
 .. versionadded:: 3.16
 %End

--- a/python/server/auto_generated/qgsserversettings.sip.in
+++ b/python/server/auto_generated/qgsserversettings.sip.in
@@ -155,6 +155,22 @@ Returns the server-wide max width of a WMS GetMap request. The lower one of this
 .. versionadded:: 3.6.2
 %End
 
+    QString projectsDirectories() const;
+%Docstring
+Returns the directory used by the landing page service to find .qgs and
+.qgz projects.
+
+.. versionadded:: 3.16
+%End
+
+    QString projectsPgConnections() const;
+%Docstring
+Returns the PostgreSQL connection string used by the landing page
+service to find projects.
+
+.. versionadded:: 3.16
+%End
+
     QString apiResourcesDirectory() const;
 %Docstring
 Returns the server-wide base directory where HTML templates and static assets (e.g. images, js and css files) are searched for.

--- a/python/server/auto_generated/qgsserversettings.sip.in
+++ b/python/server/auto_generated/qgsserversettings.sip.in
@@ -214,6 +214,7 @@ variable QGIS_SERVER_TRUST_LAYER_METADATA.
 .. versionadded:: 3.16
 %End
 
+<<<<<<< HEAD
     bool getPrintDisabled() const;
 %Docstring
 Returns ``True`` if WMS GetPrint request is disabled and the project's
@@ -221,6 +222,11 @@ reading flag DONT_LOAD_LAYOUTS is activated.
 
 The default value is ``False``, this value can be changed by setting the environment
 variable QGIS_SERVER_DISABLE_GETPRINT.
+=======
+    static QString name( QgsServerSettingsEnv::EnvVar env );
+%Docstring
+Returns the string representation of a setting.
+>>>>>>> 63c64d45a6... Add name method
 
 .. versionadded:: 3.16
 %End

--- a/python/server/auto_generated/qgsserversettings.sip.in
+++ b/python/server/auto_generated/qgsserversettings.sip.in
@@ -13,6 +13,11 @@
 
 class QgsServerSettingsEnv : QObject
 {
+%Docstring
+Provides some enum describing the environment currently supported for configuration.
+
+.. versionadded:: 3.0
+%End
 
 %TypeHeaderCode
 #include "qgsserversettings.h"

--- a/src/server/qgsserverogcapi.h
+++ b/src/server/qgsserverogcapi.h
@@ -120,7 +120,7 @@ class SERVER_EXPORT QgsServerOgcApi : public QgsServerApi
     static const QMap<QgsServerOgcApi::ContentType, QStringList> contentTypeMimes() SIP_SKIP;
 
     /**
-     * Returns contenType specializations (e.g. JSON => [GEOJSON, OPENAPI3], XML => [GML])
+     * Returns contentType specializations (e.g. JSON => [GEOJSON, OPENAPI3], XML => [GML])
      * \note not available in Python bindings
      */
     static const QHash<QgsServerOgcApi::ContentType, QList<QgsServerOgcApi::ContentType> > contentTypeAliases() SIP_SKIP;

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -479,12 +479,12 @@ int QgsServerSettings::wmsMaxWidth() const
   return value( QgsServerSettingsEnv::QGIS_SERVER_WMS_MAX_WIDTH ).toInt();
 }
 
-QString QgsServerSettings::projectsDirectories() const
+QString QgsServerSettings::landingPageProjectsDirectories() const
 {
   return value( QgsServerSettingsEnv::QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES, true ).toString();
 }
 
-QString QgsServerSettings::projectsPgConnections() const
+QString QgsServerSettings::landingPageProjectsPgConnections() const
 {
   return value( QgsServerSettingsEnv::QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS, true ).toString();
 }

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -316,8 +316,7 @@ QVariant QgsServerSettings::value( QgsServerSettingsEnv::EnvVar envVar, bool act
 {
   if ( actual )
   {
-    const QMetaEnum metaEnum( QMetaEnum::fromType<QgsServerSettingsEnv::EnvVar>() );
-    const QString envValue( getenv( metaEnum.valueToKey( envVar ) ) );
+    const QString envValue( getenv( name( envVar ).toStdString().c_str() ) );
 
     if ( ! envValue.isEmpty() )
       return envValue;
@@ -382,16 +381,21 @@ void QgsServerSettings::prioritize( const QMap<QgsServerSettingsEnv::EnvVar, QSt
   }
 }
 
+QString QgsServerSettings::name( QgsServerSettingsEnv::EnvVar env )
+{
+  const QMetaEnum metaEnumEnv( QMetaEnum::fromType<QgsServerSettingsEnv::EnvVar>() );
+  return metaEnumEnv.valueToKey( env );
+}
+
 void QgsServerSettings::logSummary() const
 {
   const QMetaEnum metaEnumSrc( QMetaEnum::fromType<QgsServerSettingsEnv::Source>() );
-  const QMetaEnum metaEnumEnv( QMetaEnum::fromType<QgsServerSettingsEnv::EnvVar>() );
 
   QgsMessageLog::logMessage( "QGIS Server Settings: ", "Server", Qgis::Info );
   for ( Setting s : mSettings )
   {
     const QString src = metaEnumSrc.valueToKey( s.src );
-    const QString var = metaEnumEnv.valueToKey( s.envVar );
+    const QString var = name( s.envVar );
 
     const QString msg = "  - " + var + " / '" + s.iniKey + "' (" + s.descr + "): '" + value( s.envVar ).toString() + "' (read from " + src + ")";
     QgsMessageLog::logMessage( msg, "Server", Qgis::Info );

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -241,6 +241,18 @@ void QgsServerSettings::initSettings()
                                    };
 
   mSettings[ sApiWfs3MaxLimit.envVar ] = sApiWfs3MaxLimit;
+
+  // projects directory for landing page service
+  const Setting sProjectsDirectories = { QgsServerSettingsEnv::QGIS_SERVER_PROJECTS_DIRECTORIES,
+                                         QgsServerSettingsEnv::DEFAULT_VALUE,
+                                         QStringLiteral( "Directories used by the landing page service to find .qgs and .qgz projects" ),
+                                         QStringLiteral( "/qgis/server_projects_directories" ),
+                                         QVariant::String,
+                                         QVariant( "" ),
+                                         QVariant()
+                                       };
+
+  mSettings[ sProjectsDirectories.envVar ] = sProjectsDirectories;
 }
 
 void QgsServerSettings::load()

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -312,8 +312,17 @@ QMap<QgsServerSettingsEnv::EnvVar, QString> QgsServerSettings::getEnv() const
   return env;
 }
 
-QVariant QgsServerSettings::value( QgsServerSettingsEnv::EnvVar envVar ) const
+QVariant QgsServerSettings::value( QgsServerSettingsEnv::EnvVar envVar, bool actual ) const
 {
+  if ( actual )
+  {
+    const QMetaEnum metaEnum( QMetaEnum::fromType<QgsServerSettingsEnv::EnvVar>() );
+    const QString envValue( getenv( metaEnum.valueToKey( envVar ) ) );
+
+    if ( ! envValue.isEmpty() )
+      return envValue;
+  }
+
   if ( mSettings[ envVar ].src == QgsServerSettingsEnv::DEFAULT_VALUE )
   {
     return mSettings[ envVar ].defaultVal;
@@ -468,12 +477,12 @@ int QgsServerSettings::wmsMaxWidth() const
 
 QString QgsServerSettings::projectsDirectories() const
 {
-  return value( QgsServerSettingsEnv::QGIS_SERVER_PROJECTS_DIRECTORIES ).toString();
+  return value( QgsServerSettingsEnv::QGIS_SERVER_PROJECTS_DIRECTORIES, true ).toString();
 }
 
 QString QgsServerSettings::projectsPgConnections() const
 {
-  return value( QgsServerSettingsEnv::QGIS_SERVER_PROJECTS_PG_CONNECTIONS ).toString();
+  return value( QgsServerSettingsEnv::QGIS_SERVER_PROJECTS_PG_CONNECTIONS, true ).toString();
 }
 
 QString QgsServerSettings::apiResourcesDirectory() const

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -253,6 +253,18 @@ void QgsServerSettings::initSettings()
                                        };
 
   mSettings[ sProjectsDirectories.envVar ] = sProjectsDirectories;
+
+  // postgresql connection string for landing page service
+  const Setting sProjectsPgConnections = { QgsServerSettingsEnv::QGIS_SERVER_PROJECTS_PG_CONNECTIONS,
+                                           QgsServerSettingsEnv::DEFAULT_VALUE,
+                                           QStringLiteral( "PostgreSQL connection strings used by the landing page service to find projects" ),
+                                           QStringLiteral( "/qgis/server_projects_pg_connections" ),
+                                           QVariant::String,
+                                           QVariant( "" ),
+                                           QVariant()
+                                         };
+
+  mSettings[ sProjectsPgConnections.envVar ] = sProjectsPgConnections;
 }
 
 void QgsServerSettings::load()

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -442,6 +442,16 @@ int QgsServerSettings::wmsMaxWidth() const
   return value( QgsServerSettingsEnv::QGIS_SERVER_WMS_MAX_WIDTH ).toInt();
 }
 
+QString QgsServerSettings::projectsDirectories() const
+{
+  return value( QgsServerSettingsEnv::QGIS_SERVER_PROJECTS_DIRECTORIES ).toString();
+}
+
+QString QgsServerSettings::projectsPgConnections() const
+{
+  return value( QgsServerSettingsEnv::QGIS_SERVER_PROJECTS_PG_CONNECTIONS ).toString();
+}
+
 QString QgsServerSettings::apiResourcesDirectory() const
 {
   return value( QgsServerSettingsEnv::QGIS_SERVER_API_RESOURCES_DIRECTORY ).toString();

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -243,7 +243,7 @@ void QgsServerSettings::initSettings()
   mSettings[ sApiWfs3MaxLimit.envVar ] = sApiWfs3MaxLimit;
 
   // projects directory for landing page service
-  const Setting sProjectsDirectories = { QgsServerSettingsEnv::QGIS_SERVER_PROJECTS_DIRECTORIES,
+  const Setting sProjectsDirectories = { QgsServerSettingsEnv::QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES,
                                          QgsServerSettingsEnv::DEFAULT_VALUE,
                                          QStringLiteral( "Directories used by the landing page service to find .qgs and .qgz projects" ),
                                          QStringLiteral( "/qgis/server_projects_directories" ),
@@ -255,7 +255,7 @@ void QgsServerSettings::initSettings()
   mSettings[ sProjectsDirectories.envVar ] = sProjectsDirectories;
 
   // postgresql connection string for landing page service
-  const Setting sProjectsPgConnections = { QgsServerSettingsEnv::QGIS_SERVER_PROJECTS_PG_CONNECTIONS,
+  const Setting sProjectsPgConnections = { QgsServerSettingsEnv::QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS,
                                            QgsServerSettingsEnv::DEFAULT_VALUE,
                                            QStringLiteral( "PostgreSQL connection strings used by the landing page service to find projects" ),
                                            QStringLiteral( "/qgis/server_projects_pg_connections" ),
@@ -477,12 +477,12 @@ int QgsServerSettings::wmsMaxWidth() const
 
 QString QgsServerSettings::projectsDirectories() const
 {
-  return value( QgsServerSettingsEnv::QGIS_SERVER_PROJECTS_DIRECTORIES, true ).toString();
+  return value( QgsServerSettingsEnv::QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES, true ).toString();
 }
 
 QString QgsServerSettings::projectsPgConnections() const
 {
-  return value( QgsServerSettingsEnv::QGIS_SERVER_PROJECTS_PG_CONNECTIONS, true ).toString();
+  return value( QgsServerSettingsEnv::QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS, true ).toString();
 }
 
 QString QgsServerSettings::apiResourcesDirectory() const

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -275,6 +275,12 @@ class SERVER_EXPORT QgsServerSettings
      */
     bool getPrintDisabled() const;
 
+    /* 
+     * Returns the string representation of a setting.
+     * \since QGIS 3.16
+     */
+    static QString name( QgsServerSettingsEnv::EnvVar env );
+
   private:
     void initSettings();
     QVariant value( QgsServerSettingsEnv::EnvVar envVar, bool actual = false ) const;

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -275,7 +275,7 @@ class SERVER_EXPORT QgsServerSettings
 
   private:
     void initSettings();
-    QVariant value( QgsServerSettingsEnv::EnvVar envVar ) const;
+    QVariant value( QgsServerSettingsEnv::EnvVar envVar, bool actual = false ) const;
     QMap<QgsServerSettingsEnv::EnvVar, QString> getEnv() const;
     void loadQSettings( const QString &envOptPath ) const;
     void prioritize( const QMap<QgsServerSettingsEnv::EnvVar, QString> &env );

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -33,7 +33,7 @@
  * \brief Provides some enum describing the environment currently supported for configuration.
  * \since QGIS 3.0
  */
-#ifndef SIP_RUN
+// #ifndef SIP_RUN
 class SERVER_EXPORT QgsServerSettingsEnv : public QObject
 {
     Q_OBJECT
@@ -75,7 +75,7 @@ class SERVER_EXPORT QgsServerSettingsEnv : public QObject
     };
     Q_ENUM( EnvVar )
 };
-#endif
+// #endif
 
 /**
  * \ingroup server
@@ -213,7 +213,7 @@ class SERVER_EXPORT QgsServerSettings
      * them with '||'.
      * \since QGIS 3.16
      */
-    QString projectsDirectories() const;
+    QString landingPageProjectsDirectories() const;
 
     /**
      * Returns the PostgreSQL connection strings used by the landing page
@@ -221,7 +221,7 @@ class SERVER_EXPORT QgsServerSettings
      * separating them with '||'.
      * \since QGIS 3.16
      */
-    QString projectsPgConnections() const;
+    QString landingPageProjectsPgConnections() const;
 
     /**
      * Returns the server-wide base directory where HTML templates and static assets (e.g. images, js and css files) are searched for.

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -33,7 +33,6 @@
  * \brief Provides some enum describing the environment currently supported for configuration.
  * \since QGIS 3.0
  */
-// #ifndef SIP_RUN
 class SERVER_EXPORT QgsServerSettingsEnv : public QObject
 {
     Q_OBJECT
@@ -75,7 +74,6 @@ class SERVER_EXPORT QgsServerSettingsEnv : public QObject
     };
     Q_ENUM( EnvVar )
 };
-// #endif
 
 /**
  * \ingroup server

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -273,7 +273,7 @@ class SERVER_EXPORT QgsServerSettings
      */
     bool getPrintDisabled() const;
 
-    /* 
+    /**
      * Returns the string representation of a setting.
      * \since QGIS 3.16
      */

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -70,7 +70,7 @@ class SERVER_EXPORT QgsServerSettingsEnv : public QObject
       QGIS_SERVER_API_WFS3_MAX_LIMIT, //!< Maximum value for "limit" in a features request, defaults to 10000 (since QGIS 3.10).
       QGIS_SERVER_TRUST_LAYER_METADATA, //!< Trust layer metadata. Improves project read time. (since QGIS 3.16).
       QGIS_SERVER_DISABLE_GETPRINT //!< Disabled WMS GetPrint request and don't load layouts. Improves project read time. (since QGIS 3.16).
-      QGIS_SERVER_PROJECTS_DIRECTORIES, //!< Directory used by the landing page service to find .qgs and .qgz projects (since QGIS 3.16)
+      QGIS_SERVER_PROJECTS_DIRECTORIES, //!< Directories used by the landing page service to find .qgs and .qgz projects (since QGIS 3.16)
       QGIS_SERVER_PROJECTS_PG_CONNECTIONS //!< PostgreSQL connection string used by the landing page service to find projects (since QGIS 3.16)
     };
     Q_ENUM( EnvVar )

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -69,9 +69,9 @@ class SERVER_EXPORT QgsServerSettingsEnv : public QObject
       QGIS_SERVER_API_RESOURCES_DIRECTORY, //!< Base directory where HTML templates and static assets (e.g. images, js and css files) are searched for (since QGIS 3.10).
       QGIS_SERVER_API_WFS3_MAX_LIMIT, //!< Maximum value for "limit" in a features request, defaults to 10000 (since QGIS 3.10).
       QGIS_SERVER_TRUST_LAYER_METADATA, //!< Trust layer metadata. Improves project read time. (since QGIS 3.16).
-      QGIS_SERVER_DISABLE_GETPRINT //!< Disabled WMS GetPrint request and don't load layouts. Improves project read time. (since QGIS 3.16).
-      QGIS_SERVER_PROJECTS_DIRECTORIES, //!< Directories used by the landing page service to find .qgs and .qgz projects (since QGIS 3.16)
-      QGIS_SERVER_PROJECTS_PG_CONNECTIONS //!< PostgreSQL connection strings used by the landing page service to find projects (since QGIS 3.16)
+      QGIS_SERVER_DISABLE_GETPRINT, //!< Disabled WMS GetPrint request and don't load layouts. Improves project read time. (since QGIS 3.16).
+      QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES, //!< Directories used by the landing page service to find .qgs and .qgz projects (since QGIS 3.16)
+      QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS //!< PostgreSQL connection strings used by the landing page service to find projects (since QGIS 3.16)
     };
     Q_ENUM( EnvVar )
 };

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -71,7 +71,7 @@ class SERVER_EXPORT QgsServerSettingsEnv : public QObject
       QGIS_SERVER_TRUST_LAYER_METADATA, //!< Trust layer metadata. Improves project read time. (since QGIS 3.16).
       QGIS_SERVER_DISABLE_GETPRINT //!< Disabled WMS GetPrint request and don't load layouts. Improves project read time. (since QGIS 3.16).
       QGIS_SERVER_PROJECTS_DIRECTORIES, //!< Directories used by the landing page service to find .qgs and .qgz projects (since QGIS 3.16)
-      QGIS_SERVER_PROJECTS_PG_CONNECTIONS //!< PostgreSQL connection string used by the landing page service to find projects (since QGIS 3.16)
+      QGIS_SERVER_PROJECTS_PG_CONNECTIONS //!< PostgreSQL connection strings used by the landing page service to find projects (since QGIS 3.16)
     };
     Q_ENUM( EnvVar )
 };

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -70,6 +70,8 @@ class SERVER_EXPORT QgsServerSettingsEnv : public QObject
       QGIS_SERVER_API_WFS3_MAX_LIMIT, //!< Maximum value for "limit" in a features request, defaults to 10000 (since QGIS 3.10).
       QGIS_SERVER_TRUST_LAYER_METADATA, //!< Trust layer metadata. Improves project read time. (since QGIS 3.16).
       QGIS_SERVER_DISABLE_GETPRINT //!< Disabled WMS GetPrint request and don't load layouts. Improves project read time. (since QGIS 3.16).
+      QGIS_SERVER_PROJECTS_DIRECTORIES, //!< Directory used by the landing page service to find .qgs and .qgz projects (since QGIS 3.16)
+      QGIS_SERVER_PROJECTS_PG_CONNECTIONS //!< PostgreSQL connection string used by the landing page service to find projects (since QGIS 3.16)
     };
     Q_ENUM( EnvVar )
 };
@@ -204,6 +206,20 @@ class SERVER_EXPORT QgsServerSettings
      * \since QGIS 3.6.2
      */
     int wmsMaxWidth() const;
+
+    /**
+     * Returns the directory used by the landing page service to find .qgs and
+     * .qgz projects.
+     * \since QGIS 3.16
+     */
+    QString projectsDirectories() const;
+
+    /**
+     * Returns the PostgreSQL connection string used by the landing page
+     * service to find projects.
+     * \since QGIS 3.16
+     */
+    QString projectsPgConnections() const;
 
     /**
      * Returns the server-wide base directory where HTML templates and static assets (e.g. images, js and css files) are searched for.

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -208,15 +208,17 @@ class SERVER_EXPORT QgsServerSettings
     int wmsMaxWidth() const;
 
     /**
-     * Returns the directory used by the landing page service to find .qgs and
-     * .qgz projects.
+     * Returns the directories used by the landing page service to find .qgs
+     * and .qgz projects. Multiple directories can be specified by separating
+     * them with '||'.
      * \since QGIS 3.16
      */
     QString projectsDirectories() const;
 
     /**
-     * Returns the PostgreSQL connection string used by the landing page
-     * service to find projects.
+     * Returns the PostgreSQL connection strings used by the landing page
+     * service to find projects. Multiple connections can be specified by
+     * separating them with '||'.
      * \since QGIS 3.16
      */
     QString projectsPgConnections() const;

--- a/src/server/services/landingpage/qgslandingpage.cpp
+++ b/src/server/services/landingpage/qgslandingpage.cpp
@@ -109,7 +109,7 @@ class QgsLandingPageModule: public QgsServiceModule
                                                                };
       // Register handlers
       landingPageApi->registerHandler<QgsServerStaticHandler>( QStringLiteral( "/(?<staticFilePath>((css|js)/.*)|favicon.ico)$" ), QStringLiteral( "landingpage" ) );
-      landingPageApi->registerHandler<QgsLandingPageHandler>();
+      landingPageApi->registerHandler<QgsLandingPageHandler>( serverIface->serverSettings() );
       landingPageApi->registerHandler<QgsLandingPageMapHandler>();
 
       // Register API

--- a/src/server/services/landingpage/qgslandingpage.cpp
+++ b/src/server/services/landingpage/qgslandingpage.cpp
@@ -77,7 +77,7 @@ class QgsProjectLoaderFilter: public QgsServerFilter
       const auto handler { serverInterface()->requestHandler() };
       if ( handler->path().startsWith( QStringLiteral( "/project/" ) ) )
       {
-        const QString projectPath { QgsLandingPageUtils::projectUriFromUrl( handler->url() ) };
+        const QString projectPath { QgsLandingPageUtils::projectUriFromUrl( handler->url(), *serverInterface()->serverSettings() ) };
         if ( ! projectPath.isEmpty() )
         {
           qputenv( "QGIS_PROJECT_FILE", projectPath.toUtf8() );
@@ -110,7 +110,7 @@ class QgsLandingPageModule: public QgsServiceModule
       // Register handlers
       landingPageApi->registerHandler<QgsServerStaticHandler>( QStringLiteral( "/(?<staticFilePath>((css|js)/.*)|favicon.ico)$" ), QStringLiteral( "landingpage" ) );
       landingPageApi->registerHandler<QgsLandingPageHandler>( serverIface->serverSettings() );
-      landingPageApi->registerHandler<QgsLandingPageMapHandler>();
+      landingPageApi->registerHandler<QgsLandingPageMapHandler>( serverIface->serverSettings() );
 
       // Register API
       registry.registerApi( landingPageApi );

--- a/src/server/services/landingpage/qgslandingpagehandlers.cpp
+++ b/src/server/services/landingpage/qgslandingpagehandlers.cpp
@@ -76,7 +76,8 @@ json QgsLandingPageHandler::projectsData() const
 }
 
 
-QgsLandingPageMapHandler::QgsLandingPageMapHandler()
+QgsLandingPageMapHandler::QgsLandingPageMapHandler( const QgsServerSettings *settings )
+  : mSettings( settings )
 {
   setContentTypes( { QgsServerOgcApi::ContentType::JSON } );
 }
@@ -85,7 +86,7 @@ void QgsLandingPageMapHandler::handleRequest( const QgsServerApiContext &context
 {
   json data;
   data[ "links" ] = json::array();
-  const QString projectPath { QgsLandingPageUtils::projectUriFromUrl( context.request()->url().path() ) };
+  const QString projectPath { QgsLandingPageUtils::projectUriFromUrl( context.request()->url().path(), *mSettings ) };
   if ( projectPath.isEmpty() )
   {
     throw QgsServerApiNotFoundError( QStringLiteral( "Requested project hash not found!" ) );

--- a/src/server/services/landingpage/qgslandingpagehandlers.cpp
+++ b/src/server/services/landingpage/qgslandingpagehandlers.cpp
@@ -28,7 +28,8 @@
 #include <QDir>
 #include <QCryptographicHash>
 
-QgsLandingPageHandler::QgsLandingPageHandler()
+QgsLandingPageHandler::QgsLandingPageHandler( const QgsServerSettings *settings )
+  : mSettings( settings )
 {
   setContentTypes( { QgsServerOgcApi::ContentType::JSON, QgsServerOgcApi::ContentType::HTML } );
 }

--- a/src/server/services/landingpage/qgslandingpagehandlers.cpp
+++ b/src/server/services/landingpage/qgslandingpagehandlers.cpp
@@ -66,7 +66,7 @@ const QString QgsLandingPageHandler::templatePath( const QgsServerApiContext &co
 json QgsLandingPageHandler::projectsData() const
 {
   json j = json::array();
-  const auto availableProjects { QgsLandingPageUtils::projects( ) };
+  const auto availableProjects { QgsLandingPageUtils::projects( *mSettings ) };
   const auto constProjectKeys { availableProjects.keys() };
   for ( const auto &p : constProjectKeys )
   {

--- a/src/server/services/landingpage/qgslandingpagehandlers.h
+++ b/src/server/services/landingpage/qgslandingpagehandlers.h
@@ -18,6 +18,7 @@
 #ifndef QGS_LANDINGPAGE_HANDLERS_H
 #define QGS_LANDINGPAGE_HANDLERS_H
 
+#include "qgsserversettings.h"
 #include "qgsserverogcapihandler.h"
 #include "qgsfields.h"
 
@@ -32,7 +33,7 @@ class QgsLandingPageHandler: public QgsServerOgcApiHandler
 {
   public:
 
-    QgsLandingPageHandler( );
+    QgsLandingPageHandler( const QgsServerSettings *settings );
 
     void handleRequest( const QgsServerApiContext &context ) const override;
 
@@ -57,7 +58,7 @@ class QgsLandingPageHandler: public QgsServerOgcApiHandler
 
     json projectsData() const;
 
-
+    const QgsServerSettings *mSettings = nullptr;
 };
 
 

--- a/src/server/services/landingpage/qgslandingpagehandlers.h
+++ b/src/server/services/landingpage/qgslandingpagehandlers.h
@@ -69,7 +69,7 @@ class QgsLandingPageMapHandler: public QgsServerOgcApiHandler
 {
   public:
 
-    QgsLandingPageMapHandler( );
+    QgsLandingPageMapHandler( const QgsServerSettings *settings );
 
     void handleRequest( const QgsServerApiContext &context ) const override;
 
@@ -87,6 +87,10 @@ class QgsLandingPageMapHandler: public QgsServerOgcApiHandler
     }
     std::string linkTitle() const override { return "Map Viewer"; }
     QgsServerOgcApi::Rel linkType() const override { return QgsServerOgcApi::Rel::self; }
+
+  private:
+
+    const QgsServerSettings *mSettings = nullptr;
 };
 
 #endif // QGS_LANDINGPAGE_HANDLERS_H

--- a/src/server/services/landingpage/qgslandingpageutils.cpp
+++ b/src/server/services/landingpage/qgslandingpageutils.cpp
@@ -55,6 +55,7 @@ QMap<QString, QString> QgsLandingPageUtils::projects( const QgsServerSettings &s
 
 
   const QString projectDir { settings.projectsDirectories() };
+  QgsMessageLog::logMessage( QStringLiteral( "PROJECTS: %1" ).arg( projectDir ), QStringLiteral( "Landing Page" ), Qgis::MessageLevel::Info );
 
   // Clear cache if QGIS_SERVER_PROJECTS_DIRECTORIES has changed
   if ( projectDir != QGIS_SERVER_PROJECTS_DIRECTORIES )
@@ -639,12 +640,12 @@ json QgsLandingPageUtils::layerTree( const QgsProject &project, const QStringLis
   return harvest( project.layerTreeRoot(), QString() );
 }
 
-QString QgsLandingPageUtils::projectUriFromUrl( const QString &url )
+QString QgsLandingPageUtils::projectUriFromUrl( const QString &url, const QgsServerSettings &settings )
 {
   const auto match { QgsLandingPageUtils::PROJECT_HASH_RE.match( url ) };
   if ( match.hasMatch() )
   {
-    const auto availableProjects { QgsLandingPageUtils::projects() };
+    const auto availableProjects { QgsLandingPageUtils::projects( settings ) };
     return availableProjects.value( match.captured( QStringLiteral( "projectHash" ) ), QString() );
   }
   return QString();

--- a/src/server/services/landingpage/qgslandingpageutils.cpp
+++ b/src/server/services/landingpage/qgslandingpageutils.cpp
@@ -75,6 +75,7 @@ QMap<QString, QString> QgsLandingPageUtils::projects( const QgsServerSettings &s
   }
 
   // Scan QGIS_SERVER_PROJECTS_DIRECTORIES
+  const QString envDirName = QgsServerSettings::name( QgsServerSettingsEnv::QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES );
   if ( AVAILABLE_PROJECTS.isEmpty() )
   {
     const auto cProjectDirs { projectDir.split( QStringLiteral( "||" ) ) };
@@ -101,17 +102,18 @@ QMap<QString, QString> QgsLandingPageUtils::projects( const QgsServerSettings &s
         }
         else
         {
-          QgsMessageLog::logMessage( QStringLiteral( "QGIS_SERVER_PROJECTS_DIRECTORIES entry '%1' was not found: skipping." ).arg( path ), QStringLiteral( "Landing Page" ), Qgis::MessageLevel::Warning );
+          QgsMessageLog::logMessage( QStringLiteral( "%1 entry '%2' was not found: skipping." ).arg( envDirName ).arg( path ), QStringLiteral( "Landing Page" ), Qgis::MessageLevel::Warning );
         }
       }
       else
       {
-        QgsMessageLog::logMessage( QStringLiteral( "QGIS_SERVER_PROJECTS_DIRECTORIES empty path: skipping." ), QStringLiteral( "Landing Page" ), Qgis::MessageLevel::Warning );
+        QgsMessageLog::logMessage( QStringLiteral( "%1 empty path: skipping." ).arg( envDirName ), QStringLiteral( "Landing Page" ), Qgis::MessageLevel::Warning );
       }
     }
   }
 
   // PG projects (there is no watcher for PG: scan every time)
+  const QString envPgName = QgsServerSettings::name( QgsServerSettingsEnv::QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS );
   const auto storage { QgsApplication::instance()->projectStorageRegistry()->projectStorageFromType( QStringLiteral( "postgresql" ) ) };
   Q_ASSERT( storage );
   const auto cPgConnections { pgConnections.split( QStringLiteral( "||" ) ) };
@@ -132,12 +134,12 @@ QMap<QString, QString> QgsLandingPageUtils::projects( const QgsServerSettings &s
       }
       else
       {
-        QgsMessageLog::logMessage( QStringLiteral( "QGIS_SERVER_PROJECTS_PG_CONNECTIONS entry '%1' was not found or has not projects: skipping." ).arg( connectionString ), QStringLiteral( "Landing Page" ), Qgis::MessageLevel::Warning );
+        QgsMessageLog::logMessage( QStringLiteral( "%1 entry '%2' was not found or has not projects: skipping." ).arg( envPgName ).arg( connectionString ), QStringLiteral( "Landing Page" ), Qgis::MessageLevel::Warning );
       }
     }
     else
     {
-      QgsMessageLog::logMessage( QStringLiteral( "QGIS_SERVER_PROJECTS_PG_CONNECTIONS empty connection: skipping." ), QStringLiteral( "Landing Page" ), Qgis::MessageLevel::Warning );
+      QgsMessageLog::logMessage( QStringLiteral( "%1 empty connection: skipping." ).arg( envPgName ), QStringLiteral( "Landing Page" ), Qgis::MessageLevel::Warning );
     }
   }
 

--- a/src/server/services/landingpage/qgslandingpageutils.cpp
+++ b/src/server/services/landingpage/qgslandingpageutils.cpp
@@ -54,7 +54,7 @@ QMap<QString, QString> QgsLandingPageUtils::projects( const QgsServerSettings &s
   } );
 
 
-  const QString projectDir { settings.projectsDirectories() };
+  const QString projectDir { settings.landingPageProjectsDirectories() };
 
   // Clear cache if QGIS_SERVER_PROJECTS_DIRECTORIES has changed
   if ( projectDir != QGIS_SERVER_PROJECTS_DIRECTORIES )
@@ -65,7 +65,7 @@ QMap<QString, QString> QgsLandingPageUtils::projects( const QgsServerSettings &s
     dirWatcher.removePaths( cWatchedDirs );
   }
 
-  const QString pgConnections { settings.projectsPgConnections() };
+  const QString pgConnections { settings.landingPageProjectsPgConnections() };
 
   // Clear cache if QGIS_SERVER_PROJECTS_PG_CONNECTIONS has changed
   if ( pgConnections != QGIS_SERVER_PROJECTS_PG_CONNECTIONS )

--- a/src/server/services/landingpage/qgslandingpageutils.cpp
+++ b/src/server/services/landingpage/qgslandingpageutils.cpp
@@ -55,7 +55,6 @@ QMap<QString, QString> QgsLandingPageUtils::projects( const QgsServerSettings &s
 
 
   const QString projectDir { settings.projectsDirectories() };
-  QgsMessageLog::logMessage( QStringLiteral( "PROJECTS: %1" ).arg( projectDir ), QStringLiteral( "Landing Page" ), Qgis::MessageLevel::Info );
 
   // Clear cache if QGIS_SERVER_PROJECTS_DIRECTORIES has changed
   if ( projectDir != QGIS_SERVER_PROJECTS_DIRECTORIES )
@@ -67,7 +66,6 @@ QMap<QString, QString> QgsLandingPageUtils::projects( const QgsServerSettings &s
   }
 
   const QString pgConnections { settings.projectsPgConnections() };
-  QgsMessageLog::logMessage( QStringLiteral( "PGONNECTIONS: %1" ).arg( pgConnections ), QStringLiteral( "Landing Page" ), Qgis::MessageLevel::Info );
 
   // Clear cache if QGIS_SERVER_PROJECTS_PG_CONNECTIONS has changed
   if ( pgConnections != QGIS_SERVER_PROJECTS_PG_CONNECTIONS )

--- a/src/server/services/landingpage/qgslandingpageutils.cpp
+++ b/src/server/services/landingpage/qgslandingpageutils.cpp
@@ -36,7 +36,7 @@ QMap<QString, QString> QgsLandingPageUtils::AVAILABLE_PROJECTS;
 
 std::once_flag initDirWatcher;
 
-QMap<QString, QString> QgsLandingPageUtils::projects( )
+QMap<QString, QString> QgsLandingPageUtils::projects( const QgsServerSettings &settings )
 {
 
   static QString QGIS_SERVER_PROJECTS_DIRECTORIES;
@@ -54,7 +54,7 @@ QMap<QString, QString> QgsLandingPageUtils::projects( )
   } );
 
 
-  const QString projectDir { QString( qgetenv( "QGIS_SERVER_PROJECTS_DIRECTORIES" ) ) };
+  const QString projectDir { settings.projectsDirectories() };
 
   // Clear cache if QGIS_SERVER_PROJECTS_DIRECTORIES has changed
   if ( projectDir != QGIS_SERVER_PROJECTS_DIRECTORIES )

--- a/src/server/services/landingpage/qgslandingpageutils.cpp
+++ b/src/server/services/landingpage/qgslandingpageutils.cpp
@@ -66,7 +66,8 @@ QMap<QString, QString> QgsLandingPageUtils::projects( const QgsServerSettings &s
     dirWatcher.removePaths( cWatchedDirs );
   }
 
-  const QString pgConnections { QString( qgetenv( "QGIS_SERVER_PROJECTS_PG_CONNECTIONS" ) ) };
+  const QString pgConnections { settings.projectsPgConnections() };
+  QgsMessageLog::logMessage( QStringLiteral( "PGONNECTIONS: %1" ).arg( pgConnections ), QStringLiteral( "Landing Page" ), Qgis::MessageLevel::Info );
 
   // Clear cache if QGIS_SERVER_PROJECTS_PG_CONNECTIONS has changed
   if ( pgConnections != QGIS_SERVER_PROJECTS_PG_CONNECTIONS )

--- a/src/server/services/landingpage/qgslandingpageutils.h
+++ b/src/server/services/landingpage/qgslandingpageutils.h
@@ -21,6 +21,7 @@
 #include <QRegularExpression>
 
 #include "nlohmann/json_fwd.hpp"
+#include "qgsserversettings.h"
 
 #ifndef SIP_RUN
 using namespace nlohmann;
@@ -45,7 +46,7 @@ struct QgsLandingPageUtils
    *
    * \returns hash of project paths (or other storage identifiers) with a digest key
    */
-  static QMap<QString, QString> projects();
+  static QMap<QString, QString> projects( const QgsServerSettings &settings );
 
   /**
    * Returns project information for a given \a projectPath

--- a/src/server/services/landingpage/qgslandingpageutils.h
+++ b/src/server/services/landingpage/qgslandingpageutils.h
@@ -77,7 +77,7 @@ struct QgsLandingPageUtils
    * Extracts and returns the (possibly empty) project URI from the \a url path
    * by examining the project hash.
    */
-  static QString projectUriFromUrl( const QString &url );
+  static QString projectUriFromUrl( const QString &url, const QgsServerSettings &settings );
 
 };
 

--- a/tests/src/python/test_qgsserver_landingpage.py
+++ b/tests/src/python/test_qgsserver_landingpage.py
@@ -66,10 +66,10 @@ class QgsServerLandingPageTest(QgsServerAPITestBase):
 
         super().setUp()
         os.environ["QGIS_SERVER_DISABLED_APIS"] = ''
-        os.environ['QGIS_SERVER_PROJECTS_DIRECTORIES'] = '||'.join(self.directories)
+        os.environ['QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES'] = '||'.join(self.directories)
 
         if not os.environ.get('TRAVIS', False):
-            os.environ['QGIS_SERVER_PROJECTS_PG_CONNECTIONS'] = "postgresql://localhost:5432?sslmode=disable&dbname=landing_page_test&schema=public"
+            os.environ['QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS'] = "postgresql://localhost:5432?sslmode=disable&dbname=landing_page_test&schema=public"
 
     def test_landing_page_redirects(self):
         """Test landing page redirects"""
@@ -156,8 +156,8 @@ class QgsServerLandingPageTest(QgsServerAPITestBase):
     def test_landing_page_json_empty(self):
         """Test landing page in JSON format with no projects"""
 
-        os.environ['QGIS_SERVER_PROJECTS_DIRECTORIES'] = ''
-        os.environ['QGIS_SERVER_PROJECTS_PG_CONNECTIONS'] = ''
+        os.environ['QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES'] = ''
+        os.environ['QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS'] = ''
         request = QgsBufferServerRequest('http://server.qgis.org/index.json')
         self.compareApi(
             request, None, 'test_landing_page_empty_index.json', subdir='landingpage')

--- a/tests/src/python/test_qgsserver_settings.py
+++ b/tests/src/python/test_qgsserver_settings.py
@@ -17,7 +17,7 @@ from qgis.PyQt.QtCore import QCoreApplication
 
 from utilities import unitTestDataPath
 from qgis.testing import unittest
-from qgis.server import QgsServerSettings
+from qgis.server import QgsServerSettings, QgsServerSettingsEnv
 
 
 class TestQgsServerSettings(unittest.TestCase):
@@ -237,32 +237,37 @@ class TestQgsServerSettings(unittest.TestCase):
         os.environ.pop(env)
 
     def test_env_actual(self):
-        env = "QGIS_SERVER_PROJECTS_DIRECTORIES"
-        env2 = "QGIS_SERVER_PROJECTS_PG_CONNECTIONS"
+        env = "QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES"
+        env2 = "QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS"
 
         os.environ[env] = "/tmp/initial"
         os.environ[env2] = "pg:initial"
 
         # test intial value
         self.settings.load()
-        self.assertEqual(self.settings.projectsDirectories(), "/tmp/initial")
-        self.assertEqual(self.settings.projectsPgConnections(), "pg:initial")
+        self.assertEqual(self.settings.landingPageProjectsDirectories(), "/tmp/initial")
+        self.assertEqual(self.settings.landingPageProjectsPgConnections(), "pg:initial")
 
         # set new environment variable
         os.environ[env] = "/tmp/new"
         os.environ[env2] = "pg:new"
 
         # test new environment variable
-        self.assertEqual(self.settings.projectsDirectories(), "/tmp/new")
-        self.assertEqual(self.settings.projectsPgConnections(), "pg:new")
+        self.assertEqual(self.settings.landingPageProjectsDirectories(), "/tmp/new")
+        self.assertEqual(self.settings.landingPageProjectsPgConnections(), "pg:new")
 
         # current environment variable are popped
         os.environ.pop(env)
         os.environ.pop(env2)
 
         # fallback to initial values
-        self.assertEqual(self.settings.projectsDirectories(), "/tmp/initial")
-        self.assertEqual(self.settings.projectsPgConnections(), "pg:initial")
+        self.assertEqual(self.settings.landingPageProjectsDirectories(), "/tmp/initial")
+        self.assertEqual(self.settings.landingPageProjectsPgConnections(), "pg:initial")
+
+    def test_env_name(self):
+        env = QgsServerSettingsEnv.QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES
+        name = QgsServerSettings.name(env)
+        self.assertEqual(name, "QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES")
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsserver_settings.py
+++ b/tests/src/python/test_qgsserver_settings.py
@@ -236,6 +236,34 @@ class TestQgsServerSettings(unittest.TestCase):
         # clear environment
         os.environ.pop(env)
 
+    def test_env_actual(self):
+        env = "QGIS_SERVER_PROJECTS_DIRECTORIES"
+        env2 = "QGIS_SERVER_PROJECTS_PG_CONNECTIONS"
+
+        os.environ[env] = "/tmp/initial"
+        os.environ[env2] = "pg:initial"
+
+        # test intial value
+        self.settings.load()
+        self.assertEqual(self.settings.projectsDirectories(), "/tmp/initial")
+        self.assertEqual(self.settings.projectsPgConnections(), "pg:initial")
+
+        # set new environment variable
+        os.environ[env] = "/tmp/new"
+        os.environ[env2] = "pg:new"
+
+        # test new environment variable
+        self.assertEqual(self.settings.projectsDirectories(), "/tmp/new")
+        self.assertEqual(self.settings.projectsPgConnections(), "pg:new")
+
+        # current environment variable are popped
+        os.environ.pop(env)
+        os.environ.pop(env2)
+
+        # fallback to initial values
+        self.assertEqual(self.settings.projectsDirectories(), "/tmp/initial")
+        self.assertEqual(self.settings.projectsPgConnections(), "pg:initial")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

The brand new landing page service introduces two settings (`QGIS_SERVER_PROJECTS_DIRECTORIES` and `QGIS_SERVER_PROJECTS_PG_CONNECTIONS`) but they're defined in the service itself.

Due to the current implementation, those environment variables are taken into account when defined in the web server configuration, but NOT when defined in the boot environment of QGIS Server.

To fix this issue and to be consistent with other services and other QGIS Server settings (like the `QGIS_SERVER_WMS_MAX_WIDTH` for example), this PR proposes to manage these two new settings by the `QgsServerSettings` class.

BTW, to be fully consistent, these settings should be named `QGIS_SERVER_LANDING_PAGE_XXXXX`, but it's maybe too long... Opinions?