### PR TITLE
Add QgsMapLayer::project() utility method

### DIFF
--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1490,7 +1490,10 @@ Sets the coordinate transform context to ``transformContext``
 
     QgsProject *project() const;
 %Docstring
-Returns the parent project if available.
+Returns the parent project if this map layer is added to a project.
+Otherwise returns ``None``
+
+.. versionadded:: 3.18
 %End
 
   signals:

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1488,6 +1488,11 @@ Sets the coordinate transform context to ``transformContext``
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
+    QgsProject *project() const;
+%Docstring
+Returns the parent project if available.
+%End
+
   signals:
 
     void beforeResolveReferences( QgsProject *project );

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1981,6 +1981,15 @@ void QgsMapLayer::setRefreshOnNotifyEnabled( bool enabled )
   mIsRefreshOnNofifyEnabled = enabled;
 }
 
+QgsProject *QgsMapLayer::project() const
+{
+  if ( QgsMapLayerStore *store = qobject_cast<QgsMapLayerStore *>( parent() ) )
+  {
+    return qobject_cast<QgsProject *>( store->parent() );
+  }
+  return nullptr;
+}
+
 void QgsMapLayer::onNotifiedTriggerRepaint( const QString &message )
 {
   if ( refreshOnNotifyMessage().isEmpty() || refreshOnNotifyMessage() == message )

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1336,7 +1336,10 @@ class CORE_EXPORT QgsMapLayer : public QObject
 #endif
 
     /**
-     * Returns the parent project if available.
+     * Returns the parent project if this map layer is added to a project.
+     * Otherwise returns NULLPTR
+     *
+     * \since QGIS 3.18
      */
     QgsProject *project() const;
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1335,6 +1335,11 @@ class CORE_EXPORT QgsMapLayer : public QObject
     % End
 #endif
 
+    /**
+     * Returns the parent project if available.
+     */
+    QgsProject *project() const;
+
   signals:
 
     /**

--- a/tests/src/python/test_qgsmaplayer.py
+++ b/tests/src/python/test_qgsmaplayer.py
@@ -15,6 +15,7 @@ import qgis  # NOQA
 import tempfile
 import glob
 import shutil
+import sip
 
 from qgis.core import (QgsReadWriteContext,
                        QgsVectorLayer,
@@ -184,6 +185,20 @@ class TestQgsMapLayer(unittest.TestCase):
         rl = QgsRasterLayer(temp_source, 'test')
         self.assertTrue(rl.isValid())
         self.assertTrue(rl.isTemporary())
+
+    def testQgsMapLayerProject(self):
+        layer = QgsVectorLayer(os.path.join(TEST_DATA_DIR, 'points.shp'), "layer", "ogr")
+        self.assertIsNone(layer.project())
+        project = QgsProject()
+        project.addMapLayer(layer)
+        self.assertEqual(layer.project(), project)
+        project2 = QgsProject()
+        project2.addMapLayer(layer)
+        self.assertEqual(layer.project(), project2)
+        project.removeMapLayer(layer)
+        self.assertFalse(sip.isdeleted(layer))
+        project2.removeMapLayer(layer)
+        self.assertTrue(sip.isdeleted(layer))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

Utility method `QgsProject *QgsMapLayer::project()` to get access to the parent project from layers. Mostly important for the unit tests that guarantee a forward proof API.
Minimal footprint implementation related to https://github.com/qgis/QGIS-Enhancement-Proposals/issues/203 .