### PR TITLE
[qgsquick] add missing currentFeature

### DIFF
--- a/src/quickgui/qgsquickfeatureslistmodel.cpp
+++ b/src/quickgui/qgsquickfeatureslistmodel.cpp
@@ -23,6 +23,8 @@ QgsQuickFeaturesListModel::QgsQuickFeaturesListModel( QObject *parent )
 {
 }
 
+QgsQuickFeaturesListModel::~QgsQuickFeaturesListModel() = default;
+
 int QgsQuickFeaturesListModel::rowCount( const QModelIndex &parent ) const
 {
   // For list models only the root node (an invalid parent) should return the list's size. For all
@@ -303,6 +305,11 @@ void QgsQuickFeaturesListModel::setCurrentFeature( QgsFeature feature )
   mCurrentFeature = feature;
   reloadFeatures();
   emit currentFeatureChanged( mCurrentFeature );
+}
+
+QgsFeature QgsQuickFeaturesListModel::currentFeature() const
+{
+  return mCurrentFeature;
 }
 
 int QgsQuickFeaturesListModel::featuresLimit() const

--- a/src/quickgui/qgsquickfeatureslistmodel.h
+++ b/src/quickgui/qgsquickfeatureslistmodel.h
@@ -58,7 +58,7 @@ class QUICK_EXPORT QgsQuickFeaturesListModel : public QAbstractListModel
       * Feature that has opened feature form.
       * This property needs to be set before opening feature form to be able to evaulate filter expressions that contain form scope.
       */
-    Q_PROPERTY( QgsFeature currentFeature WRITE setCurrentFeature NOTIFY currentFeatureChanged )
+    Q_PROPERTY( QgsFeature currentFeature READ currentFeature WRITE setCurrentFeature NOTIFY currentFeatureChanged )
 
   public:
 
@@ -76,7 +76,7 @@ class QUICK_EXPORT QgsQuickFeaturesListModel : public QAbstractListModel
 
     //! Create features list model
     explicit QgsQuickFeaturesListModel( QObject *parent = nullptr );
-    ~QgsQuickFeaturesListModel() override {};
+    ~QgsQuickFeaturesListModel() override;
 
     //! Function to get QgsQuickFeatureLayerPair by feature id
     Q_INVOKABLE QgsQuickFeatureLayerPair featureLayerPair( const int &featureId );
@@ -160,6 +160,9 @@ class QUICK_EXPORT QgsQuickFeaturesListModel : public QAbstractListModel
 
     //! Sets current feature property
     void setCurrentFeature( QgsFeature feature );
+
+    //! Gets current feature property
+    QgsFeature currentFeature() const;
 
   signals:
 


### PR DESCRIPTION
removes warning on android when compiling WITH_QGSQUICK