### PR TITLE
Fix crash due to style cache issue in QT<5.12.4. Fixes #39693 #39725 #39615

### DIFF
--- a/python/gui/auto_generated/qgscollapsiblegroupbox.sip.in
+++ b/python/gui/auto_generated/qgscollapsiblegroupbox.sip.in
@@ -97,6 +97,13 @@ Signal emitted when groupbox collapsed/expanded state is changed, and when first
     void checkClicked( bool ckd );
     void toggleCollapsed();
 
+    void setStyleSheet( const QString &style );
+%Docstring
+Overridden to prepare base call and avoid crash due to specific QT versions
+
+.. versionadded:: 3.16
+%End
+
   protected:
     void init();
 

--- a/src/gui/qgscollapsiblegroupbox.cpp
+++ b/src/gui/qgscollapsiblegroupbox.cpp
@@ -300,6 +300,15 @@ void QgsCollapsibleGroupBoxBasic::toggleCollapsed()
   clearModifiers();
 }
 
+void QgsCollapsibleGroupBoxBasic::setStyleSheet( const QString &style )
+{
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 4)
+  // Fix crash on old Qt versions, see #39693
+  QGroupBox::setStyleSheet( QString() );
+#endif
+  QGroupBox::setStyleSheet( style );
+}
+
 void QgsCollapsibleGroupBoxBasic::updateStyle()
 {
   setUpdatesEnabled( false );

--- a/src/gui/qgscollapsiblegroupbox.h
+++ b/src/gui/qgscollapsiblegroupbox.h
@@ -131,6 +131,13 @@ class GUI_EXPORT QgsCollapsibleGroupBoxBasic : public QGroupBox
     void checkClicked( bool ckd );
     void toggleCollapsed();
 
+    /**
+     * Overridden to prepare base call and avoid crash due to specific QT versions
+     *
+     * \since QGIS 3.16
+     */
+    void setStyleSheet( const QString &style );
+
   protected:
     void init();
 


### PR DESCRIPTION
Fix crash due to style cache issue in QT<5.12.4. Fixes #39693 #39725 #39615
No tests available :/

workaround to  QT bug https://bugreports.qt.io/browse/QTBUG-69204

Partially sponsored by QGIS Spanish User Group qgis.es
