### PR TITLE
Server: Call QgsProject::setInstance on project passed as parameter

### DIFF
--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -1985,7 +1985,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     friend class QgsProviderRegistry;
 
     // Required by QGIS Server for switching the current project instance
-    friend class QgsConfigCache;
+    friend class QgsServer;
 
     friend class TestQgsProject;
 };

--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -112,7 +112,6 @@ const QgsProject *QgsConfigCache::project( const QString &path, QgsServerSetting
         QStringLiteral( "Server" ), Qgis::Critical );
     }
   }
-  QgsProject::setInstance( mProjectCache[ path ] );
   return mProjectCache[ path ];
 
 }

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -373,6 +373,9 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
         project = mConfigCache->project( configFilePath, sServerInterface->serverSettings() );
       }
 
+      // Set the current project instance
+      QgsProject::setInstance( const_cast<QgsProject *>( project ) );
+
       if ( project )
       {
         sServerInterface->setConfigFilePath( project->fileName() );


### PR DESCRIPTION
## Description

Category: bugfix

The `QgsConfigCache::project` method implicitely pass the project to `QgsProject:setInstance`. 

However passing explicitely a project as parameter to `QgsServerHandler` bypass the config cache lookup and the project is not passed to `QgsProject:setInstance` as the current instance. 

Because of this, errors occurs on rendering, especially with the getPrint request:  see https://github.com/3liz/py-qgis-server/issues/18.

This PR introduce a fix by moving the  `setInstance` call outside of the `QgsConfigCache` and apply it to the current project  in a consisent way.

This issue prevent using the Qgis server python to be used correctly with instanciated QgisProject outside the config cache: I would strongly advise a backport to ltr (3.10) and release (3.14)