### PR TITLE
Georeferencer UI/UX improvements

### DIFF
--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -543,8 +543,7 @@ void QgsGeoreferencerMainWindow::linkGeorefToQgis( bool link )
 void QgsGeoreferencerMainWindow::addPoint( const QgsPointXY &pixelCoords, const QgsPointXY &mapCoords, const QgsCoordinateReferenceSystem &crs,
     bool enable, bool finalize )
 {
-  QgsGeorefDataPoint *pnt = new QgsGeorefDataPoint( mCanvas, QgisApp::instance()->mapCanvas(),
-      pixelCoords, mapCoords, QgsCoordinateReferenceSystem( crs ), enable );
+  QgsGeorefDataPoint *pnt = new QgsGeorefDataPoint( mCanvas, QgisApp::instance()->mapCanvas(), pixelCoords, mapCoords, crs, enable );
   mPoints.append( pnt );
   mGCPsDirty = true;
   if ( finalize )
@@ -635,10 +634,11 @@ void QgsGeoreferencerMainWindow::showCoordDialog( const QgsPointXY &pixelCoords 
 {
   if ( mLayer && !mMapCoordsDialog )
   {
-    mMapCoordsDialog = new QgsMapCoordsDialog( QgisApp::instance()->mapCanvas(), pixelCoords, this );
-    connect( mMapCoordsDialog, &QgsMapCoordsDialog::pointAdded, this,
-    [this]( const QgsPointXY & a, const QgsPointXY & b, const QgsCoordinateReferenceSystem & crs ) { this->addPoint( a, b, crs ); }
-           );
+    mMapCoordsDialog = new QgsMapCoordsDialog( QgisApp::instance()->mapCanvas(), pixelCoords, mProjection, this );
+    connect( mMapCoordsDialog, &QgsMapCoordsDialog::pointAdded, this, [ = ]( const QgsPointXY & a, const QgsPointXY & b, const QgsCoordinateReferenceSystem & crs )
+    {
+      addPoint( a, b, crs );
+    } );
     mMapCoordsDialog->show();
   }
 }

--- a/src/app/georeferencer/qgsmapcoordsdialog.h
+++ b/src/app/georeferencer/qgsmapcoordsdialog.h
@@ -59,7 +59,7 @@ class QgsMapCoordsDialog : public QDialog, private Ui::QgsMapCoordsDialogBase
     Q_OBJECT
 
   public:
-    QgsMapCoordsDialog( QgsMapCanvas *qgisCanvas, const QgsPointXY &pixelCoords, QWidget *parent = nullptr );
+    QgsMapCoordsDialog( QgsMapCanvas *qgisCanvas, const QgsPointXY &pixelCoords, QgsCoordinateReferenceSystem &rasterCrs, QWidget *parent = nullptr );
     ~QgsMapCoordsDialog() override;
 
   private slots:
@@ -70,10 +70,9 @@ class QgsMapCoordsDialog : public QDialog, private Ui::QgsMapCoordsDialogBase
     void maybeSetXY( const QgsPointXY &, Qt::MouseButton );
     void updateOK();
     void setPrevTool();
-    void updateCrs( const QgsCoordinateReferenceSystem &crs );
 
   signals:
-    void pointAdded( const QgsPointXY &, const QgsPointXY &, const QgsCoordinateReferenceSystem & );
+    void pointAdded( const QgsPointXY &a, const QgsPointXY &b, const QgsCoordinateReferenceSystem &crs );
 
   private:
     double dmsToDD( const QString &dms );
@@ -86,7 +85,7 @@ class QgsMapCoordsDialog : public QDialog, private Ui::QgsMapCoordsDialogBase
     QgsMapTool *mPrevMapTool = nullptr;
     QgsMapCanvas *mQgisCanvas = nullptr;
 
-    QgsCoordinateReferenceSystem mCrs;
+    QgsCoordinateReferenceSystem mRasterCrs;
 
     QgsPointXY mPixelCoords;
 };

--- a/src/ui/georeferencer/qgsmapcoordsdialogbase.ui
+++ b/src/ui/georeferencer/qgsmapcoordsdialogbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>584</width>
-    <height>221</height>
+    <height>421</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -30,50 +30,31 @@
       </widget>
      </item>
      <item>
-      <widget class="QSplitter" name="splitter">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <widget class="QLabel" name="textLabel1">
-        <property name="text">
-         <string>X / East</string>
-        </property>
-       </widget>
-       <widget class="QLineEdit" name="leXCoord"/>
-       <widget class="QLabel" name="textLabel2">
-        <property name="text">
-         <string>Y / North</string>
-        </property>
-       </widget>
-       <widget class="QLineEdit" name="leYCoord"/>
-      </widget>
+      <layout class="QGridLayout" name="coordinatesLayout">
+       <item row="0" column="0">
+        <widget class="QLabel" name="textLabel1">
+         <property name="text">
+          <string>X / East</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="leXCoord"/>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="textLabel2">
+         <property name="text">
+          <string>Y / North</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLineEdit" name="leYCoord"/>
+       </item>
+      </layout>
      </item>
      <item>
       <widget class="QgsProjectionSelectionWidget" name="mProjSelect" native="true">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>22</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>10</height>
-        </size>
-       </property>
        <property name="focusPolicy">
         <enum>Qt::StrongFocus</enum>
        </property>
@@ -85,6 +66,22 @@
         <string>Automatically hide georeferencer window </string>
        </property>
       </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Expanding</enum>
+       </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>12</width>
+          <height>12</height>
+         </size>
+        </property>
+       </spacer>
      </item>
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">

--- a/src/ui/georeferencer/qgsmapcoordsdialogbase.ui
+++ b/src/ui/georeferencer/qgsmapcoordsdialogbase.ui
@@ -54,7 +54,7 @@
       </layout>
      </item>
      <item>
-      <widget class="QgsProjectionSelectionWidget" name="mProjSelect" native="true">
+      <widget class="QgsProjectionSelectionWidget" name="mProjectionSelector" native="true">
        <property name="focusPolicy">
         <enum>Qt::StrongFocus</enum>
        </property>


### PR DESCRIPTION
## Description

UI improvements shown in this before (left) vs. PR (right):
![image](https://user-images.githubusercontent.com/1728657/101442251-8a456200-394d-11eb-9d6d-cb7ad0e9470b.png)

UX improvements:
- The default projection of the map coordinates entry dialog is the raster's projection setup by the user (in the settings window). This allows us to not use "invalid projection" every time a user opens the dialog (which is just a bad/intimidating message to users)
- When users clicks on the main map canvas to enter coordinates, _ always_ set the projection CRS to the main map canvas' CRS