### PR TITLE
[3D] Keep the last used tab of the Lights widget when configuring 3D map view

### DIFF
--- a/python/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -429,6 +429,10 @@ Returns list of directional lights defined in the scene
 .. versionadded:: 3.16
 %End
 
+    int lightsWidgetTab() const;
+%Docstring
+Returns the light widget tab that is selected by default, 0 is returned for point lights and 1 for directional lights
+%End
     void setPointLights( const QList<QgsPointLightSettings> &pointLights );
 %Docstring
 Sets list of point lights defined in the scene
@@ -441,6 +445,13 @@ Sets list of point lights defined in the scene
 Sets list of directional lights defined in the scene
 
 .. versionadded:: 3.16
+%End
+
+    void setLightsWidgetTab( int tabIndex );
+%Docstring
+Returns the light widget tab that is selected by default
+
+:param tabIndex: 0 for point lights and 1 for directional lights
 %End
 
     float fieldOfView() const;

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -143,7 +143,7 @@ void Qgs3DMapSettings::readXml( const QDomElement &elem, const QgsReadWriteConte
     }
   }
 
-  QDomElement lightWidgetSavedParameters = elem.firstChildElement( QStringLiteral( "lights-widget-saved-paramters" ) );
+  QDomElement lightWidgetSavedParameters = elem.firstChildElement( QStringLiteral( "lights-widget-saved-parameters" ) );
   if ( !lightWidgetSavedParameters.isNull() ) mOpenLightWidgetTab = lightWidgetSavedParameters.attribute( QStringLiteral( "last-open-light-tab" ) ).toInt();
   else mOpenLightWidgetTab = 0;
 
@@ -295,7 +295,7 @@ QDomElement Qgs3DMapSettings::writeXml( QDomDocument &doc, const QgsReadWriteCon
   }
   elem.appendChild( elemDirectionalLights );
 
-  QDomElement elemLightWidgetSavedParameters = doc.createElement( QStringLiteral( "lights-widget-saved-paramters" ) );
+  QDomElement elemLightWidgetSavedParameters = doc.createElement( QStringLiteral( "lights-widget-saved-parameters" ) );
   elemLightWidgetSavedParameters.setAttribute( QStringLiteral( "last-open-light-tab" ), mOpenLightWidgetTab );
   elem.appendChild( elemLightWidgetSavedParameters );
 

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -143,6 +143,10 @@ void Qgs3DMapSettings::readXml( const QDomElement &elem, const QgsReadWriteConte
     }
   }
 
+  QDomElement lightWidgetSavedParameters = elem.firstChildElement( QStringLiteral( "lights-widget-saved-paramters" ) );
+  if ( !lightWidgetSavedParameters.isNull() ) mOpenLightWidgetTab = lightWidgetSavedParameters.attribute( QStringLiteral( "last-open-light-tab" ) ).toInt();
+  else mOpenLightWidgetTab = 0;
+
   QDomElement elemMapLayers = elemTerrain.firstChildElement( QStringLiteral( "layers" ) );
   QDomElement elemMapLayer = elemMapLayers.firstChildElement( QStringLiteral( "layer" ) );
   QList<QgsMapLayerRef> mapLayers;
@@ -290,6 +294,10 @@ QDomElement Qgs3DMapSettings::writeXml( QDomDocument &doc, const QgsReadWriteCon
     elemDirectionalLights.appendChild( elemDirectionalLight );
   }
   elem.appendChild( elemDirectionalLights );
+
+  QDomElement elemLightWidgetSavedParameters = doc.createElement( QStringLiteral( "lights-widget-saved-paramters" ) );
+  elemLightWidgetSavedParameters.setAttribute( QStringLiteral( "last-open-light-tab" ), mOpenLightWidgetTab );
+  elem.appendChild( elemLightWidgetSavedParameters );
 
   QDomElement elemMapLayers = doc.createElement( QStringLiteral( "layers" ) );
   Q_FOREACH ( const QgsMapLayerRef &layerRef, mLayers )
@@ -634,6 +642,12 @@ void Qgs3DMapSettings::setDirectionalLights( const QList<QgsDirectionalLightSett
 
   mDirectionalLights = directionalLights;
   emit directionalLightsChanged();
+}
+
+void Qgs3DMapSettings::setLightsWidgetTab( int tabIndex )
+{
+  if ( tabIndex != 0 && tabIndex != 1 ) return;
+  mOpenLightWidgetTab = tabIndex;
 }
 
 void Qgs3DMapSettings::setFieldOfView( const float fieldOfView )

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -374,6 +374,11 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     QList<QgsDirectionalLightSettings> directionalLights() const { return mDirectionalLights; }
 
     /**
+     * Returns the light widget tab that is selected by default, 0 is returned for point lights and 1 for directional lights
+     */
+    int lightsWidgetTab() const { return mOpenLightWidgetTab; };
+
+    /**
      * Sets list of point lights defined in the scene
      * \since QGIS 3.6
      */
