### PR TITLE
Add API to delegate reponsibility for switching to custom map tools and enabling them in the right circumstances to qgisapp

### DIFF
--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -1270,6 +1270,33 @@ Unregister a previously registered application exit ``blocker``.
 .. versionadded:: 3.16
 %End
 
+    virtual void registerMapToolHandler( QgsAbstractMapToolHandler *handler ) = 0;
+%Docstring
+Register a new application map tool ``handler``, which can be used to automatically setup all connections
+and logic required to switch to a custom map tool whenever the state of the QGIS application
+permits.
+
+.. note::
+
+   Ownership of ``handler`` is not transferred, and the handler must
+   be unregistered when plugin is unloaded.
+
+.. seealso:: :py:class:`QgsAbstractMapToolHandler`
+
+.. seealso:: :py:func:`unregisterMapToolHandler`
+
+.. versionadded:: 3.16
+%End
+
+    virtual void unregisterMapToolHandler( QgsAbstractMapToolHandler *handler ) = 0;
+%Docstring
+Unregister a previously registered map tool ``handler``.
+
+.. seealso:: :py:func:`registerMapToolHandler`
+
+.. versionadded:: 3.16
+%End
+
     virtual void registerCustomDropHandler( QgsCustomDropHandler *handler ) = 0;
 %Docstring
 Register a new custom drop ``handler``.

