### PR TITLE
add configuration flags to QgsFields

### DIFF
--- a/python/core/auto_additions/qgsfield.py
+++ b/python/core/auto_additions/qgsfield.py
@@ -1,0 +1,7 @@
+# The following has been generated automatically from src/core/qgsfield.h
+# monkey patching scoped based enum
+QgsField.Flag.Searchable.__doc__ = "Defines if the field is searchable (used in the locator search for instance)"
+QgsField.Flag.DefaultFlags.__doc__ = "Default set of flags for a field"
+QgsField.Flag.__doc__ = 'Flags for fields\n\n.. versionadded:: 3.16\n\n' + '* ``Searchable``: ' + QgsField.Flag.Searchable.__doc__ + '\n' + '* ``DefaultFlags``: ' + QgsField.Flag.DefaultFlags.__doc__
+# --
+QgsField.Flag.baseClass = QgsField

--- a/python/core/auto_additions/qgsfield.py
+++ b/python/core/auto_additions/qgsfield.py
@@ -1,7 +1,0 @@
-# The following has been generated automatically from src/core/qgsfield.h
-# monkey patching scoped based enum
-QgsField.Flag.Searchable.__doc__ = "Defines if the field is searchable (used in the locator search for instance)"
-QgsField.Flag.DefaultFlags.__doc__ = "Default set of flags for a field"
-QgsField.Flag.__doc__ = 'Flags for fields\n\n.. versionadded:: 3.16\n\n' + '* ``Searchable``: ' + QgsField.Flag.Searchable.__doc__ + '\n' + '* ``DefaultFlags``: ' + QgsField.Flag.DefaultFlags.__doc__
-# --
-QgsField.Flag.baseClass = QgsField

--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -33,13 +33,6 @@ length, and if applicable, precision.
 
   public:
 
-    enum class Flag
-    {
-      Searchable,
-      DefaultFlags,
-    };
-    typedef QFlags<QgsField::Flag> Flags;
-
 
     QgsField( const QString &name = QString(),
               QVariant::Type type = QVariant::Invalid,
@@ -291,19 +284,7 @@ Sets the alias for the field (the friendly displayed name of the field ).
 .. versionadded:: 3.0
 %End
 
-    QgsField::Flags flags() const;
-%Docstring
-Returns the Flags for the field (searchable, …)
 
-.. versionadded:: 3.16
-%End
-
-    void setFlags( QgsField::Flags flags );
-%Docstring
-Sets the Flags for the field (searchable, …)
-
-.. versionadded:: 3.16
-%End
 
     QString displayString( const QVariant &v ) const;
 %Docstring

--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -33,6 +33,14 @@ length, and if applicable, precision.
 
   public:
 
+    enum class Flag
+    {
+      Searchable,
+      DefaultFlags,
+    };
+    typedef QFlags<QgsField::Flag> Flags;
+
+
     QgsField( const QString &name = QString(),
               QVariant::Type type = QVariant::Invalid,
               const QString &typeName = QString(),
@@ -281,6 +289,20 @@ Sets the alias for the field (the friendly displayed name of the field ).
 .. seealso:: :py:func:`alias`
 
 .. versionadded:: 3.0
+%End
+
+    QgsField::Flags flags() const;
+%Docstring
+Returns the Flags for the field (searchable, …)
+
+.. versionadded:: 3.16
+%End
+
+    void setFlags( QgsField::Flags flags );
+%Docstring
+Sets the Flags for the field (searchable, …)
+
+.. versionadded:: 3.16
 %End
 
     QString displayString( const QVariant &v ) const;

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -235,12 +235,12 @@ void QgsField::setAlias( const QString &alias )
   d->alias = alias;
 }
 
-QgsField::Flags QgsField::flags() const
+QgsField::ConfigurationFlag QgsField::flags() const
 {
   return d->flags;
 }
 
-void QgsField::setFlags( QgsField::Flags flags )
+void QgsField::setFlags( QgsField::ConfigurationFlag flags )
 {
   d->flags = flags;
 }

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -235,12 +235,12 @@ void QgsField::setAlias( const QString &alias )
   d->alias = alias;
 }
 
-QgsField::ConfigurationFlag QgsField::flags() const
+QgsField::ConfigurationFlags QgsField::configurationFlags() const
 {
   return d->flags;
 }
 
