### PR TITLE
Substitute vertex parameters with more meaningful names

### DIFF
--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -382,8 +382,7 @@ bool QgsGeometry::isMultipart() const
   }
   return QgsWkbTypes::isMultiType( d->geometry->wkbType() );
 }
-
-QgsPointXY QgsGeometry::closestVertex( const QgsPointXY &point, int &atVertex, int &beforeVertex, int &afterVertex, double &sqrDist ) const
+QgsPointXY QgsGeometry::closestVertex( const QgsPointXY &point, int &closestVertexIndex, int &previousVertexIndex, int &nextVertexIndex, double &sqrDist ) const
 {
   if ( !d->geometry )
   {
@@ -405,9 +404,9 @@ QgsPointXY QgsGeometry::closestVertex( const QgsPointXY &point, int &atVertex, i
   QgsVertexId prevVertex;
   QgsVertexId nextVertex;
   d->geometry->adjacentVertices( id, prevVertex, nextVertex );
-  atVertex = vertexNrFromVertexId( id );
-  beforeVertex = vertexNrFromVertexId( prevVertex );
-  afterVertex = vertexNrFromVertexId( nextVertex );
+  closestVertexIndex = vertexNrFromVertexId( id );
+  previousVertexIndex = vertexNrFromVertexId( prevVertex );
+  nextVertexIndex = vertexNrFromVertexId( nextVertex );
   return QgsPointXY( vp.x(), vp.y() );
 }
 
@@ -655,8 +654,8 @@ double QgsGeometry::closestVertexWithContext( const QgsPointXY &point, int &atVe
 
 double QgsGeometry::closestSegmentWithContext( const QgsPointXY &point,
     QgsPointXY &minDistPoint,
-    int &afterVertex,
-    int *leftOf,
+    int &nextVertexIndex,
+    int *leftOrRightOfSegment,
     double epsilon ) const
 {
   if ( !d->geometry )
@@ -667,13 +666,13 @@ double QgsGeometry::closestSegmentWithContext( const QgsPointXY &point,
   QgsPoint segmentPt;
   QgsVertexId vertexAfter;
 
-  double sqrDist = d->geometry->closestSegment( QgsPoint( point ), segmentPt,  vertexAfter, leftOf, epsilon );
+  double sqrDist = d->geometry->closestSegment( QgsPoint( point ), segmentPt,  vertexAfter, leftOrRightOfSegment, epsilon );
   if ( sqrDist < 0 )
     return -1;
 
   minDistPoint.setX( segmentPt.x() );
   minDistPoint.setY( segmentPt.y() );
-  afterVertex = vertexNrFromVertexId( vertexAfter );
+  nextVertexIndex = vertexNrFromVertexId( vertexAfter );
   return sqrDist;
 }
 
@@ -2503,11 +2502,6 @@ QVector<QgsPointXY> QgsGeometry::randomPointsInPolygon( int count, unsigned long
   return QgsInternalGeometryEngine::randomPointsInPolygon( *this, count, []( const QgsPointXY & ) { return true; }, seed, feedback, 0 );
 }
 ///@endcond
-
-int QgsGeometry::wkbSize( QgsAbstractGeometry::WkbFlags flags ) const
-{
-  return d->geometry ? d->geometry->wkbSize( flags ) : 0;
-}
 
 QByteArray QgsGeometry::asWkb( QgsAbstractGeometry::WkbFlags flags ) const
 {

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -624,21 +624,19 @@ class CORE_EXPORT QgsGeometry
      */
     double hausdorffDistanceDensify( const QgsGeometry &geom, double densifyFraction ) const;
 
-    //TODO QGIS 4.0 - rename beforeVertex to previousVertex, afterVertex to nextVertex
-
     /**
      * Returns the vertex closest to the given point, the corresponding vertex index, squared distance snap point / target point
      * and the indices of the vertices before and after the closest vertex.
      * \param point point to search for
-     * \param atVertex will be set to the vertex index of the closest found vertex
-     * \param beforeVertex will be set to the vertex index of the previous vertex from the closest one. Will be set to -1 if
+     * \param closestVertexIndex will be set to the vertex index of the closest found vertex
+     * \param previousVertexIndex will be set to the vertex index of the previous vertex from the closest one. Will be set to -1 if
      * not present.
-     * \param afterVertex will be set to the vertex index of the next vertex after the closest one. Will be set to -1 if
+     * \param nextVertexIndex will be set to the vertex index of the next vertex after the closest one. Will be set to -1 if
      * not present.
      * \param sqrDist will be set to the square distance between the closest vertex and the specified point
      * \returns closest point in geometry. If not found (empty geometry), returns null point and sqrDist is negative.
      */
-    QgsPointXY closestVertex( const QgsPointXY &point, int &atVertex SIP_OUT, int &beforeVertex SIP_OUT, int &afterVertex SIP_OUT, double &sqrDist SIP_OUT ) const;
+    QgsPointXY closestVertex( const QgsPointXY &point, int &closestVertexIndex SIP_OUT, int &previousVertexIndex SIP_OUT, int &nextVertexIndex SIP_OUT, double &sqrDist SIP_OUT ) const;
 
     /**
      * Returns the distance along this geometry from its first vertex to the specified vertex.
@@ -747,7 +745,7 @@ class CORE_EXPORT QgsGeometry
     double sqrDistToVertexAt( QgsPointXY &point SIP_IN, int atVertex ) const;
 
     /**
-     * Returns the nearest point on this geometry to another geometry.
+     * Returns the nearest (closest) point on this geometry to another geometry.
      * \see shortestLine()
      * \since QGIS 2.14
      */
@@ -777,14 +775,14 @@ class CORE_EXPORT QgsGeometry
      * Searches for the closest segment of geometry to the given point
      * \param point Specifies the point for search
      * \param minDistPoint Receives the nearest point on the segment
-     * \param afterVertex Receives index of the vertex after the closest segment. The vertex
-     * before the closest segment is always afterVertex - 1
-     * \param leftOf Out: Returns if the point lies on the left of left side of the geometry ( < 0 means left, > 0 means right, 0 indicates
+     * \param nextVertexIndex Receives index of the next vertex after the closest segment. The vertex
+     * before the closest segment is always nextVertexIndex - 1
+     * \param leftOrRightOfSegment Out: Returns if the point is located on the left or right side of the geometry ( < 0 means left, > 0 means right, 0 indicates
      * that the test was unsuccessful, e.g. for a point exactly on the line)
      * \param epsilon epsilon for segment snapping
      * \returns The squared Cartesian distance is also returned in sqrDist, negative number on error
      */
-    double closestSegmentWithContext( const QgsPointXY &point, QgsPointXY &minDistPoint SIP_OUT, int &afterVertex SIP_OUT, int *leftOf SIP_OUT = nullptr, double epsilon = DEFAULT_SEGMENT_EPSILON ) const;
+    double closestSegmentWithContext( const QgsPointXY &point, QgsPointXY &minDistPoint SIP_OUT, int &nextVertexIndex SIP_OUT, int *leftOrRightOfSegment SIP_OUT = nullptr, double epsilon = DEFAULT_SEGMENT_EPSILON ) const;
 
     /**
      * Adds a new ring to this geometry. This makes only sense for polygon and multipolygons.
@@ -1582,15 +1580,6 @@ class CORE_EXPORT QgsGeometry
 
 #endif
 ///@endcond
-
-    /**
-     * Returns the length of the QByteArray returned by asWkb()
-     *
-     * The optional \a flags argument specifies flags controlling WKB export behavior
-     *
-     * \since QGIS 3.16
-     */
-    int wkbSize( QgsAbstractGeometry::WkbFlags flags = QgsAbstractGeometry::WkbFlags() ) const;
 
     /**
      * Export the geometry to WKB


### PR DESCRIPTION
## Description

This PR suggests a change of variable names and documentation comments in order to achieve a more intuitive documentation in python by more meaningful variable names. This PR is a follow up to #39266

The following variable names were changed:

In **QgsGeometry::closestVertex**
atVertex -> closestVertexIndex
beforeVertex -> previousVertexIndex
afterVertex -> nextVertexIndex

In **QgsGeometry::closestSegmentWithContext**
afterVertex -> nextVertexIndex
leftOf -> leftOrRightOfSegment


<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
