### PR TITLE
Native DXF export algorithm

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingparameterdxflayers.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameterdxflayers.sip.in
@@ -1,0 +1,112 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/processing/qgsprocessingparameterdxflayers.h                *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsProcessingParameterDxfLayers : QgsProcessingParameterDefinition
+{
+%Docstring
+A parameter for Processing algorithms that need a list of input vector
+layers to export as DXF file - this parameter provides Processing
+framework's adapter for QList<QgsDxfExport.DxfLayer>.
+
+A valid value for this parameter is a list (QVariantList), where each
+item is a map (QVariantMap) in this form:
+{
+'layer':  string or QgsMapLayer,
+'attributeIndex': int
+}
+
+Static functions :py:func:`~parametersAsLayers`, :py:func:`~variantMapAsLayer`,
+:py:func:`~layerAsVariantMap` provide conversion between QgsDxfExport.DxfLayer
+representation and QVariant representation.
+
+.. note::
+
+   This class is not a part of public API.
+
+.. versionadded:: 3.18
+%End
+
+%TypeHeaderCode
+#include "qgsprocessingparameterdxflayers.h"
+%End
+  public:
+    QgsProcessingParameterDxfLayers( const QString &name, const QString &description = QString() );
+%Docstring
+Constructor for QgsProcessingParameterDxfLayers.
+%End
+
+    virtual QgsProcessingParameterDefinition *clone() const;
+
+    virtual QString type() const;
+
+    virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
+
+    virtual QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const;
+
+    virtual QString asPythonString( QgsProcessing::PythonOutputType outputType = QgsProcessing::PythonQgsProcessingAlgorithmSubclass ) const;
+
+
+    static QString typeName();
+%Docstring
+Returns the type name for the parameter class.
+%End
+    static QList<QgsDxfExport::DxfLayer> parameterAsLayers( const QVariant &layersVariant, QgsProcessingContext &context );
+%Docstring
+Converts a QVariant value (a QVariantList) to a list of input layers
+%End
+    static QgsDxfExport::DxfLayer variantMapAsLayer( const QVariantMap &layerVariantMap, QgsProcessingContext &context );
+%Docstring
+Converts a QVariant value (a QVariantMap) to a single input layer
+%End
+    static QVariantMap layerAsVariantMap( const QgsDxfExport::DxfLayer &layer );
+%Docstring
+Converts a single input layer to QVariant representation (a QVariantMap)
+%End
+};
+
+
+class QgsProcessingParameterTypeDxfLayers : QgsProcessingParameterType
+{
+%Docstring
+Parameter type definition for QgsProcessingParameterDxfLayers.
+
+.. note::
+
+   This class is not a part of public API.
+
+.. versionadded:: 3.18
+%End
+
+%TypeHeaderCode
+#include "qgsprocessingparameterdxflayers.h"
+%End
+  public:
+    virtual QgsProcessingParameterDefinition *create( const QString &name ) const /Factory/;
+
+    virtual QString description() const;
+
+    virtual QString name() const;
+
+    virtual QString id() const;
+
+    virtual QString pythonImportString() const;
+
+    virtual QString className() const;
+
+    virtual QStringList acceptedPythonTypes() const;
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/processing/qgsprocessingparameterdxflayers.h                *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/processing/qgsprocessingparameterdxflayers.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameterdxflayers.sip.in
@@ -22,6 +22,9 @@ item is a map (QVariantMap) in this form:
 'attributeIndex': int
 }
 
+Also it can accept lists (either string lists or QgsVectorLayer list)
+as well as individual layer object or string representing layer source.
+
 Static functions :py:func:`~parametersAsLayers`, :py:func:`~variantMapAsLayer`,
 :py:func:`~layerAsVariantMap` provide conversion between QgsDxfExport.DxfLayer
 representation and QVariant representation.

--- a/python/core/auto_generated/processing/qgsprocessingparameterdxflayers.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameterdxflayers.sip.in
@@ -71,38 +71,6 @@ Converts a single input layer to QVariant representation (a QVariantMap)
 };
 
 
-class QgsProcessingParameterTypeDxfLayers : QgsProcessingParameterType
-{
-%Docstring
-Parameter type definition for QgsProcessingParameterDxfLayers.
-
-.. note::
-
-   This class is not a part of public API.
-
-.. versionadded:: 3.18
-%End
-
-%TypeHeaderCode
-#include "qgsprocessingparameterdxflayers.h"
-%End
-  public:
-    virtual QgsProcessingParameterDefinition *create( const QString &name ) const /Factory/;
-
-    virtual QString description() const;
-
-    virtual QString name() const;
-
-    virtual QString id() const;
-
-    virtual QString pythonImportString() const;
-
-    virtual QString className() const;
-
-    virtual QStringList acceptedPythonTypes() const;
-};
-
-
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/core/auto_generated/processing/qgsprocessingparameterdxflayers.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameterdxflayers.sip.in
@@ -29,10 +29,6 @@ Static functions :py:func:`~parametersAsLayers`, :py:func:`~variantMapAsLayer`,
 :py:func:`~layerAsVariantMap` provide conversion between QgsDxfExport.DxfLayer
 representation and QVariant representation.
 
-.. note::
-
-   This class is not a part of public API.
-
 .. versionadded:: 3.18
 %End
 
@@ -45,7 +41,7 @@ representation and QVariant representation.
 Constructor for QgsProcessingParameterDxfLayers.
 %End
 
-    virtual QgsProcessingParameterDefinition *clone() const;
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
 
     virtual QString type() const;
 
@@ -105,6 +101,7 @@ Parameter type definition for QgsProcessingParameterDxfLayers.
 
     virtual QStringList acceptedPythonTypes() const;
 };
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -311,6 +311,8 @@ their acceptable ranges, defaults, etc.
       sipType = sipType_QgsProcessingParameterTinInputLayers;
     else if ( sipCpp->type() == QgsProcessingParameterVectorTileWriterLayers::typeName() )
       sipType = sipType_QgsProcessingParameterVectorTileWriterLayers;
+    else if ( sipCpp->type() == QgsProcessingParameterDxfLayers::typeName() )
+      sipType = sipType_QgsProcessingParameterDxfLayers;
     else
       sipType = nullptr;
 %End

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -226,6 +226,7 @@ their acceptable ranges, defaults, etc.
 %End
 %TypeHeaderCode
 #include "qgsprocessingparameteraggregate.h"
+#include "qgsprocessingparameterdxflayers.h"
 #include "qgsprocessingparameterfieldmap.h"
 #include "qgsprocessingparametertininputlayers.h"
 #include "qgsprocessingparametervectortilewriterlayers.h"

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -474,6 +474,7 @@
 %Include auto_generated/processing/qgsprocessingfeedback.sip
 %Include auto_generated/processing/qgsprocessingoutputs.sip
 %Include auto_generated/processing/qgsprocessingparameteraggregate.sip
+%Include auto_generated/processing/qgsprocessingparameterdxflayers.sip
 %Include auto_generated/processing/qgsprocessingparameterfieldmap.sip
 %Include auto_generated/processing/qgsprocessingparameters.sip
 %Include auto_generated/processing/qgsprocessingparametertininputlayers.sip

