### PR TITLE
[map overview] When project full extent changes, refresh the map overview to trigger a repainting of overview layers

### DIFF
--- a/src/gui/qgsmapoverviewcanvas.cpp
+++ b/src/gui/qgsmapoverviewcanvas.cpp
@@ -49,7 +49,7 @@ QgsMapOverviewCanvas::QgsMapOverviewCanvas( QWidget *parent, QgsMapCanvas *mapCa
   connect( mMapCanvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsMapOverviewCanvas::destinationCrsChanged );
   connect( mMapCanvas, &QgsMapCanvas::transformContextChanged, this, &QgsMapOverviewCanvas::transformContextChanged );
 
-  connect( QgsProject::instance()->viewSettings(), &QgsProjectViewSettings::presetFullExtentChanged, this, &QgsMapOverviewCanvas::updateFullExtent );
+  connect( QgsProject::instance()->viewSettings(), &QgsProjectViewSettings::presetFullExtentChanged, this, &QgsMapOverviewCanvas::refresh );
 }
 
 void QgsMapOverviewCanvas::resizeEvent( QResizeEvent *e )


### PR DESCRIPTION
## Description

@nyalldawson , small fix following up on your project extent work. When an extent is changed, we have to not only redraw the extent rect but also refresh the whole overview map to make sure overview layers are re-rendered taking the new extent into account.