### PR TITLE
Display available variables in the expression parameter dialog of a modeler

### DIFF
--- a/python/gui/auto_generated/qgsexpressionlineedit.sip.in
+++ b/python/gui/auto_generated/qgsexpressionlineedit.sip.in
@@ -127,6 +127,15 @@ an expression context for the widget.
                   create an expression context when required.
 %End
 
+    void setExpressionContext( QgsExpressionContext &context );
+%Docstring
+Set a default expression context. Will be used if no QgsEcpressionContextGenerator or layer is set.
+
+:param context: The QgsExpressionContext to use.
+
+.. versionadded:: 3.18
+%End
+
   signals:
 
     void expressionChanged( const QString &expression );

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -1848,8 +1848,11 @@ QgsProcessingExpressionParameterDefinitionWidget::QgsProcessingExpressionParamet
   vlayout->addWidget( new QLabel( tr( "Default value" ) ) );
 
   mDefaultLineEdit = new QgsExpressionLineEdit();
-  QgsExpressionContext expressionContext = createExpressionContext( context, algorithm );
-  mDefaultLineEdit->setExpressionContext( expressionContext );
+  if ( mModel )
+  {
+    QgsExpressionContext expressionContext = createExpressionContext( context, algorithm );
+    mDefaultLineEdit->setExpressionContext( expressionContext );
+  }
   if ( const QgsProcessingParameterExpression *expParam = dynamic_cast<const QgsProcessingParameterExpression *>( definition ) )
     mDefaultLineEdit->setExpression( QgsProcessingParameters::parameterAsExpression( expParam, expParam->defaultValue(), context ) );
   vlayout->addWidget( mDefaultLineEdit );

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -66,6 +66,8 @@ class QgsProcessingMapLayerComboBox;
 class QgsRasterBandComboBox;
 class QgsProcessingLayerOutputDestinationWidget;
 class QgsCheckableComboBox;
+class QgsProcessingModelAlgorithm;
+class QgsExpressionContext;
 
 ///@cond PRIVATE
 
@@ -633,11 +635,13 @@ class GUI_EXPORT QgsProcessingExpressionParameterDefinitionWidget : public QgsPr
         const QgsProcessingParameterDefinition *definition = nullptr,
         const QgsProcessingAlgorithm *algorithm = nullptr, QWidget *parent SIP_TRANSFERTHIS = nullptr );
     QgsProcessingParameterDefinition *createParameter( const QString &name, const QString &description, QgsProcessingParameterDefinition::Flags flags ) const override;
+    QgsExpressionContext createExpressionContext( QgsProcessingContext &context, const QgsProcessingAlgorithm *algorithm ) const;
 
   private:
 
     QComboBox *mParentLayerComboBox = nullptr;
     QgsExpressionLineEdit *mDefaultLineEdit = nullptr;
+    QgsProcessingModelAlgorithm *mModel = nullptr;
 
 };
 
@@ -662,6 +666,7 @@ class GUI_EXPORT QgsProcessingExpressionWidgetWrapper : public QgsAbstractProces
     // QgsProcessingParameterWidgetWrapper interface
     QWidget *createWidget() override SIP_FACTORY;
     void postInitialize( const QList< QgsAbstractProcessingParameterWidgetWrapper * > &wrappers ) override;
+
   public slots:
     void setParentLayerWrapperValue( const QgsAbstractProcessingParameterWidgetWrapper *parentWrapper );
   protected:

--- a/src/gui/qgsexpressionlineedit.h
+++ b/src/gui/qgsexpressionlineedit.h
@@ -132,6 +132,13 @@ class GUI_EXPORT QgsExpressionLineEdit : public QWidget
      */
     void registerExpressionContextGenerator( const QgsExpressionContextGenerator *generator );
 
+    /**
+     * Set a default expression context. Will be used if no QgsEcpressionContextGenerator or layer is set.
+     * \param context The QgsExpressionContext to use.
+     * \since QGIS 3.18
+     */
+    void setExpressionContext( QgsExpressionContext &context ) { mExpressionContext = context; }
+
   signals:
 
     /**


### PR DESCRIPTION
## Description

Fixes #39137 

This is my proposal to display the variables of a model in the default expression dialog.

I tried many permutations and this is the best way that I found, use the same context creation as used in the dialogs during widget initiation, cache it in the dialog. 

This was needed since the processing context couldn't be stored safely and was deleted, so adding the parameters to the function and calling it during creation was the best way to ensure that those parameters are available during creation.

Caching the context in the existing member context of the QgsExpressionLineEdit ensure that there was no need to call the context creation later.