### PR TITLE
Add QgsProject::ReadFlag::FlagSkipSnappingConfiguration

### DIFF
--- a/python/core/auto_additions/qgsproject.py
+++ b/python/core/auto_additions/qgsproject.py
@@ -8,7 +8,9 @@ QgsProject.FlagTrustLayerMetadata = QgsProject.ReadFlag.FlagTrustLayerMetadata
 QgsProject.ReadFlag.FlagTrustLayerMetadata.__doc__ = "Trust layer metadata. Improves project read time. Do not use it if layers' extent is not fixed during the project's use by QGIS and QGIS Server."
 QgsProject.FlagDontStoreOriginalStyles = QgsProject.ReadFlag.FlagDontStoreOriginalStyles
 QgsProject.ReadFlag.FlagDontStoreOriginalStyles.__doc__ = "Skip the initial XML style storage for layers. Useful for minimising project load times in non-interactive contexts."
-QgsProject.ReadFlag.__doc__ = 'Flags which control project read behavior.\n\n.. versionadded:: 3.10\n\n' + '* ``FlagDontResolveLayers``: ' + QgsProject.ReadFlag.FlagDontResolveLayers.__doc__ + '\n' + '* ``FlagDontLoadLayouts``: ' + QgsProject.ReadFlag.FlagDontLoadLayouts.__doc__ + '\n' + '* ``FlagTrustLayerMetadata``: ' + QgsProject.ReadFlag.FlagTrustLayerMetadata.__doc__ + '\n' + '* ``FlagDontStoreOriginalStyles``: ' + QgsProject.ReadFlag.FlagDontStoreOriginalStyles.__doc__
+QgsProject.FlagSkipSnappingConfiguration = QgsProject.ReadFlag.FlagSkipSnappingConfiguration
+QgsProject.ReadFlag.FlagSkipSnappingConfiguration.__doc__ = ""
+QgsProject.ReadFlag.__doc__ = 'Flags which control project read behavior.\n\n.. versionadded:: 3.10\n\n' + '* ``FlagDontResolveLayers``: ' + QgsProject.ReadFlag.FlagDontResolveLayers.__doc__ + '\n' + '* ``FlagDontLoadLayouts``: ' + QgsProject.ReadFlag.FlagDontLoadLayouts.__doc__ + '\n' + '* ``FlagTrustLayerMetadata``: ' + QgsProject.ReadFlag.FlagTrustLayerMetadata.__doc__ + '\n' + '* ``FlagDontStoreOriginalStyles``: ' + QgsProject.ReadFlag.FlagDontStoreOriginalStyles.__doc__ + '\n' + '* ``FlagSkipSnappingConfiguration``: ' + QgsProject.ReadFlag.FlagSkipSnappingConfiguration.__doc__
 # --
 # monkey patching scoped based enum
 QgsProject.FileFormat.Qgz.__doc__ = "Archive file format, supports auxiliary data"

--- a/python/core/auto_additions/qgsproject.py
+++ b/python/core/auto_additions/qgsproject.py
@@ -8,9 +8,7 @@ QgsProject.FlagTrustLayerMetadata = QgsProject.ReadFlag.FlagTrustLayerMetadata
 QgsProject.ReadFlag.FlagTrustLayerMetadata.__doc__ = "Trust layer metadata. Improves project read time. Do not use it if layers' extent is not fixed during the project's use by QGIS and QGIS Server."
 QgsProject.FlagDontStoreOriginalStyles = QgsProject.ReadFlag.FlagDontStoreOriginalStyles
 QgsProject.ReadFlag.FlagDontStoreOriginalStyles.__doc__ = "Skip the initial XML style storage for layers. Useful for minimising project load times in non-interactive contexts."
-QgsProject.FlagSkipSnappingConfiguration = QgsProject.ReadFlag.FlagSkipSnappingConfiguration
-QgsProject.ReadFlag.FlagSkipSnappingConfiguration.__doc__ = ""
-QgsProject.ReadFlag.__doc__ = 'Flags which control project read behavior.\n\n.. versionadded:: 3.10\n\n' + '* ``FlagDontResolveLayers``: ' + QgsProject.ReadFlag.FlagDontResolveLayers.__doc__ + '\n' + '* ``FlagDontLoadLayouts``: ' + QgsProject.ReadFlag.FlagDontLoadLayouts.__doc__ + '\n' + '* ``FlagTrustLayerMetadata``: ' + QgsProject.ReadFlag.FlagTrustLayerMetadata.__doc__ + '\n' + '* ``FlagDontStoreOriginalStyles``: ' + QgsProject.ReadFlag.FlagDontStoreOriginalStyles.__doc__ + '\n' + '* ``FlagSkipSnappingConfiguration``: ' + QgsProject.ReadFlag.FlagSkipSnappingConfiguration.__doc__
+QgsProject.ReadFlag.__doc__ = 'Flags which control project read behavior.\n\n.. versionadded:: 3.10\n\n' + '* ``FlagDontResolveLayers``: ' + QgsProject.ReadFlag.FlagDontResolveLayers.__doc__ + '\n' + '* ``FlagDontLoadLayouts``: ' + QgsProject.ReadFlag.FlagDontLoadLayouts.__doc__ + '\n' + '* ``FlagTrustLayerMetadata``: ' + QgsProject.ReadFlag.FlagTrustLayerMetadata.__doc__ + '\n' + '* ``FlagDontStoreOriginalStyles``: ' + QgsProject.ReadFlag.FlagDontStoreOriginalStyles.__doc__
 # --
 # monkey patching scoped based enum
 QgsProject.FileFormat.Qgz.__doc__ = "Archive file format, supports auxiliary data"

--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -41,7 +41,6 @@ open within the main QGIS application.
       FlagDontLoadLayouts,
       FlagTrustLayerMetadata,
       FlagDontStoreOriginalStyles,
-      FlagSkipSnappingConfiguration,
     };
     typedef QFlags<QgsProject::ReadFlag> ReadFlags;
 
@@ -1931,6 +1930,39 @@ This will block dirtying the specified ``project`` for the lifetime of this obje
   private:
     QgsProjectDirtyBlocker( const QgsProjectDirtyBlocker &other );
 };
