### PR TITLE
always detect GRASS installation folder on MacOS

### DIFF
--- a/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
+++ b/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
@@ -53,11 +53,6 @@ class Grass7AlgorithmProvider(QgsProcessingProvider):
             if self.activateSetting:
                 ProcessingConfig.addSetting(Setting(self.name(), self.activateSetting,
                                                     self.tr('Activate'), True))
-            if isMac():
-                ProcessingConfig.addSetting(Setting(
-                    self.name(),
-                    Grass7Utils.GRASS_FOLDER, self.tr('GRASS7 folder'),
-                    Grass7Utils.grassPath(), valuetype=Setting.FOLDER))
             ProcessingConfig.addSetting(Setting(
                 self.name(),
                 Grass7Utils.GRASS_LOG_COMMANDS,
@@ -94,8 +89,6 @@ class Grass7AlgorithmProvider(QgsProcessingProvider):
     def unload(self):
         if self.activateSetting:
             ProcessingConfig.removeSetting(self.activateSetting)
-        if isMac():
-            ProcessingConfig.removeSetting(Grass7Utils.GRASS_FOLDER)
         ProcessingConfig.removeSetting(Grass7Utils.GRASS_LOG_COMMANDS)
         ProcessingConfig.removeSetting(Grass7Utils.GRASS_LOG_CONSOLE)
         ProcessingConfig.removeSetting(Grass7Utils.GRASS_HELP_PATH)

--- a/python/plugins/processing/algs/grass7/Grass7Utils.py
+++ b/python/plugins/processing/algs/grass7/Grass7Utils.py
@@ -45,7 +45,6 @@ class Grass7Utils:
     GRASS_REGION_XMAX = 'GRASS7_REGION_XMAX'
     GRASS_REGION_YMAX = 'GRASS7_REGION_YMAX'
     GRASS_REGION_CELLSIZE = 'GRASS7_REGION_CELLSIZE'
-    GRASS_FOLDER = 'GRASS7_FOLDER'
     GRASS_LOG_COMMANDS = 'GRASS7_LOG_COMMANDS'
     GRASS_LOG_CONSOLE = 'GRASS7_LOG_CONSOLE'
     GRASS_HELP_PATH = 'GRASS_HELP_PATH'
@@ -206,27 +205,23 @@ class Grass7Utils:
         if not isWindows() and not isMac():
             return ''
 
-        if isMac():
-            folder = ProcessingConfig.getSetting(Grass7Utils.GRASS_FOLDER) or ''
-            if not os.path.exists(folder):
-                folder = None
-        else:
-            folder = None
-
-        if folder is None:
-            # Under MS-Windows, we use OSGEO4W or QGIS Path for folder
-            if isWindows():
-                if "GISBASE" in os.environ:
-                    folder = os.environ["GISBASE"]
-                else:
-                    testfolder = os.path.join(os.path.dirname(QgsApplication.prefixPath()), 'grass')
-                    if os.path.isdir(testfolder):
-                        grassfolders = sorted([f for f in os.listdir(testfolder) if f.startswith("grass-7.") and os.path.isdir(os.path.join(testfolder, f))], reverse=True, key=lambda x: [int(v) for v in x[len("grass-"):].split('.') if v != 'svn'])
-                        if grassfolders:
-                            folder = os.path.join(testfolder, grassfolders[0])
-            elif isMac():
-                # For MacOSX, we scan some well-known directories
-                # Start with QGIS bundle
+        folder = None
+        # Under MS-Windows, we use GISBASE or QGIS Path for folder
+        if isWindows():
+            if "GISBASE" in os.environ:
+                folder = os.environ["GISBASE"]
+            else:
+                testfolder = os.path.join(os.path.dirname(QgsApplication.prefixPath()), 'grass')
+                if os.path.isdir(testfolder):
+                    grassfolders = sorted([f for f in os.listdir(testfolder) if f.startswith("grass-7.") and os.path.isdir(os.path.join(testfolder, f))], reverse=True, key=lambda x: [int(v) for v in x[len("grass-"):].split('.') if v != 'svn'])
+                    if grassfolders:
+                        folder = os.path.join(testfolder, grassfolders[0])
+        elif isMac():
+            # For MacOSX, first check environment
+            if "GISBASE" in os.environ:
+                folder = os.environ["GISBASE"]
+            else:
+                # Find grass folder if it exists inside QGIS bundle
                 for version in ['', '7', '78', '76', '74', '72', '71', '70']:
                     testfolder = os.path.join(str(QgsApplication.prefixPath()),
                                               'grass{}'.format(version))


### PR DESCRIPTION
fix #38595

MacOS had (as only and only platform) custom settings parameter Grass7Utils.GRASS_FOLDER. This causing problems, since  for example if user has multiple QGIS installations or has some invalid folder in settings or path to some older QGIS version, things could crash easily. 

I have removed this extra parameter from settings and introduced environment variable `GISBASE`, commonly used in GRASS  scripts as "root" installation directory for force-override purposes. This is the same as it always was with Windows detection. If GISBASE is not present (that is default I believe most of the times), we search for `grass` folders in `QgsApplication.prefixPath()` (if packaged in bundle). If not found, the standalone GRASS is searched for (for Kyngchaos build). Just for completeness, on Linux the GRASS is purely found based on `which` tool searching for grass executable on PATH.

In short, the diference is that there is no GRASS folder in settings->processing->grass dialog, but there is new GISBASE env variable with the same purpose on MacOS. For Windows and Linux, no change.

The new behaviour is in-line with GDAL and SAGA processing tools and in-line with windows detection of GRASS. 


![Screenshot 2020-09-17 at 15 26 37](https://user-images.githubusercontent.com/804608/93477109-e07ca900-f8fa-11ea-9fba-4e087680c456.png)

