### PR TITLE
Fix duplicating features

### DIFF
--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -635,6 +635,7 @@ QgsFeature QgsVectorLayerUtils::duplicateFeature( QgsVectorLayer *layer, const Q
   context.setFeature( feature );
 
   QgsFeature newFeature = createFeature( layer, feature.geometry(), feature.attributes().toMap(), &context );
+  layer->addFeature( newFeature );
 
   const QList<QgsRelation> relations = project->relationManager()->referencedRelations( layer );
 
@@ -667,7 +668,6 @@ QgsFeature QgsVectorLayerUtils::duplicateFeature( QgsVectorLayer *layer, const Q
     }
   }
 
-  layer->addFeature( newFeature );
 
   return newFeature;
 }

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -864,7 +864,7 @@ void QgsAttributeTableModel::executeMapLayerAction( QgsMapLayerAction *action, c
 
 QgsFeature QgsAttributeTableModel::feature( const QModelIndex &idx ) const
 {
-  QgsFeature f;
+  QgsFeature f( mLayerCache->layer()->fields() );
   f.initAttributes( mAttributes.size() );
   f.setId( rowToId( idx.row() ) );
   for ( int i = 0; i < mAttributes.size(); i++ )


### PR DESCRIPTION
* adding child features was failing because the fields were not correctly set from the attribute table action
* the referenced feature is added before the referencing children (otherwise this leads to a foreign key constraint error if done in transaction mode)