### PR TITLE
Fix cmake config to find qca headers on Opensuse tumbleweed

### DIFF
--- a/cmake/FindQCA.cmake
+++ b/cmake/FindQCA.cmake
@@ -45,7 +45,7 @@ else(QCA_INCLUDE_DIR AND QCA_LIBRARY)
       "$ENV{LIB_DIR}/include"
       $ENV{INCLUDE}
       /usr/local/include
-      PATH_SUFFIXES QtCrypto qt5/QtCrypto Qca-qt5/QtCrypto qt/Qca-qt5/QtCrypto
+      PATH_SUFFIXES QtCrypto qt5/QtCrypto Qca-qt5/QtCrypto qt/Qca-qt5/QtCrypto qt5/Qca-qt5/QtCrypto
   )
 
   if(QCA_LIBRARY AND QCA_INCLUDE_DIR)


### PR DESCRIPTION
## Description

Fix to cmake configuration to build on Opensuse tumbleweed.
Qca header are in a slight other location.