### PR TITLE
Add help string for parameters in Processing

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -315,7 +315,7 @@ their acceptable ranges, defaults, etc.
 
 
     QgsProcessingParameterDefinition( const QString &name, const QString &description = QString(), const QVariant &defaultValue = QVariant(),
-                                      bool optional = false );
+                                      bool optional = false, const QString &help = QString() );
 %Docstring
 Constructor for QgsProcessingParameterDefinition.
 %End
@@ -369,6 +369,24 @@ Sets the ``description`` for the parameter. This is the user-visible string
 used to identify this parameter.
 
 .. seealso:: :py:func:`description`
+%End
+
+    QString help() const;
+%Docstring
+Returns the help for the parameter.
+
+.. seealso:: :py:func:`setHelp`
+
+.. versionadded:: 3.16
+%End
+
+    void setHelp( const QString &help );
+%Docstring
+Sets the ``help`` for the parameter.
+
+.. seealso:: :py:func:`help`
+
+.. versionadded:: 3.16
 %End
 
     QVariant defaultValue() const;
@@ -608,6 +626,7 @@ The ``variables`` list should contain the variable names only, without the usual
 %End
 
   protected:
+
 
 
 

--- a/python/plugins/processing/tools/general.py
+++ b/python/plugins/processing/tools/general.py
@@ -56,6 +56,8 @@ def algorithmHelp(id):
         print('----------------')
         for p in alg.parameterDefinitions():
             print('\n{}: {}'.format(p.name(), p.description()))
+            if p.help():
+                print('\n\t{}'.format(p.help()))
 
             print('\n\tParameter type:\t{}'.format(p.__class__.__name__))
 

--- a/src/analysis/processing/qgsalgorithmbuffer.cpp
+++ b/src/analysis/processing/qgsalgorithmbuffer.cpp
@@ -55,8 +55,9 @@ void QgsBufferAlgorithm::initAlgorithm( const QVariantMap & )
   bufferParam->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "Distance" ), QObject::tr( "Buffer distance" ), QgsPropertyDefinition::Double ) );
   bufferParam->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
   addParameter( bufferParam.release() );
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "SEGMENTS" ), QObject::tr( "Segments" ), QgsProcessingParameterNumber::Integer, 5, false, 1 ) );
-
+  auto segmentParam = qgis::make_unique < QgsProcessingParameterNumber >( QStringLiteral( "SEGMENTS" ), QObject::tr( "Segments" ), QgsProcessingParameterNumber::Integer, 5, false, 1 );
+  segmentParam->setHelp( QObject::tr( "The segments parameter controls the number of line segments to use to approximate a quarter circle when creating rounded offsets." ) );
+  addParameter( segmentParam.release() );
   addParameter( new QgsProcessingParameterEnum( QStringLiteral( "END_CAP_STYLE" ), QObject::tr( "End cap style" ), QStringList() << QObject::tr( "Round" ) << QObject::tr( "Flat" ) << QObject::tr( "Square" ), false, 0 ) );
   addParameter( new QgsProcessingParameterEnum( QStringLiteral( "JOIN_STYLE" ), QObject::tr( "Join style" ), QStringList() << QObject::tr( "Round" ) << QObject::tr( "Miter" ) << QObject::tr( "Bevel" ), false, 0 ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "MITER_LIMIT" ), QObject::tr( "Miter limit" ), QgsProcessingParameterNumber::Double, 2, false, 1 ) );

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -2110,9 +2110,10 @@ bool QgsProcessingParameters::parseScriptCodeParameterOptions( const QString &co
 // QgsProcessingParameterDefinition
 //
 
-QgsProcessingParameterDefinition::QgsProcessingParameterDefinition( const QString &name, const QString &description, const QVariant &defaultValue, bool optional )
+QgsProcessingParameterDefinition::QgsProcessingParameterDefinition( const QString &name, const QString &description, const QVariant &defaultValue, bool optional, const QString &help )
   : mName( name )
   , mDescription( description )
+  , mHelp( help )
   , mDefault( defaultValue )
   , mFlags( optional ? FlagOptional : 0 )
 {}
@@ -2208,9 +2209,13 @@ QgsProcessingProvider *QgsProcessingParameterDefinition::provider() const
 
 QString QgsProcessingParameterDefinition::toolTip() const
 {
-  return QStringLiteral( "<p><b>%1</b></p><p>%2</p>" ).arg(
-           description(),
-           QObject::tr( "Python identifier: ‘%1’" ).arg( QStringLiteral( "<i>%1</i>" ).arg( name() ) ) );
+  QString text = QStringLiteral( "<p><b>%1</b></p>" ).arg( description() );
+  if ( !help().isEmpty() )
+  {
+    text += QStringLiteral( "<p>%1</p>" ).arg( help() );
+  }
+  text += QStringLiteral( "<p>%1</p>" ).arg( QObject::tr( "Python identifier: ‘%1’" ).arg( QStringLiteral( "<i>%1</i>" ).arg( name() ) ) );
+  return text;
 }
 
 QgsProcessingParameterBoolean::QgsProcessingParameterBoolean( const QString &name, const QString &description, const QVariant &defaultValue, bool optional )

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -427,7 +427,7 @@ class CORE_EXPORT QgsProcessingParameterDefinition
      * Constructor for QgsProcessingParameterDefinition.
      */
     QgsProcessingParameterDefinition( const QString &name, const QString &description = QString(), const QVariant &defaultValue = QVariant(),
-                                      bool optional = false );
+                                      bool optional = false, const QString &help = QString() );
 
     virtual ~QgsProcessingParameterDefinition() = default;
 
