### PR TITLE
Vertex editor: make displayed coordinate precision configurable

### DIFF
--- a/src/app/vertextool/qgsvertexeditor.cpp
+++ b/src/app/vertextool/qgsvertexeditor.cpp
@@ -477,7 +477,8 @@ CoordinateItemDelegate::CoordinateItemDelegate( QObject *parent )
 
 QString CoordinateItemDelegate::displayText( const QVariant &value, const QLocale &locale ) const
 {
-  return locale.toString( value.toDouble(), 'f', 4 );
+  int dp = QgsProject::instance()->readNumEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ), 4 );
+  return locale.toString( value.toDouble(), 'f', dp );
 }
 
 QWidget *CoordinateItemDelegate::createEditor( QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &index ) const
@@ -504,6 +505,7 @@ void CoordinateItemDelegate::setEditorData( QWidget *editor, const QModelIndex &
   QLineEdit *lineEdit = qobject_cast<QLineEdit *>( editor );
   if ( lineEdit && index.isValid() )
   {
-    lineEdit->setText( QLocale().toString( index.data( ).toDouble( ), 'f', 4 ) );
+    int dp = QgsProject::instance()->readNumEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ), 4 );
+    lineEdit->setText( QLocale().toString( index.data( ).toDouble( ), 'f', dp ) );
   }
 }

--- a/src/app/vertextool/qgsvertexeditor.cpp
+++ b/src/app/vertextool/qgsvertexeditor.cpp
@@ -17,6 +17,7 @@
  ***************************************************************************/
 
 #include "qgsvertexeditor.h"
+#include "qgscoordinateutils.h"
 #include "qgsmapcanvas.h"
 #include "qgsmessagelog.h"
 #include "qgslockedfeature.h"
@@ -338,11 +339,6 @@ QgsVertexEditor::QgsVertexEditor( QgsMapCanvas *canvas )
   mTableView = new QTableView( this );
   mTableView->setSelectionMode( QTableWidget::ExtendedSelection );
   mTableView->setSelectionBehavior( QTableWidget::SelectRows );
-  mTableView->setItemDelegateForColumn( 0, new CoordinateItemDelegate( this ) );
-  mTableView->setItemDelegateForColumn( 1, new CoordinateItemDelegate( this ) );
-  mTableView->setItemDelegateForColumn( 2, new CoordinateItemDelegate( this ) );
-  mTableView->setItemDelegateForColumn( 3, new CoordinateItemDelegate( this ) );
-  mTableView->setItemDelegateForColumn( 4, new CoordinateItemDelegate( this ) );
   mTableView->setVisible( false );
   mTableView->setModel( mVertexModel );
   connect( mTableView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsVertexEditor::updateVertexSelection );
@@ -368,6 +364,16 @@ void QgsVertexEditor::updateEditor( QgsLockedFeature *lockedFeature )
     mTableView->setVisible( true );
 
     connect( mLockedFeature, &QgsLockedFeature::selectionChanged, this, &QgsVertexEditor::updateTableSelection );
+
+    if ( mLockedFeature->layer() )
+    {
+      QgsCoordinateReferenceSystem crs = mLockedFeature->layer()->crs();
+      mTableView->setItemDelegateForColumn( 0, new CoordinateItemDelegate( crs, this ) );
+      mTableView->setItemDelegateForColumn( 1, new CoordinateItemDelegate( crs, this ) );
+      mTableView->setItemDelegateForColumn( 2, new CoordinateItemDelegate( crs, this ) );
+      mTableView->setItemDelegateForColumn( 3, new CoordinateItemDelegate( crs, this ) );
+      mTableView->setItemDelegateForColumn( 4, new CoordinateItemDelegate( crs, this ) );
+    }
   }
   else
   {
@@ -469,16 +475,15 @@ void QgsVertexEditor::closeEvent( QCloseEvent *event )
 // CoordinateItemDelegate
 //
 
-CoordinateItemDelegate::CoordinateItemDelegate( QObject *parent )
-  : QStyledItemDelegate( parent )
+CoordinateItemDelegate::CoordinateItemDelegate( const QgsCoordinateReferenceSystem &crs, QObject *parent )
+  : QStyledItemDelegate( parent ), mCrs( crs )
 {
 
 }
 
 QString CoordinateItemDelegate::displayText( const QVariant &value, const QLocale &locale ) const
 {
-  int dp = QgsProject::instance()->readNumEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ), 4 );
-  return locale.toString( value.toDouble(), 'f', dp );
+  return locale.toString( value.toDouble(), 'f', displayDecimalPlaces() );
 }
 
 QWidget *CoordinateItemDelegate::createEditor( QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &index ) const
