### PR TITLE
[OAuth2] Do not emit empty scope in requests for Keycloak compatibility

### DIFF
--- a/src/auth/oauth2/qgso2.cpp
+++ b/src/auth/oauth2/qgso2.cpp
@@ -187,9 +187,12 @@ void QgsO2::link()
                                   QString( O2_OAUTH2_GRANT_TYPE_TOKEN ) ) );
     parameters.append( qMakePair( QString( O2_OAUTH2_CLIENT_ID ), clientId_ ) );
     parameters.append( qMakePair( QString( O2_OAUTH2_REDIRECT_URI ), redirectUri_ ) );
-    parameters.append( qMakePair( QString( O2_OAUTH2_SCOPE ), scope_ ) );
-    parameters.append( qMakePair( O2_OAUTH2_STATE, state_ ) );
-    parameters.append( qMakePair( QString( O2_OAUTH2_API_KEY ), apiKey_ ) );
+    if ( !scope_.isEmpty() )
+      parameters.append( qMakePair( QString( O2_OAUTH2_SCOPE ), scope_ ) );
+    if ( !state_.isEmpty() )
+      parameters.append( qMakePair( O2_OAUTH2_STATE, state_ ) );
+    if ( !apiKey_.isEmpty() )
+      parameters.append( qMakePair( QString( O2_OAUTH2_API_KEY ), apiKey_ ) );
 
     for ( auto iter = extraReqParams_.constBegin(); iter != extraReqParams_.constEnd(); ++iter )
     {
@@ -216,8 +219,10 @@ void QgsO2::link()
     parameters.append( O0RequestParameter( O2_OAUTH2_USERNAME, username_.toUtf8() ) );
     parameters.append( O0RequestParameter( O2_OAUTH2_PASSWORD, password_.toUtf8() ) );
     parameters.append( O0RequestParameter( O2_OAUTH2_GRANT_TYPE, O2_OAUTH2_GRANT_TYPE_PASSWORD ) );
-    parameters.append( O0RequestParameter( O2_OAUTH2_SCOPE, scope_.toUtf8() ) );
-    parameters.append( O0RequestParameter( O2_OAUTH2_API_KEY, apiKey_.toUtf8() ) );
+    if ( !scope_.isEmpty() )
+      parameters.append( O0RequestParameter( O2_OAUTH2_SCOPE, scope_.toUtf8() ) );
+    if ( !apiKey_.isEmpty() )
+      parameters.append( O0RequestParameter( O2_OAUTH2_API_KEY, apiKey_.toUtf8() ) );
 
 
     for ( auto iter = extraReqParams_.constBegin(); iter != extraReqParams_.constEnd(); ++iter )


### PR DESCRIPTION
When using Keycloak in OpenId Connect mode with AuthCode or ResourceOwner
methods, and no specifying a scope, we send a &scope= query parameter that
is rejected by Keycloak with
KC-SERVICES0093: Invalid parameter value for: scope

https://tools.ietf.org/html/rfc6749#section-3.3 mentions that scope is
optional : 'If the client omits the scope parameter when requesting
authorization...'
Do the same for the optional 'state' and 'api_key' parameters
