### PR TITLE
Distance is faster than finding shared edge

### DIFF
--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -171,7 +171,7 @@ void QgsGeometryGapCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &
     for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
     {
       const QgsGeometry geom = layerFeature.geometry();
-      if ( gapGeomEngine->distance( geom.constGet() ) < mContext->tolerance && QgsGeometryCheckerUtils::sharedEdgeLength( gapGeom, geom.constGet(), mContext->reducedTolerance ) > 0 )
+      if ( gapGeomEngine->distance( geom.constGet() ) < mContext->tolerance )
       {
         neighboringIds[layerFeature.layer()->id()].insert( layerFeature.feature().id() );
         gapAreaBBox.combineExtentWith( geom.boundingBox() );
@@ -349,7 +349,9 @@ bool QgsGeometryGapCheck::mergeWithNeighbor( const QMap<QString, QgsFeaturePool 
             break;
 
           case LargestArea:
-            val = QgsGeometryCheckerUtils::getGeomPart( testGeom, iPart )->area();
+            // We might get a neighbour where we touch only a corner
+            if ( QgsGeometryCheckerUtils::sharedEdgeLength( errLayerGeom.get(), QgsGeometryCheckerUtils::getGeomPart( testGeom, iPart ), mContext->reducedTolerance ) > 0 )
+              val = QgsGeometryCheckerUtils::getGeomPart( testGeom, iPart )->area();
             break;
         }
 


### PR DESCRIPTION
## Description

Followup https://github.com/qgis/QGIS/pull/39961
This was still quite slow, this delays the expensive shared edge length test to when a fix requiring it is applied to make the checks themselves run fast.

CC @olivierdalang do you see an issue with this?