### PR TITLE
[API] Improve isValid method for curve type

### DIFF
--- a/python/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -83,6 +83,8 @@ to ``p2`` will be used (i.e. winding the other way around the circle).
 
     virtual bool isEmpty() const /HoldGIL/;
 
+    virtual bool isValid( QString &error /Out/, int flags = 0 ) const /HoldGIL/;
+
     virtual int numPoints() const /HoldGIL/;
 
 

--- a/python/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -83,7 +83,7 @@ to ``p2`` will be used (i.e. winding the other way around the circle).
 
     virtual bool isEmpty() const /HoldGIL/;
 
-    virtual bool isValid( QString &error /Out/, int flags = 0 ) const /HoldGIL/;
+    virtual bool isValid( QString &error /Out/, int flags = 0 ) const;
 
     virtual int numPoints() const /HoldGIL/;
 

--- a/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
@@ -65,7 +65,7 @@ Compound curve geometry type
 
     virtual bool isEmpty() const /HoldGIL/;
 
-    virtual bool isValid( QString &error /Out/, int flags = 0 ) const /HoldGIL/;
+    virtual bool isValid( QString &error /Out/, int flags = 0 ) const;
 
 
     virtual QgsLineString *curveToLine( double tolerance = M_PI_2 / 90, SegmentationToleranceType toleranceType = MaximumAngle ) const /Factory/;

--- a/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
@@ -65,6 +65,8 @@ Compound curve geometry type
 
     virtual bool isEmpty() const /HoldGIL/;
 
+    virtual bool isValid( QString &error /Out/, int flags = 0 ) const /HoldGIL/;
+
 
     virtual QgsLineString *curveToLine( double tolerance = M_PI_2 / 90, SegmentationToleranceType toleranceType = MaximumAngle ) const /Factory/;
 

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -416,7 +416,7 @@ segment in the line.
 
     virtual bool isEmpty() const /HoldGIL/;
 
-    virtual bool isValid( QString &error /Out/, int flags = 0 ) const /HoldGIL/;
+    virtual bool isValid( QString &error /Out/, int flags = 0 ) const;
 
     virtual QgsLineString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const /Factory/;
 

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -416,6 +416,8 @@ segment in the line.
 
     virtual bool isEmpty() const /HoldGIL/;
 
