### PR TITLE
[FEATURE][locator] Add delayed fetching of results

### DIFF
--- a/python/core/auto_generated/locator/qgslocatorfilter.sip.in
+++ b/python/core/auto_generated/locator/qgslocatorfilter.sip.in
@@ -315,6 +315,27 @@ Logs a ``message`` to the log panel
 .. versionadded:: 3.2
 %End
 
+    int fetchResultsDelay() const;
+%Docstring
+Returns the delay (in milliseconds) for the filter to wait prior to fetching results.
+
+.. seealso:: :py:func:`setFetchResultsDelay`
+
+.. versionadded:: 3.18
+%End
+
+    void setFetchResultsDelay( int delay );
+%Docstring
+Sets a ``delay`` (in milliseconds) for the filter to wait prior to fetching results.
+
+.. seealso:: :py:func:`fetchResultsDelay`
+
+.. note::
+
+   If the locator filter has a FastFlag, this value is ignored.
+
+.. versionadded:: 3.18
+%End
 
   signals:
 

--- a/src/core/locator/qgslocator.cpp
+++ b/src/core/locator/qgslocator.cpp
@@ -217,6 +217,14 @@ void QgsLocator::fetchResults( const QString &string, const QgsLocatorContext &c
     filter->moveToThread( thread );
     connect( thread, &QThread::started, filter, [filter, searchString, context, feedback]
     {
+      int delay = filter->fetchResultsDelay();
+      while ( delay > 0 )
+      {
+        if ( feedback->isCanceled() )
+          break;
+        QThread::msleep( 50 );
+        delay -= 50;
+      }
       if ( !feedback->isCanceled() )
         filter->fetchResults( searchString, context, feedback );
       filter->emit finished();

--- a/src/core/locator/qgslocatorfilter.h
+++ b/src/core/locator/qgslocatorfilter.h
@@ -355,6 +355,20 @@ class CORE_EXPORT QgsLocatorFilter : public QObject
      */
     void logMessage( const QString &message, Qgis::MessageLevel level = Qgis::Info );
 
+    /**
+     * Returns the delay (in milliseconds) for the filter to wait prior to fetching results.
+     * \see setFetchResultsDelay()
+     * \since QGIS 3.18
+     */
+    int fetchResultsDelay() const { return mFetchResultsDelay; }
+
+    /**
+     * Sets a \a delay (in milliseconds) for the filter to wait prior to fetching results.
+     * \see fetchResultsDelay()
+     * \note If the locator filter has a FastFlag, this value is ignored.
+     * \since QGIS 3.18
+     */
+    void setFetchResultsDelay( int delay ) { mFetchResultsDelay = delay; }
 
   signals:
 
@@ -374,6 +388,7 @@ class CORE_EXPORT QgsLocatorFilter : public QObject
     bool mEnabled = true;
     bool mUseWithoutPrefix = true;
     QString mActivePrefifx = QString();
+    int mFetchResultsDelay = 0;
 
 };
 


### PR DESCRIPTION
## Description

This PR implements a delayed fetching of results for the locator filters. This comes in handy when spamming a locator filter at every keystroke is either overly CPU intensive or breaks usage policy.