### PR TITLE
Server profiler

### DIFF
--- a/python/server/auto_generated/qgsserversettings.sip.in
+++ b/python/server/auto_generated/qgsserversettings.sip.in
@@ -52,7 +52,8 @@ Provides some enum describing the environment currently supported for configurat
       QGIS_SERVER_TRUST_LAYER_METADATA,
       QGIS_SERVER_DISABLE_GETPRINT,
       QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES,
-      QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS
+      QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS,
+      QGIS_SERVER_LOG_PROFILE,
     };
 };
 
@@ -124,6 +125,19 @@ Returns the maximum number of cached layers.
 Returns the log level.
 
 :return: the log level.
+%End
+
+    bool logProfile();
+%Docstring
+Returns ``True`` if profile information has to be added to the logs, default value is ``False``.
+
+.. note::
+
+   this flag is only effective when :py:func:`~QgsServerSettings.logLevel` returns Qgis.Info (0)
+
+.. seealso:: :py:func:`logLevel`
+
+.. versionadded:: 3.18
 %End
 
     QString projectFile() const;

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -487,8 +487,8 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
     }
   }
 
-  // Clear the profiler after each request
-  QgsApplication::profiler()->clear( "server" );
+  // Clear the profiler server section after each request
+  QgsApplication::profiler()->clear( QStringLiteral( "server" ) );
 
 }
 

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -38,6 +38,7 @@
 #include "qgsserverapicontext.h"
 #include "qgsserverparameters.h"
 #include "qgsapplication.h"
+#include "qgsruntimeprofiler.h"
 
 #include <QDomDocument>
 #include <QNetworkDiskCache>
