### PR TITLE
[ui] Fix mesh terrain single color / ramp settings out of sync

### DIFF
--- a/src/app/3d/qgsmesh3dsymbolwidget.cpp
+++ b/src/app/3d/qgsmesh3dsymbolwidget.cpp
@@ -27,6 +27,7 @@ QgsMesh3dSymbolWidget::QgsMesh3dSymbolWidget( QgsMeshLayer *meshLayer, QWidget *
   setupUi( this );
 
   mComboBoxTextureType->addItem( tr( "Single Color" ), QgsMesh3DSymbol::SingleColor );
+  mComboBoxTextureType->setCurrentIndex( 0 );
 
   mDatasetGroupListModel = new QgsMeshDatasetGroupListModel( this );
   mComboBoxDatasetVertical->setModel( mDatasetGroupListModel );


### PR DESCRIPTION
## Description

This fixes an out of sync scenario whereas the user selects mesh as terrain type, and gets to see rendering type set to single color yet the color ramp-related widgets aren't hidden.
