### PR TITLE
[3.16] Update expression overlay functions

### DIFF
--- a/resources/function_help/json/overlay_contains
+++ b/resources/function_help/json/overlay_contains
@@ -2,7 +2,7 @@
   "name": "overlay_contains",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns whether the current feature spatially contains at least one feature from a target layer, or an array of expression-based results for the features in the target layer contained in the current feature.<br><br>Read more on the underlying GEOS \"Contains\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Contains.html'>ST_CONTAINS</a> function.",
+  "description": "Returns whether the current feature spatially contains at least one feature from a target layer, or an array of expression-based results for the features in the target layer contained in the current feature.<br><br>Read more on the underlying GEOS \"Contains\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Contains.html'>ST_Contains</a> function.",
   "arguments": [
     {
       "arg": "layer",

--- a/resources/function_help/json/overlay_crosses
+++ b/resources/function_help/json/overlay_crosses
@@ -2,50 +2,54 @@
   "name": "overlay_crosses",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Performs a spatial join of type CROSSES. This returns an array of results of an expression evaluated on features from a different layer that CROSSES the current feature, or, if no expression if provided, simply returns whether at least one feature from the other layer CROSSES the current feature.",
+  "description": "Returns whether the current feature spatially crosses at least one feature from a target layer, or an array of expression-based results for the features in the target layer crossed by the current feature.<br><br>Read more on the underlying GEOS \"Crosses\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Crosses.html'>ST_Crosses</a> function.",
   "arguments": [
     {
       "arg": "layer",
-      "description": "the other layer"
+      "description": "the layer whose overlay is checked"
     },
     {
       "arg": "expression",
-      "description": "an optional expression to evaluate on the features from the other layer (if not set, the function will just return a boolean indicating whether there is at least one match)",
+      "description": "an optional expression to evaluate on the features from the target layer. If not set, the function will just return a boolean indicating whether there is at least one match.",
       "optional": true
     },
     {
       "arg": "filter",
-      "description": "an optional expression to filter the matching features (if not set, all features will be returned)",
+      "description": "an optional expression to filter the target features to check. If not set, all the features will be checked.",
       "optional": true
     },
     {
       "arg": "limit",
-      "description": "an optional integer to limit the number of matching features (if not set, all features will be returned)",
+      "description": "an optional integer to limit the number of matching features. If not set, all the matching features will be returned.",
       "optional": true
     },
     {
       "arg": "cache",
       "description": "set this to true to build a local spatial index (most of the time, this is unwanted, unless you are working with a particularly slow data provider)",
       "optional": true,
-      "default": false
+      "default": "false"
     }
   ],
   "examples": [
     {
       "expression": "overlay_crosses('regions')",
-      "returns": "True"
+      "returns": "true if the current feature spatially crosses a region"
+    },
+    {
+      "expression": "overlay_crosses('regions', filter:= population > 10000)",
+      "returns": "true if the current feature spatially crosses a region with a population greater than 10000"
     },
     {
       "expression": "overlay_crosses('regions', name)",
-      "returns": "['South Africa', 'Africa', 'World']"
+      "returns": "an array of names, for the regions crossed by the current feature"
     },
     {
-      "expression": "overlay_crosses('regions', name, name != 'World')",
-      "returns": "['South Africa', 'Africa']"
+      "expression": "array_sort(overlay_crosses(layer:='regions', expression:=\"name\", filter:= population > 10000))",
+      "returns": "an ordered array of names, for the regions crossed by the current feature and with a population greater than 10000"
     },
     {
-      "expression": "overlay_crosses('regions', name, limit:=1)",
-      "returns": "['South Africa']"
+      "expression": "overlay_crosses(layer:='regions', expression:= geom_to_wkt($geometry), limit:=2)",
+      "returns": "an array of geometries (in WKT), for up to two regions crossed by the current feature"
     }
   ]
 }

--- a/resources/function_help/json/overlay_disjoint
+++ b/resources/function_help/json/overlay_disjoint
@@ -2,50 +2,54 @@
   "name": "overlay_disjoint",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Performs a spatial join of type DISJOINT. This returns an array of results of an expression evaluated on features from a different layer that DISJOINT the current feature, or, if no expression if provided, simply returns whether at least one feature from the other layer DISJOINT the current feature.",
+  "description": "Returns whether the current feature is spatially disjoint from at least one feature from a target layer, or an array of expression-based results for the features in the target layer that are disjoint from the current feature.<br><br>Read more on the underlying GEOS \"Disjoint\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Disjoint.html'>ST_Disjoint</a> function.",
   "arguments": [
     {
       "arg": "layer",
-      "description": "the other layer"
+      "description": "the layer whose overlay is checked"
     },
     {
       "arg": "expression",
-      "description": "an optional expression to evaluate on the features from the other layer (if not set, the function will just return a boolean indicating whether there is at least one match)",
+      "description": "an optional expression to evaluate on the features from the target layer. If not set, the function will just return a boolean indicating whether there is at least one match.",
       "optional": true
     },
     {
       "arg": "filter",
-      "description": "an optional expression to filter the matching features (if not set, all features will be returned)",
+      "description": "an optional expression to filter the target features to check. If not set, all the features will be checked.",
       "optional": true
     },
     {
       "arg": "limit",
-      "description": "an optional integer to limit the number of matching features (if not set, all features will be returned)",
+      "description": "an optional integer to limit the number of matching features. If not set, all the matching features will be returned.",
       "optional": true
     },
     {
       "arg": "cache",
       "description": "set this to true to build a local spatial index (most of the time, this is unwanted, unless you are working with a particularly slow data provider)",
       "optional": true,
-      "default": false
+      "default": "false"
     }
   ],
   "examples": [
     {
       "expression": "overlay_disjoint('regions')",
-      "returns": "True"
+      "returns": "true if the current feature is spatially disjoint from a region"
+    },
+    {
+      "expression": "overlay_disjoint('regions', filter:= population > 10000)",
+      "returns": "true if the current feature is spatially disjoint from a region with a population greater than 10000"
     },
     {
       "expression": "overlay_disjoint('regions', name)",
-      "returns": "['South Africa', 'Africa', 'World']"
+      "returns": "an array of names, for the regions spatially disjoint from the current feature"
     },
     {
-      "expression": "overlay_disjoint('regions', name, name != 'World')",
-      "returns": "['South Africa', 'Africa']"
+      "expression": "array_sort(overlay_disjoint(layer:='regions', expression:=\"name\", filter:= population > 10000))",
+      "returns": "an ordered array of names, for the regions spatially disjoint from the current feature and with a population greater than 10000"
     },
     {
-      "expression": "overlay_disjoint('regions', name, limit:=1)",
-      "returns": "['South Africa']"
+      "expression": "overlay_disjoint(layer:='regions', expression:= geom_to_wkt($geometry), limit:=2)",
+      "returns": "an array of geometries (in WKT), for up to two regions spatially disjoint from the current feature"
     }
   ]
 }

