### PR TITLE
Don't silently close QGIS with unsaved changes in the console script

### DIFF
--- a/python/console/console.py
+++ b/python/console/console.py
@@ -562,8 +562,9 @@ class PythonConsoleWidget(QWidget):
         self.findScut.setContext(Qt.WidgetWithChildrenShortcut)
         self.findScut.activated.connect(self._closeFind)
 
-        self.exit_blocker = ConsoleExitBlocker(self)
-        iface.registerApplicationExitBlocker(self.exit_blocker)
+        if iface is not None:
+            self.exit_blocker = ConsoleExitBlocker(self)
+            iface.registerApplicationExitBlocker(self.exit_blocker)
 
     def allowExit(self):
         tab_count = self.tabEditorWidget.count()

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -1236,6 +1236,30 @@ Unregister a previously registered tool factory from the development/debugging t
 .. versionadded:: 3.14
 %End
 
+    virtual void registerApplicationExitBlocker( QgsApplicationExitBlockerInterface *blocker ) = 0;
+%Docstring
+Register a new application exit blocker, which can be used to prevent the QGIS application
+from exiting while a plugin or script has unsaved changes.
+
+.. note::
+
+   Ownership of ``blocker`` is not transferred, and the blocker must
+   be unregistered when plugin is unloaded.
+
+.. seealso:: :py:func:`unregisterApplicationExitBlocker`
+
+.. versionadded:: 3.16
+%End
+
+    virtual void unregisterApplicationExitBlocker( QgsApplicationExitBlockerInterface *blocker ) = 0;
+%Docstring
+Unregister a previously registered application exit ``blocker``.
+
+.. seealso:: :py:func:`registerApplicationExitBlocker`
+
+.. versionadded:: 3.16
+%End
+
     virtual void registerCustomDropHandler( QgsCustomDropHandler *handler ) = 0;
 %Docstring
 Register a new custom drop ``handler``.

