### PR TITLE
[o2] Allow users to set a custom HTTP header to use when sending the retrieved token during requests

### DIFF
--- a/src/auth/oauth2/qgsauthoauth2config.cpp
+++ b/src/auth/oauth2/qgsauthoauth2config.cpp
@@ -50,6 +50,7 @@ QgsAuthOAuth2Config::QgsAuthOAuth2Config( QObject *parent )
   connect( this, &QgsAuthOAuth2Config::accessMethodChanged, this, &QgsAuthOAuth2Config::configChanged );
   connect( this, &QgsAuthOAuth2Config::requestTimeoutChanged, this, &QgsAuthOAuth2Config::configChanged );
   connect( this, &QgsAuthOAuth2Config::queryPairsChanged, this, &QgsAuthOAuth2Config::configChanged );
+  connect( this, &QgsAuthOAuth2Config::customHeaderChanged, this, &QgsAuthOAuth2Config::configChanged );
 
   // always recheck validity on any change
   // this, in turn, may emit validityChanged( bool )
@@ -211,6 +212,14 @@ void QgsAuthOAuth2Config::setAccessMethod( QgsAuthOAuth2Config::AccessMethod val
     emit accessMethodChanged( mAccessMethod );
 }
 
+void QgsAuthOAuth2Config::setCustomHeader( const QString &header )
+{
+  QString preval( mCustomHeader );
+  mCustomHeader = header;
+  if ( preval != header )
+    emit customHeaderChanged( mCustomHeader );
+}
+
 void QgsAuthOAuth2Config::setRequestTimeout( int value )
 {
   int preval( mRequestTimeout );
@@ -248,6 +257,7 @@ void QgsAuthOAuth2Config::setToDefaults()
   setApiKey( QString() );
   setPersistToken( false );
   setAccessMethod( QgsAuthOAuth2Config::Header );
+  setCustomHeader( QString() );
   setRequestTimeout( 30 ); // in seconds
   setQueryPairs( QVariantMap() );
 }
@@ -272,6 +282,7 @@ bool QgsAuthOAuth2Config::operator==( const QgsAuthOAuth2Config &other ) const
            && other.apiKey() == this->apiKey()
            && other.persistToken() == this->persistToken()
            && other.accessMethod() == this->accessMethod()
+           && other.customHeader() == this->customHeader()
            && other.requestTimeout() == this->requestTimeout()
            && other.queryPairs() == this->queryPairs() );
 }
@@ -406,6 +417,7 @@ QVariantMap QgsAuthOAuth2Config::mappedProperties() const
   vmap.insert( QStringLiteral( "redirectUrl" ), this->redirectUrl() );
   vmap.insert( QStringLiteral( "refreshTokenUrl" ), this->refreshTokenUrl() );
   vmap.insert( QStringLiteral( "accessMethod" ), static_cast<int>( this->accessMethod() ) );
+  vmap.insert( QStringLiteral( "customHeader" ), this->customHeader() );
   vmap.insert( QStringLiteral( "requestTimeout" ), this->requestTimeout() );
   vmap.insert( QStringLiteral( "requestUrl" ), this->requestUrl() );
   vmap.insert( QStringLiteral( "scope" ), this->scope() );

--- a/src/auth/oauth2/qgsauthoauth2config.h
+++ b/src/auth/oauth2/qgsauthoauth2config.h
@@ -55,6 +55,7 @@ class QgsAuthOAuth2Config : public QObject
     Q_PROPERTY( AccessMethod accessMethod READ accessMethod WRITE setAccessMethod NOTIFY accessMethodChanged )
     Q_PROPERTY( int requestTimeout READ requestTimeout WRITE setRequestTimeout NOTIFY requestTimeoutChanged )
     Q_PROPERTY( QVariantMap queryPairs READ queryPairs WRITE setQueryPairs NOTIFY queryPairsChanged )
+    Q_PROPERTY( QString customHeader READ customHeader WRITE setCustomHeader NOTIFY customHeaderChanged )
 
   public:
 
@@ -146,6 +147,15 @@ class QgsAuthOAuth2Config : public QObject
 
     //! Access method
     AccessMethod accessMethod() const { return mAccessMethod; }
+
+    /**
+     * Custom header for header access methods.
+     *
+     * If not set, the default HTTP Authorization header will be used.
+     *
+     * \since QGIS 3.18
+     */
+    QString customHeader() const { return mCustomHeader; }
 
     //! Request timeout
     int requestTimeout() const { return mRequestTimeout; }
