### PR TITLE
Improve marker rotation and point offset tools

### DIFF
--- a/python/core/auto_generated/symbology/qgssymbol.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbol.sip.in
@@ -322,12 +322,20 @@ matches the settings from that context.
 .. seealso:: :py:func:`drawPreviewIcon`
 %End
 
-    QImage bigSymbolPreviewImage( QgsExpressionContext *expressionContext = 0 );
+    enum PreviewFlag
+    {
+      FlagIncludeCrosshairsForMarkerSymbols,
+    };
+    typedef QFlags<QgsSymbol::PreviewFlag> PreviewFlags;
+
+
+    QImage bigSymbolPreviewImage( QgsExpressionContext *expressionContext = 0, QgsSymbol::PreviewFlags flags = QgsSymbol::FlagIncludeCrosshairsForMarkerSymbols );
 %Docstring
 Returns a large (roughly 100x100 pixel) preview image for the symbol.
 
 :param expressionContext: optional expression context, for evaluation of
                           data defined symbol properties
+:param flags: optional flags to control how preview image is generated
 
 .. seealso:: :py:func:`asImage`
 
@@ -1237,6 +1245,9 @@ style and colors instead of the symbol's normal style.
 
 
 };
+
+QFlags<QgsSymbol::PreviewFlag> operator|(QgsSymbol::PreviewFlag f1, QFlags<QgsSymbol::PreviewFlag> f2);
+
 
 
 /************************************************************************

--- a/src/app/qgsmaptooloffsetpointsymbol.h
+++ b/src/app/qgsmaptooloffsetpointsymbol.h
@@ -39,7 +39,7 @@ class APP_EXPORT QgsMapToolOffsetPointSymbol: public QgsMapToolPointSymbol
 
     void canvasPressEvent( QgsMapMouseEvent *e ) override;
     void canvasMoveEvent( QgsMapMouseEvent *e ) override;
-    void canvasReleaseEvent( QgsMapMouseEvent *e ) override;
+    void keyPressEvent( QKeyEvent *e ) override;
 
     /**
      * Returns TRUE if the symbols of a map layer can be offset. This means the layer

--- a/src/app/qgsmaptoolrotatepointsymbols.cpp
+++ b/src/app/qgsmaptoolrotatepointsymbols.cpp
@@ -69,9 +69,59 @@ bool QgsMapToolRotatePointSymbols::layerIsRotatable( QgsMapLayer *ml )
 
 void QgsMapToolRotatePointSymbols::canvasPressEvent( QgsMapMouseEvent *e )
 {
-  mCurrentRotationAttributes.clear();
-  mMarkerSymbol.reset( nullptr );
-  QgsMapToolPointSymbol::canvasPressEvent( e );
+  if ( !mRotating )
+  {
+    if ( e->button() != Qt::LeftButton )
+      return;
+
+    // first click -- starts rotation
+    mCurrentRotationAttributes.clear();
+    mMarkerSymbol.reset( nullptr );
+    QgsMapToolPointSymbol::canvasPressEvent( e );
+  }
+  else
+  {
+    // second click stops it.
+    // only left clicks "save" edits - right clicks discard them
+    if ( e->button() == Qt::LeftButton && mActiveLayer )
+    {
+      mActiveLayer->beginEditCommand( tr( "Rotate symbol" ) );
+      bool rotateSuccess = true;
+
+      //write mCurrentRotationFeature to all rotation attributes of feature (mFeatureNumber)
+      int rotation;
+      if ( mCtrlPressed ) //round to 15 degrees
+      {
+        rotation = roundTo15Degrees( mCurrentRotationFeature );
+      }
+      else
+      {
+        rotation = static_cast<int>( mCurrentRotationFeature );
+      }
+
+      QSet<int>::const_iterator it = mCurrentRotationAttributes.constBegin();
+      for ( ; it != mCurrentRotationAttributes.constEnd(); ++it )
+      {
+        if ( !mActiveLayer->changeAttributeValue( mFeatureNumber, *it, rotation ) )
+        {
+          rotateSuccess = false;
+        }
+      }
+
+      if ( rotateSuccess )
+      {
+        mActiveLayer->endEditCommand();
+      }
+      else
+      {
+        mActiveLayer->destroyEditCommand();
+      }
+      mActiveLayer->triggerRepaint();
+    }
+    mRotating = false;
+    delete mRotationItem;
+    mRotationItem = nullptr;
+  }
 }
 
 void QgsMapToolRotatePointSymbols::canvasPressOnFeature( QgsMapMouseEvent *e, const QgsFeature &feature, const QgsPointXY &snappedPoint )
@@ -156,49 +206,18 @@ void QgsMapToolRotatePointSymbols::canvasMoveEvent( QgsMapMouseEvent *e )
   setPixmapItemRotation( displayValue );
 }
 
-void QgsMapToolRotatePointSymbols::canvasReleaseEvent( QgsMapMouseEvent *e )
+void QgsMapToolRotatePointSymbols::keyPressEvent( QKeyEvent *e )
 {
-  Q_UNUSED( e )
-
-  if ( mRotating && mActiveLayer )
+  if ( mRotating && e && e->key() == Qt::Key_Escape && !e->isAutoRepeat() )
   {
-    mActiveLayer->beginEditCommand( tr( "Rotate symbol" ) );
-    bool rotateSuccess = true;
-
-    //write mCurrentRotationFeature to all rotation attributes of feature (mFeatureNumber)
-    int rotation;
-    if ( mCtrlPressed ) //round to 15 degrees
-    {
-      rotation = roundTo15Degrees( mCurrentRotationFeature );
-    }
-    else
-    {
-      rotation = static_cast<int>( mCurrentRotationFeature );
-    }
-
-    QSet<int>::const_iterator it = mCurrentRotationAttributes.constBegin();
-    for ( ; it != mCurrentRotationAttributes.constEnd(); ++it )
-    {
-      if ( !mActiveLayer->changeAttributeValue( mFeatureNumber, *it, rotation ) )
-      {
-        rotateSuccess = false;
-      }
-    }
-
-    if ( rotateSuccess )
-    {
-      mActiveLayer->endEditCommand();
-    }
-    else
-    {
-      mActiveLayer->destroyEditCommand();
-    }
+    mRotating = false;
+    delete mRotationItem;
+    mRotationItem = nullptr;
   }
-  mRotating = false;
-  delete mRotationItem;
-  mRotationItem = nullptr;
-  if ( mActiveLayer )
-    mActiveLayer->triggerRepaint();
+  else
+  {
+    QgsMapToolPointSymbol::keyPressEvent( e );
+  }
 }
 
 double QgsMapToolRotatePointSymbols::calculateAzimut( QPoint mousePos )

--- a/src/app/qgsmaptoolrotatepointsymbols.cpp
+++ b/src/app/qgsmaptoolrotatepointsymbols.cpp
@@ -223,7 +223,7 @@ void QgsMapToolRotatePointSymbols::createPixmapItem( QgsMarkerSymbol *markerSymb
     std::unique_ptr< QgsSymbol > clone( markerSymbol->clone() );
     QgsMarkerSymbol *markerClone = static_cast<QgsMarkerSymbol *>( clone.get() );
     markerClone->setDataDefinedAngle( QgsProperty() );
-    pointImage = markerClone->bigSymbolPreviewImage();
+    pointImage = markerClone->bigSymbolPreviewImage( nullptr, QgsSymbol::PreviewFlags() );
   }
 
   mRotationItem = new QgsPointRotationItem( mCanvas );

--- a/src/app/qgsmaptoolrotatepointsymbols.h
+++ b/src/app/qgsmaptoolrotatepointsymbols.h
@@ -39,7 +39,7 @@ class APP_EXPORT QgsMapToolRotatePointSymbols: public QgsMapToolPointSymbol
 
     void canvasPressEvent( QgsMapMouseEvent *e ) override;
     void canvasMoveEvent( QgsMapMouseEvent *e ) override;
-    void canvasReleaseEvent( QgsMapMouseEvent *e ) override;
+    void keyPressEvent( QKeyEvent *e ) override;
 
     /**
      * Returns TRUE if the symbols of a maplayer can be rotated. This means the layer

--- a/src/app/qgspointmarkeritem.cpp
+++ b/src/app/qgspointmarkeritem.cpp
@@ -51,6 +51,7 @@ QgsRenderContext QgsMapCanvasSymbolItem::renderContext( QPainter *painter )
   }
   //context << QgsExpressionContextUtils::layerScope( mLayer );
   context.setFeature( mFeature );
+  context.setFields( mFeature.fields() );
 
   //setup render context
   QgsMapSettings ms = mMapCanvas->mapSettings();

--- a/src/app/qgspointrotationitem.cpp
+++ b/src/app/qgspointrotationitem.cpp
@@ -117,7 +117,7 @@ void QgsPointRotationItem::setSymbol( const QImage &symbolImage )
   }
 
   const double halfItemWidth = mPixmap.width() / 2.0;
-  mArrowPath.clear();
+  mArrowPath = QPainterPath();
   mArrowPath.moveTo( halfItemWidth, pixmapHeight );
   mArrowPath.lineTo( halfItemWidth, 0 );
   mArrowPath.moveTo( mPixmap.width() * 0.25, pixmapHeight * 0.25 );

--- a/src/app/qgspointrotationitem.cpp
+++ b/src/app/qgspointrotationitem.cpp
@@ -16,6 +16,7 @@
 #include "qgspointrotationitem.h"
 #include <QPainter>
 #include <cmath>
+#include "qgsguiutils.h"
 
 QgsPointRotationItem::QgsPointRotationItem( QgsMapCanvas *canvas )
   : QgsMapCanvasItem( canvas )
@@ -37,6 +38,7 @@ void QgsPointRotationItem::paint( QPainter *painter )
   {
     return;
   }
+  painter->setRenderHint( QPainter::Antialiasing, true );
   painter->save();
 
   //do a bit of trigonometry to find out how to transform a rotated item such that the center point is at the point feature
@@ -55,12 +57,35 @@ void QgsPointRotationItem::paint( QPainter *painter )
   painter->translate( x - mPixmap.width() / 2.0, -y - mPixmap.height() / 2.0 );
   painter->drawPixmap( 0, 0, mPixmap );
 
-  //draw numeric value beside the symbol
+  //draw arrow, using a red line over a thicker white line so that the arrow is visible against a range of backgrounds
+  QPen pen;
+  pen.setWidth( QgsGuiUtils::scaleIconSize( 4 ) );
+  pen.setColor( QColor( Qt::white ) );
+  painter->setPen( pen );
+  painter->drawPath( mArrowPath );
+  pen.setWidth( QgsGuiUtils::scaleIconSize( 1 ) );
+  pen.setColor( QColor( Qt::red ) );
+  painter->setPen( pen );
+  painter->drawPath( mArrowPath );
   painter->restore();
+
+  //draw numeric value beside the symbol
+  painter->save();
+
+  QPen bufferPen;
+  bufferPen.setColor( Qt::white );
+  bufferPen.setWidthF( QgsGuiUtils::scaleIconSize( 4 ) );
   QFontMetricsF fm( mFont );
-  painter->fillRect( mPixmap.width(), 0, mItemSize.width() - mPixmap.width(), mItemSize.height(), QColor( Qt::white ) );
-  painter->setFont( mFont );
-  painter->drawText( mPixmap.width(), mPixmap.height() / 2.0 + fm.height() / 2.0, QString::number( mRotation ) );
+  QPainterPath label;
+  label.addText( mPixmap.width(), mPixmap.height() / 2.0 + fm.height() / 2.0, mFont, QString::number( mRotation ) );
+  painter->setPen( bufferPen );
+  painter->setBrush( Qt::NoBrush );
+  painter->drawPath( label );
+  painter->setPen( Qt::NoPen );
+  painter->setBrush( QBrush( Qt::black ) );
+  painter->drawPath( label );
+
+  painter->restore();
 }
 
 void QgsPointRotationItem::setPointLocation( const QgsPointXY &p )
@@ -74,25 +99,13 @@ void QgsPointRotationItem::setSymbol( const QImage &symbolImage )
   mPixmap = QPixmap::fromImage( symbolImage );
   QFontMetricsF fm( mFont );
 
-  //draw arrow
-  QPainter p( &mPixmap );
-  QPen pen;
-  pen.setWidth( 1 );
-  pen.setColor( QColor( Qt::red ) );
-  p.setPen( pen );
-  int halfItemWidth = mPixmap.width() / 2;
-  int quarterItemHeight = mPixmap.height() / 4;
-  p.drawLine( halfItemWidth, mPixmap.height(), halfItemWidth, 0 );
-  p.drawLine( halfItemWidth, 0, mPixmap.width() / 4, quarterItemHeight );
-  p.drawLine( halfItemWidth, 0, mPixmap.width() * 0.75, quarterItemHeight );
-
   //set item size
 #if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
   mItemSize.setWidth( mPixmap.width() + fm.width( QStringLiteral( "360" ) ) );
 #else
   mItemSize.setWidth( mPixmap.width() + fm.horizontalAdvance( QStringLiteral( "360" ) ) );
 #endif
-  double pixmapHeight = mPixmap.height();
+  const double pixmapHeight = mPixmap.height();
   double fontHeight = fm.height();
   if ( pixmapHeight >= fontHeight )
   {
@@ -102,6 +115,14 @@ void QgsPointRotationItem::setSymbol( const QImage &symbolImage )
   {
     mItemSize.setHeight( fm.height() );
   }
+
+  const double halfItemWidth = mPixmap.width() / 2.0;
+  mArrowPath.clear();
+  mArrowPath.moveTo( halfItemWidth, pixmapHeight );
+  mArrowPath.lineTo( halfItemWidth, 0 );
+  mArrowPath.moveTo( mPixmap.width() * 0.25, pixmapHeight * 0.25 );
+  mArrowPath.lineTo( halfItemWidth, 0 );
+  mArrowPath.lineTo( mPixmap.width() * 0.75, pixmapHeight * 0.25 );
 }
 
 int QgsPointRotationItem::painterRotation( int rotation ) const

--- a/src/app/qgspointrotationitem.h
+++ b/src/app/qgspointrotationitem.h
@@ -62,6 +62,8 @@ class APP_EXPORT QgsPointRotationItem: public QgsMapCanvasItem
     //! Symbol pixmap
     QPixmap mPixmap;
     int mRotation;
+    QPainterPath mArrowPath;
+
 };
 
 #endif // QGSPOINTROTATIONITEM_H

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -634,7 +634,7 @@ QImage QgsSymbol::asImage( QSize size, QgsRenderContext *customContext )
 }
 
 
-QImage QgsSymbol::bigSymbolPreviewImage( QgsExpressionContext *expressionContext )
+QImage QgsSymbol::bigSymbolPreviewImage( QgsExpressionContext *expressionContext, QgsSymbol::PreviewFlags flags )
 {
   QImage preview( QSize( 100, 100 ), QImage::Format_ARGB32_Premultiplied );
   preview.fill( 0 );
@@ -643,7 +643,7 @@ QImage QgsSymbol::bigSymbolPreviewImage( QgsExpressionContext *expressionContext
   p.setRenderHint( QPainter::Antialiasing );
   p.translate( 0.5, 0.5 ); // shift by half a pixel to avoid blurring due antialiasing
 
-  if ( mType == QgsSymbol::Marker )
+  if ( mType == QgsSymbol::Marker && flags & PreviewFlag::FlagIncludeCrosshairsForMarkerSymbols )
   {
     p.setPen( QPen( Qt::gray ) );
     p.drawLine( 0, 50, 100, 50 );

--- a/src/core/symbology/qgssymbol.h
+++ b/src/core/symbology/qgssymbol.h
@@ -370,14 +370,27 @@ class CORE_EXPORT QgsSymbol
     QImage asImage( QSize size, QgsRenderContext *customContext = nullptr );
 
     /**
+     * Flags for controlling how symbol preview images are generated.
+     *
+     * \since QGIS 3.16
+     */
+    enum PreviewFlag
+    {
+      FlagIncludeCrosshairsForMarkerSymbols = 1 << 0, //!< Include a crosshairs reference image in the background of marker symbol previews
+    };
+    Q_DECLARE_FLAGS( PreviewFlags, PreviewFlag )
+
+    /**
      * Returns a large (roughly 100x100 pixel) preview image for the symbol.
+     *
      * \param expressionContext optional expression context, for evaluation of
      * data defined symbol properties
+     * \param flags optional flags to control how preview image is generated
      *
      * \see asImage()
      * \see drawPreviewIcon()
      */
-    QImage bigSymbolPreviewImage( QgsExpressionContext *expressionContext = nullptr );
+    QImage bigSymbolPreviewImage( QgsExpressionContext *expressionContext = nullptr, QgsSymbol::PreviewFlags flags = QgsSymbol::FlagIncludeCrosshairsForMarkerSymbols );
 
     /**
      * Returns a string dump of the symbol's properties.
@@ -1262,6 +1275,8 @@ class CORE_EXPORT QgsFillSymbol : public QgsSymbol
     //! Translates the rings in a polygon by a set distance
     QVector<QPolygonF> *translateRings( const QVector<QPolygonF> *rings, double dx, double dy ) const;
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsSymbol::PreviewFlags )
 
 #endif
 


### PR DESCRIPTION
Fixes some issues with these tools:
- point offset preview symbol was not being shown
- tools used click and hold, instead of standard click-click behavior
- preview overlay for marker rotation was super ugly and covered too much of the underlying map