### PR TITLE
Manage Vector Layer Datasource capabilities (useEstimatedMetadata, etc)

### DIFF
--- a/python/core/auto_generated/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/qgsvectordataprovider.sip.in
@@ -53,6 +53,10 @@ of feature and attribute information from a spatial datasource.
       CancelSupport,
       CreateRenderer,
       CreateLabeling,
+      CanDisableSelectAtId,
+      CanUseEstimatedMetadata,
+      CanDisableCheckPrimaryKeyUnicity,
+      CanUseMultiFieldPrimaryKey,
     };
 
     typedef QFlags<QgsVectorDataProvider::Capability> Capabilities;

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -94,6 +94,10 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
       CancelSupport = 1 << 23, //!< Supports interruption of pending queries from a separated thread. Since QGIS 3.2
       CreateRenderer = 1 << 24, //!< Provider can create feature renderers using backend-specific formatting information. Since QGIS 3.2. See QgsVectorDataProvider::createRenderer().
       CreateLabeling = 1 << 25, //!< Provider can set labeling settings using backend-specific formatting information. Since QGIS 3.6. See QgsVectorDataProvider::createLabeling().
+      CanDisableSelectAtId = 1 << 26, //!< Provider can disable select at id. Since QGIS 3.16
+      CanUseEstimatedMetadata = 1 << 27, //!< Provider can use estimated metadata. Since QGIS 3.16
+      CanDisableCheckPrimaryKeyUnicity = 1 << 28, //!< Provider can disable check primary key unicity. Since QGIS 3.16
+      CanUseMultiFieldPrimaryKey = 1 << 29, //!< Provider can use multi-field for primary key. Since QGIS 3.16
     };
 
     Q_DECLARE_FLAGS( Capabilities, Capability )

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -295,8 +295,8 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
     cbxSelectAtId->setEnabled( false );
     cbxCheckPrimaryKeyUnicity->setEnabled( false );
     pbnDcUnlock->setEnabled( true );
-    pbnDcCancel->setEnabled( false );
-    pbnDcApply->setEnabled( false );
+    pbnDcReset->setEnabled( false );
+    pbnDcUpdate->setEnabled( false );
     if ( !( capabilities & QgsVectorDataProvider::CanDisableSelectAtId ) &&
          !( capabilities & QgsVectorDataProvider::CanUseEstimatedMetadata ) &&
          !( capabilities & QgsVectorDataProvider::CanDisableCheckPrimaryKeyUnicity ) )
@@ -355,8 +355,8 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
     }
   }
   connect( pbnDcUnlock, &QAbstractButton::clicked, this, &QgsVectorLayerProperties::pbnDcUnlock_clicked );
-  connect( pbnDcCancel, &QAbstractButton::clicked, this, &QgsVectorLayerProperties::pbnDcCancel_clicked );
-  connect( pbnDcApply, &QAbstractButton::clicked, this, &QgsVectorLayerProperties::pbnDcApply_clicked );
+  connect( pbnDcReset, &QAbstractButton::clicked, this, &QgsVectorLayerProperties::pbnDcReset_clicked );
+  connect( pbnDcUpdate, &QAbstractButton::clicked, this, &QgsVectorLayerProperties::pbnDcUpdate_clicked );
 
   mCrsSelector->setCrs( mLayer->crs() );
 
@@ -1876,12 +1876,12 @@ void QgsVectorLayerProperties::pbnDcUnlock_clicked()
   cbxUseEstimatedMetadata->setEnabled( true );
   cbxSelectAtId->setEnabled( true );
   cbxCheckPrimaryKeyUnicity->setEnabled( true );
-  pbnDcCancel->setEnabled( true );
-  pbnDcApply->setEnabled( true );
+  pbnDcReset->setEnabled( true );
+  pbnDcUpdate->setEnabled( true );
   pbnDcUnlock->setEnabled( false );
 }
 
-void QgsVectorLayerProperties::pbnDcCancel_clicked()
+void QgsVectorLayerProperties::pbnDcReset_clicked()
 {
   const QgsDataSourceUri uri = mLayer->dataProvider()->uri();
   QgsVectorDataProvider::Capabilities capabilities = mLayer->dataProvider()->capabilities();
@@ -1907,11 +1907,11 @@ void QgsVectorLayerProperties::pbnDcCancel_clicked()
   cbxSelectAtId->setEnabled( false );
   cbxCheckPrimaryKeyUnicity->setEnabled( false );
   pbnDcUnlock->setEnabled( true );
-  pbnDcCancel->setEnabled( false );
-  pbnDcApply->setEnabled( false );
+  pbnDcReset->setEnabled( false );
+  pbnDcUpdate->setEnabled( false );
 }
 
