### PR TITLE
suggest qt5-image-formats-plugins for server

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -450,6 +450,7 @@ Depends:
  qgis-providers (= ${binary:Version}),
  ${shlibs:Depends},
  ${misc:Depends}
+Recommends: qt5-image-formats-plugins
 Conflicts: qgis-mapserver
 Provides: qgis-mapserver
 Replaces: qgis-mapserver


### PR DESCRIPTION
## Description
This allows using webp in the server, see https://github.com/gem/oq-qgis-server/pull/45 for more details, @jef-n I'm not sure at all if this is how it is done, and if it should recommend or suggest, feel free to kill this PR if it is wrong/unwanted.
It would also need to be backported to 3.16