### PR TITLE
Option to add field constraint hints via programatic call in "Refactor field"

### DIFF
--- a/src/gui/processing/qgsprocessingfieldmapwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingfieldmapwidgetwrapper.cpp
@@ -120,6 +120,7 @@ void QgsProcessingFieldMapPanelWidget::setValue( const QVariant &value )
   QgsFields destinationFields;
   QMap<QString, QString> expressions;
 
+  const QgsFields layerFields = mLayer ? mLayer->fields() : QgsFields();
   const QVariantList fields = value.toList();
   for ( const QVariant &field : fields )
   {
@@ -129,6 +130,27 @@ void QgsProcessingFieldMapPanelWidget::setValue( const QVariant &value )
                 QVariant::typeToName( static_cast< QVariant::Type >( map.value( QStringLiteral( "type" ), QVariant::Invalid ).toInt() ) ),
                 map.value( QStringLiteral( "length" ), 0 ).toInt(),
                 map.value( QStringLiteral( "precision" ), 0 ).toInt() );
+
+    int layerFieldIdx = layerFields.indexFromName( f.name() );
+
+    if ( mLayer && layerFieldIdx >= 0 && ! map.contains( QStringLiteral( "constraints" ) ) )
+    {
+      f.setConstraints( layerFields.at( layerFieldIdx ).constraints() );
+    }
+    else
+    {
+      const QgsFieldConstraints::Constraints constraints = static_cast<QgsFieldConstraints::Constraints>( map.value( QStringLiteral( "constraints" ), 0 ).toInt() );
+      QgsFieldConstraints fieldConstraints;
+
+      if ( constraints & QgsFieldConstraints::ConstraintNotNull )
+        fieldConstraints.setConstraint( QgsFieldConstraints::ConstraintNotNull );
+      if ( constraints & QgsFieldConstraints::ConstraintUnique )
+        fieldConstraints.setConstraint( QgsFieldConstraints::ConstraintUnique );
+      if ( constraints & QgsFieldConstraints::ConstraintExpression )
+        fieldConstraints.setConstraint( QgsFieldConstraints::ConstraintUnique );
+
+      f.setConstraints( fieldConstraints );
+    }
 
     if ( !map.value( QStringLiteral( "expression" ) ).toString().isEmpty() )
     {

--- a/src/gui/processing/qgsprocessingfieldmapwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingfieldmapwidgetwrapper.cpp
@@ -147,7 +147,7 @@ void QgsProcessingFieldMapPanelWidget::setValue( const QVariant &value )
       if ( constraints & QgsFieldConstraints::ConstraintUnique )
         fieldConstraints.setConstraint( QgsFieldConstraints::ConstraintUnique );
       if ( constraints & QgsFieldConstraints::ConstraintExpression )
-        fieldConstraints.setConstraint( QgsFieldConstraints::ConstraintUnique );
+        fieldConstraints.setConstraint( QgsFieldConstraints::ConstraintExpression );
 
       f.setConstraints( fieldConstraints );
     }
@@ -414,5 +414,4 @@ const QgsVectorLayer *QgsProcessingFieldMapWidgetWrapper::linkedVectorLayer() co
 }
 
 /// @endcond
-
 


### PR DESCRIPTION
Allows to programatically open the algorithm dialog with preset constraint hints.

![image](https://user-images.githubusercontent.com/2820439/96720296-41444900-13b3-11eb-8d16-6715f074dfcf.png)


Test with:
```
dlg = processing.createAlgorithmDialog("native:refactorfields", { 
    'FIELDS_MAPPING' : [
        {'expression': '\"id\"','length': -1,'name': 'id','precision': 0,'type': 2},
        {'expression': '4','length': -1,'name': 'name1','precision': 0,'type': 10, 'constraints': QgsFieldConstraints.ConstraintNotNull | QgsFieldConstraints.ConstraintUnique}
        ], 
    'INPUT' : 'memory://Point?crs=EPSG:4326&field=id:integer(-1,0)&field=name:string(-1,0)', 
    'OUTPUT' : '/home/suricactus/projects/tmp/asd1.gpkg' })
res = dlg.exec_()
```