### PR TITLE
Allow disabling QgsNetworkAccessManager timeout functionality

### DIFF
--- a/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
@@ -267,6 +267,7 @@ Returns the network timeout length, in milliseconds.
     static void setTimeout( int time );
 %Docstring
 Sets the maximum timeout ``time`` for network requests, in milliseconds.
+If set to 0, no timeout is set.
 
 .. seealso:: :py:func:`timeout`
 

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -276,15 +276,18 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   // The timer will call abortRequest slot to abort the connection if needed.
   // The timer is stopped by the finished signal and is restarted on downloadProgress and
   // uploadProgress.
-  QTimer *timer = new QTimer( reply );
-  timer->setObjectName( QStringLiteral( "timeoutTimer" ) );
-  connect( timer, &QTimer::timeout, this, &QgsNetworkAccessManager::abortRequest );
-  timer->setSingleShot( true );
-  timer->start( timeout() );
+  if ( timeout() )
+  {
+    QTimer *timer = new QTimer( reply );
+    timer->setObjectName( QStringLiteral( "timeoutTimer" ) );
+    connect( timer, &QTimer::timeout, this, &QgsNetworkAccessManager::abortRequest );
+    timer->setSingleShot( true );
+    timer->start( timeout() );
 
-  connect( reply, &QNetworkReply::downloadProgress, timer, [timer] { timer->start(); } );
-  connect( reply, &QNetworkReply::uploadProgress, timer, [timer] { timer->start(); } );
-  connect( reply, &QNetworkReply::finished, timer, &QTimer::stop );
+    connect( reply, &QNetworkReply::downloadProgress, timer, [timer] { timer->start(); } );
+    connect( reply, &QNetworkReply::uploadProgress, timer, [timer] { timer->start(); } );
+    connect( reply, &QNetworkReply::finished, timer, &QTimer::stop );
+  }
   QgsDebugMsgLevel( QStringLiteral( "Created [reply:%1]" ).arg( reinterpret_cast< qint64 >( reply ), 0, 16 ), 3 );
 
   return reply;

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -424,6 +424,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
 
     /**
      * Sets the maximum timeout \a time for network requests, in milliseconds.
+     * If set to 0, no timeout is set.
      *
      * \see timeout()
      * \since QGIS 3.6


### PR DESCRIPTION
by setting the timout to 0

This can be interesting to overcome the limitations of the timeout
functionality by replacing it with QNetworkAccessManager::setTransferTimeout.
E.g. to have more than 6 downloads running in parallel.

## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
