### PR TITLE
Server: Enhance WMS Layer style restorer for SLD

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -3182,8 +3182,17 @@ namespace QgsWms
   void QgsRenderer::setLayerSld( QgsMapLayer *layer, const QDomElement &sld ) const
   {
     QString err;
+    // Defined sld style name
+    const QStringList styles = layer->styleManager()->styles();
+    QString sldStyleName = "__sld_style";
+    while ( styles.contains( sldStyleName ) )
+    {
+      sldStyleName.append( '@' );
+    }
+    layer->styleManager()->addStyleFromLayer( sldStyleName );
+    layer->styleManager()->setCurrentStyle( sldStyleName );
     layer->readSld( sld, err );
-    layer->setCustomProperty( "readSLD", true );
+    layer->setCustomProperty( "sldStyleName", sldStyleName );
   }
 
   QgsLegendSettings QgsRenderer::legendSettings() const

--- a/src/server/services/wms/qgswmsrestorer.cpp
+++ b/src/server/services/wms/qgswmsrestorer.cpp
@@ -33,20 +33,6 @@ QgsLayerRestorer::QgsLayerRestorer( const QList<QgsMapLayer *> &layers )
 
     settings.mNamedStyle = layer->styleManager()->currentStyle();
 
-    // set a custom property allowing to keep in memory if a SLD file has
-    // been loaded for rendering
-    layer->setCustomProperty( "readSLD", false );
-
-    QString errMsg;
-    QDomDocument styleDoc( QStringLiteral( "style" ) );
-    QDomElement styleXml = styleDoc.createElement( QStringLiteral( "style" ) );
-    styleDoc.appendChild( styleXml );
-    if ( !layer->writeStyle( styleXml, styleDoc, errMsg, QgsReadWriteContext() ) )
-    {
-      QgsMessageLog::logMessage( QStringLiteral( "QGIS Style has not been added to layer restorer for layer %1: %2" ).arg( layer->name(), errMsg ) );
-    }
-    ( void )settings.mQgisStyle.setContent( styleDoc.toString() );
-
     switch ( layer->type() )
     {
       case QgsMapLayerType::VectorLayer:
@@ -92,17 +78,12 @@ QgsLayerRestorer::~QgsLayerRestorer()
     layer->setName( mLayerSettings[layer].name );
 
     // if a SLD file has been loaded for rendering, we restore the previous style
-    if ( layer->customProperty( "readSLD", false ).toBool() )
+    const QString sldStyleName { layer->customProperty( "sldStyleName", "" ).toString() };
+    if ( !sldStyleName.isEmpty() )
     {
-      QString errMsg;
-      QDomElement root = settings.mQgisStyle.documentElement();
-      QgsReadWriteContext context = QgsReadWriteContext();
-      if ( !layer->readStyle( root, errMsg, context ) )
-      {
-        QgsMessageLog::logMessage( QStringLiteral( "QGIS Style has not been read from layer restorer for layer %1: %2" ).arg( layer->name(), errMsg ) );
-      }
+      layer->styleManager()->removeStyle( sldStyleName );
+      layer->removeCustomProperty( "sldStyleName" );
     }
-    layer->removeCustomProperty( "readSLD" );
 
     switch ( layer->type() )
     {

--- a/src/server/services/wms/qgswmsrestorer.h
+++ b/src/server/services/wms/qgswmsrestorer.h
@@ -57,7 +57,6 @@ class QgsLayerRestorer
       QString name;
       double mOpacity;
       QString mNamedStyle;
-      QDomDocument mQgisStyle;
       QString mFilter;
       QgsFeatureIds mSelectedFeatureIds;
     };


### PR DESCRIPTION
## Description

The WMS Layer restorer stored the QGIS style as XML document to restored it after SLD applying.

To speed up QGIS Server WMS request, the SLD will be applied in a dedicated style so it will be not necessary to store the QGIS Style as XML and restore it.
