### PR TITLE
We can trust compiled expressions, remove option to disable

### DIFF
--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -704,7 +704,6 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   cbxCheckVersion->setChecked( mSettings->value( QStringLiteral( "/qgis/checkVersion" ), true ).toBool() );
   cbxCheckVersion->setVisible( mSettings->value( QStringLiteral( "/qgis/allowVersionCheck" ), true ).toBool() );
   cbxAttributeTableDocked->setChecked( mSettings->value( QStringLiteral( "/qgis/dockAttributeTable" ), false ).toBool() );
-  cbxCompileExpressions->setChecked( mSettings->value( QStringLiteral( "/qgis/compileExpressions" ), true ).toBool() );
 
   mComboCopyFeatureFormat->addItem( tr( "Plain Text, No Geometry" ), QgsClipboard::AttributesOnly );
   mComboCopyFeatureFormat->addItem( tr( "Plain Text, WKT Geometry" ), QgsClipboard::AttributesWithWKT );
@@ -1566,8 +1565,6 @@ void QgsOptions::saveOptions()
   mSettings->setValue( QStringLiteral( "/qgis/scanZipInBrowser2" ),
                        cmbScanZipInBrowser->currentData().toString() );
   mSettings->setValue( QStringLiteral( "/qgis/mainSnappingWidgetMode" ), mSnappingMainDialogComboBox->currentData() );
-
-  mSettings->setValue( QStringLiteral( "/qgis/compileExpressions" ), cbxCompileExpressions->isChecked() );
 
   mSettings->setValue( QStringLiteral( "/qgis/legendsymbolMinimumSize" ), mLegendSymbolMinimumSizeSpinBox->value() );
   mSettings->setValue( QStringLiteral( "/qgis/legendsymbolMaximumSize" ), mLegendSymbolMaximumSizeSpinBox->value() );

--- a/src/core/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/core/providers/ogr/qgsogrfeatureiterator.cpp
@@ -196,8 +196,7 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
     }
   }
 
