### PR TITLE
[spatialite] Ensure that encodeUri and decodeUri are lossless

### DIFF
--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -5860,6 +5860,12 @@ QVariantMap QgsSpatiaLiteProviderMetadata::decodeUri( const QString &uri ) const
   QVariantMap components;
   components.insert( QStringLiteral( "path" ), dsUri.database() );
   components.insert( QStringLiteral( "layerName" ), dsUri.table() );
+  if ( !dsUri.sql().isEmpty() )
+    components.insert( QStringLiteral( "subset" ), dsUri.sql() );
+  if ( !dsUri.geometryColumn().isEmpty() )
+    components.insert( QStringLiteral( "geometryColumn" ), dsUri.geometryColumn() );
+  if ( !dsUri.keyColumn().isEmpty() )
+    components.insert( QStringLiteral( "keyColumn" ), dsUri.keyColumn() );
   return components;
 }
 
@@ -5876,6 +5882,9 @@ QString QgsSpatiaLiteProviderMetadata::encodeUri( const QVariantMap &parts ) con
   QgsDataSourceUri dsUri;
   dsUri.setDatabase( parts.value( QStringLiteral( "path" ) ).toString() );
   dsUri.setTable( parts.value( QStringLiteral( "layerName" ) ).toString() );
+  dsUri.setSql( parts.value( QStringLiteral( "subset" ) ).toString() );
+  dsUri.setGeometryColumn( parts.value( QStringLiteral( "geometryColumn" ) ).toString() );
+  dsUri.setKeyColumn( parts.value( QStringLiteral( "keyColumn" ) ).toString() );
   return dsUri.uri();
 }
 

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -965,10 +965,14 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         """Check that the provider URI decoding returns expected values"""
 
         filename = '/home/to/path/test.db'
-        uri = 'dbname=\'{}\' table="test" (geometry) sql='.format(filename)
+        uri = 'dbname=\'{}\' table="test" (geometry) key=testkey sql=1=1'.format(filename)
         registry = QgsProviderRegistry.instance()
         components = registry.decodeUri('spatialite', uri)
         self.assertEqual(components['path'], filename)
+        self.assertEqual(components['layerName'], 'test')
+        self.assertEqual(components['subset'], '1=1')
+        self.assertEqual(components['geometryColumn'], 'geometry')
+        self.assertEqual(components['keyColumn'], 'testkey')
 
     def testEncodeUri(self):
         """Check that the provider URI encoding returns expected values"""
@@ -976,9 +980,13 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         filename = '/home/to/path/test.db'
         registry = QgsProviderRegistry.instance()
 
-        parts = {'path': filename, 'layerName': 'test'}
+        parts = {'path': filename,
+                 'layerName': 'test',
+                 'subset': '1=1',
+                 'geometryColumn': 'geometry',
+                 'keyColumn': 'testkey'}
         uri = registry.encodeUri('spatialite', parts)
-        self.assertEqual(uri, 'dbname=\'{}\' table="test"'.format(filename))
+        self.assertEqual(uri, 'dbname=\'{}\' key=\'testkey\' table="test" (geometry) sql=1=1'.format(filename))
 
     def testPKNotInt(self):
         """ Check when primary key is not an integer """


### PR DESCRIPTION
## Description

Using spatialite's decodeUri/encodeUri functions to manipulate source uri leads to potential loss of subset filter et cie. This PR fixes that. I don't think it's been reported, stumbled upon when testing qfieldsync.