### PR TITLE
Add --json option to qgis_process tool

### DIFF
--- a/src/process/CMakeLists.txt
+++ b/src/process/CMakeLists.txt
@@ -4,6 +4,7 @@
 SET(QGIS_PROCESS_SRCS
   main.cpp
   qgsprocess.cpp
+  ${CMAKE_SOURCE_DIR}/external/nlohmann/json_fwd.hpp
 )
 
 IF (UNIX AND NOT ANDROID)
@@ -23,6 +24,9 @@ INCLUDE_DIRECTORIES(
 INCLUDE_DIRECTORIES(SYSTEM
   ${QT_INCLUDE_DIR}
   ${QGIS_INCLUDE_DIR}
+  ${PROJ_INCLUDE_DIR}
+  ${GDAL_INCLUDE_DIR}
+  ${GEOS_INCLUDE_DIR}
 )
 
 IF (UNIX AND NOT ANDROID)
@@ -42,6 +46,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/analysis/processing
   ${CMAKE_SOURCE_DIR}/src/python
   ${CMAKE_SOURCE_DIR}/external/nlohmann
+  ${CMAKE_SOURCE_DIR}/external
 
   ${CMAKE_BINARY_DIR}/src/core
   ${CMAKE_BINARY_DIR}/src/python
@@ -67,6 +72,9 @@ TARGET_LINK_LIBRARIES(qgis_process
   qgis_core
   qgis_analysis
   ${Qt5Core_LIBRARIES}
+  ${PROJ_LIBRARY}
+  ${GEOS_LIBRARY}
+  ${GDAL_LIBRARY}
 )
 
 IF (WITH_3D)

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -363,7 +363,7 @@ void QgsProcessingExec::loadPlugins()
   const QStringList plugins = mPythonUtils->pluginList();
   for ( const QString &plugin : plugins )
   {
-    if ( mPythonUtils->isPluginEnabled( plugin ) && mPythonUtils->pluginHasProcessingProvider( plugin ) )
+    if ( plugin == QLatin1String( "processing" ) || ( mPythonUtils->isPluginEnabled( plugin ) && mPythonUtils->pluginHasProcessingProvider( plugin ) ) )
     {
       if ( !mPythonUtils->loadPlugin( plugin ) )
       {

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -27,6 +27,8 @@
 #include "qgsprocessingparametertype.h"
 #include "processing/models/qgsprocessingmodelalgorithm.h"
 #include "qgsproject.h"
+#include "qgsgeos.h"
+#include "qgsjsonutils.h"
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_ANDROID)
 #include "sigwatch.h"
@@ -35,40 +37,94 @@
 #include <iostream>
 #include <QObject>
 
-ConsoleFeedback::ConsoleFeedback()
+#include <ogr_api.h>
+#include <gdal_version.h>
+#if PROJ_VERSION_MAJOR > 4
+#include <proj.h>
+#else
+#include <proj_api.h>
+#endif
+#include <json.hpp>
+
+ConsoleFeedback::ConsoleFeedback( bool useJson )
+  : mUseJson( useJson )
 {
-  connect( this, &QgsFeedback::progressChanged, this, &ConsoleFeedback::showTerminalProgress );
-  mTimer.start();
+  if ( !mUseJson )
+  {
+    connect( this, &QgsFeedback::progressChanged, this, &ConsoleFeedback::showTerminalProgress );
+    mTimer.start();
+  }
 }
 
 void ConsoleFeedback::setProgressText( const QString &text )
 {
-  std::cout << text.toLocal8Bit().constData() << '\n';
+  if ( !mUseJson )
+    std::cout << text.toLocal8Bit().constData() << '\n';
 }
 
 void ConsoleFeedback::reportError( const QString &error, bool )
 {
-  std::cerr << "ERROR:\t" << error.toLocal8Bit().constData() << '\n';
+  if ( !mUseJson )
+    std::cerr << "ERROR:\t" << error.toLocal8Bit().constData() << '\n';
+  else
+  {
+    if ( !mJsonLog.contains( QStringLiteral( "errors" ) ) )
+      mJsonLog.insert( QStringLiteral( "errors" ), QStringList() );
+    mJsonLog[ QStringLiteral( "errors" )] = mJsonLog.value( QStringLiteral( "errors" ) ).toStringList() << error;
+  }
 }
 
 void ConsoleFeedback::pushInfo( const QString &info )
 {
-  std::cout << info.toLocal8Bit().constData() << '\n';
+  if ( !mUseJson )
+    std::cout << info.toLocal8Bit().constData() << '\n';
+  else
+  {
+    if ( !mJsonLog.contains( QStringLiteral( "info" ) ) )
+      mJsonLog.insert( QStringLiteral( "info" ), QStringList() );
+    mJsonLog[ QStringLiteral( "info" )] = mJsonLog.value( QStringLiteral( "info" ) ).toStringList() << info;
+  }
 }
 
 void ConsoleFeedback::pushCommandInfo( const QString &info )
 {
-  std::cout << info.toLocal8Bit().constData() << '\n';
+  if ( !mUseJson )
+    std::cout << info.toLocal8Bit().constData() << '\n';
+  else
+  {
+    if ( !mJsonLog.contains( QStringLiteral( "info" ) ) )
+      mJsonLog.insert( QStringLiteral( "info" ), QStringList() );
+    mJsonLog[ QStringLiteral( "info" )] = mJsonLog.value( QStringLiteral( "info" ) ).toStringList() << info;
+  }
 }
 
 void ConsoleFeedback::pushDebugInfo( const QString &info )
 {
-  std::cout << info.toLocal8Bit().constData() << '\n';
+  if ( !mUseJson )
+    std::cout << info.toLocal8Bit().constData() << '\n';
+  else
+  {
+    if ( !mJsonLog.contains( QStringLiteral( "info" ) ) )
+      mJsonLog.insert( QStringLiteral( "info" ), QStringList() );
+    mJsonLog[ QStringLiteral( "info" )] = mJsonLog.value( QStringLiteral( "info" ) ).toStringList() << info;
+  }
 }
 
 void ConsoleFeedback::pushConsoleInfo( const QString &info )
 {
-  std::cout << info.toLocal8Bit().constData() << '\n';
+  if ( !mUseJson )
+    std::cout << info.toLocal8Bit().constData() << '\n';
+  else
+  {
+    if ( !mJsonLog.contains( QStringLiteral( "info" ) ) )
+      mJsonLog.insert( QStringLiteral( "info" ), QStringList() );
+    mJsonLog[ QStringLiteral( "info" )] = mJsonLog.value( QStringLiteral( "info" ) ).toStringList() << info;
+  }
+}
+
+QVariantMap ConsoleFeedback::jsonLog() const
+{
+  return mJsonLog;
 }
 
 void ConsoleFeedback::showTerminalProgress( double progress )
@@ -151,8 +207,9 @@ QgsProcessingExec::QgsProcessingExec()
 
 }
 
-int QgsProcessingExec::run( const QStringList &args )
+int QgsProcessingExec::run( const QStringList &constArgs )
 {
+  QStringList args = constArgs;
   QObject::connect( QgsApplication::messageLog(), static_cast < void ( QgsMessageLog::* )( const QString &message, const QString &tag, Qgis::MessageLevel level ) >( &QgsMessageLog::messageReceived ), QgsApplication::instance(),
                     [ = ]( const QString & message, const QString &, Qgis::MessageLevel level )
   {
@@ -162,6 +219,14 @@ int QgsProcessingExec::run( const QStringList &args )
         std::cerr << message.toLocal8Bit().constData() << '\n';
     }
   } );
+
+  const int jsonIndex = args.indexOf( QLatin1String( "--json" ) );
+  bool useJson = false;
+  if ( jsonIndex >= 0 )
+  {
+    useJson = true;
+    args.removeAt( jsonIndex );
+  }
 
   if ( args.size() == 1 )
   {
@@ -187,12 +252,12 @@ int QgsProcessingExec::run( const QStringList &args )
   const QString command = args.at( 1 );
   if ( command == QLatin1String( "plugins" ) )
   {
-    listPlugins();
+    listPlugins( useJson );
     return 0;
   }
   else if ( command == QLatin1String( "list" ) )
   {
-    listAlgorithms();
+    listAlgorithms( useJson );
     return 0;
   }
   else if ( command == QLatin1String( "help" ) )
@@ -204,7 +269,7 @@ int QgsProcessingExec::run( const QStringList &args )
     }
 
     const QString algId = args.at( 2 );
-    return showAlgorithmHelp( algId );
+    return showAlgorithmHelp( algId, useJson );
   }
   else if ( command == QLatin1String( "run" ) )
   {
@@ -262,7 +327,7 @@ int QgsProcessingExec::run( const QStringList &args )
       }
     }
 
