### PR TITLE
use forwarding reference to fix reference copy warning

### DIFF
--- a/src/gui/qgsexpressiontreeview.cpp
+++ b/src/gui/qgsexpressiontreeview.cpp
@@ -650,7 +650,7 @@ void QgsExpressionTreeView::loadExpressionsFromJson( const QJsonDocument &expres
   settings.beginGroup( QStringLiteral( "user" ), QgsSettings::Section::Expressions );
   mUserExpressionLabels = settings.childGroups();
 
-  for ( const QJsonValue &&expressionValue : expressionsObject["expressions"].toArray() )
+  for ( const QJsonValue && expressionValue : expressionsObject["expressions"].toArray() )
   {
     // validate the type of the array element, can be anything
     if ( ! expressionValue.isObject() )

--- a/src/gui/qgsexpressiontreeview.cpp
+++ b/src/gui/qgsexpressiontreeview.cpp
@@ -650,7 +650,7 @@ void QgsExpressionTreeView::loadExpressionsFromJson( const QJsonDocument &expres
   settings.beginGroup( QStringLiteral( "user" ), QgsSettings::Section::Expressions );
   mUserExpressionLabels = settings.childGroups();
 
-  for ( const QJsonValue &expressionValue : expressionsObject["expressions"].toArray() )
+  for ( const QJsonValue &&expressionValue : expressionsObject["expressions"].toArray() )
   {
     // validate the type of the array element, can be anything
     if ( ! expressionValue.isObject() )


### PR DESCRIPTION
warning: loop variable 'expressionValue' is always a copy because the range of type 'QJsonArray' does not return a reference


found the answer here:

![image](https://user-images.githubusercontent.com/127259/97691209-59e0ed00-1a9e-11eb-9268-b254ac0760a8.png)


https://stackoverflow.com/a/49979209/1548052