### PR TITLE
[Server] Fix + in parameter value getting converted to space if received via POST

### DIFF
--- a/src/server/qgsserverparameters.cpp
+++ b/src/server/qgsserverparameters.cpp
@@ -427,7 +427,7 @@ void QgsServerParameters::save( const QgsServerParameter &parameter )
 void QgsServerParameters::add( const QString &key, const QString &value )
 {
   QUrlQuery query;
-  query.addQueryItem( key, value );
+  query.addQueryItem( key, QUrl::toPercentEncoding( value ) );
   load( query );
 }
 
@@ -441,7 +441,7 @@ QUrlQuery QgsServerParameters::urlQuery() const
 
     for ( auto param : toMap().toStdMap() )
     {
-      query.addQueryItem( param.first, param.second );
+      query.addQueryItem( param.first, QUrl::toPercentEncoding( param.second ) );
     }
   }
 

--- a/tests/src/server/testqgsserverquerystringparameter.cpp
+++ b/tests/src/server/testqgsserverquerystringparameter.cpp
@@ -19,8 +19,11 @@
 #include <QStringList>
 
 //qgis includes...
+#include "qgsrequesthandler.h"
 #include "qgsserverquerystringparameter.h"
 #include "qgsserverapicontext.h"
+#include "qgsbufferserverrequest.h"
+#include "qgsbufferserverresponse.h"
 #include "qgsserverrequest.h"
 #include "qgsserverexception.h"
 
@@ -56,6 +59,9 @@ class TestQgsServerQueryStringParameter : public QObject
 
     // Test default values
     void testDefaultValues();
+
+    // Test QgsRequestHandler::parseInput (i.e. POST requests) with special chars
+    void testParseInput();
 };
 
 
@@ -172,6 +178,24 @@ void TestQgsServerQueryStringParameter::testDefaultValues()
   request.setUrl( QStringLiteral( "http://www.qgis.org/api/?parameter1=501" ) );
   QCOMPARE( p2.value( ctx ).toInt(), 501 );
 
+}
+
+void TestQgsServerQueryStringParameter::testParseInput()
+{
+  // Request with layers "a", "b", "c" and "äös + %&#"
+  QByteArray data( "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=a%2Cb%2Cc%2C%C3%A4%C3%B6s+%2B+%25%26%23" );
+  QgsBufferServerRequest request( QStringLiteral( "http://localhost/wms/test" ), QgsServerRequest::PostMethod, QgsServerRequest::Headers(), &data );
+  QgsBufferServerResponse response;
+
+  QgsRequestHandler requestHandler( request, response );
+  requestHandler.parseInput();
+
+  QgsServerParameters params = request.serverParameters();
+  QMap<QString, QString> paramsMap = params.toMap();
+  QCOMPARE( paramsMap["SERVICE"], QStringLiteral( "WMS" ) );
+  QCOMPARE( paramsMap["VERSION"], QStringLiteral( "1.3.0" ) );
+  QCOMPARE( paramsMap["REQUEST"], QStringLiteral( "GetMap" ) );
+  QCOMPARE( paramsMap["LAYERS"], QStringLiteral( "a,b,c,äös + %&#" ) );
 }
 
 QGSTEST_MAIN( TestQgsServerQueryStringParameter )


### PR DESCRIPTION
For example, if a layer name contains a +, and you submit a GetMap request per POST (x-www-form-urlencoded), the plus will be correctly handled at [1], but then in `QgsServerParameters::add` [2] and `QgsServerParameters::urlQuery` [3] it will be treated as a space, see the note for `QUrlQuery::addQueryItem` here [4]. So i.e. a layename `hello+world` will become `hello world`

[1] https://github.com/qgis/QGIS/blob/master/src/server/qgsrequesthandler.cpp#L224
[2] https://github.com/qgis/QGIS/blob/master/src/server/qgsserverparameters.cpp#L430
[3] https://github.com/qgis/QGIS/blob/master/src/server/qgsserverparameters.cpp#L444
[4] https://doc.qt.io/qt-5/qurlquery.html#addQueryItem