### PR TITLE
Add option to create connections for ArcGIS Vector Tile Services to easily load vector tile layers from these servers

### DIFF
--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -742,7 +742,7 @@ record in the users style table in their personal qgis.db)
 .. versionadded:: 3.0
 %End
 
-    QString loadDefaultMetadata( bool &resultFlag );
+    virtual QString loadDefaultMetadata( bool &resultFlag );
 %Docstring
 Retrieve the default metadata for this layer if one
 exists (either as a .qmd file on disk or as a

--- a/python/core/auto_generated/vectortile/qgsvectortilelayer.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilelayer.sip.in
@@ -83,17 +83,25 @@ Constructs a new vector tile layer
 
     virtual QgsMapLayerRenderer *createMapRenderer( QgsRenderContext &rendererContext ) /Factory/;
 
+
     virtual bool readXml( const QDomNode &layerNode, QgsReadWriteContext &context );
+
 
     virtual bool writeXml( QDomNode &layerNode, QDomDocument &doc, const QgsReadWriteContext &context ) const;
 
-    virtual bool readSymbology( const QDomNode &node, QString &errorMessage,
-                                QgsReadWriteContext &context, StyleCategories categories = AllStyleCategories );
 
-    virtual bool writeSymbology( QDomNode &node, QDomDocument &doc, QString &errorMessage, const QgsReadWriteContext &context,
-                                 StyleCategories categories = AllStyleCategories ) const;
+     virtual bool readSymbology( const QDomNode &node, QString &errorMessage,
+                        QgsReadWriteContext &context, StyleCategories categories = AllStyleCategories );
+
+     virtual bool writeSymbology( QDomNode &node, QDomDocument &doc, QString &errorMessage, const QgsReadWriteContext &context,
+                         StyleCategories categories = AllStyleCategories ) const;
 
     virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext );
+
+    virtual QString loadDefaultStyle( bool &resultFlag /Out/ );
+
+    virtual QString loadDefaultMetadata( bool &resultFlag /Out/ );
+
 
     virtual QString encodedSource( const QString &source, const QgsReadWriteContext &context ) const ${SIP_FINAL};
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2057,6 +2057,9 @@ void QgisApp::handleDropUriList( const QgsMimeDataUtils::UriList &lst )
     else if ( u.layerType == QLatin1String( "vector-tile" ) )
     {
       QgsVectorTileLayer *layer = new QgsVectorTileLayer( uri, u.name );
+      bool ok = false;
+      layer->loadDefaultStyle( ok );
+      layer->loadDefaultMetadata( ok );
       addMapLayer( layer );
     }
     else if ( u.layerType == QLatin1String( "plugin" ) )
@@ -5653,6 +5656,13 @@ QgsVectorTileLayer *QgisApp::addVectorTileLayerPrivate( const QString &url, cons
     // since the layer is bad, stomp on it
     return nullptr;
   }
+  bool ok = false;
+  QString error = layer->loadDefaultStyle( ok );
+  if ( !ok )
+    visibleMessageBar()->pushMessage( tr( "Error loading style" ), error, Qgis::Warning, messageTimeout() );
+  error = layer->loadDefaultMetadata( ok );
+  if ( !ok )
+    visibleMessageBar()->pushMessage( tr( "Error loading layer metadata" ), error, Qgis::Warning, messageTimeout() );
 
   QgsProject::instance()->addMapLayer( layer.get() );
   activateDeactivateLayerRelatedActions( activeLayer() );

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -739,7 +739,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \returns a QString with any status messages
      * \since QGIS 3.0
      */
