### PR TITLE
Add QgsCPLHTTPFetchOverrider class and use it in OGR provider 

### DIFF
--- a/python/core/auto_generated/qgsblockingnetworkrequest.sip.in
+++ b/python/core/auto_generated/qgsblockingnetworkrequest.sip.in
@@ -91,6 +91,66 @@ can be retrieved by calling :py:func:`~QgsBlockingNetworkRequest.errorMessage`.
 .. seealso:: :py:func:`get`
 %End
 
+    ErrorCode head( QNetworkRequest &request, bool forceRefresh = false, QgsFeedback *feedback = 0 );
+%Docstring
+Performs a "head" operation on the specified ``request``.
+
+If ``forceRefresh`` is ``False`` then previously cached replies may be used for the request. If
+it is set to ``True`` then a new query is always performed.
+
+If an :py:func:`~QgsBlockingNetworkRequest.authCfg` has been set, then any authentication configuration required will automatically be applied to
+``request``. There is no need to manually apply the authentication to the request prior to calling
+this method.
+
+The optional ``feedback`` argument can be used to abort ongoing requests.
+
+The method will return NoError if the get operation was successful. The contents of the reply can be retrieved
+by calling :py:func:`~QgsBlockingNetworkRequest.reply`.
+
+If an error was encountered then a specific ErrorCode will be returned, and a detailed error message
+can be retrieved by calling :py:func:`~QgsBlockingNetworkRequest.errorMessage`.
+
+.. versionadded:: 3.18
+%End
+
+    ErrorCode put( QNetworkRequest &request, const QByteArray &data, QgsFeedback *feedback = 0 );
+%Docstring
+Performs a "put" operation on the specified ``request``, using the given ``data``.
+
+If an :py:func:`~QgsBlockingNetworkRequest.authCfg` has been set, then any authentication configuration required will automatically be applied to
+``request``. There is no need to manually apply the authentication to the request prior to calling
+this method.
+
+The optional ``feedback`` argument can be used to abort ongoing requests.
+
+The method will return NoError if the get operation was successful. The contents of the reply can be retrieved
+by calling :py:func:`~QgsBlockingNetworkRequest.reply`.
+
+If an error was encountered then a specific ErrorCode will be returned, and a detailed error message
+can be retrieved by calling :py:func:`~QgsBlockingNetworkRequest.errorMessage`.
+
+.. versionadded:: 3.18
+%End
+
+    ErrorCode deleteResource( QNetworkRequest &request, QgsFeedback *feedback = 0 );
+%Docstring
+Performs a "delete" operation on the specified ``request``.
+
+If an :py:func:`~QgsBlockingNetworkRequest.authCfg` has been set, then any authentication configuration required will automatically be applied to
+``request``. There is no need to manually apply the authentication to the request prior to calling
+this method.
+
+The optional ``feedback`` argument can be used to abort ongoing requests.
+
+The method will return NoError if the get operation was successful. The contents of the reply can be retrieved
+by calling :py:func:`~QgsBlockingNetworkRequest.reply`.
+
+If an error was encountered then a specific ErrorCode will be returned, and a detailed error message
+can be retrieved by calling :py:func:`~QgsBlockingNetworkRequest.errorMessage`.
+
+.. versionadded:: 3.18
+%End
+
     QString errorMessage() const;
 %Docstring
 Returns the error message string, after a :py:func:`~QgsBlockingNetworkRequest.get` or :py:func:`~QgsBlockingNetworkRequest.post` request has been made.\

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -257,6 +257,7 @@ SET(QGIS_CORE_SRCS
   qgscoordinatetransform_p.cpp
   qgscoordinatetransformcontext.cpp
   qgscoordinateutils.cpp
+  qgscplhttpfetchoverrider.cpp
   qgscredentials.cpp
   qgsdartmeasurement.cpp
   qgsdatabaseschemamodel.cpp

--- a/src/core/providers/ogr/qgsogrfeatureiterator.h
+++ b/src/core/providers/ogr/qgsogrfeatureiterator.h
@@ -43,6 +43,7 @@ class QgsOgrFeatureSource final: public QgsAbstractFeatureSource
 
   private:
     QString mDataSource;
+    QString mAuthCfg;
     bool mShareSameDatasetAmongLayers;
     QString mLayerName;
     int mLayerIndex;
@@ -71,6 +72,8 @@ class QgsOgrFeatureIterator final: public QgsAbstractFeatureIteratorFromSource<Q
 
     bool rewind() override;
     bool close() override;
+
+    void setInterruptionChecker( QgsFeedback *interruptionChecker ) override;
 
   protected:
     bool checkFeature( gdal::ogr_feature_unique_ptr &fet, QgsFeature &feature ) ;
@@ -102,6 +105,9 @@ class QgsOgrFeatureIterator final: public QgsAbstractFeatureIteratorFromSource<Q
 
     bool mFirstFieldIsFid = false;
     QgsFields mFieldsWithoutFid;
+    QString mAuthCfg;
+
+    QgsFeedback *mInterruptionChecker = nullptr;
 
     /* This flag tells the iterator when to skip all calls that might reset the reading (rewind),
      * to be used when the request is for a single fid or for a list of fids and we are inside

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -28,6 +28,7 @@ email                : sherman at mrcc.com
 #include "qgssettings.h"
 #include "qgsapplication.h"
 #include "qgsauthmanager.h"
+#include "qgscplhttpfetchoverrider.h"
 #include "qgsdataitem.h"
 #include "qgsdataprovider.h"
 #include "qgsfeature.h"
@@ -490,6 +491,18 @@ QgsOgrProvider::QgsOgrProvider( QString const &uri, const ProviderOptions &optio
                           mSubsetString,
                           mOgrGeometryTypeFilter,
                           mOpenOptions );
+
+  if ( mFilePath.contains( QLatin1String( "authcfg" ) ) )
+  {
+    QRegularExpression authcfgRe( " authcfg='([^']+)'" );
+    QRegularExpressionMatch match;
+    if ( mFilePath.contains( authcfgRe, &match ) )
+    {
+      mAuthCfg = match.captured( 1 );
+    }
+  }
+  QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
+  QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
 
   open( OpenModeInitial );
 
@@ -1364,6 +1377,9 @@ QgsRectangle QgsOgrProvider::extent() const
 {
   if ( !mExtent )
   {
+    QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
+    QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
+
     mExtent.reset( new OGREnvelope() );
 
     // get the extent_ (envelope) of the layer
@@ -1433,6 +1449,9 @@ QgsRectangle QgsOgrProvider::extent() const
 
 QVariant QgsOgrProvider::defaultValue( int fieldId ) const
 {
+  QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
+  QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
+
   if ( fieldId < 0 || fieldId >= mAttributeFields.count() )
     return QVariant();
 
@@ -1848,6 +1867,9 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags )
 
 bool QgsOgrProvider::addFeatures( QgsFeatureList &flist, Flags flags )
 {
+  QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
+  QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
+
   if ( !doInitialActionsForEdition() )
     return false;
 
@@ -1988,6 +2010,9 @@ bool QgsOgrProvider::addAttributeOGRLevel( const QgsField &field, bool &ignoreEr
 
 bool QgsOgrProvider::addAttributes( const QList<QgsField> &attributes )
 {
+  QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
+  QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
+
   if ( !doInitialActionsForEdition() )
     return false;
 
@@ -2106,6 +2131,9 @@ bool QgsOgrProvider::deleteAttributes( const QgsAttributeIds &attributes )
 
 bool QgsOgrProvider::renameAttributes( const QgsFieldNameMap &renamedAttributes )
 {
+  QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
+  QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
+
   if ( !doInitialActionsForEdition() )
     return false;
 
@@ -2194,6 +2222,9 @@ bool QgsOgrProvider::rollbackTransaction()
 bool QgsOgrProvider::_setSubsetString( const QString &theSQL, bool updateFeatureCount, bool updateCapabilities, bool hasExistingRef )
 {
   QgsCPLErrorHandler handler;
+
+  QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
+  QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
 
   if ( !mOgrOrigLayer )
     return false;
@@ -2307,6 +2338,9 @@ bool QgsOgrProvider::_setSubsetString( const QString &theSQL, bool updateFeature
 
 bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_map )
 {
+  QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
+  QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
+
   if ( !doInitialActionsForEdition() )
     return false;
 
@@ -2520,6 +2554,9 @@ bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
 
 bool QgsOgrProvider::changeGeometryValues( const QgsGeometryMap &geometry_map )
 {
+  QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
+  QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
+
   if ( !doInitialActionsForEdition() )
     return false;
 
@@ -2628,6 +2665,9 @@ bool QgsOgrProvider::changeGeometryValues( const QgsGeometryMap &geometry_map )
 
 bool QgsOgrProvider::createSpatialIndex()
 {
+  QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
+  QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
+
   if ( !mOgrOrigLayer )
     return false;
   if ( !doInitialActionsForEdition() )
@@ -2670,6 +2710,9 @@ QString QgsOgrProvider::createIndexName( QString tableName, QString field )
 
 bool QgsOgrProvider::createAttributeIndex( int field )
 {
+  QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
+  QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
+
   if ( field < 0 || field >= mAttributeFields.count() )
     return false;
 
@@ -2708,6 +2751,9 @@ bool QgsOgrProvider::createAttributeIndex( int field )
 
 bool QgsOgrProvider::deleteFeatures( const QgsFeatureIds &id )
 {
+  QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
+  QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
+
   if ( !doInitialActionsForEdition() )
     return false;
 
@@ -2764,6 +2810,9 @@ bool QgsOgrProvider::deleteFeatures( const QgsFeatureIds &id )
 
 bool QgsOgrProvider::deleteFeature( QgsFeatureId id )
 {
+  QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
+  QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
+
   if ( !doInitialActionsForEdition() )
     return false;
 

--- a/src/core/providers/ogr/qgsogrprovider.h
+++ b/src/core/providers/ogr/qgsogrprovider.h
@@ -163,6 +163,8 @@ class QgsOgrProvider final: public QgsVectorDataProvider
 
     QString filePath() const { return mFilePath; }
 
+    QString authCfg() const { return mAuthCfg; }
+
     int layerIndex() const { return mLayerIndex; }
 
     QByteArray quotedIdentifier( const QByteArray &field ) const;
@@ -254,6 +256,9 @@ class QgsOgrProvider final: public QgsVectorDataProvider
 
     //! path to filename
     QString mFilePath;
+
+    //! Authentication configuration
+    QString mAuthCfg;
 
     //! layer name
     QString mLayerName;

--- a/src/core/qgsblockingnetworkrequest.cpp
+++ b/src/core/qgsblockingnetworkrequest.cpp
@@ -61,8 +61,50 @@ QgsBlockingNetworkRequest::ErrorCode QgsBlockingNetworkRequest::get( QNetworkReq
 
 QgsBlockingNetworkRequest::ErrorCode QgsBlockingNetworkRequest::post( QNetworkRequest &request, const QByteArray &data, bool forceRefresh, QgsFeedback *feedback )
 {
-  mPostData = data;
+  mPayloadData = data;
   return doRequest( Post, request, forceRefresh, feedback );
+}
+
+QgsBlockingNetworkRequest::ErrorCode QgsBlockingNetworkRequest::head( QNetworkRequest &request, bool forceRefresh, QgsFeedback *feedback )
+{
+  return doRequest( Head, request, forceRefresh, feedback );
+}
+
+QgsBlockingNetworkRequest::ErrorCode QgsBlockingNetworkRequest::put( QNetworkRequest &request, const QByteArray &data, QgsFeedback *feedback )
+{
+  mPayloadData = data;
+  return doRequest( Put, request, true, feedback );
+}
+
+QgsBlockingNetworkRequest::ErrorCode QgsBlockingNetworkRequest::deleteResource( QNetworkRequest &request, QgsFeedback *feedback )
+{
+  return doRequest( Delete, request, true, feedback );
+}
+
+void QgsBlockingNetworkRequest::sendRequestToNetworkAccessManager( const QNetworkRequest &request )
+{
+  switch ( mMethod )
+  {
+    case Get:
+      mReply = QgsNetworkAccessManager::instance()->get( request );
+      break;
+
+    case Post:
+      mReply = QgsNetworkAccessManager::instance()->post( request, mPayloadData );
+      break;
+
+    case Head:
+      mReply = QgsNetworkAccessManager::instance()->head( request );
+      break;
+
+    case Put:
+      mReply = QgsNetworkAccessManager::instance()->put( request, mPayloadData );
+      break;
+
+    case Delete:
+      mReply = QgsNetworkAccessManager::instance()->deleteResource( request );
+      break;
+  };
 }
 
 QgsBlockingNetworkRequest::ErrorCode QgsBlockingNetworkRequest::doRequest( QgsBlockingNetworkRequest::Method method, QNetworkRequest &request, bool forceRefresh, QgsFeedback *feedback )
@@ -114,16 +156,7 @@ QgsBlockingNetworkRequest::ErrorCode QgsBlockingNetworkRequest::doRequest( QgsBl
 
     success = true;
 
-    switch ( mMethod )
-    {
-      case Get:
-        mReply = QgsNetworkAccessManager::instance()->get( request );
-        break;
-
-      case Post:
-        mReply = QgsNetworkAccessManager::instance()->post( request, mPostData );
-        break;
-    };
+    sendRequestToNetworkAccessManager( request );
 
     if ( mFeedback )
       connect( mFeedback, &QgsFeedback::canceled, mReply, &QNetworkReply::abort );
@@ -295,16 +328,8 @@ void QgsBlockingNetworkRequest::replyFinished()
           mReply = nullptr;
 
           QgsDebugMsgLevel( QStringLiteral( "redirected: %1 forceRefresh=%2" ).arg( redirect.toString() ).arg( mForceRefresh ), 2 );
-          switch ( mMethod )
-          {
-            case Get:
-              mReply = QgsNetworkAccessManager::instance()->get( request );
-              break;
 
-            case Post:
-              mReply = QgsNetworkAccessManager::instance()->post( request, mPostData );
-              break;
-          };
+          sendRequestToNetworkAccessManager( request );
 
           if ( mFeedback )
             connect( mFeedback, &QgsFeedback::canceled, mReply, &QNetworkReply::abort );
@@ -361,7 +386,7 @@ void QgsBlockingNetworkRequest::replyFinished()
 
         mReplyContent = QgsNetworkReplyContent( mReply );
         const QByteArray content = mReply->readAll();
-        if ( content.isEmpty() && !mGotNonEmptyResponse )
+        if ( content.isEmpty() && !mGotNonEmptyResponse && mMethod == Get )
         {
           mErrorMessage = tr( "empty response: %1" ).arg( mReply->errorString() );
           mErrorCode = ServerExceptionError;

--- a/src/core/qgsblockingnetworkrequest.h
+++ b/src/core/qgsblockingnetworkrequest.h
@@ -107,6 +107,66 @@ class CORE_EXPORT QgsBlockingNetworkRequest : public QObject
     ErrorCode post( QNetworkRequest &request, const QByteArray &data, bool forceRefresh = false, QgsFeedback *feedback = nullptr );
 
     /**
+     * Performs a "head" operation on the specified \a request.
+     *
+     * If \a forceRefresh is FALSE then previously cached replies may be used for the request. If
+     * it is set to TRUE then a new query is always performed.
+     *
+     * If an authCfg() has been set, then any authentication configuration required will automatically be applied to
+     * \a request. There is no need to manually apply the authentication to the request prior to calling
+     * this method.
+     *
+     * The optional \a feedback argument can be used to abort ongoing requests.
+     *
+     * The method will return NoError if the get operation was successful. The contents of the reply can be retrieved
+     * by calling reply().
+     *
+     * If an error was encountered then a specific ErrorCode will be returned, and a detailed error message
+     * can be retrieved by calling errorMessage().
+     *
+     * \since 3.18
+     */
+    ErrorCode head( QNetworkRequest &request, bool forceRefresh = false, QgsFeedback *feedback = nullptr );
+
+    /**
+     * Performs a "put" operation on the specified \a request, using the given \a data.
+     *
+     * If an authCfg() has been set, then any authentication configuration required will automatically be applied to
+     * \a request. There is no need to manually apply the authentication to the request prior to calling
+     * this method.
+     *
+     * The optional \a feedback argument can be used to abort ongoing requests.
+     *
+     * The method will return NoError if the get operation was successful. The contents of the reply can be retrieved
+     * by calling reply().
+     *
+     * If an error was encountered then a specific ErrorCode will be returned, and a detailed error message
+     * can be retrieved by calling errorMessage().
+     *
+     * \since 3.18
+     */
+    ErrorCode put( QNetworkRequest &request, const QByteArray &data, QgsFeedback *feedback = nullptr );
+
+    /**
+     * Performs a "delete" operation on the specified \a request.
+     *
+     * If an authCfg() has been set, then any authentication configuration required will automatically be applied to
+     * \a request. There is no need to manually apply the authentication to the request prior to calling
+     * this method.
+     *
+     * The optional \a feedback argument can be used to abort ongoing requests.
+     *
+     * The method will return NoError if the get operation was successful. The contents of the reply can be retrieved
+     * by calling reply().
+     *
+     * If an error was encountered then a specific ErrorCode will be returned, and a detailed error message
+     * can be retrieved by calling errorMessage().
+     *
+     * \since 3.18
+     */
+    ErrorCode deleteResource( QNetworkRequest &request, QgsFeedback *feedback = nullptr );
+
+    /**
      * Returns the error message string, after a get() or post() request has been made.\
      */
     QString errorMessage() const { return mErrorMessage; }
@@ -157,14 +217,17 @@ class CORE_EXPORT QgsBlockingNetworkRequest : public QObject
     enum Method
     {
       Get,
-      Post
+      Post,
+      Head,
+      Put,
+      Delete
     };
 
     //! The reply to the request
     QNetworkReply *mReply = nullptr;
 
     Method mMethod = Get;
-    QByteArray mPostData;
+    QByteArray mPayloadData;
 
     //! Authentication configuration ID
     QString mAuthCfg;
@@ -197,6 +260,7 @@ class CORE_EXPORT QgsBlockingNetworkRequest : public QObject
 
     QString errorMessageFailedAuth();
 
+    void sendRequestToNetworkAccessManager( const QNetworkRequest &request );
 };
 
 ///@cond PRIVATE

