### PR TITLE
Raster layer can use XML extent like vector layer

### DIFF
--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -542,6 +542,24 @@ or layer with temporary data (as temporary mesh layer dataset)
     typedef QFlags<QgsMapLayer::ReadFlag> ReadFlags;
 
 
+    void setReadExtentFromXml( bool readExtentFromXml );
+%Docstring
+Flag allowing to indicate if the extent has to be read from the XML
+document when data source has no metadata or if the data provider has
+to determine it.
+
+.. versionadded:: 3.16
+%End
+
+    bool readExtentFromXml() const;
+%Docstring
+Returns ``True`` if the extent is read from the XML document when data
+source has no metadata, ``False`` if it's the data provider which determines
+it.
+
+.. versionadded:: 3.16
+%End
+
     bool readLayerXml( const QDomElement &layerElement, QgsReadWriteContext &context, QgsMapLayer::ReadFlags flags = QgsMapLayer::ReadFlags() );
 %Docstring
 Sets state from DOM document
@@ -1708,6 +1726,7 @@ Add error message
 %Docstring
 Sets error message
 %End
+
 
 
 

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -2516,24 +2516,6 @@ Sets the ``editFormConfig`` (configuration) of the form used to represent this v
 .. versionadded:: 3.0
 %End
 
-    void setReadExtentFromXml( bool readExtentFromXml );
-%Docstring
-Flag allowing to indicate if the extent has to be read from the XML
-document when data source has no metadata or if the data provider has
-to determine it.
-
-.. versionadded:: 3.0
-%End
-
-    bool readExtentFromXml() const;
-%Docstring
-Returns ``True`` if the extent is read from the XML document when data
-source has no metadata, ``False`` if it's the data provider which determines
-it.
-
-.. versionadded:: 3.0
-%End
-
     bool isEditCommandActive() const;
 %Docstring
 Tests if an edit command is active

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -428,24 +428,6 @@ to be drawn outside the data extent.
 .. versionadded:: 3.10
 %End
 
-    void setReadExtentFromXml( bool readExtentFromXml );
-%Docstring
-Flag allowing to indicate if the extent has to be read from the XML
-document when data source has no metadata or if the data provider has
-to determine it.
-
-.. versionadded:: 3.16
-%End
-
-    bool readExtentFromXml() const;
-%Docstring
-Returns ``True`` if the extent is read from the XML document when data
-source has no metadata, ``False`` if it's the data provider which determines
-it.
-
-.. versionadded:: 3.16
-%End
-
     virtual QgsMapLayerTemporalProperties *temporalProperties();
 
 

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -59,7 +59,8 @@ Constructor. Provider is not set.
     {
 
       explicit LayerOptions( bool loadDefaultStyle = true,
-                             const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext() );
+                             const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext(),
+                             bool readExtentFromXml = false );
 %Docstring
 Constructor for LayerOptions.
 %End
@@ -67,6 +68,9 @@ Constructor for LayerOptions.
       bool loadDefaultStyle;
 
       QgsCoordinateTransformContext transformContext;
+
+
+      bool readExtentFromXml;
 
       bool skipCrsValidation;
 
@@ -284,6 +288,9 @@ This will be ``None`` if the layer is invalid.
     virtual QgsMapLayerRenderer *createMapRenderer( QgsRenderContext &rendererContext ) /Factory/;
 
 
+    virtual QgsRectangle extent() const;
+
+
     void draw( QPainter *theQPainter,
                QgsRasterViewPort *myRasterViewPort,
                const QgsMapToPixel *qgsMapToPixel = 0 );
@@ -419,6 +426,24 @@ To be used for example for WMS layers with labels or symbology that happens
 to be drawn outside the data extent.
 
 .. versionadded:: 3.10
+%End
+
+    void setReadExtentFromXml( bool readExtentFromXml );
+%Docstring
+Flag allowing to indicate if the extent has to be read from the XML
+document when data source has no metadata or if the data provider has
+to determine it.
+
+.. versionadded:: 3.16
+%End
+
+    bool readExtentFromXml() const;
+%Docstring
+Returns ``True`` if the extent is read from the XML document when data
+source has no metadata, ``False`` if it's the data provider which determines
+it.
+
+.. versionadded:: 3.16
 %End
 
     virtual QgsMapLayerTemporalProperties *temporalProperties();

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -214,6 +214,16 @@ QPainter::CompositionMode QgsMapLayer::blendMode() const
   return mBlendMode;
 }
 
