### PR TITLE
[layouts] Allow negative values for grid annotation distance

### DIFF
--- a/src/gui/layout/qgslayoutmapgridwidget.cpp
+++ b/src/gui/layout/qgslayoutmapgridwidget.cpp
@@ -55,6 +55,9 @@ QgsLayoutMapGridWidget::QgsLayoutMapGridWidget( QgsLayoutItemMapGrid *mapGrid, Q
   mGridFrameMarginSpinBox->setShowClearButton( true );
   mGridFrameMarginSpinBox->setClearValue( 0 );
 
+  mDistanceToMapFrameSpinBox->setShowClearButton( true );
+  mDistanceToMapFrameSpinBox->setClearValue( 0 );
+
   connect( mIntervalXSpinBox, &QgsDoubleSpinBox::editingFinished, this, &QgsLayoutMapGridWidget::mIntervalXSpinBox_editingFinished );
   connect( mIntervalYSpinBox, &QgsDoubleSpinBox::editingFinished, this, &QgsLayoutMapGridWidget::mIntervalYSpinBox_editingFinished );
   connect( mOffsetXSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutMapGridWidget::mOffsetXSpinBox_valueChanged );

--- a/src/ui/layout/qgslayoutmapgridwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapgridwidgetbase.ui
@@ -884,6 +884,9 @@
             <property name="suffix">
              <string> mm</string>
             </property>
+            <property name="minimum">
+             <double>-99.000000000000000</double>
+            </property>
            </widget>
           </item>
           <item row="22" column="2">


### PR DESCRIPTION
This works, it was just blocked by the spin box minimum value
