### PR TITLE
[symbology] Fix SVG marker anchor calculation and improve bounds

### DIFF
--- a/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
@@ -683,13 +683,14 @@ Returns the units for the stroke width.
 
   protected:
 
-    double calculateAspectRatio( QgsSymbolRenderContext &context, double scaledSize, bool &hasDataDefinedAspectRatio ) const;
+    double calculateAspectRatio( QgsSymbolRenderContext &context, double scaledSize, bool &hasDataDefinedAspectRatio, double &scaledHeight ) const;
 %Docstring
 Calculates the marker aspect ratio between width and height.
 
 :param context: symbol render context
 :param scaledSize: size of symbol to render
 :param hasDataDefinedAspectRatio: will be set to ``True`` if marker has data defined aspectRatio
+:param scaledHeight: will be set to the resulting height taking size (i.e. width) and ratio into account
 %End
 
 

--- a/src/core/symbology/qgsmarkersymbollayer.h
+++ b/src/core/symbology/qgsmarkersymbollayer.h
@@ -613,8 +613,9 @@ class CORE_EXPORT QgsSvgMarkerSymbolLayer : public QgsMarkerSymbolLayer
      * \param context symbol render context
      * \param scaledSize size of symbol to render
      * \param hasDataDefinedAspectRatio will be set to TRUE if marker has data defined aspectRatio
+     * \param scaledHeight will be set to the resulting height taking size (i.e. width) and ratio into account
      */
-    double calculateAspectRatio( QgsSymbolRenderContext &context, double scaledSize, bool &hasDataDefinedAspectRatio ) const;
+    double calculateAspectRatio( QgsSymbolRenderContext &context, double scaledSize, bool &hasDataDefinedAspectRatio, double &scaledHeight ) const;
 
     QString mPath;
 
@@ -633,7 +634,7 @@ class CORE_EXPORT QgsSvgMarkerSymbolLayer : public QgsMarkerSymbolLayer
 
   private:
     double calculateSize( QgsSymbolRenderContext &context, bool &hasDataDefinedSize ) const;
-    void calculateOffsetAndRotation( QgsSymbolRenderContext &context, double scaledSize, QPointF &offset, double &angle ) const;
+    void calculateOffsetAndRotation( QgsSymbolRenderContext &context, double scaledWidth, double scaledHeight, QPointF &offset, double &angle ) const;
 
 };
 


### PR DESCRIPTION
## Description

This PR fixes a long-standing issue with SVG markers whereas its anchor calculation was wrongly assuming the SVG marker to be square in size. It resulted in wrong placement with setting the vertical anchor to top / bottom.