### PR TITLE
[Bugfix] Access control override filter expression instead of combine

### DIFF
--- a/src/server/qgsaccesscontrol.cpp
+++ b/src/server/qgsaccesscontrol.cpp
@@ -75,7 +75,7 @@ void QgsAccessControl::filterFeatures( const QgsVectorLayer *layer, QgsFeatureRe
 
   if ( !expression.isEmpty() )
   {
-    featureRequest.setFilterExpression( expression );
+    featureRequest.combineFilterExpression( expression );
   }
 }
 

--- a/tests/src/python/test_qgsserver_accesscontrol.py
+++ b/tests/src/python/test_qgsserver_accesscontrol.py
@@ -54,7 +54,12 @@ class RestrictedAccessControl(QgsAccessControlFilter):
         if not self._active:
             return super(RestrictedAccessControl, self).layerFilterExpression(layer)
 
-        return "$id = 1" if layer.name() == "Hello" else None
+        if layer.name() == "Hello":
+            return "$id = 1"
+        elif layer.name() == "Hello_Filter":
+            return "pkuid = 6 or pkuid = 7"
+        else:
+            return None
 
     def layerFilterSubsetString(self, layer):
         """ Return an additional subset string (typically SQL) filter """

--- a/tests/src/python/test_qgsserver_accesscontrol_wfs.py
+++ b/tests/src/python/test_qgsserver_accesscontrol_wfs.py
@@ -446,6 +446,113 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
             str(response).find("<qgs:pk>7</qgs:pk>") != -1,
             "Unexpected result in GetFeature\n%s" % response)
 
