### PR TITLE
Fix crasher when the symbol selector panel is open via symbol button widget

### DIFF
--- a/src/gui/qgssymbolbutton.cpp
+++ b/src/gui/qgssymbolbutton.cpp
@@ -111,7 +111,7 @@ void QgsSymbolButton::showSettingsDialog()
   QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
   if ( panel && panel->dockMode() )
   {
-    QgsSymbolSelectorWidget *d = new QgsSymbolSelectorWidget( newSymbol, QgsStyle::defaultStyle(), mLayer, nullptr );
+    QgsSymbolSelectorWidget *d = new QgsSymbolSelectorWidget( newSymbol, QgsStyle::defaultStyle(), mLayer, panel );
     d->setPanelTitle( mDialogTitle );
     d->setContext( symbolContext );
     connect( d, &QgsPanelWidget::widgetChanged, this, &QgsSymbolButton::updateSymbolFromWidget );

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -305,40 +305,25 @@ QgsSymbolSelectorWidget::QgsSymbolSelectorWidget( QgsSymbol *symbol, QgsStyle *s
 
   setPanelTitle( tr( "Symbol Selector" ) );
 
-  connect( QgsApplication::svgCache(), &QgsSvgCache::remoteSvgFetched, this, [ = ]
-  {
-    // when a remote svg has been fetched, update the widget's previews
-    // this is required if the symbol utilizes remote svgs, and the current previews
-    // have been generated using the temporary "downloading" svg. In this case
-    // we require the preview to be regenerated to use the correct fetched
-    // svg
-    mBlockModified = true;
-    symbolChanged();
-    updatePreview();
-    mBlockModified = false;
-  } );
-  connect( QgsApplication::imageCache(), &QgsImageCache::remoteImageFetched, this, [ = ]
-  {
-    // when a remote image has been fetched, update the widget's previews
-    // this is required if the symbol utilizes remote images, and the current previews
-    // have been generated using the temporary "downloading" image. In this case
-    // we require the preview to be regenerated to use the correct fetched
-    // image
-    mBlockModified = true;
-    symbolChanged();
-    updatePreview();
-    mBlockModified = false;
-  } );
+  // when a remote svg has been fetched, update the widget's previews
+  // this is required if the symbol utilizes remote svgs, and the current previews
+  // have been generated using the temporary "downloading" svg. In this case
+  // we require the preview to be regenerated to use the correct fetched
+  // svg
+  connect( QgsApplication::svgCache(), &QgsSvgCache::remoteSvgFetched, this, &QgsSymbolSelectorWidget::projectDataChanged );
 
-  connect( QgsProject::instance(), &QgsProject::projectColorsChanged, this, [ = ]
-  {
-    // if project color scheme changes, we need to redraw symbols - they may use project colors and accordingly
-    // need updating to reflect the new colors
-    mBlockModified = true;
-    symbolChanged();
-    updatePreview();
-    mBlockModified = false;
-  } );
+  // when a remote image has been fetched, update the widget's previews
+  // this is required if the symbol utilizes remote images, and the current previews
+  // have been generated using the temporary "downloading" image. In this case
+  // we require the preview to be regenerated to use the correct fetched
+  // image
+  connect( QgsApplication::imageCache(), &QgsImageCache::remoteImageFetched, this, &QgsSymbolSelectorWidget::projectDataChanged );
+
+  // if project color scheme changes, we need to redraw symbols - they may use project colors and accordingly
+  // need updating to reflect the new colors
+  connect( QgsProject::instance(), &QgsProject::projectColorsChanged, this, &QgsSymbolSelectorWidget::projectDataChanged );
+
+  connect( QgsProject::instance(), static_cast < void ( QgsProject::* )( const QList<QgsMapLayer *>& layers ) > ( &QgsProject::layersWillBeRemoved ), this, &QgsSymbolSelectorWidget::layersAboutToBeRemoved );
 }
 
 QMenu *QgsSymbolSelectorWidget::advancedMenu()
@@ -938,4 +923,20 @@ QDialogButtonBox *QgsSymbolSelectorDialog::buttonBox() const
 void QgsSymbolSelectorDialog::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "style_library/symbol_selector.html" ) );
+}
+
+void QgsSymbolSelectorWidget::projectDataChanged()
+{
+  mBlockModified = true;
+  symbolChanged();
+  updatePreview();
+  mBlockModified = false;
+}
+
+void QgsSymbolSelectorWidget::layersAboutToBeRemoved( const QList<QgsMapLayer *> &layers )
+{
+  if ( mVectorLayer && layers.contains( mVectorLayer ) )
+  {
+    disconnect( QgsProject::instance(), &QgsProject::projectColorsChanged, this, &QgsSymbolSelectorWidget::projectDataChanged );
+  }
 }

--- a/src/gui/symbology/qgssymbolselectordialog.h
+++ b/src/gui/symbology/qgssymbolselectordialog.h
@@ -203,6 +203,19 @@ class GUI_EXPORT QgsSymbolSelectorWidget: public QgsPanelWidget, private Ui::Qgs
      */
     void symbolModified();
 
+  private slots:
+
+    /**
+     * Called when project data (such as project colors, image cache) has changed. Updates
+     * the symbol preview to take changes into account.
+     */
+    void projectDataChanged();
+
+    /**
+     * Called when layers are about to be removed from the project.
+     */
+    void layersAboutToBeRemoved( const QList<QgsMapLayer *> &layers );
+
   private:
 
     /**


### PR DESCRIPTION
## Description

@nyalldawson , this fixes #40497 -- for some reason unknown to me, the symbol selector panel isn't destroyed (even though closePanel() calls deleteLater()). The patch was to a/ fix the missing parent when opening the panel via the symbol button, and b/ since it's not destroyed, add a hide() prior to deleteLayer() and skip symbol preview rendering when widget is hidden.

EDIT: actually, the widget gets destroyed, only too late. I assume it has to do with the way signals are dispatched et al.