### PR TITLE
Parentheses are needed in case the filter expression contains "OR"

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -862,7 +862,7 @@ void QgsRelationReferenceWidget::filterChanged()
 
   QgsFeature f;
   QgsFeatureIds featureIds;
-  QString filterExpression = mFilterExpression;
+  QString filterExpression = mFilterExpression.isEmpty() ? mFilterExpression : QStringLiteral( " ( %1 ) " ).arg( mFilterExpression );
 
   // comboboxes have to be disabled before building filters
   if ( mChainFilters )

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -862,7 +862,11 @@ void QgsRelationReferenceWidget::filterChanged()
 
   QgsFeature f;
   QgsFeatureIds featureIds;
-  QString filterExpression = mFilterExpression.isEmpty() ? mFilterExpression : QStringLiteral( " ( %1 ) " ).arg( mFilterExpression );
+  QString filterExpression = mFilterExpression;
+
+  // wrap the expression with parentheses as it might contain `OR`
+  if ( filterExpression.isEmpty() )
+    filterExpression = QStringLiteral( " ( %1 ) " ).arg( filterExpression );
 
   // comboboxes have to be disabled before building filters
   if ( mChainFilters )

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -865,7 +865,7 @@ void QgsRelationReferenceWidget::filterChanged()
   QString filterExpression = mFilterExpression;
 
   // wrap the expression with parentheses as it might contain `OR`
-  if ( filterExpression.isEmpty() )
+  if ( !filterExpression.isEmpty() )
     filterExpression = QStringLiteral( " ( %1 ) " ).arg( filterExpression );
 
   // comboboxes have to be disabled before building filters


### PR DESCRIPTION
This is a follow up PR to https://github.com/qgis/QGIS/pull/38659 . In case the filter expression is set to `1 OR 0` and there are filter fields, it will become `1 OR 0 AND field1 = 'something'` which is wrong. 

With this PR parentheses are ensured around the filter expression and the result would be ` ( 1 OR 0 ) AND field1 = 'something'`. I have added a test checking this situation.