+    def test_wfs_getfeature_featureid_hello(self):
+        query_string = "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WFS",
+            "VERSION": "1.0.0",
+            "REQUEST": "GetFeature",
+            "TYPENAME": "Hello",
+            "FEATUREID": "Hello.1"
+        }.items())])
+
+        response, headers = self._get_fullaccess(query_string)
+        self.assertTrue(
+            str(response).find("<qgs:pk>1</qgs:pk>") != -1,
+            "No result in GetFeature\n%s" % response)
+        self.assertTrue(
+            str(response).find("<qgs:color>red</qgs:color>") != -1,  # spellok
+            "No color in result of GetFeature\n%s" % response)
+
+        response, headers = self._get_restricted(query_string)
+        self.assertTrue(
+            str(response).find("<qgs:pk>1</qgs:pk>") != -1,
+            "No result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:color>red</qgs:color>") != -1,  # spellok
+            "Unexpected color in result of GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:color>NULL</qgs:color>") != -1,  # spellok
+            "Unexpected color NULL in result of GetFeature\n%s" % response)
+
+    def test_wfs_getfeature_featureid_hello(self):
+        query_string = "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WFS",
+            "VERSION": "1.0.0",
+            "REQUEST": "GetFeature",
+            "TYPENAME": "Hello",
+            "FEATUREID": "Hello.2"
+        }.items())])
+
+        response, headers = self._get_fullaccess(query_string)
+        self.assertTrue(
+            str(response).find("<qgs:pk>2</qgs:pk>") != -1,
+            "No result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>1</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+
+        response, headers = self._get_restricted(query_string)
+        self.assertFalse(
+            str(response).find("<qgs:pk>2</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>1</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+
+    def test_wfs_getfeature_featureid_hello_filter(self):
+        query_string = "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WFS",
+            "VERSION": "1.0.0",
+            "REQUEST": "GetFeature",
+            "TYPENAME": "Hello_Filter",
+            "FEATUREID": "Hello_Filter.1"
+        }.items())])
+
+        response, headers = self._get_fullaccess(query_string)
+        self.assertTrue(
+            str(response).find("<qgs:pk>1</qgs:pk>") != -1,
+            "No result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>6</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+
+        response, headers = self._get_restricted(query_string)
+        self.assertFalse(
+            str(response).find("<qgs:pk>1</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>6</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+
+    def test_wfs_getfeature_featureid_hello_filter2(self):
+        query_string = "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WFS",
+            "VERSION": "1.0.0",
+            "REQUEST": "GetFeature",
+            "TYPENAME": "Hello_Filter",
+            "FEATUREID": "Hello_Filter.6"
+        }.items())])
+
+        response, headers = self._get_fullaccess(query_string)
+        self.assertTrue(
+            str(response).find("<qgs:pk>6</qgs:pk>") != -1,
+            "No result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>7</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+
+        response, headers = self._get_restricted(query_string)
+        self.assertTrue(
+            str(response).find("<qgs:pk>6</qgs:pk>") != -1,
+            "No result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>7</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/src/python/test_qgsserver_accesscontrol_wfs.py
+++ b/tests/src/python/test_qgsserver_accesscontrol_wfs.py
@@ -127,10 +127,66 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         self.assertTrue(
             str(response).find("<qgs:pk>2</qgs:pk>") != -1,
             "No result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>1</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
 
         response, headers = self._post_restricted(data)
         self.assertFalse(
             str(response).find("<qgs:pk>2</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>1</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+
+    def test_wfs_getfeature_filter(self):
+        data = """<?xml version="1.0" encoding="UTF-8"?>
+            <wfs:GetFeature {xml_ns}>
+            <wfs:Query typeName="Hello_Filter" srsName="EPSG:3857" xmlns:feature="http://www.qgis.org/gml">
+            <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"><ogc:PropertyIsEqualTo>
+            <ogc:PropertyName>pkuid</ogc:PropertyName>
+            <ogc:Literal>1</ogc:Literal>
+            </ogc:PropertyIsEqualTo></ogc:Filter></wfs:Query></wfs:GetFeature>""".format(xml_ns=XML_NS)
+
+        response, headers = self._post_fullaccess(data)
+        self.assertTrue(
+            str(response).find("<qgs:pk>1</qgs:pk>") != -1,
+            "No result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>6</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+
+        response, headers = self._post_restricted(data)
+        self.assertFalse(
+            str(response).find("<qgs:pk>1</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>6</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+
+    def test_wfs_getfeature_filter2(self):
+        data = """<?xml version="1.0" encoding="UTF-8"?>
+            <wfs:GetFeature {xml_ns}>
+            <wfs:Query typeName="Hello_Filter" srsName="EPSG:3857" xmlns:feature="http://www.qgis.org/gml">
+            <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"><ogc:PropertyIsEqualTo>
+            <ogc:PropertyName>pkuid</ogc:PropertyName>
+            <ogc:Literal>6</ogc:Literal>
+            </ogc:PropertyIsEqualTo></ogc:Filter></wfs:Query></wfs:GetFeature>""".format(xml_ns=XML_NS)
+
+        response, headers = self._post_fullaccess(data)
+        self.assertTrue(
+            str(response).find("<qgs:pk>6</qgs:pk>") != -1,
+            "No result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>7</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+
+        response, headers = self._post_restricted(data)
+        self.assertTrue(
+            str(response).find("<qgs:pk>6</qgs:pk>") != -1,
+            "No result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>7</qgs:pk>") != -1,
             "Unexpected result in GetFeature\n%s" % response)
 
     def test_wfs_getfeature_country(self):
@@ -282,6 +338,113 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         self.assertFalse(
             str(response).find("<qgs:pk>") != -1,
             "Project based layer subsetString not respected in GetFeature with restricted access\n%s" % response)
+
+    def test_wfs_getfeature_exp_filter_hello(self):
+        query_string = "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WFS",
+            "VERSION": "1.0.0",
+            "REQUEST": "GetFeature",
+            "TYPENAME": "Hello",
+            "EXP_FILTER": "pkuid = 1"
+        }.items())])
+
+        response, headers = self._get_fullaccess(query_string)
+        self.assertTrue(
+            str(response).find("<qgs:pk>1</qgs:pk>") != -1,
+            "No result in GetFeature\n%s" % response)
+        self.assertTrue(
+            str(response).find("<qgs:color>red</qgs:color>") != -1,  # spellok
+            "No color in result of GetFeature\n%s" % response)
+
+        response, headers = self._get_restricted(query_string)
+        self.assertTrue(
+            str(response).find("<qgs:pk>1</qgs:pk>") != -1,
+            "No result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:color>red</qgs:color>") != -1,  # spellok
+            "Unexpected color in result of GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:color>NULL</qgs:color>") != -1,  # spellok
+            "Unexpected color NULL in result of GetFeature\n%s" % response)
+
+    def test_wfs_getfeature_exp_filter_hello2(self):
+        query_string = "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WFS",
+            "VERSION": "1.0.0",
+            "REQUEST": "GetFeature",
+            "TYPENAME": "Hello",
+            "EXP_FILTER": "pkuid = 2"
+        }.items())])
+
+        response, headers = self._get_fullaccess(query_string)
+        self.assertTrue(
+            str(response).find("<qgs:pk>2</qgs:pk>") != -1,
+            "No result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>1</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+
+        response, headers = self._get_restricted(query_string)
+        self.assertFalse(
+            str(response).find("<qgs:pk>2</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>1</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+
+    def test_wfs_getfeature_exp_filter_hello_filter(self):
+        query_string = "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WFS",
+            "VERSION": "1.0.0",
+            "REQUEST": "GetFeature",
+            "TYPENAME": "Hello_Filter",
+            "EXP_FILTER": "pkuid = 1"
+        }.items())])
+
+        response, headers = self._get_fullaccess(query_string)
+        self.assertTrue(
+            str(response).find("<qgs:pk>1</qgs:pk>") != -1,
+            "No result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>6</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+
+        response, headers = self._get_restricted(query_string)
+        self.assertFalse(
+            str(response).find("<qgs:pk>1</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>6</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+
+    def test_wfs_getfeature_exp_filter_hello_filter2(self):
+        query_string = "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WFS",
+            "VERSION": "1.0.0",
+            "REQUEST": "GetFeature",
+            "TYPENAME": "Hello_Filter",
+            "EXP_FILTER": "pkuid = 6"
+        }.items())])
+
+        response, headers = self._get_fullaccess(query_string)
+        self.assertTrue(
+            str(response).find("<qgs:pk>6</qgs:pk>") != -1,
+            "No result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>7</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
+
+        response, headers = self._get_restricted(query_string)
+        self.assertTrue(
+            str(response).find("<qgs:pk>6</qgs:pk>") != -1,
+            "No result in GetFeature\n%s" % response)
+        self.assertFalse(
+            str(response).find("<qgs:pk>7</qgs:pk>") != -1,
+            "Unexpected result in GetFeature\n%s" % response)
 
 
 if __name__ == "__main__":

--- a/tests/testdata/qgis_server_accesscontrol/project_grp.qgs
+++ b/tests/testdata/qgis_server_accesscontrol/project_grp.qgs
@@ -1,12 +1,13 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis projectname="QGIS Server Hello World" version="3.3.0-Master">
+<qgis projectname="QGIS Server Hello World" version="3.10.10-A Coruña">
   <homePath path=""/>
   <title>QGIS Server Hello World</title>
-  <autotransaction active="48"/>
-  <evaluateDefaultValues active="48"/>
-  <trust active="48"/>
+  <autotransaction active="0"/>
+  <evaluateDefaultValues active="0"/>
+  <trust active="0"/>
   <projectCrs>
     <spatialrefsys>
+      <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
       <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
       <srsid>3857</srsid>
       <srid>3857</srid>
@@ -19,40 +20,43 @@
   </projectCrs>
   <layer-tree-group>
     <customproperties/>
-    <layer-tree-layer id="points20150803121107046" name="db_point" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;points&quot; (geom) sql=" providerKey="spatialite" checked="Qt::Checked" expanded="1">
+    <layer-tree-layer name="db_point" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;points&quot; (geom) sql=" id="points20150803121107046" legend_exp="">
       <customproperties/>
     </layer-tree-layer>
-    <layer-tree-group name="Hello_grp" checked="Qt::Checked" expanded="1">
+    <layer-tree-group name="Hello_grp" expanded="1" checked="Qt::Checked">
       <customproperties/>
-      <layer-tree-layer id="hello20131022151106574" name="Hello" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" providerKey="spatialite" checked="Qt::Checked" expanded="1">
+      <layer-tree-layer name="Hello" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" id="hello20131022151106574" legend_exp="">
         <customproperties/>
       </layer-tree-layer>
     </layer-tree-group>
-    <layer-tree-layer id="Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c" name="Hello_OnOff" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" providerKey="spatialite" checked="Qt::Checked" expanded="1">
+    <layer-tree-layer name="Hello_OnOff" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" id="Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c" legend_exp="">
       <customproperties/>
     </layer-tree-layer>
-    <layer-tree-layer id="Hello_copy20150804164427541" name="Hello_SubsetString" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" providerKey="spatialite" checked="Qt::Checked" expanded="1">
+    <layer-tree-layer name="Hello_Filter" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" id="Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9" legend_exp="">
       <customproperties/>
     </layer-tree-layer>
-    <layer-tree-layer id="Hello_SubsetString_copy20160222085231770" name="Hello_Project_SubsetString" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=&quot;pkuid&quot; in ( 7, 8 )" providerKey="spatialite" checked="Qt::Checked" expanded="1">
+    <layer-tree-layer name="Hello_SubsetString" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" id="Hello_copy20150804164427541" legend_exp="">
       <customproperties/>
     </layer-tree-layer>
-    <layer-tree-layer id="Hello_Project_SubsetString_copy20160223113949592" name="Hello_Filter_SubsetString" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" providerKey="spatialite" checked="Qt::Checked" expanded="1">
+    <layer-tree-layer name="Hello_Project_SubsetString" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=&quot;pkuid&quot; in ( 7, 8 )" id="Hello_SubsetString_copy20160222085231770" legend_exp="">
       <customproperties/>
     </layer-tree-layer>
-    <layer-tree-layer id="dem20150730091219559" name="dem" source="./dem.tif" providerKey="gdal" checked="Qt::Checked" expanded="0">
+    <layer-tree-layer name="Hello_Filter_SubsetString" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" id="Hello_Project_SubsetString_copy20160223113949592" legend_exp="">
       <customproperties/>
     </layer-tree-layer>
-    <layer-tree-group name="Country_grp" checked="Qt::Checked" expanded="1">
+    <layer-tree-layer name="dem" expanded="0" providerKey="gdal" checked="Qt::Checked" source="./dem.tif" id="dem20150730091219559" legend_exp="">
       <customproperties/>
-      <layer-tree-layer id="country20131022151106556" name="Country" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=" providerKey="spatialite" checked="Qt::Checked" expanded="1">
+    </layer-tree-layer>
+    <layer-tree-group name="Country_grp" expanded="1" checked="Qt::Checked">
+      <customproperties/>
+      <layer-tree-layer name="Country" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=" id="country20131022151106556" legend_exp="">
         <customproperties/>
       </layer-tree-layer>
     </layer-tree-group>
-    <layer-tree-layer id="Country_copy20161127151800736" name="Country_Labels" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=" providerKey="spatialite" checked="Qt::Checked" expanded="1">
+    <layer-tree-layer name="Country_Labels" expanded="1" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=" id="Country_copy20161127151800736" legend_exp="">
       <customproperties/>
     </layer-tree-layer>
-    <layer-tree-layer id="country20170328164317226" name="Country_Diagrams" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=" providerKey="spatialite" checked="Qt::Checked" expanded="0">
+    <layer-tree-layer name="Country_Diagrams" expanded="0" providerKey="spatialite" checked="Qt::Checked" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=" id="country20170328164317226" legend_exp="">
       <customproperties/>
     </layer-tree-layer>
     <custom-order enabled="0">
@@ -66,19 +70,21 @@
       <item>Country_copy20161127151800736</item>
       <item>country20170328164317226</item>
       <item>Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c</item>
+      <item>Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9</item>
     </custom-order>
   </layer-tree-group>
-  <snapping-settings enabled="1" tolerance="40" intersection-snapping="0" unit="1" type="1" mode="3">
+  <snapping-settings type="1" mode="3" intersection-snapping="0" enabled="1" unit="1" tolerance="40">
     <individual-layer-settings>
-      <layer-setting enabled="1" tolerance="40" id="hello20131022151106574" units="1" type="1"/>
-      <layer-setting enabled="1" tolerance="0" id="points20150803121107046" units="2" type="1"/>
-      <layer-setting enabled="1" tolerance="0" id="Hello_SubsetString_copy20160222085231770" units="2" type="1"/>
-      <layer-setting enabled="1" tolerance="0" id="Hello_copy20150804164427541" units="2" type="1"/>
-      <layer-setting enabled="1" tolerance="0" id="Country_copy20161127151800736" units="2" type="1"/>
-      <layer-setting enabled="1" tolerance="0" id="Hello_Project_SubsetString_copy20160223113949592" units="2" type="1"/>
-      <layer-setting enabled="0" tolerance="12" id="Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c" units="1" type="1"/>
-      <layer-setting enabled="1" tolerance="40" id="country20131022151106556" units="1" type="1"/>
-      <layer-setting enabled="0" tolerance="0" id="country20170328164317226" units="2" type="1"/>
+      <layer-setting type="1" units="2" enabled="1" id="Hello_copy20150804164427541" tolerance="0"/>
+      <layer-setting type="1" units="1" enabled="0" id="Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9" tolerance="12"/>
+      <layer-setting type="1" units="1" enabled="1" id="hello20131022151106574" tolerance="40"/>
+      <layer-setting type="1" units="2" enabled="1" id="Country_copy20161127151800736" tolerance="0"/>
+      <layer-setting type="1" units="2" enabled="1" id="Hello_Project_SubsetString_copy20160223113949592" tolerance="0"/>
+      <layer-setting type="1" units="1" enabled="1" id="country20131022151106556" tolerance="40"/>
+      <layer-setting type="1" units="2" enabled="1" id="Hello_SubsetString_copy20160222085231770" tolerance="0"/>
+      <layer-setting type="1" units="1" enabled="0" id="Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c" tolerance="12"/>
+      <layer-setting type="1" units="2" enabled="0" id="country20170328164317226" tolerance="0"/>
+      <layer-setting type="1" units="2" enabled="1" id="points20150803121107046" tolerance="0"/>
     </individual-layer-settings>
   </snapping-settings>
   <relations/>
@@ -93,6 +99,7 @@
     <rotation>0</rotation>
     <destinationsrs>
       <spatialrefsys>
+        <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
         <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
         <srsid>3857</srsid>
         <srid>3857</srid>
@@ -104,66 +111,73 @@
       </spatialrefsys>
     </destinationsrs>
     <rendermaptile>0</rendermaptile>
+    <expressionContextScope/>
   </mapcanvas>
+  <projectModels/>
   <legend updateDrawingOrder="true">
-    <legendlayer showFeatureCount="0" drawingOrder="-1" name="db_point" open="true" checked="Qt::Checked">
-      <filegroup hidden="false" open="true">
-        <legendlayerfile visible="1" isInOverview="0" layerid="points20150803121107046"/>
+    <legendlayer name="db_point" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
+      <filegroup open="true" hidden="false">
+        <legendlayerfile layerid="points20150803121107046" visible="1" isInOverview="0"/>
       </filegroup>
     </legendlayer>
-    <legendgroup name="Hello_grp" open="true" checked="Qt::Checked">
-      <legendlayer showFeatureCount="0" drawingOrder="-1" name="Hello" open="true" checked="Qt::Checked">
-        <filegroup hidden="false" open="true">
-          <legendlayerfile visible="1" isInOverview="0" layerid="hello20131022151106574"/>
+    <legendgroup name="Hello_grp" checked="Qt::Checked" open="true">
+      <legendlayer name="Hello" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
+        <filegroup open="true" hidden="false">
+          <legendlayerfile layerid="hello20131022151106574" visible="1" isInOverview="0"/>
         </filegroup>
       </legendlayer>
     </legendgroup>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" name="Hello_OnOff" open="true" checked="Qt::Checked">
-      <filegroup hidden="false" open="true">
-        <legendlayerfile visible="1" isInOverview="0" layerid="Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c"/>
+    <legendlayer name="Hello_OnOff" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
+      <filegroup open="true" hidden="false">
+        <legendlayerfile layerid="Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c" visible="1" isInOverview="0"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" name="Hello_SubsetString" open="true" checked="Qt::Checked">
-      <filegroup hidden="false" open="true">
-        <legendlayerfile visible="1" isInOverview="0" layerid="Hello_copy20150804164427541"/>
+    <legendlayer name="Hello_Filter" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
+      <filegroup open="true" hidden="false">
+        <legendlayerfile layerid="Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9" visible="1" isInOverview="0"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" name="Hello_Project_SubsetString" open="true" checked="Qt::Checked">
-      <filegroup hidden="false" open="true">
-        <legendlayerfile visible="1" isInOverview="0" layerid="Hello_SubsetString_copy20160222085231770"/>
+    <legendlayer name="Hello_SubsetString" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
+      <filegroup open="true" hidden="false">
+        <legendlayerfile layerid="Hello_copy20150804164427541" visible="1" isInOverview="0"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" name="Hello_Filter_SubsetString" open="true" checked="Qt::Checked">
-      <filegroup hidden="false" open="true">
-        <legendlayerfile visible="1" isInOverview="0" layerid="Hello_Project_SubsetString_copy20160223113949592"/>
+    <legendlayer name="Hello_Project_SubsetString" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
+      <filegroup open="true" hidden="false">
+        <legendlayerfile layerid="Hello_SubsetString_copy20160222085231770" visible="1" isInOverview="0"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" name="dem" open="false" checked="Qt::Checked">
-      <filegroup hidden="false" open="false">
-        <legendlayerfile visible="1" isInOverview="0" layerid="dem20150730091219559"/>
+    <legendlayer name="Hello_Filter_SubsetString" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
+      <filegroup open="true" hidden="false">
+        <legendlayerfile layerid="Hello_Project_SubsetString_copy20160223113949592" visible="1" isInOverview="0"/>
       </filegroup>
     </legendlayer>
-    <legendgroup name="Country_grp" open="true" checked="Qt::Checked">
-      <legendlayer showFeatureCount="0" drawingOrder="-1" name="Country" open="true" checked="Qt::Checked">
-        <filegroup hidden="false" open="true">
-          <legendlayerfile visible="1" isInOverview="0" layerid="country20131022151106556"/>
+    <legendlayer name="dem" drawingOrder="-1" checked="Qt::Checked" open="false" showFeatureCount="0">
+      <filegroup open="false" hidden="false">
+        <legendlayerfile layerid="dem20150730091219559" visible="1" isInOverview="0"/>
+      </filegroup>
+    </legendlayer>
+    <legendgroup name="Country_grp" checked="Qt::Checked" open="true">
+      <legendlayer name="Country" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
+        <filegroup open="true" hidden="false">
+          <legendlayerfile layerid="country20131022151106556" visible="1" isInOverview="0"/>
         </filegroup>
       </legendlayer>
     </legendgroup>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" name="Country_Labels" open="true" checked="Qt::Checked">
-      <filegroup hidden="false" open="true">
-        <legendlayerfile visible="1" isInOverview="0" layerid="Country_copy20161127151800736"/>
+    <legendlayer name="Country_Labels" drawingOrder="-1" checked="Qt::Checked" open="true" showFeatureCount="0">
+      <filegroup open="true" hidden="false">
+        <legendlayerfile layerid="Country_copy20161127151800736" visible="1" isInOverview="0"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" name="Country_Diagrams" open="false" checked="Qt::Checked">
-      <filegroup hidden="false" open="false">
-        <legendlayerfile visible="1" isInOverview="0" layerid="country20170328164317226"/>
+    <legendlayer name="Country_Diagrams" drawingOrder="-1" checked="Qt::Checked" open="false" showFeatureCount="0">
+      <filegroup open="false" hidden="false">
+        <legendlayerfile layerid="country20170328164317226" visible="1" isInOverview="0"/>
       </filegroup>
     </legendlayer>
   </legend>
   <mapViewDocks/>
   <projectlayers>
-    <maplayer autoRefreshTime="0" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingTol="1" readOnly="0" maxScale="0" minScale="1e+08" autoRefreshEnabled="0" hasScaleBasedVisibilityFlag="0" geometry="Polygon" type="vector" labelsEnabled="1" simplifyMaxScale="1" simplifyLocal="1">
+    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="0" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
       <extent>
         <xmin>-19619892.68012013286352158</xmin>
         <ymin>-10327100.34232237376272678</ymin>
@@ -178,6 +192,7 @@
       <layername>Country_Labels</layername>
       <srs>
         <spatialrefsys>
+          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
           <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
@@ -200,6 +215,7 @@
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -207,7 +223,7 @@
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -220,19 +236,19 @@
       <expressionfields/>
       <map-layer-style-manager current="default">
         <map-layer-style name="custom">
-          <qgis simplifyDrawingHints="1" maximumScale="1e+08" version="2.99.0-Master" simplifyDrawingTol="1" simplifyAlgorithm="0" readOnly="0" hasScaleBasedVisibilityFlag="0" minimumScale="0" simplifyMaxScale="1" simplifyLocal="1">
+          <qgis maximumScale="1e+08" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" readOnly="0" simplifyDrawingHints="1" simplifyAlgorithm="0" version="2.99.0-Master" minimumScale="0" simplifyMaxScale="1" simplifyLocal="1">
             <edittypes>
               <edittype name="pk" widgetv2type="TextEdit">
-                <widgetv2config UseHtml="0" fieldEditable="1" IsMultiline="0" labelOnTop="0"/>
+                <widgetv2config fieldEditable="1" IsMultiline="0" labelOnTop="0" UseHtml="0"/>
               </edittype>
               <edittype name="name" widgetv2type="TextEdit">
-                <widgetv2config UseHtml="0" fieldEditable="1" IsMultiline="0" labelOnTop="0"/>
+                <widgetv2config fieldEditable="1" IsMultiline="0" labelOnTop="0" UseHtml="0"/>
               </edittype>
             </edittypes>
-            <renderer-v2 enableorderby="0" forceraster="0" type="singleSymbol" symbollevels="0">
+            <renderer-v2 type="singleSymbol" enableorderby="0" symbollevels="0" forceraster="0">
               <symbols>
-                <symbol name="0" alpha="1" clip_to_extent="1" type="fill">
-                  <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+                <symbol type="fill" alpha="1" clip_to_extent="1" name="0">
+                  <layer class="SimpleFill" enabled="1" pass="0" locked="0">
                     <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
                     <prop v="145,149,158,255" k="color"/>
                     <prop v="bevel" k="joinstyle"/>
@@ -245,7 +261,7 @@
                     <prop v="MM" k="outline_width_unit"/>
                     <prop v="solid" k="style"/>
                   </layer>
-                  <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+                  <layer class="SimpleFill" enabled="1" pass="0" locked="0">
                     <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
                     <prop v="0,0,255,255" k="color"/>
                     <prop v="bevel" k="joinstyle"/>
@@ -265,193 +281,193 @@
             </renderer-v2>
             <labeling type="simple"/>
             <customproperties>
-              <property value="0" key="embeddedWidgets/count"/>
-              <property value="pal" key="labeling"/>
-              <property value="false" key="labeling/addDirectionSymbol"/>
-              <property value="0" key="labeling/angleOffset"/>
-              <property value="0" key="labeling/blendMode"/>
-              <property value="0" key="labeling/bufferBlendMode"/>
-              <property value="255" key="labeling/bufferColorA"/>
-              <property value="255" key="labeling/bufferColorB"/>
-              <property value="255" key="labeling/bufferColorG"/>
-              <property value="255" key="labeling/bufferColorR"/>
-              <property value="false" key="labeling/bufferDraw"/>
-              <property value="64" key="labeling/bufferJoinStyle"/>
-              <property value="false" key="labeling/bufferNoFill"/>
-              <property value="1" key="labeling/bufferOpacity"/>
-              <property value="1" key="labeling/bufferSize"/>
-              <property value="false" key="labeling/bufferSizeInMapUnits"/>
-              <property value="0" key="labeling/bufferSizeMapUnitMaxScale"/>
-              <property value="0" key="labeling/bufferSizeMapUnitMinScale"/>
-              <property value="0,0,0,0,0,0" key="labeling/bufferSizeMapUnitScale"/>
-              <property value="MM" key="labeling/bufferSizeUnits"/>
-              <property value="0" key="labeling/bufferTransp"/>
-              <property value="false" key="labeling/centroidInside"/>
-              <property value="false" key="labeling/centroidWhole"/>
-              <property value="3" key="labeling/decimals"/>
-              <property value="false" key="labeling/displayAll"/>
-              <property value="0" key="labeling/dist"/>
-              <property value="false" key="labeling/distInMapUnits"/>
-              <property value="0" key="labeling/distMapUnitMaxScale"/>
-              <property value="0" key="labeling/distMapUnitMinScale"/>
-              <property value="0,0,0,0,0,0" key="labeling/distMapUnitScale"/>
-              <property value="true" key="labeling/drawLabels"/>
-              <property value="true" key="labeling/enabled"/>
-              <property value="name" key="labeling/fieldName"/>
-              <property value="false" key="labeling/fitInPolygonOnly"/>
-              <property value="false" key="labeling/fontBold"/>
-              <property value="0" key="labeling/fontCapitals"/>
-              <property value="Sans Serif" key="labeling/fontFamily"/>
-              <property value="true" key="labeling/fontItalic"/>
-              <property value="0" key="labeling/fontLetterSpacing"/>
-              <property value="false" key="labeling/fontLimitPixelSize"/>
-              <property value="10000" key="labeling/fontMaxPixelSize"/>
-              <property value="3" key="labeling/fontMinPixelSize"/>
-              <property value="40" key="labeling/fontSize"/>
-              <property value="false" key="labeling/fontSizeInMapUnits"/>
-              <property value="0" key="labeling/fontSizeMapUnitMaxScale"/>
-              <property value="0" key="labeling/fontSizeMapUnitMinScale"/>
-              <property value="0,0,0,0,0,0" key="labeling/fontSizeMapUnitScale"/>
-              <property value="Point" key="labeling/fontSizeUnit"/>
-              <property value="false" key="labeling/fontStrikeout"/>
-              <property value="true" key="labeling/fontUnderline"/>
-              <property value="50" key="labeling/fontWeight"/>
-              <property value="0" key="labeling/fontWordSpacing"/>
-              <property value="false" key="labeling/formatNumbers"/>
-              <property value="false" key="labeling/isExpression"/>
-              <property value="true" key="labeling/labelOffsetInMapUnits"/>
-              <property value="0" key="labeling/labelOffsetMapUnitMaxScale"/>
-              <property value="0" key="labeling/labelOffsetMapUnitMinScale"/>
-              <property value="0,0,0,0,0,0" key="labeling/labelOffsetMapUnitScale"/>
-              <property value="false" key="labeling/labelPerPart"/>
-              <property value="&lt;" key="labeling/leftDirectionSymbol"/>
-              <property value="false" key="labeling/limitNumLabels"/>
-              <property value="20" key="labeling/maxCurvedCharAngleIn"/>
-              <property value="-20" key="labeling/maxCurvedCharAngleOut"/>
-              <property value="2000" key="labeling/maxNumLabels"/>
-              <property value="false" key="labeling/mergeLines"/>
-              <property value="0" key="labeling/minFeatureSize"/>
-              <property value="0" key="labeling/multilineAlign"/>
-              <property value="1" key="labeling/multilineHeight"/>
-              <property value="Italic" key="labeling/namedStyle"/>
-              <property value="true" key="labeling/obstacle"/>
-              <property value="1" key="labeling/obstacleFactor"/>
-              <property value="0" key="labeling/obstacleType"/>
-              <property value="0" key="labeling/offsetType"/>
-              <property value="0" key="labeling/placeDirectionSymbol"/>
-              <property value="0" key="labeling/placement"/>
-              <property value="0" key="labeling/placementFlags"/>
-              <property value="false" key="labeling/plussign"/>
-              <property value="TR,TL,BR,BL,R,L,TSR,BSR" key="labeling/predefinedPositionOrder"/>
-              <property value="true" key="labeling/preserveRotation"/>
-              <property value="#ffffff" key="labeling/previewBkgrdColor"/>
-              <property value="5" key="labeling/priority"/>
-              <property value="4" key="labeling/quadOffset"/>
-              <property value="0" key="labeling/repeatDistance"/>
-              <property value="0" key="labeling/repeatDistanceMapUnitMaxScale"/>
-              <property value="0" key="labeling/repeatDistanceMapUnitMinScale"/>
-              <property value="0,0,0,0,0,0" key="labeling/repeatDistanceMapUnitScale"/>
-              <property value="1" key="labeling/repeatDistanceUnit"/>
-              <property value="false" key="labeling/reverseDirectionSymbol"/>
-              <property value=">" key="labeling/rightDirectionSymbol"/>
-              <property value="10000000" key="labeling/scaleMax"/>
-              <property value="1" key="labeling/scaleMin"/>
-              <property value="false" key="labeling/scaleVisibility"/>
-              <property value="6" key="labeling/shadowBlendMode"/>
-              <property value="0" key="labeling/shadowColorB"/>
-              <property value="0" key="labeling/shadowColorG"/>
-              <property value="0" key="labeling/shadowColorR"/>
-              <property value="false" key="labeling/shadowDraw"/>
-              <property value="135" key="labeling/shadowOffsetAngle"/>
-              <property value="1" key="labeling/shadowOffsetDist"/>
-              <property value="true" key="labeling/shadowOffsetGlobal"/>
-              <property value="0" key="labeling/shadowOffsetMapUnitMaxScale"/>
-              <property value="0" key="labeling/shadowOffsetMapUnitMinScale"/>
-              <property value="0,0,0,0,0,0" key="labeling/shadowOffsetMapUnitScale"/>
-              <property value="MapUnit" key="labeling/shadowOffsetUnit"/>
-              <property value="1" key="labeling/shadowOffsetUnits"/>
-              <property value="0.69999999999999996" key="labeling/shadowOpacity"/>
-              <property value="1.5" key="labeling/shadowRadius"/>
-              <property value="false" key="labeling/shadowRadiusAlphaOnly"/>
-              <property value="0" key="labeling/shadowRadiusMapUnitMaxScale"/>
-              <property value="0" key="labeling/shadowRadiusMapUnitMinScale"/>
-              <property value="0,0,0,0,0,0" key="labeling/shadowRadiusMapUnitScale"/>
-              <property value="MapUnit" key="labeling/shadowRadiusUnit"/>
-              <property value="1" key="labeling/shadowRadiusUnits"/>
-              <property value="100" key="labeling/shadowScale"/>
-              <property value="30" key="labeling/shadowTransparency"/>
-              <property value="0" key="labeling/shadowUnder"/>
-              <property value="0" key="labeling/shapeBlendMode"/>
-              <property value="255" key="labeling/shapeBorderColorA"/>
-              <property value="128" key="labeling/shapeBorderColorB"/>
-              <property value="128" key="labeling/shapeBorderColorG"/>
-              <property value="128" key="labeling/shapeBorderColorR"/>
-              <property value="0" key="labeling/shapeBorderWidth"/>
-              <property value="0" key="labeling/shapeBorderWidthMapUnitMaxScale"/>
-              <property value="0" key="labeling/shapeBorderWidthMapUnitMinScale"/>
-              <property value="0,0,0,0,0,0" key="labeling/shapeBorderWidthMapUnitScale"/>
-              <property value="MapUnit" key="labeling/shapeBorderWidthUnit"/>
-              <property value="1" key="labeling/shapeBorderWidthUnits"/>
-              <property value="false" key="labeling/shapeDraw"/>
-              <property value="255" key="labeling/shapeFillColorA"/>
-              <property value="255" key="labeling/shapeFillColorB"/>
-              <property value="255" key="labeling/shapeFillColorG"/>
-              <property value="255" key="labeling/shapeFillColorR"/>
-              <property value="64" key="labeling/shapeJoinStyle"/>
-              <property value="0" key="labeling/shapeOffsetMapUnitMaxScale"/>
-              <property value="0" key="labeling/shapeOffsetMapUnitMinScale"/>
-              <property value="0,0,0,0,0,0" key="labeling/shapeOffsetMapUnitScale"/>
-              <property value="MapUnit" key="labeling/shapeOffsetUnit"/>
-              <property value="1" key="labeling/shapeOffsetUnits"/>
-              <property value="0" key="labeling/shapeOffsetX"/>
-              <property value="0" key="labeling/shapeOffsetY"/>
-              <property value="1" key="labeling/shapeOpacity"/>
-              <property value="0" key="labeling/shapeRadiiMapUnitMaxScale"/>
-              <property value="0" key="labeling/shapeRadiiMapUnitMinScale"/>
-              <property value="0,0,0,0,0,0" key="labeling/shapeRadiiMapUnitScale"/>
-              <property value="MapUnit" key="labeling/shapeRadiiUnit"/>
-              <property value="1" key="labeling/shapeRadiiUnits"/>
-              <property value="0" key="labeling/shapeRadiiX"/>
-              <property value="0" key="labeling/shapeRadiiY"/>
-              <property value="0" key="labeling/shapeRotation"/>
-              <property value="0" key="labeling/shapeRotationType"/>
-              <property value="" key="labeling/shapeSVGFile"/>
-              <property value="0" key="labeling/shapeSizeMapUnitMaxScale"/>
-              <property value="0" key="labeling/shapeSizeMapUnitMinScale"/>
-              <property value="0,0,0,0,0,0" key="labeling/shapeSizeMapUnitScale"/>
-              <property value="0" key="labeling/shapeSizeType"/>
-              <property value="MapUnit" key="labeling/shapeSizeUnit"/>
-              <property value="1" key="labeling/shapeSizeUnits"/>
-              <property value="0" key="labeling/shapeSizeX"/>
-              <property value="0" key="labeling/shapeSizeY"/>
-              <property value="0" key="labeling/shapeTransparency"/>
-              <property value="0" key="labeling/shapeType"/>
-              <property value="&lt;substitutions/>" key="labeling/substitutions"/>
-              <property value="255" key="labeling/textColorA"/>
-              <property value="1" key="labeling/textColorB"/>
-              <property value="1" key="labeling/textColorG"/>
-              <property value="255" key="labeling/textColorR"/>
-              <property value="1" key="labeling/textOpacity"/>
-              <property value="0" key="labeling/textTransp"/>
-              <property value="0" key="labeling/upsidedownLabels"/>
-              <property value="false" key="labeling/useSubstitutions"/>
-              <property value="" key="labeling/wrapChar"/>
-              <property value="0" key="labeling/xOffset"/>
-              <property value="0" key="labeling/yOffset"/>
-              <property value="0" key="labeling/zIndex"/>
+              <property key="embeddedWidgets/count" value="0"/>
+              <property key="labeling" value="pal"/>
+              <property key="labeling/addDirectionSymbol" value="false"/>
+              <property key="labeling/angleOffset" value="0"/>
+              <property key="labeling/blendMode" value="0"/>
+              <property key="labeling/bufferBlendMode" value="0"/>
+              <property key="labeling/bufferColorA" value="255"/>
+              <property key="labeling/bufferColorB" value="255"/>
+              <property key="labeling/bufferColorG" value="255"/>
+              <property key="labeling/bufferColorR" value="255"/>
+              <property key="labeling/bufferDraw" value="false"/>
+              <property key="labeling/bufferJoinStyle" value="64"/>
+              <property key="labeling/bufferNoFill" value="false"/>
+              <property key="labeling/bufferOpacity" value="1"/>
+              <property key="labeling/bufferSize" value="1"/>
+              <property key="labeling/bufferSizeInMapUnits" value="false"/>
+              <property key="labeling/bufferSizeMapUnitMaxScale" value="0"/>
+              <property key="labeling/bufferSizeMapUnitMinScale" value="0"/>
+              <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
+              <property key="labeling/bufferSizeUnits" value="MM"/>
+              <property key="labeling/bufferTransp" value="0"/>
+              <property key="labeling/centroidInside" value="false"/>
+              <property key="labeling/centroidWhole" value="false"/>
+              <property key="labeling/decimals" value="3"/>
+              <property key="labeling/displayAll" value="false"/>
+              <property key="labeling/dist" value="0"/>
+              <property key="labeling/distInMapUnits" value="false"/>
+              <property key="labeling/distMapUnitMaxScale" value="0"/>
+              <property key="labeling/distMapUnitMinScale" value="0"/>
+              <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
+              <property key="labeling/drawLabels" value="true"/>
+              <property key="labeling/enabled" value="true"/>
+              <property key="labeling/fieldName" value="name"/>
+              <property key="labeling/fitInPolygonOnly" value="false"/>
+              <property key="labeling/fontBold" value="false"/>
+              <property key="labeling/fontCapitals" value="0"/>
+              <property key="labeling/fontFamily" value="Sans Serif"/>
+              <property key="labeling/fontItalic" value="true"/>
+              <property key="labeling/fontLetterSpacing" value="0"/>
+              <property key="labeling/fontLimitPixelSize" value="false"/>
+              <property key="labeling/fontMaxPixelSize" value="10000"/>
+              <property key="labeling/fontMinPixelSize" value="3"/>
+              <property key="labeling/fontSize" value="40"/>
+              <property key="labeling/fontSizeInMapUnits" value="false"/>
+              <property key="labeling/fontSizeMapUnitMaxScale" value="0"/>
+              <property key="labeling/fontSizeMapUnitMinScale" value="0"/>
+              <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
+              <property key="labeling/fontSizeUnit" value="Point"/>
+              <property key="labeling/fontStrikeout" value="false"/>
+              <property key="labeling/fontUnderline" value="true"/>
+              <property key="labeling/fontWeight" value="50"/>
+              <property key="labeling/fontWordSpacing" value="0"/>
+              <property key="labeling/formatNumbers" value="false"/>
+              <property key="labeling/isExpression" value="false"/>
+              <property key="labeling/labelOffsetInMapUnits" value="true"/>
+              <property key="labeling/labelOffsetMapUnitMaxScale" value="0"/>
+              <property key="labeling/labelOffsetMapUnitMinScale" value="0"/>
+              <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
+              <property key="labeling/labelPerPart" value="false"/>
+              <property key="labeling/leftDirectionSymbol" value="&lt;"/>
+              <property key="labeling/limitNumLabels" value="false"/>
+              <property key="labeling/maxCurvedCharAngleIn" value="20"/>
+              <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
+              <property key="labeling/maxNumLabels" value="2000"/>
+              <property key="labeling/mergeLines" value="false"/>
+              <property key="labeling/minFeatureSize" value="0"/>
+              <property key="labeling/multilineAlign" value="0"/>
+              <property key="labeling/multilineHeight" value="1"/>
+              <property key="labeling/namedStyle" value="Italic"/>
+              <property key="labeling/obstacle" value="true"/>
+              <property key="labeling/obstacleFactor" value="1"/>
+              <property key="labeling/obstacleType" value="0"/>
+              <property key="labeling/offsetType" value="0"/>
+              <property key="labeling/placeDirectionSymbol" value="0"/>
+              <property key="labeling/placement" value="0"/>
+              <property key="labeling/placementFlags" value="0"/>
+              <property key="labeling/plussign" value="false"/>
+              <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
+              <property key="labeling/preserveRotation" value="true"/>
+              <property key="labeling/previewBkgrdColor" value="#ffffff"/>
+              <property key="labeling/priority" value="5"/>
+              <property key="labeling/quadOffset" value="4"/>
+              <property key="labeling/repeatDistance" value="0"/>
+              <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"/>
+              <property key="labeling/repeatDistanceMapUnitMinScale" value="0"/>
+              <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
+              <property key="labeling/repeatDistanceUnit" value="1"/>
+              <property key="labeling/reverseDirectionSymbol" value="false"/>
+              <property key="labeling/rightDirectionSymbol" value=">"/>
+              <property key="labeling/scaleMax" value="10000000"/>
+              <property key="labeling/scaleMin" value="1"/>
+              <property key="labeling/scaleVisibility" value="false"/>
+              <property key="labeling/shadowBlendMode" value="6"/>
+              <property key="labeling/shadowColorB" value="0"/>
+              <property key="labeling/shadowColorG" value="0"/>
+              <property key="labeling/shadowColorR" value="0"/>
+              <property key="labeling/shadowDraw" value="false"/>
+              <property key="labeling/shadowOffsetAngle" value="135"/>
+              <property key="labeling/shadowOffsetDist" value="1"/>
+              <property key="labeling/shadowOffsetGlobal" value="true"/>
+              <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"/>
+              <property key="labeling/shadowOffsetMapUnitMinScale" value="0"/>
+              <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
+              <property key="labeling/shadowOffsetUnit" value="MapUnit"/>
+              <property key="labeling/shadowOffsetUnits" value="1"/>
+              <property key="labeling/shadowOpacity" value="0.69999999999999996"/>
+              <property key="labeling/shadowRadius" value="1.5"/>
+              <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
+              <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"/>
+              <property key="labeling/shadowRadiusMapUnitMinScale" value="0"/>
+              <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
+              <property key="labeling/shadowRadiusUnit" value="MapUnit"/>
+              <property key="labeling/shadowRadiusUnits" value="1"/>
+              <property key="labeling/shadowScale" value="100"/>
+              <property key="labeling/shadowTransparency" value="30"/>
+              <property key="labeling/shadowUnder" value="0"/>
+              <property key="labeling/shapeBlendMode" value="0"/>
+              <property key="labeling/shapeBorderColorA" value="255"/>
+              <property key="labeling/shapeBorderColorB" value="128"/>
+              <property key="labeling/shapeBorderColorG" value="128"/>
+              <property key="labeling/shapeBorderColorR" value="128"/>
+              <property key="labeling/shapeBorderWidth" value="0"/>
+              <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"/>
+              <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"/>
+              <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
+              <property key="labeling/shapeBorderWidthUnit" value="MapUnit"/>
+              <property key="labeling/shapeBorderWidthUnits" value="1"/>
+              <property key="labeling/shapeDraw" value="false"/>
+              <property key="labeling/shapeFillColorA" value="255"/>
+              <property key="labeling/shapeFillColorB" value="255"/>
+              <property key="labeling/shapeFillColorG" value="255"/>
+              <property key="labeling/shapeFillColorR" value="255"/>
+              <property key="labeling/shapeJoinStyle" value="64"/>
+              <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"/>
+              <property key="labeling/shapeOffsetMapUnitMinScale" value="0"/>
+              <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
+              <property key="labeling/shapeOffsetUnit" value="MapUnit"/>
+              <property key="labeling/shapeOffsetUnits" value="1"/>
+              <property key="labeling/shapeOffsetX" value="0"/>
+              <property key="labeling/shapeOffsetY" value="0"/>
+              <property key="labeling/shapeOpacity" value="1"/>
+              <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"/>
+              <property key="labeling/shapeRadiiMapUnitMinScale" value="0"/>
+              <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
+              <property key="labeling/shapeRadiiUnit" value="MapUnit"/>
+              <property key="labeling/shapeRadiiUnits" value="1"/>
+              <property key="labeling/shapeRadiiX" value="0"/>
+              <property key="labeling/shapeRadiiY" value="0"/>
+              <property key="labeling/shapeRotation" value="0"/>
+              <property key="labeling/shapeRotationType" value="0"/>
+              <property key="labeling/shapeSVGFile" value=""/>
+              <property key="labeling/shapeSizeMapUnitMaxScale" value="0"/>
+              <property key="labeling/shapeSizeMapUnitMinScale" value="0"/>
+              <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
+              <property key="labeling/shapeSizeType" value="0"/>
+              <property key="labeling/shapeSizeUnit" value="MapUnit"/>
+              <property key="labeling/shapeSizeUnits" value="1"/>
+              <property key="labeling/shapeSizeX" value="0"/>
+              <property key="labeling/shapeSizeY" value="0"/>
+              <property key="labeling/shapeTransparency" value="0"/>
+              <property key="labeling/shapeType" value="0"/>
+              <property key="labeling/substitutions" value="&lt;substitutions/>"/>
+              <property key="labeling/textColorA" value="255"/>
+              <property key="labeling/textColorB" value="1"/>
+              <property key="labeling/textColorG" value="1"/>
+              <property key="labeling/textColorR" value="255"/>
+              <property key="labeling/textOpacity" value="1"/>
+              <property key="labeling/textTransp" value="0"/>
+              <property key="labeling/upsidedownLabels" value="0"/>
+              <property key="labeling/useSubstitutions" value="false"/>
+              <property key="labeling/wrapChar" value=""/>
+              <property key="labeling/xOffset" value="0"/>
+              <property key="labeling/yOffset" value="0"/>
+              <property key="labeling/zIndex" value="0"/>
               <property key="variableNames"/>
               <property key="variableValues"/>
             </customproperties>
             <blendMode>0</blendMode>
             <featureBlendMode>0</featureBlendMode>
             <layerTransparency>0</layerTransparency>
-            <SingleCategoryDiagramRenderer attributeLegend="1" sizeLegend="0" diagramType="Pie">
-              <DiagramCategory lineSizeType="MM" backgroundAlpha="255" barWidth="5" height="15" diagramOrientation="Up" scaleDependency="Area" sizeScale="0,0,0,0,0,0" transparency="0" penAlpha="255" minScaleDenominator="0" minimumSize="0" enabled="0" lineSizeScale="0,0,0,0,0,0" penWidth="0" sizeType="MM" scaleBasedVisibility="0" maxScaleDenominator="1e+08" width="15" backgroundColor="#ffffff" penColor="#000000" labelPlacementMethod="XHeight" angleOffset="1440">
+            <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie" sizeLegend="0">
+              <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" angleOffset="1440" sizeScale="0,0,0,0,0,0" lineSizeScale="0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" enabled="0" transparency="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+08">
                 <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-                <attribute label="" field="" color="#000000"/>
+                <attribute color="#000000" label="" field=""/>
               </DiagramCategory>
-              <symbol name="sizeSymbol" alpha="1" clip_to_extent="1" type="marker">
-                <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
+              <symbol type="marker" alpha="1" clip_to_extent="1" name="sizeSymbol">
+                <layer class="SimpleMarker" enabled="1" pass="0" locked="0">
                   <prop v="0" k="angle"/>
                   <prop v="255,0,0,255" k="color"/>
                   <prop v="1" k="horizontal_anchor_point"/>
@@ -473,22 +489,22 @@
                 </layer>
               </symbol>
             </SingleCategoryDiagramRenderer>
-            <DiagramLayerSettings obstacle="0" showColumn="0" dist="0" xPosColumn="-1" linePlacementFlags="10" showAll="1" placement="0" yPosColumn="-1" priority="0" zIndex="0"/>
+            <DiagramLayerSettings obstacle="0" xPosColumn="-1" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showColumn="0" showAll="1" yPosColumn="-1"/>
             <annotationform>.</annotationform>
             <aliases>
-              <alias name="" index="0" field="pk"/>
-              <alias name="" index="1" field="name"/>
+              <alias name="" field="pk" index="0"/>
+              <alias name="" field="name" index="1"/>
             </aliases>
             <excludeAttributesWMS/>
             <excludeAttributesWFS/>
             <attributeactions>
-              <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+              <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
             </attributeactions>
             <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
               <columns>
-                <column name="pk" hidden="0" width="-1" type="field"/>
-                <column name="name" hidden="0" width="-1" type="field"/>
-                <column hidden="1" width="-1" type="actions"/>
+                <column type="field" width="-1" name="pk" hidden="0"/>
+                <column type="field" width="-1" name="name" hidden="0"/>
+                <column type="actions" width="-1" hidden="1"/>
               </columns>
             </attributetableconfig>
             <editform>.</editform>
@@ -515,7 +531,7 @@ def my_form_open(dialog, layer, feature):
             <featformsuppress>0</featformsuppress>
             <editorlayout>generatedlayout</editorlayout>
             <attributeEditorForm>
-              <attributeEditorContainer visibilityExpressionEnabled="0" columnCount="0" visibilityExpression="" groupBox="0" name="ttt" showLabel="1"/>
+              <attributeEditorContainer columnCount="0" visibilityExpression="" name="ttt" showLabel="1" groupBox="0" visibilityExpressionEnabled="0"/>
             </attributeEditorForm>
             <widgets/>
             <conditionalstyles>
@@ -531,10 +547,15 @@ def my_form_open(dialog, layer, feature):
         <map-layer-style name="default"/>
       </map-layer-style-manager>
       <auxiliaryLayer/>
-      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0">
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
         <symbols>
-          <symbol name="0" alpha="1" clip_to_extent="1" type="fill">
-            <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
               <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
               <prop v="145,149,158,255" k="color"/>
               <prop v="bevel" k="joinstyle"/>
@@ -548,13 +569,13 @@ def my_form_open(dialog, layer, feature):
               <prop v="solid" k="style"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
               <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
               <prop v="0,0,255,255" k="color"/>
               <prop v="bevel" k="joinstyle"/>
@@ -568,9 +589,9 @@ def my_form_open(dialog, layer, feature):
               <prop v="solid" k="style"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -580,27 +601,56 @@ def my_form_open(dialog, layer, feature):
         <sizescale/>
       </renderer-v2>
       <labeling type="simple">
-        <settings>
-          <text-style fontItalic="0" blendMode="0" fontStrikeout="0" isExpression="0" fontSizeUnit="Point" multilineHeight="1" textOpacity="1" fontSize="9" previewBkgrdColor="#ffffff" fontWordSpacing="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontCapitals="0" useSubstitutions="0" fontUnderline="0" fieldName="name" namedStyle="Normal" fontLetterSpacing="0" fontFamily="Sans Serif" textColor="0,0,0,255" fontWeight="50">
-            <text-buffer bufferSizeUnits="MM" bufferNoFill="0" bufferColor="255,255,255,255" bufferJoinStyle="64" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferDraw="0" bufferOpacity="1" bufferBlendMode="0"/>
-            <background shapeRotationType="0" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeOffsetY="0" shapeSizeX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidth="0" shapeRotation="0" shapeDraw="0" shapeRadiiUnit="MapUnit" shapeBlendMode="0" shapeSizeType="0" shapeSVGFile="" shapeOffsetUnit="MapUnit" shapeBorderColor="128,128,128,255" shapeJoinStyle="64" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MapUnit" shapeRadiiY="0" shapeFillColor="255,255,255,255" shapeType="0" shapeBorderWidthUnit="MapUnit" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeOpacity="1"/>
-            <shadow shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowOffsetUnit="MapUnit" shadowRadiusAlphaOnly="0" shadowOpacity="0.7" shadowColor="0,0,0,255" shadowOffsetAngle="135" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowScale="100" shadowBlendMode="6" shadowDraw="0" shadowRadiusUnit="MapUnit"/>
+        <settings calloutType="simple">
+          <text-style blendMode="0" fontLetterSpacing="0" fontItalic="0" fontKerning="1" fontSize="9" fontFamily="Sans Serif" fontWeight="50" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" namedStyle="Normal" useSubstitutions="0" fontCapitals="0" textOrientation="horizontal" textColor="0,0,0,255" multilineHeight="1" fontStrikeout="0" isExpression="0" fontUnderline="0" fontSizeUnit="Point" fieldName="name" previewBkgrdColor="255,255,255,255" fontWordSpacing="0">
+            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSizeUnits="MM" bufferNoFill="0" bufferSize="1" bufferColor="255,255,255,255" bufferBlendMode="0" bufferDraw="0" bufferJoinStyle="64"/>
+            <background shapeBlendMode="0" shapeRotation="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeOffsetX="0" shapeBorderWidth="0" shapeOffsetUnit="MapUnit" shapeRadiiX="0" shapeSizeUnit="MapUnit" shapeType="0" shapeRotationType="0" shapeRadiiY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeSizeX="0" shapeOffsetY="0" shapeSVGFile="" shapeSizeType="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0" shapeBorderWidthUnit="MapUnit" shapeSizeY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeRadiiUnit="MapUnit"/>
+            <shadow shadowOffsetGlobal="1" shadowColor="0,0,0,255" shadowRadius="1.5" shadowDraw="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetDist="1" shadowRadiusUnit="MapUnit" shadowOpacity="0.7" shadowRadiusAlphaOnly="0" shadowScale="100" shadowBlendMode="6" shadowOffsetUnit="MapUnit" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowOffsetAngle="135"/>
+            <dd_properties>
+              <Option type="Map">
+                <Option type="QString" name="name" value=""/>
+                <Option name="properties"/>
+                <Option type="QString" name="type" value="collection"/>
+              </Option>
+            </dd_properties>
             <substitutions/>
           </text-style>
-          <text-format decimals="3" plussign="0" multilineAlign="0" leftDirectionSymbol="&lt;" rightDirectionSymbol=">" placeDirectionSymbol="0" wrapChar="" reverseDirectionSymbol="0" addDirectionSymbol="0" formatNumbers="0"/>
-          <placement placementFlags="0" quadOffset="4" priority="5" distUnits="MM" placement="0" fitInPolygonOnly="0" rotationAngle="0" centroidInside="0" centroidWhole="0" yOffset="0" offsetUnits="MapUnit" preserveRotation="1" repeatDistance="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="20" dist="0" repeatDistanceUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" distMapUnitScale="3x:0,0,0,0,0,0" maxCurvedCharAngleOut="-20" offsetType="0"/>
-          <rendering scaleVisibility="0" obstacleFactor="1" fontMaxPixelSize="10000" fontLimitPixelSize="0" obstacleType="0" displayAll="0" scaleMax="10000000" limitNumLabels="0" drawLabels="1" obstacle="1" upsidedownLabels="0" zIndex="0" mergeLines="0" fontMinPixelSize="3" maxNumLabels="2000" minFeatureSize="0" scaleMin="1" labelPerPart="0"/>
+          <text-format decimals="3" multilineAlign="0" leftDirectionSymbol="&lt;" placeDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" wrapChar="" plussign="0" addDirectionSymbol="0" autoWrapLength="0" rightDirectionSymbol=">" reverseDirectionSymbol="0"/>
+          <placement centroidInside="0" maxCurvedCharAngleIn="20" repeatDistanceUnits="MM" fitInPolygonOnly="0" layerType="UnknownGeometry" distUnits="MM" offsetUnits="MapUnit" repeatDistance="0" overrunDistanceUnit="MM" rotationAngle="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" overrunDistance="0" geometryGenerator="" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" placement="0" placementFlags="0" geometryGeneratorEnabled="0" dist="0" distMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" xOffset="0" centroidWhole="0" quadOffset="4" yOffset="0" maxCurvedCharAngleOut="-20" priority="5" geometryGeneratorType="PointGeometry" offsetType="0"/>
+          <rendering fontMaxPixelSize="10000" minFeatureSize="0" zIndex="0" scaleMin="1" maxNumLabels="2000" drawLabels="1" limitNumLabels="0" scaleMax="10000000" fontLimitPixelSize="0" obstacleType="0" mergeLines="0" displayAll="0" obstacleFactor="1" fontMinPixelSize="3" upsidedownLabels="0" labelPerPart="0" obstacle="1" scaleVisibility="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </dd_properties>
+          <callout type="simple">
+            <Option type="Map">
+              <Option type="QString" name="anchorPoint" value="pole_of_inaccessibility"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" name="name" value=""/>
+                <Option name="properties"/>
+                <Option type="QString" name="type" value="collection"/>
+              </Option>
+              <Option type="bool" name="drawToAllParts" value="false"/>
+              <Option type="QString" name="enabled" value="0"/>
+              <Option type="QString" name="lineSymbol" value="&lt;symbol type=&quot;line&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; name=&quot;symbol&quot; force_rhr=&quot;0&quot;>&lt;layer class=&quot;SimpleLine&quot; enabled=&quot;1&quot; pass=&quot;0&quot; locked=&quot;0&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; name=&quot;name&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;type&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"/>
+              <Option type="double" name="minLength" value="0"/>
+              <Option type="QString" name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0"/>
+              <Option type="QString" name="minLengthUnit" value="MM"/>
+              <Option type="double" name="offsetFromAnchor" value="0"/>
+              <Option type="QString" name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0"/>
+              <Option type="QString" name="offsetFromAnchorUnit" value="MM"/>
+              <Option type="double" name="offsetFromLabel" value="0"/>
+              <Option type="QString" name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0"/>
+              <Option type="QString" name="offsetFromLabelUnit" value="MM"/>
+            </Option>
+          </callout>
         </settings>
       </labeling>
       <customproperties>
-        <property value="0" key="embeddedWidgets/count"/>
+        <property key="embeddedWidgets/count" value="0"/>
         <property key="variableNames"/>
         <property key="variableValues"/>
       </customproperties>
@@ -608,20 +658,24 @@ def my_form_open(dialog, layer, feature):
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory lineSizeType="MM" backgroundAlpha="255" height="15" barWidth="5" rotationOffset="270" scaleDependency="Area" diagramOrientation="Up" sizeScale="3x:0,0,0,0,0,0" penAlpha="255" minScaleDenominator="0" minimumSize="0" enabled="0" lineSizeScale="3x:0,0,0,0,0,0" penWidth="0" sizeType="MM" scaleBasedVisibility="0" opacity="1" maxScaleDenominator="1e+08" width="15" backgroundColor="#ffffff" penColor="#000000" labelPlacementMethod="XHeight">
+        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
           <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+          <attribute color="#000000" label="" field=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" dist="0" linePlacementFlags="10" showAll="1" placement="0" priority="0" zIndex="0">
+      <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
         <properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
+            <Option type="QString" name="name" value=""/>
             <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
+            <Option type="QString" name="type" value="collection"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks/>
+        <checkConfiguration/>
+      </geometryOptions>
       <fieldConfiguration>
         <field name="pk">
           <editWidget type="">
@@ -639,33 +693,39 @@ def my_form_open(dialog, layer, feature):
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="pk"/>
-        <alias name="" index="1" field="name"/>
+        <alias name="" field="pk" index="0"/>
+        <alias name="" field="name" index="1"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default applyOnUpdate="0" expression="" field="pk"/>
-        <default applyOnUpdate="0" expression="" field="name"/>
+        <default applyOnUpdate="0" field="pk" expression=""/>
+        <default applyOnUpdate="0" field="name" expression=""/>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" constraints="3" exp_strength="0" field="pk" unique_strength="1"/>
-        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="name" unique_strength="0"/>
+        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
+        <constraint constraints="0" notnull_strength="0" field="name" exp_strength="0" unique_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" field="pk" desc=""/>
-        <constraint exp="" field="name" desc=""/>
+        <constraint field="pk" desc="" exp=""/>
+        <constraint field="name" desc="" exp=""/>
       </constraintExpressions>
+      <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column name="pk" hidden="0" width="-1" type="field"/>
-          <column name="name" hidden="0" width="-1" type="field"/>
-          <column hidden="1" width="-1" type="actions"/>
+          <column type="field" width="-1" name="pk" hidden="0"/>
+          <column type="field" width="-1" name="name" hidden="0"/>
+          <column type="actions" width="-1" hidden="1"/>
         </columns>
       </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <storedexpressions/>
       <editform tolerant="1">../../../../../..</editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -690,20 +750,15 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer columnCount="0" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="0" name="ttt" showLabel="1"/>
+        <attributeEditorContainer columnCount="0" visibilityExpression="" name="ttt" showLabel="1" groupBox="0" visibilityExpressionEnabled="0"/>
       </attributeEditorForm>
       <editable/>
       <labelOnTop/>
       <widgets/>
-      <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
-      </conditionalstyles>
-      <expressionfields/>
       <previewExpression>name</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer autoRefreshTime="0" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingTol="1" readOnly="0" maxScale="0" minScale="1e+08" autoRefreshEnabled="0" hasScaleBasedVisibilityFlag="0" geometry="Polygon" type="vector" labelsEnabled="1" simplifyMaxScale="1" simplifyLocal="1">
+    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="0" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
       <extent>
         <xmin>-14746250.07513097859919071</xmin>
         <ymin>-112075.42807669920148328</ymin>
@@ -718,6 +773,7 @@ def my_form_open(dialog, layer, feature):
       <layername>Hello_Filter_SubsetString</layername>
       <srs>
         <spatialrefsys>
+          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
           <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
@@ -740,6 +796,7 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -747,7 +804,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -762,10 +819,15 @@ def my_form_open(dialog, layer, feature):
         <map-layer-style name="default"/>
       </map-layer-style-manager>
       <auxiliaryLayer/>
-      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0">
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
         <symbols>
-          <symbol name="0" alpha="1" clip_to_extent="1" type="fill">
-            <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
               <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
               <prop v="178,178,178,255" k="color"/>
               <prop v="bevel" k="joinstyle"/>
@@ -779,13 +841,13 @@ def my_form_open(dialog, layer, feature):
               <prop v="solid" k="style"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
               <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
               <prop v="230,85,192,255" k="color"/>
               <prop v="bevel" k="joinstyle"/>
@@ -799,9 +861,9 @@ def my_form_open(dialog, layer, feature):
               <prop v="solid" k="style"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -811,27 +873,31 @@ def my_form_open(dialog, layer, feature):
         <sizescale/>
       </renderer-v2>
       <customproperties>
-        <property value="_fields_" key="variableNames"/>
-        <property value="" key="variableValues"/>
+        <property key="variableNames" value="_fields_"/>
+        <property key="variableValues" value=""/>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory lineSizeType="MM" backgroundAlpha="255" height="15" barWidth="5" rotationOffset="270" scaleDependency="Area" diagramOrientation="Up" sizeScale="3x:0,0,0,0,0,0" penAlpha="255" minScaleDenominator="0" minimumSize="0" enabled="0" lineSizeScale="3x:0,0,0,0,0,0" penWidth="0" sizeType="MM" scaleBasedVisibility="0" opacity="1" maxScaleDenominator="1e+08" width="15" backgroundColor="#ffffff" penColor="#000000" labelPlacementMethod="XHeight">
+        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
           <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+          <attribute color="#000000" label="" field=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" dist="0" linePlacementFlags="10" showAll="1" placement="0" priority="0" zIndex="0">
+      <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
         <properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
+            <Option type="QString" name="name" value=""/>
             <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
+            <Option type="QString" name="type" value="collection"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks/>
+        <checkConfiguration/>
+      </geometryOptions>
       <fieldConfiguration>
         <field name="pk">
           <editWidget type="">
@@ -856,38 +922,44 @@ def my_form_open(dialog, layer, feature):
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="pk"/>
-        <alias name="" index="1" field="pkuid"/>
-        <alias name="" index="2" field="color"/>
+        <alias name="" field="pk" index="0"/>
+        <alias name="" field="pkuid" index="1"/>
+        <alias name="" field="color" index="2"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default applyOnUpdate="0" expression="" field="pk"/>
-        <default applyOnUpdate="0" expression="" field="pkuid"/>
-        <default applyOnUpdate="0" expression="" field="color"/>
+        <default applyOnUpdate="0" field="pk" expression=""/>
+        <default applyOnUpdate="0" field="pkuid" expression=""/>
+        <default applyOnUpdate="0" field="color" expression=""/>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" constraints="3" exp_strength="0" field="pk" unique_strength="1"/>
-        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pkuid" unique_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="color" unique_strength="0"/>
+        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
+        <constraint constraints="0" notnull_strength="0" field="pkuid" exp_strength="0" unique_strength="0"/>
+        <constraint constraints="0" notnull_strength="0" field="color" exp_strength="0" unique_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" field="pk" desc=""/>
-        <constraint exp="" field="pkuid" desc=""/>
-        <constraint exp="" field="color" desc=""/>
+        <constraint field="pk" desc="" exp=""/>
+        <constraint field="pkuid" desc="" exp=""/>
+        <constraint field="color" desc="" exp=""/>
       </constraintExpressions>
+      <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column name="pk" hidden="0" width="-1" type="field"/>
-          <column name="pkuid" hidden="0" width="-1" type="field"/>
-          <column name="color" hidden="0" width="-1" type="field"/>
-          <column hidden="1" width="-1" type="actions"/>
+          <column type="field" width="-1" name="pk" hidden="0"/>
+          <column type="field" width="-1" name="pkuid" hidden="0"/>
+          <column type="field" width="-1" name="color" hidden="0"/>
+          <column type="actions" width="-1" hidden="1"/>
         </columns>
       </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <storedexpressions/>
       <editform tolerant="1">../../../../../..</editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -912,27 +984,22 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer columnCount="0" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="0" name="t" showLabel="1">
-          <attributeEditorContainer columnCount="0" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" name="c1" showLabel="1">
-            <attributeEditorField name="pkuid" index="1" showLabel="1"/>
+        <attributeEditorContainer columnCount="0" visibilityExpression="" name="t" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
+          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c1" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+            <attributeEditorField name="pkuid" showLabel="1" index="1"/>
           </attributeEditorContainer>
-          <attributeEditorContainer columnCount="0" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" name="c2" showLabel="1">
-            <attributeEditorField name="color" index="2" showLabel="1"/>
+          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c2" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+            <attributeEditorField name="color" showLabel="1" index="2"/>
           </attributeEditorContainer>
         </attributeEditorContainer>
       </attributeEditorForm>
       <editable/>
       <labelOnTop/>
       <widgets/>
-      <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
-      </conditionalstyles>
-      <expressionfields/>
       <previewExpression>"pkuid"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer autoRefreshTime="0" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingTol="1" readOnly="0" maxScale="-4.65661e-10" minScale="1e+08" autoRefreshEnabled="0" hasScaleBasedVisibilityFlag="0" geometry="Polygon" type="vector" labelsEnabled="1" simplifyMaxScale="1" simplifyLocal="1">
+    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="-4.65661e-10" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
       <extent>
         <xmin>-2465695.66895584994927049</xmin>
         <ymin>80258.53580146089370828</ymin>
@@ -947,6 +1014,7 @@ def my_form_open(dialog, layer, feature):
       <layername>Hello_Project_SubsetString</layername>
       <srs>
         <spatialrefsys>
+          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
           <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
@@ -969,6 +1037,7 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -976,7 +1045,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -991,10 +1060,15 @@ def my_form_open(dialog, layer, feature):
         <map-layer-style name="default"/>
       </map-layer-style-manager>
       <auxiliaryLayer/>
-      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0">
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
         <symbols>
-          <symbol name="0" alpha="1" clip_to_extent="1" type="fill">
-            <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
               <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
               <prop v="178,178,178,255" k="color"/>
               <prop v="bevel" k="joinstyle"/>
@@ -1008,13 +1082,13 @@ def my_form_open(dialog, layer, feature):
               <prop v="solid" k="style"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
               <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
               <prop v="230,85,192,255" k="color"/>
               <prop v="bevel" k="joinstyle"/>
@@ -1028,9 +1102,9 @@ def my_form_open(dialog, layer, feature):
               <prop v="solid" k="style"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -1040,27 +1114,31 @@ def my_form_open(dialog, layer, feature):
         <sizescale/>
       </renderer-v2>
       <customproperties>
-        <property value="_fields_" key="variableNames"/>
-        <property value="" key="variableValues"/>
+        <property key="variableNames" value="_fields_"/>
+        <property key="variableValues" value=""/>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory lineSizeType="MM" backgroundAlpha="255" height="15" barWidth="5" rotationOffset="270" scaleDependency="Area" diagramOrientation="Up" sizeScale="3x:0,0,0,0,0,0" penAlpha="255" minScaleDenominator="-4.65661e-10" minimumSize="0" enabled="0" lineSizeScale="3x:0,0,0,0,0,0" penWidth="0" sizeType="MM" scaleBasedVisibility="0" opacity="1" maxScaleDenominator="1e+08" width="15" backgroundColor="#ffffff" penColor="#000000" labelPlacementMethod="XHeight">
+        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="-4.65661e-10" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
           <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+          <attribute color="#000000" label="" field=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" dist="0" linePlacementFlags="10" showAll="1" placement="0" priority="0" zIndex="0">
+      <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
         <properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
+            <Option type="QString" name="name" value=""/>
             <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
+            <Option type="QString" name="type" value="collection"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks/>
+        <checkConfiguration/>
+      </geometryOptions>
       <fieldConfiguration>
         <field name="pk">
           <editWidget type="">
@@ -1085,33 +1163,39 @@ def my_form_open(dialog, layer, feature):
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="pk"/>
-        <alias name="" index="1" field="pkuid"/>
-        <alias name="" index="2" field="color"/>
+        <alias name="" field="pk" index="0"/>
+        <alias name="" field="pkuid" index="1"/>
+        <alias name="" field="color" index="2"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default applyOnUpdate="0" expression="" field="pk"/>
-        <default applyOnUpdate="0" expression="" field="pkuid"/>
-        <default applyOnUpdate="0" expression="" field="color"/>
+        <default applyOnUpdate="0" field="pk" expression=""/>
+        <default applyOnUpdate="0" field="pkuid" expression=""/>
+        <default applyOnUpdate="0" field="color" expression=""/>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" constraints="3" exp_strength="0" field="pk" unique_strength="1"/>
-        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pkuid" unique_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="color" unique_strength="0"/>
+        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
+        <constraint constraints="0" notnull_strength="0" field="pkuid" exp_strength="0" unique_strength="0"/>
+        <constraint constraints="0" notnull_strength="0" field="color" exp_strength="0" unique_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" field="pk" desc=""/>
-        <constraint exp="" field="pkuid" desc=""/>
-        <constraint exp="" field="color" desc=""/>
+        <constraint field="pk" desc="" exp=""/>
+        <constraint field="pkuid" desc="" exp=""/>
+        <constraint field="color" desc="" exp=""/>
       </constraintExpressions>
+      <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns/>
       </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <storedexpressions/>
       <editform tolerant="1">../../../../../..</editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -1136,27 +1220,266 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer columnCount="0" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="0" name="t" showLabel="1">
-          <attributeEditorContainer columnCount="0" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" name="c1" showLabel="1">
-            <attributeEditorField name="pkuid" index="1" showLabel="1"/>
+        <attributeEditorContainer columnCount="0" visibilityExpression="" name="t" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
+          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c1" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+            <attributeEditorField name="pkuid" showLabel="1" index="1"/>
           </attributeEditorContainer>
-          <attributeEditorContainer columnCount="0" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" name="c2" showLabel="1">
-            <attributeEditorField name="color" index="2" showLabel="1"/>
+          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c2" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+            <attributeEditorField name="color" showLabel="1" index="2"/>
           </attributeEditorContainer>
         </attributeEditorContainer>
       </attributeEditorForm>
       <editable/>
       <labelOnTop/>
       <widgets/>
+      <previewExpression>"pkuid"</previewExpression>
+      <mapTip></mapTip>
+    </maplayer>
+    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="0" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
+      <extent>
+        <xmin>-14746250.07513097859919071</xmin>
+        <ymin>-112075.42807669920148328</ymin>
+        <xmax>11342200.07719692215323448</xmax>
+        <ymax>10914413.7141284141689539</ymax>
+      </extent>
+      <id>Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9</id>
+      <datasource>dbname='./helloworld.db' table="hello" (geom) sql=</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>Hello_Filter</layername>
+      <srs>
+        <spatialrefsys>
+          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+          <srsid>3857</srsid>
+          <srid>3857</srid>
+          <authid>EPSG:3857</authid>
+          <description>WGS 84 / Pseudo-Mercator</description>
+          <projectionacronym>merc</projectionacronym>
+          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <geographicflag>false</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type></type>
+        <title></title>
+        <abstract></abstract>
+        <links/>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys>
+            <wkt></wkt>
+            <proj4></proj4>
+            <srsid>0</srsid>
+            <srid>0</srid>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
+            <geographicflag>false</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent/>
+      </resourceMetadata>
+      <provider encoding="UTF-8">spatialite</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <legend type="default-vector"/>
+      <expressionfields/>
+      <map-layer-style-manager current="default">
+        <map-layer-style name="default"/>
+      </map-layer-style-manager>
+      <auxiliaryLayer/>
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
+        <symbols>
+          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
+              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+              <prop v="178,178,178,255" k="color"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="0.80000000000000004,0.80000000000000004" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="121,121,121,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0.26" k="outline_width"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="solid" k="style"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" name="name" value=""/>
+                  <Option name="properties"/>
+                  <Option type="QString" name="type" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
+              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+              <prop v="230,85,192,255" k="color"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="0,0,0,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0.26" k="outline_width"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="solid" k="style"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" name="name" value=""/>
+                  <Option name="properties"/>
+                  <Option type="QString" name="type" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation/>
+        <sizescale/>
+      </renderer-v2>
+      <customproperties>
+        <property key="dualview/previewExpressions">
+          <value>"pkuid"</value>
+        </property>
+        <property key="variableNames" value="_fields_"/>
+        <property key="variableValues" value=""/>
+      </customproperties>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerOpacity>1</layerOpacity>
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
+          <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute color="#000000" label="" field=""/>
+        </DiagramCategory>
+      </SingleCategoryDiagramRenderer>
+      <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
+        <properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </properties>
+      </DiagramLayerSettings>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks/>
+        <checkConfiguration/>
+      </geometryOptions>
+      <fieldConfiguration>
+        <field name="pk">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="pkuid">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="color">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias name="" field="pk" index="0"/>
+        <alias name="" field="pkuid" index="1"/>
+        <alias name="" field="color" index="2"/>
+      </aliases>
+      <excludeAttributesWMS/>
+      <excludeAttributesWFS/>
+      <defaults>
+        <default applyOnUpdate="0" field="pk" expression=""/>
+        <default applyOnUpdate="0" field="pkuid" expression=""/>
+        <default applyOnUpdate="0" field="color" expression=""/>
+      </defaults>
+      <constraints>
+        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
+        <constraint constraints="0" notnull_strength="0" field="pkuid" exp_strength="0" unique_strength="0"/>
+        <constraint constraints="0" notnull_strength="0" field="color" exp_strength="0" unique_strength="0"/>
+      </constraints>
+      <constraintExpressions>
+        <constraint field="pk" desc="" exp=""/>
+        <constraint field="pkuid" desc="" exp=""/>
+        <constraint field="color" desc="" exp=""/>
+      </constraintExpressions>
+      <expressionfields/>
+      <attributeactions>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+      </attributeactions>
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+        <columns>
+          <column type="field" width="-1" name="pk" hidden="0"/>
+          <column type="field" width="-1" name="pkuid" hidden="0"/>
+          <column type="field" width="-1" name="color" hidden="0"/>
+          <column type="actions" width="-1" hidden="1"/>
+        </columns>
+      </attributetableconfig>
       <conditionalstyles>
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <expressionfields/>
+      <storedexpressions/>
+      <editform tolerant="1">../../../../../..</editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath></editforminitfilepath>
+      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from PyQt4.QtGui import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <attributeEditorForm>
+        <attributeEditorContainer columnCount="0" visibilityExpression="" name="t" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
+          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c1" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+            <attributeEditorField name="pkuid" showLabel="1" index="1"/>
+          </attributeEditorContainer>
+          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c2" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+            <attributeEditorField name="color" showLabel="1" index="2"/>
+          </attributeEditorContainer>
+        </attributeEditorContainer>
+      </attributeEditorForm>
+      <editable/>
+      <labelOnTop/>
+      <widgets/>
       <previewExpression>"pkuid"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer autoRefreshTime="0" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingTol="1" readOnly="0" maxScale="0" minScale="1e+08" autoRefreshEnabled="0" hasScaleBasedVisibilityFlag="0" geometry="Polygon" type="vector" labelsEnabled="1" simplifyMaxScale="1" simplifyLocal="1">
+    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="0" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
       <extent>
         <xmin>-14746250.07513097859919071</xmin>
         <ymin>-112075.42807669920148328</ymin>
@@ -1171,6 +1494,7 @@ def my_form_open(dialog, layer, feature):
       <layername>Hello_SubsetString</layername>
       <srs>
         <spatialrefsys>
+          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
           <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
@@ -1193,6 +1517,7 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -1200,7 +1525,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -1215,10 +1540,15 @@ def my_form_open(dialog, layer, feature):
         <map-layer-style name="default"/>
       </map-layer-style-manager>
       <auxiliaryLayer/>
-      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0">
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
         <symbols>
-          <symbol name="0" alpha="1" clip_to_extent="1" type="fill">
-            <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
               <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
               <prop v="178,178,178,255" k="color"/>
               <prop v="bevel" k="joinstyle"/>
@@ -1232,13 +1562,13 @@ def my_form_open(dialog, layer, feature):
               <prop v="solid" k="style"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
               <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
               <prop v="230,85,192,255" k="color"/>
               <prop v="bevel" k="joinstyle"/>
@@ -1252,9 +1582,9 @@ def my_form_open(dialog, layer, feature):
               <prop v="solid" k="style"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -1264,27 +1594,31 @@ def my_form_open(dialog, layer, feature):
         <sizescale/>
       </renderer-v2>
       <customproperties>
-        <property value="_fields_" key="variableNames"/>
-        <property value="" key="variableValues"/>
+        <property key="variableNames" value="_fields_"/>
+        <property key="variableValues" value=""/>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory lineSizeType="MM" backgroundAlpha="255" height="15" barWidth="5" rotationOffset="270" scaleDependency="Area" diagramOrientation="Up" sizeScale="3x:0,0,0,0,0,0" penAlpha="255" minScaleDenominator="0" minimumSize="0" enabled="0" lineSizeScale="3x:0,0,0,0,0,0" penWidth="0" sizeType="MM" scaleBasedVisibility="0" opacity="1" maxScaleDenominator="1e+08" width="15" backgroundColor="#ffffff" penColor="#000000" labelPlacementMethod="XHeight">
+        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
           <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+          <attribute color="#000000" label="" field=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" dist="0" linePlacementFlags="10" showAll="1" placement="0" priority="0" zIndex="0">
+      <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
         <properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
+            <Option type="QString" name="name" value=""/>
             <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
+            <Option type="QString" name="type" value="collection"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks/>
+        <checkConfiguration/>
+      </geometryOptions>
       <fieldConfiguration>
         <field name="pk">
           <editWidget type="">
@@ -1309,33 +1643,39 @@ def my_form_open(dialog, layer, feature):
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="pk"/>
-        <alias name="" index="1" field="pkuid"/>
-        <alias name="" index="2" field="color"/>
+        <alias name="" field="pk" index="0"/>
+        <alias name="" field="pkuid" index="1"/>
+        <alias name="" field="color" index="2"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default applyOnUpdate="0" expression="" field="pk"/>
-        <default applyOnUpdate="0" expression="" field="pkuid"/>
-        <default applyOnUpdate="0" expression="" field="color"/>
+        <default applyOnUpdate="0" field="pk" expression=""/>
+        <default applyOnUpdate="0" field="pkuid" expression=""/>
+        <default applyOnUpdate="0" field="color" expression=""/>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" constraints="3" exp_strength="0" field="pk" unique_strength="1"/>
-        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pkuid" unique_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="color" unique_strength="0"/>
+        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
+        <constraint constraints="0" notnull_strength="0" field="pkuid" exp_strength="0" unique_strength="0"/>
+        <constraint constraints="0" notnull_strength="0" field="color" exp_strength="0" unique_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" field="pk" desc=""/>
-        <constraint exp="" field="pkuid" desc=""/>
-        <constraint exp="" field="color" desc=""/>
+        <constraint field="pk" desc="" exp=""/>
+        <constraint field="pkuid" desc="" exp=""/>
+        <constraint field="color" desc="" exp=""/>
       </constraintExpressions>
+      <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns/>
       </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <storedexpressions/>
       <editform tolerant="1">../../../../../..</editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -1360,27 +1700,22 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer columnCount="0" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="0" name="t" showLabel="1">
-          <attributeEditorContainer columnCount="0" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" name="c1" showLabel="1">
-            <attributeEditorField name="pkuid" index="1" showLabel="1"/>
+        <attributeEditorContainer columnCount="0" visibilityExpression="" name="t" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
+          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c1" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+            <attributeEditorField name="pkuid" showLabel="1" index="1"/>
           </attributeEditorContainer>
-          <attributeEditorContainer columnCount="0" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" name="c2" showLabel="1">
-            <attributeEditorField name="color" index="2" showLabel="1"/>
+          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c2" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+            <attributeEditorField name="color" showLabel="1" index="2"/>
           </attributeEditorContainer>
         </attributeEditorContainer>
       </attributeEditorForm>
       <editable/>
       <labelOnTop/>
       <widgets/>
-      <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
-      </conditionalstyles>
-      <expressionfields/>
       <previewExpression>"pkuid"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer autoRefreshTime="0" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingTol="1" readOnly="0" maxScale="0" minScale="1e+08" autoRefreshEnabled="0" hasScaleBasedVisibilityFlag="0" geometry="Polygon" type="vector" labelsEnabled="0" simplifyMaxScale="1" simplifyLocal="1">
+    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="0" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="0" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
       <extent>
         <xmin>-14746250.07513097859919071</xmin>
         <ymin>-112075.42807669920148328</ymin>
@@ -1395,6 +1730,7 @@ def my_form_open(dialog, layer, feature):
       <layername>Hello_OnOff</layername>
       <srs>
         <spatialrefsys>
+          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
           <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
@@ -1426,6 +1762,7 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -1433,11 +1770,11 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial minz="0" crs="" dimensions="2" maxy="0" miny="0" maxx="0" minx="0" maxz="0"/>
+          <spatial maxx="0" maxz="0" crs="" minz="0" maxy="0" miny="0" dimensions="2" minx="0"/>
           <temporal>
             <period>
               <start></start>
@@ -1454,11 +1791,11 @@ def my_form_open(dialog, layer, feature):
       <expressionfields/>
       <map-layer-style-manager current="défaut">
         <map-layer-style name="default">
-          <qgis simplifyDrawingHints="1" version="3.3.0-Master" simplifyDrawingTol="1" simplifyAlgorithm="0" readOnly="0" maxScale="0" minScale="1e+08" hasScaleBasedVisibilityFlag="0" labelsEnabled="1" simplifyMaxScale="1" simplifyLocal="1">
-            <renderer-v2 enableorderby="0" forceraster="0" type="singleSymbol" symbollevels="0">
+          <qgis maxScale="0" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" readOnly="0" simplifyDrawingHints="1" simplifyAlgorithm="0" version="3.3.0-Master" minScale="1e+08" simplifyMaxScale="1" labelsEnabled="1" simplifyLocal="1">
+            <renderer-v2 type="singleSymbol" enableorderby="0" symbollevels="0" forceraster="0">
               <symbols>
-                <symbol name="0" alpha="1" clip_to_extent="1" type="fill">
-                  <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+                <symbol type="fill" alpha="1" clip_to_extent="1" name="0">
+                  <layer class="SimpleFill" enabled="1" pass="0" locked="0">
                     <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
                     <prop v="178,178,178,255" k="color"/>
                     <prop v="bevel" k="joinstyle"/>
@@ -1472,13 +1809,13 @@ def my_form_open(dialog, layer, feature):
                     <prop v="solid" k="style"/>
                     <data_defined_properties>
                       <Option type="Map">
-                        <Option name="name" value="" type="QString"/>
+                        <Option type="QString" name="name" value=""/>
                         <Option name="properties"/>
-                        <Option name="type" value="collection" type="QString"/>
+                        <Option type="QString" name="type" value="collection"/>
                       </Option>
                     </data_defined_properties>
                   </layer>
-                  <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+                  <layer class="SimpleFill" enabled="1" pass="0" locked="0">
                     <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
                     <prop v="230,85,192,255" k="color"/>
                     <prop v="bevel" k="joinstyle"/>
@@ -1492,9 +1829,9 @@ def my_form_open(dialog, layer, feature):
                     <prop v="solid" k="style"/>
                     <data_defined_properties>
                       <Option type="Map">
-                        <Option name="name" value="" type="QString"/>
+                        <Option type="QString" name="name" value=""/>
                         <Option name="properties"/>
-                        <Option name="type" value="collection" type="QString"/>
+                        <Option type="QString" name="type" value="collection"/>
                       </Option>
                     </data_defined_properties>
                   </layer>
@@ -1508,17 +1845,17 @@ def my_form_open(dialog, layer, feature):
             <featureBlendMode>0</featureBlendMode>
             <layerOpacity>1</layerOpacity>
             <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-              <DiagramCategory lineSizeType="MM" backgroundAlpha="255" barWidth="5" height="15" rotationOffset="270" diagramOrientation="Up" scaleDependency="Area" sizeScale="3x:0,0,0,0,0,0" penAlpha="255" minScaleDenominator="0" minimumSize="0" enabled="0" lineSizeScale="3x:0,0,0,0,0,0" penWidth="0" sizeType="MM" scaleBasedVisibility="0" opacity="1" maxScaleDenominator="1e+08" width="15" backgroundColor="#ffffff" penColor="#000000" labelPlacementMethod="XHeight">
+              <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+08">
                 <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-                <attribute label="" field="" color="#000000"/>
+                <attribute color="#000000" label="" field=""/>
               </DiagramCategory>
             </SingleCategoryDiagramRenderer>
-            <DiagramLayerSettings obstacle="0" dist="0" linePlacementFlags="10" showAll="1" placement="0" priority="0" zIndex="0">
+            <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
               <properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </properties>
             </DiagramLayerSettings>
@@ -1546,29 +1883,29 @@ def my_form_open(dialog, layer, feature):
               </field>
             </fieldConfiguration>
             <aliases>
-              <alias name="" index="0" field="pk"/>
-              <alias name="" index="1" field="pkuid"/>
-              <alias name="" index="2" field="color"/>
+              <alias name="" field="pk" index="0"/>
+              <alias name="" field="pkuid" index="1"/>
+              <alias name="" field="color" index="2"/>
             </aliases>
             <excludeAttributesWMS/>
             <excludeAttributesWFS/>
             <defaults>
-              <default applyOnUpdate="0" expression="" field="pk"/>
-              <default applyOnUpdate="0" expression="" field="pkuid"/>
-              <default applyOnUpdate="0" expression="" field="color"/>
+              <default applyOnUpdate="0" field="pk" expression=""/>
+              <default applyOnUpdate="0" field="pkuid" expression=""/>
+              <default applyOnUpdate="0" field="color" expression=""/>
             </defaults>
             <constraints>
-              <constraint notnull_strength="1" constraints="3" exp_strength="0" field="pk" unique_strength="1"/>
-              <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pkuid" unique_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" exp_strength="0" field="color" unique_strength="0"/>
+              <constraint constraints="3" notnull_strength="1" exp_strength="0" field="pk" unique_strength="1"/>
+              <constraint constraints="0" notnull_strength="0" exp_strength="0" field="pkuid" unique_strength="0"/>
+              <constraint constraints="0" notnull_strength="0" exp_strength="0" field="color" unique_strength="0"/>
             </constraints>
             <constraintExpressions>
-              <constraint exp="" field="pk" desc=""/>
-              <constraint exp="" field="pkuid" desc=""/>
-              <constraint exp="" field="color" desc=""/>
+              <constraint field="pk" desc="" exp=""/>
+              <constraint field="pkuid" desc="" exp=""/>
+              <constraint field="color" desc="" exp=""/>
             </constraintExpressions>
             <attributeactions>
-              <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+              <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
             </attributeactions>
             <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
               <columns/>
@@ -1581,12 +1918,12 @@ def my_form_open(dialog, layer, feature):
             <featformsuppress>0</featformsuppress>
             <editorlayout>generatedlayout</editorlayout>
             <attributeEditorForm>
-              <attributeEditorContainer visibilityExpressionEnabled="0" columnCount="0" visibilityExpression="" groupBox="0" name="t" showLabel="1">
-                <attributeEditorContainer visibilityExpressionEnabled="0" columnCount="0" visibilityExpression="" groupBox="1" name="c1" showLabel="1">
-                  <attributeEditorField name="pkuid" index="1" showLabel="1"/>
+              <attributeEditorContainer columnCount="0" visibilityExpression="" name="t" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
+                <attributeEditorContainer columnCount="0" visibilityExpression="" name="c1" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+                  <attributeEditorField name="pkuid" showLabel="1" index="1"/>
                 </attributeEditorContainer>
-                <attributeEditorContainer visibilityExpressionEnabled="0" columnCount="0" visibilityExpression="" groupBox="1" name="c2" showLabel="1">
-                  <attributeEditorField name="color" index="2" showLabel="1"/>
+                <attributeEditorContainer columnCount="0" visibilityExpression="" name="c2" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+                  <attributeEditorField name="color" showLabel="1" index="2"/>
                 </attributeEditorContainer>
               </attributeEditorContainer>
             </attributeEditorForm>
@@ -1606,10 +1943,15 @@ def my_form_open(dialog, layer, feature):
         <map-layer-style name="défaut"/>
       </map-layer-style-manager>
       <auxiliaryLayer/>
-      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0">
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
         <symbols>
-          <symbol name="0" alpha="1" clip_to_extent="1" type="fill">
-            <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
               <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
               <prop v="178,178,178,255" k="color"/>
               <prop v="bevel" k="joinstyle"/>
@@ -1623,13 +1965,13 @@ def my_form_open(dialog, layer, feature):
               <prop v="solid" k="style"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
               <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
               <prop v="230,85,192,255" k="color"/>
               <prop v="bevel" k="joinstyle"/>
@@ -1643,9 +1985,9 @@ def my_form_open(dialog, layer, feature):
               <prop v="solid" k="style"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -1655,7 +1997,7 @@ def my_form_open(dialog, layer, feature):
         <sizescale/>
       </renderer-v2>
       <customproperties>
-        <property value="0" key="embeddedWidgets/count"/>
+        <property key="embeddedWidgets/count" value="0"/>
         <property key="variableNames"/>
         <property key="variableValues"/>
       </customproperties>
@@ -1663,20 +2005,24 @@ def my_form_open(dialog, layer, feature):
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory lineSizeType="MM" backgroundAlpha="255" height="15" barWidth="5" rotationOffset="270" scaleDependency="Area" diagramOrientation="Up" sizeScale="3x:0,0,0,0,0,0" penAlpha="255" minScaleDenominator="0" minimumSize="0" enabled="0" lineSizeScale="3x:0,0,0,0,0,0" penWidth="0" sizeType="MM" scaleBasedVisibility="0" opacity="1" maxScaleDenominator="1e+08" width="15" backgroundColor="#ffffff" penColor="#000000" labelPlacementMethod="XHeight">
+        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
           <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+          <attribute color="#000000" label="" field=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" dist="0" linePlacementFlags="2" showAll="1" placement="0" priority="0" zIndex="0">
+      <DiagramLayerSettings obstacle="0" linePlacementFlags="2" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
         <properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
+            <Option type="QString" name="name" value=""/>
             <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
+            <Option type="QString" name="type" value="collection"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks/>
+        <checkConfiguration/>
+      </geometryOptions>
       <fieldConfiguration>
         <field name="pk">
           <editWidget type="TextEdit">
@@ -1701,38 +2047,44 @@ def my_form_open(dialog, layer, feature):
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="pk"/>
-        <alias name="" index="1" field="pkuid"/>
-        <alias name="" index="2" field="color"/>
+        <alias name="" field="pk" index="0"/>
+        <alias name="" field="pkuid" index="1"/>
+        <alias name="" field="color" index="2"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default applyOnUpdate="0" expression="" field="pk"/>
-        <default applyOnUpdate="0" expression="" field="pkuid"/>
-        <default applyOnUpdate="0" expression="" field="color"/>
+        <default applyOnUpdate="0" field="pk" expression=""/>
+        <default applyOnUpdate="0" field="pkuid" expression=""/>
+        <default applyOnUpdate="0" field="color" expression=""/>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" constraints="3" exp_strength="0" field="pk" unique_strength="1"/>
-        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pkuid" unique_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="color" unique_strength="0"/>
+        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
+        <constraint constraints="0" notnull_strength="0" field="pkuid" exp_strength="0" unique_strength="0"/>
+        <constraint constraints="0" notnull_strength="0" field="color" exp_strength="0" unique_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" field="pk" desc=""/>
-        <constraint exp="" field="pkuid" desc=""/>
-        <constraint exp="" field="color" desc=""/>
+        <constraint field="pk" desc="" exp=""/>
+        <constraint field="pkuid" desc="" exp=""/>
+        <constraint field="color" desc="" exp=""/>
       </constraintExpressions>
+      <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column name="pk" hidden="0" width="-1" type="field"/>
-          <column name="pkuid" hidden="0" width="-1" type="field"/>
-          <column name="color" hidden="0" width="-1" type="field"/>
-          <column hidden="1" width="-1" type="actions"/>
+          <column type="field" width="-1" name="pk" hidden="0"/>
+          <column type="field" width="-1" name="pkuid" hidden="0"/>
+          <column type="field" width="-1" name="color" hidden="0"/>
+          <column type="actions" width="-1" hidden="1"/>
         </columns>
       </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <storedexpressions/>
       <editform tolerant="1">../../../../../..</editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -1748,12 +2100,12 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer columnCount="0" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="0" name="t" showLabel="1">
-          <attributeEditorContainer columnCount="0" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" name="c1" showLabel="1">
-            <attributeEditorField name="pkuid" index="1" showLabel="1"/>
+        <attributeEditorContainer columnCount="0" visibilityExpression="" name="t" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
+          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c1" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+            <attributeEditorField name="pkuid" showLabel="1" index="1"/>
           </attributeEditorContainer>
-          <attributeEditorContainer columnCount="0" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" name="c2" showLabel="1">
-            <attributeEditorField name="color" index="2" showLabel="1"/>
+          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c2" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+            <attributeEditorField name="color" showLabel="1" index="2"/>
           </attributeEditorContainer>
         </attributeEditorContainer>
       </attributeEditorForm>
@@ -1768,15 +2120,10 @@ def my_form_open(dialog, layer, feature):
         <field name="pkuid" labelOnTop="0"/>
       </labelOnTop>
       <widgets/>
-      <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
-      </conditionalstyles>
-      <expressionfields/>
       <previewExpression>COALESCE( "pkuid", '&lt;NULL>' )</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer autoRefreshTime="0" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingTol="1" readOnly="0" maxScale="-4.65661e-10" minScale="1e+08" autoRefreshEnabled="0" hasScaleBasedVisibilityFlag="0" geometry="Polygon" type="vector" labelsEnabled="1" simplifyMaxScale="1" simplifyLocal="1">
+    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="-4.65661e-10" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
       <extent>
         <xmin>-19619892.68012013286352158</xmin>
         <ymin>-10327100.34232237376272678</ymin>
@@ -1791,6 +2138,7 @@ def my_form_open(dialog, layer, feature):
       <layername>Country</layername>
       <srs>
         <spatialrefsys>
+          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
           <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
@@ -1813,6 +2161,7 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -1820,7 +2169,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -1834,19 +2183,19 @@ def my_form_open(dialog, layer, feature):
       <map-layer-style-manager current="default">
         <map-layer-style name="default"/>
         <map-layer-style name="origin">
-          <qgis simplifyDrawingHints="1" maximumScale="1e+08" version="2.9.0-Master" simplifyDrawingTol="1" scaleBasedLabelVisibilityFlag="0" hasScaleBasedVisibilityFlag="0" minLabelScale="1" minimumScale="-4.65661e-10" simplifyMaxScale="1" maxLabelScale="1e+08" simplifyLocal="1">
+          <qgis scaleBasedLabelVisibilityFlag="0" maximumScale="1e+08" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" maxLabelScale="1e+08" simplifyDrawingHints="1" version="2.9.0-Master" minimumScale="-4.65661e-10" simplifyMaxScale="1" minLabelScale="1" simplifyLocal="1">
             <edittypes>
               <edittype name="pk" widgetv2type="TextEdit">
-                <widgetv2config UseHtml="0" fieldEditable="1" IsMultiline="0" labelOnTop="0"/>
+                <widgetv2config fieldEditable="1" IsMultiline="0" labelOnTop="0" UseHtml="0"/>
               </edittype>
               <edittype name="name" widgetv2type="TextEdit">
-                <widgetv2config UseHtml="0" fieldEditable="1" IsMultiline="0" labelOnTop="0"/>
+                <widgetv2config fieldEditable="1" IsMultiline="0" labelOnTop="0" UseHtml="0"/>
               </edittype>
             </edittypes>
             <renderer-v2 type="singleSymbol" symbollevels="0">
               <symbols>
-                <symbol name="0" alpha="1" clip_to_extent="1" type="fill">
-                  <layer pass="0" class="SimpleFill" locked="0">
+                <symbol type="fill" alpha="1" clip_to_extent="1" name="0">
+                  <layer class="SimpleFill" pass="0" locked="0">
                     <prop v="0,0" k="border_width_map_unit_scale"/>
                     <prop v="186,221,105,255" k="color"/>
                     <prop v="bevel" k="joinstyle"/>
@@ -1858,7 +2207,7 @@ def my_form_open(dialog, layer, feature):
                     <prop v="0.26" k="outline_width"/>
                     <prop v="MM" k="outline_width_unit"/>
                     <prop v="solid" k="style"/>
-                    <effect enabled="0" type="effectStack">
+                    <effect type="effectStack" enabled="0">
                       <effect type="drawSource">
                         <prop v="0" k="blend_mode"/>
                         <prop v="2" k="draw_mode"/>
@@ -1871,7 +2220,7 @@ def my_form_open(dialog, layer, feature):
               </symbols>
               <rotation/>
               <sizescale scalemethod="area"/>
-              <effect enabled="0" type="effectStack">
+              <effect type="effectStack" enabled="0">
                 <effect type="drawSource">
                   <prop v="0" k="blend_mode"/>
                   <prop v="2" k="draw_mode"/>
@@ -1881,147 +2230,147 @@ def my_form_open(dialog, layer, feature):
               </effect>
             </renderer-v2>
             <customproperties>
-              <property value="pal" key="labeling"/>
-              <property value="false" key="labeling/addDirectionSymbol"/>
-              <property value="0" key="labeling/angleOffset"/>
-              <property value="0" key="labeling/blendMode"/>
-              <property value="0" key="labeling/bufferBlendMode"/>
-              <property value="255" key="labeling/bufferColorA"/>
-              <property value="255" key="labeling/bufferColorB"/>
-              <property value="255" key="labeling/bufferColorG"/>
-              <property value="255" key="labeling/bufferColorR"/>
-              <property value="false" key="labeling/bufferDraw"/>
-              <property value="64" key="labeling/bufferJoinStyle"/>
-              <property value="false" key="labeling/bufferNoFill"/>
-              <property value="1" key="labeling/bufferSize"/>
-              <property value="false" key="labeling/bufferSizeInMapUnits"/>
-              <property value="0" key="labeling/bufferSizeMapUnitMaxScale"/>
-              <property value="0" key="labeling/bufferSizeMapUnitMinScale"/>
-              <property value="0" key="labeling/bufferTransp"/>
-              <property value="false" key="labeling/centroidInside"/>
-              <property value="false" key="labeling/centroidWhole"/>
-              <property value="3" key="labeling/decimals"/>
-              <property value="false" key="labeling/displayAll"/>
-              <property value="0" key="labeling/dist"/>
-              <property value="false" key="labeling/distInMapUnits"/>
-              <property value="0" key="labeling/distMapUnitMaxScale"/>
-              <property value="0" key="labeling/distMapUnitMinScale"/>
-              <property value="false" key="labeling/enabled"/>
-              <property value="" key="labeling/fieldName"/>
-              <property value="false" key="labeling/fontBold"/>
-              <property value="0" key="labeling/fontCapitals"/>
-              <property value="Sans Serif" key="labeling/fontFamily"/>
-              <property value="false" key="labeling/fontItalic"/>
-              <property value="0" key="labeling/fontLetterSpacing"/>
-              <property value="false" key="labeling/fontLimitPixelSize"/>
-              <property value="10000" key="labeling/fontMaxPixelSize"/>
-              <property value="3" key="labeling/fontMinPixelSize"/>
-              <property value="9" key="labeling/fontSize"/>
-              <property value="false" key="labeling/fontSizeInMapUnits"/>
-              <property value="0" key="labeling/fontSizeMapUnitMaxScale"/>
-              <property value="0" key="labeling/fontSizeMapUnitMinScale"/>
-              <property value="false" key="labeling/fontStrikeout"/>
-              <property value="false" key="labeling/fontUnderline"/>
-              <property value="50" key="labeling/fontWeight"/>
-              <property value="0" key="labeling/fontWordSpacing"/>
-              <property value="false" key="labeling/formatNumbers"/>
-              <property value="true" key="labeling/isExpression"/>
-              <property value="true" key="labeling/labelOffsetInMapUnits"/>
-              <property value="0" key="labeling/labelOffsetMapUnitMaxScale"/>
-              <property value="0" key="labeling/labelOffsetMapUnitMinScale"/>
-              <property value="false" key="labeling/labelPerPart"/>
-              <property value="&lt;" key="labeling/leftDirectionSymbol"/>
-              <property value="false" key="labeling/limitNumLabels"/>
-              <property value="20" key="labeling/maxCurvedCharAngleIn"/>
-              <property value="-20" key="labeling/maxCurvedCharAngleOut"/>
-              <property value="2000" key="labeling/maxNumLabels"/>
-              <property value="false" key="labeling/mergeLines"/>
-              <property value="0" key="labeling/minFeatureSize"/>
-              <property value="0" key="labeling/multilineAlign"/>
-              <property value="1" key="labeling/multilineHeight"/>
-              <property value="Normal" key="labeling/namedStyle"/>
-              <property value="true" key="labeling/obstacle"/>
-              <property value="0" key="labeling/placeDirectionSymbol"/>
-              <property value="0" key="labeling/placement"/>
-              <property value="0" key="labeling/placementFlags"/>
-              <property value="false" key="labeling/plussign"/>
-              <property value="true" key="labeling/preserveRotation"/>
-              <property value="#ffffff" key="labeling/previewBkgrdColor"/>
-              <property value="5" key="labeling/priority"/>
-              <property value="4" key="labeling/quadOffset"/>
-              <property value="0" key="labeling/repeatDistance"/>
-              <property value="0" key="labeling/repeatDistanceMapUnitMaxScale"/>
-              <property value="0" key="labeling/repeatDistanceMapUnitMinScale"/>
-              <property value="1" key="labeling/repeatDistanceUnit"/>
-              <property value="false" key="labeling/reverseDirectionSymbol"/>
-              <property value=">" key="labeling/rightDirectionSymbol"/>
-              <property value="10000000" key="labeling/scaleMax"/>
-              <property value="1" key="labeling/scaleMin"/>
-              <property value="false" key="labeling/scaleVisibility"/>
-              <property value="6" key="labeling/shadowBlendMode"/>
-              <property value="0" key="labeling/shadowColorB"/>
-              <property value="0" key="labeling/shadowColorG"/>
-              <property value="0" key="labeling/shadowColorR"/>
-              <property value="false" key="labeling/shadowDraw"/>
-              <property value="135" key="labeling/shadowOffsetAngle"/>
-              <property value="1" key="labeling/shadowOffsetDist"/>
-              <property value="true" key="labeling/shadowOffsetGlobal"/>
-              <property value="0" key="labeling/shadowOffsetMapUnitMaxScale"/>
-              <property value="0" key="labeling/shadowOffsetMapUnitMinScale"/>
-              <property value="1" key="labeling/shadowOffsetUnits"/>
-              <property value="1.5" key="labeling/shadowRadius"/>
-              <property value="false" key="labeling/shadowRadiusAlphaOnly"/>
-              <property value="0" key="labeling/shadowRadiusMapUnitMaxScale"/>
-              <property value="0" key="labeling/shadowRadiusMapUnitMinScale"/>
-              <property value="1" key="labeling/shadowRadiusUnits"/>
-              <property value="100" key="labeling/shadowScale"/>
-              <property value="30" key="labeling/shadowTransparency"/>
-              <property value="0" key="labeling/shadowUnder"/>
-              <property value="0" key="labeling/shapeBlendMode"/>
-              <property value="255" key="labeling/shapeBorderColorA"/>
-              <property value="128" key="labeling/shapeBorderColorB"/>
-              <property value="128" key="labeling/shapeBorderColorG"/>
-              <property value="128" key="labeling/shapeBorderColorR"/>
-              <property value="0" key="labeling/shapeBorderWidth"/>
-              <property value="0" key="labeling/shapeBorderWidthMapUnitMaxScale"/>
-              <property value="0" key="labeling/shapeBorderWidthMapUnitMinScale"/>
-              <property value="1" key="labeling/shapeBorderWidthUnits"/>
-              <property value="false" key="labeling/shapeDraw"/>
-              <property value="255" key="labeling/shapeFillColorA"/>
-              <property value="255" key="labeling/shapeFillColorB"/>
-              <property value="255" key="labeling/shapeFillColorG"/>
-              <property value="255" key="labeling/shapeFillColorR"/>
-              <property value="64" key="labeling/shapeJoinStyle"/>
-              <property value="0" key="labeling/shapeOffsetMapUnitMaxScale"/>
-              <property value="0" key="labeling/shapeOffsetMapUnitMinScale"/>
-              <property value="1" key="labeling/shapeOffsetUnits"/>
-              <property value="0" key="labeling/shapeOffsetX"/>
-              <property value="0" key="labeling/shapeOffsetY"/>
-              <property value="0" key="labeling/shapeRadiiMapUnitMaxScale"/>
-              <property value="0" key="labeling/shapeRadiiMapUnitMinScale"/>
-              <property value="1" key="labeling/shapeRadiiUnits"/>
-              <property value="0" key="labeling/shapeRadiiX"/>
-              <property value="0" key="labeling/shapeRadiiY"/>
-              <property value="0" key="labeling/shapeRotation"/>
-              <property value="0" key="labeling/shapeRotationType"/>
-              <property value="" key="labeling/shapeSVGFile"/>
-              <property value="0" key="labeling/shapeSizeMapUnitMaxScale"/>
-              <property value="0" key="labeling/shapeSizeMapUnitMinScale"/>
-              <property value="0" key="labeling/shapeSizeType"/>
-              <property value="1" key="labeling/shapeSizeUnits"/>
-              <property value="0" key="labeling/shapeSizeX"/>
-              <property value="0" key="labeling/shapeSizeY"/>
-              <property value="0" key="labeling/shapeTransparency"/>
-              <property value="0" key="labeling/shapeType"/>
-              <property value="255" key="labeling/textColorA"/>
-              <property value="0" key="labeling/textColorB"/>
-              <property value="0" key="labeling/textColorG"/>
-              <property value="0" key="labeling/textColorR"/>
-              <property value="0" key="labeling/textTransp"/>
-              <property value="0" key="labeling/upsidedownLabels"/>
-              <property value="" key="labeling/wrapChar"/>
-              <property value="0" key="labeling/xOffset"/>
-              <property value="0" key="labeling/yOffset"/>
+              <property key="labeling" value="pal"/>
+              <property key="labeling/addDirectionSymbol" value="false"/>
+              <property key="labeling/angleOffset" value="0"/>
+              <property key="labeling/blendMode" value="0"/>
+              <property key="labeling/bufferBlendMode" value="0"/>
+              <property key="labeling/bufferColorA" value="255"/>
+              <property key="labeling/bufferColorB" value="255"/>
+              <property key="labeling/bufferColorG" value="255"/>
+              <property key="labeling/bufferColorR" value="255"/>
+              <property key="labeling/bufferDraw" value="false"/>
+              <property key="labeling/bufferJoinStyle" value="64"/>
+              <property key="labeling/bufferNoFill" value="false"/>
+              <property key="labeling/bufferSize" value="1"/>
+              <property key="labeling/bufferSizeInMapUnits" value="false"/>
+              <property key="labeling/bufferSizeMapUnitMaxScale" value="0"/>
+              <property key="labeling/bufferSizeMapUnitMinScale" value="0"/>
+              <property key="labeling/bufferTransp" value="0"/>
+              <property key="labeling/centroidInside" value="false"/>
+              <property key="labeling/centroidWhole" value="false"/>
+              <property key="labeling/decimals" value="3"/>
+              <property key="labeling/displayAll" value="false"/>
+              <property key="labeling/dist" value="0"/>
+              <property key="labeling/distInMapUnits" value="false"/>
+              <property key="labeling/distMapUnitMaxScale" value="0"/>
+              <property key="labeling/distMapUnitMinScale" value="0"/>
+              <property key="labeling/enabled" value="false"/>
+              <property key="labeling/fieldName" value=""/>
+              <property key="labeling/fontBold" value="false"/>
+              <property key="labeling/fontCapitals" value="0"/>
+              <property key="labeling/fontFamily" value="Sans Serif"/>
+              <property key="labeling/fontItalic" value="false"/>
+              <property key="labeling/fontLetterSpacing" value="0"/>
+              <property key="labeling/fontLimitPixelSize" value="false"/>
+              <property key="labeling/fontMaxPixelSize" value="10000"/>
+              <property key="labeling/fontMinPixelSize" value="3"/>
+              <property key="labeling/fontSize" value="9"/>
+              <property key="labeling/fontSizeInMapUnits" value="false"/>
+              <property key="labeling/fontSizeMapUnitMaxScale" value="0"/>
+              <property key="labeling/fontSizeMapUnitMinScale" value="0"/>
+              <property key="labeling/fontStrikeout" value="false"/>
+              <property key="labeling/fontUnderline" value="false"/>
+              <property key="labeling/fontWeight" value="50"/>
+              <property key="labeling/fontWordSpacing" value="0"/>
+              <property key="labeling/formatNumbers" value="false"/>
+              <property key="labeling/isExpression" value="true"/>
+              <property key="labeling/labelOffsetInMapUnits" value="true"/>
+              <property key="labeling/labelOffsetMapUnitMaxScale" value="0"/>
+              <property key="labeling/labelOffsetMapUnitMinScale" value="0"/>
+              <property key="labeling/labelPerPart" value="false"/>
+              <property key="labeling/leftDirectionSymbol" value="&lt;"/>
+              <property key="labeling/limitNumLabels" value="false"/>
+              <property key="labeling/maxCurvedCharAngleIn" value="20"/>
+              <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
+              <property key="labeling/maxNumLabels" value="2000"/>
+              <property key="labeling/mergeLines" value="false"/>
+              <property key="labeling/minFeatureSize" value="0"/>
+              <property key="labeling/multilineAlign" value="0"/>
+              <property key="labeling/multilineHeight" value="1"/>
+              <property key="labeling/namedStyle" value="Normal"/>
+              <property key="labeling/obstacle" value="true"/>
+              <property key="labeling/placeDirectionSymbol" value="0"/>
+              <property key="labeling/placement" value="0"/>
+              <property key="labeling/placementFlags" value="0"/>
+              <property key="labeling/plussign" value="false"/>
+              <property key="labeling/preserveRotation" value="true"/>
+              <property key="labeling/previewBkgrdColor" value="#ffffff"/>
+              <property key="labeling/priority" value="5"/>
+              <property key="labeling/quadOffset" value="4"/>
+              <property key="labeling/repeatDistance" value="0"/>
+              <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"/>
+              <property key="labeling/repeatDistanceMapUnitMinScale" value="0"/>
+              <property key="labeling/repeatDistanceUnit" value="1"/>
+              <property key="labeling/reverseDirectionSymbol" value="false"/>
+              <property key="labeling/rightDirectionSymbol" value=">"/>
+              <property key="labeling/scaleMax" value="10000000"/>
+              <property key="labeling/scaleMin" value="1"/>
+              <property key="labeling/scaleVisibility" value="false"/>
+              <property key="labeling/shadowBlendMode" value="6"/>
+              <property key="labeling/shadowColorB" value="0"/>
+              <property key="labeling/shadowColorG" value="0"/>
+              <property key="labeling/shadowColorR" value="0"/>
+              <property key="labeling/shadowDraw" value="false"/>
+              <property key="labeling/shadowOffsetAngle" value="135"/>
+              <property key="labeling/shadowOffsetDist" value="1"/>
+              <property key="labeling/shadowOffsetGlobal" value="true"/>
+              <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"/>
+              <property key="labeling/shadowOffsetMapUnitMinScale" value="0"/>
+              <property key="labeling/shadowOffsetUnits" value="1"/>
+              <property key="labeling/shadowRadius" value="1.5"/>
+              <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
+              <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"/>
+              <property key="labeling/shadowRadiusMapUnitMinScale" value="0"/>
+              <property key="labeling/shadowRadiusUnits" value="1"/>
+              <property key="labeling/shadowScale" value="100"/>
+              <property key="labeling/shadowTransparency" value="30"/>
+              <property key="labeling/shadowUnder" value="0"/>
+              <property key="labeling/shapeBlendMode" value="0"/>
+              <property key="labeling/shapeBorderColorA" value="255"/>
+              <property key="labeling/shapeBorderColorB" value="128"/>
+              <property key="labeling/shapeBorderColorG" value="128"/>
+              <property key="labeling/shapeBorderColorR" value="128"/>
+              <property key="labeling/shapeBorderWidth" value="0"/>
+              <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"/>
+              <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"/>
+              <property key="labeling/shapeBorderWidthUnits" value="1"/>
+              <property key="labeling/shapeDraw" value="false"/>
+              <property key="labeling/shapeFillColorA" value="255"/>
+              <property key="labeling/shapeFillColorB" value="255"/>
+              <property key="labeling/shapeFillColorG" value="255"/>
+              <property key="labeling/shapeFillColorR" value="255"/>
+              <property key="labeling/shapeJoinStyle" value="64"/>
+              <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"/>
+              <property key="labeling/shapeOffsetMapUnitMinScale" value="0"/>
+              <property key="labeling/shapeOffsetUnits" value="1"/>
+              <property key="labeling/shapeOffsetX" value="0"/>
+              <property key="labeling/shapeOffsetY" value="0"/>
+              <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"/>
+              <property key="labeling/shapeRadiiMapUnitMinScale" value="0"/>
+              <property key="labeling/shapeRadiiUnits" value="1"/>
+              <property key="labeling/shapeRadiiX" value="0"/>
+              <property key="labeling/shapeRadiiY" value="0"/>
+              <property key="labeling/shapeRotation" value="0"/>
+              <property key="labeling/shapeRotationType" value="0"/>
+              <property key="labeling/shapeSVGFile" value=""/>
+              <property key="labeling/shapeSizeMapUnitMaxScale" value="0"/>
+              <property key="labeling/shapeSizeMapUnitMinScale" value="0"/>
+              <property key="labeling/shapeSizeType" value="0"/>
+              <property key="labeling/shapeSizeUnits" value="1"/>
+              <property key="labeling/shapeSizeX" value="0"/>
+              <property key="labeling/shapeSizeY" value="0"/>
+              <property key="labeling/shapeTransparency" value="0"/>
+              <property key="labeling/shapeType" value="0"/>
+              <property key="labeling/textColorA" value="255"/>
+              <property key="labeling/textColorB" value="0"/>
+              <property key="labeling/textColorG" value="0"/>
+              <property key="labeling/textColorR" value="0"/>
+              <property key="labeling/textTransp" value="0"/>
+              <property key="labeling/upsidedownLabels" value="0"/>
+              <property key="labeling/wrapChar" value=""/>
+              <property key="labeling/xOffset" value="0"/>
+              <property key="labeling/yOffset" value="0"/>
             </customproperties>
             <blendMode>0</blendMode>
             <featureBlendMode>0</featureBlendMode>
@@ -2030,30 +2379,30 @@ def my_form_open(dialog, layer, feature):
             <label>0</label>
             <labelattributes>
               <label fieldname="" text="Label"/>
-              <family fieldname="" name="DejaVu Sans"/>
-              <size fieldname="" units="pt" value="12"/>
-              <bold fieldname="" on="0"/>
-              <italic fieldname="" on="0"/>
-              <underline fieldname="" on="0"/>
-              <strikeout fieldname="" on="0"/>
-              <color fieldname="" blue="0" red="0" green="0"/>
+              <family name="DejaVu Sans" fieldname=""/>
+              <size units="pt" fieldname="" value="12"/>
+              <bold on="0" fieldname=""/>
+              <italic on="0" fieldname=""/>
+              <underline on="0" fieldname=""/>
+              <strikeout on="0" fieldname=""/>
+              <color green="0" red="0" fieldname="" blue="0"/>
               <x fieldname=""/>
               <y fieldname=""/>
-              <offset units="pt" y="0" x="0" yfieldname="" xfieldname=""/>
-              <angle fieldname="" value="0" auto="0"/>
+              <offset units="pt" yfieldname="" xfieldname="" y="0" x="0"/>
+              <angle auto="0" fieldname="" value="0"/>
               <alignment fieldname="" value="center"/>
-              <buffercolor fieldname="" blue="255" red="255" green="255"/>
-              <buffersize fieldname="" units="pt" value="1"/>
-              <bufferenabled fieldname="" on=""/>
-              <multilineenabled fieldname="" on=""/>
+              <buffercolor green="255" red="255" fieldname="" blue="255"/>
+              <buffersize units="pt" fieldname="" value="1"/>
+              <bufferenabled on="" fieldname=""/>
+              <multilineenabled on="" fieldname=""/>
               <selectedonly on=""/>
             </labelattributes>
             <SingleCategoryDiagramRenderer diagramType="Pie">
-              <DiagramCategory backgroundAlpha="255" barWidth="5" height="15" diagramOrientation="Up" scaleDependency="Area" transparency="0" penAlpha="255" minScaleDenominator="-4.65661e-10" font="DejaVu Sans,11,-1,5,25,0,0,0,0,0" minimumSize="0" enabled="0" penWidth="0" sizeType="MM" scaleBasedVisibility="0" maxScaleDenominator="1e+08" width="15" backgroundColor="#ffffff" penColor="#000000" labelPlacementMethod="XHeight" angleOffset="1440">
-                <attribute label="" field="" color="#000000"/>
+              <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" font="DejaVu Sans,11,-1,5,25,0,0,0,0,0" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" angleOffset="1440" minScaleDenominator="-4.65661e-10" height="15" penColor="#000000" sizeType="MM" enabled="0" transparency="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+08">
+                <attribute color="#000000" label="" field=""/>
               </DiagramCategory>
             </SingleCategoryDiagramRenderer>
-            <DiagramLayerSettings obstacle="0" dist="0" xPosColumn="-1" linePlacementFlags="10" showAll="1" placement="0" yPosColumn="-1" priority="0"/>
+            <DiagramLayerSettings obstacle="0" xPosColumn="-1" linePlacementFlags="10" priority="0" placement="0" dist="0" showAll="1" yPosColumn="-1"/>
             <editforminit/>
             <featformsuppress>0</featformsuppress>
             <editorlayout>tablayout</editorlayout>
@@ -2066,19 +2415,19 @@ def my_form_open(dialog, layer, feature):
           </qgis>
         </map-layer-style>
         <map-layer-style name="test2">
-          <qgis simplifyDrawingHints="1" maximumScale="1e+08" version="2.9.0-Master" simplifyDrawingTol="1" scaleBasedLabelVisibilityFlag="0" hasScaleBasedVisibilityFlag="0" minLabelScale="1" minimumScale="0" simplifyMaxScale="1" maxLabelScale="1e+08" simplifyLocal="1">
+          <qgis scaleBasedLabelVisibilityFlag="0" maximumScale="1e+08" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" maxLabelScale="1e+08" simplifyDrawingHints="1" version="2.9.0-Master" minimumScale="0" simplifyMaxScale="1" minLabelScale="1" simplifyLocal="1">
             <edittypes>
               <edittype name="pk" widgetv2type="TextEdit">
-                <widgetv2config UseHtml="0" fieldEditable="1" IsMultiline="0" labelOnTop="0"/>
+                <widgetv2config fieldEditable="1" IsMultiline="0" labelOnTop="0" UseHtml="0"/>
               </edittype>
               <edittype name="name" widgetv2type="TextEdit">
-                <widgetv2config UseHtml="0" fieldEditable="1" IsMultiline="0" labelOnTop="0"/>
+                <widgetv2config fieldEditable="1" IsMultiline="0" labelOnTop="0" UseHtml="0"/>
               </edittype>
             </edittypes>
             <renderer-v2 type="singleSymbol" symbollevels="0">
               <symbols>
-                <symbol name="0" alpha="1" clip_to_extent="1" type="fill">
-                  <layer pass="0" class="SimpleFill" locked="0">
+                <symbol type="fill" alpha="1" clip_to_extent="1" name="0">
+                  <layer class="SimpleFill" pass="0" locked="0">
                     <prop v="0,0" k="border_width_map_unit_scale"/>
                     <prop v="145,149,158,255" k="color"/>
                     <prop v="bevel" k="joinstyle"/>
@@ -2090,7 +2439,7 @@ def my_form_open(dialog, layer, feature):
                     <prop v="0.26" k="outline_width"/>
                     <prop v="MM" k="outline_width_unit"/>
                     <prop v="solid" k="style"/>
-                    <effect enabled="0" type="effectStack">
+                    <effect type="effectStack" enabled="0">
                       <effect type="drawSource">
                         <prop v="0" k="blend_mode"/>
                         <prop v="2" k="draw_mode"/>
@@ -2099,7 +2448,7 @@ def my_form_open(dialog, layer, feature):
                       </effect>
                     </effect>
                   </layer>
-                  <layer pass="0" class="SimpleFill" locked="0">
+                  <layer class="SimpleFill" pass="0" locked="0">
                     <prop v="0,0" k="border_width_map_unit_scale"/>
                     <prop v="0,0,255,255" k="color"/>
                     <prop v="bevel" k="joinstyle"/>
@@ -2111,7 +2460,7 @@ def my_form_open(dialog, layer, feature):
                     <prop v="0.26" k="outline_width"/>
                     <prop v="MM" k="outline_width_unit"/>
                     <prop v="solid" k="style"/>
-                    <effect enabled="0" type="effectStack">
+                    <effect type="effectStack" enabled="0">
                       <effect type="drawSource">
                         <prop v="0" k="blend_mode"/>
                         <prop v="2" k="draw_mode"/>
@@ -2124,7 +2473,7 @@ def my_form_open(dialog, layer, feature):
               </symbols>
               <rotation/>
               <sizescale scalemethod="area"/>
-              <effect enabled="0" type="effectStack">
+              <effect type="effectStack" enabled="0">
                 <effect type="drawSource">
                   <prop v="0" k="blend_mode"/>
                   <prop v="2" k="draw_mode"/>
@@ -2134,147 +2483,147 @@ def my_form_open(dialog, layer, feature):
               </effect>
             </renderer-v2>
             <customproperties>
-              <property value="pal" key="labeling"/>
-              <property value="false" key="labeling/addDirectionSymbol"/>
-              <property value="0" key="labeling/angleOffset"/>
-              <property value="0" key="labeling/blendMode"/>
-              <property value="0" key="labeling/bufferBlendMode"/>
-              <property value="255" key="labeling/bufferColorA"/>
-              <property value="255" key="labeling/bufferColorB"/>
-              <property value="255" key="labeling/bufferColorG"/>
-              <property value="255" key="labeling/bufferColorR"/>
-              <property value="false" key="labeling/bufferDraw"/>
-              <property value="64" key="labeling/bufferJoinStyle"/>
-              <property value="false" key="labeling/bufferNoFill"/>
-              <property value="1" key="labeling/bufferSize"/>
-              <property value="false" key="labeling/bufferSizeInMapUnits"/>
-              <property value="0" key="labeling/bufferSizeMapUnitMaxScale"/>
-              <property value="0" key="labeling/bufferSizeMapUnitMinScale"/>
-              <property value="0" key="labeling/bufferTransp"/>
-              <property value="false" key="labeling/centroidInside"/>
-              <property value="false" key="labeling/centroidWhole"/>
-              <property value="3" key="labeling/decimals"/>
-              <property value="false" key="labeling/displayAll"/>
-              <property value="0" key="labeling/dist"/>
-              <property value="false" key="labeling/distInMapUnits"/>
-              <property value="0" key="labeling/distMapUnitMaxScale"/>
-              <property value="0" key="labeling/distMapUnitMinScale"/>
-              <property value="false" key="labeling/enabled"/>
-              <property value="" key="labeling/fieldName"/>
-              <property value="false" key="labeling/fontBold"/>
-              <property value="0" key="labeling/fontCapitals"/>
-              <property value="Sans Serif" key="labeling/fontFamily"/>
-              <property value="false" key="labeling/fontItalic"/>
-              <property value="0" key="labeling/fontLetterSpacing"/>
-              <property value="false" key="labeling/fontLimitPixelSize"/>
-              <property value="10000" key="labeling/fontMaxPixelSize"/>
-              <property value="3" key="labeling/fontMinPixelSize"/>
-              <property value="9" key="labeling/fontSize"/>
-              <property value="false" key="labeling/fontSizeInMapUnits"/>
-              <property value="0" key="labeling/fontSizeMapUnitMaxScale"/>
-              <property value="0" key="labeling/fontSizeMapUnitMinScale"/>
-              <property value="false" key="labeling/fontStrikeout"/>
-              <property value="false" key="labeling/fontUnderline"/>
-              <property value="50" key="labeling/fontWeight"/>
-              <property value="0" key="labeling/fontWordSpacing"/>
-              <property value="false" key="labeling/formatNumbers"/>
-              <property value="true" key="labeling/isExpression"/>
-              <property value="true" key="labeling/labelOffsetInMapUnits"/>
-              <property value="0" key="labeling/labelOffsetMapUnitMaxScale"/>
-              <property value="0" key="labeling/labelOffsetMapUnitMinScale"/>
-              <property value="false" key="labeling/labelPerPart"/>
-              <property value="&lt;" key="labeling/leftDirectionSymbol"/>
-              <property value="false" key="labeling/limitNumLabels"/>
-              <property value="20" key="labeling/maxCurvedCharAngleIn"/>
-              <property value="-20" key="labeling/maxCurvedCharAngleOut"/>
-              <property value="2000" key="labeling/maxNumLabels"/>
-              <property value="false" key="labeling/mergeLines"/>
-              <property value="0" key="labeling/minFeatureSize"/>
-              <property value="0" key="labeling/multilineAlign"/>
-              <property value="1" key="labeling/multilineHeight"/>
-              <property value="Normal" key="labeling/namedStyle"/>
-              <property value="true" key="labeling/obstacle"/>
-              <property value="0" key="labeling/placeDirectionSymbol"/>
-              <property value="0" key="labeling/placement"/>
-              <property value="0" key="labeling/placementFlags"/>
-              <property value="false" key="labeling/plussign"/>
-              <property value="true" key="labeling/preserveRotation"/>
-              <property value="#ffffff" key="labeling/previewBkgrdColor"/>
-              <property value="5" key="labeling/priority"/>
-              <property value="4" key="labeling/quadOffset"/>
-              <property value="0" key="labeling/repeatDistance"/>
-              <property value="0" key="labeling/repeatDistanceMapUnitMaxScale"/>
-              <property value="0" key="labeling/repeatDistanceMapUnitMinScale"/>
-              <property value="1" key="labeling/repeatDistanceUnit"/>
-              <property value="false" key="labeling/reverseDirectionSymbol"/>
-              <property value=">" key="labeling/rightDirectionSymbol"/>
-              <property value="10000000" key="labeling/scaleMax"/>
-              <property value="1" key="labeling/scaleMin"/>
-              <property value="false" key="labeling/scaleVisibility"/>
-              <property value="6" key="labeling/shadowBlendMode"/>
-              <property value="0" key="labeling/shadowColorB"/>
-              <property value="0" key="labeling/shadowColorG"/>
-              <property value="0" key="labeling/shadowColorR"/>
-              <property value="false" key="labeling/shadowDraw"/>
-              <property value="135" key="labeling/shadowOffsetAngle"/>
-              <property value="1" key="labeling/shadowOffsetDist"/>
-              <property value="true" key="labeling/shadowOffsetGlobal"/>
-              <property value="0" key="labeling/shadowOffsetMapUnitMaxScale"/>
-              <property value="0" key="labeling/shadowOffsetMapUnitMinScale"/>
-              <property value="1" key="labeling/shadowOffsetUnits"/>
-              <property value="1.5" key="labeling/shadowRadius"/>
-              <property value="false" key="labeling/shadowRadiusAlphaOnly"/>
-              <property value="0" key="labeling/shadowRadiusMapUnitMaxScale"/>
-              <property value="0" key="labeling/shadowRadiusMapUnitMinScale"/>
-              <property value="1" key="labeling/shadowRadiusUnits"/>
-              <property value="100" key="labeling/shadowScale"/>
-              <property value="30" key="labeling/shadowTransparency"/>
-              <property value="0" key="labeling/shadowUnder"/>
-              <property value="0" key="labeling/shapeBlendMode"/>
-              <property value="255" key="labeling/shapeBorderColorA"/>
-              <property value="128" key="labeling/shapeBorderColorB"/>
-              <property value="128" key="labeling/shapeBorderColorG"/>
-              <property value="128" key="labeling/shapeBorderColorR"/>
-              <property value="0" key="labeling/shapeBorderWidth"/>
-              <property value="0" key="labeling/shapeBorderWidthMapUnitMaxScale"/>
-              <property value="0" key="labeling/shapeBorderWidthMapUnitMinScale"/>
-              <property value="1" key="labeling/shapeBorderWidthUnits"/>
-              <property value="false" key="labeling/shapeDraw"/>
-              <property value="255" key="labeling/shapeFillColorA"/>
-              <property value="255" key="labeling/shapeFillColorB"/>
-              <property value="255" key="labeling/shapeFillColorG"/>
-              <property value="255" key="labeling/shapeFillColorR"/>
-              <property value="64" key="labeling/shapeJoinStyle"/>
-              <property value="0" key="labeling/shapeOffsetMapUnitMaxScale"/>
-              <property value="0" key="labeling/shapeOffsetMapUnitMinScale"/>
-              <property value="1" key="labeling/shapeOffsetUnits"/>
-              <property value="0" key="labeling/shapeOffsetX"/>
-              <property value="0" key="labeling/shapeOffsetY"/>
-              <property value="0" key="labeling/shapeRadiiMapUnitMaxScale"/>
-              <property value="0" key="labeling/shapeRadiiMapUnitMinScale"/>
-              <property value="1" key="labeling/shapeRadiiUnits"/>
-              <property value="0" key="labeling/shapeRadiiX"/>
-              <property value="0" key="labeling/shapeRadiiY"/>
-              <property value="0" key="labeling/shapeRotation"/>
-              <property value="0" key="labeling/shapeRotationType"/>
-              <property value="" key="labeling/shapeSVGFile"/>
-              <property value="0" key="labeling/shapeSizeMapUnitMaxScale"/>
-              <property value="0" key="labeling/shapeSizeMapUnitMinScale"/>
-              <property value="0" key="labeling/shapeSizeType"/>
-              <property value="1" key="labeling/shapeSizeUnits"/>
-              <property value="0" key="labeling/shapeSizeX"/>
-              <property value="0" key="labeling/shapeSizeY"/>
-              <property value="0" key="labeling/shapeTransparency"/>
-              <property value="0" key="labeling/shapeType"/>
-              <property value="255" key="labeling/textColorA"/>
-              <property value="0" key="labeling/textColorB"/>
-              <property value="0" key="labeling/textColorG"/>
-              <property value="0" key="labeling/textColorR"/>
-              <property value="0" key="labeling/textTransp"/>
-              <property value="0" key="labeling/upsidedownLabels"/>
-              <property value="" key="labeling/wrapChar"/>
-              <property value="0" key="labeling/xOffset"/>
-              <property value="0" key="labeling/yOffset"/>
+              <property key="labeling" value="pal"/>
+              <property key="labeling/addDirectionSymbol" value="false"/>
+              <property key="labeling/angleOffset" value="0"/>
+              <property key="labeling/blendMode" value="0"/>
+              <property key="labeling/bufferBlendMode" value="0"/>
+              <property key="labeling/bufferColorA" value="255"/>
+              <property key="labeling/bufferColorB" value="255"/>
+              <property key="labeling/bufferColorG" value="255"/>
+              <property key="labeling/bufferColorR" value="255"/>
+              <property key="labeling/bufferDraw" value="false"/>
+              <property key="labeling/bufferJoinStyle" value="64"/>
+              <property key="labeling/bufferNoFill" value="false"/>
+              <property key="labeling/bufferSize" value="1"/>
+              <property key="labeling/bufferSizeInMapUnits" value="false"/>
+              <property key="labeling/bufferSizeMapUnitMaxScale" value="0"/>
+              <property key="labeling/bufferSizeMapUnitMinScale" value="0"/>
+              <property key="labeling/bufferTransp" value="0"/>
+              <property key="labeling/centroidInside" value="false"/>
+              <property key="labeling/centroidWhole" value="false"/>
+              <property key="labeling/decimals" value="3"/>
+              <property key="labeling/displayAll" value="false"/>
+              <property key="labeling/dist" value="0"/>
+              <property key="labeling/distInMapUnits" value="false"/>
+              <property key="labeling/distMapUnitMaxScale" value="0"/>
+              <property key="labeling/distMapUnitMinScale" value="0"/>
+              <property key="labeling/enabled" value="false"/>
+              <property key="labeling/fieldName" value=""/>
+              <property key="labeling/fontBold" value="false"/>
+              <property key="labeling/fontCapitals" value="0"/>
+              <property key="labeling/fontFamily" value="Sans Serif"/>
+              <property key="labeling/fontItalic" value="false"/>
+              <property key="labeling/fontLetterSpacing" value="0"/>
+              <property key="labeling/fontLimitPixelSize" value="false"/>
+              <property key="labeling/fontMaxPixelSize" value="10000"/>
+              <property key="labeling/fontMinPixelSize" value="3"/>
+              <property key="labeling/fontSize" value="9"/>
+              <property key="labeling/fontSizeInMapUnits" value="false"/>
+              <property key="labeling/fontSizeMapUnitMaxScale" value="0"/>
+              <property key="labeling/fontSizeMapUnitMinScale" value="0"/>
+              <property key="labeling/fontStrikeout" value="false"/>
+              <property key="labeling/fontUnderline" value="false"/>
+              <property key="labeling/fontWeight" value="50"/>
+              <property key="labeling/fontWordSpacing" value="0"/>
+              <property key="labeling/formatNumbers" value="false"/>
+              <property key="labeling/isExpression" value="true"/>
+              <property key="labeling/labelOffsetInMapUnits" value="true"/>
+              <property key="labeling/labelOffsetMapUnitMaxScale" value="0"/>
+              <property key="labeling/labelOffsetMapUnitMinScale" value="0"/>
+              <property key="labeling/labelPerPart" value="false"/>
+              <property key="labeling/leftDirectionSymbol" value="&lt;"/>
+              <property key="labeling/limitNumLabels" value="false"/>
+              <property key="labeling/maxCurvedCharAngleIn" value="20"/>
+              <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
+              <property key="labeling/maxNumLabels" value="2000"/>
+              <property key="labeling/mergeLines" value="false"/>
+              <property key="labeling/minFeatureSize" value="0"/>
+              <property key="labeling/multilineAlign" value="0"/>
+              <property key="labeling/multilineHeight" value="1"/>
+              <property key="labeling/namedStyle" value="Normal"/>
+              <property key="labeling/obstacle" value="true"/>
+              <property key="labeling/placeDirectionSymbol" value="0"/>
+              <property key="labeling/placement" value="0"/>
+              <property key="labeling/placementFlags" value="0"/>
+              <property key="labeling/plussign" value="false"/>
+              <property key="labeling/preserveRotation" value="true"/>
+              <property key="labeling/previewBkgrdColor" value="#ffffff"/>
+              <property key="labeling/priority" value="5"/>
+              <property key="labeling/quadOffset" value="4"/>
+              <property key="labeling/repeatDistance" value="0"/>
+              <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"/>
+              <property key="labeling/repeatDistanceMapUnitMinScale" value="0"/>
+              <property key="labeling/repeatDistanceUnit" value="1"/>
+              <property key="labeling/reverseDirectionSymbol" value="false"/>
+              <property key="labeling/rightDirectionSymbol" value=">"/>
+              <property key="labeling/scaleMax" value="10000000"/>
+              <property key="labeling/scaleMin" value="1"/>
+              <property key="labeling/scaleVisibility" value="false"/>
+              <property key="labeling/shadowBlendMode" value="6"/>
+              <property key="labeling/shadowColorB" value="0"/>
+              <property key="labeling/shadowColorG" value="0"/>
+              <property key="labeling/shadowColorR" value="0"/>
+              <property key="labeling/shadowDraw" value="false"/>
+              <property key="labeling/shadowOffsetAngle" value="135"/>
+              <property key="labeling/shadowOffsetDist" value="1"/>
+              <property key="labeling/shadowOffsetGlobal" value="true"/>
+              <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"/>
+              <property key="labeling/shadowOffsetMapUnitMinScale" value="0"/>
+              <property key="labeling/shadowOffsetUnits" value="1"/>
+              <property key="labeling/shadowRadius" value="1.5"/>
+              <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
+              <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"/>
+              <property key="labeling/shadowRadiusMapUnitMinScale" value="0"/>
+              <property key="labeling/shadowRadiusUnits" value="1"/>
+              <property key="labeling/shadowScale" value="100"/>
+              <property key="labeling/shadowTransparency" value="30"/>
+              <property key="labeling/shadowUnder" value="0"/>
+              <property key="labeling/shapeBlendMode" value="0"/>
+              <property key="labeling/shapeBorderColorA" value="255"/>
+              <property key="labeling/shapeBorderColorB" value="128"/>
+              <property key="labeling/shapeBorderColorG" value="128"/>
+              <property key="labeling/shapeBorderColorR" value="128"/>
+              <property key="labeling/shapeBorderWidth" value="0"/>
+              <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"/>
+              <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"/>
+              <property key="labeling/shapeBorderWidthUnits" value="1"/>
+              <property key="labeling/shapeDraw" value="false"/>
+              <property key="labeling/shapeFillColorA" value="255"/>
+              <property key="labeling/shapeFillColorB" value="255"/>
+              <property key="labeling/shapeFillColorG" value="255"/>
+              <property key="labeling/shapeFillColorR" value="255"/>
+              <property key="labeling/shapeJoinStyle" value="64"/>
+              <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"/>
+              <property key="labeling/shapeOffsetMapUnitMinScale" value="0"/>
+              <property key="labeling/shapeOffsetUnits" value="1"/>
+              <property key="labeling/shapeOffsetX" value="0"/>
+              <property key="labeling/shapeOffsetY" value="0"/>
+              <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"/>
+              <property key="labeling/shapeRadiiMapUnitMinScale" value="0"/>
+              <property key="labeling/shapeRadiiUnits" value="1"/>
+              <property key="labeling/shapeRadiiX" value="0"/>
+              <property key="labeling/shapeRadiiY" value="0"/>
+              <property key="labeling/shapeRotation" value="0"/>
+              <property key="labeling/shapeRotationType" value="0"/>
+              <property key="labeling/shapeSVGFile" value=""/>
+              <property key="labeling/shapeSizeMapUnitMaxScale" value="0"/>
+              <property key="labeling/shapeSizeMapUnitMinScale" value="0"/>
+              <property key="labeling/shapeSizeType" value="0"/>
+              <property key="labeling/shapeSizeUnits" value="1"/>
+              <property key="labeling/shapeSizeX" value="0"/>
+              <property key="labeling/shapeSizeY" value="0"/>
+              <property key="labeling/shapeTransparency" value="0"/>
+              <property key="labeling/shapeType" value="0"/>
+              <property key="labeling/textColorA" value="255"/>
+              <property key="labeling/textColorB" value="0"/>
+              <property key="labeling/textColorG" value="0"/>
+              <property key="labeling/textColorR" value="0"/>
+              <property key="labeling/textTransp" value="0"/>
+              <property key="labeling/upsidedownLabels" value="0"/>
+              <property key="labeling/wrapChar" value=""/>
+              <property key="labeling/xOffset" value="0"/>
+              <property key="labeling/yOffset" value="0"/>
             </customproperties>
             <blendMode>0</blendMode>
             <featureBlendMode>0</featureBlendMode>
@@ -2283,30 +2632,30 @@ def my_form_open(dialog, layer, feature):
             <label>0</label>
             <labelattributes>
               <label fieldname="" text="Label"/>
-              <family fieldname="" name="DejaVu Sans"/>
-              <size fieldname="" units="pt" value="12"/>
-              <bold fieldname="" on="0"/>
-              <italic fieldname="" on="0"/>
-              <underline fieldname="" on="0"/>
-              <strikeout fieldname="" on="0"/>
-              <color fieldname="" blue="0" red="0" green="0"/>
+              <family name="DejaVu Sans" fieldname=""/>
+              <size units="pt" fieldname="" value="12"/>
+              <bold on="0" fieldname=""/>
+              <italic on="0" fieldname=""/>
+              <underline on="0" fieldname=""/>
+              <strikeout on="0" fieldname=""/>
+              <color green="0" red="0" fieldname="" blue="0"/>
               <x fieldname=""/>
               <y fieldname=""/>
-              <offset units="pt" y="0" x="0" yfieldname="" xfieldname=""/>
-              <angle fieldname="" value="0" auto="0"/>
+              <offset units="pt" yfieldname="" xfieldname="" y="0" x="0"/>
+              <angle auto="0" fieldname="" value="0"/>
               <alignment fieldname="" value="center"/>
-              <buffercolor fieldname="" blue="255" red="255" green="255"/>
-              <buffersize fieldname="" units="pt" value="1"/>
-              <bufferenabled fieldname="" on=""/>
-              <multilineenabled fieldname="" on=""/>
+              <buffercolor green="255" red="255" fieldname="" blue="255"/>
+              <buffersize units="pt" fieldname="" value="1"/>
+              <bufferenabled on="" fieldname=""/>
+              <multilineenabled on="" fieldname=""/>
               <selectedonly on=""/>
             </labelattributes>
             <SingleCategoryDiagramRenderer diagramType="Pie">
-              <DiagramCategory backgroundAlpha="255" barWidth="5" height="15" diagramOrientation="Up" scaleDependency="Area" transparency="0" penAlpha="255" minScaleDenominator="0" font="DejaVu Sans,11,-1,5,25,0,0,0,0,0" minimumSize="0" enabled="0" penWidth="0" sizeType="MM" scaleBasedVisibility="0" maxScaleDenominator="1e+08" width="15" backgroundColor="#ffffff" penColor="#000000" labelPlacementMethod="XHeight" angleOffset="1440">
-                <attribute label="" field="" color="#000000"/>
+              <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" font="DejaVu Sans,11,-1,5,25,0,0,0,0,0" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" angleOffset="1440" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" enabled="0" transparency="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+08">
+                <attribute color="#000000" label="" field=""/>
               </DiagramCategory>
             </SingleCategoryDiagramRenderer>
-            <DiagramLayerSettings obstacle="0" dist="0" xPosColumn="-1" linePlacementFlags="10" showAll="1" placement="0" yPosColumn="-1" priority="0"/>
+            <DiagramLayerSettings obstacle="0" xPosColumn="-1" linePlacementFlags="10" priority="0" placement="0" dist="0" showAll="1" yPosColumn="-1"/>
             <editforminit/>
             <featformsuppress>0</featformsuppress>
             <editorlayout>tablayout</editorlayout>
@@ -2320,10 +2669,15 @@ def my_form_open(dialog, layer, feature):
         </map-layer-style>
       </map-layer-style-manager>
       <auxiliaryLayer/>
-      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0">
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
         <symbols>
-          <symbol name="0" alpha="1" clip_to_extent="1" type="fill">
-            <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
               <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
               <prop v="145,149,158,255" k="color"/>
               <prop v="bevel" k="joinstyle"/>
@@ -2337,13 +2691,13 @@ def my_form_open(dialog, layer, feature):
               <prop v="solid" k="style"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
               <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
               <prop v="0,0,255,255" k="color"/>
               <prop v="bevel" k="joinstyle"/>
@@ -2357,9 +2711,9 @@ def my_form_open(dialog, layer, feature):
               <prop v="solid" k="style"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -2369,23 +2723,52 @@ def my_form_open(dialog, layer, feature):
         <sizescale/>
       </renderer-v2>
       <labeling type="simple">
-        <settings>
-          <text-style fontItalic="0" blendMode="0" fontStrikeout="0" isExpression="1" fontSizeUnit="Point" multilineHeight="1" textOpacity="1" fontSize="9" previewBkgrdColor="#ffffff" fontWordSpacing="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontCapitals="0" useSubstitutions="0" fontUnderline="0" fieldName="" namedStyle="Normal" fontLetterSpacing="0" fontFamily="Sans Serif" textColor="0,0,0,255" fontWeight="50">
-            <text-buffer bufferSizeUnits="MM" bufferNoFill="0" bufferColor="255,255,255,255" bufferJoinStyle="64" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferDraw="0" bufferOpacity="1" bufferBlendMode="0"/>
-            <background shapeRotationType="0" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeOffsetY="0" shapeSizeX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidth="0" shapeRotation="0" shapeDraw="0" shapeRadiiUnit="MM" shapeBlendMode="0" shapeSizeType="0" shapeSVGFile="" shapeOffsetUnit="MM" shapeBorderColor="128,128,128,255" shapeJoinStyle="64" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeRadiiY="0" shapeFillColor="255,255,255,255" shapeType="0" shapeBorderWidthUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeOpacity="1"/>
-            <shadow shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowOpacity="0.7" shadowColor="0,0,0,255" shadowOffsetAngle="135" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowScale="100" shadowBlendMode="6" shadowDraw="0" shadowRadiusUnit="MM"/>
+        <settings calloutType="simple">
+          <text-style blendMode="0" fontLetterSpacing="0" fontItalic="0" fontKerning="1" fontSize="9" fontFamily="Sans Serif" fontWeight="50" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" namedStyle="Normal" useSubstitutions="0" fontCapitals="0" textOrientation="horizontal" textColor="0,0,0,255" multilineHeight="1" fontStrikeout="0" isExpression="1" fontUnderline="0" fontSizeUnit="Point" fieldName="" previewBkgrdColor="255,255,255,255" fontWordSpacing="0">
+            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSizeUnits="MM" bufferNoFill="0" bufferSize="1" bufferColor="255,255,255,255" bufferBlendMode="0" bufferDraw="0" bufferJoinStyle="64"/>
+            <background shapeBlendMode="0" shapeRotation="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeOffsetX="0" shapeBorderWidth="0" shapeOffsetUnit="MM" shapeRadiiX="0" shapeSizeUnit="MM" shapeType="0" shapeRotationType="0" shapeRadiiY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeSizeX="0" shapeOffsetY="0" shapeSVGFile="" shapeSizeType="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0" shapeBorderWidthUnit="MM" shapeSizeY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeRadiiUnit="MM"/>
+            <shadow shadowOffsetGlobal="1" shadowColor="0,0,0,255" shadowRadius="1.5" shadowDraw="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetDist="1" shadowRadiusUnit="MM" shadowOpacity="0.7" shadowRadiusAlphaOnly="0" shadowScale="100" shadowBlendMode="6" shadowOffsetUnit="MM" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowOffsetAngle="135"/>
+            <dd_properties>
+              <Option type="Map">
+                <Option type="QString" name="name" value=""/>
+                <Option name="properties"/>
+                <Option type="QString" name="type" value="collection"/>
+              </Option>
+            </dd_properties>
             <substitutions/>
           </text-style>
-          <text-format decimals="3" plussign="0" multilineAlign="0" leftDirectionSymbol="&lt;" rightDirectionSymbol=">" placeDirectionSymbol="0" wrapChar="" reverseDirectionSymbol="0" addDirectionSymbol="0" formatNumbers="0"/>
-          <placement placementFlags="0" quadOffset="4" priority="5" distUnits="MM" placement="0" fitInPolygonOnly="0" rotationAngle="0" centroidInside="0" centroidWhole="0" yOffset="0" offsetUnits="MapUnit" preserveRotation="1" repeatDistance="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="20" dist="0" repeatDistanceUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" distMapUnitScale="3x:0,0,0,0,0,0" maxCurvedCharAngleOut="-20" offsetType="0"/>
-          <rendering scaleVisibility="0" obstacleFactor="1" fontMaxPixelSize="10000" fontLimitPixelSize="0" obstacleType="0" displayAll="0" scaleMax="10000000" limitNumLabels="0" drawLabels="1" obstacle="1" upsidedownLabels="0" zIndex="0" mergeLines="0" fontMinPixelSize="3" maxNumLabels="2000" minFeatureSize="0" scaleMin="1" labelPerPart="0"/>
+          <text-format decimals="3" multilineAlign="0" leftDirectionSymbol="&lt;" placeDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" wrapChar="" plussign="0" addDirectionSymbol="0" autoWrapLength="0" rightDirectionSymbol=">" reverseDirectionSymbol="0"/>
+          <placement centroidInside="0" maxCurvedCharAngleIn="20" repeatDistanceUnits="MM" fitInPolygonOnly="0" layerType="UnknownGeometry" distUnits="MM" offsetUnits="MapUnit" repeatDistance="0" overrunDistanceUnit="MM" rotationAngle="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" overrunDistance="0" geometryGenerator="" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" placement="0" placementFlags="0" geometryGeneratorEnabled="0" dist="0" distMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" xOffset="0" centroidWhole="0" quadOffset="4" yOffset="0" maxCurvedCharAngleOut="-20" priority="5" geometryGeneratorType="PointGeometry" offsetType="0"/>
+          <rendering fontMaxPixelSize="10000" minFeatureSize="0" zIndex="0" scaleMin="1" maxNumLabels="2000" drawLabels="1" limitNumLabels="0" scaleMax="10000000" fontLimitPixelSize="0" obstacleType="0" mergeLines="0" displayAll="0" obstacleFactor="1" fontMinPixelSize="3" upsidedownLabels="0" labelPerPart="0" obstacle="1" scaleVisibility="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </dd_properties>
+          <callout type="simple">
+            <Option type="Map">
+              <Option type="QString" name="anchorPoint" value="pole_of_inaccessibility"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" name="name" value=""/>
+                <Option name="properties"/>
+                <Option type="QString" name="type" value="collection"/>
+              </Option>
+              <Option type="bool" name="drawToAllParts" value="false"/>
+              <Option type="QString" name="enabled" value="0"/>
+              <Option type="QString" name="lineSymbol" value="&lt;symbol type=&quot;line&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; name=&quot;symbol&quot; force_rhr=&quot;0&quot;>&lt;layer class=&quot;SimpleLine&quot; enabled=&quot;1&quot; pass=&quot;0&quot; locked=&quot;0&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; name=&quot;name&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;type&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"/>
+              <Option type="double" name="minLength" value="0"/>
+              <Option type="QString" name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0"/>
+              <Option type="QString" name="minLengthUnit" value="MM"/>
+              <Option type="double" name="offsetFromAnchor" value="0"/>
+              <Option type="QString" name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0"/>
+              <Option type="QString" name="offsetFromAnchorUnit" value="MM"/>
+              <Option type="double" name="offsetFromLabel" value="0"/>
+              <Option type="QString" name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0"/>
+              <Option type="QString" name="offsetFromLabelUnit" value="MM"/>
+            </Option>
+          </callout>
         </settings>
       </labeling>
       <customproperties/>
@@ -2393,20 +2776,24 @@ def my_form_open(dialog, layer, feature):
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory lineSizeType="MM" backgroundAlpha="255" height="15" barWidth="5" rotationOffset="270" scaleDependency="Area" diagramOrientation="Up" sizeScale="3x:0,0,0,0,0,0" penAlpha="255" minScaleDenominator="-4.65661e-10" minimumSize="0" enabled="0" lineSizeScale="3x:0,0,0,0,0,0" penWidth="0" sizeType="MM" scaleBasedVisibility="0" opacity="1" maxScaleDenominator="1e+08" width="15" backgroundColor="#ffffff" penColor="#000000" labelPlacementMethod="XHeight">
+        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="-4.65661e-10" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
           <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+          <attribute color="#000000" label="" field=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" dist="0" linePlacementFlags="10" showAll="1" placement="0" priority="0" zIndex="0">
+      <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
         <properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
+            <Option type="QString" name="name" value=""/>
             <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
+            <Option type="QString" name="type" value="collection"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks/>
+        <checkConfiguration/>
+      </geometryOptions>
       <fieldConfiguration>
         <field name="pk">
           <editWidget type="">
@@ -2424,29 +2811,35 @@ def my_form_open(dialog, layer, feature):
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="pk"/>
-        <alias name="" index="1" field="name"/>
+        <alias name="" field="pk" index="0"/>
+        <alias name="" field="name" index="1"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default applyOnUpdate="0" expression="" field="pk"/>
-        <default applyOnUpdate="0" expression="" field="name"/>
+        <default applyOnUpdate="0" field="pk" expression=""/>
+        <default applyOnUpdate="0" field="name" expression=""/>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" constraints="3" exp_strength="0" field="pk" unique_strength="1"/>
-        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="name" unique_strength="0"/>
+        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
+        <constraint constraints="0" notnull_strength="0" field="name" exp_strength="0" unique_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" field="pk" desc=""/>
-        <constraint exp="" field="name" desc=""/>
+        <constraint field="pk" desc="" exp=""/>
+        <constraint field="name" desc="" exp=""/>
       </constraintExpressions>
+      <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns/>
       </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <storedexpressions/>
       <editform tolerant="1">../../../../../..</editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -2455,20 +2848,15 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer columnCount="0" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="0" name="ttt" showLabel="1"/>
+        <attributeEditorContainer columnCount="0" visibilityExpression="" name="ttt" showLabel="1" groupBox="0" visibilityExpressionEnabled="0"/>
       </attributeEditorForm>
       <editable/>
       <labelOnTop/>
       <widgets/>
-      <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
-      </conditionalstyles>
-      <expressionfields/>
       <previewExpression>"name"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer autoRefreshTime="0" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingTol="1" readOnly="0" maxScale="0" minScale="1e+08" autoRefreshEnabled="0" hasScaleBasedVisibilityFlag="0" geometry="Polygon" type="vector" labelsEnabled="1" simplifyMaxScale="1" simplifyLocal="1">
+    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="0" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
       <extent>
         <xmin>-19619892.68012013286352158</xmin>
         <ymin>-10327100.34232237376272678</ymin>
@@ -2483,6 +2871,7 @@ def my_form_open(dialog, layer, feature):
       <layername>Country_Diagrams</layername>
       <srs>
         <spatialrefsys>
+          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
           <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
@@ -2505,6 +2894,7 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -2512,7 +2902,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -2527,10 +2917,15 @@ def my_form_open(dialog, layer, feature):
         <map-layer-style name="default"/>
       </map-layer-style-manager>
       <auxiliaryLayer/>
-      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0">
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
         <symbols>
-          <symbol name="0" alpha="1" clip_to_extent="1" type="fill">
-            <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
               <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
               <prop v="13,126,136,255" k="color"/>
               <prop v="bevel" k="joinstyle"/>
@@ -2544,9 +2939,9 @@ def my_form_open(dialog, layer, feature):
               <prop v="solid" k="style"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -2556,7 +2951,7 @@ def my_form_open(dialog, layer, feature):
         <sizescale/>
       </renderer-v2>
       <customproperties>
-        <property value="0" key="embeddedWidgets/count"/>
+        <property key="embeddedWidgets/count" value="0"/>
         <property key="variableNames"/>
         <property key="variableValues"/>
       </customproperties>
@@ -2564,21 +2959,25 @@ def my_form_open(dialog, layer, feature):
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory lineSizeType="MM" backgroundAlpha="255" height="15" barWidth="5" rotationOffset="270" scaleDependency="Area" diagramOrientation="Up" sizeScale="3x:0,0,0,0,0,0" penAlpha="255" minScaleDenominator="inf" minimumSize="0" enabled="1" lineSizeScale="3x:0,0,0,0,0,0" penWidth="0" sizeType="MM" scaleBasedVisibility="0" opacity="1" maxScaleDenominator="1e+08" width="15" backgroundColor="#ffffff" penColor="#000000" labelPlacementMethod="XHeight">
+        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="inf" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="1" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
           <fontProperties description="Sans Serif,9,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="&quot;pk&quot;" label="pk" color="#6fe20e"/>
-          <attribute field=" length( name )" label=" length( name )" color="#38c4c2"/>
+          <attribute color="#6fe20e" label="pk" field="&quot;pk&quot;"/>
+          <attribute color="#38c4c2" label=" length( name )" field=" length( name )"/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" dist="0" linePlacementFlags="18" showAll="1" placement="0" priority="0" zIndex="0">
+      <DiagramLayerSettings obstacle="0" linePlacementFlags="18" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
         <properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
+            <Option type="QString" name="name" value=""/>
             <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
+            <Option type="QString" name="type" value="collection"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks/>
+        <checkConfiguration/>
+      </geometryOptions>
       <fieldConfiguration>
         <field name="pk">
           <editWidget type="TextEdit">
@@ -2596,33 +2995,39 @@ def my_form_open(dialog, layer, feature):
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="pk"/>
-        <alias name="" index="1" field="name"/>
+        <alias name="" field="pk" index="0"/>
+        <alias name="" field="name" index="1"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default applyOnUpdate="0" expression="" field="pk"/>
-        <default applyOnUpdate="0" expression="" field="name"/>
+        <default applyOnUpdate="0" field="pk" expression=""/>
+        <default applyOnUpdate="0" field="name" expression=""/>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" constraints="3" exp_strength="0" field="pk" unique_strength="1"/>
-        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="name" unique_strength="0"/>
+        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
+        <constraint constraints="0" notnull_strength="0" field="name" exp_strength="0" unique_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" field="pk" desc=""/>
-        <constraint exp="" field="name" desc=""/>
+        <constraint field="pk" desc="" exp=""/>
+        <constraint field="name" desc="" exp=""/>
       </constraintExpressions>
+      <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column name="pk" hidden="0" width="-1" type="field"/>
-          <column name="name" hidden="0" width="-1" type="field"/>
-          <column hidden="1" width="-1" type="actions"/>
+          <column type="field" width="-1" name="pk" hidden="0"/>
+          <column type="field" width="-1" name="name" hidden="0"/>
+          <column type="actions" width="-1" hidden="1"/>
         </columns>
       </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -2649,15 +3054,10 @@ def my_form_open(dialog, layer, feature):
       <editable/>
       <labelOnTop/>
       <widgets/>
-      <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
-      </conditionalstyles>
-      <expressionfields/>
       <previewExpression>name</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer autoRefreshTime="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" maxScale="-4.65661e-10" minScale="1e+08" autoRefreshEnabled="0" hasScaleBasedVisibilityFlag="0" type="raster">
+    <maplayer type="raster" refreshOnNotifyMessage="" maxScale="-4.65661e-10" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" minScale="1e+8" styleCategories="AllStyleCategories">
       <extent>
         <xmin>-29.99999999999666755</xmin>
         <ymin>29.99999999999666755</ymin>
@@ -2672,6 +3072,7 @@ def my_form_open(dialog, layer, feature):
       <layername>dem</layername>
       <srs>
         <spatialrefsys>
+          <wkt>GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]</wkt>
           <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
           <srsid>3452</srsid>
           <srid>4326</srid>
