### PR TITLE
Browser fields enhancements

### DIFF
--- a/src/core/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/qgsabstractdatabaseproviderconnection.cpp
@@ -275,7 +275,7 @@ QList<QgsAbstractDatabaseProviderConnection::TableProperty::GeometryColumnType> 
 
 QgsFields QgsAbstractDatabaseProviderConnection::fields( const QString &schema, const QString &tableName ) const
 {
-  QgsVectorLayer::LayerOptions options { true, true };
+  QgsVectorLayer::LayerOptions options { false, true };
   options.skipCrsValidation = true;
   QgsVectorLayer vl { tableUri( schema, tableName ), QStringLiteral( "temp_layer" ), mProviderKey, options };
   if ( vl.isValid() )

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -227,7 +227,13 @@ QgsFieldItem::~QgsFieldItem()
 
 QIcon QgsFieldItem::icon()
 {
-  return QgsFields::iconForFieldType( mField.type() );
+  const QIcon icon { QgsFields::iconForFieldType( mField.type() ) };
+  // Try subtype if icon is null
+  if ( icon.isNull() )
+  {
+    return QgsFields::iconForFieldType( mField.subType() );
+  }
+  return icon;
 }
 
 QIcon QgsFavoritesItem::iconFavorites()

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -671,32 +671,32 @@ QgsFields QgsPostgresProviderConnection::fields( const QString &schema, const QS
     // This table might expose multiple geometry columns (different geom type or SRID)
     // but we are only interested in fields here, so let's pick the first one.
     TableProperty tableInfo { table( schema, tableName ) };
-    if ( tableInfo.geometryColumnTypes().count( ) > 1 )
+    try
     {
-      try
+      QgsDataSourceUri tUri { tableUri( schema, tableName ) };
+      if ( tableInfo.geometryColumnTypes().count( ) > 1 )
       {
-        QgsDataSourceUri tUri { tableUri( schema, tableName ) };
         TableProperty::GeometryColumnType geomCol { tableInfo.geometryColumnTypes().first() };
         tUri.setGeometryColumn( tableInfo.geometryColumn() );
         tUri.setWkbType( geomCol.wkbType );
         tUri.setSrid( QString::number( geomCol.crs.postgisSrid() ) );
-        if ( tableInfo.primaryKeyColumns().count() > 0 )
-        {
-          tUri.setKeyColumn( tableInfo.primaryKeyColumns().first() );
-        }
-        tUri.setParam( QStringLiteral( "checkPrimaryKeyUnicity" ), QLatin1String( "0" ) );
-        QgsVectorLayer::LayerOptions options { false, true };
-        options.skipCrsValidation = true;
-        QgsVectorLayer vl { tUri.uri(), QStringLiteral( "temp_layer" ), mProviderKey, options };
-        if ( vl.isValid() )
-        {
-          return vl.fields();
-        }
       }
-      catch ( QgsProviderConnectionException & )
+      if ( tableInfo.primaryKeyColumns().count() > 0 )
       {
-        // fall-through
+        tUri.setKeyColumn( tableInfo.primaryKeyColumns().first() );
       }
+      tUri.setParam( QStringLiteral( "checkPrimaryKeyUnicity" ), QLatin1String( "0" ) );
+      QgsVectorLayer::LayerOptions options { false, true };
+      options.skipCrsValidation = true;
+      QgsVectorLayer vl { tUri.uri(), QStringLiteral( "temp_layer" ), mProviderKey, options };
+      if ( vl.isValid() )
+      {
+        return vl.fields();
+      }
+    }
+    catch ( QgsProviderConnectionException & )
+    {
+      // fall-through
     }
     throw ex;
   }

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -685,7 +685,7 @@ QgsFields QgsPostgresProviderConnection::fields( const QString &schema, const QS
           tUri.setKeyColumn( tableInfo.primaryKeyColumns().first() );
         }
         tUri.setParam( QStringLiteral( "checkPrimaryKeyUnicity" ), QLatin1String( "0" ) );
-        QgsVectorLayer::LayerOptions options { true, true };
+        QgsVectorLayer::LayerOptions options { false, true };
         options.skipCrsValidation = true;
         QgsVectorLayer vl { tUri.uri(), QStringLiteral( "temp_layer" ), mProviderKey, options };
         if ( vl.isValid() )

--- a/src/providers/postgres/qgspostgresproviderconnection.h
+++ b/src/providers/postgres/qgspostgresproviderconnection.h
@@ -38,6 +38,7 @@ class QgsPostgresProviderConnection : public QgsAbstractDatabaseProviderConnecti
                             const QMap<QString, QVariant> *options ) const override;
 
     QString tableUri( const QString &schema, const QString &name ) const override;
