### PR TITLE
[3D] Show the 3D rendering speed with fps counter

### DIFF
--- a/python/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -594,6 +594,24 @@ Sets whether the skybox is enabled.
 .. versionadded:: 3.16
 %End
 
+    bool isFpsCounterEnabled() const;
+%Docstring
+Returns whether FPS counter label is enabled
+
+.. seealso:: :py:func:`setIsFpsCounterEnabled`
+
+.. versionadded:: 3.18
+%End
+
+    void setIsFpsCounterEnabled( bool fpsCounterEnabled );
+%Docstring
+Sets whether FPS counter label is enabled
+
+.. seealso:: :py:func:`isFpsCounterEnabled`
+
+.. versionadded:: 3.18
+%End
+
   signals:
     void backgroundColorChanged();
 %Docstring
@@ -780,6 +798,13 @@ Emitted when skybox settings are changed
 Emitted when shadow rendering settings are changed
 
 .. versionadded:: 3.16
+%End
+
+    void fpsCounterEnabledChanged( bool fpsCounterEnabled );
+%Docstring
+Emitted when the FPS counter is enabled or disabled
+
+.. versionadded:: 3.18
 %End
 
   private:

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -499,7 +499,19 @@ void Qgs3DMapScene::onFrameTriggered( float dt )
   }
 
   updateSceneState();
-  emit fpsCountChanged( 1.0f / dt );
+
+  // lock changing the FPS counter to 5 fps
+  static int frameCount = 0;
+  static float accumulatedTime = 0.0f;
+  frameCount++;
+  accumulatedTime += dt;
+  if ( accumulatedTime >= 0.2f )
+  {
+    float fps = ( float )frameCount / accumulatedTime;
+    frameCount = 0;
+    accumulatedTime = 0.0f;
+    emit fpsCountChanged( fps );
+  }
 }
 
 void Qgs3DMapScene::createTerrain()

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -503,6 +503,14 @@ void Qgs3DMapScene::onFrameTriggered( float dt )
   // lock changing the FPS counter to 5 fps
   static int frameCount = 0;
   static float accumulatedTime = 0.0f;