-    QString loadDefaultMetadata( bool &resultFlag );
+    virtual QString loadDefaultMetadata( bool &resultFlag );
 
     /**
      * Retrieve a named metadata for this layer from a sqlite database.

--- a/src/core/vectortile/qgsvectortileconnection.cpp
+++ b/src/core/vectortile/qgsvectortileconnection.cpp
@@ -30,6 +30,17 @@ QString QgsVectorTileProviderConnection::encodedUri( const QgsVectorTileProvider
     uri.setParam( QStringLiteral( "zmin" ), QString::number( conn.zMin ) );
   if ( conn.zMax != -1 )
     uri.setParam( QStringLiteral( "zmax" ), QString::number( conn.zMax ) );
+
+  switch ( conn.serviceType )
+  {
+    case Generic:
+      break;
+
+    case ArcgisVectorTileService:
+      uri.setParam( QStringLiteral( "serviceType" ), QStringLiteral( "arcgis" ) );
+      break;
+  }
+
   return uri.encodedUri();
 }
 
@@ -42,6 +53,12 @@ QgsVectorTileProviderConnection::Data QgsVectorTileProviderConnection::decodedUr
   conn.url = dsUri.param( QStringLiteral( "url" ) );
   conn.zMin = dsUri.hasParam( QStringLiteral( "zmin" ) ) ? dsUri.param( QStringLiteral( "zmin" ) ).toInt() : -1;
   conn.zMax = dsUri.hasParam( QStringLiteral( "zmax" ) ) ? dsUri.param( QStringLiteral( "zmax" ) ).toInt() : -1;
+
+  if ( dsUri.hasParam( QStringLiteral( "serviceType" ) ) )
+  {
+    if ( dsUri.param( QStringLiteral( "serviceType" ) ) == QLatin1String( "arcgis" ) )
+      conn.serviceType = ArcgisVectorTileService;
+  }
   return conn;
 }
 
@@ -55,6 +72,17 @@ QString QgsVectorTileProviderConnection::encodedLayerUri( const QgsVectorTilePro
     uri.setParam( QStringLiteral( "zmin" ), QString::number( conn.zMin ) );
   if ( conn.zMax != -1 )
     uri.setParam( QStringLiteral( "zmax" ), QString::number( conn.zMax ) );
+
+  switch ( conn.serviceType )
+  {
+    case Generic:
+      break;
+
+    case ArcgisVectorTileService:
+      uri.setParam( QStringLiteral( "serviceType" ), QStringLiteral( "arcgis" ) );
+      break;
+  }
+
   return uri.encodedUri();
 }
 
@@ -79,6 +107,13 @@ QgsVectorTileProviderConnection::Data QgsVectorTileProviderConnection::connectio
   conn.url = settings.value( QStringLiteral( "url" ) ).toString();
   conn.zMin = settings.value( QStringLiteral( "zmin" ), -1 ).toInt();
   conn.zMax = settings.value( QStringLiteral( "zmax" ), -1 ).toInt();
+
+  if ( settings.contains( QStringLiteral( "serviceType" ) ) )
+  {
+    if ( settings.value( QStringLiteral( "serviceType" ) ) == QLatin1String( "arcgis" ) )
+      conn.serviceType = ArcgisVectorTileService;
+  }
+
   return conn;
 }
 
@@ -96,6 +131,16 @@ void QgsVectorTileProviderConnection::addConnection( const QString &name, QgsVec
   settings.setValue( QStringLiteral( "url" ), conn.url );
   settings.setValue( QStringLiteral( "zmin" ), conn.zMin );
   settings.setValue( QStringLiteral( "zmax" ), conn.zMax );
+
+  switch ( conn.serviceType )
+  {
+    case Generic:
+      break;
+
+    case ArcgisVectorTileService:
+      settings.setValue( QStringLiteral( "serviceType" ), QStringLiteral( "arcgis" ) );
+      break;
+  }
 }
 
 QString QgsVectorTileProviderConnection::selectedConnection()

--- a/src/core/vectortile/qgsvectortileconnection.cpp
+++ b/src/core/vectortile/qgsvectortileconnection.cpp
@@ -30,6 +30,14 @@ QString QgsVectorTileProviderConnection::encodedUri( const QgsVectorTileProvider
     uri.setParam( QStringLiteral( "zmin" ), QString::number( conn.zMin ) );
   if ( conn.zMax != -1 )
     uri.setParam( QStringLiteral( "zmax" ), QString::number( conn.zMax ) );
+  if ( !conn.authCfg.isEmpty() )
+    uri.setAuthConfigId( conn.authCfg );
+  if ( !conn.username.isEmpty() )
+    uri.setUsername( conn.username );
+  if ( !conn.password.isEmpty() )
+    uri.setPassword( conn.password );
+  if ( !conn.referer.isEmpty() )
+    uri.setParam( QStringLiteral( "referer" ),  conn.referer );
 
   switch ( conn.serviceType )
   {
@@ -53,6 +61,10 @@ QgsVectorTileProviderConnection::Data QgsVectorTileProviderConnection::decodedUr
   conn.url = dsUri.param( QStringLiteral( "url" ) );
   conn.zMin = dsUri.hasParam( QStringLiteral( "zmin" ) ) ? dsUri.param( QStringLiteral( "zmin" ) ).toInt() : -1;
   conn.zMax = dsUri.hasParam( QStringLiteral( "zmax" ) ) ? dsUri.param( QStringLiteral( "zmax" ) ).toInt() : -1;
+  conn.authCfg = dsUri.authConfigId();
+  conn.username = dsUri.username();
+  conn.password = dsUri.password();
+  conn.referer = dsUri.param( QStringLiteral( "referer" ) );
 
   if ( dsUri.hasParam( QStringLiteral( "serviceType" ) ) )
   {
@@ -72,6 +84,14 @@ QString QgsVectorTileProviderConnection::encodedLayerUri( const QgsVectorTilePro
     uri.setParam( QStringLiteral( "zmin" ), QString::number( conn.zMin ) );
   if ( conn.zMax != -1 )
     uri.setParam( QStringLiteral( "zmax" ), QString::number( conn.zMax ) );
+  if ( !conn.authCfg.isEmpty() )
+    uri.setAuthConfigId( conn.authCfg );
+  if ( !conn.username.isEmpty() )
+    uri.setUsername( conn.username );
+  if ( !conn.password.isEmpty() )
+    uri.setPassword( conn.password );
+  if ( !conn.referer.isEmpty() )
+    uri.setParam( QStringLiteral( "referer" ),  conn.referer );
 
   switch ( conn.serviceType )
   {
@@ -107,6 +127,10 @@ QgsVectorTileProviderConnection::Data QgsVectorTileProviderConnection::connectio
   conn.url = settings.value( QStringLiteral( "url" ) ).toString();
   conn.zMin = settings.value( QStringLiteral( "zmin" ), -1 ).toInt();
   conn.zMax = settings.value( QStringLiteral( "zmax" ), -1 ).toInt();
+  conn.authCfg = settings.value( QStringLiteral( "authcfg" ) ).toString();
+  conn.username = settings.value( QStringLiteral( "username" ) ).toString();
+  conn.password = settings.value( QStringLiteral( "password" ) ).toString();
+  conn.referer = settings.value( QStringLiteral( "referer" ) ).toString();
 
   if ( settings.contains( QStringLiteral( "serviceType" ) ) )
   {
@@ -131,6 +155,10 @@ void QgsVectorTileProviderConnection::addConnection( const QString &name, QgsVec
   settings.setValue( QStringLiteral( "url" ), conn.url );
   settings.setValue( QStringLiteral( "zmin" ), conn.zMin );
   settings.setValue( QStringLiteral( "zmax" ), conn.zMax );
+  settings.setValue( QStringLiteral( "authcfg" ), conn.authCfg );
+  settings.setValue( QStringLiteral( "username" ), conn.username );
+  settings.setValue( QStringLiteral( "password" ), conn.password );
+  settings.setValue( QStringLiteral( "referer" ), conn.referer );
 
   switch ( conn.serviceType )
   {

--- a/src/core/vectortile/qgsvectortileconnection.h
+++ b/src/core/vectortile/qgsvectortileconnection.h
@@ -54,6 +54,15 @@ class CORE_EXPORT QgsVectorTileProviderConnection : public QgsAbstractProviderCo
       int zMax = -1;
 
       ServiceType serviceType = Generic;
+
+      // Authentication configuration id
+      QString authCfg;
+      // HTTP Basic username
+      QString username;
+      // HTTP Basic password
+      QString password;
+      // Referer
+      QString referer;
     };
 
     //! Returns connection data encoded as a string

--- a/src/core/vectortile/qgsvectortileconnection.h
+++ b/src/core/vectortile/qgsvectortileconnection.h
@@ -35,12 +35,25 @@ class CORE_EXPORT QgsVectorTileProviderConnection : public QgsAbstractProviderCo
     virtual void store( const QString &name ) const override;
     virtual void remove( const QString &name ) const override;
 
+    /**
+     * Vector tile service type.
+     *
+     * \since QGIS 3.16
+     */
+    enum ServiceType
+    {
+      Generic, //!< Generic (XYZ) connection
+      ArcgisVectorTileService, //!< ArcGIS VectorTileServer connection
+    };
+
     //! Represents decoded data of a connection
     struct Data
     {
       QString url;
       int zMin = -1;
       int zMax = -1;
+
+      ServiceType serviceType = Generic;
     };
 
     //! Returns connection data encoded as a string

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -505,7 +505,13 @@ QByteArray QgsVectorTileLayer::getRawTile( QgsTileXYZ tileID )
 {
   QgsTileMatrix tileMatrix = QgsTileMatrix::fromWebMercator( tileID.zoomLevel() );
   QgsTileRange tileRange( tileID.column(), tileID.column(), tileID.row(), tileID.row() );
-  QList<QgsVectorTileRawData> rawTiles = QgsVectorTileLoader::blockingFetchTileRawData( mSourceType, mSourcePath, tileMatrix, QPointF(), tileRange );
+
+  QgsDataSourceUri dsUri;
+  dsUri.setEncodedUri( mDataSource );
+  const QString authcfg = dsUri.authConfigId();
+  const QString referer = dsUri.param( QStringLiteral( "referer" ) );
+
+  QList<QgsVectorTileRawData> rawTiles = QgsVectorTileLoader::blockingFetchTileRawData( mSourceType, mSourcePath, tileMatrix, QPointF(), tileRange, authcfg, referer );
   if ( rawTiles.isEmpty() )
     return QByteArray();
   return rawTiles.first().data;

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -172,6 +172,10 @@ class CORE_EXPORT QgsVectorTileLayer : public QgsMapLayer
     std::unique_ptr<QgsVectorTileLabeling> mLabeling;
     //! Whether we draw borders of tiles
     bool mTileBorderRendering = false;
+
+    QVariantMap mArcgisLayerConfiguration;
+
+    bool setupArcgisVectorTileServiceConnection( const QString &uri );
 };
 
 

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -93,19 +93,21 @@ class CORE_EXPORT QgsVectorTileLayer : public QgsMapLayer
 
     QgsVectorTileLayer *clone() const override SIP_FACTORY;
 
