### PR TITLE
OAuth2 fixes: threading issuing and handling of short token validity

### DIFF
--- a/src/auth/oauth2/qgsauthoauth2method.cpp
+++ b/src/auth/oauth2/qgsauthoauth2method.cpp
@@ -157,30 +157,7 @@ bool QgsAuthOAuth2Method::updateNetworkRequest( QNetworkRequest &request, const 
         QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Info );
 
         // Try to get a refresh token first
-        // go into local event loop and wait for a fired refresh-related slot
-        QEventLoop rloop( nullptr );
-        connect( o2, &QgsO2::refreshFinished, &rloop, &QEventLoop::quit );
-
-        // add single shot timer to quit refresh after an allotted timeout
-        // this should keep the local event loop from blocking forever
-        QTimer r_timer( nullptr );
-        int r_reqtimeout = o2->oauth2config()->requestTimeout() * 1000;
-        r_timer.setInterval( r_reqtimeout );
-        r_timer.setSingleShot( true );
-        connect( &r_timer, &QTimer::timeout, &rloop, &QEventLoop::quit );
-        r_timer.start();
-
-        // Asynchronously attempt the refresh
-        // TODO: This already has a timed reply setup in O2 base class (and in QgsNetworkAccessManager!)
-        //       May need to address this or app crashes will occur!
-        o2->refresh();
-
-        // block request update until asynchronous linking loop is quit
-        rloop.exec();
-        if ( r_timer.isActive() )
-        {
-          r_timer.stop();
-        }
+        o2->refreshSynchronous();
 
         // refresh result should set o2 to (un)linked
       }

--- a/src/auth/oauth2/qgso2.cpp
+++ b/src/auth/oauth2/qgso2.cpp
@@ -431,3 +431,9 @@ void QgsO2::refreshSynchronous()
     emit refreshFinished( blockingRequest.reply().error() );
   }
 }
+
+void QgsO2::computeExpirationDelay()
+{
+  const int lExpires = expires();
+  mExpirationDelay = lExpires > 0 ? lExpires - static_cast<int>( QDateTime::currentMSecsSinceEpoch() / 1000 ) : 0;
+}

--- a/src/auth/oauth2/qgso2.cpp
+++ b/src/auth/oauth2/qgso2.cpp
@@ -21,8 +21,11 @@
 #include "qgsauthoauth2config.h"
 #include "qgslogger.h"
 #include "qgsnetworkaccessmanager.h"
+#include "qgsblockingnetworkrequest.h"
 
 #include <QDir>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QSettings>
 #include <QUrl>
 #include <QUrlQuery>