+
+  if ( !mMap.isFpsCounterEnabled() )
+  {
+    frameCount = 0;
+    accumulatedTime = 0;
+    return;
+  }
+
   frameCount++;
   accumulatedTime += dt;
   if ( accumulatedTime >= 0.2f )

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -137,6 +137,7 @@ Qgs3DMapScene::Qgs3DMapScene( const Qgs3DMapSettings &map, QgsAbstract3DEngine *
   connect( &map, &Qgs3DMapSettings::eyeDomeLightingDistanceChanged, this, &Qgs3DMapScene::onEyeDomeShadingSettingsChanged );
   connect( &map, &Qgs3DMapSettings::debugShadowMapSettingsChanged, this, &Qgs3DMapScene::onDebugShadowMapSettingsChanged );
   connect( &map, &Qgs3DMapSettings::debugDepthMapSettingsChanged, this, &Qgs3DMapScene::onDebugDepthMapSettingsChanged );
+  connect( &map, &Qgs3DMapSettings::fpsCounterEnabledChanged, this, &Qgs3DMapScene::fpsCounterEnabledChanged );
 
   connect( QgsApplication::instance()->sourceCache(), &QgsSourceCache::remoteSourceFetched, this, [ = ]( const QString & url )
   {

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -498,6 +498,7 @@ void Qgs3DMapScene::onFrameTriggered( float dt )
   }
 
   updateSceneState();
+  emit fpsCountChanged( 1.0f / dt );
 }
 
 void Qgs3DMapScene::createTerrain()

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -126,6 +126,9 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     //! Emitted when the scene's state has changed
     void sceneStateChanged();
 
+    //! Emmited when the FPS Count changes (at most every frame)
+    void fpsCountChanged( float fpsCount );
+
   public slots:
     //! Updates the temporale entities
     void updateTemporal();

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -126,7 +126,7 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     //! Emitted when the scene's state has changed
     void sceneStateChanged();
 
-    //! Emitted when the FPS count changes (at most every frame)
+    //! Emitted when the FPS count changes
     void fpsCountChanged( float fpsCount );
     //! Emitted when the FPS counter is activated or deactivated
     void fpsCounterEnabledChanged( bool fpsCounterEnabled );

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -126,9 +126,9 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     //! Emitted when the scene's state has changed
     void sceneStateChanged();
 
-    //! Emmited when the FPS count changes (at most every frame)
+    //! Emitted when the FPS count changes (at most every frame)
     void fpsCountChanged( float fpsCount );
-    //! Emmited when the FPS counter is activated or deactivated
+    //! Emitted when the FPS counter is activated or deactivated
     void fpsCounterEnabledChanged( bool fpsCounterEnabled );
 
   public slots:

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -126,8 +126,10 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     //! Emitted when the scene's state has changed
     void sceneStateChanged();
 
-    //! Emmited when the FPS Count changes (at most every frame)
+    //! Emmited when the FPS count changes (at most every frame)
     void fpsCountChanged( float fpsCount );
+    //! Emmited when the FPS counter is activated or deactivated
+    void fpsCounterEnabledChanged( bool fpsCounterEnabled );
 
   public slots:
     //! Updates the temporale entities

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -61,6 +61,8 @@ Qgs3DMapSettings::Qgs3DMapSettings( const Qgs3DMapSettings &other )
   , mTransformContext( other.mTransformContext )
   , mPathResolver( other.mPathResolver )
   , mMapThemes( other.mMapThemes )
+  , mDpi( other.mDpi )
+  , mIsFpsCounterEnabled( other.mIsFpsCounterEnabled )
   , mIsSkyboxEnabled( other.mIsSkyboxEnabled )
   , mSkyboxSettings( other.mSkyboxSettings )
   , mShadowSettings( other.mShadowSettings )
@@ -270,6 +272,7 @@ void Qgs3DMapSettings::readXml( const QDomElement &elem, const QgsReadWriteConte
   mShowTerrainTileInfo = elemDebug.attribute( QStringLiteral( "terrain-tile-info" ), QStringLiteral( "0" ) ).toInt();
   mShowCameraViewCenter = elemDebug.attribute( QStringLiteral( "camera-view-center" ), QStringLiteral( "0" ) ).toInt();
   mShowLightSources = elemDebug.attribute( QStringLiteral( "show-light-sources" ), QStringLiteral( "0" ) ).toInt();
+  mIsFpsCounterEnabled = elemDebug.attribute( QStringLiteral( "show-fps-counter" ), QStringLiteral( "0" ) ).toInt();
 
   QDomElement elemTemporalRange = elem.firstChildElement( QStringLiteral( "temporal-range" ) );
   QDateTime start = QDateTime::fromString( elemTemporalRange.attribute( QStringLiteral( "start" ) ), Qt::ISODate );
@@ -379,6 +382,7 @@ QDomElement Qgs3DMapSettings::writeXml( QDomDocument &doc, const QgsReadWriteCon
   elemDebug.setAttribute( QStringLiteral( "terrain-tile-info" ), mShowTerrainTileInfo ? 1 : 0 );
   elemDebug.setAttribute( QStringLiteral( "camera-view-center" ), mShowCameraViewCenter ? 1 : 0 );
   elemDebug.setAttribute( QStringLiteral( "show-light-sources" ), mShowLightSources ? 1 : 0 );
+  elemDebug.setAttribute( QStringLiteral( "show-fps-counter" ), mIsFpsCounterEnabled ? 1 : 0 );
   elem.appendChild( elemDebug );
 
   QDomElement elemEyeDomeLighting = doc.createElement( QStringLiteral( "eye-dome-lighting" ) );
@@ -779,4 +783,12 @@ void Qgs3DMapSettings::setDebugDepthMapSettings( bool enabled, Qt::Corner corner
   mDebugDepthMapCorner = corner;
   mDebugDepthMapSize = size;
   emit debugDepthMapSettingsChanged();
+}
+
+void Qgs3DMapSettings::setIsFpsCounterEnabled( bool fpsCounterEnabled )
+{
+  if ( fpsCounterEnabled == mIsFpsCounterEnabled )
+    return;
+  mIsFpsCounterEnabled = fpsCounterEnabled;
+  emit fpsCounterEnabledChanged( mIsFpsCounterEnabled );
 }

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -529,6 +529,20 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
      */
     void setIsSkyboxEnabled( bool enabled ) { mIsSkyboxEnabled = enabled; }
 
+    /**
+     * Returns whether FPS counter label is enabled
+     * \see setIsFpsCounterEnabled()
+     * \since QGIS 3.18
+     */
+    bool isFpsCounterEnabled() const { return mIsFpsCounterEnabled; }
+
+    /**
+     * Sets whether FPS counter label is enabled
+     * \see isFpsCounterEnabled()
+     * \since QGIS 3.18
+     */
+    void setIsFpsCounterEnabled( bool fpsCounterEnabled );
+
   signals:
     //! Emitted when the background color has changed
     void backgroundColorChanged();
@@ -676,6 +690,13 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
      */
     void shadowSettingsChanged();
 
+    /**
+     * Emitted when the FPS counter is enabled or disabled
+     *
+     * \since QGIS 3.18
+     */
+    void fpsCounterEnabledChanged( bool fpsCounterEnabled );
+
   private:
 #ifdef SIP_RUN
     Qgs3DMapSettings &operator=( const Qgs3DMapSettings & );
@@ -713,6 +734,7 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     QgsPathResolver mPathResolver;
     QgsMapThemeCollection *mMapThemes = nullptr;   //!< Pointer to map themes (e.g. from the current project) to resolve map theme content from the name
     double mDpi = 96;  //!< Dot per inch value for the screen / painter
+    bool mIsFpsCounterEnabled = false;
 
     bool mIsSkyboxEnabled = false;  //!< Whether the skybox is enabled
     QgsSkyboxSettings mSkyboxSettings; //!< Skybox related configuration

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -94,8 +94,12 @@ void Qgs3DMapCanvas::setMap( Qgs3DMapSettings *map )
   mEngine->setRootEntity( newScene );
 
   if ( mScene )
+  {
+    disconnect( mScene, &Qgs3DMapScene::fpsCountChanged, this, &Qgs3DMapCanvas::fpsCountChanged );
     mScene->deleteLater();
+  }
   mScene = newScene;
+  connect( mScene, &Qgs3DMapScene::fpsCountChanged, this, &Qgs3DMapCanvas::fpsCountChanged );
 
   delete mMap;
   mMap = map;

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -96,10 +96,12 @@ void Qgs3DMapCanvas::setMap( Qgs3DMapSettings *map )
   if ( mScene )
   {
     disconnect( mScene, &Qgs3DMapScene::fpsCountChanged, this, &Qgs3DMapCanvas::fpsCountChanged );
+    disconnect( mScene, &Qgs3DMapScene::fpsCounterEnabledChanged, this, &Qgs3DMapCanvas::fpsCounterEnabledChanged );
     mScene->deleteLater();
   }
   mScene = newScene;
   connect( mScene, &Qgs3DMapScene::fpsCountChanged, this, &Qgs3DMapCanvas::fpsCountChanged );
+  connect( mScene, &Qgs3DMapScene::fpsCounterEnabledChanged, this, &Qgs3DMapCanvas::fpsCounterEnabledChanged );
 
   delete mMap;
   mMap = map;

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -93,7 +93,7 @@ class Qgs3DMapCanvas : public QWidget
     //! Emitted when the the map setting is changed
     void mapSettingsChanged();
 
-    //! Emmited when the FPS count changes (at most every frame)
+    //! Emitted when the FPS count changes (at most every frame)
     void fpsCountChanged( float fpsCount );
     //! Emitted when the FPS counter is enabled or disabeld
     void fpsCounterEnabledChanged( bool enabled );

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -93,8 +93,10 @@ class Qgs3DMapCanvas : public QWidget
     //! Emitted when the the map setting is changed
     void mapSettingsChanged();
 
-    //! Emmited when the FPS Count changes (at most every frame)
+    //! Emmited when the FPS count changes (at most every frame)
     void fpsCountChanged( float fpsCount );
+    //! Emitted when the FPS counter is enabled or disabeld
+    void fpsCounterEnabledChanged( bool enabled );
 
   private slots:
     void updateTemporalRange( const QgsDateTimeRange &timeRange );

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -93,6 +93,9 @@ class Qgs3DMapCanvas : public QWidget
     //! Emitted when the the map setting is changed
     void mapSettingsChanged();
 
+    //! Emmited when the FPS Count changes (at most every frame)
+    void fpsCountChanged( float fpsCount );
+
   private slots:
     void updateTemporalRange( const QgsDateTimeRange &timeRange );
 

--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -272,7 +272,6 @@ void Qgs3DMapCanvasDockWidget::setMapSettings( Qgs3DMapSettings *map )
 {
   whileBlocking( mActionEnableShadows )->setChecked( map->shadowSettings().renderShadows() );
   whileBlocking( mActionEnableEyeDome )->setChecked( map->eyeDomeLightingEnabled() );
-  whileBlocking( mLabelFpsCounter )->setVisible( map->isFpsCounterEnabled() );
 
   mCanvas->setMap( map );
 
@@ -283,6 +282,7 @@ void Qgs3DMapCanvasDockWidget::setMapSettings( Qgs3DMapSettings *map )
 
   // Disable button for switching the map theme if the terrain generator is a mesh
   mBtnMapThemes->setDisabled( mCanvas->map()->terrainGenerator()->type() == QgsTerrainGenerator::Mesh );
+  mLabelFpsCounter->setVisible( map->isFpsCounterEnabled() );
 }
 
 void Qgs3DMapCanvasDockWidget::setMainCanvas( QgsMapCanvas *canvas )
@@ -409,7 +409,7 @@ void Qgs3DMapCanvasDockWidget::onTotalPendingJobsCountChanged()
 
 void Qgs3DMapCanvasDockWidget::updateFpsCount( float fpsCount )
 {
-  mLabelFpsCounter->setText( QString( "%1 fps" ).arg( fpsCount, 10, 'f', 2, QLatin1Char( ' ' ) ) );
+  mLabelFpsCounter->setText( QStringLiteral( "%1 fps" ).arg( fpsCount, 10, 'f', 2, QLatin1Char( ' ' ) ) );
 }
 
 void Qgs3DMapCanvasDockWidget::mapThemeMenuAboutToShow()

--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -168,6 +168,7 @@ Qgs3DMapCanvasDockWidget::Qgs3DMapCanvasDockWidget( QWidget *parent )
   } );
 
   connect( mCanvas, &Qgs3DMapCanvas::fpsCountChanged, this, &Qgs3DMapCanvasDockWidget::updateFpsCount );
+  connect( mCanvas, &Qgs3DMapCanvas::fpsCounterEnabledChanged, this, &Qgs3DMapCanvasDockWidget::toggleFpsCounter );
 
   mMapToolIdentify = new Qgs3DMapToolIdentify( mCanvas );
 
@@ -262,10 +263,16 @@ void Qgs3DMapCanvasDockWidget::toggleNavigationWidget( bool visibility )
   mCanvas->setOnScreenNavigationVisibility( visibility );
 }
 
