### PR TITLE
Do not register QgsFilterLineEdit's child widgets as QgsOptionsDialogHighlightWidget

### DIFF
--- a/src/gui/qgsoptionsdialoghighlightwidget.cpp
+++ b/src/gui/qgsoptionsdialoghighlightwidget.cpp
@@ -24,6 +24,7 @@
 
 #include "qgsoptionsdialoghighlightwidget.h"
 #include "qgsmessagebaritem.h"
+#include "qgsfilterlineedit.h"
 
 #include "qgsoptionsdialoghighlightwidgetsimpl.h"
 
@@ -41,7 +42,9 @@ QgsOptionsDialogHighlightWidget *QgsOptionsDialogHighlightWidget::createWidget( 
   while ( ( parent = parent->parentWidget() ) )
   {
     // do not register message bar content, items disappear and causes QGIS to crash
-    if ( qobject_cast< QgsMessageBarItem * >( parent ) )
+    // do not register QgsFilterLineEdit's child widgets, the clear button might be deleted
+    if ( qobject_cast< QgsMessageBarItem * >( parent ) ||
+         qobject_cast< QgsFilterLineEdit * >( parent ) )
     {
       // return invalid widget
       return nullptr;


### PR DESCRIPTION
## Description
`QgsSpinBox` and `QgsDoubleSpinBox` use a `QgsFilterLineEdit` that has a button to clear its contents. This button is deleted 
once it is pressed and re-created when the spinbox value has changed, so if it is registered for highlighting and the button is pressed QGIS crashes when trying to highlight search results!
This allows proper usage of `QgsSpinbox` and `QgsDoubleSpinBox` in options, as well as `QgsFilterLineEdit` (not used yet used in options)

Fixes #40111

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
