### PR TITLE
cmake: Catch missing sip5 binary

### DIFF
--- a/cmake/FindSIP.py
+++ b/cmake/FindSIP.py
@@ -30,6 +30,8 @@
 # Redistribution and use is allowed according to the terms of the BSD license.
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 
+import sys
+
 try:
     import sipbuild
 except ImportError:  # Code for SIP v4
@@ -48,12 +50,15 @@ except ImportError:  # Code for SIP v4
     else:
         print("sip_module_dir:%s" % sipcfg.sip_mod_dir)
 else:  # Code for SIP v5
+    import shutil
+    sip_bin = shutil.which("sip5")
+    if not sip_bin:
+        sys.exit(1)
+
     print("sip_version:%06.0x" % sipbuild.version.SIP_VERSION)
     print("sip_version_num:%d" % sipbuild.version.SIP_VERSION)
     print("sip_version_str:%s" % sipbuild.version.SIP_VERSION_STR)
-
-    import shutil
-    print("sip_bin:%s" % shutil.which("sip5"))
+    print("sip_bin:%s" % sip_bin)
 
     from distutils.sysconfig import get_python_lib
     python_modules_dir = get_python_lib(plat_specific=1)


### PR DESCRIPTION
I somehow can not compile QGIS on my new Ubuntu 20.10 box due to messed up dependencies. Turns out it is possible to pass SIP detection test when sip5 binary is missing. It gets set to None and CMake is OK with it. This PR prevents reporting SIP found if sip5 binary is missing.
