### PR TITLE
select feature context menu

### DIFF
--- a/python/gui/auto_generated/qgsmaptool.sip.in
+++ b/python/gui/auto_generated/qgsmaptool.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 %ModuleHeaderCode
 // fix to allow compilation with sip 4.7 that for some reason
 // doesn't add these includes to the file where the code from
@@ -194,13 +195,15 @@ The values is calculated from :py:func:`~QgsMapTool.searchRadiusMM`.
 .. versionadded:: 2.3
 %End
 
-    virtual void populateContextMenu( QMenu *menu );
+    virtual void populateContextMenu( QMenu *menu, QgsMapMouseEvent *event = 0 );
 %Docstring
 Allows the tool to populate and customize the given ``menu``,
 prior to showing it in response to a right-mouse button click.
 
 ``menu`` will be initially populated with a set of default, generic actions.
 Any new actions added to the menu should be correctly parented to ``menu``.
+
+A pointer to the map mouse ``event`` can be provided to allow particular behavior depending on the map tool.
 
 The default implementation does nothing.
 

--- a/python/gui/auto_generated/qgsmaptool.sip.in
+++ b/python/gui/auto_generated/qgsmaptool.sip.in
@@ -223,7 +223,7 @@ Any new actions added to the menu should be correctly parented to ``menu``.
 
 A pointer to the map mouse ``event`` can be provided to allow particular behavior depending on the map tool.
 
-This method can return true to inform the caller that the menu was effectivly populated.
+This method can return true to inform the caller that the menu was effectively populated.
 
 The default implementation does nothing and returns false.
 

--- a/python/gui/auto_generated/qgsmaptool.sip.in
+++ b/python/gui/auto_generated/qgsmaptool.sip.in
@@ -225,14 +225,14 @@ A pointer to the map mouse ``event`` can be provided to allow particular behavio
 
 This method can return true to inform the caller that the menu was effectivly populated.
 
-The default implementation does nothing and return false;
+The default implementation does nothing and returns false.
 
 .. note::
 
    The context menu is only shown when the ShowContextMenu flag
    is present in :py:func:`~QgsMapTool.flags`.
 
-.. versionadded:: 3.14
+.. versionadded:: 3.18
 %End
 
   signals:

--- a/python/gui/auto_generated/qgsmaptool.sip.in
+++ b/python/gui/auto_generated/qgsmaptool.sip.in
@@ -195,7 +195,25 @@ The values is calculated from :py:func:`~QgsMapTool.searchRadiusMM`.
 .. versionadded:: 2.3
 %End
 
-    virtual void populateContextMenu( QMenu *menu, QgsMapMouseEvent *event = 0 );
+    virtual void populateContextMenu( QMenu *menu );
+%Docstring
+Allows the tool to populate and customize the given ``menu``,
+prior to showing it in response to a right-mouse button click.
+
+``menu`` will be initially populated with a set of default, generic actions.
+Any new actions added to the menu should be correctly parented to ``menu``.
+
+The default implementation does nothing.
+
+.. note::
+
+   The context menu is only shown when the ShowContextMenu flag
+   is present in :py:func:`~QgsMapTool.flags`.
+
+.. versionadded:: 3.14
+%End
+
+    virtual bool populateContextMenuWithEvent( QMenu *menu, QgsMapMouseEvent *event );
 %Docstring
 Allows the tool to populate and customize the given ``menu``,
 prior to showing it in response to a right-mouse button click.
@@ -205,7 +223,9 @@ Any new actions added to the menu should be correctly parented to ``menu``.
 
 A pointer to the map mouse ``event`` can be provided to allow particular behavior depending on the map tool.
 
-The default implementation does nothing.
+This method can return true to inform the caller that the menu was effectivly populated.
+
+The default implementation does nothing and return false;
 
 .. note::
 

--- a/src/app/qgsmaptoolselect.cpp
+++ b/src/app/qgsmaptoolselect.cpp
@@ -143,6 +143,7 @@ QgsMapTool::Flags QgsMapToolSelect::flags() const
 
 bool QgsMapToolSelect::populateContextMenuWithEvent( QMenu *menu, QgsMapMouseEvent *event )
 {
+  Q_ASSERT( menu );
   menu->addSeparator();
   QgsVectorLayer *vlayer = QgsMapToolSelectUtils::getCurrentVectorLayer( mCanvas );
 

--- a/src/app/qgsmaptoolselect.cpp
+++ b/src/app/qgsmaptoolselect.cpp
@@ -169,6 +169,8 @@ bool QgsMapToolSelect::populateContextMenuWithEvent( QMenu *menu, QgsMapMouseEve
 
   menuActions->populateMenu( menu );
 
+  // cppcheck wrongly believes menuActions will leak
+  // cppcheck-suppress memleak
   return true;
 }
 

--- a/src/app/qgsmaptoolselect.cpp
+++ b/src/app/qgsmaptoolselect.cpp
@@ -141,9 +141,7 @@ QgsMapTool::Flags QgsMapToolSelect::flags() const
   return QgsMapTool::flags();
 }
 
