### PR TITLE
Add method to retrieve original metadata from point cloud files

### DIFF
--- a/python/core/auto_generated/pointcloud/qgspointclouddataprovider.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointclouddataprovider.sip.in
@@ -183,6 +183,21 @@ Lidar Point Classes.
 .. seealso:: :py:func:`lasClassificationCodes`
 %End
 
+
+    static QMap< int, QString > dataFormatIds();
+%Docstring
+Returns the map of LAS data format ID to untranslated string value.
+
+.. seealso:: :py:func:`translatedDataFormatIds`
+%End
+
+    static QMap< int, QString > translatedDataFormatIds();
+%Docstring
+Returns the map of LAS data format ID to translated string value.
+
+.. seealso:: :py:func:`dataFormatIds`
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/pointcloud/qgspointclouddataprovider.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointclouddataprovider.sip.in
@@ -78,6 +78,14 @@ This method will not attempt to calculate the data bounds, rather it will return
 are included in the data source's metadata.
 %End
 
+    virtual QVariantMap originalMetadata() const;
+%Docstring
+Returns a representation of the original metadata included in a point cloud dataset.
+
+This is a free-form dictionary of values, the contents and structure of which will vary by provider and
+dataset.
+%End
+
     virtual QgsPointCloudRenderer *createRenderer( const QVariantMap &configuration = QVariantMap() ) const /Factory/;
 %Docstring
 Creates a new 2D point cloud renderer, using provider backend specific information.

--- a/src/core/pointcloud/qgspointclouddataprovider.cpp
+++ b/src/core/pointcloud/qgspointclouddataprovider.cpp
@@ -41,6 +41,11 @@ QgsGeometry QgsPointCloudDataProvider::polygonBounds() const
   return QgsGeometry::fromRect( extent() );
 }
 
+QVariantMap QgsPointCloudDataProvider::originalMetadata() const
+{
+  return QVariantMap();
+}
+
 QgsPointCloudRenderer *QgsPointCloudDataProvider::createRenderer( const QVariantMap & ) const
 {
   return nullptr;

--- a/src/core/pointcloud/qgspointclouddataprovider.cpp
+++ b/src/core/pointcloud/qgspointclouddataprovider.cpp
@@ -125,6 +125,38 @@ QMap<int, QString> QgsPointCloudDataProvider::translatedLasClassificationCodes()
   return sCodes;
 }
 
+QMap<int, QString> QgsPointCloudDataProvider::dataFormatIds()
+{
+  static QMap< int, QString > sCodes
+  {
+    {0, QStringLiteral( "No color or time stored" )},
+    {1, QStringLiteral( "Time is stored" )},
+    {2, QStringLiteral( "Color is stored" )},
+    {3, QStringLiteral( "Color and time are stored" )},
+    {6, QStringLiteral( "Time is stored" )},
+    {7, QStringLiteral( "Time and color are stored)" )},
+    {8, QStringLiteral( "Time, color and near infrared are stored" )},
+  };
+
+  return sCodes;
+}
+
+QMap<int, QString> QgsPointCloudDataProvider::translatedDataFormatIds()
+{
+  static QMap< int, QString > sCodes
+  {
+    {0, QObject::tr( "No color or time stored" )},
+    {1, QObject::tr( "Time is stored" )},
+    {2, QObject::tr( "Color is stored" )},
+    {3, QObject::tr( "Color and time are stored" )},
+    {6, QObject::tr( "Time is stored" )},
+    {7, QObject::tr( "Time and color are stored)" )},
+    {8, QObject::tr( "Time, color and near infrared are stored" )},
+  };
+
+  return sCodes;
+}
+
 QVariant QgsPointCloudDataProvider::metadataStatistic( const QString &, QgsStatisticalSummary::Statistic ) const
 {
   return QVariant();

--- a/src/core/pointcloud/qgspointclouddataprovider.h
+++ b/src/core/pointcloud/qgspointclouddataprovider.h
@@ -101,6 +101,14 @@ class CORE_EXPORT QgsPointCloudDataProvider: public QgsDataProvider
     virtual QgsGeometry polygonBounds() const;
 
     /**
+     * Returns a representation of the original metadata included in a point cloud dataset.
+     *
+     * This is a free-form dictionary of values, the contents and structure of which will vary by provider and
+     * dataset.
+     */
+    virtual QVariantMap originalMetadata() const;
+
+    /**
      * Creates a new 2D point cloud renderer, using provider backend specific information.
      *
      * The \a configuration map can be used to pass provider-specific configuration maps to the provider to

--- a/src/core/pointcloud/qgspointclouddataprovider.h
+++ b/src/core/pointcloud/qgspointclouddataprovider.h
@@ -235,6 +235,21 @@ class CORE_EXPORT QgsPointCloudDataProvider: public QgsDataProvider
      */
     static QMap< int, QString > translatedLasClassificationCodes();
 
+
+    /**
+     * Returns the map of LAS data format ID to untranslated string value.
+     *
+     * \see translatedDataFormatIds()
+     */
+    static QMap< int, QString > dataFormatIds();
+
+    /**
+     * Returns the map of LAS data format ID to translated string value.
+     *
+     * \see dataFormatIds()
+     */
+    static QMap< int, QString > translatedDataFormatIds();
+
 };
 
 #endif // QGSMESHDATAPROVIDER_H

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -443,6 +443,41 @@ QString QgsPointCloudLayer::htmlMetadata() const
                   + QStringLiteral( "</td></tr>\n" );
   }
 
