### PR TITLE
Refresh the attribute table styles when feature modified programmatically

### DIFF
--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -766,10 +766,10 @@ bool QgsAttributeTableModel::setData( const QModelIndex &index, const QVariant &
   if ( !index.isValid() || index.column() >= mFieldCount || role != Qt::EditRole || !layer()->isEditable() )
     return false;
 
+  mRowStylesMap.remove( mFeat.id() );
+
   if ( !layer()->isModified() )
     return false;
-
-  mRowStylesMap.remove( mFeat.id() );
 
   return true;
 }


### PR DESCRIPTION
**Describe the bug**
Confitional formatting rules are not applied if the attribute is updated programatically for the first matching row. If multiple rows are selected, the conditional formatting rules are applied for all the features but the first feature.

| before | after |
|----------|--------|
| ![Peek 2020-12-21 07-58](https://user-images.githubusercontent.com/2820439/102744464-8b6d8a80-4362-11eb-8c5b-72a42719660c.gif)  | ![Peek 2020-12-21 07-54](https://user-images.githubusercontent.com/2820439/102744307-3598e280-4362-11eb-8f85-295141455232.gif) |

**Explanation**
1) you change an attribute programatically
2) this triggers the `QgsVectorLayerEditBuffer::changeAttributeValue`, all good
3) inside `QgsVectorLayerEditBuffer::changeAttributeValue` we push to the undoStack, make sense. BUT by pushing to the undoStack, we call `QgsAttributeTableModel::setData`, which invalidates the cached attribute table styles.
4) Since invalidating the attribute table styles cache depends on whether the layer has been modified, which depends whether the undoStack is not empty, we have the bug: we add a new undoStack item, but before finishing ,we check if the undoStack is empty, which it is, because we are in the middle of undoStack push.

I have traced who calls `QgsAttributeTableModel::setData` for a situation where it gets called and `layer()->isModified()` is false (other than the bug here), but failed to find any. Even if there is a hidden scenario that I missed, the worst thing would be additional performance penalty, since the attribute table styles cache has been cleared for that row.

Used the code below to trigger a change programatically.
```python
layer = iface.activeLayer()
selected_features = layer.getFeatures()
layer.startEditing()

for feature in selected_features:
    feature["disease"] = not feature["disease"]
    layer.updateFeature(feature)

layer.commitChanges()
```

Fixes #39532

I would suggest backporting.