### PR TITLE
Tag some inexpensive, frequently called methods with the HoldGIL annotation

### DIFF
--- a/python/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -29,22 +29,22 @@ Examples are storing a layer extent or the current view extent of a map
 
     QgsRectangle(); // optimised constructor for null rectangle - no need to call normalize here
 
-    explicit QgsRectangle( double xMin, double yMin = 0, double xMax = 0, double yMax = 0 );
+    explicit QgsRectangle( double xMin, double yMin = 0, double xMax = 0, double yMax = 0 ) /HoldGIL/;
 %Docstring
 Constructor
 %End
 
-    QgsRectangle( const QgsPointXY &p1, const QgsPointXY &p2 );
+    QgsRectangle( const QgsPointXY &p1, const QgsPointXY &p2 ) /HoldGIL/;
 %Docstring
 Construct a rectangle from two points. The rectangle is normalized after construction.
 %End
 
-    QgsRectangle( const QRectF &qRectF );
+    QgsRectangle( const QRectF &qRectF ) /HoldGIL/;
 %Docstring
 Construct a rectangle from a QRectF. The rectangle is normalized after construction.
 %End
 
-    QgsRectangle( const QgsRectangle &other );
+    QgsRectangle( const QgsRectangle &other ) /HoldGIL/;
 %Docstring
 Copy constructor
 %End
@@ -79,48 +79,48 @@ Sets the rectangle from four points. The rectangle is
 normalised after construction.
 %End
 
-    void setXMinimum( double x );
+    void setXMinimum( double x ) /HoldGIL/;
 %Docstring
 Set the minimum x value.
 %End
 
-    void setXMaximum( double x );
+    void setXMaximum( double x ) /HoldGIL/;
 %Docstring
 Set the maximum x value.
 %End
 
-    void setYMinimum( double y );
+    void setYMinimum( double y ) /HoldGIL/;
 %Docstring
 Set the minimum y value.
 %End
 
-    void setYMaximum( double y );
+    void setYMaximum( double y ) /HoldGIL/;
 %Docstring
 Set the maximum y value.
 %End
 
-    void setMinimal();
+    void setMinimal() /HoldGIL/;
 %Docstring
 Set a rectangle so that min corner is at max
 and max corner is at min. It is NOT normalized.
 %End
 
-    double xMaximum() const;
+    double xMaximum() const /HoldGIL/;
 %Docstring
 Returns the x maximum value (right side of rectangle).
 %End
 
-    double xMinimum() const;
+    double xMinimum() const /HoldGIL/;
 %Docstring
 Returns the x minimum value (left side of rectangle).
 %End
 
-    double yMaximum() const;
+    double yMaximum() const /HoldGIL/;
 %Docstring
 Returns the y maximum value (top side of rectangle).
 %End
 
-    double yMinimum() const;
+    double yMinimum() const /HoldGIL/;
 %Docstring
 Returns the y minimum value (bottom side of rectangle).
 %End
@@ -130,7 +130,7 @@ Returns the y minimum value (bottom side of rectangle).
 Normalize the rectangle so it has non-negative width/height.
 %End
 
-    double width() const;
+    double width() const /HoldGIL/;
 %Docstring
 Returns the width of the rectangle.
 
@@ -139,7 +139,7 @@ Returns the width of the rectangle.
 .. seealso:: :py:func:`area`
 %End
 
-    double height() const;
+    double height() const /HoldGIL/;
 %Docstring
 Returns the height of the rectangle.
 
@@ -148,7 +148,7 @@ Returns the height of the rectangle.
 .. seealso:: :py:func:`area`
 %End
 
-    double area() const;
+    double area() const /HoldGIL/;
 %Docstring
 Returns the area of the rectangle.
 
@@ -161,7 +161,7 @@ Returns the area of the rectangle.
 .. versionadded:: 3.0
 %End
 
-    double perimeter() const;
+    double perimeter() const /HoldGIL/;
 %Docstring
 Returns the perimeter of the rectangle.
 
@@ -170,7 +170,7 @@ Returns the perimeter of the rectangle.
 .. versionadded:: 3.0
 %End
 
-    QgsPointXY center() const;
+    QgsPointXY center() const /HoldGIL/;
 %Docstring
 Returns the center point of the rectangle.
 %End

--- a/python/core/auto_generated/qgspointxy.sip.in
+++ b/python/core/auto_generated/qgspointxy.sip.in
@@ -33,12 +33,12 @@ supports Z and M values.
   public:
     QgsPointXY();
 
-    QgsPointXY( const QgsPointXY &p );
+    QgsPointXY( const QgsPointXY &p ) /HoldGIL/;
 %Docstring
 Create a point from another point
 %End
 
-    QgsPointXY( double x, double y );
+    QgsPointXY( double x, double y ) /HoldGIL/;
 %Docstring
 Create a point from x,y coordinates
 
@@ -46,7 +46,7 @@ Create a point from x,y coordinates
 :param y: y coordinate
 %End
 
-    QgsPointXY( QPointF point );
+    QgsPointXY( QPointF point ) /HoldGIL/;
 %Docstring
 Create a point from a QPointF
 
@@ -55,7 +55,7 @@ Create a point from a QPointF
 .. versionadded:: 2.7
 %End
 
-    QgsPointXY( QPoint point );
+    QgsPointXY( QPoint point ) /HoldGIL/;
 %Docstring
 Create a point from a QPoint
 
@@ -64,7 +64,7 @@ Create a point from a QPoint
 .. versionadded:: 2.7
 %End
 
