### PR TITLE
Move responsibility for determining whether a map renderer job requires flattening onto a temporary image to the QgsMapLayerRenderer subclasses

### DIFF
--- a/python/core/auto_generated/qgsmaplayerrenderer.sip.in
+++ b/python/core/auto_generated/qgsmaplayerrenderer.sip.in
@@ -53,6 +53,24 @@ Constructor for QgsMapLayerRenderer, with the associated ``layerID`` and render 
 Do the rendering (based on data stored in the class)
 %End
 
+    virtual bool forceRasterRender() const;
+%Docstring
+Returns ``True`` if the renderer must be rendered to a raster paint device (e.g. QImage).
+
+Some layer settings require layers to be effectively "flattened" while rendering maps,
+which is achieved by first rendering the layer onto a raster paint device and then compositing
+the resultant image onto the final map render.
+
+E.g. if a layer contains features with transparency or alternative blending modes, and
+the effects of these opacity or blending modes should be restricted to only affect other
+features within the SAME layer, then a flattened raster based render is required.
+
+Subclasses should return ``True`` whenever their corresponding layer settings require the
+layer to always be rendered using a raster paint device.
+
+.. versionadded:: 3.18
+%End
+
     virtual QgsFeedback *feedback() const;
 %Docstring
 Access to feedback object of the layer renderer (may be ``None``)
@@ -76,6 +94,7 @@ Returns the render context associated with the renderer.
 
 .. versionadded:: 3.10
 %End
+
 
   protected:
 

--- a/src/core/annotations/qgsannotationlayerrenderer.cpp
+++ b/src/core/annotations/qgsannotationlayerrenderer.cpp
@@ -21,6 +21,7 @@
 QgsAnnotationLayerRenderer::QgsAnnotationLayerRenderer( QgsAnnotationLayer *layer, QgsRenderContext &context )
   : QgsMapLayerRenderer( layer->id(), &context )
   , mFeedback( qgis::make_unique< QgsFeedback >() )
+  , mLayerOpacity( layer->opacity() )
 {
   // clone items from layer
   const QMap< QString, QgsAnnotationItem * > items = layer->items();
@@ -56,4 +57,9 @@ bool QgsAnnotationLayerRenderer::render()
     item->render( context, mFeedback.get() );
   }
   return true;
+}
+
+bool QgsAnnotationLayerRenderer::forceRasterRender() const
+{
+  return renderContext()->testFlag( QgsRenderContext::UseAdvancedEffects ) && ( !qgsDoubleNear( mLayerOpacity, 1.0 ) );
 }

--- a/src/core/annotations/qgsannotationlayerrenderer.h
+++ b/src/core/annotations/qgsannotationlayerrenderer.h
@@ -44,10 +44,12 @@ class CORE_EXPORT QgsAnnotationLayerRenderer : public QgsMapLayerRenderer
     ~QgsAnnotationLayerRenderer() override;
     QgsFeedback *feedback() const override;
     bool render() override;
+    bool forceRasterRender() const override;
 
   private:
     QVector< QgsAnnotationItem *> mItems;
     std::unique_ptr< QgsFeedback > mFeedback;
+    double mLayerOpacity = 1.0;
 
 };
 

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -47,6 +47,7 @@ QgsMeshLayerRenderer::QgsMeshLayerRenderer(
   : QgsMapLayerRenderer( layer->id(), &context )
   , mFeedback( new QgsMeshLayerRendererFeedback )
   , mRendererSettings( layer->rendererSettings() )
+  , mLayerOpacity( layer->opacity() )
 {
   // make copies for mesh data
   // cppcheck-suppress assertWithSideEffect
@@ -299,6 +300,11 @@ bool QgsMeshLayerRenderer::render()
   renderVectorDataset();
 
   return true;
+}
+
+bool QgsMeshLayerRenderer::forceRasterRender() const
+{
+  return renderContext()->testFlag( QgsRenderContext::UseAdvancedEffects ) && ( !qgsDoubleNear( mLayerOpacity, 1.0 ) );
 }
 
 void QgsMeshLayerRenderer::renderMesh()

--- a/src/core/mesh/qgsmeshlayerrenderer.h
+++ b/src/core/mesh/qgsmeshlayerrenderer.h
@@ -97,6 +97,7 @@ class QgsMeshLayerRenderer : public QgsMapLayerRenderer
     ~QgsMeshLayerRenderer() override = default;
     QgsFeedback *feedback() const override;
     bool render() override;
+    bool forceRasterRender() const override;
 
   private:
     void renderMesh();
@@ -151,6 +152,10 @@ class QgsMeshLayerRenderer : public QgsMapLayerRenderer
 
     // output screen size
     QSize mOutputSize;
+
+  private:
+
+    double mLayerOpacity = 1.0;
 };
 
 

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -151,6 +151,13 @@ bool QgsPointCloudLayerRenderer::render()
   return true;
 }
 