@@ -505,7 +510,11 @@ void CoordinateItemDelegate::setEditorData( QWidget *editor, const QModelIndex &
   QLineEdit *lineEdit = qobject_cast<QLineEdit *>( editor );
   if ( lineEdit && index.isValid() )
   {
-    int dp = QgsProject::instance()->readNumEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ), 4 );
-    lineEdit->setText( QLocale().toString( index.data( ).toDouble( ), 'f', dp ) );
+    lineEdit->setText( QLocale().toString( index.data( ).toDouble( ), 'f', displayDecimalPlaces() ) );
   }
+}
+
+int CoordinateItemDelegate::displayDecimalPlaces() const
+{
+  return QgsCoordinateUtils::calculateCoordinatePrecisionForCrs( mCrs, QgsProject::instance() );
 }

--- a/src/app/vertextool/qgsvertexeditor.h
+++ b/src/app/vertextool/qgsvertexeditor.h
@@ -133,7 +133,7 @@ class APP_EXPORT CoordinateItemDelegate : public QStyledItemDelegate
 
   public:
 
-    explicit CoordinateItemDelegate( QObject *parent = nullptr );
+    explicit CoordinateItemDelegate( const QgsCoordinateReferenceSystem &crs, QObject *parent = nullptr );
 
     QString displayText( const QVariant &value, const QLocale &locale ) const override;
 
@@ -141,6 +141,11 @@ class APP_EXPORT CoordinateItemDelegate : public QStyledItemDelegate
     QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem & /*option*/, const QModelIndex &index ) const override;
     void setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const override;
     void setEditorData( QWidget *editor, const QModelIndex &index ) const override;
+
+  private:
+    //! Returns number of decimal places to display after the dot
+    int displayDecimalPlaces() const;
+    QgsCoordinateReferenceSystem mCrs;
 };
 
 

--- a/src/core/qgscoordinateutils.cpp
+++ b/src/core/qgscoordinateutils.cpp
@@ -67,6 +67,31 @@ int QgsCoordinateUtils::calculateCoordinatePrecision( double mapUnitsPerPixel, c
   return dp;
 }
 
+int QgsCoordinateUtils::calculateCoordinatePrecisionForCrs( const QgsCoordinateReferenceSystem &crs, QgsProject *project )
+{
+  QgsProject *prj = project;
+  if ( !prj )
+  {
+    prj = QgsProject::instance();
+  }
+
+  bool automatic = prj->readBoolEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/Automatic" ) );
+  if ( !automatic )
+  {
+    return prj->readNumEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ), 6 );
+  }
+
+  QgsUnitTypes::DistanceUnit unit = crs.mapUnits();
+  if ( unit == QgsUnitTypes::DistanceDegrees )
+  {
+    return 8;
+  }
+  else
+  {
+    return 3;
+  }
+}
+
 QString QgsCoordinateUtils::formatCoordinateForProject( QgsProject *project, const QgsPointXY &point, const QgsCoordinateReferenceSystem &destCrs, int precision )
 {
   if ( !project )

--- a/src/core/qgscoordinateutils.h
+++ b/src/core/qgscoordinateutils.h
@@ -61,6 +61,15 @@ class CORE_EXPORT QgsCoordinateUtils
     Q_INVOKABLE static int calculateCoordinatePrecision( double mapUnitsPerPixel, const QgsCoordinateReferenceSystem &mapCrs, QgsProject *project = nullptr );
 
     /**
+     * Calculates coordinate precision for a CRS / Project. Considers CRS units and project settings
+     * \param crs Coordinate system
+     * \param project QGIS project. Takes QgsProject::instance() if NULL
+     * \returns number of decimal places behind the dot
+     * \since QGIS 3.18
+     */
+    Q_INVOKABLE static int calculateCoordinatePrecisionForCrs( const QgsCoordinateReferenceSystem &crs, QgsProject *project = nullptr );
+
+    /**
      * Formats a \a point coordinate for use with the specified \a project, respecting the project's
      * coordinate display settings.
      * \since QGIS 3.2


### PR DESCRIPTION
In the vertex editor, coordinates are displayed with 4 decimal places after the dot. This is a problem e.g. with lat/lon data. This PR sets the decimal places to the value configured in the project.