### PR TITLE
correctly determine if variables are static in aggregate expression and filter, give @parent in generic aggregates

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -907,7 +907,7 @@ static QVariant fcnAggregateGeneric( QgsAggregateCalculator::Aggregate aggregate
   QString cacheKey;
   if ( !isStatic )
   {
-    cacheKey = QStringLiteral( "aggfcn:%1:%2:%3:%4:%5%6:%7" ).arg( vl->id(), QString::number( aggregate ), subExpression, parameters.filter,
+    cacheKey = QStringLiteral( "agg:%1:%2:%3:%4:%5%6:%7" ).arg( vl->id(), QString::number( aggregate ), subExpression, parameters.filter,
                QString::number( context->feature().id() ), QString( qHash( context->feature() ) ), orderBy );
   }
   else

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -674,6 +674,7 @@ static QVariant fcnAggregate( const QVariantList &values, const QgsExpressionCon
     {
       return context->cachedValue( cacheKey );
     }
+
     QgsExpressionContext subContext( *context );
     QgsExpressionContextScope *subScope = new QgsExpressionContextScope();
     subScope->setVariable( QStringLiteral( "parent" ), context->feature() );
@@ -921,6 +922,9 @@ static QVariant fcnAggregateGeneric( QgsAggregateCalculator::Aggregate aggregate
   bool ok = false;
 
   QgsExpressionContext subContext( *context );
+  QgsExpressionContextScope *subScope = new QgsExpressionContextScope();
+  subScope->setVariable( QStringLiteral( "parent" ), context->feature() );
+  subContext.appendScope( subScope );
   result = vl->aggregate( aggregate, subExpression, parameters, &subContext, &ok );
 
   if ( !ok )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2045,6 +2045,11 @@ class TestQgsExpression: public QObject
         QgsExpression exp( QString( "with_variable('my_var',\"col1\", aggregate(layer:='aggregate_layer', aggregate:='concatenate_unique', expression:=\"col2\", filter:=\"col1\"=@my_var))" ) );
         QString res = exp.evaluate( &context ).toString();
         QCOMPARE( res, f.attribute( "col2" ) );
+
+        // also test for generic aggregates
+        exp = QString( "with_variable('my_var',\"col1\", sum(expression:=\"col1\", filter:=\"col1\"=@my_var))" );
+        res = exp.evaluate( &context ).toInt();
+        QCOMPARE( res, f.attribute( "col1" ).toInt() );
       }
     }
 

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2029,6 +2029,25 @@ class TestQgsExpression: public QObject
       QCOMPARE( res.toInt(), 1 );
     }
 
+    void test_aggregate_with_variable()
+    {
+      // this checks that a variable can be non static in a aggregate, i.e. the result will change across the fetched features
+      // see https://github.com/qgis/QGIS/issues/33382
+      QgsExpressionContext context;
+      context.appendScope( QgsExpressionContextUtils::layerScope( mAggregatesLayer ) );
+      QgsFeature f;
+
+      QgsFeatureIterator it = mAggregatesLayer->getFeatures();
+
+      while ( it.nextFeature( f ) )
+      {
+        context.setFeature( f );
+        QgsExpression exp( QString( "with_variable('my_var',\"col1\", aggregate(layer:='aggregate_layer', aggregate:='concatenate_unique', expression:=\"col2\", filter:=\"col1\"=@my_var))" ) );
+        QString res = exp.evaluate( &context ).toString();
+        QCOMPARE( res, f.attribute( "col2" ) );
+      }
+    }
+
     void aggregate_data()
     {
       QTest::addColumn<QString>( "string" );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2048,8 +2048,8 @@ class TestQgsExpression: public QObject
 
         // also test for generic aggregates
         exp = QString( "with_variable('my_var',\"col1\", sum(expression:=\"col1\", filter:=\"col1\"=@my_var))" );
-        res = exp.evaluate( &context ).toInt();
-        QCOMPARE( res, f.attribute( "col1" ).toInt() );
+        int res2 = exp.evaluate( &context ).toInt();
+        QCOMPARE( res2, f.attribute( "col1" ).toInt() );
       }
     }
 

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2194,6 +2194,8 @@ class TestQgsExpression: public QObject
       QTest::newRow( "group by and filter named" ) << "sum(expression:=\"col1\", group_by:=\"col3\", filter:=\"col1\">=3)" << false << QVariant( 7 );
       QTest::newRow( "group by expression" ) << "sum(\"col1\", \"col1\" % 2)" << false << QVariant( 14 );
       QTest::newRow( "group by with null value" ) << "sum(\"col1\", \"col4\")" << false << QVariant( 8 );
+
+      QTest::newRow( "filter by @parent attribute in generic aggregate" ) << "maximum(\"col1\", filter:=\"col1\"<attribute(@parent,'col1'))" << false << QVariant( 3 );
     }
 
     void maptip_display_data()

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2044,7 +2044,7 @@ class TestQgsExpression: public QObject
         context.setFeature( f );
         QgsExpression exp( QString( "with_variable('my_var',\"col1\", aggregate(layer:='aggregate_layer', aggregate:='concatenate_unique', expression:=\"col2\", filter:=\"col1\"=@my_var))" ) );
         QString res = exp.evaluate( &context ).toString();
-        QCOMPARE( res, f.attribute( "col2" ) );
+        QCOMPARE( res, f.attribute( "col2" ).toString() );
 
         // also test for generic aggregates
         exp = QString( "with_variable('my_var',\"col1\", sum(expression:=\"col1\", filter:=\"col1\"=@my_var))" );


### PR DESCRIPTION

fixes #33382