+void Qgs3DMapCanvasDockWidget::toggleFpsCounter( bool visibility )
+{
+  mLabelFpsCounter->setVisible( visibility );
+}
+
 void Qgs3DMapCanvasDockWidget::setMapSettings( Qgs3DMapSettings *map )
 {
   whileBlocking( mActionEnableShadows )->setChecked( map->shadowSettings().renderShadows() );
   whileBlocking( mActionEnableEyeDome )->setChecked( map->eyeDomeLightingEnabled() );
+  whileBlocking( mLabelFpsCounter )->setVisible( map->isFpsCounterEnabled() );
 
   mCanvas->setMap( map );
 

--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -167,6 +167,8 @@ Qgs3DMapCanvasDockWidget::Qgs3DMapCanvasDockWidget( QWidget *parent )
     QgisApp::instance()->messageBar()->pushSuccess( tr( "Save as Image" ), tr( "Successfully saved the 3D map to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( fileName ).toString(), QDir::toNativeSeparators( fileName ) ) );
   } );
 
+  connect( mCanvas, &Qgs3DMapCanvas::fpsCountChanged, this, &Qgs3DMapCanvasDockWidget::updateFpsCount );
+
   mMapToolIdentify = new Qgs3DMapToolIdentify( mCanvas );
 
   mMapToolMeasureLine = new Qgs3DMapToolMeasureLine( mCanvas );
@@ -174,6 +176,7 @@ Qgs3DMapCanvasDockWidget::Qgs3DMapCanvasDockWidget( QWidget *parent )
   mLabelPendingJobs = new QLabel( this );
   mProgressPendingJobs = new QProgressBar( this );
   mProgressPendingJobs->setRange( 0, 0 );
+  mLabelFpsCounter = new QLabel( this );
 
   mAnimationWidget = new Qgs3DAnimationWidget( this );
   mAnimationWidget->setVisible( false );
@@ -185,6 +188,7 @@ Qgs3DMapCanvasDockWidget::Qgs3DMapCanvasDockWidget( QWidget *parent )
   topLayout->addStretch( 1 );
   topLayout->addWidget( mLabelPendingJobs );
   topLayout->addWidget( mProgressPendingJobs );
+  topLayout->addWidget( mLabelFpsCounter );
 
   QVBoxLayout *layout = new QVBoxLayout;
   layout->setContentsMargins( 0, 0, 0, 0 );
@@ -394,6 +398,11 @@ void Qgs3DMapCanvasDockWidget::onTotalPendingJobsCountChanged()
   mLabelPendingJobs->setVisible( count );
   if ( count )
     mLabelPendingJobs->setText( tr( "Loading %1 tiles" ).arg( count ) );
+}
+
+void Qgs3DMapCanvasDockWidget::updateFpsCount( float fpsCount )
+{
+  mLabelFpsCounter->setText( QString( "%1 fps" ).arg( fpsCount, 10, 'f', 2, QLatin1Char( ' ' ) ) );
 }
 
 void Qgs3DMapCanvasDockWidget::mapThemeMenuAboutToShow()

