### PR TITLE
Dramatic speed up to project load when non millimeter symbol sizes are used

### DIFF
--- a/python/core/auto_generated/symbology/qgsarrowsymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsarrowsymbollayer.sip.in
@@ -45,6 +45,8 @@ Create a new QgsArrowSymbolLayer
 
     virtual bool hasDataDefinedProperties() const;
 
+    virtual bool usesMapUnits() const;
+
 
     double arrowWidth() const;
 %Docstring

--- a/python/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
@@ -152,6 +152,8 @@ Returns the units for the symbol's stroke width.
 
     virtual QgsUnitTypes::RenderUnit outputUnit() const;
 
+    virtual bool usesMapUnits() const;
+
 
     virtual void setMapUnitScale( const QgsMapUnitScale &scale );
 

--- a/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
@@ -159,6 +159,8 @@ Returns the map unit scale for the fill's offset.
 
     virtual QgsUnitTypes::RenderUnit outputUnit() const;
 
+    virtual bool usesMapUnits() const;
+
 
     virtual void setMapUnitScale( const QgsMapUnitScale &scale );
 
@@ -399,6 +401,8 @@ Returns the map unit scale for the fill's offset.
     virtual void setOutputUnit( QgsUnitTypes::RenderUnit unit );
 
     virtual QgsUnitTypes::RenderUnit outputUnit() const;
+
+    virtual bool usesMapUnits() const;
 
 
     virtual void setMapUnitScale( const QgsMapUnitScale &scale );
@@ -743,6 +747,8 @@ Returns the units used for the offset of the shapeburst fill.
 
     virtual QgsUnitTypes::RenderUnit outputUnit() const;
 
+    virtual bool usesMapUnits() const;
+
 
     virtual void setMapUnitScale( const QgsMapUnitScale &scale );
 
@@ -903,6 +909,8 @@ Used internally when reading/writing symbols.
     virtual QgsRasterFillSymbolLayer *clone() const /Factory/;
 
     virtual double estimateMaxBleed( const QgsRenderContext &context ) const;
+
+    virtual bool usesMapUnits() const;
 
 
     virtual QgsSymbol *subSymbol();
@@ -1184,6 +1192,8 @@ Used internally when reading/writing symbols.
     virtual QgsSVGFillSymbolLayer *clone() const /Factory/;
 
     virtual void toSld( QDomDocument &doc, QDomElement &element, const QgsStringMap &props ) const;
+
+    virtual bool usesMapUnits() const;
 
 
     void setSvgFilePath( const QString &svgPath );
@@ -1658,6 +1668,8 @@ Returns the map unit scale for the pattern's line offset.
 
     virtual QgsUnitTypes::RenderUnit outputUnit() const;
 
+    virtual bool usesMapUnits() const;
+
     virtual void setMapUnitScale( const QgsMapUnitScale &scale );
 
     virtual QgsMapUnitScale mapUnitScale() const;
@@ -1976,6 +1988,8 @@ Returns the unit scale for the vertical offset between rows in the pattern.
 
     virtual QgsUnitTypes::RenderUnit outputUnit() const;
 
+    virtual bool usesMapUnits() const;
+
 
     virtual void setMapUnitScale( const QgsMapUnitScale &scale );
 
@@ -2061,6 +2075,8 @@ Caller takes ownership of the returned symbol layer.
     virtual void setOutputUnit( QgsUnitTypes::RenderUnit unit );
 
     virtual QgsUnitTypes::RenderUnit outputUnit() const;
+
+    virtual bool usesMapUnits() const;
 
 
     virtual void setMapUnitScale( const QgsMapUnitScale &scale );
@@ -2253,6 +2269,8 @@ Caller takes ownership of the returned symbol layer.
     virtual void setOutputUnit( QgsUnitTypes::RenderUnit unit );
 
     virtual QgsUnitTypes::RenderUnit outputUnit() const;
+
+    virtual bool usesMapUnits() const;
 
 
     virtual void setMapUnitScale( const QgsMapUnitScale &scale );

--- a/python/core/auto_generated/symbology/qgsgeometrygeneratorsymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsgeometrygeneratorsymbollayer.sip.in
@@ -46,6 +46,8 @@ that is created by this generator.
 
     virtual void stopFeatureRender( const QgsFeature &feature, QgsRenderContext &context );
 
+    virtual bool usesMapUnits() const;
+
 
     virtual QgsSymbolLayer *clone() const /Factory/;
 

--- a/python/core/auto_generated/symbology/qgslinesymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgslinesymbollayer.sip.in
@@ -66,6 +66,8 @@ Creates a new QgsSimpleLineSymbolLayer from an SLD XML DOM ``element``.
 
     virtual QgsUnitTypes::RenderUnit outputUnit() const;
 
+    virtual bool usesMapUnits() const;
+
     virtual void setMapUnitScale( const QgsMapUnitScale &scale );
 
     virtual QgsMapUnitScale mapUnitScale() const;
@@ -770,6 +772,8 @@ Creates a new QgsMarkerLineSymbolLayer from an SLD XML DOM ``element``.
 
     virtual void setOutputUnit( QgsUnitTypes::RenderUnit unit );
 
