### PR TITLE
Label (title) of relation editor widget instances

### DIFF
--- a/python/core/auto_generated/qgsattributeeditorelement.sip.in
+++ b/python/core/auto_generated/qgsattributeeditorelement.sip.in
@@ -456,6 +456,21 @@ If it's empty, then it's considered as a 1:M relationship.
 .. versionadded:: 3.16
 %End
 
+    QString label() const;
+%Docstring
+Determines the label of this element
+
+.. versionadded:: 3.16
+%End
+
+    void setLabel( const QString &label = QString() );
+%Docstring
+Sets ``label`` for this element
+If it's empty it takes the relation id as label
+
+.. versionadded:: 3.16
+%End
+
 };
 
 QFlags<QgsAttributeEditorRelation::Button> operator|(QgsAttributeEditorRelation::Button f1, QFlags<QgsAttributeEditorRelation::Button> f2);

--- a/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
@@ -145,6 +145,20 @@ If it's empty, then it's considered as a 1:M relationship.
 .. versionadded:: 3.16
 %End
 
+    QString label() const;
+%Docstring
+Determines the label of this element
+
+.. versionadded:: 3.16
+%End
+
+    void setLabel( const QString &label = QString() );
+%Docstring
+Sets ``label`` for this element
+If it's empty it takes the relation id as label
+
+.. versionadded:: 3.16
+%End
 
     QgsRelation relation() const;
 %Docstring

--- a/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
@@ -213,6 +213,21 @@ If it's empty, then it's considered as a 1:M relationship.
 .. versionadded:: 3.16
 %End
 
+    QString label() const;
+%Docstring
+Determines the label of this element
+
+.. versionadded:: 3.16
+%End
+
+    void setLabel( const QString &label = QString() );
+%Docstring
+Sets ``label`` for this element
+If it's empty it takes the relation id as label
+
+.. versionadded:: 3.16
+%End
+
     QgsFeature feature() const;
 %Docstring
 Returns the widget's current feature

--- a/src/core/qgsattributeeditorelement.cpp
+++ b/src/core/qgsattributeeditorelement.cpp
@@ -99,6 +99,7 @@ QgsAttributeEditorElement *QgsAttributeEditorRelation::clone( QgsAttributeEditor
   element->mButtons = mButtons;
   element->mForceSuppressFormPopup = mForceSuppressFormPopup;
   element->mNmRelationId = mNmRelationId;
+  element->mLabel = mLabel;
 
   return element;
 }
@@ -137,6 +138,7 @@ void QgsAttributeEditorRelation::saveConfiguration( QDomElement &elem ) const
   elem.setAttribute( QStringLiteral( "buttons" ), qgsFlagValueToKeys( mButtons ) );
   elem.setAttribute( QStringLiteral( "forceSuppressFormPopup" ), mForceSuppressFormPopup );
   elem.setAttribute( QStringLiteral( "nmRelationId" ), mNmRelationId.toString() );
+  elem.setAttribute( QStringLiteral( "label" ), mLabel );
 }
 
 QString QgsAttributeEditorRelation::typeIdentifier() const
@@ -197,6 +199,16 @@ void QgsAttributeEditorRelation::setNmRelationId( const QVariant &nmRelationId )
 QVariant QgsAttributeEditorRelation::nmRelationId() const
 {
   return mNmRelationId;
+}
+
+void QgsAttributeEditorRelation::setLabel( const QString &label )
+{
+  mLabel = label;
+}
+
+QString QgsAttributeEditorRelation::label() const
+{
+  return mLabel;
 }
 
 QgsAttributeEditorElement *QgsAttributeEditorQmlElement::clone( QgsAttributeEditorElement *parent ) const

--- a/src/core/qgsattributeeditorelement.h
+++ b/src/core/qgsattributeeditorelement.h
@@ -494,6 +494,19 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
      */
     void setNmRelationId( const QVariant &nmRelationId = QVariant() );
 
