### PR TITLE
OGR provider: make decodeUri() set a 'databaseName' component

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5471,8 +5471,8 @@ bool QgisApp::addVectorLayersPrivate( const QStringList &layerQStringList, const
       // Try to extract the database name and use it as base name
       // sublayers names (if any) will be appended to the layer name
       auto parts( QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "ogr" ), src ) );
-      if ( parts.value( QStringLiteral( "layerName" ) ).isValid() )
-        baseName = parts.value( QStringLiteral( "layerName" ) ).toString();
+      if ( parts.value( QStringLiteral( "databaseName" ) ).isValid() )
+        baseName = parts.value( QStringLiteral( "databaseName" ) ).toString();
       else
         baseName = src;
     }

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3424,6 +3424,7 @@ QVariantMap QgsOgrProviderMetadata::decodeUri( const QString &uri )
   QString layerName;
   QString subset;
   QString geometryType;
+  QString databaseName;
 
   int layerId = -1;
 
@@ -3486,12 +3487,12 @@ QVariantMap QgsOgrProviderMetadata::decodeUri( const QString &uri )
        uri.startsWith( QStringLiteral( "IDB" ), Qt::CaseSensitivity::CaseInsensitive ) ||
        uri.startsWith( QStringLiteral( "OCI" ), Qt::CaseSensitivity::CaseInsensitive ) )
   {
-    auto parts( uri.split( ':' ) );
+    auto parts( path.split( ':' ) );
     if ( parts.count( ) > 1 )
     {
       auto dataParts( parts.at( 1 ).split( ',' ) );
       if ( dataParts.count() > 0 )
-        layerName = dataParts.at( 0 );
+        databaseName = dataParts.at( 0 );
     }
   }
 
@@ -3507,6 +3508,8 @@ QVariantMap QgsOgrProviderMetadata::decodeUri( const QString &uri )
     uriComponents.insert( QStringLiteral( "subset" ), subset );
   if ( !geometryType.isEmpty() )
     uriComponents.insert( QStringLiteral( "geometryType" ), geometryType );
+  if ( !databaseName.isEmpty() )
+    uriComponents.insert( QStringLiteral( "databaseName" ), databaseName );
   return uriComponents;
 }
 

--- a/tests/src/core/testqgsogrprovider.cpp
+++ b/tests/src/core/testqgsogrprovider.cpp
@@ -125,15 +125,26 @@ void TestQgsOgrProvider::setupProxy()
 void TestQgsOgrProvider::decodeUri()
 {
   auto parts( QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "ogr" ), QStringLiteral( "MySQL:database_name,host=localhost,port=3306 authcfg='f8wwfx8'" ) ) );
-  QCOMPARE( parts.size(), 3 );
-  QCOMPARE( parts.value( QStringLiteral( "layerName" ) ).toString(), QString( "database_name" ) );
+  QCOMPARE( parts.size(), 4 );
+  QCOMPARE( parts.value( QStringLiteral( "databaseName" ) ).toString(), QString( "database_name" ) );
+  QVERIFY( parts.value( QStringLiteral( "layerName" ) ).toString().isEmpty() );
   QVERIFY( !parts.value( QStringLiteral( "layerId" ) ).isValid() );
   QCOMPARE( parts.value( QStringLiteral( "path" ) ).toString(), QString( "MySQL:database_name,host=localhost,port=3306 authcfg='f8wwfx8'" ) );
+  QCOMPARE( QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "ogr" ), parts ), QStringLiteral( "MySQL:database_name,host=localhost,port=3306 authcfg='f8wwfx8'" ) );
+
   parts = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "ogr" ), QStringLiteral( "MYSQL:westholland,user=root,password=psv9570,port=3306,tables=bedrijven" ) );
-  QCOMPARE( parts.size(), 3 );
-  QCOMPARE( parts.value( QStringLiteral( "layerName" ) ).toString(), QString( "westholland" ) );
+  QCOMPARE( parts.size(), 4 );
+  QCOMPARE( parts.value( QStringLiteral( "databaseName" ) ).toString(), QString( "westholland" ) );
   QVERIFY( !parts.value( QStringLiteral( "layerId" ) ).isValid() );
   QCOMPARE( parts.value( QStringLiteral( "path" ) ).toString(), QString( "MYSQL:westholland,user=root,password=psv9570,port=3306,tables=bedrijven" ) );
+
+  parts = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "ogr" ), QStringLiteral( "MYSQL:westholland|layername=foo" ) );
+  QCOMPARE( parts.size(), 4 );
+  QCOMPARE( parts.value( QStringLiteral( "databaseName" ) ).toString(), QString( "westholland" ) );
+  QCOMPARE( parts.value( QStringLiteral( "layerName" ) ).toString(), QString( "foo" ) );
+  QVERIFY( !parts.value( QStringLiteral( "layerId" ) ).isValid() );
+  QCOMPARE( parts.value( QStringLiteral( "path" ) ).toString(), QString( "MYSQL:westholland" ) );
+
   parts = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "ogr" ), QStringLiteral( "/path/to/a/geopackage.gpkg|layername=a_layer" ) );
   QCOMPARE( parts.size(), 3 );
   QCOMPARE( parts.value( QStringLiteral( "layerName" ) ).toString(), QString( "a_layer" ) );


### PR DESCRIPTION
Instead of hijacking 'layerName' which has a different semantics.

This modifies commit 84eed010f, which returns the database name in
the layerName URI component, which is not the right semantic, since
layerName should be a OGR layer name.

With this fix encodeUri() can roundtrip with decodeUri()
