### PR TITLE
UI Improvements for vector tile symbology/labeling

### DIFF
--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -93,11 +93,20 @@ QgsExpressionContext QgsSymbolLayerWidget::createExpressionContext() const
   //TODO - show actual value
   expContext.setOriginalValueVariable( QVariant() );
 
-  expContext.setHighlightedVariables( QStringList() << QgsExpressionContext::EXPR_ORIGINAL_VALUE << QgsExpressionContext::EXPR_SYMBOL_COLOR
-                                      << QgsExpressionContext::EXPR_GEOMETRY_PART_COUNT << QgsExpressionContext::EXPR_GEOMETRY_PART_NUM
-                                      << QgsExpressionContext::EXPR_GEOMETRY_POINT_COUNT << QgsExpressionContext::EXPR_GEOMETRY_POINT_NUM
-                                      << QgsExpressionContext::EXPR_CLUSTER_COLOR << QgsExpressionContext::EXPR_CLUSTER_SIZE
-                                      << QStringLiteral( "symbol_layer_count" ) << QStringLiteral( "symbol_layer_index" ) );
+  QStringList highlights;
+  highlights << QgsExpressionContext::EXPR_ORIGINAL_VALUE << QgsExpressionContext::EXPR_SYMBOL_COLOR
+             << QgsExpressionContext::EXPR_GEOMETRY_PART_COUNT << QgsExpressionContext::EXPR_GEOMETRY_PART_NUM
+             << QgsExpressionContext::EXPR_GEOMETRY_POINT_COUNT << QgsExpressionContext::EXPR_GEOMETRY_POINT_NUM
+             << QgsExpressionContext::EXPR_CLUSTER_COLOR << QgsExpressionContext::EXPR_CLUSTER_SIZE
+             << QStringLiteral( "symbol_layer_count" ) << QStringLiteral( "symbol_layer_index" );
+
+
+  if ( expContext.hasVariable( QStringLiteral( "zoom_level" ) ) )
+  {
+    highlights << QStringLiteral( "zoom_level" );
+  }
+
+  expContext.setHighlightedVariables( highlights );
 
   return expContext;
 }

--- a/src/gui/vectortile/qgsvectortilebasiclabelingwidget.cpp
+++ b/src/gui/vectortile/qgsvectortilebasiclabelingwidget.cpp
@@ -396,6 +396,16 @@ void QgsVectorTileBasicLabelingWidget::editStyleAtIndex( const QModelIndex &prox
   context.setMapCanvas( mMapCanvas );
   context.setMessageBar( mMessageBar );
 
+  if ( mMapCanvas )
+  {
+    const int zoom = QgsVectorTileUtils::scaleToZoomLevel( mMapCanvas->scale(), 0, 99 );
+    QList<QgsExpressionContextScope> scopes = context.additionalExpressionContextScopes();
+    QgsExpressionContextScope tileScope;
+    tileScope.setVariable( "zoom_level", zoom, true );
+    scopes << tileScope;
+    context.setAdditionalExpressionContextScopes( scopes );
+  }
+
   QgsVectorLayer *vectorLayer = nullptr;  // TODO: have a temporary vector layer with sub-layer's fields?
 
   QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );

