### PR TITLE
Avoid emitting QgsProject::snappingConfigChanged multiple times when reading or clearing projects

### DIFF
--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -888,12 +888,15 @@ void QgsProject::clear()
   int alpha = mSettings.value( QStringLiteral( "qgis/default_selection_color_alpha" ), 255 ).toInt();
   setSelectionColor( QColor( red, green, blue, alpha ) );
 
+  mSnappingConfig.clearIndividualLayerSettings();
+
   removeAllMapLayers();
   mRootGroup->clear();
   if ( mMainAnnotationLayer )
     mMainAnnotationLayer->reset();
 
   snapSingleBlocker.release();
+
   if ( !mBlockSnappingUpdates )
     emit snappingConfigChanged( mSnappingConfig );
 
@@ -3475,6 +3478,7 @@ void QgsProject::removeAllMapLayers()
   mLayerStore->removeAllMapLayers();
 
   snapSingleBlocker.release();
+  mSnappingConfig.clearIndividualLayerSettings();
   if ( !mBlockSnappingUpdates )
     emit snappingConfigChanged( mSnappingConfig );
 }

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -84,7 +84,7 @@
 // canonical project instance
 QgsProject *QgsProject::sProject = nullptr;
 
-
+///@cond PRIVATE
 class ScopedIntIncrementor
 {
   public:
@@ -114,6 +114,7 @@ class ScopedIntIncrementor
   private:
     int *mVariable = nullptr;
 };
