### PR TITLE
Fix 3d point cloud rgb renderer handling of rgb attribute types

### DIFF
--- a/python/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
+++ b/python/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
@@ -233,8 +233,13 @@ class QgsRgbPointCloud3DSymbol : QgsPointCloud3DSymbol
 Constructor for :py:class:`QgsRGBPointCloud3DSymbol`
 %End
 
+
+
     virtual QString symbolType() const;
 
+%Docstring
+QgsRgbPointCloud3DSymbol cannot be copied - use :py:func:`~QgsRgbPointCloud3DSymbol.clone` instead
+%End
     virtual QgsAbstract3DSymbol *clone() const /Factory/;
 
 
@@ -244,6 +249,147 @@ Constructor for :py:class:`QgsRGBPointCloud3DSymbol`
 
 
     virtual unsigned int byteStride();
+
+    QString redAttribute() const;
+%Docstring
+Returns the attribute to use for the red channel.
+
+.. seealso:: :py:func:`greenAttribute`
+
+.. seealso:: :py:func:`blueAttribute`
+
+.. seealso:: :py:func:`setRedAttribute`
+%End
+
+    void setRedAttribute( const QString &attribute );
+%Docstring
+Sets the ``attribute`` to use for the red channel.
+
+.. seealso:: :py:func:`setGreenAttribute`
+
+.. seealso:: :py:func:`setBlueAttribute`
+
+.. seealso:: :py:func:`redAttribute`
+%End
+
+    QString greenAttribute() const;
+%Docstring
+Returns the attribute to use for the green channel.
+
+.. seealso:: :py:func:`redAttribute`
+
+.. seealso:: :py:func:`blueAttribute`
+
+.. seealso:: :py:func:`setGreenAttribute`
+%End
+
+    void setGreenAttribute( const QString &attribute );
+%Docstring
+Sets the ``attribute`` to use for the green channel.
+
+.. seealso:: :py:func:`setRedAttribute`
+
+.. seealso:: :py:func:`setBlueAttribute`
+
+.. seealso:: :py:func:`greenAttribute`
+%End
+
+    QString blueAttribute() const;
+%Docstring
+Returns the attribute to use for the blue channel.
+
+.. seealso:: :py:func:`greenAttribute`
+
+.. seealso:: :py:func:`redAttribute`
+
+.. seealso:: :py:func:`setBlueAttribute`
+%End
+
+    void setBlueAttribute( const QString &attribute );
+%Docstring
+Sets the ``attribute`` to use for the blue channel.
+
+.. seealso:: :py:func:`setRedAttribute`
+
+.. seealso:: :py:func:`setGreenAttribute`
+
+.. seealso:: :py:func:`blueAttribute`
+%End
+
+    QgsContrastEnhancement *redContrastEnhancement();
+%Docstring
+Returns the contrast enhancement to use for the red channel.
+
+.. seealso:: :py:func:`setRedContrastEnhancement`
+
+.. seealso:: :py:func:`greenContrastEnhancement`
+
+.. seealso:: :py:func:`blueContrastEnhancement`
+%End
+
+    void setRedContrastEnhancement( QgsContrastEnhancement *enhancement /Transfer/ );
+%Docstring
+Sets the contrast ``enhancement`` to use for the red channel.
+
+Ownership of ``enhancement`` is transferred.
+
+.. seealso:: :py:func:`redContrastEnhancement`
+
+.. seealso:: :py:func:`setGreenContrastEnhancement`
+
+.. seealso:: :py:func:`setBlueContrastEnhancement`
+%End
+
+    QgsContrastEnhancement *greenContrastEnhancement();
+%Docstring
+Returns the contrast enhancement to use for the green channel.
+
+.. seealso:: :py:func:`setGreenContrastEnhancement`
+
+.. seealso:: :py:func:`redContrastEnhancement`
+
+.. seealso:: :py:func:`blueContrastEnhancement`
+%End
+
+    void setGreenContrastEnhancement( QgsContrastEnhancement *enhancement /Transfer/ );
+%Docstring
+Sets the contrast ``enhancement`` to use for the green channel.
+
+Ownership of ``enhancement`` is transferred.
+
+.. seealso:: :py:func:`greenContrastEnhancement`
+
+.. seealso:: :py:func:`setRedContrastEnhancement`
+
+.. seealso:: :py:func:`setBlueContrastEnhancement`
+%End
+
+    QgsContrastEnhancement *blueContrastEnhancement();
+%Docstring
+Returns the contrast enhancement to use for the blue channel.
+
+.. seealso:: :py:func:`setBlueContrastEnhancement`
+
+.. seealso:: :py:func:`redContrastEnhancement`
+
+.. seealso:: :py:func:`greenContrastEnhancement`
+%End
+
+    void setBlueContrastEnhancement( QgsContrastEnhancement *enhancement /Transfer/ );
+%Docstring
+Sets the contrast ``enhancement`` to use for the blue channel.
+
+Ownership of ``enhancement`` is transferred.
+
+.. seealso:: :py:func:`blueContrastEnhancement`
+
+.. seealso:: :py:func:`setRedContrastEnhancement`
+
+.. seealso:: :py:func:`setGreenContrastEnhancement`
+%End
+
+  private:
+    QgsRgbPointCloud3DSymbol( const QgsRgbPointCloud3DSymbol &other );
 };
 
 /************************************************************************

--- a/src/3d/qgspointcloudlayer3drenderer.h
+++ b/src/3d/qgspointcloudlayer3drenderer.h
@@ -80,6 +80,42 @@ class _3D_NO_EXPORT QgsPointCloud3DRenderContext : public Qgs3DRenderContext
      */
     void setSymbol( QgsPointCloud3DSymbol *symbol );
 
