### PR TITLE
Make it possible to use 'inbuilt:'-uri with OGR provider

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -4616,6 +4616,12 @@ void QgsOgrProvider::open( OpenMode mode )
   {
     mFilePath += ",tables=" + mLayerName;
   }
+  else if ( mFilePath.startsWith( QLatin1String( "inbuilt:" ) ) )
+  {
+    // be able to use an 'inbuild:'-uri to load ogr data from QGIS resources
+    // eg in python: iface.addVectorLayer('inbuilt:/data/world_map.gpkg|layername=countries', 'Countries', 'ogr')
+    mFilePath = QgsApplication::pkgDataPath() + QStringLiteral( "/resources" ) + mFilePath.mid( 8 );
+  }
 
   if ( mode == OpenModeForceReadOnly )
     openReadOnly = true;


### PR DESCRIPTION
Not sure if this is still handy, but I was looking for some code to use the world map in the PyQGIS cookbook...

Loading the easter egg 'world' actually loads an inbuild gpkg from
the (install dir) resources directory.
It ends up in the project file with the eg following uri:
 source="inbuilt:/data/world_map.gpkg|layername=countries"
This commit makes it possible to actually (re)use that uri in the
OGR provider.

So in pyqgis you can now do:
```
iface.addVectorLayer('inbuilt:/data/world_map.gpkg|layername=countries', 'Countries', 'ogr')
```

I do not think this breaks anything?
I'm aware this also works
```
iface.addVectorLayer(QgsApplication.pkgDataPath() + '/resources/data/world_map.gpkg|layername=Countries', '', 'ogr')
```