+    virtual bool isValid( QString &error /Out/, int flags = 0 ) const /HoldGIL/;
+
     virtual QgsLineString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const /Factory/;
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false );

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -407,7 +407,7 @@ bool QgsCircularString::isValid( QString &error SIP_OUT, int flags ) const
 {
   if ( !isEmpty() && ( numPoints() < 3 ) )
   {
-    error = QObject::tr( "CircularString have less than 3 points and is not empty." );
+    error = QObject::tr( "CircularString has less than 3 points and is not empty." );
     return false;
   }
   return QgsCurve::isValid( error, flags );

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -407,7 +407,7 @@ bool QgsCircularString::isValid( QString &error SIP_OUT, int flags ) const
 {
   if ( !isEmpty() && ( numPoints() < 3 ) )
   {
-    error = QString( "Geometry have less than 3 points and is not empty." );
+    error = QString( "CircularString have less than 3 points and is not empty." );
     return false;
   }
   return QgsCurve::isValid( error, flags );

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -403,7 +403,7 @@ bool QgsCircularString::isEmpty() const
   return mX.isEmpty();
 }
 
-bool QgsCircularString::isValid( QString &error SIP_OUT, int flags ) const
+bool QgsCircularString::isValid( QString &error, int flags ) const
 {
   if ( !isEmpty() && ( numPoints() < 3 ) )
   {

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -407,7 +407,7 @@ bool QgsCircularString::isValid( QString &error SIP_OUT, int flags ) const
 {
   if ( !isEmpty() && ( numPoints() < 3 ) )
   {
-    error = QString( "CircularString have less than 3 points and is not empty." );
+    error = QObject::tr( "CircularString have less than 3 points and is not empty." );
     return false;
   }
   return QgsCurve::isValid( error, flags );

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -403,6 +403,16 @@ bool QgsCircularString::isEmpty() const
   return mX.isEmpty();
 }
 
+bool QgsCircularString::isValid( QString &error SIP_OUT, int flags ) const
+{
+  if ( !isEmpty() && ( numPoints() < 3 ) )
+  {
+    error = QString( "Geometry have less than 3 points and is not empty." );
+    return false;
+  }
+  return QgsCurve::isValid( error, flags );
+}
+
 //curve interface
 double QgsCircularString::length() const
 {

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -82,7 +82,7 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     json asJsonObject( int precision = 17 ) const override SIP_SKIP;
     bool isEmpty() const override SIP_HOLDGIL;
-    bool isValid( QString &error SIP_OUT, int flags = 0 ) const override SIP_HOLDGIL;
+    bool isValid( QString &error SIP_OUT, int flags = 0 ) const override;
     int numPoints() const override SIP_HOLDGIL;
 
     /**

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -82,6 +82,7 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     json asJsonObject( int precision = 17 ) const override SIP_SKIP;
     bool isEmpty() const override SIP_HOLDGIL;
+    bool isValid( QString &error SIP_OUT, int flags = 0 ) const override SIP_HOLDGIL;
     int numPoints() const override SIP_HOLDGIL;
 
     /**

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -393,11 +393,11 @@ bool QgsCompoundCurve::isValid( QString &error SIP_OUT, int flags ) const
   if ( mCurves.isEmpty() )
     return true;
 
-  for ( QgsCurve *curve : mCurves )
+  for ( int i = 0; i < mCurves.size() ; ++i )
   {
-    if ( !curve->isValid( error, flags ) )
+    if ( !mCurves[i]->isValid( error, flags ) )
     {
-      error = QString( "At least one curve is not valid." );
+      error = QStringLiteral("Curve[%1]: %2").arg(i).arg(error);
       return false;
     }
   }

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -397,7 +397,7 @@ bool QgsCompoundCurve::isValid( QString &error SIP_OUT, int flags ) const
   {
     if ( !mCurves[i]->isValid( error, flags ) )
     {
-      error = QObject::tr( "Curve[%1]: %2" ).arg( i ).arg( error );
+      error = QObject::tr( "Curve[%1]: %2" ).arg( i + 1 ).arg( error );
       return false;
     }
   }
@@ -1027,4 +1027,3 @@ void QgsCompoundCurve::swapXy()
   }
   clearCache();
 }
-

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -397,7 +397,7 @@ bool QgsCompoundCurve::isValid( QString &error SIP_OUT, int flags ) const
   {
     if ( !mCurves[i]->isValid( error, flags ) )
     {
-      error = QObject::tr("Curve[%1]: %2").arg(i).arg(error);
+      error = QObject::tr( "Curve[%1]: %2" ).arg( i ).arg( error );
       return false;
     }
   }

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -388,6 +388,22 @@ bool QgsCompoundCurve::isEmpty() const
   return true;
 }
 
+bool QgsCompoundCurve::isValid( QString &error SIP_OUT, int flags ) const
+{
+  if ( mCurves.isEmpty() )
+    return true;
+
+  for ( QgsCurve *curve : mCurves )
+  {
+    if ( !curve->isValid( error, flags ) )
+    {
+      error = QString( "At least one curve is not valid." );
+      return false;
+    }
+  }
+  return QgsCurve::isValid( error, flags );
+}
+
 QgsLineString *QgsCompoundCurve::curveToLine( double tolerance, SegmentationToleranceType toleranceType ) const
 {
   QgsLineString *line = new QgsLineString();

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -397,7 +397,7 @@ bool QgsCompoundCurve::isValid( QString &error SIP_OUT, int flags ) const
   {
     if ( !mCurves[i]->isValid( error, flags ) )
     {
-      error = QStringLiteral("Curve[%1]: %2").arg(i).arg(error);
+      error = QObject::tr("Curve[%1]: %2").arg(i).arg(error);
       return false;
     }
   }

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -388,7 +388,7 @@ bool QgsCompoundCurve::isEmpty() const
   return true;
 }
 
-bool QgsCompoundCurve::isValid( QString &error SIP_OUT, int flags ) const
+bool QgsCompoundCurve::isValid( QString &error, int flags ) const
 {
   if ( mCurves.isEmpty() )
     return true;

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -60,7 +60,7 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
     void points( QgsPointSequence &pts SIP_OUT ) const override;
     int numPoints() const override SIP_HOLDGIL;
     bool isEmpty() const override SIP_HOLDGIL;
-    bool isValid( QString &error SIP_OUT, int flags = 0 ) const override SIP_HOLDGIL;
+    bool isValid( QString &error SIP_OUT, int flags = 0 ) const override;
 
     /**
      * Returns a new line string geometry corresponding to a segmentized approximation

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -60,6 +60,7 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
     void points( QgsPointSequence &pts SIP_OUT ) const override;
     int numPoints() const override SIP_HOLDGIL;
     bool isEmpty() const override SIP_HOLDGIL;
+    bool isValid( QString &error SIP_OUT, int flags = 0 ) const override SIP_HOLDGIL;
 
     /**
      * Returns a new line string geometry corresponding to a segmentized approximation

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -310,7 +310,7 @@ bool QgsLineString::isEmpty() const
   return mX.isEmpty();
 }
 
-bool QgsLineString::isValid( QString &error SIP_OUT, int flags ) const
+bool QgsLineString::isValid( QString &error, int flags ) const
 {
   if ( !isEmpty() && ( numPoints() < 2 ) )
   {

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -314,7 +314,7 @@ bool QgsLineString::isValid( QString &error SIP_OUT, int flags ) const
 {
   if ( !isEmpty() && ( numPoints() < 2 ) )
   {
-    error = QString( "Geometry have less than 2 points and is not empty." );
+    error = QString( "LineString have less than 2 points and is not empty." );
     return false;
   }
   return QgsCurve::isValid( error, flags );

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -310,6 +310,16 @@ bool QgsLineString::isEmpty() const
   return mX.isEmpty();
 }
 
+bool QgsLineString::isValid( QString &error SIP_OUT, int flags ) const
+{
+  if ( !isEmpty() && ( numPoints() < 2 ) )
+  {
+    error = QString( "Geometry have less than 2 points and is not empty." );
+    return false;
+  }
+  return QgsCurve::isValid( error, flags );
+}
+
 QgsLineString *QgsLineString::snappedToGrid( double hSpacing, double vSpacing, double dSpacing, double mSpacing ) const
 {
   // prepare result

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -314,7 +314,7 @@ bool QgsLineString::isValid( QString &error SIP_OUT, int flags ) const
 {
   if ( !isEmpty() && ( numPoints() < 2 ) )
   {
-    error = QString( "LineString have less than 2 points and is not empty." );
+    error = QObject::tr( "LineString have less than 2 points and is not empty." );
     return false;
   }
   return QgsCurve::isValid( error, flags );

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -314,7 +314,7 @@ bool QgsLineString::isValid( QString &error SIP_OUT, int flags ) const
 {
   if ( !isEmpty() && ( numPoints() < 2 ) )
   {
-    error = QObject::tr( "LineString have less than 2 points and is not empty." );
+    error = QObject::tr( "LineString has less than 2 points and is not empty." );
     return false;
   }
   return QgsCurve::isValid( error, flags );

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -586,6 +586,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     QgsLineString *clone() const override SIP_FACTORY;
     void clear() override;
     bool isEmpty() const override SIP_HOLDGIL;
+    bool isValid( QString &error SIP_OUT, int flags = 0 ) const override SIP_HOLDGIL;
     QgsLineString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
 

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -586,7 +586,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     QgsLineString *clone() const override SIP_FACTORY;
     void clear() override;
     bool isEmpty() const override SIP_HOLDGIL;
-    bool isValid( QString &error SIP_OUT, int flags = 0 ) const override SIP_HOLDGIL;
+    bool isValid( QString &error SIP_OUT, int flags = 0 ) const override;
     QgsLineString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
 

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -504,7 +504,7 @@ void TestQgsGeometry::isValid()
   invalidLine.addVertex( QgsPoint( 0, 0 ) );
   curve.addCurve( invalidLine.clone() );
   QVERIFY( !curve.isValid( error ) );
-  QCOMPARE( error, QStringLiteral( "At least one curve is not valid." ) );
+  QCOMPARE( error, QStringLiteral( "Curve[2]: LineString have less than 2 points and is not empty." ) );
 }
 
 void TestQgsGeometry::equality()

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -478,7 +478,7 @@ void TestQgsGeometry::isValid()
   QVERIFY( line.isValid( error ) );
   line.addVertex( QgsPoint( 0, 0 ) );
   QVERIFY( !line.isValid( error ) );
-  QCOMPARE( error, QStringLiteral( "Geometry have less than 2 points and is not empty." ) );
+  QCOMPARE( error, QStringLiteral( "LineString have less than 2 points and is not empty." ) );
   line.addVertex( QgsPoint( 1, 1 ) );
   QVERIFY( line.isValid( error ) );
 

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -504,7 +504,7 @@ void TestQgsGeometry::isValid()
   invalidLine.addVertex( QgsPoint( 0, 0 ) );
   curve.addCurve( invalidLine.clone() );
   QVERIFY( !curve.isValid( error ) );
-  QCOMPARE( error, QStringLiteral( "Curve[2]: LineString has less than 2 points and is not empty." ) );
+  QCOMPARE( error, QStringLiteral( "Curve[3]: LineString has less than 2 points and is not empty." ) );
 }
 
 void TestQgsGeometry::equality()

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -478,7 +478,7 @@ void TestQgsGeometry::isValid()
   QVERIFY( line.isValid( error ) );
   line.addVertex( QgsPoint( 0, 0 ) );
   QVERIFY( !line.isValid( error ) );
-  QCOMPARE( error, QStringLiteral( "LineString have less than 2 points and is not empty." ) );
+  QCOMPARE( error, QStringLiteral( "LineString has less than 2 points and is not empty." ) );
   line.addVertex( QgsPoint( 1, 1 ) );
   QVERIFY( line.isValid( error ) );
 
@@ -488,7 +488,7 @@ void TestQgsGeometry::isValid()
   QgsPointSequence pts = QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 2.5, 2.3 );
   circ.setPoints( pts );
   QVERIFY( !circ.isValid( error ) );
-  QCOMPARE( error, QStringLiteral( "CircularString have less than 3 points and is not empty." ) );
+  QCOMPARE( error, QStringLiteral( "CircularString has less than 3 points and is not empty." ) );
   pts.append( QgsPoint( 5, 5 ) );
   circ.setPoints( pts );
   QVERIFY( circ.isValid( error ) );
@@ -504,7 +504,7 @@ void TestQgsGeometry::isValid()
   invalidLine.addVertex( QgsPoint( 0, 0 ) );
   curve.addCurve( invalidLine.clone() );
   QVERIFY( !curve.isValid( error ) );
-  QCOMPARE( error, QStringLiteral( "Curve[2]: LineString have less than 2 points and is not empty." ) );
+  QCOMPARE( error, QStringLiteral( "Curve[2]: LineString has less than 2 points and is not empty." ) );
 }
 
 void TestQgsGeometry::equality()

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -488,7 +488,7 @@ void TestQgsGeometry::isValid()
   QgsPointSequence pts = QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 2.5, 2.3 );
   circ.setPoints( pts );
   QVERIFY( !circ.isValid( error ) );
-  QCOMPARE( error, QStringLiteral( "Geometry have less than 3 points and is not empty." ) );
+  QCOMPARE( error, QStringLiteral( "CircularString have less than 3 points and is not empty." ) );
   pts.append( QgsPoint( 5, 5 ) );
   circ.setPoints( pts );
   QVERIFY( circ.isValid( error ) );

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -83,6 +83,7 @@ class TestQgsGeometry : public QObject
     void asVariant(); //test conversion to and from a QVariant
     void referenced();
     void isEmpty();
+    void isValid();
     void equality();
     void vertexIterator();
     void partIterator();
@@ -467,6 +468,43 @@ void TestQgsGeometry::isEmpty()
 
   QgsGeometryCollection collection;
   QVERIFY( collection.isEmpty() );
+}
+
+void TestQgsGeometry::isValid()
+{
+  QString error;
+  // LineString
+  QgsLineString line;
+  QVERIFY( line.isValid( error ) );
+  line.addVertex( QgsPoint( 0, 0 ) );
+  QVERIFY( !line.isValid( error ) );
+  QCOMPARE( error, QStringLiteral( "Geometry have less than 2 points and is not empty." ) );
+  line.addVertex( QgsPoint( 1, 1 ) );
+  QVERIFY( line.isValid( error ) );
+
+  // CircularString
+  QgsCircularString circ;
+  QVERIFY( circ.isValid( error ) );
+  QgsPointSequence pts = QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 2.5, 2.3 );
+  circ.setPoints( pts );
+  QVERIFY( !circ.isValid( error ) );
+  QCOMPARE( error, QStringLiteral( "Geometry have less than 3 points and is not empty." ) );
+  pts.append( QgsPoint( 5, 5 ) );
+  circ.setPoints( pts );
+  QVERIFY( circ.isValid( error ) );
+
+  // CompoundCurve
+  QgsCompoundCurve curve;
+  QVERIFY( curve.isValid( error ) );
+  curve.addCurve( line.clone() );
+  QVERIFY( curve.isValid( error ) );
+  curve.addCurve( circ.clone() );
+  QVERIFY( curve.isValid( error ) );
+  QgsLineString invalidLine;
+  invalidLine.addVertex( QgsPoint( 0, 0 ) );
+  curve.addCurve( invalidLine.clone() );
+  QVERIFY( !curve.isValid( error ) );
+  QCOMPARE( error, QStringLiteral( "At least one curve is not valid." ) );
 }
 
 void TestQgsGeometry::equality()


### PR DESCRIPTION
## Description

Follow-up https://github.com/qgis/QGIS/pull/39348#discussion_r504164836 and https://github.com/qgis/QGIS/pull/9379#discussion_r269432326

- A line string is valid when it has at least 2 points or if it is empty.
- A circular string is valid when it has at least 3 points or if it is empty.

Nota: I've added these checks in the existing isValid method, is that okay with you, or is it better to put in another method to distinguish this check and the geos check.

cc @m-kuhn @nyalldawson 