+
+    /**
+     * Retrieves the attribute \a value from \a data at the specified \a offset, where
+     * \a type indicates the original data type for the attribute.
+     */
+    template <typename T>
+    void getAttribute( const char *data, std::size_t offset, QgsPointCloudAttribute::DataType type, T &value ) const
+    {
+      switch ( type )
+      {
+        case QgsPointCloudAttribute::Char:
+          value = *( data + offset );
+          return;
+
+        case QgsPointCloudAttribute::Int32:
+          value = *reinterpret_cast< const qint32 * >( data + offset );
+          return;
+
+        case QgsPointCloudAttribute::Short:
+          value = *reinterpret_cast< const short * >( data + offset );
+          return;
+
+        case QgsPointCloudAttribute::UShort:
+          value = *reinterpret_cast< const unsigned short * >( data + offset );
+          return;
+
+        case QgsPointCloudAttribute::Float:
+          value = *reinterpret_cast< const float * >( data + offset );
+          return;
+
+        case QgsPointCloudAttribute::Double:
+          value = *reinterpret_cast< const double * >( data + offset );
+          return;
+      }
+    }
+
   private:
 #ifdef SIP_RUN
     QgsPointCloudRenderContext( const QgsPointCloudRenderContext &rh );

--- a/src/3d/symbols/qgspointcloud3dsymbol.h
+++ b/src/3d/symbols/qgspointcloud3dsymbol.h
@@ -23,6 +23,7 @@
 #include "qgsabstract3dsymbol.h"
 #include "qgscolorrampshader.h"
 #include "qgspointcloudlayer.h"
