### PR TITLE
OriginalXmlProperties optimization

### DIFF
--- a/src/core/layertree/qgslayertreeutils.cpp
+++ b/src/core/layertree/qgslayertreeutils.cpp
@@ -314,9 +314,8 @@ void QgsLayerTreeUtils::removeInvalidLayers( QgsLayerTreeGroup *group )
 
 void QgsLayerTreeUtils::storeOriginalLayersProperties( QgsLayerTreeGroup *group,  const QDomDocument *doc )
 {
-  const QDomNodeList mlNodeList( doc->documentElement()
-                                 .firstChildElement( QStringLiteral( "projectlayers" ) )
-                                 .elementsByTagName( QStringLiteral( "maplayer" ) ) );
+
+  const QDomElement projectLayersElement { doc->documentElement().firstChildElement( QStringLiteral( "projectlayers" ) ) };
 
   std::function<void ( QgsLayerTreeNode * )> _store = [ & ]( QgsLayerTreeNode * node )
   {
@@ -325,22 +324,23 @@ void QgsLayerTreeUtils::storeOriginalLayersProperties( QgsLayerTreeGroup *group,
       QgsMapLayer *l( QgsLayerTree::toLayer( node )->layer() );
       if ( l )
       {
-        for ( int i = 0; i < mlNodeList.count(); i++ )
+        QDomElement layerElement { projectLayersElement.firstChildElement( QStringLiteral( "maplayer" ) ) };
+        while ( ! layerElement.isNull() )
         {
-          QDomNode mlNode( mlNodeList.at( i ) );
-          QString id( mlNode.firstChildElement( QStringLiteral( "id" ) ).firstChild().nodeValue() );
+          const QString id( layerElement.firstChildElement( QStringLiteral( "id" ) ).firstChild().nodeValue() );
           if ( id == l->id() )
           {
             QDomImplementation DomImplementation;
             QDomDocumentType documentType = DomImplementation.createDocumentType( QStringLiteral( "qgis" ), QStringLiteral( "http://mrcc.com/qgis.dtd" ), QStringLiteral( "SYSTEM" ) );
             QDomDocument document( documentType );
-            QDomElement element = mlNode.toElement();
-            document.appendChild( element );
+            document.appendChild( layerElement );
             QString str;
             QTextStream stream( &str );
             document.save( stream, 4 /*indent*/ );
             l->setOriginalXmlProperties( str );
+            break;
           }
+          layerElement = layerElement.nextSiblingElement( );
         }
       }
     }

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1629,6 +1629,7 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
   // or wanted to pass them through when saving
   if ( !( flags & QgsProject::ReadFlag::FlagDontStoreOriginalStyles ) )
   {
+    profile.switchTask( tr( "Storing original layer properties" ) );
     QgsLayerTreeUtils::storeOriginalLayersProperties( mRootGroup, doc.get() );
   }
 

--- a/tests/src/python/test_qgsprojectbadlayers.py
+++ b/tests/src/python/test_qgsprojectbadlayers.py
@@ -129,7 +129,7 @@ class TestQgsProjectBadLayers(unittest.TestCase):
         raster.setOriginalXmlProperties('pippo')
         self.assertEqual(raster.originalXmlProperties(), 'pippo')
 
-        # Now create and invalid project:
+        # Now create an invalid project:
         bad_project_path = os.path.join(temp_dir.path(), 'project_bad.qgs')
         with open(project_path, 'r') as infile:
             with open(bad_project_path, 'w+') as outfile:


### PR DESCRIPTION
Dramatic speed improvement in XML original properties storage.

The original implementation used a call to QDomNodeList::count() method
that calls QDomNodeListPrivate::createList() -> DETACH!

By using a while loop we prevent the detach and it's more than 10 times faster.

