### PR TITLE
fix displaying enabled/disable mesh dataset group

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshdataset.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataset.sip.in
@@ -883,9 +883,18 @@ Returns the count of children
 
     int totalChildCount() const;
 %Docstring
-Returns the total count of children, that is included deeper children
+Returns the total count of children, that is included deeper children and disabled items
 
-:return:
+:return: the total children's count
+%End
+
+    QList<int> enabledDatasetGroupIndexes() const;
+%Docstring
+Returns a list of enabled dataset group indexes, included deeper children
+
+:return: the list of dataset group indexes
+
+.. versionadded:: 3.16.3
 %End
 
     QgsMeshDatasetGroupTreeItem *parentItem() const;

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -273,6 +273,18 @@ Returns the list of indexes of dataset groups handled by the layer
 .. versionadded:: 3.16
 %End
 
+    QList<int> enabledDatasetGroupsIndexes() const;
+%Docstring
+Returns the list of indexes of enables dataset groups handled by the layer
+
+.. note::
+
+   indexes are used to distinguish all the dataset groups handled by the layer (from dataprovider, extra dataset group,...)
+   In the layer scope, those indexes can be different from the data provider indexes.
+
+.. versionadded:: 3.16.3
+%End
+
     QgsMeshDatasetGroupMetadata datasetGroupMetadata( const QgsMeshDatasetIndex &index ) const;
 %Docstring
 Returns the dataset groups metadata

--- a/src/core/mesh/qgsmeshdataset.cpp
+++ b/src/core/mesh/qgsmeshdataset.cpp
@@ -590,6 +590,20 @@ int QgsMeshDatasetGroupTreeItem::totalChildCount() const
   return count;
 }
 
+QList<int> QgsMeshDatasetGroupTreeItem::enabledDatasetGroupIndexes() const
+{
+  QList<int> indexesList;
+
+  for ( int i = 0; i < mChildren.count(); ++i )
+  {
+    if ( mChildren.at( i )->isEnabled() )
+      indexesList.append( mChildren.at( i )->datasetGroupIndex() );
+    indexesList.append( mChildren.at( i )->enabledDatasetGroupIndexes() );
+  }
+
+  return indexesList;
+}
+
 QgsMeshDatasetGroupTreeItem *QgsMeshDatasetGroupTreeItem::parentItem() const
 {
   return mParent;

--- a/src/core/mesh/qgsmeshdataset.h
+++ b/src/core/mesh/qgsmeshdataset.h
@@ -866,10 +866,18 @@ class CORE_EXPORT QgsMeshDatasetGroupTreeItem
     int childCount() const;
 
     /**
-     * Returns the total count of children, that is included deeper children
-     * \return
-     */
+    * Returns the total count of children, that is included deeper children and disabled items
+    * \return the total children's count
+    */
     int totalChildCount() const;
+
+    /**
+     * Returns a list of enabled dataset group indexes, included deeper children
+     * \return the list of dataset group indexes
+     *
+     * \since QGIS 3.16.3
+     */
+    QList<int> enabledDatasetGroupIndexes() const;
 
     /**
      * Returns the parent item, nullptr if it is root item

--- a/src/core/mesh/qgsmeshdatasetgroupstore.cpp
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.cpp
@@ -27,6 +27,11 @@ QList<int> QgsMeshDatasetGroupStore::datasetGroupIndexes() const
   return mRegistery.keys();
 }
 
+QList<int> QgsMeshDatasetGroupStore::enabledDatasetGroupIndexes() const
+{
+  return mDatasetGroupTreeRootItem->enabledDatasetGroupIndexes();
+}
+
 int QgsMeshDatasetGroupStore::datasetGroupCount() const
 {
   return mRegistery.count();

--- a/src/core/mesh/qgsmeshdatasetgroupstore.h
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.h
@@ -156,6 +156,13 @@ class QgsMeshDatasetGroupStore: public QObject
     //! Returns a list of all group indexes
     QList<int> datasetGroupIndexes() const;
 
+    /**
+     * Returns a list of all group indexes that are enabled
+     *
+     * \since QGIS 3.16.3
+    */
+    QList<int> enabledDatasetGroupIndexes() const;
+
     //! Returns the count of dataset groups
     int datasetGroupCount() const;
 

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -359,6 +359,11 @@ QList<int> QgsMeshLayer::datasetGroupsIndexes() const
   return mDatasetGroupStore->datasetGroupIndexes();
 }
 
