### PR TITLE
[Georeferencer] Reproject data points in the desired output projection

### DIFF
--- a/src/app/georeferencer/qgsgcpcanvasitem.cpp
+++ b/src/app/georeferencer/qgsgcpcanvasitem.cpp
@@ -50,7 +50,7 @@ void QgsGCPCanvasItem::paint( QPainter *p )
   if ( mDataPoint )
   {
     enabled = mDataPoint->isEnabled();
-    worldCoords = mDataPoint->mapCoords();
+    worldCoords = mDataPoint->transCoords();
     id = mDataPoint->id();
   }
 

--- a/src/app/georeferencer/qgsgcpcanvasitem.h
+++ b/src/app/georeferencer/qgsgcpcanvasitem.h
@@ -39,6 +39,8 @@ class QgsGCPCanvasItem : public QgsMapCanvasItem
     //! Calls prepareGeometryChange()
     void checkBoundingRectChange();
 
+    QgsMapCanvas *canvas() const { return mMapCanvas; }
+
   private:
 
     const QgsGeorefDataPoint *mDataPoint = nullptr;

--- a/src/app/georeferencer/qgsgcplist.h
+++ b/src/app/georeferencer/qgsgcplist.h
@@ -21,6 +21,7 @@
 
 class QgsGeorefDataPoint;
 class QgsPointXY;
+class QgsCoordinateReferenceSystem;
 
 // what is better use inherid or agrigate QList?
 class QgsGCPList : public QList<QgsGeorefDataPoint *>
@@ -29,7 +30,7 @@ class QgsGCPList : public QList<QgsGeorefDataPoint *>
     QgsGCPList() = default;
     QgsGCPList( const QgsGCPList &list );
 
-    void createGCPVectors( QVector<QgsPointXY> &mapCoords, QVector<QgsPointXY> &pixelCoords );
+    void createGCPVectors( QVector<QgsPointXY> &mapCoords, QVector<QgsPointXY> &pixelCoords, const QgsCoordinateReferenceSystem targetCrs );
     int size() const;
     int sizeAll() const;
 

--- a/src/app/georeferencer/qgsgeorefdatapoint.h
+++ b/src/app/georeferencer/qgsgeorefdatapoint.h
@@ -17,6 +17,7 @@
 #define QGSGEOREFDATAPOINT_H
 
 #include "qgsmapcanvasitem.h"
+#include "qgscoordinatereferencesystem.h"
 
 class QgsGCPCanvasItem;
 
@@ -28,7 +29,7 @@ class QgsGeorefDataPoint : public QObject
     //! constructor
     QgsGeorefDataPoint( QgsMapCanvas *srcCanvas, QgsMapCanvas *dstCanvas,
                         const QgsPointXY &pixelCoords, const QgsPointXY &mapCoords,
-                        bool enable );
+                        const QgsCoordinateReferenceSystem proj, bool enable );
     QgsGeorefDataPoint( const QgsGeorefDataPoint &p );
     ~QgsGeorefDataPoint() override;
 
@@ -38,6 +39,9 @@ class QgsGeorefDataPoint : public QObject
 
     QgsPointXY mapCoords() const { return mMapCoords; }
     void setMapCoords( const QgsPointXY &p );
+
+    QgsPointXY transCoords() const;
+    void setTransCoords( const QgsPointXY &p );
 
     bool isEnabled() const { return mEnabled; }
     void setEnabled( bool enabled );
@@ -53,6 +57,8 @@ class QgsGeorefDataPoint : public QObject
     QPointF residual() const { return mResidual; }
     void setResidual( QPointF r );
 
+    QgsCoordinateReferenceSystem crs() const { return mCrs; }
+
   public slots:
     void moveTo( QPoint, bool isMapPlugin );
     void updateCoords();
@@ -64,8 +70,10 @@ class QgsGeorefDataPoint : public QObject
     QgsGCPCanvasItem *mGCPDestinationItem = nullptr;
     QgsPointXY mPixelCoords;
     QgsPointXY mMapCoords;
+    QgsPointXY mTransCoords;
 
     int mId;
+    QgsCoordinateReferenceSystem mCrs;
     bool mEnabled;
     QPointF mResidual;
 

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -540,11 +540,11 @@ void QgsGeoreferencerMainWindow::linkGeorefToQgis( bool link )
 }
 
 // GCPs slots
