### PR TITLE
Lazy construct expression context for memory provider feature sources

### DIFF
--- a/src/core/providers/memory/qgsmemoryfeatureiterator.h
+++ b/src/core/providers/memory/qgsmemoryfeatureiterator.h
@@ -38,12 +38,14 @@ class QgsMemoryFeatureSource final: public QgsAbstractFeatureSource
 
     QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) override;
 
+    QgsExpressionContext *expressionContext();
+
   private:
     QgsFields mFields;
     QgsFeatureMap mFeatures;
     std::unique_ptr< QgsSpatialIndex > mSpatialIndex;
     QString mSubsetString;
-    QgsExpressionContext mExpressionContext;
+    std::unique_ptr< QgsExpressionContext > mExpressionContext;
     QgsCoordinateReferenceSystem mCrs;
 
     friend class QgsMemoryFeatureIterator;


### PR DESCRIPTION
It's not free to calculate, and is only used when
iterating over a memory layer with a subset string set

Results in a big speed up to scripts which fire off many individual
feature requests to a memory provider layer