-    QgsPointXY( const QgsPoint &point );
+    QgsPointXY( const QgsPoint &point ) /HoldGIL/;
 %Docstring
 Create a new point.
 Z and M values will be dropped.
@@ -74,33 +74,33 @@ Z and M values will be dropped.
 
     ~QgsPointXY();
 
-    void setX( double x );
+    void setX( double x ) /HoldGIL/;
 %Docstring
 Sets the x value of the point
 
 :param x: x coordinate
 %End
 
-    void setY( double y );
+    void setY( double y ) /HoldGIL/;
 %Docstring
 Sets the y value of the point
 
 :param y: y coordinate
 %End
 
-    void set( double x, double y );
+    void set( double x, double y ) /HoldGIL/;
 %Docstring
 Sets the x and y value of the point
 %End
 
-    double x() const;
+    double x() const /HoldGIL/;
 %Docstring
 Gets the x value of the point
 
 :return: x coordinate
 %End
 
-    double y() const;
+    double y() const /HoldGIL/;
 %Docstring
 Gets the y value of the point
 
@@ -128,21 +128,21 @@ Returns the well known text representation for the point (e.g. "POINT(x y)").
 The wkt is created without an SRID.
 %End
 
-    double sqrDist( double x, double y ) const;
+    double sqrDist( double x, double y ) const /HoldGIL/;
 %Docstring
 Returns the squared distance between this point a specified x, y coordinate.
 
 .. seealso:: :py:func:`distance`
 %End
 
-    double sqrDist( const QgsPointXY &other ) const;
+    double sqrDist( const QgsPointXY &other ) const /HoldGIL/;
 %Docstring
 Returns the squared distance between this point another point.
 
 .. seealso:: :py:func:`distance`
 %End
 
-    double distance( double x, double y ) const;
+    double distance( double x, double y ) const /HoldGIL/;
 %Docstring
 Returns the distance between this point and a specified x, y coordinate.
 
@@ -154,7 +154,7 @@ Returns the distance between this point and a specified x, y coordinate.
 .. versionadded:: 2.16
 %End
 
-    double distance( const QgsPointXY &other ) const;
+    double distance( const QgsPointXY &other ) const /HoldGIL/;
 %Docstring
 Returns the distance between this point and another point.
 
@@ -165,17 +165,17 @@ Returns the distance between this point and another point.
 .. versionadded:: 2.16
 %End
 
-    double sqrDistToSegment( double x1, double y1, double x2, double y2, QgsPointXY &minDistPoint /Out/, double epsilon = DEFAULT_SEGMENT_EPSILON ) const;
+    double sqrDistToSegment( double x1, double y1, double x2, double y2, QgsPointXY &minDistPoint /Out/, double epsilon = DEFAULT_SEGMENT_EPSILON ) const /HoldGIL/;
 %Docstring
 Returns the minimum distance between this point and a segment
 %End
 
-    double azimuth( const QgsPointXY &other ) const;
+    double azimuth( const QgsPointXY &other ) const /HoldGIL/;
 %Docstring
 Calculates azimuth between this point and other one (clockwise in degree, starting from north)
 %End
 
-    QgsPointXY project( double distance, double bearing ) const;
+    QgsPointXY project( double distance, double bearing ) const /HoldGIL/;
 %Docstring
 Returns a new point which corresponds to this point projected by a specified distance
 in a specified bearing.
@@ -186,7 +186,7 @@ in a specified bearing.
 .. versionadded:: 2.16
 %End
 
-    bool isEmpty() const;
+    bool isEmpty() const /HoldGIL/;
 %Docstring
 Returns ``True`` if the geometry is empty.
 Unlike :py:class:`QgsPoint`, this class is also used to retrieve graphical coordinates like QPointF.
@@ -196,7 +196,7 @@ A QgsPointXY is considered empty, when the coordinates have not been explicitly 
 .. versionadded:: 3.10
 %End
 
-    bool compare( const QgsPointXY &other, double epsilon = 4 * DBL_EPSILON ) const;
+    bool compare( const QgsPointXY &other, double epsilon = 4 * DBL_EPSILON ) const /HoldGIL/;
 %Docstring
 Compares this point with another point with a fuzzy tolerance
 
@@ -208,11 +208,11 @@ Compares this point with another point with a fuzzy tolerance
 .. versionadded:: 2.9
 %End
 
-    bool operator==( const QgsPointXY &other );
+    bool operator==( const QgsPointXY &other ) /HoldGIL/;
 
-    bool operator!=( const QgsPointXY &other ) const;
+    bool operator!=( const QgsPointXY &other ) const /HoldGIL/;
 
-    void multiply( double scalar );
+    void multiply( double scalar ) /HoldGIL/;
 %Docstring
 Multiply x and y by the given value
 %End

--- a/python/core/auto_generated/raster/qgsrasterblock.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterblock.sip.in
@@ -65,8 +65,14 @@ This method does not return ``True`` if size is not zero and all values are
 %End
 
     static int typeSize( int dataType ) /HoldGIL/;
+%Docstring
+Returns the size in bytes for the specified ``dataType``.
+%End
 
     int dataTypeSize() const /HoldGIL/;
+%Docstring
+Data type size in bytes.
+%End
 
     static bool typeIsNumeric( Qgis::DataType type );
 %Docstring

--- a/python/core/auto_generated/raster/qgsrasterblock.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterblock.sip.in
@@ -45,14 +45,14 @@ Reset block
 %End
 
 
-    bool isValid() const;
+    bool isValid() const /HoldGIL/;
 %Docstring
 Returns ``True`` if the block is valid (correctly filled with data).
 An empty block may still be valid (if zero size block was requested).
 If the block is not valid, error may be retrieved by :py:func:`~QgsRasterBlock.error` method.
 %End
 
