### PR TITLE
Improved color vision deficiency sim

### DIFF
--- a/python/gui/auto_generated/qgsprevieweffect.sip.in
+++ b/python/gui/auto_generated/qgsprevieweffect.sip.in
@@ -24,10 +24,10 @@ color blindness modes.
     enum PreviewMode
     {
       PreviewMono,
-      PreviewAchromatopsia,
-      PreviewProtanopia,
-      PreviewDeuteranopia,
-      PreviewTritanopia
+      PreviewGrayscale
+      PreviewProtanope,
+      PreviewDeuteranope,
+      PreviewTritanope
     };
 
     QgsPreviewEffect( QObject *parent /TransferThis/ );

--- a/python/gui/auto_generated/qgsprevieweffect.sip.in
+++ b/python/gui/auto_generated/qgsprevieweffect.sip.in
@@ -23,10 +23,11 @@ color blindness modes.
   public:
     enum PreviewMode
     {
-      PreviewGrayscale,
       PreviewMono,
-      PreviewProtanope,
-      PreviewDeuteranope
+      PreviewAchromatopsia,
+      PreviewProtanopia,
+      PreviewDeuteranopia,
+      PreviewTritanopia
     };
 
     QgsPreviewEffect( QObject *parent /TransferThis/ );

--- a/python/gui/auto_generated/qgsprevieweffect.sip.in
+++ b/python/gui/auto_generated/qgsprevieweffect.sip.in
@@ -23,8 +23,8 @@ color blindness modes.
   public:
     enum PreviewMode
     {
-      PreviewMono,
       PreviewGrayscale,
+      PreviewMono,
       PreviewProtanope,
       PreviewDeuteranope,
       PreviewTritanope

--- a/python/gui/auto_generated/qgsprevieweffect.sip.in
+++ b/python/gui/auto_generated/qgsprevieweffect.sip.in
@@ -24,7 +24,7 @@ color blindness modes.
     enum PreviewMode
     {
       PreviewMono,
-      PreviewGrayscale
+      PreviewGrayscale,
       PreviewProtanope,
       PreviewDeuteranope,
       PreviewTritanope

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -557,24 +557,24 @@ QgsLayoutDesignerDialog::QgsLayoutDesignerDialog( QWidget *parent, Qt::WindowFla
     mView->setPreviewMode( QgsPreviewEffect::PreviewMono );
     mView->setPreviewModeEnabled( true );
   } );
-  connect( mActionPreviewAchromatopsia, &QAction::triggered, this, [ = ]
+  connect( mActionPreviewModeGrayscale, &QAction::triggered, this, [ = ]
   {
-    mView->setPreviewMode( QgsPreviewEffect::PreviewAchromatopsia );
+    mView->setPreviewMode( QgsPreviewEffect::PreviewGrayscale );
     mView->setPreviewModeEnabled( true );
   } );
-  connect( mActionPreviewProtanopia, &QAction::triggered, this, [ = ]
+  connect( mActionPreviewProtanope, &QAction::triggered, this, [ = ]
   {
-    mView->setPreviewMode( QgsPreviewEffect::PreviewProtanopia );
+    mView->setPreviewMode( QgsPreviewEffect::PreviewProtanope );
     mView->setPreviewModeEnabled( true );
   } );
-  connect( mActionPreviewDeuteranopia, &QAction::triggered, this, [ = ]
+  connect( mActionPreviewDeuteranope, &QAction::triggered, this, [ = ]
   {
-    mView->setPreviewMode( QgsPreviewEffect::PreviewDeuteranopia );
+    mView->setPreviewMode( QgsPreviewEffect::PreviewDeuteranope );
     mView->setPreviewModeEnabled( true );
   } );
-  connect( mActionPreviewTritanopia, &QAction::triggered, this, [ = ]
+  connect( mActionPreviewTritanope, &QAction::triggered, this, [ = ]
   {
-    mView->setPreviewMode( QgsPreviewEffect::PreviewTritanopia );
+    mView->setPreviewMode( QgsPreviewEffect::PreviewTritanope );
     mView->setPreviewModeEnabled( true );
   } );
   QActionGroup *previewGroup = new QActionGroup( this );
@@ -582,10 +582,9 @@ QgsLayoutDesignerDialog::QgsLayoutDesignerDialog( QWidget *parent, Qt::WindowFla
   mActionPreviewModeOff->setActionGroup( previewGroup );
   mActionPreviewModeGrayscale->setActionGroup( previewGroup );
   mActionPreviewModeMono->setActionGroup( previewGroup );
-  mActionPreviewAchromatopsia->setActionGroup( previewGroup );
-  mActionPreviewProtanopia->setActionGroup( previewGroup );
-  mActionPreviewDeuteranopia->setActionGroup( previewGroup );
-  mActionPreviewTritanopia->setActionGroup( previewGroup );
+  mActionPreviewProtanope->setActionGroup( previewGroup );
+  mActionPreviewDeuteranope->setActionGroup( previewGroup );
+  mActionPreviewTritanope->setActionGroup( previewGroup );
 
   connect( mActionSaveAsTemplate, &QAction::triggered, this, &QgsLayoutDesignerDialog::saveAsTemplate );
   connect( mActionLoadFromTemplate, &QAction::triggered, this, &QgsLayoutDesignerDialog::addItemsFromTemplate );

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -552,24 +552,29 @@ QgsLayoutDesignerDialog::QgsLayoutDesignerDialog( QWidget *parent, Qt::WindowFla
   {
     mView->setPreviewModeEnabled( false );
   } );
-  connect( mActionPreviewModeGrayscale, &QAction::triggered, this, [ = ]
-  {
-    mView->setPreviewMode( QgsPreviewEffect::PreviewGrayscale );
-    mView->setPreviewModeEnabled( true );
-  } );
   connect( mActionPreviewModeMono, &QAction::triggered, this, [ = ]
   {
     mView->setPreviewMode( QgsPreviewEffect::PreviewMono );
     mView->setPreviewModeEnabled( true );
   } );
-  connect( mActionPreviewProtanope, &QAction::triggered, this, [ = ]
+  connect( mActionPreviewAchromatopsia, &QAction::triggered, this, [ = ]
   {
-    mView->setPreviewMode( QgsPreviewEffect::PreviewProtanope );
+    mView->setPreviewMode( QgsPreviewEffect::PreviewAchromatopsia );
     mView->setPreviewModeEnabled( true );
   } );
-  connect( mActionPreviewDeuteranope, &QAction::triggered, this, [ = ]
+  connect( mActionPreviewProtanopia, &QAction::triggered, this, [ = ]
   {
-    mView->setPreviewMode( QgsPreviewEffect::PreviewDeuteranope );
+    mView->setPreviewMode( QgsPreviewEffect::PreviewProtanopia );
+    mView->setPreviewModeEnabled( true );
+  } );
+  connect( mActionPreviewDeuteranopia, &QAction::triggered, this, [ = ]
+  {
+    mView->setPreviewMode( QgsPreviewEffect::PreviewDeuteranopia );
+    mView->setPreviewModeEnabled( true );
+  } );
+  connect( mActionPreviewTritanopia, &QAction::triggered, this, [ = ]
+  {
+    mView->setPreviewMode( QgsPreviewEffect::PreviewTritanopia );
     mView->setPreviewModeEnabled( true );
   } );
   QActionGroup *previewGroup = new QActionGroup( this );
@@ -577,8 +582,10 @@ QgsLayoutDesignerDialog::QgsLayoutDesignerDialog( QWidget *parent, Qt::WindowFla
   mActionPreviewModeOff->setActionGroup( previewGroup );
   mActionPreviewModeGrayscale->setActionGroup( previewGroup );
   mActionPreviewModeMono->setActionGroup( previewGroup );
-  mActionPreviewProtanope->setActionGroup( previewGroup );
-  mActionPreviewDeuteranope->setActionGroup( previewGroup );
+  mActionPreviewAchromatopsia->setActionGroup( previewGroup );
+  mActionPreviewProtanopia->setActionGroup( previewGroup );
+  mActionPreviewDeuteranopia->setActionGroup( previewGroup );
+  mActionPreviewTritanopia->setActionGroup( previewGroup );
 
   connect( mActionSaveAsTemplate, &QAction::triggered, this, &QgsLayoutDesignerDialog::saveAsTemplate );
   connect( mActionLoadFromTemplate, &QAction::triggered, this, &QgsLayoutDesignerDialog::addItemsFromTemplate );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3061,10 +3061,11 @@ void QgisApp::createActionGroups()
   QActionGroup *mPreviewGroup = new QActionGroup( this );
   mPreviewGroup->setExclusive( true );
   mActionPreviewModeOff->setActionGroup( mPreviewGroup );
-  mActionPreviewModeGrayscale->setActionGroup( mPreviewGroup );
   mActionPreviewModeMono->setActionGroup( mPreviewGroup );
-  mActionPreviewProtanope->setActionGroup( mPreviewGroup );
-  mActionPreviewDeuteranope->setActionGroup( mPreviewGroup );
+  mActionPreviewAchromatopsia->setActionGroup( mPreviewGroup );
+  mActionPreviewProtanopia->setActionGroup( mPreviewGroup );
+  mActionPreviewDeuteranopia->setActionGroup( mPreviewGroup );
+  mActionPreviewTritanopia->setActionGroup( mPreviewGroup );
 }
 
 void QgisApp::setAppStyleSheet( const QString &stylesheet )
@@ -4302,10 +4303,11 @@ void QgisApp::setupConnections()
 
   // connect preview modes actions
   connect( mActionPreviewModeOff, &QAction::triggered, this, &QgisApp::disablePreviewMode );
-  connect( mActionPreviewModeGrayscale, &QAction::triggered, this, &QgisApp::activateGrayscalePreview );
   connect( mActionPreviewModeMono, &QAction::triggered, this, &QgisApp::activateMonoPreview );
-  connect( mActionPreviewProtanope, &QAction::triggered, this, &QgisApp::activateProtanopePreview );
-  connect( mActionPreviewDeuteranope, &QAction::triggered, this, &QgisApp::activateDeuteranopePreview );
+  connect( mActionPreviewAchromatopsia, &QAction::triggered, this, &QgisApp::activateAchromatopsiaPreview );
+  connect( mActionPreviewProtanopia, &QAction::triggered, this, &QgisApp::activateProtanopiaPreview );
+  connect( mActionPreviewDeuteranopia, &QAction::triggered, this, &QgisApp::activateDeuteranopiaPreview );
+  connect( mActionPreviewTritanopia, &QAction::triggered, this, &QgisApp::activateTritanopiaPreview );
 
   // setup undo/redo actions
   connect( mUndoWidget, &QgsUndoWidget::undoStackChanged, this, &QgisApp::updateUndoActions );
@@ -7694,28 +7696,34 @@ void QgisApp::disablePreviewMode()
   mMapCanvas->setPreviewModeEnabled( false );
 }
 
-void QgisApp::activateGrayscalePreview()
-{
-  mMapCanvas->setPreviewModeEnabled( true );
-  mMapCanvas->setPreviewMode( QgsPreviewEffect::PreviewGrayscale );
-}
-
 void QgisApp::activateMonoPreview()
 {
   mMapCanvas->setPreviewModeEnabled( true );
   mMapCanvas->setPreviewMode( QgsPreviewEffect::PreviewMono );
 }
 
-void QgisApp::activateProtanopePreview()
+void QgisApp::activateAchromatopsiaPreview()
 {
   mMapCanvas->setPreviewModeEnabled( true );
-  mMapCanvas->setPreviewMode( QgsPreviewEffect::PreviewProtanope );
+  mMapCanvas->setPreviewMode( QgsPreviewEffect::PreviewAchromatopsia );
 }
 
-void QgisApp::activateDeuteranopePreview()
+void QgisApp::activateProtanopiaPreview()
 {
   mMapCanvas->setPreviewModeEnabled( true );
-  mMapCanvas->setPreviewMode( QgsPreviewEffect::PreviewDeuteranope );
+  mMapCanvas->setPreviewMode( QgsPreviewEffect::PreviewProtanopia );
+}
+
+void QgisApp::activateDeuteranopiaPreview()
+{
+  mMapCanvas->setPreviewModeEnabled( true );
+  mMapCanvas->setPreviewMode( QgsPreviewEffect::PreviewDeuteranopia );
+}
+
+void QgisApp::activateTritanopiaPreview()
+{
+  mMapCanvas->setPreviewModeEnabled( true );
+  mMapCanvas->setPreviewMode( QgsPreviewEffect::PreviewTritanopia );
 }
 
 void QgisApp::toggleFilterLegendByExpression( bool checked )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3062,7 +3062,7 @@ void QgisApp::createActionGroups()
   mPreviewGroup->setExclusive( true );
   mActionPreviewModeOff->setActionGroup( mPreviewGroup );
   mActionPreviewModeMono->setActionGroup( mPreviewGroup );
-  mActionPreviewGrayscale->setActionGroup( mPreviewGroup );
+  mActionPreviewModeGrayscale->setActionGroup( mPreviewGroup );
   mActionPreviewProtanope->setActionGroup( mPreviewGroup );
   mActionPreviewDeuteranope->setActionGroup( mPreviewGroup );
   mActionPreviewTritanope->setActionGroup( mPreviewGroup );
@@ -4304,7 +4304,7 @@ void QgisApp::setupConnections()
   // connect preview modes actions
   connect( mActionPreviewModeOff, &QAction::triggered, this, &QgisApp::disablePreviewMode );
   connect( mActionPreviewModeMono, &QAction::triggered, this, &QgisApp::activateMonoPreview );
-  connect( mActionPreviewGrayscale, &QAction::triggered, this, &QgisApp::activateGrayscalePreview );
+  connect( mActionPreviewModeGrayscale, &QAction::triggered, this, &QgisApp::activateGrayscalePreview );
   connect( mActionPreviewProtanope, &QAction::triggered, this, &QgisApp::activateProtanopePreview );
   connect( mActionPreviewDeuteranope, &QAction::triggered, this, &QgisApp::activateDeuteranopePreview );
   connect( mActionPreviewTritanope, &QAction::triggered, this, &QgisApp::activateTritanopePreview );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3062,10 +3062,10 @@ void QgisApp::createActionGroups()
   mPreviewGroup->setExclusive( true );
   mActionPreviewModeOff->setActionGroup( mPreviewGroup );
   mActionPreviewModeMono->setActionGroup( mPreviewGroup );
-  mActionPreviewAchromatopsia->setActionGroup( mPreviewGroup );
-  mActionPreviewProtanopia->setActionGroup( mPreviewGroup );
-  mActionPreviewDeuteranopia->setActionGroup( mPreviewGroup );
-  mActionPreviewTritanopia->setActionGroup( mPreviewGroup );
+  mActionPreviewGrayscale->setActionGroup( mPreviewGroup );
+  mActionPreviewProtanope->setActionGroup( mPreviewGroup );
+  mActionPreviewDeuteranope->setActionGroup( mPreviewGroup );
+  mActionPreviewTritanope->setActionGroup( mPreviewGroup );
 }
 
 void QgisApp::setAppStyleSheet( const QString &stylesheet )
@@ -4304,10 +4304,10 @@ void QgisApp::setupConnections()
   // connect preview modes actions
   connect( mActionPreviewModeOff, &QAction::triggered, this, &QgisApp::disablePreviewMode );
   connect( mActionPreviewModeMono, &QAction::triggered, this, &QgisApp::activateMonoPreview );
-  connect( mActionPreviewAchromatopsia, &QAction::triggered, this, &QgisApp::activateAchromatopsiaPreview );
-  connect( mActionPreviewProtanopia, &QAction::triggered, this, &QgisApp::activateProtanopiaPreview );
-  connect( mActionPreviewDeuteranopia, &QAction::triggered, this, &QgisApp::activateDeuteranopiaPreview );
-  connect( mActionPreviewTritanopia, &QAction::triggered, this, &QgisApp::activateTritanopiaPreview );
+  connect( mActionPreviewGrayscale, &QAction::triggered, this, &QgisApp::activateGrayscalePreview );
+  connect( mActionPreviewProtanope, &QAction::triggered, this, &QgisApp::activateProtanopePreview );
+  connect( mActionPreviewDeuteranope, &QAction::triggered, this, &QgisApp::activateDeuteranopePreview );
+  connect( mActionPreviewTritanope, &QAction::triggered, this, &QgisApp::activateTritanopePreview );
 
   // setup undo/redo actions
   connect( mUndoWidget, &QgsUndoWidget::undoStackChanged, this, &QgisApp::updateUndoActions );
@@ -7702,28 +7702,28 @@ void QgisApp::activateMonoPreview()
   mMapCanvas->setPreviewMode( QgsPreviewEffect::PreviewMono );
 }
 
-void QgisApp::activateAchromatopsiaPreview()
+void QgisApp::activateGrayscalePreview()
 {
   mMapCanvas->setPreviewModeEnabled( true );
-  mMapCanvas->setPreviewMode( QgsPreviewEffect::PreviewAchromatopsia );
+  mMapCanvas->setPreviewMode( QgsPreviewEffect::PreviewGrayscale );
 }
 
-void QgisApp::activateProtanopiaPreview()
+void QgisApp::activateProtanopePreview()
 {
   mMapCanvas->setPreviewModeEnabled( true );
-  mMapCanvas->setPreviewMode( QgsPreviewEffect::PreviewProtanopia );
+  mMapCanvas->setPreviewMode( QgsPreviewEffect::PreviewProtanope );
 }
 
-void QgisApp::activateDeuteranopiaPreview()
+void QgisApp::activateDeuteranopePreview()
 {
   mMapCanvas->setPreviewModeEnabled( true );
-  mMapCanvas->setPreviewMode( QgsPreviewEffect::PreviewDeuteranopia );
+  mMapCanvas->setPreviewMode( QgsPreviewEffect::PreviewDeuteranope );
 }
 
-void QgisApp::activateTritanopiaPreview()
+void QgisApp::activateTritanopePreview()
 {
   mMapCanvas->setPreviewModeEnabled( true );
-  mMapCanvas->setPreviewMode( QgsPreviewEffect::PreviewTritanopia );
+  mMapCanvas->setPreviewMode( QgsPreviewEffect::PreviewTritanope );
 }
 
 void QgisApp::toggleFilterLegendByExpression( bool checked )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1889,28 +1889,35 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void disablePreviewMode();
 
     /**
-     * Enable a grayscale preview mode on the map canvas
-     * \since QGIS 2.3
-    */
-    void activateGrayscalePreview();
-
-    /**
      * Enable a monochrome preview mode on the map canvas
      * \since QGIS 2.3
     */
     void activateMonoPreview();
 
     /**
-     * Enable a color blindness (protanope) preview mode on the map canvas
-     * \since QGIS 2.3
+     * Enable a color blindness (achromatopsia) preview mode on the map canvas
+     * Replaces the grayscale preview mode
+     * \since QGIS 3.17
     */
-    void activateProtanopePreview();
+    void activateAchromatopsiaPreview();
 
     /**
-     * Enable a color blindness (deuteranope) preview mode on the map canvas
+     * Enable a color blindness (protanopia) preview mode on the map canvas
      * \since QGIS 2.3
     */
-    void activateDeuteranopePreview();
+    void activateProtanopiaPreview();
+
+    /**
+     * Enable a color blindness (deuteranopia) preview mode on the map canvas
+     * \since QGIS 2.3
+    */
+    void activateDeuteranopiaPreview();
+
+    /**
+     * Enable a color blindness (tritanopia) preview mode on the map canvas
+     * \since QGIS 3.17
+    */
+    void activateTritanopiaPreview();
 
     void toggleFilterLegendByExpression( bool );
     void updateFilterLegend();

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1895,29 +1895,28 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void activateMonoPreview();
 
     /**
-     * Enable a color blindness (achromatopsia) preview mode on the map canvas
-     * Replaces the grayscale preview mode
-     * \since QGIS 3.17
+     * Enable a grayscale preview mode on the map canvas
+     * \since QGIS 2.3
     */
-    void activateAchromatopsiaPreview();
+    void activateGrayscalePreview();
 
     /**
      * Enable a color blindness (protanopia) preview mode on the map canvas
      * \since QGIS 2.3
     */
-    void activateProtanopiaPreview();
+    void activateProtanopePreview();
 
     /**
      * Enable a color blindness (deuteranopia) preview mode on the map canvas
      * \since QGIS 2.3
     */
-    void activateDeuteranopiaPreview();
+    void activateDeuteranopePreview();
 
     /**
      * Enable a color blindness (tritanopia) preview mode on the map canvas
      * \since QGIS 3.17
     */
-    void activateTritanopiaPreview();
+    void activateTritanopePreview();
 
     void toggleFilterLegendByExpression( bool );
     void updateFilterLegend();

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1914,7 +1914,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     /**
      * Enable a color blindness (tritanopia) preview mode on the map canvas
-     * \since QGIS 3.17
+     * \since QGIS 3.18
     */
     void activateTritanopePreview();
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2410,7 +2410,7 @@ QgsPreviewEffect::PreviewMode QgsMapCanvas::previewMode() const
 {
   if ( !mPreviewEffect )
   {
-    return QgsPreviewEffect::PreviewGrayscale;
+    return QgsPreviewEffect::PreviewAchromatopsia;
   }
 
   return mPreviewEffect->mode();

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2410,7 +2410,7 @@ QgsPreviewEffect::PreviewMode QgsMapCanvas::previewMode() const
 {
   if ( !mPreviewEffect )
   {
-    return QgsPreviewEffect::PreviewAchromatopsia;
+    return QgsPreviewEffect::PreviewGrayscale;
   }
 
   return mPreviewEffect->mode();

--- a/src/gui/qgsprevieweffect.cpp
+++ b/src/gui/qgsprevieweffect.cpp
@@ -21,7 +21,7 @@
 
 QgsPreviewEffect::QgsPreviewEffect( QObject *parent )
   : QGraphicsEffect( parent )
-  , mMode( PreviewAchromatopsia )
+  , mMode( PreviewGrayscale )
 {
   //effect is disabled by default
   setEnabled( false );
@@ -60,10 +60,10 @@ void QgsPreviewEffect::draw( QPainter *painter )
       painter->drawImage( offset, bwImage );
       break;
     }
-    case QgsPreviewEffect::PreviewAchromatopsia:
-    case QgsPreviewEffect::PreviewProtanopia:
-    case QgsPreviewEffect::PreviewDeuteranopia:
-    case QgsPreviewEffect::PreviewTritanopia:
+    case QgsPreviewEffect::PreviewGrayscale:
+    case QgsPreviewEffect::PreviewProtanope:
+    case QgsPreviewEffect::PreviewDeuteranope:
+    case QgsPreviewEffect::PreviewTritanope:
     {
       QRgb *line = nullptr;
 
@@ -98,17 +98,17 @@ QRgb QgsPreviewEffect::simulateColorBlindness( QRgb &originalColor, QgsPreviewEf
   //https://www.inf.ufrgs.br/~oliveira/pubs_files/CVD_Simulation/CVD_Simulation.html
   switch ( mode )
   {
-    case PreviewAchromatopsia:
-      simulateAchromatopsia( r, g, b, red, green, blue );
+    case PreviewGrayscale:
+      simulateGrayscale( r, g, b, red, green, blue );
       break;
-    case PreviewProtanopia:
-      simulateProtanopia( r, g, b, red, green, blue );
+    case PreviewProtanope:
+      simulateProtanope( r, g, b, red, green, blue );
       break;
-    case PreviewDeuteranopia:
-      simulateDeuteranopia( r, g, b, red, green, blue );
+    case PreviewDeuteranope:
+      simulateDeuteranope( r, g, b, red, green, blue );
       break;
-    case PreviewTritanopia:
-      simulateTritanopia( r, g, b, red, green, blue );
+    case PreviewTritanope:
+      simulateTritanope( r, g, b, red, green, blue );
       break;
     default:
       break;
@@ -122,28 +122,28 @@ QRgb QgsPreviewEffect::simulateColorBlindness( QRgb &originalColor, QgsPreviewEf
   return qRgb( r, g, b );
 }
 
-void QgsPreviewEffect::simulateAchromatopsia( int &r, int &g, int &b, int &red, int &green, int &blue )
+void QgsPreviewEffect::simulateGrayscale( int &r, int &g, int &b, int &red, int &green, int &blue )
 {
   r = ( 0.299 * red ) + ( 0.587 * green ) + ( 0.114 * blue );
   g = r;
   b = r;
 }
 
-void QgsPreviewEffect::simulateProtanopia( int &r, int &g, int &b, int &red, int &green, int &blue )
+void QgsPreviewEffect::simulateProtanope( int &r, int &g, int &b, int &red, int &green, int &blue )
 {
   r = ( 0.152286 * red ) + ( 1.052583 * green ) + ( -0.204868 * blue );
   g = ( 0.114503 * red ) + ( 0.786281 * green ) + ( 0.099216 * blue );
   b = ( -0.003882 * red ) + ( -0.048116 * green ) + ( 1.051998 * blue );
 }
 
-void QgsPreviewEffect::simulateDeuteranopia( int &r, int &g, int &b, int &red, int &green, int &blue )
+void QgsPreviewEffect::simulateDeuteranope( int &r, int &g, int &b, int &red, int &green, int &blue )
 {
   r = ( 0.367322 * red ) + ( 0.860646 * green ) + ( -0.227968 * blue );
   g = ( 0.280085 * red ) + ( 0.672501 * green ) + ( 0.047413 * blue );
   b = ( -0.011820 * red ) + ( 0.042940 * green ) + ( 0.968881 * blue );
 }
 
-void QgsPreviewEffect::simulateTritanopia( int &r, int &g, int &b, int &red, int &green, int &blue )
+void QgsPreviewEffect::simulateTritanope( int &r, int &g, int &b, int &red, int &green, int &blue )
 {
   r = ( 1.255528 * red ) + ( -0.076749 * green ) + ( -0.178779 * blue );
   g = ( -0.078411 * red ) + ( 0.930809 * green ) + ( 0.147602 * blue );

--- a/src/gui/qgsprevieweffect.cpp
+++ b/src/gui/qgsprevieweffect.cpp
@@ -21,7 +21,7 @@
 
 QgsPreviewEffect::QgsPreviewEffect( QObject *parent )
   : QGraphicsEffect( parent )
-  , mMode( PreviewGrayscale )
+  , mMode( PreviewAchromatopsia )
 {
   //effect is disabled by default
   setEnabled( false );
@@ -54,31 +54,16 @@ void QgsPreviewEffect::draw( QPainter *painter )
 
   switch ( mMode )
   {
-    case QgsPreviewEffect::PreviewGrayscale:
-    {
-      QRgb *line = nullptr;
-
-      for ( int y = 0; y < image.height(); y++ )
-      {
-        line = ( QRgb * )image.scanLine( y );
-        for ( int x = 0; x < image.width(); x++ )
-        {
-          int gray = 0.21 * qRed( line[x] ) + 0.72 * qGreen( line[x] ) + 0.07 * qBlue( line[x] );
-          line[x] = qRgb( gray, gray, gray );
-        }
-      }
-
-      painter->drawImage( offset, image );
-      break;
-    }
     case QgsPreviewEffect::PreviewMono:
     {
       QImage bwImage = image.convertToFormat( QImage::Format_Mono );
       painter->drawImage( offset, bwImage );
       break;
     }
-    case QgsPreviewEffect::PreviewProtanope:
-    case QgsPreviewEffect::PreviewDeuteranope:
+    case QgsPreviewEffect::PreviewAchromatopsia:
+    case QgsPreviewEffect::PreviewProtanopia:
+    case QgsPreviewEffect::PreviewDeuteranopia:
+    case QgsPreviewEffect::PreviewTritanopia:
     {
       QRgb *line = nullptr;
 
@@ -104,49 +89,63 @@ QRgb QgsPreviewEffect::simulateColorBlindness( QRgb &originalColor, QgsPreviewEf
   int green = qGreen( originalColor );
   int blue = qBlue( originalColor );
 
-  //convert RGB to LMS color space
-  // (http://vision.psychol.cam.ac.uk/jdmollon/papers/colourmaps.pdf p245, equation 4) #spellok
-  double L = ( 17.8824 * red ) + ( 43.5161 * green ) + ( 4.11935 * blue );
-  double M = ( 3.45565 * red ) + ( 27.1554 * green ) + ( 3.86714 * blue );
-  double S = ( 0.0299566 * red ) + ( 0.184309 * green ) + ( 1.46709 * blue );
+  int r = red;
+  int g = green;
+  int b = blue;
 
   //simulate color blindness
+  //matrix values taken from Machado et al. (2009), https://doi.org/10.1109/TVCG.2009.113:
+  //https://www.inf.ufrgs.br/~oliveira/pubs_files/CVD_Simulation/CVD_Simulation.html
   switch ( mode )
   {
-    case PreviewProtanope:
-      simulateProtanopeLMS( L, M, S );
+    case PreviewAchromatopsia:
+      simulateAchromatopsia( r, g, b, red, green, blue );
       break;
-    case PreviewDeuteranope:
-      simulateDeuteranopeLMS( L, M, S );
+    case PreviewProtanopia:
+      simulateProtanopia( r, g, b, red, green, blue );
+      break;
+    case PreviewDeuteranopia:
+      simulateDeuteranopia( r, g, b, red, green, blue );
+      break;
+    case PreviewTritanopia:
+      simulateTritanopia( r, g, b, red, green, blue );
       break;
     default:
       break;
   }
 
-  //convert LMS back to RGB color space
-  //(http://vision.psychol.cam.ac.uk/jdmollon/papers/colourmaps.pdf p248, equation 6) #spellok
-  red = ( 0.080944 * L ) + ( -0.130504 * M ) + ( 0.116721 * S );
-  green = ( -0.0102485 * L ) + ( 0.0540194 * M ) + ( -0.113615 * S );
-  blue = ( -0.000365294 * L ) + ( -0.00412163 * M ) + ( 0.693513 * S );
-
   //restrict values to 0-255
-  red = std::max( std::min( 255, red ), 0 );
-  green = std::max( std::min( 255, green ), 0 );
-  blue = std::max( std::min( 255, blue ), 0 );
+  r = std::max( std::min( 255, r ), 0 );
+  g = std::max( std::min( 255, g ), 0 );
+  b = std::max( std::min( 255, b ), 0 );
 
-  return qRgb( red, green, blue );
+  return qRgb( r, g, b );
 }
 
-void QgsPreviewEffect::simulateProtanopeLMS( double &L, double &M, double &S )
+void QgsPreviewEffect::simulateAchromatopsia( int &r, int &g, int &b, int &red, int &green, int &blue )
 {
-  //adjust L component to simulate vision of Protanope
-  //(http://vision.psychol.cam.ac.uk/jdmollon/papers/colourmaps.pdf p248, equation 5) #spellok
-  L = ( 2.02344 * M ) + ( -2.52581 * S );
+  r = ( 0.299 * red ) + ( 0.587 * green ) + ( 0.114 * blue );
+  g = r;
+  b = r;
 }
 
-void QgsPreviewEffect::simulateDeuteranopeLMS( double &L, double &M, double &S )
+void QgsPreviewEffect::simulateProtanopia( int &r, int &g, int &b, int &red, int &green, int &blue )
 {
-  //adjust M component to simulate vision of Deuteranope
-  //(http://vision.psychol.cam.ac.uk/jdmollon/papers/colourmaps.pdf p248, equation 5) #spellok
-  M = ( 0.494207 * L ) + ( 1.24827 * S );
+  r = ( 0.152286 * red ) + ( 1.052583 * green ) + ( -0.204868 * blue );
+  g = ( 0.114503 * red ) + ( 0.786281 * green ) + ( 0.099216 * blue );
+  b = ( -0.003882 * red ) + ( -0.048116 * green ) + ( 1.051998 * blue );
+}
+
+void QgsPreviewEffect::simulateDeuteranopia( int &r, int &g, int &b, int &red, int &green, int &blue )
+{
+  r = ( 0.367322 * red ) + ( 0.860646 * green ) + ( -0.227968 * blue );
+  g = ( 0.280085 * red ) + ( 0.672501 * green ) + ( 0.047413 * blue );
+  b = ( -0.011820 * red ) + ( 0.042940 * green ) + ( 0.968881 * blue );
+}
+
+void QgsPreviewEffect::simulateTritanopia( int &r, int &g, int &b, int &red, int &green, int &blue )
+{
+  r = ( 1.255528 * red ) + ( -0.076749 * green ) + ( -0.178779 * blue );
+  g = ( -0.078411 * red ) + ( 0.930809 * green ) + ( 0.147602 * blue );
+  b = ( 0.004733 * red ) + ( 0.691367 * green ) + ( 0.303900 * blue );
 }

--- a/src/gui/qgsprevieweffect.cpp
+++ b/src/gui/qgsprevieweffect.cpp
@@ -124,7 +124,7 @@ QRgb QgsPreviewEffect::simulateColorBlindness( QRgb &originalColor, QgsPreviewEf
 
 void QgsPreviewEffect::simulateGrayscale( int &r, int &g, int &b, int &red, int &green, int &blue )
 {
-  r = ( 0.299 * red ) + ( 0.587 * green ) + ( 0.114 * blue );
+  r = ( 0.2126 * red ) + ( 0.7152 * green ) + ( 0.0722 * blue );
   g = r;
   b = r;
 }

--- a/src/gui/qgsprevieweffect.h
+++ b/src/gui/qgsprevieweffect.h
@@ -36,10 +36,10 @@ class GUI_EXPORT QgsPreviewEffect: public QGraphicsEffect
     enum PreviewMode
     {
       PreviewMono,
-      PreviewAchromatopsia,
-      PreviewProtanopia,
-      PreviewDeuteranopia,
-      PreviewTritanopia
+      PreviewGrayscale,
+      PreviewProtanope,
+      PreviewDeuteranope,
+      PreviewTritanope
     };
 
     QgsPreviewEffect( QObject *parent SIP_TRANSFERTHIS );
@@ -68,10 +68,10 @@ class GUI_EXPORT QgsPreviewEffect: public QGraphicsEffect
     PreviewMode mMode;
 
     QRgb simulateColorBlindness( QRgb &originalColor, PreviewMode type );
-    void simulateAchromatopsia( int &r, int &g, int &b, int &red, int &green, int &blue );
-    void simulateProtanopia( int &r, int &g, int &b, int &red, int &green, int &blue );
-    void simulateDeuteranopia( int &r, int &g, int &b, int &red, int &green, int &blue );
-    void simulateTritanopia( int &r, int &g, int &b, int &red, int &green, int &blue );
+    void simulateGrayscale( int &r, int &g, int &b, int &red, int &green, int &blue );
+    void simulateProtanope( int &r, int &g, int &b, int &red, int &green, int &blue );
+    void simulateDeuteranope( int &r, int &g, int &b, int &red, int &green, int &blue );
+    void simulateTritanope( int &r, int &g, int &b, int &red, int &green, int &blue );
 };
 
 #endif // QGSPREVIEWEFFECT_H

--- a/src/gui/qgsprevieweffect.h
+++ b/src/gui/qgsprevieweffect.h
@@ -35,10 +35,11 @@ class GUI_EXPORT QgsPreviewEffect: public QGraphicsEffect
   public:
     enum PreviewMode
     {
-      PreviewGrayscale,
       PreviewMono,
-      PreviewProtanope,
-      PreviewDeuteranope
+      PreviewAchromatopsia,
+      PreviewProtanopia,
+      PreviewDeuteranopia,
+      PreviewTritanopia
     };
 
     QgsPreviewEffect( QObject *parent SIP_TRANSFERTHIS );
@@ -67,8 +68,10 @@ class GUI_EXPORT QgsPreviewEffect: public QGraphicsEffect
     PreviewMode mMode;
 
     QRgb simulateColorBlindness( QRgb &originalColor, PreviewMode type );
-    void simulateProtanopeLMS( double &L, double &M, double &S );
-    void simulateDeuteranopeLMS( double &L, double &M, double &S );
+    void simulateAchromatopsia( int &r, int &g, int &b, int &red, int &green, int &blue );
+    void simulateProtanopia( int &r, int &g, int &b, int &red, int &green, int &blue );
+    void simulateDeuteranopia( int &r, int &g, int &b, int &red, int &green, int &blue );
+    void simulateTritanopia( int &r, int &g, int &b, int &red, int &green, int &blue );
 };
 
 #endif // QGSPREVIEWEFFECT_H

--- a/src/gui/qgsprevieweffect.h
+++ b/src/gui/qgsprevieweffect.h
@@ -35,8 +35,8 @@ class GUI_EXPORT QgsPreviewEffect: public QGraphicsEffect
   public:
     enum PreviewMode
     {
-      PreviewMono,
       PreviewGrayscale,
+      PreviewMono,
       PreviewProtanope,
       PreviewDeuteranope,
       PreviewTritanope

--- a/src/ui/layout/qgslayoutdesignerbase.ui
+++ b/src/ui/layout/qgslayoutdesignerbase.ui
@@ -242,10 +242,11 @@
       <string>&amp;Preview</string>
      </property>
      <addaction name="mActionPreviewModeOff"/>
-     <addaction name="mActionPreviewModeGrayscale"/>
      <addaction name="mActionPreviewModeMono"/>
-     <addaction name="mActionPreviewProtanope"/>
-     <addaction name="mActionPreviewDeuteranope"/>
+     <addaction name="mActionPreviewAchromatopsia"/>
+     <addaction name="mActionPreviewProtanopia"/>
+     <addaction name="mActionPreviewDeuteranopia"/>
+     <addaction name="mActionPreviewTritanopia"/>
     </widget>
     <addaction name="mActionRefreshView"/>
     <addaction name="menuPreview"/>
@@ -1101,24 +1102,40 @@
     <string>Simulate Fax (&amp;Mono)</string>
    </property>
   </action>
-  <action name="mActionPreviewProtanope">
+  <action name="mActionPreviewAchromatopsia">
    <property name="checkable">
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Simulate Color Blindness (&amp;Protanope)</string>
+    <string>Simulate Achromatopsia Color Blindness and Photocopy (&amp;Grayscale)</string>
    </property>
   </action>
-  <action name="mActionPreviewDeuteranope">
+  <action name="mActionPreviewProtanopia">
    <property name="checkable">
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Simulate Color Blindness (&amp;Deuteranope)</string>
+    <string>Simulate Protonopia Color Blindness (&amp;No Red)</string>
+   </property>
+  </action>
+  <action name="mActionPreviewDeuteranopia">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Simulate Deuteranopia Color Blindness (&amp;No Green)</string>
+   </property>
+  </action>
+  <action name="mActionPreviewTritanopia">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Simulate Tritanopia Color Blindness (&amp;Tritanopia)</string>
    </property>
   </action>
   <action name="mActionShowPage">
-   <property name="checkable">
+   <property name="checkable">q
     <bool>true</bool>
    </property>
    <property name="text">

--- a/src/ui/layout/qgslayoutdesignerbase.ui
+++ b/src/ui/layout/qgslayoutdesignerbase.ui
@@ -1091,7 +1091,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Simulate Fax (&amp;Mono)</string>
+    <string>Simulate Monochrome</string>
    </property>
   </action>
   <action name="mActionPreviewModeGrayscale">
@@ -1099,7 +1099,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Simulate Achromatopsia Color Blindness and Photocopy (&amp;Grayscale)</string>
+    <string>Simulate Achromatopsia Color Blindness (&amp;Grayscale)</string>
    </property>
   </action>
   <action name="mActionPreviewProtanope">

--- a/src/ui/layout/qgslayoutdesignerbase.ui
+++ b/src/ui/layout/qgslayoutdesignerbase.ui
@@ -243,7 +243,7 @@
      </property>
      <addaction name="mActionPreviewModeOff"/>
      <addaction name="mActionPreviewModeMono"/>
-     <addaction name="mActionPreviewGrayscale"/>
+     <addaction name="mActionPreviewModeGrayscale"/>
      <addaction name="mActionPreviewProtanope"/>
      <addaction name="mActionPreviewDeuteranope"/>
      <addaction name="mActionPreviewTritanope"/>
@@ -1123,7 +1123,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Simulate Tritanopia Color Blindness (&amp;Tritanopia)</string>
+    <string>Simulate Tritanopia Color Blindness (&amp;No Blue)</string>
    </property>
   </action>
   <action name="mActionShowPage">

--- a/src/ui/layout/qgslayoutdesignerbase.ui
+++ b/src/ui/layout/qgslayoutdesignerbase.ui
@@ -243,10 +243,10 @@
      </property>
      <addaction name="mActionPreviewModeOff"/>
      <addaction name="mActionPreviewModeMono"/>
-     <addaction name="mActionPreviewAchromatopsia"/>
-     <addaction name="mActionPreviewProtanopia"/>
-     <addaction name="mActionPreviewDeuteranopia"/>
-     <addaction name="mActionPreviewTritanopia"/>
+     <addaction name="mActionPreviewGrayscale"/>
+     <addaction name="mActionPreviewProtanope"/>
+     <addaction name="mActionPreviewDeuteranope"/>
+     <addaction name="mActionPreviewTritanope"/>
     </widget>
     <addaction name="mActionRefreshView"/>
     <addaction name="menuPreview"/>
@@ -1086,14 +1086,6 @@
     <string>Normal</string>
    </property>
   </action>
-  <action name="mActionPreviewModeGrayscale">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Simulate Photocopy (&amp;Grayscale)</string>
-   </property>
-  </action>
   <action name="mActionPreviewModeMono">
    <property name="checkable">
     <bool>true</bool>
@@ -1102,7 +1094,7 @@
     <string>Simulate Fax (&amp;Mono)</string>
    </property>
   </action>
-  <action name="mActionPreviewAchromatopsia">
+  <action name="mActionPreviewModeGrayscale">
    <property name="checkable">
     <bool>true</bool>
    </property>
@@ -1110,7 +1102,7 @@
     <string>Simulate Achromatopsia Color Blindness and Photocopy (&amp;Grayscale)</string>
    </property>
   </action>
-  <action name="mActionPreviewProtanopia">
+  <action name="mActionPreviewProtanope">
    <property name="checkable">
     <bool>true</bool>
    </property>
@@ -1118,7 +1110,7 @@
     <string>Simulate Protonopia Color Blindness (&amp;No Red)</string>
    </property>
   </action>
-  <action name="mActionPreviewDeuteranopia">
+  <action name="mActionPreviewDeuteranope">
    <property name="checkable">
     <bool>true</bool>
    </property>
@@ -1126,7 +1118,7 @@
     <string>Simulate Deuteranopia Color Blindness (&amp;No Green)</string>
    </property>
   </action>
-  <action name="mActionPreviewTritanopia">
+  <action name="mActionPreviewTritanope">
    <property name="checkable">
     <bool>true</bool>
    </property>

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -116,10 +116,11 @@
       <string>Preview Mode</string>
      </property>
      <addaction name="mActionPreviewModeOff"/>
-     <addaction name="mActionPreviewModeGrayscale"/>
      <addaction name="mActionPreviewModeMono"/>
-     <addaction name="mActionPreviewProtanope"/>
-     <addaction name="mActionPreviewDeuteranope"/>
+     <addaction name="mActionPreviewAchromatopsia"/>
+     <addaction name="mActionPreviewProtanopia"/>
+     <addaction name="mActionPreviewDeuteranopia"/>
+     <addaction name="mActionPreviewTritanopia"/>
     </widget>
     <addaction name="mActionNewMapCanvas"/>
     <addaction name="mActionNew3DMapCanvas"/>
@@ -2632,17 +2633,6 @@ Acts on the currently active layer only.</string>
     <string>Normal Preview Mode</string>
    </property>
   </action>
-  <action name="mActionPreviewModeGrayscale">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Simulate Photocopy (Grayscale)</string>
-   </property>
-   <property name="toolTip">
-    <string>Simulate Photocopy (Grayscale)</string>
-   </property>
-  </action>
   <action name="mActionPreviewModeMono">
    <property name="checkable">
     <bool>true</bool>
@@ -2654,26 +2644,48 @@ Acts on the currently active layer only.</string>
     <string>Simulate Fax (Mono)</string>
    </property>
   </action>
-  <action name="mActionPreviewProtanope">
+  <action name="mActionPreviewAchromatopsia">
    <property name="checkable">
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Simulate Color Blindness (Protanope)</string>
+    <string>Simulate Achromatopsia Color Blindness and Photocopy (Grayscale)</string>
    </property>
    <property name="toolTip">
-    <string>Simulate Color Blindness (Protanope)</string>
+    <string>Simulate Achromatopsia Color Blindness and Photocopy (Grayscale)</string>
    </property>
   </action>
-  <action name="mActionPreviewDeuteranope">
+  <action name="mActionPreviewProtanopia">
    <property name="checkable">
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Simulate Color Blindness (Deuteranope)</string>
+    <string>Simulate Protanopia Color Blindness (No Red)</string>
    </property>
    <property name="toolTip">
-    <string>Simulate Color Blindness (Deuteranope)</string>
+    <string>Simulate Protanopia Color Blindness (No Red)</string>
+   </property>
+  </action>
+  <action name="mActionPreviewDeuteranopia">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Simulate Deuteranopia Color Blindness (No Green)</string>
+   </property>
+   <property name="toolTip">
+    <string>Simulate Deuteranopia Color Blindness (No Green)</string>
+   </property>
+  </action>
+  <action name="mActionPreviewTritanopia">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Simulate Tritanopia Color Blindness (No Blue)</string>
+   </property>
+   <property name="toolTip">
+    <string>Simulate Color Blindness (No Blue)</string>
    </property>
   </action>
   <action name="mActionSetLayerScaleVisibility">

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -2638,10 +2638,10 @@ Acts on the currently active layer only.</string>
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Simulate Fax (Mono)</string>
+    <string>Simulate Monochrome</string>
    </property>
    <property name="toolTip">
-    <string>Simulate Fax (Mono)</string>
+    <string>Simulate Monochrome</string>
    </property>
   </action>
   <action name="mActionPreviewModeGrayscale">
@@ -2649,10 +2649,10 @@ Acts on the currently active layer only.</string>
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Simulate Achromatopsia Color Blindness and Photocopy (Grayscale)</string>
+    <string>Simulate Achromatopsia Color Blindness (Grayscale)</string>
    </property>
    <property name="toolTip">
-    <string>Simulate Achromatopsia Color Blindness and Photocopy (Grayscale)</string>
+    <string>Simulate Achromatopsia Color Blindness (Grayscale)</string>
    </property>
   </action>
   <action name="mActionPreviewProtanope">

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -117,10 +117,10 @@
      </property>
      <addaction name="mActionPreviewModeOff"/>
      <addaction name="mActionPreviewModeMono"/>
-     <addaction name="mActionPreviewAchromatopsia"/>
-     <addaction name="mActionPreviewProtanopia"/>
-     <addaction name="mActionPreviewDeuteranopia"/>
-     <addaction name="mActionPreviewTritanopia"/>
+     <addaction name="mActionPreviewGrayscale"/>
+     <addaction name="mActionPreviewProtanope"/>
+     <addaction name="mActionPreviewDeuteranope"/>
+     <addaction name="mActionPreviewTritanope"/>
     </widget>
     <addaction name="mActionNewMapCanvas"/>
     <addaction name="mActionNew3DMapCanvas"/>
@@ -2644,7 +2644,7 @@ Acts on the currently active layer only.</string>
     <string>Simulate Fax (Mono)</string>
    </property>
   </action>
-  <action name="mActionPreviewAchromatopsia">
+  <action name="mActionPreviewGrayscale">
    <property name="checkable">
     <bool>true</bool>
    </property>
@@ -2655,7 +2655,7 @@ Acts on the currently active layer only.</string>
     <string>Simulate Achromatopsia Color Blindness and Photocopy (Grayscale)</string>
    </property>
   </action>
-  <action name="mActionPreviewProtanopia">
+  <action name="mActionPreviewProtanope">
    <property name="checkable">
     <bool>true</bool>
    </property>
@@ -2666,7 +2666,7 @@ Acts on the currently active layer only.</string>
     <string>Simulate Protanopia Color Blindness (No Red)</string>
    </property>
   </action>
-  <action name="mActionPreviewDeuteranopia">
+  <action name="mActionPreviewDeuteranope">
    <property name="checkable">
     <bool>true</bool>
    </property>
@@ -2677,7 +2677,7 @@ Acts on the currently active layer only.</string>
     <string>Simulate Deuteranopia Color Blindness (No Green)</string>
    </property>
   </action>
-  <action name="mActionPreviewTritanopia">
+  <action name="mActionPreviewTritanope">
    <property name="checkable">
     <bool>true</bool>
    </property>

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -117,7 +117,7 @@
      </property>
      <addaction name="mActionPreviewModeOff"/>
      <addaction name="mActionPreviewModeMono"/>
-     <addaction name="mActionPreviewGrayscale"/>
+     <addaction name="mActionPreviewModeGrayscale"/>
      <addaction name="mActionPreviewProtanope"/>
      <addaction name="mActionPreviewDeuteranope"/>
      <addaction name="mActionPreviewTritanope"/>
@@ -2644,7 +2644,7 @@ Acts on the currently active layer only.</string>
     <string>Simulate Fax (Mono)</string>
    </property>
   </action>
-  <action name="mActionPreviewGrayscale">
+  <action name="mActionPreviewModeGrayscale">
    <property name="checkable">
     <bool>true</bool>
    </property>

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -2685,7 +2685,7 @@ Acts on the currently active layer only.</string>
     <string>Simulate Tritanopia Color Blindness (No Blue)</string>
    </property>
    <property name="toolTip">
-    <string>Simulate Color Blindness (No Blue)</string>
+    <string>Simulate Tritanopia Color Blindness (No Blue)</string>
    </property>
   </action>
   <action name="mActionSetLayerScaleVisibility">


### PR DESCRIPTION
This modifies the previous support for grayscale
and LMS-based simulation for protanopia and
deuteranopia, and brings it in line with the
methodology currently used in Chromium and Firefox
(https://bugs.chromium.org/p/chromium/issues/detail?id=1003700,
https://bugzilla.mozilla.org/show_bug.cgi?id=1655053).

QGIS now uses updated grayscale luminance
calculations (renamed to achromatopsia), a
precomputed protanopia matrix (renamed from
protanope), a precomputed deuteranopia matrix
(renamed from deuteranope), and an additional mode
for tritanopia using a similarly precomputed matrix.

This commit addresses issue #29760.
