### PR TITLE
Fix constraint metadata is duplicated after opening layer properties

### DIFF
--- a/src/gui/qgsmetadatawidget.cpp
+++ b/src/gui/qgsmetadatawidget.cpp
@@ -542,6 +542,7 @@ void QgsMetadataWidget::setUiFromMetadata()
     mRightsModel->setStringList( layerMetadata->rights() );
 
     // Constraints
+    mConstraintsModel->clear();
     const QList<QgsLayerMetadata::Constraint> &constraints = layerMetadata->constraints();
     for ( const QgsLayerMetadata::Constraint &constraint : constraints )
     {


### PR DESCRIPTION
Fixes #38916