+///@endcond
 
 
 /**

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -84,6 +84,38 @@
 // canonical project instance
 QgsProject *QgsProject::sProject = nullptr;
 
+
+class ScopedIntIncrementor
+{
+  public:
+
+    ScopedIntIncrementor( int *variable )
+      : mVariable( variable )
+    {
+      ( *mVariable )++;
+    }
+
+    ScopedIntIncrementor( const ScopedIntIncrementor &other ) = delete;
+    ScopedIntIncrementor &operator=( const ScopedIntIncrementor &other ) = delete;
+
+    void release()
+    {
+      if ( mVariable )
+        ( *mVariable )--;
+
+      mVariable = nullptr;
+    }
+
+    ~ScopedIntIncrementor()
+    {
+      release();
+    }
+
+  private:
+    int *mVariable = nullptr;
+};
+
+
 /**
     Take the given scope and key and convert them to a string list of key
     tokens that will be used to navigate through a Property hierarchy
@@ -779,6 +811,7 @@ void QgsProject::setTransformContext( const QgsCoordinateTransformContext &conte
 
 void QgsProject::clear()
 {
+  ScopedIntIncrementor snapSingleBlocker( &mBlockSnappingUpdates );
 
   mProjectScope.reset();
   mFile.setFileName( QString() );
@@ -815,7 +848,6 @@ void QgsProject::clear()
   mTimeSettings->reset();
   mDisplaySettings->reset();
   mSnappingConfig.reset();
-  emit snappingConfigChanged( mSnappingConfig );
   emit avoidIntersectionsModeChanged();
   emit topologicalEditingChanged();
 
@@ -860,6 +892,10 @@ void QgsProject::clear()
   mRootGroup->clear();
   if ( mMainAnnotationLayer )
     mMainAnnotationLayer->reset();
+
+  snapSingleBlocker.release();
+  if ( !mBlockSnappingUpdates )
+    emit snappingConfigChanged( mSnappingConfig );
 
   setDirty( false );
   emit homePathChanged();
@@ -1283,6 +1319,9 @@ bool QgsProject::read( QgsProject::ReadFlags flags )
 
 bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags flags )
 {
+  // avoid multiple emission of snapping updated signals
+  ScopedIntIncrementor snapSignalBlock( &mBlockSnappingUpdates );
+
   QFile projectFile( filename );
   clearError();
 
@@ -1707,7 +1746,11 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
   emit readProjectWithContext( *doc, context );
 
   profile.switchTask( tr( "Updating interface" ) );
-  emit snappingConfigChanged( mSnappingConfig );
+
+  snapSignalBlock.release();
+  if ( !mBlockSnappingUpdates )
+    emit snappingConfigChanged( mSnappingConfig );
+
   emit avoidIntersectionsModeChanged();
   emit topologicalEditingChanged();
   emit projectColorsChanged();
@@ -2013,13 +2056,13 @@ void QgsProject::onMapLayersAdded( const QList<QgsMapLayer *> &layers )
     }
   }
 
-  if ( mSnappingConfig.addLayers( layers ) )
+  if ( !mBlockSnappingUpdates && mSnappingConfig.addLayers( layers ) )
     emit snappingConfigChanged( mSnappingConfig );
 }
 
 void QgsProject::onMapLayersRemoved( const QList<QgsMapLayer *> &layers )
 {
-  if ( mSnappingConfig.removeLayers( layers ) )
+  if ( !mBlockSnappingUpdates && mSnappingConfig.removeLayers( layers ) )
     emit snappingConfigChanged( mSnappingConfig );
 }
 
@@ -3424,8 +3467,16 @@ QgsAnnotationLayer *QgsProject::mainAnnotationLayer()
 
 void QgsProject::removeAllMapLayers()
 {
+  if ( mLayerStore->count() == 0 )
+    return;
+
+  ScopedIntIncrementor snapSingleBlocker( &mBlockSnappingUpdates );
   mProjectScope.reset();
   mLayerStore->removeAllMapLayers();
+
+  snapSingleBlocker.release();
+  if ( !mBlockSnappingUpdates )
+    emit snappingConfigChanged( mSnappingConfig );
 }
 
 void QgsProject::reloadAllLayers()

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -2072,6 +2072,8 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
 
     mutable std::unique_ptr< QgsExpressionContextScope > mProjectScope;
 
+    int mBlockSnappingUpdates = 0;
+
     friend class QgsProjectDirtyBlocker;
 
     // Required to avoid creating a new project in it's destructor

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -807,6 +807,37 @@ class TestQgsProject(unittest.TestCase):
         self.assertTrue(prj.crs().isValid())
         self.assertEqual(prj.crs().authid(), 'EPSG:2056')
 
+    def testSnappingChangedSignal(self):
+        """
+        Test the snappingConfigChanged signal
+        """
+        project = QgsProject()
+        spy = QSignalSpy(project.snappingConfigChanged)
+        l0 = QgsVectorLayer(os.path.join(TEST_DATA_DIR, "points.shp"), "points", "ogr")
+        l1 = QgsVectorLayer(os.path.join(TEST_DATA_DIR, "lines.shp"), "lines", "ogr")
+        l2 = QgsVectorLayer(os.path.join(TEST_DATA_DIR, "polys.shp"), "polys", "ogr")
+        project.addMapLayers([l0, l1])
+        self.assertEqual(len(spy), 1)
+        project.addMapLayer(l2)
+        self.assertEqual(len(spy), 2)
+
+        tmpDir = QTemporaryDir()
+        tmpFile = "{}/project_snap.qgs".format(tmpDir.path())
+        self.assertTrue(project.write(tmpFile))
+
+        # only ONE signal!
+        project.clear()
+        self.assertEqual(len(spy), 3)
+
+        p2 = QgsProject()
+        spy2 = QSignalSpy(p2.snappingConfigChanged)
+        p2.read(tmpFile)
+        # only ONE signal!
+        self.assertEqual(len(spy2), 1)
+
+        p2.removeAllMapLayers()
+        self.assertEqual(len(spy2), 2)
+
     def testRelativePaths(self):
         """
         Test whether paths to layer sources are stored as relative to the project path

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -821,6 +821,8 @@ class TestQgsProject(unittest.TestCase):
         project.addMapLayer(l2)
         self.assertEqual(len(spy), 2)
 
+        self.assertEqual(len(project.snappingConfig().individualLayerSettings()), 3)
+
         tmpDir = QTemporaryDir()
         tmpFile = "{}/project_snap.qgs".format(tmpDir.path())
         self.assertTrue(project.write(tmpFile))
@@ -829,14 +831,19 @@ class TestQgsProject(unittest.TestCase):
         project.clear()
         self.assertEqual(len(spy), 3)
 
+        self.assertFalse(project.snappingConfig().individualLayerSettings())
+
         p2 = QgsProject()
         spy2 = QSignalSpy(p2.snappingConfigChanged)
         p2.read(tmpFile)
         # only ONE signal!
         self.assertEqual(len(spy2), 1)
 
+        self.assertEqual(len(p2.snappingConfig().individualLayerSettings()), 3)
+
         p2.removeAllMapLayers()
         self.assertEqual(len(spy2), 2)
+        self.assertFalse(p2.snappingConfig().individualLayerSettings())
 
     def testRelativePaths(self):
         """


### PR DESCRIPTION
Alternative non-server specific approach to https://github.com/qgis/QGIS/pull/40418