### PR TITLE
[FEATURE] Add a subset string editor provider concept and registry 

### DIFF
--- a/python/gui/auto_generated/qgsgui.sip.in
+++ b/python/gui/auto_generated/qgsgui.sip.in
@@ -118,6 +118,13 @@ Returns the registry of GUI-related components of data providers
 .. versionadded:: 3.10
 %End
 
+    static QgsSubsetStringEditorProviderRegistry *subsetStringEditorProviderRegistry() /KeepReference/;
+%Docstring
+Returns the registry of subset string editors of data providers
+
+.. versionadded:: 3.18
+%End
+
     static void enableAutoGeometryRestore( QWidget *widget, const QString &key = QString() );
 %Docstring
 Register the widget to allow its position to be automatically saved and restored when open and closed.

--- a/python/gui/auto_generated/qgsproviderguimetadata.sip.in
+++ b/python/gui/auto_generated/qgsproviderguimetadata.sip.in
@@ -64,6 +64,17 @@ Returns source select providers
    Ownership of created source select providers is passed to the caller.
 %End
 
+    virtual QList<QgsSubsetStringEditorProvider *> subsetStringEditorProviders() /Factory/;
+%Docstring
+Returns subset string editor providers
+
+.. note::
+
+   Ownership of created  providers is passed to the caller.
+
+.. versionadded:: 3.18
+%End
+
     QString key() const;
 %Docstring
 Returns unique provider key

--- a/python/gui/auto_generated/qgsproviderguiregistry.sip.in
+++ b/python/gui/auto_generated/qgsproviderguiregistry.sip.in
@@ -81,6 +81,17 @@ Returns all project storage gui providers registered in provider with ``provider
    Ownership of created project storage gui providers is passed to the caller.
 %End
 
+    virtual QList<QgsSubsetStringEditorProvider *> subsetStringEditorProviders( const QString &providerKey ) /Factory/;
+%Docstring
+Returns all subset string editor providers registered in provider with ``providerKey``
+
+.. note::
+
+   Ownership of providers is passed to the caller.
+
+.. versionadded:: 3.18
+%End
+
 
 };
 

--- a/python/gui/auto_generated/qgsquerybuilder.sip.in
+++ b/python/gui/auto_generated/qgsquerybuilder.sip.in
@@ -39,7 +39,14 @@ vector layer properties dialog
 
 
     QString sql() const;
+%Docstring
+Returns the sql statement entered in the dialog.
+%End
+
     void setSql( const QString &sqlStatement );
+%Docstring
+Set the sql statement to display in the dialog.
+%End
 
     virtual QString subsetString() const;
     virtual void setSubsetString( const QString &subsetString );

--- a/python/gui/auto_generated/qgsquerybuilder.sip.in
+++ b/python/gui/auto_generated/qgsquerybuilder.sip.in
@@ -7,7 +7,7 @@
  ************************************************************************/
 
 