+    virtual bool usesMapUnits() const;
+
     virtual QSet<QString> usedAttributes( const QgsRenderContext &context ) const;
 
     virtual bool hasDataDefinedProperties() const;
@@ -879,6 +883,8 @@ serialized in the ``properties`` map (corresponding to the output from
     virtual bool hasDataDefinedProperties() const;
 
     virtual void setDataDefinedProperty( QgsSymbolLayer::Property key, const QgsProperty &property );
+
+    virtual bool usesMapUnits() const;
 
 
     double hashAngle() const;

--- a/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
@@ -260,6 +260,8 @@ Creates a new QgsSimpleMarkerSymbolLayer from an SLD XML element.
 
     virtual QgsMapUnitScale mapUnitScale() const;
 
+    virtual bool usesMapUnits() const;
+
     virtual QRectF bounds( QPointF point, QgsSymbolRenderContext &context );
 
     virtual QColor fillColor() const;
@@ -512,6 +514,8 @@ Creates a new QgsFilledMarkerSymbolLayer.
 
     virtual QColor color() const;
 
+    virtual bool usesMapUnits() const;
+
 
   private:
     QgsFilledMarkerSymbolLayer( const QgsFilledMarkerSymbolLayer & );
@@ -562,6 +566,8 @@ Used internally when reading/writing symbols.
 
 
     virtual QgsStringMap properties() const;
+
+    virtual bool usesMapUnits() const;
 
 
     virtual QgsSvgMarkerSymbolLayer *clone() const /Factory/;
@@ -749,6 +755,8 @@ Used internally when reading/writing symbols.
 
     virtual QgsRasterMarkerSymbolLayer *clone() const /Factory/;
 
+    virtual bool usesMapUnits() const;
+
 
     double calculateAspectRatio( QgsSymbolRenderContext &context, double scaledSize, bool &hasDataDefinedAspectRatio ) const;
 %Docstring
@@ -910,6 +918,8 @@ Creates a new QgsFontMarkerSymbolLayer from an SLD XML ``element``.
 
 
     virtual void writeSldMarker( QDomDocument &doc, QDomElement &element, const QgsStringMap &props ) const;
+
+    virtual bool usesMapUnits() const;
 
 
 

--- a/python/core/auto_generated/symbology/qgsmasksymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsmasksymbollayer.sip.in
@@ -59,6 +59,8 @@ Create a new QgsMaskMarkerSymbolLayer
 
     virtual QRectF bounds( QPointF point, QgsSymbolRenderContext &context );
 
+    virtual bool usesMapUnits() const;
+
 
     virtual void drawPreviewIcon( QgsSymbolRenderContext &context, QSize size );
 

--- a/python/core/auto_generated/symbology/qgssymbol.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbol.sip.in
@@ -383,6 +383,13 @@ may use it to specify the units for the line width.
 .. seealso:: :py:func:`setOutputUnit`
 %End
 
+    bool usesMapUnits() const;
+%Docstring
+Returns ``True`` if the symbol has any components which use map unit based sizes.
+
+.. versionadded:: 3.18
+%End
+
     void setOutputUnit( QgsUnitTypes::RenderUnit unit );
 %Docstring
 Sets the units to use for sizes and widths within the symbol. Individual

--- a/python/core/auto_generated/symbology/qgssymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayer.sip.in
@@ -371,6 +371,13 @@ layer may use it to specify the units for the line width.
 .. seealso:: :py:func:`setOutputUnit`
 %End
 
+    virtual bool usesMapUnits() const;
+%Docstring
+Returns ``True`` if the symbol layer has any components which use map unit based sizes.
+
+.. versionadded:: 3.18
+%End
+
     virtual void setMapUnitScale( const QgsMapUnitScale &scale );
     virtual QgsMapUnitScale mapUnitScale() const;
 

--- a/python/core/auto_generated/symbology/qgsvectorfieldsymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsvectorfieldsymbollayer.sip.in
@@ -65,6 +65,8 @@ A symbol layer class for displaying displacement arrows based on point layer att
 
     virtual QgsStringMap properties() const;
 
+    virtual bool usesMapUnits() const;
+
 
     virtual void toSld( QDomDocument &doc, QDomElement &element, const QgsStringMap &props ) const;
 

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -305,8 +305,10 @@ QgsSymbolLegendNode::QgsSymbolLegendNode( QgsLayerTreeLayer *nodeLayer, const Qg
 
   connect( nodeLayer, &QObject::destroyed, this, [ = ]() { mLayerNode = nullptr; } );
 
-  if ( auto *lSymbol = mItem.symbol() )
-    mSymbolUsesMapUnits = ( lSymbol->outputUnit() != QgsUnitTypes::RenderMillimeters );
+  if ( const QgsSymbol *symbol = mItem.symbol() )
+  {
+    mSymbolUsesMapUnits = symbol->usesMapUnits();
+  }
 }
 
 Qt::ItemFlags QgsSymbolLegendNode::flags() const

--- a/src/core/symbology/qgsarrowsymbollayer.cpp
+++ b/src/core/symbology/qgsarrowsymbollayer.cpp
@@ -174,6 +174,16 @@ bool QgsArrowSymbolLayer::hasDataDefinedProperties() const
   return false;
 }
 
