### PR TITLE
Improve QGIS Server WMS GetCapabilities output for root layer <Title> and <Abstract>

### DIFF
--- a/python/server/auto_generated/qgsserverprojectutils.sip.in
+++ b/python/server/auto_generated/qgsserverprojectutils.sip.in
@@ -36,7 +36,7 @@ Returns the owsService title defined in project.
 
 :param project: the QGIS project
 
-:return: the owsService title if defined in project with project title as fallback, "untitled" otherwise.
+:return: the owsService title if defined in project with project title as fallback, "Untitled" otherwise.
 %End
 
   QString owsServiceAbstract( const QgsProject &project );

--- a/python/server/auto_generated/qgsserverprojectutils.sip.in
+++ b/python/server/auto_generated/qgsserverprojectutils.sip.in
@@ -36,7 +36,7 @@ Returns the owsService title defined in project.
 
 :param project: the QGIS project
 
-:return: the owsService title if defined in project.
+:return: the owsService title if defined in project with project title as fallback, "untitled" otherwise.
 %End
 
   QString owsServiceAbstract( const QgsProject &project );

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -37,22 +37,14 @@ bool QgsServerProjectUtils::owsServiceCapabilities( const QgsProject &project )
 
 QString QgsServerProjectUtils::owsServiceTitle( const QgsProject &project )
 {
-  QString title;
-  QString serviceTitle = project.readEntry( QStringLiteral( "WMSServiceTitle" ), QStringLiteral( "/" ) );
-  if ( !serviceTitle.isEmpty() )
+  QString title = project.readEntry( QStringLiteral( "WMSServiceTitle" ), QStringLiteral( "/" ) );
+  if ( title.isEmpty() )
   {
-    title = serviceTitle;
+    title = project.title();
   }
-  else
+  if ( title.isEmpty() )
   {
-    if ( !project.title().isEmpty() )
-    {
-      title = project.title();
-    }
-    else
-    {
-      title = QStringLiteral( "untitled" );
-    }
+    title = QObject::tr( "Untitled" );
   }
   return title;
 }

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -37,7 +37,24 @@ bool QgsServerProjectUtils::owsServiceCapabilities( const QgsProject &project )
 
 QString QgsServerProjectUtils::owsServiceTitle( const QgsProject &project )
 {
-  return project.readEntry( QStringLiteral( "WMSServiceTitle" ), QStringLiteral( "/" ) );
+  QString title;
+  QString serviceTitle = project.readEntry( QStringLiteral( "WMSServiceTitle" ), QStringLiteral( "/" ) );
+  if ( !serviceTitle.isEmpty() )
+  {
+    title = serviceTitle;
+  }
+  else
+  {
+    if ( !project.title().isEmpty() )
+    {
+      title = project.title();
+    }
+    else
+    {
+      title = QStringLiteral( "untitled" );
+    }
+  }
+  return title;
 }
 
 QString QgsServerProjectUtils::owsServiceAbstract( const QgsProject &project )

--- a/src/server/qgsserverprojectutils.h
+++ b/src/server/qgsserverprojectutils.h
@@ -68,7 +68,7 @@ namespace QgsServerProjectUtils
   /**
    * Returns the owsService title defined in project.
    * \param project the QGIS project
-   * \returns the owsService title if defined in project.
+   * \returns the owsService title if defined in project with project title as fallback, "untitled" otherwise.
    */
   SERVER_EXPORT QString owsServiceTitle( const QgsProject &project );
 

