### PR TITLE
[delimitedtext] Ensure that encodeUri and decodeUri are lossless

### DIFF
--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -1262,14 +1262,54 @@ QString  QgsDelimitedTextProvider::description() const
 
 QVariantMap QgsDelimitedTextProviderMetadata::decodeUri( const QString &uri ) const
 {
+  const QUrl url( uri );
+  const QUrlQuery queryItems( url.query() );
+
+  QString subset;
+  QStringList openOptions;
+  for ( const auto &item : queryItems.queryItems() )
+  {
+    if ( item.first == QStringLiteral( "subset" ) )
+    {
+      subset = item.second;
+    }
+    else
+    {
+      openOptions << QStringLiteral( "%1=%2" ).arg( item.first, item.second );
+    }
+  }
+
   QVariantMap components;
-  components.insert( QStringLiteral( "path" ), QUrl( uri ).toLocalFile() );
+  components.insert( QStringLiteral( "path" ), url.toLocalFile() );
+  if ( !subset.isEmpty() )
+    components.insert( QStringLiteral( "subset" ), subset );
+  components.insert( QStringLiteral( "openOptions" ), openOptions );
   return components;
 }
 
 QString QgsDelimitedTextProviderMetadata::encodeUri( const QVariantMap &parts ) const
 {
-  return QStringLiteral( "file://%1" ).arg( parts.value( QStringLiteral( "path" ) ).toString() );
+  QUrl url( QStringLiteral( "file://%1" ).arg( parts.value( QStringLiteral( "path" ) ).toString() ) );
+  const QStringList openOptions = parts.value( QStringLiteral( "openOptions" ) ).toStringList();
+
+  QUrlQuery queryItems;
+  for ( const auto &option : openOptions )
+  {
+    int separator = option.indexOf( '=' );
+    if ( separator >= 0 )
+    {
+      queryItems.addQueryItem( option.mid( 0, separator ), option.mid( separator + 1 ) );
+    }
+    else
+    {
+      queryItems.addQueryItem( option, QString() );
+    }
+  }
+  if ( parts.contains( QStringLiteral( "subset" ) ) )
+    queryItems.addQueryItem( QStringLiteral( "subset" ), parts.value( QStringLiteral( "subset" ) ).toString() );
+  url.setQuery( queryItems );
+
+  return url.toString();
 }
 
 QgsDataProvider *QgsDelimitedTextProviderMetadata::createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags )

--- a/tests/src/python/test_qgsdelimitedtextprovider.py
+++ b/tests/src/python/test_qgsdelimitedtextprovider.py
@@ -47,7 +47,7 @@ from qgis.core import (
     QgsFeatureSource)
 
 from qgis.testing import start_app, unittest
-from utilities import unitTestDataPath, compareWkt
+from utilities import unitTestDataPath, compareWkt, compareUrl
 
 from providertestbase import ProviderTestCase
 
@@ -292,6 +292,10 @@ class TestQgsDelimitedTextProviderOther(unittest.TestCase):
             if verbose:
                 print(testname)
             layer = QgsVectorLayer(urlstr, 'test', 'delimitedtext')
+
+            # decodeUri / encodeUri check
+            self.assertTrue(compareUrl(layer.source(), QgsProviderRegistry.instance().encodeUri('delimitedtext', QgsProviderRegistry.instance().decodeUri('delimitedtext', layer.source()))))
+
             uri = layer.dataProvider().dataSourceUri()
             if verbose:
                 print(uri)

--- a/tests/src/python/utilities.py
+++ b/tests/src/python/utilities.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     from urllib.request import urlopen, HTTPError, URLError
 
-from qgis.PyQt.QtCore import QDir
+from qgis.PyQt.QtCore import QDir, QUrl, QUrlQuery
 
 from qgis.core import (
     QgsCoordinateReferenceSystem,
@@ -128,6 +128,20 @@ def doubleNear(a, b, tol=0.0000000001):
     Tests whether two floats are near, within a specified tolerance
     """
     return abs(float(a) - float(b)) < tol
+
+
+def compareUrl(a, b):
+    url_a = QUrl(a)
+    url_b = QUrl(b)
+    query_a = QUrlQuery(url_a.query()).queryItems()
+    query_b = QUrlQuery(url_b.query()).queryItems()
+
+    url_equal = url_a.path() == url_b.path()
+    for item in query_a:
+        if item not in query_b:
+            url_equal = False
+
+    return url_equal
 
 
 def compareWkt(a, b, tol=0.000001):


### PR DESCRIPTION
## Description

This fixes addition of delimited text provider layers (reported in issue  #39968) by ensuring that decodeUri/encodeUri functios are lossless.

I've implemented this in a way that is compatible with the work done in the ogr provider, via a QStringList openOptions passed / returned as part of the QVariantMap.