### PR TITLE
FIX 37847 New feature is hidden when created from attribute table

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -623,7 +623,7 @@ void QgsAttributeTableDialog::mActionAddFeatureViaAttributeTable_triggered()
   if ( action.addFeature() )
   {
     masterModel->reload( masterModel->index( 0, 0 ), masterModel->index( masterModel->rowCount() - 1, masterModel->columnCount() - 1 ) );
-    mMainView->setCurrentEditSelection( QgsFeatureIds() << action.feature()->id() );
+    mMainView->setCurrentEditSelection( QgsFeatureIds() << action.feature().id() );
   }
 }
 
@@ -644,7 +644,7 @@ void QgsAttributeTableDialog::mActionAddFeatureViaAttributeForm_triggered()
   if ( action.addFeature() )
   {
     masterModel->reload( masterModel->index( 0, 0 ), masterModel->index( masterModel->rowCount() - 1, masterModel->columnCount() - 1 ) );
-    mMainView->setCurrentEditSelection( QgsFeatureIds() << action.feature()->id() );
+    mMainView->setCurrentEditSelection( QgsFeatureIds() << action.feature().id() );
   }
 }
 

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -623,6 +623,7 @@ void QgsAttributeTableDialog::mActionAddFeatureViaAttributeTable_triggered()
   if ( action.addFeature() )
   {
     masterModel->reload( masterModel->index( 0, 0 ), masterModel->index( masterModel->rowCount() - 1, masterModel->columnCount() - 1 ) );
+    mMainView->setCurrentEditSelection( QgsFeatureIds() << action.feature()->id() );
   }
 }
 
@@ -643,6 +644,7 @@ void QgsAttributeTableDialog::mActionAddFeatureViaAttributeForm_triggered()
   if ( action.addFeature() )
   {
     masterModel->reload( masterModel->index( 0, 0 ), masterModel->index( masterModel->rowCount() - 1, masterModel->columnCount() - 1 ) );
+    mMainView->setCurrentEditSelection( QgsFeatureIds() << action.feature()->id() );
   }
 }
 

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -314,4 +314,9 @@ void QgsFeatureAction::onFeatureSaved( const QgsFeature &feature )
   }
 }
 
+QgsFeature QgsFeatureAction::feature() const
+{
+  return mFeature ? *mFeature : QgsFeature();
+}
+
 QHash<QgsVectorLayer *, QgsAttributeMap> QgsFeatureAction::sLastUsedValues;

--- a/src/app/qgsfeatureaction.h
+++ b/src/app/qgsfeatureaction.h
@@ -61,6 +61,12 @@ class APP_EXPORT QgsFeatureAction : public QAction
      */
     void setForceSuppressFormPopup( bool force );
 
+    /**
+     * Returns the current feature. It might be nullptr feature, so it's safe to use this method only
+     * right after`addFeature()` returned true.
+     */
+    QgsFeature *feature() const { return mFeature; }
+
   signals:
 
     /**

--- a/src/app/qgsfeatureaction.h
+++ b/src/app/qgsfeatureaction.h
@@ -62,10 +62,9 @@ class APP_EXPORT QgsFeatureAction : public QAction
     void setForceSuppressFormPopup( bool force );
 
     /**
-     * Returns the current feature. It might be nullptr feature, so it's safe to use this method only
-     * right after`addFeature()` returned true.
+     * Returns the added feature or invalid feature in case addFeature() was not successful.
      */
-    QgsFeature *feature() const { return mFeature; }
+    QgsFeature feature() const;
 
   signals:
 

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -189,18 +189,27 @@ void QgsFeatureListView::selectAll()
 void QgsFeatureListView::setEditSelection( const QgsFeatureIds &fids )
 {
   QItemSelection selection;
+  QModelIndex firstModelIdx;
 
   const auto constFids = fids;
   for ( QgsFeatureId fid : constFids )
   {
-    selection.append( QItemSelectionRange( mModel->mapToMaster( mModel->fidToIdx( fid ) ) ) );
+    QModelIndex modelIdx = mModel->fidToIdx( fid );
+
+    if ( ! firstModelIdx.isValid() )
+      firstModelIdx = modelIdx;
+
+    selection.append( QItemSelectionRange( mModel->mapToMaster( firstModelIdx ) ) );
   }
 
   bool ok = true;
   emit aboutToChangeEditSelection( ok );
 
   if ( ok )
+  {
     mCurrentEditSelectionModel->select( selection, QItemSelectionModel::ClearAndSelect );
+    scrollTo( firstModelIdx );
+  }
 }
 
 void QgsFeatureListView::setEditSelection( const QModelIndex &index, QItemSelectionModel::SelectionFlags command )
@@ -212,7 +221,10 @@ void QgsFeatureListView::setEditSelection( const QModelIndex &index, QItemSelect
   Q_ASSERT( index.model() == mModel->masterModel() || !index.isValid() );
 
   if ( ok )
+  {
     mCurrentEditSelectionModel->select( index, command );
+    scrollTo( index );
+  }
 }
 
 void QgsFeatureListView::repaintRequested( const QModelIndexList &indexes )

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -199,7 +199,7 @@ void QgsFeatureListView::setEditSelection( const QgsFeatureIds &fids )
     if ( ! firstModelIdx.isValid() )
       firstModelIdx = modelIdx;
 
-    selection.append( QItemSelectionRange( mModel->mapToMaster( firstModelIdx ) ) );
+    selection.append( QItemSelectionRange( mModel->mapToMaster( modelIdx ) ) );
   }
 
   bool ok = true;


### PR DESCRIPTION
Now when a new feature is added in the attribute table when in form view, the new feature is automatically selected and the feature list on the left side is ensured to show it (not necessarily on top). In response of #37847 .

![Peek 2020-09-09 09-45](https://user-images.githubusercontent.com/2820439/92564504-f0a0e280-f281-11ea-952c-58f0bb569733.gif)
