### PR TITLE
Only show "reload data" button on the attribute table if the underlying provider supports it

### DIFF
--- a/python/core/auto_generated/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/qgsdataprovider.sip.in
@@ -301,12 +301,16 @@ databases and servers.
    It'd be nice to eventually be raster/vector neutral.
 %End
 
+
     virtual void reloadData();
 %Docstring
-Reloads the data from the source by calling :py:func:`~QgsDataProvider.reloadProviderData` implemented
-by providers with data caches to synchronize, changes in the data source, feature
-counts and other specific actions.
+Reloads the data from the source for providers with data caches to synchronize,
+changes in the data source, feature counts and other specific actions.
 Emits the `dataChanged` signal
+
+.. note::
+
+   only available for providers which implement the :py:func:`~QgsDataProvider.reloadProviderData` method.
 %End
 
     virtual QDateTime timestamp() const;

--- a/python/core/auto_generated/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/qgsvectordataprovider.sip.in
@@ -53,6 +53,7 @@ of feature and attribute information from a spatial datasource.
       CancelSupport,
       CreateRenderer,
       CreateLabeling,
+      ReloadData,
     };
 
     typedef QFlags<QgsVectorDataProvider::Capability> Capabilities;

--- a/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -76,7 +76,8 @@ Base class for raster data providers.
       ReadLayerMetadata,
       WriteLayerMetadata,
       ProviderHintBenefitsFromResampling,
-      ProviderHintCanPerformProviderResampling
+      ProviderHintCanPerformProviderResampling,
+      ReloadData
     };
 
     typedef QFlags<QgsRasterDataProvider::ProviderCapability> ProviderCapabilities;

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -269,11 +269,13 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   mActionFeatureActions->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mAction.svg" ) ) );
 
   // toggle editing
-  bool canChangeAttributes = mLayer->dataProvider()->capabilities() & QgsVectorDataProvider::ChangeAttributeValues;
-  bool canDeleteFeatures = mLayer->dataProvider()->capabilities() & QgsVectorDataProvider::DeleteFeatures;
-  bool canAddAttributes = mLayer->dataProvider()->capabilities() & QgsVectorDataProvider::AddAttributes;
-  bool canDeleteAttributes = mLayer->dataProvider()->capabilities() & QgsVectorDataProvider::DeleteAttributes;
-  bool canAddFeatures = mLayer->dataProvider()->capabilities() & QgsVectorDataProvider::AddFeatures;
+  QgsVectorDataProvider::Capabilities capabilities = mLayer->dataProvider()->capabilities();
+  bool canChangeAttributes = capabilities & QgsVectorDataProvider::ChangeAttributeValues;
+  bool canDeleteFeatures = capabilities & QgsVectorDataProvider::DeleteFeatures;
+  bool canAddAttributes = capabilities & QgsVectorDataProvider::AddAttributes;
+  bool canDeleteAttributes = capabilities & QgsVectorDataProvider::DeleteAttributes;
+  bool canAddFeatures = capabilities & QgsVectorDataProvider::AddFeatures;
+  bool canReload = capabilities & QgsVectorDataProvider::ReloadData;
 
   mActionToggleEditing->blockSignals( true );
   mActionToggleEditing->setCheckable( true );
@@ -296,6 +298,9 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
     mToolbar->removeAction( mActionAddFeature );
     mToolbar->removeAction( mActionPasteFeatures );
   }
+
+  if ( !canReload )
+    mToolbar->removeAction( mActionReload );
 
   mMainViewButtonGroup->setId( mTableViewButton, QgsDualView::AttributeTable );
   mMainViewButtonGroup->setId( mAttributeViewButton, QgsDualView::AttributeEditor );
@@ -596,7 +601,7 @@ void QgsAttributeTableDialog::mActionSaveEdits_triggered()
 
 void QgsAttributeTableDialog::mActionReload_triggered()
 {
-  mMainView->masterModel()->layer()->dataProvider()->reloadData();
+  mMainView->masterModel()->layer()->reload();
 }
 
 void QgsAttributeTableDialog::mActionAddFeature_triggered()

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -1641,8 +1641,9 @@ QString QgsGdalProvider::description() const
 
 QgsRasterDataProvider::ProviderCapabilities QgsGdalProvider::providerCapabilities() const
 {
-  return QgsRasterDataProvider::ProviderHintBenefitsFromResampling |
-         QgsRasterDataProvider::ProviderHintCanPerformProviderResampling;
+  return ProviderCapability::ProviderHintBenefitsFromResampling |
+         ProviderCapability::ProviderHintCanPerformProviderResampling |
+         ProviderCapability::ReloadData;
 }
 
 // This is used also by global isValidRasterFileName

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3015,6 +3015,7 @@ void QgsOgrProvider::computeCapabilities()
   }
 
   ability |= ReadLayerMetadata;
