### PR TITLE
VectorFileWriter/OGR provider: workaround GDAL 3.1.x bug regarding XLSX and ODS creation

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -4340,6 +4340,18 @@ void QgsOgrProviderUtils::GDALCloseWrapper( GDALDatasetH hDS )
       GDALClose( hDS );
     }
   }
+
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,1,0) && GDAL_VERSION_NUM <= GDAL_COMPUTE_VERSION(3,1,3)
+  else if ( mGDALDriverName == QLatin1String( "XLSX" ) ||
+            mGDALDriverName == QLatin1String( "ODS" ) )
+  {
+    // Workaround bug in GDAL 3.1.0 to 3.1.3 that creates XLSX and ODS files incompatible with LibreOffice due to use of ZIP64
+    CPLSetThreadLocalConfigOption( "CPL_CREATE_ZIP64", "NO" );
+    GDALClose( hDS );
+    CPLSetThreadLocalConfigOption( "CPL_CREATE_ZIP64", nullptr );
+  }
+#endif
+
   else
   {
     GDALClose( hDS );
@@ -6186,7 +6198,25 @@ OGRErr QgsOgrLayer::RollbackTransaction()
 OGRErr QgsOgrLayer::SyncToDisk()
 {
   QMutexLocker locker( &ds->mutex );
-  return OGR_L_SyncToDisk( hLayer );
+
+  OGRErr eErr;
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,1,0) && GDAL_VERSION_NUM <= GDAL_COMPUTE_VERSION(3,1,3)
+  // Workaround bug in GDAL 3.1.0 to 3.1.3 that creates XLSX and ODS files incompatible with LibreOffice due to use of ZIP64
+  QString drvName = GDALGetDriverShortName( GDALGetDatasetDriver( ds->hDS ) );
+  if ( drvName == QLatin1String( "XLSX" ) ||
+       drvName == QLatin1String( "ODS" ) )
+  {
+    CPLSetThreadLocalConfigOption( "CPL_CREATE_ZIP64", "NO" );
+    eErr = OGR_L_SyncToDisk( hLayer );
+    CPLSetThreadLocalConfigOption( "CPL_CREATE_ZIP64", nullptr );
+  }
+  else
+#endif
+  {
+    eErr = OGR_L_SyncToDisk( hLayer );
+  }
+
+  return eErr;
 }
 
 void QgsOgrLayer::ExecuteSQLNoReturn( const QByteArray &sql )

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2696,6 +2696,21 @@ QgsVectorFileWriter::~QgsVectorFileWriter()
     }
   }
 
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,1,0) && GDAL_VERSION_NUM <= GDAL_COMPUTE_VERSION(3,1,3)
+  if ( mDS )
+  {
+    // Workaround bug in GDAL 3.1.0 to 3.1.3 that creates XLSX and ODS files incompatible with LibreOffice due to use of ZIP64
+    QString drvName = GDALGetDriverShortName( GDALGetDatasetDriver( mDS.get() ) );
+    if ( drvName == QLatin1String( "XLSX" ) ||
+         drvName == QLatin1String( "ODS" ) )
+    {
+      CPLSetThreadLocalConfigOption( "CPL_CREATE_ZIP64", "NO" );
+      mDS.reset();
+      CPLSetThreadLocalConfigOption( "CPL_CREATE_ZIP64", nullptr );
+    }
+  }
+#endif
+
   mDS.reset();
 
   if ( mOgrRef )


### PR DESCRIPTION
GDAL 3.1.0 to 3.1.3 will create XLSX and ODS files with ZIP64 extensions,
which make them incompatible of current LibreOffice versions.

This has been fixed in GDAL now, but this can be workaround on QGIS side too
if using those buggy versions.
