### PR TITLE
[QgsQuick] Added soft and hard constraints in the form

### DIFF
--- a/src/quickgui/attributes/qgsquickattributeformmodel.cpp
+++ b/src/quickgui/attributes/qgsquickattributeformmodel.cpp
@@ -23,7 +23,8 @@ QgsQuickAttributeFormModel::QgsQuickAttributeFormModel( QObject *parent )
   setSourceModel( mSourceModel );
   connect( mSourceModel, &QgsQuickAttributeFormModelBase::hasTabsChanged, this, &QgsQuickAttributeFormModel::hasTabsChanged );
   connect( mSourceModel, &QgsQuickAttributeFormModelBase::attributeModelChanged, this, &QgsQuickAttributeFormModel::attributeModelChanged );
-  connect( mSourceModel, &QgsQuickAttributeFormModelBase::constraintsValidChanged, this, &QgsQuickAttributeFormModel::constraintsValidChanged );
+  connect( mSourceModel, &QgsQuickAttributeFormModelBase::constraintsHardValidChanged, this, &QgsQuickAttributeFormModel::constraintsHardValidChanged );
+  connect( mSourceModel, &QgsQuickAttributeFormModelBase::constraintsSoftValidChanged, this, &QgsQuickAttributeFormModel::constraintsSoftValidChanged );
 }
 
 bool QgsQuickAttributeFormModel::hasTabs() const
@@ -46,9 +47,14 @@ void QgsQuickAttributeFormModel::setAttributeModel( QgsQuickAttributeModel *attr
   mSourceModel->setAttributeModel( attributeModel );
 }
 
-bool QgsQuickAttributeFormModel::constraintsValid() const
+bool QgsQuickAttributeFormModel::constraintsHardValid() const
 {
-  return mSourceModel->constraintsValid();
+  return mSourceModel->constraintsHardValid();
+}
+
+bool QgsQuickAttributeFormModel::constraintsSoftValid() const
+{
+  return mSourceModel->constraintsSoftValid();
 }
 
 void QgsQuickAttributeFormModel::save()

--- a/src/quickgui/attributes/qgsquickattributeformmodel.h
+++ b/src/quickgui/attributes/qgsquickattributeformmodel.h
@@ -49,8 +49,10 @@ class QUICK_EXPORT QgsQuickAttributeFormModel : public QSortFilterProxyModel
     //! Whether use tabs layout
     Q_PROPERTY( bool hasTabs READ hasTabs WRITE setHasTabs NOTIFY hasTabsChanged )
 
-    //! Returns TRUE if all constraints defined on fields are satisfied with the current attribute values
-    Q_PROPERTY( bool constraintsValid READ constraintsValid NOTIFY constraintsValidChanged )
+    //! Returns TRUE if all hard constraints defined on fields are satisfied with the current attribute values
+    Q_PROPERTY( bool constraintsHardValid READ constraintsHardValid NOTIFY constraintsHardValidChanged )
+    //! Returns TRUE if all soft constraints defined on fields are satisfied with the current attribute values
+    Q_PROPERTY( bool constraintsSoftValid READ constraintsSoftValid NOTIFY constraintsSoftValidChanged )
 
   public:
 
@@ -69,7 +71,8 @@ class QUICK_EXPORT QgsQuickAttributeFormModel : public QSortFilterProxyModel
       Group, //!< Group
       AttributeEditorElement, //!< Attribute editor element
       CurrentlyVisible, //!< Field visible
-      ConstraintValid, //!< Contraint valid
+      ConstraintSoftValid, //! Constraint soft valid
+      ConstraintHardValid, //! Constraint hard valid
       ConstraintDescription //!< Contraint description
     };
 
@@ -90,8 +93,11 @@ class QUICK_EXPORT QgsQuickAttributeFormModel : public QSortFilterProxyModel
     //! \copydoc QgsQuickAttributeFormModel::attributeModel
     void setAttributeModel( QgsQuickAttributeModel *attributeModel );
 
-    //! \copydoc QgsQuickAttributeFormModel::constraintsValid
-    bool constraintsValid() const;
+    //! \copydoc QgsQuickAttributeFormModel::constraintsHardValid
+    bool constraintsHardValid() const;
+
+    //! \copydoc QgsQuickAttributeFormModel::constraintsSoftValid
+    bool constraintsSoftValid() const;
 
     //! Updates QgsFeature based on changes
     Q_INVOKABLE void save();
@@ -109,8 +115,11 @@ class QUICK_EXPORT QgsQuickAttributeFormModel : public QSortFilterProxyModel
     //! \copydoc QgsQuickAttributeFormModel::hasTabs
     void hasTabsChanged();
 
