### PR TITLE
3d ui tweaks and refinements

### DIFF
--- a/src/app/3d/qgs3dmapcanvasdockwidget.h
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.h
@@ -78,8 +78,12 @@ class APP_EXPORT Qgs3DMapCanvasDockWidget : public QgsDockWidget
     Qgs3DMapToolIdentify *mMapToolIdentify = nullptr;
     Qgs3DMapToolMeasureLine *mMapToolMeasureLine = nullptr;
     QMenu *mMapThemeMenu = nullptr;
+    QMenu *mOptionsMenu = nullptr;
     QList<QAction *> mMapThemeMenuPresetActions;
     QToolButton *mBtnMapThemes = nullptr;
+    QAction *mActionEnableShadows = nullptr;
+    QAction *mActionEnableEyeDome = nullptr;
+    QToolButton *mBtnOptions = nullptr;
 };
 
 #endif // QGS3DMAPCANVASDOCKWIDGET_H

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -75,6 +75,10 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
   spinMapResolution->setClearValue( 512 );
   spinScreenError->setClearValue( 3 );
   spinGroundError->setClearValue( 1 );
+  edlStrengthSpinBox->setClearValue( 1000 );
+  edlDistanceSpinBox->setClearValue( 1 );
+  mDebugShadowMapSizeSpinBox->setClearValue( 0.1 );
+  mDebugDepthMapSizeSpinBox->setClearValue( 0.1 );
 
   cboTerrainLayer->setAllowEmptyLayer( true );
   cboTerrainLayer->setFilters( QgsMapLayerProxyModel::RasterLayer );

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -205,8 +205,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>239</width>
-                <height>251</height>
+                <width>707</width>
+                <height>604</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutTerrain">
@@ -393,8 +393,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>77</width>
-                <height>43</height>
+                <width>707</width>
+                <height>604</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutLight">
@@ -477,7 +477,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>699</width>
+                <width>707</width>
                 <height>604</height>
                </rect>
               </property>
@@ -567,7 +567,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>699</width>
+                <width>707</width>
                 <height>604</height>
                </rect>
               </property>
@@ -666,9 +666,9 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>-22</y>
-                <width>685</width>
-                <height>632</height>
+                <y>-66</y>
+                <width>693</width>
+                <height>670</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutAdvanced">
@@ -806,7 +806,7 @@
                   <item row="2" column="0">
                    <widget class="QGroupBox" name="mDebugShadowMapGroupBox">
                     <property name="title">
-                     <string>Debug shadow map</string>
+                     <string>Debug Shadow Map</string>
                     </property>
                     <property name="checkable">
                      <bool>true</bool>
@@ -833,7 +833,7 @@
                       </widget>
                      </item>
                      <item row="1" column="1">
-                      <widget class="QDoubleSpinBox" name="mDebugShadowMapSizeSpinBox">
+                      <widget class="QgsDoubleSpinBox" name="mDebugShadowMapSizeSpinBox">
                        <property name="maximum">
                         <double>1.000000000000000</double>
                        </property>
@@ -851,7 +851,7 @@
                   <item row="3" column="0">
                    <widget class="QGroupBox" name="mDebugDepthMapGroupBox">
                     <property name="title">
-                     <string>Debug depth map</string>
+                     <string>Debug Depth Map</string>
                     </property>
                     <property name="checkable">
                      <bool>true</bool>
@@ -878,7 +878,7 @@
                       </widget>
                      </item>
                      <item row="1" column="1">
-                      <widget class="QDoubleSpinBox" name="mDebugDepthMapSizeSpinBox">
+                      <widget class="QgsDoubleSpinBox" name="mDebugDepthMapSizeSpinBox">
                        <property name="maximum">
                         <double>1.000000000000000</double>
                        </property>
@@ -896,7 +896,7 @@
                   <item row="1" column="0">
                    <widget class="QGroupBox" name="edlGroupBox">
                     <property name="title">
-                     <string>Eye Dome Lighting</string>
+                     <string>Show Eye Dome Lighting</string>
                     </property>
                     <property name="checkable">
                      <bool>true</bool>
@@ -906,9 +906,12 @@
                     </property>
                     <layout class="QGridLayout" name="gridLayout_2">
                      <item row="0" column="1">
-                      <widget class="QDoubleSpinBox" name="edlStrengthSpinBox">
+                      <widget class="QgsDoubleSpinBox" name="edlStrengthSpinBox">
                        <property name="maximum">
                         <double>10000.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>100.000000000000000</double>
                        </property>
                        <property name="value">
                         <double>1000.000000000000000</double>
@@ -918,19 +921,19 @@
                      <item row="0" column="0">
                       <widget class="QLabel" name="label">
                        <property name="text">
-                        <string>Eye dome lighting strength</string>
+                        <string>Lighting strength</string>
                        </property>
                       </widget>
                      </item>
                      <item row="1" column="0">
                       <widget class="QLabel" name="label_2">
                        <property name="text">
-                        <string>Eye dome lighting distance</string>
+                        <string>Lighting distance</string>
                        </property>
                       </widget>
                      </item>
                      <item row="1" column="1">
-                      <widget class="QSpinBox" name="edlDistanceSpinBox">
+                      <widget class="QgsSpinBox" name="edlDistanceSpinBox">
                        <property name="minimum">
                         <number>1</number>
                        </property>
@@ -979,6 +982,11 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
@@ -994,11 +1002,6 @@
    <class>QgsMapLayerComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsmaplayercombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsLightsWidget</class>


### PR DESCRIPTION
- fix capitalisation and appearance of eye dome lighting settings
- add quick toggles for shadows and eye dome by changing the options button to a drop down menu containing these actions. It's very handy to be able to quickly toggle these options without having to open the full config dialog and apply new map settings