-
-
-void QgsMapToolSelect::populateContextMenu( QMenu *menu, QgsMapMouseEvent *event )
+bool QgsMapToolSelect::populateContextMenuWithEvent( QMenu *menu, QgsMapMouseEvent *event )
 {
   menu->addSeparator();
   QgsVectorLayer *vlayer = QgsMapToolSelectUtils::getCurrentVectorLayer( mCanvas );
@@ -163,13 +161,14 @@ void QgsMapToolSelect::populateContextMenu( QMenu *menu, QgsMapMouseEvent *event
   else if ( modifiers & Qt::ControlModifier )
     behavior = QgsVectorLayer::RemoveFromSelection;
 
-  QgsMapToolSelectUtils::QgsMapToolSelectMenuActions *menuActions
-    = new QgsMapToolSelectUtils::QgsMapToolSelectMenuActions( mCanvas, vlayer, behavior, menu );
-
   QgsRectangle r = QgsMapToolSelectUtils::expandSelectRectangle( mapPoint, mCanvas, vlayer );
-  QgsFeatureIds selectedFeatures = QgsMapToolSelectUtils::getMatchingFeatures( mCanvas, QgsGeometry::fromRect( r ), false, false );
 
-  menu->addActions( menuActions->actions( selectedFeatures ) );
+  QgsMapToolSelectUtils::QgsMapToolSelectMenuActions *menuActions
+    = new QgsMapToolSelectUtils::QgsMapToolSelectMenuActions( mCanvas, vlayer, behavior, QgsGeometry::fromRect( r ), menu );
+
+  menuActions->populateMenu( menu );
+
+  return true;
 }
 
 void QgsMapToolSelect::selectFeatures( Qt::KeyboardModifiers modifiers )
@@ -204,21 +203,3 @@ void QgsMapToolSelect::modifiersChanged( bool ctrlModifier, bool shiftModifier, 
   else if ( ctrlModifier && shiftModifier && altModifier )
     emit modeChanged( GeometryWithinIntersectWithSelection );
 }
-
-void QgsMapToolSelect::highlightFeature( const QgsFeatureId &id, QgsVectorLayer *layer )
-{
-  for ( QgsHighlight *hl : mHighlights )
-    delete hl;
-
-  mHighlights.clear();
-
-  QgsFeature feat = layer->getFeature( id );
-  mHighlights.append( new QgsHighlight( mCanvas, feat.geometry(), layer ) );
-
-}
-
-
-
-
-
-

--- a/src/app/qgsmaptoolselect.cpp
+++ b/src/app/qgsmaptoolselect.cpp
@@ -144,8 +144,12 @@ QgsMapTool::Flags QgsMapToolSelect::flags() const
 bool QgsMapToolSelect::populateContextMenuWithEvent( QMenu *menu, QgsMapMouseEvent *event )
 {
   Q_ASSERT( menu );
-  menu->addSeparator();
   QgsVectorLayer *vlayer = QgsMapToolSelectUtils::getCurrentVectorLayer( mCanvas );
+
+  if ( !vlayer )
+    return false;
+
+  menu->addSeparator();
 
   Qt::KeyboardModifiers modifiers = Qt::NoModifier;
   QgsPointXY mapPoint;

--- a/src/app/qgsmaptoolselect.cpp
+++ b/src/app/qgsmaptoolselect.cpp
@@ -205,15 +205,15 @@ void QgsMapToolSelect::modifiersChanged( bool ctrlModifier, bool shiftModifier, 
     emit modeChanged( GeometryWithinIntersectWithSelection );
 }
 
-void QgsMapToolSelect::hightLightFeature( const QgsFeatureId &id, QgsVectorLayer *layer )
+void QgsMapToolSelect::highlightFeature( const QgsFeatureId &id, QgsVectorLayer *layer )
 {
-  for ( QgsHighlight *hl : mHightlights )
+  for ( QgsHighlight *hl : mHighlights )
     delete hl;
 
-  mHightlights.clear();
+  mHighlights.clear();
 
   QgsFeature feat = layer->getFeature( id );
-  mHightlights.append( new QgsHighlight( mCanvas, feat.geometry(), layer ) );
+  mHighlights.append( new QgsHighlight( mCanvas, feat.geometry(), layer ) );
 
 }
 

--- a/src/app/qgsmaptoolselect.h
+++ b/src/app/qgsmaptoolselect.h
@@ -21,6 +21,8 @@
 #include "qgsmaptoolselectionhandler.h"
 
 class QgsMapCanvas;
+class QgsHighlight;
+
 class QMouseEvent;
 
 class APP_EXPORT QgsMapToolSelect : public QgsMapTool
@@ -52,6 +54,9 @@ class APP_EXPORT QgsMapToolSelect : public QgsMapTool
     void deactivate() override;
     Flags flags() const override;
 
+
+    void populateContextMenu( QMenu *menu, QgsMapMouseEvent *event = nullptr ) override;
+
   signals:
 
     void modeChanged( Mode mode );
@@ -63,6 +68,11 @@ class APP_EXPORT QgsMapToolSelect : public QgsMapTool
     std::unique_ptr<QgsMapToolSelectionHandler> mSelectionHandler;
 
     void modifiersChanged( bool ctrlModifier, bool shiftModifier, bool altModifier );
+
+    void hightLightFeature( const QgsFeatureId &id, QgsVectorLayer *layer );
+
+    QList<QgsHighlight *> mHightlights;
+
 };
 
 #endif

--- a/src/app/qgsmaptoolselect.h
+++ b/src/app/qgsmaptoolselect.h
@@ -69,9 +69,9 @@ class APP_EXPORT QgsMapToolSelect : public QgsMapTool
 
     void modifiersChanged( bool ctrlModifier, bool shiftModifier, bool altModifier );
 
-    void hightLightFeature( const QgsFeatureId &id, QgsVectorLayer *layer );
+    void highlightFeature( const QgsFeatureId &id, QgsVectorLayer *layer );
 
-    QList<QgsHighlight *> mHightlights;
+    QList<QgsHighlight *> mHighlights;
 
 };
 

--- a/src/app/qgsmaptoolselect.h
+++ b/src/app/qgsmaptoolselect.h
@@ -54,8 +54,7 @@ class APP_EXPORT QgsMapToolSelect : public QgsMapTool
     void deactivate() override;
     Flags flags() const override;
 
-
-    void populateContextMenu( QMenu *menu, QgsMapMouseEvent *event = nullptr ) override;
+    bool populateContextMenuWithEvent( QMenu *menu, QgsMapMouseEvent *event ) override;
 
   signals:
 
@@ -68,11 +67,6 @@ class APP_EXPORT QgsMapToolSelect : public QgsMapTool
     std::unique_ptr<QgsMapToolSelectionHandler> mSelectionHandler;
 
     void modifiersChanged( bool ctrlModifier, bool shiftModifier, bool altModifier );
-
-    void highlightFeature( const QgsFeatureId &id, QgsVectorLayer *layer );
-
-    QList<QgsHighlight *> mHighlights;
-
 };
 
 #endif

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -428,7 +428,7 @@ QList<QAction *> QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::actions( co
 
 QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::~QgsMapToolSelectMenuActions()
 {
-  removeHighLight();
+  removeHighlight();
 }
 
 void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::selectFeature()
@@ -460,7 +460,7 @@ void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::selectFeature()
 
 void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::highLightFeatures()
 {
-  removeHighLight();
+  removeHighlight();
 
   if ( !mVectorLayer )
     return;
@@ -492,7 +492,7 @@ void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::highLightFeatures()
       {
         QgsHighlight *hl = new QgsHighlight( mCanvas, geom, mVectorLayer );
         styleHighlight( hl );
-        mHighLight.append( hl );
+        mHighlight.append( hl );
       }
     }
   }
@@ -502,15 +502,15 @@ void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::highLightFeatures()
 void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::onLayerDestroyed()
 {
   mVectorLayer = nullptr;
-  removeHighLight();
+  removeHighlight();
 }
 