--- a/python/plugins/processing/tests/testdata/expected/dxfexport.dxf
+++ b/python/plugins/processing/tests/testdata/expected/dxfexport.dxf
@@ -1,0 +1,2994 @@
+999
+DXF created from QGIS
+  0
+SECTION
+  2
+HEADER
+  9
+$ACADVER
+  1
+AC1015
+  9
+$EXTMIN
+ 10
+0.0
+ 20
+-5.0
+ 30
+0.0
+  9
+$EXTMAX
+ 10
+8.0
+ 20
+3.0
+ 30
+0.0
+  9
+$LTSCALE
+ 40
+1.0
+  9
+$PDMODE
+ 70
+    33
+  9
+$PDSIZE
+ 40
+     1
+  9
+$PSLTSCALE
+ 70
+     0
+  9
+$HANDSEED
+  5
+9999999
+  9
+$DWGCODEPAGE
+  3
+8859_1
+  0
+ENDSEC
+  0
+SECTION
+  2
+TABLES
+  0
+TABLE
+  2
+LTYPE
+  5
+64
+100
+AcDbSymbolTable
+ 70
+     5
+  0
+LTYPE
+  5
+65
+100
+AcDbSymbolTableRecord
+100
+AcDbLinetypeTableRecord
+  2
+ByLayer
+ 70
+    64
+  3
+Defaultstyle
+ 72
+    65
+ 73
+     0
+ 40
+0.0
+  0
+LTYPE
+  5
+66
+100
+AcDbSymbolTableRecord
+100
+AcDbLinetypeTableRecord
+  2
+ByBlock
+ 70
+    64
+  3
+Defaultstyle
+ 72
+    65
+ 73
+     0
+ 40
+0.0
+  0
+LTYPE
+  5
+67
+100
+AcDbSymbolTableRecord
+100
+AcDbLinetypeTableRecord
+  2
+CONTINUOUS
+ 70
+    64
+  3
+Defaultstyle
+ 72
+    65
+ 73
+     0
+ 40
+0.0
+  0
+LTYPE
+  5
+68
+100
+AcDbSymbolTableRecord
+100
+AcDbLinetypeTableRecord
+  2
+DASH
+ 70
+    64
+  3
+
+ 72
+    65
+ 73
+     2
+ 40
+0.02335619738710756
+ 49
+0.01796630568239043
+ 74
+     0
+ 49
+-0.00538989170471713
+ 74
+     0
+  0
+LTYPE
+  5
+69
+100
+AcDbSymbolTableRecord
+100
+AcDbLinetypeTableRecord
+  2
+DOT
+ 70
+    64
+  3
+
+ 72
+    65
+ 73
+     2
+ 40
+0.01077978340943426
+ 49
+0.00538989170471713
+ 74
+     0
+ 49
+-0.00538989170471713
+ 74
+     0
+  0
+LTYPE
+  5
+6a
+100
+AcDbSymbolTableRecord
+100
+AcDbLinetypeTableRecord
+  2
+DASHDOT
+ 70
+    64
+  3
+
+ 72
+    65
+ 73
+     4
+ 40
+0.03413598079654181
+ 49
+0.01796630568239043
+ 74
+     0
+ 49
+-0.00538989170471713
+ 74
+     0
+ 49
+0.00538989170471713
+ 74
+     0
+ 49
+-0.00538989170471713
+ 74
+     0
+  0
+LTYPE
+  5
+6b
+100
+AcDbSymbolTableRecord
+100
+AcDbLinetypeTableRecord
+  2
+DASHDOTDOT
+ 70
+    64
+  3
+
+ 72
+    65
+ 73
+     6
+ 40
+0.04491576420597607
+ 49
+0.01796630568239043
+ 74
+     0
+ 49
+-0.00538989170471713
+ 74
+     0
+ 49
+0.00538989170471713
+ 74
+     0
+ 49
+-0.00538989170471713
+ 74
+     0
+ 49
+0.00538989170471713
+ 74
+     0
+ 49
+-0.00538989170471713
+ 74
+     0
+  0
+ENDTAB
+  0
+TABLE
+  2
+BLOCK_RECORD
+  5
+6c
+100
+AcDbSymbolTable
+ 70
+     0
+  0
+BLOCK_RECORD
+  5
+6d
+100
+AcDbSymbolTableRecord
+100
+AcDbBlockTableRecord
+  2
+*Model_Space
+  0
+BLOCK_RECORD
+  5
+6e
+100
+AcDbSymbolTableRecord
+100
+AcDbBlockTableRecord
+  2
+*Paper_Space
+  0
+BLOCK_RECORD
+  5
+6f
+100
+AcDbSymbolTableRecord
+100
+AcDbBlockTableRecord
+  2
+*Paper_Space0
+  0
+ENDTAB
+  0
+TABLE
+  2
+APPID
+  5
+70
+100
+AcDbSymbolTable
+ 70
+     1
+  0
+APPID
+  5
+71
+100
+AcDbSymbolTableRecord
+100
+AcDbRegAppTableRecord
+  2
+ACAD
+ 70
+     0
+  0
+ENDTAB
+  0
+TABLE
+  2
+VIEW
+  5
+72
+100
+AcDbSymbolTable
+ 70
+     0
+  0
+ENDTAB
+  0
+TABLE
+  2
+UCS
+  5
+73
+100
+AcDbSymbolTable
+ 70
+     0
+  0
+ENDTAB
+  0
+TABLE
+  2
+VPORT
+  5
+74
+100
+AcDbSymbolTable
+  0
+VPORT
+  5
+75
+100
+AcDbSymbolTableRecord
+100
+AcDbViewportTableRecord
+  2
+*ACTIVE
+ 70
+     0
+ 10
+0.0
+ 20
+0.0
+ 11
+1.0
+ 21
+1.0
+ 12
+0.0
+ 22
+0.0
+ 13
+0.0
+ 23
+0.0
+ 14
+1.0
+ 24
+1.0
+ 15
+1.0
+ 25
+1.0
+ 16
+0.0
+ 26
+0.0
+ 36
+1.0
+ 17
+4.0
+ 27
+-1.0
+ 40
+8.0
+ 41
+1.0
+ 42
+50.0
+ 43
+0.0
+ 44
+0.0
+ 50
+0.0
+ 51
+0.0
+ 71
+     0
+ 72
+   100
+ 73
+     1
+ 74
+     1
+ 75
+     0
+ 76
+     0
+ 77
+     0
+ 78
+     0
+281
+     0
+ 65
+     1
+110
+0.0
+120
+0.0
+130
+0.0
+111
+1.0
+121
+0.0
+131
+0.0
+112
+0.0
+122
+1.0
+132
+0.0
+ 79
+     0
+146
+0.0
+ 70
+     0
+  0
+ENDTAB
+  0
+TABLE
+  2
+DIMSTYLE
+  5
+76
+100
+AcDbSymbolTable
+100
+AcDbDimStyleTable
+ 70
+     0
+  0
+ENDTAB
+  0
+TABLE
+  2
+LAYER
+  5
+77
+100
+AcDbSymbolTable
+ 70
+     2
+  0
+LAYER
+  5
+78
+100
+AcDbSymbolTableRecord
+100
+AcDbLayerTableRecord
+  2
+0
+ 70
+    64
+ 62
+     1
+  6
+CONTINUOUS
+390
+f
+  0
+LAYER
+  5
+79
+100
+AcDbSymbolTableRecord
+100
+AcDbLayerTableRecord
+  2
+points
+ 70
+    64
+ 62
+     1
+  6
+CONTINUOUS
+390
+f
+  0
+ENDTAB
+  0
+TABLE
+  2
+STYLE
+  5
+7a
+100
+AcDbSymbolTable
+ 70
+     1
+  0
+STYLE
+  5
+7b
+100
+AcDbSymbolTableRecord
+100
+AcDbTextStyleTableRecord
+  2
+STANDARD
+ 70
+    64
+ 40
+0.0
+ 41
+1.0
+ 50
+0.0
+ 71
+     0
+ 42
+5.0
+  3
+romans.shx
+  4
+
+  0
+ENDTAB
+  0
+ENDSEC
+  0
+SECTION
+  2
+BLOCKS
+  0
+BLOCK
+  5
+7c
+330
+6d
+100
+AcDbEntity
+  8
+0
+100
+AcDbBlockBegin
+  2
+*Model_Space
+ 70
+     0
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  3
+*Model_Space
+  1
+
+  0
+ENDBLK
+  5
+7d
+100
+AcDbEntity
+  8
+0
+100
+AcDbBlockEnd
+  0
+BLOCK
+  5
+7e
+330
+6e
+100
+AcDbEntity
+  8
+0
+100
+AcDbBlockBegin
+  2
+*Paper_Space
+ 70
+     0
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  3
+*Paper_Space
+  1
+
+  0
+ENDBLK
+  5
+7f
+100
+AcDbEntity
+  8
+0
+100
+AcDbBlockEnd
+  0
+BLOCK
+  5
+80
+330
+6f
+100
+AcDbEntity
+  8
+0
+100
+AcDbBlockBegin
+  2
+*Paper_Space0
+ 70
+     0
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  3
+*Paper_Space0
+  1
+
+  0
+ENDBLK
+  5
+81
+100
+AcDbEntity
+  8
+0
+100
+AcDbBlockEnd
+  0
+ENDSEC
+  0
+SECTION
+  2
+ENTITIES
+  0
+POINT
+  5
+82
+100
+AcDbEntity
+100
+AcDbPoint
+  8
+points
+420
+     0
+ 10
+1.0
+ 20
+1.0
+  0
+POINT
+  5
+83
+100
+AcDbEntity
+100
+AcDbPoint
+  8
+points
+420
+     0
+ 10
+3.0
+ 20
+3.0
+  0
+POINT
+  5
+84
+100
+AcDbEntity
+100
+AcDbPoint
+  8
+points
+420
+     0
+ 10
+2.0
+ 20
+2.0
+  0
+POINT
+  5
+85
+100
+AcDbEntity
+100
+AcDbPoint
+  8
+points
+420
+     0
+ 10
+5.0
+ 20
+2.0
+  0
+POINT
+  5
+86
+100
+AcDbEntity
+100
+AcDbPoint
+  8
+points
+420
+     0
+ 10
+4.0
+ 20
+1.0
+  0
+POINT
+  5
+87
+100
+AcDbEntity
+100
+AcDbPoint
+  8
+points
+420
+     0
+ 10
+0.0
+ 20
+-5.0
+  0
+POINT
+  5
+88
+100
+AcDbEntity
+100
+AcDbPoint
+  8
+points
+420
+     0
+ 10
+8.0
+ 20
+-1.0
+  0
+POINT
+  5
+89
+100
+AcDbEntity
+100
+AcDbPoint
+  8
+points
+420
+     0
+ 10
+7.0
+ 20
+-1.0
+  0
+POINT
+  5
+8a
+100
+AcDbEntity
+100
+AcDbPoint
+  8
+points
+420
+     0
+ 10
+0.0
+ 20
+-1.0
+  0
+ENDSEC
+0
+SECTION
+2
+OBJECTS
+0
+DICTIONARY
+5
+C
+330
+0
+100
+AcDbDictionary
+281
+   1
+3
+ACAD_GROUP
+350
+D
+3
+ACAD_LAYOUT
+350
+1A
+3
+ACAD_MLEADERSTYLE
+350
+43
+3
+ACAD_MLINESTYLE
+350
+17
+3
+ACAD_PLOTSETTINGS
+350
+19
+3
+ACAD_PLOTSTYLENAME
+350
+E
+3
+ACAD_TABLESTYLE
+350
+42
+3
+ACAD_VISUALSTYLE
+350
+2A
+0
+DICTIONARY
+5
+D
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+   1
+0
+DICTIONARY
+5
+1A
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+   1
+3
+Layout1
+350
+1E
+3
+Layout2
+350
+26
+3
+Model
+350
+22
+0
+DICTIONARY
+5
+43
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+   1
+0
+DICTIONARY
+5
+17
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+   1
+3
+Standard
+350
+18
+0
+DICTIONARY
+5
+19
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+   1
+0
+ACDBDICTIONARYWDFLT
+5
+E
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+   1
+3
+Normal
+350
+F
+100
+AcDbDictionaryWithDefault
+340
+F
+0
+DICTIONARY
+5
+42
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+   1
+0
+DICTIONARY
+5
+2A
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+   1
+3
+2dWireframe
+350
+2F
+3
+3D Hidden
+350
+31
+3
+3dWireframe
+350
+30
+3
+Basic
+350
+32
+3
+Brighten
+350
+36
+3
+ColorChange
+350
+3A
+3
+Conceptual
+350
+34
+3
+Dim
+350
+35
+3
+Facepattern
+350
+39
+3
+Flat
+350
+2B
+3
+FlatWithEdges
+350
+2C
+3
+Gouraud
+350
+2D
+3
+GouraudWithEdges
+350
+2E
+3
+Linepattern
+350
+38
+3
+Realistic
+350
+33
+3
+Thicken
+350
+37
+0
+LAYOUT
+5
+1E
+102
+{ACAD_REACTORS
+330
+1A
+102
+}
+330
+1A
+100
+AcDbPlotSettings
+1
+
+2
+none_device
+4
+
+6
+
+40
+0.0
+41
+0.0
+42
+0.0
+43
+0.0
+44
+0.0
+45
+0.0
+46
+0.0
+47
+0.0
+48
+0.0
+49
+0.0
+140
+0.0
+141
+0.0
+142
+1.0
+143
+1.0
+70
+ 688
+72
+   0
+73
+   0
+74
+   5
+7
+
+75
+  16
+76
+   0
+77
+   2
+78
+ 300
+147
+1.0
+148
+0.0
+149
+0.0
+100
+AcDbLayout
+1
+Layout1
+70
+   1
+71
+   1
+10
+0.0
+20
+0.0
+11
+12.0
+21
+9.0
+12
+0.0
+22
+0.0
+32
+0.0
+14
+1.000000000000000E+20
+24
+1.000000000000000E+20
+34
+1.000000000000000E+20
+15
+-1.000000000000000E+20
+25
+-1.000000000000000E+20
+35
+-1.000000000000000E+20
+146
+0.0
+13
+0.0
+23
+0.0
+33
+0.0
+16
+1.0
+26
+0.0
+36
+0.0
+17
+0.0
+27
+1.0
+37
+0.0
+76
+   0
+330
+1B
+0
+LAYOUT
+5
+26
+102
+{ACAD_REACTORS
+330
+1A
+102
+}
+330
+1A
+100
+AcDbPlotSettings
+1
+
+2
+none_device
+4
+
+6
+
+40
+0.0
+41
+0.0
+42
+0.0
+43
+0.0
+44
+0.0
+45
+0.0
+46
+0.0
+47
+0.0
+48
+0.0
+49
+0.0
+140
+0.0
+141
+0.0
+142
+1.0
+143
+1.0
+70
+ 688
+72
+   0
+73
+   0
+74
+   5
+7
+
+75
+  16
+76
+   0
+77
+   2
+78
+ 300
+147
+1.0
+148
+0.0
+149
+0.0
+100
+AcDbLayout
+1
+Layout2
+70
+   1
+71
+   2
+10
+0.0
+20
+0.0
+11
+0.0
+21
+0.0
+12
+0.0
+22
+0.0
+32
+0.0
+14
+0.0
+24
+0.0
+34
+0.0
+15
+0.0
+25
+0.0
+35
+0.0
+146
+0.0
+13
+0.0
+23
+0.0
+33
+0.0
+16
+1.0
+26
+0.0
+36
+0.0
+17
+0.0
+27
+1.0
+37
+0.0
+76
+   0
+330
+23
+0
+LAYOUT
+5
+22
+102
+{ACAD_REACTORS
+330
+1A
+102
+}
+330
+1A
+100
+AcDbPlotSettings
+1
+
+2
+none_device
+4
+
+6
+
+40
+0.0
+41
+0.0
+42
+0.0
+43
+0.0
+44
+0.0
+45
+0.0
+46
+0.0
+47
+0.0
+48
+0.0
+49
+0.0
+140
+0.0
+141
+0.0
+142
+1.0
+143
+1.0
+70
+1712
+72
+   0
+73
+   0
+74
+   0
+7
+
+75
+   0
+76
+   0
+77
+   2
+78
+ 300
+147
+1.0
+148
+0.0
+149
+0.0
+100
+AcDbLayout
+1
+Model
+70
+   1
+71
+   0
+10
+0.0
+20
+0.0
+11
+12.0
+21
+9.0
+12
+0.0
+22
+0.0
+32
+0.0
+14
+30.0
+24
+49.75
+34
+0.0
+15
+130.5
+25
+163.1318914119703
+35
+0.0
+146
+0.0
+13
+0.0
+23
+0.0
+33
+0.0
+16
+1.0
+26
+0.0
+36
+0.0
+17
+0.0
+27
+1.0
+37
+0.0
+76
+   0
+330
+1F
+331
+29
+0
+MLINESTYLE
+5
+18
+102
+{ACAD_REACTORS
+330
+17
+102
+}
+330
+17
+100
+AcDbMlineStyle
+2
+Standard
+70
+   0
+3
+
+62
+ 256
+51
+90.0
+52
+90.0
+71
+   2
+49
+0.5
+62
+ 256
+6
+BYLAYER
+49
+-0.5
+62
+ 256
+6
+BYLAYER
+0
+ACDBPLACEHOLDER
+5
+F
+102
+{ACAD_REACTORS
+330
+E
+102
+}
+330
+E
+0
+VISUALSTYLE
+5
+2F
+102
+{ACAD_REACTORS
+330
+2A
+102
+}
+330
+2A
+100
+AcDbVisualStyle
+2
+2dWireframe
+70
+   4
+71
+   0
+72
+   2
+73
+   0
+90
+      0
+40
+-0.6
+41
+-30.0
+62
+   5
+63
+   7
+421
+16777215
+74
+   1
+91
+      4
+64
+   7
+65
+ 257
+75
+   1
+175
+   1
+42
+1.0
+92
+      0
+66
+ 257
+43
+1.0
+76
+   1
+77
+   6
+78
+   2
+67
+   7
+79
+   5
+170
+   0
+171
+   0
+290
+   0
+174
+   0
+93
+      1
+44
+0.0
+173
+   0
+291
+   0
+45
+0.0
+1001
+ACAD
+1000
+AcDbSavedByObjectVersion
+1070
+   0
+0
+VISUALSTYLE
+5
+31
+102
+{ACAD_REACTORS
+330
+2A
+102
+}
+330
+2A
+100
+AcDbVisualStyle
+2
+3D Hidden
+70
+   6
+71
+   1
+72
+   2
+73
+   2
+90
+      0
+40
+-0.6
+41
+-30.0
+62
+   5
+63
+   7
+421
+16777215
+74
+   2
+91
+      2
+64
+   7
+65
+ 257
+75
+   2
+175
+   1
+42
+40.0
+92
+      0
+66
+ 257
+43
+1.0
+76
+   1
+77
+   6
+78
+   2
+67
+   7
+79
+   3
+170
+   0
+171
+   0
+290
+   0
+174
+   0
+93
+      1
+44
+0.0
+173
+   0
+291
+   0
+45
+0.0
+1001
+ACAD
+1000
+AcDbSavedByObjectVersion
+1070
+   0
+0
+VISUALSTYLE
+5
+30
+102
+{ACAD_REACTORS
+330
+2A
+102
+}
+330
+2A
+100
+AcDbVisualStyle
+2
+3dWireframe
+70
+   5
+71
+   0
+72
+   2
+73
+   0
+90
+      0
+40
+-0.6
+41
+-30.0
+62
+   5
+63
+   7
+421
+16777215
+74
+   1
+91
+      4
+64
+   7
+65
+ 257
+75
+   1
+175
+   1
+42
+1.0
+92
+      0
+66
+ 257
+43
+1.0
+76
+   1
+77
+   6
+78
+   2
+67
+   7
+79
+   5
+170
+   0
+171
+   0
+290
+   0
+174
+   0
+93
+      1
+44
+0.0
+173
+   0
+291
+   0
+45
+0.0
+1001
+ACAD
+1000
+AcDbSavedByObjectVersion
+1070
+   0
+0
+VISUALSTYLE
+5
+32
+102
+{ACAD_REACTORS
+330
+2A
+102
+}
+330
+2A
+100
+AcDbVisualStyle
+2
+Basic
+70
+   7
+71
+   1
+72
+   0
+73
+   1
+90
+      0
+40
+-0.6
+41
+-30.0
+62
+   5
+63
+   7
+421
+16777215
+74
+   0
+91
+      4
+64
+   7
+65
+ 257
+75
+   1
+175
+   1
+42
+1.0
+92
+      8
+66
+   7
+43
+1.0
+76
+   1
+77
+   6
+78
+   2
+67
+   7
+79
+   5
+170
+   0
+171
+   0
+290
+   0
+174
+   0
+93
+      1
+44
+0.0
+173
+   0
+291
+   1
+45
+0.0
+1001
+ACAD
+1000
+AcDbSavedByObjectVersion
+1070
+   0
+0
+VISUALSTYLE
+5
+36
+102
+{ACAD_REACTORS
+330
+2A
+102
+}
+330
+2A
+100
+AcDbVisualStyle
+2
+Brighten
+70
+  12
+71
+   2
+72
+   2
+73
+   0
+90
+      0
+40
+-0.6
+41
+-30.0
+62
+   5
+63
+   7
+421
+16777215
+74
+   1
+91
+      4
+64
+   7
+65
+ 257
+75
+   1
+175
+   1
+42
+1.0
+92
+      8
+66
+   7
+43
+1.0
+76
+   1
+77
+   6
+78
+   2
+67
+   7
+79
+   5
+170
+   0
+171
+   0
+290
+   0
+174
+   0
+93
+      1
+44
+50.0
+173
+   0
+291
+   1
+45
+0.0
+1001
+ACAD
+1000
+AcDbSavedByObjectVersion
+1070
+   0
+0
+VISUALSTYLE
+5
+3A
+102
+{ACAD_REACTORS
+330
+2A
+102
+}
+330
+2A
+100
+AcDbVisualStyle
+2
+ColorChange
+70
+  16
+71
+   2
+72
+   2
+73
+   3
+90
+      0
+40
+-0.6
+41
+-30.0
+62
+   5
+63
+   8
+421
+8421504
+74
+   1
+91
+      4
+64
+   7
+65
+ 257
+75
+   1
+175
+   1
+42
+1.0
+92
+      8
+66
+   8
+424
+8421504
+43
+1.0
+76
+   1
+77
+   6
+78
+   2
+67
+   7
+79
+   5
+170
+   0
+171
+   0
+290
+   0
+174
+   0
+93
+      1
+44
+0.0
+173
+   0
+291
+   1
+45
+0.0
+1001
+ACAD
+1000
+AcDbSavedByObjectVersion
+1070
+   0
+0
+VISUALSTYLE
+5
+34
+102
+{ACAD_REACTORS
+330
+2A
+102
+}
+330
+2A
+100
+AcDbVisualStyle
+2
+Conceptual
+70
+   9
+71
+   3
+72
+   2
+73
+   0
+90
+      0
+40
+-0.6
+41
+-30.0
+62
+   5
+63
+   7
+421
+16777215
+74
+   2
+91
+      2
+64
+   7
+65
+ 257
+75
+   1
+175
+   1
+42
+40.0
+92
+      8
+66
+   7
+43
+1.0
+76
+   1
+77
+   6
+78
+   2
+67
+   7
+79
+   3
+170
+   0
+171
+   0
+290
+   0
+174
+   0
+93
+      1
+44
+0.0
+173
+   0
+291
+   0
+45
+0.0
+1001
+ACAD
+1000
+AcDbSavedByObjectVersion
+1070
+   0
+0
+VISUALSTYLE
+5
+35
+102
+{ACAD_REACTORS
+330
+2A
+102
+}
+330
+2A
+100
+AcDbVisualStyle
+2
+Dim
+70
+  11
+71
+   2
+72
+   2
+73
+   0
+90
+      0
+40
+-0.6
+41
+-30.0
+62
+   5
+63
+   7
+421
+16777215
+74
+   1
+91
+      4
+64
+   7
+65
+ 257
+75
+   1
+175
+   1
+42
+1.0
+92
+      8
+66
+   7
+43
+1.0
+76
+   1
+77
+   6
+78
+   2
+67
+   7
+79
+   5
+170
+   0
+171
+   0
+290
+   0
+174
+   0
+93
+      1
+44
+-50.0
+173
+   0
+291
+   1
+45
+0.0
+1001
+ACAD
+1000
+AcDbSavedByObjectVersion
+1070
+   0
+0
+VISUALSTYLE
+5
+39
+102
+{ACAD_REACTORS
+330
+2A
+102
+}
+330
+2A
+100
+AcDbVisualStyle
+2
+Facepattern
+70
+  15
+71
+   2
+72
+   2
+73
+   0
+90
+      0
+40
+-0.6
+41
+-30.0
+62
+   5
+63
+   7
+421
+16777215
+74
+   1
+91
+      4
+64
+   7
+65
+ 257
+75
+   1
+175
+   1
+42
+1.0
+92
+      8
+66
+   7
+43
+1.0
+76
+   1
+77
+   6
+78
+   2
+67
+   7
+79
+   5
+170
+   0
+171
+   0
+290
+   0
+174
+   0
+93
+      1
+44
+0.0
+173
+   0
+291
+   1
+45
+0.0
+1001
+ACAD
+1000
+AcDbSavedByObjectVersion
+1070
+   0
+0
+VISUALSTYLE
+5
+2B
+102
+{ACAD_REACTORS
+330
+2A
+102
+}
+330
+2A
+100
+AcDbVisualStyle
+2
+Flat
+70
+   0
+71
+   2
+72
+   1
+73
+   1
+90
+      2
+40
+-0.6
+41
+30.0
+62
+   5
+63
+   7
+421
+16777215
+74
+   0
+91
+      4
+64
+   7
+65
+ 257
+75
+   1
+175
+   1
+42
+1.0
+92
+      8
+66
+   7
+43
+1.0
+76
+   1
+77
+   6
+78
+   2
+67
+   7
+79
+   5
+170
+   0
+171
+   0
+290
+   0
+174
+   0
+93
+     13
+44
+0.0
+173
+   0
+291
+   1
+45
+0.0
+1001
+ACAD
+1000
+AcDbSavedByObjectVersion
+1070
+   0
+0
+VISUALSTYLE
+5
+2C
+102
+{ACAD_REACTORS
+330
+2A
+102
+}
+330
+2A
+100
+AcDbVisualStyle
+2
+FlatWithEdges
+70
+   1
+71
+   2
+72
+   1
+73
+   1
+90
+      2
+40
+-0.6
+41
+30.0
+62
+   5
+63
+   7
+421
+16777215
+74
+   1
+91
+      4
+64
+   7
+65
+ 257
+75
+   1
+175
+   1
+42
+1.0
+92
+      0
+66
+ 257
+43
+1.0
+76
+   1
+77
+   6
+78
+   2
+67
+   7
+79
+   5
+170
+   0
+171
+   0
+290
+   0
+174
+   0
+93
+     13
+44
+0.0
+173
+   0
+291
+   1
+45
+0.0
+1001
+ACAD
+1000
+AcDbSavedByObjectVersion
+1070
+   0
+0
+VISUALSTYLE
+5
+2D
+102
+{ACAD_REACTORS
+330
+2A
+102
+}
+330
+2A
+100
+AcDbVisualStyle
+2
+Gouraud
+70
+   2
+71
+   2
+72
+   2
+73
+   1
+90
+      2
+40
+-0.6
+41
+30.0
+62
+   5
+63
+   7
+421
+16777215
+74
+   0
+91
+      4
+64
+   7
+65
+ 257
+75
+   1
+175
+   1
+42
+1.0
+92
+      0
+66
+   7
+43
+1.0
+76
+   1
+77
+   6
+78
+   2
+67
+   7
+79
+   5
+170
+   0
+171
+   0
+290
+   0
+174
+   0
+93
+     13
+44
+0.0
+173
+   0
+291
+   1
+45
+0.0
+1001
+ACAD
+1000
+AcDbSavedByObjectVersion
+1070
+   0
+0
+VISUALSTYLE
+5
+2E
+102
+{ACAD_REACTORS
+330
+2A
+102
+}
+330
+2A
+100
+AcDbVisualStyle
+2
+GouraudWithEdges
+70
+   3
+71
+   2
+72
+   2
+73
+   1
+90
+      2
+40
+-0.6
+41
+30.0
+62
+   5
+63
+   7
+421
+16777215
+74
+   1
+91
+      4
+64
+   7
+65
+ 257
+75
+   1
+175
+   1
+42
+1.0
+92
+      0
+66
+ 257
+43
+1.0
+76
+   1
+77
+   6
+78
+   2
+67
+   7
+79
+   5
+170
+   0
+171
+   0
+290
+   0
+174
+   0
+93
+     13
+44
+0.0
+173
+   0
+291
+   1
+45
+0.0
+1001
+ACAD
+1000
+AcDbSavedByObjectVersion
+1070
+   0
+0
+VISUALSTYLE
+5
+38
+102
+{ACAD_REACTORS
+330
+2A
+102
+}
+330
+2A
+100
+AcDbVisualStyle
+2
+Linepattern
+70
+  14
+71
+   2
+72
+   2
+73
+   0
+90
+      0
+40
+-0.6
+41
+-30.0
+62
+   5
+63
+   7
+421
+16777215
+74
+   1
+91
+      4
+64
+   7
+65
+ 257
+75
+   7
+175
+   7
+42
+1.0
+92
+      8
+66
+   7
+43
+1.0
+76
+   1
+77
+   6
+78
+   2
+67
+   7
+79
+   5
+170
+   0
+171
+   0
+290
+   0
+174
+   0
+93
+      1
+44
+0.0
+173
+   0
+291
+   1
+45
+0.0
+1001
+ACAD
+1000
+AcDbSavedByObjectVersion
+1070
+   0
+0
+VISUALSTYLE
+5
+33
+102
+{ACAD_REACTORS
+330
+2A
+102
+}
+330
+2A
+100
+AcDbVisualStyle
+2
+Realistic
+70
+   8
+71
+   2
+72
+   2
+73
+   0
+90
+      0
+40
+-0.6
+41
+-30.0
+62
+   5
+63
+   7
+421
+16777215
+74
+   1
+91
+      0
+64
+   7
+65
+ 257
+75
+   1
+175
+   1
+42
+1.0
+92
+      8
+66
+   8
+424
+7895160
+43
+1.0
+76
+   1
+77
+   6
+78
+   2
+67
+   7
+79
+   5
+170
+   0
+171
+   0
+290
+   0
+174
+   0
+93
+     13
+44
+0.0
+173
+   0
+291
+   0
+45
+0.0
+1001
+ACAD
+1000
+AcDbSavedByObjectVersion
+1070
+   0
+0
+VISUALSTYLE
+5
+37
+102
+{ACAD_REACTORS
+330
+2A
+102
+}
+330
+2A
+100
+AcDbVisualStyle
+2
+Thicken
+70
+  13
+71
+   2
+72
+   2
+73
+   0
+90
+      0
+40
+-0.6
+41
+-30.0
+62
+   5
+63
+   7
+421
+16777215
+74
+   1
+91
+      4
+64
+   7
+65
+ 257
+75
+   1
+175
+   1
+42
+1.0
+92
+     12
+66
+   7
+43
+1.0
+76
+   1
+77
+   6
+78
+   2
+67
+   7
+79
+   5
+170
+   0
+171
+   0
+290
+   0
+174
+   0
+93
+      1
+44
+0.0
+173
+   0
+291
+   1
+45
+0.0
+1001
+ACAD
+1000
+AcDbSavedByObjectVersion
+1070
+   0
+0
+ENDSEC
+  0
+EOF

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
@@ -2561,22 +2561,4 @@ tests:
             angle:
               precision: 2
 
