### PR TITLE
Safety check for expression initialized

### DIFF
--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -133,13 +133,13 @@ QVariant QgsGraduatedSymbolRenderer::valueForFeature( const QgsFeature &feature,
 {
   QgsAttributes attrs = feature.attributes();
   QVariant value;
-  if ( mAttrNum < 0 || mAttrNum >= attrs.count() )
+  if ( mExpression )
   {
     value = mExpression->evaluate( &context.expressionContext() );
   }
   else
   {
-    value = attrs.at( mAttrNum );
+    value = attrs.value( mAttrNum );
   }
 
   return value;


### PR DESCRIPTION
It's pretty much the only explanation for a stack trace like in #40762. I cannot find a way to reproduce, but a crash is bad, so here's a fix to avoid the crash. This doesn't lead to a useful map tip (reference to map tip here because that's what triggered the crash in #40762).

