### PR TITLE
[pointclouds] Don't prematurely convert point coordinates to float values

### DIFF
--- a/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
@@ -270,7 +270,7 @@ void QgsSingleColorPointCloud3DSymbolHandler::processNode( QgsPointCloudIndex *p
     double x = offset.x() + scale.x() * ix;
     double y = offset.y() + scale.y() * iy;
     double z = offset.z() + scale.z() * iz;
-    QVector3D point( x, y, z );
+    QgsVector3D point( x, y, z );
     QgsVector3D p = context.map().mapToWorldCoordinates( point );
     outNormal.positions.push_back( QVector3D( p.x(), p.y(), p.z() ) );
   }
@@ -370,7 +370,7 @@ void QgsColorRampPointCloud3DSymbolHandler::processNode( QgsPointCloudIndex *pc,
     double x = offset.x() + scale.x() * ix;
     double y = offset.y() + scale.y() * iy;
     double z = offset.z() + scale.z() * iz;
-    QVector3D point( x, y, z );
+    QgsVector3D point( x, y, z );
 
     QgsVector3D p = context.map().mapToWorldCoordinates( point );
     outNormal.positions.push_back( QVector3D( p.x(), p.y(), p.z() ) );
@@ -471,7 +471,7 @@ void QgsRGBPointCloud3DSymbolHandler::processNode( QgsPointCloudIndex *pc, const
     double x = offset.x() + scale.x() * ix;
     double y = offset.y() + scale.y() * iy;
     double z = offset.z() + scale.z() * iz;
-    QVector3D point( x, y, z );
+    QgsVector3D point( x, y, z );
     QgsVector3D p = context.map().mapToWorldCoordinates( point );
 
     QVector3D color( 0.0f, 0.0f, 0.0f );


### PR DESCRIPTION
(and then convert immediately convert them back to doubles)

This causes unwanted rounding of the coordinates before Qgs3DUtils::mapToWorldCoordinates
has been able to apply the correction for the map's origin

Ultimately fixes vertical "banding" effects seen in some point clouds

Here's what the bug looked like when viewing a point cloud from above (vs the 2d render of the same cloud in the terrain below it)

![image](https://user-images.githubusercontent.com/1829991/101308098-c963ac80-3894-11eb-825b-0e05a569cf15.png)


or more drastic examples (3d view on top, 2d view of same cloud below)

![image](https://user-images.githubusercontent.com/1829991/101308129-dc767c80-3894-11eb-94f6-fd1f708e8870.png)


![image](https://user-images.githubusercontent.com/1829991/101308134-df716d00-3894-11eb-88e8-94e0f8692e26.png)