@@ -2694,6 +3095,7 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -2701,23 +3103,28 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
       </resourceMetadata>
-      <customproperties>
-        <property value="Value" key="identify/format"/>
-      </customproperties>
       <provider>gdal</provider>
       <noData>
-        <noDataList bandNo="1" useSrcNoData="1"/>
+        <noDataList useSrcNoData="1" bandNo="1"/>
       </noData>
       <map-layer-style-manager current="default">
         <map-layer-style name="default"/>
       </map-layer-style-manager>
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>0</Searchable>
+      </flags>
+      <customproperties>
+        <property key="identify/format" value="Value"/>
+      </customproperties>
       <pipe>
-        <rasterrenderer alphaBand="0" gradient="BlackToWhite" grayBand="1" type="singlebandgray" opacity="1">
+        <rasterrenderer type="singlebandgray" opacity="1" alphaBand="0" gradient="BlackToWhite" grayBand="1">
           <rasterTransparency/>
           <minMaxOrigin>
             <limits>None</limits>
@@ -2734,12 +3141,12 @@ def my_form_open(dialog, layer, feature):
           </contrastEnhancement>
         </rasterrenderer>
         <brightnesscontrast contrast="0" brightness="0"/>
-        <huesaturation saturation="0" grayscaleMode="0" colorizeGreen="128" colorizeOn="0" colorizeStrength="100" colorizeRed="255" colorizeBlue="128"/>
+        <huesaturation colorizeBlue="128" colorizeStrength="100" saturation="0" grayscaleMode="0" colorizeOn="0" colorizeRed="255" colorizeGreen="128"/>
         <rasterresampler maxOversampling="2"/>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
