### PR TITLE
fix mesh vector ui

### DIFF
--- a/src/gui/mesh/qgsmeshrenderervectorsettingswidget.cpp
+++ b/src/gui/mesh/qgsmeshrenderervectorsettingswidget.cpp
@@ -260,7 +260,6 @@ void QgsMeshRendererVectorSettingsWidget::syncToLayer( )
 void QgsMeshRendererVectorSettingsWidget::onSymbologyChanged( int currentIndex )
 {
   mStreamlineWidget->setVisible( currentIndex == QgsMeshRendererVectorSettings::Streamlines );
-  mArrowWidget->setVisible( currentIndex == QgsMeshRendererVectorSettings::Arrows );
   mArrowLengthGroupBox->setVisible( currentIndex == QgsMeshRendererVectorSettings::Arrows );
   mHeadOptionsGroupBox->setVisible( currentIndex == QgsMeshRendererVectorSettings::Arrows );
   mTracesGroupBox->setVisible( currentIndex == QgsMeshRendererVectorSettings::Traces );

--- a/src/gui/mesh/qgsmeshrenderervectorsettingswidget.cpp
+++ b/src/gui/mesh/qgsmeshrenderervectorsettingswidget.cpp
@@ -261,6 +261,8 @@ void QgsMeshRendererVectorSettingsWidget::onSymbologyChanged( int currentIndex )
 {
   mStreamlineWidget->setVisible( currentIndex == QgsMeshRendererVectorSettings::Streamlines );
   mArrowWidget->setVisible( currentIndex == QgsMeshRendererVectorSettings::Arrows );
+  mArrowLengthGroupBox->setVisible( currentIndex == QgsMeshRendererVectorSettings::Arrows );
+  mHeadOptionsGroupBox->setVisible( currentIndex == QgsMeshRendererVectorSettings::Arrows );
   mTracesGroupBox->setVisible( currentIndex == QgsMeshRendererVectorSettings::Traces );
 
   mDisplayVectorsOnGridGroupBox->setVisible( currentIndex != QgsMeshRendererVectorSettings::Traces );

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -56,7 +56,6 @@
 #include <QPixmap>
 #include <QStatusBar>
 #include <QVariant>
-#include <QMenu>
 
 QgsMapToolIdentify::QgsMapToolIdentify( QgsMapCanvas *canvas )
   : QgsMapTool( canvas )

--- a/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
@@ -405,7 +405,7 @@
     </widget>
    </item>
    <item row="11" column="0" colspan="2">
-    <widget class="QGroupBox" name="headOptionsGroupBox">
+    <widget class="QGroupBox" name="mHeadOptionsGroupBox">
      <property name="title">
       <string>Head Options</string>
      </property>
@@ -465,7 +465,7 @@
     </widget>
    </item>
    <item row="12" column="0" colspan="2">
-    <widget class="QGroupBox" name="generalOptionsGroupBox">
+    <widget class="QGroupBox" name="mArrowLengthGroupBox">
      <property name="title">
       <string>Arrow Length</string>
      </property>

--- a/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
@@ -593,27 +593,6 @@
         </widget>
        </widget>
       </item>
-      <item>
-       <widget class="QWidget" name="mArrowWidget" native="true">
-        <layout class="QVBoxLayout" name="verticalLayout_4">
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-        </layout>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
Some ui groups only related to arrow symbology are visible when stream line or trace symbology are selected.
This PR fix this issue.