### PR TITLE
Fix ZoomToFeature in Relation Editor Widget

### DIFF
--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -438,8 +438,8 @@ void QgsRelationEditorWidget::updateButtons()
       ||
       (
         mRelation.isValid() &&
-        mRelation.referencedLayer()->geometryType() != QgsWkbTypes::NullGeometry &&
-        mRelation.referencedLayer()->geometryType() != QgsWkbTypes::UnknownGeometry
+        mRelation.referencingLayer()->geometryType() != QgsWkbTypes::NullGeometry &&
+        mRelation.referencingLayer()->geometryType() != QgsWkbTypes::UnknownGeometry
       )
     )
   );


### PR DESCRIPTION
On one to many relations if the parent or the child is spatial and the other one is not, it should consider the spatial status of the child to decide if it can zoom to feature instead of the parent (current feature).