### PR TITLE
QgisApp::askUserForOGRSublayers(): make sure all layers get opened with the same GDAL datasets

### DIFF
--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2034,9 +2034,10 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     /**
      * This method will open a dialog so the user can select OGR sublayers to load,
-     * and then returns a list of these layers.
+     * and then returns a list of these layers. It will destroy the passed layer
+     * in the process
      */
-    QList< QgsMapLayer * > askUserForOGRSublayers( QgsVectorLayer *layer, const QStringList &subLayers );
+    QList< QgsMapLayer * > askUserForOGRSublayers( QgsVectorLayer *&layerTransferOwnership, const QStringList &subLayers );
 
     /**
      * Add a raster layer to the map (passed in as a ptr).


### PR DESCRIPTION
This fixes a scenario inspired from #39431, but doesn't fix the exact one
of that ticket.

The scenario fixed by this ticket is:
- Enable grouped transaction in project settings
- Open a GeoPackage with 2 layers 'a' and 'b'
- Toggle edit mode
- Create a feature in 'a'
- Create a feature in 'b' -> when validating an error message of database
  locked would appear without this fix

The reason is that the 2 layers got opened in 2 separate GDAL datasets,
and this doesn't play well with the grouped transaction mechanism that will
start a transaction in each dataset. SQLite locking will then kick in.
So here we avoid this to happen by making sure the OGRProvider that is used
to return the list of sublayers is closed before opening them. That way the
mechanism in the OGR provider to share the same GDALDataset works.

This actaally explains why the scenario in #39431 still fails. When we
create the second layer, the OGR provider cannot re-use the GDALDataset used
to open the first layer, as it got modified in between (see
https://github.com/qgis/QGIS/pull/5689#issuecomment-346625386 for a case
where this was needed), and in particular doesn't know there are now 2 layers.
So we end up having 2 GDALDataset opened on the same .gpkg file and starting
transactions...

Fixing #39431 would propably require to modify QgsNewGeoPackageLayerDialog::apply()
to possibly use an existing GDALDataset openeded and cached in
QgsOgrProvider::sMapSharedDS global map.
Probably better, make QgsNewGeoPackageLayerDialog::apply() use
QgsOgrProvider::createEmptyLayer(), and modify that one to reuse an
existing GDALDataset, and no longer call QgsOgrProviderUtils::invalidateCachedLastModifiedDate()