--- a/src/core/qgscplhttpfetchoverrider.cpp
+++ b/src/core/qgscplhttpfetchoverrider.cpp
@@ -1,0 +1,208 @@
+/***************************************************************************
+    qgscplhttpfetchoverrider.cpp
+    ----------------------------
+    begin                : September 2020
+    copyright            : (C) 2020 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscplhttpfetchoverrider.h"
+#include "qgslogger.h"
+#include "qgsblockingnetworkrequest.h"
+
+#include "cpl_http.h"
+#include "gdal.h"
+
+#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3,2,0)
+
+QgsCPLHTTPFetchOverrider::QgsCPLHTTPFetchOverrider( const QString &authCfg, QgsFeedback *feedback )
+{
+  Q_UNUSED( authCfg );
+  Q_UNUSED( feedback );
+  Q_UNUSED( mAuthCfg );
+  Q_UNUSED( mFeedback );
+}
+
+QgsCPLHTTPFetchOverrider::~QgsCPLHTTPFetchOverrider()
+{
+}
+
+#else
+
+QgsCPLHTTPFetchOverrider::QgsCPLHTTPFetchOverrider( const QString &authCfg, QgsFeedback *feedback ):
+  mAuthCfg( authCfg ),
+  mFeedback( feedback )
+{
+  CPLHTTPPushFetchCallback( QgsCPLHTTPFetchOverrider::callback, this );
+}
+
+QgsCPLHTTPFetchOverrider::~QgsCPLHTTPFetchOverrider()
+{
+  CPLHTTPPopFetchCallback();
+}
+
+
+CPLHTTPResult *QgsCPLHTTPFetchOverrider::callback( const char *pszURL,
+    CSLConstList papszOptions,
+    GDALProgressFunc /* pfnProgress */,
+    void * /*pProgressArg */,
+    CPLHTTPFetchWriteFunc pfnWrite,
+    void *pWriteArg,
+    void *pUserData )
+{
+  QgsCPLHTTPFetchOverrider *pThis = static_cast<QgsCPLHTTPFetchOverrider *>( pUserData );
+
+  auto psResult = static_cast<CPLHTTPResult *>( CPLCalloc( sizeof( CPLHTTPResult ), 1 ) );
+  if ( CSLFetchNameValue( papszOptions, "CLOSE_PERSISTENT" ) )
+  {
+    // CLOSE_PERSISTENT is a CPL trick to maintain a curl handle open over
+    // a series of CPLHTTPFetch() call to the same server.
+    // Just return a dummy result to acknowledge we 'processed' it
+    return psResult;
+  }
+
+  // Look for important options we don't handle yet
+  for ( const char *pszOption : { "FORM_FILE_PATH", "FORM_ITEM_COUNT" } )
+  {
+    if ( CSLFetchNameValue( papszOptions, pszOption ) )
+    {
+      QgsDebugMsg( QStringLiteral( "Option %1 not handled" ).arg( pszOption ) );
+      return nullptr;
+    }
+  }
+
+  QgsBlockingNetworkRequest blockingRequest;
+  blockingRequest.setAuthCfg( pThis->mAuthCfg );
+
+  QNetworkRequest request( QString::fromUtf8( pszURL ) );
+  for ( const auto &keyValue : pThis->mAttributes )
+  {
+    request.setAttribute( keyValue.first, keyValue.second );
+  }
+
+  // Store request headers
+  const char *pszHeaders = CSLFetchNameValue( papszOptions, "HEADERS" );
+  if ( pszHeaders )
+  {
+    char **papszTokensHeaders = CSLTokenizeString2( pszHeaders, "\r\n", 0 );
+    for ( int i = 0; papszTokensHeaders[i] != nullptr; ++i )
+    {
+      char *pszKey = nullptr;
+      const char *pszValue = CPLParseNameValue( papszTokensHeaders[i], &pszKey );
+      if ( pszKey && pszValue )
+      {
+        request.setRawHeader(
+          QByteArray::fromStdString( pszKey ),
+          QByteArray::fromStdString( pszValue ) );
+      }
+      CPLFree( pszKey );
+    }
+    CSLDestroy( papszTokensHeaders );
+  }
+
+  constexpr bool forceRefresh = true;
+  const char *pszCustomRequest = CSLFetchNameValue( papszOptions, "CUSTOMREQUEST" );
+  const char *pszPostFields = CSLFetchNameValue( papszOptions, "POSTFIELDS" );
+  QgsBlockingNetworkRequest::ErrorCode errCode;
+  if ( pszPostFields )
+  {
+    if ( pszCustomRequest == nullptr || EQUAL( pszCustomRequest, "POST" ) )
+    {
+      errCode = blockingRequest.post( request,
+                                      QByteArray::fromStdString( pszPostFields ),
+                                      forceRefresh,
+                                      pThis->mFeedback );
+    }
+    else if ( EQUAL( pszCustomRequest, "PUT" ) )
+    {
+      errCode = blockingRequest.put( request,
+                                     QByteArray::fromStdString( pszPostFields ),
+                                     pThis->mFeedback );
+    }
+    else
+    {
+      QgsDebugMsg( QStringLiteral( "Invalid CUSTOMREQUEST = %1 when POSTFIELDS is defined" ).arg( pszCustomRequest ) );
+      return nullptr;
+    }
+  }
+  else
+  {
+    if ( pszCustomRequest == nullptr || EQUAL( pszCustomRequest, "GET" ) )
+    {
+      errCode = blockingRequest.get( request, forceRefresh, pThis->mFeedback );
+    }
+    else if ( EQUAL( pszCustomRequest, "HEAD" ) )
+    {
+      errCode = blockingRequest.head( request, forceRefresh, pThis->mFeedback );
+    }
+    else if ( EQUAL( pszCustomRequest, "DELETE" ) )
+    {
+      errCode = blockingRequest.deleteResource( request, pThis->mFeedback );
+    }
+    else
+    {
+      QgsDebugMsg( QStringLiteral( "Invalid CUSTOMREQUEST = %1 when POSTFIELDS is not defined" ).arg( pszCustomRequest ) );
+      return nullptr;
+    }
+  }
+  if ( errCode != QgsBlockingNetworkRequest::NoError )
+  {
+    psResult->nStatus = 1;
+    psResult->pszErrBuf = CPLStrdup( blockingRequest.errorMessage().toUtf8() );
+    return psResult;
+  }
+
+  QgsNetworkReplyContent reply( blockingRequest.reply() );
+
+  // Store response headers
+  for ( const auto &pair : reply.rawHeaderPairs() )
+  {
+    if ( EQUAL( pair.first.toStdString().c_str(), "Content-Type" ) )
+    {
+      CPLFree( psResult->pszContentType );
+      psResult->pszContentType = CPLStrdup( pair.second.toStdString().c_str() );
+    }
+    psResult->papszHeaders = CSLAddNameValue(
+                               psResult->papszHeaders,
+                               pair.first.toStdString().c_str(),
+                               pair.second.toStdString().c_str() );
+  }
+
+  // Process content
+  QByteArray content( reply.content() );
+
+  // Poor-man implementation of the pfnWrite mechanism which is supposed to be
+  // called on the fly as bytes are received
+  if ( pfnWrite )
+  {
+    if ( static_cast<int>( pfnWrite( content.data(), 1, content.size(), pWriteArg ) ) != content.size() )
+    {
+      psResult->nStatus = 1;
+      psResult->pszErrBuf = CPLStrdup( "download interrupted by user" );
+      return psResult;
+    }
+  }
+  else
+  {
+    psResult->nDataLen = static_cast<int>( content.size() );
+    psResult->pabyData = static_cast<GByte *>( CPLMalloc( psResult->nDataLen + 1 ) );
+    memcpy( psResult->pabyData, content.constData(), psResult->nDataLen );
+    psResult->pabyData[psResult->nDataLen] = 0;
+  }
+
+  return psResult;
+}
+
+#endif
+
+void QgsCPLHTTPFetchOverrider::setAttribute( QNetworkRequest::Attribute code, const QVariant &value )
+{
+  mAttributes[code] = value;
+}

