### PR TITLE
QgsQueryBuilder: improvements for easier subclassing

### DIFF
--- a/python/gui/auto_generated/qgsquerybuilder.sip.in
+++ b/python/gui/auto_generated/qgsquerybuilder.sip.in
@@ -41,6 +41,25 @@ vector layer properties dialog
     QString sql();
     void setSql( const QString &sqlStatement );
 
+%If (HAVE_QSCI_SIP)
+
+    QgsCodeEditor *codeEditorWidget() const;
+%Docstring
+Returns the code editor widget for the SQL.
+
+.. versionadded:: 3.18
+%End
+%End
+%If (!HAVE_QSCI_SIP)
+
+    QWidget *codeEditorWidget() const;
+%Docstring
+Returns the code editor widget for the SQL.
+
+.. versionadded:: 3.18
+%End
+%End
+
   public slots:
     virtual void accept();
 
@@ -48,9 +67,10 @@ vector layer properties dialog
 
     void clear();
 
-    void test();
+    virtual void test();
 %Docstring
-Test the constructed sql statement to see if the vector layer data provider likes it.
+The default implementation tests that the constructed sql statement to
+see if the vector layer data provider likes it.
 The number of rows that would be returned is displayed in a message box.
 The test uses a "select count(*) from ..." query to test the SQL
 statement.

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -89,7 +89,7 @@ QgsQueryBuilder::QgsQueryBuilder( QgsVectorLayer *layer,
   layerSubsetStringChanged();
 
   lblDataUri->setText( tr( "Set provider filter on %1" ).arg( layer->name() ) );
-  txtSQL->setText( mOrigSubsetString );
+  mTxtSql->setText( mOrigSubsetString );
 
   mFilterLineEdit->setShowSearchIcon( true );
   mFilterLineEdit->setPlaceholderText( tr( "Search…" ) );
@@ -100,14 +100,14 @@ QgsQueryBuilder::QgsQueryBuilder( QgsVectorLayer *layer,
 
 void QgsQueryBuilder::showEvent( QShowEvent *event )
 {
-  txtSQL->setFocus();
+  mTxtSql->setFocus();
   QDialog::showEvent( event );
 }
 
 void QgsQueryBuilder::populateFields()
 {
   const QgsFields &fields = mLayer->fields();
-  txtSQL->setFields( fields );
+  mTxtSql->setFields( fields );
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
     if ( fields.fieldOrigin( idx ) != QgsFields::OriginProvider )
@@ -235,7 +235,7 @@ void QgsQueryBuilder::test()
   // by counting the number of records that would be
   // returned
 
-  if ( mLayer->setSubsetString( txtSQL->text() ) )
+  if ( mLayer->setSubsetString( mTxtSql->text() ) )
   {
     const long featureCount { mLayer->featureCount() };
     // Check for errors
@@ -270,9 +270,9 @@ void QgsQueryBuilder::test()
 
 void QgsQueryBuilder::accept()
 {
-  if ( txtSQL->text() != mOrigSubsetString )
+  if ( mTxtSql->text() != mOrigSubsetString )
   {
-    if ( !mLayer->setSubsetString( txtSQL->text() ) )
+    if ( !mLayer->setSubsetString( mTxtSql->text() ) )
     {
       //error in query - show the problem
       if ( mLayer->dataProvider()->hasErrors() )
@@ -305,54 +305,54 @@ void QgsQueryBuilder::reject()
 
 void QgsQueryBuilder::btnEqual_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " = " ) );
-  txtSQL->setFocus();
+  mTxtSql->insertText( QStringLiteral( " = " ) );
+  mTxtSql->setFocus();
 }
 
 void QgsQueryBuilder::btnLessThan_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " < " ) );
-  txtSQL->setFocus();
+  mTxtSql->insertText( QStringLiteral( " < " ) );
+  mTxtSql->setFocus();
 }
 
 void QgsQueryBuilder::btnGreaterThan_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " > " ) );