@@ -296,143 +297,54 @@ void QgsServer::putenv( const QString &var, const QString &val )
 
 void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &response, const QgsProject *project )
 {
-  Qgis::MessageLevel logLevel = QgsServerLogger::instance()->logLevel();
-  QElapsedTimer time; //used for measuring request time if loglevel < 1
-
-  qApp->processEvents();
-
-  if ( logLevel == Qgis::Info )
+  const Qgis::MessageLevel logLevel = QgsServerLogger::instance()->logLevel();
   {
-    time.start();
-  }
+    std::unique_ptr<QgsScopedRuntimeProfile> profile = qgis::make_unique<QgsScopedRuntimeProfile>( QStringLiteral( "handleRequest" ),   QStringLiteral( "server" ) );
 
-  response.clear();
+    qApp->processEvents();
 
-  // Pass the filters to the requestHandler, this is needed for the following reasons:
-  // Allow server request to call sendResponse plugin hook if enabled
-  QgsFilterResponseDecorator responseDecorator( sServerInterface->filters(), response );
+    response.clear();
 
-  //Request handler
-  QgsRequestHandler requestHandler( request, response );
+    // Pass the filters to the requestHandler, this is needed for the following reasons:
+    // Allow server request to call sendResponse plugin hook if enabled
+    QgsFilterResponseDecorator responseDecorator( sServerInterface->filters(), response );
 
-  try
-  {
-    // TODO: split parse input into plain parse and processing from specific services
-    requestHandler.parseInput();
-  }
-  catch ( QgsMapServiceException &e )
-  {
-    QgsMessageLog::logMessage( "Parse input exception: " + e.message(), QStringLiteral( "Server" ), Qgis::Critical );
-    requestHandler.setServiceException( e );
-  }
+    //Request handler
+    QgsRequestHandler requestHandler( request, response );
 
-  // Set the request handler into the interface for plugins to manipulate it
-  sServerInterface->setRequestHandler( &requestHandler );
-
-  // Initialize configfilepath so that is is available
-  // before calling plugin methods
-  // Note that plugins may still change that value using
-  // setConfigFilePath() interface method
-  if ( ! project )
-  {
-    QString configFilePath = configPath( *sConfigFilePath, request.serverParameters().map() );
-    sServerInterface->setConfigFilePath( configFilePath );
-  }
-  else
-  {
-    sServerInterface->setConfigFilePath( project->fileName() );
-  }
-
-  // Call  requestReady() method (if enabled)
-  // This may also throw exceptions if there are errors in python plugins code
-  try
-  {
-    responseDecorator.start();
-  }
-  catch ( QgsException &ex )
-  {
-    // Internal server error
-    response.sendError( 500, QStringLiteral( "Internal Server Error" ) );
-    QgsMessageLog::logMessage( ex.what(), QStringLiteral( "Server" ), Qgis::Critical );
-  }
-
-  // Plugins may have set exceptions
-  if ( !requestHandler.exceptionRaised() )
-  {
     try
     {
-      const QgsServerParameters params = request.serverParameters();
-      printRequestParameters( params.toMap(), logLevel );
-
-      // Setup project (config file path)
-      if ( ! project )
-      {
-        QString configFilePath = configPath( *sConfigFilePath, params.map() );
-
-        // load the project if needed and not empty
-        if ( ! configFilePath.isEmpty() )
-        {
-          project = mConfigCache->project( configFilePath, sServerInterface->serverSettings() );
-        }
-      }
-
-      // Set the current project instance
-      QgsProject::setInstance( const_cast<QgsProject *>( project ) );
-
-      if ( project )
-      {
-        sServerInterface->setConfigFilePath( project->fileName() );
-      }
-      else
-      {
-        sServerInterface->setConfigFilePath( QString() );
-      }
-
-      // Note that at this point we still might not have set a valid project.
-      // There are APIs that work without a project (e.g. the landing page catalog API that
-      // lists the available projects metadata).
-
-      // Dispatcher: if SERVICE is set, we assume a OWS service, if not, let's try an API
-      // TODO: QGIS 4 fix the OWS services and treat them as APIs
-      QgsServerApi *api = nullptr;
-      if ( params.service().isEmpty() && ( api = sServiceRegistry->apiForRequest( request ) ) )
-      {
-        QgsServerApiContext context { api->rootPath(), &request, &responseDecorator, project, sServerInterface };
-        api->executeRequest( context );
-      }
-      else
-      {
-
-        // Project is mandatory for OWS at this point
-        if ( ! project )
-        {
-          throw QgsServerException( QStringLiteral( "Project file error. For OWS services: please provide a SERVICE and a MAP parameter pointing to a valid QGIS project file" ) );
-        }
-
-        if ( ! params.fileName().isEmpty() )
-        {
-          const QString value = QString( "attachment; filename=\"%1\"" ).arg( params.fileName() );
-          requestHandler.setResponseHeader( QStringLiteral( "Content-Disposition" ), value );
-        }
-
-        // Lookup for service
-        QgsService *service = sServiceRegistry->getService( params.service(), params.version() );
-        if ( service )
-        {
-          service->executeRequest( request, responseDecorator, project );
-        }
-        else
-        {
-          throw QgsOgcServiceException( QStringLiteral( "Service configuration error" ),
-                                        QStringLiteral( "Service unknown or unsupported. Current supported services (case-sensitive): WMS WFS WCS WMTS SampleService, or use a WFS3 (OGC API Features) endpoint" ) );
-        }
-      }
+      // TODO: split parse input into plain parse and processing from specific services
+      requestHandler.parseInput();
     }
-    catch ( QgsServerException &ex )
+    catch ( QgsMapServiceException &e )
     {
-      responseDecorator.write( ex );
-      QString format;
-      QgsMessageLog::logMessage( ex.formatResponse( format ), QStringLiteral( "Server" ), Qgis::Warning );
+      QgsMessageLog::logMessage( "Parse input exception: " + e.message(), QStringLiteral( "Server" ), Qgis::Critical );
+      requestHandler.setServiceException( e );
+    }
+
+    // Set the request handler into the interface for plugins to manipulate it
+    sServerInterface->setRequestHandler( &requestHandler );
+
+    // Initialize configfilepath so that is is available
+    // before calling plugin methods
+    // Note that plugins may still change that value using
+    // setConfigFilePath() interface method
+    if ( ! project )
+    {
+      QString configFilePath = configPath( *sConfigFilePath, request.serverParameters().map() );
+      sServerInterface->setConfigFilePath( configFilePath );
+    }
+    else
+    {
+      sServerInterface->setConfigFilePath( project->fileName() );
+    }
+
+    // Call  requestReady() method (if enabled)
+    // This may also throw exceptions if there are errors in python plugins code
+    try
+    {
+      responseDecorator.start();
     }
     catch ( QgsException &ex )
     {
@@ -440,30 +352,131 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
       response.sendError( 500, QStringLiteral( "Internal Server Error" ) );
       QgsMessageLog::logMessage( ex.what(), QStringLiteral( "Server" ), Qgis::Critical );
     }
-  }
 
-  // Terminate the response
-  // This may also throw exceptions if there are errors in python plugins code
-  try
-  {
-    responseDecorator.finish();
-  }
-  catch ( QgsException &ex )
-  {
-    // Internal server error
-    response.sendError( 500, QStringLiteral( "Internal Server Error" ) );
-    QgsMessageLog::logMessage( ex.what(), QStringLiteral( "Server" ), Qgis::Critical );
-  }
+    // Plugins may have set exceptions
+    if ( !requestHandler.exceptionRaised() )
+    {
+      try
+      {
+        const QgsServerParameters params = request.serverParameters();
+        printRequestParameters( params.toMap(), logLevel );
+
+        // Setup project (config file path)
+        if ( ! project )
+        {
+          QString configFilePath = configPath( *sConfigFilePath, params.map() );
+
+          // load the project if needed and not empty
+          if ( ! configFilePath.isEmpty() )
+          {
+            project = mConfigCache->project( configFilePath, sServerInterface->serverSettings() );
+          }
+        }
+
+        // Set the current project instance
+        QgsProject::setInstance( const_cast<QgsProject *>( project ) );
+
+        if ( project )
+        {
+          sServerInterface->setConfigFilePath( project->fileName() );
+        }
+        else
+        {
+          sServerInterface->setConfigFilePath( QString() );
+        }
+
+        // Note that at this point we still might not have set a valid project.
+        // There are APIs that work without a project (e.g. the landing page catalog API that
+        // lists the available projects metadata).
+
+        // Dispatcher: if SERVICE is set, we assume a OWS service, if not, let's try an API
+        // TODO: QGIS 4 fix the OWS services and treat them as APIs
+        QgsServerApi *api = nullptr;
+        if ( params.service().isEmpty() && ( api = sServiceRegistry->apiForRequest( request ) ) )
+        {
+          QgsServerApiContext context { api->rootPath(), &request, &responseDecorator, project, sServerInterface };
+          api->executeRequest( context );
+        }
+        else
+        {
+
+          // Project is mandatory for OWS at this point
+          if ( ! project )
+          {
+            throw QgsServerException( QStringLiteral( "Project file error. For OWS services: please provide a SERVICE and a MAP parameter pointing to a valid QGIS project file" ) );
+          }
+
+          if ( ! params.fileName().isEmpty() )
+          {
+            const QString value = QString( "attachment; filename=\"%1\"" ).arg( params.fileName() );
+            requestHandler.setResponseHeader( QStringLiteral( "Content-Disposition" ), value );
+          }
+
+          // Lookup for service
+          QgsService *service = sServiceRegistry->getService( params.service(), params.version() );
+          if ( service )
+          {
+            service->executeRequest( request, responseDecorator, project );
+          }
+          else
+          {
+            throw QgsOgcServiceException( QStringLiteral( "Service configuration error" ),
+                                          QStringLiteral( "Service unknown or unsupported. Current supported services (case-sensitive): WMS WFS WCS WMTS SampleService, or use a WFS3 (OGC API Features) endpoint" ) );
+          }
+        }
+      }
+      catch ( QgsServerException &ex )
+      {
+        responseDecorator.write( ex );
+        QString format;
+        QgsMessageLog::logMessage( ex.formatResponse( format ), QStringLiteral( "Server" ), Qgis::Warning );
+      }
+      catch ( QgsException &ex )
+      {
+        // Internal server error
+        response.sendError( 500, QStringLiteral( "Internal Server Error" ) );
+        QgsMessageLog::logMessage( ex.what(), QStringLiteral( "Server" ), Qgis::Critical );
+      }
+    }
+
+    // Terminate the response
+    // This may also throw exceptions if there are errors in python plugins code
+    try
+    {
+      responseDecorator.finish();
+    }
+    catch ( QgsException &ex )
+    {
+      // Internal server error
+      response.sendError( 500, QStringLiteral( "Internal Server Error" ) );
+      QgsMessageLog::logMessage( ex.what(), QStringLiteral( "Server" ), Qgis::Critical );
+    }
 
 
-  // We are done using requestHandler in plugins, make sure we don't access
-  // to a deleted request handler from Python bindings
-  sServerInterface->clearRequestHandler();
+    // We are done using requestHandler in plugins, make sure we don't access
+    // to a deleted request handler from Python bindings
+    sServerInterface->clearRequestHandler();
+  }
 
   if ( logLevel == Qgis::Info )
   {
-    QgsMessageLog::logMessage( "Request finished in " + QString::number( time.elapsed() ) + " ms", QStringLiteral( "Server" ), Qgis::Info );
+    QgsMessageLog::logMessage( "Request finished in " + QString::number( QgsApplication::profiler()->profileTime( QStringLiteral( "handleRequest" ), QStringLiteral( "server" ) ) * 1000.0 ) + " ms", QStringLiteral( "Server" ), Qgis::Info );
+    if ( sSettings->logProfile() )
+    {
+      for ( int row = 0; row < QgsApplication::profiler()->rowCount( ); row++ )
+      {
+        const auto idx { QgsApplication::profiler()->index( row, 0 ) };
+        QgsMessageLog::logMessage( QStringLiteral( "Profile %1, %2 : %3 ms" )
+                                   .arg( QgsApplication::profiler()->data( idx, QgsRuntimeProfilerNode::Roles::Group ).toString() )
+                                   .arg( QgsApplication::profiler()->data( idx, QgsRuntimeProfilerNode::Roles::Name ).toString() )
+                                   .arg( QString::number( QgsApplication::profiler()->data( idx, QgsRuntimeProfilerNode::Roles::Elapsed ).toDouble() * 1000.0, 'f', 6 ) ), QStringLiteral( "Server" ), Qgis::Info );
+      }
+    }
   }
