### PR TITLE
Fix 'hide all layers' action's UX

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7928,8 +7928,12 @@ void QgisApp::stopRendering()
 void QgisApp::hideAllLayers()
 {
   QgsDebugMsgLevel( QStringLiteral( "hiding all layers!" ), 3 );
-  mLayerTreeView->layerTreeModel()->rootGroup()->setItemVisibilityCheckedRecursive( false );
 
+  const auto constChildren = mLayerTreeView->layerTreeModel()->rootGroup()->children();
+  for ( QgsLayerTreeNode *node : constChildren )
+  {
+    node->setItemVisibilityCheckedRecursive( false );
+  }
 }
 
 void QgisApp::showAllLayers()


### PR DESCRIPTION
## Description

The 'hide all layers' action is broken, and this PR fixes it. 

Prior to this PR, triggering the hide all layers action would hide an _invisible to users_ root group. As a result, any subsequent addition of new layers (or even toggling of existing layers in the layer tree) would fail to show/draw those layers on the canvas.

The only way to get out of this broken state of affairs is to trigger the 'show all layers' action.

This PR fixes this broken UX by looping through children of the layer tree's root group and recursively set item visibility to false. 