### PR TITLE
Ensure that accessing QgsFieldFormatterRegistry is thread safe

### DIFF
--- a/python/core/auto_generated/qgsfieldformatterregistry.sip.in
+++ b/python/core/auto_generated/qgsfieldformatterregistry.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsFieldFormatterRegistry : QObject
 {
 %Docstring

--- a/src/core/qgsfieldformatterregistry.cpp
+++ b/src/core/qgsfieldformatterregistry.cpp
@@ -26,7 +26,7 @@
 #include "qgsrangefieldformatter.h"
 #include "qgscheckboxfieldformatter.h"
 #include "qgsfallbackfieldformatter.h"
-
+#include "qgsreadwritelocker.h"
 
 QgsFieldFormatterRegistry::QgsFieldFormatterRegistry( QObject *parent )
   : QObject( parent )
@@ -45,13 +45,16 @@ QgsFieldFormatterRegistry::QgsFieldFormatterRegistry( QObject *parent )
 
 QgsFieldFormatterRegistry::~QgsFieldFormatterRegistry()
 {
+  QgsReadWriteLocker locker( mLock, QgsReadWriteLocker::Write );
   qDeleteAll( mFieldFormatters );
   delete mFallbackFieldFormatter;
 }
 
 void QgsFieldFormatterRegistry::addFieldFormatter( QgsFieldFormatter *formatter )
 {
+  QgsReadWriteLocker locker( mLock, QgsReadWriteLocker::Write );
   mFieldFormatters.insert( formatter->id(), formatter );
+  locker.unlock();
   emit fieldFormatterAdded( formatter );
 }
 
@@ -62,6 +65,7 @@ void QgsFieldFormatterRegistry::removeFieldFormatter( QgsFieldFormatter *formatt
 
 void QgsFieldFormatterRegistry::removeFieldFormatter( const QString &id )
 {
+  QgsReadWriteLocker locker( mLock, QgsReadWriteLocker::Write );
   if ( QgsFieldFormatter *formatter = mFieldFormatters.take( id ) )
   {
     emit fieldFormatterRemoved( formatter );
@@ -71,6 +75,7 @@ void QgsFieldFormatterRegistry::removeFieldFormatter( const QString &id )
 
 QgsFieldFormatter *QgsFieldFormatterRegistry::fieldFormatter( const QString &id ) const
 {
+  QgsReadWriteLocker locker( mLock, QgsReadWriteLocker::Read );
   return mFieldFormatters.value( id, mFallbackFieldFormatter );
 }
 

--- a/src/core/qgsfieldformatterregistry.h
+++ b/src/core/qgsfieldformatterregistry.h
@@ -23,6 +23,8 @@
 #include "qgis_sip.h"
 #include "qgis_core.h"
 
+#include <QReadWriteLock>
+
 class QgsFieldFormatter;
 class QgsVectorLayer;
 
@@ -94,6 +96,7 @@ class CORE_EXPORT QgsFieldFormatterRegistry : public QObject
   private:
     QHash<QString, QgsFieldFormatter *> mFieldFormatters;
     QgsFieldFormatter *mFallbackFieldFormatter = nullptr;
+    mutable QReadWriteLock mLock;
 };
 
 #endif // QGSFIELDKITREGISTRY_H


### PR DESCRIPTION
Unlikely to cause crashes in practice, but it makes me nervous and making it thread safe is the right thing to do...