### PR TITLE
Added a unified way to check if the layer supports editing

### DIFF
--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -1791,6 +1791,15 @@ Makes layer read-only (editing disabled) or not
 :return: ``False`` if the layer is in editing yet
 %End
 
+    bool supportsEditing();
+%Docstring
+Returns whether the layer supports editing or not
+
+:return: ``False`` if the layer is read only or the data provider has no editing capabilities
+
+.. versionadded:: 3.18
+%End
+
     bool changeGeometry( QgsFeatureId fid, QgsGeometry &geometry, bool skipDefaultValue = false );
 %Docstring
 Changes a feature's ``geometry`` within the layer's edit buffer
@@ -2921,6 +2930,13 @@ Emitted when the read only state of this layer is changed.
 Only applies to manually set readonly state, not to the edit mode.
 
 .. versionadded:: 3.0
+%End
+
+    void supportsEditingChanged();
+%Docstring
+Emitted when the read only state or the data provider of this layer is changed.
+
+.. versionadded:: 3.18
 %End
 
     void symbolFeatureCountMapChanged();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11082,7 +11082,7 @@ bool QgisApp::toggleEditing( QgsMapLayer *layer, bool allowCancel )
 
   if ( !vlayer->isEditable() && !vlayer->readOnly() )
   {
-    if ( !( vlayer->dataProvider()->capabilities() & QgsVectorDataProvider::EditingCapabilities ) )
+    if ( !vlayer->supportsEditing() )
     {
       mActionToggleEditing->setChecked( false );
       mActionToggleEditing->setEnabled( false );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -14741,12 +14741,12 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
         bool canChangeAttributes = dprovider->capabilities() & QgsVectorDataProvider::ChangeAttributeValues;
         bool canDeleteFeatures = dprovider->capabilities() & QgsVectorDataProvider::DeleteFeatures;
         bool canAddFeatures = dprovider->capabilities() & QgsVectorDataProvider::AddFeatures;
-        bool canSupportEditing = dprovider->capabilities() & QgsVectorDataProvider::EditingCapabilities;
         bool canChangeGeometry = isSpatial && dprovider->capabilities() & QgsVectorDataProvider::ChangeGeometries;
+        bool canSupportEditing = vlayer->supportsEditing();
 
         mActionLayerSubsetString->setEnabled( !isEditable && dprovider->supportsSubsetString() );
 
-        mActionToggleEditing->setEnabled( canSupportEditing && !vlayer->readOnly() );
+        mActionToggleEditing->setEnabled( canSupportEditing );
         mActionToggleEditing->setChecked( canSupportEditing && isEditable );
         mActionSaveLayerEdits->setEnabled( canSupportEditing && isEditable && vlayer->isModified() );
         mUndoDock->widget()->setEnabled( canSupportEditing && isEditable );

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -240,8 +240,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
         // allow editing
         const QgsVectorDataProvider *provider = vlayer->dataProvider();
-        if ( provider &&
-             ( provider->capabilities() & QgsVectorDataProvider::EditingCapabilities ) )
+        if ( vlayer->supportsEditing() )
         {
           if ( toggleEditingAction )
           {

--- a/src/app/qgsguivectorlayertools.cpp
+++ b/src/app/qgsguivectorlayertools.cpp
@@ -56,7 +56,7 @@ bool QgsGuiVectorLayerTools::startEditing( QgsVectorLayer *layer ) const
 
   if ( !layer->isEditable() && !layer->readOnly() )
   {
-    if ( !( layer->dataProvider()->capabilities() & QgsVectorDataProvider::EditingCapabilities ) )
+    if ( !layer->supportsEditing() )
     {
       QgisApp::instance()->messageBar()->pushMessage( tr( "Start editing failed" ),
           tr( "Provider cannot be opened for editing" ),

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1434,12 +1434,7 @@ bool QgsVectorLayer::startEditing()
   }
 
   // allow editing if provider supports any of the capabilities
-  if ( !( mDataProvider->capabilities() & QgsVectorDataProvider::EditingCapabilities ) )
-  {
-    return false;
-  }
-
-  if ( mReadOnly )
+  if ( supportsEditing() )
   {
     return false;
   }

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -201,6 +201,8 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
   connect( QgsProject::instance()->relationManager(), &QgsRelationManager::relationsLoaded, this, &QgsVectorLayer::onRelationsLoaded );
 
   connect( this, &QgsVectorLayer::subsetStringChanged, this, &QgsMapLayer::configChanged );
+  connect( this, &QgsVectorLayer::dataSourceChanged, this, &QgsVectorLayer::supportsEditingChanged );
+  connect( this, &QgsVectorLayer::readOnlyChanged, this, &QgsVectorLayer::supportsEditingChanged );
 
   // Default simplify drawing settings
   QgsSettings settings;
@@ -3665,6 +3667,14 @@ bool QgsVectorLayer::setReadOnly( bool readonly )
   mReadOnly = readonly;
   emit readOnlyChanged();
   return true;
+}
+
+bool QgsVectorLayer::supportsEditing()
+{
+  if ( ! mDataProvider )
+    return false;
+
+  return mDataProvider->capabilities() & QgsVectorDataProvider::EditingCapabilities && ! mReadOnly;
 }
 
 bool QgsVectorLayer::isModified() const

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1434,7 +1434,7 @@ bool QgsVectorLayer::startEditing()
   }
 
   // allow editing if provider supports any of the capabilities
-  if ( supportsEditing() )
+  if ( !supportsEditing() )
   {
     return false;
   }

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -392,6 +392,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     Q_PROPERTY( QString mapTipTemplate READ mapTipTemplate WRITE setMapTipTemplate NOTIFY mapTipTemplateChanged )
     Q_PROPERTY( QgsEditFormConfig editFormConfig READ editFormConfig WRITE setEditFormConfig NOTIFY editFormConfigChanged )
     Q_PROPERTY( bool readOnly READ isReadOnly WRITE setReadOnly NOTIFY readOnlyChanged )
+    Q_PROPERTY( bool supportsEditing READ supportsEditing NOTIFY supportsEditingChanged )
 
   public:
 
@@ -1692,6 +1693,13 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     bool setReadOnly( bool readonly = true );
 
     /**
+     * Returns whether the layer supports editing or not
+     * \return FALSE if the layer is read only or the data provider has no editing capabilities
+     * \since QGIS 3.18
+     */
+    bool supportsEditing();
+
+    /**
      * Changes a feature's \a geometry within the layer's edit buffer
      * (but does not immediately commit the changes). The \a fid argument
      * specifies the ID of the feature to be changed.
@@ -2717,6 +2725,13 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \since QGIS 3.0
      */
     void readOnlyChanged();
+
+    /**
+     * Emitted when the read only state or the data provider of this layer is changed.
+     *
+     * \since QGIS 3.18
+     */
+    void supportsEditingChanged();
 
     /**
      * Emitted when the feature count for symbols on this layer has been recalculated.


### PR DESCRIPTION
Added a unified way whether the layer supports editing or not. Currently it has to check both whether the data providers has that capability and the layer is not read-only. This is error prone, as seen in #40694. Fixes #40694

Also I need this value in QML.