-  txtSQL->setFocus();
+  mTxtSql->insertText( QStringLiteral( " > " ) );
+  mTxtSql->setFocus();
 }
 
 void QgsQueryBuilder::btnPct_clicked()
 {
-  txtSQL->insertText( QStringLiteral( "%" ) );
-  txtSQL->setFocus();
+  mTxtSql->insertText( QStringLiteral( "%" ) );
+  mTxtSql->setFocus();
 }
 
 void QgsQueryBuilder::btnIn_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " IN " ) );
-  txtSQL->setFocus();
+  mTxtSql->insertText( QStringLiteral( " IN " ) );
+  mTxtSql->setFocus();
 }
 
 void QgsQueryBuilder::btnNotIn_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " NOT IN " ) );
-  txtSQL->setFocus();
+  mTxtSql->insertText( QStringLiteral( " NOT IN " ) );
+  mTxtSql->setFocus();
 }
 
 void QgsQueryBuilder::btnLike_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " LIKE " ) );
-  txtSQL->setFocus();
+  mTxtSql->insertText( QStringLiteral( " LIKE " ) );
+  mTxtSql->setFocus();
 }
 
 QString QgsQueryBuilder::sql()
 {
-  return txtSQL->text();
+  return mTxtSql->text();
 }
 
 void QgsQueryBuilder::setSql( const QString &sqlStatement )
 {
-  txtSQL->setText( sqlStatement );
+  mTxtSql->setText( sqlStatement );
 }
 
 void QgsQueryBuilder::lstFields_clicked( const QModelIndex &index )
@@ -371,59 +371,59 @@ void QgsQueryBuilder::lstFields_clicked( const QModelIndex &index )
 
 void QgsQueryBuilder::lstFields_doubleClicked( const QModelIndex &index )
 {
-  txtSQL->insertText( '\"' + mLayer->fields().at( mModelFields->data( index, Qt::UserRole + 1 ).toInt() ).name() + '\"' );
-  txtSQL->setFocus();
+  mTxtSql->insertText( '\"' + mLayer->fields().at( mModelFields->data( index, Qt::UserRole + 1 ).toInt() ).name() + '\"' );
+  mTxtSql->setFocus();
 }
 
 void QgsQueryBuilder::lstValues_doubleClicked( const QModelIndex &index )
 {
   QVariant value = index.data( Qt::UserRole + 1 );
   if ( value.isNull() )
-    txtSQL->insertText( QStringLiteral( "NULL" ) );
+    mTxtSql->insertText( QStringLiteral( "NULL" ) );
   else if ( value.type() == QVariant::Date && mLayer->providerType() == QLatin1String( "ogr" ) && mLayer->storageType() == QLatin1String( "ESRI Shapefile" ) )
-    txtSQL->insertText( '\'' + value.toDate().toString( QStringLiteral( "yyyy/MM/dd" ) ) + '\'' );
+    mTxtSql->insertText( '\'' + value.toDate().toString( QStringLiteral( "yyyy/MM/dd" ) ) + '\'' );
   else if ( value.type() == QVariant::Int || value.type() == QVariant::Double || value.type() == QVariant::LongLong || value.type() == QVariant::Bool )
-    txtSQL->insertText( value.toString() );
+    mTxtSql->insertText( value.toString() );
   else
-    txtSQL->insertText( '\'' + value.toString().replace( '\'', QLatin1String( "''" ) ) + '\'' );
+    mTxtSql->insertText( '\'' + value.toString().replace( '\'', QLatin1String( "''" ) ) + '\'' );
 
-  txtSQL->setFocus();
+  mTxtSql->setFocus();
 }
 
 void QgsQueryBuilder::btnLessEqual_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " <= " ) );
-  txtSQL->setFocus();
+  mTxtSql->insertText( QStringLiteral( " <= " ) );
+  mTxtSql->setFocus();
 }
 
 void QgsQueryBuilder::btnGreaterEqual_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " >= " ) );
-  txtSQL->setFocus();
+  mTxtSql->insertText( QStringLiteral( " >= " ) );
+  mTxtSql->setFocus();
 }
 
 void QgsQueryBuilder::btnNotEqual_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " != " ) );