--- a/src/app/3d/qgs3dmapcanvasdockwidget.h
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.h
@@ -65,6 +65,7 @@ class APP_EXPORT Qgs3DMapCanvasDockWidget : public QgsDockWidget
     void onMainCanvasLayersChanged();
     void onMainCanvasColorChanged();
     void onTotalPendingJobsCountChanged();
+    void updateFpsCount( float fpsCount );
     void mapThemeMenuAboutToShow();
     //! Renames the active map theme called \a theme to \a newTheme
     void currentMapThemeRenamed( const QString &theme, const QString &newTheme );
@@ -75,6 +76,7 @@ class APP_EXPORT Qgs3DMapCanvasDockWidget : public QgsDockWidget
     QgsMapCanvas *mMainCanvas = nullptr;
     QProgressBar *mProgressPendingJobs = nullptr;
     QLabel *mLabelPendingJobs = nullptr;
+    QLabel *mLabelFpsCounter = nullptr;
     Qgs3DMapToolIdentify *mMapToolIdentify = nullptr;
     Qgs3DMapToolMeasureLine *mMapToolMeasureLine = nullptr;
     QMenu *mMapThemeMenu = nullptr;

--- a/src/app/3d/qgs3dmapcanvasdockwidget.h
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.h
@@ -61,6 +61,7 @@ class APP_EXPORT Qgs3DMapCanvasDockWidget : public QgsDockWidget
     void measureLine();
     void exportScene();
     void toggleNavigationWidget( bool visibility );
