### PR TITLE
Fix duplicate parameter warnings shown when loading models

### DIFF
--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -1348,6 +1348,9 @@ QVariant QgsProcessingModelAlgorithm::toVariant() const
   QVariantMap paramDefMap;
   for ( const QgsProcessingParameterDefinition *def : mParameters )
   {
+    if ( def->name() == QStringLiteral( "VERBOSE_LOG" ) )
+      continue;
+
     paramDefMap.insert( def->name(), def->toVariantMap() );
   }
   map.insert( QStringLiteral( "parameterDefinitions" ), paramDefMap );
@@ -1420,7 +1423,12 @@ bool QgsProcessingModelAlgorithm::loadVariant( const QVariant &model )
     // otherwise models may become unusable (e.g. due to removed plugins providing algs/parameters)
     // with no way for users to repair them
     if ( param )
+    {
+      if ( param->name() == QLatin1String( "VERBOSE_LOG" ) )
+        return; // internal parameter -- some versions of QGIS incorrectly stored this in the model definition file
+
       addParameter( param.release() );
+    }
     else
     {
       QVariantMap map = value.toMap();

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -9677,7 +9677,12 @@ void TestQgsProcessing::modelerAlgorithm()
   alg5.setDesignerParameterValues( lastParams );
 
   QDomDocument doc = QDomDocument( "model" );
-  QDomElement elem = QgsXmlUtils::writeVariant( alg5.toVariant(), doc );
+  alg5.initAlgorithm();
+  const QVariant v = alg5.toVariant();
+  // make sure private parameters weren't included in the definition
+  QVERIFY( !v.toMap().value( QStringLiteral( "parameterDefinitions" ) ).toMap().contains( QStringLiteral( "VERBOSE_LOG" ) ) );
+
+  QDomElement elem = QgsXmlUtils::writeVariant( v, doc );
   doc.appendChild( elem );
 
   QgsProcessingModelAlgorithm alg6;


### PR DESCRIPTION
This is caused because the internal hidden VERBOSE_LOG parameter was
always being added to the model twice, so now we skip it during
writing/reading the model