-    <maplayer autoRefreshTime="0" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingTol="1" readOnly="0" maxScale="0" minScale="1e+08" autoRefreshEnabled="0" hasScaleBasedVisibilityFlag="0" geometry="Polygon" type="vector" labelsEnabled="1" simplifyMaxScale="1" simplifyLocal="1">
+    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="0" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="MultiPolygon" styleCategories="AllStyleCategories" geometry="Polygon" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1">
       <extent>
         <xmin>-14746250.07513097859919071</xmin>
         <ymin>-112075.42807669920148328</ymin>
@@ -2754,6 +3161,7 @@ def my_form_open(dialog, layer, feature):
       <layername>Hello</layername>
       <srs>
         <spatialrefsys>
+          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
           <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
@@ -2776,6 +3184,7 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -2783,7 +3192,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -2798,10 +3207,15 @@ def my_form_open(dialog, layer, feature):
         <map-layer-style name="default"/>
       </map-layer-style-manager>
       <auxiliaryLayer/>
-      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0">
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
         <symbols>
-          <symbol name="0" alpha="1" clip_to_extent="1" type="fill">
-            <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
               <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
               <prop v="178,178,178,255" k="color"/>
               <prop v="bevel" k="joinstyle"/>
@@ -2815,13 +3229,13 @@ def my_form_open(dialog, layer, feature):
               <prop v="solid" k="style"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
               <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
               <prop v="230,85,192,255" k="color"/>
               <prop v="bevel" k="joinstyle"/>
