### PR TITLE
Raster classification: show number of digits according to data type

### DIFF
--- a/src/core/raster/qgscolorrampshader.cpp
+++ b/src/core/raster/qgscolorrampshader.cpp
@@ -404,13 +404,45 @@ bool QgsColorRampShader::shade( double value, int *returnRedValue, int *returnGr
 
   const QgsColorRampShader::ColorRampItem &currentColorRampItem = colorRampItems[idx];
 
-  if ( colorRampType() == Interpolated )
+  switch ( colorRampType() )
   {
-    // Interpolate the color between two class breaks linearly.
-    if ( idx < 1 || overflow || currentColorRampItem.value - DOUBLE_DIFF_THRESHOLD <= value )
+    case Interpolated:
     {
-      if ( mClip && ( overflow
-                      || currentColorRampItem.value - DOUBLE_DIFF_THRESHOLD > value ) )
+      // Interpolate the color between two class breaks linearly.
+      if ( idx < 1 || overflow || currentColorRampItem.value - DOUBLE_DIFF_THRESHOLD <= value )
+      {
+        if ( mClip && ( overflow
+                        || currentColorRampItem.value - DOUBLE_DIFF_THRESHOLD > value ) )
+        {
+          return false;
+        }
+        *returnRedValue   = currentColorRampItem.color.red();
+        *returnGreenValue = currentColorRampItem.color.green();
+        *returnBlueValue  = currentColorRampItem.color.blue();
+        *returnAlphaValue = currentColorRampItem.color.alpha();
+        return true;
+      }
+
+      const QgsColorRampShader::ColorRampItem &previousColorRampItem = colorRampItems[idx - 1];
+
+      float currentRampRange = currentColorRampItem.value - previousColorRampItem.value;
+      float offsetInRange = value - previousColorRampItem.value;
+      float scale = offsetInRange / currentRampRange;
+      const QRgb c1 = previousColorRampItem.color.rgba();
+      const QRgb c2 = currentColorRampItem.color.rgba();
+
+      *returnRedValue   = qRed( c1 )   + static_cast< int >( ( qRed( c2 )   - qRed( c1 ) )   * scale );
+      *returnGreenValue = qGreen( c1 ) + static_cast< int >( ( qGreen( c2 ) - qGreen( c1 ) ) * scale );
+      *returnBlueValue  = qBlue( c1 )  + static_cast< int >( ( qBlue( c2 )  - qBlue( c1 ) )  * scale );
+      *returnAlphaValue = qAlpha( c1 ) + static_cast< int >( ( qAlpha( c2 ) - qAlpha( c1 ) ) * scale );
+      return true;
+    };
+    case Discrete:
+    {
+      // Assign the color of the higher class for every pixel between two class breaks.
+      // NOTE: The implementation has always been different than the documentation,
+      //       which said lower class before, see https://github.com/qgis/QGIS/issues/22009
+      if ( overflow )
       {
         return false;
       }
@@ -419,51 +451,22 @@ bool QgsColorRampShader::shade( double value, int *returnRedValue, int *returnGr
       *returnBlueValue  = currentColorRampItem.color.blue();
       *returnAlphaValue = currentColorRampItem.color.alpha();
       return true;
-    }
-
-    const QgsColorRampShader::ColorRampItem &previousColorRampItem = colorRampItems[idx - 1];
-
-    float currentRampRange = currentColorRampItem.value - previousColorRampItem.value;
-    float offsetInRange = value - previousColorRampItem.value;
-    float scale = offsetInRange / currentRampRange;
-    const QRgb c1 = previousColorRampItem.color.rgba();
-    const QRgb c2 = currentColorRampItem.color.rgba();
-
-    *returnRedValue   = qRed( c1 )   + static_cast< int >( ( qRed( c2 )   - qRed( c1 ) )   * scale );
-    *returnGreenValue = qGreen( c1 ) + static_cast< int >( ( qGreen( c2 ) - qGreen( c1 ) ) * scale );
-    *returnBlueValue  = qBlue( c1 )  + static_cast< int >( ( qBlue( c2 )  - qBlue( c1 ) )  * scale );
-    *returnAlphaValue = qAlpha( c1 ) + static_cast< int >( ( qAlpha( c2 ) - qAlpha( c1 ) ) * scale );
-    return true;
-  }
-  else if ( colorRampType() == Discrete )
-  {
-    // Assign the color of the higher class for every pixel between two class breaks.
-    // NOTE: The implementation has always been different than the documentation,
-    //       which said lower class before, see https://github.com/qgis/QGIS/issues/22009
-    if ( overflow )
+    };
+    case Exact:
     {
-      return false;
-    }
-    *returnRedValue   = currentColorRampItem.color.red();
-    *returnGreenValue = currentColorRampItem.color.green();
-    *returnBlueValue  = currentColorRampItem.color.blue();
-    *returnAlphaValue = currentColorRampItem.color.alpha();
-    return true;
-  }
-  else // EXACT
-  {
-    // Assign the color of the exact matching value in the color ramp item list
-    if ( !overflow && currentColorRampItem.value - DOUBLE_DIFF_THRESHOLD <= value )
-    {
-      *returnRedValue   = currentColorRampItem.color.red();
-      *returnGreenValue = currentColorRampItem.color.green();
-      *returnBlueValue  = currentColorRampItem.color.blue();
-      *returnAlphaValue = currentColorRampItem.color.alpha();
-      return true;
-    }
-    else
-    {
-      return false;
+      // Assign the color of the exact matching value in the color ramp item list
+      if ( !overflow && currentColorRampItem.value - DOUBLE_DIFF_THRESHOLD <= value )
+      {
+        *returnRedValue   = currentColorRampItem.color.red();
+        *returnGreenValue = currentColorRampItem.color.green();
+        *returnBlueValue  = currentColorRampItem.color.blue();
+        *returnAlphaValue = currentColorRampItem.color.alpha();
+        return true;
+      }
+      else
+      {
+        return false;
+      }
     }
   }
 }