+bool QgsArrowSymbolLayer::usesMapUnits() const
+{
+  return mArrowWidthUnit == QgsUnitTypes::RenderMapUnits || mArrowWidthUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mArrowStartWidthUnit == QgsUnitTypes::RenderMapUnits || mArrowStartWidthUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mHeadLengthUnit == QgsUnitTypes::RenderMapUnits || mHeadLengthUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mHeadThicknessUnit == QgsUnitTypes::RenderMapUnits || mHeadThicknessUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mWidthUnit == QgsUnitTypes::RenderMapUnits || mWidthUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits;
+}
+
 void QgsArrowSymbolLayer::startRender( QgsSymbolRenderContext &context )
 {
   mExpressionScope.reset( new QgsExpressionContextScope() );

--- a/src/core/symbology/qgsarrowsymbollayer.h
+++ b/src/core/symbology/qgsarrowsymbollayer.h
@@ -48,6 +48,7 @@ class CORE_EXPORT QgsArrowSymbolLayer : public QgsLineSymbolLayer
     bool setSubSymbol( QgsSymbol *symbol SIP_TRANSFER ) override;
     QSet<QString> usedAttributes( const QgsRenderContext &context ) const override;
     bool hasDataDefinedProperties() const override;
+    bool usesMapUnits() const override;
 
     //! Gets current arrow width
     double arrowWidth() const { return mArrowWidth; }

--- a/src/core/symbology/qgsellipsesymbollayer.cpp
+++ b/src/core/symbology/qgsellipsesymbollayer.cpp
@@ -665,6 +665,14 @@ QgsUnitTypes::RenderUnit QgsEllipseSymbolLayer::outputUnit() const
   return unit;
 }
 
+bool QgsEllipseSymbolLayer::usesMapUnits() const
+{
+  return mSymbolWidthUnit == QgsUnitTypes::RenderMapUnits || mSymbolWidthUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mSymbolHeightUnit == QgsUnitTypes::RenderMapUnits || mSymbolHeightUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mStrokeWidthUnit == QgsUnitTypes::RenderMapUnits || mStrokeWidthUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits;
+}
+
 void QgsEllipseSymbolLayer::setMapUnitScale( const QgsMapUnitScale &scale )
 {
   QgsMarkerSymbolLayer::setMapUnitScale( scale );

--- a/src/core/symbology/qgsellipsesymbollayer.h
+++ b/src/core/symbology/qgsellipsesymbollayer.h
@@ -137,6 +137,7 @@ class CORE_EXPORT QgsEllipseSymbolLayer: public QgsMarkerSymbolLayer
 
     void setOutputUnit( QgsUnitTypes::RenderUnit unit ) override;
     QgsUnitTypes::RenderUnit outputUnit() const override;
+    bool usesMapUnits() const override;
 
     void setMapUnitScale( const QgsMapUnitScale &scale ) override;
     QgsMapUnitScale mapUnitScale() const override;

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -73,6 +73,12 @@ QgsUnitTypes::RenderUnit QgsSimpleFillSymbolLayer::outputUnit() const
   return unit;
 }
 
+bool QgsSimpleFillSymbolLayer::usesMapUnits() const
+{
+  return mStrokeWidthUnit == QgsUnitTypes::RenderMapUnits || mStrokeWidthUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits;
+}
+
 void QgsSimpleFillSymbolLayer::setMapUnitScale( const QgsMapUnitScale &scale )
 {
   mStrokeWidthMapUnitScale = scale;
@@ -992,6 +998,11 @@ QgsUnitTypes::RenderUnit QgsGradientFillSymbolLayer::outputUnit() const
   return mOffsetUnit;
 }
 
+bool QgsGradientFillSymbolLayer::usesMapUnits() const
+{
+  return mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits;
+}
+
 void QgsGradientFillSymbolLayer::setMapUnitScale( const QgsMapUnitScale &scale )
 {
   mOffsetMapUnitScale = scale;
@@ -1622,6 +1633,12 @@ QgsUnitTypes::RenderUnit QgsShapeburstFillSymbolLayer::outputUnit() const
   return QgsUnitTypes::RenderUnknownUnit;
 }
 
+bool QgsShapeburstFillSymbolLayer::usesMapUnits() const
+{
+  return mDistanceUnit == QgsUnitTypes::RenderMapUnits || mDistanceUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits;
+}
+
 void QgsShapeburstFillSymbolLayer::setMapUnitScale( const QgsMapUnitScale &scale )
 {
   mDistanceMapUnitScale = scale;
@@ -2198,6 +2215,12 @@ void QgsSVGFillSymbolLayer::toSld( QDomDocument &doc, QDomElement &element, cons
   }
 }
 
+bool QgsSVGFillSymbolLayer::usesMapUnits() const
+{
+  return mPatternWidthUnit == QgsUnitTypes::RenderMapUnits || mPatternWidthUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mSvgStrokeWidthUnit == QgsUnitTypes::RenderMapUnits || mSvgStrokeWidthUnit == QgsUnitTypes::RenderMetersInMapUnits;
+}
+
 QgsSymbolLayer *QgsSVGFillSymbolLayer::createFromSld( QDomElement &element )
 {
   QString path, mimeType;
@@ -2466,6 +2489,13 @@ QgsUnitTypes::RenderUnit QgsLinePatternFillSymbolLayer::outputUnit() const
     return QgsUnitTypes::RenderUnknownUnit;
   }
   return unit;
