### PR TITLE
add field icon in DnD tree

### DIFF
--- a/python/core/auto_generated/qgsfields.sip.in
+++ b/python/core/auto_generated/qgsfields.sip.in
@@ -296,7 +296,7 @@ Utility function to return a list of QgsField instances
 Returns an icon corresponding to a field index, based on the field's type and source
 
 :param fieldIdx: the field index
-:param considerOrigin: , if True the icon will the origin of the field
+:param considerOrigin: if ``True`` the icon will the origin of the field
 
 .. versionadded:: 2.14
 %End

--- a/python/core/auto_generated/qgsfields.sip.in
+++ b/python/core/auto_generated/qgsfields.sip.in
@@ -291,9 +291,12 @@ Utility function to return a list of QgsField instances
     bool operator==( const QgsFields &other ) const;
     bool operator!=( const QgsFields &other ) const;
 
-    QIcon iconForField( int fieldIdx ) const /Factory/;
+    QIcon iconForField( int fieldIdx, bool considerOrigin = false ) const /Factory/;
 %Docstring
 Returns an icon corresponding to a field index, based on the field's type and source
+
+:param fieldIdx: the field index
+:param considerOrigin: , if True the icon will the origin of the field
 
 .. versionadded:: 2.14
 %End

--- a/src/core/qgsfields.cpp
+++ b/src/core/qgsfields.cpp
@@ -272,9 +272,24 @@ QgsFields::iterator QgsFields::end()
   return iterator( &d->fields.last() + 1 );
 }
 
-QIcon QgsFields::iconForField( int fieldIdx ) const
+QIcon QgsFields::iconForField( int fieldIdx, bool considerOrigin ) const
 {
-  return QgsFields::iconForFieldType( d->fields.at( fieldIdx ).field.type() );
+  if ( considerOrigin )
+  {
+    switch ( fieldOrigin( fieldIdx ) )
+    {
+      case QgsFields::OriginExpression:
+        return QgsApplication::getThemeIcon( QStringLiteral( "/mIconExpression.svg" ) );
+        break;
+
+      case QgsFields::OriginJoin:
+        return QgsApplication::getThemeIcon( QStringLiteral( "/propertyicons/join.svg" ) );
+
+      default:
+        return iconForFieldType( d->fields.at( fieldIdx ).field.type() );
+    }
+  }
+  return iconForFieldType( d->fields.at( fieldIdx ).field.type() );
 }
 
 QIcon QgsFields::iconForFieldType( const QVariant::Type &type )

--- a/src/core/qgsfields.h
+++ b/src/core/qgsfields.h
@@ -321,9 +321,11 @@ class CORE_EXPORT  QgsFields
 
     /**
      * Returns an icon corresponding to a field index, based on the field's type and source
+     * \param fieldIdx the field index
+     * \param considerOrigin, if True the icon will the origin of the field
      * \since QGIS 2.14
      */
-    QIcon iconForField( int fieldIdx ) const SIP_FACTORY;
+    QIcon iconForField( int fieldIdx, bool considerOrigin = false ) const SIP_FACTORY;
 #ifdef SIP_RUN
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )

--- a/src/core/qgsfields.h
+++ b/src/core/qgsfields.h
@@ -322,7 +322,7 @@ class CORE_EXPORT  QgsFields
     /**
      * Returns an icon corresponding to a field index, based on the field's type and source
      * \param fieldIdx the field index
-     * \param considerOrigin, if True the icon will the origin of the field
+     * \param considerOrigin if TRUE the icon will the origin of the field
      * \since QGIS 2.14
      */
     QIcon iconForField( int fieldIdx, bool considerOrigin = false ) const SIP_FACTORY;

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -97,7 +97,7 @@ void QgsAttributesFormProperties::initAvailableWidgetsTree()
   for ( int i = 0; i < fields.size(); ++i )
   {
     const QgsField field = fields.at( i );
-    DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Field, field.name(), field.name(), QColor() );
+    DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Field, field.name(), field.name() );
     itemData.setShowLabel( true );
 
     FieldConfig cfg( mLayer, i );

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -97,12 +97,12 @@ void QgsAttributesFormProperties::initAvailableWidgetsTree()
   for ( int i = 0; i < fields.size(); ++i )
   {
     const QgsField field = fields.at( i );
-    DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Field, field.name(), field.name() );
+    DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Field, field.name(), field.name(), QColor() );
     itemData.setShowLabel( true );
 
     FieldConfig cfg( mLayer, i );
 
