### PR TITLE
Save gap exceptions after saving the topological layer

### DIFF
--- a/src/app/qgsgeometryvalidationservice.cpp
+++ b/src/app/qgsgeometryvalidationservice.cpp
@@ -281,7 +281,7 @@ void QgsGeometryValidationService::enableLayerChecks( QgsVectorLayer *layer )
         {
           connect( layer, &QgsVectorLayer::editingStarted, gapsLayer, [gapsLayer] { gapsLayer->startEditing(); } );
           connect( layer, &QgsVectorLayer::beforeRollBack, gapsLayer, [gapsLayer] { gapsLayer->rollBack(); } );
-          connect( layer, &QgsVectorLayer::editingStopped, gapsLayer, [gapsLayer] { gapsLayer->commitChanges(); } );
+          connect( layer, &QgsVectorLayer::afterCommitChanges, gapsLayer, [gapsLayer] { gapsLayer->commitChanges(); } );
         }
         else
         {


### PR DESCRIPTION
## Description

If a layer has "gap checks" enabled, exceptions can be added to a separate "gap layer". This separate layer is put into edit mode automatically when the main layer is being edited. Committing changes however was not always done because the connection was on the wrong signal, leaving the two layers in an inconsistent state.