### PR TITLE
Fix QGIS/rpm

### DIFF
--- a/rpm/default.cfg
+++ b/rpm/default.cfg
@@ -12,7 +12,6 @@ OUTDIR="result"
 ARCHS=(
         "fedora-31-x86_64"
         "fedora-32-x86_64"
-        "fedora-33-x86_64"
       )
 
 # Which git branch to export. Normally take the current

--- a/rpm/default.cfg
+++ b/rpm/default.cfg
@@ -10,12 +10,12 @@ OUTDIR="result"
 
 # Which arches to build for. Check /etc/mock for possible options
 ARCHS=(
-        "fedora-28-i386"
-        "fedora-28-x86_64"
-        "fedora-29-i386"
-        "fedora-29-x86_64"
-        "fedora-30-i386"
-        "fedora-30-x86_64"
+        "fedora-31-i386"
+        "fedora-31-x86_64"
+        "fedora-32-i386"
+        "fedora-32-x86_64"
+        "fedora-33-i386"
+        "fedora-33-x86_64"
       )
 
 # Which git branch to export. Normally take the current

--- a/rpm/default.cfg
+++ b/rpm/default.cfg
@@ -10,11 +10,8 @@ OUTDIR="result"
 
 # Which arches to build for. Check /etc/mock for possible options
 ARCHS=(
-        "fedora-31-i386"
         "fedora-31-x86_64"
-        "fedora-32-i386"
         "fedora-32-x86_64"
-        "fedora-33-i386"
         "fedora-33-x86_64"
       )
 

--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -276,34 +276,6 @@ rm -f %{buildroot}%{_datadir}/%{name}/doc/INSTALL*
 
 %find_lang %{name} --with-qt
 
-# TODO: Remove all %%post, %%posttrans and %%postun after F28 EoL
-# Ref: https://fedoraproject.org/wiki/Changes/RemoveObsoleteScriptlets
-%post
-/sbin/ldconfig
-touch --no-create %{_datadir}/icons/hicolor &>/dev/null || :
-touch --no-create %{_datadir}/mime/packages &> /dev/null || :
-
-%postun
-/sbin/ldconfig
-if [ $1 -eq 0 ] ; then
-    touch --no-create %{_datadir}/icons/hicolor &>/dev/null
-    gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
-    touch --no-create %{_datadir}/mime/packages &> /dev/null || :
-    update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
-fi
-
-%posttrans
-gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
-update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
-
-%post grass -p /sbin/ldconfig
-
-%postun grass -p /sbin/ldconfig
-
-%post -n python3-qgis -p /sbin/ldconfig
-
-%postun -n python3-qgis -p /sbin/ldconfig
-
 %files -f %{name}.lang
 %doc BUGS NEWS.md Exception_to_GPL_for_Qt.txt ChangeLog.gz
 # QGIS shows the following files in the GUI, including the license text


### PR DESCRIPTION
Update the content of rpm/ so it works on modern fedoras.

* update default version to buidl using mock.
* remove 32bit builds as these will go away.
* cleanup spec file from cruft related to pre 28 versions of Fedora. 
