### PR TITLE
fix crash with missing layer of a  relation

### DIFF
--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -231,18 +231,25 @@ void QgsFeatureListView::repaintRequested()
 
 void QgsFeatureListView::mouseMoveEvent( QMouseEvent *event )
 {
-  QPoint pos = event->pos();
-
-  QModelIndex index = indexAt( pos );
-
-  if ( mEditSelectionDrag )
+  if ( mModel )
   {
-    if ( index.isValid() )
-      setEditSelection( mModel->mapToMaster( index ), QItemSelectionModel::ClearAndSelect );
+    QPoint pos = event->pos();
+
+    QModelIndex index = indexAt( pos );
+
+    if ( mEditSelectionDrag )
+    {
+      if ( index.isValid() )
+        setEditSelection( mModel->mapToMaster( index ), QItemSelectionModel::ClearAndSelect );
+    }
+    else
+    {
+      selectRow( index, false );
+    }
   }
   else
   {
-    selectRow( index, false );
+    QgsDebugMsg( QStringLiteral( "No model assigned to this view" ) );
   }
 }
 

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -47,6 +47,9 @@ QgsFilteredSelectionManager::QgsFilteredSelectionManager( QgsVectorLayer *layer,
   : QgsVectorLayerSelectionManager( layer, parent )
   , mRequest( request )
 {
+  if ( ! layer )
+    return;
+
   for ( auto fid : layer->selectedFeatureIds() )
     if ( mRequest.acceptFeature( layer->getFeature( fid ) ) )
       mSelectedFeatureIds << fid;
@@ -922,7 +925,7 @@ void QgsRelationEditorWidget::updateUi()
 
       initDualView( mNmRelation.referencedLayer(), nmRequest );
     }
-    else
+    else if ( mRelation.referencingLayer() )
     {
       initDualView( mRelation.referencingLayer(), myRequest );
     }


### PR DESCRIPTION
If layers have been removed from a project, a relation might become invalid.
This fixes a crash occuring when showing the relation editor for such a relation.

Now, the relation editor stays disabled.