### PR TITLE
[Oracle] Fix generated columns when evaluate default value is on

### DIFF
--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -1214,7 +1214,7 @@ QVariant QgsOracleProvider::defaultValue( int fieldId ) const
 QString QgsOracleProvider::defaultValueClause( int fieldId ) const
 {
   QString defVal = mDefaultValues.value( fieldId, QString() ).toString();
-  bool isGenerated = mAlwaysGenerated.value( fieldId, false );
+  const bool isGenerated = mAlwaysGenerated.value( fieldId, false );
 
   if ( isGenerated )
   {

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -554,6 +554,7 @@ bool QgsOracleProvider::loadFields()
 {
   mAttributeFields.clear();
   mDefaultValues.clear();
+  mAlwaysGenerated.clear();
 
   QgsOracleConn *conn = connectionRO();
   QSqlQuery qry( *conn );
@@ -1213,6 +1214,12 @@ QVariant QgsOracleProvider::defaultValue( int fieldId ) const
 QString QgsOracleProvider::defaultValueClause( int fieldId ) const
 {
   QString defVal = mDefaultValues.value( fieldId, QString() ).toString();
+  bool isGenerated = mAlwaysGenerated.value( fieldId, false );
+
+  if ( isGenerated )
+  {
+    return defVal;
+  }
 
   if ( !providerProperty( EvaluateDefaultValues, false ).toBool() && !defVal.isEmpty() )
   {
@@ -1667,6 +1674,7 @@ bool QgsOracleProvider::deleteAttributes( const QgsAttributeIds &ids )
       //delete the attribute from mAttributeFields
       mAttributeFields.remove( id );
       mDefaultValues.removeAt( id );
+      mAlwaysGenerated.removeAt( id );
     }
 
     if ( !conn->commit( db ) )

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -30,6 +30,7 @@ from qgis.core import (
     QgsTestUtils,
     QgsFeatureSource,
     QgsFieldConstraints,
+    QgsDataProvider,
     QgsVectorLayerUtils,
     NULL
 )
@@ -1214,3 +1215,19 @@ class ProviderTestCase(FeatureSourceTestCase):
         self.assertEqual(feature.attribute(1), "test:10")
         self.assertFalse(QgsVectorLayerUtils.fieldIsEditable(vl, 1, feature))
         self.assertFalse(QgsVectorLayerUtils.fieldIsEditable(vl, 0, feature))
+
+        # Test insertion with default value evaluation on provider side to be sure
+        # it doesn't fail generated columns
+        vl.dataProvider().setProviderProperty(QgsDataProvider.EvaluateDefaultValues, True)
+
+        vl.startEditing()
+        feature = QgsVectorLayerUtils.createFeature(vl, QgsGeometry(), {0: 8})
+        vl.addFeature(feature)
+        self.assertTrue(feature.id() < 0)
+        # to be fixed
+        # self.assertEqual(QgsVectorLayerUtils.fieldIsEditable(vl, 1, feature), editable)
+        vl.commitChanges()
+
+        feature = vl.getFeature(8)
+        self.assertTrue(feature.isValid())
+        self.assertEqual(feature.attribute(1), "test:8")

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -1224,10 +1224,12 @@ class ProviderTestCase(FeatureSourceTestCase):
         feature = QgsVectorLayerUtils.createFeature(vl, QgsGeometry(), {0: 8})
         vl.addFeature(feature)
         self.assertTrue(feature.id() < 0)
-        # to be fixed
-        # self.assertEqual(QgsVectorLayerUtils.fieldIsEditable(vl, 1, feature), editable)
-        vl.commitChanges()
+        self.assertFalse(QgsVectorLayerUtils.fieldIsEditable(vl, 1, feature))
+        self.assertTrue(QgsVectorLayerUtils.fieldIsEditable(vl, 0, feature))
+        self.assertTrue(vl.commitChanges())
 
         feature = vl.getFeature(8)
         self.assertTrue(feature.isValid())
         self.assertEqual(feature.attribute(1), "test:8")
+        self.assertFalse(QgsVectorLayerUtils.fieldIsEditable(vl, 1, feature))
+        self.assertFalse(QgsVectorLayerUtils.fieldIsEditable(vl, 0, feature))


### PR DESCRIPTION
## Description

We must not evaluate generated columns when the option *Evaluate default value on provider side* is checked, else any feature creation will fail.