+
+
+class QgsProjectSnappingConfigChangedBlocker
+{
+%Docstring
+Temporarily blocks QgsProject emission of snapping config changed signal for the lifetime of the object.
+
+QgsProjectSnappingConfigChangedBlocker supports "stacked" blocking, so two QgsProjectSnappingConfigChangedBlocker created
+for the same project will both need to be destroyed before the project can be dirtied again.
+
+.. versionadded:: 3.18
+%End
+
+%TypeHeaderCode
+#include "qgsproject.h"
+%End
+  public:
+
+    QgsProjectSnappingConfigChangedBlocker( QgsProject *project );
+%Docstring
+QgsProjectSnappingConfigChangedBlocker
+
+This will block emission of snapping config changed signal the specified ``project`` for the lifetime of this object.
+%End
+
+
+
+    ~QgsProjectSnappingConfigChangedBlocker();
+
+  private:
+    QgsProjectSnappingConfigChangedBlocker( const QgsProjectSnappingConfigChangedBlocker &other );
+};
+
 
 
 

--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -41,6 +41,7 @@ open within the main QGIS application.
       FlagDontLoadLayouts,
       FlagTrustLayerMetadata,
       FlagDontStoreOriginalStyles,
+      FlagSkipSnappingConfiguration,
     };
     typedef QFlags<QgsProject::ReadFlag> ReadFlags;
 

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -473,7 +473,7 @@ QVector<QgsDataItem *> QgsProjectRootDataItem::createChildren()
   QVector<QgsDataItem *> childItems;
 
   QgsProject p;
-  if ( !p.read( mPath, QgsProject::ReadFlag::FlagDontResolveLayers | QgsProject::ReadFlag::FlagDontLoadLayouts | QgsProject::ReadFlag::FlagDontStoreOriginalStyles ) )
+  if ( !p.read( mPath, QgsProject::ReadFlag::FlagDontResolveLayers | QgsProject::ReadFlag::FlagDontLoadLayouts | QgsProject::ReadFlag::FlagDontStoreOriginalStyles | QgsProject::ReadFlag::FlagSkipSnappingConfiguration ) )
   {
     childItems.append( new QgsErrorItem( nullptr, p.error(), mPath + "/error" ) );
     return childItems;

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -473,7 +473,8 @@ QVector<QgsDataItem *> QgsProjectRootDataItem::createChildren()
   QVector<QgsDataItem *> childItems;
 
   QgsProject p;
-  if ( !p.read( mPath, QgsProject::ReadFlag::FlagDontResolveLayers | QgsProject::ReadFlag::FlagDontLoadLayouts | QgsProject::ReadFlag::FlagDontStoreOriginalStyles | QgsProject::ReadFlag::FlagSkipSnappingConfiguration ) )
+  QgsProjectSnappingConfigChangedBlocker snappingBlocker { &p };
+  if ( !p.read( mPath, QgsProject::ReadFlag::FlagDontResolveLayers | QgsProject::ReadFlag::FlagDontLoadLayouts | QgsProject::ReadFlag::FlagDontStoreOriginalStyles ) )
   {
     childItems.append( new QgsErrorItem( nullptr, p.error(), mPath + "/error" ) );
     return childItems;

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1285,6 +1285,9 @@ bool QgsProject::read( QgsProject::ReadFlags flags )
 
 bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags flags )
 {
+
+  mReadFlags = flags;
+
   QFile projectFile( filename );
   clearError();
 
@@ -1710,7 +1713,12 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
   emit readProjectWithContext( *doc, context );
 
   profile.switchTask( tr( "Updating interface" ) );
-  emit snappingConfigChanged( mSnappingConfig );
+
+  if ( ! flags.testFlag( QgsProject::ReadFlag::FlagSkipSnappingConfiguration ) )
+  {
+    emit snappingConfigChanged( mSnappingConfig );
+  }
+
   emit avoidIntersectionsModeChanged();
   emit topologicalEditingChanged();
   emit projectColorsChanged();
@@ -2016,14 +2024,20 @@ void QgsProject::onMapLayersAdded( const QList<QgsMapLayer *> &layers )
     }
   }
 
