### PR TITLE
[PyQGIS] Display Exception message when raised in python plugin ogcapi handler

### DIFF
--- a/python/server/server.sip.in
+++ b/python/server/server.sip.in
@@ -16,28 +16,38 @@ ${DEFAULTDOCSTRINGSIGNATURE}
 
 
 %VirtualErrorHandler serverapi_badrequest_exception_handler
-    PyObject *exception, *value, *traceback;
-    PyErr_Fetch(&exception, &value, &traceback);
+    PyObject *type, *exception, *traceback, *pyStrException;
+
+    PyErr_Fetch(&type, &exception, &traceback);
+    pyStrException = PyObject_Str(exception);
+    Py_DECREF(pyStrException);
+
     SIP_RELEASE_GIL( sipGILState );
-    QString strVal = "API bad request error";
-    if ( value && PyUnicode_Check(value) )
+
+    QString strException = "API bad request error";
+    if ( pyStrException && PyUnicode_Check(pyStrException) )
     {
-      Py_ssize_t size;
-      strVal = QString::fromUtf8( PyUnicode_AsUTF8AndSize(value, &size) );
+       strException = QString::fromUtf8( PyUnicode_AsUTF8(pyStrException) );
     }
-    throw QgsServerApiBadRequestException( strVal );
+
+    throw QgsServerApiBadRequestException( strException );
 %End
 
 
 %VirtualErrorHandler server_exception_handler
-    PyObject *exception, *value, *traceback;
-    PyErr_Fetch(&exception, &value, &traceback);
+    PyObject *type, *exception, *traceback, *pyStrException;
+
+    PyErr_Fetch(&type, &exception, &traceback);
+    pyStrException = PyObject_Str(exception);
+    Py_DECREF(pyStrException);
+
     SIP_RELEASE_GIL( sipGILState );
-    QString strVal = "Server internal error";
-    if ( value && PyUnicode_Check(value) )
+
+    QString strException = "Server internal error";
+    if ( pyStrException && PyUnicode_Check(pyStrException) )
     {
-      Py_ssize_t size;
-      strVal = QString::fromUtf8( PyUnicode_AsUTF8AndSize(value, &size) );
+       strException = QString::fromUtf8( PyUnicode_AsUTF8(pyStrException) );
     }
-    throw QgsServerException( strVal );
+
+    throw QgsServerException( strException );
 %End


### PR DESCRIPTION
## Description

When implementing a `QgsServerOgcApiHandler` and raising an exception. The exception message is not kept and a generic message is displayed `API bad request error`.

This PR fixes this.

I discover later than there is a [method](https://github.com/qgis/QGIS/blob/master/src/python/qgspythonutilsimpl.cpp#L450) to retrieve the error message, but I failed to see how to access QgsPythonUtils interface.
