### PR TITLE
Fix GPKG FID issues when running in-place mode

### DIFF
--- a/python/core/auto_generated/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerutils.sip.in
@@ -237,7 +237,7 @@ Finally, the feature's fields are set to ``fields``.
 .. versionadded:: 3.4
 %End
 
-    static QgsFeatureList makeFeatureCompatible( const QgsFeature &feature, const QgsVectorLayer *layer );
+    static QgsFeatureList makeFeatureCompatible( const QgsFeature &feature, const QgsVectorLayer *layer, QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags() );
 %Docstring
 Converts input ``feature`` to be compatible with the given ``layer``.
 
@@ -255,10 +255,12 @@ The following operations will be performed to convert the input features:
 - drop Z/M
 - convert multi part geometries to single part
 
+Optionally, ``sinkFlags`` can be specified to further refine the compatibility logic.
+
 .. versionadded:: 3.4
 %End
 
-    static QgsFeatureList makeFeaturesCompatible( const QgsFeatureList &features, const QgsVectorLayer *layer );
+    static QgsFeatureList makeFeaturesCompatible( const QgsFeatureList &features, const QgsVectorLayer *layer, QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags() );
 %Docstring
 Converts input ``features`` to be compatible with the given ``layer``.
 
@@ -275,6 +277,8 @@ The following operations will be performed to convert the input features:
 - add back M/Z values (initialized to 0)
 - drop Z/M
 - convert multi part geometries to single part
+
+Optionally, ``sinkFlags`` can be specified to further refine the compatibility logic.
 
 .. versionadded:: 3.4
 %End

--- a/python/plugins/processing/gui/AlgorithmExecutor.py
+++ b/python/plugins/processing/gui/AlgorithmExecutor.py
@@ -240,9 +240,13 @@ def execute_in_place_run(alg, parameters, context=None, feedback=None, raise_exc
 
                 active_layer.deleteFeatures(active_layer.selectedFeatureIds())
 
+                regenerate_primary_key = result_layer.customProperty('OnConvertFormatRegeneratePrimaryKey', False)
+                sink_flags = QgsFeatureSink.SinkFlags(QgsFeatureSink.RegeneratePrimaryKey) if regenerate_primary_key \
+                    else QgsFeatureSink.SinkFlags()
+
                 for f in result_layer.getFeatures():
                     new_features.extend(QgsVectorLayerUtils.
-                                        makeFeaturesCompatible([f], active_layer))
+                                        makeFeaturesCompatible([f], active_layer, sink_flags))
 
                 # Get the new ids
                 old_ids = set([f.id() for f in active_layer.getFeatures(req)])

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -715,6 +715,8 @@ QgsFeatureSink *QgsProcessingUtils::createFeatureSink( QString &destination, Qgs
       throw QgsProcessingException( QObject::tr( "Could not create memory layer" ) );
     }
 
+    layer->setCustomProperty( QStringLiteral( "OnConvertFormatRegeneratePrimaryKey" ), static_cast< bool >( sinkFlags & QgsFeatureSink::RegeneratePrimaryKey ) );
+
     // update destination to layer ID
     destination = layer->id();
 

