### PR TITLE
[ui] Add save/load connections right click browser menu to a bunch of providers

### DIFF
--- a/src/gui/vectortile/qgsvectortiledataitemguiprovider.cpp
+++ b/src/gui/vectortile/qgsvectortiledataitemguiprovider.cpp
@@ -108,8 +108,8 @@ void QgsVectorTileDataItemGuiProvider::loadXyzTilesServers( QgsDataItem *item )
   }
 
   QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::VectorTile, fileName );
-  dlg.exec();
-  item->refreshConnections();
+  if ( dlg.exec() == QDialog::Accepted )
+    item->refreshConnections();
 }
 
 ///@endcond

--- a/src/providers/arcgisrest/qgsafsdataitemguiprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsdataitemguiprovider.cpp
@@ -16,10 +16,12 @@
 #include "qgsafsdataitemguiprovider.h"
 #include "qgsafsdataitems.h"
 #include "qgsafssourceselect.h"
+#include "qgsmanageconnectionsdialog.h"
 #include "qgsnewhttpconnection.h"
 #include "qgsowsconnection.h"
 
 #include <QDesktopServices>
+#include <QFileDialog>
 #include <QMessageBox>
 
 
@@ -30,6 +32,14 @@ void QgsAfsDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
     QAction *actionNew = new QAction( tr( "New Connection…" ), menu );
     connect( actionNew, &QAction::triggered, this, [rootItem] { newConnection( rootItem ); } );
     menu->addAction( actionNew );
+
+    QAction *actionSaveServers = new QAction( tr( "Save Connections…" ), this );
+    connect( actionSaveServers, &QAction::triggered, this, [] { saveConnections(); } );
+    menu->addAction( actionSaveServers );
+
+    QAction *actionLoadServers = new QAction( tr( "Load Connections…" ), this );
+    connect( actionLoadServers, &QAction::triggered, this, [rootItem] { loadConnections( rootItem ); } );
+    menu->addAction( actionLoadServers );
   }
   else if ( QgsAfsConnectionItem *connectionItem = qobject_cast< QgsAfsConnectionItem * >( item ) )
   {
@@ -138,4 +148,24 @@ void QgsAfsDataItemGuiProvider::refreshConnection( QgsDataItem *item )
   // the parent should be updated
   if ( item->parent() )
     item->parent()->refreshConnections();
+}
+
+void QgsAfsDataItemGuiProvider::saveConnections()
+{
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Export, QgsManageConnectionsDialog::ArcgisFeatureServer );
+  dlg.exec();
+}
+
+void QgsAfsDataItemGuiProvider::loadConnections( QgsDataItem *item )
+{
+  QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Load Connections" ), QDir::homePath(),
+                     tr( "XML files (*.xml *.XML)" ) );
+  if ( fileName.isEmpty() )
+  {
+    return;
+  }
+
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::ArcgisFeatureServer, fileName );
+  dlg.exec();
+  item->refreshConnections();
 }

--- a/src/providers/arcgisrest/qgsafsdataitemguiprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsdataitemguiprovider.cpp
@@ -166,6 +166,6 @@ void QgsAfsDataItemGuiProvider::loadConnections( QgsDataItem *item )
   }
 
   QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::ArcgisFeatureServer, fileName );
-  dlg.exec();
-  item->refreshConnections();
+  if ( dlg.exec() == QDialog::Accepted )
+    item->refreshConnections();
 }

--- a/src/providers/arcgisrest/qgsafsdataitemguiprovider.h
+++ b/src/providers/arcgisrest/qgsafsdataitemguiprovider.h
@@ -40,6 +40,8 @@ class QgsAfsDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
     static void editConnection( QgsDataItem *item );
     static void deleteConnection( QgsDataItem *item );
     static void refreshConnection( QgsDataItem *item );
+    static void saveConnections();
+    static void loadConnections( QgsDataItem *item );
 };
 
 

--- a/src/providers/arcgisrest/qgsamsdataitemguiprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsdataitemguiprovider.cpp
@@ -153,6 +153,6 @@ void QgsAmsDataItemGuiProvider::loadConnections( QgsDataItem *item )
   }
 
   QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::ArcgisMapServer, fileName );
-  dlg.exec();
-  item->refreshConnections();
+  if ( dlg.exec() == QDialog::Accepted )
+    item->refreshConnections();
 }

