### PR TITLE
Fix broken layer dependencies for old projects

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2249,7 +2249,7 @@ const QList<QgsVectorLayerRef> QgisApp::findBrokenLayerDependencies( QgsVectorLa
 
         if ( found )
         {
-          // Make sure we don't add it twice
+          // Make sure we don't add it twice if it was already added by the form widgets check
           bool refFound = false;
           for ( const QgsVectorLayerRef &otherRef : qgis::as_const( brokenDependencies ) )
           {
@@ -2277,6 +2277,11 @@ void QgisApp::resolveVectorLayerDependencies( QgsVectorLayer *vl, QgsMapLayer::S
     const auto constDependencies { findBrokenLayerDependencies( vl, categories ) };
     for ( const QgsVectorLayerRef &dependency : constDependencies )
     {
+      // Temporary check for projects that were created before commit 7e8c7b3d0e094737336ff4834ea2af625d2921bf
+      if ( QgsProject::instance()->mapLayer( dependency.layerId ) )
+      {
+        continue;
+      }
       // try to aggressively resolve the broken dependencies
       bool loaded = false;
       const QString providerName { vl->dataProvider()->name() };

--- a/src/core/fieldformatter/qgsrelationreferencefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsrelationreferencefieldformatter.cpp
@@ -176,6 +176,13 @@ QVariant QgsRelationReferenceFieldFormatter::createCache( QgsVectorLayer *layer,
 
 QList<QgsVectorLayerRef> QgsRelationReferenceFieldFormatter::layerDependencies( const QVariantMap &config ) const
 {
+  // Old projects, create before the weak relations were introduced and stored with the
+  // widget configuration do not have the referenced layer details but only the "Relation" id,
+  // for these projects automatic loading of broken references is not supported.
+  if ( config.value( QStringLiteral( "ReferencedLayerId" ) ).toString().isEmpty() )
+  {
+    return {};
+  }
 
   const QList<QgsVectorLayerRef> result {{
       QgsVectorLayerRef(


### PR DESCRIPTION
Fixes #39025 by skipping the broken relations detection
for widget configuations that were created before weak
relations were introduced and add an extra check for
projects that were created before recent fixes in 3.15
with commit 7e8c7b3d0e09