-    return execute( algId, params, ellipsoid, distanceUnit, areaUnit, projectPath );
+    return execute( algId, params, ellipsoid, distanceUnit, areaUnit, useJson, projectPath );
   }
   else
   {
@@ -277,7 +342,9 @@ void QgsProcessingExec::showUsage( const QString &appName )
 
   msg << "QGIS Processing Executor - " << VERSION << " '" << RELEASE_NAME << "' ("
       << Qgis::version() << ")\n"
-      << "Usage: " << appName <<  " [command] [algorithm id or path to model file] [parameters]\n"
+      << "Usage: " << appName <<  " [--json] [command] [algorithm id or path to model file] [parameters]\n"
+      << "\nOptions:\n"
+      << "\t--json\tOutput results as JSON objects\n"
       << "\nAvailable commands:\n"
       << "\tplugins\tlist available and active plugins\n"
       << "\tlist\tlist all available processing algorithms\n"
@@ -310,47 +377,116 @@ void QgsProcessingExec::loadPlugins()
   }
 }
 
-void QgsProcessingExec::listAlgorithms()
+void QgsProcessingExec::listAlgorithms( bool useJson )
 {
-  std::cout << "Available algorithms\n\n";
+  QVariantMap json;
+  if ( !useJson )
+  {
+    std::cout << "Available algorithms\n\n";
+  }
+  else
+  {
+    addVersionInformation( json );
+  }
 
   const QList<QgsProcessingProvider *> providers = QgsApplication::processingRegistry()->providers();
+  QVariantMap jsonProviders;
   for ( QgsProcessingProvider *provider : providers )
   {
-    std::cout << provider->name().toLocal8Bit().constData() << "\n";
+    QVariantMap providerJson;
+
+    if ( !useJson )
+    {
+      std::cout << provider->name().toLocal8Bit().constData() << "\n";
+    }
+    else
+    {
+      addProviderInformation( providerJson, provider );
+    }
+    QVariantMap algorithmsJson;
     const QList<const QgsProcessingAlgorithm *> algorithms = provider->algorithms();
     for ( const QgsProcessingAlgorithm *algorithm : algorithms )
     {
-      if ( algorithm->flags() & QgsProcessingAlgorithm::FlagDeprecated || algorithm->flags() & QgsProcessingAlgorithm::FlagNotAvailableInStandaloneTool )
+      if ( algorithm->flags() & QgsProcessingAlgorithm::FlagNotAvailableInStandaloneTool )
         continue;
 
-      std::cout << "\t" << algorithm->id().toLocal8Bit().constData() << "\t" << algorithm->displayName().toLocal8Bit().constData() << "\n";
+      if ( !useJson )
+      {
+        if ( algorithm->flags() & QgsProcessingAlgorithm::FlagDeprecated )
+          continue;
+        std::cout << "\t" << algorithm->id().toLocal8Bit().constData() << "\t" << algorithm->displayName().toLocal8Bit().constData() << "\n";
+      }
+      else
+      {
+        QVariantMap algorithmJson;
+        addAlgorithmInformation( algorithmJson, algorithm );
+        algorithmsJson.insert( algorithm->id(), algorithmJson );
+      }
     }
 
-    std::cout << "\n";
+    if ( !useJson )
+    {
+      std::cout << "\n";
+    }
+    else
+    {
+      providerJson.insert( QStringLiteral( "algorithms" ), algorithmsJson );
+      jsonProviders.insert( provider->id(), providerJson );
+    }
+  }
+
+  if ( useJson )
+  {
+    json.insert( QStringLiteral( "providers" ), jsonProviders );
+    std::cout << QgsJsonUtils::jsonFromVariant( json ).dump( 2 );
   }
 }
 
