### PR TITLE
Force a canvas redraw after rotating canvas to follow GPS direction

### DIFF
--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -1061,11 +1061,13 @@ void QgsGpsInformationWidget::displayGPSInformation( const QgsGpsInformation &in
         bearingLine.setP2( wgs84ToCanvas.transform( res ).toQPointF() );
 
         mMapCanvas->setRotation( 270 - bearingLine.angle() );
+        mMapCanvas->refresh();
       }
       catch ( QgsCsException & )
       {
         QgsDebugMsg( QStringLiteral( "Coordinate exception encountered while calculating GPS bearing rotation" ) );
         mMapCanvas->setRotation( trueNorth - bearing - adjustment );
+        mMapCanvas->refresh();
       }
       mLastRotateTimer.restart();
     }


### PR DESCRIPTION
Otherwise layers will be incorrectly cropped until the next full map refresh
