### PR TITLE
Recalculate layout when legend item size changes

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
@@ -209,6 +209,13 @@ Draws label on the right side of the item
 Emitted on internal data change so the layer tree model can forward the signal to views
 %End
 
+    void sizeChanged();
+%Docstring
+Emitted when the size of this node changes.
+
+.. versionadded:: 3.16
+%End
+
   protected:
     explicit QgsLayerTreeModelLegendNode( QgsLayerTreeLayer *nodeL, QObject *parent /TransferThis/ = 0 );
 %Docstring

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -868,6 +868,17 @@ void QgsLayerTreeModel::legendNodeDataChanged()
     emit dataChanged( index, index );
 }
 
+void QgsLayerTreeModel::legendNodeSizeChanged()
+{
+  QgsLayerTreeModelLegendNode *legendNode = qobject_cast<QgsLayerTreeModelLegendNode *>( sender() );
+  if ( !legendNode )
+    return;
+
+  QModelIndex index = legendNode2index( legendNode );
+  if ( index.isValid() )
+    emit dataChanged( index, index, QVector<int> { Qt::SizeHintRole } );
+}
+
 
 void QgsLayerTreeModel::connectToLayer( QgsLayerTreeLayer *nodeLayer )
 {
@@ -1293,6 +1304,7 @@ void QgsLayerTreeModel::addLegendToLayer( QgsLayerTreeLayer *nodeL )
   {
     n->setParent( this );
     connect( n, &QgsLayerTreeModelLegendNode::dataChanged, this, &QgsLayerTreeModel::legendNodeDataChanged );
+    connect( n, &QgsLayerTreeModelLegendNode::sizeChanged, this, &QgsLayerTreeModel::legendNodeSizeChanged );
   }
 
   // See if we have an embedded node - if we do, we will not use it among active nodes.

--- a/src/core/layertree/qgslayertreemodel.h
+++ b/src/core/layertree/qgslayertreemodel.h
@@ -452,6 +452,9 @@ class CORE_EXPORT QgsLayerTreeModel : public QAbstractItemModel
     double mLegendMapViewScale;
     QTimer mDeferLegendInvalidationTimer;
 
+  private slots:
+    void legendNodeSizeChanged();
+
   private:
 
     //! Returns a temporary render context

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -68,6 +68,15 @@ QSizeF QgsLayerTreeModelLegendNode::userPatchSize() const
   return mUserSize;
 }
 
