### PR TITLE
Nam function chganged to lower case

### DIFF
--- a/resources/function_help/json/overlay_touches
+++ b/resources/function_help/json/overlay_touches
@@ -2,7 +2,7 @@
   "name": "overlay_touches",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns whether the current feature spatially touches at least one feature from a target layer, or an array of expression-based results for the features in the target layer touched by the current feature.<br><br>Read more on the underlying GEOS \"Touches\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Touches.html'>ST_TOUCHES</a> function.",
+  "description": "Returns whether the current feature spatially touches at least one feature from a target layer, or an array of expression-based results for the features in the target layer touched by the current feature.<br><br>Read more on the underlying GEOS \"Touches\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Touches.html'>ST_Touches</a> function.",
   "arguments": [
     {
       "arg": "layer",


### PR DESCRIPTION
Line 5 : ST_TOUCHES  should be ST_Touches.

Other functions also were changed to lower case (i.e. ST_CONTAINS, ST_ CROSSES  to  ST_Contains, ST_Crosses)

## Description  Display correct documentation


