### PR TITLE
PGSQL: making timestamptz a recognized date/time type.

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1054,7 +1054,7 @@ bool QgsPostgresProvider::loadFields()
         fieldType = QVariant::Time;
         fieldSize = -1;
       }
-      else if ( fieldTypeName == QLatin1String( "timestamp" ) )
+      else if ( fieldTypeName == QLatin1String( "timestamp" ) || fieldTypeName == QLatin1String( "timestamptz" ) )
       {
         fieldType = QVariant::DateTime;
         fieldSize = -1;


### PR DESCRIPTION
This trivial change makes the PostgreSQL type "TIMESTAMP WITH TIME ZONE", or "timestamptz" internally recognized as a date/time field, which can be used for the temporal capabilities. I believe this can be safely backported.

Fixes #38962.