+}
+
+bool QgsLinePatternFillSymbolLayer::usesMapUnits() const
+{
+  return mDistanceUnit == QgsUnitTypes::RenderMapUnits || mDistanceUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mLineWidthUnit == QgsUnitTypes::RenderMapUnits || mLineWidthUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits;
 }
 
 void QgsLinePatternFillSymbolLayer::setMapUnitScale( const QgsMapUnitScale &scale )
@@ -3133,6 +3163,16 @@ QgsUnitTypes::RenderUnit QgsPointPatternFillSymbolLayer::outputUnit() const
     return QgsUnitTypes::RenderUnknownUnit;
   }
   return unit;
+}
+
+bool QgsPointPatternFillSymbolLayer::usesMapUnits() const
+{
+  return mDistanceXUnit == QgsUnitTypes::RenderMapUnits || mDistanceXUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mDistanceYUnit == QgsUnitTypes::RenderMapUnits || mDistanceYUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mDisplacementXUnit == QgsUnitTypes::RenderMapUnits || mDisplacementXUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mDisplacementYUnit == QgsUnitTypes::RenderMapUnits || mDisplacementYUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mOffsetXUnit == QgsUnitTypes::RenderMapUnits || mOffsetXUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mOffsetYUnit == QgsUnitTypes::RenderMapUnits || mOffsetYUnit == QgsUnitTypes::RenderMetersInMapUnits;
 }
 
 void QgsPointPatternFillSymbolLayer::setMapUnitScale( const QgsMapUnitScale &scale )
@@ -3994,6 +4034,15 @@ QgsUnitTypes::RenderUnit QgsCentroidFillSymbolLayer::outputUnit() const
   return QgsUnitTypes::RenderUnknownUnit; //mOutputUnit;
 }
 
+bool QgsCentroidFillSymbolLayer::usesMapUnits() const
+{
+  if ( mMarker )
+  {
+    return mMarker->usesMapUnits();
+  }
+  return false;
+}
+
 void QgsCentroidFillSymbolLayer::setMapUnitScale( const QgsMapUnitScale &scale )
 {
   if ( mMarker )
@@ -4189,6 +4238,12 @@ QgsRasterFillSymbolLayer *QgsRasterFillSymbolLayer::clone() const
 double QgsRasterFillSymbolLayer::estimateMaxBleed( const QgsRenderContext &context ) const
 {
   return context.convertToPainterUnits( std::max( std::fabs( mOffset.x() ), std::fabs( mOffset.y() ) ), mOffsetUnit, mOffsetMapUnitScale );
+}
+
+bool QgsRasterFillSymbolLayer::usesMapUnits() const
+{
+  return mWidthUnit == QgsUnitTypes::RenderMapUnits || mWidthUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits;
 }
 
 void QgsRasterFillSymbolLayer::setImageFilePath( const QString &imagePath )
@@ -4651,6 +4706,15 @@ QgsUnitTypes::RenderUnit QgsRandomMarkerFillSymbolLayer::outputUnit() const
     return mMarker->outputUnit();
   }
   return QgsUnitTypes::RenderUnknownUnit; //mOutputUnit;
+}
+
+bool QgsRandomMarkerFillSymbolLayer::usesMapUnits() const
+{
+  if ( mMarker )
+  {
+    return mMarker->usesMapUnits();
+  }
+  return false;
 }
 
 void QgsRandomMarkerFillSymbolLayer::setMapUnitScale( const QgsMapUnitScale &scale )

--- a/src/core/symbology/qgsfillsymbollayer.h
+++ b/src/core/symbology/qgsfillsymbollayer.h
@@ -159,6 +159,7 @@ class CORE_EXPORT QgsSimpleFillSymbolLayer : public QgsFillSymbolLayer
 
     void setOutputUnit( QgsUnitTypes::RenderUnit unit ) override;
     QgsUnitTypes::RenderUnit outputUnit() const override;
+    bool usesMapUnits() const override;
 
     void setMapUnitScale( const QgsMapUnitScale &scale ) override;
     QgsMapUnitScale mapUnitScale() const override;
@@ -369,6 +370,7 @@ class CORE_EXPORT QgsGradientFillSymbolLayer : public QgsFillSymbolLayer
 
     void setOutputUnit( QgsUnitTypes::RenderUnit unit ) override;
     QgsUnitTypes::RenderUnit outputUnit() const override;
+    bool usesMapUnits() const override;
 
     void setMapUnitScale( const QgsMapUnitScale &scale ) override;
     QgsMapUnitScale mapUnitScale() const override;
@@ -661,6 +663,7 @@ class CORE_EXPORT QgsShapeburstFillSymbolLayer : public QgsFillSymbolLayer
 
     void setOutputUnit( QgsUnitTypes::RenderUnit unit ) override;
     QgsUnitTypes::RenderUnit outputUnit() const override;
+    bool usesMapUnits() const override;
 
     void setMapUnitScale( const QgsMapUnitScale &scale ) override;
     QgsMapUnitScale mapUnitScale() const override;
