### PR TITLE
Adding a Identify Result setting to hide the Derived attributes

### DIFF
--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -256,6 +256,8 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
 
     void mActionAutoFeatureForm_toggled( bool checked );
 
+    void mActionHideDerivedAttributes_toggled( bool checked );
+
     void mExpandAction_triggered( bool checked ) { Q_UNUSED( checked ) expandAll(); }
     void mCollapseAction_triggered( bool checked ) { Q_UNUSED( checked ) collapseAll(); }
 

--- a/src/ui/qgsidentifyresultsbase.ui
+++ b/src/ui/qgsidentifyresultsbase.ui
@@ -366,11 +366,22 @@
    </property>
   </action>
   <action name="mActionAutoFeatureForm">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="text">
     <string>Auto open form for single feature results</string>
    </property>
+  </action>
+  <action name="mActionHideDerivedAttributes">
    <property name="checkable">
     <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Hide Derived Attributes from Results</string>
+   </property>
+   <property name="toolTip">
+    <string>Hide derived attributes from results</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
See #39385. This adds boolean setting so the user can choose to show or hide the derived attribute values.
For certain use cases, OR when the user is not interested in all these geometry related info, this derived info is too much.

Setting looks like:

![Screenshot-20201015213836-340x84](https://user-images.githubusercontent.com/731673/96177860-ce5c4d80-0f2e-11eb-80d5-c162251e51cb.png)

The difference (in project with all 4 types of layers that have feature info):

![Screenshot-20201015214037-1135x1207](https://user-images.githubusercontent.com/731673/96178054-1aa78d80-0f2f-11eb-8d75-299bfd6aa73e.png)

I was uncertain how to handle the Mesh layer, as it looks like it receives 2 'features' for one click: one with the actual 'data' and one with a 'Geometry'. BOTH have a 'derived attributes', but I think the one for the data (ETA in this case) is actually valuable so keeping that one, but hiding the whole geometry stuff (see screenshot layer 1/mercator_test_puff-123).

One thing that bothers me also is that raster and mesh layers do not have their layernames (in bold) as root-node of the feature.
Happy to change/fix that too in this PR. I do not think it is helpfull to see the layer number (or is it feature number) in the result list?
