### PR TITLE
only display actions for single features in action menu

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8301,7 +8301,7 @@ void QgisApp::refreshFeatureActions()
   }
 
   //add actions registered in QgsMapLayerActionRegistry
-  QList<QgsMapLayerAction *> registeredActions = QgsGui::mapLayerActionRegistry()->mapLayerActions( vlayer );
+  QList<QgsMapLayerAction *> registeredActions = QgsGui::mapLayerActionRegistry()->mapLayerActions( vlayer, QgsMapLayerAction::SingleFeature );
   if ( !actions.isEmpty() && !registeredActions.empty() )
   {
     //add a separator between user defined and standard actions


### PR DESCRIPTION
MultipleFeatures actions should not be listed under the action menu (
![image](https://user-images.githubusercontent.com/127259/101592961-6fc3c500-39ef-11eb-933c-8435ab5dd9a3.png))
 as it only select a single feature (this could be a future improvement to allow selecting several features)

It could be an idea to show for the layer but the layer tree context menu sounds more appropriate (and the current action menu implementation only triggers actions for features).

Hence this PR, to only show for single features.