+  if ( !originalMetadata.value( QStringLiteral( "dataformat_id" ) ).toString().isEmpty() )
+  {
+    myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" )
+                  + tr( "Data format" ) + QStringLiteral( "</td><td>" )
+                  + QStringLiteral( "%1 (%2)" ).arg( QgsPointCloudDataProvider::translatedDataFormatIds().value( originalMetadata.value( QStringLiteral( "dataformat_id" ) ).toInt() ),
+                      originalMetadata.value( QStringLiteral( "dataformat_id" ) ).toString() ).trimmed()
+                  + QStringLiteral( "</td></tr>\n" );
+  }
+
+  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" )
+                + tr( "Scale X" ) + QStringLiteral( "</td><td>" )
+                + QString::number( originalMetadata.value( QStringLiteral( "scale_x" ) ).toDouble() )
+                + QStringLiteral( "</td></tr>\n" );
+  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" )
+                + tr( "Scale Y" ) + QStringLiteral( "</td><td>" )
+                + QString::number( originalMetadata.value( QStringLiteral( "scale_y" ) ).toDouble() )
+                + QStringLiteral( "</td></tr>\n" );
+  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" )
+                + tr( "Scale Z" ) + QStringLiteral( "</td><td>" )
+                + QString::number( originalMetadata.value( QStringLiteral( "scale_z" ) ).toDouble() )
+                + QStringLiteral( "</td></tr>\n" );
+
+  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" )
+                + tr( "Offset X" ) + QStringLiteral( "</td><td>" )
+                + QString::number( originalMetadata.value( QStringLiteral( "offset_x" ) ).toDouble() )
+                + QStringLiteral( "</td></tr>\n" );
+  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" )
+                + tr( "Offset Y" ) + QStringLiteral( "</td><td>" )
+                + QString::number( originalMetadata.value( QStringLiteral( "offset_y" ) ).toDouble() )
+                + QStringLiteral( "</td></tr>\n" );
+  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" )
+                + tr( "Offset Z" ) + QStringLiteral( "</td><td>" )
+                + QString::number( originalMetadata.value( QStringLiteral( "offset_z" ) ).toDouble() )
+                + QStringLiteral( "</td></tr>\n" );
+
   if ( !originalMetadata.value( QStringLiteral( "project_id" ) ).toString().isEmpty() )
   {
     myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" )

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -422,6 +422,51 @@ QString QgsPointCloudLayer::htmlMetadata() const
                 + ( pointCount < 0 ? tr( "unknown" ) : locale.toString( static_cast<qlonglong>( pointCount ) ) )
                 + QStringLiteral( "</td></tr>\n" );
 
+  const QVariantMap originalMetadata = mDataProvider ? mDataProvider->originalMetadata() : QVariantMap();
+
+  if ( originalMetadata.value( QStringLiteral( "creation_year" ) ).toInt() > 0 && originalMetadata.contains( QStringLiteral( "creation_doy" ) ) )
+  {
+    QDate creationDate( originalMetadata.value( QStringLiteral( "creation_year" ) ).toInt(), 1, 1 );
+    creationDate = creationDate.addDays( originalMetadata.value( QStringLiteral( "creation_doy" ) ).toInt() );
+
+    myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" )
+                  + tr( "Creation date" ) + QStringLiteral( "</td><td>" )
+                  + creationDate.toString( Qt::ISODate )
+                  + QStringLiteral( "</td></tr>\n" );
+  }
+  if ( originalMetadata.contains( QStringLiteral( "major_version" ) ) && originalMetadata.contains( QStringLiteral( "minor_version" ) ) )
+  {
+    myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" )
+                  + tr( "Version" ) + QStringLiteral( "</td><td>" )
+                  + QStringLiteral( "%1.%2" ).arg( originalMetadata.value( QStringLiteral( "major_version" ) ).toString(),
+                      originalMetadata.value( QStringLiteral( "minor_version" ) ).toString() )
+                  + QStringLiteral( "</td></tr>\n" );
+  }
+
+  if ( !originalMetadata.value( QStringLiteral( "project_id" ) ).toString().isEmpty() )
+  {
+    myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" )
+                  + tr( "Project ID" ) + QStringLiteral( "</td><td>" )
+                  + originalMetadata.value( QStringLiteral( "project_id" ) ).toString()
+                  + QStringLiteral( "</td></tr>\n" );
+  }
+
+  if ( !originalMetadata.value( QStringLiteral( "system_id" ) ).toString().isEmpty() )
+  {
+    myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" )
+                  + tr( "System ID" ) + QStringLiteral( "</td><td>" )
+                  + originalMetadata.value( QStringLiteral( "system_id" ) ).toString()
+                  + QStringLiteral( "</td></tr>\n" );
+  }
+
+  if ( !originalMetadata.value( QStringLiteral( "software_id" ) ).toString().isEmpty() )
+  {
+    myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" )
+                  + tr( "Software ID" ) + QStringLiteral( "</td><td>" )
+                  + originalMetadata.value( QStringLiteral( "software_id" ) ).toString()
+                  + QStringLiteral( "</td></tr>\n" );
+  }
+
   // End Provider section
   myMetadata += QLatin1String( "</table>\n<br><br>" );
 

--- a/src/core/providers/ept/qgseptpointcloudindex.h
+++ b/src/core/providers/ept/qgseptpointcloudindex.h
@@ -53,6 +53,8 @@ class QgsEptPointCloudIndex: public QgsPointCloudIndex
     QVariantList metadataClasses( const QString &attribute ) const;
     QVariant metadataClassStatistic( const QString &attribute, const QVariant &value, QgsStatisticalSummary::Statistic statistic ) const;
 
+    QVariantMap originalMetadata() const { return mOriginalMetadata; }
+
   private:
     bool loadHierarchy();
 
@@ -75,6 +77,7 @@ class QgsEptPointCloudIndex: public QgsPointCloudIndex
     QMap< QString, AttributeStatistics > mMetadataStats;
 
     QMap< QString, QMap< int, int > > mAttributeClasses;
+    QVariantMap mOriginalMetadata;
 };
 
 ///@endcond

