### PR TITLE
Another walk through expressions

### DIFF
--- a/resources/function_help/json/aggregate
+++ b/resources/function_help/json/aggregate
@@ -17,6 +17,7 @@
 	{ "expression":"aggregate(layer:='rail_stations',aggregate:='sum',expression:=\"passengers\",filter:=\"class\">3)", "returns":"sums up all values from the \"passengers\" field from features where the \"class\" attribute is greater than 3 only"},
 	{ "expression":"aggregate(layer:='rail_stations',aggregate:='concatenate', expression:=\"name\", concatenator:=',')", "returns":"comma separated list of the name field for all features in the rail_stations layer"},
 	{ "expression":"aggregate(layer:='countries', aggregate:='max', expression:=\"code\", filter:=intersects( $geometry, geometry(@parent) ) )", "returns":"The country code of an intersecting country on the layer 'countries'"},
-	{ "expression":"aggregate(layer:='rail_stations',aggregate:='sum',expression:=\"passengers\",filter:=contains( @atlas_geometry, $geometry ) )", "returns":"sum of all values from the passengers field in the rail_stations within the current atlas feature"}
+	{ "expression":"aggregate(layer:='rail_stations',aggregate:='sum',expression:=\"passengers\",filter:=contains( @atlas_geometry, $geometry ) )", "returns":"sum of all values from the passengers field in the rail_stations within the current atlas feature"},
+	{ "expression":"aggregate(layer:='rail_stations', aggregate:='collect', expression:=centroid($geometry), filter:=\"region_name\" = attribute(@parent,'name') )", "returns":"aggregates centroid geometries of the rail_stations of the same region as current feature"}
 	]
 }

--- a/resources/function_help/json/close_line
+++ b/resources/function_help/json/close_line
@@ -4,6 +4,6 @@
   "groups": ["GeometryGroup"],
   "description": "Returns a closed line string of the input line string by appending the first point to the end of the line, if it is not already closed. If the geometry is not a line string or multi line string then the result will be NULL.",
   "arguments": [ {"arg":"geometry","description":"a line string geometry"}],
-  "examples": [ { "expression":"geom_to_wkt(close_line(geom_from_wkt('LINESTRING(0 0, 1 0, 1 1)')))", "returns":"LineString (0 0, 1 0, 1 1, 0 0)"},
-                { "expression":"geom_to_wkt(close_line(geom_from_wkt('LINESTRING(0 0, 1 0, 1 1, 0 0)')))", "returns":"LineString (0 0, 1 0, 1 1, 0 0)"}]
+  "examples": [ { "expression":"geom_to_wkt(close_line(geom_from_wkt('LINESTRING(0 0, 1 0, 1 1)')))", "returns":"'LineString (0 0, 1 0, 1 1, 0 0)'"},
+                { "expression":"geom_to_wkt(close_line(geom_from_wkt('LINESTRING(0 0, 1 0, 1 1, 0 0)')))", "returns":"'LineString (0 0, 1 0, 1 1, 0 0)'"}]
 }

--- a/resources/function_help/json/closest_point
+++ b/resources/function_help/json/closest_point
@@ -10,7 +10,7 @@
   "examples": [
     {
       "expression":"geom_to_wkt(closest_point(geom_from_wkt('LINESTRING (20 80, 98 190, 110 180, 50 75 )'),geom_from_wkt('POINT(100 100)')))",
-      "returns":"Point(73.0769 115.384)"
+      "returns":"'Point(73.0769 115.384)'"
     }
   ]
 }

--- a/resources/function_help/json/collect
+++ b/resources/function_help/json/collect
@@ -9,6 +9,7 @@
 	{"arg":"filter", "optional":true, "description":"optional expression to use to filter features used to calculate aggregate"}
   ],
   "examples": [
-	{ "expression":"collect( $geometry )", "returns":"multipart geometry of aggregated geometries"}
+	{ "expression":"collect( $geometry )", "returns":"multipart geometry of aggregated geometries"},
+	{ "expression":"collect( centroid($geometry), group_by:=\"region\", filter:= \"use\" = 'civilian' )", "returns":"aggregated centroids of the civilian features based on their region value"}
   ]
 }

