### PR TITLE
Allow selection of invalid geometries

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometryengine.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryengine.sip.in
@@ -257,10 +257,30 @@ Splits this geometry according to a given line.
 
     virtual QgsAbstractGeometry *offsetCurve( double distance, int segments, int joinStyle, double miterLimit, QString *errorMsg = 0 ) const = 0 /Factory/;
 
+    void setLogErrors( bool enabled );
+%Docstring
+Sets whether warnings and errors encountered during the geometry operations should be logged.
+
+By default these errors are logged to the console and in the QGIS UI. But for some operations errors are expected and logging
+these just results in noise. In this case setting ``enabled`` to ``False`` will avoid the automatic error reporting.
+
+.. versionadded:: 3.16
+%End
+
   protected:
+
+    void logError( const QString &engineName, const QString &message ) const;
+%Docstring
+Logs an error ``message`` encountered during an operation.
+
+.. seealso:: :py:func:`setLogErrors`
+
+.. versionadded:: 3.16
+%End
 
     QgsGeometryEngine( const QgsAbstractGeometry *geometry );
 };
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -263,12 +263,24 @@ QgsFeatureIds QgsMapToolSelectUtils::getMatchingFeatures( QgsMapCanvas *canvas, 
     if ( doContains )
     {
       if ( !selectGeomTrans.contains( g ) )
-        continue;
+      {
+        // if we get an error from the contains check then it indicates that the geometry is invalid and GEOS choked on it.
+        // in this case we consider the bounding box intersection check which has already been performed by the iterator as sufficient and
+        // allow the feature to be selected
+        if ( selectGeomTrans.lastError().isEmpty() )
+          continue;
+      }
     }
     else
     {
       if ( !selectGeomTrans.intersects( g ) )
-        continue;
+      {
+        // if we get an error from the contains check then it indicates that the geometry is invalid and GEOS choked on it.
+        // in this case we consider the bounding box intersection check which has already been performed by the iterator as sufficient and
+        // allow the feature to be selected
+        if ( selectGeomTrans.lastError().isEmpty() )
+          continue;
+      }
     }
     if ( singleSelect )
     {

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -238,6 +238,7 @@ QgsFeatureIds QgsMapToolSelectUtils::getMatchingFeatures( QgsMapCanvas *canvas, 
 
   std::unique_ptr< QgsGeometryEngine > selectionGeometryEngine( QgsGeometry::createGeometryEngine( selectGeomTrans.constGet() ) );
   selectionGeometryEngine->setLogErrors( false );
+  selectionGeometryEngine->prepareGeometry();
 
   QgsRenderContext context = QgsRenderContext::fromMapSettings( canvas->mapSettings() );
   context.expressionContext() << QgsExpressionContextUtils::layerScope( vlayer );

--- a/src/core/geometry/qgsgeometryengine.h
+++ b/src/core/geometry/qgsgeometryengine.h
@@ -19,6 +19,7 @@ email                : marco.hugentobler at sourcepole dot com
 #include "qgis_core.h"
 #include "qgslinestring.h"
 #include "qgsgeometry.h"
+#include "qgslogger.h"
 
 #include <QVector>
 
@@ -273,8 +274,35 @@ class CORE_EXPORT QgsGeometryEngine
 
     virtual QgsAbstractGeometry *offsetCurve( double distance, int segments, int joinStyle, double miterLimit, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
 
+    /**
+     * Sets whether warnings and errors encountered during the geometry operations should be logged.
+     *
+     * By default these errors are logged to the console and in the QGIS UI. But for some operations errors are expected and logging
+     * these just results in noise. In this case setting \a enabled to FALSE will avoid the automatic error reporting.
+     *
+     * \since QGIS 3.16
+     */
+    void setLogErrors( bool enabled ) { mLogErrors = enabled; }
+
   protected:
     const QgsAbstractGeometry *mGeometry = nullptr;
+    bool mLogErrors = true;
+
+    /**
+     * Logs an error \a message encountered during an operation.
+     *
+     * \see setLogErrors()
+     *
+     * \since QGIS 3.16
+     */
+    void logError( const QString &engineName, const QString &message ) const
+    {
+      if ( mLogErrors )
+      {
+        QgsDebugMsg( QStringLiteral( "%1 notice: %2" ).arg( engineName, message ) );
+        qWarning( "%s exception: %s", engineName.toLocal8Bit().constData(), message.toLocal8Bit().constData() );
+      }
+    }
 
     QgsGeometryEngine( const QgsAbstractGeometry *geometry )
       : mGeometry( geometry )
@@ -282,3 +310,4 @@ class CORE_EXPORT QgsGeometryEngine
 };
 
 #endif // QGSGEOMETRYENGINE_H
+

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -57,7 +57,6 @@ static void throwGEOSException( const char *fmt, ... )
   vsnprintf( buffer, sizeof buffer, fmt, ap );
   va_end( ap );
 
-  qWarning( "GEOS exception: %s", buffer );
   QString message = QString::fromUtf8( buffer );
 
 #ifdef _MSC_VER
@@ -90,8 +89,6 @@ static void printGEOSNotice( const char *fmt, ... )
   va_start( ap, fmt );
   vsnprintf( buffer, sizeof buffer, fmt, ap );
   va_end( ap );
-
-  QgsDebugMsg( QStringLiteral( "GEOS notice: %1" ).arg( QString::fromUtf8( buffer ) ) );
 #else
   Q_UNUSED( fmt )
 #endif
@@ -238,6 +235,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::clip( const QgsRectangle &rect, QS
   }
   catch ( GEOSException &e )
   {
+    logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
     {
       *errorMsg = e.what();
@@ -545,6 +543,7 @@ QString QgsGeos::relate( const QgsAbstractGeometry *geom, QString *errorMsg ) co
   }
   catch ( GEOSException &e )
   {
+    logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
     {
       *errorMsg = e.what();
@@ -574,6 +573,7 @@ bool QgsGeos::relatePattern( const QgsAbstractGeometry *geom, const QString &pat
   }
   catch ( GEOSException &e )
   {
+    logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
     {
       *errorMsg = e.what();
@@ -1446,6 +1446,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::overlay( const QgsAbstractGeometry
   }
   catch ( GEOSException &e )
   {
+    logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
     {
       *errorMsg = e.what();
@@ -1530,6 +1531,7 @@ bool QgsGeos::relation( const QgsAbstractGeometry *geom, Relation r, QString *er
   }
   catch ( GEOSException &e )
   {
+    logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
     {
       *errorMsg = e.what();
@@ -2241,6 +2243,7 @@ QgsGeometry QgsGeos::closestPoint( const QgsGeometry &other, QString *errorMsg )
   }
   catch ( GEOSException &e )
   {
+    logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
     {
       *errorMsg = e.what();
@@ -2279,6 +2282,7 @@ QgsGeometry QgsGeos::shortestLine( const QgsGeometry &other, QString *errorMsg )
   }
   catch ( GEOSException &e )
   {
+    logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
     {
       *errorMsg = e.what();
@@ -2312,6 +2316,7 @@ double QgsGeos::lineLocatePoint( const QgsPoint &point, QString *errorMsg ) cons
   }
   catch ( GEOSException &e )
   {
+    logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
     {
       *errorMsg = e.what();

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -418,6 +418,7 @@ std::unique_ptr<LabelPosition> FeaturePart::createCandidatePointOnSurface( Point
   }
   catch ( GEOSException &e )
   {
+    qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
     return nullptr;
   }
@@ -2216,6 +2217,7 @@ bool FeaturePart::isConnected( FeaturePart *p2 )
   }
   catch ( GEOSException &e )
   {
+    qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
     return false;
   }
@@ -2256,6 +2258,7 @@ bool FeaturePart::mergeWithFeaturePart( FeaturePart *other )
   }
   catch ( GEOSException &e )
   {
+    qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
     return false;
   }

--- a/src/core/pal/geomfunction.cpp
+++ b/src/core/pal/geomfunction.cpp
@@ -383,6 +383,7 @@ bool GeomFunction::containsCandidate( const GEOSPreparedGeometry *geom, double x
   }
   catch ( GEOSException &e )
   {
+    qWarning( "GEOS exception: %s", e.what() );
     Q_NOWARN_UNREACHABLE_PUSH
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
     return false;

--- a/src/core/pal/labelposition.cpp
+++ b/src/core/pal/labelposition.cpp
@@ -213,6 +213,7 @@ bool LabelPosition::intersects( const GEOSPreparedGeometry *geometry )
   }
   catch ( GEOSException &e )
   {
+    qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
     return false;
   }
@@ -238,6 +239,7 @@ bool LabelPosition::within( const GEOSPreparedGeometry *geometry )
   }
   catch ( GEOSException &e )
   {
+    qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
     return false;
   }
@@ -293,6 +295,7 @@ bool LabelPosition::isInConflictSinglePart( const LabelPosition *lp ) const
   }
   catch ( GEOSException &e )
   {
+    qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
     return false;
   }
@@ -486,6 +489,7 @@ bool LabelPosition::crossesLine( PointSet *line ) const
   }
   catch ( GEOSException &e )
   {
+    qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
     return false;
   }
@@ -516,6 +520,7 @@ bool LabelPosition::crossesBoundary( PointSet *polygon ) const
   }
   catch ( GEOSException &e )
   {
+    qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
     return false;
   }
@@ -549,6 +554,7 @@ bool LabelPosition::intersectsWithPolygon( PointSet *polygon ) const
   }
   catch ( GEOSException &e )
   {
+    qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
   }
 
@@ -606,6 +612,7 @@ double LabelPosition::polygonIntersectionCostForParts( PointSet *polygon ) const
   }
   catch ( GEOSException &e )
   {
+    qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
   }
 

--- a/src/core/pal/pointset.cpp
+++ b/src/core/pal/pointset.cpp
@@ -262,6 +262,7 @@ bool PointSet::containsPoint( double x, double y ) const
   }
   catch ( GEOSException &e )
   {
+    qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
     return false;
   }
@@ -839,6 +840,7 @@ double PointSet::minDistanceToPoint( double px, double py, double *rx, double *r
   }
   catch ( GEOSException &e )
   {
+    qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
     return 0;
   }
@@ -895,6 +897,7 @@ void PointSet::getCentroid( double &px, double &py, bool forceInside ) const
   }
   catch ( GEOSException &e )
   {
+    qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
     return;
   }
@@ -978,6 +981,7 @@ double PointSet::length() const
   }
   catch ( GEOSException &e )
   {
+    qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
     return -1;
   }
@@ -1004,6 +1008,7 @@ double PointSet::area() const
   }
   catch ( GEOSException &e )
   {
+    qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
     return -1;
   }


### PR DESCRIPTION
When selecting features via rect, ignore GEOS errors due to invalid geometries and allow these features to be selected based on their  bounding boxes alone.

Fixes #38460

I'm not 100% on this fix. I can't see why this behavior has changed since 3.10, unless it's caused by changes in GEOS itself. Feedback is appreciated!!