### PR TITLE
Optimise QgsGeometryValidator class

### DIFF
--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -420,6 +420,16 @@ segment in the line.
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false );
 
+
+    bool hasDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false ) const;
+%Docstring
+Returns ``True`` if the linestring contains duplicate nodes within the specified tolerance.
+
+If ``useZValues`` is ``True`` then z values will also be considered when testing for duplicates.
+
+.. versionadded:: 3.16
+%End
+
     virtual QPolygonF asQPolygonF() const;
 
 

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -421,9 +421,9 @@ segment in the line.
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false );
 
 
-    bool hasDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false ) const;
+    QVector< QgsVertexId > collectDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false ) const;
 %Docstring
-Returns ``True`` if the linestring contains duplicate nodes within the specified tolerance.
+Returns a list of any duplicate nodes contained in the geometry, within the specified tolerance.
 
 If ``useZValues`` is ``True`` then z values will also be considered when testing for duplicates.
 

--- a/python/core/auto_generated/qgsvector.sip.in
+++ b/python/core/auto_generated/qgsvector.sip.in
@@ -33,30 +33,30 @@ Constructor for QgsVector taking x and y component values.
 :param y: y-component
 %End
 
-    QgsVector operator-() const;
+    QgsVector operator-() const /HoldGIL/;
 
-    QgsVector operator*( double scalar ) const;
+    QgsVector operator*( double scalar ) const /HoldGIL/;
 
-    QgsVector operator/( double scalar ) const;
+    QgsVector operator/( double scalar ) const /HoldGIL/;
 
-    double operator*( QgsVector v ) const;
+    double operator*( QgsVector v ) const /HoldGIL/;
 
-    QgsVector operator+( QgsVector other ) const;
+    QgsVector operator+( QgsVector other ) const /HoldGIL/;
 
-    QgsVector &operator+=( QgsVector other );
+    QgsVector &operator+=( QgsVector other ) /HoldGIL/;
 
-    QgsVector operator-( QgsVector other ) const;
+    QgsVector operator-( QgsVector other ) const /HoldGIL/;
 
-    QgsVector &operator-=( QgsVector other );
+    QgsVector &operator-=( QgsVector other ) /HoldGIL/;
 
-    double length() const;
+    double length() const /HoldGIL/;
 %Docstring
 Returns the length of the vector.
 
 .. seealso:: :py:func:`lengthSquared`
 %End
 
-    double lengthSquared() const;
+    double lengthSquared() const /HoldGIL/;
 %Docstring
 Returns the length of the vector.
 
@@ -65,36 +65,36 @@ Returns the length of the vector.
 .. versionadded:: 3.2
 %End
 
-    double x() const;
+    double x() const /HoldGIL/;
 %Docstring
 Returns the vector's x-component.
 
 .. seealso:: y
 %End
 
-    double y() const;
+    double y() const /HoldGIL/;
 %Docstring
 Returns the vector's y-component.
 
 .. seealso:: x
 %End
 
-    QgsVector perpVector() const;
+    QgsVector perpVector() const /HoldGIL/;
 %Docstring
 Returns the perpendicular vector to this vector (rotated 90 degrees counter-clockwise)
 %End
 
-    double angle() const;
+    double angle() const /HoldGIL/;
 %Docstring
 Returns the angle of the vector in radians.
 %End
 
-    double angle( QgsVector v ) const;
+    double angle( QgsVector v ) const /HoldGIL/;
 %Docstring
 Returns the angle between this vector and another vector in radians.
 %End
 
-    double crossProduct( QgsVector v ) const;
+    double crossProduct( QgsVector v ) const /HoldGIL/;
 %Docstring
 Returns the 2D cross product of this vector and another vector ``v``. (This is sometimes
 referred to as a "perpendicular dot product", and equals x1 * y1 - y1 * x2).
@@ -102,25 +102,25 @@ referred to as a "perpendicular dot product", and equals x1 * y1 - y1 * x2).
 .. versionadded:: 3.2
 %End
 
-    QgsVector rotateBy( double rot ) const;
+    QgsVector rotateBy( double rot ) const /HoldGIL/;
 %Docstring
 Rotates the vector by a specified angle.
 
 :param rot: angle in radians
 %End
 
-    QgsVector normalized() const;
+    QgsVector normalized() const throw( QgsException );
 %Docstring
 Returns the vector's normalized (or "unit") vector (ie same angle but length of 1.0).
