### PR TITLE
Aesthetic improvements to the first run dialog 

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1038,31 +1038,30 @@ int main( int argc, char *argv[] )
   {
     // Note: this flag is ka version number so that we can reset it once we change the version.
     // Note2: Is this a good idea can we do it better.
-
-    QgsSettings migSettings;
-    int firstRunVersion = migSettings.value( QStringLiteral( "migration/firstRunVersionFlag" ), 0 ).toInt();
-    bool showWelcome = ( firstRunVersion == 0  || Qgis::versionInt() > firstRunVersion );
-
-    std::unique_ptr< QgsVersionMigration > migration( QgsVersionMigration::canMigrate( 20000, Qgis::versionInt() ) );
-    if ( migration && ( settingsMigrationForce || migration->requiresMigration() ) )
+    // Note3: Updated to only show if we have a migration from QGIS 2 - see https://github.com/qgis/QGIS/pull/38616
+    QString path = QSettings( "QGIS", "QGIS2" ).fileName() ;
+    if ( QFile::exists( path ) )
     {
-      bool runMigration = true;
-      if ( !settingsMigrationForce && showWelcome )
+      QgsSettings migSettings;
+      int firstRunVersion = migSettings.value( QStringLiteral( "migration/firstRunVersionFlag" ), 0 ).toInt();
+      bool showWelcome = ( firstRunVersion == 0  || Qgis::versionInt() > firstRunVersion );
+      std::unique_ptr< QgsVersionMigration > migration( QgsVersionMigration::canMigrate( 20000, Qgis::versionInt() ) );
+      if ( migration && ( settingsMigrationForce || migration->requiresMigration() ) )
       {
-        QgsFirstRunDialog dlg;
-        if ( ! QFile::exists( QSettings( "QGIS", "QGIS2" ).fileName() ) )
+        bool runMigration = true;
+        if ( !settingsMigrationForce && showWelcome )
         {
-          dlg.hideMigration();
+          QgsFirstRunDialog dlg;
+          dlg.exec();
+          runMigration = dlg.migrateSettings();
+          migSettings.setValue( QStringLiteral( "migration/firstRunVersionFlag" ), Qgis::versionInt() );
         }
-        dlg.exec();
-        runMigration = dlg.migrateSettings();
-        migSettings.setValue( QStringLiteral( "migration/firstRunVersionFlag" ), Qgis::versionInt() );
-      }
 
-      if ( runMigration )
-      {
-        QgsDebugMsg( QStringLiteral( "RUNNING MIGRATION" ) );
-        migration->runMigration();
+        if ( runMigration )
+        {
+          QgsDebugMsg( QStringLiteral( "RUNNING MIGRATION" ) );
+          migration->runMigration();
+        }
       }
     }
   }

--- a/src/app/qgsfirstrundialog.cpp
+++ b/src/app/qgsfirstrundialog.cpp
@@ -32,7 +32,3 @@ bool QgsFirstRunDialog::migrateSettings()
   return ( mImportSettingsYes->isChecked() );
 }
 
-void QgsFirstRunDialog::hideMigration()
-{
-  mMigrationWidget->hide();
-}

--- a/src/app/qgsfirstrundialog.h
+++ b/src/app/qgsfirstrundialog.h
@@ -30,12 +30,6 @@ class APP_EXPORT QgsFirstRunDialog : public QDialog, private Ui::QgsFirstRunDial
 
     bool migrateSettings();
 
-    /**
-     * Hides the migration checkboxes
-     */
-    void hideMigration();
-
-
   signals:
 
   public slots:

