### PR TITLE
Cleanup margin handling in QgsCodeEditor and subclasses

### DIFF
--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -149,15 +149,17 @@ class ShellOutputScintilla(QgsCodeEditorPython):
         else:
             self.setText(txtInit + '\n')
 
+    def initializeLexer(self):
+        super().initializeLexer()
+        self.setFoldingVisible(False)
+        self.setEdgeMode(QsciScintilla.EdgeNone)
+
     def refreshSettingsOutput(self):
         # Set Python lexer
         self.initializeLexer()
         self.setReadOnly(True)
 
         self.setCaretWidth(0)  # NO (blinking) caret in the output
-
-        self.setFoldingVisible(False)
-        self.setEdgeMode(QsciScintilla.EdgeNone)
 
     def clearConsole(self):
         self.setText('')

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -107,6 +107,18 @@ class ShellScintilla(QgsCodeEditorPython, code.InteractiveInterpreter):
         self.newShortcutCAS.activated.connect(self.autoComplete)
         self.newShortcutCSS.activated.connect(self.showHistory)
 
+    def initializeLexer(self):
+        super().initializeLexer()
+        self.setCaretLineVisible(False)
+        self.setLineNumbersVisible(False)  # NO linenumbers for the input line
+        self.setFoldingVisible(False)
+        # Margin 1 is used for the '>>>' prompt (console input)
+        self.setMarginLineNumbers(1, True)
+        self.setMarginWidth(1, "00000")
+        self.setMarginType(1, 5)  # TextMarginRightJustified=5
+        self.setMarginsBackgroundColor(self.color(QgsCodeEditorColorScheme.ColorRole.Background))
+        self.setEdgeMode(QsciScintilla.EdgeNone)
+
     def _setMinimumHeight(self):
         font = self.lexer().defaultFont(0)
         fm = QFontMetrics(font)
@@ -119,17 +131,6 @@ class ShellScintilla(QgsCodeEditorPython, code.InteractiveInterpreter):
 
         # Sets minimum height for input area based of font metric
         self._setMinimumHeight()
-
-        self.setCaretLineVisible(False)
-        self.setLineNumbersVisible(False)  # NO linenumbers for the input line
-        self.setMarginWidth(QgsCodeEditor.FoldingControls, 0)
-        # Margin 1 is used for the '>>>' prompt (console input)
-        self.setMarginLineNumbers(1, True)
-        self.setMarginWidth(1, "00000")
-        self.setMarginType(1, 5)  # TextMarginRightJustified=5
-        self.setMarginsBackgroundColor(self.color(QgsCodeEditorColorScheme.ColorRole.Background))
-        self.setFoldingVisible(False)
-        self.setEdgeMode(QsciScintilla.EdgeNone)
 
     def showHistory(self):
         if not self.historyDlg.isVisible():

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -33,6 +33,8 @@ import re
 import traceback
 
 from qgis.core import QgsApplication, QgsSettings, Qgis
