### PR TITLE
[backport 3.16] Removes 'toggle editing' from the context menu of read-only layers

### DIFF
--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -238,8 +238,9 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
         // allow editing
         const QgsVectorDataProvider *provider = vlayer->dataProvider();
-        if ( provider &&
-             ( provider->capabilities() & QgsVectorDataProvider::EditingCapabilities ) )
+        if ( provider
+             && ( provider->capabilities() & QgsVectorDataProvider::EditingCapabilities )
+             && !vlayer->readOnly() )
         {
           if ( toggleEditingAction )
           {


### PR DESCRIPTION
See #40694 and #40695