### PR TITLE
Fix qt warning raised while constructing some forms of layer URIs

### DIFF
--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -89,7 +89,7 @@ QgsDataSourceUri::QgsDataSourceUri( const QString &u )
           mTable = pval;
         }
 
-        if ( uri[i] == '(' )
+        if ( i < uri.length() && uri[i] == '(' )
         {
           i++;
 


### PR DESCRIPTION
due to accessing character position past end of string