--- a/src/core/qgscplhttpfetchoverrider.h
+++ b/src/core/qgscplhttpfetchoverrider.h
@@ -1,0 +1,75 @@
+/***************************************************************************
+    qgscplhttpfetchoverrider.h
+    --------------------------
+    begin                : September 2020
+    copyright            : (C) 2020 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSCPLHTTPFETCHOVERRIDER_H
+#define QGSCPLHTTPFETCHOVERRIDER_H
+
+#define SIP_NO_FILE
+
+#include <QNetworkRequest>
+#include <QString>
+#include "qgsnetworkaccessmanager.h" // for QgsSetRequestInitiatorClass
+
+#include "cpl_http.h"
+#include "gdal.h"
+
+class QgsFeedback;
+
+#ifndef SIP_RUN
+#define QgsSetCPLHTTPFetchOverriderInitiatorClass(overrider, _class) QgsSetRequestInitiatorClass(overrider, _class)
+#endif
+
+/**
+ * \ingroup core
+ * \class QgsCPLHTTPFetchOverrider
+ * \brief Utility class to redirect GDAL's CPL HTTP calls through QgsBlockingNetworkRequest
+ *
+ * The implementation is a no-op before GDAL 3.2
+ *
+ * \note not available in Python bindings
+ * \since QGIS 3.18
+ */
+class QgsCPLHTTPFetchOverrider
+{
+  public:
+    //! Installs the redirection for the current thread
+    explicit QgsCPLHTTPFetchOverrider( const QString &authCfg = QString(), QgsFeedback *feedback = nullptr );
+
+    //! Destructor
+    ~QgsCPLHTTPFetchOverrider();
+
+    //! Define attribute that must be forwarded to the actual QNetworkRequest
+    void setAttribute( QNetworkRequest::Attribute code, const QVariant &value );
+
+  private:
+
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,2,0)
+    static CPLHTTPResult *callback( const char *pszURL,
+                                    CSLConstList papszOptions,
+                                    GDALProgressFunc pfnProgress,
+                                    void *pProgressArg,
+                                    CPLHTTPFetchWriteFunc pfnWrite,
+                                    void *pWriteArg,
+                                    void *pUserData );
+#endif
+
+    QString mAuthCfg;
+
+    QgsFeedback *mFeedback = nullptr;
+
+    std::map<QNetworkRequest::Attribute, QVariant> mAttributes;
+};
+
+#endif // QGSCPLHTTPFETCHOVERRIDER_H