-  if ( mSnappingConfig.addLayers( layers ) )
+  if ( ! mReadFlags.testFlag( QgsProject::ReadFlag::FlagSkipSnappingConfiguration ) &&
+       mSnappingConfig.addLayers( layers ) )
+  {
     emit snappingConfigChanged( mSnappingConfig );
+  }
 }
 
 void QgsProject::onMapLayersRemoved( const QList<QgsMapLayer *> &layers )
 {
-  if ( mSnappingConfig.removeLayers( layers ) )
+  if ( ! mReadFlags.testFlag( QgsProject::ReadFlag::FlagSkipSnappingConfiguration ) &&
+       mSnappingConfig.removeLayers( layers ) )
+  {
     emit snappingConfigChanged( mSnappingConfig );
+  }
 }
 
 void QgsProject::cleanTransactionGroups( bool force )

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1286,8 +1286,6 @@ bool QgsProject::read( QgsProject::ReadFlags flags )
 bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags flags )
 {
 
-  mReadFlags = flags;
-
   QFile projectFile( filename );
   clearError();
 
@@ -1342,379 +1340,388 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
 
   projectFile.close();
 
-  QgsDebugMsgLevel( "Opened document " + projectFile.fileName(), 2 );
+  bool clean = true;
 
-  // get project version string, if any
-  QgsProjectVersion fileVersion = getVersion( *doc );
-  const QgsProjectVersion thisVersion( Qgis::version() );
-
-  profile.switchTask( tr( "Updating project file" ) );
-  if ( thisVersion > fileVersion )
+  // Scope for QgsProjectSnappingConfigChangedBlocker RIIA
   {
-    QgsLogger::warning( "Loading a file that was saved with an older "
-                        "version of qgis (saved in " + fileVersion.text() +
-                        ", loaded in " + Qgis::version() +
-                        "). Problems may occur." );
 
-    QgsProjectFileTransform projectFile( *doc, fileVersion );
+    QgsProjectSnappingConfigChangedBlocker snappingBlocker { this };
 
-    // Shows a warning when an old project file is read.
-    emit oldProjectVersionWarning( fileVersion.text() );
+    QgsDebugMsgLevel( "Opened document " + projectFile.fileName(), 2 );
 
-    projectFile.updateRevision( thisVersion );
-  }
+    // get project version string, if any
+    QgsProjectVersion fileVersion = getVersion( *doc );
+    const QgsProjectVersion thisVersion( Qgis::version() );
 
-  // start new project, just keep the file name and auxiliary storage
-  profile.switchTask( tr( "Creating auxiliary storage" ) );
-  QString fileName = mFile.fileName();
-  std::unique_ptr<QgsAuxiliaryStorage> aStorage = std::move( mAuxiliaryStorage );
-  clear();
-  mAuxiliaryStorage = std::move( aStorage );
-  mFile.setFileName( fileName );
-  mCachedHomePath.clear();
-  mProjectScope.reset();
-  mSaveVersion = fileVersion;
+    profile.switchTask( tr( "Updating project file" ) );
+    if ( thisVersion > fileVersion )
+    {
+      QgsLogger::warning( "Loading a file that was saved with an older "
+                          "version of qgis (saved in " + fileVersion.text() +
+                          ", loaded in " + Qgis::version() +
+                          "). Problems may occur." );
 
-  // now get any properties
-  profile.switchTask( tr( "Reading properties" ) );
-  _getProperties( *doc, mProperties );
+      QgsProjectFileTransform projectFile( *doc, fileVersion );
 
-  // now get the data defined server properties
-  mDataDefinedServerProperties = getDataDefinedServerProperties( *doc, dataDefinedServerPropertyDefinitions() );
+      // Shows a warning when an old project file is read.
+      emit oldProjectVersionWarning( fileVersion.text() );
 
-  QgsDebugMsgLevel( QString::number( mProperties.count() ) + " properties read", 2 );
+      projectFile.updateRevision( thisVersion );
+    }
+
+    // start new project, just keep the file name and auxiliary storage
+    profile.switchTask( tr( "Creating auxiliary storage" ) );
+    QString fileName = mFile.fileName();
+    std::unique_ptr<QgsAuxiliaryStorage> aStorage = std::move( mAuxiliaryStorage );
+    clear();
+    mAuxiliaryStorage = std::move( aStorage );
+    mFile.setFileName( fileName );
+    mCachedHomePath.clear();
+    mProjectScope.reset();
+    mSaveVersion = fileVersion;
+
+    // now get any properties
+    profile.switchTask( tr( "Reading properties" ) );
+    _getProperties( *doc, mProperties );
+
+    // now get the data defined server properties
+    mDataDefinedServerProperties = getDataDefinedServerProperties( *doc, dataDefinedServerPropertyDefinitions() );
+
+    QgsDebugMsgLevel( QString::number( mProperties.count() ) + " properties read", 2 );
 
 #if 0
-  dump_( mProperties );
+    dump_( mProperties );
 #endif
 
-  // get older style project title
-  QString oldTitle;
-  _getTitle( *doc, oldTitle );
+    // get older style project title
+    QString oldTitle;
+    _getTitle( *doc, oldTitle );
 
-  readProjectFileMetadata( *doc, mSaveUser, mSaveUserFull, mSaveDateTime );
+    readProjectFileMetadata( *doc, mSaveUser, mSaveUserFull, mSaveDateTime );
 
-  QDomNodeList homePathNl = doc->elementsByTagName( QStringLiteral( "homePath" ) );
-  if ( homePathNl.count() > 0 )
-  {
-    QDomElement homePathElement = homePathNl.at( 0 ).toElement();
-    QString homePath = homePathElement.attribute( QStringLiteral( "path" ) );
-    if ( !homePath.isEmpty() )
-      setPresetHomePath( homePath );
-  }
-  else
-  {
-    emit homePathChanged();
-  }
-
-  const QColor backgroundColor( readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorRedPart" ), 255 ),
-                                readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorGreenPart" ), 255 ),
-                                readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorBluePart" ), 255 ) );
-  setBackgroundColor( backgroundColor );
-  const QColor selectionColor( readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorRedPart" ), 255 ),
-                               readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorGreenPart" ), 255 ),
-                               readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorBluePart" ), 255 ),
-                               readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorAlphaPart" ), 255 ) );
-  setSelectionColor( selectionColor );
-
-  QgsReadWriteContext context;
-  context.setPathResolver( pathResolver() );
-  context.setProjectTranslator( this );
-
-  //crs
-  QgsCoordinateReferenceSystem projectCrs;
-  if ( readNumEntry( QStringLiteral( "SpatialRefSys" ), QStringLiteral( "/ProjectionsEnabled" ), 0 ) )
-  {
-    // first preference - dedicated projectCrs node
-    QDomNode srsNode = doc->documentElement().namedItem( QStringLiteral( "projectCrs" ) );
-    if ( !srsNode.isNull() )
+    QDomNodeList homePathNl = doc->elementsByTagName( QStringLiteral( "homePath" ) );
+    if ( homePathNl.count() > 0 )
     {
-      projectCrs.readXml( srsNode );
+      QDomElement homePathElement = homePathNl.at( 0 ).toElement();
+      QString homePath = homePathElement.attribute( QStringLiteral( "path" ) );
+      if ( !homePath.isEmpty() )
+        setPresetHomePath( homePath );
+    }
+    else
+    {
+      emit homePathChanged();
     }
 
-    if ( !projectCrs.isValid() )
+    const QColor backgroundColor( readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorRedPart" ), 255 ),
+                                  readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorGreenPart" ), 255 ),
+                                  readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorBluePart" ), 255 ) );
+    setBackgroundColor( backgroundColor );
+    const QColor selectionColor( readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorRedPart" ), 255 ),
+                                 readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorGreenPart" ), 255 ),
+                                 readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorBluePart" ), 255 ),
+                                 readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorAlphaPart" ), 255 ) );
+    setSelectionColor( selectionColor );
+
+    QgsReadWriteContext context;
+    context.setPathResolver( pathResolver() );
+    context.setProjectTranslator( this );
+
+    //crs
+    QgsCoordinateReferenceSystem projectCrs;
+    if ( readNumEntry( QStringLiteral( "SpatialRefSys" ), QStringLiteral( "/ProjectionsEnabled" ), 0 ) )
     {
-      QString projCrsString = readEntry( QStringLiteral( "SpatialRefSys" ), QStringLiteral( "/ProjectCRSProj4String" ) );
-      long currentCRS = readNumEntry( QStringLiteral( "SpatialRefSys" ), QStringLiteral( "/ProjectCRSID" ), -1 );
-      const QString authid = readEntry( QStringLiteral( "SpatialRefSys" ), QStringLiteral( "/ProjectCrs" ) );
-
-      // authid should be prioritized over all
-      bool isUserAuthId = authid.startsWith( QLatin1String( "USER:" ), Qt::CaseInsensitive );
-      if ( !authid.isEmpty() && !isUserAuthId )
-        projectCrs = QgsCoordinateReferenceSystem( authid );
-
-      // try the CRS
-      if ( !projectCrs.isValid() && currentCRS >= 0 )
+      // first preference - dedicated projectCrs node
+      QDomNode srsNode = doc->documentElement().namedItem( QStringLiteral( "projectCrs" ) );
+      if ( !srsNode.isNull() )
       {
-        projectCrs = QgsCoordinateReferenceSystem::fromSrsId( currentCRS );
+        projectCrs.readXml( srsNode );
       }
 
-      // if that didn't produce a match, try the proj.4 string
-      if ( !projCrsString.isEmpty() && ( authid.isEmpty() || isUserAuthId ) && ( !projectCrs.isValid() || projectCrs.toProj() != projCrsString ) )
-      {
-        projectCrs = QgsCoordinateReferenceSystem::fromProj( projCrsString );
-      }
-
-      // last just take the given id
       if ( !projectCrs.isValid() )
       {
-        projectCrs = QgsCoordinateReferenceSystem::fromSrsId( currentCRS );
+        QString projCrsString = readEntry( QStringLiteral( "SpatialRefSys" ), QStringLiteral( "/ProjectCRSProj4String" ) );
+        long currentCRS = readNumEntry( QStringLiteral( "SpatialRefSys" ), QStringLiteral( "/ProjectCRSID" ), -1 );
+        const QString authid = readEntry( QStringLiteral( "SpatialRefSys" ), QStringLiteral( "/ProjectCrs" ) );
+
+        // authid should be prioritized over all
+        bool isUserAuthId = authid.startsWith( QLatin1String( "USER:" ), Qt::CaseInsensitive );
+        if ( !authid.isEmpty() && !isUserAuthId )
+          projectCrs = QgsCoordinateReferenceSystem( authid );
+
+        // try the CRS
+        if ( !projectCrs.isValid() && currentCRS >= 0 )
+        {
+          projectCrs = QgsCoordinateReferenceSystem::fromSrsId( currentCRS );
+        }
+
+        // if that didn't produce a match, try the proj.4 string
+        if ( !projCrsString.isEmpty() && ( authid.isEmpty() || isUserAuthId ) && ( !projectCrs.isValid() || projectCrs.toProj() != projCrsString ) )
+        {
+          projectCrs = QgsCoordinateReferenceSystem::fromProj( projCrsString );
+        }
+
+        // last just take the given id
+        if ( !projectCrs.isValid() )
+        {
+          projectCrs = QgsCoordinateReferenceSystem::fromSrsId( currentCRS );
+        }
       }
     }
-  }
-  mCrs = projectCrs;
+    mCrs = projectCrs;
 
-  QStringList datumErrors;
-  if ( !mTransformContext.readXml( doc->documentElement(), context, datumErrors ) && !datumErrors.empty() )
-  {
-    emit missingDatumTransforms( datumErrors );
-  }
-  emit transformContextChanged();
-
-  //add variables defined in project file - do this early in the reading cycle, as other components
-  //(e.g. layouts) may depend on these variables
-  QStringList variableNames = readListEntry( QStringLiteral( "Variables" ), QStringLiteral( "/variableNames" ) );
-  QStringList variableValues = readListEntry( QStringLiteral( "Variables" ), QStringLiteral( "/variableValues" ) );
-
-  mCustomVariables.clear();
-  if ( variableNames.length() == variableValues.length() )
-  {
-    for ( int i = 0; i < variableNames.length(); ++i )
+    QStringList datumErrors;
+    if ( !mTransformContext.readXml( doc->documentElement(), context, datumErrors ) && !datumErrors.empty() )
     {
-      mCustomVariables.insert( variableNames.at( i ), variableValues.at( i ) );
+      emit missingDatumTransforms( datumErrors );
     }
-  }
-  else
-  {
-    QgsMessageLog::logMessage( tr( "Project Variables Invalid" ), tr( "The project contains invalid variable settings." ) );
-  }
+    emit transformContextChanged();
 
-  QDomNodeList nl = doc->elementsByTagName( QStringLiteral( "projectMetadata" ) );
-  if ( !nl.isEmpty() )
-  {
-    QDomElement metadataElement = nl.at( 0 ).toElement();
-    mMetadata.readMetadataXml( metadataElement );
-  }
-  else
-  {
-    // older project, no metadata => remove auto generated metadata which is populated on QgsProject::clear()
-    mMetadata = QgsProjectMetadata();
-  }
-  if ( mMetadata.title().isEmpty() && !oldTitle.isEmpty() )
-  {
-    // upgrade older title storage to storing within project metadata.
-    mMetadata.setTitle( oldTitle );
-  }
-  emit metadataChanged();
+    //add variables defined in project file - do this early in the reading cycle, as other components
+    //(e.g. layouts) may depend on these variables
+    QStringList variableNames = readListEntry( QStringLiteral( "Variables" ), QStringLiteral( "/variableNames" ) );
+    QStringList variableValues = readListEntry( QStringLiteral( "Variables" ), QStringLiteral( "/variableValues" ) );
 
-  nl = doc->elementsByTagName( QStringLiteral( "autotransaction" ) );
-  if ( nl.count() )
-  {
-    QDomElement transactionElement = nl.at( 0 ).toElement();
-    if ( transactionElement.attribute( QStringLiteral( "active" ), QStringLiteral( "0" ) ).toInt() == 1 )
-      mAutoTransaction = true;
-  }
-
-  nl = doc->elementsByTagName( QStringLiteral( "evaluateDefaultValues" ) );
-  if ( nl.count() )
-  {
-    QDomElement evaluateDefaultValuesElement = nl.at( 0 ).toElement();
-    if ( evaluateDefaultValuesElement.attribute( QStringLiteral( "active" ), QStringLiteral( "0" ) ).toInt() == 1 )
-      mEvaluateDefaultValues = true;
-  }
-
-  // Read trust layer metadata config in the project
-  nl = doc->elementsByTagName( QStringLiteral( "trust" ) );
-  if ( nl.count() )
-  {
-    QDomElement trustElement = nl.at( 0 ).toElement();
-    if ( trustElement.attribute( QStringLiteral( "active" ), QStringLiteral( "0" ) ).toInt() == 1 )
-      mTrustLayerMetadata = true;
-  }
-
-  // read the layer tree from project file
-  profile.switchTask( tr( "Loading layer tree" ) );
-  mRootGroup->setCustomProperty( QStringLiteral( "loading" ), 1 );
-
-  QDomElement layerTreeElem = doc->documentElement().firstChildElement( QStringLiteral( "layer-tree-group" ) );
-  if ( !layerTreeElem.isNull() )
-  {
-    // Use a temporary tree to read the nodes to prevent signals being delivered to the models
-    QgsLayerTree tempTree;
-    tempTree.readChildrenFromXml( layerTreeElem, context );
-    mRootGroup->insertChildNodes( -1, tempTree.abandonChildren() );
-  }
-  else
-  {
-    QgsLayerTreeUtils::readOldLegend( mRootGroup, doc->documentElement().firstChildElement( QStringLiteral( "legend" ) ) );
-  }
-
-  mLayerTreeRegistryBridge->setEnabled( false );
-
-  // get the map layers
-  profile.switchTask( tr( "Reading map layers" ) );
-
-  QList<QDomNode> brokenNodes;
-  bool clean = _getMapLayers( *doc, brokenNodes, flags );
-
-  // review the integrity of the retrieved map layers
-  if ( !clean )
-  {
-    QgsDebugMsg( QStringLiteral( "Unable to get map layers from project file." ) );
-
-    if ( !brokenNodes.isEmpty() )
+    mCustomVariables.clear();
+    if ( variableNames.length() == variableValues.length() )
     {
-      QgsDebugMsg( "there are " + QString::number( brokenNodes.size() ) + " broken layers" );
-    }
-
-    // we let a custom handler decide what to do with missing layers
-    // (default implementation ignores them, there's also a GUI handler that lets user choose correct path)
-    mBadLayerHandler->handleBadLayers( brokenNodes );
-  }
-
-  mMainAnnotationLayer->readLayerXml( doc->documentElement().firstChildElement( QStringLiteral( "main-annotation-layer" ) ), context );
-  mMainAnnotationLayer->setTransformContext( mTransformContext );
-
-  // Resolve references to other layers
-  // Needs to be done here once all dependent layers are loaded
-  profile.switchTask( tr( "Resolving layer references" ) );
-  QMap<QString, QgsMapLayer *> layers = mLayerStore->mapLayers();
-  for ( QMap<QString, QgsMapLayer *>::iterator it = layers.begin(); it != layers.end(); ++it )
-  {
-    it.value()->resolveReferences( this );
-  }
-
-  mLayerTreeRegistryBridge->setEnabled( true );
-
-  // load embedded groups and layers
-  profile.switchTask( tr( "Loading embedded layers" ) );
-  loadEmbeddedNodes( mRootGroup, flags );
-
-  // now that layers are loaded, we can resolve layer tree's references to the layers
-  profile.switchTask( tr( "Resolving references" ) );
-  mRootGroup->resolveReferences( this );
-
-  if ( !layerTreeElem.isNull() )
-  {
-    mRootGroup->readLayerOrderFromXml( layerTreeElem );
-  }
-
-  // Load pre 3.0 configuration
-  QDomElement layerTreeCanvasElem = doc->documentElement().firstChildElement( QStringLiteral( "layer-tree-canvas" ) );
-  if ( !layerTreeCanvasElem.isNull( ) )
-  {
-    mRootGroup->readLayerOrderFromXml( layerTreeCanvasElem );
-  }
-
-  // Convert pre 3.4 to create layers flags
-  if ( QgsProjectVersion( 3, 4, 0 ) > mSaveVersion )
-  {
-    const QStringList requiredLayerIds = readListEntry( QStringLiteral( "RequiredLayers" ), QStringLiteral( "Layers" ) );
-    for ( const QString &layerId : requiredLayerIds )
-    {
-      if ( QgsMapLayer *layer = mapLayer( layerId ) )
+      for ( int i = 0; i < variableNames.length(); ++i )
       {
-        layer->setFlags( layer->flags() & ~QgsMapLayer::Removable );
+        mCustomVariables.insert( variableNames.at( i ), variableValues.at( i ) );
       }
     }
-    const QStringList disabledLayerIds = readListEntry( QStringLiteral( "Identify" ), QStringLiteral( "/disabledLayers" ) );
-    for ( const QString &layerId : disabledLayerIds )
+    else
     {
-      if ( QgsMapLayer *layer = mapLayer( layerId ) )
+      QgsMessageLog::logMessage( tr( "Project Variables Invalid" ), tr( "The project contains invalid variable settings." ) );
+    }
+
+    QDomNodeList nl = doc->elementsByTagName( QStringLiteral( "projectMetadata" ) );
+    if ( !nl.isEmpty() )
+    {
+      QDomElement metadataElement = nl.at( 0 ).toElement();
+      mMetadata.readMetadataXml( metadataElement );
+    }
+    else
+    {
+      // older project, no metadata => remove auto generated metadata which is populated on QgsProject::clear()
+      mMetadata = QgsProjectMetadata();
+    }
+    if ( mMetadata.title().isEmpty() && !oldTitle.isEmpty() )
+    {
+      // upgrade older title storage to storing within project metadata.
+      mMetadata.setTitle( oldTitle );
+    }
+    emit metadataChanged();
+
+    nl = doc->elementsByTagName( QStringLiteral( "autotransaction" ) );
+    if ( nl.count() )
+    {
+      QDomElement transactionElement = nl.at( 0 ).toElement();
+      if ( transactionElement.attribute( QStringLiteral( "active" ), QStringLiteral( "0" ) ).toInt() == 1 )
+        mAutoTransaction = true;
+    }
+
+    nl = doc->elementsByTagName( QStringLiteral( "evaluateDefaultValues" ) );
+    if ( nl.count() )
+    {
+      QDomElement evaluateDefaultValuesElement = nl.at( 0 ).toElement();
+      if ( evaluateDefaultValuesElement.attribute( QStringLiteral( "active" ), QStringLiteral( "0" ) ).toInt() == 1 )
+        mEvaluateDefaultValues = true;
+    }
+
+    // Read trust layer metadata config in the project
+    nl = doc->elementsByTagName( QStringLiteral( "trust" ) );
+    if ( nl.count() )
+    {
+      QDomElement trustElement = nl.at( 0 ).toElement();
+      if ( trustElement.attribute( QStringLiteral( "active" ), QStringLiteral( "0" ) ).toInt() == 1 )
+        mTrustLayerMetadata = true;
+    }
+
+    // read the layer tree from project file
+    profile.switchTask( tr( "Loading layer tree" ) );
+    mRootGroup->setCustomProperty( QStringLiteral( "loading" ), 1 );
+
+    QDomElement layerTreeElem = doc->documentElement().firstChildElement( QStringLiteral( "layer-tree-group" ) );
+    if ( !layerTreeElem.isNull() )
+    {
+      // Use a temporary tree to read the nodes to prevent signals being delivered to the models
+      QgsLayerTree tempTree;
+      tempTree.readChildrenFromXml( layerTreeElem, context );
+      mRootGroup->insertChildNodes( -1, tempTree.abandonChildren() );
+    }
+    else
+    {
+      QgsLayerTreeUtils::readOldLegend( mRootGroup, doc->documentElement().firstChildElement( QStringLiteral( "legend" ) ) );
+    }
+
+    mLayerTreeRegistryBridge->setEnabled( false );
+
+    // get the map layers
+    profile.switchTask( tr( "Reading map layers" ) );
+
+    QList<QDomNode> brokenNodes;
+    clean = _getMapLayers( *doc, brokenNodes, flags );
+
+    // review the integrity of the retrieved map layers
+    if ( !clean )
+    {
+      QgsDebugMsg( QStringLiteral( "Unable to get map layers from project file." ) );
+
+      if ( !brokenNodes.isEmpty() )
       {
-        layer->setFlags( layer->flags() & ~QgsMapLayer::Identifiable );
+        QgsDebugMsg( "there are " + QString::number( brokenNodes.size() ) + " broken layers" );
+      }
+
+      // we let a custom handler decide what to do with missing layers
+      // (default implementation ignores them, there's also a GUI handler that lets user choose correct path)
+      mBadLayerHandler->handleBadLayers( brokenNodes );
+    }
+
+    mMainAnnotationLayer->readLayerXml( doc->documentElement().firstChildElement( QStringLiteral( "main-annotation-layer" ) ), context );
+    mMainAnnotationLayer->setTransformContext( mTransformContext );
+
+    // Resolve references to other layers
+    // Needs to be done here once all dependent layers are loaded
+    profile.switchTask( tr( "Resolving layer references" ) );
+    QMap<QString, QgsMapLayer *> layers = mLayerStore->mapLayers();
+    for ( QMap<QString, QgsMapLayer *>::iterator it = layers.begin(); it != layers.end(); ++it )
+    {
+      it.value()->resolveReferences( this );
+    }
+
+    mLayerTreeRegistryBridge->setEnabled( true );
+
+    // load embedded groups and layers
+    profile.switchTask( tr( "Loading embedded layers" ) );
+    loadEmbeddedNodes( mRootGroup, flags );
+
+    // now that layers are loaded, we can resolve layer tree's references to the layers
+    profile.switchTask( tr( "Resolving references" ) );
+    mRootGroup->resolveReferences( this );
+
+    if ( !layerTreeElem.isNull() )
+    {
+      mRootGroup->readLayerOrderFromXml( layerTreeElem );
+    }
+
+    // Load pre 3.0 configuration
+    QDomElement layerTreeCanvasElem = doc->documentElement().firstChildElement( QStringLiteral( "layer-tree-canvas" ) );
+    if ( !layerTreeCanvasElem.isNull( ) )
+    {
+      mRootGroup->readLayerOrderFromXml( layerTreeCanvasElem );
+    }
+
+    // Convert pre 3.4 to create layers flags
+    if ( QgsProjectVersion( 3, 4, 0 ) > mSaveVersion )
+    {
+      const QStringList requiredLayerIds = readListEntry( QStringLiteral( "RequiredLayers" ), QStringLiteral( "Layers" ) );
+      for ( const QString &layerId : requiredLayerIds )
+      {
+        if ( QgsMapLayer *layer = mapLayer( layerId ) )
+        {
+          layer->setFlags( layer->flags() & ~QgsMapLayer::Removable );
+        }
+      }
+      const QStringList disabledLayerIds = readListEntry( QStringLiteral( "Identify" ), QStringLiteral( "/disabledLayers" ) );
+      for ( const QString &layerId : disabledLayerIds )
+      {
+        if ( QgsMapLayer *layer = mapLayer( layerId ) )
+        {
+          layer->setFlags( layer->flags() & ~QgsMapLayer::Identifiable );
+        }
       }
     }
-  }
 
-  // After bad layer handling we might still have invalid layers,
-  // store them in case the user wanted to handle them later
-  // or wanted to pass them through when saving
-  if ( !( flags & QgsProject::ReadFlag::FlagDontStoreOriginalStyles ) )
-  {
-    QgsLayerTreeUtils::storeOriginalLayersProperties( mRootGroup, doc.get() );
-  }
-
-  mRootGroup->removeCustomProperty( QStringLiteral( "loading" ) );
-
-  profile.switchTask( tr( "Loading map themes" ) );
-  mMapThemeCollection.reset( new QgsMapThemeCollection( this ) );
-  emit mapThemeCollectionChanged();
-  mMapThemeCollection->readXml( *doc );
-
-  profile.switchTask( tr( "Loading label settings" ) );
-  mLabelingEngineSettings->readSettingsFromProject( this );
-  emit labelingEngineSettingsChanged();
-
-  profile.switchTask( tr( "Loading annotations" ) );
-  mAnnotationManager->readXml( doc->documentElement(), context );
-  if ( !( flags & QgsProject::ReadFlag::FlagDontLoadLayouts ) )
-  {
-    profile.switchTask( tr( "Loading layouts" ) );
-    mLayoutManager->readXml( doc->documentElement(), *doc );
-  }
-  profile.switchTask( tr( "Loading bookmarks" ) );
-  mBookmarkManager->readXml( doc->documentElement(), *doc );
-
-  // reassign change dependencies now that all layers are loaded
-  QMap<QString, QgsMapLayer *> existingMaps = mapLayers();
-  for ( QMap<QString, QgsMapLayer *>::iterator it = existingMaps.begin(); it != existingMaps.end(); ++it )
-  {
-    it.value()->setDependencies( it.value()->dependencies() );
-  }
-
-  profile.switchTask( tr( "Loading snapping settings" ) );
-  mSnappingConfig.readProject( *doc );
-  mAvoidIntersectionsMode = static_cast<AvoidIntersectionsMode>( readNumEntry( QStringLiteral( "Digitizing" ), QStringLiteral( "/AvoidIntersectionsMode" ), static_cast<int>( AvoidIntersectionsMode::AvoidIntersectionsLayers ) ) );
-
-  profile.switchTask( tr( "Loading view settings" ) );
-  // restore older project scales settings
-  mViewSettings->setUseProjectScales( readBoolEntry( QStringLiteral( "Scales" ), QStringLiteral( "/useProjectScales" ) ) );
-  const QStringList scales = readListEntry( QStringLiteral( "Scales" ), QStringLiteral( "/ScalesList" ) );
-  QVector<double> res;
-  for ( const QString &scale : scales )
-  {
-    const QStringList parts = scale.split( ':' );
-    if ( parts.size() != 2 )
-      continue;
-
-    bool ok = false;
-    const double denominator = QLocale().toDouble( parts[1], &ok );
-    if ( ok )
+    // After bad layer handling we might still have invalid layers,
+    // store them in case the user wanted to handle them later
+    // or wanted to pass them through when saving
+    if ( !( flags & QgsProject::ReadFlag::FlagDontStoreOriginalStyles ) )
     {
-      res << denominator;
+      QgsLayerTreeUtils::storeOriginalLayersProperties( mRootGroup, doc.get() );
     }
-  }
-  mViewSettings->setMapScales( res );
-  QDomElement viewSettingsElement = doc->documentElement().firstChildElement( QStringLiteral( "ProjectViewSettings" ) );
-  if ( !viewSettingsElement.isNull() )
-    mViewSettings->readXml( viewSettingsElement, context );
 
-  // restore time settings
-  profile.switchTask( tr( "Loading temporal settings" ) );
-  QDomElement timeSettingsElement = doc->documentElement().firstChildElement( QStringLiteral( "ProjectTimeSettings" ) );
-  if ( !timeSettingsElement.isNull() )
-    mTimeSettings->readXml( timeSettingsElement, context );
+    mRootGroup->removeCustomProperty( QStringLiteral( "loading" ) );
 
-  profile.switchTask( tr( "Loading display settings" ) );
-  QDomElement displaySettingsElement = doc->documentElement().firstChildElement( QStringLiteral( "ProjectDisplaySettings" ) );
-  if ( !displaySettingsElement.isNull() )
-    mDisplaySettings->readXml( displaySettingsElement, context );
+    profile.switchTask( tr( "Loading map themes" ) );
+    mMapThemeCollection.reset( new QgsMapThemeCollection( this ) );
+    emit mapThemeCollectionChanged();
+    mMapThemeCollection->readXml( *doc );
 
-  profile.switchTask( tr( "Updating variables" ) );
-  emit customVariablesChanged();
-  profile.switchTask( tr( "Updating CRS" ) );
-  emit crsChanged();
-  emit ellipsoidChanged( ellipsoid() );
+    profile.switchTask( tr( "Loading label settings" ) );
+    mLabelingEngineSettings->readSettingsFromProject( this );
+    emit labelingEngineSettingsChanged();
 
-  // read the project: used by map canvas and legend
-  profile.switchTask( tr( "Reading external settings" ) );
-  emit readProject( *doc );
-  emit readProjectWithContext( *doc, context );
+    profile.switchTask( tr( "Loading annotations" ) );
+    mAnnotationManager->readXml( doc->documentElement(), context );
+    if ( !( flags & QgsProject::ReadFlag::FlagDontLoadLayouts ) )
+    {
+      profile.switchTask( tr( "Loading layouts" ) );
+      mLayoutManager->readXml( doc->documentElement(), *doc );
+    }
+    profile.switchTask( tr( "Loading bookmarks" ) );
+    mBookmarkManager->readXml( doc->documentElement(), *doc );
+
+    // reassign change dependencies now that all layers are loaded
+    QMap<QString, QgsMapLayer *> existingMaps = mapLayers();
+    for ( QMap<QString, QgsMapLayer *>::iterator it = existingMaps.begin(); it != existingMaps.end(); ++it )
+    {
+      it.value()->setDependencies( it.value()->dependencies() );
+    }
+
+    profile.switchTask( tr( "Loading snapping settings" ) );
+    mSnappingConfig.readProject( *doc );
+    mAvoidIntersectionsMode = static_cast<AvoidIntersectionsMode>( readNumEntry( QStringLiteral( "Digitizing" ), QStringLiteral( "/AvoidIntersectionsMode" ), static_cast<int>( AvoidIntersectionsMode::AvoidIntersectionsLayers ) ) );
+
+    profile.switchTask( tr( "Loading view settings" ) );
+    // restore older project scales settings
+    mViewSettings->setUseProjectScales( readBoolEntry( QStringLiteral( "Scales" ), QStringLiteral( "/useProjectScales" ) ) );
+    const QStringList scales = readListEntry( QStringLiteral( "Scales" ), QStringLiteral( "/ScalesList" ) );
+    QVector<double> res;
+    for ( const QString &scale : scales )
+    {
+      const QStringList parts = scale.split( ':' );
+      if ( parts.size() != 2 )
+        continue;
+
+      bool ok = false;
+      const double denominator = QLocale().toDouble( parts[1], &ok );
+      if ( ok )
+      {
+        res << denominator;
+      }
+    }
+    mViewSettings->setMapScales( res );
+    QDomElement viewSettingsElement = doc->documentElement().firstChildElement( QStringLiteral( "ProjectViewSettings" ) );
+    if ( !viewSettingsElement.isNull() )
+      mViewSettings->readXml( viewSettingsElement, context );
+
+    // restore time settings
+    profile.switchTask( tr( "Loading temporal settings" ) );
+    QDomElement timeSettingsElement = doc->documentElement().firstChildElement( QStringLiteral( "ProjectTimeSettings" ) );
+    if ( !timeSettingsElement.isNull() )
+      mTimeSettings->readXml( timeSettingsElement, context );
+
+    profile.switchTask( tr( "Loading display settings" ) );
+    QDomElement displaySettingsElement = doc->documentElement().firstChildElement( QStringLiteral( "ProjectDisplaySettings" ) );
+    if ( !displaySettingsElement.isNull() )
+      mDisplaySettings->readXml( displaySettingsElement, context );
+
+    profile.switchTask( tr( "Updating variables" ) );
+    emit customVariablesChanged();
+    profile.switchTask( tr( "Updating CRS" ) );
+    emit crsChanged();
+    emit ellipsoidChanged( ellipsoid() );
+
+    // read the project: used by map canvas and legend
+    profile.switchTask( tr( "Reading external settings" ) );
+    emit readProject( *doc );
+    emit readProjectWithContext( *doc, context );
+
+  } // end of scope for QgsProjectSnappingConfigChangedBlocker
 
   profile.switchTask( tr( "Updating interface" ) );
 
-  if ( ! flags.testFlag( QgsProject::ReadFlag::FlagSkipSnappingConfiguration ) )
+  if ( ! mBlockSnappingUpdates )
   {
     emit snappingConfigChanged( mSnappingConfig );
   }
@@ -2024,7 +2031,7 @@ void QgsProject::onMapLayersAdded( const QList<QgsMapLayer *> &layers )
     }
   }
 
-  if ( ! mReadFlags.testFlag( QgsProject::ReadFlag::FlagSkipSnappingConfiguration ) &&
+  if ( !mBlockSnappingUpdates &&
        mSnappingConfig.addLayers( layers ) )
   {
     emit snappingConfigChanged( mSnappingConfig );
@@ -2033,7 +2040,7 @@ void QgsProject::onMapLayersAdded( const QList<QgsMapLayer *> &layers )
 
 void QgsProject::onMapLayersRemoved( const QList<QgsMapLayer *> &layers )
 {
-  if ( ! mReadFlags.testFlag( QgsProject::ReadFlag::FlagSkipSnappingConfiguration ) &&
+  if ( !mBlockSnappingUpdates &&
        mSnappingConfig.removeLayers( layers ) )
   {
     emit snappingConfigChanged( mSnappingConfig );

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -122,6 +122,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
       FlagDontLoadLayouts = 1 << 1, //!< Don't load print layouts. Improves project read time if layouts are not required, and allows projects to be safely read in background threads (since print layouts are not thread safe).
       FlagTrustLayerMetadata = 1 << 2, //!< Trust layer metadata. Improves project read time. Do not use it if layers' extent is not fixed during the project's use by QGIS and QGIS Server.
       FlagDontStoreOriginalStyles = 1 << 3, //!< Skip the initial XML style storage for layers. Useful for minimising project load times in non-interactive contexts.
+      FlagSkipSnappingConfiguration = 1 << 4, //! Skip the snapping configuration. Useful for minimising project load times in non-interactive contexts.
     };
     Q_DECLARE_FLAGS( ReadFlags, ReadFlag )
 
@@ -2056,6 +2057,11 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     bool mDirty = false;                 // project has been modified since it has been read or saved
     int mDirtyBlockCount = 0;
     bool mTrustLayerMetadata = false;
+
+    /**
+     * Stores the project read flags
+     */
+    ReadFlags mReadFlags;
 
     QgsPropertyCollection mDataDefinedServerProperties;
 

--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -52,8 +52,8 @@ const QgsProject *QgsConfigCache::project( const QString &path, const QgsServerS
     QgsStoreBadLayerInfo *badLayerHandler = new QgsStoreBadLayerInfo();
     prj->setBadLayerHandler( badLayerHandler );
 
-    // Always skip original styles storage
-    QgsProject::ReadFlags readFlags = QgsProject::ReadFlag() | QgsProject::ReadFlag::FlagDontStoreOriginalStyles ;
+    // Always skip original styles storage and snapping config
+    QgsProject::ReadFlags readFlags = QgsProject::ReadFlag() | QgsProject::ReadFlag::FlagDontStoreOriginalStyles  | QgsProject::ReadFlag::FlagSkipSnappingConfiguration;
     if ( settings )
     {
       // Activate trust layer metadata flag

--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -46,6 +46,8 @@ const QgsProject *QgsConfigCache::project( const QString &path, const QgsServerS
 
     std::unique_ptr<QgsProject> prj( new QgsProject() );
 
+    QgsProjectSnappingConfigChangedBlocker snappingBlocker{ prj.get() };
+
     // This is required by virtual layers that call QgsProject::instance() inside the constructor :(
     QgsProject::setInstance( prj.get() );
 
@@ -53,7 +55,8 @@ const QgsProject *QgsConfigCache::project( const QString &path, const QgsServerS
     prj->setBadLayerHandler( badLayerHandler );
 
     // Always skip original styles storage and snapping config
-    QgsProject::ReadFlags readFlags = QgsProject::ReadFlag() | QgsProject::ReadFlag::FlagDontStoreOriginalStyles  | QgsProject::ReadFlag::FlagSkipSnappingConfiguration;
+    QgsProject::ReadFlags readFlags = QgsProject::ReadFlag() | QgsProject::ReadFlag::FlagDontStoreOriginalStyles;
+
     if ( settings )
     {
       // Activate trust layer metadata flag


### PR DESCRIPTION
This little optimization gives a ~1-2% speed gain in the server's cold start with the "monster" project (~1000 PG layers) to the first getCapabilities call.

I'm not really happy with the implementation because I need to set `mReadFlags` in the `QgsProject` instance, I did that because the `QgsProject::onMapLayersAdded` is connected immediately in `QgsProject` ctor where we have no information about the flags.

I'm open to proposals for a better way to implement this.
