### PR TITLE
OGR provider: feature count improvements

### DIFF
--- a/python/core/auto_generated/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/qgsdataprovider.sip.in
@@ -73,6 +73,7 @@ Abstract base class for spatial data provider implementations.
     enum ReadFlag
     {
       FlagTrustDataSource,
+      SkipFeatureCount,
     };
     typedef QFlags<QgsDataProvider::ReadFlag> ReadFlags;
 

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -953,7 +953,8 @@ void QgsOgrProvider::addSubLayerDetailsToSubLayerList( int i, QgsOgrLayer *layer
 
 QStringList QgsOgrProvider::subLayers() const
 {
-  return _subLayers( true );
+  const bool withFeatureCount = ( mReadFlags & QgsDataProvider::SkipFeatureCount ) == 0;
+  return _subLayers( withFeatureCount );
 }
 
 QgsLayerMetadata QgsOgrProvider::layerMetadata() const
@@ -1604,6 +1605,10 @@ QgsWkbTypes::Type QgsOgrProvider::wkbType() const
  */
 long QgsOgrProvider::featureCount() const
 {
+  if ( ( mReadFlags & QgsDataProvider::SkipFeatureCount ) != 0 )
+  {
+    return QgsVectorDataProvider::UnknownCount;
+  }
   if ( mRefreshFeatureCount )
   {
     mRefreshFeatureCount = false;

--- a/src/core/providers/ogr/qgsogrprovider.h
+++ b/src/core/providers/ogr/qgsogrprovider.h
@@ -174,10 +174,10 @@ class QgsOgrProvider final: public QgsVectorDataProvider
     void loadFields();
 
     //! Find out the number of features of the whole layer
-    void recalculateFeatureCount();
+    void recalculateFeatureCount() const;
 
     //! Tell OGR, which fields to fetch in nextFeature/featureAtId (ie. which not to ignore)
-    void setRelevantFields( bool fetchGeometry, const QgsAttributeList &fetchAttributes );
+    void setRelevantFields( bool fetchGeometry, const QgsAttributeList &fetchAttributes ) const;
 
     //! Convert a QgsField to work with OGR
     static bool convertField( QgsField &field, const QTextCodec &encoding );
@@ -294,7 +294,11 @@ class QgsOgrProvider final: public QgsVectorDataProvider
     bool mValid = false;
 
     OGRwkbGeometryType mOGRGeomType = wkbUnknown;
-    long mFeaturesCounted = QgsVectorDataProvider::Uncounted;
+
+    //! Whether the next call to featureCount() should refresh the feature count
+    mutable bool mRefreshFeatureCount = true;
+
+    mutable long mFeaturesCounted = QgsVectorDataProvider::Uncounted;
 
     mutable QStringList mSubLayerList;
 

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -122,6 +122,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
     enum ReadFlag
     {
       FlagTrustDataSource = 1 << 0, //!< Trust datasource config (primary key unicity, geometry type and srid, etc). Improves provider load time by skipping expensive checks like primary key unicity, geometry type and srid and by using estimated metadata on data load. Since QGIS 3.16
+      SkipFeatureCount = 1 << 1, //!< Make featureCount() return -1 to indicate unknown, and subLayers() to return a unknown feature count as well. Since QGIS 3.18. Only implemented by OGR provider at time of writing.
     };
     Q_DECLARE_FLAGS( ReadFlags, ReadFlag )
 

--- a/tests/src/python/test_provider_shapefile.py
+++ b/tests/src/python/test_provider_shapefile.py
@@ -22,12 +22,14 @@ import sys
 from osgeo import gdal
 from qgis.core import (
     QgsApplication,
+    QgsDataProvider,
     QgsSettings,
     QgsFeature,
     QgsField,
     QgsGeometry,
     QgsVectorLayer,
     QgsFeatureRequest,
+    QgsProviderRegistry,
     QgsVectorDataProvider,
     QgsWkbTypes,
     QgsVectorLayerExporter,
@@ -1075,6 +1077,24 @@ class TestPyQgsShapefileProvider(unittest.TestCase, ProviderTestCase):
         vl = QgsVectorLayer(datasource, 'test')
         self.assertTrue(vl.isValid())
         self.assertEqual([f.attributes() for f in vl.dataProvider().getFeatures()], [['abcŐ'], ['abcŐabcŐabcŐ']])
+
+    def testSkipFeatureCountOnFeatureCount(self):
+        """Test QgsDataProvider.SkipFeatureCount on featureCount()"""
+
+        testPath = TEST_DATA_DIR + '/' + 'lines.shp'
+        provider = QgsProviderRegistry.instance().createProvider('ogr', testPath, QgsDataProvider.ProviderOptions(), QgsDataProvider.SkipFeatureCount)
+        self.assertTrue(provider.isValid())
+        self.assertEqual(provider.featureCount(), QgsVectorDataProvider.UnknownCount)
+
+    def testSkipFeatureCountOnSubLayers(self):
+        """Test QgsDataProvider.SkipFeatureCount on subLayers()"""
+
+        datasource = os.path.join(TEST_DATA_DIR, 'shapefile')
+        provider = QgsProviderRegistry.instance().createProvider('ogr', datasource, QgsDataProvider.ProviderOptions(), QgsDataProvider.SkipFeatureCount)
+        self.assertTrue(provider.isValid())
+        sublayers = provider.subLayers()
+        self.assertTrue(len(sublayers) > 1)
+        self.assertEqual(sublayers[0].split(QgsDataProvider.sublayerSeparator())[2], '-1')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- implement deferred feature count computation. This avoids computing the feature count at provider instantiation.
-  Add QgsDataProvider::ReadFlag::SkipFeatureCount and implement it in OGR provider to avoid featureCount() to be called



