### PR TITLE
fix time step for first loaded layer

### DIFF
--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -424,7 +424,12 @@ void QgsTemporalControllerWidget::firstTemporalLayerLoaded( QgsMapLayer *layer )
 
   QgsMeshLayer *meshLayer = qobject_cast<QgsMeshLayer *>( layer );
   if ( meshLayer )
+  {
+    mBlockFrameDurationUpdates++;
     setTimeStep( meshLayer->firstValidTimeStep() );
+    mBlockFrameDurationUpdates--;
+    updateFrameDuration();
+  }
 }
 
 void QgsTemporalControllerWidget::onProjectCleared()


### PR DESCRIPTION
since 3.16, when a mesh layer is first loaded, the time step deduced form the layer data is wrong. Seems to come from https://github.com/qgis/QGIS/pull/39543.
This PR fixes this issue.