+#include "qgscontrastenhancement.h"
 
 /**
  * \ingroup 3d
@@ -214,6 +215,12 @@ class _3D_EXPORT QgsRgbPointCloud3DSymbol : public QgsPointCloud3DSymbol
     //! Constructor for QgsRGBPointCloud3DSymbol
     QgsRgbPointCloud3DSymbol();
 
+    //! QgsRgbPointCloud3DSymbol cannot be copied - use clone() instead
+    QgsRgbPointCloud3DSymbol( const QgsRgbPointCloud3DSymbol &other ) = delete;
+
+    //! QgsRgbPointCloud3DSymbol cannot be copied - use clone() instead
+    QgsRgbPointCloud3DSymbol &operator=( const QgsRgbPointCloud3DSymbol &other ) = delete;
+
     QString symbolType() const override;
     QgsAbstract3DSymbol *clone() const override SIP_FACTORY;
 
@@ -222,6 +229,135 @@ class _3D_EXPORT QgsRgbPointCloud3DSymbol : public QgsPointCloud3DSymbol
 
     unsigned int byteStride() override { return 6 * sizeof( float ); }
     void fillMaterial( Qt3DRender::QMaterial *material ) override SIP_SKIP;
+
+    /**
+     * Returns the attribute to use for the red channel.
+     *
+     * \see greenAttribute()
+     * \see blueAttribute()
+     * \see setRedAttribute()
+     */
+    QString redAttribute() const;
+
+    /**
+     * Sets the \a attribute to use for the red channel.
+     *
+     * \see setGreenAttribute()
+     * \see setBlueAttribute()
+     * \see redAttribute()
+     */
+    void setRedAttribute( const QString &attribute );
+
+    /**
+     * Returns the attribute to use for the green channel.
+     *
+     * \see redAttribute()
+     * \see blueAttribute()
+     * \see setGreenAttribute()
+     */
+    QString greenAttribute() const;
+
+    /**
+     * Sets the \a attribute to use for the green channel.
+     *
+     * \see setRedAttribute()
+     * \see setBlueAttribute()
+     * \see greenAttribute()
+     */
+    void setGreenAttribute( const QString &attribute );
+
+    /**
+     * Returns the attribute to use for the blue channel.
+     *
+     * \see greenAttribute()
+     * \see redAttribute()
+     * \see setBlueAttribute()
+     */
+    QString blueAttribute() const;
+
+    /**
+     * Sets the \a attribute to use for the blue channel.
+     *
+     * \see setRedAttribute()
+     * \see setGreenAttribute()
+     * \see blueAttribute()
+     */
+    void setBlueAttribute( const QString &attribute );
+
+    /**
+     * Returns the contrast enhancement to use for the red channel.
+     *
+     * \see setRedContrastEnhancement()
+     * \see greenContrastEnhancement()
+     * \see blueContrastEnhancement()
+     */
+    QgsContrastEnhancement *redContrastEnhancement();
+
+    /**
+     * Sets the contrast \a enhancement to use for the red channel.
+     *
+     * Ownership of \a enhancement is transferred.
+     *
+     * \see redContrastEnhancement()
+     * \see setGreenContrastEnhancement()
+     * \see setBlueContrastEnhancement()
+     */
+    void setRedContrastEnhancement( QgsContrastEnhancement *enhancement SIP_TRANSFER );
+
+    /**
+     * Returns the contrast enhancement to use for the green channel.
+     *
+     * \see setGreenContrastEnhancement()
+     * \see redContrastEnhancement()
+     * \see blueContrastEnhancement()
+     */
+    QgsContrastEnhancement *greenContrastEnhancement();
+
+    /**
+     * Sets the contrast \a enhancement to use for the green channel.
+     *
+     * Ownership of \a enhancement is transferred.
+     *
+     * \see greenContrastEnhancement()
+     * \see setRedContrastEnhancement()
+     * \see setBlueContrastEnhancement()
+     */
+    void setGreenContrastEnhancement( QgsContrastEnhancement *enhancement SIP_TRANSFER );
+
+    /**
+     * Returns the contrast enhancement to use for the blue channel.
+     *
+     * \see setBlueContrastEnhancement()
+     * \see redContrastEnhancement()
+     * \see greenContrastEnhancement()
+     */
+    QgsContrastEnhancement *blueContrastEnhancement();
+
+    /**
+     * Sets the contrast \a enhancement to use for the blue channel.
+     *
+     * Ownership of \a enhancement is transferred.
+     *
+     * \see blueContrastEnhancement()
+     * \see setRedContrastEnhancement()
+     * \see setGreenContrastEnhancement()
+     */
+    void setBlueContrastEnhancement( QgsContrastEnhancement *enhancement SIP_TRANSFER );
+
+  private:
+
+#ifdef SIP_RUN
+    QgsRgbPointCloud3DSymbol( const QgsRgbPointCloud3DSymbol &other );
+#endif
+
+    QString mRedAttribute = QStringLiteral( "Red" );
+    QString mGreenAttribute = QStringLiteral( "Green" );
+    QString mBlueAttribute = QStringLiteral( "Blue" );
+
+    std::unique_ptr< QgsContrastEnhancement > mRedContrastEnhancement;
+    std::unique_ptr< QgsContrastEnhancement > mGreenContrastEnhancement;
+    std::unique_ptr< QgsContrastEnhancement > mBlueContrastEnhancement;
+
 };
 
 #endif // QGSPOINTCLOUD3DSYMBOL_H

--- a/src/app/3d/qgspointcloud3dsymbolwidget.h
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.h
@@ -41,6 +41,16 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
     void setMinMaxFromLayer();
     void minMaxChanged();
 
+    void mRedMinLineEdit_textChanged( const QString & );
+    void mRedMaxLineEdit_textChanged( const QString & );
+    void mGreenMinLineEdit_textChanged( const QString & );
+    void mGreenMaxLineEdit_textChanged( const QString & );
+    void mBlueMinLineEdit_textChanged( const QString & );
+    void mBlueMaxLineEdit_textChanged( const QString & );
+    void redAttributeChanged();
+    void greenAttributeChanged();
+    void blueAttributeChanged();
+
   signals:
     void changed();
 
@@ -49,12 +59,18 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
 
   private:
     int mBlockChangedSignals = 0;
