### PR TITLE
Add z/elevation slicing and filtering to map renders

### DIFF
--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -775,6 +775,24 @@ Returns the list of rendered feature handlers to use while rendering the map set
 .. versionadded:: 3.10
 %End
 
+    QgsDoubleRange zRange() const;
+%Docstring
+Returns the range of z-values which will be visible in the map.
+
+.. seealso:: :py:func:`setZRange`
+
+.. versionadded:: 3.18
+%End
+
+    void setZRange( const QgsDoubleRange &range );
+%Docstring
+Sets the ``range`` of z-values which will be visible in the map.
+
+.. seealso:: :py:func:`zRange`
+
+.. versionadded:: 3.18
+%End
+
   protected:
 
 

--- a/python/core/auto_generated/qgsrange.sip.in
+++ b/python/core/auto_generated/qgsrange.sip.in
@@ -117,6 +117,10 @@ Returns ``True`` if this range overlaps another range.
 .. seealso:: :py:func:`contains`
 %End
 
+    bool operator==( const QgsRange<T> &other ) const;
+
+    bool operator!=( const QgsRange<T> &other ) const;
+
 };
 
 

--- a/python/core/auto_generated/qgsrange.sip.in
+++ b/python/core/auto_generated/qgsrange.sip.in
@@ -121,6 +121,9 @@ Returns ``True`` if this range overlaps another range.
 
     bool operator!=( const QgsRange<T> &other ) const;
 
+  protected:
+
+
 };
 
 
@@ -178,6 +181,10 @@ Returns ``True`` if the range consists of all possible values.
                   .arg( sipCpp->includeUpper() ? QStringLiteral( "]" ) : QStringLiteral( ")" ) );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
+
+    bool operator==( const QgsDoubleRange &other ) const;
+
+    bool operator!=( const QgsDoubleRange &other ) const;
 
 };
 

--- a/python/core/auto_generated/qgsrange.sip.in
+++ b/python/core/auto_generated/qgsrange.sip.in
@@ -120,12 +120,102 @@ Returns ``True`` if this range overlaps another range.
 };
 
 
-typedef QgsRange< double > QgsDoubleRange;
+
+typedef QgsRange<double> QgsRangedoubleBase;
+
+class QgsDoubleRange : QgsRangedoubleBase
+{
+%Docstring
+QgsRange which stores a range of double values.
+
+.. seealso:: :py:class:`QgsIntRange`
+
+.. seealso:: :py:class:`QgsDateRange`
+
+.. seealso:: :py:class:`QgsDateTimeRange`
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsrange.h"
+typedef QgsRange<double> QgsRangedoubleBase;
+%End
+  public:
+
+
+    QgsDoubleRange( double lower,
+                    double upper,
+                    bool includeLower = true, bool includeUpper = true );
+%Docstring
+Constructor for QgsDoubleRange. The ``lower`` and ``upper`` bounds are specified,
+and optionally whether or not these bounds are included in the range.
+%End
+
+    QgsDoubleRange();
+%Docstring
+Constructor for QgsDoubleRange containing an infinite range (see :py:func:`~QgsDoubleRange.isInfinite`).
+
+.. versionadded:: 3.18
+%End
+
+    bool isInfinite() const;
+%Docstring
+Returns ``True`` if the range consists of all possible values.
+
+.. versionadded:: 3.18
+%End
+
+};
 
 
 
+typedef QgsRange<int> QgsRangeintBase;
 
-typedef QgsRange< int > QgsIntRange;
+class QgsIntRange : QgsRangeintBase
+{
+%Docstring
+QgsRange which stores a range of integer values.
+
+.. seealso:: :py:class:`QgsDoubleRange`
+
+.. seealso:: :py:class:`QgsDateRange`
+
+.. seealso:: :py:class:`QgsDateTimeRange`
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsrange.h"
+typedef QgsRange<int> QgsRangeintBase;
+%End
+  public:
+
+
+    QgsIntRange( int lower,
+                 int upper,
+                 bool includeLower = true, bool includeUpper = true );
+%Docstring
+Constructor for QgsIntRange. The ``lower`` and ``upper`` bounds are specified,
+and optionally whether or not these bounds are included in the range.
+%End
+
+    QgsIntRange();
+%Docstring
+Constructor for QgsIntRange containing an infinite range (see :py:func:`~QgsIntRange.isInfinite`).
+
+.. versionadded:: 3.18
+%End
+
+    bool isInfinite() const;
+%Docstring
+Returns ``True`` if the range consists of all possible values.
+
+.. versionadded:: 3.18
+%End
+
+};
 
 
 template <T>

