### PR TITLE
Improve UI for formatting manual table cells

### DIFF
--- a/python/gui/auto_generated/tableeditor/qgstableeditorwidget.sip.in
+++ b/python/gui/auto_generated/tableeditor/qgstableeditorwidget.sip.in
@@ -76,7 +76,7 @@ Returns ``True`` if the current selection has a mix of numeric formats.
 .. seealso:: :py:func:`selectionNumericFormat`
 %End
 
-    QColor selectionForegroundColor();
+ QColor selectionForegroundColor() /Deprecated/;
 %Docstring
 Returns the foreground color for the currently selected cells.
 
@@ -86,6 +86,9 @@ invalid color will be returned.
 .. seealso:: :py:func:`setSelectionForegroundColor`
 
 .. seealso:: :py:func:`selectionBackgroundColor`
+
+.. deprecated::
+   use selectionTextFormat() instead.
 %End
 
     QColor selectionBackgroundColor();
@@ -278,13 +281,16 @@ current selected cells.
 Clears the contents of the currently selected cells.
 %End
 
-    void setSelectionForegroundColor( const QColor &color );
+ void setSelectionForegroundColor( const QColor &color ) /Deprecated/;
 %Docstring
 Sets the foreground color for the currently selected cells.
 
 .. seealso:: :py:func:`selectionForegroundColor`
 
 .. seealso:: :py:func:`setSelectionBackgroundColor`
+
+.. deprecated::
+   Use setSelectionTextFormat() instead.
 %End
 
     void setSelectionBackgroundColor( const QColor &color );

--- a/src/gui/tableeditor/qgstableeditordialog.cpp
+++ b/src/gui/tableeditor/qgstableeditordialog.cpp
@@ -77,7 +77,6 @@ QgsTableEditorDialog::QgsTableEditorDialog( QWidget *parent )
 
   mPropertiesDock->setFeatures( QDockWidget::NoDockWidgetFeatures );
 
-  connect( mFormattingWidget, &QgsTableEditorFormattingWidget::foregroundColorChanged, mTableWidget, &QgsTableEditorWidget::setSelectionForegroundColor );
   connect( mFormattingWidget, &QgsTableEditorFormattingWidget::backgroundColorChanged, mTableWidget, &QgsTableEditorWidget::setSelectionBackgroundColor );
 
   connect( mFormattingWidget, &QgsTableEditorFormattingWidget::horizontalAlignmentChanged, mTableWidget, &QgsTableEditorWidget::setSelectionHorizontalAlignment );
