### PR TITLE
Mdal070

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -20,8 +20,8 @@ on:
     - 'CMakeLists.txt'
 
 env:
-  QT_VERSION: 5.14.1
-  QGIS_DEPS_VERSION: 0.2.2
+  QT_VERSION: 5.14.2
+  QGIS_DEPS_VERSION: 0.5.4
 
 jobs:
   mac_os_build:

--- a/external/mdal/frmts/mdal_gdal_netcdf.cpp
+++ b/external/mdal/frmts/mdal_gdal_netcdf.cpp
@@ -39,8 +39,11 @@ bool MDAL::DriverGdalNetCDF::parseBandInfo( const MDAL::GdalDataset *cfGDALDatas
   metadata_hash::const_iterator iter;
 
   iter = metadata.find( "netcdf_dim_time" );
-  if ( iter == metadata.end() ) return true; //FAILURE, skip no-time bands
-  *time = MDAL::RelativeTimestamp( parseMetadataTime( iter->second ), mTimeUnit );
+
+  if ( iter == metadata.end() )
+    *time = MDAL::RelativeTimestamp();
+  else
+    *time = MDAL::RelativeTimestamp( parseMetadataTime( iter->second ), mTimeUnit );
 
   // NAME
   iter = metadata.find( "long_name" );

--- a/external/mdal/mdal.cpp
+++ b/external/mdal/mdal.cpp
@@ -21,7 +21,7 @@ static const char *EMPTY_STR = "";
 
 const char *MDAL_Version()
 {
-  return "0.6.93";
+  return "0.7.0";
 }
 
 MDAL_Status MDAL_LastStatus()

--- a/external/mdal/mdal_memory_data_model.cpp
+++ b/external/mdal/mdal_memory_data_model.cpp
@@ -205,9 +205,15 @@ void MDAL::MemoryMesh::addFaces( size_t faceCount, size_t driverMaxVerticesPerFa
     Face face( faceSize );
     for ( size_t i = 0; i < faceSize; ++i )
     {
-      size_t indice =  vertexIndices[indicesIndex + i];
-      if ( indice >= 0 && indice < mVertices.size() )
-        face[i] = indice;
+      const int indice = vertexIndices[indicesIndex + i];
+      if ( indice < 0 )
+      {
+        MDAL::Log::error( Err_InvalidData, "Invalid vertex index when adding faces" );
+        return;
+      }
+      size_t indiceU = static_cast< size_t >( indice );
+      if ( indiceU < mVertices.size() )
+        face[i] = indiceU;
       else
       {
         MDAL::Log::error( Err_InvalidData, "Invalid vertex index when adding faces" );


### PR DESCRIPTION
Formal release of MDAL for QGIS 3.16.x series. The full changelog from 0.6.0 release (QGIS 3.14), please see 
https://github.com/lutraconsulting/MDAL/releases/tag/0.7.0

QGIS internal copy of MDAL has been updated already with the release candidates of MDAL so the actual changes in this PR are rather small.
 