### PR TITLE
Create a GitHub release when there is a tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release 🚀
+
+on:
+  push:
+    tags:
+      - 'final-*_*_*'
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Prepare release names
+        run: |
+          VERSION_CHANGELOG=$(echo ${{ github.ref }} | cut -d '-' -f 2 | cut -d '_' -f1,2 | sed 's/_/\./g')
+          echo "version_url=https://changelog.qgis.org/en/qgis/version/${VERSION_CHANGELOG}" >> $GITHUB_ENV
+          VERSION_NAME=$(echo ${{ github.ref }} | cut -d '-' -f 2 | sed 's/_/\./g')
+          echo "version_name=${VERSION_NAME}" >> $GITHUB_ENV
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ env.version_name }}
+          body: ${{ env.version_url }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
It's a GitHub workflow to create the GitHub release when there is tag matching `final-*_*_*`.

So users on GitHub using only notifications based on "Release" will be notified. Tags only doesn't trigger the notification if I'm correct.

@m-kuhn and @jef-n What do you think ?

If accepted, this needs to be backported to the corresponding branch, I got this issue I think on another repository.