### PR TITLE
Defer resizing columns in snapping widget until the widget is actually visible

### DIFF
--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -91,6 +91,7 @@ QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas,
   mLayerTreeView = new QTreeView();
   QgsSnappingLayerTreeModel *model = new QgsSnappingLayerTreeModel( mProject, mCanvas, this );
   model->setLayerTreeModel( new QgsLayerTreeModel( mProject->layerTreeRoot(), model ) );
+  mLayerTreeView->installEventFilter( this );
 
 #ifdef ENABLE_MODELTEST
   new ModelTest( model, this );
@@ -648,8 +649,16 @@ void QgsSnappingWidget::enableSelfSnapping( bool enabled )
 
 void QgsSnappingWidget::onSnappingTreeLayersChanged()
 {
-  mLayerTreeView->expandAll();
-  mLayerTreeView->resizeColumnToContents( 0 );
+  if ( mLayerTreeView->isVisible() )
+  {
+    mLayerTreeView->expandAll();
+    mLayerTreeView->resizeColumnToContents( 0 );
+    mRequireLayerTreeViewUpdate = false;
+  }
+  else
+  {
+    mRequireLayerTreeViewUpdate = true;
+  }
 }
 
 void QgsSnappingWidget::avoidIntersectionsModeButtonTriggered( QAction *action )
@@ -827,7 +836,18 @@ void QgsSnappingWidget::setConfig( const QgsSnappingConfig &config )
   mConfig = config;
 }
 
-
+bool QgsSnappingWidget::eventFilter( QObject *watched, QEvent *event )
+{
+  if ( watched == mLayerTreeView  && event->type() == QEvent::Show )
+  {
+    if ( mRequireLayerTreeViewUpdate )
+    {
+      mLayerTreeView->expandAll();
+      mLayerTreeView->resizeColumnToContents( 0 );
+    }
+  }
+  return QWidget::eventFilter( watched, event );
+}
 
 void QgsSnappingWidget::cleanGroup( QgsLayerTreeNode *node )
 {

--- a/src/app/qgssnappingwidget.h
+++ b/src/app/qgssnappingwidget.h
@@ -87,6 +87,8 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
     //! Returns spin box used to set offset for tracing
     QgsDoubleSpinBox *tracingOffsetSpinBox() { return mTracingOffsetSpinBox; }
 
+    bool eventFilter( QObject *watched, QEvent *event ) override;
+
   signals:
     void snappingConfigChanged();
 
@@ -178,6 +180,8 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
     QTreeView *mLayerTreeView = nullptr;
     QWidget *mAdvancedConfigWidget = nullptr;
     QgsFloatingWidget *mAdvancedConfigContainer = nullptr;
+
+    bool mRequireLayerTreeViewUpdate = false;
 
     void cleanGroup( QgsLayerTreeNode *node );
 };


### PR DESCRIPTION
Otherwise this can cause a HUGE amount of unnecessary work when adding a large number
of layers (or layers with a large number of legend nodes) to a project