+void QgsMapLayer::setReadExtentFromXml( bool readExtentFromXml )
+{
+  mReadExtentFromXml = readExtentFromXml;
+}
+
+bool QgsMapLayer::readExtentFromXml() const
+{
+  return mReadExtentFromXml;
+}
+
 
 bool QgsMapLayer::readLayerXml( const QDomElement &layerElement, QgsReadWriteContext &context, QgsMapLayer::ReadFlags flags )
 {

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -558,6 +558,24 @@ class CORE_EXPORT QgsMapLayer : public QObject
     Q_DECLARE_FLAGS( ReadFlags, ReadFlag )
 
     /**
+     * Flag allowing to indicate if the extent has to be read from the XML
+     * document when data source has no metadata or if the data provider has
+     * to determine it.
+     *
+     * \since QGIS 3.16
+     */
+    void setReadExtentFromXml( bool readExtentFromXml );
+
+    /**
+     * Returns TRUE if the extent is read from the XML document when data
+     * source has no metadata, FALSE if it's the data provider which determines
+     * it.
+     *
+     * \since QGIS 3.16
+     */
+    bool readExtentFromXml() const;
+
+    /**
      * Sets state from DOM document
      * \param layerElement The DOM element corresponding to ``maplayer'' tag
      * \param context writing context (e.g. for conversion between relative and absolute paths)
@@ -1529,6 +1547,10 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     //! Extent of the layer
     mutable QgsRectangle mExtent;
+
+    //! read xml extent
+    bool mReadExtentFromXml;
+    QgsRectangle mXmlExtent;
 
     //! Indicates if the layer is valid and can be drawn
     bool mValid = false;

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1138,6 +1138,11 @@ bool QgsProject::addLayer( const QDomElement &layerElem, QList<QDomNode> &broken
   else if ( type == QLatin1String( "raster" ) )
   {
     mapLayer =  qgis::make_unique<QgsRasterLayer>();
+    // apply specific settings to raster layer
+    if ( QgsRasterLayer *rl = qobject_cast<QgsRasterLayer *>( mapLayer.get() ) )
+    {
+      rl->setReadExtentFromXml( mTrustLayerMetadata || ( flags & QgsProject::ReadFlag::FlagTrustLayerMetadata ) );
+    }
   }
   else if ( type == QLatin1String( "mesh" ) )
   {

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -153,8 +153,8 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
   , mServerProperties( new QgsVectorLayerServerProperties( this ) )
   , mAuxiliaryLayer( nullptr )
   , mAuxiliaryLayerKey( QString() )
-  , mReadExtentFromXml( options.readExtentFromXml )
 {
+  mReadExtentFromXml = options.readExtentFromXml;
   mShouldValidateCrs = !options.skipCrsValidation;
 
   if ( options.fallbackCrs.isValid() )
@@ -5566,16 +5566,6 @@ void QgsVectorLayer::setAllowCommit( bool allowCommit )
 QgsGeometryOptions *QgsVectorLayer::geometryOptions() const
 {
   return mGeometryOptions.get();
-}
-
-void QgsVectorLayer::setReadExtentFromXml( bool readExtentFromXml )
-{
-  mReadExtentFromXml = readExtentFromXml;
-}
-
-bool QgsVectorLayer::readExtentFromXml() const
-{
-  return mReadExtentFromXml;
 }
 
 void QgsVectorLayer::onDirtyTransaction( const QString &sql, const QString &name )

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2315,24 +2315,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void setEditFormConfig( const QgsEditFormConfig &editFormConfig );
 
     /**
-     * Flag allowing to indicate if the extent has to be read from the XML
-     * document when data source has no metadata or if the data provider has
-     * to determine it.
-     *
-     * \since QGIS 3.0
-     */
-    void setReadExtentFromXml( bool readExtentFromXml );
-
-    /**
-     * Returns TRUE if the extent is read from the XML document when data
-     * source has no metadata, FALSE if it's the data provider which determines
-     * it.
-     *
-     * \since QGIS 3.0
-     */
-    bool readExtentFromXml() const;
-
-    /**
      * Tests if an edit command is active
      *
      * \since QGIS 3.0

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -120,8 +120,8 @@ QgsRasterLayer::QgsRasterLayer( const QString &uri,
   , QSTRING_NOT_SET( QStringLiteral( "Not Set" ) )
   , TRSTRING_NOT_SET( tr( "Not Set" ) )
   , mTemporalProperties( new QgsRasterLayerTemporalProperties( this ) )
-  , mReadExtentFromXml( options.readExtentFromXml )
 {
+  mReadExtentFromXml = options.readExtentFromXml;
   mShouldValidateCrs = !options.skipCrsValidation;
 
   QgsDebugMsgLevel( QStringLiteral( "Entered" ), 4 );
@@ -1014,16 +1014,6 @@ QgsRectangle QgsRasterLayer::extent() const
     return mXmlExtent;
   }
   return QgsMapLayer::extent();
-}
-
-void QgsRasterLayer::setReadExtentFromXml( bool readExtentFromXml )
-{
-  mReadExtentFromXml = readExtentFromXml;
-}
-
-bool QgsRasterLayer::readExtentFromXml() const
-{
-  return mReadExtentFromXml;
 }
 
 QgsMapLayerTemporalProperties *QgsRasterLayer::temporalProperties()

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -472,24 +472,6 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
      */
     bool ignoreExtents() const;
 
-    /**
-     * Flag allowing to indicate if the extent has to be read from the XML
-     * document when data source has no metadata or if the data provider has
-     * to determine it.
-     *
-     * \since QGIS 3.16
-     */
-    void setReadExtentFromXml( bool readExtentFromXml );
-
-    /**
-     * Returns TRUE if the extent is read from the XML document when data
-     * source has no metadata, FALSE if it's the data provider which determines
-     * it.
-     *
-     * \since QGIS 3.16
-     */
-    bool readExtentFromXml() const;
-
     QgsMapLayerTemporalProperties *temporalProperties() override;
 
   public slots:
@@ -571,10 +553,6 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
     LayerType mRasterType;
 
     QgsRasterPipe mPipe;
-
-    //! read xml extent
-    bool mReadExtentFromXml;
-    QgsRectangle mXmlExtent;
 
     //! To save computations and possible infinite cycle of notifications
     QgsRectangle mLastRectangleUsedByRefreshContrastEnhancementIfNeeded;

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -107,9 +107,11 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
        * Constructor for LayerOptions.
        */
       explicit LayerOptions( bool loadDefaultStyle = true,
-                             const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext() )
+                             const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext(),
+                             bool readExtentFromXml = false )
         : loadDefaultStyle( loadDefaultStyle )
         , transformContext( transformContext )
