### PR TITLE
test_qgsproject.py: no longer used deprecated way of importing ogr

### DIFF
--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -15,7 +15,7 @@ __copyright__ = 'Copyright 2015, The QGIS Project'
 
 import os
 import re
-import ogr
+from osgeo import ogr
 import codecs
 from io import BytesIO
 from zipfile import ZipFile


### PR DESCRIPTION
This has gone with GDAL 3.2.0
