### PR TITLE
More 3d config dialog tweaks

### DIFF
--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -265,6 +265,11 @@ void Qgs3DMapCanvasDockWidget::configure()
   connect( buttons, &QDialogButtonBox::rejected, &dlg, &QDialog::reject );
   connect( buttons, &QDialogButtonBox::helpRequested, w, []() { QgsHelp::openHelp( QStringLiteral( "introduction/qgis_gui.html#scene-configuration" ) ); } );
 
+  connect( w, &Qgs3DMapConfigWidget::isValidChanged, this, [ = ]( bool valid )
+  {
+    buttons->button( QDialogButtonBox::Ok )->setEnabled( valid );
+  } );
+
   QVBoxLayout *layout = new QVBoxLayout( &dlg );
   layout->addWidget( w, 1 );
   layout->addWidget( buttons );

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -53,8 +53,8 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
   // get rid of annoying outer focus rect on Mac
   m3DOptionsListWidget->setAttribute( Qt::WA_MacShowFocusRect, false );
   m3DOptionsListWidget->setCurrentRow( settings.value( QStringLiteral( "Windows/3DMapConfig/Tab" ), 0 ).toInt() );
-
   connect( m3DOptionsListWidget, &QListWidget::currentRowChanged, this, [ = ]( int index ) { m3DOptionsStackedWidget->setCurrentIndex( index ); } );
+  m3DOptionsStackedWidget->setCurrentIndex( m3DOptionsListWidget->currentRow() );
 
   if ( !settings.contains( QStringLiteral( "Windows/3DMapConfig/OptionsSplitState" ) ) )
   {

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -311,6 +311,7 @@ void Qgs3DMapConfigWidget::onTerrainTypeChanged()
     onTerrainLayerChanged();
 
   updateMaxZoomLevel();
+  validate();
 }
 
 void Qgs3DMapConfigWidget::onTerrainLayerChanged()
@@ -329,6 +330,7 @@ void Qgs3DMapConfigWidget::onTerrainLayerChanged()
         mMeshSymbolWidget->reloadColorRampShaderMinMax();
     }
   }
+  validate();
 }
 
 void Qgs3DMapConfigWidget::updateMaxZoomLevel()
@@ -361,5 +363,36 @@ void Qgs3DMapConfigWidget::updateMaxZoomLevel()
   double tile0width = std::max( te.width(), te.height() );
   int zoomLevel = Qgs3DUtils::maxZoomLevel( tile0width, spinMapResolution->value(), spinGroundError->value() );
   labelZoomLevels->setText( QStringLiteral( "0 - %1" ).arg( zoomLevel ) );
+}
+
+void Qgs3DMapConfigWidget::validate()
+{
+  mMessageBar->clearWidgets();
+
+  bool valid = true;
+  switch ( static_cast<QgsTerrainGenerator::Type>( cboTerrainType->currentData().toInt() ) )
+  {
+    case QgsTerrainGenerator::Dem:
+      if ( ! cboTerrainLayer->currentLayer() )
+      {
+        valid = false;
+        mMessageBar->pushMessage( tr( "An elevation layer must be selected for a DEM terrain" ), Qgis::Warning, 0 );
+      }
+      break;
+
+    case QgsTerrainGenerator::Mesh:
+      if ( ! cboTerrainLayer->currentLayer() )
+      {
+        valid = false;
+        mMessageBar->pushMessage( tr( "An elevation layer must be selected for a mesh terrain" ), Qgis::Warning, 0 );
+      }
+      break;
+
+    case QgsTerrainGenerator::Online:
+    case QgsTerrainGenerator::Flat:
+      break;
+  }
+
+  emit isValidChanged( valid );
 }
 

--- a/src/app/3d/qgs3dmapconfigwidget.h
+++ b/src/app/3d/qgs3dmapconfigwidget.h
@@ -41,10 +41,14 @@ class Qgs3DMapConfigWidget : public QWidget, private Ui::Map3DConfigWidget
 
   signals:
 
+    void isValidChanged( bool valid );
+
   private slots:
     void onTerrainTypeChanged();
     void onTerrainLayerChanged();
     void updateMaxZoomLevel();
