### PR TITLE
Avoid (offline)-suffix in offlineediting

### DIFF
--- a/python/core/auto_generated/qgsofflineediting.sip.in
+++ b/python/core/auto_generated/qgsofflineediting.sip.in
@@ -36,7 +36,7 @@ class QgsOfflineEditing : QObject
 
     QgsOfflineEditing();
 
-    bool convertToOfflineProject( const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected = false, ContainerType containerType = SpatiaLite );
+    bool convertToOfflineProject( const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected = false, ContainerType containerType = SpatiaLite, const QString &layerNameSuffix = QStringLiteral( " (offline)" ) );
 %Docstring
 Convert current project for offline editing
 
@@ -45,6 +45,7 @@ Convert current project for offline editing
 :param layerIds: List of layer names to convert
 :param onlySelected: Only copy selected features from layers where a selection is present
 :param containerType: defines the SQLite file container type like SpatiaLite or GPKG
+:param layerNameSuffix: Suffix string added to the offline layer name
 %End
 
     bool isOfflineProject() const;

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -61,6 +61,7 @@ extern "C"
 #define CUSTOM_PROPERTY_REMOTE_PROVIDER "remoteProvider"
 #define CUSTOM_SHOW_FEATURE_COUNT "showFeatureCount"
 #define CUSTOM_PROPERTY_ORIGINAL_LAYERID "remoteLayerId"
+#define CUSTOM_PROPERTY_LAYERNAME_SUFFIX "layerNameSuffix"
 #define PROJECT_ENTRY_SCOPE_OFFLINE "OfflineEditingPlugin"
 #define PROJECT_ENTRY_KEY_OFFLINE_DB_PATH "/OfflineDbPath"
 
@@ -85,7 +86,7 @@ QgsOfflineEditing::QgsOfflineEditing()
  * - remove remote layers
  * - mark as offline project
  */
-bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected, ContainerType containerType )
+bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected, ContainerType containerType, const QString &layerNameSuffix )
 {
   if ( layerIds.isEmpty() )
   {
@@ -150,7 +151,7 @@ bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath,
         if ( vl )
         {
           QString origLayerId = vl->id();
-          QgsVectorLayer *newLayer = copyVectorLayer( vl, database.get(), dbPath, onlySelected, containerType );
+          QgsVectorLayer *newLayer = copyVectorLayer( vl, database.get(), dbPath, onlySelected, containerType, layerNameSuffix );
           if ( newLayer )
           {
             layerIdMapping.insert( origLayerId, newLayer );
@@ -249,7 +250,8 @@ void QgsOfflineEditing::synchronize()
     QString remoteSource = layer->customProperty( CUSTOM_PROPERTY_REMOTE_SOURCE, "" ).toString();
     QString remoteProvider = layer->customProperty( CUSTOM_PROPERTY_REMOTE_PROVIDER, "" ).toString();
     QString remoteName = layer->name();
-    remoteName.remove( QRegExp( " \\(offline\\)$" ) );
+    QString remoteNameSuffix = layer->customProperty( CUSTOM_PROPERTY_LAYERNAME_SUFFIX, " (offline)" ).toString();
+    remoteName.remove( remoteNameSuffix );
     const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
     QgsVectorLayer *remoteLayer = new QgsVectorLayer( remoteSource, remoteName, remoteProvider, options );
     if ( remoteLayer->isValid() )
@@ -539,7 +541,7 @@ void QgsOfflineEditing::createLoggingTables( sqlite3 *db )
   */
 }
 
-QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath, bool onlySelected, ContainerType containerType )
+QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath, bool onlySelected, ContainerType containerType, const QString &layerNameSuffix )
 {
   if ( !layer )
     return nullptr;
@@ -664,7 +666,7 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
                                        tableName, layer->isSpatial() ? "(Geometry)" : "" );
       QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
       newLayer = new QgsVectorLayer( connectionString,
-                                     layer->name() + " (offline)", QStringLiteral( "spatialite" ), options );
+                                     layer->name() + layerNameSuffix, QStringLiteral( "spatialite" ), options );
       break;
     }
     case GPKG:
@@ -673,7 +675,7 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
       char **options = nullptr;
 
       options = CSLSetNameValue( options, "OVERWRITE", "YES" );
