### PR TITLE
Allow Null in Relation Reference Search Widget

### DIFF
--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencesearchwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencesearchwidgetwrapper.sip.in
@@ -48,6 +48,12 @@ Returns a variant representing the current state of the widget.
 
     virtual QgsSearchWidgetWrapper::FilterFlags supportedFlags() const;
 
+
+    virtual QgsSearchWidgetWrapper::FilterFlags defaultFlags() const;
+
+%Docstring
+Returns the default flags (equalTo)
+%End
     virtual QString createExpression( QgsSearchWidgetWrapper::FilterFlags flags ) const;
 
 

--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
@@ -101,9 +101,17 @@ QString QgsRelationReferenceSearchWidgetWrapper::createExpression( QgsSearchWidg
     case QVariant::ULongLong:
     {
       if ( flags & EqualTo )
+      {
+        if ( v.isNull() )
+          return fieldName + " IS NULL";
         return fieldName + '=' + v.toString();
+      }
       else if ( flags & NotEqualTo )
+      {
+        if ( v.isNull() )
+          return fieldName + " IS NOT NULL";
         return fieldName + "<>" + v.toString();
+      }
       break;
     }
 
@@ -148,7 +156,7 @@ void QgsRelationReferenceSearchWidgetWrapper::onValueChanged( const QVariant &va
 
 void QgsRelationReferenceSearchWidgetWrapper::onValuesChanged( const QVariantList &values )
 {
-  if ( !values.isEmpty() )
+  if ( values.isEmpty() )
   {
     clearExpression();
     emit valueCleared();
@@ -215,7 +223,7 @@ void QgsRelationReferenceSearchWidgetWrapper::initWidget( QWidget *editor )
   // if no relation is given from the config, fetch one if there is only one available
   if ( !relation.isValid() && !layer()->referencingRelations( mFieldIdx ).isEmpty() && layer()->referencingRelations( mFieldIdx ).count() == 1 )
     relation = layer()->referencingRelations( mFieldIdx )[0];
-  mWidget->setRelation( relation, false );
+  mWidget->setRelation( relation, config( QStringLiteral( "AllowNULL" ) ).toBool() );
 
   mWidget->showIndeterminateState();
   connect( mWidget, &QgsRelationReferenceWidget::foreignKeysChanged, this, &QgsRelationReferenceSearchWidgetWrapper::onValuesChanged );

--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
@@ -72,6 +72,11 @@ QgsSearchWidgetWrapper::FilterFlags QgsRelationReferenceSearchWidgetWrapper::sup
   return EqualTo | NotEqualTo | IsNull | IsNotNull;
 }
 
+QgsSearchWidgetWrapper::FilterFlags QgsRelationReferenceSearchWidgetWrapper::defaultFlags() const
+{
+  return EqualTo;
+}
+
 QString QgsRelationReferenceSearchWidgetWrapper::createExpression( QgsSearchWidgetWrapper::FilterFlags flags ) const
 {
   QString fieldName = createFieldIdentifier();

--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.h
@@ -60,6 +60,11 @@ class GUI_EXPORT QgsRelationReferenceSearchWidgetWrapper : public QgsSearchWidge
     QString expression() const override;
     bool valid() const override;
     QgsSearchWidgetWrapper::FilterFlags supportedFlags() const override;
+
+    /**
+     * Returns the default flags (equalTo)
+     */
+    QgsSearchWidgetWrapper::FilterFlags defaultFlags() const override;
     QString createExpression( QgsSearchWidgetWrapper::FilterFlags flags ) const override;
 
   public slots:

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -196,6 +196,7 @@ void QgsRelationReferenceWidget::setRelation( const QgsRelation &relation, bool 
     }
     if ( mComboBox )
     {
+      mComboBox->setAllowNull( mAllowNull );
       mComboBox->setSourceLayer( mReferencedLayer );
       mComboBox->setIdentifierFields( mReferencedFields );
     }

--- a/tests/src/python/test_qgssearchwidgetwrapper.py
+++ b/tests/src/python/test_qgssearchwidgetwrapper.py
@@ -17,10 +17,12 @@ from qgis.gui import (QgsSearchWidgetWrapper,
                       QgsValueMapSearchWidgetWrapper,
                       QgsValueRelationSearchWidgetWrapper,
                       QgsCheckboxSearchWidgetWrapper,
-                      QgsDateTimeSearchWidgetWrapper)
+                      QgsDateTimeSearchWidgetWrapper,
+                      QgsRelationReferenceSearchWidgetWrapper)
 from qgis.core import (QgsVectorLayer,
                        QgsFeature,
                        QgsProject,
+                       QgsRelation
                        )
 from qgis.PyQt.QtCore import QDateTime, QDate, QTime
 from qgis.PyQt.QtWidgets import QWidget
@@ -337,6 +339,63 @@ class PyQgsDateTimeSearchWidgetWrapper(unittest.TestCase):
         self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.LessThan), '"datetime"<\'2013-04-05 13:14:15\'')
         self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.GreaterThanOrEqualTo), '"datetime">=\'2013-04-05 13:14:15\'')
         self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.LessThanOrEqualTo), '"datetime"<=\'2013-04-05 13:14:15\'')
