### PR TITLE
Align 3d point cloud renderer settings with 2d

### DIFF
--- a/python/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
+++ b/python/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
@@ -40,22 +40,18 @@ class QgsPointCloud3DSymbol : QgsAbstract3DSymbol /Abstract/
       RgbRendering
     };
 
-    static QString renderingStyletoString( RenderingStyle renderingStyle );
-%Docstring
-Converts from ``renderingStyle`` enum to a string
-%End
-    static RenderingStyle renderingStylefromString( const QString &str );
-%Docstring
-Converts from a string to rendering style
-%End
-
-    QgsPointCloud3DSymbol( QgsPointCloud3DSymbol::RenderingStyle style );
+    QgsPointCloud3DSymbol();
 %Docstring
 Constructor for QgsPointCloud3DSymbol
 %End
     ~QgsPointCloud3DSymbol();
 
     virtual QString type() const;
+
+    virtual QString symbolType() const = 0;
+%Docstring
+Returns a unique string identifier of the symbol type.
+%End
 
     float pointSize() const;
 %Docstring
@@ -69,11 +65,6 @@ Returns the point size of the point cloud
 Sets the point size
 
 .. seealso:: :py:func:`pointSize`
-%End
-
-    QgsPointCloud3DSymbol::RenderingStyle renderingStyle() const;
-%Docstring
-Returns the rendering style used to render the point cloud
 %End
 
     virtual unsigned int byteStride() = 0;
@@ -105,6 +96,8 @@ class QgsSingleColorPointCloud3DSymbol : QgsPointCloud3DSymbol
 %Docstring
 Constructor for QgsSingleColorPointCloud3DSymbol
 %End
+
+    virtual QString symbolType() const;
 
     virtual QgsAbstract3DSymbol *clone() const /Factory/;
 
@@ -156,6 +149,8 @@ Constructor for QgsColorRampPointCloud3DSymbol
 %End
 
     virtual QgsAbstract3DSymbol *clone() const /Factory/;
+
+    virtual QString symbolType() const;
 
 
     virtual void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const;
@@ -237,6 +232,8 @@ class QgsRgbPointCloud3DSymbol : QgsPointCloud3DSymbol
 %Docstring
 Constructor for :py:class:`QgsRGBPointCloud3DSymbol`
 %End
+
+    virtual QString symbolType() const;
 
     virtual QgsAbstract3DSymbol *clone() const /Factory/;
 

