### PR TITLE
Vector Tile layer properties metadata improvements

### DIFF
--- a/python/core/auto_generated/vectortile/qgsvectortilelayer.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilelayer.sip.in
@@ -99,6 +99,8 @@ Constructs a new vector tile layer
 
     virtual QString decodedSource( const QString &source, const QString &provider, const QgsReadWriteContext &context ) const ${SIP_FINAL};
 
+    virtual QString htmlMetadata() const;
+
 
 
     QString sourceType() const;

--- a/src/app/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/app/vectortile/qgsvectortilelayerproperties.cpp
@@ -36,9 +36,11 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
 
   mRendererWidget = new QgsVectorTileBasicRendererWidget( nullptr, canvas, messageBar, this );
   mOptsPage_Style->layout()->addWidget( mRendererWidget );
+  mOptsPage_Style->layout()->setContentsMargins( 0, 0, 0, 0 );
 
   mLabelingWidget = new QgsVectorTileBasicLabelingWidget( nullptr, canvas, messageBar, this );
   mOptsPage_Labeling->layout()->addWidget( mLabelingWidget );
+  mOptsPage_Labeling->layout()->setContentsMargins( 0, 0, 0, 0 );
 
   connect( this, &QDialog::accepted, this, &QgsVectorTileLayerProperties::apply );
   connect( buttonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsVectorTileLayerProperties::apply );

--- a/src/app/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/app/vectortile/qgsvectortilelayerproperties.cpp
@@ -25,6 +25,7 @@
 #include "qgsgui.h"
 #include "qgsnative.h"
 #include "qgsapplication.h"
+#include "qgsmetadatawidget.h"
 
 #include <QFileDialog>
 #include <QMenu>
@@ -34,6 +35,7 @@
 QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *lyr, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent, Qt::WindowFlags flags )
   : QgsOptionsDialogBase( QStringLiteral( "VectorTileLayerProperties" ), parent, flags )
   , mLayer( lyr )
+  , mMapCanvas( canvas )
 {
   setupUi( this );
 
@@ -74,6 +76,17 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
   mMetadataViewer->page()->settings()->setAttribute( QWebSettings::JavascriptEnabled, true );
 
 #endif
+  mOptsPage_Information->setContentsMargins( 0, 0, 0, 0 );
+
+  QVBoxLayout *layout = new QVBoxLayout( metadataFrame );
+  layout->setContentsMargins( 0, 0, 0, 0 );
+  metadataFrame->setContentsMargins( 0, 0, 0, 0 );
+  mMetadataWidget = new QgsMetadataWidget( this, mLayer );
+  mMetadataWidget->layout()->setContentsMargins( 0, 0, 0, 0 );
+  mMetadataWidget->setMapCanvas( mMapCanvas );
+  layout->addWidget( mMetadataWidget );
+  metadataFrame->setLayout( layout );
+  mOptsPage_Metadata->setContentsMargins( 0, 0, 0, 0 );
 
   // update based on lyr's current state
   syncToLayer();
@@ -89,27 +102,35 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
 
   QString title = QString( tr( "Layer Properties - %1" ) ).arg( mLayer->name() );
 
-  if ( !mLayer->styleManager()->isDefault( mLayer->styleManager()->currentStyle() ) )
-    title += QStringLiteral( " (%1)" ).arg( mLayer->styleManager()->currentStyle() );
-  restoreOptionsBaseUi( title );
-
-  QPushButton *btnStyle = new QPushButton( tr( "Style" ) );
+  mBtnStyle = new QPushButton( tr( "Style" ) );
   QMenu *menuStyle = new QMenu( this );
   menuStyle->addAction( tr( "Load Style…" ), this, &QgsVectorTileLayerProperties::loadStyle );
   menuStyle->addAction( tr( "Save Style…" ), this, &QgsVectorTileLayerProperties::saveStyleAs );
   menuStyle->addSeparator();
   menuStyle->addAction( tr( "Save as Default" ), this, &QgsVectorTileLayerProperties::saveDefaultStyle );
   menuStyle->addAction( tr( "Restore Default" ), this, &QgsVectorTileLayerProperties::loadDefaultStyle );
-  btnStyle->setMenu( menuStyle );
+  mBtnStyle->setMenu( menuStyle );
   connect( menuStyle, &QMenu::aboutToShow, this, &QgsVectorTileLayerProperties::aboutToShowStyleMenu );
 
-  buttonBox->addButton( btnStyle, QDialogButtonBox::ResetRole );
+  buttonBox->addButton( mBtnStyle, QDialogButtonBox::ResetRole );
+
+  mBtnMetadata = new QPushButton( tr( "Metadata" ), this );
+  QMenu *menuMetadata = new QMenu( this );
+  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), this, &QgsVectorTileLayerProperties::loadMetadata );
+  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), this, &QgsVectorTileLayerProperties::saveMetadataAs );
+  mBtnMetadata->setMenu( menuMetadata );
+  buttonBox->addButton( mBtnMetadata, QDialogButtonBox::ResetRole );
+
+  if ( !mLayer->styleManager()->isDefault( mLayer->styleManager()->currentStyle() ) )
+    title += QStringLiteral( " (%1)" ).arg( mLayer->styleManager()->currentStyle() );
+  restoreOptionsBaseUi( title );
 }
 
 void QgsVectorTileLayerProperties::apply()
 {
   mRendererWidget->apply();
   mLabelingWidget->apply();
+  mMetadataWidget->acceptMetadata();
 }
 
 void QgsVectorTileLayerProperties::syncToLayer()
