### PR TITLE
fix the default terrain elevation offset min & max

### DIFF
--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -305,10 +305,10 @@
                   <item row="5" column="1" colspan="2">
                    <widget class="QgsDoubleSpinBox" name="terrainElevationOffsetSpinBox">
                     <property name="minimum">
-                     <double>-1000.000000000000000</double>
+                     <double>-1000000.000000000000000</double>
                     </property>
                     <property name="maximum">
-                     <double>1000.000000000000000</double>
+                     <double>1000000.000000000000000</double>
                     </property>
                    </widget>
                   </item>


### PR DESCRIPTION
## Description

Change the default minimum and maximum of the terrain elevation spinbox since the range [-1000, 1000] was too small for some datasets,