### PR TITLE
Use unique PostGIS geometrytype based names

### DIFF
--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -437,7 +437,7 @@ QVector<QgsDataItem *> QgsPGSchemaItem::createChildren()
       {
         if ( prev && prev->name().indexOf( layerItem->name() ) == 0 )
         {
-          layerItem->setName( layerItem->name() + QString( ":" ) + QgsPostgresConn::displayStringForWkbType( layerProperty.types.at( i ) ) );
+          layerItem->setName( layerItem->name() + QChar( ':' ) + QgsPostgresConn::displayStringForWkbType( layerProperty.types.at( i ) ) );
         }
         items.append( layerItem );
       }

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -428,12 +428,20 @@ QVector<QgsDataItem *> QgsPGSchemaItem::createChildren()
       }
     }
 
+    QgsDataItem *prev = nullptr;
     for ( int i = 0; i < layerProperty.size(); i++ )
     {
       QgsDataItem *layerItem = nullptr;
       layerItem = createLayer( layerProperty.at( i ) );
       if ( layerItem )
+      {
+        if ( prev && prev->name().indexOf( layerItem->name() ) == 0 )
+        {
+          layerItem->setName( layerItem->name() + QString( ":" ) + QgsPostgresConn::displayStringForWkbType( layerProperty.types.at( i ) ) );
+        }
         items.append( layerItem );
+      }
+      prev = layerItem;
     }
   }
 


### PR DESCRIPTION
This prevents issues when expanding table attributes in the browser
when several tables have a generic geometry attribute and are listed
multiple times.

Creating unique names ("tablename:GeometryType" except for the first table
which keeps the default name) prevents these issues.

## Description

![Screenshot from 2020-11-12 14-34-00](https://user-images.githubusercontent.com/1104260/98946484-3c773e80-24f4-11eb-9e73-145fbdb25235.png)

After expanding "Fields" from both the "inrichtingselement" layers and restarting,
the top "inrichtingselement" layer with `Points` misses the expand black triangle!

A right-mouse "Refresh" of the enclosing schema fixes this...

This PR creates unique names:

![Screenshot from 2020-11-12 19-52-03](https://user-images.githubusercontent.com/1104260/98983098-9ee63400-2520-11eb-81aa-c084ae61ed1b.png)

It is not clear to me what the root cause for this issue is.

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
