### PR TITLE
few fixes in custom processing parameters

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingparameteraggregate.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameteraggregate.sip.in
@@ -67,39 +67,6 @@ Sets the ``name`` of the parent layer parameter. Use an empty string if this is 
 };
 
 
-
-class QgsProcessingParameterTypeAggregate : QgsProcessingParameterType
-{
-%Docstring
-Parameter type definition for QgsProcessingParameterAggregate.
-
-.. note::
-
-   This class is not a part of public API.
-
-.. versionadded:: 3.14
-%End
-
-%TypeHeaderCode
-#include "qgsprocessingparameteraggregate.h"
-%End
-  public:
-    virtual QgsProcessingParameterDefinition *create( const QString &name ) const /Factory/;
-
-    virtual QString description() const;
-
-    virtual QString name() const;
-
-    virtual QString id() const;
-
-    virtual QString pythonImportString() const;
-
-    virtual QString className() const;
-
-    virtual QStringList acceptedPythonTypes() const;
-};
-
-
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/core/auto_generated/processing/qgsprocessingparameterfieldmap.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameterfieldmap.sip.in
@@ -67,38 +67,6 @@ Sets the ``name`` of the parent layer parameter. Use an empty string if this is 
 };
 
 
-class QgsProcessingParameterTypeFieldMapping : QgsProcessingParameterType
-{
-%Docstring
-Parameter type definition for QgsProcessingParameterFieldMapping.
-
-.. note::
-
-   This class is not a part of public API.
-
-.. versionadded:: 3.14
-%End
-
-%TypeHeaderCode
-#include "qgsprocessingparameterfieldmap.h"
-%End
-  public:
-    virtual QgsProcessingParameterDefinition *create( const QString &name ) const /Factory/;
-
-    virtual QString description() const;
-
-    virtual QString name() const;
-
-    virtual QString id() const;
-
-    virtual QString pythonImportString() const;
-
-    virtual QString className() const;
-
-    virtual QStringList acceptedPythonTypes() const;
-};
-
-
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -224,6 +224,12 @@ their acceptable ranges, defaults, etc.
 %TypeHeaderCode
 #include "qgsprocessingparameters.h"
 %End
+%TypeHeaderCode
+#include "qgsprocessingparameteraggregate.h"
+#include "qgsprocessingparameterfieldmap.h"
+#include "qgsprocessingparametertininputlayers.h"
+#include "qgsprocessingparametervectortilewriterlayers.h"
+%End
 %ConvertToSubClassCode
     if ( sipCpp->type() == QgsProcessingParameterBoolean::typeName() )
       sipType = sipType_QgsProcessingParameterBoolean;

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -303,6 +303,8 @@ their acceptable ranges, defaults, etc.
       sipType = sipType_QgsProcessingParameterFieldMapping;
     else if ( sipCpp->type() == QgsProcessingParameterTinInputLayers::typeName() )
       sipType = sipType_QgsProcessingParameterTinInputLayers;
+    else if ( sipCpp->type() == QgsProcessingParameterVectorTileWriterLayers::typeName() )
+      sipType = sipType_QgsProcessingParameterVectorTileWriterLayers;
     else
       sipType = nullptr;
 %End

--- a/python/core/auto_generated/processing/qgsprocessingparametertininputlayers.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparametertininputlayers.sip.in
@@ -64,10 +64,15 @@ Returns the type name for the parameter class.
 %End
 };
 
+
 class QgsProcessingParameterTypeTinInputLayers : QgsProcessingParameterType
 {
 %Docstring
 Parameter type definition for QgsProcessingParameterTinInputLayers.
+
+.. note::
+
+   This class is not a part of public API.
 
 .. versionadded:: 3.16
 %End
@@ -90,6 +95,7 @@ Parameter type definition for QgsProcessingParameterTinInputLayers.
 
     virtual QStringList acceptedPythonTypes() const;
 };
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/auto_generated/processing/qgsprocessingparametertininputlayers.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparametertininputlayers.sip.in
@@ -65,38 +65,6 @@ Returns the type name for the parameter class.
 };
 
 
