### PR TITLE
Move widgets from Q(Double)SpinBox to Qgs(Double)SpinBox 

### DIFF
--- a/src/plugins/geometry_checker/CMakeLists.txt
+++ b/src/plugins/geometry_checker/CMakeLists.txt
@@ -45,6 +45,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core/effects
   ${CMAKE_SOURCE_DIR}/src/core/providers/ogr
   ${CMAKE_SOURCE_DIR}/src/gui
+  ${CMAKE_SOURCE_DIR}/src/gui/editorwidgets
   ${CMAKE_SOURCE_DIR}/src/analysis/vector/geometry_checker
   ${CMAKE_SOURCE_DIR}/src/plugins
   ${CMAKE_SOURCE_DIR}/external

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.ui
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.ui
@@ -353,7 +353,7 @@
               <number>2</number>
              </property>
              <item row="1" column="2">
-              <widget class="QDoubleSpinBox" name="doubleSpinBoxAngle">
+              <widget class="QgsDoubleSpinBox" name="doubleSpinBoxAngle">
                <property name="decimals">
                 <number>6</number>
                </property>
@@ -377,7 +377,7 @@
               </widget>
              </item>
              <item row="2" column="2">
-              <widget class="QDoubleSpinBox" name="doubleSpinBoxArea">
+              <widget class="QgsDoubleSpinBox" name="doubleSpinBoxArea">
                <property name="decimals">
                 <number>6</number>
                </property>
@@ -387,7 +387,7 @@
               </widget>
              </item>
              <item row="0" column="2">
-              <widget class="QDoubleSpinBox" name="doubleSpinBoxSegmentLength">
+              <widget class="QgsDoubleSpinBox" name="doubleSpinBoxSegmentLength">
                <property name="decimals">
                 <number>6</number>
                </property>
@@ -432,7 +432,7 @@
                  <number>0</number>
                 </property>
                 <item row="1" column="2">
-                 <widget class="QDoubleSpinBox" name="doubleSpinBoxSliverArea">
+                 <widget class="QgsDoubleSpinBox" name="doubleSpinBoxSliverArea">
                   <property name="enabled">
                    <bool>false</bool>
                   </property>
@@ -471,7 +471,7 @@
                  </widget>
                 </item>
                 <item row="0" column="2">
-                 <widget class="QDoubleSpinBox" name="doubleSpinBoxSliverThinness">
+                 <widget class="QgsDoubleSpinBox" name="doubleSpinBoxSliverThinness">
                   <property name="decimals">
                    <number>0</number>
                   </property>
@@ -531,7 +531,7 @@
               </widget>
              </item>
              <item row="3" column="1">
-              <widget class="QDoubleSpinBox" name="doubleSpinBoxGapArea">
+              <widget class="QgsDoubleSpinBox" name="doubleSpinBoxGapArea">
                <property name="decimals">
                 <number>6</number>
                </property>
@@ -568,7 +568,7 @@
               </widget>
              </item>
              <item row="2" column="1">
-              <widget class="QDoubleSpinBox" name="doubleSpinBoxOverlapArea">
+              <widget class="QgsDoubleSpinBox" name="doubleSpinBoxOverlapArea">
                <property name="decimals">
                 <number>6</number>
                </property>
@@ -664,7 +664,7 @@
              <number>2</number>
             </property>
             <item row="0" column="1">
-             <widget class="QSpinBox" name="spinBoxTolerance">
+             <widget class="QgsSpinBox" name="spinBoxTolerance">
               <property name="prefix">
                <string notr="true">1E-</string>
               </property>
@@ -892,6 +892,16 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsVScrollArea</class>
    <extends>QScrollArea</extends>

--- a/src/providers/delimitedtext/CMakeLists.txt
+++ b/src/providers/delimitedtext/CMakeLists.txt
@@ -26,6 +26,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/symbology
   ${CMAKE_SOURCE_DIR}/src/gui
+  ${CMAKE_SOURCE_DIR}/src/gui/editorwidgets
   ${CMAKE_SOURCE_DIR}/external
   ${CMAKE_SOURCE_DIR}/external/nlohmann
 

--- a/src/providers/grass/CMakeLists.txt
+++ b/src/providers/grass/CMakeLists.txt
@@ -11,6 +11,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core/raster
   ${CMAKE_SOURCE_DIR}/src/core/symbology
   ${CMAKE_SOURCE_DIR}/src/gui
+  ${CMAKE_SOURCE_DIR}/src/gui/editorwidgets
   ${CMAKE_SOURCE_DIR}/external
   ${CMAKE_SOURCE_DIR}/external/nlohmann
 

--- a/src/providers/grass/qgsgrassoptionsbase.ui
+++ b/src/providers/grass/qgsgrassoptionsbase.ui
@@ -500,7 +500,7 @@
                  </widget>
                 </item>
                 <item row="1" column="1">
-                 <widget class="QDoubleSpinBox" name="mRegionWidthSpinBox">
+                 <widget class="QgsDoubleSpinBox" name="mRegionWidthSpinBox">
                   <property name="decimals">
                    <number>1</number>
                   </property>
@@ -566,6 +566,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>

--- a/src/providers/wms/CMakeLists.txt
+++ b/src/providers/wms/CMakeLists.txt
@@ -30,6 +30,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core/symbology
   ${CMAKE_SOURCE_DIR}/src/gui
   ${CMAKE_SOURCE_DIR}/src/gui/auth
+  ${CMAKE_SOURCE_DIR}/src/gui/editorwidgets
   ${CMAKE_SOURCE_DIR}/external
   ${CMAKE_SOURCE_DIR}/external/nlohmann
 

--- a/src/ui/3d/map3dexportwidget.ui
+++ b/src/ui/3d/map3dexportwidget.ui
@@ -126,7 +126,7 @@
       <widget class="QLineEdit" name="sceneNameLineEdit"/>
      </item>
      <item row="4" column="1" colspan="2">
-      <widget class="QDoubleSpinBox" name="scaleSpinBox">
+      <widget class="QgsDoubleSpinBox" name="scaleSpinBox">
        <property name="minimum">
         <double>0.100000000000000</double>
        </property>
@@ -150,6 +150,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsFileWidget</class>
    <extends>QWidget</extends>

--- a/src/ui/3d/map3dexportwidget.ui
+++ b/src/ui/3d/map3dexportwidget.ui
@@ -26,7 +26,7 @@
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
      <item row="3" column="1" colspan="2">
-      <widget class="QSpinBox" name="terrainTextureResolutionSpinBox">
+      <widget class="QgsSpinBox" name="terrainTextureResolutionSpinBox">
        <property name="minimum">
         <number>16</number>
        </property>
@@ -90,7 +90,7 @@
       </widget>
      </item>
      <item row="2" column="1" colspan="2">
-      <widget class="QSpinBox" name="terrainResolutionSpinBox">
+      <widget class="QgsSpinBox" name="terrainResolutionSpinBox">
        <property name="minimum">
         <number>1</number>
        </property>
@@ -160,6 +160,11 @@
    <extends>QWidget</extends>
    <header>qgsfilewidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/3d/point3dsymbolwidget.ui
+++ b/src/ui/3d/point3dsymbolwidget.ui
@@ -291,7 +291,7 @@
       </widget>
      </item>
      <item row="8" column="1">
-      <widget class="QDoubleSpinBox" name="spinBillboardHeight">
+      <widget class="QgsDoubleSpinBox" name="spinBillboardHeight">
        <property name="maximum">
         <double>99999.000000000000000</double>
        </property>

--- a/src/ui/3d/polygon3dsymbolwidget.ui
+++ b/src/ui/3d/polygon3dsymbolwidget.ui
@@ -181,7 +181,7 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QDoubleSpinBox" name="spinEdgeWidth">
+       <widget class="QgsDoubleSpinBox" name="spinEdgeWidth">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
           <horstretch>1</horstretch>

