### PR TITLE
Add a dual handle range slider widget

### DIFF
--- a/python/gui/auto_generated/qgsrangeslider.sip.in
+++ b/python/gui/auto_generated/qgsrangeslider.sip.in
@@ -1,0 +1,217 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsrangeslider.h                                             *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsRangeSlider : QWidget
+{
+%Docstring
+A slider control with two interactive endpoints, for interactive selection of a range of values.
+
+.. versionadded:: 3.18
+%End
+
+%TypeHeaderCode
+#include "qgsrangeslider.h"
+%End
+  public:
+
+    QgsRangeSlider( QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsRangeSlider, with the specified ``parent`` widget.
+%End
+
+    int minimum() const;
+%Docstring
+Returns the minimum value allowed by the widget.
+
+.. seealso:: :py:func:`setMinimum`
+
+.. seealso:: :py:func:`maximum`
+%End
+
+    int maximum() const;
+%Docstring
+Returns the maximum value allowed by the widget.
+
+.. seealso:: :py:func:`setMaximum`
+
+.. seealso:: :py:func:`minimum`
+%End
+
+    int lowerValue() const;
+%Docstring
+Returns the lower value for the range selected in the widget.
+
+.. seealso:: :py:func:`upperValue`
+
+.. seealso:: :py:func:`setLowerValue`
+%End
+
+    int upperValue() const;
+%Docstring
+Returns the upper value for the range selected in the widget.
+
+.. seealso:: :py:func:`lowerValue`
+
+.. seealso:: :py:func:`setUpperValue`
+%End
+
+    void setTickPosition( QSlider::TickPosition position );
+%Docstring
+Sets the ``position`` of the tick marks shown in the widget.
+
+.. seealso:: :py:func:`tickPosition`
+%End
+
+    QSlider::TickPosition tickPosition() const;
+%Docstring
+Returns the position of the tick marks shown in the widget.
+
+.. seealso:: :py:func:`setTickPosition`
+%End
+
+    void setTickInterval( int interval );
+%Docstring
+Sets the ``interval`` for tick marks shown in the widget.
+
+.. seealso:: :py:func:`tickInterval`
+%End
+
+    int tickInterval() const;
+%Docstring
+Returns the interval for tick marks shown in the widget.
+
+.. seealso:: :py:func:`setTickInterval`
+%End
+
+    void setOrientation( Qt::Orientation orientation );
+%Docstring
+Sets the ``orientation`` of the slider.
+
+.. seealso:: :py:func:`orientation`
+%End
+
+    Qt::Orientation orientation() const;
+%Docstring
+Returns the orientation of the slider.
+
+.. seealso:: :py:func:`setOrientation`
+%End
+
+    bool invertedAppearance() const;
+%Docstring
+Returns ``True`` if the slider has its values inverted.
+
+If this property is ``False`` (the default), the minimum and maximum will be shown in its classic
+position for the widget. If the value is ``True``, the minimum and maximum appear at their opposite location.
+
+.. seealso:: :py:func:`setInvertedAppearance`
+%End
+
+    void setInvertedAppearance( bool inverted );
+%Docstring
+Sets whether the slider has its values ``inverted``.
+
+If this property is ``False`` (the default), the minimum and maximum will be shown in its classic
+position for the widget. If the value is ``True``, the minimum and maximum appear at their opposite location.
+
+.. seealso:: :py:func:`setInvertedAppearance`
+%End
+
+    virtual void paintEvent( QPaintEvent *event );
+
+    virtual void mousePressEvent( QMouseEvent *event );
+
+    virtual void mouseMoveEvent( QMouseEvent *event );
+
+    virtual QSize sizeHint() const;
+
+
+  public slots:
+
+    void setMaximum( int maximum );
+%Docstring
+Sets the ``maximum`` value allowed in the widget.
+
+.. seealso:: :py:func:`maximum`
+
+.. seealso:: :py:func:`setMinimum`
+%End
+
+    void setMinimum( int minimum );
+%Docstring
+Sets the ``minimum`` value allowed in the widget.
+
+.. seealso:: :py:func:`minimum`
+
+.. seealso:: :py:func:`setMaximum`
+%End
+
+    void setRangeLimits( int minimum, int maximum );
+%Docstring
+Sets the ``minimum`` and ``maximum`` range limits for values allowed in the widget.
+
+.. seealso:: :py:func:`setMinimum`
+
+.. seealso:: :py:func:`setMaximum`
+%End
+
+    void setLowerValue( int value );
+%Docstring
+Sets the lower ``value`` for the range currently selected in the widget.
+
+.. seealso:: :py:func:`lowerValue`
+
+.. seealso:: :py:func:`setRange`
+
+.. seealso:: :py:func:`setUpperValue`
+%End
+
+    void setUpperValue( int value );
+%Docstring
+Sets the upper ``value`` for the range currently selected in the widget.
+
+.. seealso:: :py:func:`upperValue`
+
+.. seealso:: :py:func:`setRange`
+
+.. seealso:: :py:func:`setLowerValue`
+%End
+
+    void setRange( int lower, int upper );
+%Docstring
+Sets the current range selected in the widget.
+
+.. seealso:: :py:func:`setLowerValue`
+
+.. seealso:: :py:func:`setUpperValue`
+%End
+
+  signals:
+
+    void rangeChanged( int minimum, int maximum );
+%Docstring
+Emitted when the range selected in the widget is changed.
+%End
+
+    void rangeLimitsChanged( int minimum, int maximum );
+%Docstring
+Emitted when the limits of values allowed in the widget is changed.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsrangeslider.h                                             *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/qgsrangeslider.sip.in
+++ b/python/gui/auto_generated/qgsrangeslider.sip.in
@@ -142,6 +142,8 @@ position for the widget. If the value is ``True``, the minimum and maximum appea
 
     virtual QSize sizeHint() const;
 
+    virtual QSize minimumSizeHint() const;
+
 
   public slots:
 

--- a/python/gui/auto_generated/qgsrangeslider.sip.in
+++ b/python/gui/auto_generated/qgsrangeslider.sip.in
@@ -112,24 +112,25 @@ Returns the orientation of the slider.
 .. seealso:: :py:func:`setOrientation`
 %End
 
-    bool invertedAppearance() const;
+    bool flippedDirection() const;
 %Docstring
-Returns ``True`` if the slider has its values inverted.
+Returns ``True`` if the slider has its values flipped.
 
 If this property is ``False`` (the default), the minimum and maximum will be shown in its classic
 position for the widget. If the value is ``True``, the minimum and maximum appear at their opposite location.
 
-.. seealso:: :py:func:`setInvertedAppearance`
+.. seealso:: :py:func:`setFlippedDirection`
 %End
 
-    void setInvertedAppearance( bool inverted );
+    void setFlippedDirection( bool flipped );
 %Docstring
-Sets whether the slider has its values ``inverted``.
+Sets whether the slider has its values ``flipped``.
 
 If this property is ``False`` (the default), the minimum and maximum will be shown in its classic
 position for the widget. If the value is ``True``, the minimum and maximum appear at their opposite location.
+(i.e. minimum at the bottom of a vertical slider, maximum at the top of a vertical slider).
 
-.. seealso:: :py:func:`setInvertedAppearance`
+.. seealso:: :py:func:`flippedDirection`
 %End
 
     virtual void paintEvent( QPaintEvent *event );

--- a/python/gui/auto_generated/qgsrangeslider.sip.in
+++ b/python/gui/auto_generated/qgsrangeslider.sip.in
@@ -146,6 +146,28 @@ position for the widget. If the value is ``True``, the minimum and maximum appea
     virtual QSize minimumSizeHint() const;
 
 
+    int singleStep() const;
+%Docstring
+Returns the single step value for the widget.
+
+This corresponds to the smaller increment or decrement applied when the user presses an arrow key.
+
+.. seealso:: :py:func:`setSingleStep`
+
+.. seealso:: :py:func:`pageStep`
+%End
+
+    int pageStep() const;
+%Docstring
+Returns the page step value for the widget.
+
+This corresponds to the larger increment or decrement applied when the user presses the page increment key (usually PageUp or PageDown).
+
+.. seealso:: :py:func:`setPageStep`
+
+.. seealso:: :py:func:`singleStep`
+%End
+
   public slots:
 
     void setMaximum( int maximum );
@@ -204,6 +226,28 @@ Sets the current range selected in the widget.
 .. seealso:: :py:func:`setLowerValue`
 
 .. seealso:: :py:func:`setUpperValue`
+%End
+
+    void setSingleStep( int step );
+%Docstring
+Sets the single ``step`` value for the widget.
+
+This corresponds to the smaller increment or decrement applied when the user presses an arrow key.
+
+.. seealso:: :py:func:`singleStep`
+
+.. seealso:: :py:func:`pageStep`
+%End
+
+    void setPageStep( int step );
+%Docstring
+Sets the page ``step`` value for the widget.
+
+This corresponds to the larger increment or decrement applied when the user presses the page increment key (usually PageUp or PageDown).
+
+.. seealso:: :py:func:`pageStep`
+
+.. seealso:: :py:func:`setSingleStep`
 %End
 
     virtual bool event( QEvent *event );

--- a/python/gui/auto_generated/qgsrangeslider.sip.in
+++ b/python/gui/auto_generated/qgsrangeslider.sip.in
@@ -27,6 +27,13 @@ A slider control with two interactive endpoints, for interactive selection of a 
 Constructor for QgsRangeSlider, with the specified ``parent`` widget.
 %End
 
+    QgsRangeSlider( Qt::Orientation orientation, QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsRangeSlider, with the specified ``parent`` widget.
+
+The ``orientation`` parameter determines whether the slider is horizontal or vertical.
+%End
+
     int minimum() const;
 %Docstring
 Returns the minimum value allowed by the widget.

--- a/python/gui/auto_generated/qgsrangeslider.sip.in
+++ b/python/gui/auto_generated/qgsrangeslider.sip.in
@@ -131,6 +131,8 @@ position for the widget. If the value is ``True``, the minimum and maximum appea
 
     virtual void mouseMoveEvent( QMouseEvent *event );
 
+    virtual void mouseReleaseEvent( QMouseEvent *event );
+
     virtual QSize sizeHint() const;
 
 
@@ -193,6 +195,9 @@ Sets the current range selected in the widget.
 
 .. seealso:: :py:func:`setUpperValue`
 %End
+
+    virtual bool event( QEvent *event );
+
 
   signals:
 

--- a/python/gui/auto_generated/qgsrangeslider.sip.in
+++ b/python/gui/auto_generated/qgsrangeslider.sip.in
@@ -141,6 +141,8 @@ position for the widget. If the value is ``True``, the minimum and maximum appea
 
     virtual void mouseReleaseEvent( QMouseEvent *event );
 
+    virtual void keyPressEvent( QKeyEvent *event );
+
     virtual QSize sizeHint() const;
 
     virtual QSize minimumSizeHint() const;

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -171,6 +171,7 @@
 %Include auto_generated/qgsproviderguiregistry.sip
 %Include auto_generated/qgsproxystyle.sip
 %Include auto_generated/qgsquerybuilder.sip
+%Include auto_generated/qgsrangeslider.sip
 %Include auto_generated/qgsrasterformatsaveoptionswidget.sip
 %Include auto_generated/qgsrasterlayersaveasdialog.sip
 %Include auto_generated/qgsrasterpyramidsoptionswidget.sip

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -551,6 +551,7 @@ set(QGIS_GUI_SRCS
   qgsproviderconnectioncombobox.cpp
   qgsproxystyle.cpp
   qgsquerybuilder.cpp
+  qgsrangeslider.cpp
   qgsrasterformatsaveoptionswidget.cpp
   qgsrasterlayersaveasdialog.cpp
   qgsrasterpyramidsoptionswidget.cpp
@@ -791,6 +792,7 @@ set(QGIS_GUI_HDRS
   qgsproviderguiregistry.h
   qgsproxystyle.h
   qgsquerybuilder.h
+  qgsrangeslider.h
   qgsrasterformatsaveoptionswidget.h
   qgsrasterlayersaveasdialog.h
   qgsrasterpyramidsoptionswidget.h

--- a/src/gui/qgsrangeslider.cpp
+++ b/src/gui/qgsrangeslider.cpp
@@ -317,6 +317,26 @@ QRect QgsRangeSlider::selectedRangeRect()
   return selectionRect.adjusted( -1, 1, 1, -1 );
 }
 
+int QgsRangeSlider::pageStep() const
+{
+  return mPageStep;
+}
+
+void QgsRangeSlider::setPageStep( int step )
+{
+  mPageStep = step;
+}
+
+int QgsRangeSlider::singleStep() const
+{
+  return mSingleStep;
+}
+
+void QgsRangeSlider::setSingleStep( int step )
+{
+  mSingleStep = step;
+}
+
 void QgsRangeSlider::setTickPosition( QSlider::TickPosition position )
 {
   mStyleOption.tickPosition = position;

--- a/src/gui/qgsrangeslider.cpp
+++ b/src/gui/qgsrangeslider.cpp
@@ -430,21 +430,29 @@ void QgsRangeSlider::mousePressEvent( QMouseEvent *event )
 
   mPreDragLowerValue = mLowerValue;
   mPreDragUpperValue = mUpperValue;
+  mRangeDragOffset = 0;
 
-  if ( overLowerControl && overUpperControl )
+  if ( ( overLowerControl || overUpperControl ) && event->modifiers() & Qt::ShiftModifier )
+  {
+    mActiveControl = Range; // shift + drag over handle moves the whole range
+    mRangeDragOffset = overUpperControl ? mUpperClickOffset : mLowerClickOffset;
+  }
+  else if ( overLowerControl && overUpperControl )
     mActiveControl = Both;
   else if ( overLowerControl )
     mActiveControl = Lower;
   else if ( overUpperControl )
     mActiveControl = Upper;
   else if ( overSelectedRange )
+  {
     mActiveControl = Range;
+  }
   else
     mActiveControl = None;
 
   if ( mActiveControl != None )
   {
-    mStartDragPos = pixelPosToRangeValue( pick( event->pos() ) );
+    mStartDragPos = pixelPosToRangeValue( pick( event->pos() ) - mRangeDragOffset );
   }
 }
 
@@ -531,6 +539,7 @@ void QgsRangeSlider::mouseMoveEvent( QMouseEvent *event )
 
     case Range:
     {
+      newPosition = pixelPosToRangeValue( pick( event->pos() ) - mRangeDragOffset ) ;
       int delta = newPosition - mStartDragPos;
 
       if ( delta > 0 )

--- a/src/gui/qgsrangeslider.cpp
+++ b/src/gui/qgsrangeslider.cpp
@@ -444,14 +444,11 @@ void QgsRangeSlider::mouseMoveEvent( QMouseEvent *event )
     case Lower:
     {
       // adjust value to account for lower handle click offset
-      newPosition = pixelPosToRangeValue( pick( event->pos() ) - mLowerClickOffset );
-      if ( newPosition <= mUpperValue )
+      newPosition = std::min( mUpperValue, pixelPosToRangeValue( pick( event->pos() ) - mLowerClickOffset ) );
+      if ( mLowerValue != newPosition )
       {
-        if ( mLowerValue != newPosition )
-        {
-          mLowerValue = newPosition;
-          changed = true;
-        }
+        mLowerValue = newPosition;
+        changed = true;
       }
       break;
     }
@@ -459,14 +456,11 @@ void QgsRangeSlider::mouseMoveEvent( QMouseEvent *event )
     case Upper:
     {
       // adjust value to account for upper handle click offset
-      newPosition = pixelPosToRangeValue( pick( event->pos() ) - mUpperClickOffset );
-      if ( newPosition >= mLowerValue )
+      newPosition = std::max( mLowerValue, pixelPosToRangeValue( pick( event->pos() ) - mUpperClickOffset ) );
+      if ( mUpperValue != newPosition )
       {
-        if ( mUpperValue != newPosition )
-        {
-          mUpperValue = newPosition;
-          changed = true;
-        }
+        mUpperValue = newPosition;
+        changed = true;
       }
       break;
     }

--- a/src/gui/qgsrangeslider.cpp
+++ b/src/gui/qgsrangeslider.cpp
@@ -18,10 +18,16 @@
 #include <QMouseEvent>
 
 QgsRangeSlider::QgsRangeSlider( QWidget *parent )
+  : QgsRangeSlider( Qt::Horizontal, parent )
+{
+}
+
+QgsRangeSlider::QgsRangeSlider( Qt::Orientation orientation, QWidget *parent )
   : QWidget( parent )
 {
   mStyleOption.minimum = 0;
   mStyleOption.maximum = 100;
+  mStyleOption.orientation = orientation;
 
   setFocusPolicy( Qt::FocusPolicy( style()->styleHint( QStyle::SH_Button_FocusPolicy ) ) );
   QSizePolicy sp( QSizePolicy::Expanding, QSizePolicy::Fixed, QSizePolicy::Slider );

--- a/src/gui/qgsrangeslider.cpp
+++ b/src/gui/qgsrangeslider.cpp
@@ -36,7 +36,8 @@ QgsRangeSlider::QgsRangeSlider( Qt::Orientation orientation, QWidget *parent )
   setSizePolicy( sp );
   setAttribute( Qt::WA_WState_OwnSizePolicy, false );
 
-  installEventFilter( this );
+  setAttribute( Qt::WA_Hover );
+  setMouseTracking( true );
 }
 
 int QgsRangeSlider::maximum() const
@@ -233,30 +234,39 @@ bool QgsRangeSlider::newHoverControl( const QPoint &pos )
     mHoverRect = lowerHandleRect;
     mHoverControl = Lower;
     mHoverSubControl = QStyle::SC_SliderHandle;
+    setCursor( Qt::OpenHandCursor );
   }
   else if ( upperHandleRect.contains( pos ) )
   {
     mHoverRect = upperHandleRect;
     mHoverControl = Upper;
     mHoverSubControl = QStyle::SC_SliderHandle;
+    setCursor( Qt::OpenHandCursor );
   }
   else if ( grooveRect.contains( pos ) )
   {
     mHoverRect = grooveRect;
     mHoverControl = None;
     mHoverSubControl = QStyle::SC_SliderGroove;
+
+    if ( selectedRangeRect().contains( pos ) )
+      setCursor( Qt::OpenHandCursor );
+    else
+      unsetCursor();
   }
   else if ( tickmarksRect.contains( pos ) )
   {
     mHoverRect = tickmarksRect;
     mHoverControl = None;
     mHoverSubControl = QStyle::SC_SliderTickmarks;
+    unsetCursor();
   }
   else
   {
     mHoverRect = QRect();
     mHoverControl = None;
     mHoverSubControl = QStyle::SC_None;
+    unsetCursor();
   }
   return mHoverSubControl != lastHoverSubControl || mHoverControl != lastHoverControl;
 }

--- a/src/gui/qgsrangeslider.cpp
+++ b/src/gui/qgsrangeslider.cpp
@@ -936,14 +936,49 @@ void QgsRangeSlider::keyPressEvent( QKeyEvent *event )
       break;
     }
 
-#if 0
     case Qt::Key_Home:
-      action = SliderToMinimum;
+      switch ( mFocusControl )
+      {
+        case Lower:
+          applyStep( mFlipped ? mUpperValue - mLowerValue : mStyleOption.minimum - mLowerValue );
+          break;
+
+        case Upper:
+          applyStep( mFlipped ? mStyleOption.maximum - mUpperValue : mLowerValue - mUpperValue );
+          break;
+
+        case Range:
+          applyStep( mFlipped ? mStyleOption.maximum - mUpperValue : mStyleOption.minimum  - mLowerValue );
+          break;
+
+        case None:
+        case Both:
+          break;
+      }
+
       break;
+
     case Qt::Key_End:
-      action = SliderToMaximum;
+      switch ( mFocusControl )
+      {
+        case Lower:
+          applyStep( mFlipped ? mStyleOption.minimum - mLowerValue : mUpperValue - mLowerValue );
+          break;
+
+        case Upper:
+          applyStep( mFlipped ? mLowerValue - mUpperValue : mStyleOption.maximum - mUpperValue );
+          break;
+
+        case Range:
+          applyStep( mFlipped ? mStyleOption.minimum  - mLowerValue : mStyleOption.maximum - mUpperValue );
+          break;
+
+        case None:
+        case Both:
+          break;
+      }
       break;
-#endif
+
     default:
       event->ignore();
       break;

--- a/src/gui/qgsrangeslider.cpp
+++ b/src/gui/qgsrangeslider.cpp
@@ -494,17 +494,33 @@ void QgsRangeSlider::mouseReleaseEvent( QMouseEvent *event )
 
 QSize QgsRangeSlider::sizeHint() const
 {
-  static constexpr int sliderLength = 84;
-  static constexpr int tickSpace = 5;
+  ensurePolished();
 
-  int w = sliderLength;
-  int h = style()->pixelMetric( QStyle::PM_SliderThickness, &mStyleOption, this );
+  // these hardcoded magic values look like a hack, but they are taken straight from the Qt QSlider widget code!
+  static constexpr int SLIDER_LENGTH = 84;
+  static constexpr int TICK_SPACE = 5;
 
-  if ( mStyleOption.tickPosition & QSlider::TicksAbove || mStyleOption.tickPosition & QSlider::TicksBelow )
+  int thick = style()->pixelMetric( QStyle::PM_SliderThickness, &mStyleOption, this );
+  if ( mStyleOption.tickPosition & QSlider::TicksAbove )
+    thick += TICK_SPACE;
+  if ( mStyleOption.tickPosition & QSlider::TicksBelow )
+    thick += TICK_SPACE;
+  int w = thick, h = SLIDER_LENGTH;
+  if ( mStyleOption.orientation == Qt::Horizontal )
   {
-    h += tickSpace;
+    std::swap( w, h );
   }
-
   return style()->sizeFromContents( QStyle::CT_Slider, &mStyleOption, QSize( w, h ), this );
+}
+
+QSize QgsRangeSlider::minimumSizeHint() const
+{
+  QSize s = sizeHint();
+  int length = style()->pixelMetric( QStyle::PM_SliderLength, &mStyleOption, this );
+  if ( mStyleOption.orientation == Qt::Horizontal )
+    s.setWidth( length );
+  else
+    s.setHeight( length );
+  return s;
 }
 

--- a/src/gui/qgsrangeslider.cpp
+++ b/src/gui/qgsrangeslider.cpp
@@ -708,6 +708,10 @@ void QgsRangeSlider::mouseReleaseEvent( QMouseEvent *event )
 
 void QgsRangeSlider::keyPressEvent( QKeyEvent *event )
 {
+  Control destControl = mFocusControl;
+  if ( ( destControl == Lower || destControl == Upper ) && mLowerValue == mUpperValue )
+    destControl = Both; //ambiguous destination, because both sliders are on top of each other
+
   switch ( event->key() )
   {
     case Qt::Key_Left:
@@ -715,6 +719,9 @@ void QgsRangeSlider::keyPressEvent( QKeyEvent *event )
       switch ( mStyleOption.orientation )
       {
         case Qt::Horizontal:
+          if ( destControl == Both )
+            mFocusControl = mFlipped ? Upper : Lower;
+
           applyStep( mFlipped ? mSingleStep : -mSingleStep );
           break;
 
@@ -764,6 +771,8 @@ void QgsRangeSlider::keyPressEvent( QKeyEvent *event )
       switch ( mStyleOption.orientation )
       {
         case Qt::Horizontal:
+          if ( destControl == Both )
+            mFocusControl = mFlipped ? Lower : Upper;
           applyStep( mFlipped ? -mSingleStep : mSingleStep );
           break;
 
@@ -851,6 +860,9 @@ void QgsRangeSlider::keyPressEvent( QKeyEvent *event )
           break;
 
         case Qt::Vertical:
+          if ( destControl == Both )
+            mFocusControl = mFlipped ? Upper : Lower;
+
           applyStep( mFlipped ? mSingleStep : -mSingleStep );
           break;
       }
@@ -900,6 +912,9 @@ void QgsRangeSlider::keyPressEvent( QKeyEvent *event )
           break;
 
         case Qt::Vertical:
+          if ( destControl == Both )
+            mFocusControl = mFlipped ? Lower : Upper;
+
           applyStep( mFlipped ? -mSingleStep : mSingleStep );
           break;
       }
@@ -911,10 +926,16 @@ void QgsRangeSlider::keyPressEvent( QKeyEvent *event )
       switch ( mStyleOption.orientation )
       {
         case Qt::Horizontal:
+          if ( destControl == Both )
+            mFocusControl = mFlipped ? Lower : Upper;
+
           applyStep( mFlipped ? -mPageStep : mPageStep );
           break;
 
         case Qt::Vertical:
+          if ( destControl == Both )
+            mFocusControl = mFlipped ? Upper : Lower;
+
           applyStep( mFlipped ? mPageStep : -mPageStep );
           break;
       }
@@ -926,10 +947,16 @@ void QgsRangeSlider::keyPressEvent( QKeyEvent *event )
       switch ( mStyleOption.orientation )
       {
         case Qt::Horizontal:
+          if ( destControl == Both )
+            mFocusControl = mFlipped ? Upper : Lower;
+
           applyStep( mFlipped ? mPageStep : -mPageStep );
           break;
 
         case Qt::Vertical:
+          if ( destControl == Both )
+            mFocusControl = mFlipped ? Lower : Upper;
+
           applyStep( mFlipped ? -mPageStep : mPageStep );
           break;
       }
@@ -937,7 +964,7 @@ void QgsRangeSlider::keyPressEvent( QKeyEvent *event )
     }
 
     case Qt::Key_Home:
-      switch ( mFocusControl )
+      switch ( destControl )
       {
         case Lower:
           applyStep( mFlipped ? mUpperValue - mLowerValue : mStyleOption.minimum - mLowerValue );
@@ -951,15 +978,21 @@ void QgsRangeSlider::keyPressEvent( QKeyEvent *event )
           applyStep( mFlipped ? mStyleOption.maximum - mUpperValue : mStyleOption.minimum  - mLowerValue );
           break;
 
-        case None:
         case Both:
+          if ( destControl == Both )
+            mFocusControl = mFlipped ? Upper : Lower;
+
+          applyStep( mFlipped ? mStyleOption.maximum - mUpperValue : mStyleOption.minimum - mLowerValue );
+          break;
+
+        case None:
           break;
       }
 
       break;
 
     case Qt::Key_End:
-      switch ( mFocusControl )
+      switch ( destControl )
       {
         case Lower:
           applyStep( mFlipped ? mStyleOption.minimum - mLowerValue : mUpperValue - mLowerValue );
@@ -973,8 +1006,14 @@ void QgsRangeSlider::keyPressEvent( QKeyEvent *event )
           applyStep( mFlipped ? mStyleOption.minimum  - mLowerValue : mStyleOption.maximum - mUpperValue );
           break;
 
-        case None:
         case Both:
+          if ( destControl == Both )
+            mFocusControl = mFlipped ? Lower : Upper;
+
+          applyStep( mFlipped ? mStyleOption.minimum - mLowerValue : mStyleOption.maximum - mUpperValue );
+          break;
+
+        case None:
           break;
       }
       break;

--- a/src/gui/qgsrangeslider.cpp
+++ b/src/gui/qgsrangeslider.cpp
@@ -1,0 +1,289 @@
+/***************************************************************************
+    qgsrangeslider.cpp
+    ---------------------
+    begin                : November 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsrangeslider.h"
+#include <QPainter>
+#include <QMouseEvent>
+
+QgsRangeSlider::QgsRangeSlider( QWidget *parent )
+  : QWidget( parent )
+{
+  mStyleOption.minimum = 0;
+  mStyleOption.maximum = 100;
+}
+
+int QgsRangeSlider::maximum() const
+{
+  return mStyleOption.maximum;
+}
+
+void QgsRangeSlider::setMaximum( int maximum )
+{
+  if ( mStyleOption.maximum == maximum )
+    return;
+
+  mStyleOption.maximum = maximum;
+  emit rangeLimitsChanged( mStyleOption.minimum, mStyleOption.maximum );
+  update();
+}
+
+int QgsRangeSlider::minimum() const
+{
+  return mStyleOption.minimum;
+}
+
+void QgsRangeSlider::setMinimum( int minimum )
+{
+  if ( mStyleOption.minimum == minimum )
+    return;
+  mStyleOption.minimum = minimum;
+  emit rangeLimitsChanged( mStyleOption.minimum, mStyleOption.maximum );
+  update();
+}
+
+void QgsRangeSlider::setRangeLimits( int minimum, int maximum )
+{
+  if ( mStyleOption.minimum == minimum && mStyleOption.maximum == maximum )
+    return;
+
+  mStyleOption.minimum = minimum;
+  mStyleOption.maximum = maximum;
+  emit rangeLimitsChanged( mStyleOption.minimum, mStyleOption.maximum );
+  update();
+}
+
+int QgsRangeSlider::lowerValue() const
+{
+  return mLowerValue;
+}
+
+void QgsRangeSlider::setLowerValue( int lowerValue )
+{
+  if ( lowerValue == mLowerValue )
+    return;
+
+  mLowerValue = lowerValue;
+  emit rangeChanged( mLowerValue, mUpperValue );
+  update();
+}
+
+int QgsRangeSlider::upperValue() const
+{
+  return mUpperValue;
+}
+
+
+void QgsRangeSlider::setUpperValue( int upperValue )
+{
+  if ( upperValue == mUpperValue )
+    return;
+
+  mUpperValue = upperValue;
+  emit rangeChanged( mLowerValue, mUpperValue );
+  update();
+}
+
+void QgsRangeSlider::setRange( int lower, int upper )
+{
+  if ( lower == mLowerValue && upper == mUpperValue )
+    return;
+
+  mLowerValue = lower;
+  mUpperValue = upper;
+  emit rangeChanged( mLowerValue, mUpperValue );
+  update();
+}
+
+void QgsRangeSlider::setTickPosition( QSlider::TickPosition position )
+{
+  mStyleOption.tickPosition = position;
+  update();
+}
+
+QSlider::TickPosition QgsRangeSlider::tickPosition() const
+{
+  return mStyleOption.tickPosition;
+}
+
+void QgsRangeSlider::setTickInterval( int interval )
+{
+  mStyleOption.tickInterval = interval;
+  update();
+}
+
+int QgsRangeSlider::tickInterval() const
+{
+  return mStyleOption.tickInterval;
+}
+
+void QgsRangeSlider::setOrientation( Qt::Orientation orientation )
+{
+  mStyleOption.orientation = orientation;
+  update();
+}
+
+Qt::Orientation QgsRangeSlider::orientation() const
+{
+  return mStyleOption.orientation;
+}
+
+bool QgsRangeSlider::invertedAppearance() const
+{
+  return mInverted;
+}
+
+void QgsRangeSlider::setInvertedAppearance( bool inverted )
+{
+  mInverted = inverted;
+  update();
+}
+
+void QgsRangeSlider::paintEvent( QPaintEvent * )
+{
+  QPainter painter( this );
+
+  mStyleOption.initFrom( this );
+  mStyleOption.rect = rect();
+  mStyleOption.sliderPosition = 0;
+  mStyleOption.subControls = QStyle::SC_SliderGroove | QStyle::SC_SliderTickmarks;
+
+  // draw groove
+  style()->drawComplexControl( QStyle::CC_Slider, &mStyleOption, &painter );
+
+  QColor color = palette().color( QPalette::Highlight );
+  color.setAlpha( 160 );
+  painter.setBrush( QBrush( color ) );
+  painter.setPen( Qt::NoPen );
+
+  mStyleOption.sliderPosition = mInverted ? mStyleOption.maximum - mLowerValue : mLowerValue;
+  const QRect lowerHandleRect = style()->subControlRect( QStyle::CC_Slider, &mStyleOption, QStyle::SC_SliderHandle, nullptr );
+
+  mStyleOption.sliderPosition = mInverted ? mStyleOption.maximum - mUpperValue : mUpperValue;
+  const QRect upperHandleRect = style()->subControlRect( QStyle::CC_Slider, &mStyleOption, QStyle::SC_SliderHandle, nullptr );
+
+  const QRect grooveRect = style()->subControlRect( QStyle::CC_Slider, &mStyleOption, QStyle::SC_SliderGroove, nullptr );
+
+  QRect selectionRect;
+  switch ( mStyleOption.orientation )
+  {
+    case Qt::Horizontal:
+      selectionRect = mInverted ? QRect( upperHandleRect.left(),
+                                         grooveRect.y(),
+                                         lowerHandleRect.right() - upperHandleRect.right(),
+                                         grooveRect.height()
+                                       )
+                      : QRect( lowerHandleRect.right(),
+                               grooveRect.y(),
+                               upperHandleRect.left() - lowerHandleRect.right(),
+                               grooveRect.height()
+                             );
+      break;
+
+    case Qt::Vertical:
+      selectionRect = mInverted ? QRect( grooveRect.x(),
+                                         lowerHandleRect.bottom(),
+                                         grooveRect.width(),
+                                         upperHandleRect.top() - lowerHandleRect.top()
+                                       )
+                      : QRect( grooveRect.x(),
+                               upperHandleRect.top(),
+                               grooveRect.width(),
+                               lowerHandleRect.bottom() - upperHandleRect.top()
+                             );
+      break;
+  }
+
+  painter.drawRect( selectionRect.adjusted( -1, 1, 1, -1 ) );
+
+  // draw first handle
+  mStyleOption.subControls = QStyle::SC_SliderHandle;
+  mStyleOption.sliderPosition = mInverted ? mStyleOption.maximum - mLowerValue : mLowerValue;
+  style()->drawComplexControl( QStyle::CC_Slider, &mStyleOption, &painter );
+
+  // draw second handle
+  mStyleOption.sliderPosition = mInverted ? mStyleOption.maximum - mUpperValue : mUpperValue;
+  style()->drawComplexControl( QStyle::CC_Slider, &mStyleOption, &painter );
+}
+
+void QgsRangeSlider::mousePressEvent( QMouseEvent *event )
+{
+  mStyleOption.sliderPosition = mInverted ? mStyleOption.maximum - mLowerValue : mLowerValue;
+  mLowerControl = style()->hitTestComplexControl( QStyle::CC_Slider, &mStyleOption, event->pos(), this );
+
+  mStyleOption.sliderPosition = mInverted ? mStyleOption.maximum - mUpperValue : mUpperValue;
+  mUpperControl = style()->hitTestComplexControl( QStyle::CC_Slider, &mStyleOption, event->pos(), this );
+}
+
+void QgsRangeSlider::mouseMoveEvent( QMouseEvent *event )
+{
+  const int distance = mStyleOption.maximum - mStyleOption.minimum;
+
+  int pos = style()->sliderValueFromPosition( 0, distance,
+            mStyleOption.orientation == Qt::Horizontal ? event->pos().x() : event->pos().y(),
+            mStyleOption.orientation == Qt::Horizontal ? rect().width() : rect().height() );
+
+  if ( mInverted )
+    pos = mStyleOption.maximum - pos;
+
+  bool changed = false;
+  bool overLowerHandle = false;
+  if ( mLowerControl == QStyle::SC_SliderHandle )
+  {
+    if ( pos <= mUpperValue )
+    {
+      overLowerHandle = true;
+      if ( mLowerValue != pos )
+      {
+        mLowerValue = pos;
+        changed = true;
+      }
+    }
+  }
+
+  if ( !overLowerHandle && mUpperControl == QStyle::SC_SliderHandle )
+  {
+    if ( pos >= mLowerValue )
+    {
+      if ( mUpperValue != pos )
+      {
+        mUpperValue = pos;
+        changed = true;
+      }
+    }
+  }
+
+  if ( changed )
+  {
+    update();
+    emit rangeChanged( mLowerValue, mUpperValue );
+  }
+}
+
+QSize QgsRangeSlider::sizeHint() const
+{
+  static constexpr int sliderLength = 84;
+  static constexpr int tickSpace = 5;
+
+  int w = sliderLength;
+  int h = style()->pixelMetric( QStyle::PM_SliderThickness, &mStyleOption, this );
+
+  if ( mStyleOption.tickPosition & QSlider::TicksAbove || mStyleOption.tickPosition & QSlider::TicksBelow )
+  {
+    h += tickSpace;
+  }
+
+  return style()->sizeFromContents( QStyle::CT_Slider, &mStyleOption, QSize( w, h ), this );
+}
+

--- a/src/gui/qgsrangeslider.cpp
+++ b/src/gui/qgsrangeslider.cpp
@@ -89,15 +89,15 @@ void QgsRangeSlider::setMinimum( int minimum )
 
 void QgsRangeSlider::setRangeLimits( int minimum, int maximum )
 {
+  if ( maximum < minimum )
+    std::swap( minimum, maximum );
+
   if ( mStyleOption.minimum == minimum && mStyleOption.maximum == maximum )
     return;
-
-  maximum = std::max( minimum, maximum );
 
   mStyleOption.minimum = minimum;
   mStyleOption.maximum = maximum;
   emit rangeLimitsChanged( mStyleOption.minimum, mStyleOption.maximum );
-
 
   if ( mUpperValue < minimum || mLowerValue < minimum || mUpperValue > maximum || mLowerValue > maximum )
   {

--- a/src/gui/qgsrangeslider.cpp
+++ b/src/gui/qgsrangeslider.cpp
@@ -288,9 +288,9 @@ QRect QgsRangeSlider::selectedRangeRect()
   switch ( mStyleOption.orientation )
   {
     case Qt::Horizontal:
-      selectionRect = mFlipped ? QRect( upperHandleRect.left(),
+      selectionRect = mFlipped ? QRect( upperHandleRect.right(),
                                         grooveRect.y(),
-                                        lowerHandleRect.right() - upperHandleRect.right(),
+                                        lowerHandleRect.left() - upperHandleRect.right(),
                                         grooveRect.height()
                                       )
                       : QRect( lowerHandleRect.right(),
@@ -302,9 +302,9 @@ QRect QgsRangeSlider::selectedRangeRect()
 
     case Qt::Vertical:
       selectionRect = mFlipped ? QRect( grooveRect.x(),
-                                        lowerHandleRect.bottom(),
+                                        lowerHandleRect.top(),
                                         grooveRect.width(),
-                                        upperHandleRect.top() - lowerHandleRect.top()
+                                        upperHandleRect.bottom() - lowerHandleRect.top()
                                       )
                       : QRect( grooveRect.x(),
                                upperHandleRect.top(),

--- a/src/gui/qgsrangeslider.cpp
+++ b/src/gui/qgsrangeslider.cpp
@@ -162,7 +162,7 @@ int QgsRangeSlider::pixelPosToRangeValue( int pos ) const
 
   int value = QStyle::sliderValueFromPosition( mStyleOption.minimum, mStyleOption.maximum, pos - sliderMin,
               sliderMax - sliderMin );
-  if ( mInverted )
+  if ( mFlipped )
     value = mStyleOption.maximum - value;
   return value;
 }
@@ -187,9 +187,9 @@ bool QgsRangeSlider::newHoverControl( const QPoint &pos )
 
   mStyleOption.subControls = QStyle::SC_All;
 
-  mStyleOption.sliderPosition = mInverted ? mStyleOption.maximum - mLowerValue : mLowerValue;
+  mStyleOption.sliderPosition = mFlipped ? mStyleOption.maximum - mLowerValue : mLowerValue;
   QRect lowerHandleRect = style()->subControlRect( QStyle::CC_Slider, &mStyleOption, QStyle::SC_SliderHandle, this );
-  mStyleOption.sliderPosition = mInverted ? mStyleOption.maximum - mUpperValue : mUpperValue;
+  mStyleOption.sliderPosition = mFlipped ? mStyleOption.maximum - mUpperValue : mUpperValue;
   QRect upperHandleRect = style()->subControlRect( QStyle::CC_Slider, &mStyleOption, QStyle::SC_SliderHandle, this );
 
   QRect grooveRect = style()->subControlRect( QStyle::CC_Slider, &mStyleOption, QStyle::SC_SliderGroove, this );
@@ -260,14 +260,14 @@ Qt::Orientation QgsRangeSlider::orientation() const
   return mStyleOption.orientation;
 }
 
-bool QgsRangeSlider::invertedAppearance() const
+bool QgsRangeSlider::flippedDirection() const
 {
-  return mInverted;
+  return mFlipped;
 }
 
-void QgsRangeSlider::setInvertedAppearance( bool inverted )
+void QgsRangeSlider::setFlippedDirection( bool flipped )
 {
-  mInverted = inverted;
+  mFlipped = flipped;
   update();
 }
 
@@ -290,11 +290,11 @@ void QgsRangeSlider::paintEvent( QPaintEvent * )
   painter.setPen( Qt::NoPen );
 
   mStyleOption.activeSubControls = mHoverControl == Lower || mActiveControl == Lower ? QStyle::SC_SliderHandle : QStyle::SC_None;
-  mStyleOption.sliderPosition = mInverted ? mStyleOption.maximum - mLowerValue : mLowerValue;
+  mStyleOption.sliderPosition = mFlipped ? mStyleOption.maximum - mLowerValue : mLowerValue;
   const QRect lowerHandleRect = style()->subControlRect( QStyle::CC_Slider, &mStyleOption, QStyle::SC_SliderHandle, nullptr );
 
   mStyleOption.activeSubControls = mHoverControl == Upper || mActiveControl == Lower ? QStyle::SC_SliderHandle : QStyle::SC_None;
-  mStyleOption.sliderPosition = mInverted ? mStyleOption.maximum - mUpperValue : mUpperValue;
+  mStyleOption.sliderPosition = mFlipped ? mStyleOption.maximum - mUpperValue : mUpperValue;
   const QRect upperHandleRect = style()->subControlRect( QStyle::CC_Slider, &mStyleOption, QStyle::SC_SliderHandle, nullptr );
 
   const QRect grooveRect = style()->subControlRect( QStyle::CC_Slider, &mStyleOption, QStyle::SC_SliderGroove, nullptr );
@@ -303,11 +303,11 @@ void QgsRangeSlider::paintEvent( QPaintEvent * )
   switch ( mStyleOption.orientation )
   {
     case Qt::Horizontal:
-      selectionRect = mInverted ? QRect( upperHandleRect.left(),
-                                         grooveRect.y(),
-                                         lowerHandleRect.right() - upperHandleRect.right(),
-                                         grooveRect.height()
-                                       )
+      selectionRect = mFlipped ? QRect( upperHandleRect.left(),
+                                        grooveRect.y(),
+                                        lowerHandleRect.right() - upperHandleRect.right(),
+                                        grooveRect.height()
+                                      )
                       : QRect( lowerHandleRect.right(),
                                grooveRect.y(),
                                upperHandleRect.left() - lowerHandleRect.right(),
@@ -316,11 +316,11 @@ void QgsRangeSlider::paintEvent( QPaintEvent * )
       break;
 
     case Qt::Vertical:
-      selectionRect = mInverted ? QRect( grooveRect.x(),
-                                         lowerHandleRect.bottom(),
-                                         grooveRect.width(),
-                                         upperHandleRect.top() - lowerHandleRect.top()
-                                       )
+      selectionRect = mFlipped ? QRect( grooveRect.x(),
+                                        lowerHandleRect.bottom(),
+                                        grooveRect.width(),
+                                        upperHandleRect.top() - lowerHandleRect.top()
+                                      )
                       : QRect( grooveRect.x(),
                                upperHandleRect.top(),
                                grooveRect.width(),
@@ -334,7 +334,7 @@ void QgsRangeSlider::paintEvent( QPaintEvent * )
   // draw first handle
   mStyleOption.subControls = QStyle::SC_SliderHandle;
   mStyleOption.activeSubControls = mHoverControl == Lower || mActiveControl == Lower ? QStyle::SC_SliderHandle : QStyle::SC_None;
-  mStyleOption.sliderPosition = mInverted ? mStyleOption.maximum - mLowerValue : mLowerValue;
+  mStyleOption.sliderPosition = mFlipped ? mStyleOption.maximum - mLowerValue : mLowerValue;
   if ( mActiveControl == Lower )
     mStyleOption.state |= QStyle::State_Sunken;
   else
@@ -343,7 +343,7 @@ void QgsRangeSlider::paintEvent( QPaintEvent * )
 
   // draw second handle
   mStyleOption.activeSubControls = mHoverControl == Upper || mActiveControl == Lower ? QStyle::SC_SliderHandle : QStyle::SC_None;
-  mStyleOption.sliderPosition = mInverted ? mStyleOption.maximum - mUpperValue : mUpperValue;
+  mStyleOption.sliderPosition = mFlipped ? mStyleOption.maximum - mUpperValue : mUpperValue;
   if ( mActiveControl == Upper )
     mStyleOption.state |= QStyle::State_Sunken;
   else
@@ -361,10 +361,10 @@ void QgsRangeSlider::mousePressEvent( QMouseEvent *event )
 
   event->accept();
 
-  mStyleOption.sliderPosition = mInverted ? mStyleOption.maximum - mLowerValue : mLowerValue;
+  mStyleOption.sliderPosition = mFlipped ? mStyleOption.maximum - mLowerValue : mLowerValue;
   const bool overLowerControl = style()->hitTestComplexControl( QStyle::CC_Slider, &mStyleOption, event->pos(), this ) == QStyle::SC_SliderHandle;
   const QRect lowerSliderRect = style()->subControlRect( QStyle::CC_Slider, &mStyleOption, QStyle::SC_SliderHandle, this );
-  mStyleOption.sliderPosition = mInverted ? mStyleOption.maximum - mUpperValue : mUpperValue;
+  mStyleOption.sliderPosition = mFlipped ? mStyleOption.maximum - mUpperValue : mUpperValue;
   const bool overUpperControl = style()->hitTestComplexControl( QStyle::CC_Slider, &mStyleOption, event->pos(), this ) == QStyle::SC_SliderHandle;
   const QRect upperSliderRect = style()->subControlRect( QStyle::CC_Slider, &mStyleOption, QStyle::SC_SliderHandle, this );
 

--- a/src/gui/qgsrangeslider.h
+++ b/src/gui/qgsrangeslider.h
@@ -136,6 +136,7 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
     void paintEvent( QPaintEvent *event ) override;
     void mousePressEvent( QMouseEvent *event ) override;
     void mouseMoveEvent( QMouseEvent *event ) override;
+    void mouseReleaseEvent( QMouseEvent *event ) override;
     QSize sizeHint() const override;
 
   public slots:
@@ -190,6 +191,8 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
      */
     void setRange( int lower, int upper );
 
+    bool event( QEvent *event ) override;
+
   signals:
 
     /**
@@ -204,12 +207,24 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
 
   private:
 
+    bool updateHoverControl( const QPoint &pos );
+    bool newHoverControl( const QPoint &pos );
+
     int mLowerValue = 0;
     int mUpperValue = 0;
 
     QStyleOptionSlider mStyleOption;
-    QStyle::SubControl mLowerControl = QStyle::SC_None;
-    QStyle::SubControl mUpperControl = QStyle::SC_None;
+    enum Control
+    {
+      None,
+      Lower,
+      Upper
+    };
+    Control mActiveControl = None;
+    Control mHoverControl = None;
+    QStyle::SubControl mHoverSubControl = QStyle::SC_None;
+    QRect mHoverRect;
+
     bool mInverted = false;
 };
 

--- a/src/gui/qgsrangeslider.h
+++ b/src/gui/qgsrangeslider.h
@@ -121,24 +121,25 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
     Qt::Orientation orientation() const;
 
     /**
-     * Returns TRUE if the slider has its values inverted.
+     * Returns TRUE if the slider has its values flipped.
      *
      * If this property is FALSE (the default), the minimum and maximum will be shown in its classic
      * position for the widget. If the value is TRUE, the minimum and maximum appear at their opposite location.
      *
-     * \see setInvertedAppearance()
+     * \see setFlippedDirection()
      */
-    bool invertedAppearance() const;
+    bool flippedDirection() const;
 
     /**
-     * Sets whether the slider has its values \a inverted.
+     * Sets whether the slider has its values \a flipped.
      *
      * If this property is FALSE (the default), the minimum and maximum will be shown in its classic
      * position for the widget. If the value is TRUE, the minimum and maximum appear at their opposite location.
+     * (i.e. minimum at the bottom of a vertical slider, maximum at the top of a vertical slider).
      *
-     * \see setInvertedAppearance()
+     * \see flippedDirection()
      */
-    void setInvertedAppearance( bool inverted );
+    void setFlippedDirection( bool flipped );
 
     void paintEvent( QPaintEvent *event ) override;
     void mousePressEvent( QMouseEvent *event ) override;
@@ -241,7 +242,7 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
     QStyle::SubControl mHoverSubControl = QStyle::SC_None;
     QRect mHoverRect;
 
-    bool mInverted = false;
+    bool mFlipped = false;
 };
 
 #endif // QGSRANGESLIDER_H

--- a/src/gui/qgsrangeslider.h
+++ b/src/gui/qgsrangeslider.h
@@ -145,6 +145,7 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
     void mouseMoveEvent( QMouseEvent *event ) override;
     void mouseReleaseEvent( QMouseEvent *event ) override;
     QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
 
   public slots:
 

--- a/src/gui/qgsrangeslider.h
+++ b/src/gui/qgsrangeslider.h
@@ -207,6 +207,8 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
 
   private:
 
+    int pick( const QPoint &pt ) const;
+    int pixelPosToRangeValue( int pos ) const;
     bool updateHoverControl( const QPoint &pos );
     bool newHoverControl( const QPoint &pos );
 
@@ -218,9 +220,15 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
     {
       None,
       Lower,
-      Upper
+      Upper,
+      Both
     };
     Control mActiveControl = None;
+    int mStartDragPos = -1;
+    int mLowerClickOffset = 0;
+    int mUpperClickOffset = 0;
+    int mPreDragLowerValue = -1;
+    int mPreDragUpperValue = -1;
     Control mHoverControl = None;
     QStyle::SubControl mHoverSubControl = QStyle::SC_None;
     QRect mHoverRect;

--- a/src/gui/qgsrangeslider.h
+++ b/src/gui/qgsrangeslider.h
@@ -148,6 +148,26 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
     QSize sizeHint() const override;
     QSize minimumSizeHint() const override;
 
+    /**
+     * Returns the single step value for the widget.
+     *
+     * This corresponds to the smaller increment or decrement applied when the user presses an arrow key.
+     *
+     * \see setSingleStep()
+     * \see pageStep()
+     */
+    int singleStep() const;
+
+    /**
+     * Returns the page step value for the widget.
+     *
+     * This corresponds to the larger increment or decrement applied when the user presses the page increment key (usually PageUp or PageDown).
+     *
+     * \see setPageStep()
+     * \see singleStep()
+     */
+    int pageStep() const;
+
   public slots:
 
     /**
@@ -200,6 +220,26 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
      */
     void setRange( int lower, int upper );
 
+    /**
+     * Sets the single \a step value for the widget.
+     *
+     * This corresponds to the smaller increment or decrement applied when the user presses an arrow key.
+     *
+     * \see singleStep()
+     * \see pageStep()
+     */
+    void setSingleStep( int step );
+
+    /**
+     * Sets the page \a step value for the widget.
+     *
+     * This corresponds to the larger increment or decrement applied when the user presses the page increment key (usually PageUp or PageDown).
+     *
+     * \see pageStep()
+     * \see setSingleStep()
+     */
+    void setPageStep( int step );
+
     bool event( QEvent *event ) override;
 
   signals:
@@ -225,6 +265,9 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
 
     int mLowerValue = 0;
     int mUpperValue = 0;
+
+    int mSingleStep = 1;
+    int mPageStep = 10;
 
     QStyleOptionSlider mStyleOption;
     enum Control

--- a/src/gui/qgsrangeslider.h
+++ b/src/gui/qgsrangeslider.h
@@ -238,6 +238,7 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
     int mStartDragPos = -1;
     int mLowerClickOffset = 0;
     int mUpperClickOffset = 0;
+    int mRangeDragOffset = 0;
     int mPreDragLowerValue = -1;
     int mPreDragUpperValue = -1;
     Control mHoverControl = None;

--- a/src/gui/qgsrangeslider.h
+++ b/src/gui/qgsrangeslider.h
@@ -145,6 +145,7 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
     void mousePressEvent( QMouseEvent *event ) override;
     void mouseMoveEvent( QMouseEvent *event ) override;
     void mouseReleaseEvent( QMouseEvent *event ) override;
+    void keyPressEvent( QKeyEvent *event ) override;
     QSize sizeHint() const override;
     QSize minimumSizeHint() const override;
 
@@ -262,6 +263,8 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
     bool newHoverControl( const QPoint &pos );
     QRect selectedRangeRect();
     void drawFocusRect();
+
+    void applyStep( int step );
 
     int mLowerValue = 0;
     int mUpperValue = 0;

--- a/src/gui/qgsrangeslider.h
+++ b/src/gui/qgsrangeslider.h
@@ -264,8 +264,6 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
     QRect selectedRangeRect();
     void drawFocusRect();
 
-    void applyStep( int step );
-
     int mLowerValue = 0;
     int mUpperValue = 0;
 
@@ -281,6 +279,9 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
       Both,
       Range
     };
+
+    void applyStep( int step );
+
     Control mActiveControl = None;
     int mStartDragPos = -1;
     int mLowerClickOffset = 0;

--- a/src/gui/qgsrangeslider.h
+++ b/src/gui/qgsrangeslider.h
@@ -40,6 +40,13 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
     QgsRangeSlider( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
     /**
+     * Constructor for QgsRangeSlider, with the specified \a parent widget.
+     *
+     * The \a orientation parameter determines whether the slider is horizontal or vertical.
+     */
+    QgsRangeSlider( Qt::Orientation orientation, QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
      * Returns the minimum value allowed by the widget.
      *
      * \see setMinimum()

--- a/src/gui/qgsrangeslider.h
+++ b/src/gui/qgsrangeslider.h
@@ -1,0 +1,216 @@
+/***************************************************************************
+    qgsrangeslider.h
+    ---------------------
+    begin                : November 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSRANGESLIDER_H
+#define QGSRANGESLIDER_H
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+
+#include <QWidget>
+#include <QStyleOptionSlider>
+
+/**
+ * \ingroup gui
+ * A slider control with two interactive endpoints, for interactive selection of a range of values.
+ *
+ * \since QGIS 3.18
+ */
+class GUI_EXPORT QgsRangeSlider : public QWidget
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsRangeSlider, with the specified \a parent widget.
+     */
+    QgsRangeSlider( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
+     * Returns the minimum value allowed by the widget.
+     *
+     * \see setMinimum()
+     * \see maximum()
+     */
+    int minimum() const;
+
+    /**
+     * Returns the maximum value allowed by the widget.
+     *
+     * \see setMaximum()
+     * \see minimum()
+     */
+    int maximum() const;
+
+    /**
+     * Returns the lower value for the range selected in the widget.
+     *
+     * \see upperValue()
+     * \see setLowerValue()
+     */
+    int lowerValue() const;
+
+    /**
+     * Returns the upper value for the range selected in the widget.
+     *
+     * \see lowerValue()
+     * \see setUpperValue()
+     */
+    int upperValue() const;
+
+    /**
+     * Sets the \a position of the tick marks shown in the widget.
+     *
+     * \see tickPosition()
+     */
+    void setTickPosition( QSlider::TickPosition position );
+
+    /**
+     * Returns the position of the tick marks shown in the widget.
+     *
+     * \see setTickPosition()
+     */
+    QSlider::TickPosition tickPosition() const;
+
+    /**
+     * Sets the \a interval for tick marks shown in the widget.
+     *
+     * \see tickInterval()
+     */
+    void setTickInterval( int interval );
+
+    /**
+     * Returns the interval for tick marks shown in the widget.
+     *
+     * \see setTickInterval()
+     */
+    int tickInterval() const;
+
+    /**
+     * Sets the \a orientation of the slider.
+     *
+     * \see orientation()
+     */
+    void setOrientation( Qt::Orientation orientation );
+
+    /**
+     * Returns the orientation of the slider.
+     *
+     * \see setOrientation()
+     */
+    Qt::Orientation orientation() const;
+
+    /**
+     * Returns TRUE if the slider has its values inverted.
+     *
+     * If this property is FALSE (the default), the minimum and maximum will be shown in its classic
+     * position for the widget. If the value is TRUE, the minimum and maximum appear at their opposite location.
+     *
+     * \see setInvertedAppearance()
+     */
+    bool invertedAppearance() const;
+
+    /**
+     * Sets whether the slider has its values \a inverted.
+     *
+     * If this property is FALSE (the default), the minimum and maximum will be shown in its classic
+     * position for the widget. If the value is TRUE, the minimum and maximum appear at their opposite location.
+     *
+     * \see setInvertedAppearance()
+     */
+    void setInvertedAppearance( bool inverted );
+
+    void paintEvent( QPaintEvent *event ) override;
+    void mousePressEvent( QMouseEvent *event ) override;
+    void mouseMoveEvent( QMouseEvent *event ) override;
+    QSize sizeHint() const override;
+
+  public slots:
+
+    /**
+     * Sets the \a maximum value allowed in the widget.
+     *
+     * \see maximum()
+     * \see setMinimum()
+     */
+    void setMaximum( int maximum );
+
+    /**
+     * Sets the \a minimum value allowed in the widget.
+     *
+     * \see minimum()
+     * \see setMaximum()
+     */
+    void setMinimum( int minimum );
+
+    /**
+     * Sets the \a minimum and \a maximum range limits for values allowed in the widget.
+     *
+     * \see setMinimum()
+     * \see setMaximum()
+     */
+    void setRangeLimits( int minimum, int maximum );
+
+    /**
+     * Sets the lower \a value for the range currently selected in the widget.
+     *
+     * \see lowerValue()
+     * \see setRange()
+     * \see setUpperValue()
+     */
+    void setLowerValue( int value );
+
+    /**
+     * Sets the upper \a value for the range currently selected in the widget.
+     *
+     * \see upperValue()
+     * \see setRange()
+     * \see setLowerValue()
+     */
+    void setUpperValue( int value );
+
+    /**
+     * Sets the current range selected in the widget.
+     *
+     * \see setLowerValue()
+     * \see setUpperValue()
+     */
+    void setRange( int lower, int upper );
+
+  signals:
+
+    /**
+     * Emitted when the range selected in the widget is changed.
+     */
+    void rangeChanged( int minimum, int maximum );
+
+    /**
+     * Emitted when the limits of values allowed in the widget is changed.
+     */
+    void rangeLimitsChanged( int minimum, int maximum );
+
+  private:
+
+    int mLowerValue = 0;
+    int mUpperValue = 0;
+
+    QStyleOptionSlider mStyleOption;
+    QStyle::SubControl mLowerControl = QStyle::SC_None;
+    QStyle::SubControl mUpperControl = QStyle::SC_None;
+    bool mInverted = false;
+};
+
+#endif // QGSRANGESLIDER_H

--- a/src/gui/qgsrangeslider.h
+++ b/src/gui/qgsrangeslider.h
@@ -221,6 +221,7 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
     bool updateHoverControl( const QPoint &pos );
     bool newHoverControl( const QPoint &pos );
     QRect selectedRangeRect();
+    void drawFocusRect();
 
     int mLowerValue = 0;
     int mUpperValue = 0;
@@ -242,6 +243,7 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
     int mPreDragLowerValue = -1;
     int mPreDragUpperValue = -1;
     Control mHoverControl = None;
+    Control mFocusControl = Lower;
     QStyle::SubControl mHoverSubControl = QStyle::SC_None;
     QRect mHoverRect;
 

--- a/src/gui/qgsrangeslider.h
+++ b/src/gui/qgsrangeslider.h
@@ -220,6 +220,7 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
     int pixelPosToRangeValue( int pos ) const;
     bool updateHoverControl( const QPoint &pos );
     bool newHoverControl( const QPoint &pos );
+    QRect selectedRangeRect();
 
     int mLowerValue = 0;
     int mUpperValue = 0;
@@ -230,7 +231,8 @@ class GUI_EXPORT QgsRangeSlider : public QWidget
       None,
       Lower,
       Upper,
-      Both
+      Both,
+      Range
     };
     Control mActiveControl = None;
     int mStartDragPos = -1;

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -229,6 +229,7 @@ ADD_PYTHON_TEST(PyQgsProviderConnectionSpatialite test_qgsproviderconnection_spa
 ADD_PYTHON_TEST(PyQgsProviderRegistry test_qgsproviderregistry.py)
 ADD_PYTHON_TEST(TestQgsRandomMarkerSymbolLayer test_qgsrandommarkersymbollayer.py)
 ADD_PYTHON_TEST(PyQgsRange test_qgsrange.py)
+ADD_PYTHON_TEST(PyQgsRangeSlider test_qgsrangeslider.py)
 ADD_PYTHON_TEST(PyQgsRangeWidgets test_qgsrangewidgets.py)
 ADD_PYTHON_TEST(PyQgsRasterBandComboBox test_qgsrasterbandcombobox.py)
 ADD_PYTHON_TEST(PyQgsRasterFileWriter test_qgsrasterfilewriter.py)

--- a/tests/src/python/test_qgsrangeslider.py
+++ b/tests/src/python/test_qgsrangeslider.py
@@ -260,7 +260,7 @@ class TestQgsRangeSlider(unittest.TestCase):
         w.setRange(0, 10)
         self.assertEqual(len(spy), 5)
 
-        w.setRangeLimits(7, 3) # flipped
+        w.setRangeLimits(7, 3)  # flipped
         self.assertEqual(w.lowerValue(), 3)
         self.assertEqual(w.upperValue(), 7)
         self.assertEqual(len(spy), 6)

--- a/tests/src/python/test_qgsrangeslider.py
+++ b/tests/src/python/test_qgsrangeslider.py
@@ -39,6 +39,12 @@ class TestQgsRangeSlider(unittest.TestCase):
         w.setFlippedDirection(True)
         self.assertTrue(w.flippedDirection())
 
+        w.setSingleStep(2)
+        self.assertEqual(w.singleStep(), 2)
+
+        w.setPageStep(5)
+        self.assertEqual(w.pageStep(), 5)
+
     def testLimits(self):
         w = QgsRangeSlider()
         spy = QSignalSpy(w.rangeLimitsChanged)

--- a/tests/src/python/test_qgsrangeslider.py
+++ b/tests/src/python/test_qgsrangeslider.py
@@ -1,0 +1,271 @@
+# -*- coding: utf-8 -*-
+"""QGIS Unit tests for QgsRangeSlider
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+__author__ = 'Nyall Dawson'
+__date__ = '2020-11-25'
+__copyright__ = 'Copyright 2020, The QGIS Project'
+
+import qgis  # NOQA
+
+from qgis.gui import QgsRangeSlider
+
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtWidgets import QSlider
+from qgis.PyQt.QtTest import QSignalSpy
+
+from qgis.testing import start_app, unittest
+
+start_app()
+
+
+class TestQgsRangeSlider(unittest.TestCase):
+
+    def testSettersGetters(self):
+        w = QgsRangeSlider()
+        w.setOrientation(Qt.Horizontal)
+        self.assertEqual(w.orientation(), Qt.Horizontal)
+        w.setOrientation(Qt.Vertical)
+        self.assertEqual(w.orientation(), Qt.Vertical)
+
+        w.setTickPosition(QSlider.TicksAbove)
+        self.assertEqual(w.tickPosition(), QSlider.TicksAbove)
+        w.setTickInterval(5)
+        self.assertEqual(w.tickInterval(), 5)
+        w.setFlippedDirection(True)
+        self.assertTrue(w.flippedDirection())
+
+    def testLimits(self):
+        w = QgsRangeSlider()
+        spy = QSignalSpy(w.rangeLimitsChanged)
+
+        w.setMaximum(50)
+        self.assertEqual(w.minimum(), 0)
+        self.assertEqual(w.maximum(), 50)
+        self.assertEqual(len(spy), 1)
+        self.assertEqual(spy[-1], [0, 50])
+        w.setMaximum(50)
+        self.assertEqual(len(spy), 1)
+
+        w.setMinimum(40)
+        self.assertEqual(w.minimum(), 40)
+        self.assertEqual(w.maximum(), 50)
+        self.assertEqual(len(spy), 2)
+        self.assertEqual(spy[-1], [40, 50])
+        w.setMinimum(40)
+        self.assertEqual(len(spy), 2)
+
+        w.setRangeLimits(40, 50)
+        self.assertEqual(w.minimum(), 40)
+        self.assertEqual(w.maximum(), 50)
+        self.assertEqual(len(spy), 2)
+        w.setRangeLimits(40, 60)
+        self.assertEqual(w.minimum(), 40)
+        self.assertEqual(w.maximum(), 60)
+        self.assertEqual(len(spy), 3)
+        self.assertEqual(spy[-1], [40, 60])
+        w.setRangeLimits(45, 60)
+        self.assertEqual(w.minimum(), 45)
+        self.assertEqual(w.maximum(), 60)
+        self.assertEqual(len(spy), 4)
+        self.assertEqual(spy[-1], [45, 60])
+        w.setRangeLimits(30, 70)
+        self.assertEqual(w.minimum(), 30)
+        self.assertEqual(w.maximum(), 70)
+        self.assertEqual(len(spy), 5)
+        self.assertEqual(spy[-1], [30, 70])
+
+        # inconsistent ranges
+        w.setMinimum(80)
+        self.assertEqual(w.minimum(), 80)
+        self.assertEqual(w.maximum(), 80)
+        self.assertEqual(len(spy), 6)
+        self.assertEqual(spy[-1], [80, 80])
+
+        w.setRangeLimits(10, 20)
+        self.assertEqual(len(spy), 7)
+        w.setMaximum(8)
+        self.assertEqual(w.minimum(), 8)
+        self.assertEqual(w.maximum(), 8)
+        self.assertEqual(len(spy), 8)
+        self.assertEqual(spy[-1], [8, 8])
+
+        w.setRangeLimits(20, 10)
+        self.assertEqual(w.minimum(), 10)
+        self.assertEqual(w.maximum(), 20)
+        self.assertEqual(len(spy), 9)
+        self.assertEqual(spy[-1], [10, 20])
+        w.setRangeLimits(20, 10)
+        self.assertEqual(w.minimum(), 10)
+        self.assertEqual(w.maximum(), 20)
+        self.assertEqual(len(spy), 9)
+
+    def testValues(self):
+        w = QgsRangeSlider()
+        w.setRangeLimits(0, 10)
+
+        w.setUpperValue(7)
+
+        spy = QSignalSpy(w.rangeChanged)
+
+        w.setLowerValue(5)
+        self.assertEqual(w.lowerValue(), 5)
+        self.assertEqual(len(spy), 1)
+        self.assertEqual(spy[-1], [5, 7])
+        w.setLowerValue(5)
+        self.assertEqual(w.lowerValue(), 5)
+        self.assertEqual(len(spy), 1)
+
+        w.setUpperValue(8)
+        self.assertEqual(w.lowerValue(), 5)
+        self.assertEqual(w.upperValue(), 8)
+        self.assertEqual(len(spy), 2)
+        self.assertEqual(spy[-1], [5, 8])
+        w.setUpperValue(8)
+        self.assertEqual(w.lowerValue(), 5)
+        self.assertEqual(w.upperValue(), 8)
+        self.assertEqual(len(spy), 2)
+
+        w.setRange(3, 7)
+        self.assertEqual(w.lowerValue(), 3)
+        self.assertEqual(w.upperValue(), 7)
+        self.assertEqual(len(spy), 3)
+        self.assertEqual(spy[-1], [3, 7])
+        w.setRange(3, 7)
+        self.assertEqual(w.lowerValue(), 3)
+        self.assertEqual(w.upperValue(), 7)
+        self.assertEqual(len(spy), 3)
+
+        w.setRange(3, 8)
+        self.assertEqual(w.lowerValue(), 3)
+        self.assertEqual(w.upperValue(), 8)
+        self.assertEqual(len(spy), 4)
+        self.assertEqual(spy[-1], [3, 8])
+
+        w.setRange(4, 8)
+        self.assertEqual(w.lowerValue(), 4)
+        self.assertEqual(w.upperValue(), 8)
+        self.assertEqual(len(spy), 5)
+        self.assertEqual(spy[-1], [4, 8])
+
+        # set min > max, max should be raised
+        w.setLowerValue(9)
+        self.assertEqual(w.lowerValue(), 9)
+        self.assertEqual(w.upperValue(), 9)
+        self.assertEqual(len(spy), 6)
+        self.assertEqual(spy[-1], [9, 9])
+
+        w.setRange(4, 8)
+        self.assertEqual(len(spy), 7)
+
+        # set max < min, min should be lowered
+        w.setUpperValue(3)
+        self.assertEqual(w.lowerValue(), 3)
+        self.assertEqual(w.upperValue(), 3)
+        self.assertEqual(len(spy), 8)
+        self.assertEqual(spy[-1], [3, 3])
+
+        # set to values outside limit, should be clamped
+        w.setUpperValue(12)
+        self.assertEqual(w.lowerValue(), 3)
+        self.assertEqual(w.upperValue(), 10)
+        self.assertEqual(len(spy), 9)
+        self.assertEqual(spy[-1], [3, 10])
+
+        w.setLowerValue(-2)
+        self.assertEqual(w.lowerValue(), 0)
+        self.assertEqual(w.upperValue(), 10)
+        self.assertEqual(len(spy), 10)
+        self.assertEqual(spy[-1], [0, 10])
+
+        w.setUpperValue(-3)
+        self.assertEqual(w.lowerValue(), 0)
+        self.assertEqual(w.upperValue(), 0)
+        self.assertEqual(len(spy), 11)
+        self.assertEqual(spy[-1], [0, 0])
+
+        w.setLowerValue(13)
+        self.assertEqual(w.lowerValue(), 10)
+        self.assertEqual(w.upperValue(), 10)
+        self.assertEqual(len(spy), 12)
+        self.assertEqual(spy[-1], [10, 10])
+
+        w.setRange(-2, 3)
+        self.assertEqual(w.lowerValue(), 0)
+        self.assertEqual(w.upperValue(), 3)
+        self.assertEqual(len(spy), 13)
+        self.assertEqual(spy[-1], [0, 3])
+
+        w.setRange(3, 13)
+        self.assertEqual(w.lowerValue(), 3)
+        self.assertEqual(w.upperValue(), 10)
+        self.assertEqual(len(spy), 14)
+        self.assertEqual(spy[-1], [3, 10])
+
+        w.setRange(-3, -2)
+        self.assertEqual(w.lowerValue(), 0)
+        self.assertEqual(w.upperValue(), 0)
+        self.assertEqual(len(spy), 15)
+        self.assertEqual(spy[-1], [0, 0])
+
+        w.setRange(12, 13)
+        self.assertEqual(w.lowerValue(), 10)
+        self.assertEqual(w.upperValue(), 10)
+        self.assertEqual(len(spy), 16)
+        self.assertEqual(spy[-1], [10, 10])
+
+        # flipped ranges
+        w.setRange(7, 4)
+        self.assertEqual(w.lowerValue(), 4)
+        self.assertEqual(w.upperValue(), 7)
+        self.assertEqual(len(spy), 17)
+        self.assertEqual(spy[-1], [4, 7])
+
+    def testChangeLimitsOutsideValue(self):
+        # force value changes via limit changes
+        w = QgsRangeSlider()
+        w.setRangeLimits(0, 10)
+
+        w.setUpperValue(7)
+
+        spy = QSignalSpy(w.rangeChanged)
+
+        w.setMaximum(5)
+        self.assertEqual(w.lowerValue(), 0)
+        self.assertEqual(w.upperValue(), 5)
+        self.assertEqual(len(spy), 1)
+        self.assertEqual(spy[-1], [0, 5])
+
+        w.setMinimum(2)
+        self.assertEqual(w.lowerValue(), 2)
+        self.assertEqual(w.upperValue(), 5)
+        self.assertEqual(len(spy), 2)
+        self.assertEqual(spy[-1], [2, 5])
+
+        w.setRangeLimits(0, 10)
+        w.setRange(0, 10)
+        self.assertEqual(len(spy), 3)
+
+        w.setRangeLimits(3, 7)
+        self.assertEqual(w.lowerValue(), 3)
+        self.assertEqual(w.upperValue(), 7)
+        self.assertEqual(len(spy), 4)
+        self.assertEqual(spy[-1], [3, 7])
+
+        w.setRangeLimits(0, 10)
+        w.setRange(0, 10)
+        self.assertEqual(len(spy), 5)
+
+        w.setRangeLimits(7, 3) # flipped
+        self.assertEqual(w.lowerValue(), 3)
+        self.assertEqual(w.upperValue(), 7)
+        self.assertEqual(len(spy), 6)
+        self.assertEqual(spy[-1], [3, 7])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This widget implements a slider which allows users to set a value range, with a lower and upper value.

TODO:

- [x] tests
- [x] fix hardcoded values in sizeHint()
- [x] keyboard interaction
- [x] allow dragging range from center of slider
- [x] nicely handle interactions which move the lower value over the upper or vice versa

![Peek 2020-11-24 17-29](https://user-images.githubusercontent.com/1829991/100062010-a8ee2800-2e7a-11eb-926c-ba1ed37ff81d.gif)


