### PR TITLE
Expression preview widget: do not disable feature picker (fixes #38646)

### DIFF
--- a/src/gui/qgsexpressionpreviewwidget.cpp
+++ b/src/gui/qgsexpressionpreviewwidget.cpp
@@ -49,20 +49,7 @@ void QgsExpressionPreviewWidget::setCurrentFeature( const QgsFeature &feature )
 {
   // todo: update the combo box if it has been set externaly?
 
-  // force the feature to be valid, so it can evaluate an invalid feature but having its fields set
-  if ( !feature.isValid() )
-  {
-    QgsFeature validFeature( feature );
-    validFeature.setValid( true );
-    mExpressionContext.setFeature( validFeature );
-    mFeaturePickerWidget->setEnabled( false );
-    mFeaturePickerWidget->setToolTip( tr( "No feature was found on this layer to evaluate the expression." ) );
-  }
-  else
-  {
-    mExpressionContext.setFeature( feature );
-    mFeaturePickerWidget->setEnabled( true );
-  }
+  mExpressionContext.setFeature( feature );
   refreshPreview();
 }
 
@@ -92,6 +79,16 @@ void QgsExpressionPreviewWidget::refreshPreview()
   else
   {
     mExpression = QgsExpression( mExpressionText );
+
+    if ( !mExpressionContext.feature().isValid() )
+    {
+      if ( !mExpression.referencedColumns().isEmpty() || mExpression.needsGeometry() )
+      {
+        mPreviewLabel->setText( tr( "No feature was found on this layer to evaluate the expression." ) );
+        mPreviewLabel->setStyleSheet( QStringLiteral( "color: rgba(255, 6, 10,  255);" ) );
+        return;
+      }
+    }
 
     if ( mUseGeomCalculator )
     {


### PR DESCRIPTION
In the text edit of the feature picker, if one currently enters an invalid value,
the whole feature picker becomes disabled, which requires to close and re-open
the expression string builder dialog.

So instead of doing this, use the preview label to indicate that a valid
feature is needed to evaluate the expression, for expressions that require feature
fields.

Previous related pull requests are:
https://github.com/qgis/QGIS/pull/37518
https://github.com/qgis/QGIS/pull/37139