-void QgsVectorLayerProperties::pbnDcApply_clicked()
+void QgsVectorLayerProperties::pbnDcUpdate_clicked()
 {
   // Clone QgsDataSourceUri
   QgsDataSourceUri uri( mLayer->dataProvider()->uri().uri( false ) );
@@ -1935,7 +1935,7 @@ void QgsVectorLayerProperties::pbnDcApply_clicked()
 
   mLayer->dataProvider()->setUri( uri );
 
-  pbnDcCancel_clicked();
+  pbnDcReset_clicked();
 }
 
 void QgsVectorLayerProperties::optionsStackedWidget_CurrentChanged( int index )

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -108,6 +108,10 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     void loadDefaultMetadata();
     void pbnUpdateExtents_clicked();
 
+    void pbnDcUnlock_clicked();
+    void pbnDcCancel_clicked();
+    void pbnDcApply_clicked();
+
     void mButtonAddJoin_clicked();
     void mButtonEditJoin_clicked();
     void mJoinTreeWidget_itemDoubleClicked( QTreeWidgetItem *item, int column );

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -109,8 +109,8 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     void pbnUpdateExtents_clicked();
 
     void pbnDcUnlock_clicked();
-    void pbnDcCancel_clicked();
-    void pbnDcApply_clicked();
+    void pbnDcReset_clicked();
+    void pbnDcUpdate_clicked();
 
     void mButtonAddJoin_clicked();
     void mButtonEditJoin_clicked();

--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -1213,7 +1213,8 @@ QgsVectorDataProvider::Capabilities QgsDb2Provider::capabilities() const
       cap |= ChangeGeometries;
 
     return cap | DeleteFeatures | ChangeAttributeValues |
-           QgsVectorDataProvider::SelectAtId;
+           QgsVectorDataProvider::SelectAtId |
+           QgsVectorDataProvider::CanUseEstimatedMetadata;
   }
 }
 

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -1706,7 +1706,8 @@ QgsVectorDataProvider::Capabilities QgsMssqlProvider::capabilities() const
     cap |= ChangeGeometries;
 
   return cap | DeleteFeatures | ChangeAttributeValues | DeleteAttributes |
-         QgsVectorDataProvider::SelectAtId;
+         QgsVectorDataProvider::SelectAtId |
+         QgsVectorDataProvider::CanUseEstimatedMetadata;
 }
 
 bool QgsMssqlProvider::createSpatialIndex()

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -885,6 +885,9 @@ bool QgsOracleProvider::hasSufficientPermsAndCapabilities()
 
   qry.finish();
 
+  // QgsDatasourceUri capabilities
+  mEnabledCapabilities |= QgsVectorDataProvider::CanUseEstimatedMetadata;
+
   return true;
 }
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1499,6 +1499,12 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
     mEnabledCapabilities |= QgsVectorDataProvider::ChangeFeatures;
   }
 
+  // QgsDatasourceUri capabilities
+  mEnabledCapabilities |= QgsVectorDataProvider::CanDisableSelectAtId;
+  mEnabledCapabilities |= QgsVectorDataProvider::CanUseEstimatedMetadata;
+  mEnabledCapabilities |= QgsVectorDataProvider::CanDisableCheckPrimaryKeyUnicity;
+  mEnabledCapabilities |= QgsVectorDataProvider::CanUseMultiFieldPrimaryKey;
+
   return true;
 }
 

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -439,8 +439,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>644</width>
-                <height>664</height>
+                <width>653</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -566,7 +566,7 @@ border-radius: 2px;</string>
                  <property name="checkable">
                   <bool>false</bool>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">vectorgeneral</string>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -658,6 +658,109 @@ border-radius: 2px;</string>
                      <enum>Qt::Vertical</enum>
                     </property>
                    </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QgsCollapsibleGroupBox" name="mDatasourceCapabilities">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="title">
+                  <string>Datasource capabilities</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_31">
+                  <item>
+                   <widget class="QCheckBox" name="cbxUseEstimatedMetadata">
+                    <property name="text">
+                     <string>Use estimated Metadata</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QWidget" name="mPrimaryKeyWidget" native="true">
+                    <layout class="QHBoxLayout" name="mPrimaryKeyLayout">
+                     <item>
+                      <widget class="QLabel" name="label">
+                       <property name="text">
+                        <string>Primary Key</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QgsFieldComboBox" name="mPrimaryKeyComboBox"/>
+                     </item>
+                     <item>
+                      <widget class="QCheckBox" name="cbxSelectAtId">
+                       <property name="text">
+                        <string>Select at Id</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QCheckBox" name="cbxCheckPrimaryKeyUnicity">
+                       <property name="text">
+                        <string>Check unicity</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_10">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_11">
+                    <item>
+                     <widget class="QPushButton" name="pbnDcUnlock">
+                      <property name="text">
+                       <string>Unlock</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="pbnDcCancel">
+                      <property name="text">
+                       <string>Cancel</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="pbnDcApply">
+                      <property name="enabled">
+                       <bool>true</bool>
+                      </property>
+                      <property name="text">
+                       <string>Apply</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="horizontalSpacer_11">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>40</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
                   </item>
                  </layout>
                 </widget>
