### PR TITLE
QgsAuthOAuth2Method: use a recursive mutex

### DIFF
--- a/src/auth/oauth2/qgsauthoauth2method.h
+++ b/src/auth/oauth2/qgsauthoauth2method.h
@@ -114,7 +114,7 @@ class QgsAuthOAuth2Method : public QgsAuthMethod
 
     QgsO2 *authO2( const QString &authcfg );
 
-    QMutex mNetworkRequestMutex;
+    QMutex mNetworkRequestMutex { QMutex::Recursive };
 };
 
 #endif // QGSAUTHOAUTH2METHOD_H


### PR DESCRIPTION
Otherwise in case of network error, onNetworkError() will deadlock on
the mutex taken by updateNetworkRequest(), as in below stack trace

```
0  syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
1  0x00007f15da17b7b5 in QBasicMutex::lockInternal() () from /opt/qt59/lib/libQt5Core.so.5
2  0x00007f15da17b817 in QMutex::lock() () from /opt/qt59/lib/libQt5Core.so.5
3  0x0000000000418de3 in QMutexLocker::QMutexLocker (this=0x7ffe69fe5ef8, m=0x2853ac8) at /opt/qt59/include/QtCore/qmutex.h:200
4  0x00007f159cf93843 in QgsAuthOAuth2Method::onNetworkError (this=0x2853a90, err=QNetworkReply::ContentNotFoundError) at /home/even/qgis/QGIS/src/auth/oauth2/qgsauthoauth2method.cpp:438
5  0x00007f159cf7a2cf in QgsAuthOAuth2Method::qt_static_metacall (_o=0x2853a90, _c=QMetaObject::InvokeMetaMethod, _id=7, _a=0x7f158000c480) at /home/even/qgis/QGIS/build/src/auth/oauth2/oauth2authmethod_autogen/EWIEGA46WW/moc_qgsauthoauth2method.cpp:118
6  0x00007f15da3915c9 in QObject::event(QEvent*) () from /opt/qt59/lib/libQt5Core.so.5
7  0x00007f15dacd13fc in QApplicationPrivate::notify_helper(QObject*, QEvent*) () from /opt/qt59/lib/libQt5Widgets.so.5
8  0x00007f15dacd8e07 in QApplication::notify(QObject*, QEvent*) () from /opt/qt59/lib/libQt5Widgets.so.5
9  0x00007f15dc060b3b in QgsApplication::notify (this=0x7ffe69feb7e0, receiver=0x2853a90, event=0x7f1580008d20) at /home/even/qgis/QGIS/src/core/qgsapplication.cpp:460
10 0x00007f15da364108 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () from /opt/qt59/lib/libQt5Core.so.5
11 0x00007f15da3668eb in QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) () from /opt/qt59/lib/libQt5Core.so.5
12 0x00007f15da3b9c93 in ?? () from /opt/qt59/lib/libQt5Core.so.5
13 0x00007f15d0227197 in g_main_context_dispatch () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
14 0x00007f15d02273f0 in ?? () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
15 0x00007f15d022749c in g_main_context_iteration () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
16 0x00007f15da3b929f in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () from /opt/qt59/lib/libQt5Core.so.5
17 0x00007f15da36213a in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () from /opt/qt59/lib/libQt5Core.so.5
18 0x00007f159cf914d0 in QgsAuthOAuth2Method::updateNetworkRequest (this=0x2853a90, request=..., authcfg=..., dataprovider=...) at /home/even/qgis/QGIS/src/auth/oauth2/qgsauthoauth2method.cpp:179
19 0x00007f15dbd38424 in QgsAuthManager::updateNetworkRequest (this=0x2841f20, request=..., authcfg=..., dataprovider=...) at /home/even/qgis/QGIS/src/core/auth/qgsauthmanager.cpp:1473
```

