### PR TITLE
[processing] Add Zonal statistics algorithm that creates a new output

### DIFF
--- a/python/analysis/auto_generated/vector/qgszonalstatistics.sip.in
+++ b/python/analysis/auto_generated/vector/qgszonalstatistics.sip.in
@@ -42,6 +42,17 @@ A class that calculates raster statistics (count, sum, mean) for a polygon or mu
     typedef QFlags<QgsZonalStatistics::Statistic> Statistics;
 
 
+    enum Result
+    {
+      Success,
+      LayerTypeWrong,
+      LayerInvalid,
+      RasterInvalid,
+      RasterBandInvalid,
+      FailedToCreateField,
+      Cancelled
+    };
+
     QgsZonalStatistics( QgsVectorLayer *polygonLayer,
                         QgsRasterLayer *rasterLayer,
                         const QString &attributePrefix = QString(),
@@ -95,11 +106,27 @@ added to ``polygonLayer`` for each statistic calculated.
 .. versionadded:: 3.2
 %End
 
-    int calculateStatistics( QgsFeedback *feedback );
-%Docstring
-Starts the calculation
 
-:return: 0 in case of success
+    QgsZonalStatistics( QgsFeatureSource *source,
+                        QgsFeatureSink *sink,
+                        QgsRasterInterface *rasterInterface,
+                        const QgsCoordinateReferenceSystem &rasterCrs,
+                        const QMap<QgsZonalStatistics::Statistic, int> &statFieldIndexes,
+                        const QgsFields &fields,
+                        double rasterUnitsPerPixelX,
+                        double rasterUnitsPerPixelY,
+                        int rasterBand = 1,
+                        QgsZonalStatistics::Statistics stats = QgsZonalStatistics::Statistic::All );
+%Docstring
+
+
+.. versionadded:: 3.16
+%End
+
+
+    QgsZonalStatistics::Result calculateStatistics( QgsFeedback *feedback );
+%Docstring
+Runs the calculation.
 %End
 
     static QString displayName( QgsZonalStatistics::Statistic statistic );

--- a/python/analysis/auto_generated/vector/qgszonalstatistics.sip.in
+++ b/python/analysis/auto_generated/vector/qgszonalstatistics.sip.in
@@ -107,23 +107,6 @@ added to ``polygonLayer`` for each statistic calculated.
 %End
 
 
-    QgsZonalStatistics( QgsFeatureSource *source,
-                        QgsFeatureSink *sink,
-                        QgsRasterInterface *rasterInterface,
-                        const QgsCoordinateReferenceSystem &rasterCrs,
-                        const QMap<QgsZonalStatistics::Statistic, int> &statFieldIndexes,
-                        const QgsFields &fields,
-                        double rasterUnitsPerPixelX,
-                        double rasterUnitsPerPixelY,
-                        int rasterBand = 1,
-                        QgsZonalStatistics::Statistics stats = QgsZonalStatistics::Statistic::All );
-%Docstring
-
-
-.. versionadded:: 3.16
-%End
-
-
     QgsZonalStatistics::Result calculateStatistics( QgsFeedback *feedback );
 %Docstring
 Runs the calculation.
@@ -145,6 +128,16 @@ Returns a short, friendly display name for a ``statistic``, suitable for use in 
 .. seealso:: :py:func:`displayName`
 
 .. versionadded:: 3.12
+%End
+
+    static QMap<QgsZonalStatistics::Statistic, QVariant> calculateStatistics( QgsRasterInterface *rasterInterface, const QgsGeometry &geometry, int cellSizeX, int cellSizeY, int rasterBand, QgsZonalStatistics::Statistics statistics );
+%Docstring
+Calculates the specified ``statistics`` for the pixels of ``rasterBand``
+in ``rasterInterface`` (a raster layer :py:func:`~QgsZonalStatistics.dataProvider` ) within polygon ``geometry``.
+
+Returns a map of statistic to result value.
+
+.. versionadded:: 3.16
 %End
 
       public:

--- a/python/analysis/auto_generated/vector/qgszonalstatistics.sip.in
+++ b/python/analysis/auto_generated/vector/qgszonalstatistics.sip.in
@@ -50,7 +50,7 @@ A class that calculates raster statistics (count, sum, mean) for a polygon or mu
       RasterInvalid,
       RasterBandInvalid,
       FailedToCreateField,
-      Cancelled
+      Canceled
     };
 
     QgsZonalStatistics( QgsVectorLayer *polygonLayer,

--- a/python/analysis/auto_generated/vector/qgszonalstatistics.sip.in
+++ b/python/analysis/auto_generated/vector/qgszonalstatistics.sip.in
@@ -130,7 +130,7 @@ Returns a short, friendly display name for a ``statistic``, suitable for use in 
 .. versionadded:: 3.12
 %End
 
-    static QMap<QgsZonalStatistics::Statistic, QVariant> calculateStatistics( QgsRasterInterface *rasterInterface, const QgsGeometry &geometry, int cellSizeX, int cellSizeY, int rasterBand, QgsZonalStatistics::Statistics statistics );
+    static QMap<QgsZonalStatistics::Statistic, QVariant> calculateStatistics( QgsRasterInterface *rasterInterface, const QgsGeometry &geometry, double cellSizeX, double cellSizeY, int rasterBand, QgsZonalStatistics::Statistics statistics );
 %Docstring
 Calculates the specified ``statistics`` for the pixels of ``rasterBand``
 in ``rasterInterface`` (a raster layer :py:func:`~QgsZonalStatistics.dataProvider` ) within polygon ``geometry``.

--- a/python/plugins/processing/tests/testdata/expected/stats.geojson
+++ b/python/plugins/processing/tests/testdata/expected/stats.geojson
@@ -1,0 +1,9 @@
+{
+"type": "FeatureCollection",
+"name": "stats",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+"features": [
+{ "type": "Feature", "properties": { "fid": "polygon_mask.0", "stats_count": 24882.0, "stats_sum": 89005.0, "stats_mean": 3.5770838357045251, "stats_median": 6.0, "stats_stdev": 2.4739349627559846, "stats_min": 1.0, "stats_max": 6.0, "stats_range": 5.0, "stats_minority": 4.0, "stats_majority": 6.0, "stats_variety": 4.0, "stats_variance": 6.1203541999464539 }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ 18.6744202640594, 45.798496472749385 ], [ 18.683204095342351, 45.807861586984885 ], [ 18.68966279481511, 45.80456765025378 ], [ 18.694829754393322, 45.800175734612303 ], [ 18.694442232424951, 45.796235927933921 ], [ 18.683849965289628, 45.790358511413707 ], [ 18.675970351932861, 45.790229337424257 ], [ 18.673193111159573, 45.789970989445344 ], [ 18.6744202640594, 45.798496472749385 ] ] ] ] } },
+{ "type": "Feature", "properties": { "fid": "polygon_mask.1", "stats_count": 14055.0, "stats_sum": 42165.0, "stats_mean": 3.0, "stats_median": 3.0, "stats_stdev": 0.0, "stats_min": 3.0, "stats_max": 3.0, "stats_range": 0.0, "stats_minority": 3.0, "stats_majority": 3.0, "stats_variety": 1.0, "stats_variance": 0.0 }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ 18.690696186730751, 45.786612465719514 ], [ 18.694442232424951, 45.791133555350441 ], [ 18.70090093189771, 45.785643660798598 ], [ 18.699738365992616, 45.781122571167664 ], [ 18.688435641915287, 45.777957808426017 ], [ 18.680491441563792, 45.779895418267841 ], [ 18.6800393326007, 45.783318528988403 ], [ 18.690696186730751, 45.786612465719514 ] ] ] ] } }
+]
+}

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests3.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests3.yaml
@@ -2163,4 +2163,33 @@ tests:
           - '<SrcDataSource>.*\/multilines\.gml</SrcDataSource>'
           - '<SrcLayer>multilines</SrcLayer>'
 