@@ -243,6 +264,68 @@ void QgsVectorTileLayerProperties::aboutToShowStyleMenu()
   QgsMapLayerStyleGuiUtils::instance()->addStyleManagerActions( m, mLayer );
 }
 
+void QgsVectorTileLayerProperties::loadMetadata()
+{
+  QgsSettings myQSettings;  // where we keep last used filter in persistent state
+  QString myLastUsedDir = myQSettings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
+
+  QString myFileName = QFileDialog::getOpenFileName( this, tr( "Load layer metadata from metadata file" ), myLastUsedDir,
+                       tr( "QGIS Layer Metadata File" ) + " (*.qmd)" );
+  if ( myFileName.isNull() )
+  {
+    return;
+  }
+
+  QString myMessage;
+  bool defaultLoadedFlag = false;
+  myMessage = mLayer->loadNamedMetadata( myFileName, defaultLoadedFlag );
+
+  //reset if the default style was loaded OK only
+  if ( defaultLoadedFlag )
+  {
+    mMetadataWidget->setMetadata( &mLayer->metadata() );
+  }
+  else
+  {
+    //let the user know what went wrong
+    QMessageBox::warning( this, tr( "Load Metadata" ), myMessage );
+  }
+
+  QFileInfo myFI( myFileName );
+  QString myPath = myFI.path();
+  myQSettings.setValue( QStringLiteral( "style/lastStyleDir" ), myPath );
+
+  activateWindow(); // set focus back to properties dialog
+}
+
+void QgsVectorTileLayerProperties::saveMetadataAs()
+{
+  QgsSettings myQSettings;  // where we keep last used filter in persistent state
+  QString myLastUsedDir = myQSettings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
+
+  QString myOutputFileName = QFileDialog::getSaveFileName( this, tr( "Save Layer Metadata as QMD" ),
+                             myLastUsedDir, tr( "QMD File" ) + " (*.qmd)" );
+  if ( myOutputFileName.isNull() ) //dialog canceled
+  {
+    return;
+  }
+
+  mMetadataWidget->acceptMetadata();
+
+  //ensure the user never omitted the extension from the file name
+  if ( !myOutputFileName.endsWith( QgsMapLayer::extensionPropertyType( QgsMapLayer::Metadata ), Qt::CaseInsensitive ) )
+  {
+    myOutputFileName += QgsMapLayer::extensionPropertyType( QgsMapLayer::Metadata );
+  }
+
+  bool defaultLoadedFlag = false;
+  QString message = mLayer->saveNamedMetadata( myOutputFileName, defaultLoadedFlag );
+  if ( defaultLoadedFlag )
+    myQSettings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( myOutputFileName ).absolutePath() );
+  else
+    QMessageBox::information( this, tr( "Save Metadata" ), message );
+}
+
 void QgsVectorTileLayerProperties::showHelp()
 {
   const QVariant helpPage = mOptionsStackedWidget->currentWidget()->property( "helpPage" );
@@ -264,4 +347,13 @@ void QgsVectorTileLayerProperties::urlClicked( const QUrl &url )
     QgsGui::instance()->nativePlatformInterface()->openFileExplorerAndSelectFile( url.toLocalFile() );
   else
     QDesktopServices::openUrl( url );
+}
+
+void QgsVectorTileLayerProperties::optionsStackedWidget_CurrentChanged( int index )
+{
+  QgsOptionsDialogBase::optionsStackedWidget_CurrentChanged( index );
+
+  bool isMetadataPanel = ( index == mOptStackedWidget->indexOf( mOptsPage_Metadata ) );
+  mBtnStyle->setVisible( ! isMetadataPanel );
+  mBtnMetadata->setVisible( isMetadataPanel );
 }

