### PR TITLE
Make GPS bearing line ellipsoid aware

### DIFF
--- a/src/app/gps/qgsgpsbearingitem.cpp
+++ b/src/app/gps/qgsgpsbearingitem.cpp
@@ -24,7 +24,7 @@
 #include "qgsproject.h"
 #include "qgsmessagelog.h"
 #include "qgssymbol.h"
-
+#include "qgslogger.h"
 
 QgsGpsBearingItem::QgsGpsBearingItem( QgsMapCanvas *mapCanvas )
   : QgsMapCanvasLineSymbolItem( mapCanvas )
@@ -75,9 +75,37 @@ void QgsGpsBearingItem::updatePosition()
 
 void QgsGpsBearingItem::updateLine()
 {
-  QLineF bearingLine;
-  bearingLine.setP1( toCanvasCoordinates( mCenter ) );
-  bearingLine.setLength( 5 * std::max( mMapCanvas->width(), mMapCanvas->height() ) );
-  bearingLine.setAngle( 90 - mBearing  - mMapCanvas->rotation() );
+  QPolygonF bearingLine;
+
+  QgsCoordinateTransform wgs84ToCanvas( mWgs84CRS, mMapCanvas->mapSettings().destinationCrs(), QgsProject::instance()->transformContext() );
+
+  try
+  {
+    bearingLine << mMapCanvas->getCoordinateTransform()->transform( wgs84ToCanvas.transform( mCenterWGS84 ) ).toQPointF();
+
+    // project out the bearing line by roughly twice the size of the canvas
+    QgsDistanceArea da1;
+    da1.setSourceCrs( mMapCanvas->mapSettings().destinationCrs(), QgsProject::instance()->transformContext() );
+    da1.setEllipsoid( QgsProject::instance()->ellipsoid() );
+    const double totalLength = 2 * da1.measureLine( mMapCanvas->mapSettings().extent().center(), QgsPointXY( mMapCanvas->mapSettings().extent().xMaximum(),
+                               mMapCanvas->mapSettings().extent().yMaximum() ) );
+
+    QgsDistanceArea da;
+    da.setSourceCrs( mWgs84CRS, QgsProject::instance()->transformContext() );
+    da.setEllipsoid( QgsProject::instance()->ellipsoid() );
+    // use 20 segments, projected from GPS position, in order to render a nice ellipsoid aware bearing line
+    for ( int i = 1; i < 20; i++ )
+    {
+      const double distance = totalLength * i / 20;
+      const QgsPointXY res = da.computeSpheroidProject( mCenterWGS84, distance, mBearing * M_PI / 180.0 );
+      bearingLine << mMapCanvas->getCoordinateTransform()->transform( wgs84ToCanvas.transform( res ) ).toQPointF();
+    }
+  }
+  catch ( QgsCsException & )
+  {
+    QgsDebugMsg( QStringLiteral( "Coordinate exception encountered while drawing GPS bearing line" ) );
+    bearingLine.clear();
+  }
+
   setLine( bearingLine );
 }

--- a/src/app/qgspointmarkeritem.cpp
+++ b/src/app/qgspointmarkeritem.cpp
@@ -166,9 +166,16 @@ QgsMapCanvasLineSymbolItem::QgsMapCanvasLineSymbolItem( QgsMapCanvas *canvas )
   setSymbol( qgis::make_unique< QgsLineSymbol >() );
 }
 
-void QgsMapCanvasLineSymbolItem::setLine( const QLineF &line )
+void QgsMapCanvasLineSymbolItem::setLine( const QPolygonF &line )
 {
   mLine = line;
+  update();
+}
+
+void QgsMapCanvasLineSymbolItem::setLine( const QLineF &line )
+{
+  mLine.clear();
+  mLine << line.p1() << line.p2();
   update();
 }
 
@@ -179,9 +186,7 @@ QRectF QgsMapCanvasLineSymbolItem::boundingRect() const
 
 void QgsMapCanvasLineSymbolItem::renderSymbol( QgsRenderContext &context, const QgsFeature &feature )
 {
-  QPolygonF points;
-  points << mLine.p1() << mLine.p2();
-  lineSymbol()->renderPolyline( points, &feature, context );
+  lineSymbol()->renderPolyline( mLine, &feature, context );
 }
 
 QgsLineSymbol *QgsMapCanvasLineSymbolItem::lineSymbol()

--- a/src/app/qgspointmarkeritem.h
+++ b/src/app/qgspointmarkeritem.h
@@ -142,6 +142,11 @@ class APP_EXPORT QgsMapCanvasLineSymbolItem: public QgsMapCanvasSymbolItem
 
     /**
      * Sets the line to draw (in map coordinates)
+     */
+    void setLine( const QPolygonF &line );
+
+    /**
+     * Sets the line to draw (in map coordinates)
     */
     void setLine( const QLineF &line );
 
@@ -151,7 +156,7 @@ class APP_EXPORT QgsMapCanvasLineSymbolItem: public QgsMapCanvasSymbolItem
 
   private:
 
-    QLineF mLine;
+    QPolygonF mLine;
 
     QgsLineSymbol *lineSymbol();
 };


### PR DESCRIPTION
...instead of just a straight line drawn from the GPS point. The straight line approach is too naive and doesn't well represent the actual GPS bearing.