### PR TITLE
Fix visible state of buttons in the Relation Editor Widget

### DIFF
--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -430,12 +430,6 @@ void QgsRelationEditorWidget::updateButtons()
   mDeleteFeatureButton->setEnabled( editable && selectionNotEmpty );
   mUnlinkFeatureButton->setEnabled( linkable && selectionNotEmpty );
 
-  mZoomToFeatureButton->setVisible(
-    mButtons.testFlag( QgsAttributeEditorRelation::Button::ZoomToChildFeature ) &&
-    mEditorContext.mapCanvas() &&
-    mChildIsSpatial
-  );
-
   mZoomToFeatureButton->setEnabled( selectionNotEmpty );
 
   mToggleEditingButton->setChecked( editable );

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -432,19 +432,8 @@ void QgsRelationEditorWidget::updateButtons()
 
   mZoomToFeatureButton->setVisible(
     mButtons.testFlag( QgsAttributeEditorRelation::Button::ZoomToChildFeature ) &&
-    mEditorContext.mapCanvas() && (
-      (
-        mNmRelation.isValid() &&
-        mNmRelation.referencedLayer()->geometryType() != QgsWkbTypes::NullGeometry &&
-        mNmRelation.referencedLayer()->geometryType() != QgsWkbTypes::UnknownGeometry
-      )
-      ||
-      (
-        mRelation.isValid() &&
-        mRelation.referencingLayer()->geometryType() != QgsWkbTypes::NullGeometry &&
-        mRelation.referencingLayer()->geometryType() != QgsWkbTypes::UnknownGeometry
-      )
-    )
+    mEditorContext.mapCanvas() &&
+    mChildIsSpatial
   );
 
   mZoomToFeatureButton->setEnabled( selectionNotEmpty );

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -322,7 +322,6 @@ void QgsRelationEditorWidget::setRelations( const QgsRelation &relation, const Q
     if ( it.value()->layers().contains( mRelation.referencingLayer() ) )
     {
       mToggleEditingButton->setVisible( false );
-      mSaveEditsButton->setVisible( false );
     }
   }
 
@@ -343,7 +342,6 @@ void QgsRelationEditorWidget::setRelations( const QgsRelation &relation, const Q
   if ( canChangeAttributes && !lyr->readOnly() )
   {
     mToggleEditingButton->setEnabled( true );
-    updateButtons();
   }
   else
   {
@@ -429,7 +427,7 @@ void QgsRelationEditorWidget::updateButtons()
   mLinkFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::Link ) );
   mUnlinkFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::Unlink ) );
   mSaveEditsButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::SaveChildEdits ) );
-  mAddFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::AddChildFeature ) );
+  mAddFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::AddChildFeature ) && mToggleEditingButton->isVisible() );
   mAddFeatureGeometryButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::AddChildFeature ) && mEditorContext.mapCanvas() && mEditorContext.cadDockWidget() && spatial );
   mDuplicateFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::DuplicateChildFeature ) );
   mDeleteFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::DeleteChildFeature ) );

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -424,14 +424,14 @@ void QgsRelationEditorWidget::updateButtons()
   mToggleEditingButton->setChecked( editable );
   mSaveEditsButton->setEnabled( editable );
 
