### PR TITLE
QgsVectorLayerExporter: defer GPKG spatial index creation at file closing

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -2710,13 +2710,21 @@ bool QgsOgrProvider::deleteFeatures( const QgsFeatureIds &id )
     returnvalue = false;
   }
 
-  if ( mFeaturesCounted != QgsVectorDataProvider::Uncounted &&
-       mFeaturesCounted != QgsVectorDataProvider::UnknownCount )
+  if ( mGDALDriverName == QLatin1String( "ESRI Shapefile" ) )
   {
-    if ( returnvalue )
-      mFeaturesCounted -= id.size();
-    else
-      recalculateFeatureCount();
+    // Shapefile behaves in a special way due to possible recompaction
+    recalculateFeatureCount();
+  }
+  else
+  {
+    if ( mFeaturesCounted != QgsVectorDataProvider::Uncounted &&
+         mFeaturesCounted != QgsVectorDataProvider::UnknownCount )
+    {
+      if ( returnvalue )
+        mFeaturesCounted -= id.size();
+      else
+        recalculateFeatureCount();
+    }
   }
 
   clearMinMaxCache();

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -1875,7 +1875,14 @@ bool QgsOgrProvider::addFeatures( QgsFeatureList &flist, Flags flags )
     returnvalue = false;
   }
 
-  recalculateFeatureCount();
+  if ( mFeaturesCounted != QgsVectorDataProvider::Uncounted &&
+       mFeaturesCounted != QgsVectorDataProvider::UnknownCount )
+  {
+    if ( returnvalue )
+      mFeaturesCounted += flist.size();
+    else
+      recalculateFeatureCount();
+  }
 
   if ( returnvalue )
     clearMinMaxCache();
@@ -2703,7 +2710,14 @@ bool QgsOgrProvider::deleteFeatures( const QgsFeatureIds &id )
     returnvalue = false;
   }
 
-  recalculateFeatureCount();
+  if ( mFeaturesCounted != QgsVectorDataProvider::Uncounted &&
+       mFeaturesCounted != QgsVectorDataProvider::UnknownCount )
+  {
+    if ( returnvalue )
+      mFeaturesCounted -= id.size();
+    else
+      recalculateFeatureCount();
+  }
 
   clearMinMaxCache();
 

--- a/src/core/qgsvectorlayerexporter.h
+++ b/src/core/qgsvectorlayerexporter.h
@@ -164,6 +164,8 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
 
     QgsFeatureList mFeatureBuffer;
 
+    bool mCreateSpatialIndex = true;
+
 #ifdef SIP_RUN
     QgsVectorLayerExporter( const QgsVectorLayerExporter &rh );
 #endif

--- a/src/core/qgsvectorlayerexporter.h
+++ b/src/core/qgsvectorlayerexporter.h
@@ -166,6 +166,8 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
 
     bool mCreateSpatialIndex = true;
 
+    int mFeatureSizeBuffer;
+
 #ifdef SIP_RUN
     QgsVectorLayerExporter( const QgsVectorLayerExporter &rh );
 #endif


### PR DESCRIPTION
Should fix the issue raised in
https://lists.osgeo.org/pipermail/qgis-developer/2020-October/062422.html

The difference with QgsVectorFileWriter is that QgsVectorFileWriter does not
close and re-open the layer, so the defered spatial index creation mechanism
that is built-in in the GPKG driver works. But in the case of
QgsVectorLayerExporter, we close and re-open and thus the spatial index gets
created immediately.
