### PR TITLE
[3d] Fix crash when line feature cannot be buffered (3.10 backport)

### DIFF
--- a/src/3d/symbols/qgsline3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsline3dsymbol_p.cpp
@@ -115,6 +115,8 @@ void QgsBufferedLine3DSymbolHandler::processFeature( QgsFeature &f, const Qgs3DR
 
   QgsGeos engine( g );
   QgsAbstractGeometry *buffered = engine.buffer( mSymbol.width() / 2., nSegments, endCapStyle, joinStyle, mitreLimit ); // factory
+  if ( !buffered )
+    return;
 
   if ( QgsWkbTypes::flatType( buffered->wkbType() ) == QgsWkbTypes::Polygon )
   {


### PR DESCRIPTION
Backport from #39251