### PR TITLE
Added sanity check of links between graphicitems showing error in dialog. Fixes #40724 #39260

### DIFF
--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -148,7 +148,7 @@ Sets the message ``bar`` associated with the scene.
 .. seealso:: :py:func:`messageBar`
 %End
 
-    void showWarning( const QString &shortMessage, const QString &title, const QString &longMessage, Qgis::MessageLevel level = Qgis::Warning );
+    void showWarning( const QString &shortMessage, const QString &title, const QString &longMessage, Qgis::MessageLevel level = Qgis::Warning ) const;
 %Docstring
 Shows a warning message, allowing users to click a button to see the full details (``longMessage``).
 %End

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -235,8 +235,9 @@ class ModelerDialog(QgsModelDesignerDialog):
             scene.setFlag(QgsModelGraphicsScene.FlagHideComments)
 
         context = createContext()
-        scene.createItems(self.model(), context)
         self.setModelScene(scene)
+        # create items later that setModelScene to setup link to messageBar to the scene
+        scene.createItems(self.model(), context)
 
     def create_widget_context(self):
         """

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -983,12 +983,21 @@ QString QgsModelChildAlgorithmGraphicItem::linkPointText( Qt::Edge edge, int ind
   if ( const QgsProcessingModelChildAlgorithm *child = dynamic_cast< const QgsProcessingModelChildAlgorithm * >( component() ) )
   {
     if ( !child->algorithm() )
-      return 0;
+      return QString();
 
     switch ( edge )
     {
       case Qt::BottomEdge:
       {
+        if ( index >= child->algorithm()->outputDefinitions().length() )
+        {
+          // something goes wrong and tried to link to an not existing output
+          QgsMessageLog::logMessage(
+            tr( "Cannot link output for child: %1" ).arg( child->algorithm()->name() ),
+            "QgsModelChildAlgorithmGraphicItem", Qgis::Warning, true );
+          return QString();
+        }
+
         const QgsProcessingOutputDefinition *output = child->algorithm()->outputDefinitions().at( index );
         QString title = output->description();
         if ( mResults.contains( output->name() ) )
@@ -1006,6 +1015,14 @@ QString QgsModelChildAlgorithmGraphicItem::linkPointText( Qt::Edge edge, int ind
           return param->flags() & QgsProcessingParameterDefinition::FlagHidden || param->isDestination();
         } ), params.end() );
 
+        if ( index >= params.length() )
+        {
+          // something goes wrong and tried to link to an not existing source parameter
+          QgsMessageLog::logMessage(
+            tr( "Cannot link source for child: %1" ).arg( child->algorithm()->name() ),
+            "QgsModelChildAlgorithmGraphicItem", Qgis::Warning, true );
+          return QString();
+        }
 
         QString title = params.at( index )->description();
         if ( !mInputs.value( params.at( index )->name() ).toString().isEmpty() )

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -22,6 +22,7 @@
 #include "qgsmessagebar.h"
 #include "qgsmessagebaritem.h"
 #include "qgsmessageviewer.h"
+#include "qgsapplication.h"
 #include <QGraphicsSceneMouseEvent>
 #include <QPushButton>
 
@@ -409,6 +410,20 @@ QList<QgsModelGraphicsScene::LinkSource> QgsModelGraphicsScene::linkSourcesForPa
           LinkSource l;
           l.item = mChildAlgorithmItems.value( source.outputChildId() );
           l.edge = Qt::BottomEdge;
+
+          // do sanity check of linked index
+          if ( i >= model->childAlgorithm( source.outputChildId() ).algorithm()->outputDefinitions().length() )
+          {
+            QString short_message = tr( "Check output links for alg: %1" ).arg( model->childAlgorithm( source.outputChildId() ).algorithm()->name() );
+            QString long_message = tr( "Cannot link output for alg: %1" ).arg( model->childAlgorithm( source.outputChildId() ).algorithm()->name() );
+            QString title( tr( "Algorithm link error" ) );
+            if ( messageBar() )
+              showWarning( const_cast<QString &>( short_message ), const_cast<QString &>( title ), const_cast<QString &>( long_message ) );
+            else
+              QgsMessageLog::logMessage( long_message, "QgsModelGraphicsScene", Qgis::Warning, true );
+            break;
+          }
+
           l.linkIndex = i;
           res.append( l );
         }
@@ -467,7 +482,7 @@ void QgsModelGraphicsScene::setMessageBar( QgsMessageBar *messageBar )
   mMessageBar = messageBar;
 }
 
-void QgsModelGraphicsScene::showWarning( const QString &shortMessage, const QString &title, const QString &longMessage, Qgis::MessageLevel level )
+void QgsModelGraphicsScene::showWarning( const QString &shortMessage, const QString &title, const QString &longMessage, Qgis::MessageLevel level ) const
 {
   QgsMessageBarItem *messageWidget = mMessageBar->createMessage( QString(), shortMessage );
   QPushButton *detailsButton = new QPushButton( tr( "Details" ) );
@@ -484,4 +499,3 @@ void QgsModelGraphicsScene::showWarning( const QString &shortMessage, const QStr
 }
 
 ///@endcond
-

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -164,7 +164,7 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
     /**
      * Shows a warning message, allowing users to click a button to see the full details (\a longMessage).
      */
-    void showWarning( const QString &shortMessage, const QString &title, const QString &longMessage, Qgis::MessageLevel level = Qgis::Warning );
+    void showWarning( const QString &shortMessage, const QString &title, const QString &longMessage, Qgis::MessageLevel level = Qgis::Warning ) const;
 
   signals:
 


### PR DESCRIPTION
## Description

Modeler sometimes crash due to lack of links among graphicItems. This PR add some more sanity check to prevent this crashes and showing the the error to allow better debug.

This PR fixees crash reported in #40724 #39260