### PR TITLE
Render 0 width buffered lines as super-narrow walls/fences instead of nothing

### DIFF
--- a/src/3d/symbols/qgsline3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsline3dsymbol_p.cpp
@@ -119,7 +119,16 @@ void QgsBufferedLine3DSymbolHandler::processFeature( const QgsFeature &f, const 
   const double mitreLimit = 0;
 
   QgsGeos engine( g );
-  QgsAbstractGeometry *buffered = engine.buffer( mSymbol->width() / 2., nSegments, endCapStyle, joinStyle, mitreLimit ); // factory
+
+  double width = mSymbol->width();
+  if ( qgsDoubleNear( width, 0 ) )
+  {
+    // a zero-width buffered line should be treated like a "wall" or "fence" -- we fake this by bumping the width to a very tiny amount,
+    // so that we get a very narrow polygon shape to work with...
+    width = 0.001;
+  }
+
+  QgsAbstractGeometry *buffered = engine.buffer( width / 2., nSegments, endCapStyle, joinStyle, mitreLimit ); // factory
   if ( !buffered )
     return;
 

--- a/src/app/3d/qgsline3dsymbolwidget.cpp
+++ b/src/app/3d/qgsline3dsymbolwidget.cpp
@@ -24,7 +24,7 @@ QgsLine3DSymbolWidget::QgsLine3DSymbolWidget( QWidget *parent )
   setupUi( this );
 
   spinHeight->setClearValue( 0.0 );
-  spinWidth->setClearValue( 0.0 );
+  spinWidth->setClearValue( 0.0, tr( "Hairline" ) );
   spinExtrusion->setClearValue( 0.0 );
 
   QgsLine3DSymbol defaultLine;
@@ -86,7 +86,6 @@ QString QgsLine3DSymbolWidget::symbolType() const
 void QgsLine3DSymbolWidget::updateGuiState()
 {
   bool simple = chkSimpleLines->isChecked();
-  //spinWidth->setEnabled( !simple );
   spinExtrusion->setEnabled( !simple );
   widgetMaterial->setTechnique( chkSimpleLines->isChecked() ? QgsMaterialSettingsRenderingTechnique::Lines
                                 : QgsMaterialSettingsRenderingTechnique::Triangles );


### PR DESCRIPTION
If a buffered line symbol is set to 0 width, transparently bump the width up to a tiny amount so that the tesselator actually has a (super narrow) polygon to work from

This means that 3d buffered lines set to 0 width will actually render like walls or fences, matching user expectations...

Before:

![image](https://user-images.githubusercontent.com/1829991/99921456-398f1000-2d76-11eb-8900-5ebbcc48ff74.png)

After:

![image](https://user-images.githubusercontent.com/1829991/99921453-3136d500-2d76-11eb-8e54-05287c6594c6.png)
