### PR TITLE
Skip line-pattern conversion, not supported yet

### DIFF
--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -403,6 +403,11 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
   }
 
   const QVariantMap jsonPaint = jsonLayer.value( QStringLiteral( "paint" ) ).toMap();
+  if ( jsonPaint.contains( QStringLiteral( "line-pattern" ) ) )
+  {
+    context.pushWarning( QObject::tr( "%1: Skipping unsupported line-pattern property" ).arg( context.layerId() ) );
+    return false;
+  }
 
   QgsPropertyCollection ddProperties;
 


### PR DESCRIPTION
## Description

It's better to skip those than converting into a extra-wide and meaningless simple line symbol.