### PR TITLE
Fix crash with legend creation of raster singleband pseudocolor renderer

### DIFF
--- a/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
@@ -438,6 +438,17 @@ QList<QgsLayerTreeModelLegendNode *> QgsSingleBandPseudoColorRenderer::createLeg
     res << new QgsSimpleLegendNode( nodeLayer, name );
   }
 
+  if ( !rampShader->sourceColorRamp() )
+  {
+    const QList< QPair< QString, QColor > > items = legendSymbologyItems();
+    res.reserve( items.size() );
+    for ( const QPair< QString, QColor > &item : items )
+    {
+      res << new QgsRasterSymbolLegendNode( nodeLayer, item.second, item.first );
+    }
+    return res;
+  }
+
   switch ( rampShader->colorRampType() )
   {
     case QgsColorRampShader::Interpolated:


### PR DESCRIPTION
## Description

@nyalldawson , some single band pseudocolor renderer's shader might not have a source ramp associated to it (old project files et cie), let's not crash there ;)