### PR TITLE
MacOS proj bundle folder

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1227,16 +1227,6 @@ int main( int argc, char *argv[] )
     }
   }
 
-  // Point PROJ_LIB at any PROJ_LIB share directory embedded in the app bundle
-  if ( !getenv( "PROJ_LIB" ) )
-  {
-    QString projLib( QDir::cleanPath( QgsApplication::pkgDataPath().append( "/proj" ) ) );
-    if ( QFile::exists( projLib ) )
-    {
-      setenv( "PROJ_LIB", projLib.toUtf8().constData(), 1 );
-    }
-  }
-
   // Point PYTHONHOME to embedded interpreter if present in the bundle
   if ( !getenv( "PYTHONHOME" ) )
   {

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -340,7 +340,7 @@ void QgsApplication::init( QString profileFolder )
   QString projLib( QDir::cleanPath( pkgDataPath().append( "/proj" ) ) );
   if ( QFile::exists( projLib ) )
   {
-    currentProjSearchPaths.append(projLib);
+    currentProjSearchPaths.append( projLib );
   }
 #endif // Q_OS_MACX
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -335,6 +335,15 @@ void QgsApplication::init( QString profileFolder )
   // append local user-writable folder as a proj search path
   QStringList currentProjSearchPaths = QgsProjUtils::searchPaths();
   currentProjSearchPaths.append( qgisSettingsDirPath() + QStringLiteral( "proj" ) );
+#ifdef Q_OS_MACX
+  // append bundled proj lib for MacOS
+  QString projLib( QDir::cleanPath( pkgDataPath().append( "/proj" ) ) );
+  if ( QFile::exists( projLib ) )
+  {
+    currentProjSearchPaths.append(projLib);
+  }
+#endif // Q_OS_MACX
+
   char **newPaths = new char *[currentProjSearchPaths.length()];
   for ( int i = 0; i < currentProjSearchPaths.count(); ++i )
   {
@@ -346,8 +355,7 @@ void QgsApplication::init( QString profileFolder )
     CPLFree( newPaths[i] );
   }
   delete [] newPaths;
-#endif
-
+#endif // PROJ_VERSION_MAJOR>=6
 
   // allow Qt to search for Qt plugins (e.g. sqldrivers) in our plugin directory
   QCoreApplication::addLibraryPath( pluginPath() );


### PR DESCRIPTION
looks like PROJ_LIB is ignored, so lets set the bundle dir directly in the search path. getting is set here is also beneficial for QGIS server (qgis_mapserver), since it has different mail function

related to #38919

 