### PR TITLE
[processing] PointsToPath allow expression for order fields

### DIFF
--- a/python/plugins/processing/algs/qgis/PointsToPaths.py
+++ b/python/plugins/processing/algs/qgis/PointsToPaths.py
@@ -130,13 +130,17 @@ class PointsToPaths(QgisAlgorithm):
         if expression.hasParserError():
             raise QgsProcessingException(expression.parserErrorString())
         expression.prepare(expression_context)
+        order_field_type = QVariant.String
+        if expression.isField():
+            field_name = next(iter(expression.referencedColumns()))
+            order_field_type = source.fields().field(field_name).type()
 
         fields = QgsFields()
         if group_field_def is not None:
             fields.append(group_field_def)
-        begin_field = QgsField('begin', QVariant.String)
+        begin_field = QgsField('begin', order_field_type)
         fields.append(begin_field)
-        end_field = QgsField('end', QVariant.String)
+        end_field = QgsField('end', order_field_type)
         fields.append(end_field)
 
         output_wkb = QgsWkbTypes.LineString

--- a/python/plugins/processing/algs/qgis/PointsToPaths.py
+++ b/python/plugins/processing/algs/qgis/PointsToPaths.py
@@ -83,7 +83,7 @@ class PointsToPaths(QgisAlgorithm):
         order_field_param.setFlags(order_field_param.flags() | QgsProcessingParameterDefinition.FlagHidden)
         self.addParameter(order_field_param)
         self.addParameter(QgsProcessingParameterExpression(self.ORDER_EXPRESSION,
-                                                           self.tr('Order expression'), parentLayerParameterName=self.INPUT))
+                                                           self.tr('Order expression'), parentLayerParameterName=self.INPUT, optional=True))
         self.addParameter(QgsProcessingParameterField(self.GROUP_FIELD,
                                                       self.tr('Group field'), parentLayerParameterName=self.INPUT, optional=True))
         self.addParameter(QgsProcessingParameterString(self.DATE_FORMAT,
@@ -121,6 +121,9 @@ class PointsToPaths(QgisAlgorithm):
 
         if order_field_name:
             order_expression = QgsExpression.quotedColumnRef(order_field_name)
+
+        if not order_expression:
+            raise QgsProcessingException(self.tr('ORDER_EXPRESSION parameter is missing.'))
 
         expression_context = self.createExpressionContext(parameters, context, source)
         expression = QgsExpression(order_expression)


### PR DESCRIPTION
Allows using `$id` as expression for a csv with ordered values

Adds a new parameter `ORDER_EXPRESSION` to the PointsToPath algorithm.