--- a/python/gui/auto_generated/qgsapplicationexitblockerinterface.sip.in
+++ b/python/gui/auto_generated/qgsapplicationexitblockerinterface.sip.in
@@ -1,0 +1,77 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsapplicationexitblockerinterface.h                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsApplicationExitBlockerInterface
+{
+%Docstring
+An interface that may be implemented to allow plugins or scripts to temporarily block
+the QGIS application from exiting.
+
+This interface allows plugins to implement custom logic to determine whether it is safe
+for the application to exit, e.g. by checking whether the plugin or script has any
+unsaved changes which should be saved or discarded before allowing QGIS to exit.
+
+QgsApplicationExitBlockerInterface are registered via the iface object:
+
+Example
+-------
+
+.. code-block:: python
+
+       class MyPluginExitBlocker(QgsApplicationExitBlockerInterface):
+
+          def allowExit(self):
+              if self.has_unsaved_changes():
+                  # show a warning prompt
+                  # ...
+                  # prevent QGIS application from exiting
+                  return False
+
+              # allow QGIS application to exit
+              return True
+
+       my_blocker = MyPluginExitBlocker()
+       iface.registerApplicationExitBlocker(my_blocker)
+
+.. versionadded:: 3.16
+%End
+
+%TypeHeaderCode
+#include "qgsapplicationexitblockerinterface.h"
+%End
+  public:
+
+    virtual ~QgsApplicationExitBlockerInterface();
+
+    virtual bool allowExit() = 0;
+%Docstring
+Called whenever the QGIS application has been asked to exit by a user.
+
+The subclass can use this method to implement custom logic handling whether it is safe
+for the application to exit, e.g. by checking whether the plugin or script has any unsaved
+changes which should be saved or discarded before allowing QGIS to exit.
+
+The implementation should return ``True`` if it is safe for QGIS to exit, or ``False`` if it
+wishes to prevent the application from exiting.
+
+.. note::
+
+   It is safe to use GUI widgets in implementations of this function, including message
+   boxes or custom dialogs with event loops.
+%End
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsapplicationexitblockerinterface.h                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -7,6 +7,7 @@
 %Include auto_generated/qgsadvanceddigitizingfloater.sip
 %Include auto_generated/qgsaggregatetoolbutton.sip
 %Include auto_generated/qgsalignmentcombobox.sip
+%Include auto_generated/qgsapplicationexitblockerinterface.sip
 %Include auto_generated/qgsattributedialog.sip
 %Include auto_generated/qgsattributeeditorcontext.sip
 %Include auto_generated/qgsattributeform.sip

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -111,6 +111,7 @@ class Qgs3DMapCanvasDockWidget;
 class QgsHandleBadLayersHandler;
 class QgsNetworkAccessManager;
 class QgsGpsConnection;
+class QgsApplicationExitBlockerInterface;
 
 class QDomDocument;
 class QNetworkReply;
@@ -745,6 +746,23 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     //! Unregister a previously registered dev tool factory
     void unregisterDevToolFactory( QgsDevToolWidgetFactory *factory );
+
+    /**
+     * Register a new application exit blocker, which can be used to prevent the QGIS application
+     * from exiting while a plugin or script has unsaved changes.
+     *
+     * \note Ownership of \a blocker is not transferred, and the blocker must
+     *       be unregistered when plugin is unloaded.
+     *
+     * \see unregisterApplicationExitBlocker()
+     */
+    void registerApplicationExitBlocker( QgsApplicationExitBlockerInterface *blocker );
+
+    /**
+     * Unregister a previously registered application exit \a blocker.
+     * \see registerApplicationExitBlocker()
+    */
+    void unregisterApplicationExitBlocker( QgsApplicationExitBlockerInterface *blocker );
 
     //! Register a new custom drop handler.
     void registerCustomDropHandler( QgsCustomDropHandler *handler );
@@ -2094,6 +2112,12 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      */
     bool checkMemoryLayers();
 
+    /**
+     * Checks whether any registered application exit blockers should prevent
+     * the application from exiting.
+     */
+    bool checkExitBlockers();
+
     //! Checks for running tasks dependent on the open project
     bool checkTasksDependOnProject();
 
@@ -2568,6 +2592,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QList<QPointer<QgsOptionsWidgetFactory>> mProjectPropertiesWidgetFactories;
 
     QList<QgsDevToolWidgetFactory * > mDevToolFactories;
+
+    QList<QgsApplicationExitBlockerInterface * > mApplicationExitBlockers;
 
     QVector<QPointer<QgsCustomDropHandler>> mCustomDropHandlers;
     QVector<QPointer<QgsCustomProjectOpenHandler>> mCustomProjectOpenHandlers;

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -571,6 +571,16 @@ void QgisAppInterface::unregisterDevToolWidgetFactory( QgsDevToolWidgetFactory *
   qgis->unregisterDevToolFactory( factory );
 }
 
+void QgisAppInterface::registerApplicationExitBlocker( QgsApplicationExitBlockerInterface *blocker )
+{
+  qgis->registerApplicationExitBlocker( blocker );
+}
+
+void QgisAppInterface::unregisterApplicationExitBlocker( QgsApplicationExitBlockerInterface *blocker )
+{
+  qgis->unregisterApplicationExitBlocker( blocker );
+}
+
 void QgisAppInterface::registerCustomDropHandler( QgsCustomDropHandler *handler )
 {
   qgis->registerCustomDropHandler( handler );

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -150,6 +150,8 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     void unregisterProjectPropertiesWidgetFactory( QgsOptionsWidgetFactory *factory ) override;
     void registerDevToolWidgetFactory( QgsDevToolWidgetFactory *factory ) override;
     void unregisterDevToolWidgetFactory( QgsDevToolWidgetFactory *factory ) override;
+    void registerApplicationExitBlocker( QgsApplicationExitBlockerInterface *blocker ) override;
+    void unregisterApplicationExitBlocker( QgsApplicationExitBlockerInterface *blocker ) override;
     void registerCustomDropHandler( QgsCustomDropHandler *handler ) override;
     void unregisterCustomDropHandler( QgsCustomDropHandler *handler ) override;
     void registerCustomProjectOpenHandler( QgsCustomProjectOpenHandler *handler ) override;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -592,6 +592,7 @@ SET(QGIS_GUI_HDRS
   qgsadvanceddigitizingfloater.h
   qgsaggregatetoolbutton.h
   qgsalignmentcombobox.h
+  qgsapplicationexitblockerinterface.h
   qgsattributedialog.h
   qgsattributeeditorcontext.h
   qgsattributeform.h

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -65,6 +65,7 @@ class QgsMeshLayer;
 class QgsBrowserGuiModel;
 class QgsDevToolWidgetFactory;
 class QgsGpsConnection;
+class QgsApplicationExitBlockerInterface;
 
 
 /**
@@ -1024,6 +1025,25 @@ class GUI_EXPORT QgisInterface : public QObject
      * \since QGIS 3.14
     */
     virtual void unregisterDevToolWidgetFactory( QgsDevToolWidgetFactory *factory ) = 0;
+
+    /**
+     * Register a new application exit blocker, which can be used to prevent the QGIS application
+     * from exiting while a plugin or script has unsaved changes.
+     *
+     * \note Ownership of \a blocker is not transferred, and the blocker must
+     *       be unregistered when plugin is unloaded.
+     *
+     * \see unregisterApplicationExitBlocker()
+     * \since QGIS 3.16
+     */
+    virtual void registerApplicationExitBlocker( QgsApplicationExitBlockerInterface *blocker ) = 0;
+
+    /**
+     * Unregister a previously registered application exit \a blocker.
+     * \see registerApplicationExitBlocker()
+     * \since QGIS 3.16
+    */
+    virtual void unregisterApplicationExitBlocker( QgsApplicationExitBlockerInterface *blocker ) = 0;
 
     /**
      * Register a new custom drop \a handler.

--- a/src/gui/qgsapplicationexitblockerinterface.h
+++ b/src/gui/qgsapplicationexitblockerinterface.h
@@ -1,0 +1,78 @@
+/***************************************************************************
+    qgsapplicationexitblockerinterface.h
+    ---------------------
+    begin                : October 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSAPPLICATIONEXITBLOCKERINTERFACE_H
+#define QGSAPPLICATIONEXITBLOCKERINTERFACE_H
+
+#include "qgis_gui.h"
+#include <QStringList>
+#include <QObject>
+
+/**
+ * \ingroup gui
+ * An interface that may be implemented to allow plugins or scripts to temporarily block
+ * the QGIS application from exiting.
+ *
+ * This interface allows plugins to implement custom logic to determine whether it is safe
+ * for the application to exit, e.g. by checking whether the plugin or script has any
+ * unsaved changes which should be saved or discarded before allowing QGIS to exit.
+ *
+ * QgsApplicationExitBlockerInterface are registered via the iface object:
+ *
+ * ### Example
+ *
+ * \code{.py}
+ *   class MyPluginExitBlocker(QgsApplicationExitBlockerInterface):
+ *
+ *      def allowExit(self):
+ *          if self.has_unsaved_changes():
+ *              # show a warning prompt
+ *              # ...
+ *              # prevent QGIS application from exiting
+ *              return False
+ *
+ *          # allow QGIS application to exit
+ *          return True
+ *
+ *   my_blocker = MyPluginExitBlocker()
+ *   iface.registerApplicationExitBlocker(my_blocker)
+ * \endcode
+ *
+ * \since QGIS 3.16
+ */
+class GUI_EXPORT QgsApplicationExitBlockerInterface
+{
+
+  public:
+
+    virtual ~QgsApplicationExitBlockerInterface() = default;
+
+    /**
+     * Called whenever the QGIS application has been asked to exit by a user.
+     *
+     * The subclass can use this method to implement custom logic handling whether it is safe
+     * for the application to exit, e.g. by checking whether the plugin or script has any unsaved
+     * changes which should be saved or discarded before allowing QGIS to exit.
+     *
+     * The implementation should return TRUE if it is safe for QGIS to exit, or FALSE if it
+     * wishes to prevent the application from exiting.
+     *
+     * \note It is safe to use GUI widgets in implementations of this function, including message
+     * boxes or custom dialogs with event loops.
+    */
+    virtual bool allowExit() = 0;
+};
+
+#endif // QgsCustomProjectOpenHandler_H


### PR DESCRIPTION
This leads to data loss, so instead prompt the user what to do with the unsaved changes before exiting

Also adds an interface for plugins and scripts to register custom logic to prevent the QGIS application from exiting, so that plugins can implement custom logic to determine whether it is safe for the application to exit, e.g. by checking whether the plugin or script has any unsaved changes which should be saved or discarded before allowing QGIS to exit.