-      options = CSLSetNameValue( options, "IDENTIFIER", tr( "%1 (offline)" ).arg( layer->id() ).toUtf8().constData() );
+      options = CSLSetNameValue( options, "IDENTIFIER", layer->id().toUtf8().constData() );
       options = CSLSetNameValue( options, "DESCRIPTION", layer->dataComment().toUtf8().constData() );
 
       //the FID-name should not exist in the original data
@@ -768,7 +770,7 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
 
       QString uri = QStringLiteral( "%1|layername=%2" ).arg( offlineDbPath,  tableName );
       QgsVectorLayer::LayerOptions layerOptions { QgsProject::instance()->transformContext() };
-      newLayer = new QgsVectorLayer( uri, layer->name() + " (offline)", QStringLiteral( "ogr" ), layerOptions );
+      newLayer = new QgsVectorLayer( uri, layer->name() + layerNameSuffix, QStringLiteral( "ogr" ), layerOptions );
       break;
     }
   }
@@ -871,6 +873,7 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
     newLayer->setCustomProperty( CUSTOM_PROPERTY_REMOTE_SOURCE, layer->source() );
     newLayer->setCustomProperty( CUSTOM_PROPERTY_REMOTE_PROVIDER, layer->providerType() );
     newLayer->setCustomProperty( CUSTOM_PROPERTY_ORIGINAL_LAYERID, layer->id() );
+    newLayer->setCustomProperty( CUSTOM_PROPERTY_LAYERNAME_SUFFIX, layerNameSuffix );
 
     // register this layer with the central layers registry
     QgsProject::instance()->addMapLayers(

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -251,7 +251,8 @@ void QgsOfflineEditing::synchronize()
     QString remoteProvider = layer->customProperty( CUSTOM_PROPERTY_REMOTE_PROVIDER, "" ).toString();
     QString remoteName = layer->name();
     QString remoteNameSuffix = layer->customProperty( CUSTOM_PROPERTY_LAYERNAME_SUFFIX, " (offline)" ).toString();
-    remoteName.remove( remoteNameSuffix );
+    if ( remoteName.endsWith( remoteNameSuffix ) )
+      remoteName.chop( remoteNameSuffix.size() );
     const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
     QgsVectorLayer *remoteLayer = new QgsVectorLayer( remoteSource, remoteName, remoteProvider, options );
     if ( remoteLayer->isValid() )

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -675,7 +675,7 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
       char **options = nullptr;
 
       options = CSLSetNameValue( options, "OVERWRITE", "YES" );
-      options = CSLSetNameValue( options, "IDENTIFIER", layer->id().toUtf8().constData() );
+      options = CSLSetNameValue( options, "IDENTIFIER", tr( "%1 (offline)" ).arg( layer->id() ).toUtf8().constData() );
       options = CSLSetNameValue( options, "DESCRIPTION", layer->dataComment().toUtf8().constData() );
 
       //the FID-name should not exist in the original data

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -64,8 +64,9 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
      * \param layerIds List of layer names to convert
      * \param onlySelected Only copy selected features from layers where a selection is present
      * \param containerType defines the SQLite file container type like SpatiaLite or GPKG
+     * \param layerNameSuffix Suffix string added to the offline layer name
      */
-    bool convertToOfflineProject( const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected = false, ContainerType containerType = SpatiaLite );
+    bool convertToOfflineProject( const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected = false, ContainerType containerType = SpatiaLite, const QString &layerNameSuffix = QStringLiteral( " (offline)" ) );
 
     //! Returns TRUE if current project is offline
     bool isOfflineProject() const;
@@ -117,7 +118,7 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
     bool createOfflineDb( const QString &offlineDbPath, ContainerType containerType = SpatiaLite );
     void createLoggingTables( sqlite3 *db );
 
-    QgsVectorLayer *copyVectorLayer( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath, bool onlySelected, ContainerType containerType = SpatiaLite );
+    QgsVectorLayer *copyVectorLayer( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath, bool onlySelected, ContainerType containerType = SpatiaLite, const QString &layerNameSuffix = QStringLiteral( " (offline)" ) );
 
     void applyAttributesAdded( QgsVectorLayer *remoteLayer, sqlite3 *db, int layerId, int commitNo );
     void applyFeaturesAdded( QgsVectorLayer *offlineLayer, QgsVectorLayer *remoteLayer, sqlite3 *db, int layerId );

--- a/src/plugins/offline_editing/offline_editing_plugin.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin.cpp
@@ -104,7 +104,7 @@ void QgsOfflineEditingPlugin::convertProject()
     }
 
     mProgressDialog->setTitle( tr( "Converting to Offline Project" ) );