--- a/resources/function_help/json/combine
+++ b/resources/function_help/json/combine
@@ -5,8 +5,8 @@
   "description": "Returns the combination of two geometries.",
   "arguments": [ {"arg":"geometry1","description":"a geometry"},
                  {"arg":"geometry2","description":"a geometry"}],
-  "examples": [ { "expression":"geom_to_wkt( combine( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 2 1)' ) ) )", "returns":"MULTILINESTRING((4 4, 2 1), (3 3, 4 4), (4 4, 5 5))"},
-  { "expression":"geom_to_wkt( combine( geom_from_wkt( 'LINESTRING(3 3, 4 4)' ), geom_from_wkt( 'LINESTRING(3 3, 6 6, 2 1)' ) ) )", "returns":"LINESTRING(3 3, 4 4, 6 6, 2 1)"}
+  "examples": [ { "expression":"geom_to_wkt( combine( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 2 1)' ) ) )", "returns":"'MULTILINESTRING((4 4, 2 1), (3 3, 4 4), (4 4, 5 5))'"},
+  { "expression":"geom_to_wkt( combine( geom_from_wkt( 'LINESTRING(3 3, 4 4)' ), geom_from_wkt( 'LINESTRING(3 3, 6 6, 2 1)' ) ) )", "returns":"'LINESTRING(3 3, 4 4, 6 6, 2 1)'"}
   ]
 }
 

--- a/resources/function_help/json/concatenate
+++ b/resources/function_help/json/concatenate
@@ -7,7 +7,7 @@
 	{"arg":"expression", "description":"sub expression of field to aggregate"},
 	{"arg":"group_by", "optional":true, "description":"optional expression to use to group aggregate calculations"},
 	{"arg":"filter", "optional":true, "description":"optional expression to use to filter features used to calculate aggregate"},
-	{"arg":"concatenator", "optional":true, "default":"''", "description":"optional string to use to join values"},
+	{"arg":"concatenator", "optional":true, "description":"optional string to use to join values. Empty by default."},
 	{"arg":"order_by", "optional":true, "description":"optional expression to use to order features used to calculate aggregate. By default, the features will be returned in an unspecified order."}
   ],
   "examples": [

--- a/resources/function_help/json/concatenate_unique
+++ b/resources/function_help/json/concatenate_unique
@@ -7,10 +7,10 @@
 	{"arg":"expression", "description":"sub expression of field to aggregate"},
 	{"arg":"group_by", "optional":true, "description":"optional expression to use to group aggregate calculations"},
 	{"arg":"filter", "optional":true, "description":"optional expression to use to filter features used to calculate aggregate"},
-	{"arg":"concatenator", "optional":true, "default":"''", "description":"optional string to use to join values"},
+	{"arg":"concatenator", "optional":true, "description":"optional string to use to join values. Empty by default."},
 	{"arg":"order_by", "optional":true, "description":"optional expression to use to order features used to calculate aggregate. By default, the features will be returned in an unspecified order."}
   ],
   "examples": [
-	{ "expression":"concatenate(\"town_name\",group_by:=\"state\",concatenator:=',')", "returns":"comma separated list of unique town_names, grouped by state field"}
+	{ "expression":"concatenate_unique(\"town_name\",group_by:=\"state\",concatenator:=',')", "returns":"comma separated list of unique town_names, grouped by state field"}
   ]
 }

--- a/resources/function_help/json/convex_hull
+++ b/resources/function_help/json/convex_hull
@@ -4,6 +4,6 @@
   "groups": ["GeometryGroup"],
   "description": "Returns the convex hull of a geometry. It represents the minimum convex geometry that encloses all geometries within the set.",
   "arguments": [ {"arg":"geometry","description":"a geometry"}],