--- a/src/app/vectortile/qgsvectortilelayerproperties.h
+++ b/src/app/vectortile/qgsvectortilelayerproperties.h
@@ -26,6 +26,7 @@ class QgsMessageBar;
 class QgsVectorTileBasicLabelingWidget;
 class QgsVectorTileBasicRendererWidget;
 class QgsVectorTileLayer;
+class QgsMetadataWidget;
 
 
 class QgsVectorTileLayerProperties : public QgsOptionsDialogBase, private Ui::QgsVectorTileLayerPropertiesBase
@@ -42,8 +43,13 @@ class QgsVectorTileLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     void loadStyle();
     void saveStyleAs();
     void aboutToShowStyleMenu();
+    void loadMetadata();
+    void saveMetadataAs();
     void showHelp();
     void urlClicked( const QUrl &url );
+
+  protected slots:
+    void optionsStackedWidget_CurrentChanged( int index ) override SIP_SKIP ;
 
   private:
     void syncToLayer();
@@ -53,6 +59,15 @@ class QgsVectorTileLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
 
     QgsVectorTileBasicRendererWidget *mRendererWidget = nullptr;
     QgsVectorTileBasicLabelingWidget *mLabelingWidget = nullptr;
+
+    QPushButton *mBtnStyle = nullptr;
+    QPushButton *mBtnMetadata = nullptr;
+    QAction *mActionLoadMetadata = nullptr;
+    QAction *mActionSaveMetadataAs = nullptr;
+
+    QgsMapCanvas *mMapCanvas = nullptr;
+    QgsMetadataWidget *mMetadataWidget = nullptr;
+
 };
 
 #endif // QGSVECTORTILELAYERPROPERTIES_H

--- a/src/app/vectortile/qgsvectortilelayerproperties.h
+++ b/src/app/vectortile/qgsvectortilelayerproperties.h
@@ -43,6 +43,7 @@ class QgsVectorTileLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     void saveStyleAs();
     void aboutToShowStyleMenu();
     void showHelp();
+    void urlClicked( const QUrl &url );
 
   private:
     void syncToLayer();

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -25,6 +25,7 @@
 #include "qgsvectortileutils.h"
 
 #include "qgsdatasourceuri.h"
+#include "qgslayermetadataformatter.h"
 
 
 QgsVectorTileLayer::QgsVectorTileLayer( const QString &uri, const QString &baseName )
@@ -284,6 +285,66 @@ QString QgsVectorTileLayer::decodedSource( const QString &source, const QString 
   }
 
   return source;
