### PR TITLE
1st fix for broken GetFeatureInfo URLs in REST WMTS layers

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3026,7 +3026,8 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
       {
         // rewrite the URL if the one in the capabilities document is incorrect
         // strip every thing after the ? from the base url
-        const QString base = mSettings.mBaseUrl.split( QRegularExpression( "\\?" ) )[0];
+        const QList parts = mSettings.mBaseUrl.split( QRegularExpression( "\\?" ) );
+        const QString base = parts.isEmpty() ? mSettings.mBaseUrl : parts.first();
         // and strip everything before the `rest` element (at least for GeoServer)
         const int index = url.length() - url.lastIndexOf( QStringLiteral( "rest" ) ) + 1; // +1 for the /
         url = base + url.right( index );
@@ -3054,7 +3055,6 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
     else if ( !getFeatureInfoUrl().isNull() )
     {
       // KVP
-      QgsDebugMsg( QStringLiteral( "KVP ignore GetFeatureURL %1" ).arg( mSettings.mIgnoreGetFeatureInfoUrl ) );
       QUrl url( mSettings.mIgnoreGetFeatureInfoUrl ? mSettings.mBaseUrl : getFeatureInfoUrl() );
       QUrlQuery query( url );
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3018,30 +3018,21 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
     if ( mTileLayer->getFeatureInfoURLs.contains( formatStr ) )
     {
       // REST
-      
+
 
       QString url = mTileLayer->getFeatureInfoURLs[ formatStr ];
 
-      if (mSettings.mIgnoreGetFeatureInfoUrl)
+      if ( mSettings.mIgnoreGetFeatureInfoUrl )
       {
         // rewrite the URL if the one in the capabilities document is incorrect
-        QString base = mSettings.mBaseUrl;
-        QgsDebugMsgLevel( QStringLiteral( "1 base=%1" ).arg( base ), 2 );
         // strip every thing after the ? from the base url
-        base = base.split(QRegExp("\\?"))[0];
-        QgsDebugMsgLevel( QStringLiteral( "2 base=%1" ).arg( base ), 2 );
+        const QString base = mSettings.mBaseUrl.split( QRegularExpression( "\\?" ) )[0];
         // and strip everything before the `rest` element (at least for GeoServer)
-        QgsDebugMsgLevel( QStringLiteral( "url=%1" ).arg( url ), 2 );
-        int index = url.length() - url.lastIndexOf("rest") + 1; // +1 for the /
-        QgsDebugMsgLevel( QStringLiteral( "url=%1" ).arg( url.right(index) ), 2 );
-
-
-        url = base + url.right(index);
-        QgsDebugMsgLevel( QStringLiteral( "new url=%1" ).arg( url ), 2 );
-
+        const int index = url.length() - url.lastIndexOf( QStringLiteral( "rest" ) ) + 1; // +1 for the /
+        url = base + url.right( index );
       }
 
-      QgsDebugMsgLevel( QStringLiteral( "getfeatureinfo: %1" ).arg( url), 2 );
+      QgsDebugMsgLevel( QStringLiteral( "getfeatureinfo: %1" ).arg( url ), 2 );
 
       url.replace( QLatin1String( "{layer}" ), mSettings.mActiveSubLayers[0], Qt::CaseInsensitive );
       url.replace( QLatin1String( "{style}" ), mSettings.mActiveSubStyles[0], Qt::CaseInsensitive );

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3018,7 +3018,30 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
     if ( mTileLayer->getFeatureInfoURLs.contains( formatStr ) )
     {
       // REST
+      
+
       QString url = mTileLayer->getFeatureInfoURLs[ formatStr ];
+
+      if (mSettings.mIgnoreGetFeatureInfoUrl)
+      {
+        // rewrite the URL if the one in the capabilities document is incorrect
+        QString base = mSettings.mBaseUrl;
+        QgsDebugMsgLevel( QStringLiteral( "1 base=%1" ).arg( base ), 2 );
+        // strip every thing after the ? from the base url
+        base = base.split(QRegExp("\\?"))[0];
+        QgsDebugMsgLevel( QStringLiteral( "2 base=%1" ).arg( base ), 2 );
+        // and strip everything before the `rest` element (at least for GeoServer)
+        QgsDebugMsgLevel( QStringLiteral( "url=%1" ).arg( url ), 2 );
+        int index = url.length() - url.lastIndexOf("rest") + 1; // +1 for the /
+        QgsDebugMsgLevel( QStringLiteral( "url=%1" ).arg( url.right(index) ), 2 );
+
+
+        url = base + url.right(index);
+        QgsDebugMsgLevel( QStringLiteral( "new url=%1" ).arg( url ), 2 );
+
+      }
+
+      QgsDebugMsgLevel( QStringLiteral( "getfeatureinfo: %1" ).arg( url), 2 );
 
       url.replace( QLatin1String( "{layer}" ), mSettings.mActiveSubLayers[0], Qt::CaseInsensitive );
       url.replace( QLatin1String( "{style}" ), mSettings.mActiveSubStyles[0], Qt::CaseInsensitive );
@@ -3040,6 +3063,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
     else if ( !getFeatureInfoUrl().isNull() )
     {
       // KVP
+      QgsDebugMsg( QStringLiteral( "KVP ignore GetFeatureURL %1" ).arg( mSettings.mIgnoreGetFeatureInfoUrl ) );
       QUrl url( mSettings.mIgnoreGetFeatureInfoUrl ? mSettings.mBaseUrl : getFeatureInfoUrl() );
       QUrlQuery query( url );
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3026,7 +3026,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
       {
         // rewrite the URL if the one in the capabilities document is incorrect
         // strip every thing after the ? from the base url
-        const QList parts = mSettings.mBaseUrl.split( QRegularExpression( "\\?" ) );
+        const QStringList parts = mSettings.mBaseUrl.split( QRegularExpression( "\\?" ) );
         const QString base = parts.isEmpty() ? mSettings.mBaseUrl : parts.first();
         // and strip everything before the `rest` element (at least for GeoServer)
         const int index = url.length() - url.lastIndexOf( QStringLiteral( "rest" ) ) + 1; // +1 for the /


### PR DESCRIPTION
## Description

This makes a first attempt to fix broken links for GetFeatureInfo requests when the ignore getFeatureInfo URL checkbox is set when using a REST WMTS layer. 

Currently, this will only work for the "Well Known" layer URLs of a GeoServer install, but other people may know of a better way of fixing this for other systems and we could try some sort of heuristic. 

If there is an easy way to unit test this then please let me know and I'll see about adding tests, but I have tested against a locally broken GeoServer install as described in #39002. 

Fixes #39002 

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
