### PR TITLE
Improve legend performance

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreemodel.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreemodel.sip.in
@@ -415,6 +415,7 @@ Filter nodes from QgsMapLayerLegend according to the current filtering rules
 
 
 
+
 };
 
 QFlags<QgsLayerTreeModel::Flag> operator|(QgsLayerTreeModel::Flag f1, QFlags<QgsLayerTreeModel::Flag> f2);

--- a/src/core/layertree/qgslayertreemodel.h
+++ b/src/core/layertree/qgslayertreemodel.h
@@ -435,6 +435,12 @@ class CORE_EXPORT QgsLayerTreeModel : public QAbstractItemModel
     //! Per layer data about layer's legend nodes
     QHash<QgsLayerTreeLayer *, LayerLegendData> mLegend;
 
+    /**
+     * Keep track of layer nodes for which the legend
+     * size needs to be recalculated
+     */
+    QSet<QgsLayerTreeLayer *> mInvalidatedNodes;
+
     QFont mFontLayer;
     QFont mFontGroup;
 


### PR DESCRIPTION
Only recalculate the position of the icons for affected legend nodes.
Avoids brute forcing over complex legends as soon as something is changed.

Fixes #38890
