### PR TITLE
[locator] autocomplete + allow restricting search to a single field in active layer filter

### DIFF
--- a/python/core/auto_generated/locator/qgslocator.sip.in
+++ b/python/core/auto_generated/locator/qgslocator.sip.in
@@ -149,13 +149,6 @@ Emitted whenever a filter encounters a matching ``result`` after the :py:func:`~
 is called.
 %End
 
-    void searchBegan();
-%Docstring
-Emitted when locator has begun a search, before actually preparing it.
-
-.. versionadded:: 3.16
-%End
-
     void searchPrepared();
 %Docstring
 Emitted when locator has prepared the search (:py:func:`QgsLocatorFilter.prepare`)

--- a/python/core/auto_generated/locator/qgslocator.sip.in
+++ b/python/core/auto_generated/locator/qgslocator.sip.in
@@ -151,7 +151,7 @@ is called.
 
     void searchBegan();
 %Docstring
-Emitted when locator has begun a search, before actualy preparing it.
+Emitted when locator has begun a search, before actually preparing it.
 
 .. versionadded:: 3.16
 %End

--- a/python/core/auto_generated/locator/qgslocator.sip.in
+++ b/python/core/auto_generated/locator/qgslocator.sip.in
@@ -133,12 +133,35 @@ Will call clearPreviousResults on all filters
 .. versionadded:: 3.2
 %End
 
+    QStringList completionList() const;
+%Docstring
+Returns the list for auto completion
+This list is updated when preparing the search
+
+.. versionadded:: 3.16
+%End
+
   signals:
 
     void foundResult( const QgsLocatorResult &result );
 %Docstring
 Emitted whenever a filter encounters a matching ``result`` after the :py:func:`~QgsLocator.fetchResults` method
 is called.
+%End
+
+    void searchBegan();
+%Docstring
+Emitted when locator has begun a search, before actualy preparing it.
+
+.. versionadded:: 3.16
+%End
+
+    void searchPrepared();
+%Docstring
+Emitted when locator has prepared the search (:py:func:`QgsLocatorFilter.prepare`)
+before the search is actually performed
+
+.. versionadded:: 3.16
 %End
 
     void finished();

--- a/python/core/auto_generated/locator/qgslocatorfilter.sip.in
+++ b/python/core/auto_generated/locator/qgslocatorfilter.sip.in
@@ -169,7 +169,7 @@ Prepares the filter instance for an upcoming search for the specified ``string``
 from the main thread, and individual filter subclasses should perform whatever
 tasks are required in order to allow a subsequent search to safely execute
 on a background thread.
-The method return an autocompletion list
+The method returns an autocompletion list
 %End
 
     virtual void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) = 0;

--- a/python/core/auto_generated/locator/qgslocatorfilter.sip.in
+++ b/python/core/auto_generated/locator/qgslocatorfilter.sip.in
@@ -163,12 +163,13 @@ results from this filter.
 .. seealso:: :py:func:`activePrefix`
 %End
 
-    virtual void prepare( const QString &string, const QgsLocatorContext &context );
+    virtual QStringList prepare( const QString &string, const QgsLocatorContext &context );
 %Docstring
 Prepares the filter instance for an upcoming search for the specified ``string``. This method is always called
 from the main thread, and individual filter subclasses should perform whatever
 tasks are required in order to allow a subsequent search to safely execute
 on a background thread.
+The method return an autocompletion list
 %End
 
     virtual void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) = 0;

--- a/python/gui/auto_generated/locator/qgslocatorwidget.sip.in
+++ b/python/gui/auto_generated/locator/qgslocatorwidget.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsLocatorWidget : QWidget
 {
 %Docstring

--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -605,18 +605,18 @@ void QgsAllLayersFeaturesLocatorFilter::openConfigWidget( QWidget *parent )
   globalLimitSpinBox->setMinimum( 1 );
   globalLimitSpinBox->setMaximum( 200 );
   formLayout->addRow( tr( "&Maximum number of results:" ), globalLimitSpinBox );
-  QSpinBox *parLayerLimitSpinBox = new QSpinBox( dlg.get() );
-  parLayerLimitSpinBox->setValue( settings.value( QStringLiteral( "%1/limit_per_layer" ).arg( key ), 8, QgsSettings::App ).toInt() );
-  parLayerLimitSpinBox->setMinimum( 1 );
-  parLayerLimitSpinBox->setMaximum( 200 );
-  formLayout->addRow( tr( "&Maximum number of results per layer:" ), parLayerLimitSpinBox );
+  QSpinBox *perLayerLimitSpinBox = new QSpinBox( dlg.get() );
+  perLayerLimitSpinBox->setValue( settings.value( QStringLiteral( "%1/limit_per_layer" ).arg( key ), 8, QgsSettings::App ).toInt() );
+  perLayerLimitSpinBox->setMinimum( 1 );
+  perLayerLimitSpinBox->setMaximum( 200 );
+  formLayout->addRow( tr( "&Maximum number of results per layer:" ), perLayerLimitSpinBox );
   QDialogButtonBox *buttonbBox = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel, dlg.get() );
   formLayout->addRow( buttonbBox );
   dlg->setLayout( formLayout );
   connect( buttonbBox, &QDialogButtonBox::accepted, [&]()
   {
     settings.setValue( QStringLiteral( "%1/limit_global" ).arg( key ), globalLimitSpinBox->value(), QgsSettings::App );
-    settings.setValue( QStringLiteral( "%1/limit_per_layer" ).arg( key ), parLayerLimitSpinBox->value(), QgsSettings::App );
+    settings.setValue( QStringLiteral( "%1/limit_per_layer" ).arg( key ), perLayerLimitSpinBox->value(), QgsSettings::App );
     dlg->accept();
   } );
   connect( buttonbBox, &QDialogButtonBox::rejected, dlg.get(), &QDialog::reject );

--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -244,35 +244,58 @@ QgsActiveLayerFeaturesLocatorFilter *QgsActiveLayerFeaturesLocatorFilter::clone(
   return new QgsActiveLayerFeaturesLocatorFilter();
 }
 
-void QgsActiveLayerFeaturesLocatorFilter::prepare( const QString &string, const QgsLocatorContext &context )
+QString QgsActiveLayerFeaturesLocatorFilter::fieldRestriction( QString &searchString ) const
+{
+  QString _fieldRestriction;
+  if ( searchString.startsWith( '@' ) )
+  {
+    _fieldRestriction = searchString.left( std::max( searchString.indexOf( ' ' ), 0 ) ).remove( 0, 1 );
+    searchString = searchString.mid( _fieldRestriction.length() + 2 );
+  }
+  return _fieldRestriction;
+}
+
+QStringList QgsActiveLayerFeaturesLocatorFilter::prepare( const QString &string, const QgsLocatorContext &context )
 {
   // Normally skip very short search strings, unless when specifically searching using this filter
   if ( string.length() < 3 && !context.usingPrefix )
-    return;
+    return QStringList();
 
   QgsSettings settings;
   mMaxTotalResults = settings.value( QStringLiteral( "locator_filters/active_layer_features/limit_global" ), 30, QgsSettings::App ).toInt();
 
-  bool allowNumeric = false;
-  double numericalValue = string.toDouble( &allowNumeric );
-
   QgsVectorLayer *layer = qobject_cast< QgsVectorLayer *>( QgisApp::instance()->activeLayer() );
   if ( !layer )
-    return;
+    return QStringList();
 
   mDispExpression = QgsExpression( layer->displayExpression() );
   mContext.appendScopes( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
   mDispExpression.prepare( &mContext );
 
+  // determine if search is restricted to a specific field
+  QString searchString = string;
+  QString _fieldRestriction = fieldRestriction( searchString );
+  bool allowNumeric = false;
+  double numericalValue = searchString.toDouble( &allowNumeric );
+
   // build up request expression
   QStringList expressionParts;
+  QStringList completionList;
   const QgsFields fields = layer->fields();
+  QgsAttributeList subsetOfAttributes;
   for ( const QgsField &field : fields )
   {
+    if ( !_fieldRestriction.isEmpty() && !field.name().startsWith( _fieldRestriction ) )
+      continue;
+
+    if ( !_fieldRestriction.isEmpty() )
+      subsetOfAttributes << layer->fields().indexFromName( field.name() );
+
+    completionList.append( QStringLiteral( "@%1 " ).arg( field.name() ) );
     if ( field.type() == QVariant::String )
     {
       expressionParts << QStringLiteral( "%1 ILIKE '%%2%'" ).arg( QgsExpression::quotedColumnRef( field.name() ),
-                      string );
+                      searchString );
     }
     else if ( allowNumeric && field.isNumeric() )
     {
@@ -285,6 +308,9 @@ void QgsActiveLayerFeaturesLocatorFilter::prepare( const QString &string, const 
   QgsFeatureRequest req;
   req.setFlags( QgsFeatureRequest::NoGeometry );
   req.setFilterExpression( expression );
+  if ( !_fieldRestriction.isEmpty() )
+    req.setSubsetOfAttributes( subsetOfAttributes );
+
   req.setLimit( 30 );
   mIterator = layer->getFeatures( req );
 
@@ -295,12 +321,16 @@ void QgsActiveLayerFeaturesLocatorFilter::prepare( const QString &string, const 
   {
     mAttributeAliases.append( layer->attributeDisplayName( idx ) );
   }
+
+  return completionList;
 }
 
 void QgsActiveLayerFeaturesLocatorFilter::fetchResults( const QString &string, const QgsLocatorContext &, QgsFeedback *feedback )
 {
   int found = 0;
   QgsFeature f;
+  QString searchString = string;
+  fieldRestriction( searchString );
 
   while ( mIterator.nextFeature( f ) )
   {
@@ -317,7 +347,7 @@ void QgsActiveLayerFeaturesLocatorFilter::fetchResults( const QString &string, c
     for ( const QVariant &var : attributes )
     {
       QString attrString = var.toString();
-      if ( attrString.contains( string, Qt::CaseInsensitive ) )
+      if ( attrString.contains( searchString, Qt::CaseInsensitive ) )
       {
         if ( idx < mAttributeAliases.count() )
           result.displayString = QStringLiteral( "%1 (%2)" ).arg( attrString, mAttributeAliases[idx] );
@@ -334,7 +364,7 @@ void QgsActiveLayerFeaturesLocatorFilter::fetchResults( const QString &string, c
 
     result.userData = QVariantList() << f.id() << mLayerId;
     result.icon = mLayerIcon;
-    result.score = static_cast< double >( string.length() ) / result.displayString.size();
+    result.score = static_cast< double >( searchString.length() ) / result.displayString.size();
     emit resultFetched( result );
 
     found++;
@@ -395,11 +425,11 @@ QgsAllLayersFeaturesLocatorFilter *QgsAllLayersFeaturesLocatorFilter::clone() co
   return new QgsAllLayersFeaturesLocatorFilter();
 }
 
-void QgsAllLayersFeaturesLocatorFilter::prepare( const QString &string, const QgsLocatorContext &context )
+QStringList QgsAllLayersFeaturesLocatorFilter::prepare( const QString &string, const QgsLocatorContext &context )
 {
   // Normally skip very short search strings, unless when specifically searching using this filter
   if ( string.length() < 3 && !context.usingPrefix )
-    return;
+    return QStringList();
 
   QgsSettings settings;
   mMaxTotalResults = settings.value( "locator_filters/all_layers_features/limit_global", 15, QgsSettings::App ).toInt();
@@ -445,6 +475,8 @@ void QgsAllLayersFeaturesLocatorFilter::prepare( const QString &string, const Qg
 
     mPreparedLayers.append( preparedLayer );
   }
+
+  return QStringList();
 }
 
 void QgsAllLayersFeaturesLocatorFilter::fetchResults( const QString &string, const QgsLocatorContext &, QgsFeedback *feedback )

--- a/src/app/locator/qgsinbuiltlocatorfilters.h
+++ b/src/app/locator/qgsinbuiltlocatorfilters.h
@@ -102,13 +102,19 @@ class APP_EXPORT QgsActiveLayerFeaturesLocatorFilter : public QgsLocatorFilter
     Priority priority() const override { return Medium; }
     QString prefix() const override { return QStringLiteral( "f" ); }
 
-    void prepare( const QString &string, const QgsLocatorContext &context ) override;
+    QStringList prepare( const QString &string, const QgsLocatorContext &context ) override;
     void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
     void triggerResult( const QgsLocatorResult &result ) override;
     bool hasConfigWidget() const override {return true;}
     void openConfigWidget( QWidget *parent ) override;
 
   private:
+
+    /**
+     * Returns the field restriction if defined (starting with @)
+     * The \a searchString is modified acccordingly by removing the field restriction
+     */
+    QString fieldRestriction( QString &searchString ) const;
 
     QgsExpression mDispExpression;
     QgsExpressionContext mContext;
@@ -150,7 +156,7 @@ class APP_EXPORT QgsAllLayersFeaturesLocatorFilter : public QgsLocatorFilter
     Priority priority() const override { return Medium; }
     QString prefix() const override { return QStringLiteral( "af" ); }
 
-    void prepare( const QString &string, const QgsLocatorContext &context ) override;
+    QStringList prepare( const QString &string, const QgsLocatorContext &context ) override;
     void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
     void triggerResult( const QgsLocatorResult &result ) override;
     void triggerResultFromAction( const QgsLocatorResult &result, const int actionId ) override;

--- a/src/app/locator/qgsinbuiltlocatorfilters.h
+++ b/src/app/locator/qgsinbuiltlocatorfilters.h
@@ -112,7 +112,7 @@ class APP_EXPORT QgsActiveLayerFeaturesLocatorFilter : public QgsLocatorFilter
 
     /**
      * Returns the field restriction if defined (starting with @)
-     * The \a searchString is modified acccordingly by removing the field restriction
+     * The \a searchString is modified accordingly by removing the field restriction
      */
     QString fieldRestriction( QString &searchString ) const;
 

--- a/src/core/locator/qgslocator.cpp
+++ b/src/core/locator/qgslocator.cpp
@@ -124,7 +124,7 @@ void QgsLocator::registerFilter( QgsLocatorFilter *filter )
 
 void QgsLocator::fetchResults( const QString &string, const QgsLocatorContext &c, QgsFeedback *feedback )
 {
-  mAutocompleList.clear();
+  mAutocompletionList.clear();
   emit searchBegan();
 
   QgsLocatorContext context( c );
@@ -193,7 +193,7 @@ void QgsLocator::fetchResults( const QString &string, const QgsLocatorContext &c
         autoCompleteList[i].prepend( QStringLiteral( "%1 " ).arg( prefix ) );
       }
     }
-    mAutocompleList.append( autoCompleteList );
+    mAutocompletionList.append( autoCompleteList );
 
     if ( clone->flags() & QgsLocatorFilter::FlagFast )
     {

--- a/src/core/locator/qgslocator.cpp
+++ b/src/core/locator/qgslocator.cpp
@@ -125,7 +125,6 @@ void QgsLocator::registerFilter( QgsLocatorFilter *filter )
 void QgsLocator::fetchResults( const QString &string, const QgsLocatorContext &c, QgsFeedback *feedback )
 {
   mAutocompletionList.clear();
-  emit searchBegan();
 
   QgsLocatorContext context( c );
   // ideally this should not be required, as well behaved callers

--- a/src/core/locator/qgslocator.h
+++ b/src/core/locator/qgslocator.h
@@ -150,7 +150,7 @@ class CORE_EXPORT QgsLocator : public QObject
      * This list is updated when preparing the search
      * \since QGIS 3.16
      */
-    QStringList completionList() const {return mAutocompleList;}
+    QStringList completionList() const {return mAutocompletionList;}
 
   signals:
 
@@ -191,7 +191,7 @@ class CORE_EXPORT QgsLocator : public QObject
     QList< QgsLocatorFilter * > mFilters;
     QList< QThread * > mActiveThreads;
 
-    QStringList mAutocompleList;
+    QStringList mAutocompletionList;
 
     void cancelRunningQuery();
 

--- a/src/core/locator/qgslocator.h
+++ b/src/core/locator/qgslocator.h
@@ -145,6 +145,13 @@ class CORE_EXPORT QgsLocator : public QObject
      */
     void clearPreviousResults();
 
+    /**
+     * Returns the list for auto completion
+     * This list is updated when preparing the search
+     * \since QGIS 3.16
+     */
+    QStringList completionList() const {return mAutocompleList;}
+
   signals:
 
     /**
@@ -152,6 +159,19 @@ class CORE_EXPORT QgsLocator : public QObject
      * is called.
      */
     void foundResult( const QgsLocatorResult &result );
+
+    /**
+     * Emitted when locator has begun a search, before actualy preparing it.
+     * \since QGIS 3.16
+     */
+    void searchBegan();
+
+    /**
+     * Emitted when locator has prepared the search (\see QgsLocatorFilter::prepare)
+     * before the search is actually performed
+     * \since QGIS 3.16
+     */
+    void searchPrepared();
 
     /**
      * Emitted when locator has finished a query, either as a result
@@ -170,6 +190,8 @@ class CORE_EXPORT QgsLocator : public QObject
 
     QList< QgsLocatorFilter * > mFilters;
     QList< QThread * > mActiveThreads;
+
+    QStringList mAutocompleList;
 
     void cancelRunningQuery();
 

--- a/src/core/locator/qgslocator.h
+++ b/src/core/locator/qgslocator.h
@@ -161,12 +161,6 @@ class CORE_EXPORT QgsLocator : public QObject
     void foundResult( const QgsLocatorResult &result );
 
     /**
-     * Emitted when locator has begun a search, before actually preparing it.
-     * \since QGIS 3.16
-     */
-    void searchBegan();
-
-    /**
      * Emitted when locator has prepared the search (\see QgsLocatorFilter::prepare)
      * before the search is actually performed
      * \since QGIS 3.16

--- a/src/core/locator/qgslocator.h
+++ b/src/core/locator/qgslocator.h
@@ -161,7 +161,7 @@ class CORE_EXPORT QgsLocator : public QObject
     void foundResult( const QgsLocatorResult &result );
 
     /**
-     * Emitted when locator has begun a search, before actualy preparing it.
+     * Emitted when locator has begun a search, before actually preparing it.
      * \since QGIS 3.16
      */
     void searchBegan();

--- a/src/core/locator/qgslocatorfilter.h
+++ b/src/core/locator/qgslocatorfilter.h
@@ -219,7 +219,7 @@ class CORE_EXPORT QgsLocatorFilter : public QObject
      * from the main thread, and individual filter subclasses should perform whatever
      * tasks are required in order to allow a subsequent search to safely execute
      * on a background thread.
-     * The method return an autocompletion list
+     * The method returns an autocompletion list
      */
     virtual QStringList prepare( const QString &string, const QgsLocatorContext &context ) { Q_UNUSED( string ) Q_UNUSED( context ); return QStringList();}
 

--- a/src/core/locator/qgslocatorfilter.h
+++ b/src/core/locator/qgslocatorfilter.h
@@ -219,8 +219,9 @@ class CORE_EXPORT QgsLocatorFilter : public QObject
      * from the main thread, and individual filter subclasses should perform whatever
      * tasks are required in order to allow a subsequent search to safely execute
      * on a background thread.
+     * The method return an autocompletion list
      */
-    virtual void prepare( const QString &string, const QgsLocatorContext &context ) { Q_UNUSED( string ) Q_UNUSED( context ); }
+    virtual QStringList prepare( const QString &string, const QgsLocatorContext &context ) { Q_UNUSED( string ) Q_UNUSED( context ); return QStringList();}
 
     /**
      * Retrieves the filter results for a specified search \a string. The \a context

--- a/src/gui/locator/qgslocatorwidget.cpp
+++ b/src/gui/locator/qgslocatorwidget.cpp
@@ -24,14 +24,17 @@
 #include "qgsapplication.h"
 #include "qgslogger.h"
 #include "qgsguiutils.h"
+
 #include <QLayout>
 #include <QCompleter>
 #include <QMenu>
+#include <QTextLayout>
+#include <QTextLine>
 
 QgsLocatorWidget::QgsLocatorWidget( QWidget *parent )
   : QWidget( parent )
   , mModelBridge( new QgsLocatorModelBridge( this ) )
-  , mLineEdit( new QgsFilterLineEdit() )
+  , mLineEdit( new QgsLocatorLineEdit( this ) )
   , mResultsView( new QgsLocatorResultsView() )
 {
   mLineEdit->setShowClearButton( true );
@@ -85,7 +88,7 @@ QgsLocatorWidget::QgsLocatorWidget( QWidget *parent )
 
   connect( mModelBridge, &QgsLocatorModelBridge::resultAdded, this, &QgsLocatorWidget::resultAdded );
   connect( mModelBridge, &QgsLocatorModelBridge::isRunningChanged, this, [ = ]() {mLineEdit->setShowSpinner( mModelBridge->isRunning() );} );
-  connect( mModelBridge, & QgsLocatorModelBridge::resultsCleared, this, [ = ]() {mHasSelectedResult = false;} );
+  connect( mModelBridge, &QgsLocatorModelBridge::resultsCleared, this, [ = ]() {mHasSelectedResult = false;} );
 
   // have a tiny delay between typing text in line edit and showing the window
   mPopupTimer.setInterval( 100 );
@@ -260,8 +263,11 @@ bool QgsLocatorWidget::eventFilter( QObject *obj, QEvent *event )
         mResultsContainer->hide();
         return true;
       case Qt::Key_Tab:
-        mHasSelectedResult = true;
-        mResultsView->selectNextResult();
+        if ( !mLineEdit->performCompletion() )
+        {
+          mHasSelectedResult = true;
+          mResultsView->selectNextResult();
+        }
         return true;
       case Qt::Key_Backtab:
         mHasSelectedResult = true;
@@ -330,7 +336,6 @@ void QgsLocatorWidget::configMenuAboutToShow()
 }
 
 
-
 void QgsLocatorWidget::acceptCurrentEntry()
 {
   if ( mModelBridge->hasQueueRequested() )
@@ -351,8 +356,6 @@ void QgsLocatorWidget::acceptCurrentEntry()
     mModelBridge->triggerResult( index );
   }
 }
-
-
 
 ///@cond PRIVATE
 
@@ -447,6 +450,76 @@ void QgsLocatorFilterFilter::fetchResults( const QString &string, const QgsLocat
 void QgsLocatorFilterFilter::triggerResult( const QgsLocatorResult &result )
 {
   mLocator->search( result.userData.toString() );
+}
+
+QgsLocatorLineEdit::QgsLocatorLineEdit( QgsLocatorWidget *locator, QWidget *parent )
+  : QgsFilterLineEdit( parent )
+  , mLocatorWidget( locator )
+{
+  connect( mLocatorWidget->locator(), &QgsLocator::searchPrepared, this, [&] { update(); } );
+}
+
+void QgsLocatorLineEdit::paintEvent( QPaintEvent *event )
+{
+  // this adds the completion as grey text at the right of the cursor
+  // see https://stackoverflow.com/a/50425331/1548052
+  // this is possible that the completion might be badly rendered if the cursor is larger than the line edit
+  // this sounds acceptable as it is not very likely to use completion for super long texts
+  // for more details see https://stackoverflow.com/a/54218192/1548052
+
+  QLineEdit::paintEvent( event );
+
+  if ( !hasFocus() )
+    return;
+
+  QString currentText = text();
+
+  if ( currentText.length() == 0 || cursorPosition() < currentText.length() )
+    return;
+
+  const QStringList completionList = mLocatorWidget->locator()->completionList();
+
+  QString completion;
+  for ( const QString &candidate : completionList )
+  {
+    if ( candidate.startsWith( currentText ) )
+    {
+      completion = candidate.right( candidate.length() - currentText.length() );
+      mCompletionText = candidate;
+      break;
+    }
+  }
+
+  if ( completion.isEmpty() )
+    return;
+
+  ensurePolished(); // ensure font() is up to date
+
+  QRect cr = cursorRect();
+  QPoint pos = cr.topRight() - QPoint( cr.width() / 2, 0 );
+
+  QTextLayout l( completion, font() );
+  l.beginLayout();
+  QTextLine line = l.createLine();
+  line.setLineWidth( width() - pos.x() );
+  line.setPosition( pos );
+  l.endLayout();
+
+  QPainter p( this );
+  p.setPen( QPen( Qt::gray, 1 ) );
+  l.draw( &p, QPoint( 0, 0 ) );
+}
+
+bool QgsLocatorLineEdit::performCompletion()
+{
+  if ( !mCompletionText.isEmpty() )
+  {
+    setText( mCompletionText );
+    mCompletionText.clear();
+    return true;
+  }
+  else
+    return false;
 }
 
 

--- a/src/gui/locator/qgslocatorwidget.cpp
+++ b/src/gui/locator/qgslocatorwidget.cpp
@@ -479,6 +479,7 @@ void QgsLocatorLineEdit::paintEvent( QPaintEvent *event )
 
   const QStringList completionList = mLocatorWidget->locator()->completionList();
 
+  mCompletionText.clear();
   QString completion;
   for ( const QString &candidate : completionList )
   {

--- a/src/gui/locator/qgslocatorwidget.h
+++ b/src/gui/locator/qgslocatorwidget.h
@@ -21,6 +21,8 @@
 #include "qgis_gui.h"
 #include "qgslocatorfilter.h"
 #include "qgsfloatingwidget.h"
+#include "qgsfilterlineedit.h"
+
 #include <QWidget>
 #include <QTreeView>
 #include <QFocusEvent>
@@ -28,10 +30,10 @@
 #include <QTimer>
 
 class QgsLocator;
-class QgsFilterLineEdit;
 class QgsLocatorResultsView;
 class QgsMapCanvas;
 class QgsLocatorModelBridge;
+class QgsLocatorLineEdit;
 
 /**
  * \class QgsLocatorWidget
@@ -98,7 +100,7 @@ class GUI_EXPORT QgsLocatorWidget : public QWidget
 
   private:
     QgsLocatorModelBridge *mModelBridge = nullptr;
-    QgsFilterLineEdit *mLineEdit = nullptr;
+    QgsLocatorLineEdit *mLineEdit = nullptr;
     QgsFloatingWidget *mResultsContainer = nullptr;
     QgsLocatorResultsView *mResultsView = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;
@@ -110,6 +112,7 @@ class GUI_EXPORT QgsLocatorWidget : public QWidget
     bool mHasSelectedResult = false;
 
     void acceptCurrentEntry();
+
 };
 
 #ifndef SIP_RUN
@@ -169,6 +172,30 @@ class GUI_EXPORT QgsLocatorResultsView : public QTreeView
      */
     void selectPreviousResult();
 
+};
+
+
+/**
+ * \class QgsLocatorLineEdit
+ * \ingroup gui
+ * Custom line edit to handle completion within the line edit as a light gray text
+ * \since QGIS 3.16
+ */
+class QgsLocatorLineEdit : public QgsFilterLineEdit
+{
+    Q_OBJECT
+  public:
+    explicit QgsLocatorLineEdit( QgsLocatorWidget *locator, QWidget *parent = nullptr );
+
+    //! Perform completion and returns true if successful
+    bool performCompletion();
+
+  protected:
+    void paintEvent( QPaintEvent *event ) override;
+
+  private:
+    QgsLocatorWidget *mLocatorWidget = nullptr;
+    QString mCompletionText = nullptr;
 };
 
 ///@endcond

--- a/src/gui/locator/qgslocatorwidget.h
+++ b/src/gui/locator/qgslocatorwidget.h
@@ -187,7 +187,7 @@ class QgsLocatorLineEdit : public QgsFilterLineEdit
   public:
     explicit QgsLocatorLineEdit( QgsLocatorWidget *locator, QWidget *parent = nullptr );
 
-    //! Perform completion and returns true if successful
+    //! Performs completion and returns true if successful
     bool performCompletion();
 
   protected:


### PR DESCRIPTION

### enable auto completion in locator
a locator filter can now return a completion list while preparing the search
the line edit will use the first matching completion and display it as light grey text
the completion can be triggered by pressing Tab key


### active layer locator filter field name restriction
the filter can now restrict the search to a specific field by typing @+field_name
auto-completion is provided for the field names

### demo
![locator](https://user-images.githubusercontent.com/127259/92394304-9983fc00-f121-11ea-9099-a363c93277eb.gif)


(included in this PR the commit from #38628 )
