### PR TITLE
Server landing page: use cached projects

### DIFF
--- a/python/server/auto_generated/qgsconfigcache.sip.in
+++ b/python/server/auto_generated/qgsconfigcache.sip.in
@@ -36,7 +36,7 @@ Removes an entry from cache.
 :param path: The path of the project
 %End
 
-    const QgsProject *project( const QString &path, QgsServerSettings *settings = 0 );
+    const QgsProject *project( const QString &path, const QgsServerSettings *settings = 0 );
 %Docstring
 If the project is not cached yet, then the project is read from the
 path. If the project is not available, then ``None`` is returned.

--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -39,7 +39,7 @@ QgsConfigCache::QgsConfigCache()
 }
 
 
-const QgsProject *QgsConfigCache::project( const QString &path, QgsServerSettings *settings )
+const QgsProject *QgsConfigCache::project( const QString &path, const QgsServerSettings *settings )
 {
   if ( ! mProjectCache[ path ] )
   {

--- a/src/server/qgsconfigcache.h
+++ b/src/server/qgsconfigcache.h
@@ -63,7 +63,7 @@ class SERVER_EXPORT QgsConfigCache : public QObject
      * \returns the project or NULLPTR if an error happened
      * \since QGIS 3.0
      */
-    const QgsProject *project( const QString &path, QgsServerSettings *settings = nullptr );
+    const QgsProject *project( const QString &path, const QgsServerSettings *settings = nullptr );
 
   private:
     QgsConfigCache() SIP_FORCE;

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -370,7 +370,10 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
         QString configFilePath = configPath( *sConfigFilePath, params.map() );
 
         // load the project if needed and not empty
-        project = mConfigCache->project( configFilePath, sServerInterface->serverSettings() );
+        if ( ! configFilePath.isEmpty() )
+        {
+          project = mConfigCache->project( configFilePath, sServerInterface->serverSettings() );
+        }
       }
 
       // Set the current project instance
@@ -380,6 +383,14 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
       {
         sServerInterface->setConfigFilePath( project->fileName() );
       }
+      else
+      {
+        sServerInterface->setConfigFilePath( QString() );
+      }
+
+      // Note that at this point we still might not have set a valid project.
+      // There are APIs that work without a project (e.g. the landing page catalog API that
+      // lists the available projects metadata).
 
       // Dispatcher: if SERVICE is set, we assume a OWS service, if not, let's try an API
       // TODO: QGIS 4 fix the OWS services and treat them as APIs

--- a/src/server/services/landingpage/qgslandingpagehandlers.cpp
+++ b/src/server/services/landingpage/qgslandingpagehandlers.cpp
@@ -19,7 +19,6 @@
 #include "qgslandingpageutils.h"
 #include "qgsserverinterface.h"
 #include "qgsserverresponse.h"
-#include "qgsproject.h"
 #include "qgsserverprojectutils.h"
 #include "qgsvectorlayer.h"
 #include "qgslayertreenode.h"
@@ -91,7 +90,7 @@ void QgsLandingPageMapHandler::handleRequest( const QgsServerApiContext &context
   {
     throw QgsServerApiNotFoundError( QStringLiteral( "Requested project hash not found!" ) );
   }
-  data[ "project" ] = QgsLandingPageUtils::projectInfo( projectPath );
+  data[ "project" ] = QgsLandingPageUtils::projectInfo( projectPath, mSettings );
   write( data, context, {{ "pageTitle", linkTitle() }, { "navigation", json::array() }} );
 }
 

--- a/src/server/services/landingpage/qgslandingpageutils.h
+++ b/src/server/services/landingpage/qgslandingpageutils.h
@@ -49,9 +49,9 @@ struct QgsLandingPageUtils
   static QMap<QString, QString> projects( const QgsServerSettings &settings );
 
   /**
-   * Returns project information for a given \a projectPath
+   * Returns project information for a given \a projectPath and optional \a serverSettings
    */
-  static json projectInfo( const QString &projectPath );
+  static json projectInfo( const QString &projectPath, const QgsServerSettings *serverSettings = nullptr );
 
   /**
    * Returns the layer tree information for the given \a project


### PR DESCRIPTION
Now that we have view settings initial extent in the QgsProject instance we can exploit project cache completely.