### PR TITLE
Allow users to load MapBox GL Json style configuration files when importing style for vector tile layers

### DIFF
--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -431,7 +431,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         {
           QMenu *copyStyleMenu = menuStyleManager->addMenu( tr( "Copy Style" ) );
           copyStyleMenu->setToolTipsVisible( true );
-          QgsMapLayerStyleCategoriesModel *model = new QgsMapLayerStyleCategoriesModel( copyStyleMenu );
+          QgsMapLayerStyleCategoriesModel *model = new QgsMapLayerStyleCategoriesModel( layer->type(), copyStyleMenu );
           model->setShowAllCategories( true );
           for ( int row = 0; row < model->rowCount(); ++row )
           {
@@ -470,7 +470,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
                 QgsMapLayer::StyleCategories sourceCategories = QgsXmlUtils::readFlagAttribute( myRoot, QStringLiteral( "styleCategories" ), QgsMapLayer::AllStyleCategories );
 
-                QgsMapLayerStyleCategoriesModel *model = new QgsMapLayerStyleCategoriesModel( pasteStyleMenu );
+                QgsMapLayerStyleCategoriesModel *model = new QgsMapLayerStyleCategoriesModel( layer->type(), pasteStyleMenu );
                 model->setShowAllCategories( true );
                 for ( int row = 0; row < model->rowCount(); ++row )
                 {

--- a/src/app/vectortile/qgsvectortilelayerproperties.h
+++ b/src/app/vectortile/qgsvectortilelayerproperties.h
@@ -20,6 +20,8 @@
 
 #include "ui_qgsvectortilelayerpropertiesbase.h"
 
+#include "qgsmaplayerstylemanager.h"
+
 class QgsMapLayer;
 class QgsMapCanvas;
 class QgsMessageBar;
@@ -37,6 +39,7 @@ class QgsVectorTileLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
 
   private slots:
     void apply();
+    void onCancel();
 
     void loadDefaultStyle();
     void saveDefaultStyle();
@@ -68,6 +71,11 @@ class QgsVectorTileLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsMetadataWidget *mMetadataWidget = nullptr;
 
+    /**
+     * Previous layer style. Used to reset style to previous state if new style
+     * was loaded but dialog is canceled.
+    */
+    QgsMapLayerStyle mOldStyle;
 };
 
 #endif // QGSVECTORTILELAYERPROPERTIES_H

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -25,7 +25,6 @@ SET(QGIS_GUI_SRCS
   vector/qgsjoindialog.cpp
   vector/qgssourcefieldsproperties.cpp
   vector/qgsvectorlayerlegendwidget.cpp
-  vector/qgsvectorlayerloadstyledialog.cpp
   vector/qgsvectorlayerproperties.cpp
   vector/qgsvectorlayersavestyledialog.cpp
   vector/qgswmsdimensiondialog.cpp
@@ -460,6 +459,7 @@ SET(QGIS_GUI_SRCS
   qgsmaplayeractionregistry.cpp
   qgsmaplayercombobox.cpp
   qgsmaplayerconfigwidgetfactory.cpp
+  qgsmaplayerloadstyledialog.cpp
   qgsmaplayerstylecategoriesmodel.cpp
   qgsmaplayerstyleguiutils.cpp
   qgsmaplayerstylemanagerwidget.cpp
@@ -698,6 +698,7 @@ SET(QGIS_GUI_HDRS
   qgsmaplayercombobox.h
   qgsmaplayerconfigwidget.h
   qgsmaplayerconfigwidgetfactory.h
+  qgsmaplayerloadstyledialog.h
   qgsmaplayerstylecategoriesmodel.h
   qgsmaplayerstyleguiutils.h
   qgsmaplayerstylemanagerwidget.h
@@ -1086,7 +1087,6 @@ SET(QGIS_GUI_HDRS
   vector/qgsjoindialog.h
   vector/qgssourcefieldsproperties.h
   vector/qgsvectorlayerlegendwidget.h
-  vector/qgsvectorlayerloadstyledialog.h
   vector/qgsvectorlayerproperties.h
   vector/qgsvectorlayersavestyledialog.h
   vector/qgswmsdimensiondialog.h

--- a/src/gui/qgsmaplayerloadstyledialog.cpp
+++ b/src/gui/qgsmaplayerloadstyledialog.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-    qgsloadstylefromdbdialog.cpp
+    qgsmaplayerloadstyledialog.cpp
     ---------------------
     begin                : April 2013
     copyright            : (C) 2013 by Emilio Loi
@@ -16,7 +16,7 @@
 #include <QMessageBox>
 #include <QVector>
 
-#include "qgsvectorlayerloadstyledialog.h"
+#include "qgsmaplayerloadstyledialog.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
 #include "qgsvectorlayerproperties.h"

--- a/src/gui/qgsmaplayerloadstyledialog.h
+++ b/src/gui/qgsmaplayerloadstyledialog.h
@@ -27,23 +27,61 @@
 
 class QgsMapLayerStyleCategoriesModel;
 
+/**
+ * \ingroup gui
+ * A reusable dialog which allows users to select stored layer styles and categories to load
+ * for a map layer.
+ *
+ * Currently supports
+ *
+ * - vector layers
+ * - vector tile layers
+ *
+ * \since QGIS 3.16
+ */
 class GUI_EXPORT QgsMapLayerLoadStyleDialog : public QDialog, private Ui::QgsVectorLayerLoadStyleDialog
 {
     Q_OBJECT
   public:
+
+    /**
+     * Constructor for QgsMapLayerLoadStyleDialog, associated with the specified map \a layer.
+     */
     explicit QgsMapLayerLoadStyleDialog( QgsMapLayer *layer, QWidget *parent = nullptr );
 
+    /**
+     * Returns the list of selected style categories the user has opted to load.
+     */
     QgsMapLayer::StyleCategories styleCategories() const;
 
+    /**
+     * Returns the selected vector style type, for vector layers only.
+     */
     QgsVectorLayerProperties::StyleType currentStyleType() const;
 
+    /**
+     * Returns the file extension for the selected layer style source file.
+     *
+     * \see filePath()
+     */
     QString fileExtension() const;
 
+    /**
+     * Returns the full path to the selected layer style source file.
+     *
+     * \see fileExtension()
+     */
     QString filePath() const;
 
+    /**
+     * Initialize list of database stored styles.
+     */
     void initializeLists( const QStringList &ids, const QStringList &names, const QStringList &descriptions, int sectionLimit );
+
+    /**
+     * Returns the ID of the selected database stored style.
+     */
     QString selectedStyleId();
-    void selectionChanged( QTableWidget *styleTable );
 
   public slots:
     void accept() override;
@@ -56,6 +94,8 @@ class GUI_EXPORT QgsMapLayerLoadStyleDialog : public QDialog, private Ui::QgsVec
     void showHelp();
 
   private:
+    void selectionChanged( QTableWidget *styleTable );
+
     QgsMapLayer *mLayer = nullptr;
     QgsMapLayerStyleCategoriesModel *mModel;
     QString mSelectedStyleId;

--- a/src/gui/qgsmaplayerloadstyledialog.h
+++ b/src/gui/qgsmaplayerloadstyledialog.h
@@ -27,15 +27,17 @@
 
 class QgsMapLayerStyleCategoriesModel;
 
-class GUI_EXPORT QgsVectorLayerLoadStyleDialog : public QDialog, private Ui::QgsVectorLayerLoadStyleDialog
+class GUI_EXPORT QgsMapLayerLoadStyleDialog : public QDialog, private Ui::QgsVectorLayerLoadStyleDialog
 {
     Q_OBJECT
   public:
-    explicit QgsVectorLayerLoadStyleDialog( QgsVectorLayer *layer, QWidget *parent = nullptr );
+    explicit QgsMapLayerLoadStyleDialog( QgsMapLayer *layer, QWidget *parent = nullptr );
 
     QgsMapLayer::StyleCategories styleCategories() const;
 
     QgsVectorLayerProperties::StyleType currentStyleType() const;
+
+    QString fileExtension() const;
 
     QString filePath() const;
 
@@ -54,7 +56,7 @@ class GUI_EXPORT QgsVectorLayerLoadStyleDialog : public QDialog, private Ui::Qgs
     void showHelp();
 
   private:
-    QgsVectorLayer *mLayer = nullptr;
+    QgsMapLayer *mLayer = nullptr;
     QgsMapLayerStyleCategoriesModel *mModel;
     QString mSelectedStyleId;
     QString mSelectedStyleName;

--- a/src/gui/qgsmaplayerloadstyledialog.h
+++ b/src/gui/qgsmaplayerloadstyledialog.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-    qgsvectorlayerloadstyle.h
+    qgsmaplayerloadstyledialog.h
     ---------------------
     begin                : April 2013
     copyright            : (C) 2013 by Emilio Loi
@@ -13,8 +13,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef QGSLOADFILEFROMDBDIALOG_H
-#define QGSLOADFILEFROMDBDIALOG_H
+#ifndef QGSMAPLAYERLOADSTYLEDIALOG_H
+#define QGSMAPLAYERLOADSTYLEDIALOG_H
 
 // We don't want to expose this in the public API
 #define SIP_NO_FILE
@@ -66,4 +66,4 @@ class GUI_EXPORT QgsMapLayerLoadStyleDialog : public QDialog, private Ui::QgsVec
     QPushButton *mCancelButton = nullptr;
 };
 
-#endif //QGSLOADFILEFROMDBDIALOG_H
+#endif //QGSMAPLAYERLOADSTYLEDIALOG_H

--- a/src/gui/qgsmaplayerstylecategoriesmodel.cpp
+++ b/src/gui/qgsmaplayerstylecategoriesmodel.cpp
@@ -26,7 +26,7 @@ QgsMapLayerStyleCategoriesModel::QgsMapLayerStyleCategoriesModel( QgsMapLayerTyp
       break;
 
     case QgsMapLayerType::VectorTileLayer:
-      mCategoryList << QgsMapLayer::StyleCategory::Symbology << QgsMapLayer::StyleCategory::Labeling;
+      mCategoryList << QgsMapLayer::StyleCategory::Symbology << QgsMapLayer::StyleCategory::Labeling << QgsMapLayer::StyleCategory::AllStyleCategories;
       break;
 
     case QgsMapLayerType::RasterLayer:

--- a/src/gui/qgsmaplayerstylecategoriesmodel.cpp
+++ b/src/gui/qgsmaplayerstylecategoriesmodel.cpp
@@ -16,10 +16,27 @@
 #include "qgsmaplayerstylecategoriesmodel.h"
 #include "qgsapplication.h"
 
-QgsMapLayerStyleCategoriesModel::QgsMapLayerStyleCategoriesModel( QObject *parent )
+QgsMapLayerStyleCategoriesModel::QgsMapLayerStyleCategoriesModel( QgsMapLayerType type, QObject *parent )
   : QAbstractListModel( parent )
 {
-  mCategoryList = qgsEnumMap<QgsMapLayer::StyleCategory>().keys();
+  switch ( type )
+  {
+    case QgsMapLayerType::VectorLayer:
+      mCategoryList = qgsEnumMap<QgsMapLayer::StyleCategory>().keys();
+      break;
+
+    case QgsMapLayerType::VectorTileLayer:
+      mCategoryList << QgsMapLayer::StyleCategory::Symbology << QgsMapLayer::StyleCategory::Labeling;
+      break;
+
+    case QgsMapLayerType::RasterLayer:
+    case QgsMapLayerType::AnnotationLayer:
+    case QgsMapLayerType::PluginLayer:
+    case QgsMapLayerType::MeshLayer:
+      // not yet handled by the model
+      break;
+  }
+
   // move All categories to top
   mCategoryList.move( mCategoryList.indexOf( QgsMapLayer::AllStyleCategories ), 0 );
 }

--- a/src/gui/qgsmaplayerstylecategoriesmodel.h
+++ b/src/gui/qgsmaplayerstylecategoriesmodel.h
@@ -36,8 +36,11 @@ class GUI_EXPORT QgsMapLayerStyleCategoriesModel : public QAbstractListModel
     Q_OBJECT
 
   public:
-    //! constructor
-    explicit QgsMapLayerStyleCategoriesModel( QObject *parent = nullptr );
+
+    /**
+     * Constructor for QgsMapLayerStyleCategoriesModel, for the specified layer \a type.
+     */
+    explicit QgsMapLayerStyleCategoriesModel( QgsMapLayerType type, QObject *parent = nullptr );
 
     //! Reset the model data
     void setCategories( QgsMapLayer::StyleCategories categories );

--- a/src/gui/vector/qgsvectorlayerloadstyledialog.cpp
+++ b/src/gui/vector/qgsvectorlayerloadstyledialog.cpp
@@ -74,7 +74,7 @@ QgsVectorLayerLoadStyleDialog::QgsVectorLayerLoadStyleDialog( QgsVectorLayer *la
   }
 
   // fill style categories
-  mModel = new QgsMapLayerStyleCategoriesModel( this );
+  mModel = new QgsMapLayerStyleCategoriesModel( mLayer->type(), this );
   QgsMapLayer::StyleCategories lastStyleCategories = settings.flagValue( QStringLiteral( "style/lastStyleCategories" ), QgsMapLayer::AllStyleCategories );
   mModel->setCategories( lastStyleCategories );
   mStyleCategoriesListView->setModel( mModel );

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -60,7 +60,7 @@
 #include "qgssymbollayer.h"
 #include "qgsgeometryoptions.h"
 #include "qgsvectorlayersavestyledialog.h"
-#include "qgsvectorlayerloadstyledialog.h"
+#include "qgsmaplayerloadstyledialog.h"
 #include "qgsmessagebar.h"
 #include "qgssymbolwidgetcontext.h"
 #include "qgsexpressioncontextutils.h"

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -1290,7 +1290,7 @@ void QgsVectorLayerProperties::loadStyle()
 
   //get the list of styles in the db
   int sectionLimit = mLayer->listStylesInDatabase( ids, names, descriptions, errorMsg );
-  QgsVectorLayerLoadStyleDialog dlg( mLayer );
+  QgsMapLayerLoadStyleDialog dlg( mLayer );
   dlg.initializeLists( ids, names, descriptions, sectionLimit );
 
   if ( dlg.exec() )

--- a/src/gui/vector/qgsvectorlayersavestyledialog.cpp
+++ b/src/gui/vector/qgsvectorlayersavestyledialog.cpp
@@ -79,7 +79,7 @@ QgsVectorLayerSaveStyleDialog::QgsVectorLayerSaveStyleDialog( QgsVectorLayer *la
   } );
 
   // fill style categories
-  mModel = new QgsMapLayerStyleCategoriesModel( this );
+  mModel = new QgsMapLayerStyleCategoriesModel( mLayer->type(), this );
   QgsMapLayer::StyleCategories lastStyleCategories = settings.flagValue( QStringLiteral( "style/lastStyleCategories" ), QgsMapLayer::AllStyleCategories );
   mModel->setCategories( lastStyleCategories );
   mStyleCategoriesListView->setModel( mModel );

--- a/src/ui/qgsvectorlayerloadstyledialog.ui
+++ b/src/ui/qgsvectorlayerloadstyledialog.ui
@@ -143,20 +143,7 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="5" column="1">
+   <item row="5" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Close|QDialogButtonBox::Help|QDialogButtonBox::Open</set>


### PR DESCRIPTION
From the standard layer properties -> Load Style dialog users are now given the option of selecting a JSON MapBox GL style
file.