+
+    void validate();
 
   private:
     Qgs3DMapSettings *mMap = nullptr;

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>593</width>
-    <height>623</height>
+    <width>775</width>
+    <height>620</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -179,7 +179,7 @@
           <number>0</number>
          </property>
          <widget class="QWidget" name="mPageTerrain">
-	  <layout class="QVBoxLayout" name="verticalLayout_61">
+          <layout class="QVBoxLayout" name="verticalLayout_61">
            <item>
             <widget class="QgsScrollArea" name="scrollAreaTerrain">
              <property name="frameShape">
@@ -294,22 +294,19 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupMeshTerrainShading">
-                 <property name="title">
-                  <string>Mesh Terrain Settings</string>
-                 </property>
+                <widget class="QFrame" name="groupMeshTerrainShading">
                  <layout class="QVBoxLayout" name="verticalLayout">
                   <property name="leftMargin">
-                   <number>9</number>
+                   <number>0</number>
                   </property>
                   <property name="topMargin">
-                   <number>9</number>
+                   <number>0</number>
                   </property>
                   <property name="rightMargin">
-                   <number>9</number>
+                   <number>0</number>
                   </property>
                   <property name="bottomMargin">
-                   <number>9</number>
+                   <number>0</number>
                   </property>
                  </layout>
                 </widget>
@@ -361,7 +358,7 @@
           </layout>
          </widget>
          <widget class="QWidget" name="mPageLight">
-	  <layout class="QVBoxLayout" name="verticalLayout_64">
+          <layout class="QVBoxLayout" name="verticalLayout_64">
            <item>
             <widget class="QgsScrollArea" name="scrollAreaLight">
              <property name="frameShape">
@@ -375,7 +372,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>98</width>
+                <width>71</width>
                 <height>47</height>
                </rect>
               </property>
@@ -397,7 +394,7 @@
                  <property name="title">
                   <string>Lights</string>
                  </property>
-		 <layout class="QVBoxLayout" name="verticalLayout_31">
+                 <layout class="QVBoxLayout" name="verticalLayout_31">
                   <property name="leftMargin">
                    <number>0</number>
                   </property>
@@ -450,7 +447,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>174</width>
+                <width>177</width>
                 <height>47</height>
                </rect>
               </property>
@@ -517,7 +514,7 @@
           </layout>
          </widget>
          <widget class="QWidget" name="mPageCameraSkybox">
-	  <layout class="QVBoxLayout" name="verticalLayout_62">
+          <layout class="QVBoxLayout" name="verticalLayout_62">
            <item>
             <widget class="QgsScrollArea" name="scrollAreaCameraSkybox">
              <property name="frameShape">
@@ -531,7 +528,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>173</width>
+                <width>175</width>
                 <height>132</height>
                </rect>
               </property>
@@ -608,7 +605,7 @@
           </layout>
          </widget>
          <widget class="QWidget" name="mPageAdvanced">
-	  <layout class="QVBoxLayout" name="verticalLayout_63">
+          <layout class="QVBoxLayout" name="verticalLayout_63">
            <item>
             <widget class="QgsScrollArea" name="scrollAreaAdvanced">
              <property name="frameShape">
@@ -622,7 +619,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>302</width>
+                <width>304</width>
                 <height>330</height>
                </rect>
               </property>
@@ -644,7 +641,7 @@
                  <property name="title">
                   <string>Advanced Settings</string>
                  </property>
-		 <layout class="QVBoxLayout" name="verticalLayout_32">
+                 <layout class="QVBoxLayout" name="verticalLayout_32">
                   <item>
                    <layout class="QGridLayout" name="gridLayoutAdvanced">
                     <item row="4" column="0" colspan="2">
@@ -790,10 +787,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsScrollArea</class>
@@ -802,9 +798,10 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsPhongMaterialWidget</class>
@@ -850,4 +847,5 @@
  <resources>
   <include location="../../../images/images.qrc"/>
  </resources>
+ <connections/>
 </ui>

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -180,6 +180,15 @@
          </property>
          <widget class="QWidget" name="mPageTerrain">
           <layout class="QVBoxLayout" name="verticalLayout_61">
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
            <item>
             <widget class="QgsScrollArea" name="scrollAreaTerrain">
              <property name="frameShape">