@@ -966,8 +1069,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>199</width>
-                <height>119</height>
+                <width>104</width>
+                <height>102</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -1111,7 +1214,7 @@ border-radius: 2px;</string>
                 <property name="checkable">
                  <bool>false</bool>
                 </property>
-                <property name="syncGroup" stdset="0">
+                <property name="syncGroup">
                  <string notr="true">vectormeta</string>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_11">
@@ -1445,7 +1548,7 @@ border-radius: 2px;</string>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_50">
                  <item row="0" column="0">
-                  <widget class="QgsFieldExpressionWidget" name="mDisplayExpressionWidget" native="true">
+                  <widget class="QgsFieldExpressionWidget" name="mDisplayExpressionWidget">
                    <property name="focusPolicy">
                     <enum>Qt::StrongFocus</enum>
                    </property>
@@ -1509,7 +1612,7 @@ border-radius: 2px;</string>
                   </widget>
                  </item>
                  <item row="1" column="0" colspan="2">
-                  <widget class="QgsFieldExpressionWidget" name="mMapTipExpressionFieldWidget" native="true">
+                  <widget class="QgsFieldExpressionWidget" name="mMapTipExpressionFieldWidget">
                    <property name="focusPolicy">
                     <enum>Qt::StrongFocus</enum>
                    </property>
@@ -1563,8 +1666,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>652</width>
-                <height>368</height>
+                <width>695</width>
+                <height>424</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -1590,7 +1693,7 @@ border-radius: 2px;</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_6">
                   <item row="0" column="0">
-                   <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget" native="true">
+                   <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget">
                     <property name="focusPolicy">
                      <enum>Qt::StrongFocus</enum>
                     </property>
@@ -2055,8 +2158,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>644</width>
-                <height>808</height>
+                <width>370</width>
+                <height>769</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -2077,7 +2180,7 @@ border-radius: 2px;</string>
                  <property name="title">
                   <string>Description</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">vectormeta</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_5">
@@ -2219,7 +2322,7 @@ border-radius: 2px;</string>
                  <property name="title">
                   <string>Attribution</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">vectormeta</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_7">
@@ -2265,7 +2368,7 @@ border-radius: 2px;</string>
                  <property name="title">
                   <string>MetadataUrl</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">vectormeta</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_9">
@@ -2583,6 +2686,17 @@ border-radius: 2px;</string>
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsFieldComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsfieldcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFieldExpressionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfieldexpressionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsFilterLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qgsfilterlineedit.h</header>
@@ -2597,6 +2711,12 @@ border-radius: 2px;</string>
    <class>QgsScaleRangeWidget</class>
    <extends>QWidget</extends>
    <header>qgsscalerangewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsLayerTreeEmbeddedConfigWidget</class>
@@ -2614,12 +2734,6 @@ border-radius: 2px;</string>
    <class>QgsScaleComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsscalecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsFieldExpressionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsfieldexpressionwidget.h</header>
-   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsCodeEditorHTML</class>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -731,19 +731,19 @@ border-radius: 2px;</string>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QPushButton" name="pbnDcCancel">
+                     <widget class="QPushButton" name="pbnDcReset">
                       <property name="text">
-                       <string>Cancel</string>
+                       <string>Reset</string>
                       </property>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QPushButton" name="pbnDcApply">
+                     <widget class="QPushButton" name="pbnDcUpdate">
                       <property name="enabled">
                        <bool>true</bool>
                       </property>
                       <property name="text">
-                       <string>Apply</string>
+                       <string>Update datasource</string>
                       </property>
                      </widget>
                     </item>


### PR DESCRIPTION
## Description

For some Vector Providers (postgres, oracle, db2, mssql), the datasource provides parameters to use estimated metadata, to disable select at id or to disable check primary key unicity.

These parameters could be configured at the provider or layer level. Once the layer has been created, the user cannot change these parameters.

To speed up project loading, it is usefull to be able to activate use estimated metadata or disable check primary key unicity. It is interesting to be able to disable check primary key unicity when you user is sure that unicity is managed at the provider level.

To provide a User Interface to manage these parameters once the layer has been created, I proposed to add new vector provider capabilities: 
```
      CanDisableSelectAtId,
      CanUseEstimatedMetadata,
      CanDisbaleCheckPrimaryKeyUnicity,
      CanUseMultiFieldPrimaryKey,
```
Based on these capabilities, the vector layer properties dialog provides a group box with checkboxes and push buttons to update these datasource parameters. If the provider does not have associated capabilities, the checkboxes and possibly the groupbox are hidden.
