### PR TITLE
Support hidpi sprites when converting mapboxgl styles

### DIFF
--- a/python/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
+++ b/python/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
@@ -495,7 +495,7 @@ Converts a MapBox GL expression to a QGIS expression.
    This is private API only, and may change in future QGIS versions
 %End
 
-    static QImage retrieveSprite( const QString &name, QgsMapBoxGlStyleConversionContext &context );
+    static QImage retrieveSprite( const QString &name, QgsMapBoxGlStyleConversionContext &context, QSize &spriteSize );
 %Docstring
 Retrieves the sprite image with the specified ``name``, taken from the specified ``context``.
 

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -334,6 +334,8 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
       // when fill-pattern exists, set and insert QgsRasterFillSymbolLayer
       QgsRasterFillSymbolLayer *rasterFill = new QgsRasterFillSymbolLayer();
       rasterFill->setImageFilePath( sprite );
+      rasterFill->setWidth( spriteSize.width() );
+      rasterFill->setWidthUnit( context.targetUnit() );
       rasterFill->setCoordinateMode( QgsRasterFillSymbolLayer::Viewport );
 
       if ( rasterOpacity >= 0 )
@@ -344,6 +346,7 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
       if ( !spriteProperty.isEmpty() )
       {
         ddRasterProperties.setProperty( QgsSymbolLayer::PropertyFile, QgsProperty::fromExpression( spriteProperty ) );
+        ddRasterProperties.setProperty( QgsSymbolLayer::PropertyWidth, QgsProperty::fromExpression( spriteSizeProperty ) );
       }
 
       rasterFill->setDataDefinedProperties( ddRasterProperties );

--- a/src/core/vectortile/qgsmapboxglstyleconverter.h
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.h
@@ -482,7 +482,7 @@ class CORE_EXPORT QgsMapBoxGlStyleConverter
      * The \a context must have valid sprite definitions and images set via QgsMapBoxGlStyleConversionContext::setSprites()
      * prior to conversion.
      */
-    static QImage retrieveSprite( const QString &name, QgsMapBoxGlStyleConversionContext &context );
+    static QImage retrieveSprite( const QString &name, QgsMapBoxGlStyleConversionContext &context, QSize &spriteSize );
 
     /**
      * Retrieves the sprite image with the specified \a name, taken from the specified \a context as a base64 encoded value


### PR DESCRIPTION
## Description

Mapbox GL style spec supports HiDPI-friendly sprites, let us use that. This results in a converted style that's printer friendlier, and looks good on HiDPI screens (hello there QField, Input, et cie).