### PR TITLE
Fixes #38549 : update featurefiltermodel when values are set to null

### DIFF
--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -659,5 +659,5 @@ void QgsFeatureFilterModel::setExtraIdentifierValues( const QVariantList &extraI
 
 void QgsFeatureFilterModel::setExtraIdentifierValuesToNull()
 {
-  mExtraIdentifierValues = QVariantList();
+  setExtraIdentifierValues( QVariantList() );
 }


### PR DESCRIPTION
## Description

This issue is only in 3.10 (the code has changed quite a lot in master), `setExtraIdentifierValues` needs to be called to update the widget and avoid old values to remain. 