### PR TITLE
remove warning when trying to pan to non spatial layer features

### DIFF
--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -583,7 +583,7 @@ void QgsDualView::panZoomGroupButtonToggled( QAbstractButton *button, bool check
     QgsSettings().setEnumValue( QStringLiteral( "/qgis/attributeTable/featureListBrowsingAction" ), NoAction );
   }
 
-  if ( checked )
+  if ( checked && mLayer->isSpatial() )
     panOrZoomToFeature( mFeatureListView->currentEditSelection() );
 }
 
@@ -618,7 +618,8 @@ void QgsDualView::featureListCurrentEditSelectionChanged( const QgsFeature &feat
     featureset << feat.id();
     setCurrentEditSelection( featureset );
 
-    panOrZoomToFeature( featureset );
+    if ( mLayer->isSpatial() )
+      panOrZoomToFeature( featureset );
 
   }
   else


### PR DESCRIPTION
These warnings were occurring from the attribute table / dual view.