### PR TITLE
[FEATURE] Allow to reverse selected features

### DIFF
--- a/src/app/qgsmaptoolreverseline.h
+++ b/src/app/qgsmaptoolreverseline.h
@@ -41,10 +41,12 @@ class APP_EXPORT QgsMapToolReverseLine: public QgsMapToolEdit
 
     //! called when map tool is being deactivated
     void deactivate() override;
+    void activate() override;
 
   private:
     QgsVectorLayer *vlayer = nullptr;
 
+    bool reverseLine( const QgsFeatureId fid, const int partNum = 0 );
     QgsGeometry partUnderPoint( QPoint p, QgsFeatureId &fid, int &partNum );
 
     /* Rubberband that shows the part being reversed*/


### PR DESCRIPTION
## Description

This PR aims to facilitate the use of reverse line map tools.

For now, you have to click on each part to reverse lines/parts. However, you may want to reverse all selected lines at the same time. Of course, you may use processing tools, but for some users is not efficient (more click click in processing). 

This PR introduce a method to automatically reverse line if they are selected [1]. Obviously, you can always click on parts to reverse it after.

[1] For multiline, all parts are reversed.

Fixes #37834