### PR TITLE
[processing] Add a cluster size attribute to the dbscan cluster algorithm

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/dbscan_5_2.gml
+++ b/python/plugins/processing/tests/testdata/expected/dbscan_5_2.gml
@@ -16,6 +16,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>-0.426063829787234,2.19255319148936</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID>1</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>7</ogr:CLUSTER_SIZE>
     </ogr:dbscan_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -23,6 +24,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1.45053191489362,1.96914893617021</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID>1</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>7</ogr:CLUSTER_SIZE>
     </ogr:dbscan_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -30,6 +32,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1.40585106382979,0.807446808510639</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID>1</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>7</ogr:CLUSTER_SIZE>
     </ogr:dbscan_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -37,6 +40,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0.199468085106383,-0.443617021276596</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID>1</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>7</ogr:CLUSTER_SIZE>
     </ogr:dbscan_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -44,6 +48,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3.63989361702128,0.315957446808511</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>4</ogr:id>
       <ogr:CLUSTER_ID>1</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>7</ogr:CLUSTER_SIZE>
     </ogr:dbscan_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -51,6 +56,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4.28776595744681,-0.823404255319149</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>1</ogr:id>
       <ogr:CLUSTER_ID>1</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>7</ogr:CLUSTER_SIZE>
     </ogr:dbscan_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -58,6 +64,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.04734042553191,0.070212765957447</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>4</ogr:id>
       <ogr:CLUSTER_ID>1</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>7</ogr:CLUSTER_SIZE>
     </ogr:dbscan_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -65,6 +72,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>6.90159574468085,0.40531914893617</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -72,6 +80,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9.09095744680851,-2.61063829787234</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>6</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -79,6 +88,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.04734042553191,4.22553191489362</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>8</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_5_2>
   </gml:featureMember>
 </ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/dbscan_5_2.xsd
+++ b/python/plugins/processing/tests/testdata/expected/dbscan_5_2.xsd
@@ -30,6 +30,13 @@
             </xs:restriction>
           </xs:simpleType>
         </xs:element>
+        <xs:element name="CLUSTER_SIZE" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
       </xs:sequence>
     </xs:extension>
   </xs:complexContent>

--- a/python/plugins/processing/tests/testdata/expected/dbscan_multiple_clusters.gml
+++ b/python/plugins/processing/tests/testdata/expected/dbscan_multiple_clusters.gml
@@ -16,6 +16,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>-0.426063829787234,2.19255319148936</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID>1</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>4</ogr:CLUSTER_SIZE>
     </ogr:dbscan_multiple_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -23,6 +24,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1.45053191489362,1.96914893617021</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID>1</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>4</ogr:CLUSTER_SIZE>
     </ogr:dbscan_multiple_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -30,6 +32,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1.40585106382979,0.807446808510639</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID>1</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>4</ogr:CLUSTER_SIZE>
     </ogr:dbscan_multiple_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -37,6 +40,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0.199468085106383,-0.443617021276596</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID>1</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>4</ogr:CLUSTER_SIZE>
     </ogr:dbscan_multiple_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -44,6 +48,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3.63989361702128,0.315957446808511</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>4</ogr:id>
       <ogr:CLUSTER_ID>2</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>4</ogr:CLUSTER_SIZE>
     </ogr:dbscan_multiple_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -51,6 +56,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4.28776595744681,-0.823404255319149</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>1</ogr:id>
       <ogr:CLUSTER_ID>2</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>4</ogr:CLUSTER_SIZE>
     </ogr:dbscan_multiple_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -58,6 +64,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.04734042553191,0.070212765957447</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>4</ogr:id>
       <ogr:CLUSTER_ID>2</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>4</ogr:CLUSTER_SIZE>
     </ogr:dbscan_multiple_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -65,6 +72,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>6.90159574468085,0.40531914893617</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID>2</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>4</ogr:CLUSTER_SIZE>
     </ogr:dbscan_multiple_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -72,6 +80,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9.09095744680851,-2.61063829787234</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>6</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_multiple_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -79,6 +88,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.04734042553191,4.22553191489362</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>8</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_multiple_clusters>
   </gml:featureMember>
 </ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/dbscan_multiple_clusters.xsd
