### PR TITLE
Fix glaring plugin integration gap, add an interface to add pages to the project properties dialog

### DIFF
--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -988,6 +988,14 @@ the dialog to open at a specific page.
 .. versionadded:: 3.0
 %End
 
+    virtual void showProjectPropertiesDialog( const QString &currentPage = QString() ) = 0;
+%Docstring
+Opens the project properties dialog. The ``currentPage`` argument can be used to force
+the dialog to open at a specific page.
+
+.. versionadded:: 3.16
+%End
+
     virtual void buildStyleSheet( const QMap<QString, QVariant> &opts ) = 0;
 %Docstring
 Generate stylesheet
@@ -1176,6 +1184,33 @@ Unregister a previously registered tab in the options dialog.
 .. seealso:: :py:func:`registerOptionsWidgetFactory`
 
 .. versionadded:: 3.0
+%End
+
+    virtual void registerProjectPropertiesWidgetFactory( QgsOptionsWidgetFactory *factory ) = 0;
+%Docstring
+Register a new tab in the project properties dialog.
+
+.. note::
+
+   Ownership of the factory is not transferred, and the factory must
+   be unregistered when plugin is unloaded.
+
+.. seealso:: :py:class:`QgsOptionsWidgetFactory`
+
+.. seealso:: :py:func:`unregisterProjectPropertiesWidgetFactory`
+
+.. versionadded:: 3.16
+%End
+
+    virtual void unregisterProjectPropertiesWidgetFactory( QgsOptionsWidgetFactory *factory ) = 0;
+%Docstring
+Unregister a previously registered tab in the options dialog.
+
+.. seealso:: :py:class:`QgsOptionsWidgetFactory`
+
+.. seealso:: :py:func:`registerProjectPropertiesWidgetFactory`
+
+.. versionadded:: 3.16
 %End
 
     virtual void registerDevToolWidgetFactory( QgsDevToolWidgetFactory *factory ) = 0;

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -733,6 +733,12 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Unregister a previously registered tab in the options dialog
     void unregisterOptionsWidgetFactory( QgsOptionsWidgetFactory *factory );
 
+    //! Register a new tab in the project properties dialog
+    void registerProjectPropertiesWidgetFactory( QgsOptionsWidgetFactory *factory );
+
+    //! Unregister a previously registered tab in the project properties dialog
+    void unregisterProjectPropertiesWidgetFactory( QgsOptionsWidgetFactory *factory );
+
     //! Register a dev tool factory
     void registerDevToolFactory( QgsDevToolWidgetFactory *factory );
 
@@ -2555,6 +2561,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     QList<QgsMapLayerConfigWidgetFactory *> mMapLayerPanelFactories;
     QList<QPointer<QgsOptionsWidgetFactory>> mOptionsWidgetFactories;
+    QList<QPointer<QgsOptionsWidgetFactory>> mProjectPropertiesWidgetFactories;
 
     QList<QgsDevToolWidgetFactory * > mDevToolFactories;
 

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -445,6 +445,11 @@ void QgisAppInterface::showOptionsDialog( QWidget *parent, const QString &curren
   return qgis->showOptionsDialog( parent, currentPage );
 }
 
