### PR TITLE
Fix crash when removing a layer while Select by Expression dialog in opened

### DIFF
--- a/src/gui/qgsexpressionselectiondialog.cpp
+++ b/src/gui/qgsexpressionselectiondialog.cpp
@@ -41,6 +41,7 @@ QgsExpressionSelectionDialog::QgsExpressionSelectionDialog( QgsVectorLayer *laye
   connect( mActionSelectIntersect, &QAction::triggered, this, &QgsExpressionSelectionDialog::mActionSelectIntersect_triggered );
   connect( mButtonZoomToFeatures, &QToolButton::clicked, this, &QgsExpressionSelectionDialog::mButtonZoomToFeatures_clicked );
   connect( mPbnClose, &QPushButton::clicked, this, &QgsExpressionSelectionDialog::mPbnClose_clicked );
+  connect( mLayer, &QgsVectorLayer::willBeDeleted, this, &QgsExpressionSelectionDialog::close );
 
   setWindowTitle( tr( "%1 — Select by Expression" ).arg( layer->name() ) );
 


### PR DESCRIPTION
Fixes QGIS crashing when removing a layer that has a "Select by Expression" dialog opened. 

Fixes https://github.com/qgis/QGIS/issues/40554

## Description

Connected the slot "QgsExpressionSelectionDialog::close" and the signal "QgsVectorLayer::willBeDeleted" to catch the layer removal event and close the dialog before the layer is actually removed.