### PR TITLE
Use plural form to indicate units in map item grid properties

### DIFF
--- a/src/gui/layout/qgslayoutmapgridwidget.cpp
+++ b/src/gui/layout/qgslayoutmapgridwidget.cpp
@@ -112,10 +112,10 @@ QgsLayoutMapGridWidget::QgsLayoutMapGridWidget( QgsLayoutItemMapGrid *mapGrid, Q
 
   blockAllSignals( true );
 
-  mMapGridUnitComboBox->addItem( tr( "Map Unit" ), QgsLayoutItemMapGrid::MapUnit );
+  mMapGridUnitComboBox->addItem( tr( "Map Units" ), QgsLayoutItemMapGrid::MapUnit );
   mMapGridUnitComboBox->addItem( tr( "Fit Segment Width" ), QgsLayoutItemMapGrid::DynamicPageSizeBased );
-  mMapGridUnitComboBox->addItem( tr( "Millimeter" ), QgsLayoutItemMapGrid::MM );
-  mMapGridUnitComboBox->addItem( tr( "Centimeter" ), QgsLayoutItemMapGrid::CM );
+  mMapGridUnitComboBox->addItem( tr( "Millimeters" ), QgsLayoutItemMapGrid::MM );
+  mMapGridUnitComboBox->addItem( tr( "Centimeters" ), QgsLayoutItemMapGrid::CM );
 
   mGridTypeComboBox->insertItem( 0, tr( "Solid" ), QgsLayoutItemMapGrid::Solid );
   mGridTypeComboBox->insertItem( 1, tr( "Cross" ), QgsLayoutItemMapGrid::Cross );

--- a/src/gui/layout/qgslayoutmapgridwidget.cpp
+++ b/src/gui/layout/qgslayoutmapgridwidget.cpp
@@ -416,8 +416,8 @@ void QgsLayoutMapGridWidget::insertFrameDisplayEntries( QComboBox *c )
 void QgsLayoutMapGridWidget::insertAnnotationDisplayEntries( QComboBox *c )
 {
   c->insertItem( 0, tr( "Show All" ), QgsLayoutItemMapGrid::ShowAll );
-  c->insertItem( 1, tr( "Show Latitude Only" ), QgsLayoutItemMapGrid::LatitudeOnly );
-  c->insertItem( 2, tr( "Show Longitude Only" ), QgsLayoutItemMapGrid::LongitudeOnly );
+  c->insertItem( 1, tr( "Show Latitude/Y Only" ), QgsLayoutItemMapGrid::LatitudeOnly );
+  c->insertItem( 2, tr( "Show Longitude/X Only" ), QgsLayoutItemMapGrid::LongitudeOnly );
   c->insertItem( 3, tr( "Disabled" ), QgsLayoutItemMapGrid::HideAll );
 }
 

--- a/src/ui/layout/qgslayoutmapgridwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapgridwidgetbase.ui
@@ -76,7 +76,7 @@
          <item>
           <widget class="QCheckBox" name="mEnabledCheckBox">
            <property name="text">
-            <string>Grid enabled</string>
+            <string>Enable grid</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
and active form for the checkbox
Same as in label properties and other places