### PR TITLE
Add temporalExtentsChanged signal to QgsTemporalNavigationObject

### DIFF
--- a/python/core/auto_generated/qgsrange.sip.in
+++ b/python/core/auto_generated/qgsrange.sip.in
@@ -258,6 +258,8 @@ If the range is empty and ``other`` is not, the range is changed and set to ``ot
 
     bool operator==( const QgsTemporalRange<T> &other ) const;
 
+    bool operator!=( const QgsTemporalRange<T> &other ) const;
+
 };
 
 

--- a/python/core/auto_generated/qgstemporalnavigationobject.sip.in
+++ b/python/core/auto_generated/qgstemporalnavigationobject.sip.in
@@ -203,6 +203,11 @@ Emitted whenever the animation ``state`` changes.
 Emitted whenever the navigation ``mode`` changes.
 %End
 
+    void temporalExtentsChanged( QgsDateTimeRange extent );
+%Docstring
+Emitted whenever the temporalExtent ``extent`` changes.
+%End
+
   public slots:
 
     void play();

--- a/python/core/auto_generated/qgstemporalnavigationobject.sip.in
+++ b/python/core/auto_generated/qgstemporalnavigationobject.sip.in
@@ -203,7 +203,7 @@ Emitted whenever the animation ``state`` changes.
 Emitted whenever the navigation ``mode`` changes.
 %End
 
-    void temporalExtentsChanged( QgsDateTimeRange extent );
+    void temporalExtentsChanged( const QgsDateTimeRange &extent );
 %Docstring
 Emitted whenever the temporalExtent ``extent`` changes.
 %End

--- a/src/core/qgsrange.h
+++ b/src/core/qgsrange.h
@@ -458,6 +458,11 @@ class QgsTemporalRange
              mIncludeUpper == other.includeEnd();
     }
 
+    bool operator!=( const QgsTemporalRange<T> &other ) const
+    {
+      return ( ! operator==( other ) );
+    }
+
   private:
 
     T mLower;

--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -148,6 +148,8 @@ void QgsTemporalNavigationObject::setTemporalExtents( const QgsDateTimeRange &te
     case NavigationOff:
       break;
   }
+
+  emit temporalExtentsChanged( mTemporalExtents );
 }
 
 QgsDateTimeRange QgsTemporalNavigationObject::temporalExtents() const