+  - algorithm: native:zonalstatisticsfb
+    name: Test (native:zonalstatisticsfb)
+    params:
+      COLUMN_PREFIX: stats_
+      INPUT:
+        name: custom/zonal_stats.shp
+        type: vector
+      INPUT_RASTER:
+        name: custom/dem_zones.tif
+        type: raster
+      RASTER_BAND: 1
+      STATISTICS:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+      - 8
+      - 9
+      - 10
+      - 11
+    results:
+      OUTPUT:
+        name: expected/stats.geojson
+        type: vector
+
 # See ../README.md for a description of the file format

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -197,6 +197,7 @@ SET(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmwritevectortiles.cpp
   processing/qgsalgorithmzonalhistogram.cpp
   processing/qgsalgorithmzonalstatistics.cpp
+  processing/qgsalgorithmzonalstatisticsfeaturebased.cpp
   processing/qgsbookmarkalgorithms.cpp
   processing/qgsprojectstylealgorithms.cpp
   processing/qgsstylealgorithms.cpp

--- a/src/analysis/processing/qgsalgorithmzonalstatistics.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalstatistics.cpp
@@ -64,7 +64,7 @@ QString QgsZonalStatisticsAlgorithm::groupId() const
 QString QgsZonalStatisticsAlgorithm::shortHelpString() const
 {
   return QObject::tr( "This algorithm calculates statistics of a raster layer for each feature "
-                      "of an overlapping polygon vector layer. The reults will be written in place." );
+                      "of an overlapping polygon vector layer. The results will be written in place." );
 }
 
 QgsProcessingAlgorithm::Flags QgsZonalStatisticsAlgorithm::flags() const

--- a/src/analysis/processing/qgsalgorithmzonalstatistics.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalstatistics.cpp
@@ -69,7 +69,7 @@ QString QgsZonalStatisticsAlgorithm::shortHelpString() const
 
 QgsProcessingAlgorithm::Flags QgsZonalStatisticsAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagNoThreading;
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagNoThreading | QgsProcessingAlgorithm::FlagDeprecated;
 }
 
 QgsZonalStatisticsAlgorithm *QgsZonalStatisticsAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmzonalstatistics.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalstatistics.cpp