+from qgis.gui import QgsCodeEditor
+
 from .ui_console_history_dlg import Ui_HistoryDialogPythonConsole
 
 _init_commands = ["import sys", "import os", "import re", "import math", "from qgis.core import *",
@@ -119,10 +121,8 @@ class ShellScintilla(QgsCodeEditorPython, code.InteractiveInterpreter):
         self._setMinimumHeight()
 
         self.setCaretLineVisible(False)
-        self.setMarginLineNumbers(0, False)  # NO linenumbers for the input line
-        self.setMarginWidth(0, 0)
-        # margin 2 is the folding
-        self.setMarginWidth(2, 0)
+        self.setLineNumbersVisible(False)  # NO linenumbers for the input line
+        self.setMarginWidth(QgsCodeEditor.FoldingControls, 0)
         # Margin 1 is used for the '>>>' prompt (console input)
         self.setMarginLineNumbers(1, True)
         self.setMarginWidth(1, "00000")

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -96,11 +96,17 @@ Returns whether line numbers are visible in the editor.
 
     void setFoldingVisible( bool folding );
 %Docstring
-Set folding visible state
+Set whether the folding controls are visible in the editor.
 
-:param folding: Set folding in the editor
+.. seealso:: :py:func:`foldingVisible`
 %End
+
     bool foldingVisible();
+%Docstring
+Returns ``True`` if the folding controls are visible in the editor.
+
+.. seealso:: :py:func:`setFoldingVisible`
+%End
 
     void insertText( const QString &text );
 %Docstring

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -30,6 +30,13 @@ A text editor based on QScintilla2.
 %End
   public:
 
+    enum MarginRole
+    {
+      LineNumbers,
+      ErrorIndicators,
+      FoldingControls,
+    };
+
     QgsCodeEditor( QWidget *parent /TransferThis/ = 0, const QString &title = QString(), bool folding = false, bool margin = false );
 %Docstring
 Construct a new code editor.
@@ -37,7 +44,7 @@ Construct a new code editor.
 :param parent: The parent QWidget
 :param title: The title to show in the code editor dialog
 :param folding: ``False``: Enable folding for code editor
-:param margin: ``False``: Enable margin for code editor
+:param margin: ``False``: Enable margin for code editor (deprecated)
 
 .. versionadded:: 2.6
 %End
@@ -49,13 +56,43 @@ Set the widget title
 :param title: widget title
 %End
 
-    void setMarginVisible( bool margin );
+ void setMarginVisible( bool margin ) /Deprecated/;
 %Docstring
 Set margin visible state
 
 :param margin: Set margin in the editor
+
+.. deprecated::
+   Use base class methods for individual margins instead, or setLineNumbersVisible()
 %End
-    bool marginVisible();
+
+ bool marginVisible() /Deprecated/;
+%Docstring
+Returns whether margins are in a visible state
+
+.. deprecated::
+   Use base class methods for individual margins instead, or lineNumbersVisible()
+%End
+
+    void setLineNumbersVisible( bool visible );
+%Docstring
+Sets whether line numbers should be visible in the editor.
+
+Defaults to ``False``.
+
+.. seealso:: :py:func:`lineNumbersVisible`
+
+.. versionadded:: 3.16
+%End
+
+    bool lineNumbersVisible() const;
+%Docstring
+Returns whether line numbers are visible in the editor.
+
+.. seealso:: :py:func:`setLineNumbersVisible`
+
+.. versionadded:: 3.16
+%End
 
     void setFoldingVisible( bool folding );
 %Docstring

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -230,9 +230,9 @@ void QgsCodeEditor::setSciWidget()
   setMatchedBraceBackgroundColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::MatchedBraceBackground ) );
 
   setLineNumbersVisible( false );
+  setFoldingVisible( false );
 
   setMarginWidth( QgsCodeEditor::MarginRole::ErrorIndicators, 0 );
-  setMarginWidth( QgsCodeEditor::MarginRole::FoldingControls, 0 );
 
   setMarginsForegroundColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::MarginForeground ) );
   setMarginsBackgroundColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::MarginBackground ) );
@@ -311,11 +311,15 @@ void QgsCodeEditor::setFoldingVisible( bool folding )
   mFolding = folding;
   if ( folding )
   {
+    setMarginWidth( QgsCodeEditor::MarginRole::FoldingControls, "0" );
+    setMarginsForegroundColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::MarginForeground ) );
+    setMarginsBackgroundColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::MarginBackground ) );
     setFolding( QsciScintilla::PlainFoldStyle );
   }
   else
   {
     setFolding( QsciScintilla::NoFoldStyle );
+    setMarginWidth( QgsCodeEditor::MarginRole::FoldingControls, 0 );
   }
 }
 

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -107,10 +107,15 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
     bool lineNumbersVisible() const;
 
     /**
-     * Set folding visible state
-     *  \param folding Set folding in the editor
+     * Set whether the folding controls are visible in the editor.
+     * \see foldingVisible()
      */
     void setFoldingVisible( bool folding );
