### PR TITLE
fix 3D mesh terrain not displayed when opening project

### DIFF
--- a/src/3d/mesh/qgsmeshterraingenerator.cpp
+++ b/src/3d/mesh/qgsmeshterraingenerator.cpp
@@ -90,6 +90,7 @@ void QgsMeshTerrainGenerator::rootChunkHeightRange( float &hMin, float &hMax ) c
 void QgsMeshTerrainGenerator::resolveReferences( const QgsProject &project )
 {
   mLayer = QgsMapLayerRef( project.mapLayer( mLayer.layerId ) );
+  updateTriangularMesh();
 }
 
 void QgsMeshTerrainGenerator::setLayer( QgsMeshLayer *layer )


### PR DESCRIPTION
3D mesh terrain is not generated when opening the project.
It is a regression that, I think, it was introduced when the terrain mesh generator has been made thread safe, just before 3.16.0 release.
This PR fixes this issue...