+}
+
+QString QgsVectorTileLayer::htmlMetadata() const
+{
+  QgsLayerMetadataFormatter htmlFormatter( metadata() );
+
+  QString info = QStringLiteral( "<html><head></head>\n<body>\n" );
+
+  info += QStringLiteral( "<h1>" ) + tr( "Information from provider" ) + QStringLiteral( "</h1>\n<hr>\n" ) %
+          QStringLiteral( "<table class=\"list-view\">\n" ) %
+
+          // name
+          QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "Name" ) % QStringLiteral( "</td><td>" ) % name() % QStringLiteral( "</td></tr>\n" );
+
+  info += QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "URI" ) % QStringLiteral( "</td><td>" ) % source() % QStringLiteral( "</td></tr>\n" );
+  info += QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "Source type" ) % QStringLiteral( "</td><td>" ) % sourceType() % QStringLiteral( "</td></tr>\n" );
+
+  const QString url = sourcePath();
+  info += QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "Source path" ) % QStringLiteral( "</td><td>%1" ).arg( QStringLiteral( "<a href=\"%1\">%2</a>" ).arg( QUrl( url ).toString(), sourcePath() ) ) + QStringLiteral( "</td></tr>\n" );
+
+  info += QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "Zoom levels" ) % QStringLiteral( "</td><td>" ) % QStringLiteral( "%1 - %2" ).arg( sourceMinZoom() ).arg( sourceMaxZoom() ) % QStringLiteral( "</td></tr>\n" );
+  info += QStringLiteral( "</table>" );
+
+  // End Provider section
+  info += QStringLiteral( "</table>\n<br><br>" );
+
+  // Identification section
+  info += QStringLiteral( "<h1>" ) % tr( "Identification" ) % QStringLiteral( "</h1>\n<hr>\n" ) %
+          htmlFormatter.identificationSectionHtml() %
+          QStringLiteral( "<br><br>\n" ) %
+
+          // extent section
+          QStringLiteral( "<h1>" ) % tr( "Extent" ) % QStringLiteral( "</h1>\n<hr>\n" ) %
+          htmlFormatter.extentSectionHtml( ) %
+          QStringLiteral( "<br><br>\n" ) %
+
+          // Start the Access section
+          QStringLiteral( "<h1>" ) % tr( "Access" ) % QStringLiteral( "</h1>\n<hr>\n" ) %
+          htmlFormatter.accessSectionHtml( ) %
+          QStringLiteral( "<br><br>\n" ) %
+
+
+          // Start the contacts section
+          QStringLiteral( "<h1>" ) % tr( "Contacts" ) % QStringLiteral( "</h1>\n<hr>\n" ) %
+          htmlFormatter.contactsSectionHtml( ) %
+          QStringLiteral( "<br><br>\n" ) %
+
+          // Start the links section
+          QStringLiteral( "<h1>" ) % tr( "References" ) % QStringLiteral( "</h1>\n<hr>\n" ) %
+          htmlFormatter.linksSectionHtml( ) %
+          QStringLiteral( "<br><br>\n" ) %
+
+          // Start the history section
+          QStringLiteral( "<h1>" ) % tr( "History" ) % QStringLiteral( "</h1>\n<hr>\n" ) %
+          htmlFormatter.historySectionHtml( ) %
+          QStringLiteral( "<br><br>\n" ) %
+
+          QStringLiteral( "\n</body>\n</html>\n" );
+
+  return info;
 }
 
 QByteArray QgsVectorTileLayer::getRawTile( QgsTileXYZ tileID )

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -109,6 +109,7 @@ class CORE_EXPORT QgsVectorTileLayer : public QgsMapLayer
 
     QString encodedSource( const QString &source, const QgsReadWriteContext &context ) const FINAL;
     QString decodedSource( const QString &source, const QString &provider, const QgsReadWriteContext &context ) const FINAL;
