### PR TITLE
[processing] swap wrongly set default and minimum value for pixel size in the create constant raster algorithm (fix #39732)

### DIFF
--- a/src/analysis/processing/qgsalgorithmconstantraster.cpp
+++ b/src/analysis/processing/qgsalgorithmconstantraster.cpp
@@ -66,7 +66,7 @@ void QgsConstantRasterAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterExtent( QStringLiteral( "EXTENT" ), QObject::tr( "Desired extent" ) ) );
   addParameter( new QgsProcessingParameterCrs( QStringLiteral( "TARGET_CRS" ), QObject::tr( "Target CRS" ), QStringLiteral( "ProjectCrs" ) ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "PIXEL_SIZE" ), QObject::tr( "Pixel size" ),
-                QgsProcessingParameterNumber::Double, 0.00001, false, 0.01 ) );
+                QgsProcessingParameterNumber::Double, 0.01, false, 0.00001 ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "NUMBER" ), QObject::tr( "Constant value" ),
                 QgsProcessingParameterNumber::Double, 1, false ) );
 


### PR DESCRIPTION
## Description

Seems default and minimum values in the Create Constant Raster algorithm were mixed by mistake, so default was smaller than allowed minimum value.

Fixes #39732