### PR TITLE
Add api to set the maximal extent for a project

### DIFF
--- a/python/core/auto_generated/geometry/qgsreferencedgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsreferencedgeometry.sip.in
@@ -77,8 +77,8 @@ Constructor for QgsReferencedRectangle.
 
     operator QVariant() const;
 
-    bool operator==( const QgsReferencedRectangle &other );
-    bool operator!=( const QgsReferencedRectangle &other );
+    bool operator==( const QgsReferencedRectangle &other ) const;
+    bool operator!=( const QgsReferencedRectangle &other ) const;
 
     SIP_PYOBJECT __repr__();
 %MethodCode

--- a/python/core/auto_generated/qgsprojectviewsettings.sip.in
+++ b/python/core/auto_generated/qgsprojectviewsettings.sip.in
@@ -182,6 +182,13 @@ Emitted when the list of custom project map scales changes.
 .. seealso:: :py:func:`setMapScales`
 %End
 
+    void presetFullExtentChanged();
+%Docstring
+Emitted whenever the :py:func:`~QgsProjectViewSettings.presetFullExtent` is changed.
+
+.. versionadded:: 3.18
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/qgsprojectviewsettings.sip.in
+++ b/python/core/auto_generated/qgsprojectviewsettings.sip.in
@@ -22,9 +22,11 @@ map canvas, e.g. map scales and default view extent for the project.
 %End
   public:
 
-    QgsProjectViewSettings( QObject *parent = 0 );
+    QgsProjectViewSettings( QgsProject *project = 0 );
 %Docstring
-Constructor for QgsProjectViewSettings with the specified ``parent`` object.
+Constructor for QgsProjectViewSettings for the specified ``project``.
+
+Ownership is transferred to the ``project``.
 %End
 
     void reset();
@@ -62,6 +64,49 @@ when this project is opened.
    view used when the project is opened for the very first time.
 
 .. seealso:: :py:func:`defaultViewExtent`
+%End
+
+    QgsReferencedRectangle presetFullExtent() const;
+%Docstring
+Returns the project's preset full extent.
+
+This extent represents the maximal limits of the project. The full extent defaults to a null rectangle,
+which indicates that the maximal extent should be calculated based on the layers in the project.
+
+.. seealso:: :py:func:`setPresetFullExtent`
+
+.. seealso:: :py:func:`fullExtent`
+
+.. versionadded:: 3.18
+%End
+
+    void setPresetFullExtent( const QgsReferencedRectangle &extent );
+%Docstring
+Sets the project's preset full ``extent``.
+
+This extent represents the maximal limits of the project. Setting the full ``extent`` to a null rectangle
+indicates that the maximal extent should be calculated based on the layers in the project.
+
+.. seealso:: :py:func:`setPresetFullExtent`
+
+.. seealso:: :py:func:`fullExtent`
+
+.. versionadded:: 3.18
+%End
+
+    QgsReferencedRectangle fullExtent() const;
+%Docstring
+Returns the full extent of the project, which represents the maximal limits of the project.
+
+The returned extent will be in the project's CRS.
+
+If the :py:func:`~QgsProjectViewSettings.presetFullExtent` is non null, this will be returned as the full extent.
+Otherwise the full extent will be calculated based on the extent of all layers
+in the project.
+
+.. seealso:: :py:func:`presetFullExtent`
+
+.. seealso:: :py:func:`setPresetFullExtent`
 %End
 
     void setMapScales( const QVector<double> &scales );

--- a/src/core/geometry/qgsreferencedgeometry.cpp
+++ b/src/core/geometry/qgsreferencedgeometry.cpp
@@ -26,12 +26,12 @@ QgsReferencedRectangle::QgsReferencedRectangle( const QgsRectangle &rect, const 
   , QgsReferencedGeometryBase( crs )
 {}
 
-bool QgsReferencedRectangle::operator==( const QgsReferencedRectangle &other )
+bool QgsReferencedRectangle::operator==( const QgsReferencedRectangle &other ) const
 {
   return QgsRectangle::operator==( other ) && crs() == other.crs();
 }
 
-bool QgsReferencedRectangle::operator!=( const QgsReferencedRectangle &other )
+bool QgsReferencedRectangle::operator!=( const QgsReferencedRectangle &other ) const
 {
   return !( *this == other );
 }

--- a/src/core/geometry/qgsreferencedgeometry.h
+++ b/src/core/geometry/qgsreferencedgeometry.h
@@ -91,8 +91,8 @@ class CORE_EXPORT QgsReferencedRectangle : public QgsRectangle, public QgsRefere
       return QVariant::fromValue( *this );
     }
 