+
+  // Clear the profiler after each request
+  QgsApplication::profiler()->clear( "server" );
+
 }
 
 

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -265,6 +265,19 @@ void QgsServerSettings::initSettings()
                                          };
 
   mSettings[ sProjectsPgConnections.envVar ] = sProjectsPgConnections;
+
+  // log profile
+  const Setting sLogProfile = { QgsServerSettingsEnv::QGIS_SERVER_LOG_PROFILE,
+                                QgsServerSettingsEnv::DEFAULT_VALUE,
+                                QStringLiteral( "Add detailed profile information to the logs, only effective when QGIS_SERVER_LOG_LEVEL=0" ),
+                                QStringLiteral( "/qgis/server_log_profile" ),
+                                QVariant::Bool,
+                                QVariant( false ),
+                                QVariant()
+                              };
+
+  mSettings[ sLogProfile.envVar ] = sLogProfile;
+
 }
 
 void QgsServerSettings::load()
@@ -512,4 +525,9 @@ bool QgsServerSettings::trustLayerMetadata() const
 bool QgsServerSettings::getPrintDisabled() const
 {
   return value( QgsServerSettingsEnv::QGIS_SERVER_DISABLE_GETPRINT ).toBool();
+}
+
+bool QgsServerSettings::logProfile()
+{
+  return value( QgsServerSettingsEnv::QGIS_SERVER_LOG_PROFILE, false ).toBool();
 }

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -70,7 +70,8 @@ class SERVER_EXPORT QgsServerSettingsEnv : public QObject
       QGIS_SERVER_TRUST_LAYER_METADATA, //!< Trust layer metadata. Improves project read time. (since QGIS 3.16).
       QGIS_SERVER_DISABLE_GETPRINT, //!< Disabled WMS GetPrint request and don't load layouts. Improves project read time. (since QGIS 3.16).
       QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES, //!< Directories used by the landing page service to find .qgs and .qgz projects (since QGIS 3.16)