+
+
+class PyQgsRelationReferenceSearchWidgetWrapper(unittest.TestCase):
+
+    def testCreateExpression(self):
+        """ Test creating an expression using the widget"""
+        layer = QgsVectorLayer("Point?field=fldtxt:string&field=fldint:integer", "test", "memory")
+        # setup value relation
+        parent_layer = QgsVectorLayer("Point?field=stringkey:string&field=intkey:integer&field=display:string", "parent", "memory")
+        f1 = QgsFeature(parent_layer.fields(), 1)
+        f1.setAttributes(['a', 1, 'value a'])
+        f2 = QgsFeature(parent_layer.fields(), 2)
+        f2.setAttributes(['b', 2, 'value b'])
+        f3 = QgsFeature(parent_layer.fields(), 3)
+        f3.setAttributes(['c', 3, 'value c'])
+        parent_layer.dataProvider().addFeatures([f1, f2, f3])
+        QgsProject.instance().addMapLayers([layer, parent_layer])
+
+        relationManager = QgsProject.instance().relationManager()
+        relation = QgsRelation()
+        relation.setId('relation')
+        relation.setReferencingLayer(layer.id())
+        relation.setReferencedLayer(parent_layer.id())
+        relation.addFieldPair('fldtxt', 'stringkey')
+        self.assertTrue(relation.isValid())
+
+        relationManager.addRelation(relation)
+
+        # Everything valid
+        config = {'Relation': relation.id(), 'AllowNULL': True}
+
+        w = QgsRelationReferenceSearchWidgetWrapper(layer, 0, None)
+        w.setConfig(config)
+
+        w.widget().setForeignKey('a')
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.IsNull), '"fldtxt" IS NULL')
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.IsNotNull), '"fldtxt" IS NOT NULL')
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.EqualTo), '"fldtxt"=\'a\'')
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.NotEqualTo), '"fldtxt"<>\'a\'')
+
+        w.widget().setForeignKey('b')
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.IsNull), '"fldtxt" IS NULL')
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.IsNotNull), '"fldtxt" IS NOT NULL')
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.EqualTo), '"fldtxt"=\'b\'')
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.NotEqualTo), '"fldtxt"<>\'b\'')
+
+        w.widget().setForeignKey('c')
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.IsNull), '"fldtxt" IS NULL')
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.IsNotNull), '"fldtxt" IS NOT NULL')
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.EqualTo), '"fldtxt"=\'c\'')
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.NotEqualTo), '"fldtxt"<>\'c\'')
+
+        w.widget().setForeignKey(None)
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.IsNull), '"fldtxt" IS NULL')
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.IsNotNull), '"fldtxt" IS NOT NULL')
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.EqualTo), '"fldtxt" IS NULL')
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.NotEqualTo), '"fldtxt" IS NOT NULL')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Having NULL available in the combo box on a field filter, getting back all features containing no FK.

Same in the _Select / Filter Feature Form (Ctrl+F)_ - means a NULL + Equal To is like the Flag "IS NULL".

Additionally in the _Select / Filter Feature Form (Ctrl+F)_ the "Equal To" flag is chosen as default as soon as the value changed (like in the Value Relation Widget) like suggested here  #37843
