### PR TITLE
Removed superfluous bracket

### DIFF
--- a/src/gui/vector/qgssourcefieldsproperties.cpp
+++ b/src/gui/vector/qgssourcefieldsproperties.cpp
@@ -71,7 +71,7 @@ QgsSourceFieldsProperties::QgsSourceFieldsProperties( QgsVectorLayer *layer, QWi
   wfsWi->setToolTip( tr( "Defines if this field is available in QGIS Server WFS (and OAPIF) service" ) );
   mFieldsList->setHorizontalHeaderItem( AttrWFSCol, wfsWi );
   const auto searchableWi = new QTableWidgetItem( QStringLiteral( "Searchable" ) );
-  searchableWi->setToolTip( tr( "Defines if this field is searchable (active layer locator filter))" ) );
+  searchableWi->setToolTip( tr( "Defines if this field is searchable (active layer locator filter)" ) );
   mFieldsList->setHorizontalHeaderItem( AttrSearchableCol, searchableWi );
   mFieldsList->setHorizontalHeaderItem( AttrAliasCol, new QTableWidgetItem( tr( "Alias" ) ) );
 


### PR DESCRIPTION
Line 74  : (active layer locator filter))"  should be;  (active layer locator filter)"  One closing bracket, not two
Removed one superfluous bracket

## Description
Display correct documentation