-class QgsQueryBuilder : QDialog
+class QgsQueryBuilder : QgsSubsetStringEditorInterface
 {
 %Docstring
 Query Builder for layers.
@@ -38,8 +38,11 @@ vector layer properties dialog
     virtual void showEvent( QShowEvent *event );
 
 
-    QString sql();
+    QString sql() const;
     void setSql( const QString &sqlStatement );
+
+    virtual QString subsetString() const;
+    virtual void setSubsetString( const QString &subsetString );
 
 %If (HAVE_QSCI_SIP)
 

--- a/python/gui/auto_generated/qgssubsetstringeditorinterface.sip.in
+++ b/python/gui/auto_generated/qgssubsetstringeditorinterface.sip.in
@@ -1,0 +1,46 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgssubsetstringeditorinterface.h                             *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsSubsetStringEditorInterface: QDialog
+{
+%Docstring
+Interface for a dialog that can edit subset strings
+
+.. versionadded:: 3.18
+%End
+
+%TypeHeaderCode
+#include "qgssubsetstringeditorinterface.h"
+%End
+  public:
+    QgsSubsetStringEditorInterface( QWidget *parent /TransferThis/ = 0,
+                                    Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
+%Docstring
+Constructor
+%End
+
+    virtual QString subsetString() const = 0;
+%Docstring
+Returns the subset string entered in the dialog.
+%End
+
+    virtual void setSubsetString( const QString &subsetString ) = 0;
+%Docstring
+Sets a subset string into the dialog.
+%End
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgssubsetstringeditorinterface.h                             *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/qgssubsetstringeditorprovider.sip.in
+++ b/python/gui/auto_generated/qgssubsetstringeditorprovider.sip.in
@@ -1,0 +1,72 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgssubsetstringeditorprovider.h                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsSubsetStringEditorProvider
+{
+%Docstring
+This is the interface for those who want to provide a dialog to edit a
+subset string.
+
+.. versionadded:: 3.18
+%End
+
+%TypeHeaderCode
+#include "qgssubsetstringeditorprovider.h"
+%End
+  public:
+    virtual ~QgsSubsetStringEditorProvider();
+
+    virtual QString providerKey() const = 0;
+%Docstring
+Provider key
+%End
+
+    virtual QString name() const;
+%Docstring
+Subset string editor provider name, this is useful to retrieve
+a particular subset string editor in case the provider has more
+than one, it should be unique among all providers.
+
+The default implementation returns the :py:func:`~QgsSubsetStringEditorProvider.providerKey`
+%End
+
+    virtual bool canHandleLayer( QgsVectorLayer *layer ) const = 0;
+%Docstring
+Returns true if the provider can handle the layer
+%End
+
+    virtual bool canHandleLayerStorageType( QgsVectorLayer *layer ) const;
+%Docstring
+Returns true if the provider can handle specifically the
+layer->:py:func:`~QgsSubsetStringEditorProvider.provider`->:py:func:`~QgsSubsetStringEditorProvider.storageType`
+This method will only be called if :py:func:`~QgsSubsetStringEditorProvider.canHandleLayer` returned true.
+Typically a generic SQL provider for the OGR provider will return false,
+whereas a dedicated plugin with a specific behavior for a OGR driver
+will return true.
+%End
+
+    virtual QgsSubsetStringEditorInterface *createDialog( QgsVectorLayer *layer, QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags ) = 0 /Factory/;
+%Docstring
+Creates a new dialog to edit the subset string of the provided ``layer``.
+It may return None if it cannot handle the layer.
+The returned object must be destroyed by the caller.
+On successful :py:func:`~QgsSubsetStringEditorProvider.accept`, the QgsSubsetStringEditorInterface implementation
+is responsible for setting the updated string on layer.
+%End
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgssubsetstringeditorprovider.h                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/qgssubsetstringeditorproviderregistry.sip.in
+++ b/python/gui/auto_generated/qgssubsetstringeditorproviderregistry.sip.in
@@ -1,0 +1,83 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgssubsetstringeditorproviderregistry.h                      *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsSubsetStringEditorProviderRegistry
+{
+%Docstring
+This class keeps a list of subset string editor providers.
+
+QgsSubsetStringEditorProviderRegistry is not usually directly created, but rather accessed through
+:py:func:`QgsGui.subsetStringEditorProvideRegistry()`.
+
+.. versionadded:: 3.18
+%End
+
+%TypeHeaderCode
+#include "qgssubsetstringeditorproviderregistry.h"
+%End
+  public:
+
+    QgsSubsetStringEditorProviderRegistry();
+    ~QgsSubsetStringEditorProviderRegistry();
+
+
+    QList< QgsSubsetStringEditorProvider *> providers();
+%Docstring
+Gets list of available providers
+%End
+
+    void addProvider( QgsSubsetStringEditorProvider *provider /Transfer/ );
+%Docstring
+Add a ``provider`` implementation. Takes ownership of the object.
+%End
+
+    bool removeProvider( QgsSubsetStringEditorProvider *provider /Transfer/ );
+%Docstring
+Remove ``provider`` implementation from the list (``provider`` object is deleted)
+
+:return: ``True`` if the provider was actually removed and deleted
+%End
+
+    void initializeFromProviderGuiRegistry( QgsProviderGuiRegistry *providerGuiRegistry );
+%Docstring
+Initializes the registry. The registry needs to be passed explicitly
+(instead of using singleton) because this gets called from QgsGui constructor.
+%End
+
+    QgsSubsetStringEditorProvider *providerByName( const QString &name );
+%Docstring
+Returns a provider by ``name`` or ``None`` if not found
+%End
+
+    QList<QgsSubsetStringEditorProvider *> providersByKey( const QString &providerKey );
+%Docstring
+Returns a (possibly empty) list of providers by data ``providerkey``
+%End
+
+    QgsSubsetStringEditorInterface *createDialog( QgsVectorLayer *layer, QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags ) /TransferBack/;
+%Docstring
+Creates a new dialog to edit the subset string of the provided ``layer``.
+It will default to returning a :py:class:`QgsQueryBuilder`* if no provider was found.
+The returned object must be destroyed by the caller.
+%End
+
+  private:
+    QgsSubsetStringEditorProviderRegistry( const QgsSubsetStringEditorProviderRegistry &rh );
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgssubsetstringeditorproviderregistry.h                      *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -183,6 +183,9 @@
 %Include auto_generated/qgsscalewidget.sip
 %Include auto_generated/qgsscrollarea.sip
 %Include auto_generated/qgssearchquerybuilder.sip
+%Include auto_generated/qgssubsetstringeditorinterface.sip
+%Include auto_generated/qgssubsetstringeditorprovider.sip
+%Include auto_generated/qgssubsetstringeditorproviderregistry.sip
 %Include auto_generated/qgsshortcutsmanager.sip
 %Include auto_generated/qgsslider.sip
 %Include auto_generated/qgssnapindicator.sip

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -339,6 +339,9 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsstatusbarmagnifierwidget.h"
 #include "qgsstatusbarscalewidget.h"
 #include "qgsstyle.h"
+#include "qgssubsetstringeditorproviderregistry.h"
+#include "qgssubsetstringeditorprovider.h"
+#include "qgssubsetstringeditorinterface.h"
 #include "qgssvgannotation.h"
 #include "qgstaskmanager.h"
 #include "qgstaskmanagerwidget.h"
@@ -11496,16 +11499,16 @@ void QgisApp::layerSubsetString( QgsMapLayer *mapLayer )
   }
 
   // launch the query builder
-  std::unique_ptr<QgsQueryBuilder> qb( new QgsQueryBuilder( vlayer, this ) );
+  std::unique_ptr<QgsSubsetStringEditorInterface> qb( QgsGui::subsetStringEditorProviderRegistry()->createDialog( vlayer, this ) );
   QString subsetBefore = vlayer->subsetString();
 
   // Set the sql in the query builder to the same in the prop dialog
   // (in case the user has already changed it)
-  qb->setSql( vlayer->subsetString() );
+  qb->setSubsetString( vlayer->subsetString() );
   // Open the query builder and refresh symbology if sql has changed
   // Note: repaintRequested is emitted directly from QgsQueryBuilder
   //       when the sql is set in the layer.
-  if ( qb->exec() && ( subsetBefore != qb->sql() ) && mLayerTreeView )
+  if ( qb->exec() && ( subsetBefore != qb->subsetString() ) && mLayerTreeView )
   {
     mLayerTreeView->refreshLayerSymbology( vlayer->id() );
     activateDeactivateLayerRelatedActions( vlayer );

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -558,6 +558,9 @@ set(QGIS_GUI_SRCS
   qgsscalewidget.cpp
   qgsscrollarea.cpp
   qgssearchquerybuilder.cpp
+  qgssubsetstringeditorinterface.cpp
+  qgssubsetstringeditorprovider.cpp
+  qgssubsetstringeditorproviderregistry.cpp
   qgsshortcutsmanager.cpp
   qgsslider.cpp
   qgssnapindicator.cpp
@@ -796,6 +799,9 @@ set(QGIS_GUI_HDRS
   qgsscalewidget.h
   qgsscrollarea.h
   qgssearchquerybuilder.h
+  qgssubsetstringeditorinterface.h
+  qgssubsetstringeditorprovider.h
+  qgssubsetstringeditorproviderregistry.h
   qgsshortcutsmanager.h
   qgsslider.h
   qgssnapindicator.h

--- a/src/gui/qgsgui.cpp
+++ b/src/gui/qgsgui.cpp
@@ -58,7 +58,7 @@
 #include "qgsmessagebaritem.h"
 #include "qgsnumericformatguiregistry.h"
 #include "qgscodeeditorcolorschemeregistry.h"
-
+#include "qgssubsetstringeditorproviderregistry.h"
 
 QgsGui *QgsGui::instance()
 {
@@ -79,6 +79,11 @@ QgsEditorWidgetRegistry *QgsGui::editorWidgetRegistry()
 QgsSourceSelectProviderRegistry *QgsGui::sourceSelectProviderRegistry()
 {
   return instance()->mSourceSelectProviderRegistry;
+}
+
+QgsSubsetStringEditorProviderRegistry *QgsGui::subsetStringEditorProviderRegistry()
+{
+  return instance()->mSubsetStringEditorProviderRegistry;
 }
 
 QgsShortcutsManager *QgsGui::shortcutsManager()
@@ -185,6 +190,7 @@ QgsGui::~QgsGui()
   delete mProjectStorageGuiRegistry;
   delete mProviderGuiRegistry;
   delete mCodeEditorColorSchemeRegistry;
+  delete mSubsetStringEditorProviderRegistry;
 }
 
 QColor QgsGui::sampleColor( QPoint point )
@@ -238,10 +244,12 @@ QgsGui::QgsGui()
   mDataItemGuiProviderRegistry = new QgsDataItemGuiProviderRegistry();
   mSourceSelectProviderRegistry = new QgsSourceSelectProviderRegistry();
   mNumericFormatGuiRegistry = new QgsNumericFormatGuiRegistry();
+  mSubsetStringEditorProviderRegistry = new QgsSubsetStringEditorProviderRegistry();
 
   mProjectStorageGuiRegistry->initializeFromProviderGuiRegistry( mProviderGuiRegistry );
   mDataItemGuiProviderRegistry->initializeFromProviderGuiRegistry( mProviderGuiRegistry );
   mSourceSelectProviderRegistry->initializeFromProviderGuiRegistry( mProviderGuiRegistry );
+  mSubsetStringEditorProviderRegistry->initializeFromProviderGuiRegistry( mProviderGuiRegistry );
 
   mEditorWidgetRegistry = new QgsEditorWidgetRegistry();
   mShortcutsManager = new QgsShortcutsManager();

--- a/src/gui/qgsgui.h
+++ b/src/gui/qgsgui.h
@@ -40,6 +40,7 @@ class QgsProjectStorageGuiRegistry;
 class QgsNumericFormatGuiRegistry;
 class QgsCodeEditorColorSchemeRegistry;
 class QgsMessageBar;
+class QgsSubsetStringEditorProviderRegistry;
 
 /**
  * \ingroup gui
@@ -155,6 +156,12 @@ class GUI_EXPORT QgsGui : public QObject
     static QgsProviderGuiRegistry *providerGuiRegistry() SIP_KEEPREFERENCE;
 
     /**
+     * Returns the registry of subset string editors of data providers
+     * \since QGIS 3.18
+     */
+    static QgsSubsetStringEditorProviderRegistry *subsetStringEditorProviderRegistry() SIP_KEEPREFERENCE;
+
+    /**
      * Register the widget to allow its position to be automatically saved and restored when open and closed.
      * Use this to avoid needing to call saveGeometry() and restoreGeometry() on your widget.
      */
@@ -255,6 +262,7 @@ class GUI_EXPORT QgsGui : public QObject
     QgsDataItemGuiProviderRegistry *mDataItemGuiProviderRegistry = nullptr;
     QgsCodeEditorColorSchemeRegistry *mCodeEditorColorSchemeRegistry = nullptr;
     QgsProjectStorageGuiRegistry *mProjectStorageGuiRegistry = nullptr;
+    QgsSubsetStringEditorProviderRegistry *mSubsetStringEditorProviderRegistry = nullptr;
     std::unique_ptr< QgsWindowManagerInterface > mWindowManager;
 
 #ifdef SIP_RUN

--- a/src/gui/qgsproviderguimetadata.cpp
+++ b/src/gui/qgsproviderguimetadata.cpp
@@ -42,6 +42,11 @@ QList<QgsSourceSelectProvider *> QgsProviderGuiMetadata::sourceSelectProviders()
   return QList<QgsSourceSelectProvider *>();
 }
 
+QList<QgsSubsetStringEditorProvider *> QgsProviderGuiMetadata::subsetStringEditorProviders()
+{
+  return QList<QgsSubsetStringEditorProvider *>();
+}
+
 QString QgsProviderGuiMetadata::key() const
 {
   return mKey;

--- a/src/gui/qgsproviderguimetadata.h
+++ b/src/gui/qgsproviderguimetadata.h
@@ -27,6 +27,7 @@
 class QgsDataItemGuiProvider;
 class QgsSourceSelectProvider;
 class QgsProjectStorageGuiProvider;
+class QgsSubsetStringEditorProvider;
 
 /**
  * \ingroup gui
@@ -68,6 +69,13 @@ class GUI_EXPORT QgsProviderGuiMetadata
      * \note Ownership of created source select providers is passed to the caller.
      */
     virtual QList<QgsSourceSelectProvider *> sourceSelectProviders() SIP_FACTORY;
+
+    /**
+     * Returns subset string editor providers
+     * \note Ownership of created  providers is passed to the caller.
+     * \since QGIS 3.18
+     */
+    virtual QList<QgsSubsetStringEditorProvider *> subsetStringEditorProviders() SIP_FACTORY;
 
     //! Returns unique provider key
     QString key() const;

--- a/src/gui/qgsproviderguiregistry.cpp
+++ b/src/gui/qgsproviderguiregistry.cpp
@@ -213,6 +213,14 @@ QList<QgsProjectStorageGuiProvider *> QgsProviderGuiRegistry::projectStorageGuiP
   return QList<QgsProjectStorageGuiProvider *>();
 }
 
+QList<QgsSubsetStringEditorProvider *> QgsProviderGuiRegistry::subsetStringEditorProviders( const QString &providerKey )
+{
+  QgsProviderGuiMetadata *meta = findMetadata_( mProviders, providerKey );
+  if ( meta )
+    return meta->subsetStringEditorProviders();
+  return QList<QgsSubsetStringEditorProvider *>();
+}
+
 QStringList QgsProviderGuiRegistry::providerList() const
 {
   QStringList lst;

--- a/src/gui/qgsproviderguiregistry.h
+++ b/src/gui/qgsproviderguiregistry.h
@@ -33,6 +33,7 @@ class QgsProviderGuiMetadata;
 class QgsDataItemGuiProvider;
 class QgsSourceSelectProvider;
 class QgsProjectStorageGuiProvider;
+class QgsSubsetStringEditorProvider;
 
 /**
  * \ingroup gui
@@ -85,6 +86,13 @@ class GUI_EXPORT QgsProviderGuiRegistry
      * \note Ownership of created project storage gui providers is passed to the caller.
      */
     virtual QList<QgsProjectStorageGuiProvider *> projectStorageGuiProviders( const QString &providerKey ) SIP_FACTORY;
+
+    /**
+     * Returns all subset string editor providers registered in provider with \a providerKey
+     * \note Ownership of providers is passed to the caller.
+     * \since QGIS 3.18
+     */
+    virtual QList<QgsSubsetStringEditorProvider *> subsetStringEditorProviders( const QString &providerKey ) SIP_FACTORY;
 
     //! Type for data provider metadata associative container
     SIP_SKIP typedef std::map<QString, QgsProviderGuiMetadata *> GuiProviders;

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -37,7 +37,7 @@
 // connection to the database
 QgsQueryBuilder::QgsQueryBuilder( QgsVectorLayer *layer,
                                   QWidget *parent, Qt::WindowFlags fl )
-  : QDialog( parent, fl )
+  : QgsSubsetStringEditorInterface( parent, fl )
   , mPreviousFieldRow( -1 )
   , mLayer( layer )
 {
@@ -345,7 +345,7 @@ void QgsQueryBuilder::btnLike_clicked()
   mTxtSql->setFocus();
 }
 
-QString QgsQueryBuilder::sql()
+QString QgsQueryBuilder::sql() const
 {
   return mTxtSql->text();
 }

--- a/src/gui/qgsquerybuilder.h
+++ b/src/gui/qgsquerybuilder.h
@@ -58,7 +58,10 @@ class GUI_EXPORT QgsQueryBuilder : public QgsSubsetStringEditorInterface, privat
 
     void showEvent( QShowEvent *event ) override;
 
+    //! Returns the sql statement entered in the dialog.
     QString sql() const;
+
+    //! Set the sql statement to display in the dialog.
     void setSql( const QString &sqlStatement );
 
     QString subsetString() const override { return sql(); }

--- a/src/gui/qgsquerybuilder.h
+++ b/src/gui/qgsquerybuilder.h
@@ -24,6 +24,7 @@
 #include "ui_qgsquerybuilderbase.h"
 #include "qgsguiutils.h"
 #include "qgis_gui.h"
+#include "qgssubsetstringeditorinterface.h"
 
 class QgsVectorLayer;
 class QgsCodeEditor;
@@ -40,7 +41,7 @@ class QgsCodeEditor;
  * will be returned.
  *
  */
-class GUI_EXPORT QgsQueryBuilder : public QDialog, private Ui::QgsQueryBuilderBase
+class GUI_EXPORT QgsQueryBuilder : public QgsSubsetStringEditorInterface, private Ui::QgsQueryBuilderBase
 {
     Q_OBJECT
   public:
@@ -57,8 +58,11 @@ class GUI_EXPORT QgsQueryBuilder : public QDialog, private Ui::QgsQueryBuilderBa
 
     void showEvent( QShowEvent *event ) override;
 
-    QString sql();
+    QString sql() const;
     void setSql( const QString &sqlStatement );
+
+    QString subsetString() const override { return sql(); }
+    void setSubsetString( const QString &subsetString ) override { setSql( subsetString ); }
 
 #ifdef SIP_RUN
     SIP_IF_FEATURE( HAVE_QSCI_SIP )

--- a/src/gui/qgssqlcomposerdialog.cpp
+++ b/src/gui/qgssqlcomposerdialog.cpp
@@ -21,6 +21,7 @@ email                : even.rouault at spatialys.com
 #include "qgssqlcomposerdialog.h"
 #include "qgssqlstatement.h"
 #include "qgshelp.h"
+#include "qgsvectorlayer.h"
 
 #include <QMessageBox>
 #include <QKeyEvent>
@@ -28,7 +29,12 @@ email                : even.rouault at spatialys.com
 #include <Qsci/qscilexer.h>
 
 QgsSQLComposerDialog::QgsSQLComposerDialog( QWidget *parent, Qt::WindowFlags fl )
-  : QDialog( parent, fl )
+  : QgsSQLComposerDialog( nullptr, parent, fl )
+{}
+
+QgsSQLComposerDialog::QgsSQLComposerDialog( QgsVectorLayer *layer, QWidget *parent, Qt::WindowFlags fl )
+  : QgsSubsetStringEditorInterface( parent, fl )
+  , mLayer( layer )
 {
   setupUi( this );
   connect( mTablesCombo, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsSQLComposerDialog::mTablesCombo_currentIndexChanged );
@@ -220,6 +226,10 @@ void QgsSQLComposerDialog::accept()
     {
       QMessageBox::warning( this, tr( "SQL Evaluation" ), warningMsg );
     }
+  }
+  if ( mLayer )
+  {
+    mLayer->setSubsetString( sql() );
   }
   QDialog::accept();
 }

--- a/src/gui/qgssqlcomposerdialog.h
+++ b/src/gui/qgssqlcomposerdialog.h
@@ -27,15 +27,18 @@ email                : even.rouault at spatialys.com
 #include <QStringList>
 #include <QSet>
 #include "qgis_gui.h"
+#include "qgssubsetstringeditorinterface.h"
 
 SIP_NO_FILE
+
+class QgsVectorLayer;
 
 /**
  * \ingroup gui
  * SQL composer dialog
  *  \note not available in Python bindings
  */
-class GUI_EXPORT QgsSQLComposerDialog : public QDialog, private Ui::QgsSQLComposerDialogBase
+class GUI_EXPORT QgsSQLComposerDialog : public QgsSubsetStringEditorInterface, private Ui::QgsSQLComposerDialogBase
 {
     Q_OBJECT
 
@@ -109,6 +112,15 @@ class GUI_EXPORT QgsSQLComposerDialog : public QDialog, private Ui::QgsSQLCompos
 
     //! constructor
     explicit QgsSQLComposerDialog( QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
+
+    /**
+     * This constructor is used on an existing layer. On successful accept, it will update the layer subset string.
+     * \param layer existing vector layer
+     * \param parent Parent widget
+     * \param fl dialog flags
+     */
+    QgsSQLComposerDialog( QgsVectorLayer *layer, QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
+
     ~QgsSQLComposerDialog() override;
 
     //! initialize the SQL statement
@@ -116,6 +128,9 @@ class GUI_EXPORT QgsSQLComposerDialog : public QDialog, private Ui::QgsSQLCompos
 
     //! Gets the SQL statement
     QString sql() const;
+
+    QString subsetString() const override { return sql(); }
+    void setSubsetString( const QString &subsetString ) override { setSql( subsetString ); }
 
     //! add a list of table names
     void addTableNames( const QStringList &list );
@@ -174,6 +189,7 @@ class GUI_EXPORT QgsSQLComposerDialog : public QDialog, private Ui::QgsSQLCompos
     void splitSQLIntoFields();
 
   private:
+    QgsVectorLayer *mLayer = nullptr;
     QStringList mApiList;
     QSet<QString> mAlreadySelectedTables;
     TableSelectedCallback *mTableSelectedCallback = nullptr;

--- a/src/gui/qgssubsetstringeditorinterface.cpp
+++ b/src/gui/qgssubsetstringeditorinterface.cpp
@@ -1,0 +1,22 @@
+/***************************************************************************
+    qgssubsetstringeditorinterface.cpp
+     --------------------------------------
+    Date                 : 15-Nov-2020
+    Copyright            : (C) 2020 by Even Rouault
+    Email                : even.rouault at spatials.com
+****************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgssubsetstringeditorinterface.h"
+
+QgsSubsetStringEditorInterface::QgsSubsetStringEditorInterface( QWidget *parent,
+    Qt::WindowFlags fl )
+  : QDialog( parent, fl )
+{}

--- a/src/gui/qgssubsetstringeditorinterface.h
+++ b/src/gui/qgssubsetstringeditorinterface.h
@@ -1,0 +1,49 @@
+/***************************************************************************
+    qgssubsetstringeditorinterface.h
+     --------------------------------------
+    Date                 : 15-Nov-2020
+    Copyright            : (C) 2020 by Even Rouault
+    Email                : even.rouault at spatials.com
+****************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSUBSETSTRINGEDITORINTERFACE_H
+#define QGSSUBSETSTRINGEDITORINTERFACE_H
+
+#include <QDialog>
+#include <QString>
+#include "qgis.h"
+#include "qgis_gui.h"
+#include "qgsguiutils.h"
+
+/**
+ * \ingroup gui
+ * \class QgsSubsetStringEditorInterface
+ * \brief Interface for a dialog that can edit subset strings
+ *
+ * \since QGIS 3.18
+ */
+class GUI_EXPORT QgsSubsetStringEditorInterface: public QDialog
+{
+    Q_OBJECT
+
+  public:
+    //! Constructor
+    QgsSubsetStringEditorInterface( QWidget *parent SIP_TRANSFERTHIS = nullptr,
+                                    Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
+
+    //! Returns the subset string entered in the dialog.
+    virtual QString subsetString() const = 0;
+
+    //! Sets a subset string into the dialog.
+    virtual void setSubsetString( const QString &subsetString ) = 0;
+};
+
+#endif

--- a/src/gui/qgssubsetstringeditorprovider.cpp
+++ b/src/gui/qgssubsetstringeditorprovider.cpp
@@ -1,0 +1,19 @@
+/***************************************************************************
+    qgssubsetstringeditorprovider.cpp
+     --------------------------------------
+    Date                 : 15-Nov-2020
+    Copyright            : (C) 2020 by Even Rouault
+    Email                : even.rouault at spatials.com
+****************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgssubsetstringeditorprovider.h"
+
+QgsSubsetStringEditorProvider::~QgsSubsetStringEditorProvider() = default;

--- a/src/gui/qgssubsetstringeditorprovider.h
+++ b/src/gui/qgssubsetstringeditorprovider.h
@@ -1,0 +1,78 @@
+/***************************************************************************
+    qgssubsetstringeditorprovider.h
+     --------------------------------------
+    Date                 : 15-Nov-2020
+    Copyright            : (C) 2020 by Even Rouault
+    Email                : even.rouault at spatials.com
+****************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSUBSETSTRINGEDITORPROVIDER_H
+#define QGSSUBSETSTRINGEDITORPROVIDER_H
+
+#include "qgis.h"
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include "qgsguiutils.h"
+
+class QWidget;
+class QgsVectorLayer;
+class QgsSubsetStringEditorInterface;
+
+/**
+ * \ingroup gui
+ * \class QgsSubsetStringEditorProvider
+ * This is the interface for those who want to provide a dialog to edit a
+ * subset string.
+ *
+ * \since QGIS 3.18
+ */
+class GUI_EXPORT QgsSubsetStringEditorProvider
+{
+  public:
+    //! Destructor.
+    virtual ~QgsSubsetStringEditorProvider();
+
+    //! Provider key
+    virtual QString providerKey() const = 0;
+
+    /**
+     * Subset string editor provider name, this is useful to retrieve
+     * a particular subset string editor in case the provider has more
+     * than one, it should be unique among all providers.
+     *
+     * The default implementation returns the providerKey()
+     */
+    virtual QString name() const { return providerKey(); }
+
+    //! Returns true if the provider can handle the layer
+    virtual bool canHandleLayer( QgsVectorLayer *layer ) const = 0;
+
+    /**
+     * Returns true if the provider can handle specifically the
+     * layer->provider()->storageType()
+     * This method will only be called if canHandleLayer() returned true.
+     * Typically a generic SQL provider for the OGR provider will return false,
+     * whereas a dedicated plugin with a specific behavior for a OGR driver
+     * will return true.
+     */
+    virtual bool canHandleLayerStorageType( QgsVectorLayer *layer ) const { Q_UNUSED( layer ); return false; }
+
+    /**
+     * Creates a new dialog to edit the subset string of the provided \a layer.
+     * It may return nullptr if it cannot handle the layer.
+     * The returned object must be destroyed by the caller.
+     * On successful accept(), the QgsSubsetStringEditorInterface implementation
+     * is responsible for setting the updated string on layer.
+     */
+    virtual QgsSubsetStringEditorInterface *createDialog( QgsVectorLayer *layer, QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags ) = 0 SIP_FACTORY;
+};
+
+#endif

--- a/src/gui/qgssubsetstringeditorproviderregistry.cpp
+++ b/src/gui/qgssubsetstringeditorproviderregistry.cpp
@@ -1,0 +1,120 @@
+/***************************************************************************
+    qgssubsetstringeditorproviderregistry.cpp
+     ----------------------------------------
+    Date                 : 15-Nov-2020
+    Copyright            : (C) 2020 by Even Rouault
+    Email                : even.rouault at spatials.com
+****************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgssubsetstringeditorprovider.h"
+#include "qgssubsetstringeditorproviderregistry.h"
+#include "qgsproviderguiregistry.h"
+#include "qgsquerybuilder.h"
+
+#include <memory>
+
+QgsSubsetStringEditorProviderRegistry::QgsSubsetStringEditorProviderRegistry() = default;
+
+QgsSubsetStringEditorProviderRegistry::~QgsSubsetStringEditorProviderRegistry()
+{
+  qDeleteAll( mProviders );
+}
+
+QList<QgsSubsetStringEditorProvider *> QgsSubsetStringEditorProviderRegistry::providers()
+{
+  return mProviders;
+}
+
+void QgsSubsetStringEditorProviderRegistry::addProvider( QgsSubsetStringEditorProvider *provider )
+{
+  mProviders.append( provider );
+}
+
+bool QgsSubsetStringEditorProviderRegistry::removeProvider( QgsSubsetStringEditorProvider *provider )
+{
+  int index = mProviders.indexOf( provider );
+  if ( index >= 0 )
+  {
+    delete mProviders.takeAt( index );
+    return true;
+  }
+  return false;
+}
+
+
+void QgsSubsetStringEditorProviderRegistry::initializeFromProviderGuiRegistry( QgsProviderGuiRegistry *providerGuiRegistry )
+{
+  if ( !providerGuiRegistry )
+    return;
+
+  const QStringList providersList = providerGuiRegistry->providerList();
+  for ( const QString &key : providersList )
+  {
+    const QList<QgsSubsetStringEditorProvider *> providerList = providerGuiRegistry->subsetStringEditorProviders( key );
+    // the function is a factory - we keep ownership of the returned providers
+    for ( auto provider : providerList )
+    {
+      addProvider( provider );
+    }
+  }
+}
+
+QgsSubsetStringEditorProvider *QgsSubsetStringEditorProviderRegistry::providerByName( const QString &name )
+{
+  const QList<QgsSubsetStringEditorProvider *> providerList = providers();
+  for ( const auto provider :  providerList )
+  {
+    if ( provider->name() == name )
+    {
+      return provider;
+    }
+  }
+  return nullptr;
+}
+
+QList<QgsSubsetStringEditorProvider *> QgsSubsetStringEditorProviderRegistry::providersByKey( const QString &providerKey )
+{
+  QList<QgsSubsetStringEditorProvider *> result;
+  const QList<QgsSubsetStringEditorProvider *> providerList = providers();
+  for ( const auto provider : providerList )
+  {
+    if ( provider->providerKey() == providerKey )
+    {
+      result << provider;
+    }
+  }
+  return result;
+}
+
+QgsSubsetStringEditorInterface *QgsSubsetStringEditorProviderRegistry::createDialog( QgsVectorLayer *layer, QWidget *parent, Qt::WindowFlags fl )
+{
+  const QList<QgsSubsetStringEditorProvider *> providerList = providers();
+  QgsSubsetStringEditorProvider *bestProviderCandidate = nullptr;
+  // Loop over providers to find one that can handle the layer.
+  // And prefer one that will also indicate to handle the storage type.
+  for ( const auto provider : providerList )
+  {
+    if ( provider->canHandleLayer( layer ) )
+    {
+      if ( provider->canHandleLayerStorageType( layer ) )
+      {
+        return provider->createDialog( layer, parent, fl );
+      }
+      bestProviderCandidate = provider;
+    }
+  }
+  if ( bestProviderCandidate )
+  {
+    return bestProviderCandidate->createDialog( layer, parent, fl );
+  }
+
+  return new QgsQueryBuilder( layer, parent, fl );
+}

--- a/src/gui/qgssubsetstringeditorproviderregistry.h
+++ b/src/gui/qgssubsetstringeditorproviderregistry.h
@@ -1,0 +1,91 @@
+/***************************************************************************
+    qgssubsetstringeditorproviderregistry.h
+     --------------------------------------
+    Date                 : 15-Nov-2020
+    Copyright            : (C) 2020 by Even Rouault
+    Email                : even.rouault at spatials.com
+****************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSUBSETSTRINGEDITORPROVIDERREGISTRY_H
+#define QGSSUBSETSTRINGEDITORPROVIDERREGISTRY_H
+
+#include <QWidget>
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include "qgsguiutils.h"
+
+class QgsSubsetStringEditorInterface;
+class QgsSubsetStringEditorProvider;
+class QgsProviderGuiRegistry;
+
+/**
+ * \ingroup gui
+ * This class keeps a list of subset string editor providers.
+ *
+ * QgsSubsetStringEditorProviderRegistry is not usually directly created, but rather accessed through
+ * QgsGui::subsetStringEditorProvideRegistry().
+ *
+ * \since QGIS 3.18
+ */
+class GUI_EXPORT QgsSubsetStringEditorProviderRegistry
+{
+  public:
+
+    QgsSubsetStringEditorProviderRegistry();
+    ~QgsSubsetStringEditorProviderRegistry();
+
+    //! QgsDataItemProviderRegistry cannot be copied.
+    QgsSubsetStringEditorProviderRegistry( const QgsSubsetStringEditorProviderRegistry &rh ) = delete;
+    //! QgsDataItemProviderRegistry cannot be copied.
+    QgsSubsetStringEditorProviderRegistry &operator=( const QgsSubsetStringEditorProviderRegistry &rh ) = delete;
+
+    //! Gets list of available providers
+    QList< QgsSubsetStringEditorProvider *> providers();
+
+    //! Add a \a provider implementation. Takes ownership of the object.
+    void addProvider( QgsSubsetStringEditorProvider *provider SIP_TRANSFER );
+
+    /**
+     * Remove \a provider implementation from the list (\a provider object is deleted)
+     * \returns TRUE if the provider was actually removed and deleted
+     */
+    bool removeProvider( QgsSubsetStringEditorProvider *provider SIP_TRANSFER );
+
+    /**
+     * Initializes the registry. The registry needs to be passed explicitly
+     * (instead of using singleton) because this gets called from QgsGui constructor.
+     */
+    void initializeFromProviderGuiRegistry( QgsProviderGuiRegistry *providerGuiRegistry );
+
+    //! Returns a provider by \a name or NULLPTR if not found
+    QgsSubsetStringEditorProvider *providerByName( const QString &name );
+
+    //! Returns a (possibly empty) list of providers by data \a providerkey
+    QList<QgsSubsetStringEditorProvider *> providersByKey( const QString &providerKey );
+
+    /**
+     * Creates a new dialog to edit the subset string of the provided \a layer.
+     * It will default to returning a QgsQueryBuilder* if no provider was found.
+     * The returned object must be destroyed by the caller.
+     */
+    QgsSubsetStringEditorInterface *createDialog( QgsVectorLayer *layer, QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags ) SIP_TRANSFERBACK;
+
+  private:
+#ifdef SIP_RUN
+    QgsSubsetStringEditorProviderRegistry( const QgsSubsetStringEditorProviderRegistry &rh );
+#endif
+
+    //! available providers. this class owns the pointers
+    QList<QgsSubsetStringEditorProvider *> mProviders;
+};
+
+#endif // QGSSUBSETSTRINGEDITORPROVIDERREGISTRY_H

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -46,7 +46,9 @@
 #include "qgsvectorlayerproperties.h"
 #include "qgsconfig.h"
 #include "qgsvectordataprovider.h"
-#include "qgsquerybuilder.h"
+#include "qgssubsetstringeditorproviderregistry.h"
+#include "qgssubsetstringeditorprovider.h"
+#include "qgssubsetstringeditorinterface.h"
 #include "qgsdatasourceuri.h"
 #include "qgsrenderer.h"
 #include "qgsexpressioncontext.h"
@@ -844,16 +846,16 @@ void QgsVectorLayerProperties::urlClicked( const QUrl &url )
 void QgsVectorLayerProperties::pbnQueryBuilder_clicked()
 {
   // launch the query builder
-  QgsQueryBuilder *qb = new QgsQueryBuilder( mLayer, this );
+  QgsSubsetStringEditorInterface *dialog = QgsGui::subsetStringEditorProviderRegistry()->createDialog( mLayer, this );
 
   // Set the sql in the query builder to the same in the prop dialog
   // (in case the user has already changed it)
-  qb->setSql( txtSubsetSQL->text() );
+  dialog->setSubsetString( txtSubsetSQL->text() );
   // Open the query builder
-  if ( qb->exec() )
+  if ( dialog->exec() )
   {
     // if the sql is changed, update it in the prop subset text box
-    txtSubsetSQL->setText( qb->sql() );
+    txtSubsetSQL->setText( dialog->subsetString() );
     //TODO If the sql is changed in the prop dialog, the layer extent should be recalculated
 
     // The datasource for the layer needs to be updated with the new sql since this gets
@@ -861,7 +863,7 @@ void QgsVectorLayerProperties::pbnQueryBuilder_clicked()
 
   }
   // delete the query builder object
-  delete qb;
+  delete dialog;
 }
 
 void QgsVectorLayerProperties::pbnIndex_clicked()

--- a/src/providers/wfs/CMakeLists.txt
+++ b/src/providers/wfs/CMakeLists.txt
@@ -35,6 +35,7 @@ if (WITH_GUI)
     qgswfssourceselect.cpp
     qgswfsnewconnection.cpp
     qgswfsguiutils.cpp
+    qgswfssubsetstringeditor.cpp
   )
 endif()
 

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -122,6 +122,8 @@ class QgsWFSProvider final: public QgsVectorDataProvider
 
     bool empty() const override;
 
+    std::shared_ptr<QgsWFSSharedData> sharedData() const { return mShared; }
+
   private slots:
 
     void featureReceivedAnalyzeOneFeature( QVector<QgsFeatureUniqueIdPair> );

--- a/src/providers/wfs/qgswfsshareddata.h
+++ b/src/providers/wfs/qgswfsshareddata.h
@@ -46,6 +46,8 @@ class QgsWFSSharedData : public QObject, public QgsBackgroundCachedSharedData
 
     bool hasGeometry() const override { return !mGeometryAttribute.isEmpty(); }
 
+    const QgsWfsCapabilities::Capabilities &capabilities() const { return mCaps; }
+
   signals:
 
     //! Raise error

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -35,6 +35,7 @@
 #include "qgsgui.h"
 #include "qgsquerybuilder.h"
 #include "qgswfsguiutils.h"
+#include "qgswfssubsetstringeditor.h"
 
 #include <QDomDocument>
 #include <QListWidgetItem>
@@ -531,82 +532,6 @@ void QgsWFSSourceSelect::addButtonClicked()
   }
 }
 
-QgsWFSValidatorCallback::QgsWFSValidatorCallback( QObject *parent,
-    const QgsWFSDataSourceURI &uri,
-    const QString &allSql,
-    const QgsWfsCapabilities::Capabilities &caps )
-  : QObject( parent )
-  , mURI( uri )
-  , mAllSql( allSql )
-  , mCaps( caps )
-{
-}
-
-bool QgsWFSValidatorCallback::isValid( const QString &sqlStr, QString &errorReason, QString &warningMsg )
-{
-  errorReason.clear();
-  if ( sqlStr.isEmpty() || sqlStr == mAllSql )
-    return true;
-
-  QgsWFSDataSourceURI uri( mURI );
-  uri.setSql( sqlStr );
-
-  QgsDataProvider::ProviderOptions options;
-  QgsWFSProvider p( uri.uri(), options, mCaps );
-  if ( !p.isValid() )
-  {
-    errorReason = p.processSQLErrorMsg();
-    return false;
-  }
-  warningMsg = p.processSQLWarningMsg();
-
-  return true;
-}
-
-QgsWFSTableSelectedCallback::QgsWFSTableSelectedCallback( QgsSQLComposerDialog *dialog,
-    const QgsWFSDataSourceURI &uri,
-    const QgsWfsCapabilities::Capabilities &caps )
-  : QObject( dialog )
-  , mDialog( dialog )
-  , mURI( uri )
-  , mCaps( caps )
-{
-}
-
-void QgsWFSTableSelectedCallback::tableSelected( const QString &name )
-{
-  QString typeName( QgsSQLStatement::stripQuotedIdentifier( name ) );
-  QString prefixedTypename( mCaps.addPrefixIfNeeded( typeName ) );
-  if ( prefixedTypename.isEmpty() )
-    return;
-  QgsWFSDataSourceURI uri( mURI );
-  uri.setTypeName( prefixedTypename );
-
-  QgsDataProvider::ProviderOptions providerOptions;
-  QgsWFSProvider p( uri.uri(), providerOptions, mCaps );
-  if ( !p.isValid() )
-  {
-    return;
-  }
-
-  QList< QgsSQLComposerDialog::PairNameType> fieldList;
-  QString fieldNamePrefix( QgsSQLStatement::quotedIdentifierIfNeeded( typeName ) + "." );
-  const auto constToList = p.fields().toList();
-  for ( const QgsField &field : constToList )
-  {
-    QString fieldName( fieldNamePrefix + QgsSQLStatement::quotedIdentifierIfNeeded( field.name() ) );
-    fieldList << QgsSQLComposerDialog::PairNameType( fieldName, field.typeName() );
-  }
-  if ( !p.geometryAttribute().isEmpty() )
-  {
-    QString fieldName( fieldNamePrefix + QgsSQLStatement::quotedIdentifierIfNeeded( p.geometryAttribute() ) );
-    fieldList << QgsSQLComposerDialog::PairNameType( fieldName, QStringLiteral( "geometry" ) );
-  }
-  fieldList << QgsSQLComposerDialog::PairNameType( fieldNamePrefix + "*", QString() );
-
-  mDialog->addColumnNames( fieldList, name );
-}
-
 void QgsWFSSourceSelect::buildQuery( const QModelIndex &index )
 {
   if ( !index.isValid() )
@@ -681,97 +606,9 @@ void QgsWFSSourceSelect::buildQuery( const QModelIndex &index )
     sql = allSql;
   }
 
-  QgsSQLComposerDialog *d = new QgsSQLComposerDialog( this );
+  auto d = QgsWfsSubsetStringEditor::create( nullptr, &p, this );
 
-  QgsWFSValidatorCallback *validatorCbk = new QgsWFSValidatorCallback( d, uri, allSql, mCaps );
-  d->setSQLValidatorCallback( validatorCbk );
-
-  QgsWFSTableSelectedCallback *tableSelectedCbk = new QgsWFSTableSelectedCallback( d, uri, mCaps );
-  d->setTableSelectedCallback( tableSelectedCbk );
-
-  const bool bSupportJoins = mCaps.featureTypes.size() > 1 && mCaps.supportsJoins;
-  d->setSupportMultipleTables( bSupportJoins, QgsSQLStatement::quotedIdentifierIfNeeded( displayedTypeName ) );
-
-  QMap< QString, QString > mapTypenameToTitle;
-  Q_FOREACH ( const QgsWfsCapabilities::FeatureType f, mCaps.featureTypes )
-    mapTypenameToTitle[f.name] = f.title;
-
-  QList< QgsSQLComposerDialog::PairNameTitle > tablenames;
-  tablenames << QgsSQLComposerDialog::PairNameTitle(
-               QgsSQLStatement::quotedIdentifierIfNeeded( displayedTypeName ), mapTypenameToTitle[typeName] );
-  if ( bSupportJoins )
-  {
-    for ( int i = 0; i < mModel->rowCount(); i++ )
-    {
-      const QString iterTypename = mModel->index( i, MODEL_IDX_NAME ).data().toString();
-      if ( iterTypename != typeName )
-      {
-        QString displayedIterTypename( iterTypename );
-        QString unprefixedIterTypename( QgsWFSUtils::removeNamespacePrefix( iterTypename ) );
-        if ( !mCaps.setAmbiguousUnprefixedTypename.contains( unprefixedIterTypename ) )
-          displayedIterTypename = unprefixedIterTypename;
-
-        tablenames << QgsSQLComposerDialog::PairNameTitle(
-                     QgsSQLStatement::quotedIdentifierIfNeeded( displayedIterTypename ), mapTypenameToTitle[iterTypename] );
-      }
-    }
-  }
-  d->addTableNames( tablenames );
-
-  QList< QgsSQLComposerDialog::Function> functionList;
-  Q_FOREACH ( const QgsWfsCapabilities::Function &f, mCaps.functionList )
-  {
-    QgsSQLComposerDialog::Function dialogF;
-    dialogF.name = f.name;
-    dialogF.returnType = f.returnType;
-    dialogF.minArgs = f.minArgs;
-    dialogF.maxArgs = f.maxArgs;
-    Q_FOREACH ( const QgsWfsCapabilities::Argument &arg, f.argumentList )
-    {
-      dialogF.argumentList << QgsSQLComposerDialog::Argument( arg.name, arg.type );
-    }
-    functionList << dialogF;
-  }
-  d->addFunctions( functionList );
-
-  QList< QgsSQLComposerDialog::Function> spatialPredicateList;
-  Q_FOREACH ( const QgsWfsCapabilities::Function &f, mCaps.spatialPredicatesList )
-  {
-    QgsSQLComposerDialog::Function dialogF;
-    dialogF.name = f.name;
-    dialogF.returnType = f.returnType;
-    dialogF.minArgs = f.minArgs;
-    dialogF.maxArgs = f.maxArgs;
-    Q_FOREACH ( const QgsWfsCapabilities::Argument &arg, f.argumentList )
-    {
-      dialogF.argumentList << QgsSQLComposerDialog::Argument( arg.name, arg.type );
-    }
-    spatialPredicateList << dialogF;
-  }
-  d->addSpatialPredicates( spatialPredicateList );
-
-  QList< QgsSQLComposerDialog::PairNameType> fieldList;
-  QString fieldNamePrefix;
-  if ( bSupportJoins )
-  {
-    fieldNamePrefix = QgsSQLStatement::quotedIdentifierIfNeeded( displayedTypeName ) + ".";
-  }
-  const auto constToList = p.fields().toList();
-  for ( const QgsField &field : constToList )
-  {
-    QString fieldName( fieldNamePrefix + QgsSQLStatement::quotedIdentifierIfNeeded( field.name() ) );
-    fieldList << QgsSQLComposerDialog::PairNameType( fieldName, field.typeName() );
-  }
-  if ( !p.geometryAttribute().isEmpty() )
-  {
-    QString fieldName( fieldNamePrefix + QgsSQLStatement::quotedIdentifierIfNeeded( p.geometryAttribute() ) );
-    fieldList << QgsSQLComposerDialog::PairNameType( fieldName, QStringLiteral( "geometry" ) );
-  }
-  fieldList << QgsSQLComposerDialog::PairNameType( fieldNamePrefix + "*", QString() );
-
-  d->addColumnNames( fieldList, QgsSQLStatement::quotedIdentifierIfNeeded( displayedTypeName ) );
-
-  d->setSql( sql );
+  d->setSubsetString( sql );
 
   mSQLIndex = index;
   mSQLComposerDialog = d;
@@ -803,7 +640,7 @@ void QgsWFSSourceSelect::updateSql()
   const QString typeName = mSQLIndex.sibling( mSQLIndex.row(), MODEL_IDX_NAME ).data().toString();
   QModelIndex filterIndex = mSQLIndex.sibling( mSQLIndex.row(), MODEL_IDX_SQL );
 
-  QString sql = mSQLComposerDialog->sql();
+  QString sql = mSQLComposerDialog->subsetString();
   mSQLComposerDialog = nullptr;
 
   QString displayedTypeName( typeName );

--- a/src/providers/wfs/qgswfssourceselect.h
+++ b/src/providers/wfs/qgswfssourceselect.h
@@ -25,7 +25,6 @@
 #include "qgsoapifcollection.h"
 #include "qgsproviderregistry.h"
 #include "qgsabstractdatasourcewidget.h"
-#include "qgssqlcomposerdialog.h"
 
 #include <QItemDelegate>
 #include <QStandardItemModel>
@@ -33,6 +32,7 @@
 
 class QgsProjectionSelectionDialog;
 class QgsWfsCapabilities;
+class QgsSubsetStringEditorInterface;
 
 class QgsWFSItemDelegate : public QItemDelegate
 {
@@ -43,21 +43,6 @@ class QgsWFSItemDelegate : public QItemDelegate
 
     QSize sizeHint( const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
 
-};
-
-class QgsWFSValidatorCallback: public QObject, public QgsSQLComposerDialog::SQLValidatorCallback
-{
-    Q_OBJECT
-
-  public:
-    QgsWFSValidatorCallback( QObject *parent,
-                             const QgsWFSDataSourceURI &uri, const QString &allSql,
-                             const QgsWfsCapabilities::Capabilities &caps );
-    bool isValid( const QString &sql, QString &errorReason, QString &warningMsg ) override;
-  private:
-    QgsWFSDataSourceURI mURI;
-    QString mAllSql;
-    const QgsWfsCapabilities::Capabilities &mCaps;
 };
 
 class QgsWFSSourceSelect: public QgsAbstractDataSourceWidget, private Ui::QgsWFSSourceSelectBase
@@ -91,7 +76,7 @@ class QgsWFSSourceSelect: public QgsAbstractDataSourceWidget, private Ui::QgsWFS
     QPushButton *mBuildQueryButton = nullptr;
     QgsWfsCapabilities::Capabilities mCaps;
     QModelIndex mSQLIndex;
-    QgsSQLComposerDialog *mSQLComposerDialog = nullptr;
+    QgsSubsetStringEditorInterface *mSQLComposerDialog = nullptr;
     QString mVersion;
 
     /**
@@ -137,23 +122,6 @@ class QgsWFSSourceSelect: public QgsAbstractDataSourceWidget, private Ui::QgsWFS
     void startOapifCollectionsRequest( const QString &url );
     void resizeTreeViewAfterModelFill();
     bool isOapif() const { return mVersion == QLatin1String( "OGC_API_FEATURES" ); }
-};
-
-
-class QgsWFSTableSelectedCallback: public QObject, public QgsSQLComposerDialog::TableSelectedCallback
-{
-    Q_OBJECT
-
-  public:
-    QgsWFSTableSelectedCallback( QgsSQLComposerDialog *dialog,
-                                 const QgsWFSDataSourceURI &uri,
-                                 const QgsWfsCapabilities::Capabilities &caps );
-    void tableSelected( const QString &name ) override;
-
-  private:
-    QgsSQLComposerDialog *mDialog = nullptr;
-    QgsWFSDataSourceURI mURI;
-    const QgsWfsCapabilities::Capabilities &mCaps;
 };
 
 #endif

--- a/src/providers/wfs/qgswfssubsetstringeditor.cpp
+++ b/src/providers/wfs/qgswfssubsetstringeditor.cpp
@@ -1,0 +1,202 @@
+/***************************************************************************
+    qgswfssubsetstringeditor.cpp
+     --------------------------------------
+    Date                 : 15-Nov-2020
+    Copyright            : (C) 2020 by Even Rouault
+    Email                : even.rouault at spatials.com
+****************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgswfssubsetstringeditor.h"
+#include "qgswfsprovider.h"
+#include "qgswfsshareddata.h"
+#include "qgswfsutils.h"
+#include "qgssqlstatement.h"
+
+QgsSubsetStringEditorInterface *QgsWfsSubsetStringEditor::create( QgsVectorLayer *layer, QgsWFSProvider *provider, QWidget *parent, Qt::WindowFlags fl )
+{
+  Q_ASSERT( provider );
+  const auto caps = provider->sharedData()->capabilities();
+
+  QgsWFSDataSourceURI uri( provider->uri().uri( false ) );
+  const QString typeName( uri.typeName() );
+  QString displayedTypeName( typeName );
+  if ( !caps.setAmbiguousUnprefixedTypename.contains( QgsWFSUtils::removeNamespacePrefix( typeName ) ) )
+    displayedTypeName = QgsWFSUtils::removeNamespacePrefix( typeName );
+  QString allSql( "SELECT * FROM " + QgsSQLStatement::quotedIdentifierIfNeeded( displayedTypeName ) );
+
+  QgsSQLComposerDialog *d = new QgsSQLComposerDialog( layer, parent, fl );
+
+  QgsWFSValidatorCallback *validatorCbk = new QgsWFSValidatorCallback( d, uri, allSql, caps );
+  d->setSQLValidatorCallback( validatorCbk );
+
+  QgsWFSTableSelectedCallback *tableSelectedCbk = new QgsWFSTableSelectedCallback( d, uri, caps );
+  d->setTableSelectedCallback( tableSelectedCbk );
+
+  const bool bSupportJoins = caps.featureTypes.size() > 1 && caps.supportsJoins;
+  d->setSupportMultipleTables( bSupportJoins, QgsSQLStatement::quotedIdentifierIfNeeded( displayedTypeName ) );
+
+  QMap< QString, QString > mapTypenameToTitle;
+  Q_FOREACH ( const QgsWfsCapabilities::FeatureType f, caps.featureTypes )
+    mapTypenameToTitle[f.name] = f.title;
+
+  QList< QgsSQLComposerDialog::PairNameTitle > tablenames;
+  tablenames << QgsSQLComposerDialog::PairNameTitle(
+               QgsSQLStatement::quotedIdentifierIfNeeded( displayedTypeName ), mapTypenameToTitle[typeName] );
+  if ( bSupportJoins )
+  {
+    for ( const auto &featureType : caps.featureTypes )
+    {
+      const QString iterTypename = featureType.name;
+      if ( iterTypename != typeName )
+      {
+        QString displayedIterTypename( iterTypename );
+        QString unprefixedIterTypename( QgsWFSUtils::removeNamespacePrefix( iterTypename ) );
+        if ( !caps.setAmbiguousUnprefixedTypename.contains( unprefixedIterTypename ) )
+          displayedIterTypename = unprefixedIterTypename;
+
+        tablenames << QgsSQLComposerDialog::PairNameTitle(
+                     QgsSQLStatement::quotedIdentifierIfNeeded( displayedIterTypename ), mapTypenameToTitle[iterTypename] );
+      }
+    }
+  }
+  d->addTableNames( tablenames );
+
+  QList< QgsSQLComposerDialog::Function> functionList;
+  Q_FOREACH ( const QgsWfsCapabilities::Function &f, caps.functionList )
+  {
+    QgsSQLComposerDialog::Function dialogF;
+    dialogF.name = f.name;
+    dialogF.returnType = f.returnType;
+    dialogF.minArgs = f.minArgs;
+    dialogF.maxArgs = f.maxArgs;
+    Q_FOREACH ( const QgsWfsCapabilities::Argument &arg, f.argumentList )
+    {
+      dialogF.argumentList << QgsSQLComposerDialog::Argument( arg.name, arg.type );
+    }
+    functionList << dialogF;
+  }
+  d->addFunctions( functionList );
+
+  QList< QgsSQLComposerDialog::Function> spatialPredicateList;
+  Q_FOREACH ( const QgsWfsCapabilities::Function &f, caps.spatialPredicatesList )
+  {
+    QgsSQLComposerDialog::Function dialogF;
+    dialogF.name = f.name;
+    dialogF.returnType = f.returnType;
+    dialogF.minArgs = f.minArgs;
+    dialogF.maxArgs = f.maxArgs;
+    Q_FOREACH ( const QgsWfsCapabilities::Argument &arg, f.argumentList )
+    {
+      dialogF.argumentList << QgsSQLComposerDialog::Argument( arg.name, arg.type );
+    }
+    spatialPredicateList << dialogF;
+  }
+  d->addSpatialPredicates( spatialPredicateList );
+
+  QList< QgsSQLComposerDialog::PairNameType> fieldList;
+  QString fieldNamePrefix;
+  if ( bSupportJoins )
+  {
+    fieldNamePrefix = QgsSQLStatement::quotedIdentifierIfNeeded( displayedTypeName ) + ".";
+  }
+  const auto constToList = provider->fields().toList();
+  for ( const QgsField &field : constToList )
+  {
+    QString fieldName( fieldNamePrefix + QgsSQLStatement::quotedIdentifierIfNeeded( field.name() ) );
+    fieldList << QgsSQLComposerDialog::PairNameType( fieldName, field.typeName() );
+  }
+  if ( !provider->geometryAttribute().isEmpty() )
+  {
+    QString fieldName( fieldNamePrefix + QgsSQLStatement::quotedIdentifierIfNeeded( provider->geometryAttribute() ) );
+    fieldList << QgsSQLComposerDialog::PairNameType( fieldName, QStringLiteral( "geometry" ) );
+  }
+  fieldList << QgsSQLComposerDialog::PairNameType( fieldNamePrefix + "*", QString() );
+
+  d->addColumnNames( fieldList, QgsSQLStatement::quotedIdentifierIfNeeded( displayedTypeName ) );
+
+  return d;
+}
+
+QgsWFSValidatorCallback::QgsWFSValidatorCallback( QObject *parent,
+    const QgsWFSDataSourceURI &uri,
+    const QString &allSql,
+    const QgsWfsCapabilities::Capabilities &caps )
+  : QObject( parent )
+  , mURI( uri )
+  , mAllSql( allSql )
+  , mCaps( caps )
+{
+}
+
+bool QgsWFSValidatorCallback::isValid( const QString &sqlStr, QString &errorReason, QString &warningMsg )
+{
+  errorReason.clear();
+  if ( sqlStr.isEmpty() || sqlStr == mAllSql )
+    return true;
+
+  QgsWFSDataSourceURI uri( mURI );
+  uri.setSql( sqlStr );
+
+  QgsDataProvider::ProviderOptions options;
+  QgsWFSProvider p( uri.uri(), options, mCaps );
+  if ( !p.isValid() )
+  {
+    errorReason = p.processSQLErrorMsg();
+    return false;
+  }
+  warningMsg = p.processSQLWarningMsg();
+
+  return true;
+}
+
+QgsWFSTableSelectedCallback::QgsWFSTableSelectedCallback( QgsSQLComposerDialog *dialog,
+    const QgsWFSDataSourceURI &uri,
+    const QgsWfsCapabilities::Capabilities &caps )
+  : QObject( dialog )
+  , mDialog( dialog )
+  , mURI( uri )
+  , mCaps( caps )
+{
+}
+
+void QgsWFSTableSelectedCallback::tableSelected( const QString &name )
+{
+  QString typeName( QgsSQLStatement::stripQuotedIdentifier( name ) );
+  QString prefixedTypename( mCaps.addPrefixIfNeeded( typeName ) );
+  if ( prefixedTypename.isEmpty() )
+    return;
+  QgsWFSDataSourceURI uri( mURI );
+  uri.setTypeName( prefixedTypename );
+
+  QgsDataProvider::ProviderOptions providerOptions;
+  QgsWFSProvider p( uri.uri(), providerOptions, mCaps );
+  if ( !p.isValid() )
+  {
+    return;
+  }
+
+  QList< QgsSQLComposerDialog::PairNameType> fieldList;
+  QString fieldNamePrefix( QgsSQLStatement::quotedIdentifierIfNeeded( typeName ) + "." );
+  const auto constToList = p.fields().toList();
+  for ( const QgsField &field : constToList )
+  {
+    QString fieldName( fieldNamePrefix + QgsSQLStatement::quotedIdentifierIfNeeded( field.name() ) );
+    fieldList << QgsSQLComposerDialog::PairNameType( fieldName, field.typeName() );
+  }
+  if ( !p.geometryAttribute().isEmpty() )
+  {
+    QString fieldName( fieldNamePrefix + QgsSQLStatement::quotedIdentifierIfNeeded( p.geometryAttribute() ) );
+    fieldList << QgsSQLComposerDialog::PairNameType( fieldName, QStringLiteral( "geometry" ) );
+  }
+  fieldList << QgsSQLComposerDialog::PairNameType( fieldNamePrefix + "*", QString() );
+
+  mDialog->addColumnNames( fieldList, name );
+}

--- a/src/providers/wfs/qgswfssubsetstringeditor.h
+++ b/src/providers/wfs/qgswfssubsetstringeditor.h
@@ -1,0 +1,67 @@
+/***************************************************************************
+    qgswfssubsetstringeditor.h
+     --------------------------------------
+    Date                 : 15-Nov-2020
+    Copyright            : (C) 2020 by Even Rouault
+    Email                : even.rouault at spatials.com
+****************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSWFSSUBSETSTRINGEDITOR_H
+#define QGSWFSSUBSETSTRINGEDITOR_H
+
+#include "qgssubsetstringeditorinterface.h"
+#include "qgsvectorlayer.h"
+#include "qgsguiutils.h"
+#include "qgssqlcomposerdialog.h"
+#include "qgswfsprovider.h"
+#include "qgswfscapabilities.h"
+
+#include <QWidget>
+
+class QgsWfsSubsetStringEditor
+{
+  public:
+    //! Instantiate a QgsSQLComposerDialog
+    static QgsSubsetStringEditorInterface *create( QgsVectorLayer *layer, QgsWFSProvider *provider, QWidget *parent, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
+};
+
+class QgsWFSValidatorCallback: public QObject, public QgsSQLComposerDialog::SQLValidatorCallback
+{
+    Q_OBJECT
+
+  public:
+    QgsWFSValidatorCallback( QObject *parent,
+                             const QgsWFSDataSourceURI &uri, const QString &allSql,
+                             const QgsWfsCapabilities::Capabilities &caps );
+    bool isValid( const QString &sql, QString &errorReason, QString &warningMsg ) override;
+  private:
+    QgsWFSDataSourceURI mURI;
+    QString mAllSql;
+    const QgsWfsCapabilities::Capabilities mCaps;
+};
+
+class QgsWFSTableSelectedCallback: public QObject, public QgsSQLComposerDialog::TableSelectedCallback
+{
+    Q_OBJECT
+
+  public:
+    QgsWFSTableSelectedCallback( QgsSQLComposerDialog *dialog,
+                                 const QgsWFSDataSourceURI &uri,
+                                 const QgsWfsCapabilities::Capabilities &caps );
+    void tableSelected( const QString &name ) override;
+
+  private:
+    QgsSQLComposerDialog *mDialog = nullptr;
+    QgsWFSDataSourceURI mURI;
+    const QgsWfsCapabilities::Capabilities mCaps;
+};
+
+#endif

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -278,6 +278,7 @@ ADD_PYTHON_TEST(PyQgsSymbolExpressionVariables test_qgssymbolexpressionvariables
 ADD_PYTHON_TEST(PyQgsSyntacticSugar test_syntactic_sugar.py)
 ADD_PYTHON_TEST(PyQgsStringUtils test_qgsstringutils.py)
 ADD_PYTHON_TEST(PyQgsStyleModel test_qgsstylemodel.py)
+ADD_PYTHON_TEST(PyQgsSubsetStringEditorProviderRegistry test_qgssubsetstringeditorproviderregistry.py)
 ADD_PYTHON_TEST(PyQgsSvgSourceLineEdit test_qgssvgsourcelineedit.py)
 ADD_PYTHON_TEST(PyQgsSymbol test_qgssymbol.py)
 ADD_PYTHON_TEST(PyQgsSymbolLayerUtils test_qgssymbollayerutils.py)

--- a/tests/src/python/test_qgssubsetstringeditorproviderregistry.py
+++ b/tests/src/python/test_qgssubsetstringeditorproviderregistry.py
@@ -12,11 +12,24 @@ __copyright__ = 'Copyright 2018, The QGIS Project'
 
 import qgis  # NOQA
 
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtWidgets import QDialog
+
+from qgis.core import QgsVectorLayer
 from qgis.gui import (QgsGui,
+                      QgsQueryBuilder,
+                      QgsSubsetStringEditorInterface,
                       QgsSubsetStringEditorProvider)
 from qgis.testing import start_app, unittest
 
 app = start_app()
+
+
+class SubsetStringDialog(QgsSubsetStringEditorInterface):
+
+    def __init__(self, parent=None, fl=Qt.WindowFlags()):
+        super().__init__(parent, fl)
+        self.setObjectName("my_custom_dialog")
 
 
 class TestProvider(QgsSubsetStringEditorProvider):
@@ -29,10 +42,10 @@ class TestProvider(QgsSubsetStringEditorProvider):
         return self._name
 
     def canHandleLayer(self, layer):
-        return False
+        return layer.name() == "layer_for_this_provider"
 
     def createDialog(self, layer, parent, fl):
-        return None
+        return SubsetStringDialog(parent, fl)
 
 
 class TestQgsSubsetStringEditorProviderRegistry(unittest.TestCase):
@@ -77,6 +90,42 @@ class TestQgsSubsetStringEditorProviderRegistry(unittest.TestCase):
         self.assertIsNotNone(registry.providerByName('WFS'))
         self.assertIsNone(registry.providerByName('i_do_not_exist'))
         self.assertEqual(registry.providerByName('WFS').providerKey(), 'WFS')
+
+    def testCreateDialogWithDefaultImplementation(self):
+        """ Tests that createDialog() returns the default implementation when no provider kicks in """
+
+        registry = QgsGui.subsetStringEditorProviderRegistry()
+        p1 = TestProvider('p1')
+        try:
+            registry.addProvider(p1)
+
+            vl = QgsVectorLayer(
+                'Polygon?crs=epsg:4326&field=id:int',
+                'test',
+                'memory')
+            self.assertIsNotNone(registry.createDialog(vl))
+            self.assertEqual(registry.createDialog(vl).objectName(),
+                             QgsQueryBuilder(vl).objectName())
+        finally:
+            registry.removeProvider(p1)
+
+    def testCreateDialogWithCustomImplementation(self):
+        """ Tests that createDialog() returns a custom implementation """
+
+        registry = QgsGui.subsetStringEditorProviderRegistry()
+        p1 = TestProvider('p1')
+        try:
+            registry.addProvider(p1)
+
+            vl = QgsVectorLayer(
+                'Polygon?crs=epsg:4326&field=id:int',
+                'layer_for_this_provider',
+                'memory')
+            self.assertIsNotNone(registry.createDialog(vl))
+            self.assertEqual(registry.createDialog(vl).objectName(),
+                             SubsetStringDialog().objectName())
+        finally:
+            registry.removeProvider(p1)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgssubsetstringeditorproviderregistry.py
+++ b/tests/src/python/test_qgssubsetstringeditorproviderregistry.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""QGIS Unit tests for QgsSubsetStringEditorProviderRegistry
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+__author__ = 'Even Rouault'
+__date__ = '15/11/2020'
+__copyright__ = 'Copyright 2018, The QGIS Project'
+
+import qgis  # NOQA
+
+from qgis.gui import (QgsGui,
+                      QgsSubsetStringEditorProvider)
+from qgis.testing import start_app, unittest
+
+app = start_app()
+
+
+class TestProvider(QgsSubsetStringEditorProvider):
+
+    def __init__(self, name):
+        super().__init__()
+        self._name = name
+
+    def providerKey(self):
+        return self._name
+
+    def canHandleLayer(self, layer):
+        return False
+
+    def createDialog(self, layer, parent, fl):
+        return None
+
+
+class TestQgsSubsetStringEditorProviderRegistry(unittest.TestCase):
+
+    def testGuiRegistry(self):
+        # ensure there is an application instance
+        self.assertIsNotNone(QgsGui.subsetStringEditorProviderRegistry())
+
+    def testRegistry(self):
+        registry = QgsGui.subsetStringEditorProviderRegistry()
+        initial_providers = registry.providers()
+        self.assertTrue(initial_providers)  # we expect a bunch of default providers
+        self.assertTrue([p.name() for p in initial_providers if p.name() == 'WFS'])
+
+        # add a new provider
+        p1 = TestProvider('p1')
+        registry.addProvider(p1)
+        self.assertIn(p1, registry.providers())
+
+        p2 = TestProvider('p2')
+        registry.addProvider(p2)
+        self.assertIn(p1, registry.providers())
+        self.assertIn(p2, registry.providers())
+
+        registry.removeProvider(None)
+        p3 = TestProvider('p3')
+        # not in registry yet
+        registry.removeProvider(p3)
+
+        registry.removeProvider(p1)
+        self.assertNotIn('p1', [p.name() for p in registry.providers()])
+        self.assertIn(p2, registry.providers())
+
+        registry.removeProvider(p2)
+        self.assertNotIn('p2', [p.name() for p in registry.providers()])
+        self.assertEqual(registry.providers(), initial_providers)
+
+    def testProviderKey(self):
+        """Tests finding provider by name and return providerKey"""
+
+        registry = QgsGui.subsetStringEditorProviderRegistry()
+        self.assertIsNotNone(registry.providerByName('WFS'))
+        self.assertIsNone(registry.providerByName('i_do_not_exist'))
+        self.assertEqual(registry.providerByName('WFS').providerKey(), 'WFS')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The aim of this work is to be able to provide custom subset string editor
GUI according to the layer. Typically, so that a WFS layer uses the same
editor than in its select source, or that a plugin can provide a custom
editor.

* Add QgsSubsetStringEditorInterface: abstract interface to define a dialog
  that can edit a subset string
* Make QgsQueryBuilder implement QgsSubsetStringEditorInterface
* Add QgsSubsetStringEditorProvider: interface for thos who want to provide
  a dialog to edit a subset string.
* Add QgsSubsetStringEditorProviderRegistry: keeps a list of subset string
  editor providers. Transposed from QgsDataItemGuiProviderRegistry
* Add QgsGui::subsetStringEditorProviderRegistry()

Make 'Add Filter' context menu entry and 'Edit query' in vector layer
properties dialog use the subset string provider registry

WFS provider: declare its QgsSQLComposerDialog implementation as a
subset string editor provider
