### PR TITLE
[themes] Fix missing background fill for user input widgets 

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -1040,3 +1040,7 @@ QWidget#QgsRendererMeshPropsWidgetBase QTabWidget#mStyleOptionsTab QTabBar::tab 
 QWidget#QgsRasterCalcDialogBase QWidget#mOperatorsGroupBox QPushButton {
     min-width:2.3em;
 }
+
+QFrame#mUserInputContainer { 
+    background-color: @background;
+}

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -869,6 +869,7 @@ QTreeView#viewGraduated::indicator:unchecked,
 QTreeView#viewCategories::indicator:unchecked,
 QTreeView#viewRules::indicator:unchecked 
 {
+    border: none;
     image: url(@theme_path/icons/eye-blocked.svg);
 }
 
@@ -877,6 +878,7 @@ QTreeView#viewGraduated::indicator:checked,
 QTreeView#viewCategories::indicator:checked, 
 QTreeView#viewRules::indicator:checked 
 {
+    border: none;
     image: url(@theme_path/icons/eye.svg);
 }
 

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -1077,3 +1077,7 @@ QWidget#QgsRendererMeshPropsWidgetBase QTabWidget#mStyleOptionsTab QTabBar::tab 
 QWidget#QgsRasterCalcDialogBase QWidget#mOperatorsGroupBox QPushButton {
     min-width:2.3em;
 }
+
+QFrame#mUserInputContainer { 
+    background-color: @background;
+}

--- a/src/gui/qgsuserinputwidget.cpp
+++ b/src/gui/qgsuserinputwidget.cpp
@@ -23,6 +23,7 @@ QgsUserInputWidget::QgsUserInputWidget( QWidget *parent )
   //TODO add title tr( "User Input Panel" )
 
   QFrame *f = new QFrame();
+  f->setObjectName( QStringLiteral( "mUserInputContainer" ) );
 
   QPalette pal = palette();
   pal.setBrush( backgroundRole(), pal.window() );


### PR DESCRIPTION
## Description

Using non default themes, our user input widgets overlayed over the map canvas were missing a background. This PR fixes that (as well as a tiny night mapping regression with custom layer tree indicator)

![image](https://user-images.githubusercontent.com/1728657/96397673-2ecfe100-11f4-11eb-96b7-78a85142a676.png)