-    //! \copydoc QgsQuickAttributeFormModel::constraintsValid
-    void constraintsValidChanged();
+    //! \copydoc QgsQuickAttributeFormModel::constraintsHardValid
+    void constraintsHardValidChanged();
+
+    //! \copydoc QgsQuickAttributeFormModel::constraintsSoftValid
+    void constraintsSoftValidChanged();
 
   protected:
     virtual bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;

--- a/src/quickgui/attributes/qgsquickattributeformmodelbase.cpp
+++ b/src/quickgui/attributes/qgsquickattributeformmodelbase.cpp
@@ -376,12 +376,12 @@ void QgsQuickAttributeFormModelBase::updateVisibility( int fieldIndex )
 
 bool QgsQuickAttributeFormModelBase::constraintsHardValid() const
 {
-    return mConstraintsHardValid;
+  return mConstraintsHardValid;
 }
 
 bool QgsQuickAttributeFormModelBase::constraintsSoftValid() const
 {
-    return mConstraintsSoftValid;
+  return mConstraintsSoftValid;
 }
 
 QVariant QgsQuickAttributeFormModelBase::attribute( const QString &name ) const
@@ -395,20 +395,20 @@ QVariant QgsQuickAttributeFormModelBase::attribute( const QString &name ) const
 
 void QgsQuickAttributeFormModelBase::setConstraintsHardValid( bool constraintsHardValid )
 {
-    if ( constraintsHardValid == mConstraintsHardValid )
-      return;
+  if ( constraintsHardValid == mConstraintsHardValid )
+    return;
 
-    mConstraintsHardValid = constraintsHardValid;
-    emit constraintsHardValidChanged();
+  mConstraintsHardValid = constraintsHardValid;
+  emit constraintsHardValidChanged();
 }
 
 void QgsQuickAttributeFormModelBase::setConstraintsSoftValid( bool constraintsSoftValid )
 {
-    if ( constraintsSoftValid == mConstraintsSoftValid )
-      return;
+  if ( constraintsSoftValid == mConstraintsSoftValid )
+    return;
 
-    mConstraintsSoftValid = constraintsSoftValid;
-    emit constraintsSoftValidChanged();
+  mConstraintsSoftValid = constraintsSoftValid;
+  emit constraintsSoftValidChanged();
 }
 
 bool QgsQuickAttributeFormModelBase::hasTabs() const

--- a/src/quickgui/attributes/qgsquickattributeformmodelbase.h
+++ b/src/quickgui/attributes/qgsquickattributeformmodelbase.h
@@ -56,8 +56,10 @@ class QgsQuickAttributeFormModelBase : public QStandardItemModel
     //! Whether use tabs layout
     Q_PROPERTY( bool hasTabs READ hasTabs WRITE setHasTabs NOTIFY hasTabsChanged )
 
-    //! Returns TRUE if all constraints defined on fields are satisfied with the current attribute values
-    Q_PROPERTY( bool constraintsValid READ constraintsValid NOTIFY constraintsValidChanged )
+    //! Returns TRUE if all hard constraints defined on fields are satisfied with the current attribute values
+    Q_PROPERTY( bool constraintsHardValid READ constraintsHardValid NOTIFY constraintsHardValidChanged )
+    //! Returns TRUE if all soft constraints defined on fields are satisfied with the current attribute values
+    Q_PROPERTY( bool constraintsSoftValid READ constraintsSoftValid NOTIFY constraintsSoftValidChanged )
 
   public:
     //! Constructor
@@ -83,8 +85,11 @@ class QgsQuickAttributeFormModelBase : public QStandardItemModel
     //! Creates a new feature
     void create();
 
-    //! \copydoc QgsQuickAttributeFormModelBase::constraintsValid
-    bool constraintsValid() const;
+    //! \copydoc QgsQuickAttributeFormModelBase::constraintsHardValid
+    bool constraintsHardValid() const;
+
+    //! \copydoc QgsQuickAttributeFormModelBase::constraintsSoftValid
+    bool constraintsSoftValid() const;
 
     /**
      * Gets the value of attribute of the feature in the model
@@ -93,13 +98,21 @@ class QgsQuickAttributeFormModelBase : public QStandardItemModel
      */
     QVariant attribute( const QString &name ) const;
 
+    //! \copydoc QgsQuickAttributeFormModelBase::constraintsHardValid
+    void setConstraintsHardValid( bool constraintsHardValid );
+
+    //! \copydoc QgsQuickAttributeFormModelBase::constraintsSoftValid
+    void setConstraintsSoftValid( bool constraintsSoftValid );
+
   signals:
     //! \copydoc QgsQuickAttributeFormModelBase::attributeModel
     void attributeModelChanged();
     //! \copydoc QgsQuickAttributeFormModelBase::hasTabs
     void hasTabsChanged();