+
+    /**
+     * Returns TRUE if the folding controls are visible in the editor.
+     * \see setFoldingVisible()
+     */
     bool foldingVisible() { return mFolding; }
 
     /**

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -45,12 +45,26 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
   public:
 
     /**
+     * Margin roles.
+     *
+     * This enum contains the roles which the different numbered margins are used for.
+     *
+     * \since QGIS 3.16
+     */
+    enum MarginRole
+    {
+      LineNumbers = 0, //!< Line numbers
+      ErrorIndicators = 1, //!< Error indicators
+      FoldingControls = 2, //!< Folding controls
+    };
+
+    /**
      * Construct a new code editor.
      *
      * \param parent The parent QWidget
      * \param title The title to show in the code editor dialog
      * \param folding FALSE: Enable folding for code editor
-     * \param margin FALSE: Enable margin for code editor
+     * \param margin FALSE: Enable margin for code editor (deprecated)
      * \since QGIS 2.6
      */
     QgsCodeEditor( QWidget *parent SIP_TRANSFERTHIS = nullptr, const QString &title = QString(), bool folding = false, bool margin = false );
@@ -63,10 +77,34 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
 
     /**
      * Set margin visible state
-     *  \param margin Set margin in the editor
+     * \param margin Set margin in the editor
+     * \deprecated Use base class methods for individual margins instead, or setLineNumbersVisible()
      */
