### PR TITLE
Fix diagram settings are not correctly restored when loading a QML file

### DIFF
--- a/src/gui/vector/qgsdiagramproperties.cpp
+++ b/src/gui/vector/qgsdiagramproperties.cpp
@@ -261,7 +261,30 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer *layer, QWidget *pare
   mPaintEffect.reset( QgsPaintEffectRegistry::defaultStack() );
   mPaintEffect->setEnabled( false );
 
-  const QgsDiagramRenderer *dr = layer->diagramRenderer();
+  syncToLayer();
+
+  connect( mAddAttributeExpression, &QPushButton::clicked, this, &QgsDiagramProperties::showAddAttributeExpressionDialog );
+  registerDataDefinedButton( mBackgroundColorDDBtn, QgsDiagramLayerSettings::BackgroundColor );
+  registerDataDefinedButton( mLineColorDDBtn, QgsDiagramLayerSettings::StrokeColor );
+  registerDataDefinedButton( mLineWidthDDBtn, QgsDiagramLayerSettings::StrokeWidth );
+  registerDataDefinedButton( mCoordXDDBtn, QgsDiagramLayerSettings::PositionX );
+  registerDataDefinedButton( mCoordYDDBtn, QgsDiagramLayerSettings::PositionY );
+  registerDataDefinedButton( mDistanceDDBtn, QgsDiagramLayerSettings::Distance );
+  registerDataDefinedButton( mPriorityDDBtn, QgsDiagramLayerSettings::Priority );
+  registerDataDefinedButton( mZOrderDDBtn, QgsDiagramLayerSettings::ZIndex );
+  registerDataDefinedButton( mShowDiagramDDBtn, QgsDiagramLayerSettings::Show );
+  registerDataDefinedButton( mAlwaysShowDDBtn, QgsDiagramLayerSettings::AlwaysShow );
+  registerDataDefinedButton( mIsObstacleDDBtn, QgsDiagramLayerSettings::IsObstacle );
+  registerDataDefinedButton( mStartAngleDDBtn, QgsDiagramLayerSettings::StartAngle );
+
+  connect( mButtonSizeLegendSettings, &QPushButton::clicked, this, &QgsDiagramProperties::showSizeLegendDialog );
+}
+
+void QgsDiagramProperties::syncToLayer()
+{
+  mDiagramAttributesTreeWidget->clear();
+
+  const QgsDiagramRenderer *dr = mLayer->diagramRenderer();
   if ( !dr ) //no diagram renderer yet, insert reasonable default
   {
     mDiagramTypeComboBox->blockSignals( true );
@@ -277,12 +300,12 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer *layer, QWidget *pare
     mIncreaseMinimumSizeSpinBox->setEnabled( false );
     mIncreaseMinimumSizeLabel->setEnabled( false );
     mBarWidthSpinBox->setValue( 5 );
-    mScaleVisibilityGroupBox->setChecked( layer->hasScaleBasedVisibility() );
-    mScaleRangeWidget->setScaleRange( layer->minimumScale(), layer->maximumScale() );
+    mScaleVisibilityGroupBox->setChecked( mLayer->hasScaleBasedVisibility() );
+    mScaleRangeWidget->setScaleRange( mLayer->minimumScale(), mLayer->maximumScale() );
     mShowAllCheckBox->setChecked( true );
     mCheckBoxAttributeLegend->setChecked( true );
 
-    switch ( layerType )
+    switch ( mLayer->geometryType() )
     {
       case QgsWkbTypes::PointGeometry:
         radAroundPoint->setChecked( true );
@@ -339,8 +362,8 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer *layer, QWidget *pare
       mDiagramPenColorButton->setColor( settingList.at( 0 ).penColor );
       mPenWidthSpinBox->setValue( settingList.at( 0 ).penWidth );
       mDiagramSizeSpinBox->setValue( ( size.width() + size.height() ) / 2.0 );
-      mScaleRangeWidget->setScaleRange( ( settingList.at( 0 ).minimumScale > 0 ? settingList.at( 0 ).minimumScale : layer->minimumScale() ),
-                                        ( settingList.at( 0 ).maximumScale > 0 ? settingList.at( 0 ).maximumScale : layer->maximumScale() ) );
+      mScaleRangeWidget->setScaleRange( ( settingList.at( 0 ).minimumScale > 0 ? settingList.at( 0 ).minimumScale : mLayer->minimumScale() ),
+                                        ( settingList.at( 0 ).maximumScale > 0 ? settingList.at( 0 ).maximumScale : mLayer->maximumScale() ) );
       mScaleVisibilityGroupBox->setChecked( settingList.at( 0 ).scaleBasedVisibility );
       mDiagramUnitComboBox->setUnit( settingList.at( 0 ).sizeType );
       mDiagramUnitComboBox->setMapUnitScale( settingList.at( 0 ).sizeScale );
@@ -451,7 +474,7 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer *layer, QWidget *pare
       }
     }
 
-    const QgsDiagramLayerSettings *dls = layer->diagramLayerSettings();
+    const QgsDiagramLayerSettings *dls = mLayer->diagramLayerSettings();
     if ( dls )
     {
       mDiagramDistanceSpinBox->setValue( dls->distance() );
@@ -514,22 +537,6 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer *layer, QWidget *pare
     }
   }
   mPaintEffectWidget->setPaintEffect( mPaintEffect.get() );
