### PR TITLE
Stale bot on "feedback" issues

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,4 +1,4 @@
-name: "Close stale issues"
+name: "Handle stale issues"
 on:
   schedule:
   - cron: "30 1 * * *"

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,0 +1,39 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: >
+  The QGIS project highly values your report and would love to see it addressed.
+  However, this issue has been left in feedback mode for the last 14 days and is
+  being automatically marked as "stale".
+  
+  If you would like to continue with this issue, please provide any missing information
+  or answer any open questions. If you could resolve the issue yourself meanwhile,
+  please leave a note for future readers with the same problem and close the issue.
+
+  In case you should have any uncertainty, please leave a comment and we will be
+  happy to help you proceed with this issue.
+  
+  If there is no further activity on this issue, it will be closed in a week.
+
+close-issue-message: >
+  While we hate to see this happen, this Issue has been automatically closed because
+  it has not had any activity in the last 21 days despite being marked as feedback.
+  If this issue should be reconsidered, please follow the guidelines in the previous
+  comment and reopen this issue.
+  
+  Or, if you have any further questions, there are also
+  [further support channels](https://www.qgis.org/en/site/forusers/support.html)
+  that can help you.
+        stale-issue-label: 'stale'
+        only-labels: 'feedback'
+        days-before-stale: 14
+        days-before-close: 7

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -24,7 +24,7 @@ jobs:
   
   If there is no further activity on this issue, it will be closed in a week.
 
-close-issue-message: >
+        close-issue-message: >
   While we hate to see this happen, this Issue has been automatically closed because
   it has not had any activity in the last 21 days despite being marked as feedback.
   If this issue should be reconsidered, please follow the guidelines in the previous


### PR DESCRIPTION
## Description

Will stale issues with the "feedback" label after 14 days and close them after 21 days without any interaction.

@gioman what do you think?