### PR TITLE
QgsProperty is not virtual

### DIFF
--- a/python/core/auto_generated/qgsproperty.sip.in
+++ b/python/core/auto_generated/qgsproperty.sip.in
@@ -200,7 +200,7 @@ QgsProperty objects are implicitly shared and can be inexpensively copied.
 Constructor for a :py:class:`QgsAbstractProperty`. The property will be set to an InvalidProperty type.
 %End
 
-    virtual ~QgsProperty();
+    ~QgsProperty();
 
     static QgsProperty fromExpression( const QString &expression, bool isActive = true );
 %Docstring

--- a/src/core/qgsproperty.h
+++ b/src/core/qgsproperty.h
@@ -246,7 +246,7 @@ class CORE_EXPORT QgsProperty
      */
     QgsProperty();
 
-    virtual ~QgsProperty();
+    ~QgsProperty();
 
     /**
      * Returns a new ExpressionBasedProperty created from the specified expression.


### PR DESCRIPTION
Should allow to remove the vtable for QgsProperty (aka micro optimizing)