--- a/src/providers/arcgisrest/qgsamsdataitemguiprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsdataitemguiprovider.cpp
@@ -15,10 +15,12 @@
 
 #include "qgsamsdataitemguiprovider.h"
 #include "qgsamsdataitems.h"
+#include "qgsmanageconnectionsdialog.h"
 #include "qgsnewhttpconnection.h"
 #include "qgsowsconnection.h"
 
 #include <QDesktopServices>
+#include <QFileDialog>
 #include <QMessageBox>
 
 
@@ -29,6 +31,14 @@ void QgsAmsDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
     QAction *actionNew = new QAction( tr( "New Connection…" ), menu );
     connect( actionNew, &QAction::triggered, this, [rootItem] { newConnection( rootItem ); } );
     menu->addAction( actionNew );
+
+    QAction *actionSaveServers = new QAction( tr( "Save Connections…" ), this );
+    connect( actionSaveServers, &QAction::triggered, this, [] { saveConnections(); } );
+    menu->addAction( actionSaveServers );
+
+    QAction *actionLoadServers = new QAction( tr( "Load Connections…" ), this );
+    connect( actionLoadServers, &QAction::triggered, this, [rootItem] { loadConnections( rootItem ); } );
+    menu->addAction( actionLoadServers );
   }
   if ( QgsAmsConnectionItem *connectionItem = qobject_cast< QgsAmsConnectionItem * >( item ) )
   {
@@ -125,4 +135,24 @@ void QgsAmsDataItemGuiProvider::refreshConnection( QgsDataItem *item )
   // the parent should be updated
   if ( item->parent() )
     item->parent()->refreshConnections();
+}
+
+void QgsAmsDataItemGuiProvider::saveConnections()
+{
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Export, QgsManageConnectionsDialog::ArcgisMapServer );
+  dlg.exec();
+}
+
+void QgsAmsDataItemGuiProvider::loadConnections( QgsDataItem *item )
+{
+  QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Load Connections" ), QDir::homePath(),
+                     tr( "XML files (*.xml *.XML)" ) );
+  if ( fileName.isEmpty() )
+  {
+    return;
+  }
+
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::ArcgisMapServer, fileName );
+  dlg.exec();
+  item->refreshConnections();
 }

--- a/src/providers/arcgisrest/qgsamsdataitemguiprovider.h
+++ b/src/providers/arcgisrest/qgsamsdataitemguiprovider.h
@@ -40,6 +40,8 @@ class QgsAmsDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
     static void editConnection( QgsDataItem *item );
     static void deleteConnection( QgsDataItem *item );
     static void refreshConnection( QgsDataItem *item );
+    static void saveConnections();
+    static void loadConnections( QgsDataItem *item );
 };
 
 

--- a/src/providers/db2/qgsdb2dataitemguiprovider.cpp
+++ b/src/providers/db2/qgsdb2dataitemguiprovider.cpp
@@ -139,6 +139,6 @@ void QgsDb2DataItemGuiProvider::loadConnections( QgsDataItem *item )
   }
 
   QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::DB2, fileName );
-  dlg.exec();
-  item->refreshConnections();
+  if ( dlg.exec() == QDialog::Accepted )
+    item->refreshConnections();
 }

--- a/src/providers/db2/qgsdb2dataitemguiprovider.cpp
+++ b/src/providers/db2/qgsdb2dataitemguiprovider.cpp
@@ -17,9 +17,10 @@
 #include "qgsdb2dataitems.h"
 #include "qgsdb2newconnection.h"
 #include "qgsdb2sourceselect.h"
-
+#include "qgsmanageconnectionsdialog.h"
 #include "qgssettings.h"
 
