### PR TITLE
[3d] Fixes for point cloud 3D renderer

### DIFF
--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -271,6 +271,14 @@ void QgsChunkedEntity::update( QgsChunkNode *node, const SceneState &state )
   {
     // error is not acceptable and children are ready to be used - recursive descent
 
+    if ( mAdditiveStrategy )
+    {
+      // With additive strategy enabled, also all parent nodes are added to active nodes.
+      // This is desired when child nodes add more detailed data rather than just replace
+      // coarser data in parents. We use this e.g. with point cloud data.
+      mActiveNodes << node;
+    }
+
     QgsChunkNode *const *children = node->children();
     for ( int i = 0; i < node->childCount(); ++i )
       update( children[i], state );

--- a/src/3d/chunks/qgschunkedentity_p.h
+++ b/src/3d/chunks/qgschunkedentity_p.h
@@ -100,6 +100,16 @@ class QgsChunkedEntity : public Qt3DCore::QEntity
     //! Returns whether object picking is currently enabled
     bool hasPickingEnabled() const { return mPickingEnabled; }
 
+    //! Sets whether additive strategy is enabled - see usingAditiveStrategy()
+    void setUsingAdditiveStrategy( bool additive ) { mAdditiveStrategy = additive; }
+
+    /**
+     * Returns whether additive strategy is enabled.
+     * With additive strategy enabled, also all parent nodes are added to active nodes.
+     * This is desired when child nodes add more detailed data rather than just replace coarser data in parents.
+     */
+    bool usingAditiveStrategy() const { return mAdditiveStrategy; }
+
   protected:
     //! Cancels the background job that is currently in progress
     void cancelActiveJob( QgsChunkQueueJob *job );
@@ -173,6 +183,12 @@ class QgsChunkedEntity : public Qt3DCore::QEntity
 
     //! If picking is enabled, QObjectPicker objects will be assigned to chunks and pickedObject() signals fired on mouse click
     bool mPickingEnabled = false;
+
+    /**
+     * With additive strategy enabled, also all parent nodes are added to active nodes.
+     * This is desired when child nodes add more detailed data rather than just replace coarser data in parents.
+     */
+    bool mAdditiveStrategy = false;
 
     bool mIsValid = true;
 };

--- a/src/3d/chunks/qgschunknode_p.h
+++ b/src/3d/chunks/qgschunknode_p.h
@@ -67,6 +67,16 @@ struct QgsChunkNodeId
     else
       return QStringLiteral( "%1/%2/%3/%4" ).arg( d ).arg( x ).arg( y ).arg( z );   // octree
   }
+
+  bool operator==( const QgsChunkNodeId &other ) const
+  {
+    return d == other.d && x == other.x && y == other.y && z == other.z;
+  }
+
+  bool operator!=( const QgsChunkNodeId &other ) const
+  {
+    return !(*this == other );
+  }
 };
 
 /**

--- a/src/3d/chunks/qgschunknode_p.h
+++ b/src/3d/chunks/qgschunknode_p.h
@@ -75,7 +75,7 @@ struct QgsChunkNodeId
 
   bool operator!=( const QgsChunkNodeId &other ) const
   {
-    return !(*this == other );
+    return !( *this == other );
   }
 };
 

--- a/src/3d/qgsaabb.cpp
+++ b/src/3d/qgsaabb.cpp
@@ -92,3 +92,8 @@ QList<QVector3D> QgsAABB::verticesForLines() const
   }
   return vertices;
 }
+
+QString QgsAABB::toString() const
+{
+  return QString( "X %1 - %2  Y %3 - %4  Z %5 - %6" ).arg( xMin ).arg( xMax ).arg( yMin ).arg( yMax ).arg( zMin ).arg( zMax );
+}

--- a/src/3d/qgsaabb.cpp
+++ b/src/3d/qgsaabb.cpp
@@ -95,5 +95,5 @@ QList<QVector3D> QgsAABB::verticesForLines() const
 
 QString QgsAABB::toString() const
 {
-  return QString( "X %1 - %2  Y %3 - %4  Z %5 - %6" ).arg( xMin ).arg( xMax ).arg( yMin ).arg( yMax ).arg( zMin ).arg( zMax );
+  return QStringLiteral( "X %1 - %2  Y %3 - %4  Z %5 - %6" ).arg( xMin ).arg( xMax ).arg( yMin ).arg( yMax ).arg( zMin ).arg( zMax );
 }

--- a/src/3d/qgsaabb.h
+++ b/src/3d/qgsaabb.h
@@ -75,6 +75,9 @@ class _3D_EXPORT QgsAABB
     //! Returns a list of pairs of vertices (useful for display of bounding boxes)
     QList<QVector3D> verticesForLines() const;
 
+    //! Return text representation of the bounding box
+    QString toString() const;
+
     float xMin = 0.0f;
     float yMin = 0.0f;
     float zMin = 0.0f;

--- a/src/3d/qgsaabb.h
+++ b/src/3d/qgsaabb.h
@@ -75,7 +75,7 @@ class _3D_EXPORT QgsAABB
     //! Returns a list of pairs of vertices (useful for display of bounding boxes)
     QList<QVector3D> verticesForLines() const;
 
-    //! Return text representation of the bounding box
+    //! Returns text representation of the bounding box
     QString toString() const;
 
     float xMin = 0.0f;

--- a/src/3d/qgspointcloudlayerchunkloader_p.cpp
+++ b/src/3d/qgspointcloudlayerchunkloader_p.cpp
@@ -303,8 +303,9 @@ QVector<QgsChunkNode *> QgsPointCloudLayerChunkLoaderFactory::createChildren( Qg
     // while in our 3D scene the X,Z axes define the horizontal plane
     float chXMin = dx ? xc : bbox.xMin;
     float chXMax = dx ? bbox.xMax : xc;
-    float chZMin = dy ? zc : bbox.zMin;
-    float chZMax = dy ? bbox.zMax : zc;
+    // Z axis: values are increasing to the south
+    float chZMin = !dy ? zc : bbox.zMin;
+    float chZMax = !dy ? bbox.zMax : zc;
     float chYMin = dz ? yc : bbox.yMin;
     float chYMax = dz ? bbox.yMax : yc;
     children << new QgsChunkNode( childId, QgsAABB( chXMin, chYMin, chZMin, chXMax, chYMax, chZMax ), childError, node );

--- a/src/3d/qgspointcloudlayerchunkloader_p.cpp
+++ b/src/3d/qgspointcloudlayerchunkloader_p.cpp
@@ -333,6 +333,7 @@ QgsPointCloudLayerChunkedEntity::QgsPointCloudLayerChunkedEntity( QgsPointCloudI
   : QgsChunkedEntity( 5, // max. allowed screen error (in pixels)  -- // TODO
                       new QgsPointCloudLayerChunkLoaderFactory( map, pc ), true )
 {
+  setUsingAdditiveStrategy( true );
   setShowBoundingBoxes( true );
 }
 


### PR DESCRIPTION
This makes 3D renderer to behave correctly:
1. add data of child nodes to the existing parent nodes's data rather than replacing it
2. fix bounding box calculation that was causing incorrect culling of nodes

![qgis-3d-point-cloud-trencin](https://user-images.githubusercontent.com/193367/97224980-400b8580-17d2-11eb-952e-c972dd83b600.gif)
