### PR TITLE
Drop the conflicting Ctrl+Alt+A shortcut 

### DIFF
--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1234,9 +1234,6 @@
    <property name="text">
     <string>Deselect Features from All Layers</string>
    </property>
-   <property name="shortcut">
-    <string>Ctrl+Alt+A</string>
-   </property>
   </action>
   <action name="mActionDeselectActiveLayer">
    <property name="icon">


### PR DESCRIPTION
A few months ago (24e1a8269cf5837) the **Ctrl+Shift+A** shortcut (*Deselect all features from all layers*) was replaced with **Ctrl+Alt+A**, as the old one has been used for a new action, *Deselect features only from the current layer* (452ca911903e).

Unfortunately in Windows **Ctrl+Alt+A** is an alias to **GrAlt+A**, what is used for national characters in some localisations (Polish for example, but according to [Wikipedia](https://en.wikipedia.org/wiki/AltGr_key) also in Belgian, Latvian, Turkish, UK, Irish and Dutch), so that change broke the Locator bar and possibly other text inputs in scope of the map canvas. By the way, in Polish Debian/KDE the new shortcut seems to not work at all.

I propose to just drop that troublesome shortcut, leaving the old action (*for all layers*) without any. I can't find any other reasonable and safe shortcut for that action, and if there is only **Ctrl+Alt+A**, the new action (*current layer only*) probably deserves more for it. It's also consistent with its use in the Attribute table.

@suricactus is it ok for you?