### PR TITLE
Add static Null Crs for default constructed CRS

### DIFF
--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -111,7 +111,9 @@ QString getFullProjString( PJ *obj )
 
 QgsCoordinateReferenceSystem::QgsCoordinateReferenceSystem()
 {
-  d = new QgsCoordinateReferenceSystemPrivate();
+  static QgsCoordinateReferenceSystem nullCrs = QgsCoordinateReferenceSystem( QString() );
+
+  d = nullCrs.d;
 }
 
 QgsCoordinateReferenceSystem::QgsCoordinateReferenceSystem( const QString &definition )


### PR DESCRIPTION
Considerably improves performance regarding default constructed crs, which is often constructed for throwaway reasons.

E.g.

```
variant.value<QgsCoordinateReferenceSystem>();
```

Gives a couple of percent of performance improvements for rendering with expressions.

Supersedes https://github.com/qgis/QGIS/pull/40749