### PR TITLE
Fix typo in name of QgsFeaturePickerModelBase::identifierIsNull() method

### DIFF
--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -40,7 +40,7 @@ QgsFeatureFilterModel::QgsFeatureFilterModel( QObject *parent )
 {
   setFetchGeometry( false );
   setFetchLimit( QgsSettings().value( QStringLiteral( "maxEntriesRelationWidget" ), 100, QgsSettings::Gui ).toInt() );
-  setExtraIdentifierValueUnguarded( nullIentifier() );
+  setExtraIdentifierValueUnguarded( nullIdentifier() );
 }
 
 QString QgsFeatureFilterModel::identifierField() const
@@ -104,7 +104,7 @@ bool QgsFeatureFilterModel::identifierIsNull( const QVariant &identifier ) const
   return true;
 }
 
-QVariant QgsFeatureFilterModel::nullIentifier() const
+QVariant QgsFeatureFilterModel::nullIdentifier() const
 {
   QVariantList nullValues;
   for ( int i = 0; i < mIdentifierFields.count(); i++ )
@@ -139,7 +139,7 @@ QVariantList QgsFeatureFilterModel::extraIdentifierValues() const
   QVariantList values = mExtraIdentifierValue.toList();
   if ( values.count() != mIdentifierFields.count() )
   {
-    return nullIentifier().toList();
+    return nullIdentifier().toList();
   }
   return values;
 }

--- a/src/core/qgsfeaturefiltermodel.h
+++ b/src/core/qgsfeaturefiltermodel.h
@@ -122,7 +122,7 @@ class CORE_EXPORT QgsFeatureFilterModel : public QgsFeaturePickerModelBase
 
     bool identifierIsNull( const QVariant &identifier ) const override;
 
-    QVariant nullIentifier() const override;
+    QVariant nullIdentifier() const override;
 
     QStringList mIdentifierFields;
 };

--- a/src/core/qgsfeaturepickermodel.cpp
+++ b/src/core/qgsfeaturepickermodel.cpp
@@ -25,7 +25,7 @@ QgsFeaturePickerModel::QgsFeaturePickerModel( QObject *parent )
   :  QgsFeaturePickerModelBase( parent )
 {
   setFetchGeometry( true );
-  setExtraIdentifierValueUnguarded( nullIentifier() );
+  setExtraIdentifierValueUnguarded( nullIdentifier() );
 
   connect( this, &QgsFeaturePickerModelBase::extraIdentifierValueIndexChanged, this, [ = ]() {emit featureChanged( feature() );} );
 }
@@ -53,10 +53,10 @@ bool QgsFeaturePickerModel::compareEntries( const QgsFeatureExpressionValuesGath
 
 bool QgsFeaturePickerModel::identifierIsNull( const QVariant &identifier ) const
 {
-  return identifier.value<QgsFeatureId>() == nullIentifier();
+  return identifier.value<QgsFeatureId>() == nullIdentifier();
 }
 
-QVariant QgsFeaturePickerModel::nullIentifier() const
+QVariant QgsFeaturePickerModel::nullIdentifier() const
 {
   return FID_NULL;
 }

--- a/src/core/qgsfeaturepickermodel.h
+++ b/src/core/qgsfeaturepickermodel.h
@@ -72,7 +72,7 @@ class CORE_EXPORT QgsFeaturePickerModel : public QgsFeaturePickerModelBase
 
     bool identifierIsNull( const QVariant &identifier ) const override;
 
-    QVariant nullIentifier() const override;
+    QVariant nullIdentifier() const override;
 };
 
 #endif // QGSFEATUREPICKERMODEL_H

--- a/src/core/qgsfeaturepickermodelbase.cpp
+++ b/src/core/qgsfeaturepickermodelbase.cpp
@@ -232,7 +232,7 @@ void QgsFeaturePickerModelBase::updateCompleter()
 
   if ( mExtraValueIndex == -1 )
   {
-    setExtraIdentifierValueUnguarded( nullIentifier() );
+    setExtraIdentifierValueUnguarded( nullIdentifier() );
   }
 
   // Only reloading the current entry?

--- a/src/core/qgsfeaturepickermodelbase.h
+++ b/src/core/qgsfeaturepickermodelbase.h
@@ -299,7 +299,7 @@ class CORE_EXPORT QgsFeaturePickerModelBase : public QAbstractItemModel SIP_ABST
     virtual bool compareEntries( const QgsFeatureExpressionValuesGatherer::Entry &a, const QgsFeatureExpressionValuesGatherer::Entry &b ) const = 0;
 
     //! Returns a null identifier
-    virtual QVariant nullIentifier() const = 0;
+    virtual QVariant nullIdentifier() const = 0;
 
     /**
      * Returns TRUE if the entry is null


### PR DESCRIPTION
This is a protected virtual method, not exposed to SIP. So this should cause
no compatibility issue.
