### PR TITLE
[MetaSearch] Disable buttons after inspecting CSW in server tab in order to fix a Python error and also reset the bbox rubber band when needed

### DIFF
--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -554,6 +554,8 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
         # disable only service buttons
         self.reset_buttons(True, False, False)
 
+        self.rubber_band.reset()
+
         if not self.treeRecords.selectedItems():
             return
 

--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -285,7 +285,7 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
             self.textMetadata.document().setDefaultStyleSheet(style)
             self.textMetadata.setHtml(metadata)
 
-            # clear results in Search tab
+            # clear results and disable buttons in Search tab
             self.clear_results()
 
     def add_connection(self):
@@ -433,10 +433,7 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
         self.constraints = []
 
         # clear all fields and disable buttons
-        self.lblResults.clear()
-        self.treeRecords.clear()
-
-        self.reset_buttons()
+        self.clear_results()
 
         # save some settings
         self.settings.setValue('/MetaSearch/returnRecords',
@@ -547,7 +544,9 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
     def clear_results(self):
         """clear search results"""
 
+        self.lblResults.clear()
         self.treeRecords.clear()
+        self.reset_buttons()
 
     def record_clicked(self):
         """record clicked signal"""


### PR DESCRIPTION
## Description

Fixes a Python error, similar to https://github.com/qgis/QGIS/issues/37748 (already fixed by https://github.com/qgis/QGIS/pull/37779), that occurs when a navigation button in the Search tab is pressed after a "Service info" request is performed in the "Services" tab:
```
An error has occurred while executing Python code: 

AttributeError: 'CatalogueServiceWeb' object has no attribute 'results' 
Traceback (most recent call last):
  File "C:/PROGRA~1/QGIS31~1.2/apps/qgis/./python/plugins\MetaSearch\dialogs\maindialog.py", line 659, in navigate
    if self.startfrom >= self.catalog.results["matches"]:
AttributeError: 'CatalogueServiceWeb' object has no attribute 'results'
```

and also avoids to display an incorrect result info after the treeRecords is cleared:

![image](https://user-images.githubusercontent.com/16253859/103469036-06ba3d80-4d60-11eb-8cb5-c486eb2795d9.png)


It also fixes a bug in the records bbox display: the bbox ribbon band is not properly cleared passing from a record with a bbox to a record without a bbox.

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
