### PR TITLE
fix mssql iterator

### DIFF
--- a/src/core/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/qgsabstractdatabaseproviderconnection.cpp
@@ -445,7 +445,7 @@ QList<QList<QVariant> > QgsAbstractDatabaseProviderConnection::QueryResult::rows
   // mRowCount might be -1 (unknown)
   while ( mResultIterator && ( mRowCount < 0 || mRows.count() < mRowCount ) )
   {
-    const QVariantList row { mResultIterator->nextRow() };
+    const QVariantList row( mResultIterator->nextRow() );
     if ( row.isEmpty() )
     {
       break;
@@ -462,7 +462,7 @@ QList<QVariant> QgsAbstractDatabaseProviderConnection::QueryResult::nextRow()
     return QList<QVariant>();
   }
 
-  const QList<QVariant> row { mResultIterator->nextRow() };
+  const QList<QVariant> row( mResultIterator->nextRow() );
 
   if ( ! row.isEmpty() )
   {

--- a/src/providers/mssql/qgsmssqlproviderconnection.cpp
+++ b/src/providers/mssql/qgsmssqlproviderconnection.cpp
@@ -280,7 +280,7 @@ QgsAbstractDatabaseProviderConnection::QueryResult QgsMssqlProviderConnection::e
 
 QVariantList QgssMssqlProviderResultIterator::nextRow()
 {
-  const QVariantList currentRow { mNextRow };
+  const QVariantList currentRow( mNextRow );
   mNextRow = nextRowPrivate();
   return currentRow;
 }


### PR DESCRIPTION
Initialization of QVariantList with brace with an QVariantList creates a list with one empty QVariantList instead of an empty list.
That leads to an issue with MSSQL
fix https://github.com/qgis/QGIS/issues/40836

@elpaso 