### PR TITLE
Add mapToolActionGroup to iface object

### DIFF
--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -448,6 +448,16 @@ Returns the native "Vertex Tool for Active Layer" action.
 .. versionadded:: 3.6
 %End
 
+    virtual QActionGroup *mapToolActionGroup() = 0;
+%Docstring
+Returns the action group for map tools.
+
+Any actions added by plugins for toggling a map tool should also be added to this action
+group so that they behave identically to the native, in-built map tool actions.
+
+.. versionadded:: 3.16
+%End
+
     virtual QAction *actionPan() = 0;
 %Docstring
 Returns the native pan action. Call :py:func:`~QgisInterface.trigger` on it to set the default pan map tool.

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -643,7 +643,7 @@ QToolBar *QgisAppInterface::rasterToolBar() { return qgis->rasterToolBar(); }
 QToolBar *QgisAppInterface::vectorToolBar() { return qgis->vectorToolBar(); }
 QToolBar *QgisAppInterface::databaseToolBar() { return qgis->databaseToolBar(); }
 QToolBar *QgisAppInterface::webToolBar() { return qgis->webToolBar(); }
-
+QActionGroup *QgisAppInterface::mapToolActionGroup() { return qgis->mMapToolGroup; }
 QAction *QgisAppInterface::actionNewProject() { return qgis->actionNewProject(); }
 QAction *QgisAppInterface::actionOpenProject() { return qgis->actionOpenProject(); }
 QAction *QgisAppInterface::actionSaveProject() { return qgis->actionSaveProject(); }

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -189,6 +189,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QToolBar *vectorToolBar() override;
     QToolBar *databaseToolBar() override;
     QToolBar *webToolBar() override;
+    QActionGroup *mapToolActionGroup() override;
     QAction *actionNewProject() override;
     QAction *actionOpenProject() override;
     QAction *actionSaveProject() override;

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -35,6 +35,7 @@ class QToolBar;
 class QDockWidget;
 class QMainWindow;
 class QWidget;
+class QActionGroup;
 
 class QgsAdvancedDigitizingDockWidget;
 class QgsAttributeDialog;
@@ -433,6 +434,16 @@ class GUI_EXPORT QgisInterface : public QObject
      * \since QGIS 3.6
     */
     virtual QAction *actionVertexToolActiveLayer() = 0;
+
+    /**
+     * Returns the action group for map tools.
+     *
+     * Any actions added by plugins for toggling a map tool should also be added to this action
+     * group so that they behave identically to the native, in-built map tool actions.
+     *
+     * \since QGIS 3.16
+     */
+    virtual QActionGroup *mapToolActionGroup() = 0;
 
     // View menu actions
     //! Returns the native pan action. Call trigger() on it to set the default pan map tool.


### PR DESCRIPTION
Any actions added by plugins for toggling a map tool should also be added to this action group so that they behave identically
to the native, in-built map tool actions.

Without this interface method you have to resort to a fragile findChildren approach to make truely native-behaving map tools.
