### PR TITLE
Make interval output

### DIFF
--- a/resources/function_help/json/make_interval
+++ b/resources/function_help/json/make_interval
@@ -13,7 +13,8 @@
     {"arg":"seconds","description":"Number of seconds", "optional": true, "default": "0"}
   ],
   "examples": [
-    { "expression":"make_interval(hours:=3)", "returns":"3 hour interval"},
-    { "expression":"make_interval(days:=2, hours:=3)", "returns":"2 day, 3 hour interval"}
+    { "expression":"make_interval(hours:=3)", "returns":"interval: 3 hours"},
+    { "expression":"make_interval(days:=2, hours:=3)", "returns":"interval: 2.125 days"},
+    { "expression":"make_interval(minutes:=0.5, seconds:=5)", "returns":"interval: 35 seconds"}
   ]
 }

--- a/resources/function_help/json/to_interval
+++ b/resources/function_help/json/to_interval
@@ -4,6 +4,9 @@
   "groups": ["Conversions", "Date and Time"],
   "description": "Converts a string to an interval type. Can be used to take days, hours, month, etc of a date.",
   "arguments": [ {"arg":"string","description":"a string representing an interval. Allowable formats include {n} days {n} hours {n} months."}],
-  "examples": [ { "expression":"to_datetime('2012-05-05 12:00:00') - to_interval('1 day 2 hours')", "returns":"2012-05-04T10:00:00"}
+  "examples": [
+    { "expression":"to_interval('1 day 2 hours')", "returns":"interval: 1.08333 days"},
+    { "expression":"to_interval( '0.5 hours' )", "returns":"interval: 30 minutes"},
+    { "expression":"to_datetime('2012-05-05 12:00:00') - to_interval('1 day 2 hours')", "returns":"2012-05-04T10:00:00"}
   ]
 }

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -974,7 +974,6 @@ QString QgsExpression::formatPreviewString( const QVariant &value, const bool ht
   }
   else if ( value.canConvert< QgsInterval >() )
   {
-    //result is a feature
     QgsInterval interval = value.value<QgsInterval>();
     return startToken + tr( "interval: %1 days" ).arg( interval.days() ) + endToken;
   }

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -975,7 +975,22 @@ QString QgsExpression::formatPreviewString( const QVariant &value, const bool ht
   else if ( value.canConvert< QgsInterval >() )
   {
     QgsInterval interval = value.value<QgsInterval>();
-    return startToken + tr( "interval: %1 days" ).arg( interval.days() ) + endToken;
+    if ( interval.days() > 1 )
+    {
+      return startToken + tr( "interval: %1 days" ).arg( interval.days() ) + endToken;
+    }
+    else if ( interval.hours() > 1 )
+    {
+      return startToken + tr( "interval: %1 hours" ).arg( interval.hours() ) + endToken;
+    }
+    else if ( interval.minutes() > 1 )
+    {
+      return startToken + tr( "interval: %1 minutes" ).arg( interval.minutes() ) + endToken;
+    }
+    else
+    {
+      return startToken + tr( "interval: %1 seconds" ).arg( interval.seconds() ) + endToken;
+    }
   }
   else if ( value.canConvert< QgsGradientColorRamp >() )
   {


### PR DESCRIPTION
See: https://github.com/qgis/QGIS/issues/38073

The output in the examples of the 'make_interval' was not inline with the actual output.
The help said: make_interval(hours:=3) would show you: '3 hour interval) but the expression preview actually showed: 'interval: 0.125 days'
It turned out that the output of the interval was ALWAYS in days (only).
This commit will choose 'days', 'hours' or 'seconds' depending on the size of the interval (if > 1).
Both the examples of 'make_interval' and 'to_interval' are made inline with the actual output.
Screenie:
![Screenshot-20201004155553-1192x582](https://user-images.githubusercontent.com/731673/95017529-1ab7ab80-065a-11eb-8cb1-392b1da8b8b8.png)

As said in the issue, it would be possible (working with modulus) to create strings like: '1 days, 3 hours, 15 minutes and 3 seconds', but to me that seemed a little overkill for a string representation of an object?
