### PR TITLE
Fix crash in 3d when changing symbol properties (3.14 backport)

### DIFF
--- a/src/3d/symbols/qgsline3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsline3dsymbol_p.cpp
@@ -78,7 +78,7 @@ class QgsBufferedLine3DSymbolHandler : public QgsFeature3DHandler
     void makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, LineData &out, bool selected );
 
     // input specific for this class
-    const QgsLine3DSymbol &mSymbol;
+    QgsLine3DSymbol mSymbol;
     // inputs - generic
     QgsFeatureIds mSelectedIds;
 
@@ -223,7 +223,7 @@ class QgsSimpleLine3DSymbolHandler : public QgsFeature3DHandler
     Qt3DExtras::QPhongMaterial *material( const QgsLine3DSymbol &symbol ) const;
 
     // input specific for this class
-    const QgsLine3DSymbol &mSymbol;
+    QgsLine3DSymbol mSymbol;
     // inputs - generic
     QgsFeatureIds mSelectedIds;
 
@@ -336,7 +336,7 @@ class QgsThickLine3DSymbolHandler : public QgsFeature3DHandler
     Qt3DExtras::QPhongMaterial *material( const QgsLine3DSymbol &symbol ) const;
 
     // input specific for this class
-    const QgsLine3DSymbol &mSymbol;
+    QgsLine3DSymbol mSymbol;
     // inputs - generic
     QgsFeatureIds mSelectedIds;
 

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -85,7 +85,7 @@ class QgsInstancedPoint3DSymbolHandler : public QgsFeature3DHandler
     void makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PointData &out, bool selected );
 
     // input specific for this class
-    const QgsPoint3DSymbol &mSymbol;
+    QgsPoint3DSymbol mSymbol;
     // inputs - generic
     QgsFeatureIds mSelectedIds;
 
@@ -373,7 +373,7 @@ class QgsModelPoint3DSymbolHandler : public QgsFeature3DHandler
     void makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PointData &out, bool selected );
 
     // input specific for this class
-    const QgsPoint3DSymbol &mSymbol;
+    QgsPoint3DSymbol mSymbol;
     // inputs - generic
     QgsFeatureIds mSelectedIds;
 
@@ -519,7 +519,7 @@ class QgsPoint3DBillboardSymbolHandler : public QgsFeature3DHandler
     void makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PointData &out, bool selected );
 
     // input specific for this class
-    const QgsPoint3DSymbol &mSymbol;
+    QgsPoint3DSymbol mSymbol;
     // inputs - generic
     QgsFeatureIds mSelectedIds;
 

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -457,6 +457,9 @@ void QgsModelPoint3DSymbolHandler::addSceneEntities( const Qgs3DMapSettings &map
 
 void QgsModelPoint3DSymbolHandler::addMeshEntities( const Qgs3DMapSettings &map, const QVector<QVector3D> &positions, const QgsPoint3DSymbol &symbol, Qt3DCore::QEntity *parent, bool are_selected )
 {
+  if ( positions.empty() )
+    return;
+
   // build the default material
   Qt3DExtras::QPhongMaterial *mat = Qgs3DUtils::phongMaterial( symbol.material() );
 

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -63,7 +63,7 @@ class QgsPolygon3DSymbolHandler : public QgsFeature3DHandler
     Qt3DExtras::QPhongMaterial *material( const QgsPolygon3DSymbol &symbol ) const;
 
     // input specific for this class
-    const QgsPolygon3DSymbol &mSymbol;
+    QgsPolygon3DSymbol mSymbol;
     // inputs - generic
     QgsFeatureIds mSelectedIds;
 


### PR DESCRIPTION
Supersedes https://github.com/qgis/QGIS/pull/38429