### PR TITLE
[needs-docs][ui] UI/UX revamp of the 3D map configuration dialog

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -453,6 +453,7 @@
         <file>themes/default/mActionFirst.svg</file>
         <file>themes/default/mIconAtlas.svg</file>
         <file>themes/default/mIconAutoPlacementSettings.svg</file>
+        <file>themes/default/mIconCamera.svg</file>
         <file>themes/default/mIconCertificate.svg</file>
         <file>themes/default/mIconCertificateMissing.svg</file>
         <file>themes/default/mIconCertificateTrusted.svg</file>
@@ -523,6 +524,7 @@
         <file>themes/default/mIconRasterGroup.svg</file>
         <file>themes/default/mIconRasterLink.svg</file>
         <file>themes/default/mIconRasterLayer.svg</file>
+        <file>themes/default/mIconShadow.svg</file>
         <file>themes/default/mIconSelectAdd.svg</file>
         <file>themes/default/mIconSelected.svg</file>
         <file>themes/default/mIconSelectIntersect.svg</file>

--- a/images/themes/default/mIconCamera.svg
+++ b/images/themes/default/mIconCamera.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g stroke-linecap="round" stroke-linejoin="round">
+  <path d="m15.619 1.5002c-2.8639 0.00412-5.3081 2.1148-5.7864 4.9981-0.81844-1.3597-2.2692-2.1883-3.8322-2.1888-2.4855-1.352e-4 -4.5004 2.0573-4.5002 4.5952-9.373e-4 2.2916 1.6518 4.2336 3.8742 4.5522l0.21041 0.04313h10.226v-0.0057c3.1699-0.10297 5.6878-2.756 5.6891-5.9945-9.8e-5 -3.3136-2.6307-5.9998-5.8758-5.9998z" fill="#e6e6e6" stroke="#9a9a9a"/>
+  <path d="m3.5 14.5v3h2v3c-0.026027 2.0135-0.00738 2 2 2h8c1.9869-1.73e-4 2 0.0074 2-2v-1l4 3v-8l-4 3v-3z" fill="#141414" stroke="#2e2e2e"/>
+  <ellipse cx="15.641" cy="7.4558" rx="1.9686" ry="1.932" fill="#6d97c4" stroke="#415a75"/>
+  <ellipse cx="6" cy="9" rx="1.9686" ry="1.932" fill="#6d97c4" stroke="#415a75"/>
+ </g>
+</svg>

--- a/images/themes/default/mIconShadow.svg
+++ b/images/themes/default/mIconShadow.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs>
+  <radialGradient id="radialGradient869" cx="6.1089" cy="6.2365" r="6" gradientTransform="matrix(1.1139 1.0868 -1.0854 1.1124 6.3466 1.1526)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#ffebeb" offset="0"/>
+   <stop stop-color="#be0f0f" offset=".516"/>
+   <stop stop-color="#280000" offset="1"/>
+  </radialGradient>
+ </defs>
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g>
+  <ellipse transform="matrix(.10977 .99396 -.88858 .45873 0 0)" cx="19.588" cy="-12.501" rx="7.9704" ry="10.549"/>
+  <circle cx="8" cy="16" r="7" fill="url(#radialGradient869)" style="paint-order:stroke fill markers"/>
+ </g>
+</svg>

--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -255,7 +255,7 @@ void Qgs3DMapCanvasDockWidget::configure()
   QDialog dlg;
   dlg.setWindowTitle( tr( "3D Configuration" ) );
   dlg.setObjectName( QStringLiteral( "3DConfigurationDialog" ) );
-  dlg.setMinimumSize( 380, 460 );
+  dlg.setMinimumSize( 600, 460 );
   QgsGui::instance()->enableAutoGeometryRestore( &dlg );
 
   Qgs3DMapSettings *map = mCanvas->map();

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -54,6 +54,8 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
   m3DOptionsListWidget->setAttribute( Qt::WA_MacShowFocusRect, false );
   m3DOptionsListWidget->setCurrentRow( settings.value( QStringLiteral( "Windows/3DMapConfig/Tab" ), 0 ).toInt() );
 
