### PR TITLE
Remove leftover code

### DIFF
--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -257,13 +257,6 @@ int QgsRasterDataProvider::colorInterpretation( int bandNo ) const
 //Random Static convenience function
 //
 /////////////////////////////////////////////////////////
-// convenience function for building metadata() HTML table cells
-
-QString QgsRasterDataProvider::htmlMetadata()
-{
-  QString s;
-  return s;
-}
 
 // TODO
 // (WMS) IdentifyFormatFeature is not consistent with QgsRaster::IdentifyFormatValue.


### PR DESCRIPTION
Removes unused code, this method is defined as abstract.

https://github.com/qgis/QGIS/blob/master/src/core/raster/qgsrasterdataprovider.h#L345