### PR TITLE
Add temporalFrameDurationChanged signal, and make view more aware of …

### DIFF
--- a/python/core/auto_generated/qgstemporalnavigationobject.sip.in
+++ b/python/core/auto_generated/qgstemporalnavigationobject.sip.in
@@ -208,6 +208,12 @@ Emitted whenever the navigation ``mode`` changes.
 Emitted whenever the temporalExtent ``extent`` changes.
 %End
 
+    void temporalFrameDurationChanged( const QgsInterval &interval );
+%Docstring
+Emitted whenever the frameDuration ``interval`` of the controller changes.
+%End
+
+
   public slots:
 
     void play();

--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -178,8 +178,16 @@ long long QgsTemporalNavigationObject::currentFrameNumber() const
 
 void QgsTemporalNavigationObject::setFrameDuration( QgsInterval frameDuration )
 {
+  if ( mFrameDuration == frameDuration )
+  {
+    return;
+  }
   mFrameDuration = frameDuration;
+  emit temporalFrameDurationChanged( mFrameDuration );
   setCurrentFrameNumber( 0 );
+  // forcing an update of our views
+  QgsDateTimeRange range = dateTimeRangeForFrameNumber( mCurrentFrameNumber );
+  emit updateTemporalRange( range );
 }
 
 QgsInterval QgsTemporalNavigationObject::frameDuration() const

--- a/src/core/qgstemporalnavigationobject.h
+++ b/src/core/qgstemporalnavigationobject.h
@@ -222,6 +222,12 @@ class CORE_EXPORT QgsTemporalNavigationObject : public QgsTemporalController, pu
      */
     void temporalExtentsChanged( const QgsDateTimeRange &extent );
 
