### PR TITLE
Don't default to placing each input file in a separate  band in build vrt algorithm

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -420,6 +420,10 @@ the parameter's behavior and use in depth.
 Returns the default value for the parameter.
 
 .. seealso:: :py:func:`setDefaultValue`
+
+.. seealso:: :py:func:`defaultValueForGui`
+
+.. seealso:: :py:func:`guiDefaultValueOverride`
 %End
 
     void setDefaultValue( const QVariant &value );
@@ -428,6 +432,52 @@ Sets the default ``value`` for the parameter. Caller takes responsibility
 to ensure that ``value`` is a valid input for the parameter subclass.
 
 .. seealso:: :py:func:`defaultValue`
+
+.. seealso:: :py:func:`setGuiDefaultValueOverride`
+%End
+
+    QVariant guiDefaultValueOverride() const;
+%Docstring
+Returns the default value to use in the GUI for the parameter.
+
+Usually this will return an invalid variant, which indicates that the standard :py:func:`~QgsProcessingParameterDefinition.defaultValue`
+will be used in the GUI.
+
+.. seealso:: :py:func:`defaultValue`
+
+.. seealso:: :py:func:`setGuiDefaultValueOverride`
+
+.. seealso:: :py:func:`defaultValueForGui`
+
+.. versionadded:: 3.18
+%End
+
+    void setGuiDefaultValueOverride( const QVariant &value );
+%Docstring
+Sets the default ``value`` to use for the parameter in GUI widgets. Caller takes responsibility
+to ensure that ``value`` is a valid input for the parameter subclass.
+
+Usually the :py:func:`~QgsProcessingParameterDefinition.guiDefaultValueOverride` is a invalid variant, which indicates that the standard :py:func:`~QgsProcessingParameterDefinition.defaultValue`
+should be used in the GUI. In cases where it is decided that a previous default value was inappropriate,
+setting a non-invalid default GUI value can be used to change the default value for the parameter shown
+to users when running algorithms without changing the actual :py:func:`~QgsProcessingParameterDefinition.defaultValue` and potentially breaking
+third party scripts.
+
+.. seealso:: :py:func:`guiDefaultValueOverride`
+
+.. seealso:: :py:func:`setDefaultValue`
+
+.. versionadded:: 3.18
+%End
+
+    QVariant defaultValueForGui() const;
+%Docstring
+Returns the default value to use for the parameter in a GUI.
+
+This will be the parameter's :py:func:`~QgsProcessingParameterDefinition.defaultValue`, unless a :py:func:`~QgsProcessingParameterDefinition.guiDefaultValueOverride` is set to
+override that.
+
+.. versionadded:: 3.18
 %End
 
     Flags flags() const;
@@ -652,6 +702,7 @@ The ``variables`` list should contain the variable names only, without the usual
 %End
 
   protected:
+
 
 
 

--- a/python/plugins/processing/algs/gdal/buildvrt.py
+++ b/python/plugins/processing/algs/gdal/buildvrt.py
@@ -111,8 +111,8 @@ class buildvrt(GdalAlgorithm):
                                                      defaultValue=0))
 
         separate_param = QgsProcessingParameterBoolean(self.SEPARATE,
-                                                        self.tr('Place each input file into a separate band'),
-                                                        defaultValue=True)
+                                                       self.tr('Place each input file into a separate band'),
+                                                       defaultValue=True)
         # default to not using separate bands is a friendlier option, but we can't change the parameter's actual
         # defaultValue without breaking API!
         separate_param.setGuiDefaultValueOverride(False)

--- a/python/plugins/processing/algs/gdal/buildvrt.py
+++ b/python/plugins/processing/algs/gdal/buildvrt.py
@@ -109,9 +109,15 @@ class buildvrt(GdalAlgorithm):
                                                      self.tr('Resolution'),
                                                      options=[i[0] for i in self.RESOLUTION_OPTIONS],
                                                      defaultValue=0))
-        self.addParameter(QgsProcessingParameterBoolean(self.SEPARATE,
+
+        separate_param = QgsProcessingParameterBoolean(self.SEPARATE,
                                                         self.tr('Place each input file into a separate band'),
-                                                        defaultValue=True))
+                                                        defaultValue=True)
+        # default to not using separate bands is a friendlier option, but we can't change the parameter's actual
+        # defaultValue without breaking API!
+        separate_param.setGuiDefaultValueOverride(False)
+        self.addParameter(separate_param)
+
         self.addParameter(QgsProcessingParameterBoolean(self.PROJ_DIFFERENCE,
                                                         self.tr('Allow projection difference'),
                                                         defaultValue=False))

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -2447,6 +2447,7 @@ QVariantMap QgsProcessingParameterDefinition::toVariantMap() const
   map.insert( QStringLiteral( "description" ), mDescription );
   map.insert( QStringLiteral( "help" ), mHelp );
   map.insert( QStringLiteral( "default" ), mDefault );
