### PR TITLE
[layer tree] Avoid needless layer tree model computations for scale-based layer visibility

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreemodel.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreemodel.sip.in
@@ -374,7 +374,7 @@ Updates model when node's name has changed
 emit :py:func:`~QgsLayerTreeModel.dataChanged` for layer tree node items
 %End
 
-    void refreshScaleBasedLayers( const QModelIndex &index = QModelIndex() );
+    void refreshScaleBasedLayers( const QModelIndex &index = QModelIndex(), double previousScale = 0.0 );
 %Docstring
 Updates layer data for scale dependent layers, should be called when map scale changes.
 Emits :py:func:`~QgsLayerTreeModel.dataChanged` for all scale dependent layers.

--- a/src/core/layertree/qgslayertreemodel.h
+++ b/src/core/layertree/qgslayertreemodel.h
@@ -340,7 +340,7 @@ class CORE_EXPORT QgsLayerTreeModel : public QAbstractItemModel
      * Emits dataChanged() for all scale dependent layers.
      * \since QGIS 2.16
      */
-    void refreshScaleBasedLayers( const QModelIndex &index = QModelIndex() );
+    void refreshScaleBasedLayers( const QModelIndex &index = QModelIndex(), double previousScale = 0.0 );
 
     static QIcon iconGroup();
 


### PR DESCRIPTION
## Description

This PR optimizes the layer tree model by avoiding needless computations around scale-based layer visibility. Optimizations include:
- If the map canvas scale hasn't changed, avoid triggering scale-based layer visibility check loop
- In cases scale _has_ changed, make sure the model only emits dataChanged for layers that go from hidden to visible (or vice versa)
- Restrict dataChanged roles to _only_ the ones that are impacted by visibility change

With the PR applied, I can't see any freeze when panning on the canvas with the test project in #38978 . 