### PR TITLE
[ui] Insure color/value changes in the colormap tree are reflected in the color ramp button of the color ramp shader widget

### DIFF
--- a/python/core/auto_generated/raster/qgscolorrampshader.sip.in
+++ b/python/core/auto_generated/raster/qgscolorrampshader.sip.in
@@ -117,6 +117,13 @@ Returns the source color ramp.
 .. versionadded:: 3.0
 %End
 
+    QgsColorRamp *createColorRamp();
+%Docstring
+Creates a gradient color ramp from shader settings.
+
+.. versionadded:: 3.16
+%End
+
     void setSourceColorRamp( QgsColorRamp *colorramp /Transfer/ );
 %Docstring
 Set the source color ramp. Ownership is transferred to the shader.

--- a/python/core/auto_generated/raster/qgscolorrampshader.sip.in
+++ b/python/core/auto_generated/raster/qgscolorrampshader.sip.in
@@ -117,11 +117,11 @@ Returns the source color ramp.
 .. versionadded:: 3.0
 %End
 
-    QgsColorRamp *createColorRamp();
+    QgsColorRamp *createColorRamp() const /Factory/;
 %Docstring
 Creates a gradient color ramp from shader settings.
 
-.. versionadded:: 3.16
+.. versionadded:: 3.18
 %End
 
     void setSourceColorRamp( QgsColorRamp *colorramp /Transfer/ );

--- a/src/core/raster/qgscolorrampshader.cpp
+++ b/src/core/raster/qgscolorrampshader.cpp
@@ -135,7 +135,7 @@ QgsColorRamp *QgsColorRampShader::sourceColorRamp() const
   return mSourceColorRamp.get();
 }
 
-QgsColorRamp *QgsColorRampShader::createColorRamp()
+QgsColorRamp *QgsColorRampShader::createColorRamp() const
 {
   std::unique_ptr<QgsGradientColorRamp> ramp = qgis::make_unique< QgsGradientColorRamp >();
   int count = mColorRampItemList.size();

--- a/src/core/raster/qgscolorrampshader.cpp
+++ b/src/core/raster/qgscolorrampshader.cpp
@@ -135,6 +135,50 @@ QgsColorRamp *QgsColorRampShader::sourceColorRamp() const
   return mSourceColorRamp.get();
 }
 
