### PR TITLE
[MetaSearch] Fix navigation through the results pages

### DIFF
--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -98,7 +98,7 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
         self.rubber_band.setWidth(5)
 
         # form inputs
-        self.startfrom = 0
+        self.startfrom = 1
         self.maxrecords = 10
         self.timeout = 10
         self.disable_ssl_verification = False
@@ -450,7 +450,7 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
         self.catalog_password = self.settings.value('%s/password' % key)
 
         # start position and number of records to return
-        self.startfrom = 0
+        self.startfrom = 1
         self.maxrecords = self.spnRecords.value()
 
         # set timeout
@@ -511,10 +511,10 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
 
         self.treeRecords.clear()
 
-        position = self.catalog.results['returned'] + self.startfrom
+        position = self.catalog.results['returned'] + self.startfrom - 1
 
         msg = self.tr('Showing {0} - {1} of %n result(s)', 'number of results',
-                      self.catalog.results['matches']).format(self.startfrom + 1,
+                      self.catalog.results['matches']).format(self.startfrom,
                                                               position)
 
         self.lblResults.setText(msg)
@@ -651,24 +651,24 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
         caller = self.sender().objectName()
 
         if caller == 'btnFirst':
-            self.startfrom = 0
+            self.startfrom = 1
         elif caller == 'btnLast':
-            self.startfrom = self.catalog.results['matches'] - self.maxrecords
+            self.startfrom = self.catalog.results['matches'] - self.maxrecords + 1
         elif caller == 'btnNext':
-            self.startfrom += self.maxrecords
-            if self.startfrom >= self.catalog.results["matches"]:
+            if self.startfrom > self.catalog.results["matches"] - self.maxrecords:
                 msg = self.tr('End of results. Go to start?')
                 res = QMessageBox.information(self, self.tr('Navigation'),
                                               msg,
                                               (QMessageBox.Ok |
                                                QMessageBox.Cancel))
                 if res == QMessageBox.Ok:
-                    self.startfrom = 0
+                    self.startfrom = 1
                 else:
                     return
+            else:
+                self.startfrom += self.maxrecords
         elif caller == "btnPrev":
-            self.startfrom -= self.maxrecords
-            if self.startfrom <= 0:
+            if self.startfrom == 1:
                 msg = self.tr('Start of results. Go to end?')
                 res = QMessageBox.information(self, self.tr('Navigation'),
                                               msg,
@@ -676,9 +676,13 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
                                                QMessageBox.Cancel))
                 if res == QMessageBox.Ok:
                     self.startfrom = (self.catalog.results['matches'] -
-                                      self.maxrecords)
+                                      self.maxrecords + 1)
                 else:
                     return
+            elif self.startfrom <= self.maxrecords:
+                self.startfrom = 1
+            else:
+                self.startfrom -= self.maxrecords
 
         try:
             with OverrideCursor(Qt.WaitCursor):


### PR DESCRIPTION
## Description

Fixes some weird behaviours when navigating through the results pages due to using a 0-based instead of 1-based startposition parameter in the getrecords request and some missing cases in the navigation logic.

before:
![103475803-c1722c00-4db0-11eb-9a10-f5b1595156db](https://user-images.githubusercontent.com/16253859/103477820-97296a00-4dc2-11eb-9f38-c9087c1bb50e.gif)

after:
![Video_2021-01-03_113626](https://user-images.githubusercontent.com/16253859/103478242-731b5800-4dc5-11eb-928f-0a9966ed159f.gif)


<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
