### PR TITLE
change return type of QgsRasterDataProvider::clone()

### DIFF
--- a/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -96,7 +96,7 @@ source and it's parameters.
 The ``options`` argument specifies generic provider options and since QGIS 3.16 creation flags are specified within the ``flags`` value.
 %End
 
-    virtual QgsRasterInterface *clone() const = 0;
+    virtual QgsRasterDataProvider *clone() const = 0;
 
 
     virtual QgsRasterDataProvider::ProviderCapabilities providerCapabilities() const;

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -121,7 +121,7 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
                            const QgsDataProvider::ProviderOptions &providerOptions = QgsDataProvider::ProviderOptions(),
                            QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() );
 
-    QgsRasterInterface *clone() const override = 0;
+    QgsRasterDataProvider *clone() const override = 0;
 
     /**
      * Returns flags containing the supported capabilities of the data provider.

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -412,7 +412,7 @@ QgsLayerMetadata QgsAmsProvider::layerMetadata() const
   return mLayerMetadata;
 }
 
-QgsRasterInterface *QgsAmsProvider::clone() const
+QgsAmsProvider *QgsAmsProvider::clone() const
 {
   QgsDataProvider::ProviderOptions options;
   options.transformContext = transformContext();

--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -98,7 +98,7 @@ class QgsAmsProvider : public QgsRasterDataProvider
     QString lastError() override { return mError; }
     Qgis::DataType dataType( int /*bandNo*/ ) const override { return Qgis::ARGB32; }
     Qgis::DataType sourceDataType( int /*bandNo*/ ) const override { return Qgis::ARGB32; }
-    QgsRasterInterface *clone() const override;
+    QgsAmsProvider *clone() const override;
     QString htmlMetadata() override;
     bool supportsLegendGraphic() const override { return true; }
     QImage getLegendGraphic( double scale = 0, bool forceRefresh = false, const QgsRectangle *visibleExtent = nullptr ) override;

--- a/src/providers/grass/qgsgrassrasterprovider.cpp
+++ b/src/providers/grass/qgsgrassrasterprovider.cpp
@@ -167,7 +167,7 @@ QgsGrassRasterProvider::~QgsGrassRasterProvider()
   QgsDebugMsg( "QgsGrassRasterProvider: deconstructing." );
 }
 
-QgsRasterInterface *QgsGrassRasterProvider::clone() const
+QgsGrassRasterProvider *QgsGrassRasterProvider::clone() const
 {
   QgsGrassRasterProvider *provider = new QgsGrassRasterProvider( dataSourceUri() );
   provider->copyBaseSettings( *this );

--- a/src/providers/grass/qgsgrassrasterprovider.h
+++ b/src/providers/grass/qgsgrassrasterprovider.h
@@ -102,7 +102,7 @@ class GRASS_LIB_EXPORT QgsGrassRasterProvider : public QgsRasterDataProvider
 
     ~QgsGrassRasterProvider() override;
 
-    QgsRasterInterface *clone() const override;
+    QgsGrassRasterProvider *clone() const override;
 
     /**
      * Returns a provider name

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
@@ -695,7 +695,7 @@ int QgsPostgresRasterProvider::bandCount() const
   return mBandCount;
 }
 
-QgsRasterInterface *QgsPostgresRasterProvider::clone() const
+QgsPostgresRasterProvider *QgsPostgresRasterProvider::clone() const
 {
   QgsDataProvider::ProviderOptions options;
   options.transformContext = transformContext();

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.h
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.h
@@ -55,7 +55,7 @@ class QgsPostgresRasterProvider : public QgsRasterDataProvider
     // QgsRasterInterface interface
     virtual Qgis::DataType dataType( int bandNo ) const override;
     virtual int bandCount() const override;
-    virtual QgsRasterInterface *clone() const override;
+    virtual QgsPostgresRasterProvider *clone() const override;
     virtual Qgis::DataType sourceDataType( int bandNo ) const override;
     virtual int xBlockSize() const override;
     virtual int yBlockSize() const override;


### PR DESCRIPTION
To allow cloning of raster data provider without casting.
Not sure if it was intentionally QgsRasterInterface... 