### PR TITLE
Allow more flexibility for raster legends, and implement legend for raster contour renderer as a proof of concept

### DIFF
--- a/python/core/auto_generated/raster/qgspalettedrasterrenderer.sip.in
+++ b/python/core/auto_generated/raster/qgspalettedrasterrenderer.sip.in
@@ -86,7 +86,7 @@ Returns the raster band used for rendering the raster.
 
     virtual void writeXml( QDomDocument &doc, QDomElement &parentElem ) const;
 
-    virtual void legendSymbologyItems( QList< QPair< QString, QColor > > &symbolItems /Out/ ) const;
+    virtual QList< QPair< QString, QColor > > legendSymbologyItems() const;
 
     virtual QList<int> usesBands() const;
 

--- a/python/core/auto_generated/raster/qgsrastercontourrenderer.sip.in
+++ b/python/core/auto_generated/raster/qgsrastercontourrenderer.sip.in
@@ -48,6 +48,8 @@ Creates an instance of the renderer based on definition from XML (used by render
 
     virtual QList<int> usesBands() const;
 
+    virtual QList<QgsLayerTreeModelLegendNode *> createLegendNodes( QgsLayerTreeLayer *nodeLayer ) /Factory/;
+
 
 
     int inputBand() const;

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -297,9 +297,12 @@ This will be ``None`` if the layer is invalid.
 This is an overloaded version of the :py:func:`~QgsRasterLayer.draw` function that is called by both :py:func:`~QgsRasterLayer.draw` and thumbnailAsPixmap
 %End
 
-    QgsLegendColorList legendSymbologyItems() const;
+ QgsLegendColorList legendSymbologyItems() const /Deprecated/;
 %Docstring
-Returns a list with classification items (Text and color)
+Returns a list with classification items (Text and color).
+
+.. deprecated::
+   use QgsRasterRenderer.createLegendNodes() instead.
 %End
 
     virtual bool isSpatial() const;

--- a/python/core/auto_generated/raster/qgsrasterrenderer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterrenderer.sip.in
@@ -105,9 +105,11 @@ nodata values will be used.
     void setAlphaBand( int band );
     int alphaBand() const;
 
-    virtual void legendSymbologyItems( QList< QPair< QString, QColor > > &symbolItems /Out/ ) const;
+    virtual QList< QPair< QString, QColor > > legendSymbologyItems() const;
 %Docstring
-Gets symbology items if provided by renderer
+Returns symbology items if provided by renderer.
+
+.. seealso:: :py:func:`createLegendNodes`
 %End
 
     virtual QList<QgsLayerTreeModelLegendNode *> createLegendNodes( QgsLayerTreeLayer *nodeLayer ) /Factory/;

--- a/python/core/auto_generated/raster/qgsrasterrenderer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterrenderer.sip.in
@@ -110,6 +110,18 @@ nodata values will be used.
 Gets symbology items if provided by renderer
 %End
 
+    virtual QList<QgsLayerTreeModelLegendNode *> createLegendNodes( QgsLayerTreeLayer *nodeLayer ) /Factory/;
+%Docstring
+Creates a set of legend nodes representing the renderer.
+
+The default implementation calls :py:func:`~QgsRasterRenderer.legendSymbologyItems` and creates corresponding legend nodes for each returned
+symbology item.
+
+Subclasses can override this to return more legend nodes which better represent the renderer.
+
+.. versionadded:: 3.18
+%End
+
     virtual void readXml( const QDomElement &rendererElem );
 
 %Docstring

--- a/python/core/auto_generated/raster/qgssinglebandgrayrenderer.sip.in
+++ b/python/core/auto_generated/raster/qgssinglebandgrayrenderer.sip.in
@@ -54,7 +54,7 @@ Takes ownership
     virtual void writeXml( QDomDocument &doc, QDomElement &parentElem ) const;
 
 
-    virtual void legendSymbologyItems( QList< QPair< QString, QColor > > &symbolItems /Out/ ) const;
+    virtual QList< QPair< QString, QColor > > legendSymbologyItems() const;
 
 
     virtual QList<int> usesBands() const;

--- a/python/core/auto_generated/raster/qgssinglebandpseudocolorrenderer.sip.in
+++ b/python/core/auto_generated/raster/qgssinglebandpseudocolorrenderer.sip.in
@@ -75,7 +75,7 @@ Creates a color ramp shader
 
     virtual void writeXml( QDomDocument &doc, QDomElement &parentElem ) const;
 
-    virtual void legendSymbologyItems( QList< QPair< QString, QColor > > &symbolItems /Out/ ) const;
+    virtual QList< QPair< QString, QColor > > legendSymbologyItems() const;
 
     virtual QList<int> usesBands() const;
 

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -300,7 +300,9 @@ QgsSymbolLegendNode::QgsSymbolLegendNode( QgsLayerTreeLayer *nodeLayer, const Qg
   mSymbolMaximumSize = settings.value( "/qgis/legendsymbolMaximumSize", 20.0 ).toDouble();
 
   updateLabel();
-  connect( qobject_cast<QgsVectorLayer *>( nodeLayer->layer() ), &QgsVectorLayer::symbolFeatureCountMapChanged, this, &QgsSymbolLegendNode::updateLabel );
+  if ( QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( nodeLayer->layer() ) )
+    connect( vl, &QgsVectorLayer::symbolFeatureCountMapChanged, this, &QgsSymbolLegendNode::updateLabel );
+
   connect( nodeLayer, &QObject::destroyed, this, [ = ]() { mLayerNode = nullptr; } );
 
   if ( auto *lSymbol = mItem.symbol() )

--- a/src/core/qgsmaplayerlegend.cpp
+++ b/src/core/qgsmaplayerlegend.cpp
@@ -27,6 +27,7 @@
 #include "qgsdiagramrenderer.h"
 #include "qgssymbollayerutils.h"
 #include "qgspointcloudrenderer.h"
+#include "qgsrasterrenderer.h"
 
 QgsMapLayerLegend::QgsMapLayerLegend( QObject *parent )
   : QObject( parent )
@@ -426,28 +427,7 @@ QList<QgsLayerTreeModelLegendNode *> QgsDefaultRasterLayerLegend::createLayerTre
     nodes << new QgsWmsLegendNode( nodeLayer );
   }
 
-  QgsLegendColorList rasterItemList = mLayer->legendSymbologyItems();
-  if ( rasterItemList.isEmpty() )
-    return nodes;
-
-  // Paletted raster may have many colors, for example UInt16 may have 65536 colors
-  // and it is very slow, so we limit max count
-  int count = 0;
-  int max_count = 1000;
-
-  for ( QgsLegendColorList::const_iterator itemIt = rasterItemList.constBegin();
-        itemIt != rasterItemList.constEnd(); ++itemIt, ++count )
-  {
-    nodes << new QgsRasterSymbolLegendNode( nodeLayer, itemIt->second, itemIt->first );
-
-    if ( count == max_count )
-    {
-      QString label = tr( "following %1 items\nnot displayed" ).arg( rasterItemList.size() - max_count );
-      nodes << new QgsSimpleLegendNode( nodeLayer, label );
-      break;
-    }
-  }
-
+  nodes.append( mLayer->renderer()->createLegendNodes( nodeLayer ) );
   return nodes;
 }
 

