### PR TITLE
Don't show degrees based annotation format options for non-geographic map grids

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -990,6 +990,13 @@ Emitted when the map's associated ``theme`` is changed.
 .. versionadded:: 3.14
 %End
 
+    void crsChanged();
+%Docstring
+Emitted when the map's coordinate reference system is changed.
+
+.. versionadded:: 3.18
+%End
+
   public slots:
 
     virtual void refresh();

--- a/python/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
@@ -1118,6 +1118,15 @@ Retrieves the second fill color for the grid frame.
     virtual void refresh();
 
 
+  signals:
+
+    void crsChanged();
+%Docstring
+Emitted whenever the grid's CRS is changed.
+
+.. versionadded:: 3.18
+%End
+
 };
 
 QFlags<QgsLayoutItemMapGrid::FrameSideFlag> operator|(QgsLayoutItemMapGrid::FrameSideFlag f1, QFlags<QgsLayoutItemMapGrid::FrameSideFlag> f2);

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -300,7 +300,11 @@ QgsCoordinateReferenceSystem QgsLayoutItemMap::crs() const
 
 void QgsLayoutItemMap::setCrs( const QgsCoordinateReferenceSystem &crs )
 {
+  if ( mCrs == crs )
+    return;
+
   mCrs = crs;
+  emit crsChanged();
 }
 
 QList<QgsMapLayer *> QgsLayoutItemMap::layers() const
@@ -707,15 +711,13 @@ bool QgsLayoutItemMap::readPropertiesFromElement( const QDomElement &itemElem, c
   }
 
   QDomNodeList crsNodeList = itemElem.elementsByTagName( QStringLiteral( "crs" ) );
+  QgsCoordinateReferenceSystem crs;
   if ( !crsNodeList.isEmpty() )
   {
     QDomElement crsElem = crsNodeList.at( 0 ).toElement();
-    mCrs.readXml( crsElem );
+    crs.readXml( crsElem );
   }
-  else
-  {
-    mCrs = QgsCoordinateReferenceSystem();
-  }
+  setCrs( crs );
 
   //map rotation
   mMapRotation = itemElem.attribute( QStringLiteral( "mapRotation" ), QStringLiteral( "0" ) ).toDouble();
@@ -1856,9 +1858,15 @@ void QgsLayoutItemMap::refreshDataDefinedProperty( const QgsLayoutObject::DataDe
   if ( property == QgsLayoutObject::MapCrs || property == QgsLayoutObject::AllProperties )
   {
     bool ok;
-    QString crsVar = mDataDefinedProperties.valueAsString( QgsLayoutObject::MapCrs, context, QString(), &ok );
+    const QString crsVar = mDataDefinedProperties.valueAsString( QgsLayoutObject::MapCrs, context, QString(), &ok );
     if ( ok && QgsCoordinateReferenceSystem( crsVar ).isValid() )
-      mCrs = QgsCoordinateReferenceSystem( crsVar );
+    {
+      const QgsCoordinateReferenceSystem newCrs( crsVar );
+      if ( newCrs.isValid() )
+      {
+        setCrs( newCrs );
+      }
+    }
   }
   //updates data defined properties and redraws item to match
   if ( property == QgsLayoutObject::MapRotation || property == QgsLayoutObject::MapScale ||
@@ -1992,6 +2000,7 @@ void QgsLayoutItemMap::connectUpdateSlot()
       {
         //using project CRS, which just changed....
         invalidateCache();
+        emit crsChanged();
       }
     } );
 

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -910,6 +910,13 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem, public QgsTemporalRan
      */
     void themeChanged( const QString &theme );
 
+    /**
+     * Emitted when the map's coordinate reference system is changed.
+     *
+     * \since QGIS 3.18
+     */
+    void crsChanged();
+
   public slots:
 
     void refresh() override;

