### PR TITLE
Don't html-escape log message in processing panel

### DIFF
--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -403,7 +403,7 @@ void QgsProcessingAlgorithmDialogBase::reportError( const QString &error, bool f
 
 void QgsProcessingAlgorithmDialogBase::pushInfo( const QString &info )
 {
-  setInfo( info );
+  setInfo( info, false, false );
   processEvents();
 }
 


### PR DESCRIPTION
## Description

![aa](https://user-images.githubusercontent.com/9266424/93364948-7952ec00-f849-11ea-9b0e-43b814d45b8e.png)

Fixes https://github.com/qgis/QGIS/issues/37934.