### PR TITLE
Transaction group: keep editing status after save

### DIFF
--- a/src/core/qgstransactiongroup.cpp
+++ b/src/core/qgstransactiongroup.cpp
@@ -85,7 +85,7 @@ void QgsTransactionGroup::onEditingStarted()
   {
     mTransaction->addLayer( layer );
     layer->startEditing();
-    connect( layer, &QgsVectorLayer::beforeCommitChanges, this, &QgsTransactionGroup::onCommitChanges );
+    connect( layer, &QgsVectorLayer::beforeCommitChanges, this, &QgsTransactionGroup::onBeforeCommitChanges );
     connect( layer, &QgsVectorLayer::beforeRollBack, this, &QgsTransactionGroup::onRollback );
   }
 }
@@ -95,7 +95,7 @@ void QgsTransactionGroup::onLayerDeleted()
   mLayers.remove( static_cast<QgsVectorLayer *>( sender() ) );
 }
 
-void QgsTransactionGroup::onCommitChanges()
+void QgsTransactionGroup::onBeforeCommitChanges( bool stopEditing )
 {
   if ( mEditingStopping )
     return;
@@ -111,7 +111,7 @@ void QgsTransactionGroup::onCommitChanges()
     for ( QgsVectorLayer *layer : constMLayers )
     {
       if ( layer != sender() )
-        layer->commitChanges();
+        layer->commitChanges( stopEditing );
     }
 
     disableTransaction();
@@ -160,7 +160,7 @@ void QgsTransactionGroup::disableTransaction()
   const auto constMLayers = mLayers;
   for ( QgsVectorLayer *layer : constMLayers )
   {
-    disconnect( layer, &QgsVectorLayer::beforeCommitChanges, this, &QgsTransactionGroup::onCommitChanges );
+    disconnect( layer, &QgsVectorLayer::beforeCommitChanges, this, &QgsTransactionGroup::onBeforeCommitChanges );
     disconnect( layer, &QgsVectorLayer::beforeRollBack, this, &QgsTransactionGroup::onRollback );
   }
 }

--- a/src/core/qgstransactiongroup.h
+++ b/src/core/qgstransactiongroup.h
@@ -82,7 +82,7 @@ class CORE_EXPORT QgsTransactionGroup : public QObject
   private slots:
     void onEditingStarted();
     void onLayerDeleted();
-    void onCommitChanges();
+    void onBeforeCommitChanges( bool stopEditing );
     void onRollback();
 
   private:

--- a/tests/src/python/test_qgspostgrestransaction.py
+++ b/tests/src/python/test_qgspostgrestransaction.py
@@ -104,6 +104,27 @@ class TestQgsPostgresTransaction(unittest.TestCase):
         self.assertIsNone(noTg)
         self.rollbackTransaction()
 
+    def test_transactionGroupEditingStatus(self):
+        """Not particularly related to PG but it fits here nicely: test GH #39282"""
+
+        project = QgsProject()
+        project.setAutoTransaction(True)
+
+        vl_b = QgsVectorLayer(self.dbconn + ' sslmode=disable key=\'pk\' table="qgis_test"."books" sql=', 'books',
+                              'postgres')
+        vl_a = QgsVectorLayer(self.dbconn + ' sslmode=disable key=\'pk\' table="qgis_test"."authors" sql=',
+                              'authors', 'postgres')
+
+        project.addMapLayers([vl_a, vl_b])
+
+        vl_a.startEditing()
+        self.assertTrue(vl_a.isEditable())
+        self.assertTrue(vl_b.isEditable())
+
+        self.assertTrue(vl_a.commitChanges(False))
+        self.assertTrue(vl_a.isEditable())
+        self.assertTrue(vl_b.isEditable())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #39282
