### PR TITLE
Move getters and setters for layer opacity from QgsVectorLayer to QgsMapLayer

### DIFF
--- a/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
@@ -93,22 +93,6 @@ This map contains references to items owned by the layer, and ownership of these
 with the layer.
 %End
 
-    void setOpacity( double opacity );
-%Docstring
-Sets the ``opacity`` for the annotation layer, where ``opacity`` is a value between 0 (totally transparent)
-and 1.0 (fully opaque).
-
-.. seealso:: :py:func:`opacity`
-%End
-
-    double opacity() const;
-%Docstring
-Returns the opacity for the annotation layer, where opacity is a value between 0 (totally transparent)
-and 1.0 (fully opaque).
-
-.. seealso:: :py:func:`setOpacity`
-%End
-
     virtual QgsAnnotationLayer *clone() const /Factory/;
 
     virtual QgsMapLayerRenderer *createMapRenderer( QgsRenderContext &rendererContext ) /Factory/;

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -450,6 +450,38 @@ Returns the current blending mode for a layer.
 .. seealso:: :py:func:`setBlendMode`
 %End
 
+    void setOpacity( double opacity );
+%Docstring
+Sets the ``opacity`` for the layer, where ``opacity`` is a value between 0 (totally transparent)
+and 1.0 (fully opaque).
+
+.. seealso:: :py:func:`opacity`
+
+.. seealso:: :py:func:`opacityChanged`
+
+.. note::
+
+   Prior to QGIS 3.18, this method was available for vector layers only
+
+.. versionadded:: 3.18
+%End
+
+    double opacity() const;
+%Docstring
+Returns the opacity for the layer, where opacity is a value between 0 (totally transparent)
+and 1.0 (fully opaque).
+
+.. seealso:: :py:func:`setOpacity`
+
+.. seealso:: :py:func:`opacityChanged`
+
+.. note::
+
+   Prior to QGIS 3.18, this method was available for vector layers only
+
+.. versionadded:: 3.18
+%End
+
     bool readOnly() const;
 %Docstring
 Returns if this layer is read only.
@@ -1490,6 +1522,22 @@ Data of layer changed
 Signal emitted when the blend mode is changed, through :py:func:`QgsMapLayer.setBlendMode()`
 %End
 
+    void opacityChanged( double opacity );
+%Docstring
+Emitted when the layer's opacity is changed, where ``opacity`` is a value between 0 (transparent)
+and 1 (opaque).
+
+.. seealso:: :py:func:`setOpacity`
+
+.. seealso:: :py:func:`opacity`
+
+.. note::
+
+   Prior to QGIS 3.18, this signal was available for vector layers only
+
+.. versionadded:: 3.18
+%End
+
     void rendererChanged();
 %Docstring
 Signal emitted when renderer is changed.
@@ -1740,6 +1788,7 @@ this method is now deprecated and always return ``False``, because circular depe
 
 .. deprecated:: QGIS 3.10
 %End
+
 
 
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -450,7 +450,7 @@ Returns the current blending mode for a layer.
 .. seealso:: :py:func:`setBlendMode`
 %End
 
-    void setOpacity( double opacity );
+    virtual void setOpacity( double opacity );
 %Docstring
 Sets the ``opacity`` for the layer, where ``opacity`` is a value between 0 (totally transparent)
 and 1.0 (fully opaque).
@@ -466,7 +466,7 @@ and 1.0 (fully opaque).
 .. versionadded:: 3.18
 %End
 
-    double opacity() const;
+    virtual double opacity() const;
 %Docstring
 Returns the opacity for the layer, where opacity is a value between 0 (totally transparent)
 and 1.0 (fully opaque).

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -2408,30 +2408,6 @@ Sets the blending mode used for rendering each feature
 Returns the current blending mode for features
 %End
 
-    void setOpacity( double opacity );
-%Docstring
-Sets the ``opacity`` for the vector layer, where ``opacity`` is a value between 0 (totally transparent)
-and 1.0 (fully opaque).
-
-.. seealso:: :py:func:`opacity`
-
-.. seealso:: :py:func:`opacityChanged`
-
-.. versionadded:: 3.0
-%End
-
-    double opacity() const;
-%Docstring
-Returns the opacity for the vector layer, where opacity is a value between 0 (totally transparent)
-and 1.0 (fully opaque).
-
-.. seealso:: :py:func:`setOpacity`
-
-.. seealso:: :py:func:`opacityChanged`
-
-.. versionadded:: 3.0
-%End
-
     virtual QString htmlMetadata() const ${SIP_FINAL};
 
 
@@ -2862,18 +2838,6 @@ Emitted when the font family defined for labeling layer is not found on system
     void featureBlendModeChanged( QPainter::CompositionMode blendMode );
 %Docstring
 Signal emitted when :py:func:`~QgsVectorLayer.setFeatureBlendMode` is called
-%End
-
-    void opacityChanged( double opacity );
-%Docstring
-Emitted when the layer's opacity is changed, where ``opacity`` is a value between 0 (transparent)
-and 1 (opaque).
-
-.. seealso:: :py:func:`setOpacity`
-
-.. seealso:: :py:func:`opacity`
-
-.. versionadded:: 3.0
 %End
 
     void editCommandStarted( const QString &text );

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -338,6 +338,11 @@ In a world file, this is normally the first row (without the sign).
 .. seealso:: :py:func:`rasterUnitsPerPixelX`
 %End
 
