### PR TITLE
Name function changed to lower case

### DIFF
--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -2,7 +2,7 @@
   "name": "overlay_intersects",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns whether the current feature spatially intersects at least one feature from a target layer, or an array of expression-based results for the features in the target layer intersected by the current feature.<br><br>Read more on the underlying GEOS \"Intersects\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Intersects.html'>ST_INTERSECTS</a> function.",
+  "description": "Returns whether the current feature spatially intersects at least one feature from a target layer, or an array of expression-based results for the features in the target layer intersected by the current feature.<br><br>Read more on the underlying GEOS \"Intersects\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Intersects.html'>ST_Intersects</a> function.",
   "arguments": [
     {
       "arg": "layer",


### PR DESCRIPTION
Line 5 : ST_INTERSECTS  should be ST_Intersects.

Other functions also were changed to lower case (i.e. ST_CONTAINS, ST_ CROSSES  to  ST_Contains, ST_Crosses)

## Description  Display correct documentation

