### PR TITLE
Copy LayerTreeNode's custom properties when converting project to offline

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreenode.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreenode.sip.in
@@ -240,6 +240,8 @@ Read a custom property from layer. Properties are stored in a map and saved in p
 %Docstring
 Remove a custom property from layer. Properties are stored in a map and saved in project file.
 %End
+
+
     QStringList customProperties() const;
 %Docstring
 Returns list of keys stored in custom properties
@@ -247,6 +249,26 @@ Returns list of keys stored in custom properties
     bool takeChild( QgsLayerTreeNode *node );
 %Docstring
 Remove a child from a node
+%End
+
+
+    const QgsObjectCustomProperties &customPropertiesMap() const;
+%Docstring
+Read all custom properties from layer tree node
+
+.. seealso:: :py:func:`setCustomPropertiesMap`
+
+.. versionadded:: 3.16
+%End
+
+
+    void setCustomPropertiesMap( const QgsObjectCustomProperties &properties );
+%Docstring
+Set custom properties for layer tree node. Current properties are dropped.
+
+.. seealso:: :py:func:`customPropertiesMap`
+
+.. versionadded:: 3.16
 %End
 
   signals:

--- a/src/core/layertree/qgslayertreenode.cpp
+++ b/src/core/layertree/qgslayertreenode.cpp
@@ -205,6 +205,16 @@ QStringList QgsLayerTreeNode::customProperties() const
   return mProperties.keys();
 }
 
+const QgsObjectCustomProperties &QgsLayerTreeNode::customPropertiesMap() const
+{
+  return mProperties;
+}
+
+void QgsLayerTreeNode::setCustomPropertiesMap( const QgsObjectCustomProperties &properties )
+{
+  mProperties = properties;
+}
+
 void QgsLayerTreeNode::readCommonXml( QDomElement &element )
 {
   mProperties.readXml( element );

--- a/src/core/layertree/qgslayertreenode.h
+++ b/src/core/layertree/qgslayertreenode.h
@@ -227,10 +227,31 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
     QVariant customProperty( const QString &key, const QVariant &defaultValue = QVariant() ) const;
     //! Remove a custom property from layer. Properties are stored in a map and saved in project file.
     void removeCustomProperty( const QString &key );
+
+    // TODO: Harmonize this with QgsMapLayer::customPropertyKeys() for QGIS 4 API
+
     //! Returns list of keys stored in custom properties
     QStringList customProperties() const;
     //! Remove a child from a node
     bool takeChild( QgsLayerTreeNode *node );
+
+    // TODO: Harmonize this with QgsMapLayer::customProperties() for QGIS 4 API
+
+    /**
+     * Read all custom properties from layer tree node
+     * \see setCustomPropertiesMap
+     * \since QGIS 3.16
+     */
+    const QgsObjectCustomProperties &customPropertiesMap() const;
+
+    // TODO: Harmonize this with QgsMapLayer::setCustomProperties() for QGIS 4 API
+
+    /**
+     * Set custom properties for layer tree node. Current properties are dropped.
+     * \see customPropertiesMap
+     * \since QGIS 3.16
+     */
+    void setCustomPropertiesMap( const QgsObjectCustomProperties &properties );
 
   signals:
 

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -59,7 +59,6 @@ extern "C"
 #define CUSTOM_PROPERTY_IS_OFFLINE_EDITABLE "isOfflineEditable"
 #define CUSTOM_PROPERTY_REMOTE_SOURCE "remoteSource"
 #define CUSTOM_PROPERTY_REMOTE_PROVIDER "remoteProvider"
-#define CUSTOM_SHOW_FEATURE_COUNT "showFeatureCount"
 #define CUSTOM_PROPERTY_ORIGINAL_LAYERID "remoteLayerId"
 #define PROJECT_ENTRY_SCOPE_OFFLINE "OfflineEditingPlugin"
 #define PROJECT_ENTRY_KEY_OFFLINE_DB_PATH "/OfflineDbPath"
@@ -283,7 +282,7 @@ void QgsOfflineEditing::synchronize()
       //set QgsLayerTreeNode properties back
       QgsLayerTreeLayer *layerTreeLayer = QgsProject::instance()->layerTreeRoot()->findLayer( offlineLayer->id() );
       QgsLayerTreeLayer *newLayerTreeLayer = QgsProject::instance()->layerTreeRoot()->findLayer( remoteLayer->id() );
-      newLayerTreeLayer->setCustomProperty( CUSTOM_SHOW_FEATURE_COUNT, layerTreeLayer->customProperty( CUSTOM_SHOW_FEATURE_COUNT ) );
+      newLayerTreeLayer->setCustomPropertiesMap( layerTreeLayer->customPropertiesMap() );
 
       // apply layer edit log
       QString qgisLayerId = layer->id();
@@ -895,8 +894,8 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
         if ( newLayerTreeLayer )
         {
           QgsLayerTreeNode *newLayerTreeLayerClone = newLayerTreeLayer->clone();
-          //copy the showFeatureCount property to the new node
-          newLayerTreeLayerClone->setCustomProperty( CUSTOM_SHOW_FEATURE_COUNT, layerTreeLayer->customProperty( CUSTOM_SHOW_FEATURE_COUNT ) );
+          // Copy the custom properties from original layer
+          newLayerTreeLayerClone->setCustomPropertiesMap( layerTreeLayer->customPropertiesMap() );
           newLayerTreeLayerClone->setItemVisibilityChecked( layerTreeLayer->isVisible() );
           QgsLayerTreeGroup *grp = qobject_cast<QgsLayerTreeGroup *>( newLayerTreeLayer->parent() );
           parentTreeGroup->insertChildNode( index, newLayerTreeLayerClone );

--- a/tests/src/core/testqgsofflineediting.cpp
+++ b/tests/src/core/testqgsofflineediting.cpp
@@ -123,6 +123,8 @@ void TestQgsOfflineEditing::createSpatialiteAndSynchronizeBack()
   //set on LayerTreeNode showFeatureCount property
   QgsLayerTreeLayer *layerTreelayer = QgsProject::instance()->layerTreeRoot()->findLayer( mpLayer->id() );
   layerTreelayer->setCustomProperty( QStringLiteral( "showFeatureCount" ), 1 );
+  // LayerTreeNode custom property
+  layerTreelayer->setCustomProperty( QStringLiteral( "myCustomProperty" ), true );
 
   //convert
   mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, QgsOfflineEditing::SpatiaLite );
@@ -135,6 +137,8 @@ void TestQgsOfflineEditing::createSpatialiteAndSynchronizeBack()
   QCOMPARE( layerTreelayer->customProperty( QStringLiteral( "showFeatureCount" ), 0 ).toInt(), 1 );
   //unset on LayerTreeNode showFeatureCount property
   layerTreelayer->setCustomProperty( QStringLiteral( "showFeatureCount" ), 0 );
+  // Check layerTreeNode custom property
+  QVERIFY( layerTreelayer->customProperty( QStringLiteral( "myCustomProperty" ), false ).toBool() );
 
   //synchronize back
   mOfflineEditing->synchronize();
@@ -147,6 +151,8 @@ void TestQgsOfflineEditing::createSpatialiteAndSynchronizeBack()
   //check LayerTreeNode showFeatureCount property
   layerTreelayer = QgsProject::instance()->layerTreeRoot()->findLayer( mpLayer->id() );
   QCOMPARE( layerTreelayer->customProperty( QStringLiteral( "showFeatureCount" ), 0 ).toInt(), 0 );
+  // Check LayerTreeNode custom property
+  QVERIFY( layerTreelayer->customProperty( QStringLiteral( "myCustomProperty" ), false ).toBool() );
 }
 
 void TestQgsOfflineEditing::createGeopackageAndSynchronizeBack()
