### PR TITLE
hide splash screen when loading the project

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1394,6 +1394,9 @@ int main( int argc, char *argv[] )
   /////////////////////////////////////////////////////////////////////
   if ( ! sProjectFileName.isEmpty() )
   {
+    // in case the project contains broken layers, interactive
+    // "Handle Bad Layers" is displayed that could be blocked by splash screen
+    mypSplash->hide();
     qgis->openProject( sProjectFileName );
   }
 


### PR DESCRIPTION
fix https://github.com/qgis/QGIS/issues/27051
fix https://github.com/qgis/QGIS/issues/34784

I am not sure this is correct fix, since now the splash screen is not visible during project load even there are no broken layers.
- Maybe better to not show it once hidden? 
- Or somehow pass splash object to `QgsHandleBadLayersHandler::handleBadLayers` and temporary hide it there? 
