### PR TITLE
fix digitizing with curve #39590

### DIFF
--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -594,10 +594,12 @@ int QgsMapToolCapture::addVertex( const QgsPointXY &point, const QgsPointLocator
             mSnappingMatches.append( match );
           }
         }
+        mCaptureLastPoint = mapPoint;
         mTempRubberBand->reset( mCaptureMode == CapturePolygon ? QgsWkbTypes::PolygonGeometry : QgsWkbTypes::LineGeometry, mDigitizingType, firstCapturedMapPoint() );
       }
       else if ( mCaptureCurve.numPoints() == 0 )
       {
+        mCaptureLastPoint = mapPoint;
         mCaptureCurve.addVertex( layerPoint );
         mSnappingMatches.append( match );
       }
@@ -610,7 +612,6 @@ int QgsMapToolCapture::addVertex( const QgsPointXY &point, const QgsPointLocator
       }
 
       mTempRubberBand->addPoint( mapPoint );
-      mCaptureLastPoint = mapPoint;
     }
     else
     {

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -294,8 +294,11 @@ void TestQgsMapToolAddFeatureLine::testNoTracing()
   QCOMPARE( utils.existingFeatureIds().count(), 1 );
 
   utils.mouseClick( 1, 1, Qt::LeftButton );
+  utils.mouseMove( 5, 5 );
   utils.mouseClick( 3, 2, Qt::LeftButton );
+  utils.mouseMove( 5, 5 );
   utils.mouseClick( 4, 2, Qt::LeftButton );
+  utils.mouseMove( 5, 5 );
   utils.mouseClick( 4, 2, Qt::RightButton );
 
   newFid = utils.newFeatureId( oldFids );


### PR DESCRIPTION
fix #39590
The new digitizing with curve feature  (https://github.com/qgis/QGIS/pull/37685) had been broken by #39308 that didn't make the test fail because only mouse moves broke the feature behavior.
