### PR TITLE
[QgsQuick] Value relation key column type changed

### DIFF
--- a/src/quickgui/plugin/editor/qgsquickrange.qml
+++ b/src/quickgui/plugin/editor/qgsquickrange.qml
@@ -151,7 +151,7 @@ Item {
     Slider {
       id: slider
       visible: fieldItem.widgetStyle === "Slider"
-      value: fieldItem.parent.value
+      value: fieldItem.parent.value ? fieldItem.parent.value : 0
       width: parent.width - valueLabel.width
       height: fieldItem.height
       implicitWidth: width

--- a/src/quickgui/plugin/qgsquickfeatureform.qml
+++ b/src/quickgui/plugin/qgsquickfeatureform.qml
@@ -349,7 +349,7 @@ Item {
             model: QgsQuick.SubModel {
               id: contentModel
               model: form.model
-              rootIndex: form.model.hasTabs ? form.model.index(currentIndex, 0) : undefined
+              rootIndex: form.model.hasTabs ? form.model.index(currentIndex, 0) : null
             }
 
             delegate: fieldItem
@@ -379,7 +379,7 @@ Item {
       Label {
         id: fieldLabel
 
-        text: qsTr(Name) || ''
+        text: Name ? qsTr(Name) : ''
         font.bold: true
         color: ConstraintSoftValid && ConstraintHardValid ? form.style.constraint.validColor : form.style.constraint.invalidColor
       }
@@ -392,7 +392,7 @@ Item {
           top: fieldLabel.bottom
         }
 
-        text: qsTr(ConstraintDescription)
+        text: ConstraintDescription ? qsTr(ConstraintDescription) : ''
         visible: !ConstraintHardValid || !ConstraintSoftValid
         height: visible ? undefined : 0
         wrapMode: Text.WordWrap
@@ -428,7 +428,11 @@ Item {
 
           active: widget !== 'Hidden'
 
-          source: form.loadWidgetFn(widget.toLowerCase())
+          source: {
+            if ( widget )
+               return form.loadWidgetFn(widget.toLowerCase())
+            else return ''
+          }
         }
 
         Connections {
@@ -442,7 +446,7 @@ Item {
           target: form
           ignoreUnknownSignals: true
           onSaved: {
-            if (typeof attributeEditorLoader.item.callbackOnSave === "function") {
+            if (attributeEditorLoader.item && typeof attributeEditorLoader.item.callbackOnSave === "function") {
               attributeEditorLoader.item.callbackOnSave()
             }
           }

--- a/src/quickgui/qgsquickfeatureslistmodel.cpp
+++ b/src/quickgui/qgsquickfeatureslistmodel.cpp
@@ -253,7 +253,7 @@ int QgsQuickFeaturesListModel::rowFromAttribute( const int role, const QVariant 
   return -1;
 }
 
-int QgsQuickFeaturesListModel::keyFromAttribute( const int role, const QVariant &value ) const
+QVariant QgsQuickFeaturesListModel::keyFromAttribute( const int role, const QVariant &value ) const
 {
   for ( int i = 0; i < mFeatures.count(); ++i )
   {
@@ -261,10 +261,10 @@ int QgsQuickFeaturesListModel::keyFromAttribute( const int role, const QVariant 
     if ( d == value )
     {
       QVariant key = data( index( i, 0 ), KeyColumn );
-      return key.toInt();
+      return key;
     }
   }
-  return -1;
+  return QVariant();
 }
 
 QgsQuickFeatureLayerPair QgsQuickFeaturesListModel::featureLayerPair( const int &featureId )

--- a/src/quickgui/qgsquickfeatureslistmodel.h
+++ b/src/quickgui/qgsquickfeatureslistmodel.h
@@ -112,7 +112,7 @@ class QUICK_EXPORT QgsQuickFeaturesListModel : public QAbstractListModel
      * \return KeyColumn role for found feature, returns -1 if no feature is found. If more features
      * match requested role and value, KeyColumn for first is returned.
      */
-    Q_INVOKABLE int keyFromAttribute( const int role, const QVariant &value ) const;
+    Q_INVOKABLE QVariant keyFromAttribute( const int role, const QVariant &value ) const;
 
     //! Returns maximum amount of features that can be queried from layer
     int featuresLimit() const;


### PR DESCRIPTION
## Value relation key column type changed

Value relation widget expected only `Integer` type values as key in referenced table. Changed it to `QVariant` as it is in QGIS. It is the file `src/quickgui/qgsquickfeatureslistmodel.h`.

While investigating this issue I found several nulls/undefineds in console, so the first commit address them. It is basically just checking is variable is defined.