@@ -292,6 +302,16 @@ class QgsAuthOAuth2Config : public QObject
     void setPersistToken( bool persist );
     //! Set access method to \a value
     void setAccessMethod( QgsAuthOAuth2Config::AccessMethod value );
+
+    /**
+     * Sets the custom \a header for header access methods.
+     *
+     * If \a header is empty, the default HTTP Authorization header will be used.
+     *
+     * \since QGIS 3.18
+     */
+    void setCustomHeader( const QString &header );
+
     //! Set request timeout to \a value
     void setRequestTimeout( int value );
     //! Set query pairs to \a pairs
@@ -344,6 +364,14 @@ class QgsAuthOAuth2Config : public QObject
     void persistTokenChanged( bool );
     //! Emitted when configuration access method has changed
     void accessMethodChanged( QgsAuthOAuth2Config::AccessMethod );
+
+    /**
+     * Emitted when custom authorization header has changed.
+     *
+     * \since QGIS 3.18
+     */
+    void customHeaderChanged( const QString & );
+
     //! Emitted when configuration request timeout has changed
     void requestTimeoutChanged( int );
     //! Emitted when configuration query pair has changed
@@ -371,6 +399,7 @@ class QgsAuthOAuth2Config : public QObject
     QString mApiKey;
     bool mPersistToken = false;
     AccessMethod mAccessMethod = AccessMethod::Header;
+    QString mCustomHeader;
     int mRequestTimeout = 30 ; // in seconds
     QVariantMap mQueryPairs;
     bool mValid = false;

--- a/src/auth/oauth2/qgsauthoauth2edit.cpp
+++ b/src/auth/oauth2/qgsauthoauth2edit.cpp
@@ -186,6 +186,8 @@ void QgsAuthOAuth2Edit::setupConnections()
   connect( spnbxRequestTimeout, static_cast<void ( QSpinBox::* )( int )>( &QSpinBox::valueChanged ),
            mOAuthConfigCustom.get(), &QgsAuthOAuth2Config::setRequestTimeout );
 
+  connect( mTokenHeaderLineEdit, &QLineEdit::textChanged, mOAuthConfigCustom.get(), &QgsAuthOAuth2Config::setCustomHeader );
+
   connect( mOAuthConfigCustom.get(), &QgsAuthOAuth2Config::validityChanged, this, &QgsAuthOAuth2Edit::configValidityChanged );
 
   if ( mParentName )
@@ -397,6 +399,7 @@ void QgsAuthOAuth2Edit::loadFromOAuthConfig( const QgsAuthOAuth2Config *config )
     lePassword->setText( config->password() );
     leScope->setText( config->scope() );
     leApiKey->setText( config->apiKey() );
+    mTokenHeaderLineEdit->setText( config->customHeader() );
 
     // advanced
     chkbxTokenPersist->setChecked( config->persistToken() );
@@ -868,6 +871,18 @@ void QgsAuthOAuth2Edit::populateAccessMethods()
 void QgsAuthOAuth2Edit::updateConfigAccessMethod( int indx )
 {
   mOAuthConfigCustom->setAccessMethod( static_cast<QgsAuthOAuth2Config::AccessMethod>( indx ) );
+  switch ( static_cast<QgsAuthOAuth2Config::AccessMethod>( indx ) )
+  {
+    case QgsAuthOAuth2Config::Header:
+      mTokenHeaderLineEdit->setVisible( true );
+      mTokenHeaderLabel->setVisible( true );
+      break;
+    case QgsAuthOAuth2Config::Form:
+    case QgsAuthOAuth2Config::Query:
+      mTokenHeaderLineEdit->setVisible( false );
+      mTokenHeaderLabel->setVisible( false );
+      break;
+  }
 }
 
 void QgsAuthOAuth2Edit::addQueryPairRow( const QString &key, const QString &val )

--- a/src/auth/oauth2/qgsauthoauth2edit.ui
+++ b/src/auth/oauth2/qgsauthoauth2edit.ui
@@ -75,7 +75,7 @@
        </sizepolicy>
       </property>
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="tabCustom">
        <attribute name="title">
@@ -141,7 +141,7 @@
                 </sizepolicy>
                </property>
                <property name="text">
-                <string>Grant Flow</string>
+                <string>Grant flow</string>
                </property>
               </widget>
              </item>
@@ -202,9 +202,9 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>0</y>
-             <width>406</width>
-             <height>441</height>
+             <y>-288</y>
+             <width>401</width>
+             <height>568</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout">
@@ -223,6 +223,22 @@
             <property name="spacing">
              <number>6</number>
             </property>
+            <item row="16" column="0">
+             <widget class="QLabel" name="lblAccessMethod">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Access method</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
             <item row="11" column="0">
              <widget class="QLabel" name="lblScope">
               <property name="text">