--- a/src/ui/3d/qgslightswidget.ui
+++ b/src/ui/3d/qgslightswidget.ui
@@ -55,7 +55,7 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QDoubleSpinBox" name="spinPositionX">
+          <widget class="QgsDoubleSpinBox" name="spinPositionX">
            <property name="decimals">
             <number>1</number>
            </property>
@@ -75,7 +75,7 @@
           </widget>
          </item>
          <item row="5" column="1">
-          <widget class="QDoubleSpinBox" name="spinIntensity">
+          <widget class="QgsDoubleSpinBox" name="spinIntensity">
            <property name="decimals">
             <number>1</number>
            </property>
@@ -92,7 +92,7 @@
           </widget>
          </item>
          <item row="1" column="1" rowspan="2">
-          <widget class="QDoubleSpinBox" name="spinPositionY">
+          <widget class="QgsDoubleSpinBox" name="spinPositionY">
            <property name="decimals">
             <number>1</number>
            </property>
@@ -112,7 +112,7 @@
           </widget>
          </item>
          <item row="3" column="1">
-          <widget class="QDoubleSpinBox" name="spinPositionZ">
+          <widget class="QgsDoubleSpinBox" name="spinPositionZ">
            <property name="decimals">
             <number>1</number>
            </property>
@@ -141,7 +141,7 @@
           </widget>
          </item>
          <item row="7" column="1">
-          <widget class="QDoubleSpinBox" name="spinA0">
+          <widget class="QgsDoubleSpinBox" name="spinA0">
            <property name="maximum">
             <double>9.000000000000000</double>
            </property>
@@ -151,7 +151,7 @@
           </widget>
          </item>
          <item row="8" column="1">
-          <widget class="QDoubleSpinBox" name="spinA1">
+          <widget class="QgsDoubleSpinBox" name="spinA1">
            <property name="maximum">
             <double>9.000000000000000</double>
            </property>
@@ -161,7 +161,7 @@
           </widget>
          </item>
          <item row="9" column="1">
-          <widget class="QDoubleSpinBox" name="spinA2">
+          <widget class="QgsDoubleSpinBox" name="spinA2">
            <property name="maximum">
             <double>9.000000000000000</double>
            </property>
@@ -217,7 +217,7 @@
        <item row="1" column="0" colspan="3">
         <layout class="QGridLayout" name="gridLayout_3">
          <item row="3" column="1">
-          <widget class="QDoubleSpinBox" name="spinDirectionZ">
+          <widget class="QgsDoubleSpinBox" name="spinDirectionZ">
            <property name="decimals">
             <number>1</number>
            </property>
@@ -267,7 +267,7 @@
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="QDoubleSpinBox" name="spinDirectionY">
+          <widget class="QgsDoubleSpinBox" name="spinDirectionY">
            <property name="decimals">
             <number>1</number>
            </property>
@@ -280,7 +280,7 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QDoubleSpinBox" name="spinDirectionX">
+          <widget class="QgsDoubleSpinBox" name="spinDirectionX">
            <property name="decimals">
             <number>1</number>
            </property>
@@ -293,7 +293,7 @@
           </widget>
          </item>
          <item row="5" column="1">
-          <widget class="QDoubleSpinBox" name="spinDirectionalIntensity">
+          <widget class="QgsDoubleSpinBox" name="spinDirectionalIntensity">
            <property name="decimals">
             <number>1</number>
            </property>
@@ -362,6 +362,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>

--- a/src/ui/3d/qgsmesh3dpropswidget.ui
+++ b/src/ui/3d/qgsmesh3dpropswidget.ui
@@ -309,7 +309,7 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QDoubleSpinBox" name="mArrowsSpacingSpinBox">
+       <widget class="QgsDoubleSpinBox" name="mArrowsSpacingSpinBox">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
           <horstretch>0</horstretch>

--- a/src/ui/3d/qgsvectorlayer3dpropertieswidget.ui
+++ b/src/ui/3d/qgsvectorlayer3dpropertieswidget.ui
@@ -42,7 +42,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QSpinBox" name="spinZoomLevelsCount">
+         <widget class="QgsSpinBox" name="spinZoomLevelsCount">
           <property name="minimum">
            <number>1</number>
           </property>
@@ -74,6 +74,11 @@
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
+++ b/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
@@ -64,7 +64,7 @@
     </widget>
    </item>
    <item row="3" column="1">
-    <widget class="QSpinBox" name="mColumnCountSpinBox">
+    <widget class="QgsSpinBox" name="mColumnCountSpinBox">
      <property name="minimum">
       <number>1</number>
      </property>
@@ -115,6 +115,11 @@
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsFieldExpressionWidget</class>

--- a/src/ui/auth/qgsauthsslimportdialog.ui
+++ b/src/ui/auth/qgsauthsslimportdialog.ui
@@ -127,7 +127,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QSpinBox" name="spinbxPort">
+             <widget class="QgsSpinBox" name="spinbxPort">
               <property name="maximum">
                <number>50000</number>
               </property>
@@ -170,7 +170,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QSpinBox" name="spinbxTimeout">
+           <widget class="QgsSpinBox" name="spinbxTimeout">
             <property name="font">
              <font>
               <pointsize>8</pointsize>
@@ -272,6 +272,11 @@
    <extends>QWidget</extends>
    <header>qgsauthsslconfigwidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>

--- a/src/ui/editorwidgets/qgsrangeconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrangeconfigdlgbase.ui
@@ -159,13 +159,13 @@
         </widget>
        </item>
        <item row="0" column="1">
-        <widget class="QDoubleSpinBox" name="minimumDoubleSpinBox"/>
+        <widget class="QgsDoubleSpinBox" name="minimumDoubleSpinBox"/>
        </item>
        <item row="1" column="1">
-        <widget class="QDoubleSpinBox" name="maximumDoubleSpinBox"/>
+        <widget class="QgsDoubleSpinBox" name="maximumDoubleSpinBox"/>
        </item>
        <item row="2" column="1">
-        <widget class="QDoubleSpinBox" name="stepDoubleSpinBox">
+        <widget class="QgsDoubleSpinBox" name="stepDoubleSpinBox">
          <property name="value">
           <double>1.000000000000000</double>
          </property>
@@ -185,6 +185,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>

--- a/src/ui/editorwidgets/qgsrangeconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrangeconfigdlgbase.ui
@@ -52,7 +52,7 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QSpinBox" name="precisionSpinBox">
+       <widget class="QgsSpinBox" name="precisionSpinBox">
         <property name="toolTip">
          <string>Number of decimal places</string>
         </property>
@@ -108,7 +108,7 @@
         </widget>
        </item>
        <item row="0" column="1">
-        <widget class="QSpinBox" name="minimumSpinBox"/>
+        <widget class="QgsSpinBox" name="minimumSpinBox"/>
        </item>
        <item row="1" column="0">
         <widget class="QLabel" name="maximumLabel">
@@ -118,7 +118,7 @@
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QSpinBox" name="maximumSpinBox"/>
+        <widget class="QgsSpinBox" name="maximumSpinBox"/>
        </item>
        <item row="2" column="0">
         <widget class="QLabel" name="stepLabel">
@@ -128,7 +128,7 @@
         </widget>
        </item>
        <item row="2" column="1">
-        <widget class="QSpinBox" name="stepSpinBox"/>
+        <widget class="QgsSpinBox" name="stepSpinBox"/>
        </item>
       </layout>
      </widget>
@@ -185,6 +185,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>

--- a/src/ui/editorwidgets/qgsvaluerelationconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsvaluerelationconfigdlgbase.ui
@@ -124,7 +124,7 @@
     </widget>
    </item>
    <item row="9" column="1">