-      QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS //!< PostgreSQL connection strings used by the landing page service to find projects (since QGIS 3.16)
+      QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS, //!< PostgreSQL connection strings used by the landing page service to find projects (since QGIS 3.16)
+      QGIS_SERVER_LOG_PROFILE, //!< When QGIS_SERVER_LOG_LEVEL is 0 this flag adds to the logs detailed information about the time taken by the different processing steps inside the QGIS Server request (since QGIS 3.16)
     };
     Q_ENUM( EnvVar )
 };
@@ -145,6 +146,15 @@ class SERVER_EXPORT QgsServerSettings
      * \returns the log level.
      */
     Qgis::MessageLevel logLevel() const;
+
+    /**
+     * Returns TRUE if profile information has to be added to the logs, default value is FALSE.
+     *
+     * \note this flag is only effective when logLevel() returns Qgis::Info (0)
+     * \see logLevel()
+     * \since QGIS 3.18
+     */
+    bool logProfile();
 
     /**
      * Returns the QGS project file to use.


### PR DESCRIPTION
Add **optional** detailed profiler information to the server logs when log level is info.

Use a dedicated setting to activate it: `QGIS_SERVER_LOG_PROFILE`.

Sample output

```txt
18:50:59 INFO Server[158570]: Profile: startup, Load color schemes : 0 ms
18:50:59 INFO Server[158570]: Profile: startup, Load bookmarks : 0 ms
18:50:59 INFO Server[158570]: Profile: startup, Load default style database : 30 ms
18:50:59 INFO Server[158570]: Profile: - startup, Load symbols : 28 ms
18:50:59 INFO Server[158570]: Profile: -- startup, cat trail : 2 ms
18:50:59 INFO Server[158570]: Profile: -- startup, dash  black : 0 ms
18:50:59 INFO Server[158570]: Profile: -- startup, dash blue : 0 ms
18:50:59 INFO Server[158570]: Profile: -- startup, dash gray 1 : 0 ms
```