-Will throw a QgsException if called on a vector with length of 0.
+
+:raises QgsException: if called on a vector with length of 0.
 %End
 
-    bool operator==( QgsVector other ) const;
+    bool operator==( QgsVector other ) const /HoldGIL/;
 
     bool operator!=( QgsVector other ) const;
 
-
-    QString toString( int precision = 17 ) const;
+    QString toString( int precision = 17 ) const /HoldGIL/;
 %Docstring
 Returns a string representation of the vector.
 Members will be truncated to the specified ``precision``.

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -363,6 +363,41 @@ bool QgsLineString::removeDuplicateNodes( double epsilon, bool useZValues )
   return result;
 }
 
+bool QgsLineString::hasDuplicateNodes( double epsilon, bool useZValues ) const
+{
+  if ( mX.count() <= 1 )
+    return false;
+
+  const double *x = mX.constData();
+  const double *y = mY.constData();
+  bool hasZ = is3D();
+  bool useZ = hasZ && useZValues;
+  const double *z = useZ ? mZ.constData() : nullptr;
+
+  double prevX = *x++;
+  double prevY = *y++;
+  double prevZ = z ? *z++ : 0;
+  for ( int i = 1; i < mX.count(); ++i )
+  {
+    double currentX = *x++;
+    double currentY = *y++;
+    double currentZ = useZ ? *z++ : 0;
+    if ( qgsDoubleNear( currentX, prevX, epsilon ) &&
+         qgsDoubleNear( currentY, prevY, epsilon ) &&
+         ( !useZ || qgsDoubleNear( currentZ, prevZ, epsilon ) ) )
+    {
+      return true;
+    }
+    else
+    {
+      prevX = currentX;
+      prevY = currentY;
+      prevZ = currentZ;
+    }
+  }
+  return false;
+}
+
 QPolygonF QgsLineString::asQPolygonF() const
 {
   const int nb = mX.size();

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -363,10 +363,11 @@ bool QgsLineString::removeDuplicateNodes( double epsilon, bool useZValues )
   return result;
 }
 
-bool QgsLineString::hasDuplicateNodes( double epsilon, bool useZValues ) const
+QVector< QgsVertexId > QgsLineString::collectDuplicateNodes( double epsilon, bool useZValues ) const
 {
+  QVector< QgsVertexId > res;
   if ( mX.count() <= 1 )
-    return false;
+    return res;
 
   const double *x = mX.constData();
   const double *y = mY.constData();
@@ -377,6 +378,8 @@ bool QgsLineString::hasDuplicateNodes( double epsilon, bool useZValues ) const
   double prevX = *x++;
   double prevY = *y++;
   double prevZ = z ? *z++ : 0;
+
+  QgsVertexId id;
   for ( int i = 1; i < mX.count(); ++i )
   {
     double currentX = *x++;
@@ -386,7 +389,8 @@ bool QgsLineString::hasDuplicateNodes( double epsilon, bool useZValues ) const
          qgsDoubleNear( currentY, prevY, epsilon ) &&
          ( !useZ || qgsDoubleNear( currentZ, prevZ, epsilon ) ) )
     {
-      return true;
+      id.vertex = i;
+      res << id;
     }
     else
     {
@@ -395,7 +399,7 @@ bool QgsLineString::hasDuplicateNodes( double epsilon, bool useZValues ) const
       prevZ = currentZ;
     }
   }
-  return false;
+  return res;
 }
 
 QPolygonF QgsLineString::asQPolygonF() const

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -590,13 +590,13 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
 
     /**
-     * Returns TRUE if the linestring contains duplicate nodes within the specified tolerance.
+     * Returns a list of any duplicate nodes contained in the geometry, within the specified tolerance.
      *
      * If \a useZValues is TRUE then z values will also be considered when testing for duplicates.
      *
      * \since QGIS 3.16
      */
-    bool hasDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) const;
+    QVector< QgsVertexId > collectDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) const;
 
     QPolygonF asQPolygonF() const override;
 

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -588,6 +588,16 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     bool isEmpty() const override SIP_HOLDGIL;
     QgsLineString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
+
+    /**
+     * Returns TRUE if the linestring contains duplicate nodes within the specified tolerance.
+     *
+     * If \a useZValues is TRUE then z values will also be considered when testing for duplicates.
+     *
+     * \since QGIS 3.16
+     */
+    bool hasDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) const;
+
     QPolygonF asQPolygonF() const override;
 
     bool fromWkb( QgsConstWkbPtr &wkb ) override;

