### PR TITLE
Zoom to multiple selected layer(s) in layer tree

### DIFF
--- a/python/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
@@ -49,7 +49,19 @@ Action to uncheck a group and all its children
 Action to check a group and all its parents
 %End
 
-    QAction *actionZoomToLayer( QgsMapCanvas *canvas, QObject *parent = 0 ) /Factory/;
+ QAction *actionZoomToLayer( QgsMapCanvas *canvas, QObject *parent = 0 ) /Factory/;
+%Docstring
+
+.. deprecated:: QGIS 3.18
+  use actionZoomToLayers()
+%End
+
+    QAction *actionZoomToLayers( QgsMapCanvas *canvas, QObject *parent = 0 ) /Factory/;
+%Docstring
+Action to zoom to all the selected layer(s) in the layer tree
+
+.. versionadded:: 3.18
+%End
 
     QAction *actionZoomToSelection( QgsMapCanvas *canvas, QObject *parent = 0 ) /Factory/;
 %Docstring
@@ -98,7 +110,21 @@ Action to enable/disable mutually exclusive flag of a group (only one child node
 .. versionadded:: 2.12
 %End
 
-    void zoomToLayer( QgsMapCanvas *canvas );
+ void zoomToLayer( QgsMapCanvas *canvas );
+%Docstring
+
+.. deprecated:: QGIS 3.18
+  use zoomToLayers()
+%End
+
+    void zoomToLayers( QgsMapCanvas *canvas );
+%Docstring
+Zooms to all the selected layer(s) in the layer tree
+
+.. seealso:: :py:func:`zoomToLayers`
+
+.. versionadded:: 3.18
+%End
 
     void zoomToSelection( QgsMapCanvas *canvas );
 %Docstring
@@ -117,7 +143,20 @@ Action to enable/disable mutually exclusive flag of a group (only one child node
     void removeGroupOrLayer();
     void renameGroupOrLayer();
     void showFeatureCount();
-    void zoomToLayer();
+
+ void zoomToLayer();
+%Docstring
+
+.. deprecated:: QGIS 3.18
+  use zoomToLayers()
+%End
+
+    void zoomToLayers();
+%Docstring
+Slot to zoom to all the selected layer(s) in the layer tree
+
+.. versionadded:: 3.18
+%End
 
     void zoomToSelection();
 %Docstring

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -517,6 +517,10 @@ Returns the native zoom full extent action. Call :py:func:`~QgisInterface.trigge
 %Docstring
 Returns the native zoom to layer action. Call :py:func:`~QgisInterface.trigger` on it to zoom to the active layer.
 %End
+    virtual QAction *actionZoomToLayers() = 0;
+%Docstring
+Returns the native zoom to layers action. Call :py:func:`~QgisInterface.trigger` on it to zoom to the selected layers.
+%End
     virtual QAction *actionZoomToSelected() = 0;
 %Docstring
 Returns the native zoom to selected action. Call :py:func:`~QgisInterface.trigger` on it to zoom to the current selection.

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2735,7 +2735,7 @@ void QgisApp::createActions()
   connect( mActionMeasureArea, &QAction::triggered, this, &QgisApp::measureArea );
   connect( mActionMeasureAngle, &QAction::triggered, this, &QgisApp::measureAngle );
   connect( mActionZoomFullExtent, &QAction::triggered, this, &QgisApp::zoomFull );
-  connect( mActionZoomToLayer, &QAction::triggered, this, &QgisApp::zoomToLayerExtent );
+  connect( mActionZoomToLayers, &QAction::triggered, this, &QgisApp::zoomToLayerExtent );
   connect( mActionZoomToSelected, &QAction::triggered, this, &QgisApp::zoomToSelected );
   connect( mActionZoomLast, &QAction::triggered, this, &QgisApp::zoomToPrevious );
   connect( mActionZoomNext, &QAction::triggered, this, &QgisApp::zoomToNext );
@@ -4098,7 +4098,7 @@ void QgisApp::setTheme( const QString &themeName )
   mActionPanToSelected->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionPanToSelected.svg" ) ) );
   mActionZoomLast->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomLast.svg" ) ) );
   mActionZoomNext->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomNext.svg" ) ) );
-  mActionZoomToLayer->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomToLayer.svg" ) ) );
+  mActionZoomToLayers->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomToLayer.svg" ) ) );
   mActionZoomActualSize->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomActual.svg" ) ) );
   mActionIdentify->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionIdentify.svg" ) ) );
   mActionFeatureAction->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mAction.svg" ) ) );
@@ -12163,7 +12163,7 @@ void QgisApp::legendGroupSetWmsData()
 
 void QgisApp::zoomToLayerExtent()
 {
-  mLayerTreeView->defaultActions()->zoomToLayer( mMapCanvas );
+  mLayerTreeView->defaultActions()->zoomToLayers( mMapCanvas );
 }
 
 void QgisApp::showPluginManager()
@@ -14653,7 +14653,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
     mActionIncreaseGamma->setEnabled( false );
     mActionDecreaseGamma->setEnabled( false );
     mActionZoomActualSize->setEnabled( false );
-    mActionZoomToLayer->setEnabled( false );
+    mActionZoomToLayers->setEnabled( false );
 
     enableDigitizeWithCurveAction( false );
 
@@ -14664,7 +14664,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
 
   mActionLayerProperties->setEnabled( QgsProject::instance()->layerIsEmbedded( layer->id() ).isEmpty() );
   mActionAddToOverview->setEnabled( true );
-  mActionZoomToLayer->setEnabled( true );
+  mActionZoomToLayers->setEnabled( true );
 
   mActionCopyStyle->setEnabled( true );
   mActionPasteStyle->setEnabled( clipboard()->hasFormat( QStringLiteral( QGSCLIPBOARD_STYLE_MIME ) ) );
@@ -14695,7 +14695,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionIncreaseGamma->setEnabled( false );
       mActionDecreaseGamma->setEnabled( false );
       mActionZoomActualSize->setEnabled( false );
-      mActionZoomToLayer->setEnabled( isSpatial );
+      mActionZoomToLayers->setEnabled( isSpatial );
       mActionZoomToSelected->setEnabled( isSpatial );
       mActionLabeling->setEnabled( isSpatial );
       mActionDiagramProperties->setEnabled( isSpatial );
@@ -14949,7 +14949,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionSelectFreehand->setEnabled( false );
       mActionSelectRadius->setEnabled( false );
       mActionZoomActualSize->setEnabled( true );
-      mActionZoomToLayer->setEnabled( true );
+      mActionZoomToLayers->setEnabled( true );
       mActionZoomToSelected->setEnabled( false );
       mActionOpenTable->setEnabled( false );
       mActionSelectAll->setEnabled( false );
@@ -15062,7 +15062,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionSelectFreehand->setEnabled( false );
       mActionSelectRadius->setEnabled( false );
       mActionZoomActualSize->setEnabled( false );
-      mActionZoomToLayer->setEnabled( true );
+      mActionZoomToLayers->setEnabled( true );
       mActionZoomToSelected->setEnabled( false );
       mActionOpenTable->setEnabled( false );
       mActionSelectAll->setEnabled( false );
@@ -15127,7 +15127,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionSelectFreehand->setEnabled( false );
       mActionSelectRadius->setEnabled( false );
       mActionZoomActualSize->setEnabled( false );
-      mActionZoomToLayer->setEnabled( true );
+      mActionZoomToLayers->setEnabled( true );
       mActionZoomToSelected->setEnabled( false );
       mActionOpenTable->setEnabled( false );
       mActionSelectAll->setEnabled( false );
@@ -15192,7 +15192,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionSelectFreehand->setEnabled( false );
       mActionSelectRadius->setEnabled( false );
       mActionZoomActualSize->setEnabled( false );
-      mActionZoomToLayer->setEnabled( true );
+      mActionZoomToLayers->setEnabled( true );
       mActionZoomToSelected->setEnabled( false );
       mActionOpenTable->setEnabled( false );
       mActionSelectAll->setEnabled( false );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2735,6 +2735,7 @@ void QgisApp::createActions()
   connect( mActionMeasureArea, &QAction::triggered, this, &QgisApp::measureArea );
   connect( mActionMeasureAngle, &QAction::triggered, this, &QgisApp::measureAngle );
   connect( mActionZoomFullExtent, &QAction::triggered, this, &QgisApp::zoomFull );
+  connect( mActionZoomToLayer, &QAction::triggered, this, &QgisApp::zoomToLayerExtent );
   connect( mActionZoomToLayers, &QAction::triggered, this, &QgisApp::zoomToLayerExtent );
   connect( mActionZoomToSelected, &QAction::triggered, this, &QgisApp::zoomToSelected );
   connect( mActionZoomLast, &QAction::triggered, this, &QgisApp::zoomToPrevious );
@@ -4098,6 +4099,7 @@ void QgisApp::setTheme( const QString &themeName )
   mActionPanToSelected->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionPanToSelected.svg" ) ) );
   mActionZoomLast->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomLast.svg" ) ) );
   mActionZoomNext->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomNext.svg" ) ) );
+  mActionZoomToLayer->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomToLayer.svg" ) ) );
   mActionZoomToLayers->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomToLayer.svg" ) ) );
   mActionZoomActualSize->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomActual.svg" ) ) );
   mActionIdentify->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionIdentify.svg" ) ) );
@@ -14654,6 +14656,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
     mActionDecreaseGamma->setEnabled( false );
     mActionZoomActualSize->setEnabled( false );
     mActionZoomToLayers->setEnabled( false );
+    mActionZoomToLayer->setEnabled( false );
 
     enableDigitizeWithCurveAction( false );
 
@@ -14665,6 +14668,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
   mActionLayerProperties->setEnabled( QgsProject::instance()->layerIsEmbedded( layer->id() ).isEmpty() );
   mActionAddToOverview->setEnabled( true );
   mActionZoomToLayers->setEnabled( true );
+  mActionZoomToLayer->setEnabled( true );
 
   mActionCopyStyle->setEnabled( true );
   mActionPasteStyle->setEnabled( clipboard()->hasFormat( QStringLiteral( QGSCLIPBOARD_STYLE_MIME ) ) );
@@ -14695,6 +14699,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionIncreaseGamma->setEnabled( false );
       mActionDecreaseGamma->setEnabled( false );
       mActionZoomActualSize->setEnabled( false );
+      mActionZoomToLayer->setEnabled( isSpatial );
       mActionZoomToLayers->setEnabled( isSpatial );
       mActionZoomToSelected->setEnabled( isSpatial );
       mActionLabeling->setEnabled( isSpatial );
@@ -14949,6 +14954,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionSelectFreehand->setEnabled( false );
       mActionSelectRadius->setEnabled( false );
       mActionZoomActualSize->setEnabled( true );
+      mActionZoomToLayer->setEnabled( true );
       mActionZoomToLayers->setEnabled( true );
       mActionZoomToSelected->setEnabled( false );
       mActionOpenTable->setEnabled( false );
@@ -15062,6 +15068,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionSelectFreehand->setEnabled( false );
       mActionSelectRadius->setEnabled( false );
       mActionZoomActualSize->setEnabled( false );
+      mActionZoomToLayer->setEnabled( true );
       mActionZoomToLayers->setEnabled( true );
       mActionZoomToSelected->setEnabled( false );
       mActionOpenTable->setEnabled( false );
@@ -15127,6 +15134,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionSelectFreehand->setEnabled( false );
       mActionSelectRadius->setEnabled( false );
       mActionZoomActualSize->setEnabled( false );
+      mActionZoomToLayer->setEnabled( true );
       mActionZoomToLayers->setEnabled( true );
       mActionZoomToSelected->setEnabled( false );
       mActionOpenTable->setEnabled( false );
@@ -15192,6 +15200,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionSelectFreehand->setEnabled( false );
       mActionSelectRadius->setEnabled( false );
       mActionZoomActualSize->setEnabled( false );
+      mActionZoomToLayer->setEnabled( true );
       mActionZoomToLayers->setEnabled( true );
       mActionZoomToSelected->setEnabled( false );
       mActionOpenTable->setEnabled( false );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -509,7 +509,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QAction *actionMeasure() { return mActionMeasure; }
     QAction *actionMeasureArea() { return mActionMeasureArea; }
     QAction *actionZoomFullExtent() { return mActionZoomFullExtent; }
-    QAction *actionZoomToLayer() { return mActionZoomToLayer; }
+    QAction *actionZoomToLayers() { return mActionZoomToLayers; }
     QAction *actionZoomToSelected() { return mActionZoomToSelected; }
     QAction *actionZoomLast() { return mActionZoomLast; }
     QAction *actionZoomNext() { return mActionZoomNext; }

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -509,6 +509,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QAction *actionMeasure() { return mActionMeasure; }
     QAction *actionMeasureArea() { return mActionMeasureArea; }
     QAction *actionZoomFullExtent() { return mActionZoomFullExtent; }
+    QAction *actionZoomToLayer() { return mActionZoomToLayer; }
     QAction *actionZoomToLayers() { return mActionZoomToLayers; }
     QAction *actionZoomToSelected() { return mActionZoomToSelected; }
     QAction *actionZoomLast() { return mActionZoomLast; }

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -700,7 +700,7 @@ QAction *QgisAppInterface::actionFeatureAction() { return qgis->actionFeatureAct
 QAction *QgisAppInterface::actionMeasure() { return qgis->actionMeasure(); }
 QAction *QgisAppInterface::actionMeasureArea() { return qgis->actionMeasureArea(); }
 QAction *QgisAppInterface::actionZoomFullExtent() { return qgis->actionZoomFullExtent(); }
-QAction *QgisAppInterface::actionZoomToLayer() { return qgis->actionZoomToLayer(); }
+QAction *QgisAppInterface::actionZoomToLayers() { return qgis->actionZoomToLayers(); }
 QAction *QgisAppInterface::actionZoomToSelected() { return qgis->actionZoomToSelected(); }
 QAction *QgisAppInterface::actionZoomLast() { return qgis->actionZoomLast(); }
 QAction *QgisAppInterface::actionZoomNext() { return qgis->actionZoomNext(); }

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -700,6 +700,7 @@ QAction *QgisAppInterface::actionFeatureAction() { return qgis->actionFeatureAct
 QAction *QgisAppInterface::actionMeasure() { return qgis->actionMeasure(); }
 QAction *QgisAppInterface::actionMeasureArea() { return qgis->actionMeasureArea(); }
 QAction *QgisAppInterface::actionZoomFullExtent() { return qgis->actionZoomFullExtent(); }
+QAction *QgisAppInterface::actionZoomToLayer() { return qgis->actionZoomToLayer(); }
 QAction *QgisAppInterface::actionZoomToLayers() { return qgis->actionZoomToLayers(); }
 QAction *QgisAppInterface::actionZoomToSelected() { return qgis->actionZoomToSelected(); }
 QAction *QgisAppInterface::actionZoomLast() { return qgis->actionZoomLast(); }

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -231,7 +231,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QAction *actionMeasure() override;
     QAction *actionMeasureArea() override;
     QAction *actionZoomFullExtent() override;
-    QAction *actionZoomToLayer() override;
+    QAction *actionZoomToLayers() override;
     QAction *actionZoomToSelected() override;
     QAction *actionZoomLast() override;
     QAction *actionZoomNext() override;

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -231,6 +231,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QAction *actionMeasure() override;
     QAction *actionMeasureArea() override;
     QAction *actionZoomFullExtent() override;
+    QAction *actionZoomToLayer() override;
     QAction *actionZoomToLayers() override;
     QAction *actionZoomToSelected() override;
     QAction *actionZoomLast() override;

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -151,9 +151,9 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       if ( layer && layer->isSpatial() )
       {
 
-        QAction *zoomToLayer = actions->actionZoomToLayer( mCanvas, menu );
-        zoomToLayer->setEnabled( layer->isValid() );
-        menu->addAction( zoomToLayer );
+        QAction *zoomToLayers = actions->actionZoomToLayers( mCanvas, menu );
+        zoomToLayers->setEnabled( layer->isValid() );
+        menu->addAction( zoomToLayers );
         if ( vlayer )
         {
           QAction *actionZoomSelected = actions->actionZoomToSelection( mCanvas, menu );

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -150,6 +150,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
       if ( layer && layer->isSpatial() )
       {
+
         QAction *zoomToLayer = actions->actionZoomToLayer( mCanvas, menu );
         zoomToLayer->setEnabled( layer->isValid() );
         menu->addAction( zoomToLayer );

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -95,6 +95,7 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
   connect( mMapCanvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsMapCanvasDockWidget::mapCrsChanged );
   connect( mMapCanvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsMapCanvasDockWidget::updateExtentRect );
   connect( mActionZoomFullExtent, &QAction::triggered, mMapCanvas, &QgsMapCanvas::zoomToFullExtent );
+  connect( mActionZoomToLayer, &QAction::triggered, mMapCanvas, [ = ] { QgisApp::instance()->layerTreeView()->defaultActions()->zoomToLayer( mMapCanvas ); } );
   connect( mActionZoomToLayers, &QAction::triggered, mMapCanvas, [ = ] { QgisApp::instance()->layerTreeView()->defaultActions()->zoomToLayers( mMapCanvas ); } );
   connect( mActionZoomToSelected, &QAction::triggered, mMapCanvas, [ = ] { mMapCanvas->zoomToSelected(); } );
   mapCrsChanged();

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -95,7 +95,7 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
   connect( mMapCanvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsMapCanvasDockWidget::mapCrsChanged );
   connect( mMapCanvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsMapCanvasDockWidget::updateExtentRect );
   connect( mActionZoomFullExtent, &QAction::triggered, mMapCanvas, &QgsMapCanvas::zoomToFullExtent );
-  connect( mActionZoomToLayer, &QAction::triggered, mMapCanvas, [ = ] { QgisApp::instance()->layerTreeView()->defaultActions()->zoomToLayer( mMapCanvas ); } );
+  connect( mActionZoomToLayers, &QAction::triggered, mMapCanvas, [ = ] { QgisApp::instance()->layerTreeView()->defaultActions()->zoomToLayers( mMapCanvas ); } );
   connect( mActionZoomToSelected, &QAction::triggered, mMapCanvas, [ = ] { mMapCanvas->zoomToSelected(); } );
   mapCrsChanged();
 

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -95,7 +95,6 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
   connect( mMapCanvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsMapCanvasDockWidget::mapCrsChanged );
   connect( mMapCanvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsMapCanvasDockWidget::updateExtentRect );
   connect( mActionZoomFullExtent, &QAction::triggered, mMapCanvas, &QgsMapCanvas::zoomToFullExtent );
-  connect( mActionZoomToLayer, &QAction::triggered, mMapCanvas, [ = ] { QgisApp::instance()->layerTreeView()->defaultActions()->zoomToLayer( mMapCanvas ); } );
   connect( mActionZoomToLayers, &QAction::triggered, mMapCanvas, [ = ] { QgisApp::instance()->layerTreeView()->defaultActions()->zoomToLayers( mMapCanvas ); } );
   connect( mActionZoomToSelected, &QAction::triggered, mMapCanvas, [ = ] { mMapCanvas->zoomToSelected(); } );
   mapCrsChanged();

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -91,9 +91,20 @@ QAction *QgsLayerTreeViewDefaultActions::actionShowFeatureCount( QObject *parent
 QAction *QgsLayerTreeViewDefaultActions::actionZoomToLayer( QgsMapCanvas *canvas, QObject *parent )
 {
   QAction *a = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomToLayer.svg" ) ),
+                            tr( "&Zoom to Layer" ), parent );
+  a->setData( QVariant::fromValue( reinterpret_cast<void *>( canvas ) ) );
+  Q_NOWARN_DEPRECATED_PUSH
+  connect( a, &QAction::triggered, this, static_cast<void ( QgsLayerTreeViewDefaultActions::* )()>( &QgsLayerTreeViewDefaultActions::zoomToLayer ) );
+  Q_NOWARN_DEPRECATED_POP
+  return a;
+}
+
+QAction *QgsLayerTreeViewDefaultActions::actionZoomToLayers( QgsMapCanvas *canvas, QObject *parent )
+{
+  QAction *a = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomToLayer.svg" ) ),
                             tr( "&Zoom to Layer(s)" ), parent );
   a->setData( QVariant::fromValue( reinterpret_cast<void *>( canvas ) ) );
-  connect( a, &QAction::triggered, this, static_cast<void ( QgsLayerTreeViewDefaultActions::* )()>( &QgsLayerTreeViewDefaultActions::zoomToLayer ) );
+  connect( a, &QAction::triggered, this, static_cast<void ( QgsLayerTreeViewDefaultActions::* )()>( &QgsLayerTreeViewDefaultActions::zoomToLayers ) );
   return a;
 }
 
@@ -280,8 +291,18 @@ void QgsLayerTreeViewDefaultActions::showFeatureCount()
     l->setCustomProperty( QStringLiteral( "showFeatureCount" ), newValue ? 0 : 1 );
 }
 
-
 void QgsLayerTreeViewDefaultActions::zoomToLayer( QgsMapCanvas *canvas )
+{
+  QgsMapLayer *layer = mView->currentLayer();
+  if ( !layer )
+    return;
+
+  QList<QgsMapLayer *> layers;
+  layers << layer;
+  zoomToLayers( canvas, layers );
+}
+
+void QgsLayerTreeViewDefaultActions::zoomToLayers( QgsMapCanvas *canvas )
 {
   QList<QgsMapLayer *> layers = mView->selectedLayers();
   if ( layers.isEmpty() )
@@ -319,6 +340,15 @@ void QgsLayerTreeViewDefaultActions::zoomToLayer()
   QgsMapCanvas *canvas = reinterpret_cast<QgsMapCanvas *>( s->data().value<void *>() );
   QApplication::setOverrideCursor( Qt::WaitCursor );
   zoomToLayer( canvas );
+  QApplication::restoreOverrideCursor();
+}
+
+void QgsLayerTreeViewDefaultActions::zoomToLayers()
+{
+  QAction *s = qobject_cast<QAction *>( sender() );
+  QgsMapCanvas *canvas = reinterpret_cast<QgsMapCanvas *>( s->data().value<void *>() );
+  QApplication::setOverrideCursor( Qt::WaitCursor );
+  zoomToLayers( canvas );
   QApplication::restoreOverrideCursor();
 }
 

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -103,7 +103,7 @@ QAction *QgsLayerTreeViewDefaultActions::actionZoomToLayers( QgsMapCanvas *canva
 {
   QAction *a = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomToLayer.svg" ) ),
                             tr( "&Zoom to Layer(s)" ), parent );
-  a->setData( QVariant::fromValue( reinterpret_cast<void *>( canvas ) ) );
+  a->setData( QVariant::fromValue( canvas ) );
   connect( a, &QAction::triggered, this, static_cast<void ( QgsLayerTreeViewDefaultActions::* )()>( &QgsLayerTreeViewDefaultActions::zoomToLayers ) );
   return a;
 }
@@ -346,7 +346,7 @@ void QgsLayerTreeViewDefaultActions::zoomToLayer()
 void QgsLayerTreeViewDefaultActions::zoomToLayers()
 {
   QAction *s = qobject_cast<QAction *>( sender() );
-  QgsMapCanvas *canvas = reinterpret_cast<QgsMapCanvas *>( s->data().value<void *>() );
+  QgsMapCanvas *canvas = s->data().value<QgsMapCanvas *>();
   QApplication::setOverrideCursor( Qt::WaitCursor );
   zoomToLayers( canvas );
   QApplication::restoreOverrideCursor();

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -91,7 +91,7 @@ QAction *QgsLayerTreeViewDefaultActions::actionShowFeatureCount( QObject *parent
 QAction *QgsLayerTreeViewDefaultActions::actionZoomToLayer( QgsMapCanvas *canvas, QObject *parent )
 {
   QAction *a = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomToLayer.svg" ) ),
-                            tr( "&Zoom to Layer" ), parent );
+                            tr( "&Zoom to Layer(s)" ), parent );
   a->setData( QVariant::fromValue( reinterpret_cast<void *>( canvas ) ) );
   connect( a, &QAction::triggered, this, static_cast<void ( QgsLayerTreeViewDefaultActions::* )()>( &QgsLayerTreeViewDefaultActions::zoomToLayer ) );
   return a;
@@ -283,12 +283,10 @@ void QgsLayerTreeViewDefaultActions::showFeatureCount()
 
 void QgsLayerTreeViewDefaultActions::zoomToLayer( QgsMapCanvas *canvas )
 {
-  QgsMapLayer *layer = mView->currentLayer();
-  if ( !layer )
+  QList<QgsMapLayer *> layers = mView->selectedLayers();
+  if ( layers.isEmpty() )
     return;
 
-  QList<QgsMapLayer *> layers;
-  layers << layer;
   zoomToLayers( canvas, layers );
 }
 

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.h
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.h
@@ -57,7 +57,12 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
     //! Action to check a group and all its parents
     QAction *actionCheckAndAllParents( QObject *parent = nullptr );
 
-    QAction *actionZoomToLayer( QgsMapCanvas *canvas, QObject *parent = nullptr ) SIP_FACTORY;
+    /**
+     * \deprecated since QGIS 3.18, use actionZoomToLayers()
+     */
+    Q_DECL_DEPRECATED QAction *actionZoomToLayer( QgsMapCanvas *canvas, QObject *parent = nullptr ) SIP_FACTORY;
+
+    QAction *actionZoomToLayers( QgsMapCanvas *canvas, QObject *parent = nullptr ) SIP_FACTORY;
 
     /**
      * Action to zoom to selected features of a vector layer
@@ -96,7 +101,12 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
      */
     QAction *actionMutuallyExclusiveGroup( QObject *parent = nullptr ) SIP_FACTORY;
 
-    void zoomToLayer( QgsMapCanvas *canvas );
+    /**
+    * \deprecated since QGIS 3.18, use zoomToLayers()
+    */
+    Q_DECL_DEPRECATED void zoomToLayer( QgsMapCanvas *canvas );
+
+    void zoomToLayers( QgsMapCanvas *canvas );
 
     /**
      * \see zoomToSelection()
@@ -113,7 +123,13 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
     void removeGroupOrLayer();
     void renameGroupOrLayer();
     void showFeatureCount();
-    void zoomToLayer();
+
+    /**
+     * \deprecated since QGIS 3.18, use zoomToLayers()
+     */
+    Q_DECL_DEPRECATED void zoomToLayer();
+
+    void zoomToLayers();
 
     /**
      * Slot to zoom to selected features of a vector layer

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.h
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.h
@@ -62,6 +62,10 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
      */
     Q_DECL_DEPRECATED QAction *actionZoomToLayer( QgsMapCanvas *canvas, QObject *parent = nullptr ) SIP_FACTORY;
 
+    /**
+     * Action to zoom to all the selected layer(s) in the layer tree
+     * \since QGIS 3.18
+     */
     QAction *actionZoomToLayers( QgsMapCanvas *canvas, QObject *parent = nullptr ) SIP_FACTORY;
 
     /**
@@ -106,6 +110,11 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
     */
     Q_DECL_DEPRECATED void zoomToLayer( QgsMapCanvas *canvas );
 
+    /**
+     * Zooms to all the selected layer(s) in the layer tree
+     * \see zoomToLayers()
+     * \since QGIS 3.18
+     */
     void zoomToLayers( QgsMapCanvas *canvas );
 
     /**
@@ -129,6 +138,10 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
      */
     Q_DECL_DEPRECATED void zoomToLayer();
 
+    /**
+     * Slot to zoom to all the selected layer(s) in the layer tree
+     * \since QGIS 3.18
+     */
     void zoomToLayers();
 
     /**

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -476,7 +476,7 @@ class GUI_EXPORT QgisInterface : public QObject
     //! Returns the native zoom full extent action. Call trigger() on it to zoom to the full extent.
     virtual QAction *actionZoomFullExtent() = 0;
     //! Returns the native zoom to layer action. Call trigger() on it to zoom to the active layer.
-    virtual QAction *actionZoomToLayer() = 0;
+    virtual QAction *actionZoomToLayers() = 0;
     //! Returns the native zoom to selected action. Call trigger() on it to zoom to the current selection.
     virtual QAction *actionZoomToSelected() = 0;
     //! Returns the native zoom last action. Call trigger() on it to zoom to last.

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -476,6 +476,8 @@ class GUI_EXPORT QgisInterface : public QObject
     //! Returns the native zoom full extent action. Call trigger() on it to zoom to the full extent.
     virtual QAction *actionZoomFullExtent() = 0;
     //! Returns the native zoom to layer action. Call trigger() on it to zoom to the active layer.
+    virtual QAction *actionZoomToLayer() = 0;
+    //! Returns the native zoom to layers action. Call trigger() on it to zoom to the selected layers.
     virtual QAction *actionZoomToLayers() = 0;
     //! Returns the native zoom to selected action. Call trigger() on it to zoom to the current selection.
     virtual QAction *actionZoomToSelected() = 0;

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -135,7 +135,7 @@
     <addaction name="separator"/>
     <addaction name="mActionZoomFullExtent"/>
     <addaction name="mActionZoomToSelected"/>
-    <addaction name="mActionZoomToLayer"/>
+    <addaction name="mActionZoomToLayers"/>
     <addaction name="mActionZoomActualSize"/>
     <addaction name="mActionZoomLast"/>
     <addaction name="mActionZoomNext"/>
@@ -537,7 +537,7 @@
    <addaction name="mActionZoomOut"/>
    <addaction name="mActionZoomFullExtent"/>
    <addaction name="mActionZoomToSelected"/>
-   <addaction name="mActionZoomToLayer"/>
+   <addaction name="mActionZoomToLayers"/>
    <addaction name="mActionZoomActualSize"/>
    <addaction name="mActionZoomLast"/>
    <addaction name="mActionZoomNext"/>
@@ -1345,7 +1345,7 @@
     <string>Ctrl+Shift+F</string>
    </property>
   </action>
-  <action name="mActionZoomToLayer">
+  <action name="mActionZoomToLayers">
    <property name="icon">
     <iconset resource="../../images/images.qrc">
      <normaloff>:/images/themes/default/mActionZoomToLayer.svg</normaloff>:/images/themes/default/mActionZoomToLayer.svg</iconset>

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1345,6 +1345,15 @@
     <string>Ctrl+Shift+F</string>
    </property>
   </action>
+  <action name="mActionZoomToLayer">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomToLayer.svg</normaloff>:/images/themes/default/mActionZoomToLayer.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Zoom to &amp;Layer</string>
+   </property>
+  </action>
   <action name="mActionZoomToLayers">
    <property name="icon">
     <iconset resource="../../images/images.qrc">

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1351,7 +1351,7 @@
      <normaloff>:/images/themes/default/mActionZoomToLayer.svg</normaloff>:/images/themes/default/mActionZoomToLayer.svg</iconset>
    </property>
    <property name="text">
-    <string>Zoom to &amp;Layer</string>
+    <string>Zoom to &amp;Layer(s)</string>
    </property>
   </action>
   <action name="mActionZoomToSelected">

--- a/src/ui/qgsmapcanvasdockwidgetbase.ui
+++ b/src/ui/qgsmapcanvasdockwidgetbase.ui
@@ -43,7 +43,7 @@
       </property>
       <addaction name="mActionZoomFullExtent"/>
       <addaction name="mActionZoomToSelected"/>
-      <addaction name="mActionZoomToLayer"/>
+      <addaction name="mActionZoomToLayers"/>
      </widget>
     </item>
     <item>
@@ -87,6 +87,15 @@
    </property>
    <property name="text">
     <string>Zoom to &amp;Layer</string>
+   </property>
+  </action>
+  <action name="mActionZoomToLayers">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomToLayer.svg</normaloff>:/images/themes/default/mActionZoomToLayer.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Zoom to &amp;Layers</string>
    </property>
   </action>
   <action name="mActionZoomFullExtent">


### PR DESCRIPTION
## Description

(Issue #40459)

This pull request implements the changes necessary to the "Zoom to Layer" function (available from the layer tree context menu and the View menu) so it can zoom to the extent of all the selected layers in the layer tree.

Instead of feeding currentLayer() into QgsLayerTreeViewDefaultActions::zoomToLayer(), it feeds selectedLayers(). zoomToLayers() is then called with a list of layers and loops through them to zoom to their combined extent, like the "Zoom to Group" function.

The menu item labels in the layer tree context menu and in the View menu are also changed to "Zoom to Layer(s)" to reflect the ability to zoom to one or more layers.



![ezgif-7-91c5beb1d125](https://user-images.githubusercontent.com/59714546/101234295-f1cc8a80-368b-11eb-9b52-8f42a4f994a2.gif)
