### PR TITLE
Fail model run if an algorithm is not available on the system

### DIFF
--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -264,11 +264,20 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
 {
   QSet< QString > toExecute;
   QMap< QString, QgsProcessingModelChildAlgorithm >::const_iterator childIt = mChildAlgorithms.constBegin();
+  QSet< QString > broken;
   for ( ; childIt != mChildAlgorithms.constEnd(); ++childIt )
   {
-    if ( childIt->isActive() && childIt->algorithm() )
-      toExecute.insert( childIt->childId() );
+    if ( childIt->isActive() )
+    {
+      if ( childIt->algorithm() )
+        toExecute.insert( childIt->childId() );
+      else
+        broken.insert( childIt->childId() );
+    }
   }
+
+  if ( !broken.empty() )
+    throw QgsProcessingException( QCoreApplication::translate( "QgsProcessingModelAlgorithm", "Can not run model, the following algorithms are not available on this system: %1" ).arg( broken.values().join( QStringLiteral( ", " ) ) ) );
 
   QElapsedTimer totalTime;
   totalTime.start();

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -277,7 +277,7 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
   }
 
   if ( !broken.empty() )
-    throw QgsProcessingException( QCoreApplication::translate( "QgsProcessingModelAlgorithm", "Can not run model, the following algorithms are not available on this system: %1" ).arg( broken.values().join( QStringLiteral( ", " ) ) ) );
+    throw QgsProcessingException( QCoreApplication::translate( "QgsProcessingModelAlgorithm", "Cannot run model, the following algorithms are not available on this system: %1" ).arg( broken.values().join( QStringLiteral( ", " ) ) ) );
 
   QElapsedTimer totalTime;
   totalTime.start();
@@ -1942,4 +1942,3 @@ QVariantMap QgsProcessingModelAlgorithm::designerParameterValues() const
 }
 
 ///@endcond
-


### PR DESCRIPTION
## Description

When running a processing model with an algorithm which is missing (e.g. because a processing plugin is missing on the current system), the run will be aborted immediately and the user notified about the problem.

So far, the model would just run and report that it "succeeded" but skip any algorithms which depended on the missing one.