-void QgsGeoreferencerMainWindow::addPoint( const QgsPointXY &pixelCoords, const QgsPointXY &mapCoords,
+void QgsGeoreferencerMainWindow::addPoint( const QgsPointXY &pixelCoords, const QgsPointXY &mapCoords, const QgsCoordinateReferenceSystem &crs,
     bool enable, bool finalize )
 {
   QgsGeorefDataPoint *pnt = new QgsGeorefDataPoint( mCanvas, QgisApp::instance()->mapCanvas(),
-      pixelCoords, mapCoords, enable );
+      pixelCoords, mapCoords, QgsCoordinateReferenceSystem( crs ), enable );
   mPoints.append( pnt );
   mGCPsDirty = true;
   if ( finalize )
@@ -612,7 +612,6 @@ void QgsGeoreferencerMainWindow::movePoint( QPoint p )
   if ( mvPoint )
   {
     mvPoint->moveTo( p, isMapPlugin );
-    mGCPListWidget->updateGCPList();
   }
 
 }
@@ -620,6 +619,7 @@ void QgsGeoreferencerMainWindow::movePoint( QPoint p )
 void QgsGeoreferencerMainWindow::releasePoint( QPoint p )
 {
   Q_UNUSED( p )
+  mGCPListWidget->updateGCPList();
   // Get Map Sender
   if ( sender() == mToolMovePoint )
   {
@@ -637,7 +637,7 @@ void QgsGeoreferencerMainWindow::showCoordDialog( const QgsPointXY &pixelCoords 
   {
     mMapCoordsDialog = new QgsMapCoordsDialog( QgisApp::instance()->mapCanvas(), pixelCoords, this );
     connect( mMapCoordsDialog, &QgsMapCoordsDialog::pointAdded, this,
-    [this]( const QgsPointXY & a, const QgsPointXY & b ) { this->addPoint( a, b ); }
+    [this]( const QgsPointXY & a, const QgsPointXY & b, const QgsCoordinateReferenceSystem & crs ) { this->addPoint( a, b, crs ); }
            );
     mMapCoordsDialog->show();
   }
@@ -1291,13 +1291,14 @@ bool QgsGeoreferencerMainWindow::loadGCPs( /*bool verbose*/ )
 
     QgsPointXY mapCoords( ls.at( 0 ).toDouble(), ls.at( 1 ).toDouble() ); // map x,y
     QgsPointXY pixelCoords( ls.at( 2 ).toDouble(), ls.at( 3 ).toDouble() ); // pixel x,y
-    if ( ls.count() == 5 || ls.count() == 8 )
+    QgsCoordinateReferenceSystem proj( ls.at( 8 ) );
+    if ( ls.count() == 5 || ls.count() == 9 )
     {
       bool enable = ls.at( 4 ).toInt();
-      addPoint( pixelCoords, mapCoords, enable, false );
+      addPoint( pixelCoords, mapCoords, proj, enable, false );
     }
     else
-      addPoint( pixelCoords, mapCoords, true, false );
+      addPoint( pixelCoords, mapCoords, proj, true, false );
 
     ++i;
   }
@@ -1324,7 +1325,7 @@ void QgsGeoreferencerMainWindow::saveGCPs()
     points << "mapX,mapY,pixelX,pixelY,enable,dX,dY,residual" << endl;
     for ( QgsGeorefDataPoint *pt : qgis::as_const( mPoints ) )
     {
-      points << QStringLiteral( "%1,%2,%3,%4,%5,%6,%7,%8" )
+      points << QStringLiteral( "%1,%2,%3,%4,%5,%6,%7,%8,%9" )
              .arg( qgsDoubleToString( pt->mapCoords().x() ),
                    qgsDoubleToString( pt->mapCoords().y() ),
                    qgsDoubleToString( pt->pixelCoords().x() ),
@@ -1332,7 +1333,8 @@ void QgsGeoreferencerMainWindow::saveGCPs()
              .arg( pt->isEnabled() )
              .arg( qgsDoubleToString( pt->residual().x() ),
                    qgsDoubleToString( pt->residual().y() ),
-                   qgsDoubleToString( std::sqrt( pt->residual().x() * pt->residual().x() + pt->residual().y() * pt->residual().y() ) ) )
+                   qgsDoubleToString( std::sqrt( pt->residual().x() * pt->residual().x() + pt->residual().y() * pt->residual().y() ) ),
+                   pt->crs().toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ) )
              << endl;
     }
 
@@ -1803,8 +1805,8 @@ bool QgsGeoreferencerMainWindow::writePDFReportFile( const QString &fileName, co
     {
       currentGCPStrings << tr( "no" );
     }
-    currentGCPStrings << QString::number( ( *gcpIt )->pixelCoords().x(), 'f', 0 ) << QString::number( ( *gcpIt )->pixelCoords().y(), 'f', 0 ) << QString::number( ( *gcpIt )->mapCoords().x(), 'f', 3 )
-                      <<  QString::number( ( *gcpIt )->mapCoords().y(), 'f', 3 ) <<  QString::number( residual.x() ) <<  QString::number( residual.y() ) << QString::number( residualTot );
+    currentGCPStrings << QString::number( ( *gcpIt )->pixelCoords().x(), 'f', 0 ) << QString::number( ( *gcpIt )->pixelCoords().y(), 'f', 0 ) << QString::number( ( *gcpIt )->transCoords().x(), 'f', 3 )
+                      <<  QString::number( ( *gcpIt )->transCoords().y(), 'f', 3 ) <<  QString::number( residual.x() ) <<  QString::number( residual.y() ) << QString::number( residualTot );
     gcpTableContents << currentGCPStrings;
   }
 
@@ -1910,7 +1912,7 @@ QString QgsGeoreferencerMainWindow::generateGDALtranslateCommand( bool generateT
   for ( QgsGeorefDataPoint *pt : qgis::as_const( mPoints ) )
   {
     gdalCommand << QStringLiteral( "-gcp %1 %2 %3 %4" ).arg( pt->pixelCoords().x() ).arg( -pt->pixelCoords().y() )
-                .arg( pt->mapCoords().x() ).arg( pt->mapCoords().y() );
+                .arg( pt->transCoords().x() ).arg( pt->transCoords().y() );
   }
 
   QFileInfo rasterFileInfo( mRasterFileName );
@@ -2017,7 +2019,7 @@ bool QgsGeoreferencerMainWindow::updateGeorefTransform()
 {
   QVector<QgsPointXY> mapCoords, pixelCoords;
   if ( mGCPListWidget->gcpList() )
-    mGCPListWidget->gcpList()->createGCPVectors( mapCoords, pixelCoords );
+    mGCPListWidget->gcpList()->createGCPVectors( mapCoords, pixelCoords, mProjection );
   else
     return false;
 

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -88,7 +88,7 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
 
     // gcps
     void addPoint( const QgsPointXY &pixelCoords, const QgsPointXY &mapCoords,
-                   bool enable = true, bool finalize = true );
+                   const QgsCoordinateReferenceSystem &crs, bool enable = true, bool finalize = true );
     void deleteDataPoint( QPoint pixelCoords );
     void deleteDataPoint( int index );
     void showCoordDialog( const QgsPointXY &pixelCoords );

--- a/src/app/georeferencer/qgsmapcoordsdialog.h
+++ b/src/app/georeferencer/qgsmapcoordsdialog.h
@@ -20,6 +20,8 @@
 #include "qgspointxy.h"
 #include "qgsmapcanvas.h"
 #include "qgspointlocator.h"
+#include "qgsprojectionselectionwidget.h"
+#include "qgscoordinatereferencesystem.h"
 
 
 #include "ui_qgsmapcoordsdialogbase.h"
@@ -68,18 +70,23 @@ class QgsMapCoordsDialog : public QDialog, private Ui::QgsMapCoordsDialogBase
     void maybeSetXY( const QgsPointXY &, Qt::MouseButton );
     void updateOK();
     void setPrevTool();
+    void updateCrs( const QgsCoordinateReferenceSystem &crs );
 
   signals:
-    void pointAdded( const QgsPointXY &, const QgsPointXY & );
+    void pointAdded( const QgsPointXY &, const QgsPointXY &, const QgsCoordinateReferenceSystem & );
 
   private:
     double dmsToDD( const QString &dms );
 
     QPushButton *mPointFromCanvasPushButton = nullptr;
 
+    //QgsProjectionSelectionWidget *mProjSelect = nullptr;
+
     QgsGeorefMapToolEmitPoint *mToolEmitPoint = nullptr;
     QgsMapTool *mPrevMapTool = nullptr;
     QgsMapCanvas *mQgisCanvas = nullptr;
+
+    QgsCoordinateReferenceSystem mCrs;
 
     QgsPointXY mPixelCoords;
 };

--- a/src/ui/georeferencer/qgsmapcoordsdialogbase.ui
+++ b/src/ui/georeferencer/qgsmapcoordsdialogbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>531</width>
-    <height>212</height>
+    <width>584</width>
+    <height>221</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,67 +16,96 @@
   <property name="sizeGripEnabled">
    <bool>true</bool>
   </property>
-  <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0,0">
-   <item row="1" column="0">
-    <widget class="QLabel" name="textLabel1">
-     <property name="text">
-      <string>X / East</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="4">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" colspan="4">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter X and Y coordinates (DMS (&lt;span style=&quot; font-style:italic;&quot;&gt;dd mm ss.ss&lt;/span&gt;), DD (&lt;span style=&quot; font-style:italic;&quot;&gt;dd.dd&lt;/span&gt;) or projected coordinates (&lt;span style=&quot; font-style:italic;&quot;&gt;mmmm.mm&lt;/span&gt;)) which correspond with the selected point on the image. Alternatively, click the button with icon of a pencil and then click a corresponding point on map canvas of QGIS to fill in coordinates of that point.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="QLabel" name="textLabel2">
-     <property name="text">
-      <string>Y / North</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="1" column="3">
-    <widget class="QLineEdit" name="leYCoord"/>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="leXCoord"/>
-   </item>
-   <item row="4" column="0" colspan="4">
-    <widget class="QCheckBox" name="mMinimizeWindowCheckBox">
-     <property name="text">
-      <string>Automatically hide georeferencer window </string>
-     </property>
-    </widget>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter X and Y coordinates (DMS (&lt;span style=&quot; font-style:italic;&quot;&gt;dd mm ss.ss&lt;/span&gt;), DD (&lt;span style=&quot; font-style:italic;&quot;&gt;dd.dd&lt;/span&gt;) or projected coordinates (&lt;span style=&quot; font-style:italic;&quot;&gt;mmmm.mm&lt;/span&gt;)) which correspond with the selected point on the image. Alternatively, click the button with icon of a pencil and then click a corresponding point on map canvas of QGIS to fill in coordinates of that point.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSplitter" name="splitter">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <widget class="QLabel" name="textLabel1">
+        <property name="text">
+         <string>X / East</string>
+        </property>
+       </widget>
+       <widget class="QLineEdit" name="leXCoord"/>
+       <widget class="QLabel" name="textLabel2">
+        <property name="text">
+         <string>Y / North</string>
+        </property>
+       </widget>
+       <widget class="QLineEdit" name="leYCoord"/>
+      </widget>
+     </item>
+     <item>
+      <widget class="QgsProjectionSelectionWidget" name="mProjSelect" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>22</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>10</height>
+        </size>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="mMinimizeWindowCheckBox">
+       <property name="text">
+        <string>Automatically hide georeferencer window </string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>leXCoord</tabstop>
   <tabstop>leYCoord</tabstop>
@@ -90,8 +119,8 @@
    <slot>close()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>194</x>
-     <y>180</y>
+     <x>203</x>
+     <y>213</y>
     </hint>
     <hint type="destinationlabel">
      <x>194</x>
@@ -110,8 +139,8 @@
      <y>119</y>
     </hint>
     <hint type="destinationlabel">
-     <x>236</x>
-     <y>119</y>
+     <x>521</x>
+     <y>124</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
## Description

This is a proposal to improve the georeferencer plugin in a way that doesn't force the user to set the canvas to the same crs as the desired output.

To do this I am storing the original projection of the points and reprojecting them when needed to georeference the file.

I have noticed that moving those points is quite finnicky, I'm not too sure if this is due to these changes or just my testing VM/build.

Still need to work on the UI ti add the crs selector properly. 
 