-class QgsProcessingParameterTypeTinInputLayers : QgsProcessingParameterType
-{
-%Docstring
-Parameter type definition for QgsProcessingParameterTinInputLayers.
-
-.. note::
-
-   This class is not a part of public API.
-
-.. versionadded:: 3.16
-%End
-
-%TypeHeaderCode
-#include "qgsprocessingparametertininputlayers.h"
-%End
-  public:
-    virtual QgsProcessingParameterDefinition *create( const QString &name ) const /Factory/;
-
-    virtual QString description() const;
-
-    virtual QString name() const;
-
-    virtual QString id() const;
-
-    virtual QString pythonImportString() const;
-
-    virtual QString className() const;
-
-    virtual QStringList acceptedPythonTypes() const;
-};
-
-
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/core/auto_generated/processing/qgsprocessingparametervectortilewriterlayers.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparametervectortilewriterlayers.sip.in
@@ -72,38 +72,6 @@ Converts a single input layer to QVariant representation (a QVariantMap)
 };
 
 
-class QgsProcessingParameterTypeVectorTileWriterLayers : QgsProcessingParameterType
-{
-%Docstring
-Parameter type definition for QgsProcessingParameterVectorTileWriterLayers.
-
-.. note::
-
-   This class is not a part of public API.
-
-.. versionadded:: 3.14
-%End
-
-%TypeHeaderCode
-#include "qgsprocessingparametervectortilewriterlayers.h"
-%End
-  public:
-    virtual QgsProcessingParameterDefinition *create( const QString &name ) const /Factory/;
-
-    virtual QString description() const;
-
-    virtual QString name() const;
-
-    virtual QString id() const;
-
-    virtual QString pythonImportString() const;
-
-    virtual QString className() const;
-
-    virtual QStringList acceptedPythonTypes() const;
-};
-
-
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/core/auto_generated/processing/qgsprocessingparametervectortilewriterlayers.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparametervectortilewriterlayers.sip.in
@@ -28,10 +28,6 @@ A valid value for this parameter is a list (QVariantList), where each item is a 
 Static functions :py:func:`~parametersAsLayers`, :py:func:`~variantMapAsLayer`, :py:func:`~layerAsVariantMap` provide conversion between
 QgsVectorTileWriter.Layer representation and QVariant representation.
 
-.. note::
-
-   This class is not a part of public API.
-
 .. versionadded:: 3.14
 %End
 

--- a/src/core/processing/qgsprocessingparameteraggregate.h
+++ b/src/core/processing/qgsprocessingparameteraggregate.h
@@ -63,7 +63,7 @@ class CORE_EXPORT QgsProcessingParameterAggregate : public QgsProcessingParamete
 
 };
 
-
+#ifndef SIP_RUN
 ///@cond PRIVATE
 
 /**
@@ -113,5 +113,6 @@ class CORE_EXPORT QgsProcessingParameterTypeAggregate : public QgsProcessingPara
 };
 
 ///@endcond
+#endif
 
 #endif // QGSPROCESSINGPARAMETERAGGREGATE_H

--- a/src/core/processing/qgsprocessingparameterfieldmap.h
+++ b/src/core/processing/qgsprocessingparameterfieldmap.h
@@ -63,6 +63,7 @@ class CORE_EXPORT QgsProcessingParameterFieldMapping : public QgsProcessingParam
 
 };
 
+#ifndef SIP_RUN
 ///@cond PRIVATE
 
 /**
@@ -112,5 +113,6 @@ class CORE_EXPORT QgsProcessingParameterTypeFieldMapping : public QgsProcessingP
 };
 
 ///@endcond
+#endif
 
 #endif // QGSPROCESSINGPARAMETERFIELDMAP_H

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -331,6 +331,12 @@ class CORE_EXPORT QgsProcessingParameterDefinition
 {
 
 #ifdef SIP_RUN
+    % TypeHeaderCode
+#include "qgsprocessingparameteraggregate.h"
+#include "qgsprocessingparameterfieldmap.h"
+#include "qgsprocessingparametertininputlayers.h"
+#include "qgsprocessingparametervectortilewriterlayers.h"
+    % End
     SIP_CONVERT_TO_SUBCLASS_CODE
     if ( sipCpp->type() == QgsProcessingParameterBoolean::typeName() )
       sipType = sipType_QgsProcessingParameterBoolean;

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -410,6 +410,8 @@ class CORE_EXPORT QgsProcessingParameterDefinition
       sipType = sipType_QgsProcessingParameterFieldMapping;
     else if ( sipCpp->type() == QgsProcessingParameterTinInputLayers::typeName() )
       sipType = sipType_QgsProcessingParameterTinInputLayers;
+    else if ( sipCpp->type() == QgsProcessingParameterVectorTileWriterLayers::typeName() )
+      sipType = sipType_QgsProcessingParameterVectorTileWriterLayers;
     else
       sipType = nullptr;
     SIP_END

--- a/src/core/processing/qgsprocessingparametertininputlayers.h
+++ b/src/core/processing/qgsprocessingparametertininputlayers.h
@@ -65,10 +65,13 @@ class CORE_EXPORT QgsProcessingParameterTinInputLayers: public QgsProcessingPara
     static QString typeName() { return QStringLiteral( "tininputlayers" ); }
 };
 
+///@cond PRIVATE
+
 /**
  * Parameter type definition for QgsProcessingParameterTinInputLayers.
  *
  * \ingroup core
+ * \note This class is not a part of public API.
  * \since QGIS 3.16
  */
 class CORE_EXPORT QgsProcessingParameterTypeTinInputLayers : public QgsProcessingParameterType