+void QgisAppInterface::showProjectPropertiesDialog( const QString &currentPage )
+{
+  return qgis->showProjectProperties( currentPage );
+}
+
 QMap<QString, QVariant> QgisAppInterface::defaultStyleSheetOptions()
 {
   return qgis->styleSheetBuilder()->defaultOptions();
@@ -544,6 +549,16 @@ void QgisAppInterface::registerOptionsWidgetFactory( QgsOptionsWidgetFactory *fa
 void QgisAppInterface::unregisterOptionsWidgetFactory( QgsOptionsWidgetFactory *factory )
 {
   qgis->unregisterOptionsWidgetFactory( factory );
+}
+
+void QgisAppInterface::registerProjectPropertiesWidgetFactory( QgsOptionsWidgetFactory *factory )
+{
+  qgis->registerProjectPropertiesWidgetFactory( factory );
+}
+
+void QgisAppInterface::unregisterProjectPropertiesWidgetFactory( QgsOptionsWidgetFactory *factory )
+{
+  qgis->unregisterProjectPropertiesWidgetFactory( factory );
 }
 
 void QgisAppInterface::registerDevToolWidgetFactory( QgsDevToolWidgetFactory *factory )

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -115,6 +115,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QList<QgsLayoutDesignerInterface *> openLayoutDesigners() override;
     QgsLayoutDesignerInterface *openLayoutDesigner( QgsMasterLayoutInterface *layout ) override;
     void showOptionsDialog( QWidget *parent = nullptr, const QString &currentPage = QString() ) override;
+    void showProjectPropertiesDialog( const QString &currentPage = QString() ) override;
     QMap<QString, QVariant> defaultStyleSheetOptions() override;
     void buildStyleSheet( const QMap<QString, QVariant> &opts ) override;
     void saveStyleSheetOptions( const QMap<QString, QVariant> &opts ) override;
@@ -145,6 +146,8 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     void unregisterMapLayerConfigWidgetFactory( QgsMapLayerConfigWidgetFactory *factory ) override;
     void registerOptionsWidgetFactory( QgsOptionsWidgetFactory *factory ) override;
     void unregisterOptionsWidgetFactory( QgsOptionsWidgetFactory *factory ) override;
+    void registerProjectPropertiesWidgetFactory( QgsOptionsWidgetFactory *factory ) override;
+    void unregisterProjectPropertiesWidgetFactory( QgsOptionsWidgetFactory *factory ) override;
     void registerDevToolWidgetFactory( QgsDevToolWidgetFactory *factory ) override;
     void unregisterDevToolWidgetFactory( QgsDevToolWidgetFactory *factory ) override;
     void registerCustomDropHandler( QgsCustomDropHandler *handler ) override;

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -17,14 +17,18 @@
  ***************************************************************************/
 
 
-#include "qgsoptionsdialogbase.h"
 #include "ui_qgsprojectpropertiesbase.h"
+
+#include "qgsoptionsdialogbase.h"
+#include "qgsoptionswidgetfactory.h"
 #include "qgis.h"
 #include "qgsunittypes.h"
 #include "qgsguiutils.h"
 #include "qgsscalewidget.h"
 #include "qgshelp.h"
 #include "qgis_app.h"
+
+#include <QList>
 
 class QgsMapCanvas;
 class QgsRelationManagerDialog;
@@ -35,6 +39,7 @@ class QgsMetadataWidget;
 class QgsTreeWidgetItem;
 class QgsLayerCapabilitiesModel;
 class QgsBearingNumericFormat;
+class QgsOptionsPageWidget;
 
 /**
  * Dialog to set project level properties
@@ -48,7 +53,8 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
 
   public:
     //! Constructor
-    QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
+    QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags,
+                          const QList<QgsOptionsWidgetFactory *> &optionsFactories = QList<QgsOptionsWidgetFactory *>() );
 
     ~QgsProjectProperties() override;
 
@@ -249,6 +255,8 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     QList<EllipsoidDefs> mEllipsoidList;
     int mEllipsoidIndex;
     bool mBlockCrsUpdates = false;
+
+    QList< QgsOptionsPageWidget * > mAdditionalProjectPropertiesWidgets;
 
     std::unique_ptr< QgsBearingNumericFormat > mBearingFormat;
 

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -849,6 +849,13 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual void showOptionsDialog( QWidget *parent = nullptr, const QString &currentPage = QString() ) = 0;
 
     /**
+     * Opens the project properties dialog. The \a currentPage argument can be used to force
+     * the dialog to open at a specific page.
+     * \since QGIS 3.16
+     */
+    virtual void showProjectPropertiesDialog( const QString &currentPage = QString() ) = 0;
+
+    /**
      * Generate stylesheet
      * \param opts generated default option values, or a changed copy of them
      */
@@ -983,6 +990,24 @@ class GUI_EXPORT QgisInterface : public QObject
      * \since QGIS 3.0
     */
     virtual void unregisterOptionsWidgetFactory( QgsOptionsWidgetFactory *factory ) = 0;
+
+    /**
+     * Register a new tab in the project properties dialog.
+     * \note Ownership of the factory is not transferred, and the factory must
+     *       be unregistered when plugin is unloaded.
+     * \see QgsOptionsWidgetFactory
+     * \see unregisterProjectPropertiesWidgetFactory()
+     * \since QGIS 3.16
+     */
+    virtual void registerProjectPropertiesWidgetFactory( QgsOptionsWidgetFactory *factory ) = 0;
+
+    /**
+     * Unregister a previously registered tab in the options dialog.
+     * \see QgsOptionsWidgetFactory
+     * \see registerProjectPropertiesWidgetFactory()
+     * \since QGIS 3.16
+    */
+    virtual void unregisterProjectPropertiesWidgetFactory( QgsOptionsWidgetFactory *factory ) = 0;
 
     /**
      * Register a new tool in the development/debugging tools dock.


### PR DESCRIPTION
## Description

This PR 'fixes' a glaring plugin integration gap by adding an interface to add page(s) to the project properties dialog. This is how it looks:
![Screenshot from 2020-09-17 11-38-13](https://user-images.githubusercontent.com/1728657/93420953-53c1f300-f8da-11ea-9a6d-216ca3db72a1.png)

I would like to call for this PR to be merged into upcoming 3.16 (which is set to become our new LTR). Rational for doing so:
- virtually all code addition is in /src/app
- code added has been well tested as it's essentially mirroring what the interface has had for adding pages to the options dialog since 3.0
- IMHO, we really want this in this LTR to be as useful as it possibly can be for plugin developers.