### PR TITLE
Add a string output for overlay-* functions

### DIFF
--- a/resources/function_help/json/overlay_contains
+++ b/resources/function_help/json/overlay_contains
@@ -44,6 +44,10 @@
       "returns": "an array of names, for the regions contained in the current feature"
     },
     {
+      "expression": "array_to_string(overlay_contains('regions', name))",
+      "returns": "a string as a comma separated list of names, for the regions contained in the current feature"
+    },
+    {
       "expression": "array_sort(overlay_contains(layer:='regions', expression:=\"name\", filter:= population > 10000))",
       "returns": "an ordered array of names, for the regions contained in the current feature and with a population greater than 10000"
     },

--- a/resources/function_help/json/overlay_crosses
+++ b/resources/function_help/json/overlay_crosses
@@ -44,6 +44,10 @@
       "returns": "an array of names, for the regions crossed by the current feature"
     },
     {
+      "expression": "array_to_string(overlay_crosses('regions', name))",
+      "returns": "a string as a comma separated list of names, for the regions crossed by the current feature"
+    },
+    {
       "expression": "array_sort(overlay_crosses(layer:='regions', expression:=\"name\", filter:= population > 10000))",
       "returns": "an ordered array of names, for the regions crossed by the current feature and with a population greater than 10000"
     },

--- a/resources/function_help/json/overlay_disjoint
+++ b/resources/function_help/json/overlay_disjoint
@@ -44,6 +44,10 @@
       "returns": "an array of names, for the regions spatially disjoint from the current feature"
     },
     {
+      "expression": "array_to_string(overlay_disjoint('regions', name))",
+      "returns": "a string as a comma separated list of names, for the regions spatially disjoint from the current feature"
+    },
+    {
       "expression": "array_sort(overlay_disjoint(layer:='regions', expression:=\"name\", filter:= population > 10000))",
       "returns": "an ordered array of names, for the regions spatially disjoint from the current feature and with a population greater than 10000"
     },

--- a/resources/function_help/json/overlay_equals
+++ b/resources/function_help/json/overlay_equals
@@ -44,6 +44,10 @@
       "returns": "an array of names, for the regions spatially equal to the current feature"
     },
     {
+      "expression": "array_to_string(overlay_equals('regions', name))",
+      "returns": "a string as a comma separated list of names, for the regions spatially equal to the current feature"
+    },
+    {
       "expression": "array_sort(overlay_equals(layer:='regions', expression:=\"name\", filter:= population > 10000))",
       "returns": "an ordered array of names, for the regions spatially equal to the current feature and with a population greater than 10000"
     },

--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -44,6 +44,10 @@
       "returns": "an array of names, for the regions intersected by the current feature"
     },
     {
+      "expression": "array_to_string(overlay_intersects('regions', name))",
+      "returns": "a string as a comma separated list of names, for the regions intersected by the current feature"
+    },
+    {
       "expression": "array_sort(overlay_intersects(layer:='regions', expression:=\"name\", filter:= population > 10000))",
       "returns": "an ordered array of names, for the regions intersected by the current feature and with a population greater than 10000"
     },

--- a/resources/function_help/json/overlay_nearest
+++ b/resources/function_help/json/overlay_nearest
@@ -47,11 +47,15 @@
     },
     {
       "expression": "overlay_nearest('airports', name)",
-      "returns": "the name of the closest airport to the current feature"
+      "returns": "the name of the closest airport to the current feature, as an array"
+    },
+    {
+      "expression": "array_to_string(overlay_nearest('airports', name))",
+      "returns": "the name of the closest airport to the current feature, as a string"
     },
     {
       "expression": "overlay_nearest(layer:='airports', expression:= name, max_distance:= 5000)",
-      "returns": "the name of the closest airport within a distance of 5000 map units from the current feature"
+      "returns": "the name of the closest airport within a distance of 5000 map units from the current feature, as an array"
     },
     {
       "expression": "overlay_nearest(layer:='airports', expression:=\"name\", filter:= \"Use\"='Civilian', limit:=3)",

--- a/resources/function_help/json/overlay_touches
+++ b/resources/function_help/json/overlay_touches
@@ -44,6 +44,10 @@
       "returns": "an array of names, for the regions touched by the current feature"
     },
     {
+      "expression": "string_to_array(overlay_touches('regions', name))",
+      "returns": "a string as a comma separated list of names, for the regions touched by the current feature"
+    },
+    {
       "expression": "array_sort(overlay_touches(layer:='regions', expression:=\"name\", filter:= population > 10000))",
       "returns": "an ordered array of names, for the regions touched by the current feature and with a population greater than 10000"
     },

--- a/resources/function_help/json/overlay_within
+++ b/resources/function_help/json/overlay_within
@@ -44,6 +44,10 @@
       "returns": "an array of names, for the regions containing the current feature"
     },
     {
+      "expression": "array_to_string(overlay_within('regions', name))",
+      "returns": "a string as a comma separated list of names, for the regions containing the current feature"
+    },
+    {
       "expression": "array_sort(overlay_within(layer:='regions', expression:=\"name\", filter:= population > 10000))",
       "returns": "an ordered array of names, for the regions containing the current feature and with a population greater than 10000"
     },


### PR DESCRIPTION
refs https://github.com/qgis/QGIS/pull/38405#issuecomment-727248945
Rewording welcome!
@m-kuhn  https://github.com/qgis/QGIS/pull/38405#issuecomment-727206517 is too technical for me (I have no idea how to insert a dynamic (released and locale aware) URL in the json help file.