-  txtSQL->setFocus();
+  mTxtSql->insertText( QStringLiteral( " != " ) );
+  mTxtSql->setFocus();
 }
 
 void QgsQueryBuilder::btnAnd_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " AND " ) );
-  txtSQL->setFocus();
+  mTxtSql->insertText( QStringLiteral( " AND " ) );
+  mTxtSql->setFocus();
 }
 
 void QgsQueryBuilder::btnNot_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " NOT " ) );
-  txtSQL->setFocus();
+  mTxtSql->insertText( QStringLiteral( " NOT " ) );
+  mTxtSql->setFocus();
 }
 
 void QgsQueryBuilder::btnOr_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " OR " ) );
-  txtSQL->setFocus();
+  mTxtSql->insertText( QStringLiteral( " OR " ) );
+  mTxtSql->setFocus();
 }
 
 void QgsQueryBuilder::onTextChanged( const QString &text )
@@ -434,14 +434,14 @@ void QgsQueryBuilder::onTextChanged( const QString &text )
 
 void QgsQueryBuilder::clear()
 {
-  txtSQL->clear();
+  mTxtSql->clear();
   mLayer->setSubsetString( QString() );
 }
 
 void QgsQueryBuilder::btnILike_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " ILIKE " ) );
-  txtSQL->setFocus();
+  mTxtSql->insertText( QStringLiteral( " ILIKE " ) );
+  mTxtSql->setFocus();
 }
 
 void QgsQueryBuilder::setDatasourceDescription( const QString &uri )
@@ -479,7 +479,7 @@ void QgsQueryBuilder::saveQuery()
 
   QDomDocument xmlDoc;
   QDomElement queryElem = xmlDoc.createElement( QStringLiteral( "Query" ) );
-  QDomText queryTextNode = xmlDoc.createTextNode( txtSQL->text() );
+  QDomText queryTextNode = xmlDoc.createTextNode( mTxtSql->text() );
   queryElem.appendChild( queryTextNode );
   xmlDoc.appendChild( queryElem );
 
@@ -531,8 +531,8 @@ void QgsQueryBuilder::loadQuery()
     return;
   }
 
-  txtSQL->clear();
-  txtSQL->insertText( query );
+  mTxtSql->clear();
+  mTxtSql->insertText( query );
 }
 
 void QgsQueryBuilder::layerSubsetStringChanged()

--- a/src/gui/qgsquerybuilder.h
+++ b/src/gui/qgsquerybuilder.h
@@ -26,6 +26,7 @@
 #include "qgis_gui.h"
 
 class QgsVectorLayer;
+class QgsCodeEditor;
 
 /**
  * \ingroup gui
@@ -59,18 +60,45 @@ class GUI_EXPORT QgsQueryBuilder : public QDialog, private Ui::QgsQueryBuilderBa
     QString sql();
     void setSql( const QString &sqlStatement );
 
+#ifdef SIP_RUN
+    SIP_IF_FEATURE( HAVE_QSCI_SIP )
+
+    /**
+     * Returns the code editor widget for the SQL.
+     * \since QGIS 3.18
+     */
+    QgsCodeEditor *codeEditorWidget() const;
+    SIP_END
+    SIP_IF_FEATURE( !HAVE_QSCI_SIP )
+
+    /**
+     * Returns the code editor widget for the SQL.
+     * \since QGIS 3.18
+     */
+    QWidget *codeEditorWidget() const;
+    SIP_END
+#else
+
+    /**
+     * Returns the code editor widget for the SQL.
+     * \since QGIS 3.18
+     */
+    QgsCodeEditor *codeEditorWidget() const { return txtSQL; }
+#endif
+
   public slots:
     void accept() override;
     void reject() override;
     void clear();
 
     /**
-     * Test the constructed sql statement to see if the vector layer data provider likes it.
+     * The default implementation tests that the constructed sql statement to
+     * see if the vector layer data provider likes it.
      * The number of rows that would be returned is displayed in a message box.
      * The test uses a "select count(*) from ..." query to test the SQL
      * statement.
      */
