### PR TITLE
Reuse QgsPostgresConn to prevent deadlock

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -29,6 +29,7 @@
 #include "qgssettings.h"
 #include "qgsjsonutils.h"
 #include "qgspostgresstringutils.h"
+#include "qgspostgresconnpool.h"
 
 #include <QApplication>
 #include <QStringList>
@@ -140,6 +141,17 @@ Oid QgsPostgresResult::PQoidValue()
 {
   Q_ASSERT( mRes );
   return ::PQoidValue( mRes );
+}
+
+QgsPoolPostgresConn::QgsPoolPostgresConn( const QString &connInfo )
+  : mPgConn( QgsPostgresConnPool::instance()->acquireConnection( connInfo ) )
+{
+}
+
+QgsPoolPostgresConn::~QgsPoolPostgresConn()
+{
+  if ( mPgConn )
+    QgsPostgresConnPool::instance()->releaseConnection( mPgConn );
 }
 
 

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -188,6 +188,17 @@ class QgsPostgresResult
 
 };
 
+//! Wraps acquireConnection() and releaseConnection() from a QgsPostgresConnPool.
+// This can be used for creating std::shared_ptr<QgsPoolPostgresConn>.
+class QgsPoolPostgresConn
+{
+    class QgsPostgresConn *mPgConn;
+  public:
+    QgsPoolPostgresConn( const QString &connInfo );
+    ~QgsPoolPostgresConn();
+
+    class QgsPostgresConn *get() const { return mPgConn; }
+};
 
 class QgsPostgresConn : public QObject
 {

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -198,7 +198,7 @@ QList<QVariantList> QgsPostgresProviderConnection::executeSql( const QString &sq
   return executeSqlPrivate( sql, true, feedback );
 }
 
-QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QString &sql, bool resolveTypes, QgsFeedback *feedback ) const
+QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QString &sql, bool resolveTypes, QgsFeedback *feedback, QgsPostgresConn *pgconn ) const
 {
   QList<QVariantList> results;
 
@@ -209,7 +209,7 @@ QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QStr
   }
 
   const QgsDataSourceUri dsUri { uri() };
-  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( dsUri.connectionInfo( false ) );
+  QgsPostgresConn *conn = pgconn ? pgconn : QgsPostgresConnPool::instance()->acquireConnection( dsUri.connectionInfo( false ) );
   if ( !conn )
   {
     throw QgsProviderConnectionException( QObject::tr( "Connection failed: %1" ).arg( uri() ) );
@@ -269,7 +269,7 @@ QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QStr
             break;
           }
           const Oid oid { res.PQftype( rowIdx ) };
-          QList<QVariantList> typeRes { executeSqlPrivate( QStringLiteral( "SELECT typname FROM pg_type WHERE oid = %1" ).arg( oid ), false ) };
+          QList<QVariantList> typeRes { executeSqlPrivate( QStringLiteral( "SELECT typname FROM pg_type WHERE oid = %1" ).arg( oid ), false, nullptr, conn ) };
           // Set the default to string
           QVariant::Type vType { QVariant::Type::String };
           if ( typeRes.size() > 0 && typeRes.first().size() > 0 )
@@ -357,7 +357,8 @@ QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QStr
         results.push_back( row );
       }
     }
-    QgsPostgresConnPool::instance()->releaseConnection( conn );
+    if ( ! pgconn )
+      QgsPostgresConnPool::instance()->releaseConnection( conn );
     if ( ! errCause.isEmpty() )
     {
       throw QgsProviderConnectionException( errCause );

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -209,7 +209,7 @@ QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QStr
   }
 
   if ( ! pgconn )
-    pgconn = std::shared_ptr<QgsPoolPostgresConn>( new QgsPoolPostgresConn( QgsDataSourceUri( uri() ).connectionInfo( false ) ) );
+    pgconn = std::make_shared<QgsPoolPostgresConn>( QgsDataSourceUri( uri() ).connectionInfo( false ) );
   QgsPostgresConn *conn = pgconn->get();
   if ( ! conn )
   {

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -198,7 +198,7 @@ QList<QVariantList> QgsPostgresProviderConnection::executeSql( const QString &sq
   return executeSqlPrivate( sql, true, feedback );
 }
 
-QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QString &sql, bool resolveTypes, QgsFeedback *feedback, QgsPostgresConn *pgconn ) const
+QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QString &sql, bool resolveTypes, QgsFeedback *feedback, std::shared_ptr<QgsPoolPostgresConn> pgconn ) const
 {
   QList<QVariantList> results;
 
@@ -208,9 +208,10 @@ QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QStr
     return results;
   }
 
