### PR TITLE
Fix layout order on drag drop action, fix #39136

### DIFF
--- a/src/core/layout/qgslayoutmodel.cpp
+++ b/src/core/layout/qgslayoutmodel.cpp
@@ -308,7 +308,7 @@ bool zOrderDescending( QgsLayoutItem *item1, QgsLayoutItem *item2 )
 bool QgsLayoutModel::dropMimeData( const QMimeData *data,
                                    Qt::DropAction action, int row, int column, const QModelIndex &parent )
 {
-  if ( column != ItemId )
+  if ( column != ItemId & column != -1 )
   {
     return false;
   }
@@ -362,7 +362,7 @@ bool QgsLayoutModel::dropMimeData( const QMimeData *data,
   int destPos = 0;
   if ( beginRow < rowCount() )
   {
-    QgsLayoutItem *itemBefore = mItemsInScene.at( beginRow );
+    QgsLayoutItem *itemBefore = mItemsInScene.at( beginRow - 1 );
     destPos = mItemZList.indexOf( itemBefore );
   }
   else

--- a/src/core/layout/qgslayoutmodel.cpp
+++ b/src/core/layout/qgslayoutmodel.cpp
@@ -308,7 +308,7 @@ bool zOrderDescending( QgsLayoutItem *item1, QgsLayoutItem *item2 )
 bool QgsLayoutModel::dropMimeData( const QMimeData *data,
                                    Qt::DropAction action, int row, int column, const QModelIndex &parent )
 {
-  if ( column != ItemId & column != -1 )
+  if ( column != ItemId && column != -1 )
   {
     return false;
   }
@@ -1050,4 +1050,3 @@ bool QgsLayoutProxyModel::filterAcceptsRow( int sourceRow, const QModelIndex &so
 
   return true;
 }
-

--- a/tests/src/core/testqgslayoutmodel.cpp
+++ b/tests/src/core/testqgslayoutmodel.cpp
@@ -51,6 +51,7 @@ class TestQgsLayoutModel : public QObject
     void reorderDown(); //test reordering an item down
     void reorderTop(); //test reordering an item to top
     void reorderBottom(); //test reordering an item to bottom
+    void moveItem(); //test move an item in the item tree
     void findItemAbove(); //test getting composer item above
     void findItemBelow(); //test getting composer item below
     void setItemRemoved(); //test setting an item as removed
@@ -559,6 +560,60 @@ void TestQgsLayoutModel::reorderBottom()
   QCOMPARE( layout.itemsModel()->data( layout.itemsModel()->index( 3, 2, QModelIndex() ), Qt::DisplayRole ).toString(), QStringLiteral( "i3" ) );
 
   delete label;
+}
+
+void TestQgsLayoutModel::moveItem()
+{
+  QgsLayout layout( QgsProject::instance() );
+
+  //some items in layout
+  QgsLayoutItem *item1 = new QgsLayoutItemMap( &layout );
+  layout.addLayoutItem( item1 );
+  item1->setId( QStringLiteral( "i1" ) );
+  QgsLayoutItem *item2 = new QgsLayoutItemMap( &layout );
+  layout.addLayoutItem( item2 );
+  item2->setId( QStringLiteral( "i2" ) );
+  QgsLayoutItem *item3 = new QgsLayoutItemMap( &layout );
+  layout.addLayoutItem( item3 );
+  item3->setId( QStringLiteral( "i3" ) );
+
+  // start with an empty model
+  layout.itemsModel()->clear();
+
+  layout.itemsModel()->rebuildZList();
+
+  //check z list
+  QCOMPARE( layout.itemsModel()->zOrderListSize(), 3 );
+  QCOMPARE( layout.itemsModel()->zOrderList().at( 0 ), item3 );
+  QCOMPARE( layout.itemsModel()->zOrderList().at( 1 ), item2 );
+  QCOMPARE( layout.itemsModel()->zOrderList().at( 2 ), item1 );
+
+  QCOMPARE( layout.itemsModel()->data( layout.itemsModel()->index( 0, 2, QModelIndex() ), Qt::DisplayRole ).toString(), QString() );
+  QCOMPARE( layout.itemsModel()->data( layout.itemsModel()->index( 1, 2, QModelIndex() ), Qt::DisplayRole ).toString(), QStringLiteral( "i3" ) );
+  QCOMPARE( layout.itemsModel()->data( layout.itemsModel()->index( 2, 2, QModelIndex() ), Qt::DisplayRole ).toString(), QStringLiteral( "i2" ) );
+  QCOMPARE( layout.itemsModel()->data( layout.itemsModel()->index( 3, 2, QModelIndex() ), Qt::DisplayRole ).toString(), QStringLiteral( "i1" ) );
+
+  QgsLayoutModel *model = layout.itemsModel();
+  QMimeData *mimedata = model->mimeData( QModelIndexList() << model->index( 2, 2 ) ); // get i2
+  model->dropMimeData( mimedata, Qt::MoveAction, 1, 2, QModelIndex() ); // move i2 at the top
+
+  QCOMPARE( layout.itemsModel()->data( layout.itemsModel()->index( 1, 2, QModelIndex() ), Qt::DisplayRole ).toString(), QStringLiteral( "i2" ) );
+  QCOMPARE( layout.itemsModel()->data( layout.itemsModel()->index( 2, 2, QModelIndex() ), Qt::DisplayRole ).toString(), QStringLiteral( "i3" ) );
+  QCOMPARE( layout.itemsModel()->data( layout.itemsModel()->index( 3, 2, QModelIndex() ), Qt::DisplayRole ).toString(), QStringLiteral( "i1" ) );
+
+  mimedata = model->mimeData( QModelIndexList() << model->index( 1, 2 ) ); // get i2
+  model->dropMimeData( mimedata, Qt::MoveAction, -1, -1, QModelIndex() ); // move i2 at the bottom
+
+  QCOMPARE( layout.itemsModel()->data( layout.itemsModel()->index( 1, 2, QModelIndex() ), Qt::DisplayRole ).toString(), QStringLiteral( "i3" ) );
+  QCOMPARE( layout.itemsModel()->data( layout.itemsModel()->index( 2, 2, QModelIndex() ), Qt::DisplayRole ).toString(), QStringLiteral( "i1" ) );
+  QCOMPARE( layout.itemsModel()->data( layout.itemsModel()->index( 3, 2, QModelIndex() ), Qt::DisplayRole ).toString(), QStringLiteral( "i2" ) );
+
+  mimedata = model->mimeData( QModelIndexList() << model->index( 3, 2 ) ); // get i2
+  model->dropMimeData( mimedata, Qt::MoveAction, 2, 2, QModelIndex() ); // move i2 between i3 and i1
+
+  QCOMPARE( layout.itemsModel()->data( layout.itemsModel()->index( 1, 2, QModelIndex() ), Qt::DisplayRole ).toString(), QStringLiteral( "i3" ) );
+  QCOMPARE( layout.itemsModel()->data( layout.itemsModel()->index( 2, 2, QModelIndex() ), Qt::DisplayRole ).toString(), QStringLiteral( "i2" ) );
+  QCOMPARE( layout.itemsModel()->data( layout.itemsModel()->index( 3, 2, QModelIndex() ), Qt::DisplayRole ).toString(), QStringLiteral( "i1" ) );
 }
 
 void TestQgsLayoutModel::findItemAbove()


### PR DESCRIPTION
## Description

Bug described by @nicogodet in #39136 

In layout list item, drag and drop to move item doesn't work as expected. In the [dropMimeData](https://github.com/qgis/QGIS/compare/master...SebastienPeillet:fix_layout_order_on_drag-drop_action?expand=1#diff-66138644cf02582ee3590cf5657517a7R308) function, the index use to insert the moved item is shifted by one.

Futhermore when user drops item on last line, input `column` variable is initiated on -1, so column is not equal to `ItemId` [here](https://github.com/qgis/QGIS/compare/master...SebastienPeillet:fix_layout_order_on_drag-drop_action?expand=1#diff-66138644cf02582ee3590cf5657517a7R311). In consequence the item is not moved at the bottom of the list.

I added a new test in [testqgslayoutmodel.cpp](https://github.com/qgis/QGIS/compare/master...SebastienPeillet:fix_layout_order_on_drag-drop_action?expand=1#diff-ac42da3851bd88ac4291deaccc824a05R565) to check that the dropMimeData works as expected