### PR TITLE
[3D] [point cloud] adjust screen space error from UI

### DIFF
--- a/python/3d/auto_generated/qgspointcloudlayer3drenderer.sip.in
+++ b/python/3d/auto_generated/qgspointcloudlayer3drenderer.sip.in
@@ -62,6 +62,24 @@ Returns 3D symbol associated with the renderer
     virtual void resolveReferences( const QgsProject &project );
 
 
+    double maximumScreenError() const;
+%Docstring
+Returns the maximum screen error allowed when rendering the point cloud.
+
+Larger values result in a faster render with less points rendered.
+
+.. seealso:: :py:func:`setMaximumScreenError`
+%End
+
+    void setMaximumScreenError( double error );
+%Docstring
+Sets the maximum screen ``error`` allowed when rendering the point cloud.
+
+Larger values result in a faster render with less points rendered.
+
+.. seealso:: :py:func:`maximumScreenError`
+%End
+
   private:
     QgsPointCloudLayer3DRenderer( const QgsPointCloudLayer3DRenderer & );
     QgsPointCloudLayer3DRenderer &operator=( const QgsPointCloudLayer3DRenderer & );

--- a/src/3d/qgspointcloudlayer3drenderer.cpp
+++ b/src/3d/qgspointcloudlayer3drenderer.cpp
@@ -99,7 +99,7 @@ Qt3DCore::QEntity *QgsPointCloudLayer3DRenderer::createEntity( const Qgs3DMapSet
   if ( !mSymbol )
     return nullptr;
 
-  return new QgsPointCloudLayerChunkedEntity( pcl->dataProvider()->index(), map, dynamic_cast<QgsPointCloud3DSymbol *>( mSymbol->clone() ) );
+  return new QgsPointCloudLayerChunkedEntity( pcl->dataProvider()->index(), map, dynamic_cast<QgsPointCloud3DSymbol *>( mSymbol->clone() ), maximumScreenError() );
 }
 
 void QgsPointCloudLayer3DRenderer::setSymbol( QgsPointCloud3DSymbol *symbol )