-  - algorithm: native:dxfexport
-    name: Test DXF export
-    params:
-      CRS: EPSG:4326
-      ENCODING: 0
-      FORCE_2D: false
-      LAYERS:
-      - attributeIndex: -1
-        layer: /home/alex/devel/qgis/python/plugins/processing/tests/testdata/points.gml
-      MTEXT: true
-      SYMBOLOGY_MODE: 0
-      SYMBOLOGY_SCALE: 1000000.0
-      USE_LAYER_TITLE: false
-    results:
-      OUTPUT:
-        name: expected/dxfexport.dxf
-        type: file
-
 # See ../README.md for a description of the file format

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
@@ -2561,5 +2561,22 @@ tests:
             angle:
               precision: 2
 
+  - algorithm: native:dxfexport
+    name: Test DXF export
+    params:
+      CRS: EPSG:4326
+      ENCODING: 0
+      FORCE_2D: false
+      LAYERS:
+      - attributeIndex: -1
+        layer: /home/alex/devel/qgis/python/plugins/processing/tests/testdata/points.gml
+      MTEXT: true
+      SYMBOLOGY_MODE: 0
+      SYMBOLOGY_SCALE: 1000000.0
+      USE_LAYER_TITLE: false
+    results:
+      OUTPUT:
+        name: expected/dxfexport.dxf
+        type: file
 
 # See ../README.md for a description of the file format

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -55,6 +55,7 @@ SET(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmdrape.cpp
   processing/qgsalgorithmdropgeometry.cpp
   processing/qgsalgorithmdropmzvalues.cpp
+  processing/qgsalgorithmdxfexport.cpp
   processing/qgsalgorithmexecutepostgisquery.cpp
   processing/qgsalgorithmexecutespatialitequery.cpp
   processing/qgsalgorithmexecutespatialitequeryregistered.cpp
@@ -413,6 +414,7 @@ ENDIF (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 INCLUDE_DIRECTORIES(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/src/core/
+  ${CMAKE_SOURCE_DIR}/src/core/dxf
   ${CMAKE_SOURCE_DIR}/src/core/geocoding
   ${CMAKE_SOURCE_DIR}/src/core/geometry
   ${CMAKE_SOURCE_DIR}/src/core/labeling

--- a/src/analysis/processing/qgsalgorithmdxfexport.cpp
+++ b/src/analysis/processing/qgsalgorithmdxfexport.cpp
@@ -27,12 +27,12 @@ QString QgsDxfExportAlgorithm::name() const
 
 QString QgsDxfExportAlgorithm::displayName() const
 {
-  return QObject::tr( "Export DXF" );
+  return QObject::tr( "Export layers to DXF" );
 }
 
 QStringList QgsDxfExportAlgorithm::tags() const
 {
-  return QObject::tr( "layer,export,dxf,cad" ).split( ',' );
+  return QObject::tr( "layer,export,dxf,cad,dwg" ).split( ',' );
 }
 
 QString QgsDxfExportAlgorithm::group() const
@@ -58,13 +58,13 @@ QgsDxfExportAlgorithm *QgsDxfExportAlgorithm::createInstance() const
 void QgsDxfExportAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterDxfLayers( QStringLiteral( "LAYERS" ), QObject::tr( "Input layers" ) ) );
-  addParameter( new QgsProcessingParameterEnum( QStringLiteral( "SYMBOLOGY_MODE" ), QObject::tr( "Symbology mode" ), QStringList() << QObject::tr( "No symbology" ) << QObject::tr( "Feature symbology" ) << QObject::tr( "Symbol layer symbology" ), false, 0 ) );
+  addParameter( new QgsProcessingParameterEnum( QStringLiteral( "SYMBOLOGY_MODE" ), QObject::tr( "Symbology mode" ), QStringList() << QObject::tr( "No Symbology" ) << QObject::tr( "Feature Symbology" ) << QObject::tr( "Symbol Layer Symbology" ), false, 0 ) );
   addParameter( new QgsProcessingParameterScale( QStringLiteral( "SYMBOLOGY_SCALE" ), QObject::tr( "Symbology scale" ), 1000000 ) );
   addParameter( new QgsProcessingParameterEnum( QStringLiteral( "ENCODING" ), QObject::tr( "Encoding" ), QgsDxfExport::encodings() ) );
   addParameter( new QgsProcessingParameterCrs( QStringLiteral( "CRS" ), QObject::tr( "CRS" ), QStringLiteral( "EPSG:4326" ) ) );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "USE_LAYER_TITLE" ), QObject::tr( "Use layer title as name" ), false ) );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "FORCE_2D" ), QObject::tr( "Force 2D output" ),  false ) );