+  ability |= ReloadData;
 
   if ( updateModeActivated )
     leaveUpdateMode();

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -406,11 +406,14 @@ class CORE_EXPORT QgsDataProvider : public QObject
       return QString();
     }
 
+    // TODO QGIS 4 -> Make `reloadData()` non virtual. This should be implemented in `reloadProviderData()`.
+
     /**
-     * Reloads the data from the source by calling reloadProviderData() implemented
-     * by providers with data caches to synchronize, changes in the data source, feature
-     * counts and other specific actions.
+     * Reloads the data from the source for providers with data caches to synchronize,
+     * changes in the data source, feature counts and other specific actions.
      * Emits the `dataChanged` signal
+     *
+     * \note only available for providers which implement the reloadProviderData() method.
      */
     virtual void reloadData();
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -262,7 +262,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     /**
      * Returns the layer's data provider, it may be NULLPTR.
      */
-    virtual QgsDataProvider *dataProvider();
+    Q_INVOKABLE virtual QgsDataProvider *dataProvider();
 
     /**
      * Returns the layer's data provider in a const-correct manner, it may be NULLPTR.
@@ -502,8 +502,8 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     /**
      * Synchronises with changes in the datasource
-        */
-    virtual void reload() {}
+     */
+    Q_INVOKABLE virtual void reload() {}
 
     /**
      * Returns new instance of QgsMapLayerRenderer that will be used for rendering of given context

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -94,6 +94,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
       CancelSupport = 1 << 23, //!< Supports interruption of pending queries from a separated thread. Since QGIS 3.2
       CreateRenderer = 1 << 24, //!< Provider can create feature renderers using backend-specific formatting information. Since QGIS 3.2. See QgsVectorDataProvider::createRenderer().
       CreateLabeling = 1 << 25, //!< Provider can set labeling settings using backend-specific formatting information. Since QGIS 3.6. See QgsVectorDataProvider::createLabeling().
+      ReloadData = 1 << 26, //!< Provider is able to force reload data
     };
 
     Q_DECLARE_FLAGS( Capabilities, Capability )
@@ -400,7 +401,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
      * a spatial filter is active on this provider, so it may
      * be prudent to check this value per intended operation.
      */
