### PR TITLE
[expression] Avoid paying the price of a QgsCoordinateReferenceSystem destruction if we didn't need one

### DIFF
--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -278,8 +278,8 @@ void QgsExpression::initGeomCalculator( const QgsExpressionContext *context )
     // actually don't do it right away, cos it's expensive to create and only a very small number of expression
     // functions actually require it. Let's lazily construct it when needed
     d->mDaEllipsoid = context->variable( QStringLiteral( "project_ellipsoid" ) ).toString();
-    d->mDaCrs = context->variable( QStringLiteral( "_layer_crs" ) ).value<QgsCoordinateReferenceSystem>();
-    d->mDaTransformContext = context->variable( QStringLiteral( "_project_transform_context" ) ).value<QgsCoordinateTransformContext>();
+    d->mDaCrs = qgis::make_unique<QgsCoordinateReferenceSystem>( context->variable( QStringLiteral( "_layer_crs" ) ).value<QgsCoordinateReferenceSystem>() );
+    d->mDaTransformContext = qgis::make_unique<QgsCoordinateTransformContext>( context->variable( QStringLiteral( "_project_transform_context" ) ).value<QgsCoordinateTransformContext>() );
   }
 
   // Set the distance units from the context if it has not been set by setDistanceUnits()
@@ -396,12 +396,12 @@ QString QgsExpression::dump() const
 
 QgsDistanceArea *QgsExpression::geomCalculator()
 {
-  if ( !d->mCalc && d->mDaCrs.isValid() )
+  if ( !d->mCalc && d->mDaCrs && d->mDaCrs->isValid() && d->mDaTransformContext )
   {
     // calculator IS required, so initialize it now...
     d->mCalc = std::shared_ptr<QgsDistanceArea>( new QgsDistanceArea() );
     d->mCalc->setEllipsoid( d->mDaEllipsoid.isEmpty() ? geoNone() : d->mDaEllipsoid );
-    d->mCalc->setSourceCrs( d->mDaCrs, d->mDaTransformContext );
+    d->mCalc->setSourceCrs( *d->mDaCrs.get(), *d->mDaTransformContext.get() );
   }
 
   return d->mCalc.get();

--- a/src/core/expression/qgsexpression_p.h
+++ b/src/core/expression/qgsexpression_p.h
@@ -47,12 +47,15 @@ class QgsExpressionPrivate
       , mParserErrors( other.mParserErrors )
       , mExp( other.mExp )
       , mDaEllipsoid( other.mDaEllipsoid )
-      , mDaCrs( other.mDaCrs )
-      , mDaTransformContext( other.mDaTransformContext )
       , mCalc( other.mCalc )
       , mDistanceUnit( other.mDistanceUnit )
       , mAreaUnit( other.mAreaUnit )
-    {}
+    {
+      if ( other.mDaCrs )
+        mDaCrs = qgis::make_unique<QgsCoordinateReferenceSystem>( *other.mDaCrs.get() );
+      if ( other.mDaTransformContext )
+        mDaTransformContext = qgis::make_unique<QgsCoordinateTransformContext>( *other.mDaTransformContext.get() );
+    }
 
     ~QgsExpressionPrivate()
     {
@@ -71,8 +74,8 @@ class QgsExpressionPrivate
     QString mExp;
 
     QString mDaEllipsoid;
-    QgsCoordinateReferenceSystem mDaCrs;
-    QgsCoordinateTransformContext mDaTransformContext;
+    std::unique_ptr<QgsCoordinateReferenceSystem> mDaCrs;
+    std::unique_ptr<QgsCoordinateTransformContext> mDaTransformContext;
 
     std::shared_ptr<QgsDistanceArea> mCalc;
     QgsUnitTypes::DistanceUnit mDistanceUnit = QgsUnitTypes::DistanceUnknownUnit;


### PR DESCRIPTION
## Description

This PR aims at avoiding the non-negligible cost of the QgsCoordinateReferenceSystem destructor when a QgsExpression hasn't made use of it.