-  "examples": [ { "expression":"geom_to_wkt( convex_hull( geom_from_wkt( 'LINESTRING(3 3, 4 4, 4 10)' ) ) )", "returns":"POLYGON((3 3,4 10,4 4,3 3))"}
+  "examples": [ { "expression":"geom_to_wkt( convex_hull( geom_from_wkt( 'LINESTRING(3 3, 4 4, 4 10)' ) ) )", "returns":"'POLYGON((3 3, 4 10, 4 4, 3 3))'"}
   ]
 }

--- a/resources/function_help/json/difference
+++ b/resources/function_help/json/difference
@@ -5,5 +5,5 @@
   "description": "Returns a geometry that represents that part of geometry1 that does not intersect with geometry2.",
   "arguments": [ {"arg":"geometry1","description":"a geometry"},
                  {"arg":"geometry2","description":"a geometry"}],
-  "examples": [ { "expression":"geom_to_wkt( difference( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4)' ) ) )", "returns":"LINESTRING(4 4, 5 5)"} ]
+  "examples": [ { "expression":"geom_to_wkt( difference( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4)' ) ) )", "returns":"'LINESTRING(4 4, 5 5)'"} ]
 }

--- a/resources/function_help/json/extend
+++ b/resources/function_help/json/extend
@@ -6,6 +6,6 @@
   "arguments": [ {"arg":"geometry","description":"a (multi)linestring geometry"},
                  {"arg":"start_distance","description":"distance to extend the start of the line"},
                  {"arg":"end_distance","description":"distance to extend the end of the line."}],
-  "examples": [ { "expression":"geom_to_wkt(extend(geom_from_wkt('LineString(0 0, 1 0, 1 1)'),1,2))", "returns":"LineString (-1 0, 1 0, 1 3)"}]
+  "examples": [ { "expression":"geom_to_wkt(extend(geom_from_wkt('LineString(0 0, 1 0, 1 1)'),1,2))", "returns":"'LineString (-1 0, 1 0, 1 3)'"}]
 }
 

--- a/resources/function_help/json/extend
+++ b/resources/function_help/json/extend
@@ -7,6 +7,5 @@
                  {"arg":"start_distance","description":"distance to extend the start of the line"},
                  {"arg":"end_distance","description":"distance to extend the end of the line."}],
   "examples": [ { "expression":"geom_to_wkt(extend(geom_from_wkt('LineString(0 0, 1 0, 1 1)'),1,2))", "returns":"'LineString (-1 0, 1 0, 1 3)'"},
-                { "expression":"geom_to_wkt(extend(geom_from_wkt('multiLineString((0 0, 1 0, 1 1), (2 2, 0 2, 0 5))'),1,2))", "returns":"'MultiLineString ((-1 0, 1 0, 1 3),(3 2, 0 2, 0 7))'"}]
+                { "expression":"geom_to_wkt(extend(geom_from_wkt('MultiLineString((0 0, 1 0, 1 1), (2 2, 0 2, 0 5))'),1,2))", "returns":"'MultiLineString ((-1 0, 1 0, 1 3),(3 2, 0 2, 0 7))'"}]
 }
-

--- a/resources/function_help/json/extend
+++ b/resources/function_help/json/extend
@@ -2,10 +2,11 @@
   "name": "extend",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Extends the start and end of a linestring geometry by a specified amount. Lines are extended using the bearing of the first and last segment in the line. Distances are in the Spatial Reference System of this geometry.",
+  "description": "Extends the start and end of a linestring geometry by a specified amount. Lines are extended using the bearing of the first and last segment in the line. For a multilinestring, all the parts are extended. Distances are in the Spatial Reference System of this geometry.",
   "arguments": [ {"arg":"geometry","description":"a (multi)linestring geometry"},
                  {"arg":"start_distance","description":"distance to extend the start of the line"},
                  {"arg":"end_distance","description":"distance to extend the end of the line."}],