+bool QgsPointCloudLayerRenderer::forceRasterRender() const
+{
+  // point cloud layers should always be rasterized -- we don't want to export points as vectors
+  // to formats like PDF!
+  return true;
+}
+
 QList<IndexedPointCloudNode> QgsPointCloudLayerRenderer::traverseTree( const QgsPointCloudIndex *pc,
     const QgsRenderContext &context,
     IndexedPointCloudNode n,

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.h
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.h
@@ -54,6 +54,7 @@ class CORE_EXPORT QgsPointCloudLayerRenderer: public QgsMapLayerRenderer
     ~QgsPointCloudLayerRenderer();
 
     bool render() override;
+    bool forceRasterRender() const override;
 
   private:
 

--- a/src/core/qgsmaplayerrenderer.h
+++ b/src/core/qgsmaplayerrenderer.h
@@ -19,6 +19,7 @@
 #include <QStringList>
 
 #include "qgis_core.h"
+#include "qgis_sip.h"
 
 class QgsFeedback;
 class QgsRenderContext;
@@ -65,6 +66,24 @@ class CORE_EXPORT QgsMapLayerRenderer
     virtual bool render() = 0;
 
     /**
+     * Returns TRUE if the renderer must be rendered to a raster paint device (e.g. QImage).
+     *
+     * Some layer settings require layers to be effectively "flattened" while rendering maps,
+     * which is achieved by first rendering the layer onto a raster paint device and then compositing
+     * the resultant image onto the final map render.
+     *
+     * E.g. if a layer contains features with transparency or alternative blending modes, and
+     * the effects of these opacity or blending modes should be restricted to only affect other
+     * features within the SAME layer, then a flattened raster based render is required.
+     *
+     * Subclasses should return TRUE whenever their corresponding layer settings require the
+     * layer to always be rendered using a raster paint device.
+     *
+     * \since QGIS 3.18
+     */
+    virtual bool forceRasterRender() const { return false; }
+
+    /**
      * Access to feedback object of the layer renderer (may be NULLPTR)
      * \since QGIS 3.0
      */
@@ -82,6 +101,14 @@ class CORE_EXPORT QgsMapLayerRenderer
      * \since QGIS 3.10
      */
     QgsRenderContext *renderContext() { return mContext; }
+
+    /**
+     * Returns the render context associated with the renderer.
+     *
+     * \note Not available in Python bindings
+     * \since QGIS 3.18
+     */
+    const QgsRenderContext *renderContext() const SIP_SKIP { return mContext; }
 
   protected:
     QStringList mErrors;

--- a/src/core/qgsmaprendererjob.h
+++ b/src/core/qgsmaprendererjob.h
@@ -417,8 +417,6 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
      */
     static bool reprojectToLayerExtent( const QgsMapLayer *ml, const QgsCoordinateTransform &ct, QgsRectangle &extent, QgsRectangle &r2 );
 
-    bool needTemporaryImage( QgsMapLayer *ml );
-
     const QgsFeatureFilterProvider *mFeatureFilterProvider = nullptr;
 
     //! Convenient method to allocate a new image and stack an error if not enough memory is available

--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -127,6 +127,20 @@ QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer *layer, QgsRender
   prepareDiagrams( layer, mAttrNames );
 
   mClippingRegions = QgsMapClippingUtils::collectClippingRegionsForLayer( context, layer );
+
+  if ( mRenderer && mRenderer->forceRasterRender() )
+  {
+    //raster rendering is forced for this layer
+    mForceRasterRender = true;
+  }
+  if ( context.testFlag( QgsRenderContext::UseAdvancedEffects ) &&
+       ( ( layer->blendMode() != QPainter::CompositionMode_SourceOver )
+         || ( layer->featureBlendMode() != QPainter::CompositionMode_SourceOver )
+         || ( !qgsDoubleNear( layer->opacity(), 1.0 ) ) ) )
+  {
+    //layer properties require rasterization
+    mForceRasterRender = true;
+  }
 }
 
 QgsVectorLayerRenderer::~QgsVectorLayerRenderer()