@@ -2835,9 +3249,9 @@ def my_form_open(dialog, layer, feature):
               <prop v="solid" k="style"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -2851,20 +3265,24 @@ def my_form_open(dialog, layer, feature):
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory lineSizeType="MM" backgroundAlpha="255" height="15" barWidth="5" rotationOffset="270" scaleDependency="Area" diagramOrientation="Up" sizeScale="3x:0,0,0,0,0,0" penAlpha="255" minScaleDenominator="0" minimumSize="0" enabled="0" lineSizeScale="3x:0,0,0,0,0,0" penWidth="0" sizeType="MM" scaleBasedVisibility="0" opacity="1" maxScaleDenominator="1e+08" width="15" backgroundColor="#ffffff" penColor="#000000" labelPlacementMethod="XHeight">
+        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
           <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+          <attribute color="#000000" label="" field=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" dist="0" linePlacementFlags="10" showAll="1" placement="0" priority="0" zIndex="0">
+      <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
         <properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
+            <Option type="QString" name="name" value=""/>
             <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
+            <Option type="QString" name="type" value="collection"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks/>
+        <checkConfiguration/>
+      </geometryOptions>
       <fieldConfiguration>
         <field name="pk">
           <editWidget type="">
@@ -2889,33 +3307,39 @@ def my_form_open(dialog, layer, feature):
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="pk"/>
-        <alias name="" index="1" field="pkuid"/>
-        <alias name="" index="2" field="color"/>
+        <alias name="" field="pk" index="0"/>
+        <alias name="" field="pkuid" index="1"/>
+        <alias name="" field="color" index="2"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default applyOnUpdate="0" expression="" field="pk"/>
-        <default applyOnUpdate="0" expression="" field="pkuid"/>
-        <default applyOnUpdate="0" expression="" field="color"/>
+        <default applyOnUpdate="0" field="pk" expression=""/>
+        <default applyOnUpdate="0" field="pkuid" expression=""/>
+        <default applyOnUpdate="0" field="color" expression=""/>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" constraints="3" exp_strength="0" field="pk" unique_strength="1"/>
-        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pkuid" unique_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="color" unique_strength="0"/>
+        <constraint constraints="3" notnull_strength="1" field="pk" exp_strength="0" unique_strength="1"/>
+        <constraint constraints="0" notnull_strength="0" field="pkuid" exp_strength="0" unique_strength="0"/>
+        <constraint constraints="0" notnull_strength="0" field="color" exp_strength="0" unique_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" field="pk" desc=""/>
-        <constraint exp="" field="pkuid" desc=""/>
-        <constraint exp="" field="color" desc=""/>
+        <constraint field="pk" desc="" exp=""/>
+        <constraint field="pkuid" desc="" exp=""/>
+        <constraint field="color" desc="" exp=""/>
       </constraintExpressions>