-  "examples": [ { "expression":"geom_to_wkt(extend(geom_from_wkt('LineString(0 0, 1 0, 1 1)'),1,2))", "returns":"'LineString (-1 0, 1 0, 1 3)'"}]
+  "examples": [ { "expression":"geom_to_wkt(extend(geom_from_wkt('LineString(0 0, 1 0, 1 1)'),1,2))", "returns":"'LineString (-1 0, 1 0, 1 3)'"},
+                { "expression":"geom_to_wkt(extend(geom_from_wkt('multiLineString((0 0, 1 0, 1 1), (2 2, 0 2, 0 5))'),1,2))", "returns":"'MultiLineString ((-1 0, 1 0, 1 3),(3 2, 0 2, 0 7))'"}]
 }
 

--- a/resources/function_help/json/flip_coordinates
+++ b/resources/function_help/json/flip_coordinates
@@ -4,6 +4,6 @@
   "groups": ["GeometryGroup"],
   "description": "Returns a copy of the geometry with the x and y coordinates swapped. Useful for repairing geometries which have had their latitude and longitude values reversed.",
   "arguments": [ {"arg":"geometry","description":"a geometry"}],
-  "examples": [ { "expression":"geom_to_wkt(flip_coordinates(make_point(1, 2)))", "returns":"Point (2 1)"}
+  "examples": [ { "expression":"geom_to_wkt(flip_coordinates(make_point(1, 2)))", "returns":"'Point (2 1)'"}
   ]
 }

--- a/resources/function_help/json/force_rhr
+++ b/resources/function_help/json/force_rhr
@@ -4,6 +4,6 @@
   "groups": ["GeometryGroup"],
   "description": "Forces a geometry to respect the Right-Hand-Rule, in which the area that is bounded by a polygon is to the right of the boundary. In particular, the exterior ring is oriented in a clockwise direction and the interior rings in a counter-clockwise direction.",
   "arguments": [ {"arg":"geometry","description":"a geometry. Any non-polygon geometries are returned unchanged."}],
-  "examples": [ { "expression":"geom_to_wkt(force_rhr(geometry:=geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1))')))", "returns":"Polygon ((-1 -1, 0 2, 4 2, 4 0, -1 -1))"}]
+  "examples": [ { "expression":"geom_to_wkt(force_rhr(geometry:=geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1))')))", "returns":"'Polygon ((-1 -1, 0 2, 4 2, 4 0, -1 -1))'"}]
 }
 

--- a/resources/function_help/json/geom_to_wkt
+++ b/resources/function_help/json/geom_to_wkt
@@ -6,7 +6,7 @@
   "arguments": [ {"arg":"geometry","description":"a geometry"},
                  {"arg":"precision","description":"numeric precision", "optional":true, "default":"8"}],
   "examples": [ { "expression":"geom_to_wkt( make_point(6, 50) )", "returns":"'POINT(6 50)'"},
-                { "expression":"geom_to_wkt(centroid(geom_from_wkt('Polygon((1 1, 0 0, -1 1, 1 1))')))", "returns":"POINT(0 0.66666667)"},
-                { "expression":"geom_to_wkt(centroid(geom_from_wkt('Polygon((1 1, 0 0, -1 1, 1 1))')), 2)", "returns":"POINT(0 0.67)"}
+                { "expression":"geom_to_wkt(centroid(geom_from_wkt('Polygon((1 1, 0 0, -1 1, 1 1))')))", "returns":"'POINT(0 0.66666667)'"},
+                { "expression":"geom_to_wkt(centroid(geom_from_wkt('Polygon((1 1, 0 0, -1 1, 1 1))')), 2)", "returns":"'POINT(0 0.67)'"}
  ]
 }

--- a/resources/function_help/json/intersection
+++ b/resources/function_help/json/intersection
@@ -5,5 +5,5 @@
   "description": "Returns a geometry that represents the shared portion of two geometries.",
   "arguments": [ {"arg":"geometry1","description":"a geometry"},
                  {"arg":"geometry2","description":"a geometry"}],
-  "examples": [ { "expression":"geom_to_wkt( intersection( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4)' ) ) )", "returns":"LINESTRING(3 3, 4 4)"} ]
+  "examples": [ { "expression":"geom_to_wkt( intersection( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4)' ) ) )", "returns":"'LINESTRING(3 3, 4 4)'"} ]
 }

