### PR TITLE
Fix circle by three tangents parrallel when two are parallels

### DIFF
--- a/python/core/auto_generated/geometry/qgscircle.sip.in
+++ b/python/core/auto_generated/geometry/qgscircle.sip.in
@@ -93,7 +93,9 @@ The azimuth is the angle between ``center`` and ``pt1``.
 
     static QgsCircle from3Tangents( const QgsPoint &pt1_tg1, const QgsPoint &pt2_tg1,
                                     const QgsPoint &pt1_tg2, const QgsPoint &pt2_tg2,
-                                    const QgsPoint &pt1_tg3, const QgsPoint &pt2_tg3, double epsilon = 1E-8 ) /HoldGIL/;
+                                    const QgsPoint &pt1_tg3, const QgsPoint &pt2_tg3,
+                                    double epsilon = 1E-8,
+                                    QgsPoint pos = QgsPoint() ) /HoldGIL/;
 %Docstring
 Constructs a circle by 3 tangents on the circle (aka inscribed circle of a triangle).
 Z and m values are dropped for the center point.
@@ -106,6 +108,41 @@ The azimuth always takes the default value.
 :param pt1_tg3: First point of the third tangent.
 :param pt2_tg3: Second point of the third tangent.
 :param epsilon: Value used to compare point.
+
+.. versionadded:: 3.18
+
+.. seealso:: :py:func:`from3TangentsMulti`
+%End
+
+    static QVector<QgsCircle> from3TangentsMulti( const QgsPoint &pt1_tg1, const QgsPoint &pt2_tg1,
+        const QgsPoint &pt1_tg2, const QgsPoint &pt2_tg2,
+        const QgsPoint &pt1_tg3, const QgsPoint &pt2_tg3,
+        double epsilon = 1E-8,
+        QgsPoint pos = QgsPoint() ) /HoldGIL/;
+%Docstring
+Returns an array of circle constructed by 3 tangents on the circle (aka inscribed circle of a triangle).
+
+The vector can contain 0, 1 or 2 circles:
+
+- 0: Impossible to construct a circle from 3 tangents (three parallel tangents)
+- 1: The three tangents make a triangle or when two tangents are parallel there are two possible circles (see examples).
+  If pos is not an empty point, we use its coordinates to determine which circle will be returned.
+  More precisely the circle that will be returned will be the one whose center is on the same side as pos relative to the third tangent.
+- 2: Returns both solutions when two tangents are parallel (this implies that pos is an empty point).
+
+Z and m values are dropped for the center point.
+The azimuth always takes the default value.
+
+:param pt1_tg1: First point of the first tangent.
+:param pt2_tg1: Second point of the first tangent.
+:param pt1_tg2: First point of the second tangent.
+:param pt2_tg2: Second point of the second tangent.
+:param pt1_tg3: First point of the third tangent.
+:param pt2_tg3: Second point of the third tangent.
+:param epsilon: Value used to compare point.
+:param pos: (optional) Point to determine which circle use in case of multi return.
+
+.. seealso:: :py:func:`from3Tangents`
 %End
 
     static QgsCircle fromExtent( const QgsPoint &pt1, const QgsPoint &pt2 ) /HoldGIL/;

--- a/python/core/auto_generated/geometry/qgscircle.sip.in
+++ b/python/core/auto_generated/geometry/qgscircle.sip.in
@@ -108,8 +108,8 @@ The azimuth always takes the default value.
 :param pt1_tg3: First point of the third tangent.
 :param pt2_tg3: Second point of the third tangent.
 :param epsilon: Value used to compare point.
-:param pos: Point to determine which circle use in case of multiple possible circles.
-            If the solution is not unique and pos is an empty point, an empty circle is returned. -- This case happens only when two tangents are parallels. (since QGIS 3.18)
+:param pos: Point to determine which circle use in case of multi return.
+            If the solution is not unique and pos is an empty point, an empty circle is returned. -- This case happens only when two tangets are parallels. (since QGIS 3.18)
 
 .. seealso:: :py:func:`from3TangentsMulti`
 

--- a/python/core/auto_generated/geometry/qgscircle.sip.in
+++ b/python/core/auto_generated/geometry/qgscircle.sip.in
@@ -109,8 +109,7 @@ The azimuth always takes the default value.
 :param pt2_tg3: Second point of the third tangent.
 :param epsilon: Value used to compare point.
 :param pos: Point to determine which circle use in case of multi return.
-
-.. versionadded:: 3.18
+            If the solution is not unique and pos is an empty point, an empty circle is returned. -- This case happens only when two tangets are parallels. (since QGIS 3.18)
 
 .. seealso:: :py:func:`from3TangentsMulti`
 

--- a/python/core/auto_generated/geometry/qgscircle.sip.in
+++ b/python/core/auto_generated/geometry/qgscircle.sip.in
@@ -109,7 +109,7 @@ The azimuth always takes the default value.
 :param pt2_tg3: Second point of the third tangent.
 :param epsilon: Value used to compare point.
 :param pos: Point to determine which circle use in case of multiple possible circles.
