### PR TITLE
Set a clear value for spinboxes to avoid clear icon for default values

### DIFF
--- a/src/app/3d/qgs3danimationexportdialog.cpp
+++ b/src/app/3d/qgs3danimationexportdialog.cpp
@@ -31,6 +31,9 @@
 Qgs3DAnimationExportDialog::Qgs3DAnimationExportDialog(): QDialog( nullptr )
 {
   setupUi( this );
+  mFpsSpinBox->setClearValue( 30 );
+  mWidthSpinBox->setClearValue( 800 );
+  mHeightSpinBox->setClearValue( 600 );
   QgsSettings settings;
 
   const QString templateText = settings.value( QStringLiteral( "Export3DAnimation/fileNameTemplate" ),

--- a/src/app/3d/qgslightswidget.cpp
+++ b/src/app/3d/qgslightswidget.cpp
@@ -34,9 +34,6 @@ QgsLightsWidget::QgsLightsWidget( QWidget *parent )
   spinA0->setClearValue( 0.0 );
   spinA1->setClearValue( 0.0 );
   spinA2->setClearValue( 0.0 );
-  spinDirectionX->setClearValue( 0.0 );
-  spinDirectionY->setClearValue( -1.0 );
-  spinDirectionZ->setClearValue( 0.0 );
   spinDirectionalIntensity->setClearValue( 0.5 );
 
   mLightsModel = new QgsLightsModel( this );

--- a/src/app/3d/qgslightswidget.cpp
+++ b/src/app/3d/qgslightswidget.cpp
@@ -35,7 +35,7 @@ QgsLightsWidget::QgsLightsWidget( QWidget *parent )
   spinA1->setClearValue( 0.0 );
   spinA2->setClearValue( 0.0 );
   spinDirectionX->setClearValue( 0.0 );
-  spinDirectionY->setClearValue( 0.0 );
+  spinDirectionY->setClearValue( -1.0 );
   spinDirectionZ->setClearValue( 0.0 );
   spinDirectionalIntensity->setClearValue( 0.0 );
 

--- a/src/app/3d/qgslightswidget.cpp
+++ b/src/app/3d/qgslightswidget.cpp
@@ -37,7 +37,7 @@ QgsLightsWidget::QgsLightsWidget( QWidget *parent )
   spinDirectionX->setClearValue( 0.0 );
   spinDirectionY->setClearValue( -1.0 );
   spinDirectionZ->setClearValue( 0.0 );
-  spinDirectionalIntensity->setClearValue( 0.0 );
+  spinDirectionalIntensity->setClearValue( 0.5 );
 
   mLightsModel = new QgsLightsModel( this );
   mLightsListView->setModel( mLightsModel );

--- a/src/app/3d/qgslightswidget.cpp
+++ b/src/app/3d/qgslightswidget.cpp
@@ -27,6 +27,18 @@ QgsLightsWidget::QgsLightsWidget( QWidget *parent )
 {
   setupUi( this );
 
+  spinPositionX->setClearValue( 0.0 );
+  spinPositionY->setClearValue( 1000.0 );
+  spinPositionZ->setClearValue( 0.0 );
+  spinIntensity->setClearValue( 0.5 );
+  spinA0->setClearValue( 0.0 );
+  spinA1->setClearValue( 0.0 );
+  spinA2->setClearValue( 0.0 );
+  spinDirectionX->setClearValue( 0.0 );
+  spinDirectionY->setClearValue( 0.0 );
+  spinDirectionZ->setClearValue( 0.0 );
+  spinDirectionalIntensity->setClearValue( 0.0 );
+
   mLightsModel = new QgsLightsModel( this );
   mLightsListView->setModel( mLightsModel );
 

--- a/src/app/3d/qgsmap3dexportwidget.cpp
+++ b/src/app/3d/qgsmap3dexportwidget.cpp
@@ -32,6 +32,9 @@ QgsMap3DExportWidget::QgsMap3DExportWidget( Qgs3DMapScene *scene, Qgs3DMapExport
   mExportSettings( exportSettings )
 {
   ui->setupUi( this );
+  ui->terrainResolutionSpinBox->setClearValue( 128 );
+  ui->terrainTextureResolutionSpinBox->setClearValue( 512 );
+  ui->scaleSpinBox->setClearValue( 1.0 );
 
   ui->selectFolderWidget->setStorageMode( QgsFileWidget::StorageMode::GetDirectory );
 

--- a/src/app/3d/qgsmesh3dsymbolwidget.cpp
+++ b/src/app/3d/qgsmesh3dsymbolwidget.cpp
@@ -25,6 +25,9 @@ QgsMesh3dSymbolWidget::QgsMesh3dSymbolWidget( QgsMeshLayer *meshLayer, QWidget *
   : QWidget( parent )
 {
   setupUi( this );
+  mSpinBoxWireframeLineWidth->setClearValue( 1.0 );
+  mSpinBoxVerticaleScale->setClearValue( 1.0 );
+  mArrowsSpacingSpinBox->setClearValue( 25.0 );
 
   mComboBoxTextureType->addItem( tr( "Single Color" ), QgsMesh3DSymbol::SingleColor );
   mComboBoxTextureType->setCurrentIndex( 0 );

--- a/src/app/3d/qgspoint3dsymbolwidget.cpp
+++ b/src/app/3d/qgspoint3dsymbolwidget.cpp
@@ -40,6 +40,14 @@ QgsPoint3DSymbolWidget::QgsPoint3DSymbolWidget( QWidget *parent )
   spinRX->setClearValue( 0.0 );
   spinRY->setClearValue( 0.0 );
   spinRZ->setClearValue( 0.0 );
+  spinRadius->setClearValue( 10.0 );
+  spinMinorRadius->setClearValue( 5.0 );
+  spinTopRadius->setClearValue( 0.0 );
+  spinBottomRadius->setClearValue( 10.0 );
+  spinSize->setClearValue( 10.0 );
+  spinLength->setClearValue( 10.0 );
+  spinTopRadius->setClearValue( 0.0 );
+  spinBillboardHeight->setClearValue( 0.0 );
 
   cboShape->addItem( tr( "Sphere" ), QgsPoint3DSymbol::Sphere );
   cboShape->addItem( tr( "Cylinder" ), QgsPoint3DSymbol::Cylinder );

--- a/src/app/3d/qgspolygon3dsymbolwidget.cpp
+++ b/src/app/3d/qgspolygon3dsymbolwidget.cpp
@@ -24,6 +24,7 @@ QgsPolygon3DSymbolWidget::QgsPolygon3DSymbolWidget( QWidget *parent )
   setupUi( this );
   spinHeight->setClearValue( 0.0 );
   spinExtrusion->setClearValue( 0.0 );
+  spinEdgeWidth->setClearValue( 1.0 );
 
   QgsPolygon3DSymbol defaultSymbol;
   setSymbol( &defaultSymbol, nullptr );

--- a/src/app/3d/qgsvectorlayer3dpropertieswidget.cpp
+++ b/src/app/3d/qgsvectorlayer3dpropertieswidget.cpp
@@ -21,6 +21,7 @@ QgsVectorLayer3DPropertiesWidget::QgsVectorLayer3DPropertiesWidget( QWidget *par
   : QWidget( parent )
 {
   setupUi( this );
+  spinZoomLevelsCount->setClearValue( 3 );
 
   groupLayerRendering->setCollapsed( true );
 

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -257,10 +257,12 @@ QgsGpsInformationWidget::QgsGpsInformationWidget( QgsMapCanvas *mapCanvas, QWidg
   mTravelBearingCheckBox->setChecked( mySettings.value( QStringLiteral( "gps/calculateBearingFromTravel" ), "false" ).toBool() );
   mSliderMarkerSize->setValue( mySettings.value( QStringLiteral( "gps/markerSize" ), "12" ).toInt() );
   mSpinTrackWidth->setValue( mySettings.value( QStringLiteral( "gps/trackWidth" ), "2" ).toInt() );
+  mSpinTrackWidth->setClearValue( 2 );
   mBtnTrackColor->setColor( mySettings.value( QStringLiteral( "gps/trackColor" ), QColor( Qt::red ) ).value<QColor>() );
   QString myPortMode = mySettings.value( QStringLiteral( "gps/portMode" ), "scanPorts" ).toString();
 
   mSpinMapExtentMultiplier->setValue( mySettings.value( QStringLiteral( "gps/mapExtentMultiplier" ), "50" ).toInt() );
+  mSpinMapExtentMultiplier->setClearValue( 50 );
   mDateTimeFormat = mySettings.value( QStringLiteral( "gps/dateTimeFormat" ), "" ).toString(); // zero-length string signifies default format
 
   mGpsdHost->setText( mySettings.value( QStringLiteral( "gps/gpsdHost" ), "localhost" ).toString() );
@@ -421,6 +423,7 @@ QgsGpsInformationWidget::QgsGpsInformationWidget( QgsMapCanvas *mapCanvas, QWidg
   mCbxLeapSeconds->setChecked( mySettings.value( QStringLiteral( "gps/applyLeapSeconds" ), true ).toBool() );
   // Leap seconds as of 2019-06-20, if the default changes, it can be updated in qgis_global_settings.ini
   mLeapSeconds->setValue( mySettings.value( QStringLiteral( "gps/leapSecondsCorrection" ), 18 ).toInt() );
+  mLeapSeconds->setClearValue( 18 );
 
   connect( mAcquisitionTimer.get(), &QTimer::timeout,
            this, &QgsGpsInformationWidget::switchAcquisition );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -174,14 +174,17 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   if ( identifyValue <= 0.0 )
     identifyValue = Qgis::DEFAULT_SEARCH_RADIUS_MM;
   spinBoxIdentifyValue->setMinimum( 0.0 );
+  spinBoxIdentifyValue->setClearValue( Qgis::DEFAULT_SEARCH_RADIUS_MM );
   spinBoxIdentifyValue->setValue( identifyValue );
   QColor highlightColor = QColor( mSettings->value( QStringLiteral( "/Map/highlight/color" ), Qgis::DEFAULT_HIGHLIGHT_COLOR.name() ).toString() );
   int highlightAlpha = mSettings->value( QStringLiteral( "/Map/highlight/colorAlpha" ), Qgis::DEFAULT_HIGHLIGHT_COLOR.alpha() ).toInt();
   highlightColor.setAlpha( highlightAlpha );
   mIdentifyHighlightColorButton->setColor( highlightColor );
   double highlightBuffer = mSettings->value( QStringLiteral( "/Map/highlight/buffer" ), Qgis::DEFAULT_HIGHLIGHT_BUFFER_MM ).toDouble();
+  mIdentifyHighlightBufferSpinBox->setClearValue( Qgis::DEFAULT_HIGHLIGHT_BUFFER_MM );
   mIdentifyHighlightBufferSpinBox->setValue( highlightBuffer );
   double highlightMinWidth = mSettings->value( QStringLiteral( "/Map/highlight/minWidth" ), Qgis::DEFAULT_HIGHLIGHT_MIN_WIDTH_MM ).toDouble();
+  mIdentifyHighlightMinWidthSpinBox->setClearValue( Qgis::DEFAULT_HIGHLIGHT_MIN_WIDTH_MM );
   mIdentifyHighlightMinWidthSpinBox->setValue( highlightMinWidth );
 
   // custom environment variables
@@ -351,16 +354,20 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
   //Network timeout
   mNetworkTimeoutSpinBox->setValue( QgsNetworkAccessManager::timeout() );
+  mNetworkTimeoutSpinBox->setClearValue( QgsNetworkAccessManager::timeout() );
   leUserAgent->setText( mSettings->value( QStringLiteral( "/qgis/networkAndProxy/userAgent" ), "Mozilla/5.0" ).toString() );
 
   // WMS capabilities expiry time
   mDefaultCapabilitiesExpirySpinBox->setValue( mSettings->value( QStringLiteral( "/qgis/defaultCapabilitiesExpiry" ), 24 ).toInt() );
+  mDefaultCapabilitiesExpirySpinBox->setClearValue( 24 );
 
   // WMS/WMS-C tile expiry time
   mDefaultTileExpirySpinBox->setValue( mSettings->value( QStringLiteral( "/qgis/defaultTileExpiry" ), 24 ).toInt() );
+  mDefaultTileExpirySpinBox->setClearValue( 24 );
 
   // WMS/WMS-C default max retry in case of tile request errors
   mDefaultTileMaxRetrySpinBox->setValue( mSettings->value( QStringLiteral( "/qgis/defaultTileMaxRetry" ), 3 ).toInt() );
+  mDefaultTileMaxRetrySpinBox->setClearValue( 3 );
 
   // Proxy stored authentication configurations
   mAuthSettings->setDataprovider( QStringLiteral( "proxy" ) );
@@ -408,6 +415,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mCacheSize->setSingleStep( 1024 );
   qint64 cacheSize = mSettings->value( QStringLiteral( "cache/size" ), 50 * 1024 * 1024 ).toLongLong();
   mCacheSize->setValue( static_cast<int>( cacheSize / 1024 ) );
+  mCacheSize->setClearValue( static_cast<int>( cacheSize / 1024 ) );
   connect( mBrowseCacheDirectory, &QAbstractButton::clicked, this, &QgsOptions::browseCacheDirectory );
   connect( mClearCache, &QAbstractButton::clicked, this, &QgsOptions::clearCache );
 
@@ -434,6 +442,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mAttrTableViewComboBox->setCurrentIndex( mAttrTableViewComboBox->findData( mSettings->value( QStringLiteral( "/qgis/attributeTableView" ), -1 ).toInt() ) );
 
   spinBoxAttrTableRowCache->setValue( mSettings->value( QStringLiteral( "/qgis/attributeTableRowCache" ), 10000 ).toInt() );
+  spinBoxAttrTableRowCache->setClearValue ( 10000 );
   spinBoxAttrTableRowCache->setSpecialValueText( tr( "All" ) );
 
   cmbPromptSublayers->clear();
@@ -566,6 +575,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
   // set decimal places of the measure tool
   int decimalPlaces = mSettings->value( QStringLiteral( "/qgis/measure/decimalplaces" ), "3" ).toInt();
+  mDecimalPlacesSpinBox->setClearValue( 3 );
   mDecimalPlacesSpinBox->setRange( 0, 12 );
   mDecimalPlacesSpinBox->setValue( decimalPlaces );
 
@@ -612,6 +622,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mFontFamilyComboBox->blockSignals( false );
 
   mMessageTimeoutSpnBx->setValue( mSettings->value( QStringLiteral( "/qgis/messageTimeout" ), 5 ).toInt() );
+  mMessageTimeoutSpnBx->setClearValue( 5 );
 
   QString name = mSettings->value( QStringLiteral( "/qgis/style" ) ).toString();
   whileBlocking( cmbStyle )->setCurrentIndex( cmbStyle->findText( name, Qt::MatchFixedString ) );
@@ -631,6 +642,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   chkUseRenderCaching->setChecked( mSettings->value( QStringLiteral( "/qgis/enable_render_caching" ), true ).toBool() );
   chkParallelRendering->setChecked( mSettings->value( QStringLiteral( "/qgis/parallel_rendering" ), true ).toBool() );
   spinMapUpdateInterval->setValue( mSettings->value( QStringLiteral( "/qgis/map_update_interval" ), 250 ).toInt() );
+  spinMapUpdateInterval->setClearValue( 250 );
   chkMaxThreads->setChecked( QgsApplication::maxThreads() != -1 );
   spinMaxThreads->setEnabled( chkMaxThreads->isChecked() );
   spinMaxThreads->setRange( 1, QThread::idealThreadCount() );
@@ -657,6 +669,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
     tolerance = tolerance * 180.0 / M_PI; //value shown to the user is degree, not rad
   }
   mSegmentationToleranceSpinBox->setValue( tolerance );
+  mSegmentationToleranceSpinBox->setClearValue( 1.0 );
 
   QStringList myScalesList = Qgis::defaultProjectScales().split( ',' );
   myScalesList.append( QStringLiteral( "1:1" ) );
@@ -672,6 +685,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   doubleSpinBoxMagnifierDefault->setDecimals( 0 );
   doubleSpinBoxMagnifierDefault->setSuffix( QStringLiteral( "%" ) );
   doubleSpinBoxMagnifierDefault->setValue( magnifierVal );
+  doubleSpinBoxMagnifierDefault->setClearValue( 100 );
 
   // Default local simplification algorithm
   mSimplifyAlgorithmComboBox->addItem( tr( "Distance" ), static_cast<int>( QgsVectorSimplifyMethod::Distance ) );
@@ -704,13 +718,17 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
   // Map Tips delay
   mMapTipsDelaySpinBox->setValue( mSettings->value( QStringLiteral( "qgis/mapTipsDelay" ), 850 ).toInt() );
+  mMapTipsDelaySpinBox->setClearValue( 850 );
 
   //
   // Raster properties
   //
   spnRed->setValue( mSettings->value( QStringLiteral( "/Raster/defaultRedBand" ), 1 ).toInt() );
+  spnRed->setClearValue( 1 );
   spnGreen->setValue( mSettings->value( QStringLiteral( "/Raster/defaultGreenBand" ), 2 ).toInt() );
+  spnGreen->setClearValue( 2 );
   spnBlue->setValue( mSettings->value( QStringLiteral( "/Raster/defaultBlueBand" ), 3 ).toInt() );
+  spnBlue->setClearValue( 3 );
 
   mZoomedInResamplingComboBox->insertItem( 0, tr( "Nearest neighbour" ), QStringLiteral( "nearest neighbour" ) );
   mZoomedInResamplingComboBox->insertItem( 1, tr( "Bilinear" ), QStringLiteral( "bilinear" ) );
@@ -723,6 +741,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   QString zoomedOutResampling = mSettings->value( QStringLiteral( "/Raster/defaultZoomedOutResampling" ), QStringLiteral( "nearest neighbour" ) ).toString();
   mZoomedOutResamplingComboBox->setCurrentIndex( mZoomedOutResamplingComboBox->findData( zoomedOutResampling ) );
   spnOversampling->setValue( mSettings->value( QStringLiteral( "/Raster/defaultOversampling" ), 2.0 ).toDouble() );
+  spnOversampling->setClearValue( 2.0 );
   mCbEarlyResampling->setChecked( mSettings->value( QStringLiteral( "/Raster/defaultEarlyResampling" ), false ).toBool() );
 
   initContrastEnhancement( cboxContrastEnhancementAlgorithmSingleBand, QStringLiteral( "singleBand" ),
@@ -740,6 +759,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
                     QgsRasterMinMaxOrigin::limitsString( QgsRasterLayer::MULTIPLE_BAND_MULTI_BYTE_MIN_MAX_LIMITS ) );
 
   spnThreeBandStdDev->setValue( mSettings->value( QStringLiteral( "/Raster/defaultStandardDeviation" ), QgsRasterMinMaxOrigin::DEFAULT_STDDEV_FACTOR ).toDouble() );
+  spnThreeBandStdDev->setClearValue( QgsRasterMinMaxOrigin::DEFAULT_STDDEV_FACTOR );
 
   mRasterCumulativeCutLowerDoubleSpinBox->setValue( 100.0 * mSettings->value( QStringLiteral( "/Raster/cumulativeCutLower" ), QString::number( QgsRasterMinMaxOrigin::CUMULATIVE_CUT_LOWER ) ).toDouble() );
   mRasterCumulativeCutUpperDoubleSpinBox->setValue( 100.0 * mSettings->value( QStringLiteral( "/Raster/cumulativeCutUpper" ), QString::number( QgsRasterMinMaxOrigin::CUMULATIVE_CUT_UPPER ) ).toDouble() );
@@ -807,6 +827,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   connect( pbnTemplateFolderReset, &QAbstractButton::pressed, this, &QgsOptions::resetTemplateFolder );
 
   setZoomFactorValue();
+  spinZoomFactor->setClearValue( 200 );
 
   // predefined scales for scale combobox
   QString scalePaths = mSettings->value( QStringLiteral( "Map/scales" ), Qgis::defaultProjectScales() ).toString();
@@ -974,7 +995,9 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
   //grid and guide defaults
   mGridResolutionSpinBox->setValue( mSettings->value( QStringLiteral( "LayoutDesigner/defaultSnapGridResolution" ), 10.0, QgsSettings::Gui ).toDouble() );
+  mGridResolutionSpinBox->setClearValue( 10.0 );
   mSnapToleranceSpinBox->setValue( mSettings->value( QStringLiteral( "LayoutDesigner/defaultSnapTolerancePixels" ), 5, QgsSettings::Gui ).toInt() );
+  mSnapToleranceSpinBox->setClearValue( 5 );
   mOffsetXSpinBox->setValue( mSettings->value( QStringLiteral( "LayoutDesigner/defaultSnapGridOffsetX" ), 0, QgsSettings::Gui ).toDouble() );
   mOffsetYSpinBox->setValue( mSettings->value( QStringLiteral( "LayoutDesigner/defaultSnapGridOffsetY" ), 0, QgsSettings::Gui ).toDouble() );
 
@@ -1042,6 +1065,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mDefaultZValueSpinBox->setValue(
     mSettings->value( QStringLiteral( "/qgis/digitizing/default_z_value" ), Qgis::DEFAULT_Z_COORDINATE ).toDouble()
   );
+  mDefaultZValueSpinBox->setClearValue( Qgis::DEFAULT_Z_COORDINATE );
 
   //default snap mode
   mSnappingEnabledDefault->setChecked( mSettings->value( QStringLiteral( "/qgis/digitizing/default_snap_enabled" ),  false ).toBool() );
@@ -1054,7 +1078,9 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   QgsSnappingConfig::SnappingTypeFlag defaultSnapMode = mSettings->flagValue( QStringLiteral( "/qgis/digitizing/default_snap_type" ),  QgsSnappingConfig::VertexFlag );
   mDefaultSnapModeComboBox->setCurrentIndex( mDefaultSnapModeComboBox->findData( static_cast<int>( defaultSnapMode ) ) );
   mDefaultSnappingToleranceSpinBox->setValue( mSettings->value( QStringLiteral( "/qgis/digitizing/default_snapping_tolerance" ), Qgis::DEFAULT_SNAP_TOLERANCE ).toDouble() );
+  mDefaultSnappingToleranceSpinBox->setClearValue( Qgis::DEFAULT_SNAP_TOLERANCE );
   mSearchRadiusVertexEditSpinBox->setValue( mSettings->value( QStringLiteral( "/qgis/digitizing/search_radius_vertex_edit" ), 10 ).toDouble() );
+  mSearchRadiusVertexEditSpinBox->setClearValue( 10 );
   QgsTolerance::UnitType defSnapUnits = mSettings->enumValue( QStringLiteral( "/qgis/digitizing/default_snapping_tolerance_unit" ), Qgis::DEFAULT_SNAP_UNITS );
   if ( defSnapUnits == QgsTolerance::ProjectUnits || defSnapUnits == QgsTolerance::LayerUnits )
   {
@@ -1106,6 +1132,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
     mMarkerStyleComboBox->setCurrentIndex( mMarkerStyleComboBox->findText( tr( "None" ) ) );
   }
   mMarkerSizeSpinBox->setValue( mSettings->value( QStringLiteral( "/qgis/digitizing/marker_size_mm" ), 2.0 ).toDouble() );
+  mMarkerSizeSpinBox->setClearValue( 2.0 );
 
   chkReuseLastValues->setChecked( mSettings->value( QStringLiteral( "/qgis/digitizing/reuseLastValues" ), false ).toBool() );
   chkDisableAttributeValuesDlg->setChecked( mSettings->value( QStringLiteral( "/qgis/digitizing/disable_enter_attribute_values_dialog" ), false ).toBool() );
@@ -1122,7 +1149,9 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   QgsGeometry::JoinStyle joinStyleSetting = mSettings->enumValue( QStringLiteral( "/qgis/digitizing/offset_join_style" ), QgsGeometry::JoinStyleRound );
   mOffsetJoinStyleComboBox->setCurrentIndex( mOffsetJoinStyleComboBox->findData( joinStyleSetting ) );
   mOffsetQuadSegSpinBox->setValue( mSettings->value( QStringLiteral( "/qgis/digitizing/offset_quad_seg" ), 8 ).toInt() );
+  mOffsetQuadSegSpinBox->setClearValue( 8 );
   mCurveOffsetMiterLimitComboBox->setValue( mSettings->value( QStringLiteral( "/qgis/digitizing/offset_miter_limit" ), 5.0 ).toDouble() );
+  mCurveOffsetMiterLimitComboBox->setClearValue( 5.0 );
 
   mTracingConvertToCurveCheckBox->setChecked( mSettings->value( QStringLiteral( "/qgis/digitizing/convert_to_curve" ), false ).toBool() );
 

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -415,7 +415,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mCacheSize->setSingleStep( 1024 );
   qint64 cacheSize = mSettings->value( QStringLiteral( "cache/size" ), 50 * 1024 * 1024 ).toLongLong();
   mCacheSize->setValue( static_cast<int>( cacheSize / 1024 ) );
-  mCacheSize->setClearValue( static_cast<int>( cacheSize / 1024 ) );
+  mCacheSize->setClearValue( 50 * 1024 );
   connect( mBrowseCacheDirectory, &QAbstractButton::clicked, this, &QgsOptions::browseCacheDirectory );
   connect( mClearCache, &QAbstractButton::clicked, this, &QgsOptions::clearCache );
 

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -354,7 +354,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
   //Network timeout
   mNetworkTimeoutSpinBox->setValue( QgsNetworkAccessManager::timeout() );
-  mNetworkTimeoutSpinBox->setClearValue( QgsNetworkAccessManager::timeout() );
+  mNetworkTimeoutSpinBox->setClearValue( 60000 );
   leUserAgent->setText( mSettings->value( QStringLiteral( "/qgis/networkAndProxy/userAgent" ), "Mozilla/5.0" ).toString() );
 
   // WMS capabilities expiry time

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -442,7 +442,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mAttrTableViewComboBox->setCurrentIndex( mAttrTableViewComboBox->findData( mSettings->value( QStringLiteral( "/qgis/attributeTableView" ), -1 ).toInt() ) );
 
   spinBoxAttrTableRowCache->setValue( mSettings->value( QStringLiteral( "/qgis/attributeTableRowCache" ), 10000 ).toInt() );
-  spinBoxAttrTableRowCache->setClearValue ( 10000 );
+  spinBoxAttrTableRowCache->setClearValue( 10000 );
   spinBoxAttrTableRowCache->setSpecialValueText( tr( "All" ) );
 
   cmbPromptSublayers->clear();

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -661,6 +661,7 @@ QgsOffsetUserWidget::QgsOffsetUserWidget( QWidget *parent )
   setupUi( this );
 
   mOffsetSpinBox->setDecimals( 6 );
+  mOffsetSpinBox->setClearValue( 0.0 );
 
   // fill comboboxes
   mJoinStyleComboBox->addItem( tr( "Round" ), QgsGeometry::JoinStyleRound );
@@ -678,7 +679,9 @@ QgsOffsetUserWidget::QgsOffsetUserWidget( QWidget *parent )
 
   mJoinStyleComboBox->setCurrentIndex( mJoinStyleComboBox->findData( joinStyle ) );
   mQuadrantSpinBox->setValue( quadSegments );
+  mQuadrantSpinBox->setClearValue( 8 );
   mMiterLimitSpinBox->setValue( miterLimit );
+  mMiterLimitSpinBox->setClearValue( 5.0 );
   mCapStyleComboBox->setCurrentIndex( mCapStyleComboBox->findData( capStyle ) );
 
   // connect signals

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -589,6 +589,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   {
     mWMSPrecisionSpinBox->setValue( WMSprecision );
   }
+  mWMSPrecisionSpinBox->setClearValue( 8 );
 
   bool ok = false;
   QStringList values;
@@ -678,11 +679,13 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   {
     mWMSImageQualitySpinBox->setValue( imageQuality );
   }
+  mWMSImageQualitySpinBox->setClearValue( 90 );
 
   // WMS tileBuffer
   mWMSTileBufferSpinBox->setValue( QgsProject::instance()->readNumEntry( QStringLiteral( "WMSTileBuffer" ), QStringLiteral( "/" ), 0 ) );
 
   mWMSMaxAtlasFeaturesSpinBox->setValue( QgsProject::instance()->readNumEntry( QStringLiteral( "WMSMaxAtlasFeatures" ), QStringLiteral( "/" ), 1 ) );
+  mWMSMaxAtlasFeaturesSpinBox->setClearValue( 1 );
 
   QString defaultValueToolTip = tr( "In case of no other information to evaluate the map unit sized symbols, it uses default scale (on projected CRS) or default map units per mm (on geographic CRS)." );
   if ( QgsProject::instance()->crs().isGeographic() )
@@ -704,7 +707,8 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   }
 
   mWMTSUrlLineEdit->setText( QgsProject::instance()->readEntry( QStringLiteral( "WMTSUrl" ), QStringLiteral( "/" ), QString() ) );
-  mWMTSMinScaleLineEdit->setValue( QgsProject::instance()->readNumEntry( QStringLiteral( "WMTSMinScale" ), QStringLiteral( "/" ), 5000 ) );
+  mWMTSMinScaleSpinBox->setValue( QgsProject::instance()->readNumEntry( QStringLiteral( "WMTSMinScale" ), QStringLiteral( "/" ), 5000 ) );
+  mWMTSMinScaleSpinBox->setClearValue( 5000 );
 
   bool wmtsProject = QgsProject::instance()->readBoolEntry( QStringLiteral( "WMTSLayers" ), QStringLiteral( "Project" ) );
   bool wmtsPngProject = QgsProject::instance()->readBoolEntry( QStringLiteral( "WMTSPngLayers" ), QStringLiteral( "Project" ) );
@@ -1399,7 +1403,7 @@ void QgsProjectProperties::apply()
   }
 
   QgsProject::instance()->writeEntry( QStringLiteral( "WMTSUrl" ), QStringLiteral( "/" ), mWMTSUrlLineEdit->text() );
-  QgsProject::instance()->writeEntry( QStringLiteral( "WMTSMinScale" ), QStringLiteral( "/" ), mWMTSMinScaleLineEdit->value() );
+  QgsProject::instance()->writeEntry( QStringLiteral( "WMTSMinScale" ), QStringLiteral( "/" ), mWMTSMinScaleSpinBox->value() );
   bool wmtsProject = false;
   bool wmtsPngProject = false;
   bool wmtsJpegProject = false;

--- a/src/gui/auth/qgsauthsslimportdialog.cpp
+++ b/src/gui/auth/qgsauthsslimportdialog.cpp
@@ -104,7 +104,9 @@ QgsAuthSslImportDialog::QgsAuthSslImportDialog( QWidget *parent )
 
     leServer->setSelection( 0, leServer->text().size() );
     pteSessionStatus->setReadOnly( true );
+    spinbxTimeout->setClearValue( 15 );
     spinbxTimeout->setValue( 15 );
+    spinbxPort->setClearValue( 443 );
 
     grpbxServer->setCollapsed( false );
     radioServerImport->setChecked( true );

--- a/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
@@ -21,6 +21,7 @@ QgsRangeConfigDlg::QgsRangeConfigDlg( QgsVectorLayer *vl, int fieldIdx, QWidget 
   : QgsEditorConfigWidget( vl, fieldIdx, parent )
 {
   setupUi( this );
+  precisionSpinBox->setClearValue( 4 );
 
   minimumSpinBox->setMinimum( std::numeric_limits<int>::lowest() );
   minimumSpinBox->setMaximum( std::numeric_limits<int>::max() );
@@ -32,6 +33,7 @@ QgsRangeConfigDlg::QgsRangeConfigDlg( QgsVectorLayer *vl, int fieldIdx, QWidget 
 
   stepSpinBox->setMaximum( std::numeric_limits<int>::max() );
   stepSpinBox->setValue( 1 );
+  stepSpinBox->setClearValue( 1 );
 
   minimumDoubleSpinBox->setMinimum( std::numeric_limits<double>::lowest() );
   minimumDoubleSpinBox->setMaximum( std::numeric_limits<double>::max() );
@@ -44,6 +46,7 @@ QgsRangeConfigDlg::QgsRangeConfigDlg( QgsVectorLayer *vl, int fieldIdx, QWidget 
   // Use integer here:
   stepDoubleSpinBox->setMaximum( std::numeric_limits<int>::max() );
   stepDoubleSpinBox->setValue( 1 );
+  stepDoubleSpinBox->setClearValue( 1 );
 
 
   QString text;

--- a/src/gui/effects/qgspainteffectwidget.cpp
+++ b/src/gui/effects/qgspainteffectwidget.cpp
@@ -850,6 +850,7 @@ QgsColorEffectWidget::QgsColorEffectWidget( QWidget *parent )
   mBrightnessSpinBox->setClearValue( 0 );
   mContrastSpinBox->setClearValue( 0 );
   mSaturationSpinBox->setClearValue( 0 );
+  mColorizeStrengthSpinBox->setClearValue( 100 );
   mColorizeColorButton->setAllowOpacity( false );
 
   mGrayscaleCombo->addItem( tr( "Off" ), QgsImageOperation::GrayscaleOff );

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -58,6 +58,9 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   mConfigWidgets << mRendererMeshPropertiesWidget;
   mOptsPage_StyleContent->layout()->addWidget( mRendererMeshPropertiesWidget );
 
+  mSimplifyReductionFactorSpinBox->setClearValue( 10.0 );
+  mSimplifyMeshResolutionSpinBox->setClearValue( 5 );
+
   mStaticDatasetWidget->setLayer( mMeshLayer );
   mIsMapSettingsTemporal = mMeshLayer && canvas && canvas->mapSettings().isTemporal();
 

--- a/src/gui/mesh/qgsmeshrenderervectorsettingswidget.cpp
+++ b/src/gui/mesh/qgsmeshrenderervectorsettingswidget.cpp
@@ -29,6 +29,12 @@ QgsMeshRendererVectorSettingsWidget::QgsMeshRendererVectorSettingsWidget( QWidge
   mColoringMethodComboBox->addItem( tr( "Single Color" ), QgsInterpolatedLineColor::SingleColor );
   mColoringMethodComboBox->addItem( tr( "Color Ramp Shader" ), QgsInterpolatedLineColor::ColorRamp );
 
+  mXSpacingSpinBox->setClearValue( 10.0 );
+  mYSpacingSpinBox->setClearValue( 10.0 );
+  mStreamlinesDensitySpinBox->setClearValue( 5.0 );
+  mTracesParticlesCountSpinBox->setClearValue( 1000 );
+  mTracesMaxLengthSpinBox->setClearValue( 100.0 );
+
   connect( mColorWidget, &QgsColorButton::colorChanged, this, &QgsMeshRendererVectorSettingsWidget::widgetChanged );
   connect( mColoringMethodComboBox, qgis::overload<int>::of( &QComboBox::currentIndexChanged ),
            this, &QgsMeshRendererVectorSettingsWidget::onColoringMethodChanged );

--- a/src/gui/mesh/qgsmeshrenderervectorsettingswidget.cpp
+++ b/src/gui/mesh/qgsmeshrenderervectorsettingswidget.cpp
@@ -31,7 +31,7 @@ QgsMeshRendererVectorSettingsWidget::QgsMeshRendererVectorSettingsWidget( QWidge
 
   mXSpacingSpinBox->setClearValue( 10.0 );
   mYSpacingSpinBox->setClearValue( 10.0 );
-  mStreamlinesDensitySpinBox->setClearValue( 5.0 );
+  mStreamlinesDensitySpinBox->setClearValue( 15.0 );
   mTracesParticlesCountSpinBox->setClearValue( 1000 );
   mTracesMaxLengthSpinBox->setClearValue( 100.0 );
 

--- a/src/gui/numericformats/qgsnumericformatwidget.cpp
+++ b/src/gui/numericformats/qgsnumericformatwidget.cpp
@@ -33,6 +33,7 @@ QgsBasicNumericFormatWidget::QgsBasicNumericFormatWidget( const QgsNumericFormat
   setupUi( this );
   setFormat( format->clone() );
 
+  mDecimalsSpinBox->setClearValue( 6 );
   mThousandsLineEdit->setShowClearButton( true );
   mDecimalLineEdit->setShowClearButton( true );
 
@@ -140,6 +141,7 @@ QgsBearingNumericFormatWidget::QgsBearingNumericFormatWidget( const QgsNumericFo
 {
   setupUi( this );
 
+  mDecimalsSpinBox->setClearValue( 6 );
   mFormatComboBox->addItem( QObject::tr( "0 to 180°, with E/W suffix" ), QgsBearingNumericFormat::UseRange0To180WithEWDirectionalSuffix );
   mFormatComboBox->addItem( QObject::tr( "-180 to +180°" ), QgsBearingNumericFormat::UseRangeNegative180ToPositive180 );
   mFormatComboBox->addItem( QObject::tr( "0 to 360°" ), QgsBearingNumericFormat::UseRange0To360 );
@@ -223,6 +225,7 @@ QgsCurrencyNumericFormatWidget::QgsCurrencyNumericFormatWidget( const QgsNumeric
   : QgsNumericFormatWidget( parent )
 {
   setupUi( this );
+  mDecimalsSpinBox->setClearValue( 2 );
   setFormat( format->clone() );
 
   connect( mShowPlusCheckBox, &QCheckBox::toggled, this, [ = ]( bool checked )
@@ -300,6 +303,7 @@ QgsPercentageNumericFormatWidget::QgsPercentageNumericFormatWidget( const QgsNum
 {
   setupUi( this );
 
+  mDecimalsSpinBox->setClearValue( 6 );
   mScalingComboBox->addItem( QObject::tr( "Values are Percentages (e.g. 50)" ), QgsPercentageNumericFormat::ValuesArePercentage );
   mScalingComboBox->addItem( QObject::tr( "Values are Fractions (e.g. 0.5)" ), QgsPercentageNumericFormat::ValuesAreFractions );
 
@@ -368,6 +372,7 @@ QgsScientificNumericFormatWidget::QgsScientificNumericFormatWidget( const QgsNum
   : QgsNumericFormatWidget( parent )
 {
   setupUi( this );
+  mDecimalsSpinBox->setClearValue( 6 );
   setFormat( format->clone() );
 
   connect( mShowPlusCheckBox, &QCheckBox::toggled, this, [ = ]( bool checked )

--- a/src/gui/qgsaddattrdialog.cpp
+++ b/src/gui/qgsaddattrdialog.cpp
@@ -55,7 +55,9 @@ QgsAddAttrDialog::QgsAddAttrDialog( QgsVectorLayer *vlayer, QWidget *parent, Qt:
 
   //default values for field width and precision
   mLength->setValue( 10 );
+  mLength->setClearValue( 10 );
   mPrec->setValue( 3 );
+  mPrec->setClearValue( 3 );
   mTypeBox_currentIndexChanged( 0 );
 
   if ( mIsShapeFile )

--- a/src/gui/qgslimitedrandomcolorrampdialog.cpp
+++ b/src/gui/qgslimitedrandomcolorrampdialog.cpp
@@ -28,6 +28,13 @@ QgsLimitedRandomColorRampWidget::QgsLimitedRandomColorRampWidget( const QgsLimit
   , mRamp( ramp )
 {
   setupUi( this );
+  spinCount->setClearValue( 10 );
+  spinHue1->setClearValue( 0 );
+  spinHue2->setClearValue( 359 );
+  spinSat1->setClearValue( 100 );
+  spinSat2->setClearValue( 240 );
+  spinVal1->setClearValue( 200 );
+  spinVal2->setClearValue( 240 );
 
   updateUi();
 

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -160,21 +160,26 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
   // brightness/contrast controls
   connect( mSliderBrightness, &QAbstractSlider::valueChanged, mBrightnessSpinBox, &QSpinBox::setValue );
   connect( mBrightnessSpinBox, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), mSliderBrightness, &QAbstractSlider::setValue );
+  mBrightnessSpinBox->setClearValue( 0 );
 
   connect( mSliderContrast, &QAbstractSlider::valueChanged, mContrastSpinBox, &QSpinBox::setValue );
   connect( mContrastSpinBox, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), mSliderContrast, &QAbstractSlider::setValue );
+  mContrastSpinBox->setClearValue( 0 );
 
   // gamma correction controls
   connect( mSliderGamma, &QAbstractSlider::valueChanged, this, &QgsRasterLayerProperties::updateGammaSpinBox );
   connect( mGammaSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsRasterLayerProperties::updateGammaSlider );
+  mGammaSpinBox->setClearValue( 1.0 );
 
   // Connect saturation slider and spin box
   connect( sliderSaturation, &QAbstractSlider::valueChanged, spinBoxSaturation, &QSpinBox::setValue );
   connect( spinBoxSaturation, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), sliderSaturation, &QAbstractSlider::setValue );
+  spinBoxSaturation->setClearValue( 0 );
 
   // Connect colorize strength slider and spin box
   connect( sliderColorizeStrength, &QAbstractSlider::valueChanged, spinColorizeStrength, &QSpinBox::setValue );
   connect( spinColorizeStrength, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), sliderColorizeStrength, &QAbstractSlider::setValue );
+  spinColorizeStrength->setClearValue( 100 );
 
   // enable or disable saturation slider and spin box depending on grayscale combo choice
   connect( comboGrayscale, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsRasterLayerProperties::toggleSaturationControls );

--- a/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
@@ -70,20 +70,25 @@ QgsRendererRasterPropertiesWidget::QgsRendererRasterPropertiesWidget( QgsMapLaye
 
   connect( mSliderBrightness, &QAbstractSlider::valueChanged, mBrightnessSpinBox, &QSpinBox::setValue );
   connect( mBrightnessSpinBox, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), mSliderBrightness, &QAbstractSlider::setValue );
+  mBrightnessSpinBox->setClearValue( 0 );
 
   connect( mSliderContrast, &QAbstractSlider::valueChanged, mContrastSpinBox, &QSpinBox::setValue );
   connect( mContrastSpinBox, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), mSliderContrast, &QAbstractSlider::setValue );
+  mContrastSpinBox->setClearValue( 0 );
 
   connect( mSliderGamma, &QAbstractSlider::valueChanged, this, &QgsRendererRasterPropertiesWidget::updateGammaSpinBox );
   connect( mGammaSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsRendererRasterPropertiesWidget::updateGammaSlider );
+  mGammaSpinBox->setClearValue( 1.0 );
 
   // Connect saturation slider and spin box
   connect( sliderSaturation, &QAbstractSlider::valueChanged, spinBoxSaturation, &QSpinBox::setValue );
   connect( spinBoxSaturation, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), sliderSaturation, &QAbstractSlider::setValue );
+  spinBoxSaturation->setClearValue( 0 );
 
   // Connect colorize strength slider and spin box
   connect( sliderColorizeStrength, &QAbstractSlider::valueChanged, spinColorizeStrength, &QSpinBox::setValue );
   connect( spinColorizeStrength, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), sliderColorizeStrength, &QAbstractSlider::setValue );
+  spinColorizeStrength->setClearValue( 100 );
 
   // enable or disable saturation slider and spin box depending on grayscale combo choice
   connect( comboGrayscale, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsRendererRasterPropertiesWidget::toggleSaturationControls );

--- a/src/gui/symbology/qgs25drendererwidget.cpp
+++ b/src/gui/symbology/qgs25drendererwidget.cpp
@@ -66,11 +66,13 @@ Qgs25DRendererWidget::Qgs25DRendererWidget( QgsVectorLayer *layer, QgsStyle *sty
 
   mHeightWidget->setField( height.isNull() ? QStringLiteral( "10" ) : height.toString() );
   mAngleWidget->setValue( angle.isNull() ? 70 : angle.toDouble() );
+  mAngleWidget->setClearValue( 70 );
   mWallColorButton->setColor( mRenderer->wallColor() );
   mRoofColorButton->setColor( mRenderer->roofColor() );
   mShadowColorButton->setColor( mRenderer->shadowColor() );
   mShadowEnabledWidget->setChecked( mRenderer->shadowEnabled() );
   mShadowSizeWidget->setValue( mRenderer->shadowSpread() );
+  mShadowSizeWidget->setClearValue( 4 );
   mWallExpositionShading->setChecked( mRenderer->wallShadingEnabled() );
 
   connect( mAngleWidget, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &Qgs25DRendererWidget::updateRenderer );

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -490,6 +490,7 @@ QgsGraduatedSymbolRendererWidget::QgsGraduatedSymbolRendererWidget( QgsVectorLay
 
   spinPrecision->setMinimum( QgsClassificationMethod::MIN_PRECISION );
   spinPrecision->setMaximum( QgsClassificationMethod::MAX_PRECISION );
+  spinPrecision->setClearValue( 4 );
 
   spinGraduatedClasses->setShowClearButton( false );
 

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -1584,6 +1584,7 @@ QgsShapeburstFillSymbolLayerWidget::QgsShapeburstFillSymbolLayerWidget( QgsVecto
 
   spinOffsetX->setClearValue( 0.0 );
   spinOffsetY->setClearValue( 0.0 );
+  mSpinMaxDistance->setClearValue( 5.0 );
 
   btnColorRamp->setShowGradientOnly( true );
 

--- a/src/gui/vector/qgsfieldcalculator.cpp
+++ b/src/gui/vector/qgsfieldcalculator.cpp
@@ -82,7 +82,9 @@ QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent )
 
   //default values for field width and precision
   mOutputFieldWidthSpinBox->setValue( 10 );
+  mOutputFieldWidthSpinBox->setClearValue( 10 );
   mOutputFieldPrecisionSpinBox->setValue( 3 );
+  mOutputFieldPrecisionSpinBox->setClearValue( 3 );
   setPrecisionMinMax();
 
   if ( vl->providerType() == QLatin1String( "ogr" ) && vl->storageType() == QLatin1String( "ESRI Shapefile" ) )

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -517,6 +517,7 @@ void QgsVectorLayerProperties::syncToLayer()
   const QgsVectorSimplifyMethod &simplifyMethod = mLayer->simplifyMethod();
   mSimplifyDrawingGroupBox->setChecked( simplifyMethod.simplifyHints() != QgsVectorSimplifyMethod::NoSimplification );
   mSimplifyDrawingSpinBox->setValue( simplifyMethod.threshold() );
+  mSimplifyDrawingSpinBox->setClearValue( 1.0 );
 
   QString remark = QStringLiteral( " (%1)" ).arg( tr( "Not supported" ) );
   const QgsVectorDataProvider *provider = mLayer->dataProvider();

--- a/src/gui/vectortile/qgsarcgisvectortileconnectiondialog.cpp
+++ b/src/gui/vectortile/qgsarcgisvectortileconnectiondialog.cpp
@@ -31,6 +31,7 @@ QgsArcgisVectorTileConnectionDialog::QgsArcgisVectorTileConnectionDialog( QWidge
   // Behavior for min and max zoom checkbox
   connect( mCheckBoxZMin, &QCheckBox::toggled, mSpinZMin, &QSpinBox::setEnabled );
   connect( mCheckBoxZMax, &QCheckBox::toggled, mSpinZMax, &QSpinBox::setEnabled );
+  mSpinZMax->setClearValue( 14 );
 
   buttonBox->button( QDialogButtonBox::Ok )->setDisabled( true );
   connect( mEditName, &QLineEdit::textChanged, this, &QgsArcgisVectorTileConnectionDialog::updateOkButtonState );

--- a/src/gui/vectortile/qgsvectortileconnectiondialog.cpp
+++ b/src/gui/vectortile/qgsvectortileconnectiondialog.cpp
@@ -31,6 +31,7 @@ QgsVectorTileConnectionDialog::QgsVectorTileConnectionDialog( QWidget *parent )
   // Behavior for min and max zoom checkbox
   connect( mCheckBoxZMin, &QCheckBox::toggled, mSpinZMin, &QSpinBox::setEnabled );
   connect( mCheckBoxZMax, &QCheckBox::toggled, mSpinZMax, &QSpinBox::setEnabled );
+  mSpinZMax->setClearValue( 14 );
 
   buttonBox->button( QDialogButtonBox::Ok )->setDisabled( true );
   connect( mEditName, &QLineEdit::textChanged, this, &QgsVectorTileConnectionDialog::updateOkButtonState );

--- a/src/providers/wms/qgsxyzconnectiondialog.cpp
+++ b/src/providers/wms/qgsxyzconnectiondialog.cpp
@@ -28,6 +28,7 @@ QgsXyzConnectionDialog::QgsXyzConnectionDialog( QWidget *parent )
   // Behavior for min and max zoom checkbox
   connect( mCheckBoxZMin, &QCheckBox::toggled, mSpinZMin, &QSpinBox::setEnabled );
   connect( mCheckBoxZMax, &QCheckBox::toggled, mSpinZMax, &QSpinBox::setEnabled );
+  mSpinZMax->setClearValue( 18 );
 
   buttonBox->button( QDialogButtonBox::Ok )->setDisabled( true );
   connect( mEditName, &QLineEdit::textChanged, this, &QgsXyzConnectionDialog::updateOkButtonState );

--- a/src/ui/qgsarcgisvectortileconnectiondialog.ui
+++ b/src/ui/qgsarcgisvectortileconnectiondialog.ui
@@ -96,7 +96,7 @@
        </widget>
       </item>
       <item row="3" column="2">
-       <widget class="QSpinBox" name="mSpinZMin">
+       <widget class="QgsSpinBox" name="mSpinZMin">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -113,7 +113,7 @@
        </widget>
       </item>
       <item row="4" column="2">
-       <widget class="QSpinBox" name="mSpinZMax">
+       <widget class="QgsSpinBox" name="mSpinZMax">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -176,6 +176,11 @@
    <extends>QWidget</extends>
    <header>auth/qgsauthsettingswidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -2626,7 +2626,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QgsSpinBox" name="mWMTSMinScaleLineEdit">
+                     <widget class="QgsSpinBox" name="mWMTSMinScaleSpinBox">
                       <property name="minimum">
                        <number>1</number>
                       </property>
@@ -3278,7 +3278,7 @@
   <tabstop>mMaxWidthLineEdit</tabstop>
   <tabstop>mMaxHeightLineEdit</tabstop>
   <tabstop>mWMSImageQualitySpinBox</tabstop>
-  <tabstop>mWMTSMinScaleLineEdit</tabstop>
+  <tabstop>mWMTSMinScaleSpinBox</tabstop>
   <tabstop>mWMTSUrlLineEdit</tabstop>
   <tabstop>twWFSLayers</tabstop>
   <tabstop>pbnWFSLayersSelectAll</tabstop>


### PR DESCRIPTION
follow-up https://github.com/qgis/QGIS/pull/39075#issuecomment-703347291
To do it, I use either the default value set in the .ui file or the one set in the GUI (with uncertainty whether this value is a default for all or only related to my settings/data). I don't catch all of them, but still lesser clear icons to display, now.

There are a couple of widgets I'm really unsure of how to do or whether my change works, I'll probably open another PR.