-void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::removeHighLight()
+void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::removeHighlight()
 {
-  for ( QgsHighlight *hl : mHighLight )
+  for ( QgsHighlight *hl : mHighlight )
     delete hl;
 
-  mHighLight.clear();
+  mHighlight.clear();
 }
 
 void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::styleHighlight( QgsHighlight *highlight )

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -372,7 +372,7 @@ QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::~QgsMapToolSelectMenuActions
 
 void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::populateMenu( QMenu *menu )
 {
-  mActionChooseAll = new QAction( textForChooseAll(), menu );
+  mActionChooseAll = new QAction( textForChooseAll(), this );
   menu->addAction( mActionChooseAll );
   connect( mActionChooseAll, &QAction::triggered, this, &QgsMapToolSelectMenuActions::chooseAllCandidateFeature );
   mMenuChooseOne = new QMenu( textForChooseOneMenu() );

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -21,6 +21,7 @@ email                : jpalmer at linz dot govt dot nz
 #include "qgsmessagebar.h"
 #include "qgsmapcanvas.h"
 #include "qgsvectorlayer.h"
+#include "qgsvectorlayerfeatureiterator.h"
 #include "qgsfeature.h"
 #include "qgsgeometry.h"
 #include "qgshighlight.h"
@@ -36,6 +37,7 @@ email                : jpalmer at linz dot govt dot nz
 #include <QMouseEvent>
 #include <QApplication>
 #include <QAction>
+#include <QtConcurrent>
 
 QgsVectorLayer *QgsMapToolSelectUtils::getCurrentVectorLayer( QgsMapCanvas *canvas )
 {
@@ -160,28 +162,11 @@ void QgsMapToolSelectUtils::setSelectedFeatures( QgsMapCanvas *canvas, const Qgs
   QApplication::restoreOverrideCursor();
 }
 
-
-QgsFeatureIds QgsMapToolSelectUtils::getMatchingFeatures( QgsMapCanvas *canvas, const QgsGeometry &selectGeometry, bool doContains, bool singleSelect )
+static bool transformSelectGeometry( const QgsGeometry &selectGeometry,  QgsGeometry selectGeomTrans, const QgsCoordinateTransform &ct )
 {
-  QgsFeatureIds newSelectedFeatures;
-
-  if ( selectGeometry.type() != QgsWkbTypes::PolygonGeometry )
-    return newSelectedFeatures;
-
-  QgsVectorLayer *vlayer = QgsMapToolSelectUtils::getCurrentVectorLayer( canvas );
-  if ( !vlayer )
-    return newSelectedFeatures;
-
-  // toLayerCoordinates will throw an exception for any 'invalid' points in
-  // the rubber band.
-  // For example, if you project a world map onto a globe using EPSG 2163
-  // and then click somewhere off the globe, an exception will be thrown.
-  QgsGeometry selectGeomTrans = selectGeometry;
-
+  selectGeomTrans = selectGeometry;
   try
   {
-    QgsCoordinateTransform ct( canvas->mapSettings().destinationCrs(), vlayer->crs(), QgsProject::instance() );
-
     if ( !ct.isShortCircuited() && selectGeomTrans.type() == QgsWkbTypes::PolygonGeometry )
     {
       // convert add more points to the edges of the rectangle
@@ -213,6 +198,7 @@ QgsFeatureIds QgsMapToolSelectUtils::getMatchingFeatures( QgsMapCanvas *canvas, 
     }
 
     selectGeomTrans.transform( ct );
+    return true;
   }
   catch ( QgsCsException &cse )
   {
@@ -223,8 +209,29 @@ QgsFeatureIds QgsMapToolSelectUtils::getMatchingFeatures( QgsMapCanvas *canvas, 
       QObject::tr( "CRS Exception" ),
       QObject::tr( "Selection extends beyond layer's coordinate system" ),
       Qgis::Warning );
-    return newSelectedFeatures;
+    return false;
   }
+}
+
+QgsFeatureIds QgsMapToolSelectUtils::getMatchingFeatures( QgsMapCanvas *canvas, const QgsGeometry &selectGeometry, bool doContains, bool singleSelect )
+{
+  QgsFeatureIds newSelectedFeatures;
+
+  if ( selectGeometry.type() != QgsWkbTypes::PolygonGeometry )
+    return newSelectedFeatures;
+
+  QgsVectorLayer *vlayer = QgsMapToolSelectUtils::getCurrentVectorLayer( canvas );
+  if ( !vlayer )
+    return newSelectedFeatures;
+
+  // toLayerCoordinates will throw an exception for any 'invalid' points in
+  // the rubber band.
+  // For example, if you project a world map onto a globe using EPSG 2163
+  // and then click somewhere off the globe, an exception will be thrown.
+  QgsGeometry selectGeomTrans = selectGeometry;
+  QgsCoordinateTransform ct( canvas->mapSettings().destinationCrs(), vlayer->crs(), QgsProject::instance() );
+  if ( !transformSelectGeometry( selectGeometry, selectGeometry, ct ) )
+    return newSelectedFeatures;
 
   QgsDebugMsgLevel( "Selection layer: " + vlayer->name(), 3 );
   QgsDebugMsgLevel( "Selection polygon: " + selectGeomTrans.asWkt(), 3 );
@@ -338,100 +345,241 @@ QgsFeatureIds QgsMapToolSelectUtils::getMatchingFeatures( QgsMapCanvas *canvas, 
 }
 
 
-QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::QgsMapToolSelectMenuActions(
-  QgsMapCanvas *canvas,
-  QgsVectorLayer *vectorLayer,
-  QgsVectorLayer::SelectBehavior behavior,
-  QObject *parent ):
+QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::QgsMapToolSelectMenuActions( QgsMapCanvas *canvas,
+    QgsVectorLayer *vectorLayer,
+    QgsVectorLayer::SelectBehavior behavior, QgsGeometry selectionGeometry,
+    QObject *parent ):
   QObject( parent ),
   mCanvas( canvas ),
   mVectorLayer( vectorLayer ),
-  mBehavior( behavior )
+  mBehavior( behavior ),
+  mSelectGeometry( selectionGeometry )
 {
   connect( mVectorLayer, &QgsMapLayer::destroyed, this, &QgsMapToolSelectMenuActions::onLayerDestroyed );
+
+  mFutureWatcher = new QFutureWatcher<QgsFeatureIds>( this );
+  connect( mFutureWatcher, &QFutureWatcher<void>::finished, this, &QgsMapToolSelectMenuActions::onSearchFinished );
 }
 
-QList<QAction *> QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::actions( const QgsFeatureIds &featureCanditateIds )
-{
-  QList<QAction *> actionsList;
-
-  QString beginningOfText;
-
-  QgsFeatureIds effectiveFeatureIds = featureCanditateIds;
-
-  switch ( mBehavior )
-  {
-    case QgsVectorLayer::SetSelection:
-      beginningOfText = tr( "Select " );
-      break;
-    case QgsVectorLayer::AddToSelection:
-    {
-      beginningOfText = tr( "Add " );
-      QgsFeatureIds existingSelection = mVectorLayer->selectedFeatureIds();
-      for ( const QgsFeatureId &selected : featureCanditateIds )
-      {
-        if ( existingSelection.contains( selected ) )
-          effectiveFeatureIds.remove( selected );
-      }
-    }
-    break;
-
-    case QgsVectorLayer::IntersectSelection:
-    {
-      beginningOfText = tr( "Intersect " );
-      QgsFeatureIds existingSelection = mVectorLayer->selectedFeatureIds();
-      for ( const QgsFeatureId &selected : featureCanditateIds )
-      {
-        if ( !existingSelection.contains( selected ) )
-          effectiveFeatureIds.remove( selected );
-      }
-    }
-    break;
-    case QgsVectorLayer::RemoveFromSelection:
-    {
-      beginningOfText = tr( "Remove " );
-      QgsFeatureIds existingSelection = mVectorLayer->selectedFeatureIds();
-      for ( const QgsFeatureId &selected : featureCanditateIds )
-      {
-        if ( !existingSelection.contains( selected ) )
-          effectiveFeatureIds.remove( selected );
-      }
-    }
-    break;
-  }
-
-  if ( !effectiveFeatureIds.isEmpty() )
-  {
-    if ( effectiveFeatureIds.size() > 1 )
-    {
-      QAction *actionAll = new QAction( beginningOfText + tr( "All Features (%1)" ).arg( effectiveFeatureIds.count() ), this );
-      connect( actionAll, &QAction::triggered, this, &QgsMapToolSelectMenuActions::selectFeature );
-      connect( actionAll, &QAction::hovered, this, &QgsMapToolSelectMenuActions::highLightFeatures );
-      QVariantList list;
-      for ( const QgsFeatureId &id : effectiveFeatureIds )
-        list.append( id );
-
-      actionAll->setData( list );
-      actionsList.append( actionAll );
-    }
-    for ( const QgsFeatureId &id : effectiveFeatureIds )
-    {
-      QAction *featureAction = new QAction( beginningOfText + tr( "Feature %1" ).arg( id ), this ) ;
-      featureAction->setData( id );
-      connect( featureAction, &QAction::triggered, this, &QgsMapToolSelectMenuActions::selectFeature );
-      connect( featureAction, &QAction::hovered, this, &QgsMapToolSelectMenuActions::highLightFeatures );
-      actionsList.append( featureAction );
-    }
-  }
-  return actionsList;
-}
 
 QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::~QgsMapToolSelectMenuActions()
 {
   removeHighlight();
+  mJobData->isCanceled = true;
+  if ( mFutureWatcher )
+    mFutureWatcher->waitForFinished();
 }
 
-void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::selectFeature()
+void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::populateMenu( QMenu *menu )
+{
+  mActionChooseAll = new QAction( textForChooseAll(), menu );
+  menu->addAction( mActionChooseAll );
+  connect( mActionChooseAll, &QAction::triggered, this, &QgsMapToolSelectMenuActions::chooseAllCandidateFeature );
+  mMenuChooseOne = new QMenu( textForChooseOneMenu() );
+  menu->addMenu( mMenuChooseOne );
+  mMenuChooseOne->setEnabled( false );
+
+  startFeatureSearch();
+}
+
+void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::startFeatureSearch()
+{
+  mJobData = std::make_shared<DataForSearchingJob>();
+  mJobData->isCanceled = false;
+  mJobData->source.reset( new QgsVectorLayerFeatureSource( mVectorLayer ) );
+  mJobData->selectGeometry = mSelectGeometry;
+  mJobData->context = QgsRenderContext::fromMapSettings( mCanvas->mapSettings() );
+  mJobData->ct = QgsCoordinateTransform( mCanvas->mapSettings().destinationCrs(), mVectorLayer->crs(), mJobData->context.transformContext() );
+  mJobData->featureRenderer.reset( mVectorLayer->renderer()->clone() );
+  mJobData->context.expressionContext() << QgsExpressionContextUtils::layerScope( mVectorLayer );
+  mJobData->selectBehavior = mBehavior;
+  if ( mBehavior != QgsVectorLayer::SetSelection )
+    mJobData->existingSelection = mVectorLayer->selectedFeatureIds();
+  QFuture<QgsFeatureIds> future = QtConcurrent::run( search, mJobData );
+  mFutureWatcher->setFuture( future );
+}
+
+QgsFeatureIds QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::search( std::shared_ptr<DataForSearchingJob> data )
+{
+  QgsFeatureIds newSelectedFeatures;
+
+  if ( data->selectGeometry.type() != QgsWkbTypes::PolygonGeometry )
+    return newSelectedFeatures;
+
+  QgsGeometry selectGeomTrans = data->selectGeometry;
+
+  if ( ! transformSelectGeometry( data->selectGeometry, selectGeomTrans, data->ct ) )
+    return newSelectedFeatures;
+
+
+  // make sure the selection geometry is valid, or intersection tests won't work correctly...
+  if ( !selectGeomTrans.isGeosValid( ) )
+  {
+    // a zero width buffer is safer than calling make valid here!
+    selectGeomTrans = selectGeomTrans.buffer( 0, 1 );
+  }
+
+  std::unique_ptr< QgsGeometryEngine > selectionGeometryEngine( QgsGeometry::createGeometryEngine( selectGeomTrans.constGet() ) );
+  selectionGeometryEngine->setLogErrors( false );
+  selectionGeometryEngine->prepareGeometry();
+
+  std::unique_ptr<QgsFeatureRenderer> r;
+  if ( data->featureRenderer )
+  {
+    r.reset( data->featureRenderer->clone() );
+    r->startRender( data->context, data->source->fields() );
+  }
+
+  QgsFeatureRequest request;
+  request.setFilterRect( selectGeomTrans.boundingBox() );
+  request.setFlags( QgsFeatureRequest::ExactIntersect );
+
+  if ( r )
+    request.setSubsetOfAttributes( r->usedAttributes( data->context ), data->source->fields() );
+
+  QgsFeatureIterator fit = data->source->getFeatures( request );
+
+  QgsFeature f;
+
+  while ( fit.nextFeature( f ) && !data->isCanceled )
+  {
+    data->context.expressionContext().setFeature( f );
+    // make sure to only use features that are visible
+    if ( r && !r->willRenderFeature( f, data->context ) )
+      continue;
+
+    QgsGeometry g = f.geometry();
+    QString errorMessage;
+
+    // if we get an error from the intersects check then it indicates that the geometry is invalid and GEOS choked on it.
+    // in this case we consider the bounding box intersection check which has already been performed by the iterator as sufficient and
+    // allow the feature to be selected
+    const bool notIntersects = !selectionGeometryEngine->intersects( g.constGet(), &errorMessage ) &&
+                               ( errorMessage.isEmpty() || /* message will be non empty if geometry g is invalid */
+                                 !selectionGeometryEngine->intersects( g.makeValid().constGet(), &errorMessage ) ); /* second chance for invalid geometries, repair and re-test */
+
+    if ( !errorMessage.isEmpty() )
+    {
+      // intersects relation test still failed, even after trying to make valid!
+      QgsMessageLog::logMessage( QObject::tr( "Error determining selection: %1" ).arg( errorMessage ), QString(), Qgis::Warning );
+    }
+
+    if ( notIntersects )
+      continue;
+
+    newSelectedFeatures.insert( f.id() );
+  }
+
+  if ( r )
+    r->stopRender( data->context );
+  return filterIds( newSelectedFeatures, data->existingSelection, data->selectBehavior );
+}
+
+void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::onSearchFinished()
+{
+  if ( mFutureWatcher && !mFutureWatcher->isFinished() )
+    return;
+
+  mAllFeatureIds = mFutureWatcher->result();
+  mActionChooseAll->setText( textForChooseAll( mAllFeatureIds.size() ) );
+  if ( !mAllFeatureIds.isEmpty() )
+    connect( mActionChooseAll, &QAction::hovered, this, &QgsMapToolSelectMenuActions::highlightFeatures );
+  else
+    mActionChooseAll->setEnabled( false );
+  if ( mAllFeatureIds.count() > 1 )
+    populateChooseOneMenu( mAllFeatureIds );
+}
+
+
+QString QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::textForChooseAll( qint64 featureCount ) const
+{
+  if ( featureCount == 0 || featureCount == 1 )
+  {
+    switch ( mBehavior )
+    {
+      case QgsVectorLayer::SetSelection:
+        return tr( "Select" );
+        break;
+      case QgsVectorLayer::AddToSelection:
+        return tr( "Add to Selection" );
+        break;
+      case QgsVectorLayer::IntersectSelection:
+        return tr( "Intersect with Selection" );
+        break;
+      case QgsVectorLayer::RemoveFromSelection:
+        return tr( "Remove from Selection" );
+        break;
+    }
+  }
+
+  QString featureCountText;
+  if ( featureCount < 0 )
+    featureCountText = QStringLiteral( "Searching..." );
+  else
+    featureCountText = QString::number( featureCount );
+
+  switch ( mBehavior )
+  {
+    case QgsVectorLayer::SetSelection:
+      return tr( "Select All (%1)" ).arg( featureCountText );
+      break;
+    case QgsVectorLayer::AddToSelection:
+      return tr( "Add All to Selection (%1)" ).arg( featureCountText );
+      break;
+    case QgsVectorLayer::IntersectSelection:
+      return tr( "Intersect All with Selection (%1)" ).arg( featureCountText );
+      break;
+    case QgsVectorLayer::RemoveFromSelection:
+      return tr( "Remove All (%1) from Selection (%1)" ).arg( featureCountText );
+      break;
+  }
+
+  return QString();
+}
+
+QString QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::textForChooseOneMenu() const
+{
+  switch ( mBehavior )
+  {
+    case QgsVectorLayer::SetSelection:
+      return tr( "Select One" );
+      break;
+    case QgsVectorLayer::AddToSelection:
+      return tr( "Add One to Selection" );
+      break;
+    case QgsVectorLayer::IntersectSelection:
+      return tr( "Intersect One with Selection" );
+      break;
+    case QgsVectorLayer::RemoveFromSelection:
+      return tr( "Remove One from Selection" );
+      break;
+  }
+
+  return QString();
+}
+
+
+void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::populateChooseOneMenu( const QgsFeatureIds &ids )
+{
+  QgsFeatureIds displayedFeatureIds;
+
+  QgsFeatureIds::ConstIterator it = ids.constBegin();
+  while ( displayedFeatureIds.count() <= 20 && it != ids.constEnd() ) //for now hardcoded, but maybe define a settings for this
+    displayedFeatureIds.insert( *( it++ ) );
+
+  for ( QgsFeatureId id : qgis::as_const( displayedFeatureIds ) )
+  {
+    QAction *featureAction = new QAction( tr( "Feature %1" ).arg( id ), this ) ;
+    featureAction->setData( id );
+    connect( featureAction, &QAction::triggered, this, &QgsMapToolSelectMenuActions::chooseOneCandidateFeature );
+    connect( featureAction, &QAction::hovered, this, &QgsMapToolSelectMenuActions::highlightFeatures );
+    mMenuChooseOne->addAction( featureAction );
+  }
+
+  mMenuChooseOne->setEnabled( ids.count() != 0 );
+}
+
+void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::chooseOneCandidateFeature()
 {
   if ( !mVectorLayer )
     return;
@@ -443,22 +591,31 @@ void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::selectFeature()
   QVariant featureVariant = senderAction->data();
 
   QgsFeatureIds ids;
-  if ( featureVariant.type() == QVariant::List )
-  {
-    QVariantList list = featureVariant.toList();
-    for ( const QVariant &var : list )
-      ids.insert( var.toLongLong() );
-  }
-
   if ( featureVariant.type() == QVariant::LongLong )
     ids.insert( featureVariant.toLongLong() );
 
   if ( !ids.empty() )
     mVectorLayer->selectByIds( ids, mBehavior );
-
 }
 
-void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::highLightFeatures()
+void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::chooseAllCandidateFeature()
+{
+  if ( ! mFutureWatcher )
+    return;
+
+  if ( !mFutureWatcher->isFinished() )
+  {
+    QApplication::setOverrideCursor( Qt::WaitCursor );
+    mFutureWatcher->waitForFinished();
+    QApplication::restoreOverrideCursor();
+    mAllFeatureIds = mFutureWatcher->result();
+  }
+
+  if ( !mAllFeatureIds.empty() )
+    mVectorLayer->selectByIds( mAllFeatureIds, mBehavior );
+}
+
+void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::highlightFeatures()
 {
   removeHighlight();
 
@@ -469,21 +626,26 @@ void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::highLightFeatures()
   if ( !senderAction )
     return;
 
-  QVariant featureVariant = senderAction->data();
-
   QgsFeatureIds ids;
-  if ( featureVariant.type() == QVariant::List )
+  if ( senderAction == mActionChooseAll )
+    ids = mAllFeatureIds;
+  else
   {
-    QVariantList list = featureVariant.toList();
-    for ( const QVariant &var : list )
-      ids.insert( var.toLongLong() );
-  }
+    QVariant featureVariant = senderAction->data();
+    if ( featureVariant.type() == QVariant::List )
+    {
+      QVariantList list = featureVariant.toList();
+      for ( const QVariant &var : list )
+        ids.insert( var.toLongLong() );
+    }
 
-  if ( featureVariant.type() == QVariant::LongLong )
-    ids.insert( featureVariant.toLongLong() );
+    if ( featureVariant.type() == QVariant::LongLong )
+      ids.insert( featureVariant.toLongLong() );
+  }
 
   if ( !ids.empty() )
   {
+    int count = 0;
     for ( const QgsFeatureId &id : ids )
     {
       QgsFeature feat = mVectorLayer->getFeature( id );
@@ -493,24 +655,12 @@ void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::highLightFeatures()
         QgsHighlight *hl = new QgsHighlight( mCanvas, geom, mVectorLayer );
         styleHighlight( hl );
         mHighlight.append( hl );
+        count++;
       }
+      if ( count > 1000 ) //for now hardcoded, but maybe define a settings for this
+        return;
     }
   }
-
-}
-
-void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::onLayerDestroyed()
-{
-  mVectorLayer = nullptr;
-  removeHighlight();
-}
-
-void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::removeHighlight()
-{
-  for ( QgsHighlight *hl : mHighlight )
-    delete hl;
-
-  mHighlight.clear();
 }
 
 void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::styleHighlight( QgsHighlight *highlight )
@@ -526,4 +676,51 @@ void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::styleHighlight( QgsHigh
   highlight->setFillColor( color ); // sets fill with alpha
   highlight->setBuffer( buffer );
   highlight->setMinWidth( minWidth );
+}
+
+QgsFeatureIds QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::filterIds( const QgsFeatureIds &ids,
+    const QgsFeatureIds &existingSelection,
+    QgsVectorLayer::SelectBehavior behavior )
+{
+  QgsFeatureIds effectiveFeatureIds = ids;
+  switch ( behavior )
+  {
+    case QgsVectorLayer::SetSelection:
+      break;
+    case QgsVectorLayer::AddToSelection:
+    {
+      for ( QgsFeatureId newSelected : ids )
+      {
+        if ( existingSelection.contains( newSelected ) )
+          effectiveFeatureIds.remove( newSelected );
+      }
+    }
+    break;
+    case QgsVectorLayer::IntersectSelection:
+    case QgsVectorLayer::RemoveFromSelection:
+    {
+      for ( QgsFeatureId newSelected : ids )
+      {
+        if ( !existingSelection.contains( newSelected ) )
+          effectiveFeatureIds.remove( newSelected );
+      }
+    }
+    break;
+  }
+
+  return effectiveFeatureIds;
+}
+
+
+void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::onLayerDestroyed()
+{
+  mVectorLayer = nullptr;
+  mJobData->isCanceled = true;
+  removeHighlight();
+}
+
+void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::removeHighlight()
+{
+  qDeleteAll( mHighlight );
+  mHighlight.clear();
 }

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -530,7 +530,7 @@ QString QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::textForChooseAll( qi
       return tr( "Intersect All with Selection (%1)" ).arg( featureCountText );
       break;
     case QgsVectorLayer::RemoveFromSelection:
-      return tr( "Remove All (%1) from Selection (%1)" ).arg( featureCountText );
+      return tr( "Remove All from Selection (%1)" ).arg( featureCountText );
       break;
   }
 

--- a/src/app/qgsmaptoolselectutils.h
+++ b/src/app/qgsmaptoolselectutils.h
@@ -19,6 +19,7 @@ email                : jpalmer at linz dot govt dot nz
 #include <Qt>
 #include <QRect>
 #include <QPoint>
+#include <QList>
 
 #include "qgsvectorlayer.h"
 
@@ -27,6 +28,8 @@ class QgsMapCanvas;
 class QgsVectorLayer;
 class QgsGeometry;
 class QgsRubberBand;
+class QMenu;
+class QgsHighlight;
 
 /**
   Namespace containing methods which are useful for the select maptool widgets
@@ -114,6 +117,49 @@ namespace QgsMapToolSelectUtils
    * \param rubberBand The rubberband that will be set in map units using the input rectangle
   */
   void setRubberBand( QgsMapCanvas *canvas, QRect &selectRect, QgsRubberBand *rubberBand );
+
+  /**
+   * Class that handles actions which can be displayed in a context menu related to feature selection.
+   */
+  class QgsMapToolSelectMenuActions : public QObject
+  {
+      Q_OBJECT
+    public:
+
+      /**
+      * Constructor
+      * \param canvas The map canvas where where are the selected features
+      * \param vectorLayr The vector layer
+      * \param behavior behavior of select
+      * \param parent a QObject that owns the instance ot this class
+      */
+      QgsMapToolSelectMenuActions( QgsMapCanvas *canvas,
+                                   QgsVectorLayer *vectorLayer,
+                                   QgsVectorLayer::SelectBehavior behavior,
+                                   QObject *parent );
+
+      /**
+       * Returns action that correspond to the feature canditate to be selected.
+       * @param featureIds
+       * @return
+       */
+      QList<QAction *> actions( const QgsFeatureIds &featureCanditateIds );
+      ~QgsMapToolSelectMenuActions();
+
+    private slots:
+      void selectFeature();
+      void highLightFeatures();
+      void onLayerDestroyed();
+      void removeHighLight();
+
+    private:
+      QgsMapCanvas *mCanvas = nullptr;
+      QList<QgsHighlight *> mHighLight;
+      QgsVectorLayer *mVectorLayer = nullptr;
+      QgsVectorLayer::SelectBehavior mBehavior = QgsVectorLayer::SetSelection;
+
+      void styleHighlight( QgsHighlight *highlight );
+  };
 }
 
 #endif

--- a/src/app/qgsmaptoolselectutils.h
+++ b/src/app/qgsmaptoolselectutils.h
@@ -140,8 +140,8 @@ namespace QgsMapToolSelectUtils
 
       /**
        * Returns action that correspond to the feature canditate to be selected.
-       * @param featureIds
-       * @return
+       * \param featureIds the feature ids
+       * \return the list ad adapted actions
        */
       QList<QAction *> actions( const QgsFeatureIds &featureCanditateIds );
       ~QgsMapToolSelectMenuActions();
@@ -150,11 +150,11 @@ namespace QgsMapToolSelectUtils
       void selectFeature();
       void highLightFeatures();
       void onLayerDestroyed();
-      void removeHighLight();
+      void removeHighlight();
 
     private:
       QgsMapCanvas *mCanvas = nullptr;
-      QList<QgsHighlight *> mHighLight;
+      QList<QgsHighlight *> mHighlight;
       QgsVectorLayer *mVectorLayer = nullptr;
       QgsVectorLayer::SelectBehavior mBehavior = QgsVectorLayer::SetSelection;
 

--- a/src/app/qgsmaptoolselectutils.h
+++ b/src/app/qgsmaptoolselectutils.h
@@ -152,9 +152,8 @@ namespace QgsMapToolSelectUtils
       void populateMenu( QMenu *menu );
 
     private slots:
-      void chooseOneCandidateFeature();
       void chooseAllCandidateFeature();
-      void highlightFeatures();
+      void highlightAllFeatures();
       void onLayerDestroyed();
       void removeHighlight();
       void onSearchFinished();
@@ -197,6 +196,9 @@ namespace QgsMapToolSelectUtils
       std::shared_ptr<DataForSearchingJob> mJobData;
 
       static QgsFeatureIds search( std::shared_ptr<DataForSearchingJob> data );
+
+      void chooseOneCandidateFeature( QgsFeatureId id );
+      void highlightOneFeature( QgsFeatureId id );
   };
 
 }

