### PR TITLE
Revert "DB manager: PG read enum value for sslmode"

### DIFF
--- a/python/plugins/db_manager/db_plugins/postgis/plugin.py
+++ b/python/plugins/db_manager/db_plugins/postgis/plugin.py
@@ -84,7 +84,7 @@ class PostGisDBPlugin(DBPlugin):
 
         useEstimatedMetadata = settings.value("estimatedMetadata", False, type=bool)
         try:
-            sslmode = settings.enumValue("sslmode", QgsDataSourceUri.SslPrefer)
+            sslmode = settings.value("sslmode", QgsDataSourceUri.SslPrefer, type=int)
         except TypeError:
             sslmode = QgsDataSourceUri.SslPrefer
 


### PR DESCRIPTION
This reverts commit 26e9ec98e76591286576d2dde098578877bef9c0.

It results in unfixable crashes on many platforms, likely due to some issue in sip itself. We can't ship 3.16 in this state!! :laughing: 

Fixes #38393, reopens #38245

The original bug (being asked twice for credentials) is preferable over a hard crash