--- a/src/core/providers/ept/qgseptprovider.cpp
+++ b/src/core/providers/ept/qgseptprovider.cpp
@@ -93,6 +93,11 @@ QVariant QgsEptProvider::metadataClassStatistic( const QString &attribute, const
   return mIndex->metadataClassStatistic( attribute, value, statistic );
 }
 
+QVariantMap QgsEptProvider::originalMetadata() const
+{
+  return mIndex->originalMetadata();
+}
+
 QVariant QgsEptProvider::metadataStatistic( const QString &attribute, QgsStatisticalSummary::Statistic statistic ) const
 {
   return mIndex->metadataStatistic( attribute, statistic );

--- a/src/core/providers/ept/qgseptprovider.h
+++ b/src/core/providers/ept/qgseptprovider.h
@@ -56,6 +56,7 @@ class QgsEptProvider: public QgsPointCloudDataProvider
     QVariant metadataStatistic( const QString &attribute, QgsStatisticalSummary::Statistic statistic ) const override;
     QVariantList metadataClasses( const QString &attribute ) const override;
     QVariant metadataClassStatistic( const QString &attribute, const QVariant &value, QgsStatisticalSummary::Statistic statistic ) const override;
+    QVariantMap originalMetadata() const override;
 
   private:
     std::unique_ptr<QgsEptPointCloudIndex> mIndex;

--- a/src/providers/pdal/qgspdalprovider.h
+++ b/src/providers/pdal/qgspdalprovider.h
@@ -38,6 +38,7 @@ class QgsPdalProvider: public QgsPointCloudDataProvider
     QgsRectangle extent() const override;
     QgsPointCloudAttributeCollection attributes() const override;
     int pointCount() const override;
+    QVariantMap originalMetadata() const override;
 
     bool isValid() const override;
 
@@ -53,6 +54,7 @@ class QgsPdalProvider: public QgsPointCloudDataProvider
     QgsRectangle mExtent;
     bool mIsValid = false;
     int mPointCount = 0;
+    QVariantMap mOriginalMetadata;
 };
 
 class QgsPdalProviderMetadata : public QgsProviderMetadata

