### PR TITLE
Fix self-snapping for layers with CRS that differs from project CRS

### DIFF
--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -288,7 +288,7 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
 
     for ( QgsVectorLayer *vl : mExtraSnapLayers )
     {
-      QgsPointLocator *loc = locatorForLayer( vl );
+      QgsPointLocator *loc = locatorForLayerUsingStrategy( vl, pointMap, tolerance );
       _updateBestMatch( bestMatch, pointMap, loc, type, tolerance, filter, false );
       if ( mSnappingConfig.intersectionSnapping() )
         edges << loc->edgesInRect( pointMap, tolerance );
@@ -357,7 +357,7 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
 
     for ( QgsVectorLayer *vl : mExtraSnapLayers )
     {
-      QgsPointLocator *loc = locatorForLayer( vl );
+      QgsPointLocator *loc = locatorForLayerUsingStrategy( vl, pointMap, maxTolerance );
       _updateBestMatch( bestMatch, pointMap, loc, maxTypes, maxTolerance, filter, false );
       if ( mSnappingConfig.intersectionSnapping() )
         edges << loc->edgesInRect( pointMap, maxTolerance );
@@ -399,7 +399,7 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
 
     for ( QgsVectorLayer *vl : mExtraSnapLayers )
     {
-      QgsPointLocator *loc = locatorForLayer( vl );
+      QgsPointLocator *loc = locatorForLayerUsingStrategy( vl, pointMap, tolerance );
       _updateBestMatch( bestMatch, pointMap, loc, type, tolerance, filter, false );
       if ( mSnappingConfig.intersectionSnapping() )
         edges << loc->edgesInRect( pointMap, tolerance );


### PR DESCRIPTION
## Description

Currently, self-snapping does not work if the layer CRS is different from the project CRS (no points are snapped, see #39268). This PR corrects how the `QgsPointLocator` is created for extra snap layer that is used for self-snapping.

Fixes #39268