-  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "MTEXT" ), QObject::tr( "Export labels as MTEXT element" ),  true ) );
+  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "MTEXT" ), QObject::tr( "Export labels as MTEXT elements" ),  true ) );
   addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "DXF" ), QObject::tr( "DXF Files" ) + " (*.dxf *.DXF)" ) );
 }
 

--- a/src/analysis/processing/qgsalgorithmdxfexport.cpp
+++ b/src/analysis/processing/qgsalgorithmdxfexport.cpp
@@ -71,7 +71,6 @@ void QgsDxfExportAlgorithm::initAlgorithm( const QVariantMap & )
 QVariantMap QgsDxfExportAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QgsMapSettings mapSettings;
-  mapSettings.setDestinationCrs( context.project()->crs() );
   mapSettings.setTransformContext( context.transformContext() );
 
   QList<QgsVectorLayer *> mapLayers;

--- a/src/analysis/processing/qgsalgorithmdxfexport.cpp
+++ b/src/analysis/processing/qgsalgorithmdxfexport.cpp
@@ -1,0 +1,137 @@
+/***************************************************************************
+  qgsalgorithmdxfexport.cpp
+  ---------------------
+  Date                 : September 2020
+  Copyright            : (C) 2020 by Alexander Bruy
+  Email                : alexamder dot bruy at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmdxfexport.h"
+
+#include "qgsprocessingparameterdxflayers.h"
+#include "qgsdxfexport.h"
+
+///@cond PRIVATE
+
+
+QString QgsDxfExportAlgorithm::name() const
+{
+  return QStringLiteral( "dxfexport" );
+}
+
+QString QgsDxfExportAlgorithm::displayName() const
+{
+  return QObject::tr( "Export DXF" );
+}
+
+QStringList QgsDxfExportAlgorithm::tags() const
+{
+  return QObject::tr( "layer,export,dxf,cad" ).split( ',' );
+}
+
+QString QgsDxfExportAlgorithm::group() const
+{
+  return QObject::tr( "Vector general" );
+}
+
+QString QgsDxfExportAlgorithm::groupId() const
+{
+  return QStringLiteral( "vectorgeneral" );
+}
+
+QString QgsDxfExportAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "Exports layers to DXF file." );
+}
+
+QgsDxfExportAlgorithm *QgsDxfExportAlgorithm::createInstance() const
+{
+  return new QgsDxfExportAlgorithm();
+}
+
+void QgsDxfExportAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterDxfLayers( QStringLiteral( "LAYERS" ), QObject::tr( "Input layers" ) ) );
+  addParameter( new QgsProcessingParameterEnum( QStringLiteral( "SYMBOLOGY_MODE" ), QObject::tr( "Symbology mode" ), QStringList() << QObject::tr( "No symbology" ) << QObject::tr( "Feature symbology" ) << QObject::tr( "Symbol layer symbology" ), false, 0 ) );
+  addParameter( new QgsProcessingParameterScale( QStringLiteral( "SYMBOLOGY_SCALE" ), QObject::tr( "Symbology scale" ), 1000000 ) );
+  addParameter( new QgsProcessingParameterEnum( QStringLiteral( "ENCODING" ), QObject::tr( "Encoding" ), QgsDxfExport::encodings() ) );
+  addParameter( new QgsProcessingParameterCrs( QStringLiteral( "CRS" ), QObject::tr( "CRS" ), QStringLiteral( "EPSG:4326" ) ) );
+  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "USE_LAYER_TITLE" ), QObject::tr( "Use layer title as name" ), false ) );
+  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "FORCE_2D" ), QObject::tr( "Force 2D output" ),  false ) );
+  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "MTEXT" ), QObject::tr( "Export labels as MTEXT element" ),  true ) );
+  addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "DXF" ), QObject::tr( "DXF Files" ) + " (*.dxf *.DXF)" ) );
+}
+
+QVariantMap QgsDxfExportAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  QgsMapSettings mapSettings;
+  mapSettings.setDestinationCrs( context.project()->crs() );
+  mapSettings.setTransformContext( context.transformContext() );
+
+  QList<QgsVectorLayer *> mapLayers;
+
+  QVariant layersVariant = parameters.value( parameterDefinition( QStringLiteral( "LAYERS" ) )->name() );
+  const QList<QgsDxfExport::DxfLayer> layers = QgsProcessingParameterDxfLayers::parameterAsLayers( layersVariant, context );
+  for ( const QgsDxfExport::DxfLayer &layer : layers )
+  {
+    if ( !layer.layer() )
+      throw QgsProcessingException( QObject::tr( "Unknown input layer" ) );
+
+    mapLayers.push_back( layer.layer() );
+  }
+
+  QgsDxfExport::SymbologyExport symbologyMode = static_cast< QgsDxfExport::SymbologyExport >( parameterAsInt( parameters, QStringLiteral( "SYMBOLOGY_MODE" ), context ) );
+  double symbologyScale = parameterAsDouble( parameters, QStringLiteral( "SYMBOLOGY_SCALE" ), context );
+  QString encoding = QgsDxfExport::encodings().at( parameterAsInt( parameters, QStringLiteral( "ENCODING" ), context ) );
+  QgsCoordinateReferenceSystem crs = parameterAsCrs( parameters, QStringLiteral( "CRS" ), context );
+  bool useLayerTitle = parameterAsBool( parameters, QStringLiteral( "USE_LAYER_TITLE" ), context );
+  bool useMText = parameterAsBool( parameters, QStringLiteral( "MTEXT" ), context );
+  bool force2D = parameterAsBool( parameters, QStringLiteral( "FORCE_2D" ), context );
+  QString outputFile = parameterAsFileOutput( parameters, QStringLiteral( "OUTPUT" ), context );
+
+  QgsDxfExport dxfExport;
+
+  dxfExport.setMapSettings( mapSettings );
+  dxfExport.addLayers( layers );
+  dxfExport.setSymbologyScale( symbologyScale );
+  dxfExport.setSymbologyExport( symbologyMode );
+  dxfExport.setLayerTitleAsName( useLayerTitle );
+  dxfExport.setDestinationCrs( crs );
+  dxfExport.setForce2d( force2D );
+
+  QgsDxfExport::Flags flags = QgsDxfExport::Flags();
+  if ( useMText )
+    flags = flags | QgsDxfExport::FlagNoMText;
+  dxfExport.setFlags( flags );
+
+  QFile dxfFile( outputFile );
+  switch ( dxfExport.writeToFile( &dxfFile, encoding ) )
+  {
+    case QgsDxfExport::ExportResult::Success:
+      feedback->pushInfo( QObject::tr( "DXF export completed" ) );
+      break;
+
+    case QgsDxfExport::ExportResult::DeviceNotWritableError:
+      feedback->reportError( QObject::tr( "DXF export failed, device is not writable" ), true );
+      break;
+
+    case QgsDxfExport::ExportResult::InvalidDeviceError:
+      feedback->reportError( QObject::tr( "DXF export failed, the device is invalid" ), true );
+      break;
+
+    case QgsDxfExport::ExportResult::EmptyExtentError:
+      feedback->reportError( QObject::tr( "DXF export failed, the extent could not be determined" ), true );
+      break;
+  }
+
+  QVariantMap outputs;
+  outputs.insert( QStringLiteral( "OUTPUT" ), outputFile );
+  return outputs;
+}

--- a/src/analysis/processing/qgsalgorithmdxfexport.cpp
+++ b/src/analysis/processing/qgsalgorithmdxfexport.cpp
@@ -106,7 +106,7 @@ QVariantMap QgsDxfExportAlgorithm::processAlgorithm( const QVariantMap &paramete
   dxfExport.setForce2d( force2D );
 
   QgsDxfExport::Flags flags = QgsDxfExport::Flags();
-  if ( useMText )
+  if ( !useMText )
     flags = flags | QgsDxfExport::FlagNoMText;
   dxfExport.setFlags( flags );
 

--- a/src/analysis/processing/qgsalgorithmdxfexport.cpp
+++ b/src/analysis/processing/qgsalgorithmdxfexport.cpp
@@ -20,7 +20,6 @@
 
 ///@cond PRIVATE
 
-
 QString QgsDxfExportAlgorithm::name() const
 {
   return QStringLiteral( "dxfexport" );
@@ -135,3 +134,5 @@ QVariantMap QgsDxfExportAlgorithm::processAlgorithm( const QVariantMap &paramete
   outputs.insert( QStringLiteral( "OUTPUT" ), outputFile );
   return outputs;
 }
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmdxfexport.cpp
+++ b/src/analysis/processing/qgsalgorithmdxfexport.cpp
@@ -3,7 +3,7 @@
   ---------------------
   Date                 : September 2020
   Copyright            : (C) 2020 by Alexander Bruy
-  Email                : alexamder dot bruy at gmail dot com
+  Email                : alexander dot bruy at gmail dot com
  ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/analysis/processing/qgsalgorithmdxfexport.cpp
+++ b/src/analysis/processing/qgsalgorithmdxfexport.cpp
@@ -47,7 +47,7 @@ QString QgsDxfExportAlgorithm::groupId() const
 
 QString QgsDxfExportAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "Exports layers to DXF file." );
+  return QObject::tr( "Exports layers to DXF file. For each layer, you can choose a field whose values are used to split features in generated destination layers in the DXF output." );
 }
 
 QgsDxfExportAlgorithm *QgsDxfExportAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmdxfexport.cpp
+++ b/src/analysis/processing/qgsalgorithmdxfexport.cpp
@@ -118,15 +118,15 @@ QVariantMap QgsDxfExportAlgorithm::processAlgorithm( const QVariantMap &paramete
       break;
 
     case QgsDxfExport::ExportResult::DeviceNotWritableError:
-      feedback->reportError( QObject::tr( "DXF export failed, device is not writable" ), true );
+      throw QgsProcessingException( QObject::tr( "DXF export failed, device is not writable" ) );
       break;
 
     case QgsDxfExport::ExportResult::InvalidDeviceError:
-      feedback->reportError( QObject::tr( "DXF export failed, the device is invalid" ), true );
+      throw QgsProcessingException( QObject::tr( "DXF export failed, the device is invalid" ) );
       break;
 
     case QgsDxfExport::ExportResult::EmptyExtentError:
-      feedback->reportError( QObject::tr( "DXF export failed, the extent could not be determined" ), true );
+      throw QgsProcessingException( QObject::tr( "DXF export failed, the extent could not be determined" ) );
       break;
   }
 

--- a/src/analysis/processing/qgsalgorithmdxfexport.h
+++ b/src/analysis/processing/qgsalgorithmdxfexport.h
@@ -1,0 +1,45 @@
+/***************************************************************************
+  qgsalgorithmdxfexport.h
+  ---------------------
+  Date                 : September 2020
+  Copyright            : (C) 2020 by Alexander Bruy
+  Email                : alexander dot bruy at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSDXFEXPORTALGORITHM_H
+#define QGSDXFEXPORTALGORITHM_H
+
+#define SIP_NO_FILE
+
+#include "qgsprocessingalgorithm.h"
+
+///@cond PRIVATE
+
+class QgsDxfExportAlgorithm : public QgsProcessingAlgorithm
+{
+  public:
+    QgsDxfExportAlgorithm() = default;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QgsDxfExportAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+};
+
+///@endcond PRIVATE
+
+#endif // QGSDXFEXPORTALGORITHM_H

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -51,6 +51,7 @@
 #include "qgsalgorithmdrape.h"
 #include "qgsalgorithmdropgeometry.h"
 #include "qgsalgorithmdropmzvalues.h"
+#include "qgsalgorithmdxfexport.h"
 #include "qgsalgorithmexecutepostgisquery.h"
 #include "qgsalgorithmexecutespatialitequery.h"
 #include "qgsalgorithmexecutespatialitequeryregistered.h"
@@ -276,6 +277,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsDrapeToZAlgorithm() );
   addAlgorithm( new QgsDropGeometryAlgorithm() );
   addAlgorithm( new QgsDropMZValuesAlgorithm() );
+  addAlgorithm( new QgsDxfExportAlgorithm() );
   addAlgorithm( new QgsExecutePostgisQueryAlgorithm() );
   addAlgorithm( new QgsExecuteRegisteredSpatialiteQueryAlgorithm() );
   addAlgorithm( new QgsExecuteSpatialiteQueryAlgorithm() );

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -161,6 +161,7 @@ SET(QGIS_CORE_SRCS
   processing/qgsprocessingfeedback.cpp
   processing/qgsprocessingoutputs.cpp
   processing/qgsprocessingparameteraggregate.cpp
+  processing/qgsprocessingparameterdxflayers.cpp
   processing/qgsprocessingparameterfieldmap.cpp
   processing/qgsprocessingparameters.cpp
   processing/qgsprocessingparametertininputlayers.cpp
@@ -1353,6 +1354,7 @@ SET(QGIS_CORE_HDRS
   processing/qgsprocessingfeedback.h
   processing/qgsprocessingoutputs.h
   processing/qgsprocessingparameteraggregate.h
+  processing/qgsprocessingparameterdxflayers.h
   processing/qgsprocessingparameterfieldmap.h
   processing/qgsprocessingparameters.h
   processing/qgsprocessingparametertininputlayers.h

--- a/src/core/processing/qgsprocessingparameterdxflayers.cpp
+++ b/src/core/processing/qgsprocessingparameterdxflayers.cpp
@@ -144,6 +144,6 @@ QVariantMap QgsProcessingParameterDxfLayers::layerAsVariantMap( const QgsDxfExpo
     return vm;
 
   vm[ QStringLiteral( "layer" )] = layer.layer()->id();
-  vm[ QStringLiteral( "attributeIndex" ) ] = layer. layerOutputAttributeIndex();
+  vm[ QStringLiteral( "attributeIndex" ) ] = layer.layerOutputAttributeIndex();
   return vm;
 }

--- a/src/core/processing/qgsprocessingparameterdxflayers.cpp
+++ b/src/core/processing/qgsprocessingparameterdxflayers.cpp
@@ -1,0 +1,149 @@
+/***************************************************************************
+  qgsprocessingparameterdxflayers.cpp
+  ---------------------
+  Date                 : September 2020
+  Copyright            : (C) 2020 by Alexander Bruy
+  Email                : alexander dot bruy at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsprocessingparameterdxflayers.h"
+#include "qgsvectorlayer.h"
+
+
+QgsProcessingParameterDxfLayers::QgsProcessingParameterDxfLayers( const QString &name, const QString &description )
+  : QgsProcessingParameterDefinition( name, description, QVariant(), false )
+{
+}
+
+QgsProcessingParameterDefinition *QgsProcessingParameterDxfLayers::clone() const
+{
+  return new QgsProcessingParameterDxfLayers( *this );
+}
+
+QString QgsProcessingParameterDxfLayers::type() const
+{
+  return typeName();
+}
+
+bool QgsProcessingParameterDxfLayers::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context ) const
+{
+  if ( !input.isValid() )
+    return mFlags & FlagOptional;
+
+  if ( input.type() != QVariant::List )
+    return false;
+
+  const QVariantList layerList = input.toList();
+  if ( layerList.isEmpty() )
+    return false;
+
+  for ( const QVariant &variantLayer : layerList )
+  {
+    if ( variantLayer.type() != QVariant::Map )
+      return false;
+
+    QVariantMap layerMap = variantLayer.toMap();
+
+    if ( !layerMap.contains( QStringLiteral( "layer" ) ) || !layerMap.contains( QStringLiteral( "attributeIndex" ) ) )
+      return false;
+
+    if ( !context )
+      continue;  // when called without context, we will skip checking whether the layer can be resolved
+
+    QgsMapLayer *mapLayer = QgsProcessingUtils::mapLayerFromString( layerMap.value( QStringLiteral( "layer" ) ).toString(), *context );
+    if ( !mapLayer || mapLayer->type() != QgsMapLayerType::VectorLayer )
+      return false;
+
+    QgsVectorLayer *vectorLayer = static_cast<QgsVectorLayer *>( mapLayer );
+
+    if ( !vectorLayer )
+      return false;
+
+    if ( layerMap.value( QStringLiteral( "attributeIndex" ) ).toInt() >= vectorLayer->fields().count() )
+      return false;
+  }
+
+  return true;
+}
+
+QString QgsProcessingParameterDxfLayers::valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const
+{
+  QStringList parts;
+  const QList<QgsDxfExport::DxfLayer> layers = parameterAsLayers( value, context );
+  for ( const QgsDxfExport::DxfLayer &layer : layers )
+  {
+    QStringList layerDefParts;
+    layerDefParts << QStringLiteral( "'layer': " ) + QgsProcessingUtils::stringToPythonLiteral( QgsProcessingUtils::normalizeLayerSource( layer.layer()->source() ) );
+    if ( layer.layerOutputAttributeIndex() >= -1 )
+      layerDefParts << QStringLiteral( "'attributeIndex': " ) + QgsProcessingUtils::variantToPythonLiteral( layer.layerOutputAttributeIndex() );
+
+    QString layerDef = QStringLiteral( "{%1}" ).arg( layerDefParts.join( ',' ) );
+    parts << layerDef;
+  }
+  return parts.join( ',' ).prepend( '[' ).append( ']' );
+}
+
+QString QgsProcessingParameterDxfLayers::asPythonString( QgsProcessing::PythonOutputType outputType ) const
+{
+  switch ( outputType )
+  {
+    case QgsProcessing::PythonQgsProcessingAlgorithmSubclass:
+    {
+      QString code = QStringLiteral( "QgsProcessingParameterDxfLayers('%1', '%2')" ).arg( name(), description() );
+      return code;
+    }
+  }
+  return QString();
+}
+
+QList<QgsDxfExport::DxfLayer> QgsProcessingParameterDxfLayers::parameterAsLayers( const QVariant &layersVariant, QgsProcessingContext &context )
+{
+  QList<QgsDxfExport::DxfLayer> layers;
+  const QVariantList layersVariantList = layersVariant.toList();
+  for ( const QVariant &layerItem : layersVariantList )
+  {
+    QVariantMap layerVariantMap = layerItem.toMap();
+    layers << variantMapAsLayer( layerVariantMap, context );
+  }
+  return layers;
+}
+
+QgsDxfExport::DxfLayer QgsProcessingParameterDxfLayers::variantMapAsLayer( const QVariantMap &layerVariantMap, QgsProcessingContext &context )
+{
+  QVariant layerVariant = layerVariantMap[ QStringLiteral( "layer" ) ];
+
+  QgsVectorLayer *inputLayer = nullptr;
+  if ( ( inputLayer = qobject_cast< QgsVectorLayer * >( qvariant_cast<QObject *>( layerVariant ) ) ) )
+  {
+    // good
+  }
+  else if ( ( inputLayer = qobject_cast< QgsVectorLayer * >( QgsProcessingUtils::mapLayerFromString( layerVariant.toString(), context ) ) ) )
+  {
+    // good
+  }
+  else
+  {
+    // bad
+  }
+
+  QgsDxfExport::DxfLayer dxfLayer( inputLayer, layerVariantMap[ QStringLiteral( "attributeIndex" ) ].toInt() );
+  return dxfLayer;
+}
+
+QVariantMap QgsProcessingParameterDxfLayers::layerAsVariantMap( const QgsDxfExport::DxfLayer &layer )
+{
+  QVariantMap vm;
+  if ( !layer.layer() )
+    return vm;
+
+  vm[ QStringLiteral( "layer" )] = layer.layer()->id();
+  vm[ QStringLiteral( "attributeIndex" ) ] = layer. layerOutputAttributeIndex();
+  return vm;
+}

--- a/src/core/processing/qgsprocessingparameterdxflayers.h
+++ b/src/core/processing/qgsprocessingparameterdxflayers.h
@@ -40,7 +40,6 @@
  * representation and QVariant representation.
  *
  * \ingroup core
- * \note This class is not a part of public API.
  * \since QGIS 3.18
  */
 class CORE_EXPORT QgsProcessingParameterDxfLayers : public QgsProcessingParameterDefinition
