### PR TITLE
[OGR provider] Check return value of commitTransaction() in addFeatures() and deleteFeatures(); call rollback when an error was detected before

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.h
+++ b/src/core/providers/ogr/qgsogrprovider.h
@@ -211,6 +211,9 @@ class QgsOgrProvider final: public QgsVectorDataProvider
     //! Commits a transaction
     bool commitTransaction();
 
+    //! Rolls back a transaction
+    bool rollbackTransaction();
+
     //! Does the real job of settings the subset string and adds an argument to disable update capabilities
     bool _setSubsetString( const QString &theSQL, bool updateFeatureCount = true, bool updateCapabilities = true, bool hasExistingRef = true );
 


### PR DESCRIPTION
Calling rollback() didn't seem to be strictly needed, but makes more sense than calling commit() when we know that something wrong happened.