+    QString htmlMetadata() const override;
 
     // new methods
 

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -851,7 +851,7 @@ void QgsRasterLayerProperties::sync()
   pixmapPalette->repaint();
 #endif
 
-  QgsDebugMsg( QStringLiteral( "populate metadata tab" ) );
+  QgsDebugMsgLevel( QStringLiteral( "populate metadata tab" ), 2 );
   /*
    * Metadata Tab
    */

--- a/src/ui/qgsvectortilelayerpropertiesbase.ui
+++ b/src/ui/qgsvectortilelayerpropertiesbase.ui
@@ -102,6 +102,9 @@
           <property name="text">
            <string>Information</string>
           </property>
+          <property name="toolTip">
+           <string>Information</string>
+          </property>
           <property name="icon">
            <iconset resource="../../images/images.qrc">
             <normaloff>:/images/themes/default/propertyicons/metadata.svg</normaloff>:/images/themes/default/propertyicons/metadata.svg</iconset>
@@ -123,9 +126,24 @@
           <property name="text">
            <string>Labels</string>
           </property>
+          <property name="toolTip">
+           <string>Labels</string>
+          </property>
           <property name="icon">
            <iconset resource="../../images/images.qrc">
             <normaloff>:/images/themes/default/propertyicons/labels.svg</normaloff>:/images/themes/default/propertyicons/labels.svg</iconset>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Metadata</string>
+          </property>
+          <property name="toolTip">
+           <string>Metadata</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/propertyicons/editmetadata.svg</normaloff>:/images/themes/default/propertyicons/editmetadata.svg</iconset>
           </property>
          </item>
         </widget>
@@ -209,6 +227,32 @@
          </widget>
          <widget class="QWidget" name="mOptsPage_Labeling">
           <layout class="QVBoxLayout" name="verticalLayout_4"/>
+         </widget>
+         <widget class="QWidget" name="mOptsPage_Metadata">
+          <layout class="QVBoxLayout" name="verticalLayout_5">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QFrame" name="metadataFrame">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Raised</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
         </widget>
        </item>

--- a/src/ui/qgsvectortilelayerpropertiesbase.ui
+++ b/src/ui/qgsvectortilelayerpropertiesbase.ui
@@ -48,7 +48,16 @@
        <enum>QFrame::Raised</enum>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -137,7 +146,16 @@
        <enum>QFrame::Raised</enum>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -152,21 +170,39 @@
           <enum>QFrame::Plain</enum>
          </property>
          <property name="currentIndex">
-          <number>2</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="mOptsPage_Information">
           <layout class="QVBoxLayout" name="verticalLayout_20">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
-            <widget class="QTextBrowser" name="mInformationTextBrowser"/>
+            <widget class="QgsWebView" name="mMetadataViewer" native="true"/>
            </item>
           </layout>
          </widget>
          <widget class="QWidget" name="mOptsPage_Style">
           <layout class="QVBoxLayout" name="verticalLayout_14">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
           </layout>
@@ -195,7 +231,16 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
        <number>0</number>
       </property>
       <item row="0" column="0" colspan="2">
@@ -219,11 +264,16 @@
    <extends>QLineEdit</extends>
    <header>qgsfilterlineedit.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsWebView</class>
+   <extends>QWidget</extends>
+   <header>qgswebview.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mSearchLineEdit</tabstop>
   <tabstop>mOptionsListWidget</tabstop>
-  <tabstop>mInformationTextBrowser</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
- make the first tab look consistent with other layer types (here's the before/after):

Before:
![image](https://user-images.githubusercontent.com/1829991/92338639-f87f4c00-f0f4-11ea-9fc3-e16347abbf1d.png)

After:
![image](https://user-images.githubusercontent.com/1829991/92338668-2cf30800-f0f5-11ea-812b-0e7e3fae48c2.png)


- Add QGIS layer metadata editing tab, because vector tile layers can also have useful metadata which users want to set (e.g. attribution and source details)

