### PR TITLE
[RPM] Make spec file compatible with Fedora 33

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -255,12 +255,12 @@ gzip ChangeLog
       %{configure_with_sha} \
       .
 
-make %{?_smp_mflags}
+%cmake_build
 
 %install
 # Necessary for the test suite
 #export LD_LIBRARY_PATH=%{_builddir}%{name}-%{version}/output/%{_lib}
-make install DESTDIR=%{buildroot}
+%cmake_install
 
 # Install MIME type definitions
 install -d %{buildroot}%{_datadir}/mime/packages


### PR DESCRIPTION
## Description

Update the QGIS spec file to make it compile on Fedora 33. The change is backward compatible with any currently supported Fedora release (31 and 32)

Needs backport to 3.10 and 3.16