### PR TITLE
[processing] fix loading geometryless tables with PostGISExecuteAndLo…

### DIFF
--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -584,7 +584,7 @@ QString QgsDataSourceUri::uri( bool expandAuthConfig ) const
   {
     uri += QStringLiteral( " table=%1%2" )
            .arg( quotedTablename(),
-                 mGeometryColumn.isNull() ? QString() : QStringLiteral( " (%1)" ).arg( columnName ) );
+                 mGeometryColumn.isEmpty() ? QString() : QStringLiteral( " (%1)" ).arg( columnName ) );
   }
   else if ( !mSchema.isEmpty() )
   {


### PR DESCRIPTION

## Description

Fix #39688

Force `geom_field = None` for empty string because the method `setDataSource`does not work properly with.