-            If the solution is not unique and pos is an empty point, an empty circle is returned. -- This case happens only when two tangets are parallels. (since QGIS 3.18)
+            If the solution is not unique and pos is an empty point, an empty circle is returned. -- This case happens only when two tangents are parallels. (since QGIS 3.18)
 
 .. seealso:: :py:func:`from3TangentsMulti`
 

--- a/python/core/auto_generated/geometry/qgscircle.sip.in
+++ b/python/core/auto_generated/geometry/qgscircle.sip.in
@@ -108,7 +108,7 @@ The azimuth always takes the default value.
 :param pt1_tg3: First point of the third tangent.
 :param pt2_tg3: Second point of the third tangent.
 :param epsilon: Value used to compare point.
-:param pos: Point to determine which circle use in case of multi return.
+:param pos: Point to determine which circle use in case of multiple possible circles.
             If the solution is not unique and pos is an empty point, an empty circle is returned. -- This case happens only when two tangets are parallels. (since QGIS 3.18)
 
 .. seealso:: :py:func:`from3TangentsMulti`

--- a/python/core/auto_generated/geometry/qgscircle.sip.in
+++ b/python/core/auto_generated/geometry/qgscircle.sip.in
@@ -108,10 +108,24 @@ The azimuth always takes the default value.
 :param pt1_tg3: First point of the third tangent.
 :param pt2_tg3: Second point of the third tangent.
 :param epsilon: Value used to compare point.
+:param pos: Point to determine which circle use in case of multi return.
 
 .. versionadded:: 3.18
 
 .. seealso:: :py:func:`from3TangentsMulti`