+    /**
+     * Emitted whenever the frameDuration \a interval of the controller changes.
+     */
+    void temporalFrameDurationChanged( const QgsInterval &interval );
+
+
   public slots:
 
     /**

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -53,6 +53,7 @@ QgsTemporalControllerWidget::QgsTemporalControllerWidget( QWidget *parent )
   setWidgetStateFromNavigationMode( mNavigationObject->navigationMode() );
   connect( mNavigationObject, &QgsTemporalNavigationObject::navigationModeChanged, this, &QgsTemporalControllerWidget::setWidgetStateFromNavigationMode );
   connect( mNavigationObject, &QgsTemporalNavigationObject::temporalExtentsChanged, this, &QgsTemporalControllerWidget::setDates );
+  connect( mNavigationObject, &QgsTemporalNavigationObject::temporalFrameDurationChanged, this, &QgsTemporalControllerWidget::setTimeStep );
   connect( mNavigationOff, &QPushButton::clicked, this, &QgsTemporalControllerWidget::mNavigationOff_clicked );
   connect( mNavigationFixedRange, &QPushButton::clicked, this, &QgsTemporalControllerWidget::mNavigationFixedRange_clicked );
   connect( mNavigationAnimated, &QPushButton::clicked, this, &QgsTemporalControllerWidget::mNavigationAnimated_clicked );

--- a/src/gui/qgstemporalcontrollerwidget.h
+++ b/src/gui/qgstemporalcontrollerwidget.h
@@ -90,7 +90,10 @@ class GUI_EXPORT QgsTemporalControllerWidget : public QgsPanelWidget, private Ui
     QgsMapLayerModel *mMapLayerModel = nullptr;
 
     void firstTemporalLayerLoaded( QgsMapLayer *layer );
-    void setTimeStep( const QgsInterval &timeStep );
+    void setTimeStep( const QgsInterval &timeStep, bool blocking = false );
+    void setTimeStepWithBlocking( const QgsInterval &timeStep );
+    QMap<double, int> prepareTimeStepValues( const QgsInterval &timeStep );
+    void saveTimeStepToProject();
 
   private slots:
 

--- a/tests/src/core/testqgstemporalnavigationobject.cpp
+++ b/tests/src/core/testqgstemporalnavigationobject.cpp
@@ -203,7 +203,7 @@ void TestQgsTemporalNavigationObject::frameSettings()
 
   navigationObject->setCurrentFrameNumber( 1 );
   QCOMPARE( navigationObject->currentFrameNumber(), 1 );
-  QCOMPARE( temporalRangeSignal.count(), 2 );
+  QCOMPARE( temporalRangeSignal.count(), 3 );
 
   navigationObject->setFramesPerSecond( 1 );
   QCOMPARE( navigationObject->framesPerSecond(), 1.0 );


### PR DESCRIPTION
This commit adds a new signal to the QgsTemporalNavigationObject, which is
emitted when the frameDuration (of current QgsTemporalNavigationObject) is
changed.

It also fixes the issue that changing the frame in the Temporal
Navigation-WIDGET itself was not reflected in the widget itself. To see this, change the 'Step' spinbox in the widget and see that now the Frame-text (next to the little buttons in the top) is also changing.

![Screenshot-20201020112923-717x119](https://user-images.githubusercontent.com/731673/96567932-a9b5fc00-12c7-11eb-8a80-89443861f447.png)

I was a little puzzled about which signals to emit where. I even thought that this new signal was not needed at all because to me it looks like the 'updateTemporalRange( range )' signal is actually more or less used as 'modelChanged' signal?
But to be honest I always loose my way in the needed granularity of signals in model/view models...

Anyway: I really hope this will still make it in QGIS 3.16 as:
- it fixes gui glitches (like changing the Step not reflected in Frame: text
- it makes it truly possible now to register and actually use the temporal controller stuff in PyQGIS/Plugins

Sorry for being late :-(

Some example PyQGIS code I use to test it (and which I am planning to add to the cookbook after cleaning up...)
Note that this holds some old stuff:

```
l=iface.mapCanvas().currentLayer()
p=l.temporalProperties()
p.setMode(QgsVectorLayerTemporalProperties.ModeFeatureDateTimeInstantFromField)
# QgsVectorLayerTemporalProperties::setStartField( const QString &startFieldName )
#p.setStartField('t_start') # 6dots
p.setStartField('Time')   # view3
# void QgsVectorLayerTemporalProperties::setDurationUnits( QgsUnitTypes::TemporalUnit units )
# QgsUnitTypes.TemporalUnit.TemporalSeconds
p.setDurationUnits(QgsUnitTypes.TemporalUnit.TemporalSeconds)
p.setFixedDuration(1800)  # setting the LAYERS event duration
p.setIsActive(True) # OK
#p.changed.emit() # does not update the Layer Panel

# to update the legend (the temporal indicator) !!
node=QgsProject.instance().layerTreeRoot().findLayer(l) # find QgsLayerTreeLayer in QgsLayerTree
iface.layerTreeView().model().refreshLayerLegend(node)

# get a handle to current project and determine start and end range of current temporal enabled layers
project = QgsProject.instance()
range = QgsTemporalUtils.calculateTemporalRangeForProject(project)
print(f'Project Temporal Range: start: {range.begin().toString()} end: {range.end().toString()}')

# ??? get a handle to the Temporal Controller (QgsTemporalController) of this MapCanvas
c = iface.mapCanvas().temporalController()
#import sip
#sip.cast(iface.mapCanvas().temporalController(), QgsTemporalNavigationObject).setTemporalExtents(range)
#c.setTemporalExtents(range)

#c.temporalExtentsChanged.emit(range) # ?? should go vai c.setTemporalExtents(range)??
c.setTemporalExtents(range)

duration = c.frameDuration()
print(f'Player frameDuration: {duration.seconds()} seconds')  # PLAYER duration!!

#i=QgsInterval()
#i.setSeconds(3600)
#c.setFrameDuration(i)
# quicker via:
c.setFrameDuration(QgsInterval(QgsInterval.HOUR*1))

duration = c.frameDuration()
print(f'Player frameDuration: {duration.seconds()} seconds')  # PLAYER duration!!


#c = iface.mapCanvas().temporalController()
#c.skipToEnd()
#c.next()
#c.previous()
```