-    QTreeWidgetItem *item = mAvailableWidgetsTree->addItem( catitem, itemData );
+    QTreeWidgetItem *item = mAvailableWidgetsTree->addItem( catitem, itemData, -1, fields.iconForField( i, true ) );
 
     item->setData( 0, FieldConfigRole, cfg );
     item->setData( 0, FieldNameRole, field.name() );
@@ -937,7 +937,7 @@ QgsAttributesDnDTree::QgsAttributesDnDTree( QgsVectorLayer *layer, QWidget *pare
   connect( this, &QTreeWidget::itemDoubleClicked, this, &QgsAttributesDnDTree::onItemDoubleClicked );
 }
 
-QTreeWidgetItem *QgsAttributesDnDTree::addItem( QTreeWidgetItem *parent, QgsAttributesFormProperties::DnDTreeItemData data, int index )
+QTreeWidgetItem *QgsAttributesDnDTree::addItem( QTreeWidgetItem *parent, QgsAttributesFormProperties::DnDTreeItemData data, int index, const QIcon &icon )
 {
   QTreeWidgetItem *newItem = new QTreeWidgetItem( QStringList() << data.name() );
 
@@ -961,6 +961,7 @@ QTreeWidgetItem *QgsAttributesDnDTree::addItem( QTreeWidgetItem *parent, QgsAttr
 
   newItem->setData( 0, QgsAttributesFormProperties::DnDTreeRole, data );
   newItem->setText( 0, data.displayName() );
+  newItem->setIcon( 0, icon );
 
   if ( index < 0 )
     parent->addChild( newItem );
@@ -1500,4 +1501,3 @@ void QgsAttributesFormProperties::DnDTreeItemData::setBackgroundColor( const QCo
 {
   mBackgroundColor = backgroundColor;
 }
-

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -273,7 +273,7 @@ class GUI_EXPORT QgsAttributesDnDTree : public QTreeWidget
      * Adds a new item to a \a parent. If \a index is -1, the item is added to the end of the parent's existing children.
      * Otherwise it is inserted at the specified \a index.
      */
-    QTreeWidgetItem *addItem( QTreeWidgetItem *parent, QgsAttributesFormProperties::DnDTreeItemData data, int index = -1 );
+    QTreeWidgetItem *addItem( QTreeWidgetItem *parent, QgsAttributesFormProperties::DnDTreeItemData data, int index = -1, const QIcon &icon = QIcon() );
     QTreeWidgetItem *addContainer( QTreeWidgetItem *parent, const QString &title, int columnCount );
 
     enum Type

--- a/src/gui/vector/qgssourcefieldsproperties.cpp
+++ b/src/gui/vector/qgssourcefieldsproperties.cpp
@@ -198,21 +198,7 @@ void QgsSourceFieldsProperties::setRow( int row, int idx, const QgsField &field 
 {
   QTableWidgetItem *dataItem = new QTableWidgetItem();
   dataItem->setData( Qt::DisplayRole, idx );
-
-  switch ( mLayer->fields().fieldOrigin( idx ) )
-  {
-    case QgsFields::OriginExpression:
-      dataItem->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mIconExpression.svg" ) ) );
-      break;
-
-    case QgsFields::OriginJoin:
-      dataItem->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/propertyicons/join.svg" ) ) );
-      break;
-
-    default:
-      dataItem->setIcon( mLayer->fields().iconForField( idx ) );
-      break;
-  }
+  dataItem->setIcon( mLayer->fields().iconForField( idx, true ) );
   mFieldsList->setItem( row, AttrIdCol, dataItem );
 
   // in case we insert and not append reindex remaining widgets by 1


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/127259/96182059-3746c400-0f35-11eb-88f8-3d4020c9471a.png)

Really useful when you don't want to distinguish joined fields, or more generally to show the field type.

Can this be seen as bugfix?