### PR TITLE
Add backported label after a successful backport

### DIFF
--- a/.github/label-backported.yml
+++ b/.github/label-backported.yml
@@ -1,0 +1,2 @@
+backported:
+  - '**'

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,6 +11,7 @@ jobs:
     name: Backport
     steps:
       - name: Backport Bot
+        id: backport
         if: github.event.pull_request.merged && ( ( github.event.action == 'closed' && contains( join( github.event.pull_request.labels.*.name ), 'backport') ) || contains( github.event.label.name, 'backport' ) )
         uses: Gaurav0/backport@v1.0.26
         with:
@@ -18,3 +19,10 @@ jobs:
           bot_token: ddbdec32940df79f1adf2369b4b10f10b5a66f65
           bot_token_key: a1b2c3d47311f8e29e204f85a81b4df4a44e252c
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Backported Label
+        if: steps.backport.conclution == 'success'
+        uses: actions/labeler@main
+        with:
+          configuration-path: .github/label-backported.yml
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,7 +21,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Backported Label
-        if: steps.backport.conclution == 'success'
+        if: steps.backport.conclusion == 'success'
         uses: actions/labeler@main
         with:
           configuration-path: .github/label-backported.yml


### PR DESCRIPTION
Add "backported" label after a successful backport operation

:crossed_fingers: 