-  const QgsDataSourceUri dsUri { uri() };
-  QgsPostgresConn *conn = pgconn ? pgconn : QgsPostgresConnPool::instance()->acquireConnection( dsUri.connectionInfo( false ) );
-  if ( !conn )
+  if ( ! pgconn )
+    pgconn = std::shared_ptr<QgsPoolPostgresConn>( new QgsPoolPostgresConn( QgsDataSourceUri( uri() ).connectionInfo( false ) ) );
+  QgsPostgresConn *conn = pgconn->get();
+  if ( ! conn )
   {
     throw QgsProviderConnectionException( QObject::tr( "Connection failed: %1" ).arg( uri() ) );
   }
@@ -269,7 +270,7 @@ QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QStr
             break;
           }
           const Oid oid { res.PQftype( rowIdx ) };
-          QList<QVariantList> typeRes { executeSqlPrivate( QStringLiteral( "SELECT typname FROM pg_type WHERE oid = %1" ).arg( oid ), false, nullptr, conn ) };
+          QList<QVariantList> typeRes { executeSqlPrivate( QStringLiteral( "SELECT typname FROM pg_type WHERE oid = %1" ).arg( oid ), false, nullptr, pgconn ) };
           // Set the default to string
           QVariant::Type vType { QVariant::Type::String };
           if ( typeRes.size() > 0 && typeRes.first().size() > 0 )
@@ -357,8 +358,6 @@ QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QStr
         results.push_back( row );
       }
     }
-    if ( ! pgconn )
-      QgsPostgresConnPool::instance()->releaseConnection( conn );
     if ( ! errCause.isEmpty() )
     {
       throw QgsProviderConnectionException( errCause );

--- a/src/providers/postgres/qgspostgresproviderconnection.h
+++ b/src/providers/postgres/qgspostgresproviderconnection.h
@@ -61,7 +61,7 @@ class QgsPostgresProviderConnection : public QgsAbstractDatabaseProviderConnecti
 
   private:
 
-    QList<QVariantList> executeSqlPrivate( const QString &sql, bool resolveTypes = true, QgsFeedback *feedback = nullptr ) const;
+    QList<QVariantList> executeSqlPrivate( const QString &sql, bool resolveTypes = true, QgsFeedback *feedback = nullptr, class QgsPostgresConn *pgconn = nullptr ) const;
     void setDefaultCapabilities();
     void dropTablePrivate( const QString &schema, const QString &name ) const;
     void renameTablePrivate( const QString &schema, const QString &name, const QString &newName ) const;

--- a/src/providers/postgres/qgspostgresproviderconnection.h
+++ b/src/providers/postgres/qgspostgresproviderconnection.h
@@ -61,7 +61,7 @@ class QgsPostgresProviderConnection : public QgsAbstractDatabaseProviderConnecti
 
   private:
 
-    QList<QVariantList> executeSqlPrivate( const QString &sql, bool resolveTypes = true, QgsFeedback *feedback = nullptr, class QgsPostgresConn *pgconn = nullptr ) const;
+    QList<QVariantList> executeSqlPrivate( const QString &sql, bool resolveTypes = true, QgsFeedback *feedback = nullptr, std::shared_ptr< class QgsPoolPostgresConn > pgconn = nullptr ) const;
     void setDefaultCapabilities();
     void dropTablePrivate( const QString &schema, const QString &name ) const;
     void renameTablePrivate( const QString &schema, const QString &name, const QString &newName ) const;


### PR DESCRIPTION
QgsPostgresProviderConnection::executeSqlPrivate() has a nested
call to itself which may cause a deadlock when the connectionpool is
exhausted:

Two active threads can acquire a Postgres connection at the start of
executeSqlPrivate() and end up both waiting to acquire the second
connection.

## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
