### PR TITLE
Fix Qt5LinguistTools detection/lrelease binary location

### DIFF
--- a/i18n/CMakeLists.txt
+++ b/i18n/CMakeLists.txt
@@ -1,4 +1,5 @@
-find_program(QT_LRELEASE_EXECUTABLE NAMES lrelease-qt5 lrelease)
+find_package(Qt5LinguistTools REQUIRED)
+set(QT_LRELEASE_EXECUTABLE Qt5::lrelease)
 
 macro(ADD_TRANSLATION_FILES _sources )
     foreach (_current_FILE ${ARGN})


### PR DESCRIPTION
Correctly find the Qt5 module that provides the path to Qt5-based lrelease.
Available since >= Qt-5.3.1 which is well below the current minimum for QGIS.

Fixes build error when lrelease is not provided in PATH: `/bin/sh: QT_LRELEASE_EXECUTABLE-NOTFOUND: command not found`