### PR TITLE
[3d] Add a tiny padding to the vector layer chunk loader root bounding box to avoid points at edge chopped off

### DIFF
--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -142,6 +142,13 @@ QgsVectorLayerChunkLoaderFactory::QgsVectorLayerChunkLoaderFactory( const Qgs3DM
   , mLeafLevel( leafLevel )
 {
   QgsAABB rootBbox = Qgs3DUtils::layerToWorldExtent( vl->extent(), zMin, zMax, vl->crs(), map.origin(), map.crs(), map.transformContext() );
+  // add small padding to avoid clipping of point features located at the edge of the bounding box
+  rootBbox.xMin -= 1.0;
+  rootBbox.xMax += 1.0;
+  rootBbox.yMin -= 1.0;
+  rootBbox.yMax += 1.0;
+  rootBbox.zMin -= 1.0;
+  rootBbox.zMax += 1.0;
   setupQuadtree( rootBbox, -1, leafLevel );  // negative root error means that the node does not contain anything
 }
 


### PR DESCRIPTION
## Description

The problem fixed here is a bit hard to explain, here's a GIF:
![Peek 2020-12-21 17-08](https://user-images.githubusercontent.com/1728657/102837847-5418df80-442f-11eb-835b-04d1caa2a129.gif)

Basically, point layers had this issue whereas features at the very edge of the layer extent would end up being clipped away by the chunk loader's 3D world bounding box-derived set of feature tiles. The conversion between map CRS and world units inserted decimal variances that killed points :fearful: 

Solution: add a small padding (1 world unit) to the bounding box. 

Result:
![Peek 2020-12-21 17-05-good](https://user-images.githubusercontent.com/1728657/102838003-b5d94980-442f-11eb-88d5-0c4eaab3ab00.gif)
