### PR TITLE
[processing] Fix crash in model designer when a child algorithm contains hidden parameters

### DIFF
--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -183,11 +183,11 @@ void QgsModelGraphicsScene::createItems( QgsProcessingModelAlgorithm *model, Qgs
             addItem( arrow );
           }
         }
+        if ( parameter->isDestination() )
+          bottomIdx++;
+        else
+          topIdx++;
       }
-      if ( parameter->isDestination() )
-        bottomIdx++;
-      else
-        topIdx++;
     }
     const QList< QgsProcessingModelChildDependency > dependencies = it.value().dependencies();
     for ( const QgsProcessingModelChildDependency &depend : dependencies )


### PR DESCRIPTION
Supersedes https://github.com/qgis/QGIS/pull/39009