### PR TITLE
QgsVectorLayerExporter: RAM based logic to decide when to flush features

### DIFF
--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -196,6 +196,15 @@ Sets the geometry from a WKT string.
     typedef QFlags<QgsAbstractGeometry::WkbFlag> WkbFlags;
 
 
+    virtual int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const = 0;
+%Docstring
+Returns the length of the QByteArray returned by :py:func:`~QgsAbstractGeometry.asWkb`
+
+The optional ``flags`` argument specifies flags controlling WKB export behavior
+
+.. versionadded:: 3.16
+%End
+
     virtual QByteArray asWkb( WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const = 0;
 %Docstring
 Returns a WKB representation of the geometry.

--- a/python/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -71,6 +71,8 @@ to ``p2`` will be used (i.e. winding the other way around the circle).
     virtual bool fromWkt( const QString &wkt );
 
 
+    virtual int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
+
     virtual QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
 
     virtual QString asWkt( int precision = 17 ) const;

--- a/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
@@ -42,6 +42,8 @@ Compound curve geometry type
     virtual bool fromWkt( const QString &wkt );
 
 
+    virtual int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
+
     virtual QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
 
     virtual QString asWkt( int precision = 17 ) const;

--- a/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -46,6 +46,8 @@ Curve polygon geometry type
     virtual bool fromWkt( const QString &wkt );
 
 
+    virtual int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
+
     virtual QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
 
     virtual QString asWkt( int precision = 17 ) const;

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1552,6 +1552,15 @@ is null, a ValueError will be raised.
 
 
 
+    int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
+%Docstring
+Returns the length of the QByteArray returned by :py:func:`~QgsGeometry.asWkb`
+
+The optional ``flags`` argument specifies flags controlling WKB export behavior
+
+.. versionadded:: 3.16
+%End
+
     QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
 %Docstring
 Export the geometry to WKB

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -162,6 +162,9 @@ An IndexError will be raised if no geometry with the specified index exists.
 
     virtual bool fromWkt( const QString &wkt );
 
+
+    virtual int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
+
     virtual QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
 
     virtual QString asWkt( int precision = 17 ) const;

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -438,6 +438,8 @@ If ``useZValues`` is ``True`` then z values will also be considered when testing
     virtual bool fromWkt( const QString &wkt );
 
 
+    virtual int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
+
     virtual QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
 
     virtual QString asWkt( int precision = 17 ) const;

--- a/python/core/auto_generated/geometry/qgspoint.sip.in
+++ b/python/core/auto_generated/geometry/qgspoint.sip.in
@@ -369,6 +369,8 @@ Example
 
     virtual bool fromWkt( const QString &wkt );
 
+    virtual int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
+
     virtual QByteArray asWkb( QgsAbstractGeometry::WkbFlags = QgsAbstractGeometry::WkbFlags() ) const;
 
     virtual QString asWkt( int precision = 17 ) const;

--- a/python/core/auto_generated/geometry/qgspolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgspolygon.sip.in
@@ -46,6 +46,8 @@ Ownership of ``exterior`` and ``rings`` is transferred to the polygon.
 
     virtual bool fromWkb( QgsConstWkbPtr &wkb );
 
+    virtual int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
+
     virtual QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
 
     virtual QgsPolygon *surfaceToPolygon() const /Factory/;

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -549,6 +549,17 @@ before this method can be used.
 .. seealso:: :py:func:`setFields`
 %End
 
+    int approximateMemoryUsage() const;
+%Docstring
+Returns the approximate RAM usage of the feature, in bytes.
+
+This method takes into account the size of variable elements (strings,
+geometry, ...), but the value returned should be considered as a lower
+bound estimation.
+
+.. versionadded:: 3.16
+%End
+
     operator QVariant() const;
 
 }; // class QgsFeature

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -253,6 +253,15 @@ class CORE_EXPORT QgsAbstractGeometry
     Q_DECLARE_FLAGS( WkbFlags, WkbFlag )
 
     /**
+     * Returns the length of the QByteArray returned by asWkb()
+     *
+     * The optional \a flags argument specifies flags controlling WKB export behavior
+     *
+     * \since QGIS 3.16
+     */
+    virtual int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const = 0;
+
+    /**
      * Returns a WKB representation of the geometry.
      *
      * The optional \a flags argument specifies flags controlling WKB export behavior (since QGIS 3.14).

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -329,13 +329,17 @@ bool QgsCircularString::fromWkt( const QString &wkt )
   return true;
 }
 
-QByteArray QgsCircularString::asWkb( WkbFlags ) const
+int QgsCircularString::wkbSize( QgsAbstractGeometry::WkbFlags ) const
 {
   int binarySize = sizeof( char ) + sizeof( quint32 ) + sizeof( quint32 );
   binarySize += numPoints() * ( 2 + is3D() + isMeasure() ) * sizeof( double );
+  return binarySize;
+}
 
+QByteArray QgsCircularString::asWkb( WkbFlags flags ) const
+{
   QByteArray wkbArray;
-  wkbArray.resize( binarySize );
+  wkbArray.resize( QgsCircularString::wkbSize( flags ) );
   QgsWkbPtr wkb( wkbArray );
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -75,6 +75,7 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
     bool fromWkb( QgsConstWkbPtr &wkb ) override;
     bool fromWkt( const QString &wkt ) override;
 
+    int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const override;
     QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -227,27 +227,27 @@ bool QgsCompoundCurve::fromWkt( const QString &wkt )
   return true;
 }
 
-QByteArray QgsCompoundCurve::asWkb( WkbFlags flags ) const
+int QgsCompoundCurve::wkbSize( QgsAbstractGeometry::WkbFlags flags ) const
 {
   int binarySize = sizeof( char ) + sizeof( quint32 ) + sizeof( quint32 );
-  QVector<QByteArray> wkbForCurves;
-  wkbForCurves.reserve( mCurves.size() );
   for ( const QgsCurve *curve : mCurves )
   {
-    QByteArray wkbForCurve = curve->asWkb( flags );
-    binarySize += wkbForCurve.length();
-    wkbForCurves << wkbForCurve;
+    binarySize += curve->wkbSize( flags );
   }
+  return binarySize;
+}
 
+QByteArray QgsCompoundCurve::asWkb( WkbFlags flags ) const
+{
   QByteArray wkbArray;
-  wkbArray.resize( binarySize );
+  wkbArray.resize( QgsCompoundCurve::wkbSize( flags ) );
   QgsWkbPtr wkb( wkbArray );
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );
   wkb << static_cast<quint32>( mCurves.size() );
-  for ( const QByteArray &wkbForCurve : qgis::as_const( wkbForCurves ) )
+  for ( const QgsCurve *curve : mCurves )
   {
-    wkb << wkbForCurve;
+    wkb << curve->asWkb( flags );
   }
   return wkbArray;
 }

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -46,6 +46,7 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
     bool fromWkb( QgsConstWkbPtr &wkb ) override;
     bool fromWkt( const QString &wkt ) override;
 
+    int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const override;
     QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -51,6 +51,7 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     bool fromWkb( QgsConstWkbPtr &wkb ) override;
     bool fromWkt( const QString &wkt ) override;
 
+    int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const override;
     QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2504,6 +2504,11 @@ QVector<QgsPointXY> QgsGeometry::randomPointsInPolygon( int count, unsigned long
 }
 ///@endcond
 
+int QgsGeometry::wkbSize( QgsAbstractGeometry::WkbFlags flags ) const
+{
+  return d->geometry ? d->geometry->wkbSize( flags ) : 0;
+}
+
 QByteArray QgsGeometry::asWkb( QgsAbstractGeometry::WkbFlags flags ) const
 {
   return d->geometry ? d->geometry->asWkb( flags ) : QByteArray();

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1584,6 +1584,15 @@ class CORE_EXPORT QgsGeometry
 ///@endcond
 
     /**
+     * Returns the length of the QByteArray returned by asWkb()
+     *
+     * The optional \a flags argument specifies flags controlling WKB export behavior
+     *
+     * \since QGIS 3.16
+     */
+    int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
+
+    /**
      * Export the geometry to WKB
      *
      * The optional \a flags argument specifies flags controlling WKB export behavior (since QGIS 3.14).

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -186,6 +186,8 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
 
     bool fromWkb( QgsConstWkbPtr &wkb ) override;
     bool fromWkt( const QString &wkt ) override;
+
+    int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const override;
     QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -490,13 +490,17 @@ bool QgsLineString::fromWkt( const QString &wkt )
   return true;
 }
 
-QByteArray QgsLineString::asWkb( WkbFlags ) const
+int QgsLineString::wkbSize( QgsAbstractGeometry::WkbFlags ) const
 {
   int binarySize = sizeof( char ) + sizeof( quint32 ) + sizeof( quint32 );
   binarySize += numPoints() * ( 2 + is3D() + isMeasure() ) * sizeof( double );
+  return binarySize;
+}
 
+QByteArray QgsLineString::asWkb( WkbFlags flags ) const
+{
   QByteArray wkbArray;
-  wkbArray.resize( binarySize );
+  wkbArray.resize( QgsLineString::wkbSize( flags ) );
   QgsWkbPtr wkb( wkbArray );
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -603,6 +603,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     bool fromWkb( QgsConstWkbPtr &wkb ) override;
     bool fromWkt( const QString &wkt ) override;
 
+    int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const override;
     QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -230,13 +230,17 @@ bool QgsPoint::fromWkt( const QString &wkt )
  * See details in QEP #17
  ****************************************************************************/
 