+QList<int> QgsMeshLayer::enabledDatasetGroupsIndexes() const
+{
+  return mDatasetGroupStore->enabledDatasetGroupIndexes();
+}
+
 QgsMeshDatasetGroupMetadata QgsMeshLayer::datasetGroupMetadata( const QgsMeshDatasetIndex &index ) const
 {
   return mDatasetGroupStore->datasetGroupMetadata( index );

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -345,6 +345,16 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     QList<int> datasetGroupsIndexes() const;
 
     /**
+     * Returns the list of indexes of enables dataset groups handled by the layer
+     *
+     * \note indexes are used to distinguish all the dataset groups handled by the layer (from dataprovider, extra dataset group,...)
+     * In the layer scope, those indexes can be different from the data provider indexes.
+     *
+     * \since QGIS 3.16.3
+     */
+    QList<int> enabledDatasetGroupsIndexes() const;
+
+    /**
      * Returns the dataset groups metadata
      *
      * \note indexes are used to distinguish all the dataset groups handled by the layer (from dataprovider, extra dataset group,...)

--- a/src/gui/mesh/qgsmeshdatasetgrouptreeview.cpp
+++ b/src/gui/mesh/qgsmeshdatasetgrouptreeview.cpp
@@ -509,10 +509,7 @@ int QgsMeshDatasetGroupListModel::rowCount( const QModelIndex &parent ) const
 {
   Q_UNUSED( parent );
   if ( mRootItem )
-  {
-    QList<int> list = mRootItem->enabledDatasetGroupIndexes();
     return mRootItem->enabledDatasetGroupIndexes().count();
-  }
   else
     return 0;
 }

--- a/src/gui/mesh/qgsmeshdatasetgrouptreeview.cpp
+++ b/src/gui/mesh/qgsmeshdatasetgrouptreeview.cpp
@@ -494,17 +494,25 @@ void QgsMeshActiveDatasetGroupTreeView::setActiveGroup()
   setActiveVectorGroup( vectorGroup );
 }
 
+QgsMeshDatasetGroupListModel::QgsMeshDatasetGroupListModel( QObject *parent ): QAbstractListModel( parent )
+{}
+
 void QgsMeshDatasetGroupListModel::syncToLayer( QgsMeshLayer *layer )
 {
+  beginResetModel();
   if ( layer )
     mRootItem = layer->datasetGroupTreeRootItem();
+  endResetModel();
 }
 
 int QgsMeshDatasetGroupListModel::rowCount( const QModelIndex &parent ) const
 {
   Q_UNUSED( parent );
   if ( mRootItem )
-    return mRootItem->totalChildCount();
+  {
+    QList<int> list = mRootItem->enabledDatasetGroupIndexes();
+    return mRootItem->enabledDatasetGroupIndexes().count();
+  }
   else
     return 0;
 }
@@ -517,7 +525,12 @@ QVariant QgsMeshDatasetGroupListModel::data( const QModelIndex &index, int role 
   if ( index.row() >= rowCount( QModelIndex() ) )
     return QVariant();
 
-  QgsMeshDatasetGroupTreeItem *item = mRootItem->childFromDatasetGroupIndex( index.row() );
+  QList<int> list = mRootItem->enabledDatasetGroupIndexes();
+  if ( index.row() >= list.count() )
+    return QVariant();
+
+  QgsMeshDatasetGroupTreeItem *item = mRootItem->childFromDatasetGroupIndex( list.at( index.row() ) );
+
   if ( !item )
     return QVariant();
 

--- a/src/gui/mesh/qgsmeshdatasetgrouptreeview.cpp
+++ b/src/gui/mesh/qgsmeshdatasetgrouptreeview.cpp
@@ -525,7 +525,7 @@ QVariant QgsMeshDatasetGroupListModel::data( const QModelIndex &index, int role 
   if ( index.row() >= rowCount( QModelIndex() ) )
     return QVariant();
 
-  QList<int> list = mRootItem->enabledDatasetGroupIndexes();
+  const QList<int> list = mRootItem->enabledDatasetGroupIndexes();
   if ( index.row() >= list.count() )
     return QVariant();
 

--- a/src/gui/mesh/qgsmeshdatasetgrouptreeview.h
+++ b/src/gui/mesh/qgsmeshdatasetgrouptreeview.h
@@ -274,8 +274,7 @@ class GUI_EXPORT QgsMeshActiveDatasetGroupTreeView : public QTreeView
 class GUI_EXPORT QgsMeshDatasetGroupListModel: public QAbstractListModel
 {
   public:
-    explicit QgsMeshDatasetGroupListModel( QObject *parent ): QAbstractListModel( parent )
-    {}
+    explicit QgsMeshDatasetGroupListModel( QObject *parent );
 
     //! Add groups to the model from mesh layer
     void syncToLayer( QgsMeshLayer *layer );

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -259,6 +259,7 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
   int activeScalarGroup = layer->rendererSettings().activeScalarDatasetGroup();
   int activeVectorGroup = layer->rendererSettings().activeVectorDatasetGroup();
 
+  const QList<int> allGroup = layer->enabledDatasetGroupsIndexes();
   if ( isTemporal ) //non active dataset group value are only accesible if temporal is active
   {
     const QgsDateTimeRange &time = identifyContext.temporalRange();
@@ -267,7 +268,6 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
     if ( activeVectorGroup >= 0 && activeVectorGroup != activeScalarGroup )
       datasetIndexList.append( layer->activeVectorDatasetAtTime( time ) );
 
-    const QList<int> allGroup = layer->datasetGroupsIndexes();
     for ( int groupIndex : allGroup )
     {
       if ( groupIndex != activeScalarGroup && groupIndex != activeVectorGroup )
@@ -276,10 +276,21 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
   }
   else
   {
+    // only active dataset group
     if ( activeScalarGroup >= 0 )
       datasetIndexList.append( layer->staticScalarDatasetIndex() );
     if ( activeVectorGroup >= 0 && activeVectorGroup != activeScalarGroup )
       datasetIndexList.append( layer->staticVectorDatasetIndex() );
+
+    // ...and static dataset group
+    for ( int groupIndex : allGroup )
+    {
+      if ( groupIndex != activeScalarGroup && groupIndex != activeVectorGroup )
+      {
+        if ( !layer->datasetGroupMetadata( groupIndex ).isTemporal() )
+          datasetIndexList.append( groupIndex );
+      }
+    }
   }
 
   //create results

--- a/tests/src/core/testqgsmeshlayer.cpp
+++ b/tests/src/core/testqgsmeshlayer.cpp
@@ -1301,9 +1301,18 @@ void TestQgsMeshLayer::test_dataset_group_item_tree_item()
     QCOMPARE( rootItem->childFromDatasetGroupIndex( i )->name(), names.at( i ) );
 
   // Disable some items
+  QList<int> enabledList = rootItem->enabledDatasetGroupIndexes();
+  QCOMPARE( enabledList.count(), 22 );
+  QList<int> newList = enabledList;
+  newList.removeOne( 7 );
   rootItem->childFromDatasetGroupIndex( 7 )->setIsEnabled( false );
+  QCOMPARE( newList, rootItem->enabledDatasetGroupIndexes() );
+  newList.removeOne( 10 );
   rootItem->childFromDatasetGroupIndex( 10 )->setIsEnabled( false );
+  QCOMPARE( newList, rootItem->enabledDatasetGroupIndexes() );
+  newList.removeOne( 15 );
   rootItem->childFromDatasetGroupIndex( 15 )->setIsEnabled( false );
+  QCOMPARE( newList, rootItem->enabledDatasetGroupIndexes() );
 
   QDomDocument doc;
   QgsReadWriteContext context;


### PR DESCRIPTION
In the mesh layer properties table, it is possible to disable dataset groups in the source tab. that allows to no displaying unwanted dataset group.
For now the dataset groups are only disabled in the dataset group tree view used to choose the dataset group to display in the canvas. Dataset groups are not disabled in other different parts of QGIS (mesh calculator, identify map tool, dataset group combo box).
This PR fixes this issue.

Other minor fixes :
- bad updating of dataset groups list from dataset group list model.
- static dataset group not displayed in the identify tool when temporal navigation is off.

fix #39396