--- a/src/app/qgsmaptoolselectutils.h
+++ b/src/app/qgsmaptoolselectutils.h
@@ -26,6 +26,7 @@ email                : jpalmer at linz dot govt dot nz
 class QMouseEvent;
 class QgsMapCanvas;
 class QgsVectorLayer;
+class QgsVectorLayerFeatureSource;
 class QgsGeometry;
 class QgsRubberBand;
 class QMenu;
@@ -120,6 +121,7 @@ namespace QgsMapToolSelectUtils
 
   /**
    * Class that handles actions which can be displayed in a context menu related to feature selection.
+   * \since QGIS 3.18
    */
   class QgsMapToolSelectMenuActions : public QObject
   {
@@ -131,35 +133,72 @@ namespace QgsMapToolSelectUtils
       * \param canvas The map canvas where where are the selected features
       * \param vectorLayr The vector layer
       * \param behavior behavior of select
+      * \param selectionGeometry the geometry used to select the feature
       * \param parent a QObject that owns the instance ot this class
       */
       QgsMapToolSelectMenuActions( QgsMapCanvas *canvas,
                                    QgsVectorLayer *vectorLayer,
                                    QgsVectorLayer::SelectBehavior behavior,
-                                   QObject *parent );
+                                   QgsGeometry selectionGeometry,
+                                   QObject *parent = nullptr );
 