-void QgsProcessingExec::listPlugins()
+void QgsProcessingExec::listPlugins( bool useJson )
 {
-  std::cout << "Available plugins\n";
-  std::cout << "(* indicates loaded plugins which implement Processing providers)\n\n";
+  QVariantMap json;
 
+  if ( !useJson )
+  {
+    std::cout << "Available plugins\n";
+    std::cout << "(* indicates loaded plugins which implement Processing providers)\n\n";
+  }
+  else
+  {
+    addVersionInformation( json );
+  }
+
+  QVariantMap jsonPlugins;
   const QStringList plugins = mPythonUtils->pluginList();
   for ( const QString &plugin : plugins )
   {
     if ( !mPythonUtils->pluginHasProcessingProvider( plugin ) )
       continue;
 
-    if ( mPythonUtils->isPluginLoaded( plugin ) )
-      std::cout << "* ";
+    if ( !useJson )
+    {
+      if ( mPythonUtils->isPluginLoaded( plugin ) )
+        std::cout << "* ";
+      else
+        std::cout << "  ";
+      std::cout << plugin.toLocal8Bit().constData() << "\n";
+    }
     else
-      std::cout << "  ";
-    std::cout << plugin.toLocal8Bit().constData() << "\n";
+    {
+      QVariantMap jsonPlugin;
+      jsonPlugin.insert( QStringLiteral( "loaded" ), mPythonUtils->isPluginLoaded( plugin ) );
+      jsonPlugins.insert( plugin, jsonPlugin );
+    }
+  }
+
+  if ( useJson )
+  {
+    json.insert( QStringLiteral( "plugins" ), jsonPlugins );
+    std::cout << QgsJsonUtils::jsonFromVariant( json ).dump( 2 );
   }
 }
 
-int QgsProcessingExec::showAlgorithmHelp( const QString &id )
+int QgsProcessingExec::showAlgorithmHelp( const QString &id, bool useJson )
 {
   std::unique_ptr< QgsProcessingModelAlgorithm > model;
   const QgsProcessingAlgorithm *alg = nullptr;
@@ -375,74 +511,171 @@ int QgsProcessingExec::showAlgorithmHelp( const QString &id )
     }
   }
 
