### PR TITLE
Proper invalidation of OGR sources on sync to disc

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -2544,11 +2544,10 @@ bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
   if ( mTransaction )
     mTransaction->dirtyLastSavePoint();
 
-  if ( mOgrLayer->SyncToDisk() != OGRERR_NONE )
+  if ( !syncToDisc() )
   {
     pushError( tr( "OGR error syncing to disk: %1" ).arg( CPLGetLastErrorMsg() ) );
   }
-  QgsOgrConnPool::instance()->invalidateConnections( QgsOgrProviderUtils::connectionPoolId( dataSourceUri( true ), mShareSameDatasetAmongLayers ) );
   return returnValue;
 }
 
@@ -2655,11 +2654,10 @@ bool QgsOgrProvider::changeGeometryValues( const QgsGeometryMap &geometry_map )
   if ( mTransaction )
     mTransaction->dirtyLastSavePoint();
 
-  if ( mOgrLayer->SyncToDisk() != OGRERR_NONE )
+  if ( !syncToDisc() )
   {
     pushError( tr( "OGR error syncing to disk: %1" ).arg( CPLGetLastErrorMsg() ) );
   }
-  QgsOgrConnPool::instance()->invalidateConnections( QgsOgrProviderUtils::connectionPoolId( dataSourceUri( true ), mShareSameDatasetAmongLayers ) );
   return returnvalue;
 }
 
@@ -4572,6 +4570,8 @@ QString QgsOgrProviderUtils::quotedValue( const QVariant &value )
 
 bool QgsOgrProvider::syncToDisc()
 {
+  QgsOgrConnPool::instance()->invalidateConnections( QgsOgrProviderUtils::connectionPoolId( dataSourceUri( true ), mShareSameDatasetAmongLayers ) );
+
   //for shapefiles, remove spatial index files and create a new index
   QgsOgrConnPool::instance()->unref( QgsOgrProviderUtils::connectionPoolId( dataSourceUri( true ), mShareSameDatasetAmongLayers ) );
   bool shapeIndex = false;


### PR DESCRIPTION
## Description

Aims to fix #39574 and #35144 using guidance from @jef-n and @rouault, thanks to you both.

See https://github.com/OSGeo/gdal/issues/3157 for background.

If this is a good fix, I think it should be considered a candidate for backport.

I have not yet verified if this actually resolves the issues as I currently lack a Windows development setup for GDAL + QGIS. This PR was done with a Ubuntu 20.04 based development setup and I've verified to the best of my ability that the changes work and have no adverse effects there.

Let me know if this needs to be verified on a Windows setup to be considered to merge, otherwise I will follow up with testing and verification on a nightly Windows build.