@@ -49,7 +48,7 @@ class CORE_EXPORT QgsProcessingParameterDxfLayers : public QgsProcessingParamete
     //! Constructor for QgsProcessingParameterDxfLayers.
     QgsProcessingParameterDxfLayers( const QString &name, const QString &description = QString() );
 
-    QgsProcessingParameterDefinition *clone() const override;
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override;
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
@@ -65,6 +64,7 @@ class CORE_EXPORT QgsProcessingParameterDxfLayers : public QgsProcessingParamete
     static QVariantMap layerAsVariantMap( const QgsDxfExport::DxfLayer &layer );
 };
 
+///@cond PRIVATE
 
 /**
  * Parameter type definition for QgsProcessingParameterDxfLayers.
@@ -111,5 +111,7 @@ class CORE_EXPORT QgsProcessingParameterTypeDxfLayers : public QgsProcessingPara
       return QStringList() << QObject::tr( "list[dict]: list of input layers as dictionaries, see QgsProcessingParameterDxfLayers docs" );
     }
 };
+
+///@endcond
 
 #endif // QGSPROCESSINGPARAMETERDXFLAYERS_H

--- a/src/core/processing/qgsprocessingparameterdxflayers.h
+++ b/src/core/processing/qgsprocessingparameterdxflayers.h
@@ -108,7 +108,15 @@ class CORE_EXPORT QgsProcessingParameterTypeDxfLayers : public QgsProcessingPara
 
     QStringList acceptedPythonTypes() const override
     {
-      return QStringList() << QObject::tr( "list[dict]: list of input layers as dictionaries, see QgsProcessingParameterDxfLayers docs" );
+      return QStringList() << QObject::tr( "list[dict]: list of input layers as dictionaries, see QgsProcessingParameterDxfLayers docs" )
+             << QObject::tr( "list[str]: list of layer IDs" )
+             << QObject::tr( "list[str]: list of layer names" )
+             << QObject::tr( "list[str]: list of layer sources" )
+             << QObject::tr( "str: layer ID" )
+             << QObject::tr( "str: layer name" )
+             << QObject::tr( "str: layer source" )
+             << QStringLiteral( "list[QgsMapLayer]" )
+             << QStringLiteral( "QgsVectorLayer" );
     }
 };
 

--- a/src/core/processing/qgsprocessingparameterdxflayers.h
+++ b/src/core/processing/qgsprocessingparameterdxflayers.h
@@ -1,0 +1,112 @@
+/***************************************************************************
+  qgsprocessingparameterdxflayers.h
+  ---------------------
+  Date                 : September 2020
+  Copyright            : (C) 2020 by Alexander Bruy
+  Email                : alexander dot bruy at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPROCESSINGPARAMETERDXFLAYERS_H
+#define QGSPROCESSINGPARAMETERDXFLAYERS_H
+
+#include "qgsprocessingparameters.h"
+#include "qgsprocessingparametertype.h"
+#include "qgsdxfexport.h"
+
+/**
+ * A parameter for Processing algorithms that need a list of input vector
+ * layers to export as DXF file - this parameter provides Processing
+ * framework's adapter for QList<QgsDxfExport::DxfLayer>.
+ *
+ * A valid value for this parameter is a list (QVariantList), where each
+ * item is a map (QVariantMap) in this form:
+ * {
+ *   'layer':  string or QgsMapLayer,
+ *   'attributeIndex': int
+ * }
+ *
+ * Static functions parametersAsLayers(), variantMapAsLayer(),
+ * layerAsVariantMap() provide conversion between QgsDxfExport::DxfLayer
+ * representation and QVariant representation.
+ *
+ * \ingroup core
+ * \note This class is not a part of public API.
+ * \since QGIS 3.18
+ */
+class CORE_EXPORT QgsProcessingParameterDxfLayers : public QgsProcessingParameterDefinition
+{
+  public:
+    //! Constructor for QgsProcessingParameterDxfLayers.
+    QgsProcessingParameterDxfLayers( const QString &name, const QString &description = QString() );
+
+    QgsProcessingParameterDefinition *clone() const override;
+    QString type() const override;
+    bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
+    QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
+    QString asPythonString( QgsProcessing::PythonOutputType outputType = QgsProcessing::PythonQgsProcessingAlgorithmSubclass ) const override;
+
+    //! Returns the type name for the parameter class.
+    static QString typeName() { return QStringLiteral( "dxflayers" ); }
+    //! Converts a QVariant value (a QVariantList) to a list of input layers
+    static QList<QgsDxfExport::DxfLayer> parameterAsLayers( const QVariant &layersVariant, QgsProcessingContext &context );
+    //! Converts a QVariant value (a QVariantMap) to a single input layer
+    static QgsDxfExport::DxfLayer variantMapAsLayer( const QVariantMap &layerVariantMap, QgsProcessingContext &context );
+    //! Converts a single input layer to QVariant representation (a QVariantMap)
+    static QVariantMap layerAsVariantMap( const QgsDxfExport::DxfLayer &layer );
+};
+
+
+/**
+ * Parameter type definition for QgsProcessingParameterDxfLayers.
+ *
+ * \ingroup core
+ * \note This class is not a part of public API.
+ * \since QGIS 3.18
+ */
+class CORE_EXPORT QgsProcessingParameterTypeDxfLayers : public QgsProcessingParameterType
+{
+  public:
+    QgsProcessingParameterDefinition *create( const QString &name ) const override SIP_FACTORY
+    {
+      return new QgsProcessingParameterDxfLayers( name );
+    }
+
+    QString description() const override
+    {
+      return QCoreApplication::translate( "Processing", "An input allowing selection of multiple layers for export to DXF file." );
+    }
+
+    QString name() const override
+    {
+      return QCoreApplication::translate( "Processing", "DXF Layers" );
+    }
+
+    QString id() const override
+    {
+      return QgsProcessingParameterDxfLayers::typeName();
+    }
+
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterDxfLayers" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterDxfLayers" );
+    }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QObject::tr( "list[dict]: list of input layers as dictionaries, see QgsProcessingParameterDxfLayers docs" );
+    }
+};
+
+#endif // QGSPROCESSINGPARAMETERDXFLAYERS_H

