### PR TITLE
[processing] correctly escape parentheses in GDAL command (fix #39525)

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -217,11 +217,12 @@ class GdalUtils:
 
     @staticmethod
     def escapeAndJoin(strList):
+        escChars = [' ', '&', '(', ')']
         joined = ''
         for s in strList:
             if not isinstance(s, str):
                 s = str(s)
-            if s and s[0] != '-' and (' ' in s or '&' in s):
+            if s and s[0] != '-' and any(c in s for c in escChars):
                 escaped = '"' + s.replace('\\', '\\\\').replace('"', '\\"') \
                           + '"'
             else:

--- a/python/plugins/processing/tests/GdalAlgorithmsGeneralTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsGeneralTest.py
@@ -349,7 +349,7 @@ class TestGdalAlgorithms(unittest.TestCase):
                              '+proj=utm +zone=36 +south      +a=600000 +b=70000       +towgs84=-143,-90,-294,0,0,0,0 +units=m +no_defs')
 
     def testEscapeAndJoin(self):
-        self.assertEqual(GdalUtils.escapeAndJoin([1, "a", "a b", "a&b"]), '1 a "a b" "a&b"')
+        self.assertEqual(GdalUtils.escapeAndJoin([1, "a", "a b", "a&b", "a(b)"]), '1 a "a b" "a&b" "a(b)"')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

Correctly handle case when file path (either input or output) contains parentheses in the generated GDAL command.

Fixes #39525.