### PR TITLE
Allow the usage of opacity parameter in a WMS provider URL

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -138,6 +138,27 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
   mActiveSubStyles = uri.params( QStringLiteral( "styles" ) );
   QgsDebugMsgLevel( "Entering: layers:" + mActiveSubLayers.join( ", " ) + ", styles:" + mActiveSubStyles.join( ", " ), 2 );
 
+  //opacities
+  if ( uri.hasParam( QStringLiteral( "opacities" ) ) )
+  {
+    mOpacities.clear();
+    QStringList opacities = uri.params( QStringLiteral( "opacities" ) );
+    QStringList::const_iterator oIt = opacities.constBegin();
+    for ( ; oIt != opacities.constEnd(); ++oIt )
+    {
+      bool ok = false;
+      oIt->toInt( &ok );
+      if ( ok )
+      {
+        mOpacities.append( *oIt );
+      }
+      else
+      {
+        mOpacities.append( QStringLiteral( "255" ) );
+      }
+    }
+  }
+
   mImageMimeType = uri.param( QStringLiteral( "format" ) );
   QgsDebugMsgLevel( "Setting image encoding to " + mImageMimeType + '.', 2 );
 

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -142,15 +142,14 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
   if ( uri.hasParam( QStringLiteral( "opacities" ) ) )
   {
     mOpacities.clear();
-    QStringList opacities = uri.params( QStringLiteral( "opacities" ) );
-    QStringList::const_iterator oIt = opacities.constBegin();
-    for ( ; oIt != opacities.constEnd(); ++oIt )
+    const QStringList opacities = uri.params( QStringLiteral( "opacities" ) );
+    for ( const QString &opacity : opacities )
     {
       bool ok = false;
-      oIt->toInt( &ok );
+      opacity.toInt( &ok );
       if ( ok )
       {
-        mOpacities.append( *oIt );
+        mOpacities.append( opacity );
       }
       else
       {

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -933,6 +933,8 @@ class QgsWmsSettings
     QStringList mActiveSubLayers;
     QStringList mActiveSubStyles;
 
+    QStringList mOpacities;
+
     /**
      * Visibility status of the given active sublayer
      */

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -933,6 +933,7 @@ class QgsWmsSettings
     QStringList mActiveSubLayers;
     QStringList mActiveSubStyles;
 
+    //! Opacities for wms layers. Same ordering as mActiveSubLayers/mActiveSubStyles
     QStringList mOpacities;
 
     /**

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1068,6 +1068,11 @@ QUrl QgsWmsProvider::createRequestUrlWMS( const QgsRectangle &viewExtent, int pi
   setQueryItem( query, QStringLiteral( "HEIGHT" ), QString::number( pixelHeight ) );
   setQueryItem( query, QStringLiteral( "LAYERS" ), layers );
   setQueryItem( query, QStringLiteral( "STYLES" ), styles );
+  QStringList opacityList = mSettings.mOpacities;
+  if ( !opacityList.isEmpty() )
+  {
+    setQueryItem( query, QStringLiteral( "OPACITIES" ), mSettings.mOpacities.join( ',' ) );
+  }
 
   // For WMS-T layers
   if ( temporalCapabilities() &&

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1891,7 +1891,7 @@ namespace QgsWms
     for ( ; paramIt != paramMap.constEnd(); ++paramIt )
     {
       QString paramName = paramIt.key().toLower();
-      if ( paramName == QLatin1String( "layers" ) || paramName == QLatin1String( "styles" ) )
+      if ( paramName == QLatin1String( "layers" ) || paramName == QLatin1String( "styles" ) || paramName == QLatin1String( "opacities" ) )
       {
         const QStringList values = paramIt.value().split( ',' );
         for ( const QString &value : values )


### PR DESCRIPTION
The OPACITIES-Parameter is supported by QGIS Server. Even if it is not WMS-standard, it could be usefull to set opacities in an external WMS-Layer or from a plugin. This PR adds support for this parameter in the WMS-provider url and and QGIS Server external wms layers. 