### PR TITLE
UUID expressions function with string format parameter

### DIFF
--- a/resources/function_help/json/uuid
+++ b/resources/function_help/json/uuid
@@ -2,7 +2,22 @@
   "name": "uuid",
   "type": "function",
   "groups": ["Record and Attributes"],
-  "description": "Generates a Universally Unique Identifier (UUID) for each row using the Qt <a href='https://doc.qt.io/qt-5/quuid.html#createUuid'>QUuid::createUuid</a> method. Each UUID is 38 characters long.",
-  "examples": [ { "expression":"uuid()", "returns":"'{0bd2f60f-f157-4a6d-96af-d4ba4cb366a1}'"}
+  "description": "Generates a Universally Unique Identifier (UUID) for each row using the Qt <a href='https://doc.qt.io/qt-5/quuid.html#createUuid'>QUuid::createUuid</a> method.",
+  "variants": [
+    {
+      "variant": "No parameters",
+      "variant_description": "If called with no parameters, the function will generate the UUID with the default string format 'WithBraces'. Each UUID is 38 characters long.",
+      "arguments": [],
+      "examples": [ { "expression":"uuid()", "returns":"'{0bd2f60f-f157-4a6d-96af-d4ba4cb366a1}'" } ]
+    },
+    {
+      "variant": "A 'stringFormat' parameter",
+      "variant_description": "If called with a 'stringFormat' parameter, the function will generate the UUID and format it accordingly using Qt <a href='https://doc.qt.io/qt-5/quuid.html#StringFormat-enum'>QUuid::StringFormat</a>",
+      "arguments": [ { "arg": "stringFormat", "description": "The string format of the UUID. This can be 'WithBraces' to format with curly braces, 'WithoutBraces' to format without braces or 'Id128' to format only with hex digits, without braces or dashes." } ],
+      "examples": [
+        { "expression": "uuid('WithoutBraces')", "returns": "'0bd2f60f-f157-4a6d-96af-d4ba4cb366a1'" },
+        { "expression": "uuid('Id128')", "returns": "'0bd2f60ff1574a6d96afd4ba4cb366a1'" }
+      ]
+    }
   ]
 }

--- a/resources/function_help/json/uuid
+++ b/resources/function_help/json/uuid
@@ -3,21 +3,17 @@
   "type": "function",
   "groups": ["Record and Attributes"],
   "description": "Generates a Universally Unique Identifier (UUID) for each row using the Qt <a href='https://doc.qt.io/qt-5/quuid.html#createUuid'>QUuid::createUuid</a> method.",
-  "variants": [
-    {
-      "variant": "No parameters",
-      "variant_description": "If called with no parameters, the function will generate the UUID with the default string format 'WithBraces'. Each UUID is 38 characters long.",
-      "arguments": [],
-      "examples": [ { "expression":"uuid()", "returns":"'{0bd2f60f-f157-4a6d-96af-d4ba4cb366a1}'" } ]
-    },
-    {
-      "variant": "A 'stringFormat' parameter",
-      "variant_description": "If called with a 'stringFormat' parameter, the function will generate the UUID and format it accordingly using Qt <a href='https://doc.qt.io/qt-5/quuid.html#StringFormat-enum'>QUuid::StringFormat</a>",
-      "arguments": [ { "arg": "stringFormat", "description": "The string format of the UUID. This can be 'WithBraces' to format with curly braces, 'WithoutBraces' to format without braces or 'Id128' to format only with hex digits, without braces or dashes." } ],
-      "examples": [
-        { "expression": "uuid('WithoutBraces')", "returns": "'0bd2f60f-f157-4a6d-96af-d4ba4cb366a1'" },
-        { "expression": "uuid('Id128')", "returns": "'0bd2f60ff1574a6d96afd4ba4cb366a1'" }
-      ]
-    }
+  "arguments": [
+        {
+          "arg": "format",
+          "optional": true,
+          "default": "'WithBraces'",
+          "description": "The format, as the UUID will be formatted. 'WithBraces', 'WithoutBraces' or 'Id128'."
+        }
+  ],
+  "examples": [ 
+  		{ "expression":"uuid()", "returns":"'{0bd2f60f-f157-4a6d-96af-d4ba4cb366a1}'" },
+  		{ "expression": "uuid('WithoutBraces')", "returns": "'0bd2f60f-f157-4a6d-96af-d4ba4cb366a1'" },
+  		{ "expression": "uuid('Id128')", "returns": "'0bd2f60ff1574a6d96afd4ba4cb366a1'" }
   ]
 }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6683,7 +6683,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
     currentFeatureFunc->setIsStatic( false );
     functions << currentFeatureFunc;
 
-    QgsStaticExpressionFunction *uuidFunc = new QgsStaticExpressionFunction( QStringLiteral( "uuid" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "stringFormat" ), true, QStringLiteral( "WithBraces" ) ), fcnUuid, QStringLiteral( "Record and Attributes" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "$uuid" ) );
+    QgsStaticExpressionFunction *uuidFunc = new QgsStaticExpressionFunction( QStringLiteral( "uuid" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "format" ), true, QStringLiteral( "WithBraces" ) ), fcnUuid, QStringLiteral( "Record and Attributes" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "$uuid" ) );
     uuidFunc->setIsStatic( false );
     functions << uuidFunc;
 

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1465,9 +1465,16 @@ static QVariant fcnRegexpSubstr( const QVariantList &values, const QgsExpression
   }
 }
 
