### PR TITLE
When calling processing.run() and an QgsProcessingExpection occurs, don't raise a generic "something went wrong" exception

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -337,7 +337,8 @@ is passed in order to make a best guess determination of the output properties.
 .. versionadded:: 3.14
 %End
 
-    QVariantMap run( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback, bool *ok /Out/ = 0, const QVariantMap &configuration = QVariantMap() ) const;
+    QVariantMap run( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback, bool *ok /Out/ = 0, const QVariantMap &configuration = QVariantMap(),
+                     bool catchExceptions = true ) const throw( QgsProcessingException );
 %Docstring
 Executes the algorithm using the specified ``parameters``. This method internally
 creates a copy of the algorithm before running it, so it is safe to call
@@ -348,6 +349,9 @@ The ``context`` argument specifies the context in which the algorithm is being r
 Algorithm progress should be reported using the supplied ``feedback`` object.
 
 If specified, ``ok`` will be set to ``True`` if algorithm was successfully run.
+
+If ``catchExceptions`` is set to ``False``, then QgsProcessingExceptions raised during
+the algorithm run will not be automatically caught and will be raised instead.
 
 :return: A map of algorithm outputs. These may be output layer references, or calculated
          values such as statistical calculations.

--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -156,7 +156,7 @@ class Processing(object):
             feedback.pushInfo(
                 Processing.tr('Warning: Not all input layers use the same CRS.\nThis can cause unexpected results.'))
 
-        ret, results = execute(alg, parameters, context, feedback)
+        ret, results = execute(alg, parameters, context, feedback, catch_exceptions=False)
         if ret:
             feedback.pushInfo(
                 Processing.tr('Results: {}').format(results))

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -445,7 +445,7 @@ QgsProcessingAlgorithm::VectorProperties QgsProcessingAlgorithm::sinkProperties(
   return VectorProperties();
 }
 
-QVariantMap QgsProcessingAlgorithm::run( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback, bool *ok, const QVariantMap &configuration ) const
+QVariantMap QgsProcessingAlgorithm::run( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback, bool *ok, const QVariantMap &configuration, bool catchExceptions ) const
 {
   std::unique_ptr< QgsProcessingAlgorithm > alg( create( configuration ) );
   if ( ok )
@@ -462,6 +462,9 @@ QVariantMap QgsProcessingAlgorithm::run( const QVariantMap &parameters, QgsProce
   }
   catch ( QgsProcessingException &e )
   {
+    if ( !catchExceptions )
+      throw e;
+
     QgsMessageLog::logMessage( e.what(), QObject::tr( "Processing" ), Qgis::Critical );
     feedback->reportError( e.what() );
     return QVariantMap();

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -378,13 +378,17 @@ class CORE_EXPORT QgsProcessingAlgorithm
      *
      * If specified, \a ok will be set to TRUE if algorithm was successfully run.
      *
+     * If \a catchExceptions is set to FALSE, then QgsProcessingExceptions raised during
+     * the algorithm run will not be automatically caught and will be raised instead.
+     *
      * \returns A map of algorithm outputs. These may be output layer references, or calculated
      * values such as statistical calculations.
      *
      * \note this method can only be called from the main thread. Use prepare(), runPrepared() and postProcess()
      * if you need to run algorithms from a background thread, or use the QgsProcessingAlgRunnerTask class.
      */
-    QVariantMap run( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback, bool *ok SIP_OUT = nullptr, const QVariantMap &configuration = QVariantMap() ) const;
+    QVariantMap run( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback, bool *ok SIP_OUT = nullptr, const QVariantMap &configuration = QVariantMap(),
+                     bool catchExceptions = true ) const SIP_THROW( QgsProcessingException );
 
     /**
      * Prepares the algorithm for execution. This must be run in the main thread, and allows the algorithm


### PR DESCRIPTION
... but instead ensure that the original exception with the proper error message is raised for catching in Python instead