--- a/src/3d/qgspointcloudlayer3drenderer.cpp
+++ b/src/3d/qgspointcloudlayer3drenderer.cpp
@@ -118,7 +118,7 @@ void QgsPointCloudLayer3DRenderer::writeXml( QDomElement &elem, const QgsReadWri
   QDomElement elemSymbol = doc.createElement( QStringLiteral( "symbol" ) );
   if ( mSymbol )
   {
-    elemSymbol.setAttribute( QStringLiteral( "type" ), mSymbol->type() );
+    elemSymbol.setAttribute( QStringLiteral( "type" ), mSymbol->symbolType() );
     mSymbol->writeXml( elemSymbol, context );
   }
   elem.appendChild( elemSymbol );
@@ -129,22 +129,17 @@ void QgsPointCloudLayer3DRenderer::readXml( const QDomElement &elem, const QgsRe
   mLayerRef = QgsMapLayerRef( elem.attribute( QStringLiteral( "layer" ) ) );
 
   QDomElement elemSymbol = elem.firstChildElement( QStringLiteral( "symbol" ) );
-  QgsPointCloud3DSymbol::RenderingStyle renderingStyle = QgsPointCloud3DSymbol::renderingStylefromString( elemSymbol.attribute( QStringLiteral( "rendering-style" ) ) );
-  switch ( renderingStyle )
-  {
-    case QgsPointCloud3DSymbol::RenderingStyle::NoRendering:
-      mSymbol.reset( nullptr );
-      break;
-    case QgsPointCloud3DSymbol::RenderingStyle::SingleColor:
-      mSymbol.reset( new QgsSingleColorPointCloud3DSymbol );
-      break;
-    case QgsPointCloud3DSymbol::RenderingStyle::ColorRamp:
-      mSymbol.reset( new QgsColorRampPointCloud3DSymbol );
-      break;
-    case QgsPointCloud3DSymbol::RenderingStyle::RgbRendering:
-      mSymbol.reset( new QgsRgbPointCloud3DSymbol );
-      break;
-  }
+
+  const QString symbolType = elemSymbol.attribute( QStringLiteral( "type" ) );
+  if ( symbolType == QLatin1String( "single-color" ) )
+    mSymbol.reset( new QgsSingleColorPointCloud3DSymbol );
+  else if ( symbolType == QLatin1String( "color-ramp" ) )
+    mSymbol.reset( new QgsColorRampPointCloud3DSymbol );
+  else if ( symbolType == QLatin1String( "rgb" ) )
+    mSymbol.reset( new QgsRgbPointCloud3DSymbol );
+  else
+    mSymbol.reset();
+
   if ( mSymbol )
     mSymbol->readXml( elemSymbol, context );
 }

--- a/src/3d/qgspointcloudlayerchunkloader_p.cpp
+++ b/src/3d/qgspointcloudlayerchunkloader_p.cpp
@@ -60,20 +60,13 @@ QgsPointCloudLayerChunkLoader::QgsPointCloudLayerChunkLoader( const QgsPointClou
   Q_ASSERT( pc->hasNode( pcNode ) );
 
   QgsDebugMsgLevel( QStringLiteral( "loading entity %1" ).arg( node->tileId().text() ), 2 );
-  switch ( symbol->renderingStyle() )
-  {
-    case QgsPointCloud3DSymbol::RenderingStyle::NoRendering:
-      break;
-    case QgsPointCloud3DSymbol::RenderingStyle::SingleColor:
-      mHandler.reset( new QgsSingleColorPointCloud3DSymbolHandler() );
-      break;
-    case QgsPointCloud3DSymbol::RenderingStyle::ColorRamp:
-      mHandler.reset( new QgsColorRampPointCloud3DSymbolHandler() );
-      break;
-    case QgsPointCloud3DSymbol::RenderingStyle::RgbRendering:
-      mHandler.reset( new QgsRGBPointCloud3DSymbolHandler() );
-      break;
-  }
+
+  if ( symbol->symbolType() == QLatin1String( "single-color" ) )
+    mHandler.reset( new QgsSingleColorPointCloud3DSymbolHandler() );
+  else if ( symbol->symbolType() == QLatin1String( "color-ramp" ) )
+    mHandler.reset( new QgsColorRampPointCloud3DSymbolHandler() );
+  else if ( symbol->symbolType() == QLatin1String( "rgb" ) )
+    mHandler.reset( new QgsRGBPointCloud3DSymbolHandler() );
 
   //
   // this will be run in a background thread

--- a/src/3d/symbols/qgspointcloud3dsymbol.h
+++ b/src/3d/symbols/qgspointcloud3dsymbol.h
@@ -52,17 +52,17 @@ class _3D_EXPORT QgsPointCloud3DSymbol : public QgsAbstract3DSymbol SIP_ABSTRACT
       RgbRendering
     };
 
-    //! Converts from \a renderingStyle enum to a string
-    static QString renderingStyletoString( RenderingStyle renderingStyle );
-    //! Converts from a string to rendering style
-    static RenderingStyle renderingStylefromString( const QString &str );
-
     //! Constructor for QgsPointCloud3DSymbol
-    QgsPointCloud3DSymbol( QgsPointCloud3DSymbol::RenderingStyle style );
+    QgsPointCloud3DSymbol();
     //! Destructor for QgsPointCloud3DSymbol
     ~QgsPointCloud3DSymbol() override;
 
     QString type() const override { return "pointcloud"; }
+
+    /**
+     * Returns a unique string identifier of the symbol type.
+     */
+    virtual QString symbolType() const = 0;
 
     /**
      * Returns the point size of the point cloud
@@ -76,16 +76,12 @@ class _3D_EXPORT QgsPointCloud3DSymbol : public QgsAbstract3DSymbol SIP_ABSTRACT
      */
     void setPointSize( float size );
 
-    //! Returns the rendering style used to render the point cloud
-    QgsPointCloud3DSymbol::RenderingStyle renderingStyle() const { return mRenderingStyle; }
-
     //! Returns the byte stride for the geometries used to for the vertex buffer
     virtual unsigned int byteStride() = 0;
     //! Used to fill material object with necessary QParameters (and consequently opengl uniforms)
     virtual void fillMaterial( Qt3DRender::QMaterial *material ) = 0 SIP_SKIP;
 
   protected:
-    QgsPointCloud3DSymbol::RenderingStyle mRenderingStyle = QgsPointCloud3DSymbol::NoRendering;
     float mPointSize = 2.0;
 };
 
@@ -104,6 +100,7 @@ class _3D_EXPORT QgsSingleColorPointCloud3DSymbol : public QgsPointCloud3DSymbol
     //! Constructor for QgsSingleColorPointCloud3DSymbol
     QgsSingleColorPointCloud3DSymbol();
 
+    QString symbolType() const override;
     QgsAbstract3DSymbol *clone() const override SIP_FACTORY;
 
     void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const override;
@@ -126,7 +123,7 @@ class _3D_EXPORT QgsSingleColorPointCloud3DSymbol : public QgsPointCloud3DSymbol
 
 
   private:
