### PR TITLE
[Backport 3.10] ReadEntry ok value must be set to False when property doesn't exist

### DIFF
--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -326,7 +326,7 @@ Writes the project to its current associated file (see fileName() ).
 
     bool writeEntry( const QString &scope, const QString &key, bool value ) /PyName=writeEntryBool/;
 %Docstring
-Write a boolean entry to the project file.
+Write a boolean ``value`` to the project file.
 
 Keys are '/'-delimited entries, implying
 a hierarchy of keys and corresponding values
@@ -338,11 +338,13 @@ a hierarchy of keys and corresponding values
 .. note::
 
    available in Python bindings as writeEntryBool
+
+.. seealso:: :py:func:`readBoolEntry`
 %End
 
     bool writeEntry( const QString &scope, const QString &key, double value ) /PyName=writeEntryDouble/;
 %Docstring
-Write a double entry to the project file.
+Write a double ``value`` to the project file.
 
 Keys are '/'-delimited entries, implying
 a hierarchy of keys and corresponding values
@@ -354,11 +356,13 @@ a hierarchy of keys and corresponding values
 .. note::
 
    available in Python bindings as writeEntryDouble
+
+.. seealso:: :py:func:`readDoubleEntry`
 %End
 
     bool writeEntry( const QString &scope, const QString &key, int value );
 %Docstring
-Write an integer entry to the project file.
+Write an integer ``value`` to the project file.
 
 Keys are '/'-delimited entries, implying
 a hierarchy of keys and corresponding values
@@ -366,11 +370,13 @@ a hierarchy of keys and corresponding values
 .. note::
 
    The key string must be valid xml tag names in order to be saved to the file.
+
+.. seealso:: :py:func:`readNumEntry`
 %End
 
     bool writeEntry( const QString &scope, const QString &key, const QString &value );
 %Docstring
-Write a string entry to the project file.
+Write a string ``value`` to the project file.
 
 Keys are '/'-delimited entries, implying
 a hierarchy of keys and corresponding values
@@ -378,11 +384,13 @@ a hierarchy of keys and corresponding values
 .. note::
 
    The key string must be valid xml tag names in order to be saved to the file.
+
+.. seealso:: :py:func:`readEntry`
 %End
 
     bool writeEntry( const QString &scope, const QString &key, const QStringList &value );
 %Docstring
-Write a string list entry to the project file.
+Write a string list ``value`` to the project file.
 
 Keys are '/'-delimited entries, implying
 a hierarchy of keys and corresponding values
@@ -390,62 +398,82 @@ a hierarchy of keys and corresponding values
 .. note::
 
    The key string must be valid xml tag names in order to be saved to the file.
+
+.. seealso:: :py:func:`readListEntry`
 %End
 
     QStringList readListEntry( const QString &scope, const QString &key, const QStringList &def = QStringList(), bool *ok /Out/ = 0 ) const;
 %Docstring
-Key value accessors
+Reads a string list from the specified ``scope`` and ``key``.
 
-keys would be the familiar QgsSettings-like '/' delimited entries,
-implying a hierarchy of keys and corresponding values
+:param scope: entry scope (group) name
+:param key: entry key name. Keys are '/'-delimited entries, implying a hierarchy of keys and corresponding values.
+:param def: default value to return if the specified ``key`` does not exist within the ``scope``.
+
+:return: - entry value as a string list
+         - ok: set to ``True`` if key exists and has been successfully retrieved as a string list
 %End
 
     QString readEntry( const QString &scope, const QString &key, const QString &def = QString(), bool *ok /Out/ = 0 ) const;
 %Docstring
+Reads a string from the specified ``scope`` and ``key``.
 
-:param def: returned value if key doesn't exist
+:param scope: entry scope (group) name
+:param key: entry key name. Keys are '/'-delimited entries, implying a hierarchy of keys and corresponding values.
+:param def: default value to return if the specified ``key`` does not exist within the ``scope``.
 
 :return: - entry value as string from ``scope`` given its ``key``
-         - ok: set to ``True`` if key exists and has been successfully retrieved
+         - ok: set to ``True`` if key exists and has been successfully retrieved as a string value
 %End
 
     int readNumEntry( const QString &scope, const QString &key, int def = 0, bool *ok /Out/ = 0 ) const;
 %Docstring
