### PR TITLE
Add note about Python bindings in QgsAction

### DIFF
--- a/python/core/auto_generated/qgsaction.sip.in
+++ b/python/core/auto_generated/qgsaction.sip.in
@@ -42,7 +42,7 @@ Create a new QgsAction
 :param description: A human readable description string
 :param command: The action text. Its interpretation depends on the type
 :param capture: If this is set to ``True``, the output will be captured when an action is run
-:param enabledOnlyWhenEditable: if ``True`` then action is only enable in editmode
+:param enabledOnlyWhenEditable: if ``True`` then action is only enable in editmode. Not available in Python bindings.
 %End
 
     QgsAction( ActionType type, const QString &description, const QString &action, const QString &icon, bool capture, const QString &shortTitle = QString(), const QSet<QString> &actionScopes = QSet<QString>(), const QString &notificationMessage = QString() );
@@ -57,7 +57,7 @@ Create a new QgsAction
 :param shortTitle: A short string used to label user interface elements like buttons
 :param actionScopes: A set of scopes in which this action will be available
 :param notificationMessage: A particular message which reception will trigger the action
-:param enabledOnlyWhenEditable: if ``True`` then action is only enable in editmode
+:param enabledOnlyWhenEditable: if ``True`` then action is only enable in editmode. Not available in Python bindings.
 %End
 
     QString name() const;
@@ -126,6 +126,12 @@ Whether to capture output for display when this action is run
 Returns whether only enabled in editable mode
 %End
 
+    void setEnabledOnlyWhenEditable( bool enable );
+%Docstring
+Set whether the action is only enabled in editable mode
+
+.. versionadded:: 3.16
+%End
 
     bool runable() const;
 %Docstring

--- a/src/core/qgsaction.h
+++ b/src/core/qgsaction.h
@@ -57,7 +57,7 @@ class CORE_EXPORT QgsAction
      * \param description   A human readable description string
      * \param command       The action text. Its interpretation depends on the type
      * \param capture       If this is set to TRUE, the output will be captured when an action is run
-     * \param enabledOnlyWhenEditable if TRUE then action is only enable in editmode
+     * \param enabledOnlyWhenEditable if TRUE then action is only enable in editmode. Not available in Python bindings.
      */
 #ifndef SIP_RUN
     QgsAction( ActionType type, const QString &description, const QString &command, bool capture = false, bool enabledOnlyWhenEditable = false )
@@ -90,7 +90,7 @@ class CORE_EXPORT QgsAction
      * \param shortTitle           A short string used to label user interface elements like buttons
      * \param actionScopes         A set of scopes in which this action will be available
      * \param notificationMessage  A particular message which reception will trigger the action
-     * \param enabledOnlyWhenEditable if TRUE then action is only enable in editmode
+     * \param enabledOnlyWhenEditable if TRUE then action is only enable in editmode. Not available in Python bindings.
      */
 #ifndef SIP_RUN
     QgsAction( ActionType type, const QString &description, const QString &action, const QString &icon, bool capture, const QString &shortTitle = QString(), const QSet<QString> &actionScopes = QSet<QString>(), const QString &notificationMessage = QString(), bool enabledOnlyWhenEditable = false )
@@ -171,6 +171,13 @@ class CORE_EXPORT QgsAction
 
     //! Returns whether only enabled in editable mode
     bool isEnabledOnlyWhenEditable() const { return mIsEnabledOnlyWhenEditable; }
+
+    /**
+     * Set whether the action is only enabled in editable mode
+     *
+     * \since QGIS 3.16
+     */
+    void setEnabledOnlyWhenEditable( bool enable ) { mIsEnabledOnlyWhenEditable = enable; };
 
 
     //! Checks if the action is runable on the current platform


### PR DESCRIPTION
## Description

From : https://qgis.org/pyqgis/3.10/core/QgsAction.html

```
QgsAction(type: QgsAction.ActionType, description: str, command: str, capture: bool = False) Create a new QgsAction

Parameters

        type – The type of this action

        description – A human readable description string

        command – The action text. Its interpretation depends on the type

        capture – If this is set to True, the output will be captured when an action is run

        enabledOnlyWhenEditable – if True then action is only enable in editmode

```

The constructor is missing this parameter.

@signedav Why is it not possible to create an action enabled only when the layer is editable? 
To overpass this bindings, we need to use a QML and load it to have this kind of action.