### PR TITLE
[processing] Fix generated layers stored in geopackage always report a feature count of 0

### DIFF
--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -796,7 +796,11 @@ QgsFeatureSink *QgsProcessingUtils::createFeatureSink( QString &destination, Qgs
 
         // use destination string as layer name (eg "postgis:..." )
         if ( !layerName.isEmpty() )
-          uri += QStringLiteral( "|layername=%1" ).arg( layerName );
+        {
+          QVariantMap parts = QgsProviderRegistry::instance()->decodeUri( providerKey, uri );
+          parts.insert( QStringLiteral( "layerName" ), layerName );
+          uri = QgsProviderRegistry::instance()->encodeUri( providerKey, parts );
+        }
 
         std::unique_ptr< QgsVectorLayer > layer = qgis::make_unique<QgsVectorLayer>( uri, destination, providerKey, layerOptions );
         // update destination to layer ID
@@ -827,11 +831,9 @@ QgsFeatureSink *QgsProcessingUtils::createFeatureSink( QString &destination, Qgs
         // use destination string as layer name (eg "postgis:..." )
         if ( !layerName.isEmpty() )
           uri += QStringLiteral( "|layername=%1" ).arg( layerName );
-        std::unique_ptr< QgsVectorLayer > layer = qgis::make_unique<QgsVectorLayer>( uri, destination, providerKey, layerOptions );
-        // update destination to layer ID
-        destination = layer->id();
+        // update destination to generated URI
+        destination = uri;
 
-        context.temporaryLayerStore()->addMapLayer( layer.release() );
         return new QgsProcessingFeatureSink( exporter.release(), destination, context, true );
       }
     }

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -1955,6 +1955,7 @@ void TestQgsProcessing::createFeatureSink()
   destination = QStringLiteral( "ogr:dbname='%1' table=\"polygons\" (geom) sql=" ).arg( geopackagePath );
   sink.reset( QgsProcessingUtils::createFeatureSink( destination, context, fields, QgsWkbTypes::Polygon, QgsCoordinateReferenceSystem::fromEpsgId( 3111 ) ) );
   QVERIFY( sink.get() );
+  QCOMPARE( destination, QStringLiteral( "%1|layername=polygons" ).arg( geopackagePath ) );
   f = QgsFeature( fields );
   f.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "Polygon((0 0, 0 1, 1 1, 1 0, 0 0 ))" ) ) );
   f.setAttributes( QgsAttributes() << "val" );
@@ -1970,6 +1971,7 @@ void TestQgsProcessing::createFeatureSink()
   QString destination2 = QStringLiteral( "ogr:dbname='%1' table=\"points\" (geom) sql=" ).arg( geopackagePath );
   sink.reset( QgsProcessingUtils::createFeatureSink( destination2, context, fields, QgsWkbTypes::Point, QgsCoordinateReferenceSystem::fromEpsgId( 3111 ) ) );
   QVERIFY( sink.get() );
+  QCOMPARE( destination2, QStringLiteral( "%1|layername=points" ).arg( geopackagePath ) );
   f = QgsFeature( fields );
   f.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "Point(0 0)" ) ) );
   f.setAttributes( QgsAttributes() << "val2" );


### PR DESCRIPTION
Remove outdated approach which saw an empty copy of the destination
layer loaded immediately, and which was ultimately added to the
project and was unaware of features subsequently added to the underlying
geopackage data source.

Fixes another issue identified by @timlinux 's recent screencast