--- a/src/gui/vectortile/qgsvectortilebasiclabelingwidget.cpp
+++ b/src/gui/vectortile/qgsvectortilebasiclabelingwidget.cpp
@@ -55,6 +55,7 @@ QVariant QgsVectorTileBasicLabelingListModel::data( const QModelIndex &index, in
   switch ( role )
   {
     case Qt::DisplayRole:
+    case Qt::ToolTipRole:
     {
       if ( index.column() == 0 )
         return style.styleName();

--- a/src/gui/vectortile/qgsvectortilebasiclabelingwidget.cpp
+++ b/src/gui/vectortile/qgsvectortilebasiclabelingwidget.cpp
@@ -19,6 +19,8 @@
 #include "qgsvectortilelayer.h"
 
 #include "qgslabelinggui.h"
+#include "qgsmapcanvas.h"
+#include "qgsvectortileutils.h"
 
 #include <QMenu>
 
@@ -283,6 +285,7 @@ bool QgsVectorTileBasicLabelingListModel::dropMimeData( const QMimeData *data,
 
 QgsVectorTileBasicLabelingWidget::QgsVectorTileBasicLabelingWidget( QgsVectorTileLayer *layer, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent )
   : QgsMapLayerConfigWidget( layer, canvas, parent )
+  , mMapCanvas( canvas )
   , mMessageBar( messageBar )
 {
 
@@ -300,6 +303,15 @@ QgsVectorTileBasicLabelingWidget::QgsVectorTileBasicLabelingWidget( QgsVectorTil
   connect( btnRemoveRule, &QAbstractButton::clicked, this, &QgsVectorTileBasicLabelingWidget::removeStyle );
 
   connect( viewStyles, &QAbstractItemView::doubleClicked, this, &QgsVectorTileBasicLabelingWidget::editStyleAtIndex );
+
+  if ( mMapCanvas )
+  {
+    connect( mMapCanvas, &QgsMapCanvas::scaleChanged, this, [ = ]( double scale )
+    {
+      mLabelCurrentZoom->setText( tr( "Current zoom: %1" ).arg( QgsVectorTileUtils::scaleToZoomLevel( scale, 0, 99 ) ) );
+    } );
+    mLabelCurrentZoom->setText( tr( "Current zoom: %1" ).arg( QgsVectorTileUtils::scaleToZoomLevel( mMapCanvas->scale(), 0, 99 ) ) );
+  }
 
   setLayer( layer );
 }

--- a/src/gui/vectortile/qgsvectortilebasiclabelingwidget.h
+++ b/src/gui/vectortile/qgsvectortilebasiclabelingwidget.h
@@ -65,6 +65,7 @@ class GUI_EXPORT QgsVectorTileBasicLabelingWidget : public QgsMapLayerConfigWidg
     QgsVectorTileLayer *mVTLayer = nullptr;
     std::unique_ptr<QgsVectorTileBasicLabeling> mLabeling;
     QgsVectorTileBasicLabelingListModel *mModel = nullptr;
+    QgsMapCanvas *mMapCanvas = nullptr;
     QgsMessageBar *mMessageBar = nullptr;
 };
 

--- a/src/gui/vectortile/qgsvectortilebasiclabelingwidget.h
+++ b/src/gui/vectortile/qgsvectortilebasiclabelingwidget.h
@@ -23,6 +23,7 @@
 #include "qgswkbtypes.h"
 
 #include <memory>
+#include <QSortFilterProxyModel>
 
 ///@cond PRIVATE
 #define SIP_NO_FILE
@@ -32,6 +33,7 @@ class QgsVectorTileBasicLabelingListModel;
 class QgsVectorTileLayer;
 class QgsMapCanvas;
 class QgsMessageBar;
+class QgsVectorTileBasicLabelingProxyModel;
 
 /**
  * \ingroup gui
@@ -65,6 +67,7 @@ class GUI_EXPORT QgsVectorTileBasicLabelingWidget : public QgsMapLayerConfigWidg
     QgsVectorTileLayer *mVTLayer = nullptr;
     std::unique_ptr<QgsVectorTileBasicLabeling> mLabeling;
     QgsVectorTileBasicLabelingListModel *mModel = nullptr;
+    QgsVectorTileBasicLabelingProxyModel *mProxyModel = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsMessageBar *mMessageBar = nullptr;
 };
@@ -103,6 +106,13 @@ class QgsVectorTileBasicLabelingListModel : public QAbstractListModel
 {
     Q_OBJECT
   public:
+
+    enum Role
+    {
+      MinZoom = Qt::UserRole + 1,
+      MaxZoom,
+    };
+
     QgsVectorTileBasicLabelingListModel( QgsVectorTileBasicLabeling *r, QObject *parent = nullptr );
 
     int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
@@ -125,6 +135,24 @@ class QgsVectorTileBasicLabelingListModel : public QAbstractListModel
   private:
     QgsVectorTileBasicLabeling *mLabeling = nullptr;
 };
+
+class QgsVectorTileBasicLabelingProxyModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+  public:
+    QgsVectorTileBasicLabelingProxyModel( QgsVectorTileBasicLabelingListModel *source, QObject *parent = nullptr );
+
+    void setCurrentZoom( int zoom );
+    void setFilterVisible( bool enabled );
+
+    bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
+
+  private:
+
+    bool mFilterVisible = false;
+    int mCurrentZoom = -1;
+};
+
 
 ///@endcond
 

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
@@ -60,6 +60,7 @@ QVariant QgsVectorTileBasicRendererListModel::data( const QModelIndex &index, in
   switch ( role )
   {
     case Qt::DisplayRole:
+    case Qt::ToolTipRole:
     {
       if ( index.column() == 0 )
         return style.styleName();

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
@@ -410,6 +410,16 @@ void QgsVectorTileBasicRendererWidget::editStyleAtIndex( const QModelIndex &prox
   context.setMapCanvas( mMapCanvas );
   context.setMessageBar( mMessageBar );
 
+  if ( mMapCanvas )
+  {
+    const int zoom = QgsVectorTileUtils::scaleToZoomLevel( mMapCanvas->scale(), 0, 99 );
+    QList<QgsExpressionContextScope> scopes = context.additionalExpressionContextScopes();
+    QgsExpressionContextScope tileScope;
+    tileScope.setVariable( "zoom_level", zoom, true );
+    scopes << tileScope;
+    context.setAdditionalExpressionContextScopes( scopes );
+  }
+
   QgsVectorLayer *vectorLayer = nullptr;  // TODO: have a temporary vector layer with sub-layer's fields?
 
   QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
@@ -21,6 +21,8 @@
 #include "qgsvectortilelayer.h"
 #include "qgssymbolselectordialog.h"
 #include "qgsstyle.h"
+#include "qgsmapcanvas.h"
+#include "qgsvectortileutils.h"
 
 #include <QAbstractListModel>
 #include <QInputDialog>
@@ -298,6 +300,7 @@ bool QgsVectorTileBasicRendererListModel::dropMimeData( const QMimeData *data,
 
 QgsVectorTileBasicRendererWidget::QgsVectorTileBasicRendererWidget( QgsVectorTileLayer *layer, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent )
   : QgsMapLayerConfigWidget( layer, canvas, parent )
+  , mMapCanvas( canvas )
   , mMessageBar( messageBar )
 {
   setupUi( this );
@@ -313,6 +316,15 @@ QgsVectorTileBasicRendererWidget::QgsVectorTileBasicRendererWidget( QgsVectorTil
   connect( btnRemoveRule, &QAbstractButton::clicked, this, &QgsVectorTileBasicRendererWidget::removeStyle );
 
   connect( viewStyles, &QAbstractItemView::doubleClicked, this, &QgsVectorTileBasicRendererWidget::editStyleAtIndex );
+
+  if ( mMapCanvas )
+  {
+    connect( mMapCanvas, &QgsMapCanvas::scaleChanged, this, [ = ]( double scale )
+    {
+      mLabelCurrentZoom->setText( tr( "Current zoom: %1" ).arg( QgsVectorTileUtils::scaleToZoomLevel( scale, 0, 99 ) ) );
+    } );
+    mLabelCurrentZoom->setText( tr( "Current zoom: %1" ).arg( QgsVectorTileUtils::scaleToZoomLevel( mMapCanvas->scale(), 0, 99 ) ) );
+  }
 
   setLayer( layer );
 }

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
@@ -23,6 +23,8 @@
 #include "qgswkbtypes.h"
 
 #include <memory>
+#include <QSortFilterProxyModel>
+
 
 ///@cond PRIVATE
 #define SIP_NO_FILE
@@ -32,6 +34,7 @@ class QgsVectorTileBasicRendererListModel;
 class QgsVectorTileLayer;
 class QgsMapCanvas;
 class QgsMessageBar;
+class QgsVectorTileBasicRendererProxyModel;
 
 /**
  * \ingroup gui
@@ -65,6 +68,7 @@ class GUI_EXPORT QgsVectorTileBasicRendererWidget : public QgsMapLayerConfigWidg
     QgsVectorTileLayer *mVTLayer = nullptr;
     std::unique_ptr<QgsVectorTileBasicRenderer> mRenderer;
     QgsVectorTileBasicRendererListModel *mModel = nullptr;
+    QgsVectorTileBasicRendererProxyModel *mProxyModel = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsMessageBar *mMessageBar = nullptr;
 };
@@ -76,6 +80,13 @@ class QgsVectorTileBasicRendererListModel : public QAbstractListModel
 {
     Q_OBJECT
   public:
+
+    enum Role
+    {
+      MinZoom = Qt::UserRole + 1,
+      MaxZoom,
+    };
+
     QgsVectorTileBasicRendererListModel( QgsVectorTileBasicRenderer *r, QObject *parent = nullptr );
 
     int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
@@ -97,6 +108,23 @@ class QgsVectorTileBasicRendererListModel : public QAbstractListModel
 
   private:
     QgsVectorTileBasicRenderer *mRenderer = nullptr;
+};
+
+class QgsVectorTileBasicRendererProxyModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+  public:
+    QgsVectorTileBasicRendererProxyModel( QgsVectorTileBasicRendererListModel *source, QObject *parent = nullptr );
+
+    void setCurrentZoom( int zoom );
+    void setFilterVisible( bool enabled );
+
+    bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
+
+  private:
+
+    bool mFilterVisible = false;
+    int mCurrentZoom = -1;
 };
 
 ///@endcond

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
@@ -65,6 +65,7 @@ class GUI_EXPORT QgsVectorTileBasicRendererWidget : public QgsMapLayerConfigWidg
     QgsVectorTileLayer *mVTLayer = nullptr;
     std::unique_ptr<QgsVectorTileBasicRenderer> mRenderer;
     QgsVectorTileBasicRendererListModel *mModel = nullptr;
+    QgsMapCanvas *mMapCanvas = nullptr;
     QgsMessageBar *mMessageBar = nullptr;
 };
 

--- a/src/ui/qgsvectortilebasiclabelingwidget.ui
+++ b/src/ui/qgsvectortilebasiclabelingwidget.ui
@@ -93,6 +93,13 @@
        </property>
       </spacer>
      </item>
+     <item>
+      <widget class="QLabel" name="mLabelCurrentZoom">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>

--- a/src/ui/qgsvectortilebasiclabelingwidget.ui
+++ b/src/ui/qgsvectortilebasiclabelingwidget.ui
@@ -100,6 +100,16 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QCheckBox" name="mCheckVisibleOnly">
+       <property name="toolTip">
+        <string>Hides any rules which are invisible because they fall outside the current map canvas zoom level</string>
+       </property>
+       <property name="text">
+        <string>Visible rules only</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>

--- a/src/ui/qgsvectortilebasicrendererwidget.ui
+++ b/src/ui/qgsvectortilebasicrendererwidget.ui
@@ -93,6 +93,13 @@
        </property>
       </spacer>
      </item>
+     <item>
+      <widget class="QLabel" name="mLabelCurrentZoom">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>

--- a/src/ui/qgsvectortilebasicrendererwidget.ui
+++ b/src/ui/qgsvectortilebasicrendererwidget.ui
@@ -100,6 +100,16 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QCheckBox" name="mCheckVisibleOnly">
+       <property name="toolTip">
+        <string>Hides any rules which are invisible because they fall outside the current map canvas zoom level</string>
+       </property>
+       <property name="text">
+        <string>Visible rules only</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>


### PR DESCRIPTION
Some quality of life improvements for users editing complex vector tiles styles:

- show tooltips in the lists, so you can easily see the full filter rules and names without resizing columns
- show the current canvas zoom level in the widgets, and allow users to filter the list of styles to only show those which are currently visible. Makes it much easier to identify which style is being used to render the current map!
- Set the @zoom_level variable to the correct canvas zoom level when editing symbols, so that expression previews work nicely.