### PR TITLE
Dump backtraces on uncaught exceptions

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -386,6 +386,11 @@ void myMessageOutput( QtMsgType type, const QMessageLogContext &, const QString 
       break;
     case QtCriticalMsg:
       myPrint( "Critical: %s\n", msg.toLocal8Bit().constData() );
+
+#ifdef QGISDEBUG
+      dumpBacktrace( 20 );
+#endif
+
       break;
     case QtWarningMsg:
     {

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -448,19 +448,19 @@ bool QgsApplication::notify( QObject *receiver, QEvent *event )
   }
   catch ( QgsException &e )
   {
-    QgsDebugMsg( "Caught unhandled QgsException: " + e.what() );
+    qCritical() << "Caught unhandled QgsException: " << e.what();
     if ( qApp->thread() == QThread::currentThread() )
       QMessageBox::critical( activeWindow(), tr( "Exception" ), e.what() );
   }
   catch ( std::exception &e )
   {
-    QgsDebugMsg( "Caught unhandled std::exception: " + QString::fromLatin1( e.what() ) );
+    qCritical() << "Caught unhandled std::exception: " << e.what();
     if ( qApp->thread() == QThread::currentThread() )
       QMessageBox::critical( activeWindow(), tr( "Exception" ), e.what() );
   }
   catch ( ... )
   {
-    QgsDebugMsg( QStringLiteral( "Caught unhandled unknown exception" ) );
+    qCritical() << "Caught unhandled unknown exception";
     if ( qApp->thread() == QThread::currentThread() )
       QMessageBox::critical( activeWindow(), tr( "Exception" ), tr( "unknown exception" ) );
   }


### PR DESCRIPTION
Instead of just logging that we encountered the exception, give more useful debug info by dumping the backtrace