### PR TITLE
[vertextool] Fix crash when switching layers with a locked feature present

### DIFF
--- a/src/app/vertextool/qgslockedfeature.cpp
+++ b/src/app/vertextool/qgslockedfeature.cpp
@@ -39,9 +39,6 @@ QgsLockedFeature::QgsLockedFeature( QgsFeatureId featureId,
   , mLayer( layer )
   , mCanvas( canvas )
 {
-  // signal changing of current layer
-  connect( QgisApp::instance()->layerTreeView(), &QgsLayerTreeView::currentLayerChanged, this, &QgsLockedFeature::currentLayerChanged );
-
   replaceVertexMap();
 }
 
@@ -63,12 +60,6 @@ QgsLockedFeature::~QgsLockedFeature()
   }
 
   delete mGeometry;
-}
-
-void QgsLockedFeature::currentLayerChanged( QgsMapLayer *layer )
-{
-  if ( layer == mLayer )
-    deleteLater();
 }
 
 void QgsLockedFeature::updateGeometry( const QgsGeometry *geom )
@@ -110,11 +101,6 @@ void QgsLockedFeature::endGeometryChange()
   mChangingGeometry = false;
 
   connect( mLayer, &QgsVectorLayer::geometryChanged, this, &QgsLockedFeature::geometryChanged );
-}
-
-void QgsLockedFeature::canvasLayersChanged()
-{
-  currentLayerChanged( mCanvas->currentLayer() );
 }
 
 void QgsLockedFeature::featureDeleted( QgsFeatureId fid )

--- a/src/app/vertextool/qgslockedfeature.h
+++ b/src/app/vertextool/qgslockedfeature.h
@@ -140,16 +140,6 @@ class QgsLockedFeature: public QObject
     void geometryChanged( QgsFeatureId, const QgsGeometry & );
 
     /*
-     * the current layer changed - destroy
-     */
-    void currentLayerChanged( QgsMapLayer *layer );
-
-    /*
-     * the current layer changed - destroy
-     */
-    void canvasLayersChanged();
-
-    /*
      * the changes are rolling back - stop monitoring the geometry
      */
     void beforeRollBack();

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -328,6 +328,8 @@ void QgsVertexTool::activate()
   {
     showVertexEditor();  //#spellok
   }
+  connect( mCanvas, &QgsMapCanvas::currentLayerChanged, this, &QgsVertexTool::currentLayerChanged );
+
   QgsMapToolAdvancedDigitizing::activate();
 }
 
@@ -344,7 +346,20 @@ void QgsVertexTool::deactivate()
     it->cleanup();
   mValidations.clear();
 
+  disconnect( mCanvas, &QgsMapCanvas::currentLayerChanged, this, &QgsVertexTool::currentLayerChanged );
+
   QgsMapToolAdvancedDigitizing::deactivate();
+}
+
+void QgsVertexTool::currentLayerChanged( QgsMapLayer *layer )
+{
+  if ( mMode == QgsVertexTool::ActiveLayer )
+  {
+    if ( mLockedFeature && mLockedFeature->layer() != layer )
+    {
+      cleanupLockedFeature();
+    }
+  }
 }
 
 void QgsVertexTool::addDragBand( const QgsPointXY &v1, const QgsPointXY &v2 )

--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -124,6 +124,8 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
 
     void lockedFeatureSelectionChanged();
 
+    void currentLayerChanged( QgsMapLayer *layer );
+
   private:
 
     void buildDragBandsForVertices( const QSet<Vertex> &movingVertices, const QgsPointXY &dragVertexMapPoint );


### PR DESCRIPTION
## Description

This fixes a vertex tool crasher reported in issue #40320 -- I'm pretty sure I suffered from this one several times but never remembered the steps that led to the crash. 