+  connect( m3DOptionsListWidget, &QListWidget::currentRowChanged, this, [ = ]( int index ) { m3DOptionsStackedWidget->setCurrentIndex( index ); } );
+
   if ( !settings.contains( QStringLiteral( "Windows/3DMapConfig/OptionsSplitState" ) ) )
   {
     // set left list widget width on initial showing

--- a/src/app/3d/qgs3dmapconfigwidget.h
+++ b/src/app/3d/qgs3dmapconfigwidget.h
@@ -35,6 +35,8 @@ class Qgs3DMapConfigWidget : public QWidget, private Ui::Map3DConfigWidget
     //! construct widget. does not take ownership of the passed map.
     explicit Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas *mainCanvas, QWidget *parent = nullptr );
 
+    ~Qgs3DMapConfigWidget() override;
+
     void apply();
 
   signals:

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>555</width>
-    <height>675</height>
+    <width>593</width>
+    <height>623</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,23 +27,140 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QgsScrollArea" name="scrollArea">
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
+    <widget class="QSplitter" name="m3DOptionsSplitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
      </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>-98</y>
-        <width>541</width>
-        <height>782</height>
-       </rect>
+     <widget class="QFrame" name="m3DOptionsListFrame">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>1</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
       </property>
-      <layout class="QGridLayout" name="gridLayout_4">
+      <property name="minimumSize">
+       <size>
+        <width>32</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_23">
+       <property name="leftMargin">
+        <number>3</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QListWidget" name="m3DOptionsListWidget">
+         <property name="minimumSize">
+          <size>
+           <width>32</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="showDropIndicator" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>20</width>
+           <height>20</height>
+          </size>
+         </property>
+         <item>
+          <property name="text">
+           <string>Terrain</string>
+          </property>
+          <property name="toolTip">
+           <string>Terrain settings</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../images/images.qrc">
+            <normaloff>:/images/themes/default/mLayoutItem3DMap.svg</normaloff>:/images/themes/default/mLayoutItem3DMap.svg</iconset>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Lights</string>
+          </property>
+          <property name="toolTip">
+           <string>Lights settings</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionHighlightFeature.svg</normaloff>:/images/themes/default/mActionHighlightFeature.svg</iconset>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Shadow</string>
+          </property>
+          <property name="toolTip">
+           <string>Shadow settings</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../images/images.qrc">
+            <normaloff>:/images/themes/default/mIconShadow.svg</normaloff>:/images/themes/default/mIconShadow.svg</iconset>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Camera &amp; Skybox</string>
+          </property>
+          <property name="toolTip">
+           <string>Camera and skybox settings</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../images/images.qrc">
+            <normaloff>:/images/themes/default/mIconCamera.svg</normaloff>:/images/themes/default/mIconCamera.svg</iconset>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Advanced</string>
+          </property>
+          <property name="toolTip">
+           <string>Advanced settings</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../images/images.qrc">
+            <normaloff>:/images/themes/default/propertyicons/system.svg</normaloff>:/images/themes/default/propertyicons/system.svg</iconset>
+          </property>
+         </item>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QFrame" name="m3DOptionGroupsFrame">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>10</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -56,355 +173,613 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item row="0" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="cameraTerrain">
-         <property name="title">
-          <string>Camera</string>
+       <item>
+        <widget class="QStackedWidget" name="m3DOptionsStackedWidget">
+         <property name="currentIndex">
+          <number>0</number>
          </property>
