### PR TITLE
Support compiling qgis_analysis when QT_NO_PRINTER is defined.

### DIFF
--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -95,10 +95,6 @@ SET(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmjoinbynearest.cpp
   processing/qgsalgorithmjoinwithlines.cpp
   processing/qgsalgorithmkmeansclustering.cpp
-  processing/qgsalgorithmlayoutatlastoimage.cpp
-  processing/qgsalgorithmlayoutatlastopdf.cpp
-  processing/qgsalgorithmlayouttoimage.cpp
-  processing/qgsalgorithmlayouttopdf.cpp
   processing/qgsalgorithmlinedensity.cpp
   processing/qgsalgorithmlineintersection.cpp
   processing/qgsalgorithmlinesubstring.cpp
@@ -373,6 +369,16 @@ SET(QGIS_ANALYSIS_HDRS
   vector/qgsgeometrysnappersinglesource.h
   vector/qgszonalstatistics.h
 )
+
+IF(TARGET Qt5::PrintSupport)
+  SET(QGIS_ANALYSIS_SRCS ${QGIS_ANALYSIS_SRCS}
+
+    processing/qgsalgorithmlayoutatlastoimage.cpp
+    processing/qgsalgorithmlayoutatlastopdf.cpp
+    processing/qgsalgorithmlayouttoimage.cpp
+    processing/qgsalgorithmlayouttopdf.cpp
+  )
+ENDIF()
 
 FIND_PACKAGE(EXIV2 REQUIRED)
 

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -91,10 +91,12 @@
 #include "qgsalgorithminterpolatepoint.h"
 #include "qgsalgorithmintersection.h"
 #include "qgsalgorithmkmeansclustering.h"
+#ifndef QT_NO_PRINTER
 #include "qgsalgorithmlayoutatlastoimage.h"
 #include "qgsalgorithmlayoutatlastopdf.h"
 #include "qgsalgorithmlayouttoimage.h"
 #include "qgsalgorithmlayouttopdf.h"
+#endif
 #include "qgsalgorithmlinedensity.h"
 #include "qgsalgorithmlineintersection.h"
 #include "qgsalgorithmlinesubstring.h"
@@ -330,10 +332,12 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsKMeansClusteringAlgorithm() );
   addAlgorithm( new QgsLayerToBookmarksAlgorithm() );
   addAlgorithm( new QgsLayoutMapExtentToLayerAlgorithm() );
+#ifndef QT_NO_PRINTER
   addAlgorithm( new QgsLayoutAtlasToImageAlgorithm() );
   addAlgorithm( new QgsLayoutAtlasToPdfAlgorithm() );
   addAlgorithm( new QgsLayoutToImageAlgorithm() );
   addAlgorithm( new QgsLayoutToPdfAlgorithm() );
+#endif
   addAlgorithm( new QgsLineDensityAlgorithm() );
   addAlgorithm( new QgsLineIntersectionAlgorithm() );
   addAlgorithm( new QgsLineSubstringAlgorithm() );

--- a/tests/src/analysis/testqgsprocessingalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingalgs.cpp
@@ -143,10 +143,13 @@ class TestQgsProcessingAlgs: public QObject
 
     void saveLog();
     void setProjectVariable();
+
+#ifndef QT_NO_PRINTER
     void exportLayoutPdf();
     void exportLayoutPng();
     void exportAtlasLayoutPdf();
     void exportAtlasLayoutPng();
+#endif
 
     void tinMeshCreation();
     void exportMeshVertices();
@@ -4593,6 +4596,7 @@ void TestQgsProcessingAlgs::setProjectVariable()
   QCOMPARE( scope->variable( QStringLiteral( "my_var" ) ).toInt(), 13 );
 }
 
+#ifndef QT_NO_PRINTER
 void TestQgsProcessingAlgs::exportLayoutPdf()
 {
   QgsProject p;
@@ -4789,6 +4793,7 @@ void TestQgsProcessingAlgs::exportAtlasLayoutPng()
   QVERIFY( QFile::exists( QDir::tempPath() + "/my_atlas/custom_10.png" ) );
   QVERIFY( imageCheck( "export_atlas_custom_layers", QDir::tempPath() + "/my_atlas/custom_1.png" ) );
 }
+#endif
 
 void TestQgsProcessingAlgs::tinMeshCreation()
 {


### PR DESCRIPTION
This commit allow compilation for iOS target where QtPrinter isn't available.
Affected classes:
* QgsLayoutAtlasToImageAlgorithm
* QgsLayoutAtlasToPdfAlgorithm
* QgsLayoutToImageAlgorithm
* QgsLayoutToPdfAlgorithm

**Related links**
https://forum.qt.io/topic/107731/printsupport-missing-on-ios
https://bugreports.qt.io/browse/QTBUG-34555