-    void setValid( bool valid );
+    void setValid( bool valid ) /HoldGIL/;
 %Docstring
 Mark block as valid or invalid
 %End
@@ -64,9 +64,9 @@ This method does not return ``True`` if size is not zero and all values are
 'no data' (null).
 %End
 
-    static int typeSize( int dataType );
+    static int typeSize( int dataType ) /HoldGIL/;
 
-    int dataTypeSize() const;
+    int dataTypeSize() const /HoldGIL/;
 
     static bool typeIsNumeric( Qgis::DataType type );
 %Docstring
@@ -78,7 +78,7 @@ Returns ``True`` if data type is numeric
 Returns ``True`` if data type is color
 %End
 
-    Qgis::DataType dataType() const;
+    Qgis::DataType dataType() const  /HoldGIL/;
 %Docstring
 Returns data type
 %End
@@ -88,7 +88,7 @@ Returns data type
 For given data type returns wider type and sets no data value
 %End
 
-    bool hasNoDataValue() const;
+    bool hasNoDataValue() const /HoldGIL/;
 %Docstring
 ``True`` if the block has no data value.
 
@@ -97,7 +97,7 @@ For given data type returns wider type and sets no data value
 .. seealso:: :py:func:`noDataValue`
 %End
 
-    bool hasNoData() const;
+    bool hasNoData() const /HoldGIL/;
 %Docstring
 Returns ``True`` if the block may contain no data. It does not guarantee
 that it really contains any no data. It can be used to speed up processing.
