### PR TITLE
Save ~150ms in project loading times by storing QgsSettings instance

### DIFF
--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -48,6 +48,7 @@
 #include "qgsprojecttranslator.h"
 #include "qgsattributeeditorelement.h"
 #include "qgscolorscheme.h"
+#include "qgssettings.h"
 
 class QFileInfo;
 class QDomDocument;
@@ -2066,6 +2067,8 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     std::unique_ptr< QTranslator > mTranslator;
 
     bool mIsBeingDeleted = false;
+
+    QgsSettings mSettings;
 
     mutable std::unique_ptr< QgsExpressionContextScope > mProjectScope;
 


### PR DESCRIPTION
Another micro optimization: by storing a qgssettings instance in the project and re-using it there is small speed improvement.