### PR TITLE
Add option for Natural Sorting on Points to Paths algorithm

### DIFF
--- a/python/plugins/processing/algs/qgis/PointsToPaths.py
+++ b/python/plugins/processing/algs/qgis/PointsToPaths.py
@@ -218,7 +218,7 @@ class PointsToPaths(QgisAlgorithm):
     def natural_sort_key(self, value, _nsre=re.compile('([0-9]+)')):
         if not value[0]:
             retVal = (False, None)
-        elif type(value[0]) in (str, unicode):
+        elif type(value[0]) == str:
             retVal = (True, [int(text) if text.isdecimal() else text.lower() for text in _nsre.split(value[0])])
         else:
             retVal = (True, value[0])

--- a/python/plugins/processing/tests/testdata/expected/points_to_path_natural_sort.gml
+++ b/python/plugins/processing/tests/testdata/expected/points_to_path_natural_sort.gml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ points_to_path_natural_sort.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>10</gml:X><gml:Y>4</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                              
+  <gml:featureMember>
+    <ogr:points_to_path_natural_sort fid="points_to_path_natural_sort.0">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>0,-5 0,-1 1,1 2,2 3,3 5,4 4,3 3,2 2,0 2,-4</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:id2>0</ogr:id2>
+      <ogr:begin xsi:nil="true"/>
+      <ogr:end>b11z</ogr:end>
+    </ogr:points_to_path_natural_sort>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path_natural_sort fid="points_to_path_natural_sort.1">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>4,1 5,2 6,2 7,3 7,-1 8,-1 9,0 10,0</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:id2>1</ogr:id2>
+      <ogr:begin xsi:nil="true"/>
+      <ogr:end>γ3</ogr:end>
+    </ogr:points_to_path_natural_sort>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/points_to_path_natural_sort.xsd
+++ b/python/plugins/processing/tests/testdata/expected/points_to_path_natural_sort.xsd
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="points_to_path_natural_sort" type="ogr:points_to_path_natural_sort_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="points_to_path_natural_sort_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:LineStringPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="begin" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="end" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/points_to_path.gml
+++ b/python/plugins/processing/tests/testdata/points_to_path.gml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ points_to_path.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>10</gml:X><gml:Y>4</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                              
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.9">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>10</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:char_id>a2</ogr:char_id>
+    </ogr:points_to_path>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.10">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>11</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:char_id>a11</ogr:char_id>
+    </ogr:points_to_path>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.11">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>12</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:char_id>a3</ogr:char_id>
+    </ogr:points_to_path>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.12">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>13</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:char_id>α01</ogr:char_id>
+    </ogr:points_to_path>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.13">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>14</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:char_id></ogr:char_id>
+    </ogr:points_to_path>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.14">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>15</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:char_id xsi:nil="true"/>
+    </ogr:points_to_path>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.15">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>16</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:char_id>α20</ogr:char_id>
+    </ogr:points_to_path>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.16">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>17</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:char_id>α11α</ogr:char_id>
+    </ogr:points_to_path>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.17">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>18</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:char_id>a1</ogr:char_id>
+    </ogr:points_to_path>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>1</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:char_id>a41a</ogr:char_id>
+    </ogr:points_to_path>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,4</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>2</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:char_id>a40</ogr:char_id>
+    </ogr:points_to_path>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>3</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:char_id>a41b</ogr:char_id>
+    </ogr:points_to_path>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>10,0</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>4</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:char_id>γ3</ogr:char_id>
+    </ogr:points_to_path>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,-4</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>5</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:char_id>b11z</ogr:char_id>
+    </ogr:points_to_path>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>6,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>6</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:char_id>α2</ogr:char_id>
+    </ogr:points_to_path>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>7</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:char_id>α11</ogr:char_id>
+    </ogr:points_to_path>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,0</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>8</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:char_id>b2z</ogr:char_id>
+    </ogr:points_to_path>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path fid="points.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9,0</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>9</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:char_id>β42</ogr:char_id>
+    </ogr:points_to_path>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/points_to_path.xsd
+++ b/python/plugins/processing/tests/testdata/points_to_path.xsd
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="points_to_path" type="ogr:points_to_path_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="points_to_path_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="char_id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests2.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests2.yaml
@@ -1613,6 +1613,20 @@ tests:
         name: expected/points_to_path_close_path.gml
         type: vector
 
+  - algorithm: qgis:pointstopath
+    name: Points to path (natural sort)
+    params:
+      INPUT:
+        name: points_to_path.gml
+        type: vector
+      ORDER_FIELD: char_id
+      NATURAL_SORT: true
+      GROUP_FIELD: id2
+    results:
+      OUTPUT:
+        name: expected/points_to_path_natural_sort.gml
+        type: vector
+
   - algorithm: native:joinattributestable
     name: join the attribute table by common field (one-to-one)
     params:


### PR DESCRIPTION
## Description
When using a *text* field for sorting on the *Points to Paths* algorithm the resulting order is not what most users would expect:
`a1,a11,a2,a222,a3`

This PR adds a *Sort text naturally* checkbox that when enabled will use a natural sort algorithm:
`a1,a2,a3,a11,a222`

Fixes #35525

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
