### PR TITLE
[3d] Fix flat/online terrain generator extent not saved

### DIFF
--- a/src/3d/terrain/qgsflatterraingenerator.cpp
+++ b/src/3d/terrain/qgsflatterraingenerator.cpp
@@ -116,6 +116,7 @@ void QgsFlatTerrainGenerator::writeXml( QDomElement &elem ) const
   elemExtent.setAttribute( QStringLiteral( "xmax" ), QString::number( r.xMaximum() ) );
   elemExtent.setAttribute( QStringLiteral( "ymin" ), QString::number( r.yMinimum() ) );
   elemExtent.setAttribute( QStringLiteral( "ymax" ), QString::number( r.yMaximum() ) );
+  elem.appendChild( elemExtent );
 
   // crs is not read/written - it should be the same as destination crs of the map
 }

--- a/src/3d/terrain/qgsonlineterraingenerator.cpp
+++ b/src/3d/terrain/qgsonlineterraingenerator.cpp
@@ -66,6 +66,7 @@ void QgsOnlineTerrainGenerator::writeXml( QDomElement &elem ) const
   elemExtent.setAttribute( QStringLiteral( "xmax" ), QString::number( r.xMaximum() ) );
   elemExtent.setAttribute( QStringLiteral( "ymin" ), QString::number( r.yMinimum() ) );
   elemExtent.setAttribute( QStringLiteral( "ymax" ), QString::number( r.yMaximum() ) );
+  elem.appendChild( elemExtent );
 
   elem.setAttribute( QStringLiteral( "resolution" ), mResolution );
   elem.setAttribute( QStringLiteral( "skirt-height" ), mSkirtHeight );
@@ -75,6 +76,9 @@ void QgsOnlineTerrainGenerator::writeXml( QDomElement &elem ) const
 
 void QgsOnlineTerrainGenerator::readXml( const QDomElement &elem )
 {
+  mResolution = elem.attribute( QStringLiteral( "resolution" ) ).toInt();
+  mSkirtHeight = elem.attribute( QStringLiteral( "skirt-height" ) ).toFloat();
+
   QDomElement elemExtent = elem.firstChildElement( QStringLiteral( "extent" ) );
   double xmin = elemExtent.attribute( QStringLiteral( "xmin" ) ).toDouble();
   double xmax = elemExtent.attribute( QStringLiteral( "xmax" ) ).toDouble();
@@ -82,9 +86,6 @@ void QgsOnlineTerrainGenerator::readXml( const QDomElement &elem )
   double ymax = elemExtent.attribute( QStringLiteral( "ymax" ) ).toDouble();
 
   setExtent( QgsRectangle( xmin, ymin, xmax, ymax ) );
-
-  mResolution = elem.attribute( QStringLiteral( "resolution" ) ).toInt();
-  mSkirtHeight = elem.attribute( QStringLiteral( "skirt-height" ) ).toFloat();
 
   // crs is not read/written - it should be the same as destination crs of the map
 }


### PR DESCRIPTION
## Description

Until now, restoring a online terrain 3D scene upon project load failed (ouch). This PR addresses that by fixing the writeXml() function of online terrain (as well as flat) so the extent DOM element is actually saved. For online terrain, when reading the XML, we need to restore resolution value prior to restoring the extent so that the QgsDemHeightMapGenerator is re-created with the proper resolution value.

That fixes the last serious bug I had when using online terrain with 3D scenes.