+    int mDisableMinMaxWidgetRefresh = 0;
     QgsPointCloudLayer *mLayer = nullptr;
 
     bool mBlockMinMaxChanged = false;
 
     double mProviderMin = std::numeric_limits< double >::quiet_NaN();
     double mProviderMax = std::numeric_limits< double >::quiet_NaN();
+
+    void createValidators();
+    void setCustomMinMaxValues( QgsRgbPointCloud3DSymbol *r ) const;
+    void minMaxModified();
+    void setMinMaxValue( const QgsContrastEnhancement *ce, QLineEdit *minEdit, QLineEdit *maxEdit );
 
 };
 

--- a/src/core/pointcloud/qgspointcloudrendererregistry.cpp
+++ b/src/core/pointcloud/qgspointcloudrendererregistry.cpp
@@ -99,7 +99,7 @@ QgsPointCloudRenderer *QgsPointCloudRendererRegistry::defaultRenderer( const Qgs
       const int maxValue = std::max( blueMax.toInt(), std::max( redMax.toInt(), greenMax.toInt() ) );
       // try and guess suitable range from input max values -- we don't just take the provider max value directly here, but rather see if it's
       // likely to be 8 bit or 16 bit color values
-      const int rangeGuess = maxValue > 255 ? 65024 : 255;
+      const int rangeGuess = maxValue > 255 ? 65535 : 255;
 
       if ( rangeGuess > 255 )
       {

--- a/src/gui/pointcloud/qgspointcloudrgbrendererwidget.cpp
+++ b/src/gui/pointcloud/qgspointcloudrgbrendererwidget.cpp
@@ -221,7 +221,7 @@ void QgsPointCloudRgbRendererWidget::redAttributeChanged()
 
       // try and guess suitable range from input max values -- we don't just take the provider max value directly here, but rather see if it's
       // likely to be 8 bit or 16 bit color values
-      mRedMaxLineEdit->setText( QLocale().toString( maxValue > 255 ? 65024 : 255 ) );
+      mRedMaxLineEdit->setText( QLocale().toString( maxValue > 255 ? 65535 : 255 ) );
       mDisableMinMaxWidgetRefresh--;
       emitWidgetChanged();
     }
@@ -241,7 +241,7 @@ void QgsPointCloudRgbRendererWidget::greenAttributeChanged()
 
       // try and guess suitable range from input max values -- we don't just take the provider max value directly here, but rather see if it's
       // likely to be 8 bit or 16 bit color values
-      mGreenMaxLineEdit->setText( QLocale().toString( maxValue > 255 ? 65024 : 255 ) );
+      mGreenMaxLineEdit->setText( QLocale().toString( maxValue > 255 ? 65535 : 255 ) );
       mDisableMinMaxWidgetRefresh--;
       emitWidgetChanged();
     }
@@ -261,7 +261,7 @@ void QgsPointCloudRgbRendererWidget::blueAttributeChanged()
 
       // try and guess suitable range from input max values -- we don't just take the provider max value directly here, but rather see if it's
       // likely to be 8 bit or 16 bit color values
-      mBlueMaxLineEdit->setText( QLocale().toString( maxValue > 255 ? 65024 : 255 ) );
+      mBlueMaxLineEdit->setText( QLocale().toString( maxValue > 255 ? 65535 : 255 ) );
       mDisableMinMaxWidgetRefresh--;
       emitWidgetChanged();
     }

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>549</width>
-    <height>484</height>
+    <width>563</width>
+    <height>464</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -64,7 +64,7 @@
    <item row="2" column="0" colspan="3">
     <widget class="QStackedWidget" name="mStackedWidget">
      <property name="currentIndex">
-      <number>3</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="noRendererPage"/>
      <widget class="QWidget" name="singleColorRendererPage">
@@ -88,19 +88,6 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
-        <widget class="QgsColorButton" name="mSingleColorBtn">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>...</string>
-         </property>
-        </widget>
-       </item>
        <item row="1" column="1">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
@@ -114,10 +101,23 @@
          </property>
         </spacer>
        </item>
+       <item row="0" column="1">
+        <widget class="QgsColorButton" name="mSingleColorBtn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>...</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="colorRampRendererPage">
-      <layout class="QGridLayout" name="gridLayout_3" rowstretch="0,0,1" columnstretch="0,1">
+      <layout class="QGridLayout" name="gridLayout_3" rowstretch="0,0,0" columnstretch="0,0">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -139,6 +139,9 @@
        </item>
        <item row="0" column="1">
         <widget class="QgsPointCloudAttributeComboBox" name="mRenderingParameterComboBox"/>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <widget class="QgsColorRampShaderWidget" name="mColorRampShaderWidget" native="true"/>
        </item>
        <item row="1" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1,0,1,0">
