### PR TITLE
Geographic extent storing

### DIFF
--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -505,6 +505,15 @@ Returns new instance of :py:class:`QgsMapLayerRenderer` that will be used for re
 Returns the extent of the layer.
 %End
 
+    QgsRectangle geographicExtent() const;
+%Docstring
+Returns the geographic extent (EPSG:4326) of the layer.
+
+.. seealso:: :py:func:`setExtent`
+
+.. versionadded:: 3.18
+%End
+
     bool isValid() const;
 %Docstring
 Returns the status of the layer. An invalid layer is one which has a bad datasource
@@ -1700,24 +1709,7 @@ Copies attributes like name, short name, ... into another layer.
 Sets the ``extent`` in layer CRS.
 
 If the layer CRS is not EPSG:4326 and the geographic extent is
-known, using :py:func:`~QgsMapLayer.setExtents` is faster.
-
-.. seealso:: :py:func:`setExtents`
-%End
-
-    virtual void setExtents( const QgsRectangle &extent, const QgsRectangle &geographicExtent );
-%Docstring
-Simultaneously sets the ``extent`` and the ``geographicExtent``.
-
-This call can be used to skip the costly coordinate transformation when setting
-the layer extent in case the geographic extent is already known (e.g. when loading
-a project).
-
-.. seealso:: :py:func:`setExtent`
-
-.. seealso:: :py:func:`geographicExtent`
-
-.. versionadded:: 3.18
+known.
 %End
 
     void setValid( bool valid );
@@ -1846,15 +1838,6 @@ this method is now deprecated and always return ``False``, because circular depe
 
 
 
-
-    QgsRectangle geographicExtent() const;
-%Docstring
-Returns the geographic extent (EPSG:4326) of the layer.
-
-.. seealso:: :py:func:`setExtent`
-
-.. versionadded:: 3.18
-%End
 
 };
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -505,14 +505,14 @@ Returns new instance of :py:class:`QgsMapLayerRenderer` that will be used for re
 Returns the extent of the layer.
 %End
 
-    QgsRectangle geographicExtent( bool actual = false ) const;
+    QgsRectangle wgs84Extent( bool forceRecalculate = false ) const;
 %Docstring
-Returns the geographic extent (EPSG:4326) of the layer according to
+Returns the WGS84 extent (EPSG:4326) of the layer according to
 ReadFlag.FlagTrustLayerMetadata. If that flag is activated, then the
-geographic extent read in the qgs project is returned. Otherwise, the
-actual geographic extent is returned.
+WGS84 extent read in the qgs project is returned. Otherwise, the actual
+WGS84 extent is returned.
 
-:param actual: True to return the current geographic extent whatever the read flags
+:param forceRecalculate: True to return the current WGS84 extent whatever the read flags
 
 .. versionadded:: 3.18
 %End
@@ -1707,9 +1707,9 @@ Copies attributes like name, short name, ... into another layer.
 .. versionadded:: 3.0
 %End
 
-    virtual void setExtent( const QgsRectangle &extent );
+    virtual void setExtent( const QgsRectangle &rect );
 %Docstring
-Sets the ``extent`` in layer CRS.
+Sets the extent
 %End
 
     void setValid( bool valid );

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -505,7 +505,7 @@ Returns new instance of :py:class:`QgsMapLayerRenderer` that will be used for re
 Returns the extent of the layer.
 %End
 
-    QgsRectangle geographicExtent() const;
+    QgsRectangle geographicExtent( bool actual = false ) const;
 %Docstring
 Returns the geographic extent (EPSG:4326) of the layer.
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1813,6 +1813,13 @@ Sets error message
 %End
 
     void invalidateWgs84Extent();
+%Docstring
+Invalidates the WGS84 extent. If FlagTrustLayerMetadata is enabled,
+the extent is not invalidated because we want to trust metadata whatever
+happens.
+
+.. versionadded:: 3.18
+%End
 
 
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -507,9 +507,12 @@ Returns the extent of the layer.
 
     QgsRectangle geographicExtent( bool actual = false ) const;
 %Docstring
-Returns the geographic extent (EPSG:4326) of the layer.
+Returns the geographic extent (EPSG:4326) of the layer according to
+ReadFlag.FlagTrustLayerMetadata. If that flag is activated, then the
+geographic extent read in the qgs project is returned. Otherwise, the
+actual geographic extent is returned.
 
-.. seealso:: :py:func:`setExtent`
+:param actual: True to return the current geographic extent whatever the read flags
 
 .. versionadded:: 3.18
 %End
@@ -1707,9 +1710,6 @@ Copies attributes like name, short name, ... into another layer.
     virtual void setExtent( const QgsRectangle &extent );
 %Docstring
 Sets the ``extent`` in layer CRS.