--- a/tests/src/python/mockedwebserver.py
+++ b/tests/src/python/mockedwebserver.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python
+###############################################################################
+# $Id$
+#
+# Project:  Adapted from GDAL/OGR Test Suite
+# Purpose:  Fake HTTP server
+# Author:   Even Rouault <even dot rouault at spatialys.com>
+#
+###############################################################################
+# Copyright (c) 2010-2020, Even Rouault <even dot rouault at spatialys.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+###############################################################################
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+
+import contextlib
+import time
+import sys
+
+do_log = False
+custom_handler = None
+
+
+@contextlib.contextmanager
+def install_http_handler(handler_instance):
+    global custom_handler
+    custom_handler = handler_instance
+    try:
+        yield
+    finally:
+        handler_instance.final_check()
+        custom_handler = None
+
+
+class RequestResponse(object):
+    def __init__(self, method, path, code, headers=None, body=None, custom_method=None, expected_headers=None, expected_body=None, add_content_length_header=True, unexpected_headers=[]):
+        self.method = method
+        self.path = path
+        self.code = code
+        self.headers = {} if headers is None else headers
+        self.body = body
+        self.custom_method = custom_method
+        self.expected_headers = {} if expected_headers is None else expected_headers
+        self.expected_body = expected_body
+        self.add_content_length_header = add_content_length_header
+        self.unexpected_headers = unexpected_headers
+
+
+class SequentialHandler(object):
+    def __init__(self):
+        self.req_count = 0
+        self.req_resp = []
+        self.unexpected = False
+
+    def final_check(self):
+        assert not self.unexpected
+        assert self.req_count == len(self.req_resp), (self.req_count, len(self.req_resp))
+
+    def add(self, method, path, code=None, headers=None, body=None, custom_method=None, expected_headers=None, expected_body=None, add_content_length_header=True, unexpected_headers=[]):
+        hdrs = {} if headers is None else headers
+        expected_hdrs = {} if expected_headers is None else expected_headers
+        req = RequestResponse(method, path, code, hdrs, body, custom_method, expected_hdrs, expected_body, add_content_length_header, unexpected_headers)
+        self.req_resp.append(req)
+        return req
+
+    def _process_req_resp(self, req_resp, request):
+        if req_resp.custom_method:
+            req_resp.custom_method(request)
+        else:
+
+            if req_resp.expected_headers:
+                for k in req_resp.expected_headers:
+                    if k not in request.headers or request.headers[k] != req_resp.expected_headers[k]:
+                        sys.stderr.write('Did not get expected headers: %s\n' % str(request.headers))
+                        request.send_response(400)
+                        request.send_header('Content-Length', 0)
+                        request.end_headers()
+                        self.unexpected = True
+                        return
+
+            for k in req_resp.unexpected_headers:
+                if k in request.headers:
+                    sys.stderr.write('Did not expect header: %s\n' % k)
+                    request.send_response(400)
+                    request.send_header('Content-Length', 0)
+                    request.end_headers()
+                    self.unexpected = True
+                    return
+
+            if req_resp.expected_body:
+                content = request.rfile.read(int(request.headers['Content-Length']))
+                if content != req_resp.expected_body:
+                    sys.stderr.write('Did not get expected content: %s\n' % content)
+                    request.send_response(400)
+                    request.send_header('Content-Length', 0)
+                    request.end_headers()
+                    self.unexpected = True
+                    return
+
+            request.send_response(req_resp.code)
+            for k in req_resp.headers:
+                request.send_header(k, req_resp.headers[k])
+            if req_resp.add_content_length_header:
+                if req_resp.body:
+                    request.send_header('Content-Length', len(req_resp.body))
+                elif 'Content-Length' not in req_resp.headers:
+                    request.send_header('Content-Length', '0')
+            request.end_headers()
+            if req_resp.body:
+                try:
+                    request.wfile.write(req_resp.body)
+                except:
+                    request.wfile.write(req_resp.body.encode('ascii'))
+
+    def process(self, method, request):
+        if self.req_count < len(self.req_resp):
+            req_resp = self.req_resp[self.req_count]
+            if method == req_resp.method and request.path == req_resp.path:
+                self.req_count += 1
+                self._process_req_resp(req_resp, request)
+                return
+
+        request.send_error(500, 'Unexpected %s request for %s, req_count = %d' % (method, request.path, self.req_count))
+        self.unexpected = True
+
+    def do_HEAD(self, request):
+        self.process('HEAD', request)
+
+    def do_GET(self, request):
+        self.process('GET', request)
+
+    def do_POST(self, request):
+        self.process('POST', request)
+
+    def do_PUT(self, request):
+        self.process('PUT', request)
+
+    def do_DELETE(self, request):
+        self.process('DELETE', request)
+
+
+class DispatcherHttpHandler(BaseHTTPRequestHandler):
+
+    # protocol_version = 'HTTP/1.1'
+
+    def log_request(self, code='-', size='-'):
+        # pylint: disable=unused-argument
+        pass
+
+    def do_HEAD(self):
+
+        if do_log:
+            f = open('/tmp/log.txt', 'a')
+            f.write('HEAD %s\n' % self.path)
+            f.close()
+
+        custom_handler.do_HEAD(self)
+
+    def do_DELETE(self):
+
+        if do_log:
+            f = open('/tmp/log.txt', 'a')
+            f.write('DELETE %s\n' % self.path)
+            f.close()
+
+        custom_handler.do_DELETE(self)
+
+    def do_POST(self):
+
+        if do_log:
+            f = open('/tmp/log.txt', 'a')
+            f.write('POST %s\n' % self.path)
+            f.close()
+
+        custom_handler.do_POST(self)
+
+    def do_PUT(self):
+
+        if do_log:
+            f = open('/tmp/log.txt', 'a')
+            f.write('PUT %s\n' % self.path)
+            f.close()
+
+        custom_handler.do_PUT(self)
+
+    def do_GET(self):
+
+        if do_log:
+            f = open('/tmp/log.txt', 'a')
+            f.write('GET %s\n' % self.path)
+            f.close()
+
+        custom_handler.do_GET(self)
+
+
+class ThreadedHttpServer(Thread):
+
+    def __init__(self, handlerClass):
+        Thread.__init__(self)
+        self.server = HTTPServer(('', 0), handlerClass)
+        self.running = False
+
+    def getPort(self):
+        return self.server.server_address[1]
+
+    def run(self):
+        try:
+            self.running = True
+            self.server.serve_forever()
+        except KeyboardInterrupt:
+            print('^C received, shutting down server')
+            self.stop()
+
+    def start_and_wait_ready(self):
+        self.start()
+        while not self.running:
+            time.sleep(1)
+
+    def stop(self):
+        self.server.shutdown()
+        self.server.server_close()
+
+
+def launch(handler=None):
+    if handler is None:
+        handler = DispatcherHttpHandler
+    server = ThreadedHttpServer(handler)
+    server.start_and_wait_ready()
+    return server, server.getPort()
+
+
+@contextlib.contextmanager
+def install_http_server(handler=None):
+    server, port = launch(handler)
+    try:
+        yield port
+    finally:
+        server.stop()