-    void test();
+    virtual void test();
 
     /**
      * Save query to the XML file
@@ -105,6 +133,7 @@ class GUI_EXPORT QgsQueryBuilder : public QDialog, private Ui::QgsQueryBuilderBa
     void btnNot_clicked();
     void btnOr_clicked();
     void onTextChanged( const QString &text );
+    void layerSubsetStringChanged();
 
     /**
      * Gets all distinct values for the field. Values are inserted
@@ -150,5 +179,8 @@ class GUI_EXPORT QgsQueryBuilder : public QDialog, private Ui::QgsQueryBuilderBa
 
     //! original subset string
     QString mOrigSubsetString;
+
+    //! whether to ignore subsetStringChanged() signal from the layer
+    bool mIgnoreLayerSubsetStringChangedSignal = false;
 };
 #endif //QGSQUERYBUILDER_H

--- a/src/gui/qgsquerybuilder.h
+++ b/src/gui/qgsquerybuilder.h
@@ -83,7 +83,7 @@ class GUI_EXPORT QgsQueryBuilder : public QDialog, private Ui::QgsQueryBuilderBa
      * Returns the code editor widget for the SQL.
      * \since QGIS 3.18
      */
-    QgsCodeEditor *codeEditorWidget() const { return txtSQL; }
+    QgsCodeEditor *codeEditorWidget() const { return mTxtSql; }
 #endif
 
   public slots:

--- a/src/gui/qgssearchquerybuilder.cpp
+++ b/src/gui/qgssearchquerybuilder.cpp
@@ -191,7 +191,7 @@ void QgsSearchQueryBuilder::btnGetAllValues_clicked()
 
 void QgsSearchQueryBuilder::btnTest_clicked()
 {
-  long count = countRecords( txtSQL->text() );
+  long count = countRecords( mTxtSql->text() );
 
   // error?
   if ( count == -1 )
@@ -259,14 +259,14 @@ long QgsSearchQueryBuilder::countRecords( const QString &searchString )
 void QgsSearchQueryBuilder::btnOk_clicked()
 {
   // if user hits OK and there is no query, skip the validation
-  if ( txtSQL->text().trimmed().length() > 0 )
+  if ( mTxtSql->text().trimmed().length() > 0 )
   {
     accept();
     return;
   }
 
   // test the query to see if it will result in a valid layer
-  long numRecs = countRecords( txtSQL->text() );
+  long numRecs = countRecords( mTxtSql->text() );
   if ( numRecs == -1 )
   {
     // error shown in countRecords
@@ -284,97 +284,97 @@ void QgsSearchQueryBuilder::btnOk_clicked()
 
 void QgsSearchQueryBuilder::btnEqual_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " = " ) );
+  mTxtSql->insertText( QStringLiteral( " = " ) );
 }
 
 void QgsSearchQueryBuilder::btnLessThan_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " < " ) );
+  mTxtSql->insertText( QStringLiteral( " < " ) );
 }
 
 void QgsSearchQueryBuilder::btnGreaterThan_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " > " ) );
+  mTxtSql->insertText( QStringLiteral( " > " ) );
 }
 
 void QgsSearchQueryBuilder::btnPct_clicked()
 {
-  txtSQL->insertText( QStringLiteral( "%" ) );
+  mTxtSql->insertText( QStringLiteral( "%" ) );
 }
 
 void QgsSearchQueryBuilder::btnIn_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " IN " ) );
+  mTxtSql->insertText( QStringLiteral( " IN " ) );
 }
 
 void QgsSearchQueryBuilder::btnNotIn_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " NOT IN " ) );
+  mTxtSql->insertText( QStringLiteral( " NOT IN " ) );
 }
 
 void QgsSearchQueryBuilder::btnLike_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " LIKE " ) );
