### PR TITLE
Server: skip initial style storage

### DIFF
--- a/python/core/auto_additions/qgsproject.py
+++ b/python/core/auto_additions/qgsproject.py
@@ -6,7 +6,9 @@ QgsProject.FlagDontLoadLayouts = QgsProject.ReadFlag.FlagDontLoadLayouts
 QgsProject.ReadFlag.FlagDontLoadLayouts.__doc__ = "Don't load print layouts. Improves project read time if layouts are not required, and allows projects to be safely read in background threads (since print layouts are not thread safe)."
 QgsProject.FlagTrustLayerMetadata = QgsProject.ReadFlag.FlagTrustLayerMetadata
 QgsProject.ReadFlag.FlagTrustLayerMetadata.__doc__ = "Trust layer metadata. Improves project read time. Do not use it if layers' extent is not fixed during the project's use by QGIS and QGIS Server."
-QgsProject.ReadFlag.__doc__ = 'Flags which control project read behavior.\n\n.. versionadded:: 3.10\n\n' + '* ``FlagDontResolveLayers``: ' + QgsProject.ReadFlag.FlagDontResolveLayers.__doc__ + '\n' + '* ``FlagDontLoadLayouts``: ' + QgsProject.ReadFlag.FlagDontLoadLayouts.__doc__ + '\n' + '* ``FlagTrustLayerMetadata``: ' + QgsProject.ReadFlag.FlagTrustLayerMetadata.__doc__
+QgsProject.FlagDontStoreOriginalStyles = QgsProject.ReadFlag.FlagDontStoreOriginalStyles
+QgsProject.ReadFlag.FlagDontStoreOriginalStyles.__doc__ = "Skip the initial XML style storage for layers. Mainly useful in server's context where there is no chance that the user will save the project again."
+QgsProject.ReadFlag.__doc__ = 'Flags which control project read behavior.\n\n.. versionadded:: 3.10\n\n' + '* ``FlagDontResolveLayers``: ' + QgsProject.ReadFlag.FlagDontResolveLayers.__doc__ + '\n' + '* ``FlagDontLoadLayouts``: ' + QgsProject.ReadFlag.FlagDontLoadLayouts.__doc__ + '\n' + '* ``FlagTrustLayerMetadata``: ' + QgsProject.ReadFlag.FlagTrustLayerMetadata.__doc__ + '\n' + '* ``FlagDontStoreOriginalStyles``: ' + QgsProject.ReadFlag.FlagDontStoreOriginalStyles.__doc__
 # --
 # monkey patching scoped based enum
 QgsProject.FileFormat.Qgz.__doc__ = "Archive file format, supports auxiliary data"

--- a/python/core/auto_additions/qgsproject.py
+++ b/python/core/auto_additions/qgsproject.py
@@ -7,7 +7,7 @@ QgsProject.ReadFlag.FlagDontLoadLayouts.__doc__ = "Don't load print layouts. Imp
 QgsProject.FlagTrustLayerMetadata = QgsProject.ReadFlag.FlagTrustLayerMetadata
 QgsProject.ReadFlag.FlagTrustLayerMetadata.__doc__ = "Trust layer metadata. Improves project read time. Do not use it if layers' extent is not fixed during the project's use by QGIS and QGIS Server."
 QgsProject.FlagDontStoreOriginalStyles = QgsProject.ReadFlag.FlagDontStoreOriginalStyles
-QgsProject.ReadFlag.FlagDontStoreOriginalStyles.__doc__ = "Skip the initial XML style storage for layers. Mainly useful in server's context where there is no chance that the user will save the project again."
+QgsProject.ReadFlag.FlagDontStoreOriginalStyles.__doc__ = "Skip the initial XML style storage for layers. Useful for minimising project load times in non-interactive contexts."
 QgsProject.ReadFlag.__doc__ = 'Flags which control project read behavior.\n\n.. versionadded:: 3.10\n\n' + '* ``FlagDontResolveLayers``: ' + QgsProject.ReadFlag.FlagDontResolveLayers.__doc__ + '\n' + '* ``FlagDontLoadLayouts``: ' + QgsProject.ReadFlag.FlagDontLoadLayouts.__doc__ + '\n' + '* ``FlagTrustLayerMetadata``: ' + QgsProject.ReadFlag.FlagTrustLayerMetadata.__doc__ + '\n' + '* ``FlagDontStoreOriginalStyles``: ' + QgsProject.ReadFlag.FlagDontStoreOriginalStyles.__doc__
 # --
 # monkey patching scoped based enum

--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -40,6 +40,7 @@ open within the main QGIS application.
       FlagDontResolveLayers,
       FlagDontLoadLayouts,
       FlagTrustLayerMetadata,
+      FlagDontStoreOriginalStyles,
     };
     typedef QFlags<QgsProject::ReadFlag> ReadFlags;
 

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -690,7 +690,7 @@ void QgsProjectItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
 
       QgsProject p;
       QgsTemporaryCursorOverride override( Qt::WaitCursor );
