### PR TITLE
Add rotation widget to the georeferencer canvas

### DIFF
--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -771,6 +771,13 @@ void QgsGeoreferencerMainWindow::extentsChangedQGisCanvas()
   }
 }
 
+void QgsGeoreferencerMainWindow::updateCanvasRotation()
+{
+  double degrees = mRotationEdit->value();
+  mCanvas->setRotation( degrees );
+  mCanvas->refresh();
+}
+
 // Canvas info slots (copy/pasted from QGIS :) )
 void QgsGeoreferencerMainWindow::showMouseCoords( const QgsPointXY &p )
 {
@@ -1069,6 +1076,26 @@ QLabel *QgsGeoreferencerMainWindow::createBaseLabelStatus()
 
 void QgsGeoreferencerMainWindow::createStatusBar()
 {
+  // add a widget to show/set current rotation
+  mRotationLabel = createBaseLabelStatus();
+  mRotationLabel->setObjectName( QStringLiteral( "mRotationLabel" ) );
+  mRotationLabel->setText( tr( "Rotation" ) );
+  mRotationLabel->setToolTip( tr( "Current clockwise map rotation in degrees" ) );
+  statusBar()->addPermanentWidget( mRotationLabel, 0 );
+
+  mRotationEdit = new QgsDoubleSpinBox( statusBar() );
+  mRotationEdit->setObjectName( QStringLiteral( "mRotationEdit" ) );
+  mRotationEdit->setClearValue( 0.0 );
+  mRotationEdit->setKeyboardTracking( false );
+  mRotationEdit->setMaximumWidth( 120 );
+  mRotationEdit->setDecimals( 1 );
+  mRotationEdit->setRange( -360.0, 360.0 );
+  mRotationEdit->setWrapping( true );
+  mRotationEdit->setSingleStep( 5.0 );
+  mRotationEdit->setSuffix( tr( " °" ) );
+  mRotationEdit->setToolTip( tr( "Current clockwise map rotation in degrees" ) );
+  statusBar()->addPermanentWidget( mRotationEdit, 0 );
+
   mTransformParamLabel = createBaseLabelStatus();
   mTransformParamLabel->setText( tr( "Transform: " ) + convertTransformEnumToString( mTransformParam ) );
   mTransformParamLabel->setToolTip( tr( "Current transform parametrisation" ) );
@@ -1098,6 +1125,9 @@ void QgsGeoreferencerMainWindow::setupConnections()
 
   // Connect extents changed - Use for need add again Raster
   connect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsGeoreferencerMainWindow::extentsChanged );
+
+  // Connect mapCanvas rotation widget
+  connect( mRotationEdit, static_cast < void ( QgsDoubleSpinBox::* )( double ) > ( &QgsDoubleSpinBox::valueChanged ), this, &QgsGeoreferencerMainWindow::updateCanvasRotation );
 }
 
 void QgsGeoreferencerMainWindow::removeOldLayer()
@@ -1111,6 +1141,7 @@ void QgsGeoreferencerMainWindow::removeOldLayer()
   }
   mCanvas->setLayers( QList<QgsMapLayer *>() );
   mCanvas->clearCache();
+  mRotationEdit->clear();
   mCanvas->refresh();
 }
 

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -28,6 +28,7 @@ class QPlainTextEdit;
 class QLabel;
 
 class QgisInterface;
+class QgsDoubleSpinBox;
 class QgsGeorefDataPoint;
 class QgsGCPListWidget;
 class QgsMapTool;
@@ -105,6 +106,7 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     void jumpToGCP( uint theGCPIndex );
     void extentsChangedGeorefCanvas();
     void extentsChangedQGisCanvas();
+    void updateCanvasRotation();
 
     // canvas info
     void showMouseCoords( const QgsPointXY &pt );
@@ -211,6 +213,8 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     QLabel *mCoordsLabel = nullptr;
     QLabel *mTransformParamLabel = nullptr;
     QLabel *mEPSG = nullptr;
+    QLabel *mRotationLabel = nullptr;
+    QgsDoubleSpinBox *mRotationEdit = nullptr;
     unsigned int mMousePrecisionDecimalPlaces;
 
     QString mRasterFileName;


### PR DESCRIPTION
## Description
You have your maps scanned with arbitrary orientations? No problem!

![rotate](https://user-images.githubusercontent.com/11358178/93689288-bb905d80-fad5-11ea-802b-d6b122caa207.gif)


<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
