### PR TITLE
Authentication failed when WFS uses OAuth2 method

### DIFF
--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -1518,6 +1518,7 @@ bool QgsAuthManager::updateDataSourceUriItems( QStringList &connectionItems, con
     if ( !( authmethod->supportedExpansions() & QgsAuthMethod::DataSourceUri ) )
     {
       QgsDebugMsg( QStringLiteral( "Data source URI updating not supported by authcfg: %1" ).arg( authcfg ) );
+      connectionItems << "authcfg=" + authcfg;
       return true;
     }
 


### PR DESCRIPTION
**QGIS Verison : 3.14.16  (The bug is solved in the new version)**
When QgsAuthMethod does not support QgsAuthMethod::DataSourceUri, the AuthConfigId of the uri will be discarded, causing the request to fail verification. 
Because the default value of expandAuthConfig is true, it will call updateDataSourceUriItems by default when converting uri.
```
QString QgsDataSourceUri::connectionInfo( bool expandAuthConfig ) const
{
  ......
  if ( !mAuthConfigId.isEmpty() )
  {
    if ( expandAuthConfig )
    {
      if ( !QgsApplication::authManager()->updateDataSourceUriItems( connectionItems, mAuthConfigId ) )
      {
        QgsDebugMsg( QStringLiteral( "Data source URI FAILED to update via loading configuration ID '%1'" ).arg( mAuthConfigId ) );
      }
    }
    else
    {
      connectionItems << "authcfg=" + mAuthConfigId;
    }
  }

  return connectionItems.join( QStringLiteral( " " ) );
}
```
```
bool QgsAuthManager::updateDataSourceUriItems( QStringList &connectionItems, const QString &authcfg,
    const QString &dataprovider )
{
  if ( isDisabled() )
    return false;

  QgsAuthMethod *authmethod = configAuthMethod( authcfg );
  if ( authmethod )
  {
    **if ( !( authmethod->supportedExpansions() & QgsAuthMethod::DataSourceUri ) )**
    {
      QgsDebugMsg( QStringLiteral( "Data source URI updating not supported by authcfg: %1" ).arg( authcfg ) );
      return true;
    }

    if ( !authmethod->updateDataSourceUriItems( connectionItems, authcfg, dataprovider.toLower() ) )
    {
      authmethod->clearCachedConfig( authcfg );
      return false;
    }
    return true;
  }

  return false;
}
```