-    <widget class="QSpinBox" name="mNofColumns"/>
+    <widget class="QgsSpinBox" name="mNofColumns"/>
    </item>
    <item row="2" column="1">
     <widget class="QgsFieldComboBox" name="mKeyColumn"/>
@@ -156,6 +156,11 @@
    <class>QgsFieldComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsfieldcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsMapLayerComboBox</class>

--- a/src/ui/effects/widget_coloreffects.ui
+++ b/src/ui/effects/widget_coloreffects.ui
@@ -171,7 +171,7 @@
          </widget>
         </item>
         <item row="3" column="2">
-         <widget class="QSpinBox" name="mColorizeStrengthSpinBox">
+         <widget class="QgsSpinBox" name="mColorizeStrengthSpinBox">
           <property name="suffix">
            <string>%</string>
           </property>
@@ -300,6 +300,11 @@
    <class>QgsEffectDrawModeComboBox</class>
    <extends>QComboBox</extends>
    <header>qgseffectdrawmodecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsOpacityWidget</class>

--- a/src/ui/layout/qgslayoutnewpagedialog.ui
+++ b/src/ui/layout/qgslayoutnewpagedialog.ui
@@ -137,7 +137,7 @@
    <item row="1" column="0" colspan="4">
     <layout class="QGridLayout" name="gridLayout_4" columnstretch="0,1,0,1">
      <item row="0" column="1">
-      <widget class="QSpinBox" name="mPagesSpinBox">
+      <widget class="QgsSpinBox" name="mPagesSpinBox">
        <property name="minimum">
         <number>1</number>
        </property>
@@ -193,7 +193,7 @@
       </widget>
      </item>
      <item row="1" column="2">
-      <widget class="QSpinBox" name="mExistingPageSpinBox">
+      <widget class="QgsSpinBox" name="mExistingPageSpinBox">
        <property name="minimum">
         <number>1</number>
        </property>
@@ -242,6 +242,11 @@
    <class>QgsLayoutUnitsComboBox</class>
    <extends>QComboBox</extends>
    <header>qgslayoutunitscombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
+++ b/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
@@ -487,7 +487,7 @@ border-radius: 2px;</string>
                </widget>
               </item>
               <item row="0" column="2">
-               <widget class="QDoubleSpinBox" name="mSimplifyReductionFactorSpinBox">
+               <widget class="QgsDoubleSpinBox" name="mSimplifyReductionFactorSpinBox">
                 <property name="decimals">
                  <number>1</number>
                 </property>
@@ -770,6 +770,11 @@ border-radius: 2px;</string>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsScrollArea</class>

--- a/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
+++ b/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
@@ -471,7 +471,7 @@ border-radius: 2px;</string>
                </widget>
               </item>
               <item row="1" column="2">
-               <widget class="QSpinBox" name="mSimplifyMeshResolutionSpinBox">
+               <widget class="QgsSpinBox" name="mSimplifyMeshResolutionSpinBox">
                 <property name="suffix">
                  <string> pixels/triangle</string>
                 </property>
@@ -775,6 +775,11 @@ border-radius: 2px;</string>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsScrollArea</class>

--- a/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
@@ -98,7 +98,7 @@
        </widget>
       </item>
       <item row="0" column="2" rowspan="3">
-       <widget class="QDoubleSpinBox" name="mScalarEdgeStrokeWidthSpinBox">
+       <widget class="QgsDoubleSpinBox" name="mScalarEdgeStrokeWidthSpinBox">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -223,6 +223,11 @@
    <extends>QWidget</extends>
    <header>raster/qgscolorrampshaderwidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsMeshVariableStrokeWidthButton</class>

--- a/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
@@ -519,7 +519,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QDoubleSpinBox" name="mStreamlinesDensitySpinBox">
+            <widget class="QgsDoubleSpinBox" name="mStreamlinesDensitySpinBox">
              <property name="suffix">
               <string>%</string>
              </property>
@@ -588,7 +588,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QDoubleSpinBox" name="mTracesMaxLengthSpinBox">
+         <widget class="QgsDoubleSpinBox" name="mTracesMaxLengthSpinBox">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
             <horstretch>0</horstretch>

--- a/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
@@ -653,7 +653,7 @@
   </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
-   <extends>QWidget</extends>
+   <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>

--- a/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
@@ -252,7 +252,7 @@
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="QSpinBox" name="mYSpacingSpinBox">
+         <widget class="QgsSpinBox" name="mYSpacingSpinBox">
           <property name="suffix">
            <string> px</string>
           </property>
@@ -561,7 +561,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QSpinBox" name="mTracesParticlesCountSpinBox">
+         <widget class="QgsSpinBox" name="mTracesParticlesCountSpinBox">
           <property name="maximum">
            <number>1000000</number>
           </property>

--- a/src/ui/numericformats/qgsbasicnumericformatwidgetbase.ui
+++ b/src/ui/numericformats/qgsbasicnumericformatwidgetbase.ui
@@ -66,7 +66,7 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QSpinBox" name="mDecimalsSpinBox">
+    <widget class="QgsSpinBox" name="mDecimalsSpinBox">
      <property name="value">
       <number>6</number>
      </property>
@@ -124,6 +124,11 @@
    <extends>QWidget</extends>
    <header>qgspanelwidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsFilterLineEdit</class>

--- a/src/ui/numericformats/qgsbearingnumericformatwidgetbase.ui
+++ b/src/ui/numericformats/qgsbearingnumericformatwidgetbase.ui
@@ -28,7 +28,7 @@
     </spacer>
    </item>
    <item row="1" column="1">
-    <widget class="QSpinBox" name="mDecimalsSpinBox">
+    <widget class="QgsSpinBox" name="mDecimalsSpinBox">
      <property name="value">
       <number>6</number>
      </property>
@@ -61,6 +61,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsPanelWidget</class>
    <extends>QWidget</extends>

--- a/src/ui/numericformats/qgscurrencynumericformatwidgetbase.ui
+++ b/src/ui/numericformats/qgscurrencynumericformatwidgetbase.ui
@@ -43,7 +43,7 @@
     </widget>
    </item>
    <item row="2" column="1">
-    <widget class="QSpinBox" name="mDecimalsSpinBox">
+    <widget class="QgsSpinBox" name="mDecimalsSpinBox">
      <property name="value">
       <number>2</number>
      </property>
@@ -92,6 +92,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsPanelWidget</class>
    <extends>QWidget</extends>

--- a/src/ui/numericformats/qgspercentagenumericformatwidgetbase.ui
+++ b/src/ui/numericformats/qgspercentagenumericformatwidgetbase.ui
@@ -45,7 +45,7 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QSpinBox" name="mDecimalsSpinBox">
+    <widget class="QgsSpinBox" name="mDecimalsSpinBox">
      <property name="value">
       <number>2</number>
      </property>
@@ -78,6 +78,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsPanelWidget</class>
    <extends>QWidget</extends>

--- a/src/ui/numericformats/qgsscientificnumericformatwidgetbase.ui
+++ b/src/ui/numericformats/qgsscientificnumericformatwidgetbase.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="1">
-    <widget class="QSpinBox" name="mDecimalsSpinBox">
+    <widget class="QgsSpinBox" name="mDecimalsSpinBox">
      <property name="value">
       <number>6</number>
      </property>

--- a/src/ui/qgsaddattrdialogbase.ui
+++ b/src/ui/qgsaddattrdialogbase.ui
@@ -87,7 +87,7 @@
     </widget>
    </item>
    <item row="4" column="1">
-    <widget class="QSpinBox" name="mLength">
+    <widget class="QgsSpinBox" name="mLength">
      <property name="toolTip">
       <string>Total length of field (including the number of digits after the decimal place for decimal fields).&lt;br&gt;For example 123.45 requires a decimal field length of 5, and 123456 requires an integer field length of 6.</string>
      </property>