@@ -167,8 +173,9 @@ void TestQgsOfflineEditing::createGeopackageAndSynchronizeBack()
   layerTreelayer->setItemVisibilityChecked( false );
   QgsMapLayerStyle style;
   style.readFromLayer( mpLayer );
-
   mpLayer->styleManager()->addStyle( QStringLiteral( "testStyle" ), style );
+  // LayerTreeNode custom property
+  layerTreelayer->setCustomProperty( QStringLiteral( "myCustomProperty" ), true );
 
   //convert
   mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, QgsOfflineEditing::GPKG );
@@ -181,6 +188,8 @@ void TestQgsOfflineEditing::createGeopackageAndSynchronizeBack()
   //check LayerTreeNode showFeatureCount property
   layerTreelayer = QgsProject::instance()->layerTreeRoot()->findLayer( mpLayer->id() );
   QCOMPARE( layerTreelayer->customProperty( QStringLiteral( "showFeatureCount" ), 0 ).toInt(), 1 );
+  // Check layerTreeNode custom property
+  QVERIFY( layerTreelayer->customProperty( QStringLiteral( "myCustomProperty" ), false ).toBool() );
   QCOMPARE( layerTreelayer->isVisible(), false );
   QVERIFY( mpLayer->styleManager()->styles().contains( QStringLiteral( "testStyle" ) ) );
 
@@ -213,6 +222,8 @@ void TestQgsOfflineEditing::createGeopackageAndSynchronizeBack()
   //check LayerTreeNode showFeatureCount property
   layerTreelayer = QgsProject::instance()->layerTreeRoot()->findLayer( mpLayer->id() );
   QCOMPARE( layerTreelayer->customProperty( QStringLiteral( "showFeatureCount" ), 0 ).toInt(), 0 );
+  // Check layerTreeNode custom property
+  QVERIFY( layerTreelayer->customProperty( QStringLiteral( "myCustomProperty" ), false ).toBool() );
 
   //get last feature
   QgsFeature f = mpLayer->getFeature( mpLayer->dataProvider()->featureCount() - 1 );


### PR DESCRIPTION
When converting a project to offline, QGIS should copy all original layerTreeNode's custom properties to the new one. 

Note that this is already done for QgsMapLayers (see https://github.com/qgis/QGIS/pull/35114).
