### PR TITLE
fix segmentation fault 11 on MacOS during closing QGIS

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1849,6 +1849,8 @@ QgisApp::~QgisApp()
   mGeometryValidationDock = nullptr;
   delete mSnappingUtils;
   mSnappingUtils = nullptr;
+  delete mUserInputDockWidget;
+  mUserInputDockWidget = nullptr;
 
   QgsGui::instance()->nativePlatformInterface()->cleanup();
 


### PR DESCRIPTION
Fix segmentation fault 11 on MacOS during closing QGIS

```
void QgsFloatingWidget::onAnchorPointChanged()
 anchorWidgetOrigin = mAnchorWidget->mapTo( parentWidget(), anchorWidgetOrigin );
```

looks like that `mMapCanvas` was deleted before `mUserInputDockWidget`, but user input dock widget has mapcanvas as parent, causing segfault

unable to find the open reported issue on this, it is only on shutdown of QGIS and potentially very platform dependent

stack

```
Termination Signal:    Segmentation fault: 11
Termination Reason:    Namespace SIGNAL, Code 0xb
Terminating Process:   exc handler [53061]

VM Regions Near 0x8:
--> 
    __TEXT                 0000000101361000-00000001013cb000 [  424K] r-x/r-x SM=COW  /opt/QGIS/*/QGIS.app/Contents/MacOS/QGIS

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   org.qt-project.QtWidgets      	0x0000000102836760 QWidget::mapTo(QWidget const*, QPoint const&) const + 32
1   org.qgis.qgis3_gui            	0x0000000104b8d6f4 QgsFloatingWidget::onAnchorPointChanged() + 660
2   org.qgis.qgis3_gui            	0x0000000104b8e194 QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (QgsFloatingWidget::*)()>::call(void (QgsFloatingWidget::*)(), QgsFloatingWidget*, void**) + 132
3   org.qgis.qgis3_gui            	0x0000000104b8e0e8 void QtPrivate::FunctionPointer<void (QgsFloatingWidget::*)()>::call<QtPrivate::List<>, void>(void (QgsFloatingWidget::*)(), QgsFloatingWidget*, void**) + 88
4   org.qgis.qgis3_gui            	0x0000000104b8e005 QtPrivate::QSlotObject<void (QgsFloatingWidget::*)(), QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) + 165
5   org.qt-project.QtCore         	0x00000001036bfa95 void doActivate<false>(QObject*, int, void**) + 1157
6   org.qgis.qgis3_gui            	0x000000010405afc5 QgsFloatingWidgetEventFilter::anchorPointChanged() + 37
7   org.qgis.qgis3_gui            	0x0000000104b8de92 QgsFloatingWidgetEventFilter::eventFilter(QObject*, QEvent*) + 66
8   org.qt-project.QtCore         	0x000000010368cca4 QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) + 148
9   org.qt-project.QtWidgets      	0x0000000102810f45 QApplicationPrivate::notify_helper(QObject*, QEvent*) + 245
10  org.qt-project.QtWidgets      	0x00000001028123e6 QApplication::notify(QObject*, QEvent*) + 598
11  org.qgis.qgi
```