### PR TITLE
[console] Fix exception when running scripts (followup cce7aa7)

### DIFF
--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -120,6 +120,24 @@ Returns the monospaced font to use for code editors.
 %End
 
 
+    void addWarning( int lineNumber, const QString &warning );
+%Docstring
+Adds a ``warning`` message and indicator to the specified a ``lineNumber``.
+
+.. seealso:: :py:func:`clearWarnings`
+
+.. versionadded:: 3.16
+%End
+
+    void clearWarnings();
+%Docstring
+Clears all warning messages from the editor.
+
+.. seealso:: :py:func:`addWarning`
+
+.. versionadded:: 3.16
+%End
+
   protected:
 
     bool isFixedPitch( const QFont &font );

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -135,6 +135,22 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      */
     void setCustomAppearance( const QString &scheme = QString(), const QMap< QgsCodeEditorColorScheme::ColorRole, QColor > &customColors = QMap< QgsCodeEditorColorScheme::ColorRole, QColor >(), const QString &fontFamily = QString(), int fontSize = 0 ) SIP_SKIP;
 
+    /**
+     * Adds a \a warning message and indicator to the specified a \a lineNumber.
+     *
+     * \see clearWarnings()
+     * \since QGIS 3.16
+     */
+    void addWarning( int lineNumber, const QString &warning );
+
+    /**
+     * Clears all warning messages from the editor.
+     *
+     * \see addWarning()
+     * \since QGIS 3.16
+     */
+    void clearWarnings();
+
   protected:
 
     bool isFixedPitch( const QFont &font );
@@ -188,7 +204,11 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
     QString mFontFamily;
     int mFontSize = 0;
 
+    QVector< int > mWarningLines;
+
     static QMap< QgsCodeEditorColorScheme::ColorRole, QString > sColorRoleToSettingsKey;
+
+    static constexpr int MARKER_NUMBER = 6;
 };
 
 // clazy:excludeall=qstring-allocations


### PR DESCRIPTION
and move responsibility for showing warning messages to QgsCodeEditor
base class, so that the same code can be used by other dialog script editors
