### PR TITLE
[FEATURE][map overview] Support zooming in/out by scrolling mouse wheel over map overview panel

### DIFF
--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -963,6 +963,16 @@ Set a list of resolutions (map units per pixel) to which to "snap to" when zoomi
 .. versionadded:: 3.12
 %End
 
+    double zoomInFactor() const;
+%Docstring
+Returns the zoom in factor.
+%End
+
+    double zoomOutFactor() const;
+%Docstring
+Returns the zoom in factor.
+%End
+
     const QList<double> &zoomResolutions() const;
 %Docstring
 

--- a/python/gui/auto_generated/qgsmapoverviewcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapoverviewcanvas.sip.in
@@ -108,6 +108,12 @@ Overridden mouse press event
 Overridden mouse release event
 %End
 
+    virtual void wheelEvent( QWheelEvent *e );
+
+%Docstring
+Overridden mouse release event
+%End
+
     void updatePanningWidget( QPoint pos );
 %Docstring
 called when panning to reflect mouse movement

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -873,6 +873,16 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     void setZoomResolutions( const QList<double> &resolutions ) { mZoomResolutions = resolutions; }
 
     /**
+     * Returns the zoom in factor.
+     */
+    double zoomInFactor() const;
+
+    /**
+     * Returns the zoom in factor.
+     */
+    double zoomOutFactor() const;
+
+    /**
      * \returns List of resolutions to which to "snap to" when zooming the map
      * \see setZoomResolutions()
      * \since QGIS 3.12
@@ -1329,8 +1339,6 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     bool panOperationInProgress();
 
     int nextZoomLevel( const QList<double> &resolutions, bool zoomIn = true ) const;
-    double zoomInFactor() const;
-    double zoomOutFactor() const;
 
     /**
      * Make sure to remove any rendered images of temporal-enabled layers from cache (does nothing if cache is not enabled)

--- a/src/gui/qgsmapoverviewcanvas.cpp
+++ b/src/gui/qgsmapoverviewcanvas.cpp
@@ -145,6 +145,28 @@ void QgsMapOverviewCanvas::mouseReleaseEvent( QMouseEvent *e )
 }
 
 
+void QgsMapOverviewCanvas::wheelEvent( QWheelEvent *e )
+{
+  double zoomFactor = e->angleDelta().y() > 0 ? 1. / mMapCanvas->zoomInFactor() : mMapCanvas->zoomOutFactor();
+
+  // "Normal" mouse have an angle delta of 120, precision mouses provide data faster, in smaller steps
+  zoomFactor = 1.0 + ( zoomFactor - 1.0 ) / 120.0 * std::fabs( e->angleDelta().y() );
+
+  if ( e->modifiers() & Qt::ControlModifier )
+  {
+    //holding ctrl while wheel zooming results in a finer zoom
+    zoomFactor = 1.0 + ( zoomFactor - 1.0 ) / 20.0;
+  }
+
+  double signedWheelFactor = e->angleDelta().y() > 0 ? 1 / zoomFactor : zoomFactor;
+
+  const QgsMapToPixel &cXf = mSettings.mapToPixel();
+  QgsPointXY center = cXf.toMapCoordinates( e->pos() );
+
+  updatePanningWidget( e->pos() );
+  mMapCanvas->zoomByFactor( signedWheelFactor, &center );
+}
+
 void QgsMapOverviewCanvas::mouseMoveEvent( QMouseEvent *e )
 {
   // move with panning widget if tracking cursor

--- a/src/gui/qgsmapoverviewcanvas.h
+++ b/src/gui/qgsmapoverviewcanvas.h
@@ -95,6 +95,9 @@ class GUI_EXPORT QgsMapOverviewCanvas : public QWidget
     //! Overridden mouse release event
     void mouseReleaseEvent( QMouseEvent *e ) override;
 
+    //! Overridden mouse release event
+    void wheelEvent( QWheelEvent *e ) override;
+
     //! called when panning to reflect mouse movement
     void updatePanningWidget( QPoint pos );
 


### PR DESCRIPTION
## Description

I often find myself clicking on an area of the overview panel only to then move the mouse over the canvas to zoom in / out via the mouse wheel. There's no reason not to support zooming in / out via mouse wheel over the overview panel, so here we are:
![Peek 2020-12-10 14-58](https://user-images.githubusercontent.com/1728657/101738232-683c1300-3af8-11eb-8135-300b98259477.gif)