+    virtual void setOpacity( double opacity ) ${SIP_FINAL};
+
+    virtual double opacity() const ${SIP_FINAL};
+
+
     void setContrastEnhancement( QgsContrastEnhancement::ContrastEnhancementAlgorithm algorithm,
                                  QgsRasterMinMaxOrigin::Limits limits = QgsRasterMinMaxOrigin::MinMax,
                                  const QgsRectangle &extent = QgsRectangle(),

--- a/src/core/annotations/qgsannotationlayer.cpp
+++ b/src/core/annotations/qgsannotationlayer.cpp
@@ -38,7 +38,7 @@ QgsAnnotationLayer::~QgsAnnotationLayer()
 
 void QgsAnnotationLayer::reset()
 {
-  mOpacity = 1.0;
+  setOpacity( 1.0 );
   setCrs( QgsCoordinateReferenceSystem() );
   setTransformContext( QgsCoordinateTransformContext() );
   clear();
@@ -79,19 +79,11 @@ bool QgsAnnotationLayer::isEmpty() const
   return mItems.empty();
 }
 
-void QgsAnnotationLayer::setOpacity( double opacity )
-{
-  mOpacity = opacity;
-  triggerRepaint();
-}
-
 QgsAnnotationLayer *QgsAnnotationLayer::clone() const
 {
   QgsAnnotationLayer::LayerOptions options( mTransformContext );
   std::unique_ptr< QgsAnnotationLayer > layer = qgis::make_unique< QgsAnnotationLayer >( name(), options );
   QgsMapLayer::clone( layer.get() );
-
-  layer->setOpacity( opacity() );
 
   for ( auto it = mItems.constBegin(); it != mItems.constEnd(); ++it )
   {

--- a/src/core/annotations/qgsannotationlayer.cpp
+++ b/src/core/annotations/qgsannotationlayer.cpp
@@ -20,6 +20,7 @@
 #include "qgsannotationitemregistry.h"
 #include "qgsapplication.h"
 #include "qgslogger.h"
+#include "qgspainting.h"
 #include <QUuid>
 
 QgsAnnotationLayer::QgsAnnotationLayer( const QString &name, const LayerOptions &options )
@@ -195,6 +196,16 @@ bool QgsAnnotationLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QStr
     layerOpacityElem.appendChild( layerOpacityText );
     node.appendChild( layerOpacityElem );
   }
+
+  if ( categories.testFlag( Symbology ) )
+  {
+    // add the blend mode field
+    QDomElement blendModeElem  = doc.createElement( QStringLiteral( "blendMode" ) );
+    QDomText blendModeText = doc.createTextNode( QString::number( QgsPainting::getBlendModeEnum( blendMode() ) ) );
+    blendModeElem.appendChild( blendModeText );
+    node.appendChild( blendModeElem );
+  }
+
   return true;
 }
 
@@ -209,5 +220,17 @@ bool QgsAnnotationLayer::readSymbology( const QDomNode &node, QString &, QgsRead
       setOpacity( e.text().toDouble() );
     }
   }
+
+  if ( categories.testFlag( Symbology ) )
+  {
+    // get and set the blend mode if it exists
+    QDomNode blendModeNode = node.namedItem( QStringLiteral( "blendMode" ) );
+    if ( !blendModeNode.isNull() )
+    {
+      QDomElement e = blendModeNode.toElement();
+      setBlendMode( QgsPainting::getCompositionMode( static_cast< QgsPainting::BlendMode >( e.text().toInt() ) ) );
+    }
+  }
+
   return true;
 }

--- a/src/core/annotations/qgsannotationlayer.h
+++ b/src/core/annotations/qgsannotationlayer.h
@@ -117,20 +117,6 @@ class CORE_EXPORT QgsAnnotationLayer : public QgsMapLayer
      */
     QMap<QString, QgsAnnotationItem *> items() const { return mItems; }
 
-    /**
-     * Sets the \a opacity for the annotation layer, where \a opacity is a value between 0 (totally transparent)
-     * and 1.0 (fully opaque).
-     * \see opacity()
-     */
-    void setOpacity( double opacity );
-
-    /**
-     * Returns the opacity for the annotation layer, where opacity is a value between 0 (totally transparent)
-     * and 1.0 (fully opaque).
-     * \see setOpacity()
-     */
-    double opacity() const { return mOpacity; }
-
     QgsAnnotationLayer *clone() const override SIP_FACTORY;
     QgsMapLayerRenderer *createMapRenderer( QgsRenderContext &rendererContext ) override SIP_FACTORY;
     QgsRectangle extent() const override;
@@ -142,7 +128,6 @@ class CORE_EXPORT QgsAnnotationLayer : public QgsMapLayer
 
   private:
     QMap<QString, QgsAnnotationItem *> mItems;