@@ -475,6 +475,20 @@ class CORE_EXPORT QgsProcessingParameterDefinition
      * \see description()
      */
     void setDescription( const QString &description ) { mDescription = description; }
+
+    /**
+     * Returns the help for the parameter.
+     * \see setHelp()
+     * \since QGIS 3.16
+     */
+    QString help() const { return mHelp; }
+
+    /**
+     * Sets the \a help for the parameter.
+     * \see help()
+     * \since QGIS 3.16
+     */
+    void setHelp( const QString &help ) { mHelp = help; }
 
     /**
      * Returns the default value for the parameter.
@@ -696,6 +710,9 @@ class CORE_EXPORT QgsProcessingParameterDefinition
 
     //! Parameter description
     QString mDescription;
+
+    //! Parameter help
+    QString mHelp;
 
     //! Default value for parameter
     QVariant mDefault;

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -395,6 +395,10 @@ int QgsProcessingExec::showAlgorithmHelp( const QString &id )
       continue;
 
     std::cout << QStringLiteral( "%1: %2\n" ).arg( p->name(), p->description() ).toLocal8Bit().constData();
+    if ( ! p->help().isEmpty() )
+    {
+      std::cout << QStringLiteral( "\t%1\n" ).arg( p->help() ).toLocal8Bit().constData();
+    }
     std::cout << QStringLiteral( "\tArgument type:\t%1\n" ).arg( p->type() ).toLocal8Bit().constData();
 
     if ( p->type() == QgsProcessingParameterEnum::typeName() )

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -6352,11 +6352,13 @@ void TestProcessingGui::paramConfigWidget()
 
   // using a parameter definition as initial values
   def->setDescription( QStringLiteral( "test desc" ) );
+  def->setHelp( QStringLiteral( "test help" ) );
   def->setFlags( QgsProcessingParameterDefinition::FlagOptional );
   widget = qgis::make_unique< QgsProcessingParameterDefinitionWidget >( QStringLiteral( "string" ), context, widgetContext, def.get() );
   def.reset( widget->createParameter( QStringLiteral( "param_name" ) ) );
   QCOMPARE( def->name(), QStringLiteral( "param_name" ) );
   QCOMPARE( def->description(), QStringLiteral( "test desc" ) );
+  QCOMPARE( def->help(), QStringLiteral( "test help" ) );
   QVERIFY( def->flags() & QgsProcessingParameterDefinition::FlagOptional );
   QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced ) );
   def->setFlags( QgsProcessingParameterDefinition::FlagAdvanced );


### PR DESCRIPTION
## Description

This PR restores the previous behavior from QGIS 2 where we could set a help string at the parameter level.

This will be visible in the tooltip, in the CLI qgis_process and Python Processing API.

![Selection_016](https://user-images.githubusercontent.com/1609292/92464062-ee308100-f1cc-11ea-8365-7089777b90e9.png)
