### PR TITLE
Some tweaks to 3D map view Configuration dialog

### DIFF
--- a/src/app/3d/qgsshadowrenderingsettingswidget.cpp
+++ b/src/app/3d/qgsshadowrenderingsettingswidget.cpp
@@ -24,6 +24,10 @@ QgsShadowRenderingSettingsWidget::QgsShadowRenderingSettingsWidget( QWidget *par
   : QWidget( parent )
 {
   setupUi( this );
+
+  shadowRenderinMaximumDistanceSpinBox->setClearValue( 500.00 );
+  shadowBiasSpinBox->setClearValue( 0.000010 );
+  shadowMapResolutionSpinBox->setClearValue( 2048 );
 }
 
 void QgsShadowRenderingSettingsWidget::setShadowSettings( const QgsShadowSettings &shadowSettings )

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -101,6 +101,18 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_6">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
           <item row="0" column="0">
            <layout class="QGridLayout" name="gridLayout_5"/>
           </item>

--- a/src/ui/3d/qgslightswidget.ui
+++ b/src/ui/3d/qgslightswidget.ui
@@ -216,7 +216,7 @@
       <layout class="QGridLayout" name="gridLayout_4">
        <item row="1" column="0" colspan="3">
         <layout class="QGridLayout" name="gridLayout_3">
-         <item row="4" column="1">
+         <item row="3" column="1">
           <widget class="QDoubleSpinBox" name="spinDirectionZ">
            <property name="decimals">
             <number>1</number>
@@ -229,7 +229,7 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="1">
+         <item row="4" column="1">
           <widget class="QgsColorButton" name="btnDirectionalColor">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -245,28 +245,28 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="0">
+         <item row="5" column="0">
           <widget class="QLabel" name="label_14">
            <property name="text">
             <string>Intensity</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="0" rowspan="2">
+         <item row="2" column="0">
           <widget class="QLabel" name="label_13">
            <property name="text">
             <string>Y</string>
            </property>
           </widget>
          </item>
-         <item row="4" column="0">
+         <item row="3" column="0">
           <widget class="QLabel" name="label_10">
            <property name="text">
             <string>Z</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="1" rowspan="2">
+         <item row="2" column="1">
           <widget class="QDoubleSpinBox" name="spinDirectionY">
            <property name="decimals">
             <number>1</number>
@@ -292,7 +292,7 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="1">
+         <item row="5" column="1">
           <widget class="QDoubleSpinBox" name="spinDirectionalIntensity">
            <property name="decimals">
             <number>1</number>
@@ -302,7 +302,7 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="0">
+         <item row="4" column="0">
           <widget class="QLabel" name="label_16">
            <property name="text">
             <string>Color</string>
@@ -319,7 +319,7 @@
          <item row="0" column="0" colspan="2">
           <widget class="QLabel" name="label_11">
            <property name="text">
-            <string>Light direction:</string>
+            <string>Light direction</string>
            </property>
           </widget>
          </item>

--- a/src/ui/3d/shadowrenderingsettingswidget.ui
+++ b/src/ui/3d/shadowrenderingsettingswidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>350</width>
+    <width>416</width>
     <height>139</height>
    </rect>
   </property>
@@ -14,7 +14,7 @@
    <item row="0" column="0">
     <widget class="QLabel" name="labelUsedDirectionalLight">
      <property name="text">
-      <string>Used directional light</string>
+      <string>Directional light</string>
      </property>
     </widget>
    </item>
@@ -30,6 +30,9 @@
    </item>
    <item row="1" column="1">
     <widget class="QDoubleSpinBox" name="shadowRenderinMaximumDistanceSpinBox">
+     <property name="suffix">
+      <string> map units</string>
+     </property>
      <property name="maximum">
       <double>9999999999.000000000000000</double>
      </property>
@@ -67,6 +70,9 @@
    </item>
    <item row="3" column="1">
     <widget class="QSpinBox" name="shadowMapResolutionSpinBox">
+     <property name="suffix">
+      <string> px</string>
+     </property>
      <property name="minimum">
       <number>128</number>
      </property>

--- a/src/ui/3d/shadowrenderingsettingswidget.ui
+++ b/src/ui/3d/shadowrenderingsettingswidget.ui
@@ -29,7 +29,7 @@
     </widget>
    </item>
    <item row="1" column="1">
-    <widget class="QDoubleSpinBox" name="shadowRenderinMaximumDistanceSpinBox">
+    <widget class="QgsDoubleSpinBox" name="shadowRenderinMaximumDistanceSpinBox">
      <property name="suffix">
       <string> map units</string>
      </property>
@@ -49,12 +49,15 @@
     </widget>
    </item>
    <item row="2" column="1">
-    <widget class="QDoubleSpinBox" name="shadowBiasSpinBox">
+    <widget class="QgsDoubleSpinBox" name="shadowBiasSpinBox">
      <property name="decimals">
       <number>10</number>
      </property>
      <property name="maximum">
       <double>1.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.000010000000000</double>
      </property>
      <property name="value">
       <double>0.000010000000000</double>
@@ -69,7 +72,7 @@
     </widget>
    </item>
    <item row="3" column="1">
-    <widget class="QSpinBox" name="shadowMapResolutionSpinBox">
+    <widget class="QgsSpinBox" name="shadowMapResolutionSpinBox">
      <property name="suffix">
       <string> px</string>
      </property>
@@ -86,6 +89,18 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Fixing labels and margins, adding units suffix to spinboxes (btw if someone can confirm that those are right) and ui cleanup

Before
![image](https://user-images.githubusercontent.com/7983394/93878838-029b7000-fcdb-11ea-9097-884bfb7f44b5.png)

After
![image](https://user-images.githubusercontent.com/7983394/93877728-2fe71e80-fcd9-11ea-9101-d7f5aac44020.png)

I wonder whether to remove the "light direction" label or offset the X, Y and Z labels. This is what we do eg in labels formatting multiline properties, or somehow in layout map item grid interval property, but it's not the case in the tab next door, aka "point lights" (for attenuation)

And if someone knows how we can get rid of this blank space at the bottom of the properties...