### PR TITLE
Fix server virtual layers load

### DIFF
--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -43,7 +43,11 @@ const QgsProject *QgsConfigCache::project( const QString &path, QgsServerSetting
 {
   if ( ! mProjectCache[ path ] )
   {
+
     std::unique_ptr<QgsProject> prj( new QgsProject() );
+
+    // This is required by virtual layers that call QgsProject::instance() inside the constructor :(
+    QgsProject::setInstance( prj.get() );
 
     QgsStoreBadLayerInfo *badLayerHandler = new QgsStoreBadLayerInfo();
     prj->setBadLayerHandler( badLayerHandler );
@@ -113,7 +117,6 @@ const QgsProject *QgsConfigCache::project( const QString &path, QgsServerSetting
     }
   }
   return mProjectCache[ path ];
-
 }
 
 QDomDocument *QgsConfigCache::xmlDocument( const QString &filePath )


### PR DESCRIPTION
Another chapter of the tragic https://github.com/qgis/QGIS/pull/38488 saga.

This happens because virtual layers ctor calls reloadData which calls project::instance but on server it just calls the wrong instance (because initially is nullptr and on subsequent calls it might be and instance of a different project).
