### PR TITLE
windows: use Threads along with HDF5 in mdal provider on windows

### DIFF
--- a/src/providers/mdal/CMakeLists.txt
+++ b/src/providers/mdal/CMakeLists.txt
@@ -18,6 +18,10 @@ IF (WITH_GUI)
 ENDIF ()
 
 SET(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/external/mdal/cmake ${CMAKE_MODULE_PATH})
+IF(MSVC)
+  # HDF5 with enabled thread safety (HDF5_ENABLE_THREADSAFE=ON) on Windows needs Threads::Threads
+  FIND_PACKAGE(Threads)
+ENDIF(MSVC)
 FIND_PACKAGE(HDF5)
 FIND_PACKAGE(NetCDF)
 FIND_PACKAGE(LibXml2)


### PR DESCRIPTION
 (for HDF5_ENABLE_THREADSAFE=ON)

(cherry picked from commit 12a44c7829dda01dfa9ebc35f6d56bd6d295833f)