-      /**
-       * Returns action that correspond to the feature canditate to be selected.
-       * \param featureIds the feature ids
-       * \return the list ad adapted actions
-       */
-      QList<QAction *> actions( const QgsFeatureIds &featureCanditateIds );
+
       ~QgsMapToolSelectMenuActions();
 
+      /**
+      * Populates the \a menu with "All Feature" action and a empty menu that could contain later the "One Feature" actions
+      * Starts the search for canditate features to be selected on an other thread, actions/menus will be updated at the end of this task
+      */
+      void populateMenu( QMenu *menu );
+
     private slots:
-      void selectFeature();
-      void highLightFeatures();
+      void chooseOneCandidateFeature();
+      void chooseAllCandidateFeature();
+      void highlightFeatures();
       void onLayerDestroyed();
       void removeHighlight();
+      void onSearchFinished();
 
     private:
       QgsMapCanvas *mCanvas = nullptr;
-      QList<QgsHighlight *> mHighlight;
       QgsVectorLayer *mVectorLayer = nullptr;
       QgsVectorLayer::SelectBehavior mBehavior = QgsVectorLayer::SetSelection;
+      QgsGeometry mSelectGeometry;
+      QAction *mActionChooseAll = nullptr;
+      QMenu *mMenuChooseOne = nullptr;
+      QFutureWatcher<QgsFeatureIds> *mFutureWatcher = nullptr;
+      QgsFeatureIds mAllFeatureIds;
+      QList<QgsHighlight *> mHighlight;
+
+      void startFeatureSearch();
 
       void styleHighlight( QgsHighlight *highlight );
