### PR TITLE
Add square brackets around the saved expression

### DIFF
--- a/python/plugins/processing/algs/qgis/ui/RasterCalculatorWidgets.py
+++ b/python/plugins/processing/algs/qgis/ui/RasterCalculatorWidgets.py
@@ -188,7 +188,7 @@ class ExpressionWidget(BASE, WIDGET):
         used = [v for v in self.options.values() if v in exp]
 
         for i, v in enumerate(used):
-            exp = exp.replace(v, chr(97 + i))
+            exp = exp.replace(v, f'[{chr(97 + i)}]')
 
         dlg = AddNewExpressionDialog(exp)
         dlg.exec_()


### PR DESCRIPTION
## Description

When saving a raster expression the generated expression didn't contain square brackets around the letters used for band identifiers. Sticking with the NDVI example:

```
("NIR@1" - "Red@1") / ("NIR@1" + "Red@1")
```

becomes

```
(a - b) / (a + b)
```

Due to the way the expression is parsed these would not be interactie parameters for the user to set as the parameters requre square brackets around the layer tags. This change simply updates the string replacement to include the square brackets so you would get instead:

```
([a] - [b]) / ([a] + [b])
```