-    virtual QgsMapLayerRenderer *createMapRenderer( QgsRenderContext &rendererContext ) override SIP_FACTORY;
+    QgsMapLayerRenderer *createMapRenderer( QgsRenderContext &rendererContext ) override SIP_FACTORY;
 
-    virtual bool readXml( const QDomNode &layerNode, QgsReadWriteContext &context ) override;
+    bool readXml( const QDomNode &layerNode, QgsReadWriteContext &context ) override;
 
-    virtual bool writeXml( QDomNode &layerNode, QDomDocument &doc, const QgsReadWriteContext &context ) const override;
+    bool writeXml( QDomNode &layerNode, QDomDocument &doc, const QgsReadWriteContext &context ) const override;
 
-    virtual bool readSymbology( const QDomNode &node, QString &errorMessage,
-                                QgsReadWriteContext &context, StyleCategories categories = AllStyleCategories ) override;
+    bool readSymbology( const QDomNode &node, QString &errorMessage,
+                        QgsReadWriteContext &context, StyleCategories categories = AllStyleCategories ) override;
 
-    virtual bool writeSymbology( QDomNode &node, QDomDocument &doc, QString &errorMessage, const QgsReadWriteContext &context,
-                                 StyleCategories categories = AllStyleCategories ) const override;
+    bool writeSymbology( QDomNode &node, QDomDocument &doc, QString &errorMessage, const QgsReadWriteContext &context,
+                         StyleCategories categories = AllStyleCategories ) const override;
 