--- a/tests/src/python/test_qgspointcloudprovider.py
+++ b/tests/src/python/test_qgspointcloudprovider.py
@@ -99,7 +99,7 @@ class TestQgsPointCloudDataProvider(unittest.TestCase):
         layer = QgsPointCloudLayer(unitTestDataPath() + '/point_clouds/ept/sunshine-coast/ept.json', 'test', 'ept')
         self.assertEqual(layer.dataProvider().originalMetadata()['major_version'], 1.0)
         self.assertEqual(layer.dataProvider().originalMetadata()['minor_version'], 2.0)
-        self.assertEqual(layer.dataProvider().originalMetadata()['software_id'], 'PDAL 2.1.0 (Releas)')
+        self.assertEqual(layer.dataProvider().originalMetadata()['software_id'], 'PDAL 2.1.0 (Releas)')  #spellok
         self.assertEqual(layer.dataProvider().originalMetadata()['creation_year'], 2020.0)
         self.assertEqual(layer.dataProvider().originalMetadata()['creation_doy'], 309.0)
 
@@ -108,7 +108,7 @@ class TestQgsPointCloudDataProvider(unittest.TestCase):
         layer = QgsPointCloudLayer(unitTestDataPath() + '/point_clouds/las/cloud.las', 'test', 'pdal')
         self.assertEqual(layer.dataProvider().originalMetadata()['major_version'], 1.0)
         self.assertEqual(layer.dataProvider().originalMetadata()['minor_version'], 2.0)
-        self.assertEqual(layer.dataProvider().originalMetadata()['software_id'], 'PDAL 2.1.0 (Releas)')
+        self.assertEqual(layer.dataProvider().originalMetadata()['software_id'], 'PDAL 2.1.0 (Releas)')  #spellok
         self.assertEqual(layer.dataProvider().originalMetadata()['creation_year'], 2020.0)
         self.assertEqual(layer.dataProvider().originalMetadata()['creation_doy'], 309.0)
 

--- a/tests/src/python/test_qgspointcloudprovider.py
+++ b/tests/src/python/test_qgspointcloudprovider.py
@@ -94,6 +94,24 @@ class TestQgsPointCloudDataProvider(unittest.TestCase):
         self.assertEqual(layer.dataProvider().metadataClassStatistic('Classification', 5, QgsStatisticalSummary.Count),
                          3)
 