@@ -107,7 +107,7 @@
     </widget>
    </item>
    <item row="5" column="1">
-    <widget class="QSpinBox" name="mPrec">
+    <widget class="QgsSpinBox" name="mPrec">
      <property name="toolTip">
       <string>Maximum number of digits after the decimal place. For example 123.45 requires a field precision of 2.</string>
      </property>
@@ -135,6 +135,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+ </customwidgets>
  <layoutdefault spacing="6" margin="11"/>
  <tabstops>
   <tabstop>mNameEdit</tabstop>

--- a/src/ui/qgsaddtaborgroupbase.ui
+++ b/src/ui/qgsaddtaborgroupbase.ui
@@ -89,7 +89,7 @@
     </widget>
    </item>
    <item row="1" column="1">
-    <widget class="QSpinBox" name="mColumnCountSpinBox">
+    <widget class="QgsSpinBox" name="mColumnCountSpinBox">
      <property name="minimum">
       <number>1</number>
      </property>
@@ -110,6 +110,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>mName</tabstop>
   <tabstop>mTabButton</tabstop>

--- a/src/ui/qgsalignrasterdialog.ui
+++ b/src/ui/qgsalignrasterdialog.ui
@@ -103,7 +103,7 @@
      <item row="2" column="2">
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
-        <widget class="QDoubleSpinBox" name="mSpinCellSizeX">
+        <widget class="QgsDoubleSpinBox" name="mSpinCellSizeX">
          <property name="decimals">
           <number>6</number>
          </property>
@@ -113,7 +113,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QDoubleSpinBox" name="mSpinCellSizeY">
+        <widget class="QgsDoubleSpinBox" name="mSpinCellSizeY">
          <property name="decimals">
           <number>6</number>
          </property>
@@ -127,7 +127,7 @@
      <item row="3" column="2">
       <layout class="QHBoxLayout" name="horizontalLayout_4">
        <item>
-        <widget class="QDoubleSpinBox" name="mSpinGridOffsetX">
+        <widget class="QgsDoubleSpinBox" name="mSpinGridOffsetX">
          <property name="decimals">
           <number>6</number>
          </property>
@@ -137,7 +137,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QDoubleSpinBox" name="mSpinGridOffsetY">
+        <widget class="QgsDoubleSpinBox" name="mSpinGridOffsetY">
          <property name="decimals">
           <number>6</number>
          </property>
@@ -217,6 +217,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>

--- a/src/ui/qgscolorrampshaderwidgetbase.ui
+++ b/src/ui/qgscolorrampshaderwidgetbase.ui
@@ -227,7 +227,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QSpinBox" name="mNumberOfEntriesSpinBox">
+      <widget class="QgsSpinBox" name="mNumberOfEntriesSpinBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -267,6 +267,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsColorRampButton</class>
    <extends>QToolButton</extends>

--- a/src/ui/qgscompoundcolorwidget.ui
+++ b/src/ui/qgscompoundcolorwidget.ui
@@ -186,7 +186,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QSpinBox" name="mSpinBoxRadius">
+            <widget class="QgsSpinBox" name="mSpinBoxRadius">
              <property name="suffix">
               <string> px</string>
              </property>
@@ -942,6 +942,11 @@
   </action>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>

--- a/src/ui/qgsdecorationgriddialog.ui
+++ b/src/ui/qgsdecorationgriddialog.ui
@@ -252,7 +252,7 @@
           <widget class="QSpinBox" name="mCoordinatePrecisionSpinBox"/>
          </item>
          <item row="2" column="1">
-          <widget class="QDoubleSpinBox" name="mDistanceToMapFrameSpinBox"/>
+          <widget class="QgsDoubleSpinBox" name="mDistanceToMapFrameSpinBox"/>
          </item>
          <item row="0" column="1">
           <widget class="QComboBox" name="mAnnotationDirectionComboBox"/>
@@ -349,6 +349,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsFontButton</class>
    <extends>QToolButton</extends>

--- a/src/ui/qgsdecorationgriddialog.ui
+++ b/src/ui/qgsdecorationgriddialog.ui
@@ -249,7 +249,7 @@
           <enum>QLayout::SetMinimumSize</enum>
          </property>
          <item row="3" column="1">
-          <widget class="QSpinBox" name="mCoordinatePrecisionSpinBox"/>
+          <widget class="QgsSpinBox" name="mCoordinatePrecisionSpinBox"/>
          </item>
          <item row="2" column="1">
           <widget class="QgsDoubleSpinBox" name="mDistanceToMapFrameSpinBox"/>
@@ -349,6 +349,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>

--- a/src/ui/qgsdecorationnortharrowdialog.ui
+++ b/src/ui/qgsdecorationnortharrowdialog.ui
@@ -315,7 +315,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QSpinBox" name="spinAngle">
+         <widget class="QgsSpinBox" name="spinAngle">
           <property name="maximum">
            <number>360</number>
           </property>

--- a/src/ui/qgsdelimitedtextsourceselectbase.ui
+++ b/src/ui/qgsdelimitedtextsourceselectbase.ui
@@ -660,7 +660,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QSpinBox" name="rowCounter">
+             <widget class="QgsSpinBox" name="rowCounter">
               <property name="minimumSize">
                <size>
                 <width>0</width>
@@ -1406,6 +1406,11 @@
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>

--- a/src/ui/qgsfieldcalculatorbase.ui
+++ b/src/ui/qgsfieldcalculatorbase.ui
@@ -168,7 +168,7 @@
        <number>3</number>
       </property>
       <item row="5" column="3">
-       <widget class="QSpinBox" name="mOutputFieldPrecisionSpinBox">
+       <widget class="QgsSpinBox" name="mOutputFieldPrecisionSpinBox">
         <property name="toolTip">
          <string>Maximum number of digits after the decimal place. For example 123.45 requires a field precision of 2.</string>
         </property>
@@ -204,7 +204,7 @@
        <widget class="QComboBox" name="mOutputFieldTypeComboBox"/>
       </item>
       <item row="5" column="1">
-       <widget class="QSpinBox" name="mOutputFieldWidthSpinBox">
+       <widget class="QgsSpinBox" name="mOutputFieldWidthSpinBox">
         <property name="toolTip">
          <string>Total length of field (including the number of digits after the decimal place for decimal fields).&lt;br&gt;For example 123.45 requires a decimal field length of 5, and 123456 requires an integer field length of 6.</string>
         </property>
@@ -258,6 +258,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsExpressionBuilderWidget</class>
    <extends>QWidget</extends>

--- a/src/ui/qgsgpsinformationwidgetbase.ui
+++ b/src/ui/qgsgpsinformationwidgetbase.ui
@@ -1497,12 +1497,12 @@ gray = no data
   </customwidget>
   <customwidget>
    <class>QgsColorButton</class>
-   <extends>QWidget</extends>
+   <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsSpinBox</class>
-   <extends>QWidget</extends>
+   <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>

--- a/src/ui/qgsgpsinformationwidgetbase.ui
+++ b/src/ui/qgsgpsinformationwidgetbase.ui
@@ -915,7 +915,7 @@ gray = no data
                   </widget>
                  </item>
                  <item row="1" column="1">
-                  <widget class="QSpinBox" name="mSpinTrackWidth">
+                  <widget class="QgsSpinBox" name="mSpinTrackWidth">
                    <property name="toolTip">
                     <string>Track width in pixels</string>
                    </property>
@@ -1007,7 +1007,7 @@ gray = no data
                   <widget class="QComboBox" name="mCboTimeZones"/>
                  </item>
                  <item row="4" column="1">
