### PR TITLE
[Backport 3.16] Refresh the attribute table styles when feature modified programmatically

### DIFF
--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -766,10 +766,10 @@ bool QgsAttributeTableModel::setData( const QModelIndex &index, const QVariant &
   if ( !index.isValid() || index.column() >= mFieldCount || role != Qt::EditRole || !layer()->isEditable() )
     return false;
 
+  mRowStylesMap.remove( mFeat.id() );
+
   if ( !layer()->isModified() )
     return false;
-
-  mRowStylesMap.remove( mFeat.id() );
 
   return true;
 }


### PR DESCRIPTION
Manual backport of #40699 to 3.16.