+#include <QFileDialog>
 
 void QgsDb2DataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu, const QList<QgsDataItem *> &, QgsDataItemGuiContext )
 {
@@ -28,6 +29,14 @@ void QgsDb2DataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
     QAction *actionNew = new QAction( tr( "New Connection…" ), menu );
     connect( actionNew, &QAction::triggered, this, [rootItem] { newConnection( rootItem ); } );
     menu->addAction( actionNew );
+
+    QAction *actionSaveServers = new QAction( tr( "Save Connections…" ), this );
+    connect( actionSaveServers, &QAction::triggered, this, [] { saveConnections(); } );
+    menu->addAction( actionSaveServers );
+
+    QAction *actionLoadServers = new QAction( tr( "Load Connections…" ), this );
+    connect( actionLoadServers, &QAction::triggered, this, [rootItem] { loadConnections( rootItem ); } );
+    menu->addAction( actionLoadServers );
   }
   else if ( QgsDb2ConnectionItem *connItem = qobject_cast< QgsDb2ConnectionItem * >( item ) )
   {
@@ -112,4 +121,24 @@ void QgsDb2DataItemGuiProvider::deleteConnection( QgsDataItem *item )
 void QgsDb2DataItemGuiProvider::refreshConnection( QgsDataItem *item )
 {
   item->refresh();
+}
+
+void QgsDb2DataItemGuiProvider::saveConnections()
+{
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Export, QgsManageConnectionsDialog::DB2 );
+  dlg.exec();
+}
+
+void QgsDb2DataItemGuiProvider::loadConnections( QgsDataItem *item )
+{
+  QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Load Connections" ), QDir::homePath(),
+                     tr( "XML files (*.xml *.XML)" ) );
+  if ( fileName.isEmpty() )
+  {
+    return;
+  }
+
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::DB2, fileName );
+  dlg.exec();
+  item->refreshConnections();
 }

--- a/src/providers/db2/qgsdb2dataitemguiprovider.h
+++ b/src/providers/db2/qgsdb2dataitemguiprovider.h
@@ -37,6 +37,8 @@ class QgsDb2DataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
     static void editConnection( QgsDataItem *item );
     static void deleteConnection( QgsDataItem *item );
     static void refreshConnection( QgsDataItem *item );
+    static void saveConnections();
+    static void loadConnections( QgsDataItem *item );
 };
 
 #endif // QGSDB2DATAITEMGUIPROVIDER_H

--- a/src/providers/geonode/qgsgeonodedataitemguiprovider.cpp
+++ b/src/providers/geonode/qgsgeonodedataitemguiprovider.cpp
@@ -97,6 +97,6 @@ void QgsGeoNodeDataItemGuiProvider::loadConnections( QgsDataItem *item )
   }
 
   QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::GeoNode, fileName );
-  dlg.exec();
-  item->refreshConnections();
+  if ( dlg.exec() == QDialog::Accepted )
+    item->refreshConnections();
 }

--- a/src/providers/geonode/qgsgeonodedataitemguiprovider.cpp
+++ b/src/providers/geonode/qgsgeonodedataitemguiprovider.cpp
@@ -16,7 +16,9 @@
 #include "qgsgeonodedataitemguiprovider.h"
 #include "qgsgeonodedataitems.h"
 #include "qgsgeonodenewconnection.h"
+#include "qgsmanageconnectionsdialog.h"
 
+#include <QFileDialog>
 #include <QMessageBox>
 
 void QgsGeoNodeDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu, const QList<QgsDataItem *> &, QgsDataItemGuiContext )
@@ -26,6 +28,14 @@ void QgsGeoNodeDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMen
     QAction *actionNew = new QAction( tr( "New Connection…" ), menu );
     connect( actionNew, &QAction::triggered, this, [rootItem] { newConnection( rootItem ); } );
     menu->addAction( actionNew );
+
+    QAction *actionSaveServers = new QAction( tr( "Save Connections…" ), this );
+    connect( actionSaveServers, &QAction::triggered, this, [] { saveConnections(); } );
+    menu->addAction( actionSaveServers );
+
+    QAction *actionLoadServers = new QAction( tr( "Load Connections…" ), this );
+    connect( actionLoadServers, &QAction::triggered, this, [rootItem] { loadConnections( rootItem ); } );
+    menu->addAction( actionLoadServers );
   }
   else if ( QgsGeoNodeConnectionItem *connItem = qobject_cast< QgsGeoNodeConnectionItem * >( item ) )
   {
@@ -69,4 +79,24 @@ void QgsGeoNodeDataItemGuiProvider::deleteConnection( QgsDataItem *item )
 
   QgsGeoNodeConnectionUtils::deleteConnection( item->name() );
   item->parent()->refresh();
+}
+
+void QgsGeoNodeDataItemGuiProvider::saveConnections()
+{
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Export, QgsManageConnectionsDialog::GeoNode );
+  dlg.exec();
+}
+
+void QgsGeoNodeDataItemGuiProvider::loadConnections( QgsDataItem *item )
+{
+  QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Load Connections" ), QDir::homePath(),
+                     tr( "XML files (*.xml *.XML)" ) );
+  if ( fileName.isEmpty() )
+  {
+    return;
+  }
+
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::GeoNode, fileName );
+  dlg.exec();
+  item->refreshConnections();
 }

