### PR TITLE
add qt5-image-formats-plugins to qgis server

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -485,6 +485,7 @@ Architecture: any
 Depends:
  qgis-providers (= ${binary:Version}),
  python3-qgis (= ${binary:Version}),
+ qt5-image-formats-plugins,
  ${shlibs:Depends},
  ${misc:Depends}
 Description: QGIS server providing various OGC services


### PR DESCRIPTION
Follow up to https://github.com/qgis/QGIS/commit/71a755a023d65494328a882fbacfff7dad611158
the qt5-image-formats-plugins dependency was added to qgis-common but qgis-server does not depend on qgis-common.

@jef-n again not sure if you want it this way or if qgis-server should depend on qgis.common. 