### PR TITLE
[API] Add bisector method

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -700,6 +700,26 @@ A Z dimension is added to ``point`` if one of the point in the list
 .. versionadded:: 3.0
 %End
 
+    static bool bisector( double aX, double aY, double bX, double bY, double cX, double cY,
+                          double &pointX /Out/, double &pointY /Out/ ) /HoldGIL/;
+%Docstring
+Returns the point (``pointX``, ``pointY``) forming the bisector from point (``aX``, ``aY``) to the segment (``bX``, ``bY``) (``cX``, ``cY``).
+The bisector segment of ABC is (A-point)
+
+:param aX: x-coordinate of first vertex in triangle
+:param aY: y-coordinate of first vertex in triangle
+:param bX: x-coordinate of second vertex in triangle
+:param bY: y-coordinate of second vertex in triangle
+:param cX: x-coordinate of third vertex in triangle
+:param cY: y-coordinate of third vertex in triangle
+
+:return: - ``True`` if the bisector exists (A B and C are not collinear)
+         - pointX: x-coordinate of generated point
+         - pointY: y-coordinate of generated point
+
+.. versionadded:: 3.16
+%End
+
 
 };
 

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1717,3 +1717,21 @@ bool QgsGeometryUtils::setZValueFromPoints( const QgsPointSequence &points, QgsP
 
   return rc;
 }
+
+bool QgsGeometryUtils::bisector( double aX, double aY, double bX, double bY, double cX, double cY,
+                                 double &pointX SIP_OUT, double &pointY SIP_OUT )
+{
+  const QgsPoint pA = QgsPoint( aX, aY );
+  const QgsPoint pB = QgsPoint( bX, bY );
+  const QgsPoint pC = QgsPoint( cX, cY );
+  const double angle = ( pA.azimuth( pB ) + pA.azimuth( pC ) ) / 2.0;
+
+  QgsPoint pOut;
+  bool intersection = false;
+  QgsGeometryUtils::segmentIntersection( pB, pC, pA, pA.project( 1.0, angle ), pOut, intersection );
+
+  pointX = pOut.x();
+  pointY = pOut.y();
+
+  return intersection;
+}

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -727,6 +727,25 @@ class CORE_EXPORT QgsGeometryUtils
      */
     static bool setZValueFromPoints( const QgsPointSequence &points, QgsPoint &point );
 
+    /**
+     * Returns the point (\a pointX, \a pointY) forming the bisector from point (\a aX, \a aY) to the segment (\a bX, \a bY) (\a cX, \a cY).
+     * The bisector segment of ABC is (A-point)
+     *
+     * \param aX x-coordinate of first vertex in triangle
+     * \param aY y-coordinate of first vertex in triangle
+     * \param bX x-coordinate of second vertex in triangle
+     * \param bY y-coordinate of second vertex in triangle
+     * \param cX x-coordinate of third vertex in triangle
+     * \param cY y-coordinate of third vertex in triangle
+     * \param pointX x-coordinate of generated point
+     * \param pointY y-coordinate of generated point
+     * \returns TRUE if the bisector exists (A B and C are not collinear)
+     *
+     * \since QGIS 3.16
+     */
+    static bool bisector( double aX, double aY, double bX, double bY, double cX, double cY,
+                          double &pointX SIP_OUT, double &pointY SIP_OUT ) SIP_HOLDGIL;
+
     //! \note not available in Python bindings
     enum ComponentType SIP_SKIP
     {

--- a/tests/src/core/testqgsgeometryutils.cpp
+++ b/tests/src/core/testqgsgeometryutils.cpp
@@ -81,6 +81,7 @@ class TestQgsGeometryUtils: public QObject
     void testWeightedPointInTriangle_data();
     void testWeightedPointInTriangle();
     void testPointContinuesArc();
+    void testBisector();
 };
 
 
@@ -1497,5 +1498,19 @@ void TestQgsGeometryUtils::testPointContinuesArc()
   QVERIFY( !QgsGeometryUtils::pointContinuesArc( QgsPoint( 0, 0 ), QgsPoint( 1, 1 ), QgsPoint( 2, 0 ), QgsPoint( 1.01, -1 ), 0.000000001, 0.05 ) );
 }
 
+void TestQgsGeometryUtils::testBisector()
+{
+  double x, y;
+  QVERIFY( QgsGeometryUtils::bisector( 5, 5, 0, 0, -7, 11, x, y ) );
+  QGSCOMPARENEAR( x, -2.416, 10e-3 );
+  QGSCOMPARENEAR( y, 3.797, 10e-3 );
+
+  QVERIFY( QgsGeometryUtils::bisector( 2.5, 2, 0, 0, 5, 0, x, y ) );
+  QGSCOMPARENEAR( x, 2.5, 10e-3 );
+  QGSCOMPARENEAR( y, 0, 10e-3 );
+
+  // collinear
+  QVERIFY( !QgsGeometryUtils::bisector( 5, 5, 0, 0, 1, 1, x, y ) );
+}
 QGSTEST_MAIN( TestQgsGeometryUtils )
 #include "testqgsgeometryutils.moc"


### PR DESCRIPTION
## Description

This method is convenient to calculate the bisector from A to BC in an ABC triangle.

It will be used in other parts later (QgsCircle, QgsTriangle and CoGo functions todo).

Note: There is certainly a more relevant name for this method.