+    /**
+     * Determines the label of this element
+     * \since QGIS 3.16
+     */
+    QString label() const;
+
+    /**
+     * Sets \a label for this element
+     * If it's empty it takes the relation id as label
+     * \since QGIS 3.16
+     */
+    void setLabel( const QString &label = QString() );
+
   private:
     void saveConfiguration( QDomElement &elem ) const override;
     QString typeIdentifier() const override;
@@ -502,6 +515,7 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
     Buttons mButtons = Buttons( Button::AllButtons );
     bool mForceSuppressFormPopup = false;
     QVariant mNmRelationId;
+    QString mLabel;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsAttributeEditorRelation::Buttons )

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -693,6 +693,11 @@ QgsAttributeEditorElement *QgsEditFormConfig::attributeEditorElementFromDomEleme
       // pre QGIS 3.16 compatibility - the widgets section is read before
       relElement->setNmRelationId( widgetConfig( elem.attribute( QStringLiteral( "relation" ) ) ).value( QStringLiteral( "nm-rel" ) ) );
     }
+    if ( elem.hasAttribute( "label" ) )
+    {
+      QString label = elem.attribute( QStringLiteral( "label" ) );
+      relElement->setLabel( label );
+    }
     newElement = relElement;
   }
   else if ( elem.tagName() == QLatin1String( "attributeEditorQmlElement" ) )

--- a/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
+++ b/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
@@ -118,6 +118,8 @@ void QgsAttributeWidgetRelationEditWidget::setRelationEditorConfiguration( const
   mRelationCardinalityCombo->setToolTip( tr( "For a many to many (N:M) relation, the direct link has to be selected. The in-between table will be hidden." ) );
   setNmRelationId( config.nmRelationId );
 
+  mRelationLabelEdit->setText( config.label );
+
   mRelationForceSuppressFormPopupCheckBox->setChecked( config.forceSuppressFormPopup );
 }
 
@@ -135,6 +137,7 @@ QgsAttributesFormProperties::RelationEditorConfiguration QgsAttributeWidgetRelat
   relEdCfg.buttons = buttons;
   relEdCfg.nmRelationId = mRelationCardinalityCombo->currentData();
   relEdCfg.forceSuppressFormPopup = mRelationForceSuppressFormPopupCheckBox->isChecked();
+  relEdCfg.label = mRelationLabelEdit->text();
   return relEdCfg;
 }
 

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -280,3 +280,17 @@ QVariant QgsRelationWidgetWrapper::nmRelationId() const
     return mWidget->nmRelationId();
   return QVariant();
 }
+
+
+void QgsRelationWidgetWrapper::setLabel( const QString &label )
+{
+  if ( mWidget )
+    mWidget->setLabel( label );
+}
+
+QString QgsRelationWidgetWrapper::label() const
+{
+  if ( mWidget )
+    return mWidget->label();
+  return QString();
+}

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
@@ -134,6 +134,18 @@ class GUI_EXPORT QgsRelationWidgetWrapper : public QgsWidgetWrapper
      */
     void setNmRelationId( const QVariant &nmRelationId = QVariant() );
 