+    void toggleFpsCounter( bool visibility );
 
     void onMainCanvasLayersChanged();
     void onMainCanvasColorChanged();

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -144,6 +144,7 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
   chkShowBoundingBoxes->setChecked( mMap->showTerrainBoundingBoxes() );
   chkShowCameraViewCenter->setChecked( mMap->showCameraViewCenter() );
   chkShowLightSourceOrigins->setChecked( mMap->showLightSourceOrigins() );
+  mFpsCounterCheckBox->setChecked( mMap->isFpsCounterEnabled() );
 
   groupTerrainShading->setChecked( mMap->isTerrainShadingEnabled() );
   widgetTerrainMaterial->setTechnique( QgsMaterialSettingsRenderingTechnique::TrianglesWithFixedTexture );
@@ -326,6 +327,7 @@ void Qgs3DMapConfigWidget::apply()
   mMap->setShowTerrainBoundingBoxes( chkShowBoundingBoxes->isChecked() );
   mMap->setShowCameraViewCenter( chkShowCameraViewCenter->isChecked() );
   mMap->setShowLightSourceOrigins( chkShowLightSourceOrigins->isChecked() );
+  mMap->setIsFpsCounterEnabled( mFpsCounterCheckBox->isChecked() );
   mMap->setTerrainShadingEnabled( groupTerrainShading->isChecked() );
 
   std::unique_ptr< QgsAbstractMaterialSettings > terrainMaterial( widgetTerrainMaterial->settings() );

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -179,7 +179,7 @@
        <item>
         <widget class="QStackedWidget" name="m3DOptionsStackedWidget">
          <property name="currentIndex">