-    double mOpacity = 1;
     QgsCoordinateTransformContext mTransformContext;
 };
 

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -623,8 +623,8 @@ QSizeF QgsSymbolLegendNode::drawSymbol( const QgsLegendSettings &settings, ItemC
     double dotsPerMM = context->scaleFactor();
 
     int opacity = 255;
-    if ( QgsVectorLayer *vectorLayer = qobject_cast<QgsVectorLayer *>( layerNode()->layer() ) )
-      opacity = static_cast<int >( std::round( 255 * vectorLayer->opacity() ) );
+    if ( QgsMapLayer *layer = layerNode()->layer() )
+      opacity = static_cast<int >( std::round( 255 * layer->opacity() ) );
 
     QgsScopedQPainterState painterState( p );
     context->setPainterFlagsUsingContext( p );
@@ -718,8 +718,8 @@ QJsonObject QgsSymbolLegendNode::exportSymbolToJson( const QgsLegendSettings &se
   QImage img( pix.toImage().convertToFormat( QImage::Format_ARGB32_Premultiplied ) );
 
   int opacity = 255;
-  if ( QgsVectorLayer *vectorLayer = qobject_cast<QgsVectorLayer *>( layerNode()->layer() ) )
-    opacity = ( 255 * vectorLayer->opacity() );
+  if ( QgsMapLayer *layer = layerNode()->layer() )
+    opacity = ( 255 * layer->opacity() );
 
   if ( opacity != 255 )
   {

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -1056,6 +1056,17 @@ bool QgsMeshLayer::readSymbology( const QDomNode &node, QString &errorMessage,
     setBlendMode( QgsPainting::getCompositionMode( static_cast< QgsPainting::BlendMode >( e.text().toInt() ) ) );
   }
 
+  // get and set the layer transparency
+  if ( categories.testFlag( Rendering ) )
+  {
+    QDomNode layerOpacityNode = node.namedItem( QStringLiteral( "layerOpacity" ) );
+    if ( !layerOpacityNode.isNull() )
+    {
+      QDomElement e = layerOpacityNode.toElement();
+      setOpacity( e.text().toDouble() );
+    }
+  }
+
   return true;
 }
 
@@ -1080,6 +1091,15 @@ bool QgsMeshLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString &e
   QDomText blendModeText = doc.createTextNode( QString::number( QgsPainting::getBlendModeEnum( blendMode() ) ) );
   blendModeElement.appendChild( blendModeText );
   node.appendChild( blendModeElement );
+
+  // add the layer opacity
+  if ( categories.testFlag( Rendering ) )
+  {
+    QDomElement layerOpacityElem  = doc.createElement( QStringLiteral( "layerOpacity" ) );
+    QDomText layerOpacityText = doc.createTextNode( QString::number( opacity() ) );
+    layerOpacityElem.appendChild( layerOpacityText );
+    node.appendChild( layerOpacityElem );
+  }
 
   return true;
 }

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -182,14 +182,12 @@ bool QgsPointCloudLayer::readStyle( const QDomNode &node, QString &, QgsReadWrit
   // get and set the layer transparency and scale visibility if they exists
   if ( categories.testFlag( Rendering ) )
   {
-#if 0 // TODO
     QDomNode layerOpacityNode = node.namedItem( QStringLiteral( "layerOpacity" ) );
     if ( !layerOpacityNode.isNull() )
     {
       QDomElement e = layerOpacityNode.toElement();
       setOpacity( e.text().toDouble() );
     }
-#endif
 
     const bool hasScaleBasedVisibiliy { node.attributes().namedItem( QStringLiteral( "hasScaleBasedVisibilityFlag" ) ).nodeValue() == '1' };
     setScaleBasedVisibility( hasScaleBasedVisibiliy );
@@ -252,12 +250,11 @@ bool QgsPointCloudLayer::writeStyle( QDomNode &node, QDomDocument &doc, QString 
   // add the layer opacity and scale visibility
   if ( categories.testFlag( Rendering ) )
   {
-#if 0 // TODO
-    QDomElement layerOpacityElem  = doc.createElement( QStringLiteral( "layerOpacity" ) );
+    QDomElement layerOpacityElem = doc.createElement( QStringLiteral( "layerOpacity" ) );
     QDomText layerOpacityText = doc.createTextNode( QString::number( opacity() ) );
     layerOpacityElem.appendChild( layerOpacityText );
     node.appendChild( layerOpacityElem );
-#endif
+
     mapLayerNode.setAttribute( QStringLiteral( "hasScaleBasedVisibilityFlag" ), hasScaleBasedVisibility() ? 1 : 0 );
     mapLayerNode.setAttribute( QStringLiteral( "maxScale" ), maximumScale() );
     mapLayerNode.setAttribute( QStringLiteral( "minScale" ), minimumScale() );

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -252,6 +252,7 @@ void QgsApplication::init( QString profileFolder )
   QMetaType::registerComparators<QgsProcessingModelChildDependency>();
   QMetaType::registerEqualsComparator<QgsProcessingFeatureSourceDefinition>();
   QMetaType::registerEqualsComparator<QgsProperty>();
+  qRegisterMetaType<QPainter::CompositionMode>( "QPainter::CompositionMode" );
 
   ( void ) resolvePkgPath();
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -124,6 +124,7 @@ void QgsMapLayer::clone( QgsMapLayer *layer ) const
   layer->mShouldValidateCrs = mShouldValidateCrs;
   layer->setCrs( crs() );
   layer->setCustomProperties( mCustomProperties );
+  layer->setOpacity( mLayerOpacity );
 }
 
 QgsMapLayerType QgsMapLayer::type() const
@@ -214,6 +215,19 @@ QPainter::CompositionMode QgsMapLayer::blendMode() const
   return mBlendMode;
 }
 
+void QgsMapLayer::setOpacity( double opacity )
+{
+  if ( qgsDoubleNear( mLayerOpacity, opacity ) )
+    return;
+  mLayerOpacity = opacity;
+  emit opacityChanged( opacity );
+  emit styleChanged();
+}
+
+double QgsMapLayer::opacity() const
+{
+  return mLayerOpacity;
+}
 
 bool QgsMapLayer::readLayerXml( const QDomElement &layerElement, QgsReadWriteContext &context, QgsMapLayer::ReadFlags flags )
 {

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -483,7 +483,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \note Prior to QGIS 3.18, this method was available for vector layers only
      * \since QGIS 3.18
      */
-    void setOpacity( double opacity );
+    virtual void setOpacity( double opacity );
 
     /**
      * Returns the opacity for the layer, where opacity is a value between 0 (totally transparent)
@@ -493,7 +493,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \note Prior to QGIS 3.18, this method was available for vector layers only
      * \since QGIS 3.18
      */
-    double opacity() const;
+    virtual double opacity() const;
 
     //! Returns if this layer is read only.
     bool readOnly() const { return isReadOnly(); }

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -90,6 +90,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     Q_PROPERTY( QgsCoordinateReferenceSystem crs READ crs WRITE setCrs NOTIFY crsChanged )
     Q_PROPERTY( QgsMapLayerType type READ type CONSTANT )
     Q_PROPERTY( bool isValid READ isValid NOTIFY isValidChanged )
+    Q_PROPERTY( double opacity READ opacity WRITE setOpacity NOTIFY opacityChanged )
 
 #ifdef SIP_RUN
     SIP_CONVERT_TO_SUBCLASS_CODE
@@ -473,6 +474,26 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \see setBlendMode()
     */
     QPainter::CompositionMode blendMode() const;
+
+    /**
+     * Sets the \a opacity for the layer, where \a opacity is a value between 0 (totally transparent)
+     * and 1.0 (fully opaque).
+     * \see opacity()
+     * \see opacityChanged()
+     * \note Prior to QGIS 3.18, this method was available for vector layers only
+     * \since QGIS 3.18
+     */
+    void setOpacity( double opacity );
+
+    /**
+     * Returns the opacity for the layer, where opacity is a value between 0 (totally transparent)
+     * and 1.0 (fully opaque).
+     * \see setOpacity()
+     * \see opacityChanged()
+     * \note Prior to QGIS 3.18, this method was available for vector layers only
+     * \since QGIS 3.18
+     */
+    double opacity() const;
 
     //! Returns if this layer is read only.
     bool readOnly() const { return isReadOnly(); }
@@ -1338,6 +1359,16 @@ class CORE_EXPORT QgsMapLayer : public QObject
     void blendModeChanged( QPainter::CompositionMode blendMode );
 
     /**
+     * Emitted when the layer's opacity is changed, where \a opacity is a value between 0 (transparent)
+     * and 1 (opaque).
+     * \see setOpacity()
+     * \see opacity()
+     * \note Prior to QGIS 3.18, this signal was available for vector layers only
+     * \since QGIS 3.18
+     */
+    void opacityChanged( double opacity );
+
+    /**
      * Signal emitted when renderer is changed.
      * \see styleChanged()
     */
@@ -1605,6 +1636,13 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \since QGIS 3.10
      */
     bool mShouldValidateCrs = true;
+
+    /**
+     * Layer opacity.
+     *
+     * \since QGIS 3.18
+     */
+    double mLayerOpacity = 1.0;
 
   private:
 

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -78,7 +78,7 @@ QHash<QgsMapLayer *, int> QgsMapRendererJob::perLayerRenderingTime() const
   QHash<QgsMapLayer *, int> result;
   for ( auto it = mPerLayerRenderingTime.constBegin(); it != mPerLayerRenderingTime.constEnd(); ++it )
   {
-    if ( auto && lKey = it.key() )
+    if ( auto &&lKey = it.key() )
       result.insert( lKey, it.value() );
   }
   return result;
@@ -395,7 +395,10 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter *painter, QgsLabelingEn
       styleOverride.setOverrideStyle( mSettings.layerStyleOverrides().value( ml->id() ) );
 
     job.blendMode = ml->blendMode();
-    job.opacity = ml->opacity();
+
+    // raster layer opacity is handled directly within the raster layer renderer, so don't
+    // apply default opacity handling here!
+    job.opacity = ml->type() != QgsMapLayerType::RasterLayer ? ml->opacity() : 1.0;
 
     // if we can use the cache, let's do it and avoid rendering!
     if ( mCache && mCache->hasCacheImage( ml->id() ) )

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -78,7 +78,7 @@ QHash<QgsMapLayer *, int> QgsMapRendererJob::perLayerRenderingTime() const
   QHash<QgsMapLayer *, int> result;
   for ( auto it = mPerLayerRenderingTime.constBegin(); it != mPerLayerRenderingTime.constEnd(); ++it )
   {
-    if ( auto &&lKey = it.key() )
+    if ( auto && lKey = it.key() )
       result.insert( lKey, it.value() );
   }
   return result;
@@ -395,15 +395,7 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter *painter, QgsLabelingEn
       styleOverride.setOverrideStyle( mSettings.layerStyleOverrides().value( ml->id() ) );
 
     job.blendMode = ml->blendMode();
-    job.opacity = 1.0;
-    if ( vl )
-    {
-      job.opacity = vl->opacity();
-    }
-    else if ( QgsAnnotationLayer *al = qobject_cast<QgsAnnotationLayer *>( ml ) )
-    {
-      job.opacity = al->opacity();
-    }
+    job.opacity = ml->opacity();
 
     // if we can use the cache, let's do it and avoid rendering!
     if ( mCache && mCache->hasCacheImage( ml->id() ) )
@@ -964,13 +956,10 @@ bool QgsMapRendererJob::needTemporaryImage( QgsMapLayer *ml )
     case QgsMapLayerType::PointCloudLayer:
     case QgsMapLayerType::VectorTileLayer:
     case QgsMapLayerType::PluginLayer:
-      break;
-
     case QgsMapLayerType::AnnotationLayer:
     {
-      QgsAnnotationLayer *al = qobject_cast<QgsAnnotationLayer *>( ml );
       if ( mSettings.testFlag( QgsMapSettings::UseAdvancedEffects ) &&
-           ( !qgsDoubleNear( al->opacity(), 1.0 ) ) )
+           ( !qgsDoubleNear( ml->opacity(), 1.0 ) ) )
       {
         //layer properties require rasterization
         return true;

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -276,7 +276,6 @@ QgsVectorLayer *QgsVectorLayer::clone() const
   layer->selectByIds( selectedFeatureIds() );
   layer->setAttributeTableConfig( attributeTableConfig() );
   layer->setFeatureBlendMode( featureBlendMode() );
-  layer->setOpacity( opacity() );
   layer->setReadExtentFromXml( readExtentFromXml() );
 
   const auto constActions = actions()->actions();
@@ -4341,22 +4340,6 @@ QPainter::CompositionMode QgsVectorLayer::featureBlendMode() const
 {
   return mFeatureBlendMode;
 }
-
-void QgsVectorLayer::setOpacity( double opacity )
-{
-  if ( qgsDoubleNear( mLayerOpacity, opacity ) )
-    return;
-  mLayerOpacity = opacity;
-  emit opacityChanged( opacity );
-  emit styleChanged();
-}
-
-double QgsVectorLayer::opacity() const
-{
-  return mLayerOpacity;
-}
-
-
 
 void QgsVectorLayer::readSldLabeling( const QDomNode &node )
 {

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -392,7 +392,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     Q_PROPERTY( QString mapTipTemplate READ mapTipTemplate WRITE setMapTipTemplate NOTIFY mapTipTemplateChanged )
     Q_PROPERTY( QgsEditFormConfig editFormConfig READ editFormConfig WRITE setEditFormConfig NOTIFY editFormConfigChanged )
     Q_PROPERTY( bool readOnly READ isReadOnly WRITE setReadOnly NOTIFY readOnlyChanged )
-    Q_PROPERTY( double opacity READ opacity WRITE setOpacity NOTIFY opacityChanged )
 
   public:
 
@@ -2222,24 +2221,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     //! Returns the current blending mode for features
     QPainter::CompositionMode featureBlendMode() const;
 
-    /**
-     * Sets the \a opacity for the vector layer, where \a opacity is a value between 0 (totally transparent)
-     * and 1.0 (fully opaque).
-     * \see opacity()
-     * \see opacityChanged()
-     * \since QGIS 3.0
-     */
-    void setOpacity( double opacity );
-
-    /**
-     * Returns the opacity for the vector layer, where opacity is a value between 0 (totally transparent)
-     * and 1.0 (fully opaque).
-     * \see setOpacity()
-     * \see opacityChanged()
-     * \since QGIS 3.0
-     */
-    double opacity() const;
-
     QString htmlMetadata() const FINAL;
 
     /**
@@ -2661,15 +2642,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void featureBlendModeChanged( QPainter::CompositionMode blendMode );
 
     /**
-     * Emitted when the layer's opacity is changed, where \a opacity is a value between 0 (transparent)
-     * and 1 (opaque).
-     * \see setOpacity()
-     * \see opacity()
-     * \since QGIS 3.0
-     */
-    void opacityChanged( double opacity );
-
-    /**
      * Signal emitted when a new edit command has been started
      *
      * \param text Description for this edit command
@@ -2887,9 +2859,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     //! Blend mode for features
     QPainter::CompositionMode mFeatureBlendMode = QPainter::CompositionMode_SourceOver;
-
-    //! Layer opacity
-    double mLayerOpacity = 1.0;
 
     //! Flag if the vertex markers should be drawn only for selection (TRUE) or for all features (FALSE)
     bool mVertexMarkerOnlyForSelection = false;

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -590,6 +590,21 @@ double QgsRasterLayer::rasterUnitsPerPixelY() const
   return 1;
 }
 
+void QgsRasterLayer::setOpacity( double opacity )
+{
+  if ( !mPipe.renderer() || mPipe.renderer()->opacity() == opacity )
+    return;
+
+  mPipe.renderer()->setOpacity( opacity );
+  emit opacityChanged( opacity );
+  emit styleChanged();
+}
+
+double QgsRasterLayer::opacity() const
+{
+  return mPipe.renderer() ? mPipe.renderer()->opacity() : 1.0;
+}
+
 void QgsRasterLayer::init()
 {
   mRasterType = QgsRasterLayer::GrayOrUndefined;

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -379,6 +379,9 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
      */
     double rasterUnitsPerPixelY() const;
 
+    void setOpacity( double opacity ) FINAL;
+    double opacity() const FINAL;
+
     /**
      * \brief Set contrast enhancement algorithm
      *  \param algorithm Contrast enhancement algorithm

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -30,6 +30,7 @@
 #include "qgsblockingnetworkrequest.h"
 #include "qgsmapboxglstyleconverter.h"
 #include "qgsjsonutils.h"
+#include "qgspainting.h"
 
 QgsVectorTileLayer::QgsVectorTileLayer( const QString &uri, const QString &baseName )
   : QgsMapLayer( QgsMapLayerType::VectorTileLayer, baseName )
@@ -265,6 +266,28 @@ bool QgsVectorTileLayer::readSymbology( const QDomNode &node, QString &errorMess
     }
   }
 
+  if ( categories.testFlag( Symbology ) )
+  {
+    // get and set the blend mode if it exists
+    QDomNode blendModeNode = node.namedItem( QStringLiteral( "blendMode" ) );
+    if ( !blendModeNode.isNull() )
+    {
+      QDomElement e = blendModeNode.toElement();
+      setBlendMode( QgsPainting::getCompositionMode( static_cast< QgsPainting::BlendMode >( e.text().toInt() ) ) );
+    }
+  }
+
+  // get and set the layer transparency
+  if ( categories.testFlag( Rendering ) )
+  {
+    QDomNode layerOpacityNode = node.namedItem( QStringLiteral( "layerOpacity" ) );
+    if ( !layerOpacityNode.isNull() )
+    {
+      QDomElement e = layerOpacityNode.toElement();
+      setOpacity( e.text().toDouble() );
+    }
+  }
+
   return true;
 }
 
@@ -292,6 +315,24 @@ bool QgsVectorTileLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QStr
     elemLabeling.setAttribute( QStringLiteral( "type" ), mLabeling->type() );
     mLabeling->writeXml( elemLabeling, context );
     elem.appendChild( elemLabeling );
+  }
+
+  if ( categories.testFlag( Symbology ) )
+  {
+    // add the blend mode field
+    QDomElement blendModeElem  = doc.createElement( QStringLiteral( "blendMode" ) );
+    QDomText blendModeText = doc.createTextNode( QString::number( QgsPainting::getBlendModeEnum( blendMode() ) ) );
+    blendModeElem.appendChild( blendModeText );
+    node.appendChild( blendModeElem );
+  }
+
+  // add the layer opacity
+  if ( categories.testFlag( Rendering ) )
+  {
+    QDomElement layerOpacityElem  = doc.createElement( QStringLiteral( "layerOpacity" ) );
+    QDomText layerOpacityText = doc.createTextNode( QString::number( opacity() ) );
+    layerOpacityElem.appendChild( layerOpacityText );
+    node.appendChild( layerOpacityElem );
   }
 
   return true;

--- a/src/gui/layertree/qgslayertreeembeddedwidgetsimpl.cpp
+++ b/src/gui/layertree/qgslayertreeembeddedwidgetsimpl.cpp
@@ -61,10 +61,14 @@ QgsLayerTreeOpacityWidget::QgsLayerTreeOpacityWidget( QgsMapLayer *layer )
   switch ( mLayer->type() )
   {
     case QgsMapLayerType::VectorLayer:
+    case QgsMapLayerType::PluginLayer:
+    case QgsMapLayerType::MeshLayer:
+    case QgsMapLayerType::VectorTileLayer:
+    case QgsMapLayerType::AnnotationLayer:
+    case QgsMapLayerType::PointCloudLayer:
     {
-      QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( mLayer );
-      mSlider->setValue( vl->opacity() * 1000.0 );
-      connect( vl, &QgsVectorLayer::opacityChanged, this, &QgsLayerTreeOpacityWidget::layerTrChanged );
+      mSlider->setValue( mLayer->opacity() * 1000.0 );
+      connect( mLayer, &QgsMapLayer::opacityChanged, this, &QgsLayerTreeOpacityWidget::layerTrChanged );
       break;
     }
 
@@ -74,14 +78,6 @@ QgsLayerTreeOpacityWidget::QgsLayerTreeOpacityWidget( QgsMapLayer *layer )
       // TODO: there is no signal for raster layers
       break;
     }
-
-    case QgsMapLayerType::PluginLayer:
-    case QgsMapLayerType::MeshLayer:
-    case QgsMapLayerType::VectorTileLayer:
-    case QgsMapLayerType::AnnotationLayer:
-    case QgsMapLayerType::PointCloudLayer:
-      break;
-
   }
 }
 
@@ -107,22 +103,21 @@ void QgsLayerTreeOpacityWidget::updateOpacityFromSlider()
   switch ( mLayer->type() )
   {
     case QgsMapLayerType::VectorLayer:
-    {
-      qobject_cast<QgsVectorLayer *>( mLayer )->setOpacity( value / 1000.0 );
-      break;
-    }
-    case QgsMapLayerType::RasterLayer:
-    {
-      qobject_cast<QgsRasterLayer *>( mLayer )->renderer()->setOpacity( value / 1000.0 );
-      break;
-    }
-
     case QgsMapLayerType::PluginLayer:
     case QgsMapLayerType::MeshLayer:
     case QgsMapLayerType::VectorTileLayer:
     case QgsMapLayerType::AnnotationLayer:
     case QgsMapLayerType::PointCloudLayer:
+    {
+      mLayer->setOpacity( value / 1000.0 );
       break;
+    }
+
+    case QgsMapLayerType::RasterLayer:
+    {
+      qobject_cast<QgsRasterLayer *>( mLayer )->renderer()->setOpacity( value / 1000.0 );
+      break;
+    }
   }
 
   mLayer->triggerRepaint();
@@ -131,7 +126,7 @@ void QgsLayerTreeOpacityWidget::updateOpacityFromSlider()
 void QgsLayerTreeOpacityWidget::layerTrChanged()
 {
   mSlider->blockSignals( true );
-  mSlider->setValue( qobject_cast<QgsVectorLayer *>( mLayer )->opacity() * 1000.0 );
+  mSlider->setValue( mLayer->opacity() * 1000.0 );
   mSlider->blockSignals( false );
 }
 
@@ -153,22 +148,9 @@ QgsLayerTreeOpacityWidget *QgsLayerTreeOpacityWidget::Provider::createWidget( Qg
   return new QgsLayerTreeOpacityWidget( layer );
 }
 
-bool QgsLayerTreeOpacityWidget::Provider::supportsLayer( QgsMapLayer *layer )
+bool QgsLayerTreeOpacityWidget::Provider::supportsLayer( QgsMapLayer * )
 {
-  switch ( layer->type() )
-  {
-    case QgsMapLayerType::VectorLayer:
-    case QgsMapLayerType::RasterLayer:
-      return true;
-
-    case QgsMapLayerType::MeshLayer:
-    case QgsMapLayerType::VectorTileLayer:
-    case QgsMapLayerType::PluginLayer:
-    case QgsMapLayerType::AnnotationLayer:
-    case QgsMapLayerType::PointCloudLayer:
-      return false;
-  }
-  return false;
+  return true;
 }
 
 ///@endcond

--- a/src/gui/layertree/qgslayertreeembeddedwidgetsimpl.cpp
+++ b/src/gui/layertree/qgslayertreeembeddedwidgetsimpl.cpp
@@ -20,11 +20,7 @@
 #include <QLabel>
 #include <QSlider>
 #include <QTimer>
-
-#include "qgsrasterlayer.h"
-#include "qgsrasterrenderer.h"
-#include "qgsvectorlayer.h"
-
+#include "qgsmaplayer.h"
 
 ///@cond PRIVATE
 
@@ -58,27 +54,8 @@ QgsLayerTreeOpacityWidget::QgsLayerTreeOpacityWidget( QgsMapLayer *layer )
   connect( mSlider, &QAbstractSlider::valueChanged, this, &QgsLayerTreeOpacityWidget::sliderValueChanged );
 
   // init from layer
-  switch ( mLayer->type() )
-  {
-    case QgsMapLayerType::VectorLayer:
-    case QgsMapLayerType::PluginLayer:
-    case QgsMapLayerType::MeshLayer:
-    case QgsMapLayerType::VectorTileLayer:
-    case QgsMapLayerType::AnnotationLayer:
-    case QgsMapLayerType::PointCloudLayer:
-    {
-      mSlider->setValue( mLayer->opacity() * 1000.0 );
-      connect( mLayer, &QgsMapLayer::opacityChanged, this, &QgsLayerTreeOpacityWidget::layerTrChanged );
-      break;
-    }
-
-    case QgsMapLayerType::RasterLayer:
-    {
-      mSlider->setValue( qobject_cast<QgsRasterLayer *>( mLayer )->renderer()->opacity() * 1000 );
-      // TODO: there is no signal for raster layers
-      break;
-    }
-  }
+  mSlider->setValue( mLayer->opacity() * 1000.0 );
+  connect( mLayer, &QgsMapLayer::opacityChanged, this, &QgsLayerTreeOpacityWidget::layerTrChanged );
 }
 
 QSize QgsLayerTreeOpacityWidget::sizeHint() const
@@ -99,27 +76,7 @@ void QgsLayerTreeOpacityWidget::sliderValueChanged( int value )
 void QgsLayerTreeOpacityWidget::updateOpacityFromSlider()
 {
   int value = mSlider->value();
-
-  switch ( mLayer->type() )
-  {
-    case QgsMapLayerType::VectorLayer:
-    case QgsMapLayerType::PluginLayer:
-    case QgsMapLayerType::MeshLayer:
-    case QgsMapLayerType::VectorTileLayer:
-    case QgsMapLayerType::AnnotationLayer:
-    case QgsMapLayerType::PointCloudLayer:
-    {
-      mLayer->setOpacity( value / 1000.0 );
-      break;
-    }
-
-    case QgsMapLayerType::RasterLayer:
-    {
-      qobject_cast<QgsRasterLayer *>( mLayer )->renderer()->setOpacity( value / 1000.0 );
-      break;
-    }
-  }
-
+  mLayer->setOpacity( value / 1000.0 );
   mLayer->triggerRepaint();
 }
 

--- a/tests/src/core/testqgsmaplayer.cpp
+++ b/tests/src/core/testqgsmaplayer.cpp
@@ -28,22 +28,6 @@
 #include "qgsvectorlayerref.h"
 #include "qgsmaplayerlistutils.h"
 
-class TestSignalReceiver : public QObject
-{
-    Q_OBJECT
-
-  public:
-    TestSignalReceiver()
-      : QObject( nullptr )
-    {}
-    QPainter::CompositionMode blendMode =  QPainter::CompositionMode_SourceOver ;
-  public slots:
-    void onBlendModeChanged( const QPainter::CompositionMode blendMode )
-    {
-      this->blendMode = blendMode;
-    }
-};
-
 /**
  * \ingroup UnitTests
  * This is a unit test for the QgsMapLayer class.
@@ -131,15 +115,22 @@ void TestQgsMapLayer::formatName()
 
 void TestQgsMapLayer::setBlendMode()
 {
-  TestSignalReceiver receiver;
-  QObject::connect( mpLayer, SIGNAL( blendModeChanged( const QPainter::CompositionMode ) ),
-                    &receiver, SLOT( onBlendModeChanged( const QPainter::CompositionMode ) ) );
-  QCOMPARE( int( receiver.blendMode ), 0 );
+  QSignalSpy spy( mpLayer, &QgsMapLayer::blendModeChanged );
+
   mpLayer->setBlendMode( QPainter::CompositionMode_Screen );
   // check the signal has been correctly emitted
-  QCOMPARE( receiver.blendMode, QPainter::CompositionMode_Screen );
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.at( 0 ).at( 0 ).toInt(), QPainter::CompositionMode_Screen );
   // check accessor
   QCOMPARE( mpLayer->blendMode(), QPainter::CompositionMode_Screen );
+
+  mpLayer->setBlendMode( QPainter::CompositionMode_Screen );
+  QCOMPARE( spy.count(), 1 );
+
+  mpLayer->setBlendMode( QPainter::CompositionMode_Darken );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( spy.at( 1 ).at( 0 ).toInt(), QPainter::CompositionMode_Darken );
+  QCOMPARE( mpLayer->blendMode(), QPainter::CompositionMode_Darken );
 }
 
 void TestQgsMapLayer::isInScaleRange_data()

--- a/tests/src/core/testqgsmaplayer.cpp
+++ b/tests/src/core/testqgsmaplayer.cpp
@@ -120,7 +120,7 @@ void TestQgsMapLayer::setBlendMode()
   mpLayer->setBlendMode( QPainter::CompositionMode_Screen );
   // check the signal has been correctly emitted
   QCOMPARE( spy.count(), 1 );
-  QCOMPARE( spy.at( 0 ).at( 0 ).toInt(), QPainter::CompositionMode_Screen );
+  QCOMPARE( spy.at( 0 ).at( 0 ).toInt(), static_cast< int >( QPainter::CompositionMode_Screen ) );
   // check accessor
   QCOMPARE( mpLayer->blendMode(), QPainter::CompositionMode_Screen );
 
@@ -129,7 +129,7 @@ void TestQgsMapLayer::setBlendMode()
 
   mpLayer->setBlendMode( QPainter::CompositionMode_Darken );
   QCOMPARE( spy.count(), 2 );
-  QCOMPARE( spy.at( 1 ).at( 0 ).toInt(), QPainter::CompositionMode_Darken );
+  QCOMPARE( spy.at( 1 ).at( 0 ).toInt(), static_cast< int >( QPainter::CompositionMode_Darken ) );
   QCOMPARE( mpLayer->blendMode(), QPainter::CompositionMode_Darken );
 }
 

--- a/tests/src/core/testqgsrasterlayer.cpp
+++ b/tests/src/core/testqgsrasterlayer.cpp
@@ -120,22 +120,6 @@ class TestQgsRasterLayer : public QObject
     QString mReport;
 };
 
-class TestSignalReceiver : public QObject
-{
-    Q_OBJECT
-
-  public:
-    TestSignalReceiver()
-      : QObject( nullptr )
-    {}
-    bool rendererChanged =  false ;
-  public slots:
-    void onRendererChanged()
-    {
-      rendererChanged = true;
-    }
-};
-
 //runs before all tests
 void TestQgsRasterLayer::initTestCase()
 {
@@ -906,13 +890,10 @@ void TestQgsRasterLayer::singleBandPseudoRendererNoDataColor()
 
 void TestQgsRasterLayer::setRenderer()
 {
-  TestSignalReceiver receiver;
-  QObject::connect( mpRasterLayer, SIGNAL( rendererChanged() ),
-                    &receiver, SLOT( onRendererChanged() ) );
+  QSignalSpy spy( mpRasterLayer, &QgsRasterLayer::rendererChanged );
   QgsRasterRenderer *renderer = ( QgsRasterRenderer * ) mpRasterLayer->renderer()->clone();
-  QCOMPARE( receiver.rendererChanged, false );
   mpRasterLayer->setRenderer( renderer );
-  QCOMPARE( receiver.rendererChanged, true );
+  QCOMPARE( spy.count(), 1 );
   QCOMPARE( mpRasterLayer->renderer(), renderer );
 }
 

--- a/tests/src/core/testqgsrasterlayer.cpp
+++ b/tests/src/core/testqgsrasterlayer.cpp
@@ -94,6 +94,7 @@ class TestQgsRasterLayer : public QObject
     void singleBandPseudoRendererNoData();
     void singleBandPseudoRendererNoDataColor();
     void setRenderer();
+    void setLayerOpacity();
     void regression992(); //test for issue #992 - GeoJP2 images improperly displayed as all black
     void testRefreshRendererIfNeeded();
     void sample();
@@ -895,6 +896,26 @@ void TestQgsRasterLayer::setRenderer()
   mpRasterLayer->setRenderer( renderer );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( mpRasterLayer->renderer(), renderer );
+}
+
+void TestQgsRasterLayer::setLayerOpacity()
+{
+  QSignalSpy spy( mpRasterLayer, &QgsMapLayer::opacityChanged );
+
+  mpRasterLayer->setOpacity( 0.5 );
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.at( 0 ).at( 0 ).toDouble(), 0.5 );
+  QCOMPARE( mpRasterLayer->opacity(), 0.5 );
+  // QgsRasterLayer::setOpacity is a proxy to QgsRasterRenderer::setOpacity
+  QCOMPARE( mpRasterLayer->renderer()->opacity(), 0.5 );
+
+  mpRasterLayer->setOpacity( 0.5 );
+  QCOMPARE( spy.count(), 1 );
+  mpRasterLayer->setOpacity( 1.0 );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( spy.at( 1 ).at( 0 ).toDouble(), 1.0 );
+  QCOMPARE( mpRasterLayer->opacity(), 1.0 );
+  QCOMPARE( mpRasterLayer->renderer()->opacity(), 1.0 );
 }
 
 void TestQgsRasterLayer::regression992()

--- a/tests/src/core/testqgsvectorlayer.cpp
+++ b/tests/src/core/testqgsvectorlayer.cpp
@@ -260,14 +260,14 @@ void TestQgsVectorLayer::setFeatureBlendMode()
 
   mpPointsLayer->setFeatureBlendMode( QPainter::CompositionMode_Screen );
   QCOMPARE( spy.count(), 1 );
-  QCOMPARE( spy.at( 0 ).at( 0 ).toInt(), QPainter::CompositionMode_Screen );
+  QCOMPARE( spy.at( 0 ).at( 0 ).toInt(), static_cast< int >( QPainter::CompositionMode_Screen ) );
   QCOMPARE( mpPointsLayer->featureBlendMode(), QPainter::CompositionMode_Screen );
   mpPointsLayer->setFeatureBlendMode( QPainter::CompositionMode_Screen );
   QCOMPARE( spy.count(), 1 );
 
   mpPointsLayer->setFeatureBlendMode( QPainter::CompositionMode_Darken );
   QCOMPARE( spy.count(), 2 );
-  QCOMPARE( spy.at( 1 ).at( 0 ).toInt(), QPainter::CompositionMode_Darken );
+  QCOMPARE( spy.at( 1 ).at( 0 ).toInt(), static_cast< int >( QPainter::CompositionMode_Darken ) );
   QCOMPARE( mpPointsLayer->featureBlendMode(), QPainter::CompositionMode_Darken );
 }
 

--- a/tests/src/core/testqgsvectorlayer.cpp
+++ b/tests/src/core/testqgsvectorlayer.cpp
@@ -37,32 +37,6 @@
 //qgis test includes
 #include "qgsrenderchecker.h"
 
-class TestSignalReceiver : public QObject
-{
-    Q_OBJECT
-
-  public:
-    TestSignalReceiver()
-      : QObject( nullptr )
-      , featureBlendMode( QPainter::CompositionMode( 0 ) )
-    {}
-    bool rendererChanged =  false ;
-    QPainter::CompositionMode featureBlendMode;
-    double opacity =  1.0 ;
-  public slots:
-    void onRendererChanged()
-    {
-      rendererChanged = true;
-    }
-    void onFeatureBlendModeChanged( const QPainter::CompositionMode blendMode )
-    {
-      featureBlendMode = blendMode;
-    }
-    void onLayerOpacityChanged( double layerOpacity )
-    {
-      opacity = layerOpacity;
-    }
-};
 
 /**
  * \ingroup UnitTests
@@ -76,9 +50,9 @@ class TestQgsVectorLayer : public QObject
 
   private:
     bool mTestHasError =  false ;
-    QgsMapLayer *mpPointsLayer = nullptr;
-    QgsMapLayer *mpLinesLayer = nullptr;
-    QgsMapLayer *mpPolysLayer = nullptr;
+    QgsVectorLayer *mpPointsLayer = nullptr;
+    QgsVectorLayer *mpLinesLayer = nullptr;
+    QgsVectorLayer *mpPolysLayer = nullptr;
     QgsVectorLayer *mpNonSpatialLayer = nullptr;
     QString mTestDataDir;
     QString mReport;
@@ -91,11 +65,11 @@ class TestQgsVectorLayer : public QObject
     void init() {} // will be called before each testfunction is executed.
     void cleanup() {} // will be called after every testfunction.
 
-    void QgsVectorLayerNonSpatialIterator();
-    void QgsVectorLayerGetValues();
-    void QgsVectorLayersetRenderer();
-    void QgsVectorLayersetFeatureBlendMode();
-    void QgsVectorLayersetLayerTransparency();
+    void nonSpatialIterator();
+    void getValues();
+    void setRenderer();
+    void setFeatureBlendMode();
+    void setLayerTransparency();
     void uniqueValues();
     void minimumValue();
     void maximumValue();
@@ -177,7 +151,7 @@ void TestQgsVectorLayer::cleanupTestCase()
   QgsApplication::exitQgis();
 }
 
-void TestQgsVectorLayer::QgsVectorLayerNonSpatialIterator()
+void TestQgsVectorLayer::nonSpatialIterator()
 {
   QgsFeature f;
   QgsAttributeList myList;
@@ -192,7 +166,7 @@ void TestQgsVectorLayer::QgsVectorLayerNonSpatialIterator()
   QVERIFY( myCount == 3 );
 }
 
-void TestQgsVectorLayer::QgsVectorLayerGetValues()
+void TestQgsVectorLayer::getValues()
 {
   QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "Point?field=col1:real" ), QStringLiteral( "layer" ), QStringLiteral( "memory" ) );
   QVERIFY( layer->isValid() );
@@ -269,69 +243,67 @@ void TestQgsVectorLayer::QgsVectorLayerGetValues()
   delete layer;
 }
 
-void TestQgsVectorLayer::QgsVectorLayersetRenderer()
+void TestQgsVectorLayer::setRenderer()
 {
-  QgsVectorLayer *vLayer = static_cast< QgsVectorLayer * >( mpPointsLayer );
-  TestSignalReceiver receiver;
-  QObject::connect( vLayer, SIGNAL( rendererChanged() ),
-                    &receiver, SLOT( onRendererChanged() ) );
+  QSignalSpy spy( mpPointsLayer, &QgsVectorLayer::rendererChanged );
+
   QgsSingleSymbolRenderer *symbolRenderer = new QgsSingleSymbolRenderer( QgsSymbol::defaultSymbol( QgsWkbTypes::PointGeometry ) );
 
-  QCOMPARE( receiver.rendererChanged, false );
-  vLayer->setRenderer( symbolRenderer );
-  QCOMPARE( receiver.rendererChanged, true );
-  QCOMPARE( vLayer->renderer(), symbolRenderer );
+  mpPointsLayer->setRenderer( symbolRenderer );
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( mpPointsLayer->renderer(), symbolRenderer );
 }
 
-void TestQgsVectorLayer::QgsVectorLayersetFeatureBlendMode()
+void TestQgsVectorLayer::setFeatureBlendMode()
 {
-  QgsVectorLayer *vLayer = static_cast< QgsVectorLayer * >( mpPointsLayer );
-  TestSignalReceiver receiver;
-  QObject::connect( vLayer, SIGNAL( featureBlendModeChanged( const QPainter::CompositionMode ) ),
-                    &receiver, SLOT( onFeatureBlendModeChanged( const QPainter::CompositionMode ) ) );
+  QSignalSpy spy( mpPointsLayer, &QgsVectorLayer::featureBlendModeChanged );
 
-  QCOMPARE( int( receiver.featureBlendMode ), 0 );
-  vLayer->setFeatureBlendMode( QPainter::CompositionMode_Screen );
-  QCOMPARE( receiver.featureBlendMode, QPainter::CompositionMode_Screen );
-  QCOMPARE( vLayer->featureBlendMode(), QPainter::CompositionMode_Screen );
+  mpPointsLayer->setFeatureBlendMode( QPainter::CompositionMode_Screen );
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.at( 0 ).at( 0 ).toInt(), QPainter::CompositionMode_Screen );
+  QCOMPARE( mpPointsLayer->featureBlendMode(), QPainter::CompositionMode_Screen );
+  mpPointsLayer->setFeatureBlendMode( QPainter::CompositionMode_Screen );
+  QCOMPARE( spy.count(), 1 );
+
+  mpPointsLayer->setFeatureBlendMode( QPainter::CompositionMode_Darken );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( spy.at( 1 ).at( 0 ).toInt(), QPainter::CompositionMode_Darken );
+  QCOMPARE( mpPointsLayer->featureBlendMode(), QPainter::CompositionMode_Darken );
 }
 
-void TestQgsVectorLayer::QgsVectorLayersetLayerTransparency()
+void TestQgsVectorLayer::setLayerTransparency()
 {
-  QgsVectorLayer *vLayer = static_cast< QgsVectorLayer * >( mpPointsLayer );
-  TestSignalReceiver receiver;
-  QObject::connect( vLayer, &QgsVectorLayer::opacityChanged,
-                    &receiver, &TestSignalReceiver::onLayerOpacityChanged );
+  QSignalSpy spy( mpPointsLayer, &QgsMapLayer::opacityChanged );
 
-  QCOMPARE( receiver.opacity, 1.0 );
-  vLayer->setOpacity( 0.5 );
-  QCOMPARE( receiver.opacity, 0.5 );
-  QCOMPARE( vLayer->opacity(), 0.5 );
+  mpPointsLayer->setOpacity( 0.5 );
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.at( 0 ).at( 0 ).toDouble(), 0.5 );
+  QCOMPARE( mpPointsLayer->opacity(), 0.5 );
+  mpPointsLayer->setOpacity( 0.5 );
+  QCOMPARE( spy.count(), 1 );
+  mpPointsLayer->setOpacity( 1.0 );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( spy.at( 1 ).at( 0 ).toDouble(), 1.0 );
+  QCOMPARE( mpPointsLayer->opacity(), 1.0 );
 }
 
 void TestQgsVectorLayer::uniqueValues()
 {
-  QgsVectorLayer *vLayer = static_cast< QgsVectorLayer * >( mpPointsLayer );
-
   //test with invalid field
-  QSet<QVariant> values = vLayer->uniqueValues( 1000 );
+  QSet<QVariant> values = mpPointsLayer->uniqueValues( 1000 );
   QCOMPARE( values.count(), 0 );
 }
 
 void TestQgsVectorLayer::minimumValue()
 {
-  QgsVectorLayer *vLayer = static_cast< QgsVectorLayer * >( mpPointsLayer );
-
   //test with invalid field
-  QCOMPARE( vLayer->minimumValue( 1000 ), QVariant() );
+  QCOMPARE( mpPointsLayer->minimumValue( 1000 ), QVariant() );
 }
 
 void TestQgsVectorLayer::maximumValue()
 {
-  QgsVectorLayer *vLayer = static_cast< QgsVectorLayer * >( mpPointsLayer );
-
   //test with invalid field
-  QCOMPARE( vLayer->maximumValue( 1000 ), QVariant() );
+  QCOMPARE( mpPointsLayer->maximumValue( 1000 ), QVariant() );
 }
 
 void TestQgsVectorLayer::isSpatial()


### PR DESCRIPTION
All the logic for rendering non-opaque layers is handled in a layer type agnostic way already, so this just allows the existing handling to be used for mesh/point cloud/vector tile/etc layers also

(API only, no user-visible changes or way to set opacity for these other layer types!)