### PR TITLE
It's FAR too expensive to construct a QgsSettings object for every symbol node

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
@@ -293,6 +293,9 @@ and allowing interaction with the symbol / renderer.
 %End
   public:
 
+    static double MINIMUM_SIZE;
+    static double MAXIMUM_SIZE;
+
     QgsSymbolLegendNode( QgsLayerTreeLayer *nodeLayer, const QgsLegendSymbolItem &item, QObject *parent /TransferThis/ = 0 );
 %Docstring
 Constructor for QgsSymbolLegendNode.

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -38,6 +38,7 @@
 #include "qgsexpressioncontextutils.h"
 #include "qgslocaldefaultsettings.h"
 #include "qgsnumericformatwidget.h"
+#include "qgslayertreemodellegendnode.h"
 
 #include "qgsattributetablefiltermodel.h"
 #include "qgslocalizeddatapathregistry.h"
@@ -1570,6 +1571,8 @@ void QgsOptions::saveOptions()
 
   mSettings->setValue( QStringLiteral( "/qgis/legendsymbolMinimumSize" ), mLegendSymbolMinimumSizeSpinBox->value() );
   mSettings->setValue( QStringLiteral( "/qgis/legendsymbolMaximumSize" ), mLegendSymbolMaximumSizeSpinBox->value() );
+  QgsSymbolLegendNode::MINIMUM_SIZE = mLegendSymbolMinimumSizeSpinBox->value();
+  QgsSymbolLegendNode::MAXIMUM_SIZE = mLegendSymbolMaximumSizeSpinBox->value();
 
   mSettings->setValue( QStringLiteral( "/qgis/defaultLegendGraphicResolution" ), mLegendGraphicResolutionSpinBox->value() );
   mSettings->setValue( QStringLiteral( "/qgis/mapTipsDelay" ), mMapTipsDelaySpinBox->value() );

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -341,8 +341,10 @@ class CORE_EXPORT QgsSymbolLegendNode : public QgsLayerTreeModelLegendNode
 {
     Q_OBJECT
 
-
   public:
+
+    static double MINIMUM_SIZE;
+    static double MAXIMUM_SIZE;
 
     /**
      * Constructor for QgsSymbolLegendNode.
@@ -497,8 +499,6 @@ class CORE_EXPORT QgsSymbolLegendNode : public QgsLayerTreeModelLegendNode
     bool mSymbolUsesMapUnits;
 
     QSize mIconSize;
-    double mSymbolMinimumSize = 0.5;
-    double mSymbolMaximumSize = 20.0;
 
     QString mTextOnSymbolLabel;
     QgsTextFormat mTextOnSymbolTextFormat;


### PR DESCRIPTION
…, especially for complex projects. So only read the valid size ranges once, and store them for subsequent use