--- a/src/providers/geonode/qgsgeonodedataitemguiprovider.h
+++ b/src/providers/geonode/qgsgeonodedataitemguiprovider.h
@@ -32,6 +32,8 @@ class QgsGeoNodeDataItemGuiProvider : public QObject, public QgsDataItemGuiProvi
     static void newConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
     static void deleteConnection( QgsDataItem *item );
+    static void saveConnections();
+    static void loadConnections( QgsDataItem *item );
 };
 
 #endif // QGSGEONODEDATAITEMGUIPROVIDER_H

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
@@ -244,6 +244,6 @@ void QgsMssqlDataItemGuiProvider::loadConnections( QgsDataItem *item )
   }
 
   QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::MSSQL, fileName );
-  dlg.exec();
-  item->refreshConnections();
+  if ( dlg.exec() == QDialog::Accepted )
+    item->refreshConnections();
 }

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
@@ -13,12 +13,14 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsmanageconnectionsdialog.h"
 #include "qgsmssqlconnection.h"
 #include "qgsmssqldataitemguiprovider.h"
 #include "qgsmssqldataitems.h"
 #include "qgsmssqlnewconnection.h"
 #include "qgsmssqlsourceselect.h"
 
+#include <QFileDialog>
 #include <QInputDialog>
 #include <QMessageBox>
 
@@ -30,6 +32,14 @@ void QgsMssqlDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu 
     QAction *actionNew = new QAction( tr( "New Connection…" ), menu );
     connect( actionNew, &QAction::triggered, this, [rootItem] { newConnection( rootItem ); } );
     menu->addAction( actionNew );
+
+    QAction *actionSaveServers = new QAction( tr( "Save Connections…" ), this );
+    connect( actionSaveServers, &QAction::triggered, this, [] { saveConnections(); } );
+    menu->addAction( actionSaveServers );
+
+    QAction *actionLoadServers = new QAction( tr( "Load Connections…" ), this );
+    connect( actionLoadServers, &QAction::triggered, this, [rootItem] { loadConnections( rootItem ); } );
+    menu->addAction( actionLoadServers );
   }
   else if ( QgsMssqlConnectionItem *connItem = qobject_cast< QgsMssqlConnectionItem * >( item ) )
   {
@@ -216,4 +226,24 @@ void QgsMssqlDataItemGuiProvider::truncateTable( QgsMssqlLayerItem *layerItem )
   {
     QMessageBox::information( nullptr, tr( "Truncate Table" ), tr( "Table truncated successfully." ) );
   }
+}
+
+void QgsMssqlDataItemGuiProvider::saveConnections()
+{
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Export, QgsManageConnectionsDialog::MSSQL );
+  dlg.exec();
+}
+
+void QgsMssqlDataItemGuiProvider::loadConnections( QgsDataItem *item )
+{
+  QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Load Connections" ), QDir::homePath(),
+                     tr( "XML files (*.xml *.XML)" ) );
+  if ( fileName.isEmpty() )
+  {
+    return;
+  }
+
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::MSSQL, fileName );
+  dlg.exec();
+  item->refreshConnections();
 }

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.h
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.h
@@ -42,6 +42,8 @@ class QgsMssqlDataItemGuiProvider : public QObject, public QgsDataItemGuiProvide
     static void deleteConnection( QgsDataItem *item );
     static void createSchema( QgsMssqlConnectionItem *connItem );
     static void truncateTable( QgsMssqlLayerItem *layerItem );
+    static void saveConnections();
+    static void loadConnections( QgsDataItem *item );
 };
 
 #endif // QGSMSSQLDATAITEMGUIPROVIDER_H

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -15,12 +15,14 @@
 
 #include "qgspostgresdataitemguiprovider.h"
 
+#include "qgsmanageconnectionsdialog.h"
 #include "qgspostgresdataitems.h"
 #include "qgspostgresprovider.h"
 #include "qgspgnewconnection.h"
 #include "qgsnewnamedialog.h"
 #include "qgspgsourceselect.h"
 
