### PR TITLE
[geometry validation] Show context menu for stable problem resolution methods

### DIFF
--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -444,7 +444,7 @@ QList<QgsGeometryCheckResolutionMethod> QgsGeometryGapCheck::availableResolution
   };
 
   if ( mAllowedGapsSource )
-    fixes << QgsGeometryCheckResolutionMethod( AddToAllowedGaps, tr( "Add gap to allowed exceptions" ), tr( "Create a new feature from the gap geometry on the allowed exceptions layer." ), true );
+    fixes << QgsGeometryCheckResolutionMethod( AddToAllowedGaps, tr( "Add Gap to Allowed Exceptions" ), tr( "Create a new feature from the gap geometry on the allowed exceptions layer." ), true );
 
   fixes << QgsGeometryCheckResolutionMethod( NoChange, tr( "No action" ), tr( "Do not perform any action and mark this error as fixed." ), false );
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -444,7 +444,7 @@ QList<QgsGeometryCheckResolutionMethod> QgsGeometryGapCheck::availableResolution
   };
 
   if ( mAllowedGapsSource )
-    fixes << QgsGeometryCheckResolutionMethod( AddToAllowedGaps, tr( "Add gap to allowed exceptions" ), tr( "Create a new feature from the gap geometry on the allowed exceptions layer." ), false );
+    fixes << QgsGeometryCheckResolutionMethod( AddToAllowedGaps, tr( "Add gap to allowed exceptions" ), tr( "Create a new feature from the gap geometry on the allowed exceptions layer." ), true );
 
   fixes << QgsGeometryCheckResolutionMethod( NoChange, tr( "No action" ), tr( "Do not perform any action and mark this error as fixed." ), false );
 

--- a/src/app/qgsgeometryvalidationdock.cpp
+++ b/src/app/qgsgeometryvalidationdock.cpp
@@ -73,8 +73,9 @@ QgsGeometryValidationDock::QgsGeometryValidationDock( const QString &title, QgsM
 
   mProblemDetailWidget->setVisible( false );
 
-  // Problem resolution is unstable and therefore disabled by default
-  mResolutionWidget->setVisible( QgsSettings().value( QStringLiteral( "geometry_validation/enable_problem_resolution" ) ) == QLatin1String( "true" ) );
+  // Some problem resolutions are unstable, show all of them only if the user opted in
+  bool showUnreliableResolutionMethods = QgsSettings().value( QStringLiteral( "geometry_validation/enable_problem_resolution" ) ).toString().compare( QLatin1String( "true" ), Qt::CaseInsensitive ) == 0;
+  mResolutionWidget->setVisible( showUnreliableResolutionMethods );
 }
 
 QgsGeometryValidationModel *QgsGeometryValidationDock::geometryValidationModel() const