-          <number>4</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="mPageTerrain">
           <layout class="QVBoxLayout" name="verticalLayout_61">
@@ -693,7 +693,7 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>-47</y>
+                <y>0</y>
                 <width>690</width>
                 <height>681</height>
                </rect>

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -179,7 +179,7 @@
        <item>
         <widget class="QStackedWidget" name="m3DOptionsStackedWidget">
          <property name="currentIndex">
-          <number>0</number>
+          <number>4</number>
          </property>
          <widget class="QWidget" name="mPageTerrain">
           <layout class="QVBoxLayout" name="verticalLayout_61">
@@ -205,7 +205,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>707</width>
+                <width>704</width>
                 <height>604</height>
                </rect>
               </property>
@@ -410,8 +410,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>707</width>
-                <height>604</height>
+                <width>77</width>
+                <height>45</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutLight">
@@ -494,8 +494,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>707</width>
-                <height>604</height>
+                <width>140</width>
+                <height>45</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutShadow">
@@ -584,8 +584,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>707</width>
-                <height>604</height>
+                <width>201</width>
+                <height>161</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutCameraSkybox">
@@ -693,9 +693,9 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>-66</y>
-                <width>693</width>
-                <height>670</height>
+                <y>-47</y>
+                <width>690</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutAdvanced">
@@ -717,119 +717,6 @@
                   <string>Advanced Settings</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_11">
-                  <item row="0" column="0">
-                   <layout class="QGridLayout" name="gridLayoutAdvanced">
-                    <item row="4" column="0" colspan="2">
-                     <widget class="QCheckBox" name="chkShowLabels">
-                      <property name="text">
-                       <string>Show labels</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="6" column="0" colspan="2">
-                     <widget class="QCheckBox" name="chkShowBoundingBoxes">
-                      <property name="text">
-                       <string>Show bounding boxes</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="7" column="0" colspan="2">
-                     <widget class="QCheckBox" name="chkShowCameraViewCenter">
-                      <property name="text">
-                       <string>Show camera's view center</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="1">
-                     <widget class="QgsDoubleSpinBox" name="spinScreenError">
-                      <property name="suffix">
-                       <string> px</string>
-                      </property>
-                      <property name="decimals">
-                       <number>1</number>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="1">
-                     <widget class="QgsSpinBox" name="spinMapResolution">
-                      <property name="suffix">
-                       <string> px</string>
-                      </property>
-                      <property name="maximum">
-                       <number>4096</number>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="2" column="1">
-                     <widget class="QgsDoubleSpinBox" name="spinGroundError">
-                      <property name="suffix">
-                       <string> map units</string>
-                      </property>
-                      <property name="decimals">
-                       <number>1</number>
-                      </property>
-                      <property name="minimum">
-                       <double>0.100000000000000</double>
-                      </property>
-                      <property name="maximum">
-                       <double>1000.000000000000000</double>
-                      </property>
-                      <property name="value">
-                       <double>1.000000000000000</double>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="3" column="1">
-                     <widget class="QLabel" name="labelZoomLevels">
-                      <property name="text">
-                       <string>0</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="0">
-                     <widget class="QLabel" name="label_5">
-                      <property name="text">
-                       <string>Max. screen error</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="0">
-                     <widget class="QLabel" name="label_4">
-                      <property name="text">
-                       <string>Map tile resolution</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="3" column="0">
-                     <widget class="QLabel" name="label_7">
-                      <property name="text">
-                       <string>Zoom levels</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="2" column="0">
-                     <widget class="QLabel" name="label_6">
-                      <property name="text">
-                       <string>Max. ground error</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="5" column="0" colspan="2">
-                     <widget class="QCheckBox" name="chkShowTileInfo">
-                      <property name="text">
-                       <string>Show map tile info</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="8" column="0" colspan="2">
-                     <widget class="QCheckBox" name="chkShowLightSourceOrigins">
-                      <property name="text">
-                       <string>Show light sources</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
                   <item row="2" column="0">
                    <widget class="QGroupBox" name="mDebugShadowMapGroupBox">
                     <property name="title">