--- a/src/server/qgsserverprojectutils.h
+++ b/src/server/qgsserverprojectutils.h
@@ -68,7 +68,7 @@ namespace QgsServerProjectUtils
   /**
    * Returns the owsService title defined in project.
    * \param project the QGIS project
-   * \returns the owsService title if defined in project with project title as fallback, "untitled" otherwise.
+   * \returns the owsService title if defined in project with project title as fallback, "Untitled" otherwise.
    */
   SERVER_EXPORT QString owsServiceTitle( const QgsProject &project );
 

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -842,7 +842,7 @@ namespace QgsWms
     if ( !rootLayerAbstract.isEmpty() )
     {
       QDomElement layerParentAbstElem = doc.createElement( QStringLiteral( "Abstract" ) );
-      QDomText layerParentAbstText = doc.createTextNode( rootLayerAbstract );
+      QDomText layerParentAbstText = doc.createCDATASection( rootLayerAbstract );
       layerParentAbstElem.appendChild( layerParentAbstText );
       layerParentElem.appendChild( layerParentAbstElem );
     }

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -846,17 +846,34 @@ namespace QgsWms
       layerParentElem.appendChild( layerParentNameElem );
     }
 
-    if ( !project->title().isEmpty() )
+    // Root Layer title
+    QDomText layerParentTitleText;
+    QString rootLayerTitle = QgsServerProjectUtils::owsServiceTitle( *project );
+    QDomElement layerParentTitleElem = doc.createElement( QStringLiteral( "Title" ) );
+    if ( !rootLayerTitle.isEmpty() )
     {
-      // Root Layer title
-      QDomElement layerParentTitleElem = doc.createElement( QStringLiteral( "Title" ) );
-      QDomText layerParentTitleText = doc.createTextNode( project->title() );
-      layerParentTitleElem.appendChild( layerParentTitleText );
-      layerParentElem.appendChild( layerParentTitleElem );
+      layerParentTitleText = doc.createTextNode( rootLayerTitle );
+    }
+    else
+    {
+      if ( !project->title().isEmpty() )
+      {
+        layerParentTitleText = doc.createTextNode( project->title() );
+      }
+      else
+      {
+        layerParentTitleText = doc.createTextNode( QStringLiteral( "untitled" ) );
+      }
+    }
+    layerParentTitleElem.appendChild( layerParentTitleText );
+    layerParentElem.appendChild( layerParentTitleElem );
 
-      // Root Layer abstract
+    // Root Layer abstract
+    QString rootLayerAbstract = QgsServerProjectUtils::owsServiceAbstract( *project );
+    if ( !rootLayerAbstract.isEmpty() )
+    {
       QDomElement layerParentAbstElem = doc.createElement( QStringLiteral( "Abstract" ) );
-      QDomText layerParentAbstText = doc.createTextNode( project->title() );
+      QDomText layerParentAbstText = doc.createTextNode( rootLayerAbstract );
       layerParentAbstElem.appendChild( layerParentAbstText );
       layerParentElem.appendChild( layerParentAbstElem );
     }

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -266,24 +266,9 @@ namespace QgsWms
     nameElem.appendChild( nameText );
     serviceElem.appendChild( nameElem );
 
-    QDomText titleText;
-    QString title = QgsServerProjectUtils::owsServiceTitle( *project );
+    // Service title
     QDomElement titleElem = doc.createElement( QStringLiteral( "Title" ) );
-    if ( !title.isEmpty() )
-    {
-      titleText = doc.createTextNode( title );
-    }
-    else
-    {
-      if ( !project->title().isEmpty() )
-      {
-        titleText = doc.createTextNode( project->title() );
-      }
-      else
-      {
-        titleText = doc.createTextNode( QStringLiteral( "untitled" ) );
-      }
-    }
+    QDomText titleText = doc.createTextNode( QgsServerProjectUtils::owsServiceTitle( *project ) );
     titleElem.appendChild( titleText );
     serviceElem.appendChild( titleElem );
 
@@ -847,24 +832,8 @@ namespace QgsWms
     }
 
     // Root Layer title
-    QDomText layerParentTitleText;
-    QString rootLayerTitle = QgsServerProjectUtils::owsServiceTitle( *project );
     QDomElement layerParentTitleElem = doc.createElement( QStringLiteral( "Title" ) );
