### PR TITLE
[curves tracing] expose settings for tracing curves in the UI

### DIFF
--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -1160,6 +1160,10 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mCurveOffsetMiterLimitComboBox->setClearValue( 5.0 );
 
   mTracingConvertToCurveCheckBox->setChecked( mSettings->value( QStringLiteral( "/qgis/digitizing/convert_to_curve" ), false ).toBool() );
+  mTracingCustomAngleToleranceSpinBox->setValue( mSettings->value( QStringLiteral( "/qgis/digitizing/convert_to_curve_angle_tolerance" ), 1e-6 ).toDouble() );
+  mTracingCustomAngleToleranceSpinBox->setClearValue( 1e-6 );
+  mTracingCustomDistanceToleranceSpinBox->setValue( mSettings->value( QStringLiteral( "/qgis/digitizing/convert_to_curve_distance_tolerance" ), 1e-6 ).toDouble() );
+  mTracingCustomDistanceToleranceSpinBox->setClearValue( 1e-6 );
 
   // load gdal driver list only when gdal tab is first opened
   mLoadedGdalDriverList = false;
@@ -1782,6 +1786,8 @@ void QgsOptions::saveOptions()
   mSettings->setValue( QStringLiteral( "/qgis/digitizing/offset_miter_limit" ), mCurveOffsetMiterLimitComboBox->value() );
 
   mSettings->setValue( QStringLiteral( "/qgis/digitizing/convert_to_curve" ), mTracingConvertToCurveCheckBox->isChecked() );
+  mSettings->setValue( QStringLiteral( "/qgis/digitizing/convert_to_curve_angle_tolerance" ), mTracingCustomAngleToleranceSpinBox->value() );
+  mSettings->setValue( QStringLiteral( "/qgis/digitizing/convert_to_curve_distance_tolerance" ), mTracingCustomDistanceToleranceSpinBox->value() );
 
   // default scale list
   QString myPaths;

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -4905,7 +4905,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                   <item row="1" column="2">
                    <widget class="QgsDoubleSpinBox" name="mTracingCustomAngleToleranceSpinBox">
                     <property name="toolTip">
-                     <string>Parameter used by the convert to curves algorithm when tracing curves.</string>
+                     <string>This specifies the maximum angular deviation (in radians) allowed for a series of points to be converted to a curve.</string>
                     </property>
                     <property name="decimals">
                      <number>10</number>
@@ -4918,7 +4918,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                   <item row="2" column="2">
                    <widget class="QgsDoubleSpinBox" name="mTracingCustomDistanceToleranceSpinBox">
                     <property name="toolTip">
-                     <string>Parameter used by the convert to curves algorithm when tracing curves.</string>
+                     <string>This specifies the maximum deviation allowed between the original location of vertices and where they would fall on the candidate curved geometry for a series of points to be converted to a curve.</string>
                     </property>
                     <property name="decimals">
                      <number>10</number>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1029</width>
-    <height>730</height>
+    <height>744</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -332,7 +332,7 @@
        <item>
         <widget class="QStackedWidget" name="mOptionsStackedWidget">
          <property name="currentIndex">
-          <number>0</number>
+          <number>9</number>
          </property>
          <widget class="QWidget" name="mOptionsPageGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -361,8 +361,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>1019</height>
+                <width>846</width>
+                <height>743</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -1133,8 +1133,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>1084</height>
+                <width>846</width>
+                <height>940</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -1672,8 +1672,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>679</height>
+                <width>861</width>
+                <height>691</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -1864,8 +1864,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>679</height>
+                <width>861</width>
+                <height>691</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_47">
@@ -1947,8 +1947,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>804</height>
+                <width>861</width>
+                <height>691</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -2356,8 +2356,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>1198</height>
+                <width>846</width>
+                <height>844</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_22">
@@ -3161,8 +3161,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>679</height>
+                <width>861</width>
+                <height>691</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -3371,14 +3371,14 @@
                       <property name="whatsThis">
                        <string extracomment="MAP_RESOLUTION or DPI value overloading getMap default value (set 0 to use default)"/>
                       </property>
+                      <property name="suffix">
+                       <string> dpi</string>
+                      </property>
                       <property name="minimum">
                        <number>0</number>
                       </property>
                       <property name="maximum">
                        <number>1000000</number>
-                      </property>
-                      <property name="suffix">
-                       <string> dpi</string>
                       </property>
                      </widget>
                     </item>
@@ -3417,6 +3417,9 @@
                         <verstretch>0</verstretch>
                        </sizepolicy>
                       </property>
+                      <property name="toolTip">
+                       <string extracomment="(set value to 0 to skip minimum size)"/>
+                      </property>
                       <property name="suffix">
                        <string> mm</string>
                       </property>
@@ -3424,19 +3427,16 @@
                        <number>2</number>
                       </property>
                       <property name="maximum">
-                       <double>999.00</double>
+                       <double>999.000000000000000</double>
                       </property>
                       <property name="singleStep">
                        <double>0.200000000000000</double>
                       </property>
                       <property name="value">