@@ -875,6 +762,19 @@
                     </layout>
                    </widget>
                   </item>
+                  <item row="4" column="0">
+                   <spacer name="verticalSpacerAdvanced">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
                   <item row="3" column="0">
                    <widget class="QGroupBox" name="mDebugDepthMapGroupBox">
                     <property name="title">
@@ -919,6 +819,126 @@
                      </item>
                     </layout>
                    </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <layout class="QGridLayout" name="gridLayoutAdvanced">
+                    <item row="1" column="1">
+                     <widget class="QgsDoubleSpinBox" name="spinScreenError">
+                      <property name="suffix">
+                       <string> px</string>
+                      </property>
+                      <property name="decimals">
+                       <number>1</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="1">
+                     <widget class="QgsDoubleSpinBox" name="spinGroundError">
+                      <property name="suffix">
+                       <string> map units</string>
+                      </property>
+                      <property name="decimals">
+                       <number>1</number>
+                      </property>
+                      <property name="minimum">
+                       <double>0.100000000000000</double>
+                      </property>
+                      <property name="maximum">
+                       <double>1000.000000000000000</double>
+                      </property>
+                      <property name="value">
+                       <double>1.000000000000000</double>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="8" column="0" colspan="2">
+                     <widget class="QCheckBox" name="chkShowCameraViewCenter">
+                      <property name="text">
+                       <string>Show camera's view center</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="0">
+                     <widget class="QLabel" name="label_6">
+                      <property name="text">
+                       <string>Max. ground error</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="7" column="0" colspan="2">
+                     <widget class="QCheckBox" name="chkShowBoundingBoxes">
+                      <property name="text">
+                       <string>Show bounding boxes</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="1">
+                     <widget class="QgsSpinBox" name="spinMapResolution">
+                      <property name="suffix">
+                       <string> px</string>
+                      </property>
+                      <property name="maximum">
+                       <number>4096</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="3" column="1">
+                     <widget class="QLabel" name="labelZoomLevels">
+                      <property name="text">
+                       <string>0</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="0">
+                     <widget class="QLabel" name="label_5">
+                      <property name="text">
+                       <string>Max. screen error</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="6" column="0" colspan="2">
+                     <widget class="QCheckBox" name="chkShowTileInfo">
+                      <property name="text">
+                       <string>Show map tile info</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="5" column="0" colspan="2">
+                     <widget class="QCheckBox" name="chkShowLabels">
+                      <property name="text">
+                       <string>Show labels</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="0">
+                     <widget class="QLabel" name="label_4">
+                      <property name="text">
+                       <string>Map tile resolution</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="9" column="0" colspan="2">
+                     <widget class="QCheckBox" name="chkShowLightSourceOrigins">
+                      <property name="text">
+                       <string>Show light sources</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="3" column="0">
+                     <widget class="QLabel" name="label_7">
+                      <property name="text">
+                       <string>Zoom levels</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="10" column="0" colspan="2">
+                     <widget class="QCheckBox" name="mFpsCounterCheckBox">
+                      <property name="text">
+                       <string>Enable FPS counter</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
                   </item>
                   <item row="1" column="0">
                    <widget class="QGroupBox" name="edlGroupBox">
@@ -971,19 +991,6 @@
                      </item>
                     </layout>
                    </widget>
-                  </item>
-                  <item row="4" column="0">
-                   <spacer name="verticalSpacerAdvanced">
-                    <property name="orientation">
-                     <enum>Qt::Vertical</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>20</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                   </spacer>
                   </item>
                  </layout>
                 </widget>


### PR DESCRIPTION
## Description
This adds a label to see the performance of the 3D rendering.

![fps-counter](https://user-images.githubusercontent.com/29183781/101389482-caf79980-38c1-11eb-8bf4-2f7a0c3cc4c8.gif)

You can see the FPS counter above the navigation widget.