@@ -834,6 +837,7 @@ class CORE_EXPORT QgsRasterFillSymbolLayer: public QgsImageFillSymbolLayer
     QgsStringMap properties() const override;
     QgsRasterFillSymbolLayer *clone() const override SIP_FACTORY;
     double estimateMaxBleed( const QgsRenderContext &context ) const override;
+    bool usesMapUnits() const override;
 
     //override QgsImageFillSymbolLayer's support for sub symbols
     QgsSymbol *subSymbol() override { return nullptr; }
@@ -1062,6 +1066,7 @@ class CORE_EXPORT QgsSVGFillSymbolLayer: public QgsImageFillSymbolLayer
     QgsStringMap properties() const override;
     QgsSVGFillSymbolLayer *clone() const override SIP_FACTORY;
     void toSld( QDomDocument &doc, QDomElement &element, const QgsStringMap &props ) const override;
+    bool usesMapUnits() const override;
 
     /**
      * Sets the path to the SVG file to render in the fill.
@@ -1494,6 +1499,7 @@ class CORE_EXPORT QgsLinePatternFillSymbolLayer: public QgsImageFillSymbolLayer
 
     void setOutputUnit( QgsUnitTypes::RenderUnit unit ) override;
     QgsUnitTypes::RenderUnit outputUnit() const override;
+    bool usesMapUnits() const override;
     void setMapUnitScale( const QgsMapUnitScale &scale ) override;
     QgsMapUnitScale mapUnitScale() const override;
     bool setSubSymbol( QgsSymbol *symbol SIP_TRANSFER ) override;
@@ -1756,6 +1762,7 @@ class CORE_EXPORT QgsPointPatternFillSymbolLayer: public QgsImageFillSymbolLayer
 
     void setOutputUnit( QgsUnitTypes::RenderUnit unit ) override;
     QgsUnitTypes::RenderUnit outputUnit() const override;
+    bool usesMapUnits() const override;
 
     void setMapUnitScale( const QgsMapUnitScale &scale ) override;
     QgsMapUnitScale mapUnitScale() const override;
@@ -1848,6 +1855,7 @@ class CORE_EXPORT QgsRandomMarkerFillSymbolLayer : public QgsFillSymbolLayer
 
     void setOutputUnit( QgsUnitTypes::RenderUnit unit ) override;
     QgsUnitTypes::RenderUnit outputUnit() const override;
+    bool usesMapUnits() const override;
 
     void setMapUnitScale( const QgsMapUnitScale &scale ) override;
     QgsMapUnitScale mapUnitScale() const override;
@@ -2036,6 +2044,7 @@ class CORE_EXPORT QgsCentroidFillSymbolLayer : public QgsFillSymbolLayer
 
     void setOutputUnit( QgsUnitTypes::RenderUnit unit ) override;
     QgsUnitTypes::RenderUnit outputUnit() const override;
+    bool usesMapUnits() const override;
 
     void setMapUnitScale( const QgsMapUnitScale &scale ) override;
     QgsMapUnitScale mapUnitScale() const override;

--- a/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
+++ b/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
@@ -107,6 +107,17 @@ void QgsGeometryGeneratorSymbolLayer::stopFeatureRender( const QgsFeature &, Qgs
   mRenderingFeature = false;
 }
 
+bool QgsGeometryGeneratorSymbolLayer::usesMapUnits() const
+{
+  if ( mFillSymbol )
+    return mFillSymbol->usesMapUnits();
+  else if ( mLineSymbol )
+    return mLineSymbol->usesMapUnits();
+  else if ( mMarkerSymbol )
+    return mMarkerSymbol->usesMapUnits();
+  return false;
+}
+
 QgsSymbolLayer *QgsGeometryGeneratorSymbolLayer::clone() const
 {
   QgsGeometryGeneratorSymbolLayer *clone = new QgsGeometryGeneratorSymbolLayer( mExpression->expression() );

--- a/src/core/symbology/qgsgeometrygeneratorsymbollayer.h
+++ b/src/core/symbology/qgsgeometrygeneratorsymbollayer.h
@@ -52,6 +52,7 @@ class CORE_EXPORT QgsGeometryGeneratorSymbolLayer : public QgsSymbolLayer
     void stopRender( QgsSymbolRenderContext &context ) override;
     void startFeatureRender( const QgsFeature &feature, QgsRenderContext &context ) override;
     void stopFeatureRender( const QgsFeature &feature, QgsRenderContext &context ) override;
+    bool usesMapUnits() const override;
 
     QgsSymbolLayer *clone() const override SIP_FACTORY;
 

--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -60,6 +60,12 @@ QgsUnitTypes::RenderUnit  QgsSimpleLineSymbolLayer::outputUnit() const
   return unit;
 }
 
+bool QgsSimpleLineSymbolLayer::usesMapUnits() const
+{
+  return mWidthUnit == QgsUnitTypes::RenderMapUnits || mWidthUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits;
+}
+
 void QgsSimpleLineSymbolLayer::setMapUnitScale( const QgsMapUnitScale &scale )
 {
   QgsLineSymbolLayer::setMapUnitScale( scale );
@@ -2391,6 +2397,15 @@ void QgsMarkerLineSymbolLayer::setOutputUnit( QgsUnitTypes::RenderUnit unit )
   setOffsetAlongLineUnit( unit );
 }
 
+bool QgsMarkerLineSymbolLayer::usesMapUnits() const
+{
+  return  intervalUnit() == QgsUnitTypes::RenderMapUnits || intervalUnit() == QgsUnitTypes::RenderMetersInMapUnits
+          || offsetAlongLineUnit() == QgsUnitTypes::RenderMapUnits || offsetAlongLineUnit() == QgsUnitTypes::RenderMetersInMapUnits
+          || averageAngleUnit() == QgsUnitTypes::RenderMapUnits || averageAngleUnit() == QgsUnitTypes::RenderMetersInMapUnits
+          || mWidthUnit == QgsUnitTypes::RenderMapUnits || mWidthUnit == QgsUnitTypes::RenderMetersInMapUnits
+          || mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits
+          || ( mMarker && mMarker->usesMapUnits() );
+}
 
 QSet<QString> QgsMarkerLineSymbolLayer::usedAttributes( const QgsRenderContext &context ) const
 {
@@ -2583,6 +2598,17 @@ void QgsHashedLineSymbolLayer::setDataDefinedProperty( QgsSymbolLayer::Property 
     mHashSymbol->setDataDefinedWidth( property );
   }
   QgsLineSymbolLayer::setDataDefinedProperty( key, property );
+}
+
+bool QgsHashedLineSymbolLayer::usesMapUnits() const
+{
+  return mHashLengthUnit == QgsUnitTypes::RenderMapUnits || mHashLengthUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || intervalUnit() == QgsUnitTypes::RenderMapUnits || intervalUnit() == QgsUnitTypes::RenderMetersInMapUnits
+         || offsetAlongLineUnit() == QgsUnitTypes::RenderMapUnits || offsetAlongLineUnit() == QgsUnitTypes::RenderMetersInMapUnits
+         || averageAngleUnit() == QgsUnitTypes::RenderMapUnits || averageAngleUnit() == QgsUnitTypes::RenderMetersInMapUnits
+         || mWidthUnit == QgsUnitTypes::RenderMapUnits || mWidthUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || ( mHashSymbol && mHashSymbol->usesMapUnits() );
 }
 
 void QgsHashedLineSymbolLayer::setSymbolLineAngle( double angle )

--- a/src/core/symbology/qgslinesymbollayer.h
+++ b/src/core/symbology/qgslinesymbollayer.h
@@ -75,6 +75,7 @@ class CORE_EXPORT QgsSimpleLineSymbolLayer : public QgsLineSymbolLayer
     QString ogrFeatureStyle( double mmScaleFactor, double mapUnitScaleFactor ) const override;
     void setOutputUnit( QgsUnitTypes::RenderUnit unit ) override;
     QgsUnitTypes::RenderUnit outputUnit() const override;
+    bool usesMapUnits() const override;
     void setMapUnitScale( const QgsMapUnitScale &scale ) override;
     QgsMapUnitScale mapUnitScale() const override;
     double estimateMaxBleed( const QgsRenderContext &context ) const override;
@@ -734,6 +735,7 @@ class CORE_EXPORT QgsMarkerLineSymbolLayer : public QgsTemplatedLineSymbolLayerB
     double width( const QgsRenderContext &context ) const override;
     double estimateMaxBleed( const QgsRenderContext &context ) const override;
     void setOutputUnit( QgsUnitTypes::RenderUnit unit ) override;
+    bool usesMapUnits() const override;
     QSet<QString> usedAttributes( const QgsRenderContext &context ) const override;
     bool hasDataDefinedProperties() const override;
     void setDataDefinedProperty( QgsSymbolLayer::Property key, const QgsProperty &property ) override;
@@ -819,6 +821,7 @@ class CORE_EXPORT QgsHashedLineSymbolLayer : public QgsTemplatedLineSymbolLayerB
     QSet<QString> usedAttributes( const QgsRenderContext &context ) const override;
     bool hasDataDefinedProperties() const override;
     void setDataDefinedProperty( QgsSymbolLayer::Property key, const QgsProperty &property ) override;
+    bool usesMapUnits() const override;
 
     /**
      * Returns the angle to use when drawing the hashed lines sections, in degrees clockwise.

--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -1491,6 +1491,13 @@ QgsMapUnitScale QgsSimpleMarkerSymbolLayer::mapUnitScale() const
   return QgsMapUnitScale();
 }
 
+bool QgsSimpleMarkerSymbolLayer::usesMapUnits() const
+{
+  return mSizeUnit == QgsUnitTypes::RenderMapUnits || mSizeUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mStrokeWidthUnit == QgsUnitTypes::RenderMapUnits || mStrokeWidthUnit == QgsUnitTypes::RenderMetersInMapUnits;
+}
+
 QRectF QgsSimpleMarkerSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext &context )
 {
   QRectF symbolBounds = QgsSimpleMarkerSymbolLayerBase::bounds( point, context );
@@ -1719,6 +1726,13 @@ void QgsFilledMarkerSymbolLayer::setColor( const QColor &c )
 QColor QgsFilledMarkerSymbolLayer::color() const
 {
   return mFill ?  mFill->color() : mColor;
+}
+
+bool QgsFilledMarkerSymbolLayer::usesMapUnits() const
+{
+  return mSizeUnit == QgsUnitTypes::RenderMapUnits || mSizeUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || ( mFill && mFill->usesMapUnits() );
 }
 
 void QgsFilledMarkerSymbolLayer::draw( QgsSymbolRenderContext &context, QgsSimpleMarkerSymbolLayerBase::Shape shape, const QPolygonF &polygon, const QPainterPath &path )
@@ -2234,6 +2248,13 @@ QgsStringMap QgsSvgMarkerSymbolLayer::properties() const
   map[QStringLiteral( "horizontal_anchor_point" )] = QString::number( mHorizontalAnchorPoint );
   map[QStringLiteral( "vertical_anchor_point" )] = QString::number( mVerticalAnchorPoint );
   return map;
+}
+
+bool QgsSvgMarkerSymbolLayer::usesMapUnits() const
+{
+  return mSizeUnit == QgsUnitTypes::RenderMapUnits || mSizeUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mStrokeWidthUnit == QgsUnitTypes::RenderMapUnits || mStrokeWidthUnit == QgsUnitTypes::RenderMetersInMapUnits;
 }
 
 QgsSvgMarkerSymbolLayer *QgsSvgMarkerSymbolLayer::clone() const
@@ -2915,6 +2936,12 @@ QgsRasterMarkerSymbolLayer *QgsRasterMarkerSymbolLayer::clone() const
   return m;
 }
 
+bool QgsRasterMarkerSymbolLayer::usesMapUnits() const
+{
+  return mSizeUnit == QgsUnitTypes::RenderMapUnits || mSizeUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits;
+}
+
 void QgsRasterMarkerSymbolLayer::setMapUnitScale( const QgsMapUnitScale &scale )
 {
   QgsMarkerSymbolLayer::setMapUnitScale( scale );
@@ -3373,6 +3400,13 @@ void QgsFontMarkerSymbolLayer::writeSldMarker( QDomDocument &doc, QDomElement &e
   // <Displacement>
   QPointF offset = QgsSymbolLayerUtils::rescaleUom( mOffset, mOffsetUnit, props );
   QgsSymbolLayerUtils::createDisplacementElement( doc, graphicElem, offset );
+}
+
+bool QgsFontMarkerSymbolLayer::usesMapUnits() const
+{
+  return mSizeUnit == QgsUnitTypes::RenderMapUnits || mSizeUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mStrokeWidthUnit == QgsUnitTypes::RenderMapUnits || mStrokeWidthUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits;
 }
 
 QRectF QgsFontMarkerSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext &context )

--- a/src/core/symbology/qgsmarkersymbollayer.h
+++ b/src/core/symbology/qgsmarkersymbollayer.h
@@ -247,6 +247,7 @@ class CORE_EXPORT QgsSimpleMarkerSymbolLayer : public QgsSimpleMarkerSymbolLayer
     QgsUnitTypes::RenderUnit outputUnit() const override;
     void setMapUnitScale( const QgsMapUnitScale &scale ) override;
     QgsMapUnitScale mapUnitScale() const override;
+    bool usesMapUnits() const override;
     QRectF bounds( QPointF point, QgsSymbolRenderContext &context ) override;
     QColor fillColor() const override { return mColor; }
     void setFillColor( const QColor &color ) override { mColor = color; }
@@ -462,6 +463,7 @@ class CORE_EXPORT QgsFilledMarkerSymbolLayer : public QgsSimpleMarkerSymbolLayer
     bool hasDataDefinedProperties() const override;
     void setColor( const QColor &c ) override;
     QColor color() const override;
+    bool usesMapUnits() const override;
 
   private:
 #ifdef SIP_RUN
@@ -515,6 +517,7 @@ class CORE_EXPORT QgsSvgMarkerSymbolLayer : public QgsMarkerSymbolLayer
     void renderPoint( QPointF point, QgsSymbolRenderContext &context ) override;
 
     QgsStringMap properties() const override;
+    bool usesMapUnits() const override;
 
     QgsSvgMarkerSymbolLayer *clone() const override SIP_FACTORY;
 
@@ -686,6 +689,7 @@ class CORE_EXPORT QgsRasterMarkerSymbolLayer : public QgsMarkerSymbolLayer
     QgsStringMap properties() const override;
 
     QgsRasterMarkerSymbolLayer *clone() const override SIP_FACTORY;
+    bool usesMapUnits() const override;
 
     /**
      * Calculates the marker aspect ratio between width and height.
@@ -841,6 +845,7 @@ class CORE_EXPORT QgsFontMarkerSymbolLayer : public QgsMarkerSymbolLayer
     QgsFontMarkerSymbolLayer *clone() const override SIP_FACTORY;
 
     void writeSldMarker( QDomDocument &doc, QDomElement &element, const QgsStringMap &props ) const override;
+    bool usesMapUnits() const override;
 
     // new methods
 

--- a/src/core/symbology/qgsmasksymbollayer.cpp
+++ b/src/core/symbology/qgsmasksymbollayer.cpp
@@ -120,6 +120,12 @@ QRectF QgsMaskMarkerSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext &
   return mSymbol->bounds( point, context.renderContext() );
 }
 
+bool QgsMaskMarkerSymbolLayer::usesMapUnits() const
+{
+  return mSizeUnit == QgsUnitTypes::RenderMapUnits || mSizeUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || ( mSymbol && mSymbol->usesMapUnits() );
+}
+
 void QgsMaskMarkerSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContext &context )
 {
   if ( !context.renderContext().painter() )

--- a/src/core/symbology/qgsmasksymbollayer.h
+++ b/src/core/symbology/qgsmasksymbollayer.h
@@ -58,6 +58,7 @@ class CORE_EXPORT QgsMaskMarkerSymbolLayer : public QgsMarkerSymbolLayer
     void stopRender( QgsSymbolRenderContext &context ) override;
     void renderPoint( QPointF point, QgsSymbolRenderContext &context ) override;
     QRectF bounds( QPointF point, QgsSymbolRenderContext &context ) override;
+    bool usesMapUnits() const override;
 
     virtual void drawPreviewIcon( QgsSymbolRenderContext &context, QSize size ) override;
 

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -283,6 +283,23 @@ QgsUnitTypes::RenderUnit QgsSymbol::outputUnit() const
   return unit;
 }
 
+bool QgsSymbol::usesMapUnits() const
+{
+  if ( mLayers.empty() )
+  {
+    return false;
+  }
+
+  for ( const QgsSymbolLayer *layer : mLayers )
+  {
+    if ( layer->usesMapUnits() )
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
 QgsMapUnitScale QgsSymbol::mapUnitScale() const
 {
   if ( mLayers.empty() )

--- a/src/core/symbology/qgssymbol.h
+++ b/src/core/symbology/qgssymbol.h
@@ -436,6 +436,13 @@ class CORE_EXPORT QgsSymbol
     QgsUnitTypes::RenderUnit outputUnit() const;
 
     /**
+     * Returns TRUE if the symbol has any components which use map unit based sizes.
+     *
+     * \since QGIS 3.18
+     */
+    bool usesMapUnits() const;
+
+    /**
      * Sets the units to use for sizes and widths within the symbol. Individual
      * symbol definitions will interpret this in different ways, e.g., a marker symbol
      * may use it to specify the units for the marker size, while a line symbol

--- a/src/core/symbology/qgssymbollayer.cpp
+++ b/src/core/symbology/qgssymbollayer.cpp
@@ -234,6 +234,11 @@ bool QgsSymbolLayer::isCompatibleWithSymbol( QgsSymbol *symbol ) const
   return symbol->type() == mType;
 }
 
+bool QgsSymbolLayer::usesMapUnits() const
+{
+  return false;
+}
+
 void QgsSymbolLayer::setRenderingPass( int renderingPass )
 {
   mRenderingPass = renderingPass;

--- a/src/core/symbology/qgssymbollayer.h
+++ b/src/core/symbology/qgssymbollayer.h
@@ -392,6 +392,13 @@ class CORE_EXPORT QgsSymbolLayer
      */
     virtual QgsUnitTypes::RenderUnit outputUnit() const { return QgsUnitTypes::RenderUnknownUnit; }
 
