### PR TITLE
[ogr] Fix decodeUri unable to handle newline characters in the subset string

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3433,7 +3433,7 @@ QVariantMap QgsOgrProviderMetadata::decodeUri( const QString &uri )
     const QRegularExpression geometryTypeRegex( QStringLiteral( "\\|geometrytype=([a-zA-Z0-9]*)" ) );
     const QRegularExpression layerNameRegex( QStringLiteral( "\\|layername=([^|]*)" ) );
     const QRegularExpression layerIdRegex( QStringLiteral( "\\|layerid=([^|]*)" ) );
-    const QRegularExpression subsetRegex( QStringLiteral( "\\|subset=(.*)$" ) );
+    const QRegularExpression subsetRegex( QStringLiteral( "\\|subset=((?:.*[\r\n]*)*)\\Z" ) );
 
 
     // we first try to split off the geometry type component, if that's present. That's a known quantity which

--- a/tests/src/core/testqgsogrprovider.cpp
+++ b/tests/src/core/testqgsogrprovider.cpp
@@ -220,12 +220,12 @@ void TestQgsOgrProvider::decodeUri()
   QVERIFY( !parts.value( QStringLiteral( "layerId" ) ).isValid() );
   QCOMPARE( parts.value( QStringLiteral( "subset" ) ).toString(), QString( "A IN (3,4,5) or \"b\"='x|layerid'" ) );
   QCOMPARE( parts.value( QStringLiteral( "path" ) ).toString(), QString( "/path/to/a/geopackage.gpkg" ) );
-  parts = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "ogr" ), QStringLiteral( "/path/to/a/geopackage.gpkg|layerid=4|subset=A IN (3,4,5) or \"b\"='x|layerid'|geometrytype=polygonz|layername=my_subset" ) );
+  parts = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "ogr" ), QStringLiteral( "/path/to/a/geopackage.gpkg|layerid=4|subset=A IN (3,4,5) or \n\"b\"='x|layerid'|geometrytype=polygonz|layername=my_subset" ) );
   QCOMPARE( parts.size(), 5 );
   QCOMPARE( parts.value( QStringLiteral( "layerName" ) ).toString(), QString( "my_subset" ) );
   QCOMPARE( parts.value( QStringLiteral( "geometryType" ) ).toString(), QString( "polygonz" ) );
   QVERIFY( !parts.value( QStringLiteral( "layerId" ) ).isValid() );
-  QCOMPARE( parts.value( QStringLiteral( "subset" ) ).toString(), QString( "A IN (3,4,5) or \"b\"='x|layerid'" ) );
+  QCOMPARE( parts.value( QStringLiteral( "subset" ) ).toString(), QString( "A IN (3,4,5) or \n\"b\"='x|layerid'" ) );
   QCOMPARE( parts.value( QStringLiteral( "path" ) ).toString(), QString( "/path/to/a/geopackage.gpkg" ) );
 }
 


### PR DESCRIPTION
## Description

The OGR provider's decoeUri function didn't handle newline characters in subset string properly, resulting in a broken decoded file path and missing subset part.

This was uncovered while testing PR #39104 .