### PR TITLE
Increase default shadow maximum distance

### DIFF
--- a/src/3d/qgsshadowsettings.cpp
+++ b/src/3d/qgsshadowsettings.cpp
@@ -45,7 +45,7 @@ void QgsShadowSettings::readXml( const QDomElement &element, const QgsReadWriteC
   Q_UNUSED( context );
   mRenderShadows = element.attribute( QStringLiteral( "shadow-rendering-enabled" ), QStringLiteral( "0" ) ).toInt();
   mSelectedDirectionalLight = element.attribute( QStringLiteral( "selected-directional-light" ), QStringLiteral( "-1" ) ).toInt();
-  mMaximumShadowRenderingDistance = element.attribute( QStringLiteral( "max-shadow-rendering-distance" ), QStringLiteral( "500" ) ).toInt();
+  mMaximumShadowRenderingDistance = element.attribute( QStringLiteral( "max-shadow-rendering-distance" ), QStringLiteral( "1500" ) ).toInt();
   mShadowBias = element.attribute( QStringLiteral( "shadow-bias" ), QStringLiteral( "0.00001" ) ).toFloat();
   mShadowMapResolution = element.attribute( QStringLiteral( "shadow-map-resolution" ), QStringLiteral( "2048" ) ).toInt();
 }

--- a/src/3d/qgsshadowsettings.h
+++ b/src/3d/qgsshadowsettings.h
@@ -102,7 +102,7 @@ class _3D_EXPORT QgsShadowSettings
   private:
     bool mRenderShadows = false;
     int mSelectedDirectionalLight = 0;
-    double mMaximumShadowRenderingDistance = 500.0;
+    double mMaximumShadowRenderingDistance = 1500.0;
     double mShadowBias = 0.00001;
     int mShadowMapResolution = 2048;
 };

--- a/src/app/3d/qgsshadowrenderingsettingswidget.cpp
+++ b/src/app/3d/qgsshadowrenderingsettingswidget.cpp
@@ -25,7 +25,7 @@ QgsShadowRenderingSettingsWidget::QgsShadowRenderingSettingsWidget( QWidget *par
 {
   setupUi( this );
 
-  shadowRenderinMaximumDistanceSpinBox->setClearValue( 500.00 );
+  shadowRenderinMaximumDistanceSpinBox->setClearValue( 1500.00 );
   shadowBiasSpinBox->setClearValue( 0.000010 );
   shadowMapResolutionSpinBox->setClearValue( 2048 );
 }


### PR DESCRIPTION
The previous default value (500) wass too short for good results
with point cloud scenes, and produced a very distinct visual cut off where the
shadows vanish