@@ -64,7 +64,7 @@ QString QgsZonalStatisticsAlgorithm::groupId() const
 QString QgsZonalStatisticsAlgorithm::shortHelpString() const
 {
   return QObject::tr( "This algorithm calculates statistics of a raster layer for each feature "
-                      "of an overlapping polygon vector layer." );
+                      "of an overlapping polygon vector layer. The reults will be written in place." );
 }
 
 QgsProcessingAlgorithm::Flags QgsZonalStatisticsAlgorithm::flags() const
@@ -89,14 +89,14 @@ void QgsZonalStatisticsAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterRasterLayer( QStringLiteral( "INPUT_RASTER" ), QObject::tr( "Raster layer" ) ) );
   addParameter( new QgsProcessingParameterBand( QStringLiteral( "RASTER_BAND" ),
                 QObject::tr( "Raster band" ), 1, QStringLiteral( "INPUT_RASTER" ) ) );
-  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT_VECTOR" ), QObject::tr( "Feature source containing zones" ),
+  addParameter( new QgsProcessingParameterVectorLayer( QStringLiteral( "INPUT_VECTOR" ), QObject::tr( "Vector layer containing zones" ),
                 QList< int >() << QgsProcessing::TypeVectorPolygon ) );
   addParameter( new QgsProcessingParameterString( QStringLiteral( "COLUMN_PREFIX" ), QObject::tr( "Output column prefix" ), QStringLiteral( "_" ) ) );
 
   addParameter( new QgsProcessingParameterEnum( QStringLiteral( "STATISTICS" ), QObject::tr( "Statistics to calculate" ),
                 statChoices, true, QVariantList() << 0 << 1 << 2 ) );
 
-  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Zonal statistics" ), QgsProcessing::TypeVectorPolygon, QVariant(), false, true, true ) );
+  addOutput( new QgsProcessingOutputVectorLayer( QStringLiteral( "INPUT_VECTOR" ), QObject::tr( "Zonal statistics" ), QgsProcessing::TypeVectorPolygon ) );
 }
 
 bool QgsZonalStatisticsAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
@@ -129,62 +129,24 @@ bool QgsZonalStatisticsAlgorithm::prepareAlgorithm( const QVariantMap &parameter
 
 QVariantMap QgsZonalStatisticsAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
-  std::unique_ptr<QgsFeatureSource> source( parameterAsSource( parameters, QStringLiteral( "INPUT_VECTOR" ), context ) );
-  if ( !source )
+  QgsVectorLayer *layer = parameterAsVectorLayer( parameters, QStringLiteral( "INPUT_VECTOR" ), context );
+  if ( !layer )
     throw QgsProcessingException( QObject::tr( "Invalid zones layer" ) );
 
-  QgsFields fields = source->fields();
-  QMap<QgsZonalStatistics::Statistic, int> statFieldIndexes;
-
-  for ( QgsZonalStatistics::Statistic stat :
-        {
-          QgsZonalStatistics::Count,
-          QgsZonalStatistics::Sum,
-          QgsZonalStatistics::Mean,
-          QgsZonalStatistics::Median,
-          QgsZonalStatistics::StDev,
-          QgsZonalStatistics::Min,
-          QgsZonalStatistics::Max,
-          QgsZonalStatistics::Range,
-          QgsZonalStatistics::Minority,
-          QgsZonalStatistics::Majority,
-          QgsZonalStatistics::Variety,
-          QgsZonalStatistics::Variance
-        } )
-  {
-    if ( mStats & stat )
-    {
-      QgsField field = QgsField( mPrefix + QgsZonalStatistics::shortName( stat ), QVariant::Double, QStringLiteral( "double precision" ) );
-      if ( fields.names().contains( field.name() ) )
-      {
-        throw QgsProcessingException( QObject::tr( "Field %1 already exists" ).arg( field.name() ) );
-      }
-      fields.append( field );
-      statFieldIndexes.insert( stat, fields.count() - 1 );
-    }
-  }
-
-  QString dest;
-  std::unique_ptr< QgsFeatureSink > sink( parameterAsSink( parameters, QStringLiteral( "OUTPUT" ), context, dest, fields, QgsWkbTypes::MultiPolygon, source->sourceCrs() ) );
-  if ( !sink )
-    throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "OUTPUT" ) ) );
-
-  QgsZonalStatistics zs( source.get(),
-                         sink.get(),
+  QgsZonalStatistics zs( layer,
                          mInterface.get(),
                          mCrs,
-                         statFieldIndexes,
-                         fields,
                          mPixelSizeX,
                          mPixelSizeY,
+                         mPrefix,
                          mBand,
-                         mStats
+                         QgsZonalStatistics::Statistics( mStats )
                        );
 
   zs.calculateStatistics( feedback );
 
   QVariantMap outputs;
-  outputs.insert( QStringLiteral( "OUTPUT" ), dest );
+  outputs.insert( QStringLiteral( "INPUT_VECTOR" ), layer->id() );
   return outputs;
 }
 

