### PR TITLE
[VirtualLayer] don't convert bool to string in virtual layer

### DIFF
--- a/src/providers/virtual/qgsvirtuallayersqlitemodule.cpp
+++ b/src/providers/virtual/qgsvirtuallayersqlitemodule.cpp
@@ -696,6 +696,7 @@ int vtableColumn( sqlite3_vtab_cursor *cursor, sqlite3_context *ctxt, int idx )
     {
       case QVariant::Int:
       case QVariant::UInt:
+      case QVariant::Bool:
         sqlite3_result_int( ctxt, v.toInt() );
         break;
       case QVariant::LongLong:

--- a/tests/src/python/test_provider_virtual.py
+++ b/tests/src/python/test_provider_virtual.py
@@ -1271,6 +1271,41 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(gpkg_virtual_layer.featureCount(), 1)
         self.assertEqual(gpkg_virtual_layer.subsetString(), '"join_value" = \'twenty\'')
 
+    def test_bool_fields(self):
+
+        ml = QgsVectorLayer("NoGeometry?field=a:int&field=b:boolean", "mem", "memory")
+        self.assertEqual(ml.isValid(), True)
+        QgsProject.instance().addMapLayer(ml)
+
+        ml.startEditing()
+        f1 = QgsFeature(ml.fields())
+        f1.setAttribute('a', 1)
+        f1.setAttribute('b', True)
+        f2 = QgsFeature(ml.fields())
+        f2.setAttribute('a', 2)
+        f2.setAttribute('b', False)
+        ml.addFeatures([f1, f2])
+        ml.commitChanges()
+
+        self.assertEqual([(f['a'], f['b']) for f in ml.getFeatures()], [(1, True), (2, False)])
+
+        df = QgsVirtualLayerDefinition()
+        df.setQuery('select * from mem')
+        vl = QgsVectorLayer(df.toString(), "testq", "virtual")
+        self.assertEqual([(f['a'], f['b']) for f in vl.getFeatures()], [(1, True), (2, False)])
+
+        df = QgsVirtualLayerDefinition()
+        df.setQuery('select * from mem where b')
+        vl = QgsVectorLayer(df.toString(), "testq", "virtual")
+        self.assertEqual([(f['a'], f['b']) for f in vl.getFeatures()], [(1, True)])
+
+        df = QgsVirtualLayerDefinition()
+        df.setQuery('select * from mem where not b')
+        vl = QgsVectorLayer(df.toString(), "testq", "virtual")
+        self.assertEqual([(f['a'], f['b']) for f in vl.getFeatures()], [(2, False)])
+
+        QgsProject.instance().removeMapLayer(ml.id())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

Fixes #31798 : don't convert boolean to string in virtual layer