+Reads an integer from the specified ``scope`` and ``key``.
 
-:param def: returned value if key doesn't exist
+:param scope: entry scope (group) name
+:param key: entry key name. Keys are '/'-delimited entries, implying a hierarchy of keys and corresponding values.
+:param def: default value to return if the specified ``key`` does not exist within the ``scope``.
 
 :return: - entry value as integer from ``scope`` given its ``key``
-         - ok: set to ``True`` if key exists and has been successfully retrieved
+         - ok: set to ``True`` if key exists and has been successfully retrieved as an integer
 %End
 
     double readDoubleEntry( const QString &scope, const QString &key, double def = 0, bool *ok /Out/ = 0 ) const;
 %Docstring
+Reads a double from the specified ``scope`` and ``key``.
 
-:param def: returned value if key doesn't exist
+:param scope: entry scope (group) name
+:param key: entry key name. Keys are '/'-delimited entries, implying a hierarchy of keys and corresponding values.
+:param default: value to return if the specified ``key`` does not exist within the ``scope``.
 
 :return: - entry value as double from ``scope`` given its ``key``
-         - ok: set to ``True`` if key exists and has been successfully retrieved
+         - ok: set to ``True`` if key exists and has been successfully retrieved as a double
 %End
 
     bool readBoolEntry( const QString &scope, const QString &key, bool def = false, bool *ok /Out/ = 0 ) const;
 %Docstring
+Reads a boolean from the specified ``scope`` and ``key``.
 
-:param def: returned value if key doesn't exist
+:param scope: entry scope (group) name
+:param key: entry key name. Keys are '/'-delimited entries, implying a hierarchy of keys and corresponding values.
+:param default: value to return if the specified ``key`` does not exist within the ``scope``.
 
 :return: - entry value as boolean from ``scope`` given its ``key``
-         - ok: set to ``True`` if key exists and has been successfully retrieved
+         - ok: set to ``True`` if key exists and has been successfully retrieved as a boolean
 %End
 
 
     bool removeEntry( const QString &scope, const QString &key );
 %Docstring
-Remove the given key
+Remove the given ``key`` from the specified ``scope``.
 %End
-
 
     QStringList entryList( const QString &scope, const QString &key ) const;
 %Docstring
-Returns keys with values -- do not return keys that contain other keys
+Returns a list of child keys with values which exist within the the specified ``scope`` and ``key``.
+
+This method does not return keys that contain other keys. See :py:func:`~QgsProject.subkeyList` to retrieve keys
+which contain other keys.
 
 .. note::
 
@@ -454,7 +482,10 @@ Returns keys with values -- do not return keys that contain other keys
 
     QStringList subkeyList( const QString &scope, const QString &key ) const;
 %Docstring
-Returns keys with keys -- do not return keys that contain only values
+Returns a list of child keys which contain other keys that exist within the the specified ``scope`` and ``key``.
+
+This method only returns keys with keys, it will not return keys that contain only values. See
+:py:func:`~QgsProject.entryList` to retrieve keys with values.
 
 .. note::
 
@@ -463,6 +494,9 @@ Returns keys with keys -- do not return keys that contain only values
 
 
     void dumpProperties() const;
+%Docstring
+Dump out current project properties to stderr
+%End
 
     QgsPathResolver pathResolver() const;
 %Docstring
@@ -481,7 +515,7 @@ Paths written to the project file should be prepared with this method.
 
     QString readPath( const QString &filename ) const;
 %Docstring
-Turn filename read from the project file to an absolute path
+Transforms a ``filename`` read from the project file to an absolute path.
 %End
 
     QString error() const;
@@ -497,7 +531,9 @@ Deletes old handler and takes ownership of the new one.
 
     QString layerIsEmbedded( const QString &id ) const;
 %Docstring
-Returns project file path if layer is embedded from other project file. Returns empty string if layer is not embedded
+Returns the source project file path if the layer with matching ``id`` is embedded from other project file.
+
+Returns an empty string if the matching layer is not embedded.
 %End
 
 