+
+      QString textForChooseAll( qint64 featureCount = -1 ) const;
+      QString textForChooseOneMenu() const;
+      void populateChooseOneMenu( const QgsFeatureIds &ids );
+
+      static QgsFeatureIds filterIds( const QgsFeatureIds &ids,
+                                      const QgsFeatureIds &existingSelection,
+                                      QgsVectorLayer::SelectBehavior behavior );
+
+      struct DataForSearchingJob
+      {
+        bool isCanceled;
+        std::unique_ptr<QgsVectorLayerFeatureSource> source;
+        QgsGeometry selectGeometry;
+        QgsCoordinateTransform ct;
+        QgsRenderContext context;
+        std::unique_ptr<QgsFeatureRenderer> featureRenderer;
+        QgsVectorLayer::SelectBehavior selectBehavior;
+        QgsFeatureIds existingSelection;
+      };
+
+      std::shared_ptr<DataForSearchingJob> mJobData;
+
+      static QgsFeatureIds search( std::shared_ptr<DataForSearchingJob> data );
   };
+
 }
 
 #endif

--- a/src/app/qgsmaptoolselectutils.h
+++ b/src/app/qgsmaptoolselectutils.h
@@ -147,7 +147,7 @@ namespace QgsMapToolSelectUtils
 
       /**
       * Populates the \a menu with "All Feature" action and a empty menu that could contain later the "One Feature" actions
-      * Starts the search for canditate features to be selected on an other thread, actions/menus will be updated at the end of this task
+      * Starts the search for canditate features to be selected on another thread, actions/menus will be updated at the end of this task
       */
       void populateMenu( QMenu *menu );
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -118,7 +118,6 @@ class QgsMapCanvas::CanvasProperties
 QgsMapCanvas::QgsMapCanvas( QWidget *parent )
   : QGraphicsView( parent )
   , mCanvasProperties( new CanvasProperties )
