### PR TITLE
Fix #38071: Clear mTreeInitialExpand and search upon new connection

### DIFF
--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -270,6 +270,9 @@ void QgsWMSSourceSelect::clear()
   lstLayers->clear();
   lstTilesets->clearContents();
 
+  mTreeInitialExpand.clear();
+  mLayersFilterLineEdit->clearValue();
+
   mCRSs.clear();
 
   const auto constButtons = mImageFormatGroup->buttons();


### PR DESCRIPTION
See
https://github.com/qgis/QGIS/issues/38071

When you clear the 'search/filter' input in the WMS source select dialog in between 2 different connections, you get a big crash here:

https://github.com/qgis/QGIS/blob/master/src/providers/wms/qgswmssourceselect.cpp#L1137-L1145

My conclusion was that the mTreeInitialExpand ("// save the current status of the layer true" ??) see 

https://github.com/qgis/QGIS/blob/master/src/providers/wms/qgswmssourceselect.h#L193-L194

was holding the information of the 'old' connection.

So in the clear method I clear both the mTreeInitialExpand AND the filter input.

@3nids if you think it is better to fix it in the loop of

https://github.com/qgis/QGIS/blob/master/src/providers/wms/qgswmssourceselect.cpp#L1137-L1145

let me know.