+  map.insert( QStringLiteral( "defaultGui" ), mGuiDefault );
   map.insert( QStringLiteral( "flags" ), static_cast< int >( mFlags ) );
   map.insert( QStringLiteral( "metadata" ), mMetadata );
   return map;
@@ -2458,6 +2459,7 @@ bool QgsProcessingParameterDefinition::fromVariantMap( const QVariantMap &map )
   mDescription = map.value( QStringLiteral( "description" ) ).toString();
   mHelp = map.value( QStringLiteral( "help" ) ).toString();
   mDefault = map.value( QStringLiteral( "default" ) );
+  mGuiDefault = map.value( QStringLiteral( "defaultGui" ) );
   mFlags = static_cast< Flags >( map.value( QStringLiteral( "flags" ) ).toInt() );
   mMetadata = map.value( QStringLiteral( "metadata" ) ).toMap();
   return true;

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -589,7 +589,8 @@ QStringList QgsProcessingParameters::parameterAsEnumStrings( const QgsProcessing
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
   QSet<QString> subtraction = enumValues.toSet().subtract( enumDef->options().toSet() );
 #else
-  QSet<QString> subtraction = QSet<QString>( enumValues.begin(), enumValues.end() ).subtract( QSet<QString>( enumDef->options().begin(), enumDef->options().end() ) );
+  const QStringList options = enumDef->options();
+  QSet<QString> subtraction = QSet<QString>( enumValues.begin(), enumValues.end() ).subtract( QSet<QString>( options.begin(), options.end() ) );
 #endif
 
   if ( enumValues.isEmpty() || !subtraction.isEmpty() )

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -521,6 +521,8 @@ class CORE_EXPORT QgsProcessingParameterDefinition
     /**
      * Returns the default value for the parameter.
      * \see setDefaultValue()
+     * \see defaultValueForGui()
+     * \see guiDefaultValueOverride()
      */
     QVariant defaultValue() const { return mDefault; }
 
@@ -528,8 +530,50 @@ class CORE_EXPORT QgsProcessingParameterDefinition
      * Sets the default \a value for the parameter. Caller takes responsibility
      * to ensure that \a value is a valid input for the parameter subclass.
      * \see defaultValue()
+     * \see setGuiDefaultValueOverride()
      */
     void setDefaultValue( const QVariant &value ) { mDefault = value; }
+
+    /**
+     * Returns the default value to use in the GUI for the parameter.
+     *
+     * Usually this will return an invalid variant, which indicates that the standard defaultValue()
+     * will be used in the GUI.
+     *
+     * \see defaultValue()
+     * \see setGuiDefaultValueOverride()
+     * \see defaultValueForGui()
+     *
+     * \since QGIS 3.18
+     */
+    QVariant guiDefaultValueOverride() const { return mGuiDefault; }
+
+    /**
+     * Sets the default \a value to use for the parameter in GUI widgets. Caller takes responsibility
+     * to ensure that \a value is a valid input for the parameter subclass.
+     *
+     * Usually the guiDefaultValueOverride() is a invalid variant, which indicates that the standard defaultValue()
+     * should be used in the GUI. In cases where it is decided that a previous default value was inappropriate,
+     * setting a non-invalid default GUI value can be used to change the default value for the parameter shown
+     * to users when running algorithms without changing the actual defaultValue() and potentially breaking
+     * third party scripts.
+     *
+     * \see guiDefaultValueOverride()
+     * \see setDefaultValue()
+     *
+     * \since QGIS 3.18
+     */
+    void setGuiDefaultValueOverride( const QVariant &value ) { mGuiDefault = value; }
+
+    /**
+     * Returns the default value to use for the parameter in a GUI.
+     *
+     * This will be the parameter's defaultValue(), unless a guiDefaultValueOverride() is set to
+     * override that.
+     *
+     * \since QGIS 3.18
+     */
+    QVariant defaultValueForGui() const { return mGuiDefault.isValid() ? mGuiDefault : mDefault; }
 
     /**
      * Returns any flags associated with the parameter.
@@ -744,6 +788,9 @@ class CORE_EXPORT QgsProcessingParameterDefinition
 
     //! Default value for parameter
     QVariant mDefault;
+
+    //! Default value for parameter in GUI
+    QVariant mGuiDefault;
 
     //! Parameter flags
     Flags mFlags;

--- a/src/gui/processing/qgsprocessingmaplayercombobox.cpp
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.cpp
@@ -251,7 +251,7 @@ void QgsProcessingMapLayerComboBox::setValue( const QVariant &value, QgsProcessi
     }
     else
     {
-      val = val.value< QgsProperty >().valueAsString( context.expressionContext(), mParameter->defaultValue().toString() );
+      val = val.value< QgsProperty >().valueAsString( context.expressionContext(), mParameter->defaultValueForGui().toString() );
     }
   }
 

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -55,7 +55,7 @@ QgsProcessingLayerOutputDestinationWidget::QgsProcessingLayerOutputDestinationWi
   QgsSettings settings;
   mEncoding = settings.value( QStringLiteral( "/Processing/encoding" ), QStringLiteral( "System" ) ).toString();
 
-  if ( !mParameter->defaultValue().isValid() )
+  if ( !mParameter->defaultValueForGui().isValid() )
   {
     // no default value -- we default to either skipping the output or a temporary output, depending on the createByDefault value
     if ( mParameter->flags() & QgsProcessingParameterDefinition::FlagOptional && !mParameter->createByDefault() )
@@ -65,7 +65,7 @@ QgsProcessingLayerOutputDestinationWidget::QgsProcessingLayerOutputDestinationWi
   }
   else
   {
-    setValue( mParameter->defaultValue() );
+    setValue( mParameter->defaultValueForGui() );
   }
 
   setToolTip( mParameter->toolTip() );

--- a/src/gui/processing/qgsprocessingwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.cpp
@@ -153,7 +153,7 @@ QWidget *QgsAbstractProcessingParameterWidgetWrapper::createWrappedWidget( QgsPr
   if ( !dynamic_cast<const QgsProcessingDestinationParameter * >( mParameterDefinition ) )
   {
     // an exception -- output widgets handle this themselves
-    setWidgetValue( mParameterDefinition->defaultValue(), context );
+    setWidgetValue( mParameterDefinition->defaultValueForGui(), context );
   }
 
   return wrappedWidget;

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -87,7 +87,7 @@ QgsProcessingBooleanParameterDefinitionWidget::QgsProcessingBooleanParameterDefi
 
   mDefaultCheckBox = new QCheckBox( tr( "Checked" ) );
   if ( const QgsProcessingParameterBoolean *boolParam = dynamic_cast<const QgsProcessingParameterBoolean *>( definition ) )
-    mDefaultCheckBox->setChecked( QgsProcessingParameters::parameterAsBool( boolParam, boolParam->defaultValue(), context ) );
+    mDefaultCheckBox->setChecked( QgsProcessingParameters::parameterAsBool( boolParam, boolParam->defaultValueForGui(), context ) );
   else
     mDefaultCheckBox->setChecked( false );
   vlayout->addWidget( mDefaultCheckBox );
@@ -251,7 +251,7 @@ QgsProcessingCrsParameterDefinitionWidget::QgsProcessingCrsParameterDefinitionWi
 
   mCrsSelector = new QgsProjectionSelectionWidget();
   if ( const QgsProcessingParameterCrs *crsParam = dynamic_cast<const QgsProcessingParameterCrs *>( definition ) )
-    mCrsSelector->setCrs( QgsProcessingParameters::parameterAsCrs( crsParam, crsParam->defaultValue(), context ) );
+    mCrsSelector->setCrs( QgsProcessingParameters::parameterAsCrs( crsParam, crsParam->defaultValueForGui(), context ) );
   else
     mCrsSelector->setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
 
@@ -409,7 +409,7 @@ QgsProcessingStringParameterDefinitionWidget::QgsProcessingStringParameterDefini
 
   mDefaultLineEdit = new QLineEdit();
   if ( const QgsProcessingParameterString *stringParam = dynamic_cast<const QgsProcessingParameterString *>( definition ) )
-    mDefaultLineEdit->setText( QgsProcessingParameters::parameterAsString( stringParam, stringParam->defaultValue(), context ) );
+    mDefaultLineEdit->setText( QgsProcessingParameters::parameterAsString( stringParam, stringParam->defaultValueForGui(), context ) );
   vlayout->addWidget( mDefaultLineEdit );
 
   mMultiLineCheckBox = new QCheckBox( tr( "Multiline input" ) );
@@ -643,7 +643,7 @@ QgsProcessingNumberParameterDefinitionWidget::QgsProcessingNumberParameterDefini
     mTypeComboBox->setCurrentIndex( mTypeComboBox->findData( numberParam->dataType() ) );
     mMinLineEdit->setText( QString::number( numberParam->minimum() ) );
     mMaxLineEdit->setText( QString::number( numberParam->maximum() ) );
-    mDefaultLineEdit->setText( numberParam->defaultValue().toString() );
+    mDefaultLineEdit->setText( numberParam->defaultValueForGui().toString() );
   }
 
   setLayout( vlayout );
@@ -761,19 +761,19 @@ QWidget *QgsProcessingNumericWidgetWrapper::createWidget()
       }
       else
       {
-        if ( numberDef->defaultValue().isValid() )
+        if ( numberDef->defaultValueForGui().isValid() )
         {
           // if default value for parameter, we clear to that
           bool ok = false;
           if ( mDoubleSpinBox )
           {
-            double defaultVal = numberDef->defaultValue().toDouble( &ok );
+            double defaultVal = numberDef->defaultValueForGui().toDouble( &ok );
             if ( ok )
               mDoubleSpinBox->setClearValue( defaultVal );
           }
           else
           {
-            int intVal = numberDef->defaultValue().toInt( &ok );
+            int intVal = numberDef->defaultValueForGui().toInt( &ok );
             if ( ok )
               mSpinBox->setClearValue( intVal );
           }
@@ -986,7 +986,7 @@ QgsProcessingDistanceParameterDefinitionWidget::QgsProcessingDistanceParameterDe
   {
     mMinLineEdit->setText( QString::number( distParam->minimum() ) );
     mMaxLineEdit->setText( QString::number( distParam->maximum() ) );
-    mDefaultLineEdit->setText( distParam->defaultValue().toString() );
+    mDefaultLineEdit->setText( distParam->defaultValueForGui().toString() );
   }
 
   setLayout( vlayout );
@@ -1199,7 +1199,7 @@ QgsProcessingScaleParameterDefinitionWidget::QgsProcessingScaleParameterDefiniti
 
   if ( const QgsProcessingParameterScale *scaleParam = dynamic_cast<const QgsProcessingParameterScale *>( definition ) )
   {
-    mDefaultLineEdit->setText( scaleParam->defaultValue().toString() );
+    mDefaultLineEdit->setText( scaleParam->defaultValueForGui().toString() );
   }
 
   vlayout->addWidget( mDefaultLineEdit );
@@ -1321,7 +1321,7 @@ QgsProcessingRangeParameterDefinitionWidget::QgsProcessingRangeParameterDefiniti
   if ( const QgsProcessingParameterRange *rangeParam = dynamic_cast<const QgsProcessingParameterRange *>( definition ) )
   {
     mTypeComboBox->setCurrentIndex( mTypeComboBox->findData( rangeParam->dataType() ) );
-    const QList< double > range = QgsProcessingParameters::parameterAsRange( rangeParam, rangeParam->defaultValue(), context );
+    const QList< double > range = QgsProcessingParameters::parameterAsRange( rangeParam, rangeParam->defaultValueForGui(), context );
     mMinLineEdit->setText( QString::number( range.at( 0 ) ) );
     mMaxLineEdit->setText( QString::number( range.at( 1 ) ) );
   }
@@ -1566,7 +1566,7 @@ QgsProcessingMatrixParameterDefinitionWidget::QgsProcessingMatrixParameterDefini
   mMatrixWidget = new QgsProcessingMatrixModelerWidget();
   if ( const QgsProcessingParameterMatrix *matrixParam = dynamic_cast<const QgsProcessingParameterMatrix *>( definition ) )
   {
-    mMatrixWidget->setValue( matrixParam->headers(), matrixParam->defaultValue() );
+    mMatrixWidget->setValue( matrixParam->headers(), matrixParam->defaultValueForGui() );
     mMatrixWidget->setFixedRows( matrixParam->hasFixedNumberRows() );
   }
   vlayout->addWidget( mMatrixWidget );
@@ -1700,7 +1700,7 @@ QgsProcessingFileParameterDefinitionWidget::QgsProcessingFileParameterDefinition
   if ( const QgsProcessingParameterFile *fileParam = dynamic_cast<const QgsProcessingParameterFile *>( definition ) )
   {
     mDefaultFileWidget->setStorageMode( fileParam->behavior() == QgsProcessingParameterFile::File ? QgsFileWidget::GetFile : QgsFileWidget::GetDirectory );
-    mDefaultFileWidget->setFilePath( fileParam->defaultValue().toString() );
+    mDefaultFileWidget->setFilePath( fileParam->defaultValueForGui().toString() );
   }
   else
     mDefaultFileWidget->setStorageMode( QgsFileWidget::GetFile );
@@ -1846,7 +1846,7 @@ QgsProcessingExpressionParameterDefinitionWidget::QgsProcessingExpressionParamet
 
   mDefaultLineEdit = new QgsExpressionLineEdit();
   if ( const QgsProcessingParameterExpression *expParam = dynamic_cast<const QgsProcessingParameterExpression *>( definition ) )
-    mDefaultLineEdit->setExpression( QgsProcessingParameters::parameterAsExpression( expParam, expParam->defaultValue(), context ) );
+    mDefaultLineEdit->setExpression( QgsProcessingParameters::parameterAsExpression( expParam, expParam->defaultValueForGui(), context ) );
   vlayout->addWidget( mDefaultLineEdit );
 
   vlayout->addWidget( new QLabel( tr( "Parent layer" ) ) );
@@ -2357,7 +2357,7 @@ QgsProcessingEnumParameterDefinitionWidget::QgsProcessingEnumParameterDefinition
   {
     mEnumWidget->setAllowMultiple( enumParam->allowMultiple() );
     mEnumWidget->setOptions( enumParam->options() );
-    mEnumWidget->setDefaultOptions( enumParam->defaultValue() );
+    mEnumWidget->setDefaultOptions( enumParam->defaultValueForGui() );
   }
   vlayout->addWidget( mEnumWidget );
   setLayout( vlayout );
@@ -3034,7 +3034,7 @@ QgsProcessingPointParameterDefinitionWidget::QgsProcessingPointParameterDefiniti
   mDefaultLineEdit->setPlaceholderText( tr( "Point as 'x,y'" ) );
   if ( const QgsProcessingParameterPoint *pointParam = dynamic_cast<const QgsProcessingParameterPoint *>( definition ) )
   {
-    QgsPointXY point = QgsProcessingParameters::parameterAsPoint( pointParam, pointParam->defaultValue(), context );
+    QgsPointXY point = QgsProcessingParameters::parameterAsPoint( pointParam, pointParam->defaultValueForGui(), context );
     mDefaultLineEdit->setText( QStringLiteral( "%1,%2" ).arg( QString::number( point.x(), 'f' ), QString::number( point.y(), 'f' ) ) );
   }
 
@@ -3207,7 +3207,7 @@ QgsProcessingGeometryParameterDefinitionWidget::QgsProcessingGeometryParameterDe
   mDefaultLineEdit->setPlaceholderText( tr( "Geometry as WKT" ) );
   if ( const QgsProcessingParameterGeometry *geometryParam = dynamic_cast<const QgsProcessingParameterGeometry *>( definition ) )
   {
-    QgsGeometry g = QgsProcessingParameters::parameterAsGeometry( geometryParam, geometryParam->defaultValue(), context );
+    QgsGeometry g = QgsProcessingParameters::parameterAsGeometry( geometryParam, geometryParam->defaultValueForGui(), context );
     if ( !g.isNull() )
       mDefaultLineEdit->setText( g.asWkt() );
   }
@@ -3324,7 +3324,7 @@ QgsProcessingColorParameterDefinitionWidget::QgsProcessingColorParameterDefiniti
 
   if ( const QgsProcessingParameterColor *colorParam = dynamic_cast<const QgsProcessingParameterColor *>( definition ) )
   {
-    const QColor c = QgsProcessingParameters::parameterAsColor( colorParam, colorParam->defaultValue(), context );
+    const QColor c = QgsProcessingParameters::parameterAsColor( colorParam, colorParam->defaultValueForGui(), context );
     if ( !c.isValid() )
       mDefaultColorButton->setToNull();
     else
@@ -3373,9 +3373,9 @@ QWidget *QgsProcessingColorWidgetWrapper::createWidget()
       mColorButton->setAllowOpacity( colorParam->opacityEnabled() );
       mColorButton->setToolTip( parameterDefinition()->toolTip() );
       mColorButton->setColorDialogTitle( parameterDefinition()->description() );
-      if ( colorParam->defaultValue().value< QColor >().isValid() )
+      if ( colorParam->defaultValueForGui().value< QColor >().isValid() )
       {
-        mColorButton->setDefaultColor( colorParam->defaultValue().value< QColor >() );
+        mColorButton->setDefaultColor( colorParam->defaultValueForGui().value< QColor >() );
       }
 
       connect( mColorButton, &QgsColorButton::colorChanged, this, [ = ]
@@ -3464,7 +3464,7 @@ QgsProcessingCoordinateOperationParameterDefinitionWidget::QgsProcessingCoordina
 
   mDefaultLineEdit = new QLineEdit();
   if ( const QgsProcessingParameterCoordinateOperation *coordParam = dynamic_cast<const QgsProcessingParameterCoordinateOperation *>( definition ) )
-    mDefaultLineEdit->setText( QgsProcessingParameters::parameterAsString( coordParam, coordParam->defaultValue(), context ) );
+    mDefaultLineEdit->setText( QgsProcessingParameters::parameterAsString( coordParam, coordParam->defaultValueForGui(), context ) );
   vlayout->addWidget( mDefaultLineEdit );
 
   mSourceParamComboBox = new QComboBox();
@@ -3573,10 +3573,10 @@ QWidget *QgsProcessingCoordinateOperationWidgetWrapper::createWidget()
       mOperationWidget->setSourceCrs( mSourceCrs );
       mOperationWidget->setDestinationCrs( mDestCrs );
       mOperationWidget->setMapCanvas( mCanvas );
-      if ( !coordParam->defaultValue().toString().isEmpty() )
+      if ( !coordParam->defaultValueForGui().toString().isEmpty() )
       {
         QgsCoordinateOperationWidget::OperationDetails deets;
-        deets.proj = coordParam->defaultValue().toString();
+        deets.proj = coordParam->defaultValueForGui().toString();
         mOperationWidget->setSelectedOperation( deets );
       }
 
@@ -3954,7 +3954,7 @@ QgsProcessingFieldParameterDefinitionWidget::QgsProcessingFieldParameterDefiniti
   mDefaultLineEdit->setToolTip( tr( "Default field name, or ; separated list of field names for multiple field parameters" ) );
   if ( const QgsProcessingParameterField *fieldParam = dynamic_cast<const QgsProcessingParameterField *>( definition ) )
   {
-    const QStringList fields = QgsProcessingParameters::parameterAsFields( fieldParam, fieldParam->defaultValue(), context );
+    const QStringList fields = QgsProcessingParameters::parameterAsFields( fieldParam, fieldParam->defaultValueForGui(), context );
     mDefaultLineEdit->setText( fields.join( ';' ) );
   }
   vlayout->addWidget( mDefaultLineEdit );
@@ -4141,8 +4141,8 @@ void QgsProcessingFieldWidgetWrapper::setParentLayerWrapperValue( const QgsAbstr
       val << field.name();
     setWidgetValue( val, *context );
   }
-  else if ( fieldParam->defaultValue().isValid() )
-    setWidgetValue( parameterDefinition()->defaultValue(), *context );
+  else if ( fieldParam->defaultValueForGui().isValid() )
+    setWidgetValue( parameterDefinition()->defaultValueForGui(), *context );
 }
 
 void QgsProcessingFieldWidgetWrapper::setWidgetValue( const QVariant &value, QgsProcessingContext &context )
@@ -4303,8 +4303,8 @@ QgsProcessingMapThemeParameterDefinitionWidget::QgsProcessingMapThemeParameterDe
 
   if ( const QgsProcessingParameterMapTheme *themeParam = dynamic_cast<const QgsProcessingParameterMapTheme *>( definition ) )
   {
-    if ( themeParam->defaultValue().isValid() )
-      mDefaultComboBox->setCurrentText( QgsProcessingParameters::parameterAsString( themeParam, themeParam->defaultValue(), context ) );
+    if ( themeParam->defaultValueForGui().isValid() )
+      mDefaultComboBox->setCurrentText( QgsProcessingParameters::parameterAsString( themeParam, themeParam->defaultValueForGui(), context ) );
     else
       mDefaultComboBox->setCurrentIndex( mDefaultComboBox->findData( -1 ) );
   }
@@ -4642,7 +4642,7 @@ QgsProcessingProviderConnectionParameterDefinitionWidget::QgsProcessingProviderC
   if ( connectionParam )
   {
     mProviderComboBox->setCurrentIndex( mProviderComboBox->findData( connectionParam->providerId() ) );
-    mDefaultEdit->setText( connectionParam->defaultValue().toString() );
+    mDefaultEdit->setText( connectionParam->defaultValueForGui().toString() );
   }
 }
 
@@ -4824,7 +4824,7 @@ QgsProcessingDatabaseSchemaParameterDefinitionWidget::QgsProcessingDatabaseSchem
 
   if ( schemaParam )
   {
-    mDefaultEdit->setText( schemaParam->defaultValue().toString() );
+    mDefaultEdit->setText( schemaParam->defaultValueForGui().toString() );
   }
 }
 
@@ -4903,8 +4903,8 @@ void QgsProcessingDatabaseSchemaWidgetWrapper::setParentConnectionWrapperValue( 
     mSchemaComboBox->setConnectionName( connection, dynamic_cast< const QgsProcessingParameterProviderConnection * >( parentWrapper->parameterDefinition() )->providerId() );
 
   const QgsProcessingParameterDatabaseSchema *schemaParam = static_cast< const QgsProcessingParameterDatabaseSchema * >( parameterDefinition() );
-  if ( schemaParam->defaultValue().isValid() )
-    setWidgetValue( parameterDefinition()->defaultValue(), *context );
+  if ( schemaParam->defaultValueForGui().isValid() )
+    setWidgetValue( parameterDefinition()->defaultValueForGui(), *context );
 }
 
 void QgsProcessingDatabaseSchemaWidgetWrapper::setWidgetValue( const QVariant &value, QgsProcessingContext &context )
@@ -5079,7 +5079,7 @@ QgsProcessingDatabaseTableParameterDefinitionWidget::QgsProcessingDatabaseTableP
 
   if ( tableParam )
   {
-    mDefaultEdit->setText( tableParam->defaultValue().toString() );
+    mDefaultEdit->setText( tableParam->defaultValueForGui().toString() );
   }
 }
 
@@ -5156,8 +5156,8 @@ void QgsProcessingDatabaseTableWidgetWrapper::setParentConnectionWrapperValue( c
     mTableComboBox->setConnectionName( mConnection, mProvider );
 
     const QgsProcessingParameterDatabaseTable *tableParam = static_cast< const QgsProcessingParameterDatabaseTable * >( parameterDefinition() );
-    if ( tableParam->defaultValue().isValid() )
-      setWidgetValue( parameterDefinition()->defaultValue(), *context );
+    if ( tableParam->defaultValueForGui().isValid() )
+      setWidgetValue( parameterDefinition()->defaultValueForGui(), *context );
   }
 }
 
@@ -5184,8 +5184,8 @@ void QgsProcessingDatabaseTableWidgetWrapper::setParentSchemaWrapperValue( const
     mTableComboBox->setConnectionName( mConnection, mProvider );
 
     const QgsProcessingParameterDatabaseTable *tableParam = static_cast< const QgsProcessingParameterDatabaseTable * >( parameterDefinition() );
-    if ( tableParam->defaultValue().isValid() )
-      setWidgetValue( parameterDefinition()->defaultValue(), *context );
+    if ( tableParam->defaultValueForGui().isValid() )
+      setWidgetValue( parameterDefinition()->defaultValueForGui(), *context );
   }
 
 }
@@ -5306,10 +5306,10 @@ QgsProcessingExtentParameterDefinitionWidget::QgsProcessingExtentParameterDefini
   mDefaultWidget->setNullValueAllowed( true, tr( "Not set" ) );
   if ( const QgsProcessingParameterExtent *extentParam = dynamic_cast<const QgsProcessingParameterExtent *>( definition ) )
   {
-    if ( extentParam->defaultValue().isValid() )
+    if ( extentParam->defaultValueForGui().isValid() )
     {
-      QgsRectangle rect = QgsProcessingParameters::parameterAsExtent( extentParam, extentParam->defaultValue(), context );
-      QgsCoordinateReferenceSystem crs = QgsProcessingParameters::parameterAsExtentCrs( extentParam, extentParam->defaultValue(), context );
+      QgsRectangle rect = QgsProcessingParameters::parameterAsExtent( extentParam, extentParam->defaultValueForGui(), context );
+      QgsCoordinateReferenceSystem crs = QgsProcessingParameters::parameterAsExtentCrs( extentParam, extentParam->defaultValueForGui(), context );
       mDefaultWidget->setCurrentExtent( rect, crs );
       mDefaultWidget->setOutputExtentFromCurrent();
     }
@@ -5571,7 +5571,7 @@ void QgsProcessingMapLayerWidgetWrapper::setWidgetContext( const QgsProcessingPa
     if ( !( parameterDefinition()->flags() & QgsProcessingParameterDefinition::FlagOptional ) )
     {
       // non optional parameter -- if no default value set, default to active layer
-      if ( !parameterDefinition()->defaultValue().isValid() )
+      if ( !parameterDefinition()->defaultValueForGui().isValid() )
         mComboBox->setLayer( context.activeLayer() );
     }
   }
@@ -6058,7 +6058,7 @@ QgsProcessingBandParameterDefinitionWidget::QgsProcessingBandParameterDefinition
   mDefaultLineEdit->setToolTip( tr( "Band number (separate bands with ; for multiple band parameters)" ) );
   if ( const QgsProcessingParameterBand *bandParam = dynamic_cast<const QgsProcessingParameterBand *>( definition ) )
   {
-    const QList< int > bands = QgsProcessingParameters::parameterAsInts( bandParam, bandParam->defaultValue(), context );
+    const QList< int > bands = QgsProcessingParameters::parameterAsInts( bandParam, bandParam->defaultValueForGui(), context );
     QStringList defVal;
     for ( int b : bands )
     {
@@ -6266,8 +6266,8 @@ void QgsProcessingBandWidgetWrapper::setParentLayerWrapperValue( const QgsAbstra
     }
   }
 
-  if ( parameterDefinition()->defaultValue().isValid() )
-    setWidgetValue( parameterDefinition()->defaultValue(), *context );
+  if ( parameterDefinition()->defaultValueForGui().isValid() )
+    setWidgetValue( parameterDefinition()->defaultValueForGui(), *context );
 }
 
 void QgsProcessingBandWidgetWrapper::setWidgetValue( const QVariant &value, QgsProcessingContext &context )

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -708,7 +708,7 @@ void QgsGraduatedSymbolRendererWidget::updateUiFromRenderer( bool updateCount )
     for ( const auto &ppww : qgis::as_const( mParameterWidgetWrappers ) )
     {
       const QgsProcessingParameterDefinition *def = ppww->parameterDefinition();
-      QVariant value = method->parameterValues().value( def->name(), def->defaultValue() );
+      QVariant value = method->parameterValues().value( def->name(), def->defaultValueForGui() );
       ppww->setParameterValue( value, context );
     }
   }
@@ -841,7 +841,7 @@ void QgsGraduatedSymbolRendererWidget::updateMethodParameters()
     QgsAbstractProcessingParameterWidgetWrapper *ppww = QgsGui::processingGuiRegistry()->createParameterWidgetWrapper( def, QgsProcessingGui::Standard );
     mParametersLayout->addRow( ppww->createWrappedLabel(), ppww->createWrappedWidget( context ) );
 
-    QVariant value = method->parameterValues().value( def->name(), def->defaultValue() );
+    QVariant value = method->parameterValues().value( def->name(), def->defaultValueForGui() );
     ppww->setParameterValue( value, context );
 
     connect( ppww, &QgsAbstractProcessingParameterWidgetWrapper::widgetValueHasChanged, this, &QgsGraduatedSymbolRendererWidget::classifyGraduated );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -2337,6 +2337,12 @@ void TestQgsProcessing::parameterGeneral()
   QCOMPARE( param.flags(), QgsProcessingParameterDefinition::FlagHidden );
   param.setDefaultValue( true );
   QCOMPARE( param.defaultValue(), QVariant( true ) );
+  QCOMPARE( param.defaultValueForGui(), QVariant( true ) );
+  QVERIFY( !param.guiDefaultValueOverride().isValid() );
+  param.setGuiDefaultValueOverride( false );
+  QCOMPARE( param.guiDefaultValueOverride(), QVariant( false ) );
+  QCOMPARE( param.defaultValueForGui(), QVariant( false ) );
+
   param.setDefaultValue( QVariant() );
   QCOMPARE( param.defaultValue(), QVariant() );
   param.setHelp( QStringLiteral( "my help" ) );
@@ -2354,6 +2360,7 @@ void TestQgsProcessing::parameterGeneral()
   param.setAdditionalExpressionContextVariables( QStringList() << "a" << "b" );
   QCOMPARE( param.additionalExpressionContextVariables(), QStringList() << "a" << "b" );
   std::unique_ptr< QgsProcessingParameterDefinition > param2( param.clone() );
+  QCOMPARE( param2->guiDefaultValueOverride(), param.guiDefaultValueOverride() );
   QCOMPARE( param2->additionalExpressionContextVariables(), QStringList() << "a" << "b" );
 
   QVariantMap map = param.toVariantMap();
@@ -2363,6 +2370,7 @@ void TestQgsProcessing::parameterGeneral()
   QCOMPARE( fromMap.description(), param.description() );
   QCOMPARE( fromMap.flags(), param.flags() );
   QCOMPARE( fromMap.defaultValue(), param.defaultValue() );
+  QCOMPARE( fromMap.guiDefaultValueOverride(), param.guiDefaultValueOverride() );
   QCOMPARE( fromMap.metadata(), param.metadata() );
   QCOMPARE( fromMap.help(), QStringLiteral( "my help" ) );
 }


### PR DESCRIPTION
Creating a multi-band vrt is much less common vs creating a mosaic
style vrt, so set the default to the most common use case
and most predictable outcome.

The default behaviour has annoyed me for some time, but its only on watching @timlinux's latest screencast that I've finally decided to fix it :laughing: 
