### PR TITLE
[processing] fix method name in GUI wrapper for batch processing

### DIFF
--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -804,7 +804,7 @@ class MultipleLayerWidgetWrapper(WidgetWrapper):
                                                                         False)
                 return [options[i] if isinstance(i, int) else i for i in self.widget.selectedoptions]
         elif self.dialogType == DIALOG_BATCH:
-            return self.widget.value()
+            return self.widget.getValue()
         else:
             options = self._getOptions()
             values = [options[i] if isinstance(i, int) else QgsProcessingModelChildParameterSource.fromStaticValue(i)


### PR DESCRIPTION
## Description

Fixes the bug reported [here](https://www.mail-archive.com/qgis-user@lists.osgeo.org/msg46512.html):
> I'm running QGis 3.10.11 Desktop with GRASS 7.8.4.

> I have a list of rasters that I would like to do r.report (GRASS) for
> each one of them. I'm trying to run r.report with a batch process, but the
> following error is occurring:

```
Message:  
2020-10-31T09:52:36     WARNING    Python error : An error has occurred while executing Python code: See message log (Python Error) for more details.
2020-10-31T09:52:36     WARNING    Wrong or missing parameter value: Raster layer(s) to report on (row 1)
2020-10-31T09:52:36     WARNING    Wrong or missing parameter value: Raster layer(s) to report on (row 2) -- 
Python Error
2020-10-31T09:52:36     WARNING    Traceback (most recent call last):
              File "C:/PROGRA~1/QGIS3~1.10/apps/qgis-ltr/./python/plugins\processing\gui\wrappers.py", line 209, in widgetValue
              return self.value()
              File "C:/PROGRA~1/QGIS3~1.10/apps/qgis-ltr/./python/plugins\processing\gui\wrappers.py", line 806, in value
              return self.widget.value()
             AttributeError: 'BatchInputSelectionPanel' object has no attribute 'value'
```

See also https://github.com/qgis/QGIS/commit/aac040534f61ebd12d4e7b89d699f10f5eb64dfc, https://github.com/qgis/QGIS/commit/943b992ed3c8d115d2aa01e0acba1655190d4fe4, https://github.com/qgis/QGIS/commit/f085f5527658c0a81b9a065a6fcee4d654d16bb6

Should https://github.com/qgis/QGIS/blob/7ab1f19a952f59c07439778684f321f11f64fedf/python/plugins/processing/gui/wrappers.py#L1163
also be fixed although EnumWidgetWrapper is deprecated and moved to c++?

This PR needs to be backported.

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
