### PR TITLE
Add explicit capitalization option for "Title Case"

### DIFF
--- a/python/core/auto_generated/textrenderer/qgstextformat.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextformat.sip.in
@@ -370,6 +370,24 @@ Sets the ``orientation`` for the text.
 .. versionadded:: 3.10
 %End
 
+    QgsStringUtils::Capitalization capitalization() const;
+%Docstring
+Returns the text capitalization style.
+
+.. seealso:: :py:func:`setCapitalization`
+
+.. versionadded:: 3.16
+%End
+
+    void setCapitalization( QgsStringUtils::Capitalization capitalization );
+%Docstring
+Sets the text ``capitalization`` style.
+
+.. seealso:: :py:func:`capitalization`
+
+.. versionadded:: 3.16
+%End
+
     bool allowHtmlFormatting() const;
 %Docstring
 Returns ``True`` if text should be treated as a HTML document and HTML tags should be used for formatting

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -129,7 +129,7 @@ void QgsPalLayerSettings::initPropertyDefinitions()
     { QgsPalLayerSettings::FontSizeUnit, QgsPropertyDefinition( "FontSizeUnit", QObject::tr( "Font size units" ), QgsPropertyDefinition::RenderUnits, origin ) },
     { QgsPalLayerSettings::FontTransp, QgsPropertyDefinition( "FontTransp", QObject::tr( "Text transparency" ), QgsPropertyDefinition::Opacity, origin ) },
     { QgsPalLayerSettings::FontOpacity, QgsPropertyDefinition( "FontOpacity", QObject::tr( "Text opacity" ), QgsPropertyDefinition::Opacity, origin ) },
-    { QgsPalLayerSettings::FontCase, QgsPropertyDefinition( "FontCase", QgsPropertyDefinition::DataTypeString, QObject::tr( "Font case" ), QObject::tr( "string " ) + QStringLiteral( "[<b>NoChange</b>|<b>Upper</b>|<br><b>Lower</b>|<b>Capitalize</b>]" ), origin ) },
+    { QgsPalLayerSettings::FontCase, QgsPropertyDefinition( "FontCase", QgsPropertyDefinition::DataTypeString, QObject::tr( "Font case" ), QObject::tr( "string " ) + QStringLiteral( "[<b>NoChange</b>|<b>Upper</b>|<br><b>Lower</b>|<b>Title</b>|<b>Capitalize</b>]" ), origin ) },
     { QgsPalLayerSettings::FontLetterSpacing, QgsPropertyDefinition( "FontLetterSpacing", QObject::tr( "Letter spacing" ), QgsPropertyDefinition::Double, origin ) },
     { QgsPalLayerSettings::FontWordSpacing, QgsPropertyDefinition( "FontWordSpacing", QObject::tr( "Word spacing" ), QgsPropertyDefinition::Double, origin ) },
     { QgsPalLayerSettings::FontBlendMode, QgsPropertyDefinition( "FontBlendMode", QObject::tr( "Text blend mode" ), QgsPropertyDefinition::BlendMode, origin ) },
@@ -1834,9 +1834,9 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
   }
 
   // apply capitalization
-  QgsStringUtils::Capitalization capitalization = QgsStringUtils::MixedCase;
+  QgsStringUtils::Capitalization capitalization = mFormat.capitalization();
   // maintain API - capitalization may have been set in textFont
-  if ( mFormat.font().capitalization() != QFont::MixedCase )
+  if ( capitalization == QgsStringUtils::MixedCase && mFormat.font().capitalization() != QFont::MixedCase )
   {
     capitalization = static_cast< QgsStringUtils::Capitalization >( mFormat.font().capitalization() );
   }
@@ -1866,6 +1866,10 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
         else if ( fcase.compare( QLatin1String( "Capitalize" ), Qt::CaseInsensitive ) == 0 )
         {
           capitalization = QgsStringUtils::ForceFirstLetterToCapital;
+        }
+        else if ( fcase.compare( QLatin1String( "Title" ), Qt::CaseInsensitive ) == 0 )
+        {
+          capitalization = QgsStringUtils::TitleCase;
         }
       }
     }