@@ -193,8 +202,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>527</width>
-                <height>605</height>
+                <width>705</width>
+                <height>620</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutTerrain">
@@ -359,6 +368,15 @@
          </widget>
          <widget class="QWidget" name="mPageLight">
           <layout class="QVBoxLayout" name="verticalLayout_64">
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
            <item>
             <widget class="QgsScrollArea" name="scrollAreaLight">
              <property name="frameShape">
@@ -372,8 +390,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>71</width>
-                <height>47</height>
+                <width>705</width>
+                <height>620</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutLight">
@@ -434,6 +452,15 @@
          </widget>
          <widget class="QWidget" name="mPageShadow">
           <layout class="QVBoxLayout" name="verticalLayout_6">
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
            <item>
             <widget class="QgsScrollArea" name="scrollAreaShadow">
              <property name="frameShape">
@@ -447,8 +474,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>177</width>
-                <height>47</height>
+                <width>705</width>
+                <height>620</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutShadow">
@@ -515,6 +542,15 @@
          </widget>
          <widget class="QWidget" name="mPageCameraSkybox">
           <layout class="QVBoxLayout" name="verticalLayout_62">
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
            <item>
             <widget class="QgsScrollArea" name="scrollAreaCameraSkybox">
              <property name="frameShape">
@@ -528,8 +564,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>175</width>
-                <height>132</height>
+                <width>705</width>
+                <height>620</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutCameraSkybox">
@@ -606,6 +642,15 @@
          </widget>
          <widget class="QWidget" name="mPageAdvanced">
           <layout class="QVBoxLayout" name="verticalLayout_63">
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
            <item>
             <widget class="QgsScrollArea" name="scrollAreaAdvanced">
              <property name="frameShape">
@@ -619,8 +664,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>304</width>
-                <height>330</height>
+                <width>705</width>
+                <height>620</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutAdvanced">

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Configure 3D Map Rendering</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_4">
+  <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,1">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -26,6 +26,9 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
+   <item>
+    <widget class="QgsMessageBar" name="mMessageBar" native="true"/>
+   </item>
    <item>
     <widget class="QSplitter" name="m3DOptionsSplitter">
      <property name="orientation">
@@ -203,7 +206,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>705</width>
-                <height>620</height>
+                <height>604</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutTerrain">
@@ -843,12 +846,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsPhongMaterialWidget</class>
    <extends>QWidget</extends>
    <header>qgsphongmaterialwidget.h</header>
@@ -868,6 +865,12 @@
    <class>QgsLightsWidget</class>
    <extends>QWidget</extends>
    <header>qgslightswidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMessageBar</class>
+   <extends>QWidget</extends>
+   <header>qgsmessagebar.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -321,7 +321,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QgsCollapsibleGroupBox" name="groupTerrainShading">
+                <widget class="QGroupBox" name="groupTerrainShading">
                  <property name="title">
                   <string>Terrain Shading</string>
                  </property>
@@ -492,7 +492,7 @@
                 <number>0</number>
                </property>
                <item>
-                <widget class="QgsCollapsibleGroupBox" name="groupShadowRendering">
+                <widget class="QGroupBox" name="groupShadowRendering">
                  <property name="title">
                   <string>Show Shadows</string>
                  </property>
@@ -608,7 +608,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QgsCollapsibleGroupBox" name="groupSkyboxSettings">
+                <widget class="QGroupBox" name="groupSkyboxSettings">
                  <property name="title">
                   <string>Show Skybox</string>
                  </property>

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -494,7 +494,7 @@
                <item>
                 <widget class="QgsCollapsibleGroupBox" name="groupShadowRendering">
                  <property name="title">
-                  <string>Shadow Rendering</string>
+                  <string>Show Shadows</string>
                  </property>
                  <property name="checkable">
                   <bool>true</bool>
@@ -610,7 +610,7 @@
                <item>
                 <widget class="QgsCollapsibleGroupBox" name="groupSkyboxSettings">
                  <property name="title">
-                  <string>Skybox Rendering</string>
+                  <string>Show Skybox</string>
                  </property>
                  <property name="checkable">
                   <bool>true</bool>


### PR DESCRIPTION
Notably this includes a fix for the paper cut encountered by @timlinux where a terrain could be set to Mesh or DEM without requiring the user to actually select a layer, resulting in a broken terrain for the map:

![image](https://user-images.githubusercontent.com/1829991/96389784-a7cf3880-11f4-11eb-9322-bad8b091d1de.png)
