### PR TITLE
Don't use generic "QgsMapLayer" class name in map layer Python repr strings

### DIFF
--- a/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
@@ -50,6 +50,12 @@ The ``options`` argument specifies load-time layer options.
 %End
     ~QgsAnnotationLayer();
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsAnnotationLayer: '%1'>" ).arg( sipCpp->name() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
     void reset();
 %Docstring
 Resets the annotation layer to a default state, and clears all items from it.

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -113,11 +113,17 @@ data.
     ~QgsMeshLayer();
 
 
-    virtual QgsMeshDataProvider *dataProvider();
-
+    SIP_PYOBJECT __repr__();
 %Docstring
 QgsMeshLayer cannot be copied.
 %End
+%MethodCode
+    QString str = QStringLiteral( "<QgsMeshLayer: '%1' (%2)>" ).arg( sipCpp->name(), sipCpp->dataProvider() ? sipCpp->dataProvider()->name() : QStringLiteral( "Invalid" ) );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
+    virtual QgsMeshDataProvider *dataProvider();
+
     virtual QgsMeshLayer *clone() const /Factory/;
 
     virtual QgsRectangle extent() const;

--- a/python/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
@@ -56,11 +56,17 @@ Constructor - creates a point cloud layer
     ~QgsPointCloudLayer();
 
 
-    virtual QgsPointCloudLayer *clone() const /Factory/;
-
+    SIP_PYOBJECT __repr__();
 %Docstring
 QgsPointCloudLayer cannot be copied.
 %End
+%MethodCode
+    QString str = QStringLiteral( "<QgsPointCloudLayer: '%1' (%2)>" ).arg( sipCpp->name(), sipCpp->dataProvider() ? sipCpp->dataProvider()->name() : QStringLiteral( "Invalid" ) );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
+    virtual QgsPointCloudLayer *clone() const /Factory/;
+
     virtual QgsRectangle extent() const;
 
     virtual QgsMapLayerRenderer *createMapRenderer( QgsRenderContext &rendererContext ) /Factory/;

--- a/python/core/auto_generated/qgsauxiliarystorage.sip.in
+++ b/python/core/auto_generated/qgsauxiliarystorage.sip.in
@@ -55,6 +55,12 @@ Constructor
 
 
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsAuxiliaryLayer: '%1'>" ).arg( sipCpp->name() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
     QgsAuxiliaryLayer *clone( QgsVectorLayer *layer ) const /Factory/;
 %Docstring
 Returns a new instance equivalent to this one. The underlying table

--- a/python/core/auto_generated/qgspluginlayer.sip.in
+++ b/python/core/auto_generated/qgspluginlayer.sip.in
@@ -25,6 +25,12 @@ In order to be readable from project files, they should set these attributes in 
     QgsPluginLayer( const QString &layerType, const QString &layerName = QString() );
     ~QgsPluginLayer();
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsPluginLayer: '%1'>" ).arg( sipCpp->name() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
     virtual QgsPluginLayer *clone() const = 0;
 
 %Docstring

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -427,6 +427,15 @@ data.
     ~QgsVectorLayer();
 
 
+    SIP_PYOBJECT __repr__();
+%Docstring
+QgsVectorLayer cannot be copied.
+%End
+%MethodCode
+    QString str = QStringLiteral( "<QgsVectorLayer: '%1' (%2)>" ).arg( sipCpp->name(), sipCpp->dataProvider() ? sipCpp->dataProvider()->name() : QStringLiteral( "Invalid" ) );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
     virtual QgsVectorLayer *clone() const /Factory/;
 
 %Docstring

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -90,6 +90,12 @@ The main tasks carried out by the constructor are:
 
     ~QgsRasterLayer();
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsRasterLayer: '%1' (%2)>" ).arg( sipCpp->name(), sipCpp->dataProvider() ? sipCpp->dataProvider()->name() : QStringLiteral( "Invalid" ) );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
     virtual QgsRasterLayer *clone() const /Factory/;
 
 %Docstring