+
+Example
+-------
+
+.. code-block:: python
+
+      # [(0 0), (5 0)] and [(5 5), (10 5)] are parallels
+      QgsCircle.from3Tangents(QgsPoint(0, 0), QgsPoint(5, 0), QgsPoint(5, 5), QgsPoint(10, 5), QgsPoint(2.5, 0), QgsPoint(7.5, 5))
+      # <QgsCircle: Empty>
+      QgsCircle.from3Tangents(QgsPoint(0, 0), QgsPoint(5, 0), QgsPoint(5, 5), QgsPoint(10, 5), QgsPoint(2.5, 0), QgsPoint(7.5, 5), pos=QgsPoint(2, 0))
+      # <QgsCircle: Circle (Center: Point (1.46446609406726203 2.49999999999999911), Radius: 2.5, Azimuth: 0)>
+      QgsCircle.from3Tangents(QgsPoint(0, 0), QgsPoint(5, 0), QgsPoint(5, 5), QgsPoint(10, 5), QgsPoint(2.5, 0), QgsPoint(7.5, 5), pos=QgsPoint(3, 0))
+      # <QgsCircle: Circle (Center: Point (8.53553390593273775 2.5), Radius: 2.5, Azimuth: 0)>
 %End
 
     static QVector<QgsCircle> from3TangentsMulti( const QgsPoint &pt1_tg1, const QgsPoint &pt2_tg1,
@@ -143,6 +157,22 @@ The azimuth always takes the default value.
 :param pos: (optional) Point to determine which circle use in case of multi return.
 
 .. seealso:: :py:func:`from3Tangents`
+
+Example
+-------
+
+.. code-block:: python
+
+      # [(0 0), (5 0)] and [(5 5), (10 5)] are parallels
+      QgsCircle.from3TangentsMulti(QgsPoint(0, 0), QgsPoint(5, 0), QgsPoint(5, 5), QgsPoint(10, 5), QgsPoint(2.5, 0), QgsPoint(7.5, 5))
+      # [<QgsCircle: Circle (Center: Point (8.53553390593273775 2.5), Radius: 2.5, Azimuth: 0)>, <QgsCircle: Circle (Center: Point (1.46446609406726203 2.49999999999999911), Radius: 2.5, Azimuth: 0)>]
+      QgsCircle.from3TangentsMulti(QgsPoint(0, 0), QgsPoint(5, 0), QgsPoint(5, 5), QgsPoint(10, 5), QgsPoint(2.5, 0), QgsPoint(7.5, 5), pos=QgsPoint(2, 0))
+      # [<QgsCircle: Circle (Center: Point (1.46446609406726203 2.49999999999999911), Radius: 2.5, Azimuth: 0)>]
+      QgsCircle.from3TangentsMulti(QgsPoint(0, 0), QgsPoint(5, 0), QgsPoint(5, 5), QgsPoint(10, 5), QgsPoint(2.5, 0), QgsPoint(7.5, 5), pos=QgsPoint(3, 0))
+      # [<QgsCircle: Circle (Center: Point (8.53553390593273775 2.5), Radius: 2.5, Azimuth: 0)>]
+      # [(0 0), (5 0)], [(5 5), (10 5)] and [(15 5), (20 5)] are parallels
+      QgsCircle.from3TangentsMulti(QgsPoint(0, 0), QgsPoint(5, 0), QgsPoint(5, 5), QgsPoint(10, 5), QgsPoint(15, 5), QgsPoint(20, 5))
+      # []
 %End
 
     static QgsCircle fromExtent( const QgsPoint &pt1, const QgsPoint &pt2 ) /HoldGIL/;

--- a/src/app/qgsmaptoolcircle3tangents.cpp
+++ b/src/app/qgsmaptoolcircle3tangents.cpp
@@ -86,7 +86,7 @@ void QgsMapToolCircle3Tangents::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       mCircle = QgsCircle().from3Tangents( mPoints.at( 0 ), mPoints.at( 1 ), mPoints.at( 2 ), mPoints.at( 3 ), mPoints.at( 4 ), mPoints.at( 5 ), 1E-8, pos );
       if ( mCircle.isEmpty() )
       {
-        QgisApp::instance()->messageBar()->pushMessage( tr( "Error" ), tr( "The three segments are parallels" ), Qgis::Critical );
+        QgisApp::instance()->messageBar()->pushMessage( tr( "Error" ), tr( "The three segments are parallel" ), Qgis::Critical );
         mPoints.clear();
         mPosPoints.clear();
         delete mTempRubberBand;

--- a/src/app/qgsmaptoolcircle3tangents.cpp
+++ b/src/app/qgsmaptoolcircle3tangents.cpp
@@ -34,6 +34,19 @@ QgsMapToolCircle3Tangents::QgsMapToolCircle3Tangents( QgsMapToolCapture *parentT
   mToolName = tr( "Add circle from 3 tangents" );
 }
 
+static QgsPoint getFirstPointOnParallels( const QgsPoint p1_line1, const QgsPoint p2_line1, const QgsPoint pos_line1, const QgsPoint p1_line2, const QgsPoint p2_line2, const QgsPoint pos_line2, const QgsPoint p1_line3, const QgsPoint p2_line3 )
+{
+  QgsPoint intersection;
+  bool isInter;
+
+  if ( ( !QgsGeometryUtils::segmentIntersection( p1_line1, p2_line1, p1_line2, p2_line2, intersection, isInter, true ) ) || ( !QgsGeometryUtils::segmentIntersection( p1_line1, p2_line1, p1_line3, p2_line3, intersection, isInter, true ) ) )
+    return pos_line1;
+  if ( !QgsGeometryUtils::segmentIntersection( p1_line2, p2_line2, p1_line3, p2_line3, intersection, isInter, true ) )
+    return pos_line2;
+
+  return QgsPoint();
+}
+
 void QgsMapToolCircle3Tangents::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
 {
   QgsPoint point = mapPoint( *e );
@@ -56,6 +69,7 @@ void QgsMapToolCircle3Tangents::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   {
     if ( match.isValid() && ( mPoints.size() <= 2 * 2 ) )
     {
+      mPosPoints.append( mapPoint( match.point() ) );
       match.edgePoints( p1, p2 );
       mPoints.append( mapPoint( p1 ) );
       mPoints.append( mapPoint( p2 ) );
@@ -68,11 +82,13 @@ void QgsMapToolCircle3Tangents::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       match.edgePoints( p1, p2 );
       mPoints.append( mapPoint( p1 ) );
       mPoints.append( mapPoint( p2 ) );
-      mCircle = QgsCircle().from3Tangents( mPoints.at( 0 ), mPoints.at( 1 ), mPoints.at( 2 ), mPoints.at( 3 ), mPoints.at( 4 ), mPoints.at( 5 ) );
+      const QgsPoint pos = getFirstPointOnParallels( mPoints.at( 0 ), mPoints.at( 1 ), mPosPoints.at( 0 ), mPoints.at( 2 ), mPoints.at( 3 ), mPosPoints.at( 1 ), mPoints.at( 4 ), mPoints.at( 5 ) );
+      mCircle = QgsCircle().from3Tangents( mPoints.at( 0 ), mPoints.at( 1 ), mPoints.at( 2 ), mPoints.at( 3 ), mPoints.at( 4 ), mPoints.at( 5 ), 1E-8, pos );
       if ( mCircle.isEmpty() )
       {
-        QgisApp::instance()->messageBar()->pushMessage( tr( "Error" ), tr( "At least two segments are parallels" ), Qgis::Critical );
+        QgisApp::instance()->messageBar()->pushMessage( tr( "Error" ), tr( "The three segments are parallels" ), Qgis::Critical );
         mPoints.clear();
+        mPosPoints.clear();
         delete mTempRubberBand;
         mTempRubberBand = nullptr;
       }
@@ -104,7 +120,8 @@ void QgsMapToolCircle3Tangents::cadCanvasMoveEvent( QgsMapMouseEvent *e )
     match.edgePoints( p1, p2 );
     if ( mPoints.size() == 4 )
     {
-      mCircle = QgsCircle().from3Tangents( mPoints.at( 0 ), mPoints.at( 1 ), mPoints.at( 2 ), mPoints.at( 3 ), QgsPoint( p1 ), QgsPoint( p2 ) );
+      const QgsPoint pos = getFirstPointOnParallels( mPoints.at( 0 ), mPoints.at( 1 ), mPosPoints.at( 0 ), mPoints.at( 2 ), mPoints.at( 3 ), mPosPoints.at( 1 ), QgsPoint( p1 ), QgsPoint( p2 ) );
+      mCircle = QgsCircle().from3Tangents( mPoints.at( 0 ), mPoints.at( 1 ), mPoints.at( 2 ), mPoints.at( 3 ), QgsPoint( p1 ), QgsPoint( p2 ), 1E-8, pos );
       mTempRubberBand->setGeometry( mCircle.toLineString() );
       mTempRubberBand->show();
     }
@@ -122,4 +139,10 @@ void QgsMapToolCircle3Tangents::cadCanvasMoveEvent( QgsMapMouseEvent *e )
     }
   }
 
+}
+
+void QgsMapToolCircle3Tangents::clean( )
+{
+  mPosPoints.clear();
+  QgsMapToolAddCircle::clean();
 }

--- a/src/app/qgsmaptoolcircle3tangents.h
+++ b/src/app/qgsmaptoolcircle3tangents.h
@@ -29,6 +29,10 @@ class QgsMapToolCircle3Tangents: public QgsMapToolAddCircle
 
     void cadCanvasReleaseEvent( QgsMapMouseEvent *e ) override;
     void cadCanvasMoveEvent( QgsMapMouseEvent *e ) override;
+    void clean() override;
+  private:
+    //! Snapped points on the segments. Useful to determine which circle to choose in case of there are two parallels
+    QVector<QgsPoint> mPosPoints;
 };
 
 #endif // QGSMAPTOOLCIRCLE3TANGENTS_H

--- a/src/core/geometry/qgscircle.cpp
+++ b/src/core/geometry/qgscircle.cpp
@@ -188,19 +188,112 @@ QgsCircle QgsCircle::fromCenterPoint( const QgsPoint &center, const QgsPoint &pt
   return QgsCircle( centerPt, centerPt.distance( pt1 ), azimuth );
 }
 
-QgsCircle QgsCircle::from3Tangents( const QgsPoint &pt1_tg1, const QgsPoint &pt2_tg1, const QgsPoint &pt1_tg2, const QgsPoint &pt2_tg2, const QgsPoint &pt1_tg3, const QgsPoint &pt2_tg3, double epsilon )
+static QVector<QgsCircle> from2ParallelsLine( const QgsPoint &pt1_par1, const QgsPoint &pt2_par1, const QgsPoint &pt1_par2, const QgsPoint &pt2_par2, const QgsPoint &pt1_line1, const QgsPoint &pt2_line1, QgsPoint pos, double epsilon )
+{
+  const double radius = QgsGeometryUtils::perpendicularSegment( pt1_par2, pt1_par1, pt2_par1 ).length() / 2.0;
+
+  bool isInter;
+  QgsPoint ptInter;
+  QVector<QgsCircle> circles;
+
+  QgsPoint ptInter_par1line1, ptInter_par2line1;
+  double angle1, angle2;
+  double x, y;
+  QgsGeometryUtils::angleBisector( pt1_par1.x(), pt1_par1.y(), pt2_par1.x(), pt2_par1.y(), pt1_line1.x(), pt1_line1.y(), pt2_line1.x(), pt2_line1.y(), x, y, angle1 );
+  ptInter_par1line1.setX( x );
+  ptInter_par1line1.setY( y );
+
+  QgsGeometryUtils::angleBisector( pt1_par2.x(), pt1_par2.y(), pt2_par2.x(), pt2_par2.y(), pt1_line1.x(), pt1_line1.y(), pt2_line1.x(), pt2_line1.y(), x, y, angle2 );
+  ptInter_par2line1.setX( x );
+  ptInter_par2line1.setY( y );
+
+  QgsPoint center;
+  QgsGeometryUtils::segmentIntersection( ptInter_par1line1, ptInter_par1line1.project( 1.0, angle1 ), ptInter_par2line1, ptInter_par2line1.project( 1.0, angle2 ), center, isInter, epsilon, true );
+  if ( isInter )
+  {
+    if ( !pos.isEmpty() )
+    {
+      if ( QgsGeometryUtils::leftOfLine( center, pt1_line1, pt2_line1 ) == QgsGeometryUtils::leftOfLine( pos, pt1_line1, pt2_line1 ) )
+      {
+        circles.append( QgsCircle( center, radius ) );
+      }
+    }
+    else
+    {
+      circles.append( QgsCircle( center, radius ) );
+    }
+  }
+
+  QgsGeometryUtils::segmentIntersection( ptInter_par1line1, ptInter_par1line1.project( 1.0, angle1 ), ptInter_par2line1, ptInter_par2line1.project( 1.0, angle2 + 90.0 ), center, isInter, epsilon, true );
+  if ( isInter )
+  {
+    if ( !pos.isEmpty() )
+    {
+      if ( QgsGeometryUtils::leftOfLine( center, pt1_line1, pt2_line1 ) == QgsGeometryUtils::leftOfLine( pos, pt1_line1, pt2_line1 ) )
+      {
+        circles.append( QgsCircle( center, radius ) );
+      }
+    }
+    else
+    {
+      circles.append( QgsCircle( center, radius ) );
+    }
+  }
+
+  QgsGeometryUtils::segmentIntersection( ptInter_par1line1, ptInter_par1line1.project( 1.0, angle1 + 90.0 ), ptInter_par2line1, ptInter_par2line1.project( 1.0, angle2 ), center, isInter, epsilon, true );
+  if ( isInter and not circles.contains( QgsCircle( center, radius ) ) )
+  {
+    if ( !pos.isEmpty() )
+    {
+      if ( QgsGeometryUtils::leftOfLine( center, pt1_line1, pt2_line1 ) == QgsGeometryUtils::leftOfLine( pos, pt1_line1, pt2_line1 ) )
+      {
+        circles.append( QgsCircle( center, radius ) );
+      }
+    }
+    else
+    {
+      circles.append( QgsCircle( center, radius ) );
+    }
+  }
+  QgsGeometryUtils::segmentIntersection( ptInter_par1line1, ptInter_par1line1.project( 1.0, angle1 + 90.0 ), ptInter_par2line1, ptInter_par2line1.project( 1.0, angle2 + 90.0 ), center, isInter, epsilon, true );
+  if ( isInter and not circles.contains( QgsCircle( center, radius ) ) )
+  {
+    if ( !pos.isEmpty() )
+    {
+      if ( QgsGeometryUtils::leftOfLine( center, pt1_line1, pt2_line1 ) == QgsGeometryUtils::leftOfLine( pos, pt1_line1, pt2_line1 ) )
+      {
+        circles.append( QgsCircle( center, radius ) );
+      }
+    }
+    else
+    {
+      circles.append( QgsCircle( center, radius ) );
+    }
+  }
+
+  return circles;
+}
+
+QVector<QgsCircle> QgsCircle::from3TangentsMulti( const QgsPoint &pt1_tg1, const QgsPoint &pt2_tg1, const QgsPoint &pt1_tg2, const QgsPoint &pt2_tg2, const QgsPoint &pt1_tg3, const QgsPoint &pt2_tg3, double epsilon, QgsPoint pos )
 {
   QgsPoint p1, p2, p3;
-  bool isIntersect = false;
-  QgsGeometryUtils::segmentIntersection( pt1_tg1, pt2_tg1, pt1_tg2, pt2_tg2, p1, isIntersect, epsilon );
-  if ( !isIntersect )
-    return QgsCircle();
-  QgsGeometryUtils::segmentIntersection( pt1_tg1, pt2_tg1, pt1_tg3, pt2_tg3, p2, isIntersect, epsilon );
-  if ( !isIntersect )
-    return QgsCircle();
-  QgsGeometryUtils::segmentIntersection( pt1_tg2, pt2_tg2, pt1_tg3, pt2_tg3, p3, isIntersect, epsilon );
-  if ( !isIntersect )
-    return QgsCircle();
+  bool isIntersect_tg1tg2 = false;
+  bool isIntersect_tg1tg3 = false;
+  bool isIntersect_tg2tg3 = false;
+  QgsGeometryUtils::segmentIntersection( pt1_tg1, pt2_tg1, pt1_tg2, pt2_tg2, p1, isIntersect_tg1tg2, epsilon );
+  QgsGeometryUtils::segmentIntersection( pt1_tg1, pt2_tg1, pt1_tg3, pt2_tg3, p2, isIntersect_tg1tg3, epsilon );
+  QgsGeometryUtils::segmentIntersection( pt1_tg2, pt2_tg2, pt1_tg3, pt2_tg3, p3, isIntersect_tg2tg3, epsilon );
+
+  QVector<QgsCircle> circles;
+  if ( !isIntersect_tg1tg2 && !isIntersect_tg2tg3 ) // three lines are parallels
+    return circles;
+
+  if ( !isIntersect_tg1tg2 )
+    return from2ParallelsLine( pt1_tg1, pt2_tg1, pt1_tg2, pt2_tg2, pt1_tg3, pt2_tg3, pos, epsilon );
+  else if ( !isIntersect_tg1tg3 )
+    return from2ParallelsLine( pt1_tg1, pt2_tg1, pt1_tg3, pt2_tg3, pt1_tg2, pt2_tg2, pos, epsilon );
+  else if ( !isIntersect_tg2tg3 )
+    return from2ParallelsLine( pt1_tg2, pt2_tg2, pt1_tg3, pt2_tg3, pt1_tg1, pt1_tg1, pos, epsilon );
 
   if ( p1.is3D() )
   {
@@ -217,7 +310,16 @@ QgsCircle QgsCircle::from3Tangents( const QgsPoint &pt1_tg1, const QgsPoint &pt2
     p3.convertTo( QgsWkbTypes::dropZ( p3.wkbType() ) );
   }
 
-  return QgsTriangle( p1, p2, p3 ).inscribedCircle();
+  circles.append( QgsTriangle( p1, p2, p3 ).inscribedCircle() );
+  return circles;
+}
+
+QgsCircle QgsCircle::from3Tangents( const QgsPoint &pt1_tg1, const QgsPoint &pt2_tg1, const QgsPoint &pt1_tg2, const QgsPoint &pt2_tg2, const QgsPoint &pt1_tg3, const QgsPoint &pt2_tg3, double epsilon, QgsPoint pos )
+{
+  const QVector<QgsCircle> circles = from3TangentsMulti( pt1_tg1, pt2_tg1, pt1_tg2, pt2_tg2, pt1_tg3, pt2_tg3, epsilon, pos );
+  if ( circles.length() != 1 )
+    return QgsCircle();
+  return circles.at( 0 );
 }
 
 QgsCircle QgsCircle::minimalCircleFrom3Points( const QgsPoint &pt1, const QgsPoint &pt2, const QgsPoint &pt3, double epsilon )

--- a/src/core/geometry/qgscircle.h
+++ b/src/core/geometry/qgscircle.h
@@ -111,10 +111,44 @@ class CORE_EXPORT QgsCircle : public QgsEllipse
      * \param pt1_tg3 First point of the third tangent.
      * \param pt2_tg3 Second point of the third tangent.
      * \param epsilon Value used to compare point.
+     * \param pos Point to determine which circle use in case of multi return. This case happens only when two tangets are parallels. \since QGIS 3.18
+     *
+     * \see from3TangentsMulti()
      */
     static QgsCircle from3Tangents( const QgsPoint &pt1_tg1, const QgsPoint &pt2_tg1,
                                     const QgsPoint &pt1_tg2, const QgsPoint &pt2_tg2,
-                                    const QgsPoint &pt1_tg3, const QgsPoint &pt2_tg3, double epsilon = 1E-8 ) SIP_HOLDGIL;
+                                    const QgsPoint &pt1_tg3, const QgsPoint &pt2_tg3,
+                                    double epsilon = 1E-8,
+                                    QgsPoint pos = QgsPoint() ) SIP_HOLDGIL;
+
+    /**
+     * Returns an array of circle constructed by 3 tangents on the circle (aka inscribed circle of a triangle).
+     *
+     * The vector can contain 0, 1 or 2 circles:
+     *
+     * - 0: Impossible to construct a circle from 3 tangents (three parallel tangents)
+     * - 1: The three tangents make a triangle or when two tangents are parallel there are two possible circles (see examples).
+     *   If pos is not an empty point, we use its coordinates to determine which circle will be returned.
+     *   More precisely the circle that will be returned will be the one whose center is on the same side as pos relative to the third tangent.
+     * - 2: Returns both solutions when two tangents are parallel (this implies that pos is an empty point).
+     *
+     * Z and m values are dropped for the center point.
+     * The azimuth always takes the default value.
+     * \param pt1_tg1 First point of the first tangent.
+     * \param pt2_tg1 Second point of the first tangent.
+     * \param pt1_tg2 First point of the second tangent.
+     * \param pt2_tg2 Second point of the second tangent.
+     * \param pt1_tg3 First point of the third tangent.
+     * \param pt2_tg3 Second point of the third tangent.
+     * \param epsilon Value used to compare point.
+     * \param pos (optional) Point to determine which circle use in case of multi return.
+     * \see from3Tangents()
+     */
+    static QVector<QgsCircle> from3TangentsMulti( const QgsPoint &pt1_tg1, const QgsPoint &pt2_tg1,
+        const QgsPoint &pt1_tg2, const QgsPoint &pt2_tg2,
+        const QgsPoint &pt1_tg3, const QgsPoint &pt2_tg3,
+        double epsilon = 1E-8,
+        QgsPoint pos = QgsPoint() ) SIP_HOLDGIL;
 
     /**
      * Constructs a circle by an extent (aka bounding box / QgsRectangle).

--- a/src/core/geometry/qgscircle.h
+++ b/src/core/geometry/qgscircle.h
@@ -112,7 +112,7 @@ class CORE_EXPORT QgsCircle : public QgsEllipse
      * \param pt2_tg3 Second point of the third tangent.
      * \param epsilon Value used to compare point.
      * \param pos Point to determine which circle use in case of multi return.
-     * If the solution is not unique and pos is an empty point, an empty circle is returned. -- This case happens only when two tangets are parallels. \since QGIS 3.18
+     * If the solution is not unique and pos is an empty point, an empty circle is returned. -- This case happens only when two tangets are parallels. (since QGIS 3.18)
      *
      * \see from3TangentsMulti()
      *

--- a/src/core/geometry/qgscircle.h
+++ b/src/core/geometry/qgscircle.h
@@ -111,9 +111,22 @@ class CORE_EXPORT QgsCircle : public QgsEllipse
      * \param pt1_tg3 First point of the third tangent.
      * \param pt2_tg3 Second point of the third tangent.
      * \param epsilon Value used to compare point.
-     * \param pos Point to determine which circle use in case of multi return. This case happens only when two tangets are parallels. \since QGIS 3.18
+     * \param pos Point to determine which circle use in case of multi return.
+     * If the solution is not unique and pos is an empty point, an empty circle is returned. -- This case happens only when two tangets are parallels. \since QGIS 3.18
      *
      * \see from3TangentsMulti()
+     *
+     * ### Example
+     *
+     * \code{.py}
+     *  # [(0 0), (5 0)] and [(5 5), (10 5)] are parallels
+     *  QgsCircle.from3Tangents(QgsPoint(0, 0), QgsPoint(5, 0), QgsPoint(5, 5), QgsPoint(10, 5), QgsPoint(2.5, 0), QgsPoint(7.5, 5))
+     *  # <QgsCircle: Empty>
+     *  QgsCircle.from3Tangents(QgsPoint(0, 0), QgsPoint(5, 0), QgsPoint(5, 5), QgsPoint(10, 5), QgsPoint(2.5, 0), QgsPoint(7.5, 5), pos=QgsPoint(2, 0))
+     *  # <QgsCircle: Circle (Center: Point (1.46446609406726203 2.49999999999999911), Radius: 2.5, Azimuth: 0)>
+     *  QgsCircle.from3Tangents(QgsPoint(0, 0), QgsPoint(5, 0), QgsPoint(5, 5), QgsPoint(10, 5), QgsPoint(2.5, 0), QgsPoint(7.5, 5), pos=QgsPoint(3, 0))
+     *  # <QgsCircle: Circle (Center: Point (8.53553390593273775 2.5), Radius: 2.5, Azimuth: 0)>
+     * \endcode
      */
     static QgsCircle from3Tangents( const QgsPoint &pt1_tg1, const QgsPoint &pt2_tg1,
                                     const QgsPoint &pt1_tg2, const QgsPoint &pt2_tg2,
@@ -142,7 +155,24 @@ class CORE_EXPORT QgsCircle : public QgsEllipse
      * \param pt2_tg3 Second point of the third tangent.
      * \param epsilon Value used to compare point.
      * \param pos (optional) Point to determine which circle use in case of multi return.
+     *
      * \see from3Tangents()
+     *
+     * ### Example
+     *
+     * \code{.py}
+     *
+     *  # [(0 0), (5 0)] and [(5 5), (10 5)] are parallels
+     *  QgsCircle.from3TangentsMulti(QgsPoint(0, 0), QgsPoint(5, 0), QgsPoint(5, 5), QgsPoint(10, 5), QgsPoint(2.5, 0), QgsPoint(7.5, 5))
+     *  # [<QgsCircle: Circle (Center: Point (8.53553390593273775 2.5), Radius: 2.5, Azimuth: 0)>, <QgsCircle: Circle (Center: Point (1.46446609406726203 2.49999999999999911), Radius: 2.5, Azimuth: 0)>]
+     *  QgsCircle.from3TangentsMulti(QgsPoint(0, 0), QgsPoint(5, 0), QgsPoint(5, 5), QgsPoint(10, 5), QgsPoint(2.5, 0), QgsPoint(7.5, 5), pos=QgsPoint(2, 0))
+     *  # [<QgsCircle: Circle (Center: Point (1.46446609406726203 2.49999999999999911), Radius: 2.5, Azimuth: 0)>]
+     *  QgsCircle.from3TangentsMulti(QgsPoint(0, 0), QgsPoint(5, 0), QgsPoint(5, 5), QgsPoint(10, 5), QgsPoint(2.5, 0), QgsPoint(7.5, 5), pos=QgsPoint(3, 0))
+     *  # [<QgsCircle: Circle (Center: Point (8.53553390593273775 2.5), Radius: 2.5, Azimuth: 0)>]
+     *  # [(0 0), (5 0)], [(5 5), (10 5)] and [(15 5), (20 5)] are parallels
+     *  QgsCircle.from3TangentsMulti(QgsPoint(0, 0), QgsPoint(5, 0), QgsPoint(5, 5), QgsPoint(10, 5), QgsPoint(15, 5), QgsPoint(20, 5))
+     *  # []
+     * \endcode
      */
     static QVector<QgsCircle> from3TangentsMulti( const QgsPoint &pt1_tg1, const QgsPoint &pt2_tg1,
         const QgsPoint &pt1_tg2, const QgsPoint &pt2_tg2,

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -7933,7 +7933,35 @@ void TestQgsGeometry::circle()
   QVERIFY( circ_tgt.isEmpty() );
   circ_tgt = QgsCircle().from3Tangents( QgsPoint( 5, 0 ), QgsPoint( 0, 5 ), QgsPoint( 0, 0 ), QgsPoint( 0, 5 ), QgsPoint( 1, 0 ), QgsPoint( 1, 5 ) );
   QVERIFY( circ_tgt.isEmpty() );
-
+  // with 2 parallels
+  const double epsilon = 1e-8;
+  circ_tgt = QgsCircle().from3Tangents( QgsPoint( 0, 0 ), QgsPoint( 5, 0 ), QgsPoint( 5, 5 ), QgsPoint( 10, 5 ), QgsPoint( 2.5, 0 ), QgsPoint( 7.5, 5 ) );
+  QVERIFY( circ_tgt.isEmpty() );
+  circ_tgt = QgsCircle().from3Tangents( QgsPoint( 0, 0 ), QgsPoint( 5, 0 ), QgsPoint( 5, 5 ), QgsPoint( 10, 5 ), QgsPoint( 2.5, 0 ), QgsPoint( 7.5, 5 ), epsilon, QgsPoint( 2, 0 ) );
+  QGSCOMPARENEARPOINT( circ_tgt.center(), QgsPoint( 1.4645, 2.5000 ), 0.0001 );
+  QGSCOMPARENEAR( circ_tgt.radius(), 2.5, 0.0001 );
+  circ_tgt = QgsCircle().from3Tangents( QgsPoint( 0, 0 ), QgsPoint( 5, 0 ), QgsPoint( 5, 5 ), QgsPoint( 10, 5 ), QgsPoint( 2.5, 0 ), QgsPoint( 7.5, 5 ), epsilon, QgsPoint( 3, 0 ) );
+  QGSCOMPARENEARPOINT( circ_tgt.center(), QgsPoint( 8.5355, 2.5000 ), 0.0001 );
+  QGSCOMPARENEAR( circ_tgt.radius(), 2.5, 0.0001 );
+// from3tangentsMulti
+  QVector<QgsCircle> circles_tgt;
+  circles_tgt = QgsCircle().from3TangentsMulti( QgsPoint( 0, 0 ), QgsPoint( 5, 0 ), QgsPoint( 5, 5 ), QgsPoint( 10, 5 ), QgsPoint( 2.5, 0 ), QgsPoint( 7.5, 5 ) );
+  QCOMPARE( circles_tgt.count(), 2 );
+  circ_tgt = circles_tgt.at( 0 );
+  QGSCOMPARENEARPOINT( circ_tgt.center(), QgsPoint( 8.5355, 2.5000 ), 0.0001 );
+  QGSCOMPARENEAR( circ_tgt.radius(), 2.5, 0.0001 );
+  circ_tgt = circles_tgt.at( 1 );
+  QGSCOMPARENEARPOINT( circ_tgt.center(), QgsPoint( 1.4645, 2.5000 ), 0.0001 );
+  QGSCOMPARENEAR( circ_tgt.radius(), 2.5, 0.0001 );
+  circles_tgt = QgsCircle().from3TangentsMulti( QgsPoint( 0, 0 ), QgsPoint( 5, 0 ), QgsPoint( 5, 5 ), QgsPoint( 10, 5 ), QgsPoint( 2.5, 0 ), QgsPoint( 7.5, 5 ), epsilon, QgsPoint( 2, 0 ) );
+  QCOMPARE( circles_tgt.count(), 1 );
+  circ_tgt = circles_tgt.at( 0 );
+  QGSCOMPARENEARPOINT( circ_tgt.center(), QgsPoint( 1.4645, 2.5000 ), 0.0001 );
+  QGSCOMPARENEAR( circ_tgt.radius(), 2.5, 0.0001 );
+  circles_tgt = QgsCircle().from3TangentsMulti( QgsPoint( 0, 0 ), QgsPoint( 5, 0 ), QgsPoint( 5, 5 ), QgsPoint( 10, 5 ), QgsPoint( 2.5, 0 ), QgsPoint( 7.5, 5 ), epsilon, QgsPoint( 3, 0 ) );
+  QCOMPARE( circles_tgt.count(), 1 );
+  circles_tgt = QgsCircle().from3TangentsMulti( QgsPoint( 0, 0 ), QgsPoint( 5, 0 ), QgsPoint( 5, 5 ), QgsPoint( 10, 5 ), QgsPoint( 15, 5 ), QgsPoint( 20, 5 ) );
+  QVERIFY( circles_tgt.isEmpty() );
   // check that Z dimension is ignored in case of using tangents
   QgsCircle circ_tgt_z = QgsCircle().from3Tangents( QgsPoint( 0, 0, 333 ), QgsPoint( 0, 1, 1 ), QgsPoint( 2, 0, 2 ), QgsPoint( 3, 0, 3 ), QgsPoint( 5, 0, 4 ), QgsPoint( 0, 5, 5 ) );
   QCOMPARE( circ_tgt_z.center().is3D(), false );


### PR DESCRIPTION
## Description

This PR fixes and improves the behavior of the tool when two lines are parallel.

I don't think I've broken the API since I only add a point with a default value that allows to get back the same behavior as before this PR.

UI design: we take the coordinates of the first click on the parallel tangent to determine the positioning of the circle as discussed with @pigreco and @hareldunn -- This is what can be found in other CAD software.

![circles_3tgts mkv](https://user-images.githubusercontent.com/7521540/102762842-240f0500-4379-11eb-867a-5f02f377ff8d.gif)
