### PR TITLE
Show preview icons in rule based labeling list of rules and vector tile labeling list of rules

### DIFF
--- a/src/gui/labeling/qgsrulebasedlabelingwidget.cpp
+++ b/src/gui/labeling/qgsrulebasedlabelingwidget.cpp
@@ -31,6 +31,7 @@
 #include <QClipboard>
 #include <QMessageBox>
 
+const double ICON_PADDING_FACTOR = 0.16;
 
 static QList<QgsExpressionContextScope *> _globalProjectAtlasMapLayerScopes( QgsMapCanvas *mapCanvas, const QgsMapLayer *layer )
 {
@@ -291,8 +292,8 @@ QVariant QgsRuleBasedLabelingModel::data( const QModelIndex &index, int role ) c
   }
   else if ( role == Qt::DecorationRole && index.column() == 0 && rule->settings() )
   {
-    // TODO return QgsSymbolLayerUtils::symbolPreviewIcon( rule->symbol(), QSize( 16, 16 ) );
-    return QVariant();
+    const int iconSize = QgsGuiUtils::scaleIconSize( 16 );
+    return QgsPalLayerSettings::labelSettingsPreviewPixmap( *rule->settings(), QSize( iconSize, iconSize ), QString(),  static_cast< int >( iconSize * ICON_PADDING_FACTOR ) );
   }
   else if ( role == Qt::TextAlignmentRole )
   {

--- a/src/gui/vectortile/qgsvectortilebasiclabelingwidget.cpp
+++ b/src/gui/vectortile/qgsvectortilebasiclabelingwidget.cpp
@@ -26,6 +26,7 @@
 
 ///@cond PRIVATE
 
+const double ICON_PADDING_FACTOR = 0.16;
 
 QgsVectorTileBasicLabelingListModel::QgsVectorTileBasicLabelingListModel( QgsVectorTileBasicLabeling *l, QObject *parent )
   : QAbstractListModel( parent )
@@ -94,6 +95,16 @@ QVariant QgsVectorTileBasicLabelingListModel::data( const QModelIndex &index, in
       if ( index.column() != 0 )
         return QVariant();
       return style.isEnabled() ? Qt::Checked : Qt::Unchecked;
+    }
+
+    case Qt::DecorationRole:
+    {
+      if ( index.column() == 0 )
+      {
+        const int iconSize = QgsGuiUtils::scaleIconSize( 16 );
+        return QgsPalLayerSettings::labelSettingsPreviewPixmap( style.labelSettings(), QSize( iconSize, iconSize ), QString(),  static_cast< int >( iconSize * ICON_PADDING_FACTOR ) );
+      }
+      break;
     }
 
     case MinZoom:


### PR DESCRIPTION
Makes it MUCH easier to identify specific rules in the list, and matches
appearance with the rule based renderer/vector tile renderer list appearances.

![image](https://user-images.githubusercontent.com/1829991/93031669-0e9a8880-f670-11ea-99e4-6e2bec1ee3bc.png)