-  , mMenu( new QMenu( this ) )
   , mExpressionContextScope( tr( "Map Canvas" ) )
 {
   mScene = new QGraphicsScene();
@@ -810,12 +809,12 @@ void QgsMapCanvas::showContextMenu( QgsMapMouseEvent *event )
 {
   const QgsPointXY mapPoint = event->originalMapPoint();
 
-  mMenu->clear();
+  QMenu menu;
 
-  QMenu *copyCoordinateMenu = new QMenu( tr( "Copy Coordinate" ), mMenu );
+  QMenu *copyCoordinateMenu = new QMenu( tr( "Copy Coordinate" ), &menu );
   copyCoordinateMenu->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionEditCopy.svg" ) ) );
 
-  auto addCoordinateFormat = [ = ]( const QString identifier, const QgsCoordinateReferenceSystem & crs )
+  auto addCoordinateFormat = [ &, this]( const QString identifier, const QgsCoordinateReferenceSystem & crs )
   {
     QgsCoordinateTransform ct( mSettings.destinationCrs(), crs, mSettings.transformContext() );
     try
@@ -857,7 +856,7 @@ void QgsMapCanvas::showContextMenu( QgsMapMouseEvent *event )
       QAction *copyCoordinateAction = new QAction( QStringLiteral( "%3 (%1, %2)" ).arg(
             QString::number( transformedPoint.x(), 'f', displayPrecision ),
             QString::number( transformedPoint.y(), 'f', displayPrecision ),
-            identifier ), mMenu );
+            identifier ), &menu );
 
       connect( copyCoordinateAction, &QAction::triggered, this, [displayPrecision, transformedPoint]
       {
@@ -896,7 +895,7 @@ void QgsMapCanvas::showContextMenu( QgsMapMouseEvent *event )
     }
   }
   copyCoordinateMenu->addSeparator();
-  QAction *setCustomCrsAction = new QAction( tr( "Set Custom CRS…" ), mMenu );
+  QAction *setCustomCrsAction = new QAction( tr( "Set Custom CRS…" ), &menu );
   connect( setCustomCrsAction, &QAction::triggered, this, [ = ]
   {
     QgsProjectionSelectionDialog selector( this );
@@ -908,14 +907,14 @@ void QgsMapCanvas::showContextMenu( QgsMapMouseEvent *event )
   } );
   copyCoordinateMenu->addAction( setCustomCrsAction );
 
-  mMenu->addMenu( copyCoordinateMenu );
+  menu.addMenu( copyCoordinateMenu );
 
   if ( mMapTool )
-    mMapTool->populateContextMenu( mMenu );
+    mMapTool->populateContextMenu( &menu, event );
 
-  emit contextMenuAboutToShow( mMenu, event );
+  emit contextMenuAboutToShow( &menu, event );
 
-  mMenu->exec( event->globalPos() );
+  menu.exec( event->globalPos() );
 }
 
 void QgsMapCanvas::setTemporalRange( const QgsDateTimeRange &dateTimeRange )

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -910,7 +910,8 @@ void QgsMapCanvas::showContextMenu( QgsMapMouseEvent *event )
   menu.addMenu( copyCoordinateMenu );
 
   if ( mMapTool )
