### PR TITLE
Fix: proj4 v6 wkt initializes an invalid CRS

### DIFF
--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -2067,6 +2067,15 @@ bool QgsCoordinateReferenceSystem::readXml( const QDomNode &node )
 
       const QString wkt = srsNode.namedItem( QStringLiteral( "wkt" ) ).toElement().text();
       initialized = createFromWktInternal( wkt, description );
+
+      // the wkt can be a valid crs description but it can be an invalid crs
+      // this depends on the proj4 version
+      // a wkt provided by proj4 version >= 6 can be invalid for proj4 <= 5
+      // but the proj4 string provides a valid crs
+      if ( initialized && !isValid() )
+      {
+        initialized = false;
+      }
     }
 
     if ( !initialized )


### PR DESCRIPTION
## Description
The wkt can be a valid crs description but it can be an invalid crs. This depends on the proj4 version. A wkt provided by proj4 version >= 6 can be invalid for proj4 <= 5 but the proj4 string provides a valid crs.

For exemple this WKT is provided by proj4 version 6. It initializes an invalid CRS with proj4 version <= 5.
```
PROJCRS["unknown",
    BASEGEOGCRS["unknown",
        DATUM["World Geodetic System 1984",
            ELLIPSOID["WGS 84",
                6378137,
                298.257223563,
                LENGTHUNIT["metre",1]
            ],
            ID["EPSG",6326]
        ],
        PRIMEM["Greenwich",0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8901]
        ]
    ],
    CONVERSION["unknown",
        METHOD["Mercator (variant B)",
            ID["EPSG",9805]
        ],
        PARAMETER["Latitude of 1st standard parallel",
            46,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8823]
        ],
        PARAMETER["Longitude of natural origin",
            0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8802]
        ],
        PARAMETER["False easting",
            0,
            LENGTHUNIT["metre",1],
            ID["EPSG",8806]
        ],
        PARAMETER["False northing",
            0,
            LENGTHUNIT["metre",1],
            ID["EPSG",8807]
        ]
    ],
    CS["Cartesian",2],
    AXIS["(E)",
        east,
        ORDER[1],
        LENGTHUNIT["metre",
            1,
            ID["EPSG",9001]
        ]
    ],
    AXIS["(N)",
        north,
        ORDER[2],
        LENGTHUNIT["metre",
            1,
            ID["EPSG",9001]
        ]
    ]
]
```