--- a/tests/src/python/test_qgsblockingnetworkrequest.py
+++ b/tests/src/python/test_qgsblockingnetworkrequest.py
@@ -15,6 +15,7 @@ __copyright__ = 'Copyright 2018, The QGIS Project'
 
 import qgis  # NOQA
 
+import mockedwebserver
 import os
 from qgis.testing import unittest, start_app
 from qgis.core import QgsBlockingNetworkRequest
@@ -22,9 +23,6 @@ from utilities import unitTestDataPath
 from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtNetwork import QNetworkReply, QNetworkRequest
-import socketserver
-import threading
-import http.server
 
 app = start_app()
 
@@ -33,16 +31,11 @@ class TestQgsBlockingNetworkRequest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        # Bring up a simple HTTP server
-        os.chdir(unitTestDataPath() + '')
-        handler = http.server.SimpleHTTPRequestHandler
+        cls.server, cls.port = mockedwebserver.launch()
 
-        cls.httpd = socketserver.TCPServer(('localhost', 0), handler)
-        cls.port = cls.httpd.server_address[1]
-
-        cls.httpd_thread = threading.Thread(target=cls.httpd.serve_forever)
-        cls.httpd_thread.setDaemon(True)
-        cls.httpd_thread.start()
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.stop()
 
     def testFetchEmptyUrl(self):
         request = QgsBlockingNetworkRequest()