--- a/src/core/qgsmaplayerlegend.cpp
+++ b/src/core/qgsmaplayerlegend.cpp
@@ -427,7 +427,8 @@ QList<QgsLayerTreeModelLegendNode *> QgsDefaultRasterLayerLegend::createLayerTre
     nodes << new QgsWmsLegendNode( nodeLayer );
   }
 
-  nodes.append( mLayer->renderer()->createLegendNodes( nodeLayer ) );
+  if ( mLayer->renderer() )
+    nodes.append( mLayer->renderer()->createLegendNodes( nodeLayer ) );
   return nodes;
 }
 

--- a/src/core/raster/qgspalettedrasterrenderer.cpp
+++ b/src/core/raster/qgspalettedrasterrenderer.cpp
@@ -317,14 +317,15 @@ bool QgsPalettedRasterRenderer::accept( QgsStyleEntityVisitorInterface *visitor 
   return true;
 }
 
-void QgsPalettedRasterRenderer::legendSymbologyItems( QList< QPair< QString, QColor > > &symbolItems ) const
+QList< QPair< QString, QColor > > QgsPalettedRasterRenderer::legendSymbologyItems() const
 {
-  ClassData::const_iterator it = mClassData.constBegin();
-  for ( ; it != mClassData.constEnd(); ++it )
+  QList< QPair< QString, QColor > > symbolItems;
+  for ( const QgsPalettedRasterRenderer::Class &classData : mClassData )
   {
-    QString lab = it->label.isEmpty() ? QString::number( it->value ) : it->label;
-    symbolItems << qMakePair( lab, it->color );
+    const QString lab = classData.label.isEmpty() ? QString::number( classData.value ) : classData.label;
+    symbolItems << qMakePair( lab, classData.color );
   }
+  return symbolItems;
 }
 
 QList<int> QgsPalettedRasterRenderer::usesBands() const