-void QgsField::setFlags( QgsField::ConfigurationFlag flags )
+void QgsField::setConfigurationFlags( QgsField::ConfigurationFlags flags )
 {
   d->flags = flags;
 }

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -45,8 +45,7 @@ QgsField::QgsField( QString nam, QString typ, int len, int prec, bool num,
 }
 #endif
 QgsField::QgsField( const QString &name, QVariant::Type type,
-                    const QString &typeName, int len, int prec, const QString &comment,
-                    QVariant::Type subType )
+                    const QString &typeName, int len, int prec, const QString &comment, QVariant::Type subType )
 {
   d = new QgsFieldPrivate( name, type, subType, typeName, len, prec, comment );
 }
@@ -234,6 +233,16 @@ QString QgsField::alias() const
 void QgsField::setAlias( const QString &alias )
 {
   d->alias = alias;
+}
+
+QgsField::Flags QgsField::flags() const
+{
+  return d->flags;
+}
+
+void QgsField::setFlags( QgsField::Flags flags )
+{
+  d->flags = flags;
 }
 
 /***************************************************************************

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -60,7 +60,7 @@ class CORE_EXPORT QgsField
     Q_PROPERTY( QString alias READ alias WRITE setAlias )
     Q_PROPERTY( QgsDefaultValue defaultValueDefinition READ defaultValueDefinition WRITE setDefaultValueDefinition )
     Q_PROPERTY( QgsFieldConstraints constraints READ constraints WRITE setConstraints )
-    Q_PROPERTY( ConfigurationFlags flags READ flags WRITE setFlags )
+    Q_PROPERTY( ConfigurationFlags configurationFlags READ configurationFlags WRITE setConfigurationFlags )
 
 
   public:
@@ -305,13 +305,13 @@ class CORE_EXPORT QgsField
      * Returns the Flags for the field (searchable, …)
      * \since QGIS 3.16
      */
-    QgsField::ConfigurationFlag flags() const SIP_SKIP;
+    QgsField::ConfigurationFlags configurationFlags() const SIP_SKIP;
 
     /**
      * Sets the Flags for the field (searchable, …)
      * \since QGIS 3.16
      */
-    void setFlags( QgsField::ConfigurationFlag flags ) SIP_SKIP;
+    void setConfigurationFlags( QgsField::ConfigurationFlags configurationFlags ) SIP_SKIP;
 
     //! Formats string for display
     QString displayString( const QVariant &v ) const;

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -60,8 +60,22 @@ class CORE_EXPORT QgsField
     Q_PROPERTY( QString alias READ alias WRITE setAlias )
     Q_PROPERTY( QgsDefaultValue defaultValueDefinition READ defaultValueDefinition WRITE setDefaultValueDefinition )
     Q_PROPERTY( QgsFieldConstraints constraints READ constraints WRITE setConstraints )
+    Q_PROPERTY( Flags flags READ flags WRITE setFlags )
+
 
   public:
+
+    /**
+       * Flags for fields
+       * \since QGIS 3.16
+       */
+    enum class Flag : int
+    {
+      Searchable = 0x1, //!< Defines if the field is searchable (used in the locator search for instance)
+      DefaultFlags = Searchable, //!< Default set of flags for a field
+    };
+    Q_ENUM( Flag )
+    Q_DECLARE_FLAGS( Flags, Flag )
 
     /**
      * Constructor. Constructs a new QgsField object.
@@ -281,6 +295,18 @@ class CORE_EXPORT QgsField
      * \since QGIS 3.0
      */
     void setAlias( const QString &alias );
+
+    /**
+     * Returns the Flags for the field (searchable, …)
+     * \since QGIS 3.16
+     */
+    QgsField::Flags flags() const;
+
+    /**
+     * Sets the Flags for the field (searchable, …)
+     * \since QGIS 3.16
+     */
+    void setFlags( QgsField::Flags flags );
 
     //! Formats string for display
     QString displayString( const QVariant &v ) const;

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -60,22 +60,27 @@ class CORE_EXPORT QgsField
     Q_PROPERTY( QString alias READ alias WRITE setAlias )
     Q_PROPERTY( QgsDefaultValue defaultValueDefinition READ defaultValueDefinition WRITE setDefaultValueDefinition )
     Q_PROPERTY( QgsFieldConstraints constraints READ constraints WRITE setConstraints )
-    Q_PROPERTY( Flags flags READ flags WRITE setFlags )
+    Q_PROPERTY( ConfigurationFlags flags READ flags WRITE setFlags )
 
 
   public:
 