-    virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext ) override;
+    void setTransformContext( const QgsCoordinateTransformContext &transformContext ) override;
+    QString loadDefaultStyle( bool &resultFlag SIP_OUT ) override;
+    QString loadDefaultMetadata( bool &resultFlag SIP_OUT ) override;
 
     QString encodedSource( const QString &source, const QgsReadWriteContext &context ) const FINAL;
     QString decodedSource( const QString &source, const QString &provider, const QgsReadWriteContext &context ) const FINAL;

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -41,6 +41,11 @@ QgsVectorTileLayerRenderer::QgsVectorTileLayerRenderer( QgsVectorTileLayer *laye
   , mFeedback( new QgsFeedback )
 {
 
+  QgsDataSourceUri dsUri;
+  dsUri.setEncodedUri( layer->source() );
+  mAuthCfg = dsUri.authConfigId();
+  mReferer = dsUri.param( QStringLiteral( "referer" ) );
+
   if ( QgsLabelingEngine *engine = context.labelingEngine() )
   {
     if ( layer->labeling() )
@@ -106,13 +111,13 @@ bool QgsVectorTileLayerRenderer::render()
   {
     QElapsedTimer tFetch;
     tFetch.start();
-    rawTiles = QgsVectorTileLoader::blockingFetchTileRawData( mSourceType, mSourcePath, mTileMatrix, viewCenter, mTileRange );
+    rawTiles = QgsVectorTileLoader::blockingFetchTileRawData( mSourceType, mSourcePath, mTileMatrix, viewCenter, mTileRange, mAuthCfg, mReferer );
     QgsDebugMsgLevel( QStringLiteral( "Tile fetching time: %1" ).arg( tFetch.elapsed() / 1000. ), 2 );
     QgsDebugMsgLevel( QStringLiteral( "Fetched tiles: %1" ).arg( rawTiles.count() ), 2 );
   }
   else
   {
-    asyncLoader.reset( new QgsVectorTileLoader( mSourcePath, mTileMatrix, mTileRange, viewCenter, mFeedback.get() ) );
+    asyncLoader.reset( new QgsVectorTileLoader( mSourcePath, mTileMatrix, mTileRange, viewCenter, mAuthCfg, mReferer, mFeedback.get() ) );
     QObject::connect( asyncLoader.get(), &QgsVectorTileLoader::tileRequestFinished, [this]( const QgsVectorTileRawData & rawTile )
     {
       QgsDebugMsgLevel( QStringLiteral( "Got tile asynchronously: " ) + rawTile.id.toString(), 2 );

--- a/src/core/vectortile/qgsvectortilelayerrenderer.h
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.h
@@ -56,6 +56,10 @@ class QgsVectorTileLayerRenderer : public QgsMapLayerRenderer
     QString mSourceType;
     //! Path/URL of the source. Format depends on source type
     QString mSourcePath;
+
+    QString mAuthCfg;
+    QString mReferer;
+
     //! Minimum zoom level at which source has any valid tiles (negative = unconstrained)
     int mSourceMinZoom = -1;
     //! Maximum zoom level at which source has any valid tiles (negative = unconstrained)

--- a/src/core/vectortile/qgsvectortileloader.cpp
+++ b/src/core/vectortile/qgsvectortileloader.cpp
@@ -22,10 +22,15 @@
 #include "qgsmbtiles.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgsvectortileutils.h"
+#include "qgsapplication.h"
+#include "qgsauthmanager.h"
+#include "qgsmessagelog.h"
 
-QgsVectorTileLoader::QgsVectorTileLoader( const QString &uri, const QgsTileMatrix &tileMatrix, const QgsTileRange &range, const QPointF &viewCenter, QgsFeedback *feedback )
+QgsVectorTileLoader::QgsVectorTileLoader( const QString &uri, const QgsTileMatrix &tileMatrix, const QgsTileRange &range, const QPointF &viewCenter, const QString &authid, const QString &referer, QgsFeedback *feedback )
   : mEventLoop( new QEventLoop )
   , mFeedback( feedback )
+  , mAuthCfg( authid )
+  , mReferer( referer )
 {
   if ( feedback )
   {
@@ -89,6 +94,14 @@ void QgsVectorTileLoader::loadFromNetworkAsync( const QgsTileXYZ &id, const QgsT
   request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
   request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
 
+  if ( !mReferer.isEmpty() )
+    request.setRawHeader( "Referer", mReferer.toUtf8() );
+
+  if ( !mAuthCfg.isEmpty() &&  !QgsApplication::authManager()->updateNetworkRequest( request, mAuthCfg ) )
+  {
+    QgsMessageLog::logMessage( tr( "network request update failed for authentication config" ), tr( "Network" ) );
+  }
+
   QNetworkReply *reply = QgsNetworkAccessManager::instance()->get( request );
   connect( reply, &QNetworkReply::finished, this, &QgsVectorTileLoader::tileReplyFinished );
 
@@ -143,7 +156,7 @@ void QgsVectorTileLoader::canceled()
 
 //////
 
-QList<QgsVectorTileRawData> QgsVectorTileLoader::blockingFetchTileRawData( const QString &sourceType, const QString &sourcePath, const QgsTileMatrix &tileMatrix, const QPointF &viewCenter, const QgsTileRange &range )
+QList<QgsVectorTileRawData> QgsVectorTileLoader::blockingFetchTileRawData( const QString &sourceType, const QString &sourcePath, const QgsTileMatrix &tileMatrix, const QPointF &viewCenter, const QgsTileRange &range, const QString &authid, const QString &referer )
 {
   QList<QgsVectorTileRawData> rawTiles;
 
@@ -159,7 +172,7 @@ QList<QgsVectorTileRawData> QgsVectorTileLoader::blockingFetchTileRawData( const
   QgsVectorTileUtils::sortTilesByDistanceFromCenter( tiles, viewCenter );
   for ( QgsTileXYZ id : qgis::as_const( tiles ) )
   {
-    QByteArray rawData = isUrl ? loadFromNetwork( id, tileMatrix, sourcePath ) : loadFromMBTiles( id, mbReader );
+    QByteArray rawData = isUrl ? loadFromNetwork( id, tileMatrix, sourcePath, authid, referer ) : loadFromMBTiles( id, mbReader );
     if ( !rawData.isEmpty() )
     {
       rawTiles.append( QgsVectorTileRawData( id, rawData ) );
@@ -168,12 +181,17 @@ QList<QgsVectorTileRawData> QgsVectorTileLoader::blockingFetchTileRawData( const
   return rawTiles;
 }
 
-QByteArray QgsVectorTileLoader::loadFromNetwork( const QgsTileXYZ &id, const QgsTileMatrix &tileMatrix, const QString &requestUrl )
+QByteArray QgsVectorTileLoader::loadFromNetwork( const QgsTileXYZ &id, const QgsTileMatrix &tileMatrix, const QString &requestUrl, const QString &authid, const QString &referer )
 {
   QString url = QgsVectorTileUtils::formatXYZUrlTemplate( requestUrl, id, tileMatrix );
   QNetworkRequest nr;
   nr.setUrl( QUrl( url ) );
+
+  if ( !referer.isEmpty() )
+    nr.setRawHeader( "Referer", referer.toUtf8() );
+
   QgsBlockingNetworkRequest req;
+  req.setAuthCfg( authid );
   QgsDebugMsgLevel( QStringLiteral( "Blocking request: " ) + url, 2 );
   QgsBlockingNetworkRequest::ErrorCode errCode = req.get( nr );
   if ( errCode != QgsBlockingNetworkRequest::NoError )

--- a/src/core/vectortile/qgsvectortileloader.h
+++ b/src/core/vectortile/qgsvectortileloader.h
@@ -59,10 +59,20 @@ class QgsVectorTileLoader : public QObject
   public:
 
     //! Returns raw tile data for the specified range of tiles. Blocks the caller until all tiles are fetched.
-    static QList<QgsVectorTileRawData> blockingFetchTileRawData( const QString &sourceType, const QString &sourcePath, const QgsTileMatrix &tileMatrix, const QPointF &viewCenter, const QgsTileRange &range );
+    static QList<QgsVectorTileRawData> blockingFetchTileRawData( const QString &sourceType,
+        const QString &sourcePath,
+        const QgsTileMatrix &tileMatrix,
+        const QPointF &viewCenter,
+        const QgsTileRange &range,
+        const QString &authid,
+        const QString &referer );
 
     //! Returns raw tile data for a single tile, doing a HTTP request. Block the caller until tile data are downloaded.
-    static QByteArray loadFromNetwork( const QgsTileXYZ &id, const QgsTileMatrix &tileMatrix, const QString &requestUrl );
+    static QByteArray loadFromNetwork( const QgsTileXYZ &id,
+                                       const QgsTileMatrix &tileMatrix,
+                                       const QString &requestUrl,
+                                       const QString &authid,
+                                       const QString &referer );
     //! Returns raw tile data for a single tile loaded from MBTiles file
     static QByteArray loadFromMBTiles( const QgsTileXYZ &id, QgsMbTiles &mbTileReader );
 
@@ -71,7 +81,8 @@ class QgsVectorTileLoader : public QObject
     //
 
     //! Constructs tile loader for doing asynchronous requests and starts network requests
-    QgsVectorTileLoader( const QString &uri, const QgsTileMatrix &tileMatrix, const QgsTileRange &range, const QPointF &viewCenter, QgsFeedback *feedback );
+    QgsVectorTileLoader( const QString &uri, const QgsTileMatrix &tileMatrix, const QgsTileRange &range, const QPointF &viewCenter,
+                         const QString &authid, const QString &referer, QgsFeedback *feedback );
     ~QgsVectorTileLoader();
 
     //! Blocks the caller until all asynchronous requests are finished (with a success or a failure)
@@ -93,6 +104,10 @@ class QgsVectorTileLoader : public QObject
     std::unique_ptr<QEventLoop> mEventLoop;
     //! Feedback object that allows cancellation of pending requests
     QgsFeedback *mFeedback;
+
+    QString mAuthCfg;
+    QString mReferer;
+
     //! Running tile requests
     QList<QNetworkReply *> mReplies;
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -326,6 +326,7 @@ SET(QGIS_GUI_SRCS
   tableeditor/qgstableeditorformattingwidget.cpp
   tableeditor/qgstableeditorwidget.cpp
 
+  vectortile/qgsarcgisvectortileconnectiondialog.cpp
   vectortile/qgsvectortilebasiclabelingwidget.cpp
   vectortile/qgsvectortilebasicrendererwidget.cpp
   vectortile/qgsvectortileconnectiondialog.cpp
@@ -1131,6 +1132,7 @@ SET(QGIS_GUI_HDRS
   tableeditor/qgstableeditorformattingwidget.h
   tableeditor/qgstableeditorwidget.h
 
+  vectortile/qgsarcgisvectortileconnectiondialog.h
   vectortile/qgsvectortilebasiclabelingwidget.h
   vectortile/qgsvectortilebasicrendererwidget.h
   vectortile/qgsvectortileconnectiondialog.h

--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -771,6 +771,7 @@ QDomDocument QgsManageConnectionsDialog::saveVectorTileConnections( const QStrin
     el.setAttribute( QStringLiteral( "url" ), settings.value( path + "/url" ).toString() );
     el.setAttribute( QStringLiteral( "zmin" ), settings.value( path + "/zmin", -1 ).toInt() );
     el.setAttribute( QStringLiteral( "zmax" ), settings.value( path + "/zmax", -1 ).toInt() );
+    el.setAttribute( QStringLiteral( "serviceType" ), settings.value( path + "/serviceType", -1 ).toInt() );
 
     root.appendChild( el );
   }
@@ -1616,6 +1617,7 @@ void QgsManageConnectionsDialog::loadVectorTileConnections( const QDomDocument &
     settings.setValue( QStringLiteral( "url" ), child.attribute( QStringLiteral( "url" ) ) );
     settings.setValue( QStringLiteral( "zmin" ), child.attribute( QStringLiteral( "zmin" ) ) );
     settings.setValue( QStringLiteral( "zmax" ), child.attribute( QStringLiteral( "zmax" ) ) );
+    settings.setValue( QStringLiteral( "serviceType" ), child.attribute( QStringLiteral( "serviceType" ) ) );
     settings.endGroup();
 
     child = child.nextSiblingElement();

--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -772,6 +772,10 @@ QDomDocument QgsManageConnectionsDialog::saveVectorTileConnections( const QStrin
     el.setAttribute( QStringLiteral( "zmin" ), settings.value( path + "/zmin", -1 ).toInt() );
     el.setAttribute( QStringLiteral( "zmax" ), settings.value( path + "/zmax", -1 ).toInt() );
     el.setAttribute( QStringLiteral( "serviceType" ), settings.value( path + "/serviceType", -1 ).toInt() );
+    el.setAttribute( QStringLiteral( "authcfg" ), settings.value( path + "/authcfg" ).toString() );
+    el.setAttribute( QStringLiteral( "username" ), settings.value( path + "/username" ).toString() );
+    el.setAttribute( QStringLiteral( "password" ), settings.value( path + "/password" ).toString() );
+    el.setAttribute( QStringLiteral( "referer" ), settings.value( path + "/referer" ).toString() );
 
     root.appendChild( el );
   }
@@ -1618,6 +1622,11 @@ void QgsManageConnectionsDialog::loadVectorTileConnections( const QDomDocument &
     settings.setValue( QStringLiteral( "zmin" ), child.attribute( QStringLiteral( "zmin" ) ) );
     settings.setValue( QStringLiteral( "zmax" ), child.attribute( QStringLiteral( "zmax" ) ) );
     settings.setValue( QStringLiteral( "serviceType" ), child.attribute( QStringLiteral( "serviceType" ) ) );
+    settings.setValue( QStringLiteral( "authcfg" ), child.attribute( QStringLiteral( "authcfg" ) ) );
+    settings.setValue( QStringLiteral( "username" ), child.attribute( QStringLiteral( "username" ) ) );
+    settings.setValue( QStringLiteral( "password" ), child.attribute( QStringLiteral( "password" ) ) );
+    settings.setValue( QStringLiteral( "referer" ), child.attribute( QStringLiteral( "referer" ) ) );
+
     settings.endGroup();
 
     child = child.nextSiblingElement();

--- a/src/gui/vectortile/qgsarcgisvectortileconnectiondialog.cpp
+++ b/src/gui/vectortile/qgsarcgisvectortileconnectiondialog.cpp
@@ -50,6 +50,9 @@ QString QgsArcgisVectorTileConnectionDialog::connectionUri() const
 {
   QgsVectorTileProviderConnection::Data conn;
   conn.url = mEditUrl->text();
+  if ( conn.url.endsWith( '/' ) )
+    conn.url = conn.url.left( conn.url.length() - 1 );
+
   conn.serviceType = QgsVectorTileProviderConnection::ArcgisVectorTileService;
   conn.username = mAuthSettings->username();
   conn.password = mAuthSettings->password();

--- a/src/gui/vectortile/qgsarcgisvectortileconnectiondialog.cpp
+++ b/src/gui/vectortile/qgsarcgisvectortileconnectiondialog.cpp
@@ -1,0 +1,63 @@
+/***************************************************************************
+    qgsarcgisvectortileconnectiondialog.cpp
+    ---------------------
+    begin                : September 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsarcgisvectortileconnectiondialog.h"
+#include "qgsvectortileconnection.h"
+#include "qgsgui.h"
+
+#include <QMessageBox>
+#include <QPushButton>
+
+///@cond PRIVATE
+
+QgsArcgisVectorTileConnectionDialog::QgsArcgisVectorTileConnectionDialog( QWidget *parent )
+  : QDialog( parent )
+{
+  setupUi( this );
+  QgsGui::enableAutoGeometryRestore( this );
+
+  buttonBox->button( QDialogButtonBox::Ok )->setDisabled( true );
+  connect( mEditName, &QLineEdit::textChanged, this, &QgsArcgisVectorTileConnectionDialog::updateOkButtonState );
+  connect( mEditUrl, &QLineEdit::textChanged, this, &QgsArcgisVectorTileConnectionDialog::updateOkButtonState );
+}
+
+void QgsArcgisVectorTileConnectionDialog::setConnection( const QString &name, const QString &uri )
+{
+  mEditName->setText( name );
+
+  QgsVectorTileProviderConnection::Data conn = QgsVectorTileProviderConnection::decodedUri( uri );
+  mEditUrl->setText( conn.url );
+}
+
+QString QgsArcgisVectorTileConnectionDialog::connectionUri() const
+{
+  QgsVectorTileProviderConnection::Data conn;
+  conn.url = mEditUrl->text();
+  conn.serviceType = QgsVectorTileProviderConnection::ArcgisVectorTileService;
+  return QgsVectorTileProviderConnection::encodedUri( conn );
+}
+
+QString QgsArcgisVectorTileConnectionDialog::connectionName() const
+{
+  return mEditName->text();
+}
+
+void QgsArcgisVectorTileConnectionDialog::updateOkButtonState()
+{
+  bool enabled = !mEditName->text().isEmpty() && !mEditUrl->text().isEmpty();
+  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( enabled );
+}
+
+///@endcond

--- a/src/gui/vectortile/qgsarcgisvectortileconnectiondialog.cpp
+++ b/src/gui/vectortile/qgsarcgisvectortileconnectiondialog.cpp
@@ -39,6 +39,11 @@ void QgsArcgisVectorTileConnectionDialog::setConnection( const QString &name, co
 
   QgsVectorTileProviderConnection::Data conn = QgsVectorTileProviderConnection::decodedUri( uri );
   mEditUrl->setText( conn.url );
+
+  mAuthSettings->setUsername( conn.username );
+  mAuthSettings->setPassword( conn.password );
+  mEditReferer->setText( conn.referer );
+  mAuthSettings->setConfigId( conn.authCfg );
 }
 
 QString QgsArcgisVectorTileConnectionDialog::connectionUri() const
@@ -46,6 +51,10 @@ QString QgsArcgisVectorTileConnectionDialog::connectionUri() const
   QgsVectorTileProviderConnection::Data conn;
   conn.url = mEditUrl->text();
   conn.serviceType = QgsVectorTileProviderConnection::ArcgisVectorTileService;
+  conn.username = mAuthSettings->username();
+  conn.password = mAuthSettings->password();
+  conn.referer = mEditReferer->text();
+  conn.authCfg = mAuthSettings->configId( );
   return QgsVectorTileProviderConnection::encodedUri( conn );
 }
 

--- a/src/gui/vectortile/qgsarcgisvectortileconnectiondialog.h
+++ b/src/gui/vectortile/qgsarcgisvectortileconnectiondialog.h
@@ -38,9 +38,6 @@ class QgsArcgisVectorTileConnectionDialog : public QDialog, public Ui::QgsArcgis
   private slots:
     void updateOkButtonState();
 
-  private:
-    QString mBaseKey;
-    QString mCredentialsBaseKey;
 };
 
 ///@endcond

--- a/src/gui/vectortile/qgsarcgisvectortileconnectiondialog.h
+++ b/src/gui/vectortile/qgsarcgisvectortileconnectiondialog.h
@@ -1,0 +1,48 @@
+/***************************************************************************
+    qgsarcgisvectortileconnectiondialog.h
+    ---------------------
+    begin                : September 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSARCGISVECTORTILECONNECTIONDIALOG_H
+#define QGSARCGISVECTORTILECONNECTIONDIALOG_H
+
+///@cond PRIVATE
+#define SIP_NO_FILE
+
+#include <QDialog>
+
+#include "ui_qgsarcgisvectortileconnectiondialog.h"
+
+
+class QgsArcgisVectorTileConnectionDialog : public QDialog, public Ui::QgsArcgisVectorTileConnectionDialog
+{
+    Q_OBJECT
+  public:
+    explicit QgsArcgisVectorTileConnectionDialog( QWidget *parent = nullptr );
+
+    void setConnection( const QString &name, const QString &uri );
+
+    QString connectionUri() const;
+    QString connectionName() const;
+
+  private slots:
+    void updateOkButtonState();
+
+  private:
+    QString mBaseKey;
+    QString mCredentialsBaseKey;
+};
+
+///@endcond
+
+#endif // QGSVECTORTILECONNECTIONDIALOG_H

--- a/src/gui/vectortile/qgsvectortileconnectiondialog.cpp
+++ b/src/gui/vectortile/qgsvectortileconnectiondialog.cpp
@@ -47,6 +47,11 @@ void QgsVectorTileConnectionDialog::setConnection( const QString &name, const QS
   mSpinZMin->setValue( conn.zMin != -1 ? conn.zMin : 0 );
   mCheckBoxZMax->setChecked( conn.zMax != -1 );
   mSpinZMax->setValue( conn.zMax != -1 ? conn.zMax : 14 );
+
+  mAuthSettings->setUsername( conn.username );
+  mAuthSettings->setPassword( conn.password );
+  mEditReferer->setText( conn.referer );
+  mAuthSettings->setConfigId( conn.authCfg );
 }
 
 QString QgsVectorTileConnectionDialog::connectionUri() const
@@ -57,6 +62,10 @@ QString QgsVectorTileConnectionDialog::connectionUri() const
     conn.zMin = mSpinZMin->value();
   if ( mCheckBoxZMax->isChecked() )
     conn.zMax = mSpinZMax->value();
+  conn.username = mAuthSettings->username();
+  conn.password = mAuthSettings->password();
+  conn.referer = mEditReferer->text();
+  conn.authCfg = mAuthSettings->configId( );
   return QgsVectorTileProviderConnection::encodedUri( conn );
 }
 

--- a/src/gui/vectortile/qgsvectortileconnectiondialog.h
+++ b/src/gui/vectortile/qgsvectortileconnectiondialog.h
@@ -40,9 +40,6 @@ class QgsVectorTileConnectionDialog : public QDialog, public Ui::QgsVectorTileCo
   private slots:
     void updateOkButtonState();
 
-  private:
-    QString mBaseKey;
-    QString mCredentialsBaseKey;
 };
 
 ///@endcond

--- a/src/gui/vectortile/qgsvectortiledataitemguiprovider.cpp
+++ b/src/gui/vectortile/qgsvectortiledataitemguiprovider.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsvectortiledataitems.h"
 #include "qgsvectortileconnectiondialog.h"
+#include "qgsarcgisvectortileconnectiondialog.h"
 #include "qgsvectortileconnection.h"
 #include "qgsmanageconnectionsdialog.h"
 
@@ -40,9 +41,15 @@ void QgsVectorTileDataItemGuiProvider::populateContextMenu( QgsDataItem *item, Q
 
   if ( QgsVectorTileRootItem *rootItem = qobject_cast< QgsVectorTileRootItem * >( item ) )
   {
-    QAction *actionNew = new QAction( tr( "New Connection…" ), this );
+    QAction *actionNew = new QAction( tr( "New Generic Connection…" ), this );
     connect( actionNew, &QAction::triggered, this, [rootItem] { newConnection( rootItem ); } );
     menu->addAction( actionNew );
+
+    QAction *actionNewArcGISConnection = new QAction( tr( "New ArcGIS Vector Tile Service Connection…" ), this );
+    connect( actionNewArcGISConnection, &QAction::triggered, this, [rootItem] { newArcGISConnection( rootItem ); } );
+    menu->addAction( actionNewArcGISConnection );
+
+    menu->addSeparator();
 
     QAction *actionSaveXyzTilesServers = new QAction( tr( "Save Connections…" ), this );
     connect( actionSaveXyzTilesServers, &QAction::triggered, this, [] { saveXyzTilesServers(); } );
@@ -56,15 +63,39 @@ void QgsVectorTileDataItemGuiProvider::populateContextMenu( QgsDataItem *item, Q
 
 void QgsVectorTileDataItemGuiProvider::editConnection( QgsDataItem *item )
 {
-  QgsVectorTileConnectionDialog dlg;
-  QString uri = QgsVectorTileProviderConnection::encodedUri( QgsVectorTileProviderConnection::connection( item->name() ) );
-  dlg.setConnection( item->name(), uri );
-  if ( !dlg.exec() )
-    return;
+  const QgsVectorTileProviderConnection::Data connection = QgsVectorTileProviderConnection::connection( item->name() );
+  QString uri = QgsVectorTileProviderConnection::encodedUri( connection );
 
-  QgsVectorTileProviderConnection::deleteConnection( item->name() );
-  QgsVectorTileProviderConnection::Data conn = QgsVectorTileProviderConnection::decodedUri( dlg.connectionUri() );
-  QgsVectorTileProviderConnection::addConnection( dlg.connectionName(), conn );
+  switch ( connection.serviceType )
+  {
+    case QgsVectorTileProviderConnection::Generic:
+    {
+      QgsVectorTileConnectionDialog dlg;
+
+      dlg.setConnection( item->name(), uri );
+      if ( !dlg.exec() )
+        return;
+
+      QgsVectorTileProviderConnection::deleteConnection( item->name() );
+      QgsVectorTileProviderConnection::Data conn = QgsVectorTileProviderConnection::decodedUri( dlg.connectionUri() );
+      QgsVectorTileProviderConnection::addConnection( dlg.connectionName(), conn );
+      break;
+    }
+
+    case QgsVectorTileProviderConnection::ArcgisVectorTileService:
+    {
+      QgsArcgisVectorTileConnectionDialog dlg;
+
+      dlg.setConnection( item->name(), uri );
+      if ( !dlg.exec() )
+        return;
+
+      QgsVectorTileProviderConnection::deleteConnection( item->name() );
+      QgsVectorTileProviderConnection::Data conn = QgsVectorTileProviderConnection::decodedUri( dlg.connectionUri() );
+      QgsVectorTileProviderConnection::addConnection( dlg.connectionName(), conn );
+      break;
+    }
+  }
 
   item->parent()->refreshConnections();
 }
@@ -83,6 +114,18 @@ void QgsVectorTileDataItemGuiProvider::deleteConnection( QgsDataItem *item )
 void QgsVectorTileDataItemGuiProvider::newConnection( QgsDataItem *item )
 {
   QgsVectorTileConnectionDialog dlg;
+  if ( !dlg.exec() )
+    return;
+
+  QgsVectorTileProviderConnection::Data conn = QgsVectorTileProviderConnection::decodedUri( dlg.connectionUri() );
+  QgsVectorTileProviderConnection::addConnection( dlg.connectionName(), conn );
+
+  item->refreshConnections();
+}
+
+void QgsVectorTileDataItemGuiProvider::newArcGISConnection( QgsDataItem *item )
+{
+  QgsArcgisVectorTileConnectionDialog dlg;
   if ( !dlg.exec() )
     return;
 

--- a/src/gui/vectortile/qgsvectortiledataitemguiprovider.h
+++ b/src/gui/vectortile/qgsvectortiledataitemguiprovider.h
@@ -36,6 +36,7 @@ class QgsVectorTileDataItemGuiProvider : public QObject, public QgsDataItemGuiPr
     static void editConnection( QgsDataItem *item );
     static void deleteConnection( QgsDataItem *item );
     static void newConnection( QgsDataItem *item );
+    static void newArcGISConnection( QgsDataItem *item );
     static void saveXyzTilesServers();
     static void loadXyzTilesServers( QgsDataItem *item );
 

--- a/src/gui/vectortile/qgsvectortilesourceselect.h
+++ b/src/gui/vectortile/qgsvectortilesourceselect.h
@@ -48,6 +48,7 @@ class QgsVectorTileSourceSelect : public QgsAbstractDataSourceWidget, private Ui
 
     //! Opens the create connection dialog to build a new connection
     void btnNew_clicked();
+    void newArcgisVectorTileServerConnection();
     //! Opens a dialog to edit an existing connection
     void btnEdit_clicked();
     //! Deletes the selected connection

--- a/src/ui/qgsarcgisvectortileconnectiondialog.ui
+++ b/src/ui/qgsarcgisvectortileconnectiondialog.ui
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsArcgisVectorTileConnectionDialog</class>
+ <widget class="QDialog" name="QgsArcgisVectorTileConnectionDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>659</width>
+    <height>184</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>ArcGIS Vector Tile Service Connection</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="mGroupBox">
+     <property name="title">
+      <string>Connection Details</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLineEdit" name="mEditName">
+        <property name="toolTip">
+         <string>Name of the new connection</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Service URL</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLineEdit" name="mEditUrl">
+        <property name="toolTip">
+         <string>URL of the VectorTileServer API endpoint, e.g. https://domain/arcgis/rest/services/Layer_1/VectorTileServer</string>
+        </property>
+        <property name="placeholderText">
+         <string>https://domain/arcgis/rest/services/Layer_1/VectorTileServer</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="2">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>mEditName</tabstop>
+  <tabstop>mEditUrl</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QgsArcgisVectorTileConnectionDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>224</x>
+     <y>381</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsArcgisVectorTileConnectionDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>292</x>
+     <y>387</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/qgsarcgisvectortileconnectiondialog.ui
+++ b/src/ui/qgsarcgisvectortileconnectiondialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>659</width>
-    <height>184</height>
+    <height>336</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -34,6 +34,16 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="lblReferer">
+        <property name="text">
+         <string>Referer</string>
+        </property>
+        <property name="buddy">
+         <cstring>mEditReferer</cstring>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
@@ -51,18 +61,36 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="2">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
+      <item row="3" column="2">
+       <widget class="QLineEdit" name="mEditReferer">
+        <property name="toolTip">
+         <string>Optional custom referer</string>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="QGroupBox" name="mAuthGroupBox">
+        <property name="title">
+         <string>Authentication</string>
         </property>
-       </spacer>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item>
+          <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true"/>
+         </item>
+        </layout>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -79,6 +107,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsAuthSettingsWidget</class>
+   <extends>QWidget</extends>
+   <header>auth/qgsauthsettingswidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>mEditName</tabstop>
   <tabstop>mEditUrl</tabstop>

--- a/src/ui/qgstilesourceselectbase.ui
+++ b/src/ui/qgstilesourceselectbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>558</width>
-    <height>155</height>
+    <height>166</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -17,42 +17,6 @@
       <string>Connections</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="1">
-       <widget class="QPushButton" name="btnNew">
-        <property name="toolTip">
-         <string>Create a new service connection</string>
-        </property>
-        <property name="text">
-         <string>&amp;New</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="btnEdit">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="toolTip">
-         <string>Edit selected service connection</string>
-        </property>
-        <property name="text">
-         <string>Edit</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QPushButton" name="btnDelete">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="toolTip">
-         <string>Remove connection to selected service</string>
-        </property>
-        <property name="text">
-         <string>Remove</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="4">
        <spacer>
         <property name="orientation">
@@ -69,8 +33,37 @@
         </property>
        </spacer>
       </item>
+      <item row="0" column="0" colspan="7">
+       <widget class="QComboBox" name="cmbConnections"/>
+      </item>
+      <item row="1" column="2">
+       <widget class="QToolButton" name="btnEdit">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>Edit selected service connection</string>
+        </property>
+        <property name="text">
+         <string>Edit</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QToolButton" name="btnDelete">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>Remove connection to selected service</string>
+        </property>
+        <property name="text">
+         <string>Remove</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="5">
-       <widget class="QPushButton" name="btnLoad">
+       <widget class="QToolButton" name="btnLoad">
         <property name="toolTip">
          <string>Load connections from file</string>
         </property>
@@ -80,7 +73,7 @@
        </widget>
       </item>
       <item row="1" column="6">
-       <widget class="QPushButton" name="btnSave">
+       <widget class="QToolButton" name="btnSave">
         <property name="toolTip">
          <string>Save connections to file</string>
         </property>
@@ -89,8 +82,15 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0" colspan="7">
-       <widget class="QComboBox" name="cmbConnections"/>
+      <item row="1" column="0" colspan="2">
+       <widget class="QToolButton" name="btnNew">
+        <property name="toolTip">
+         <string>Create a new service connection</string>
+        </property>
+        <property name="text">
+         <string>&amp;New</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/ui/qgsvectortileconnectiondialog.ui
+++ b/src/ui/qgsvectortileconnectiondialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>659</width>
-    <height>208</height>
+    <height>442</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,23 +20,20 @@
       <string>Connection Details</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="7" column="2">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
          <string>URL</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLineEdit" name="mEditUrl">
+        <property name="toolTip">
+         <string>URL of the connection, {x}, {y}, and {z} will be replaced with actual values. Use {-y} for inverted y axis.</string>
+        </property>
+        <property name="placeholderText">
+         <string>http://example.com/{z}/{x}/{y}.pbf</string>
         </property>
        </widget>
       </item>
@@ -53,10 +50,13 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Name</string>
+      <item row="2" column="2">
+       <widget class="QSpinBox" name="mSpinZMin">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
        </widget>
       </item>
@@ -64,26 +64,6 @@
        <widget class="QLineEdit" name="mEditName">
         <property name="toolTip">
          <string>Name of the new connection</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QLineEdit" name="mEditUrl">
-        <property name="toolTip">
-         <string>URL of the connection, {x}, {y}, and {z} will be replaced with actual values. Use {-y} for inverted y axis.</string>
-        </property>
-        <property name="placeholderText">
-         <string>http://example.com/{z}/{x}/{y}.pbf</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0" colspan="2">
-       <widget class="QCheckBox" name="mCheckBoxZMax">
-        <property name="text">
-         <string>Max. Zoom Level</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -97,13 +77,61 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="2">
-       <widget class="QSpinBox" name="mSpinZMin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+      <item row="7" column="0" colspan="3">
+       <widget class="QGroupBox" name="mAuthGroupBox">
+        <property name="title">
+         <string>Authentication</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item>
+          <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="lblReferer">
+        <property name="text">
+         <string>Referer</string>
+        </property>
+        <property name="buddy">
+         <cstring>mEditReferer</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0" colspan="2">
+       <widget class="QCheckBox" name="mCheckBoxZMax">
+        <property name="text">
+         <string>Max. Zoom Level</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="2">
+       <widget class="QLineEdit" name="mEditReferer">
+        <property name="toolTip">
+         <string>Optional custom referer</string>
         </property>
        </widget>
       </item>
@@ -122,6 +150,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsAuthSettingsWidget</class>
+   <extends>QWidget</extends>
+   <header>auth/qgsauthsettingswidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>mEditName</tabstop>
   <tabstop>mEditUrl</tabstop>


### PR DESCRIPTION
(also add support for authentication configuration and custom referer string to vector tile connections)

This change adds explicit UI options for adding and configuring connections to ESRI vector tile services. While these services use the standard vector tile framework for data retrieval, they can be directly added by creating a connection using the VectorTileService API endpoint on the ArcGIS server.

After a user adds a layer from a VectorTileService, the server's default styling and labeling for the layer is automatically loaded immediately for the user:

![Peek 2020-09-07 16-08](https://user-images.githubusercontent.com/1829991/92353827-7575ea00-f124-11ea-8a29-f2a6990d2ecc.gif)


