### PR TITLE
Fix warning regarding ABC import from collections

### DIFF
--- a/tests/src/python/test_qgsdelimitedtextprovider.py
+++ b/tests/src/python/test_qgsdelimitedtextprovider.py
@@ -29,7 +29,11 @@ import tempfile
 import inspect
 import time
 import test_qgsdelimitedtextprovider_wanted as want  # NOQA
-import collections
+
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
 
 rebuildTests = 'REBUILD_DELIMITED_TEXT_TESTS' in os.environ
 
@@ -305,11 +309,11 @@ class TestQgsDelimitedTextProviderOther(unittest.TestCase):
                 for nr, r in enumerate(requests):
                     if verbose:
                         print(("Processing request", nr + 1, repr(r)))
-                    if isinstance(r, collections.Callable):
+                    if isinstance(r, Callable):
                         r(layer)
                         if verbose:
                             print("Request function executed")
-                    if isinstance(r, collections.Callable):
+                    if isinstance(r, Callable):
                         continue
                     rfields, rtypes, rdata = self.layerData(layer, r, nr * 1000)
                     if len(rfields) > len(fields):

--- a/tests/src/python/test_qgspallabeling_base.py
+++ b/tests/src/python/test_qgspallabeling_base.py
@@ -11,7 +11,6 @@ the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
 """
 
-import collections
 
 __author__ = 'Larry Shaffer'
 __date__ = '07/09/2013'
@@ -24,6 +23,11 @@ import sys
 import datetime
 import glob
 import shutil
+
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
 
 from qgis.PyQt.QtCore import QSize, qDebug, Qt
 from qgis.PyQt.QtGui import QFont, QColor
@@ -267,7 +271,7 @@ class TestQgsPalLabeling(unittest.TestCase):
                 value = getattr(lyr, attr)
                 if isinstance(value, (QgsGeometry, QgsStringReplacementCollection, QgsCoordinateTransform)):
                     continue  # ignore these objects
-                if not isinstance(value, collections.Callable):
+                if not isinstance(value, Callable):
                     res[attr] = value
         return res
 


### PR DESCRIPTION
## Description

Importing ABC from collections has been deprecated since Python 3.4 and will be removed in Python 3.10. Hence import ABC from collections in Python 2 and collections.abc in Python 3 for compatibility.
