### PR TITLE
Limit number of rows for Postgis retrieveLayerTypes and fix PostGIS browser issues

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1924,7 +1924,17 @@ void QgsPostgresConn::retrieveLayerTypes( QVector<QgsPostgresLayerProperty *> &l
 
       sql += QLatin1String( ") " );
 
-      sql += " FROM " + table;
+      if ( type == QgsWkbTypes::Unknown )
+      {
+        sql += QStringLiteral( " FROM (SELECT %1 from %2 LIMIT %3) as _unused" )
+               .arg( quotedIdentifier( layerProperty.geometryColName ) )
+               .arg( table )
+               .arg( GEOM_TYPE_SELECT_LIMIT );
+      }
+      else
+      {
+        sql += " FROM " + table;
+      }
 
       QgsDebugMsgLevel( "Geometry types,srids and dims query: " + sql, 2 );
 

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -489,7 +489,9 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
       gtableName = QStringLiteral( "geometry_columns" );
     }
     // Geography since postgis 1.5
-    else if ( i == SctGeography && mPostgisVersionMajor >= 1 && mPostgisVersionMinor >= 5 )
+    else if ( i == SctGeography
+              && ( mPostgisVersionMajor >= 2
+                   || ( mPostgisVersionMajor == 1 && mPostgisVersionMinor >= 5 ) ) )
     {
       tableName  = QStringLiteral( "l.f_table_name" );
       schemaName = QStringLiteral( "l.f_table_schema" );

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -314,7 +314,7 @@ QgsPGLayerItem::QgsPGLayerItem( QgsDataItem *parent, const QString &name, const 
   : QgsLayerItem( parent, name, path, QString(), layerType, layerProperty.isRaster ? QStringLiteral( "postgresraster" ) : QStringLiteral( "postgres" ) )
   , mLayerProperty( layerProperty )
 {
-  mCapabilities |= Delete | Fertile;
+  mCapabilities |= Delete | Fertile | Fast;
   mUri = createUri();
   // No rasters for now
   setState( layerProperty.isRaster ? Populated : NotPopulated );

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -428,12 +428,20 @@ QVector<QgsDataItem *> QgsPGSchemaItem::createChildren()
       }
     }
 
+    QgsDataItem *prev = nullptr;
     for ( int i = 0; i < layerProperty.size(); i++ )
     {
       QgsDataItem *layerItem = nullptr;
       layerItem = createLayer( layerProperty.at( i ) );
       if ( layerItem )
+      {
+        if ( prev && prev->name().indexOf( layerItem->name() ) == 0 )
+        {
+          layerItem->setName( layerItem->name() + QString( ":" ) + QgsPostgresConn::displayStringForWkbType( layerProperty.types.at( i ) ) );
+        }
         items.append( layerItem );
+      }
+      prev = layerItem;
     }
   }
 

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -198,7 +198,7 @@ QList<QVariantList> QgsPostgresProviderConnection::executeSql( const QString &sq
   return executeSqlPrivate( sql, true, feedback );
 }
 
-QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QString &sql, bool resolveTypes, QgsFeedback *feedback ) const
+QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QString &sql, bool resolveTypes, QgsFeedback *feedback, QgsPostgresConn *pgconn ) const
 {
   QList<QVariantList> results;
 
@@ -209,7 +209,7 @@ QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QStr
   }
 
   const QgsDataSourceUri dsUri { uri() };
-  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( dsUri.connectionInfo( false ) );
+  QgsPostgresConn *conn = pgconn ? pgconn : QgsPostgresConnPool::instance()->acquireConnection( dsUri.connectionInfo( false ) );
   if ( !conn )
   {
     throw QgsProviderConnectionException( QObject::tr( "Connection failed: %1" ).arg( uri() ) );
@@ -269,7 +269,7 @@ QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QStr
             break;
           }
           const Oid oid { res.PQftype( rowIdx ) };
-          QList<QVariantList> typeRes { executeSqlPrivate( QStringLiteral( "SELECT typname FROM pg_type WHERE oid = %1" ).arg( oid ), false ) };
+          QList<QVariantList> typeRes { executeSqlPrivate( QStringLiteral( "SELECT typname FROM pg_type WHERE oid = %1" ).arg( oid ), false, nullptr, conn ) };
           // Set the default to string
           QVariant::Type vType { QVariant::Type::String };
           if ( typeRes.size() > 0 && typeRes.first().size() > 0 )
@@ -357,7 +357,8 @@ QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QStr
         results.push_back( row );
       }
     }
