### PR TITLE
Add getter for QgsLocatorResults.userData

### DIFF
--- a/python/core/auto_generated/locator/qgslocatorfilter.sip.in
+++ b/python/core/auto_generated/locator/qgslocatorfilter.sip.in
@@ -34,6 +34,14 @@ Constructor for QgsLocatorResult.
 Constructor for QgsLocatorResult.
 %End
 
+
+    QVariant getUserData() const;
+%Docstring
+Returns the ``userData``.
+
+.. versionadded:: 3.18
+%End
+
     QgsLocatorFilter *filter;
 
     QString displayString;

--- a/src/core/locator/qgslocatorfilter.cpp
+++ b/src/core/locator/qgslocatorfilter.cpp
@@ -100,3 +100,8 @@ void QgsLocatorFilter::logMessage( const QString &message, Qgis::MessageLevel le
   QgsMessageLog::logMessage( QString( "%1: %2" ).arg( name(), message ), QStringLiteral( "Locator bar" ), level );
 }
 
+
+QVariant QgsLocatorResult::getUserData() const
+{
+  return userData;
+}

--- a/src/core/locator/qgslocatorfilter.h
+++ b/src/core/locator/qgslocatorfilter.h
@@ -54,6 +54,14 @@ class CORE_EXPORT QgsLocatorResult
       , userData( userData )
     {}
 
+
+    /**
+     * Returns the ``userData``.
+     *
+     * \since QGIS 3.18
+     */
+    QVariant getUserData() const;
+
     /**
      * Filter from which the result was obtained. This is automatically set.
      */


### PR DESCRIPTION
Looks like sip doesn't really realize when a property is updated. Add a getter interface to avoid any caching issues on sip side.

References https://github.com/opengisch/qgis-swiss-locator/issues/9