+++ b/python/plugins/processing/tests/testdata/expected/dbscan_multiple_clusters.xsd
@@ -30,6 +30,13 @@
             </xs:restriction>
           </xs:simpleType>
         </xs:element>
+        <xs:element name="CLUSTER_SIZE" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
       </xs:sequence>
     </xs:extension>
   </xs:complexContent>

--- a/python/plugins/processing/tests/testdata/expected/dbscan_no_clusters.gml
+++ b/python/plugins/processing/tests/testdata/expected/dbscan_no_clusters.gml
@@ -16,6 +16,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>-0.426063829787234,2.19255319148936</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_no_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -23,6 +24,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1.45053191489362,1.96914893617021</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_no_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -30,6 +32,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1.40585106382979,0.807446808510639</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_no_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -37,6 +40,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0.199468085106383,-0.443617021276596</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_no_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -44,6 +48,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3.63989361702128,0.315957446808511</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>4</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_no_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -51,6 +56,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4.28776595744681,-0.823404255319149</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>1</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_no_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -58,6 +64,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.04734042553191,0.070212765957447</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>4</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_no_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -65,6 +72,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>6.90159574468085,0.40531914893617</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_no_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -72,6 +80,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9.09095744680851,-2.61063829787234</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>6</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_no_clusters>
   </gml:featureMember>
   <gml:featureMember>
@@ -79,6 +88,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.04734042553191,4.22553191489362</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>8</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_no_clusters>
   </gml:featureMember>
 </ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/dbscan_no_clusters.xsd
+++ b/python/plugins/processing/tests/testdata/expected/dbscan_no_clusters.xsd
@@ -30,6 +30,13 @@
             </xs:restriction>
           </xs:simpleType>
         </xs:element>
+        <xs:element name="CLUSTER_SIZE" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
       </xs:sequence>
     </xs:extension>
   </xs:complexContent>

--- a/python/plugins/processing/tests/testdata/expected/dbscan_star_5_2.gml
+++ b/python/plugins/processing/tests/testdata/expected/dbscan_star_5_2.gml
@@ -16,6 +16,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>-0.426063829787234,2.19255319148936</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_star_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -23,6 +24,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1.45053191489362,1.96914893617021</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID>1</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>3</ogr:CLUSTER_SIZE>
     </ogr:dbscan_star_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -30,6 +32,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1.40585106382979,0.807446808510639</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID>1</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>3</ogr:CLUSTER_SIZE>
     </ogr:dbscan_star_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -37,6 +40,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0.199468085106383,-0.443617021276596</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_star_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -44,6 +48,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3.63989361702128,0.315957446808511</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>4</ogr:id>
       <ogr:CLUSTER_ID>1</ogr:CLUSTER_ID>
+      <ogr:CLUSTER_SIZE>3</ogr:CLUSTER_SIZE>
     </ogr:dbscan_star_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -51,6 +56,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4.28776595744681,-0.823404255319149</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>1</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_star_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -58,6 +64,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.04734042553191,0.070212765957447</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>4</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_star_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -65,6 +72,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>6.90159574468085,0.40531914893617</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>5</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_star_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -72,6 +80,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9.09095744680851,-2.61063829787234</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>6</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_star_5_2>
   </gml:featureMember>
   <gml:featureMember>
@@ -79,6 +88,7 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.04734042553191,4.22553191489362</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:id>8</ogr:id>
       <ogr:CLUSTER_ID xsi:nil="true"/>
+      <ogr:CLUSTER_SIZE xsi:nil="true"/>
     </ogr:dbscan_star_5_2>
   </gml:featureMember>
 </ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/dbscan_star_5_2.xsd
+++ b/python/plugins/processing/tests/testdata/expected/dbscan_star_5_2.xsd
@@ -30,6 +30,13 @@
             </xs:restriction>
           </xs:simpleType>
         </xs:element>
+        <xs:element name="CLUSTER_SIZE" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
       </xs:sequence>
     </xs:extension>
   </xs:complexContent>

