### PR TITLE
Update user groups symbology to use radial gradient with centroid as base point

### DIFF
--- a/resources/data/user_groups.qml
+++ b/resources/data/user_groups.qml
@@ -1,79 +1,79 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="3.15.0-Master" styleCategories="Symbology|MapTips">
-  <renderer-v2 type="RuleRenderer" symbollevels="0" forceraster="0" enableorderby="0">
+<qgis styleCategories="Symbology|MapTips" version="3.15.0-Master">
+  <renderer-v2 type="RuleRenderer" symbollevels="0" enableorderby="0" forceraster="0">
     <rules key="{7c035b8b-7431-4fee-87be-6dc156a20233}">
-      <rule symbol="0" filter="ug_name is not NULL" key="{49603121-7528-4de3-885b-45a422234c3b}" label="User group"/>
-      <rule symbol="1" filter="ELSE" key="{b7e9bc39-65ae-47ca-af82-6a3d3b0c49be}" label="No user group"/>
+      <rule filter="ug_name is not NULL" label="User group" key="{49603121-7528-4de3-885b-45a422234c3b}" symbol="0"/>
+      <rule filter="ELSE" label="No user group" key="{b7e9bc39-65ae-47ca-af82-6a3d3b0c49be}" symbol="1"/>
     </rules>
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="fill" name="0" force_rhr="0">
-        <layer locked="0" pass="0" enabled="1" class="GradientFill">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="145,175,35,255"/>
-          <prop k="color1" v="247,252,245,255"/>
-          <prop k="color2" v="0,68,27,255"/>
-          <prop k="color_type" v="0"/>
-          <prop k="coordinate_mode" v="0"/>
-          <prop k="discrete" v="0"/>
-          <prop k="gradient_color2" v="93,152,48,255"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="rampType" v="gradient"/>
-          <prop k="reference_point1" v="0.5,0"/>
-          <prop k="reference_point1_iscentroid" v="0"/>
-          <prop k="reference_point2" v="0.5,1"/>
-          <prop k="reference_point2_iscentroid" v="0"/>
-          <prop k="spread" v="0"/>
-          <prop k="stops" v="0.13;229,245,224,255:0.26;199,233,192,255:0.39;161,217,155,255:0.52;116,196,118,255:0.65;65,171,93,255:0.78;35,139,69,255:0.9;0,109,44,255"/>
-          <prop k="type" v="0"/>
+      <symbol type="fill" name="0" alpha="1" clip_to_extent="1" force_rhr="0">
+        <layer class="GradientFill" pass="0" enabled="1" locked="0">
+          <prop v="0" k="angle"/>
+          <prop v="145,175,35,255" k="color"/>
+          <prop v="247,252,245,255" k="color1"/>
+          <prop v="0,68,27,255" k="color2"/>
+          <prop v="0" k="color_type"/>
+          <prop v="0" k="coordinate_mode"/>
+          <prop v="0" k="discrete"/>
+          <prop v="93,152,48,255" k="gradient_color2"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="gradient" k="rampType"/>
+          <prop v="0,0" k="reference_point1"/>
+          <prop v="1" k="reference_point1_iscentroid"/>
+          <prop v="1,1" k="reference_point2"/>
+          <prop v="0" k="reference_point2_iscentroid"/>
+          <prop v="0" k="spread"/>
+          <prop v="0.13;229,245,224,255:0.26;199,233,192,255:0.39;161,217,155,255:0.52;116,196,118,255:0.65;65,171,93,255:0.78;35,139,69,255:0.9;0,109,44,255" k="stops"/>
+          <prop v="1" k="type"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" pass="0" enabled="1" class="SimpleFill">
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="77,175,74,255"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="56,128,54,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.26"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="no"/>
+        <layer class="SimpleFill" pass="0" enabled="1" locked="0">
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="77,175,74,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="56,128,54,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="no" k="style"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" type="fill" name="1" force_rhr="0">
-        <layer locked="0" pass="0" enabled="1" class="SimpleFill">
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="224,220,202,154"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="119,116,104,154"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.26"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="solid"/>
+      <symbol type="fill" name="1" alpha="1" clip_to_extent="1" force_rhr="0">
+        <layer class="SimpleFill" pass="0" enabled="1" locked="0">
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="224,220,202,154" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="119,116,104,154" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>


### PR DESCRIPTION
Followup https://github.com/qgis/QGIS/pull/38505

I initially added the linear gradient to mimic the QGIS logo style, but it looks much better the radial gradient using centroids. See the before/after:

Before:
![user_groups_linear](https://user-images.githubusercontent.com/652785/96390291-9563e900-1179-11eb-9144-f1c5405dbb61.png)

After:
![user_groups_radial](https://user-images.githubusercontent.com/652785/96390292-96951600-1179-11eb-895a-dec4e0562a0e.png)



(Suggested by @zacharlie)