--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -392,7 +392,7 @@ a hierarchy of keys and corresponding values
    The key string must be valid xml tag names in order to be saved to the file.
 %End
 
-    QStringList readListEntry( const QString &scope, const QString &key, const QStringList &def = QStringList(), bool *ok = 0 ) const;
+    QStringList readListEntry( const QString &scope, const QString &key, const QStringList &def = QStringList(), bool *ok /Out/ = 0 ) const;
 %Docstring
 Key value accessors
 
@@ -400,10 +400,41 @@ keys would be the familiar QgsSettings-like '/' delimited entries,
 implying a hierarchy of keys and corresponding values
 %End
 
-    QString readEntry( const QString &scope, const QString &key, const QString &def = QString(), bool *ok = 0 ) const;
-    int readNumEntry( const QString &scope, const QString &key, int def = 0, bool *ok = 0 ) const;
-    double readDoubleEntry( const QString &scope, const QString &key, double def = 0, bool *ok = 0 ) const;
-    bool readBoolEntry( const QString &scope, const QString &key, bool def = false, bool *ok = 0 ) const;
+    QString readEntry( const QString &scope, const QString &key, const QString &def = QString(), bool *ok /Out/ = 0 ) const;
+%Docstring
+
+:param def: returned value if key doesn't exist
+
+:return: - entry value as string from ``scope`` given its ``key``
+         - ok: set to ``True`` if key exists and has been successfully retrieved
+%End
+
+    int readNumEntry( const QString &scope, const QString &key, int def = 0, bool *ok /Out/ = 0 ) const;
+%Docstring
+
+:param def: returned value if key doesn't exist
+
+:return: - entry value as integer from ``scope`` given its ``key``
+         - ok: set to ``True`` if key exists and has been successfully retrieved
+%End
+
+    double readDoubleEntry( const QString &scope, const QString &key, double def = 0, bool *ok /Out/ = 0 ) const;
+%Docstring
+
+:param def: returned value if key doesn't exist
+
+:return: - entry value as double from ``scope`` given its ``key``
+         - ok: set to ``True`` if key exists and has been successfully retrieved
+%End
+
+    bool readBoolEntry( const QString &scope, const QString &key, bool def = false, bool *ok /Out/ = 0 ) const;
+%Docstring
+
+:param def: returned value if key doesn't exist
+
+:return: - entry value as boolean from ``scope`` given its ``key``
+         - ok: set to ``True`` if key exists and has been successfully retrieved
+%End
 
 
     bool removeEntry( const QString &scope, const QString &key );

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -2271,6 +2271,9 @@ QStringList QgsProject::readListEntry( const QString &scope,
       return value.toStringList();
     }
   }
+  else if ( ok )
+    *ok = false;
+
 
   return def;
 }
@@ -2296,6 +2299,8 @@ QString QgsProject::readEntry( const QString &scope,
     if ( valid )
       return value.toString();
   }
+  else if ( ok )
+    *ok = false;
 
   return def;
 }
@@ -2343,6 +2348,8 @@ double QgsProject::readDoubleEntry( const QString &scope, const QString &key,
     if ( valid )
       return value.toDouble();
   }
+  else if ( ok )
+    *ok = false;
 
   return def;
 }
@@ -2363,6 +2370,8 @@ bool QgsProject::readBoolEntry( const QString &scope, const QString &key, bool d
     if ( valid )
       return value.toBool();
   }