--- a/resources/function_help/json/intersection
+++ b/resources/function_help/json/intersection
@@ -5,5 +5,7 @@
   "description": "Returns a geometry that represents the shared portion of two geometries.",
   "arguments": [ {"arg":"geometry1","description":"a geometry"},
                  {"arg":"geometry2","description":"a geometry"}],
-  "examples": [ { "expression":"geom_to_wkt( intersection( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4)' ) ) )", "returns":"'LINESTRING(3 3, 4 4)'"} ]
+  "examples": [ { "expression":"geom_to_wkt( intersection( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4)' ) ) )", "returns":"'LINESTRING(3 3, 4 4)'"},
+  { "expression":"geom_to_wkt( intersection( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'MULTIPOINT(3.5 3.5, 4 5)' ) ) )", "returns":"'POINT(3.5 3.5)'"}
+  ]
 }

--- a/resources/function_help/json/minimal_circle
+++ b/resources/function_help/json/minimal_circle
@@ -7,7 +7,7 @@
     {"arg":"geometry","description":"a geometry"},
     {"arg":"segments", "optional": true, "default": "36", "description": "optional argument for polygon segmentation. By default this value is 36"}],
   "examples": [
-    { "expression":"geom_to_wkt( minimal_circle( geom_from_wkt( 'LINESTRING(0 5, 0 -5, 2 1)' ), 4 ) )", "returns":"Polygon ((0 5, 5 -0, -0 -5, -5 0, 0 5))"},
-    { "expression":"geom_to_wkt( minimal_circle( geom_from_wkt( 'MULTIPOINT(1 2, 3 4, 3 2)' ), 4 ) )", "returns":"Polygon ((3 4, 3 2, 1 2, 1 4, 3 4))"}
+    { "expression":"geom_to_wkt( minimal_circle( geom_from_wkt( 'LINESTRING(0 5, 0 -5, 2 1)' ), 4 ) )", "returns":"'Polygon ((0 5, 5 -0, -0 -5, -5 0, 0 5))'"},
+    { "expression":"geom_to_wkt( minimal_circle( geom_from_wkt( 'MULTIPOINT(1 2, 3 4, 3 2)' ), 4 ) )", "returns":"'Polygon ((3 4, 3 2, 1 2, 1 4, 3 4))'"}
   ]
 }

--- a/resources/function_help/json/op_regex
+++ b/resources/function_help/json/op_regex
@@ -1,7 +1,7 @@
 {
   "name": "~",
   "type": "operator",
-  "description": "Performs a regular expression match on a string value.",
+  "description": "Performs a regular expression match on a string value. Backslash characters must be double escaped (e.g., \"\\\\\\\\s\" to match a white space character).",
   "arguments": [
         { "arg": "string", "description": "A string value" },
         { "arg": "regex", "description": "A regular expression. Slashes must be escaped, eg \\\\\\\\d." }
@@ -9,6 +9,7 @@
   "examples": [
 	{ "expression":"'hello' ~ 'll'", "returns":"1"},
 	{ "expression":"'hello' ~ '^ll'", "returns":"0"},
-	{ "expression":"'hello' ~ 'llo$'", "returns":"1"}
+	{ "expression":"'hello' ~ 'llo$'", "returns":"1"},
+	{ "expression":"'abc123' ~ '\\\\\\\\d+'", "returns":"1"}
   ]
 }

--- a/resources/function_help/json/order_parts
+++ b/resources/function_help/json/order_parts
@@ -10,12 +10,12 @@
   ],
   "examples": [
     {
-      "expression":"order_parts(geom_from_wkt('MultiPolygon (((1 1, 5 1, 5 5, 1 5, 1 1)),((1 1, 9 1, 9 9, 1 9, 1 1)))'), 'area($geometry)', False)",
-      "returns":"MultiPolygon (((1 1, 9 1, 9 9, 1 9, 1 1)),((1 1, 5 1, 5 5, 1 5, 1 1)))"
+      "expression":"geom_to_wkt(order_parts(geom_from_wkt('MultiPolygon (((1 1, 5 1, 5 5, 1 5, 1 1)),((1 1, 9 1, 9 9, 1 9, 1 1)))'), 'area($geometry)', False))",
+      "returns":"'MultiPolygon (((1 1, 9 1, 9 9, 1 9, 1 1)),((1 1, 5 1, 5 5, 1 5, 1 1)))'"
     },
     {
-      "expression":"order_parts(geom_from_wkt('LineString(1 2, 3 2, 4 3)'), '1', True)",
-      "returns":"LineString(1 2, 3 2, 4 3)"
+      "expression":"geom_to_wkt(order_parts(geom_from_wkt('LineString(1 2, 3 2, 4 3)'), '1', True))",
+      "returns":"'LineString(1 2, 3 2, 4 3)'"
     }
   ]
 }