--- a/src/analysis/processing/qgsalgorithmdbscanclustering.cpp
+++ b/src/analysis/processing/qgsalgorithmdbscanclustering.cpp
@@ -69,6 +69,10 @@ void QgsDbscanClusteringAlgorithm::initAlgorithm( const QVariantMap & )
                         QObject::tr( "Cluster field name" ), QStringLiteral( "CLUSTER_ID" ) );
   fieldNameParam->setFlags( fieldNameParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
   addParameter( fieldNameParam.release() );
+  auto sizeFieldNameParam = qgis::make_unique<QgsProcessingParameterString>( QStringLiteral( "SIZE_FIELD_NAME" ),
+                            QObject::tr( "Cluster size field name" ), QStringLiteral( "CLUSTER_SIZE" ) );
+  sizeFieldNameParam->setFlags( sizeFieldNameParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( sizeFieldNameParam.release() );
 
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Clusters" ), QgsProcessing::TypeVectorPoint ) );
 
@@ -113,9 +117,11 @@ QVariantMap QgsDbscanClusteringAlgorithm::processAlgorithm( const QVariantMap &p
   const bool borderPointsAreNoise = parameterAsBoolean( parameters, QStringLiteral( "DBSCAN*" ), context );
 
   QgsFields outputFields = source->fields();
-  const QString clusterFieldName = parameterAsString( parameters, QStringLiteral( "FIELD_NAME" ), context );
   QgsFields newFields;
+  const QString clusterFieldName = parameterAsString( parameters, QStringLiteral( "FIELD_NAME" ), context );
   newFields.append( QgsField( clusterFieldName, QVariant::Int ) );
+  const QString clusterSizeFieldName = parameterAsString( parameters, QStringLiteral( "SIZE_FIELD_NAME" ), context );
+  newFields.append( QgsField( clusterSizeFieldName, QVariant::Int ) );
   outputFields = QgsProcessingUtils::combineFields( outputFields, newFields );
 
   QString dest;
@@ -133,11 +139,13 @@ QVariantMap QgsDbscanClusteringAlgorithm::processAlgorithm( const QVariantMap &p
   feedback->pushInfo( QObject::tr( "Analysing clusters" ) );
   std::unordered_map< QgsFeatureId, int> idToCluster;
   idToCluster.reserve( index.size() );
+  std::unordered_map< int, int> clusterSize;
   QgsFeatureIterator features = source->getFeatures( QgsFeatureRequest().setNoAttributes() );
   const long featureCount = source->featureCount();
+  dbscan( minSize, eps, borderPointsAreNoise, featureCount, features, index, idToCluster, clusterSize, feedback );
 
-  int clusterCount = 0;
-  dbscan( minSize, eps, borderPointsAreNoise, featureCount, features, index, idToCluster, clusterCount, feedback );
+  // cluster size
+  std::for_each( idToCluster.begin(), idToCluster.end(), [ &clusterSize ]( std::pair< QgsFeatureId, int > idCluster ) { clusterSize[ idCluster.second ]++; } );
 
   // write clusters
   const double writeStep = featureCount > 0 ? 10.0 / featureCount : 1;
@@ -157,11 +165,11 @@ QVariantMap QgsDbscanClusteringAlgorithm::processAlgorithm( const QVariantMap &p
     auto cluster = idToCluster.find( feat.id() );
     if ( cluster != idToCluster.end() )
     {
-      attr << cluster->second;
+      attr << cluster->second  << clusterSize[ cluster->second ];
     }
     else
     {
-      attr << QVariant();
+      attr << QVariant() << QVariant();
     }
     feat.setAttributes( attr );
     sink->addFeature( feat, QgsFeatureSink::FastInsert );
@@ -169,7 +177,7 @@ QVariantMap QgsDbscanClusteringAlgorithm::processAlgorithm( const QVariantMap &p
 
   QVariantMap outputs;
   outputs.insert( QStringLiteral( "OUTPUT" ), dest );
-  outputs.insert( QStringLiteral( "NUM_CLUSTERS" ), clusterCount );
+  outputs.insert( QStringLiteral( "NUM_CLUSTERS" ), static_cast< unsigned int >( clusterSize.size() ) );
   return outputs;
 }
 
@@ -181,7 +189,7 @@ void QgsDbscanClusteringAlgorithm::dbscan( const std::size_t minSize,
     QgsFeatureIterator features,
     QgsSpatialIndexKDBush &index,
     std::unordered_map< QgsFeatureId, int> &idToCluster,
-    int &clusterCount,
+    std::unordered_map< int, int> &clusterSize,
     QgsProcessingFeedback *feedback )
 {
   const double step = featureCount > 0 ? 90.0 / featureCount : 1;
@@ -191,7 +199,7 @@ void QgsDbscanClusteringAlgorithm::dbscan( const std::size_t minSize,
 
   QgsFeature feat;
   int i = 0;
-  clusterCount = 0;
+  int clusterCount = 0;
 
   while ( features.nextFeature( feat ) )
   {
@@ -244,6 +252,7 @@ void QgsDbscanClusteringAlgorithm::dbscan( const std::size_t minSize,
 
     // start new cluster
     clusterCount++;
+    clusterSize[ clusterCount ] = 0;
     idToCluster[ feat.id() ] = clusterCount;
     feedback->setProgress( ++i * step );
 

--- a/src/analysis/processing/qgsalgorithmdbscanclustering.cpp
+++ b/src/analysis/processing/qgsalgorithmdbscanclustering.cpp
@@ -139,12 +139,12 @@ QVariantMap QgsDbscanClusteringAlgorithm::processAlgorithm( const QVariantMap &p
   feedback->pushInfo( QObject::tr( "Analysing clusters" ) );
   std::unordered_map< QgsFeatureId, int> idToCluster;
   idToCluster.reserve( index.size() );
-  std::unordered_map< int, int> clusterSize;
   QgsFeatureIterator features = source->getFeatures( QgsFeatureRequest().setNoAttributes() );
   const long featureCount = source->featureCount();
-  dbscan( minSize, eps, borderPointsAreNoise, featureCount, features, index, idToCluster, clusterSize, feedback );
+  dbscan( minSize, eps, borderPointsAreNoise, featureCount, features, index, idToCluster, feedback );
 
   // cluster size
+  std::unordered_map< int, int> clusterSize;
   std::for_each( idToCluster.begin(), idToCluster.end(), [ &clusterSize ]( std::pair< QgsFeatureId, int > idCluster ) { clusterSize[ idCluster.second ]++; } );
 
   // write clusters
@@ -189,7 +189,6 @@ void QgsDbscanClusteringAlgorithm::dbscan( const std::size_t minSize,
     QgsFeatureIterator features,
     QgsSpatialIndexKDBush &index,
     std::unordered_map< QgsFeatureId, int> &idToCluster,
-    std::unordered_map< int, int> &clusterSize,
     QgsProcessingFeedback *feedback )
 {
   const double step = featureCount > 0 ? 90.0 / featureCount : 1;
@@ -252,7 +251,6 @@ void QgsDbscanClusteringAlgorithm::dbscan( const std::size_t minSize,
 
     // start new cluster
     clusterCount++;
-    clusterSize[ clusterCount ] = 0;
     idToCluster[ feat.id() ] = clusterCount;
     feedback->setProgress( ++i * step );
 

--- a/src/analysis/processing/qgsalgorithmdbscanclustering.h
+++ b/src/analysis/processing/qgsalgorithmdbscanclustering.h
@@ -61,7 +61,6 @@ class ANALYSIS_EXPORT QgsDbscanClusteringAlgorithm : public QgsProcessingAlgorit
                         QgsFeatureIterator features,
                         QgsSpatialIndexKDBush &index,
                         std::unordered_map< QgsFeatureId, int> &idToCluster,
-                        std::unordered_map< int, int> &clusterSize,
                         QgsProcessingFeedback *feedback );
 };
 

--- a/src/analysis/processing/qgsalgorithmdbscanclustering.h
+++ b/src/analysis/processing/qgsalgorithmdbscanclustering.h
@@ -61,7 +61,7 @@ class ANALYSIS_EXPORT QgsDbscanClusteringAlgorithm : public QgsProcessingAlgorit
                         QgsFeatureIterator features,
                         QgsSpatialIndexKDBush &index,
                         std::unordered_map< QgsFeatureId, int> &idToCluster,
-                        int &clusterCount,
+                        std::unordered_map< int, int> &clusterSize,
                         QgsProcessingFeedback *feedback );
 };
 


### PR DESCRIPTION
## Description

This PR adds a new cluster size attribute attached to output features of the DBSCAN cluster algorithm. The value represents the number of features within an identified cluster. Useful attribute in many cases.