### PR TITLE
[CI][Oracle] Use an already configured docker image to speed up database start-up

### DIFF
--- a/.ci/travis/linux/docker-compose.travis.yml
+++ b/.ci/travis/linux/docker-compose.travis.yml
@@ -12,7 +12,7 @@ services:
       - SSL_CA_FILE=/etc/ssl/certs/issuer_ca_cert.pem
 
   oracle:
-    image: oslandia/oracle-for-qgis-tests:18.4.0-xe
+    image: oslandia/oracle-for-qgis-tests-configured:18.4.0-xe
     environment:
       - ORACLE_SID=XE
       - ORACLE_PWD=adminpass


### PR DESCRIPTION
## Description

Oracle database start-up takes around 10-15 minutes and slow down the whole QGIS CI process. 

I built an already configured database docker image. Its size is bigger (10.2GB versus 8.57GB) but start-up takes around 1 minute.

This PR proposed to switch to this image.

