### PR TITLE
Allow users to optionally specify the URL for default style for vector tile connections

### DIFF
--- a/src/core/vectortile/qgsvectortileconnection.cpp
+++ b/src/core/vectortile/qgsvectortileconnection.cpp
@@ -38,6 +38,8 @@ QString QgsVectorTileProviderConnection::encodedUri( const QgsVectorTileProvider
     uri.setPassword( conn.password );
   if ( !conn.referer.isEmpty() )
     uri.setParam( QStringLiteral( "referer" ),  conn.referer );
+  if ( !conn.styleUrl.isEmpty() )
+    uri.setParam( QStringLiteral( "styleUrl" ),  conn.styleUrl );
 
   switch ( conn.serviceType )
   {
@@ -65,6 +67,7 @@ QgsVectorTileProviderConnection::Data QgsVectorTileProviderConnection::decodedUr
   conn.username = dsUri.username();
   conn.password = dsUri.password();
   conn.referer = dsUri.param( QStringLiteral( "referer" ) );
+  conn.styleUrl = dsUri.param( QStringLiteral( "styleUrl" ) );
 
   if ( dsUri.hasParam( QStringLiteral( "serviceType" ) ) )
   {
@@ -92,6 +95,8 @@ QString QgsVectorTileProviderConnection::encodedLayerUri( const QgsVectorTilePro
     uri.setPassword( conn.password );
   if ( !conn.referer.isEmpty() )
     uri.setParam( QStringLiteral( "referer" ),  conn.referer );
+  if ( !conn.styleUrl.isEmpty() )
+    uri.setParam( QStringLiteral( "styleUrl" ),  conn.styleUrl );
 
   switch ( conn.serviceType )
   {
@@ -131,6 +136,7 @@ QgsVectorTileProviderConnection::Data QgsVectorTileProviderConnection::connectio
   conn.username = settings.value( QStringLiteral( "username" ) ).toString();
   conn.password = settings.value( QStringLiteral( "password" ) ).toString();
   conn.referer = settings.value( QStringLiteral( "referer" ) ).toString();
+  conn.styleUrl = settings.value( QStringLiteral( "styleUrl" ) ).toString();
 
   if ( settings.contains( QStringLiteral( "serviceType" ) ) )
   {
@@ -159,6 +165,7 @@ void QgsVectorTileProviderConnection::addConnection( const QString &name, QgsVec
   settings.setValue( QStringLiteral( "username" ), conn.username );
   settings.setValue( QStringLiteral( "password" ), conn.password );
   settings.setValue( QStringLiteral( "referer" ), conn.referer );
+  settings.setValue( QStringLiteral( "styleUrl" ), conn.styleUrl );
 
   switch ( conn.serviceType )
   {

--- a/src/core/vectortile/qgsvectortileconnection.h
+++ b/src/core/vectortile/qgsvectortileconnection.h
@@ -55,14 +55,18 @@ class CORE_EXPORT QgsVectorTileProviderConnection : public QgsAbstractProviderCo
 
       ServiceType serviceType = Generic;
 
-      // Authentication configuration id
+      //! Authentication configuration id
       QString authCfg;
-      // HTTP Basic username
+      //! HTTP Basic username
       QString username;
-      // HTTP Basic password
+      //! HTTP Basic password
       QString password;
-      // Referer
+      //! Referer
       QString referer;
+
+      //! Optional style URL (will override any default styles)
+      QString styleUrl;
+
     };
 
     //! Returns connection data encoded as a string

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -296,10 +296,22 @@ QString QgsVectorTileLayer::loadDefaultStyle( bool &resultFlag )
 {
   QgsDataSourceUri dsUri;
   dsUri.setEncodedUri( mDataSource );
-  if ( mSourceType == QStringLiteral( "xyz" ) && dsUri.param( QStringLiteral( "serviceType" ) ) == QLatin1String( "arcgis" ) )
+
+  QString styleUrl;
+  if ( !dsUri.param( QStringLiteral( "styleUrl" ) ).isEmpty() )
   {
-    QNetworkRequest request = QNetworkRequest( QUrl( mArcgisLayerConfiguration.value( QStringLiteral( "serviceUri" ) ).toString()
-                              + '/' + mArcgisLayerConfiguration.value( QStringLiteral( "defaultStyles" ) ).toString() ) );
+    styleUrl = dsUri.param( QStringLiteral( "styleUrl" ) );
+  }
+  else if ( mSourceType == QStringLiteral( "xyz" ) && dsUri.param( QStringLiteral( "serviceType" ) ) == QLatin1String( "arcgis" ) )
+  {
+    // for ArcMap VectorTileServices we default to the defaultStyles URL from the layer configuration
+    styleUrl = mArcgisLayerConfiguration.value( QStringLiteral( "serviceUri" ) ).toString()
+               + '/' + mArcgisLayerConfiguration.value( QStringLiteral( "defaultStyles" ) ).toString();
+  }
+
+  if ( !styleUrl.isEmpty() )
+  {
+    QNetworkRequest request = QNetworkRequest( QUrl( styleUrl ) );
 
     QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsVectorTileLayer" ) );
 

--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -776,6 +776,7 @@ QDomDocument QgsManageConnectionsDialog::saveVectorTileConnections( const QStrin
     el.setAttribute( QStringLiteral( "username" ), settings.value( path + "/username" ).toString() );
     el.setAttribute( QStringLiteral( "password" ), settings.value( path + "/password" ).toString() );
     el.setAttribute( QStringLiteral( "referer" ), settings.value( path + "/referer" ).toString() );
+    el.setAttribute( QStringLiteral( "styleUrl" ), settings.value( path + "/styleUrl" ).toString() );
 
     root.appendChild( el );
   }
@@ -1626,6 +1627,7 @@ void QgsManageConnectionsDialog::loadVectorTileConnections( const QDomDocument &
     settings.setValue( QStringLiteral( "username" ), child.attribute( QStringLiteral( "username" ) ) );
     settings.setValue( QStringLiteral( "password" ), child.attribute( QStringLiteral( "password" ) ) );
     settings.setValue( QStringLiteral( "referer" ), child.attribute( QStringLiteral( "referer" ) ) );
+    settings.setValue( QStringLiteral( "styleUrl" ), child.attribute( QStringLiteral( "styleUrl" ) ) );
 
     settings.endGroup();
 

--- a/src/gui/vectortile/qgsarcgisvectortileconnectiondialog.cpp
+++ b/src/gui/vectortile/qgsarcgisvectortileconnectiondialog.cpp
@@ -44,6 +44,8 @@ void QgsArcgisVectorTileConnectionDialog::setConnection( const QString &name, co
   mAuthSettings->setPassword( conn.password );
   mEditReferer->setText( conn.referer );
   mAuthSettings->setConfigId( conn.authCfg );
+
+  mEditStyleUrl->setText( conn.styleUrl );
 }
 
 QString QgsArcgisVectorTileConnectionDialog::connectionUri() const
@@ -58,6 +60,9 @@ QString QgsArcgisVectorTileConnectionDialog::connectionUri() const
   conn.password = mAuthSettings->password();
   conn.referer = mEditReferer->text();
   conn.authCfg = mAuthSettings->configId( );
+
+  conn.styleUrl = mEditStyleUrl->text();
+
   return QgsVectorTileProviderConnection::encodedUri( conn );
 }
 

--- a/src/gui/vectortile/qgsvectortileconnectiondialog.cpp
+++ b/src/gui/vectortile/qgsvectortileconnectiondialog.cpp
@@ -52,6 +52,8 @@ void QgsVectorTileConnectionDialog::setConnection( const QString &name, const QS
   mAuthSettings->setPassword( conn.password );
   mEditReferer->setText( conn.referer );
   mAuthSettings->setConfigId( conn.authCfg );
+
+  mEditStyleUrl->setText( conn.styleUrl );
 }
 
 QString QgsVectorTileConnectionDialog::connectionUri() const
@@ -66,6 +68,7 @@ QString QgsVectorTileConnectionDialog::connectionUri() const
   conn.password = mAuthSettings->password();
   conn.referer = mEditReferer->text();
   conn.authCfg = mAuthSettings->configId( );
+  conn.styleUrl = mEditStyleUrl->text();
   return QgsVectorTileProviderConnection::encodedUri( conn );
 }
 

--- a/src/ui/qgsarcgisvectortileconnectiondialog.ui
+++ b/src/ui/qgsarcgisvectortileconnectiondialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>659</width>
-    <height>336</height>
+    <width>529</width>
+    <height>335</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,6 +20,13 @@
       <string>Connection Details</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <item row="4" column="2">
+       <widget class="QLineEdit" name="mEditReferer">
+        <property name="toolTip">
+         <string>Optional custom referer</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0" colspan="2">
        <widget class="QLabel" name="label">
         <property name="text">
@@ -27,48 +34,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
-       <widget class="QLineEdit" name="mEditName">
-        <property name="toolTip">
-         <string>Name of the new connection</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="lblReferer">
-        <property name="text">
-         <string>Referer</string>
-        </property>
-        <property name="buddy">
-         <cstring>mEditReferer</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Service URL</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QLineEdit" name="mEditUrl">
-        <property name="toolTip">
-         <string>URL of the VectorTileServer API endpoint, e.g. https://domain/arcgis/rest/services/Layer_1/VectorTileServer</string>
-        </property>
-        <property name="placeholderText">
-         <string>https://domain/arcgis/rest/services/Layer_1/VectorTileServer</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="QLineEdit" name="mEditReferer">
-        <property name="toolTip">
-         <string>Optional custom referer</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="3">
+      <item row="3" column="0" colspan="3">
        <widget class="QGroupBox" name="mAuthGroupBox">
         <property name="title">
          <string>Authentication</string>
@@ -90,6 +56,60 @@
           <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true"/>
          </item>
         </layout>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Service URL</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLineEdit" name="mEditUrl">
+        <property name="toolTip">
+         <string>URL of the VectorTileServer API endpoint, e.g. https://domain/arcgis/rest/services/Layer_1/VectorTileServer</string>
+        </property>
+        <property name="placeholderText">
+         <string>https://domain/arcgis/rest/services/Layer_1/VectorTileServer</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="lblReferer">
+        <property name="text">
+         <string>Referer</string>
+        </property>
+        <property name="buddy">
+         <cstring>mEditReferer</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLineEdit" name="mEditName">
+        <property name="toolTip">
+         <string>Name of the new connection</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Style URL</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QLineEdit" name="mEditStyleUrl">
+        <property name="toolTip">
+         <string>If specified, will override the default style defined for the layer with the entered URL</string>
+        </property>
+        <property name="placeholderText">
+         <string>Optional</string>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
      </layout>

--- a/src/ui/qgsvectortileconnectiondialog.ui
+++ b/src/ui/qgsvectortileconnectiondialog.ui
@@ -20,46 +20,6 @@
       <string>Connection Details</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>URL</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QLineEdit" name="mEditUrl">
-        <property name="toolTip">
-         <string>URL of the connection, {x}, {y}, and {z} will be replaced with actual values. Use {-y} for inverted y axis.</string>
-        </property>
-        <property name="placeholderText">
-         <string>http://example.com/{z}/{x}/{y}.pbf</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="2">
-       <widget class="QSpinBox" name="mSpinZMax">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="value">
-         <number>14</number>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="QSpinBox" name="mSpinZMin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="2">
        <widget class="QLineEdit" name="mEditName">
         <property name="toolTip">
@@ -67,17 +27,14 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="mCheckBoxZMin">
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label">
         <property name="text">
-         <string>Min. Zoom Level</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
+         <string>Name</string>
         </property>
        </widget>
       </item>
-      <item row="7" column="0" colspan="3">
+      <item row="8" column="0" colspan="3">
        <widget class="QGroupBox" name="mAuthGroupBox">
         <property name="title">
          <string>Authentication</string>
@@ -101,7 +58,24 @@
         </layout>
        </widget>
       </item>
-      <item row="8" column="0">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>URL</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QSpinBox" name="mSpinZMin">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
        <widget class="QLabel" name="lblReferer">
         <property name="text">
          <string>Referer</string>
@@ -111,10 +85,16 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Name</string>
+      <item row="6" column="2">
+       <widget class="QSpinBox" name="mSpinZMax">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="value">
+         <number>14</number>
         </property>
        </widget>
       </item>
@@ -128,10 +108,50 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="2">
+      <item row="1" column="2">
+       <widget class="QLineEdit" name="mEditUrl">
+        <property name="toolTip">
+         <string>URL of the connection, {x}, {y}, and {z} will be replaced with actual values. Use {-y} for inverted y axis.</string>
+        </property>
+        <property name="placeholderText">
+         <string>http://example.com/{z}/{x}/{y}.pbf</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="mCheckBoxZMin">
+        <property name="text">
+         <string>Min. Zoom Level</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="2">
        <widget class="QLineEdit" name="mEditReferer">
         <property name="toolTip">
          <string>Optional custom referer</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Style URL</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="2">
+       <widget class="QLineEdit" name="mEditStyleUrl">
+        <property name="toolTip">
+         <string>If specified, the layer will be automatically styled using styling JSON from the entered URL.</string>
+        </property>
+        <property name="placeholderText">
+         <string>Optional</string>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -165,6 +185,8 @@
   <tabstop>mSpinZMin</tabstop>
   <tabstop>mCheckBoxZMax</tabstop>
   <tabstop>mSpinZMax</tabstop>
+  <tabstop>mEditStyleUrl</tabstop>
+  <tabstop>mEditReferer</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
When setting up a vector tile source connection, there's a new option
to enter a URL to a MapBox GL JSON style configuration. If one has
been entered, then that style will be applied whenever the layers
from the connection are added to QGIS.

Works also with Arcgis vectortileservice connections -- in this
case the URL overrides the default style configuration specified
in the server configuration.

![Peek 2020-09-09 09-25](https://user-images.githubusercontent.com/1829991/92537605-da922280-f27f-11ea-9472-802eb88016fe.gif)
