### PR TITLE
Add saturation sync when loading qml file, FIX: #39072

### DIFF
--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -770,6 +770,24 @@ void QgsRasterLayerProperties::sync()
     mGammaSpinBox->setValue( brightnessFilter->gamma() );
   }
 
+  // Hue and saturation color control
+  const QgsHueSaturationFilter *hueSaturationFilter = mRasterLayer->hueSaturationFilter();
+  //set hue and saturation controls to current values
+  if ( hueSaturationFilter )
+  {
+    sliderSaturation->setValue( hueSaturationFilter->saturation() );
+    comboGrayscale->setCurrentIndex( ( int ) hueSaturationFilter->grayscaleMode() );
+
+    // Set state of saturation controls based on grayscale mode choice
+    toggleSaturationControls( static_cast<int>( hueSaturationFilter->grayscaleMode() ) );
+
+    // Set state of colorize controls
+    mColorizeCheck->setChecked( hueSaturationFilter->colorizeOn() );
+    btnColorizeColor->setColor( hueSaturationFilter->colorizeColor() );
+    toggleColorizeControls( hueSaturationFilter->colorizeOn() );
+    sliderColorizeStrength->setValue( hueSaturationFilter->colorizeStrength() );
+  }
+
   /*
    * Transparent Pixel Tab
    */


### PR DESCRIPTION
## Description

FIX: #39072

As described by @elitonfilho, when a user loads a .qml file in the qgsRasterLayerProperties dialog, the related style was loaded but saturation widgets (slider, spinbox, combo box, etc) were not update in the dialog. If the user clicks on OK button the style was corrupted by dialog values.

This PR fixes it by synchronizing widgets with loaded values.