### PR TITLE
Initialize regular expressions once

### DIFF
--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -538,20 +538,20 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
           {
             esc_regexp.replace( 0, 1, QStringLiteral( ".*" ) );
           }
-          QRegExp rx1( QStringLiteral( "[^\\\\](%)" ) );
+          const thread_local QRegExp rx1( QStringLiteral( "[^\\\\](%)" ) );
           int pos = 0;
           while ( ( pos = rx1.indexIn( esc_regexp, pos ) ) != -1 )
           {
             esc_regexp.replace( pos + 1, 1, QStringLiteral( ".*" ) );
             pos += 1;
           }
-          QRegExp rx2( QStringLiteral( "\\\\%" ) );
+          const thread_local QRegExp rx2( QStringLiteral( "\\\\%" ) );
           esc_regexp.replace( rx2, QStringLiteral( "%" ) );
           if ( esc_regexp.startsWith( '_' ) )
           {
             esc_regexp.replace( 0, 1, QStringLiteral( "." ) );
           }
-          QRegExp rx3( QStringLiteral( "[^\\\\](_)" ) );
+          const thread_local QRegExp rx3( QStringLiteral( "[^\\\\](_)" ) );
           pos = 0;
           while ( ( pos = rx3.indexIn( esc_regexp, pos ) ) != -1 )
           {

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -538,20 +538,20 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
           {
             esc_regexp.replace( 0, 1, QStringLiteral( ".*" ) );
           }
-          const thread_local QRegExp rx1( QStringLiteral( "[^\\\\](%)" ) );
+          thread_local QRegExp rx1( QStringLiteral( "[^\\\\](%)" ) );
           int pos = 0;
           while ( ( pos = rx1.indexIn( esc_regexp, pos ) ) != -1 )
           {
             esc_regexp.replace( pos + 1, 1, QStringLiteral( ".*" ) );
             pos += 1;
           }
-          const thread_local QRegExp rx2( QStringLiteral( "\\\\%" ) );
+          thread_local QRegExp rx2( QStringLiteral( "\\\\%" ) );
           esc_regexp.replace( rx2, QStringLiteral( "%" ) );
           if ( esc_regexp.startsWith( '_' ) )
           {
             esc_regexp.replace( 0, 1, QStringLiteral( "." ) );
           }
-          const thread_local QRegExp rx3( QStringLiteral( "[^\\\\](_)" ) );
+          thread_local QRegExp rx3( QStringLiteral( "[^\\\\](_)" ) );
           pos = 0;
           while ( ( pos = rx3.indexIn( esc_regexp, pos ) ) != -1 )
           {

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -532,7 +532,7 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
         bool matches;
         if ( mOp == boLike || mOp == boILike || mOp == boNotLike || mOp == boNotILike ) // change from LIKE syntax to regexp
         {
-          QString esc_regexp = QRegularExpression::escape( regexp );
+          QString esc_regexp = QRegExp::escape( regexp );
           // manage escape % and _
           if ( esc_regexp.startsWith( '%' ) )
           {
@@ -559,10 +559,8 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
             pos += 1;
           }
           esc_regexp.replace( QStringLiteral( "\\\\_" ), QStringLiteral( "_" ) );
-          QRegularExpression::PatternOption option;
-          if ( mOp == boILike || mOp == boNotILike )
-            option = QRegularExpression::CaseInsensitiveOption;
-          matches = QRegularExpression( esc_regexp, option ).match( str ).hasMatch();
+
+          matches = QRegExp( esc_regexp, mOp == boLike || mOp == boNotLike ? Qt::CaseSensitive : Qt::CaseInsensitive ).exactMatch( str );
         }
         else
         {
@@ -1365,8 +1363,8 @@ bool QgsExpressionNodeColumnRef::prepareNode( QgsExpression *parent, const QgsEx
 
 QString QgsExpressionNodeColumnRef::dump() const
 {
-  const thread_local QRegularExpression re( QStringLiteral( "^[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*$" ) );
-  return re.match( mName ).hasMatch() ? mName : QgsExpression::quotedColumnRef( mName );
+  const thread_local QRegExp re( QStringLiteral( "^[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*$" ) );
+  return re.exactMatch( mName ) ? mName : QgsExpression::quotedColumnRef( mName );
 }
 
 QSet<QString> QgsExpressionNodeColumnRef::referencedColumns() const

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -532,39 +532,40 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
         bool matches;
         if ( mOp == boLike || mOp == boILike || mOp == boNotLike || mOp == boNotILike ) // change from LIKE syntax to regexp
         {
-          QString esc_regexp = QRegExp::escape( regexp );
+          QString esc_regexp = QRegularExpression::escape( regexp );
           // manage escape % and _
           if ( esc_regexp.startsWith( '%' ) )
           {
             esc_regexp.replace( 0, 1, QStringLiteral( ".*" ) );
           }
-          QRegExp rx( "[^\\\\](%)" );
+          QRegExp rx1( QStringLiteral( "[^\\\\](%)" ) );
           int pos = 0;
-          while ( ( pos = rx.indexIn( esc_regexp, pos ) ) != -1 )
+          while ( ( pos = rx1.indexIn( esc_regexp, pos ) ) != -1 )
           {
             esc_regexp.replace( pos + 1, 1, QStringLiteral( ".*" ) );
             pos += 1;
           }
-          rx.setPattern( QStringLiteral( "\\\\%" ) );
-          esc_regexp.replace( rx, QStringLiteral( "%" ) );
+          QRegExp rx2( QStringLiteral( "\\\\%" ) );
+          esc_regexp.replace( rx2, QStringLiteral( "%" ) );
           if ( esc_regexp.startsWith( '_' ) )
           {
             esc_regexp.replace( 0, 1, QStringLiteral( "." ) );
           }
-          rx.setPattern( QStringLiteral( "[^\\\\](_)" ) );
+          QRegExp rx3( QStringLiteral( "[^\\\\](_)" ) );
           pos = 0;
-          while ( ( pos = rx.indexIn( esc_regexp, pos ) ) != -1 )
+          while ( ( pos = rx3.indexIn( esc_regexp, pos ) ) != -1 )
           {
             esc_regexp.replace( pos + 1, 1, '.' );
             pos += 1;
           }
-          rx.setPattern( QStringLiteral( "\\\\_" ) );
-          esc_regexp.replace( rx, QStringLiteral( "_" ) );
+          const static QRegularExpression sRx4( QStringLiteral( "\\\\_" ) );
+          QRegularExpression rx4( sRx4 );
+          esc_regexp.replace( rx4, QStringLiteral( "_" ) );
           matches = QRegExp( esc_regexp, mOp == boLike || mOp == boNotLike ? Qt::CaseSensitive : Qt::CaseInsensitive ).exactMatch( str );
         }
         else
         {
-          matches = QRegExp( regexp ).indexIn( str ) != -1;
+          matches = QRegularExpression( regexp ).match( str ).hasMatch();
         }
 
         if ( mOp == boNotLike || mOp == boNotILike )
@@ -1363,7 +1364,9 @@ bool QgsExpressionNodeColumnRef::prepareNode( QgsExpression *parent, const QgsEx
 
 QString QgsExpressionNodeColumnRef::dump() const
 {
-  return QRegExp( "^[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*$" ).exactMatch( mName ) ? mName : QgsExpression::quotedColumnRef( mName );
+  const static QRegularExpression sRe( QStringLiteral( "^[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*$" ) );
+  QRegularExpression re( sRe );
+  return re.match( mName ).hasMatch() ? mName : QgsExpression::quotedColumnRef( mName );
 }
 
 QSet<QString> QgsExpressionNodeColumnRef::referencedColumns() const

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -558,9 +558,11 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
             esc_regexp.replace( pos + 1, 1, '.' );
             pos += 1;
           }
-          const thread_local QRegularExpression rx4( QStringLiteral( "\\\\_" ) );
-          esc_regexp.replace( rx4, QStringLiteral( "_" ) );
-          matches = QRegExp( esc_regexp, mOp == boLike || mOp == boNotLike ? Qt::CaseSensitive : Qt::CaseInsensitive ).exactMatch( str );
+          esc_regexp.replace( QStringLiteral( "\\\\_" ), QStringLiteral( "_" ) );
+          QRegularExpression::PatternOption option;
+          if ( mOp == boILike || mOp == boNotILike )
+            option = QRegularExpression::CaseInsensitiveOption;
+          matches = QRegularExpression( esc_regexp, option ).match( str ).hasMatch();
         }
         else
         {

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -558,8 +558,7 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
             esc_regexp.replace( pos + 1, 1, '.' );
             pos += 1;
           }
-          const static QRegularExpression sRx4( QStringLiteral( "\\\\_" ) );
-          QRegularExpression rx4( sRx4 );
+          const thread_local QRegularExpression rx4( QStringLiteral( "\\\\_" ) );
           esc_regexp.replace( rx4, QStringLiteral( "_" ) );
           matches = QRegExp( esc_regexp, mOp == boLike || mOp == boNotLike ? Qt::CaseSensitive : Qt::CaseInsensitive ).exactMatch( str );
         }
@@ -1364,8 +1363,7 @@ bool QgsExpressionNodeColumnRef::prepareNode( QgsExpression *parent, const QgsEx
 
 QString QgsExpressionNodeColumnRef::dump() const
 {
-  const static QRegularExpression sRe( QStringLiteral( "^[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*$" ) );
-  QRegularExpression re( sRe );
+  const thread_local QRegularExpression re( QStringLiteral( "^[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*$" ) );
   return re.match( mName ).hasMatch() ? mName : QgsExpression::quotedColumnRef( mName );
 }
 

--- a/src/core/geometry/qgsmultipoint.cpp
+++ b/src/core/geometry/qgsmultipoint.cpp
@@ -65,8 +65,7 @@ bool QgsMultiPoint::fromWkt( const QString &wkt )
 {
   QString collectionWkt( wkt );
   //test for non-standard MultiPoint(x1 y1, x2 y2) format
-  static const QRegularExpression sRegex( QStringLiteral( "^\\s*MultiPoint\\s*[ZM]*\\s*\\(\\s*[-\\d]" ), QRegularExpression::CaseInsensitiveOption );
-  QRegularExpression regex( sRegex );
+  const thread_local QRegularExpression regex( QStringLiteral( "^\\s*MultiPoint\\s*[ZM]*\\s*\\(\\s*[-\\d]" ), QRegularExpression::CaseInsensitiveOption );
   const QRegularExpressionMatch match = regex.match( collectionWkt );
   if ( match.hasMatch() )
   {

--- a/src/core/geometry/qgsmultipoint.cpp
+++ b/src/core/geometry/qgsmultipoint.cpp
@@ -21,6 +21,7 @@ email                : marco.hugentobler at sourcepole dot com
 
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QRegularExpression>
 #include <nlohmann/json.hpp>
 
 QgsMultiPoint::QgsMultiPoint()
@@ -64,9 +65,10 @@ bool QgsMultiPoint::fromWkt( const QString &wkt )
 {
   QString collectionWkt( wkt );
   //test for non-standard MultiPoint(x1 y1, x2 y2) format
-  QRegExp regex( "^\\s*MultiPoint\\s*[ZM]*\\s*\\(\\s*[-\\d]" );
-  regex.setCaseSensitivity( Qt::CaseInsensitive );
-  if ( regex.indexIn( collectionWkt ) >= 0 )
+  static const QRegularExpression sRegex( QStringLiteral( "^\\s*MultiPoint\\s*[ZM]*\\s*\\(\\s*[-\\d]" ), QRegularExpression::CaseInsensitiveOption );
+  QRegularExpression regex( sRegex );
+  const QRegularExpressionMatch match = regex.match( collectionWkt );
+  if ( match.hasMatch() )
   {
     //alternate style without extra brackets, upgrade to standard
     collectionWkt.replace( '(', QLatin1String( "((" ) ).replace( ')', QLatin1String( "))" ) ).replace( ',', QLatin1String( "),(" ) );

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1095,7 +1095,8 @@ QString QgsApplication::userStylePath()
 
 QRegExp QgsApplication::shortNameRegExp()
 {
-  return QRegExp( "^[A-Za-z][A-Za-z0-9\\._-]*" );
+  static const QRegExp regexp( QStringLiteral( "^[A-Za-z][A-Za-z0-9\\._-]*" ) );
+  return regexp;
 }
 
 QString QgsApplication::userLoginName()

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -878,7 +878,7 @@ void QgsApplication::setUITheme( const QString &themeName )
   {
     // apply OS-specific UI scale factor to stylesheet's em values
     int index = 0;
-    const thread_local QRegularExpression regex( QStringLiteral( "(?<=[\\s:])([0-9\\.]+)(?=em)" ) );
+    const static QRegularExpression regex( QStringLiteral( "(?<=[\\s:])([0-9\\.]+)(?=em)" ) );
     QRegularExpressionMatch match = regex.match( styledata, index );
     while ( match.hasMatch() )
     {

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -878,7 +878,7 @@ void QgsApplication::setUITheme( const QString &themeName )
   {
     // apply OS-specific UI scale factor to stylesheet's em values
     int index = 0;
-    QRegularExpression regex( QStringLiteral( "(?<=[\\s:])([0-9\\.]+)(?=em)" ) );
+    const thread_local QRegularExpression regex( QStringLiteral( "(?<=[\\s:])([0-9\\.]+)(?=em)" ) );
     QRegularExpressionMatch match = regex.match( styledata, index );
     while ( match.hasMatch() )
     {
@@ -1095,7 +1095,7 @@ QString QgsApplication::userStylePath()
 
 QRegExp QgsApplication::shortNameRegExp()
 {
-  static const QRegExp regexp( QStringLiteral( "^[A-Za-z][A-Za-z0-9\\._-]*" ) );
+  const thread_local QRegExp regexp( QStringLiteral( "^[A-Za-z][A-Za-z0-9\\._-]*" ) );
   return regexp;
 }
 

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -316,7 +316,7 @@ bool QgsCoordinateReferenceSystem::createFromString( const QString &definition )
   }
   else
   {
-    const thread_local QRegularExpression reCrsStr( "^(?:(wkt|proj4|proj)\\:)?(.+)$", QRegularExpression::CaseInsensitiveOption );
+    const thread_local QRegularExpression reCrsStr( QStringLiteral( "^(?:(wkt|proj4|proj)\\:)?(.+)$" ), QRegularExpression::CaseInsensitiveOption );
     match = reCrsStr.match( definition );
     if ( match.capturedStart() == 0 )
     {
@@ -406,7 +406,7 @@ bool QgsCoordinateReferenceSystem::createFromOgcWmsCrs( const QString &crs )
   QString wmsCrs = crs;
 
   thread_local const QRegExp re_uri( QStringLiteral( "http://www\\.opengis\\.net/def/crs/([^/]+).+/([^/]+)" ), Qt::CaseInsensitive );
-  thread_local const QRegExp re_urn( "urn:ogc:def:crs:([^:]+).+([^:]+)", Qt::CaseInsensitive );
+  thread_local const QRegExp re_urn( QStringLiteral( "urn:ogc:def:crs:([^:]+).+([^:]+)" ), Qt::CaseInsensitive );
   if ( re_uri.exactMatch( wmsCrs ) )
   {
     wmsCrs = re_uri.cap( 1 ) + ':' + re_uri.cap( 2 );

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -1037,8 +1037,7 @@ bool QgsCoordinateReferenceSystem::createFromProj( const QString &projString, co
 #else
   Q_UNUSED( identify )
 
-  static const QRegularExpression sProjRegExp( QStringLiteral( "\\+proj=(\\S+)" ) );
-  QRegularExpression myProjRegExp( sProjRegExp );
+  QRegExp projRegExp( QStringLiteral( "\\+proj=(\\S+)" ) );
   int myStart = myProjRegExp.indexIn( myProj4String );
   if ( myStart == -1 )
   {
@@ -1051,8 +1050,7 @@ bool QgsCoordinateReferenceSystem::createFromProj( const QString &projString, co
 
   d->mProjectionAcronym = myProjRegExp.cap( 1 );
 
-  static const QRegularExpression sEllipseRegExp( QStringLiteral( "\\+ellps=(\\S+)" ) );
-  QRegularExpression myEllipseRegExp( sEllipseRegExp );
+  QRegExp myEllipseRegExp( QStringLiteral( "\\+ellps=(\\S+)" ) );
   myStart = myEllipseRegExp.indexIn( myProj4String );
   if ( myStart == -1 )
   {
@@ -1063,8 +1061,7 @@ bool QgsCoordinateReferenceSystem::createFromProj( const QString &projString, co
     d->mEllipsoidAcronym = myEllipseRegExp.cap( 1 );
   }
 
-  static const QRegularExpression sAxisRegExp( QStringLiteral( "\\+a=(\\S+)" ) );
-  QRegularExpression myAxisRegExp( sAxisRegExp );
+  QRegExp myAxisRegExp( QStringLiteral( "\\+a=(\\S+)" ) );
   myStart = myAxisRegExp.indexIn( myProj4String );
 
   long mySrsId = 0;
@@ -1080,10 +1077,8 @@ bool QgsCoordinateReferenceSystem::createFromProj( const QString &projString, co
     // Ticket #722 - aaronr
     // Check if we can swap the lat_1 and lat_2 params (if they exist) to see if we match...
     // First we check for lat_1 and lat_2
-    static const QRegularExpression sLat1RegExp( QStringLiteral( "\\+lat_1=\\S+" ) );
-    static const QRegularExpression sLat2RegExp( QStringLiteral( "\\+lat_2=\\S+" ) );
-    QRegularExpression myLat1RegExp( sLat1RegExp );
-    QRegularExpression myLat2RegExp( sLat2RegExp );
+    QRegExp myLat1RegExp( QStringLiteral( "\\+lat_1=\\S+" ) );
+    QRegExp myLat2RegExp( QStringLiteral( "\\+lat_2=\\S+" ) );
     int myStart1 = 0;
     int myLength1 = 0;
     int myStart2 = 0;
@@ -3142,7 +3137,7 @@ int QgsCoordinateReferenceSystem::syncDatabase()
         continue;
       }
 
-      QReExp ellipseRegExp( "\\+ellps=(\\S+)" );
+      QRegExp ellipseRegExp( "\\+ellps=(\\S+)" );
       QString ellps;
       if ( ellipseRegExp.indexIn( proj4 ) >= 0 )
       {

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -288,8 +288,7 @@ bool QgsCoordinateReferenceSystem::createFromString( const QString &definition )
   locker.unlock();
 
   bool result = false;
-  const static QRegularExpression sReCrsId( QStringLiteral( "^(epsg|esri|osgeo|ignf|zangi|iau2000|postgis|internal|user)\\:(\\w+)$" ), QRegularExpression::CaseInsensitiveOption );
-  QRegularExpression reCrsId( sReCrsId );
+  const thread_local QRegularExpression reCrsId( QStringLiteral( "^(epsg|esri|osgeo|ignf|zangi|iau2000|postgis|internal|user)\\:(\\w+)$" ), QRegularExpression::CaseInsensitiveOption );
   QRegularExpressionMatch match = reCrsId.match( definition );
   if ( match.capturedStart() == 0 )
   {
@@ -317,8 +316,7 @@ bool QgsCoordinateReferenceSystem::createFromString( const QString &definition )
   }
   else
   {
-    const static QRegularExpression sReCrsStr( "^(?:(wkt|proj4|proj)\\:)?(.+)$", QRegularExpression::CaseInsensitiveOption );
-    QRegularExpression reCrsStr( sReCrsStr );
+    const thread_local QRegularExpression reCrsStr( "^(?:(wkt|proj4|proj)\\:)?(.+)$", QRegularExpression::CaseInsensitiveOption );
     match = reCrsStr.match( definition );
     if ( match.capturedStart() == 0 )
     {
@@ -407,8 +405,7 @@ bool QgsCoordinateReferenceSystem::createFromOgcWmsCrs( const QString &crs )
 
   QString wmsCrs = crs;
 
-  static const QRegularExpression sReUri( QStringLiteral( "http://www\\.opengis\\.net/def/crs/([^/]+).+/([^/]+)" ), QRegularExpression::CaseInsensitiveOption );
-  QRegularExpression reUri( sReUri );
+  thread_local const QRegularExpression reUri( QStringLiteral( "http://www\\.opengis\\.net/def/crs/([^/]+).+/([^/]+)" ), QRegularExpression::CaseInsensitiveOption );
   QRegularExpressionMatch re_uri_match = reUri.match( wmsCrs );
   if ( re_uri_match.hasMatch() )
   {
@@ -416,15 +413,13 @@ bool QgsCoordinateReferenceSystem::createFromOgcWmsCrs( const QString &crs )
   }
   else
   {
-    static const QRegularExpression sReUrn( QStringLiteral( "urn:ogc:def:crs:([^:]+).+([^:]+)" ), QRegularExpression::CaseInsensitiveOption );
-    QRegularExpression reUrn( sReUrn );
+    thread_local const QRegularExpression reUrn( QStringLiteral( "urn:ogc:def:crs:([^:]+).+([^:]+)" ), QRegularExpression::CaseInsensitiveOption );
     QRegularExpressionMatch re_urn_match = reUrn.match( wmsCrs );
     if ( re_urn_match.hasMatch() )
       wmsCrs = re_urn_match.captured( 1 ) + ':' + re_urn_match.captured( 2 );
     else
     {
-      static const QRegularExpression sReUrnCustom( QStringLiteral( "(user|custom|qgis):(\\d+)" ), QRegularExpression::CaseInsensitiveOption );
-      QRegularExpression reUrnCustom( sReUrnCustom );
+      thread_local const QRegularExpression reUrnCustom( QStringLiteral( "(user|custom|qgis):(\\d+)" ), QRegularExpression::CaseInsensitiveOption );
       QRegularExpressionMatch re_urn_custom_match = reUrnCustom.match( wmsCrs );
       if ( re_urn_custom_match.hasMatch() && createFromSrsId( re_urn_custom_match.captured( 2 ).toInt() ) )
       {
@@ -1038,7 +1033,7 @@ bool QgsCoordinateReferenceSystem::createFromProj( const QString &projString, co
   Q_UNUSED( identify )
 
   QRegExp projRegExp( QStringLiteral( "\\+proj=(\\S+)" ) );
-  int myStart = myProjRegExp.indexIn( myProj4String );
+  int myStart = projRegExp.indexIn( myProj4String );
   if ( myStart == -1 )
   {
     locker.changeMode( QgsReadWriteLocker::Write );
@@ -1048,7 +1043,7 @@ bool QgsCoordinateReferenceSystem::createFromProj( const QString &projString, co
     return d->mIsValid;
   }
 
-  d->mProjectionAcronym = myProjRegExp.cap( 1 );
+  d->mProjectionAcronym = projRegExp.cap( 1 );
 
   QRegExp myEllipseRegExp( QStringLiteral( "\\+ellps=(\\S+)" ) );
   myStart = myEllipseRegExp.indexIn( myProj4String );
@@ -1125,8 +1120,7 @@ bool QgsCoordinateReferenceSystem::createFromProj( const QString &projString, co
     // also with parameters containing spaces (e.g. +nadgrids)
     // make sure result is trimmed (#5598)
     QStringList myParams;
-    static const QRegularExpression sRegExp( "\\s+(?=\\+)" );
-    QRegularExpression regExp( sRegExp );
+    thread_local const QRegularExpression regExp( "\\s+(?=\\+)" );
     {
       const auto constSplit = myProj4String.split( regExp, QString::SkipEmptyParts );
       for ( const QString &param : constSplit )
@@ -2447,8 +2441,7 @@ bool testIsGeographic( PJ *crs )
 
 void getOperationAndEllipsoidFromProjString( const QString &proj, QString &operation, QString &ellipsoid )
 {
-  static const QRegularExpression sProjRegExp( QStringLiteral( "\\+proj=(\\S+)" ) );
-  QRegularExpression projRegExp( sProjRegExp );
+  thread_local const QRegularExpression projRegExp( QStringLiteral( "\\+proj=(\\S+)" ) );
   const QRegularExpressionMatch projMatch = projRegExp.match( proj );
   if ( !projMatch.hasMatch() )
   {
@@ -2457,8 +2450,7 @@ void getOperationAndEllipsoidFromProjString( const QString &proj, QString &opera
   }
   operation = projMatch.captured( 1 );
 
-  static const QRegularExpression sEllipseRegExp( QStringLiteral( "\\+(?:ellps|datum)=(\\S+)" ) );
-  QRegularExpression ellipseRegExp( sEllipseRegExp );
+  thread_local const QRegularExpression ellipseRegExp( QStringLiteral( "\\+(?:ellps|datum)=(\\S+)" ) );
   const QRegularExpressionMatch ellipseMatch = projRegExp.match( proj );
   QString ellps;
   if ( !ellipseMatch.hasMatch() )

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -288,7 +288,8 @@ bool QgsCoordinateReferenceSystem::createFromString( const QString &definition )
   locker.unlock();
 
   bool result = false;
-  QRegularExpression reCrsId( QStringLiteral( "^(epsg|esri|osgeo|ignf|zangi|iau2000|postgis|internal|user)\\:(\\w+)$" ), QRegularExpression::CaseInsensitiveOption );
+  const static QRegularExpression sReCrsId( QStringLiteral( "^(epsg|esri|osgeo|ignf|zangi|iau2000|postgis|internal|user)\\:(\\w+)$" ), QRegularExpression::CaseInsensitiveOption );
+  QRegularExpression reCrsId( sReCrsId );
   QRegularExpressionMatch match = reCrsId.match( definition );
   if ( match.capturedStart() == 0 )
   {
@@ -316,7 +317,8 @@ bool QgsCoordinateReferenceSystem::createFromString( const QString &definition )
   }
   else
   {
-    QRegularExpression reCrsStr( "^(?:(wkt|proj4|proj)\\:)?(.+)$", QRegularExpression::CaseInsensitiveOption );
+    const static QRegularExpression sReCrsStr( "^(?:(wkt|proj4|proj)\\:)?(.+)$", QRegularExpression::CaseInsensitiveOption );
+    QRegularExpression reCrsStr( sReCrsStr );
     match = reCrsStr.match( definition );
     if ( match.capturedStart() == 0 )
     {
@@ -405,25 +407,32 @@ bool QgsCoordinateReferenceSystem::createFromOgcWmsCrs( const QString &crs )
 
   QString wmsCrs = crs;
 
-  QRegExp re_uri( "http://www\\.opengis\\.net/def/crs/([^/]+).+/([^/]+)", Qt::CaseInsensitive );
-  QRegExp re_urn( "urn:ogc:def:crs:([^:]+).+([^:]+)", Qt::CaseInsensitive );
-  if ( re_uri.exactMatch( wmsCrs ) )
+  static const QRegularExpression sReUri( QStringLiteral( "http://www\\.opengis\\.net/def/crs/([^/]+).+/([^/]+)" ), QRegularExpression::CaseInsensitiveOption );
+  QRegularExpression reUri( sReUri );
+  QRegularExpressionMatch re_uri_match = reUri.match( wmsCrs );
+  if ( re_uri_match.hasMatch() )
   {
-    wmsCrs = re_uri.cap( 1 ) + ':' + re_uri.cap( 2 );
-  }
-  else if ( re_urn.exactMatch( wmsCrs ) )
-  {
-    wmsCrs = re_urn.cap( 1 ) + ':' + re_urn.cap( 2 );
+    wmsCrs = re_uri_match.captured( 1 ) + ':' + re_uri_match.captured( 2 );
   }
   else
   {
-    re_urn.setPattern( QStringLiteral( "(user|custom|qgis):(\\d+)" ) );
-    if ( re_urn.exactMatch( wmsCrs ) && createFromSrsId( re_urn.cap( 2 ).toInt() ) )
+    static const QRegularExpression sReUrn( QStringLiteral( "urn:ogc:def:crs:([^:]+).+([^:]+)" ), QRegularExpression::CaseInsensitiveOption );
+    QRegularExpression reUrn( sReUrn );
+    QRegularExpressionMatch re_urn_match = reUrn.match( wmsCrs );
+    if ( re_urn_match.hasMatch() )
+      wmsCrs = re_urn_match.captured( 1 ) + ':' + re_urn_match.captured( 2 );
+    else
     {
-      locker.changeMode( QgsReadWriteLocker::Write );
-      if ( !sDisableOgcCache )
-        sOgcCache()->insert( crs, *this );
-      return d->mIsValid;
+      static const QRegularExpression sReUrnCustom( QStringLiteral( "(user|custom|qgis):(\\d+)" ), QRegularExpression::CaseInsensitiveOption );
+      QRegularExpression reUrnCustom( sReUrnCustom );
+      QRegularExpressionMatch re_urn_custom_match = reUrnCustom.match( wmsCrs );
+      if ( re_urn_custom_match.hasMatch() && createFromSrsId( re_urn_custom_match.captured( 2 ).toInt() ) )
+      {
+        locker.changeMode( QgsReadWriteLocker::Write );
+        if ( !sDisableOgcCache )
+          sOgcCache()->insert( crs, *this );
+        return d->mIsValid;
+      }
     }
   }
 
@@ -1028,7 +1037,8 @@ bool QgsCoordinateReferenceSystem::createFromProj( const QString &projString, co
 #else
   Q_UNUSED( identify )
 
-  QRegExp myProjRegExp( "\\+proj=(\\S+)" );
+  static const QRegularExpression sProjRegExp( QStringLiteral( "\\+proj=(\\S+)" ) );
+  QRegularExpression myProjRegExp( sProjRegExp );
   int myStart = myProjRegExp.indexIn( myProj4String );
   if ( myStart == -1 )
   {
@@ -1041,7 +1051,8 @@ bool QgsCoordinateReferenceSystem::createFromProj( const QString &projString, co
 
   d->mProjectionAcronym = myProjRegExp.cap( 1 );
 
-  QRegExp myEllipseRegExp( "\\+ellps=(\\S+)" );
+  static const QRegularExpression sEllipseRegExp( QStringLiteral( "\\+ellps=(\\S+)" ) );
+  QRegularExpression myEllipseRegExp( sEllipseRegExp );
   myStart = myEllipseRegExp.indexIn( myProj4String );
   if ( myStart == -1 )
   {
@@ -1052,7 +1063,8 @@ bool QgsCoordinateReferenceSystem::createFromProj( const QString &projString, co
     d->mEllipsoidAcronym = myEllipseRegExp.cap( 1 );
   }
 
-  QRegExp myAxisRegExp( "\\+a=(\\S+)" );
+  static const QRegularExpression sAxisRegExp( QStringLiteral( "\\+a=(\\S+)" ) );
+  QRegularExpression myAxisRegExp( sAxisRegExp );
   myStart = myAxisRegExp.indexIn( myProj4String );
 
   long mySrsId = 0;
@@ -1068,8 +1080,10 @@ bool QgsCoordinateReferenceSystem::createFromProj( const QString &projString, co
     // Ticket #722 - aaronr
     // Check if we can swap the lat_1 and lat_2 params (if they exist) to see if we match...
     // First we check for lat_1 and lat_2
-    QRegExp myLat1RegExp( "\\+lat_1=\\S+" );
-    QRegExp myLat2RegExp( "\\+lat_2=\\S+" );
+    static const QRegularExpression sLat1RegExp( QStringLiteral( "\\+lat_1=\\S+" ) );
+    static const QRegularExpression sLat2RegExp( QStringLiteral( "\\+lat_2=\\S+" ) );
+    QRegularExpression myLat1RegExp( sLat1RegExp );
+    QRegularExpression myLat2RegExp( sLat2RegExp );
     int myStart1 = 0;
     int myLength1 = 0;
     int myStart2 = 0;
@@ -1116,7 +1130,8 @@ bool QgsCoordinateReferenceSystem::createFromProj( const QString &projString, co
     // also with parameters containing spaces (e.g. +nadgrids)
     // make sure result is trimmed (#5598)
     QStringList myParams;
-    const QRegExp regExp( "\\s+(?=\\+)" );
+    static const QRegularExpression sRegExp( "\\s+(?=\\+)" );
+    QRegularExpression regExp( sRegExp );
     {
       const auto constSplit = myProj4String.split( regExp, QString::SkipEmptyParts );
       for ( const QString &param : constSplit )
@@ -2437,19 +2452,23 @@ bool testIsGeographic( PJ *crs )
 
 void getOperationAndEllipsoidFromProjString( const QString &proj, QString &operation, QString &ellipsoid )
 {
-  QRegExp projRegExp( "\\+proj=(\\S+)" );
-  if ( projRegExp.indexIn( proj ) < 0 )
+  static const QRegularExpression sProjRegExp( QStringLiteral( "\\+proj=(\\S+)" ) );
+  QRegularExpression projRegExp( sProjRegExp );
+  const QRegularExpressionMatch projMatch = projRegExp.match( proj );
+  if ( !projMatch.hasMatch() )
   {
     QgsDebugMsgLevel( QStringLiteral( "no +proj argument found [%2]" ).arg( proj ), 2 );
     return;
   }
-  operation = projRegExp.cap( 1 );
+  operation = projMatch.captured( 1 );
 
-  QRegExp ellipseRegExp( "\\+(?:ellps|datum)=(\\S+)" );
+  static const QRegularExpression sEllipseRegExp( QStringLiteral( "\\+(?:ellps|datum)=(\\S+)" ) );
+  QRegularExpression ellipseRegExp( sEllipseRegExp );
+  const QRegularExpressionMatch ellipseMatch = projRegExp.match( proj );
   QString ellps;
-  if ( ellipseRegExp.indexIn( proj ) >= 0 )
+  if ( !ellipseMatch.hasMatch() )
   {
-    ellipsoid = ellipseRegExp.cap( 1 );
+    ellipsoid = ellipseMatch.captured( 1 );
   }
   else
   {
@@ -2458,7 +2477,7 @@ void getOperationAndEllipsoidFromProjString( const QString &proj, QString &opera
     // and will result in oddities within other areas of QGIS (e.g. project ellipsoid won't be correctly
     // set for these CRSes). Better just hack around and make the constraint happy for now,
     // and hope that the definitions get corrected in future.
-    ellipsoid = "";
+    ellipsoid.clear();
   }
 }
 
@@ -3123,7 +3142,7 @@ int QgsCoordinateReferenceSystem::syncDatabase()
         continue;
       }
 
-      QRegExp ellipseRegExp( "\\+ellps=(\\S+)" );
+      QReExp ellipseRegExp( "\\+ellps=(\\S+)" );
       QString ellps;
       if ( ellipseRegExp.indexIn( proj4 ) >= 0 )
       {

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -405,29 +405,25 @@ bool QgsCoordinateReferenceSystem::createFromOgcWmsCrs( const QString &crs )
 
   QString wmsCrs = crs;
 
-  thread_local const QRegularExpression reUri( QStringLiteral( "http://www\\.opengis\\.net/def/crs/([^/]+).+/([^/]+)" ), QRegularExpression::CaseInsensitiveOption );
-  QRegularExpressionMatch re_uri_match = reUri.match( wmsCrs );
-  if ( re_uri_match.hasMatch() )
+  thread_local const QRegExp re_uri( QStringLiteral( "http://www\\.opengis\\.net/def/crs/([^/]+).+/([^/]+)" ), Qt::CaseInsensitive );
+  thread_local const QRegExp re_urn( "urn:ogc:def:crs:([^:]+).+([^:]+)", Qt::CaseInsensitive );
+  if ( re_uri.exactMatch( wmsCrs ) )
   {
-    wmsCrs = re_uri_match.captured( 1 ) + ':' + re_uri_match.captured( 2 );
+    wmsCrs = re_uri.cap( 1 ) + ':' + re_uri.cap( 2 );
+  }
+  else if ( re_urn.exactMatch( wmsCrs ) )
+  {
+    wmsCrs = re_urn.cap( 1 ) + ':' + re_urn.cap( 2 );
   }
   else
   {
-    thread_local const QRegularExpression reUrn( QStringLiteral( "urn:ogc:def:crs:([^:]+).+([^:]+)" ), QRegularExpression::CaseInsensitiveOption );
-    QRegularExpressionMatch re_urn_match = reUrn.match( wmsCrs );
-    if ( re_urn_match.hasMatch() )
-      wmsCrs = re_urn_match.captured( 1 ) + ':' + re_urn_match.captured( 2 );
-    else
+    thread_local const QRegExp re_urn_custom( QStringLiteral( "(user|custom|qgis):(\\d+)" ), Qt::CaseInsensitive );
+    if ( re_urn_custom.exactMatch( wmsCrs ) && createFromSrsId( re_urn.cap( 2 ).toInt() ) )
     {
-      thread_local const QRegularExpression reUrnCustom( QStringLiteral( "(user|custom|qgis):(\\d+)" ), QRegularExpression::CaseInsensitiveOption );
-      QRegularExpressionMatch re_urn_custom_match = reUrnCustom.match( wmsCrs );
-      if ( re_urn_custom_match.hasMatch() && createFromSrsId( re_urn_custom_match.captured( 2 ).toInt() ) )
-      {
-        locker.changeMode( QgsReadWriteLocker::Write );
-        if ( !sDisableOgcCache )
-          sOgcCache()->insert( crs, *this );
-        return d->mIsValid;
-      }
+      locker.changeMode( QgsReadWriteLocker::Write );
+      if ( !sDisableOgcCache )
+        sOgcCache()->insert( crs, *this );
+      return d->mIsValid;
     }
   }
 

--- a/src/core/qgsprojutils.cpp
+++ b/src/core/qgsprojutils.cpp
@@ -256,8 +256,7 @@ bool QgsProjUtils::coordinateOperationIsAvailable( const QString &projDef )
 
 QList<QgsDatumTransform::GridDetails> QgsProjUtils::gridsUsed( const QString &proj )
 {
-  static QRegularExpression sRegex( QStringLiteral( "\\+(?:nad)?grids=(.*?)\\s" ) );
-  QRegularExpression regex( sRegex );
+  const thread_local QRegularExpression regex( QStringLiteral( "\\+(?:nad)?grids=(.*?)\\s" ) );
 
   QList< QgsDatumTransform::GridDetails > grids;
   QRegularExpressionMatchIterator matches = regex.globalMatch( proj );

--- a/src/core/qgsprojutils.cpp
+++ b/src/core/qgsprojutils.cpp
@@ -257,9 +257,10 @@ bool QgsProjUtils::coordinateOperationIsAvailable( const QString &projDef )
 QList<QgsDatumTransform::GridDetails> QgsProjUtils::gridsUsed( const QString &proj )
 {
   static QRegularExpression sRegex( QStringLiteral( "\\+(?:nad)?grids=(.*?)\\s" ) );
+  QRegularExpression regex( sRegex );
 
   QList< QgsDatumTransform::GridDetails > grids;
-  QRegularExpressionMatchIterator matches = sRegex.globalMatch( proj );
+  QRegularExpressionMatchIterator matches = regex.globalMatch( proj );
   while ( matches.hasNext() )
   {
     const QRegularExpressionMatch match = matches.next();


### PR DESCRIPTION
## Description

Reduces the cost of preparing static regular expressions repeatedly

Gives a 7% performance boost on simple `like` expressions