### PR TITLE
[3d] Use project's full extent when setting flat/online terrain extent

### DIFF
--- a/src/3d/chunks/qgschunkloader_p.h
+++ b/src/3d/chunks/qgschunkloader_p.h
@@ -63,8 +63,9 @@ class QgsChunkLoader : public QgsChunkQueueJob
  * Factory for chunk loaders for a particular type of entity
  * \since QGIS 3.0
  */
-class QgsChunkLoaderFactory
+class QgsChunkLoaderFactory  : public QObject
 {
+    Q_OBJECT
   public:
     virtual ~QgsChunkLoaderFactory() = default;
 
@@ -89,6 +90,7 @@ class QgsChunkLoaderFactory
  */
 class _3D_EXPORT QgsQuadtreeChunkLoaderFactory : public QgsChunkLoaderFactory
 {
+    Q_OBJECT
   public:
     QgsQuadtreeChunkLoaderFactory();
     virtual ~QgsQuadtreeChunkLoaderFactory();

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -220,7 +220,7 @@ Qgs3DMapScene::Qgs3DMapScene( const Qgs3DMapSettings &map, QgsAbstract3DEngine *
 
   // force initial update of chunked entities
   onCameraChanged();
-  // force initial update of eye dome shadng
+  // force initial update of eye dome shading
   onEyeDomeShadingSettingsChanged();
   // force initial update of debugging setting of preview quads
   onDebugShadowMapSettingsChanged();

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -601,7 +601,14 @@ float Qgs3DMapSettings::maxTerrainGroundError() const
 
 void Qgs3DMapSettings::setTerrainGenerator( QgsTerrainGenerator *gen )
 {
+  if ( mTerrainGenerator )
+  {
+    disconnect( mTerrainGenerator.get(), &QgsTerrainGenerator::extentChanged, this, &Qgs3DMapSettings::terrainGeneratorChanged );
+  }
+
   mTerrainGenerator.reset( gen );
+  connect( mTerrainGenerator.get(), &QgsTerrainGenerator::extentChanged, this, &Qgs3DMapSettings::terrainGeneratorChanged );
+
   emit terrainGeneratorChanged();
 }
 

--- a/src/3d/terrain/qgsflatterraingenerator.cpp
+++ b/src/3d/terrain/qgsflatterraingenerator.cpp
@@ -141,8 +141,13 @@ void QgsFlatTerrainGenerator::setCrs( const QgsCoordinateReferenceSystem &crs )
 
 void QgsFlatTerrainGenerator::setExtent( const QgsRectangle &extent )
 {
+  if ( mExtent == extent )
+    return;
+
   mExtent = extent;
   updateTilingScheme();
+
+  emit extentChanged();
 }
 
 void QgsFlatTerrainGenerator::updateTilingScheme()

--- a/src/3d/terrain/qgsflatterraingenerator.h
+++ b/src/3d/terrain/qgsflatterraingenerator.h
@@ -52,6 +52,7 @@ class FlatTerrainChunkLoader : public QgsTerrainTileLoader
  */
 class _3D_EXPORT QgsFlatTerrainGenerator : public QgsTerrainGenerator
 {
+    Q_OBJECT
   public:
     //! Creates flat terrain generator object
     QgsFlatTerrainGenerator() = default;
@@ -61,12 +62,10 @@ class _3D_EXPORT QgsFlatTerrainGenerator : public QgsTerrainGenerator
     QgsTerrainGenerator *clone() const override SIP_FACTORY;
     Type type() const override;
     QgsRectangle extent() const override;
+    void setExtent( const QgsRectangle &extent ) override;
     void rootChunkHeightRange( float &hMin, float &hMax ) const override;
     void writeXml( QDomElement &elem ) const override;
     void readXml( const QDomElement &elem ) override;
-
-    //! Sets extent of the terrain
-    void setExtent( const QgsRectangle &extent );
 
     //! Sets CRS of the terrain
     void setCrs( const QgsCoordinateReferenceSystem &crs );

--- a/src/3d/terrain/qgsonlineterraingenerator.cpp
+++ b/src/3d/terrain/qgsonlineterraingenerator.cpp
@@ -98,8 +98,13 @@ void QgsOnlineTerrainGenerator::setCrs( const QgsCoordinateReferenceSystem &crs,
 
 void QgsOnlineTerrainGenerator::setExtent( const QgsRectangle &extent )
 {
+  if ( mExtent == extent )
+    return;
+
   mExtent = extent;
   updateGenerator();
+
+  emit extentChanged();
 }
 
 void QgsOnlineTerrainGenerator::updateGenerator()

--- a/src/3d/terrain/qgsonlineterraingenerator.h
+++ b/src/3d/terrain/qgsonlineterraingenerator.h
@@ -36,13 +36,11 @@ class QgsDemHeightMapGenerator;
  */
 class _3D_EXPORT QgsOnlineTerrainGenerator : public QgsTerrainGenerator
 {
+    Q_OBJECT
   public:
     //! Constructor for QgsOnlineTerrainGenerator
     QgsOnlineTerrainGenerator();
     ~QgsOnlineTerrainGenerator() override;
-
-    //! Sets extent of the terrain
-    void setExtent( const QgsRectangle &extent );
 
     //! Sets CRS of the terrain
     void setCrs( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context );
@@ -65,6 +63,7 @@ class _3D_EXPORT QgsOnlineTerrainGenerator : public QgsTerrainGenerator
     QgsTerrainGenerator *clone() const override SIP_FACTORY;
     Type type() const override;
     QgsRectangle extent() const override;
+    void setExtent( const QgsRectangle &extent ) override;
     float heightAt( double x, double y, const Qgs3DMapSettings &map ) const override;
     void writeXml( QDomElement &elem ) const override;
     void readXml( const QDomElement &elem ) override;

--- a/src/3d/terrain/qgsterraingenerator.h
+++ b/src/3d/terrain/qgsterraingenerator.h
@@ -46,6 +46,7 @@ class QgsProject;
  */
 class _3D_EXPORT QgsTerrainGenerator : public QgsQuadtreeChunkLoaderFactory
 {
+    Q_OBJECT
   public:
 
     //! Enumeration of the available terrain generators
@@ -68,6 +69,9 @@ class _3D_EXPORT QgsTerrainGenerator : public QgsQuadtreeChunkLoaderFactory
 
     //! extent of the terrain in terrain's CRS
     virtual QgsRectangle extent() const = 0;
+
+    //! sets the extent of the terrain in terrain's CRS
+    virtual void setExtent( const QgsRectangle &extent ) { Q_UNUSED( extent ) }
 
     //! Returns bounding box of the root chunk
     virtual QgsAABB rootChunkBbox( const Qgs3DMapSettings &map ) const;
@@ -102,11 +106,18 @@ class _3D_EXPORT QgsTerrainGenerator : public QgsQuadtreeChunkLoaderFactory
     //! Returns whether the terrain generator is valid
     bool isValid() const;
 
+  signals:
+
+    //! Emitted when the terrain extent has changed
+    void extentChanged();
+
   protected:
+
     QgsTilingScheme mTerrainTilingScheme;   //!< Tiling scheme of the terrain
     QgsTerrainEntity *mTerrain = nullptr;
 
     bool mIsValid = true;
+
 };
 
 

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -27,8 +27,12 @@
 #include "qgs3dmaptool.h"
 #include "qgswindow3dengine.h"
 #include "qgs3dnavigationwidget.h"
+#include "qgsproject.h"
+#include "qgsprojectviewsettings.h"
 #include "qgssettings.h"
 #include "qgstemporalcontroller.h"
+#include "qgsflatterraingenerator.h"
+#include "qgsonlineterraingenerator.h"
 
 Qgs3DMapCanvas::Qgs3DMapCanvas( QWidget *parent )
   : QWidget( parent )
@@ -117,8 +121,37 @@ QgsCameraController *Qgs3DMapCanvas::cameraController()
   return mScene ? mScene->cameraController() : nullptr;
 }
 
-void Qgs3DMapCanvas::resetView()
+void Qgs3DMapCanvas::resetView( bool resetExtent )
 {
+  if ( resetExtent )
+  {
+    if ( map()->terrainGenerator()->type() == QgsTerrainGenerator::Flat ||
+         map()->terrainGenerator()->type() == QgsTerrainGenerator::Online )
+    {
+      const QgsReferencedRectangle extent = QgsProject::instance()->viewSettings()->fullExtent();
+      QgsCoordinateTransform ct( extent.crs(), map()->crs(), QgsProject::instance()->transformContext() );
+      ct.setBallparkTransformsAreAppropriate( true );
+      QgsRectangle rect;
+      try
+      {
+        rect = ct.transformBoundingBox( extent );
+      }
+      catch ( QgsCsException & )
+      {
+        rect = extent;
+      }
+      map()->terrainGenerator()->setExtent( rect );
+
+      // reproject terrain's extent to map CRS
+      QgsRectangle te = map()->terrainGenerator()->extent();
+      QgsCoordinateTransform terrainToMapTransform( map()->terrainGenerator()->crs(), map()->crs(), QgsProject::instance() );
+      te = terrainToMapTransform.transformBoundingBox( te );
+
+      QgsPointXY center = te.center();
+      map()->setOrigin( QgsVector3D( center.x(), center.y(), 0 ) );
+    }
+  }
+
   mScene->viewZoomFull();
 }
 

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -56,7 +56,7 @@ class Qgs3DMapCanvas : public QWidget
     QgsCameraController *cameraController();
 
     //! Resets camera position to the default: looking down at the origin of world coordinates
-    void resetView();
+    void resetView( bool resetExtent = false );
 
     //! Sets camera position to look down at the given point (in map coordinates) in given distance from plane with zero elevation
     void setViewFromTop( const QgsPointXY &center, float distance, float rotation = 0 );

--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -284,7 +284,7 @@ void Qgs3DMapCanvasDockWidget::setMainCanvas( QgsMapCanvas *canvas )
 
 void Qgs3DMapCanvasDockWidget::resetView()
 {
-  mCanvas->resetView();
+  mCanvas->resetView( true );
 }
 
 void Qgs3DMapCanvasDockWidget::configure()

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -28,6 +28,7 @@
 #include "qgsrasterlayer.h"
 #include "qgsmeshlayer.h"
 #include "qgsproject.h"
+#include "qgsprojectviewsettings.h"
 #include "qgsmesh3dsymbolwidget.h"
 #include "qgssettings.h"
 #include "qgsskyboxrenderingsettingswidget.h"
@@ -219,7 +220,7 @@ void Qgs3DMapConfigWidget::apply()
     {
       QgsFlatTerrainGenerator *flatTerrainGen = new QgsFlatTerrainGenerator;
       flatTerrainGen->setCrs( mMap->crs() );
-      flatTerrainGen->setExtent( mMainCanvas->fullExtent() );
+      flatTerrainGen->setExtent( QgsProject::instance()->viewSettings()->fullExtent() );
       mMap->setTerrainGenerator( flatTerrainGen );
       needsUpdateOrigin = true;
     }
@@ -266,7 +267,7 @@ void Qgs3DMapConfigWidget::apply()
       {
         QgsOnlineTerrainGenerator *onlineTerrainGen = new QgsOnlineTerrainGenerator;
         onlineTerrainGen->setCrs( mMap->crs(), QgsProject::instance()->transformContext() );
-        onlineTerrainGen->setExtent( mMainCanvas->fullExtent() );
+        onlineTerrainGen->setExtent( QgsProject::instance()->viewSettings()->fullExtent() );
         onlineTerrainGen->setResolution( spinTerrainResolution->value() );
         onlineTerrainGen->setSkirtHeight( spinTerrainSkirtHeight->value() );
         mMap->setTerrainGenerator( onlineTerrainGen );

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -212,6 +212,19 @@ void Qgs3DMapConfigWidget::apply()
 {
   bool needsUpdateOrigin = false;
 
+  const QgsReferencedRectangle extent = QgsProject::instance()->viewSettings()->fullExtent();
+  QgsCoordinateTransform ct( extent.crs(), mMap->crs(), QgsProject::instance()->transformContext() );
+  ct.setBallparkTransformsAreAppropriate( true );
+  QgsRectangle rect;
+  try
+  {
+    rect = ct.transformBoundingBox( extent );
+  }
+  catch ( QgsCsException & )
+  {
+    rect = extent;
+  }
+
   QgsTerrainGenerator::Type terrainType = static_cast<QgsTerrainGenerator::Type>( cboTerrainType->currentData().toInt() );
 
   switch ( terrainType )
@@ -220,7 +233,7 @@ void Qgs3DMapConfigWidget::apply()
     {
       QgsFlatTerrainGenerator *flatTerrainGen = new QgsFlatTerrainGenerator;
       flatTerrainGen->setCrs( mMap->crs() );
-      flatTerrainGen->setExtent( QgsProject::instance()->viewSettings()->fullExtent() );
+      flatTerrainGen->setExtent( rect );
       mMap->setTerrainGenerator( flatTerrainGen );
       needsUpdateOrigin = true;
     }
@@ -267,7 +280,7 @@ void Qgs3DMapConfigWidget::apply()
       {
         QgsOnlineTerrainGenerator *onlineTerrainGen = new QgsOnlineTerrainGenerator;
         onlineTerrainGen->setCrs( mMap->crs(), QgsProject::instance()->transformContext() );
-        onlineTerrainGen->setExtent( QgsProject::instance()->viewSettings()->fullExtent() );
+        onlineTerrainGen->setExtent( rect );
         onlineTerrainGen->setResolution( spinTerrainResolution->value() );
         onlineTerrainGen->setSkirtHeight( spinTerrainSkirtHeight->value() );
         mMap->setTerrainGenerator( onlineTerrainGen );


### PR DESCRIPTION
## Description

By using the brand new project view setting's full extent, it'll allow for users to avoid having a 3D scene extent set to the whole world when XYZ layer(s) is/are present.

@nyalldawson , as discussed.