+  else if ( ok )
+    *ok = false;
 
   return def;
 }

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -337,118 +337,158 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     bool write();
 
     /**
-     * Write a boolean entry to the project file.
+     * Write a boolean \a value to the project file.
      *
      * Keys are '/'-delimited entries, implying
      * a hierarchy of keys and corresponding values
      *
      * \note The key string must be valid xml tag names in order to be saved to the file.
      * \note available in Python bindings as writeEntryBool
+     *
+     * \see readBoolEntry()
      */
     bool writeEntry( const QString &scope, const QString &key, bool value ) SIP_PYNAME( writeEntryBool );
 
     /**
-     * Write a double entry to the project file.
+     * Write a double \a value to the project file.
      *
      * Keys are '/'-delimited entries, implying
      * a hierarchy of keys and corresponding values
      *
      * \note The key string must be valid xml tag names in order to be saved to the file.
      * \note available in Python bindings as writeEntryDouble
+     *
+     * \see readDoubleEntry()
      */
     bool writeEntry( const QString &scope, const QString &key, double value ) SIP_PYNAME( writeEntryDouble );
 
     /**
-     * Write an integer entry to the project file.
+     * Write an integer \a value to the project file.
      *
      * Keys are '/'-delimited entries, implying
      * a hierarchy of keys and corresponding values
      *
      * \note The key string must be valid xml tag names in order to be saved to the file.
+     *
+     * \see readNumEntry()
      */
     bool writeEntry( const QString &scope, const QString &key, int value );
 
     /**
-     * Write a string entry to the project file.
+     * Write a string \a value to the project file.
      *
      * Keys are '/'-delimited entries, implying
      * a hierarchy of keys and corresponding values
      *
      * \note The key string must be valid xml tag names in order to be saved to the file.
+     *
+     * \see readEntry()
      */
     bool writeEntry( const QString &scope, const QString &key, const QString &value );
 
     /**
-     * Write a string list entry to the project file.
+     * Write a string list \a value to the project file.
      *
      * Keys are '/'-delimited entries, implying
      * a hierarchy of keys and corresponding values
      *
      * \note The key string must be valid xml tag names in order to be saved to the file.
+     *
+     * \see readListEntry()
      */
     bool writeEntry( const QString &scope, const QString &key, const QStringList &value );
 
     /**
-     * Key value accessors
+     * Reads a string list from the specified \a scope and \a key.
      *
-     * keys would be the familiar QgsSettings-like '/' delimited entries,
-     * implying a hierarchy of keys and corresponding values
+     * \param scope entry scope (group) name
+     * \param key entry key name. Keys are '/'-delimited entries, implying a hierarchy of keys and corresponding values.
+     * \param def default value to return if the specified \a key does not exist within the \a scope.
+     * \param ok set to TRUE if key exists and has been successfully retrieved as a string list
+     *
+     * \returns entry value as a string list
      */
     QStringList readListEntry( const QString &scope, const QString &key, const QStringList &def = QStringList(), bool *ok SIP_OUT = nullptr ) const;
 
     /**
-     * \param def returned value if key doesn't exist
-     * \param ok set to TRUE if key exists and has been successfully retrieved
+     * Reads a string from the specified \a scope and \a key.
+     *
+     * \param scope entry scope (group) name
+     * \param key entry key name. Keys are '/'-delimited entries, implying a hierarchy of keys and corresponding values.
+     * \param def default value to return if the specified \a key does not exist within the \a scope.
+     * \param ok set to TRUE if key exists and has been successfully retrieved as a string value
+     *
      * \returns entry value as string from \a scope given its \a key
      */
     QString readEntry( const QString &scope, const QString &key, const QString &def = QString(), bool *ok SIP_OUT = nullptr ) const;
 
     /**
-     * \param def returned value if key doesn't exist
-     * \param ok set to TRUE if key exists and has been successfully retrieved
+     * Reads an integer from the specified \a scope and \a key.
+     *
+     * \param scope entry scope (group) name
+     * \param key entry key name. Keys are '/'-delimited entries, implying a hierarchy of keys and corresponding values.
+     * \param def default value to return if the specified \a key does not exist within the \a scope.
+     * \param ok set to TRUE if key exists and has been successfully retrieved as an integer
+     *
      * \returns entry value as integer from \a scope given its \a key
      */
     int readNumEntry( const QString &scope, const QString &key, int def = 0, bool *ok SIP_OUT = nullptr ) const;
 
     /**
-     * \param def returned value if key doesn't exist
-     * \param ok set to TRUE if key exists and has been successfully retrieved
+     * Reads a double from the specified \a scope and \a key.
+     *
+     * \param scope entry scope (group) name
+     * \param key entry key name. Keys are '/'-delimited entries, implying a hierarchy of keys and corresponding values.
+     * \param default value to return if the specified \a key does not exist within the \a scope.
+     * \param ok set to TRUE if key exists and has been successfully retrieved as a double
+     *
      * \returns entry value as double from \a scope given its \a key
      */
     double readDoubleEntry( const QString &scope, const QString &key, double def = 0, bool *ok SIP_OUT = nullptr ) const;
 
     /**
-     * \param def returned value if key doesn't exist
-     * \param ok set to TRUE if key exists and has been successfully retrieved
+     * Reads a boolean from the specified \a scope and \a key.
+     *
+     * \param scope entry scope (group) name
+     * \param key entry key name. Keys are '/'-delimited entries, implying a hierarchy of keys and corresponding values.
+     * \param default value to return if the specified \a key does not exist within the \a scope.
+     * \param ok set to TRUE if key exists and has been successfully retrieved as a boolean
+     *
      * \returns entry value as boolean from \a scope given its \a key
      */
     bool readBoolEntry( const QString &scope, const QString &key, bool def = false, bool *ok SIP_OUT = nullptr ) const;
 