-    if ( mOfflineEditing->convertToOfflineProject( myPluginGui->offlineDataPath(), myPluginGui->offlineDbFile(), selectedLayerIds, myPluginGui->onlySelected(), myPluginGui->dbContainerType() ) )
+    if ( mOfflineEditing->convertToOfflineProject( myPluginGui->offlineDataPath(), myPluginGui->offlineDbFile(), selectedLayerIds, myPluginGui->onlySelected(), myPluginGui->dbContainerType(), QStringLiteral( "" ) ) )
     {
       updateActions();
       // Redraw, to make the offline layer visible

--- a/src/plugins/offline_editing/offline_editing_plugin.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin.cpp
@@ -104,7 +104,7 @@ void QgsOfflineEditingPlugin::convertProject()
     }
 
     mProgressDialog->setTitle( tr( "Converting to Offline Project" ) );
-    if ( mOfflineEditing->convertToOfflineProject( myPluginGui->offlineDataPath(), myPluginGui->offlineDbFile(), selectedLayerIds, myPluginGui->onlySelected(), myPluginGui->dbContainerType(), QStringLiteral( "" ) ) )
+    if ( mOfflineEditing->convertToOfflineProject( myPluginGui->offlineDataPath(), myPluginGui->offlineDbFile(), selectedLayerIds, myPluginGui->onlySelected(), myPluginGui->dbContainerType(), QString() ) )
     {
       updateActions();
       // Redraw, to make the offline layer visible

--- a/tests/src/core/testqgsofflineediting.cpp
+++ b/tests/src/core/testqgsofflineediting.cpp
@@ -52,6 +52,9 @@ class TestQgsOfflineEditing : public QObject
     void init(); // will be called before each testfunction is executed.
     void cleanup(); // will be called after every testfunction.
 
+    void createSpatialiteAndSynchronizeBack_data();
+    void createGeopackageAndSynchronizeBack_data();
+
     void createSpatialiteAndSynchronizeBack();
     void createGeopackageAndSynchronizeBack();
     void removeConstraintsOnDefaultValues();
@@ -113,8 +116,32 @@ void TestQgsOfflineEditing::cleanup()
   dir.remove( offlineDbFile );
 }
 
+void TestQgsOfflineEditing::createSpatialiteAndSynchronizeBack_data()
+{
+  QTest::addColumn<QString>( "suffix_input" );
+  QTest::addColumn<QString>( "suffix_result" );
+
+  QTest::newRow( "no suffix" ) << QString() << QStringLiteral( " (offline)" );
+  QTest::newRow( "empty suffix" ) << QStringLiteral( "" ) << QStringLiteral( "" );
+  QTest::newRow( "another suffix" ) << QStringLiteral( "another suffix" ) << QStringLiteral( "another suffix" );
+}
+
+void TestQgsOfflineEditing::createGeopackageAndSynchronizeBack_data()
+{
+  QTest::addColumn<QString>( "suffix_input" );
+  QTest::addColumn<QString>( "suffix_result" );
+
+  QTest::newRow( "no suffix" ) << QString() << QStringLiteral( " (offline)" );
+  QTest::newRow( "empty suffix" ) << QStringLiteral( "" ) << QStringLiteral( "" );
+  QTest::newRow( "another suffix" ) << QStringLiteral( "another suffix" ) << QStringLiteral( "another suffix" );
+}
+
 void TestQgsOfflineEditing::createSpatialiteAndSynchronizeBack()
 {
+
+  QFETCH( QString, suffix_input );
+  QFETCH( QString, suffix_result );
+
   offlineDbFile = "TestQgsOfflineEditing.sqlite";
   QCOMPARE( mpLayer->name(), QStringLiteral( "points" ) );
   QCOMPARE( mpLayer->featureCount(), numberOfFeatures );
@@ -125,10 +152,16 @@ void TestQgsOfflineEditing::createSpatialiteAndSynchronizeBack()
   layerTreelayer->setCustomProperty( QStringLiteral( "showFeatureCount" ), 1 );
 
   //convert
-  mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, QgsOfflineEditing::SpatiaLite );
 