--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -128,11 +128,12 @@ void QgsTemporalNavigationObject::setNavigationMode( const NavigationMode mode )
 
 void QgsTemporalNavigationObject::setTemporalExtents( const QgsDateTimeRange &temporalExtents )
 {
-  if ( !( mTemporalExtents == temporalExtents ) )
+  if ( mTemporalExtents == temporalExtents )
   {
-    mTemporalExtents = temporalExtents;
-    emit temporalExtentsChanged( mTemporalExtents );
+    return;
   }
+  mTemporalExtents = temporalExtents;
+  emit temporalExtentsChanged( mTemporalExtents );
 
   switch ( mNavigationMode )
   {

--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -139,11 +139,11 @@ void QgsTemporalNavigationObject::setTemporalExtents( const QgsDateTimeRange &te
   {
     case Animated:
     {
-      int currentFrameNmber = mCurrentFrameNumber;
+      int currentFrameNumber = mCurrentFrameNumber;
       setCurrentFrameNumber( 0 );
 
       //Force to emit signal if the current frame number doesn't change
-      if ( currentFrameNmber == mCurrentFrameNumber )
+      if ( currentFrameNumber == mCurrentFrameNumber )
         emit updateTemporalRange( dateTimeRangeForFrameNumber( 0 ) );
       break;
     }

--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -128,7 +128,11 @@ void QgsTemporalNavigationObject::setNavigationMode( const NavigationMode mode )
 
 void QgsTemporalNavigationObject::setTemporalExtents( const QgsDateTimeRange &temporalExtents )
 {
-  mTemporalExtents = temporalExtents;
+  if ( !( mTemporalExtents == temporalExtents ) )
+  {
+    mTemporalExtents = temporalExtents;
+    emit temporalExtentsChanged( mTemporalExtents );
+  }
 
   switch ( mNavigationMode )
   {
@@ -149,7 +153,6 @@ void QgsTemporalNavigationObject::setTemporalExtents( const QgsDateTimeRange &te
       break;
   }
 
-  emit temporalExtentsChanged( mTemporalExtents );
 }
 
 QgsDateTimeRange QgsTemporalNavigationObject::temporalExtents() const

--- a/src/core/qgstemporalnavigationobject.h
+++ b/src/core/qgstemporalnavigationobject.h
@@ -217,6 +217,11 @@ class CORE_EXPORT QgsTemporalNavigationObject : public QgsTemporalController, pu
      */
     void navigationModeChanged( NavigationMode mode );
 
+    /**
+     * Emitted whenever the temporalExtent \a extent changes.
+     */
+    void temporalExtentsChanged( QgsDateTimeRange extent );
+
   public slots:
 
     /**

--- a/src/core/qgstemporalnavigationobject.h
+++ b/src/core/qgstemporalnavigationobject.h
@@ -220,7 +220,7 @@ class CORE_EXPORT QgsTemporalNavigationObject : public QgsTemporalController, pu
     /**
      * Emitted whenever the temporalExtent \a extent changes.
      */
-    void temporalExtentsChanged( QgsDateTimeRange extent );
+    void temporalExtentsChanged( const QgsDateTimeRange &extent );
 
   public slots:
 

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -575,12 +575,7 @@ void QgsTemporalControllerWidget::setDates( const QgsDateTimeRange &range )
     whileBlocking( mEndDateTime )->setDateTime( range.end() );
     whileBlocking( mFixedRangeStartDateTime )->setDateTime( range.begin() );
     whileBlocking( mFixedRangeEndDateTime )->setDateTime( range.end() );
-    // only if range is different from mNavigationObject->temporalExtents update
-    // else recursion as updateTemporalExtent itself calls mNavigationObject->setTemporalExtents
-    if ( range != mNavigationObject->temporalExtents() )
-    {
-      updateTemporalExtent();
-    }
+    updateTemporalExtent();
   }
 }
 

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -577,9 +577,9 @@ void QgsTemporalControllerWidget::setDates( const QgsDateTimeRange &range )
     whileBlocking( mFixedRangeEndDateTime )->setDateTime( range.end() );
     // only if range is different from mNavigationObject->temporalExtents update
     // else recursion as updateTemporalExtent itself calls mNavigationObject->setTemporalExtents
-    if ( !(range == mNavigationObject->temporalExtents()) )
+    if ( !( range == mNavigationObject->temporalExtents() ) )
     {
-        updateTemporalExtent();
+      updateTemporalExtent();
     }
   }
 }

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -577,7 +577,7 @@ void QgsTemporalControllerWidget::setDates( const QgsDateTimeRange &range )
     whileBlocking( mFixedRangeEndDateTime )->setDateTime( range.end() );
     // only if range is different from mNavigationObject->temporalExtents update
     // else recursion as updateTemporalExtent itself calls mNavigationObject->setTemporalExtents
-    if ( !( range == mNavigationObject->temporalExtents() ) )
+    if ( range != mNavigationObject->temporalExtents() )
     {
       updateTemporalExtent();
     }

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -52,6 +52,7 @@ QgsTemporalControllerWidget::QgsTemporalControllerWidget( QWidget *parent )
 
   setWidgetStateFromNavigationMode( mNavigationObject->navigationMode() );
   connect( mNavigationObject, &QgsTemporalNavigationObject::navigationModeChanged, this, &QgsTemporalControllerWidget::setWidgetStateFromNavigationMode );
+  connect( mNavigationObject, &QgsTemporalNavigationObject::temporalExtentsChanged, this, &QgsTemporalControllerWidget::setDates );
   connect( mNavigationOff, &QPushButton::clicked, this, &QgsTemporalControllerWidget::mNavigationOff_clicked );
   connect( mNavigationFixedRange, &QPushButton::clicked, this, &QgsTemporalControllerWidget::mNavigationFixedRange_clicked );
   connect( mNavigationAnimated, &QPushButton::clicked, this, &QgsTemporalControllerWidget::mNavigationAnimated_clicked );
@@ -574,7 +575,12 @@ void QgsTemporalControllerWidget::setDates( const QgsDateTimeRange &range )
     whileBlocking( mEndDateTime )->setDateTime( range.end() );
     whileBlocking( mFixedRangeStartDateTime )->setDateTime( range.begin() );
     whileBlocking( mFixedRangeEndDateTime )->setDateTime( range.end() );
-    updateTemporalExtent();
+    // only if range is different from mNavigationObject->temporalExtents update
+    // else recursion as updateTemporalExtent itself calls mNavigationObject->setTemporalExtents
+    if ( !(range == mNavigationObject->temporalExtents()) )
+    {
+        updateTemporalExtent();
+    }
   }
 }
 


### PR DESCRIPTION
This is my take on making it possible to configure a Temporal Layer via PyQGIS.

Python code below was working, but the change was NOT reflected in the controller gui (the DateTime inputs after Range)

You can test using this project/data https://github.com/qgis/QGIS/files/5134771/TimeTestDataProject.zip from the #38468 issue

``` 

l=iface.mapCanvas().currentLayer()
p=l.temporalProperties()
p.setMode(QgsVectorLayerTemporalProperties.ModeFeatureDateTimeInstantFromField)
# QgsVectorLayerTemporalProperties::setStartField( const QString &startFieldName )
p.setStartField('t_start')
p.setDurationUnits(QgsUnitTypes.TemporalUnit.TemporalSeconds)
p.setFixedDuration(3600)
p.setIsActive(True) # OK

# get a handle to current project and determine start and end range of current temporal enabled layers
project = QgsProject.instance()
range = QgsTemporalUtils.calculateTemporalRangeForProject(project)
print(f's_range: {range.begin().toString()}')
print(f't_range: {range.end().toString()}')

# now (re)set the TemporalExtents of the controller (both the navigation AND the controller widget)
c = iface.mapCanvas().temporalController()
c.setTemporalExtents(range)

# NOW the Range inputs are updated, before this PR they did not

```

Note that to make it fully possible to register a layer via PyQGIS, *end* reflect that in the gui, also the Step and StepUnit inputs should be updatable (that is via setting it in QgsTemporalNavigationObject, and then via a signal (like this one here) the QgsTemporalControllerWidget should be updated.

It all works, but it is not clear to me which other files should be updated now.