-    void setMarginVisible( bool margin );
-    bool marginVisible() { return mMargin; }
+    Q_DECL_DEPRECATED void setMarginVisible( bool margin ) SIP_DEPRECATED;
+
+    /**
+     * Returns whether margins are in a visible state
+     * \deprecated Use base class methods for individual margins instead, or lineNumbersVisible()
+     */
+    Q_DECL_DEPRECATED bool marginVisible() SIP_DEPRECATED { return mMargin; }
+
+    /**
+     * Sets whether line numbers should be visible in the editor.
+     *
+     * Defaults to FALSE.
+     *
+     * \see lineNumbersVisible()
+     * \since QGIS 3.16
+     */
+    void setLineNumbersVisible( bool visible );
+
+    /**
+     * Returns whether line numbers are visible in the editor.
+     *
+     * \see setLineNumbersVisible()
+     * \since QGIS 3.16
+     */
+    bool lineNumbersVisible() const;
 
     /**
      * Set folding visible state

--- a/src/gui/codeeditors/qgscodeeditorcss.cpp
+++ b/src/gui/codeeditors/qgscodeeditorcss.cpp
@@ -29,7 +29,6 @@ QgsCodeEditorCSS::QgsCodeEditorCSS( QWidget *parent )
   {
     setTitle( tr( "CSS Editor" ) );
   }
-  setMarginVisible( false );
   setFoldingVisible( true );
   QgsCodeEditorCSS::initializeLexer();
 }

--- a/src/gui/codeeditors/qgscodeeditorexpression.cpp
+++ b/src/gui/codeeditors/qgscodeeditorexpression.cpp
@@ -27,7 +27,6 @@ QgsCodeEditorExpression::QgsCodeEditorExpression( QWidget *parent )
   {
     setTitle( tr( "Expression Editor" ) );
   }
-  setMarginVisible( false );
   setFoldingVisible( false );
   setAutoCompletionCaseSensitivity( false );
   QgsCodeEditorExpression::initializeLexer(); // avoid cppcheck warning by explicitly specifying namespace

--- a/src/gui/codeeditors/qgscodeeditorhtml.cpp
+++ b/src/gui/codeeditors/qgscodeeditorhtml.cpp
@@ -30,7 +30,6 @@ QgsCodeEditorHTML::QgsCodeEditorHTML( QWidget *parent )
   {
     setTitle( tr( "HTML Editor" ) );
   }
-  setMarginVisible( false );
   setFoldingVisible( true );
   QgsCodeEditorHTML::initializeLexer();
 }

--- a/src/gui/codeeditors/qgscodeeditorjs.cpp
+++ b/src/gui/codeeditors/qgscodeeditorjs.cpp
@@ -29,7 +29,6 @@ QgsCodeEditorJavascript::QgsCodeEditorJavascript( QWidget *parent )
   {
     setTitle( tr( "JavaScript Editor" ) );
   }
-  setMarginVisible( false );
   setFoldingVisible( true );
   QgsCodeEditorJavascript::initializeLexer();
 }

--- a/src/gui/codeeditors/qgscodeeditorjs.cpp
+++ b/src/gui/codeeditors/qgscodeeditorjs.cpp
@@ -60,5 +60,6 @@ void QgsCodeEditorJavascript::initializeLexer()
   lexer->setColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::Identifier ), QsciLexerJavaScript::Identifier );
 
   setLexer( lexer );
+  setLineNumbersVisible( true );
   runPostLexerConfigurationTasks();
 }

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -168,17 +168,16 @@ void QgsCodeEditorPython::initializeLexer()
       setAutoCompletionSource( AcsAPIs );
   }
 
-  setMarginVisible( true );
+  setLineNumbersVisible( true );
 
   // Margin 2 is used for the 'folding'
-  setMarginWidth( 2, "0" );
+  setMarginWidth( QgsCodeEditor::MarginRole::FoldingControls, "0" );
   setMarginsForegroundColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::MarginForeground ) );
   setMarginsBackgroundColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::MarginBackground ) );
 
   setFoldingVisible( true );
   setIndentationsUseTabs( false );
   setIndentationGuides( true );
-
 
   runPostLexerConfigurationTasks();
 }

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -169,12 +169,6 @@ void QgsCodeEditorPython::initializeLexer()
   }
 
   setLineNumbersVisible( true );
-
-  // Margin 2 is used for the 'folding'
-  setMarginWidth( QgsCodeEditor::MarginRole::FoldingControls, "0" );
-  setMarginsForegroundColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::MarginForeground ) );
-  setMarginsBackgroundColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::MarginBackground ) );
-
   setFoldingVisible( true );
   setIndentationsUseTabs( false );
   setIndentationGuides( true );

--- a/src/gui/codeeditors/qgscodeeditorsql.cpp
+++ b/src/gui/codeeditors/qgscodeeditorsql.cpp
@@ -29,7 +29,6 @@ QgsCodeEditorSQL::QgsCodeEditorSQL( QWidget *parent )
   {
     setTitle( tr( "SQL Editor" ) );
   }
-  setMarginVisible( false );
   setFoldingVisible( false );
   setAutoCompletionCaseSensitivity( false );
   QgsCodeEditorSQL::initializeLexer(); // avoid cppcheck warning by explicitly specifying namespace

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -202,7 +202,8 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   txtExpressionString->setCallTipsVisible( 0 );
 
   setExpectedOutputFormat( QString() );
-  mFunctionBuilderHelp->setMarginVisible( false );
+  mFunctionBuilderHelp->setLineNumbersVisible( false );
+  mFunctionBuilderHelp->setMarginWidth( QgsCodeEditor::MarginRole::FoldingControls, 0 );
   mFunctionBuilderHelp->setEdgeMode( QsciScintilla::EdgeNone );
   mFunctionBuilderHelp->setEdgeColumn( 0 );
   mFunctionBuilderHelp->setReadOnly( true );

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -203,7 +203,7 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
 
   setExpectedOutputFormat( QString() );
   mFunctionBuilderHelp->setLineNumbersVisible( false );
-  mFunctionBuilderHelp->setMarginWidth( QgsCodeEditor::MarginRole::FoldingControls, 0 );
+  mFunctionBuilderHelp->setFoldingVisible( false );
   mFunctionBuilderHelp->setEdgeMode( QsciScintilla::EdgeNone );
   mFunctionBuilderHelp->setEdgeColumn( 0 );
   mFunctionBuilderHelp->setReadOnly( true );

--- a/src/providers/virtual/qgsvirtuallayersourceselect.cpp
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.cpp
@@ -43,8 +43,7 @@ QgsVirtualLayerSourceSelect::QgsVirtualLayerSourceSelect( QWidget *parent, Qt::W
   setupUi( this );
   setupButtons( buttonBox );
 
-  mQueryEdit->setMarginWidth( 1, QStringLiteral( "000" ) );
-  mQueryEdit->setMarginLineNumbers( 1, true );
+  mQueryEdit->setLineNumbersVisible( true );
 
   connect( mTestButton, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::testQuery );
   connect( mBrowseCRSBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::browseCRS );


### PR DESCRIPTION
Avoids a lot of fragile direct margin manipulation