--- a/python/core/auto_generated/vectortile/qgsvectortilelayer.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilelayer.sip.in
@@ -77,6 +77,12 @@ Constructs a new vector tile layer
 %End
     ~QgsVectorTileLayer();
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsVectorTileLayer: '%1'>" ).arg( sipCpp->name() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
 
     virtual QgsVectorTileLayer *clone() const /Factory/;
 

--- a/src/core/annotations/qgsannotationlayer.h
+++ b/src/core/annotations/qgsannotationlayer.h
@@ -72,6 +72,14 @@ class CORE_EXPORT QgsAnnotationLayer : public QgsMapLayer
     QgsAnnotationLayer( const QString &name, const QgsAnnotationLayer::LayerOptions &options );
     ~QgsAnnotationLayer() override;
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsAnnotationLayer: '%1'>" ).arg( sipCpp->name() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     /**
      * Resets the annotation layer to a default state, and clears all items from it.
      */

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -151,6 +151,14 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     //! QgsMeshLayer cannot be copied.
     QgsMeshLayer &operator=( QgsMeshLayer const &rhs ) = delete;
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsMeshLayer: '%1' (%2)>" ).arg( sipCpp->name(), sipCpp->dataProvider() ? sipCpp->dataProvider()->name() : QStringLiteral( "Invalid" ) );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     QgsMeshDataProvider *dataProvider() override;
     const QgsMeshDataProvider *dataProvider() const override SIP_SKIP;
     QgsMeshLayer *clone() const override SIP_FACTORY;

--- a/src/core/pointcloud/qgspointcloudlayer.h
+++ b/src/core/pointcloud/qgspointcloudlayer.h
@@ -92,6 +92,14 @@ class CORE_EXPORT QgsPointCloudLayer : public QgsMapLayer
     //! QgsPointCloudLayer cannot be copied.
     QgsPointCloudLayer &operator=( QgsPointCloudLayer const &rhs ) = delete;
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsPointCloudLayer: '%1' (%2)>" ).arg( sipCpp->name(), sipCpp->dataProvider() ? sipCpp->dataProvider()->name() : QStringLiteral( "Invalid" ) );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     QgsPointCloudLayer *clone() const override SIP_FACTORY;
     QgsRectangle extent() const override;
     QgsMapLayerRenderer *createMapRenderer( QgsRenderContext &rendererContext ) override SIP_FACTORY;

--- a/src/core/qgsauxiliarystorage.h
+++ b/src/core/qgsauxiliarystorage.h
@@ -80,6 +80,14 @@ class CORE_EXPORT QgsAuxiliaryLayer : public QgsVectorLayer
 
     QgsAuxiliaryLayer &operator=( QgsAuxiliaryLayer const &rhs ) = delete;
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsAuxiliaryLayer: '%1'>" ).arg( sipCpp->name() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     /**
      * Returns a new instance equivalent to this one. The underlying table
      * is duplicate for the layer given in parameter. Note that the current

