### PR TITLE
Fix some GEOS noise when trying to register a line string with only one vertex as a feature in the labeling engine

### DIFF
--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -2657,6 +2657,13 @@ void QgsPalLayerSettings::registerObstacleFeature( const QgsFeature &f, QgsRende
     return;
   }
 
+  // don't even try to register linestrings with only one vertex as an obstacle
+  if ( const QgsLineString *ls = qgsgeometry_cast< const QgsLineString * >( geom.constGet() ) )
+  {
+    if ( ls->numPoints() < 2 )
+      return;
+  }
+
   // simplify?
   const QgsVectorSimplifyMethod &simplifyMethod = context.vectorSimplifyMethod();
   std::unique_ptr<QgsGeometry> scopedClonedGeom;


### PR DESCRIPTION
We no longer try to register these features as obstacles for labels -
it's not possible to handle these and they just result in noisy
geos warnings on the console.
