### PR TITLE
Don't install owslib through pip, it tries to install pyproj and a custom proj build (3.10 backport)

### DIFF
--- a/.docker/qgis3-build-deps-focal.dockerfile
+++ b/.docker/qgis3-build-deps-focal.dockerfile
@@ -72,6 +72,7 @@ RUN  apt-get update \
     python3-gdal \
     python3-mock \
     python3-nose2 \
+    python3-owslib \
     python3-pip \
     python3-psycopg2 \
     python3-pyqt5 \
@@ -112,7 +113,6 @@ RUN  apt-get update \
     mock \
     future \
     termcolor \
-    owslib \
     oauthlib \
     pyopenssl \
   && apt-get clean

--- a/.docker/qgis3-build-deps.dockerfile
+++ b/.docker/qgis3-build-deps.dockerfile
@@ -72,6 +72,7 @@ RUN  apt-get update \
     python3-gdal \
     python3-mock \
     python3-nose2 \
+    python3-owslib \
     python3-pip \
     python3-psycopg2 \
     python3-pyproj \
@@ -120,7 +121,6 @@ RUN  apt-get update \
     mock \
     future \
     termcolor \
-    owslib \
     oauthlib \
     pyopenssl \
     pep8 \


### PR DESCRIPTION
Resurrects travis builds for 3.10 branch