### PR TITLE
[temporal] Update the identify tool to take temporal range context in to account

### DIFF
--- a/python/core/auto_generated/qgsidentifycontext.sip.in
+++ b/python/core/auto_generated/qgsidentifycontext.sip.in
@@ -1,0 +1,61 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsidentifycontext.h                                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsIdentifyContext
+{
+%Docstring
+Identify contexts are used to encapsulate the settings to be used to perform
+an identify action.
+
+.. versionadded:: 3.16.1
+%End
+
+%TypeHeaderCode
+#include "qgsidentifycontext.h"
+%End
+  public:
+
+    QgsIdentifyContext();
+%Docstring
+Constructor for QgsIdentifyContext
+%End
+
+    void setTemporalRange( const QgsDateTimeRange &range );
+%Docstring
+Set datetime ``range`` to be used with the identify action.
+
+.. seealso:: :py:func:`temporalRange`
+
+.. seealso:: :py:func:`isTemporal`
+%End
+
+    const QgsDateTimeRange &temporalRange() const;
+%Docstring
+Returns the datetime range to be used with the identify action.
+
+.. seealso:: :py:func:`setTemporalRange`
+
+.. seealso:: :py:func:`isTemporal`
+%End
+
+    bool isTemporal() const;
+%Docstring
+Returns ``True`` if the temporal range setting is enabled.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsidentifycontext.h                                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -91,6 +91,7 @@
 %Include auto_generated/qgshistogram.sip
 %Include auto_generated/qgshstoreutils.sip
 %Include auto_generated/qgshtmlutils.sip
+%Include auto_generated/qgsidentifycontext.sip
 %Include auto_generated/qgsimagecache.sip
 %Include auto_generated/qgsinterval.sip
 %Include auto_generated/qgsjsonutils.sip

--- a/python/gui/auto_generated/qgsmaptoolidentify.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolidentify.sip.in
@@ -85,7 +85,7 @@ constructor
     virtual void deactivate();
 
 
-    QList<QgsMapToolIdentify::IdentifyResult> identify( int x, int y, const QList<QgsMapLayer *> &layerList = QList<QgsMapLayer *>(), IdentifyMode mode = DefaultQgsSetting );
+    QList<QgsMapToolIdentify::IdentifyResult> identify( int x, int y, const QList<QgsMapLayer *> &layerList = QList<QgsMapLayer *>(), IdentifyMode mode = DefaultQgsSetting, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
 %Docstring
 Performs the identification.
 
@@ -93,11 +93,12 @@ Performs the identification.
 :param y: y coordinates of mouseEvent
 :param layerList: Performs the identification within the given list of layers. Default value is an empty list, i.e. uses all the layers.
 :param mode: Identification mode. Can use QGIS default settings or a defined mode. Default mode is DefaultQgsSetting.
+:param identifyContext: Identify context object.
 
 :return: a list of IdentifyResult
 %End
 
-    QList<QgsMapToolIdentify::IdentifyResult> identify( int x, int y, IdentifyMode mode, LayerType layerType = AllLayers );
+    QList<QgsMapToolIdentify::IdentifyResult> identify( int x, int y, IdentifyMode mode, LayerType layerType = AllLayers, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
 %Docstring
 Performs the identification.
 To avoid being forced to specify IdentifyMode with a list of layers
@@ -107,15 +108,16 @@ this has been made private and two publics methods are offered
 :param y: y coordinates of mouseEvent
 :param mode: Identification mode. Can use QGIS default settings or a defined mode.
 :param layerType: Only performs identification in a certain type of layers (raster, vector, mesh). Default value is AllLayers.
+:param identifyContext: Identify context object.
 
 :return: a list of IdentifyResult
 %End
 
-    QList<QgsMapToolIdentify::IdentifyResult> identify( const QgsGeometry &geometry, IdentifyMode mode, LayerType layerType );
+    QList<QgsMapToolIdentify::IdentifyResult> identify( const QgsGeometry &geometry, IdentifyMode mode, LayerType layerType, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
 %Docstring
 Performs identification based on a geometry (in map coordinates)
 %End
-    QList<QgsMapToolIdentify::IdentifyResult> identify( const QgsGeometry &geometry, IdentifyMode mode, const QList<QgsMapLayer *> &layerList, LayerType layerType );
+    QList<QgsMapToolIdentify::IdentifyResult> identify( const QgsGeometry &geometry, IdentifyMode mode, const QList<QgsMapLayer *> &layerList, LayerType layerType, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
 %Docstring
 Performs identification based on a geometry (in map coordinates)
 %End
@@ -137,7 +139,7 @@ this menu can also be customized
 
   protected:
 
-    QList<QgsMapToolIdentify::IdentifyResult> identify( int x, int y, IdentifyMode mode,  const QList<QgsMapLayer *> &layerList, LayerType layerType = AllLayers );
+    QList<QgsMapToolIdentify::IdentifyResult> identify( int x, int y, IdentifyMode mode,  const QList<QgsMapLayer *> &layerList, LayerType layerType = AllLayers, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
 %Docstring
 Performs the identification.
 To avoid being forced to specify IdentifyMode with a list of layers
@@ -148,20 +150,40 @@ this has been made private and two publics methods are offered
 :param mode: Identification mode. Can use QGIS default settings or a defined mode.
 :param layerList: Performs the identification within the given list of layers.
 :param layerType: Only performs identification in a certain type of layers (raster, vector, mesh).
+:param identifyContext: Identify context object.
 
 :return: a list of IdentifyResult
 %End
 
 
-    bool identifyLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMapLayer *layer, const QgsPointXY &point, const QgsRectangle &viewExtent, double mapUnitsPerPixel, QgsMapToolIdentify::LayerType layerType = AllLayers );
+    bool identifyLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMapLayer *layer, const QgsPointXY &point, const QgsRectangle &viewExtent, double mapUnitsPerPixel, QgsMapToolIdentify::LayerType layerType = AllLayers, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
 %Docstring
 Call the right method depending on layer type
 %End
 
-    bool identifyRasterLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsRasterLayer *layer, QgsPointXY point, const QgsRectangle &viewExtent, double mapUnitsPerPixel );
-    bool identifyVectorLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorLayer *layer, const QgsPointXY &point );
+    bool identifyRasterLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsRasterLayer *layer, QgsPointXY point, const QgsRectangle &viewExtent, double mapUnitsPerPixel, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
+%Docstring
+Performs the identification against a given raster layer.
 
-    bool identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMeshLayer *layer, const QgsPointXY &point );
+:param results: list of identify results
+:param layer: raster layer to identify from
+:param point: point coordinate to identify
+:param viewExtent: view extent
+:param mapUnitsPerPixel: map units per pixel value
+:param identifyContext: identify context object
+%End
+
+    bool identifyVectorLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorLayer *layer, const QgsPointXY &point, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
+%Docstring
+Performs the identification against a given vector layer.
+
+:param results: list of identify results
+:param layer: raster layer to identify from
+:param point: point coordinate to identify
+:param identifyContext: identify context object
+%End
+
+    bool identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMeshLayer *layer, const QgsPointXY &point, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
 %Docstring
 Identifies data from active scalar and vector dataset from the mesh layer
 

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -22,6 +22,7 @@
 #include "qgsfields.h"
 #include "qgsgeometry.h"
 #include "qgslogger.h"
+#include "qgsidentifycontext.h"
 #include "qgsidentifyresultsdialog.h"
 #include "qgsidentifymenu.h"
 #include "qgsmapcanvas.h"
@@ -129,7 +130,10 @@ void QgsMapToolIdentifyAction::identifyFromGeometry()
   identifyMenu()->setShowFeatureActions( extendedMenu );
   IdentifyMode mode = extendedMenu ? LayerSelection : DefaultQgsSetting;
 
-  QList<IdentifyResult> results = QgsMapToolIdentify::identify( geometry, mode, AllLayers );
+  QgsIdentifyContext identifyContext;
+  if ( mCanvas->mapSettings().isTemporal() )
+    identifyContext.setTemporalRange( mCanvas->temporalRange() );
+  QList<IdentifyResult> results = QgsMapToolIdentify::identify( geometry, mode, AllLayers, identifyContext );
 
   disconnect( this, &QgsMapToolIdentifyAction::identifyMessage, QgisApp::instance(), &QgisApp::showStatusMessage );
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -317,6 +317,7 @@ SET(QGIS_CORE_SRCS
   qgshistogram.cpp
   qgshstoreutils.cpp
   qgshtmlutils.cpp
+  qgsidentifycontext.cpp
   qgsimagecache.cpp
   qgsinterval.cpp
   qgsjsonutils.cpp
@@ -892,6 +893,7 @@ SET(QGIS_CORE_HDRS
   qgshistogram.h
   qgshstoreutils.h
   qgshtmlutils.h
+  qgsidentifycontext.h
   qgsimagecache.h
   qgsindexedfeature.h
   qgsinterval.h

--- a/src/core/qgsidentifycontext.cpp
+++ b/src/core/qgsidentifycontext.cpp
@@ -1,0 +1,32 @@
+/***************************************************************************
+     qgsidentifycontext.cpp
+     ----------------------
+    Date                 : November 2020
+    Copyright            : (C) 2020 by Mathieu Pellerin
+    Email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsidentifycontext.h"
+
+
+void QgsIdentifyContext::setTemporalRange( const QgsDateTimeRange &range )
+{
+  mTemporalRange = range;
+}
+
+const QgsDateTimeRange &QgsIdentifyContext::temporalRange() const
+{
+  return mTemporalRange;
+}
+
+bool QgsIdentifyContext::isTemporal() const
+{
+  return mTemporalRange.begin().isValid() || mTemporalRange.end().isValid();
+}

--- a/src/core/qgsidentifycontext.h
+++ b/src/core/qgsidentifycontext.h
@@ -1,0 +1,65 @@
+/***************************************************************************
+     qgsidentifycontext.h
+     --------------------
+    Date                 : November 2020
+    Copyright            : (C) 2020 by Mathieu Pellerin
+    Email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSIDENTIFYCONTEXT_H
+#define QGSIDENTIFYCONTEXT_H
+
+#include "qgis_core.h"
+#include "qgis_sip.h"
+
+#include "qgsrange.h"
+
+/**
+ * \ingroup core
+ * \class QgsIdentifyContext
+ * \brief Identify contexts are used to encapsulate the settings to be used to perform
+ * an identify action.
+ *
+ * \since QGIS 3.16.1
+ */
+class CORE_EXPORT QgsIdentifyContext
+{
+  public:
+
+    //! Constructor for QgsIdentifyContext
+    QgsIdentifyContext() = default;
+
+    /**
+     * Set datetime \a range to be used with the identify action.
+     *
+     * \see temporalRange()
+     * \see isTemporal()
+    */
+    void setTemporalRange( const QgsDateTimeRange &range );
+
+    /**
+     * Returns the datetime range to be used with the identify action.
+     *
+     * \see setTemporalRange()
+     * \see isTemporal()
+    */
+    const QgsDateTimeRange &temporalRange() const;
+
+    /**
+     * Returns TRUE if the temporal range setting is enabled.
+    */
+    bool isTemporal() const;
+
+  private:
+
+    QgsDateTimeRange mTemporalRange;
+
+};
+
+#endif // QGSEXPRESSIONCONTEXT_H

--- a/src/gui/qgsmaptoolidentify.h
+++ b/src/gui/qgsmaptoolidentify.h
@@ -18,6 +18,7 @@
 
 #include "qgsfeature.h"
 #include "qgsfields.h"
+#include "qgsidentifycontext.h"
 #include "qgsmaptool.h"
 #include "qgspointxy.h"
 #include "qgsunittypes.h"
@@ -113,9 +114,10 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
      * \param y y coordinates of mouseEvent
      * \param layerList Performs the identification within the given list of layers. Default value is an empty list, i.e. uses all the layers.
      * \param mode Identification mode. Can use QGIS default settings or a defined mode. Default mode is DefaultQgsSetting.
+     * \param identifyContext Identify context object.
      * \returns a list of IdentifyResult
     */
-    QList<QgsMapToolIdentify::IdentifyResult> identify( int x, int y, const QList<QgsMapLayer *> &layerList = QList<QgsMapLayer *>(), IdentifyMode mode = DefaultQgsSetting );
+    QList<QgsMapToolIdentify::IdentifyResult> identify( int x, int y, const QList<QgsMapLayer *> &layerList = QList<QgsMapLayer *>(), IdentifyMode mode = DefaultQgsSetting, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
 
     /**
      * Performs the identification.
@@ -125,21 +127,22 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
      * \param y y coordinates of mouseEvent
      * \param mode Identification mode. Can use QGIS default settings or a defined mode.
      * \param layerType Only performs identification in a certain type of layers (raster, vector, mesh). Default value is AllLayers.
+     * \param identifyContext Identify context object.
      * \returns a list of IdentifyResult
      */
-    QList<QgsMapToolIdentify::IdentifyResult> identify( int x, int y, IdentifyMode mode, LayerType layerType = AllLayers );
+    QList<QgsMapToolIdentify::IdentifyResult> identify( int x, int y, IdentifyMode mode, LayerType layerType = AllLayers, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
 
     //! Performs identification based on a geometry (in map coordinates)
-    QList<QgsMapToolIdentify::IdentifyResult> identify( const QgsGeometry &geometry, IdentifyMode mode, LayerType layerType );
+    QList<QgsMapToolIdentify::IdentifyResult> identify( const QgsGeometry &geometry, IdentifyMode mode, LayerType layerType, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
     //! Performs identification based on a geometry (in map coordinates)
-    QList<QgsMapToolIdentify::IdentifyResult> identify( const QgsGeometry &geometry, IdentifyMode mode, const QList<QgsMapLayer *> &layerList, LayerType layerType );
+    QList<QgsMapToolIdentify::IdentifyResult> identify( const QgsGeometry &geometry, IdentifyMode mode, const QList<QgsMapLayer *> &layerList, LayerType layerType, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
 
 
     /**
      * Returns a pointer to the identify menu which will be used in layer selection mode
      * this menu can also be customized
      */
-    QgsIdentifyMenu *identifyMenu() {return mIdentifyMenu;}
+    QgsIdentifyMenu *identifyMenu() { return mIdentifyMenu; }
 
   public slots:
     void formatChanged( QgsRasterLayer *layer );
@@ -160,17 +163,35 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
      * \param mode Identification mode. Can use QGIS default settings or a defined mode.
      * \param layerList Performs the identification within the given list of layers.
      * \param layerType Only performs identification in a certain type of layers (raster, vector, mesh).
+     * \param identifyContext Identify context object.
      * \returns a list of IdentifyResult
      */
-    QList<QgsMapToolIdentify::IdentifyResult> identify( int x, int y, IdentifyMode mode,  const QList<QgsMapLayer *> &layerList, LayerType layerType = AllLayers );
+    QList<QgsMapToolIdentify::IdentifyResult> identify( int x, int y, IdentifyMode mode,  const QList<QgsMapLayer *> &layerList, LayerType layerType = AllLayers, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
 
     QgsIdentifyMenu *mIdentifyMenu = nullptr;
 
     //! Call the right method depending on layer type
-    bool identifyLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMapLayer *layer, const QgsPointXY &point, const QgsRectangle &viewExtent, double mapUnitsPerPixel, QgsMapToolIdentify::LayerType layerType = AllLayers );
+    bool identifyLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMapLayer *layer, const QgsPointXY &point, const QgsRectangle &viewExtent, double mapUnitsPerPixel, QgsMapToolIdentify::LayerType layerType = AllLayers, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
 
-    bool identifyRasterLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsRasterLayer *layer, QgsPointXY point, const QgsRectangle &viewExtent, double mapUnitsPerPixel );
-    bool identifyVectorLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorLayer *layer, const QgsPointXY &point );
+    /**
+     * Performs the identification against a given raster layer.
+     * \param results list of identify results
+     * \param layer raster layer to identify from
+     * \param point point coordinate to identify
+     * \param viewExtent view extent
+     * \param mapUnitsPerPixel map units per pixel value
+     * \param identifyContext identify context object
+     */
+    bool identifyRasterLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsRasterLayer *layer, QgsPointXY point, const QgsRectangle &viewExtent, double mapUnitsPerPixel, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
+
+    /**
+     * Performs the identification against a given vector layer.
+     * \param results list of identify results
+     * \param layer raster layer to identify from
+     * \param point point coordinate to identify
+     * \param identifyContext identify context object
+     */
+    bool identifyVectorLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorLayer *layer, const QgsPointXY &point, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
 
     /**
      * Identifies data from active scalar and vector dataset from the mesh layer
@@ -178,7 +199,7 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
      * Works only if layer was already rendered (triangular mesh is created)
      * \since QGIS 3.6
      */
-    bool identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMeshLayer *layer, const QgsPointXY &point );
+    bool identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMeshLayer *layer, const QgsPointXY &point, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
 
     //! Returns derived attributes map for a clicked point in map coordinates. May be 2D or 3D point.
     QMap< QString, QString > derivedAttributesForPoint( const QgsPoint &point );
@@ -206,11 +227,11 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
 
   private:
 
-    bool identifyLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMapLayer *layer, const QgsGeometry &geometry, const QgsRectangle &viewExtent, double mapUnitsPerPixel, QgsMapToolIdentify::LayerType layerType = AllLayers );
-    bool identifyRasterLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsRasterLayer *layer, const QgsGeometry &geometry, const QgsRectangle &viewExtent, double mapUnitsPerPixel );
-    bool identifyVectorLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorLayer *layer, const QgsGeometry &geometry );
-    bool identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMeshLayer *layer, const QgsGeometry &geometry );
-    bool identifyVectorTileLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorTileLayer *layer, const QgsGeometry &geometry );
+    bool identifyLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMapLayer *layer, const QgsGeometry &geometry, const QgsRectangle &viewExtent, double mapUnitsPerPixel, QgsMapToolIdentify::LayerType layerType = AllLayers, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
+    bool identifyRasterLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsRasterLayer *layer, const QgsGeometry &geometry, const QgsRectangle &viewExtent, double mapUnitsPerPixel, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
+    bool identifyVectorLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorLayer *layer, const QgsGeometry &geometry, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
+    bool identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMeshLayer *layer, const QgsGeometry &geometry, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
+    bool identifyVectorTileLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorTileLayer *layer, const QgsGeometry &geometry, const QgsIdentifyContext &identifyContext = QgsIdentifyContext() );
 
     /**
      * Desired units for distance display.


### PR DESCRIPTION
## Description

This PR fixes #39798 (and #39856 ) by making the map tool's identify feature aware of the main map canvas' temporal range state.

It's one outstanding regression when moving away from timemanager to QGIS' native temporal support that's definitively worth fixing on 3.16 too.

@nyalldawson , as always, your review is most welcome.