+      <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns/>
       </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <storedexpressions/>
       <editform tolerant="1">../../../../../..</editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -2924,27 +3348,22 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer columnCount="0" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="0" name="t" showLabel="1">
-          <attributeEditorContainer columnCount="0" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" name="c1" showLabel="1">
-            <attributeEditorField name="pkuid" index="1" showLabel="1"/>
+        <attributeEditorContainer columnCount="0" visibilityExpression="" name="t" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
+          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c1" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+            <attributeEditorField name="pkuid" showLabel="1" index="1"/>
           </attributeEditorContainer>
-          <attributeEditorContainer columnCount="0" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" name="c2" showLabel="1">
-            <attributeEditorField name="color" index="2" showLabel="1"/>
+          <attributeEditorContainer columnCount="0" visibilityExpression="" name="c2" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+            <attributeEditorField name="color" showLabel="1" index="2"/>
           </attributeEditorContainer>
         </attributeEditorContainer>
       </attributeEditorForm>
       <editable/>
       <labelOnTop/>
       <widgets/>
-      <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
-      </conditionalstyles>
-      <expressionfields/>
       <previewExpression>COALESCE( "pkuid", '&lt;NULL>' )</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer autoRefreshTime="0" refreshOnNotifyEnabled="0" simplifyDrawingHints="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingTol="1" readOnly="0" maxScale="0" minScale="1e+08" autoRefreshEnabled="0" hasScaleBasedVisibilityFlag="0" geometry="Point" type="vector" labelsEnabled="1" simplifyMaxScale="1" simplifyLocal="1">
+    <maplayer simplifyAlgorithm="0" simplifyMaxScale="1" simplifyDrawingTol="1" refreshOnNotifyMessage="" minScale="1e+8" maxScale="0" refreshOnNotifyEnabled="0" readOnly="0" type="vector" wkbType="Point" styleCategories="AllStyleCategories" geometry="Point" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="0">
       <extent>
         <xmin>1000</xmin>
         <ymin>2000</ymin>
@@ -2959,6 +3378,7 @@ def my_form_open(dialog, layer, feature):
       <layername>db_point</layername>
       <srs>
         <spatialrefsys>
+          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
           <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
@@ -2981,6 +3401,7 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -2988,7 +3409,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -3003,10 +3424,15 @@ def my_form_open(dialog, layer, feature):
         <map-layer-style name="default"/>
       </map-layer-style-manager>
       <auxiliaryLayer/>
-      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0">
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
         <symbols>
-          <symbol name="0" alpha="1" clip_to_extent="1" type="marker">
-            <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
+          <symbol type="marker" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
+            <layer class="SimpleMarker" enabled="1" pass="0" locked="0">
               <prop v="0" k="angle"/>
               <prop v="172,96,98,255" k="color"/>
               <prop v="1" k="horizontal_anchor_point"/>
@@ -3027,9 +3453,9 @@ def my_form_open(dialog, layer, feature):
               <prop v="1" k="vertical_anchor_point"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -3043,20 +3469,24 @@ def my_form_open(dialog, layer, feature):
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-        <DiagramCategory lineSizeType="MM" backgroundAlpha="255" height="15" barWidth="5" rotationOffset="270" scaleDependency="Area" diagramOrientation="Up" sizeScale="3x:0,0,0,0,0,0" penAlpha="255" minScaleDenominator="0" minimumSize="0" enabled="0" lineSizeScale="3x:0,0,0,0,0,0" penWidth="0" sizeType="MM" scaleBasedVisibility="0" opacity="1" maxScaleDenominator="1e+08" width="15" backgroundColor="#ffffff" penColor="#000000" labelPlacementMethod="XHeight">
+        <DiagramCategory scaleDependency="Area" barWidth="5" minimumSize="0" width="15" scaleBasedVisibility="0" rotationOffset="270" penWidth="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" penAlpha="255" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" height="15" penColor="#000000" sizeType="MM" opacity="1" enabled="0" backgroundAlpha="255" diagramOrientation="Up" maxScaleDenominator="1e+8">
           <fontProperties description="DejaVu Sans,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+          <attribute color="#000000" label="" field=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" dist="0" linePlacementFlags="10" showAll="1" placement="0" priority="0" zIndex="0">
+      <DiagramLayerSettings obstacle="0" linePlacementFlags="10" zIndex="0" priority="0" placement="0" dist="0" showAll="1">
         <properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
+            <Option type="QString" name="name" value=""/>
             <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
+            <Option type="QString" name="type" value="collection"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks/>
+        <checkConfiguration/>
+      </geometryOptions>
       <fieldConfiguration>
         <field name="gid">
           <editWidget type="">
@@ -3081,33 +3511,39 @@ def my_form_open(dialog, layer, feature):
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="gid"/>
-        <alias name="" index="1" field="name"/>
-        <alias name="" index="2" field="color"/>
+        <alias name="" field="gid" index="0"/>
+        <alias name="" field="name" index="1"/>
+        <alias name="" field="color" index="2"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default applyOnUpdate="0" expression="" field="gid"/>
-        <default applyOnUpdate="0" expression="" field="name"/>
-        <default applyOnUpdate="0" expression="" field="color"/>
+        <default applyOnUpdate="0" field="gid" expression=""/>
+        <default applyOnUpdate="0" field="name" expression=""/>
+        <default applyOnUpdate="0" field="color" expression=""/>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" constraints="3" exp_strength="0" field="gid" unique_strength="1"/>
-        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="name" unique_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="color" unique_strength="0"/>
+        <constraint constraints="3" notnull_strength="1" field="gid" exp_strength="0" unique_strength="1"/>
+        <constraint constraints="0" notnull_strength="0" field="name" exp_strength="0" unique_strength="0"/>
+        <constraint constraints="0" notnull_strength="0" field="color" exp_strength="0" unique_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" field="gid" desc=""/>
-        <constraint exp="" field="name" desc=""/>
-        <constraint exp="" field="color" desc=""/>
+        <constraint field="gid" desc="" exp=""/>
+        <constraint field="name" desc="" exp=""/>
+        <constraint field="color" desc="" exp=""/>
       </constraintExpressions>
+      <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns/>
       </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <storedexpressions/>
       <editform tolerant="1">../../../../../..</editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -3118,11 +3554,6 @@ def my_form_open(dialog, layer, feature):
       <editable/>
       <labelOnTop/>
       <widgets/>
-      <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
-      </conditionalstyles>
-      <expressionfields/>
       <previewExpression>"name"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
@@ -3138,176 +3569,208 @@ def my_form_open(dialog, layer, feature):
     <layer id="Country_copy20161127151800736"/>
     <layer id="country20170328164317226"/>
     <layer id="Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c"/>
+    <layer id="Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9"/>
   </layerorder>
   <properties>
-    <WMSPrecision type="QString">5</WMSPrecision>
-    <WMSContactMail type="QString"></WMSContactMail>
-    <WMSServiceCapabilities type="bool">true</WMSServiceCapabilities>
-    <SpatialRefSys>
-      <ProjectionsEnabled type="int">1</ProjectionsEnabled>
-      <ProjectCRSProj4String type="QString">+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</ProjectCRSProj4String>
-      <ProjectCRSID type="int">3857</ProjectCRSID>
-      <ProjectCrs type="QString">EPSG:3857</ProjectCrs>
-    </SpatialRefSys>
-    <Measurement>
-      <DistanceUnits type="QString">meters</DistanceUnits>
-      <AreaUnits type="QString">m2</AreaUnits>
-    </Measurement>
-    <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
-    <WMSSegmentizeFeatureInfoGeometry type="bool">false</WMSSegmentizeFeatureInfoGeometry>
-    <WMSKeywordList type="QStringList">
-      <value></value>
-    </WMSKeywordList>
-    <Measure>
-      <Ellipsoid type="QString">WGS84</Ellipsoid>
-    </Measure>
-    <WFSUrl type="QString"></WFSUrl>
-    <PAL>
-      <DrawRectOnly type="bool">false</DrawRectOnly>
-      <CandidatesLine type="int">50</CandidatesLine>
-      <CandidatesPoint type="int">16</CandidatesPoint>
-      <SearchMethod type="int">0</SearchMethod>
-      <ShowingAllLabels type="bool">false</ShowingAllLabels>
-      <ShowingCandidates type="bool">false</ShowingCandidates>
-      <DrawOutlineLabels type="bool">true</DrawOutlineLabels>
-      <ShowingPartialsLabels type="bool">true</ShowingPartialsLabels>
-      <CandidatesPolygon type="int">30</CandidatesPolygon>
-    </PAL>
     <DefaultStyles>
-      <ColorRamp type="QString"></ColorRamp>
       <AlphaInt type="int">255</AlphaInt>
+      <ColorRamp type="QString"></ColorRamp>
       <Fill type="QString"></Fill>
       <Line type="QString"></Line>
-      <RandomColors type="bool">true</RandomColors>
-      <Opacity type="double">1</Opacity>
       <Marker type="QString"></Marker>
+      <Opacity type="double">1</Opacity>
+      <RandomColors type="bool">true</RandomColors>
     </DefaultStyles>
-    <WMSServiceAbstract type="QString">Simple test app.</WMSServiceAbstract>
-    <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
-    <PositionPrecision>
-      <DecimalPlaces type="int">2</DecimalPlaces>
-      <DegreeFormat type="QString">D</DegreeFormat>
-      <Automatic type="bool">true</Automatic>
-    </PositionPrecision>
-    <WMSFees type="QString">conditions unknown</WMSFees>
     <Digitizing>
-      <LayerSnappingList type="QStringList">
-        <value>country20131022151106556</value>
-        <value>hello20131022151106574</value>
-      </LayerSnappingList>
-      <SnappingMode type="QString">advanced</SnappingMode>
-      <LayerSnappingToleranceList type="QStringList">
-        <value>40.000000</value>
-        <value>40.000000</value>
-      </LayerSnappingToleranceList>
+      <AvoidIntersectionsList type="QStringList"/>
+      <DefaultSnapTolerance type="double">40</DefaultSnapTolerance>
+      <DefaultSnapToleranceUnit type="int">1</DefaultSnapToleranceUnit>
+      <DefaultSnapType type="QString">to vertex</DefaultSnapType>
       <LayerSnapToList type="QStringList">
         <value>to_vertex</value>
         <value>to_vertex</value>
       </LayerSnapToList>
-      <LayerSnappingToleranceUnitList type="QStringList">
-        <value>1</value>
-        <value>1</value>
-      </LayerSnappingToleranceUnitList>
       <LayerSnappingEnabledList type="QStringList">
         <value>enabled</value>
         <value>enabled</value>
       </LayerSnappingEnabledList>
-      <DefaultSnapTolerance type="double">40</DefaultSnapTolerance>
-      <DefaultSnapToleranceUnit type="int">1</DefaultSnapToleranceUnit>
-      <AvoidIntersectionsList type="QStringList"/>
-      <DefaultSnapType type="QString">to vertex</DefaultSnapType>
+      <LayerSnappingList type="QStringList">
+        <value>country20131022151106556</value>
+        <value>hello20131022151106574</value>
+      </LayerSnappingList>
+      <LayerSnappingToleranceList type="QStringList">
+        <value>40.000000</value>
+        <value>40.000000</value>
+      </LayerSnappingToleranceList>
+      <LayerSnappingToleranceUnitList type="QStringList">
+        <value>1</value>
+        <value>1</value>
+      </LayerSnappingToleranceUnitList>
+      <SnappingMode type="QString">advanced</SnappingMode>
     </Digitizing>
