### PR TITLE
Correctly expose metadata tab for mesh layers

### DIFF
--- a/python/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
+++ b/python/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
@@ -38,6 +38,8 @@ Adds properties page from a factory
 .. versionadded:: 3.16
 %End
 
+  protected slots:
+
 };
 
 

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -116,18 +116,11 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
                        mOptStackedWidget->indexOf( mOptsPage_Style ) );
   }
 
-  QString title = tr( "Layer Properties — %1" ).arg( lyr->name() );
-
-  if ( !mMeshLayer->styleManager()->isDefault( mMeshLayer->styleManager()->currentStyle() ) )
-    title += QStringLiteral( " (%1)" ).arg( mMeshLayer->styleManager()->currentStyle() );
-  restoreOptionsBaseUi( title );
-
   //Add help page references
   mOptsPage_Information->setProperty( "helpPage", QStringLiteral( "working_with_mesh/mesh_properties.html#information-properties" ) );
   mOptsPage_Source->setProperty( "helpPage", QStringLiteral( "working_with_mesh/mesh_properties.html#source-properties" ) );
   mOptsPage_Style->setProperty( "helpPage", QStringLiteral( "working_with_mesh/mesh_properties.html#symbology-properties" ) );
   mOptsPage_Rendering->setProperty( "helpPage", QStringLiteral( "working_with_mesh/mesh_properties.html#rendering-properties" ) );
-
 
   mBtnStyle = new QPushButton( tr( "Style" ) );
   QMenu *menuStyle = new QMenu( this );
@@ -147,6 +140,12 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), this, &QgsMeshLayerProperties::saveMetadataAs );
   mBtnMetadata->setMenu( menuMetadata );
   buttonBox->addButton( mBtnMetadata, QDialogButtonBox::ResetRole );
+
+  QString title = tr( "Layer Properties — %1" ).arg( lyr->name() );
+
+  if ( !mMeshLayer->styleManager()->isDefault( mMeshLayer->styleManager()->currentStyle() ) )
+    title += QStringLiteral( " (%1)" ).arg( mMeshLayer->styleManager()->currentStyle() );
+  restoreOptionsBaseUi( title );
 }
 
 void QgsMeshLayerProperties::addPropertiesPageFactory( QgsMapLayerConfigWidgetFactory *factory )

--- a/src/gui/mesh/qgsmeshlayerproperties.h
+++ b/src/gui/mesh/qgsmeshlayerproperties.h
@@ -32,6 +32,7 @@ class QgsMapLayerConfigWidget;
 class QgsMeshLayer3DRendererWidget;
 class QgsMeshStaticDatasetWidget;
 class QgsMapLayerConfigWidgetFactory;
+class QgsMetadataWidget;
 
 /**
  * Property sheet for a mesh map layer.
@@ -57,6 +58,9 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
      * \since QGIS 3.16
      */
     void addPropertiesPageFactory( QgsMapLayerConfigWidgetFactory *factory );
+
+  protected slots:
+    void optionsStackedWidget_CurrentChanged( int index ) override SIP_SKIP ;
 
   private slots:
     //! Synchronizes widgets state with associated mesh layer
@@ -88,6 +92,8 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
     void onStaticDatasetCheckBoxChanged();
 
     void urlClicked( const QUrl &url );
+    void loadMetadata();
+    void saveMetadataAs();
 
   private:
     //! Pointer to the mesh styling widget
@@ -107,7 +113,13 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
     */
     QgsMapLayerStyle mOldStyle;
 
-    QgsMapCanvas *mCanvas;
+    QPushButton *mBtnStyle = nullptr;
+    QPushButton *mBtnMetadata = nullptr;
+    QAction *mActionLoadMetadata = nullptr;
+    QAction *mActionSaveMetadataAs = nullptr;
+
+    QgsMapCanvas *mCanvas = nullptr;
+    QgsMetadataWidget *mMetadataWidget = nullptr;
 
     bool mIsMapSettingsTemporal = false;
 

--- a/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
+++ b/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
@@ -102,6 +102,9 @@
           <property name="text">
            <string>Information</string>
           </property>
+          <property name="toolTip">
+           <string>Information</string>
+          </property>
           <property name="icon">
            <iconset resource="../../../images/images.qrc">
             <normaloff>:/images/themes/default/propertyicons/metadata.svg</normaloff>:/images/themes/default/propertyicons/metadata.svg</iconset>
@@ -109,6 +112,9 @@
          </item>
          <item>
           <property name="text">
+           <string>Source</string>
+          </property>
+          <property name="toolTip">
            <string>Source</string>
           </property>
           <property name="icon">
@@ -132,6 +138,9 @@
           <property name="text">
            <string>Rendering</string>
           </property>
+          <property name="toolTip">
+           <string>Rendering</string>
+          </property>
           <property name="icon">
            <iconset resource="../../../images/images.qrc">
             <normaloff>:/images/themes/default/propertyicons/rendering.svg</normaloff>:/images/themes/default/propertyicons/rendering.svg</iconset>
@@ -147,6 +156,18 @@
           <property name="icon">
            <iconset resource="../../../images/images.qrc">
             <normaloff>:/images/themes/default/propertyicons/temporal.svg</normaloff>:/images/themes/default/propertyicons/temporal.svg</iconset>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Metadata</string>
+          </property>
+          <property name="toolTip">
+           <string>Metadata</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../images/images.qrc">
+            <normaloff>:/images/themes/default/propertyicons/editmetadata.svg</normaloff>:/images/themes/default/propertyicons/editmetadata.svg</iconset>
           </property>
          </item>
         </widget>
@@ -239,8 +260,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>661</width>
-                <height>506</height>
+                <width>470</width>
+                <height>383</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -452,8 +473,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>661</width>
-                <height>506</height>
+                <width>100</width>
+                <height>30</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -745,6 +766,32 @@ border-radius: 2px;</string>
               </size>
              </property>
             </spacer>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="mOptsPage_Metadata">
+          <layout class="QVBoxLayout" name="verticalLayout_8">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QFrame" name="metadataFrame">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Raised</enum>
+             </property>
+            </widget>
            </item>
           </layout>
          </widget>


### PR DESCRIPTION
Just like all other map layer types, meshes CAN have metadata set, so expose this via a metadata tab in their layer properties window just like any other layer type.

Ultimately this is about making mesh layers appear as "first class citizens" in QGIS, and not inferior to vector/raster in any way :laughing: 