-QByteArray QgsPoint::asWkb( WkbFlags ) const
+int QgsPoint::wkbSize( WkbFlags ) const
 {
   int binarySize = sizeof( char ) + sizeof( quint32 );
   binarySize += ( 2 + is3D() + isMeasure() ) * sizeof( double );
+  return binarySize;
+}
 
+QByteArray QgsPoint::asWkb( WkbFlags flags ) const
+{
   QByteArray wkbArray;
-  wkbArray.resize( binarySize );
+  wkbArray.resize( QgsPoint::wkbSize( flags ) );
   QgsWkbPtr wkb( wkbArray );
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -490,6 +490,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
     void clear() override;
     bool fromWkb( QgsConstWkbPtr &wkb ) override;
     bool fromWkt( const QString &wkt ) override;
+    int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const override;
     QByteArray asWkb( QgsAbstractGeometry::WkbFlags = QgsAbstractGeometry::WkbFlags() ) const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;

--- a/src/core/geometry/qgspolygon.cpp
+++ b/src/core/geometry/qgspolygon.cpp
@@ -121,7 +121,7 @@ bool QgsPolygon::fromWkb( QgsConstWkbPtr &wkbPtr )
   return true;
 }
 
-QByteArray QgsPolygon::asWkb( QgsAbstractGeometry::WkbFlags flags ) const
+int QgsPolygon::wkbSize( QgsAbstractGeometry::WkbFlags ) const
 {
   int binarySize = sizeof( char ) + sizeof( quint32 ) + sizeof( quint32 );
 
@@ -135,8 +135,13 @@ QByteArray QgsPolygon::asWkb( QgsAbstractGeometry::WkbFlags flags ) const
     binarySize += sizeof( quint32 ) + curve->numPoints() * ( 2 + curve->is3D() + curve->isMeasure() ) * sizeof( double );
   }
 
