### PR TITLE
traverse tree in 2D rendering by map error

### DIFF
--- a/src/core/pointcloud/qgspointcloudindex.cpp
+++ b/src/core/pointcloud/qgspointcloudindex.cpp
@@ -150,25 +150,7 @@ QgsPointCloudIndex::QgsPointCloudIndex() = default;
 
 QgsPointCloudIndex::~QgsPointCloudIndex() = default;
 
-QList<IndexedPointCloudNode> QgsPointCloudIndex::traverseTree( const QgsRectangle &extent, IndexedPointCloudNode n, int maxDepth )
-{
-  QList<IndexedPointCloudNode> nodes;
-
-  if ( !extent.intersects( nodeMapExtent( n ) ) )
-    return nodes;
-
-  nodes.append( n );
-
-  for ( auto nn : children( n ) )
-  {
-    if ( maxDepth > 0 )
-      nodes += traverseTree( extent, nn, maxDepth - 1 );
-  }
-
-  return nodes;
-}
-
-QList<IndexedPointCloudNode> QgsPointCloudIndex::children( const IndexedPointCloudNode &n )
+QList<IndexedPointCloudNode> QgsPointCloudIndex::nodeChildren( const IndexedPointCloudNode &n ) const
 {
   Q_ASSERT( mHierarchy.contains( n ) );
   QList<IndexedPointCloudNode> lst;

--- a/src/core/pointcloud/qgspointcloudindex.h
+++ b/src/core/pointcloud/qgspointcloudindex.h
@@ -153,11 +153,8 @@ class CORE_EXPORT QgsPointCloudIndex: public QObject
     //! Returns whether the octree contain given node
     bool hasNode( const IndexedPointCloudNode &n ) const { return mHierarchy.contains( n ); }
 
-    //! Traverses tree and returns all nodes in specified depth
-    QList<IndexedPointCloudNode> traverseTree( const QgsRectangle &extent, IndexedPointCloudNode n, int maxDepth = 3 );
-
     //! Returns all children of node
-    QList<IndexedPointCloudNode> children( const IndexedPointCloudNode &n );
+    QList<IndexedPointCloudNode> nodeChildren( const IndexedPointCloudNode &n ) const;
 
     //! Returns all attributes that are stored in the file
     QgsPointCloudAttributeCollection attributes() const;

--- a/src/core/pointcloud/qgspointcloudrenderer.h
+++ b/src/core/pointcloud/qgspointcloudrenderer.h
@@ -71,10 +71,14 @@ class CORE_EXPORT QgsPointCloudRendererConfig
     //! Sets color ramp
     void setColorRamp( const QgsColorRamp *value );
 
+    //! Returns maximum allowed screen error in pixels
+    float maximumScreenError() const;
+
   private:
     double mZMin = 0, mZMax = 0;
     int mPenWidth = 1;
     std::unique_ptr<QgsColorRamp> mColorRamp;
+    float mMaximumScreenError = 5;
 };
 
 ///@endcond
@@ -100,6 +104,10 @@ class CORE_EXPORT QgsPointCloudLayerRenderer: public QgsMapLayerRenderer
     bool render() override;
 
   private:
+
+    //! Traverses tree and returns all nodes in specified depth
+    QList<IndexedPointCloudNode> traverseTree( const QgsPointCloudIndex *pc, const QgsRenderContext &context, IndexedPointCloudNode n, float maxErrorPixels, float nodeErrorPixels );
+
     QgsPointCloudLayer *mLayer = nullptr;
 
     QgsPointCloudRendererConfig mConfig;


### PR DESCRIPTION
Determines how many nodes level to load in 2D renderer based on screen error. Same approach that is already implemented in 3D renderer.

![progressive_2d_renderer](https://user-images.githubusercontent.com/804608/98217717-280ed100-1f4b-11eb-99be-3511b7d51fa8.gif)

see https://github.com/wonder-sk/point-cloud-experiments/issues/15