### PR TITLE
Coordinate operation widget: avoid repeating scope and remarks

### DIFF
--- a/src/gui/qgscoordinateoperationwidget.cpp
+++ b/src/gui/qgscoordinateoperationwidget.cpp
@@ -252,18 +252,22 @@ void QgsCoordinateOperationWidget::loadAvailableOperations()
     QStringList authorityCodes;
 
     QStringList opText;
+    QString lastSingleOpScope;
+    QString lastSingleOpRemarks;
     for ( const QgsDatumTransform::SingleOperationDetails &singleOpDetails : transform.operationDetails )
     {
       QString text;
       if ( !singleOpDetails.scope.isEmpty() )
       {
         text += QStringLiteral( "<b>%1</b>: %2" ).arg( tr( "Scope" ), formatScope( singleOpDetails.scope ) );
+        lastSingleOpScope = singleOpDetails.scope;
       }
       if ( !singleOpDetails.remarks.isEmpty() )
       {
         if ( !text.isEmpty() )
           text += QStringLiteral( "<br>" );
         text += QStringLiteral( "<b>%1</b>: %2" ).arg( tr( "Remarks" ), singleOpDetails.remarks );
+        lastSingleOpRemarks = singleOpDetails.remarks;
       }
       if ( !singleOpDetails.areaOfUse.isEmpty() )
       {
@@ -284,11 +288,11 @@ void QgsCoordinateOperationWidget::loadAvailableOperations()
     }
 
     QString text;
-    if ( !transform.scope.isEmpty() )
+    if ( !transform.scope.isEmpty() && transform.scope != lastSingleOpScope )
     {
       text += QStringLiteral( "<b>%1</b>: %2" ).arg( tr( "Scope" ), transform.scope );
     }
-    if ( !transform.remarks.isEmpty() )
+    if ( !transform.remarks.isEmpty() && transform.remarks != lastSingleOpRemarks )
     {
       if ( !text.isEmpty() )
         text += QStringLiteral( "<br>" );


### PR DESCRIPTION
For coordinate operations that are not concatenated operations, we
currently display twice the scope and remarks. Let's strip a bit of
text to avoid confusing users even more :-)

Before:
![](https://user-images.githubusercontent.com/1192433/93502123-a0c3ba80-f916-11ea-8a47-415169330513.png)

After:
![image](https://user-images.githubusercontent.com/1192433/93514317-57c83200-f927-11ea-8eae-1ddb2c0781d9.png)

