### PR TITLE
3d light default tweaks

### DIFF
--- a/src/3d/qgsdirectionallightsettings.h
+++ b/src/3d/qgsdirectionallightsettings.h
@@ -60,7 +60,7 @@ class _3D_EXPORT QgsDirectionalLightSettings
   private:
     QgsVector3D mDirection { -0.32, -0.91, -0.27 };
     QColor mColor = Qt::white;
-    float mIntensity = 0.5;
+    float mIntensity = 1.0;
 };
 
 #endif // QGSDIRECTIONALLIGHTSETTINGS_H

--- a/src/3d/qgsdirectionallightsettings.h
+++ b/src/3d/qgsdirectionallightsettings.h
@@ -58,7 +58,7 @@ class _3D_EXPORT QgsDirectionalLightSettings
     bool operator==( const QgsDirectionalLightSettings &other );
 
   private:
-    QgsVector3D mDirection = QgsVector3D( 0.0, -1.0, 0.0 );
+    QgsVector3D mDirection { -0.32, -0.91, -0.27 };
     QColor mColor = Qt::white;
     float mIntensity = 0.5;
 };

--- a/src/3d/qgspointlightsettings.h
+++ b/src/3d/qgspointlightsettings.h
@@ -79,7 +79,7 @@ class _3D_EXPORT QgsPointLightSettings
     bool operator==( const QgsPointLightSettings &other );
 
   private:
-    QgsVector3D mPosition;
+    QgsVector3D mPosition { 0, 1000, 0 };
     QColor mColor = Qt::white;
     float mIntensity = 0.5;
     float mConstantAttenuation = 1.0f;

--- a/src/3d/qgspointlightsettings.h
+++ b/src/3d/qgspointlightsettings.h
@@ -81,7 +81,7 @@ class _3D_EXPORT QgsPointLightSettings
   private:
     QgsVector3D mPosition { 0, 1000, 0 };
     QColor mColor = Qt::white;
-    float mIntensity = 0.5;
+    float mIntensity = 1.0;
     float mConstantAttenuation = 1.0f;
     float mLinearAttenuation = 0.0f;
     float mQuadraticAttenuation = 0.0f;

--- a/src/app/3d/qgslightswidget.cpp
+++ b/src/app/3d/qgslightswidget.cpp
@@ -30,11 +30,11 @@ QgsLightsWidget::QgsLightsWidget( QWidget *parent )
   spinPositionX->setClearValue( 0.0 );
   spinPositionY->setClearValue( 1000.0 );
   spinPositionZ->setClearValue( 0.0 );
-  spinIntensity->setClearValue( 0.5 );
+  spinIntensity->setClearValue( 1.0 );
   spinA0->setClearValue( 0.0 );
   spinA1->setClearValue( 0.0 );
   spinA2->setClearValue( 0.0 );
-  spinDirectionalIntensity->setClearValue( 0.5 );
+  spinDirectionalIntensity->setClearValue( 1.0 );
 
   mLightsModel = new QgsLightsModel( this );
   mLightsListView->setModel( mLightsModel );

--- a/src/app/3d/qgslightswidget.cpp
+++ b/src/app/3d/qgslightswidget.cpp
@@ -187,6 +187,7 @@ void QgsLightsWidget::onAddLight()
 
   const QModelIndex newIndex = mLightsModel->addPointLight( QgsPointLightSettings() );
   mLightsListView->selectionModel()->select( newIndex, QItemSelectionModel::ClearAndSelect );
+  emit lightsAdded();
 }
 
 void QgsLightsWidget::onAddDirectionalLight()
@@ -199,6 +200,7 @@ void QgsLightsWidget::onAddDirectionalLight()
 
   const QModelIndex newIndex = mLightsModel->addDirectionalLight( QgsDirectionalLightSettings() );
   mLightsListView->selectionModel()->select( newIndex, QItemSelectionModel::ClearAndSelect );
+  emit lightsAdded();
 }
 
 void QgsLightsWidget::onRemoveLight()
@@ -210,11 +212,15 @@ void QgsLightsWidget::onRemoveLight()
   }
 
   const int directionalCount = mLightsModel->directionalLights().size();
+  const int pointCount = mLightsModel->pointLights().size();
 
   mLightsModel->removeRows( selected.indexes().at( 0 ).row(), 1 );
 
   if ( mLightsModel->directionalLights().size() != directionalCount )
     emit directionalLightsCountChanged( mLightsModel->directionalLights().size() );
+
+  if ( mLightsModel->rowCount( QModelIndex() ) != directionalCount + pointCount )
+    emit lightsRemoved();
 }
 
 void QgsLightsWidget::setAzimuthAltitude()

--- a/src/app/3d/qgslightswidget.h
+++ b/src/app/3d/qgslightswidget.h
@@ -82,6 +82,9 @@ class QgsLightsWidget : public QWidget, private Ui::QgsLightsWidget
 
   signals:
     void directionalLightsCountChanged( int count );
+    void lightsRemoved();
+    void lightsAdded();
+
   private slots:
     void selectedLightChanged( const QItemSelection &selected, const QItemSelection &deselected );
     void updateCurrentLightParameters();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13049,9 +13049,8 @@ void QgisApp::new3DMapCanvas()
     flatTerrain->setExtent( fullExtent );
     map->setTerrainGenerator( flatTerrain );
 