--- a/src/core/processing/qgsprocessingparameterdxflayers.h
+++ b/src/core/processing/qgsprocessingparameterdxflayers.h
@@ -64,6 +64,7 @@ class CORE_EXPORT QgsProcessingParameterDxfLayers : public QgsProcessingParamete
     static QVariantMap layerAsVariantMap( const QgsDxfExport::DxfLayer &layer );
 };
 
+#ifndef SIP_RUN
 ///@cond PRIVATE
 
 /**
@@ -121,5 +122,6 @@ class CORE_EXPORT QgsProcessingParameterTypeDxfLayers : public QgsProcessingPara
 };
 
 ///@endcond
+#endif
 
 #endif // QGSPROCESSINGPARAMETERDXFLAYERS_H

--- a/src/core/processing/qgsprocessingparameterdxflayers.h
+++ b/src/core/processing/qgsprocessingparameterdxflayers.h
@@ -32,6 +32,9 @@
  *   'attributeIndex': int
  * }
  *
+ * Also it can accept lists (either string lists or QgsVectorLayer list)
+ * as well as individual layer object or string representing layer source.
+ *
  * Static functions parametersAsLayers(), variantMapAsLayer(),
  * layerAsVariantMap() provide conversion between QgsDxfExport::DxfLayer
  * representation and QVariant representation.

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -333,6 +333,7 @@ class CORE_EXPORT QgsProcessingParameterDefinition
 #ifdef SIP_RUN
     % TypeHeaderCode
 #include "qgsprocessingparameteraggregate.h"
+#include "qgsprocessingparameterdxflayers.h"
 #include "qgsprocessingparameterfieldmap.h"
 #include "qgsprocessingparametertininputlayers.h"
 #include "qgsprocessingparametervectortilewriterlayers.h"

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -418,6 +418,8 @@ class CORE_EXPORT QgsProcessingParameterDefinition
       sipType = sipType_QgsProcessingParameterTinInputLayers;
     else if ( sipCpp->type() == QgsProcessingParameterVectorTileWriterLayers::typeName() )
       sipType = sipType_QgsProcessingParameterVectorTileWriterLayers;
+    else if ( sipCpp->type() == QgsProcessingParameterDxfLayers::typeName() )
+      sipType = sipType_QgsProcessingParameterDxfLayers;
     else
       sipType = nullptr;
     SIP_END

--- a/src/core/processing/qgsprocessingregistry.cpp
+++ b/src/core/processing/qgsprocessingregistry.cpp
@@ -22,6 +22,7 @@
 #include "qgsprocessingparametertininputlayers.h"
 #include "qgsprocessingparameterfieldmap.h"
 #include "qgsprocessingparameteraggregate.h"
+#include "qgsprocessingparameterdxflayers.h"
 
 QgsProcessingRegistry::QgsProcessingRegistry( QObject *parent SIP_TRANSFERTHIS )
   : QObject( parent )
@@ -69,6 +70,7 @@ QgsProcessingRegistry::QgsProcessingRegistry( QObject *parent SIP_TRANSFERTHIS )
   addParameterType( new QgsProcessingParameterTypeFieldMapping() );
   addParameterType( new QgsProcessingParameterTypeAggregate() );
   addParameterType( new QgsProcessingParameterTypeTinInputLayers() );
+  addParameterType( new QgsProcessingParameterTypeDxfLayers() );
 }
 
 QgsProcessingRegistry::~QgsProcessingRegistry()

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -292,6 +292,7 @@ SET(QGIS_GUI_SRCS
   processing/qgsprocessingalgorithmconfigurationwidget.cpp
   processing/qgsprocessingalgorithmdialogbase.cpp
   processing/qgsprocessingconfigurationwidgets.cpp
+  processing/qgsprocessingdxflayerswidgetwrapper.cpp
   processing/qgsprocessingenummodelerwidget.cpp
   processing/qgsprocessingfeaturesourceoptionswidget.cpp
   processing/qgsprocessingfieldmapwidgetwrapper.cpp
@@ -1051,6 +1052,7 @@ SET(QGIS_GUI_HDRS
   processing/qgsprocessingalgorithmconfigurationwidget.h
   processing/qgsprocessingalgorithmdialogbase.h
   processing/qgsprocessingconfigurationwidgets.h
+  processing/qgsprocessingdxflayerswidgetwrapper.h
   processing/qgsprocessingenummodelerwidget.h
   processing/qgsprocessingfeaturesourceoptionswidget.h
   processing/qgsprocessingfieldmapwidgetwrapper.h
@@ -1317,6 +1319,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core/annotations
   ${CMAKE_SOURCE_DIR}/src/core/auth
   ${CMAKE_SOURCE_DIR}/src/core/callouts
+  ${CMAKE_SOURCE_DIR}/src/core/dxf
   ${CMAKE_SOURCE_DIR}/src/core/fieldformatter
   ${CMAKE_SOURCE_DIR}/src/core/geocoding
   ${CMAKE_SOURCE_DIR}/src/core/geometry

--- a/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
@@ -1,0 +1,318 @@
+/***************************************************************************
+  qgsprocessingdxflayerswidgetwrapper.cpp
+  ---------------------
+  Date                 : September 2020
+  Copyright            : (C) 2020 by Alexander Bruy
+  Email                : alexander dot bruy at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsprocessingdxflayerswidgetwrapper.h"
+
+#include <QBoxLayout>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QStandardItemModel>
+#include <QToolButton>
+
+#include "qgspanelwidget.h"
+#include "qgsprocessingcontext.h"
+#include "qgsprocessingparameterdxflayers.h"
+
+/// @cond private
+
+//
+// QgsProcessingDxfLayerDetailsWidget
+//
+
+QgsProcessingDxfLayerDetailsWidget::QgsProcessingDxfLayerDetailsWidget( const QVariant &value, QgsProject *project )
+{
+  setupUi( this );
+
+  mFieldsComboBox->setAllowEmptyFieldName( true );
+
+  QgsProcessingContext context;
+  context.setProject( project );
+
+  QgsDxfExport::DxfLayer layer = QgsProcessingParameterDxfLayers::variantMapAsLayer( value.toMap(), context );
+  mLayer = layer.layer();
+
+  if ( !mLayer )
+    return;
+
+  mFieldsComboBox->setLayer( mLayer );
+  mFieldsComboBox->setCurrentIndex( layer.layerOutputAttributeIndex() );
+
+  connect( mFieldsComboBox, &QgsFieldComboBox::fieldChanged, this, &QgsPanelWidget::widgetChanged );
+}
+
+QVariant QgsProcessingDxfLayerDetailsWidget::value() const
+{
+  int index = mLayer->fields().lookupField( mFieldsComboBox->currentField() );
+  QgsDxfExport::DxfLayer layer( mLayer, index );
+  return QgsProcessingParameterDxfLayers::layerAsVariantMap( layer );
+}
+
+
+//
+// QgsProcessingDxfLayersPanelWidget
+//
+
+QgsProcessingDxfLayersPanelWidget::QgsProcessingDxfLayersPanelWidget(
+  const QVariant &value,
+  QgsProject *project,
+  QWidget *parent )
+  : QgsProcessingMultipleSelectionPanelWidget( QVariantList(), QVariantList(), parent )
+  , mProject( project )
+{
+  connect( listView(), &QListView::doubleClicked, this, &QgsProcessingDxfLayersPanelWidget::configureLayer );
+
+  QPushButton *configureLayerButton = new QPushButton( tr( "Configure Layer…" ) );
+  connect( configureLayerButton, &QPushButton::clicked, this, &QgsProcessingDxfLayersPanelWidget::configureLayer );
+  buttonBox()->addButton( configureLayerButton, QDialogButtonBox::ActionRole );
+
+  // populate the list: first layers already selected, then layers from project not yet selected
+  QgsProcessingContext context;
+  context.setProject( project );
+
+  QSet<const QgsVectorLayer *> seenVectorLayers;
+  const QVariantList valueList = value.toList();
+  for ( const QVariant &v : valueList )
+  {
+    QgsDxfExport::DxfLayer layer = QgsProcessingParameterDxfLayers::variantMapAsLayer( v.toMap(), context );
+    if ( !layer.layer() )
+      continue;  // skip any invalid layers
+
+    addOption( v, titleForLayer( layer ), true );
+    seenVectorLayers.insert( layer.layer() );
+  }
+
+  const QList<QgsVectorLayer *> options = QgsProcessingUtils::compatibleVectorLayers( project, QList< int >() );
+  for ( const QgsVectorLayer *layer : options )
+  {
+    if ( seenVectorLayers.contains( layer ) )
+      continue;
+
+    QVariantMap vm;
+    vm["layer"] = layer->id();
+
+    QString title = layer->name();
+    addOption( vm, title, false );
+  }
+}
+
+void QgsProcessingDxfLayersPanelWidget::configureLayer()
+{
+  const QModelIndexList selection = listView()->selectionModel()->selectedIndexes();
+  if ( selection.size() != 1 )
+  {
+    QMessageBox::warning( this, tr( "Configure Layer" ), tr( "Please select a single layer." ) );
+    return;
+  }
+
+  QStandardItem *item = mModel->itemFromIndex( selection[0] );
+  QVariant value = item->data( Qt::UserRole );
+
+  QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
+  if ( panel && panel->dockMode() )
+  {
+    QgsProcessingDxfLayerDetailsWidget *widget = new QgsProcessingDxfLayerDetailsWidget( value, mProject );
+    widget->setPanelTitle( tr( "Configure Layer" ) );
+    widget->buttonBox()->hide();
+
+    connect( widget, &QgsProcessingDxfLayerDetailsWidget::widgetChanged, this, [ = ]()
+    {
+      setItemValue( item, widget->value() );
+    } );
+    panel->openPanel( widget );
+  }
+  else
+  {
+    QDialog dlg;
+    dlg.setWindowTitle( tr( "Configure Layer" ) );
+    QVBoxLayout *vLayout = new QVBoxLayout();
+    QgsProcessingDxfLayerDetailsWidget *widget = new QgsProcessingDxfLayerDetailsWidget( value, mProject );
+    vLayout->addWidget( widget );
+    connect( widget->buttonBox(), &QDialogButtonBox::accepted, &dlg, &QDialog::accept );
+    connect( widget->buttonBox(), &QDialogButtonBox::rejected, &dlg, &QDialog::reject );
+    dlg.setLayout( vLayout );
+    if ( dlg.exec() )
+    {
+      setItemValue( item, widget->value() );
+    }
+  }
+}
+
+void QgsProcessingDxfLayersPanelWidget::setItemValue( QStandardItem *item, const QVariant &value )
+{
+  QgsProcessingContext context;
+  context.setProject( mProject );
+
+  QgsDxfExport::DxfLayer layer = QgsProcessingParameterDxfLayers::variantMapAsLayer( value.toMap(), context );
+
+  item->setText( titleForLayer( layer ) );
+  item->setData( value, Qt::UserRole );
+}
+
+QString QgsProcessingDxfLayersPanelWidget::titleForLayer( const QgsDxfExport::DxfLayer &layer )
+{
+  QString title = layer.layer()->name();
+
+  if ( layer.layerOutputAttributeIndex() != -1 )
+    title += tr( " [split attribute: %1]" ).arg( layer.splitLayerAttribute() );
+
+  return title;
+}
+
+
+//
+// QgsProcessingDxfLayersWidget
+//
+
+QgsProcessingDxfLayersWidget::QgsProcessingDxfLayersWidget( QWidget *parent )
+  : QWidget( parent )
+{
+  QHBoxLayout *hl = new QHBoxLayout();
+  hl->setMargin( 0 );
+  hl->setContentsMargins( 0, 0, 0, 0 );
+
+  mLineEdit = new QLineEdit();
+  mLineEdit->setEnabled( false );
+  hl->addWidget( mLineEdit, 1 );
+
+  mToolButton = new QToolButton();
+  mToolButton->setText( QString( QChar( 0x2026 ) ) );
+  hl->addWidget( mToolButton );
+
+  setLayout( hl );
+
+  updateSummaryText();
+
+  connect( mToolButton, &QToolButton::clicked, this, &QgsProcessingDxfLayersWidget::showDialog );
+}
+
+void QgsProcessingDxfLayersWidget::setValue( const QVariant &value )
+{
+  if ( value.isValid() )
+    mValue = value.type() == QVariant::List ? value.toList() : QVariantList() << value;
+  else
+    mValue.clear();
+
+  updateSummaryText();
+  emit changed();
+}
+
+void QgsProcessingDxfLayersWidget::setProject( QgsProject *project )
+{
+  mProject = project;
+}
+
+void QgsProcessingDxfLayersWidget::showDialog()
+{
+  QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
+  if ( panel && panel->dockMode() )
+  {
+    QgsProcessingDxfLayersPanelWidget *widget = new QgsProcessingDxfLayersPanelWidget( mValue, mProject );
+    widget->setPanelTitle( tr( "Input layers" ) );
+    connect( widget, &QgsProcessingMultipleSelectionPanelWidget::selectionChanged, this, [ = ]()
+    {
+      setValue( widget->selectedOptions() );
+    } );
+    connect( widget, &QgsProcessingMultipleSelectionPanelWidget::acceptClicked, widget, &QgsPanelWidget::acceptPanel );
+    panel->openPanel( widget );
+  }
+  else
+  {
+    QDialog dlg;
+    dlg.setWindowTitle( tr( "Input layers" ) );
+    QVBoxLayout *vLayout = new QVBoxLayout();
+    QgsProcessingDxfLayersPanelWidget *widget = new QgsProcessingDxfLayersPanelWidget( mValue, mProject );
+    vLayout->addWidget( widget );
+    widget->buttonBox()->addButton( QDialogButtonBox::Cancel );
+    connect( widget->buttonBox(), &QDialogButtonBox::accepted, &dlg, &QDialog::accept );
+    connect( widget->buttonBox(), &QDialogButtonBox::rejected, &dlg, &QDialog::reject );
+    dlg.setLayout( vLayout );
+    if ( dlg.exec() )
+    {
+      setValue( widget->selectedOptions() );
+    }
+  }
+}
+
+void QgsProcessingDxfLayersWidget::updateSummaryText()
+{
+  mLineEdit->setText( tr( "%1 vector layers selected" ).arg( mValue.count() ) );
+}
+
+
+//
+// QgsProcessingDxfLayersWidgetWrapper
+//
+
+QgsProcessingDxfLayersWidgetWrapper::QgsProcessingDxfLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+  : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
+{
+}
+
+QString QgsProcessingDxfLayersWidgetWrapper::parameterType() const
+{
+  return QgsProcessingParameterDxfLayers::typeName();
+}
+
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingDxfLayersWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+{
+  return new QgsProcessingDxfLayersWidgetWrapper( parameter, type );
+}
+
+QWidget *QgsProcessingDxfLayersWidgetWrapper::createWidget()
+{
+  mPanel = new QgsProcessingDxfLayersWidget( nullptr );
+  mPanel->setProject( widgetContext().project() );
+  connect( mPanel, &QgsProcessingDxfLayersWidget::changed, this, [ = ]
+  {
+    emit widgetValueHasChanged( this );
+  } );
+  return mPanel;
+}
+
+void QgsProcessingDxfLayersWidgetWrapper::setWidgetContext( const QgsProcessingParameterWidgetContext &context )
+{
+  QgsAbstractProcessingParameterWidgetWrapper::setWidgetContext( context );
+  if ( mPanel )
+  {
+    mPanel->setProject( context.project() );
+  }
+}
+
+void QgsProcessingDxfLayersWidgetWrapper::setWidgetValue( const QVariant &value, QgsProcessingContext &context )
+{
+  Q_UNUSED( context )
+  if ( mPanel )
+  {
+    mPanel->setValue( value );
+  }
+}
+
+QVariant QgsProcessingDxfLayersWidgetWrapper::widgetValue() const
+{
+  return mPanel ? mPanel->value() : QVariant();
+}
+
+QStringList QgsProcessingDxfLayersWidgetWrapper::compatibleParameterTypes() const
+{
+  return QStringList();
+}
+
+QStringList QgsProcessingDxfLayersWidgetWrapper::compatibleOutputTypes() const
+{
+  return QStringList();
+}
+
+/// @endcond

--- a/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
@@ -23,7 +23,6 @@
 #include <QToolButton>
 
 #include "qgspanelwidget.h"
-#include "qgsprocessingcontext.h"
 #include "qgsprocessingparameters.h"
 #include "qgsprocessingoutputs.h"
 #include "qgsprocessingparameterdxflayers.h"
@@ -40,10 +39,9 @@ QgsProcessingDxfLayerDetailsWidget::QgsProcessingDxfLayerDetailsWidget( const QV
 
   mFieldsComboBox->setAllowEmptyFieldName( true );
 
-  QgsProcessingContext context;
-  context.setProject( project );
+  mContext.setProject( project );
 
-  QgsDxfExport::DxfLayer layer = QgsProcessingParameterDxfLayers::variantMapAsLayer( value.toMap(), context );
+  QgsDxfExport::DxfLayer layer = QgsProcessingParameterDxfLayers::variantMapAsLayer( value.toMap(), mContext );
   mLayer = layer.layer();
 
   if ( !mLayer )
@@ -81,14 +79,13 @@ QgsProcessingDxfLayersPanelWidget::QgsProcessingDxfLayersPanelWidget(
   buttonBox()->addButton( configureLayerButton, QDialogButtonBox::ActionRole );
 
   // populate the list: first layers already selected, then layers from project not yet selected
-  QgsProcessingContext context;
-  context.setProject( project );
+  mContext.setProject( project );
 
   QSet<const QgsVectorLayer *> seenVectorLayers;
   const QVariantList valueList = value.toList();
   for ( const QVariant &v : valueList )
   {
-    QgsDxfExport::DxfLayer layer = QgsProcessingParameterDxfLayers::variantMapAsLayer( v.toMap(), context );
+    QgsDxfExport::DxfLayer layer = QgsProcessingParameterDxfLayers::variantMapAsLayer( v.toMap(), mContext );
     if ( !layer.layer() )
       continue;  // skip any invalid layers
 
@@ -155,10 +152,9 @@ void QgsProcessingDxfLayersPanelWidget::configureLayer()
 
 void QgsProcessingDxfLayersPanelWidget::setItemValue( QStandardItem *item, const QVariant &value )
 {
-  QgsProcessingContext context;
-  context.setProject( mProject );
+  mContext.setProject( mProject );
 
-  QgsDxfExport::DxfLayer layer = QgsProcessingParameterDxfLayers::variantMapAsLayer( value.toMap(), context );
+  QgsDxfExport::DxfLayer layer = QgsProcessingParameterDxfLayers::variantMapAsLayer( value.toMap(), mContext );
 
   item->setText( titleForLayer( layer ) );
   item->setData( value, Qt::UserRole );

--- a/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
@@ -24,6 +24,8 @@
 
 #include "qgspanelwidget.h"
 #include "qgsprocessingcontext.h"
+#include "qgsprocessingparameters.h"
+#include "qgsprocessingoutputs.h"
 #include "qgsprocessingparameterdxflayers.h"
 
 /// @cond private
@@ -308,12 +310,23 @@ QVariant QgsProcessingDxfLayersWidgetWrapper::widgetValue() const
 
 QStringList QgsProcessingDxfLayersWidgetWrapper::compatibleParameterTypes() const
 {
-  return QStringList();
+  return QStringList()
+         << QgsProcessingParameterMultipleLayers::typeName()
+         << QgsProcessingParameterMapLayer::typeName()
+         << QgsProcessingParameterVectorLayer::typeName()
+         << QgsProcessingParameterFeatureSource::typeName()
+         << QgsProcessingParameterFile::typeName()
+         << QgsProcessingParameterString::typeName();
 }
 
 QStringList QgsProcessingDxfLayersWidgetWrapper::compatibleOutputTypes() const
 {
-  return QStringList();
+  return QStringList()
+         << QgsProcessingOutputString::typeName()
+         << QgsProcessingOutputMapLayer::typeName()
+         << QgsProcessingOutputVectorLayer::typeName()
+         << QgsProcessingOutputMultipleLayers::typeName()
+         << QgsProcessingOutputFile::typeName();
 }
 
 /// @endcond

--- a/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
@@ -102,6 +102,7 @@ QgsProcessingDxfLayersPanelWidget::QgsProcessingDxfLayersPanelWidget(
 
     QVariantMap vm;
     vm["layer"] = layer->id();
+    vm["attributeIndex"] = -1;
 
     QString title = layer->name();
     addOption( vm, title, false );

--- a/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.h
@@ -1,0 +1,142 @@
+/***************************************************************************
+  qgsprocessingdxflayerswidgetwrapper.h
+  ---------------------
+  Date                 : September 2020
+  Copyright            : (C) 2020 by Alexander bruy
+  Email                : alexander dot bruy at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPROCESSINGDXFLAYERSWIDGETWRAPPER_H
+#define QGSPROCESSINGDXFLAYERSWIDGETWRAPPER_H
+
+#define SIP_NO_FILE
+
+#include "qgsprocessingwidgetwrapper.h"
+#include "qgsprocessingmultipleselectiondialog.h"
+#include "qgsdxfexport.h"
+
+#include "ui_qgsprocessingdxflayerdetailswidgetbase.h"
+
+class QLineEdit;
+class QToolButton;
+
+/// @cond private
+
+class GUI_EXPORT QgsProcessingDxfLayerDetailsWidget : public QgsPanelWidget, private Ui::QgsProcessingDxfLayerDetailsWidget
+{
+  public:
+    QgsProcessingDxfLayerDetailsWidget( const QVariant &value, QgsProject *project );
+
+    QVariant value() const;
+
+    QDialogButtonBox *buttonBox() { return mButtonBox; }
+
+  private:
+    QgsVectorLayer *mLayer = nullptr;
+};
+
+
+class GUI_EXPORT QgsProcessingDxfLayersPanelWidget : public QgsProcessingMultipleSelectionPanelWidget
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsProcessingDxfLayersPanelWidget.
+     */
+    QgsProcessingDxfLayersPanelWidget(
+      const QVariant &value,
+      QgsProject *project,
+      QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+  private slots:
+
+    void configureLayer();
+
+  private:
+    void setItemValue( QStandardItem *item, const QVariant &value );
+    QString titleForLayer( const QgsDxfExport::DxfLayer &layer );
+
+    QgsProject *mProject = nullptr;
+};
+
+
+class GUI_EXPORT QgsProcessingDxfLayersWidget : public QWidget
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProcessingDxfLayersWidget( QWidget *parent = nullptr );
+
+    QVariant value() const { return mValue; }
+    void setValue( const QVariant &value );
+
+    void setProject( QgsProject *project );
+
+  signals:
+
+    void changed();
+
+  private slots:
+
+    void showDialog();
+
+  private:
+
+    void updateSummaryText();
+
+    QLineEdit *mLineEdit = nullptr;
+    QToolButton *mToolButton = nullptr;
+
+    QVariantList mValue;
+
+    QgsProject *mProject = nullptr;
+
+    friend class TestProcessingGui;
+};
+
+
+class GUI_EXPORT QgsProcessingDxfLayersWidgetWrapper : public QgsAbstractProcessingParameterWidgetWrapper, public QgsProcessingParameterWidgetFactoryInterface
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProcessingDxfLayersWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr,
+                                         QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+
+    // QgsProcessingParameterWidgetFactoryInterface
+    QString parameterType() const override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+
+    // QgsProcessingParameterWidgetWrapper interface
+    QWidget *createWidget() override SIP_FACTORY;
+    void setWidgetContext( const QgsProcessingParameterWidgetContext &context ) override;
+
+  protected:
+
+    void setWidgetValue( const QVariant &value, QgsProcessingContext &context ) override;
+    QVariant widgetValue() const override;
+
+    QStringList compatibleParameterTypes() const override;
+    QStringList compatibleOutputTypes() const override;
+
+  private:
+
+    QgsProcessingDxfLayersWidget *mPanel = nullptr;
+
+    friend class TestProcessingGui;
+};
+
+/// @endcond
+
+#endif // QGSPROCESSINGDXFLAYERSWIDGETWRAPPER_H