+#include <QFileDialog>
 #include <QInputDialog>
 #include <QMessageBox>
 
@@ -32,6 +34,14 @@ void QgsPostgresDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMe
     QAction *actionNew = new QAction( tr( "New Connection…" ), this );
     connect( actionNew, &QAction::triggered, this, [rootItem] { newConnection( rootItem ); } );
     menu->addAction( actionNew );
+
+    QAction *actionSaveServers = new QAction( tr( "Save Connections…" ), this );
+    connect( actionSaveServers, &QAction::triggered, this, [] { saveConnections(); } );
+    menu->addAction( actionSaveServers );
+
+    QAction *actionLoadServers = new QAction( tr( "Load Connections…" ), this );
+    connect( actionLoadServers, &QAction::triggered, this, [rootItem] { loadConnections( rootItem ); } );
+    menu->addAction( actionLoadServers );
   }
 
   if ( QgsPGConnectionItem *connItem = qobject_cast< QgsPGConnectionItem * >( item ) )
@@ -487,4 +497,24 @@ void QgsPostgresDataItemGuiProvider::refreshMaterializedView( QgsPGLayerItem *la
 
   conn->unref();
   QMessageBox::information( nullptr, tr( "Refresh View" ), tr( "Materialized view refreshed successfully." ) );
+}
+
+void QgsPostgresDataItemGuiProvider::saveConnections()
+{
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Export, QgsManageConnectionsDialog::PostGIS );
+  dlg.exec();
+}
+
+void QgsPostgresDataItemGuiProvider::loadConnections( QgsDataItem *item )
+{
+  QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Load Connections" ), QDir::homePath(),
+                     tr( "XML files (*.xml *.XML)" ) );
+  if ( fileName.isEmpty() )
+  {
+    return;
+  }
+
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::PostGIS, fileName );
+  dlg.exec();
+  item->refreshConnections();
 }

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -515,6 +515,6 @@ void QgsPostgresDataItemGuiProvider::loadConnections( QgsDataItem *item )
   }
 
   QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::PostGIS, fileName );
-  dlg.exec();
-  item->refreshConnections();
+  if ( dlg.exec() == QDialog::Accepted )
+    item->refreshConnections();
 }

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.h
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.h
@@ -49,6 +49,8 @@ class QgsPostgresDataItemGuiProvider : public QObject, public QgsDataItemGuiProv
     static void renameLayer( QgsPGLayerItem *layerItem );
     static void truncateTable( QgsPGLayerItem *layerItem );
     static void refreshMaterializedView( QgsPGLayerItem *layerItem );
+    static void saveConnections();
+    static void loadConnections( QgsDataItem *item );
 
 };
 

--- a/src/providers/wcs/qgswcsdataitemguiprovider.cpp
+++ b/src/providers/wcs/qgswcsdataitemguiprovider.cpp
@@ -15,10 +15,12 @@
 
 #include "qgswcsdataitemguiprovider.h"
 
+#include "qgsmanageconnectionsdialog.h"
 #include "qgswcsdataitems.h"
 #include "qgsnewhttpconnection.h"
 #include "qgsowsconnection.h"
 
+#include <QFileDialog>
 #include <QMessageBox>
 
 
@@ -29,6 +31,14 @@ void QgsWcsDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
     QAction *actionNew = new QAction( tr( "New Connection…" ), this );
     connect( actionNew, &QAction::triggered, this, [rootItem] { newConnection( rootItem ); } );
     menu->addAction( actionNew );
+
+    QAction *actionSaveServers = new QAction( tr( "Save Connections…" ), this );
+    connect( actionSaveServers, &QAction::triggered, this, [] { saveConnections(); } );
+    menu->addAction( actionSaveServers );
+
+    QAction *actionLoadServers = new QAction( tr( "Load Connections…" ), this );
+    connect( actionLoadServers, &QAction::triggered, this, [rootItem] { loadConnections( rootItem ); } );
+    menu->addAction( actionLoadServers );
   }
 
   if ( QgsWCSConnectionItem *connItem = qobject_cast< QgsWCSConnectionItem * >( item ) )