--- a/src/core/raster/qgspalettedrasterrenderer.h
+++ b/src/core/raster/qgspalettedrasterrenderer.h
@@ -100,7 +100,7 @@ class CORE_EXPORT QgsPalettedRasterRenderer: public QgsRasterRenderer
     int band() const { return mBand; }
 
     void writeXml( QDomDocument &doc, QDomElement &parentElem ) const override;
-    void legendSymbologyItems( QList< QPair< QString, QColor > > &symbolItems SIP_OUT ) const override;
+    QList< QPair< QString, QColor > > legendSymbologyItems() const override;
     QList<int> usesBands() const override;
     void toSld( QDomDocument &doc, QDomElement &element, const QgsStringMap &props = QgsStringMap() ) const override;
     bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;

--- a/src/core/raster/qgsrastercontourrenderer.cpp
+++ b/src/core/raster/qgsrastercontourrenderer.cpp
@@ -18,6 +18,7 @@
 #include "qgslinesymbollayer.h"
 #include "qgsreadwritecontext.h"
 #include "qgssymbollayerutils.h"
+#include "qgslayertreemodellegendnode.h"
 
 #include <gdal_alg.h>
 
@@ -213,6 +214,22 @@ QList<int> QgsRasterContourRenderer::usesBands() const
     bandList << mInputBand;
   }
   return bandList;
+}
+
+QList<QgsLayerTreeModelLegendNode *> QgsRasterContourRenderer::createLegendNodes( QgsLayerTreeLayer *nodeLayer )
+{
+  QList<QgsLayerTreeModelLegendNode *> nodes;
+
+  QgsLegendSymbolItem contourItem( mContourSymbol.get(), QString::number( mContourInterval ), QStringLiteral( "contour" ) );
+  nodes << new QgsSymbolLegendNode( nodeLayer, contourItem );
+
+  if ( mContourIndexInterval > 0 )
+  {
+    QgsLegendSymbolItem indexItem( mContourIndexSymbol.get(), QString::number( mContourIndexInterval ), QStringLiteral( "index" ) );
+    nodes << new QgsSymbolLegendNode( nodeLayer, indexItem );
+  }
+
+  return nodes;
 }
 
 void QgsRasterContourRenderer::setContourSymbol( QgsLineSymbol *symbol )

--- a/src/core/raster/qgsrastercontourrenderer.h
+++ b/src/core/raster/qgsrastercontourrenderer.h
@@ -49,6 +49,7 @@ class CORE_EXPORT QgsRasterContourRenderer : public QgsRasterRenderer
     QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback *feedback = nullptr ) override SIP_FACTORY;
 
     QList<int> usesBands() const override;
+    QList<QgsLayerTreeModelLegendNode *> createLegendNodes( QgsLayerTreeLayer *nodeLayer ) SIP_FACTORY override;
 
     //
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -300,17 +300,12 @@ void QgsRasterLayer::draw( QPainter *theQPainter,
   }
 
   QgsDebugMsgLevel( QStringLiteral( "total raster draw time (ms):     %1" ).arg( time.elapsed(), 5 ), 4 );