-      if ( p.read( projectPath, QgsProject::ReadFlag::FlagDontResolveLayers ) )
+      if ( p.read( projectPath, QgsProject::ReadFlag::FlagDontResolveLayers | QgsProject::ReadFlag::FlagDontStoreOriginalStyles ) )
       {
         p.accept( &visitor );
         override.release();

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -473,7 +473,7 @@ QVector<QgsDataItem *> QgsProjectRootDataItem::createChildren()
   QVector<QgsDataItem *> childItems;
 
   QgsProject p;
-  if ( !p.read( mPath, QgsProject::ReadFlag::FlagDontResolveLayers | QgsProject::ReadFlag::FlagDontLoadLayouts ) )
+  if ( !p.read( mPath, QgsProject::ReadFlag::FlagDontResolveLayers | QgsProject::ReadFlag::FlagDontLoadLayouts | QgsProject::ReadFlag::FlagDontStoreOriginalStyles ) )
   {
     childItems.append( new QgsErrorItem( nullptr, p.error(), mPath + "/error" ) );
     return childItems;

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1627,7 +1627,10 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
   // After bad layer handling we might still have invalid layers,
   // store them in case the user wanted to handle them later
   // or wanted to pass them through when saving
-  QgsLayerTreeUtils::storeOriginalLayersProperties( mRootGroup, doc.get() );
+  if ( !( flags & QgsProject::ReadFlag::FlagDontStoreOriginalStyles ) )
+  {
+    QgsLayerTreeUtils::storeOriginalLayersProperties( mRootGroup, doc.get() );
+  }
 
   mRootGroup->removeCustomProperty( QStringLiteral( "loading" ) );
 

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -121,7 +121,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
       FlagDontResolveLayers = 1 << 0, //!< Don't resolve layer paths (i.e. don't load any layer content). Dramatically improves project read time if the actual data from the layers is not required.
       FlagDontLoadLayouts = 1 << 1, //!< Don't load print layouts. Improves project read time if layouts are not required, and allows projects to be safely read in background threads (since print layouts are not thread safe).
       FlagTrustLayerMetadata = 1 << 2, //!< Trust layer metadata. Improves project read time. Do not use it if layers' extent is not fixed during the project's use by QGIS and QGIS Server.
-      FlagDontStoreOriginalStyles = 1 << 3, //!< Skip the initial XML style storage for layers. Mainly useful in server's context where there is no chance that the user will save the project again.
+      FlagDontStoreOriginalStyles = 1 << 3, //!< Skip the initial XML style storage for layers. Useful for minimising project load times in non-interactive contexts.
     };
     Q_DECLARE_FLAGS( ReadFlags, ReadFlag )
 

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -121,6 +121,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
       FlagDontResolveLayers = 1 << 0, //!< Don't resolve layer paths (i.e. don't load any layer content). Dramatically improves project read time if the actual data from the layers is not required.
       FlagDontLoadLayouts = 1 << 1, //!< Don't load print layouts. Improves project read time if layouts are not required, and allows projects to be safely read in background threads (since print layouts are not thread safe).
       FlagTrustLayerMetadata = 1 << 2, //!< Trust layer metadata. Improves project read time. Do not use it if layers' extent is not fixed during the project's use by QGIS and QGIS Server.
+      FlagDontStoreOriginalStyles = 1 << 3, //!< Skip the initial XML style storage for layers. Mainly useful in server's context where there is no chance that the user will save the project again.
     };
     Q_DECLARE_FLAGS( ReadFlags, ReadFlag )
 

--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -52,7 +52,8 @@ const QgsProject *QgsConfigCache::project( const QString &path, const QgsServerS
     QgsStoreBadLayerInfo *badLayerHandler = new QgsStoreBadLayerInfo();
     prj->setBadLayerHandler( badLayerHandler );
 
-    QgsProject::ReadFlags readFlags = QgsProject::ReadFlag();
+    // Always skip original styles storage
+    QgsProject::ReadFlags readFlags = QgsProject::ReadFlag() | QgsProject::ReadFlag::FlagDontStoreOriginalStyles ;
     if ( settings )
     {
       // Activate trust layer metadata flag

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -451,6 +451,12 @@ void TestQgsProject::testReadFlags()
   QCOMPARE( qobject_cast< QgsVectorLayer * >( layers.value( QStringLiteral( "points20170310142652246" ) ) )->renderer()->type(), QStringLiteral( "categorizedSymbol" ) );
   QCOMPARE( qobject_cast< QgsVectorLayer * >( layers.value( QStringLiteral( "lines20170310142652255" ) ) )->renderer()->type(), QStringLiteral( "categorizedSymbol" ) );
   QCOMPARE( qobject_cast< QgsVectorLayer * >( layers.value( QStringLiteral( "polys20170310142652234" ) ) )->renderer()->type(), QStringLiteral( "categorizedSymbol" ) );
+  QVERIFY( ! layers.value( QStringLiteral( "polys20170310142652234" ) )->originalXmlProperties().isEmpty() );
+
+  // do not store styles
+  QVERIFY( p.read( project1Path, QgsProject::ReadFlag::FlagDontStoreOriginalStyles ) );
+  layers = p.mapLayers();
+  QVERIFY( layers.value( QStringLiteral( "polys20170310142652234" ) )->originalXmlProperties().isEmpty() );
 
   // project with embedded groups
   QString project2Path = QString( TEST_DATA_DIR ) + QStringLiteral( "/embedded_groups/project2.qgs" );


### PR DESCRIPTION
Background: at project load time for all layers a copy of the style
is loaded and stored as a DOM document. This was implemented for
broken layers to make it possible to store the style back to the
project if a broken layer was kept in the project.

Of course this is not needed nor useful in a server context.

By introducing a new project load flag and using it in the server
config (projects) cache we allow to skip the initial storage of
styles for the server and cut the startup times of our test "monster"
project (~1000 PG layers) from 26 seconds to 15.

Before you ask: I chose to always store the original style
with the idea that we might have been able to use the original
style copy also to "restore" styles to their initial state.
This was never implemented, so I guess we might be good to
make the initial style copy selectively available for broken
layers only in order to speed up project loading in the general
case (desktop).