+#ifndef SIP_RUN
+
     /**
-       * Flags for fields
+       * Configuration flags for fields
+       * These flags are meant to be user-configurable
+       * and are not describing any information from the data provider.
        * \since QGIS 3.16
        */
-    enum class Flag : int
+    enum class ConfigurationFlag : int
     {
       Searchable = 0x1, //!< Defines if the field is searchable (used in the locator search for instance)
       DefaultFlags = Searchable, //!< Default set of flags for a field
     };
-    Q_ENUM( Flag )
-    Q_DECLARE_FLAGS( Flags, Flag )
+    Q_ENUM( ConfigurationFlag )
+    Q_DECLARE_FLAGS( ConfigurationFlags, ConfigurationFlag )
+#endif
 
     /**
      * Constructor. Constructs a new QgsField object.
@@ -300,13 +305,13 @@ class CORE_EXPORT QgsField
      * Returns the Flags for the field (searchable, …)
      * \since QGIS 3.16
      */
-    QgsField::Flags flags() const;
+    QgsField::ConfigurationFlag flags() const SIP_SKIP;
 
     /**
      * Sets the Flags for the field (searchable, …)
      * \since QGIS 3.16
      */
-    void setFlags( QgsField::Flags flags );
+    void setFlags( QgsField::ConfigurationFlag flags ) SIP_SKIP;
 
     //! Formats string for display
     QString displayString( const QVariant &v ) const;

--- a/src/core/qgsfield_p.h
+++ b/src/core/qgsfield_p.h
@@ -116,7 +116,7 @@ class QgsFieldPrivate : public QSharedData
     QString alias;
 
     //! Flags for the field (searchable, …)
-    QgsField::Flags flags = QgsField::Flag::DefaultFlags;
+    QgsField::Flags flags = QgsField::ConfigurationFlag::DefaultFlags;
 
     //! Default value
     QgsDefaultValue defaultValueDefinition;

--- a/src/core/qgsfield_p.h
+++ b/src/core/qgsfield_p.h
@@ -32,6 +32,8 @@
 #include "qgsfieldconstraints.h"
 #include "qgseditorwidgetsetup.h"
 #include "qgsdefaultvalue.h"
+#include "qgsfield.h"
+
 #include <QString>
 #include <QVariant>
 #include <QSharedData>
@@ -73,6 +75,7 @@ class QgsFieldPrivate : public QSharedData
       , precision( other.precision )
       , comment( other.comment )
       , alias( other.alias )
+      , flags( other.flags )
       , defaultValueDefinition( other.defaultValueDefinition )
       , constraints( other.constraints )
     {
@@ -85,7 +88,7 @@ class QgsFieldPrivate : public QSharedData
       return ( ( name == other.name ) && ( type == other.type ) && ( subType == other.subType )
                && ( length == other.length ) && ( precision == other.precision )
                && ( alias == other.alias ) && ( defaultValueDefinition == other.defaultValueDefinition )
-               && ( constraints == other.constraints ) );
+               && ( constraints == other.constraints )  && ( flags == other.flags ) );
     }
 
     //! Name
@@ -111,6 +114,9 @@ class QgsFieldPrivate : public QSharedData
 
     //! Alias for field name (friendly name shown to users)
     QString alias;
+
+    //! Flags for the field (searchable, …)
+    QgsField::Flags flags = QgsField::Flag::DefaultFlags;
 
     //! Default value
     QgsDefaultValue defaultValueDefinition;

--- a/src/core/qgsfield_p.h
+++ b/src/core/qgsfield_p.h
@@ -116,7 +116,7 @@ class QgsFieldPrivate : public QSharedData
     QString alias;
 
     //! Flags for the field (searchable, …)
-    QgsField::Flags flags = QgsField::ConfigurationFlag::DefaultFlags;
+    QgsField::ConfigurationFlags flags = QgsField::ConfigurationFlag::DefaultFlags;
 
     //! Default value
     QgsDefaultValue defaultValueDefinition;


### PR DESCRIPTION
This is a preliminary work to allow defining if fields are searchable in active layer locator filter
(feature request: https://github.com/qgis/QGIS/issues/36701)

The idea to use flags is to make this future proof and easily extend the flags.
Saving/reading to XML will be handy using [QMetaEnum::valueToKeys](https://doc.qt.io/qt-5/qmetaenum.html#valueToKeys)

(Later on, WMS/WFS capabilities could be moved to these flags)