### PR TITLE
Return a proper QgsProviderConnectionException from python table()

### DIFF
--- a/python/core/auto_generated/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/qgsabstractdatabaseproviderconnection.sip.in
@@ -487,7 +487,7 @@ Raises a QgsProviderConnectionException if any errors are encountered.
 %End
 
 
-    virtual QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table ) const;
+    virtual QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table ) const throw( QgsProviderConnectionException );
 %Docstring
 Returns information on a ``table`` in the given ``schema``.
 Raises a QgsProviderConnectionException if any errors are encountered or if the table does not exist.

--- a/src/core/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/qgsabstractdatabaseproviderconnection.h
@@ -526,7 +526,7 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
      * \note Not available in Python bindings
      * \since QGIS 3.12
      */
-    virtual QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table ) const;
+    virtual QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table ) const SIP_THROW( QgsProviderConnectionException );
 
     /**
      * Returns information on the tables in the given schema.

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -354,6 +354,14 @@ IMPORT FOREIGN SCHEMA qgis_test LIMIT TO ( "someData" )
             'out_db',
             'spatial_index'}))
 
+    def test_exceptions(self):
+        """Test that exception are converted to Python QgsProviderConnectionException"""
+
+        md = QgsProviderRegistry.instance().providerMetadata('postgres')
+        conn = md.createConnection(self.uri, {})
+        with self.assertRaises(QgsProviderConnectionException):
+            conn.table('my_not_existent_schema', 'my_not_existent_table')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #39151