-         <layout class="QGridLayout" name="gridLayout">
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Field of View</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1" colspan="2">
-           <widget class="QgsSpinBox" name="spinCameraFieldOfView">
-            <property name="suffix">
-             <string>°</string>
-            </property>
-            <property name="maximum">
-             <number>180</number>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="9" column="0">
-        <widget class="QCheckBox" name="chkShowLabels">
-         <property name="text">
-          <string>Show labels</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="groupShadowRendering">
-         <property name="title">
-          <string>Shadow rendering</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_6">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item row="0" column="0">
-           <layout class="QGridLayout" name="gridLayout_5"/>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="groupMeshTerrainShading">
-         <property name="title">
-          <string>Mesh Terrain Settings</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <property name="leftMargin">
-           <number>9</number>
-          </property>
-          <property name="topMargin">
-           <number>9</number>
-          </property>
-          <property name="rightMargin">
-           <number>9</number>
-          </property>
-          <property name="bottomMargin">
-           <number>9</number>
-          </property>
-         </layout>
-        </widget>
-       </item>
-       <item row="11" column="0">
-        <widget class="QCheckBox" name="chkShowBoundingBoxes">
-         <property name="text">
-          <string>Show bounding boxes</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="groupTerrainShading">
-         <property name="title">
-          <string>Terrain Shading</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QgsPhongMaterialWidget" name="widgetTerrainMaterial" native="true"/>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="12" column="0">
-        <widget class="QCheckBox" name="chkShowCameraViewCenter">
-         <property name="text">
-          <string>Show camera's view center</string>
-         </property>
-        </widget>
-       </item>
-       <item row="14" column="0">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="1" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="groupTerrain">
-         <property name="title">
-          <string>Terrain</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout1">
-          <item row="1" column="1" colspan="2">
-           <widget class="QgsMapLayerComboBox" name="cboTerrainLayer"/>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="labelTerrainLayer">
-            <property name="text">
-             <string>Elevation</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1" colspan="2">
-           <widget class="QComboBox" name="cboTerrainType"/>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="labelTerrainResolution">
-            <property name="text">
-             <string>Tile resolution</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1" colspan="2">
-           <widget class="QgsDoubleSpinBox" name="spinTerrainScale">
-            <property name="value">
-             <double>1.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="labelTerrainType">
-            <property name="text">
-             <string>Type</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1" colspan="2">
-           <widget class="QgsSpinBox" name="spinTerrainResolution">
-            <property name="suffix">
-             <string> px</string>
-            </property>
-            <property name="maximum">
-             <number>4096</number>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="labelTerrainScale">
-            <property name="text">
-             <string>Vertical scale</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="labelTerrainSkirtHeight">
-            <property name="text">
-             <string>Skirt height</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1" colspan="2">
-           <widget class="QgsDoubleSpinBox" name="spinTerrainSkirtHeight">
-            <property name="suffix">
-             <string> map units</string>
-            </property>
-            <property name="decimals">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <double>10000.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>10.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="8" column="0">
-        <layout class="QGridLayout" name="gridLayout_2">
-         <item row="1" column="1">
-          <widget class="QgsDoubleSpinBox" name="spinScreenError">
-           <property name="suffix">
-            <string> px</string>
-           </property>
-           <property name="decimals">
-            <number>1</number>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QgsSpinBox" name="spinMapResolution">
-           <property name="suffix">
-            <string> px</string>
-           </property>
-           <property name="maximum">
-            <number>4096</number>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QgsDoubleSpinBox" name="spinGroundError">
-           <property name="suffix">
-            <string> map units</string>
-           </property>
-           <property name="decimals">
-            <number>1</number>
-           </property>
-           <property name="minimum">
-            <double>0.100000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>1000.000000000000000</double>
-           </property>
-           <property name="value">
-            <double>1.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QLabel" name="labelZoomLevels">
-           <property name="text">
-            <string>0</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_5">
-           <property name="text">
-            <string>Max. screen error</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_4">
-           <property name="text">
-            <string>Map tile resolution</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="label_7">
-           <property name="text">
-            <string>Zoom levels</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="label_6">
-           <property name="text">
-            <string>Max. ground error</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="10" column="0">
-        <widget class="QCheckBox" name="chkShowTileInfo">
-         <property name="text">
-          <string>Show map tile info</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="groupLights">
-         <property name="title">
-          <string>Lights</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_3">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QgsLightsWidget" name="widgetLights" native="true"/>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="13" column="0">
-        <widget class="QCheckBox" name="chkShowLightSourceOrigins">
-         <property name="text">
-          <string>Show light sources</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="groupSkyboxSettings">
-         <property name="title">
-          <string>Skybox rendering</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_3"/>
+         <widget class="QWidget" name="mPageTerrain">
+          <layout class="QVBoxLayout" name="verticalLayout_6">
+           <item>
+            <widget class="QgsScrollArea" name="scrollAreaTerrain">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaTerrainWidgetContents">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>527</width>
+                <height>605</height>
+               </rect>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayoutTerrain">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QGroupBox" name="groupTerrain">
+                 <property name="title">
+                  <string>Terrain</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout1">
+                  <item row="1" column="1" colspan="2">
+                   <widget class="QgsMapLayerComboBox" name="cboTerrainLayer"/>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="labelTerrainLayer">
+                    <property name="text">
+                     <string>Elevation</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1" colspan="2">
+                   <widget class="QComboBox" name="cboTerrainType"/>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="labelTerrainResolution">
+                    <property name="text">
+                     <string>Tile resolution</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1" colspan="2">
+                   <widget class="QgsDoubleSpinBox" name="spinTerrainScale">
+                    <property name="value">
+                     <double>1.000000000000000</double>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="labelTerrainType">
+                    <property name="text">
+                     <string>Type</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="1" colspan="2">
+                   <widget class="QgsSpinBox" name="spinTerrainResolution">
+                    <property name="suffix">
+                     <string> px</string>
+                    </property>
+                    <property name="maximum">
+                     <number>4096</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="labelTerrainScale">
+                    <property name="text">
+                     <string>Vertical scale</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="0">
+                   <widget class="QLabel" name="labelTerrainSkirtHeight">
+                    <property name="text">
+                     <string>Skirt height</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="1" colspan="2">
+                   <widget class="QgsDoubleSpinBox" name="spinTerrainSkirtHeight">
+                    <property name="suffix">
+                     <string> map units</string>
+                    </property>
+                    <property name="decimals">
+                     <number>1</number>
+                    </property>
+                    <property name="maximum">
+                     <double>10000.000000000000000</double>
+                    </property>
+                    <property name="singleStep">
+                     <double>10.000000000000000</double>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupMeshTerrainShading">
+                 <property name="title">
+                  <string>Mesh Terrain Settings</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout">
+                  <property name="leftMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>9</number>
+                  </property>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QgsCollapsibleGroupBox" name="groupTerrainShading">
+                 <property name="title">
+                  <string>Terrain Shading</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_2">
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <widget class="QgsPhongMaterialWidget" name="widgetTerrainMaterial" native="true"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacerTerrain">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="mPageLight">
+          <layout class="QVBoxLayout" name="verticalLayout_6">
+           <item>
+            <widget class="QgsScrollArea" name="scrollAreaLight">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaLightWidgetContents">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>98</width>
+                <height>47</height>
+               </rect>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayoutLight">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QGroupBox" name="groupLights">
+                 <property name="title">
+                  <string>Lights</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_3">
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <widget class="QgsLightsWidget" name="widgetLights" native="true"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacerLights">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="mPageShadow">
+          <layout class="QVBoxLayout" name="verticalLayout_6">
+           <item>
+            <widget class="QgsScrollArea" name="scrollAreaShadow">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaShadowWidgetContents">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>174</width>
+                <height>47</height>
+               </rect>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayoutShadow">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QgsCollapsibleGroupBox" name="groupShadowRendering">
+                 <property name="title">
+                  <string>Shadow Rendering</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_6">
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item row="0" column="0">
+                   <layout class="QGridLayout" name="gridLayout_5"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacerShadow">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="mPageCameraSkybox">
+          <layout class="QVBoxLayout" name="verticalLayout_6">
+           <item>
+            <widget class="QgsScrollArea" name="scrollAreaCameraSkybox">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaCameraSkyboxWidgetContents">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>173</width>
+                <height>132</height>
+               </rect>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayoutCameraSkybox">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QGroupBox" name="cameraTerrain">
+                 <property name="title">
+                  <string>Camera</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout">
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_3">
+                    <property name="text">
+                     <string>Field of View</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1" colspan="2">
+                   <widget class="QgsSpinBox" name="spinCameraFieldOfView">
+                    <property name="suffix">
+                     <string>°</string>
+                    </property>
+                    <property name="maximum">
+                     <number>180</number>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QgsCollapsibleGroupBox" name="groupSkyboxSettings">
+                 <property name="title">
+                  <string>Skybox Rendering</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_3"/>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacerCameraSkybox">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="mPageAdvanced">
+          <layout class="QVBoxLayout" name="verticalLayout_6">
+           <item>
+            <widget class="QgsScrollArea" name="scrollAreaAdvanced">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaAdvancedWidgetContents">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>302</width>
+                <height>330</height>
+               </rect>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayoutAdvanced">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QGroupBox" name="groupAdvanced">
+                 <property name="title">
+                  <string>Advanced Settings</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_3">
+                  <item>
+                   <layout class="QGridLayout" name="gridLayoutAdvanced">
+                    <item row="4" column="0" colspan="2">
+                     <widget class="QCheckBox" name="chkShowLabels">
+                      <property name="text">
+                       <string>Show labels</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="6" column="0" colspan="2">
+                     <widget class="QCheckBox" name="chkShowBoundingBoxes">
+                      <property name="text">
+                       <string>Show bounding boxes</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="7" column="0" colspan="2">
+                     <widget class="QCheckBox" name="chkShowCameraViewCenter">
+                      <property name="text">
+                       <string>Show camera's view center</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="1">
+                     <widget class="QgsDoubleSpinBox" name="spinScreenError">
+                      <property name="suffix">
+                       <string> px</string>
+                      </property>
+                      <property name="decimals">
+                       <number>1</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="1">
+                     <widget class="QgsSpinBox" name="spinMapResolution">
+                      <property name="suffix">
+                       <string> px</string>
+                      </property>
+                      <property name="maximum">
+                       <number>4096</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="1">
+                     <widget class="QgsDoubleSpinBox" name="spinGroundError">
+                      <property name="suffix">
+                       <string> map units</string>
+                      </property>
+                      <property name="decimals">
+                       <number>1</number>
+                      </property>
+                      <property name="minimum">
+                       <double>0.100000000000000</double>
+                      </property>
+                      <property name="maximum">
+                       <double>1000.000000000000000</double>
+                      </property>
+                      <property name="value">
+                       <double>1.000000000000000</double>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="3" column="1">
+                     <widget class="QLabel" name="labelZoomLevels">
+                      <property name="text">
+                       <string>0</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="0">
+                     <widget class="QLabel" name="label_5">
+                      <property name="text">
+                       <string>Max. screen error</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="0">
+                     <widget class="QLabel" name="label_4">
+                      <property name="text">
+                       <string>Map tile resolution</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="3" column="0">
+                     <widget class="QLabel" name="label_7">
+                      <property name="text">
+                       <string>Zoom levels</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="0">
+                     <widget class="QLabel" name="label_6">
+                      <property name="text">
+                       <string>Max. ground error</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="5" column="0" colspan="2">
+                     <widget class="QCheckBox" name="chkShowTileInfo">
+                      <property name="text">
+                       <string>Show map tile info</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="8" column="0" colspan="2">
+                     <widget class="QCheckBox" name="chkShowLightSourceOrigins">
+                      <property name="text">
+                       <string>Show light sources</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacerAdvanced">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>
@@ -455,7 +830,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>scrollArea</tabstop>
   <tabstop>spinCameraFieldOfView</tabstop>
   <tabstop>cboTerrainType</tabstop>
   <tabstop>cboTerrainLayer</tabstop>
