### PR TITLE
[processing]field calculator : allow creating field already present (…

### DIFF
--- a/src/analysis/processing/qgsalgorithmfieldcalculator.cpp
+++ b/src/analysis/processing/qgsalgorithmfieldcalculator.cpp
@@ -139,7 +139,7 @@ bool QgsFieldCalculatorAlgorithm::prepareAlgorithm( const QVariantMap &parameter
   }
   else
   {
-   feedback->pushWarning( QObject::tr( "Field name %1 already exists and will be replaced" ).arg( field.name() ) );
+    feedback->pushWarning( QObject::tr( "Field name %1 already exists and will be replaced" ).arg( field.name() ) );
   }
 
   QString dest;
@@ -211,4 +211,3 @@ bool QgsFieldCalculatorAlgorithm::supportInPlaceEdit( const QgsMapLayer *layer )
 }
 
 ///@endcond
-

--- a/src/analysis/processing/qgsalgorithmfieldcalculator.cpp
+++ b/src/analysis/processing/qgsalgorithmfieldcalculator.cpp
@@ -101,7 +101,7 @@ QgsFieldCalculatorAlgorithm *QgsFieldCalculatorAlgorithm::createInstance() const
 }
 
 
-bool QgsFieldCalculatorAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+bool QgsFieldCalculatorAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   std::unique_ptr< QgsProcessingFeatureSource > source( parameterAsSource( parameters, QStringLiteral( "INPUT" ), context ) );
 
@@ -131,10 +131,16 @@ bool QgsFieldCalculatorAlgorithm::prepareAlgorithm( const QVariantMap &parameter
 
   mFields = source->fields();
 
-  int fieldIdx = mFields.lookupField( field.name() );
+  int fieldIdx = mFields.indexFromName( field.name() );
 
   if ( fieldIdx < 0 )
+  {
     mFields.append( field );
+  }
+  else
+  {
+   feedback->pushWarning( QObject::tr( "Field name %1 already exists and will be replaced" ).arg( field.name() ) );
+  }
 
   QString dest;
 


### PR DESCRIPTION
…case insensitive equal)

## Description

For the moment, the field calculator does not allow creating a field which is the same (case insensitivity speaking) as an other already present .


## Why

For now, this algorithm uses `lookupField`   and regarding the documentation,
this method matches in the following order:

1. The exact field name taking case sensitivity into account
2. Looks for the field name by case insensitive comparison
3. The field alias (case insensitive)

## Proposed solution

Using the method `indexFromName` which is more precise than `lookupField`
I also added a  message to warn the user when he tries to add an existing field but maybe it's not necessary.

## Fix

#40701 