### PR TITLE
Point cloud layer style/metadata handling fixes

### DIFF
--- a/python/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
@@ -83,8 +83,6 @@ QgsPointCloudLayer cannot be copied.
 
     virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext );
 
-    virtual QString loadDefaultStyle( bool &resultFlag /Out/ );
-
     virtual void setDataSource( const QString &dataSource, const QString &baseName, const QString &provider, const QgsDataProvider::ProviderOptions &options, bool loadDefaultStyleFlag = false );
 
     virtual QString htmlMetadata() const;

--- a/src/app/pointcloud/qgspointcloudlayerproperties.cpp
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.cpp
@@ -87,6 +87,10 @@ QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *
   QMenu *menuMetadata = new QMenu( this );
   mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), this, &QgsPointCloudLayerProperties::loadMetadata );
   mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), this, &QgsPointCloudLayerProperties::saveMetadataAs );
+  menuMetadata->addSeparator();
+  menuMetadata->addAction( tr( "Save as Default" ), this, &QgsPointCloudLayerProperties::saveDefaultMetadata );
+  menuMetadata->addAction( tr( "Restore Default" ), this, &QgsPointCloudLayerProperties::loadDefaultMetadata );
+
   mBtnMetadata->setMenu( menuMetadata );
   buttonBox->addButton( mBtnMetadata, QDialogButtonBox::ResetRole );
 
@@ -301,6 +305,33 @@ void QgsPointCloudLayerProperties::saveMetadataAs()
     myQSettings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( myOutputFileName ).absolutePath() );
   else
     QMessageBox::information( this, tr( "Save Metadata" ), message );
+}
+
+void QgsPointCloudLayerProperties::saveDefaultMetadata()
+{
+  mMetadataWidget->acceptMetadata();
+
+  bool defaultSavedFlag = false;
+  QString errorMsg = mLayer->saveDefaultMetadata( defaultSavedFlag );
+  if ( !defaultSavedFlag )
+  {
+    QMessageBox::warning( this, tr( "Default Metadata" ), errorMsg );
+  }
+}
+
+void QgsPointCloudLayerProperties::loadDefaultMetadata()
+{
+  bool defaultLoadedFlag = false;
+  QString myMessage = mLayer->loadNamedMetadata( mLayer->metadataUri(), defaultLoadedFlag );
+  //reset if the default metadata was loaded OK only
+  if ( defaultLoadedFlag )
+  {
+    mMetadataWidget->setMetadata( &mLayer->metadata() );
+  }
+  else
+  {
+    QMessageBox::information( this, tr( "Default Metadata" ), myMessage );
+  }
 }
 
 void QgsPointCloudLayerProperties::showHelp()

--- a/src/app/pointcloud/qgspointcloudlayerproperties.cpp
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.cpp
@@ -102,6 +102,12 @@ QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *
 void QgsPointCloudLayerProperties::apply()
 {
   mMetadataWidget->acceptMetadata();
+
+  // TODO -- move to proper widget classes!
+  mLayer->setCustomProperty( QStringLiteral( "pcMin" ), mMinZSpin->value() );
+  mLayer->setCustomProperty( QStringLiteral( "pcMax" ), mMaxZSpin->value() );
+  mLayer->setCustomProperty( QStringLiteral( "pcRamp" ), mBtnColorRamp->colorRampName().isEmpty() ? QStringLiteral( "Viridis" ) : mBtnColorRamp->colorRampName() );
+  mLayer->triggerRepaint();
 }
 
 void QgsPointCloudLayerProperties::onCancel()
@@ -131,6 +137,11 @@ void QgsPointCloudLayerProperties::syncToLayer()
   mInformationTextBrowser->setOpenLinks( false );
   connect( mInformationTextBrowser, &QTextBrowser::anchorClicked, this, &QgsPointCloudLayerProperties::urlClicked );
 
+  // TODO -- move to proper widget classes!
+  mMinZSpin->setValue( mLayer->customProperty( QStringLiteral( "pcMin" ), 400 ).toInt() );
+  mMaxZSpin->setValue( mLayer->customProperty( QStringLiteral( "pcMax" ), 600 ).toInt() );
+  mBtnColorRamp->setColorRampFromName( mLayer->customProperty( QStringLiteral( "pcRamp" ), QStringLiteral( "Viridis" ) ).toString() );
+  mBtnColorRamp->setColorRampName( mLayer->customProperty( QStringLiteral( "pcRamp" ), QStringLiteral( "Viridis" ) ).toString() );
 }
 
 

--- a/src/app/pointcloud/qgspointcloudlayerproperties.h
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.h
@@ -46,6 +46,8 @@ class QgsPointCloudLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     void aboutToShowStyleMenu();
     void loadMetadata();
     void saveMetadataAs();