-  std::cout << QStringLiteral( "%1 (%2)\n" ).arg( alg->displayName(), alg->id() ).toLocal8Bit().constData();
-  std::cout << "\n----------------\n";
-  std::cout << "Description\n";
-  std::cout << "----------------\n";
-  if ( !alg->shortDescription().isEmpty() )
-    std::cout << alg->shortDescription().toLocal8Bit().constData() << '\n';
-  if ( !alg->shortHelpString().isEmpty() && alg->shortHelpString() != alg->shortDescription() )
-    std::cout << alg->shortHelpString().toLocal8Bit().constData() << '\n';
+  QVariantMap json;
+  if ( !useJson )
+  {
+    std::cout << QStringLiteral( "%1 (%2)\n" ).arg( alg->displayName(), alg->id() ).toLocal8Bit().constData();
+    std::cout << "\n----------------\n";
+    std::cout << "Description\n";
+    std::cout << "----------------\n";
+    if ( !alg->shortDescription().isEmpty() )
+      std::cout << alg->shortDescription().toLocal8Bit().constData() << '\n';
+    if ( !alg->shortHelpString().isEmpty() && alg->shortHelpString() != alg->shortDescription() )
+      std::cout << alg->shortHelpString().toLocal8Bit().constData() << '\n';
 
-  std::cout << "\n----------------\n";
-  std::cout << "Arguments\n";
-  std::cout << "----------------\n\n";
+    std::cout << "\n----------------\n";
+    std::cout << "Arguments\n";
+    std::cout << "----------------\n\n";
+  }
+  else
+  {
+    addVersionInformation( json );
 
+    QVariantMap algorithmDetails;
+    algorithmDetails.insert( QStringLiteral( "id" ), alg->id() );
+    addAlgorithmInformation( algorithmDetails, alg );
+    json.insert( QStringLiteral( "algorithm_details" ), algorithmDetails );
+    QVariantMap providerJson;
+    addProviderInformation( providerJson, alg->provider() );
+    json.insert( QStringLiteral( "provider_details" ), providerJson );
+  }
+
+
+  QVariantMap parametersJson;
   const QgsProcessingParameterDefinitions defs = alg->parameterDefinitions();
   for ( const QgsProcessingParameterDefinition *p : defs )
   {
     if ( p->flags() & QgsProcessingParameterDefinition::FlagHidden )
       continue;
 
-    std::cout << QStringLiteral( "%1: %2\n" ).arg( p->name(), p->description() ).toLocal8Bit().constData();
+    QVariantMap parameterJson;
+
+    if ( !useJson )
+      std::cout << QStringLiteral( "%1: %2\n" ).arg( p->name(), p->description() ).toLocal8Bit().constData();
+    else
+    {
+      parameterJson.insert( QStringLiteral( "name" ), p->name() );
+      parameterJson.insert( QStringLiteral( "description" ), p->description() );
+
+
+      if ( const QgsProcessingParameterType *type = QgsApplication::processingRegistry()->parameterType( p->type() ) )
+      {
+        QVariantMap typeDetails;
+        typeDetails.insert( QStringLiteral( "id" ), type->id() );
+        typeDetails.insert( QStringLiteral( "name" ), type->name() );
+        typeDetails.insert( QStringLiteral( "description" ), type->description() );
+        typeDetails.insert( QStringLiteral( "metadata" ), type->metadata() );
+        typeDetails.insert( QStringLiteral( "acceptable_values" ), type->acceptedStringValues() );
+
+        parameterJson.insert( QStringLiteral( "type" ), typeDetails );
+      }
+      else
+      {
+        parameterJson.insert( QStringLiteral( "type" ), p->type() );
+      }
+
+      parameterJson.insert( QStringLiteral( "is_destination" ), p->isDestination() );
+      parameterJson.insert( QStringLiteral( "default_value" ), p->defaultValue() );
+      parameterJson.insert( QStringLiteral( "optional" ), bool( p->flags() & QgsProcessingParameterDefinition::FlagOptional ) );
+      parameterJson.insert( QStringLiteral( "is_advanced" ), bool( p->flags() & QgsProcessingParameterDefinition::FlagAdvanced ) );
+
+      parameterJson.insert( QStringLiteral( "raw_definition" ), p->toVariantMap() );
+    }
+
     if ( ! p->help().isEmpty() )
     {
-      std::cout << QStringLiteral( "\t%1\n" ).arg( p->help() ).toLocal8Bit().constData();
+      if ( !useJson )
+        std::cout << QStringLiteral( "\t%1\n" ).arg( p->help() ).toLocal8Bit().constData();
+      else
+        parameterJson.insert( QStringLiteral( "help" ), p->help() );
     }
-    std::cout << QStringLiteral( "\tArgument type:\t%1\n" ).arg( p->type() ).toLocal8Bit().constData();
+    if ( !useJson )
+      std::cout << QStringLiteral( "\tArgument type:\t%1\n" ).arg( p->type() ).toLocal8Bit().constData();
 
     if ( p->type() == QgsProcessingParameterEnum::typeName() )
     {
       const QgsProcessingParameterEnum *enumParam = static_cast< const QgsProcessingParameterEnum * >( p );
       QStringList options;
+      QVariantMap jsonOptions;
       for ( int i = 0; i < enumParam->options().count(); ++i )
+      {
         options << QStringLiteral( "\t\t- %1: %2" ).arg( i ).arg( enumParam->options().at( i ) );
+        jsonOptions.insert( QString::number( i ), enumParam->options().at( i ) );
+      }
 
-      std::cout << QStringLiteral( "\tAvailable values:\n%1\n" ).arg( options.join( '\n' ) ).toLocal8Bit().constData();
+      if ( !useJson )
+        std::cout << QStringLiteral( "\tAvailable values:\n%1\n" ).arg( options.join( '\n' ) ).toLocal8Bit().constData();
+      else
+        parameterJson.insert( QStringLiteral( "available_options" ), jsonOptions );
     }
 
     // acceptable command line values
-    if ( const QgsProcessingParameterType *type = QgsApplication::processingRegistry()->parameterType( p->type() ) )
+    if ( !useJson )
     {
-      const QStringList values = type->acceptedStringValues();
-      if ( !values.isEmpty() )
+      if ( const QgsProcessingParameterType *type = QgsApplication::processingRegistry()->parameterType( p->type() ) )
       {
-        std::cout << "\tAcceptable values:\n";
-        for ( const QString &val : values )
+        const QStringList values = type->acceptedStringValues();
+        if ( !values.isEmpty() )
         {
-          std::cout << QStringLiteral( "\t\t- %1" ).arg( val ).toLocal8Bit().constData() << "\n";
+          std::cout << "\tAcceptable values:\n";
+          for ( const QString &val : values )
+          {
+            std::cout << QStringLiteral( "\t\t- %1" ).arg( val ).toLocal8Bit().constData() << "\n";
+          }
         }
       }
     }
+
+    parametersJson.insert( p->name(), parameterJson );
   }
 