@@ -147,4 +147,14 @@ void QgsPointCloudLayer3DRenderer::readXml( const QDomElement &elem, const QgsRe
 void QgsPointCloudLayer3DRenderer::resolveReferences( const QgsProject &project )
 {
   mLayerRef.setLayer( project.mapLayer( mLayerRef.layerId ) );
+}
+
+double QgsPointCloudLayer3DRenderer::maximumScreenError() const
+{
+  return mMaximumScreenError;
+}
+
+void QgsPointCloudLayer3DRenderer::setMaximumScreenError( double error )
+{
+  mMaximumScreenError = error;
 }

--- a/src/3d/qgspointcloudlayer3drenderer.cpp
+++ b/src/3d/qgspointcloudlayer3drenderer.cpp
@@ -132,7 +132,7 @@ void QgsPointCloudLayer3DRenderer::readXml( const QDomElement &elem, const QgsRe
   QDomElement elemSymbol = elem.firstChildElement( QStringLiteral( "symbol" ) );
 
   const QString symbolType = elemSymbol.attribute( QStringLiteral( "type" ) );
-  mMaximumScreenError = elem.attribute( QStringLiteral( "max-screen-error" ), QStringLiteral( "5.0" ) ).toDouble();
+  mMaximumScreenError = elem.attribute( QStringLiteral( "max-screen-error" ), QStringLiteral( "1.0" ) ).toDouble();
 
   if ( symbolType == QLatin1String( "single-color" ) )
     mSymbol.reset( new QgsSingleColorPointCloud3DSymbol );

--- a/src/3d/qgspointcloudlayer3drenderer.cpp
+++ b/src/3d/qgspointcloudlayer3drenderer.cpp
@@ -114,6 +114,7 @@ void QgsPointCloudLayer3DRenderer::writeXml( QDomElement &elem, const QgsReadWri
   QDomDocument doc = elem.ownerDocument();
 
   elem.setAttribute( QStringLiteral( "layer" ), mLayerRef.layerId );
+  elem.setAttribute( QStringLiteral( "max-screen-error" ), maximumScreenError() );
 
   QDomElement elemSymbol = doc.createElement( QStringLiteral( "symbol" ) );
   if ( mSymbol )
@@ -131,6 +132,8 @@ void QgsPointCloudLayer3DRenderer::readXml( const QDomElement &elem, const QgsRe
   QDomElement elemSymbol = elem.firstChildElement( QStringLiteral( "symbol" ) );
 
   const QString symbolType = elemSymbol.attribute( QStringLiteral( "type" ) );
+  mMaximumScreenError = elem.attribute( QStringLiteral( "max-screen-error" ), QStringLiteral( "5.0" ) ).toDouble();
+
   if ( symbolType == QLatin1String( "single-color" ) )
     mSymbol.reset( new QgsSingleColorPointCloud3DSymbol );
   else if ( symbolType == QLatin1String( "color-ramp" ) )

--- a/src/3d/qgspointcloudlayer3drenderer.h
+++ b/src/3d/qgspointcloudlayer3drenderer.h
@@ -178,9 +178,28 @@ class _3D_EXPORT QgsPointCloudLayer3DRenderer : public QgsAbstract3DRenderer
     void readXml( const QDomElement &elem, const QgsReadWriteContext &context ) override;
     void resolveReferences( const QgsProject &project ) override;
 
+    /**
+     * Returns the maximum screen error allowed when rendering the point cloud.
+     *
+     * Larger values result in a faster render with less points rendered.
+     *
+     * \see setMaximumScreenError()
+     */
+    double maximumScreenError() const;
+
+    /**
+     * Sets the maximum screen \a error allowed when rendering the point cloud.
+     *
+     * Larger values result in a faster render with less points rendered.
+     *
+     * \see maximumScreenError()
+     */
+    void setMaximumScreenError( double error );
+
   private:
     QgsMapLayerRef mLayerRef; //!< Layer used to extract mesh data from
     std::unique_ptr< QgsPointCloud3DSymbol > mSymbol;
+    double mMaximumScreenError = 1.0;
 
   private:
 #ifdef SIP_RUN

--- a/src/3d/qgspointcloudlayerchunkloader_p.cpp
+++ b/src/3d/qgspointcloudlayerchunkloader_p.cpp
@@ -190,8 +190,8 @@ QgsAABB nodeBoundsToAABB( QgsPointCloudDataBounds nodeBounds, QgsVector3D offset
 }
 
 
-QgsPointCloudLayerChunkedEntity::QgsPointCloudLayerChunkedEntity( QgsPointCloudIndex *pc, const Qgs3DMapSettings &map, QgsPointCloud3DSymbol *symbol )
-  : QgsChunkedEntity( 5, // max. allowed screen error (in pixels)  -- // TODO
+QgsPointCloudLayerChunkedEntity::QgsPointCloudLayerChunkedEntity( QgsPointCloudIndex *pc, const Qgs3DMapSettings &map, QgsPointCloud3DSymbol *symbol, float maxScreenError )
+  : QgsChunkedEntity( maxScreenError,
                       new QgsPointCloudLayerChunkLoaderFactory( map, pc, symbol ), true )
 {
   setUsingAdditiveStrategy( true );

--- a/src/3d/qgspointcloudlayerchunkloader_p.h
+++ b/src/3d/qgspointcloudlayerchunkloader_p.h
@@ -115,7 +115,7 @@ class QgsPointCloudLayerChunkedEntity : public QgsChunkedEntity
 {
     Q_OBJECT
   public:
-    explicit QgsPointCloudLayerChunkedEntity( QgsPointCloudIndex *pc, const Qgs3DMapSettings &map, QgsPointCloud3DSymbol *symbol );
+    explicit QgsPointCloudLayerChunkedEntity( QgsPointCloudIndex *pc, const Qgs3DMapSettings &map, QgsPointCloud3DSymbol *symbol, float maxScreenError );
 
     ~QgsPointCloudLayerChunkedEntity();
 };

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -527,3 +527,8 @@ void QgsPointCloud3DSymbolWidget::blueAttributeChanged()
     }
   }
 }
+
+double QgsPointCloud3DSymbolWidget::maximumScreenError() const
+{
+  return mMaxScreenErrorSpinBox->value();
+}

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -86,6 +86,7 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
   if ( symbol )
     setSymbol( symbol );
 
+
   connect( mPointSizeSpinBox, qgis::overload<double>::of( &QDoubleSpinBox::valueChanged ), this, &QgsPointCloud3DSymbolWidget::emitChangedSignal );
   connect( mRenderingStyleComboBox, qgis::overload< int >::of( &QComboBox::currentIndexChanged ), this, &QgsPointCloud3DSymbolWidget::onRenderingStyleChanged );
   connect( mScalarRecalculateMinMaxButton, &QPushButton::clicked, this, &QgsPointCloud3DSymbolWidget::setMinMaxFromLayer );
@@ -95,6 +96,8 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
            this, &QgsPointCloud3DSymbolWidget::rampAttributeChanged );
   connect( mColorRampShaderMinEdit, qgis::overload<double>::of( &QDoubleSpinBox::valueChanged ), this, &QgsPointCloud3DSymbolWidget::minMaxChanged );
   connect( mColorRampShaderMaxEdit, qgis::overload<double>::of( &QDoubleSpinBox::valueChanged ), this, &QgsPointCloud3DSymbolWidget::minMaxChanged );
+
+  connect( mMaxScreenErrorSpinBox, qgis::overload<double>::of( &QDoubleSpinBox::valueChanged ), this, &QgsPointCloud3DSymbolWidget::maximumScreenErrorChanged );
 
   rampAttributeChanged();
 }
@@ -528,7 +531,16 @@ void QgsPointCloud3DSymbolWidget::blueAttributeChanged()
   }
 }
 
