### PR TITLE
[georeferencer] Add basic keyboard interface for the CPL list widget

### DIFF
--- a/src/app/georeferencer/qgsgcplistwidget.cpp
+++ b/src/app/georeferencer/qgsgcplistwidget.cpp
@@ -111,7 +111,7 @@ void QgsGCPListWidget::itemDoubleClicked( QModelIndex index )
     emit jumpToGCP( id );
   }
 }
-#include <QDebug>
+
 void QgsGCPListWidget::itemClicked( QModelIndex index )
 {
   index = static_cast<const QSortFilterProxyModel *>( model() )->mapToSource( index );
@@ -148,9 +148,9 @@ void QgsGCPListWidget::keyPressEvent( QKeyEvent *e )
       if ( model()->rowCount() > 0 )
       {
         setCurrentIndex( model()->index( index.row() == model()->rowCount() ? index.row() - 1 : index.row(), index.column() ) );
+        return;
       }
     }
-    e->ignore();
   }
   else if ( e->key() == Qt::Key_Space )
   {
@@ -165,8 +165,8 @@ void QgsGCPListWidget::keyPressEvent( QKeyEvent *e )
       emit pointEnabled( p, sourceIndex.row() );
       adjustTableContent();
       setCurrentIndex( model()->index( index.row(), index.column() ) );
+      return;
     }
-    e->ignore();
   }
   else if ( e->key() == Qt::Key_Up )
   {
@@ -174,7 +174,7 @@ void QgsGCPListWidget::keyPressEvent( QKeyEvent *e )
     if ( index.isValid() && index.row() > 0 )
     {
       setCurrentIndex( model()->index( index.row() - 1, index.column() ) );
-      e->ignore();
+      return;
     }
   }
   else if ( e->key() == Qt::Key_Down )
@@ -183,7 +183,7 @@ void QgsGCPListWidget::keyPressEvent( QKeyEvent *e )
     if ( index.isValid() && index.row() < ( model()->rowCount() - 1 ) )
     {
       setCurrentIndex( model()->index( index.row() + 1, index.column() ) );
-      e->ignore();
+      return;
     }
   }
   else if ( e->key() == Qt::Key_Left )
@@ -192,7 +192,7 @@ void QgsGCPListWidget::keyPressEvent( QKeyEvent *e )
     if ( index.isValid() && index.column() > 0 )
     {
       setCurrentIndex( model()->index( index.row(), index.column() - 1 ) );
-      e->ignore();
+      return;
     }
   }
   else if ( e->key() == Qt::Key_Right )
@@ -201,9 +201,10 @@ void QgsGCPListWidget::keyPressEvent( QKeyEvent *e )
     if ( index.isValid() && index.column() < ( model()->columnCount() - 1 ) )
     {
       setCurrentIndex( model()->index( index.row(), index.column() + 1 ) );
-      e->ignore();
+      return;
     }
   }
+  e->ignore();
 }
 
 void QgsGCPListWidget::updateItemCoords( QWidget *editor )

--- a/src/app/georeferencer/qgsgcplistwidget.cpp
+++ b/src/app/georeferencer/qgsgcplistwidget.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <QKeyEvent>
 #include <QHeaderView>
 #include <QDoubleSpinBox>
 #include <QLineEdit>
@@ -41,7 +42,7 @@ QgsGCPListWidget::QgsGCPListWidget( QWidget *parent )
   setSortingEnabled( true );
 
   setContextMenuPolicy( Qt::CustomContextMenu );
-  setFocusPolicy( Qt::NoFocus );
+  setFocusPolicy( Qt::ClickFocus );
 
   verticalHeader()->hide();
   setAlternatingRowColors( true );
@@ -110,7 +111,7 @@ void QgsGCPListWidget::itemDoubleClicked( QModelIndex index )
     emit jumpToGCP( id );
   }
 }
-
+#include <QDebug>
 void QgsGCPListWidget::itemClicked( QModelIndex index )
 {
   index = static_cast<const QSortFilterProxyModel *>( model() )->mapToSource( index );
@@ -134,6 +135,75 @@ void QgsGCPListWidget::itemClicked( QModelIndex index )
 
   mPrevRow = index.row();
   mPrevColumn = index.column();
+}
+
+void QgsGCPListWidget::keyPressEvent( QKeyEvent *e )
+{
+  if ( e->key() == Qt::Key_Delete )
+  {
+    QModelIndex index = currentIndex();
+    if ( index.isValid() )
+    {
+      removeRow();
+      if ( model()->rowCount() > 0 )
+      {
+        setCurrentIndex( model()->index( index.row() == model()->rowCount() ? index.row() - 1 : index.row(), index.column() ) );
+      }
+    }
+    e->ignore();
+  }
+  else if ( e->key() == Qt::Key_Space )
+  {
+    QModelIndex index = currentIndex();
+    if ( index.isValid() )
+    {
+      QModelIndex sourceIndex = static_cast<const QSortFilterProxyModel *>( model() )->mapToSource( index );
+      QgsGeorefDataPoint *p = mGCPList->at( sourceIndex.row() );
+      p->setEnabled( !p->isEnabled() );
+
+      mGCPListModel->updateModel();
+      emit pointEnabled( p, sourceIndex.row() );
+      adjustTableContent();
+      setCurrentIndex( model()->index( index.row(), index.column() ) );
+    }
+    e->ignore();
+  }
+  else if ( e->key() == Qt::Key_Up )
+  {
+    QModelIndex index = currentIndex();
+    if ( index.isValid() && index.row() > 0 )
+    {
+      setCurrentIndex( model()->index( index.row() - 1, index.column() ) );
+      e->ignore();
+    }
+  }
+  else if ( e->key() == Qt::Key_Down )
+  {
+    QModelIndex index = currentIndex();
+    if ( index.isValid() && index.row() < ( model()->rowCount() - 1 ) )
+    {
+      setCurrentIndex( model()->index( index.row() + 1, index.column() ) );
+      e->ignore();
+    }
+  }
+  else if ( e->key() == Qt::Key_Left )
+  {
+    QModelIndex index = currentIndex();
+    if ( index.isValid() && index.column() > 0 )
+    {
+      setCurrentIndex( model()->index( index.row(), index.column() - 1 ) );
+      e->ignore();
+    }
+  }
+  else if ( e->key() == Qt::Key_Right )
+  {
+    QModelIndex index = currentIndex();
+    if ( index.isValid() && index.column() < ( model()->columnCount() - 1 ) )
+    {
+      setCurrentIndex( model()->index( index.row(), index.column() + 1 ) );
+      e->ignore();
+    }
+  }
 }
 
 void QgsGCPListWidget::updateItemCoords( QWidget *editor )

--- a/src/app/georeferencer/qgsgcplistwidget.h
+++ b/src/app/georeferencer/qgsgcplistwidget.h
@@ -40,6 +40,8 @@ class QgsGCPListWidget : public QTableView
     void updateGCPList();
     void closeEditors();
 
+    void keyPressEvent( QKeyEvent *e ) override;
+
   public slots:
     // This slot is called by the list view if an item is double-clicked
     void itemDoubleClicked( QModelIndex index );


### PR DESCRIPTION
## Description

Add basic keyboard interface for the CPL list widget:
- Pressing the del key will delete the selected point
- Pressing the space key will toggle the enabled state of the selected point
- Pressing the up/down/left/right keys will move selection around

I had to use the georeferencer quite a lot this week, and trying to kill as many pains as possible.