### PR TITLE
Fix 3d camera yaw and pitch sensitivity

### DIFF
--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -305,8 +305,8 @@ void QgsCameraController::onPositionChanged( Qt3DInput::QMouseEvent *mouse )
     // rotate/tilt using mouse (camera moves as it rotates around its view center)
     float pitch = mCameraPose.pitchAngle();
     float yaw = mCameraPose.headingAngle();
-    pitch += dy;
-    yaw -= dx / 2;
+    pitch += 0.2f * dy;
+    yaw -= 0.2f * dx;
     mCameraPose.setPitchAngle( pitch );
     mCameraPose.setHeadingAngle( yaw );
     updateCameraFromPose();
@@ -315,7 +315,7 @@ void QgsCameraController::onPositionChanged( Qt3DInput::QMouseEvent *mouse )
   {
     // rotate/tilt using mouse (camera stays at one position as it rotates)
     float diffPitch = 0.2f * dy;
-    float diffYaw = 0.2f * -dx / 2;
+    float diffYaw = - 0.2f * dx;
     rotateCamera( diffPitch, diffYaw );
     updateCameraFromPose( true );
   }


### PR DESCRIPTION
## Description
Rotating the camera, either with shift or ctrl, had double sensitivity for pitch than for yaw. If that was not enough, when rotating with shift or middle mouse button, slow mouse movements on the already slow yaw control were not registered correctly because of integer division!

This should make controlling the camera a little more comfortable.


<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
