### PR TITLE
Transaction and Geopackage datasets: make it work when the layer whose edition is turned off hasn't been modified (fixes #38697)

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10751,7 +10751,7 @@ bool QgisApp::toggleEditing( QgsMapLayer *layer, bool allowCancel )
 
   bool res = true;
 
-  QString connString = QgsDataSourceUri( vlayer->source() ).connectionInfo();
+  QString connString = QgsTransaction::connectionString( vlayer->source() );
   QString key = vlayer->providerType();
 
   QMap< QPair< QString, QString>, QgsTransactionGroup *> transactionGroups = QgsProject::instance()->transactionGroups();


### PR DESCRIPTION
We cannot use QgsDataSourceUri::connectionInfo() as it returns an empty string
for OGR datasources. So use QgsTransaction::connectionString() as in other places.