--- a/src/core/labeling/qgsvectorlayerlabeling.cpp
+++ b/src/core/labeling/qgsvectorlayerlabeling.cpp
@@ -269,15 +269,18 @@ void QgsAbstractVectorLayerLabeling::writeTextSymbolizer( QDomNode &parent, QgsP
   }
   else
   {
-    if ( font.capitalization() == QFont::AllUppercase )
+    QgsStringUtils::Capitalization capitalization = format.capitalization();
+    if ( capitalization == QgsStringUtils::MixedCase && font.capitalization() != QFont::MixedCase )
+      capitalization = static_cast< QgsStringUtils::Capitalization >( font.capitalization() );
+    if ( capitalization == QgsStringUtils::AllUppercase )
     {
       appendSimpleFunction( doc, labelElement, QStringLiteral( "strToUpperCase" ), settings.fieldName );
     }
-    else if ( font.capitalization() == QFont::AllLowercase )
+    else if ( capitalization == QgsStringUtils::AllLowercase )
     {
       appendSimpleFunction( doc, labelElement, QStringLiteral( "strToLowerCase" ), settings.fieldName );
     }
-    else if ( font.capitalization() == QFont::Capitalize )
+    else if ( capitalization == QgsStringUtils::ForceFirstLetterToCapital )
     {
       appendSimpleFunction( doc, labelElement, QStringLiteral( "strCapitalize" ), settings.fieldName );
     }

--- a/src/core/qgsstringutils.cpp
+++ b/src/core/qgsstringutils.cpp
@@ -73,7 +73,8 @@ QString QgsStringUtils::capitalize( const QString &string, QgsStringUtils::Capit
         splitWords = QRegularExpression( QStringLiteral( "\\b" ), QRegularExpression::UseUnicodePropertiesOption );
       }
 
-      const QStringList parts = string.split( splitWords, QString::SkipEmptyParts );
+      const bool allSameCase = string.toLower() == string || string.toUpper() == string;
+      const QStringList parts = ( allSameCase ? string.toLower() : string ).split( splitWords, QString::SkipEmptyParts );
       QString result;
       bool firstWord = true;
       int i = 0;

--- a/src/core/textrenderer/qgstextformat.h
+++ b/src/core/textrenderer/qgstextformat.h
@@ -23,6 +23,7 @@
 #include "qgstextbackgroundsettings.h"
 #include "qgstextshadowsettings.h"
 #include "qgstextmasksettings.h"
+#include "qgsstringutils.h"
 
 #include <QSharedDataPointer>
 
@@ -338,6 +339,22 @@ class CORE_EXPORT QgsTextFormat
      * \since QGIS 3.10
      */
     void setOrientation( TextOrientation orientation );
+
+    /**
+     * Returns the text capitalization style.
+     *
+     * \see setCapitalization()
+     * \since QGIS 3.16
+     */
+    QgsStringUtils::Capitalization capitalization() const;
+
+    /**
+     * Sets the text \a capitalization style.
+     *
+     * \see capitalization()
+     * \since QGIS 3.16
+     */
+    void setCapitalization( QgsStringUtils::Capitalization capitalization );
 
     /**
      * Returns TRUE if text should be treated as a HTML document and HTML tags should be used for formatting

--- a/src/core/textrenderer/qgstextrenderer_p.h
+++ b/src/core/textrenderer/qgstextrenderer_p.h
@@ -28,6 +28,8 @@
 #include "qgsapplication.h"
 #include "qgspainteffect.h"
 #include "qgssymbollayerreference.h"
+#include "qgsstringutils.h"
+
 #include <QSharedData>
 #include <QPainter>
 
@@ -271,6 +273,7 @@ class QgsTextSettingsPrivate : public QSharedData
       , orientation( other.orientation )
       , previewBackgroundColor( other.previewBackgroundColor )
       , allowHtmlFormatting( other.allowHtmlFormatting )
+      , capitalization( other.capitalization )
       , mDataDefinedProperties( other.mDataDefinedProperties )
     {
     }
@@ -287,8 +290,8 @@ class QgsTextSettingsPrivate : public QSharedData
     double multilineHeight = 1.0 ; //0.0 to 10.0, leading between lines as multiplyer of line height
     QgsTextFormat::TextOrientation orientation = QgsTextFormat::HorizontalOrientation;
     QColor previewBackgroundColor = Qt::white;
-
     bool allowHtmlFormatting = false;
+    QgsStringUtils::Capitalization capitalization = QgsStringUtils::MixedCase;
 
     //! Property collection for data defined settings
     QgsPropertyCollection mDataDefinedProperties;

--- a/src/gui/qgstextformatwidget.h
+++ b/src/gui/qgstextformatwidget.h
@@ -272,7 +272,6 @@ class GUI_EXPORT QgsTextFormatWidget : public QWidget, public QgsExpressionConte
     void onSubstitutionsChanged( const QgsStringReplacementCollection &substitutions );
     void previewScaleChanged( double scale );
     void mFontSizeSpinBox_valueChanged( double d );
-    void mFontCapitalsComboBox_currentIndexChanged( int index );
     void mFontFamilyCmbBx_currentFontChanged( const QFont &f );
     void mFontStyleComboBox_currentIndexChanged( const QString &text );
     void mFontUnderlineBtn_toggled( bool ckd );

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -650,8 +650,19 @@ void TestQgsLabelingEngine::testCapitalization()
   provider2->registerFeature( f, context );
   QCOMPARE( provider2->mLabels.at( 0 )->labelText(), QString( "A TEST LABEL" ) );
 
+  font.setCapitalization( QFont::MixedCase );
+  format.setCapitalization( QgsStringUtils::AllUppercase );
+  format.setFont( font );
+  settings.setFormat( format );
+  QgsVectorLayerLabelProvider *provider2b = new QgsVectorLayerLabelProvider( vl, QStringLiteral( "test2" ), true, &settings );
+  engine.addProvider( provider2b );
+  provider2b->prepare( context, attributes );
+  provider2b->registerFeature( f, context );
+  QCOMPARE( provider2b->mLabels.at( 0 )->labelText(), QString( "A TEST LABEL" ) );
+
   //lowercase
   font.setCapitalization( QFont::AllLowercase );
+  format.setCapitalization( QgsStringUtils::MixedCase );
   format.setFont( font );
   settings.setFormat( format );
   QgsVectorLayerLabelProvider *provider3 = new QgsVectorLayerLabelProvider( vl, QStringLiteral( "test3" ), true, &settings );
@@ -660,8 +671,19 @@ void TestQgsLabelingEngine::testCapitalization()
   provider3->registerFeature( f, context );
   QCOMPARE( provider3->mLabels.at( 0 )->labelText(), QString( "a test label" ) );
 
+  font.setCapitalization( QFont::MixedCase );
+  format.setCapitalization( QgsStringUtils::AllLowercase );
+  format.setFont( font );
+  settings.setFormat( format );
+  QgsVectorLayerLabelProvider *provider3b = new QgsVectorLayerLabelProvider( vl, QStringLiteral( "test3" ), true, &settings );
+  engine.addProvider( provider3b );
+  provider3b->prepare( context, attributes );
+  provider3b->registerFeature( f, context );
+  QCOMPARE( provider3b->mLabels.at( 0 )->labelText(), QString( "a test label" ) );
+
   //first letter uppercase
   font.setCapitalization( QFont::Capitalize );
+  format.setCapitalization( QgsStringUtils::MixedCase );
   format.setFont( font );
   settings.setFormat( format );
   QgsVectorLayerLabelProvider *provider4 = new QgsVectorLayerLabelProvider( vl, QStringLiteral( "test4" ), true, &settings );
@@ -669,6 +691,26 @@ void TestQgsLabelingEngine::testCapitalization()
   provider4->prepare( context, attributes );
   provider4->registerFeature( f, context );
   QCOMPARE( provider4->mLabels.at( 0 )->labelText(), QString( "A TeSt LABEL" ) );
+
+  font.setCapitalization( QFont::MixedCase );
+  format.setCapitalization( QgsStringUtils::ForceFirstLetterToCapital );
+  format.setFont( font );
+  settings.setFormat( format );
+  QgsVectorLayerLabelProvider *provider4b = new QgsVectorLayerLabelProvider( vl, QStringLiteral( "test4" ), true, &settings );
+  engine.addProvider( provider4b );
+  provider4b->prepare( context, attributes );
+  provider4b->registerFeature( f, context );
+  QCOMPARE( provider4b->mLabels.at( 0 )->labelText(), QString( "A TeSt LABEL" ) );
+
+  settings.fieldName = QStringLiteral( "'A TEST LABEL'" );
+  format.setCapitalization( QgsStringUtils::TitleCase );
+  format.setFont( font );
+  settings.setFormat( format );
+  QgsVectorLayerLabelProvider *provider5 = new QgsVectorLayerLabelProvider( vl, QStringLiteral( "test4" ), true, &settings );
+  engine.addProvider( provider5 );
+  provider5->prepare( context, attributes );
+  provider5->registerFeature( f, context );
+  QCOMPARE( provider5->mLabels.at( 0 )->labelText(), QString( "A Test Label" ) );
 }
 
 void TestQgsLabelingEngine::testNumberFormat()

--- a/tests/src/core/testqgsstringutils.cpp
+++ b/tests/src/core/testqgsstringutils.cpp
@@ -173,6 +173,8 @@ void TestQgsStringUtils::titleCase_data()
   QTest::newRow( "empty string" ) << "" << "";
   QTest::newRow( "single character" ) << "a" << "A";
   QTest::newRow( "string 1" ) << "follow step-by-step instructions" << "Follow Step-by-Step Instructions";
+  QTest::newRow( "originally uppercase" ) << "FOLLOW STEP-BY-STEP INSTRUCTIONS" << "Follow Step-by-Step Instructions";
+  QTest::newRow( "string 1" ) << "Follow step-by-step instructions" << "Follow Step-by-Step Instructions";
   QTest::newRow( "string 2" ) << "this sub-phrase is nice" << "This Sub-Phrase Is Nice";
   QTest::newRow( "" ) << "catchy title: a subtitle" << "Catchy Title: A Subtitle";
   QTest::newRow( "string 3" ) << "all words capitalized" << "All Words Capitalized";

--- a/tests/src/python/test_qgstextrenderer.py
+++ b/tests/src/python/test_qgstextrenderer.py
@@ -33,7 +33,8 @@ from qgis.core import (QgsTextBufferSettings,
                        QgsProperty,
                        QgsFontUtils,
                        QgsSymbolLayerId,
-                       QgsSymbolLayerReference)
+                       QgsSymbolLayerReference,
+                       QgsStringUtils)
 from qgis.PyQt.QtGui import (QColor, QPainter, QFont, QImage, QBrush, QPen, QFontMetricsF)
 from qgis.PyQt.QtCore import (Qt, QSizeF, QPointF, QRectF, QDir, QSize)
 from qgis.PyQt.QtXml import QDomDocument
@@ -139,6 +140,10 @@ class PyQgsTextRenderer(unittest.TestCase):
 
         t = QgsTextFormat()
         t.setOrientation(QgsTextFormat.VerticalOrientation)
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.setCapitalization(QgsStringUtils.TitleCase)
         self.assertTrue(t.isValid())
 
         t = QgsTextFormat()
@@ -681,6 +686,7 @@ class PyQgsTextRenderer(unittest.TestCase):
         font = getTestFont()
         font.setKerning(False)
         s.setFont(font)
+        s.setCapitalization(QgsStringUtils.TitleCase)
         s.setNamedStyle('Italic')
         s.setSize(5)
         s.setSizeUnit(QgsUnitTypes.RenderPoints)
@@ -782,6 +788,10 @@ class PyQgsTextRenderer(unittest.TestCase):
         self.assertNotEqual(s, s2)
         s = self.createFormatSettings()
 
+        s.setCapitalization(QgsStringUtils.ForceFirstLetterToCapital)
+        self.assertNotEqual(s, s2)
+        s = self.createFormatSettings()
+
         s.dataDefinedProperties().setProperty(QgsPalLayerSettings.Bold, QgsProperty.fromExpression('1>3'))
         self.assertNotEqual(s, s2)
 
@@ -807,6 +817,7 @@ class PyQgsTextRenderer(unittest.TestCase):
         self.assertEqual(s.lineHeight(), 5)
         self.assertEqual(s.previewBackgroundColor().name(), '#6496c8')
         self.assertEqual(s.orientation(), QgsTextFormat.VerticalOrientation)
+        self.assertEqual(s.capitalization(), QgsStringUtils.TitleCase)
         self.assertTrue(s.allowHtmlFormatting())
         self.assertEqual(s.dataDefinedProperties().property(QgsPalLayerSettings.Bold).expressionString(), '1>2')
 


### PR DESCRIPTION
Adds a new capitalization option for "Title Case", and renames the confusing "Capitalize First Letter" option to "Force First Letter to Capital"

This change is intended to clarify the role of the "capitalize first letter" option, and to provide an option which actually does what users expect the "capitalize first letter" option to do.

The current option has been a constant source of user confusion and repeating bug reports, and while it's behavior can be justified it also is not at all user-friendly.

Fixes #16539