### PR TITLE
[db manager] Import Dialog - Remove "Update options" button

### DIFF
--- a/python/plugins/db_manager/dlg_import_vector.py
+++ b/python/plugins/db_manager/dlg_import_vector.py
@@ -86,7 +86,6 @@ class DlgImportVector(QDialog, Ui_Dialog):
         if mode == self.ASK_FOR_INPUT_MODE:
             self.btnChooseInputFile.clicked.connect(self.chooseInputFile)
             self.cboInputLayer.currentTextChanged.connect(self.updateInputLayer)
-            self.btnUpdateInputLayer.clicked.connect(self.updateInputLayer)
 
             self.editPrimaryKey.setText(self.default_pk)
             self.editGeomColumn.setText(self.default_geom)

--- a/python/plugins/db_manager/ui/DlgImportVector.ui
+++ b/python/plugins/db_manager/ui/DlgImportVector.ui
@@ -82,13 +82,6 @@
           </property>
          </spacer>
         </item>
-        <item>
-         <widget class="QPushButton" name="btnUpdateInputLayer">
-          <property name="text">
-           <string>Update options</string>
-          </property>
-         </widget>
-        </item>
        </layout>
       </item>
      </layout>
@@ -299,7 +292,6 @@
   <tabstop>cboInputLayer</tabstop>
   <tabstop>btnChooseInputFile</tabstop>
   <tabstop>chkSelectedFeatures</tabstop>
-  <tabstop>btnUpdateInputLayer</tabstop>
   <tabstop>cboSchema</tabstop>
   <tabstop>cboTable</tabstop>
   <tabstop>chkPrimaryKey</tabstop>


### PR DESCRIPTION
It's hard to guess for a user what the button does, and it often appears to be doing nothing.
It's also easy to achieve the same by changing the layer in the combo box

![Screenshot from 2020-09-01 18-41-09](https://user-images.githubusercontent.com/588407/91882163-dc0d8a80-ec82-11ea-9676-42a7b947de2d.png)

Or is someone actively using this button and will be missing it? If this is the case, what is the scenario?