### PR TITLE
[Oracle] Fix new connection greyed ok button

### DIFF
--- a/src/providers/oracle/qgsoraclenewconnection.cpp
+++ b/src/providers/oracle/qgsoraclenewconnection.cpp
@@ -195,6 +195,11 @@ void QgsOracleNewConnection::showHelp()
 
 void QgsOracleNewConnection::updateOkButtonState()
 {
-  bool enabled = !txtName->text().isEmpty() && !txtHost->text().isEmpty() && !txtPort->text().isEmpty() && !txtDatabase->text().isEmpty();
+  // User can set database without host and port, meaning he is using a service (tnsnames.ora)
+  // if he sets host, port has to be set also (and vice versa)
+  // https://github.com/qgis/QGIS/issues/38979
+
+  bool enabled = !txtName->text().isEmpty() && !txtDatabase->text().isEmpty()
+                 && ( txtHost->text().isEmpty() == txtPort->text().isEmpty() );
   buttonBox->button( QDialogButtonBox::Ok )->setEnabled( enabled );
 }

--- a/src/ui/qgsoraclenewconnectionbase.ui
+++ b/src/ui/qgsoraclenewconnectionbase.ui
@@ -55,7 +55,11 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_1">
       <item row="1" column="1" colspan="2">
-       <widget class="QLineEdit" name="txtDatabase"/>
+       <widget class="QLineEdit" name="txtDatabase">
+        <property name="toolTip">
+         <string>Database name, or service name (described in tnsnames.ora) if no host and port has been set</string>
+        </property>
+       </widget>
       </item>
       <item row="3" column="1" colspan="2">
        <widget class="QLineEdit" name="txtPort">


### PR DESCRIPTION
## Description

Fixes #38979 : When creating a new Oracle connection, database can be either the database name or a service name (described in tnsnames.ora file), so we don't have to disable the OK button when only database and name are set. 

At first, I planned to add a *Service* field like it's done in Postgres but it would break all Oracle existing configuration, so better not to.
