### PR TITLE
Separate qgis_process params with --

### DIFF
--- a/tests/src/python/test_qgsprocessexecutable.py
+++ b/tests/src/python/test_qgsprocessexecutable.py
@@ -160,7 +160,7 @@ class TestQgsProcessExecutable(unittest.TestCase):
         self.assertIn('inputs', output.lower())
         self.assertEqual(rc, 1)
 
-    def testAlgorithmRun(self):
+    def testAlgorithmRunLegacy(self):
         output_file = self.TMP_DIR + '/polygon_centroid.shp'
         rc, output, err = self.run_process(['run', 'native:centroids', '--INPUT={}'.format(TEST_DATA_DIR + '/polys.shp'), '--OUTPUT={}'.format(output_file)])
         if os.environ.get('TRAVIS', '') != 'true':
@@ -172,9 +172,21 @@ class TestQgsProcessExecutable(unittest.TestCase):
         self.assertTrue(os.path.exists(output_file))
         self.assertEqual(rc, 0)
 
+    def testAlgorithmRun(self):
+        output_file = self.TMP_DIR + '/polygon_centroid.shp'
+        rc, output, err = self.run_process(['run', 'native:centroids', '--', 'INPUT={}'.format(TEST_DATA_DIR + '/polys.shp'), 'OUTPUT={}'.format(output_file)])
+        if os.environ.get('TRAVIS', '') != 'true':
+            # Travis DOES have errors, due to QStandardPaths: XDG_RUNTIME_DIR not set warnings raised by Qt
+            self.assertFalse(err)
+        self.assertIn('0...10...20...30...40...50...60...70...80...90', output.lower())
+        self.assertIn('results', output.lower())
+        self.assertIn('OUTPUT:\t' + output_file, output)
+        self.assertTrue(os.path.exists(output_file))
+        self.assertEqual(rc, 0)
+
     def testAlgorithmRunJson(self):
         output_file = self.TMP_DIR + '/polygon_centroid2.shp'
-        rc, output, err = self.run_process(['run', '--json', 'native:centroids', '--INPUT={}'.format(TEST_DATA_DIR + '/polys.shp'), '--OUTPUT={}'.format(output_file)])
+        rc, output, err = self.run_process(['run', '--json', 'native:centroids', '--', 'INPUT={}'.format(TEST_DATA_DIR + '/polys.shp'), 'OUTPUT={}'.format(output_file)])
         res = json.loads(output)
 
         self.assertIn('gdal_version', res)
@@ -201,7 +213,7 @@ class TestQgsProcessExecutable(unittest.TestCase):
 
     def testModelRun(self):
         output_file = self.TMP_DIR + '/model_output.shp'
-        rc, output, err = self.run_process(['run', TEST_DATA_DIR + '/test_model.model3', '--FEATS={}'.format(TEST_DATA_DIR + '/polys.shp'), '--native:centroids_1:CENTROIDS={}'.format(output_file)])
+        rc, output, err = self.run_process(['run', TEST_DATA_DIR + '/test_model.model3', '--', 'FEATS={}'.format(TEST_DATA_DIR + '/polys.shp'), 'native:centroids_1:CENTROIDS={}'.format(output_file)])
         if os.environ.get('TRAVIS', '') != 'true':
             # Travis DOES have errors, due to QStandardPaths: XDG_RUNTIME_DIR not set warnings raised by Qt
             self.assertFalse(err)


### PR DESCRIPTION
## Description

Collision free parameters for qgis_process by separating executable args and algorithm args with `--`

```
qgis_process run algname --distanceUnits=meters -- PARAM1=23 PARAM2=/path/to/file distanceUnits=someOtherParam
```

Still supports the legacy version using `--PARAM=VALUE` syntax

@nyalldawson looking for your feedback before finetuning