### PR TITLE
[gps] Ensure that the status bar GPS distance readout only shows in response to a mouse action

### DIFF
--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -1634,12 +1634,14 @@ void QgsGpsInformationWidget::updateGpsDistanceStatusMessage( bool forceDisplay 
   if ( !mNmea )
     return;
 
+  static constexpr int GPS_DISTANCE_MESSAGE_TIMEOUT_MS = 2000;
+
   if ( !forceDisplay )
   {
     // if we aren't forcing the display of the message (i.e. in direct response to a mouse cursor movement),
     // then only show an updated message when the GPS position changes if the previous forced message occurred < 2 seconds ago.
     // otherwise we end up showing infinite messages as the GPS position constantly changes...
-    if ( mLastForcedStatusUpdate.hasExpired( 2000 ) )
+    if ( mLastForcedStatusUpdate.hasExpired( GPS_DISTANCE_MESSAGE_TIMEOUT_MS ) )
       return;
   }
   else
@@ -1654,7 +1656,8 @@ void QgsGpsInformationWidget::updateGpsDistanceStatusMessage( bool forceDisplay 
   const QString distanceString = QgsDistanceArea::formatDistance( distance, distanceDecimalPlaces, QgsProject::instance()->distanceUnits() );
   const QString bearingString = mBearingNumericFormat->formatDouble( bearing, QgsNumericFormatContext() );
 
-  QgisApp::instance()->statusBarIface()->showMessage( tr( "%1 (%2) from GPS location" ).arg( distanceString, bearingString ), forceDisplay ? 2000 : 2000 - mLastForcedStatusUpdate.elapsed() );
+  QgisApp::instance()->statusBarIface()->showMessage( tr( "%1 (%2) from GPS location" ).arg( distanceString, bearingString ), forceDisplay ? GPS_DISTANCE_MESSAGE_TIMEOUT_MS
+      : GPS_DISTANCE_MESSAGE_TIMEOUT_MS - mLastForcedStatusUpdate.elapsed() );
 }
 
 void QgsGpsInformationWidget::updateTimestampDestinationFields( QgsMapLayer *mapLayer )

--- a/src/app/gps/qgsgpsinformationwidget.h
+++ b/src/app/gps/qgsgpsinformationwidget.h
@@ -136,7 +136,7 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, public QgsMapCa
 #endif
     void createRubberBand();
 
-    void updateGpsDistanceStatusMessage();
+    void updateGpsDistanceStatusMessage( bool forceDisplay );
 
     QgsCoordinateReferenceSystem mWgs84CRS;
     QgsCoordinateTransform mCanvasToWgs84Transform;
@@ -170,6 +170,7 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, public QgsMapCa
     std::unique_ptr< QgsBearingNumericFormat > mBearingNumericFormat;
 
     QElapsedTimer mLastRotateTimer;
+    QElapsedTimer mLastForcedStatusUpdate;
 
     friend class TestQgsGpsInformationWidget;
 };


### PR DESCRIPTION
... and doesn't always re-show as a result of a GPS position change

Otherwise as soon as the message appears, it will endlessly
re-show as the GPS position is constantly changing. Instead
ensure that the message starts showing for a maximum of
2 seconds in response to a mouse movement, yet will update
during these 2 seconds if the GPS position is updated during
this time.