-    mMapTool->populateContextMenu( &menu, event );
+    if ( !mapTool()->populateContextMenuWithEvent( &menu, event ) )
+      mMapTool->populateContextMenu( &menu );
 
   emit contextMenuAboutToShow( &menu, event );
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -1168,9 +1168,6 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! Pointer to project linked to this canvas
     QgsProject *mProject = nullptr;
 
-    //! Context menu
-    QMenu *mMenu = nullptr;
-
     //! recently used extent
     QList <QgsRectangle> mLastExtent;
     int mLastExtentIndex = -1;

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -225,7 +225,7 @@ double QgsMapTool::searchRadiusMU( QgsMapCanvas *canvas )
   return searchRadiusMU( context );
 }
 
-void QgsMapTool::populateContextMenu( QMenu * )
+void QgsMapTool::populateContextMenu( QMenu *, QgsMapMouseEvent * )
 {
 
 }

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -225,7 +225,14 @@ double QgsMapTool::searchRadiusMU( QgsMapCanvas *canvas )
   return searchRadiusMU( context );
 }
 
-void QgsMapTool::populateContextMenu( QMenu *, QgsMapMouseEvent * )
+
+void QgsMapTool::populateContextMenu( QMenu * )
 {
 
+}
+
+
+bool QgsMapTool::populateContextMenuWithEvent( QMenu *, QgsMapMouseEvent * )
+{
+  return false;
 }

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -26,6 +26,8 @@
 #include <QGestureEvent>
 #include "qgis_gui.h"
 
+#include "qgspointxy.h"
+
 class QgsMapLayer;
 class QgsMapCanvas;
 class QgsRenderContext;
@@ -205,6 +207,8 @@ class GUI_EXPORT QgsMapTool : public QObject
      * \a menu will be initially populated with a set of default, generic actions.
      * Any new actions added to the menu should be correctly parented to \a menu.
      *
+     * A pointer to the map mouse \a event can be provided to allow particular behavior depending on the map tool.
+     *
      * The default implementation does nothing.
      *
      * \note The context menu is only shown when the ShowContextMenu flag
@@ -212,7 +216,7 @@ class GUI_EXPORT QgsMapTool : public QObject
      *
      * \since QGIS 3.14
      */
-    virtual void populateContextMenu( QMenu *menu );
+    virtual void populateContextMenu( QMenu *menu, QgsMapMouseEvent *event = nullptr );
 
   signals:
     //! emit a message

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -226,12 +226,12 @@ class GUI_EXPORT QgsMapTool : public QObject
      *
      * This method can return true to inform the caller that the menu was effectivly populated.
      *
-     * The default implementation does nothing and return false;
+     * The default implementation does nothing and returns false.
      *
      * \note The context menu is only shown when the ShowContextMenu flag
      * is present in flags().
      *
-     * \since QGIS 3.14
+     * \since QGIS 3.18
      */
     virtual bool populateContextMenuWithEvent( QMenu *menu, QgsMapMouseEvent *event );
 

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -26,7 +26,6 @@
 #include <QGestureEvent>
 #include "qgis_gui.h"
 
-#include "qgspointxy.h"
 
 class QgsMapLayer;
 class QgsMapCanvas;
@@ -207,8 +206,6 @@ class GUI_EXPORT QgsMapTool : public QObject
      * \a menu will be initially populated with a set of default, generic actions.
      * Any new actions added to the menu should be correctly parented to \a menu.
      *
-     * A pointer to the map mouse \a event can be provided to allow particular behavior depending on the map tool.
-     *
      * The default implementation does nothing.
      *
      * \note The context menu is only shown when the ShowContextMenu flag
@@ -216,7 +213,27 @@ class GUI_EXPORT QgsMapTool : public QObject
      *
      * \since QGIS 3.14
      */
-    virtual void populateContextMenu( QMenu *menu, QgsMapMouseEvent *event = nullptr );
+    virtual void populateContextMenu( QMenu *menu );
+
+    /**
+     * Allows the tool to populate and customize the given \a menu,
+     * prior to showing it in response to a right-mouse button click.
+     *
+     * \a menu will be initially populated with a set of default, generic actions.
+     * Any new actions added to the menu should be correctly parented to \a menu.
+     *
+     * A pointer to the map mouse \a event can be provided to allow particular behavior depending on the map tool.
+     *
+     * This method can return true to inform the caller that the menu was effectivly populated.
+     *
+     * The default implementation does nothing and return false;
+     *
+     * \note The context menu is only shown when the ShowContextMenu flag
+     * is present in flags().
+     *
+     * \since QGIS 3.14
+     */
+    virtual bool populateContextMenuWithEvent( QMenu *menu, QgsMapMouseEvent *event );
 
   signals:
     //! emit a message

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -224,7 +224,7 @@ class GUI_EXPORT QgsMapTool : public QObject
      *
      * A pointer to the map mouse \a event can be provided to allow particular behavior depending on the map tool.
      *
-     * This method can return true to inform the caller that the menu was effectivly populated.
+     * This method can return true to inform the caller that the menu was effectively populated.
      *
      * The default implementation does nothing and returns false.
      *


### PR DESCRIPTION
This PR adds the possibility to select feature from a context menu on the map canvas :
**EDIT :** GIF and text updated

The candidate for selection are the feature that are under the mouse cursor. The search of the feature is realized on a parallel thread to avoid freezing.

![contextSelect](https://user-images.githubusercontent.com/7416892/100169052-ecf02580-2e98-11eb-9194-80b39eab8ecc.gif)
To simulate cases where there are a lot of feature with several seconds of search, a 4 seconds sleep has been added in the parallel thread to realized this GIF:

![contextSelect_2](https://user-images.githubusercontent.com/7416892/100167617-d8f6f480-2e95-11eb-94b9-6150489980df.gif)
The behavior is the following:
1. Just after opening, the menu contain only one action to choose "All"
2. When the parallel thread finishes, the menus/actions are updated
3. the user choose

If the user does not wait for the thread finish, two cases:
- the user quit the menu, the thread is cancelled
- the user choose "All", the application waits the thread finishes and selects all.

Funded by Kristianstad (www.kristianstad.se)