--- a/resources/function_help/json/overlay_equals
+++ b/resources/function_help/json/overlay_equals
@@ -2,50 +2,54 @@
   "name": "overlay_equals",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Performs a spatial join of type EQUALS. This returns an array of results of an expression evaluated on features from a different layer that EQUALS the current feature, or, if no expression if provided, simply returns whether at least one feature from the other layer EQUALS the current feature.",
+  "description": "Returns whether the current feature spatially equals to at least one feature from a target layer, or an array of expression-based results for the features in the target layer that are spatially equal to the current feature.<br><br>Read more on the underlying GEOS \"Equals\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Equals.html'>ST_Equals</a> function.",
   "arguments": [
     {
       "arg": "layer",
-      "description": "the other layer"
+      "description": "the layer whose overlay is checked"
     },
     {
       "arg": "expression",
-      "description": "an optional expression to evaluate on the features from the other layer (if not set, the function will just return a boolean indicating whether there is at least one match)",
+      "description": "an optional expression to evaluate on the features from the target layer. If not set, the function will just return a boolean indicating whether there is at least one match.",
       "optional": true
     },
     {
       "arg": "filter",
-      "description": "an optional expression to filter the matching features (if not set, all features will be returned)",
+      "description": "an optional expression to filter the target features to check. If not set, all the features will be checked.",
       "optional": true
     },
     {
       "arg": "limit",
-      "description": "an optional integer to limit the number of matching features (if not set, all features will be returned)",
+      "description": "an optional integer to limit the number of matching features. If not set, all the matching features will be returned.",
       "optional": true
     },
     {
       "arg": "cache",
       "description": "set this to true to build a local spatial index (most of the time, this is unwanted, unless you are working with a particularly slow data provider)",
       "optional": true,
-      "default": false
+      "default": "false"
     }
   ],
   "examples": [
     {
       "expression": "overlay_equals('regions')",
-      "returns": "True"
+      "returns": "true if the current feature is spatially equal to a region"
+    },
+    {
+      "expression": "overlay_equals('regions', filter:= population > 10000)",
+      "returns": "true if the current feature is spatially equal to a region with a population greater than 10000"
     },
     {
       "expression": "overlay_equals('regions', name)",
-      "returns": "['South Africa', 'Africa', 'World']"
+      "returns": "an array of names, for the regions spatially equal to the current feature"
     },
     {
-      "expression": "overlay_equals('regions', name, name != 'World')",
-      "returns": "['South Africa', 'Africa']"
+      "expression": "array_sort(overlay_equals(layer:='regions', expression:=\"name\", filter:= population > 10000))",
+      "returns": "an ordered array of names, for the regions spatially equal to the current feature and with a population greater than 10000"
     },
     {
-      "expression": "overlay_equals('regions', name, limit:=1)",
-      "returns": "['South Africa']"
+      "expression": "overlay_equals(layer:='regions', expression:= geom_to_wkt($geometry), limit:=2)",
+      "returns": "an array of geometries (in WKT), for up to two regions spatially equal to the current feature"
     }
   ]
 }

