### PR TITLE
Fix 'invisible news' issue : after hiding the news it never comes back

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12160,6 +12160,8 @@ void QgisApp::showOptionsDialog( QWidget *parent, const QString &currentPage, in
     double factor = mySettings.value( QStringLiteral( "qgis/magnifier_factor_default" ), 1.0 ).toDouble();
     mMagnifierWidget->setDefaultFactor( factor );
     mMagnifierWidget->updateMagnification( factor );
+
+    mWelcomePage->updateNewsFeedVisibility();
   }
 }
 

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -678,7 +678,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mSimplifyAlgorithmComboBox->addItem( tr( "Visvalingam" ), static_cast<int>( QgsVectorSimplifyMethod::Visvalingam ) );
   mSimplifyAlgorithmComboBox->setCurrentIndex( mSimplifyAlgorithmComboBox->findData( mSettings->enumValue( QStringLiteral( "/qgis/simplifyAlgorithm" ), QgsVectorSimplifyMethod::NoSimplification ) ) );
 
-  // Slightly awkard here at the settings value is true to use QImage,
+  // Slightly awkward here at the settings value is true to use QImage,
   // but the checkbox is true to use QPixmap
   chkAddedVisibility->setChecked( mSettings->value( QStringLiteral( "/qgis/new_layers_visible" ), true ).toBool() );
   cbxLegendClassifiers->setChecked( mSettings->value( QStringLiteral( "/qgis/showLegendClassifiers" ), false ).toBool() );

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -438,8 +438,11 @@ void QgsWelcomePage::updateNewsFeedVisibility()
   else
   {
     mSplitter2->restoreState( QgsSettings().value( QStringLiteral( "Windows/WelcomePage/SplitState2" ), QVariant(), QgsSettings::App ).toByteArray() );
-    int splitSize = mSplitter2->height() / 2;
-    mSplitter2->setSizes( QList< int > { splitSize, splitSize} );
+    if ( mSplitter2->sizes().first() == 0 )
+    {
+      int splitSize = mSplitter2->height() / 2;
+      mSplitter2->setSizes( QList< int > { splitSize, splitSize} );
+    }
   }
 }
 

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -438,6 +438,8 @@ void QgsWelcomePage::updateNewsFeedVisibility()
   else
   {
     mSplitter2->restoreState( QgsSettings().value( QStringLiteral( "Windows/WelcomePage/SplitState2" ), QVariant(), QgsSettings::App ).toByteArray() );
+    int splitSize = mSplitter2->height() / 2;
+    mSplitter2->setSizes( QList< int > { splitSize, splitSize} );
   }
 }
 

--- a/src/app/qgswelcomepage.h
+++ b/src/app/qgswelcomepage.h
@@ -63,6 +63,8 @@ class QgsWelcomePage : public QWidget
     void showContextMenuForProjects( QPoint point );
     void showContextMenuForTemplates( QPoint point );
     void showContextMenuForNews( QPoint point );
+
+  public slots:
     void updateNewsFeedVisibility();
 
   private:


### PR DESCRIPTION
Should be backported to LTR too.

## Description

There is a bug in QGIS where if you go to settings and hide the news feed, then re-enable it in settings, you never see it displayed.  This is because the restore logic first sets it to 0 when hiding it then restores it to the last size (i.e. 0) when restoring it. I added logic so that restoring the news now sets the splitter to 50% of the height. The screencast below shows it now restoring properly.

![qgis-news-resizing](https://user-images.githubusercontent.com/178003/91553919-1ba44180-e926-11ea-9459-01c9b9944929.gif)


As a second improvement we could also force the news panel to update after changing settings...something for another time....