### PR TITLE
[layer tree] Fix corrupted tree when filter (by extent) is on with legend widget(s) enabled

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
@@ -38,7 +38,19 @@ and customized look.
     enum LegendNodeRoles
     {
       RuleKeyRole,
-      ParentRuleKeyRole
+      ParentRuleKeyRole,
+      NodeTypeRole,
+    };
+
+    enum NodeTypes
+    {
+      SimpleLegend,
+      SymbolLegend,
+      RasterSymbolLegend,
+      ImageLegend,
+      WmsLegend,
+      DataDefinedSizeLegend,
+      EmbeddedWidget,
     };
 
     QgsLayerTreeLayer *layerNode() const;

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -1230,22 +1230,38 @@ QList<QgsLayerTreeModelLegendNode *> QgsLayerTreeModel::filterLegendNodes( const
     {
       for ( QgsLayerTreeModelLegendNode *node : qgis::as_const( nodes ) )
       {
-        QString ruleKey = node->data( QgsSymbolLegendNode::RuleKeyRole ).toString();
-        bool checked = mLegendFilterUsesExtent || node->data( Qt::CheckStateRole ).toInt() == Qt::Checked;
-        if ( checked )
+        switch ( node->data( QgsSymbolLegendNode::NodeTypeRole ).value<QgsLayerTreeModelLegendNode::NodeTypes>() )
         {
-          if ( QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( node->layerNode()->layer() ) )
-          {
-            if ( mLegendFilterHitTest->legendKeyVisible( ruleKey, vl ) )
-              filtered << node;
-          }
-          else
-          {
+          case QgsLayerTreeModelLegendNode::EmbeddedWidget:
             filtered << node;
+            break;
+
+          case QgsLayerTreeModelLegendNode::SimpleLegend:
+          case QgsLayerTreeModelLegendNode::SymbolLegend:
+          case QgsLayerTreeModelLegendNode::RasterSymbolLegend:
+          case QgsLayerTreeModelLegendNode::ImageLegend:
+          case QgsLayerTreeModelLegendNode::WmsLegend:
+          case QgsLayerTreeModelLegendNode::DataDefinedSizeLegend:
+          {
+            const QString ruleKey = node->data( QgsSymbolLegendNode::RuleKeyRole ).toString();
+            bool checked = mLegendFilterUsesExtent || node->data( Qt::CheckStateRole ).toInt() == Qt::Checked;
+            if ( checked )
+            {
+              if ( QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( node->layerNode()->layer() ) )
+              {
+                if ( mLegendFilterHitTest->legendKeyVisible( ruleKey, vl ) )
+                  filtered << node;
+              }
+              else
+              {
+                filtered << node;
+              }
+            }
+            else  // unknown node type or unchecked
+              filtered << node;
+            break;
           }
         }
-        else  // unknown node type or unchecked
-          filtered << node;
       }
     }
   }

--- a/src/core/layertree/qgslayertreemodel.h
+++ b/src/core/layertree/qgslayertreemodel.h
@@ -500,6 +500,8 @@ class EmbeddedWidgetLegendNode : public QgsLayerTreeModelLegendNode
     {
       if ( role == RuleKeyRole )
         return mRuleKey;
+      else if ( role == QgsLayerTreeModelLegendNode::NodeTypeRole )
+        return QgsLayerTreeModelLegendNode::EmbeddedWidget;
       return QVariant();
     }
 

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -511,6 +511,10 @@ QVariant QgsSymbolLegendNode::data( int role ) const
   {
     return mItem.parentRuleKey();
   }
+  else if ( role == QgsLayerTreeModelLegendNode::NodeTypeRole )
+  {
+    return QgsLayerTreeModelLegendNode::SymbolLegend;
+  }
 
   return QVariant();
 }
@@ -851,6 +855,8 @@ QVariant QgsSimpleLegendNode::data( int role ) const
     return mIcon;
   else if ( role == RuleKeyRole && !mKey.isEmpty() )
     return mKey;
+  else if ( role == QgsLayerTreeModelLegendNode::NodeTypeRole )
+    return QgsLayerTreeModelLegendNode::SimpleLegend;
   else
     return QVariant();
 }
@@ -873,6 +879,10 @@ QVariant QgsImageLegendNode::data( int role ) const
   else if ( role == Qt::SizeHintRole )
   {
     return mImage.size();
+  }
+  else if ( role == QgsLayerTreeModelLegendNode::NodeTypeRole )
+  {
+    return QgsLayerTreeModelLegendNode::ImageLegend;
   }
   return QVariant();
 }
@@ -931,9 +941,14 @@ QVariant QgsRasterSymbolLegendNode::data( int role ) const
     return QIcon( pix );
   }
   else if ( role == Qt::DisplayRole || role == Qt::EditRole )
+  {
     return mUserLabel.isEmpty() ? mLabel : mUserLabel;
-  else
-    return QVariant();
+  }
+  else if ( role == QgsLayerTreeModelLegendNode::NodeTypeRole )
+  {
+    return QgsLayerTreeModelLegendNode::RasterSymbolLegend;
+  }
+  return QVariant();
 }
 
 
@@ -1085,6 +1100,10 @@ QVariant QgsWmsLegendNode::data( int role ) const
   {
     return getLegendGraphic().size();
   }
+  else if ( role == QgsLayerTreeModelLegendNode::NodeTypeRole )
+  {
+    return QgsLayerTreeModelLegendNode::WmsLegend;
+  }
   return QVariant();
 }
 
@@ -1220,6 +1239,10 @@ QVariant QgsDataDefinedSizeLegendNode::data( int role ) const
   {
     cacheImage();
     return mImage.size();
+  }
+  else if ( role == QgsLayerTreeModelLegendNode::NodeTypeRole )
+  {
+    return QgsLayerTreeModelLegendNode::DataDefinedSizeLegend;
   }
   return QVariant();
 }

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -60,10 +60,24 @@ class CORE_EXPORT QgsLayerTreeModelLegendNode : public QObject
 #endif
   public:
 
+    //! Legend node data roles
     enum LegendNodeRoles
     {
-      RuleKeyRole = Qt::UserRole,     //!< Rule key of the node (QString)
-      ParentRuleKeyRole               //!< Rule key of the parent legend node - for legends with tree hierarchy (QString). Added in 2.8
+      RuleKeyRole = Qt::UserRole, //!< Rule key of the node (QString)
+      ParentRuleKeyRole, //!< Rule key of the parent legend node - for legends with tree hierarchy (QString). Added in 2.8
+      NodeTypeRole, //!< Type of node. Added in 3.16
+    };
+
+    //! Types of legend nodes
+    enum NodeTypes
+    {
+      SimpleLegend, //!< Simple label with icon legend node type
+      SymbolLegend, //!< Vector symbol legend node type
+      RasterSymbolLegend, //!< Raster symbol legend node type
+      ImageLegend, //!< Raster image legend node type
+      WmsLegend, //!< WMS legend node type
+      DataDefinedSizeLegend, //!< Marker symbol legend node type
+      EmbeddedWidget, //!< Embedded widget placeholder node type
     };
 
     //! Returns pointer to the parent layer node
@@ -277,6 +291,7 @@ class CORE_EXPORT QgsLayerTreeModelLegendNode : public QObject
     QSizeF mUserSize;
     bool mColumnBreakBeforeNode = false;
 };
+Q_DECLARE_METATYPE( QgsLayerTreeModelLegendNode::NodeTypes )
 
 #include "qgslegendsymbolitem.h"
 #include "qgstextformat.h"


### PR DESCRIPTION
## Description

Without that fix, legend widgets are corrupting the layer tree when users have filter by extent switched on.