--- a/src/core/layout/qgslayoutitemmapgrid.cpp
+++ b/src/core/layout/qgslayoutitemmapgrid.cpp
@@ -203,6 +203,11 @@ QgsLayoutItemMapGrid::QgsLayoutItemMapGrid( const QString &name, QgsLayoutItemMa
 
   connect( mMap, &QgsLayoutItemMap::extentChanged, this, &QgsLayoutItemMapGrid::refreshDataDefinedProperties );
   connect( mMap, &QgsLayoutItemMap::mapRotationChanged, this, &QgsLayoutItemMapGrid::refreshDataDefinedProperties );
+  connect( mMap, &QgsLayoutItemMap::crsChanged, this, [ = ]
+  {
+    if ( !mCRS.isValid() )
+      emit crsChanged();
+  } );
 }
 
 void QgsLayoutItemMapGrid::createDefaultGridLineSymbol()
@@ -438,8 +443,12 @@ bool QgsLayoutItemMapGrid::readXml( const QDomElement &itemElem, const QDomDocum
 
 void QgsLayoutItemMapGrid::setCrs( const QgsCoordinateReferenceSystem &crs )
 {
+  if ( mCRS == crs )
+    return;
+
   mCRS = crs;
   mTransformDirty = true;
+  emit crsChanged();
 }
 
 bool QgsLayoutItemMapGrid::usesAdvancedEffects() const

--- a/src/core/layout/qgslayoutitemmapgrid.h
+++ b/src/core/layout/qgslayoutitemmapgrid.h
@@ -1006,6 +1006,15 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
     bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
     void refresh() override;
 
+  signals:
+
+    /**
+     * Emitted whenever the grid's CRS is changed.
+     *
+     * \since QGIS 3.18
+     */
+    void crsChanged();
+
   private:
 
     QgsLayoutItemMapGrid() = delete;

--- a/src/gui/layout/qgslayoutmapgridwidget.cpp
+++ b/src/gui/layout/qgslayoutmapgridwidget.cpp
@@ -133,16 +133,6 @@ QgsLayoutMapGridWidget::QgsLayoutMapGridWidget( QgsLayoutItemMapGrid *mapGrid, Q
   insertFrameDisplayEntries( mFrameDivisionsTopComboBox );
   insertFrameDisplayEntries( mFrameDivisionsBottomComboBox );
 
-  mAnnotationFormatComboBox->addItem( tr( "Decimal" ), QgsLayoutItemMapGrid::Decimal );
-  mAnnotationFormatComboBox->addItem( tr( "Decimal with Suffix" ), QgsLayoutItemMapGrid::DecimalWithSuffix );
-  mAnnotationFormatComboBox->addItem( tr( "Degree, Minute" ), QgsLayoutItemMapGrid::DegreeMinuteNoSuffix );
-  mAnnotationFormatComboBox->addItem( tr( "Degree, Minute with Suffix" ), QgsLayoutItemMapGrid::DegreeMinute );
-  mAnnotationFormatComboBox->addItem( tr( "Degree, Minute Aligned" ), QgsLayoutItemMapGrid::DegreeMinutePadded );
-  mAnnotationFormatComboBox->addItem( tr( "Degree, Minute, Second" ), QgsLayoutItemMapGrid::DegreeMinuteSecondNoSuffix );
-  mAnnotationFormatComboBox->addItem( tr( "Degree, Minute, Second with Suffix" ), QgsLayoutItemMapGrid::DegreeMinuteSecond );
-  mAnnotationFormatComboBox->addItem( tr( "Degree, Minute, Second Aligned" ), QgsLayoutItemMapGrid::DegreeMinuteSecondPadded );
-  mAnnotationFormatComboBox->addItem( tr( "Custom" ), QgsLayoutItemMapGrid::CustomFormat );
-
   insertAnnotationDisplayEntries( mAnnotationDisplayLeftComboBox );
   insertAnnotationDisplayEntries( mAnnotationDisplayRightComboBox );
   insertAnnotationDisplayEntries( mAnnotationDisplayTopComboBox );
@@ -201,6 +191,9 @@ QgsLayoutMapGridWidget::QgsLayoutMapGridWidget( QgsLayoutItemMapGrid *mapGrid, Q
   registerDataDefinedButton( mFrameDivisionsTopDDBtn, QgsLayoutObject::MapGridFrameDivisionsTop );
   registerDataDefinedButton( mFrameDivisionsBottomDDBtn, QgsLayoutObject::MapGridFrameDivisionsBottom );
 
+  // call to initially populate mAnnotationFormatComboBox
+  onCrsChanged();
+
   updateGuiElements();
 
   blockAllSignals( false );
@@ -220,6 +213,8 @@ QgsLayoutMapGridWidget::QgsLayoutMapGridWidget( QgsLayoutItemMapGrid *mapGrid, Q
   }
   mAnnotationFontButton->setLayer( coverageLayer() );
   mAnnotationFontButton->registerExpressionContextGenerator( mMapGrid );
+
+  connect( mMapGrid, &QgsLayoutItemMapGrid::crsChanged, this, &QgsLayoutMapGridWidget::onCrsChanged );
 }
 
 void QgsLayoutMapGridWidget::populateDataDefinedButtons()
@@ -1079,6 +1074,55 @@ void QgsLayoutMapGridWidget::annotationTextFormatChanged()
   mMap->update();
 }
 
+void QgsLayoutMapGridWidget::onCrsChanged()
+{
+  mBlockAnnotationFormatUpdates++;
+  const QgsLayoutItemMapGrid::AnnotationFormat prevFormat = static_cast< QgsLayoutItemMapGrid::AnnotationFormat  >( mAnnotationFormatComboBox->currentData().toInt() );
+
+  mAnnotationFormatComboBox->clear();
+  mAnnotationFormatComboBox->addItem( tr( "Decimal" ), QgsLayoutItemMapGrid::Decimal );
+  mAnnotationFormatComboBox->addItem( tr( "Decimal with Suffix" ), QgsLayoutItemMapGrid::DecimalWithSuffix );
+
+  // only show degree based options for geographic CRSes
+  const QgsCoordinateReferenceSystem crs = mMapGrid->crs().isValid() ? mMapGrid->crs() : mMap->crs();
+  switch ( crs.mapUnits() )
+  {
+    case QgsUnitTypes::DistanceMeters:
+    case QgsUnitTypes::DistanceKilometers:
+    case QgsUnitTypes::DistanceFeet:
+    case QgsUnitTypes::DistanceNauticalMiles:
+    case QgsUnitTypes::DistanceYards:
+    case QgsUnitTypes::DistanceMiles:
+    case QgsUnitTypes::DistanceCentimeters:
+    case QgsUnitTypes::DistanceMillimeters:
+      break;
+
+    case QgsUnitTypes::DistanceDegrees:
+    case QgsUnitTypes::DistanceUnknownUnit:
+      mAnnotationFormatComboBox->addItem( tr( "Degree, Minute" ), QgsLayoutItemMapGrid::DegreeMinuteNoSuffix );
+      mAnnotationFormatComboBox->addItem( tr( "Degree, Minute with Suffix" ), QgsLayoutItemMapGrid::DegreeMinute );
+      mAnnotationFormatComboBox->addItem( tr( "Degree, Minute Aligned" ), QgsLayoutItemMapGrid::DegreeMinutePadded );
+      mAnnotationFormatComboBox->addItem( tr( "Degree, Minute, Second" ), QgsLayoutItemMapGrid::DegreeMinuteSecondNoSuffix );
+      mAnnotationFormatComboBox->addItem( tr( "Degree, Minute, Second with Suffix" ), QgsLayoutItemMapGrid::DegreeMinuteSecond );
+      mAnnotationFormatComboBox->addItem( tr( "Degree, Minute, Second Aligned" ), QgsLayoutItemMapGrid::DegreeMinuteSecondPadded );
+      break;
+  }
+  mAnnotationFormatComboBox->addItem( tr( "Custom" ), QgsLayoutItemMapGrid::CustomFormat );
+
+  const int prevIndex = mAnnotationFormatComboBox->findData( prevFormat );
+  if ( prevIndex >= 0 )
+    mAnnotationFormatComboBox->setCurrentIndex( prevIndex );
+  else
+    mAnnotationFormatComboBox->setCurrentIndex( 0 );
+  mBlockAnnotationFormatUpdates--;
+
+  const QgsLayoutItemMapGrid::AnnotationFormat newFormat = static_cast< QgsLayoutItemMapGrid::AnnotationFormat  >( mAnnotationFormatComboBox->currentData().toInt() );
+  if ( newFormat != prevFormat )
+  {
+    mAnnotationFormatComboBox_currentIndexChanged( mAnnotationFormatComboBox->currentIndex() );
+  }
+}
+
 void QgsLayoutMapGridWidget::mGridBlendComboBox_currentIndexChanged( int index )
 {
   Q_UNUSED( index )
@@ -1335,6 +1379,8 @@ void QgsLayoutMapGridWidget::mAnnotationFormatComboBox_currentIndexChanged( int 
   {
     return;
   }
+  if ( mBlockAnnotationFormatUpdates )
+    return;
 
   mMap->beginCommand( tr( "Change Annotation Format" ) );
 

--- a/src/gui/layout/qgslayoutmapgridwidget.cpp
+++ b/src/gui/layout/qgslayoutmapgridwidget.cpp
@@ -48,9 +48,9 @@ QgsLayoutMapGridWidget::QgsLayoutMapGridWidget( QgsLayoutItemMapGrid *mapGrid, Q
   mFrameStyleComboBox->addItem( tr( "Line Border (Nautical)" ), QgsLayoutItemMapGrid::LineBorderNautical );
 
   mRotatedTicksLengthModeComboBox->addItem( tr( "Orthogonal" ), QgsLayoutItemMapGrid::OrthogonalTicks );
-  mRotatedTicksLengthModeComboBox->addItem( tr( "Fixed length" ), QgsLayoutItemMapGrid::NormalizedTicks );
+  mRotatedTicksLengthModeComboBox->addItem( tr( "Fixed Length" ), QgsLayoutItemMapGrid::NormalizedTicks );
   mRotatedAnnotationsLengthModeComboBox->addItem( tr( "Orthogonal" ), QgsLayoutItemMapGrid::OrthogonalTicks );
-  mRotatedAnnotationsLengthModeComboBox->addItem( tr( "Fixed length" ), QgsLayoutItemMapGrid::NormalizedTicks );
+  mRotatedAnnotationsLengthModeComboBox->addItem( tr( "Fixed Length" ), QgsLayoutItemMapGrid::NormalizedTicks );
 
   mGridFrameMarginSpinBox->setShowClearButton( true );
   mGridFrameMarginSpinBox->setClearValue( 0 );

--- a/src/gui/layout/qgslayoutmapgridwidget.h
+++ b/src/gui/layout/qgslayoutmapgridwidget.h
@@ -124,10 +124,12 @@ class GUI_EXPORT QgsLayoutMapGridWidget: public QgsLayoutItemBaseWidget, private
     void minIntervalChanged( double interval );
     void maxIntervalChanged( double interval );
     void annotationTextFormatChanged();
+    void onCrsChanged();
 
   private:
     QPointer< QgsLayoutItemMap > mMap;
     QPointer< QgsLayoutItemMapGrid > mMapGrid;
+    int mBlockAnnotationFormatUpdates = 0;
 
     //! Blocks / unblocks the signals of all GUI elements
     void blockAllSignals( bool b );


### PR DESCRIPTION
Fixes another paper cut from @timlinux 's recent screencast. No longer offer the various "degrees" based options as possible annotation formats for layout map grids if the grid's CRS isn't a latitude/longitude based CRS. For non-geographic CRSses like this, only show the generic decimal formatting options.

(The degrees based options give nonsense results for non-degrees based CRSes.)