### PR TITLE
 UI: better information message when toggling off edition mode on a transaction group

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10751,7 +10751,7 @@ bool QgisApp::toggleEditing( QgsMapLayer *layer, bool allowCancel )
 
   bool res = true;
 
-  QString connString = QgsDataSourceUri( vlayer->source() ).connectionInfo();
+  QString connString = QgsTransaction::connectionString( vlayer->source() );
   QString key = vlayer->providerType();
 
   QMap< QPair< QString, QString>, QgsTransactionGroup *> transactionGroups = QgsProject::instance()->transactionGroups();


### PR DESCRIPTION
(On top of PR #38779. Probably not appropriate for backport as it impacts translated strings)

Previously, we always displayed the name of the layer we toggled off, even if
it was not modified, which could be confusing.
Now we will display up to two layer names that have been modified.
