### PR TITLE
[processing] don't set any default value for optional NODATA parameter in GDAL rastrize algorithm (fix #39752).

### DIFF
--- a/python/plugins/processing/algs/gdal/rasterize.py
+++ b/python/plugins/processing/algs/gdal/rasterize.py
@@ -99,7 +99,6 @@ class rasterize(GdalAlgorithm):
         self.addParameter(QgsProcessingParameterNumber(self.NODATA,
                                                        self.tr('Assign a specified nodata value to output bands'),
                                                        type=QgsProcessingParameterNumber.Double,
-                                                       defaultValue=0.0,
                                                        optional=True))
 
         options_param = QgsProcessingParameterString(self.OPTIONS,

--- a/python/plugins/processing/algs/gdal/rasterize.py
+++ b/python/plugins/processing/algs/gdal/rasterize.py
@@ -23,6 +23,7 @@ __copyright__ = '(C) 2013, Alexander Bruy'
 
 import os
 
+from qgis.PyQt.QtCore import QVariant
 from qgis.PyQt.QtGui import QIcon
 
 from qgis.core import (QgsRasterFileWriter,
@@ -96,10 +97,12 @@ class rasterize(GdalAlgorithm):
                                                        defaultValue=0.0))
         self.addParameter(QgsProcessingParameterExtent(self.EXTENT,
                                                        self.tr('Output extent')))
-        self.addParameter(QgsProcessingParameterNumber(self.NODATA,
-                                                       self.tr('Assign a specified nodata value to output bands'),
-                                                       type=QgsProcessingParameterNumber.Double,
-                                                       optional=True))
+        nodataParam = QgsProcessingParameterNumber(self.NODATA,
+                                                   self.tr('Assign a specified nodata value to output bands'),
+                                                   type=QgsProcessingParameterNumber.Double,
+                                                   optional=True)
+        nodataParam.setGuiDefaultValueOverride(QVariant(QVariant.Double))
+        self.addParameter(nodataParam)
 
         options_param = QgsProcessingParameterString(self.OPTIONS,
                                                      self.tr('Additional creation options'),


### PR DESCRIPTION
## Description
NODATA parameter by default set to 0 and as result taken into account when GDAL command-line generated. This can lead to 
avoid unexpected conversion of valid values to nodata values.

With "Not set" by default users can apply NODATA only when needed.

Fixes #39752.
