### PR TITLE
Fix logic in QgsUserInputWidget which incorrectly deletes other widgets whenever one existing widget is deleted (3.10 backport)

### DIFF
--- a/src/gui/qgsuserinputwidget.cpp
+++ b/src/gui/qgsuserinputwidget.cpp
@@ -75,14 +75,14 @@ void QgsUserInputWidget::widgetDestroyed( QObject *obj )
   if ( obj->isWidgetType() )
   {
     QWidget *w = qobject_cast<QWidget *>( obj );
-    QMap<QWidget *, QFrame *>::iterator i = mWidgetList.find( w );
-    while ( i != mWidgetList.end() )
+    auto it = mWidgetList.find( w );
+    if ( it != mWidgetList.end() )
     {
-      if ( i.value() )
+      if ( QFrame *frame = it.value() )
       {
-        i.value()->deleteLater();
+        frame->deleteLater();
       }
-      i = mWidgetList.erase( i );
+      mWidgetList.erase( it );
     }
   }
   if ( mWidgetList.count() == 0 )


### PR DESCRIPTION
Fixes calls to iface.addUserInputWidget() does not show any widget if
an existing user input widget is already shown

(cherry picked from commit d8351c0a211588c7eed9bc3a887ca8c38fe950c0)