--- a/resources/function_help/json/oriented_bbox
+++ b/resources/function_help/json/oriented_bbox
@@ -4,6 +4,6 @@
   "groups": ["GeometryGroup"],
   "description":"Returns a geometry which represents the minimal oriented bounding box of an input geometry.",
   "arguments": [ {"arg":"geometry","description":"a geometry"} ],
-  "examples": [ { "expression":"geom_to_wkt( oriented_bbox( geom_from_wkt( 'MULTIPOINT(1 2, 3 4, 3 2)' ) ) )", "returns":"Polygon ((1 4, 1 2, 3 2, 3 4, 1 4))"}]
+  "examples": [ { "expression":"geom_to_wkt( oriented_bbox( geom_from_wkt( 'MULTIPOINT(1 2, 3 4, 3 2)' ) ) )", "returns":"'Polygon ((3 2, 3 4, 1 4, 1 2, 3 2))'"}]
 }
 

--- a/resources/function_help/json/pole_of_inaccessibility
+++ b/resources/function_help/json/pole_of_inaccessibility
@@ -5,5 +5,5 @@
   "description": "Calculates the approximate pole of inaccessibility for a surface, which is the most distant internal point from the boundary of the surface. This function uses the 'polylabel' algorithm (Vladimir Agafonkin, 2016), which is an iterative approach guaranteed to find the true pole of inaccessibility within a specified tolerance. More precise tolerances require more iterations and will take longer to calculate.",
   "arguments": [ {"arg":"geometry","description":"a geometry"},
                  {"arg":"tolerance","description":"maximum distance between the returned point and the true pole location"}],
-  "examples": [ { "expression":"geom_to_wkt(pole_of_inaccessibility( geom_from_wkt('POLYGON((0 1,0 9,3 10,3 3, 10 3, 10 1, 0 1))'), 0.1))", "returns":"Point(1.55, 1.55)"}]
+  "examples": [ { "expression":"geom_to_wkt(pole_of_inaccessibility( geom_from_wkt('POLYGON((0 1, 0 9, 3 10, 3 3, 10 3, 10 1, 0 1))'), 0.1))'", "returns":"'Point(1.546875 2.546875)'"}]
 }

--- a/resources/function_help/json/project
+++ b/resources/function_help/json/project
@@ -10,6 +10,6 @@
     {"arg":"elevation","description":"angle of inclination in radians", "optional":true}
   ],
   "examples": [
-	{ "expression":"geom_to_wkt(project(make_point(1, 2), 3, radians(270)))", "returns":"Point(-2, 2)"}
+	{ "expression":"geom_to_wkt(project(make_point(1, 2), 3, radians(270)))", "returns":"'Point(-2, 2)'"}
   ]
 }

--- a/resources/function_help/json/regexp_replace
+++ b/resources/function_help/json/regexp_replace
@@ -7,5 +7,8 @@
   {"arg":"regex","description":"The regular expression to replace. Backslash characters must be double escaped (e.g., \"\\\\\\\\s\" to match a white space character)."},
   {"arg":"replacement","description":"The string that will replace any matching occurrences of the supplied regular expression. Captured groups can be inserted into the replacement string using \\\\\\\\1, \\\\\\\\2, etc."}
   ],