+    /**
+     * Determines the label of this element
+     * \since QGIS 3.16
+     */
+    QString label() const;
+
+    /**
+     * Sets \a label for this element
+     * If it's empty it takes the relation id as label
+     * \since QGIS 3.16
+     */
+    void setLabel( const QString &label = QString() );
 
     /**
      * The relation for which this wrapper is created.

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1961,6 +1961,7 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
       rww->setShowLabel( relDef->showLabel() );
       rww->setNmRelationId( relDef->nmRelationId() );
       rww->setForceSuppressFormPopup( relDef->forceSuppressFormPopup() );
+      rww->setLabel( relDef->label() );
 
       mWidgets.append( rww );
       mFormWidgets.append( formWidget );

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -1009,6 +1009,18 @@ QVariant QgsRelationEditorWidget::nmRelationId() const
   return mNmRelationId;
 }
 
+QString QgsRelationEditorWidget::label() const
+{
+  return mLabel;
+}
+
+void QgsRelationEditorWidget::setLabel( const QString &label )
+{
+  mLabel = label;
+
+  updateTitle();
+}
+
 void QgsRelationEditorWidget::setShowUnlinkButton( bool showUnlinkButton )
 {
   mUnlinkFeatureButton->setVisible( showUnlinkButton );
@@ -1069,10 +1081,18 @@ void QgsRelationEditorWidget::unsetMapTool()
 
 void QgsRelationEditorWidget::updateTitle()
 {
-  if ( mShowLabel && mRelation.isValid() )
+  if ( mShowLabel && !mLabel.isEmpty() )
+  {
+    setTitle( mLabel );
+  }
+  else if ( mShowLabel && mRelation.isValid() )
+  {
     setTitle( mRelation.name() );
+  }
   else
+  {
     setTitle( QString() );
+  }
 }
 
 QgsFeature QgsRelationEditorWidget::feature() const

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -248,6 +248,19 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     void setNmRelationId( const QVariant &nmRelationId = QVariant() );
 
     /**
+     * Determines the label of this element
+     * \since QGIS 3.16
+     */
+    QString label() const;
+
+    /**
+     * Sets \a label for this element
+     * If it's empty it takes the relation id as label
+     * \since QGIS 3.16
+     */
+    void setLabel( const QString &label = QString() );
+
+    /**
      * Returns the widget's current feature
      *
      * \since QGIS 3.14
@@ -321,6 +334,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
 
     bool mForceSuppressFormPopup = false;
     QVariant mNmRelationId;
+    QString mLabel;
 
     /**
      * Deletes the features

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -413,6 +413,7 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       relEdConfig.buttons = relationEditor->visibleButtons();
       relEdConfig.nmRelationId = relationEditor->nmRelationId();
       relEdConfig.forceSuppressFormPopup = relationEditor->forceSuppressFormPopup();
+      relEdConfig.label = relationEditor->label();
       itemData.setRelationEditorConfiguration( relEdConfig );
       newWidget = tree->addItem( parent, itemData );
       break;
@@ -659,6 +660,7 @@ QgsAttributeEditorElement *QgsAttributesFormProperties::createAttributeEditorWid
       relDef->setVisibleButtons( itemData.relationEditorConfiguration().buttons );
       relDef->setNmRelationId( itemData.relationEditorConfiguration().nmRelationId );
       relDef->setForceSuppressFormPopup( itemData.relationEditorConfiguration().forceSuppressFormPopup );
+      relDef->setLabel( itemData.relationEditorConfiguration().label );
       widgetDef = relDef;
       break;
     }

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -70,6 +70,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
       QgsAttributeEditorRelation::Buttons buttons = QgsAttributeEditorRelation::Button::AllButtons;
       QVariant nmRelationId;
       bool forceSuppressFormPopup = false;
+      QString label;
     };
 
     struct QmlElementEditorConfiguration

--- a/src/ui/attributeformconfig/qgsattributewidgetrelationeditwidget.ui
+++ b/src/ui/attributeformconfig/qgsattributewidgetrelationeditwidget.ui
@@ -7,13 +7,37 @@
     <x>0</x>
     <y>0</y>
     <width>340</width>
-    <height>293</height>
+    <height>361</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Attribute Widget Relation Edit Widget</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetDefaultConstraint</enum>
+     </property>
+     <item>
+      <widget class="QLabel" name="labelLabel">
+       <property name="text">
+        <string>Label</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="mRelationLabelEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
    <item>
     <widget class="QCheckBox" name="mRelationShowLinkCheckBox">
      <property name="text">


### PR DESCRIPTION
Since there can be multiple instances of the relation as Relation Editor Widgets the titles need to be configurable.
![instance_label](https://user-images.githubusercontent.com/28384354/92586137-294ab700-f296-11ea-9418-da39a93353cd.png)
![instancelabel2](https://user-images.githubusercontent.com/28384354/92586143-2b147a80-f296-11ea-886c-9d0e3a176bb9.png)

Resolves #37675