-} //end of draw method
+}
 
 QgsLegendColorList QgsRasterLayer::legendSymbologyItems() const
 {
-  QList< QPair< QString, QColor > > symbolList;
   QgsRasterRenderer *renderer = mPipe.renderer();
-  if ( renderer )
-  {
-    renderer->legendSymbologyItems( symbolList );
-  }
-  return symbolList;
+  return renderer ? renderer->legendSymbologyItems() : QList< QPair< QString, QColor > >();;
 }
 
 QString QgsRasterLayer::htmlMetadata() const

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -344,8 +344,12 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
                QgsRasterViewPort *myRasterViewPort,
                const QgsMapToPixel *qgsMapToPixel = nullptr );
 
-    //! Returns a list with classification items (Text and color)
-    QgsLegendColorList legendSymbologyItems() const;
+    /**
+     * Returns a list with classification items (Text and color).
+     *
+     * \deprecated use QgsRasterRenderer::createLegendNodes() instead.
+     */
+    Q_DECL_DEPRECATED QgsLegendColorList legendSymbologyItems() const SIP_DEPRECATED;
 
     bool isSpatial() const override { return true; }
 

--- a/src/core/raster/qgsrasterrenderer.cpp
+++ b/src/core/raster/qgsrasterrenderer.cpp
@@ -102,12 +102,16 @@ void QgsRasterRenderer::setRasterTransparency( QgsRasterTransparency *t )
   mRasterTransparency = t;
 }
 
