### PR TITLE
Fixes value relation line edit not found values

### DIFF
--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -244,13 +244,21 @@ void QgsValueRelationWidgetWrapper::updateValues( const QVariant &value, const Q
   }
   else if ( mLineEdit )
   {
+    mLineEdit->clear();
+    bool wasFound { false };
     for ( const QgsValueRelationFieldFormatter::ValueRelationItem &i : qgis::as_const( mCache ) )
     {
       if ( i.key == value )
       {
         mLineEdit->setText( i.value );
+        wasFound = true;
         break;
       }
+    }
+    // Value could not be found
+    if ( ! wasFound )
+    {
+      mLineEdit->setText( tr( "(no selection)" ) );
     }
   }
 }


### PR DESCRIPTION
When there is no match in the relation layer,
show "(no selection)" instead of NOT updating
the widget (which was the reported issue).

Fixes #38552
