### PR TITLE
fix webp rendering in server

### DIFF
--- a/src/server/services/wms/qgswmsutils.cpp
+++ b/src/server/services/wms/qgswmsutils.cpp
@@ -152,6 +152,7 @@ namespace QgsWms
         saveFormat = "JPEG";
         break;
       case WEBP:
+        result = img;
         contentType = QStringLiteral( "image/webp" );
         saveFormat = QStringLiteral( "WEBP" );
         break;


### PR DESCRIPTION
## Description

currently, qgis server always returns content-length=0 this change addresses the issue.
This needs to be backported to 3.16