-double QgsPointCloud3DSymbolWidget::maximumScreenError() const
+void QgsPointCloud3DSymbolWidget::setMaximumScreenError( double maxScreenError )
 {
-  return mMaxScreenErrorSpinBox->value();
+  mMaxScreenErrorSpinBox->setValue( maxScreenError );
+  mMaximumScreenError = maxScreenError;
+}
+
+void QgsPointCloud3DSymbolWidget::maximumScreenErrorChanged( double maxScreenError )
+{
+  if ( maxScreenError == mMaximumScreenError )
+    return;
+  mMaximumScreenError = maxScreenError;
+  emitChangedSignal();
 }

--- a/src/app/3d/qgspointcloud3dsymbolwidget.h
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.h
@@ -32,7 +32,9 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
     void setSymbol( QgsPointCloud3DSymbol *symbol );
 
     QgsPointCloud3DSymbol *symbol() const;
-    double maximumScreenError() const;
+
+    void setMaximumScreenError( double maxScreenError );
+    double maximumScreenError() const { return mMaximumScreenError; }
 
   private slots:
     void reloadColorRampShaderMinMax();
@@ -51,6 +53,7 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
     void redAttributeChanged();
     void greenAttributeChanged();
     void blueAttributeChanged();
+    void maximumScreenErrorChanged( double maxScreenError );
 
   signals:
     void changed();
@@ -64,6 +67,7 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
     QgsPointCloudLayer *mLayer = nullptr;
 
     bool mBlockMinMaxChanged = false;
+    double mMaximumScreenError = 5.0f;
 
     double mProviderMin = std::numeric_limits< double >::quiet_NaN();
     double mProviderMax = std::numeric_limits< double >::quiet_NaN();

--- a/src/app/3d/qgspointcloud3dsymbolwidget.h
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.h
@@ -32,6 +32,7 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
     void setSymbol( QgsPointCloud3DSymbol *symbol );
 
     QgsPointCloud3DSymbol *symbol() const;
+    double maximumScreenError() const;
 
   private slots:
     void reloadColorRampShaderMinMax();

--- a/src/app/3d/qgspointcloud3dsymbolwidget.h
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.h
@@ -67,7 +67,7 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
     QgsPointCloudLayer *mLayer = nullptr;
 
     bool mBlockMinMaxChanged = false;
-    double mMaximumScreenError = 5.0f;
+    double mMaximumScreenError = 1.0f;
 
     double mProviderMin = std::numeric_limits< double >::quiet_NaN();
     double mProviderMax = std::numeric_limits< double >::quiet_NaN();

--- a/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
+++ b/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
@@ -50,6 +50,7 @@ QgsPointCloudLayer3DRenderer *QgsPointCloudLayer3DRendererWidget::renderer()
   QgsPointCloud3DSymbol *sym = mWidgetPointCloudSymbol->symbol();
   renderer->setSymbol( sym );
   renderer->setLayer( qobject_cast<QgsPointCloudLayer *>( mLayer ) );
+  renderer->setMaximumScreenError( mWidgetPointCloudSymbol->maximumScreenError() );
   return renderer;
 }
 

--- a/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
+++ b/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
@@ -41,7 +41,10 @@ QgsPointCloudLayer3DRendererWidget::QgsPointCloudLayer3DRendererWidget( QgsPoint
 void QgsPointCloudLayer3DRendererWidget::setRenderer( const QgsPointCloudLayer3DRenderer *renderer )
 {
   if ( renderer != nullptr )
+  {
     mWidgetPointCloudSymbol->setSymbol( const_cast<QgsPointCloud3DSymbol *>( renderer->symbol() ) );
+    mWidgetPointCloudSymbol->setMaximumScreenError( renderer->maximumScreenError() );
+  }
 }
 
 QgsPointCloudLayer3DRenderer *QgsPointCloudLayer3DRendererWidget::renderer()

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -58,6 +58,23 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="1">
+       <widget class="QDoubleSpinBox" name="mMaxScreenErrorSpinBox">
+        <property name="maximum">
+         <double>100000.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>5.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Maximum screen space error</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -64,7 +64,7 @@
          <double>100000.000000000000000</double>
         </property>
         <property name="value">
-         <double>5.000000000000000</double>
+         <double>1.000000000000000</double>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
## Description
This adds the ability to choose the screen space error used to render the point cloud.
![screen_space_error_adjustment](https://user-images.githubusercontent.com/29183781/101176123-5b29aa80-3646-11eb-8863-3dbc111d4e98.gif)
