### PR TITLE
[browser] Correctly save expanded node state when closing QGIS

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1839,6 +1839,7 @@ QgisApp::~QgisApp()
   }
 
   // these may have references to map layers which need to be cleaned up
+  mBrowserWidget->close(); // close first, to trigger save of state
   delete mBrowserWidget;
   mBrowserWidget = nullptr;
   delete mBrowserWidget2;


### PR DESCRIPTION
Otherwise browser expanded nodes are never saved, and the browser
always returns to some random previous state
