### PR TITLE
List availabale GDAL vector drivers (fix #18738)

### DIFF
--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -99,7 +99,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   setupUi( this );
   connect( cbxProjectDefaultNew, &QCheckBox::toggled, this, &QgsOptions::cbxProjectDefaultNew_toggled );
   connect( leLayerGlobalCrs, &QgsProjectionSelectionWidget::crsChanged, this, &QgsOptions::leLayerGlobalCrs_crsChanged );
-  connect( lstGdalDrivers, &QTreeWidget::itemDoubleClicked, this, &QgsOptions::lstGdalDrivers_itemDoubleClicked );
+  connect( lstRasterDrivers, &QTreeWidget::itemDoubleClicked, this, &QgsOptions::lstRasterDrivers_itemDoubleClicked );
   connect( mProjectOnLaunchCmbBx, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsOptions::mProjectOnLaunchCmbBx_currentIndexChanged );
   connect( spinFontSize, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsOptions::spinFontSize_valueChanged );
   connect( mFontFamilyRadioQt, &QRadioButton::released, this, &QgsOptions::mFontFamilyRadioQt_released );
@@ -1890,7 +1890,7 @@ void QgsOptions::leLayerGlobalCrs_crsChanged( const QgsCoordinateReferenceSystem
   mLayerDefaultCrs = crs;
 }
 
-void QgsOptions::lstGdalDrivers_itemDoubleClicked( QTreeWidgetItem *item, int column )
+void QgsOptions::lstRasterDrivers_itemDoubleClicked( QTreeWidgetItem *item, int column )
 {
   Q_UNUSED( column )
   // edit driver if driver supports write
@@ -2259,6 +2259,7 @@ void QgsOptions::loadGdalDriverList()
   QStringList myDrivers;
   QStringList myGdalWriteDrivers;
   QMap<QString, QString> myDriversFlags, myDriversExt, myDriversLongName;
+  QMap<QString, bool> driversType; // true for raster, false for vector
 
   // make sure we save list when accept()
   mLoadedGdalDriverList = true;
@@ -2280,33 +2281,53 @@ void QgsOptions::loadGdalDriverList()
       continue;
     }
 
-    // in GDAL 2.0 vector and mixed drivers are returned by GDALGetDriver, so filter out non-raster drivers
-    // TODO add same UI for vector drivers
+    // in GDAL 2.0 both vector and raster drivers are returned by GDALGetDriver
     if ( QString( GDALGetMetadataItem( myGdalDriver, GDAL_DCAP_RASTER, nullptr ) ) != QLatin1String( "YES" ) )
-      continue;
+    {
+      driversType[myGdalDriverDescription] = false;
+    }
+    else
+    {
+      driversType[myGdalDriverDescription] = true;
+    }
 
     myGdalDriverDescription = GDALGetDescription( myGdalDriver );
     myDrivers << myGdalDriverDescription;
 
     QgsDebugMsg( QStringLiteral( "driver #%1 - %2" ).arg( i ).arg( myGdalDriverDescription ) );
 
-    // get driver R/W flags, taken from GDALGeneralCmdLineProcessor()
-    const char *pszRWFlag, *pszVirtualIO;
-    if ( QgsGdalUtils::supportsRasterCreate( myGdalDriver ) )
+    // get driver R/W flags, adopted from GDALGeneralCmdLineProcessor()
+    QString driverFlags = "";
+    if ( driversType[myGdalDriverDescription] )
     {
-      myGdalWriteDrivers << myGdalDriverDescription;
-      pszRWFlag = "rw+";
+      if ( QgsGdalUtils::supportsRasterCreate( myGdalDriver ) )
+      {
+        myGdalWriteDrivers << myGdalDriverDescription;
+        driverFlags = "rw+";
+      }
+      else if ( GDALGetMetadataItem( myGdalDriver, GDAL_DCAP_CREATECOPY,
+                                     nullptr ) )
+        driverFlags = "rw";
+      else
+        driverFlags = "ro";
     }
-    else if ( GDALGetMetadataItem( myGdalDriver, GDAL_DCAP_CREATECOPY,
-                                   nullptr ) )
-      pszRWFlag = "rw";
     else
-      pszRWFlag = "ro";
+    {
+      if ( GDALGetMetadataItem( myGdalDriver, GDAL_DCAP_OPEN, nullptr ) )
+        driverFlags = "r";
+
+      if ( GDALGetMetadataItem( myGdalDriver, GDAL_DCAP_CREATE, nullptr ) )
+        driverFlags += "w+";
+      else if ( GDALGetMetadataItem( myGdalDriver, GDAL_DCAP_CREATECOPY, nullptr ) )
+        driverFlags += "w";
+      else
+        driverFlags += "o";
+    }
+
     if ( GDALGetMetadataItem( myGdalDriver, GDAL_DCAP_VIRTUALIO, nullptr ) )
-      pszVirtualIO = "v";
-    else
-      pszVirtualIO = "";
-    myDriversFlags[myGdalDriverDescription] = QStringLiteral( "%1%2" ).arg( pszRWFlag, pszVirtualIO );
+      driverFlags += "v";
+
+    myDriversFlags[myGdalDriverDescription] = driverFlags;
 
     // get driver extensions and long name
     // the gdal provider can override/add extensions but there is no interface to query this
@@ -2344,13 +2365,24 @@ void QgsOptions::loadGdalDriverList()
     QString myFlags = myDriversFlags[myName];
     mypItem->setText( 2, myFlags );
     mypItem->setText( 3, myDriversLongName[myName] );
-    lstGdalDrivers->addTopLevelItem( mypItem );
+    if ( driversType[myName] )
+    {
+      lstRasterDrivers->addTopLevelItem( mypItem );
+    }
+    else
+    {
+      lstVectorDrivers->addTopLevelItem( mypItem );
+    }
   }