-                  <widget class="QSpinBox" name="mLeapSeconds"/>
+                  <widget class="QgsSpinBox" name="mLeapSeconds"/>
                  </item>
                  <item row="4" column="0">
                   <widget class="QCheckBox" name="mCbxLeapSeconds">
@@ -1056,7 +1056,7 @@ gray = no data
                  <number>20</number>
                 </property>
                 <item>
-                 <widget class="QSpinBox" name="mSpinMapExtentMultiplier">
+                 <widget class="QgsSpinBox" name="mSpinMapExtentMultiplier">
                   <property name="enabled">
                    <bool>false</bool>
                   </property>

--- a/src/ui/qgsgraduatedsymbolrendererwidget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererwidget.ui
@@ -181,7 +181,7 @@ Use &quot;%1&quot; for the lower bound of the classification, and &quot;%2&quot;
       </widget>
      </item>
      <item>
-      <widget class="QSpinBox" name="spinPrecision">
+      <widget class="QgsSpinBox" name="spinPrecision">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
          <horstretch>0</horstretch>

--- a/src/ui/qgshistogramwidgetbase.ui
+++ b/src/ui/qgshistogramwidgetbase.ui
@@ -50,7 +50,7 @@
     </widget>
    </item>
    <item row="2" column="2">
-    <widget class="QSpinBox" name="mBinsSpinBox">
+    <widget class="QgsSpinBox" name="mBinsSpinBox">
      <property name="minimum">
       <number>1</number>
      </property>
@@ -79,6 +79,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QwtPlot</class>
    <extends>QFrame</extends>

--- a/src/ui/qgslimitedrandomcolorrampwidgetbase.ui
+++ b/src/ui/qgslimitedrandomcolorrampwidgetbase.ui
@@ -24,7 +24,7 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QSpinBox" name="spinHue1">
+      <widget class="QgsSpinBox" name="spinHue1">
        <property name="maximum">
         <number>359</number>
        </property>
@@ -38,7 +38,7 @@
       </widget>
      </item>
      <item row="0" column="3">
-      <widget class="QSpinBox" name="spinHue2">
+      <widget class="QgsSpinBox" name="spinHue2">
        <property name="maximum">
         <number>359</number>
        </property>
@@ -48,7 +48,7 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QSpinBox" name="spinSat1">
+      <widget class="QgsSpinBox" name="spinSat1">
        <property name="maximum">
         <number>255</number>
        </property>
@@ -69,7 +69,7 @@
       </widget>
      </item>
      <item row="1" column="3">
-      <widget class="QSpinBox" name="spinSat2">
+      <widget class="QgsSpinBox" name="spinSat2">
        <property name="maximum">
         <number>255</number>
        </property>
@@ -79,7 +79,7 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QSpinBox" name="spinVal1">
+      <widget class="QgsSpinBox" name="spinVal1">
        <property name="maximum">
         <number>255</number>
        </property>
@@ -100,7 +100,7 @@
       </widget>
      </item>
      <item row="2" column="3">
-      <widget class="QSpinBox" name="spinVal2">
+      <widget class="QgsSpinBox" name="spinVal2">
        <property name="maximum">
         <number>255</number>
        </property>
@@ -117,7 +117,7 @@
       </widget>
      </item>
      <item row="3" column="1">
-      <widget class="QSpinBox" name="spinCount">
+      <widget class="QgsSpinBox" name="spinCount">
        <property name="minimum">
         <number>1</number>
        </property>
@@ -166,6 +166,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsPanelWidget</class>
    <extends>QWidget</extends>

--- a/src/ui/qgsoffsetuserinputwidget.ui
+++ b/src/ui/qgsoffsetuserinputwidget.ui
@@ -21,7 +21,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="1" column="2">
-    <widget class="QDoubleSpinBox" name="mOffsetSpinBox">
+    <widget class="QgsDoubleSpinBox" name="mOffsetSpinBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -119,7 +119,7 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="mMiterLimitSpinBox">
+       <widget class="QgsDoubleSpinBox" name="mMiterLimitSpinBox">
         <property name="minimum">
          <double>1.000000000000000</double>
         </property>
@@ -143,6 +143,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsoffsetuserinputwidget.ui
+++ b/src/ui/qgsoffsetuserinputwidget.ui
@@ -102,7 +102,7 @@
        </widget>
       </item>
       <item row="0" column="3">
-       <widget class="QSpinBox" name="mQuadrantSpinBox">
+       <widget class="QgsSpinBox" name="mQuadrantSpinBox">
         <property name="minimum">
          <number>1</number>
         </property>
@@ -148,6 +148,11 @@
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/ui/qgsoffsetuserinputwidget.ui
+++ b/src/ui/qgsoffsetuserinputwidget.ui
@@ -157,33 +157,6 @@
  </customwidgets>
  <resources>
   <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -2444,7 +2444,7 @@
                       </widget>
                      </item>
                      <item row="1" column="2">
-                      <widget class="QDoubleSpinBox" name="mSimplifyDrawingSpinBox">
+                      <widget class="QgsDoubleSpinBox" name="mSimplifyDrawingSpinBox">
                        <property name="toolTip">
                         <string>Higher values result in more simplification</string>
                        </property>
@@ -2547,7 +2547,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QDoubleSpinBox" name="doubleSpinBoxMagnifierDefault"/>
+                     <widget class="QgsDoubleSpinBox" name="doubleSpinBoxMagnifierDefault"/>
                     </item>
                     <item>
                      <spacer name="horizontalSpacer_4">
@@ -2612,7 +2612,7 @@
                    </widget>
                   </item>
                   <item row="0" column="1">
-                   <widget class="QDoubleSpinBox" name="mSegmentationToleranceSpinBox"/>
+                   <widget class="QgsDoubleSpinBox" name="mSegmentationToleranceSpinBox"/>
                   </item>
                   <item row="1" column="0">
                    <widget class="QLabel" name="mToleranceTypeLabel">
@@ -2732,7 +2732,7 @@
                      <item row="3" column="1">
                       <layout class="QHBoxLayout" name="horizontalLayoutOversampling">
                        <item>
-                        <widget class="QDoubleSpinBox" name="spnOversampling"/>
+                        <widget class="QgsDoubleSpinBox" name="spnOversampling"/>
                        </item>
                        <item>
                         <spacer name="horizontalSpacer_25">
@@ -2915,7 +2915,7 @@
                          </widget>
                         </item>
                         <item>
-                         <widget class="QDoubleSpinBox" name="mRasterCumulativeCutLowerDoubleSpinBox">
+                         <widget class="QgsDoubleSpinBox" name="mRasterCumulativeCutLowerDoubleSpinBox">
                           <property name="decimals">
                            <number>1</number>
                           </property>
@@ -2929,7 +2929,7 @@
                          </widget>
                         </item>
                         <item>
-                         <widget class="QDoubleSpinBox" name="mRasterCumulativeCutUpperDoubleSpinBox">
+                         <widget class="QgsDoubleSpinBox" name="mRasterCumulativeCutUpperDoubleSpinBox">
                           <property name="decimals">
                            <number>1</number>
                           </property>
@@ -2981,7 +2981,7 @@
                          </widget>
                         </item>
                         <item>
-                         <widget class="QDoubleSpinBox" name="spnThreeBandStdDev">
+                         <widget class="QgsDoubleSpinBox" name="spnThreeBandStdDev">
                           <property name="maximum">
                            <double>10.000000000000000</double>
                           </property>
@@ -3433,7 +3433,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QDoubleSpinBox" name="spinBoxIdentifyValue">
+                     <widget class="QgsDoubleSpinBox" name="spinBoxIdentifyValue">
                       <property name="suffix">
                        <string> mm</string>
                       </property>