-    <WMSOnlineResource type="QString"></WMSOnlineResource>
+    <Gui>
+      <CanvasColorBluePart type="int">255</CanvasColorBluePart>
+      <CanvasColorGreenPart type="int">255</CanvasColorGreenPart>
+      <CanvasColorRedPart type="int">255</CanvasColorRedPart>
+      <SelectionColorAlphaPart type="int">128</SelectionColorAlphaPart>
+      <SelectionColorBluePart type="int">108</SelectionColorBluePart>
+      <SelectionColorGreenPart type="int">246</SelectionColorGreenPart>
+      <SelectionColorRedPart type="int">255</SelectionColorRedPart>
+    </Gui>
+    <Identify>
+      <disabledLayers type="QStringList"/>
+    </Identify>
     <Legend>
       <filterByMap type="bool">false</filterByMap>
     </Legend>
-    <WCSLayers type="QStringList">
-      <value>dem20150730091219559</value>
-    </WCSLayers>
-    <WMSServiceTitle type="QString">QGIS Server test</WMSServiceTitle>
-    <WFSLayers type="QStringList">
-      <value>Hello_SubsetString_copy20160222085231770</value>
-      <value>Hello_copy20150804164427541</value>
-      <value>country20131022151106556</value>
-      <value>hello20131022151106574</value>
-      <value>points20150803121107046</value>
-      <value>Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c</value>
-    </WFSLayers>
-    <WMSMaxWidth type="int">5000</WMSMaxWidth>
-    <WMSRequestDefinedDataSources type="bool">false</WMSRequestDefinedDataSources>
+    <Macros>
+      <pythonCode type="QString"></pythonCode>
+    </Macros>
+    <Measure>
+      <Ellipsoid type="QString">WGS84</Ellipsoid>
+    </Measure>
+    <Measurement>
+      <AreaUnits type="QString">m2</AreaUnits>
+      <DistanceUnits type="QString">meters</DistanceUnits>
+    </Measurement>
+    <PAL>
+      <CandidatesLine type="int">50</CandidatesLine>
+      <CandidatesPoint type="int">16</CandidatesPoint>
+      <CandidatesPolygon type="int">30</CandidatesPolygon>
+      <DrawOutlineLabels type="bool">true</DrawOutlineLabels>
+      <DrawRectOnly type="bool">false</DrawRectOnly>
+      <DrawUnplaced type="bool">false</DrawUnplaced>
+      <SearchMethod type="int">0</SearchMethod>
+      <ShowingAllLabels type="bool">false</ShowingAllLabels>
+      <ShowingCandidates type="bool">false</ShowingCandidates>
+      <ShowingPartialsLabels type="bool">true</ShowingPartialsLabels>
+      <TextFormat type="int">0</TextFormat>
+      <UnplacedColor type="QString">255,0,0,255</UnplacedColor>
+    </PAL>
     <Paths>
       <Absolute type="bool">false</Absolute>
     </Paths>
+    <PositionPrecision>
+      <Automatic type="bool">true</Automatic>
+      <DecimalPlaces type="int">2</DecimalPlaces>
+      <DegreeFormat type="QString">D</DegreeFormat>
+    </PositionPrecision>
+    <SpatialRefSys>
+      <ProjectCRSID type="int">3857</ProjectCRSID>
+      <ProjectCRSProj4String type="QString">+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</ProjectCRSProj4String>
+      <ProjectCrs type="QString">EPSG:3857</ProjectCrs>
+      <ProjectionsEnabled type="int">1</ProjectionsEnabled>
+    </SpatialRefSys>
+    <TimeManager>
+      <active type="int">1</active>
+      <animationFrameLength type="int">2000</animationFrameLength>
+      <currentMapTimePosition type="int">0</currentMapTimePosition>
+      <loopAnimation type="int">0</loopAnimation>
+      <playBackwards type="int">0</playBackwards>
+      <showLabel type="int">1</showLabel>
+      <timeFrameSize type="int">1</timeFrameSize>
+      <timeFrameType type="QString">days</timeFrameType>
+      <timeLayerList type="QStringList"/>
+      <timeLayerManager type="QString"></timeLayerManager>
+    </TimeManager>
     <Variables>
-      <variableValues type="QStringList"/>
       <variableNames type="QStringList"/>
+      <variableValues type="QStringList"/>
     </Variables>
-    <WMSRestrictedComposers type="QStringList"/>
-    <WMSContactPosition type="QString"></WMSContactPosition>
-    <WMSContactPhone type="QString"></WMSContactPhone>
+    <WCSLayers type="QStringList">
+      <value>dem20150730091219559</value>
+    </WCSLayers>
+    <WCSUrl type="QString"></WCSUrl>
+    <WFSLayers type="QStringList">
+      <value>Hello_SubsetString_copy20160222085231770</value>
+      <value>Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9</value>
+      <value>Hello_copy20150804164427541</value>
+      <value>Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c</value>
+      <value>country20131022151106556</value>
+      <value>hello20131022151106574</value>
+      <value>points20150803121107046</value>
+    </WFSLayers>
+    <WFSLayersPrecision>
+      <Hello_SubsetString_copy20160222085231770 type="int">1</Hello_SubsetString_copy20160222085231770>
+      <Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9 type="int">8</Hello_SubsetString_e829f18d_ef33_4bfd_883f_97c1d2dd50f9>
+      <Hello_copy20150804164427541 type="int">1</Hello_copy20150804164427541>
+      <Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c type="int">8</Hello_e995a3b8_79e4_4b73_8da1_82dc300b4b8c>
+      <country20131022151106556 type="int">1</country20131022151106556>
+      <hello20131022151106574 type="int">0</hello20131022151106574>
+      <points20150803121107046 type="int">1</points20150803121107046>
+    </WFSLayersPrecision>
     <WFSTLayers>
-      <Update type="QStringList">
-        <value>points20150803121107046</value>
-      </Update>
-      <Insert type="QStringList">
-        <value>points20150803121107046</value>
-      </Insert>
       <Delete type="QStringList">
         <value>points20150803121107046</value>
       </Delete>
+      <Insert type="QStringList">
+        <value>points20150803121107046</value>
+      </Insert>
+      <Update type="QStringList">
+        <value>points20150803121107046</value>
+      </Update>
     </WFSTLayers>
+    <WFSUrl type="QString"></WFSUrl>
+    <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
     <WMSAddWktGeometry type="bool">true</WMSAddWktGeometry>
-    <WMSMaxHeight type="int">5000</WMSMaxHeight>
-    <WCSUrl type="QString"></WCSUrl>
-    <Gui>
-      <CanvasColorRedPart type="int">255</CanvasColorRedPart>
-      <SelectionColorBluePart type="int">108</SelectionColorBluePart>
-      <CanvasColorBluePart type="int">255</CanvasColorBluePart>
-      <SelectionColorGreenPart type="int">246</SelectionColorGreenPart>
-      <SelectionColorAlphaPart type="int">128</SelectionColorAlphaPart>
-      <SelectionColorRedPart type="int">255</SelectionColorRedPart>
-      <CanvasColorGreenPart type="int">255</CanvasColorGreenPart>
-    </Gui>
+    <WMSContactMail type="QString"></WMSContactMail>
+    <WMSContactOrganization type="QString">QGIS</WMSContactOrganization>
+    <WMSContactPerson type="QString">Stéphane Brunner</WMSContactPerson>
+    <WMSContactPhone type="QString"></WMSContactPhone>
+    <WMSContactPosition type="QString"></WMSContactPosition>
+    <WMSCrsList type="QStringList">
+      <value>EPSG:3857</value>
+      <value>EPSG:4326</value>
+    </WMSCrsList>
+    <WMSDefaultMapUnitsPerMm type="double">1</WMSDefaultMapUnitsPerMm>
     <WMSExtent type="QStringList">
       <value>-20609693.37008669599890709</value>
       <value>-11055006.82298868149518967</value>
       <value>20961935.60850896313786507</value>
       <value>19143772.79360072687268257</value>
     </WMSExtent>
-    <WFSLayersPrecision>
-      <country20131022151106556 type="int">1</country20131022151106556>
-      <Hello_copy20150804164427541 type="int">1</Hello_copy20150804164427541>
-      <hello20131022151106574 type="int">0</hello20131022151106574>
-      <Hello_SubsetString_copy20160222085231770 type="int">1</Hello_SubsetString_copy20160222085231770>
-      <points20150803121107046 type="int">1</points20150803121107046>
-    </WFSLayersPrecision>
-    <WMSCrsList type="QStringList">
-      <value>EPSG:3857</value>
-      <value>EPSG:4326</value>
-    </WMSCrsList>
-    <WMSContactPerson type="QString">Stéphane Brunner</WMSContactPerson>
-    <WMSUrl type="QString"></WMSUrl>
-    <WMSRestrictedLayers type="QStringList"/>
-    <TimeManager>
-      <loopAnimation type="int">0</loopAnimation>
-      <timeFrameSize type="int">1</timeFrameSize>
-      <playBackwards type="int">0</playBackwards>
-      <timeLayerList type="QStringList"/>
-      <currentMapTimePosition type="int">0</currentMapTimePosition>
-      <active type="int">1</active>
-      <timeFrameType type="QString">days</timeFrameType>
-      <showLabel type="int">1</showLabel>
-      <timeLayerManager type="QString"></timeLayerManager>
-      <animationFrameLength type="int">2000</animationFrameLength>
-    </TimeManager>
-    <Macros>
-      <pythonCode type="QString"></pythonCode>
-    </Macros>
-    <Identify>
-      <disabledLayers type="QStringList"/>
-    </Identify>
+    <WMSFees type="QString">conditions unknown</WMSFees>
     <WMSImageQuality type="int">90</WMSImageQuality>
-    <WMSContactOrganization type="QString">QGIS</WMSContactOrganization>
+    <WMSKeywordList type="QStringList">
+      <value></value>
+    </WMSKeywordList>
+    <WMSMaxAtlasFeatures type="int">1</WMSMaxAtlasFeatures>
+    <WMSMaxHeight type="int">5000</WMSMaxHeight>
+    <WMSMaxWidth type="int">5000</WMSMaxWidth>
+    <WMSOnlineResource type="QString"></WMSOnlineResource>
+    <WMSPrecision type="QString">5</WMSPrecision>
+    <WMSRequestDefinedDataSources type="bool">false</WMSRequestDefinedDataSources>
+    <WMSRestrictedComposers type="QStringList"/>
+    <WMSRestrictedLayers type="QStringList"/>
+    <WMSRootName type="QString"></WMSRootName>
+    <WMSSegmentizeFeatureInfoGeometry type="bool">false</WMSSegmentizeFeatureInfoGeometry>
+    <WMSServiceAbstract type="QString">Simple test app.</WMSServiceAbstract>
+    <WMSServiceCapabilities type="bool">true</WMSServiceCapabilities>
+    <WMSServiceTitle type="QString">QGIS Server test</WMSServiceTitle>
+    <WMSTileBuffer type="int">0</WMSTileBuffer>
+    <WMSUrl type="QString"></WMSUrl>
+    <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
+    <WMTSGrids>
+      <CRS type="QStringList"/>
+      <Config type="QStringList"/>
+    </WMTSGrids>
+    <WMTSJpegLayers>
+      <Group type="QStringList"/>
+      <Layer type="QStringList"/>
+      <Project type="bool">false</Project>
+    </WMTSJpegLayers>
+    <WMTSLayers>
+      <Group type="QStringList"/>
+      <Layer type="QStringList"/>
+      <Project type="bool">false</Project>
+    </WMTSLayers>
+    <WMTSMinScale type="int">5000</WMTSMinScale>
+    <WMTSPngLayers>
+      <Group type="QStringList"/>
+      <Layer type="QStringList"/>
+      <Project type="bool">false</Project>
+    </WMTSPngLayers>
+    <WMTSUrl type="QString"></WMTSUrl>
   </properties>
   <visibility-presets/>
   <transformContext/>
@@ -3318,18 +3781,27 @@ def my_form_open(dialog, layer, feature):
     <type></type>
     <title>QGIS Server Hello World</title>
     <abstract></abstract>
+    <contact>
+      <name></name>
+      <organization></organization>
+      <position></position>
+      <voice></voice>
+      <fax></fax>
+      <email></email>
+      <role></role>
+    </contact>
     <links/>
     <author></author>
-    <creation></creation>
+    <creation>2000-01-01T00:00:00</creation>
   </projectMetadata>
   <Annotations/>
   <Layouts>
-    <Layout units="mm" worldFileMap="" printResolution="300" name="layoutA4">
-      <Snapper tolerance="5" snapToGuides="1" snapToItems="1" snapToGrid="0"/>
-      <Grid resUnits="mm" offsetX="0" offsetUnits="mm" resolution="10" offsetY="0"/>
+    <Layout units="mm" name="layoutA4" worldFileMap="" printResolution="300">
+      <Snapper snapToGrid="0" snapToItems="1" tolerance="5" snapToGuides="1"/>
+      <Grid offsetUnits="mm" resUnits="mm" offsetX="0" offsetY="0" resolution="10"/>
       <PageCollection>
-        <symbol name="" alpha="1" clip_to_extent="1" type="fill">
-          <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <symbol type="fill" alpha="1" clip_to_extent="1" name="" force_rhr="0">
+          <layer class="SimpleFill" enabled="1" pass="0" locked="0">
             <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
             <prop v="255,255,255,255" k="color"/>
             <prop v="miter" k="joinstyle"/>
@@ -3343,74 +3815,96 @@ def my_form_open(dialog, layer, feature):
             <prop v="solid" k="style"/>
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" name="name" value=""/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" name="type" value="collection"/>
               </Option>
             </data_defined_properties>
           </layer>
         </symbol>
-        <LayoutItem blendMode="0" referencePoint="0" excludeFromExports="0" positionLock="false" templateUuid="{0c6ae758-b774-432f-b8b7-7bbbbbb2fbc4}" zValue="0" id="" outlineWidthM="0.3,mm" type="65638" frame="false" background="true" visibility="1" itemRotation="0" opacity="1" positionOnPage="0,0,mm" groupUuid="" frameJoinStyle="miter" size="297,210,mm" uuid="{0c6ae758-b774-432f-b8b7-7bbbbbb2fbc4}" position="0,0,mm">
-          <FrameColor blue="0" alpha="255" red="0" green="0"/>
-          <BackgroundColor blue="255" alpha="255" red="255" green="255"/>
+        <LayoutItem itemRotation="0" blendMode="0" position="0,0,mm" zValue="0" templateUuid="{0c6ae758-b774-432f-b8b7-7bbbbbb2fbc4}" type="65638" groupUuid="" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" size="297,210,mm" positionOnPage="0,0,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{0c6ae758-b774-432f-b8b7-7bbbbbb2fbc4}" background="true">
+          <FrameColor alpha="255" green="0" red="0" blue="0"/>
+          <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
           <LayoutObject>
             <dataDefinedProperties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" name="name" value=""/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" name="type" value="collection"/>
               </Option>
             </dataDefinedProperties>
             <customproperties/>
           </LayoutObject>
+          <symbol type="fill" alpha="1" clip_to_extent="1" name="" force_rhr="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
+              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+              <prop v="255,255,255,255" k="color"/>
+              <prop v="miter" k="joinstyle"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="35,35,35,255" k="outline_color"/>
+              <prop v="no" k="outline_style"/>
+              <prop v="0.26" k="outline_width"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="solid" k="style"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" name="name" value=""/>
+                  <Option name="properties"/>
+                  <Option type="QString" name="type" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
         </LayoutItem>
         <GuideCollection visible="1"/>
       </PageCollection>
-      <LayoutItem blendMode="0" referencePoint="0" excludeFromExports="0" positionLock="false" templateUuid="{df61fc2f-86dc-402e-a37a-bc577e6349cd}" marginY="1" zValue="4" id="idtextbox" marginX="1" outlineWidthM="0.3,mm" type="65641" frame="false" background="false" visibility="1" halign="1" itemRotation="0" opacity="1" valign="32" positionOnPage="21.5381,157.547,mm" groupUuid="" frameJoinStyle="miter" size="120.853,35.0992,mm" labelText="QGIS" htmlState="0" uuid="{df61fc2f-86dc-402e-a37a-bc577e6349cd}" position="21.5381,157.547,mm">
-        <FrameColor blue="0" alpha="255" red="0" green="0"/>
-        <BackgroundColor blue="255" alpha="255" red="255" green="255"/>
+      <LayoutItem itemRotation="0" blendMode="0" position="21.5381,157.547,mm" zValue="4" templateUuid="{df61fc2f-86dc-402e-a37a-bc577e6349cd}" halign="1" htmlState="0" labelText="QGIS" type="65641" groupUuid="" marginX="1" marginY="1" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="idtextbox" size="120.853,35.0992,mm" positionOnPage="21.5381,157.547,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{df61fc2f-86dc-402e-a37a-bc577e6349cd}" background="false" valign="32">
+        <FrameColor alpha="255" green="0" red="0" blue="0"/>
+        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
         <LabelFont description="DejaVu Sans,10,-1,5,50,0,0,0,0,0" style=""/>
-        <FontColor blue="0" red="0" green="0"/>
+        <FontColor alpha="255" green="0" red="0" blue="0"/>
       </LayoutItem>
-      <LayoutItem blendMode="0" referencePoint="0" excludeFromExports="0" positionLock="false" templateUuid="{e2138dff-8012-45c7-9a52-a543ca96ac60}" zValue="3" id="" followPreset="false" outlineWidthM="0.3,mm" type="65639" mapFlags="1" frame="false" background="true" visibility="1" followPresetName="" mapRotation="0" itemRotation="0" keepLayerSet="false" opacity="1" drawCanvasItems="true" positionOnPage="21.3911,46,mm" groupUuid="" frameJoinStyle="miter" size="242,104,mm" uuid="{e2138dff-8012-45c7-9a52-a543ca96ac60}" position="21.3911,46,mm">
-        <FrameColor blue="0" alpha="255" red="0" green="0"/>
-        <BackgroundColor blue="255" alpha="255" red="255" green="255"/>
+      <LayoutItem itemRotation="0" blendMode="0" labelMargin="0,mm" position="21.3911,46,mm" zValue="3" templateUuid="{e2138dff-8012-45c7-9a52-a543ca96ac60}" mapFlags="1" keepLayerSet="false" followPresetName="" type="65639" groupUuid="" drawCanvasItems="true" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" followPreset="false" size="242,104,mm" positionOnPage="21.3911,46,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" mapRotation="0" uuid="{e2138dff-8012-45c7-9a52-a543ca96ac60}" background="true">
+        <FrameColor alpha="255" green="0" red="0" blue="0"/>
+        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
-        <Extent xmax="33978427.73650816082954407" ymax="16020257.03109830431640148" ymin="-13032965.18542143888771534" xmin="-33626185.49808585643768311"/>
+        <Extent ymin="-13032965.18542143888771534" ymax="16020257.03109830431640148" xmax="33978427.73650816082954407" xmin="-33626185.49808585643768311"/>
         <LayerSet>
-          <Layer name="db_point" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;points&quot; (geom) sql=" provider="spatialite">points20150803121107046</Layer>
-          <Layer name="Hello" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" provider="spatialite">hello20131022151106574</Layer>
-          <Layer name="Hello_SubsetString" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" provider="spatialite">Hello_copy20150804164427541</Layer>
-          <Layer name="Hello_Project_SubsetString" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=&quot;pkuid&quot; in ( 7, 8 )" provider="spatialite">Hello_SubsetString_copy20160222085231770</Layer>
-          <Layer name="Hello_Filter_SubsetString" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" provider="spatialite">Hello_Project_SubsetString_copy20160223113949592</Layer>
-          <Layer name="dem" source="/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/dem.tif" provider="gdal">dem20150730091219559</Layer>
-          <Layer name="Country" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=" provider="spatialite">country20131022151106556</Layer>
-          <Layer name="Country_Labels" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=" provider="spatialite">Country_copy20161127151800736</Layer>
-          <Layer name="Country_Diagrams" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=" provider="spatialite">country20170328164317226</Layer>
+          <Layer provider="spatialite" name="db_point" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;points&quot; (geom) sql=">points20150803121107046</Layer>
+          <Layer provider="spatialite" name="Hello" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=">hello20131022151106574</Layer>
+          <Layer provider="spatialite" name="Hello_SubsetString" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=">Hello_copy20150804164427541</Layer>
+          <Layer provider="spatialite" name="Hello_Project_SubsetString" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=&quot;pkuid&quot; in ( 7, 8 )">Hello_SubsetString_copy20160222085231770</Layer>
+          <Layer provider="spatialite" name="Hello_Filter_SubsetString" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=">Hello_Project_SubsetString_copy20160223113949592</Layer>
+          <Layer provider="gdal" name="dem" source="/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/dem.tif">dem20150730091219559</Layer>
+          <Layer provider="spatialite" name="Country" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=">country20131022151106556</Layer>
+          <Layer provider="spatialite" name="Country_Labels" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=">Country_copy20161127151800736</Layer>
+          <Layer provider="spatialite" name="Country_Diagrams" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=">country20170328164317226</Layer>
         </LayerSet>
-        <ComposerMapGrid unit="0" annotationPrecision="3" name="Grid 1" show="1" bottomAnnotationDirection="0" annotationFormat="0" gridFramePenColor="0,0,0,255" topAnnotationDisplay="0" rightAnnotationPosition="1" intervalX="0" rightAnnotationDirection="0" gridFrameStyle="0" bottomAnnotationPosition="1" rightAnnotationDisplay="0" frameFillColor2="0,0,0,255" leftAnnotationPosition="1" showAnnotation="0" intervalY="0" crossLength="3" leftAnnotationDisplay="0" uuid="{2097ba82-73aa-4cf8-911e-b3472427ff3f}" gridFrameSideFlags="15" topFrameDivisions="0" leftAnnotationDirection="0" annotationExpression="" offsetY="0" blendMode="0" leftFrameDivisions="0" topAnnotationPosition="1" topAnnotationDirection="0" frameFillColor1="255,255,255,255" frameAnnotationDistance="1" gridStyle="0" annotationFontColor="0,0,0,255" gridFrameWidth="2" gridFramePenThickness="0.5" rightFrameDivisions="0" bottomAnnotationDisplay="0" bottomFrameDivisions="0" offsetX="0">
+        <ComposerMapGrid annotationExpression="" leftAnnotationDisplay="0" rightAnnotationPosition="1" topAnnotationDisplay="0" rightAnnotationDirection="0" annotationPrecision="3" bottomAnnotationDirection="0" topAnnotationPosition="1" rightAnnotationDisplay="0" leftAnnotationDirection="0" rightFrameDivisions="0" annotationFontColor="0,0,0,255" intervalY="0" uuid="{2097ba82-73aa-4cf8-911e-b3472427ff3f}" frameAnnotationDistance="1" frameFillColor1="255,255,255,255" offsetY="0" offsetX="0" blendMode="0" unit="0" leftFrameDivisions="0" crossLength="3" topAnnotationDirection="0" bottomFrameDivisions="0" frameFillColor2="0,0,0,255" showAnnotation="0" name="Grid 1" gridFrameMargin="0" gridFrameStyle="0" annotationFormat="0" position="3" minimumIntervalWidth="50" bottomAnnotationDisplay="0" maximumIntervalWidth="100" leftAnnotationPosition="1" gridFrameSideFlags="15" bottomAnnotationPosition="1" gridFramePenColor="0,0,0,255" intervalX="0" topFrameDivisions="0" gridFramePenThickness="0.5" gridStyle="0" gridFrameWidth="2" show="1">
           <lineStyle>
-            <symbol name="" alpha="1" clip_to_extent="1" type="line">
-              <layer enabled="1" pass="0" class="SimpleLine" locked="0">
+            <symbol type="line" alpha="1" clip_to_extent="1" name="" force_rhr="0">
+              <layer class="SimpleLine" enabled="1" pass="0" locked="0">
                 <prop v="square" k="capstyle"/>
                 <prop v="5;2" k="customdash"/>
                 <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
@@ -3424,21 +3918,22 @@ def my_form_open(dialog, layer, feature):
                 <prop v="0" k="offset"/>
                 <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
                 <prop v="MM" k="offset_unit"/>
+                <prop v="0" k="ring_filter"/>
                 <prop v="0" k="use_custom_dash"/>
                 <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" value="" type="QString"/>
+                    <Option type="QString" name="name" value=""/>
                     <Option name="properties"/>
-                    <Option name="type" value="collection" type="QString"/>
+                    <Option type="QString" name="type" value="collection"/>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </lineStyle>
           <markerStyle>
-            <symbol name="" alpha="1" clip_to_extent="1" type="marker">
-              <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
+            <symbol type="marker" alpha="1" clip_to_extent="1" name="" force_rhr="0">
+              <layer class="SimpleMarker" enabled="1" pass="0" locked="0">
                 <prop v="0" k="angle"/>
                 <prop v="0,0,0,255" k="color"/>
                 <prop v="1" k="horizontal_anchor_point"/>
@@ -3459,59 +3954,70 @@ def my_form_open(dialog, layer, feature):
                 <prop v="1" k="vertical_anchor_point"/>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" value="" type="QString"/>
+                    <Option type="QString" name="name" value=""/>
                     <Option name="properties"/>
-                    <Option name="type" value="collection" type="QString"/>
+                    <Option type="QString" name="type" value="collection"/>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </markerStyle>
           <annotationFontProperties description=",11,-1,5,50,0,0,0,0,0" style=""/>
+          <LayoutObject>
+            <dataDefinedProperties>
+              <Option type="Map">
+                <Option type="QString" name="name" value=""/>
+                <Option name="properties"/>
+                <Option type="QString" name="type" value="collection"/>
+              </Option>
+            </dataDefinedProperties>
+            <customproperties/>
+          </LayoutObject>
         </ComposerMapGrid>
-        <AtlasMap margin="0.10000000000000001" scalingMode="2" atlasDriven="0"/>
+        <AtlasMap atlasDriven="0" margin="0.10000000000000001" scalingMode="2"/>
+        <labelBlockingItems/>
       </LayoutItem>
-      <LayoutItem blendMode="0" referencePoint="0" excludeFromExports="0" positionLock="false" templateUuid="{b3f8da1e-352d-4ea6-b8c1-c2464bfdd050}" marginY="1" zValue="2" id="" marginX="1" outlineWidthM="0.3,mm" type="65641" frame="false" background="false" visibility="1" halign="1" itemRotation="0" opacity="1" valign="32" positionOnPage="213.302,161.791,mm" groupUuid="" frameJoinStyle="miter" size="64.3016,11.0626,mm" labelText="Welcome to our world...." htmlState="0" uuid="{b3f8da1e-352d-4ea6-b8c1-c2464bfdd050}" position="213.302,161.791,mm">
-        <FrameColor blue="0" alpha="255" red="0" green="0"/>
-        <BackgroundColor blue="255" alpha="255" red="255" green="255"/>
+      <LayoutItem itemRotation="0" blendMode="0" position="213.302,161.791,mm" zValue="2" templateUuid="{b3f8da1e-352d-4ea6-b8c1-c2464bfdd050}" halign="1" htmlState="0" labelText="Welcome to our world...." type="65641" groupUuid="" marginX="1" marginY="1" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" size="64.3016,11.0626,mm" positionOnPage="213.302,161.791,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{b3f8da1e-352d-4ea6-b8c1-c2464bfdd050}" background="false" valign="32">
+        <FrameColor alpha="255" green="0" red="0" blue="0"/>
+        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
         <LabelFont description="DejaVu Sans,12,-1,5,75,0,0,0,0,0" style=""/>
-        <FontColor blue="0" red="0" green="0"/>
+        <FontColor alpha="255" green="0" red="0" blue="0"/>
       </LayoutItem>
-      <LayoutItem blendMode="0" referencePoint="0" excludeFromExports="0" positionLock="false" templateUuid="{4f60a368-b33d-4bd1-950a-76a48f3c8695}" marginY="1" zValue="1" id="" marginX="1" outlineWidthM="0.3,mm" type="65641" frame="false" background="false" visibility="1" halign="1" itemRotation="0" opacity="1" valign="32" positionOnPage="49.9838,9.33411,mm" groupUuid="" frameJoinStyle="miter" size="215.03,28.0023,mm" labelText="QGIS Mapserver" htmlState="0" uuid="{4f60a368-b33d-4bd1-950a-76a48f3c8695}" position="49.9838,9.33411,mm">
-        <FrameColor blue="0" alpha="255" red="0" green="0"/>
-        <BackgroundColor blue="255" alpha="255" red="255" green="255"/>
+      <LayoutItem itemRotation="0" blendMode="0" position="49.9838,9.33411,mm" zValue="1" templateUuid="{4f60a368-b33d-4bd1-950a-76a48f3c8695}" halign="1" htmlState="0" labelText="QGIS Mapserver" type="65641" groupUuid="" marginX="1" marginY="1" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" size="215.03,28.0023,mm" positionOnPage="49.9838,9.33411,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{4f60a368-b33d-4bd1-950a-76a48f3c8695}" background="false" valign="32">
+        <FrameColor alpha="255" green="0" red="0" blue="0"/>
+        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
         <LabelFont description="DejaVu Sans,48,-1,5,75,0,0,0,0,0" style=""/>
-        <FontColor blue="0" red="0" green="0"/>
+        <FontColor alpha="255" green="0" red="0" blue="0"/>
       </LayoutItem>
       <customproperties/>
-      <Atlas enabled="0" filenamePattern="'output_'||@atlas_featurenumber" coverageLayer="" hideCoverage="0" sortFeatures="0" pageNameExpression="" filterFeatures="0"/>
+      <Atlas pageNameExpression="" hideCoverage="0" enabled="0" filterFeatures="0" coverageLayer="" filenamePattern="'output_'||@atlas_featurenumber" sortFeatures="0"/>
     </Layout>