+
   // adjust column width
   for ( int i = 0; i < 4; i++ )
   {
-    lstGdalDrivers->resizeColumnToContents( i );
-    lstGdalDrivers->setColumnWidth( i, lstGdalDrivers->columnWidth( i ) + 5 );
+    lstRasterDrivers->resizeColumnToContents( i );
+    lstRasterDrivers->setColumnWidth( i, lstRasterDrivers->columnWidth( i ) + 5 );
+
+    lstVectorDrivers->resizeColumnToContents( i );
+    lstVectorDrivers->setColumnWidth( i, lstVectorDrivers->columnWidth( i ) + 5 );
   }
 
   // populate cmbEditCreateOptions with gdal write drivers - sorted, GTiff first
@@ -2374,9 +2406,10 @@ void QgsOptions::saveGdalDriverList()
   const auto oldSkippedGdalDrivers = QgsApplication::skippedGdalDrivers();
   auto deferredSkippedGdalDrivers = QgsApplication::deferredSkippedGdalDrivers();
   QStringList skippedGdalDrivers;
-  for ( int i = 0; i < lstGdalDrivers->topLevelItemCount(); i++ )
+  // raster drivers
+  for ( int i = 0; i < lstRasterDrivers->topLevelItemCount(); i++ )
   {
-    QTreeWidgetItem *mypItem = lstGdalDrivers->topLevelItem( i );
+    QTreeWidgetItem *mypItem = lstRasterDrivers->topLevelItem( i );
     const auto &driverName( mypItem->text( 0 ) );
     if ( mypItem->checkState( 0 ) == Qt::Unchecked )
     {
@@ -2396,6 +2429,31 @@ void QgsOptions::saveGdalDriverList()
       }
     }
   }
