### PR TITLE
Fix #38468 NOT taking the range.begin into account

### DIFF
--- a/src/core/qgsvectorlayertemporalproperties.cpp
+++ b/src/core/qgsvectorlayertemporalproperties.cpp
@@ -440,10 +440,10 @@ QString QgsVectorLayerTemporalProperties::createFilterString( const QgsVectorLay
       }
       else
       {
-        return QStringLiteral( "(%1 %2 %3 AND %1 %4 %5) OR %1 IS NULL" ).arg( QgsExpression::quotedColumnRef( mStartFieldName ),
-               range.includeBeginning() ? QStringLiteral( ">=" ) : QStringLiteral( ">" ),
+        // Working with features with events with a duration, so taking this duration into account (+ QgsInterval( -mFixedDuration, mDurationUnit ) ))
+        // Then we are NOT taking the range.includeBeginning() and range.includeEnd() into account (deliberatly, see #38468)
+        return QStringLiteral( "(%1 > %2 AND %1 < %3) OR %1 IS NULL" ).arg( QgsExpression::quotedColumnRef( mStartFieldName ),
                dateTimeExpressionLiteral( range.begin() + QgsInterval( -mFixedDuration, mDurationUnit ) ),
-               range.includeEnd() ? QStringLiteral( "<=" ) : QStringLiteral( "<" ),
                dateTimeExpressionLiteral( range.end() ) );
       }
     }

--- a/src/core/qgsvectorlayertemporalproperties.cpp
+++ b/src/core/qgsvectorlayertemporalproperties.cpp
@@ -441,7 +441,7 @@ QString QgsVectorLayerTemporalProperties::createFilterString( const QgsVectorLay
       else
       {
         // Working with features with events with a duration, so taking this duration into account (+ QgsInterval( -mFixedDuration, mDurationUnit ) ))
-        // Then we are NOT taking the range.includeBeginning() and range.includeEnd() into account (deliberatly, see #38468)
+        // Then we are NOT taking the range.includeBeginning() and range.includeEnd() into account (deliberately, see #38468)
         return QStringLiteral( "(%1 > %2 AND %1 < %3) OR %1 IS NULL" ).arg( QgsExpression::quotedColumnRef( mStartFieldName ),
                dateTimeExpressionLiteral( range.begin() + QgsInterval( -mFixedDuration, mDurationUnit ) ),
                dateTimeExpressionLiteral( range.end() ) );

--- a/tests/src/python/test_qgsvectorlayertemporalproperties.py
+++ b/tests/src/python/test_qgsvectorlayertemporalproperties.py
@@ -177,18 +177,17 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         props.setFixedDuration(3)
         props.setDurationUnits(QgsUnitTypes.TemporalDays)
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)))
-        self.assertEqual(props.createFilterString(context, range), '("start_field" >= make_datetime(2019,3,1,11,12,13) AND "start_field" <= make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
+        self.assertEqual(props.createFilterString(context, range), '("start_field" > make_datetime(2019,3,1,11,12,13) AND "start_field" < make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
 
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeBeginning=False)
-        self.assertEqual(props.createFilterString(context, range), '("start_field" > make_datetime(2019,3,1,11,12,13) AND "start_field" <= make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
+        self.assertEqual(props.createFilterString(context, range), '("start_field" > make_datetime(2019,3,1,11,12,13) AND "start_field" < make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
 
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeEnd=False)
-        self.assertEqual(props.createFilterString(context, range), '("start_field" >= make_datetime(2019,3,1,11,12,13) AND "start_field" < make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
+        self.assertEqual(props.createFilterString(context, range), '("start_field" > make_datetime(2019,3,1,11,12,13) AND "start_field" < make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
 
         props.setDurationUnits(QgsUnitTypes.TemporalMinutes)
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)))
-        self.assertEqual(props.createFilterString(context, range),
-                         '("start_field" >= make_datetime(2019,3,4,11,9,13) AND "start_field" <= make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
+        self.assertEqual(props.createFilterString(context, range), '("start_field" > make_datetime(2019,3,4,11,9,13) AND "start_field" < make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
 
         # accumulate mode
         props.setAccumulateFeatures(True)


### PR DESCRIPTION
See #38468 for more discussion.

Reasoning is: if working with events with duration of exact 1hour
you do NOT want to see 2 of them show up if your temporal view
frame is also exact 1 hour

I added some comments in the code, because for me it was pretty hard to find this out. 
If for others though this is very clear, feel free to remove the commit

Mmm, maybe this deserves a test...  what about pulling this in 3.16 and I promise I create one :-)
(creating tests takes me always so much time...)
