### PR TITLE
Use an explicit version of pyogctest

### DIFF
--- a/.github/workflows/ogc.yml
+++ b/.github/workflows/ogc.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           sudo apt-get install python3-virtualenv virtualenv git
           git clone https://github.com/pblottiere/pyogctest
+          cd pyogctest && git checkout 1.0.0 && cd -
           virtualenv -p /usr/bin/python3 venv && source venv/bin/activate && pip install -e pyogctest/
 
       - name: Download WMS 1.3.0 dataset


### PR DESCRIPTION
## Description

By using an explicit version of ``pyogctest``, the QGIS continuous integration mechanism won't be dependent on ``pyogctest`` master branch status. I'll keep thing up to date in case of new tags.