-    bool operator==( const QgsReferencedRectangle &other );
-    bool operator!=( const QgsReferencedRectangle &other );
+    bool operator==( const QgsReferencedRectangle &other ) const;
+    bool operator!=( const QgsReferencedRectangle &other ) const;
 
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();

--- a/src/core/qgsprojectviewsettings.cpp
+++ b/src/core/qgsprojectviewsettings.cpp
@@ -15,10 +15,13 @@
 
 #include "qgsprojectviewsettings.h"
 #include "qgis.h"
+#include "qgsproject.h"
+#include "qgslogger.h"
 #include <QDomElement>
 
-QgsProjectViewSettings::QgsProjectViewSettings( QObject *parent )
-  : QObject( parent )
+QgsProjectViewSettings::QgsProjectViewSettings( QgsProject *project )
+  : QObject( project )
+  , mProject( project )
 {
 
 }
@@ -26,6 +29,7 @@ QgsProjectViewSettings::QgsProjectViewSettings( QObject *parent )
 void QgsProjectViewSettings::reset()
 {
   mDefaultViewExtent = QgsReferencedRectangle();
+  mPresetFullExtent = QgsReferencedRectangle();
   if ( mUseProjectScales || !mMapScales.empty() )
   {
     mUseProjectScales = false;
@@ -42,6 +46,85 @@ QgsReferencedRectangle QgsProjectViewSettings::defaultViewExtent() const
 void QgsProjectViewSettings::setDefaultViewExtent( const QgsReferencedRectangle &extent )
 {
   mDefaultViewExtent = extent;
+}
+
+QgsReferencedRectangle QgsProjectViewSettings::presetFullExtent() const
+{
+  return mPresetFullExtent;
+}
+
+void QgsProjectViewSettings::setPresetFullExtent( const QgsReferencedRectangle &extent )
+{
+  mPresetFullExtent = extent;
+}
+
+QgsReferencedRectangle QgsProjectViewSettings::fullExtent() const
+{
+  if ( !mProject )
+    return mPresetFullExtent;
+
+  if ( !mPresetFullExtent.isNull() )
+  {
+    QgsCoordinateTransform ct( mPresetFullExtent.crs(), mProject->crs(), mProject->transformContext() );
+    ct.setBallparkTransformsAreAppropriate( true );
+    return QgsReferencedRectangle( ct.transformBoundingBox( mPresetFullExtent ), mProject->crs() );
+  }
+  else
+  {
+    // reset the map canvas extent since the extent may now be smaller
+    // We can't use a constructor since QgsRectangle normalizes the rectangle upon construction
+    QgsRectangle fullExtent;
+    fullExtent.setMinimal();
+
+    // iterate through the map layers and test each layers extent
+    // against the current min and max values
+    const QMap<QString, QgsMapLayer *> layers = mProject->mapLayers( true );
+    QgsDebugMsgLevel( QStringLiteral( "Layer count: %1" ).arg( layers.count() ), 5 );
+    for ( auto it = layers.constBegin(); it != layers.constEnd(); ++it )
+    {
+      QgsDebugMsgLevel( "Updating extent using " + it.value()->name(), 5 );
+      QgsDebugMsgLevel( "Input extent: " + it.value()->extent().toString(), 5 );
+
+      if ( it.value()->extent().isNull() )
+        continue;
+
+      // Layer extents are stored in the coordinate system (CS) of the
+      // layer. The extent must be projected to the canvas CS
+      QgsCoordinateTransform ct( it.value()->crs(), mProject->crs(), mProject->transformContext() );
+      ct.setBallparkTransformsAreAppropriate( true );
+      const QgsRectangle extent = ct.transformBoundingBox( it.value()->extent() );
+
+      QgsDebugMsgLevel( "Output extent: " + extent.toString(), 5 );
+      fullExtent.combineExtentWith( extent );
+    }
+
+    if ( fullExtent.width() == 0.0 || fullExtent.height() == 0.0 )
+    {
+      // If all of the features are at the one point, buffer the
+      // rectangle a bit. If they are all at zero, do something a bit
+      // more crude.
+
+      if ( fullExtent.xMinimum() == 0.0 && fullExtent.xMaximum() == 0.0 &&
+           fullExtent.yMinimum() == 0.0 && fullExtent.yMaximum() == 0.0 )
+      {
+        fullExtent.set( -1.0, -1.0, 1.0, 1.0 );
+      }
+      else
+      {
+        const double padFactor = 1e-8;
+        double widthPad = fullExtent.xMinimum() * padFactor;
+        double heightPad = fullExtent.yMinimum() * padFactor;
+        double xmin = fullExtent.xMinimum() - widthPad;
+        double xmax = fullExtent.xMaximum() + widthPad;
+        double ymin = fullExtent.yMinimum() - heightPad;
+        double ymax = fullExtent.yMaximum() + heightPad;
+        fullExtent.set( xmin, ymin, xmax, ymax );
+      }
+    }
+
+    QgsDebugMsgLevel( "Full extent: " + fullExtent.toString(), 5 );
+    return QgsReferencedRectangle( fullExtent, mProject->crs() );
+  }
 }
 
 void QgsProjectViewSettings::setMapScales( const QVector<double> &scales )
@@ -116,6 +199,22 @@ bool QgsProjectViewSettings::readXml( const QDomElement &element, const QgsReadW
     mDefaultViewExtent = QgsReferencedRectangle();
   }
 
+  QDomElement presetViewElement = element.firstChildElement( QStringLiteral( "PresetFullExtent" ) );
+  if ( !presetViewElement.isNull() )
+  {
+    double xMin = presetViewElement.attribute( QStringLiteral( "xmin" ) ).toDouble();
+    double yMin = presetViewElement.attribute( QStringLiteral( "ymin" ) ).toDouble();
+    double xMax = presetViewElement.attribute( QStringLiteral( "xmax" ) ).toDouble();
+    double yMax = presetViewElement.attribute( QStringLiteral( "ymax" ) ).toDouble();
+    QgsCoordinateReferenceSystem crs;
+    crs.readXml( presetViewElement );
+    mPresetFullExtent = QgsReferencedRectangle( QgsRectangle( xMin, yMin, xMax, yMax ), crs );
+  }
+  else
+  {
+    mPresetFullExtent = QgsReferencedRectangle();
+  }
+
   return true;
 }
 
@@ -142,6 +241,17 @@ QDomElement QgsProjectViewSettings::writeXml( QDomDocument &doc, const QgsReadWr
     defaultViewElement.setAttribute( QStringLiteral( "ymax" ), qgsDoubleToString( mDefaultViewExtent.yMaximum() ) );
     mDefaultViewExtent.crs().writeXml( defaultViewElement, doc );
     element.appendChild( defaultViewElement );
+  }
+
+  if ( !mPresetFullExtent.isNull() )
+  {
+    QDomElement presetViewElement = doc.createElement( QStringLiteral( "PresetFullExtent" ) );
+    presetViewElement.setAttribute( QStringLiteral( "xmin" ), qgsDoubleToString( mPresetFullExtent.xMinimum() ) );
+    presetViewElement.setAttribute( QStringLiteral( "ymin" ), qgsDoubleToString( mPresetFullExtent.yMinimum() ) );
+    presetViewElement.setAttribute( QStringLiteral( "xmax" ), qgsDoubleToString( mPresetFullExtent.xMaximum() ) );
+    presetViewElement.setAttribute( QStringLiteral( "ymax" ), qgsDoubleToString( mPresetFullExtent.yMaximum() ) );
+    mPresetFullExtent.crs().writeXml( presetViewElement, doc );
+    element.appendChild( presetViewElement );
   }
 
   return element;

--- a/src/core/qgsprojectviewsettings.cpp
+++ b/src/core/qgsprojectviewsettings.cpp
@@ -29,7 +29,12 @@ QgsProjectViewSettings::QgsProjectViewSettings( QgsProject *project )
 void QgsProjectViewSettings::reset()
 {
   mDefaultViewExtent = QgsReferencedRectangle();
+
+  const bool fullExtentChanged = !mPresetFullExtent.isNull();
   mPresetFullExtent = QgsReferencedRectangle();
+  if ( fullExtentChanged )
+    emit presetFullExtentChanged();
+
   if ( mUseProjectScales || !mMapScales.empty() )
   {
     mUseProjectScales = false;
@@ -55,7 +60,11 @@ QgsReferencedRectangle QgsProjectViewSettings::presetFullExtent() const
 
 void QgsProjectViewSettings::setPresetFullExtent( const QgsReferencedRectangle &extent )
 {
+  if ( extent == mPresetFullExtent )
+    return;
+
   mPresetFullExtent = extent;
+  emit presetFullExtentChanged();
 }
 
 QgsReferencedRectangle QgsProjectViewSettings::fullExtent() const
@@ -208,11 +217,11 @@ bool QgsProjectViewSettings::readXml( const QDomElement &element, const QgsReadW
     double yMax = presetViewElement.attribute( QStringLiteral( "ymax" ) ).toDouble();
     QgsCoordinateReferenceSystem crs;
     crs.readXml( presetViewElement );
-    mPresetFullExtent = QgsReferencedRectangle( QgsRectangle( xMin, yMin, xMax, yMax ), crs );
+    setPresetFullExtent( QgsReferencedRectangle( QgsRectangle( xMin, yMin, xMax, yMax ), crs ) );
   }
   else
   {
-    mPresetFullExtent = QgsReferencedRectangle();
+    setPresetFullExtent( QgsReferencedRectangle() );
   }
 
   return true;

--- a/src/core/qgsprojectviewsettings.h
+++ b/src/core/qgsprojectviewsettings.h
@@ -184,6 +184,13 @@ class CORE_EXPORT QgsProjectViewSettings : public QObject
      */
     void mapScalesChanged();
 
+    /**
+     * Emitted whenever the presetFullExtent() is changed.
+     *
+     * \since QGIS 3.18
+     */
+    void presetFullExtentChanged();
+
   private:
 
     QgsProject *mProject = nullptr;

--- a/src/core/qgsprojectviewsettings.h
+++ b/src/core/qgsprojectviewsettings.h
@@ -23,6 +23,7 @@
 class QDomElement;
 class QgsReadWriteContext;
 class QDomDocument;
+class QgsProject;
 
 /**
  * Contains settings and properties relating to how a QgsProject should be displayed inside
@@ -38,9 +39,11 @@ class CORE_EXPORT QgsProjectViewSettings : public QObject
   public:
 
     /**
-     * Constructor for QgsProjectViewSettings with the specified \a parent object.
+     * Constructor for QgsProjectViewSettings for the specified \a project.
+     *
+     * Ownership is transferred to the \a project.
      */
-    QgsProjectViewSettings( QObject *parent = nullptr );
+    QgsProjectViewSettings( QgsProject *project = nullptr );
 
     /**
      * Resets the settings to a default state.
@@ -74,6 +77,46 @@ class CORE_EXPORT QgsProjectViewSettings : public QObject
      * \see defaultViewExtent()
      */
     void setDefaultViewExtent( const QgsReferencedRectangle &extent );
+
+    /**
+     * Returns the project's preset full extent.
+     *
+     * This extent represents the maximal limits of the project. The full extent defaults to a null rectangle,
+     * which indicates that the maximal extent should be calculated based on the layers in the project.
+     *
+     * \see setPresetFullExtent()
+     * \see fullExtent()
+     *
+     * \since QGIS 3.18
+     */
+    QgsReferencedRectangle presetFullExtent() const;
+
+    /**
+     * Sets the project's preset full \a extent.
+     *
+     * This extent represents the maximal limits of the project. Setting the full \a extent to a null rectangle
+     * indicates that the maximal extent should be calculated based on the layers in the project.
+     *
+     * \see setPresetFullExtent()
+     * \see fullExtent()
+     *
+     * \since QGIS 3.18
+     */
+    void setPresetFullExtent( const QgsReferencedRectangle &extent );
+
+    /**
+     * Returns the full extent of the project, which represents the maximal limits of the project.
+     *
+     * The returned extent will be in the project's CRS.
+     *
+     * If the presetFullExtent() is non null, this will be returned as the full extent.
+     * Otherwise the full extent will be calculated based on the extent of all layers
+     * in the project.
+     *
+     * \see presetFullExtent()
+     * \see setPresetFullExtent()
+     */
+    QgsReferencedRectangle fullExtent() const;
 
     /**
      * Sets the list of custom project map \a scales.
@@ -143,9 +186,11 @@ class CORE_EXPORT QgsProjectViewSettings : public QObject
 
   private:
 
+    QgsProject *mProject = nullptr;
     QVector<double> mMapScales;
     bool mUseProjectScales = false;
     QgsReferencedRectangle mDefaultViewExtent;
+    QgsReferencedRectangle mPresetFullExtent;
 };
 
 #endif // QGSPROJECTVIEWSETTINGS_H

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1049,20 +1049,30 @@ void QgsMapCanvas::saveAsImage( const QString &fileName, QPixmap *theQPixmap, co
   }
   QTextStream myStream( &myWorldFile );
   myStream << QgsMapSettingsUtils::worldFileContent( mapSettings() );
-} // saveAsImage
-
-
+}
 
 QgsRectangle QgsMapCanvas::extent() const
 {
   return mapSettings().visibleExtent();
-} // extent
+}
 
 QgsRectangle QgsMapCanvas::fullExtent() const
 {
-  return mapSettings().fullExtent();
-} // extent
+  const QgsReferencedRectangle extent = QgsProject::instance()->viewSettings()->fullExtent();
+  QgsCoordinateTransform ct( extent.crs(), QgsProject::instance()->crs(), QgsProject::instance()->transformContext() );
+  ct.setBallparkTransformsAreAppropriate( true );
+  QgsRectangle rect;
+  try
+  {
+    rect = ct.transformBoundingBox( extent );
+  }
+  catch ( QgsCsException & )
+  {
+    rect = mapSettings().fullExtent();
+  }
 
+  return rect;
+}
 
 void QgsMapCanvas::setExtent( const QgsRectangle &r, bool magnified )
 {

--- a/src/gui/qgsmapoverviewcanvas.cpp
+++ b/src/gui/qgsmapoverviewcanvas.cpp
@@ -48,6 +48,8 @@ QgsMapOverviewCanvas::QgsMapOverviewCanvas( QWidget *parent, QgsMapCanvas *mapCa
   connect( mMapCanvas, &QgsMapCanvas::extentsChanged, this, &QgsMapOverviewCanvas::drawExtentRect );
   connect( mMapCanvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsMapOverviewCanvas::destinationCrsChanged );
   connect( mMapCanvas, &QgsMapCanvas::transformContextChanged, this, &QgsMapOverviewCanvas::transformContextChanged );
+
+  connect( QgsProject::instance()->viewSettings(), &QgsProjectViewSettings::presetFullExtentChanged, this, &QgsMapOverviewCanvas::updateFullExtent );
 }
 
 void QgsMapOverviewCanvas::resizeEvent( QResizeEvent *e )

--- a/src/gui/qgsmapoverviewcanvas.cpp
+++ b/src/gui/qgsmapoverviewcanvas.cpp
@@ -252,15 +252,22 @@ void QgsMapOverviewCanvas::setLayers( const QList<QgsMapLayer *> &layers )
 
 void QgsMapOverviewCanvas::updateFullExtent()
 {
-  QgsReferencedRectangle extent = QgsProject::instance()->viewSettings()->fullExtent();
-  QgsCoordinateTransform ct( extent.crs(), mSettings.destinationCrs(), QgsProject::instance()->transformContext() );
-  ct.setBallparkTransformsAreAppropriate( true );
   QgsRectangle rect;
-  try
+  if ( !QgsProject::instance()->viewSettings()->presetFullExtent().isNull() )
   {
-    rect = ct.transformBoundingBox( extent );
+    QgsReferencedRectangle extent = QgsProject::instance()->viewSettings()->fullExtent();
+    QgsCoordinateTransform ct( extent.crs(), mSettings.destinationCrs(), QgsProject::instance()->transformContext() );
+    ct.setBallparkTransformsAreAppropriate( true );
+    try
+    {
+      rect = ct.transformBoundingBox( extent );
+    }
+    catch ( QgsCsException & )
+    {
+    }
   }
-  catch ( QgsCsException & )
+
+  if ( rect.isNull() )
   {
     if ( mSettings.hasValidSettings() )
       rect = mSettings.fullExtent();

--- a/tests/src/python/test_qgsprojectviewsettings.py
+++ b/tests/src/python/test_qgsprojectviewsettings.py
@@ -141,6 +141,25 @@ class TestQgsProjectViewSettings(unittest.TestCase):
         p.reset()
         self.assertTrue(p.presetFullExtent().isNull())
 
+    def testPresetFullExtentChangedSignal(self):
+        p = QgsProjectViewSettings()
+        spy = QSignalSpy(p.presetFullExtentChanged)
+
+        p.setPresetFullExtent(QgsReferencedRectangle(QgsRectangle(1, 2, 3, 4), QgsCoordinateReferenceSystem("EPSG:3857")))
+        self.assertEqual(len(spy), 1)
+
+        p.setPresetFullExtent(QgsReferencedRectangle(QgsRectangle(1, 2, 3, 4), QgsCoordinateReferenceSystem("EPSG:3857")))
+        self.assertEqual(len(spy), 1)
+
+        p.setPresetFullExtent(QgsReferencedRectangle(QgsRectangle(1, 2, 3, 4), QgsCoordinateReferenceSystem("EPSG:4326")))
+        self.assertEqual(len(spy), 2)
+
+        p.reset()
+        self.assertEqual(len(spy), 3)
+
+        p.reset()
+        self.assertEqual(len(spy), 3)
+
     def testFullExtent(self):
         p = QgsProject()
         p.setCrs(QgsCoordinateReferenceSystem('EPSG:3857'))

--- a/tests/src/python/test_qgsprojectviewsettings.py
+++ b/tests/src/python/test_qgsprojectviewsettings.py
@@ -11,13 +11,18 @@ __date__ = '30/10/2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
 
 import qgis  # NOQA
+import os
 
 from qgis.core import (QgsProject,
                        QgsProjectViewSettings,
                        QgsReadWriteContext,
                        QgsReferencedRectangle,
                        QgsRectangle,
-                       QgsCoordinateReferenceSystem)
+                       QgsCoordinateReferenceSystem,
+                       QgsVectorLayer,
+                       QgsFeature,
+                       QgsGeometry,
+                       QgsPointXY)
 from qgis.gui import QgsMapCanvas
 
 from qgis.PyQt.QtCore import QTemporaryDir
@@ -122,6 +127,78 @@ class TestQgsProjectViewSettings(unittest.TestCase):
         self.assertAlmostEqual(canvas.extent().yMaximum(), 0.02245788, 3)
         self.assertEqual(canvas.mapSettings().destinationCrs().authid(), 'EPSG:4326')
 
+    def testPresetFullExtent(self):
+        p = QgsProjectViewSettings()
+        self.assertTrue(p.presetFullExtent().isNull())
+
+        p.setPresetFullExtent(QgsReferencedRectangle(QgsRectangle(1, 2, 3, 4), QgsCoordinateReferenceSystem("EPSG:3857")))
+        self.assertEqual(p.presetFullExtent(), QgsReferencedRectangle(QgsRectangle(1, 2, 3, 4), QgsCoordinateReferenceSystem("EPSG:3857")))
+
+        p.setPresetFullExtent(QgsReferencedRectangle())
+        self.assertTrue(p.presetFullExtent().isNull())
+
+        p.setPresetFullExtent(QgsReferencedRectangle(QgsRectangle(1, 2, 3, 4), QgsCoordinateReferenceSystem("EPSG:3857")))
+        p.reset()
+        self.assertTrue(p.presetFullExtent().isNull())
+
+    def testFullExtent(self):
+        p = QgsProject()
+        p.setCrs(QgsCoordinateReferenceSystem('EPSG:3857'))
+        self.assertTrue(p.viewSettings().fullExtent().isNull())
+
+        p.viewSettings().setPresetFullExtent(QgsReferencedRectangle(QgsRectangle(1, 2, 3, 4), QgsCoordinateReferenceSystem("EPSG:4326")))
+        self.assertAlmostEqual(p.viewSettings().fullExtent().xMinimum(), 111319, -1)
+        self.assertAlmostEqual(p.viewSettings().fullExtent().xMaximum(), 333958, -1)
+        self.assertAlmostEqual(p.viewSettings().fullExtent().yMinimum(), 222684, -1)
+        self.assertAlmostEqual(p.viewSettings().fullExtent().yMaximum(), 445640, -1)
+        self.assertEqual(p.viewSettings().fullExtent().crs().authid(), 'EPSG:3857')
+
+        # add layers
+        shapefile = os.path.join(TEST_DATA_DIR, 'polys.shp')
+        layer = QgsVectorLayer(shapefile, 'Polys', 'ogr')
+        p.addMapLayer(layer)
+        # no change, because preset extent is set
+        self.assertAlmostEqual(p.viewSettings().fullExtent().xMinimum(), 111319, -1)
+        self.assertAlmostEqual(p.viewSettings().fullExtent().xMaximum(), 333958, -1)
+        self.assertAlmostEqual(p.viewSettings().fullExtent().yMinimum(), 222684, -1)
+        self.assertAlmostEqual(p.viewSettings().fullExtent().yMaximum(), 445640, -1)
+        self.assertEqual(p.viewSettings().fullExtent().crs().authid(), 'EPSG:3857')
+        # remove preset extent
+        p.viewSettings().setPresetFullExtent(QgsReferencedRectangle())
+        # extent should come from layers
+        self.assertAlmostEqual(p.viewSettings().fullExtent().xMinimum(), -13238432, -2)
+        self.assertAlmostEqual(p.viewSettings().fullExtent().xMaximum(), -9327461, -2)
+        self.assertAlmostEqual(p.viewSettings().fullExtent().yMinimum(), 2815417, -2)
+        self.assertAlmostEqual(p.viewSettings().fullExtent().yMaximum(), 5897492, -2)
+        self.assertEqual(p.viewSettings().fullExtent().crs().authid(), 'EPSG:3857')
+
+        # add another layer
+        shapefile = os.path.join(TEST_DATA_DIR, 'lines.shp')
+        layer = QgsVectorLayer(shapefile, 'Lines', 'ogr')
+        p.addMapLayer(layer)
+        self.assertAlmostEqual(p.viewSettings().fullExtent().xMinimum(), -13238432, -2)
+        self.assertAlmostEqual(p.viewSettings().fullExtent().xMaximum(), -9164115, -2)
+        self.assertAlmostEqual(p.viewSettings().fullExtent().yMinimum(), 2657217, -2)
+        self.assertAlmostEqual(p.viewSettings().fullExtent().yMaximum(), 5897492, -2)
+        self.assertEqual(p.viewSettings().fullExtent().crs().authid(), 'EPSG:3857')
+
+        # add a layer with a different crs
+        layer = QgsVectorLayer("Point?crs=EPSG:3857&field=fldtxt:string&field=fldint:integer",
+                               "x", "memory")
+        p.addMapLayer(layer)
+        f = QgsFeature()
+        f.setAttributes(["test", 123])
+        f.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(-8164115, 5997492)))
+        layer.startEditing()
+        layer.addFeatures([f])
+        layer.commitChanges()
+
+        self.assertAlmostEqual(p.viewSettings().fullExtent().xMinimum(), -13238432, -2)
+        self.assertAlmostEqual(p.viewSettings().fullExtent().xMaximum(), -8164115, -2)
+        self.assertAlmostEqual(p.viewSettings().fullExtent().yMinimum(), 2657217, -2)
+        self.assertAlmostEqual(p.viewSettings().fullExtent().yMaximum(), 5997492, -2)
+        self.assertEqual(p.viewSettings().fullExtent().crs().authid(), 'EPSG:3857')
+
     def testReadWrite(self):
         p = QgsProjectViewSettings()
         self.assertFalse(p.mapScales())
@@ -140,6 +217,8 @@ class TestQgsProjectViewSettings(unittest.TestCase):
         p.setUseProjectScales(True)
         p.setMapScales([56, 78, 99])
         p.setDefaultViewExtent(QgsReferencedRectangle(QgsRectangle(1, 2, 3, 4), QgsCoordinateReferenceSystem("EPSG:3857")))
+        p.setPresetFullExtent(
+            QgsReferencedRectangle(QgsRectangle(11, 12, 13, 14), QgsCoordinateReferenceSystem("EPSG:3111")))
         elem = p.writeXml(doc, QgsReadWriteContext())
 
         p2 = QgsProjectViewSettings()
@@ -149,6 +228,8 @@ class TestQgsProjectViewSettings(unittest.TestCase):
         self.assertTrue(p2.useProjectScales())
         self.assertEqual(len(spy), 1)
         self.assertEqual(p2.defaultViewExtent(), QgsReferencedRectangle(QgsRectangle(1, 2, 3, 4), QgsCoordinateReferenceSystem("EPSG:3857")))
+        self.assertEqual(p2.presetFullExtent(),
+                         QgsReferencedRectangle(QgsRectangle(11, 12, 13, 14), QgsCoordinateReferenceSystem("EPSG:3111")))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If set, this extent will be used when zooming to full extent (or for the
full extent for a map overview frame) instead of the extent calculated
from all map layers.

The intention is to eventually allow users a way to manually set their
desired "area of interest" for a project, so that zooming to full extent
won't zoom all the way out when the project contains global or national
datasets...

Sponsored by SLYR