### PR TITLE
Add transform context to QgsLocatorContext

### DIFF
--- a/python/core/auto_generated/locator/qgslocatorcontext.sip.in
+++ b/python/core/auto_generated/locator/qgslocatorcontext.sip.in
@@ -31,6 +31,8 @@ Constructor for QgsLocatorContext.
 
     QgsCoordinateReferenceSystem targetExtentCrs;
 
+    QgsCoordinateTransformContext transformContext;
+
     bool usingPrefix;
 
 };

--- a/python/core/auto_generated/locator/qgslocatormodelbridge.sip.in
+++ b/python/core/auto_generated/locator/qgslocatormodelbridge.sip.in
@@ -62,6 +62,26 @@ Returns ``True`` if the a search is currently running
 Triggers the result at given ``index`` and with optional ``actionId`` if an additional action was triggered
 %End
 
+    QgsCoordinateTransformContext transformContext() const;
+%Docstring
+Returns the coordinate transform context, which should be used whenever the
+locator constructs a coordinate transform.
+
+.. seealso:: :py:func:`setTransformContext`
+
+.. versionadded:: 3.18
+%End
+
+    void setTransformContext( const QgsCoordinateTransformContext &context );
+%Docstring
+Sets the coordinate transform ``context``, which should be used whenever the
+locator constructs a coordinate transform.
+
+.. seealso:: :py:func:`transformContext`
+
+.. versionadded:: 3.18
+%End
+
   signals:
     void resultAdded();
 %Docstring

--- a/src/core/locator/qgslocatorcontext.h
+++ b/src/core/locator/qgslocatorcontext.h
@@ -21,6 +21,7 @@
 #include "qgis_core.h"
 #include "qgsrectangle.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgscoordinatetransformcontext.h"
 
 /**
  * \class QgsLocatorContext
@@ -50,6 +51,14 @@ class CORE_EXPORT QgsLocatorContext
      * \see targetExtent
      */
     QgsCoordinateReferenceSystem targetExtentCrs;
+
+    /**
+     * Coordinate transform context, to use whenever performing coordinate transformations inside
+     * a locator.
+     *
+     * \since QGIS 3.16
+     */
+    QgsCoordinateTransformContext transformContext;
 
     /**
      * Will be TRUE if search is being conducted using a filter prefix.

--- a/src/core/locator/qgslocatormodelbridge.cpp
+++ b/src/core/locator/qgslocatormodelbridge.cpp
@@ -141,5 +141,6 @@ QgsLocatorContext QgsLocatorModelBridge::createContext()
   QgsLocatorContext context;
   context.targetExtent = mCanvasExtent;
   context.targetExtentCrs = mCanvasCrs;
+  context.transformContext = mTransformContext;
   return context;
 }

--- a/src/core/locator/qgslocatormodelbridge.h
+++ b/src/core/locator/qgslocatormodelbridge.h
@@ -22,6 +22,7 @@
 
 #include "qgis_core.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgscoordinatetransformcontext.h"
 #include "qgsrectangle.h"
 
 class QAction;
@@ -66,6 +67,24 @@ class CORE_EXPORT QgsLocatorModelBridge : public QObject
     //! Triggers the result at given \a index and with optional \a actionId if an additional action was triggered
     void triggerResult( const QModelIndex &index,  const int actionId = -1 );
 
+    /**
+     * Returns the coordinate transform context, which should be used whenever the
+     * locator constructs a coordinate transform.
+     *
+     * \see setTransformContext()
+     * \since QGIS 3.18
+     */
+    QgsCoordinateTransformContext transformContext() const { return mTransformContext; }
+
+    /**
+     * Sets the coordinate transform \a context, which should be used whenever the
+     * locator constructs a coordinate transform.
+     *
+     * \see transformContext()
+     * \since QGIS 3.18
+     */
+    void setTransformContext( const QgsCoordinateTransformContext &context ) { mTransformContext = context; }
+
   signals:
     //! Emitted when a result is added
     void resultAdded();
@@ -108,6 +127,7 @@ class CORE_EXPORT QgsLocatorModelBridge : public QObject
     // see discussion in https://github.com/qgis/QGIS/pull/8404
     QgsRectangle mCanvasExtent;
     QgsCoordinateReferenceSystem mCanvasCrs;
+    QgsCoordinateTransformContext mTransformContext;
 };
 
 #endif // QGSLOCATORMODELBRIDGE_H

--- a/src/gui/locator/qgslocatorwidget.cpp
+++ b/src/gui/locator/qgslocatorwidget.cpp
@@ -114,6 +114,12 @@ QgsLocatorWidget::QgsLocatorWidget( QWidget *parent )
   } );
   connect( mMenu, &QMenu::aboutToShow, this, &QgsLocatorWidget::configMenuAboutToShow );
 
+  mModelBridge->setTransformContext( QgsProject::instance()->transformContext() );
+  connect( QgsProject::instance(), &QgsProject::transformContextChanged,
+           this, [ = ]
+  {
+    mModelBridge->setTransformContext( QgsProject::instance()->transformContext() );
+  } );
 }
 
 QgsLocator *QgsLocatorWidget::locator()


### PR DESCRIPTION
Allows locators to correctly perform transformations during their result fetching/handling