--- a/src/core/qgspluginlayer.h
+++ b/src/core/qgspluginlayer.h
@@ -36,6 +36,14 @@ class CORE_EXPORT QgsPluginLayer : public QgsMapLayer
     QgsPluginLayer( const QString &layerType, const QString &layerName = QString() );
     ~QgsPluginLayer() override;
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsPluginLayer: '%1'>" ).arg( sipCpp->name() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     /**
      * Returns a new instance equivalent to this one.
      * \returns a new layer instance

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -557,6 +557,14 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     //! QgsVectorLayer cannot be copied.
     QgsVectorLayer &operator=( QgsVectorLayer const &rhs ) = delete;
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsVectorLayer: '%1' (%2)>" ).arg( sipCpp->name(), sipCpp->dataProvider() ? sipCpp->dataProvider()->name() : QStringLiteral( "Invalid" ) );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     /**
      * Returns a new instance equivalent to this one. A new provider is
      *  created for the same data source and renderers for features and diagrams

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -157,6 +157,14 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
 
     ~QgsRasterLayer() override;
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsRasterLayer: '%1' (%2)>" ).arg( sipCpp->name(), sipCpp->dataProvider() ? sipCpp->dataProvider()->name() : QStringLiteral( "Invalid" ) );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     /**
      * Returns a new instance equivalent to this one. A new provider is
      *  created for the same data source and renderer is cloned too.

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -89,6 +89,14 @@ class CORE_EXPORT QgsVectorTileLayer : public QgsMapLayer
     explicit QgsVectorTileLayer( const QString &path = QString(), const QString &baseName = QString() );
     ~QgsVectorTileLayer() override;
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsVectorTileLayer: '%1'>" ).arg( sipCpp->name() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     // implementation of virtual functions from QgsMapLayer
 
     QgsVectorTileLayer *clone() const override SIP_FACTORY;

--- a/tests/src/python/test_python_repr.py
+++ b/tests/src/python/test_python_repr.py
@@ -19,7 +19,8 @@ from qgis.core import QgsGeometry, QgsPoint, QgsPointXY, QgsCircle, QgsCircularS
     QgsMimeDataUtils, QgsVector, QgsVector3D, QgsVectorLayer, QgsReferencedPointXY, QgsReferencedRectangle,\
     QgsCoordinateReferenceSystem, QgsCoordinateTransform, QgsProject, QgsClassificationRange, QgsBookmark, \
     QgsLayoutMeasurement, QgsLayoutPoint, QgsLayoutSize, QgsUnitTypes, QgsConditionalStyle, QgsTableCell, QgsProperty, \
-    QgsVertexId, QgsReferencedGeometry, QgsProviderRegistry
+    QgsVertexId, QgsReferencedGeometry, QgsProviderRegistry, QgsRasterLayer, QgsAnnotationLayer, QgsPointCloudLayer,\
+    QgsVectorTileLayer, QgsMeshLayer
 
 start_app()
 
@@ -187,7 +188,17 @@ class TestPython__repr__(unittest.TestCase):
         vl = QgsVectorLayer(
             'Point?crs=epsg:4326&field=pk:integer&field=cnt:integer&field=name:string(0)&field=name2:string(0)&field=num_char:string&key=pk',
             'QGIS搖滾', 'memory')
-        self.assertEqual(vl.__repr__(), "<QgsMapLayer: 'QGIS搖滾' (memory)>")
+        self.assertEqual(vl.__repr__(), "<QgsVectorLayer: 'QGIS搖滾' (memory)>")
+        rl = QgsRasterLayer('', 'QGIS搖滾', 'gdal')
+        self.assertEqual(rl.__repr__(), "<QgsRasterLayer: 'QGIS搖滾' (gdal)>")
+        ml = QgsMeshLayer('', 'QGIS搖滾', 'mdal')
+        self.assertEqual(ml.__repr__(), "<QgsMeshLayer: 'QGIS搖滾' (Invalid)>")
+        al = QgsAnnotationLayer('QGIS搖滾', QgsAnnotationLayer.LayerOptions(QgsProject.instance().transformContext()))
+        self.assertEqual(al.__repr__(), "<QgsAnnotationLayer: 'QGIS搖滾'>")
+        pcl = QgsPointCloudLayer('', 'QGIS搖滾', 'pc')
+        self.assertEqual(pcl.__repr__(), "<QgsPointCloudLayer: 'QGIS搖滾' (Invalid)>")
+        vtl = QgsVectorTileLayer('', 'QGIS搖滾')
+        self.assertEqual(vtl.__repr__(), "<QgsVectorTileLayer: 'QGIS搖滾'>")
 
     def testQgsProjectRepr(self):
         p = QgsProject()


### PR DESCRIPTION
Rather use actual layer subclass type, e.g. QgsVectorLayer