--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -2,50 +2,54 @@
   "name": "overlay_intersects",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Performs a spatial join of type INTERSECTS. This returns an array of results of an expression evaluated on features from a different layer that INTERSECTS the current feature, or, if no expression if provided, simply returns whether at least one feature from the other layer INTERSECTS the current feature.",
+  "description": "Returns whether the current feature spatially intersects at least one feature from a target layer, or an array of expression-based results for the features in the target layer intersected by the current feature.<br><br>Read more on the underlying GEOS \"Intersects\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Intersects.html'>ST_INTERSECTS</a> function.",
   "arguments": [
     {
       "arg": "layer",
-      "description": "the other layer"
+      "description": "the layer whose overlay is checked"
     },
     {
       "arg": "expression",
-      "description": "an optional expression to evaluate on the features from the other layer (if not set, the function will just return a boolean indicating whether there is at least one match)",
+      "description": "an optional expression to evaluate on the features from the target layer. If not set, the function will just return a boolean indicating whether there is at least one match.",
       "optional": true
     },
     {
       "arg": "filter",
-      "description": "an optional expression to filter the matching features (if not set, all features will be returned)",
+      "description": "an optional expression to filter the target features to check. If not set, all the features will be checked.",
       "optional": true
     },
     {
       "arg": "limit",
-      "description": "an optional integer to limit the number of matching features (if not set, all features will be returned)",
+      "description": "an optional integer to limit the number of matching features. If not set, all the matching features will be returned.",
       "optional": true
     },
     {
       "arg": "cache",
       "description": "set this to true to build a local spatial index (most of the time, this is unwanted, unless you are working with a particularly slow data provider)",
       "optional": true,
-      "default": false
+      "default": "false"
     }
   ],
   "examples": [
     {
       "expression": "overlay_intersects('regions')",
-      "returns": "True"
+      "returns": "true if the current feature spatially intersects a region"
+    },
+    {
+      "expression": "overlay_intersects('regions', filter:= population > 10000)",
+      "returns": "true if the current feature spatially intersects a region with a population greater than 10000"
     },
     {
       "expression": "overlay_intersects('regions', name)",
-      "returns": "['South Africa', 'Africa', 'World']"
+      "returns": "an array of names, for the regions intersected by the current feature"
     },
     {
-      "expression": "overlay_intersects('regions', name, name != 'World')",
-      "returns": "['South Africa', 'Africa']"
+      "expression": "array_sort(overlay_intersects(layer:='regions', expression:=\"name\", filter:= population > 10000))",
+      "returns": "an ordered array of names, for the regions intersected by the current feature and with a population greater than 10000"
     },
     {
-      "expression": "overlay_intersects('regions', name, limit:=1)",
-      "returns": "['South Africa']"
+      "expression": "overlay_intersects(layer:='regions', expression:= geom_to_wkt($geometry), limit:=2)",
+      "returns": "an array of geometries (in WKT), for up to two regions intersected by the current feature"
     }
   ]
 }