@@ -347,4 +350,84 @@ void QgsO2::onVerificationReceived( QMap<QString, QString> response )
 QNetworkAccessManager *QgsO2::getManager()
 {
   return QgsNetworkAccessManager::instance();
+}
+
+/// Parse JSON data into a QVariantMap
+static QVariantMap parseTokenResponse( const QByteArray &data )
+{
+  QJsonParseError err;
+  QJsonDocument doc = QJsonDocument::fromJson( data, &err );
+  if ( err.error != QJsonParseError::NoError )
+  {
+    qWarning() << "parseTokenResponse: Failed to parse token response due to err:" << err.errorString();
+    return QVariantMap();
+  }
+
+  if ( !doc.isObject() )
+  {
+    qWarning() << "parseTokenResponse: Token response is not an object";
+    return QVariantMap();
+  }
+
+  return doc.object().toVariantMap();
+}
+
+// Code adapted from O2::refresh(), but using QgsBlockingNetworkRequest
+void QgsO2::refreshSynchronous()
+{
+  qDebug() << "O2::refresh: Token: ..." << refreshToken().right( 7 );
+
+  if ( refreshToken().isEmpty() )
+  {
+    qWarning() << "O2::refresh: No refresh token";
+    onRefreshError( QNetworkReply::AuthenticationRequiredError );
+    return;
+  }
+  if ( refreshTokenUrl_.isEmpty() )
+  {
+    qWarning() << "O2::refresh: Refresh token URL not set";
+    onRefreshError( QNetworkReply::AuthenticationRequiredError );
+    return;
+  }
+
+  QNetworkRequest refreshRequest( refreshTokenUrl_ );
+  refreshRequest.setHeader( QNetworkRequest::ContentTypeHeader, O2_MIME_TYPE_XFORM );
+  QMap<QString, QString> parameters;
+  parameters.insert( O2_OAUTH2_CLIENT_ID, clientId_ );
+  parameters.insert( O2_OAUTH2_CLIENT_SECRET, clientSecret_ );
+  parameters.insert( O2_OAUTH2_REFRESH_TOKEN, refreshToken() );
+  parameters.insert( O2_OAUTH2_GRANT_TYPE, O2_OAUTH2_REFRESH_TOKEN );
+
+  QByteArray data = buildRequestBody( parameters );
+
+  QgsBlockingNetworkRequest blockingRequest;
+  QgsBlockingNetworkRequest::ErrorCode errCode = blockingRequest.post( refreshRequest, data, true );
+  if ( errCode == QgsBlockingNetworkRequest::NoError )
+  {
+    QByteArray reply = blockingRequest.reply().content();
+    QVariantMap tokens = parseTokenResponse( reply );
+    if ( tokens.contains( QStringLiteral( "error" ) ) )
+    {
+      qDebug() << " Error refreshing token" << tokens.value( QStringLiteral( "error" ) ).toMap().value( QStringLiteral( "message" ) ).toString().toLocal8Bit().constData();
+      unlink();
+    }
+    else
+    {
+      setToken( tokens.value( O2_OAUTH2_ACCESS_TOKEN ).toString() );
+      setExpires( QDateTime::currentMSecsSinceEpoch() / 1000 + tokens.value( O2_OAUTH2_EXPIRES_IN ).toInt() );
+      const QString refreshToken = tokens.value( O2_OAUTH2_REFRESH_TOKEN ).toString();
+      if ( !refreshToken.isEmpty() )
+        setRefreshToken( refreshToken );
+      setLinked( true );
+      qDebug() << " New token expires in" << expires() << "seconds";
+      emit linkingSucceeded();
+    }
+    emit refreshFinished( QNetworkReply::NoError );
+  }
+  else
+  {
+    unlink();
+    qDebug() << "O2::onRefreshFinished: Error" << blockingRequest.errorMessage();
+    emit refreshFinished( blockingRequest.reply().error() );
+  }
 }

--- a/src/auth/oauth2/qgso2.h
+++ b/src/auth/oauth2/qgso2.h
@@ -61,6 +61,16 @@ class QgsO2: public O2
     //! Refresh token in a synchronous way
     void refreshSynchronous();
 
+    /**
+     * Compute expiration delay from current timestamp and expires()
+     * Should only be called just after a refresh / link event. */
+    void computeExpirationDelay();
+
+    /** Returns expiration delay.
+     * May be 0 if it is unknown
+     */
+    int expirationDelay() const { return mExpirationDelay; }
+
   public slots:
 
     //! Clear all properties
@@ -104,6 +114,7 @@ class QgsO2: public O2
     QString state_;
     QgsAuthOAuth2Config *mOAuth2Config;
     bool mIsLocalHost = false;
+    int mExpirationDelay = 0;
 
     static QString O2_OAUTH2_STATE;
 };

--- a/src/auth/oauth2/qgso2.h
+++ b/src/auth/oauth2/qgso2.h
@@ -58,6 +58,9 @@ class QgsO2: public O2
     //! Store oauth2 state to a random value when called
     void setState( const QString &value );
 
+    //! Refresh token in a synchronous way
+    void refreshSynchronous();
+
   public slots:
 
     //! Clear all properties
@@ -101,6 +104,7 @@ class QgsO2: public O2
     QString state_;
     QgsAuthOAuth2Config *mOAuth2Config;
     bool mIsLocalHost = false;
+
     static QString O2_OAUTH2_STATE;
 };
 


### PR DESCRIPTION
Two fixes:
- avoid infinite loop when refreshing token from non-main thread
- avoid constant token refreshing if the expiration delay is < 2 minutes