-                       <double>0.10</double>
+                       <double>0.100000000000000</double>
                       </property>
                       <property name="showClearButton" stdset="0">
                        <bool>true</bool>
-                      </property>
-                      <property name="toolTip">
-                       <string extracomment="(set value to 0 to skip minimum size)"/>
                       </property>
                      </widget>
                     </item>
@@ -3475,6 +3475,9 @@
                         <verstretch>0</verstretch>
                        </sizepolicy>
                       </property>
+                      <property name="toolTip">
+                       <string extracomment="(set value to 0 to skip maximum size)"/>
+                      </property>
                       <property name="suffix">
                        <string> mm</string>
                       </property>
@@ -3482,19 +3485,16 @@
                        <number>2</number>
                       </property>
                       <property name="maximum">
-                       <double>999.00</double>
+                       <double>999.000000000000000</double>
                       </property>
                       <property name="singleStep">
                        <double>0.200000000000000</double>
                       </property>
                       <property name="value">
-                       <double>20.00</double>
+                       <double>20.000000000000000</double>
                       </property>
                       <property name="showClearButton" stdset="0">
                        <bool>true</bool>
-                      </property>
-                      <property name="toolTip">
-                       <string extracomment="(set value to 0 to skip maximum size)"/>
                       </property>
                      </widget>
                     </item>
@@ -3540,14 +3540,14 @@
                   </item>
                   <item>
                    <widget class="QgsSpinBox" name="mMapTipsDelaySpinBox">
-                    <property name="suffix">
-                     <string> ms</string>
-                    </property>
                     <property name="toolTip">
                      <string extracomment="MAP_RESOLUTION or DPI value overloading getMap default value (set 0 to use default)"/>
                     </property>
                     <property name="whatsThis">
                      <string extracomment="MAP_RESOLUTION or DPI value overloading getMap default value (set 0 to use default)"/>
+                    </property>
+                    <property name="suffix">
+                     <string> ms</string>
                     </property>
                     <property name="minimum">
                      <number>0</number>
@@ -3606,8 +3606,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>709</height>
+                <width>861</width>
+                <height>691</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
@@ -4123,8 +4123,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>679</height>
+                <width>861</width>
+                <height>691</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_46">
@@ -4303,8 +4303,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>956</height>
+                <width>846</width>
+                <height>714</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -4888,6 +4888,46 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                     </property>
                    </widget>
                   </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_44">
+                    <property name="text">
+                     <string>Angle tolerance when tracing curves</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="label_70">
+                    <property name="text">
+                     <string>Distance tolerance when tracing curves</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="2">
+                   <widget class="QgsDoubleSpinBox" name="mTracingCustomAngleToleranceSpinBox">
+                    <property name="toolTip">
+                     <string>Parameter used by the convert to curves algorithm when tracing curves.</string>
+                    </property>
+                    <property name="decimals">
+                     <number>10</number>
+                    </property>
+                    <property name="maximum">
+                     <double>9999.000000000000000</double>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="2">
+                   <widget class="QgsDoubleSpinBox" name="mTracingCustomDistanceToleranceSpinBox">
+                    <property name="toolTip">
+                     <string>Parameter used by the convert to curves algorithm when tracing curves.</string>
+                    </property>
+                    <property name="decimals">
+                     <number>10</number>
+                    </property>
+                    <property name="maximum">
+                     <double>9999.000000000000000</double>
+                    </property>
+                   </widget>
+                  </item>
                  </layout>
                 </widget>
                </item>
@@ -4937,8 +4977,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>679</height>
+                <width>861</width>
+                <height>691</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_39">
@@ -5218,8 +5258,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>679</height>
+                <width>861</width>
+                <height>691</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -5490,8 +5530,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>699</height>
+                <width>437</width>
+                <height>513</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_33">
@@ -5971,7 +6011,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                  <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Fira Sans'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.14286pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Noto Sans'; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                </widget>
@@ -6337,6 +6377,8 @@ p, li { white-space: pre-wrap; }
   <tabstop>mOffsetQuadSegSpinBox</tabstop>
   <tabstop>mCurveOffsetMiterLimitComboBox</tabstop>
   <tabstop>mTracingConvertToCurveCheckBox</tabstop>
+  <tabstop>mTracingCustomAngleToleranceSpinBox</tabstop>
+  <tabstop>mTracingCustomDistanceToleranceSpinBox</tabstop>
   <tabstop>mOptionsScrollArea_12</tabstop>
   <tabstop>mComposerFontComboBox</tabstop>
   <tabstop>mGridStyleComboBox</tabstop>


### PR DESCRIPTION
## Description

This exposes the settings used when tracing curves in the main settings dialog.

These setting did already exist (introduced by https://github.com/qgis/QGIS/pull/37826) but so far were not exposed in the UI, as they are rather technical. Yet, experience shows it's still relatively common that these settings must be tweaked by users to get good results.

If possible, we'd like to backport this to 3.16.

![image](https://user-images.githubusercontent.com/1894106/99658744-3509e500-2a60-11eb-919e-858534d3e372.png)

