### PR TITLE
Use mIgnoreGetMapUrl flag to adjust getLegendGraphic requests

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -350,12 +350,13 @@ QString QgsWmsProvider::getLegendGraphicUrl() const
       break;
     }
   }
-
+  QgsDebugMsgLevel( QStringLiteral( "step 1-> getLegendGraphicUrl is %1" ).arg( url ), 6 );
   if ( url.isEmpty() && !mCaps.mCapabilities.capability.request.getLegendGraphic.dcpType.isEmpty() )
   {
     url = mCaps.mCapabilities.capability.request.getLegendGraphic.dcpType.front().http.get.onlineResource.xlinkHref;
   }
 
+  QgsDebugMsgLevel( QStringLiteral( "step 2-> getLegendGraphicUrl is %1" ).arg( url ), 6 );
   if ( url.isEmpty() )
   {
     for ( const QgsWmtsTileLayer &l : mCaps.mTileLayersSupported )
@@ -380,6 +381,34 @@ QString QgsWmsProvider::getLegendGraphicUrl() const
         break;
     }
   }
+  if ( mSettings.mIgnoreGetMapUrl )
+  {
+    if ( url.isEmpty() )
+    {
+      QgsDebugMsgLevel( QStringLiteral( "converting getLegendGraphicUrl is %1" ).arg( url ), 9 );
+      // rewrite the URL if the one in the capabilities document is incorrect
+      // strip every thing after the ? from the base url
+      const QStringList parts = mSettings.mBaseUrl.split( QRegularExpression( "\\?" ) );
+      const QString base = parts.isEmpty() ? mSettings.mBaseUrl : parts.first();
+      // and strip everything before the `rest` element (at least for GeoServer)
+      const int index = url.length() - url.lastIndexOf( QStringLiteral( "rest" ) ) + 1; // +1 for the /
+      url = base + url.right( index );
+    }
+    else
+    {
+      QgsDebugMsgLevel( QStringLiteral( "converting getLegendGraphicUrl is %1" ).arg( url ), 9 );
+      // rewrite the URL if the one in the capabilities document is incorrect
+      // strip every thing after the ? from the base url
+      const QStringList parts1 = mSettings.mBaseUrl.split( QRegularExpression( "\\?" ) );
+      const QString base = parts1.isEmpty() ? mSettings.mBaseUrl : parts1.first();
+      const QStringList parts2 = url.split( QRegularExpression( "\\?" ) );
+      const QString base2 = parts2.isEmpty() ? url : parts2.last();
+      // and strip everything before the `rest` element (at least for GeoServer)
+      url = base + "?" + base2;
+    }
+  }
+  QgsDebugMsgLevel( QStringLiteral( "final getLegendGraphicUrl is %1" ).arg( url ), 6 );
+
 
   return url.isEmpty() ? url : prepareUri( url );
 }


### PR DESCRIPTION
## Description

If a WMS or WMTS reports an incorrect URL in it's capabilities document QGis allows users to ignore them but getLegend requests don't ignore the capabilities value. Until #21425 is implemented then make the legend graphic url dependent on if the getMap URL is being ignored. 

see #39080 

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
