### PR TITLE
[processing] don't change order or select deleted item in multiple input parameter selector

### DIFF
--- a/python/gui/auto_generated/processing/qgsprocessingmultipleselectiondialog.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingmultipleselectiondialog.sip.in
@@ -74,6 +74,12 @@ Sets a callback function to use when encountering an invalid geometry and
 Returns the ordered list of selected options.
 %End
 
+    void selectOptions( const QVariantList &options ) const;
+%Docstring
+Select the given ``options``. Existing selected option are not unselected.
+%End
+
+
     QDialogButtonBox *buttonBox();
 %Docstring
 Returns the widget's button box.

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.h
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.h
@@ -94,6 +94,12 @@ class GUI_EXPORT QgsProcessingMultipleSelectionPanelWidget : public QgsPanelWidg
     QVariantList selectedOptions() const;
 
     /**
+     * Select the given \a options. Existing selected option are not unselected.
+     */
+    void selectOptions( const QVariantList &options ) const;
+
+
+    /**
      * Returns the widget's button box.
      */
     QDialogButtonBox *buttonBox() { return mButtonBox; }

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -6510,9 +6510,10 @@ void QgsProcessingMultipleLayerPanelWidget::showDialog()
   QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
   if ( panel && panel->dockMode() )
   {
-    QgsProcessingMultipleInputPanelWidget *widget = new QgsProcessingMultipleInputPanelWidget( mParam, mValue, mModelSources, mModel );
+    QgsProcessingMultipleInputPanelWidget *widget = new QgsProcessingMultipleInputPanelWidget( mParam, QVariantList(), mModelSources, mModel );
     widget->setPanelTitle( mParam->description() );
     widget->setProject( mProject );
+    widget->selectOptions( mValue );
     connect( widget, &QgsProcessingMultipleSelectionPanelWidget::selectionChanged, this, [ = ]()
     {
       setValue( widget->selectedOptions() );


### PR DESCRIPTION
## Description

When selecting layers in processing multiple layer parameter selector, we lost order (selected ones are at the top), and deleted selected layer are still available for selection. 

![bugselected](https://user-images.githubusercontent.com/14358135/99512107-64015780-2989-11eb-9a2c-491402105a6d.gif)

Same issue exists for enum type. At first, I wanted to fix at a higher level, in *QgsProcessingMultipleSelectionPanelWidget* but it [looks like](https://github.com/qgis/QGIS/blob/master/src/gui/processing/qgsprocessingmultipleselectiondialog.h#L51) it's the wanted behavior. 

I don't understand why we would like to have selected options that don't exist in the available ones. Am I missing something? 

Can we agree on changing the API documentation and avoid to select options that don't exist?

What it looks like with my PR

![selected_fixed](https://user-images.githubusercontent.com/14358135/99513459-f35b3a80-298a-11eb-8702-08f3b0990e79.gif)

Still needs to be done:
- [ ] Update tests and add new ones
- [ ] Fix enum