-    QColor mSingleColor = Qt::blue;
+    QColor mSingleColor = QColor( 0, 0, 255 );
 };
 
 /**
@@ -145,6 +142,7 @@ class _3D_EXPORT QgsColorRampPointCloud3DSymbol : public QgsPointCloud3DSymbol
     QgsColorRampPointCloud3DSymbol();
 
     QgsAbstract3DSymbol *clone() const override SIP_FACTORY;
+    QString symbolType() const override;
 
     void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const override;
     void readXml( const QDomElement &elem, const QgsReadWriteContext &context ) override;
@@ -216,6 +214,7 @@ class _3D_EXPORT QgsRgbPointCloud3DSymbol : public QgsPointCloud3DSymbol
     //! Constructor for QgsRGBPointCloud3DSymbol
     QgsRgbPointCloud3DSymbol();
 
+    QString symbolType() const override;
     QgsAbstract3DSymbol *clone() const override SIP_FACTORY;
 
     void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const override;

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -30,6 +30,9 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
 
   mRenderingParameterComboBox->setLayer( layer );
 
+  mSingleColorBtn->setAllowOpacity( false );
+  mSingleColorBtn->setColorDialogTitle( tr( "Select Point Color" ) );
+
   mRenderingStyleComboBox->addItem( tr( "No Rendering" ), QgsPointCloud3DSymbol::NoRendering );
   mRenderingStyleComboBox->addItem( tr( "Single Color" ), QgsPointCloud3DSymbol::SingleColor );
   mRenderingStyleComboBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "styleicons/singlebandpseudocolor.svg" ) ), tr( "Attribute by Ramp" ), QgsPointCloud3DSymbol::ColorRamp );
@@ -42,12 +45,14 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
   connect( mRenderingStyleComboBox, qgis::overload< int >::of( &QComboBox::currentIndexChanged ), this, &QgsPointCloud3DSymbolWidget::onRenderingStyleChanged );
   connect( mColorRampShaderMinMaxReloadButton, &QPushButton::clicked, this, &QgsPointCloud3DSymbolWidget::reloadColorRampShaderMinMax );
   connect( mColorRampShaderWidget, &QgsColorRampShaderWidget::widgetChanged, this, &QgsPointCloud3DSymbolWidget::emitChangedSignal );
+  connect( mSingleColorBtn, &QgsColorButton::colorChanged, this, &QgsPointCloud3DSymbolWidget::emitChangedSignal );
 }
 
 void QgsPointCloud3DSymbolWidget::setSymbol( QgsPointCloud3DSymbol *symbol )
 {
   mBlockChangedSignals++;
   mRenderingStyleComboBox->setCurrentIndex( mRenderingStyleComboBox->findData( symbol->renderingStyle() ) );
+  mStackedWidget->setCurrentIndex( static_cast< int >( symbol->renderingStyle() ) );
   if ( symbol )
   {
     switch ( symbol->renderingStyle() )

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -142,30 +142,7 @@ void QgsPointCloud3DSymbolWidget::reloadColorRampShaderMinMax()
 void QgsPointCloud3DSymbolWidget::onRenderingStyleChanged()
 {
   const QgsPointCloud3DSymbol::RenderingStyle currentStyle = static_cast< QgsPointCloud3DSymbol::RenderingStyle>( mRenderingStyleComboBox->currentData().toInt() );
-  switch ( currentStyle )
-  {
-    case QgsPointCloud3DSymbol::RenderingStyle::NoRendering:
-      mColorRampFrame->setVisible( false );
-      mSingleColorFrame->setVisible( false );
-      mPointSizeFrame->setVisible( false );
-      break;
-    case QgsPointCloud3DSymbol::RenderingStyle::SingleColor:
-      mColorRampFrame->setVisible( false );
-      mSingleColorFrame->setVisible( true );
-      mPointSizeFrame->setVisible( true );
-      break;
-    case QgsPointCloud3DSymbol::RenderingStyle::ColorRamp:
-      mColorRampFrame->setVisible( true );
-      mSingleColorFrame->setVisible( false );
-      mPointSizeFrame->setVisible( true );
-      break;
-    case QgsPointCloud3DSymbol::RenderingStyle::RgbRendering:
-      mColorRampFrame->setVisible( false );
-      mSingleColorFrame->setVisible( false );
-      mPointSizeFrame->setVisible( true );
-      break;
-  }
-
+  mStackedWidget->setCurrentIndex( static_cast< int >( currentStyle ) );
   emitChangedSignal();
 }
 

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -165,6 +165,8 @@ void QgsPointCloud3DSymbolWidget::onRenderingStyleChanged()
       mPointSizeFrame->setVisible( true );
       break;
   }
+
+  emitChangedSignal();
 }
 
 void QgsPointCloud3DSymbolWidget::emitChangedSignal()

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -38,14 +38,15 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
   if ( symbol )
     setSymbol( symbol );
 
-  connect( mPointSizeSpinBox, qgis::overload<double>::of( &QDoubleSpinBox::valueChanged ), this, &QgsPointCloud3DSymbolWidget::changed );
+  connect( mPointSizeSpinBox, qgis::overload<double>::of( &QDoubleSpinBox::valueChanged ), this, &QgsPointCloud3DSymbolWidget::emitChangedSignal );
   connect( mRenderingStyleComboBox, qgis::overload< int >::of( &QComboBox::currentIndexChanged ), this, &QgsPointCloud3DSymbolWidget::onRenderingStyleChanged );
   connect( mColorRampShaderMinMaxReloadButton, &QPushButton::clicked, this, &QgsPointCloud3DSymbolWidget::reloadColorRampShaderMinMax );
-  connect( mColorRampShaderWidget, &QgsColorRampShaderWidget::widgetChanged, this, &QgsPointCloud3DSymbolWidget::changed );
+  connect( mColorRampShaderWidget, &QgsColorRampShaderWidget::widgetChanged, this, &QgsPointCloud3DSymbolWidget::emitChangedSignal );
 }
 
 void QgsPointCloud3DSymbolWidget::setSymbol( QgsPointCloud3DSymbol *symbol )
 {
+  mBlockChangedSignals++;
   mRenderingStyleComboBox->setCurrentIndex( mRenderingStyleComboBox->findData( symbol->renderingStyle() ) );
   if ( symbol )
   {
@@ -80,6 +81,7 @@ void QgsPointCloud3DSymbolWidget::setSymbol( QgsPointCloud3DSymbol *symbol )
   }
 
   onRenderingStyleChanged();
+  mBlockChangedSignals--;
 }
 
 QgsPointCloud3DSymbol *QgsPointCloud3DSymbolWidget::symbol() const
@@ -163,4 +165,12 @@ void QgsPointCloud3DSymbolWidget::onRenderingStyleChanged()
       mPointSizeFrame->setVisible( true );
       break;
   }
+}
+
+void QgsPointCloud3DSymbolWidget::emitChangedSignal()
+{
+  if ( mBlockChangedSignals )
+    return;
+
+  emit changed();
 }

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -18,6 +18,7 @@
 #include "qgspointcloudlayer.h"
 #include "qgspointcloud3dsymbol.h"
 #include "qgspointcloudlayer3drenderer.h"
+#include "qgsapplication.h"
 
 QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *layer, QgsPointCloud3DSymbol *symbol, QWidget *parent )
   : QWidget( parent )
@@ -28,6 +29,11 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
   mPointSizeSpinBox->setClearValue( 2.0 );
 
   mRenderingParameterComboBox->setLayer( layer );
+
+  mRenderingStyleComboBox->addItem( tr( "No Rendering" ), QgsPointCloud3DSymbol::NoRendering );
+  mRenderingStyleComboBox->addItem( tr( "Single Color" ), QgsPointCloud3DSymbol::SingleColor );
+  mRenderingStyleComboBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "styleicons/singlebandpseudocolor.svg" ) ), tr( "Attribute by Ramp" ), QgsPointCloud3DSymbol::ColorRamp );
+  mRenderingStyleComboBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "styleicons/multibandcolor.svg" ) ), tr( "RGB" ), QgsPointCloud3DSymbol::RgbRendering );
 
   if ( symbol )
     setSymbol( symbol );
@@ -40,7 +46,7 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
 
 void QgsPointCloud3DSymbolWidget::setSymbol( QgsPointCloud3DSymbol *symbol )
 {
-  mRenderingStyleComboBox->setCurrentIndex( symbol ? symbol->renderingStyle() : 0 );
+  mRenderingStyleComboBox->setCurrentIndex( mRenderingStyleComboBox->findData( symbol->renderingStyle() ) );
   if ( symbol )
   {
     switch ( symbol->renderingStyle() )
@@ -73,13 +79,13 @@ void QgsPointCloud3DSymbolWidget::setSymbol( QgsPointCloud3DSymbol *symbol )
     }
   }
 
-  onRenderingStyleChanged( mRenderingStyleComboBox->currentIndex() );
+  onRenderingStyleChanged();
 }
 
 QgsPointCloud3DSymbol *QgsPointCloud3DSymbolWidget::symbol() const
 {
   QgsPointCloud3DSymbol *retSymb = nullptr;
-  QgsPointCloud3DSymbol::RenderingStyle renderingStyle = static_cast< QgsPointCloud3DSymbol::RenderingStyle >( mRenderingStyleComboBox->currentIndex() );
+  QgsPointCloud3DSymbol::RenderingStyle renderingStyle = static_cast< QgsPointCloud3DSymbol::RenderingStyle >( mRenderingStyleComboBox->currentData().toInt() );
 
   switch ( renderingStyle )
   {
@@ -131,9 +137,9 @@ void QgsPointCloud3DSymbolWidget::reloadColorRampShaderMinMax()
   mColorRampShaderWidget->classify();
 }
 
-void QgsPointCloud3DSymbolWidget::onRenderingStyleChanged( int current )
+void QgsPointCloud3DSymbolWidget::onRenderingStyleChanged()
 {
-  QgsPointCloud3DSymbol::RenderingStyle currentStyle = static_cast< QgsPointCloud3DSymbol::RenderingStyle >( current );
+  const QgsPointCloud3DSymbol::RenderingStyle currentStyle = static_cast< QgsPointCloud3DSymbol::RenderingStyle>( mRenderingStyleComboBox->currentData().toInt() );
   switch ( currentStyle )
   {
     case QgsPointCloud3DSymbol::RenderingStyle::NoRendering:

--- a/src/app/3d/qgspointcloud3dsymbolwidget.h
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.h
@@ -36,6 +36,7 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
   private slots:
     void reloadColorRampShaderMinMax();
     void onRenderingStyleChanged();
+    void emitChangedSignal();
 
   signals:
     void changed();
@@ -44,6 +45,7 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
     void setColorRampMinMax( double min, double max );
 
   private:
+    int mBlockChangedSignals = 0;
     QgsPointCloudLayer *mLayer = nullptr;
 
 };

--- a/src/app/3d/qgspointcloud3dsymbolwidget.h
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.h
@@ -37,6 +37,9 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
     void reloadColorRampShaderMinMax();
     void onRenderingStyleChanged();
     void emitChangedSignal();
+    void rampAttributeChanged();
+    void setMinMaxFromLayer();
+    void minMaxChanged();
 
   signals:
     void changed();
@@ -47,6 +50,11 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
   private:
     int mBlockChangedSignals = 0;
     QgsPointCloudLayer *mLayer = nullptr;
+
+    bool mBlockMinMaxChanged = false;
+
+    double mProviderMin = std::numeric_limits< double >::quiet_NaN();
+    double mProviderMax = std::numeric_limits< double >::quiet_NaN();
 
 };
 

--- a/src/app/3d/qgspointcloud3dsymbolwidget.h
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.h
@@ -17,6 +17,7 @@
 #define QGSPOINTCLOUD3DSYMBOLWIDGET_H
 
 #include "ui_qgspointcloud3dsymbolwidget.h"
+#include "qgspointcloud3dsymbol.h"
 
 class QgsPointCloudLayer;
 class QgsPointCloud3DSymbol;
@@ -34,7 +35,7 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
 
   private slots:
     void reloadColorRampShaderMinMax();
-    void onRenderingStyleChanged( int current );
+    void onRenderingStyleChanged();
 
   signals:
     void changed();

--- a/src/gui/pointcloud/qgspointcloudattributebyramprendererwidget.cpp
+++ b/src/gui/pointcloud/qgspointcloudattributebyramprendererwidget.cpp
@@ -29,7 +29,7 @@ QgsPointCloudAttributeByRampRendererWidget::QgsPointCloudAttributeByRampRenderer
 {
   setupUi( this );
 
-  mAttributeComboBox->setAllowEmptyAttributeName( true );
+  mAttributeComboBox->setAllowEmptyAttributeName( false );
   mAttributeComboBox->setFilters( QgsPointCloudAttributeProxyModel::Numeric );
 
   if ( layer )
@@ -105,6 +105,7 @@ void QgsPointCloudAttributeByRampRendererWidget::attributeChanged()
     }
   }
   mScalarRecalculateMinMaxButton->setEnabled( !std::isnan( mProviderMin ) && !std::isnan( mProviderMax ) );
+  emitWidgetChanged();
 }
 
 void QgsPointCloudAttributeByRampRendererWidget::setMinMaxFromLayer()

--- a/src/gui/raster/qgscolorrampshaderwidget.cpp
+++ b/src/gui/raster/qgscolorrampshaderwidget.cpp
@@ -260,7 +260,9 @@ void QgsColorRampShaderWidget::dumpClasses()
   {
     const auto labelData { mColormapTreeWidget->model()->itemData( mColormapTreeWidget->model()->index( row, LabelColumn ) ) };
     const auto valueData { mColormapTreeWidget->model()->itemData( mColormapTreeWidget->model()->index( row, ValueColumn ) ) };
-    qDebug() << "Class" << row << ":" <<  labelData[ Qt::ItemDataRole::DisplayRole ] << valueData[ Qt::ItemDataRole::DisplayRole ];
+    QgsDebugMsgLevel( QStringLiteral( "Class %1 : %2 %3" ).arg( row )
+                      .arg( labelData[ Qt::ItemDataRole::DisplayRole ].toString(),
+                            valueData[ Qt::ItemDataRole::DisplayRole ].toString() ), 2 );
   }
 }
 #endif

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -11,144 +11,19 @@
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="0" colspan="4">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item row="5" column="0" colspan="4">
-    <widget class="QFrame" name="mColorRampFrame">
-     <layout class="QGridLayout" name="gridLayout_2">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <item row="1" column="2">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Max</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="mColorRampShaderMinEdit">
-        <property name="minimum">
-         <double>-10000000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>10000000.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>0.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QDoubleSpinBox" name="mColorRampShaderMaxEdit">
-        <property name="minimum">
-         <double>-10000000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>10000000.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>1.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Min</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="4">
-       <widget class="QPushButton" name="mColorRampShaderMinMaxReloadButton">
-        <property name="text">
-         <string>Apply</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2" colspan="3">
-       <widget class="QgsPointCloudAttributeComboBox" name="mRenderingParameterComboBox"/>
-      </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Rendering parameter</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="5">
-       <widget class="QgsColorRampShaderWidget" name="mColorRampShaderWidget" native="true"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="2" colspan="2">
-    <widget class="QComboBox" name="mRenderingStyleComboBox"/>
-   </item>
-   <item row="7" column="0" colspan="4">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Rendering style</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="4">
-    <widget class="QFrame" name="mSingleColorFrame">
-     <layout class="QGridLayout" name="gridLayout_3">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <item row="1" column="1">
-       <widget class="QgsColorButton" name="mSingleColorBtn">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" rowspan="2">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Single Color</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="4">
-    <widget class="QFrame" name="mPointSizeFrame">
-     <layout class="QGridLayout" name="gridLayout_4">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-     </layout>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="4">
     <widget class="QGroupBox" name="mLayerRenderingGroupBox_2">
      <property name="title">
       <string>Point Symbol</string>
@@ -184,6 +59,189 @@
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item row="1" column="2" colspan="2">
+    <widget class="QComboBox" name="mRenderingStyleComboBox"/>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Rendering style</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="4">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="4">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="0" colspan="4">
+    <widget class="QStackedWidget" name="mStackedWidget">
+     <widget class="QWidget" name="page"/>
+     <widget class="QWidget" name="page_3">
+      <widget class="QLabel" name="label_6">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>30</y>
+         <width>263</width>
+         <height>32</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Single Color</string>
+       </property>
+      </widget>
+      <widget class="QgsColorButton" name="mSingleColorBtn">
+       <property name="geometry">
+        <rect>
+         <x>269</x>
+         <y>36</y>
+         <width>262</width>
+         <height>26</height>
+        </rect>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+      </widget>
+     </widget>
+     <widget class="QWidget" name="page_4">
+      <widget class="QLabel" name="label_5">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>20</y>
+         <width>214</width>
+         <height>27</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Rendering parameter</string>
+       </property>
+      </widget>
+      <widget class="QgsPointCloudAttributeComboBox" name="mRenderingParameterComboBox">
+       <property name="geometry">
+        <rect>
+         <x>230</x>
+         <y>20</y>
+         <width>311</width>
+         <height>27</height>
+        </rect>
+       </property>
+      </widget>
+      <widget class="QPushButton" name="mColorRampShaderMinMaxReloadButton">
+       <property name="geometry">
+        <rect>
+         <x>450</x>
+         <y>40</y>
+         <width>90</width>
+         <height>27</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Apply</string>
+       </property>
+      </widget>
+      <widget class="QDoubleSpinBox" name="mColorRampShaderMaxEdit">
+       <property name="geometry">
+        <rect>
+         <x>326</x>
+         <y>40</y>
+         <width>118</width>
+         <height>28</height>
+        </rect>
+       </property>
+       <property name="minimum">
+        <double>-10000000.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>10000000.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_3">
+       <property name="geometry">
+        <rect>
+         <x>9</x>
+         <y>40</y>
+         <width>90</width>
+         <height>28</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Min</string>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_2">
+       <property name="geometry">
+        <rect>
+         <x>229</x>
+         <y>40</y>
+         <width>91</width>
+         <height>28</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Max</string>
+       </property>
+      </widget>
+      <widget class="QDoubleSpinBox" name="mColorRampShaderMinEdit">
+       <property name="geometry">
+        <rect>
+         <x>105</x>
+         <y>40</y>
+         <width>118</width>
+         <height>28</height>
+        </rect>
+       </property>
+       <property name="minimum">
+        <double>-10000000.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>10000000.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>0.000000000000000</double>
+       </property>
+      </widget>
+      <widget class="QgsColorRampShaderWidget" name="mColorRampShaderWidget" native="true">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>70</y>
+         <width>531</width>
+         <height>77</height>
+        </rect>
+       </property>
+      </widget>
+     </widget>
+     <widget class="QWidget" name="page_5"/>
+     <widget class="QWidget" name="page_2"/>
     </widget>
    </item>
   </layout>

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -18,61 +18,6 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0" colspan="4">
-    <widget class="QFrame" name="mPointSizeFrame">
-     <layout class="QGridLayout" name="gridLayout_4">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Point size</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QgsDoubleSpinBox" name="mPointSizeSpinBox">
-        <property name="maximum">
-         <double>10.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>2.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="4">
-    <widget class="QFrame" name="mSingleColorFrame">
-     <layout class="QGridLayout" name="gridLayout_3">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <item row="1" column="1">
-       <widget class="QgsColorButton" name="mSingleColorBtn">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" rowspan="2">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Single Color</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="5" column="0" colspan="4">
     <widget class="QFrame" name="mColorRampFrame">
      <layout class="QGridLayout" name="gridLayout_2">
@@ -142,9 +87,113 @@
      </layout>
     </widget>
    </item>
+   <item row="1" column="2" colspan="2">
+    <widget class="QComboBox" name="mRenderingStyleComboBox"/>
+   </item>
+   <item row="7" column="0" colspan="4">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Rendering style</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="4">
+    <widget class="QFrame" name="mSingleColorFrame">
+     <layout class="QGridLayout" name="gridLayout_3">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <item row="1" column="1">
+       <widget class="QgsColorButton" name="mSingleColorBtn">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" rowspan="2">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Single Color</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="4">
+    <widget class="QFrame" name="mPointSizeFrame">
+     <layout class="QGridLayout" name="gridLayout_4">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+     </layout>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="4">
+    <widget class="QGroupBox" name="mLayerRenderingGroupBox_2">
+     <property name="title">
+      <string>Point Symbol</string>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5" columnstretch="1,2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>3</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="lblTransparency_4">
+        <property name="text">
+         <string>Point size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsDoubleSpinBox" name="mPointSizeSpinBox">
+        <property name="maximum">
+         <double>10.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>2.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsPointCloudAttributeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgspointcloudattributecombobox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
@@ -153,7 +202,7 @@
   <customwidget>
    <class>QgsColorRampShaderWidget</class>
    <extends>QWidget</extends>
-   <header>qgscolorrampshaderwidget.h</header>
+   <header>raster/qgscolorrampshaderwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -161,11 +210,6 @@
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsPointCloudAttributeComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgspointcloudattributecombobox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -23,7 +23,7 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="5" column="0" colspan="4">
+   <item row="3" column="0" colspan="4">
     <widget class="QGroupBox" name="mLayerRenderingGroupBox_2">
      <property name="title">
       <string>Point Symbol</string>
@@ -64,41 +64,26 @@
    <item row="1" column="2" colspan="2">
     <widget class="QComboBox" name="mRenderingStyleComboBox"/>
    </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Rendering style</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="0" colspan="4">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="4">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="3" column="0" colspan="4">
     <widget class="QStackedWidget" name="mStackedWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>3</number>
      </property>
-     <widget class="QWidget" name="page"/>
-     <widget class="QWidget" name="page_3">
+     <widget class="QWidget" name="noRendererPage"/>
+     <widget class="QWidget" name="singleColorRendererPage">
       <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item row="0" column="0">
         <widget class="QLabel" name="label_6">
          <property name="text">
@@ -134,120 +119,100 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="page_4">
-      <widget class="QLabel" name="label_5">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>20</y>
-         <width>214</width>
-         <height>27</height>
-        </rect>
+     <widget class="QWidget" name="colorRampRendererPage">
+      <layout class="QGridLayout" name="gridLayout_3" rowstretch="0,0,1" columnstretch="0,1">
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-       <property name="text">
-        <string>Rendering parameter</string>
+       <property name="topMargin">
+        <number>0</number>
        </property>
-      </widget>
-      <widget class="QgsPointCloudAttributeComboBox" name="mRenderingParameterComboBox">
-       <property name="geometry">
-        <rect>
-         <x>230</x>
-         <y>20</y>
-         <width>311</width>
-         <height>27</height>
-        </rect>
+       <property name="rightMargin">
+        <number>0</number>
        </property>
-      </widget>
-      <widget class="QPushButton" name="mColorRampShaderMinMaxReloadButton">
-       <property name="geometry">
-        <rect>
-         <x>450</x>
-         <y>40</y>
-         <width>90</width>
-         <height>27</height>
-        </rect>
+       <property name="bottomMargin">
+        <number>0</number>
        </property>
-       <property name="text">
-        <string>Apply</string>
-       </property>
-      </widget>
-      <widget class="QDoubleSpinBox" name="mColorRampShaderMaxEdit">
-       <property name="geometry">
-        <rect>
-         <x>326</x>
-         <y>40</y>
-         <width>118</width>
-         <height>28</height>
-        </rect>
-       </property>
-       <property name="minimum">
-        <double>-10000000.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>10000000.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_3">
-       <property name="geometry">
-        <rect>
-         <x>9</x>
-         <y>40</y>
-         <width>90</width>
-         <height>28</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Min</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_2">
-       <property name="geometry">
-        <rect>
-         <x>229</x>
-         <y>40</y>
-         <width>91</width>
-         <height>28</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Max</string>
-       </property>
-      </widget>
-      <widget class="QDoubleSpinBox" name="mColorRampShaderMinEdit">
-       <property name="geometry">
-        <rect>
-         <x>105</x>
-         <y>40</y>
-         <width>118</width>
-         <height>28</height>
-        </rect>
-       </property>
-       <property name="minimum">
-        <double>-10000000.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>10000000.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>0.000000000000000</double>
-       </property>
-      </widget>
-      <widget class="QgsColorRampShaderWidget" name="mColorRampShaderWidget" native="true">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>70</y>
-         <width>531</width>
-         <height>77</height>
-        </rect>
-       </property>
-      </widget>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_5">
+         <property name="text">
+          <string>Attribute</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QgsPointCloudAttributeComboBox" name="mRenderingParameterComboBox"/>
+       </item>
+       <item row="1" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1,0,1,0">
+         <item>
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Min</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="mColorRampShaderMinEdit">
+           <property name="decimals">
+            <number>6</number>
+           </property>
+           <property name="minimum">
+            <double>-9999999999.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>9999999999.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>0.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Max</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="mColorRampShaderMaxEdit">
+           <property name="decimals">
+            <number>6</number>
+           </property>
+           <property name="minimum">
+            <double>-9999999999.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>9999999999.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>1.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="mScalarRecalculateMinMaxButton">
+           <property name="text">
+            <string>Load</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <widget class="QgsColorRampShaderWidget" name="mColorRampShaderWidget" native="true"/>
+       </item>
+      </layout>
      </widget>
-     <widget class="QWidget" name="page_5"/>
-     <widget class="QWidget" name="page_2"/>
+     <widget class="QWidget" name="rgbRendererPage"/>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Rendering style</string>
+     </property>
     </widget>
    </item>
   </layout>

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -93,40 +93,46 @@
    </item>
    <item row="3" column="0" colspan="4">
     <widget class="QStackedWidget" name="mStackedWidget">
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
      <widget class="QWidget" name="page"/>
      <widget class="QWidget" name="page_3">
-      <widget class="QLabel" name="label_6">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>30</y>
-         <width>263</width>
-         <height>32</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Single Color</string>
-       </property>
-      </widget>
-      <widget class="QgsColorButton" name="mSingleColorBtn">
-       <property name="geometry">
-        <rect>
-         <x>269</x>
-         <y>36</y>
-         <width>262</width>
-         <height>26</height>
-        </rect>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>...</string>
-       </property>
-      </widget>
+      <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string>Color</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QgsColorButton" name="mSingleColorBtn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>...</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </widget>
      <widget class="QWidget" name="page_4">
       <widget class="QLabel" name="label_5">

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -11,50 +11,6 @@
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="2" colspan="2">
-    <widget class="QComboBox" name="mRenderingStyleComboBox">
-     <item>
-      <property name="text">
-       <string>No Rendering</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Single color</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Color ramp</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>RGB rendering</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="4">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Rendering style</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="0" colspan="4">
     <widget class="Line" name="line">
      <property name="orientation">

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -23,7 +23,7 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="3" column="0" colspan="4">
+   <item row="3" column="0" colspan="3">
     <widget class="QGroupBox" name="mLayerRenderingGroupBox_2">
      <property name="title">
       <string>Point Symbol</string>
@@ -61,10 +61,7 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="2" colspan="2">
-    <widget class="QComboBox" name="mRenderingStyleComboBox"/>
-   </item>
-   <item row="2" column="0" colspan="4">
+   <item row="2" column="0" colspan="3">
     <widget class="QStackedWidget" name="mStackedWidget">
      <property name="currentIndex">
       <number>3</number>
@@ -208,12 +205,8 @@
      <widget class="QWidget" name="rgbRendererPage"/>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Rendering style</string>
-     </property>
-    </widget>
+   <item row="1" column="0" colspan="3">
+    <widget class="QComboBox" name="mRenderingStyleComboBox"/>
    </item>
   </layout>
  </widget>

--- a/src/ui/pointcloud/qgspointcloudattributebyramprendererwidgetbase.ui
+++ b/src/ui/pointcloud/qgspointcloudattributebyramprendererwidgetbase.ui
@@ -14,6 +14,18 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,1">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item row="1" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1,0,1,0">
      <item>

--- a/src/ui/pointcloud/qgspointcloudclassifiedrendererwidgetbase.ui
+++ b/src/ui/pointcloud/qgspointcloudclassifiedrendererwidgetbase.ui
@@ -11,6 +11,18 @@
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item row="1" column="0" colspan="2">
     <widget class="QTreeView" name="viewCategories">
      <property name="contextMenuPolicy">

--- a/src/ui/pointcloud/qgspointcloudrgbrendererwidgetbase.ui
+++ b/src/ui/pointcloud/qgspointcloudrgbrendererwidgetbase.ui
@@ -15,16 +15,16 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="leftMargin">
-    <number>3</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
-    <number>3</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>3</number>
+    <number>0</number>
    </property>
    <property name="bottomMargin">
-    <number>3</number>
+    <number>0</number>
    </property>
    <item>
     <layout class="QGridLayout" name="gridLayout">


### PR DESCRIPTION
Makes the 2d and 3d point cloud renderer settings behavior as close as possible a match for each other:


2d:

![image](https://user-images.githubusercontent.com/1829991/101110852-ac757200-3625-11eb-96b9-e3a45de6c1c1.png)

3d:

![image](https://user-images.githubusercontent.com/1829991/101110872-b5feda00-3625-11eb-9329-5948ddc284f1.png)

