### PR TITLE
[processing] Allow field parameter to reference a MultipleLayers parameter

### DIFF
--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -20,6 +20,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsmeshlayer.h"
 #include "qgsrasterlayer.h"
+#include "qgsproject.h"
 #include "processing/models/qgsprocessingmodelchildparametersource.h"
 #include <QStandardItemModel>
 #include <QStandardItem>
@@ -328,6 +329,24 @@ void QgsProcessingMultipleInputPanelWidget::addDirectory()
 
 void QgsProcessingMultipleInputPanelWidget::populateFromProject( QgsProject *project )
 {
+  connect( project, &QgsProject::layerRemoved, this, [&]( const QString & layerId )
+  {
+    for ( int i = 0; i < mModel->rowCount(); ++i )
+    {
+      const QStandardItem *item = mModel->item( i );
+      if ( item->data( Qt::UserRole ) == layerId )
+      {
+        bool isChecked = ( item->checkState() == Qt::Checked );
+        mModel->removeRow( i );
+
+        if ( isChecked )
+          emit selectionChanged();
+
+        break;
+      }
+    }
+  } );
+
   QgsSettings settings;
   auto addLayer = [&]( const QgsMapLayer * layer )
   {

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -4093,7 +4093,7 @@ void QgsProcessingFieldWidgetWrapper::setParentLayerWrapperValue( const QgsAbstr
     QgsVectorLayer *vlayer = qobject_cast< QgsVectorLayer * >( layers.at( 0 ) );
     QgsFields fields = vlayer && vlayer->isValid() ? vlayer->fields() : QgsFields();
     const  QList< QgsMapLayer * > remainingLayers = layers.mid( 1 );
-    for ( QgsMapLayer* layer : remainingLayers )
+    for ( QgsMapLayer *layer : remainingLayers )
     {
       if ( fields.isEmpty() )
         break;
@@ -6472,6 +6472,14 @@ void QgsProcessingMultipleLayerPanelWidget::setValue( const QVariant &value )
 void QgsProcessingMultipleLayerPanelWidget::setProject( QgsProject *project )
 {
   mProject = project;
+  connect( mProject, &QgsProject::layerRemoved, this, [&]( const QString & layerId )
+  {
+    if ( mValue.removeAll( layerId ) )
+    {
+      updateSummaryText();
+      emit changed();
+    }
+  } );
 }
 
 void QgsProcessingMultipleLayerPanelWidget::setModel( QgsProcessingModelAlgorithm *model, const QString &modelChildAlgorithmID )

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -3907,6 +3907,17 @@ QgsProcessingFieldParameterDefinitionWidget::QgsProcessingFieldParameterDefiniti
           mParentLayerComboBox->setCurrentIndex( mParentLayerComboBox->count() - 1 );
         }
       }
+      else if ( const QgsProcessingParameterMultipleLayers *definition = dynamic_cast< const QgsProcessingParameterMultipleLayers * >( lModel->parameterDefinition( it.value().parameterName() ) ) )
+      {
+        if ( definition->layerType() == QgsProcessing::TypeVector )
+        {
+          mParentLayerComboBox-> addItem( definition->description(), definition->name() );
+          if ( !initialParent.isEmpty() && initialParent == definition->name() )
+          {
+            mParentLayerComboBox->setCurrentIndex( mParentLayerComboBox->count() - 1 );
+          }
+        }
+      }
     }
   }
 

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -3015,6 +3015,28 @@ void TestProcessingGui::testFieldWrapper()
         break;
     }
     delete w;
+
+    // MultipleLayers as parent layer
+    QgsVectorLayer *vl2 = new QgsVectorLayer( QStringLiteral( "LineString?field=bbb:string" ), QStringLiteral( "y" ), QStringLiteral( "memory" ) );
+    p.addMapLayer( vl2 );
+
+    QgsProcessingFieldWidgetWrapper wrapper8( &param, type );
+    wrapper8.registerProcessingContextGenerator( &generator );
+    w = wrapper8.createWrappedWidget( context );
+    layerWrapper.setWidgetValue( QVariantList() << vl->id() << vl2->id(), context );
+    wrapper8.setParentLayerWrapperValue( &layerWrapper );
+
+    switch ( type )
+    {
+      case QgsProcessingGui::Standard:
+      case QgsProcessingGui::Batch:
+        QCOMPARE( wrapper8.widgetValue().toList(), QVariantList() << QStringLiteral( "bbb" ) );
+        break;
+
+      case QgsProcessingGui::Modeler:
+        break;
+    }
+    delete w;
   };
 
   // standard wrapper


### PR DESCRIPTION
## Description

*FieldParameter* can reference a *VectorLayer*, so every fields available in the layer are displayed in the field combo box. 

While I was working on improving the interface between QGIS and OTB, I stumble on some OTB algorithms that take a multiple layers parameter and a field parameter to select a common field upon all this layers. This is for training purpose for instance where you select several vector layers and give a field which contains the class or the features you want to train on.

This is not possible in QGIS at the time. Would that make sense to add this kind of behavior ? 

In this proposition, to be able to select a field from different layers, ALL layer have to be vector ones and the field need to be in ALL the layers.

If we agree, I'll complete these PR:
- [x] Finish implementation: If parentParameter returns only one layer, we never goes in the dedicated QgsVectorLayer branch, and we never grab ownership. We have to deal with deleted layer, or deleted/modified fields.
- [x] add tests
- [x] Change Widget from modeler to be able to select a MultipleLayers from the Field Parameter widget



