### PR TITLE
[Processing][GDAL] Clip Raster by extent - override CRS

### DIFF
--- a/python/plugins/processing/tests/testdata/gdal_algorithm_raster_tests.yaml
+++ b/python/plugins/processing/tests/testdata/gdal_algorithm_raster_tests.yaml
@@ -24,6 +24,7 @@ tests:
       INPUT:
         name: dem.tif
         type: raster
+      OVERCRS: false
       NODATA: 0.0
       OPTIONS: ''
       PROJWIN: 18.673038221977773,18.699957975064194,45.782253906735804,45.80350236352593
@@ -39,6 +40,7 @@ tests:
       INPUT:
         name: dem.tif
         type: raster
+      OVERCRS: false
       NODATA: 0.0
       OPTIONS: ''
       PROJWIN: 18.674136950224096,18.70011285383855,45.78239420868433,45.80342583519035


### PR DESCRIPTION
## Description

The GDAL algorithm Clip raster by extent does not provide the capabilities to override the output CRS.

In some cases, QGIS does not read the projection defined in the input layer. The user has defined the layer's CRS, but if QGIS has not read the INPUT CRS, the GDAL algorithm does the same so the OUTPUT layer has no CRS. 

The work around is to use the GDAL Assign projection algorithm.

The solution would be to override the OUTPUT layer's CRS by using `-a_srs` in the command line.

We propose to fix it by adding a boolean parameter to override the OUTPUT layer's CRS by the INPUT layer's one.