--- a/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.h
@@ -18,6 +18,7 @@
 
 #define SIP_NO_FILE
 
+#include "qgsprocessingcontext.h"
 #include "qgsprocessingwidgetwrapper.h"
 #include "qgsprocessingmultipleselectiondialog.h"
 #include "qgsdxfexport.h"
@@ -40,6 +41,7 @@ class GUI_EXPORT QgsProcessingDxfLayerDetailsWidget : public QgsPanelWidget, pri
 
   private:
     QgsVectorLayer *mLayer = nullptr;
+    QgsProcessingContext mContext;
 };
 
 
@@ -66,6 +68,7 @@ class GUI_EXPORT QgsProcessingDxfLayersPanelWidget : public QgsProcessingMultipl
     QString titleForLayer( const QgsDxfExport::DxfLayer &layer );
 
     QgsProject *mProject = nullptr;
+    QgsProcessingContext mContext;
 };
 
 

--- a/src/gui/processing/qgsprocessingguiregistry.cpp
+++ b/src/gui/processing/qgsprocessingguiregistry.cpp
@@ -21,6 +21,7 @@
 #include "qgsprocessingvectortilewriterlayerswidgetwrapper.h"
 #include "qgsprocessingfieldmapwidgetwrapper.h"
 #include "qgsprocessingaggregatewidgetwrapper.h"
