### PR TITLE
[Postgres] Fix estimate row on table

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -143,22 +143,15 @@ QgsPostgresProvider::QgsPostgresProvider( QString const &uri, const ProviderOpti
   if ( mSchemaName.isEmpty() && mTableName.startsWith( '(' ) && mTableName.endsWith( ')' ) )
   {
     mIsQuery = true;
-    mQuery = mTableName;
+    setQuery( mTableName );
     mTableName.clear();
   }
   else
   {
     mIsQuery = false;
 
-    if ( !mSchemaName.isEmpty() )
-    {
-      mQuery += quotedIdentifier( mSchemaName ) + '.';
-    }
-
-    if ( !mTableName.isEmpty() )
-    {
-      mQuery += quotedIdentifier( mTableName );
-    }
+    setQuery( ( !mSchemaName.isEmpty() ? quotedIdentifier( mSchemaName ) + '.' : QString() )
+              + ( !mTableName.isEmpty() ? quotedIdentifier( mTableName ) : QString() ) );
   }
 
   mUseEstimatedMetadata = mUri.useEstimatedMetadata();
@@ -1463,9 +1456,9 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
     while ( mQuery.contains( regex ) );
 
     // convert the custom query into a subquery
-    mQuery = QStringLiteral( "%1 AS %2" )
-             .arg( mQuery,
-                   quotedIdentifier( alias ) );
+    setQuery( QStringLiteral( "%1 AS %2" )
+              .arg( mQuery,
+                    quotedIdentifier( alias ) ) );
 
     QString sql = QStringLiteral( "SELECT * FROM %1 LIMIT 1" ).arg( mQuery );
 
@@ -5034,55 +5027,69 @@ QgsAttrPalIndexNameHash QgsPostgresProvider::palAttributeIndexNames() const
   return mAttrPalIndexName;
 }
 