-    //! \copydoc QgsQuickAttributeFormModelBase::constraintsValid
-    void constraintsValidChanged();
+    //! \copydoc QgsQuickAttributeFormModelBase::constraintsHardValid
+    void constraintsHardValidChanged();
+    //! \copydoc QgsQuickAttributeFormModelBase::constraintsSoftValid
+    void constraintsSoftValidChanged();
 
   private slots:
     void onFeatureChanged();
@@ -112,7 +125,6 @@ class QgsQuickAttributeFormModelBase : public QStandardItemModel
     void updateAttributeValue( QStandardItem *item );
     void flatten( QgsAttributeEditorContainer *container, QStandardItem *parent, const QString &parentVisibilityExpressions, QVector<QStandardItem *> &items );
     void updateVisibility( int fieldIndex = -1 );
-    void setConstraintsValid( bool constraintsValid );
 
     QgsQuickAttributeModel *mAttributeModel = nullptr; // not owned
     QgsVectorLayer *mLayer = nullptr; // not owned
@@ -121,10 +133,11 @@ class QgsQuickAttributeFormModelBase : public QStandardItemModel
 
     typedef QPair<QgsExpression, QVector<QStandardItem *> > VisibilityExpression;
     QList<VisibilityExpression> mVisibilityExpressions;
-    QMap<QStandardItem *, QgsExpression> mConstraints;
+    QMap<QStandardItem *, QgsFieldConstraints> mConstraints;
 
     QgsExpressionContext mExpressionContext;
-    bool mConstraintsValid = false;
+    bool mConstraintsHardValid = false;
+    bool mConstraintsSoftValid = false;
 };
 
 /// @endcond

--- a/src/quickgui/plugin/qgsquickfeatureform.qml
+++ b/src/quickgui/plugin/qgsquickfeatureform.qml
@@ -144,6 +144,16 @@ Item {
   }
 
   function save() {
+    if ( !model.constraintsHardValid )
+    {
+      console.log( qsTr( 'Constraints not valid') )
+      return
+    }
+    else if ( !model.constraintsSoftValid )
+    {
+      console.log( qsTr( 'Note: soft constraints were not met') )
+    }
+
     parent.focus = true
     if ( form.state === "Add" ) {
       model.create()
@@ -356,7 +366,7 @@ Item {
 
         text: qsTr(Name) || ''
         font.bold: true
-        color: ConstraintValid ? form.style.constraint.validColor : form.style.constraint.invalidColor
+        color: ConstraintSoftValid && ConstraintHardValid ? form.style.constraint.validColor : form.style.constraint.invalidColor
       }
 
       Label {
@@ -368,8 +378,8 @@ Item {
         }
 
         text: qsTr(ConstraintDescription)
-        height: ConstraintValid ? 0 : undefined
-        visible: !ConstraintValid
+        visible: !ConstraintHardValid || !ConstraintSoftValid
+        height:  visible ? 0 : undefined
 
         color: form.style.constraint.descriptionColor
       }
@@ -389,7 +399,10 @@ Item {
           property var config: EditorWidgetConfig
           property var widget: EditorWidget
           property var field: Field
-          property var constraintValid: ConstraintValid
+          property var constraintHardValid: ConstraintHardValid
+          property var constraintSoftValid: ConstraintSoftValid
+          property bool constraintsHardValid: form.model.constraintsHardValid
+          property bool constraintsSoftValid: form.model.constraintsSoftValid
           property var homePath: form.project ? form.project.homePath : ""
           property var customStyle: form.style
           property var externalResourceHandler: form.externalResourceHandler
@@ -481,10 +494,10 @@ Item {
         }
 
         background: Rectangle {
-          color: model.constraintsValid ? form.style.toolbutton.backgroundColor : form.style.toolbutton.backgroundColorInvalid
+          color: model.constraintsSoftValid && model.constraintsHardValid ? form.style.toolbutton.backgroundColor : form.style.toolbutton.backgroundColorInvalid
         }
 
-        enabled: model.constraintsValid
+        enabled: model.constraintsHardValid
 
         onClicked: {
           form.save()

--- a/src/quickgui/plugin/qgsquickfeatureform.qml
+++ b/src/quickgui/plugin/qgsquickfeatureform.qml
@@ -379,8 +379,8 @@ Item {
 
         text: qsTr(ConstraintDescription)
         visible: !ConstraintHardValid || !ConstraintSoftValid
-        height:  visible ? 0 : undefined
-
+        height: visible ? undefined : 0
+        wrapMode: Text.WordWrap
         color: form.style.constraint.descriptionColor
       }
 


### PR DESCRIPTION
In the current version of QgsQuick forms, soft and hard constraints are not distinguished and used only for a form styling.
If any hard constrain is not met, the form cannot be saved. An unmet soft constrain should only notify a user.

TODO: Notify user about unmet constraints with more than coloured label.