+  mTxtSql->insertText( QStringLiteral( " LIKE " ) );
 }
 
 QString QgsSearchQueryBuilder::searchString()
 {
-  return txtSQL->text();
+  return mTxtSql->text();
 }
 
 void QgsSearchQueryBuilder::setSearchString( const QString &searchString )
 {
-  txtSQL->setText( searchString );
+  mTxtSql->setText( searchString );
 }
 
 void QgsSearchQueryBuilder::lstFields_doubleClicked( const QModelIndex &index )
 {
-  txtSQL->insertText( QgsExpression::quotedColumnRef( mModelFields->data( index ).toString() ) );
+  mTxtSql->insertText( QgsExpression::quotedColumnRef( mModelFields->data( index ).toString() ) );
 }
 
 void QgsSearchQueryBuilder::lstValues_doubleClicked( const QModelIndex &index )
 {
-  txtSQL->insertText( mModelValues->data( index ).toString() );
+  mTxtSql->insertText( mModelValues->data( index ).toString() );
 }
 
 void QgsSearchQueryBuilder::btnLessEqual_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " <= " ) );
+  mTxtSql->insertText( QStringLiteral( " <= " ) );
 }
 
 void QgsSearchQueryBuilder::btnGreaterEqual_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " >= " ) );
+  mTxtSql->insertText( QStringLiteral( " >= " ) );
 }
 
 void QgsSearchQueryBuilder::btnNotEqual_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " != " ) );
+  mTxtSql->insertText( QStringLiteral( " != " ) );
 }
 
 void QgsSearchQueryBuilder::btnAnd_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " AND " ) );
+  mTxtSql->insertText( QStringLiteral( " AND " ) );
 }
 
 void QgsSearchQueryBuilder::btnNot_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " NOT " ) );
+  mTxtSql->insertText( QStringLiteral( " NOT " ) );
 }
 
 void QgsSearchQueryBuilder::btnOr_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " OR " ) );
+  mTxtSql->insertText( QStringLiteral( " OR " ) );
 }
 
 void QgsSearchQueryBuilder::btnClear_clicked()
 {
-  txtSQL->clear();
+  mTxtSql->clear();
 }
 
 void QgsSearchQueryBuilder::btnILike_clicked()
 {
-  txtSQL->insertText( QStringLiteral( " ILIKE " ) );
+  mTxtSql->insertText( QStringLiteral( " ILIKE " ) );
 }
 
 void QgsSearchQueryBuilder::saveQuery()
@@ -402,7 +402,7 @@ void QgsSearchQueryBuilder::saveQuery()
 
   QDomDocument xmlDoc;
   QDomElement queryElem = xmlDoc.createElement( QStringLiteral( "Query" ) );
-  QDomText queryTextNode = xmlDoc.createTextNode( txtSQL->text() );
+  QDomText queryTextNode = xmlDoc.createTextNode( mTxtSql->text() );
   queryElem.appendChild( queryTextNode );
   xmlDoc.appendChild( queryElem );
 
@@ -506,8 +506,8 @@ void QgsSearchQueryBuilder::loadQuery()
   }
 #endif
 
-  txtSQL->clear();
-  txtSQL->insertText( newQueryText );
+  mTxtSql->clear();
+  mTxtSql->insertText( newQueryText );
 }
 
 void QgsSearchQueryBuilder::showHelp()

--- a/src/ui/qgsquerybuilderbase.ui
+++ b/src/ui/qgsquerybuilderbase.ui
@@ -323,7 +323,7 @@ p, li { white-space: pre-wrap; }
            <number>11</number>
           </property>
           <item row="0" column="0">
-           <widget class="QgsCodeEditorSQL" name="txtSQL" native="true"/>
+           <widget class="QgsCodeEditorSQL" name="mTxtSql" native="true"/>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
- Make test() method virtual so it can be overriden in a derived class
- Make enabling/disabling of "use unfiltered layer" checkbox automatic
  when layer's subsetString is changed (for example by an overriden
  test() implementation)
- Add a codeEditorWidget() method that returns the sql editor widget,
  so that custom behavior can be added.