-    virtual QgsVectorDataProvider::Capabilities capabilities() const;
+    Q_INVOKABLE virtual QgsVectorDataProvider::Capabilities capabilities() const;
 
     /**
      *  Returns the above in friendly format.

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -101,7 +101,8 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
       ReadLayerMetadata = 1 << 1, //!< Provider can read layer metadata from data store. Since QGIS 3.0. See QgsDataProvider::layerMetadata()
       WriteLayerMetadata = 1 << 2, //!< Provider can write layer metadata to the data store. Since QGIS 3.0. See QgsDataProvider::writeLayerMetadata()
       ProviderHintBenefitsFromResampling = 1 << 3, //!< Provider benefits from resampling and should apply user default resampling settings (since QGIS 3.10)
-      ProviderHintCanPerformProviderResampling = 1 << 4 //!< Provider can perform resampling (to be opposed to post rendering resampling) (since QGIS 3.16)
+      ProviderHintCanPerformProviderResampling = 1 << 4, //!< Provider can perform resampling (to be opposed to post rendering resampling) (since QGIS 3.16)
+      ReloadData = 1 << 5 //!< Is able to force reload data / clear local caches. Since QGIS 3.18, see QgsDataProvider::reloadProviderData()
     };
 
     //! Provider capabilities

--- a/src/core/raster/qgsrasterinterface.h
+++ b/src/core/raster/qgsrasterinterface.h
@@ -183,16 +183,16 @@ class CORE_EXPORT QgsRasterInterface
     enum Capability
     {
       NoCapabilities   = 0,
-      Size             = 1 << 1, // original data source size (and thus resolution) is known, it is not always available, for example for WMS
-      Create           = 1 << 2, // create new datasets
-      Remove           = 1 << 3, // delete datasets
-      BuildPyramids    = 1 << 4, // supports building of pyramids (overviews)
-      Identify         = 1 << 5, // at least one identify format supported
-      IdentifyValue    = 1 << 6, // numerical values
-      IdentifyText     = 1 << 7, // WMS text
-      IdentifyHtml     = 1 << 8, // WMS HTML
-      IdentifyFeature  = 1 << 9, // WMS GML -> feature
-      Prefetch         = 1 << 10, // allow prefetching of out-of-view images
+      Size             = 1 << 1, //!< Original data source size (and thus resolution) is known, it is not always available, for example for WMS
+      Create           = 1 << 2, //!< Create new datasets
+      Remove           = 1 << 3, //!< Delete datasets
+      BuildPyramids    = 1 << 4, //!< Supports building of pyramids (overviews)
+      Identify         = 1 << 5, //!< At least one identify format supported
+      IdentifyValue    = 1 << 6, //!< Numerical values
+      IdentifyText     = 1 << 7, //!< WMS text
+      IdentifyHtml     = 1 << 8, //!< WMS HTML
+      IdentifyFeature  = 1 << 9, //!< WMS GML -> feature
+      Prefetch         = 1 << 10, //!< Allow prefetching of out-of-view images
     };
 
     QgsRasterInterface( QgsRasterInterface *input = nullptr );

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -319,7 +319,7 @@ QgsLayerMetadata QgsAfsProvider::layerMetadata() const
 
 QgsVectorDataProvider::Capabilities QgsAfsProvider::capabilities() const
 {
-  QgsVectorDataProvider::Capabilities c = QgsVectorDataProvider::SelectAtId | QgsVectorDataProvider::ReadLayerMetadata;
+  QgsVectorDataProvider::Capabilities c = QgsVectorDataProvider::SelectAtId | QgsVectorDataProvider::ReadLayerMetadata | QgsVectorDataProvider::Capability::ReloadData;
   if ( !mRendererDataMap.empty() )
   {
     c = c | QgsVectorDataProvider::CreateRenderer;

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -338,7 +338,7 @@ QgsAmsProvider::QgsAmsProvider( const QgsAmsProvider &other, const QgsDataProvid
 
 QgsRasterDataProvider::ProviderCapabilities QgsAmsProvider::providerCapabilities() const
 {
-  return QgsRasterDataProvider::ReadLayerMetadata;
+  return ProviderCapability::ReadLayerMetadata | ProviderCapability::ReloadData;
 }
 
 QString QgsAmsProvider::name() const { return AMS_PROVIDER_KEY; }

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1317,6 +1317,8 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
 {
   QgsDebugMsgLevel( QStringLiteral( "Checking for permissions on the relation" ), 2 );
 
+  mEnabledCapabilities = QgsVectorDataProvider::Capability::ReloadData;
+
   QgsPostgresResult testAccess;
   if ( !mIsQuery )
   {
@@ -1348,7 +1350,7 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
     // the latter flag is here just for compatibility
     if ( !mSelectAtIdDisabled )
     {
-      mEnabledCapabilities = QgsVectorDataProvider::SelectAtId;
+      mEnabledCapabilities |= QgsVectorDataProvider::SelectAtId;
     }
 
     if ( !inRecovery )

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -614,7 +614,7 @@ bool QgsVirtualLayerProvider::isValid() const
 
 QgsVectorDataProvider::Capabilities QgsVirtualLayerProvider::capabilities() const
 {
-  QgsVectorDataProvider::Capabilities capabilities = CancelSupport;
+  QgsVectorDataProvider::Capabilities capabilities = CancelSupport | QgsVectorDataProvider::Capability::ReloadData;
 
   if ( !mDefinition.uid().isNull() )
   {

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -1595,6 +1595,11 @@ QString  QgsWcsProvider::description() const
   return WCS_DESCRIPTION;
 }
 
+QgsRasterDataProvider::ProviderCapabilities QgsWcsProvider::providerCapabilities() const
+{
+  return ProviderCapability::ReloadData;
+}
+
 void QgsWcsProvider::reloadProviderData()
 {
   clearCache();

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -187,6 +187,7 @@ class QgsWcsProvider final: public QgsRasterDataProvider, QgsGdalProviderBase
     QString lastErrorFormat() override;
     QString name() const override;
     QString description() const override;
+    QgsRasterDataProvider::ProviderCapabilities providerCapabilities() const override;
     QList<QgsColorRampShader::ColorRampItem> colorTable( int bandNo )const override;
 
     int colorInterpretation( int bandNo ) const override;

--- a/src/providers/wfs/qgsoapifprovider.cpp
+++ b/src/providers/wfs/qgsoapifprovider.cpp
@@ -254,7 +254,7 @@ bool QgsOapifProvider::isValid() const
 
 QgsVectorDataProvider::Capabilities QgsOapifProvider::capabilities() const
 {
-  return QgsVectorDataProvider::SelectAtId | QgsVectorDataProvider::ReadLayerMetadata;
+  return QgsVectorDataProvider::SelectAtId | QgsVectorDataProvider::ReadLayerMetadata | QgsVectorDataProvider::Capability::ReloadData;
 }
 
 bool QgsOapifProvider::empty() const

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -1795,7 +1795,7 @@ QStringList QgsWFSProvider::insertedFeatureIds( const QDomDocument &serverRespon
 
 bool QgsWFSProvider::getCapabilities()
 {
-  mCapabilities = QgsVectorDataProvider::SelectAtId;
+  mCapabilities = QgsVectorDataProvider::SelectAtId | QgsVectorDataProvider::Capability::ReloadData;
 
   if ( mShared->mCaps.version.isEmpty() )
   {

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -583,7 +583,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
 
         self.assertEqual(vl.featureCount(), 1)
 
-        self.assertEqual(vl.dataProvider().capabilities(), QgsVectorDataProvider.SelectAtId)
+        self.assertTrue(vl.dataProvider().capabilities() & QgsVectorDataProvider.SelectAtId)
 
         (ret, _) = vl.dataProvider().addFeatures([QgsFeature()])
         self.assertFalse(ret)
@@ -915,7 +915,8 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
                          | QgsVectorDataProvider.ChangeAttributeValues
                          | QgsVectorDataProvider.ChangeGeometries
                          | QgsVectorDataProvider.DeleteFeatures
-                         | QgsVectorDataProvider.SelectAtId)
+                         | QgsVectorDataProvider.SelectAtId
+                         | QgsVectorDataProvider.ReloadData)
 
         (ret, _) = vl.dataProvider().addFeatures([QgsFeature()])
         self.assertFalse(ret)
@@ -3429,7 +3430,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
 
         self.assertEqual(vl.featureCount(), 1)
 
-        self.assertEqual(vl.dataProvider().capabilities(), QgsVectorDataProvider.SelectAtId)
+        self.assertTrue(vl.dataProvider().capabilities() & QgsVectorDataProvider.SelectAtId)
 
         (ret, _) = vl.dataProvider().addFeatures([QgsFeature()])
         self.assertFalse(ret)
@@ -4725,7 +4726,8 @@ Can't recognize service requested.
                          | QgsVectorDataProvider.ChangeAttributeValues
                          | QgsVectorDataProvider.ChangeGeometries
                          | QgsVectorDataProvider.DeleteFeatures
-                         | QgsVectorDataProvider.SelectAtId)
+                         | QgsVectorDataProvider.SelectAtId
+                         | QgsVectorDataProvider.ReloadData)
 
         # Transaction response failure (no modifications)
         shutil.copy(os.path.join(TEST_DATA_DIR, 'provider', 'wfst-1-1', 'transaction_response_empty.xml'), sanitize(endpoint, '?SERVICE=WFS&POSTDATA=<Transaction xmlns="http:__www.opengis.net_wfs" xmlns:xsi="http:__www.w3.org_2001_XMLSchema-instance" xmlns:gml="http:__www.opengis.net_gml" xmlns:ws1="ws1" xsi:schemaLocation="ws1 http:__fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=ws1:polygons" version="1.1.0" service="WFS"><Insert xmlns="http:__www.opengis.net_wfs"><polygons xmlns="ws1"_><_Insert><_Transaction>'))


### PR DESCRIPTION
## Description

Only show "reload data" button on the attribute table if the underlying provider supports it