@@ -230,63 +246,30 @@
               </property>
              </widget>
             </item>
-            <item row="7" column="0">
-             <widget class="QLabel" name="lblClientId">
-              <property name="text">
-               <string>Client ID</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="14" column="0" colspan="4">
-             <widget class="QLabel" name="label">
-              <property name="font">
-               <font>
-                <pointsize>12</pointsize>
-                <italic>true</italic>
-               </font>
-              </property>
-              <property name="text">
-               <string>Advanced</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="8" column="1" colspan="3">
-             <widget class="QgsPasswordLineEdit" name="leClientSecret">
+            <item row="3" column="1" colspan="3">
+             <widget class="QLineEdit" name="leRefreshTokenUrl">
               <property name="placeholderText">
-               <string>Required</string>
+               <string>Optional</string>
               </property>
              </widget>
+            </item>
+            <item row="20" column="1">
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>0</height>
+               </size>
+              </property>
+             </spacer>
             </item>
             <item row="4" column="0">
              <widget class="QLabel" name="lblRedirectUrl">
               <property name="text">
                <string>Redirect URL</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1" colspan="3">
-             <widget class="QPlainTextEdit" name="pteDescription">
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>40</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="lblDescription">
-              <property name="text">
-               <string>Description</string>
               </property>
               <property name="wordWrap">
                <bool>true</bool>
@@ -300,165 +283,24 @@
               </property>
              </widget>
             </item>
-            <item row="12" column="1" colspan="3">
-             <widget class="QLineEdit" name="leApiKey">
-              <property name="placeholderText">
-               <string>Optional</string>
-              </property>
-             </widget>
-            </item>
-            <item row="9" column="0">
-             <widget class="QLabel" name="lblUsername">
+            <item row="15" column="1" colspan="2">
+             <widget class="QCheckBox" name="chkbxTokenPersist">
               <property name="text">
-               <string>Username</string>
+               <string>Persist between launches</string>
               </property>
              </widget>
             </item>
-            <item row="17" column="0">
-             <widget class="QLabel" name="lblRequestTimeout">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Request Timeout</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="17" column="1">
-             <widget class="QSpinBox" name="spnbxRequestTimeout">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>Authorization-related timeout</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignCenter</set>
-              </property>
-              <property name="suffix">
-               <string> seconds</string>
-              </property>
-              <property name="minimum">
-               <number>5</number>
-              </property>
-              <property name="maximum">
-               <number>3600</number>
-              </property>
-              <property name="value">
-               <number>30</number>
-              </property>
-             </widget>
-            </item>
-            <item row="16" column="0">
-             <widget class="QLabel" name="lblAccessMethod">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Access Method</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="12" column="0">
-             <widget class="QLabel" name="lblApiKey">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>API Key</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="lblRefreshTokenUrl">
-              <property name="text">
-               <string>Refresh Token URL</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1" colspan="3">
-             <widget class="QLineEdit" name="leRefreshTokenUrl">
-              <property name="placeholderText">
-               <string>Optional</string>
-              </property>
-             </widget>
-            </item>
-            <item row="15" column="0">
-             <widget class="QLabel" name="lblTokenPersist">
-              <property name="text">
-               <string>Token Session</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="10" column="1" colspan="3">
-             <widget class="QgsPasswordLineEdit" name="lePassword">
+            <item row="2" column="1" colspan="3">
+             <widget class="QLineEdit" name="leTokenUrl">
               <property name="placeholderText">
                <string>Required</string>
               </property>
              </widget>
             </item>
-            <item row="7" column="1" colspan="3">
-             <widget class="QLineEdit" name="leClientId">
-              <property name="placeholderText">
-               <string>Required</string>
-              </property>
-             </widget>
-            </item>
-            <item row="9" column="1" colspan="3">
-             <widget class="QLineEdit" name="leUsername">
-              <property name="placeholderText">
-               <string>Required</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="lblRequestUrl">
+            <item row="7" column="0">
+             <widget class="QLabel" name="lblClientId">
               <property name="text">
-               <string>Request URL</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="13" column="0" colspan="4">
-             <widget class="Line" name="line">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="lblTokenUrl">
-              <property name="text">
-               <string>Token URL</string>
+               <string>Client ID</string>
               </property>
               <property name="wordWrap">
                <bool>true</bool>
@@ -481,24 +323,93 @@
             <item row="8" column="0">
              <widget class="QLabel" name="lblClientSecret">
               <property name="text">
-               <string>Client Secret</string>
+               <string>Client secret</string>
               </property>
               <property name="wordWrap">
                <bool>true</bool>
               </property>
              </widget>
             </item>
