### PR TITLE
[browser] Gpkg and other container types can be dragged to the map to allow layers to be added from them

### DIFF
--- a/src/core/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/core/providers/ogr/qgsgeopackagedataitems.cpp
@@ -394,3 +394,17 @@ bool QgsGeoPackageCollectionItem::layerCollection() const
 {
   return true;
 }
+
+bool QgsGeoPackageCollectionItem::hasDragEnabled() const
+{
+  return true;
+}
+
+QgsMimeDataUtils::Uri QgsGeoPackageCollectionItem::mimeUri() const
+{
+  QgsMimeDataUtils::Uri u;
+  u.providerKey = QStringLiteral( "ogr" );
+  u.uri = path();
+  u.layerType = QStringLiteral( "vector" );
+  return u;
+}

--- a/src/core/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/core/providers/ogr/qgsgeopackagedataitems.h
@@ -65,6 +65,8 @@ class CORE_EXPORT QgsGeoPackageCollectionItem : public QgsDataCollectionItem
     // QgsDataItem interface
   public:
     bool layerCollection() const override;
+    bool hasDragEnabled() const override;
+    QgsMimeDataUtils::Uri mimeUri() const override;
 };
 
 

--- a/src/core/providers/ogr/qgsogrdataitems.cpp
+++ b/src/core/providers/ogr/qgsogrdataitems.cpp
@@ -442,6 +442,20 @@ bool QgsOgrDataCollectionItem::createConnection( const QString &name, const QStr
   return saveConnection( path, ogrDriverName );
 }
 
+bool QgsOgrDataCollectionItem::hasDragEnabled() const
+{
+  return true;
+}
+
+QgsMimeDataUtils::Uri QgsOgrDataCollectionItem::mimeUri() const
+{
+  QgsMimeDataUtils::Uri u;
+  u.providerKey = QStringLiteral( "ogr" );
+  u.uri = path();
+  u.layerType = QStringLiteral( "vector" );
+  return u;
+}
+
 // ---------------------------------------------------------------------------
 
 QString QgsOgrDataItemProvider::name()

--- a/src/core/providers/ogr/qgsogrdataitems.h
+++ b/src/core/providers/ogr/qgsogrdataitems.h
@@ -129,6 +129,9 @@ class CORE_EXPORT QgsOgrDataCollectionItem final: public QgsDataCollectionItem
      * \param ogrDriverName the OGR/GDAL driver name (e.g. "GPKG")
      */
     static bool createConnection( const QString &name, const QString &extensions, const QString &ogrDriverName );
+
+    bool hasDragEnabled() const override;
+    QgsMimeDataUtils::Uri mimeUri() const override;
 };
 
 //! Provider for OGR root data item


### PR DESCRIPTION
Otherwise it's impossible to select multiple gpkg files from the
browser to add them all at once, and users have to add them
one-by-one
