### PR TITLE
[layer tree] Avoid blurry icons on devices with a pixel ratio != 1

### DIFF
--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -937,6 +937,17 @@ Set a single custom expression variable.
 .. versionadded:: 3.0
 %End
 
+    static int scaleIconSize( int standardSize );
+%Docstring
+Scales an icon size to compensate for display pixel density, making the icon
+size hi-dpi friendly, whilst still resulting in pixel-perfect sizes for low-dpi
+displays.
+
+``standardSize`` should be set to a standard icon size, e.g. 16, 24, 48, etc.
+
+.. versionadded:: 3.16
+%End
+
     int maxConcurrentConnectionsPerPool() const;
 %Docstring
 The maximum number of concurrent connections per connections pool.

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -13,18 +13,16 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QApplication>
-#include <QDesktopWidget>
 #include <QMimeData>
 #include <QTextStream>
 
 #include "qgslayertreemodel.h"
 
+#include "qgsapplication.h"
 #include "qgslayertree.h"
 #include "qgslayertreeutils.h"
 #include "qgslayertreemodellegendnode.h"
 #include "qgsproject.h"
-#include "qgsapplication.h"
 #include "qgsdataitem.h"
 #include "qgsmaphittest.h"
 #include "qgsmaplayer.h"
@@ -723,12 +721,7 @@ void QgsLayerTreeModel::setLayerStyleOverrides( const QMap<QString, QString> &ov
 
 int QgsLayerTreeModel::scaleIconSize( int standardSize )
 {
-  QFontMetrics fm( ( QFont() ) );
-  const double scale = 1.1 * standardSize / 24;
-  int scaledIconSize = static_cast< int >( std::floor( std::max( Qgis::UI_SCALE_FACTOR * fm.height() * scale, static_cast< double >( standardSize ) ) ) );
-  if ( QApplication::desktop() )
-    scaledIconSize *= QApplication::desktop()->devicePixelRatio();
-  return scaledIconSize;
+  return QgsApplication::scaleIconSize( standardSize );
 }
 
 void QgsLayerTreeModel::nodeWillAddChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo )

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -13,6 +13,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <QApplication>
+#include <QDesktopWidget>
 #include <QMimeData>
 #include <QTextStream>
 
@@ -723,7 +725,10 @@ int QgsLayerTreeModel::scaleIconSize( int standardSize )
 {
   QFontMetrics fm( ( QFont() ) );
   const double scale = 1.1 * standardSize / 24;
-  return static_cast< int >( std::floor( std::max( Qgis::UI_SCALE_FACTOR * fm.height() * scale, static_cast< double >( standardSize ) ) ) );
+  int scaledIconSize = static_cast< int >( std::floor( std::max( Qgis::UI_SCALE_FACTOR * fm.height() * scale, static_cast< double >( standardSize ) ) ) );
+  if ( QApplication::desktop() )
+    scaledIconSize *= QApplication::desktop()->devicePixelRatio();
+  return scaledIconSize;
 }
 
 void QgsLayerTreeModel::nodeWillAddChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo )

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -75,6 +75,8 @@
 
 #include "layout/qgspagesizeregistry.h"
 
+#include <QApplication>
+#include <QDesktopWidget>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
@@ -1276,7 +1278,6 @@ void QgsApplication::initQgis()
 
 }
 
-
 QgsAuthManager *QgsApplication::authManager()
 {
   if ( auto *lInstance = instance() )
@@ -1819,6 +1820,16 @@ void QgsApplication::setCustomVariable( const QString &name, const QVariant &val
   settings.setValue( QStringLiteral( "variables/" ) + name, value );
 
   emit instance()->customVariablesChanged();
+}
+
+int QgsApplication::scaleIconSize( int standardSize )
+{
+  QFontMetrics fm( ( QFont() ) );
+  const double scale = 1.1 * standardSize / 24;
+  int scaledIconSize = static_cast< int >( std::floor( std::max( Qgis::UI_SCALE_FACTOR * fm.height() * scale, static_cast< double >( standardSize ) ) ) );
+  if ( QApplication::desktop() )
+    scaledIconSize *= QApplication::desktop()->devicePixelRatio();
+  return scaledIconSize;
 }
 
 int QgsApplication::maxConcurrentConnectionsPerPool() const

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -872,6 +872,17 @@ class CORE_EXPORT QgsApplication : public QApplication
     static void setCustomVariable( const QString &name, const QVariant &value );
 
     /**
+     * Scales an icon size to compensate for display pixel density, making the icon
+     * size hi-dpi friendly, whilst still resulting in pixel-perfect sizes for low-dpi
+     * displays.
+     *
+     * \a standardSize should be set to a standard icon size, e.g. 16, 24, 48, etc.
+     *
+     * \since QGIS 3.16
+     */
+    static int scaleIconSize( int standardSize );
+
+    /**
      * The maximum number of concurrent connections per connections pool.
      *
      * \note QGIS may in some situations allocate more than this amount

--- a/src/gui/qgsguiutils.cpp
+++ b/src/gui/qgsguiutils.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 #include "qgsguiutils.h"
 
+#include "qgsapplication.h"
 #include "qgssettings.h"
 #include "qgsencodingfiledialog.h"
 #include "qgslogger.h"
@@ -243,9 +244,7 @@ namespace QgsGuiUtils
 
   int scaleIconSize( int standardSize )
   {
-    QFontMetrics fm( ( QFont() ) );
-    const double scale = 1.1 * standardSize / 24;
-    return static_cast< int >( std::floor( std::max( Qgis::UI_SCALE_FACTOR * fm.height() * scale, static_cast< double >( standardSize ) ) ) );
+    return QgsApplication::scaleIconSize( standardSize );
   }
 
   QSize iconSize( bool dockableToolbar )


### PR DESCRIPTION
## Description

The layer tree model's scaleIconSize() function needs to take into account the device pixel ratio to produce properly sized icons in environments where Qt's high dpi scaling (i.e. AA_EnableHighDpiScaling) is switched on.

See before (left) vs. PR (rigth):
![image](https://user-images.githubusercontent.com/1728657/95841690-dc17a480-0d6f-11eb-9328-f1306b911cf6.png)

