### PR TITLE
Fix writing weak relations to XML

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2639,17 +2639,17 @@ bool QgsVectorLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString 
     const auto constReferencingRelations { QgsProject::instance()->relationManager()->referencingRelations( this ) };
     for ( const auto &rel : constReferencingRelations )
     {
-      QgsWeakRelation::writeXml( this, rel, referencedLayersElement, doc );
+      QgsWeakRelation::writeXml( this, QgsWeakRelation::Referencing, rel, referencedLayersElement, doc );
     }
 
     // Store referencing layers: relations where "this" is the parent layer (the referenced part, that holds the FK)
     QDomElement referencingLayersElement = doc.createElement( QStringLiteral( "referencingLayers" ) );
     node.appendChild( referencedLayersElement );
 
-    const auto constReferencedRelations { QgsProject::instance()->relationManager()->referencingRelations( this ) };
+    const auto constReferencedRelations { QgsProject::instance()->relationManager()->referencedRelations( this ) };
     for ( const auto &rel : constReferencedRelations )
     {
-      QgsWeakRelation::writeXml( this, rel, referencingLayersElement, doc );
+      QgsWeakRelation::writeXml( this, QgsWeakRelation::Referenced, rel, referencingLayersElement, doc );
     }
 
   }

--- a/src/core/qgsweakrelation.h
+++ b/src/core/qgsweakrelation.h
@@ -110,12 +110,13 @@ class CORE_EXPORT QgsWeakRelation
      * Writes a weak relation infoto an XML structure. Used for saving .qgs projects
      *
      * \param layer the layer which we save the weak relation for
+     * \param type determines if the layer is referencing or referenced
      * \param relation the relation to save as a weak relation
      * \param node The parent node in which the relation will be created
      * \param doc  The document in which the relation will be saved
      * \since QGIS 3.16
      */
-    static void writeXml( const QgsVectorLayer *layer, const QgsRelation &relation, QDomNode &node, QDomDocument &doc );
+    static void writeXml( const QgsVectorLayer *layer, WeakRelationType type, const QgsRelation &relation, QDomNode &node, QDomDocument &doc );
 
   private:
 

--- a/tests/src/core/testqgsweakrelation.cpp
+++ b/tests/src/core/testqgsweakrelation.cpp
@@ -136,15 +136,17 @@ void TestQgsWeakRelation::testReadWrite()
       QStringLiteral( "qgis" ), QStringLiteral( "http://mrcc.com/qgis.dtd" ), QStringLiteral( "SYSTEM" ) );
   QDomDocument doc( documentType );
 
+  // Check the XML is written for the referenced layer
   QDomElement node = doc.createElement( QStringLiteral( "relation" ) );
-  QgsWeakRelation::writeXml( &referencedLayer, relation, node, doc );
+  QgsWeakRelation::writeXml( &referencedLayer, QgsWeakRelation::Referenced, relation, node, doc );
   QgsWeakRelation weakRelReferenced( QgsWeakRelation::readXml( &referencedLayer, QgsWeakRelation::Referenced, node,  QgsProject::instance()->pathResolver() ) );
   QCOMPARE( weakRelReferenced.fieldPairs(), fieldPairs );
   QCOMPARE( weakRelReferenced.strength(), QgsRelation::RelationStrength::Association );
   QCOMPARE( weakRelReferenced.referencedLayer().resolve( QgsProject::instance() ), &referencedLayer );
 
+  // Check the XML is written for the referencing layer
   node = doc.createElement( QStringLiteral( "relation" ) );
-  QgsWeakRelation::writeXml( &referencingLayer, relation, node, doc );
+  QgsWeakRelation::writeXml( &referencingLayer, QgsWeakRelation::Referencing, relation, node, doc );
   QgsWeakRelation weakRelReferencing( QgsWeakRelation::readXml( &referencingLayer, QgsWeakRelation::Referencing, node,  QgsProject::instance()->pathResolver() ) );
   QCOMPARE( weakRelReferencing.fieldPairs(), fieldPairs );
   QCOMPARE( weakRelReferencing.strength(), QgsRelation::RelationStrength::Association );


### PR DESCRIPTION
While hunting another bug, I came across a problem with the `QgsWeakRelation::writeXML()`.

See this: 

