### PR TITLE
[wms] When decoding uri strings, insure local files are mapped to a 'path'  key

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -4644,7 +4644,22 @@ QVariantMap QgsWmsProviderMetadata::decodeUri( const QString &uri ) const
   QVariantMap decoded;
   for ( const auto &item : constItems )
   {
-    decoded[ item.first ] = item.second;
+    if ( item.first == QStringLiteral( "url" ) )
+    {
+      const QUrl url( item.second );
+      if ( url.isLocalFile() )
+      {
+        decoded[ QStringLiteral( "path" ) ] = url.toLocalFile();
+      }
+      else
+      {
+        decoded[ item.first ] = item.second;
+      }
+    }
+    else
+    {
+      decoded[ item.first ] = item.second;
+    }
   }
   return decoded;
 }
@@ -4655,7 +4670,14 @@ QString QgsWmsProviderMetadata::encodeUri( const QVariantMap &parts ) const
   QList<QPair<QString, QString> > items;
   for ( auto it = parts.constBegin(); it != parts.constEnd(); ++it )
   {
-    items.push_back( {it.key(), it.value().toString() } );
+    if ( it.key() == QStringLiteral( "path" ) )
+    {
+      items.push_back( { QStringLiteral( "url" ), QUrl::fromLocalFile( it.value().toString() ).toString() } );
+    }
+    else
+    {
+      items.push_back( { it.key(), it.value().toString() } );
+    }
   }
   query.setQueryItems( items );
   return query.toString();

--- a/tests/src/providers/testqgswmsprovider.cpp
+++ b/tests/src/providers/testqgswmsprovider.cpp
@@ -167,6 +167,17 @@ class TestQgsWmsProvider: public QObject
 
     }
 
+    void providerUriLocalFile()
+    {
+      QString uriString = QStringLiteral( "url=file:///my/local/tiles.mbtiles&type=mbtiles" );
+      QVariantMap parts = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "wms" ), uriString );
+      QVariantMap expectedParts { { QString( "type" ), QVariant( "mbtiles" ) },
+        { QString( "path" ), QVariant( "/my/local/tiles.mbtiles" ) } };
+      QCOMPARE( parts, expectedParts );
+
+      QString encodedUri = QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "wms" ), parts );
+      QCOMPARE( encodedUri, uriString );
+    }
 
     bool imageCheck( const QString &testType, QgsMapLayer *layer, const QgsRectangle &extent )
     {


### PR DESCRIPTION
## Description

Whenever an URL element refers to a local file when decoding a wms provider URI string,  that should be mapped to a "path" key in the returned QVariantMap to harmonize the return with other providers. 