### PR TITLE
Handle 'inbuilt:' vector uri

### DIFF
--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2100,7 +2100,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Open a vector tile layer - this is the generic function which takes all parameters
     QgsVectorTileLayer *addVectorTileLayerPrivate( const QString &uri, const QString &baseName, bool guiWarning = true );
 
-    //! Open a point cloyd layer - this is the generic function which takes all parameters
+    //! Open a point cloud layer - this is the generic function which takes all parameters
     QgsPointCloudLayer *addPointCloudLayerPrivate( const QString &uri,
         const QString &baseName,
         const QString &providerKey,


### PR DESCRIPTION
This is take 2 to make it possible to use the inbuilt-vector data (world map etc) to be used in PyQGIS etc:
```
iface.addVectorLayer('inbuilt:/data/world_map.gpkg|layername=countries', 'Countries', 'ogr')
```
First take was: #39175 There @nyalldawson proposed to do it not ogr-specific but on a higher level. This is my first attempt to do it as he described there: https://github.com/qgis/QGIS/pull/39175#pullrequestreview-501689631

Not sure if that was what he meant. I think more code has to get rewritten here (as for example now a inbuilt-uri WITHOUT layername-part will not load AND not popup the 'choose layer dialog', because the vectorLayerPath is const... 
Should I create a copy of it and use that in the whole function?
Or am I totally wrong anyway.

One argument why I like #39175 actually better is that (untill now) inbuild is only used with OGR provider (and it is/was a oneline change). But feel free to disagree/comment or stop me from trying :-)

Also note that my proposed plan B in #39175 
```
iface.addVectorLayer(QgsApplication.pkgDataPath() + '/resources/data/world_map.gpkg|layername=Countries', '', 'ogr')
```
actually does not work on Linux distro installs, because the gpkg in the resource is not readable by the average user apparently.