@@ -87,4 +97,24 @@ void QgsWcsDataItemGuiProvider::refreshConnection( QgsDataItem *item )
   // the parent should be updated
   if ( item->parent() )
     item->parent()->refreshConnections();
+}
+
+void QgsWcsDataItemGuiProvider::saveConnections()
+{
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Export, QgsManageConnectionsDialog::WCS );
+  dlg.exec();
+}
+
+void QgsWcsDataItemGuiProvider::loadConnections( QgsDataItem *item )
+{
+  QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Load Connections" ), QDir::homePath(),
+                     tr( "XML files (*.xml *.XML)" ) );
+  if ( fileName.isEmpty() )
+  {
+    return;
+  }
+
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::WCS, fileName );
+  dlg.exec();
+  item->refreshConnections();
 }

--- a/src/providers/wcs/qgswcsdataitemguiprovider.cpp
+++ b/src/providers/wcs/qgswcsdataitemguiprovider.cpp
@@ -115,6 +115,6 @@ void QgsWcsDataItemGuiProvider::loadConnections( QgsDataItem *item )
   }
 
   QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::WCS, fileName );
-  dlg.exec();
-  item->refreshConnections();
+  if ( dlg.exec() == QDialog::Accepted )
+    item->refreshConnections();
 }

--- a/src/providers/wcs/qgswcsdataitemguiprovider.h
+++ b/src/providers/wcs/qgswcsdataitemguiprovider.h
@@ -33,6 +33,8 @@ class QgsWcsDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
     static void editConnection( QgsDataItem *item );
     static void deleteConnection( QgsDataItem *item );
     static void refreshConnection( QgsDataItem *item );
+    static void saveConnections();
+    static void loadConnections( QgsDataItem *item );
 
 };
 

--- a/src/providers/wfs/qgswfsdataitemguiprovider.cpp
+++ b/src/providers/wfs/qgswfsdataitemguiprovider.cpp
@@ -15,11 +15,13 @@
 
 #include "qgswfsdataitemguiprovider.h"
 
+#include "qgsmanageconnectionsdialog.h"
 #include "qgsnewhttpconnection.h"
 #include "qgswfsconnection.h"
 #include "qgswfsconstants.h"
 #include "qgswfsdataitems.h"
 
+#include <QFileDialog>
 #include <QMessageBox>
 
 
@@ -30,6 +32,14 @@ void QgsWfsDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
     QAction *actionNew = new QAction( tr( "New Connection…" ), this );
     connect( actionNew, &QAction::triggered, this, [rootItem] { newConnection( rootItem ); } );
     menu->addAction( actionNew );
+
+    QAction *actionSaveServers = new QAction( tr( "Save Connections…" ), this );
+    connect( actionSaveServers, &QAction::triggered, this, [] { saveConnections(); } );
+    menu->addAction( actionSaveServers );
+
+    QAction *actionLoadServers = new QAction( tr( "Load Connections…" ), this );
+    connect( actionLoadServers, &QAction::triggered, this, [rootItem] { loadConnections( rootItem ); } );
+    menu->addAction( actionLoadServers );
   }
 
   if ( QgsWfsConnectionItem *connItem = qobject_cast< QgsWfsConnectionItem * >( item ) )
@@ -90,4 +100,24 @@ void QgsWfsDataItemGuiProvider::refreshConnection( QgsDataItem *item )
   // the parent should be updated
   if ( item->parent() )
     item->parent()->refreshConnections();
+}
+
+void QgsWfsDataItemGuiProvider::saveConnections()
+{
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Export, QgsManageConnectionsDialog::WFS );
+  dlg.exec();
+}
+
+void QgsWfsDataItemGuiProvider::loadConnections( QgsDataItem *item )
+{
+  QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Load Connections" ), QDir::homePath(),
+                     tr( "XML files (*.xml *.XML)" ) );
+  if ( fileName.isEmpty() )
+  {
+    return;
+  }
+
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::WFS, fileName );
+  dlg.exec();
+  item->refreshConnections();
 }

--- a/src/providers/wfs/qgswfsdataitemguiprovider.cpp
+++ b/src/providers/wfs/qgswfsdataitemguiprovider.cpp
@@ -118,6 +118,6 @@ void QgsWfsDataItemGuiProvider::loadConnections( QgsDataItem *item )
   }
 
   QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::WFS, fileName );