+  return binarySize;
+}
+
+QByteArray QgsPolygon::asWkb( QgsAbstractGeometry::WkbFlags flags ) const
+{
   QByteArray wkbArray;
-  wkbArray.resize( binarySize );
+  wkbArray.resize( QgsPolygon::wkbSize() );
   QgsWkbPtr wkb( wkbArray );
   wkb << static_cast<char>( QgsApplication::endian() );
 

--- a/src/core/geometry/qgspolygon.h
+++ b/src/core/geometry/qgspolygon.h
@@ -53,6 +53,7 @@ class CORE_EXPORT QgsPolygon: public QgsCurvePolygon
     QgsPolygon *clone() const override SIP_FACTORY;
     void clear() override;
     bool fromWkb( QgsConstWkbPtr &wkb ) override;
+    int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const override;
     QByteArray asWkb( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const override;
     QgsPolygon *surfaceToPolygon() const override SIP_FACTORY;
 

--- a/src/core/qgsfeature.cpp
+++ b/src/core/qgsfeature.cpp
@@ -18,6 +18,8 @@ email                : sherman at mrcc.com
 #include "qgsfields.h"
 #include "qgsgeometry.h"
 #include "qgsrectangle.h"
+#include "qgsfield_p.h" // for approximateMemoryUsage()
+#include "qgsfields_p.h" // for approximateMemoryUsage()
 
 #include "qgsmessagelog.h"
 
@@ -278,6 +280,58 @@ int QgsFeature::fieldNameIndex( const QString &fieldName ) const
 {
   return d->fields.lookupField( fieldName );
 }
+
+static size_t qgsQStringApproximateMemoryUsage( const QString &str )
+{
+  return sizeof( QString ) + str.size() * sizeof( QChar );
+}
+
+static size_t qgsQVariantApproximateMemoryUsage( const QVariant &v )
+{
+  // A QVariant has a private structure that is a union of things whose larger
+  // size if a long long, and a int
+  size_t s = sizeof( QVariant ) + sizeof( long long ) + sizeof( int );
+  if ( v.type() == QVariant::String )
+  {
+    s += qgsQStringApproximateMemoryUsage( v.toString() );
+  }
+  else if ( v.type() == QVariant::StringList )
+  {
+    for ( const QString &str : v.toStringList() )
+      s += qgsQStringApproximateMemoryUsage( str );
+  }
+  else if ( v.type() == QVariant::List )
+  {
+    for ( const QVariant &subV : v.toList() )
+      s += qgsQVariantApproximateMemoryUsage( subV );
+  }
+  return s;
+}
+
+int QgsFeature::approximateMemoryUsage() const
+{
+  size_t s = sizeof( *this ) + sizeof( *d );
+
+  // Attributes
+  for ( const QVariant &attr : qgis::as_const( d->attributes ) )
+  {
+    s += qgsQVariantApproximateMemoryUsage( attr );
+  }
+
+  // Geometry
+  s += sizeof( QAtomicInt ) + sizeof( void * ); // ~ sizeof(QgsGeometryPrivate)
+  // For simplicity we consider that the RAM usage is the one of the WKB
+  // representation
+  s += d->geometry.wkbSize();
+
+  // Fields
+  s += sizeof( QgsFieldsPrivate );
+  // TODO potentially: take into account the length of the name, comment, default value, etc...
+  s += d->fields.size() * ( sizeof( QgsField )  + sizeof( QgsFieldPrivate ) );
+
+  return static_cast<int>( s );
+}
+
 
 /***************************************************************************
  * This class is considered CRITICAL and any change MUST be accompanied with

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -536,6 +536,17 @@ class CORE_EXPORT QgsFeature
      */
     int fieldNameIndex( const QString &fieldName ) const;
 
+    /**
+     * Returns the approximate RAM usage of the feature, in bytes.
+     *
+     * This method takes into account the size of variable elements (strings,
+     * geometry, ...), but the value returned should be considered as a lower
+     * bound estimation.
+     *
+     * \since QGIS 3.16
+     */
+    int approximateMemoryUsage() const;
+
     //! Allows direct construction of QVariants from features.
     operator QVariant() const
     {

--- a/src/core/qgsvectorlayerexporter.h
+++ b/src/core/qgsvectorlayerexporter.h
@@ -163,10 +163,9 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
     int mAttributeCount;
 
     QgsFeatureList mFeatureBuffer;
+    int mFeatureBufferMemoryUsage = 0;
 
     bool mCreateSpatialIndex = true;
-
-    int mFeatureSizeBuffer;
 
 #ifdef SIP_RUN
     QgsVectorLayerExporter( const QgsVectorLayerExporter &rh );

--- a/tests/src/core/testqgsfeature.cpp
+++ b/tests/src/core/testqgsfeature.cpp
@@ -124,6 +124,7 @@ void TestQgsFeature::attributesTest()
 void TestQgsFeature::constructorTest()
 {
   QgsFeature f;
+  QVERIFY( f.approximateMemoryUsage() > 0 );
   QVERIFY( FID_IS_NULL( f.id() ) );
   QgsFeature f2 { QgsFields() };
   QVERIFY( FID_IS_NULL( f2.id() ) );
@@ -222,6 +223,7 @@ void TestQgsFeature::attributes()
   feature.setAttributes( mAttrs );
   QCOMPARE( feature.attributes(), mAttrs );
   QCOMPARE( feature.attributes(), mAttrs );
+  QVERIFY( feature.approximateMemoryUsage() > QgsFeature().approximateMemoryUsage() );
 
   //test implicit sharing detachment
   QgsFeature copy( feature );
@@ -286,6 +288,7 @@ void TestQgsFeature::geometry()
   //test no double delete of geometry when setting:
   feature.setGeometry( QgsGeometry( mGeometry2 ) );
   QVERIFY( feature.hasGeometry() );
+  QVERIFY( feature.approximateMemoryUsage() > QgsFeature().approximateMemoryUsage() );
   feature.setGeometry( QgsGeometry( mGeometry ) );
   QCOMPARE( feature.geometry().asWkb(), mGeometry.asWkb() );
 
@@ -355,6 +358,8 @@ void TestQgsFeature::fields()
   QVERIFY( original.fields().isEmpty() );
   original.setFields( mFields );
   QCOMPARE( original.fields(), mFields );
+  QVERIFY( original.approximateMemoryUsage() > QgsFeature().approximateMemoryUsage() );
+
   QgsFeature copy( original );
   QCOMPARE( copy.fields(), original.fields() );
 

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -802,6 +802,7 @@ void TestQgsGeometry::point()
   //to/from WKB
   QgsPoint p12( QgsWkbTypes::PointZM, 1.0, 2.0, 3.0, -4.0 );
   QByteArray wkb12 = p12.asWkb();
+  QCOMPARE( wkb12.size(), p12.wkbSize() );
   QgsPoint p13;
   QgsConstWkbPtr wkb12ptr( wkb12 );
   p13.fromWkb( wkb12ptr );
@@ -815,6 +816,7 @@ void TestQgsGeometry::point()
   QgsLineString line;
   p13 = QgsPoint( 1, 2 );
   QByteArray wkbLine = line.asWkb();
+  QCOMPARE( wkbLine.size(), line.wkbSize() );
   QgsConstWkbPtr wkbLinePtr( wkbLine );
   QVERIFY( !p13.fromWkb( wkbLinePtr ) );
   QCOMPARE( p13.wkbType(), QgsWkbTypes::Point );
@@ -1802,6 +1804,7 @@ void TestQgsGeometry::circularString()
                  << QgsPoint( QgsWkbTypes::PointZM, 11, 22, 21, 24 )
                  << QgsPoint( QgsWkbTypes::PointZM, 1, 22, 31, 34 ) );
   QByteArray wkb15 = l15.asWkb();
+  QCOMPARE( wkb15.size(), l15.wkbSize() );
   QgsCircularString l16;
   QgsConstWkbPtr wkb15ptr( wkb15 );
   l16.fromWkb( wkb15ptr );
@@ -3769,6 +3772,7 @@ void TestQgsGeometry::lineString()
                  << QgsPoint( QgsWkbTypes::PointZM, 11, 22, 21, 24 )
                  << QgsPoint( QgsWkbTypes::PointZM, 1, 22, 31, 34 ) );
   QByteArray wkb15 = l15.asWkb();
+  QCOMPARE( wkb15.size(), l15.wkbSize() );
   QgsLineString l16;
   QgsConstWkbPtr wkb15ptr( wkb15 );
   l16.fromWkb( wkb15ptr );
@@ -5639,6 +5643,7 @@ void TestQgsGeometry::polygon()
                    << QgsPoint( QgsWkbTypes::Point, 9, 1 ) << QgsPoint( QgsWkbTypes::Point, 1, 1 ) );
   p16.addInteriorRing( ring );
   QByteArray wkb16 = p16.asWkb();
+  QCOMPARE( wkb16.size(), p16.wkbSize() );
   QgsPolygon p17;
   QgsConstWkbPtr wkb16ptr( wkb16 );
   p17.fromWkb( wkb16ptr );
@@ -5657,6 +5662,7 @@ void TestQgsGeometry::polygon()
                    << QgsPoint( QgsWkbTypes::PointZ, 9, 1, 4 ) << QgsPoint( QgsWkbTypes::PointZ, 1, 1, 1 ) );
   p16.addInteriorRing( ring );
   wkb16 = p16.asWkb();
