### PR TITLE
Add QgsDataItem::Fast flag for QgsPGLayerItem

### DIFF
--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -314,7 +314,7 @@ QgsPGLayerItem::QgsPGLayerItem( QgsDataItem *parent, const QString &name, const 
   : QgsLayerItem( parent, name, path, QString(), layerType, layerProperty.isRaster ? QStringLiteral( "postgresraster" ) : QStringLiteral( "postgres" ) )
   , mLayerProperty( layerProperty )
 {
-  mCapabilities |= Delete | Fertile;
+  mCapabilities |= Delete | Fertile | Fast;
   mUri = createUri();
   // No rasters for now
   setState( layerProperty.isRaster ? Populated : NotPopulated );


### PR DESCRIPTION
This prevents creating Futures for building GUI elements
for each layer attribute in parallel.

If QGis is quit with generic Geometry layers expanded in the PostGIS
browser, then restarting QGis and reopening these schemas in the browser
results often in never ending hourglasses shown for the Geometry layers.

The root cause is that some Futures are never completed, probably
due to a race condition. Adding the Fast flag prevents creating these
Futures and does not result in a measurable slowdown for the GUI.

## Description

When restarting QGIS (after having inspected a `geometry` table in the first session) I get 2 eternal hourglasses (one for the linestring and one for the polygon version).

![Screenshot from 2020-11-10 11-54-10](https://user-images.githubusercontent.com/1104260/98665184-9e487480-234b-11eb-8564-4a702351822d.png)

QGIS hangs on exit with:

```
src/core/qgsdataitem.cpp:370 : (deleteLater) [431651ms] mFutureWatcher not finished -> schedule to delete later
src/core/qgsdataitem.cpp:370 : (deleteLater) [0ms] mFutureWatcher not finished -> schedule to delete later
```
EDIT:

The root cause is a deadlock due to the max number of connections:
https://github.com/qgis/QGIS/blob/8c06a1ac43983b3d9b3a75246d3d68dc22be834e/src/core/qgsapplication.cpp#L122

Raising from `4` to `8` fixes this issue (but with more layers even higher numbers are needed)

This matches inspection of Postgres during the hang, there are 4 queries pending with results.

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
