### PR TITLE
Add easter egg to show map of user groups (keywords: 'user groups')

### DIFF
--- a/resources/data/user_groups.qml
+++ b/resources/data/user_groups.qml
@@ -1,0 +1,90 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.15.0-Master" styleCategories="Symbology|MapTips">
+  <renderer-v2 type="RuleRenderer" symbollevels="0" forceraster="0" enableorderby="0">
+    <rules key="{7c035b8b-7431-4fee-87be-6dc156a20233}">
+      <rule symbol="0" filter="ug_name is not NULL" key="{49603121-7528-4de3-885b-45a422234c3b}" label="User group"/>
+      <rule symbol="1" filter="ELSE" key="{b7e9bc39-65ae-47ca-af82-6a3d3b0c49be}" label="No user group"/>
+    </rules>
+    <symbols>
+      <symbol alpha="1" clip_to_extent="1" type="fill" name="0" force_rhr="0">
+        <layer locked="0" pass="0" enabled="1" class="GradientFill">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="145,175,35,255"/>
+          <prop k="color1" v="247,252,245,255"/>
+          <prop k="color2" v="0,68,27,255"/>
+          <prop k="color_type" v="0"/>
+          <prop k="coordinate_mode" v="0"/>
+          <prop k="discrete" v="0"/>
+          <prop k="gradient_color2" v="93,152,48,255"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="rampType" v="gradient"/>
+          <prop k="reference_point1" v="0.5,0"/>
+          <prop k="reference_point1_iscentroid" v="0"/>
+          <prop k="reference_point2" v="0.5,1"/>
+          <prop k="reference_point2_iscentroid" v="0"/>
+          <prop k="spread" v="0"/>
+          <prop k="stops" v="0.13;229,245,224,255:0.26;199,233,192,255:0.39;161,217,155,255:0.52;116,196,118,255:0.65;65,171,93,255:0.78;35,139,69,255:0.9;0,109,44,255"/>
+          <prop k="type" v="0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+        <layer locked="0" pass="0" enabled="1" class="SimpleFill">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="77,175,74,255"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="56,128,54,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="no"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" clip_to_extent="1" type="fill" name="1" force_rhr="0">
+        <layer locked="0" pass="0" enabled="1" class="SimpleFill">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="224,220,202,154"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="119,116,104,154"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <mapTip>&lt;b style="color:#505050">[% "ug_name" %]&lt;/b>&lt;br>
+&lt;img style="height:70px" src="[% ug_logo_url %]" alt="(No user group in [% NAME %])">&lt;br>
+&lt;a href="[% ug_website %]">[% "ug_website" %]&lt;/a>&lt;br>
+&lt;i style="color:gray">[% CASE WHEN "ug_year" IS NOT NULL THEN '(Registered in '|| "ug_year" ||')' ELSE '' END %]&lt;/i></mapTip>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/resources/data/user_groups_data.json
+++ b/resources/data/user_groups_data.json
@@ -1,0 +1,259 @@
+{
+  "type": "FeatureCollection",
+  "name": "user_groups_data",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "CO",
+        "name": "Grupo de Usuarios QGIS Colombia",
+        "logo_url": "https:\/\/raw.githubusercontent.com\/qgisco\/material-difusion\/master\/logos\/qgisco_logo_qgis_colombia_347x150.png",
+        "website": "https:\/\/qgisusers.co",
+        "year": 2018
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "BR",
+        "name": "QGIS Brasil (Brazil)",
+        "logo_url": "https:\/\/i1.wp.com\/qgisbrasil.org\/wp-content\/uploads\/2017\/08\/mini_qgis_brasil_original.png",
+        "website": "http:\/\/qgisbrasil.org",
+        "year": 2016
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "FR",
+        "name": "Groupe des Utilisateurs de QGIS - France",
+        "logo_url": "https:\/\/raw.githubusercontent.com\/OSGeo-fr\/QGIS-user-fr\/c778257ef4e01af531d43d2c9c257b30f7b495f5\/marketing\/logos\/qgis-logo-fr_final.svg",
+        "website": "http:\/\/conf.qgis.osgeo.fr",
+        "year": 2017
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "DK",
+        "name": "QGIS Brugergruppe Danmark (Denmark)",
+        "logo_url": "https:\/\/changelog.qgis.org\/media\/images\/projects\/d21940f669c52525e7d73835885f27a570d3c80c.png",
+        "website": "http:\/\/qgis.dk",
+        "year": 2015
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "GB",
+        "name": "QGIS UK (England, Scotland, Wales)",
+        "logo_url": "https:\/\/pbs.twimg.com\/profile_images\/864206708272484352\/rqOeGldR_400x400.jpg",
+        "website": "http:\/\/qgis.uk",
+        "year": 2015
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "DE",
+        "name": "QGIS Anwendergruppe Deutschland (Germany)",
+        "logo_url": "https:\/\/qgis.de\/lib\/exe\/fetch.php?w=164&tok=7ed605&media=site:qgis-de3_b.png",
+        "website": "http:\/\/qgis.de",
+        "year": 2015
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "IT",
+        "name": "Gruppo degli utenti italiani di QGIS (Italy)",
+        "logo_url": "https:\/\/pbs.twimg.com\/profile_images\/1214617887761207301\/SRkxH22U_400x400.jpg",
+        "website": "http:\/\/qgis.it",
+        "year": 2015
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "JP",
+        "name": "QGIS User Group Japan (OSGeo.JP)",
+        "logo_url": "https:\/\/www.qgis.org\/en\/_static\/logo.png",
+        "website": "http:\/\/qgis.jp",
+        "year": 2016
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "PE",
+        "name": "Lima Perú QGIS User Group (Peru)",
+        "logo_url": "https:\/\/avatars0.githubusercontent.com\/u\/68319150?s=200&v=4",
+        "website": "http:\/\/qgis.pe",
+        "year": 2015
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "PL",
+        "name": "Polska Grupa Użytkowników QGIS (Poland)",
+        "logo_url": "http:\/\/qgis.pl\/_static\/logo.png",
+        "website": "http:\/\/qgis.pl",
+        "year": 2016
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "PT",
+        "name": "QGIS Portugal",
+        "logo_url": "https:\/\/www.qgis.pt\/wp-content\/uploads\/2020\/01\/index-1-150x150.jpg",
+        "website": "https:\/\/www.qgis.pt",
+        "year": 2015
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "NO",
+        "name": "QGIS Norge (Norway)",
+        "logo_url": "https:\/\/qgisnorge.github.io\/img\/qgis-nor-icon.svg",
+        "website": "https:\/\/qgisnorge.github.io",
+        "year": 2017
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "ZA",
+        "name": "QGIS ZA (South Africa)",
+        "logo_url": "https:\/\/qgis.org.za\/static\/images\/QGis_Logo_UG.png",
+        "website": "https:\/\/qgis.org.za",
+        "year": 2017
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "SE",
+        "name": "QGIS Sverige (Sweden)",
+        "logo_url": "http:\/\/www.qgis.se\/wp-content\/uploads\/2017\/05\/qgis_sverige_logotyp-1.png",
+        "website": "http:\/\/qgis.se",
+        "year": 2017
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "KE",
+        "name": "QGIS Kenya",
+        "logo_url": "https:\/\/qgis.or.ke\/images\/qgiskenya_logo.png",
+        "website": "https:\/\/qgis.or.ke",
+        "year": 2017
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "AU",
+        "name": "QGIS Australia",
+        "logo_url": "https:\/\/pbs.twimg.com\/profile_images\/1161058815678136320\/nrj1anrP_400x400.jpg",
+        "website": "https:\/\/www.qgis-au.org",
+        "year": 2017
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "US",
+        "name": "QGIS USA",
+        "logo_url": "https:\/\/pbs.twimg.com\/profile_images\/949318914533543936\/lPkMi_Xx_400x400.jpg",
+        "website": "http:\/\/qgis.us",
+        "year": 2017
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "MX",
+        "name": "QGIS México",
+        "logo_url": "https:\/\/pbs.twimg.com\/profile_images\/1248456549250392065\/4d7uAf5v_400x400.jpg",
+        "website": "http:\/\/qgis.mx",
+        "year": 2017
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "RO",
+        "name": "Asociația Utilizatorilor QGIS (Romania)",
+        "logo_url": "https:\/\/qgis.ro\/content\/images\/size\/w300\/2018\/03\/asociatia_qgis_1200.png",
+        "website": "https:\/\/qgis.ro",
+        "year": 2018
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "ES",
+        "name": "Association of QGIS users in Spain",
+        "logo_url": "http:\/\/qgis.es\/images\/qgis_logo.png",
+        "website": "http:\/\/qgis.es",
+        "year": 2018
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "NL",
+        "name": "QGIS gebruikersgroep (Netherlands)",
+        "logo_url": "https:\/\/pbs.twimg.com\/profile_images\/1188779173705330688\/VDJW42Jw_400x400.png",
+        "website": "http:\/\/qgis.nl",
+        "year": 2020
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "ID",
+        "name": "Komunitas Pengguna QGIS Indonesia",
+        "logo_url": "https:\/\/pbs.twimg.com\/profile_images\/1234428372781977601\/KOOccZoG_400x400.jpg",
+        "website": "https:\/\/qgis-id.github.io",
+        "year": 2020
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "CH",
+        "name": "QGIS user group Switzerland",
+        "logo_url": "https:\/\/qgis.ch\/logo.png",
+        "website": "https:\/\/qgis.ch",
+        "year": 2015
+      },
+      "geometry": null
+    }
+  ]
+}

