### PR TITLE
[Backport 3.10] Show new feature in attribute table when added

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -834,6 +834,7 @@ void QgsAttributeTableDialog::mActionAddFeature_triggered()
   if ( action.addFeature() )
   {
     masterModel->reload( masterModel->index( 0, 0 ), masterModel->index( masterModel->rowCount() - 1, masterModel->columnCount() - 1 ) );
+    mMainView->setCurrentEditSelection( QgsFeatureIds() << action.feature().id() );
   }
 }
 

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -313,4 +313,9 @@ void QgsFeatureAction::onFeatureSaved( const QgsFeature &feature )
   }
 }
 
+QgsFeature QgsFeatureAction::feature() const
+{
+  return mFeature ? *mFeature : QgsFeature();
+}
+
 QHash<QgsVectorLayer *, QgsAttributeMap> QgsFeatureAction::sLastUsedValues;

--- a/src/app/qgsfeatureaction.h
+++ b/src/app/qgsfeatureaction.h
@@ -61,6 +61,11 @@ class APP_EXPORT QgsFeatureAction : public QAction
      */
     void setForceSuppressFormPopup( bool force );
 
+    /**
+     * Returns the added feature or invalid feature in case addFeature() was not successful.
+     */
+    QgsFeature feature() const;
+
   signals:
 
     /**

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -189,18 +189,27 @@ void QgsFeatureListView::selectAll()
 void QgsFeatureListView::setEditSelection( const QgsFeatureIds &fids )
 {
   QItemSelection selection;
+  QModelIndex firstModelIdx;
 
   const auto constFids = fids;
   for ( QgsFeatureId fid : constFids )
   {
-    selection.append( QItemSelectionRange( mModel->mapToMaster( mModel->fidToIdx( fid ) ) ) );
+    QModelIndex modelIdx = mModel->fidToIdx( fid );
+
+    if ( ! firstModelIdx.isValid() )
+      firstModelIdx = modelIdx;
+
+    selection.append( QItemSelectionRange( mModel->mapToMaster( modelIdx ) ) );
   }
 
   bool ok = true;
   emit aboutToChangeEditSelection( ok );
 
   if ( ok )
+  {
     mCurrentEditSelectionModel->select( selection, QItemSelectionModel::ClearAndSelect );
+    scrollTo( firstModelIdx );
+  }
 }
 
 void QgsFeatureListView::setEditSelection( const QModelIndex &index, QItemSelectionModel::SelectionFlags command )
@@ -211,7 +220,10 @@ void QgsFeatureListView::setEditSelection( const QModelIndex &index, QItemSelect
   Q_ASSERT( index.model() == mModel->masterModel() || !index.isValid() );
 
   if ( ok )
+  {
     mCurrentEditSelectionModel->select( index, command );
+    scrollTo( index );
+  }
 }
 
 void QgsFeatureListView::repaintRequested( const QModelIndexList &indexes )


### PR DESCRIPTION
Now when a new feature is added in the attribute table when in form view, the new feature is automatically selected and the feature list on the left side is ensured to show it (not necessarily on top). In response of #37847 .

Backport https://github.com/qgis/QGIS/pull/38658