--- a/python/gui/auto_generated/qgsabstractmaptoolhandler.sip.in
+++ b/python/gui/auto_generated/qgsabstractmaptoolhandler.sip.in
@@ -1,0 +1,115 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsabstractmaptoolhandler.h                                  *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsAbstractMapToolHandler
+{
+%Docstring
+An abstract base class for map tool handlers which automatically handle all the necessary
+logic for toggling the map tool and enabling/disabling the associated action
+when the QGIS application is in a state permissible for the tool.
+
+Creating these handlers avoids a lot of complex setup code and manual connections
+which are otherwise necessary to ensure that a map tool is correctly activated and
+deactivated when the state of the QGIS application changes (e.g. when the active
+layer is changed, when edit modes are toggled, when other map tools are switched
+to, etc).
+
+- ### Example
+
+.. code-block:: python
+
+       class MyMapTool(QgsMapTool):
+          ...
+
+       class MyMapToolHandler(QgsAbstractMapToolHandler):
+
+          def __init__(self, tool, action):
+              super().__init__(tool, action)
+
+          def isCompatibleWithLayer(self, layer, context):
+              # this tool can only be activated when an editable vector layer is selected
+              return isinstance(layer, QgsVectorLayer) and layer.isEditable()
+
+       my_tool = MyMapTool()
+       my_action = QAction('My Map Tool')
+
+       my_handler = MyMapToolHandler(my_tool, my_action)
+       iface.registerMapToolHandler(my_handler)
+
+.. versionadded:: 3.16
+%End
+
+%TypeHeaderCode
+#include "qgsabstractmaptoolhandler.h"
+%End
+  public:
+
+    struct Context
+    {
+      bool dummy;
+    };
+
+    QgsAbstractMapToolHandler( QgsMapTool *tool, QAction *action );
+%Docstring
+Constructor for a map tool handler for the specified ``tool``.
+
+The ``action`` argument must be set to the action associated with switching
+to the tool.
+
+The ownership of neither ``tool`` nor ``action`` is transferred, and the caller
+is responsible for ensuring that these objects exist for the lifetime of the
+handler.
+
+.. warning::
+
+   The handler will be responsible for creating the appropriate
+   connections between the ``action`` and the ``tool``. These should NOT be
+   manually connected elsewhere!
+%End
+
+    virtual ~QgsAbstractMapToolHandler();
+
+    QgsMapTool *mapTool();
+%Docstring
+Returns the tool associated with this handler.
+%End
+
+    QAction *action();
+%Docstring
+Returns the action associated with toggling the tool.
+%End
+
+    virtual bool isCompatibleWithLayer( QgsMapLayer *layer, const QgsAbstractMapToolHandler::Context &context ) = 0;
+%Docstring
+Returns ``True`` if the associated map tool is compatible with the specified ``layer``.
+
+Additional information is available through the ``context`` argument.
+%End
+
+    virtual void setLayerForTool( QgsMapLayer *layer );
+%Docstring
+Sets the ``layer`` to use for the tool.
+
+Called whenever a new layer should be associated with the tool, e.g. as a result of the
+user selecting a different active layer.
+
+The default implementation does nothing.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsabstractmaptoolhandler.h                                  *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -2,6 +2,7 @@
 %Include auto_generated/qgisinterface.sip
 %Include auto_generated/qgs3dsymbolwidget.sip
 %Include auto_generated/qgsabstractdatasourcewidget.sip
+%Include auto_generated/qgsabstractmaptoolhandler.sip
 %Include auto_generated/qgsactionmenu.sip
 %Include auto_generated/qgsadvanceddigitizingdockwidget.sip
 %Include auto_generated/qgsadvanceddigitizingfloater.sip

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -112,6 +112,7 @@ class QgsHandleBadLayersHandler;
 class QgsNetworkAccessManager;
 class QgsGpsConnection;
 class QgsApplicationExitBlockerInterface;
+class QgsAbstractMapToolHandler;
 
 class QDomDocument;
 class QNetworkReply;
@@ -763,6 +764,25 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * \see registerApplicationExitBlocker()
     */
     void unregisterApplicationExitBlocker( QgsApplicationExitBlockerInterface *blocker );
+
+    /**
+     * Register a new application map tool \a handler, which can be used to automatically setup all connections
+     * and logic required to switch to a custom map tool whenever the state of the QGIS application
+     * permits.
+     *
+     * \note Ownership of \a handler is not transferred, and the handler must
+     *       be unregistered when plugin is unloaded.
+     *
+     * \see QgsAbstractMapToolHandler
+     * \see unregisterMapToolHandler()
+     */
+    void registerMapToolHandler( QgsAbstractMapToolHandler *handler );
+
+    /**
+     * Unregister a previously registered map tool \a handler.
+     * \see registerMapToolHandler()
+    */
+    void unregisterMapToolHandler( QgsAbstractMapToolHandler *handler );
 
     //! Register a new custom drop handler.
     void registerCustomDropHandler( QgsCustomDropHandler *handler );
@@ -2167,6 +2187,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Configure layer tree view according to the user options from QgsSettings
     void setupLayerTreeViewFromSettings();
 
+    void switchToMapToolViaHandler();
+
     void readSettings();
     void writeSettings();
     void createActions();
@@ -2595,6 +2617,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QList<QgsDevToolWidgetFactory * > mDevToolFactories;
 
     QList<QgsApplicationExitBlockerInterface * > mApplicationExitBlockers;
+    QList<QgsAbstractMapToolHandler * > mMapToolHandlers;
 
     QVector<QPointer<QgsCustomDropHandler>> mCustomDropHandlers;
     QVector<QPointer<QgsCustomProjectOpenHandler>> mCustomProjectOpenHandlers;

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -581,6 +581,16 @@ void QgisAppInterface::unregisterApplicationExitBlocker( QgsApplicationExitBlock
   qgis->unregisterApplicationExitBlocker( blocker );
 }
 
+void QgisAppInterface::registerMapToolHandler( QgsAbstractMapToolHandler *handler )
+{
+  qgis->registerMapToolHandler( handler );
+}
+
+void QgisAppInterface::unregisterMapToolHandler( QgsAbstractMapToolHandler *handler )
+{
+  qgis->unregisterMapToolHandler( handler );
+}
+
 void QgisAppInterface::registerCustomDropHandler( QgsCustomDropHandler *handler )
 {
   qgis->registerCustomDropHandler( handler );

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -152,6 +152,8 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     void unregisterDevToolWidgetFactory( QgsDevToolWidgetFactory *factory ) override;
     void registerApplicationExitBlocker( QgsApplicationExitBlockerInterface *blocker ) override;
     void unregisterApplicationExitBlocker( QgsApplicationExitBlockerInterface *blocker ) override;
+    void registerMapToolHandler( QgsAbstractMapToolHandler *handler ) override;
+    void unregisterMapToolHandler( QgsAbstractMapToolHandler *handler ) override;
     void registerCustomDropHandler( QgsCustomDropHandler *handler ) override;
     void unregisterCustomDropHandler( QgsCustomDropHandler *handler ) override;
     void registerCustomProjectOpenHandler( QgsCustomProjectOpenHandler *handler ) override;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -359,6 +359,7 @@ SET(QGIS_GUI_SRCS
 
   qgisinterface.cpp
   qgs3dsymbolwidget.cpp
+  qgsabstractmaptoolhandler.cpp
   qgsactionmenu.cpp
   qgsaddattrdialog.cpp
   qgsaddtaborgroup.cpp
@@ -589,6 +590,7 @@ SET(QGIS_GUI_HDRS
 
   qgs3dsymbolwidget.h
   qgsabstractdatasourcewidget.h
+  qgsabstractmaptoolhandler.h
   qgsactionmenu.h
   qgsaddattrdialog.h
   qgsaddtaborgroup.h

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -67,6 +67,7 @@ class QgsBrowserGuiModel;
 class QgsDevToolWidgetFactory;
 class QgsGpsConnection;
 class QgsApplicationExitBlockerInterface;
+class QgsAbstractMapToolHandler;
 
 
 /**
@@ -1055,6 +1056,27 @@ class GUI_EXPORT QgisInterface : public QObject
      * \since QGIS 3.16
     */
     virtual void unregisterApplicationExitBlocker( QgsApplicationExitBlockerInterface *blocker ) = 0;
+
+    /**
+     * Register a new application map tool \a handler, which can be used to automatically setup all connections
+     * and logic required to switch to a custom map tool whenever the state of the QGIS application
+     * permits.
+     *
+     * \note Ownership of \a handler is not transferred, and the handler must
+     *       be unregistered when plugin is unloaded.
+     *
+     * \see QgsAbstractMapToolHandler
+     * \see unregisterMapToolHandler()
+     * \since QGIS 3.16
+     */
+    virtual void registerMapToolHandler( QgsAbstractMapToolHandler *handler ) = 0;
+
+    /**
+     * Unregister a previously registered map tool \a handler.
+     * \see registerMapToolHandler()
+     * \since QGIS 3.16
+    */
+    virtual void unregisterMapToolHandler( QgsAbstractMapToolHandler *handler ) = 0;
 
     /**
      * Register a new custom drop \a handler.

--- a/src/gui/qgsabstractmaptoolhandler.cpp
+++ b/src/gui/qgsabstractmaptoolhandler.cpp
@@ -1,0 +1,43 @@
+/***************************************************************************
+    qgsabstractmaptoolhandler.cpp
+    ---------------------
+    begin                : October 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsabstractmaptoolhandler.h"
+
+QgsAbstractMapToolHandler::QgsAbstractMapToolHandler( QgsMapTool *tool, QAction *action )
+  : mMapTool( tool )
+  , mAction( action )
+{
+
+}
+
+QgsAbstractMapToolHandler::~QgsAbstractMapToolHandler() = default;
+
+
+QgsMapTool *QgsAbstractMapToolHandler::mapTool()
+{
+  return mMapTool;
+}
+
+QAction *QgsAbstractMapToolHandler::action()
+{
+  return mAction;
+}
+
+void QgsAbstractMapToolHandler::setLayerForTool( QgsMapLayer * )
+{
+
+}
+
+

--- a/src/gui/qgsabstractmaptoolhandler.h
+++ b/src/gui/qgsabstractmaptoolhandler.h
@@ -1,0 +1,128 @@
+/***************************************************************************
+    qgsabstractmaptoolhandler.h
+    ---------------------
+    begin                : October 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSABSTRACTMAPTOOLHANDLER_H
+#define QGSABSTRACTMAPTOOLHANDLER_H
+
+#include "qgis_gui.h"
+
+class QgsMapLayer;
+class QgsMapTool;
+class QAction;
+
+/**
+ * \ingroup gui
+ * An abstract base class for map tool handlers which automatically handle all the necessary
+ * logic for toggling the map tool and enabling/disabling the associated action
+ * when the QGIS application is in a state permissible for the tool.
+ *
+ * Creating these handlers avoids a lot of complex setup code and manual connections
+ * which are otherwise necessary to ensure that a map tool is correctly activated and
+ * deactivated when the state of the QGIS application changes (e.g. when the active
+ * layer is changed, when edit modes are toggled, when other map tools are switched
+ * to, etc).
+ *
+ * - ### Example
+ *
+ * \code{.py}
+ *   class MyMapTool(QgsMapTool):
+ *      ...
+ *
+ *   class MyMapToolHandler(QgsAbstractMapToolHandler):
+ *
+ *      def __init__(self, tool, action):
+ *          super().__init__(tool, action)
+ *
+ *      def isCompatibleWithLayer(self, layer, context):
+ *          # this tool can only be activated when an editable vector layer is selected
+ *          return isinstance(layer, QgsVectorLayer) and layer.isEditable()
+ *
+ *   my_tool = MyMapTool()
+ *   my_action = QAction('My Map Tool')
+ *
+ *   my_handler = MyMapToolHandler(my_tool, my_action)
+ *   iface.registerMapToolHandler(my_handler)
+ * \endcode
+ *
+ * \since QGIS 3.16
+ */
+class GUI_EXPORT QgsAbstractMapToolHandler
+{
+
+  public:
+
+    /**
+     * Context of a QgsAbstractMapToolHandler call.
+     *
+     * \since QGIS 3.16
+     */
+    struct Context
+    {
+      //! Placeholder only
+      bool dummy = false;
+    };
+
+    /**
+     * Constructor for a map tool handler for the specified \a tool.
+     *
+     * The \a action argument must be set to the action associated with switching
+     * to the tool.
+     *
+     * The ownership of neither \a tool nor \a action is transferred, and the caller
+     * is responsible for ensuring that these objects exist for the lifetime of the
+     * handler.
+     *
+     * \warning The handler will be responsible for creating the appropriate
+     * connections between the \a action and the \a tool. These should NOT be
+     * manually connected elsewhere!
+     */
+    QgsAbstractMapToolHandler( QgsMapTool *tool, QAction *action );
+
+    virtual ~QgsAbstractMapToolHandler();
+
+    /**
+     * Returns the tool associated with this handler.
+     */
+    QgsMapTool *mapTool();
+
+    /**
+     * Returns the action associated with toggling the tool.
+     */
+    QAction *action();
+
+    /**
+     * Returns TRUE if the associated map tool is compatible with the specified \a layer.
+     *
+     * Additional information is available through the \a context argument.
+    */
+    virtual bool isCompatibleWithLayer( QgsMapLayer *layer, const QgsAbstractMapToolHandler::Context &context ) = 0;
+
+    /**
+     * Sets the \a layer to use for the tool.
+     *
+     * Called whenever a new layer should be associated with the tool, e.g. as a result of the
+     * user selecting a different active layer.
+     *
+     * The default implementation does nothing.
+     */
+    virtual void setLayerForTool( QgsMapLayer *layer );
+
+  private:
+
+    QgsMapTool *mMapTool = nullptr;
+    QAction *mAction = nullptr;
+};
+
+#endif // QGSABSTRACTMAPTOOLHANDLER_H


### PR DESCRIPTION
Having had to do this for a plugin this week I've realised what a nightmare it is for plugin authors to handle. At best you can get about 60% of the native map tool behavior reimplemented, but it's ends up being a horrible amount of fragile code (including things like finding child widgets from the main window).

So instead, this PR provides an iface method and new class for delegating all responsibility and logic for activating a custom map tool and ensuring it can only be enabled in the right circumstances to QGIS app

From the dox:

An abstract base class for map tool handlers which automatically handle all the necessary
logic for toggling the map tool and enabling/disabling the associated action
when the QGIS application is in a state permissible for the tool.

Creating these handlers avoids a lot of complex setup code and manual connections
which are otherwise necessary to ensure that a map tool is correctly activated and
deactivated when the state of the QGIS application changes (e.g. when the active
layer is changed, when edit modes are toggled, when other map tools are switched
to, etc).

- ### Example

```
  class MyMapTool(QgsMapTool):
     ...

  class MyMapToolHandler(QgsAbstractMapToolHandler):

     def __init__(self, tool, action):
         super().__init__(tool, action)

     def isCompatibleWithLayer(self, layer, context):
         # this tool can only be activated when an editable vector layer is selected
         return isinstance(layer, QgsVectorLayer) and layer.isEditable()

  my_tool = MyMapTool()
  my_action = QAction('My Map Tool')

  my_handler = MyMapToolHandler(my_tool, my_action)
  iface.registerMapToolHandler(my_handler)
```