+void QgsLayerTreeModelLegendNode::setUserPatchSize( QSizeF size )
+{
+  if ( mUserSize == size )
+    return;
+
+  mUserSize = size;
+  emit sizeChanged();
+}
+
 QgsLayerTreeModelLegendNode::ItemMetrics QgsLayerTreeModelLegendNode::draw( const QgsLegendSettings &settings, ItemContext *ctx )
 {
   QFont symbolLabelFont = settings.style( QgsLegendStyle::SymbolLabel ).font();
@@ -1146,6 +1155,7 @@ void QgsWmsLegendNode::getLegendGraphicFinished( const QImage &image )
     if ( image != mImage )
     {
       mImage = image;
+      setUserPatchSize( mImage.size() );
       emit dataChanged();
     }
     mValid = true; // only if not null I guess

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -107,7 +107,7 @@ class CORE_EXPORT QgsLayerTreeModelLegendNode : public QObject
      * \see userPatchSize()
      * \since QGIS 3.14
      */
-    virtual void setUserPatchSize( QSizeF size ) { mUserSize = size; }
+    virtual void setUserPatchSize( QSizeF size );
 
     /**
      * Sets whether a forced column break should occur before the node.
@@ -254,6 +254,13 @@ class CORE_EXPORT QgsLayerTreeModelLegendNode : public QObject
   signals:
     //! Emitted on internal data change so the layer tree model can forward the signal to views
     void dataChanged();
+
+    /**
+     * Emitted when the size of this node changes.
+     *
+     * \since QGIS 3.16
+     */
+    void sizeChanged();
 
   protected:
     //! Construct the node with pointer to its parent layer node

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -76,28 +76,31 @@ QgsLayerTreeView::~QgsLayerTreeView()
 
 void QgsLayerTreeView::setModel( QAbstractItemModel *model )
 {
-  if ( !qobject_cast<QgsLayerTreeModel *>( model ) )
+  QgsLayerTreeModel *layerTreeModel = qobject_cast<QgsLayerTreeModel *>( model );
+  if ( !layerTreeModel )
     return;
 
   connect( model, &QAbstractItemModel::rowsInserted, this, &QgsLayerTreeView::modelRowsInserted );
   connect( model, &QAbstractItemModel::rowsRemoved, this, &QgsLayerTreeView::modelRowsRemoved );
 
   if ( mMessageBar )
-    connect( layerTreeModel(), &QgsLayerTreeModel::messageEmitted,
+    connect( layerTreeModel, &QgsLayerTreeModel::messageEmitted,
              [ = ]( const QString & message, Qgis::MessageLevel level = Qgis::Info, int duration = 5 )
   {mMessageBar->pushMessage( message, level, duration );}
          );
 
   QTreeView::setModel( model );
 
-  connect( layerTreeModel()->rootGroup(), &QgsLayerTreeNode::expandedChanged, this, &QgsLayerTreeView::onExpandedChanged );
-  connect( layerTreeModel()->rootGroup(), &QgsLayerTreeNode::customPropertyChanged, this, &QgsLayerTreeView::onCustomPropertyChanged );
+  connect( layerTreeModel->rootGroup(), &QgsLayerTreeNode::expandedChanged, this, &QgsLayerTreeView::onExpandedChanged );
+  connect( layerTreeModel->rootGroup(), &QgsLayerTreeNode::customPropertyChanged, this, &QgsLayerTreeView::onCustomPropertyChanged );
 
   connect( selectionModel(), &QItemSelectionModel::currentChanged, this, &QgsLayerTreeView::onCurrentChanged );
 
-  connect( layerTreeModel(), &QAbstractItemModel::modelReset, this, &QgsLayerTreeView::onModelReset );
+  connect( layerTreeModel, &QAbstractItemModel::modelReset, this, &QgsLayerTreeView::onModelReset );
 
-  updateExpandedStateFromNode( layerTreeModel()->rootGroup() );
+  connect( layerTreeModel, &QgsLayerTreeModel::dataChanged, this, &QgsLayerTreeView::onDataChanged );
+
+  updateExpandedStateFromNode( layerTreeModel->rootGroup() );
 }
 
 QgsLayerTreeModel *QgsLayerTreeView::layerTreeModel() const
@@ -585,4 +588,17 @@ void QgsLayerTreeView::onHorizontalScroll( int value )
 {
   Q_UNUSED( value )
   viewport()->update();
+}
+
+void QgsLayerTreeView::onDataChanged( const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles )
+{
+  Q_UNUSED( topLeft )
+  Q_UNUSED( bottomRight )
+
+  // If an item is resized asynchroneously (e.g. wms legend)
+  // The items below will need to be shifted vertically.
+  // This doesn't happen automatically, unless the viewport update is triggered.
+
+  if ( roles.contains( Qt::SizeHintRole ) )
+    viewport()->update();
 }

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -595,7 +595,7 @@ void QgsLayerTreeView::onDataChanged( const QModelIndex &topLeft, const QModelIn
   Q_UNUSED( topLeft )
   Q_UNUSED( bottomRight )
 
-  // If an item is resized asynchroneously (e.g. wms legend)
+  // If an item is resized asynchronously (e.g. wms legend)
   // The items below will need to be shifted vertically.
   // This doesn't happen automatically, unless the viewport update is triggered.
 

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -248,6 +248,8 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
     //! Handles updating the viewport to avoid flicker
     void onHorizontalScroll( int value );
 
+    void onDataChanged( const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles );
+
   protected:
     //! helper class with default actions. Lazily initialized.
     QgsLayerTreeViewDefaultActions *mDefaultActions = nullptr;


### PR DESCRIPTION
This triggers an `update()` of the legend viewport when the size of the legend item changes.

The solution is only partially satisfying. This should be done automatically by the model / view themselves. And it seems to work correctly for WMS. I couldn't find out why.

This patch works without any side effects. Happy to dump it in favor of an alternative approach.

Fixes #38881