-    QgsPostgresConnPool::instance()->releaseConnection( conn );
+    if ( ! pgconn )
+      QgsPostgresConnPool::instance()->releaseConnection( conn );
     if ( ! errCause.isEmpty() )
     {
       throw QgsProviderConnectionException( errCause );

--- a/src/providers/postgres/qgspostgresproviderconnection.h
+++ b/src/providers/postgres/qgspostgresproviderconnection.h
@@ -61,7 +61,7 @@ class QgsPostgresProviderConnection : public QgsAbstractDatabaseProviderConnecti
 
   private:
 
-    QList<QVariantList> executeSqlPrivate( const QString &sql, bool resolveTypes = true, QgsFeedback *feedback = nullptr ) const;
+    QList<QVariantList> executeSqlPrivate( const QString &sql, bool resolveTypes = true, QgsFeedback *feedback = nullptr, class QgsPostgresConn *pgconn = nullptr ) const;
     void setDefaultCapabilities();
     void dropTablePrivate( const QString &schema, const QString &name ) const;
     void renameTablePrivate( const QString &schema, const QString &name, const QString &newName ) const;


### PR DESCRIPTION
## Description

I have various PostgreSQL databases with many millions of objects and with QGIS 3.16 when using the PostGIS dataprovider for inspecting tables/fields it takes over 15 minutes for each table to open.

The reason is that the whole table is read to determine the geometry types.  

"Don't resolve type of unrestricted colums" or "use estimated metadata" makes no difference.

This PR only inspects the first GEOM_TYPE_SELECT_LIMIT rows.

See https://github.com/qgis/QGIS/issues/39897

EDIT: Note that part of the problem is that tables are hidden when "Don't resolve type of unrestricted colums" is active, but they ARE scanned anyway when clicking on OTHER tables from the same connection in the PostGIS browser.

EDIT2: Note that there is another problem:

```
2020-11-09T11:58:50     WARNING    Unsupported spatial column type Geography
```
is reported because this test is broken since QGis 3.16:

```
else if ( i == SctGeography && mPostgisVersionMajor >= 1 && mPostgisVersionMinor >= 5 )
```

it should be:

```
else if ( i == SctGeography && (mPostgisVersionMajor >= 2 || mPostgisVersionMajor == 1 && mPostgisVersionMinor >= 5) )
```
Will add this to this PR.

EDIT 3:

When restarting QGIS (after having inspected a `geometry` table in the first session) I get 2 eternal hourglasses (one for the linestring and one for the polygon version).

![Screenshot from 2020-11-10 11-54-10](https://user-images.githubusercontent.com/1104260/98665184-9e487480-234b-11eb-8564-4a702351822d.png)

QGIS hangs on exit with:

```
src/core/qgsdataitem.cpp:370 : (deleteLater) [431651ms] mFutureWatcher not finished -> schedule to delete later
src/core/qgsdataitem.cpp:370 : (deleteLater) [0ms] mFutureWatcher not finished -> schedule to delete later
```

Will see if I can find the cause of that issue.

EDIT 4: 

The root cause is a deadlock due to the max number of connections:
https://github.com/qgis/QGIS/blob/8c06a1ac43983b3d9b3a75246d3d68dc22be834e/src/core/qgsapplication.cpp#L122

Raising from `4` to `8` fixes this issue or applying https://github.com/qgis/QGIS/pull/39885/commits/e8156c9ec26bdb85cd5ea7cdc22335729d24f136

This matches inspection of Postgres during the hang, there are 4 queries pending with results.

This fixes the hourglass issues but note:

![Screenshot from 2020-11-12 14-34-00](https://user-images.githubusercontent.com/1104260/98946484-3c773e80-24f4-11eb-9e73-145fbdb25235.png)

After expanding "Fields" from both the "inrichtingselement" layers and restarting,
the top "inrichtingselement" layer with `Points` misses the expand black triangle!

A right-mouse "Refresh" of the enclosing schema fixes this...

Applying https://github.com/qgis/QGIS/pull/39885/commits/09ed20b790b8c9ee29380a32fb70cb16d70b8091 fixes this.

![Screenshot from 2020-11-12 19-52-03](https://user-images.githubusercontent.com/1104260/98983098-9ee63400-2520-11eb-81aa-c084ae61ed1b.png)

EDIT 5:

I added a commit which caches the Postgres connection and reduces deadlocks:

https://github.com/qgis/QGIS/pull/39885/commits/18cc7ba332e6e40d0e5521f7b9bec90850f87390

This nested call of `executeSqlPrivate()` within `executeSqlPrivate()` causes the deadlock when 2 two threads acquire the first connection but both wait when trying to acquire this second connection:

https://github.com/qgis/QGIS/blob/b4811f2b0ba0b6006b1d27ec6e8f1aa098dc178b/src/providers/postgres/qgspostgresproviderconnection.cpp#L272


<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