-
-    //! Remove the given key
+    /**
+     * Remove the given \a key from the specified \a scope.
+     */
     bool removeEntry( const QString &scope, const QString &key );
 
-
     /**
-     * Returns keys with values -- do not return keys that contain other keys
+     * Returns a list of child keys with values which exist within the the specified \a scope and \a key.
+     *
+     * This method does not return keys that contain other keys. See subkeyList() to retrieve keys
+     * which contain other keys.
      *
      * \note equivalent to QgsSettings entryList()
      */
     QStringList entryList( const QString &scope, const QString &key ) const;
 
     /**
-     * Returns keys with keys -- do not return keys that contain only values
+     * Returns a list of child keys which contain other keys that exist within the the specified \a scope and \a key.
+     *
+     * This method only returns keys with keys, it will not return keys that contain only values. See
+     * entryList() to retrieve keys with values.
      *
      * \note equivalent to QgsSettings subkeyList()
      */
     QStringList subkeyList( const QString &scope, const QString &key ) const;
 
+    // TODO Now slightly broken since re-factoring.  Won't print out top-level key
+    //           and redundantly prints sub-keys.
 
     /**
      * Dump out current project properties to stderr
      */
-    // TODO Now slightly broken since re-factoring.  Won't print out top-level key
-    //           and redundantly prints sub-keys.
     void dumpProperties() const;
 
     /**
@@ -465,7 +505,9 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     */
     QString writePath( const QString &filename ) const;
 
-    //! Turn filename read from the project file to an absolute path
+    /**
+     * Transforms a \a filename read from the project file to an absolute path.
+     */
     QString readPath( const QString &filename ) const;
 
     //! Returns error message from previous read/write
@@ -477,7 +519,11 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      */
     void setBadLayerHandler( QgsProjectBadLayerHandler *handler SIP_TRANSFER );
 
-    //! Returns project file path if layer is embedded from other project file. Returns empty string if layer is not embedded
+    /**
+     * Returns the source project file path if the layer with matching \a id is embedded from other project file.
+     *
+     * Returns an empty string if the matching layer is not embedded.
+     */
     QString layerIsEmbedded( const QString &id ) const;
 
     /**

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -394,12 +394,35 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * keys would be the familiar QgsSettings-like '/' delimited entries,
      * implying a hierarchy of keys and corresponding values
      */
-    QStringList readListEntry( const QString &scope, const QString &key, const QStringList &def = QStringList(), bool *ok = nullptr ) const;
+    QStringList readListEntry( const QString &scope, const QString &key, const QStringList &def = QStringList(), bool *ok SIP_OUT = nullptr ) const;
 
