### PR TITLE
[GUI] OGR Database connection dialog: relax checks to enable 'OK' button

### DIFF
--- a/src/gui/ogr/qgsnewogrconnection.cpp
+++ b/src/gui/ogr/qgsnewogrconnection.cpp
@@ -123,7 +123,7 @@ void QgsNewOgrConnection::showHelp()
 
 void QgsNewOgrConnection::updateOkButtonState()
 {
-  bool enabled = !txtName->text().isEmpty() && !txtHost->text().isEmpty() && !txtDatabase->text().isEmpty() && !txtPort->text().isEmpty();
+  bool enabled = !txtName->text().isEmpty();
   buttonBox->button( QDialogButtonBox::Ok )->setEnabled( enabled );
 }
 


### PR DESCRIPTION
Currently when defining a new OGR Database connection, one must fill
the database, host and port numbers. Some/most of them are optional on the
OGR side (for example the MYSQL driver only requires the database name,
but the PG driver could for example work without any depending on the PG
config), so do not require them at all. The 'Test connection' button is
already there for users to check they've properly filled the form.