@@ -67,10 +60,14 @@ class TestQgsBlockingNetworkRequest(unittest.TestCase):
     def testFetchBadUrl2(self):
         request = QgsBlockingNetworkRequest()
         spy = QSignalSpy(request.downloadFinished)
-        err = request.get(QNetworkRequest(QUrl('http://localhost:' + str(TestQgsBlockingNetworkRequest.port) + '/ffff')))
+
+        handler = mockedwebserver.SequentialHandler()
+        handler.add('GET', '/ffff', 404)
+        with mockedwebserver.install_http_handler(handler):
+            err = request.get(QNetworkRequest(QUrl('http://localhost:' + str(TestQgsBlockingNetworkRequest.port) + '/ffff')))
         self.assertEqual(len(spy), 1)
         self.assertEqual(err, QgsBlockingNetworkRequest.ServerExceptionError)
-        self.assertIn('File not found', request.errorMessage())
+        self.assertIn('Not Found', request.errorMessage())
         reply = request.reply()
         self.assertEqual(reply.error(), QNetworkReply.ContentNotFoundError)
         self.assertFalse(reply.content())
@@ -78,24 +75,71 @@ class TestQgsBlockingNetworkRequest(unittest.TestCase):
     def testGet(self):
         request = QgsBlockingNetworkRequest()
         spy = QSignalSpy(request.downloadFinished)