-    QString readEntry( const QString &scope, const QString &key, const QString &def = QString(), bool *ok = nullptr ) const;
-    int readNumEntry( const QString &scope, const QString &key, int def = 0, bool *ok = nullptr ) const;
-    double readDoubleEntry( const QString &scope, const QString &key, double def = 0, bool *ok = nullptr ) const;
-    bool readBoolEntry( const QString &scope, const QString &key, bool def = false, bool *ok = nullptr ) const;
+    /**
+     * \param def returned value if key doesn't exist
+     * \param ok set to TRUE if key exists and has been successfully retrieved
+     * \returns entry value as string from \a scope given its \a key
+     */
+    QString readEntry( const QString &scope, const QString &key, const QString &def = QString(), bool *ok SIP_OUT = nullptr ) const;
+
+    /**
+     * \param def returned value if key doesn't exist
+     * \param ok set to TRUE if key exists and has been successfully retrieved
+     * \returns entry value as integer from \a scope given its \a key
+     */
+    int readNumEntry( const QString &scope, const QString &key, int def = 0, bool *ok SIP_OUT = nullptr ) const;
+
+    /**
+     * \param def returned value if key doesn't exist
+     * \param ok set to TRUE if key exists and has been successfully retrieved
+     * \returns entry value as double from \a scope given its \a key
+     */
+    double readDoubleEntry( const QString &scope, const QString &key, double def = 0, bool *ok SIP_OUT = nullptr ) const;
+
+    /**
+     * \param def returned value if key doesn't exist
+     * \param ok set to TRUE if key exists and has been successfully retrieved
+     * \returns entry value as boolean from \a scope given its \a key
+     */
+    bool readBoolEntry( const QString &scope, const QString &key, bool def = false, bool *ok SIP_OUT = nullptr ) const;
 
 
     //! Remove the given key

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -439,7 +439,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      *
      * \param scope entry scope (group) name
      * \param key entry key name. Keys are '/'-delimited entries, implying a hierarchy of keys and corresponding values.
-     * \param default value to return if the specified \a key does not exist within the \a scope.
+     * \param def default value to return if the specified \a key does not exist within the \a scope.
      * \param ok set to TRUE if key exists and has been successfully retrieved as a double
      *
      * \returns entry value as double from \a scope given its \a key
@@ -451,7 +451,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      *
      * \param scope entry scope (group) name
      * \param key entry key name. Keys are '/'-delimited entries, implying a hierarchy of keys and corresponding values.
-     * \param default value to return if the specified \a key does not exist within the \a scope.
+     * \param def default value to return if the specified \a key does not exist within the \a scope.
      * \param ok set to TRUE if key exists and has been successfully retrieved as a boolean
      *
      * \returns entry value as boolean from \a scope given its \a key

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -189,10 +189,22 @@ class TestQgsProject(unittest.TestCase):
         prj = QgsProject.instance()
         prj.read(os.path.join(TEST_DATA_DIR, 'labeling/test-labeling.qgs'))
 
-        # valid key, valid int value
-        self.assertEqual(prj.readNumEntry("SpatialRefSys", "/ProjectionsEnabled", -1)[0], 0)
+        # add a test entry list
+        prj.writeEntry("TestScope", "/TestListProperty", ["Entry1", "Entry2"])
+
+        # valid key, valid value
+        self.assertEqual(prj.readNumEntry("SpatialRefSys", "/ProjectionsEnabled", -1), (0, True))
+        self.assertEqual(prj.readEntry("SpatialRefSys", "/ProjectCrs"), ("EPSG:32613", True))
+        self.assertEqual(prj.readBoolEntry("PAL", "/ShowingCandidates"), (False, True))
+        self.assertEqual(prj.readNumEntry("PAL", "/CandidatesPolygon"), (8., True))
+        self.assertEqual(prj.readListEntry("TestScope", "/TestListProperty"), (["Entry1", "Entry2"], True))
+
         # invalid key
-        self.assertEqual(prj.readNumEntry("SpatialRefSys", "/InvalidKey", -1)[0], -1)
+        self.assertEqual(prj.readNumEntry("SpatialRefSys", "/InvalidKey", -1), (-1, False))
+        self.assertEqual(prj.readEntry("SpatialRefSys", "/InvalidKey", "wrong"), ("wrong", False))
+        self.assertEqual(prj.readBoolEntry("PAL", "/InvalidKey", True), (True, False))
+        self.assertEqual(prj.readDoubleEntry("PAL", "/InvalidKey", 42.), (42., False))
+        self.assertEqual(prj.readListEntry("TestScope", "/InvalidKey", ["Default1", "Default2"]), (["Default1", "Default2"], False))
 
     def testEmbeddedGroup(self):
         testdata_path = unitTestDataPath('embedded_groups') + '/'


### PR DESCRIPTION
Backport #39426 in 3.10