### PR TITLE
Optimise rendering of complex vector tiles

### DIFF
--- a/python/core/auto_generated/vectortile/qgsvectortilebasicrenderer.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilebasicrenderer.sip.in
@@ -157,6 +157,8 @@ Constructs renderer with no styles
 
     virtual void startRender( QgsRenderContext &context, int tileZoom, const QgsTileRange &tileRange );
 
+    virtual QSet< QString > requiredLayers( QgsRenderContext &context, int tileZoom ) const;
+
     virtual void stopRender( QgsRenderContext &context );
 
     virtual void renderTile( const QgsVectorTileRendererData &tile, QgsRenderContext &context );

--- a/python/core/auto_generated/vectortile/qgsvectortilerenderer.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilerenderer.sip.in
@@ -109,6 +109,18 @@ Initializes rendering. It should be paired with a :py:func:`~QgsVectorTileRender
 %End
 
 
+
+    virtual QSet< QString > requiredLayers( QgsRenderContext &context, int tileZoom ) const;
+%Docstring
+Returns a list of the layers required for rendering.
+
+Only layers which are visible at the specified ``tileZoom`` should be included in this list.
+
+An empty string present in the list indicates that all layer in the tiles are required.
+
+.. versionadded:: 3.16
+%End
+
     virtual void stopRender( QgsRenderContext &context ) = 0;
 %Docstring
 Finishes rendering and cleans up any resources

--- a/src/core/vectortile/qgsvectortilebasiclabeling.cpp
+++ b/src/core/vectortile/qgsvectortilebasiclabeling.cpp
@@ -143,6 +143,19 @@ QMap<QString, QSet<QString> > QgsVectorTileBasicLabelProvider::usedAttributes( c
   return requiredFields;
 }
 
+QSet<QString> QgsVectorTileBasicLabelProvider::requiredLayers( QgsRenderContext &, int tileZoom ) const
+{
+  QSet< QString > res;
+  for ( const QgsVectorTileBasicLabelingStyle &layerStyle : qgis::as_const( mStyles ) )
+  {
+    if ( layerStyle.isActive( tileZoom ) )
+    {
+      res.insert( layerStyle.layerName() );
+    }
+  }
+  return res;
+}
+
 void QgsVectorTileBasicLabelProvider::setFields( const QMap<QString, QgsFields> &perLayerFields )
 {
   mPerLayerFields = perLayerFields;

--- a/src/core/vectortile/qgsvectortilebasiclabeling.h
+++ b/src/core/vectortile/qgsvectortilebasiclabeling.h
@@ -150,6 +150,7 @@ class QgsVectorTileBasicLabelProvider : public QgsVectorTileLabelProvider
     // virtual functions from QgsVectorTileLabelProvider
     void registerTileFeatures( const QgsVectorTileRendererData &tile, QgsRenderContext &context ) override;
     QMap<QString, QSet<QString> > usedAttributes( const QgsRenderContext &context, int tileZoom ) const override;
+    QSet< QString > requiredLayers( QgsRenderContext &context, int tileZoom ) const override;
     void setFields( const QMap<QString, QgsFields> &perLayerFields ) override;
 
   private:

--- a/src/core/vectortile/qgsvectortilebasicrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilebasicrenderer.cpp
@@ -142,6 +142,19 @@ QMap<QString, QSet<QString> > QgsVectorTileBasicRenderer::usedAttributes( const 
   return mRequiredFields;
 }
 
+QSet<QString> QgsVectorTileBasicRenderer::requiredLayers( QgsRenderContext &, int tileZoom ) const
+{
+  QSet< QString > res;
+  for ( const QgsVectorTileBasicRendererStyle &layerStyle : qgis::as_const( mStyles ) )
+  {
+    if ( layerStyle.isActive( tileZoom ) )
+    {
+      res.insert( layerStyle.layerName() );
+    }
+  }
+  return res;
+}
+
 void QgsVectorTileBasicRenderer::stopRender( QgsRenderContext &context )
 {
   Q_UNUSED( context )

--- a/src/core/vectortile/qgsvectortilebasicrenderer.h
+++ b/src/core/vectortile/qgsvectortilebasicrenderer.h
@@ -134,6 +134,7 @@ class CORE_EXPORT QgsVectorTileBasicRenderer : public QgsVectorTileRenderer
     QgsVectorTileBasicRenderer *clone() const override SIP_FACTORY;
     void startRender( QgsRenderContext &context, int tileZoom, const QgsTileRange &tileRange ) override;
     QMap<QString, QSet<QString> > usedAttributes( const QgsRenderContext & ) override SIP_SKIP;
+    QSet< QString > requiredLayers( QgsRenderContext &context, int tileZoom ) const override;
     void stopRender( QgsRenderContext &context ) override;
     void renderTile( const QgsVectorTileRendererData &tile, QgsRenderContext &context ) override;
     void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const override;

--- a/src/core/vectortile/qgsvectortilelabeling.h
+++ b/src/core/vectortile/qgsvectortilelabeling.h
@@ -39,6 +39,19 @@ class QgsVectorTileLabelProvider : public QgsVectorLayerLabelProvider
     //! Returns field names for each sub-layer that are required for labeling
     virtual QMap<QString, QSet<QString> > usedAttributes( const QgsRenderContext &context, int tileZoom ) const = 0;
 
+    //TODO QGIS 4.0 -- make pure virtual
+
+    /**
+     * Returns a list of the layers required for labeling.
+     *
+     * Only layers which are labeled at the specified \a tileZoom should be included in this list.
+     *
+     * An empty string present in the list indicates that all layer in the tiles are required.
+     *
+     * \since QGIS 3.16
+     */
+    virtual QSet< QString > requiredLayers( QgsRenderContext &context, int tileZoom ) const { Q_UNUSED( context ); Q_UNUSED( tileZoom ); return QSet< QString >() << QString(); }
+
     //! Sets fields for each sub-layer
     virtual void setFields( const QMap<QString, QgsFields> &perLayerFields ) = 0;
 

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -151,6 +151,8 @@ bool QgsVectorTileLayerRenderer::render()
   for ( QString layerName : requiredFields.keys() )
     mPerLayerFields[layerName] = QgsVectorTileUtils::makeQgisFields( requiredFields[layerName] );
 
+  mRequiredLayers = mRenderer->requiredLayers( ctx, mTileZoom );
+
   if ( mLabelProvider )
   {
     mLabelProvider->setFields( mPerLayerFields );
@@ -160,6 +162,8 @@ bool QgsVectorTileLayerRenderer::render()
       ctx.labelingEngine()->removeProvider( mLabelProvider );
       mLabelProvider = nullptr; // provider is deleted by the engine
     }
+
+    mRequiredLayers.unite( mLabelProvider->requiredLayers( ctx, mTileZoom ) );
   }
 
   if ( !isAsync )
@@ -212,7 +216,7 @@ void QgsVectorTileLayerRenderer::decodeAndDrawTile( const QgsVectorTileRawData &
 
   QgsVectorTileRendererData tile( rawTile.id );
   tile.setFields( mPerLayerFields );
-  tile.setFeatures( decoder.layerFeatures( mPerLayerFields, ct ) );
+  tile.setFeatures( decoder.layerFeatures( mPerLayerFields, ct, &mRequiredLayers ) );
   tile.setTilePolygon( QgsVectorTileUtils::tilePolygon( rawTile.id, ct, mTileMatrix, ctx.mapToPixel() ) );
 
   mTotalDecodeTime += tLoad.elapsed();

--- a/src/core/vectortile/qgsvectortilelayerrenderer.h
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.h
@@ -88,6 +88,10 @@ class QgsVectorTileLayerRenderer : public QgsMapLayerRenderer
     QgsTileRange mTileRange;
     //! Cached QgsFields object for each sub-layer that will be rendered
     QMap<QString, QgsFields> mPerLayerFields;
+
+    //! Cached list of layers required for renderer and labeling
+    QSet< QString > mRequiredLayers;
+
     //! Counter of total elapsed time to decode tiles (ms)
     int mTotalDecodeTime = 0;
     //! Counter of total elapsed time to render tiles (ms)

--- a/src/core/vectortile/qgsvectortilemvtdecoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.cpp
@@ -77,7 +77,7 @@ QStringList QgsVectorTileMVTDecoder::layerFieldNames( const QString &layerName )
   return fieldNames;
 }
 
-QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString, QgsFields> &perLayerFields, const QgsCoordinateTransform &ct ) const
+QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString, QgsFields> &perLayerFields, const QgsCoordinateTransform &ct, const QSet<QString> *layerSubset ) const
 {
   QgsVectorTileFeatures features;
 
@@ -93,7 +93,10 @@ QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString
   {
     const ::vector_tile::Tile_Layer &layer = tile.layers( layerNum );
 
-    QString layerName = layer.name().c_str();
+    const QString layerName = layer.name().c_str();
+    if ( layerSubset && !layerSubset->contains( QString() ) && !layerSubset->contains( layerName ) )
+      continue;
+
     QVector<QgsFeature> layerFeatures;
     QgsFields layerFields = perLayerFields[layerName];
 

--- a/src/core/vectortile/qgsvectortilemvtdecoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.cpp
@@ -193,6 +193,12 @@ QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString
             QgsDebugMsg( QStringLiteral( "Malformed geometry: invalid cmdCount" ) );
             break;
           }
+
+          if ( feature.type() == vector_tile::Tile_GeomType_POINT )
+            outputPoints.reserve( outputPoints.size() + cmdCount );
+          else
+            tmpPoints.reserve( tmpPoints.size() + cmdCount );
+
           for ( unsigned j = 0; j < cmdCount; j++ )
           {
             unsigned v = feature.geometry( i + 1 );
@@ -231,6 +237,7 @@ QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString
             QgsDebugMsg( QStringLiteral( "Malformed geometry: invalid cmdCount" ) );
             break;
           }
+          tmpPoints.reserve( tmpPoints.size() + cmdCount );
           for ( unsigned j = 0; j < cmdCount; j++ )
           {
             unsigned v = feature.geometry( i + 1 );
@@ -288,10 +295,11 @@ QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString
       {
         geomType = QStringLiteral( "Point" );
         if ( outputPoints.count() == 1 )
-          f.setGeometry( QgsGeometry( outputPoints[0] ) );
+          f.setGeometry( QgsGeometry( outputPoints.at( 0 ) ) );
         else
         {
           QgsMultiPoint *mp = new QgsMultiPoint;
+          mp->reserve( outputPoints.count() );
           for ( int k = 0; k < outputPoints.count(); ++k )
             mp->addGeometry( outputPoints[k] );
           f.setGeometry( QgsGeometry( mp ) );
@@ -305,10 +313,11 @@ QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString
         outputLinestrings.append( new QgsLineString( tmpPoints ) );
 
         if ( outputLinestrings.count() == 1 )
-          f.setGeometry( QgsGeometry( outputLinestrings[0] ) );
+          f.setGeometry( QgsGeometry( outputLinestrings.at( 0 ) ) );
         else
         {
           QgsMultiLineString *mls = new QgsMultiLineString;
+          mls->reserve( outputLinestrings.size() );
           for ( int k = 0; k < outputLinestrings.count(); ++k )
             mls->addGeometry( outputLinestrings[k] );
           f.setGeometry( QgsGeometry( mls ) );
@@ -319,10 +328,11 @@ QgsVectorTileFeatures QgsVectorTileMVTDecoder::layerFeatures( const QMap<QString
         geomType = QStringLiteral( "Polygon" );
 
         if ( outputPolygons.count() == 1 )
-          f.setGeometry( QgsGeometry( outputPolygons[0] ) );
+          f.setGeometry( QgsGeometry( outputPolygons.at( 0 ) ) );
         else
         {
           QgsMultiPolygon *mpl = new QgsMultiPolygon;
+          mpl->reserve( outputPolygons.size() );
           for ( int k = 0; k < outputPolygons.count(); ++k )
             mpl->addGeometry( outputPolygons[k] );
           f.setGeometry( QgsGeometry( mpl ) );

--- a/src/core/vectortile/qgsvectortilemvtdecoder.h
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.h
@@ -48,8 +48,13 @@ class CORE_EXPORT QgsVectorTileMVTDecoder
     //! Returns a list of all field names in a tile. It can only be called after a successful decode()
     QStringList layerFieldNames( const QString &layerName ) const;
 
-    //! Returns decoded features grouped by sub-layers. It can only be called after a successful decode()
-    QgsVectorTileFeatures layerFeatures( const QMap<QString, QgsFields> &perLayerFields, const QgsCoordinateTransform &ct ) const;
+    /**
+     * Returns decoded features grouped by sub-layers. It can only be called after a successful decode()
+     *
+     * If \a layerSubset is specified then only features from the specified layers will be returned.
+     */
+    QgsVectorTileFeatures layerFeatures( const QMap<QString, QgsFields> &perLayerFields, const QgsCoordinateTransform &ct,
+                                         const QSet< QString > *layerSubset = nullptr ) const;
 
   private:
     vector_tile::Tile tile;

--- a/src/core/vectortile/qgsvectortilerenderer.h
+++ b/src/core/vectortile/qgsvectortilerenderer.h
@@ -115,6 +115,19 @@ class CORE_EXPORT QgsVectorTileRenderer
     //! Returns field names of sub-layers that will be used for rendering. Must be called between startRender/stopRender.
     virtual QMap<QString, QSet<QString> > usedAttributes( const QgsRenderContext & ) SIP_SKIP { return QMap<QString, QSet<QString> >(); }
 
+    //TODO QGIS 4.0 -- make pure virtual
+
+    /**
+     * Returns a list of the layers required for rendering.
+     *
+     * Only layers which are visible at the specified \a tileZoom should be included in this list.
+     *
+     * An empty string present in the list indicates that all layer in the tiles are required.
+     *
+     * \since QGIS 3.16
+     */
+    virtual QSet< QString > requiredLayers( QgsRenderContext &context, int tileZoom ) const { Q_UNUSED( context ); Q_UNUSED( tileZoom ); return QSet< QString >() << QString(); }
+
     //! Finishes rendering and cleans up any resources
     virtual void stopRender( QgsRenderContext &context ) = 0;
 


### PR DESCRIPTION
Instead of ALWAYS converting all features in a tile to QGIS representations,
now we intelligently skip over any layers which aren't required for
rendering or labeling (e.g. because the current renderer/labeling
configuration is disabling these layers or doesn't have a rule for
them).

This improves rendering speed with sources like the OS ZoomStack tiles,
which have a LOT of detail even at small map scales (e.g. building
data is present in very zoomed out tiles!!).