### PR TITLE
Commit data on scale changed for advanced snap configuration min/max scale

### DIFF
--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -129,6 +129,7 @@ QWidget *QgsSnappingLayerDelegate::createEditor( QWidget *parent, const QStyleOp
   {
     QgsScaleWidget *minLimitSp = new QgsScaleWidget( parent );
     minLimitSp->setToolTip( tr( "Minimum scale from which snapping is enabled (i.e. most \"zoomed out\" scale)" ) );
+    connect( minLimitSp, &QgsScaleWidget::scaleChanged, this, &QgsSnappingLayerDelegate::onScaleChanged );
     return minLimitSp;
   }
 
@@ -136,10 +137,16 @@ QWidget *QgsSnappingLayerDelegate::createEditor( QWidget *parent, const QStyleOp
   {
     QgsScaleWidget *maxLimitSp = new QgsScaleWidget( parent );
     maxLimitSp->setToolTip( tr( "Maximum scale up to which snapping is enabled (i.e. most \"zoomed in\" scale)" ) );
+    connect( maxLimitSp, &QgsScaleWidget::scaleChanged, this, &QgsSnappingLayerDelegate::onScaleChanged );
     return maxLimitSp;
   }
 
   return nullptr;
+}
+
+void QgsSnappingLayerDelegate::onScaleChanged()
+{
+  emit commitData( qobject_cast<QgsScaleWidget *>( sender() ) );
 }
 
 void QgsSnappingLayerDelegate::setEditorData( QWidget *editor, const QModelIndex &index ) const

--- a/src/app/qgssnappinglayertreemodel.h
+++ b/src/app/qgssnappinglayertreemodel.h
@@ -40,6 +40,9 @@ class APP_EXPORT QgsSnappingLayerDelegate : public QItemDelegate
     void setEditorData( QWidget *editor, const QModelIndex &index ) const override;
     void setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const override;
 
+  private slots:
+    void onScaleChanged();
+
   private:
     QgsMapCanvas *mCanvas = nullptr;
 };


### PR DESCRIPTION
## Description 

Fixes #39031 : commitData signal must be sent so the item view is aware that model needs to be updated

@obrix Is there any special reason why you use a QgsScaleWidget instead of a QgsScaleComboBox. The former just adds a button to get current scale from canvas but was not set as visible.