@@ -138,6 +152,11 @@ QgsVectorLayerRenderer::~QgsVectorLayerRenderer()
 QgsFeedback *QgsVectorLayerRenderer::feedback() const
 {
   return mInterruptionChecker.get();
+}
+
+bool QgsVectorLayerRenderer::forceRasterRender() const
+{
+  return mForceRasterRender;
 }
 
 bool QgsVectorLayerRenderer::render()

--- a/src/core/qgsvectorlayerrenderer.h
+++ b/src/core/qgsvectorlayerrenderer.h
@@ -78,6 +78,7 @@ class QgsVectorLayerRenderer : public QgsMapLayerRenderer
     QgsVectorLayerRenderer( QgsVectorLayer *layer, QgsRenderContext &context );
     ~QgsVectorLayerRenderer() override;
     QgsFeedback *feedback() const override;
+    bool forceRasterRender() const override;
 
     /**
      * Returns the feature renderer.
@@ -167,6 +168,7 @@ class QgsVectorLayerRenderer : public QgsMapLayerRenderer
     bool mApplyClipGeometries = false;
     QgsGeometry mLabelClipFeatureGeom;
     bool mApplyLabelClipGeometries = false;
+    bool mForceRasterRender = false;
 
 };
 

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -339,3 +339,9 @@ QgsFeedback *QgsRasterLayerRenderer::feedback() const
   return mFeedback;
 }
 
+bool QgsRasterLayerRenderer::forceRasterRender() const
+{
+  // preview of intermediate raster rendering results requires a temporary output image
+  return renderContext()->testFlag( QgsRenderContext::RenderPartialOutput );
+}
+

--- a/src/core/raster/qgsrasterlayerrenderer.h
+++ b/src/core/raster/qgsrasterlayerrenderer.h
@@ -75,6 +75,7 @@ class CORE_EXPORT QgsRasterLayerRenderer : public QgsMapLayerRenderer
 
     bool render() override;
     QgsFeedback *feedback() const override;
+    bool forceRasterRender() const override;
 
   private:
 

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -39,6 +39,7 @@ QgsVectorTileLayerRenderer::QgsVectorTileLayerRenderer( QgsVectorTileLayer *laye
   , mRenderer( layer->renderer()->clone() )
   , mDrawTileBoundaries( layer->isTileBorderRenderingEnabled() )
   , mFeedback( new QgsFeedback )
+  , mLayerOpacity( layer->opacity() )
 {
 
   QgsDataSourceUri dsUri;
@@ -191,6 +192,11 @@ bool QgsVectorTileLayerRenderer::render()
   QgsDebugMsgLevel( QStringLiteral( "Total time: %1" ).arg( tTotal.elapsed() / 1000. ), 2 );
 
   return !ctx.renderingStopped();
+}
+
+bool QgsVectorTileLayerRenderer::forceRasterRender() const
+{
+  return renderContext()->testFlag( QgsRenderContext::UseAdvancedEffects ) && ( !qgsDoubleNear( mLayerOpacity, 1.0 ) );
 }
 
 void QgsVectorTileLayerRenderer::decodeAndDrawTile( const QgsVectorTileRawData &rawTile )

--- a/src/core/vectortile/qgsvectortilelayerrenderer.h
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.h
@@ -46,6 +46,7 @@ class QgsVectorTileLayerRenderer : public QgsMapLayerRenderer
 
     virtual bool render() override;
     virtual QgsFeedback *feedback() const override { return mFeedback.get(); }
+    bool forceRasterRender() const override;
 
   private:
     void decodeAndDrawTile( const QgsVectorTileRawData &rawTile );
@@ -98,6 +99,7 @@ class QgsVectorTileLayerRenderer : public QgsMapLayerRenderer
     int mTotalDrawTime = 0;
 
     QList< QgsMapClippingRegion > mClippingRegions;
+    double mLayerOpacity = 1.0;
 };
 
 


### PR DESCRIPTION
This avoids the generic QgsMapRendererJob class from having hardcoded
layer type dependent behavior, and instead moves that layer-type specific
logic to the subclasses designed for that particular layer