-        err = request.get(QNetworkRequest(QUrl('http://localhost:' + str(TestQgsBlockingNetworkRequest.port) + '/qgis_local_server/index.html')))
+        handler = mockedwebserver.SequentialHandler()
+        handler.add('GET', '/test.html', 200, {'Content-type': 'text/html'}, '<html></html>\n')
+        with mockedwebserver.install_http_handler(handler):
+            err = request.get(QNetworkRequest(QUrl('http://localhost:' + str(TestQgsBlockingNetworkRequest.port) + '/test.html')), True)
         self.assertEqual(len(spy), 1)
         self.assertEqual(err, QgsBlockingNetworkRequest.NoError)
         self.assertEqual(request.errorMessage(), '')
         reply = request.reply()
         self.assertEqual(reply.error(), QNetworkReply.NoError)
-        self.assertEqual(reply.content(), '<!DOCTYPE html>\n<html lang="en">\n<head>\n\t<meta charset="utf-8" />\n\t<title>Local QGIS Server Default Index</title>\n</head>\n<body>\n  <h2 style="font-family:Arial;">Web Server Working<h2/>\n</body>\n</html>\n')
+        self.assertEqual(reply.content(), '<html></html>\n')
         self.assertEqual(reply.rawHeaderList(), [b'Server',
                                                  b'Date',
                                                  b'Content-type',
-                                                 b'Content-Length',
-                                                 b'Last-Modified'])
+                                                 b'Content-Length'])
         self.assertEqual(reply.rawHeader(b'Content-type'), 'text/html')
         self.assertEqual(reply.rawHeader(b'xxxxxxxxx'), '')
         self.assertEqual(reply.attribute(QNetworkRequest.HttpStatusCodeAttribute), 200)
         self.assertEqual(reply.attribute(QNetworkRequest.HttpReasonPhraseAttribute), 'OK')