--- a/python/core/auto_generated/qgsrange.sip.in
+++ b/python/core/auto_generated/qgsrange.sip.in
@@ -170,6 +170,15 @@ Returns ``True`` if the range consists of all possible values.
 .. versionadded:: 3.18
 %End
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsDoubleRange: %1%2, %3%4>" ).arg( sipCpp->includeLower() ? QStringLiteral( "[" ) : QStringLiteral( "(" ) )
+                  .arg( sipCpp->lower() )
+                  .arg( sipCpp->upper() )
+                  .arg( sipCpp->includeUpper() ? QStringLiteral( "]" ) : QStringLiteral( ")" ) );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
 };
 
 
@@ -217,6 +226,15 @@ Constructor for QgsIntRange containing an infinite range (see :py:func:`~QgsIntR
 Returns ``True`` if the range consists of all possible values.
 
 .. versionadded:: 3.18
+%End
+
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsIntRange: %1%2, %3%4>" ).arg( sipCpp->includeLower() ? QStringLiteral( "[" ) : QStringLiteral( "(" ) )
+                  .arg( sipCpp->lower() )
+                  .arg( sipCpp->upper() )
+                  .arg( sipCpp->includeUpper() ? QStringLiteral( "]" ) : QStringLiteral( ")" ) );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
 };

--- a/python/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/core/auto_generated/qgsrendercontext.sip.in
@@ -866,6 +866,24 @@ rendering using QBrush objects.
 .. versionadded:: 3.16
 %End
 
+    QgsDoubleRange zRange() const;
+%Docstring
+Returns the range of z-values which should be rendered.
+
+.. seealso:: :py:func:`setZRange`
+
+.. versionadded:: 3.18
+%End
+
+    void setZRange( const QgsDoubleRange &range );
+%Docstring
+Sets the ``range`` of z-values which should be rendered.
+
+.. seealso:: :py:func:`zRange`
+
+.. versionadded:: 3.18
+%End
+
 };
 
 QFlags<QgsRenderContext::Flag> operator|(QgsRenderContext::Flag f1, QFlags<QgsRenderContext::Flag> f2);

--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -973,6 +973,24 @@ Set a list of resolutions (map units per pixel) to which to "snap to" when zoomi
 .. versionadded:: 3.12
 %End
 
+    QgsDoubleRange zRange() const;
+%Docstring
+Returns the range of z-values which will be visible in the map.
+
+.. seealso:: :py:func:`setZRange`
+
+.. versionadded:: 3.18
+%End
+
+    void setZRange( const QgsDoubleRange &range );
+%Docstring
+Sets the ``range`` of z-values which will be visible in the map.
+
+.. seealso:: :py:func:`zRange`
+
+.. versionadded:: 3.18
+%End
+
   signals:
 
     void xyCoordinates( const QgsPointXY &p );

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -747,3 +747,13 @@ QList<QgsRenderedFeatureHandlerInterface *> QgsMapSettings::renderedFeatureHandl
 {
   return mRenderedFeatureHandlers;
 }
+
+QgsDoubleRange QgsMapSettings::zRange() const
+{
+  return mZRange;
+}
+
+void QgsMapSettings::setZRange( const QgsDoubleRange &zRange )
+{
+  mZRange = zRange;
+}

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -676,6 +676,22 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
      */
     QList< QgsRenderedFeatureHandlerInterface * > renderedFeatureHandlers() const;
 
+    /**
+     * Returns the range of z-values which will be visible in the map.
+     *
+     * \see setZRange()
+     * \since QGIS 3.18
+     */
+    QgsDoubleRange zRange() const;
+
+    /**
+     * Sets the \a range of z-values which will be visible in the map.
+     *
+     * \see zRange()
+     * \since QGIS 3.18
+     */
+    void setZRange( const QgsDoubleRange &range );
+
   protected:
 
     double mDpi;
@@ -743,6 +759,9 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
     QList< QgsLabelBlockingRegion > mLabelBlockingRegions;
     QList< QgsMapClippingRegion > mClippingRegions;
     QList< QgsRenderedFeatureHandlerInterface * > mRenderedFeatureHandlers;
+
+    QgsDoubleRange mZRange;
+
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsMapSettings::Flags )

--- a/src/core/qgsrange.h
+++ b/src/core/qgsrange.h
@@ -262,8 +262,8 @@ class CORE_EXPORT QgsDoubleRange : public QgsRange< double >
 
     bool operator==( const QgsDoubleRange &other ) const
     {
-      return qgsDoubleNear( mIncludeLower, other.mIncludeLower ) &&
-             qgsDoubleNear( mIncludeUpper, other.mIncludeUpper ) &&
+      return qgsDoubleNear( mLower, other.mLower ) &&
+             qgsDoubleNear( mUpper, other.mUpper ) &&
              mIncludeLower == other.includeLower() &&
              mIncludeUpper == other.includeUpper();
     }

--- a/src/core/qgsrange.h
+++ b/src/core/qgsrange.h
@@ -192,6 +192,7 @@ class QgsRange
 
 /**
  * QgsRange which stores a range of double values.
+ * \ingroup core
  * \see QgsIntRange
  * \see QgsDateRange
  * \see QgsDateTimeRange
@@ -263,6 +264,7 @@ class CORE_EXPORT QgsDoubleRange : public QgsRange< double >
 
 /**
  * QgsRange which stores a range of integer values.
+ * \ingroup core
  * \see QgsDoubleRange
  * \see QgsDateRange
  * \see QgsDateTimeRange

--- a/src/core/qgsrange.h
+++ b/src/core/qgsrange.h
@@ -247,6 +247,17 @@ class CORE_EXPORT QgsDoubleRange : public QgsRange< double >
       return lower() == std::numeric_limits< double >::lowest() && upper() == std::numeric_limits< double >::max();
     }
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsDoubleRange: %1%2, %3%4>" ).arg( sipCpp->includeLower() ? QStringLiteral( "[" ) : QStringLiteral( "(" ) )
+                  .arg( sipCpp->lower() )
+                  .arg( sipCpp->upper() )
+                  .arg( sipCpp->includeUpper() ? QStringLiteral( "]" ) : QStringLiteral( ")" ) );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
 };
 
 
@@ -306,6 +317,17 @@ class CORE_EXPORT QgsIntRange : public QgsRange< int >
     {
       return lower() == std::numeric_limits< int >::lowest() && upper() == std::numeric_limits< int >::max();
     }
+
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsIntRange: %1%2, %3%4>" ).arg( sipCpp->includeLower() ? QStringLiteral( "[" ) : QStringLiteral( "(" ) )
+                  .arg( sipCpp->lower() )
+                  .arg( sipCpp->upper() )
+                  .arg( sipCpp->includeUpper() ? QStringLiteral( "]" ) : QStringLiteral( ")" ) );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
 
 };
 

--- a/src/core/qgsrange.h
+++ b/src/core/qgsrange.h
@@ -167,6 +167,19 @@ class QgsRange
       return false;
     }
 
+    bool operator==( const QgsRange<T> &other ) const
+    {
+      return mLower == other.mLower &&
+             mUpper == other.mUpper &&
+             mIncludeLower == other.includeLower() &&
+             mIncludeUpper == other.includeUpper();
+    }
+
+    bool operator!=( const QgsRange<T> &other ) const
+    {
+      return ( ! operator==( other ) );
+    }
+
   private:
 
     T mLower;

--- a/src/core/qgsrange.h
+++ b/src/core/qgsrange.h
@@ -184,9 +184,57 @@ class QgsRange
  * \see QgsDateTimeRange
  * \since QGIS 3.0
  */
-typedef QgsRange< double > QgsDoubleRange;
+class CORE_EXPORT QgsDoubleRange : public QgsRange< double >
+{
+  public:
 
+#ifndef SIP_RUN
 
+    /**
+     * Constructor for QgsDoubleRange. The \a lower and \a upper bounds are specified,
+     * and optionally whether or not these bounds are included in the range.
+     *
+     * The default values for \a lower and \a upper construct an infinite range (see isInfinite()).
+     *
+     * \since QGIS 3.18
+     */
+    QgsDoubleRange( double lower = std::numeric_limits< double >::lowest(),
+                    double upper = std::numeric_limits< double >::max(),
+                    bool includeLower = true, bool includeUpper = true )
+      : QgsRange( lower, upper, includeLower, includeUpper )
+    {}
+#else
+
+    /**
+     * Constructor for QgsDoubleRange. The \a lower and \a upper bounds are specified,
+     * and optionally whether or not these bounds are included in the range.
+     */
+    QgsDoubleRange( double lower,
+                    double upper,
+                    bool includeLower = true, bool includeUpper = true )
+      : QgsRange( lower, upper, includeLower, includeUpper )
+    {}
+
+    /**
+     * Constructor for QgsDoubleRange containing an infinite range (see isInfinite()).
+     *
+     * \since QGIS 3.18
+     */
+    QgsDoubleRange()
+      : QgsRange( std::numeric_limits< double >::lowest(), std::numeric_limits< double >::max(), true, true )
+    {}
+#endif
+
+    /**
+     * Returns TRUE if the range consists of all possible values.
+     * \since QGIS 3.18
+     */
+    bool isInfinite() const
+    {
+      return lower() == std::numeric_limits< double >::lowest() && upper() == std::numeric_limits< double >::max();
+    }
+
+};
 
 
 /**
@@ -196,7 +244,57 @@ typedef QgsRange< double > QgsDoubleRange;
  * \see QgsDateTimeRange
  * \since QGIS 3.0
  */
-typedef QgsRange< int > QgsIntRange;
+class CORE_EXPORT QgsIntRange : public QgsRange< int >
+{
+  public:
+
+#ifndef SIP_RUN
+
+    /**
+     * Constructor for QgsIntRange. The \a lower and \a upper bounds are specified,
+     * and optionally whether or not these bounds are included in the range.
+     *
+     * The default values for \a lower and \a upper construct an infinite range (see isInfinite()).
+     *
+     * \since QGIS 3.18
+     */
+    QgsIntRange( int lower = std::numeric_limits< int >::lowest(),
+                 int upper = std::numeric_limits< int >::max(),
+                 bool includeLower = true, bool includeUpper = true )
+      : QgsRange( lower, upper, includeLower, includeUpper )
+    {}
+#else
+
+    /**
+     * Constructor for QgsIntRange. The \a lower and \a upper bounds are specified,
+     * and optionally whether or not these bounds are included in the range.
+     */
+    QgsIntRange( int lower,
+                 int upper,
+                 bool includeLower = true, bool includeUpper = true )
+      : QgsRange( lower, upper, includeLower, includeUpper )
+    {}
+
+    /**
+     * Constructor for QgsIntRange containing an infinite range (see isInfinite()).
+     *
+     * \since QGIS 3.18
+     */
+    QgsIntRange()
+      : QgsRange( std::numeric_limits< int >::lowest(), std::numeric_limits< int >::max(), true, true )
+    {}
+#endif
+
+    /**
+     * Returns TRUE if the range consists of all possible values.
+     * \since QGIS 3.18
+     */
+    bool isInfinite() const
+    {
+      return lower() == std::numeric_limits< int >::lowest() && upper() == std::numeric_limits< int >::max();
+    }
+
+};
 
 
 /**

--- a/src/core/qgsrange.h
+++ b/src/core/qgsrange.h
@@ -20,6 +20,7 @@
 
 #include "qgis_sip.h"
 #include "qgis_core.h"
+#include "qgis.h"
 
 #include <QDate>
 #include <QDateTime>
@@ -180,7 +181,7 @@ class QgsRange
       return ( ! operator==( other ) );
     }
 
-  private:
+  protected:
 
     T mLower;
     T mUpper;
@@ -258,6 +259,19 @@ class CORE_EXPORT QgsDoubleRange : public QgsRange< double >
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
+
+    bool operator==( const QgsDoubleRange &other ) const
+    {
+      return qgsDoubleNear( mIncludeLower, other.mIncludeLower ) &&
+             qgsDoubleNear( mIncludeUpper, other.mIncludeUpper ) &&
+             mIncludeLower == other.includeLower() &&
+             mIncludeUpper == other.includeUpper();
+    }
+
+    bool operator!=( const QgsDoubleRange &other ) const
+    {
+      return ( ! operator==( other ) );
+    }
 
 };
 

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -70,6 +70,7 @@ QgsRenderContext::QgsRenderContext( const QgsRenderContext &rh )
   , mClippingRegions( rh.mClippingRegions )
   , mFeatureClipGeometry( rh.mFeatureClipGeometry )
   , mTextureOrigin( rh.mTextureOrigin )
+  , mZRange( rh.mZRange )
 #ifdef QGISDEBUG
   , mHasTransformContext( rh.mHasTransformContext )
 #endif
@@ -106,6 +107,7 @@ QgsRenderContext &QgsRenderContext::operator=( const QgsRenderContext &rh )
   mClippingRegions = rh.mClippingRegions;
   mFeatureClipGeometry = rh.mFeatureClipGeometry;
   mTextureOrigin = rh.mTextureOrigin;
+  mZRange = rh.mZRange;
   setIsTemporal( rh.isTemporal() );
   if ( isTemporal() )
     setTemporalRange( rh.temporalRange() );
@@ -237,6 +239,8 @@ QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings &mapSet
   ctx.setIsTemporal( mapSettings.isTemporal() );
   if ( ctx.isTemporal() )
     ctx.setTemporalRange( mapSettings.temporalRange() );
+
+  ctx.setZRange( mapSettings.zRange() );
 
   ctx.mClippingRegions = mapSettings.clippingRegions();
 
@@ -545,6 +549,16 @@ QPointF QgsRenderContext::textureOrigin() const
 void QgsRenderContext::setTextureOrigin( const QPointF &origin )
 {
   mTextureOrigin = origin;
+}
+
+QgsDoubleRange QgsRenderContext::zRange() const
+{
+  return mZRange;
+}
+
+void QgsRenderContext::setZRange( const QgsDoubleRange &range )
+{
+  mZRange = range;
 }
 
 

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -856,6 +856,22 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
      */
     void setTextureOrigin( const QPointF &origin );
 
+    /**
+     * Returns the range of z-values which should be rendered.
+     *
+     * \see setZRange()
+     * \since QGIS 3.18
+     */
+    QgsDoubleRange zRange() const;
+
+    /**
+     * Sets the \a range of z-values which should be rendered.
+     *
+     * \see zRange()
+     * \since QGIS 3.18
+     */
+    void setZRange( const QgsDoubleRange &range );
+
   private:
 
     Flags mFlags;
@@ -951,6 +967,8 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
     QgsGeometry mFeatureClipGeometry;
 
     QPointF mTextureOrigin;
+
+    QgsDoubleRange mZRange;
 
 #ifdef QGISDEBUG
     bool mHasTransformContext = false;

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1326,6 +1326,16 @@ void QgsMapCanvas::zoomToSelected( QgsVectorLayer *layer )
   zoomToFeatureExtent( rect );
 }
 
+QgsDoubleRange QgsMapCanvas::zRange() const
+{
+  return mSettings.zRange();
+}
+
+void QgsMapCanvas::setZRange( const QgsDoubleRange &range )
+{
+  mSettings.setZRange( range );
+}
+
 void QgsMapCanvas::zoomToFeatureExtent( QgsRectangle &rect )
 {
   // no selected features, only one selected point feature

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -879,6 +879,22 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
      */
     const QList<double> &zoomResolutions() const { return mZoomResolutions; }
 
+    /**
+     * Returns the range of z-values which will be visible in the map.
+     *
+     * \see setZRange()
+     * \since QGIS 3.18
+     */
+    QgsDoubleRange zRange() const;
+
+    /**
+     * Sets the \a range of z-values which will be visible in the map.
+     *
+     * \see zRange()
+     * \since QGIS 3.18
+     */
+    void setZRange( const QgsDoubleRange &range );
+
   private slots:
     //! called when current maptool is destroyed
     void mapToolDestroyed();

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -244,7 +244,7 @@ void TestQgsAttributeTable::testVisibleTemporal()
   mQgisApp->mapCanvas()->resize( 500, 500 );
   mQgisApp->mapCanvas()->setLayers( QList< QgsMapLayer *>() << tempLayer.get() );
   mQgisApp->mapCanvas()->setExtent( QgsRectangle( -1, -1, 1, 1 ) );
-  mQgisApp->mapCanvas()->setTemporalRange( QgsDateTimeRange( QDateTime( QDate( 2020, 1, 1 ) ), QDateTime( QDate( 2020, 2, 1 ) ) ) );
+  mQgisApp->mapCanvas()->setTemporalRange( QgsDateTimeRange( QDateTime( QDate( 2020, 1, 1 ), QTime( 0, 0, 0 ) ), QDateTime( QDate( 2020, 2, 1 ), QTime( 0, 0, 0 ) ) ) );
 
   std::unique_ptr< QgsAttributeTableDialog > dlg( new QgsAttributeTableDialog( tempLayer.get(), QgsAttributeTableFilterModel::ShowVisible ) );
 

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -117,6 +117,10 @@ void TestQgsMapSettings::testGettersSetters()
   simplify.setSimplifyHints( QgsVectorSimplifyMethod::GeometrySimplification );
   ms.setSimplifyMethod( simplify );
   QCOMPARE( ms.simplifyMethod().simplifyHints(), QgsVectorSimplifyMethod::GeometrySimplification );
+
+  QVERIFY( ms.zRange().isInfinite() );
+  ms.setZRange( QgsDoubleRange( 1, 10 ) );
+  QCOMPARE( ms.zRange(), QgsDoubleRange( 1, 10 ) );
 }
 
 void TestQgsMapSettings::testLabelingEngineSettings()

--- a/tests/src/python/test_python_repr.py
+++ b/tests/src/python/test_python_repr.py
@@ -316,7 +316,7 @@ class TestPython__repr__(unittest.TestCase):
         self.assertEqual(QgsDoubleRange(1, 10, False).__repr__(),
                          "<QgsDoubleRange: (1, 10]>")
         self.assertEqual(QgsDoubleRange(1, 10, True, False).__repr__(),
-                         "<QgsDoubleRange:  [1, 10)>")
+                         "<QgsDoubleRange: [1, 10)>")
 
     def testIntRange(self):
         self.assertEqual(QgsIntRange(1, 10).__repr__(), "<QgsIntRange: [1, 10]>")

--- a/tests/src/python/test_python_repr.py
+++ b/tests/src/python/test_python_repr.py
@@ -14,13 +14,51 @@ import qgis  # NOQA
 
 from PyQt5.QtCore import QVariant
 from qgis.testing import unittest, start_app
-from qgis.core import QgsGeometry, QgsPoint, QgsPointXY, QgsCircle, QgsCircularString, QgsCompoundCurve,\
-    QgsCurvePolygon, QgsEllipse, QgsLineString, QgsMultiCurve, QgsRectangle, QgsExpression, QgsField, QgsError,\
-    QgsMimeDataUtils, QgsVector, QgsVector3D, QgsVectorLayer, QgsReferencedPointXY, QgsReferencedRectangle,\
-    QgsCoordinateReferenceSystem, QgsCoordinateTransform, QgsProject, QgsClassificationRange, QgsBookmark, \
-    QgsLayoutMeasurement, QgsLayoutPoint, QgsLayoutSize, QgsUnitTypes, QgsConditionalStyle, QgsTableCell, QgsProperty, \
-    QgsVertexId, QgsReferencedGeometry, QgsProviderRegistry, QgsRasterLayer, QgsAnnotationLayer, QgsPointCloudLayer,\
-    QgsVectorTileLayer, QgsMeshLayer, QgsDataSourceUri
+from qgis.core import (
+    QgsGeometry,
+    QgsPoint,
+    QgsPointXY,
+    QgsCircle,
+    QgsCircularString,
+    QgsCompoundCurve,
+    QgsCurvePolygon,
+    QgsEllipse,
+    QgsLineString,
+    QgsMultiCurve,
+    QgsRectangle,
+    QgsExpression,
+    QgsField,
+    QgsError,
+    QgsMimeDataUtils,
+    QgsVector,
+    QgsVector3D,
+    QgsVectorLayer,
+    QgsReferencedPointXY,
+    QgsReferencedRectangle,
+    QgsCoordinateReferenceSystem,
+    QgsCoordinateTransform,
+    QgsProject,
+    QgsClassificationRange,
+    QgsBookmark,
+    QgsLayoutMeasurement,
+    QgsLayoutPoint,
+    QgsLayoutSize,
+    QgsUnitTypes,
+    QgsConditionalStyle,
+    QgsTableCell,
+    QgsProperty,
+    QgsVertexId,
+    QgsReferencedGeometry,
+    QgsProviderRegistry,
+    QgsRasterLayer,
+    QgsAnnotationLayer,
+    QgsPointCloudLayer,
+    QgsVectorTileLayer,
+    QgsMeshLayer,
+    QgsDataSourceUri,
+    QgsDoubleRange,
+    QgsIntRange
+)
 
 start_app()
 
@@ -272,6 +310,20 @@ class TestPython__repr__(unittest.TestCase):
         ds = QgsDataSourceUri()
         ds.setConnection(aHost='my_host', aPort='2322', aDatabase='my_db', aUsername='user', aPassword='pw')
         self.assertEqual(ds.__repr__(), "<QgsDataSourceUri: dbname='my_db' host=my_host port=2322 user='user' password='pw'>")
+
+    def testDoubleRange(self):
+        self.assertEqual(QgsDoubleRange(1, 10).__repr__(), "<QgsDoubleRange: [1, 10]>")
+        self.assertEqual(QgsDoubleRange(1, 10, False).__repr__(),
+                         "<QgsDoubleRange: (1, 10]>")
+        self.assertEqual(QgsDoubleRange(1, 10, True, False).__repr__(),
+                         "<QgsDoubleRange:  [1, 10)>")
+
+    def testIntRange(self):
+        self.assertEqual(QgsIntRange(1, 10).__repr__(), "<QgsIntRange: [1, 10]>")
+        self.assertEqual(QgsIntRange(1, 10, False).__repr__(),
+                         "<QgsIntRange: (1, 10]>")
+        self.assertEqual(QgsIntRange(1, 10, True, False).__repr__(),
+                         "<QgsIntRange: [1, 10)>")
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsrange.py
+++ b/tests/src/python/test_qgsrange.py
@@ -14,6 +14,7 @@ import qgis  # NOQA
 
 from qgis.testing import unittest
 from qgis.core import (QgsIntRange,
+                       QgsDoubleRange,
                        QgsDateRange)
 from qgis.PyQt.QtCore import QDate
 
@@ -32,6 +33,14 @@ class TestQgsIntRange(unittest.TestCase):
         self.assertEqual(range.upper(), 3)
         self.assertFalse(range.includeLower())
         self.assertFalse(range.includeUpper())
+
+    def testIsInfinite(self):
+        range = QgsIntRange()
+        self.assertTrue(range.isInfinite())
+        range2 = QgsIntRange(range.lower(), 5)
+        self.assertFalse(range2.isInfinite())
+        range2 = QgsIntRange(5, range.upper())
+        self.assertFalse(range2.isInfinite())
 
     def testIsEmpty(self):
         range = QgsIntRange(1, 1)
@@ -186,6 +195,30 @@ class TestQgsIntRange(unittest.TestCase):
         self.assertFalse(range.overlaps(QgsIntRange(-1, 0)))
         self.assertFalse(range.overlaps(QgsIntRange(-10, -1)))
         self.assertFalse(range.overlaps(QgsIntRange(11, 12)))
+
+
+class TestQgsDoubleRange(unittest.TestCase):
+
+    def testGetters(self):
+        range = QgsDoubleRange(1.0, 11.0)
+        self.assertEqual(range.lower(), 1)
+        self.assertEqual(range.upper(), 11)
+        self.assertTrue(range.includeLower())
+        self.assertTrue(range.includeUpper())
+
+        range = QgsDoubleRange(-1.0, 3.0, False, False)
+        self.assertEqual(range.lower(), -1)
+        self.assertEqual(range.upper(), 3)
+        self.assertFalse(range.includeLower())
+        self.assertFalse(range.includeUpper())
+
+    def testIsInfinite(self):
+        range = QgsDoubleRange()
+        self.assertTrue(range.isInfinite())
+        range2 = QgsDoubleRange(range.lower(), 5)
+        self.assertFalse(range2.isInfinite())
+        range2 = QgsDoubleRange(5, range.upper())
+        self.assertFalse(range2.isInfinite())
 
 
 class TestQgsDateRange(unittest.TestCase):

--- a/tests/src/python/test_qgsrange.py
+++ b/tests/src/python/test_qgsrange.py
@@ -42,6 +42,13 @@ class TestQgsIntRange(unittest.TestCase):
         range2 = QgsIntRange(5, range.upper())
         self.assertFalse(range2.isInfinite())
 
+    def testEquality(self):
+        self.assertEqual(QgsIntRange(1, 10), QgsIntRange(1, 10))
+        self.assertNotEqual(QgsIntRange(1, 10), QgsIntRange(1, 11))
+        self.assertNotEqual(QgsIntRange(1, 10), QgsIntRange(2, 10))
+        self.assertNotEqual(QgsIntRange(1, 10, False), QgsIntRange(1, 10))
+        self.assertNotEqual(QgsIntRange(1, 10, True, False), QgsIntRange(1, 10))
+
     def testIsEmpty(self):
         range = QgsIntRange(1, 1)
         # should not be empty because 1 is included
@@ -211,6 +218,13 @@ class TestQgsDoubleRange(unittest.TestCase):
         self.assertEqual(range.upper(), 3)
         self.assertFalse(range.includeLower())
         self.assertFalse(range.includeUpper())
+
+    def testEquality(self):
+        self.assertEqual(QgsDoubleRange(1, 10), QgsDoubleRange(1, 10))
+        self.assertNotEqual(QgsDoubleRange(1, 10), QgsDoubleRange(1, 11))
+        self.assertNotEqual(QgsDoubleRange(1, 10), QgsDoubleRange(2, 10))
+        self.assertNotEqual(QgsDoubleRange(1, 10, False), QgsDoubleRange(1, 10))
+        self.assertNotEqual(QgsDoubleRange(1, 10, True, False), QgsDoubleRange(1, 10))
 
     def testIsInfinite(self):
         range = QgsDoubleRange()

--- a/tests/src/python/test_qgsrendercontext.py
+++ b/tests/src/python/test_qgsrendercontext.py
@@ -25,7 +25,8 @@ from qgis.core import (QgsRenderContext,
                        QgsRenderedFeatureHandlerInterface,
                        QgsDateTimeRange,
                        QgsMapClippingRegion,
-                       QgsGeometry)
+                       QgsGeometry,
+                       QgsDoubleRange)
 from qgis.PyQt.QtCore import QSize, QDateTime
 from qgis.PyQt.QtGui import QPainter, QImage
 from qgis.testing import start_app, unittest
@@ -58,6 +59,10 @@ class TestQgsRenderContext(unittest.TestCase):
         c.setMapExtent(QgsRectangle(1, 2, 3, 4))
         self.assertEqual(c.mapExtent(), QgsRectangle(1, 2, 3, 4))
 
+        self.assertTrue(c.zRange().isInfinite())
+        c.setZRange(QgsDoubleRange(1, 10))
+        self.assertEqual(c.zRange(), QgsDoubleRange(1, 10))
+
     def testCopyConstructor(self):
         """
         Test the copy constructor
@@ -66,10 +71,12 @@ class TestQgsRenderContext(unittest.TestCase):
 
         c1.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysText)
         c1.setMapExtent(QgsRectangle(1, 2, 3, 4))
+        c1.setZRange(QgsDoubleRange(1, 10))
 
         c2 = QgsRenderContext(c1)
         self.assertEqual(c2.textRenderFormat(), QgsRenderContext.TextFormatAlwaysText)
         self.assertEqual(c2.mapExtent(), QgsRectangle(1, 2, 3, 4))
+        self.assertEqual(c2.zRange(), QgsDoubleRange(1, 10))
 
         c1.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysOutlines)
         c2 = QgsRenderContext(c1)
@@ -129,6 +136,7 @@ class TestQgsRenderContext(unittest.TestCase):
         ms.setFlag(QgsMapSettings.Antialiasing, True)
         ms.setFlag(QgsMapSettings.LosslessImageRendering, True)
         ms.setFlag(QgsMapSettings.Render3DMap, True)
+        ms.setZRange(QgsDoubleRange(1, 10))
 
         ms.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysText)
         rc = QgsRenderContext.fromMapSettings(ms)
@@ -136,10 +144,13 @@ class TestQgsRenderContext(unittest.TestCase):
         self.assertTrue(rc.testFlag(QgsRenderContext.Antialiasing))
         self.assertTrue(rc.testFlag(QgsRenderContext.LosslessImageRendering))
         self.assertTrue(rc.testFlag(QgsRenderContext.Render3DMap))
+        self.assertEqual(ms.zRange(), QgsDoubleRange(1, 10))
 
         ms.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysOutlines)
+        ms.setZRange(QgsDoubleRange())
         rc = QgsRenderContext.fromMapSettings(ms)
         self.assertEqual(rc.textRenderFormat(), QgsRenderContext.TextFormatAlwaysOutlines)
+        self.assertTrue(ms.zRange().isInfinite())
 
         self.assertEqual(rc.mapExtent(), QgsRectangle(10000, 20000, 30000, 40000))
 


### PR DESCRIPTION
Implements https://github.com/qgis/QGIS-Enhancement-Proposals/issues/201, and adds support for setting z range for filtering map renders to QgsMapSettings/QgsRenderContext/QgsMapCanvas.

API only for now, and requires support to be added to the various map layer types.