-  "examples": [ { "expression":"regexp_replace('QGIS SHOULD ROCK','\\\\\\\\sSHOULD\\\\\\\\s',' DOES ')", "returns":"'QGIS DOES ROCK'"}]
+  "examples": [ { "expression":"regexp_replace('QGIS SHOULD ROCK','\\\\\\\\sSHOULD\\\\\\\\s',' DOES ')", "returns":"'QGIS DOES ROCK'"},
+                { "expression":"regexp_replace('ABC123','\\\\\\\\d+','')", "returns":"'ABC'"},
+                { "expression":"regexp_replace('my name is John','(.*) is (.*)','\\\\\\\\2 is \\\\\\\\1')", "returns":"'John is my name'"}
+              ]
 }

--- a/resources/function_help/json/shortest_line
+++ b/resources/function_help/json/shortest_line
@@ -10,7 +10,7 @@
   "examples": [
     {
       "expression":"geom_to_wkt(shortest_line(geom_from_wkt('LINESTRING (20 80, 98 190, 110 180, 50 75 )'),geom_from_wkt('POINT(100 100)')))",
-      "returns":"LineString(73.0769 115.384, 100 100)"
+      "returns":"'LineString(73.0769 115.384, 100 100)'"
     }
   ]
 }

--- a/resources/function_help/json/sym_difference
+++ b/resources/function_help/json/sym_difference
@@ -5,5 +5,5 @@
   "description": "Returns a geometry that represents the portions of two geometries that do not intersect.",
   "arguments": [ {"arg":"geometry1","description":"a geometry"},
                  {"arg":"geometry2","description":"a geometry"}],
-  "examples": [ { "expression":"geom_to_wkt( sym_difference( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 8 8)' ) ) )", "returns":"LINESTRING(5 5, 8 8)"} ]
+  "examples": [ { "expression":"geom_to_wkt( sym_difference( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 8 8)' ) ) )", "returns":"'LINESTRING(5 5, 8 8)'"} ]
 }

--- a/resources/function_help/json/transform
+++ b/resources/function_help/json/transform
@@ -7,6 +7,6 @@
   {"arg":"source_auth_id","description":"the source auth CRS ID"},
   {"arg":"dest_auth_id","description":"the destination auth CRS ID"}
   ],
-  "examples": [ { "expression":"geom_to_wkt( transform( $geometry, 'EPSG:2154', 'EPSG:4326' ) )", "returns":"POINT(0 51)"}
+  "examples": [ { "expression":"geom_to_wkt( transform( make_point(488995.53240249, 7104473.38600835), 'EPSG:2154', 'EPSG:4326' ) )", "returns":"'POINT(0 51)'"}
   ]
 }

--- a/resources/function_help/json/union
+++ b/resources/function_help/json/union
@@ -5,5 +5,5 @@
   "description": "Returns a geometry that represents the point set union of the geometries.",
   "arguments": [ {"arg":"geometry1","description":"a geometry"},
                  {"arg":"geometry2","description":"a geometry"}],
-  "examples": [ { "expression":"geom_to_wkt( union( geom_from_wkt( 'POINT(4 4)' ), geom_from_wkt( 'POINT(5 5)' ) ) )", "returns":"MULTIPOINT(4 4, 5 5)"} ]
+  "examples": [ { "expression":"geom_to_wkt( union( make_point(4, 4), make_point(5, 5) ) )", "returns":"'MULTIPOINT(4 4, 5 5)'"} ]
 }


### PR DESCRIPTION
- Indicate the geom_to_wkt output as a string
- Indicate actual input/output for examples if possible 
- Fix description of the filter argument of the concatenate* function. '' as default value looked confusing IMO.
- Mention backslash for ~ function (fix qgis/QGIS-Documentation#5760) and add some regex examples
- Add example to the collect aggregate function (fix #24962)
