### PR TITLE
Fix crash when snapping to curved geometry without curved segments

### DIFF
--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -466,8 +466,10 @@ static QgsPointLocator::MatchList _geometrySegmentsInRect( QgsGeometry *geom, co
   for ( auto part = straightGeom.const_parts_begin(); part != straightGeom.const_parts_end(); ++part )
   {
     // Checking for invalid linestrings
-    // A linestring should/(must?) have at least two points
-    if ( qgsgeometry_cast<QgsLineString *>( *part )->numPoints() < 2 )
+    // A linestring should/(must?) have at least two points.
+    QgsCurve *curve = qgsgeometry_cast<QgsCurve *>( *part );
+    Q_ASSERT( !curve->hasCurvedSegments() );
+    if ( curve->numPoints() < 2 )
       continue;
 
     QgsAbstractGeometry::vertex_iterator it = ( *part )->vertices_begin();


### PR DESCRIPTION
When a geometry that supports curves has only straight segments and a user snaps to it with "snap to intersections" enabled, QGIS crashes.

Fixes https://github.com/qgis/QGIS/issues/33234
