### PR TITLE
Added missing space

### DIFF
--- a/src/analysis/processing/qgsalgorithmrandompointsonlines.cpp
+++ b/src/analysis/processing/qgsalgorithmrandompointsonlines.cpp
@@ -120,7 +120,7 @@ QString QgsRandomPointsOnLinesAlgorithm::shortHelpString() const
                       "this (Euclidean) distance from the generated location. "
                       "With <i>Minimum distance between points</i>, only points on the same "
                       "line feature are considered, while for <i>Global minimum distance "
-                      "between points</i> all previously generated points are considered."
+                      "between points</i> all previously generated points are considered. "
                       "If the <i>Global minimum distance between points</i> is set larger "
                       "than the (local) <i>Minimum distance between points</i>, the latter "
                       "has no effect.<br> "


### PR DESCRIPTION
Line 123/124 : "generated points are considered.""If the"  should be:  "generated points are considered. ""If the"
                       to display correct in Help. 
                       Therefore added one space after the dot behind "considered" to make that happen.

## Description  ;  Display correct documentation

Adding the one space does not effect the working of the algorithm.
It is just to display correct documentation

Not sure if this should be backported (it is just a minor enhancement)

