### PR TITLE
Homogenize the look of Identify Results for different LayerTypes

### DIFF
--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -881,10 +881,12 @@ void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,
 
   if ( !layItem )
   {
-    layItem = new QTreeWidgetItem( QStringList() << QString::number( lstResults->topLevelItemCount() ) << layer->name() );
+    layItem = new QTreeWidgetItem( QStringList() << layer->name() << QString::number( lstResults->topLevelItemCount() ) );
     layItem->setData( 0, Qt::UserRole, QVariant::fromValue( qobject_cast<QObject *>( layer ) ) );
-
     lstResults->addTopLevelItem( layItem );
+    QFont boldFont;
+    boldFont.setBold( true );
+    layItem->setFont( 0, boldFont );
 
     QComboBox *formatCombo = new QComboBox();
 
@@ -1122,10 +1124,13 @@ void QgsIdentifyResultsDialog::addFeature( QgsMeshLayer *layer,
 
   if ( !layItem )
   {
-    layItem = new QTreeWidgetItem( QStringList() << QString::number( lstResults->topLevelItemCount() ) << layer->name() );
+    layItem = new QTreeWidgetItem( QStringList() << layer->name() << QString::number( lstResults->topLevelItemCount() ) );
     layItem->setData( 0, Qt::UserRole, QVariant::fromValue( qobject_cast<QObject *>( layer ) ) );
-
     lstResults->addTopLevelItem( layItem );
+    QFont boldFont;
+    boldFont.setBold( true );
+    layItem->setFont( 0, boldFont );
+
     connect( layer, &QObject::destroyed, this, &QgsIdentifyResultsDialog::layerDestroyed );
     connect( layer, &QgsMapLayer::crsChanged, this, &QgsIdentifyResultsDialog::layerDestroyed );
   }


### PR DESCRIPTION
Minimal gui fix:

The code to build the Treeview for the Identify Results is split
in four, for the four different LayerTypes (vector, raster, mesh,
vector-tile).

But although vector and vector tile showed the 'toplevel' in bold
with the layername, the others showed... layer-count and name
in normal font.

This commit changes it so if you use the identify tool in a mixed
layer environment, they look more or less the same...

@PeterPetrik or is there a special reason to show it like this?
Same question for raster-people...

In screenshot below there are 4 different layer types.
Left is current situation
Right is this PR
( minor change, I know but it bugged me :-) )

![Screenshot-20201020162754-1674x619](https://user-images.githubusercontent.com/731673/96602249-1abed900-12f3-11eb-9b14-4111b1945ca7.png)

