### PR TITLE
Fix tessellator crash with 2d triangle again

### DIFF
--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -626,7 +626,10 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
         }
         mData << p.first << p.second;
       }
-      xData++; yData++; zData++;
+      xData++; yData++;
+      // zData can be nullptr if mNoZ or triangle is 2D
+      if ( zData )
+        zData++;
     }
 
     if ( mAddBackFaces )

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -604,7 +604,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
     const double *zData = !mNoZ ? exterior->zData() : nullptr;
     for ( int i = 0; i < 3; i++ )
     {
-      float z = mNoZ ? 0 : *zData;
+      float z = !zData ? 0 : *zData;
       if ( z < zMin )
         zMin = z;
       if ( z > zMax )

--- a/tests/src/3d/testqgstessellator.cpp
+++ b/tests/src/3d/testqgstessellator.cpp
@@ -406,7 +406,8 @@ void TestQgsTessellator::testCrash2DTriangle()
   // test tessellation of a 2D triangle - https://github.com/qgis/QGIS/issues/36024
   QgsPolygon polygon;
   polygon.fromWkt( "Polygon((0 0, 42 0, 42 42, 0 0))" );
-  QgsTessellator t( 0, 0, true, false, false, true );
+  // must not be declared with mNoz = true
+  QgsTessellator t( 0, 0, true );
   t.addPolygon( polygon, 0 ); // must not crash - that's all we test here
 }
 


### PR DESCRIPTION
## Description
Re-apply 8ba73c6 's fix and mend #36024 's broken test

Fixes #39976

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