-  mLinkFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::Link ) );
-  mUnlinkFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::Unlink ) );
-  mSaveEditsButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::SaveChildEdits ) );
-  mAddFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::AddChildFeature ) && mToggleEditingButton->isVisible() );
-  mAddFeatureGeometryButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::AddChildFeature ) && mEditorContext.mapCanvas() && mEditorContext.cadDockWidget() && spatial );
-  mDuplicateFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::DuplicateChildFeature ) );
-  mDeleteFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::DeleteChildFeature ) );
-  mZoomToFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::ZoomToChildFeature ) && mEditorContext.mapCanvas() && spatial );
+  mLinkFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsAttributeEditorRelation::Button::Link ) );
+  mUnlinkFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsAttributeEditorRelation::Button::Unlink ) );
+  mSaveEditsButton->setVisible( mButtonsVisibility.testFlag( QgsAttributeEditorRelation::Button::SaveChildEdits ) && mToggleEditingButton->isVisible() );
+  mAddFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsAttributeEditorRelation::Button::AddChildFeature ) );
+  mAddFeatureGeometryButton->setVisible( mButtonsVisibility.testFlag( QgsAttributeEditorRelation::Button::AddChildFeature ) && mEditorContext.mapCanvas() && mEditorContext.cadDockWidget() && spatial );
+  mDuplicateFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsAttributeEditorRelation::Button::DuplicateChildFeature ) );
+  mDeleteFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsAttributeEditorRelation::Button::DeleteChildFeature ) );
+  mZoomToFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsAttributeEditorRelation::Button::ZoomToChildFeature ) && mEditorContext.mapCanvas() && spatial );
 }
 
 void QgsRelationEditorWidget::addFeatureGeometry()
@@ -943,7 +943,7 @@ bool QgsRelationEditorWidget::showSaveChildEditsButton() const
 
 void QgsRelationEditorWidget::setVisibleButtons( const QgsAttributeEditorRelation::Buttons &buttons )
 {
-  mButtons = buttons;
+  mButtonsVisibility = buttons;
   updateButtons();
 }
 

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -358,9 +358,11 @@ void QgsRelationEditorWidget::setRelations( const QgsRelation &relation, const Q
   }
 
   if ( mNmRelation.isValid() )
-    mZoomToFeatureButton->setVisible( mNmRelation.referencedLayer()->isSpatial() );
+    mChildIsSpatial = mNmRelation.referencedLayer()->isSpatial();
   else
-    mZoomToFeatureButton->setVisible( mRelation.referencingLayer()->isSpatial() );
+    mChildIsSpatial = mRelation.referencingLayer()->isSpatial();
+
+  mZoomToFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::ZoomToChildFeature ) && mChildIsSpatial );
 
   setObjectName( QStringLiteral( "referenced/" ) + mRelation.name() );
 
@@ -429,6 +431,7 @@ void QgsRelationEditorWidget::updateButtons()
   mUnlinkFeatureButton->setEnabled( linkable && selectionNotEmpty );
 
   mZoomToFeatureButton->setVisible(
+    mButtons.testFlag( QgsAttributeEditorRelation::Button::ZoomToChildFeature ) &&
     mEditorContext.mapCanvas() && (
       (
         mNmRelation.isValid() &&
@@ -959,14 +962,15 @@ bool QgsRelationEditorWidget::showSaveChildEditsButton() const
 
 void QgsRelationEditorWidget::setVisibleButtons( const QgsAttributeEditorRelation::Buttons &buttons )
 {
-  mLinkFeatureButton->setVisible( buttons.testFlag( QgsAttributeEditorRelation::Button::Link ) );
-  mUnlinkFeatureButton->setVisible( buttons.testFlag( QgsAttributeEditorRelation::Button::Unlink ) );
-  mSaveEditsButton->setVisible( buttons.testFlag( QgsAttributeEditorRelation::Button::SaveChildEdits ) );
-  mAddFeatureButton->setVisible( buttons.testFlag( QgsAttributeEditorRelation::Button::AddChildFeature ) );
-  mAddFeatureGeometryButton->setVisible( buttons.testFlag( QgsAttributeEditorRelation::Button::AddChildFeature ) );
-  mDuplicateFeatureButton->setVisible( buttons.testFlag( QgsAttributeEditorRelation::Button::DuplicateChildFeature ) );
-  mDeleteFeatureButton->setVisible( buttons.testFlag( QgsAttributeEditorRelation::Button::DeleteChildFeature ) );
-  mZoomToFeatureButton->setVisible( buttons.testFlag( QgsAttributeEditorRelation::Button::ZoomToChildFeature ) );
+  mButtons = buttons;
+  mLinkFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::Link ) );
+  mUnlinkFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::Unlink ) );
+  mSaveEditsButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::SaveChildEdits ) );
+  mAddFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::AddChildFeature ) );
+  mAddFeatureGeometryButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::AddChildFeature ) );
+  mDuplicateFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::DuplicateChildFeature ) );
+  mDeleteFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::DeleteChildFeature ) );
+  mZoomToFeatureButton->setVisible( mButtons.testFlag( QgsAttributeEditorRelation::Button::ZoomToChildFeature ) && mChildIsSpatial );
 }
 
 QgsAttributeEditorRelation::Buttons QgsRelationEditorWidget::visibleButtons() const

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -441,8 +441,8 @@ void QgsRelationEditorWidget::updateButtons()
       ||
       (
         mRelation.isValid() &&
-        mRelation.referencedLayer()->geometryType() != QgsWkbTypes::NullGeometry &&
-        mRelation.referencedLayer()->geometryType() != QgsWkbTypes::UnknownGeometry
+        mRelation.referencingLayer()->geometryType() != QgsWkbTypes::NullGeometry &&
+        mRelation.referencingLayer()->geometryType() != QgsWkbTypes::UnknownGeometry
       )
     )
   );

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -329,7 +329,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     QObjectUniquePtr<QgsMapToolDigitizeFeature> mMapToolDigitize;
     QButtonGroup *mViewModeButtonGroup = nullptr;
 