-
-If the layer CRS is not EPSG:4326 and the geographic extent is
-known.
 %End
 
     void setValid( bool valid );

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1695,9 +1695,29 @@ Copies attributes like name, short name, ... into another layer.
 .. versionadded:: 3.0
 %End
 
-    virtual void setExtent( const QgsRectangle &rect );
+    virtual void setExtent( const QgsRectangle &extent );
 %Docstring
-Sets the extent
+Sets the ``extent`` in layer CRS.
+
+If the layer CRS is not EPSG:4326 and the geographic extent is
+known, using :py:func:`~QgsMapLayer.setExtents` is faster.
+
+.. seealso:: :py:func:`setExtents`
+%End
+
+    virtual void setExtents( const QgsRectangle &extent, const QgsRectangle &geographicExtent );
+%Docstring
+Simultaneously sets the ``extent`` and the ``geographicExtent``.
+
+This call can be used to skip the costly coordinate transformation when setting
+the layer extent in case the geographic extent is already known (e.g. when loading
+a project).
+
+.. seealso:: :py:func:`setExtent`
+
+.. seealso:: :py:func:`geographicExtent`
+
+.. versionadded:: 3.18
 %End
 
     void setValid( bool valid );
@@ -1812,6 +1832,7 @@ Sets error message
 
 
 
+
  bool hasDependencyCycle( const QSet<QgsMapLayerDependency> & ) const;
 %Docstring
 Checks whether a new set of dependencies will introduce a cycle
@@ -1825,6 +1846,15 @@ this method is now deprecated and always return ``False``, because circular depe
 
 
 
+
+    QgsRectangle geographicExtent() const;
+%Docstring
+Returns the geographic extent (EPSG:4326) of the layer.
+
+.. seealso:: :py:func:`setExtent`
+
+.. versionadded:: 3.18
+%End
 
 };
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1823,8 +1823,6 @@ Sets error message
 
 
 
-
-
  bool hasDependencyCycle( const QSet<QgsMapLayerDependency> & ) const;
 %Docstring
 Checks whether a new set of dependencies will introduce a cycle

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -514,7 +514,7 @@ WGS84 extent is returned.
 
 :param forceRecalculate: True to return the current WGS84 extent whatever the read flags
 
-.. versionadded:: 3.18
+.. versionadded:: 3.20
 %End
 
     bool isValid() const;
@@ -1818,7 +1818,7 @@ Invalidates the WGS84 extent. If FlagTrustLayerMetadata is enabled,
 the extent is not invalidated because we want to trust metadata whatever
 happens.
 
-.. versionadded:: 3.18
+.. versionadded:: 3.20
 %End
 
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1812,6 +1812,8 @@ Add error message
 Sets error message
 %End
 
+    void invalidateWgs84Extent();
+
 
 
 

--- a/python/core/auto_generated/qgsxmlutils.sip.in
+++ b/python/core/auto_generated/qgsxmlutils.sip.in
@@ -50,7 +50,7 @@ Encodes a distance unit to a DOM element.
 .. seealso:: :py:func:`readMapUnits`
 %End
 
-    static QDomElement writeRectangle( const QgsRectangle &rect, QDomDocument &doc );
+    static QDomElement writeRectangle( const QgsRectangle &rect, QDomDocument &doc, const QString &elementName = QStringLiteral( "extent" ) );
 
     static QDomElement writeVariant( const QVariant &value, QDomDocument &doc );
 %Docstring

--- a/python/core/auto_generated/qgsxmlutils.sip.in
+++ b/python/core/auto_generated/qgsxmlutils.sip.in
@@ -51,6 +51,15 @@ Encodes a distance unit to a DOM element.
 %End
 
     static QDomElement writeRectangle( const QgsRectangle &rect, QDomDocument &doc, const QString &elementName = QStringLiteral( "extent" ) );
+%Docstring
+Encodes a rectangle to a DOM element.
+
+:param rect: rectangle to encode
+:param doc: DOM document
+:param elementName: name of the DOM element
+
+:return: element containing encoded rectangle
+%End
 
     static QDomElement writeVariant( const QVariant &value, QDomDocument &doc );
 %Docstring

