### PR TITLE
Add/fix examples using the get_feature* functions

### DIFF
--- a/resources/function_help/json/get_feature_by_id
+++ b/resources/function_help/json/get_feature_by_id
@@ -5,5 +5,5 @@
   "description": "Returns the feature with an id on a layer.",
   "arguments": [ {"arg":"layer","description":"layer, layer name or layer id"},
                  {"arg":"feature_id","description":"the id of the feature which should be returned"}],
-  "examples": [ { "expression":"get_feature('streets', 1)", "returns":"the feature with the id 1 on the layer \"streets\""}]
+  "examples": [ { "expression":"get_feature_by_id('streets', 1)", "returns":"the feature with the id 1 on the layer \"streets\""}]
 }

--- a/resources/function_help/json/is_selected
+++ b/resources/function_help/json/is_selected
@@ -14,13 +14,17 @@
             "variant": "One 'feature' parameter",
             "variant_description": "If called with a 'feature' parameter only, the function returns true if the specified feature from the current layer is selected.",
             "arguments": [ { "arg": "feature", "description": "The feature which should be checked for selection." } ],
-            "examples": [ { "expression": "is_selected(@atlas_feature)", "returns": "True if the current atlas feature is selected." } ]
+            "examples": [ { "expression": "is_selected(@atlas_feature)", "returns": "True if the current atlas feature is selected." },
+                          { "expression": "is_selected(get_feature_by_id('streets', 1))", "returns": "True if the feature with the id 1 on the active \"streets\" layer is selected." }
+                        ]
         },
         {
             "variant" : "Two parameters",
             "variant_description": "If the function is called with both a layer and a feature, it will return true if the specified feature from the specified layer is selected.",
-            "arguments": [ { "arg": "layer", "description": "The layer (or its ID or name) on which the selection will be checked." }, { "arg": "feature", "description": "The feature which should be checked for selection." } ],
-            "examples": [ { "expression": "is_selected( 'streets', get_feature('streets', 'name', \"street_name\"))", "returns": "True if the current building's street is selected (assuming the building layer has a field named 'street_name' and the 'streets' layer has a field called 'name')." } ]
+            "arguments": [ { "arg": "layer", "description": "The layer (its ID or name) on which the selection will be checked." }, { "arg": "feature", "description": "The feature which should be checked for selection." } ],
+            "examples": [ { "expression": "is_selected( 'streets', get_feature('streets', 'name', \"street_name\"))", "returns": "True if the current building's street is selected (assuming the building layer has a field named 'street_name' and the 'streets' layer has a field called 'name')." },
+                          { "expression": "is_selected( 'streets', get_feature_by_id('streets', 1))", "returns": "True if the feature with the id 1 on the \"streets\" layer is selected." }
+                        ]
         }
   ]
  }

--- a/resources/function_help/json/is_selected
+++ b/resources/function_help/json/is_selected
@@ -15,6 +15,7 @@
             "variant_description": "If called with a 'feature' parameter only, the function returns true if the specified feature from the current layer is selected.",
             "arguments": [ { "arg": "feature", "description": "The feature which should be checked for selection." } ],
             "examples": [ { "expression": "is_selected(@atlas_feature)", "returns": "True if the current atlas feature is selected." },
+                          { "expression": "is_selected(get_feature('streets', 'name', 'Main St.')))", "returns": "True if the unique named \"Main St.\" feature on the active \"streets\" layer is selected." },
                           { "expression": "is_selected(get_feature_by_id('streets', 1))", "returns": "True if the feature with the id 1 on the active \"streets\" layer is selected." }
                         ]
         },
@@ -22,7 +23,7 @@
             "variant" : "Two parameters",
             "variant_description": "If the function is called with both a layer and a feature, it will return true if the specified feature from the specified layer is selected.",
             "arguments": [ { "arg": "layer", "description": "The layer (its ID or name) on which the selection will be checked." }, { "arg": "feature", "description": "The feature which should be checked for selection." } ],
-            "examples": [ { "expression": "is_selected( 'streets', get_feature('streets', 'name', \"street_name\"))", "returns": "True if the current building's street is selected (assuming the building layer has a field named 'street_name' and the 'streets' layer has a field called 'name')." },
+            "examples": [ { "expression": "is_selected( 'streets', get_feature('streets', 'name', \"street_name\"))", "returns": "True if the current building's street is selected (assuming the building layer has a field named 'street_name' and the 'streets' layer has a field called 'name' with unique values)." },
                           { "expression": "is_selected( 'streets', get_feature_by_id('streets', 1))", "returns": "True if the feature with the id 1 on the \"streets\" layer is selected." }
                         ]
         }


### PR DESCRIPTION
This PR mainly adds/reviews examples of the is_selected function:
* it's somehow misleading to use get_feature function to check whether a feature is selected, since we can't assure which feature will be returned, in case there are more than one sharing the attribute value. Hence, suggestion to add in the help that the field has unique values (it's not necessary for the function, but at least the result is predictable) --> time to have a get_features(layer, field, value) function that would return an array of features? (though I'm unclear on how we would interact with its elements)
* the previous point leads to suggest examples with get_feature_by_id that really returns unique and identifiable feature, but I still feel there's some inconsistency in the use (see #40066)


