### PR TITLE
[processing] extract_by_location fix duplicate rows when mutiple pred…

### DIFF
--- a/src/analysis/processing/qgsalgorithmextractbylocation.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbylocation.cpp
@@ -1,4 +1,4 @@
-    /***************************************************************************
+/***************************************************************************
                          qgsalgorithmextractbylocation.cpp
                          ---------------------
     begin                : April 2017
@@ -312,10 +312,10 @@ void QgsLocationBasedAlgorithm::processByIteratingOverIntersectSource( const Qgs
             break;
         }
         if ( isMatch )
-            break;
+          break;
       }
 
-      if ( isMatch  )
+      if ( isMatch )
       {
         foundSet.insert( testFeature.id() );
         handleFeatureFunction( testFeature );
@@ -517,6 +517,5 @@ QVariantMap QgsExtractByLocationAlgorithm::processAlgorithm( const QVariantMap &
 }
 
 ///@endcond
-
 
 

--- a/src/analysis/processing/qgsalgorithmextractbylocation.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbylocation.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+    /***************************************************************************
                          qgsalgorithmextractbylocation.cpp
                          ---------------------
     begin                : April 2017
@@ -277,9 +277,10 @@ void QgsLocationBasedAlgorithm::processByIteratingOverIntersectSource( const Qgs
         engine->prepareGeometry();
       }
 
+      bool isMatch = false;
+
       for ( Predicate predicate : qgis::as_const( predicates ) )
       {
-        bool isMatch = false;
         switch ( predicate )
         {
           case Intersects:
@@ -311,10 +312,13 @@ void QgsLocationBasedAlgorithm::processByIteratingOverIntersectSource( const Qgs
             break;
         }
         if ( isMatch )
-        {
-          foundSet.insert( testFeature.id() );
-          handleFeatureFunction( testFeature );
-        }
+            break;
+      }
+
+      if ( isMatch  )
+      {
+        foundSet.insert( testFeature.id() );
+        handleFeatureFunction( testFeature );
       }
 
     }


### PR DESCRIPTION
…icate are chosen

## Description

Bug described here : #32653

## Note
I think it should solve the problem because it uses the same logic from `processByIteratingOverTargetSource` ( line 188)
Seems to work with the sample data provided with the issue


