### PR TITLE
[delimitedtext] Fix broken encodeUri handling of file path on windows

### DIFF
--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -1289,7 +1289,7 @@ QVariantMap QgsDelimitedTextProviderMetadata::decodeUri( const QString &uri ) co
 
 QString QgsDelimitedTextProviderMetadata::encodeUri( const QVariantMap &parts ) const
 {
-  QUrl url( QStringLiteral( "file://%1" ).arg( parts.value( QStringLiteral( "path" ) ).toString() ) );
+  QUrl url = QUrl::fromLocalFile( parts.value( QStringLiteral( "path" ) ).toString() );
   const QStringList openOptions = parts.value( QStringLiteral( "openOptions" ) ).toStringList();
 
   QUrlQuery queryItems;


### PR DESCRIPTION
## Description

Last bit needed to fix #39968 -- turns out the delimited text provider's encodeUri didn't properly handle windows paths.