### PR TITLE
OGR decodeUri: be tolerant on layerName case

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3473,9 +3473,9 @@ QVariantMap QgsOgrProviderMetadata::decodeUri( const QString &uri )
 
   if ( path.contains( '|' ) )
   {
-    const QRegularExpression geometryTypeRegex( QStringLiteral( "\\|geometrytype=([a-zA-Z0-9]*)" ) );
-    const QRegularExpression layerNameRegex( QStringLiteral( "\\|layername=([^|]*)" ) );
-    const QRegularExpression layerIdRegex( QStringLiteral( "\\|layerid=([^|]*)" ) );
+    const QRegularExpression geometryTypeRegex( QStringLiteral( "\\|geometrytype=([a-zA-Z0-9]*)" ), QRegularExpression::PatternOption::CaseInsensitiveOption );
+    const QRegularExpression layerNameRegex( QStringLiteral( "\\|layername=([^|]*)" ), QRegularExpression::PatternOption::CaseInsensitiveOption );
+    const QRegularExpression layerIdRegex( QStringLiteral( "\\|layerid=([^|]*)" ), QRegularExpression::PatternOption::CaseInsensitiveOption );
     const QRegularExpression subsetRegex( QStringLiteral( "\\|subset=((?:.*[\r\n]*)*)\\Z" ) );
     const QRegularExpression openOptionRegex( QStringLiteral( "\\|option:([^|]*)" ) );
 

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -257,10 +257,25 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         self.assertEqual(components["path"], filename)
         self.assertEqual(components["layerName"], 'test')
 
+        uri = '{}|layerName=test'.format(filename)
+        components = registry.decodeUri('ogr', uri)
+        self.assertEqual(components["path"], filename)
+        self.assertEqual(components["layerName"], 'test')
+
         uri = '{}|layerid=0'.format(filename)
         components = registry.decodeUri('ogr', uri)
         self.assertEqual(components["path"], filename)
         self.assertEqual(components["layerId"], 0)
+
+        uri = '{}|layerId=0'.format(filename)
+        components = registry.decodeUri('ogr', uri)
+        self.assertEqual(components["path"], filename)
+        self.assertEqual(components["layerId"], 0)
+
+        uri = '{}|geometryType=POINT'.format(filename)
+        components = registry.decodeUri('ogr', uri)
+        self.assertEqual(components["path"], filename)
+        self.assertEqual(components["geometryType"], 'POINT')
 
     def testEncodeUri(self):
 


### PR DESCRIPTION
Unreported issue: discovered in the QGIS-Documentation
test CI issue
https://travis-ci.org/github/qgis/QGIS-Documentation/builds/734917369#L679

No need to backport because this was introduced recently.

CC: @DelazJ 