### PR TITLE
Add warning message on closing project to python console (Fix #38529)

### DIFF
--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -1094,6 +1094,7 @@ class EditorTabWidget(QTabWidget):
         color = Qt.darkGray if modified else Qt.black
         self.tabBar().setTabTextColor(index, color)
         self.parent.saveFileButton.setEnabled(modified)
+        QgsApplication.setConsoleDirty(modified)
 
     def closeTab(self, tab):
         if self.count() < 2:

--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -488,6 +488,16 @@ initialize qgis.db
 Create the users theme folder
 %End
 
+    static void setConsoleDirty( bool isConsoleDirty );
+%Docstring
+Set dirty the python console.
+%End
+
+    static bool isConsoleDirty();
+%Docstring
+Returns ``True`` if python console is dirty.
+%End
+
     static void exitQgis();
 %Docstring
 deletes provider registry and map layer registry

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6301,7 +6301,7 @@ void QgisApp::fileExit()
   }
 
   QgsCanvasRefreshBlocker refreshBlocker;
-  if ( checkUnsavedLayerEdits() && checkMemoryLayers() && saveDirty() )
+  if ( checkUnsavedLayerEdits() && checkMemoryLayers() && checkConsoleDirty() && saveDirty() )
   {
     closeProject();
     userProfileManager()->setDefaultFromActive();
@@ -7338,7 +7338,7 @@ void QgisApp::openProject( QAction *action )
   if ( checkTasksDependOnProject() )
     return;
 
-  if ( checkUnsavedLayerEdits() && checkMemoryLayers() && saveDirty() )
+  if ( checkUnsavedLayerEdits() && checkMemoryLayers() && checkConsoleDirty() && saveDirty() )
     addProject( project );
 }
 
@@ -7383,7 +7383,7 @@ void QgisApp::openProject( const QString &fileName )
     return;
 
   // possibly save any pending work before opening a different project
-  if ( checkUnsavedLayerEdits() && checkMemoryLayers() && saveDirty() )
+  if ( checkUnsavedLayerEdits() && checkMemoryLayers() && checkConsoleDirty() && saveDirty() )
   {
     // error handling and reporting is in addProject() function
     addProject( fileName );
@@ -13014,6 +13014,18 @@ bool QgisApp::checkMemoryLayers()
     close &= QMessageBox::warning( this,
                                    tr( "Close Project" ),
                                    tr( "This project includes one or more temporary scratch layers. These layers are not saved to disk and their contents will be permanently lost. Are you sure you want to proceed?" ),
+                                   QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel ) == QMessageBox::Yes;
+
+  return close;
+}
+
+bool QgisApp::checkConsoleDirty()
+{
+  bool close = true;
+  if ( QgsApplication::isConsoleDirty() )
+    close &= QMessageBox::warning( this,
+                                   tr( "Close Project" ),
+                                   tr( "The Python Console has some change not saved. Are you sure you want to proceed?" ),
                                    QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel ) == QMessageBox::Yes;
 
   return close;

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2087,6 +2087,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Checks for running tasks dependent on the open project
     bool checkTasksDependOnProject();
 
+    //! Checks if python console is dirty
+    bool checkConsoleDirty();
+
     /**
      * Helper function to union several geometries together (used in function mergeSelectedFeatures)
      * \returns empty geometry in case of error or if canceled

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -118,6 +118,7 @@
 QObject *ABISYM( QgsApplication::mFileOpenEventReceiver ) = nullptr;
 bool ABISYM( QgsApplication::mInitialized ) = false;
 bool ABISYM( QgsApplication::mRunningFromBuildDir ) = false;
+bool ABISYM( QgsApplication::mConsoleDirty ) = false;
 const char *QgsApplication::QGIS_ORGANIZATION_NAME = "QGIS";
 const char *QgsApplication::QGIS_ORGANIZATION_DOMAIN = "qgis.org";
 const char *QgsApplication::QGIS_APPLICATION_NAME = "QGIS3";

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -469,6 +469,12 @@ class CORE_EXPORT QgsApplication : public QApplication
     //! Create the users theme folder
     static bool createThemeFolder();
 
+    //! Set dirty the python console.
+    static void setConsoleDirty( bool isConsoleDirty ) { ABISYM( mConsoleDirty ) = isConsoleDirty; }
+
+    //! Returns TRUE if python console is dirty.
+    static bool isConsoleDirty() { return ABISYM( mConsoleDirty ); }
+
     //! deletes provider registry and map layer registry
     static void exitQgis();
 
@@ -925,6 +931,8 @@ class CORE_EXPORT QgsApplication : public QApplication
 
     static void copyPath( const QString &src, const QString &dst );
     static QObject *ABISYM( mFileOpenEventReceiver );
+
+    static bool ABISYM( mConsoleDirty );
 
     static bool ABISYM( mInitialized );
 


### PR DESCRIPTION
## Description

Add warning message on closing project when changes not saved are present in python console.

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
