### PR TITLE
Make Pause/Stop button checked in start of Temporal Controller

### DIFF
--- a/src/ui/qgstemporalcontrollerwidgetbase.ui
+++ b/src/ui/qgstemporalcontrollerwidgetbase.ui
@@ -329,6 +329,9 @@
            <property name="checkable">
             <bool>true</bool>
            </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
           </widget>
          </item>
          <item>


### PR DESCRIPTION
Minimal tweak, just to make the state of the controller more clear.
My itch was that the button was unchecked in the beginning (as NOT in 'stopped/paused' state).
First I thought to make ONE button which toggled between pause/play, BUT with a playback button also in place, this makes a ui mess.
So this was easiest:
Before:
![Screenshot-20201118213350-334x114](https://user-images.githubusercontent.com/731673/99584837-c5571400-29e5-11eb-88dc-19e965258092.png)
After (on fresh start of controller):
![Screenshot-20201118213444-338x107](https://user-images.githubusercontent.com/731673/99584917-e7509680-29e5-11eb-9018-8266581b5b29.png)

With me now either clicking on the pause button, will enable the play(forward) button, which is intuitive in my view.


