### PR TITLE
rotated ticks folloup : improve UI

### DIFF
--- a/src/gui/layout/qgslayoutmapgridwidget.cpp
+++ b/src/gui/layout/qgslayoutmapgridwidget.cpp
@@ -63,11 +63,11 @@ QgsLayoutMapGridWidget::QgsLayoutMapGridWidget( QgsLayoutItemMapGrid *mapGrid, Q
   connect( mFrameWidthSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutMapGridWidget::mFrameWidthSpinBox_valueChanged );
   connect( mGridFrameMarginSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutMapGridWidget::mGridFrameMarginSpinBox_valueChanged );
   connect( mFrameStyleComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsLayoutMapGridWidget::mFrameStyleComboBox_currentIndexChanged );
-  connect( mRotatedTicksCheckBox, &QCheckBox::toggled, this, &QgsLayoutMapGridWidget::mRotatedTicksCheckBox_toggled );
+  connect( mRotatedTicksGroupBox, &QGroupBox::toggled, this, &QgsLayoutMapGridWidget::mRotatedTicksGroupBox_toggled );
   connect( mRotatedTicksLengthModeComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsLayoutMapGridWidget::mRotatedTicksLengthModeComboBox_currentIndexChanged );
   connect( mRotatedTicksThresholdSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutMapGridWidget::mRotatedTicksThresholdSpinBox_valueChanged );
   connect( mRotatedTicksMarginToCornerSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutMapGridWidget::mRotatedTicksMarginToCornerSpinBox_valueChanged );
-  connect( mRotatedAnnotationsCheckBox, &QCheckBox::toggled, this, &QgsLayoutMapGridWidget::mRotatedAnnotationsCheckBox_toggled );
+  connect( mRotatedAnnotationsGroupBox, &QGroupBox::toggled, this, &QgsLayoutMapGridWidget::mRotatedAnnotationsGroupBox_toggled );
   connect( mRotatedAnnotationsLengthModeComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsLayoutMapGridWidget::mRotatedAnnotationsLengthModeComboBox_currentIndexChanged );
   connect( mRotatedAnnotationsThresholdSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutMapGridWidget::mRotatedAnnotationsThresholdSpinBox_valueChanged );
   connect( mRotatedAnnotationsMarginToCornerSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutMapGridWidget::mRotatedAnnotationsMarginToCornerSpinBox_valueChanged );
@@ -347,7 +347,7 @@ void QgsLayoutMapGridWidget::toggleFrameControls( bool frameEnabled, bool frameF
   mRightDivisionsLabel->setEnabled( frameEnabled );
   mTopDivisionsLabel->setEnabled( frameEnabled );
   mBottomDivisionsLabel->setEnabled( frameEnabled );
-  mRotatedTicksCheckBox->setEnabled( rotationEnabled );
+  mRotatedTicksGroupBox->setEnabled( rotationEnabled );
   mRotatedTicksLengthModeComboBox->setEnabled( rotationEnabled );
   mRotatedTicksThresholdSpinBox->setEnabled( rotationEnabled );
   mRotatedTicksMarginToCornerSpinBox->setEnabled( rotationEnabled );
@@ -570,12 +570,12 @@ void QgsLayoutMapGridWidget::setGridItems()
   mCheckGridTopSide->setChecked( mMapGrid->testFrameSideFlag( QgsLayoutItemMapGrid::FrameTop ) );
   mCheckGridBottomSide->setChecked( mMapGrid->testFrameSideFlag( QgsLayoutItemMapGrid::FrameBottom ) );
 
-  mRotatedTicksCheckBox->setChecked( mMapGrid->rotatedTicksEnabled() );
+  mRotatedTicksGroupBox->setChecked( mMapGrid->rotatedTicksEnabled() );
   mRotatedTicksLengthModeComboBox->setCurrentIndex( mRotatedTicksLengthModeComboBox->findData( mMapGrid->rotatedTicksLengthMode() ) );
   mRotatedTicksThresholdSpinBox->setValue( mMapGrid->rotatedTicksMinimumAngle() );
   mRotatedTicksMarginToCornerSpinBox->setValue( mMapGrid->rotatedTicksMarginToCorner() );
 
-  mRotatedAnnotationsCheckBox->setChecked( mMapGrid->rotatedAnnotationsEnabled() );
+  mRotatedAnnotationsGroupBox->setChecked( mMapGrid->rotatedAnnotationsEnabled() );
   mRotatedAnnotationsLengthModeComboBox->setCurrentIndex( mRotatedAnnotationsLengthModeComboBox->findData( mMapGrid->rotatedAnnotationsLengthMode() ) );
   mRotatedAnnotationsThresholdSpinBox->setValue( mMapGrid->rotatedAnnotationsMinimumAngle() );
   mRotatedAnnotationsMarginToCornerSpinBox->setValue( mMapGrid->rotatedAnnotationsMarginToCorner() );
@@ -897,7 +897,7 @@ void QgsLayoutMapGridWidget::mFrameStyleComboBox_currentIndexChanged( int )
   mMap->endCommand();
 }
 
-void QgsLayoutMapGridWidget::mRotatedTicksCheckBox_toggled( bool state )
+void QgsLayoutMapGridWidget::mRotatedTicksGroupBox_toggled( bool state )
 {
   if ( !mMapGrid || !mMap )
   {
@@ -950,7 +950,7 @@ void QgsLayoutMapGridWidget::mRotatedTicksMarginToCornerSpinBox_valueChanged( do
   mMap->endCommand();
 }
 
-void QgsLayoutMapGridWidget::mRotatedAnnotationsCheckBox_toggled( bool state )
+void QgsLayoutMapGridWidget::mRotatedAnnotationsGroupBox_toggled( bool state )
 {
   if ( !mMapGrid || !mMap )
   {

--- a/src/gui/layout/qgslayoutmapgridwidget.cpp
+++ b/src/gui/layout/qgslayoutmapgridwidget.cpp
@@ -348,9 +348,6 @@ void QgsLayoutMapGridWidget::toggleFrameControls( bool frameEnabled, bool frameF
   mTopDivisionsLabel->setEnabled( frameEnabled );
   mBottomDivisionsLabel->setEnabled( frameEnabled );
   mRotatedTicksGroupBox->setEnabled( rotationEnabled );
-  mRotatedTicksLengthModeComboBox->setEnabled( rotationEnabled );
-  mRotatedTicksThresholdSpinBox->setEnabled( rotationEnabled );
-  mRotatedTicksMarginToCornerSpinBox->setEnabled( rotationEnabled );
 }
 
 void QgsLayoutMapGridWidget::insertAnnotationPositionEntries( QComboBox *c )

--- a/src/gui/layout/qgslayoutmapgridwidget.h
+++ b/src/gui/layout/qgslayoutmapgridwidget.h
@@ -50,11 +50,11 @@ class GUI_EXPORT QgsLayoutMapGridWidget: public QgsLayoutItemBaseWidget, private
     void mOffsetYSpinBox_valueChanged( double value );
     void mCrossWidthSpinBox_valueChanged( double val );
     void mFrameWidthSpinBox_valueChanged( double val );
-    void mRotatedTicksCheckBox_toggled( bool checked );
+    void mRotatedTicksGroupBox_toggled( bool checked );
     void mRotatedTicksLengthModeComboBox_currentIndexChanged( int );
     void mRotatedTicksThresholdSpinBox_valueChanged( double val );
     void mRotatedTicksMarginToCornerSpinBox_valueChanged( double val );
-    void mRotatedAnnotationsCheckBox_toggled( bool checked );
+    void mRotatedAnnotationsGroupBox_toggled( bool checked );
     void mRotatedAnnotationsLengthModeComboBox_currentIndexChanged( int );
     void mRotatedAnnotationsThresholdSpinBox_valueChanged( double val );
     void mRotatedAnnotationsMarginToCornerSpinBox_valueChanged( double val );

--- a/src/ui/layout/qgslayoutmapgridwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapgridwidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>436</width>
+    <width>507</width>
     <height>1205</height>
    </rect>
   </property>
@@ -48,8 +48,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>421</width>
-        <height>1209</height>
+        <width>492</width>
+        <height>1211</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -144,7 +144,7 @@
              <number>2</number>
             </property>
             <property name="showClearButton" stdset="0">
-             <bool>false</bool>
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -230,6 +230,9 @@
                 </property>
                 <property name="maximum">
                  <double>9999999.000000000000000</double>
+                </property>
+                <property name="showClearButton" stdset="0">
+                  <bool>true</bool>
                 </property>
                </widget>
               </item>
@@ -550,13 +553,6 @@
           <item row="10" column="1" colspan="4">
            <widget class="QComboBox" name="mFrameDivisionsRightComboBox"/>
           </item>
-          <item row="5" column="4">
-           <widget class="QgsPropertyOverrideButton" name="mFrameMarginDDBtn">
-            <property name="text">
-             <string>…</string>
-            </property>
-           </widget>
-          </item>
           <item row="13" column="0" colspan="5">
            <layout class="QGridLayout" name="gridLayout_4">
             <item row="0" column="1">
@@ -566,17 +562,17 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="1">
-             <widget class="QCheckBox" name="mCheckGridBottomSide">
-              <property name="text">
-               <string>Bottom side</string>
-              </property>
-             </widget>
-            </item>
             <item row="0" column="0">
              <widget class="QCheckBox" name="mCheckGridLeftSide">
               <property name="text">
                <string>Left side</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QCheckBox" name="mCheckGridBottomSide">
+              <property name="text">
+               <string>Bottom side</string>
               </property>
              </widget>
             </item>
@@ -682,7 +678,7 @@
              <item row="0" column="1">
               <widget class="QComboBox" name="mRotatedTicksLengthModeComboBox">
                <property name="toolTip">
-                <string>Determines how the ticks are aligned when rotated.</string>
+                <string>Determines how the ticks length is defined when rotated.</string>
                </property>
               </widget>
              </item>
@@ -694,9 +690,12 @@
               </widget>
              </item>
              <item row="1" column="1">
-              <widget class="QDoubleSpinBox" name="mRotatedTicksThresholdSpinBox">
+              <widget class="QgsDoubleSpinBox" name="mRotatedTicksThresholdSpinBox">
                <property name="toolTip">
-                <string>Grid lines intersecting the border below this threshold will be ignored. This only makes sense for rotated grids.</string>
+                <string>Grid lines intersecting the border below this threshold will be ignored.</string>
+               </property>
+               <property name="showClearButton" stdset="0">
+                <bool>true</bool>
                </property>
                <property name="suffix">
                 <string> °</string>
@@ -720,9 +719,12 @@
               </widget>
              </item>
              <item row="2" column="1">
-              <widget class="QDoubleSpinBox" name="mRotatedTicksMarginToCornerSpinBox">
+              <widget class="QgsDoubleSpinBox" name="mRotatedTicksMarginToCornerSpinBox">
                <property name="toolTip">
-                <string>Outwards facing ticks closer to the corners than this margin will be ignored. This only makes sense for rotated grids.</string>
+                <string>Outwards facing ticks closer to the corners than this margin will be ignored.</string>
+               </property>
+               <property name="showClearButton" stdset="0">
+                <bool>true</bool>
                </property>
                <property name="suffix">
                 <string> mm</string>
@@ -736,6 +738,13 @@
               </widget>
              </item>
             </layout>
+           </widget>
+          </item>
+          <item row="5" column="4">
+           <widget class="QgsPropertyOverrideButton" name="mFrameMarginDDBtn">
+            <property name="text">
+             <string>…</string>
+            </property>
            </widget>
           </item>
          </layout>
@@ -762,22 +771,34 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0">
-          <item row="16" column="0">
-           <widget class="QLabel" name="mCoordinatePrecisionLabel">
+          <item row="8" column="0">
+           <widget class="QLabel" name="mAnnotationPositionLabelRight">
             <property name="text">
-             <string>Coordinate precision</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
+             <string>Right</string>
             </property>
            </widget>
           </item>
-          <item row="14" column="2">
-           <widget class="QgsPropertyOverrideButton" name="mLabelDistDDBtn">
+          <item row="7" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDirectionComboBoxLeft"/>
+          </item>
+          <item row="6" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationPositionLeftComboBox"/>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="mAnnotationFormatLabel">
             <property name="text">
-             <string>…</string>
+             <string>Format</string>
             </property>
            </widget>
+          </item>
+          <item row="8" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDisplayRightComboBox"/>
+          </item>
+          <item row="9" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationPositionRightComboBox"/>
+          </item>
+          <item row="10" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDirectionComboBoxRight"/>
           </item>
           <item row="0" column="1" colspan="2">
            <layout class="QHBoxLayout" name="horizontalLayout_13">
@@ -797,85 +818,7 @@
             </item>
            </layout>
           </item>
-          <item row="11" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationPositionBottomComboBox"/>
-          </item>
-          <item row="3" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDirectionComboBoxLeft"/>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="mAnnotationPositionLabelLeft">
-            <property name="text">
-             <string>Left</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="mAnnotationFormatLabel">
-            <property name="text">
-             <string>Format</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDisplayLeftComboBox"/>
-          </item>
           <item row="14" column="0">
-           <widget class="QLabel" name="mDistanceToMapFrameLabel">
-            <property name="text">
-             <string>Distance to map frame</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="10" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDisplayBottomComboBox"/>
-          </item>
-          <item row="4" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDisplayRightComboBox"/>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="mAnnotationPositionLabelRight">
-            <property name="text">
-             <string>Right</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationPositionRightComboBox"/>
-          </item>
-          <item row="14" column="1">
-           <widget class="QgsDoubleSpinBox" name="mDistanceToMapFrameSpinBox">
-            <property name="suffix">
-             <string> mm</string>
-            </property>
-           </widget>
-          </item>
-          <item row="12" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDirectionComboBoxBottom"/>
-          </item>
-          <item row="13" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Font</string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDirectionComboBoxTop"/>
-          </item>
-          <item row="2" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationPositionLeftComboBox"/>
-          </item>
-          <item row="7" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDisplayTopComboBox"/>
-          </item>
-          <item row="10" column="0">
            <widget class="QLabel" name="mAnnotationPositionLabelBottom">
             <property name="text">
              <string>Bottom</string>
@@ -885,7 +828,13 @@
             </property>
            </widget>
           </item>
-          <item row="7" column="0">
+          <item row="15" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationPositionBottomComboBox"/>
+          </item>
+          <item row="11" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDisplayTopComboBox"/>
+          </item>
+          <item row="11" column="0">
            <widget class="QLabel" name="mAnnotationPositionLabelTop">
             <property name="text">
              <string>Top</string>
@@ -895,14 +844,26 @@
             </property>
            </widget>
           </item>
-          <item row="16" column="1" colspan="2">
-           <widget class="QgsSpinBox" name="mCoordinatePrecisionSpinBox">
-            <property name="showClearButton" stdset="0">
-             <bool>false</bool>
+          <item row="12" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationPositionTopComboBox"/>
+          </item>
+          <item row="17" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Font</string>
             </property>
            </widget>
           </item>
           <item row="13" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDirectionComboBoxTop"/>
+          </item>
+          <item row="16" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDirectionComboBoxBottom"/>
+          </item>
+          <item row="14" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDisplayBottomComboBox"/>
+          </item>
+          <item row="17" column="1" colspan="2">
            <widget class="QgsFontButton" name="mAnnotationFontButton">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -915,13 +876,48 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationPositionTopComboBox"/>
+          <item row="20" column="1" colspan="2">
+           <widget class="QgsSpinBox" name="mCoordinatePrecisionSpinBox">
+            <property name="showClearButton" stdset="0">
+             <bool>false</bool>
+            </property>
+           </widget>
           </item>
-          <item row="6" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDirectionComboBoxRight"/>
+          <item row="18" column="0">
+           <widget class="QLabel" name="mDistanceToMapFrameLabel">
+            <property name="text">
+             <string>Distance to map frame</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
           </item>
-          <item row="17" column="0" colspan="3">
+          <item row="18" column="2">
+           <widget class="QgsPropertyOverrideButton" name="mLabelDistDDBtn">
+            <property name="text">
+             <string>…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="18" column="1">
+           <widget class="QgsDoubleSpinBox" name="mDistanceToMapFrameSpinBox">
+            <property name="suffix">
+             <string> mm</string>
+            </property>
+           </widget>
+          </item>
+          <item row="20" column="0">
+           <widget class="QLabel" name="mCoordinatePrecisionLabel">
+            <property name="text">
+             <string>Coordinate precision</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="21" column="0" colspan="3">
            <widget class="QGroupBox" name="mRotatedAnnotationsGroupBox">
             <property name="title">
              <string>Rotate annotations</string>
@@ -938,7 +934,11 @@
               </widget>
              </item>
              <item row="0" column="1">
-              <widget class="QComboBox" name="mRotatedAnnotationsLengthModeComboBox"/>
+              <widget class="QComboBox" name="mRotatedAnnotationsLengthModeComboBox">
+                <property name="toolTip">
+                  <string>Determines how the ticks length is defined when rotated.</string>
+                </property>
+              </widget>
              </item>
              <item row="1" column="0">
               <widget class="QLabel" name="label_9">
@@ -948,7 +948,13 @@
               </widget>
              </item>
              <item row="1" column="1">
-              <widget class="QDoubleSpinBox" name="mRotatedAnnotationsThresholdSpinBox">
+              <widget class="QgsDoubleSpinBox" name="mRotatedAnnotationsThresholdSpinBox">
+               <property name="toolTip">
+                <string>Grid lines intersecting the border below this threshold will be ignored.</string>
+               </property>
+               <property name="showClearButton" stdset="0">
+                <bool>true</bool>
+               </property>
                <property name="suffix">
                 <string> °</string>
                </property>
@@ -968,9 +974,12 @@
               </widget>
              </item>
              <item row="2" column="1">
-              <widget class="QDoubleSpinBox" name="mRotatedAnnotationsMarginToCornerSpinBox">
+              <widget class="QgsDoubleSpinBox" name="mRotatedAnnotationsMarginToCornerSpinBox">
                <property name="toolTip">
-                <string>Outwards facing annotations closer to the corners than this margin will be ignored. This only makes sense for rotated grids.</string>
+                <string>Outwards facing annotations closer to the corners than this margin will be ignored.</string>
+               </property>
+               <property name="showClearButton" stdset="0">
+                <bool>true</bool>
                </property>
                <property name="suffix">
                 <string> mm</string>
@@ -984,6 +993,30 @@
               </widget>
              </item>
             </layout>
+           </widget>
+          </item>
+          <item row="1" column="1" colspan="2">
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <widget class="QComboBox" name="mAnnotationDisplayLeftComboBox"/>
+            </item>
+            <item>
+             <widget class="QgsPropertyOverrideButton" name="mAnnotationDisplayLeftDDBtn">
+              <property name="text">
+               <string>…</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="mAnnotationPositionLabelLeft">
+            <property name="text">
+             <string>Left</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
            </widget>
           </item>
          </layout>
@@ -1100,7 +1133,6 @@
   <tabstop>mDrawAnnotationGroupBox</tabstop>
   <tabstop>mAnnotationFormatComboBox</tabstop>
   <tabstop>mAnnotationFormatButton</tabstop>
-  <tabstop>mAnnotationDisplayLeftComboBox</tabstop>
   <tabstop>mAnnotationPositionLeftComboBox</tabstop>
   <tabstop>mAnnotationDirectionComboBoxLeft</tabstop>
   <tabstop>mAnnotationDisplayRightComboBox</tabstop>

--- a/src/ui/layout/qgslayoutmapgridwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapgridwidgetbase.ui
@@ -48,8 +48,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>425</width>
-        <height>1660</height>
+        <width>421</width>
+        <height>1209</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -439,8 +439,35 @@
           <string notr="true">composermapgrid</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,0,0,0,0">
-          <item row="9" column="1" colspan="4">
-           <widget class="QComboBox" name="mFrameDivisionsLeftComboBox"/>
+          <item row="9" column="0">
+           <widget class="QLabel" name="mLeftDivisionsLabel">
+            <property name="text">
+             <string>Left divisions</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="mFramePenLabel">
+            <property name="text">
+             <string>Frame line thickness</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1" colspan="4">
+           <widget class="QComboBox" name="mFrameStyleComboBox"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="mFrameStyleLabel_2">
+            <property name="text">
+             <string>Frame style</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="1" colspan="4">
+           <widget class="QComboBox" name="mFrameDivisionsBottomComboBox"/>
           </item>
           <item row="10" column="0">
            <widget class="QLabel" name="mRightDivisionsLabel">
@@ -459,74 +486,10 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="mFrameMarginLabel">
-            <property name="text">
-             <string>Frame margin</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="1">
-           <widget class="QgsDoubleSpinBox" name="mGridFramePenSizeSpinBox">
-            <property name="suffix">
-             <string> mm</string>
-            </property>
-            <property name="showClearButton" stdset="0">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="0">
-           <widget class="QLabel" name="mLeftDivisionsLabel">
-            <property name="text">
-             <string>Left divisions</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="mFrameStyleLabel_2">
-            <property name="text">
-             <string>Frame style</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <widget class="QLabel" name="mFramePenLabel">
-            <property name="text">
-             <string>Frame line thickness</string>
-            </property>
-           </widget>
-          </item>
-          <item row="12" column="1" colspan="4">
-           <widget class="QComboBox" name="mFrameDivisionsBottomComboBox"/>
-          </item>
-          <item row="5" column="1" colspan="3">
-           <widget class="QgsDoubleSpinBox" name="mGridFrameMarginSpinBox">
-            <property name="suffix">
-             <string> mm</string>
-            </property>
-            <property name="showClearButton" stdset="0">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
           <item row="3" column="4">
            <widget class="QgsPropertyOverrideButton" name="mFrameSizeDDBtn">
             <property name="text">
              <string>…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="10" column="1" colspan="4">
-           <widget class="QComboBox" name="mFrameDivisionsRightComboBox"/>
-          </item>
-          <item row="16" column="0">
-           <widget class="QLabel" name="label_7">
-            <property name="text">
-             <string>Skip low angled ticks</string>
             </property>
            </widget>
           </item>
@@ -537,11 +500,18 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1" colspan="4">
-           <widget class="QComboBox" name="mFrameStyleComboBox"/>
-          </item>
           <item row="3" column="1" colspan="3">
            <widget class="QgsDoubleSpinBox" name="mFrameWidthSpinBox">
+            <property name="suffix">
+             <string> mm</string>
+            </property>
+            <property name="showClearButton" stdset="0">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QgsDoubleSpinBox" name="mGridFramePenSizeSpinBox">
             <property name="suffix">
              <string> mm</string>
             </property>
@@ -557,46 +527,33 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="0">
-           <widget class="QLabel" name="mFrameFillLabel">
+          <item row="5" column="0">
+           <widget class="QLabel" name="mFrameMarginLabel">
             <property name="text">
-             <string>Frame fill colors</string>
+             <string>Frame margin</string>
             </property>
            </widget>
           </item>
-          <item row="12" column="0">
-           <widget class="QLabel" name="mBottomDivisionsLabel">
-            <property name="text">
-             <string>Bottom divisions</string>
+          <item row="9" column="1" colspan="4">
+           <widget class="QComboBox" name="mFrameDivisionsLeftComboBox"/>
+          </item>
+          <item row="5" column="1" colspan="3">
+           <widget class="QgsDoubleSpinBox" name="mGridFrameMarginSpinBox">
+            <property name="suffix">
+             <string> mm</string>
+            </property>
+            <property name="showClearButton" stdset="0">
+             <bool>false</bool>
             </property>
            </widget>
+          </item>
+          <item row="10" column="1" colspan="4">
+           <widget class="QComboBox" name="mFrameDivisionsRightComboBox"/>
           </item>
           <item row="5" column="4">
            <widget class="QgsPropertyOverrideButton" name="mFrameMarginDDBtn">
             <property name="text">
              <string>…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="11" column="1" colspan="4">
-           <widget class="QComboBox" name="mFrameDivisionsTopComboBox"/>
-          </item>
-          <item row="16" column="1" colspan="4">
-           <widget class="QDoubleSpinBox" name="mRotatedTicksThresholdSpinBox">
-            <property name="toolTip">
-             <string>Grid lines intersecting the border below this threshold will be ignored. This only makes sense for rotated grids.</string>
-            </property>
-            <property name="suffix">
-             <string> °</string>
-            </property>
-            <property name="decimals">
-             <number>2</number>
-            </property>
-            <property name="maximum">
-             <double>90.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>0.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -632,8 +589,25 @@
             </item>
            </layout>
           </item>
-          <item row="8" column="3" colspan="2">
-           <widget class="QgsColorButton" name="mGridFrameFill2ColorButton">
+          <item row="12" column="0">
+           <widget class="QLabel" name="mBottomDivisionsLabel">
+            <property name="text">
+             <string>Bottom divisions</string>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="1" colspan="4">
+           <widget class="QComboBox" name="mFrameDivisionsTopComboBox"/>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="mFrameFillLabel">
+            <property name="text">
+             <string>Frame fill colors</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="3" colspan="2">
+           <widget class="QgsColorButton" name="mGridFramePenColorButton">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -670,8 +644,8 @@
             </property>
            </widget>
           </item>
-          <item row="7" column="3" colspan="2">
-           <widget class="QgsColorButton" name="mGridFramePenColorButton">
+          <item row="8" column="3" colspan="2">
+           <widget class="QgsColorButton" name="mGridFrameFill2ColorButton">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -689,52 +663,79 @@
             </property>
            </widget>
           </item>
-          <item row="15" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>Rotated ticks alignment</string>
-            </property>
-           </widget>
-          </item>
-          <item row="15" column="1" colspan="4">
-           <widget class="QComboBox" name="mRotatedTicksLengthModeComboBox">
-            <property name="toolTip">
-             <string>Determines how the ticks are aligned when rotated.</string>
-            </property>
-           </widget>
-          </item>
-          <item row="14" column="0">
-           <widget class="QLabel" name="label_8">
-            <property name="text">
+          <item row="14" column="0" colspan="5">
+           <widget class="QGroupBox" name="mRotatedTicksGroupBox">
+            <property name="title">
              <string>Rotate ticks</string>
             </property>
-           </widget>
-          </item>
-          <item row="14" column="1" colspan="4">
-           <widget class="QCheckBox" name="mRotatedTicksCheckBox">
-            <property name="text">
-             <string/>
+            <property name="checkable">
+             <bool>true</bool>
             </property>
-           </widget>
-          </item>
-          <item row="17" column="0">
-           <widget class="QLabel" name="label_annot_corner">
-            <property name="text">
-             <string>Margin to map corner</string>
-            </property>
-           </widget>
-          </item>
-          <item row="17" column="1" colspan="4">
-           <widget class="QDoubleSpinBox" name="mRotatedTicksMarginToCornerSpinBox">
-            <property name="toolTip">
-             <string>Outwards facing ticks closer to the corners than this margin will be ignored. This only makes sense for rotated grids.</string>
-            </property>
-            <property name="decimals">
-             <number>0</number>
-            </property>
-            <property name="value">
-             <double>0.000000000000000</double>
-            </property>
+            <layout class="QFormLayout" name="formLayout">
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_6">
+               <property name="text">
+                <string>Ticks alignment</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QComboBox" name="mRotatedTicksLengthModeComboBox">
+               <property name="toolTip">
+                <string>Determines how the ticks are aligned when rotated.</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_7">
+               <property name="text">
+                <string>Skip below angle</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QDoubleSpinBox" name="mRotatedTicksThresholdSpinBox">
+               <property name="toolTip">
+                <string>Grid lines intersecting the border below this threshold will be ignored. This only makes sense for rotated grids.</string>
+               </property>
+               <property name="suffix">
+                <string> °</string>
+               </property>
+               <property name="decimals">
+                <number>2</number>
+               </property>
+               <property name="maximum">
+                <double>90.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>0.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="label_annot_corner">
+               <property name="text">
+                <string>Margin from map corner</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QDoubleSpinBox" name="mRotatedTicksMarginToCornerSpinBox">
+               <property name="toolTip">
+                <string>Outwards facing ticks closer to the corners than this margin will be ignored. This only makes sense for rotated grids.</string>
+               </property>
+               <property name="suffix">
+                <string> mm</string>
+               </property>
+               <property name="decimals">
+                <number>2</number>
+               </property>
+               <property name="value">
+                <double>0.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>
@@ -761,35 +762,15 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0">
-          <item row="17" column="0">
-           <widget class="QLabel" name="label_11">
+          <item row="16" column="0">
+           <widget class="QLabel" name="mCoordinatePrecisionLabel">
             <property name="text">
-             <string>Rotate annotations</string>
+             <string>Coordinate precision</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
             </property>
            </widget>
-          </item>
-          <item row="19" column="1" colspan="2">
-           <widget class="QDoubleSpinBox" name="mRotatedAnnotationsThresholdSpinBox">
-            <property name="suffix">
-             <string> °</string>
-            </property>
-            <property name="decimals">
-             <number>2</number>
-            </property>
-            <property name="maximum">
-             <double>90.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="18" column="0">
-           <widget class="QLabel" name="label_10">
-            <property name="text">
-             <string>Rotated annotations alignment</string>
-            </property>
-           </widget>
-          </item>
-          <item row="11" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationPositionBottomComboBox"/>
           </item>
           <item row="14" column="2">
            <widget class="QgsPropertyOverrideButton" name="mLabelDistDDBtn">
@@ -798,18 +779,26 @@
             </property>
            </widget>
           </item>
-          <item row="14" column="0">
-           <widget class="QLabel" name="mDistanceToMapFrameLabel">
-            <property name="text">
-             <string>Distance to map frame</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
+          <item row="0" column="1" colspan="2">
+           <layout class="QHBoxLayout" name="horizontalLayout_13">
+            <item>
+             <widget class="QComboBox" name="mAnnotationFormatComboBox"/>
+            </item>
+            <item>
+             <widget class="QToolButton" name="mAnnotationFormatButton">
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../../images/images.qrc">
+                <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
-          <item row="10" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDisplayBottomComboBox"/>
+          <item row="11" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationPositionBottomComboBox"/>
           </item>
           <item row="3" column="1" colspan="2">
            <widget class="QComboBox" name="mAnnotationDirectionComboBoxLeft"/>
@@ -834,38 +823,62 @@
           <item row="1" column="1" colspan="2">
            <widget class="QComboBox" name="mAnnotationDisplayLeftComboBox"/>
           </item>
-          <item row="0" column="1" colspan="2">
-           <layout class="QHBoxLayout" name="horizontalLayout_13">
-            <item>
-             <widget class="QComboBox" name="mAnnotationFormatComboBox"/>
-            </item>
-            <item>
-             <widget class="QToolButton" name="mAnnotationFormatButton">
-              <property name="text">
-               <string>…</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../../images/images.qrc">
-                <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="18" column="1" colspan="2">
-           <widget class="QComboBox" name="mRotatedAnnotationsLengthModeComboBox"/>
-          </item>
-          <item row="19" column="0">
-           <widget class="QLabel" name="label_9">
+          <item row="14" column="0">
+           <widget class="QLabel" name="mDistanceToMapFrameLabel">
             <property name="text">
-             <string>Skip low angled annotations</string>
+             <string>Distance to map frame</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item row="16" column="0">
-           <widget class="QLabel" name="mCoordinatePrecisionLabel">
+          <item row="10" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDisplayBottomComboBox"/>
+          </item>
+          <item row="4" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDisplayRightComboBox"/>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="mAnnotationPositionLabelRight">
             <property name="text">
-             <string>Coordinate precision</string>
+             <string>Right</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationPositionRightComboBox"/>
+          </item>
+          <item row="14" column="1">
+           <widget class="QgsDoubleSpinBox" name="mDistanceToMapFrameSpinBox">
+            <property name="suffix">
+             <string> mm</string>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDirectionComboBoxBottom"/>
+          </item>
+          <item row="13" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Font</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDirectionComboBoxTop"/>
+          </item>
+          <item row="2" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationPositionLeftComboBox"/>
+          </item>
+          <item row="7" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDisplayTopComboBox"/>
+          </item>
+          <item row="10" column="0">
+           <widget class="QLabel" name="mAnnotationPositionLabelBottom">
+            <property name="text">
+             <string>Bottom</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -882,65 +895,10 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDisplayRightComboBox"/>
-          </item>
-          <item row="8" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationPositionTopComboBox"/>
-          </item>
-          <item row="2" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationPositionLeftComboBox"/>
-          </item>
-          <item row="10" column="0">
-           <widget class="QLabel" name="mAnnotationPositionLabelBottom">
-            <property name="text">
-             <string>Bottom</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="17" column="1" colspan="2">
-           <widget class="QCheckBox" name="mRotatedAnnotationsCheckBox">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDirectionComboBoxRight"/>
-          </item>
-          <item row="12" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDirectionComboBoxBottom"/>
-          </item>
-          <item row="14" column="1">
-           <widget class="QgsDoubleSpinBox" name="mDistanceToMapFrameSpinBox">
-            <property name="suffix">
-             <string> mm</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDisplayTopComboBox"/>
-          </item>
           <item row="16" column="1" colspan="2">
            <widget class="QgsSpinBox" name="mCoordinatePrecisionSpinBox">
             <property name="showClearButton" stdset="0">
              <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationPositionRightComboBox"/>
-          </item>
-          <item row="9" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDirectionComboBoxTop"/>
-          </item>
-          <item row="13" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Font</string>
             </property>
            </widget>
           </item>
@@ -957,31 +915,75 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="mAnnotationPositionLabelRight">
-            <property name="text">
-             <string>Right</string>
-            </property>
-           </widget>
+          <item row="8" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationPositionTopComboBox"/>
           </item>
-          <item row="20" column="0">
-           <widget class="QLabel" name="label_12">
-            <property name="text">
-             <string>Margin to map corner</string>
-            </property>
-           </widget>
+          <item row="6" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDirectionComboBoxRight"/>
           </item>
-          <item row="20" column="1" colspan="2">
-           <widget class="QDoubleSpinBox" name="mRotatedAnnotationsMarginToCornerSpinBox">
-            <property name="toolTip">
-             <string>Outwards facing annotations closer to the corners than this margin will be ignored. This only makes sense for rotated grids.</string>
+          <item row="17" column="0" colspan="3">
+           <widget class="QGroupBox" name="mRotatedAnnotationsGroupBox">
+            <property name="title">
+             <string>Rotate annotations</string>
             </property>
-            <property name="decimals">
-             <number>0</number>
+            <property name="checkable">
+             <bool>true</bool>
             </property>
-            <property name="value">
-             <double>0.000000000000000</double>
-            </property>
+            <layout class="QFormLayout" name="formLayout_2">
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_10">
+               <property name="text">
+                <string>Annotations alignment</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QComboBox" name="mRotatedAnnotationsLengthModeComboBox"/>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_9">
+               <property name="text">
+                <string>Skip below angle</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QDoubleSpinBox" name="mRotatedAnnotationsThresholdSpinBox">
+               <property name="suffix">
+                <string> °</string>
+               </property>
+               <property name="decimals">
+                <number>2</number>
+               </property>
+               <property name="maximum">
+                <double>90.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="label_12">
+               <property name="text">
+                <string>Margin from map corner</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QDoubleSpinBox" name="mRotatedAnnotationsMarginToCornerSpinBox">
+               <property name="toolTip">
+                <string>Outwards facing annotations closer to the corners than this margin will be ignored. This only makes sense for rotated grids.</string>
+               </property>
+               <property name="suffix">
+                <string> mm</string>
+               </property>
+               <property name="decimals">
+                <number>2</number>
+               </property>
+               <property name="value">
+                <double>0.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>
@@ -1091,7 +1093,7 @@
   <tabstop>mCheckGridRightSide</tabstop>
   <tabstop>mCheckGridTopSide</tabstop>
   <tabstop>mCheckGridBottomSide</tabstop>
-  <tabstop>mRotatedTicksCheckBox</tabstop>
+  <tabstop>mRotatedTicksGroupBox</tabstop>
   <tabstop>mRotatedTicksLengthModeComboBox</tabstop>
   <tabstop>mRotatedTicksThresholdSpinBox</tabstop>
   <tabstop>mRotatedTicksMarginToCornerSpinBox</tabstop>
@@ -1114,7 +1116,7 @@
   <tabstop>mDistanceToMapFrameSpinBox</tabstop>
   <tabstop>mLabelDistDDBtn</tabstop>
   <tabstop>mCoordinatePrecisionSpinBox</tabstop>
-  <tabstop>mRotatedAnnotationsCheckBox</tabstop>
+  <tabstop>mRotatedAnnotationsGroupBox</tabstop>
   <tabstop>mRotatedAnnotationsLengthModeComboBox</tabstop>
   <tabstop>mRotatedAnnotationsThresholdSpinBox</tabstop>
   <tabstop>mRotatedAnnotationsMarginToCornerSpinBox</tabstop>

--- a/src/ui/layout/qgslayoutmapgridwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapgridwidgetbase.ui
@@ -49,7 +49,7 @@
         <x>0</x>
         <y>0</y>
         <width>492</width>
-        <height>1211</height>
+        <height>1209</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -232,7 +232,7 @@
                  <double>9999999.000000000000000</double>
                 </property>
                 <property name="showClearButton" stdset="0">
-                  <bool>true</bool>
+                 <bool>true</bool>
                 </property>
                </widget>
               </item>
@@ -694,9 +694,6 @@
                <property name="toolTip">
                 <string>Grid lines intersecting the border below this threshold will be ignored.</string>
                </property>
-               <property name="showClearButton" stdset="0">
-                <bool>true</bool>
-               </property>
                <property name="suffix">
                 <string> °</string>
                </property>
@@ -708,6 +705,9 @@
                </property>
                <property name="value">
                 <double>0.000000000000000</double>
+               </property>
+               <property name="showClearButton" stdset="0">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -723,9 +723,6 @@
                <property name="toolTip">
                 <string>Outwards facing ticks closer to the corners than this margin will be ignored.</string>
                </property>
-               <property name="showClearButton" stdset="0">
-                <bool>true</bool>
-               </property>
                <property name="suffix">
                 <string> mm</string>
                </property>
@@ -734,6 +731,9 @@
                </property>
                <property name="value">
                 <double>0.000000000000000</double>
+               </property>
+               <property name="showClearButton" stdset="0">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -771,6 +771,12 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0">
+          <item row="15" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationPositionBottomComboBox"/>
+          </item>
+          <item row="10" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDirectionComboBoxRight"/>
+          </item>
           <item row="8" column="0">
            <widget class="QLabel" name="mAnnotationPositionLabelRight">
             <property name="text">
@@ -778,27 +784,11 @@
             </property>
            </widget>
           </item>
-          <item row="7" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDirectionComboBoxLeft"/>
-          </item>
-          <item row="6" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationPositionLeftComboBox"/>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="mAnnotationFormatLabel">
-            <property name="text">
-             <string>Format</string>
-            </property>
-           </widget>
-          </item>
           <item row="8" column="1" colspan="2">
            <widget class="QComboBox" name="mAnnotationDisplayRightComboBox"/>
           </item>
-          <item row="9" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationPositionRightComboBox"/>
-          </item>
-          <item row="10" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDirectionComboBoxRight"/>
+          <item row="6" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationPositionLeftComboBox"/>
           </item>
           <item row="0" column="1" colspan="2">
            <layout class="QHBoxLayout" name="horizontalLayout_13">
@@ -817,19 +807,6 @@
              </widget>
             </item>
            </layout>
-          </item>
-          <item row="14" column="0">
-           <widget class="QLabel" name="mAnnotationPositionLabelBottom">
-            <property name="text">
-             <string>Bottom</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="15" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationPositionBottomComboBox"/>
           </item>
           <item row="11" column="1" colspan="2">
            <widget class="QComboBox" name="mAnnotationDisplayTopComboBox"/>
@@ -857,24 +834,28 @@
           <item row="13" column="1" colspan="2">
            <widget class="QComboBox" name="mAnnotationDirectionComboBoxTop"/>
           </item>
-          <item row="16" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDirectionComboBoxBottom"/>
-          </item>
-          <item row="14" column="1" colspan="2">
-           <widget class="QComboBox" name="mAnnotationDisplayBottomComboBox"/>
-          </item>
-          <item row="17" column="1" colspan="2">
-           <widget class="QgsFontButton" name="mAnnotationFontButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
+          <item row="14" column="0">
+           <widget class="QLabel" name="mAnnotationPositionLabelBottom">
             <property name="text">
-             <string>Font</string>
+             <string>Bottom</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
             </property>
            </widget>
+          </item>
+          <item row="7" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDirectionComboBoxLeft"/>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="mAnnotationFormatLabel">
+            <property name="text">
+             <string>Format</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationPositionRightComboBox"/>
           </item>
           <item row="20" column="1" colspan="2">
            <widget class="QgsSpinBox" name="mCoordinatePrecisionSpinBox">
@@ -893,6 +874,13 @@
             </property>
            </widget>
           </item>
+          <item row="18" column="1">
+           <widget class="QgsDoubleSpinBox" name="mDistanceToMapFrameSpinBox">
+            <property name="suffix">
+             <string> mm</string>
+            </property>
+           </widget>
+          </item>
           <item row="18" column="2">
            <widget class="QgsPropertyOverrideButton" name="mLabelDistDDBtn">
             <property name="text">
@@ -900,12 +888,11 @@
             </property>
            </widget>
           </item>
-          <item row="18" column="1">
-           <widget class="QgsDoubleSpinBox" name="mDistanceToMapFrameSpinBox">
-            <property name="suffix">
-             <string> mm</string>
-            </property>
-           </widget>
+          <item row="16" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDirectionComboBoxBottom"/>
+          </item>
+          <item row="14" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDisplayBottomComboBox"/>
           </item>
           <item row="20" column="0">
            <widget class="QLabel" name="mCoordinatePrecisionLabel">
@@ -914,6 +901,19 @@
             </property>
             <property name="wordWrap">
              <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="17" column="1" colspan="2">
+           <widget class="QgsFontButton" name="mAnnotationFontButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Font</string>
             </property>
            </widget>
           </item>
@@ -935,9 +935,9 @@
              </item>
              <item row="0" column="1">
               <widget class="QComboBox" name="mRotatedAnnotationsLengthModeComboBox">
-                <property name="toolTip">
-                  <string>Determines how the ticks length is defined when rotated.</string>
-                </property>
+               <property name="toolTip">
+                <string>Determines how the ticks length is defined when rotated.</string>
+               </property>
               </widget>
              </item>
              <item row="1" column="0">
@@ -952,9 +952,6 @@
                <property name="toolTip">
                 <string>Grid lines intersecting the border below this threshold will be ignored.</string>
                </property>
-               <property name="showClearButton" stdset="0">
-                <bool>true</bool>
-               </property>
                <property name="suffix">
                 <string> °</string>
                </property>
@@ -963,6 +960,9 @@
                </property>
                <property name="maximum">
                 <double>90.000000000000000</double>
+               </property>
+               <property name="showClearButton" stdset="0">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -978,9 +978,6 @@
                <property name="toolTip">
                 <string>Outwards facing annotations closer to the corners than this margin will be ignored.</string>
                </property>
-               <property name="showClearButton" stdset="0">
-                <bool>true</bool>
-               </property>
                <property name="suffix">
                 <string> mm</string>
                </property>
@@ -990,26 +987,18 @@
                <property name="value">
                 <double>0.000000000000000</double>
                </property>
+               <property name="showClearButton" stdset="0">
+                <bool>true</bool>
+               </property>
               </widget>
              </item>
             </layout>
            </widget>
           </item>
-          <item row="1" column="1" colspan="2">
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
-            <item>
-             <widget class="QComboBox" name="mAnnotationDisplayLeftComboBox"/>
-            </item>
-            <item>
-             <widget class="QgsPropertyOverrideButton" name="mAnnotationDisplayLeftDDBtn">
-              <property name="text">
-               <string>…</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
+          <item row="2" column="1" colspan="2">
+           <widget class="QComboBox" name="mAnnotationDisplayLeftComboBox"/>
           </item>
-          <item row="1" column="0">
+          <item row="2" column="0">
            <widget class="QLabel" name="mAnnotationPositionLabelLeft">
             <property name="text">
              <string>Left</string>

--- a/src/ui/layout/qgslayoutmapgridwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapgridwidgetbase.ui
@@ -662,7 +662,7 @@
           <item row="14" column="0" colspan="5">
            <widget class="QGroupBox" name="mRotatedTicksGroupBox">
             <property name="title">
-             <string>Rotate ticks</string>
+             <string>Follow grid rotation</string>
             </property>
             <property name="checkable">
              <bool>true</bool>
@@ -920,7 +920,7 @@
           <item row="21" column="0" colspan="3">
            <widget class="QGroupBox" name="mRotatedAnnotationsGroupBox">
             <property name="title">
-             <string>Rotate annotations</string>
+             <string>Follow grid rotation</string>
             </property>
             <property name="checkable">
              <bool>true</bool>


### PR DESCRIPTION
## Description

Followup of PR #38524 improving a little bit the UI :
- grouped rotated ticks/annotations into a groupbox
- added units for margin to border
- rephrased some labels

This replaces PR #38854 

![image](https://user-images.githubusercontent.com/1894106/94268708-dd5a6c00-ff3d-11ea-91f3-a719e00aabb0.png)
![image](https://user-images.githubusercontent.com/1894106/94268767-f2cf9600-ff3d-11ea-914e-104824d65e6b.png)



