### PR TITLE
Don't delete QgsSymbolSelectorWidget symbol when widget is closed

### DIFF
--- a/src/gui/qgssymbolbutton.cpp
+++ b/src/gui/qgssymbolbutton.cpp
@@ -115,7 +115,6 @@ void QgsSymbolButton::showSettingsDialog()
     d->setPanelTitle( mDialogTitle );
     d->setContext( symbolContext );
     connect( d, &QgsPanelWidget::widgetChanged, this, &QgsSymbolButton::updateSymbolFromWidget );
-    connect( d, &QgsPanelWidget::panelAccepted, this, &QgsSymbolButton::cleanUpSymbolSelector );
     panel->openPanel( d );
   }
   else
@@ -141,15 +140,6 @@ void QgsSymbolButton::updateSymbolFromWidget()
 {
   if ( QgsSymbolSelectorWidget *w = qobject_cast<QgsSymbolSelectorWidget *>( sender() ) )
     setSymbol( w->symbol()->clone() );
-}
-
-void QgsSymbolButton::cleanUpSymbolSelector( QgsPanelWidget *container )
-{
-  QgsSymbolSelectorWidget *w = qobject_cast<QgsSymbolSelectorWidget *>( container );
-  if ( !w )
-    return;
-
-  delete w->symbol();
 }
 
 QgsMapCanvas *QgsSymbolButton::mapCanvas() const

--- a/src/gui/qgssymbolbutton.h
+++ b/src/gui/qgssymbolbutton.h
@@ -234,7 +234,6 @@ class GUI_EXPORT QgsSymbolButton : public QToolButton
 
     void showSettingsDialog();
     void updateSymbolFromWidget();
-    void cleanUpSymbolSelector( QgsPanelWidget *container );
 
     /**
      * Creates the drop-down menu entries


### PR DESCRIPTION
## Description

Fixes #38920 :  Don't delete the symbol without deleting the widget. The widget is still connected to some signals (see constructor) and try to access the deleting symbol in slot method. The widget and the symbol will be deleted by QgsPanelWidgetStack::closePanel (panel has autoDelete flag)


