### PR TITLE
Treat GeoPDF files as databases in browser panel

### DIFF
--- a/src/core/providers/ogr/qgsogrdataitems.cpp
+++ b/src/core/providers/ogr/qgsogrdataitems.cpp
@@ -619,6 +619,7 @@ QgsDataItem *QgsOgrDataItemProvider::createDataItem( const QString &pathIn, QgsD
       QStringLiteral( "kml" ),
       QStringLiteral( "osm" ),
       QStringLiteral( "mdb" ),
+      QStringLiteral( "pdf" ),
       QStringLiteral( "pbf" ) };
   static QStringList sOgrSupportedDbDriverNames { QStringLiteral( "GPKG" ),
       QStringLiteral( "db" ),


### PR DESCRIPTION
Since these can have multiple sub layers, we need to allow users
to expand them out to pick a specific layer or it is not possible
to repair broken GeoPDF layer sources in projects.