+    void saveDefaultMetadata();
+    void loadDefaultMetadata();
     void showHelp();
     void urlClicked( const QUrl &url );
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5786,12 +5786,8 @@ QgsPointCloudLayer *QgisApp::addPointCloudLayerPrivate( const QString &uri, cons
     return nullptr;
   }
   bool ok = false;
-  QString error = layer->loadDefaultStyle( ok );
-  if ( !ok )
-    visibleMessageBar()->pushMessage( tr( "Error loading style" ), error, Qgis::Warning, messageTimeout() );
-  error = layer->loadDefaultMetadata( ok );
-  if ( !ok )
-    visibleMessageBar()->pushMessage( tr( "Error loading layer metadata" ), error, Qgis::Warning, messageTimeout() );
+  layer->loadDefaultStyle( ok );
+  layer->loadDefaultMetadata( ok );
 
   QgsProject::instance()->addMapLayer( layer.get() );
   activateDeactivateLayerRelatedActions( activeLayer() );

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -148,8 +148,6 @@ void QgsPointCloudLayer::setTransformContext( const QgsCoordinateTransformContex
 
 void QgsPointCloudLayer::setDataSource( const QString &dataSource, const QString &baseName, const QString &provider, const QgsDataProvider::ProviderOptions &options, bool loadDefaultStyleFlag )
 {
-  Q_UNUSED( loadDefaultStyleFlag )
-
   if ( mDataProvider )
     disconnect( mDataProvider.get(), &QgsPointCloudDataProvider::dataChanged, this, &QgsPointCloudLayer::dataChanged );
 
@@ -184,6 +182,12 @@ void QgsPointCloudLayer::setDataSource( const QString &dataSource, const QString
   }
 
   setCrs( mDataProvider->crs() );
+
+  if ( loadDefaultStyleFlag )
+  {
+    bool defaultLoadedFlag = false;
+    loadDefaultStyle( defaultLoadedFlag );
+  }
 
   connect( mDataProvider.get(), &QgsPointCloudDataProvider::dataChanged, this, &QgsPointCloudLayer::dataChanged );
 

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -120,11 +120,23 @@ bool QgsPointCloudLayer::writeXml( QDomNode &layerNode, QDomDocument &doc, const
 
 bool QgsPointCloudLayer::readSymbology( const QDomNode &node, QString &errorMessage, QgsReadWriteContext &context, QgsMapLayer::StyleCategories categories )
 {
-  Q_UNUSED( errorMessage )
-
   QDomElement elem = node.toElement();
 
   readCommonStyle( elem, context, categories );
+
+  // hack for now !!
+  if ( categories.testFlag( Symbology ) )
+  {
+    const QDomElement elemRenderer = elem.firstChildElement( QStringLiteral( "renderer" ) );
+    if ( elemRenderer.isNull() )
+    {
+      errorMessage = tr( "Missing <renderer> tag" );
+      //  return false;
+    }
+    setCustomProperty( QStringLiteral( "pcMin" ), elemRenderer.attribute( QStringLiteral( "pcMin" ), QStringLiteral( "400" ) ).toInt() );
+    setCustomProperty( QStringLiteral( "pcMax" ), elemRenderer.attribute( QStringLiteral( "pcMax" ), QStringLiteral( "600" ) ).toInt() );
+    setCustomProperty( QStringLiteral( "pcRamp" ), elemRenderer.attribute( QStringLiteral( "pcRamp" ), QStringLiteral( "Viridis" ) ) );
+  }
 
   return true;
 }
@@ -133,10 +145,20 @@ bool QgsPointCloudLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QStr
     const QgsReadWriteContext &context, QgsMapLayer::StyleCategories categories ) const
 {
   Q_UNUSED( errorMessage )
-  Q_UNUSED( context )
-  Q_UNUSED( categories )
-  Q_UNUSED( node )
-  Q_UNUSED( doc )
+
+  QDomElement elem = node.toElement();
+  writeCommonStyle( elem, doc, context, categories );
+
+  // hack for now !!
+  if ( categories.testFlag( Symbology ) )
+  {
+    QDomElement elemRenderer = doc.createElement( QStringLiteral( "renderer" ) );
+    elemRenderer.setAttribute( QStringLiteral( "pcMin" ), customProperty( QStringLiteral( "pcMin" ), 400 ).toInt() );
+    elemRenderer.setAttribute( QStringLiteral( "pcMax" ), customProperty( QStringLiteral( "pcMax" ), 600 ).toInt() );
+    elemRenderer.setAttribute( QStringLiteral( "pcRamp" ), customProperty( QStringLiteral( "pcRamp" ),  QStringLiteral( "Viridis" ) ).toString() );
+    elem.appendChild( elemRenderer );
+  }
+
   return false;
 }
 

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -159,7 +159,7 @@ bool QgsPointCloudLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QStr
     elem.appendChild( elemRenderer );
   }
 
-  return false;
+  return true;
 }
 
 void QgsPointCloudLayer::setTransformContext( const QgsCoordinateTransformContext &transformContext )

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -146,12 +146,6 @@ void QgsPointCloudLayer::setTransformContext( const QgsCoordinateTransformContex
     mDataProvider->setTransformContext( transformContext );
 }
 
