### PR TITLE
Do not set field constraints from the layer in refactor fields alg

### DIFF
--- a/src/gui/processing/qgsprocessingfieldmapwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingfieldmapwidgetwrapper.cpp
@@ -131,13 +131,7 @@ void QgsProcessingFieldMapPanelWidget::setValue( const QVariant &value )
                 map.value( QStringLiteral( "length" ), 0 ).toInt(),
                 map.value( QStringLiteral( "precision" ), 0 ).toInt() );
 
-    int layerFieldIdx = layerFields.indexFromName( f.name() );
-
-    if ( mLayer && layerFieldIdx >= 0 && ! map.contains( QStringLiteral( "constraints" ) ) )
-    {
-      f.setConstraints( layerFields.at( layerFieldIdx ).constraints() );
-    }
-    else
+    if ( map.contains( QStringLiteral( "constraints" ) ) )
     {
       const QgsFieldConstraints::Constraints constraints = static_cast<QgsFieldConstraints::Constraints>( map.value( QStringLiteral( "constraints" ), 0 ).toInt() );
       QgsFieldConstraints fieldConstraints;


### PR DESCRIPTION
When implementing the support for programatically set constraint hints, I put extra field constraints from the layer, which are a mistake. Please find more info here https://github.com/qgis/QGIS/pull/39529#discussion_r525315115 .