### PR TITLE
Fixes an (unreported?) issue with invalid MSSQL data items

### DIFF
--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -136,6 +136,7 @@ QVector<QgsDataItem *> QgsMssqlConnectionItem::createChildren()
   if ( !QgsMssqlConnection::openDatabase( db ) )
   {
     children.append( new QgsErrorItem( this, db.lastError().text(), mPath + "/error" ) );
+    setAsPopulated();
     return children;
   }
 


### PR DESCRIPTION
The issue was triggered when refreshing the browser with an
invalid MSSQL connection, the Populated state was never set
and the spinning icon was shown forever.