--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -743,12 +743,15 @@ QgsFeatureList QgsVectorLayerUtils::makeFeatureCompatible( const QgsFeature &fea
   // Fix attributes
   QgsVectorLayerUtils::matchAttributesToFields( newF, layer->fields( ) );
 
-  if ( sinkFlags & QgsFeatureSink::RegeneratePrimaryKey && layer->storageType() == QLatin1String( "GPKG" ) )
+  if ( sinkFlags & QgsFeatureSink::RegeneratePrimaryKey )
   {
-    // drop incoming fid value, let it be regenerated
-    const int fidIndex = layer->fields().lookupField( QStringLiteral( "fid" ) );
-    if ( fidIndex >= 0 )
-      newF.setAttribute( fidIndex, QVariant() );
+    // drop incoming primary key values, let them be regenerated
+    const QgsAttributeList pkIndexes = layer->dataProvider()->pkAttributeIndexes();
+    for ( int index : pkIndexes )
+    {
+      if ( index >= 0 )
+        newF.setAttribute( index, QVariant() );
+    }
   }
 
   // Does geometry need transformations?

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -20,6 +20,7 @@
 #include "qgsgeometry.h"
 #include "qgsvectorlayerfeatureiterator.h"
 #include "qgssymbollayerreference.h"
+#include "qgsfeaturesink.h"
 
 class QgsFeatureRenderer;
 class QgsSymbolLayer;
@@ -264,9 +265,11 @@ class CORE_EXPORT QgsVectorLayerUtils
      * - drop Z/M
      * - convert multi part geometries to single part
      *
+     * Optionally, \a sinkFlags can be specified to further refine the compatibility logic.
+     *
      * \since QGIS 3.4
      */
-    static QgsFeatureList makeFeatureCompatible( const QgsFeature &feature, const QgsVectorLayer *layer );
+    static QgsFeatureList makeFeatureCompatible( const QgsFeature &feature, const QgsVectorLayer *layer, QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags() );
 
     /**
      * Converts input \a features to be compatible with the given \a layer.
@@ -285,9 +288,11 @@ class CORE_EXPORT QgsVectorLayerUtils
      * - drop Z/M
      * - convert multi part geometries to single part
      *
+     * Optionally, \a sinkFlags can be specified to further refine the compatibility logic.
+     *
      * \since QGIS 3.4
      */
-    static QgsFeatureList makeFeaturesCompatible( const QgsFeatureList &features, const QgsVectorLayer *layer );
+    static QgsFeatureList makeFeaturesCompatible( const QgsFeatureList &features, const QgsVectorLayer *layer, QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags() );
 
     /**
      * \return true if the \param feature field at index \param fieldIndex from \param layer

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -1808,6 +1808,7 @@ void TestQgsProcessing::createFeatureSink()
   QCOMPARE( static_cast< QgsProxyFeatureSink *>( sink.get() )->destinationSink(), layer->dataProvider() );
   QCOMPARE( layer->dataProvider()->name(), QStringLiteral( "memory" ) );
   QCOMPARE( destination, layer->id() );
+  QVERIFY( !layer->customProperty( QStringLiteral( "OnConvertFormatRegeneratePrimaryKey" ) ).toBool() );
   QCOMPARE( context.temporaryLayerStore()->mapLayer( layer->id() ), layer ); // layer should be in store
   QgsFeature f;
   QCOMPARE( layer->featureCount(), 0L );
@@ -1854,13 +1855,14 @@ void TestQgsProcessing::createFeatureSink()
   destination = QStringLiteral( "memory:mylayer" );
   QgsFields fields;
   fields.append( QgsField( QStringLiteral( "my_field" ), QVariant::String, QString(), 100 ) );
-  sink.reset( QgsProcessingUtils::createFeatureSink( destination, context, fields, QgsWkbTypes::PointZM, QgsCoordinateReferenceSystem::fromEpsgId( 3111 ) ) );
+  sink.reset( QgsProcessingUtils::createFeatureSink( destination, context, fields, QgsWkbTypes::PointZM, QgsCoordinateReferenceSystem::fromEpsgId( 3111 ), QVariantMap(), QStringList(), QStringList(), QgsFeatureSink::RegeneratePrimaryKey ) );
   QVERIFY( sink.get() );
   layer = qobject_cast< QgsVectorLayer *>( QgsProcessingUtils::mapLayerFromString( destination, context, false ) );
   QVERIFY( layer );
   QCOMPARE( static_cast< QgsProxyFeatureSink *>( sink.get() )->destinationSink(), layer->dataProvider() );
   QCOMPARE( layer->dataProvider()->name(), QStringLiteral( "memory" ) );
   QCOMPARE( layer->name(), QStringLiteral( "mylayer" ) );
+  QVERIFY( layer->customProperty( QStringLiteral( "OnConvertFormatRegeneratePrimaryKey" ) ).toBool() );
   QCOMPARE( layer->wkbType(), QgsWkbTypes::PointZM );
   QCOMPARE( layer->crs().authid(), QStringLiteral( "EPSG:3111" ) );
   QCOMPARE( layer->fields().size(), 1 );

--- a/tests/src/python/test_qgsprocessinginplace.py
+++ b/tests/src/python/test_qgsprocessinginplace.py
@@ -915,6 +915,7 @@ class TestQgsProcessingInPlace(unittest.TestCase):
 
     def test_regenerate_fid(self):
         """Test RegeneratePrimaryKey flag"""
+
         temp_dir = QTemporaryDir()
         temp_path = temp_dir.path()
         gpkg_name = 'bug_31634_Multi_to_Singleparts_FID.gpkg'

--- a/tests/src/python/test_qgsprocessinginplace.py
+++ b/tests/src/python/test_qgsprocessinginplace.py
@@ -28,7 +28,8 @@ from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsProject,
     QgsProcessingException,
-    QgsVectorLayer
+    QgsVectorLayer,
+    QgsFeatureSink
 )
 from processing.core.Processing import Processing
 from processing.core.ProcessingConfig import ProcessingConfig
@@ -911,6 +912,26 @@ class TestQgsProcessingInPlace(unittest.TestCase):
             pks.add(f.attribute(0))
 
         self.assertTrue(gpkg_layer.commitChanges())
+
+    def test_regenerate_fid(self):
+        """Test RegeneratePrimaryKey flag"""
+        temp_dir = QTemporaryDir()
+        temp_path = temp_dir.path()
+        gpkg_name = 'bug_31634_Multi_to_Singleparts_FID.gpkg'
+        gpkg_path = os.path.join(temp_path, gpkg_name)
+        shutil.copyfile(os.path.join(unitTestDataPath(), gpkg_name), gpkg_path)
+
+        gpkg_layer = QgsVectorLayer(gpkg_path + '|layername=Multi_to_Singleparts_FID_bug', 'lyr', 'ogr')
+        self.assertTrue(gpkg_layer.isValid())
+
+        f = next(gpkg_layer.getFeatures())
+        self.assertEqual(f['fid'], 1)
+        res = QgsVectorLayerUtils.makeFeatureCompatible(f, gpkg_layer)
+        self.assertEqual([ff['fid'] for ff in res], [1])
+
+        # if RegeneratePrimaryKey set then we should discard fid field
+        res = QgsVectorLayerUtils.makeFeatureCompatible(f, gpkg_layer, QgsFeatureSink.RegeneratePrimaryKey)
+        self.assertEqual([ff['fid'] for ff in res], [None])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Correctly discard fid field values when running algorithms with the RegeneratePrimaryKey flag in in-place mode

Fixes #37761, fixes #33816