-        self.assertEqual(reply.attribute(QNetworkRequest.HttpStatusCodeAttribute), 200)
         self.assertEqual(reply.attribute(QNetworkRequest.RedirectionTargetAttribute), None)
+
+    def testHead(self):
+        request = QgsBlockingNetworkRequest()
+        spy = QSignalSpy(request.downloadFinished)
+        handler = mockedwebserver.SequentialHandler()
+        handler.add('HEAD', '/test.html', 200, {'Content-type': 'text/html'})
+        with mockedwebserver.install_http_handler(handler):
+            err = request.head(QNetworkRequest(QUrl('http://localhost:' + str(TestQgsBlockingNetworkRequest.port) + '/test.html')), True)
+        self.assertEqual(len(spy), 1)
+        self.assertEqual(err, QgsBlockingNetworkRequest.NoError)
+        self.assertEqual(request.errorMessage(), '')
+
+    def testPost(self):
+        request = QgsBlockingNetworkRequest()
+        spy = QSignalSpy(request.downloadFinished)
+        handler = mockedwebserver.SequentialHandler()
+        handler.add('POST', '/test.html', 200, expected_body=b"foo")
+        with mockedwebserver.install_http_handler(handler):
+            req = QNetworkRequest(QUrl('http://localhost:' + str(TestQgsBlockingNetworkRequest.port) + '/test.html'))
+            req.setHeader(QNetworkRequest.ContentTypeHeader, 'text/plain')
+            err = request.post(req, b"foo")
+        self.assertEqual(err, QgsBlockingNetworkRequest.NoError)
+        self.assertEqual(request.errorMessage(), '')
+
+    def testPut(self):
+        request = QgsBlockingNetworkRequest()
+        spy = QSignalSpy(request.downloadFinished)
+        handler = mockedwebserver.SequentialHandler()
+        handler.add('PUT', '/test.html', 200, expected_body=b"foo")
+        with mockedwebserver.install_http_handler(handler):
+            req = QNetworkRequest(QUrl('http://localhost:' + str(TestQgsBlockingNetworkRequest.port) + '/test.html'))
+            req.setHeader(QNetworkRequest.ContentTypeHeader, 'text/plain')
+            err = request.put(req, b"foo")
+        self.assertEqual(err, QgsBlockingNetworkRequest.NoError)
+        self.assertEqual(request.errorMessage(), '')
+
+    def testDelete(self):
+        request = QgsBlockingNetworkRequest()
+        spy = QSignalSpy(request.downloadFinished)
+        handler = mockedwebserver.SequentialHandler()
+        handler.add('DELETE', '/test.html', 200)
+        with mockedwebserver.install_http_handler(handler):
+            err = request.deleteResource(QNetworkRequest(QUrl('http://localhost:' + str(TestQgsBlockingNetworkRequest.port) + '/test.html')))
+        self.assertEqual(len(spy), 1)
+        self.assertEqual(err, QgsBlockingNetworkRequest.NoError)
+        self.assertEqual(request.errorMessage(), '')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This utility class redirects GDAL's CPL HTTP calls through QgsBlockingNetworkRequest,
for GDAL >= 3.2 (see OSGeo/gdal#2991)

And also QgsBlockingNetworkRequest: add head(), put() and deleteResource() methods