--- a/src/core/annotations/qgsannotationlayer.cpp
+++ b/src/core/annotations/qgsannotationlayer.cpp
@@ -120,6 +120,7 @@ QgsRectangle QgsAnnotationLayer::extent() const
 void QgsAnnotationLayer::setTransformContext( const QgsCoordinateTransformContext &context )
 {
   mTransformContext = context;
+  invalidateWgs84Extent();
 }
 
 bool QgsAnnotationLayer::readXml( const QDomNode &layerNode, QgsReadWriteContext &context )

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -539,6 +539,7 @@ void QgsMeshLayer::setTransformContext( const QgsCoordinateTransformContext &tra
 {
   if ( mDataProvider )
     mDataProvider->setTransformContext( transformContext );
+  invalidateWgs84Extent();
 }
 
 QgsMeshDatasetIndex QgsMeshLayer::datasetIndexAtTime( const QgsDateTimeRange &timeRange, int datasetGroupIndex ) const

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -277,6 +277,7 @@ void QgsPointCloudLayer::setTransformContext( const QgsCoordinateTransformContex
 {
   if ( mDataProvider )
     mDataProvider->setTransformContext( transformContext );
+  invalidateWgs84Extent();
 }
 
 void QgsPointCloudLayer::setDataSource( const QString &dataSource, const QString &baseName, const QString &provider,

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -2049,3 +2049,12 @@ void QgsMapLayer::updateExtent( const QgsRectangle &extent ) const
 
   mWgs84Extent = wgs84Extent( true );
 }
+
+void QgsMapLayer::invalidateWgs84Extent()
+{
+  // do not update the wgs84 extent if we trust layer metadata
+  if ( mReadFlags & QgsMapLayer::ReadFlag::FlagTrustLayerMetadata )
+    return;
+
+  mWgs84Extent = QgsRectangle();
+}

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -2015,7 +2015,7 @@ QgsRectangle QgsMapLayer::geographicExtent( bool actual ) const
 {
   QgsRectangle geoExtent;
 
-  if ( mReadFlags & QgsMapLayer::ReadFlag::FlagTrustLayerMetadata and not actual )
+  if ( mReadFlags & QgsMapLayer::ReadFlag::FlagTrustLayerMetadata && ! actual )
   {
     geoExtent = mGeographicExtent;
   }

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -56,6 +56,7 @@
 #include "qgsvectordataprovider.h"
 #include "qgsxmlutils.h"
 #include "qgsstringutils.h"
+#include "qgsmessagelog.h"
 #include "qgsmaplayertemporalproperties.h"
 #include "qgsmaplayerelevationproperties.h"
 
@@ -2028,6 +2029,7 @@ QgsRectangle QgsMapLayer::wgs84Extent( bool forceRecalculate ) const
     }
     catch ( const QgsCsException &cse )
     {
+      QgsMessageLog::logMessage( tr( "Error transforming extent: %1" ).arg( cse.what() ) );
       wgs84Extent = QgsRectangle();
     }
   }

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -411,6 +411,7 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
   if ( !extent().isNull() )
   {
     layerElement.appendChild( QgsXmlUtils::writeRectangle( mExtent, document ) );
+    layerElement.appendChild( QgsXmlUtils::writeRectangle( mExtent, document, QStringLiteral( "geographicExtent" ) ) );
   }
 
   layerElement.setAttribute( QStringLiteral( "autoRefreshTime" ), QString::number( mRefreshTimer->interval() ) );
@@ -1899,9 +1900,17 @@ void QgsMapLayer::emitStyleChanged()
   emit styleChanged();
 }
 
-void QgsMapLayer::setExtent( const QgsRectangle &r )
+void QgsMapLayer::setExtent( const QgsRectangle &extent )
 {
-  mExtent = r;
+  mExtent = extent;
+  const QgsCoordinateTransform transformer { crs(), QgsCoordinateReferenceSystem::fromEpsgId( 4326 ), transformContext() };
+  mGeographicExtent = transformer.transform( extent );
+}
+
+void QgsMapLayer::setExtents( const QgsRectangle &extent, const QgsRectangle &geographicExtent )
+{
+  mExtent = extent;
+  mGeographicExtent = geographicExtent;
 }
 
 bool QgsMapLayer::isReadOnly() const
@@ -2000,4 +2009,9 @@ void QgsMapLayer::onNotified( const QString &message )
     triggerRepaint();
     emit dataChanged();
   }
+}
+
+QgsRectangle QgsMapLayer::geographicExtent() const
+{
+  return mGeographicExtent;
 }

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -392,15 +392,13 @@ bool QgsMapLayer::readLayerXml( const QDomElement &layerElement, QgsReadWriteCon
   setRefreshOnNofifyMessage( layerElement.attribute( QStringLiteral( "refreshOnNotifyMessage" ), QString() ) );
   setRefreshOnNotifyEnabled( layerElement.attribute( QStringLiteral( "refreshOnNotifyEnabled" ), QStringLiteral( "0" ) ).toInt() );
 
-  // geographic extent
-  // if ( mReadExtentFromXml )
-  // {
-  QDomNode geoExtentNode = layerElement.namedItem( QStringLiteral( "geographicExtent" ) );
-  if ( !geoExtentNode.isNull() )
+  // geographic extent is read only if necessary
+  if ( mReadFlags & QgsMapLayer::ReadFlag::FlagTrustLayerMetadata )
   {
-    mGeographicExtent = QgsXmlUtils::readRectangle( geoExtentNode.toElement() );
+    const QDomNode geoExtentNode = layerElement.namedItem( QStringLiteral( "geographicExtent" ) );
+    if ( !geoExtentNode.isNull() )
+      mGeographicExtent = QgsXmlUtils::readRectangle( geoExtentNode.toElement() );
   }
-  // }
 
   return ! layerError;
 } // bool QgsMapLayer::readLayerXML

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1911,7 +1911,7 @@ void QgsMapLayer::emitStyleChanged()
 
 void QgsMapLayer::setExtent( const QgsRectangle &extent )
 {
-  mExtent = extent;
+  updateExtent( extent );
 }
 
 bool QgsMapLayer::isReadOnly() const
