### PR TITLE
[ui][processing] Fix model designer dialog not remember panel state

### DIFF
--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -77,13 +77,14 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   : QMainWindow( parent, flags )
 {
   setupUi( this );
-  QgsGui::enableAutoGeometryRestore( this );
 
   setAttribute( Qt::WA_DeleteOnClose );
   setDockOptions( dockOptions() | QMainWindow::GroupedDragging );
   setWindowFlags( Qt::WindowMinimizeButtonHint |
                   Qt::WindowMaximizeButtonHint |
                   Qt::WindowCloseButtonHint );
+
+  QgsGui::enableAutoGeometryRestore( this );
 
   mModel = qgis::make_unique< QgsProcessingModelAlgorithm >();
   mModel->setProvider( QgsApplication::processingRegistry()->providerById( QStringLiteral( "model" ) ) );
@@ -339,11 +340,18 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
     repaintModel();
     endUndoCommand();
   } );
+
   updateWindowTitle();
+
+  // restore the toolbar and dock widgets positions using Qt settings API
+  restoreState( settings.value( QStringLiteral( "ModelDesigner/state" ), QByteArray(), QgsSettings::App ).toByteArray() );
 }
 
 QgsModelDesignerDialog::~QgsModelDesignerDialog()
 {
+  // store the toolbar/dock widget settings using Qt settings API
+  QgsSettings().setValue( QStringLiteral( "ModelDesigner/state" ), saveState(), QgsSettings::App );
+
   mIgnoreUndoStackChanges++;
   delete mSelectTool; // delete mouse handles before everything else
 }


### PR DESCRIPTION
## Description

Raise your hand if you've ever been irritated at the model designer not remembering its customized panel position.

:hand: :hand: :hand: :hand: :hand: :hand: :hand: :hand: :hand: :hand: :hand: 