-  if ( request.filterType() == QgsFeatureRequest::FilterExpression
-       && QgsSettings().value( QStringLiteral( "qgis/compileExpressions" ), true ).toBool() )
+  if ( request.filterType() == QgsFeatureRequest::FilterExpression )
   {
     QgsSqlExpressionCompiler *compiler = nullptr;
     if ( source->mDriverName == QLatin1String( "SQLite" ) || source->mDriverName == QLatin1String( "GPKG" ) )

--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -199,25 +199,18 @@ QgsOracleFeatureIterator::QgsOracleFeatureIterator( QgsOracleFeatureSource *sour
   bool useFallback = false;
   if ( request.filterType() == QgsFeatureRequest::FilterExpression )
   {
-    if ( QgsSettings().value( QStringLiteral( "qgis/compileExpressions" ), true ).toBool() )
+    QgsOracleExpressionCompiler compiler( mSource );
+    QgsSqlExpressionCompiler::Result result = compiler.compile( mRequest.filterExpression() );
+    if ( result == QgsSqlExpressionCompiler::Complete || result == QgsSqlExpressionCompiler::Partial )
     {
-      QgsOracleExpressionCompiler compiler( mSource );
-      QgsSqlExpressionCompiler::Result result = compiler.compile( mRequest.filterExpression() );
-      if ( result == QgsSqlExpressionCompiler::Complete || result == QgsSqlExpressionCompiler::Partial )
-      {
-        fallbackStatement = whereClause;
-        useFallback = true;
-        whereClause = QgsOracleUtils::andWhereClauses( whereClause, compiler.result() );
+      fallbackStatement = whereClause;
+      useFallback = true;
+      whereClause = QgsOracleUtils::andWhereClauses( whereClause, compiler.result() );
 
-        //if only partial success when compiling expression, we need to double-check results using QGIS' expressions
-        mExpressionCompiled = ( result == QgsSqlExpressionCompiler::Complete );
-        mCompileStatus = ( mExpressionCompiled ? Compiled : PartiallyCompiled );
-        limitAtProvider = mExpressionCompiled;
-      }
-      else
-      {
-        limitAtProvider = false;
-      }
+      //if only partial success when compiling expression, we need to double-check results using QGIS' expressions
+      mExpressionCompiled = ( result == QgsSqlExpressionCompiler::Complete );
+      mCompileStatus = ( mExpressionCompiled ? Compiled : PartiallyCompiled );
+      limitAtProvider = mExpressionCompiled;
     }
     else
     {

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -113,23 +113,16 @@ QgsPostgresFeatureIterator::QgsPostgresFeatureIterator( QgsPostgresFeatureSource
     }
     mFilterRequiresGeometry = request.filterExpression()->needsGeometry();
 
-    if ( QgsSettings().value( QStringLiteral( "qgis/compileExpressions" ), true ).toBool() )
-    {
-      //IMPORTANT - this MUST be the last clause added!
-      QgsPostgresExpressionCompiler compiler = QgsPostgresExpressionCompiler( source );
+    //IMPORTANT - this MUST be the last clause added!
+    QgsPostgresExpressionCompiler compiler = QgsPostgresExpressionCompiler( source );
 
-      if ( compiler.compile( request.filterExpression() ) == QgsSqlExpressionCompiler::Complete )
-      {
-        useFallbackWhereClause = true;
-        fallbackWhereClause = whereClause;
-        whereClause = QgsPostgresUtils::andWhereClauses( whereClause, compiler.result() );
-        mExpressionCompiled = true;
-        mCompileStatus = Compiled;
-      }
-      else
-      {
-        limitAtProvider = false;
-      }
+    if ( compiler.compile( request.filterExpression() ) == QgsSqlExpressionCompiler::Complete )
+    {
+      useFallbackWhereClause = true;
+      fallbackWhereClause = whereClause;
+      whereClause = QgsPostgresUtils::andWhereClauses( whereClause, compiler.result() );
+      mExpressionCompiled = true;
+      mCompileStatus = Compiled;
     }
     else
     {

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -123,33 +123,24 @@ QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeature
       mFetchGeometry = true;
     }
 
-    if ( QgsSettings().value( QStringLiteral( "qgis/compileExpressions" ), true ).toBool() )
+    QgsSQLiteExpressionCompiler compiler = QgsSQLiteExpressionCompiler( source->mFields );
+    QgsSqlExpressionCompiler::Result result = compiler.compile( request.filterExpression() );
+    if ( result == QgsSqlExpressionCompiler::Complete || result == QgsSqlExpressionCompiler::Partial )
     {
-      QgsSQLiteExpressionCompiler compiler = QgsSQLiteExpressionCompiler( source->mFields );
-
-      QgsSqlExpressionCompiler::Result result = compiler.compile( request.filterExpression() );
-
-      if ( result == QgsSqlExpressionCompiler::Complete || result == QgsSqlExpressionCompiler::Partial )
+      whereClause = compiler.result();
+      if ( !whereClause.isEmpty() )
       {
-        whereClause = compiler.result();
-        if ( !whereClause.isEmpty() )
-        {
-          useFallbackWhereClause = true;
-          fallbackWhereClause = whereClauses.join( QLatin1String( " AND " ) );
-          whereClauses.append( whereClause );
-          //if only partial success when compiling expression, we need to double-check results using QGIS' expressions
-          mExpressionCompiled = ( result == QgsSqlExpressionCompiler::Complete );
-          mCompileStatus = ( mExpressionCompiled ? Compiled : PartiallyCompiled );
-        }
-      }
-      if ( result != QgsSqlExpressionCompiler::Complete )
-      {
-        //can't apply limit at provider side as we need to check all results using QGIS expressions
-        limitAtProvider = false;
+        useFallbackWhereClause = true;
+        fallbackWhereClause = whereClauses.join( QLatin1String( " AND " ) );
+        whereClauses.append( whereClause );
+        //if only partial success when compiling expression, we need to double-check results using QGIS' expressions
+        mExpressionCompiled = ( result == QgsSqlExpressionCompiler::Complete );
+        mCompileStatus = ( mExpressionCompiled ? Compiled : PartiallyCompiled );
       }
     }
-    else
+    if ( result != QgsSqlExpressionCompiler::Complete )
     {
+      //can't apply limit at provider side as we need to check all results using QGIS expressions
       limitAtProvider = false;
     }
   }
@@ -163,40 +154,33 @@ QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeature
 
     mOrderByCompiled = true;
 
-    if ( QgsSettings().value( QStringLiteral( "qgis/compileExpressions" ), true ).toBool() )
+    const auto constOrderBy = request.orderBy();
+    for ( const QgsFeatureRequest::OrderByClause &clause : constOrderBy )
     {
-      const auto constOrderBy = request.orderBy();
-      for ( const QgsFeatureRequest::OrderByClause &clause : constOrderBy )
+      QgsSQLiteExpressionCompiler compiler = QgsSQLiteExpressionCompiler( source->mFields );
+      QgsExpression expression = clause.expression();
+      if ( compiler.compile( &expression ) == QgsSqlExpressionCompiler::Complete )
       {
-        QgsSQLiteExpressionCompiler compiler = QgsSQLiteExpressionCompiler( source->mFields );
-        QgsExpression expression = clause.expression();
-        if ( compiler.compile( &expression ) == QgsSqlExpressionCompiler::Complete )
-        {
-          QString part;
-          part = compiler.result();
+        QString part;
+        part = compiler.result();
 
-          if ( clause.nullsFirst() )
-            orderByParts << QStringLiteral( "%1 IS NOT NULL" ).arg( part );
-          else
-            orderByParts << QStringLiteral( "%1 IS NULL" ).arg( part );
-
-          part += clause.ascending() ? " COLLATE NOCASE ASC" : " COLLATE NOCASE DESC";
-          orderByParts << part;
-        }
+        if ( clause.nullsFirst() )
+          orderByParts << QStringLiteral( "%1 IS NOT NULL" ).arg( part );
         else
-        {
-          // Bail out on first non-complete compilation.
-          // Most important clauses at the beginning of the list
-          // will still be sent and used to pre-sort so the local
-          // CPU can use its cycles for fine-tuning.
-          mOrderByCompiled = false;
-          break;
-        }
+          orderByParts << QStringLiteral( "%1 IS NULL" ).arg( part );
+
+        part += clause.ascending() ? " COLLATE NOCASE ASC" : " COLLATE NOCASE DESC";
+        orderByParts << part;
       }
-    }
-    else
-    {
-      mOrderByCompiled = false;
+      else
+      {
+        // Bail out on first non-complete compilation.
+        // Most important clauses at the beginning of the list
+        // will still be sent and used to pre-sort so the local
+        // CPU can use its cycles for fine-tuning.
+        mOrderByCompiled = false;
+        break;
+      }
     }
 
     if ( !mOrderByCompiled )

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -2087,7 +2087,7 @@
                   <item row="0" column="2">
                    <widget class="QComboBox" name="cmbScanItemsInBrowser"/>
                   </item>
-                  <item row="6" column="0" colspan="4">
+                  <item row="5" column="0" colspan="4">
                    <widget class="QCheckBox" name="cbxEvaluateDefaultValues">
                     <property name="toolTip">
                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When digitizing a new feature, default values are retrieved from the database. With this option turned on, the default values will be evaluated at the time of digitizing. With this option turned off, the default values will be evaluated at the time of saving.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -2139,13 +2139,6 @@
                    <widget class="QLabel" name="label_30">
                     <property name="text">
                      <string>Scan for valid items in the browser dock</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="0" colspan="4">
-                   <widget class="QCheckBox" name="cbxCompileExpressions">
-                    <property name="text">
-                     <string>Execute expressions on server-side if possible</string>
                     </property>
                    </widget>
                   </item>


### PR DESCRIPTION
## Description

Spotted while doing rendering profiling against postgres provider: calling QgsSettings in a provider iterator is costly enough not to want to do it. 

What this means practically is the removal of the app setting to toggle off compiled expression. I believe it's not only a speed gain here but the right thing to do:
- compiled expressions have been around long enough to trust it
- the removal of an obscure checkbox option is good, and helps make sure all users go through the same tested code