### PR TITLE
Fix scenarios under which digitizing on layer with a CRS different from the project fails

### DIFF
--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -526,7 +526,7 @@ transform point coordinates from layer's CRS to output CRS
 :return: the transformed point
 %End
 
-    QgsPoint layerToMapCoordinates( const QgsMapLayer *layer, QgsPoint point ) const;
+    QgsPoint layerToMapCoordinates( const QgsMapLayer *layer, const QgsPoint &point ) const;
 %Docstring
 transform point coordinates from layer's CRS to output CRS
 
@@ -551,7 +551,7 @@ transform point coordinates from output CRS to layer's CRS
 :return: the transformed point
 %End
 
-    QgsPoint mapToLayerCoordinates( const QgsMapLayer *layer, QgsPoint point ) const;
+    QgsPoint mapToLayerCoordinates( const QgsMapLayer *layer, const QgsPoint &point ) const;
 %Docstring
 transform point coordinates from output CRS to layer's CRS
 

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -646,6 +646,16 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
     return;
   }
 
+  std::vector< int > zNanPositions;
+  for ( int i = 0; i < numPoints; i++ )
+  {
+    if ( std::isnan( z[i] ) )
+    {
+      zNanPositions.push_back( i );
+      z[i] = 0.0;
+    }
+  }
+
 #if PROJ_VERSION_MAJOR>=6
   std::vector< double > xprev( numPoints );
   memcpy( xprev.data(), x, sizeof( double ) * numPoints );
@@ -795,6 +805,12 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
     }
   }
 #endif
