### PR TITLE
Server landing page clean env

### DIFF
--- a/src/server/services/landingpage/qgslandingpage.cpp
+++ b/src/server/services/landingpage/qgslandingpage.cpp
@@ -74,6 +74,9 @@ class QgsProjectLoaderFilter: public QgsServerFilter
 
     void requestReady() override
     {
+      // Always clear the environment
+      qputenv( "QGIS_PROJECT_FILE", "" );
+      serverInterface()->setConfigFilePath( QString() );
       const auto handler { serverInterface()->requestHandler() };
       if ( handler->path().startsWith( QLatin1String( "/project/" ) ) )
       {


### PR DESCRIPTION
This is necessary when returning to the home page after
an invalid project has been browsed and QGIS_SERVER_IGNORE_BAD_LAYERS
was not set.
