### PR TITLE
Fix import geotagged photos algorithm assigns form widgets to wrong field when saving the results to GPKG [3.10 backport]

### DIFF
--- a/src/analysis/processing/qgsalgorithmimportphotos.cpp
+++ b/src/analysis/processing/qgsalgorithmimportphotos.cpp
@@ -236,13 +236,17 @@ class SetEditorWidgetForPhotoAttributePostProcessor : public QgsProcessingLayerP
         // photo field shows picture viewer
         config.insert( QStringLiteral( "DocumentViewer" ), 1 );
         config.insert( QStringLiteral( "FileWidget" ), true );
-        vl->setEditorWidgetSetup( 0, QgsEditorWidgetSetup( QStringLiteral( "ExternalResource" ), config ) );
+        config.insert( QStringLiteral( "UseLink" ), true );
+        config.insert( QStringLiteral( "FullUrl" ), true );
+        vl->setEditorWidgetSetup( vl->fields().lookupField( QStringLiteral( "photo" ) ), QgsEditorWidgetSetup( QStringLiteral( "ExternalResource" ), config ) );
 
         config.clear();
         // path field is a directory link
         config.insert( QStringLiteral( "FileWidgetButton" ), true );
         config.insert( QStringLiteral( "StorageMode" ), 1 );
-        vl->setEditorWidgetSetup( 2, QgsEditorWidgetSetup( QStringLiteral( "ExternalResource" ), config ) );
+        config.insert( QStringLiteral( "UseLink" ), true );
+        config.insert( QStringLiteral( "FullUrl" ), true );
+        vl->setEditorWidgetSetup( vl->fields().lookupField( QStringLiteral( "directory" ) ), QgsEditorWidgetSetup( QStringLiteral( "ExternalResource" ), config ) );
       }
     }
 };


### PR DESCRIPTION
(or other formats which automatically insert new fields into the result layer)

Also tweak widget behavior for newer resource widget functionality

(cherry picked from commit ff336ade18f4d6b307e4ed0e98fee77ee11a157c)