+void QgsPostgresProvider::setQuery( const QString &query )
+{
+  mQuery = query;
+
+  mKind = Relkind::NotSet;
+}
+
 QgsPostgresProvider::Relkind QgsPostgresProvider::relkind() const
 {
+  if ( mKind != Relkind::NotSet )
+    return mKind;
+
   if ( mIsQuery || !connectionRO() )
-    return Relkind::Unknown;
+  {
+    mKind = Relkind::Unknown;
+  }
+  else
+  {
+    QString sql = QStringLiteral( "SELECT relkind FROM pg_class WHERE oid=regclass(%1)::oid" ).arg( quotedValue( mQuery ) );
+    QgsPostgresResult res( connectionRO()->PQexec( sql ) );
+    QString type = res.PQgetvalue( 0, 0 );
 
-  QString sql = QStringLiteral( "SELECT relkind FROM pg_class WHERE oid=regclass(%1)::oid" ).arg( quotedValue( mQuery ) );
-  QgsPostgresResult res( connectionRO()->PQexec( sql ) );
-  QString type = res.PQgetvalue( 0, 0 );
+    mKind = Relkind::Unknown;
 
-  QgsPostgresProvider::Relkind kind = Relkind::Unknown;
-
-  if ( type == QLatin1String( "r" ) )
-  {
-    kind = Relkind::OrdinaryTable;
-  }
-  else if ( type == QLatin1String( "i" ) )
-  {
-    kind = Relkind::Index;
-  }
-  else if ( type == QLatin1String( "s" ) )
-  {
-    kind = Relkind::Sequence;
-  }
-  else if ( type == QLatin1String( "v" ) )
-  {
-    kind = Relkind::View;
-  }
-  else if ( type == QLatin1String( "m" ) )
-  {
-    kind = Relkind::MaterializedView;
-  }
-  else if ( type == QLatin1String( "c" ) )
-  {
-    kind = Relkind::CompositeType;
-  }
-  else if ( type == QLatin1String( "t" ) )
-  {
-    kind = Relkind::ToastTable;
-  }
-  else if ( type == QLatin1String( "f" ) )
-  {
-    kind = Relkind::ForeignTable;
-  }
-  else if ( type == QLatin1String( "p" ) )
-  {
-    kind = Relkind::PartitionedTable;
+    if ( type == QLatin1String( "r" ) )
+    {
+      mKind = Relkind::OrdinaryTable;
+    }
+    else if ( type == QLatin1String( "i" ) )
+    {
+      mKind = Relkind::Index;
+    }
+    else if ( type == QLatin1String( "s" ) )
+    {
+      mKind = Relkind::Sequence;
+    }
+    else if ( type == QLatin1String( "v" ) )
+    {
+      mKind = Relkind::View;
+    }
+    else if ( type == QLatin1String( "m" ) )
+    {
+      mKind = Relkind::MaterializedView;
+    }
+    else if ( type == QLatin1String( "c" ) )
+    {
+      mKind = Relkind::CompositeType;
+    }
+    else if ( type == QLatin1String( "t" ) )
+    {
+      mKind = Relkind::ToastTable;
+    }
+    else if ( type == QLatin1String( "f" ) )
+    {
+      mKind = Relkind::ForeignTable;
+    }
+    else if ( type == QLatin1String( "p" ) )
+    {
+      mKind = Relkind::PartitionedTable;
+    }
   }
 
-  return kind;
+  return mKind;
 }
 
 bool QgsPostgresProvider::hasMetadata() const

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -56,6 +56,7 @@ class QgsPostgresProvider final: public QgsVectorDataProvider
 
     enum Relkind
     {
+      NotSet,
       Unknown,
       OrdinaryTable, // r
       Index, // i
@@ -244,7 +245,16 @@ class QgsPostgresProvider final: public QgsVectorDataProvider
     void setListening( bool isListening ) override;
 
   private:
+
+    /**
+     * \returns relation kind
+     */
     Relkind relkind() const;
+
+    /**
+     * Change internal query with \a query
+     */
+    void setQuery( const QString &query );
 
     bool declareCursor( const QString &cursorName,
                         const QgsAttributeList &fetchAttributes,
@@ -376,6 +386,11 @@ class QgsPostgresProvider final: public QgsVectorDataProvider
      * SQL statement used to limit the features retrieved
      */
     QString mSqlWhereClause;
+
+    /**
+     * Kind of relation
+     */
+    mutable Relkind mKind = Relkind::NotSet;
 
     /**
      * Data type for the primary key

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2296,6 +2296,17 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         for f in vl0.getFeatures():
             self.assertNotEqual(f.attribute(0), NULL)
 
+    def testFeatureCountEstimatedOnTable(self):
+        """
+        Test feature count on table when estimated data is enabled
+        """
+        vl = QgsVectorLayer(
+            self.dbconn +
+            ' sslmode=disable key=\'pk\' estimatedmetadata=true srid=4326 type=POINT table="qgis_test"."someData" (geom) sql=',
+            'test', 'postgres')
+        self.assertTrue(vl.isValid())
+        self.assertTrue(vl.featureCount() > 0)
+
     def testFeatureCountEstimatedOnView(self):
         """
         Test feature count on view when estimated data is enabled
@@ -2308,7 +2319,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
             ' sslmode=disable key=\'pk\' estimatedmetadata=true srid=4326 type=POINT table="qgis_test"."somedataview" (geom) sql=',
             'test', 'postgres')
         self.assertTrue(vl.isValid())
-        self.assertTrue(self.source.featureCount() > 0)
+        self.assertTrue(vl.featureCount() > 0)
 
     def testIdentityPk(self):
         """Test a table with identity pk, see GH #29560"""


### PR DESCRIPTION
## Description

Fixes #40162

Restore old code for estimating rows on table using *reltuples* from *pg_class* because it appears more close to the true than the *plan rows* estimation used for views (reltuples is always 0 in views). Especially when we delete massively rows like pointed in the issue. 

This PR also lazily request and store the relation kind attribute to avoid requesting it every time we need it. 
