### PR TITLE
QgsRendererPropertiesDialog: initialize mDockMode member

### DIFF
--- a/src/gui/symbology/qgsrendererpropertiesdialog.h
+++ b/src/gui/symbology/qgsrendererpropertiesdialog.h
@@ -161,7 +161,7 @@ class GUI_EXPORT QgsRendererPropertiesDialog : public QDialog, private Ui::QgsRe
     QgsFeatureRequest::OrderBy mOrderBy;
 
   private:
-    bool mDockMode;
+    bool mDockMode = false;
 
     friend class QgsAppScreenShots;
 };


### PR DESCRIPTION
Otherwise when adding a layer for the first time, Valgrind raises
the following warning:

==27708== Conditional jump or move depends on uninitialised value(s)
==27708==    at 0x689F04D: QgsRendererWidget::setDockMode(bool) (qgsrendererwidget.cpp:354)
==27708==    by 0x68B7456: QgsSingleSymbolRendererWidget::setDockMode(bool) (qgssinglesymbolrendererwidget.cpp:110)
==27708==    by 0x68972F9: QgsRendererPropertiesDialog::rendererChanged() (qgsrendererpropertiesdialog.cpp:273)
==27708==    by 0x689C7A6: QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (QgsRendererPropertiesDialog::*)()>::call(void (QgsRendererPropertiesDialog::*)(), QgsRendererPropertiesDialog*, void**) (qobjectdefs_impl.h:136)
==27708==    by 0x689C675: void QtPrivate::FunctionPointer<void (QgsRendererPropertiesDialog::*)()>::call<QtPrivate::List<>, void>(void (QgsRendererPropertiesDialog::*)(), QgsRendererPropertiesDialog*, void**) (qobjectdefs_impl.h:169)
==27708==    by 0x689C1D0: QtPrivate::QSlotObject<void (QgsRendererPropertiesDialog::*)(), QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) (qobject_impl.h:120)
==27708==    by 0xB17F8B5: QMetaObject::activate(QObject*, int, int, void**) (in /opt/qt59/lib/libQt5Core.so.5.9.1)
==27708==    by 0xA569F10: QComboBox::currentIndexChanged(int) (in /opt/qt59/lib/libQt5Widgets.so.5.9.1)
==27708==    by 0xA56C280: ??? (in /opt/qt59/lib/libQt5Widgets.so.5.9.1)
==27708==    by 0xA56EA6C: ??? (in /opt/qt59/lib/libQt5Widgets.so.5.9.1)
==27708==    by 0xA56EC8E: QComboBox::setCurrentIndex(int) (in /opt/qt59/lib/libQt5Widgets.so.5.9.1)
==27708==    by 0x6897DA7: QgsRendererPropertiesDialog::syncToLayer() (qgsrendererpropertiesdialog.cpp:383)
==27708==    by 0x68961EF: QgsRendererPropertiesDialog::QgsRendererPropertiesDialog(QgsVectorLayer*, QgsStyle*, bool, QWidget*) (qgsrendererpropertiesdialog.cpp:120)
==27708==    by 0x54BEAB8: QgsLayerStylingWidget::updateCurrentWidgetLayer() (qgslayerstylingwidget.cpp:480)
==27708==    by 0x54C51DB: QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (QgsLayerStylingWidget::*)()>::call(void (QgsLayerStylingWidget::*)(), QgsLayerStylingWidget*, void**) (qobjectdefs_impl.h:136)
==27708==    by 0x54C4ED7: void QtPrivate::FunctionPointer<void (QgsLayerStylingWidget::*)()>::call<QtPrivate::List<>, void>(void (QgsLayerStylingWidget::*)(), QgsLayerStylingWidget*, void**) (qobjectdefs_impl.h:169)
==27708==    by 0x54C49DA: QtPrivate::QSlotObject<void (QgsLayerStylingWidget::*)(), QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) (qobject_impl.h:120)
==27708==    by 0xB17F8B5: QMetaObject::activate(QObject*, int, int, void**) (in /opt/qt59/lib/libQt5Core.so.5.9.1)
==27708==    by 0xA717170: QListWidget::currentRowChanged(int) (in /opt/qt59/lib/libQt5Widgets.so.5.9.1)
==27708==    by 0xA717ABE: ??? (in /opt/qt59/lib/libQt5Widgets.so.5.9.1)
==27708==    by 0xB17F588: QMetaObject::activate(QObject*, int, int, void**) (in /opt/qt59/lib/libQt5Core.so.5.9.1)
==27708==    by 0xB102CD9: QItemSelectionModel::currentChanged(QModelIndex const&, QModelIndex const&) (in /opt/qt59/lib/libQt5Core.so.5.9.1)
==27708==    by 0xB102F5F: QItemSelectionModel::setCurrentIndex(QModelIndex const&, QFlags<QItemSelectionModel::SelectionFlag>) (in /opt/qt59/lib/libQt5Core.so.5.9.1)
==27708==    by 0xA717EFD: QListWidget::setCurrentRow(int) (in /opt/qt59/lib/libQt5Widgets.so.5.9.1)
==27708==    by 0x54BD527: QgsLayerStylingWidget::setLayer(QgsMapLayer*) (qgslayerstylingwidget.cpp:302)
==27708==    by 0x54C5134: QtPrivate::FunctorCall<QtPrivate::IndexesList<0>, QtPrivate::List<QgsMapLayer*>, void, void (QgsLayerStylingWidget::*)(QgsMapLayer*)>::call(void (QgsLayerStylingWidget::*)(QgsMapLayer*), QgsLayerStylingWidget*, void**) (qobjectdefs_impl.h:136)
==27708==    by 0x54C4E92: void QtPrivate::FunctionPointer<void (QgsLayerStylingWidget::*)(QgsMapLayer*)>::call<QtPrivate::List<QgsMapLayer*>, void>(void (QgsLayerStylingWidget::*)(QgsMapLayer*), QgsLayerStylingWidget*, void**) (qobjectdefs_impl.h:169)
==27708==    by 0x54C48FE: QtPrivate::QSlotObject<void (QgsLayerStylingWidget::*)(QgsMapLayer*), QtPrivate::List<QgsMapLayer*>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) (qobject_impl.h:120)
==27708==    by 0xB17F8B5: QMetaObject::activate(QObject*, int, int, void**) (in /opt/qt59/lib/libQt5Core.so.5.9.1)
==27708==    by 0x665A0B9: QgsMapLayerComboBox::layerChanged(QgsMapLayer*) (moc_qgsmaplayercombobox.cpp:209)
==27708==    by 0x7109BB7: QgsMapLayerComboBox::rowsChanged() (qgsmaplayercombobox.cpp:143)
==27708==    by 0x710A6B8: QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (QgsMapLayerComboBox::*)()>::call(void (QgsMapLayerComboBox::*)(), QgsMapLayerComboBox*, void**) (qobjectdefs_impl.h:136)
==27708==    by 0x710A585: void QtPrivate::FunctionPointer<void (QgsMapLayerComboBox::*)()>::call<QtPrivate::List<>, void>(void (QgsMapLayerComboBox::*)(), QgsMapLayerComboBox*, void**) (qobjectdefs_impl.h:169)
==27708==    by 0x710A4AA: QtPrivate::QSlotObject<void (QgsMapLayerComboBox::*)(), QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) (qobject_impl.h:120)
==27708==    by 0xB17F8B5: QMetaObject::activate(QObject*, int, int, void**) (in /opt/qt59/lib/libQt5Core.so.5.9.1)
==27708==    by 0xB0F26AD: QAbstractItemModel::rowsInserted(QModelIndex const&, int, int, QAbstractItemModel::QPrivateSignal) (in /opt/qt59/lib/libQt5Core.so.5.9.1)
==27708==    by 0xB0FA71A: QAbstractItemModel::endInsertRows() (in /opt/qt59/lib/libQt5Core.so.5.9.1)
==27708==    by 0xB11AF9A: ??? (in /opt/qt59/lib/libQt5Core.so.5.9.1)
==27708==    by 0xB11D693: ??? (in /opt/qt59/lib/libQt5Core.so.5.9.1)
==27708==    by 0xB121098: ??? (in /opt/qt59/lib/libQt5Core.so.5.9.1)

## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