@@ -106,7 +106,7 @@ Not the difference between this method and :py:func:`~QgsRasterBlock.hasNoDataVa
 :return: ``True`` if the block may contain no data
 %End
 
-    void setNoDataValue( double noDataValue );
+    void setNoDataValue( double noDataValue ) /HoldGIL/;
 %Docstring
 Sets cell value that will be considered as "no data".
 
@@ -115,7 +115,7 @@ Sets cell value that will be considered as "no data".
 .. versionadded:: 3.0
 %End
 
-    void resetNoDataValue();
+    void resetNoDataValue() /HoldGIL/;
 %Docstring
 Reset no data value: if there was a no data value previously set,
 it will be discarded.
@@ -125,7 +125,7 @@ it will be discarded.
 .. versionadded:: 3.0
 %End
 
-    double noDataValue() const;
+    double noDataValue() const /HoldGIL/;
 %Docstring
 Returns no data value. If the block does not have a no data value the
 returned value is undefined.
@@ -145,7 +145,7 @@ Gets byte array representing a value.
 :return: byte array representing the value
 %End
 
-    double value( int row, int column ) const;
+    double value( int row, int column ) const /HoldGIL/;
 %Docstring
 Read a single value if type of block is numeric. If type is color,
 returned value is undefined.
@@ -159,7 +159,7 @@ returned value is undefined.
 %End
 
 
-    double value( qgssize index ) const;
+    double value( qgssize index ) const /HoldGIL/;
 %Docstring
 Reads a single value if type of block is numeric. If type is color,
 returned value is undefined.
@@ -173,7 +173,7 @@ returned value is undefined.
 
 
 
-    QRgb color( int row, int column ) const;
+    QRgb color( int row, int column ) const /HoldGIL/;
 %Docstring
 Read a single color
 
@@ -183,7 +183,7 @@ Read a single color
 :return: color
 %End
 
-    QRgb color( qgssize index ) const;
+    QRgb color( qgssize index ) const /HoldGIL/;
 %Docstring
 Read a single value
 
@@ -192,7 +192,7 @@ Read a single value
 :return: color
 %End
 
-    bool isNoData( int row, int column ) const;
+    bool isNoData( int row, int column ) const /HoldGIL/;
 %Docstring
 Checks if value at position is no data
 
@@ -204,7 +204,7 @@ Checks if value at position is no data
 .. seealso:: :py:func:`valueAndNoData`
 %End
 
-    bool isNoData( qgssize row, qgssize column ) const;
+    bool isNoData( qgssize row, qgssize column ) const /HoldGIL/;
 %Docstring
 Check if value at position is no data
 
@@ -216,7 +216,7 @@ Check if value at position is no data
 .. seealso:: :py:func:`valueAndNoData`
 %End
 
-    bool isNoData( qgssize index ) const;
+    bool isNoData( qgssize index ) const /HoldGIL/;
 %Docstring
 Check if value at position is no data
 
@@ -227,7 +227,7 @@ Check if value at position is no data
 .. seealso:: :py:func:`valueAndNoData`
 %End
 
-    bool setValue( int row, int column, double value );
+    bool setValue( int row, int column, double value ) /HoldGIL/;
 %Docstring
 Set value on position
 
@@ -238,7 +238,7 @@ Set value on position
 :return: ``True`` on success
 %End
 
-    bool setValue( qgssize index, double value );
+    bool setValue( qgssize index, double value ) /HoldGIL/;
 %Docstring
 Set value on index (indexed line by line)
 
@@ -248,7 +248,7 @@ Set value on index (indexed line by line)
 :return: ``True`` on success
 %End
 
-    bool setColor( int row, int column, QRgb color );
+    bool setColor( int row, int column, QRgb color ) /HoldGIL/;
 %Docstring
 Set color on position
 
@@ -259,7 +259,7 @@ Set color on position
 :return: ``True`` on success
 %End
 
-    bool setColor( qgssize index, QRgb color );
+    bool setColor( qgssize index, QRgb color ) /HoldGIL/;
 %Docstring
 Set color on index (indexed line by line)
 
@@ -270,7 +270,7 @@ Set color on index (indexed line by line)
 %End
 
 
-    bool setIsNoData( int row, int column );
+    bool setIsNoData( int row, int column ) /HoldGIL/;
 %Docstring
 Set no data on pixel
 
@@ -280,7 +280,7 @@ Set no data on pixel
 :return: ``True`` on success
 %End
 
-    bool setIsNoData( qgssize index );
+    bool setIsNoData( qgssize index ) /HoldGIL/;
 %Docstring
 Set no data on pixel
 
@@ -303,7 +303,7 @@ Set the whole block to no data except specified rectangle
 :return: ``True`` on success
 %End
 
-    void setIsData( int row, int column );
+    void setIsData( int row, int column ) /HoldGIL/;
 %Docstring
 Remove no data flag on pixel. If the raster block does not have an explicit
 no data value set then an internal map of no data pixels is maintained for the block.
@@ -316,7 +316,7 @@ method. This method has no effect for raster blocks with an explicit no data val
 .. versionadded:: 2.10
 %End
 
-    void setIsData( qgssize index );
+    void setIsData( qgssize index ) /HoldGIL/;
 %Docstring
 Remove no data flag on pixel. If the raster block does not have an explicit
 no data value set then an internal map of no data pixels is maintained for the block.
@@ -427,7 +427,7 @@ The output rect has x oriented from left to right and y from top to bottom
 :return: the rectangle covered by sub extent
 %End
 
-    int width() const;
+    int width() const /HoldGIL/;
 %Docstring
 Returns the width (number of columns) of the raster block.
 
@@ -436,7 +436,7 @@ Returns the width (number of columns) of the raster block.
 .. versionadded:: 2.10
 %End
 
-    int height() const;
+    int height() const /HoldGIL/;
 %Docstring
 Returns the height (number of rows) of the raster block.
 

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -446,6 +446,7 @@ sub fix_annotations {
     $line =~ s/\bSIP_NODEFAULTCTORS\b/\/NoDefaultCtors\//;
     $line =~ s/\bSIP_OUT\b/\/Out\//g;
     $line =~ s/\bSIP_RELEASEGIL\b/\/ReleaseGIL\//;
+    $line =~ s/\bSIP_HOLDGIL\b/\/HoldGIL\//;    
     $line =~ s/\bSIP_TRANSFER\b/\/Transfer\//g;
     $line =~ s/\bSIP_TRANSFERBACK\b/\/TransferBack\//;
     $line =~ s/\bSIP_TRANSFERTHIS\b/\/TransferThis\//;

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -46,23 +46,23 @@ class CORE_EXPORT QgsRectangle
     QgsRectangle() = default; // optimised constructor for null rectangle - no need to call normalize here
 
     //! Constructor
-    explicit QgsRectangle( double xMin, double yMin = 0, double xMax = 0, double yMax = 0 )
-      : mXmin( xMin )
-      , mYmin( yMin )
-      , mXmax( xMax )
-      , mYmax( yMax )
+    explicit QgsRectangle( double xMin, double yMin = 0, double xMax = 0, double yMax = 0 ) SIP_HOLDGIL
+  : mXmin( xMin )
+    , mYmin( yMin )
+    , mXmax( xMax )
+    , mYmax( yMax )
     {
       normalize();
     }
 
     //! Construct a rectangle from two points. The rectangle is normalized after construction.
-    QgsRectangle( const QgsPointXY &p1, const QgsPointXY &p2 )
+    QgsRectangle( const QgsPointXY &p1, const QgsPointXY &p2 ) SIP_HOLDGIL
     {
       set( p1, p2 );
     }
 
     //! Construct a rectangle from a QRectF. The rectangle is normalized after construction.
-    QgsRectangle( const QRectF &qRectF )
+    QgsRectangle( const QRectF &qRectF ) SIP_HOLDGIL
     {
       mXmin = qRectF.topLeft().x();
       mYmin = qRectF.topLeft().y();
@@ -71,7 +71,7 @@ class CORE_EXPORT QgsRectangle
     }
 
     //! Copy constructor
-    QgsRectangle( const QgsRectangle &other )
+    QgsRectangle( const QgsRectangle &other ) SIP_HOLDGIL
     {
       mXmin = other.xMinimum();
       mYmin = other.yMinimum();
@@ -127,28 +127,28 @@ class CORE_EXPORT QgsRectangle
     /**
      * Set the minimum x value.
      */
-    void setXMinimum( double x ) { mXmin = x; }
+    void setXMinimum( double x ) SIP_HOLDGIL { mXmin = x; }
 
     /**
      * Set the maximum x value.
      */
-    void setXMaximum( double x ) { mXmax = x; }
+    void setXMaximum( double x ) SIP_HOLDGIL { mXmax = x; }
 
     /**
      * Set the minimum y value.
      */
-    void setYMinimum( double y ) { mYmin = y; }
+    void setYMinimum( double y ) SIP_HOLDGIL { mYmin = y; }
 
     /**
      * Set the maximum y value.
      */
-    void setYMaximum( double y ) { mYmax = y; }
+    void setYMaximum( double y ) SIP_HOLDGIL { mYmax = y; }
 
     /**
      * Set a rectangle so that min corner is at max
      * and max corner is at min. It is NOT normalized.
      */
-    void setMinimal()
+    void setMinimal() SIP_HOLDGIL
     {
       mXmin = std::numeric_limits<double>::max();
       mYmin = std::numeric_limits<double>::max();
@@ -159,22 +159,22 @@ class CORE_EXPORT QgsRectangle
     /**
      * Returns the x maximum value (right side of rectangle).
      */
-    double xMaximum() const { return mXmax; }
+    double xMaximum() const SIP_HOLDGIL { return mXmax; }
 
     /**
      * Returns the x minimum value (left side of rectangle).
      */
-    double xMinimum() const { return mXmin; }
+    double xMinimum() const SIP_HOLDGIL { return mXmin; }
 
     /**
      * Returns the y maximum value (top side of rectangle).
      */
-    double yMaximum() const { return mYmax; }
+    double yMaximum() const SIP_HOLDGIL { return mYmax; }
 
     /**
      * Returns the y minimum value (bottom side of rectangle).
      */
-    double yMinimum() const { return mYmin; }
+    double yMinimum() const SIP_HOLDGIL { return mYmin; }
 
     /**
      * Normalize the rectangle so it has non-negative width/height.
@@ -199,14 +199,14 @@ class CORE_EXPORT QgsRectangle
      * \see height()
      * \see area()
      */
-    double width() const { return mXmax - mXmin; }
+    double width() const SIP_HOLDGIL { return mXmax - mXmin; }
 
     /**
      * Returns the height of the rectangle.
      * \see width()
      * \see area()
      */
-    double height() const { return mYmax - mYmin; }
+    double height() const SIP_HOLDGIL { return mYmax - mYmin; }
 
     /**
      * Returns the area of the rectangle.
@@ -215,19 +215,19 @@ class CORE_EXPORT QgsRectangle
      * \see perimeter()
      * \since QGIS 3.0
      */
-    double area() const { return ( mXmax - mXmin ) * ( mYmax - mYmin ); }
+    double area() const SIP_HOLDGIL { return ( mXmax - mXmin ) * ( mYmax - mYmin ); }
 
     /**
      * Returns the perimeter of the rectangle.
      * \see area()
      * \since QGIS 3.0
      */
-    double perimeter() const { return 2 * ( mXmax - mXmin ) + 2 * ( mYmax - mYmin ); }
+    double perimeter() const SIP_HOLDGIL { return 2 * ( mXmax - mXmin ) + 2 * ( mYmax - mYmin ); }
 
     /**
      * Returns the center point of the rectangle.
      */
-    QgsPointXY center() const { return QgsPointXY( mXmax * 0.5 + mXmin * 0.5, mYmin * 0.5 + mYmax * 0.5 ); }
+    QgsPointXY center() const SIP_HOLDGIL { return QgsPointXY( mXmax * 0.5 + mXmin * 0.5, mYmin * 0.5 + mYmax * 0.5 ); }
 
     /**
      * Scale the rectangle around its center point.

--- a/src/core/qgis_sip.h
+++ b/src/core/qgis_sip.h
@@ -152,6 +152,11 @@
 #define SIP_RELEASEGIL
 
 /*
+ * https://www.riverbankcomputing.com/static/Docs/sip/annotations.html?highlight=keepreference#function-annotation-HoldGIL
+ */
+#define SIP_HOLDGIL
+
+/*
  * Will insert a `%Feature feature` directive in sip files
  */
 #define SIP_FEATURE(feature)

--- a/src/core/qgspointxy.h
+++ b/src/core/qgspointxy.h
@@ -52,17 +52,17 @@ class CORE_EXPORT QgsPointXY
     QgsPointXY() = default;
 
     //! Create a point from another point
-    QgsPointXY( const QgsPointXY &p );
+    QgsPointXY( const QgsPointXY &p ) SIP_HOLDGIL;
 
     /**
      * Create a point from x,y coordinates
      * \param x x coordinate
      * \param y y coordinate
      */
-    QgsPointXY( double x, double y )
-      : mX( x )
-      , mY( y )
-      , mIsEmpty( false )
+    QgsPointXY( double x, double y ) SIP_HOLDGIL
+  : mX( x )
+    , mY( y )
+    , mIsEmpty( false )
     {}
 
     /**
@@ -70,10 +70,10 @@ class CORE_EXPORT QgsPointXY
      * \param point QPointF source
      * \since QGIS 2.7
      */
-    QgsPointXY( QPointF point )
-      : mX( point.x() )
-      , mY( point.y() )
-      , mIsEmpty( false )
+    QgsPointXY( QPointF point ) SIP_HOLDGIL
+  : mX( point.x() )
+    , mY( point.y() )
+    , mIsEmpty( false )
     {}
 
     /**
@@ -81,10 +81,10 @@ class CORE_EXPORT QgsPointXY
      * \param point QPoint source
      * \since QGIS 2.7
      */
-    QgsPointXY( QPoint point )
-      : mX( point.x() )
-      , mY( point.y() )
-      , mIsEmpty( false )
+    QgsPointXY( QPoint point ) SIP_HOLDGIL
+  : mX( point.x() )
+    , mY( point.y() )
+    , mIsEmpty( false )
     {}
 
     /**
@@ -93,7 +93,7 @@ class CORE_EXPORT QgsPointXY
      *
      * \since QGIS 3.0
      */
-    QgsPointXY( const QgsPoint &point );
+    QgsPointXY( const QgsPoint &point ) SIP_HOLDGIL;
 
     // IMPORTANT - while QgsPointXY is inherited by QgsReferencedPointXY, we do NOT want a virtual destructor here
     // because this class MUST be lightweight and we don't want the cost of the vtable here.
@@ -104,7 +104,7 @@ class CORE_EXPORT QgsPointXY
      * Sets the x value of the point
      * \param x x coordinate
      */
-    void setX( double x )
+    void setX( double x ) SIP_HOLDGIL
     {
       mX = x;
       mIsEmpty = false;
@@ -114,14 +114,14 @@ class CORE_EXPORT QgsPointXY
      * Sets the y value of the point
      * \param y y coordinate
      */
-    void setY( double y )
+    void setY( double y ) SIP_HOLDGIL
     {
       mY = y;
       mIsEmpty = false;
     }
 
     //! Sets the x and y value of the point
-    void set( double x, double y )
+    void set( double x, double y ) SIP_HOLDGIL
     {
       mX = x;
       mY = y;
@@ -132,7 +132,7 @@ class CORE_EXPORT QgsPointXY
      * Gets the x value of the point
      * \returns x coordinate
      */
-    double x() const
+    double x() const SIP_HOLDGIL
     {
       return mX;
     }
@@ -141,7 +141,7 @@ class CORE_EXPORT QgsPointXY
      * Gets the y value of the point
      * \returns y coordinate
      */
-    double y() const
+    double y() const SIP_HOLDGIL
     {
       return mY;
     }
@@ -172,7 +172,7 @@ class CORE_EXPORT QgsPointXY
      * Returns the squared distance between this point a specified x, y coordinate.
      * \see distance()
     */
-    double sqrDist( double x, double y ) const
+    double sqrDist( double x, double y ) const SIP_HOLDGIL
     {
       return ( mX - x ) * ( mX - x ) + ( mY - y ) * ( mY - y );
     }
@@ -181,7 +181,7 @@ class CORE_EXPORT QgsPointXY
      * Returns the squared distance between this point another point.
      * \see distance()
     */
-    double sqrDist( const QgsPointXY &other ) const
+    double sqrDist( const QgsPointXY &other ) const SIP_HOLDGIL
     {
       return sqrDist( other.x(), other.y() );
     }
@@ -193,7 +193,7 @@ class CORE_EXPORT QgsPointXY
      * \see sqrDist()
      * \since QGIS 2.16
     */
-    double distance( double x, double y ) const
+    double distance( double x, double y ) const SIP_HOLDGIL
     {
       return std::sqrt( sqrDist( x, y ) );
     }
@@ -204,16 +204,16 @@ class CORE_EXPORT QgsPointXY
      * \see sqrDist()
      * \since QGIS 2.16
     */
-    double distance( const QgsPointXY &other ) const
+    double distance( const QgsPointXY &other ) const SIP_HOLDGIL
     {
       return std::sqrt( sqrDist( other ) );
     }
 
     //! Returns the minimum distance between this point and a segment
-    double sqrDistToSegment( double x1, double y1, double x2, double y2, QgsPointXY &minDistPoint SIP_OUT, double epsilon = DEFAULT_SEGMENT_EPSILON ) const;
+    double sqrDistToSegment( double x1, double y1, double x2, double y2, QgsPointXY &minDistPoint SIP_OUT, double epsilon = DEFAULT_SEGMENT_EPSILON ) const SIP_HOLDGIL;
 
     //! Calculates azimuth between this point and other one (clockwise in degree, starting from north)
-    double azimuth( const QgsPointXY &other ) const;
+    double azimuth( const QgsPointXY &other ) const SIP_HOLDGIL;
 
     /**
      * Returns a new point which corresponds to this point projected by a specified distance
@@ -222,7 +222,7 @@ class CORE_EXPORT QgsPointXY
      * \param bearing angle to project in, clockwise in degrees starting from north
      * \since QGIS 2.16
      */
-    QgsPointXY project( double distance, double bearing ) const;
+    QgsPointXY project( double distance, double bearing ) const SIP_HOLDGIL;
 
     /**
      * Returns TRUE if the geometry is empty.
@@ -231,7 +231,7 @@ class CORE_EXPORT QgsPointXY
      * A QgsPointXY is considered empty, when the coordinates have not been explicitly filled in.
      * \since QGIS 3.10
      */
-    bool isEmpty() const { return mIsEmpty; }
+    bool isEmpty() const SIP_HOLDGIL { return mIsEmpty; }
 
     /**
      * Compares this point with another point with a fuzzy tolerance
@@ -240,13 +240,13 @@ class CORE_EXPORT QgsPointXY
      * \returns TRUE if points are equal within specified tolerance
      * \since QGIS 2.9
      */
-    bool compare( const QgsPointXY &other, double epsilon = 4 * std::numeric_limits<double>::epsilon() ) const
+    bool compare( const QgsPointXY &other, double epsilon = 4 * std::numeric_limits<double>::epsilon() ) const SIP_HOLDGIL
     {
       return ( qgsDoubleNear( mX, other.x(), epsilon ) && qgsDoubleNear( mY, other.y(), epsilon ) );
     }
 
     //! equality operator
-    bool operator==( const QgsPointXY &other )
+    bool operator==( const QgsPointXY &other ) SIP_HOLDGIL
     {
       if ( isEmpty() && other.isEmpty() )
         return true;
@@ -263,7 +263,7 @@ class CORE_EXPORT QgsPointXY
     }
 
     //! Inequality operator
-    bool operator!=( const QgsPointXY &other ) const
+    bool operator!=( const QgsPointXY &other ) const SIP_HOLDGIL
     {
       if ( isEmpty() && other.isEmpty() )
         return false;
@@ -280,14 +280,14 @@ class CORE_EXPORT QgsPointXY
     }
 
     //! Multiply x and y by the given value
-    void multiply( double scalar )
+    void multiply( double scalar ) SIP_HOLDGIL
     {
       mX *= scalar;
       mY *= scalar;
     }
 
     //! Assignment
-    QgsPointXY &operator=( const QgsPointXY &other )
+    QgsPointXY &operator=( const QgsPointXY &other ) SIP_HOLDGIL
     {
       if ( &other != this )
       {

--- a/src/core/raster/qgsrasterblock.h
+++ b/src/core/raster/qgsrasterblock.h
@@ -77,7 +77,9 @@ class CORE_EXPORT QgsRasterBlock
      */
     bool isEmpty() const;
 
-    // Return data type size in bytes
+    /**
+     * Returns the size in bytes for the specified \a dataType.
+     */
     static int typeSize( int dataType ) SIP_HOLDGIL
     {
       // Modified and extended copy from GDAL
@@ -113,7 +115,9 @@ class CORE_EXPORT QgsRasterBlock
       }
     }
 
-    // Data type in bytes
+    /**
+     * Data type size in bytes.
+     */
     int dataTypeSize() const SIP_HOLDGIL
     {
       return typeSize( mDataType );

--- a/src/core/raster/qgsrasterblock.h
+++ b/src/core/raster/qgsrasterblock.h
@@ -65,10 +65,10 @@ class CORE_EXPORT QgsRasterBlock
      *  An empty block may still be valid (if zero size block was requested).
      *  If the block is not valid, error may be retrieved by error() method.
      */
-    bool isValid() const { return mValid; }
+    bool isValid() const SIP_HOLDGIL { return mValid; }
 
     //! \brief Mark block as valid or invalid
-    void setValid( bool valid ) { mValid = valid; }
+    void setValid( bool valid ) SIP_HOLDGIL { mValid = valid; }
 
     /**
      * Returns TRUE if block is empty, i.e. its size is 0 (zero rows or cols).
@@ -78,7 +78,7 @@ class CORE_EXPORT QgsRasterBlock
     bool isEmpty() const;
 
     // Return data type size in bytes
-    static int typeSize( int dataType )
+    static int typeSize( int dataType ) SIP_HOLDGIL
     {
       // Modified and extended copy from GDAL
       switch ( dataType )
@@ -114,7 +114,7 @@ class CORE_EXPORT QgsRasterBlock
     }
 
     // Data type in bytes
-    int dataTypeSize() const
+    int dataTypeSize() const SIP_HOLDGIL
     {
       return typeSize( mDataType );
     }
@@ -126,7 +126,7 @@ class CORE_EXPORT QgsRasterBlock
     static bool typeIsColor( Qgis::DataType type );
 
     //! Returns data type
-    Qgis::DataType dataType() const { return mDataType; }
+    Qgis::DataType dataType() const  SIP_HOLDGIL { return mDataType; }
 
     //! For given data type returns wider type and sets no data value
     static Qgis::DataType typeWithNoDataValue( Qgis::DataType dataType, double *noDataValue );
@@ -136,7 +136,7 @@ class CORE_EXPORT QgsRasterBlock
      * \returns TRUE if the block has no data value
      * \see noDataValue(), setNoDataValue(), resetNoDataValue()
      */
-    bool hasNoDataValue() const { return mHasNoDataValue; }
+    bool hasNoDataValue() const SIP_HOLDGIL { return mHasNoDataValue; }
 
     /**
      * Returns TRUE if the block may contain no data. It does not guarantee
@@ -144,7 +144,7 @@ class CORE_EXPORT QgsRasterBlock
      * Not the difference between this method and hasNoDataValue().
      * \returns TRUE if the block may contain no data
     */
-    bool hasNoData() const
+    bool hasNoData() const SIP_HOLDGIL
     {
       return mHasNoDataValue || mNoDataBitmap;
     }
@@ -154,7 +154,7 @@ class CORE_EXPORT QgsRasterBlock
      * \see noDataValue(), hasNoDataValue(), resetNoDataValue()
      * \since QGIS 3.0
      */
-    void setNoDataValue( double noDataValue );
+    void setNoDataValue( double noDataValue ) SIP_HOLDGIL;
 
     /**
      * Reset no data value: if there was a no data value previously set,
@@ -162,7 +162,7 @@ class CORE_EXPORT QgsRasterBlock
      * \see noDataValue(), hasNoDataValue(), setNoDataValue()
      * \since QGIS 3.0
      */
-    void resetNoDataValue();
+    void resetNoDataValue() SIP_HOLDGIL;
 
     /**
      * Returns no data value. If the block does not have a no data value the
@@ -170,7 +170,7 @@ class CORE_EXPORT QgsRasterBlock
      * \returns No data value
      * \see hasNoDataValue(), setNoDataValue(), resetNoDataValue()
      */
-    double noDataValue() const { return mNoDataValue; }
+    double noDataValue() const SIP_HOLDGIL { return mNoDataValue; }
 
     /**
      * Gets byte array representing a value.
@@ -188,7 +188,7 @@ class CORE_EXPORT QgsRasterBlock
      * \returns value
      * \see valueAndNoData()
     */
-    double value( int row, int column ) const
+    double value( int row, int column ) const SIP_HOLDGIL
     {
       return value( static_cast< qgssize >( row ) * mWidth + column );
     }
@@ -217,7 +217,7 @@ class CORE_EXPORT QgsRasterBlock
      * \returns value
      * \see valueAndNoData()
     */
-    inline double value( qgssize index ) const;
+    inline double value( qgssize index ) const SIP_HOLDGIL;
 
     /**
      * Reads a single value from the pixel at the specified data matrix \a index, if type of block is numeric. If type is color,
@@ -253,7 +253,7 @@ class CORE_EXPORT QgsRasterBlock
      *  \param column column index
      *  \returns color
     */
-    QRgb color( int row, int column ) const
+    QRgb color( int row, int column ) const SIP_HOLDGIL
     {
       if ( !mImage ) return NO_DATA_COLOR;
 
@@ -265,7 +265,7 @@ class CORE_EXPORT QgsRasterBlock
      *  \param index data matrix index (long type in Python)
      *  \returns color
     */
-    QRgb color( qgssize index ) const
+    QRgb color( qgssize index ) const SIP_HOLDGIL
     {
       int row = static_cast< int >( std::floor( static_cast< double >( index ) / mWidth ) );
       int column = index % mWidth;
@@ -279,7 +279,7 @@ class CORE_EXPORT QgsRasterBlock
      * \returns TRUE if value is no data
      * \see valueAndNoData()
     */
-    bool isNoData( int row, int column ) const
+    bool isNoData( int row, int column ) const SIP_HOLDGIL
     {
       return isNoData( static_cast< qgssize >( row ) * mWidth + column );
     }
@@ -291,7 +291,7 @@ class CORE_EXPORT QgsRasterBlock
      * \returns TRUE if value is no data
      * \see valueAndNoData()
     */
-    bool isNoData( qgssize row, qgssize column ) const
+    bool isNoData( qgssize row, qgssize column ) const SIP_HOLDGIL
     {
       return isNoData( row * static_cast< qgssize >( mWidth ) + column );
     }
@@ -302,7 +302,7 @@ class CORE_EXPORT QgsRasterBlock
      * \returns TRUE if value is no data
      * \see valueAndNoData()
     */
-    bool isNoData( qgssize index ) const
+    bool isNoData( qgssize index ) const SIP_HOLDGIL
     {
       if ( !mHasNoDataValue && !mNoDataBitmap )
         return false;
@@ -340,7 +340,7 @@ class CORE_EXPORT QgsRasterBlock
      *  \param value the value to be set
      *  \returns TRUE on success
     */
-    bool setValue( int row, int column, double value )
+    bool setValue( int row, int column, double value ) SIP_HOLDGIL
     {
       return setValue( static_cast< qgssize >( row ) * mWidth + column, value );
     }
@@ -351,7 +351,7 @@ class CORE_EXPORT QgsRasterBlock
      *  \param value the value to be set
      *  \returns TRUE on success
     */
-    bool setValue( qgssize index, double value )
+    bool setValue( qgssize index, double value ) SIP_HOLDGIL
     {
       if ( !mData )
       {
@@ -374,7 +374,7 @@ class CORE_EXPORT QgsRasterBlock
      *  \param color the color to be set, QRgb value
      *  \returns TRUE on success
     */
-    bool setColor( int row, int column, QRgb color )
+    bool setColor( int row, int column, QRgb color ) SIP_HOLDGIL
     {
       return setColor( static_cast< qgssize >( row ) * mWidth + column, color );
     }
@@ -385,7 +385,7 @@ class CORE_EXPORT QgsRasterBlock
      *  \param color the color to be set, QRgb value
      *  \returns TRUE on success
     */
-    bool setColor( qgssize index, QRgb color )
+    bool setColor( qgssize index, QRgb color ) SIP_HOLDGIL
     {
       if ( !mImage )
       {
@@ -425,7 +425,7 @@ class CORE_EXPORT QgsRasterBlock
      *  \param column column index
      *  \returns TRUE on success
     */
-    bool setIsNoData( int row, int column )
+    bool setIsNoData( int row, int column ) SIP_HOLDGIL
     {
       return setIsNoData( static_cast< qgssize >( row ) * mWidth + column );
     }
@@ -435,7 +435,7 @@ class CORE_EXPORT QgsRasterBlock
      *  \param index data matrix index (long type in Python)
      *  \returns TRUE on success
     */
-    bool setIsNoData( qgssize index )
+    bool setIsNoData( qgssize index ) SIP_HOLDGIL
     {
       if ( mHasNoDataValue )
       {
@@ -483,7 +483,7 @@ class CORE_EXPORT QgsRasterBlock
      *  \param column column index
      *  \since QGIS 2.10
     */
-    void setIsData( int row, int column )
+    void setIsData( int row, int column ) SIP_HOLDGIL
     {
       setIsData( static_cast< qgssize >( row )*mWidth + column );
     }
@@ -496,7 +496,7 @@ class CORE_EXPORT QgsRasterBlock
      *  \param index data matrix index (long type in Python)
      *  \since QGIS 2.10
     */
-    void setIsData( qgssize index )
+    void setIsData( qgssize index ) SIP_HOLDGIL
     {
       if ( mHasNoDataValue )
       {
@@ -636,14 +636,14 @@ class CORE_EXPORT QgsRasterBlock
      * \see height
      * \since QGIS 2.10
      */
-    int width() const { return mWidth; }
+    int width() const SIP_HOLDGIL { return mWidth; }
 
     /**
      * Returns the height (number of rows) of the raster block.
      * \see width
      * \since QGIS 2.10
      */
-    int height() const { return mHeight; }
+    int height() const SIP_HOLDGIL { return mHeight; }
 
   private:
     static QImage::Format imageFormat( Qgis::DataType dataType );


### PR DESCRIPTION
This prevents the Python GIL from being released before calling the method
(which is the default behaviour). For very cheap to call c++ methods the
cost of releasing the GIL can outweigh the cost of the c++ call, which means
it's more efficient to retain the hold on the GIL.

Ideally we'd do this everywhere, and switch to an explicit ReleaseGIL
annotation on functions which are slow or risky (raise exceptions, or
do something which can cause a GIL deadlock). But those are very tricky
to identify, so instead just explicitly hold the gil on cheap methods
which are likely to be called many times and could have an impact on
script performance.
