### PR TITLE
allow use poly2tri from system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,10 +217,13 @@ if(WITH_CORE)
   endif()
 
   # try to configure and build MDAL support
-  set (WITH_INTERNAL_MDAL TRUE CACHE BOOL "Determines whether MDAL support should be built")
+  set (WITH_INTERNAL_MDAL TRUE CACHE BOOL "Determines whether MDAL should be built from internal copy")
   if (NOT WITH_INTERNAL_MDAL)
     set (MDAL_PREFIX "" CACHE PATH "Path to MDAL base directory")
   endif()
+
+  # try to configure and build POLY2TRI support
+  set (WITH_INTERNAL_POLY2TRI TRUE CACHE BOOL "Determines whether POLY2TRI should be built from internal copy")
 
   # try to configure and build POSTGRESQL support
   set (WITH_POSTGRESQL TRUE CACHE BOOL "Determines whether POSTGRESQL support should be built")
@@ -367,6 +370,10 @@ if(WITH_CORE)
 
   if (NOT WITH_INTERNAL_MDAL)
     find_package(MDAL REQUIRED) # MDAL provider
+  endif()
+
+  if (NOT WITH_INTERNAL_POLY2TRI)
+    find_package(Poly2Tri REQUIRED)
   endif()
 
   find_package(SpatiaLite REQUIRED)

--- a/cmake/FindPoly2Tri.cmake
+++ b/cmake/FindPoly2Tri.cmake
@@ -1,0 +1,23 @@
+# Find Poly2Tri
+# ~~~~~~~~~
+# Copyright (c) 2020, Peter Petrik <zilolv at gmail dot com>
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+#
+# Once run this will define: 
+#  Poly2Tri_FOUND - System has Poly2Tri
+#  Poly2Tri_INCLUDE_DIR - The Poly2Tri include directory
+#  Poly2Tri_LIBRARY - The library needed to use Poly2Tri
+
+FIND_PATH(Poly2Tri_INCLUDE_DIR poly2tri.h
+          HINTS $ENV{LIB_DIR}/include)
+
+FIND_LIBRARY(Poly2Tri_LIBRARY NAMES poly2tri libpoly2tri
+             HINTS $ENV{LIB_DIR}/lib)
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Poly2Tri DEFAULT_MSG
+                                  Poly2Tri_LIBRARY Poly2Tri_INCLUDE_DIR)
+
+MARK_AS_ADVANCED( Poly2Tri_INCLUDE_DIR Poly2Tri_LIBRARY )

--- a/cmake/FindPoly2Tri.cmake
+++ b/cmake/FindPoly2Tri.cmake
@@ -10,14 +10,15 @@
 #  Poly2Tri_INCLUDE_DIR - The Poly2Tri include directory
 #  Poly2Tri_LIBRARY - The library needed to use Poly2Tri
 
