### PR TITLE
Allow specifying lists of values for parameters in qgis_process tool

### DIFF
--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -324,7 +324,28 @@ int QgsProcessingExec::run( const QStringList &constArgs )
         else
         {
           const QString value = parts.mid( 1 ).join( '=' );
-          params.insert( name, value );
+          if ( params.contains( name ) )
+          {
+            // parameter specified multiple times, store all of them in a list...
+            if ( params.value( name ).type() == QVariant::StringList )
+            {
+              // append to existing list
+              QStringList listValue = params.value( name ).toStringList();
+              listValue << value;
+              params.insert( name, listValue );
+            }
+            else
+            {
+              // upgrade previous value to list
+              QStringList listValue = QStringList() << params.value( name ).toString()
+                                      << value;
+              params.insert( name, listValue );
+            }
+          }
+          else
+          {
+            params.insert( name, value );
+          }
         }
       }
       else
@@ -343,7 +364,28 @@ int QgsProcessingExec::run( const QStringList &constArgs )
       {
         const QString name = parts.first();
         const QString value = parts.mid( 1 ).join( '=' );
-        params.insert( name, value );
+        if ( params.contains( name ) )
+        {
+          // parameter specified multiple times, store all of them in a list...
+          if ( params.value( name ).type() == QVariant::StringList )
+          {
+            // append to existing list
+            QStringList listValue = params.value( name ).toStringList();
+            listValue << value;
+            params.insert( name, listValue );
+          }
+          else
+          {
+            // upgrade previous value to list
+            QStringList listValue = QStringList() << params.value( name ).toString()
+                                    << value;
+            params.insert( name, listValue );
+          }
+        }
+        else
+        {
+          params.insert( name, value );
+        }
       }
     }
 
@@ -369,7 +411,7 @@ void QgsProcessingExec::showUsage( const QString &appName )
       << "\tplugins\tlist available and active plugins\n"
       << "\tlist\tlist all available processing algorithms\n"
       << "\thelp\tshow help for an algorithm. The algorithm id or a path to a model file must be specified.\n"
-      << "\trun\truns an algorithm. The algorithm id or a path to a model file and parameter values must be specified. Parameter values are specified after -- with PARAMETER=VALUE syntax.\n"
+      << "\trun\truns an algorithm. The algorithm id or a path to a model file and parameter values must be specified. Parameter values are specified after -- with PARAMETER=VALUE syntax. Ordered list values for a parameter can be created by specifying the parameter multiple times, e.g. --LAYERS=layer1.shp --LAYERS=layer2.shp\n"
       << "\t\tIf required, the ellipsoid to use for distance and area calculations can be specified via the \"--ELLIPSOID=name\" argument.\n"
       << "\t\tIf required, an existing QGIS project to use during the algorithm execution can be specified via the \"--PROJECT_PATH=path\" argument.\n";
 

--- a/tests/src/python/test_qgsprocessexecutable.py
+++ b/tests/src/python/test_qgsprocessexecutable.py
@@ -203,6 +203,33 @@ class TestQgsProcessExecutable(unittest.TestCase):
         self.assertTrue(os.path.exists(output_file))
         self.assertEqual(rc, 0)
 
+    def testAlgorithmRunListValue(self):
+        """
+        Test an algorithm which requires a list of layers as a parameter value
+        """
+        output_file = self.TMP_DIR + '/package.gpkg'
+        rc, output, err = self.run_process(['run', '--json', 'native:package', '--',
+                                            'LAYERS={}'.format(TEST_DATA_DIR + '/polys.shp'),
+                                            'LAYERS={}'.format(TEST_DATA_DIR + '/points.shp'),
+                                            'LAYERS={}'.format(TEST_DATA_DIR + '/lines.shp'),
+                                            'OUTPUT={}'.format(output_file)])
+        res = json.loads(output)
+
+        self.assertIn('gdal_version', res)
+        self.assertIn('geos_version', res)
+        self.assertIn('proj_version', res)
+        self.assertIn('qt_version', res)
+        self.assertIn('qgis_version', res)
+
+        self.assertEqual(res['algorithm_details']['name'], 'Package layers')
+        self.assertEqual(len(res['inputs']['LAYERS']), 3)
+        self.assertEqual(res['inputs']['OUTPUT'], output_file)
+        self.assertEqual(res['results']['OUTPUT'], output_file)
+        self.assertEqual(len(res['results']['OUTPUT_LAYERS']), 3)
+
+        self.assertTrue(os.path.exists(output_file))
+        self.assertEqual(rc, 0)
+
     def testModelHelp(self):
         rc, output, err = self.run_process(['help', TEST_DATA_DIR + '/test_model.model3'])
         if os.environ.get('TRAVIS', '') != 'true':


### PR DESCRIPTION
Specifying the same parameter value twice will result in a list value
being built, allowing use of algorithms which require a list of layers
(or other values) as parameters.

E.g.

     qgis_process run native:package -- LAYERS=layer1.shp LAYERS=layer2.shp OUTPUT=db.gpkg

will run the package algorithm with a list [layer1.shp, layer2.shp] as the parameter value for the LAYERS parameter