@@ -2016,7 +2016,7 @@ QgsRectangle QgsMapLayer::wgs84Extent( bool forceRecalculate ) const
 {
   QgsRectangle wgs84Extent;
 
-  if ( mReadFlags & QgsMapLayer::ReadFlag::FlagTrustLayerMetadata && ! forceRecalculate )
+  if ( ! forceRecalculate && ! mWgs84Extent.isNull() )
   {
     wgs84Extent = mWgs84Extent;
   }
@@ -2034,4 +2034,18 @@ QgsRectangle QgsMapLayer::wgs84Extent( bool forceRecalculate ) const
     }
   }
   return wgs84Extent;
+}
+
+void QgsMapLayer::updateExtent( const QgsRectangle &extent ) const
+{
+  if ( extent == mExtent )
+    return;
+
+  mExtent = extent;
+
+  // do not update the wgs84 extent if we trust layer metadata
+  if ( mReadFlags & QgsMapLayer::ReadFlag::FlagTrustLayerMetadata )
+    return;
+
+  mWgs84Extent = wgs84Extent( true );
 }

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -392,6 +392,16 @@ bool QgsMapLayer::readLayerXml( const QDomElement &layerElement, QgsReadWriteCon
   setRefreshOnNofifyMessage( layerElement.attribute( QStringLiteral( "refreshOnNotifyMessage" ), QString() ) );
   setRefreshOnNotifyEnabled( layerElement.attribute( QStringLiteral( "refreshOnNotifyEnabled" ), QStringLiteral( "0" ) ).toInt() );
 
+  // geographic extent
+  // if ( mReadExtentFromXml )
+  // {
+  QDomNode geoExtentNode = layerElement.namedItem( QStringLiteral( "geographicExtent" ) );
+  if ( !geoExtentNode.isNull() )
+  {
+    mGeographicExtent = QgsXmlUtils::readRectangle( geoExtentNode.toElement() );
+  }
+  // }
+
   return ! layerError;
 } // bool QgsMapLayer::readLayerXML
 
@@ -1905,12 +1915,6 @@ void QgsMapLayer::setExtent( const QgsRectangle &extent )
   mExtent = extent;
   const QgsCoordinateTransform transformer { crs(), QgsCoordinateReferenceSystem::fromEpsgId( 4326 ), transformContext() };
   mGeographicExtent = transformer.transform( extent );
-}
-
-void QgsMapLayer::setExtents( const QgsRectangle &extent, const QgsRectangle &geographicExtent )
-{
-  mExtent = extent;
-  mGeographicExtent = geographicExtent;
 }
 
 bool QgsMapLayer::isReadOnly() const

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -2020,7 +2020,7 @@ QgsRectangle QgsMapLayer::wgs84Extent( bool forceRecalculate ) const
   {
     wgs84Extent = mWgs84Extent;
   }