--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -29,6 +29,7 @@
 #include "qgsproject.h"
 #include "qgscoordinateutils.h"
 #include "qgsvectorlayer.h"
+#include "qgsvectorlayerjoininfo.h"
 
 
 QgsStatusBarCoordinatesWidget::QgsStatusBarCoordinatesWidget( QWidget *parent )
@@ -126,6 +127,10 @@ void QgsStatusBarCoordinatesWidget::validateCoordinates()
   else if ( mLineEdit->text() == QLatin1String( "hackfests" ) )
   {
     hackfests();
+  }
+  else if ( mLineEdit->text() == QLatin1String( "user groups" ) )
+  {
+    userGroups();
   }
   else if ( mLineEdit->text() == QLatin1String( "dizzy" ) )
   {
@@ -251,6 +256,42 @@ void QgsStatusBarCoordinatesWidget::hackfests()
   QgsProject::instance()->addMapLayer( layer );
   layer->setAutoRefreshInterval( 500 );
   layer->setAutoRefreshEnabled( true );
+}
+
+void QgsStatusBarCoordinatesWidget::userGroups()
+{
+  if ( !mMapCanvas )
+  {
+    return;
+  }
+  QString fileName = QgsApplication::pkgDataPath() + QStringLiteral( "/resources/data/world_map.gpkg|layername=countries" );
+  QFileInfo fileInfo = QFileInfo( fileName );
+  const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  QgsVectorLayer *layer = new QgsVectorLayer( fileInfo.absoluteFilePath(),
+      tr( "User Groups" ), QStringLiteral( "ogr" ), options );
+
+  QString fileNameData = QgsApplication::pkgDataPath() + QStringLiteral( "/resources/data/user_groups_data.json" );
+  QFileInfo fileInfoData = QFileInfo( fileNameData );
+  QgsVectorLayer *layerData = new QgsVectorLayer( fileInfoData.absoluteFilePath(),
+      tr( "user_groups_data" ), QStringLiteral( "ogr" ), options );
+
+  // Register layers with the layers registry
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << layer << layerData );
+
+  // Create join
+  QgsVectorLayerJoinInfo joinInfo;
+  joinInfo.setTargetFieldName( QStringLiteral( "iso_a2" ) );
+  joinInfo.setJoinLayer( layerData );
+  joinInfo.setJoinFieldName( QStringLiteral( "country" ) );
+  joinInfo.setUsingMemoryCache( true );
+  joinInfo.setPrefix( QStringLiteral( "ug_" ) );
+  joinInfo.setJoinFieldNamesSubset( nullptr );  // Use all join fields
+  layer->addJoin( joinInfo );
+
+  // Load QML for polygon symbology and maptips
+  QString fileNameStyle = QgsApplication::pkgDataPath() + QStringLiteral( "/resources/data/user_groups.qml" );
+  bool styleFlag = false;
+  layer->loadNamedStyle( fileNameStyle, styleFlag, true );
 }
 
 void QgsStatusBarCoordinatesWidget::extentsViewToggled( bool flag )

--- a/src/app/qgsstatusbarcoordinateswidget.h
+++ b/src/app/qgsstatusbarcoordinateswidget.h
@@ -62,6 +62,7 @@ class APP_EXPORT QgsStatusBarCoordinatesWidget : public QWidget
     void world();
     void contributors();
     void hackfests();
+    void userGroups();
     void showExtent();
     void ensureCoordinatesVisible();
 


### PR DESCRIPTION
## Description

Another easter egg that may be useful: a map of QGIS user groups (idea from the first QHackFriday).
This PR reuses the world map already included in `resources/data/` and adds both a new `user_groups_data.json` (beautified, to ease maintenance) and a new QML file for polygon symbology and maptips.

![user_groups](https://user-images.githubusercontent.com/652785/91677840-96798200-eb09-11ea-943d-5dd5df5a99ee.gif)


User groups data sources:
  + https://www.qgis.org/en/site/forusers/usergroups.html#qgis-usergroups
  + https://docs.google.com/spreadsheets/d/1Wte5pfcpOeZ1bfBUn7KJuYzw31_rtKyGqciBPW3RXwg/edit#gid=678994363

@timlinux