@@ -109,5 +112,7 @@ class CORE_EXPORT QgsProcessingParameterTypeTinInputLayers : public QgsProcessin
       return QStringList() << QObject::tr( "list[dict]: list of input layers as dictionaries, see QgsProcessingParameterTinInputLayers docs" );
     }
 };
+
+///@endcond
 
 #endif // QGSPROCESSINGPARAMETERTININPUTLAYERS_H

--- a/src/core/processing/qgsprocessingparametertininputlayers.h
+++ b/src/core/processing/qgsprocessingparametertininputlayers.h
@@ -65,6 +65,7 @@ class CORE_EXPORT QgsProcessingParameterTinInputLayers: public QgsProcessingPara
     static QString typeName() { return QStringLiteral( "tininputlayers" ); }
 };
 
+#ifndef SIP_RUN
 ///@cond PRIVATE
 
 /**
@@ -114,5 +115,6 @@ class CORE_EXPORT QgsProcessingParameterTypeTinInputLayers : public QgsProcessin
 };
 
 ///@endcond
+#endif
 
 #endif // QGSPROCESSINGPARAMETERTININPUTLAYERS_H

--- a/src/core/processing/qgsprocessingparametervectortilewriterlayers.h
+++ b/src/core/processing/qgsprocessingparametervectortilewriterlayers.h
@@ -39,7 +39,6 @@
  * QgsVectorTileWriter::Layer representation and QVariant representation.
  *
  * \ingroup core
- * \note This class is not a part of public API.
  * \since QGIS 3.14
  */
 class CORE_EXPORT QgsProcessingParameterVectorTileWriterLayers : public QgsProcessingParameterDefinition
@@ -66,6 +65,7 @@ class CORE_EXPORT QgsProcessingParameterVectorTileWriterLayers : public QgsProce
 
 };
 