+        , readExtentFromXml( readExtentFromXml )
       {}
 
       //! Sets to TRUE if the default layer style should be loaded
@@ -120,6 +122,14 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
        * \since QGIS 3.8
        */
       QgsCoordinateTransformContext transformContext = QgsCoordinateTransformContext();
+
+
+      /**
+       * If TRUE, the layer extent will be read from XML (i.e. stored in the
+       * project file). If FALSE, the extent will be determined by the provider on layer load.
+       * \since QGIS 3.16
+       */
+      bool readExtentFromXml = false;
 
       /**
        * Controls whether the layer is allowed to have an invalid/unknown CRS.
@@ -331,6 +341,8 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
     void reload() override;
     QgsMapLayerRenderer *createMapRenderer( QgsRenderContext &rendererContext ) override SIP_FACTORY;
 
+    QgsRectangle extent() const override;
+
     //! \brief This is an overloaded version of the draw() function that is called by both draw() and thumbnailAsPixmap
     void draw( QPainter *theQPainter,
                QgsRasterViewPort *myRasterViewPort,
@@ -460,6 +472,24 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
      */
     bool ignoreExtents() const;
 
+    /**
+     * Flag allowing to indicate if the extent has to be read from the XML
+     * document when data source has no metadata or if the data provider has
+     * to determine it.
+     *
+     * \since QGIS 3.16
+     */
+    void setReadExtentFromXml( bool readExtentFromXml );
+
+    /**
+     * Returns TRUE if the extent is read from the XML document when data
+     * source has no metadata, FALSE if it's the data provider which determines
+     * it.
+     *
+     * \since QGIS 3.16
+     */
+    bool readExtentFromXml() const;
+
     QgsMapLayerTemporalProperties *temporalProperties() override;
 
   public slots:
@@ -541,6 +571,10 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
     LayerType mRasterType;
 
     QgsRasterPipe mPipe;
+
+    //! read xml extent
+    bool mReadExtentFromXml;
+    QgsRectangle mXmlExtent;
 
     //! To save computations and possible infinite cycle of notifications
     QgsRectangle mLastRectangleUsedByRefreshContrastEnhancementIfNeeded;

--- a/tests/src/python/test_provider_postgresraster.py
+++ b/tests/src/python/test_provider_postgresraster.py
@@ -211,8 +211,8 @@ class TestPyQgsPostgresRasterProvider(unittest.TestCase):
         """Read raster extent from XML"""
 
         rl0 = QgsRasterLayer(
-                self.dbconn + ' sslmode=disable key=\'rid\' srid=3035  table="public"."raster_tiled_3035" sql=',
-                'test', 'postgresraster')
+            self.dbconn + ' sslmode=disable key=\'rid\' srid=3035  table="public"."raster_tiled_3035" sql=',
+            'test', 'postgresraster')
         self.assertTrue(rl0.isValid())
 
         # set a custom extent


### PR DESCRIPTION
## Description

The trust flag at the project level is only used to read vector layer extent from xml, not from provider.

This flag was not available for raster layer.

We propose to add the same capabilities in raster layer