-    QgsAttributeEditorRelation::Buttons mButtonsVisibility;
+    QgsAttributeEditorRelation::Buttons mButtonsVisibility = QgsAttributeEditorRelation::Button::AllButtons;
     bool mShowLabel = true;
     bool mVisible = false;
     bool mLayerInSameTransactionGroup = false;

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -332,7 +332,6 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     QgsAttributeEditorRelation::Buttons mButtons;
     bool mShowLabel = true;
     bool mVisible = false;
-    bool mChildIsSpatial = false;
 
     bool mForceSuppressFormPopup = false;
     QVariant mNmRelationId;

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -332,6 +332,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     QgsAttributeEditorRelation::Buttons mButtonsVisibility;
     bool mShowLabel = true;
     bool mVisible = false;
+    bool mLayerInSameTransactionGroup = false;
 
     bool mForceSuppressFormPopup = false;
     QVariant mNmRelationId;

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -329,8 +329,10 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     QObjectUniquePtr<QgsMapToolDigitizeFeature> mMapToolDigitize;
     QButtonGroup *mViewModeButtonGroup = nullptr;
 
+    QgsAttributeEditorRelation::Buttons mButtons;
     bool mShowLabel = true;
     bool mVisible = false;
+    bool mChildIsSpatial = false;
 
     bool mForceSuppressFormPopup = false;
     QVariant mNmRelationId;

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -329,7 +329,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     QObjectUniquePtr<QgsMapToolDigitizeFeature> mMapToolDigitize;
     QButtonGroup *mViewModeButtonGroup = nullptr;
 
-    QgsAttributeEditorRelation::Buttons mButtons;
+    QgsAttributeEditorRelation::Buttons mButtonsVisibility;
     bool mShowLabel = true;
     bool mVisible = false;
 


### PR DESCRIPTION
`mZoomToFeatureButton` visibility is set on several places and it used to override each other. Same for `mSaveEditsButton` and `mAddFeatureGeometryButton`.

To keep it stable and not being dependent on the order of the setting, it store the configured visibility of buttons in `mButtonsVisibility` and calls `upadteButtons` from `setVisibleButtons`, `setRelation`, `initDualView` and `setEditorContext`.

For `mZoomToFeatureButton` it checks if the flag is set, the editorContexts mapCanvas exists and if the referenced layer of `relation` / the referencing layer of the `nmRelation` is spacial
For `mAddFeatureGeometryButton` it checks the same, but additionally for the existence of `mEditorContext.cadDockWidget()`.

For `mSaveEditsButton` and `mToggleEditingButton` it checks has the member `mLayerInSameTransactionGroup`. This is additionally set correctly according if the parent AND the child are in this group (or with many-to-many relations additionally the "other" parent layer as well).

fixes #37718