### PR TITLE
Fix overlay_disjoint description and examples

### DIFF
--- a/resources/function_help/json/overlay_disjoint
+++ b/resources/function_help/json/overlay_disjoint
@@ -2,7 +2,7 @@
   "name": "overlay_disjoint",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns whether the current feature is spatially disjoint from at least one feature from a target layer, or an array of expression-based results for the features in the target layer that are disjoint from the current feature.<br><br>Read more on the underlying GEOS \"Disjoint\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Disjoint.html'>ST_Disjoint</a> function.",
+  "description": "Returns whether the current feature is spatially disjoint from all the features of a target layer, or an array of expression-based results for the features in the target layer that are disjoint from the current feature.<br><br>Read more on the underlying GEOS \"Disjoint\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Disjoint.html'>ST_Disjoint</a> function.",
   "arguments": [
     {
       "arg": "layer",
@@ -33,11 +33,11 @@
   "examples": [
     {
       "expression": "overlay_disjoint('regions')",
-      "returns": "true if the current feature is spatially disjoint from a region"
+      "returns": "true if the current feature is spatially disjoint from all the regions"
     },
     {
       "expression": "overlay_disjoint('regions', filter:= population > 10000)",
-      "returns": "true if the current feature is spatially disjoint from a region with a population greater than 10000"
+      "returns": "true if the current feature is spatially disjoint from all the regions with a population greater than 10000"
     },
     {
       "expression": "overlay_disjoint('regions', name)",


### PR DESCRIPTION
The current description does not seem logic to me (would return true in 99,99% of situations) and does not reflect the function behavior. You get true when there's not a single feature overlapping, and not when only one is disjoint.
The expression parameter might be worth a look but my English and reasoning are lost in the "if not set" part.