### PR TITLE
Add actions to the attribute table view so they get triggered by shortcut

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -119,12 +119,16 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
 
   mActionSelectAll->setShortcuts( QKeySequence::SelectAll );
   mActionSelectAll->setShortcutContext( Qt::WidgetWithChildrenShortcut );
+  mMainView->addAction( mActionSelectAll );
   mActionCopySelectedRows->setShortcuts( QKeySequence::Copy );
   mActionCopySelectedRows->setShortcutContext( Qt::WidgetWithChildrenShortcut );
+  mMainView->addAction( mActionCopySelectedRows );
   mActionCutSelectedRows->setShortcuts( QKeySequence::Cut );
   mActionCutSelectedRows->setShortcutContext( Qt::WidgetWithChildrenShortcut );
+  mMainView->addAction( mActionCutSelectedRows );
   mActionPasteFeatures->setShortcuts( QKeySequence::Paste );
   mActionPasteFeatures->setShortcutContext( Qt::WidgetWithChildrenShortcut );
+  mMainView->addAction( mActionPasteFeatures );
 
   QgsSettings settings;
 


### PR DESCRIPTION
## Description

Fixes #37503 and #37401 

According to *Qt::WidgetWithChildrenShortcut* documentation

> The shortcut is active when its parent widget, or any of its children has focus. Children which are top-level widgets, except pop-ups, are not affected by this shortcut context.

But in this case the parent is the menubar, not the dialog. So we need to add the actions to the QgsDualView in order to make the shortcut work when the QgsDualView has the focus.