+///@cond PRIVATE
 
 /**
  * Parameter type definition for QgsProcessingParameterVectorTileWriterLayers.
@@ -113,5 +113,6 @@ class CORE_EXPORT QgsProcessingParameterTypeVectorTileWriterLayers : public QgsP
     }
 };
 
+///@endcond
 
 #endif // QGSPROCESSINGPARAMETERVECTORTILEWRITERLAYERS_H

--- a/src/core/processing/qgsprocessingparametervectortilewriterlayers.h
+++ b/src/core/processing/qgsprocessingparametervectortilewriterlayers.h
@@ -65,6 +65,7 @@ class CORE_EXPORT QgsProcessingParameterVectorTileWriterLayers : public QgsProce
 
 };
 
+#ifndef SIP_RUN
 ///@cond PRIVATE
 
 /**
@@ -114,5 +115,6 @@ class CORE_EXPORT QgsProcessingParameterTypeVectorTileWriterLayers : public QgsP
 };
 
 ///@endcond
+#endif
 
 #endif // QGSPROCESSINGPARAMETERVECTORTILEWRITERLAYERS_H

--- a/src/gui/processing/qgsprocessingvectortilewriterlayerswidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingvectortilewriterlayerswidgetwrapper.cpp
@@ -24,7 +24,6 @@
 
 #include "qgspanelwidget.h"
 
-#include "qgsprocessingcontext.h"
 #include "qgsvectortilewriter.h"
 
 #include "qgsprocessingparametervectortilewriterlayers.h"
@@ -39,10 +38,9 @@ QgsProcessingVectorTileWriteLayerDetailsWidget::QgsProcessingVectorTileWriteLaye
 {
   setupUi( this );
 
-  QgsProcessingContext context;
-  context.setProject( project );
+  mContext.setProject( project );
 
-  QgsVectorTileWriter::Layer layer = QgsProcessingParameterVectorTileWriterLayers::variantMapAsLayer( value.toMap(), context );
+  QgsVectorTileWriter::Layer layer = QgsProcessingParameterVectorTileWriterLayers::variantMapAsLayer( value.toMap(), mContext );
   mLayer = layer.layer();
 
   if ( !mLayer )
@@ -99,15 +97,13 @@ QgsProcessingVectorTileWriterLayersPanelWidget::QgsProcessingVectorTileWriterLay
   buttonBox()->addButton( copyLayerButton, QDialogButtonBox::ActionRole );
 
   // populate the list: first layers already selected, then layers from project not yet selected
-
-  QgsProcessingContext context;
-  context.setProject( project );
+  mContext.setProject( project );
 
   QSet<const QgsVectorLayer *> seenVectorLayers;
   const QVariantList valueList = value.toList();
   for ( const QVariant &v : valueList )
   {
-    QgsVectorTileWriter::Layer layer = QgsProcessingParameterVectorTileWriterLayers::variantMapAsLayer( v.toMap(), context );
+    QgsVectorTileWriter::Layer layer = QgsProcessingParameterVectorTileWriterLayers::variantMapAsLayer( v.toMap(), mContext );
     if ( !layer.layer() )
       continue;  // skip any invalid layers
 
@@ -130,7 +126,6 @@ QgsProcessingVectorTileWriterLayersPanelWidget::QgsProcessingVectorTileWriterLay
     addOption( vm, title, false );
   }
 }
-
 
 void QgsProcessingVectorTileWriterLayersPanelWidget::configureLayer()
 {
@@ -172,7 +167,6 @@ void QgsProcessingVectorTileWriterLayersPanelWidget::configureLayer()
       setItemValue( item, widget->value() );
     }
   }
-
 }
 
 void QgsProcessingVectorTileWriterLayersPanelWidget::copyLayer()
@@ -191,10 +185,9 @@ void QgsProcessingVectorTileWriterLayersPanelWidget::copyLayer()
 
 void QgsProcessingVectorTileWriterLayersPanelWidget::setItemValue( QStandardItem *item, const QVariant &value )
 {
-  QgsProcessingContext context;
-  context.setProject( mProject );
+  mContext.setProject( mProject );
 
-  QgsVectorTileWriter::Layer layer = QgsProcessingParameterVectorTileWriterLayers::variantMapAsLayer( value.toMap(), context );
+  QgsVectorTileWriter::Layer layer = QgsProcessingParameterVectorTileWriterLayers::variantMapAsLayer( value.toMap(), mContext );
 
   item->setText( titleForLayer( layer ) );
   item->setData( value, Qt::UserRole );

--- a/src/gui/processing/qgsprocessingvectortilewriterlayerswidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingvectortilewriterlayerswidgetwrapper.h
@@ -18,6 +18,7 @@
 
 #define SIP_NO_FILE
 
+#include "qgsprocessingcontext.h"
 #include "qgsprocessingwidgetwrapper.h"
 #include "qgsprocessingmultipleselectiondialog.h"
 #include "qgsvectortilewriter.h"
@@ -41,6 +42,7 @@ class QgsProcessingVectorTileWriteLayerDetailsWidget : public QgsPanelWidget, pr
 
   private:
     QgsVectorLayer *mLayer = nullptr;
+    QgsProcessingContext mContext;
 };
 
 
@@ -68,6 +70,7 @@ class QgsProcessingVectorTileWriterLayersPanelWidget : public QgsProcessingMulti
     QString titleForLayer( const QgsVectorTileWriter::Layer &layer );
 
     QgsProject *mProject = nullptr;
+    QgsProcessingContext mContext;
 };
 
 


### PR DESCRIPTION
## Description
Fixes some issues in custom Processing parameters (based on the review comments in #39575)

- Make `QgsProcessingParameterVectorTileWriterLayers` public so it can be used in other algorithms.
- Mark `QgsProcessingParameterTypeTinInputLayers` and `QgsProcessingParameterTypeVectorTileWriterLayers` as private API
- Use member context in vector tile widget wrapper to avoid dangling pointers.