### PR TITLE
Make processing's batch process faster

### DIFF
--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -391,9 +391,13 @@ class BatchPanelFillWidget(QToolButton):
                 res = [res]
 
             first_row = self.panel.batchRowCount() if self.panel.batchRowCount() > 1 else 0
+            self.panel.addRow(len(res))
+            self.panel.tblParameters.setUpdatesEnabled(False)
             for row, value in enumerate(res):
                 self.setRowValue(row + first_row, value, context)
+            self.panel.tblParameters.setUpdatesEnabled(True)
         else:
+            self.panel.tblParameters.setUpdatesEnabled(False)
             for row in range(self.panel.batchRowCount()):
                 params, ok = self.panel.parametersForRow(row, warnOnInvalid=False)
 
@@ -415,6 +419,7 @@ class BatchPanelFillWidget(QToolButton):
                 exp = QgsExpression(dlg.expressionText())
                 value = exp.evaluate(expression_context)
                 self.setRowValue(row, value, context)
+            self.panel.tblParameters.setUpdatesEnabled(True)
 
 
 class BatchPanel(QgsPanelWidget, WIDGET):

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -225,8 +225,10 @@ class BatchPanelFillWidget(QToolButton):
 
             first_row = self.panel.batchRowCount() if self.panel.batchRowCount() > 1 else 0
             self.panel.addRow(len(files))
+            self.panel.tblParameters.setUpdatesEnabled(False)
             for row, file in enumerate(files):
                 self.setRowValue(first_row + row, file, context)
+            self.panel.tblParameters.setUpdatesEnabled(True)
 
     def showFileSelectionDialog(self):
         settings = QgsSettings()
@@ -248,8 +250,10 @@ class BatchPanelFillWidget(QToolButton):
 
         first_row = self.panel.batchRowCount() if self.panel.batchRowCount() > 1 else 0
         self.panel.addRow(len(files))
+        self.panel.tblParameters.setUpdatesEnabled(False)
         for row, file in enumerate(files):
             self.setRowValue(first_row + row, file, context)
+        self.panel.tblParameters.setUpdatesEnabled(True)
 
     def showDirectorySelectionDialog(self):
         settings = QgsSettings()
@@ -286,8 +290,10 @@ class BatchPanelFillWidget(QToolButton):
 
         first_row = self.panel.batchRowCount() if self.panel.batchRowCount() > 1 else 0
         self.panel.addRow(len(files))
+        self.panel.tblParameters.setUpdatesEnabled(False)
         for row, file in enumerate(files):
             self.setRowValue(first_row + row, file, context)
+        self.panel.tblParameters.setUpdatesEnabled(True)
 
     def showLayerSelectionDialog(self):
         layers = []

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -224,6 +224,7 @@ class BatchPanelFillWidget(QToolButton):
             context = dataobjects.createContext()
 
             first_row = self.panel.batchRowCount() if self.panel.batchRowCount() > 1 else 0
+            self.panel.addRow(len(files))
             for row, file in enumerate(files):
                 self.setRowValue(first_row + row, file, context)
 
@@ -246,6 +247,7 @@ class BatchPanelFillWidget(QToolButton):
         context = dataobjects.createContext()
 
         first_row = self.panel.batchRowCount() if self.panel.batchRowCount() > 1 else 0
+        self.panel.addRow(len(files))
         for row, file in enumerate(files):
             self.setRowValue(first_row + row, file, context)
 
@@ -283,6 +285,7 @@ class BatchPanelFillWidget(QToolButton):
         context = dataobjects.createContext()
 
         first_row = self.panel.batchRowCount() if self.panel.batchRowCount() > 1 else 0
+        self.panel.addRow(len(files))
         for row, file in enumerate(files):
             self.setRowValue(first_row + row, file, context)
 
@@ -655,34 +658,39 @@ class BatchPanel(QgsPanelWidget, WIDGET):
             param_definition = self.alg.parameterDefinition(self.column_to_parameter_definition[col])
             self.tblParameters.setCellWidget(0, col, BatchPanelFillWidget(param_definition, col, self))
 
-    def addRow(self):
-        self.wrappers.append([None] * self.tblParameters.columnCount())
-        self.tblParameters.setRowCount(self.tblParameters.rowCount() + 1)
+    def addRow(self, nb=1):
+        self.tblParameters.setUpdatesEnabled(False)
+        self.tblParameters.setRowCount(self.tblParameters.rowCount() + nb)
 
         context = dataobjects.createContext()
 
         wrappers = {}
-        row = self.tblParameters.rowCount() - 1
-        for param in self.alg.parameterDefinitions():
-            if param.isDestination():
-                continue
+        row = self.tblParameters.rowCount() - nb
+        while row < self.tblParameters.rowCount():
+            self.wrappers.append([None] * self.tblParameters.columnCount())
+            for param in self.alg.parameterDefinitions():
+                if param.isDestination():
+                    continue
 
-            column = self.parameter_to_column[param.name()]
-            wrapper = WidgetWrapperFactory.create_wrapper(param, self.parent, row, column)
-            wrappers[param.name()] = wrapper
-            self.setCellWrapper(row, column, wrapper, context)
+                column = self.parameter_to_column[param.name()]
+                wrapper = WidgetWrapperFactory.create_wrapper(param, self.parent, row, column)
+                wrappers[param.name()] = wrapper
+                self.setCellWrapper(row, column, wrapper, context)
 
-        for out in self.alg.destinationParameterDefinitions():
-            if out.flags() & QgsProcessingParameterDefinition.FlagHidden:
-                continue
+            for out in self.alg.destinationParameterDefinitions():
+                if out.flags() & QgsProcessingParameterDefinition.FlagHidden:
+                    continue
 
-            column = self.parameter_to_column[out.name()]
-            self.tblParameters.setCellWidget(
-                row, column, BatchOutputSelectionPanel(
-                    out, self.alg, row, column, self))
+                column = self.parameter_to_column[out.name()]
+                self.tblParameters.setCellWidget(
+                    row, column, BatchOutputSelectionPanel(
+                        out, self.alg, row, column, self))
 
-        for wrapper in list(wrappers.values()):
-            wrapper.postInitialize(list(wrappers.values()))
+            for wrapper in list(wrappers.values()):
+                wrapper.postInitialize(list(wrappers.values()))
+            row += 1
+
+        self.tblParameters.setUpdatesEnabled(True)
 
     def removeRows(self):
         rows = set()


### PR DESCRIPTION
## Description

This and @nyalldawson 's PR #38988 makes processing's batch process usable when adding a large number of rows (from files, expressions, etc.) and therefore fixes #38987 . 

On the long run, we probably want to avoid creating widgets for all rows all all time and instead only show widgets when editing cell values. But for now, the two drastic speed boost unlocked does the job.