@@ -3511,7 +3511,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QDoubleSpinBox" name="mIdentifyHighlightBufferSpinBox">
+                     <widget class="QgsDoubleSpinBox" name="mIdentifyHighlightBufferSpinBox">
                       <property name="toolTip">
                        <string>Lines / outlines buffer in millimeters.</string>
                       </property>
@@ -3531,7 +3531,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QDoubleSpinBox" name="mIdentifyHighlightMinWidthSpinBox">
+                     <widget class="QgsDoubleSpinBox" name="mIdentifyHighlightMinWidthSpinBox">
                       <property name="toolTip">
                        <string>Minimum line / stroke width in millimeters.</string>
                       </property>
@@ -4147,7 +4147,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                    </widget>
                   </item>
                   <item row="3" column="2">
-                   <widget class="QDoubleSpinBox" name="mDefaultZValueSpinBox">
+                   <widget class="QgsDoubleSpinBox" name="mDefaultZValueSpinBox">
                     <property name="decimals">
                      <number>3</number>
                     </property>
@@ -4367,7 +4367,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                    </spacer>
                   </item>
                   <item row="2" column="2">
-                   <widget class="QDoubleSpinBox" name="mDefaultSnappingToleranceSpinBox">
+                   <widget class="QgsDoubleSpinBox" name="mDefaultSnappingToleranceSpinBox">
                     <property name="decimals">
                      <number>5</number>
                     </property>
@@ -4417,7 +4417,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                    </spacer>
                   </item>
                   <item row="3" column="2">
-                   <widget class="QDoubleSpinBox" name="mSearchRadiusVertexEditSpinBox">
+                   <widget class="QgsDoubleSpinBox" name="mSearchRadiusVertexEditSpinBox">
                     <property name="decimals">
                      <number>5</number>
                     </property>
@@ -4521,7 +4521,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                    </widget>
                   </item>
                   <item row="2" column="2">
-                   <widget class="QDoubleSpinBox" name="mMarkerSizeSpinBox">
+                   <widget class="QgsDoubleSpinBox" name="mMarkerSizeSpinBox">
                     <property name="layoutDirection">
                      <enum>Qt::LeftToRight</enum>
                     </property>
@@ -4604,7 +4604,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                    </widget>
                   </item>
                   <item row="2" column="2">
-                   <widget class="QDoubleSpinBox" name="mCurveOffsetMiterLimitComboBox"/>
+                   <widget class="QgsDoubleSpinBox" name="mCurveOffsetMiterLimitComboBox"/>
                   </item>
                   <item row="0" column="1">
                    <spacer name="horizontalSpacer_29">
@@ -4800,7 +4800,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                    </widget>
                   </item>
                   <item row="0" column="1">
-                   <widget class="QDoubleSpinBox" name="mGridResolutionSpinBox">
+                   <widget class="QgsDoubleSpinBox" name="mGridResolutionSpinBox">
                     <property name="suffix">
                      <string> mm</string>
                     </property>
@@ -4825,7 +4825,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                   <item row="0" column="3">
                    <layout class="QHBoxLayout" name="horizontalLayout_36">
                     <item>
-                     <widget class="QDoubleSpinBox" name="mOffsetXSpinBox">
+                     <widget class="QgsDoubleSpinBox" name="mOffsetXSpinBox">
                       <property name="prefix">
                        <string>x: </string>
                       </property>
@@ -4835,7 +4835,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QDoubleSpinBox" name="mOffsetYSpinBox">
+                     <widget class="QgsDoubleSpinBox" name="mOffsetYSpinBox">
                       <property name="prefix">
                        <string>y: </string>
                       </property>
@@ -5828,6 +5828,11 @@ p, li { white-space: pre-wrap; }
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsFilterLineEdit</class>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -634,7 +634,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="spinFontSize">
+                     <widget class="QgsSpinBox" name="spinFontSize">
                       <property name="sizePolicy">
                        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
                         <horstretch>0</horstretch>
@@ -677,7 +677,7 @@
                      </spacer>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="mMessageTimeoutSpnBx">
+                     <widget class="QgsSpinBox" name="mMessageTimeoutSpnBx">
                       <property name="suffix">
                        <string> s</string>
                       </property>
@@ -1980,7 +1980,7 @@
                   <item row="5" column="1">
                    <layout class="QHBoxLayout" name="horizontalLayout_10">
                     <item>
-                     <widget class="QSpinBox" name="spinBoxAttrTableRowCache">
+                     <widget class="QgsSpinBox" name="spinBoxAttrTableRowCache">
                       <property name="minimum">
                        <number>0</number>
                       </property>
@@ -2357,7 +2357,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="spinMaxThreads"/>
+                     <widget class="QgsSpinBox" name="spinMaxThreads"/>
                     </item>
                     <item>
                      <spacer name="horizontalSpacer_41">
@@ -2384,7 +2384,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="spinMapUpdateInterval">
+                     <widget class="QgsSpinBox" name="spinMapUpdateInterval">
                       <property name="suffix">
                        <string> ms</string>
                       </property>
@@ -2665,7 +2665,7 @@
                         </widget>
                        </item>
                        <item>
-                        <widget class="QSpinBox" name="spnRed"/>
+                        <widget class="QgsSpinBox" name="spnRed"/>
                        </item>
                        <item>
                         <widget class="QLabel" name="label_23">
@@ -2675,7 +2675,7 @@
                         </widget>
                        </item>
                        <item>
-                        <widget class="QSpinBox" name="spnGreen"/>
+                        <widget class="QgsSpinBox" name="spnGreen"/>
                        </item>
                        <item>
                         <widget class="QLabel" name="label_24">
@@ -2685,7 +2685,7 @@
                         </widget>
                        </item>
                        <item>
-                        <widget class="QSpinBox" name="spnBlue"/>
+                        <widget class="QgsSpinBox" name="spnBlue"/>
                        </item>
                        <item>
                         <spacer name="horizontalSpacer_20">
@@ -3292,7 +3292,7 @@
                      </spacer>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="mLegendGraphicResolutionSpinBox">
+                     <widget class="QgsSpinBox" name="mLegendGraphicResolutionSpinBox">
                       <property name="toolTip">
                        <string extracomment="MAP_RESOLUTION or DPI value overloading getMap default value (set 0 to use default)"/>
                       </property>
@@ -3348,7 +3348,7 @@
                    </spacer>
                   </item>
                   <item>
-                   <widget class="QSpinBox" name="mMapTipsDelaySpinBox">
+                   <widget class="QgsSpinBox" name="mMapTipsDelaySpinBox">
                     <property name="toolTip">
                      <string extracomment="MAP_RESOLUTION or DPI value overloading getMap default value (set 0 to use default)"/>
                     </property>
@@ -3588,7 +3588,7 @@
                    </widget>
                   </item>
                   <item row="1" column="1">
-                   <widget class="QSpinBox" name="mDecimalPlacesSpinBox"/>
+                   <widget class="QgsSpinBox" name="mDecimalPlacesSpinBox"/>
                   </item>
                   <item row="1" column="0">
                    <widget class="QLabel" name="label_12">
@@ -4221,7 +4221,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                    </widget>
                   </item>
                   <item row="0" column="1">
-                   <widget class="QSpinBox" name="mLineWidthSpinBox">
+                   <widget class="QgsSpinBox" name="mLineWidthSpinBox">
                     <property name="toolTip">
                      <string>Line width in pixels</string>
                     </property>
@@ -4570,7 +4570,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout">
                   <item row="1" column="2">
-                   <widget class="QSpinBox" name="mOffsetQuadSegSpinBox"/>
+                   <widget class="QgsSpinBox" name="mOffsetQuadSegSpinBox"/>
                   </item>
                   <item row="2" column="0">
                    <widget class="QLabel" name="label_28">
