### PR TITLE
add qt5-image-formats-plugins to qgis server

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -485,6 +485,7 @@ Architecture: any
 Depends:
  qgis-providers (= ${binary:Version}),
  python3-qgis (= ${binary:Version}),
+ qt5-image-formats-plugins,
  ${shlibs:Depends},
  ${misc:Depends}
 Description: QGIS server providing various OGC services


### PR DESCRIPTION
Follow up to 71a755a
the qt5-image-formats-plugins dependency was added to qgis-common
but qgis-server does not depend on qgis-common.

@jef-n again not sure if you want it this way or if qgis-server should
depend on qgis.common.

## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