-            <item row="15" column="1" colspan="2">
-             <widget class="QCheckBox" name="chkbxTokenPersist">
-              <property name="text">
-               <string>Persist between launches</string>
+            <item row="0" column="1" colspan="3">
+             <widget class="QPlainTextEdit" name="pteDescription">
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>40</height>
+               </size>
               </property>
              </widget>
             </item>
-            <item row="10" column="0">
-             <widget class="QLabel" name="lblPassword">
+            <item row="14" column="0" colspan="4">
+             <widget class="QLabel" name="label">
+              <property name="font">
+               <font>
+                <pointsize>12</pointsize>
+                <italic>true</italic>
+               </font>
+              </property>
               <property name="text">
-               <string>Password</string>
+               <string>Advanced</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="lblRequestUrl">
+              <property name="text">
+               <string>Request URL</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="19" column="0">
+             <widget class="QLabel" name="lblRequestTimeout">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Request timeout</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="9" column="0">
+             <widget class="QLabel" name="lblUsername">
+              <property name="text">
+               <string>Username</string>
+              </property>
+             </widget>
+            </item>
+            <item row="9" column="1" colspan="3">
+             <widget class="QLineEdit" name="leUsername">
+              <property name="placeholderText">
+               <string>Required</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="lblDescription">
+              <property name="text">
+               <string>Description</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="13" column="0" colspan="4">
+             <widget class="Line" name="line">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
               </property>
              </widget>
             </item>
@@ -509,23 +420,13 @@
               </property>
              </widget>
             </item>
-            <item row="18" column="1">
-             <spacer name="verticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
+            <item row="3" column="0">
+             <widget class="QLabel" name="lblRefreshTokenUrl">
+              <property name="text">
+               <string>Refresh token URL</string>
               </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>0</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="2" column="1" colspan="3">
-             <widget class="QLineEdit" name="leTokenUrl">
-              <property name="placeholderText">
-               <string>Required</string>
+              <property name="wordWrap">
+               <bool>true</bool>
               </property>
              </widget>
             </item>
@@ -603,6 +504,134 @@
                 </widget>
                </item>
               </layout>
+             </widget>
+            </item>
+            <item row="8" column="1" colspan="3">
+             <widget class="QgsPasswordLineEdit" name="leClientSecret">
+              <property name="placeholderText">
+               <string>Required</string>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="1" colspan="3">
+             <widget class="QLineEdit" name="leClientId">
+              <property name="placeholderText">
+               <string>Required</string>
+              </property>
+             </widget>
+            </item>
+            <item row="19" column="1">
+             <widget class="QSpinBox" name="spnbxRequestTimeout">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Authorization-related timeout</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+              <property name="suffix">
+               <string> seconds</string>
+              </property>
+              <property name="minimum">
+               <number>5</number>
+              </property>
+              <property name="maximum">
+               <number>3600</number>
+              </property>
+              <property name="value">
+               <number>30</number>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="lblTokenUrl">
+              <property name="text">
+               <string>Token URL</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="10" column="0">
+             <widget class="QLabel" name="lblPassword">
+              <property name="text">
+               <string>Password</string>
+              </property>
+             </widget>
+            </item>
+            <item row="12" column="1" colspan="3">
+             <widget class="QLineEdit" name="leApiKey">
+              <property name="placeholderText">
+               <string>Optional</string>
+              </property>
+             </widget>
+            </item>
+            <item row="10" column="1" colspan="3">
+             <widget class="QgsPasswordLineEdit" name="lePassword">
+              <property name="placeholderText">
+               <string>Required</string>
+              </property>
+             </widget>
+            </item>
+            <item row="12" column="0">
+             <widget class="QLabel" name="lblApiKey">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>API key</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="15" column="0">
+             <widget class="QLabel" name="lblTokenPersist">
+              <property name="text">
+               <string>Token session</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="18" column="0">
+             <widget class="QLabel" name="mTokenHeaderLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Token header</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="18" column="1" colspan="3">
+             <widget class="QLineEdit" name="mTokenHeaderLineEdit">
+              <property name="toolTip">
+               <string>If set, the specified header key will be used instead of the default HTTP Authorization header when sending authenticated requests</string>
+              </property>
+              <property name="placeholderText">
+               <string>Default</string>
+              </property>
+              <property name="clearButtonEnabled">
+               <bool>true</bool>
+              </property>
              </widget>
             </item>
            </layout>
@@ -736,7 +765,7 @@
           <item row="1" column="0">
            <widget class="QLabel" name="lblSoftStatementDir">
             <property name="text">