+QList< QPair< QString, QColor > > QgsRasterRenderer::legendSymbologyItems() const
+{
+  return QList< QPair< QString, QColor > >();
+}
+
 QList<QgsLayerTreeModelLegendNode *> QgsRasterRenderer::createLegendNodes( QgsLayerTreeLayer *nodeLayer )
 {
   QList<QgsLayerTreeModelLegendNode *> nodes;
 
-  QList< QPair< QString, QColor > > rasterItemList;
-  legendSymbologyItems( rasterItemList );
+  QList< QPair< QString, QColor > > rasterItemList = legendSymbologyItems();
   if ( rasterItemList.isEmpty() )
     return nodes;
 

--- a/src/core/raster/qgsrasterrenderer.cpp
+++ b/src/core/raster/qgsrasterrenderer.cpp
@@ -19,6 +19,7 @@
 #include "qgsrastertransparency.h"
 
 #include "qgssymbollayerutils.h"
+#include "qgslayertreemodellegendnode.h"
 
 #include <QCoreApplication>
 #include <QDomDocument>
@@ -99,6 +100,35 @@ void QgsRasterRenderer::setRasterTransparency( QgsRasterTransparency *t )
 {
   delete mRasterTransparency;
   mRasterTransparency = t;
+}
+
+QList<QgsLayerTreeModelLegendNode *> QgsRasterRenderer::createLegendNodes( QgsLayerTreeLayer *nodeLayer )
+{
+  QList<QgsLayerTreeModelLegendNode *> nodes;
+
+  QList< QPair< QString, QColor > > rasterItemList;
+  legendSymbologyItems( rasterItemList );
+  if ( rasterItemList.isEmpty() )
+    return nodes;
+
+  // Paletted raster may have many colors, for example UInt16 may have 65536 colors
+  // and it is very slow, so we limit max count
+  int count = 0;
+  int max_count = 1000;
+
+  for ( auto itemIt = rasterItemList.constBegin(); itemIt != rasterItemList.constEnd(); ++itemIt, ++count )
+  {
+    nodes << new QgsRasterSymbolLegendNode( nodeLayer, itemIt->second, itemIt->first );
+
+    if ( count == max_count )
+    {
+      QString label = tr( "following %1 items\nnot displayed" ).arg( rasterItemList.size() - max_count );
+      nodes << new QgsSimpleLegendNode( nodeLayer, label );
+      break;
+    }
+  }
+
+  return nodes;
 }
 
 void QgsRasterRenderer::_writeXml( QDomDocument &doc, QDomElement &rasterRendererElem ) const

--- a/src/core/raster/qgsrasterrenderer.h
+++ b/src/core/raster/qgsrasterrenderer.h
@@ -30,6 +30,8 @@ class QDomElement;
 class QPainter;
 class QgsRasterTransparency;
 class QgsStyleEntityVisitorInterface;
+class QgsLayerTreeModelLegendNode;
+class QgsLayerTreeLayer;
 
 /**
  * \ingroup core
@@ -118,6 +120,18 @@ class CORE_EXPORT QgsRasterRenderer : public QgsRasterInterface
 
     //! Gets symbology items if provided by renderer
     virtual void legendSymbologyItems( QList< QPair< QString, QColor > > &symbolItems SIP_OUT ) const { Q_UNUSED( symbolItems ) }
+
+    /**
+     * Creates a set of legend nodes representing the renderer.
+     *
+     * The default implementation calls legendSymbologyItems() and creates corresponding legend nodes for each returned
+     * symbology item.
+     *
+     * Subclasses can override this to return more legend nodes which better represent the renderer.
+     *
+     * \since QGIS 3.18
+     */
+    virtual QList<QgsLayerTreeModelLegendNode *> createLegendNodes( QgsLayerTreeLayer *nodeLayer ) SIP_FACTORY;
 
     //! Sets base class members from xml. Usually called from create() methods of subclasses
     void readXml( const QDomElement &rendererElem ) override;

--- a/src/core/raster/qgsrasterrenderer.h
+++ b/src/core/raster/qgsrasterrenderer.h
@@ -118,8 +118,12 @@ class CORE_EXPORT QgsRasterRenderer : public QgsRasterInterface
     void setAlphaBand( int band ) { mAlphaBand = band; }
     int alphaBand() const { return mAlphaBand; }
 
-    //! Gets symbology items if provided by renderer
-    virtual void legendSymbologyItems( QList< QPair< QString, QColor > > &symbolItems SIP_OUT ) const { Q_UNUSED( symbolItems ) }
+    /**
+     * Returns symbology items if provided by renderer.
+     *
+     * \see createLegendNodes()
+     */
+    virtual QList< QPair< QString, QColor > > legendSymbologyItems() const;
 
     /**
      * Creates a set of legend nodes representing the renderer.

--- a/src/core/raster/qgssinglebandgrayrenderer.cpp
+++ b/src/core/raster/qgssinglebandgrayrenderer.cpp
@@ -198,8 +198,9 @@ void QgsSingleBandGrayRenderer::writeXml( QDomDocument &doc, QDomElement &parent
   parentElem.appendChild( rasterRendererElem );
 }
 
-void QgsSingleBandGrayRenderer::legendSymbologyItems( QList< QPair< QString, QColor > > &symbolItems ) const
+QList<QPair<QString, QColor> > QgsSingleBandGrayRenderer::legendSymbologyItems() const
 {
+  QList<QPair<QString, QColor> >  symbolItems;
   if ( mContrastEnhancement && mContrastEnhancement->contrastEnhancementAlgorithm() != QgsContrastEnhancement::NoEnhancement )
   {
     QColor minColor = ( mGradient == BlackToWhite ) ? Qt::black : Qt::white;
@@ -207,6 +208,7 @@ void QgsSingleBandGrayRenderer::legendSymbologyItems( QList< QPair< QString, QCo
     symbolItems.push_back( qMakePair( QString::number( mContrastEnhancement->minimumValue() ), minColor ) );
     symbolItems.push_back( qMakePair( QString::number( mContrastEnhancement->maximumValue() ), maxColor ) );
   }
+  return symbolItems;
 }
 
 QList<int> QgsSingleBandGrayRenderer::usesBands() const
@@ -312,8 +314,7 @@ void QgsSingleBandGrayRenderer::toSld( QDomDocument &doc, QDomElement &element, 
 
   // for each color set a ColorMapEntry tag nested into "sld:ColorMap" tag
   // e.g. <ColorMapEntry color="#EEBE2F" quantity="-300" label="label" opacity="0"/>
-  QList< QPair< QString, QColor > > classes;
-  legendSymbologyItems( classes );
+  QList< QPair< QString, QColor > > classes = legendSymbologyItems();
 
   // add ColorMap tag
   QDomElement colorMapElem = doc.createElement( QStringLiteral( "sld:ColorMap" ) );

--- a/src/core/raster/qgssinglebandgrayrenderer.h
+++ b/src/core/raster/qgssinglebandgrayrenderer.h
@@ -63,7 +63,7 @@ class CORE_EXPORT QgsSingleBandGrayRenderer: public QgsRasterRenderer
 
     void writeXml( QDomDocument &doc, QDomElement &parentElem ) const override;
 
-    void legendSymbologyItems( QList< QPair< QString, QColor > > &symbolItems SIP_OUT ) const override;
+    QList< QPair< QString, QColor > > legendSymbologyItems() const override;
 
     QList<int> usesBands() const override;
 

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
@@ -313,8 +313,9 @@ void QgsSingleBandPseudoColorRenderer::writeXml( QDomDocument &doc, QDomElement 
   parentElem.appendChild( rasterRendererElem );
 }
 
-void QgsSingleBandPseudoColorRenderer::legendSymbologyItems( QList< QPair< QString, QColor > > &symbolItems ) const
+QList< QPair< QString, QColor > > QgsSingleBandPseudoColorRenderer::legendSymbologyItems() const
 {
+  QList< QPair< QString, QColor > > symbolItems;
   if ( mShader )
   {
     QgsRasterShaderFunction *shaderFunction = mShader->rasterShaderFunction();
@@ -323,6 +324,7 @@ void QgsSingleBandPseudoColorRenderer::legendSymbologyItems( QList< QPair< QStri
       shaderFunction->legendSymbologyItems( symbolItems );
     }
   }
+  return symbolItems;
 }
 
 QList<int> QgsSingleBandPseudoColorRenderer::usesBands() const

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.h
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.h
@@ -77,7 +77,7 @@ class CORE_EXPORT QgsSingleBandPseudoColorRenderer: public QgsRasterRenderer
                        const QgsRectangle &extent = QgsRectangle() );
 
     void writeXml( QDomDocument &doc, QDomElement &parentElem ) const override;
-    void legendSymbologyItems( QList< QPair< QString, QColor > > &symbolItems SIP_OUT ) const override;
+    QList< QPair< QString, QColor > > legendSymbologyItems() const override;
     QList<int> usesBands() const override;
     void toSld( QDomDocument &doc, QDomElement &element, const QgsStringMap &props = QgsStringMap() ) const override;
     bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;

--- a/src/gui/layout/qgslayoutlegendwidget.cpp
+++ b/src/gui/layout/qgslayoutlegendwidget.cpp
@@ -1568,6 +1568,18 @@ QgsLayoutLegendNodeWidget::QgsLayoutLegendNodeWidget( QgsLayoutItemLegend *legen
       mPatchShapeButton->setShape( patchShape );
 
   }
+  else if ( QgsSymbolLegendNode *symbolLegendNode = dynamic_cast< QgsSymbolLegendNode * >( mLegendNode ) )
+  {
+    if ( symbolLegendNode->symbol() )
+    {
+      mPatchShapeButton->setSymbolType( symbolLegendNode->symbol()->type() );
+    }
+    else
+    {
+      mPatchShapeLabel->hide();
+      mPatchShapeButton->hide();
+    }
+  }
   else
   {
     mPatchShapeLabel->hide();


### PR DESCRIPTION
This PR adds API to allow raster renderers to create more specialised legend item types, instead of just the previous solid color blocks.

Using the new api I've implemented a legend for the raster contour renderer (cos it was super simple to do as a proof of concept!):

![image](https://user-images.githubusercontent.com/1829991/101117063-f19fa100-3631-11eb-874f-d2ab9b74750d.png)

Also works great in print layouts in conjunction with custom legend shapes:

![image](https://user-images.githubusercontent.com/1829991/101117091-02e8ad80-3632-11eb-8e53-c12bb0a97c20.png)

Next step -- a proper ramp based legend item for the psuedo color and grayscale renderers!