-  std::cout << "\n----------------\n";
-  std::cout << "Outputs\n";
-  std::cout << "----------------\n\n";
+  QVariantMap outputsJson;
+  if ( !useJson )
+  {
+    std::cout << "\n----------------\n";
+    std::cout << "Outputs\n";
+    std::cout << "----------------\n\n";
+  }
   const QgsProcessingOutputDefinitions outputs = alg->outputDefinitions();
   for ( const QgsProcessingOutputDefinition *o : outputs )
   {
-    std::cout << QStringLiteral( "%1: <%2>\n" ).arg( o->name(), o->type() ).toLocal8Bit().constData();
-    if ( !o->description().isEmpty() )
-      std::cout << "\t" << o->description().toLocal8Bit().constData() << '\n';
+    QVariantMap outputJson;
+    if ( !useJson )
+    {
+      std::cout << QStringLiteral( "%1: <%2>\n" ).arg( o->name(), o->type() ).toLocal8Bit().constData();
+      if ( !o->description().isEmpty() )
+        std::cout << "\t" << o->description().toLocal8Bit().constData() << '\n';
+    }
+    else
+    {
+      outputJson.insert( QStringLiteral( "description" ), o->description() );
+      outputJson.insert( QStringLiteral( "type" ), o->type() );
+      outputsJson.insert( o->name(), outputJson );
+    }
   }
-  std::cout << "\n\n";
+
+  if ( !useJson )
+  {
+    std::cout << "\n\n";
+  }
+  else
+  {
+    json.insert( QStringLiteral( "parameters" ), parametersJson );
+    json.insert( QStringLiteral( "outputs" ), outputsJson );
+    std::cout << QgsJsonUtils::jsonFromVariant( json ).dump( 2 );
+  }
 
   return 0;
 }
 
-int QgsProcessingExec::execute( const QString &id, const QVariantMap &params, const QString &ellipsoid, QgsUnitTypes::DistanceUnit distanceUnit, QgsUnitTypes::AreaUnit areaUnit, const QString &projectPath )
+int QgsProcessingExec::execute( const QString &id, const QVariantMap &params, const QString &ellipsoid, QgsUnitTypes::DistanceUnit distanceUnit, QgsUnitTypes::AreaUnit areaUnit, bool useJson, const QString &projectPath )
 {
+  QVariantMap json;
+  if ( useJson )
+  {
+    addVersionInformation( json );
+  }
+
   std::unique_ptr< QgsProcessingModelAlgorithm > model;
   const QgsProcessingAlgorithm *alg = nullptr;
   if ( QFile::exists( id ) && QFileInfo( id ).suffix() == QLatin1String( "model3" ) )
@@ -471,14 +704,14 @@ int QgsProcessingExec::execute( const QString &id, const QVariantMap &params, co
       return 1;
     }
 
-    if ( alg->flags() & QgsProcessingAlgorithm::FlagKnownIssues )
+    if ( !useJson && alg->flags() & QgsProcessingAlgorithm::FlagKnownIssues )
     {
       std::cout << "\n****************\n";
       std::cout << "Warning: this algorithm contains known issues and the results may be unreliable!\n";
       std::cout << "****************\n\n";
     }
 
-    if ( alg->flags() & QgsProcessingAlgorithm::FlagDeprecated )
+    if ( !useJson && alg->flags() & QgsProcessingAlgorithm::FlagDeprecated )
     {
       std::cout << "\n****************\n";
       std::cout << "Warning: this algorithm is deprecated and may be removed in a future QGIS version!\n";
@@ -492,6 +725,17 @@ int QgsProcessingExec::execute( const QString &id, const QVariantMap &params, co
     }
   }
 
+  if ( useJson )
+  {
+    QVariantMap algorithmDetails;
+    algorithmDetails.insert( QStringLiteral( "id" ), alg->id() );
+    addAlgorithmInformation( algorithmDetails, alg );
+    json.insert( QStringLiteral( "algorithm_details" ), algorithmDetails );
+    QVariantMap providerJson;
+    addProviderInformation( providerJson, alg->provider() );
+    json.insert( QStringLiteral( "provider_details" ), providerJson );
+  }
+
   std::unique_ptr< QgsProject > project;
   if ( !projectPath.isEmpty() )
   {
@@ -503,22 +747,46 @@ int QgsProcessingExec::execute( const QString &id, const QVariantMap &params, co
     }
   }
 
-  std::cout << "\n----------------\n";
-  std::cout << "Inputs\n";
-  std::cout << "----------------\n\n";
+  if ( !useJson )
+  {
+    std::cout << "\n----------------\n";
+    std::cout << "Inputs\n";
+    std::cout << "----------------\n\n";
+  }
+  QVariantMap inputsJson;
   for ( auto it = params.constBegin(); it != params.constEnd(); ++it )
   {
-    std::cout << it.key().toLocal8Bit().constData() << ":\t" << it.value().toString().toLocal8Bit().constData() << '\n';
+    if ( !useJson )
+      std::cout << it.key().toLocal8Bit().constData() << ":\t" << it.value().toString().toLocal8Bit().constData() << '\n';
+    else
+      inputsJson.insert( it.key(), it.value() );
   }
-
-  std::cout << "\n";
+  if ( !useJson )
+    std::cout << "\n";
+  else
+    json.insert( QStringLiteral( "inputs" ), inputsJson );
 
   if ( !ellipsoid.isEmpty() )
-    std::cout << "Using ellipsoid:\t" << ellipsoid.toLocal8Bit().constData() << '\n';
+  {
+    if ( !useJson )
+      std::cout << "Using ellipsoid:\t" << ellipsoid.toLocal8Bit().constData() << '\n';
+    else
+      json.insert( QStringLiteral( "ellipsoid" ), ellipsoid );
+  }
   if ( distanceUnit != QgsUnitTypes::DistanceUnknownUnit )
-    std::cout << "Using distance unit:\t" << QgsUnitTypes::toString( distanceUnit ).toLocal8Bit().constData() << '\n';
+  {
+    if ( !useJson )
+      std::cout << "Using distance unit:\t" << QgsUnitTypes::toString( distanceUnit ).toLocal8Bit().constData() << '\n';
+    else
+      json.insert( QStringLiteral( "distance_unit" ), QgsUnitTypes::toString( distanceUnit ) );
+  }
   if ( areaUnit != QgsUnitTypes::AreaUnknownUnit )
-    std::cout << "Using area unit:\t" << QgsUnitTypes::toString( areaUnit ).toLocal8Bit().constData() << '\n';
+  {
+    if ( !useJson )
+      std::cout << "Using area unit:\t" << QgsUnitTypes::toString( areaUnit ).toLocal8Bit().constData() << '\n';
+    else
+      json.insert( QStringLiteral( "area_unit" ), QgsUnitTypes::toString( areaUnit ) );
+  }
 
   QgsProcessingContext context;
   context.setEllipsoid( ellipsoid );
@@ -558,7 +826,7 @@ int QgsProcessingExec::execute( const QString &id, const QVariantMap &params, co
     return 1;
   }
 
-  ConsoleFeedback feedback;
+  ConsoleFeedback feedback( useJson );
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_ANDROID)
   UnixSignalWatcher sigwatch;