-  mpLayer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayersByName( QStringLiteral( "points (offline)" ) ).first() );
-  QCOMPARE( mpLayer->name(), QStringLiteral( "points (offline)" ) );
+  if ( suffix_input.isNull() )
+    mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, QgsOfflineEditing::SpatiaLite );
+  else
+    mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, QgsOfflineEditing::SpatiaLite, suffix_input );
+
+  QString layerName = QStringLiteral( "points%1" ).arg( suffix_result );
+
+  mpLayer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayersByName( layerName ).first() );
+  QCOMPARE( mpLayer->name(), layerName );
   QCOMPARE( mpLayer->featureCount(), numberOfFeatures );
   //check LayerTreeNode showFeatureCount property
   layerTreelayer = QgsProject::instance()->layerTreeRoot()->findLayer( mpLayer->id() );
@@ -151,6 +184,9 @@ void TestQgsOfflineEditing::createSpatialiteAndSynchronizeBack()
 
 void TestQgsOfflineEditing::createGeopackageAndSynchronizeBack()
 {
+  QFETCH( QString, suffix_input );
+  QFETCH( QString, suffix_result );
+
   offlineDbFile = "TestQgsOfflineEditing.gpkg";
   QCOMPARE( mpLayer->name(), QStringLiteral( "points" ) );
   QCOMPARE( mpLayer->featureCount(), numberOfFeatures );
@@ -171,10 +207,14 @@ void TestQgsOfflineEditing::createGeopackageAndSynchronizeBack()
   mpLayer->styleManager()->addStyle( QStringLiteral( "testStyle" ), style );
 
   //convert
-  mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, QgsOfflineEditing::GPKG );
+  if ( suffix_input.isNull() )
+    mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, QgsOfflineEditing::GPKG );
+  else
+    mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, QgsOfflineEditing::GPKG, suffix_input );
 
-  mpLayer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayersByName( QStringLiteral( "points (offline)" ) ).first() );
-  QCOMPARE( mpLayer->name(), QStringLiteral( "points (offline)" ) );
+  QString layerName = QStringLiteral( "points%1" ).arg( suffix_result );
+  mpLayer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayersByName( layerName ).first() );
+  QCOMPARE( mpLayer->name(), layerName );
   QCOMPARE( mpLayer->featureCount(), numberOfFeatures );
   //comparing with the number +1 because GPKG created an fid
   QCOMPARE( mpLayer->fields().size(), numberOfFields + 1 );
@@ -231,7 +271,6 @@ void TestQgsOfflineEditing::createGeopackageAndSynchronizeBack()
   mpLayer->dataProvider()->deleteFeatures( idsToClean );
   QCOMPARE( mpLayer->dataProvider()->featureCount(), numberOfFeatures );
 }
-
 
 void TestQgsOfflineEditing::removeConstraintsOnDefaultValues()
 {

--- a/tests/src/core/testqgsofflineediting.cpp
+++ b/tests/src/core/testqgsofflineediting.cpp
@@ -121,9 +121,10 @@ void TestQgsOfflineEditing::createSpatialiteAndSynchronizeBack_data()
   QTest::addColumn<QString>( "suffix_input" );
   QTest::addColumn<QString>( "suffix_result" );
 
-  QTest::newRow( "no suffix" ) << QString( "no suffix" ) << QStringLiteral( " (offline)" );
+  QTest::newRow( "no suffix" ) << QString( "no suffix" ) << QStringLiteral( " (offline)" ); //default value expected
   QTest::newRow( "null suffix" ) << QString() << QString();
   QTest::newRow( "empty suffix" ) << QStringLiteral( "" ) << QStringLiteral( "" );
+  QTest::newRow( "part of name suffix" ) << QStringLiteral( "point" ) << QStringLiteral( "point" );
   QTest::newRow( "another suffix" ) << QStringLiteral( "another suffix" ) << QStringLiteral( "another suffix" );
 }
 
@@ -132,9 +133,10 @@ void TestQgsOfflineEditing::createGeopackageAndSynchronizeBack_data()
   QTest::addColumn<QString>( "suffix_input" );
   QTest::addColumn<QString>( "suffix_result" );
 