-             <string>Software Statement</string>
+             <string>Software statement</string>
             </property>
            </widget>
           </item>
@@ -761,7 +790,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="lblConfigUrl">
             <property name="text">
-             <string>Configuration Url</string>
+             <string>Configuration URL</string>
             </property>
            </widget>
           </item>
@@ -840,7 +869,7 @@
             <x>0</x>
             <y>0</y>
             <width>413</width>
-            <height>306</height>
+            <height>275</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_3">
@@ -884,10 +913,10 @@
                <property name="wordWrap">
                 <bool>false</bool>
                </property>
-               <attribute name="horizontalHeaderDefaultSectionSize">
+               <attribute name="horizontalHeaderMinimumSectionSize">
                 <number>120</number>
                </attribute>
-               <attribute name="horizontalHeaderMinimumSectionSize">
+               <attribute name="horizontalHeaderDefaultSectionSize">
                 <number>120</number>
                </attribute>
                <attribute name="horizontalHeaderShowSortIndicator" stdset="0">

--- a/src/auth/oauth2/qgsauthoauth2method.cpp
+++ b/src/auth/oauth2/qgsauthoauth2method.cpp
@@ -253,12 +253,15 @@ bool QgsAuthOAuth2Method::updateNetworkRequest( QNetworkRequest &request, const 
   switch ( accessmethod )
   {
     case QgsAuthOAuth2Config::Header:
-      request.setRawHeader( O2_HTTP_AUTHORIZATION_HEADER, QStringLiteral( "Bearer %1" ).arg( o2->token() ).toLatin1() );
+    {
+      const QString header = o2->oauth2config()->customHeader().isEmpty() ? QString( O2_HTTP_AUTHORIZATION_HEADER ) : o2->oauth2config()->customHeader();
+      request.setRawHeader( header.toLatin1(), QStringLiteral( "Bearer %1" ).arg( o2->token() ).toLatin1() );
 #ifdef QGISDEBUG
       msg = QStringLiteral( "Updated request HEADER with access token for authcfg: %1" ).arg( authcfg );
       QgsDebugMsgLevel( msg, 2 );
 #endif
       break;
+    }
     case QgsAuthOAuth2Config::Form:
       // FIXME: what to do here if the parent request is not POST?
       //        probably have to skip this until auth system support is moved into QgsNetworkAccessManager

--- a/tests/src/auth/testqgsauthoauth2method.cpp
+++ b/tests/src/auth/testqgsauthoauth2method.cpp
@@ -120,6 +120,7 @@ QgsAuthOAuth2Config *TestQgsAuthOAuth2Method::baseConfig( bool loaded )
     config->setApiKey( "someapikey" );
     config->setPersistToken( false );
     config->setAccessMethod( QgsAuthOAuth2Config::Header );
+    config->setCustomHeader( QStringLiteral( "x-auth" ) );
     config->setRequestTimeout( 30 ); // in seconds
     QVariantMap queryPairs;
     queryPairs.insert( "pf.username", "myusername" );
@@ -141,6 +142,7 @@ QByteArray TestQgsAuthOAuth2Method::baseConfigTxt( bool pretty )
            "    \"clientId\": \"myclientid\",\n"
            "    \"clientSecret\": \"myclientsecret\",\n"
            "    \"configType\": 1,\n"
+           "    \"customHeader\": \"x-auth\",\n"
            "    \"description\": \"A test config\",\n"
            "    \"grantFlow\": 0,\n"
            "    \"id\": \"abc1234\",\n"
@@ -170,6 +172,7 @@ QByteArray TestQgsAuthOAuth2Method::baseConfigTxt( bool pretty )
            "\"clientId\":\"myclientid\","
            "\"clientSecret\":\"myclientsecret\","
            "\"configType\":1,"
+           "\"customHeader\":\"x-auth\","
            "\"description\":\"A test config\","
            "\"grantFlow\":0,"
            "\"id\":\"abc1234\","
@@ -206,6 +209,7 @@ QVariantMap TestQgsAuthOAuth2Method::baseVariantMap()
   vmap.insert( "objectName", "" );
   vmap.insert( "password", "mypassword" );
   vmap.insert( "persistToken", false );
+  vmap.insert( "customHeader", "x-auth" );
   QVariantMap qpairs;
   qpairs.insert( "pf.password", "mypassword" );
   qpairs.insert( "pf.username", "myusername" );


### PR DESCRIPTION
Some services do not use the default HTTP "Authorization" header for specifying the token, and require a custom header instead
(e.g. AGOL services must use "X-Esri-Authorization" header instead)