@@ -579,14 +847,24 @@ int QgsProcessingExec::execute( const QString &id, const QVariantMap &params, co
 #endif
 
   bool ok = false;
-  std::cout << "\n";
+  if ( !useJson )
+    std::cout << "\n";
+
   QVariantMap res = alg->run( params, context, &feedback, &ok );
 
   if ( ok )
   {
-    std::cout << "\n----------------\n";
-    std::cout << "Results\n";
-    std::cout << "----------------\n\n";
+    QVariantMap resultsJson;
+    if ( !useJson )
+    {
+      std::cout << "\n----------------\n";
+      std::cout << "Results\n";
+      std::cout << "----------------\n\n";
+    }
+    else
+    {
+      json.insert( QStringLiteral( "log" ), feedback.jsonLog() );
+    }
 
     for ( auto it = res.constBegin(); it != res.constEnd(); ++it )
     {
@@ -594,14 +872,27 @@ int QgsProcessingExec::execute( const QString &id, const QVariantMap &params, co
         continue;
 
       QVariant result = it.value();
-      if ( result.type() == QVariant::List || result.type() == QVariant::StringList )
+      if ( !useJson )
       {
-        QStringList list;
-        for ( const QVariant &v : result.toList() )
-          list << v.toString();
-        result = list.join( ", " );
+        if ( result.type() == QVariant::List || result.type() == QVariant::StringList )
+        {
+          QStringList list;
+          for ( const QVariant &v : result.toList() )
+            list << v.toString();
+          result = list.join( ", " );
+        }
+        std::cout << it.key().toLocal8Bit().constData() << ":\t" << result.toString().toLocal8Bit().constData() << '\n';
       }
-      std::cout << it.key().toLocal8Bit().constData() << ":\t" << result.toString().toLocal8Bit().constData() << '\n';
+      else
+      {
+        resultsJson.insert( it.key(), result );
+      }
+    }
+
+    if ( useJson )
+    {
+      json.insert( QStringLiteral( "results" ), resultsJson );
+      std::cout << QgsJsonUtils::jsonFromVariant( json ).dump( 2 );
     }
     return 0;
   }
@@ -609,4 +900,55 @@ int QgsProcessingExec::execute( const QString &id, const QVariantMap &params, co
   {
     return 1;
   }
+}
+
+void QgsProcessingExec::addVersionInformation( QVariantMap &json )
+{
+  json.insert( QStringLiteral( "qgis_version" ), Qgis::version() );
+  if ( QString( Qgis::devVersion() ) != QLatin1String( "exported" ) )
+  {
+    json.insert( QStringLiteral( "qgis_code_revision" ), Qgis::devVersion() );
+  }
+  json.insert( QStringLiteral( "qt_version" ), qVersion() );
+  json.insert( QStringLiteral( "gdal_version" ), GDALVersionInfo( "RELEASE_NAME" ) );
+  json.insert( QStringLiteral( "geos_version" ), GEOSversion() );
+
+#if PROJ_VERSION_MAJOR > 4
+  PJ_INFO info = proj_info();
+  json.insert( QStringLiteral( "proj_version" ), info.release );
+#else
+  json.insert( QStringLiteral( "proj_version" ), PJ_VERSION );
+#endif
+}
+
+void QgsProcessingExec::addAlgorithmInformation( QVariantMap &algorithmJson, const QgsProcessingAlgorithm *algorithm )
+{
+  algorithmJson.insert( QStringLiteral( "name" ), algorithm->displayName() );
+  algorithmJson.insert( QStringLiteral( "short_description" ), algorithm->shortDescription() );
+  algorithmJson.insert( QStringLiteral( "tags" ), algorithm->tags() );
+  algorithmJson.insert( QStringLiteral( "help_url" ), algorithm->helpUrl() );
+  algorithmJson.insert( QStringLiteral( "group" ), algorithm->group() );
+  algorithmJson.insert( QStringLiteral( "can_cancel" ), bool( algorithm->flags() & QgsProcessingAlgorithm::FlagCanCancel ) );
+  algorithmJson.insert( QStringLiteral( "requires_matching_crs" ), bool( algorithm->flags() & QgsProcessingAlgorithm::FlagRequiresMatchingCrs ) );
+  algorithmJson.insert( QStringLiteral( "has_known_issues" ), bool( algorithm->flags() & QgsProcessingAlgorithm::FlagKnownIssues ) );
+  algorithmJson.insert( QStringLiteral( "deprecated" ), bool( algorithm->flags() & QgsProcessingAlgorithm::FlagDeprecated ) );
+}
+
+void QgsProcessingExec::addProviderInformation( QVariantMap &providerJson, QgsProcessingProvider *provider )
+{
+  providerJson.insert( QStringLiteral( "name" ), provider->name() );
+  providerJson.insert( QStringLiteral( "long_name" ), provider->longName() );
+  providerJson.insert( QStringLiteral( "version" ), provider->versionInfo() );
+  providerJson.insert( QStringLiteral( "can_be_activated" ), provider->canBeActivated() );
+  if ( !provider->warningMessage().isEmpty() )
+  {
+    providerJson.insert( QStringLiteral( "warning" ), provider->warningMessage() );
+  }
+  providerJson.insert( QStringLiteral( "is_active" ), provider->isActive() );
+  providerJson.insert( QStringLiteral( "supported_output_raster_extensions" ), provider->supportedOutputRasterLayerExtensions() );
+  providerJson.insert( QStringLiteral( "supported_output_vector_extensions" ), provider->supportedOutputVectorLayerExtensions() );
+  providerJson.insert( QStringLiteral( "supported_output_table_extensions" ), provider->supportedOutputTableExtensions() );
+  providerJson.insert( QStringLiteral( "default_vector_file_extension" ), provider->defaultVectorFileExtension() );
+  providerJson.insert( QStringLiteral( "default_raster_file_extension" ), provider->defaultRasterFileExtension() );
+  providerJson.insert( QStringLiteral( "supports_non_file_based_output" ), provider->supportsNonFileBasedOutput() );
 }

--- a/src/process/qgsprocess.h
+++ b/src/process/qgsprocess.h
@@ -25,6 +25,8 @@
 
 class QgsApplication;
 
+class QgsProcessingAlgorithm;
+
 class ConsoleFeedback : public QgsProcessingFeedback
 {
     Q_OBJECT
@@ -34,7 +36,7 @@ class ConsoleFeedback : public QgsProcessingFeedback
     /**
      * Constructor for QgsProcessingAlgorithmDialogFeedback.
      */
-    ConsoleFeedback();
+    ConsoleFeedback( bool useJson );
 
   public slots:
 
@@ -44,6 +46,7 @@ class ConsoleFeedback : public QgsProcessingFeedback
     void pushCommandInfo( const QString &info ) override;
     void pushDebugInfo( const QString &info ) override;
     void pushConsoleInfo( const QString &info ) override;
+    QVariantMap jsonLog() const;
 
   private slots:
     void showTerminalProgress( double progress );
@@ -51,6 +54,8 @@ class ConsoleFeedback : public QgsProcessingFeedback
   private:
     QElapsedTimer mTimer;
     int mLastTick = -1;
+    bool mUseJson = false;
+    QVariantMap mJsonLog;
 };
 
 
@@ -66,15 +71,20 @@ class QgsProcessingExec
 
     void showUsage( const QString &appName );
     void loadPlugins();
-    void listAlgorithms();
-    void listPlugins();
-    int showAlgorithmHelp( const QString &id );
+    void listAlgorithms( bool useJson );
+    void listPlugins( bool useJson );
+    int showAlgorithmHelp( const QString &id, bool useJson );
     int execute( const QString &algId,
                  const QVariantMap &parameters,
                  const QString &ellipsoid,
                  QgsUnitTypes::DistanceUnit distanceUnit,
                  QgsUnitTypes::AreaUnit areaUnit,
+                 bool useJson,
                  const QString &projectPath = QString() );
+
+    void addVersionInformation( QVariantMap &json );
+    void addAlgorithmInformation( QVariantMap &json, const QgsProcessingAlgorithm *algorithm );
+    void addProviderInformation( QVariantMap &json, QgsProcessingProvider *provider );
 
     std::unique_ptr< QgsPythonUtils > mPythonUtils;
     std::unique_ptr<QgsPythonUtils> loadPythonSupport();

--- a/tests/src/python/test_qgsprocessexecutable.py
+++ b/tests/src/python/test_qgsprocessexecutable.py
@@ -18,6 +18,7 @@ import time
 import shutil
 import subprocess
 import tempfile
+import json
 import errno
 
 from qgis.testing import unittest
@@ -73,6 +74,19 @@ class TestQgsProcessExecutable(unittest.TestCase):
             self.assertFalse(err)
         self.assertEqual(rc, 0)
 
+    def testPluginsJson(self):
+        rc, output, err = self.run_process(['plugins', '--json'])
+        res = json.loads(output)
+        self.assertIn('gdal_version', res)
+        self.assertIn('geos_version', res)
+        self.assertIn('proj_version', res)
+        self.assertIn('qt_version', res)
+        self.assertIn('qgis_version', res)
+        self.assertIn('plugins', res)
+        self.assertIn('processing', res['plugins'])
+        self.assertTrue(res['plugins']['processing']['loaded'])
+        self.assertEqual(rc, 0)
+
     def testAlgorithmList(self):
         rc, output, err = self.run_process(['list'])
         self.assertIn('available algorithms', output.lower())
@@ -80,6 +94,23 @@ class TestQgsProcessExecutable(unittest.TestCase):
         if os.environ.get('TRAVIS', '') != 'true':
             # Travis DOES have errors, due to QStandardPaths: XDG_RUNTIME_DIR not set warnings raised by Qt
             self.assertFalse(err)
+        self.assertEqual(rc, 0)
+
+    def testAlgorithmsListJson(self):
+        rc, output, err = self.run_process(['list', '--json'])
+        res = json.loads(output)
+        self.assertIn('gdal_version', res)
+        self.assertIn('geos_version', res)
+        self.assertIn('proj_version', res)
+        self.assertIn('qt_version', res)
+        self.assertIn('qgis_version', res)
+
+        self.assertIn('providers', res)
+        self.assertIn('native', res['providers'])
+        self.assertTrue(res['providers']['native']['is_active'])
+        self.assertIn('native:buffer', res['providers']['native']['algorithms'])
+        self.assertFalse(res['providers']['native']['algorithms']['native:buffer']['deprecated'])
+
         self.assertEqual(rc, 0)
 
     def testAlgorithmHelpNoAlg(self):
@@ -95,6 +126,26 @@ class TestQgsProcessExecutable(unittest.TestCase):
         if os.environ.get('TRAVIS', '') != 'true':
             # Travis DOES have errors, due to QStandardPaths: XDG_RUNTIME_DIR not set warnings raised by Qt
             self.assertFalse(err)
+        self.assertEqual(rc, 0)
+
+    def testAlgorithmHelpJson(self):
+        rc, output, err = self.run_process(['help', 'native:buffer', '--json'])
+        res = json.loads(output)
+
+        self.assertIn('gdal_version', res)
+        self.assertIn('geos_version', res)
+        self.assertIn('proj_version', res)
+        self.assertIn('qt_version', res)
+        self.assertIn('qgis_version', res)
+
+        self.assertFalse(res['algorithm_details']['deprecated'])
+        self.assertTrue(res['provider_details']['is_active'])
+
+        self.assertIn('OUTPUT', res['outputs'])
+        self.assertEqual(res['outputs']['OUTPUT']['description'], 'Buffered')
+        self.assertEqual(res['parameters']['DISSOLVE']['description'], 'Dissolve result')
+        self.assertFalse(res['parameters']['DISTANCE']['is_advanced'])
+
         self.assertEqual(rc, 0)
 
     def testAlgorithmRunNoAlg(self):
@@ -118,6 +169,25 @@ class TestQgsProcessExecutable(unittest.TestCase):
         self.assertIn('0...10...20...30...40...50...60...70...80...90', output.lower())
         self.assertIn('results', output.lower())
         self.assertIn('OUTPUT:\t' + output_file, output)
+        self.assertTrue(os.path.exists(output_file))
+        self.assertEqual(rc, 0)
+
+    def testAlgorithmRunJson(self):
+        output_file = self.TMP_DIR + '/polygon_centroid2.shp'
+        rc, output, err = self.run_process(['run', '--json', 'native:centroids', '--INPUT={}'.format(TEST_DATA_DIR + '/polys.shp'), '--OUTPUT={}'.format(output_file)])
+        res = json.loads(output)
+
+        self.assertIn('gdal_version', res)
+        self.assertIn('geos_version', res)
+        self.assertIn('proj_version', res)
+        self.assertIn('qt_version', res)
+        self.assertIn('qgis_version', res)
+
+        self.assertEqual(res['algorithm_details']['name'], 'Centroids')
+        self.assertEqual(res['inputs']['INPUT'], TEST_DATA_DIR + '/polys.shp')
+        self.assertEqual(res['inputs']['OUTPUT'], output_file)
+        self.assertEqual(res['results']['OUTPUT'], output_file)
+
         self.assertTrue(os.path.exists(output_file))
         self.assertEqual(rc, 0)
 


### PR DESCRIPTION
This allows external tools to more easily use the standalong qgis_process
tool without resorting to fragile string parsing of the outputs from
that tool.

Refs https://github.com/paleolimbot/qgisprocess/issues/21, and means
that we play nice with other tools who want to use QGIS algorithms!
