### PR TITLE
Replace PS character in decoration title expression editor

### DIFF
--- a/src/app/decorations/qgsdecorationtitledialog.cpp
+++ b/src/app/decorations/qgsdecorationtitledialog.cpp
@@ -110,6 +110,8 @@ void QgsDecorationTitleDialog::mInsertExpressionButton_clicked()
   if ( selText.startsWith( QLatin1String( "[%" ) ) && selText.endsWith( QLatin1String( "%]" ) ) )
     selText = selText.mid( 2, selText.size() - 4 );
 
+  selText = selText.replace( QChar( 0x2029 ), QChar( '\n' ) );
+
   QgsExpressionBuilderDialog exprDlg( nullptr, selText, this, QStringLiteral( "generic" ), QgisApp::instance()->mapCanvas()->mapSettings().expressionContext() );
 
   exprDlg.setWindowTitle( QObject::tr( "Insert Expression" ) );


### PR DESCRIPTION
## Description

![bb](https://user-images.githubusercontent.com/9266424/93378538-e459ee00-f85c-11ea-8a4c-fdb7a2746430.png)

Fixes https://github.com/qgis/QGIS/issues/37803.