### PR TITLE
[layer tree][ui] Allow users to set a minimum/maximum legend size

### DIFF
--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -713,6 +713,12 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
   cmbLegendDoubleClickAction->setCurrentIndex( mSettings->value( QStringLiteral( "/qgis/legendDoubleClickAction" ), 0 ).toInt() );
 
+  // Legend symbol minimum / maximum values
+  mLegendSymbolMinimumSizeSpinBox->setClearValue( 0.0, tr( "none" ) );
+  mLegendSymbolMaximumSizeSpinBox->setClearValue( 0.0, tr( "none" ) );
+  mLegendSymbolMinimumSizeSpinBox->setValue( mSettings->value( QStringLiteral( "/qgis/legendsymbolMinimumSize" ), 0.1 ).toDouble() );
+  mLegendSymbolMaximumSizeSpinBox->setValue( mSettings->value( QStringLiteral( "/qgis/legendsymbolMaximumSize" ), 20.0 ).toDouble() );
+
   // WMS getLegendGraphic setting
   mLegendGraphicResolutionSpinBox->setValue( mSettings->value( QStringLiteral( "/qgis/defaultLegendGraphicResolution" ), 0 ).toInt() );
 
@@ -1557,6 +1563,10 @@ void QgsOptions::saveOptions()
   mSettings->setValue( QStringLiteral( "/qgis/mainSnappingWidgetMode" ), mSnappingMainDialogComboBox->currentData() );
 
   mSettings->setValue( QStringLiteral( "/qgis/compileExpressions" ), cbxCompileExpressions->isChecked() );
+
+  mSettings->setValue( QStringLiteral( "/qgis/legendsymbolMinimumSize" ), mLegendSymbolMinimumSizeSpinBox->value() );
+  mSettings->setValue( QStringLiteral( "/qgis/legendsymbolMaximumSize" ), mLegendSymbolMaximumSizeSpinBox->value() );
+
   mSettings->setValue( QStringLiteral( "/qgis/defaultLegendGraphicResolution" ), mLegendGraphicResolutionSpinBox->value() );
   mSettings->setValue( QStringLiteral( "/qgis/mapTipsDelay" ), mMapTipsDelaySpinBox->value() );
   mSettings->setEnumValue( QStringLiteral( "/qgis/copyFeatureFormat" ), ( QgsClipboard::CopyFormat )mComboCopyFeatureFormat->currentData().toInt() );

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -472,7 +472,10 @@ class CORE_EXPORT QgsSymbolLegendNode : public QgsLayerTreeModelLegendNode
     mutable QPixmap mPixmap; // cached symbol preview
     QString mLabel;
     bool mSymbolUsesMapUnits;
+
     QSize mIconSize;
+    double mSymbolMinimumSize = 0.5;
+    double mSymbolMaximumSize = 20.0;
 
     QString mTextOnSymbolLabel;
     QgsTextFormat mTextOnSymbolTextFormat;

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -3343,7 +3343,7 @@
                     <item>
                      <widget class="QLabel" name="label_58">
                       <property name="text">
-                       <string>WMS getLegendGraphic Resolution</string>
+                       <string>WMS getLegendGraphic resolution</string>
                       </property>
                      </widget>
                     </item>
@@ -3377,6 +3377,125 @@
                       <property name="maximum">
                        <number>1000000</number>
                       </property>
+                      <property name="suffix">
+                       <string> dpi</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_34">
+                    <item>
+                     <widget class="QLabel" name="labelLegendSymbolMinimumSize">
+                      <property name="text">
+                       <string>Minimum legend symbol size</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="horizontalSpacer_391">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeType">
+                       <enum>QSizePolicy::Preferred</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>30</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                    <item>
+                     <widget class="QgsDoubleSpinBox" name="mLegendSymbolMinimumSizeSpinBox">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="suffix">
+                       <string> mm</string>
+                      </property>
+                      <property name="decimals">
+                       <number>2</number>
+                      </property>
+                      <property name="maximum">
+                       <double>999.00</double>
+                      </property>
+                      <property name="singleStep">
+                       <double>0.200000000000000</double>
+                      </property>
+                      <property name="value">
+                       <double>0.10</double>
+                      </property>
+                      <property name="showClearButton" stdset="0">
+                       <bool>true</bool>
+                      </property>
+                      <property name="toolTip">
+                       <string extracomment="(set value to 0 to skip minimum size)"/>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_34">
+                    <item>
+                     <widget class="QLabel" name="labelLegendSymbolMaximumSize">
+                      <property name="text">
+                       <string>Maximum legend symbol size</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="horizontalSpacer_391">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeType">
+                       <enum>QSizePolicy::Preferred</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>30</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                    <item>
+                     <widget class="QgsDoubleSpinBox" name="mLegendSymbolMaximumSizeSpinBox">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="suffix">
+                       <string> mm</string>
+                      </property>
+                      <property name="decimals">
+                       <number>2</number>
+                      </property>
+                      <property name="maximum">
+                       <double>999.00</double>
+                      </property>
+                      <property name="singleStep">
+                       <double>0.200000000000000</double>
+                      </property>
+                      <property name="value">
+                       <double>20.00</double>
+                      </property>
+                      <property name="showClearButton" stdset="0">
+                       <bool>true</bool>
+                      </property>
+                      <property name="toolTip">
+                       <string extracomment="(set value to 0 to skip maximum size)"/>
+                      </property>
                      </widget>
                     </item>
                    </layout>
@@ -3399,7 +3518,7 @@
                      </sizepolicy>
                     </property>
                     <property name="text">
-                     <string>Delay (ms)</string>
+                     <string>Delay (in milliseconds)</string>
                     </property>
                    </widget>
                   </item>
@@ -3421,6 +3540,9 @@
                   </item>
                   <item>
                    <widget class="QgsSpinBox" name="mMapTipsDelaySpinBox">
+                    <property name="suffix">
+                     <string> ms</string>
+                    </property>
                     <property name="toolTip">
                      <string extracomment="MAP_RESOLUTION or DPI value overloading getMap default value (set 0 to use default)"/>
                     </property>


### PR DESCRIPTION
## Description

This PR fixes a long standing UI/UX issue with the layer tree panel whereas legend icons for symbols using map units can end up taking an undesirably large amount of space in the tree widget.

The PR introduces a new pair of settings, a minimum legend size value and a maximum legend size value. Those are tweaked in the settings dialog's canvas and legend panel:
![image](https://user-images.githubusercontent.com/1728657/97977444-cfcab880-1dfe-11eb-84d1-5e62ac5bd42f.png)

By default, we now max out symbol sized above 32mm by default. Users can set this to 0 to allow symbols to grow infinitely as it was before. But really, why? :wink: 

Here's an example, with symbols clipped to 25 mm:
![image](https://user-images.githubusercontent.com/1728657/97977574-01438400-1dff-11eb-96da-581da28e344d.png)

Funded by SO!GIS
CC @andreasneumann