--- a/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.cpp
@@ -164,9 +164,9 @@ QgsFeatureList QgsZonalStatisticsFeatureBasedAlgorithm::processFeature( const Qg
   attributes.resize( mOutputFields.size() );
 
   QMap<QgsZonalStatistics::Statistic, QVariant> results = QgsZonalStatistics::calculateStatistics( mRaster.get(), feature.geometry(), mPixelSizeX, mPixelSizeY, mBand, mStats );
-  for ( const auto &result : results.toStdMap() )
+  for ( auto result = results.constBegin(); result != results.constEnd(); ++result )
   {
-    attributes.replace( mStatFieldsMapping.value( result.first ), result.second );
+    attributes.replace( mStatFieldsMapping.value( result.key() ), result.value() );
   }
 
   QgsFeature resultFeature = feature;

--- a/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.cpp
@@ -108,11 +108,6 @@ QgsFields QgsZonalStatisticsFeatureBasedAlgorithm::outputFields( const QgsFields
   return mOutputFields;
 }
 
-QgsProcessingFeatureSource::Flag QgsZonalStatisticsFeatureBasedAlgorithm::sourceFlags() const
-{
-  return QgsProcessingFeatureSource::FlagSkipGeometryValidityChecks;
-}
-
 bool QgsZonalStatisticsFeatureBasedAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
   mPrefix = parameterAsString( parameters, QStringLiteral( "COLUMN_PREFIX" ), context );

--- a/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.cpp
@@ -135,7 +135,7 @@ bool QgsZonalStatisticsFeatureBasedAlgorithm::prepareAlgorithm( const QVariantMa
   mCrs = rasterLayer->crs();
   mPixelSizeX = rasterLayer->rasterUnitsPerPixelX();
   mPixelSizeY = rasterLayer->rasterUnitsPerPixelY();
-  QgsFeatureSource *source = parameterAsSource( parameters, inputParameterName(), context );
+  std::unique_ptr<QgsFeatureSource> source( parameterAsSource( parameters, inputParameterName(), context ) );
 
   mOutputFields = source->fields();
 

--- a/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.cpp
@@ -42,7 +42,7 @@ QString QgsZonalStatisticsFeatureBasedAlgorithm::name() const
 
 QString QgsZonalStatisticsFeatureBasedAlgorithm::displayName() const
 {
-  return QObject::tr( "Zonal statistics (feature based)" );
+  return QObject::tr( "Zonal statistics" );
 }
 
 QStringList QgsZonalStatisticsFeatureBasedAlgorithm::tags() const

--- a/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.cpp
@@ -1,0 +1,189 @@
+/***************************************************************************
+                         qgsalgorithmzonalstatisticsfeaturebased.cpp
+                         ---------------------
+    begin                : September 2020
+    copyright            : (C) 2020 by Matthias Kuhn
+    email                : matthias@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmzonalstatisticsfeaturebased.h"
+
+///@cond PRIVATE
+
+const std::vector< QgsZonalStatistics::Statistic > STATS
+{
+  QgsZonalStatistics::Count,
+  QgsZonalStatistics::Sum,
+  QgsZonalStatistics::Mean,
+  QgsZonalStatistics::Median,
+  QgsZonalStatistics::StDev,
+  QgsZonalStatistics::Min,
+  QgsZonalStatistics::Max,
+  QgsZonalStatistics::Range,
+  QgsZonalStatistics::Minority,
+  QgsZonalStatistics::Majority,
+  QgsZonalStatistics::Variety,
+  QgsZonalStatistics::Variance,
+};
+
+QString QgsZonalStatisticsFeatureBasedAlgorithm::name() const
+{
+  return QStringLiteral( "zonalstatisticsfb" );
+}
+
+QString QgsZonalStatisticsFeatureBasedAlgorithm::displayName() const
+{
+  return QObject::tr( "Zonal statistics (feature based)" );
+}
+
+QStringList QgsZonalStatisticsFeatureBasedAlgorithm::tags() const
+{
+  return QObject::tr( "stats,statistics,zones,layer,sum,maximum,minimum,mean,count,standard,deviation,"
+                      "median,range,majority,minority,variety,variance,summary,raster" ).split( ',' );
+}
+
+QString QgsZonalStatisticsFeatureBasedAlgorithm::group() const
+{
+  return QObject::tr( "Raster analysis" );
+}
+
+QString QgsZonalStatisticsFeatureBasedAlgorithm::groupId() const
+{
+  return QStringLiteral( "rasteranalysis" );
+}
+
+QString QgsZonalStatisticsFeatureBasedAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm calculates statistics of a raster layer for each feature "
+                      "of an overlapping polygon vector layer." );
+}
+
+QList<int> QgsZonalStatisticsFeatureBasedAlgorithm::inputLayerTypes() const
+{
+  return QList<int>() << QgsProcessing::TypeVectorPolygon;
+}
+
+QgsZonalStatisticsFeatureBasedAlgorithm *QgsZonalStatisticsFeatureBasedAlgorithm::createInstance() const
+{
+  return new QgsZonalStatisticsFeatureBasedAlgorithm();
+}
+
+void QgsZonalStatisticsFeatureBasedAlgorithm::initParameters( const QVariantMap &configuration )
+{
+  Q_UNUSED( configuration )
+  QStringList statChoices;
+  statChoices.reserve( STATS.size() );
+  for ( QgsZonalStatistics::Statistic stat : STATS )
+  {
+    statChoices << QgsZonalStatistics::displayName( stat );
+  }
+
+  addParameter( new QgsProcessingParameterRasterLayer( QStringLiteral( "INPUT_RASTER" ), QObject::tr( "Raster layer" ) ) );
+  addParameter( new QgsProcessingParameterBand( QStringLiteral( "RASTER_BAND" ),
+                QObject::tr( "Raster band" ), 1, QStringLiteral( "INPUT_RASTER" ) ) );
+
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "COLUMN_PREFIX" ), QObject::tr( "Output column prefix" ), QStringLiteral( "_" ) ) );
+
+  addParameter( new QgsProcessingParameterEnum( QStringLiteral( "STATISTICS" ), QObject::tr( "Statistics to calculate" ),
+                statChoices, true, QVariantList() << 0 << 1 << 2 ) );
+}
+
+QString QgsZonalStatisticsFeatureBasedAlgorithm::outputName() const
+{
+  return QObject::tr( "Zonal Statistics" );
+}
+
+QgsFields QgsZonalStatisticsFeatureBasedAlgorithm::outputFields( const QgsFields &inputFields ) const
+{
+  Q_UNUSED( inputFields )
+  return mOutputFields;
+}
+
+QgsProcessingFeatureSource::Flag QgsZonalStatisticsFeatureBasedAlgorithm::sourceFlags() const
+{
+  return QgsProcessingFeatureSource::FlagSkipGeometryValidityChecks;
+}
+
+bool QgsZonalStatisticsFeatureBasedAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  mPrefix = parameterAsString( parameters, QStringLiteral( "COLUMN_PREFIX" ), context );
+
+  const QList< int > stats = parameterAsEnums( parameters, QStringLiteral( "STATISTICS" ), context );
+  mStats = nullptr;
+  for ( int s : stats )
+  {
+    mStats |= STATS.at( s );
+  }
+
+  QgsRasterLayer *rasterLayer = parameterAsRasterLayer( parameters, QStringLiteral( "INPUT_RASTER" ), context );
+  if ( !rasterLayer )
+    throw QgsProcessingException( invalidRasterError( parameters, QStringLiteral( "INPUT_RASTER" ) ) );
+
+  mBand = parameterAsInt( parameters, QStringLiteral( "RASTER_BAND" ), context );
+  if ( mBand < 1 || mBand > rasterLayer->bandCount() )
+    throw QgsProcessingException( QObject::tr( "Invalid band number for BAND (%1): Valid values for input raster are 1 to %2" ).arg( mBand )
+                                  .arg( rasterLayer->bandCount() ) );
+
+  if ( !rasterLayer->dataProvider() )
+    throw QgsProcessingException( QObject::tr( "Invalid raster layer. Layer %1 is invalid." ).arg( rasterLayer->id() ) );
+
+  mRaster.reset( rasterLayer->dataProvider()->clone() );
+  mCrs = rasterLayer->crs();
+  mPixelSizeX = rasterLayer->rasterUnitsPerPixelX();
+  mPixelSizeY = rasterLayer->rasterUnitsPerPixelY();
+  QgsFeatureSource *source = parameterAsSource( parameters, inputParameterName(), context );
+
+  mOutputFields = source->fields();
+
+  for ( QgsZonalStatistics::Statistic stat : STATS )
+  {
+    if ( mStats & stat )
+    {
+      QgsField field = QgsField( mPrefix + QgsZonalStatistics::shortName( stat ), QVariant::Double, QStringLiteral( "double precision" ) );
+      if ( mOutputFields.names().contains( field.name() ) )
+      {
+        throw QgsProcessingException( QObject::tr( "Field %1 already exists" ).arg( field.name() ) );
+      }
+      mOutputFields.append( field );
+      mStatFieldsMapping.insert( stat, mOutputFields.size() - 1 );
+    }
+  }
+
+  return true;
+}
+
+QgsFeatureList QgsZonalStatisticsFeatureBasedAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  Q_UNUSED( context )
+  Q_UNUSED( feedback )
+  QgsAttributes attributes = feature.attributes();
+  attributes.resize( mOutputFields.size() );
+
+  QMap<QgsZonalStatistics::Statistic, QVariant> results = QgsZonalStatistics::calculateStatistics( mRaster.get(), feature.geometry(), mPixelSizeX, mPixelSizeY, mBand, mStats );
+  for ( const auto &result : results.toStdMap() )
+  {
+    attributes.replace( mStatFieldsMapping.value( result.first ), result.second );
+  }
+
+  QgsFeature resultFeature = feature;
+  resultFeature.setAttributes( attributes );
+
+  return QgsFeatureList { resultFeature };
+}
+
+bool QgsZonalStatisticsFeatureBasedAlgorithm::supportInPlaceEdit( const QgsMapLayer *layer ) const
+{
+  Q_UNUSED( layer )
+  return false;
+}
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.h
+++ b/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.h
@@ -52,8 +52,6 @@ class QgsZonalStatisticsFeatureBasedAlgorithm : public QgsProcessingFeatureBased
     QString outputName() const override;
     QgsFields outputFields( const QgsFields &inputFields ) const override;
 
-    QgsProcessingFeatureSource::Flag sourceFlags() const override;
-
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;

--- a/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.h
+++ b/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.h
@@ -1,0 +1,75 @@
+/***************************************************************************
+                         qgsalgorithmzonalstatisticsfeaturebased.h
+                         ------------------------------
+    begin                : September 2020
+    copyright            : (C) 2020 Matthias Kuhn
+    email                : matthias@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMZONALSTATISTICSFEATUREBASED_H
+#define QGSALGORITHMZONALSTATISTICSFEATUREBASED_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+#include "qgsvectorlayer.h"
+#include "vector/qgszonalstatistics.h"
+
+///@cond PRIVATE
+
+/**
+ * Native zonal statistics algorithm.
+ */
+class QgsZonalStatisticsFeatureBasedAlgorithm : public QgsProcessingFeatureBasedAlgorithm
+{
+
+  public:
+
+    QgsZonalStatisticsFeatureBasedAlgorithm() = default;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QList<int> inputLayerTypes() const override;
+
+    QgsZonalStatisticsFeatureBasedAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    void initParameters( const QVariantMap &configuration = QVariantMap() ) override;
+    QString outputName() const override;
+    QgsFields outputFields( const QgsFields &inputFields ) const override;
+
+    QgsProcessingFeatureSource::Flag sourceFlags() const override;
+
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
+
+  private:
+    std::unique_ptr< QgsRasterInterface > mRaster;
+    int mBand;
+    QString mPrefix;
+    QgsZonalStatistics::Statistics mStats = QgsZonalStatistics::All;
+    QgsCoordinateReferenceSystem mCrs;
+    double mPixelSizeX;
+    double mPixelSizeY;
+    QgsFields mOutputFields;
+    QMap<QgsZonalStatistics::Statistic, int> mStatFieldsMapping;
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMZONALSTATISTICSFEATUREBASED_H

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -192,6 +192,7 @@
 #include "qgsalgorithmwritevectortiles.h"
 #include "qgsalgorithmzonalhistogram.h"
 #include "qgsalgorithmzonalstatistics.h"
+#include "qgsalgorithmzonalstatisticsfeaturebased.h"
 #include "qgsalgorithmpolygonstolines.h"
 #include "qgsbookmarkalgorithms.h"
 #include "qgsprojectstylealgorithms.h"
@@ -441,6 +442,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsWriteVectorTilesMbtilesAlgorithm() );
   addAlgorithm( new QgsZonalHistogramAlgorithm() );
   addAlgorithm( new QgsZonalStatisticsAlgorithm() );
+  addAlgorithm( new QgsZonalStatisticsFeatureBasedAlgorithm() );
   addAlgorithm( new QgsPolygonsToLinesAlgorithm() );
   addAlgorithm( new QgsDensifyGeometriesByIntervalAlgorithm() );
   addAlgorithm( new QgsDensifyGeometriesByCountAlgorithm() );

--- a/src/analysis/vector/qgszonalstatistics.cpp
+++ b/src/analysis/vector/qgszonalstatistics.cpp
@@ -160,7 +160,7 @@ QgsZonalStatistics::Result QgsZonalStatistics::calculateStatistics( QgsFeedback 
   if ( feedback )
   {
     if ( feedback->isCanceled() )
-      return Cancelled;
+      return Canceled;
 
     feedback->setProgress( 100 );
   }

--- a/src/analysis/vector/qgszonalstatistics.cpp
+++ b/src/analysis/vector/qgszonalstatistics.cpp
@@ -80,6 +80,8 @@ QgsZonalStatistics::Result QgsZonalStatistics::calculateStatistics( QgsFeedback 
     return LayerInvalid;
   }
 
+  QMap<QgsZonalStatistics::Statistic, int> statFieldIndexes;
+
   //add the new fields to the provider
   QList<QgsField> newFieldList;
   for ( QgsZonalStatistics::Statistic stat :
@@ -103,7 +105,7 @@ QgsZonalStatistics::Result QgsZonalStatistics::calculateStatistics( QgsFeedback 
       QString fieldName = getUniqueFieldName( mAttributePrefix + QgsZonalStatistics::shortName( stat ), newFieldList );
       QgsField field( fieldName, QVariant::Double, QStringLiteral( "double precision" ) );
       newFieldList.push_back( field );
-      mStatFieldIndexes.insert( stat, newFieldList.count() - 1 );
+      statFieldIndexes.insert( stat, newFieldList.count() - 1 );
     }
   }
 
@@ -144,7 +146,7 @@ QgsZonalStatistics::Result QgsZonalStatistics::calculateStatistics( QgsFeedback 
     QgsAttributeMap changeAttributeMap;
     for ( const auto &result : results.toStdMap() )
     {
-      changeAttributeMap.insert( result.first, result.second );
+      changeAttributeMap.insert( statFieldIndexes.value( result.first ), result.second );
     }
 
     changeMap.insert( feature.id(), changeAttributeMap );

--- a/src/analysis/vector/qgszonalstatistics.cpp
+++ b/src/analysis/vector/qgszonalstatistics.cpp
@@ -112,10 +112,7 @@ QgsZonalStatistics::Result QgsZonalStatistics::calculateStatistics( QgsFeedback 
   long featureCount = vectorProvider->featureCount();
 
   QgsFeatureRequest request;
-
-  // If we edit in place, we don't need the other attributes
-  if ( vectorProvider )
-    request.setNoAttributes();
+  request.setNoAttributes();
 
   request.setDestinationCrs( mRasterCrs, QgsProject::instance()->transformContext() );
   QgsFeatureIterator fi = vectorProvider->getFeatures( request );
@@ -153,8 +150,7 @@ QgsZonalStatistics::Result QgsZonalStatistics::calculateStatistics( QgsFeedback 
     changeMap.insert( feature.id(), changeAttributeMap );
   }
 
-  if ( vectorProvider )
-    vectorProvider->changeAttributeValues( changeMap );
+  vectorProvider->changeAttributeValues( changeMap );
   mPolygonLayer->updateFields();
 
   if ( feedback )

--- a/src/analysis/vector/qgszonalstatistics.cpp
+++ b/src/analysis/vector/qgszonalstatistics.cpp
@@ -57,8 +57,6 @@ QgsZonalStatistics::QgsZonalStatistics( QgsVectorLayer *polygonLayer, QgsRasterI
 
 QgsZonalStatistics::Result QgsZonalStatistics::calculateStatistics( QgsFeedback *feedback )
 {
-  QgsVectorDataProvider *vectorProvider = nullptr;
-
   if ( !mRasterInterface )
   {
     return RasterInvalid;
@@ -74,7 +72,7 @@ QgsZonalStatistics::Result QgsZonalStatistics::calculateStatistics( QgsFeedback 
     return LayerTypeWrong;
   }
 
-  vectorProvider = mPolygonLayer->dataProvider();
+  QgsVectorDataProvider *vectorProvider = mPolygonLayer->dataProvider();
   if ( !vectorProvider )
   {
     return LayerInvalid;
@@ -83,6 +81,7 @@ QgsZonalStatistics::Result QgsZonalStatistics::calculateStatistics( QgsFeedback 
   QMap<QgsZonalStatistics::Statistic, int> statFieldIndexes;
 
   //add the new fields to the provider
+  int oldFieldCount = vectorProvider->fields().count();
   QList<QgsField> newFieldList;
   for ( QgsZonalStatistics::Statistic stat :
         {
@@ -105,7 +104,7 @@ QgsZonalStatistics::Result QgsZonalStatistics::calculateStatistics( QgsFeedback 
       QString fieldName = getUniqueFieldName( mAttributePrefix + QgsZonalStatistics::shortName( stat ), newFieldList );
       QgsField field( fieldName, QVariant::Double, QStringLiteral( "double precision" ) );
       newFieldList.push_back( field );
-      statFieldIndexes.insert( stat, newFieldList.count() - 1 );
+      statFieldIndexes.insert( stat, oldFieldCount + newFieldList.count() - 1 );
     }
   }
 
@@ -288,7 +287,7 @@ QString QgsZonalStatistics::shortName( QgsZonalStatistics::Statistic statistic )
   return QString();
 }
 
-QMap<QgsZonalStatistics::Statistic, QVariant> QgsZonalStatistics::calculateStatistics( QgsRasterInterface *rasterInterface, const QgsGeometry &geometry, int cellSizeX, int cellSizeY, int rasterBand, QgsZonalStatistics::Statistics statistics )
+QMap<QgsZonalStatistics::Statistic, QVariant> QgsZonalStatistics::calculateStatistics( QgsRasterInterface *rasterInterface, const QgsGeometry &geometry, double cellSizeX, double cellSizeY, int rasterBand, QgsZonalStatistics::Statistics statistics )
 {
   QMap<QgsZonalStatistics::Statistic, QVariant> results;
 

--- a/src/analysis/vector/qgszonalstatistics.h
+++ b/src/analysis/vector/qgszonalstatistics.h
@@ -66,15 +66,16 @@ class ANALYSIS_EXPORT QgsZonalStatistics
     };
     Q_DECLARE_FLAGS( Statistics, Statistic )
 
+    //! Error codes for calculation
     enum Result
     {
-      Success = 0,
-      LayerTypeWrong = 1,
-      LayerInvalid,
-      RasterInvalid,
-      RasterBandInvalid,
-      FailedToCreateField = 8,
-      Cancelled = 9
+      Success = 0, //!< Success
+      LayerTypeWrong = 1, //!< Layer is not a polygon layer
+      LayerInvalid, //!< Layer is invalid
+      RasterInvalid, //!< Raster layer is invalid
+      RasterBandInvalid, //!< The raster band does not exist on the raster layer
+      FailedToCreateField = 8, //!< Output fields could not be created
+      Canceled = 9 //!< Algorithm was canceled
     };
 
     /**

--- a/src/analysis/vector/qgszonalstatistics.h
+++ b/src/analysis/vector/qgszonalstatistics.h
@@ -128,23 +128,6 @@ class ANALYSIS_EXPORT QgsZonalStatistics
 
 
     /**
-     *
-     *
-     * \since QGIS 3.16
-     */
-    QgsZonalStatistics( QgsFeatureSource *source,
-                        QgsFeatureSink *sink,
-                        QgsRasterInterface *rasterInterface,
-                        const QgsCoordinateReferenceSystem &rasterCrs,
-                        const QMap<QgsZonalStatistics::Statistic, int> &statFieldIndexes,
-                        const QgsFields &fields,
-                        double rasterUnitsPerPixelX,
-                        double rasterUnitsPerPixelY,
-                        int rasterBand = 1,
-                        QgsZonalStatistics::Statistics stats = QgsZonalStatistics::Statistic::All );
-
-
-    /**
      * Runs the calculation.
      */
     QgsZonalStatistics::Result calculateStatistics( QgsFeedback *feedback );
@@ -162,6 +145,16 @@ class ANALYSIS_EXPORT QgsZonalStatistics
      * \since QGIS 3.12
      */
     static QString shortName( QgsZonalStatistics::Statistic statistic );
+
+    /**
+     * Calculates the specified \a statistics for the pixels of \a rasterBand
+     * in \a rasterInterface (a raster layer dataProvider() ) within polygon \a geometry.
+     *
+     * Returns a map of statistic to result value.
+     *
+     * \since QGIS 3.16
+     */
+    static QMap<QgsZonalStatistics::Statistic, QVariant> calculateStatistics( QgsRasterInterface *rasterInterface, const QgsGeometry &geometry, int cellSizeX, int cellSizeY, int rasterBand, QgsZonalStatistics::Statistics statistics );
 
   private:
     QgsZonalStatistics() = default;
@@ -229,10 +222,7 @@ class ANALYSIS_EXPORT QgsZonalStatistics
     QgsVectorLayer *mPolygonLayer = nullptr;
     QString mAttributePrefix;
     Statistics mStatistics = QgsZonalStatistics::All;
-    QgsFeatureSource *mSource = nullptr ;
-    QgsFeatureSink *mSink = nullptr ;
     QMap<QgsZonalStatistics::Statistic, int> mStatFieldIndexes;
-    QgsFields mFields;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsZonalStatistics::Statistics )

--- a/src/analysis/vector/qgszonalstatistics.h
+++ b/src/analysis/vector/qgszonalstatistics.h
@@ -155,7 +155,7 @@ class ANALYSIS_EXPORT QgsZonalStatistics
      *
      * \since QGIS 3.16
      */
-    static QMap<QgsZonalStatistics::Statistic, QVariant> calculateStatistics( QgsRasterInterface *rasterInterface, const QgsGeometry &geometry, int cellSizeX, int cellSizeY, int rasterBand, QgsZonalStatistics::Statistics statistics );
+    static QMap<QgsZonalStatistics::Statistic, QVariant> calculateStatistics(QgsRasterInterface *rasterInterface, const QgsGeometry &geometry, double cellSizeX, double cellSizeY, int rasterBand, QgsZonalStatistics::Statistics statistics );
 
   private:
     QgsZonalStatistics() = default;

--- a/src/analysis/vector/qgszonalstatistics.h
+++ b/src/analysis/vector/qgszonalstatistics.h
@@ -155,7 +155,7 @@ class ANALYSIS_EXPORT QgsZonalStatistics
      *
      * \since QGIS 3.16
      */
-    static QMap<QgsZonalStatistics::Statistic, QVariant> calculateStatistics(QgsRasterInterface *rasterInterface, const QgsGeometry &geometry, double cellSizeX, double cellSizeY, int rasterBand, QgsZonalStatistics::Statistics statistics );
+    static QMap<QgsZonalStatistics::Statistic, QVariant> calculateStatistics( QgsRasterInterface *rasterInterface, const QgsGeometry &geometry, double cellSizeX, double cellSizeY, int rasterBand, QgsZonalStatistics::Statistics statistics );
 
   private:
     QgsZonalStatistics() = default;

--- a/src/analysis/vector/qgszonalstatistics.h
+++ b/src/analysis/vector/qgszonalstatistics.h
@@ -223,7 +223,6 @@ class ANALYSIS_EXPORT QgsZonalStatistics
     QgsVectorLayer *mPolygonLayer = nullptr;
     QString mAttributePrefix;
     Statistics mStatistics = QgsZonalStatistics::All;
-    QMap<QgsZonalStatistics::Statistic, int> mStatFieldIndexes;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsZonalStatistics::Statistics )

--- a/tests/testdata/zonalstatistics/raster.tif.aux.xml
+++ b/tests/testdata/zonalstatistics/raster.tif.aux.xml
@@ -5,6 +5,7 @@
       <MDI key="STATISTICS_MEAN">865.86666666667</MDI>
       <MDI key="STATISTICS_MINIMUM">826</MDI>
       <MDI key="STATISTICS_STDDEV">17.808206597584</MDI>
+      <MDI key="STATISTICS_VALID_PERCENT">53.57</MDI>
     </Metadata>
   </PAMRasterBand>
 </PAMDataset>


### PR DESCRIPTION
So far, when calculating zonal statistics, these were always updating the original data source, adding additional fields.
This is often not desirable (cluttering the dataset) and sometimes not possible (read only data source). Also it integrates badly with the modeller, where we normally have immutable data sources and data pipelines.

This pull request adds a new **Zonal statistics (feature based)** algorithm, that works as expected.


Implements #29504
