### PR TITLE
add default UTF-8 encoding to grass provider by default

### DIFF
--- a/src/providers/grass/qgsgrassfeatureiterator.cpp
+++ b/src/providers/grass/qgsgrassfeatureiterator.cpp
@@ -743,7 +743,7 @@ QgsGrassFeatureSource::QgsGrassFeatureSource( const QgsGrassProvider *p )
   , mGrassType( p->mGrassType )
   , mQgisType( p->mQgisType )
   , mFields( p->fields() )
-  , mEncoding( p->textEncoding() )
+  , mEncoding( p->textEncoding() ) // no copying - this is a borrowed pointer from Qt
   , mEditing( p->mEditBuffer )
 {
   Q_ASSERT( mLayer );

--- a/src/providers/grass/qgsgrassprovider.cpp
+++ b/src/providers/grass/qgsgrassprovider.cpp
@@ -251,6 +251,10 @@ QgsGrassProvider::QgsGrassProvider( const QString &uri )
                   // << QgsVectorDataProvider::NativeType( tr( "Date" ), "date", QVariant::Date, 8, 8 );
                 );
 
+  // Assign default encoding
+  if ( !textEncoding() )
+    QgsVectorDataProvider::setEncoding( QStringLiteral( "UTF-8" ) );
+
   mValid = true;
 
   QgsDebugMsg( QString( "New GRASS layer opened, time (ms): %1" ).arg( time.elapsed() ) );


### PR DESCRIPTION
fixes https://github.com/qgis/QGIS/issues/37508

it fixes the crash, where the text encoding is never set in the grass provider and therefore neither in qgsgrassfeatureiterator .

I checked the grass (gis.h) headers and i do not see a way to get a source encoding and I am not sure either the UTF-8 as default is good (still it is used for exact same reason in OGR provider..)