+    /**
+     * Returns TRUE if the symbol layer has any components which use map unit based sizes.
+     *
+     * \since QGIS 3.18
+     */
+    virtual bool usesMapUnits() const;
+
     virtual void setMapUnitScale( const QgsMapUnitScale &scale ) { Q_UNUSED( scale ) }
     virtual QgsMapUnitScale mapUnitScale() const { return QgsMapUnitScale(); }
 

--- a/src/core/symbology/qgsvectorfieldsymbollayer.cpp
+++ b/src/core/symbology/qgsvectorfieldsymbollayer.cpp
@@ -246,6 +246,13 @@ QgsStringMap QgsVectorFieldSymbolLayer::properties() const
   return properties;
 }
 
+bool QgsVectorFieldSymbolLayer::usesMapUnits() const
+{
+  return mDistanceUnit == QgsUnitTypes::RenderMapUnits || mDistanceUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits
+         || mSizeUnit == QgsUnitTypes::RenderMapUnits || mSizeUnit == QgsUnitTypes::RenderMetersInMapUnits;
+}
+
 void QgsVectorFieldSymbolLayer::toSld( QDomDocument &doc, QDomElement &element, const QgsStringMap &props ) const
 {
   element.appendChild( doc.createComment( QStringLiteral( "VectorField not implemented yet..." ) ) );

--- a/src/core/symbology/qgsvectorfieldsymbollayer.h
+++ b/src/core/symbology/qgsvectorfieldsymbollayer.h
@@ -67,6 +67,7 @@ class CORE_EXPORT QgsVectorFieldSymbolLayer: public QgsMarkerSymbolLayer
 
     QgsVectorFieldSymbolLayer *clone() const override SIP_FACTORY;
     QgsStringMap properties() const override;
+    bool usesMapUnits() const override;
 
     void toSld( QDomDocument &doc, QDomElement &element, const QgsStringMap &props ) const override;
 


### PR DESCRIPTION
Add proper method to determine whether a symbol uses map unit sizes and use this to determine whether a legend item needs updating as a result of a map change

This results in a HUGE speed up when loading large projects where symbols don't use Millimeter based sizes, as the previous code assumed only that any non-millimeter size was a map unit based size.
