### PR TITLE
Rotated ticks followup

### DIFF
--- a/src/core/layout/qgslayoutitemmapgrid.cpp
+++ b/src/core/layout/qgslayoutitemmapgrid.cpp
@@ -1017,7 +1017,7 @@ void QgsLayoutItemMapGrid::drawGridFrameTicks( QPainter *p, GridExtension *exten
         continue;
 
       // If the angle is below the threshold, we don't draw the annotation
-      if ( abs( annot.angle ) / M_PI * 180.0 > 90.0 - mRotatedTicksMinimumAngle )
+      if ( abs( annot.angle ) / M_PI * 180.0 > 90.0 - mRotatedTicksMinimumAngle + 0.0001 )
         continue;
 
       // Skip outwards facing annotations that are below mRotatedTicksMarginToCorner
@@ -1216,7 +1216,7 @@ void QgsLayoutItemMapGrid::drawCoordinateAnnotation( QgsRenderContext &context, 
   AnnotationDirection anotDir = annotationDirection( frameBorder );
 
   // If the angle is below the threshold, we don't draw the annotation
-  if ( abs( annot.angle ) / M_PI * 180.0 > 90.0 - mRotatedAnnotationsMinimumAngle )
+  if ( abs( annot.angle ) / M_PI * 180.0 > 90.0 - mRotatedAnnotationsMinimumAngle + 0.0001 )
     return;
 
   QVector2D normalVector = borderToNormal2D( annot.border );

--- a/src/ui/layout/qgslayoutmapgridwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapgridwidgetbase.ui
@@ -590,7 +590,7 @@
              <string> °</string>
             </property>
             <property name="decimals">
-             <number>0</number>
+             <number>2</number>
             </property>
             <property name="maximum">
              <double>90.000000000000000</double>
@@ -774,7 +774,7 @@
              <string> °</string>
             </property>
             <property name="decimals">
-             <number>0</number>
+             <number>2</number>
             </property>
             <property name="maximum">
              <double>90.000000000000000</double>


### PR DESCRIPTION
## Description

Some more polishing around the new rotated ticks feature as per https://github.com/qgis/QGIS/issues/38676:
- allow to input decimal values for the "skip low angled ticks" param
- add some tolerance to the "angle < threshold angle" comparison to deal with precision errors

(I'll leave this PR as draft for some time as it's not new features and there may be some more fixes coming before the release with more testing being done)