-    if ( !rootLayerTitle.isEmpty() )
-    {
-      layerParentTitleText = doc.createTextNode( rootLayerTitle );
-    }
-    else
-    {
-      if ( !project->title().isEmpty() )
-      {
-        layerParentTitleText = doc.createTextNode( project->title() );
-      }
-      else
-      {
-        layerParentTitleText = doc.createTextNode( QStringLiteral( "untitled" ) );
-      }
-    }
+    QDomText layerParentTitleText = doc.createTextNode( QgsServerProjectUtils::owsServiceTitle( *project ) );
     layerParentTitleElem.appendChild( layerParentTitleText );
     layerParentElem.appendChild( layerParentTitleElem );
 
@@ -2066,6 +2035,3 @@ namespace QgsWms
 
 
 } // namespace QgsWms
-
-
-

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -838,7 +838,7 @@ namespace QgsWms
     layerParentElem.appendChild( layerParentTitleElem );
 
     // Root Layer abstract
-    QString rootLayerAbstract = QgsServerProjectUtils::owsServiceAbstract( *project );
+    const QString rootLayerAbstract = QgsServerProjectUtils::owsServiceAbstract( *project );
     if ( !rootLayerAbstract.isEmpty() )
     {
       QDomElement layerParentAbstElem = doc.createElement( QStringLiteral( "Abstract" ) );

--- a/tests/testdata/qgis_server/getcapabilities.txt
+++ b/tests/testdata/qgis_server/getcapabilities.txt
@@ -104,7 +104,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer queryable="1">
    <Name>QGIS Test Project</Name>
    <Title>QGIS TestProject</Title>
-   <Abstract>QGIS Test Project</Abstract>
+   <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/getcapabilities.txt
+++ b/tests/testdata/qgis_server/getcapabilities.txt
@@ -104,7 +104,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer queryable="1">
    <Name>QGIS Test Project</Name>
    <Title>QGIS TestProject</Title>
-   <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
+   <Abstract>Some UTF8 text èòù</Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/getcapabilities.txt
+++ b/tests/testdata/qgis_server/getcapabilities.txt
@@ -104,7 +104,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer queryable="1">
    <Name>QGIS Test Project</Name>
    <Title>QGIS TestProject</Title>
-   <Abstract>Some UTF8 text èòù</Abstract>
+   <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/getcapabilities.txt
+++ b/tests/testdata/qgis_server/getcapabilities.txt
@@ -103,7 +103,7 @@ Content-Type: text/xml; charset=utf-8
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <Layer queryable="1">
    <Name>QGIS Test Project</Name>
-   <Title>QGIS Test Project</Title>
+   <Title>QGIS TestProject</Title>
    <Abstract>QGIS Test Project</Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>

--- a/tests/testdata/qgis_server/getcapabilities_inspire.txt
+++ b/tests/testdata/qgis_server/getcapabilities_inspire.txt
@@ -125,7 +125,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer queryable="1">
    <Name>QGIS Test Project</Name>
    <Title>QGIS TestProject</Title>
-   <Abstract>Some UTF8 text èòù</Abstract>
+   <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/getcapabilities_inspire.txt
+++ b/tests/testdata/qgis_server/getcapabilities_inspire.txt
@@ -124,7 +124,7 @@ Content-Type: text/xml; charset=utf-8
   </inspire_vs:ExtendedCapabilities>
   <Layer queryable="1">
    <Name>QGIS Test Project</Name>
-   <Title>QGIS Test Project</Title>
+   <Title>QGIS TestProject</Title>
    <Abstract>QGIS Test Project</Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>

--- a/tests/testdata/qgis_server/getcapabilities_inspire.txt
+++ b/tests/testdata/qgis_server/getcapabilities_inspire.txt
@@ -125,7 +125,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer queryable="1">
    <Name>QGIS Test Project</Name>
    <Title>QGIS TestProject</Title>
-   <Abstract>QGIS Test Project</Abstract>
+   <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/getcapabilities_inspire.txt
+++ b/tests/testdata/qgis_server/getcapabilities_inspire.txt
@@ -125,7 +125,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer queryable="1">
    <Name>QGIS Test Project</Name>
    <Title>QGIS TestProject</Title>
-   <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
+   <Abstract>Some UTF8 text èòù</Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -124,7 +124,7 @@ Content-Type: text/xml; charset=utf-8
   </WFSLayers>
   <Layer>
    <Name>QGIS Test Project</Name>
-   <Title>QGIS Test Project</Title>
+   <Title>QGIS TestProject</Title>
    <Abstract>QGIS Test Project</Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -125,7 +125,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer>
    <Name>QGIS Test Project</Name>
    <Title>QGIS TestProject</Title>
-   <Abstract>Some UTF8 text èòù</Abstract>
+   <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -125,7 +125,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer>
    <Name>QGIS Test Project</Name>
    <Title>QGIS TestProject</Title>
-   <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
+   <Abstract>Some UTF8 text èòù</Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -125,7 +125,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer>
    <Name>QGIS Test Project</Name>
    <Title>QGIS TestProject</Title>
-   <Abstract>QGIS Test Project</Abstract>
+   <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/getprojectsettings_opacity.txt
+++ b/tests/testdata/qgis_server/getprojectsettings_opacity.txt
@@ -124,7 +124,7 @@ Content-Type: text/xml; charset=utf-8
   </WFSLayers>
   <Layer>
    <Name>QGIS Test Project</Name>
-   <Title>QGIS Test Project</Title>
+   <Title>QGIS TestProject</Title>
    <Abstract>QGIS Test Project</Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>

--- a/tests/testdata/qgis_server/getprojectsettings_opacity.txt
+++ b/tests/testdata/qgis_server/getprojectsettings_opacity.txt
@@ -125,7 +125,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer>
    <Name>QGIS Test Project</Name>
    <Title>QGIS TestProject</Title>
-   <Abstract>Some UTF8 text èòù</Abstract>
+   <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/getprojectsettings_opacity.txt
+++ b/tests/testdata/qgis_server/getprojectsettings_opacity.txt
@@ -125,7 +125,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer>
    <Name>QGIS Test Project</Name>
    <Title>QGIS TestProject</Title>
-   <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
+   <Abstract>Some UTF8 text èòù</Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/getprojectsettings_opacity.txt
+++ b/tests/testdata/qgis_server/getprojectsettings_opacity.txt
@@ -125,7 +125,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer>
    <Name>QGIS Test Project</Name>
    <Title>QGIS TestProject</Title>
-   <Abstract>QGIS Test Project</Abstract>
+   <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/landingpage/test_landing_page_index.json
+++ b/tests/testdata/qgis_server/landingpage/test_landing_page_index.json
@@ -262,7 +262,7 @@ Content-Type: application/json
         "owsServiceFees": "conditions unknown",
         "owsServiceKeywords": [],
         "owsServiceOnlineResource": "",
-        "owsServiceTitle": "",
+        "owsServiceTitle": "QGIS Server - Grouped Nested Layer",
         "wcsLayerIds": [],
         "wcsServiceUrl": "",
         "wfsLayerIds": [

--- a/tests/testdata/qgis_server/landingpage/test_landing_page_with_pg_index.json
+++ b/tests/testdata/qgis_server/landingpage/test_landing_page_with_pg_index.json
@@ -29,7 +29,7 @@ Content-Type: application/json
         "owsServiceFees": "conditions unknown",
         "owsServiceKeywords": [],
         "owsServiceOnlineResource": "",
-        "owsServiceTitle": "",
+        "owsServiceTitle": "QGIS Server - Grouped Nested Layer",
         "wcsLayerIds": [],
         "wcsServiceUrl": "",
         "wfsLayerIds": [

--- a/tests/testdata/qgis_server/landingpage/test_project_QGIS_Server_-_Grouped_Nested_Layer.json
+++ b/tests/testdata/qgis_server/landingpage/test_project_QGIS_Server_-_Grouped_Nested_Layer.json
@@ -15,7 +15,7 @@ Content-Type: application/json
       "owsServiceFees": "conditions unknown",
       "owsServiceKeywords": [],
       "owsServiceOnlineResource": "",
-      "owsServiceTitle": "",
+      "owsServiceTitle": "QGIS Server - Grouped Nested Layer",
       "wcsLayerIds": [],
       "wcsServiceUrl": "",
       "wfsLayerIds": [

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_1_1.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_1_1.txt
@@ -103,8 +103,8 @@ Content-Type: text/xml; charset=utf-8
   </Exception>
   <Layer queryable="1">
    <Name>QGIS Test Project</Name>
-   <Title>QGIS Test Project</Title>
-   <Abstract>QGIS Test Project</Abstract>
+   <Title>QGIS TestProject</Title>
+   <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
@@ -104,7 +104,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer queryable="1">
    <Name>QGIS Test Project</Name>
    <Title>QGIS TestProject</Title>
-   <Abstract>QGIS Test Project</Abstract>
+   <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
@@ -104,7 +104,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer queryable="1">
    <Name>QGIS Test Project</Name>
    <Title>QGIS TestProject</Title>
-   <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
+   <Abstract>Some UTF8 text èòù</Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
@@ -104,7 +104,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer queryable="1">
    <Name>QGIS Test Project</Name>
    <Title>QGIS TestProject</Title>
-   <Abstract>Some UTF8 text èòù</Abstract>
+   <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
@@ -103,7 +103,7 @@ Content-Type: text/xml; charset=utf-8
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <Layer queryable="1">
    <Name>QGIS Test Project</Name>
-   <Title>QGIS Test Project</Title>
+   <Title>QGIS TestProject</Title>
    <Abstract>QGIS Test Project</Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>

--- a/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
@@ -94,6 +94,7 @@ Content-Type: text/xml; charset=utf-8
   </Exception>
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <Layer queryable="1">
+   <Title>untitled</Title>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
@@ -5,7 +5,7 @@ Content-Type: text/xml; charset=utf-8
 <WMS_Capabilities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:qgs="http://www.qgis.org/wms" xmlns="http://www.opengis.net/wms" xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd http://www.qgis.org/wms https://www.qgis.org/?SERVICE=WMS&amp;REQUEST=GetSchemaExtension" version="1.3.0" xmlns:sld="http://www.opengis.net/sld">
  <Service>
   <Name>WMS</Name>
-  <Title>untitled</Title>
+  <Title>Untitled</Title>
   <KeywordList>
    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
   </KeywordList>
@@ -94,7 +94,7 @@ Content-Type: text/xml; charset=utf-8
   </Exception>
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <Layer queryable="1">
-   <Title>untitled</Title>
+   <Title>Untitled</Title>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/wms_getcapabilities_empty_spatial_layer.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_empty_spatial_layer.txt
@@ -5,7 +5,7 @@ Content-Type: text/xml; charset=utf-8
 <WMS_Capabilities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:qgs="http://www.qgis.org/wms" xmlns="http://www.opengis.net/wms" xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd http://www.qgis.org/wms https://www.qgis.org/?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_empty_spatial_layer.qgz&amp;SERVICE=WMS&amp;REQUEST=GetSchemaExtension" version="1.3.0" xmlns:sld="http://www.opengis.net/sld">
  <Service>
   <Name>WMS</Name>
-  <Title>untitled</Title>
+  <Title>Untitled</Title>
   <KeywordList>
    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
   </KeywordList>
@@ -94,7 +94,7 @@ Content-Type: text/xml; charset=utf-8
   </Exception>
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <Layer queryable="1">
-   <Title>untitled</Title>
+   <Title>Untitled</Title>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/wms_getcapabilities_empty_spatial_layer.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_empty_spatial_layer.txt
@@ -94,6 +94,7 @@ Content-Type: text/xml; charset=utf-8
   </Exception>
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <Layer queryable="1">
+   <Title>untitled</Title>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/wms_getcapabilities_without_title.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_without_title.txt
@@ -96,6 +96,7 @@ Content-Type: text/xml; charset=utf-8
   </Exception>
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <Layer queryable="1">
+   <Title>untitled</Title>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server/wms_getcapabilities_without_title.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_without_title.txt
@@ -5,7 +5,7 @@ Content-Type: text/xml; charset=utf-8
 <WMS_Capabilities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:qgs="http://www.qgis.org/wms" xmlns="http://www.opengis.net/wms" xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd http://www.qgis.org/wms https://www.qgis.org/?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_without_title.qgs&amp;SERVICE=WMS&amp;REQUEST=GetSchemaExtension" version="1.3.0" xmlns:sld="http://www.opengis.net/sld">
  <Service>
   <Name>WMS</Name>
-  <Title>untitled</Title>
+  <Title>Untitled</Title>
   <KeywordList>
    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
   </KeywordList>
@@ -96,7 +96,7 @@ Content-Type: text/xml; charset=utf-8
   </Exception>
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <Layer queryable="1">
-   <Title>untitled</Title>
+   <Title>Untitled</Title>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
+++ b/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
@@ -105,7 +105,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer queryable="1">
    <Name>QGIS Server WMS Dimensions</Name>
    <Title>QGIS Server WMS Dimension test</Title>
-   <Abstract>QGIS Server WMS Dimensions</Abstract>
+   <Abstract><![CDATA[Simple test app for WMS dimension]]></Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
+++ b/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
@@ -105,7 +105,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer queryable="1">
    <Name>QGIS Server WMS Dimensions</Name>
    <Title>QGIS Server WMS Dimension test</Title>
-   <Abstract>Simple test app for WMS dimension</Abstract>
+   <Abstract><![CDATA[Simple test app for WMS dimension]]></Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>

--- a/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
+++ b/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
@@ -104,7 +104,7 @@ Content-Type: text/xml; charset=utf-8
   <sld:UserDefinedSymbolization UserStyle="1" RemoteWFS="0" RemoteWCS="0" InlineFeature="0" UserLayer="0" SupportSLD="1"/>
   <Layer queryable="1">
    <Name>QGIS Server WMS Dimensions</Name>
-   <Title>QGIS Server WMS Dimensions</Title>
+   <Title>QGIS Server WMS Dimension test</Title>
    <Abstract>QGIS Server WMS Dimensions</Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>

--- a/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
+++ b/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
@@ -105,7 +105,7 @@ Content-Type: text/xml; charset=utf-8
   <Layer queryable="1">
    <Name>QGIS Server WMS Dimensions</Name>
    <Title>QGIS Server WMS Dimension test</Title>
-   <Abstract><![CDATA[Simple test app for WMS dimension]]></Abstract>
+   <Abstract>Simple test app for WMS dimension</Abstract>
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>


### PR DESCRIPTION
## Description

This PR improves the QGIS Server WMS GetCapabilities output for root layer `<Title>` and `<Abstract>`.

Fixes #40736

Before, if available, the project title was used for root layer `<Title>` and also `<Abstract>`. If there was no project title available, both elements were missing for the WMS GetCapabilities output. The result were blank fields in QGIS Desktop browser and "add WMS layer" dialogue (#40736). Also it was not possible to set an abstract different than the project title. If I understood it correct, a missing  `<Title>` for the root layer is also a violation of the OGC WMS spec.

Title and abstract from _Service Capabilities_ are preferred over _Project title_, because the assumption is that a user would expect to configure the GetCapabilities output from _Service Capabilities_ (as it's already the case for root layer `<Name>` with _Short name_) and not from the _General_ tab in project properties.
 
This PR implements the following logic:

**root layer `<Title>`**
If _Project → Properties → QGIS Server → Service Capabilities → Title_ is available, it is used for root layer `<Title>`. 
If it's not available, we use the project's title (_Project → Properties → General → Project title_).
Only if project's title is also not set, we use `<Title>untitled</Title>`.


**root layer `<Abstract>`**
If _Project → Properties → QGIS Server → Service Capabilities → Abstract_ is available, it is used for root layer `<Abstract>`. 
If it's not available, `<Abstract>` for the root layer is not included in the GetCapabilities output (according to the WMS spec `<Abstract>` is optional).







<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
