### PR TITLE
Delete an unreachable semicolon

### DIFF
--- a/src/gui/raster/qgscolorrampshaderwidget.cpp
+++ b/src/gui/raster/qgscolorrampshaderwidget.cpp
@@ -779,7 +779,7 @@ QString QgsColorRampShaderWidget::createLabel( QTreeWidgetItem *currentItem, int
       }
     }
     return QString();
-  };
+  }
 
   QgsColorRampShader::Type interpolation = static_cast< QgsColorRampShader::Type >( mColorInterpolationComboBox->currentData().toInt() );
   bool discrete = interpolation == QgsColorRampShader::Discrete;


### PR DESCRIPTION
 ## Description

*what*: Delete an unreachable semicolon. Control reaches end of non-void function.
*why*: for QGIS Coding Standards 
