### PR TITLE
Ctrl+tab love to the model and layout designer dialogs

### DIFF
--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -689,6 +689,16 @@ QgsLayoutDesignerDialog::QgsLayoutDesignerDialog( QWidget *parent, Qt::WindowFla
   connect( mActionUnlockAll, &QAction::triggered, this, &QgsLayoutDesignerDialog::unlockAllItems );
   connect( mActionLockItems, &QAction::triggered, this, &QgsLayoutDesignerDialog::lockSelectedItems );
 
+  QStringList docksTitle = settings.value( QStringLiteral( "LayoutDesigner/hiddenDocksTitle" ), QStringList(), QgsSettings::App ).toStringList();
+  QStringList docksActive = settings.value( QStringLiteral( "LayoutDesigner/hiddenDocksActive" ), QStringList(), QgsSettings::App ).toStringList();
+  if ( !docksTitle.isEmpty() )
+  {
+    for ( const auto &title : docksTitle )
+    {
+      mPanelStatus.insert( title, PanelStatus( true, docksActive.contains( title ) ) );
+    }
+  }
+  mActionHidePanels->setChecked( !docksTitle.isEmpty() );
   connect( mActionHidePanels, &QAction::toggled, this, &QgsLayoutDesignerDialog::setPanelVisibility );
 
   connect( mActionDeleteSelection, &QAction::triggered, this, [ = ]
@@ -938,6 +948,31 @@ QgsLayoutDesignerDialog::QgsLayoutDesignerDialog( QWidget *parent, Qt::WindowFla
   connect( mView, &QgsLayoutView::statusMessage, this, &QgsLayoutDesignerDialog::statusMessageReceived );
 
   connect( QgsProject::instance(), &QgsProject::isDirtyChanged, this, &QgsLayoutDesignerDialog::updateWindowTitle );
+}
+
+QgsLayoutDesignerDialog::~QgsLayoutDesignerDialog()
+{
+  QgsSettings settings;
+  if ( !mPanelStatus.isEmpty() )
+  {
+    QStringList docksTitle;
+    QStringList docksActive;
+
+    for ( const auto &panel : mPanelStatus.toStdMap() )
+    {
+      if ( panel.second.isVisible )
+        docksTitle << panel.first;
+      if ( panel.second.isActive )
+        docksActive << panel.first;
+    }
+    settings.setValue( QStringLiteral( "LayoutDesigner/hiddenDocksTitle" ), docksTitle, QgsSettings::App );
+    settings.setValue( QStringLiteral( "LayoutDesigner/hiddenDocksActive" ), docksActive, QgsSettings::App );
+  }
+  else
+  {
+    settings.remove( QStringLiteral( "LayoutDesigner/hiddenDocksTitle" ), QgsSettings::App );
+    settings.remove( QStringLiteral( "LayoutDesigner/hiddenDocksActive" ), QgsSettings::App );
+  }
 }
 
 QgsAppLayoutDesignerInterface *QgsLayoutDesignerDialog::iface()
@@ -1364,7 +1399,6 @@ void QgsLayoutDesignerDialog::setPanelVisibility( bool hidden )
   {
     mPanelStatus.clear();
     //record status of all docks
-
     for ( QDockWidget *dock : docks )
     {
       mPanelStatus.insert( dock->windowTitle(), PanelStatus( dock->isVisible(), false ) );
@@ -1383,12 +1417,10 @@ void QgsLayoutDesignerDialog::setPanelVisibility( bool hidden )
     //restore visibility of all docks
     for ( QDockWidget *dock : docks )
     {
-      if ( ! mPanelStatus.contains( dock->windowTitle() ) )
+      if ( mPanelStatus.contains( dock->windowTitle() ) )
       {
-        dock->setVisible( true );
-        continue;
+        dock->setVisible( mPanelStatus.value( dock->windowTitle() ).isVisible );
       }
-      dock->setVisible( mPanelStatus.value( dock->windowTitle() ).isVisible );
     }
 
     //restore previously active dock tabs
@@ -1398,12 +1430,13 @@ void QgsLayoutDesignerDialog::setPanelVisibility( bool hidden )
       for ( int i = 0; i < tabBar->count(); ++i )
       {
         QString tabTitle = tabBar->tabText( i );
-        if ( mPanelStatus.value( tabTitle ).isActive )
+        if ( mPanelStatus.contains( tabTitle ) && mPanelStatus.value( tabTitle ).isActive )
         {
           tabBar->setCurrentIndex( i );
         }
       }
     }
+    mPanelStatus.clear();
   }
 }
 

--- a/src/app/layout/qgslayoutdesignerdialog.h
+++ b/src/app/layout/qgslayoutdesignerdialog.h
@@ -103,6 +103,7 @@ class QgsLayoutDesignerDialog: public QMainWindow, public Ui::QgsLayoutDesignerB
   public:
 
     QgsLayoutDesignerDialog( QWidget *parent = nullptr, Qt::WindowFlags flags = Qt::WindowFlags() );
+    ~QgsLayoutDesignerDialog() override;
 
     /**
      * Returns the designer interface for the dialog.

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -367,7 +367,7 @@ QgsModelDesignerDialog::~QgsModelDesignerDialog()
     QStringList docksTitle;
     QStringList docksActive;
 
-    for ( const auto panel : mPanelStatus.toStdMap() )
+    for ( const auto &panel : mPanelStatus.toStdMap() )
     {
       if ( panel.second.isVisible )
         docksTitle << panel.first;

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -158,6 +158,18 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
     mScene->selectAll();
   } );
 
+  QStringList docksTitle = settings.value( QStringLiteral( "ModelDesigner/hiddenDocksTitle" ), QStringList(), QgsSettings::App ).toStringList();
+  QStringList docksActive = settings.value( QStringLiteral( "ModelDesigner/hiddenDocksActive" ), QStringList(), QgsSettings::App ).toStringList();
+  if ( !docksTitle.isEmpty() )
+  {
+    for ( const auto &title : docksTitle )
+    {
+      mPanelStatus.insert( title, PanelStatus( true, docksActive.contains( title ) ) );
+    }
+  }
+  mActionHidePanels->setChecked( !docksTitle.isEmpty() );
+  connect( mActionHidePanels, &QAction::toggled, this, &QgsModelDesignerDialog::setPanelVisibility );
+
   mUndoAction = mUndoStack->createUndoAction( this );
   mUndoAction->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionUndo.svg" ) ) );
   mUndoAction->setShortcuts( QKeySequence::Undo );
@@ -349,8 +361,30 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
 
 QgsModelDesignerDialog::~QgsModelDesignerDialog()
 {
+  QgsSettings settings;
+  if ( !mPanelStatus.isEmpty() )
+  {
+    QStringList docksTitle;
+    QStringList docksActive;
+
+    for ( const auto panel : mPanelStatus.toStdMap() )
+    {
+      if ( panel.second.isVisible )
+        docksTitle << panel.first;
+      if ( panel.second.isActive )
+        docksActive << panel.first;
+    }
+    settings.setValue( QStringLiteral( "ModelDesigner/hiddenDocksTitle" ), docksTitle, QgsSettings::App );
+    settings.setValue( QStringLiteral( "ModelDesigner/hiddenDocksActive" ), docksActive, QgsSettings::App );
+  }
+  else
+  {
+    settings.remove( QStringLiteral( "ModelDesigner/hiddenDocksTitle" ), QgsSettings::App );
+    settings.remove( QStringLiteral( "ModelDesigner/hiddenDocksActive" ), QgsSettings::App );
+  }
+
   // store the toolbar/dock widget settings using Qt settings API
-  QgsSettings().setValue( QStringLiteral( "ModelDesigner/state" ), saveState(), QgsSettings::App );
+  settings.setValue( QStringLiteral( "ModelDesigner/state" ), saveState(), QgsSettings::App );
 
   mIgnoreUndoStackChanges++;
   delete mSelectTool; // delete mouse handles before everything else
@@ -791,6 +825,56 @@ void QgsModelDesignerDialog::populateZoomToMenu()
       } );
       mGroupMenu->addAction( zoomAction );
     }
+  }
+}
+
+void QgsModelDesignerDialog::setPanelVisibility( bool hidden )
+{
+  const QList<QDockWidget *> docks = findChildren<QDockWidget *>();
+  const QList<QTabBar *> tabBars = findChildren<QTabBar *>();
+
+  if ( hidden )
+  {
+    mPanelStatus.clear();
+    //record status of all docks
+    for ( QDockWidget *dock : docks )
+    {
+      mPanelStatus.insert( dock->windowTitle(), PanelStatus( dock->isVisible(), false ) );
+      dock->setVisible( false );
+    }
+
+    //record active dock tabs
+    for ( QTabBar *tabBar : tabBars )
+    {
+      QString currentTabTitle = tabBar->tabText( tabBar->currentIndex() );
+      mPanelStatus[ currentTabTitle ].isActive = true;
+    }
+  }
+  else
+  {
+    //restore visibility of all docks
+    for ( QDockWidget *dock : docks )
+    {
+      if ( mPanelStatus.contains( dock->windowTitle() ) )
+      {
+        dock->setVisible( mPanelStatus.value( dock->windowTitle() ).isVisible );
+      }
+    }
+
+    //restore previously active dock tabs
+    for ( QTabBar *tabBar : tabBars )
+    {
+      //loop through all tabs in tab bar
+      for ( int i = 0; i < tabBar->count(); ++i )
+      {
+        QString tabTitle = tabBar->tabText( i );
+        if ( mPanelStatus.contains( tabTitle ) && mPanelStatus.value( tabTitle ).isActive )
+        {
+          tabBar->setCurrentIndex( i );
+        }
+      }
+    }
+    mPanelStatus.clear();
   }
 }
 

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -150,6 +150,7 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     void populateZoomToMenu();
     void validate();
     void reorderInputs();
+    void setPanelVisibility( bool hidden );
 
   private:
 
@@ -194,6 +195,17 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
 
     void fillInputsTree();
     void updateVariablesGui();
+
+    struct PanelStatus
+    {
+      PanelStatus( bool visible = true, bool active = false )
+        : isVisible( visible )
+        , isActive( active )
+      {}
+      bool isVisible;
+      bool isActive;
+    };
+    QMap< QString, PanelStatus > mPanelStatus;
 };
 
 

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -84,6 +84,8 @@
     <addaction name="mActionShowComments"/>
     <addaction name="separator"/>
     <addaction name="mActionSnappingEnabled"/>
+    <addaction name="separator"/>
+    <addaction name="mActionHidePanels"/>
    </widget>
    <widget class="QMenu" name="mMenuEdit">
     <property name="title">
@@ -694,6 +696,17 @@
   <action name="mActionReorderInputs">
    <property name="text">
     <string>Reorder Model Inputs…</string>
+   </property>
+  </action>
+  <action name="mActionHidePanels">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Toggle Panel &amp;Visibility</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Tab</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
## Description

This PR adds a ctrl+tab's toggle panel visibility action to the model designer dialog:
![Peek 2020-12-13 10-46](https://user-images.githubusercontent.com/1728657/102002613-c18e8700-3d30-11eb-858f-98700e537927.gif)

While looking into this, I've improved the layout designer dialog's own action to remember hidden panels across dialog re-opening. Without this, leaving the dialog with hidden panels leads to having to re-open individual panels when the dialog is re-opened.