### PR TITLE
fix map setting temporal be active when updating time controller

### DIFF
--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -199,7 +199,7 @@ void QgsTemporalNavigationObject::setFrameDuration( QgsInterval frameDuration )
   // forcing an update of our views
   QgsDateTimeRange range = dateTimeRangeForFrameNumber( mCurrentFrameNumber );
 
-  if ( !mBlockUpdateTemporalRangeSignal )
+  if ( !mBlockUpdateTemporalRangeSignal && mNavigationMode != NavigationOff )
     emit updateTemporalRange( range );
 }
 


### PR DESCRIPTION
When a mesh layer is loaded and it is the first layer, temporal controller is updated accordingly  with the mesh temporal data even temporal navigation is off. This update sends signal that finally sets the temporal map settings as active while the temporal navigation is off.
This PR avoids this behavior.