+#include "qgsprocessingdxflayerswidgetwrapper.h"
 #include "qgsprocessingwidgetwrapperimpl.h"
 #include "qgsprocessingtininputlayerswidget.h"
 #include "qgsprocessingparameters.h"
@@ -73,6 +74,7 @@ QgsProcessingGuiRegistry::QgsProcessingGuiRegistry()
   addParameterWidgetFactory( new QgsProcessingFieldMapWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingAggregateWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingTinInputLayersWidgetWrapper() );
+  addParameterWidgetFactory( new QgsProcessingDxfLayersWidgetWrapper() );
 }
 
 QgsProcessingGuiRegistry::~QgsProcessingGuiRegistry()

--- a/src/ui/processing/qgsprocessingdxflayerdetailswidgetbase.ui
+++ b/src/ui/processing/qgsprocessingdxflayerdetailswidgetbase.ui
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsProcessingDxfLayerDetailsWidget</class>
+ <widget class="QWidget" name="QgsProcessingDxfLayerDetailsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>393</width>
+    <height>71</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Attribute</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QDialogButtonBox" name="mButtonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QgsFieldComboBox" name="mFieldsComboBox"/>
+   </item>
+   <item row="1" column="0" colspan="3">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFieldComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsfieldcombobox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/tests/src/analysis/CMakeLists.txt
+++ b/tests/src/analysis/CMakeLists.txt
@@ -10,6 +10,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/src/core
   ${CMAKE_SOURCE_DIR}/src/core/auth
   ${CMAKE_SOURCE_DIR}/src/core/expression
+  ${CMAKE_SOURCE_DIR}/src/core/dxf
   ${CMAKE_SOURCE_DIR}/src/core/geometry
   ${CMAKE_SOURCE_DIR}/src/core/labeling
   ${CMAKE_SOURCE_DIR}/src/core/layout
@@ -89,7 +90,7 @@ SET(TESTS
  testqgsreclassifyutils.cpp
  testqgsalignraster.cpp
  testqgsnetworkanalysis.cpp
- testqgsninecellfilters.cpp 
+ testqgsninecellfilters.cpp
  testqgsmeshcalculator.cpp
  testqgsmeshcontours.cpp
  testqgstriangulation.cpp

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -52,6 +52,7 @@
 #include "qgsprocessingparameteraggregate.h"
 #include "qgsprocessingparametertininputlayers.h"
 #include "qgsprocessingparameterdxflayers.h"
+#include "qgsdxfexport.h"
 
 class DummyAlgorithm : public QgsProcessingAlgorithm
 {
@@ -8416,6 +8417,17 @@ void TestQgsProcessing::parameterDxfLayers()
 
   QString pythonCode = def->asPythonString();
   QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterDxfLayers('dxf input layer', '')" ) );
+
+  QgsDxfExport::DxfLayer dxfLayer( vectorLayer );
+  QList<QgsDxfExport::DxfLayer> dxfList = def->parameterAsLayers( QVariant( vectorLayer->source() ), context );
+  QCOMPARE( dxfList.at( 0 ).layer()->source(), dxfLayer.layer()->source() );
+  QCOMPARE( dxfList.at( 0 ).layerOutputAttributeIndex(), dxfLayer.layerOutputAttributeIndex() );
+  dxfList = def->parameterAsLayers( QVariant( QStringList() << vectorLayer->source() ), context );
+  QCOMPARE( dxfList.at( 0 ).layer()->source(), dxfLayer.layer()->source() );
+  QCOMPARE( dxfList.at( 0 ).layerOutputAttributeIndex(), dxfLayer.layerOutputAttributeIndex() );
+  dxfList = def->parameterAsLayers( layerList, context );
+  QCOMPARE( dxfList.at( 0 ).layer()->source(), dxfLayer.layer()->source() );
+  QCOMPARE( dxfList.at( 0 ).layerOutputAttributeIndex(), dxfLayer.layerOutputAttributeIndex() );
 }
 
 void TestQgsProcessing::checkParamValues()

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -51,6 +51,7 @@
 #include "qgsprocessingparameterfieldmap.h"
 #include "qgsprocessingparameteraggregate.h"
 #include "qgsprocessingparametertininputlayers.h"
+#include "qgsprocessingparameterdxflayers.h"
 
 class DummyAlgorithm : public QgsProcessingAlgorithm
 {
@@ -603,6 +604,7 @@ class TestQgsProcessing: public QObject
     void parameterFieldMapping();
     void parameterAggregate();
     void parameterTinInputLayers();
+    void parameterDxfLayers();
     void checkParamValues();
     void combineLayerExtent();
     void processingFeatureSource();
@@ -8362,6 +8364,46 @@ void TestQgsProcessing::parameterDateTime()
   QCOMPARE( fromCode->description(), QStringLiteral( "optional" ) );
   QCOMPARE( fromCode->flags(), def->flags() );
   QVERIFY( !fromCode->defaultValue().isValid() );
+}
+
+void TestQgsProcessing::parameterDxfLayers()
+{
+  QgsProcessingContext context;
+  QgsProject project;
+  context.setProject( &project );
+  QgsVectorLayer *vectorLayer = new QgsVectorLayer( QStringLiteral( "Point" ),
+      QStringLiteral( "PointLayer" ),
+      QStringLiteral( "memory" ) );
+  project.addMapLayer( vectorLayer );
+
+  std::unique_ptr< QgsProcessingParameterDxfLayers > def( new QgsProcessingParameterDxfLayers( "dxf input layer" ) );
+  QVERIFY( !def->checkValueIsAcceptable( 1 ) );
+  QVERIFY( !def->checkValueIsAcceptable( "test" ) );
+  QVERIFY( !def->checkValueIsAcceptable( "" ) );
+  QVariantList layerList;
+  QVERIFY( !def->checkValueIsAcceptable( layerList ) );
+  QVariantMap layerMap;
+  layerList.append( layerMap );
+  QVERIFY( !def->checkValueIsAcceptable( layerList ) );
+  layerMap["layer"] = "layerName";
+  layerMap["attributeIndex"] = -1;
+  layerList[0] = layerMap;
+  QVERIFY( def->checkValueIsAcceptable( layerList ) );
+  QVERIFY( !def->checkValueIsAcceptable( layerList, &context ) ); //no corresponding layer in the context's project
+  layerMap["layer"] = "PointLayer";
+  layerMap["attributeIndex"] = 1; //change for invalid attribute index
+  layerList[0] = layerMap;
+  QVERIFY( !def->checkValueIsAcceptable( layerList, &context ) );
+
+  layerMap["attributeIndex"] = -1;
+  layerList[0] = layerMap;
+  QVERIFY( def->checkValueIsAcceptable( layerList, &context ) );
+
+  QString valueAsPythonString = def->valueAsPythonString( layerList, context );
+  QCOMPARE( valueAsPythonString, QStringLiteral( "[{'layer': '%1','attributeIndex': -1}]" ).arg( vectorLayer->source() ) );
+
+  QString pythonCode = def->asPythonString();
+  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterDxfLayers('dxf input layer', '')" ) );
 }
 
 void TestQgsProcessing::checkParamValues()

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -8378,8 +8378,20 @@ void TestQgsProcessing::parameterDxfLayers()
 
   std::unique_ptr< QgsProcessingParameterDxfLayers > def( new QgsProcessingParameterDxfLayers( "dxf input layer" ) );
   QVERIFY( !def->checkValueIsAcceptable( 1 ) );
-  QVERIFY( !def->checkValueIsAcceptable( "test" ) );
+  QVERIFY( def->checkValueIsAcceptable( "test" ) );
   QVERIFY( !def->checkValueIsAcceptable( "" ) );
+  QVERIFY( !def->checkValueIsAcceptable( QVariant() ) );
+  QVERIFY( def->checkValueIsAcceptable( QVariant::fromValue( vectorLayer ) ) );
+
+  // should also be OK
+  QVERIFY( def->checkValueIsAcceptable( "c:/Users/admin/Desktop/roads_clipped_transformed_v1_reprojected_final_clipped_aAAA.shp" ) );
+  QVERIFY( def->checkValueIsAcceptable( QStringList() << "c:/Users/admin/Desktop/roads_clipped_transformed_v1_reprojected_final_clipped_aAAA.shp" ) );
+  QVERIFY( def->checkValueIsAcceptable( QVariantList() << "c:/Users/admin/Desktop/roads_clipped_transformed_v1_reprojected_final_clipped_aAAA.shp" ) );
+  // ... unless we use context, when the check that the layer actually exists is performed
+  QVERIFY( !def->checkValueIsAcceptable( "c:/Users/admin/Desktop/roads_clipped_transformed_v1_reprojected_final_clipped_aAAA.shp", &context ) );
+  QVERIFY( !def->checkValueIsAcceptable( QStringList() << "c:/Users/admin/Desktop/roads_clipped_transformed_v1_reprojected_final_clipped_aAAA.shp", &context ) );
+  QVERIFY( !def->checkValueIsAcceptable( QVariantList() << "c:/Users/admin/Desktop/roads_clipped_transformed_v1_reprojected_final_clipped_aAAA.shp", &context ) );
+
   QVariantList layerList;
   QVERIFY( !def->checkValueIsAcceptable( layerList ) );
   QVariantMap layerMap;

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -23,6 +23,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/src/core
   ${CMAKE_SOURCE_DIR}/src/core/expression
   ${CMAKE_SOURCE_DIR}/src/core/auth
+  ${CMAKE_SOURCE_DIR}/src/core/dxf
   ${CMAKE_SOURCE_DIR}/src/core/geometry
   ${CMAKE_SOURCE_DIR}/src/core/labeling
   ${CMAKE_SOURCE_DIR}/src/core/layout


### PR DESCRIPTION
## Description
Implements native DXF export algorithm using `QgsDxfExport` functionality (also used by Project→Import/Export→Export Porject to DXF). Allows to export individual layer as well as multiple layers into single DXF file. For each input layer user can select which attribute to use for splitting layer into multiple output layers.

![export](https://user-images.githubusercontent.com/776954/97008125-1b51ac80-154b-11eb-9346-64bcb0691a72.gif)

Fixes #25392.