### PR TITLE
Scroll to newly added feature in the attribute table view

### DIFF
--- a/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
@@ -76,7 +76,7 @@ Scroll to a feature with a given ``fid``.
 
 Optionally a ``column`` can be specified, which will also bring that column into view.
 
-.. versionadded:: 3.18
+.. versionadded:: 3.16
 %End
 
 

--- a/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
@@ -70,9 +70,11 @@ Returns the selected features in the attribute table in table sorted order.
 %End
 
 
-    void scrollToFeature( const QgsFeatureId &fid, int col = -1 );
+    void scrollToFeature( const QgsFeatureId &fid, int column = -1 );
 %Docstring
-Scroll to a feature with a given ``fid`` and select ``col`` if exists
+Scroll to a feature with a given ``fid``.
+
+Optionally a ``column`` can be specified, which will also bring that column into view.
 
 .. versionadded:: 3.18
 %End

--- a/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
@@ -70,6 +70,14 @@ Returns the selected features in the attribute table in table sorted order.
 %End
 
 
+    void scrollToFeature( const QgsFeatureId &fid, int col = -1 );
+%Docstring
+Scroll to a feature with a given ``fid`` and select ``col`` if exists
+
+.. versionadded:: 3.18
+%End
+
+
   protected:
 
     virtual void mousePressEvent( QMouseEvent *event );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -627,6 +627,7 @@ void QgsAttributeTableDialog::mActionAddFeatureViaAttributeTable_triggered()
   {
     masterModel->reload( masterModel->index( 0, 0 ), masterModel->index( masterModel->rowCount() - 1, masterModel->columnCount() - 1 ) );
     mMainView->setCurrentEditSelection( QgsFeatureIds() << action.feature().id() );
+    mMainView->tableView()->scrollToFeature( action.feature().id(), 0 );
   }
 }
 
@@ -648,6 +649,7 @@ void QgsAttributeTableDialog::mActionAddFeatureViaAttributeForm_triggered()
   {
     masterModel->reload( masterModel->index( 0, 0 ), masterModel->index( masterModel->rowCount() - 1, masterModel->columnCount() - 1 ) );
     mMainView->setCurrentEditSelection( QgsFeatureIds() << action.feature().id() );
+    mMainView->tableView()->scrollToFeature( action.feature().id(), 0 );
   }
 }
 

--- a/src/gui/attributetable/qgsattributetableview.cpp
+++ b/src/gui/attributetable/qgsattributetableview.cpp
@@ -497,3 +497,20 @@ void QgsAttributeTableView::recreateActionWidgets()
   }
   mActionWidgets.clear();
 }
+
+void QgsAttributeTableView::scrollToFeature( const QgsFeatureId &fid, int col )
+{
+  QModelIndex index = mFilterModel->fidToIndex( fid );
+
+  if ( !index.isValid() )
+    return;
+
+  scrollTo( index );
+
+  QModelIndex selectionIndex = index.siblingAtColumn( col );
+
+  if ( !selectionIndex.isValid() )
+    return;
+
+  selectionModel()->setCurrentIndex( index, QItemSelectionModel::SelectCurrent );
+}

--- a/src/gui/attributetable/qgsattributetableview.cpp
+++ b/src/gui/attributetable/qgsattributetableview.cpp
@@ -507,7 +507,7 @@ void QgsAttributeTableView::scrollToFeature( const QgsFeatureId &fid, int col )
 
   scrollTo( index );
 
-  QModelIndex selectionIndex = index.siblingAtColumn( col );
+  QModelIndex selectionIndex = index.sibling( index.row(), col );
 
   if ( !selectionIndex.isValid() )
     return;

--- a/src/gui/attributetable/qgsattributetableview.h
+++ b/src/gui/attributetable/qgsattributetableview.h
@@ -94,7 +94,7 @@ class GUI_EXPORT QgsAttributeTableView : public QTableView
 
       Optionally a \a column can be specified, which will also bring that column into view.
 
-     * \since QGIS 3.18
+     * \since QGIS 3.16
      */
     void scrollToFeature( const QgsFeatureId &fid, int column = -1 );
 

--- a/src/gui/attributetable/qgsattributetableview.h
+++ b/src/gui/attributetable/qgsattributetableview.h
@@ -89,6 +89,13 @@ class GUI_EXPORT QgsAttributeTableView : public QTableView
     QList<QgsFeatureId> selectedFeaturesIds() const;
 
 
+    /**
+     * Scroll to a feature with a given \a fid and select \a col if exists
+     * \since QGIS 3.18
+     */
+    void scrollToFeature( const QgsFeatureId &fid, int col = -1 );
+
+
   protected:
 
     /**

--- a/src/gui/attributetable/qgsattributetableview.h
+++ b/src/gui/attributetable/qgsattributetableview.h
@@ -90,10 +90,13 @@ class GUI_EXPORT QgsAttributeTableView : public QTableView
 
 
     /**
-     * Scroll to a feature with a given \a fid and select \a col if exists
+     * Scroll to a feature with a given \a fid.
+
+      Optionally a \a column can be specified, which will also bring that column into view.
+
      * \since QGIS 3.18
      */
-    void scrollToFeature( const QgsFeatureId &fid, int col = -1 );
+    void scrollToFeature( const QgsFeatureId &fid, int column = -1 );
 
 
   protected:


### PR DESCRIPTION
Adding a new feature in the attribute table when using the table view was not scrolling to the newly inserted row.  
https://github.com/qgis/QGIS/issues/37847#issuecomment-692728359

While the bot added 3.16 and I would be happy to see it there, I am afraid it will be postponed for 3.18?

See the new behaviour:
![Peek 2020-10-14 21-33](https://user-images.githubusercontent.com/2820439/96090952-9f63be80-0ed1-11eb-86bb-96fb13778ed0.gif)