+QgsColorRamp *QgsColorRampShader::createColorRamp()
+{
+  std::unique_ptr<QgsGradientColorRamp> ramp = qgis::make_unique< QgsGradientColorRamp >();
+  int count = mColorRampItemList.size();
+  if ( count == 0 )
+  {
+    const QColor none( 0, 0, 0, 0 );
+    ramp->setColor1( none );
+    ramp->setColor2( none );
+  }
+  else if ( count == 1 )
+  {
+    ramp->setColor1( mColorRampItemList[0].color );
+    ramp->setColor2( mColorRampItemList[0].color );
+  }
+  else
+  {
+    QgsGradientStopsList stops;
+    // minimum and maximum values can fall outside the range of the item list
+    const double min = minimumValue();
+    const double max = maximumValue();
+    for ( int i = 0; i < count; i++ )
+    {
+      double offset = ( mColorRampItemList[i].value - min ) / ( max - min );
+      if ( i == 0 )
+      {
+        ramp->setColor1( mColorRampItemList[i].color );
+        if ( offset <= 0.0 )
+          continue;
+      }
+      else if ( i == count - 1 )
+      {
+        ramp->setColor2( mColorRampItemList[i].color );
+        if ( offset >= 1.0 )
+          continue;
+      }
+      stops << QgsGradientStop( offset, mColorRampItemList[i].color );
+    }
+    ramp->setStops( stops );
+  }
+
+  return ramp.release();
+}
+
 void QgsColorRampShader::setSourceColorRamp( QgsColorRamp *colorramp )
 {
   mSourceColorRamp.reset( colorramp );

--- a/src/core/raster/qgscolorrampshader.h
+++ b/src/core/raster/qgscolorrampshader.h
@@ -158,9 +158,9 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
 
     /**
      * Creates a gradient color ramp from shader settings.
-     * \since QGIS 3.16
+     * \since QGIS 3.18
      */
-    QgsColorRamp *createColorRamp();
+    QgsColorRamp *createColorRamp() const SIP_FACTORY;
 
     /**
      * Set the source color ramp. Ownership is transferred to the shader.

--- a/src/core/raster/qgscolorrampshader.h
+++ b/src/core/raster/qgscolorrampshader.h
@@ -151,11 +151,16 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
 
     /**
      * Returns the source color ramp.
-     *
      * \see setSourceColorRamp()
      * \since QGIS 3.0
      */
     QgsColorRamp *sourceColorRamp() const;
+
+    /**
+     * Creates a gradient color ramp from shader settings.
+     * \since QGIS 3.16
+     */
+    QgsColorRamp *createColorRamp();
 
     /**
      * Set the source color ramp. Ownership is transferred to the shader.

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
@@ -429,7 +429,7 @@ QList<QgsLayerTreeModelLegendNode *> QgsSingleBandPseudoColorRenderer::createLeg
   if ( !mShader )
     return QList<QgsLayerTreeModelLegendNode *>();
 
-  QgsColorRampShader *rampShader = dynamic_cast<QgsColorRampShader *>( mShader->rasterShaderFunction() );
+  const QgsColorRampShader *rampShader = dynamic_cast<const QgsColorRampShader *>( mShader->rasterShaderFunction() );
   if ( !rampShader )
     return QList<QgsLayerTreeModelLegendNode *>();
 

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
@@ -429,7 +429,7 @@ QList<QgsLayerTreeModelLegendNode *> QgsSingleBandPseudoColorRenderer::createLeg
   if ( !mShader )
     return QList<QgsLayerTreeModelLegendNode *>();
 
-  const QgsColorRampShader *rampShader = dynamic_cast<const QgsColorRampShader *>( mShader->rasterShaderFunction() );
+  QgsColorRampShader *rampShader = dynamic_cast<QgsColorRampShader *>( mShader->rasterShaderFunction() );
   if ( !rampShader )
     return QList<QgsLayerTreeModelLegendNode *>();
 
@@ -441,24 +441,16 @@ QList<QgsLayerTreeModelLegendNode *> QgsSingleBandPseudoColorRenderer::createLeg
     res << new QgsSimpleLegendNode( nodeLayer, name );
   }
 
-  if ( !rampShader->sourceColorRamp() )
-  {
-    const QList< QPair< QString, QColor > > items = legendSymbologyItems();
-    res.reserve( items.size() );
-    for ( const QPair< QString, QColor > &item : items )
-    {
-      res << new QgsRasterSymbolLegendNode( nodeLayer, item.second, item.first );
-    }
-    return res;
-  }
-
   switch ( rampShader->colorRampType() )
   {
     case QgsColorRampShader::Interpolated:
       // for interpolated shaders we use a ramp legend node
-      res << new QgsColorRampLegendNode( nodeLayer, rampShader->sourceColorRamp()->clone(),
-                                         rampShader->legendSettings() ? *rampShader->legendSettings() : QgsColorRampLegendNodeSettings(),
-                                         rampShader->minimumValue(), rampShader->maximumValue() );
+      if ( !rampShader->colorRampItemList().isEmpty() )
+      {
+        res << new QgsColorRampLegendNode( nodeLayer, rampShader->createColorRamp(),
+                                           rampShader->legendSettings() ? *rampShader->legendSettings() : QgsColorRampLegendNodeSettings(),
+                                           rampShader->minimumValue(), rampShader->maximumValue() );
+      }
       break;
 
     case QgsColorRampShader::Discrete:

--- a/src/gui/raster/qgscolorrampshaderwidget.cpp
+++ b/src/gui/raster/qgscolorrampshaderwidget.cpp
@@ -284,6 +284,7 @@ void QgsColorRampShaderWidget::mAddEntryButton_clicked()
   autoLabel();
 
   loadMinimumMaximumFromTree();
+  updateColorRamp();
   emit widgetChanged();
 }
 
@@ -303,6 +304,7 @@ void QgsColorRampShaderWidget::mDeleteEntryButton_clicked()
   }
 
   loadMinimumMaximumFromTree();
+  updateColorRamp();
   emit widgetChanged();
 }
 
@@ -354,6 +356,12 @@ void QgsColorRampShaderWidget::mClassificationModeComboBox_currentIndexChanged( 
   QgsColorRampShader::ClassificationMode mode = static_cast< QgsColorRampShader::ClassificationMode >( mClassificationModeComboBox->itemData( index ).toInt() );
   mNumberOfEntriesSpinBox->setEnabled( mode != QgsColorRampShader::Continuous );
   emit classificationModeChanged( mode );
+}
+
+void QgsColorRampShaderWidget::updateColorRamp()
+{
+  std::unique_ptr< QgsColorRamp > ramp( shader().createColorRamp() );
+  whileBlocking( btnColorRamp )->setColorRamp( ramp.get() );
 }
 
 void QgsColorRampShaderWidget::applyColorRamp()
@@ -571,6 +579,7 @@ void QgsColorRampShaderWidget::mColormapTreeWidget_itemEdited( QTreeWidgetItem *
     {
       autoLabel();
       loadMinimumMaximumFromTree();
+      updateColorRamp();
       emit widgetChanged();
       break;
     }
@@ -586,6 +595,7 @@ void QgsColorRampShaderWidget::mColormapTreeWidget_itemEdited( QTreeWidgetItem *
     case ColorColumn:
     {
       loadMinimumMaximumFromTree();
+      updateColorRamp();
       emit widgetChanged();
       break;
     }

--- a/src/gui/raster/qgscolorrampshaderwidget.h
+++ b/src/gui/raster/qgscolorrampshaderwidget.h
@@ -134,6 +134,7 @@ class GUI_EXPORT QgsColorRampShaderWidget: public QWidget, protected Ui::QgsColo
   private slots:
 
     void applyColorRamp();
+    void updateColorRamp();
     void mAddEntryButton_clicked();
     void mDeleteEntryButton_clicked();
     void mLoadFromBandButton_clicked();

--- a/tests/src/python/test_qgsrastercolorrampshader.py
+++ b/tests/src/python/test_qgsrastercolorrampshader.py
@@ -16,7 +16,7 @@ import qgis  # NOQA
 
 from qgis.PyQt.QtGui import QColor
 
-from qgis.core import (QgsColorRampShader)
+from qgis.core import (QgsColorRampShader, QgsGradientColorRamp, QgsGradientStop)
 from qgis.testing import unittest
 
 
@@ -30,6 +30,21 @@ class TestQgsRasterColorRampShader(unittest.TestCase):
         shader.setColorRampItemList([item1, item2])
         self.assertFalse(shader.shade(float('NaN'))[0])
         self.assertFalse(shader.shade(float("inf"))[0])
+
+    def testCreateColorRamp(self):
+        shader = QgsColorRampShader(1, 3)
+
+        item1 = QgsColorRampShader.ColorRampItem(1, QColor(255, 0, 0))
+        item2 = QgsColorRampShader.ColorRampItem(2, QColor(255, 255, 0))
+        item3 = QgsColorRampShader.ColorRampItem(3, QColor(255, 255, 255))
+        shader.setColorRampItemList([item1, item2, item3])
+        shaderRamp = shader.createColorRamp()
+
+        gradientRamp = QgsGradientColorRamp(QColor(255, 0, 0), QColor(255, 255, 255), False, [QgsGradientStop(0.5, QColor(255, 255, 0))])
+
+        self.assertEqual(shaderRamp.color1(), gradientRamp.color1())
+        self.assertEqual(shaderRamp.color2(), gradientRamp.color2())
+        self.assertEqual(shaderRamp.stops(), gradientRamp.stops())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

The color ramp shader widget has had a longstanding shortcoming/issue whereas changing the values and colors of the shader via the colormap tree widget did _not_ update the source color ramp. It was irritating in the past, but now that @nyalldawson has come up with nice ramp legend items, the situation has become outright unacceptable :wink: This PR fixes the shortcoming.

GIF:
![Peek 2020-12-19 11-32](https://user-images.githubusercontent.com/1728657/102680833-adde9700-41ee-11eb-84ec-e2fc6e044cc7.gif)
_Without this PR, any color and value changes from the tree widget wouldn't be reflected in the legend either since the legend item relies on the source color ramp_