+    @unittest.skipIf('ept' not in QgsProviderRegistry.instance().providerList(), 'EPT provider not available')
+    def testOriginalMetadataEpt(self):
+        layer = QgsPointCloudLayer(unitTestDataPath() + '/point_clouds/ept/sunshine-coast/ept.json', 'test', 'ept')
+        self.assertEqual(layer.dataProvider().originalMetadata()['major_version'], 1.0)
+        self.assertEqual(layer.dataProvider().originalMetadata()['minor_version'], 2.0)
+        self.assertEqual(layer.dataProvider().originalMetadata()['software_id'], 'PDAL 2.1.0 (Releas)')
+        self.assertEqual(layer.dataProvider().originalMetadata()['creation_year'], 2020.0)
+        self.assertEqual(layer.dataProvider().originalMetadata()['creation_doy'], 309.0)
+
+    @unittest.skipIf('pdal' not in QgsProviderRegistry.instance().providerList(), 'PDAL provider not available')
+    def testOriginalMetadataPdal(self):
+        layer = QgsPointCloudLayer(unitTestDataPath() + '/point_clouds/las/cloud.las', 'test', 'pdal')
+        self.assertEqual(layer.dataProvider().originalMetadata()['major_version'], 1.0)
+        self.assertEqual(layer.dataProvider().originalMetadata()['minor_version'], 2.0)
+        self.assertEqual(layer.dataProvider().originalMetadata()['software_id'], 'PDAL 2.1.0 (Releas)')
+        self.assertEqual(layer.dataProvider().originalMetadata()['creation_year'], 2020.0)
+        self.assertEqual(layer.dataProvider().originalMetadata()['creation_doy'], 309.0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgspointcloudprovider.py
+++ b/tests/src/python/test_qgspointcloudprovider.py
@@ -99,7 +99,7 @@ class TestQgsPointCloudDataProvider(unittest.TestCase):
         layer = QgsPointCloudLayer(unitTestDataPath() + '/point_clouds/ept/sunshine-coast/ept.json', 'test', 'ept')
         self.assertEqual(layer.dataProvider().originalMetadata()['major_version'], 1.0)
         self.assertEqual(layer.dataProvider().originalMetadata()['minor_version'], 2.0)
-        self.assertEqual(layer.dataProvider().originalMetadata()['software_id'], 'PDAL 2.1.0 (Releas)')  #spellok
+        self.assertEqual(layer.dataProvider().originalMetadata()['software_id'], 'PDAL 2.1.0 (Releas)')  # spellok
         self.assertEqual(layer.dataProvider().originalMetadata()['creation_year'], 2020.0)
         self.assertEqual(layer.dataProvider().originalMetadata()['creation_doy'], 309.0)
 
@@ -108,7 +108,7 @@ class TestQgsPointCloudDataProvider(unittest.TestCase):
         layer = QgsPointCloudLayer(unitTestDataPath() + '/point_clouds/las/cloud.las', 'test', 'pdal')
         self.assertEqual(layer.dataProvider().originalMetadata()['major_version'], 1.0)
         self.assertEqual(layer.dataProvider().originalMetadata()['minor_version'], 2.0)
-        self.assertEqual(layer.dataProvider().originalMetadata()['software_id'], 'PDAL 2.1.0 (Releas)')  #spellok
+        self.assertEqual(layer.dataProvider().originalMetadata()['software_id'], 'PDAL 2.1.0 (Releas)')  # spellok
         self.assertEqual(layer.dataProvider().originalMetadata()['creation_year'], 2020.0)
         self.assertEqual(layer.dataProvider().originalMetadata()['creation_doy'], 309.0)
 


### PR DESCRIPTION
and expose some more useful metadata in layer properties (las version, software, creation date)

eg

![image](https://user-images.githubusercontent.com/1829991/101128385-4865a480-364b-11eb-9b1e-87168e02cf4a.png)