@@ -4854,7 +4854,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                    </widget>
                   </item>
                   <item row="1" column="1">
-                   <widget class="QSpinBox" name="mSnapToleranceSpinBox">
+                   <widget class="QgsSpinBox" name="mSnapToleranceSpinBox">
                     <property name="suffix">
                      <string> px</string>
                     </property>
@@ -5239,7 +5239,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="mNetworkTimeoutSpinBox">
+                     <widget class="QgsSpinBox" name="mNetworkTimeoutSpinBox">
                       <property name="maximum">
                        <number>100000000</number>
                       </property>
@@ -5257,7 +5257,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="mDefaultCapabilitiesExpirySpinBox">
+                     <widget class="QgsSpinBox" name="mDefaultCapabilitiesExpirySpinBox">
                       <property name="maximum">
                        <number>100000000</number>
                       </property>
@@ -5275,7 +5275,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="mDefaultTileExpirySpinBox">
+                     <widget class="QgsSpinBox" name="mDefaultTileExpirySpinBox">
                       <property name="maximum">
                        <number>100000000</number>
                       </property>
@@ -5293,7 +5293,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="mDefaultTileMaxRetrySpinBox">
+                     <widget class="QgsSpinBox" name="mDefaultTileMaxRetrySpinBox">
                       <property name="maximum">
                        <number>100000000</number>
                       </property>
@@ -5352,7 +5352,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                        <widget class="QLineEdit" name="mCacheDirectory"/>
                       </item>
                       <item row="4" column="1">
-                       <widget class="QSpinBox" name="mCacheSize"/>
+                       <widget class="QgsSpinBox" name="mCacheSize"/>
                       </item>
                       <item row="0" column="2">
                        <widget class="QToolButton" name="mBrowseCacheDirectory">

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -678,7 +678,7 @@
                       </widget>
                      </item>
                      <item>
-                      <widget class="QSpinBox" name="spinBoxDP">
+                      <widget class="QgsSpinBox" name="spinBoxDP">
                        <property name="toolTip">
                         <string>The number of decimal places for the manual option</string>
                        </property>
@@ -2170,7 +2170,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="mWMSMaxAtlasFeaturesSpinBox">
+                     <widget class="QgsSpinBox" name="mWMSMaxAtlasFeaturesSpinBox">
                       <property name="maximum">
                        <number>9999999</number>
                       </property>
@@ -2198,7 +2198,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="mWMSPrecisionSpinBox">
+                     <widget class="QgsSpinBox" name="mWMSPrecisionSpinBox">
                       <property name="minimum">
                        <number>1</number>
                       </property>
@@ -2567,7 +2567,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="mWMSImageQualitySpinBox">
+                     <widget class="QgsSpinBox" name="mWMSImageQualitySpinBox">
                       <property name="minimum">
                        <number>10</number>
                       </property>
@@ -2597,7 +2597,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="mWMSTileBufferSpinBox"/>
+                     <widget class="QgsSpinBox" name="mWMSTileBufferSpinBox"/>
                     </item>
                    </layout>
                   </item>
@@ -2626,7 +2626,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="mWMTSMinScaleLineEdit">
+                     <widget class="QgsSpinBox" name="mWMTSMinScaleLineEdit">
                       <property name="minimum">
                        <number>1</number>
                       </property>
@@ -3165,6 +3165,11 @@
    <extends>QWidget</extends>
    <header>qgsopacitywidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsCodeEditorPython</class>

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -1072,7 +1072,7 @@ border-radius: 2px;</string>
                    </widget>
                   </item>
                   <item row="2" column="2">
-                   <widget class="QDoubleSpinBox" name="mGammaSpinBox">
+                   <widget class="QgsDoubleSpinBox" name="mGammaSpinBox">
                     <property name="minimum">
                      <double>0.100000000000000</double>
                     </property>
@@ -1191,7 +1191,7 @@ border-radius: 2px;</string>
                    </widget>
                   </item>
                   <item>
-                   <widget class="QDoubleSpinBox" name="mMaximumOversamplingSpinBox"/>
+                   <widget class="QgsDoubleSpinBox" name="mMaximumOversamplingSpinBox"/>
                   </item>
                   <item>
                    <widget class="QCheckBox" name="mCbEarlyResampling">
@@ -1843,7 +1843,7 @@ border-radius: 2px;</string>
               </widget>
              </item>
              <item>
-              <widget class="QDoubleSpinBox" name="mRefreshLayerIntervalSpinBox">
+              <widget class="QgsDoubleSpinBox" name="mRefreshLayerIntervalSpinBox">
                <property name="toolTip">
                 <string>Higher values result in more simplification</string>
                </property>
@@ -2637,6 +2637,11 @@ p, li { white-space: pre-wrap; }
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -856,7 +856,7 @@ border-radius: 2px;</string>
                    </widget>
                   </item>
                   <item row="1" column="2">
-                   <widget class="QSpinBox" name="mBrightnessSpinBox">
+                   <widget class="QgsSpinBox" name="mBrightnessSpinBox">
                     <property name="minimum">
                      <number>-255</number>
                     </property>
@@ -895,7 +895,7 @@ border-radius: 2px;</string>
                    </widget>
                   </item>
                   <item row="1" column="6">
-                   <widget class="QSpinBox" name="mContrastSpinBox">
+                   <widget class="QgsSpinBox" name="mContrastSpinBox">
                     <property name="minimum">
                      <number>-100</number>
                     </property>
@@ -974,7 +974,7 @@ border-radius: 2px;</string>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="spinColorizeStrength">
+                     <widget class="QgsSpinBox" name="spinColorizeStrength">
                       <property name="suffix">
                        <string>%</string>
                       </property>
@@ -1127,7 +1127,7 @@ border-radius: 2px;</string>
                    </widget>
                   </item>
                   <item row="2" column="6">
-                   <widget class="QSpinBox" name="spinBoxSaturation">
+                   <widget class="QgsSpinBox" name="spinBoxSaturation">
                     <property name="minimum">
                      <number>-100</number>
                     </property>
@@ -2669,6 +2669,11 @@ p, li { white-space: pre-wrap; }
    <class>QgsFilterLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qgsfilterlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsOpacityWidget</class>

--- a/src/ui/qgsrasterminmaxwidgetbase.ui
+++ b/src/ui/qgsrasterminmaxwidgetbase.ui
@@ -76,7 +76,7 @@ count cut</string>
            </widget>
           </item>
           <item>
-           <widget class="QDoubleSpinBox" name="mCumulativeCutLowerDoubleSpinBox">
+           <widget class="QgsDoubleSpinBox" name="mCumulativeCutLowerDoubleSpinBox">
             <property name="decimals">
              <number>1</number>
             </property>
@@ -90,7 +90,7 @@ count cut</string>
            </widget>
           </item>
           <item>
-           <widget class="QDoubleSpinBox" name="mCumulativeCutUpperDoubleSpinBox">
+           <widget class="QgsDoubleSpinBox" name="mCumulativeCutUpperDoubleSpinBox">
             <property name="decimals">
              <number>1</number>
             </property>
@@ -132,7 +132,7 @@ standard de&amp;viation ×</string>
            </widget>
           </item>
           <item>
-           <widget class="QDoubleSpinBox" name="mStdDevSpinBox">
+           <widget class="QgsDoubleSpinBox" name="mStdDevSpinBox">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -231,6 +231,11 @@ standard de&amp;viation ×</string>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>

--- a/src/ui/qgsrendererrasterpropswidgetbase.ui
+++ b/src/ui/qgsrendererrasterpropswidgetbase.ui
@@ -394,7 +394,7 @@
           </widget>
          </item>
          <item row="4" column="2">
