### PR TITLE
[backport 3.10] Fix translation for geometry checks

### DIFF
--- a/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.h
@@ -25,6 +25,7 @@
  */
 class ANALYSIS_EXPORT QgsGeometryAngleCheck : public QgsGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryAngleCheck )
   public:
     enum ResolutionMethod
     {

--- a/src/analysis/vector/geometry_checker/qgsgeometryareacheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryareacheck.h
@@ -27,6 +27,7 @@ class QgsSurface;
  */
 class ANALYSIS_EXPORT QgsGeometryAreaCheck : public QgsGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryAreaCheck )
   public:
     enum ResolutionMethod { MergeLongestEdge, MergeLargestArea, MergeIdenticalAttribute, Delete, NoChange };
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
@@ -125,7 +125,6 @@ class QgsFeaturePool;
 class ANALYSIS_EXPORT QgsGeometryCheck
 {
     Q_GADGET
-    Q_DECLARE_TR_FUNCTIONS( QgsGeometryCheck )
 
   public:
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrycontainedcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycontainedcheck.h
@@ -54,6 +54,7 @@ class ANALYSIS_EXPORT QgsGeometryContainedCheckError : public QgsGeometryCheckEr
  */
 class ANALYSIS_EXPORT QgsGeometryContainedCheck : public QgsGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryContainedCheck )
   public:
     enum ResolutionMethod { Delete, NoChange };
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrydanglecheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrydanglecheck.h
@@ -25,6 +25,7 @@
  */
 class ANALYSIS_EXPORT QgsGeometryDangleCheck : public QgsGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryDangleCheck )
   public:
     QgsGeometryDangleCheck( QgsGeometryCheckContext *context, const QVariantMap &configuration )
       : QgsGeometryCheck( context, configuration )

--- a/src/analysis/vector/geometry_checker/qgsgeometrydegeneratepolygoncheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrydegeneratepolygoncheck.h
@@ -25,6 +25,7 @@
  */
 class ANALYSIS_EXPORT QgsGeometryDegeneratePolygonCheck : public QgsGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryDegeneratePolygonCheck )
   public:
     enum ResolutionMethod { DeleteRing, NoChange };
 

--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.h
@@ -58,6 +58,7 @@ class ANALYSIS_EXPORT QgsGeometryDuplicateCheckError : public QgsGeometryCheckEr
  */
 class ANALYSIS_EXPORT QgsGeometryDuplicateCheck : public QgsGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryDuplicateCheck )
   public:
     explicit QgsGeometryDuplicateCheck( QgsGeometryCheckContext *context, const QVariantMap &configuration )
       : QgsGeometryCheck( context, configuration ) {}

--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatenodescheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatenodescheck.h
@@ -25,6 +25,7 @@
  */
 class ANALYSIS_EXPORT QgsGeometryDuplicateNodesCheck : public QgsGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryDuplicateNodesCheck )
   public:
     explicit QgsGeometryDuplicateNodesCheck( QgsGeometryCheckContext *context, const QVariantMap &configuration )
       : QgsGeometryCheck( context, configuration ) {}

--- a/src/analysis/vector/geometry_checker/qgsgeometryfollowboundariescheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryfollowboundariescheck.h
@@ -28,6 +28,7 @@ class QgsSpatialIndex;
  */
 class ANALYSIS_EXPORT QgsGeometryFollowBoundariesCheck : public QgsGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryFollowBoundariesCheck )
   public:
     QgsGeometryFollowBoundariesCheck( QgsGeometryCheckContext *context, const QVariantMap &configuration, QgsVectorLayer *checkLayer );
     ~QgsGeometryFollowBoundariesCheck() override;

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.h
@@ -89,6 +89,8 @@ class ANALYSIS_EXPORT QgsGeometryGapCheckError : public QgsGeometryCheckError
 class ANALYSIS_EXPORT QgsGeometryGapCheck : public QgsGeometryCheck
 {
     Q_GADGET
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryGapCheck )
+
   public:
     //! Resolution methods for geometry gap checks
     enum ResolutionMethod

--- a/src/analysis/vector/geometry_checker/qgsgeometryholecheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryholecheck.h
@@ -25,6 +25,7 @@
  */
 class ANALYSIS_EXPORT QgsGeometryHoleCheck : public QgsGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryHoleCheck )
   public:
     explicit QgsGeometryHoleCheck( QgsGeometryCheckContext *context, const QVariantMap &configuration )
       : QgsGeometryCheck( context, configuration ) {}

--- a/src/analysis/vector/geometry_checker/qgsgeometryisvalidcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryisvalidcheck.h
@@ -53,6 +53,7 @@ class ANALYSIS_EXPORT QgsGeometryIsValidCheckError : public QgsSingleGeometryChe
  */
 class ANALYSIS_EXPORT QgsGeometryIsValidCheck : public QgsSingleGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryIsValidCheck )
   public:
 
     /**

--- a/src/analysis/vector/geometry_checker/qgsgeometrylineintersectioncheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrylineintersectioncheck.h
@@ -25,6 +25,7 @@
  */
 class ANALYSIS_EXPORT QgsGeometryLineIntersectionCheck : public QgsGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryLineIntersectionCheck )
   public:
     QgsGeometryLineIntersectionCheck( QgsGeometryCheckContext *context, const QVariantMap &configuration )
       : QgsGeometryCheck( context, configuration )