-    QgsPointLightSettings defaultPointLight;
-    defaultPointLight.setConstantAttenuation( 0 );
-    map->setPointLights( QList<QgsPointLightSettings>() << defaultPointLight );
+    // new scenes default to a single directional light
+    map->setDirectionalLights( QList<QgsDirectionalLightSettings>() << QgsDirectionalLightSettings() );
     map->setOutputDpi( QgsApplication::desktop()->logicalDpiX() );
 
     dock->setMapSettings( map );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13050,7 +13050,6 @@ void QgisApp::new3DMapCanvas()
     map->setTerrainGenerator( flatTerrain );
 
     QgsPointLightSettings defaultPointLight;
-    defaultPointLight.setPosition( QgsVector3D( 0, 1000, 0 ) );
     defaultPointLight.setConstantAttenuation( 0 );
     map->setPointLights( QList<QgsPointLightSettings>() << defaultPointLight );
     map->setOutputDpi( QgsApplication::desktop()->logicalDpiX() );

--- a/src/ui/3d/qgslightswidget.ui
+++ b/src/ui/3d/qgslightswidget.ui
@@ -64,7 +64,7 @@
    <item>
     <widget class="QStackedWidget" name="mStackedWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="page_2"/>
      <widget class="QWidget" name="page">
@@ -111,10 +111,13 @@
        <item row="5" column="1">
         <widget class="QgsDoubleSpinBox" name="spinIntensity">
          <property name="decimals">
-          <number>1</number>
+          <number>2</number>
          </property>
          <property name="maximum">
           <double>999999.000000000000000</double>
+         </property>
+         <property name="singleStep">
+          <double>0.100000000000000</double>
          </property>
         </widget>
        </item>
@@ -382,10 +385,13 @@
        <item row="7" column="1">
         <widget class="QgsDoubleSpinBox" name="spinDirectionalIntensity">
          <property name="decimals">
-          <number>1</number>
+          <number>2</number>
          </property>
          <property name="maximum">
           <double>999999.000000000000000</double>
+         </property>
+         <property name="singleStep">
+          <double>0.100000000000000</double>
          </property>
         </widget>
        </item>

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -306,6 +306,7 @@ void TestQgs3DRendering::testTerrainShading()
 
   QgsPointLightSettings defaultLight;
   defaultLight.setPosition( QgsVector3D( 0, 1000, 0 ) );
+  defaultLight.setIntensity( 0.5 );
   map->setPointLights( QList<QgsPointLightSettings>() << defaultLight );
 
   QgsOffscreen3DEngine engine;
@@ -365,6 +366,7 @@ void TestQgs3DRendering::testExtrudedPolygons()
   map->setLayers( QList<QgsMapLayer *>() << mLayerBuildings );
   map->setTerrainLayers( QList<QgsMapLayer *>() << mLayerRgb );
   QgsPointLightSettings defaultLight;
+  defaultLight.setIntensity( 0.5 );
   defaultLight.setPosition( QgsVector3D( 0, 1000, 0 ) );
   map->setPointLights( QList<QgsPointLightSettings>() << defaultLight );
 
@@ -417,6 +419,7 @@ void TestQgs3DRendering::testPolygonsEdges()
 
   map->setLayers( QList<QgsMapLayer *>() << layer.get() );
   QgsPointLightSettings defaultLight;
+  defaultLight.setIntensity( 0.5 );
   defaultLight.setPosition( QgsVector3D( 0, 1000, 0 ) );
   map->setPointLights( QList<QgsPointLightSettings>() << defaultLight );
 
@@ -517,6 +520,7 @@ void TestQgs3DRendering::testBufferedLineRendering()
   map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
   map->setLayers( QList<QgsMapLayer *>() << layerLines );
   QgsPointLightSettings defaultLight;
+  defaultLight.setIntensity( 0.5 );
   defaultLight.setPosition( QgsVector3D( 0, 1000, 0 ) );
   map->setPointLights( QList<QgsPointLightSettings>() << defaultLight );
 
@@ -563,6 +567,7 @@ void TestQgs3DRendering::testBufferedLineRenderingWidth()
   map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
   map->setLayers( QList<QgsMapLayer *>() << layerLines );
   QgsPointLightSettings defaultLight;
+  defaultLight.setIntensity( 0.5 );
   defaultLight.setPosition( QgsVector3D( 0, 1000, 0 ) );
   map->setPointLights( QList<QgsPointLightSettings>() << defaultLight );
 
@@ -632,6 +637,7 @@ void TestQgs3DRendering::testMesh()
   map->setLayers( QList<QgsMapLayer *>() << mLayerMeshDataset );
   map->setTerrainLayers( QList<QgsMapLayer *>() << mLayerMeshDataset );
   QgsPointLightSettings defaultLight;
+  defaultLight.setIntensity( 0.5 );
   defaultLight.setPosition( QgsVector3D( 0, 1000, 0 ) );
   map->setPointLights( QList<QgsPointLightSettings>() << defaultLight );
 
@@ -684,6 +690,7 @@ void TestQgs3DRendering::testRuleBasedRenderer()
   map->setLayers( QList<QgsMapLayer *>() << mLayerBuildings );
 
   QgsPointLightSettings defaultLight;
+  defaultLight.setIntensity( 0.5 );
   defaultLight.setPosition( QgsVector3D( 0, 1000, 0 ) );
   map->setPointLights( QList<QgsPointLightSettings>() << defaultLight );
 


### PR DESCRIPTION
Tweaks the configuration of newly created light sources for better (easier for users to understand) lighting, and switches newly created 3d maps to a single directional light instead of a single point light source.