### PR TITLE
When a layer is being removed from the project, gracefully close and cleanup all panels in the layer styling dock

### DIFF
--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -142,6 +142,9 @@ void QgsLayerStylingWidget::setLayer( QgsMapLayer *layer )
   if ( layer == mCurrentLayer )
     return;
 
+  // when current layer is changed, apply the main panel stack to allow it to gracefully clean up
+  mWidgetStack->acceptAllPanels();
+
   if ( mCurrentLayer )
   {
     disconnect( mCurrentLayer, &QgsMapLayer::styleChanged, this, &QgsLayerStylingWidget::updateCurrentWidgetLayer );
@@ -679,6 +682,9 @@ void QgsLayerStylingWidget::layerAboutToBeRemoved( QgsMapLayer *layer )
 {
   if ( layer == mCurrentLayer )
   {
+    // when current layer is removed, apply the main panel stack to allow it to gracefully clean up
+    mWidgetStack->acceptAllPanels();
+
     mAutoApplyTimer->stop();
     setLayer( nullptr );
   }


### PR DESCRIPTION
Supersedes https://github.com/qgis/QGIS/pull/38921

Fixes #38920
