### PR TITLE
[db manager] Show error messages directly in place

### DIFF
--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -44,8 +44,7 @@ from qgis.PyQt.QtGui import (QKeySequence,
                              QClipboard,
                              QIcon,
                              QStandardItemModel,
-                             QStandardItem,
-                             QTextOption
+                             QStandardItem
                              )
 from qgis.PyQt.Qsci import QsciAPIs, QsciScintilla
 

--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -47,7 +47,7 @@ from qgis.PyQt.QtGui import (QKeySequence,
                              QStandardItem,
                              QTextOption
                              )
-from qgis.PyQt.Qsci import QsciAPIs
+from qgis.PyQt.Qsci import QsciAPIs, QsciScintilla
 
 from qgis.core import (
     QgsProject,
@@ -439,8 +439,8 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
         if error:
             self.viewResult.setVisible(False)
             self.errorText.setVisible(True)
-            self.errorText.setWordWrapMode(QTextOption.WrapAnywhere)
-            self.errorText.setHtml('<code>' + error.msg + '</code>')
+            self.errorText.setText(error.msg)
+            self.errorText.setWrapMode(QsciScintilla.WrapWord)
         else:
             self.viewResult.setVisible(True)
             self.errorText.setVisible(False)

--- a/python/plugins/db_manager/ui/DlgSqlWindow.ui
+++ b/python/plugins/db_manager/ui/DlgSqlWindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>679</width>
-    <height>525</height>
+    <width>995</width>
+    <height>716</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -248,6 +248,16 @@
      </widget>
      <widget class="QWidget" name="layoutWidget">
       <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QTextEdit" name="errorText">
+         <property name="visible">
+          <bool>false</bool>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
        <item>
         <widget class="QTableView" name="viewResult">
          <property name="sizePolicy">

--- a/python/plugins/db_manager/ui/DlgSqlWindow.ui
+++ b/python/plugins/db_manager/ui/DlgSqlWindow.ui
@@ -249,7 +249,7 @@
      <widget class="QWidget" name="layoutWidget">
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
-        <widget class="QTextEdit" name="errorText">
+        <widget class="QgsCodeEditorSQL" name="errorText">
          <property name="visible">
           <bool>false</bool>
          </property>


### PR DESCRIPTION
The old behavior was to open up a new modal dialog. Each time way to small to read anything.
This version makes it much (!!) easier to iteratively improve a query until it's working.

Needs some fine tuning of the widget (horizontal scroll, word wrap)

![image](https://user-images.githubusercontent.com/588407/98711855-d4a2e580-2385-11eb-8a01-adcf31cc2eb0.png)
