### PR TITLE
Added method to clear all individual layer settings in QgsSnappingConfig

### DIFF
--- a/python/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/core/auto_generated/qgssnappingconfig.sip.in
@@ -413,6 +413,13 @@ Returns individual layer snappings settings (applied if mode is AdvancedConfigur
 Sets individual layer snappings settings (applied if mode is AdvancedConfiguration)
 %End
 
+    void clearIndividualLayerSettings();
+%Docstring
+Removes all individual layer snapping settings
+
+.. versionadded:: 3.16
+%End
+
     bool operator!= ( const QgsSnappingConfig &other ) const;
 
     void readProject( const QDomDocument &doc );

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -797,7 +797,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
   config.setEnabled( true );
   config.setMode( QgsSnappingConfig::AdvancedConfiguration );
   config.setIntersectionSnapping( false );  // only snap to layers
-  config.individualLayerSettings().clear();
+  config.clearIndividualLayerSettings();
 
   typedef QHash<QgsVectorLayer *, QgsSnappingConfig::IndividualLayerSettings> SettingsHashMap;
   SettingsHashMap oldLayerSettings = oldConfig.individualLayerSettings();

--- a/src/core/qgssnappingconfig.cpp
+++ b/src/core/qgssnappingconfig.cpp
@@ -373,6 +373,11 @@ QgsSnappingConfig::IndividualLayerSettings QgsSnappingConfig::individualLayerSet
   }
 }
 
+void QgsSnappingConfig::clearIndividualLayerSettings()
+{
+  mIndividualLayerSettings.clear();
+}
+
 void QgsSnappingConfig::setIndividualLayerSettings( QgsVectorLayer *vl, const IndividualLayerSettings &individualLayerSettings )
 {
   if ( !vl || !vl->isSpatial() || mIndividualLayerSettings.value( vl ) == individualLayerSettings )

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -402,6 +402,13 @@ class CORE_EXPORT QgsSnappingConfig
     void setIndividualLayerSettings( QgsVectorLayer *vl, const QgsSnappingConfig::IndividualLayerSettings &individualLayerSettings );
 
     /**
+     * Removes all individual layer snapping settings
+     *
+     * \since QGIS 3.16
+     */
+    void clearIndividualLayerSettings();
+
+    /**
      * Compare this configuration to other.
      */
     bool operator!= ( const QgsSnappingConfig &other ) const;


### PR DESCRIPTION
## Description
The vertext tool creates a temporary advanced snapping configuration containing only visible && editable layers in order to gather the candidate vertices to be moved.
With the changes in #36231,  the QHash containing individual layer settings fails to be cleared because `QgsSnappingConfig::individualLayerSettings() const`, so entries of invisible but snappable layers remain, causing #38992
https://github.com/qgis/QGIS/blob/5d2495e65a56a79ac8409e0a5ec3ad68d5fae74e/src/app/vertextool/qgsvertextool.cpp#L796-L800


Fixes #38992

@troopa81 could you review since you reviewed the original pr too?
<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
