### PR TITLE
Sanitize qgsgeometry_cast<> implementation

### DIFF
--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -18,6 +18,7 @@ email                : marco.hugentobler at sourcepole dot com
 
 #include <array>
 #include <functional>
+#include <type_traits>
 #include <QString>
 
 #include "qgis_core.h"
@@ -1154,7 +1155,7 @@ struct CORE_EXPORT QgsVertexId
 template <class T>
 inline T qgsgeometry_cast( const QgsAbstractGeometry *geom )
 {
-  return const_cast<T>( reinterpret_cast<T>( 0 )->cast( geom ) );
+  return const_cast<T>( std::remove_pointer<T>::type::cast( geom ) );
 }
 
 #endif

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -139,7 +139,7 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
      * \note Not available in Python. Objects will be automatically be converted to the appropriate target type.
      * \since QGIS 3.0
      */
-    inline const QgsCircularString *cast( const QgsAbstractGeometry *geom ) const
+    inline static const QgsCircularString *cast( const QgsAbstractGeometry *geom )
     {
       if ( geom && QgsWkbTypes::flatType( geom->wkbType() ) == QgsWkbTypes::CircularString )
         return static_cast<const QgsCircularString *>( geom );

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -141,7 +141,7 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
      * \note Not available in Python. Objects will be automatically be converted to the appropriate target type.
      * \since QGIS 3.0
      */
-    inline const QgsCompoundCurve *cast( const QgsAbstractGeometry *geom ) const
+    inline static const QgsCompoundCurve *cast( const QgsAbstractGeometry *geom )
     {
       if ( geom && QgsWkbTypes::flatType( geom->wkbType() ) == QgsWkbTypes::CompoundCurve )
         return static_cast<const QgsCompoundCurve *>( geom );

--- a/src/core/geometry/qgscurve.h
+++ b/src/core/geometry/qgscurve.h
@@ -259,7 +259,7 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry
      * \note Not available in Python. Objects will be automatically be converted to the appropriate target type.
      * \since QGIS 3.0
      */
-    inline const QgsCurve *cast( const QgsAbstractGeometry *geom ) const
+    inline static const QgsCurve *cast( const QgsAbstractGeometry *geom )
     {
       if ( !geom )
         return nullptr;

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -272,7 +272,7 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
      * \note Not available in Python. Objects will be automatically be converted to the appropriate target type.
      * \since QGIS 3.0
      */
-    inline const QgsCurvePolygon *cast( const QgsAbstractGeometry *geom ) const
+    inline static const QgsCurvePolygon *cast( const QgsAbstractGeometry *geom )
     {
       if ( !geom )
         return nullptr;

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -247,7 +247,7 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
      * \note Not available in Python. Objects will be automatically be converted to the appropriate target type.
      * \since QGIS 3.0
      */
-    inline const QgsGeometryCollection *cast( const QgsAbstractGeometry *geom ) const
+    inline static const QgsGeometryCollection *cast( const QgsAbstractGeometry *geom )
     {
       if ( geom && QgsWkbTypes::isMultiType( geom->wkbType() ) )
         return static_cast<const QgsGeometryCollection *>( geom );

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -680,7 +680,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
      * \note Not available in Python. Objects will be automatically be converted to the appropriate target type.
      * \since QGIS 3.0
      */
-    inline const QgsLineString *cast( const QgsAbstractGeometry *geom ) const
+    inline static const QgsLineString *cast( const QgsAbstractGeometry *geom )
     {
       if ( geom && QgsWkbTypes::flatType( geom->wkbType() ) == QgsWkbTypes::LineString )
         return static_cast<const QgsLineString *>( geom );

--- a/src/core/geometry/qgsmulticurve.h
+++ b/src/core/geometry/qgsmulticurve.h
@@ -103,7 +103,7 @@ class CORE_EXPORT QgsMultiCurve: public QgsGeometryCollection
      * \note Not available in Python. Objects will be automatically be converted to the appropriate target type.
      * \since QGIS 3.0
      */
-    inline const QgsMultiCurve *cast( const QgsAbstractGeometry *geom ) const
+    inline static const QgsMultiCurve *cast( const QgsAbstractGeometry *geom )
     {
       if ( !geom )
         return nullptr;

--- a/src/core/geometry/qgsmultilinestring.h
+++ b/src/core/geometry/qgsmultilinestring.h
@@ -106,7 +106,7 @@ class CORE_EXPORT QgsMultiLineString: public QgsMultiCurve
      * \note Not available in Python. Objects will be automatically be converted to the appropriate target type.
      * \since QGIS 3.0
      */
-    inline const QgsMultiLineString *cast( const QgsAbstractGeometry *geom ) const
+    inline static const QgsMultiLineString *cast( const QgsAbstractGeometry *geom )
     {
       if ( geom && QgsWkbTypes::flatType( geom->wkbType() ) == QgsWkbTypes::MultiLineString )
         return static_cast<const QgsMultiLineString *>( geom );

--- a/src/core/geometry/qgsmultipoint.h
+++ b/src/core/geometry/qgsmultipoint.h
@@ -104,7 +104,7 @@ class CORE_EXPORT QgsMultiPoint: public QgsGeometryCollection
      * \note Not available in Python. Objects will be automatically be converted to the appropriate target type.
      * \since QGIS 3.0
      */
-    inline const QgsMultiPoint *cast( const QgsAbstractGeometry *geom ) const
+    inline static const QgsMultiPoint *cast( const QgsAbstractGeometry *geom )
     {
       if ( geom && QgsWkbTypes::flatType( geom->wkbType() ) == QgsWkbTypes::MultiPoint )
         return static_cast<const QgsMultiPoint *>( geom );

--- a/src/core/geometry/qgsmultipolygon.h
+++ b/src/core/geometry/qgsmultipolygon.h
@@ -107,7 +107,7 @@ class CORE_EXPORT QgsMultiPolygon: public QgsMultiSurface
      * \note Not available in Python. Objects will be automatically be converted to the appropriate target type.
      * \since QGIS 3.0
      */
-    inline const QgsMultiPolygon *cast( const QgsAbstractGeometry *geom ) const
+    inline static const QgsMultiPolygon *cast( const QgsAbstractGeometry *geom )
     {
       if ( geom && QgsWkbTypes::flatType( geom->wkbType() ) == QgsWkbTypes::MultiPolygon )
         return static_cast<const QgsMultiPolygon *>( geom );

--- a/src/core/geometry/qgsmultisurface.h
+++ b/src/core/geometry/qgsmultisurface.h
@@ -102,7 +102,7 @@ class CORE_EXPORT QgsMultiSurface: public QgsGeometryCollection
      * \note Not available in Python. Objects will be automatically be converted to the appropriate target type.
      * \since QGIS 3.0
      */
-    inline const QgsMultiSurface *cast( const QgsAbstractGeometry *geom ) const
+    inline static const QgsMultiSurface *cast( const QgsAbstractGeometry *geom )
     {
       if ( !geom )
         return nullptr;

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -549,7 +549,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
      * \note Not available in Python. Objects will be automatically be converted to the appropriate target type.
      * \since QGIS 3.0
      */
-    inline const QgsPoint *cast( const QgsAbstractGeometry *geom ) const
+    inline static const QgsPoint *cast( const QgsAbstractGeometry *geom )
     {
       if ( geom && QgsWkbTypes::flatType( geom->wkbType() ) == QgsWkbTypes::Point )
         return static_cast<const QgsPoint *>( geom );

--- a/src/core/geometry/qgspolygon.h
+++ b/src/core/geometry/qgspolygon.h
@@ -86,7 +86,7 @@ class CORE_EXPORT QgsPolygon: public QgsCurvePolygon
      * \note Not available in Python. Objects will be automatically be converted to the appropriate target type.
      * \since QGIS 3.0
      */
-    inline const QgsPolygon *cast( const QgsAbstractGeometry *geom ) const
+    inline static const QgsPolygon *cast( const QgsAbstractGeometry *geom )
     {
       if ( !geom )
         return nullptr;

--- a/src/core/geometry/qgssurface.h
+++ b/src/core/geometry/qgssurface.h
@@ -60,7 +60,7 @@ class CORE_EXPORT QgsSurface: public QgsAbstractGeometry
      * \note Not available in Python. Objects will be automatically be converted to the appropriate target type.
      * \since QGIS 3.0
      */
-    inline const QgsSurface *cast( const QgsAbstractGeometry *geom ) const
+    inline static const QgsSurface *cast( const QgsAbstractGeometry *geom )
     {
       if ( !geom )
         return nullptr;

--- a/src/core/geometry/qgstriangle.h
+++ b/src/core/geometry/qgstriangle.h
@@ -445,7 +445,7 @@ class CORE_EXPORT QgsTriangle : public QgsPolygon
      * \note Not available in Python. Objects will be automatically be converted to the appropriate target type.
      * \since QGIS 3.0
      */
-    inline const QgsTriangle *cast( const QgsAbstractGeometry *geom ) const
+    inline static const QgsTriangle *cast( const QgsAbstractGeometry *geom )
     {
       if ( geom && QgsWkbTypes::flatType( geom->wkbType() ) == QgsWkbTypes::Triangle )
         return static_cast<const QgsTriangle *>( geom );


### PR DESCRIPTION
The previous implementation relied on dereferencing a null pointer.
This is undefined behaviour, and cppcheck rightly complains about that.
Furthermore the cast() method in QgsAbstractGeometry implementation classes
is fundamentally a static method. Change it as such.