--- a/src/ui/qgsfirstrundialog.ui
+++ b/src/ui/qgsfirstrundialog.ui
@@ -6,178 +6,101 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>659</width>
-    <height>464</height>
+    <width>742</width>
+    <height>320</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Welcome to QGIS</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2">
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0" rowspan="3">
+    <widget class="QLabel" name="label_3">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="pixmap">
+      <pixmap resource="../../images/images.qrc">:/images/icons/qgis_icon.svg</pixmap>
+     </property>
+     <property name="scaledContents">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLabel" name="mWelcomeLabel">
+     <property name="font">
+      <font>
+       <pointsize>23</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Welcome to QGIS 3</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLabel" name="mWelcomeDevLabel">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;You are running a dev version. We would love your feedback and testing.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;http://changelog.qgis.org/en/qgis/version/3.4-LTR/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2a76c6;&quot;&gt;Check out &lt;/span&gt;&lt;/a&gt;the change log for all the great new features introduced with this release!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="1">
+    <widget class="QWidget" name="mMigrationWidget" native="true">
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="1" column="0" colspan="2">
+       <widget class="QRadioButton" name="mImportSettingsYes">
+        <property name="text">
+         <string>Import settings from QGIS 2.</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Settings will be imported into the default profile and you will only see this screen once.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QRadioButton" name="mImportSettingsNo">
+        <property name="text">
+         <string>I want a clean start. Don't import my QGIS 2 settings.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Ready to go?</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
     <widget class="QPushButton" name="pushButton">
      <property name="text">
       <string>Let's get started!</string>
      </property>
     </widget>
-   </item>
-   <item row="0" column="0" colspan="2">
-    <layout class="QGridLayout" name="gridLayout">
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <item row="2" column="1" rowspan="2">
-      <widget class="QLabel" name="mWelcomeLabel">
-       <property name="font">
-        <font>
-         <pointsize>23</pointsize>
-        </font>
-       </property>
-       <property name="text">
-        <string>Welcome to QGIS 3</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0" rowspan="3">
-      <widget class="QLabel" name="label_3">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="pixmap">
-        <pixmap resource="../../images/images.qrc">:/images/icons/qgis-icon-60x60.png</pixmap>
-       </property>
-       <property name="scaledContents">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0" colspan="2">
-      <widget class="QLabel" name="label_2">
-       <property name="font">
-        <font>
-         <pointsize>16</pointsize>
-        </font>
-       </property>
-       <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://changelog.qgis.org/en/qgis/version/3.4-LTR/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2a76c6;&quot;&gt;Check out &lt;/span&gt;&lt;/a&gt;the change log for all the new stuff.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-       <property name="openExternalLinks">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QLabel" name="mWelcomeDevLabel">
-       <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;You are running a dev version.  We would love your feedback and testing.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <spacer name="verticalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Preferred</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <widget class="QWidget" name="mMigrationWidget" native="true">
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <item>
-         <spacer name="verticalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Expanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>45</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Ready to go?</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="mImportSettingsYes">
-          <property name="text">
-           <string>Import settings from QGIS 2.</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="mImportSettingsNo">
-          <property name="text">
-           <string>I want a clean start. Don't import my QGIS 2 settings.</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Settings will be imported into the default profile and you will only see this screen once.</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>

--- a/src/ui/qgsfirstrundialog.ui
+++ b/src/ui/qgsfirstrundialog.ui
@@ -14,6 +14,9 @@
    <string>Welcome to QGIS</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="horizontalSpacing">
+    <number>50</number>
+   </property>
    <item row="0" column="0" rowspan="3">
     <widget class="QLabel" name="label_3">
      <property name="sizePolicy">
@@ -58,6 +61,9 @@
    <item row="2" column="1">
     <widget class="QWidget" name="mMigrationWidget" native="true">
      <layout class="QGridLayout" name="gridLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
       <item row="1" column="0" colspan="2">
        <widget class="QRadioButton" name="mImportSettingsYes">
         <property name="text">


### PR DESCRIPTION
The first run dialog is shown for users who are either running QGIS for the first time on their system, or who are upgrading from an old 2.x installation.

In the first case, it invites the user to view the changelog (great!) and then has a big button to get started using QGIS.

In the second case, it offers to migrate the user's old settings to QGIS 3 before launching the application.

As the first impression a first time user gets, the dialog looks a little.....sad.

So this PR tries to lay out the dialog in a more pleasing way and also makes some small tweaks to the wording to hopefully make things a little more welcoming.


Before my changes:

![FirstRunScreen-BeforeFixing](https://user-images.githubusercontent.com/178003/92328356-32e6db80-f058-11ea-9f9f-0fb461ad186d.png)


After my changes - with 2.x profile migration:



![FirstRunScreen-WithOldQGIS](https://user-images.githubusercontent.com/178003/92328369-3f6b3400-f058-11ea-9c6b-5a314f442ef0.png)

After my changes - no migration of 2.x profile:

![FirstRunScreen-NoOldQGIS](https://user-images.githubusercontent.com/178003/92328383-527e0400-f058-11ea-9e2b-0e173a37fe82.png)