@@ -384,6 +389,12 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
      * \since QGIS 3.16
      */
     void setDirectionalLights( const QList<QgsDirectionalLightSettings> &directionalLights );
+
+    /**
+     * Returns the light widget tab that is selected by default
+     * \param tabIndex 0 for point lights and 1 for directional lights
+     */
+    void setLightsWidgetTab( int tabIndex );
 
     /**
      * Returns the camera lens' field of view
@@ -563,6 +574,7 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     bool mShowLabels = false; //!< Whether to display labels on terrain tiles
     QList<QgsPointLightSettings> mPointLights;  //!< List of point lights defined for the scene
     QList<QgsDirectionalLightSettings> mDirectionalLights;  //!< List of directional lights defined for the scene
+    int mOpenLightWidgetTab = 0; //!< Stores which light tab was open in the 3D
     float mFieldOfView = 45.0f; //!< Camera lens field of view value
     QList<QgsMapLayerRef> mLayers;   //!< Layers to be rendered
     QList<QgsMapLayerRef> mTerrainLayers;   //!< Terrain layers to be rendered

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -114,6 +114,7 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
 
   widgetLights->setPointLights( mMap->pointLights() );
   widgetLights->setDirectionalLights( mMap->directionalLights() );
+  widgetLights->setOpenLightTab( mMap->lightsWidgetTab() );
 
   connect( cboTerrainType, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &Qgs3DMapConfigWidget::onTerrainTypeChanged );
   connect( cboTerrainLayer, static_cast<void ( QComboBox::* )( int )>( &QgsMapLayerComboBox::currentIndexChanged ), this, &Qgs3DMapConfigWidget::onTerrainLayerChanged );
@@ -241,6 +242,7 @@ void Qgs3DMapConfigWidget::apply()
 
   mMap->setPointLights( widgetLights->pointLights() );
   mMap->setDirectionalLights( widgetLights->directionalLights() );
+  mMap->setLightsWidgetTab( widgetLights->lastOpenLightTab() );
   mMap->setIsSkyboxEnabled( groupSkyboxSettings->isChecked() );
   mMap->setSkyboxSettings( mSkyboxSettingsWidget->toSkyboxSettings() );
 }

--- a/src/app/3d/qgslightswidget.cpp
+++ b/src/app/3d/qgslightswidget.cpp
@@ -54,6 +54,11 @@ QgsLightsWidget::QgsLightsWidget( QWidget *parent )
   connect( spinDirectionZ, qgis::overload<double>::of( &QDoubleSpinBox::valueChanged ), this, &QgsLightsWidget::updateCurrentDirectionalLightParameters );
   connect( spinDirectionalIntensity, qgis::overload<double>::of( &QDoubleSpinBox::valueChanged ), this, &QgsLightsWidget::updateCurrentDirectionalLightParameters );
   connect( btnDirectionalColor, &QgsColorButton::colorChanged, this, &QgsLightsWidget::updateCurrentDirectionalLightParameters );
+
+  connect( tabWidget, &QTabWidget::currentChanged, [&]( int index )
+  {
+    mLastOpenTab = index;
+  } );
 }
 
 void QgsLightsWidget::setPointLights( const QList<QgsPointLightSettings> &pointLights )
@@ -70,6 +75,13 @@ void QgsLightsWidget::setDirectionalLights( const QList<QgsDirectionalLightSetti
   updateDirectionalLightsList();
   cboDirectionalLights->setCurrentIndex( 0 );
   onCurrentDirectionalLightChanged( 0 );
+}
+
+void QgsLightsWidget::setOpenLightTab( int tabIndex )
+{
+  if ( tabIndex != 0 && tabIndex != 1 ) return;
+  mLastOpenTab = tabIndex;
+  tabWidget->setCurrentIndex( tabIndex );
 }
 
 QList<QgsPointLightSettings> QgsLightsWidget::pointLights()

--- a/src/app/3d/qgslightswidget.h
+++ b/src/app/3d/qgslightswidget.h
@@ -36,9 +36,11 @@ class QgsLightsWidget : public QWidget, private Ui::QgsLightsWidget
 
     void setPointLights( const QList<QgsPointLightSettings> &pointLights );
     void setDirectionalLights( const QList<QgsDirectionalLightSettings> &directionalLights );
+    void setOpenLightTab( int tabIndex );
 
     QList<QgsPointLightSettings> pointLights();
     QList<QgsDirectionalLightSettings> directionalLights();
+    int lastOpenLightTab() const { return mLastOpenTab; };
 
   signals:
 
@@ -60,6 +62,7 @@ class QgsLightsWidget : public QWidget, private Ui::QgsLightsWidget
   private:
     QList<QgsPointLightSettings> mPointLights;
     QList<QgsDirectionalLightSettings> mDirectionalLights;
+    int mLastOpenTab = 0;
 };
 
 #endif // QGSLIGHTSWIDGET_H


### PR DESCRIPTION
## Description
This implements the feature request mentioned in  #38167 

