### PR TITLE
fix crashes in QGIS 3D, mostly directly at project load

### DIFF
--- a/src/3d/terrain/qgsdemterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsdemterraintileloader_p.cpp
@@ -27,6 +27,7 @@
 #include "qgsterraingenerator.h"
 
 #include <Qt3DRender/QGeometryRenderer>
+#include <QMutexLocker>
 
 ///@cond PRIVATE
 
@@ -268,6 +269,18 @@ void QgsDemHeightMapGenerator::waitForFinished()
   }
 }
 
+void QgsDemHeightMapGenerator::lazyLoadDtmCoarseData( int res, const QgsRectangle &rect )
+{
+  QMutexLocker locker( &mLazyLoadDtmCoarseDataMutex );
+  if ( mDtmCoarseData.isEmpty() )
+  {
+    std::unique_ptr< QgsRasterBlock > block( mDtm->dataProvider()->block( 1, rect, res, res ) );
+    block->convert( Qgis::Float32 );
+    mDtmCoarseData = block->data();
+    mDtmCoarseData.detach();  // make a deep copy
+  }
+}
+
 float QgsDemHeightMapGenerator::heightAt( double x, double y )
 {
   if ( !mDtm )
@@ -276,13 +289,7 @@ float QgsDemHeightMapGenerator::heightAt( double x, double y )
   // TODO: this is quite a primitive implementation: better to use heightmaps currently in use
   int res = 1024;
   QgsRectangle rect = mDtm->extent();
-  if ( mDtmCoarseData.isEmpty() )
-  {
-    std::unique_ptr< QgsRasterBlock > block( mDtm->dataProvider()->block( 1, rect, res, res ) );
-    block->convert( Qgis::Float32 );
-    mDtmCoarseData = block->data();
-    mDtmCoarseData.detach();  // make a deep copy
-  }
+  lazyLoadDtmCoarseData( res, rect );
 
   int cellX = ( int )( ( x - rect.xMinimum() ) / rect.width() * res + .5f );
   int cellY = ( int )( ( rect.yMaximum() - y ) / rect.height() * res + .5f );

--- a/src/3d/terrain/qgsdemterraintileloader_p.h
+++ b/src/3d/terrain/qgsdemterraintileloader_p.h
@@ -32,6 +32,7 @@
 #include <QtConcurrent/QtConcurrentRun>
 #include <QFutureWatcher>
 #include <QElapsedTimer>
+#include <QMutex>
 
 #include "qgschunknode_p.h"
 #include "qgsrectangle.h"
@@ -133,6 +134,8 @@ class QgsDemHeightMapGenerator : public QObject
 
     QHash<QFutureWatcher<QByteArray>*, JobData> mJobs;
 
+    void lazyLoadDtmCoarseData( int res, const QgsRectangle &rect );
+    mutable QMutex mLazyLoadDtmCoarseDataMutex;
     //! used for height queries
     QByteArray mDtmCoarseData;
 };


### PR DESCRIPTION
Fix the random crashes, usually on LOADING of 3d view. The stacktrace of those errors could be mostly ANYTHING :), and sometimes some random stuff like 

```
0   org.qt-project.QtGui           0x000000010be75af9 qt_memfillXX_avx2(unsigned char*, long long vector[4], long long) + 41
1   org.qt-project.QtGui           0x000000010bef1bd5 QImage::fill(Qt::GlobalColor) + 37
2   org.qgis.qgis3_core            0x000000010ebf2740 QgsMapRendererSequentialJob::QgsMapRendererSequentialJob(QgsMapSettings const&) + 320
```

or 

```
1   org.qt-project.Qt3DCore        0x00000001109ecde7 Qt3DCore::QScene::removePropertyTrackDataForNode(Qt3DCore::QNodeId) + 71
2   org.qt-project.Qt3DCore        0x00000001109fe708 Qt3DCore::QNodePrivate::setScene(Qt3DCore::QScene*) + 40
3   org.qt-project.Qt3DCore        0x00000001109fd957 Qt3DCore::QNodePrivate::unsetSceneHelper(Qt3DCore::QNode*) + 199
4   org.qt-project.Qt3DCore        0x0000000110a00bd1 void 
```

or 

```
6   libsystem_malloc.dylib         0x00007fff73523cf5 malloc + 21
7   org.qt-project.QtCore          0x000000010ab40bc0 QArrayData::allocate(unsigned long, unsigned long, unsigned long, QFlags<QArrayData::AllocationOption>) + 144
8   org.qt-project.QtCore          0x000000010ab9cea3 QByteArray::QByteArray(char const*, int) + 51
9   org.qt-project.Qt3DRender      0x000000011534a210 Qt3DRender::QTextureImageData::setImage(QImage const&) + 128
10  org.qgis.qgis3_3d              0x000000010c6bd3c4 TerrainTextureImageDataGenerator::operator()() + 148
11  org.qt-project.Qt3DRender      0x0000000115388bbe Qt3DRender::Render::GLTexture::loadTextureDataFromImages() + 94
```

or 

```
0   libsystem_kernel.dylib         0x00007fff734aedfa mach_msg_trap + 10
1   libsystem_kernel.dylib         0x00007fff734af170 mach_msg + 60
2   com.apple.AppKit               0x00007fff36ae9fe6 NSWaitUntilHostTime + 102
3   com.apple.AppKit               0x00007fff36f92ef0 -[NSCGLSurface synchronize] + 105
4   com.apple.AppKit               0x00007fff36f923c7 NSCGLSurfaceFlush + 89
5   GLEngine                       0x00007fff43e2992a glSwap_Exec + 186
6   com.apple.opengl               0x00007fff43e0b473 CGLFlushDrawable + 59
7   com.apple.AppKit               0x00007fff3691875a -[NSOpenGLContext flushBuffer] + 20
8   libqcocoa.dylib                0x00000001181745fd QCocoaGLContext::swapBuffers(QPlatformSurface*) + 509
9   org.qt-project.QtGui           0x0000000108f0508c QOpenGLContext::swapBuffers(QSurface*) + 
```

Due to the fact, that in this multi-threaded rendering, the memory is kind-of-corrupted (two processes are trying to persist the new data block to the same resulting member array variable)

fixes https://github.com/qgis/QGIS/issues/35483