-static QVariant fcnUuid( const QVariantList &, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * )
+static QVariant fcnUuid( const QVariantList &values, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * )
 {
-  return QUuid::createUuid().toString();
+  QUuid::StringFormat stringFormat = QUuid::StringFormat::WithBraces;
+
+  if ( values.at( 0 ).toString().compare( QStringLiteral( "WithoutBraces" ), Qt::CaseInsensitive ) == 0 )
+    stringFormat = QUuid::StringFormat::WithoutBraces;
+  else if ( values.at( 0 ).toString().compare( QStringLiteral( "Id128" ), Qt::CaseInsensitive ) == 0 )
+    stringFormat = QUuid::StringFormat::Id128;
+
+  return QUuid::createUuid().toString( stringFormat );
 }
 
 static QVariant fcnSubstr( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
@@ -6671,7 +6678,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
     currentFeatureFunc->setIsStatic( false );
     functions << currentFeatureFunc;
 
-    QgsStaticExpressionFunction *uuidFunc = new QgsStaticExpressionFunction( QStringLiteral( "uuid" ), 0, fcnUuid, QStringLiteral( "Record and Attributes" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "$uuid" ) );
+    QgsStaticExpressionFunction *uuidFunc = new QgsStaticExpressionFunction( QStringLiteral( "uuid" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "stringFormat" ), true, QStringLiteral( "WithBraces" ) ), fcnUuid, QStringLiteral( "Record and Attributes" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "$uuid" ) );
     uuidFunc->setIsStatic( false );
     functions << uuidFunc;
 

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1467,14 +1467,19 @@ static QVariant fcnRegexpSubstr( const QVariantList &values, const QgsExpression
 
 static QVariant fcnUuid( const QVariantList &values, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * )
 {
-  QUuid::StringFormat stringFormat = QUuid::StringFormat::WithBraces;
-
+  QString uuid = QUuid::createUuid().toString();
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
   if ( values.at( 0 ).toString().compare( QStringLiteral( "WithoutBraces" ), Qt::CaseInsensitive ) == 0 )
-    stringFormat = QUuid::StringFormat::WithoutBraces;
+    uuid.remove( QRegExp( "[{}]" ) );
   else if ( values.at( 0 ).toString().compare( QStringLiteral( "Id128" ), Qt::CaseInsensitive ) == 0 )
-    stringFormat = QUuid::StringFormat::Id128;
-
-  return QUuid::createUuid().toString( stringFormat );
+    uuid.remove( QRegExp( "[{}-]" ) );
+#else
+  if ( values.at( 0 ).toString().compare( QStringLiteral( "WithoutBraces" ), Qt::CaseInsensitive ) == 0 )
+    uuid = QUuid::createUuid().toString( QUuid::StringFormat::WithoutBraces );
+  else if ( values.at( 0 ).toString().compare( QStringLiteral( "Id128" ), Qt::CaseInsensitive ) == 0 )
+    uuid = QUuid::createUuid().toString( QUuid::StringFormat::Id128 );
+#endif
+  return uuid;
 }
 
 static QVariant fcnSubstr( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1702,6 +1702,11 @@ class TestQgsExpression: public QObject
       QTest::newRow( "to_base64" ) << QStringLiteral( "to_base64('QGIS')" ) << false << QVariant( "UUdJUw==" );
       QTest::newRow( "from_base64 NULL" ) << QStringLiteral( "from_base64(NULL)" ) << false << QVariant();
       QTest::newRow( "from_base64" ) << QStringLiteral( "from_base64('UUdJUw==')" ) << false << QVariant( QByteArray( QString( "QGIS" ).toLocal8Bit() ) );
+      QTest::newRow( "uuid()" ) << QStringLiteral( "regexp_match( uuid(), '({[a-zA-Z\\\\d]{8}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{12}})')" ) << false << QVariant( 1 );
+      QTest::newRow( "uuid('WithBraces')" ) << QStringLiteral( "regexp_match( uuid('WithBraces'), '({[a-zA-Z\\\\d]{8}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{12}})')" ) << false << QVariant( 1 );
+      QTest::newRow( "uuid('WithoutBraces')" ) << QStringLiteral( "regexp_match( uuid('WithoutBraces'), '([a-zA-Z\\\\d]{8}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{12})')" ) << false << QVariant( 1 );
+      QTest::newRow( "uuid('Id128')" ) << QStringLiteral( "regexp_match( uuid('Id128'), '([a-zA-Z\\\\d]{32})')" ) << false << QVariant( 1 );
+      QTest::newRow( "uuid('invalid-format')" ) << QStringLiteral( "regexp_match( uuid('invalid-format'), '({[a-zA-Z\\\\d]{8}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{12}})')" ) << false << QVariant( 1 );
     }
 
 


### PR DESCRIPTION
In the expressions: `uuid()` used to generate the UUID in the given format returned by `QUuid::createUuid` with curly braces and dashes: `{0bd2f60f-f157-4a6d-96af-d4ba4cb366a1}`

This needed to be formatted inside the expression with `substr` etc. to get it without braces or dashes.

`QUuid::createUuid` supports a `stringFormat` parameter https://doc.qt.io/qt-5/quuid.html#StringFormat-enum

Now you can enter a parameter to the `uuid` function in the expressions:
```
uuid() -> {0bd2f60f-f157-4a6d-96af-d4ba4cb366a1}
uuid('WithoutBraces') -> 0bd2f60f-f157-4a6d-96af-d4ba4cb366a1
uuid('Id128') -> 0bd2f60ff1574a6d96afd4ba4cb366a1
```