### PR TITLE
Some tweaks to Mesh layer properties

### DIFF
--- a/src/app/3d/qgsmesh3dsymbolwidget.cpp
+++ b/src/app/3d/qgsmesh3dsymbolwidget.cpp
@@ -37,7 +37,7 @@ QgsMesh3dSymbolWidget::QgsMesh3dSymbolWidget( QgsMeshLayer *meshLayer, QWidget *
   setLayer( meshLayer );
 
   connect( mChkSmoothTriangles, &QCheckBox::clicked, this, &QgsMesh3dSymbolWidget::changed );
-  connect( mChkWireframe, &QCheckBox::clicked, this, &QgsMesh3dSymbolWidget::changed );
+  connect( mGroupBoxWireframe, &QGroupBox::toggled, this, &QgsMesh3dSymbolWidget::changed );
   connect( mColorButtonWireframe, &QgsColorButton::colorChanged, this, &QgsMesh3dSymbolWidget::changed );
   connect( mSpinBoxWireframeLineWidth, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ),
            this, &QgsMesh3dSymbolWidget::changed );
@@ -75,7 +75,7 @@ void QgsMesh3dSymbolWidget::setSymbol( const QgsMesh3DSymbol *symbol )
 {
   mSymbol.reset( symbol->clone() );
   mChkSmoothTriangles->setChecked( symbol->smoothedTriangles() );
-  mChkWireframe->setChecked( symbol->wireframeEnabled() );
+  mGroupBoxWireframe->setChecked( symbol->wireframeEnabled() );
   mColorButtonWireframe->setColor( symbol->wireframeLineColor() );
   mSpinBoxWireframeLineWidth->setValue( symbol->wireframeLineWidth() );
   mSpinBoxVerticaleScale->setValue( symbol->verticalScale() );
@@ -154,7 +154,7 @@ std::unique_ptr<QgsMesh3DSymbol> QgsMesh3dSymbolWidget::symbol() const
   std::unique_ptr< QgsMesh3DSymbol > sym( mSymbol->clone() );
 
   sym->setSmoothedTriangles( mChkSmoothTriangles->isChecked() );
-  sym->setWireframeEnabled( mChkWireframe->isChecked() );
+  sym->setWireframeEnabled( mGroupBoxWireframe->isChecked() );
   sym->setWireframeLineColor( mColorButtonWireframe->color() );
   sym->setWireframeLineWidth( mSpinBoxWireframeLineWidth->value() );
   sym->setVerticalScale( mSpinBoxVerticaleScale->value() );

--- a/src/gui/mesh/qgsmeshrenderervectorsettingswidget.cpp
+++ b/src/gui/mesh/qgsmeshrenderervectorsettingswidget.cpp
@@ -199,7 +199,8 @@ void QgsMeshRendererVectorSettingsWidget::syncToLayer( )
   const QgsMeshRendererSettings rendererSettings = mMeshLayer->rendererSettings();
   const QgsMeshRendererVectorSettings settings = rendererSettings.vectorSettings( mActiveDatasetGroup );
 
-  mSymbologyGroupBox->setVisible( hasFaces );
+  symbologyLabel->setVisible( hasFaces );
+  mSymbologyVectorComboBox->setVisible( hasFaces );
   mSymbologyVectorComboBox->setCurrentIndex( hasFaces ? settings.symbology() : 0 );
 
   // Arrow settings
@@ -263,7 +264,11 @@ void QgsMeshRendererVectorSettingsWidget::onSymbologyChanged( int currentIndex )
   mTracesGroupBox->setVisible( currentIndex == QgsMeshRendererVectorSettings::Traces );
 
   mDisplayVectorsOnGridGroupBox->setVisible( currentIndex != QgsMeshRendererVectorSettings::Traces );
-  mFilterByMagGroupBox->setVisible( currentIndex != QgsMeshRendererVectorSettings::Traces );
+  filterByMagnitudeLabel->setVisible( currentIndex != QgsMeshRendererVectorSettings::Traces );
+  minimumMagLabel->setVisible( currentIndex != QgsMeshRendererVectorSettings::Traces );
+  mMinMagLineEdit->setVisible( currentIndex != QgsMeshRendererVectorSettings::Traces );
+  maximumMagLabel->setVisible( currentIndex != QgsMeshRendererVectorSettings::Traces );
+  mMaxMagLineEdit->setVisible( currentIndex != QgsMeshRendererVectorSettings::Traces );
 
   mDisplayVectorsOnGridGroupBox->setEnabled(
     currentIndex == QgsMeshRendererVectorSettings::Arrows ||
@@ -284,7 +289,7 @@ void QgsMeshRendererVectorSettingsWidget::onColoringMethodChanged()
 {
   mColorRampShaderGroupBox->setVisible( mColoringMethodComboBox->currentData() == QgsInterpolatedLineColor::ColorRamp );
   mColorWidget->setVisible( mColoringMethodComboBox->currentData() == QgsInterpolatedLineColor::SingleColor );
-  mSimgleColorLabel->setVisible( mColoringMethodComboBox->currentData() == QgsInterpolatedLineColor::SingleColor );
+  mSingleColorLabel->setVisible( mColoringMethodComboBox->currentData() == QgsInterpolatedLineColor::SingleColor );
 
   if ( mColorRampShaderWidget->shader().colorRampItemList().isEmpty() )
     loadColorRampShader();

--- a/src/ui/3d/qgsmesh3dpropswidget.ui
+++ b/src/ui/3d/qgsmesh3dpropswidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>325</width>
-    <height>566</height>
+    <height>623</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -32,46 +32,59 @@
       <string>Triangles Settings</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="mChkSmoothTriangles">
-        <property name="text">
-         <string>Smooth triangles</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="mChkWireframe">
-        <property name="text">
-         <string>Wireframe</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0" colspan="2">
        <widget class="QGroupBox" name="mGroupBoxWireframe">
         <property name="title">
-         <string>Wireframe Line Width And Color</string>
+         <string>Show wireframe</string>
         </property>
-        <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
-         <item>
-          <widget class="QgsDoubleSpinBox" name="mSpinBoxWireframeLineWidth" native="true">
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_2">
+         <item row="0" column="1">
+          <widget class="QgsDoubleSpinBox" name="mSpinBoxWireframeLineWidth">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <property name="suffix" stdset="0">
+           <property name="suffix">
             <string> px</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>1.000000000000000</double>
            </property>
           </widget>
          </item>
-         <item>
+         <item row="1" column="1">
           <widget class="QgsColorButton" name="mColorButtonWireframe"/>
          </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_9">
+           <property name="text">
+            <string>Line width</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_10">
+           <property name="text">
+            <string>Color</string>
+           </property>
+          </widget>
+         </item>
         </layout>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="mChkSmoothTriangles">
+        <property name="text">
+         <string>Smooth triangles</string>
+        </property>
        </widget>
       </item>
      </layout>
@@ -91,17 +104,17 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QgsDoubleSpinBox" name="mSpinBoxVerticaleScale" native="true">
+       <widget class="QgsDoubleSpinBox" name="mSpinBoxVerticaleScale">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="maximum" stdset="0">
+        <property name="maximum">
          <double>9999999.990000000223517</double>
         </property>
-        <property name="value" stdset="0">
+        <property name="value">
          <double>1.000000000000000</double>
         </property>
        </widget>
@@ -195,6 +208,12 @@
       </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label_5">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Rendering Style</string>
         </property>
@@ -361,10 +380,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsColorRampShaderWidget</class>
-   <extends>QWidget</extends>
-   <header>raster/qgscolorrampshaderwidget.h</header>
-   <container>1</container>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsColorButton</class>
@@ -379,11 +397,29 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
+   <class>QgsColorRampShaderWidget</class>
    <extends>QWidget</extends>
-   <header>qgsdoublespinbox.h</header>
+   <header>raster/qgscolorrampshaderwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mChkSmoothTriangles</tabstop>
+  <tabstop>mGroupBoxWireframe</tabstop>
+  <tabstop>mSpinBoxWireframeLineWidth</tabstop>
+  <tabstop>mColorButtonWireframe</tabstop>
+  <tabstop>mSpinBoxVerticaleScale</tabstop>
+  <tabstop>mComboBoxDatasetVertical</tabstop>
+  <tabstop>mCheckBoxVerticalMagnitudeRelative</tabstop>
+  <tabstop>mComboBoxTextureType</tabstop>
+  <tabstop>mColorRampShaderMinEdit</tabstop>
+  <tabstop>mColorRampShaderMaxEdit</tabstop>
+  <tabstop>mColorRampShaderMinMaxReloadButton</tabstop>
+  <tabstop>mMeshSingleColorButton</tabstop>
+  <tabstop>mGroupBoxArrowsSettings</tabstop>
+  <tabstop>mArrowsSpacingSpinBox</tabstop>
+  <tabstop>mArrowsFixedSizeCheckBox</tabstop>
+ </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>
  </resources>

--- a/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>376</width>
-    <height>1000</height>
+    <width>399</width>
+    <height>861</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -26,520 +26,26 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item>
-    <widget class="QGroupBox" name="mSymbologyGroupBox">
-     <property name="title">
-      <string>Symbology</string>
-     </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <widget class="QComboBox" name="mSymbologyVectorComboBox">
-        <item>
-         <property name="text">
-          <string>Arrows</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Streamlines</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Traces</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+   <item row="5" column="1">
+    <widget class="QgsColorButton" name="mColorWidget"/>
    </item>
-   <item>
-    <widget class="QGroupBox" name="arrowWidthColorGroupBox">
-     <property name="title">
-      <string>Line Width and Color</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="3">
-       <widget class="QComboBox" name="mColoringMethodComboBox"/>
-      </item>
-      <item row="0" column="1">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="0" column="0">
-       <widget class="QgsDoubleSpinBox" name="mLineWidthSpinBox" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Coloring Method</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" rowspan="2" colspan="4">
-       <widget class="QgsCollapsibleGroupBox" name="mColorRampShaderGroupBox">
-        <property name="title">
-         <string>Color Ramp Shader</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_5">
-         <item row="0" column="4">
-          <widget class="QPushButton" name="mColorRampShaderLoadButton">
-           <property name="text">
-            <string/>
-           </property>
-           <property name="icon">
-            <iconset resource="../../../images/images.qrc">
-             <normaloff>:/images/themes/default/mActionRefresh.svg</normaloff>:/images/themes/default/mActionRefresh.svg</iconset>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0" colspan="5">
-          <widget class="Line" name="line">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="2">
-          <widget class="QLabel" name="label_5">
-           <property name="text">
-            <string>Max</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="3">
-          <widget class="QLineEdit" name="mColorRampShaderMaximumEditLine"/>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Min</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLineEdit" name="mColorRampShaderMinimumEditLine"/>
-         </item>
-         <item row="2" column="0" colspan="5">
-          <widget class="QgsColorRampShaderWidget" name="mColorRampShaderWidget" native="true">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QgsColorButton" name="mColorWidget"/>
-      </item>
-      <item row="1" column="1" colspan="2">
-       <widget class="QLabel" name="mSimgleColorLabel">
-        <property name="text">
-         <string>Color</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+   <item row="4" column="1">
+    <widget class="QComboBox" name="mColoringMethodComboBox"/>
    </item>
-   <item>
-    <widget class="QGroupBox" name="mFilterByMagGroupBox">
-     <property name="title">
-      <string>Filter by Magnitude</string>
+   <item row="15" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <property name="checked">
-      <bool>false</bool>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <item>
-       <widget class="QLabel" name="minimumMagLabel">
-        <property name="text">
-         <string>Min</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLineEdit" name="mMinMagLineEdit"/>
-      </item>
-      <item>
-       <widget class="QLabel" name="maximumMagLabel">
-        <property name="text">
-         <string>Max</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLineEdit" name="mMaxMagLineEdit"/>
-      </item>
-     </layout>
-    </widget>
+    </spacer>
    </item>
-   <item>
-    <widget class="QGroupBox" name="mDisplayVectorsOnGridGroupBox">
-     <property name="title">
-      <string>Display on User Grid</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="xSpacingLabel">
-          <property name="text">
-           <string>X Spacing</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="ySpacingLabel">
-          <property name="text">
-           <string>Y Spacing</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QgsSpinBox" name="mXSpacingSpinBox">
-          <property name="suffix">
-           <string> px</string>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>8000</number>
-          </property>
-          <property name="singleStep">
-           <number>10</number>
-          </property>
-          <property name="value">
-           <number>10</number>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QgsSpinBox" name="mYSpacingSpinBox">
-          <property name="suffix">
-           <string> px</string>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>5000</number>
-          </property>
-          <property name="singleStep">
-           <number>10</number>
-          </property>
-          <property name="value">
-           <number>10</number>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QWidget" name="mArrowWidget" native="true">
-     <layout class="QVBoxLayout" name="verticalLayout_4">
-      <property name="spacing">
-       <number>6</number>
-      </property>
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QGroupBox" name="headOptionsGroupBox">
-        <property name="title">
-         <string>Head Options</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_4">
-         <item row="0" column="0">
-          <widget class="QLabel" name="headWidthLabel">
-           <property name="text">
-            <string>Width</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLineEdit" name="mHeadWidthLineEdit"/>
-         </item>
-         <item row="0" column="2">
-          <widget class="QLabel" name="percShaftLenLabel">
-           <property name="text">
-            <string>% of shaft length</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="headLengthLabel">
-           <property name="text">
-            <string>Length</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QLineEdit" name="mHeadLengthLineEdit"/>
-         </item>
-         <item row="1" column="2">
-          <widget class="QLabel" name="percShaftLenLabel_2">
-           <property name="text">
-            <string>% of shaft length</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="generalOptionsGroupBox">
-        <property name="title">
-         <string>Arrow Length</string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
-         <item>
-          <widget class="QComboBox" name="mShaftLengthComboBox">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="sizeAdjustPolicy">
-            <enum>QComboBox::AdjustToContents</enum>
-           </property>
-           <item>
-            <property name="text">
-             <string>Defined by Min and Max</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Scaled to Magnitude</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Fixed</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item>
-          <widget class="QStackedWidget" name="mShaftOptionsStackedWidget">
-           <property name="currentIndex">
-            <number>0</number>
-           </property>
-           <widget class="QWidget" name="page">
-            <layout class="QFormLayout" name="formLayout">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="minimumShaftLabel">
-               <property name="text">
-                <string>Minimum</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLineEdit" name="mMinimumShaftLineEdit"/>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="maximumShaftLabel">
-               <property name="text">
-                <string>Maximum</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QLineEdit" name="mMaximumShaftLineEdit"/>
-             </item>
-            </layout>
-           </widget>
-           <widget class="QWidget" name="page_2">
-            <layout class="QFormLayout" name="formLayout_2">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="scaleByFactorOfLabel">
-               <property name="text">
-                <string>Scale by a factor of</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLineEdit" name="mScaleShaftByFactorOfLineEdit"/>
-             </item>
-            </layout>
-           </widget>
-           <widget class="QWidget" name="page_3">
-            <layout class="QFormLayout" name="formLayout_3">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="LengthLabel">
-               <property name="text">
-                <string>Length</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLineEdit" name="mShaftLengthLineEdit"/>
-             </item>
-            </layout>
-           </widget>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QWidget" name="widget" native="true">
-     <layout class="QVBoxLayout" name="verticalLayout_5">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QGroupBox" name="mStreamlineWidget">
-        <property name="title">
-         <string>Streamlines Seeding Method</string>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="3,2">
-         <item>
-          <widget class="QComboBox" name="mStreamlinesSeedingMethodComboBox">
-           <item>
-            <property name="text">
-             <string>On Mesh/Grid</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Randomly</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="mStreamlinesDensityLabel">
-             <property name="text">
-              <string>Density</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QgsDoubleSpinBox" name="mStreamlinesDensitySpinBox">
-             <property name="suffix">
-              <string>%</string>
-             </property>
-             <property name="decimals">
-              <number>1</number>
-             </property>
-             <property name="value">
-              <double>5.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
+   <item row="14" column="0" colspan="2">
     <widget class="QGroupBox" name="mTracesGroupBox">
      <property name="title">
       <string>Traces</string>
@@ -629,47 +135,500 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+   <item row="6" column="0" colspan="2">
+    <widget class="QgsCollapsibleGroupBox" name="mColorRampShaderGroupBox">
+     <property name="title">
+      <string>Color Ramp Shader</string>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="4">
+       <widget class="QPushButton" name="mColorRampShaderLoadButton">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset resource="../../../images/images.qrc">
+          <normaloff>:/images/themes/default/mActionRefresh.svg</normaloff>:/images/themes/default/mActionRefresh.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="5">
+       <widget class="Line" name="line">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Max</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLineEdit" name="mColorRampShaderMaximumEditLine"/>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Min</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="mColorRampShaderMinimumEditLine"/>
+      </item>
+      <item row="2" column="0" colspan="5">
+       <widget class="QgsColorRampShaderWidget" name="mColorRampShaderWidget" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Coloring Method</string>
      </property>
-    </spacer>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="mSymbologyVectorComboBox">
+     <item>
+      <property name="text">
+       <string>Arrows</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Streamlines</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Traces</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <layout class="QGridLayout" name="gridLayout_3">
+     <item row="0" column="1">
+      <widget class="QLabel" name="minimumMagLabel">
+       <property name="text">
+        <string>Min</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLabel" name="maximumMagLabel">
+       <property name="text">
+        <string>Max</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QLineEdit" name="mMaxMagLineEdit"/>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLineEdit" name="mMinMagLineEdit"/>
+     </item>
+     <item row="0" column="0" rowspan="2">
+      <widget class="QLabel" name="filterByMagnitudeLabel">
+       <property name="text">
+        <string>Filter by magnitude</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="13" column="0" colspan="2">
+    <widget class="QGroupBox" name="mStreamlineWidget">
+     <property name="title">
+      <string>Streamlines Seeding Method</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="3,2">
+      <item>
+       <widget class="QComboBox" name="mStreamlinesSeedingMethodComboBox">
+        <item>
+         <property name="text">
+          <string>On Mesh/Grid</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Randomly</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="mStreamlinesDensityLabel">
+          <property name="text">
+           <string>Density</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsDoubleSpinBox" name="mStreamlinesDensitySpinBox">
+          <property name="suffix">
+           <string>%</string>
+          </property>
+          <property name="decimals">
+           <number>1</number>
+          </property>
+          <property name="value">
+           <double>5.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="symbologyLabel">
+     <property name="text">
+      <string>Symbology</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Line width</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0" colspan="2">
+    <widget class="QGroupBox" name="mDisplayVectorsOnGridGroupBox">
+     <property name="title">
+      <string>Display on User Grid</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="xSpacingLabel">
+        <property name="text">
+         <string>X Spacing</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsSpinBox" name="mXSpacingSpinBox">
+        <property name="suffix">
+         <string> px</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>8000</number>
+        </property>
+        <property name="singleStep">
+         <number>10</number>
+        </property>
+        <property name="value">
+         <number>10</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="ySpacingLabel">
+        <property name="text">
+         <string>Y Spacing</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QgsSpinBox" name="mYSpacingSpinBox">
+        <property name="suffix">
+         <string> px</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>5000</number>
+        </property>
+        <property name="singleStep">
+         <number>10</number>
+        </property>
+        <property name="value">
+         <number>10</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="11" column="0" colspan="2">
+    <widget class="QGroupBox" name="headOptionsGroupBox">
+     <property name="title">
+      <string>Head Options</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QLabel" name="headWidthLabel">
+        <property name="text">
+         <string>Width</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="mHeadWidthLineEdit"/>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="percShaftLenLabel">
+        <property name="text">
+         <string>% of shaft length</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="headLengthLabel">
+        <property name="text">
+         <string>Length</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="mHeadLengthLineEdit"/>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="percShaftLenLabel_2">
+        <property name="text">
+         <string>% of shaft length</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="mSingleColorLabel">
+     <property name="text">
+      <string>Color</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QgsDoubleSpinBox" name="mLineWidthSpinBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0" colspan="2">
+    <widget class="QGroupBox" name="generalOptionsGroupBox">
+     <property name="title">
+      <string>Arrow Length</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QComboBox" name="mShaftLengthComboBox">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+        <item>
+         <property name="text">
+          <string>Defined by Min and Max</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Scaled to Magnitude</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Fixed</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item>
+       <widget class="QStackedWidget" name="mShaftOptionsStackedWidget">
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <widget class="QWidget" name="page">
+         <layout class="QFormLayout" name="formLayout">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="minimumShaftLabel">
+            <property name="text">
+             <string>Minimum</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="mMinimumShaftLineEdit"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="maximumShaftLabel">
+            <property name="text">
+             <string>Maximum</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="mMaximumShaftLineEdit"/>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="page_2">
+         <layout class="QFormLayout" name="formLayout_2">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="scaleByFactorOfLabel">
+            <property name="text">
+             <string>Scale by a factor of</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="mScaleShaftByFactorOfLineEdit"/>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="page_3">
+         <layout class="QFormLayout" name="formLayout_3">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="LengthLabel">
+            <property name="text">
+             <string>Length</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="mShaftLengthLineEdit"/>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="mArrowWidget" native="true">
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsUnitSelectionWidget</class>
-   <extends>QComboBox</extends>
-   <header>qgsunitselectionwidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorRampShaderWidget</class>
-   <extends>QWidget</extends>
-   <header>raster/qgscolorrampshaderwidget.h</header>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -678,7 +637,50 @@
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsColorRampShaderWidget</class>
+   <extends>QWidget</extends>
+   <header>raster/qgscolorrampshaderwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsUnitSelectionWidget</class>
+   <extends>QComboBox</extends>
+   <header>qgsunitselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mSymbologyVectorComboBox</tabstop>
+  <tabstop>mLineWidthSpinBox</tabstop>
+  <tabstop>mColoringMethodComboBox</tabstop>
+  <tabstop>mColorWidget</tabstop>
+  <tabstop>mColorRampShaderMinimumEditLine</tabstop>
+  <tabstop>mColorRampShaderMaximumEditLine</tabstop>
+  <tabstop>mColorRampShaderLoadButton</tabstop>
+  <tabstop>mMinMagLineEdit</tabstop>
+  <tabstop>mMaxMagLineEdit</tabstop>
+  <tabstop>mDisplayVectorsOnGridGroupBox</tabstop>
+  <tabstop>mXSpacingSpinBox</tabstop>
+  <tabstop>mYSpacingSpinBox</tabstop>
+  <tabstop>mHeadWidthLineEdit</tabstop>
+  <tabstop>mHeadLengthLineEdit</tabstop>
+  <tabstop>mShaftLengthComboBox</tabstop>
+  <tabstop>mMinimumShaftLineEdit</tabstop>
+  <tabstop>mMaximumShaftLineEdit</tabstop>
+  <tabstop>mStreamlinesSeedingMethodComboBox</tabstop>
+  <tabstop>mStreamlinesDensitySpinBox</tabstop>
+  <tabstop>mTracesParticlesCountSpinBox</tabstop>
+  <tabstop>mTracesMaxLengthSpinBox</tabstop>
+  <tabstop>mTracesTailLengthMapUnitWidget</tabstop>
+  <tabstop>mShaftLengthLineEdit</tabstop>
+  <tabstop>mScaleShaftByFactorOfLineEdit</tabstop>
+ </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>
  </resources>


### PR DESCRIPTION
Reduce number of group frames for plain properties (I think we can do more here but...)
![old_vectors](https://user-images.githubusercontent.com/7983394/96986373-d7967d00-1521-11eb-8344-bb543c038417.png)

Make the wireframe checkbox and settings relation more obvious/dependent

![meshWireframe](https://user-images.githubusercontent.com/7983394/96978452-ab2d3180-151e-11eb-8261-adda61dd64f6.png)