-QString QgsPointCloudLayer::loadDefaultStyle( bool &resultFlag )
-{
-  Q_UNUSED( resultFlag )
-  return QString();
-}
-
 void QgsPointCloudLayer::setDataSource( const QString &dataSource, const QString &baseName, const QString &provider, const QgsDataProvider::ProviderOptions &options, bool loadDefaultStyleFlag )
 {
   Q_UNUSED( loadDefaultStyleFlag )

--- a/src/core/pointcloud/qgspointcloudlayer.h
+++ b/src/core/pointcloud/qgspointcloudlayer.h
@@ -110,7 +110,6 @@ class CORE_EXPORT QgsPointCloudLayer : public QgsMapLayer
                          StyleCategories categories = AllStyleCategories ) const override;
 
     void setTransformContext( const QgsCoordinateTransformContext &transformContext ) override;
-    QString loadDefaultStyle( bool &resultFlag SIP_OUT ) override;
     void setDataSource( const QString &dataSource, const QString &baseName, const QString &provider, const QgsDataProvider::ProviderOptions &options, bool loadDefaultStyleFlag = false ) override;
     QString htmlMetadata() const override;
 

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -56,6 +56,7 @@ QgsMapToolCapture::QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizin
 
   QgsVectorLayer::LayerOptions layerOptions;
   layerOptions.skipCrsValidation = true;
+  layerOptions.loadDefaultStyle = false;
   mExtraSnapLayer = new QgsVectorLayer( QStringLiteral( "LineString?crs=" ), QStringLiteral( "extra snap" ), QStringLiteral( "memory" ), layerOptions );
   mExtraSnapLayer->startEditing();
   QgsFeature f;

--- a/src/ui/qgspointcloudlayerpropertiesbase.ui
+++ b/src/ui/qgspointcloudlayerpropertiesbase.ui
@@ -112,6 +112,18 @@
          </item>
          <item>
           <property name="text">
+           <string>Symbology</string>
+          </property>
+          <property name="toolTip">
+           <string>Symbology</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/propertyicons/symbology.svg</normaloff>:/images/themes/default/propertyicons/symbology.svg</iconset>
+          </property>
+         </item>
+         <item>
+          <property name="text">
            <string>Metadata</string>
           </property>
           <property name="toolTip">
@@ -164,7 +176,7 @@
           <enum>QFrame::Plain</enum>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>1</number>
          </property>
          <widget class="QWidget" name="mOptsPage_Information">
           <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -182,6 +194,99 @@
            </property>
            <item>
             <widget class="QTextBrowser" name="mInformationTextBrowser"/>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="page">
+          <layout class="QGridLayout" name="gridLayout_2">
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_3">
+             <property name="text">
+              <string>Ramp</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Min z</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_2">
+             <property name="text">
+              <string>Max z</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QgsColorRampButton" name="mBtnColorRamp">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>120</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="1" column="2">
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="0" column="1">
+            <widget class="QgsSpinBox" name="mMinZSpin">
+             <property name="minimum">
+              <number>-999999999</number>
+             </property>
+             <property name="maximum">
+              <number>999999999</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QgsSpinBox" name="mMaxZSpin">
+             <property name="minimum">
+              <number>-999999999</number>
+             </property>
+             <property name="maximum">
+              <number>999999999</number>
+             </property>
+            </widget>
            </item>
           </layout>
          </widget>
@@ -264,6 +369,17 @@
    <class>QgsFilterLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qgsfilterlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorRampButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorrampbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/symbollayer/widget_gradientfill.ui
+++ b/src/ui/symbollayer/widget_gradientfill.ui
@@ -565,6 +565,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
@@ -574,11 +579,6 @@
    <class>QgsPropertyOverrideButton</class>
    <extends>QToolButton</extends>
    <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>


### PR DESCRIPTION
Hooks up more of the standard layer API for layer style handling.

Also includes a super basic, temporary hacky symbology page in the point cloud layer properties dialog.