+  QCOMPARE( wkb16.size(), p16.wkbSize() );
   QgsConstWkbPtr wkb16ptr2( wkb16 );
   p17.fromWkb( wkb16ptr2 );
   QCOMPARE( p16, p17 );
@@ -7220,6 +7226,7 @@ void TestQgsGeometry::triangle()
 
   // WKB
   QByteArray wkb = t5.asWkb();
+  QCOMPARE( wkb.size(), t5.wkbSize() );
   t6.clear();
   QgsConstWkbPtr wkb16ptr5( wkb );
   t6.fromWkb( wkb16ptr5 );
@@ -9035,6 +9042,7 @@ void TestQgsGeometry::curvePolygon()
                    << QgsPoint( 0.1, 0.05 ) << QgsPoint( 0, 0 ) );
   p16.addInteriorRing( ring );
   QByteArray wkb16 = p16.asWkb();
+  QCOMPARE( wkb16.size(), p16.wkbSize() );
   QgsCurvePolygon p17;
   QgsConstWkbPtr wkb16ptr( wkb16 );
   p17.fromWkb( wkb16ptr );
@@ -9064,6 +9072,7 @@ void TestQgsGeometry::curvePolygon()
   cCurve->addCurve( ext );
   p16.addInteriorRing( cCurve );
   wkb16 = p16.asWkb();