-  dlg.exec();
-  item->refreshConnections();
+  if ( dlg.exec() == QDialog::Accepted )
+    item->refreshConnections();
 }

--- a/src/providers/wfs/qgswfsdataitemguiprovider.h
+++ b/src/providers/wfs/qgswfsdataitemguiprovider.h
@@ -33,6 +33,8 @@ class QgsWfsDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
     static void editConnection( QgsDataItem *item );
     static void deleteConnection( QgsDataItem *item );
     static void refreshConnection( QgsDataItem *item );
+    static void saveConnections();
+    static void loadConnections( QgsDataItem *item );
 
 };
 

--- a/src/providers/wms/qgswmsdataitemguiproviders.cpp
+++ b/src/providers/wms/qgswmsdataitemguiproviders.cpp
@@ -133,8 +133,8 @@ void QgsWmsDataItemGuiProvider::loadConnections( QgsDataItem *item )
   }
 
   QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::WMS, fileName );
-  dlg.exec();
-  item->refreshConnections();
+  if ( dlg.exec() == QDialog::Accepted )
+    item->refreshConnections();
 }
 
 // -----------
@@ -224,6 +224,6 @@ void QgsXyzDataItemGuiProvider::loadXyzTilesServers( QgsDataItem *item )
   }
 
   QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::XyzTiles, fileName );
-  dlg.exec();
-  item->refreshConnections();
+  if ( dlg.exec() == QDialog::Accepted )
+    item->refreshConnections();
 }

--- a/src/providers/wms/qgswmsdataitemguiproviders.cpp
+++ b/src/providers/wms/qgswmsdataitemguiproviders.cpp
@@ -58,11 +58,19 @@ void QgsWmsDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
     menu->addAction( actionDelete );
   }
 
-  if ( QgsWMSRootItem *wmsRootItem = qobject_cast< QgsWMSRootItem * >( item ) )
+  if ( QgsWMSRootItem *rootItem = qobject_cast< QgsWMSRootItem * >( item ) )
   {
     QAction *actionNew = new QAction( tr( "New Connection…" ), this );
-    connect( actionNew, &QAction::triggered, this, [wmsRootItem] { newConnection( wmsRootItem ); } );
+    connect( actionNew, &QAction::triggered, this, [rootItem] { newConnection( rootItem ); } );
     menu->addAction( actionNew );
+
+    QAction *actionSaveServers = new QAction( tr( "Save Connections…" ), this );
+    connect( actionSaveServers, &QAction::triggered, this, [] { saveConnections(); } );
+    menu->addAction( actionSaveServers );
+
+    QAction *actionLoadServers = new QAction( tr( "Load Connections…" ), this );
+    connect( actionLoadServers, &QAction::triggered, this, [rootItem] { loadConnections( rootItem ); } );
+    menu->addAction( actionLoadServers );
   }
 }
 
@@ -109,6 +117,25 @@ void QgsWmsDataItemGuiProvider::refreshConnection( QgsDataItem *item )
   item->refresh();
 }
 
+void QgsWmsDataItemGuiProvider::saveConnections()
+{
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Export, QgsManageConnectionsDialog::WMS );
+  dlg.exec();
+}
+
+void QgsWmsDataItemGuiProvider::loadConnections( QgsDataItem *item )
+{
+  QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Load Connections" ), QDir::homePath(),
+                     tr( "XML files (*.xml *.XML)" ) );
+  if ( fileName.isEmpty() )
+  {
+    return;
+  }
+
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::WMS, fileName );
+  dlg.exec();
+  item->refreshConnections();
+}
 
 // -----------
 

--- a/src/providers/wms/qgswmsdataitemguiproviders.h
+++ b/src/providers/wms/qgswmsdataitemguiproviders.h
@@ -35,6 +35,8 @@ class QgsWmsDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
     static void editConnection( QgsDataItem *item );
     static void deleteConnection( QgsDataItem *item );
     static void newConnection( QgsDataItem *item );
+    static void saveConnections();
+    static void loadConnections( QgsDataItem *item );
 
 };
 


### PR DESCRIPTION
## Description

This PR insures that all supported providers have a save / load connections pair of actions when right clicking on their browser panel root item.

There's no reason to limit these super helpful UI actions to XYZ / vector tiles :) Having used this useful UI shortcut for XYZ tiles, I came to expect the same for other providers.