-    <Layout units="mm" worldFileMap="" printResolution="300" name="layoutA4copy">
-      <Snapper tolerance="5" snapToGuides="1" snapToItems="1" snapToGrid="0"/>
-      <Grid resUnits="mm" offsetX="0" offsetUnits="mm" resolution="10" offsetY="0"/>
+    <Layout units="mm" name="layoutA4copy" worldFileMap="" printResolution="300">
+      <Snapper snapToGrid="0" snapToItems="1" tolerance="5" snapToGuides="1"/>
+      <Grid offsetUnits="mm" resUnits="mm" offsetX="0" offsetY="0" resolution="10"/>
       <PageCollection>
-        <symbol name="" alpha="1" clip_to_extent="1" type="fill">
-          <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <symbol type="fill" alpha="1" clip_to_extent="1" name="" force_rhr="0">
+          <layer class="SimpleFill" enabled="1" pass="0" locked="0">
             <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
             <prop v="255,255,255,255" k="color"/>
             <prop v="miter" k="joinstyle"/>
@@ -3525,105 +4031,127 @@ def my_form_open(dialog, layer, feature):
             <prop v="solid" k="style"/>
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" name="name" value=""/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" name="type" value="collection"/>
               </Option>
             </data_defined_properties>
           </layer>
         </symbol>
-        <LayoutItem blendMode="0" referencePoint="0" excludeFromExports="0" positionLock="false" templateUuid="{b7ec60db-93ed-4cf6-86c2-b9ba296e9b88}" zValue="0" id="" outlineWidthM="0.3,mm" type="65638" frame="false" background="true" visibility="1" itemRotation="0" opacity="1" positionOnPage="0,0,mm" groupUuid="" frameJoinStyle="miter" size="297,210,mm" uuid="{b7ec60db-93ed-4cf6-86c2-b9ba296e9b88}" position="0,0,mm">
-          <FrameColor blue="0" alpha="255" red="0" green="0"/>
-          <BackgroundColor blue="255" alpha="255" red="255" green="255"/>
+        <LayoutItem itemRotation="0" blendMode="0" position="0,0,mm" zValue="0" templateUuid="{b7ec60db-93ed-4cf6-86c2-b9ba296e9b88}" type="65638" groupUuid="" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" size="297,210,mm" positionOnPage="0,0,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{b7ec60db-93ed-4cf6-86c2-b9ba296e9b88}" background="true">
+          <FrameColor alpha="255" green="0" red="0" blue="0"/>
+          <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
           <LayoutObject>
             <dataDefinedProperties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" name="name" value=""/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" name="type" value="collection"/>
               </Option>
             </dataDefinedProperties>
             <customproperties/>
           </LayoutObject>
+          <symbol type="fill" alpha="1" clip_to_extent="1" name="" force_rhr="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
+              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+              <prop v="255,255,255,255" k="color"/>
+              <prop v="miter" k="joinstyle"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="35,35,35,255" k="outline_color"/>
+              <prop v="no" k="outline_style"/>
+              <prop v="0.26" k="outline_width"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="solid" k="style"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" name="name" value=""/>
+                  <Option name="properties"/>
+                  <Option type="QString" name="type" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
         </LayoutItem>
         <GuideCollection visible="1"/>
       </PageCollection>
-      <LayoutItem resizeToContents="1" excludeFromExports="0" positionLock="false" referencePoint="0" templateUuid="{3d056e83-9087-450b-81e7-b343a652139d}" columnSpace="2" size="65.3688,96.2,mm" map_uuid="{98195e4d-0084-4747-b15b-507220be6d8a}" columnCount="1" visibility="1" titleAlignment="1" rasterBorder="1" wmsLegendWidth="50" type="65642" lineSpacing="1" title="" background="true" zValue="5" wmsLegendHeight="25" opacity="1" rasterBorderColor="0,0,0,255" uuid="{3d056e83-9087-450b-81e7-b343a652139d}" id="" boxSpace="2" legendFilterByAtlas="0" outlineWidthM="0.3,mm" blendMode="0" rasterBorderWidth="0" itemRotation="0" positionOnPage="147.933,150,mm" position="147.933,150,mm" fontColor="#000000" symbolWidth="7" symbolHeight="4" equalColumnWidth="0" frame="false" groupUuid="" wrapChar="" splitLayer="0" frameJoinStyle="miter">
-        <FrameColor blue="0" alpha="255" red="0" green="0"/>
-        <BackgroundColor blue="255" alpha="255" red="255" green="255"/>
+      <LayoutItem excludeFromExports="0" symbolWidth="7" id="" resizeToContents="1" templateUuid="{3d056e83-9087-450b-81e7-b343a652139d}" map_uuid="{98195e4d-0084-4747-b15b-507220be6d8a}" positionOnPage="147.933,150,mm" fontColor="#000000" groupUuid="" frame="false" wrapChar="" rasterBorderWidth="0" uuid="{3d056e83-9087-450b-81e7-b343a652139d}" wmsLegendHeight="25" size="65.3688,96.2,mm" visibility="1" equalColumnWidth="0" symbolHeight="4" type="65642" columnSpace="2" wmsLegendWidth="50" blendMode="0" frameJoinStyle="miter" title="" lineSpacing="1" positionLock="false" itemRotation="0" rasterBorder="1" outlineWidthM="0.3,mm" background="true" position="147.933,150,mm" referencePoint="0" splitLayer="0" opacity="1" legendFilterByAtlas="0" zValue="5" symbolAlignment="1" columnCount="1" boxSpace="2" titleAlignment="1" rasterBorderColor="0,0,0,255">
+        <FrameColor alpha="255" green="0" red="0" blue="0"/>
+        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
         <styles>
-          <style name="title" marginBottom="3.5">
+          <style name="title" marginBottom="3.5" alignment="1">
             <styleFont description="Ubuntu,16,-1,5,50,0,0,0,0,0" style=""/>
           </style>
-          <style name="group" marginTop="3">
+          <style name="group" marginTop="3" alignment="1">
             <styleFont description="Ubuntu,14,-1,5,50,0,0,0,0,0" style=""/>
           </style>
-          <style name="subgroup" marginTop="3">
+          <style name="subgroup" marginTop="3" alignment="1">
             <styleFont description="Ubuntu,12,-1,5,50,0,0,0,0,0" style=""/>
           </style>
-          <style name="symbol" marginTop="2.5">
+          <style name="symbol" marginTop="2.5" alignment="1">
             <styleFont description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
           </style>
-          <style name="symbolLabel" marginTop="2" marginLeft="2">
+          <style name="symbolLabel" marginTop="2" marginLeft="2" alignment="1">
             <styleFont description="Ubuntu,12,-1,5,50,0,0,0,0,0" style=""/>
           </style>
         </styles>
       </LayoutItem>
-      <LayoutItem blendMode="0" referencePoint="0" excludeFromExports="0" positionLock="false" templateUuid="{aaaf60fd-943b-463a-b2e5-162b0f7931a5}" marginY="1" zValue="4" id="idtextbox" marginX="1" outlineWidthM="0.3,mm" type="65641" frame="false" background="false" visibility="1" halign="1" itemRotation="0" opacity="1" valign="32" positionOnPage="21.5381,157.547,mm" groupUuid="" frameJoinStyle="miter" size="120.853,35.0992,mm" labelText="QGIS" htmlState="0" uuid="{aaaf60fd-943b-463a-b2e5-162b0f7931a5}" position="21.5381,157.547,mm">
-        <FrameColor blue="0" alpha="255" red="0" green="0"/>
-        <BackgroundColor blue="255" alpha="255" red="255" green="255"/>
+      <LayoutItem itemRotation="0" blendMode="0" position="21.5381,157.547,mm" zValue="4" templateUuid="{aaaf60fd-943b-463a-b2e5-162b0f7931a5}" halign="1" htmlState="0" labelText="QGIS" type="65641" groupUuid="" marginX="1" marginY="1" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="idtextbox" size="120.853,35.0992,mm" positionOnPage="21.5381,157.547,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{aaaf60fd-943b-463a-b2e5-162b0f7931a5}" background="false" valign="32">
+        <FrameColor alpha="255" green="0" red="0" blue="0"/>
+        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
         <LabelFont description="DejaVu Sans,10,-1,5,50,0,0,0,0,0" style=""/>
-        <FontColor blue="0" red="0" green="0"/>
+        <FontColor alpha="255" green="0" red="0" blue="0"/>
       </LayoutItem>
-      <LayoutItem blendMode="0" referencePoint="0" excludeFromExports="0" positionLock="false" templateUuid="{98195e4d-0084-4747-b15b-507220be6d8a}" zValue="3" id="" followPreset="false" outlineWidthM="0.3,mm" type="65639" mapFlags="1" frame="false" background="true" visibility="1" followPresetName="" mapRotation="0" itemRotation="0" keepLayerSet="false" opacity="1" drawCanvasItems="true" positionOnPage="21.3911,46,mm" groupUuid="" frameJoinStyle="miter" size="242,104,mm" uuid="{98195e4d-0084-4747-b15b-507220be6d8a}" position="21.3911,46,mm">
-        <FrameColor blue="0" alpha="255" red="0" green="0"/>
-        <BackgroundColor blue="255" alpha="255" red="255" green="255"/>
+      <LayoutItem itemRotation="0" blendMode="0" labelMargin="0,mm" position="21.3911,46,mm" zValue="3" templateUuid="{98195e4d-0084-4747-b15b-507220be6d8a}" mapFlags="1" keepLayerSet="false" followPresetName="" type="65639" groupUuid="" drawCanvasItems="true" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" followPreset="false" size="242,104,mm" positionOnPage="21.3911,46,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" mapRotation="0" uuid="{98195e4d-0084-4747-b15b-507220be6d8a}" background="true">
+        <FrameColor alpha="255" green="0" red="0" blue="0"/>
+        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
-        <Extent xmax="33978427.73650816082954407" ymax="16020257.03109830431640148" ymin="-13032965.18542143888771534" xmin="-33626185.49808585643768311"/>
+        <Extent ymin="-13032965.18542143888771534" ymax="16020257.03109830431640148" xmax="33978427.73650816082954407" xmin="-33626185.49808585643768311"/>
         <LayerSet>
-          <Layer name="db_point" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;points&quot; (geom) sql=" provider="spatialite">points20150803121107046</Layer>
-          <Layer name="Hello" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" provider="spatialite">hello20131022151106574</Layer>
-          <Layer name="Hello_SubsetString" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" provider="spatialite">Hello_copy20150804164427541</Layer>
-          <Layer name="Hello_Project_SubsetString" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=&quot;pkuid&quot; in ( 7, 8 )" provider="spatialite">Hello_SubsetString_copy20160222085231770</Layer>
-          <Layer name="Hello_Filter_SubsetString" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=" provider="spatialite">Hello_Project_SubsetString_copy20160223113949592</Layer>
-          <Layer name="dem" source="/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/dem.tif" provider="gdal">dem20150730091219559</Layer>
-          <Layer name="Country" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=" provider="spatialite">country20131022151106556</Layer>
-          <Layer name="Country_Labels" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=" provider="spatialite">Country_copy20161127151800736</Layer>
-          <Layer name="Country_Diagrams" source="dbname='/home/sbrunner/workspace/QGIS/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=" provider="spatialite">country20170328164317226</Layer>
+          <Layer provider="spatialite" name="db_point" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;points&quot; (geom) sql=">points20150803121107046</Layer>
+          <Layer provider="spatialite" name="Hello" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=">hello20131022151106574</Layer>
+          <Layer provider="spatialite" name="Hello_SubsetString" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=">Hello_copy20150804164427541</Layer>
+          <Layer provider="spatialite" name="Hello_Project_SubsetString" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=&quot;pkuid&quot; in ( 7, 8 )">Hello_SubsetString_copy20160222085231770</Layer>
+          <Layer provider="spatialite" name="Hello_Filter_SubsetString" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;hello&quot; (geom) sql=">Hello_Project_SubsetString_copy20160223113949592</Layer>
+          <Layer provider="gdal" name="dem" source="/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/dem.tif">dem20150730091219559</Layer>
+          <Layer provider="spatialite" name="Country" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=">country20131022151106556</Layer>
+          <Layer provider="spatialite" name="Country_Labels" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=">Country_copy20161127151800736</Layer>
+          <Layer provider="spatialite" name="Country_Diagrams" source="dbname='/home/dhont/3liz_dev/QGIS/qgis_master/tests/testdata/qgis_server_accesscontrol/helloworld.db' table=&quot;country&quot; (geom) sql=">country20170328164317226</Layer>
         </LayerSet>
-        <ComposerMapGrid unit="0" annotationPrecision="3" name="Grid 1" show="1" bottomAnnotationDirection="0" annotationFormat="0" gridFramePenColor="0,0,0,255" topAnnotationDisplay="0" rightAnnotationPosition="1" intervalX="0" rightAnnotationDirection="0" gridFrameStyle="0" bottomAnnotationPosition="1" rightAnnotationDisplay="0" frameFillColor2="0,0,0,255" leftAnnotationPosition="1" showAnnotation="0" intervalY="0" crossLength="3" leftAnnotationDisplay="0" uuid="{2097ba82-73aa-4cf8-911e-b3472427ff3f}" gridFrameSideFlags="15" topFrameDivisions="0" leftAnnotationDirection="0" annotationExpression="" offsetY="0" blendMode="0" leftFrameDivisions="0" topAnnotationPosition="1" topAnnotationDirection="0" frameFillColor1="255,255,255,255" frameAnnotationDistance="1" gridStyle="0" annotationFontColor="0,0,0,255" gridFrameWidth="2" gridFramePenThickness="0.5" rightFrameDivisions="0" bottomAnnotationDisplay="0" bottomFrameDivisions="0" offsetX="0">
+        <ComposerMapGrid annotationExpression="" leftAnnotationDisplay="0" rightAnnotationPosition="1" topAnnotationDisplay="0" rightAnnotationDirection="0" annotationPrecision="3" bottomAnnotationDirection="0" topAnnotationPosition="1" rightAnnotationDisplay="0" leftAnnotationDirection="0" rightFrameDivisions="0" annotationFontColor="0,0,0,255" intervalY="0" uuid="{2097ba82-73aa-4cf8-911e-b3472427ff3f}" frameAnnotationDistance="1" frameFillColor1="255,255,255,255" offsetY="0" offsetX="0" blendMode="0" unit="0" leftFrameDivisions="0" crossLength="3" topAnnotationDirection="0" bottomFrameDivisions="0" frameFillColor2="0,0,0,255" showAnnotation="0" name="Grid 1" gridFrameMargin="0" gridFrameStyle="0" annotationFormat="0" position="3" minimumIntervalWidth="50" bottomAnnotationDisplay="0" maximumIntervalWidth="100" leftAnnotationPosition="1" gridFrameSideFlags="15" bottomAnnotationPosition="1" gridFramePenColor="0,0,0,255" intervalX="0" topFrameDivisions="0" gridFramePenThickness="0.5" gridStyle="0" gridFrameWidth="2" show="1">
           <lineStyle>
-            <symbol name="" alpha="1" clip_to_extent="1" type="line">
-              <layer enabled="1" pass="0" class="SimpleLine" locked="0">
+            <symbol type="line" alpha="1" clip_to_extent="1" name="" force_rhr="0">
+              <layer class="SimpleLine" enabled="1" pass="0" locked="0">
                 <prop v="square" k="capstyle"/>
                 <prop v="5;2" k="customdash"/>
                 <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
@@ -3637,21 +4165,22 @@ def my_form_open(dialog, layer, feature):
                 <prop v="0" k="offset"/>
                 <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
                 <prop v="MM" k="offset_unit"/>
+                <prop v="0" k="ring_filter"/>
                 <prop v="0" k="use_custom_dash"/>
                 <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" value="" type="QString"/>
+                    <Option type="QString" name="name" value=""/>
                     <Option name="properties"/>
-                    <Option name="type" value="collection" type="QString"/>
+                    <Option type="QString" name="type" value="collection"/>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </lineStyle>
           <markerStyle>
-            <symbol name="" alpha="1" clip_to_extent="1" type="marker">
-              <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
+            <symbol type="marker" alpha="1" clip_to_extent="1" name="" force_rhr="0">
+              <layer class="SimpleMarker" enabled="1" pass="0" locked="0">
                 <prop v="0" k="angle"/>
                 <prop v="0,0,0,255" k="color"/>
                 <prop v="1" k="horizontal_anchor_point"/>
@@ -3672,59 +4201,70 @@ def my_form_open(dialog, layer, feature):
                 <prop v="1" k="vertical_anchor_point"/>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" value="" type="QString"/>
+                    <Option type="QString" name="name" value=""/>
                     <Option name="properties"/>
-                    <Option name="type" value="collection" type="QString"/>
+                    <Option type="QString" name="type" value="collection"/>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </markerStyle>
           <annotationFontProperties description=",11,-1,5,50,0,0,0,0,0" style=""/>
+          <LayoutObject>
+            <dataDefinedProperties>
+              <Option type="Map">
+                <Option type="QString" name="name" value=""/>
+                <Option name="properties"/>
+                <Option type="QString" name="type" value="collection"/>
+              </Option>
+            </dataDefinedProperties>
+            <customproperties/>
+          </LayoutObject>
         </ComposerMapGrid>
-        <AtlasMap margin="0.10000000000000001" scalingMode="2" atlasDriven="0"/>
+        <AtlasMap atlasDriven="0" margin="0.10000000000000001" scalingMode="2"/>
+        <labelBlockingItems/>
       </LayoutItem>
-      <LayoutItem blendMode="0" referencePoint="0" excludeFromExports="0" positionLock="false" templateUuid="{05c05681-4df2-4c58-b5d7-cea8e08dd782}" marginY="1" zValue="2" id="" marginX="1" outlineWidthM="0.3,mm" type="65641" frame="false" background="false" visibility="1" halign="1" itemRotation="0" opacity="1" valign="32" positionOnPage="213.302,161.791,mm" groupUuid="" frameJoinStyle="miter" size="64.3016,11.0626,mm" labelText="Welcome to our world...." htmlState="0" uuid="{05c05681-4df2-4c58-b5d7-cea8e08dd782}" position="213.302,161.791,mm">
-        <FrameColor blue="0" alpha="255" red="0" green="0"/>
-        <BackgroundColor blue="255" alpha="255" red="255" green="255"/>
+      <LayoutItem itemRotation="0" blendMode="0" position="213.302,161.791,mm" zValue="2" templateUuid="{05c05681-4df2-4c58-b5d7-cea8e08dd782}" halign="1" htmlState="0" labelText="Welcome to our world...." type="65641" groupUuid="" marginX="1" marginY="1" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" size="64.3016,11.0626,mm" positionOnPage="213.302,161.791,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{05c05681-4df2-4c58-b5d7-cea8e08dd782}" background="false" valign="32">
+        <FrameColor alpha="255" green="0" red="0" blue="0"/>
+        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
         <LabelFont description="DejaVu Sans,12,-1,5,75,0,0,0,0,0" style=""/>
-        <FontColor blue="0" red="0" green="0"/>
+        <FontColor alpha="255" green="0" red="0" blue="0"/>
       </LayoutItem>
-      <LayoutItem blendMode="0" referencePoint="0" excludeFromExports="0" positionLock="false" templateUuid="{faa8706c-3878-455c-9fd5-607cdd8739f3}" marginY="1" zValue="1" id="" marginX="1" outlineWidthM="0.3,mm" type="65641" frame="false" background="false" visibility="1" halign="1" itemRotation="0" opacity="1" valign="32" positionOnPage="49.9838,9.33411,mm" groupUuid="" frameJoinStyle="miter" size="215.03,28.0023,mm" labelText="QGIS Mapserver" htmlState="0" uuid="{faa8706c-3878-455c-9fd5-607cdd8739f3}" position="49.9838,9.33411,mm">
-        <FrameColor blue="0" alpha="255" red="0" green="0"/>
-        <BackgroundColor blue="255" alpha="255" red="255" green="255"/>
+      <LayoutItem itemRotation="0" blendMode="0" position="49.9838,9.33411,mm" zValue="1" templateUuid="{faa8706c-3878-455c-9fd5-607cdd8739f3}" halign="1" htmlState="0" labelText="QGIS Mapserver" type="65641" groupUuid="" marginX="1" marginY="1" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" size="215.03,28.0023,mm" positionOnPage="49.9838,9.33411,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{faa8706c-3878-455c-9fd5-607cdd8739f3}" background="false" valign="32">
+        <FrameColor alpha="255" green="0" red="0" blue="0"/>
+        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
         <LabelFont description="DejaVu Sans,48,-1,5,75,0,0,0,0,0" style=""/>
-        <FontColor blue="0" red="0" green="0"/>
+        <FontColor alpha="255" green="0" red="0" blue="0"/>
       </LayoutItem>
       <customproperties/>
-      <Atlas enabled="0" filenamePattern="'output_'||@atlas_featurenumber" coverageLayer="" hideCoverage="0" sortFeatures="0" pageNameExpression="" filterFeatures="0"/>
+      <Atlas pageNameExpression="" hideCoverage="0" enabled="0" filterFeatures="0" coverageLayer="" filenamePattern="'output_'||@atlas_featurenumber" sortFeatures="0"/>
     </Layout>
-    <Layout units="mm" worldFileMap="{f254751a-896d-48e8-8eb3-795d74b397c7}" printResolution="300" name="layoutA4twoMaps">
-      <Snapper tolerance="5" snapToGuides="1" snapToItems="1" snapToGrid="0"/>
-      <Grid resUnits="mm" offsetX="0" offsetUnits="mm" resolution="10" offsetY="0"/>
+    <Layout units="mm" name="layoutA4twoMaps" worldFileMap="{f254751a-896d-48e8-8eb3-795d74b397c7}" printResolution="300">
+      <Snapper snapToGrid="0" snapToItems="1" tolerance="5" snapToGuides="1"/>
+      <Grid offsetUnits="mm" resUnits="mm" offsetX="0" offsetY="0" resolution="10"/>
       <PageCollection>
-        <symbol name="" alpha="1" clip_to_extent="1" type="fill">
-          <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <symbol type="fill" alpha="1" clip_to_extent="1" name="" force_rhr="0">
+          <layer class="SimpleFill" enabled="1" pass="0" locked="0">
             <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
             <prop v="255,255,255,255" k="color"/>
             <prop v="miter" k="joinstyle"/>
@@ -3738,67 +4278,95 @@ def my_form_open(dialog, layer, feature):
             <prop v="solid" k="style"/>
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" name="name" value=""/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" name="type" value="collection"/>
               </Option>
             </data_defined_properties>
           </layer>
         </symbol>
-        <LayoutItem blendMode="0" referencePoint="0" excludeFromExports="0" positionLock="false" templateUuid="{8859d5da-91e8-4a09-bd4b-c32d62a781ce}" zValue="0" id="" outlineWidthM="0.3,mm" type="65638" frame="false" background="true" visibility="1" itemRotation="0" opacity="1" positionOnPage="0,0,mm" groupUuid="" frameJoinStyle="miter" size="297,210,mm" uuid="{8859d5da-91e8-4a09-bd4b-c32d62a781ce}" position="0,0,mm">
-          <FrameColor blue="0" alpha="255" red="0" green="0"/>
-          <BackgroundColor blue="255" alpha="255" red="255" green="255"/>
+        <LayoutItem itemRotation="0" blendMode="0" position="0,0,mm" zValue="0" templateUuid="{8859d5da-91e8-4a09-bd4b-c32d62a781ce}" type="65638" groupUuid="" referencePoint="0" outlineWidthM="0.3,mm" positionLock="false" frameJoinStyle="miter" id="" size="297,210,mm" positionOnPage="0,0,mm" excludeFromExports="0" visibility="1" frame="false" opacity="1" uuid="{8859d5da-91e8-4a09-bd4b-c32d62a781ce}" background="true">
+          <FrameColor alpha="255" green="0" red="0" blue="0"/>
+          <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
           <LayoutObject>
             <dataDefinedProperties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" name="name" value=""/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" name="type" value="collection"/>
               </Option>
             </dataDefinedProperties>
             <customproperties/>
           </LayoutObject>
+          <symbol type="fill" alpha="1" clip_to_extent="1" name="" force_rhr="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
+              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+              <prop v="255,255,255,255" k="color"/>
+              <prop v="miter" k="joinstyle"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="35,35,35,255" k="outline_color"/>
+              <prop v="no" k="outline_style"/>
+              <prop v="0.26" k="outline_width"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="solid" k="style"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" name="name" value=""/>
+                  <Option name="properties"/>
+                  <Option type="QString" name="type" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
         </LayoutItem>
         <GuideCollection visible="1"/>
       </PageCollection>
-      <LayoutItem blendMode="0" referencePoint="0" excludeFromExports="0" positionLock="false" templateUuid="{330623aa-9cad-41c0-aeb0-167bb9ffb602}" zValue="2" id="" followPreset="false" outlineWidthM="1,mm" type="65639" mapFlags="1" frame="true" background="true" visibility="1" followPresetName="" mapRotation="0" itemRotation="0" keepLayerSet="false" opacity="1" drawCanvasItems="true" positionOnPage="158.959,111.439,mm" groupUuid="" frameJoinStyle="miter" size="88.1003,70.2279,mm" uuid="{330623aa-9cad-41c0-aeb0-167bb9ffb602}" position="158.959,111.439,mm">
-        <FrameColor blue="28" alpha="255" red="227" green="26"/>
-        <BackgroundColor blue="255" alpha="255" red="255" green="255"/>
+      <LayoutItem itemRotation="0" blendMode="0" labelMargin="0,mm" position="158.959,111.439,mm" zValue="2" templateUuid="{330623aa-9cad-41c0-aeb0-167bb9ffb602}" mapFlags="1" keepLayerSet="false" followPresetName="" type="65639" groupUuid="" drawCanvasItems="true" referencePoint="0" outlineWidthM="1,mm" positionLock="false" frameJoinStyle="miter" id="" followPreset="false" size="88.1003,70.2279,mm" positionOnPage="158.959,111.439,mm" excludeFromExports="0" visibility="1" frame="true" opacity="1" mapRotation="0" uuid="{330623aa-9cad-41c0-aeb0-167bb9ffb602}" background="true">
+        <FrameColor alpha="255" green="26" red="227" blue="28"/>
+        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
-        <Extent xmax="19375243.89574331790208817" ymax="138857.9720494169741869" ymin="-5848927.97872077487409115" xmin="11863620.20301065221428871"/>
+        <Extent ymin="-5848927.97872077487409115" ymax="138857.9720494169741869" xmax="19375243.89574331790208817" xmin="11863620.20301065221428871"/>
         <LayerSet/>
-        <AtlasMap margin="0.10000000000000001" scalingMode="2" atlasDriven="0"/>
+        <AtlasMap atlasDriven="0" margin="0.10000000000000001" scalingMode="2"/>
+        <labelBlockingItems/>
       </LayoutItem>
-      <LayoutItem blendMode="0" referencePoint="0" excludeFromExports="0" positionLock="false" templateUuid="{f254751a-896d-48e8-8eb3-795d74b397c7}" zValue="1" id="" followPreset="false" outlineWidthM="1,mm" type="65639" mapFlags="1" frame="true" background="true" visibility="1" followPresetName="" mapRotation="0" itemRotation="0" keepLayerSet="false" opacity="1" drawCanvasItems="true" positionOnPage="21.4468,19.5545,mm" groupUuid="" frameJoinStyle="miter" size="122.583,77.1663,mm" uuid="{f254751a-896d-48e8-8eb3-795d74b397c7}" position="21.4468,19.5545,mm">
-        <FrameColor blue="0" alpha="255" red="0" green="0"/>
-        <BackgroundColor blue="255" alpha="255" red="255" green="255"/>
+      <LayoutItem itemRotation="0" blendMode="0" labelMargin="0,mm" position="21.4468,19.5545,mm" zValue="1" templateUuid="{f254751a-896d-48e8-8eb3-795d74b397c7}" mapFlags="1" keepLayerSet="false" followPresetName="" type="65639" groupUuid="" drawCanvasItems="true" referencePoint="0" outlineWidthM="1,mm" positionLock="false" frameJoinStyle="miter" id="" followPreset="false" size="122.583,77.1663,mm" positionOnPage="21.4468,19.5545,mm" excludeFromExports="0" visibility="1" frame="true" opacity="1" mapRotation="0" uuid="{f254751a-896d-48e8-8eb3-795d74b397c7}" background="true">
+        <FrameColor alpha="255" green="0" red="0" blue="0"/>
+        <BackgroundColor alpha="255" green="255" red="255" blue="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
-        <Extent xmax="3792585.87797374185174704" ymax="7735504.74087103083729744" ymin="3006918.29964823648333549" xmin="-3719037.81475892383605242"/>
+        <Extent ymin="3006918.29964823648333549" ymax="7735504.74087103083729744" xmax="3792585.87797374185174704" xmin="-3719037.81475892383605242"/>
         <LayerSet/>
-        <AtlasMap margin="0.10000000000000001" scalingMode="2" atlasDriven="0"/>
+        <AtlasMap atlasDriven="0" margin="0.10000000000000001" scalingMode="2"/>
+        <labelBlockingItems/>
       </LayoutItem>
       <customproperties>
-        <property value="png" key="atlasRasterFormat"/>
+        <property key="atlasRasterFormat" value="png"/>
       </customproperties>
-      <Atlas enabled="0" filenamePattern="'output_'||@atlas_featurenumber" coverageLayer="" hideCoverage="0" sortFeatures="0" pageNameExpression="" filterFeatures="0"/>
+      <Atlas pageNameExpression="" hideCoverage="0" enabled="0" filterFeatures="0" coverageLayer="" filenamePattern="'output_'||@atlas_featurenumber" sortFeatures="0"/>
     </Layout>
   </Layouts>
+  <Bookmarks/>
+  <ProjectViewSettings UseProjectScales="0">
+    <Scales/>
+  </ProjectViewSettings>
 </qgis>


### PR DESCRIPTION
## Description

In QGIS Server, QgsAccessControl is used to apply access control to data. In the case of filter Expression,
QgsAccessControl will get expression provided by plugins add applies it. But instead of combine plugins
filter expressions with expression provided in the request, QgsAccesControl was override it, and only the
last plugin filter expression is applied.

The fix replace QgsFeatureRequest::setFilterExpression by QgsFeatureRequest::combineExpression

Bug found with the new lizmap-plugin for server