### PR TITLE
Simplify Curved Types for QgsPostgresFeatureIterator

### DIFF
--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -521,8 +521,7 @@ bool QgsPostgresFeatureIterator::declareCursor( const QString &whereClause, long
 
     if ( !mRequest.simplifyMethod().forceLocalOptimization() &&
          mRequest.simplifyMethod().methodType() != QgsSimplifyMethod::NoSimplification &&
-         QgsWkbTypes::flatType( QgsWkbTypes::singleType( usedGeomType ) ) != QgsWkbTypes::Point &&
-         !QgsWkbTypes::isCurvedType( usedGeomType ) )
+         QgsWkbTypes::flatType( QgsWkbTypes::singleType( usedGeomType ) ) != QgsWkbTypes::Point )
     {
       // PostGIS simplification method to use
       QString simplifyPostgisMethod;
@@ -531,7 +530,7 @@ bool QgsPostgresFeatureIterator::declareCursor( const QString &whereClause, long
       bool postSimplification;
       postSimplification = false; // default to false. Set to true only for PostGIS >= 2.2 when using st_removerepeatedpoints
 
-      if ( mRequest.simplifyMethod().methodType() == QgsSimplifyMethod::OptimizeForRendering )
+      if ( !QgsWkbTypes::isCurvedType( usedGeomType ) && mRequest.simplifyMethod().methodType() == QgsSimplifyMethod::OptimizeForRendering )
       {
         // Optimize simplification for rendering
         if ( mConn->majorVersion() < 2 )


### PR DESCRIPTION
## Description

Currently layers with (some) curved features are never simplified PostgreSQL server side.

However in many datasets just a small fraction of the dataset features
has curves.

The existing code already has a "st_simplifypreservetopology"
branch which will simplify Linestrings and Polygons and leaves
other geometries unchanged. Use this code for curved geometry layers.



<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
