### PR TITLE
Fix missing close-comment delimiter in bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/10_bug_report.md
@@ -22,7 +22,7 @@ Checklist before submitting
 
 **How to Reproduce**
 
-<!-- Steps, sample datasets and qgis project file to reproduce the behavior. Screencasts or screenshots welcome
+<!-- Steps, sample datasets and qgis project file to reproduce the behavior. Screencasts or screenshots welcome -->
 
 1. Go to '...'
 2. Click on '....'


### PR DESCRIPTION
#39717  Description

The "How to Reproduce" section was missing a close-comment delimiter. If people were to fill out this template without noticing the problem, the resulting issue would appear to have en empty "How to Reproduce" section despite the user filling it in.