@@ -197,12 +200,235 @@
          </item>
         </layout>
        </item>
-       <item row="2" column="0" colspan="2">
-        <widget class="QgsColorRampShaderWidget" name="mColorRampShaderWidget" native="true"/>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="rgbRendererPage">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QGridLayout" name="gridLayout_4">
+         <item row="6" column="0">
+          <widget class="QLabel" name="mContrastEnhancementAlgorithmLabel">
+           <property name="text">
+            <string>Contrast
+enhancement</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="mRedBandLabel">
+           <property name="text">
+            <string>Red band</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1" colspan="4">
+          <widget class="QComboBox" name="mContrastEnhancementAlgorithmComboBox"/>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="mRedMinLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Min</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="3">
+          <widget class="QLabel" name="mRedMaxLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Max</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLineEdit" name="mRedMinLineEdit">
+           <property name="maxLength">
+            <number>16</number>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1" colspan="4">
+          <widget class="QgsPointCloudAttributeComboBox" name="mRedAttributeComboBox"/>
+         </item>
+         <item row="5" column="1">
+          <widget class="QLabel" name="mBlueMinLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Min</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="3">
+          <widget class="QLabel" name="mBlueMaxLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Max</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1" colspan="4">
+          <widget class="QgsPointCloudAttributeComboBox" name="mGreenAttributeComboBox"/>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLabel" name="mGreenMinLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Min</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="3">
+          <widget class="QLabel" name="mGreenMaxLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Max</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1" colspan="4">
+          <widget class="QgsPointCloudAttributeComboBox" name="mBlueAttributeComboBox"/>
+         </item>
+         <item row="1" column="4">
+          <widget class="QLineEdit" name="mRedMaxLineEdit">
+           <property name="maxLength">
+            <number>16</number>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLineEdit" name="mGreenMinLineEdit">
+           <property name="maxLength">
+            <number>16</number>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="mBlueBandLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Blue band</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="2">
+          <widget class="QLineEdit" name="mBlueMinLineEdit">
+           <property name="maxLength">
+            <number>16</number>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="4">
+          <widget class="QLineEdit" name="mBlueMaxLineEdit">
+           <property name="maxLength">
+            <number>16</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="mGreenBandLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Green band</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="4">
+          <widget class="QLineEdit" name="mGreenMaxLineEdit">
+           <property name="maxLength">
+            <number>16</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="rgbRendererPage"/>
     </widget>
    </item>
    <item row="1" column="0" colspan="3">

--- a/tests/src/python/test_qgspointcloudrgbrenderer.py
+++ b/tests/src/python/test_qgspointcloudrgbrenderer.py
@@ -76,13 +76,13 @@ class TestQgsPointCloudRgbRenderer(unittest.TestCase):
 
         # for this point cloud, we should default to 0-65024 ranges with contrast enhancement
         self.assertEqual(layer.renderer().redContrastEnhancement().minimumValue(), 0)
-        self.assertEqual(layer.renderer().redContrastEnhancement().maximumValue(), 65024.0)
+        self.assertEqual(layer.renderer().redContrastEnhancement().maximumValue(), 65535.0)
         self.assertEqual(layer.renderer().redContrastEnhancement().contrastEnhancementAlgorithm(), QgsContrastEnhancement.StretchToMinimumMaximum)
         self.assertEqual(layer.renderer().greenContrastEnhancement().minimumValue(), 0)
-        self.assertEqual(layer.renderer().greenContrastEnhancement().maximumValue(), 65024.0)
+        self.assertEqual(layer.renderer().greenContrastEnhancement().maximumValue(), 65535.0)
         self.assertEqual(layer.renderer().greenContrastEnhancement().contrastEnhancementAlgorithm(), QgsContrastEnhancement.StretchToMinimumMaximum)
         self.assertEqual(layer.renderer().blueContrastEnhancement().minimumValue(), 0)
-        self.assertEqual(layer.renderer().blueContrastEnhancement().maximumValue(), 65024.0)
+        self.assertEqual(layer.renderer().blueContrastEnhancement().maximumValue(), 65535.0)
         self.assertEqual(layer.renderer().blueContrastEnhancement().contrastEnhancementAlgorithm(), QgsContrastEnhancement.StretchToMinimumMaximum)
 
     def testBasic(self):


### PR DESCRIPTION
Avoid hardcoded assumption that red/green/blue attributes are always short data types (I've some clouds here which use unsigned shorts).

Also cleanup some code to avoid multiple string comparisons in the ramp based renderer