-          <widget class="QDoubleSpinBox" name="mGammaSpinBox">
+          <widget class="QgsDoubleSpinBox" name="mGammaSpinBox">
            <property name="minimum">
             <double>0.100000000000000</double>
            </property>
@@ -446,7 +446,7 @@
           <widget class="QComboBox" name="mZoomedOutResamplingComboBox"/>
          </item>
          <item row="2" column="2">
-          <widget class="QDoubleSpinBox" name="mMaximumOversamplingSpinBox"/>
+          <widget class="QgsDoubleSpinBox" name="mMaximumOversamplingSpinBox"/>
          </item>
          <item row="3" column="0">
           <widget class="QCheckBox" name="mCbEarlyResampling">
@@ -467,6 +467,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>

--- a/src/ui/qgsrendererrasterpropswidgetbase.ui
+++ b/src/ui/qgsrendererrasterpropswidgetbase.ui
@@ -144,7 +144,7 @@
               </widget>
              </item>
              <item>
-              <widget class="QSpinBox" name="spinColorizeStrength">
+              <widget class="QgsSpinBox" name="spinColorizeStrength">
                <property name="suffix">
                 <string>%</string>
                </property>
@@ -217,7 +217,7 @@
           </widget>
          </item>
          <item row="3" column="2">
-          <widget class="QSpinBox" name="mContrastSpinBox">
+          <widget class="QgsSpinBox" name="mContrastSpinBox">
            <property name="minimum">
             <number>-100</number>
            </property>
@@ -301,7 +301,7 @@
           </widget>
          </item>
          <item row="2" column="2">
-          <widget class="QSpinBox" name="spinBoxSaturation">
+          <widget class="QgsSpinBox" name="spinBoxSaturation">
            <property name="minimum">
             <number>-100</number>
            </property>
@@ -317,7 +317,7 @@
           </widget>
          </item>
          <item row="1" column="2">
-          <widget class="QSpinBox" name="mBrightnessSpinBox">
+          <widget class="QgsSpinBox" name="mBrightnessSpinBox">
            <property name="minimum">
             <number>-255</number>
            </property>
@@ -477,6 +477,11 @@
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsBlendModeComboBox</class>

--- a/src/ui/qgstextannotationdialogbase.ui
+++ b/src/ui/qgstextannotationdialogbase.ui
@@ -33,7 +33,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QSpinBox" name="mFontSizeSpinBox"/>
+      <widget class="QgsSpinBox" name="mFontSizeSpinBox"/>
      </item>
      <item>
       <widget class="QPushButton" name="mBoldPushButton">
@@ -120,6 +120,11 @@
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -1604,7 +1604,7 @@ border-radius: 2px;</string>
                    </widget>
                   </item>
                   <item row="1" column="2">
-                   <widget class="QDoubleSpinBox" name="mSimplifyDrawingSpinBox">
+                   <widget class="QgsDoubleSpinBox" name="mSimplifyDrawingSpinBox">
                     <property name="toolTip">
                      <string>Higher values result in more simplification</string>
                     </property>
@@ -1711,7 +1711,7 @@ border-radius: 2px;</string>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QDoubleSpinBox" name="mRefreshLayerIntervalSpinBox">
+                  <widget class="QgsDoubleSpinBox" name="mRefreshLayerIntervalSpinBox">
                    <property name="toolTip">
                     <string>Lower values result in more data refreshing. Canvas updates are deferred in order to avoid refreshing multiple times if more than one layer has an auto update interval set.</string>
                    </property>
@@ -2542,6 +2542,11 @@ border-radius: 2px;</string>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>

--- a/src/ui/qgsvectortileconnectiondialog.ui
+++ b/src/ui/qgsvectortileconnectiondialog.ui
@@ -66,7 +66,7 @@
        </widget>
       </item>
       <item row="2" column="2">
-       <widget class="QSpinBox" name="mSpinZMin">
+       <widget class="QgsSpinBox" name="mSpinZMin">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -86,7 +86,7 @@
        </widget>
       </item>
       <item row="6" column="2">
-       <widget class="QSpinBox" name="mSpinZMax">
+       <widget class="QgsSpinBox" name="mSpinZMax">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -176,6 +176,11 @@
    <extends>QWidget</extends>
    <header>auth/qgsauthsettingswidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsxyzconnectiondialog.ui
+++ b/src/ui/qgsxyzconnectiondialog.ui
@@ -48,7 +48,7 @@
        </widget>
       </item>
       <item row="8" column="2">
-       <widget class="QSpinBox" name="mSpinZMax">
+       <widget class="QgsSpinBox" name="mSpinZMax">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -139,7 +139,7 @@
        </widget>
       </item>
       <item row="4" column="2">
-       <widget class="QSpinBox" name="mSpinZMin">
+       <widget class="QgsSpinBox" name="mSpinZMin">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -195,6 +195,11 @@
    <extends>QWidget</extends>
    <header>auth/qgsauthsettingswidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/raster/qgscolorrampshaderwidgetbase.ui
+++ b/src/ui/raster/qgscolorrampshaderwidgetbase.ui
@@ -227,7 +227,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QSpinBox" name="mNumberOfEntriesSpinBox">
+      <widget class="QgsSpinBox" name="mNumberOfEntriesSpinBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -265,6 +265,11 @@ suffix</string>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsColorRampButton</class>
    <extends>QToolButton</extends>

--- a/src/ui/symbollayer/qgs25drendererwidgetbase.ui
+++ b/src/ui/symbollayer/qgs25drendererwidgetbase.ui
@@ -96,7 +96,7 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QDoubleSpinBox" name="mShadowSizeWidget"/>
+          <widget class="QgsDoubleSpinBox" name="mShadowSizeWidget"/>
          </item>
          <item row="1" column="0">
           <widget class="QLabel" name="label_6">
@@ -143,6 +143,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>

--- a/src/ui/symbollayer/widget_gradientfill.ui
+++ b/src/ui/symbollayer/widget_gradientfill.ui
@@ -54,7 +54,7 @@
     </widget>
    </item>
    <item row="7" column="2">
-    <widget class="QDoubleSpinBox" name="spinRefPoint1Y">
+    <widget class="QgsDoubleSpinBox" name="spinRefPoint1Y">
      <property name="maximum">
       <double>1.000000000000000</double>
      </property>
@@ -231,7 +231,7 @@
     </widget>
    </item>
    <item row="11" column="2">
-    <widget class="QDoubleSpinBox" name="spinRefPoint2Y">
+    <widget class="QgsDoubleSpinBox" name="spinRefPoint2Y">
      <property name="maximum">
       <double>1.000000000000000</double>
      </property>
@@ -325,7 +325,7 @@
     </widget>
    </item>
    <item row="6" column="2">
-    <widget class="QDoubleSpinBox" name="spinRefPoint1X">
+    <widget class="QgsDoubleSpinBox" name="spinRefPoint1X">
      <property name="maximum">
       <double>1.000000000000000</double>
      </property>
@@ -338,7 +338,7 @@
     </widget>
    </item>
    <item row="10" column="2">
-    <widget class="QDoubleSpinBox" name="spinRefPoint2X">
+    <widget class="QgsDoubleSpinBox" name="spinRefPoint2X">
      <property name="maximum">
       <double>1.000000000000000</double>
      </property>

--- a/src/ui/symbollayer/widget_shapeburstfill.ui
+++ b/src/ui/symbollayer/widget_shapeburstfill.ui
@@ -79,7 +79,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QSpinBox" name="mSpinBlurRadius">
+      <widget class="QgsSpinBox" name="mSpinBlurRadius">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>1</horstretch>
@@ -457,6 +457,11 @@
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsColorRampButton</class>


### PR DESCRIPTION
based on https://github.com/qgis/QGIS/pull/38948#issuecomment-697958015. Anything else to do?

Couldn't find how to make some plugins and providers dialogs use it.