-FIND_PATH(Poly2Tri_INCLUDE_DIR poly2tri.h
+find_path(Poly2Tri_INCLUDE_DIR poly2tri.h
           HINTS $ENV{LIB_DIR}/include)
 
-FIND_LIBRARY(Poly2Tri_LIBRARY NAMES poly2tri libpoly2tri
+find_library(Poly2Tri_LIBRARY NAMES poly2tri libpoly2tri
              HINTS $ENV{LIB_DIR}/lib)
 
-INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(Poly2Tri DEFAULT_MSG
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(Poly2Tri DEFAULT_MSG
                                   Poly2Tri_LIBRARY Poly2Tri_INCLUDE_DIR)
 
-MARK_AS_ADVANCED( Poly2Tri_INCLUDE_DIR Poly2Tri_LIBRARY )
+mark_as_advanced( Poly2Tri_INCLUDE_DIR Poly2Tri_LIBRARY )

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -11,11 +11,6 @@ set(QGIS_CORE_SRCS
   ${CMAKE_SOURCE_DIR}/external/nmea/time.c
   ${CMAKE_SOURCE_DIR}/external/nmea/tok.c
 
-  ${CMAKE_SOURCE_DIR}/external/poly2tri/common/shapes.cc
-  ${CMAKE_SOURCE_DIR}/external/poly2tri/sweep/advancing_front.cc
-  ${CMAKE_SOURCE_DIR}/external/poly2tri/sweep/cdt.cc
-  ${CMAKE_SOURCE_DIR}/external/poly2tri/sweep/sweep_context.cc
-  ${CMAKE_SOURCE_DIR}/external/poly2tri/sweep/sweep.cc
   ${CMAKE_SOURCE_DIR}/external/meshOptimizer/simplifier.cpp
 
   callouts/qgscallout.cpp
@@ -733,6 +728,19 @@ set(QGIS_CORE_SRCS
   qgsuserprofile.cpp
   qgsuserprofilemanager.cpp
 )
+
+if (WITH_INTERNAL_POLY2TRI)
+  set(QGIS_CORE_SRCS ${QGIS_CORE_SRCS}
+    ${CMAKE_SOURCE_DIR}/external/poly2tri/common/shapes.cc
+    ${CMAKE_SOURCE_DIR}/external/poly2tri/sweep/advancing_front.cc
+    ${CMAKE_SOURCE_DIR}/external/poly2tri/sweep/cdt.cc
+    ${CMAKE_SOURCE_DIR}/external/poly2tri/sweep/sweep_context.cc
+    ${CMAKE_SOURCE_DIR}/external/poly2tri/sweep/sweep.cc
+  )
+  include_directories(${CMAKE_SOURCE_DIR}/external/poly2tri)
+else (WITH_INTERNAL_POLY2TRI)
+  include_directories(${Poly2Tri_INCLUDE_DIR})
+endif (WITH_INTERNAL_POLY2TRI)
 
 file(GLOB JSON_HELP_FILES "${CMAKE_SOURCE_DIR}/resources/function_help/json/*")
 if(CMAKE_VERSION VERSION_LESS "3.18" AND NOT USING_NINJA)
@@ -1624,7 +1632,6 @@ include_directories(
   ${CMAKE_SOURCE_DIR}/external/nlohmann
   ${CMAKE_SOURCE_DIR}/external/kdbush/include
   ${CMAKE_SOURCE_DIR}/external/nmea
-  ${CMAKE_SOURCE_DIR}/external/poly2tri
   ${CMAKE_SOURCE_DIR}/external/rtree/include
   ${CMAKE_SOURCE_DIR}/external/meshOptimizer
 )
@@ -1730,6 +1737,9 @@ if(ENABLE_MODELTEST)
   target_link_libraries(qgis_core ${Qt5Test_LIBRARIES})
 endif()
 
+if (NOT WITH_INTERNAL_POLY2TRI)
+   target_link_libraries(qgis_core ${Poly2Tri_LIBRARY})
+endif()
 
 if(HAVE_OPENCL)
   target_link_libraries(qgis_core ${OpenCL_LIBRARY})

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -738,9 +738,9 @@ if (WITH_INTERNAL_POLY2TRI)
     ${CMAKE_SOURCE_DIR}/external/poly2tri/sweep/sweep.cc
   )
   include_directories(${CMAKE_SOURCE_DIR}/external/poly2tri)
-else (WITH_INTERNAL_POLY2TRI)
+else ()
   include_directories(${Poly2Tri_INCLUDE_DIR})
-endif (WITH_INTERNAL_POLY2TRI)
+endif ()
 
 file(GLOB JSON_HELP_FILES "${CMAKE_SOURCE_DIR}/resources/function_help/json/*")
 if(CMAKE_VERSION VERSION_LESS "3.18" AND NOT USING_NINJA)


### PR DESCRIPTION
allow usage of poly2tri, especially on iOS where we build everything statically it is problem since Qt has internal poly2tri library too and it conflicts with qgis_core one 

```
peter@pp-mb:~/Projects/quick/QGIS$ find /opt/Qt/5.14.2/ios/ -name "*poly2tri*"
/opt/Qt/5.14.2/ios//lib/libpoly2tri.a
/opt/Qt/5.14.2/ios//lib/libpoly2tri_debug.a
/opt/Qt/5.14.2/ios//lib/libpoly2tri.prl
/opt/Qt/5.14.2/ios//lib/libpoly2tri_debug.prl
```