### PR TITLE
Fix for diminfo as string in Oracle mdsys metadata query

### DIFF
--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -3093,7 +3093,7 @@ QgsVectorLayerExporter::ExportError QgsOracleProvider::createEmptyLayer(
       }
     }
 
-    if ( !exec( qry, QString( "INSERT INTO mdsys.user_sdo_geom_metadata(table_name,column_name,srid,diminfo) VALUES (?,?,?,%1)" ).arg( QString( diminfo ) ),
+    if ( !exec( qry, QStringLiteral( "INSERT INTO mdsys.user_sdo_geom_metadata(table_name,column_name,srid,diminfo) VALUES (?,?,?,%1)" ).arg( diminfo ),
                 QVariantList() << tableName.toUpper() << geometryColumn.toUpper() << srid ) )
     {
       throw OracleException( tr( "Could not insert metadata." ), qry );

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -3093,8 +3093,8 @@ QgsVectorLayerExporter::ExportError QgsOracleProvider::createEmptyLayer(
       }
     }
 
-    if ( !exec( qry, QString( "INSERT INTO mdsys.user_sdo_geom_metadata(table_name,column_name,srid,diminfo) VALUES (?,?,?,?)" ),
-                QVariantList() << tableName.toUpper() << geometryColumn.toUpper() << srid << diminfo ) )
+    if ( !exec( qry, QString( "INSERT INTO mdsys.user_sdo_geom_metadata(table_name,column_name,srid,diminfo) VALUES (?,?,?,%1)" ).arg( QString( diminfo ) ),
+                QVariantList() << tableName.toUpper() << geometryColumn.toUpper() << srid ) )
     {
       throw OracleException( tr( "Could not insert metadata." ), qry );
     }

--- a/tests/src/python/test_provider_oracle.py
+++ b/tests/src/python/test_provider_oracle.py
@@ -24,7 +24,10 @@ from qgis.core import (
     QgsFeature,
     QgsGeometry,
     QgsWkbTypes,
-    QgsDataProvider
+    QgsDataProvider,
+    QgsVectorLayerExporter,
+    QgsFields,
+    QgsCoordinateReferenceSystem
 )
 
 from qgis.PyQt.QtCore import QDate, QTime, QDateTime, QVariant
@@ -818,6 +821,15 @@ class TestPyQgsOracleProvider(unittest.TestCase, ProviderTestCase):
 
         attributes = [feat.attributes() for feat in vl.getFeatures()]
         self.assertEqual(attributes, [[1, 'qgis'], [2, 'test'], [3, 'qgis'], [4, 'test']])
+
+    def testCreateEmptyLayer(self):
+        uri = self.dbconn + "srid=4326 type=POINT table=\"EMPTY_LAYER\" (GEOM)"
+        exporter = QgsVectorLayerExporter(uri=uri, provider='oracle', fields=QgsFields(), geometryType=QgsWkbTypes.Type.Point, crs=QgsCoordinateReferenceSystem(4326), overwrite=True)
+        self.assertEqual(exporter.errorCount(), 0)
+        self.assertEqual(exporter.errorCode(), 0)
+        # cleanup
+        self.execSQLCommand('DROP TABLE "QGIS"."EMPTY_LAYER"')
+        self.execSQLCommand("DELETE FROM user_sdo_geom_metadata  where TABLE_NAME='EMPTY_LAYER'")
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_provider_oracle.py
+++ b/tests/src/python/test_provider_oracle.py
@@ -824,7 +824,7 @@ class TestPyQgsOracleProvider(unittest.TestCase, ProviderTestCase):
 
     def testCreateEmptyLayer(self):
         uri = self.dbconn + "srid=4326 type=POINT table=\"EMPTY_LAYER\" (GEOM)"
-        exporter = QgsVectorLayerExporter(uri=uri, provider='oracle', fields=QgsFields(), geometryType=QgsWkbTypes.Type.Point, crs=QgsCoordinateReferenceSystem(4326), overwrite=True)
+        exporter = QgsVectorLayerExporter(uri=uri, provider='oracle', fields=QgsFields(), geometryType=QgsWkbTypes.Point, crs=QgsCoordinateReferenceSystem(4326), overwrite=True)
         self.assertEqual(exporter.errorCount(), 0)
         self.assertEqual(exporter.errorCode(), 0)
         # check IF there is an empty table (will throw error if the EMPTY_LAYER table does not excist)

--- a/tests/src/python/test_provider_oracle.py
+++ b/tests/src/python/test_provider_oracle.py
@@ -827,6 +827,12 @@ class TestPyQgsOracleProvider(unittest.TestCase, ProviderTestCase):
         exporter = QgsVectorLayerExporter(uri=uri, provider='oracle', fields=QgsFields(), geometryType=QgsWkbTypes.Type.Point, crs=QgsCoordinateReferenceSystem(4326), overwrite=True)
         self.assertEqual(exporter.errorCount(), 0)
         self.assertEqual(exporter.errorCode(), 0)
+        # check IF there is an empty table (will throw error if the EMPTY_LAYER table does not excist)
+        self.execSQLCommand('SELECT count(*) FROM "QGIS"."EMPTY_LAYER"')
+        vl = QgsVectorLayer(
+            self.dbconn + ' sslmode=disable table="QGIS"."EMPTY_LAYER" sql=',
+            'test', 'oracle')
+        self.assertTrue(vl.isValid())
         # cleanup
         self.execSQLCommand('DROP TABLE "QGIS"."EMPTY_LAYER"')
         self.execSQLCommand("DELETE FROM user_sdo_geom_metadata  where TABLE_NAME='EMPTY_LAYER'")


### PR DESCRIPTION
By inserting the diminfo string into the query instead of giving it as a
param in the prepared statement, the error is fixed.
Apparently the param was resolved as a string.

Note that this NOT fix the dbmanager issue of #39855.
But it makes it possible to drag/drop a layer from the browser again.

Also added a test to test 'createEmptyLayer'