+
+  for ( const int &pos : zNanPositions )
+  {
+    z[pos] = std::numeric_limits<double>::quiet_NaN();
+  }
+
   if ( projResult != 0 )
   {
     //something bad happened....

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -500,7 +500,7 @@ QgsPoint QgsMapSettings::layerToMapCoordinates( const QgsMapLayer *layer, const 
 {
   double x = point.x();
   double y = point.y();
-  double z = !std::isnan( point.z() ) ? point.z() : 0.0;
+  double z = point.z();
 
   try
   {
@@ -513,7 +513,7 @@ QgsPoint QgsMapSettings::layerToMapCoordinates( const QgsMapLayer *layer, const 
     QgsMessageLog::logMessage( QObject::tr( "Transform error caught: %1" ).arg( cse.what() ), QObject::tr( "CRS" ) );
   }
 
-  return QgsPoint( x, y, !std::isnan( point.z() ) ? z : point.z() );
+  return QgsPoint( x, y, z );
 }
 
 
@@ -554,7 +554,7 @@ QgsPoint QgsMapSettings::mapToLayerCoordinates( const QgsMapLayer *layer, const 
 {
   double x = point.x();
   double y = point.y();
-  double z = !std::isnan( point.z() ) ? point.z() : 0.0;
+  double z = point.z();
 
   try
   {
@@ -567,7 +567,7 @@ QgsPoint QgsMapSettings::mapToLayerCoordinates( const QgsMapLayer *layer, const 
     QgsMessageLog::logMessage( QObject::tr( "Transform error caught: %1" ).arg( cse.what() ), QObject::tr( "CRS" ) );
   }
 
-  return QgsPoint( x, y, !std::isnan( point.z() ) ? z : point.z() );
+  return QgsPoint( x, y, z );
 }
 
 

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -496,11 +496,11 @@ QgsPointXY QgsMapSettings::layerToMapCoordinates( const QgsMapLayer *layer, QgsP
   return point;
 }
 
-QgsPoint QgsMapSettings::layerToMapCoordinates( const QgsMapLayer *layer, QgsPoint point ) const
+QgsPoint QgsMapSettings::layerToMapCoordinates( const QgsMapLayer *layer, const QgsPoint &point ) const
 {
   double x = point.x();
   double y = point.y();
-  double z = point.z();
+  double z = !std::isnan( point.z() ) ? point.z() : 0.0;
 
   try
   {
@@ -513,7 +513,7 @@ QgsPoint QgsMapSettings::layerToMapCoordinates( const QgsMapLayer *layer, QgsPoi
     QgsMessageLog::logMessage( QObject::tr( "Transform error caught: %1" ).arg( cse.what() ), QObject::tr( "CRS" ) );
   }
 
-  return QgsPoint( x, y, z );
+  return QgsPoint( x, y, !std::isnan( point.z() ) ? z : point.z() );
 }
 
 
@@ -550,11 +550,11 @@ QgsPointXY QgsMapSettings::mapToLayerCoordinates( const QgsMapLayer *layer, QgsP
   return point;
 }
 
-QgsPoint QgsMapSettings::mapToLayerCoordinates( const QgsMapLayer *layer, QgsPoint point ) const
+QgsPoint QgsMapSettings::mapToLayerCoordinates( const QgsMapLayer *layer, const QgsPoint &point ) const
 {
   double x = point.x();
   double y = point.y();
-  double z = point.z();
+  double z = !std::isnan( point.z() ) ? point.z() : 0.0;
 
   try
   {
@@ -567,7 +567,7 @@ QgsPoint QgsMapSettings::mapToLayerCoordinates( const QgsMapLayer *layer, QgsPoi
     QgsMessageLog::logMessage( QObject::tr( "Transform error caught: %1" ).arg( cse.what() ), QObject::tr( "CRS" ) );
   }
 
-  return QgsPoint( x, y, z );
+  return QgsPoint( x, y, !std::isnan( point.z() ) ? z : point.z() );
 }
 
 

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -468,7 +468,7 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
      * \returns the transformed point
      * \since QGIS 3.16
      */
-    QgsPoint layerToMapCoordinates( const QgsMapLayer *layer, QgsPoint point ) const;
+    QgsPoint layerToMapCoordinates( const QgsMapLayer *layer, const QgsPoint &point ) const;
 
     /**
      * \brief transform rectangle from layer's CRS to output CRS
@@ -488,7 +488,7 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
      * \returns the transformed point
      * \since QGIS 3.16
      */
-    QgsPoint mapToLayerCoordinates( const QgsMapLayer *layer, QgsPoint point ) const;
+    QgsPoint mapToLayerCoordinates( const QgsMapLayer *layer, const QgsPoint &point ) const;
 
     /**
      * \brief transform rectangle from output CRS to layer's CRS

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -394,6 +394,9 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     //! Flag to indicate a map canvas capture operation is taking place
     bool mCapturing = false;
 
+    QgsPoint mCaptureFirstPoint;
+    QgsPoint mCaptureLastPoint;
+
     //! Rubber band for polylines and polygons
     QObjectUniquePtr<QgsRubberBand> mRubberBand;
 

--- a/tests/src/core/testqgscoordinatetransform.cpp
+++ b/tests/src/core/testqgscoordinatetransform.cpp
@@ -43,6 +43,7 @@ class TestQgsCoordinateTransform: public QObject
     void transform();
     void transformLKS();
     void transformContextNormalize();
+    void transform2DPoint();
     void transformErrorMultiplePoints();
     void transformErrorOnePoint();
     void testDeprecated4240to4326();
@@ -486,6 +487,22 @@ void TestQgsCoordinateTransform::transformContextNormalize()
 #endif
 }
 
+void TestQgsCoordinateTransform::transform2DPoint()
+{
+  // Check that we properly handle 2D point transform
+  QgsCoordinateTransformContext context;
+  QgsCoordinateTransform ct( QgsCoordinateReferenceSystem::fromEpsgId( 4326 ), QgsCoordinateReferenceSystem::fromEpsgId( 3857 ), context );
+  QVERIFY( ct.isValid() );
+  QgsPoint pt( 0.0, 0.0 );
+  double x = pt.x();
+  double y = pt.y();
+  double z = pt.z();
+  ct.transformInPlace( x, y, z );
+
+  QGSCOMPARENEAR( x, 0.0, 0.01 );
+  QGSCOMPARENEAR( y, 0.0, 0.01 );
+  QGSCOMPARENEAR( z, pt.z(), 0.01 );
+}
 
 void TestQgsCoordinateTransform::transformErrorMultiplePoints()
 {

--- a/tests/src/core/testqgscoordinatetransform.cpp
+++ b/tests/src/core/testqgscoordinatetransform.cpp
@@ -501,7 +501,7 @@ void TestQgsCoordinateTransform::transform2DPoint()
 
   QGSCOMPARENEAR( x, 0.0, 0.01 );
   QGSCOMPARENEAR( y, 0.0, 0.01 );
-  QGSCOMPARENEAR( z, pt.z(), 0.01 );
+  QVERIFY( std::isnan( z ) );
 }
 
 void TestQgsCoordinateTransform::transformErrorMultiplePoints()


### PR DESCRIPTION
## Description

Partial fix for #39296. QgsMapSettings' layerToMapCoordinates( QgsVectorLayer, QgsPoint ) function wrongly assumed the provided QgsPoint always contained a valid z() value. 

@nyalldawson , review appreciated. An alternative fix would be to update the QgsCoordinateTransform transformInPlace() function to handle nan z values (by essentially skipping the z-related value checks).