### PR TITLE
[QgsQuick] Date time widget improvements

### DIFF
--- a/src/quickgui/plugin/editor/qgsquickdatetime.qml
+++ b/src/quickgui/plugin/editor/qgsquickdatetime.qml
@@ -91,7 +91,7 @@ Item {
                             // if the field is a QDate, the automatic conversion to JS date [1]
                             // leads to the creation of date time object with the time zone.
                             // For instance shapefiles has support for dates but not date/time or time.
-                            // So a date coming from a shapefile as 2001-01-01 will become 2000-12-31 19:00:00 -05 in QML/JS (in the carribeans).
+                            // So a date coming from a shapefile as 2001-01-01 will become 2000-12-31 19:00:00 -05 in QML/JS in UTC -05 zone.
                             // And when formatting this with the display format, this is shown as 2000-12-31.
                             // So we detect if the field is a date only and revert the time zone offset.
                             // [1] http://doc.qt.io/qt-5/qtqml-cppintegration-data.html#basic-qt-data-types

--- a/src/quickgui/plugin/editor/qgsquickdatetime.qml
+++ b/src/quickgui/plugin/editor/qgsquickdatetime.qml
@@ -18,6 +18,7 @@ import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.1
 import QtQuick.Controls 1.4 as Controls1
 import QtGraphicalEffects 1.0
+import QtQuick.Window 2.0
 import QgsQuick 0.1 as QgsQuick
 
 /**
@@ -167,11 +168,16 @@ Item {
           parent: ApplicationWindow.overlay
           anchors.centerIn: parent
 
-          ColumnLayout {
-              Rectangle {
+            ScrollView {
+              clip: true
+              width: parent.width
+              height: parent.height
+
+              ColumnLayout {
+                Rectangle {
                   id: calendarOverlay
                   color: "transparent"
-                  implicitWidth: ApplicationWindow.window.width * 0.8
+                  implicitWidth: Math.min(Screen.width, Screen.height) * 0.8
                   implicitHeight: implicitWidth
                   visible: main.typeFromFieldFormat === "Date" || main.typeFromFieldFormat === "Date Time"
 
@@ -185,7 +191,6 @@ Item {
                       id: calendarGrid
                       anchors.left: parent.left
                       anchors.right: parent.right
-                      //Layout.alignment: Qt.AlignHCenter
                       columns: 1
                       implicitWidth: calendarOverlay.width
                       implicitHeight: calendarOverlay.height
@@ -302,7 +307,8 @@ Item {
                           popup.close()
                       }
                   }
-              }
+                }
+             }
           }
         }
 

--- a/src/quickgui/plugin/editor/qgsquickdatetime.qml
+++ b/src/quickgui/plugin/editor/qgsquickdatetime.qml
@@ -116,7 +116,7 @@ Item {
                   onClicked: {
                     var usedDate = new Date();
                     if (value !== undefined && value !== '') {
-                      usedDate = value;
+                      usedDate = main.isDateOrTime ? value : Date.fromLocaleString(Qt.locale(), value, config['field_format'])
                     }
 
                     calendar.selectedDate = usedDate
@@ -147,7 +147,8 @@ Item {
                     anchors.fill: parent
                     onClicked: {
                       var newDate = new Date()
-                      valueChanged(newDate, false)
+                      var newValue = field.isDateOrTime ? newDate : Qt.formatDateTime(newDate, config['field_format'])
+                      valueChanged(newValue, false)
                     }
                 }
             }
@@ -197,7 +198,10 @@ Item {
 
                         Controls1.Calendar {
                           id: calendar
-                          selectedDate: main.currentValue || new Date()
+                          selectedDate: {
+                            var date = field.isDateOrTime ? main.currentValue : Date.fromLocaleString(Qt.locale(), value, config['field_format'])
+                            date || new Date()
+                          }
                           weekNumbersVisible: true
                           focus: false
                           implicitWidth: calendarOverlay.width
@@ -302,8 +306,8 @@ Item {
                             newDate.setSeconds(secondsSpinBox.value);
                           }
 
-                          label.text = timeToString(newDate)
-                          valueChanged(newDate, newDate === undefined)
+                          var newValue = field.isDateOrTime ? newDate : Qt.formatDateTime(newDate, config['field_format'])
+                          valueChanged(newValue, newValue === undefined)
                           popup.close()
                       }
                   }
@@ -313,7 +317,7 @@ Item {
         }
 
         onCurrentValueChanged: {
-            label.text = timeToString(main.currentValue)
+            label.text = field.isDateOrTime ? timeToString(main.currentValue) : main.currentValue
         }
     }
 

--- a/src/quickgui/plugin/editor/qgsquickdatetime.qml
+++ b/src/quickgui/plugin/editor/qgsquickdatetime.qml
@@ -38,11 +38,23 @@ Item {
       rightMargin: 10 * QgsQuick.Utils.dp
     }
 
+    property var timeToString: function timeToString(attrValue) {
+      if (attrValue === undefined)
+      {
+          return qsTr('(no date)')
+      }
+      else
+      {
+        return Qt.formatDateTime(attrValue, config['display_format'])
+      }
+    }
 
     ColumnLayout {
         id: main
-        property var isDateTimeType: field.type === Qt.DateTime || field.type === Qt.Date || field.type === Qt.Time
-        property var currentValue: isDateTimeType? value : Qt.formatDateTime(value, config['field_format'])
+        property var currentValue: value
+        property bool fieldIsDate: QgsQuick.Utils.fieldType( field ) === 'QDate'
+        property var typeFromFieldFormat: QgsQuick.Utils.dateTimeFieldFormat( config['field_format'] )
+        property var rowHeight: customStyle.fields.height * 0.75
 
         anchors { right: parent.right; left: parent.left }
 
@@ -56,87 +68,65 @@ Item {
                 anchors.fill: parent
                 verticalAlignment: Text.AlignVCenter
                 font.pixelSize: customStyle.fields.fontPixelSize
+                color: customStyle.fields.fontColor
                 padding: 0
+                topPadding: 10 * QgsQuick.Utils.dp
+                bottomPadding: 10 * QgsQuick.Utils.dp
                 background: Rectangle {
                     radius: customStyle.fields.cornerRadius
 
-                    border.color: label.activeFocus ? customStyle.fields.activeColor : customStyle.fields.normalColor
-                    border.width: label.activeFocus ? 2 : 1
+                    border.color: popup.opened ? customStyle.fields.activeColor : customStyle.fields.normalColor
+                    border.width: popup.opened ? 2 : 1
                     color: customStyle.fields.backgroundColor
                 }
 
-                inputMethodHints: Qt.ImhDigitsOnly
-
-                // this is a bit difficult to auto generate input mask out of date/time format using regex
-                // mainly because number of characters is a variable (e.g. "d": the day as number without a leading zero)
-                inputMask:      if (config['display_format'] === "yyyy-MM-dd" ) { "9999-99-99;_" }
-                                else if (config['display_format'] === "yyyy.MM.dd" ) { "9999.99.09;_" }
-                                else if (config['display_format'] === "yyyy-MM-dd HH:mm:ss" ) { "9999-99-09 99:99:99;_" }
-                                else if (config['display_format'] === "HH:mm:ss" ) { "99:99:99;_" }
-                                else if (config['display_format'] === "HH:mm" ) { "99:99;_" }
-                                else { "" }
-
-                text: {
-                    if ( main.currentValue === undefined )
-                      {
-                          qsTr('(no date)')
-                      }
-                      else
-                      {
-                          if ( main.isDateTimeType )
-                          {
-                              Qt.formatDateTime(main.currentValue, config['display_format'])
-                          }
-                          else
-                          {
-                              var date = Date.fromLocaleString(Qt.locale(), main.currentValue, config['field_format'])
-                              Qt.formatDateTime(date, config['display_format'])
-                          }
-                      }
-            }
-
-                color: main.currentValue === undefined ? 'transparent' : customStyle.fields.fontColor
-
-                MouseArea {
-                    enabled: config['calendar_popup']
-                    anchors.fill: parent
-                    onClicked: {
-                        popup.open()
-                    }
-                }
-
-                onTextEdited: {
-                    var date = Date.fromLocaleString(Qt.locale(), label.text, config['display_format'])
-                    if ( date.toLocaleString() !== "" )
-                    {
-                        if ( main.isDateTimeType )
+                text: if ( value === undefined )
                         {
-                            main.currentValue = date
+                          qsTr('(no date)')
                         }
                         else
                         {
-                            main.currentValue = Qt.formatDateTime(date, config['field_format'])
+                          if ( field.isDateOrTime )
+                          {
+                            // if the field is a QDate, the automatic conversion to JS date [1]
+                            // leads to the creation of date time object with the time zone.
+                            // For instance shapefiles has support for dates but not date/time or time.
+                            // So a date coming from a shapefile as 2001-01-01 will become 2000-12-31 19:00:00 -05 in QML/JS (in the carribeans).
+                            // And when formatting this with the display format, this is shown as 2000-12-31.
+                            // So we detect if the field is a date only and revert the time zone offset.
+                            // [1] http://doc.qt.io/qt-5/qtqml-cppintegration-data.html#basic-qt-data-types
+                            if (main.fieldIsDate) {
+                              Qt.formatDateTime( new Date(value.getTime() + value.getTimezoneOffset() * 60000), config['display_format'])
+                            } else {
+                              Qt.formatDateTime(value, config['display_format'])
+                            }
+                          }
+                          else
+                          {
+                            var date = Date.fromLocaleString(Qt.locale(), value, config['field_format'])
+                            Qt.formatDateTime(date, config['display_format'])
+                          }
                         }
-                        valueChanged(main.currentValue, main.currentValue === undefined)
-                    }
-                    else
-                    {
-                        valueChanged(undefined, true)
-                    }
-                }
 
-                onActiveFocusChanged: {
-                    if (activeFocus) {
-                        var mytext = label.text
-                        var cur = label.cursorPosition
-                        while ( cur > 0 )
-                        {
-                            if (!mytext.charAt(cur-1).match("[0-9]") )
-                                break
-                            cur--
-                        }
-                        label.cursorPosition = cur
+                inputMethodHints: Qt.ImhDate
+
+                MouseArea {
+                  anchors.fill: parent
+                  onClicked: {
+                    var usedDate = new Date();
+                    if (value !== undefined && value !== '') {
+                      usedDate = value;
                     }
+
+                    calendar.selectedDate = usedDate
+                    if (main.typeFromFieldFormat === "Time" || main.typeFromFieldFormat === "Date Time") {
+                      hoursSpinBox.value = usedDate.getHours()
+                      minutesSpinBox.value = usedDate.getMinutes()
+                      secondsSpinBox.value = usedDate.getSeconds()
+                    }
+
+                    popup.open()
+                  }
                 }
             }
 
@@ -154,7 +144,10 @@ Item {
 
                 MouseArea {
                     anchors.fill: parent
-                    onClicked: main.currentValue = new Date()
+                    onClicked: {
+                      var newDate = new Date()
+                      valueChanged(newDate, false)
+                    }
                 }
             }
 
@@ -167,57 +160,156 @@ Item {
         }
 
         Popup {
-            id: popup
-            modal: true
-            focus: true
-            closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
-            parent: ApplicationWindow.overlay
-            x: (window.width - width) / 2
-            y: (window.height - height) / 2
+          id: popup
+          modal: true
+          focus: true
+          closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+          parent: ApplicationWindow.overlay
+          anchors.centerIn: parent
 
-            ColumnLayout {
+          ColumnLayout {
+              Rectangle {
+                  id: calendarOverlay
+                  color: "transparent"
+                  implicitWidth: ApplicationWindow.window.width * 0.8
+                  implicitHeight: implicitWidth
+                  visible: main.typeFromFieldFormat === "Date" || main.typeFromFieldFormat === "Date Time"
 
-                Controls1.Calendar {
-                    id: calendar
-                    selectedDate: main.currentValue || new Date()
-                    weekNumbersVisible: true
-                    focus: false
+                  MouseArea {
+                      anchors.fill: parent
+                      onClicked: mouse.accepted = true
+                      onWheel: wheel.accepted = true
+                  }
 
-                    onSelectedDateChanged: {
-                        if ( main.isDateTimeType )
-                        {
-                            main.currentValue = selectedDate
-                        }
-                        else
-                        {
-                            main.currentValue = Qt.formatDateTime(selectedDate, config['field_format'])
-                        }
-                    }
-                }
+                  GridLayout {
+                      id: calendarGrid
+                      anchors.left: parent.left
+                      anchors.right: parent.right
+                      //Layout.alignment: Qt.AlignHCenter
+                      columns: 1
+                      implicitWidth: calendarOverlay.width
+                      implicitHeight: calendarOverlay.height
 
-                RowLayout {
-                    Button {
-                        text: qsTr( "Ok" )
-                        Layout.fillWidth: true
+                        Controls1.Calendar {
+                          id: calendar
+                          selectedDate: main.currentValue || new Date()
+                          weekNumbersVisible: true
+                          focus: false
+                          implicitWidth: calendarOverlay.width
+                          implicitHeight: calendarOverlay.height
+                      }
+                  }
+              }
 
-                        onClicked: popup.close()
-                    }
-                }
-            }
+              RowLayout {
+                visible: main.typeFromFieldFormat === "Time" || main.typeFromFieldFormat === "Date Time"
+                Layout.alignment: Qt.AlignHCenter
+
+                  GridLayout {
+                      id: timeGrid
+                      Layout.alignment: Qt.AlignHCenter
+                      Layout.leftMargin: 20
+                      rows: 3
+                      columns: 2
+
+                      Label {
+                          verticalAlignment: Text.AlignVCenter
+                          Layout.preferredHeight: main.rowHeight
+                          Layout.fillWidth: true
+                          Layout.row: 0
+                          Layout.column: 0
+                          text: qsTr( "Hours" )
+
+                      }
+                      SpinBox {
+                          id: hoursSpinBox
+                          Layout.preferredHeight: main.rowHeight
+                          Layout.fillWidth: true
+                          Layout.row: 0
+                          Layout.column: 1
+                          editable: true
+                          from: 0
+                          to: 23
+                          value: 12
+                          inputMethodHints: Qt.ImhTime
+                          down.indicator.width: main.rowHeight
+                          up.indicator.width: main.rowHeight
+                      }
+                      Label {
+                          verticalAlignment: Text.AlignVCenter
+                          Layout.preferredHeight: main.rowHeight
+                          Layout.fillWidth: true
+                          Layout.row: 1
+                          Layout.column: 0
+                          text: qsTr( "Minutes" )
+                      }
+                      SpinBox {
+                          id: minutesSpinBox
+                          Layout.preferredHeight: main.rowHeight
+                          Layout.fillWidth: true
+                          Layout.row: 1
+                          Layout.column: 1
+                          editable: true
+                          from: 0
+                          to: 59
+                          value: 30
+                          inputMethodHints: Qt.ImhTime
+                          down.indicator.width: main.rowHeight
+                          up.indicator.width: main.rowHeight
+                      }
+                      Label {
+                          verticalAlignment: Text.AlignVCenter
+                          Layout.preferredHeight: main.rowHeight
+                          Layout.fillWidth: true
+                          Layout.row: 2
+                          Layout.column: 0
+                          text: qsTr( "Seconds" )
+                      }
+                      SpinBox {
+                          id: secondsSpinBox
+                          Layout.preferredHeight: main.rowHeight
+                          Layout.fillWidth: true
+                          Layout.row: 2
+                          Layout.column: 1
+                          editable: true
+                          from: 0
+                          to: 59
+                          value: 30
+                          inputMethodHints: Qt.ImhTime
+                          down.indicator.width: main.rowHeight
+                          up.indicator.width: main.rowHeight
+                      }
+                  }
+              }
+
+              RowLayout {
+                  Button {
+                      text: qsTr( "OK" )
+                      Layout.fillWidth: true
+                      Layout.preferredHeight: main.rowHeight
+
+                      onClicked: {
+                          var newDate = calendar.selectedDate
+
+                          if (main.typeFromFieldFormat === "Time" || main.typeFromFieldFormat === "Date Time") {
+                            newDate.setHours(hoursSpinBox.value);
+                            newDate.setMinutes(minutesSpinBox.value);
+                            newDate.setSeconds(secondsSpinBox.value);
+                          }
+
+                          label.text = timeToString(newDate)
+                          valueChanged(newDate, newDate === undefined)
+                          popup.close()
+                      }
+                  }
+              }
+          }
         }
 
         onCurrentValueChanged: {
-            valueChanged(main.currentValue, main.currentValue === undefined)
-            if (main.currentValue === undefined)
-            {
-                label.text = qsTr('(no date)')
-                label.color = customStyle.fields.fontColor
-            }
-            else
-            {
-                label.color = customStyle.fields.fontColor
-                label.text = new Date(value).toLocaleString(Qt.locale(), config['display_format'] )
-            }
+            label.text = timeToString(main.currentValue)
         }
     }
+
 }
+

--- a/src/quickgui/plugin/editor/qgsquickdatetime.qml
+++ b/src/quickgui/plugin/editor/qgsquickdatetime.qml
@@ -18,7 +18,6 @@ import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.1
 import QtQuick.Controls 1.4 as Controls1
 import QtGraphicalEffects 1.0
-import QtQuick.Window 2.0
 import QgsQuick 0.1 as QgsQuick
 
 /**
@@ -116,7 +115,7 @@ Item {
                   onClicked: {
                     var usedDate = new Date();
                     if (value !== undefined && value !== '') {
-                      usedDate = main.isDateOrTime ? value : Date.fromLocaleString(Qt.locale(), value, config['field_format'])
+                      usedDate = field.isDateOrTime ? value : Date.fromLocaleString(Qt.locale(), value, config['field_format'])
                     }
 
                     calendar.selectedDate = usedDate
@@ -178,7 +177,7 @@ Item {
                 Rectangle {
                   id: calendarOverlay
                   color: "transparent"
-                  implicitWidth: Math.min(Screen.width, Screen.height) * 0.8
+                  implicitWidth: Math.min(popup.parent.width, popup.parent.height) * 0.8
                   implicitHeight: implicitWidth
                   visible: main.typeFromFieldFormat === "Date" || main.typeFromFieldFormat === "Date Time"
 
@@ -233,6 +232,7 @@ Item {
                       SpinBox {
                           id: hoursSpinBox
                           Layout.preferredHeight: main.rowHeight
+                          Layout.minimumWidth: main.rowHeight * 3
                           Layout.fillWidth: true
                           Layout.row: 0
                           Layout.column: 1
@@ -255,6 +255,7 @@ Item {
                       SpinBox {
                           id: minutesSpinBox
                           Layout.preferredHeight: main.rowHeight
+                          Layout.minimumWidth: main.rowHeight * 3
                           Layout.fillWidth: true
                           Layout.row: 1
                           Layout.column: 1
@@ -277,6 +278,7 @@ Item {
                       SpinBox {
                           id: secondsSpinBox
                           Layout.preferredHeight: main.rowHeight
+                          Layout.minimumWidth: main.rowHeight * 3
                           Layout.fillWidth: true
                           Layout.row: 2
                           Layout.column: 1

--- a/src/quickgui/qgsquickutils.cpp
+++ b/src/quickgui/qgsquickutils.cpp
@@ -26,6 +26,7 @@
 #include "qgsfeature.h"
 #include "qgsapplication.h"
 #include "qgsvaluerelationfieldformatter.h"
+#include "qgsdatetimefieldformatter.h"
 
 #include "qgsquickfeaturelayerpair.h"
 #include "qgsquickmapsettings.h"
@@ -381,6 +382,31 @@ void QgsQuickUtils::selectFeaturesInLayer( QgsVectorLayer *layer, const QList<in
   for ( const int &fid : fids )
     qgsFids << fid;
   layer->selectByIds( qgsFids, behavior );
+}
+
+QString QgsQuickUtils::fieldType( const QgsField &field )
+{
+  return QVariant( field.type() ).typeName();
+}
+
+QString QgsQuickUtils::dateTimeFieldFormat( const QString &fieldFormat )
+{
+  if ( QgsDateTimeFieldFormatter::DATE_FORMAT == fieldFormat )
+  {
+    return QStringLiteral( "Date" );
+  }
+  else if ( QgsDateTimeFieldFormatter::TIME_FORMAT == fieldFormat )
+  {
+    return QStringLiteral( "Time" );
+  }
+  else if ( QgsDateTimeFieldFormatter::DATETIME_FORMAT == fieldFormat )
+  {
+    return QStringLiteral( "Date Time" );
+  }
+  else
+  {
+    return QStringLiteral();
+  }
 }
 
 qreal QgsQuickUtils::screenDensity() const

--- a/src/quickgui/qgsquickutils.cpp
+++ b/src/quickgui/qgsquickutils.cpp
@@ -405,7 +405,7 @@ QString QgsQuickUtils::dateTimeFieldFormat( const QString &fieldFormat )
   }
   else
   {
-    return QString();
+    return QString( "Date Time" );
   }
 }
 

--- a/src/quickgui/qgsquickutils.cpp
+++ b/src/quickgui/qgsquickutils.cpp
@@ -393,19 +393,19 @@ QString QgsQuickUtils::dateTimeFieldFormat( const QString &fieldFormat )
 {
   if ( QgsDateTimeFieldFormatter::DATE_FORMAT == fieldFormat )
   {
-    return QStringLiteral( "Date" );
+    return QString( "Date" );
   }
   else if ( QgsDateTimeFieldFormatter::TIME_FORMAT == fieldFormat )
   {
-    return QStringLiteral( "Time" );
+    return QString( "Time" );
   }
   else if ( QgsDateTimeFieldFormatter::DATETIME_FORMAT == fieldFormat )
   {
-    return QStringLiteral( "Date Time" );
+    return QString( "Date Time" );
   }
   else
   {
-    return QStringLiteral();
+    return QString();
   }
 }
 

--- a/src/quickgui/qgsquickutils.h
+++ b/src/quickgui/qgsquickutils.h
@@ -264,6 +264,21 @@ class QUICK_EXPORT QgsQuickUtils: public QObject
      */
     Q_INVOKABLE static void selectFeaturesInLayer( QgsVectorLayer *layer, const QList<int> &fids, QgsVectorLayer::SelectBehavior behavior = QgsVectorLayer::SetSelection );
 
+
+    /**
+    * Returns the QVariant typeName of a \a field.
+    * This is a stable identifier (compared to the provider field name).
+    * \param field QgsField
+    */
+    Q_INVOKABLE static QString fieldType( const QgsField &field );
+
+
+    /**
+    * Returns field format's name for given string representing field format defined in QgsDateTimeFieldFormatter.
+    * \param fieldFormat string representing formats from QgsDateTimeFieldFormatter.
+    */
+    Q_INVOKABLE static QString dateTimeFieldFormat( const QString &fieldFormat );
+
   private:
     static void formatToMetricDistance( double srcDistance,
                                         QgsUnitTypes::DistanceUnit srcUnits,


### PR DESCRIPTION
Modified date time widget. 
* supports time and datetime
* supports custom format
* ignores calendar_popup flag in widget config - calendar or time widget is always opened to simplify user interaction as well as widget itself.
* shows calendar, time spin boxes or both according `Field format` in widget configuration.
* scrollable on small screens

Added utility functions to QgsQuickUtils needed for the widget

![IMG_0040 2](https://user-images.githubusercontent.com/6735606/92405117-4025c800-f135-11ea-9396-3fa791ddd281.PNG)