+  QCOMPARE( wkb16.size(), p16.wkbSize() );
   QgsConstWkbPtr wkb16ptr3( wkb16 );
   p17.fromWkb( wkb16ptr3 );
   QCOMPARE( p16, p17 );
@@ -10407,6 +10416,7 @@ void TestQgsGeometry::compoundCurve()
                  << QgsPoint( QgsWkbTypes::PointZM, 1, 22, 31, 34 ) );
   c15.addCurve( l15.clone() );
   QByteArray wkb15 = c15.asWkb();
+  QCOMPARE( wkb15.size(), c15.wkbSize() );
   QgsCompoundCurve c16;
   QgsConstWkbPtr wkb15ptr( wkb15 );
   c16.fromWkb( wkb15ptr );
@@ -14753,6 +14763,7 @@ void TestQgsGeometry::multiPolygon()
   part.setExteriorRing( ring.clone() );
   c16.addGeometry( part.clone() );
   QByteArray wkb16 = c16.asWkb();
+  QCOMPARE( wkb16.size(), c16.wkbSize() );
   QgsMultiPolygon c17;
   QgsConstWkbPtr wkb16ptr( wkb16 );
   c17.fromWkb( wkb16ptr );
@@ -15391,6 +15402,7 @@ void TestQgsGeometry::geometryCollection()
                    << QgsPoint( QgsWkbTypes::Point, 9, 1 ) << QgsPoint( QgsWkbTypes::Point, 1, 1 ) );
   c16.addGeometry( part2.clone() );
   QByteArray wkb16 = c16.asWkb();
+  QCOMPARE( wkb16.size(), c16.wkbSize() );
   QgsGeometryCollection c17;
   QgsConstWkbPtr wkb16ptr( wkb16 );
   c17.fromWkb( wkb16ptr );


### PR DESCRIPTION
Flush features when we have ~ 10 MB of them in memory.

This is a continuation of https://github.com/qgis/QGIS/pull/39439 , which requires new core functions: QgsGeometry::wkbSize() and QgsFeature::approximateRAMUsage() . Not sure if this is 3.16 material