@@ -164,7 +165,7 @@ void QgsGeometryValidationDock::onRowsInserted()
 
 void QgsGeometryValidationDock::showErrorContextMenu( const QPoint &pos )
 {
-  bool showUnreliableResolutionMethods = QgsSettings().value( QStringLiteral( "geometry_validation/enable_problem_resolution" ) ).compare( QLatin1String( "true" ), Qt::CaseInsensitive ) == 0;
+  bool showUnreliableResolutionMethods = QgsSettings().value( QStringLiteral( "geometry_validation/enable_problem_resolution" ) ).toString().compare( QLatin1String( "true" ), Qt::CaseInsensitive ) == 0;
 
   QModelIndex index = mErrorListView->indexAt( pos );
   QgsGeometryCheckError *error = index.data( QgsGeometryValidationModel::GeometryCheckErrorRole ).value<QgsGeometryCheckError *>();

--- a/src/app/qgsgeometryvalidationdock.cpp
+++ b/src/app/qgsgeometryvalidationdock.cpp
@@ -163,7 +163,7 @@ void QgsGeometryValidationDock::onRowsInserted()
 
 void QgsGeometryValidationDock::showErrorContextMenu( const QPoint &pos )
 {
-  bool showUnreliableResolutionMethods = QgsSettings().value( QStringLiteral( "geometry_validation/enable_problem_resolution" ) ) == QLatin1String( "true" );
+  bool showUnreliableResolutionMethods = QgsSettings().value( QStringLiteral( "geometry_validation/enable_problem_resolution" ) ).compare( QLatin1String( "true" ), Qt::CaseInsensitive ) == 0;
 
   QModelIndex index = mErrorListView->indexAt( pos );
   QgsGeometryCheckError *error = index.data( QgsGeometryValidationModel::GeometryCheckErrorRole ).value<QgsGeometryCheckError *>();

--- a/src/app/qgsgeometryvalidationdock.cpp
+++ b/src/app/qgsgeometryvalidationdock.cpp
@@ -56,6 +56,7 @@ QgsGeometryValidationDock::QgsGeometryValidationDock( const QString &title, QgsM
   mFeatureRubberband = new QgsRubberBand( mMapCanvas );
   mErrorRubberband = new QgsRubberBand( mMapCanvas );
   mErrorLocationRubberband = new QgsRubberBand( mMapCanvas );
+  mGeometryErrorContextMenu = new QMenu( this );
 
   double scaleFactor = mMapCanvas->fontMetrics().xHeight() * .4;
 
@@ -171,22 +172,22 @@ void QgsGeometryValidationDock::showErrorContextMenu( const QPoint &pos )
   {
     const QList<QgsGeometryCheckResolutionMethod> resolutionMethods = error->check()->availableResolutionMethods();
 
-    QMenu *menu = new QMenu( this );
+    mGeometryErrorContextMenu->clear();
     for ( const QgsGeometryCheckResolutionMethod &resolutionMethod : resolutionMethods )
     {
       if ( resolutionMethod.isStable() || showUnreliableResolutionMethods )
       {
-        QAction *action = new QAction( resolutionMethod.name() );
+        QAction *action = new QAction( resolutionMethod.name(), mGeometryErrorContextMenu );
         action->setToolTip( resolutionMethod.description() );
         int fixId = resolutionMethod.id();
         connect( action, &QAction::triggered, this, [ fixId, error, this ]()
         {
           mGeometryValidationService->fixError( error, fixId );
         } );
-        menu->addAction( action );
+        mGeometryErrorContextMenu->addAction( action );
       }
     }
-    menu->popup( mErrorListView->viewport()->mapToGlobal( pos ) );
+    mGeometryErrorContextMenu->popup( mErrorListView->viewport()->mapToGlobal( pos ) );
   }
 }
 

--- a/src/app/qgsgeometryvalidationdock.h
+++ b/src/app/qgsgeometryvalidationdock.h
@@ -57,7 +57,7 @@ class QgsGeometryValidationDock : public QgsDockWidget, public Ui_QgsGeometryVal
     void updateLayerTransform();
     void onDataChanged( const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles );
     void onRowsInserted();
-    void showErrorContextMenu( const QPoint& pos );
+    void showErrorContextMenu( const QPoint &pos );
 
   private:
 
@@ -82,6 +82,7 @@ class QgsGeometryValidationDock : public QgsDockWidget, public Ui_QgsGeometryVal
     QgsRubberBand *mErrorLocationRubberband = nullptr;
     QgsVectorLayer *mCurrentLayer = nullptr;
     bool mPreventZoomToError = false;
+    QMenu *mGeometryErrorContextMenu = nullptr;
 };
 
 #endif // QGSGEOMETRYVALIDATIONPANEL_H

--- a/src/app/qgsgeometryvalidationdock.h
+++ b/src/app/qgsgeometryvalidationdock.h
@@ -57,6 +57,7 @@ class QgsGeometryValidationDock : public QgsDockWidget, public Ui_QgsGeometryVal
     void updateLayerTransform();
     void onDataChanged( const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles );
     void onRowsInserted();
+    void showErrorContextMenu( const QPoint& pos );
 
   private:
 


### PR DESCRIPTION
There has been an API to flag problem resolutions as "stable" around for a while. But it has never been used.

This flags a fix "add gap to allowed exceptions" as stable since it is not affected by tolerance problems like other resolution methods.

It also offers a better UX by showing resolution methods in a context menu.

![Peek 2020-11-11 23-15](https://user-images.githubusercontent.com/588407/98870891-448f9980-2474-11eb-9c31-d8423417ecae.gif)