-
-  connect( mAddAttributeExpression, &QPushButton::clicked, this, &QgsDiagramProperties::showAddAttributeExpressionDialog );
-  registerDataDefinedButton( mBackgroundColorDDBtn, QgsDiagramLayerSettings::BackgroundColor );
-  registerDataDefinedButton( mLineColorDDBtn, QgsDiagramLayerSettings::StrokeColor );
-  registerDataDefinedButton( mLineWidthDDBtn, QgsDiagramLayerSettings::StrokeWidth );
-  registerDataDefinedButton( mCoordXDDBtn, QgsDiagramLayerSettings::PositionX );
-  registerDataDefinedButton( mCoordYDDBtn, QgsDiagramLayerSettings::PositionY );
-  registerDataDefinedButton( mDistanceDDBtn, QgsDiagramLayerSettings::Distance );
-  registerDataDefinedButton( mPriorityDDBtn, QgsDiagramLayerSettings::Priority );
-  registerDataDefinedButton( mZOrderDDBtn, QgsDiagramLayerSettings::ZIndex );
-  registerDataDefinedButton( mShowDiagramDDBtn, QgsDiagramLayerSettings::Show );
-  registerDataDefinedButton( mAlwaysShowDDBtn, QgsDiagramLayerSettings::AlwaysShow );
-  registerDataDefinedButton( mIsObstacleDDBtn, QgsDiagramLayerSettings::IsObstacle );
-  registerDataDefinedButton( mStartAngleDDBtn, QgsDiagramLayerSettings::StartAngle );
-
-  connect( mButtonSizeLegendSettings, &QPushButton::clicked, this, &QgsDiagramProperties::showSizeLegendDialog );
 }
 
 QgsDiagramProperties::~QgsDiagramProperties()

--- a/src/gui/vector/qgsdiagramproperties.h
+++ b/src/gui/vector/qgsdiagramproperties.h
@@ -40,6 +40,13 @@ class GUI_EXPORT QgsDiagramProperties : public QWidget, private Ui::QgsDiagramPr
   public:
     QgsDiagramProperties( QgsVectorLayer *layer, QWidget *parent, QgsMapCanvas *canvas );
 
+    /**
+     * Updates the widget to reflect the layer's current diagram settings.
+     *
+     * \since QGIS 3.16
+     */
+    void syncToLayer();
+
     ~QgsDiagramProperties() override;
 
     //! Adds an attribute from the list of available attributes to the assigned attributes with a random color.

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -578,6 +578,9 @@ void QgsVectorLayerProperties::syncToLayer()
   // set initial state for variable editor
   updateVariableEditor();
 
+  if ( diagramPropertiesDialog )
+    diagramPropertiesDialog->syncToLayer();
+
   // sync all plugin dialogs
   const auto constMLayerPropertiesPages = mLayerPropertiesPages;
   for ( QgsMapLayerConfigWidget *page : constMLayerPropertiesPages )


### PR DESCRIPTION
The settings were being restored, but the dialog was not updating
the reflect the loaded settings, so clicking OK caused the previous
settings to overwrite the loaded ones immediately.

Fixes #35343