@@ -98,7 +97,6 @@ QgsTableEditorDialog::QgsTableEditorDialog( QWidget *parent )
 
   connect( mTableWidget, &QgsTableEditorWidget::activeCellChanged, this, [ = ]
   {
-    mFormattingWidget->setForegroundColor( mTableWidget->selectionForegroundColor() );
     mFormattingWidget->setBackgroundColor( mTableWidget->selectionBackgroundColor() );
     mFormattingWidget->setNumericFormat( mTableWidget->selectionNumericFormat(), mTableWidget->hasMixedSelectionNumericFormat() );
     mFormattingWidget->setRowHeight( mTableWidget->selectionRowHeight() );

--- a/src/gui/tableeditor/qgstableeditorformattingwidget.cpp
+++ b/src/gui/tableeditor/qgstableeditorformattingwidget.cpp
@@ -30,10 +30,6 @@ QgsTableEditorFormattingWidget::QgsTableEditorFormattingWidget( QWidget *parent 
   mFontButton->setShowNullFormat( true );
   mFontButton->setNoFormatString( tr( "Clear Formatting" ) );
 
-  mTextColorButton->setAllowOpacity( true );
-  mTextColorButton->setColorDialogTitle( tr( "Text Color" ) );
-  mTextColorButton->setDefaultColor( QColor( 0, 0, 0 ) );
-  mTextColorButton->setShowNull( true );
   mBackgroundColorButton->setAllowOpacity( true );
   mBackgroundColorButton->setColorDialogTitle( tr( "Text Color" ) );
   mBackgroundColorButton->setDefaultColor( QColor( 255, 255, 255 ) );
@@ -45,16 +41,6 @@ QgsTableEditorFormattingWidget::QgsTableEditorFormattingWidget( QWidget *parent 
   mRowHeightSpinBox->setClearValue( 0, tr( "Automatic" ) );
   mColumnWidthSpinBox->setClearValue( 0, tr( "Automatic" ) );
 
-  connect( mTextColorButton, &QgsColorButton::colorChanged, this, [ = ]
-  {
-    if ( !mBlockSignals )
-      emit foregroundColorChanged( mTextColorButton->color() );
-  } );
-  connect( mTextColorButton, &QgsColorButton::cleared, this, [ = ]
-  {
-    if ( !mBlockSignals )
-      emit foregroundColorChanged( QColor() );
-  } );
   connect( mBackgroundColorButton, &QgsColorButton::colorChanged, this,  [ = ]
   {
     if ( !mBlockSignals )
@@ -159,13 +145,6 @@ QgsNumericFormat *QgsTableEditorFormattingWidget::numericFormat()
 QgsTextFormat QgsTableEditorFormattingWidget::textFormat() const
 {
   return mFontButton->textFormat();
-}
-
-void QgsTableEditorFormattingWidget::setForegroundColor( const QColor &color )
-{
-  mBlockSignals++;
-  mTextColorButton->setColor( color );
-  mBlockSignals--;
 }
 
 void QgsTableEditorFormattingWidget::setBackgroundColor( const QColor &color )

--- a/src/gui/tableeditor/qgstableeditorformattingwidget.h
+++ b/src/gui/tableeditor/qgstableeditorformattingwidget.h
@@ -68,14 +68,6 @@ class GUI_EXPORT QgsTableEditorFormattingWidget : public QgsPanelWidget, public 
     QgsTextFormat textFormat() const;
 
     /**
-     * Sets the cell foreground \a color to show in the widget.
-     *
-     * \see foregroundColorChanged()
-     * \see setBackgroundColor()
-     */
-    void setForegroundColor( const QColor &color );
-
-    /**
      * Sets the cell background \a color to show in the widget.
      *
      * \see backgroundColorChanged()
@@ -153,13 +145,6 @@ class GUI_EXPORT QgsTableEditorFormattingWidget : public QgsPanelWidget, public 
     QgsExpressionContext createExpressionContext() const override;
 
   signals:
-
-    /**
-     * Emitted whenever the cell foreground \a color is changed in the widget.
-     *
-     * \see setForegroundColor()
-     */
-    void foregroundColorChanged( const QColor &color );
 
     /**
      * Emitted whenever the cell background \a color is changed in the widget.

--- a/src/gui/tableeditor/qgstableeditorwidget.cpp
+++ b/src/gui/tableeditor/qgstableeditorwidget.cpp
@@ -324,7 +324,7 @@ void QgsTableEditorWidget::setTableContents( const QgsTableContents &contents )
       item->setData( CellContent, col.content() ); // can't use EditRole, because Qt. (https://bugreports.qt.io/browse/QTBUG-11549)
       item->setData( Qt::BackgroundRole, col.backgroundColor().isValid() ? col.backgroundColor() : QColor( 255, 255, 255 ) );
       item->setData( PresetBackgroundColorRole, col.backgroundColor().isValid() ? col.backgroundColor() : QVariant() );
-      item->setData( Qt::ForegroundRole, col.foregroundColor().isValid() ? col.foregroundColor() : QVariant() );
+      item->setData( Qt::ForegroundRole, col.textFormat().isValid() ? col.textFormat().color() : QVariant() );
       item->setData( TextFormat, QVariant::fromValue( col.textFormat() ) );
       item->setData( HorizontalAlignment, static_cast< int >( col.horizontalAlignment() ) );
       item->setData( VerticalAlignment, static_cast< int >( col.verticalAlignment() ) );
@@ -372,7 +372,6 @@ QgsTableContents QgsTableEditorWidget::tableContents() const
       {
         cell.setContent( i->data( CellProperty ).value< QgsProperty >().isActive() ? i->data( CellProperty ) : i->data( CellContent ) );
         cell.setBackgroundColor( i->data( PresetBackgroundColorRole ).value< QColor >() );
-        cell.setForegroundColor( i->data( Qt::ForegroundRole ).value< QColor >() );
         cell.setTextFormat( i->data( TextFormat ).value< QgsTextFormat >() );
         cell.setHorizontalAlignment( static_cast< Qt::Alignment >( i->data( HorizontalAlignment ).toInt() ) );
         cell.setVerticalAlignment( static_cast< Qt::Alignment >( i->data( VerticalAlignment ).toInt() ) );
@@ -494,25 +493,8 @@ bool QgsTableEditorWidget::hasMixedSelectionNumericFormat()
 
 QColor QgsTableEditorWidget::selectionForegroundColor()
 {
-  QColor c;
-  bool first = true;
-  const QModelIndexList selection = selectedIndexes();
-  for ( const QModelIndex &index : selection )
-  {
-    QColor indexColor = model()->data( index, Qt::ForegroundRole ).isValid() ? model()->data( index, Qt::ForegroundRole ).value< QColor >() : QColor();
-    if ( first )
-    {
-      c = indexColor;
-      first = false;
-    }
-    else if ( indexColor == c )
-      continue;
-    else
-    {
-      return QColor();
-    }
-  }
-  return c;
+  const QgsTextFormat f = selectionTextFormat();
+  return f.isValid() ? f.color() : QColor();
 }
 
 QColor QgsTableEditorWidget::selectionBackgroundColor()
@@ -963,6 +945,9 @@ void QgsTableEditorWidget::setSelectionForegroundColor( const QColor &color )
       if ( i->data( Qt::ForegroundRole ).value< QColor >() != color )
       {
         i->setData( Qt::ForegroundRole, color.isValid() ? color : QVariant() );
+        QgsTextFormat f = i->data( TextFormat ).value< QgsTextFormat >();
+        f.setColor( color );
+        i->setData( TextFormat, QVariant::fromValue( f ) );
         changed = true;
       }
     }
@@ -970,6 +955,9 @@ void QgsTableEditorWidget::setSelectionForegroundColor( const QColor &color )
     {
       QTableWidgetItem *newItem = new QTableWidgetItem();
       newItem->setData( Qt::ForegroundRole, color.isValid() ? color : QVariant() );
+      QgsTextFormat f;
+      f.setColor( color );
+      newItem->setData( TextFormat, QVariant::fromValue( f ) );
       setItem( index.row(), index.column(), newItem );
       changed = true;
     }
@@ -1138,12 +1126,14 @@ void QgsTableEditorWidget::setSelectionTextFormat( const QgsTextFormat &format )
     if ( QTableWidgetItem *i = item( index.row(), index.column() ) )
     {
       i->setData( TextFormat, QVariant::fromValue( format ) );
+      i->setData( Qt::ForegroundRole, format.color() );
       changed = true;
     }
     else
     {
       QTableWidgetItem *newItem = new QTableWidgetItem();
       newItem->setData( TextFormat, QVariant::fromValue( format ) );
+      newItem->setData( Qt::ForegroundRole, format.color() );
       setItem( index.row(), index.column(), newItem );
       changed = true;
     }

--- a/src/gui/tableeditor/qgstableeditorwidget.h
+++ b/src/gui/tableeditor/qgstableeditorwidget.h
@@ -169,8 +169,10 @@ class GUI_EXPORT QgsTableEditorWidget : public QTableWidget
      *
      * \see setSelectionForegroundColor()
      * \see selectionBackgroundColor()
+     *
+     * \deprecated use selectionTextFormat() instead.
      */
-    QColor selectionForegroundColor();
+    Q_DECL_DEPRECATED QColor selectionForegroundColor() SIP_DEPRECATED;
 
     /**
      * Returns the background color for the currently selected cells.
@@ -364,8 +366,10 @@ class GUI_EXPORT QgsTableEditorWidget : public QTableWidget
      *
      * \see selectionForegroundColor()
      * \see setSelectionBackgroundColor()
+     *
+     * \deprecated Use setSelectionTextFormat() instead.
      */
-    void setSelectionForegroundColor( const QColor &color );
+    Q_DECL_DEPRECATED void setSelectionForegroundColor( const QColor &color ) SIP_DEPRECATED;
 
     /**
      * Sets the background color for the currently selected cells.

--- a/src/ui/qgstableeditorformattingwidgetbase.ui
+++ b/src/ui/qgstableeditorformattingwidgetbase.ui
@@ -47,33 +47,13 @@
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="5" column="0">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_51">
-         <property name="text">
-          <string>Expression</string>
-         </property>
-        </widget>
-       </item>
        <item row="2" column="0" colspan="2">
-        <widget class="QGroupBox" name="groupBox_6">
+        <widget class="QGroupBox" name="groupBox_7">
          <property name="focusPolicy">
           <enum>Qt::StrongFocus</enum>
          </property>
          <property name="title">
-          <string>Colors</string>
+          <string>Formatting</string>
          </property>
          <property name="syncGroup" stdset="0">
           <string notr="true">composeritem</string>
@@ -81,8 +61,69 @@
          <property name="collapsed" stdset="0">
           <bool>false</bool>
          </property>
-         <layout class="QGridLayout" name="gridLayout_6" columnstretch="2,2,1">
+         <layout class="QGridLayout" name="gridLayout_7">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Text format</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Horizontal alignment</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Vertical alignment</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QPushButton" name="mCustomizeFormatButton">
+            <property name="text">
+             <string>Customize…</string>
+            </property>
+           </widget>
+          </item>
           <item row="3" column="1">
+           <widget class="QgsAlignmentComboBox" name="mVerticalAlignComboBox"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="mFormatNumbersCheckBox">
+            <property name="text">
+             <string>Format as number</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QgsFontButton" name="mFontButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Font</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QgsAlignmentComboBox" name="mHorizontalAlignComboBox"/>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_11">
+            <property name="text">
+             <string>Background color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
            <widget class="QgsColorButton" name="mBackgroundColorButton">
             <property name="minimumSize">
              <size>
@@ -101,128 +142,23 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_10">
-            <property name="text">
-             <string>Text color</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_11">
-            <property name="text">
-             <string>Background color</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QgsColorButton" name="mTextColorButton">
-            <property name="minimumSize">
-             <size>
-              <width>120</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>120</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
          </layout>
         </widget>
        </item>
-       <item row="3" column="0" colspan="2">
-        <widget class="QGroupBox" name="groupBox_7">
+       <item row="0" column="1">
+        <widget class="QgsFieldExpressionWidget" name="mExpressionEdit" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="focusPolicy">
           <enum>Qt::StrongFocus</enum>
          </property>
-         <property name="title">
-          <string>Formatting</string>
-         </property>
-         <property name="syncGroup" stdset="0">
-          <string notr="true">composeritem</string>
-         </property>
-         <property name="collapsed" stdset="0">
-          <bool>false</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_7">
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="mFormatNumbersCheckBox">
-            <property name="text">
-             <string>Format as number</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QPushButton" name="mCustomizeFormatButton">
-            <property name="text">
-             <string>Customize…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QgsFontButton" name="mFontButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Font</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Horizontal alignment</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_4">
-            <property name="text">
-             <string>Vertical alignment</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QgsAlignmentComboBox" name="mVerticalAlignComboBox"/>
-          </item>
-          <item row="2" column="1">
-           <widget class="QgsAlignmentComboBox" name="mHorizontalAlignComboBox"/>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Text format</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
         </widget>
        </item>
-       <item row="4" column="0" colspan="2">
+       <item row="3" column="0" colspan="2">
         <widget class="QGroupBox" name="groupBox_8">
          <property name="focusPolicy">
           <enum>Qt::StrongFocus</enum>
@@ -274,18 +210,25 @@
          </layout>
         </widget>
        </item>
-       <item row="0" column="1">
-        <widget class="QgsFieldExpressionWidget" name="mExpressionEdit" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="focusPolicy">
-          <enum>Qt::StrongFocus</enum>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_51">
+         <property name="text">
+          <string>Expression</string>
          </property>
         </widget>
+       </item>
+       <item row="4" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>
@@ -329,19 +272,18 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>groupBox_6</tabstop>
-  <tabstop>mTextColorButton</tabstop>
-  <tabstop>mBackgroundColorButton</tabstop>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>mExpressionEdit</tabstop>
   <tabstop>groupBox_7</tabstop>
   <tabstop>mFontButton</tabstop>
   <tabstop>mFormatNumbersCheckBox</tabstop>
   <tabstop>mCustomizeFormatButton</tabstop>
   <tabstop>mHorizontalAlignComboBox</tabstop>
   <tabstop>mVerticalAlignComboBox</tabstop>
+  <tabstop>mBackgroundColorButton</tabstop>
   <tabstop>groupBox_8</tabstop>
   <tabstop>mRowHeightSpinBox</tabstop>
   <tabstop>mColumnWidthSpinBox</tabstop>
-  <tabstop>scrollArea</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/tests/src/gui/testqgstableeditor.cpp
+++ b/tests/src/gui/testqgstableeditor.cpp
@@ -85,9 +85,9 @@ void TestQgsTableEditor::testData()
   c3.setVerticalAlignment( Qt::AlignBottom );
   QgsTableCell c2( 76 );
   c2.setBackgroundColor( QColor( 255, 0, 0 ) );
-  c2.setForegroundColor( QColor( 0, 255, 0 ) );
   QgsTextFormat textFormat;
   textFormat.setSize( 12.6 );
+  textFormat.setColor( QColor( 0, 255, 0 ) );
   c2.setTextFormat( textFormat );
   c2.setHorizontalAlignment( Qt::AlignRight );
   c2.setVerticalAlignment( Qt::AlignTop );
@@ -98,14 +98,14 @@ void TestQgsTableEditor::testData()
   QCOMPARE( w.tableContents().at( 0 ).size(), 3 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).horizontalAlignment(), Qt::AlignLeft );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).verticalAlignment(), Qt::AlignVCenter );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().toString(), QStringLiteral( "76" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).backgroundColor(), QColor( 255, 0, 0 ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).foregroundColor(), QColor( 0, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).textFormat().color(), QColor( 0, 255, 0 ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 1 ).numericFormat() );
   QVERIFY( w.tableContents().at( 0 ).at( 1 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).textFormat().size(), 12.6 );
@@ -113,7 +113,7 @@ void TestQgsTableEditor::testData()
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).verticalAlignment(), Qt::AlignTop );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QStringLiteral( "87" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).textFormat().isValid() );
   QVERIFY( w.tableContents().at( 0 ).at( 2 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).numericFormat()->id(), QStringLiteral( "currency" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).horizontalAlignment(), Qt::AlignJustify );
@@ -134,7 +134,9 @@ void TestQgsTableEditor::insertRowsBelow()
   c3.setNumericFormat( format.release() );
   QgsTableCell c2( 76 );
   c2.setBackgroundColor( QColor( 255, 0, 0 ) );
-  c2.setForegroundColor( QColor( 0, 255, 0 ) );
+  QgsTextFormat c2f;
+  c2f.setColor( QColor( 0, 255, 0 ) ) ;
+  c2.setTextFormat( c2f );
   w.setTableContents( QgsTableContents() << ( QgsTableRow() << QgsTableCell( QStringLiteral( "Jet" ) ) << c2 << c3 ) );
   QCOMPARE( spy.count(), 1 );
 
@@ -146,27 +148,27 @@ void TestQgsTableEditor::insertRowsBelow()
   QCOMPARE( w.tableContents().at( 0 ).size(), 3 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().toString(), QStringLiteral( "76" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).backgroundColor(), QColor( 255, 0, 0 ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).foregroundColor(), QColor( 0, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).textFormat().color(), QColor( 0, 255, 0 ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 1 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QStringLiteral( "87" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).textFormat().isValid() );
   QVERIFY( w.tableContents().at( 0 ).at( 2 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).numericFormat()->id(), QStringLiteral( "currency" ) );
   QCOMPARE( w.tableContents().at( 1 ).size(), 3 );
   QCOMPARE( w.tableContents().at( 1 ).at( 0 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 1 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 1 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 1 ).at( 0 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 1 ).at( 1 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 1 ).at( 1 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 1 ).at( 1 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 1 ).at( 1 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 1 ).at( 2 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 1 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 1 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 1 ).at( 2 ).textFormat().isValid() );
 
   // two rows selected = insert two rows, etc
   w.selectionModel()->select( w.model()->index( 0, 1 ), QItemSelectionModel::ClearAndSelect );
@@ -178,47 +180,47 @@ void TestQgsTableEditor::insertRowsBelow()
   QCOMPARE( w.tableContents().at( 0 ).size(), 3 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().toString(), QStringLiteral( "76" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).backgroundColor(), QColor( 255, 0, 0 ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).foregroundColor(), QColor( 0, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).textFormat().color(), QColor( 0, 255, 0 ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 1 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QStringLiteral( "87" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).textFormat().isValid() );
   QVERIFY( w.tableContents().at( 0 ).at( 2 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).numericFormat()->id(), QStringLiteral( "currency" ) );
   QCOMPARE( w.tableContents().at( 1 ).size(), 3 );
   QCOMPARE( w.tableContents().at( 1 ).at( 0 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 1 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 1 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 1 ).at( 0 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 1 ).at( 1 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 1 ).at( 1 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 1 ).at( 1 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 1 ).at( 1 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 1 ).at( 2 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 1 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 1 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 1 ).at( 2 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 2 ).size(), 3 );
   QCOMPARE( w.tableContents().at( 2 ).at( 0 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 2 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 2 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 2 ).at( 0 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 2 ).at( 1 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 2 ).at( 1 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 2 ).at( 1 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 2 ).at( 1 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 2 ).at( 2 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 2 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 2 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 2 ).at( 2 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 3 ).size(), 3 );
   QCOMPARE( w.tableContents().at( 3 ).at( 0 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 3 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 3 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 3 ).at( 0 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 3 ).at( 1 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 3 ).at( 1 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 3 ).at( 1 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 3 ).at( 1 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 3 ).at( 2 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 3 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 3 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 3 ).at( 2 ).textFormat().isValid() );
 
   // non consecutive selection = no action
   w.selectionModel()->select( w.model()->index( 0, 1 ), QItemSelectionModel::ClearAndSelect );
@@ -242,7 +244,9 @@ void TestQgsTableEditor::insertRowsAbove()
   c3.setNumericFormat( format.release() );
   QgsTableCell c2( 76 );
   c2.setBackgroundColor( QColor( 255, 0, 0 ) );
-  c2.setForegroundColor( QColor( 0, 255, 0 ) );
+  QgsTextFormat c2f;
+  c2f.setColor( QColor( 0, 255, 0 ) );
+  c2.setTextFormat( c2f );
   w.setTableContents( QgsTableContents() << ( QgsTableRow() << QgsTableCell( QStringLiteral( "Jet" ) ) << c2 << c3 ) );
   QCOMPARE( spy.count(), 1 );
 
@@ -254,25 +258,25 @@ void TestQgsTableEditor::insertRowsAbove()
   QCOMPARE( w.tableContents().at( 0 ).size(), 3 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 0 ).at( 1 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 1 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 1 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 0 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 1 ).size(), 3 );
   QCOMPARE( w.tableContents().at( 1 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
   QVERIFY( !w.tableContents().at( 1 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 1 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 1 ).at( 0 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 1 ).at( 0 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 1 ).at( 1 ).content().toString(), QStringLiteral( "76" ) );
   QCOMPARE( w.tableContents().at( 1 ).at( 1 ).backgroundColor(), QColor( 255, 0, 0 ) );
-  QCOMPARE( w.tableContents().at( 1 ).at( 1 ).foregroundColor(), QColor( 0, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 1 ).at( 1 ).textFormat().color(), QColor( 0, 255, 0 ) );
   QVERIFY( !w.tableContents().at( 1 ).at( 1 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 1 ).at( 2 ).content().toString(), QStringLiteral( "87" ) );
   QVERIFY( !w.tableContents().at( 1 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 1 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 1 ).at( 2 ).textFormat().isValid() );
   QVERIFY( w.tableContents().at( 1 ).at( 2 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 1 ).at( 2 ).numericFormat()->id(), QStringLiteral( "currency" ) );
 
@@ -286,45 +290,45 @@ void TestQgsTableEditor::insertRowsAbove()
   QCOMPARE( w.tableContents().at( 0 ).size(), 3 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 0 ).at( 1 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 1 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 1 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 0 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 1 ).size(), 3 );
   QCOMPARE( w.tableContents().at( 1 ).at( 0 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 1 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 1 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 1 ).at( 0 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 1 ).at( 1 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 1 ).at( 1 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 1 ).at( 1 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 1 ).at( 1 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 1 ).at( 2 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 1 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 1 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 1 ).at( 2 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 2 ).size(), 3 );
   QCOMPARE( w.tableContents().at( 2 ).at( 0 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 2 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 2 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 2 ).at( 0 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 2 ).at( 1 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 2 ).at( 1 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 2 ).at( 1 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 2 ).at( 1 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 2 ).at( 2 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 2 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 2 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 2 ).at( 2 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 3 ).size(), 3 );
   QCOMPARE( w.tableContents().at( 3 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
   QVERIFY( !w.tableContents().at( 3 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 3 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 3 ).at( 0 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 3 ).at( 0 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 3 ).at( 1 ).content().toString(), QStringLiteral( "76" ) );
   QCOMPARE( w.tableContents().at( 3 ).at( 1 ).backgroundColor(), QColor( 255, 0, 0 ) );
-  QCOMPARE( w.tableContents().at( 3 ).at( 1 ).foregroundColor(), QColor( 0, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 3 ).at( 1 ).textFormat().color(), QColor( 0, 255, 0 ) );
   QVERIFY( !w.tableContents().at( 3 ).at( 1 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 3 ).at( 2 ).content().toString(), QStringLiteral( "87" ) );
   QVERIFY( !w.tableContents().at( 3 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 3 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 3 ).at( 2 ).textFormat().isValid() );
   QVERIFY( w.tableContents().at( 3 ).at( 2 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 3 ).at( 2 ).numericFormat()->id(), QStringLiteral( "currency" ) );
 
@@ -350,7 +354,9 @@ void TestQgsTableEditor::insertColumnsBefore()
   c3.setNumericFormat( format.release() );
   QgsTableCell c2( 76 );
   c2.setBackgroundColor( QColor( 255, 0, 0 ) );
-  c2.setForegroundColor( QColor( 0, 255, 0 ) );
+  QgsTextFormat c2f;
+  c2f.setColor( QColor( 0, 255, 0 ) );
+  c2.setTextFormat( c2f );
   w.setTableContents( QgsTableContents() << ( QgsTableRow() << QgsTableCell( QStringLiteral( "Jet" ) ) << c2 << c3 ) );
   QCOMPARE( spy.count(), 1 );
 
@@ -362,18 +368,18 @@ void TestQgsTableEditor::insertColumnsBefore()
   QCOMPARE( w.tableContents().at( 0 ).size(), 4 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 0 ).at( 1 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 1 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 1 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QStringLiteral( "76" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).backgroundColor(), QColor( 255, 0, 0 ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 2 ).foregroundColor(), QColor( 0, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 2 ).textFormat().color(), QColor( 0, 255, 0 ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 2 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 3 ).content().toString(), QStringLiteral( "87" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 3 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).textFormat().isValid() );
   QVERIFY( w.tableContents().at( 0 ).at( 3 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 3 ).numericFormat()->id(), QStringLiteral( "currency" ) );
 
@@ -387,24 +393,24 @@ void TestQgsTableEditor::insertColumnsBefore()
   QCOMPARE( w.tableContents().at( 0 ).size(), 6 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 0 ).at( 1 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 1 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 1 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 0 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 0 ).at( 3 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 0 ).at( 3 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 0 ).at( 4 ).content().toString(), QStringLiteral( "76" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 4 ).backgroundColor(), QColor( 255, 0, 0 ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 4 ).foregroundColor(), QColor( 0, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 4 ).textFormat().color(), QColor( 0, 255, 0 ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 4 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 5 ).content().toString(), QStringLiteral( "87" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 5 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 5 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 5 ).textFormat().isValid() );
   QVERIFY( w.tableContents().at( 0 ).at( 5 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 5 ).numericFormat()->id(), QStringLiteral( "currency" ) );
 
@@ -430,7 +436,9 @@ void TestQgsTableEditor::insertColumnsAfter()
   c3.setNumericFormat( format.release() );
   QgsTableCell c2( 76 );
   c2.setBackgroundColor( QColor( 255, 0, 0 ) );
-  c2.setForegroundColor( QColor( 0, 255, 0 ) );
+  QgsTextFormat c2f;
+  c2f.setColor( QColor( 0, 255, 0 ) );
+  c2.setTextFormat( c2f );
   w.setTableContents( QgsTableContents() << ( QgsTableRow() << QgsTableCell( QStringLiteral( "Jet" ) ) << c2 << c3 ) );
   QCOMPARE( spy.count(), 1 );
 
@@ -442,18 +450,18 @@ void TestQgsTableEditor::insertColumnsAfter()
   QCOMPARE( w.tableContents().at( 0 ).size(), 4 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().toString(), QStringLiteral( "76" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).backgroundColor(), QColor( 255, 0, 0 ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).foregroundColor(), QColor( 0, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).textFormat().color(), QColor( 0, 255, 0 ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 1 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 0 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 0 ).at( 3 ).content().toString(), QStringLiteral( "87" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 3 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).textFormat().isValid() );
   QVERIFY( w.tableContents().at( 0 ).at( 3 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 3 ).numericFormat()->id(), QStringLiteral( "currency" ) );
 
@@ -467,24 +475,24 @@ void TestQgsTableEditor::insertColumnsAfter()
   QCOMPARE( w.tableContents().at( 0 ).size(), 6 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().toString(), QStringLiteral( "76" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).backgroundColor(), QColor( 255, 0, 0 ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).foregroundColor(), QColor( 0, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).textFormat().color(), QColor( 0, 255, 0 ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 1 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 0 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 0 ).at( 3 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 0 ).at( 3 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 0 ).at( 4 ).content().toString(), QString() );
   QVERIFY( !w.tableContents().at( 0 ).at( 4 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 4 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 4 ).textFormat().isValid() );
   QCOMPARE( w.tableContents().at( 0 ).at( 5 ).content().toString(), QStringLiteral( "87" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 5 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 5 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 5 ).textFormat().isValid() );
   QVERIFY( w.tableContents().at( 0 ).at( 5 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 5 ).numericFormat()->id(), QStringLiteral( "currency" ) );
 
@@ -510,7 +518,9 @@ void TestQgsTableEditor::deleteRows()
   QgsTableCell c2( 76 );
   c2.setNumericFormat( format.release() );
   c2.setBackgroundColor( QColor( 255, 0, 0 ) );
-  c2.setForegroundColor( QColor( 0, 255, 0 ) );
+  QgsTextFormat c2f;
+  c2f.setColor( QColor( 0, 255, 0 ) );
+  c2.setTextFormat( c2f );
   w.setTableContents( QgsTableContents() << ( QgsTableRow() << QgsTableCell( QStringLiteral( "Jet" ) ) )
                       << ( QgsTableRow() << c2 )
                       << ( QgsTableRow() << c3 )
@@ -530,15 +540,15 @@ void TestQgsTableEditor::deleteRows()
   QCOMPARE( w.tableContents().size(), 3 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 1 ).at( 0 ).content().toString(), QStringLiteral( "76" ) );
   QCOMPARE( w.tableContents().at( 1 ).at( 0 ).backgroundColor(), QColor( 255, 0, 0 ) );
-  QCOMPARE( w.tableContents().at( 1 ).at( 0 ).foregroundColor(), QColor( 0, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 1 ).at( 0 ).textFormat().color(), QColor( 0, 255, 0 ) );
   QCOMPARE( w.tableContents().at( 1 ).at( 0 ).numericFormat()->id(), QStringLiteral( "currency" ) );
   QCOMPARE( w.tableContents().at( 2 ).at( 0 ).content().toString(), QStringLiteral( "Jet3" ) );
   QVERIFY( !w.tableContents().at( 2 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 2 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 2 ).at( 0 ).textFormat().isValid() );
 
   w.selectionModel()->select( w.model()->index( 0, 0 ), QItemSelectionModel::ClearAndSelect );
   w.selectionModel()->select( w.model()->index( 2, 0 ), QItemSelectionModel::Select );
@@ -549,7 +559,7 @@ void TestQgsTableEditor::deleteRows()
   QCOMPARE( w.tableContents().at( 0 ).size(), 1 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "76" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).backgroundColor(), QColor( 255, 0, 0 ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 0 ).foregroundColor(), QColor( 0, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 0 ).textFormat().color(), QColor( 0, 255, 0 ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).numericFormat()->id(), QStringLiteral( "currency" ) );
 
   // last row can't be deleted
@@ -575,7 +585,9 @@ void TestQgsTableEditor::deleteColumns()
   QgsTableCell c2( 76 );
   c2.setNumericFormat( format.release() );
   c2.setBackgroundColor( QColor( 255, 0, 0 ) );
-  c2.setForegroundColor( QColor( 0, 255, 0 ) );
+  QgsTextFormat c2f;
+  c2f.setColor( QColor( 0, 255, 0 ) );
+  c2.setTextFormat( c2f );
   w.setTableContents( QgsTableContents() << ( QgsTableRow() << QgsTableCell( QStringLiteral( "Jet" ) ) << c2 << c3 << QgsTableCell( QStringLiteral( "Jet3" ) ) ) );
   QCOMPARE( spy.count(), 1 );
 
@@ -594,15 +606,15 @@ void TestQgsTableEditor::deleteColumns()
   QCOMPARE( w.tableContents().at( 0 ).size(), 3 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().toString(), QStringLiteral( "76" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).backgroundColor(), QColor( 255, 0, 0 ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).foregroundColor(), QColor( 0, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).textFormat().color(), QColor( 0, 255, 0 ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).numericFormat()->id(), QStringLiteral( "currency" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QStringLiteral( "Jet3" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).textFormat().isValid() );
 
   w.selectionModel()->select( w.model()->index( 0, 0 ), QItemSelectionModel::ClearAndSelect );
   w.selectionModel()->select( w.model()->index( 0, 2 ), QItemSelectionModel::Select );
@@ -613,7 +625,7 @@ void TestQgsTableEditor::deleteColumns()
   QCOMPARE( w.tableContents().at( 0 ).size(), 1 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "76" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).backgroundColor(), QColor( 255, 0, 0 ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 0 ).foregroundColor(), QColor( 0, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 0 ).textFormat().color(), QColor( 0, 255, 0 ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).numericFormat()->id(), QStringLiteral( "currency" ) );
 
   // last column can't be deleted
@@ -749,7 +761,9 @@ void TestQgsTableEditor::foregroundColor()
   c3.setNumericFormat( format.release() );
   QgsTableCell c2( 76 );
   c2.setBackgroundColor( QColor( 255, 0, 0 ) );
-  c2.setForegroundColor( QColor( 0, 255, 0 ) );
+  QgsTextFormat f = c2.textFormat();
+  f.setColor( QColor( 0, 255, 0 ) );
+  c2.setTextFormat( f );
   w.setTableContents( QgsTableContents() << ( QgsTableRow() << QgsTableCell( QStringLiteral( "Jet" ) ) << c2 << c3 << QgsTableCell( QStringLiteral( "Jet3" ) ) ) );
   QCOMPARE( spy.count(), 1 );
 
@@ -757,43 +771,45 @@ void TestQgsTableEditor::foregroundColor()
   QCOMPARE( w.tableContents().at( 0 ).size(), 4 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().toString(), QStringLiteral( "76" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).backgroundColor(), QColor( 255, 0, 0 ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).foregroundColor(), QColor( 0, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).textFormat().color(), QColor( 0, 255, 0 ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 1 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QStringLiteral( "87" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).textFormat().isValid() );
   QVERIFY( w.tableContents().at( 0 ).at( 2 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).numericFormat()->id(), QStringLiteral( "currency" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 3 ).content().toString(), QStringLiteral( "Jet3" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 3 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 3 ).numericFormat() );
 
   w.selectionModel()->clearSelection();
-  w.setSelectionForegroundColor( QColor( 255, 255, 0 ) );
+  QgsTextFormat f2;
+  f2.setColor( QColor( 255, 255, 0 ) );
+  w.setSelectionTextFormat( f2 );
   QCOMPARE( spy.count(), 1 );
 
   w.selectionModel()->select( w.model()->index( 0, 0 ), QItemSelectionModel::ClearAndSelect );
-  QVERIFY( !w.selectionForegroundColor().isValid() );
+  QVERIFY( !w.selectionTextFormat().isValid() );
   w.selectionModel()->select( w.model()->index( 0, 1 ), QItemSelectionModel::Select );
-  QVERIFY( !w.selectionForegroundColor().isValid() );
+  QVERIFY( !w.selectionTextFormat().isValid() );
   w.selectionModel()->select( w.model()->index( 0, 1 ), QItemSelectionModel::ClearAndSelect );
-  QCOMPARE( w.selectionForegroundColor(), QColor( 0, 255, 0 ) );
+  QCOMPARE( w.selectionTextFormat().color(), QColor( 0, 255, 0 ) );
   w.selectionModel()->select( w.model()->index( 0, 0 ), QItemSelectionModel::Select );
-  QVERIFY( !w.selectionForegroundColor().isValid() );
-  w.setSelectionForegroundColor( QColor( 255, 255, 0 ) );
+  QVERIFY( !w.selectionTextFormat().isValid() );
+  w.setSelectionTextFormat( f2 );
   QCOMPARE( spy.count(), 2 );
-  QCOMPARE( w.selectionForegroundColor(), QColor( 255, 255, 0 ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 0 ).foregroundColor(), QColor( 255, 255, 0 ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).foregroundColor(), QColor( 255, 255, 0 ) );
-  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).foregroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).foregroundColor().isValid() );
+  QCOMPARE( w.selectionTextFormat().color(), QColor( 255, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 0 ).textFormat().color(), QColor( 255, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).textFormat().color(), QColor( 255, 255, 0 ) );
+  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).textFormat().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).textFormat().isValid() );
   w.selectionModel()->select( w.model()->index( 0, 3 ), QItemSelectionModel::Select );
-  QVERIFY( !w.selectionForegroundColor().isValid() );
+  QVERIFY( !w.selectionTextFormat().isValid() );
 }
 
 void TestQgsTableEditor::backgroundColor()
@@ -810,7 +826,9 @@ void TestQgsTableEditor::backgroundColor()
   c3.setNumericFormat( format.release() );
   QgsTableCell c2( 76 );
   c2.setBackgroundColor( QColor( 255, 0, 0 ) );
-  c2.setForegroundColor( QColor( 0, 255, 0 ) );
+  QgsTextFormat c2f;
+  c2f.setColor( QColor( 0, 255, 0 ) );
+  c2.setTextFormat( c2f );
   w.setTableContents( QgsTableContents() << ( QgsTableRow() << QgsTableCell( QStringLiteral( "Jet" ) ) << c2 << c3 << QgsTableCell( QStringLiteral( "Jet3" ) ) ) );
   QCOMPARE( spy.count(), 1 );
 
@@ -818,20 +836,20 @@ void TestQgsTableEditor::backgroundColor()
   QCOMPARE( w.tableContents().at( 0 ).size(), 4 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().toString(), QStringLiteral( "76" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).backgroundColor(), QColor( 255, 0, 0 ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).foregroundColor(), QColor( 0, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).textFormat().color(), QColor( 0, 255, 0 ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 1 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QStringLiteral( "87" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).textFormat().isValid() );
   QVERIFY( w.tableContents().at( 0 ).at( 2 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).numericFormat()->id(), QStringLiteral( "currency" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 3 ).content().toString(), QStringLiteral( "Jet3" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 3 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 3 ).numericFormat() );
 
   w.selectionModel()->clearSelection();
@@ -1047,7 +1065,9 @@ void TestQgsTableEditor::numericFormat()
   QgsTableCell c2( 76 );
   c2.setNumericFormat( format.release() );
   c2.setBackgroundColor( QColor( 255, 0, 0 ) );
-  c2.setForegroundColor( QColor( 0, 255, 0 ) );
+  QgsTextFormat c2f;
+  c2f.setColor( QColor( 0, 255, 0 ) );
+  c2.setTextFormat( c2f );
   w.setTableContents( QgsTableContents() << ( QgsTableRow() << QgsTableCell( QStringLiteral( "Jet" ) ) << c2 << c3 << QgsTableCell( QStringLiteral( "Jet3" ) ) ) );
   QCOMPARE( spy.count(), 1 );
 
@@ -1055,20 +1075,20 @@ void TestQgsTableEditor::numericFormat()
   QCOMPARE( w.tableContents().at( 0 ).size(), 4 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 0 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().toString(), QStringLiteral( "76" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).backgroundColor(), QColor( 255, 0, 0 ) );
-  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).foregroundColor(), QColor( 0, 255, 0 ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).textFormat().color(), QColor( 0, 255, 0 ) );
   QVERIFY( w.tableContents().at( 0 ).at( 1 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).numericFormat()->id(), QStringLiteral( "currency" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QStringLiteral( "87" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 2 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 2 ).numericFormat() );
   QCOMPARE( w.tableContents().at( 0 ).at( 3 ).content().toString(), QStringLiteral( "Jet3" ) );
   QVERIFY( !w.tableContents().at( 0 ).at( 3 ).backgroundColor().isValid() );
-  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).foregroundColor().isValid() );
+  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).textFormat().isValid() );
   QVERIFY( !w.tableContents().at( 0 ).at( 3 ).numericFormat() );
 
   w.selectionModel()->clearSelection();


### PR DESCRIPTION
Instead of the confusing duplicate settings for foreground color
vs cell text color, remove the foreground color button and only
expose this color setting via the cell text color.