@@ -473,6 +847,25 @@
   <tabstop>chkShowCameraViewCenter</tabstop>
   <tabstop>chkShowLightSourceOrigins</tabstop>
  </tabstops>
- <resources/>
- <connections/>
+ <resources>
+  <include location="../../../images/images.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>m3DOptionsListWidget</sender>
+   <signal>currentRowChanged(int)</signal>
+   <receiver>m3DOptionsStackedWidget</receiver>
+   <slot>setCurrentIndex(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>34</x>
+     <y>599</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>633</x>
+     <y>411</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -850,22 +850,4 @@
  <resources>
   <include location="../../../images/images.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>m3DOptionsListWidget</sender>
-   <signal>currentRowChanged(int)</signal>
-   <receiver>m3DOptionsStackedWidget</receiver>
-   <slot>setCurrentIndex(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>34</x>
-     <y>599</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>633</x>
-     <y>411</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
 </ui>


### PR DESCRIPTION
## Description

A GIF worth a thousand words:
![Peek 2020-10-18 16-00](https://user-images.githubusercontent.com/1728657/96362955-4ad37400-115b-11eb-8b13-65d39a373a71.gif)

This PR revamps the 3D map configuration dialog to match the look and behavior of other parts of QGIS (labeling, diagrams). Over the years, the dialog has become an endless collection of widgets which the user has to scroll through, expand/collapse to reach. It was a nightmare which IMHO needed addressing prior to our upcoming 3.16 LTR.

The dialog now regroups widgets within themed panels. When reopening the dialog, the last selected panel is remembered (makes tweaking lights sooo  much easier).