+
+  // vector drivers
+  for ( int i = 0; i < lstVectorDrivers->topLevelItemCount(); i++ )
+  {
+    QTreeWidgetItem *mypItem = lstVectorDrivers->topLevelItem( i );
+    const auto &driverName( mypItem->text( 0 ) );
+    if ( mypItem->checkState( 0 ) == Qt::Unchecked )
+    {
+      skippedGdalDrivers << driverName;
+      if ( !deferredSkippedGdalDrivers.contains( driverName ) &&
+           !oldSkippedGdalDrivers.contains( driverName ) )
+      {
+        deferredSkippedGdalDrivers << driverName;
+        driverUnregisterNeeded = true;
+      }
+    }
+    else
+    {
+      if ( deferredSkippedGdalDrivers.contains( driverName ) )
+      {
+        deferredSkippedGdalDrivers.removeAll( driverName );
+      }
+    }
+  }
+
   if ( driverUnregisterNeeded )
   {
     QMessageBox::information( this, tr( "Drivers Disabled" ),

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -2406,12 +2406,11 @@ void QgsOptions::saveGdalDriverList()
   const auto oldSkippedGdalDrivers = QgsApplication::skippedGdalDrivers();
   auto deferredSkippedGdalDrivers = QgsApplication::deferredSkippedGdalDrivers();
   QStringList skippedGdalDrivers;
-  // raster drivers
-  for ( int i = 0; i < lstRasterDrivers->topLevelItemCount(); i++ )
+
+  auto checkDriver = [ & ]( QTreeWidgetItem * item )
   {
-    QTreeWidgetItem *mypItem = lstRasterDrivers->topLevelItem( i );
-    const auto &driverName( mypItem->text( 0 ) );
-    if ( mypItem->checkState( 0 ) == Qt::Unchecked )
+    const auto &driverName( item->text( 0 ) );
+    if ( item->checkState( 0 ) == Qt::Unchecked )
     {
       skippedGdalDrivers << driverName;
       if ( !deferredSkippedGdalDrivers.contains( driverName ) &&
@@ -2428,30 +2427,18 @@ void QgsOptions::saveGdalDriverList()
         deferredSkippedGdalDrivers.removeAll( driverName );
       }
     }
+  };
+
+  // raster drivers
+  for ( int i = 0; i < lstRasterDrivers->topLevelItemCount(); i++ )
+  {
+    checkDriver( lstRasterDrivers->topLevelItem( i ) );
   }
 
   // vector drivers
   for ( int i = 0; i < lstVectorDrivers->topLevelItemCount(); i++ )
   {
-    QTreeWidgetItem *mypItem = lstVectorDrivers->topLevelItem( i );
-    const auto &driverName( mypItem->text( 0 ) );
-    if ( mypItem->checkState( 0 ) == Qt::Unchecked )
-    {
-      skippedGdalDrivers << driverName;
-      if ( !deferredSkippedGdalDrivers.contains( driverName ) &&
-           !oldSkippedGdalDrivers.contains( driverName ) )
-      {
-        deferredSkippedGdalDrivers << driverName;
-        driverUnregisterNeeded = true;
-      }
-    }
-    else
-    {
-      if ( deferredSkippedGdalDrivers.contains( driverName ) )
-      {
-        deferredSkippedGdalDrivers.removeAll( driverName );
-      }
-    }
+    checkDriver( lstVectorDrivers->topLevelItem( i ) );
   }
 
   if ( driverUnregisterNeeded )

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -2282,17 +2282,16 @@ void QgsOptions::loadGdalDriverList()
     }
 
     // in GDAL 2.0 both vector and raster drivers are returned by GDALGetDriver
-    if ( QString( GDALGetMetadataItem( myGdalDriver, GDAL_DCAP_RASTER, nullptr ) ) != QLatin1String( "YES" ) )
-    {
-      driversType[myGdalDriverDescription] = QgsMapLayerType::VectorLayer;
-    }
-    else
+    myGdalDriverDescription = GDALGetDescription( myGdalDriver );
+    myDrivers << myGdalDriverDescription;
+    if ( QString( GDALGetMetadataItem( myGdalDriver, GDAL_DCAP_RASTER, nullptr ) ) == QLatin1String( "YES" ) )
     {
       driversType[myGdalDriverDescription] = QgsMapLayerType::RasterLayer;
     }
-
-    myGdalDriverDescription = GDALGetDescription( myGdalDriver );
-    myDrivers << myGdalDriverDescription;
+    else if ( QString( GDALGetMetadataItem( myGdalDriver, GDAL_DCAP_VECTOR, nullptr ) ) == QLatin1String( "YES" ) )
+    {
+      driversType[myGdalDriverDescription] = QgsMapLayerType::VectorLayer;
+    }
 
     QgsDebugMsg( QStringLiteral( "driver #%1 - %2" ).arg( i ).arg( myGdalDriverDescription ) );
 

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -2259,7 +2259,7 @@ void QgsOptions::loadGdalDriverList()
   QStringList myDrivers;
   QStringList myGdalWriteDrivers;
   QMap<QString, QString> myDriversFlags, myDriversExt, myDriversLongName;
-  QMap<QString, bool> driversType; // true for raster, false for vector
+  QMap<QString, QgsMapLayerType> driversType;
 
   // make sure we save list when accept()
   mLoadedGdalDriverList = true;
@@ -2284,11 +2284,11 @@ void QgsOptions::loadGdalDriverList()
     // in GDAL 2.0 both vector and raster drivers are returned by GDALGetDriver
     if ( QString( GDALGetMetadataItem( myGdalDriver, GDAL_DCAP_RASTER, nullptr ) ) != QLatin1String( "YES" ) )
     {
-      driversType[myGdalDriverDescription] = false;
+      driversType[myGdalDriverDescription] = QgsMapLayerType::VectorLayer;
     }
     else
     {
-      driversType[myGdalDriverDescription] = true;
+      driversType[myGdalDriverDescription] = QgsMapLayerType::RasterLayer;
     }
 
     myGdalDriverDescription = GDALGetDescription( myGdalDriver );
@@ -2298,7 +2298,7 @@ void QgsOptions::loadGdalDriverList()
 
     // get driver R/W flags, adopted from GDALGeneralCmdLineProcessor()
     QString driverFlags = "";
-    if ( driversType[myGdalDriverDescription] )
+    if ( driversType[myGdalDriverDescription] == QgsMapLayerType::RasterLayer )
     {
       if ( QgsGdalUtils::supportsRasterCreate( myGdalDriver ) )
       {
@@ -2365,7 +2365,7 @@ void QgsOptions::loadGdalDriverList()
     QString myFlags = myDriversFlags[myName];
     mypItem->setText( 2, myFlags );
     mypItem->setText( 3, myDriversLongName[myName] );
-    if ( driversType[myName] )
+    if ( driversType[myName] == QgsMapLayerType::RasterLayer )
     {
       lstRasterDrivers->addTopLevelItem( mypItem );
     }

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -86,7 +86,7 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
     void resetTemplateFolder();
     //! Slot called when user chooses to change the default 'on the fly' projection.
     void leLayerGlobalCrs_crsChanged( const QgsCoordinateReferenceSystem &crs );
-    void lstGdalDrivers_itemDoubleClicked( QTreeWidgetItem *item, int column );
+    void lstRasterDrivers_itemDoubleClicked( QTreeWidgetItem *item, int column );
     void editCreateOptions();
     void editPyramidsOptions();
     void editGdalDriver( const QString &driverName );

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1707,7 +1707,7 @@ void QgsApplication::applyGdalSkippedDrivers()
     if ( !sDeferredSkippedGdalDrivers()->contains( driverName ) )
       realDisabledDriverList << driverName;
   }
-  QString myDriverList = realDisabledDriverList.join( QStringLiteral( "," ) );
+  QString myDriverList = realDisabledDriverList.join( ',' );
   QgsDebugMsgLevel( QStringLiteral( "Gdal Skipped driver list set to:" ), 2 );
   QgsDebugMsgLevel( myDriverList, 2 );
   CPLSetConfigOption( "GDAL_SKIP", myDriverList.toUtf8() );

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1675,7 +1675,7 @@ void QgsApplication::setSkippedGdalDrivers( const QStringList &skippedGdalDriver
   *sDeferredSkippedGdalDrivers() = deferredSkippedGdalDrivers;
 
   QgsSettings settings;
-  settings.setValue( QStringLiteral( "gdal/skipList" ), skippedGdalDrivers.join( QStringLiteral( " " ) ) );
+  settings.setValue( QStringLiteral( "gdal/skipList" ), skippedGdalDrivers.join( QStringLiteral( "," ) ) );
 
   applyGdalSkippedDrivers();
 }
@@ -1687,7 +1687,7 @@ void QgsApplication::registerGdalDriversFromSettings()
   QStringList myList;
   if ( !joinedList.isEmpty() )
   {
-    myList = joinedList.split( ' ' );
+    myList = joinedList.split( QStringLiteral( "," ) );
   }
   *sGdalSkipList() = myList;
   applyGdalSkippedDrivers();
@@ -1707,7 +1707,7 @@ void QgsApplication::applyGdalSkippedDrivers()
     if ( !sDeferredSkippedGdalDrivers()->contains( driverName ) )
       realDisabledDriverList << driverName;
   }
-  QString myDriverList = realDisabledDriverList.join( ' ' );
+  QString myDriverList = realDisabledDriverList.join( QStringLiteral( "," ) );
   QgsDebugMsgLevel( QStringLiteral( "Gdal Skipped driver list set to:" ), 2 );
   QgsDebugMsgLevel( myDriverList, 2 );
   CPLSetConfigOption( "GDAL_SKIP", myDriverList.toUtf8() );

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1675,7 +1675,7 @@ void QgsApplication::setSkippedGdalDrivers( const QStringList &skippedGdalDriver
   *sDeferredSkippedGdalDrivers() = deferredSkippedGdalDrivers;
 
   QgsSettings settings;
-  settings.setValue( QStringLiteral( "gdal/skipList" ), skippedGdalDrivers.join( QStringLiteral( "," ) ) );
+  settings.setValue( QStringLiteral( "gdal/skipDrivers" ), skippedGdalDrivers.join( QStringLiteral( "," ) ) );
 
   applyGdalSkippedDrivers();
 }
@@ -1683,11 +1683,21 @@ void QgsApplication::setSkippedGdalDrivers( const QStringList &skippedGdalDriver
 void QgsApplication::registerGdalDriversFromSettings()
 {
   QgsSettings settings;
-  QString joinedList = settings.value( QStringLiteral( "gdal/skipList" ), QString() ).toString();
+  QString joinedList, delimiter;
+  if ( settings.contains( QStringLiteral( "gdal/skipDrivers" ) ) )
+  {
+    joinedList = settings.value( QStringLiteral( "gdal/skipDrivers" ), QString() ).toString();
+    delimiter = QStringLiteral( "," );
+  }
+  else
+  {
+    joinedList = settings.value( QStringLiteral( "gdal/skipList" ), QString() ).toString();
+    delimiter = QStringLiteral( " " );
+  }
   QStringList myList;
   if ( !joinedList.isEmpty() )
   {
-    myList = joinedList.split( QStringLiteral( "," ) );
+    myList = joinedList.split( delimiter );
   }
   *sGdalSkipList() = myList;
   applyGdalSkippedDrivers();

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -361,8 +361,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>645</width>
-                <height>1003</height>
+                <width>843</width>
+                <height>917</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -1059,11 +1059,11 @@
                     </item>
                     <item row="1" column="1">
                      <widget class="QRadioButton" name="mFileFormatQgsButton">
-                      <property name="text">
-                       <string>QGS Project saved in a clear text, does not embed auxiliary data</string>
-                      </property>
                       <property name="toolTip">
                        <string>The auxiliary data will be kept in a separate .qgd data file which must be distributed along with the .qgs project file.</string>
+                      </property>
+                      <property name="text">
+                       <string>QGS Project saved in a clear text, does not embed auxiliary data</string>
                       </property>
                       <attribute name="buttonGroup">
                        <string notr="true">mDefaultProjectFileFormatButtonGroup</string>
@@ -1121,8 +1121,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>539</width>
-                <height>1114</height>
+                <width>843</width>
+                <height>1072</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -1648,8 +1648,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>555</width>
-                <height>501</height>
+                <width>857</width>
+                <height>682</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -1861,8 +1861,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>848</width>
-                <height>816</height>
+                <width>843</width>
+                <height>762</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -2258,8 +2258,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>695</width>
-                <height>1139</height>
+                <width>843</width>
+                <height>1084</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_22">
@@ -3051,8 +3051,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>529</width>
-                <height>309</height>
+                <width>857</width>
+                <height>682</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -3362,8 +3362,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>606</width>
-                <height>741</height>
+                <width>857</width>
+                <height>682</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
@@ -3868,7 +3868,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                 <x>0</x>
                 <y>0</y>
                 <width>857</width>
-                <height>679</height>
+                <height>682</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_46">
@@ -4035,8 +4035,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>570</width>
-                <height>827</height>
+                <width>843</width>
+                <height>870</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -4660,8 +4660,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>469</width>
-                <height>572</height>
+                <width>857</width>
+                <height>682</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_39">
@@ -4929,110 +4929,180 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>506</width>
-                <height>367</height>
+                <width>857</width>
+                <height>682</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
                <item>
-                <widget class="QGroupBox" name="groupBox_16">
-                 <property name="title">
-                  <string>GDAL Driver Options</string>
+                <widget class="QTabWidget" name="tabWidget">
+                 <property name="currentIndex">
+                  <number>0</number>
                  </property>
-                 <layout class="QGridLayout" name="gridLayout_29">
-                  <item row="0" column="1">
-                   <widget class="QComboBox" name="cmbEditCreateOptions"/>
-                  </item>
-                  <item row="0" column="3">
-                   <spacer name="horizontalSpacer_15">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="4">
-                   <widget class="QPushButton" name="pbnEditPyramidsOptions">
-                    <property name="text">
-                     <string>Edit Pyramids Options</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="5">
-                   <spacer name="horizontalSpacer_16">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="2">
-                   <widget class="QPushButton" name="pbnEditCreateOptions">
-                    <property name="text">
-                     <string>Edit Create Options</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="groupBox_13">
-                 <property name="title">
-                  <string>GDAL Drivers</string>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_24">
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="label_17">
-                    <property name="text">
-                     <string>In some cases more than one GDAL driver can be used to load the same raster format. Use the list below to specify which to use.</string>
-                    </property>
-                    <property name="wordWrap">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="QTreeWidget" name="lstGdalDrivers">
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>141</height>
-                     </size>
-                    </property>
-                    <column>
-                     <property name="text">
-                      <string>Name</string>
+                 <widget class="QWidget" name="tab_3">
+                  <attribute name="title">
+                   <string>Raster Drivers</string>
+                  </attribute>
+                  <layout class="QVBoxLayout" name="verticalLayout_24">
+                   <item>
+                    <widget class="QGroupBox" name="groupBox_16">
+                     <property name="title">
+                      <string>Raster Driver Options</string>
                      </property>
-                    </column>
-                    <column>
-                     <property name="text">
-                      <string>Extension</string>
+                     <layout class="QGridLayout" name="gridLayout_29">
+                      <item row="0" column="1">
+                       <widget class="QComboBox" name="cmbEditCreateOptions"/>
+                      </item>
+                      <item row="0" column="3">
+                       <spacer name="horizontalSpacer_15">
+                        <property name="orientation">
+                         <enum>Qt::Horizontal</enum>
+                        </property>
+                        <property name="sizeHint" stdset="0">
+                         <size>
+                          <width>40</width>
+                          <height>20</height>
+                         </size>
+                        </property>
+                       </spacer>
+                      </item>
+                      <item row="0" column="4">
+                       <widget class="QPushButton" name="pbnEditPyramidsOptions">
+                        <property name="text">
+                         <string>Edit Pyramids Options</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="0" column="5">
+                       <spacer name="horizontalSpacer_16">
+                        <property name="orientation">
+                         <enum>Qt::Horizontal</enum>
+                        </property>
+                        <property name="sizeHint" stdset="0">
+                         <size>
+                          <width>40</width>
+                          <height>20</height>
+                         </size>
+                        </property>
+                       </spacer>
+                      </item>
+                      <item row="0" column="2">
+                       <widget class="QPushButton" name="pbnEditCreateOptions">
+                        <property name="text">
+                         <string>Edit Create Options</string>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QGroupBox" name="groupBox_13">
+                     <property name="title">
+                      <string>Raster Drivers</string>
                      </property>
-                    </column>
-                    <column>
-                     <property name="text">
-                      <string>Flags</string>
+                     <layout class="QGridLayout" name="gridLayout_24">
+                      <item row="0" column="0">
+                       <widget class="QLabel" name="label_17">
+                        <property name="text">
+                         <string>In some cases more than one GDAL driver can be used to load the same raster format. Use the list below to specify which to use.</string>
+                        </property>
+                        <property name="wordWrap">
+                         <bool>true</bool>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="1" column="0">
+                       <widget class="QTreeWidget" name="lstRasterDrivers">
+                        <property name="minimumSize">
+                         <size>
+                          <width>0</width>
+                          <height>141</height>
+                         </size>
+                        </property>
+                        <column>
+                         <property name="text">
+                          <string>Name</string>
+                         </property>
+                        </column>
+                        <column>
+                         <property name="text">
+                          <string>Extension</string>
+                         </property>
+                        </column>
+                        <column>
+                         <property name="text">
+                          <string>Flags</string>
+                         </property>
+                        </column>
+                        <column>
+                         <property name="text">
+                          <string>Description</string>
+                         </property>
+                        </column>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                 <widget class="QWidget" name="tab_4">
+                  <attribute name="title">
+                   <string>Vector Drivers</string>
+                  </attribute>
+                  <layout class="QVBoxLayout" name="verticalLayout_29">
+                   <item>
+                    <widget class="QGroupBox" name="groupBox_31">
+                     <property name="title">
+                      <string>Vector Drivers</string>
                      </property>
-                    </column>
-                    <column>
-                     <property name="text">
-                      <string>Description</string>
-                     </property>
-                    </column>
-                   </widget>
-                  </item>
-                 </layout>
+                     <layout class="QGridLayout" name="gridLayout_36">
+                      <item row="0" column="0">
+                       <widget class="QLabel" name="label_68">
+                        <property name="text">
+                         <string>In some cases more than one GDAL driver can be used to load the same vector format. Use the list below to specify which to use.</string>
+                        </property>
+                        <property name="wordWrap">
+                         <bool>true</bool>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="1" column="0">
+                       <widget class="QTreeWidget" name="lstVectorDrivers">
+                        <property name="minimumSize">
+                         <size>
+                          <width>0</width>
+                          <height>141</height>
+                         </size>
+                        </property>
+                        <column>
+                         <property name="text">
+                          <string>Name</string>
+                         </property>
+                        </column>
+                        <column>
+                         <property name="text">
+                          <string>Extension</string>
+                         </property>
+                        </column>
+                        <column>
+                         <property name="text">
+                          <string>Flags</string>
+                         </property>
+                        </column>
+                        <column>
+                         <property name="text">
+                          <string>Description</string>
+                         </property>
+                        </column>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
                 </widget>
                </item>
               </layout>
@@ -5098,8 +5168,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>633</width>
-                <height>720</height>
+                <width>857</width>
+                <height>682</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_33">
@@ -5586,7 +5656,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                  <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.AppleSystemUIFont'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Noto Sans'; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                </widget>
@@ -5960,7 +6030,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>cmbEditCreateOptions</tabstop>
   <tabstop>pbnEditCreateOptions</tabstop>
   <tabstop>pbnEditPyramidsOptions</tabstop>
-  <tabstop>lstGdalDrivers</tabstop>
+  <tabstop>lstRasterDrivers</tabstop>
   <tabstop>mAuthConfigsGrpBx</tabstop>
   <tabstop>mOptionsScrollArea_10</tabstop>
   <tabstop>mNetworkTimeoutSpinBox</tabstop>


### PR DESCRIPTION
## Description
In QGIS settings there is a GDAL tab with list of available GDAL raster drivers and their capabilities. If several drivers can be used to open data, user can disable some drivers to make sure that data will be opened with required driver. Similar situation with vector formats. For example there are FileGDB and OpenFileGDB drivers to work with .gdb files, but if data file has version 9.x, FileGDB won't be able to open it. But there are no UI with list of available vector drivers.

This pull-requst adds "Vector Drivers" tab to the GDAL section in the QGIS options dialog. At this tab user can see all available vector drivers and their capabilities as well as uncheck drivers which should not be used to open vector data.

Raster drivers
![raster](https://user-images.githubusercontent.com/776954/91309205-fba33f80-e7b8-11ea-9d30-72e07ade781f.png)

Vector drivers
![vector](https://user-images.githubusercontent.com/776954/91309225-01992080-e7b9-11ea-8350-ce9ea2821caa.png)

Fixes #18738.