### PR TITLE
[processing] OTB minor fixes

### DIFF
--- a/python/plugins/processing/algs/otb/OtbAlgorithm.py
+++ b/python/plugins/processing/algs/otb/OtbAlgorithm.py
@@ -202,7 +202,7 @@ class OtbAlgorithm(QgsProcessingAlgorithm):
         outputPixelType = None
         for k, v in parameters.items():
             # if value is None for a parameter we don't have any businees with this key
-            if not v or v is None:
+            if v is None:
                 continue
             # for 'outputpixeltype' parameter we find the pixeltype string from self.pixelTypes
             if k == 'outputpixeltype':


### PR DESCRIPTION
## Description

- Inherit system environment instead of replacing it so we keep some useful variable (LD_LIBRARY_PATH for instance)
- @rkanavath I reverted this [line modification](
https://github.com/qgis/QGIS/pull/9542/files#diff-26af2b656f3e3ae9b6c885e5904998cb8398f8eb3a4632dbb370f14f2172b63fR208) because it skipped any parameter which value was 0 (as a consequence, you cannot, for instance, select *uint8* for *outputpixeltype* because it's the first in the list)

@rkanavath Please, could you review this PR please?