+    QgsFields fields( const QString &schema, const QString &table ) const override;
     void dropVectorTable( const QString &schema, const QString &name ) const override;
     void dropRasterTable( const QString &schema, const QString &name ) const override;
     void renameVectorTable( const QString &schema, const QString &name, const QString &newName ) const override;
@@ -65,9 +66,7 @@ class QgsPostgresProviderConnection : public QgsAbstractDatabaseProviderConnecti
     void dropTablePrivate( const QString &schema, const QString &name ) const;
     void renameTablePrivate( const QString &schema, const QString &name, const QString &newName ) const;
 
-
 };
-
 
 
 #endif // QGSPOSTGRESPROVIDERCONNECTION_H

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -329,6 +329,30 @@ IMPORT FOREIGN SCHEMA qgis_test LIMIT TO ( "someData" )
         fields = conn.fields('qgis_test', 'someData')
         self.assertEqual(fields.names(), ['pk', 'cnt', 'name', 'name2', 'num_char', 'dt', 'date', 'time', 'geom'])
 
+    def test_fields_no_pk(self):
+        """Test issue: no fields are exposed for raster_columns"""
+
+        md = QgsProviderRegistry.instance().providerMetadata('postgres')
+        conn = md.createConnection(self.uri, {})
+        fields = conn.fields("public", "raster_columns")
+        self.assertEqual(fields.names(), [
+            'r_table_catalog',
+            'r_table_schema',
+            'r_table_name',
+            'r_raster_column',
+            'srid',
+            'scale_x',
+            'scale_y',
+            'blocksize_x',
+            'blocksize_y',
+            'same_alignment',
+            'regular_blocking',
+            'num_bands',
+            'pixel_types',
+            'nodata_values',
+            'out_db',
+            'spatial_index'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -334,6 +334,7 @@ IMPORT FOREIGN SCHEMA qgis_test LIMIT TO ( "someData" )
 
         md = QgsProviderRegistry.instance().providerMetadata('postgres')
         conn = md.createConnection(self.uri, {})
+        self.assertTrue(conn.tableExists('public', 'raster_columns'))
         fields = conn.fields("public", "raster_columns")
         self.assertEqual(fields.names(), [
             'r_table_catalog',

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -336,7 +336,7 @@ IMPORT FOREIGN SCHEMA qgis_test LIMIT TO ( "someData" )
         conn = md.createConnection(self.uri, {})
         self.assertTrue(conn.tableExists('public', 'raster_columns'))
         fields = conn.fields("public", "raster_columns")
-        self.assertEqual(fields.names(), [
+        self.assertTrue(set(fields.names()).issuperset({
             'r_table_catalog',
             'r_table_schema',
             'r_table_name',
@@ -352,7 +352,7 @@ IMPORT FOREIGN SCHEMA qgis_test LIMIT TO ( "someData" )
             'pixel_types',
             'nodata_values',
             'out_db',
-            'spatial_index'])
+            'spatial_index'}))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Check field `subType` for a fallback icon for fields where type is not known (for instance "name"  for PG 12 table/schema identifiers
- Fix unreported issue with `fields()` not retrieved for certain tables due to multiple geometry column types/srid