### PR TITLE
[Oracle]  Fix default value evaluation when adding features

### DIFF
--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -1353,7 +1353,7 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flag
 
       insert += delim + quotedIdentifier( fld.name() );
 
-      QString defVal = defaultValueClause( idx );
+      const QString defVal = defaultValueClause( idx );
 
       values += delim + '?';
       defaultValues.append( defVal );

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -1320,7 +1320,7 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flag
         delim = ',';
         kdelim = ',';
         fieldId << idx;
-        defaultValues << defaultValue( idx ).toString();
+        defaultValues << defaultValueClause( idx );
       }
 
       if ( !getfid.prepare( QStringLiteral( "SELECT %1 FROM %2 WHERE ROWID=?" ).arg( keys ).arg( mQuery ) ) )
@@ -1353,7 +1353,7 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flag
 
       insert += delim + quotedIdentifier( fld.name() );
 
-      QString defVal = defaultValue( idx ).toString();
+      QString defVal = defaultValueClause( idx );
 
       values += delim + '?';
       defaultValues.append( defVal );

--- a/tests/src/python/test_provider_oracle.py
+++ b/tests/src/python/test_provider_oracle.py
@@ -23,7 +23,8 @@ from qgis.core import (
     QgsTransactionGroup,
     QgsFeature,
     QgsGeometry,
-    QgsWkbTypes
+    QgsWkbTypes,
+    QgsDataProvider
 )
 
 from qgis.PyQt.QtCore import QDate, QTime, QDateTime, QVariant
@@ -776,6 +777,47 @@ class TestPyQgsOracleProvider(unittest.TestCase, ProviderTestCase):
         """
         return (QgsVectorLayer(self.dbconn + ' sslmode=disable table="QGIS"."GENERATED_COLUMNS"', 'test', 'oracle'),
                 """'test:'||TO_CHAR("pk")""")
+
+    def testEvaluateDefaultValues(self):
+        """
+        Test default values evaluation on with or without option EvaluateDefaultValues
+        see https://github.com/qgis/QGIS/issues/39504
+        """
+
+        self.execSQLCommand('DROP TABLE "QGIS"."TEST_EVAL_EXPR"', ignore_errors=True)
+        self.execSQLCommand("""CREATE TABLE "QGIS"."TEST_EVAL_EXPR" (pk INTEGER, "name" VARCHAR2(100) DEFAULT 'qgis')""")
+
+        vl = QgsVectorLayer(
+            self.dbconn + ' sslmode=disable table="QGIS"."TEST_EVAL_EXPR" sql=',
+            'test', 'oracle')
+
+        self.assertTrue(vl.isValid())
+
+        # feature with default evaluation clause (not yet evaluated)
+        feat1 = QgsFeature(vl.fields())
+        feat1.setAttributes([1, "'qgis'"])
+
+        feat2 = QgsFeature(vl.fields())
+        feat2.setAttributes([2, 'test'])
+
+        self.assertTrue(vl.dataProvider().addFeatures([feat1, feat2]))
+
+        attributes = [feat.attributes() for feat in vl.getFeatures()]
+        self.assertEqual(attributes, [[1, 'qgis'], [2, 'test']])
+
+        vl.dataProvider().setProviderProperty(QgsDataProvider.EvaluateDefaultValues, True)
+
+        # feature with already evaluated default value
+        feat1 = QgsFeature(vl.fields())
+        feat1.setAttributes([3, 'qgis'])
+
+        feat2 = QgsFeature(vl.fields())
+        feat2.setAttributes([4, 'test'])
+
+        self.assertTrue(vl.dataProvider().addFeatures([feat1, feat2]))
+
+        attributes = [feat.attributes() for feat in vl.getFeatures()]
+        self.assertEqual(attributes, [[1, 'qgis'], [2, 'test'], [3, 'qgis'], [4, 'test']])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #39504 : Provider has to evaluate *defaultValueClause* when needed, not the already evaluated string.