--- a/src/core/qgsgeometryvalidator.cpp
+++ b/src/core/qgsgeometryvalidator.cpp
@@ -243,15 +243,15 @@ void QgsGeometryValidator::validatePolygon( int idx, const QgsPolygon *polygon )
 void QgsGeometryValidator::run()
 {
   mErrorCount = 0;
+  if ( mGeometry.isNull() )
+  {
+    return;
+  }
+
   switch ( mMethod )
   {
     case QgsGeometry::ValidatorGeos:
     {
-      if ( mGeometry.isNull() )
-      {
-        return;
-      }
-
       // avoid calling geos for trivial point geometries
       if ( QgsWkbTypes::geometryType( mGeometry.wkbType() ) == QgsWkbTypes::PointGeometry )
       {

--- a/src/core/qgsgeometryvalidator.cpp
+++ b/src/core/qgsgeometryvalidator.cpp
@@ -149,7 +149,7 @@ void QgsGeometryValidator::validatePolyline( int i, const QgsLineString *line, b
 
       j -= n - 1;
 
-      QString msg = QObject::tr( "line %1 contains %n duplicate node(s) starting at vertex %2", "number of duplicate nodes", n + 1 ).arg( i + 1 ).arg( duplicateVertex.vertex - n + 1 );
+      QString msg = QObject::tr( "line %1 contains %n duplicate nodes starting at vertex %2", "number of duplicate nodes", n + 1 ).arg( i + 1 ).arg( duplicateVertex.vertex - n + 1 );
       QgsDebugMsgLevel( msg, 2 );
       emit errorFound( QgsGeometry::Error( msg, duplicationLocation ) );
       mErrorCount++;

--- a/src/core/qgsgeometryvalidator.h
+++ b/src/core/qgsgeometryvalidator.h
@@ -73,10 +73,10 @@ class CORE_EXPORT QgsGeometryValidator : public QThread
     void validatePolyline( int i, const QgsLineString *line, bool ring = false );
     void validatePolygon( int i, const QgsPolygon *polygon );
     void checkRingIntersections( int p0, int i0, const QgsLineString *ring0, int p1, int i1, const QgsLineString *ring1 );
-    double distLine2Point( double px, double py, QgsVector v, const QgsPoint &q );
-    bool intersectLines( double px, double py, QgsVector v, double qx, double qy, QgsVector w, QgsPoint &s );
+    double distLine2Point( double px, double py, QgsVector v, double qX, double qY );
+    bool intersectLines( double px, double py, QgsVector v, double qx, double qy, QgsVector w, double &sX, double &sY );
     bool ringInRing( const QgsLineString *inside, const QgsLineString *outside );
-    bool pointInRing( const QgsLineString *ring, const QgsPoint &p );
+    bool pointInRing( const QgsLineString *ring, double pX, double pY );
 
     QgsGeometry mGeometry;
     QVector<QgsGeometry::Error> *mErrors;

--- a/src/core/qgsgeometryvalidator.h
+++ b/src/core/qgsgeometryvalidator.h
@@ -70,13 +70,13 @@ class CORE_EXPORT QgsGeometryValidator : public QThread
     void addError( const QgsGeometry::Error & );
 
   private:
-    void validatePolyline( int i, QgsPolylineXY polyline, bool ring = false );
-    void validatePolygon( int i, const QgsPolygonXY &polygon );
-    void checkRingIntersections( int p0, int i0, const QgsPolylineXY &ring0, int p1, int i1, const QgsPolylineXY &ring1 );
-    double distLine2Point( const QgsPointXY &p, QgsVector v, const QgsPointXY &q );
-    bool intersectLines( const QgsPointXY &p, QgsVector v, const QgsPointXY &q, QgsVector w, QgsPointXY &s );
-    bool ringInRing( const QgsPolylineXY &inside, const QgsPolylineXY &outside );
-    bool pointInRing( const QgsPolylineXY &ring, const QgsPointXY &p );
+    void validatePolyline( int i, const QgsLineString *line, bool ring = false );
+    void validatePolygon( int i, const QgsPolygon *polygon );
+    void checkRingIntersections( int p0, int i0, const QgsLineString *ring0, int p1, int i1, const QgsLineString *ring1 );
+    double distLine2Point( double px, double py, QgsVector v, const QgsPoint &q );
+    bool intersectLines( double px, double py, QgsVector v, double qx, double qy, QgsVector w, QgsPoint &s );
+    bool ringInRing( const QgsLineString *inside, const QgsLineString *outside );
+    bool pointInRing( const QgsLineString *ring, const QgsPoint &p );
 
     QgsGeometry mGeometry;
     QVector<QgsGeometry::Error> *mErrors;

--- a/src/core/qgsvector.cpp
+++ b/src/core/qgsvector.cpp
@@ -18,92 +18,6 @@
 #include "qgis.h"
 #include "qgsexception.h"
 
-QgsVector::QgsVector( double x, double y )
-  : mX( x )
-  , mY( y )
-{
-}
-
-QgsVector QgsVector::operator-() const
-{
-  return QgsVector( -mX, -mY );
-}
-
-QgsVector QgsVector::operator*( double scalar ) const
-{
-  return QgsVector( mX * scalar, mY * scalar );
-}
-
-QgsVector QgsVector::operator/( double scalar ) const
-{
-  return *this * ( 1.0 / scalar );
-}
-
-double QgsVector::operator*( QgsVector v ) const
-{
-  return mX * v.mX + mY * v.mY;
-}
-
-QgsVector QgsVector::operator+( QgsVector other ) const
-{
-  return QgsVector( mX + other.mX, mY + other.mY );
-}
-
-QgsVector &QgsVector::operator+=( QgsVector other )
-{
-  mX += other.mX;
-  mY += other.mY;
-  return *this;
-}
-
-QgsVector QgsVector::operator-( QgsVector other ) const
-{
-  return QgsVector( mX - other.mX, mY - other.mY );
-}
-
-QgsVector &QgsVector::operator-=( QgsVector other )
-{
-  mX -= other.mX;
-  mY -= other.mY;
-  return *this;
-}
-
-double QgsVector::length() const
-{
-  return std::sqrt( mX * mX + mY * mY );
-}
-
-double QgsVector::x() const
-{
-  return mX;
-}
-
-double QgsVector::y() const
-{
-  return mY;
-}
-
-QgsVector QgsVector::perpVector() const
-{
-  return QgsVector( -mY, mX );
-}
-
-double QgsVector::angle() const
-{
-  double angle = std::atan2( mY, mX );
-  return angle < 0.0 ? angle + 2.0 * M_PI : angle;
-}
-
-double QgsVector::angle( QgsVector v ) const
-{
-  return v.angle() - angle();
-}
-
-double QgsVector::crossProduct( QgsVector v ) const
-{
-  return mX * v.y() - mY * v.x();
-}
-
 QgsVector QgsVector::rotateBy( double rot ) const
 {
   double angle = std::atan2( mY, mX ) + rot;
@@ -121,14 +35,4 @@ QgsVector QgsVector::normalized() const
   }
 
   return *this / len;
-}
-
-bool QgsVector::operator==( QgsVector other ) const
-{
-  return qgsDoubleNear( mX, other.mX ) && qgsDoubleNear( mY, other.mY );
-}
-
-bool QgsVector::operator!=( QgsVector other ) const
-{
-  return !qgsDoubleNear( mX, other.mX ) || !qgsDoubleNear( mY, other.mY );
 }

--- a/src/core/qgsvector.h
+++ b/src/core/qgsvector.h
@@ -41,66 +41,101 @@ class CORE_EXPORT QgsVector
      * \param x x-component
      * \param y y-component
      */
-    QgsVector( double x, double y );
+    QgsVector( double x, double y )
+      : mX( x )
+      , mY( y )
+    {
+    }
 
     //! Swaps the sign of the x and y components of the vector.
-    QgsVector operator-() const;
+    QgsVector operator-() const SIP_HOLDGIL
+    {
+      return QgsVector( -mX, -mY );
+    }
 
     /**
      * Returns a vector where the components have been multiplied by a scalar value.
      * \param scalar factor to multiply by
      */
-    QgsVector operator*( double scalar ) const;
+    QgsVector operator*( double scalar ) const SIP_HOLDGIL
+    {
+      return QgsVector( mX * scalar, mY * scalar );
+    }
 
     /**
      * Returns a vector where the components have been divided by a scalar value.
      * \param scalar factor to divide by
      */
-    QgsVector operator/( double scalar ) const;
+    QgsVector operator/( double scalar ) const SIP_HOLDGIL
+    {
+      return *this * ( 1.0 / scalar );
+    }
 
     /**
      * Returns the dot product of two vectors, which is the sum of the x component
      *  of this vector multiplied by the x component of another
      *  vector plus the y component of this vector multiplied by the y component of another vector.
      */
-    double operator*( QgsVector v ) const;
+    double operator*( QgsVector v ) const SIP_HOLDGIL
+    {
+      return mX * v.mX + mY * v.mY;
+    }
 
     /**
      * Adds another vector to this vector.
      * \since QGIS 3.0
      */
-    QgsVector operator+( QgsVector other ) const;
+    QgsVector operator+( QgsVector other ) const SIP_HOLDGIL
+    {
+      return QgsVector( mX + other.mX, mY + other.mY );
+    }
 
     /**
      * Adds another vector to this vector in place.
      * \since QGIS 3.0
      */
-    QgsVector &operator+=( QgsVector other );
+    QgsVector &operator+=( QgsVector other ) SIP_HOLDGIL
+    {
+      mX += other.mX;
+      mY += other.mY;
+      return *this;
+    }
 
     /**
      * Subtracts another vector to this vector.
      * \since QGIS 3.0
      */
-    QgsVector operator-( QgsVector other ) const;
+    QgsVector operator-( QgsVector other ) const SIP_HOLDGIL
+    {
+      return QgsVector( mX - other.mX, mY - other.mY );
+    }
 
     /**
      * Subtracts another vector to this vector in place.
      * \since QGIS 3.0
      */
-    QgsVector &operator-=( QgsVector other );
+    QgsVector &operator-=( QgsVector other ) SIP_HOLDGIL
+    {
+      mX -= other.mX;
+      mY -= other.mY;
+      return *this;
+    }
 
     /**
      * Returns the length of the vector.
      * \see lengthSquared()
      */
-    double length() const;
+    double length() const SIP_HOLDGIL
+    {
+      return std::sqrt( mX * mX + mY * mY );
+    }
 
     /**
      * Returns the length of the vector.
      * \see length()
      * \since QGIS 3.2
      */
-    double lengthSquared() const
+    double lengthSquared() const SIP_HOLDGIL
     {
       return mX * mX + mY * mY;
     }
@@ -109,28 +144,44 @@ class CORE_EXPORT QgsVector
      * Returns the vector's x-component.
      * \see y()
      */
-    double x() const;
+    double x() const SIP_HOLDGIL
+    {
+      return mX;
+    }
 
     /**
      * Returns the vector's y-component.
      * \see x()
      */
-    double y() const;
+    double y() const SIP_HOLDGIL
+    {
+      return mY;
+    }
 
     /**
      * Returns the perpendicular vector to this vector (rotated 90 degrees counter-clockwise)
      */
-    QgsVector perpVector() const;
+    QgsVector perpVector() const SIP_HOLDGIL
+    {
+      return QgsVector( -mY, mX );
+    }
 
     /**
      * Returns the angle of the vector in radians.
      */
-    double angle() const;
+    double angle() const SIP_HOLDGIL
+    {
+      double angle = std::atan2( mY, mX );
+      return angle < 0.0 ? angle + 2.0 * M_PI : angle;
+    }
 
     /**
      * Returns the angle between this vector and another vector in radians.
      */
-    double angle( QgsVector v ) const;
+    double angle( QgsVector v ) const SIP_HOLDGIL
+    {
+      return v.angle() - angle();
+    }
 
     /**
      * Returns the 2D cross product of this vector and another vector \a v. (This is sometimes
@@ -138,32 +189,41 @@ class CORE_EXPORT QgsVector
      *
      * \since QGIS 3.2
      */
-    double crossProduct( QgsVector v ) const;
+    double crossProduct( QgsVector v ) const SIP_HOLDGIL
+    {
+      return mX * v.y() - mY * v.x();
+    }
 
     /**
      * Rotates the vector by a specified angle.
      * \param rot angle in radians
      */
-    QgsVector rotateBy( double rot ) const;
+    QgsVector rotateBy( double rot ) const SIP_HOLDGIL;
 
     /**
      * Returns the vector's normalized (or "unit") vector (ie same angle but length of 1.0).
-     * Will throw a QgsException if called on a vector with length of 0.
+     *
+     * \throws QgsException if called on a vector with length of 0.
      */
-    QgsVector normalized() const;
+    QgsVector normalized() const SIP_THROW( QgsException );
 
     //! Equality operator
-    bool operator==( QgsVector other ) const;
+    bool operator==( QgsVector other ) const SIP_HOLDGIL
+    {
+      return qgsDoubleNear( mX, other.mX ) && qgsDoubleNear( mY, other.mY );
+    }
 
     //! Inequality operator
-    bool operator!=( QgsVector other ) const;
-
+    bool operator!=( QgsVector other ) const
+    {
+      return !qgsDoubleNear( mX, other.mX ) || !qgsDoubleNear( mY, other.mY );
+    }
 
     /**
     * Returns a string representation of the vector.
     * Members will be truncated to the specified \a precision.
     */
-    QString toString( int precision = 17 ) const
+    QString toString( int precision = 17 ) const SIP_HOLDGIL
     {
       QString str = "Vector (";
       str += qgsDoubleToString( mX, precision );
@@ -182,7 +242,8 @@ class CORE_EXPORT QgsVector
 #endif
 
   private:
-    double mX = 0.0, mY = 0.0;
+    double mX = 0.0;
+    double mY = 0.0;
 
 };
 

--- a/tests/src/python/test_qgsgeometryvalidator.py
+++ b/tests/src/python/test_qgsgeometryvalidator.py
@@ -75,13 +75,13 @@ class TestQgsGeometryValidator(unittest.TestCase):
 
         self.assertEqual(len(spy), 3)
         self.assertEqual(spy[0][0].where(), QgsPointXY(1, 6))
-        self.assertEqual(spy[0][0].what(), 'line 1 contains 2 duplicate node(s) starting at vertex 10')
+        self.assertEqual(spy[0][0].what(), 'line 1 contains 2 duplicate nodes starting at vertex 10')
 
         self.assertEqual(spy[1][0].where(), QgsPointXY(1, 3))
-        self.assertEqual(spy[1][0].what(), 'line 1 contains 3 duplicate node(s) starting at vertex 5')
+        self.assertEqual(spy[1][0].what(), 'line 1 contains 3 duplicate nodes starting at vertex 5')
 
         self.assertEqual(spy[2][0].where(), QgsPointXY(1, 1))
-        self.assertEqual(spy[2][0].what(), 'line 1 contains 3 duplicate node(s) starting at vertex 1')
+        self.assertEqual(spy[2][0].what(), 'line 1 contains 3 duplicate nodes starting at vertex 1')
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsgeometryvalidator.py
+++ b/tests/src/python/test_qgsgeometryvalidator.py
@@ -12,12 +12,18 @@ __copyright__ = 'Copyright 2016, The QGIS Project'
 
 from qgis.core import (
     QgsGeometry,
-    QgsGeometryValidator
+    QgsGeometryValidator,
+    QgsPointXY
 )
 
 from qgis.testing import (
-    unittest
+    unittest,
+    start_app
 )
+
+from qgis.PyQt.QtTest import QSignalSpy
+
+app = start_app()
 
 
 class TestQgsGeometryValidator(unittest.TestCase):
@@ -59,6 +65,23 @@ class TestQgsGeometryValidator(unittest.TestCase):
         self.assertTrue(g)
         # make sure validating this geometry doesn't crash QGIS
         QgsGeometryValidator.validateGeometry(g)
+
+    def test_linestring_duplicate_nodes(self):
+        g = QgsGeometry.fromWkt("LineString (1 1, 1 1, 1 1, 1 2, 1 3, 1 3, 1 3, 1 4, 1 5, 1 6, 1 6)")
+
+        validator = QgsGeometryValidator(g)
+        spy = QSignalSpy(validator.errorFound)
+        validator.run()
+
+        self.assertEqual(len(spy), 3)
+        self.assertEqual(spy[0][0].where(), QgsPointXY(1, 6))
+        self.assertEqual(spy[0][0].what(), 'line 1 contains 2 duplicate node(s) starting at vertex 10')
+
+        self.assertEqual(spy[1][0].where(), QgsPointXY(1, 3))
+        self.assertEqual(spy[1][0].what(), 'line 1 contains 3 duplicate node(s) starting at vertex 5')
+
+        self.assertEqual(spy[2][0].where(), QgsPointXY(1, 1))
+        self.assertEqual(spy[2][0].what(), 'line 1 contains 3 duplicate node(s) starting at vertex 1')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This class was heavily reliant on very old geometry methods, including many conversions to QgsPointXY points. This PR ports it across to the native QgsAbstractGeometry classes and avoids a bunch of unnecessary conversions and allocations in the process.

I've also added many additional optimisations and shortcuts where I could see them. 