### PR TITLE
Allow more file types to be expanded in the browser

### DIFF
--- a/src/core/providers/ogr/qgsogrdataitems.cpp
+++ b/src/core/providers/ogr/qgsogrdataitems.cpp
@@ -624,11 +624,17 @@ QgsDataItem *QgsOgrDataItemProvider::createDataItem( const QString &pathIn, QgsD
       QStringLiteral( "kml" ),
       QStringLiteral( "osm" ),
       QStringLiteral( "mdb" ),
+      QStringLiteral( "accdb" ),
+      QStringLiteral( "xls" ),
+      QStringLiteral( "xlsx" ),
+      QStringLiteral( "gpx" ),
       QStringLiteral( "pdf" ),
       QStringLiteral( "pbf" ) };
   static QStringList sOgrSupportedDbDriverNames { QStringLiteral( "GPKG" ),
       QStringLiteral( "db" ),
       QStringLiteral( "gdb" ),
+      QStringLiteral( "xlsx" ),
+      QStringLiteral( "xls" ),
       QStringLiteral( "pgdb" )};
 
   // these extensions are trivial to read, so there's no need to rely on


### PR DESCRIPTION
Allows for
- xls(x)
- ods
- gpx
- accdb

Files to be expanded in the browser. This permits map layers with these
file types to be repaired or changed via the browser interface when
they have to link to a specific child layer from the file.
