### PR TITLE
[feature][gui] add "close all tabs" to QgsMessageLogViewer

### DIFF
--- a/src/gui/qgsmessagelogviewer.cpp
+++ b/src/gui/qgsmessagelogviewer.cpp
@@ -82,6 +82,19 @@ void QgsMessageLogViewer::showContextMenuForTabBar( QPoint point )
          );
   mTabBarContextMenu->addAction( actionCloseOtherTabs );
 
+  QAction *actionCloseAllTabs = new QAction( tr( "Close All Tabs" ), mTabBarContextMenu );
+  actionCloseAllTabs->setEnabled( tabWidget->tabBar()->count() > 0 );
+  connect( actionCloseAllTabs, &QAction::triggered, this, [this]
+  {
+    int i;
+    for ( i = tabWidget->tabBar()->count() - 1; i >= 0; i-- )
+    {
+      closeTab( i );
+    }
+  }
+         );
+  mTabBarContextMenu->addAction( actionCloseAllTabs );
+
   mTabBarContextMenu->exec( tabWidget->tabBar()->mapToGlobal( point ) );
 }
 
@@ -154,14 +167,18 @@ void QgsMessageLogViewer::logMessage( const QString &message, const QString &tag
   cleanedMessage = cleanedMessage.prepend( prefix ).replace( '\n', QLatin1String( "<br>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;" ) );
   w->appendHtml( cleanedMessage );
   w->verticalScrollBar()->setValue( w->verticalScrollBar()->maximum() );
+  tabWidget->show();
+  emptyLabel->hide();
 }
 
 void QgsMessageLogViewer::closeTab( int index )
 {
-  if ( tabWidget->count() == 1 )
-    qobject_cast<QPlainTextEdit *>( tabWidget->widget( 0 ) )->clear();
-  else
-    tabWidget->removeTab( index );
+  tabWidget->removeTab( index );
+  if ( tabWidget->count() == 0 )
+  {
+    tabWidget->hide();
+    emptyLabel->show();
+  }
 }
 
 bool QgsMessageLogViewer::eventFilter( QObject *object, QEvent *event )

--- a/src/ui/qgsmessagelogviewer.ui
+++ b/src/ui/qgsmessagelogviewer.ui
@@ -16,20 +16,39 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QGridLayout">
-   <property name="margin">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
     <number>0</number>
    </property>
-   <property name="spacing">
+   <property name="topMargin">
     <number>0</number>
    </property>
-   <item row="0" column="0">
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
       <number>-1</number>
      </property>
      <property name="tabsClosable">
       <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="emptyLabel">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Message log empty</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
## Description

This adds an "Empty tab and close others" actions to the log viewer panel context menu. This saves one frustrating click when debugging and you want to clear all messages.

![image](https://user-images.githubusercontent.com/1894106/91996816-b68f8800-ed39-11ea-933a-c8985b864f97.png)


