### PR TITLE
Vector tile style conversions: further refinements

### DIFF
--- a/python/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
+++ b/python/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
@@ -122,6 +122,20 @@ Sets the sprite ``image`` and ``definitions`` JSON string to use during conversi
 .. seealso:: :py:func:`spriteDefinitions`
 %End
 
+    QString layerId() const;
+%Docstring
+Returns the layer ID of the layer currently being converted.
+
+.. seealso:: :py:func:`setLayerId`
+%End
+
+    void setLayerId( const QString &value );
+%Docstring
+Sets the layer ID of the layer currently being converted.
+
+.. seealso:: :py:func:`layerId`
+%End
+
 };
 
 class QgsMapBoxGlStyleConverter

--- a/python/core/auto_generated/vectortile/qgsvectortilelayer.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilelayer.sip.in
@@ -100,6 +100,8 @@ Constructs a new vector tile layer
 
     virtual QString loadDefaultStyle( bool &resultFlag /Out/ );
 
+
+
     virtual QString loadDefaultMetadata( bool &resultFlag /Out/ );
 
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2089,7 +2089,7 @@ void QgisApp::handleDropUriList( const QgsMimeDataUtils::UriList &lst )
       bool res = layer->loadDefaultStyle( error, warnings );
       if ( res && !warnings.empty() )
       {
-        QString message = QStringLiteral( "<p>%1</p>" ).arg( tr( "The following warnings were generated while converting the LYR file:" ) );
+        QString message = QStringLiteral( "<p>%1</p>" ).arg( tr( "The following warnings were generated while converting the vector tile style:" ) );
         message += QStringLiteral( "<ul>" );
 
         std::sort( warnings.begin(), warnings.end() );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2078,6 +2078,8 @@ void QgisApp::handleDropUriList( const QgsMimeDataUtils::UriList &lst )
     }
     else if ( u.layerType == QLatin1String( "vector-tile" ) )
     {
+      QgsTemporaryCursorOverride busyCursor( Qt::WaitCursor );
+
       QgsVectorTileLayer *layer = new QgsVectorTileLayer( uri, u.name );
       bool ok = false;
       layer->loadDefaultMetadata( ok );

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -1744,7 +1744,7 @@ QString QgsMapBoxGlStyleConverter::parsePointStops( double base, const QVariantL
     // bottom zoom and value
     const QVariant bz = stops.value( i ).toList().value( 0 );
     const QVariant bv = stops.value( i ).toList().value( 1 );
-    if ( bz.type() != QVariant::List && bz.type() != QVariant::StringList )
+    if ( bv.type() != QVariant::List && bv.type() != QVariant::StringList )
     {
       context.pushWarning( QObject::tr( "%1: Skipping unsupported offset interpolation type (%2)." ).arg( context.layerId(), QMetaType::typeName( bz.type() ) ) );
       return QString();
@@ -1753,7 +1753,7 @@ QString QgsMapBoxGlStyleConverter::parsePointStops( double base, const QVariantL
     // top zoom and value
     const QVariant tz = stops.value( i + 1 ).toList().value( 0 );
     const QVariant tv = stops.value( i + 1 ).toList().value( 1 );
-    if ( tz.type() != QVariant::List && tz.type() != QVariant::StringList )
+    if ( tv.type() != QVariant::List && tv.type() != QVariant::StringList )
     {
       context.pushWarning( QObject::tr( "%1: Skipping unsupported offset interpolation type (%2)." ).arg( context.layerId(), QMetaType::typeName( tz.type() ) ) );
       return QString();

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -83,6 +83,7 @@ void QgsMapBoxGlStyleConverter::parseLayers( const QVariantList &layers, QgsMapB
       continue;
 
     const QString styleId = jsonLayer.value( QStringLiteral( "id" ) ).toString();
+    context->setLayerId( styleId );
     const QString layerName = jsonLayer.value( QStringLiteral( "source-layer" ) ).toString();
 
     const int minZoom = jsonLayer.value( QStringLiteral( "minzoom" ), QStringLiteral( "-1" ) ).toInt();
@@ -159,7 +160,7 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
 {
   if ( !jsonLayer.contains( QStringLiteral( "paint" ) ) )
   {
-    context.pushWarning( QObject::tr( "Style layer %1 has no paint property, skipping" ).arg( jsonLayer.value( QStringLiteral( "id" ) ).toString() ) );
+    context.pushWarning( QObject::tr( "%1: Layer has no paint property, skipping" ).arg( jsonLayer.value( QStringLiteral( "id" ) ).toString() ) );
     return false;
   }
 
@@ -190,7 +191,7 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
 
       default:
       {
-        context.pushWarning( QObject::tr( "Skipping non-implemented color expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported fill-color type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonFillColor.type() ) ) );
         break;
       }
     }
@@ -233,7 +234,7 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
         break;
 
       default:
-        context.pushWarning( QObject::tr( "Skipping non-implemented color expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported fill-outline-color type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonFillOutlineColor.type() ) ) );
         break;
     }
   }
@@ -254,7 +255,7 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
       case QVariant::Map:
         if ( ddProperties.isActive( QgsSymbolLayer::PropertyFillColor ) )
         {
-          context.pushWarning( QObject::tr( "Could not set opacity of layer %1, opacity already defined in fill color" ).arg( jsonLayer.value( QStringLiteral( "id" ) ).toString() ) );
+          context.pushWarning( QObject::tr( "%1: Could not set opacity of layer, opacity already defined in fill color" ).arg( context.layerId() ) );
         }
         else
         {
@@ -268,7 +269,7 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
       case QVariant::StringList:
         if ( ddProperties.isActive( QgsSymbolLayer::PropertyFillColor ) )
         {
-          context.pushWarning( QObject::tr( "Could not set opacity of layer %1, opacity already defined in fill color" ).arg( jsonLayer.value( QStringLiteral( "id" ) ).toString() ) );
+          context.pushWarning( QObject::tr( "%1: Could not set opacity of layer, opacity already defined in fill color" ).arg( context.layerId() ) );
         }
         else
         {
@@ -279,7 +280,7 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
         break;
 
       default:
-        context.pushWarning( QObject::tr( "Skipping non-implemented opacity expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported fill-opacity type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonFillOpacity.type() ) ) );
         break;
     }
   }
@@ -303,7 +304,7 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
         break;
 
       default:
-        context.pushWarning( QObject::tr( "Skipping non-implemented fill-translate expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported fill-translate type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonFillTranslate.type() ) ) );
         break;
     }
   }
@@ -397,7 +398,7 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
 {
   if ( !jsonLayer.contains( QStringLiteral( "paint" ) ) )
   {
-    context.pushWarning( QObject::tr( "Style layer %1 has no paint property, skipping" ).arg( jsonLayer.value( QStringLiteral( "id" ) ).toString() ) );
+    context.pushWarning( QObject::tr( "%1: Style has no paint property, skipping" ).arg( context.layerId() ) );
     return false;
   }
 
@@ -428,7 +429,7 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
         break;
 
       default:
-        context.pushWarning( QObject::tr( "Skipping non-implemented color expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported line-color type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonLineColor.type() ) ) );
         break;
     }
   }
@@ -461,7 +462,7 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
         break;
 
       default:
-        context.pushWarning( QObject::tr( "Skipping non-implemented line-width expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported fill-width type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonLineWidth.type() ) ) );
         break;
     }
   }
@@ -488,7 +489,7 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
         break;
 
       default:
-        context.pushWarning( QObject::tr( "Skipping non-implemented line-offset expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported line-offset type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonLineOffset.type() ) ) );
         break;
     }
   }
@@ -507,7 +508,7 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
       case QVariant::Map:
         if ( ddProperties.isActive( QgsSymbolLayer::PropertyStrokeColor ) )
         {
-          context.pushWarning( QObject::tr( "Could not set opacity of layer %1, opacity already defined in stroke color" ).arg( jsonLayer.value( QStringLiteral( "id" ) ).toString() ) );
+          context.pushWarning( QObject::tr( "%1: Could not set opacity of layer, opacity already defined in stroke color" ).arg( context.layerId() ) );
         }
         else
         {
@@ -519,7 +520,7 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
       case QVariant::StringList:
         if ( ddProperties.isActive( QgsSymbolLayer::PropertyStrokeColor ) )
         {
-          context.pushWarning( QObject::tr( "Could not set opacity of layer %1, opacity already defined in stroke color" ).arg( jsonLayer.value( QStringLiteral( "id" ) ).toString() ) );
+          context.pushWarning( QObject::tr( "%1: Could not set opacity of layer, opacity already defined in stroke color" ).arg( context.layerId() ) );
         }
         else
         {
@@ -528,7 +529,7 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
         break;
 
       default:
-        context.pushWarning( QObject::tr( "Skipping non-implemented opacity expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported line-opacity type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonLineOpacity.type() ) ) );
         break;
     }
   }
@@ -562,7 +563,7 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
       }
 
       default:
-        context.pushWarning( QObject::tr( "Skipping non-implemented dash vector expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported line-dasharray type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonLineDashArray.type() ) ) );
         break;
     }
   }
@@ -624,7 +625,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
 
   if ( !jsonLayer.contains( QStringLiteral( "layout" ) ) )
   {
-    context.pushWarning( QObject::tr( "Style layer %1 has no layout property, skipping" ).arg( jsonLayer.value( QStringLiteral( "id" ) ).toString() ) );
+    context.pushWarning( QObject::tr( "%1: Style layer has no layout property, skipping" ).arg( context.layerId() ) );
     return;
   }
   const QVariantMap jsonLayout = jsonLayer.value( QStringLiteral( "layout" ) ).toMap();
@@ -636,7 +637,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
 
   if ( !jsonLayer.contains( QStringLiteral( "paint" ) ) )
   {
-    context.pushWarning( QObject::tr( "Style layer %1 has no paint property, skipping" ).arg( jsonLayer.value( QStringLiteral( "id" ) ).toString() ) );
+    context.pushWarning( QObject::tr( "%1: Style layer has no paint property, skipping" ).arg( context.layerId() ) );
     return;
   }
   const QVariantMap jsonPaint = jsonLayer.value( QStringLiteral( "paint" ) ).toMap();
@@ -668,7 +669,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
         break;
 
       default:
-        context.pushWarning( QObject::tr( "Skipping non-implemented text-size expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported text-size type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonTextSize.type() ) ) );
         break;
     }
 
@@ -702,7 +703,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
         break;
 
       default:
-        context.pushWarning( QObject::tr( "Skipping non-implemented text-max-width expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported text-max-width type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonTextMaxWidth.type() ) ) );
         break;
     }
   }
@@ -733,23 +734,23 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
         break;
 
       default:
-        context.pushWarning( QObject::tr( "Skipping non-implemented text-letter-spacing expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported text-letter-spacing type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonTextLetterSpacing.type() ) ) );
         break;
     }
   }
 
   QFont textFont;
   bool foundFont = false;
+  QString fontName;
   if ( jsonLayout.contains( QStringLiteral( "text-font" ) ) )
   {
     const QVariant jsonTextFont = jsonLayout.value( QStringLiteral( "text-font" ) );
     if ( jsonTextFont.type() != QVariant::List && jsonTextFont.type() != QVariant::StringList && jsonTextFont.type() != QVariant::String )
     {
-      context.pushWarning( QObject::tr( "Skipping non-implemented text-font expression" ) );
+      context.pushWarning( QObject::tr( "%1: Skipping unsupported text-font type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonTextFont.type() ) ) );
     }
     else
     {
-      QString fontName;
       switch ( jsonTextFont.type() )
       {
         case QVariant::List:
@@ -779,9 +780,9 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
         }
       }
 
-      if ( !foundFont )
+      if ( !foundFont && QgsFontUtils::fontFamilyOnSystem( fontName ) )
       {
-        // probably won't work, but we'll try anyway... maybe the json isn't following the spec correctly!!
+        // the json isn't following the spec correctly!!
         textFont = QFont( fontName );
         foundFont = true;
       }
@@ -792,16 +793,26 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
     // Defaults to ["Open Sans Regular","Arial Unicode MS Regular"].
     if ( QgsFontUtils::fontFamilyHasStyle( QStringLiteral( "Open Sans" ), QStringLiteral( "Regular" ) ) )
     {
-      textFont = QFont( QStringLiteral( "Open Sans" ) );
+      fontName = QStringLiteral( "Open Sans" );
+      textFont = QFont( fontName );
       textFont.setStyleName( QStringLiteral( "Regular" ) );
       foundFont = true;
     }
     else if ( QgsFontUtils::fontFamilyHasStyle( QStringLiteral( "Arial Unicode MS" ), QStringLiteral( "Regular" ) ) )
     {
-      textFont = QFont( QStringLiteral( "Arial Unicode MS" ) );
+      fontName = QStringLiteral( "Arial Unicode MS" );
+      textFont = QFont( fontName );
       textFont.setStyleName( QStringLiteral( "Regular" ) );
       foundFont = true;
     }
+    else
+    {
+      fontName = QStringLiteral( "Open Sans, Arial Unicode MS" );
+    }
+  }
+  if ( !foundFont )
+  {
+    context.pushWarning( QObject::tr( "%1: Referenced font %2 is not available on system" ).arg( context.layerId(), fontName ) );
   }
 
   // text color
@@ -825,7 +836,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
         break;
 
       default:
-        context.pushWarning( QObject::tr( "Skipping non-implemented text-color expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported text-color type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonTextColor.type() ) ) );
         break;
     }
   }
@@ -856,7 +867,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
         break;
 
       default:
-        context.pushWarning( QObject::tr( "Skipping non-implemented text-halo-color expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported text-halo-color type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonBufferColor.type() ) ) );
         break;
     }
   }
@@ -888,7 +899,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
         break;
 
       default:
-        context.pushWarning( QObject::tr( "Skipping non-implemented text-halo-width expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported text-halo-width type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonHaloWidth.type() ) ) );
         break;
     }
   }
@@ -907,7 +918,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
       }
 
       default:
-        context.pushWarning( QObject::tr( "Skipping non-implemented text-halo-width expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported text-halo-blur type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonTextHaloBlur.type() ) ) );
         break;
     }
   }
@@ -1048,7 +1059,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
       }
 
       default:
-        context.pushWarning( QObject::tr( "Skipping non-implemented text-field expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported text-field type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonTextField.type() ) ) );
         break;
     }
   }
@@ -1118,7 +1129,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
               break;
 
             default:
-              context.pushWarning( QObject::tr( "Skipping non-implemented text-offset expression" ) );
+              context.pushWarning( QObject::tr( "%1: Skipping unsupported text-offset type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonTextOffset.type() ) ) );
               break;
           }
 
@@ -1172,7 +1183,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
         break;
 
       default:
-        context.pushWarning( QObject::tr( "Skipping non-implemented text-anchor expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported text-justify type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonTextJustify.type() ) ) );
         break;
     }
 
@@ -1225,7 +1236,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
           break;
 
         default:
-          context.pushWarning( QObject::tr( "Skipping non-implemented text-anchor expression" ) );
+          context.pushWarning( QObject::tr( "%1: Skipping unsupported text-anchor type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonTextAnchor.type() ) ) );
           break;
       }
 
@@ -1268,7 +1279,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
           break;
 
         default:
-          context.pushWarning( QObject::tr( "Skipping non-implemented fill-translate expression" ) );
+          context.pushWarning( QObject::tr( "%1: Skipping unsupported text-offset type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonTextOffset.type() ) ) );
           break;
       }
 
@@ -1339,7 +1350,7 @@ bool QgsMapBoxGlStyleConverter::parseSymbolLayerAsRenderer( const QVariantMap &j
 {
   if ( !jsonLayer.contains( QStringLiteral( "layout" ) ) )
   {
-    context.pushWarning( QObject::tr( "Style layer %1 has no layout property, skipping" ).arg( jsonLayer.value( QStringLiteral( "id" ) ).toString() ) );
+    context.pushWarning( QObject::tr( "%1: Style layer has no layout property, skipping" ).arg( context.layerId() ) );
     return false;
   }
   const QVariantMap jsonLayout = jsonLayer.value( QStringLiteral( "layout" ) ).toMap();
@@ -1369,7 +1380,7 @@ bool QgsMapBoxGlStyleConverter::parseSymbolLayerAsRenderer( const QVariantMap &j
           break;
 
         default:
-          context.pushWarning( QObject::tr( "Skipping non-implemented symbol-spacing expression" ) );
+          context.pushWarning( QObject::tr( "%1: Skipping unsupported symbol-spacing type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonSpacing.type() ) ) );
           break;
       }
     }
@@ -1415,7 +1426,7 @@ bool QgsMapBoxGlStyleConverter::parseSymbolLayerAsRenderer( const QVariantMap &j
           break;
 
         default:
-          context.pushWarning( QObject::tr( "Skipping non-implemented icon-rotate expression" ) );
+          context.pushWarning( QObject::tr( "%1: Skipping unsupported icon-rotate type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonIconRotate.type() ) ) );
           break;
       }
     }
@@ -1502,7 +1513,7 @@ bool QgsMapBoxGlStyleConverter::parseSymbolLayerAsRenderer( const QVariantMap &j
             break;
 
           default:
-            context.pushWarning( QObject::tr( "Skipping non-implemented icon-rotate expression" ) );
+            context.pushWarning( QObject::tr( "%1: Skipping unsupported icon-rotate type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonIconRotate.type() ) ) );
             break;
         }
       }
@@ -1528,7 +1539,7 @@ bool QgsMapBoxGlStyleConverter::parseSymbolLayerAsRenderer( const QVariantMap &j
             break;
 
           default:
-            context.pushWarning( QObject::tr( "Skipping non-implemented icon-opacity expression" ) );
+            context.pushWarning( QObject::tr( "%1: Skipping unsupported icon-opacity type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonIconOpacity.type() ) ) );
             break;
         }
       }
@@ -1735,7 +1746,7 @@ QString QgsMapBoxGlStyleConverter::parsePointStops( double base, const QVariantL
     const QVariant bv = stops.value( i ).toList().value( 1 );
     if ( bz.type() != QVariant::List && bz.type() != QVariant::StringList )
     {
-      context.pushWarning( QObject::tr( "Could not convert offset interpolation, skipping." ) );
+      context.pushWarning( QObject::tr( "%1: Could not convert offset interpolation, skipping." ).arg( context.layerId() ) );
       return QString();
     }
 
@@ -1744,7 +1755,7 @@ QString QgsMapBoxGlStyleConverter::parsePointStops( double base, const QVariantL
     const QVariant tv = stops.value( i + 1 ).toList().value( 1 );
     if ( tz.type() != QVariant::List && tz.type() != QVariant::StringList )
     {
-      context.pushWarning( QObject::tr( "Could not convert offset interpolation, skipping." ) );
+      context.pushWarning( QObject::tr( "%1: Could not convert offset interpolation, skipping." ).arg( context.layerId() ) );
       return QString();
     }
 
@@ -1769,7 +1780,7 @@ QString QgsMapBoxGlStyleConverter::parseStops( double base, const QVariantList &
     const QVariant bv = stops.value( i ).toList().value( 1 );
     if ( bz.type() == QVariant::List || bz.type() == QVariant::StringList )
     {
-      context.pushWarning( QObject::tr( "QGIS does not support expressions in interpolation function, skipping." ) );
+      context.pushWarning( QObject::tr( "%1: Expressions in interpolation function are not supported, skipping." ).arg( context.layerId() ) );
       return QString();
     }
 
@@ -1778,7 +1789,7 @@ QString QgsMapBoxGlStyleConverter::parseStops( double base, const QVariantList &
     const QVariant tv = stops.value( i + 1 ).toList().value( 1 );
     if ( tz.type() == QVariant::List || tz.type() == QVariant::StringList )
     {
-      context.pushWarning( QObject::tr( "QGIS does not support expressions in interpolation function, skipping." ) );
+      context.pushWarning( QObject::tr( "%1: Expressions in interpolation function are not supported, skipping." ).arg( context.layerId() ) );
       return QString();
     }
 
@@ -1806,7 +1817,7 @@ QString QgsMapBoxGlStyleConverter::parseStringStops( const QVariantList &stops, 
     const QString bv = stops.value( i ).toList().value( 1 ).toString();
     if ( bz.type() == QVariant::List || bz.type() == QVariant::StringList )
     {
-      context.pushWarning( QObject::tr( "QGIS does not support expressions in interpolation function, skipping." ) );
+      context.pushWarning( QObject::tr( "%1: Expressions in interpolation function are not supported, skipping." ).arg( context.layerId() ) );
       return QString();
     }
 
@@ -1814,7 +1825,7 @@ QString QgsMapBoxGlStyleConverter::parseStringStops( const QVariantList &stops, 
     const QVariant tz = stops.value( i + 1 ).toList().value( 0 );
     if ( tz.type() == QVariant::List || tz.type() == QVariant::StringList )
     {
-      context.pushWarning( QObject::tr( "QGIS does not support expressions in interpolation function, skipping." ) );
+      context.pushWarning( QObject::tr( "%1: Expressions in interpolation function are not supported, skipping." ).arg( context.layerId() ) );
       return QString();
     }
 
@@ -1843,7 +1854,7 @@ QgsProperty QgsMapBoxGlStyleConverter::parseValueList( const QVariantList &json,
   }
   else
   {
-    context.pushWarning( QObject::tr( "Could not interpret value list with method %1" ).arg( method ) );
+    context.pushWarning( QObject::tr( "%1: Could not interpret value list with method %2" ).arg( context.layerId(), method ) );
     return QgsProperty();
   }
 }
@@ -1853,7 +1864,7 @@ QgsProperty QgsMapBoxGlStyleConverter::parseMatchList( const QVariantList &json,
   const QString attribute = parseExpression( json.value( 1 ).toList(), context );
   if ( attribute.isEmpty() )
   {
-    context.pushWarning( QObject::tr( "Could not interpret match list" ) );
+    context.pushWarning( QObject::tr( "%1: Could not interpret match list" ).arg( context.layerId() ) );
     return QgsProperty();
   }
 
@@ -1957,7 +1968,7 @@ QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateListByZoom( const QVarian
 {
   if ( json.value( 0 ).toString() != QLatin1String( "interpolate" ) )
   {
-    context.pushWarning( QObject::tr( "Could not interpret value list" ) );
+    context.pushWarning( QObject::tr( "%1: Could not interpret value list" ).arg( context.layerId() ) );
     return QgsProperty();
   }
 
@@ -1969,18 +1980,18 @@ QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateListByZoom( const QVarian
     base = json.value( 1 ).toList(). value( 1 ).toDouble();
   else if ( technique == QLatin1String( "cubic-bezier" ) )
   {
-    context.pushWarning( QObject::tr( "QGIS does not support cubic-bezier interpolation, linear used instead." ) );
+    context.pushWarning( QObject::tr( "%1: Cubic-bezier interpolation is not supported, linear used instead." ).arg( context.layerId() ) );
     base = 1;
   }
   else
   {
-    context.pushWarning( QObject::tr( "Skipping not implemented interpolation method %1" ).arg( technique ) );
+    context.pushWarning( QObject::tr( "%1: Skipping not implemented interpolation method %2" ).arg( context.layerId(), technique ) );
     return QgsProperty();
   }
 
   if ( json.value( 2 ).toList().value( 0 ).toString() != QLatin1String( "zoom" ) )
   {
-    context.pushWarning( QObject::tr( "Skipping not implemented interpolation input %1" ).arg( json.value( 2 ).toString() ) );
+    context.pushWarning( QObject::tr( "%1: Skipping not implemented interpolation input %2" ).arg( context.layerId(), json.value( 2 ).toString() ) );
     return QgsProperty();
   }
 
@@ -2015,7 +2026,7 @@ QColor QgsMapBoxGlStyleConverter::parseColor( const QVariant &color, QgsMapBoxGl
 {
   if ( color.type() != QVariant::String )
   {
-    context.pushWarning( QObject::tr( "Could not parse non-string color %1, skipping" ).arg( color.toString() ) );
+    context.pushWarning( QObject::tr( "%1: Could not parse non-string color %2, skipping" ).arg( context.layerId(), color.toString() ) );
     return QColor();
   }
 
@@ -2092,7 +2103,7 @@ QString QgsMapBoxGlStyleConverter::parseExpression( const QVariantList &expressi
       QString part = parseValue( expression.at( i ), context );
       if ( part.isEmpty() )
       {
-        context.pushWarning( QObject::tr( "Skipping unsupported expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported expression" ).arg( context.layerId() ) );
         return QString();
       }
       parts << part;
@@ -2149,7 +2160,7 @@ QString QgsMapBoxGlStyleConverter::parseExpression( const QVariantList &expressi
       QString part = parseValue( expression.at( i ), context );
       if ( part.isEmpty() )
       {
-        context.pushWarning( QObject::tr( "Skipping unsupported expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported expression" ).arg( context.layerId() ) );
         return QString();
       }
       parts << part;
@@ -2192,7 +2203,7 @@ QString QgsMapBoxGlStyleConverter::parseExpression( const QVariantList &expressi
       }
       else
       {
-        context.pushWarning( QObject::tr( "Skipping non-supported expression" ) );
+        context.pushWarning( QObject::tr( "%1: Skipping non-supported expression" ).arg( context.layerId() ) );
         return QString();
       }
     }
@@ -2232,7 +2243,7 @@ QString QgsMapBoxGlStyleConverter::parseExpression( const QVariantList &expressi
   }
   else
   {
-    context.pushWarning( QObject::tr( "Skipping non-supported expression" ) );
+    context.pushWarning( QObject::tr( "%1: Skipping non-supported expression" ).arg( context.layerId() ) );
     return QString();
   }
 }
@@ -2241,14 +2252,14 @@ QImage QgsMapBoxGlStyleConverter::retrieveSprite( const QString &name, QgsMapBox
 {
   if ( context.spriteImage().isNull() )
   {
-    context.pushWarning( QObject::tr( "Could not retrieve sprite '%1'" ).arg( name ) );
+    context.pushWarning( QObject::tr( "%1: Could not retrieve sprite '%2'" ).arg( context.layerId(), name ) );
     return QImage();
   }
 
   const QVariantMap spriteDefinition = context.spriteDefinitions().value( name ).toMap();
   if ( spriteDefinition.size() == 0 )
   {
-    context.pushWarning( QObject::tr( "Could not retrieve sprite '%1'" ).arg( name ) );
+    context.pushWarning( QObject::tr( "%1: Could not retrieve sprite '%2'" ).arg( context.layerId(), name ) );
     return QImage();
   }
 
@@ -2258,7 +2269,7 @@ QImage QgsMapBoxGlStyleConverter::retrieveSprite( const QString &name, QgsMapBox
                         spriteDefinition.value( QStringLiteral( "height" ) ).toInt() );
   if ( sprite.isNull() )
   {
-    context.pushWarning( QObject::tr( "Could not retrieve sprite '%1'" ).arg( name ) );
+    context.pushWarning( QObject::tr( "%1: Could not retrieve sprite '%2'" ).arg( context.layerId(), name ) );
     return QImage();
   }
 
@@ -2393,7 +2404,7 @@ QString QgsMapBoxGlStyleConverter::retrieveSpriteAsBase64( const QVariant &value
     }
 
     default:
-      context.pushWarning( QObject::tr( "Skipping unsupported sprite part" ) );
+      context.pushWarning( QObject::tr( "%1: Skipping unsupported sprite part" ).arg( context.layerId() ) );
       break;
   }
 
@@ -2416,7 +2427,7 @@ QString QgsMapBoxGlStyleConverter::parseValue( const QVariant &value, QgsMapBoxG
       return value.toString();
 
     default:
-      context.pushWarning( QObject::tr( "Skipping unsupported expression part" ) );
+      context.pushWarning( QObject::tr( "%1: Skipping unsupported expression part" ).arg( context.layerId() ) );
       break;
   }
   return QString();
@@ -2494,4 +2505,14 @@ void QgsMapBoxGlStyleConversionContext::setSprites( const QImage &image, const Q
 void QgsMapBoxGlStyleConversionContext::setSprites( const QImage &image, const QString &definitions )
 {
   setSprites( image, QgsJsonUtils::parseJson( definitions ).toMap() );
+}
+
+QString QgsMapBoxGlStyleConversionContext::layerId() const
+{
+  return mLayerId;
+}
+
+void QgsMapBoxGlStyleConversionContext::setLayerId( const QString &value )
+{
+  mLayerId = value;
 }

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -1746,7 +1746,7 @@ QString QgsMapBoxGlStyleConverter::parsePointStops( double base, const QVariantL
     const QVariant bv = stops.value( i ).toList().value( 1 );
     if ( bz.type() != QVariant::List && bz.type() != QVariant::StringList )
     {
-      context.pushWarning( QObject::tr( "%1: Could not convert offset interpolation, skipping." ).arg( context.layerId() ) );
+      context.pushWarning( QObject::tr( "%1: Skipping unsupported offset interpolation type (%2)." ).arg( context.layerId(), QMetaType::typeName( bz.type() ) ) );
       return QString();
     }
 
@@ -1755,7 +1755,7 @@ QString QgsMapBoxGlStyleConverter::parsePointStops( double base, const QVariantL
     const QVariant tv = stops.value( i + 1 ).toList().value( 1 );
     if ( tz.type() != QVariant::List && tz.type() != QVariant::StringList )
     {
-      context.pushWarning( QObject::tr( "%1: Could not convert offset interpolation, skipping." ).arg( context.layerId() ) );
+      context.pushWarning( QObject::tr( "%1: Skipping unsupported offset interpolation type (%2)." ).arg( context.layerId(), QMetaType::typeName( tz.type() ) ) );
       return QString();
     }
 

--- a/src/core/vectortile/qgsmapboxglstyleconverter.h
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.h
@@ -129,9 +129,25 @@ class CORE_EXPORT QgsMapBoxGlStyleConversionContext
      */
     void setSprites( const QImage &image, const QString &definitions );
 
+    /**
+     * Returns the layer ID of the layer currently being converted.
+     *
+     * \see setLayerId()
+     */
+    QString layerId() const;
+
+    /**
+     * Sets the layer ID of the layer currently being converted.
+     *
+     * \see layerId()
+     */
+    void setLayerId( const QString &value );
+
   private:
 
     QStringList mWarnings;
+
+    QString mLayerId;
 
     QgsUnitTypes::RenderUnit mTargetUnit = QgsUnitTypes::RenderPixels;
 

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -107,6 +107,20 @@ class CORE_EXPORT QgsVectorTileLayer : public QgsMapLayer
 
     void setTransformContext( const QgsCoordinateTransformContext &transformContext ) override;
     QString loadDefaultStyle( bool &resultFlag SIP_OUT ) override;
+
+    /**
+     * Loads the default style for the layer, and returns TRUE if the style was
+     * sucessfully loaded.
+     *
+     * The \a error string will be filled with a translated error message if an error
+     * occurs during the style load. The \a warnings list will be populated with any
+     * warning messages generated during the style load (e.g. default style properties
+     * which could not be converted).
+     *
+     * \since QGIS 3.16
+     */
+    bool loadDefaultStyle( QString &error, QStringList &warnings ) SIP_SKIP;
+
     QString loadDefaultMetadata( bool &resultFlag SIP_OUT ) override;
 
     QString encodedSource( const QString &source, const QgsReadWriteContext &context ) const FINAL;

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -110,7 +110,7 @@ class CORE_EXPORT QgsVectorTileLayer : public QgsMapLayer
 
     /**
      * Loads the default style for the layer, and returns TRUE if the style was
-     * sucessfully loaded.
+     * successfully loaded.
      *
      * The \a error string will be filled with a translated error message if an error
      * occurs during the style load. The \a warnings list will be populated with any


### PR DESCRIPTION
Aside from fixing some more issues when converting MapBox GL styles, this PR also notifies the user when a warning is raised during the conversion:

![image](https://user-images.githubusercontent.com/1829991/93151963-c008ef00-f740-11ea-94f1-a109e7682e94.png)

It's useful to advise them if a layer was not converted, or is missing a required font...