### PR TITLE
Adapt import hook to allow importing py

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -791,7 +791,7 @@ def _import(name, globals={}, locals={}, fromlist=[], level=None):
 
     mod = _builtin_import(name, globals, locals, fromlist, level)
 
-    if mod and '__file__' in mod.__dict__:
+    if mod and getattr(mod, '__file__', None):
         module_name = mod.__name__ if fromlist else name
         package_name = module_name.split('.')[0]
         # check whether the module belongs to one of our plugins


### PR DESCRIPTION
Fixes https://github.com/qgis/QGIS/issues/40564

`utils.py` patches the builtin import function. This patch checks whether `__file__` is in `mod.__dict__` (not sure why exactly) which raised a RecursionError while trying to import the `py` package since it imports itself when its `__dict__` attribute is accessed (starting the recursion there).

I don't know exactly what this piece of code is doing. As mentioned in the issue, checking `if package_name in available_plugins` seems weird to me as packages and plugins might just be two different things.
https://github.com/qgis/QGIS/blob/5deda1f4567aa0b6a6b00cd6c623d3fc0055ebe6/python/utils.py#L794-L807

Anyway this piece of code is pretty old apparently (11 years given git blame), I don't know if it's tested so the proposed patch is as minimal as it could be for being able to import `py` without raising a RecursionError.