--- a/src/analysis/vector/geometry_checker/qgsgeometrylinelayerintersectioncheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrylinelayerintersectioncheck.h
@@ -25,6 +25,7 @@
  */
 class ANALYSIS_EXPORT QgsGeometryLineLayerIntersectionCheck : public QgsGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryLineLayerIntersectionCheck )
   public:
     QgsGeometryLineLayerIntersectionCheck( QgsGeometryCheckContext *context, const QVariantMap &configuration )
       : QgsGeometryCheck( context, configuration )

--- a/src/analysis/vector/geometry_checker/qgsgeometrymissingvertexcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrymissingvertexcheck.h
@@ -85,6 +85,7 @@ class ANALYSIS_EXPORT QgsGeometryMissingVertexCheckError : public QgsGeometryChe
 class ANALYSIS_EXPORT QgsGeometryMissingVertexCheck : public QgsGeometryCheck
 {
     Q_GADGET
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryMissingVertexCheck )
 
   public:
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrymultipartcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrymultipartcheck.h
@@ -25,6 +25,7 @@
  */
 class ANALYSIS_EXPORT QgsGeometryMultipartCheck : public QgsSingleGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryMultipartCheck )
   public:
     explicit QgsGeometryMultipartCheck( QgsGeometryCheckContext *context, const QVariantMap &configuration )
       : QgsSingleGeometryCheck( context,

--- a/src/analysis/vector/geometry_checker/qgsgeometryoverlapcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryoverlapcheck.h
@@ -92,6 +92,7 @@ class ANALYSIS_EXPORT QgsGeometryOverlapCheckError : public QgsGeometryCheckErro
  */
 class ANALYSIS_EXPORT QgsGeometryOverlapCheck : public QgsGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryOverlapCheck )
   public:
 
     /**

--- a/src/analysis/vector/geometry_checker/qgsgeometrypointcoveredbylinecheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrypointcoveredbylinecheck.h
@@ -25,6 +25,7 @@
  */
 class ANALYSIS_EXPORT QgsGeometryPointCoveredByLineCheck : public QgsGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryPointCoveredByLineCheck )
   public:
     QgsGeometryPointCoveredByLineCheck( QgsGeometryCheckContext *context, const QVariantMap &configuration )
       : QgsGeometryCheck( context, configuration )

--- a/src/analysis/vector/geometry_checker/qgsgeometrypointinpolygoncheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrypointinpolygoncheck.h
@@ -25,6 +25,7 @@
  */
 class ANALYSIS_EXPORT QgsGeometryPointInPolygonCheck : public QgsGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryPointInPolygonCheck )
   public:
     QgsGeometryPointInPolygonCheck( QgsGeometryCheckContext *context, const QVariantMap &configuration )
       : QgsGeometryCheck( context, configuration )

--- a/src/analysis/vector/geometry_checker/qgsgeometrysegmentlengthcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrysegmentlengthcheck.h
@@ -25,6 +25,7 @@
  */
 class ANALYSIS_EXPORT QgsGeometrySegmentLengthCheck : public QgsGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometrySegmentLengthCheck )
   public:
     QgsGeometrySegmentLengthCheck( QgsGeometryCheckContext *context, const QVariantMap &configuration )
       : QgsGeometryCheck( context, configuration )

--- a/src/analysis/vector/geometry_checker/qgsgeometryselfcontactcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryselfcontactcheck.h
@@ -25,6 +25,7 @@
  */
 class ANALYSIS_EXPORT QgsGeometrySelfContactCheck : public QgsSingleGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometrySelfContactCheck )
   public:
     QgsGeometrySelfContactCheck( QgsGeometryCheckContext *context, const QVariantMap &configuration )
       : QgsSingleGeometryCheck( context, configuration ) {}

--- a/src/analysis/vector/geometry_checker/qgsgeometryselfintersectioncheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryselfintersectioncheck.h
@@ -50,6 +50,7 @@ class ANALYSIS_EXPORT QgsGeometrySelfIntersectionCheckError : public QgsSingleGe
  */
 class ANALYSIS_EXPORT QgsGeometrySelfIntersectionCheck : public QgsSingleGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometrySelfIntersectionCheck )
   public:
     enum ResolutionMethod
     {

--- a/src/analysis/vector/geometry_checker/qgsgeometrytypecheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrytypecheck.h
@@ -48,6 +48,7 @@ class ANALYSIS_EXPORT QgsGeometryTypeCheckError : public QgsSingleGeometryCheckE
  */
 class ANALYSIS_EXPORT QgsGeometryTypeCheck : public QgsSingleGeometryCheck
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsGeometryTypeCheck )
   public:
     QgsGeometryTypeCheck( QgsGeometryCheckContext *context, const QVariantMap &configuration, int allowedTypes )
       : QgsSingleGeometryCheck( context, configuration )


### PR DESCRIPTION
Q_DECLARE_TR_FUNCTIONS must be used in the subclass. If used from the super class
it simply does not work.

## Description

Backports #39289

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
