### PR TITLE
[OGR provider / GPKG] Avoid skipConstraintCheck() return true on the GPKG fid colum

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -1519,8 +1519,7 @@ QString QgsOgrProvider::defaultValueClause( int fieldIndex ) const
 bool QgsOgrProvider::skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint constraint, const QVariant &value ) const
 {
   Q_UNUSED( constraint )
-  // If the field is a fid, skip in case it's the default value
-  if ( fieldIndex == 0 && mFirstFieldIsFid )
+  if ( providerProperty( EvaluateDefaultValues, false ).toBool() )
   {
     return ! mDefaultValues.value( fieldIndex ).isEmpty();
   }


### PR DESCRIPTION
This aligns the QgsOgrProvider::skipConstraintCheck() implementation with QgsPostgresProvider::skipConstraintCheck()

And this makes GPKG behave like Postgres for the scenario in https://lists.osgeo.org/pipermail/qgis-developer/2020-October/062401.html