-  else
+  else if ( ! mExtent.isNull() )
   {
     const QgsCoordinateTransform transformer { crs(), QgsCoordinateReferenceSystem::fromOgcWmsCrs( geoEpsgCrsAuthId() ), transformContext() };
     try

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -515,9 +515,11 @@ class CORE_EXPORT QgsMapLayer : public QObject
     virtual QgsRectangle extent() const;
 
     /**
-     * Returns the geographic extent (EPSG:4326) of the layer.
-     *
-     * \see setExtent()
+     * Returns the geographic extent (EPSG:4326) of the layer according to
+     * ReadFlag::FlagTrustLayerMetadata. If that flag is activated, then the
+     * geographic extent read in the qgs project is returned. Otherwise, the
+     * actual geographic extent is returned.
+     * \param actual True to return the current geographic extent whatever the read flags
      * \since QGIS 3.18
      */
     QgsRectangle geographicExtent( bool actual = false ) const;
@@ -1522,9 +1524,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     /**
      * Sets the \a extent in layer CRS.
-     *
-     * If the layer CRS is not EPSG:4326 and the geographic extent is
-     * known.
      */
     virtual void setExtent( const QgsRectangle &extent );
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1612,6 +1612,8 @@ class CORE_EXPORT QgsMapLayer : public QObject
     //! Sets error message
     void setError( const QgsError &error ) { mError = error;}
 
+    void invalidateWgs84Extent();
+
     //! Indicates if the layer is valid and can be drawn
     bool mValid = false;
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -515,14 +515,14 @@ class CORE_EXPORT QgsMapLayer : public QObject
     virtual QgsRectangle extent() const;
 
     /**
-     * Returns the geographic extent (EPSG:4326) of the layer according to
+     * Returns the WGS84 extent (EPSG:4326) of the layer according to
      * ReadFlag::FlagTrustLayerMetadata. If that flag is activated, then the
-     * geographic extent read in the qgs project is returned. Otherwise, the
-     * actual geographic extent is returned.
-     * \param actual True to return the current geographic extent whatever the read flags
+     * WGS84 extent read in the qgs project is returned. Otherwise, the actual
+     * WGS84 extent is returned.
+     * \param forceRecalculate True to return the current WGS84 extent whatever the read flags
      * \since QGIS 3.18
      */
-    QgsRectangle geographicExtent( bool actual = false ) const;
+    QgsRectangle wgs84Extent( bool forceRecalculate = false ) const;
 
     /**
      * Returns the status of the layer. An invalid layer is one which has a bad datasource
@@ -1522,10 +1522,8 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     void clone( QgsMapLayer *layer ) const;
 
-    /**
-     * Sets the \a extent in layer CRS.
-     */
-    virtual void setExtent( const QgsRectangle &extent );
+    //! Sets the extent
+    virtual void setExtent( const QgsRectangle &rect );
 
     //! Sets whether layer is valid or not
     void setValid( bool valid );
@@ -1618,7 +1616,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     mutable QgsRectangle mExtent;
 
     //! Extent of the layer in EPSG:4326
-    QgsRectangle mGeographicExtent;
+    QgsRectangle mWgs84Extent;
 
     //! Indicates if the layer is valid and can be drawn
     bool mValid = false;

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -520,7 +520,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * WGS84 extent read in the qgs project is returned. Otherwise, the actual
      * WGS84 extent is returned.
      * \param forceRecalculate True to return the current WGS84 extent whatever the read flags
-     * \since QGIS 3.18
+     * \since QGIS 3.20
      */
     QgsRectangle wgs84Extent( bool forceRecalculate = false ) const;
 
@@ -1616,7 +1616,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * Invalidates the WGS84 extent. If FlagTrustLayerMetadata is enabled,
      * the extent is not invalidated because we want to trust metadata whatever
      * happens.
-     * \since QGIS 3.18
+     * \since QGIS 3.20
      */
     void invalidateWgs84Extent();
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -515,6 +515,14 @@ class CORE_EXPORT QgsMapLayer : public QObject
     virtual QgsRectangle extent() const;
 
     /**
+     * Returns the geographic extent (EPSG:4326) of the layer.
+     *
+     * \see setExtent()
+     * \since QGIS 3.18
+     */
+    QgsRectangle geographicExtent() const;
+
+    /**
      * Returns the status of the layer. An invalid layer is one which has a bad datasource
      * or other problem. Child classes set this flag when initialized.
      * \returns TRUE if the layer is valid and can be accessed
@@ -1516,25 +1524,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * Sets the \a extent in layer CRS.
      *
      * If the layer CRS is not EPSG:4326 and the geographic extent is
-     * known, using setExtents() is faster.
-     *
-     * \see setExtents()
+     * known.
      */
     virtual void setExtent( const QgsRectangle &extent );
-
-    /**
-     * Simultaneously sets the \a extent and the \a geographicExtent.
-     *
-     * This call can be used to skip the costly coordinate transformation when setting
-     * the layer extent in case the geographic extent is already known (e.g. when loading
-     * a project).
-     *
-     * \see setExtent()
-     * \see geographicExtent()
-     *
-     * \since QGIS 3.18
-     */
-    virtual void setExtents( const QgsRectangle &extent, const QgsRectangle &geographicExtent );
 
     //! Sets whether layer is valid or not
     void setValid( bool valid );
@@ -1699,14 +1691,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \since QGIS 3.18
      */
     double mLayerOpacity = 1.0;
-
-    /**
-     * Returns the geographic extent (EPSG:4326) of the layer.
-     *
-     * \see setExtent()
-     * \since QGIS 3.18
-     */
-    QgsRectangle geographicExtent() const;
 
   private:
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1512,8 +1512,29 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     void clone( QgsMapLayer *layer ) const;
 
-    //! Sets the extent
-    virtual void setExtent( const QgsRectangle &rect );
+    /**
+     * Sets the \a extent in layer CRS.
+     *
+     * If the layer CRS is not EPSG:4326 and the geographic extent is
+     * known, using setExtents() is faster.
+     *
+     * \see setExtents()
+     */
+    virtual void setExtent( const QgsRectangle &extent );
+
+    /**
+     * Simultaneously sets the \a extent and the \a geographicExtent.
+     *
+     * This call can be used to skip the costly coordinate transformation when setting
+     * the layer extent in case the geographic extent is already known (e.g. when loading
+     * a project).
+     *
+     * \see setExtent()
+     * \see geographicExtent()
+     *
+     * \since QGIS 3.18
+     */
+    virtual void setExtents( const QgsRectangle &extent, const QgsRectangle &geographicExtent );
 
     //! Sets whether layer is valid or not
     void setValid( bool valid );
@@ -1605,6 +1626,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
     //! Extent of the layer
     mutable QgsRectangle mExtent;
 
+    //! Extent of the layer in EPSG:4326
+    QgsRectangle mGeographicExtent;
+
     //! Indicates if the layer is valid and can be drawn
     bool mValid = false;
 
@@ -1675,6 +1699,14 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \since QGIS 3.18
      */
     double mLayerOpacity = 1.0;
+
+    /**
+     * Returns the geographic extent (EPSG:4326) of the layer.
+     *
+     * \see setExtent()
+     * \since QGIS 3.18
+     */
+    QgsRectangle geographicExtent() const;
 
   private:
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -520,7 +520,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \see setExtent()
      * \since QGIS 3.18
      */
-    QgsRectangle geographicExtent() const;
+    QgsRectangle geographicExtent( bool actual = false ) const;
 
     /**
      * Returns the status of the layer. An invalid layer is one which has a bad datasource

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1612,12 +1612,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
     //! Sets error message
     void setError( const QgsError &error ) { mError = error;}
 
-    //! Extent of the layer
-    mutable QgsRectangle mExtent;
-
-    //! Extent of the layer in EPSG:4326
-    QgsRectangle mWgs84Extent;
-
     //! Indicates if the layer is valid and can be drawn
     bool mValid = false;
 
@@ -1698,6 +1692,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
                                bool &resultFlag, StyleCategories categories = AllStyleCategories );
     bool loadNamedPropertyFromDatabase( const QString &db, const QString &uri, QString &xml, QgsMapLayer::PropertyType type );
 
+    // const method because extents are mutable
+    void updateExtent( const QgsRectangle &extent ) const;
+
     /**
      * This method returns TRUE by default but can be overwritten to specify
      * that a certain layer is writable.
@@ -1755,6 +1752,12 @@ class CORE_EXPORT QgsMapLayer : public QObject
     //! Renderer for 3D views
     QgsAbstract3DRenderer *m3DRenderer = nullptr;
 
+    //! Extent of the layer
+    mutable QgsRectangle mExtent;
+
+    //! Extent of the layer in EPSG:4326
+    mutable QgsRectangle mWgs84Extent;
+
     /**
      * Stores the original XML properties of the layer when loaded from the project
      *
@@ -1764,6 +1767,8 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     //! To avoid firing multiple time repaintRequested signal on circular layer circular dependencies
     bool mRepaintRequestedFired = false;
+
+    friend class QgsVectorLayer;
 };
 
 Q_DECLARE_METATYPE( QgsMapLayer * )

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1612,6 +1612,12 @@ class CORE_EXPORT QgsMapLayer : public QObject
     //! Sets error message
     void setError( const QgsError &error ) { mError = error;}
 
+    /**
+     * Invalidates the WGS84 extent. If FlagTrustLayerMetadata is enabled,
+     * the extent is not invalidated because we want to trust metadata whatever
+     * happens.
+     * \since QGIS 3.18
+     */
     void invalidateWgs84Extent();
 
     //! Indicates if the layer is valid and can be drawn

--- a/src/core/qgspluginlayer.cpp
+++ b/src/core/qgspluginlayer.cpp
@@ -40,7 +40,7 @@ QString QgsPluginLayer::pluginLayerType()
 
 void QgsPluginLayer::setExtent( const QgsRectangle &extent )
 {
-  mExtent = extent;
+  QgsMapLayer::setExtent( extent );
   static_cast<QgsPluginLayerDataProvider *>( mDataProvider )->setExtent( extent );
 }
 

--- a/src/core/qgsxmlutils.cpp
+++ b/src/core/qgsxmlutils.cpp
@@ -78,7 +78,7 @@ QDomElement QgsXmlUtils::writeMapUnits( QgsUnitTypes::DistanceUnit units, QDomDo
   return unitsNode;
 }
 
-QDomElement QgsXmlUtils::writeRectangle( const QgsRectangle &rect, QDomDocument &doc )
+QDomElement QgsXmlUtils::writeRectangle( const QgsRectangle &rect, QDomDocument &doc, const QString &elementName )
 {
   QDomElement xMin = doc.createElement( QStringLiteral( "xmin" ) );
   QDomElement yMin = doc.createElement( QStringLiteral( "ymin" ) );
@@ -95,7 +95,7 @@ QDomElement QgsXmlUtils::writeRectangle( const QgsRectangle &rect, QDomDocument 
   xMax.appendChild( xMaxText );
   yMax.appendChild( yMaxText );
 
-  QDomElement extentNode = doc.createElement( QStringLiteral( "extent" ) );
+  QDomElement extentNode = doc.createElement( elementName );
   extentNode.appendChild( xMin );
   extentNode.appendChild( yMin );
   extentNode.appendChild( xMax );

--- a/src/core/qgsxmlutils.h
+++ b/src/core/qgsxmlutils.h
@@ -59,7 +59,7 @@ class CORE_EXPORT QgsXmlUtils
      */
     static QDomElement writeMapUnits( QgsUnitTypes::DistanceUnit units, QDomDocument &doc );
 
-    static QDomElement writeRectangle( const QgsRectangle &rect, QDomDocument &doc );
+    static QDomElement writeRectangle( const QgsRectangle &rect, QDomDocument &doc, const QString &elementName = QStringLiteral( "extent" ) );
 
     /**
      * Write a QVariant to a QDomElement.

--- a/src/core/qgsxmlutils.h
+++ b/src/core/qgsxmlutils.h
@@ -59,6 +59,13 @@ class CORE_EXPORT QgsXmlUtils
      */
     static QDomElement writeMapUnits( QgsUnitTypes::DistanceUnit units, QDomDocument &doc );
 
+    /**
+     * Encodes a rectangle to a DOM element.
+     * \param rect rectangle to encode
+     * \param doc DOM document
+     * \param elementName name of the DOM element
+     * \returns element containing encoded rectangle
+     */
     static QDomElement writeRectangle( const QgsRectangle &rect, QDomDocument &doc, const QString &elementName = QStringLiteral( "extent" ) );
 
     /**

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -1759,6 +1759,7 @@ void QgsRasterLayer::setTransformContext( const QgsCoordinateTransformContext &t
 {
   if ( mDataProvider )
     mDataProvider->setTransformContext( transformContext );
+  invalidateWgs84Extent();
 }
 
 QStringList QgsRasterLayer::subLayers() const

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -848,23 +848,20 @@ QgsRectangle QgsVectorLayer::extent() const
 
   if ( !mValidExtent && mLazyExtent && mDataProvider && !mDataProvider->hasMetadata() && mReadExtentFromXml && !mXmlExtent.isNull() )
   {
-    mExtent = mXmlExtent;
+    updateExtent( mXmlExtent );
     mValidExtent = true;
     mLazyExtent = false;
   }
 
   if ( !mValidExtent && mLazyExtent && mDataProvider && mDataProvider->isValid() )
   {
-    // get the extent
-    QgsRectangle mbr = mDataProvider->extent();
+    // store the extent
+    updateExtent( mDataProvider->extent() );
+    mValidExtent = true;
+    mLazyExtent = false;
 
     // show the extent
-    QgsDebugMsgLevel( QStringLiteral( "Extent of layer: %1" ).arg( mbr.toString() ), 3 );
-    // store the extent
-    mValidExtent = true;
-    mExtent = mbr;
-
-    mLazyExtent = false;
+    QgsDebugMsgLevel( QStringLiteral( "Extent of layer: %1" ).arg( mExtent.toString() ), 3 );
   }
 
   if ( mValidExtent )
@@ -886,7 +883,7 @@ QgsRectangle QgsVectorLayer::extent() const
     // but only when there are some features already
     if ( mDataProvider->featureCount() != 0 )
     {
-      QgsRectangle r = mDataProvider->extent();
+      const QgsRectangle r = mDataProvider->extent();
       rect.combineExtentWith( r );
     }
 
@@ -897,7 +894,7 @@ QgsRectangle QgsVectorLayer::extent() const
       {
         if ( it->hasGeometry() )
         {
-          QgsRectangle r = it->geometry().boundingBox();
+          const QgsRectangle r = it->geometry().boundingBox();
           rect.combineExtentWith( r );
         }
       }
@@ -913,7 +910,7 @@ QgsRectangle QgsVectorLayer::extent() const
     {
       if ( fet.hasGeometry() && fet.geometry().type() != QgsWkbTypes::UnknownGeometry )
       {
-        QgsRectangle bb = fet.geometry().boundingBox();
+        const QgsRectangle bb = fet.geometry().boundingBox();
         rect.combineExtentWith( bb );
       }
     }
@@ -925,8 +922,8 @@ QgsRectangle QgsVectorLayer::extent() const
     rect = QgsRectangle(); // use rectangle with zero coordinates
   }
 
+  updateExtent( rect );
   mValidExtent = true;
-  mExtent = rect;
 
   // Send this (hopefully) up the chain to the map canvas
   emit recalculateExtents();

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -344,6 +344,7 @@ bool QgsVectorTileLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QStr
 void QgsVectorTileLayer::setTransformContext( const QgsCoordinateTransformContext &transformContext )
 {
   Q_UNUSED( transformContext )
+  invalidateWgs84Extent();
 }
 
 QString QgsVectorTileLayer::loadDefaultStyle( bool &resultFlag )

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1065,6 +1065,7 @@ namespace QgsWms
 
             //Ex_GeographicBoundingBox
             QgsRectangle extent = l->extent();  // layer extent by default
+            QgsRectangle geoExtent = l->geographicExtent();
             if ( l->type() == QgsMapLayerType::VectorLayer )
             {
               QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( l );
@@ -1072,6 +1073,7 @@ namespace QgsWms
               {
                 // if there's no feature, use the wms extent defined in the
                 // project...
+                geoExtent = QgsRectangle();
                 extent = QgsServerProjectUtils::wmsExtent( *project );
                 if ( extent.isNull() )
                 {
@@ -1095,7 +1097,7 @@ namespace QgsWms
               }
             }
 
-            appendLayerBoundingBoxes( doc, layerElem, extent, l->crs(), crsList, outputCrsList, project, l->geographicExtent() );
+            appendLayerBoundingBoxes( doc, layerElem, extent, l->crs(), crsList, outputCrsList, project, geoExtent );
           }
 
           // add details about supported styles of the layer
@@ -1451,6 +1453,12 @@ namespace QgsWms
             wgs84BoundingRect = QgsRectangle();
           }
         }
+      }
+
+      if ( qgsDoubleNear( wgs84BoundingRect.xMinimum(), wgs84BoundingRect.xMaximum() ) || qgsDoubleNear( wgs84BoundingRect.yMinimum(), wgs84BoundingRect.yMaximum() ) )
+      {
+        //layer bbox cannot be empty
+        wgs84BoundingRect.grow( 0.000001 );
       }
 
       //Ex_GeographicBoundingBox

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1065,7 +1065,7 @@ namespace QgsWms
 
             //Ex_GeographicBoundingBox
             QgsRectangle extent = l->extent();  // layer extent by default
-            QgsRectangle geoExtent = l->geographicExtent();
+            QgsRectangle wgs84Extent = l->wgs84Extent();
             if ( l->type() == QgsMapLayerType::VectorLayer )
             {
               QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( l );
@@ -1073,7 +1073,7 @@ namespace QgsWms
               {
                 // if there's no feature, use the wms extent defined in the
                 // project...
-                geoExtent = QgsRectangle();
+                wgs84Extent = QgsRectangle();
                 extent = QgsServerProjectUtils::wmsExtent( *project );
                 if ( extent.isNull() )
                 {
@@ -1097,7 +1097,7 @@ namespace QgsWms
               }
             }
 
-            appendLayerBoundingBoxes( doc, layerElem, extent, l->crs(), crsList, outputCrsList, project, geoExtent );
+            appendLayerBoundingBoxes( doc, layerElem, extent, l->crs(), crsList, outputCrsList, project, wgs84Extent );
           }
 
           // add details about supported styles of the layer

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1462,9 +1462,9 @@ namespace QgsWms
       }
 
       //Ex_GeographicBoundingBox
-      int wgs84precision = 6;
       QDomElement ExGeoBBoxElement;
-      QString version = doc.documentElement().attribute( QStringLiteral( "version" ) );
+      const int wgs84precision = 6;
+      const QString version = doc.documentElement().attribute( QStringLiteral( "version" ) );
       if ( version == QLatin1String( "1.1.1" ) ) // WMS Version 1.1.1
       {
         ExGeoBBoxElement = doc.createElement( QStringLiteral( "LatLonBoundingBox" ) );

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1435,7 +1435,7 @@ namespace QgsWms
       QgsRectangle wgs84BoundingRect = lGeoExtent;
       if ( wgs84BoundingRect.isNull() )
       {
-        QgsCoordinateReferenceSystem wgs84 = QgsCoordinateReferenceSystem::fromOgcWmsCrs( geoEpsgCrsAuthId() );
+        const QgsCoordinateReferenceSystem wgs84 = QgsCoordinateReferenceSystem::fromOgcWmsCrs( geoEpsgCrsAuthId() );
 
         //transform the layers native CRS into WGS84
         if ( !layerExtent.isNull() )


### PR DESCRIPTION
## Description

In case of a very big project with a lot of layers, the generation of the `GetCapabilities` document losts a lot of time due to the computation of the extent in EPSG:4326 for every layer (`tranformBoundingBox()` is very slow...). 

So we propose to store the geographic extent in the project as it is already the case for the extent. The geographic extent stored in the project is read and used only if the trust option is activated.

This optimization gives ~6% speed gain with a project of ~1000 layers:

```
$ export QGIS_SERVER_TRUST_LAYER_METADATA=0
$  time ./output/bin/qgis_mapserv.fcgi
real	0m12.875s
user	0m12.214s
sys	0m0.373s

$ export QGIS_SERVER_TRUST_LAYER_METADATA=1
$  time ./output/bin/qgis_mapserv.fcgi
real	0m12.014s
user	0m11.461s
sys	0m0.297s
```