### PR TITLE
[virtual layers] warn if unique identifier is not a valid field name

### DIFF
--- a/src/providers/virtual/qgsvirtuallayersourceselect.cpp
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.cpp
@@ -218,7 +218,18 @@ void QgsVirtualLayerSourceSelect::testQuery()
     std::unique_ptr<QgsVectorLayer> vl( new QgsVectorLayer( def.toString(), QStringLiteral( "test" ), QStringLiteral( "virtual" ), options ) );
     if ( vl->isValid() )
     {
-      QMessageBox::information( nullptr, tr( "Virtual layer test" ), tr( "No error" ) );
+      const QStringList fieldNames = vl->fields().names();
+      if ( !mUIDField->text().isEmpty() && !vl->fields().names().contains( mUIDField->text() ) )
+      {
+        QStringList bulletedFieldNames;
+        for ( const QString &fieldName : fieldNames )
+        {
+          bulletedFieldNames.append( QStringLiteral( "<li>%1" ).arg( fieldName ) );
+        }
+        QMessageBox::warning( nullptr, tr( "Virtual layer test " ), tr( "The unique identifier field <b>%1</b> was not found in list of fields:<ul>%2</ul>" ).arg( mUIDField->text(), bulletedFieldNames.join( ' ' ) ) );
+      }
+      else
+        QMessageBox::information( nullptr, tr( "Virtual layer test" ), tr( "No error" ) );
     }
     else
     {

--- a/src/providers/virtual/qgsvirtuallayersourceselect.cpp
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.cpp
@@ -224,16 +224,16 @@ void QgsVirtualLayerSourceSelect::testQuery()
         QStringList bulletedFieldNames;
         for ( const QString &fieldName : fieldNames )
         {
-          bulletedFieldNames.append( QStringLiteral( "<li>%1" ).arg( fieldName ) );
+          bulletedFieldNames.append( QLatin1String( "<li>" ) + fieldName + QLatin1String( "</li>" ) );
         }
-        QMessageBox::warning( nullptr, tr( "Virtual layer test " ), tr( "The unique identifier field <b>%1</b> was not found in list of fields:<ul>%2</ul>" ).arg( mUIDField->text(), bulletedFieldNames.join( ' ' ) ) );
+        QMessageBox::warning( nullptr, tr( "Test Virtual Layer " ), tr( "The unique identifier field <b>%1</b> was not found in list of fields:<ul>%2</ul>" ).arg( mUIDField->text(), bulletedFieldNames.join( ' ' ) ) );
       }
       else
-        QMessageBox::information( nullptr, tr( "Virtual layer test" ), tr( "No error" ) );
+        QMessageBox::information( nullptr, tr( "Test Virtual Layer" ), tr( "No error" ) );
     }
     else
     {
-      QMessageBox::critical( nullptr, tr( "Virtual layer test" ), vl->dataProvider()->error().summary() );
+      QMessageBox::critical( nullptr, tr( "Test Virtual Layer" ), vl->dataProvider()->error().summary() );
     }
   }
 }


### PR DESCRIPTION
## Description

When creating a virtual layer, a "unique identifier" field can be set. To avoid accidentally setting a wrong field name (typo etc) the "test" button now checks if there is a field with this name returned from the query and includes the list of available field names in case it does not exist.

![image](https://user-images.githubusercontent.com/588407/99396027-893a8b00-28e1-11eb-9ec2-e8c8be5fed2c.png)