```xml
<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
<qgis version="3.15.0-Master" styleCategories="Relations">
 <referencedLayers>
  <relation layerName="d_interesadodocumentotipo" referencingLayer="Usuarios_79987b60_ba7d_4764_a431_85f0395acc24" layerId="d_interesadodocumentotipo_3cdfd0b5_f3a5_47b3_8b4e_c5123b770ce7" id="usuarios_estado_fkey" name="usuarios_estado_fkey" referencedLayer="d_estadotipo_2dfc9c87_9a87_49d0_981b_bf7304ae6ccc" dataSource="dbname='fdc_model_02' host=localhost port=5432 user='postgres' key='t_id' checkPrimaryKeyUnicity='1' table=&quot;coord_cecilia&quot;.&quot;d_interesadodocumentotipo&quot;" providerKey="postgres" strength="Association">
   <fieldRef referencedField="t_id" referencingField="estado"/>
  </relation>
  <relation referencingLayer="Usuarios_79987b60_ba7d_4764_a431_85f0395acc24" id="usuarios_rol_fkey" name="usuarios_rol_fkey" referencedLayer="d_roltipo_33a4f8aa_df75_4be1_82b9_bfdd89385240" strength="Association">
   <fieldRef referencedField="t_id" referencingField="rol"/>
  </relation>
  <relation referencingLayer="Usuarios_79987b60_ba7d_4764_a431_85f0395acc24" id="usuarios_tipo_documento_fkey" name="usuarios_tipo_documento_fkey" referencedLayer="d_interesadodocumentotipo_3cdfd0b5_f3a5_47b3_8b4e_c5123b770ce7" strength="Association">
   <fieldRef referencedField="t_id" referencingField="tipo_documento"/>
  </relation>
 </referencedLayers>
 <layerGeometryType>4</layerGeometryType>
</qgis>
```

The first relation tag has mixed attributes (2 referenced layers are there involved: `d_estadotipo` and `d_interesadodocumentotipo`).

Additionally, only the first relation element gets the weak relation attributes.


With the changes of the current PR, now I get this, as expected:

```xml
<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
<qgis styleCategories="Relations" version="3.15.0-Master">
 <referencedLayers>
  <relation id="usuarios_estado_fkey" name="usuarios_estado_fkey" strength="Association" layerName="d_estadotipo" layerId="d_estadotipo_f8e4e87f_82f3_41d4_8649_0730841e13dc" dataSource="dbname='fdc_model_02' host=localhost port=5432 user='postgres' key='t_id' checkPrimaryKeyUnicity='1' table=&quot;coord_cecilia&quot;.&quot;d_estadotipo&quot;" referencingLayer="Usuarios_d42bd9b2_06b6_4924_b546_44721cc33687" providerKey="postgres" referencedLayer="d_estadotipo_f8e4e87f_82f3_41d4_8649_0730841e13dc">
   <fieldRef referencedField="t_id" referencingField="estado"/>
  </relation>
  <relation id="usuarios_rol_fkey" name="usuarios_rol_fkey" strength="Association" layerName="d_roltipo" layerId="d_roltipo_6354e952_5b91_40bb_b077_d624c9b92410" dataSource="dbname='fdc_model_02' host=localhost port=5432 user='postgres' key='t_id' checkPrimaryKeyUnicity='1' table=&quot;coord_cecilia&quot;.&quot;d_roltipo&quot;" referencingLayer="Usuarios_d42bd9b2_06b6_4924_b546_44721cc33687" providerKey="postgres" referencedLayer="d_roltipo_6354e952_5b91_40bb_b077_d624c9b92410">
   <fieldRef referencedField="t_id" referencingField="rol"/>
  </relation>
  <relation id="usuarios_tipo_documento_fkey" name="usuarios_tipo_documento_fkey" strength="Association" layerName="d_interesadodocumentotipo" layerId="d_interesadodocumentotipo_fb800a5b_a6e5_4dbd_bf78_1bfd08a2353a" dataSource="dbname='fdc_model_02' host=localhost port=5432 user='postgres' key='t_id' checkPrimaryKeyUnicity='1' table=&quot;coord_cecilia&quot;.&quot;d_interesadodocumentotipo&quot;" referencingLayer="Usuarios_d42bd9b2_06b6_4924_b546_44721cc33687" providerKey="postgres" referencedLayer="d_interesadodocumentotipo_fb800a5b_a6e5_4dbd_bf78_1bfd08a2353a">
   <fieldRef referencedField="t_id" referencingField="tipo_documento"/>
  </relation>
 </referencedLayers>
 <layerGeometryType>4</layerGeometryType>
</qgis>

```


Note: This PR is involved https://github.com/qgis/QGIS/pull/38681
@elpaso @3nids 