--- a/src/core/raster/qgspalettedrasterrenderer.cpp
+++ b/src/core/raster/qgspalettedrasterrenderer.cpp
@@ -70,10 +70,10 @@ QgsRasterRenderer *QgsPalettedRasterRenderer::create( const QDomElement &elem, Q
       QString label;
       entryElem = paletteEntries.at( i ).toElement();
       value = static_cast<int>( entryElem.attribute( QStringLiteral( "value" ), QStringLiteral( "0" ) ).toDouble() );
-      QgsDebugMsgLevel( entryElem.attribute( "color", "#000000" ), 4 );
       color = QColor( entryElem.attribute( QStringLiteral( "color" ), QStringLiteral( "#000000" ) ) );
       color.setAlpha( entryElem.attribute( QStringLiteral( "alpha" ), QStringLiteral( "255" ) ).toInt() );
       label = entryElem.attribute( QStringLiteral( "label" ) );
+      QgsDebugMsgLevel( QStringLiteral( "Value: %1, label: %2, color: %3" ).arg( value ).arg( label, entryElem.attribute( QStringLiteral( "color" ) ) ), 4 );
       classData << Class( value, color, label );
     }
   }

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
@@ -80,6 +80,10 @@ class GUI_EXPORT QgsSingleBandPseudoColorRendererWidget: public QgsRasterRendere
     int mMinMaxOrigin;
 
     void minMaxModified();
+
+    // Convert min/max to localized display value with correct precision
+    QString displayValue( const double value );
+
 };
 
 #endif // QGSSINGLEBANDCOLORRENDERERWIDGET_H


### PR DESCRIPTION
Not really a bug fix but related to #39058:

- depending on data type, show a different number of digits when
  classifying the raster
- code cleaning

Note that there will be a separate followup PR to allow the user to define the number of decimal places in the legend label.
