### PR TITLE
Fix conversion of multiplied pixel sizes for some interpolated values

### DIFF
--- a/python/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
+++ b/python/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
@@ -337,7 +337,7 @@ Takes a QColor object and returns HSLA components in required format for QGIS :p
    This is private API only, and may change in future QGIS versions
 %End
 
-    static QString interpolateExpression( int zoomMin, int zoomMax, double valueMin, double valueMax, double base );
+    static QString interpolateExpression( int zoomMin, int zoomMax, double valueMin, double valueMax, double base, double multiplier = 1 );
 %Docstring
 Generates an interpolation for values between ``valueMin`` and ``valueMax``, scaled between the
 ranges ``zoomMin`` to ``zoomMax``.

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -887,7 +887,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
   if ( textSize >= 0 )
   {
     // TODO -- this probably needs revisiting -- it was copied from the MapTiler code, but may be wrong...
-    labelSettings.priority = std::min( textSize / 3, 10.0 );
+    labelSettings.priority = std::min( textSize / ( context.pixelSizeConversionFactor() * 3 ), 10.0 );
   }
 
   labelSettings.setFormat( format );

--- a/src/core/vectortile/qgsmapboxglstyleconverter.h
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.h
@@ -346,7 +346,7 @@ class CORE_EXPORT QgsMapBoxGlStyleConverter
      *
      * \warning This is private API only, and may change in future QGIS versions
      */
-    static QString interpolateExpression( int zoomMin, int zoomMax, double valueMin, double valueMax, double base );
+    static QString interpolateExpression( int zoomMin, int zoomMax, double valueMin, double valueMax, double base, double multiplier = 1 );
 
     /**
      * Converts a value to Qt::PenCapStyle enum from JSON value.


### PR DESCRIPTION
And improve interpolation expression results (i.e. avoid useless ` * 1` parts in generated expressions