### PR TITLE
[ui] Improve the load style dialog

### DIFF
--- a/src/gui/qgsmaplayerloadstyledialog.cpp
+++ b/src/gui/qgsmaplayerloadstyledialog.cpp
@@ -59,7 +59,8 @@ QgsMapLayerLoadStyleDialog::QgsMapLayerLoadStyleDialog( QgsMapLayer *layer, QWid
   {
     QgsVectorLayerProperties::StyleType type = currentStyleType();
     QgsVectorLayer *vl = qobject_cast< QgsVectorLayer * >( mLayer );
-    mFromFileWidget->setVisible( !vl || type != QgsVectorLayerProperties::StyleType::DB );
+    mFileLabel->setVisible( !vl || type != QgsVectorLayerProperties::StyleType::DB );
+    mFileWidget->setVisible( !vl || type != QgsVectorLayerProperties::StyleType::DB );
     if ( vl )
     {
       mFromDbWidget->setVisible( type == QgsVectorLayerProperties::StyleType::DB );

--- a/src/ui/qgsvectorlayerloadstyledialog.ui
+++ b/src/ui/qgsvectorlayerloadstyledialog.ui
@@ -23,55 +23,18 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="0" column="1">
     <widget class="QComboBox" name="mStyleTypeComboBox"/>
    </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QWidget" name="mFromFileWidget" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="2" column="0">
+    <widget class="QLabel" name="mFileLabel">
+     <property name="text">
+      <string>File</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>File</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QgsFileWidget" name="mFileWidget" native="true"/>
-      </item>
-     </layout>
     </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QgsFileWidget" name="mFileWidget" native="true"/>
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="mModeLabel">
@@ -80,24 +43,24 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="label_4">
      <property name="text">
       <string>Categories</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="3" column="1">
     <widget class="QListView" name="mStyleCategoriesListView">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
     </widget>
    </item>
-   <item row="3" column="0" colspan="2">
+   <item row="1" column="0" colspan="2">
     <widget class="QWidget" name="mFromDbWidget" native="true">
      <layout class="QGridLayout" name="gridLayout_2">
       <property name="leftMargin">
@@ -143,7 +106,7 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Close|QDialogButtonBox::Help|QDialogButtonBox::Open</set>


### PR DESCRIPTION
- Remove harmful horizontal spacer to fix expanding widget issues and location of help button
- Relocate the file widget to sit on top of the category list (to harmonize with the save style dialog)

Before (left) vs. PR (right):
![image](https://user-images.githubusercontent.com/1728657/92368337-cb955e00-f121-11ea-8ee4-f3cf4480a0ab.png)