-  QTest::newRow( "no suffix" ) << QStringLiteral( "no suffix" ) << QStringLiteral( " (offline)" );
+  QTest::newRow( "no suffix" ) << QStringLiteral( "no suffix" ) << QStringLiteral( " (offline)" ); //default value expected
   QTest::newRow( "null suffix" ) << QString() << QString();
   QTest::newRow( "empty suffix" ) << QStringLiteral( "" ) << QStringLiteral( "" );
+  QTest::newRow( "part of name suffix" ) << QStringLiteral( "point" ) << QStringLiteral( "point" );
   QTest::newRow( "another suffix" ) << QStringLiteral( "another suffix" ) << QStringLiteral( "another suffix" );
 }
 

--- a/tests/src/core/testqgsofflineediting.cpp
+++ b/tests/src/core/testqgsofflineediting.cpp
@@ -121,7 +121,8 @@ void TestQgsOfflineEditing::createSpatialiteAndSynchronizeBack_data()
   QTest::addColumn<QString>( "suffix_input" );
   QTest::addColumn<QString>( "suffix_result" );
 
-  QTest::newRow( "no suffix" ) << QString() << QStringLiteral( " (offline)" );
+  QTest::newRow( "no suffix" ) << QString( "no suffix" ) << QStringLiteral( " (offline)" );
+  QTest::newRow( "null suffix" ) << QString() << QString();
   QTest::newRow( "empty suffix" ) << QStringLiteral( "" ) << QStringLiteral( "" );
   QTest::newRow( "another suffix" ) << QStringLiteral( "another suffix" ) << QStringLiteral( "another suffix" );
 }
@@ -131,7 +132,8 @@ void TestQgsOfflineEditing::createGeopackageAndSynchronizeBack_data()
   QTest::addColumn<QString>( "suffix_input" );
   QTest::addColumn<QString>( "suffix_result" );
 
-  QTest::newRow( "no suffix" ) << QString() << QStringLiteral( " (offline)" );
+  QTest::newRow( "no suffix" ) << QStringLiteral( "no suffix" ) << QStringLiteral( " (offline)" );
+  QTest::newRow( "null suffix" ) << QString() << QString();
   QTest::newRow( "empty suffix" ) << QStringLiteral( "" ) << QStringLiteral( "" );
   QTest::newRow( "another suffix" ) << QStringLiteral( "another suffix" ) << QStringLiteral( "another suffix" );
 }
@@ -152,8 +154,7 @@ void TestQgsOfflineEditing::createSpatialiteAndSynchronizeBack()
   layerTreelayer->setCustomProperty( QStringLiteral( "showFeatureCount" ), 1 );
 
   //convert
-
-  if ( suffix_input.isNull() )
+  if ( suffix_input.compare( QStringLiteral( "no suffix" ) ) == 0 )
     mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, QgsOfflineEditing::SpatiaLite );
   else
     mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, QgsOfflineEditing::SpatiaLite, suffix_input );
@@ -207,7 +208,7 @@ void TestQgsOfflineEditing::createGeopackageAndSynchronizeBack()
   mpLayer->styleManager()->addStyle( QStringLiteral( "testStyle" ), style );
 
   //convert
-  if ( suffix_input.isNull() )
+  if ( suffix_input.compare( QStringLiteral( "no suffix" ) ) == 0 )
     mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, QgsOfflineEditing::GPKG );
   else
     mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, QgsOfflineEditing::GPKG, suffix_input );


### PR DESCRIPTION
Fixes broken widgets and expressions in offline layers.

Offline layers created by offlineediting core (and with this by the offline editing plugin and QFieldSync) used to get the static suffix " (offline)".
This leaded to broken value relation widgets and broken expressions (using the layername).

The introduced suffix parameter in `convertToOfflineProject` allows to pass no suffix, and with this the layer names are unchanged in the offline project. 
This is what offline editing plugin does with this PR and QFieldSync will do it with the upcoming release as well.

Still the suffix parameter is by default " (offline)", what means that it will remain the same behavior for any other plugins using `convertToOfflineProject`. On `synchronize` it reads the suffix from a `customProperty` of the layer. If there is no such `customProperty` it's " (offline)" by default. This means, if the offline project has been created before this change and is synchronized back after this change, it will still work. So it's completely backwards compatible.

An indicator on the layer tree to visualize if it's an offline layer will follow up in another PR.