--- a/resources/function_help/json/overlay_nearest
+++ b/resources/function_help/json/overlay_nearest
@@ -2,55 +2,85 @@
   "name": "overlay_nearest",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "This returns an array of results of an expression evaluated on features from a different layer ordered BY DISTANCE to the current feature, or, if no expression if provided, simply returns whether at least one feature from the other layer was found. Note : this function can be slow and consume a lot of memory for large layers.",
+  "description": "Returns whether the current feature has feature(s) from a target layer within a given distance, or an array of expression-based results for the features in the target layer that are within a distance from the current feature.<br><br>Note: This function can be slow and consume a lot of memory for large layers.",
   "arguments": [
     {
       "arg": "layer",
-      "description": "the other layer"
+      "description": "the target layer"
     },
     {
       "arg": "expression",
-      "description": "an optional expression to evaluate on the features from the other layer (if not set, the function will just return a boolean indicating whether there is at least one match)",
+      "description": "an optional expression to evaluate on the features from the target layer. If not set, the function will just return a boolean indicating whether there is at least one match.",
       "optional": true
     },
     {
       "arg": "filter",
-      "description": "an optional expression to filter the matching features (if not set, all features will be returned)",
+      "description": "an optional expression to filter the target features to check. If not set, all the features in the target layer will be used.",
+      "optional": true
+    },
+{
+  "name": "overlay_nearest",
+  "type": "function",
+  "groups": ["GeometryGroup"],
+  "description": "Returns whether the current feature has feature(s) from a target layer within a given distance, or an array of expression-based results for the features in the target layer within a distance from the current feature.<br><br>Note: This function can be slow and consume a lot of memory for large layers.",
+  "arguments": [
+    {
+      "arg": "layer",
+      "description": "the target layer"
+    },
+    {
+      "arg": "expression",
+      "description": "an optional expression to evaluate on the features from the target layer. If not set, the function will just return a boolean indicating whether there is at least one match.",
+      "optional": true
+    },
+    {
+      "arg": "filter",
+      "description": "an optional expression to filter the target features to check. If not set, all the features in the target layer will be used.",
       "optional": true
     },
     {
       "arg": "limit",
-      "description": "an optional integer to limit the number of matching features (if not set, only the nearest feature will be returned)",
-      "optional": true
+      "description": "an optional integer to limit the number of matching features. If not set, only the nearest feature will be returned. If set to -1, returns all the matching features.",
+      "optional": true,
+      "default": "1"
     },
     {
       "arg": "max_distance",
-      "description": "an optional maximum distance to limit the number of matching features (if not set, only the nearest feature will be returned)",
+      "description": "an optional distance to limit the search of matching features. If not set, all the features in the target layer will be used.",
       "optional": true
     },
     {
       "arg": "cache",
       "description": "set this to true to build a local spatial index (most of the time, this is unwanted, unless you are working with a particularly slow data provider)",
       "optional": true,
-      "default": false
+      "default": "false"
     }
   ],
   "examples": [
     {
-      "expression": "overlay_nearest('regions')",
-      "returns": "True"
+      "expression": "overlay_nearest('airports')",
+      "returns": "true if the \"airports\" layer has at least one feature"
     },
     {
-      "expression": "overlay_nearest('regions', name)",
-      "returns": "['South Africa', 'Africa', 'World']"
+      "expression": "overlay_nearest('airports', max_distance:= 5000)",
+      "returns": "true if there is an airport within a distance of 5000 map units from the current feature"
     },
     {
-      "expression": "overlay_nearest('regions', name, name != 'World')",
-      "returns": "['South Africa', 'Africa']"
+      "expression": "overlay_nearest('airports', name)",
+      "returns": "the name of the closest airport to the current feature"
     },
     {
-      "expression": "overlay_nearest('regions', name, limit:=1)",
-      "returns": "['South Africa']"
+      "expression": "overlay_nearest(layer:='airports', expression:= name, max_distance:= 5000)",
+      "returns": "the name of the closest airport within a distance of 5000 map units from the current feature"
+    },
+    {
+      "expression": "overlay_nearest(layer:='airports', expression:=\"name\", filter:= \"Use\"='Civilian', limit:=3)",
+      "returns": "an array of names, for up to the three closest civilian airports ordered by distance"
+    },
+    {
+      "expression": "overlay_nearest(layer:='airports', expression:=\"name\", limit:= -1, max_distance:= 5000)",
+      "returns": "an array of names, for all the airports within a distance of 5000 map units from the current feature, ordered by distance"
     }
   ]
 }
+

--- a/resources/function_help/json/overlay_nearest
+++ b/resources/function_help/json/overlay_nearest
@@ -2,26 +2,6 @@
   "name": "overlay_nearest",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns whether the current feature has feature(s) from a target layer within a given distance, or an array of expression-based results for the features in the target layer that are within a distance from the current feature.<br><br>Note: This function can be slow and consume a lot of memory for large layers.",
-  "arguments": [
-    {
-      "arg": "layer",
-      "description": "the target layer"
-    },
-    {
-      "arg": "expression",
-      "description": "an optional expression to evaluate on the features from the target layer. If not set, the function will just return a boolean indicating whether there is at least one match.",
-      "optional": true
-    },
-    {
-      "arg": "filter",
-      "description": "an optional expression to filter the target features to check. If not set, all the features in the target layer will be used.",
-      "optional": true
-    },
-{
-  "name": "overlay_nearest",
-  "type": "function",
-  "groups": ["GeometryGroup"],
   "description": "Returns whether the current feature has feature(s) from a target layer within a given distance, or an array of expression-based results for the features in the target layer within a distance from the current feature.<br><br>Note: This function can be slow and consume a lot of memory for large layers.",
   "arguments": [
     {
@@ -83,4 +63,3 @@
     }
   ]
 }
-

--- a/resources/function_help/json/overlay_touches
+++ b/resources/function_help/json/overlay_touches
@@ -2,50 +2,54 @@
   "name": "overlay_touches",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Performs a spatial join of type TOUCHES. This returns an array of results of an expression evaluated on features from a different layer that TOUCHES the current feature, or, if no expression if provided, simply returns whether at least one feature from the other layer TOUCHES the current feature.",
+  "description": "Returns whether the current feature spatially touches at least one feature from a target layer, or an array of expression-based results for the features in the target layer touched by the current feature.<br><br>Read more on the underlying GEOS \"Touches\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Touches.html'>ST_TOUCHES</a> function.",
   "arguments": [
     {
       "arg": "layer",
-      "description": "the other layer"
+      "description": "the layer whose overlay is checked"
     },
     {
       "arg": "expression",
-      "description": "an optional expression to evaluate on the features from the other layer (if not set, the function will just return a boolean indicating whether there is at least one match)",
+      "description": "an optional expression to evaluate on the features from the target layer. If not set, the function will just return a boolean indicating whether there is at least one match.",
       "optional": true
     },
     {
       "arg": "filter",
-      "description": "an optional expression to filter the matching features (if not set, all features will be returned)",
+      "description": "an optional expression to filter the target features to check. If not set, all the features will be checked.",
       "optional": true
     },
     {
       "arg": "limit",
-      "description": "an optional integer to limit the number of matching features (if not set, all features will be returned)",
+      "description": "an optional integer to limit the number of matching features. If not set, all the matching features will be returned.",
       "optional": true
     },
     {
       "arg": "cache",
       "description": "set this to true to build a local spatial index (most of the time, this is unwanted, unless you are working with a particularly slow data provider)",
       "optional": true,
-      "default": false
+      "default": "false"
     }
   ],
   "examples": [
     {
       "expression": "overlay_touches('regions')",
-      "returns": "True"
+      "returns": "true if the current feature spatially touches a region"
+    },
+    {
+      "expression": "overlay_touches('regions', filter:= population > 10000)",
+      "returns": "true if the current feature spatially touches a region with a population greater than 10000"
     },
     {
       "expression": "overlay_touches('regions', name)",
-      "returns": "['South Africa', 'Africa', 'World']"
+      "returns": "an array of names, for the regions touched by the current feature"
     },
     {
-      "expression": "overlay_touches('regions', name, name != 'World')",
-      "returns": "['South Africa', 'Africa']"
+      "expression": "array_sort(overlay_touches(layer:='regions', expression:=\"name\", filter:= population > 10000))",
+      "returns": "an ordered array of names, for the regions touched by the current feature and with a population greater than 10000"
     },
     {
-      "expression": "overlay_touches('regions', name, limit:=1)",
-      "returns": "['South Africa']"
+      "expression": "overlay_touches(layer:='regions', expression:= geom_to_wkt($geometry), limit:=2)",
+      "returns": "an array of geometries (in WKT), for up to two regions touched by the current feature"
     }
   ]
 }

--- a/resources/function_help/json/overlay_within
+++ b/resources/function_help/json/overlay_within
@@ -2,50 +2,54 @@
   "name": "overlay_within",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Performs a spatial join of type WITHIN. This returns an array of results of an expression evaluated on features from a different layer that are WITHIN the current feature, or, if no expression if provided, simply returns whether at least one feature from the other layer is WITHIN the current feature.",
+  "description": "Returns whether the current feature is spatially within at least one feature from a target layer, or an array of expression-based results for the features in the target layer that contain the current feature.<br><br>Read more on the underlying GEOS \"Within\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Within.html'>ST_WITHIN</a> function.",
   "arguments": [
     {
       "arg": "layer",
-      "description": "the other layer"
+      "description": "the layer whose overlay is checked"
     },
     {
       "arg": "expression",
-      "description": "an optional expression to evaluate on the features from the other layer (if not set, the function will just return a boolean indicating whether there is at least one match)",
+      "description": "an optional expression to evaluate on the features from the target layer. If not set, the function will just return a boolean indicating whether there is at least one match.",
       "optional": true
     },
     {
       "arg": "filter",
-      "description": "an optional expression to filter the matching features (if not set, all features will be returned)",
+      "description": "an optional expression to filter the target features to check. If not set, all the features will be checked.",
       "optional": true
     },
     {
       "arg": "limit",
-      "description": "an optional integer to limit the number of matching features (if not set, all features will be returned)",
+      "description": "an optional integer to limit the number of matching features. If not set, all the matching features will be returned.",
       "optional": true
     },
     {
       "arg": "cache",
       "description": "set this to true to build a local spatial index (most of the time, this is unwanted, unless you are working with a particularly slow data provider)",
       "optional": true,
-      "default": false
+      "default": "false"
     }
   ],
   "examples": [
     {
       "expression": "overlay_within('regions')",
-      "returns": "True"
+      "returns": "true if the current feature is spatially within a region"
+    },
+    {
+      "expression": "overlay_within('regions', filter:= population > 10000)",
+      "returns": "true if the current feature is spatially within a region with a population greater than 10000"
     },
     {
       "expression": "overlay_within('regions', name)",
-      "returns": "['South Africa', 'Africa', 'World']"
+      "returns": "an array of names, for the regions containing the current feature"
     },
     {
-      "expression": "overlay_within('regions', name, name != 'World')",
-      "returns": "['South Africa', 'Africa']"
+      "expression": "array_sort(overlay_within(layer:='regions', expression:=\"name\", filter:= population > 10000))",
+      "returns": "an ordered array of names, for the regions containing the current feature and with a population greater than 10000"
     },
     {
-      "expression": "overlay_within('regions', name, limit:=1)",
-      "returns": "['South Africa']"
+      "expression": "overlay_within(layer:='regions', expression:= geom_to_wkt($geometry), limit:=2)",
+      "returns": "an array of geometries (in WKT), for up to two regions containing the current feature"
     }
   ]
 }


### PR DESCRIPTION
backports #39413 and #39549 because they fix actual issues with function description (eg st_within is reversed) and examples (#39097, #39069)