### PR TITLE
Untwine: calculate stats for attributes

### DIFF
--- a/external/untwine/bu/BuPyramid.cpp
+++ b/external/untwine/bu/BuPyramid.cpp
@@ -29,6 +29,7 @@ void BuPyramid::run(const Options& options, ProgressWriter& progress)
 {
     m_b.inputDir = options.tempDir;
     m_b.outputDir = options.outputDir;
+    m_b.stats = options.stats;
 
     readBaseInfo();
     getInputFiles();
@@ -164,7 +165,31 @@ void BuPyramid::writeInfo()
             out << "\"type\": \"" << typeString(pdal::Dimension::base(fdi.type)) << "\", ";
             if (fdi.name == "X" || fdi.name == "Y" || fdi.name == "Z")
                 out << "\"scale\": 0.01, \"offset\": 0, ";
-            out << "\"size\": " << pdal::Dimension::size(fdi.type) << " ";
+            out << "\"size\": " << pdal::Dimension::size(fdi.type);
+            const Stats *stats = m_manager.stats(fdi.name);
+            if (stats)
+            {
+                const Stats::EnumMap& v = stats->values();
+                out << ", ";
+                if (v.size())
+                {
+                    out << "\"counts\": [ ";
+                    for (auto ci = v.begin(); ci != v.end(); ++ci)
+                    {
+                        auto c = *ci;
+                        if (ci != v.begin())
+                            out << ", ";
+                        out << "{\"value\": " << c.first << ", \"count\": " << c.second << "}";
+                    }
+                    out << "], ";
+                }
+                out << "\"count\": " << m_manager.totalPoints() << ", ";
+                out << "\"maximum\": " << stats->maximum() << ", ";
+                out << "\"minimum\": " << stats->minimum() << ", ";
+                out << "\"mean\": " << stats->average() << ", ";
+                out << "\"stddev\": " << stats->stddev() << ", ";
+                out << "\"variance\": " << stats->variance();
+            }
         out << "}";
         if (di + 1 != m_b.dimInfo.end())
             out << ",";

--- a/external/untwine/bu/BuTypes.hpp
+++ b/external/untwine/bu/BuTypes.hpp
@@ -35,6 +35,7 @@ struct BaseInfo
     int maxLevel;
     DimInfoList dimInfo;
     pdal::SpatialReference srs;
+    bool stats;
 };
 
 } // namespace bu

--- a/external/untwine/bu/Processor.cpp
+++ b/external/untwine/bu/Processor.cpp
@@ -124,7 +124,7 @@ std::cerr << m_vi.key() << " Accepted/Rejected/num points = " <<
 **/
 
     // If this is the final key, append any remaining file infos as accepted points and
-    // write the accepted points as binary.
+    // write the accepted points as compressed.
     if (m_vi.key() == VoxelKey(0, 0, 0, 0))
     {
         appendRemainder(accepted);
@@ -136,7 +136,7 @@ std::cerr << m_vi.key() << " Accepted/Rejected/num points = " <<
 }
 
 
-bool Processor::acceptable(int /* pointId */, GridKey key)
+bool Processor::acceptable(int pointId, GridKey key)
 {
     VoxelInfo::Grid& grid = m_vi.grid();
 
@@ -258,6 +258,9 @@ void Processor::writeCompressedOutput(Index& index)
     std::sort(index.begin(), index.end());
 
     IndexIter pos = index.begin();
+
+    // If any of our octants has points, we have to write the parent octant, whether or not
+    // it contains points, in order to create a full tree.
     for (int octant = 0; octant < 8; ++octant)
         if (m_vi[octant].hasPoints() || m_vi[octant].mustWrite())
         {
@@ -267,26 +270,47 @@ void Processor::writeCompressedOutput(Index& index)
 }
 
 
+// o        Octant we're writing.
+// index    Index of all rejected points that were rejected and not hoisted into the parent.
+// pos      Start position of this octant's point in the index.
+// \return  Position of the first point in the next octant of our index.
 Processor::IndexIter
 Processor::writeOctantCompressed(const OctantInfo& o, Index& index, IndexIter pos)
 {
     auto begin = pos;
     pdal::PointTable table;
+    IndexedStats stats;
+
     //ABELL - fixme
     // For now we copy the dimension list so we're sure that it matches the layout, though
     // there's no reason why it should change. We should modify things to use a single
     // layout.
     DimInfoList dims = m_b.dimInfo;
     for (FileDimInfo& fdi : dims)
+    {
         fdi.dim = table.layout()->registerOrAssignDim(fdi.name, fdi.type);
+        if (m_b.stats)
+        {
+            if (fdi.dim == pdal::Dimension::Id::Classification)
+                stats.push_back({fdi.dim, Stats(fdi.name, Stats::EnumType::Enumerate, false)});
+            else
+                stats.push_back({fdi.dim, Stats(fdi.name, Stats::EnumType::NoEnum, false)});
+        }
+    }
     table.finalize();
+
     pdal::PointViewPtr view(new pdal::PointView(table));
 
+    // The octant's points can came from one or more FileInfo.  The points are sorted such
+    // all the points that come from a single FileInfo are consecutive.
     auto fii = o.fileInfos().begin();
     auto fiiEnd = o.fileInfos().end();
     size_t count = 0;
     if (fii != fiiEnd)
     {
+        // We're trying to find the range of points that come from a single FileInfo.
+        // If pos is the end of the index of the the current file info, append the points
+        // to the view.  Otherwise, advance the position.
         while (true)
         {
             if (pos == index.end() || *pos >= fii->start() + fii->numPoints())
@@ -296,6 +320,9 @@ Processor::writeOctantCompressed(const OctantInfo& o, Index& index, IndexIter po
                 if (pos == index.end())
                     break;
                 begin = pos;
+
+                // Advance through file infos as long as we don't have points that
+                // correspond to it.
                 do
                 {
                     fii++;
@@ -309,14 +336,14 @@ Processor::writeOctantCompressed(const OctantInfo& o, Index& index, IndexIter po
 flush:
     try
     {
-        flushCompressed(table, view, o);
+        flushCompressed(table, view, o, stats);
     }
     catch (pdal::pdal_error& err)
     {
         fatal(err.what());
     }
 
-    m_manager.logOctant(o.key(), count);
+    m_manager.logOctant(o.key(), count, stats);
     return pos;
 }
 
@@ -340,11 +367,24 @@ void Processor::appendCompressed(pdal::PointViewPtr view, const DimInfoList& dim
 
 
 void Processor::flushCompressed(pdal::PointTableRef table, pdal::PointViewPtr view,
-    const OctantInfo& oi)
+    const OctantInfo& oi, IndexedStats& stats)
 {
     using namespace pdal;
 
     std::string filename = m_b.outputDir + "/ept-data/" + oi.key().toString() + ".laz";
+
+    if (m_b.stats)
+    {
+        for (PointId id = 0; id < view->size(); ++id)
+        {
+            for (auto& sp : stats)
+            {
+                Dimension::Id dim = sp.first;
+                Stats& s = sp.second;
+                s.insert(view->getFieldAs<double>(dim, id));
+            }
+        }
+    }
 
     StageFactory factory;
 
@@ -352,13 +392,14 @@ void Processor::flushCompressed(pdal::PointTableRef table, pdal::PointViewPtr vi
     r.addView(view);
 
     Stage *prev = &r;
+
     if (table.layout()->hasDim(Dimension::Id::GpsTime))
     {
         Stage *f = factory.createStage("filters.sort");
         pdal::Options fopts;
         fopts.add("dimension", "gpstime");
         f->setOptions(fopts);
-        f->setInput(r);
+        f->setInput(*prev);
         prev = f;
     }
 

--- a/external/untwine/bu/Processor.hpp
+++ b/external/untwine/bu/Processor.hpp
@@ -17,6 +17,7 @@
 
 #include "BuTypes.hpp"
 #include "PointAccessor.hpp"
+#include "Stats.hpp"
 #include "VoxelInfo.hpp"
 
 namespace untwine
@@ -53,7 +54,7 @@ private:
     void appendCompressed(pdal::PointViewPtr view, const DimInfoList& dims, const FileInfo& fi,
         IndexIter begin, IndexIter end);
     void flushCompressed(pdal::PointTableRef table, pdal::PointViewPtr view,
-        const OctantInfo& oi);
+        const OctantInfo& oi, IndexedStats& stats);
 
     VoxelInfo m_vi;
     const BaseInfo& m_b;

--- a/external/untwine/bu/PyramidManager.hpp
+++ b/external/untwine/bu/PyramidManager.hpp
@@ -19,6 +19,7 @@
 
 #include "BuTypes.hpp"
 #include "OctantInfo.hpp"
+#include "Stats.hpp"
 #include "../untwine/ThreadPool.hpp"
 
 namespace untwine
@@ -42,9 +43,10 @@ public:
     void setProgress(ProgressWriter *progress);
     void queue(const OctantInfo& o);
     void run();
-    void logOctant(const VoxelKey& k, int cnt);
+    void logOctant(const VoxelKey& k, int cnt, const IndexedStats& istats);
     uint64_t totalPoints() const
         { return m_totalPoints; }
+    Stats *stats(const std::string& name);
 
 private:
     const int LevelBreak = 4;
@@ -56,6 +58,7 @@ private:
     std::queue<OctantInfo> m_queue;
     ThreadPool m_pool;
     uint64_t m_totalPoints;
+    std::map<std::string, Stats> m_stats;
     ProgressWriter *m_progress;
     //
     std::unordered_map<VoxelKey, int> m_written;

--- a/external/untwine/bu/Stats.cpp
+++ b/external/untwine/bu/Stats.cpp
@@ -1,0 +1,67 @@
+
+#include "Stats.hpp"
+
+#include <cmath>
+
+namespace untwine
+{
+
+void Stats::computeGlobalStats()
+{
+    auto compute_median = [](std::vector<double> vals)
+    {
+        std::nth_element(vals.begin(), vals.begin() + vals.size() / 2, vals.end());
+        return *(vals.begin() + vals.size() / 2);
+    };
+
+    // TODO add quantiles
+    m_median = compute_median(m_data);
+    std::transform(m_data.begin(), m_data.end(), m_data.begin(),
+       [this](double v) { return std::fabs(v - this->m_median); });
+    m_mad = compute_median(m_data);
+}
+
+// Math comes from https://prod.sandia.gov/techlib-noauth/access-control.cgi/2008/086212.pdf
+// (Pebay paper from Sandia labs, 2008)
+bool Stats::merge(const Stats& s)
+{
+    if ((m_name != s.m_name) || (m_enumerate != s.m_enumerate) || (m_advanced != s.m_advanced))
+        return false;
+
+    double n1 = m_cnt;
+    double n2 = s.m_cnt;
+    double n = n1 + n2;
+    double nsq = n * n;
+    double n1n2 = m_cnt * s.m_cnt;
+    double n1sq = n1 * n1;
+    double n2sq = n2 * n2;
+    double ncube = n * n * n;
+    double deltaMean = s.M1 - M1;
+
+    if (n == 0)
+        return true;
+
+    double m1 = M1 + s.m_cnt * deltaMean / n;
+    double m2 = M2 + s.M2 + n1n2 * std::pow(deltaMean, 2) / n;
+    double m3 = M3 + s.M3 + n1n2 * (n1 - n2) * std::pow(deltaMean, 3) / nsq +
+        3 * (n1 * s.M2 - n2 * M2) * deltaMean / n;
+    double m4 = M4 + s.M4 +
+        n1n2 * (n1sq - n1n2 + n2sq) * std::pow(deltaMean, 4) / ncube +
+        6 * (n1sq * s.M2 + n2sq * M2) * std::pow(deltaMean, 2) / nsq +
+        4 * (n1 * s.M3 - n2 * M3) * deltaMean / n;
+
+    M1 = m1;
+    M2 = m2;
+    M3 = m3;
+    M4 = m4;
+    m_min = (std::min)(m_min, s.m_min);
+    m_max = (std::max)(m_max, s.m_max);
+    m_cnt = s.m_cnt + m_cnt;
+    m_data.insert(m_data.begin(), s.m_data.begin(), s.m_data.end());
+    for (auto p : s.m_values)
+        m_values[p.first] += p.second;
+
+    return true;
+}
+
+} // namespace untwine

--- a/external/untwine/bu/Stats.hpp
+++ b/external/untwine/bu/Stats.hpp
@@ -1,0 +1,181 @@
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+#include <pdal/Dimension.hpp>
+
+#include "../untwine/Common.hpp"
+
+namespace untwine
+{
+
+class Stats
+{
+public:
+    enum EnumType
+    {
+        NoEnum,
+        Enumerate,
+        Count,
+        Global
+    };
+
+using EnumMap = std::unordered_map<double, PointCount>;
+using DataVector = std::vector<double>;
+
+public:
+    Stats(std::string name, EnumType enumerate, bool advanced = true) :
+        m_name(name), m_enumerate(enumerate), m_advanced(advanced)
+    { reset(); }
+
+    // Merge another summary with this one. 'name', 'enumerate' and 'advanced' must match
+    // or false is returns and no merge occurs.
+    bool merge(const Stats& s);
+    double minimum() const
+        { return m_min; }
+    double maximum() const
+        { return m_max; }
+    double average() const
+        { return M1; }
+    double populationVariance() const
+        { return M2 / m_cnt; }
+    double sampleVariance() const
+        { return M2 / (m_cnt - 1.0); }
+    double variance() const
+        { return sampleVariance(); }
+    double populationStddev() const
+        { return std::sqrt(populationVariance()); }
+    double sampleStddev() const
+        { return std::sqrt(sampleVariance()); }
+    double stddev() const
+        { return sampleStddev(); }
+    double populationSkewness() const
+    {
+        if (!M2 || ! m_advanced)
+            return 0;
+        return std::sqrt(double(m_cnt)) * M3 / std::pow(M2, 1.5);
+    }
+    double sampleSkewness() const
+    {
+        if (M2 == 0 || m_cnt <= 2 || !m_advanced)
+            return 0.0;
+        double c((double)m_cnt);
+        return populationSkewness() * std::sqrt(c) * std::sqrt(c - 1) / (c - 2);
+    }
+    double skewness() const
+    {
+        return sampleSkewness();
+    }
+    double populationKurtosis() const
+    {
+        if (M2 == 0 || !m_advanced)
+            return 0;
+        return double(m_cnt) * M4 / (M2 * M2);
+    }
+    double populationExcessKurtosis() const
+    {
+        if (M2 == 0 || !m_advanced)
+            return 0;
+        return populationKurtosis() - 3;
+    }
+    double sampleKurtosis() const
+    {
+        if (M2 == 0 || m_cnt <= 3 || !m_advanced)
+            return 0;
+        double c((double)m_cnt);
+        return populationKurtosis() * (c + 1) * (c - 1) / ((c - 2) * (c - 3));
+    }
+    double sampleExcessKurtosis() const
+    {
+        if (M2 == 0 || m_cnt <= 3 || !m_advanced)
+            return 0;
+        double c((double)m_cnt);
+        return sampleKurtosis() - 3 * (c - 1) * (c - 1) / ((c - 2) * (c - 3));
+    }
+    double kurtosis() const
+    {
+        return sampleExcessKurtosis();
+    }
+    double median() const
+        { return m_median; }
+    double mad() const
+        { return m_mad; }
+    PointCount count() const
+        { return m_cnt; }
+    std::string name() const
+        { return m_name; }
+    const EnumMap& values() const
+        { return m_values; }
+
+    void computeGlobalStats();
+
+    void reset()
+    {
+        m_max = (std::numeric_limits<double>::lowest)();
+        m_min = (std::numeric_limits<double>::max)();
+        m_cnt = 0;
+        m_median = 0.0;
+        m_mad = 0.0;
+        M1 = M2 = M3 = M4 = 0.0;
+    }
+
+    void insert(double value)
+    {
+        m_cnt++;
+        m_min = (std::min)(m_min, value);
+        m_max = (std::max)(m_max, value);
+
+        if (m_enumerate != NoEnum)
+            m_values[value]++;
+        if (m_enumerate == Global)
+        {
+            if (m_data.capacity() - m_data.size() < 10000)
+                m_data.reserve(m_data.capacity() + m_cnt);
+            m_data.push_back(value);
+        }
+
+        // stolen from http://www.johndcook.com/blog/skewness_kurtosis/
+
+        PointCount n(m_cnt);
+
+        // Difference from the mean
+        double delta = value - M1;
+        // Portion that this point's difference from the mean contributes
+        // to the mean.
+        double delta_n = delta / n;
+        double term1 = delta * delta_n * (n - 1);
+
+        // First moment - average.
+        M1 += delta_n;
+
+        if (m_advanced)
+        {
+            double delta_n2 = pow(delta_n, 2.0);
+            // Fourth moment - kurtosis (sum part)
+            M4 += term1 * delta_n2 * (n*n - 3*n + 3) +
+                (6 * delta_n2 * M2) - (4 * delta_n * M3);
+            // Third moment - skewness (sum part)
+            M3 += term1 * delta_n * (n - 2) - 3 * delta_n * M2;
+        }
+        // Second moment - variance (sum part)
+        M2 += term1;
+    }
+
+private:
+    std::string m_name;
+    EnumType m_enumerate;
+    bool m_advanced;
+    double m_max;
+    double m_min;
+    double m_mad;
+    double m_median;
+    EnumMap m_values;
+    DataVector m_data;
+    PointCount m_cnt;
+    double M1, M2, M3, M4;
+};
+
+using IndexedStats = std::vector<std::pair<pdal::Dimension::Id, Stats>>;
+} // namespace untwine
+

--- a/external/untwine/epf/Epf.cpp
+++ b/external/untwine/epf/Epf.cpp
@@ -73,6 +73,7 @@ void Epf::run(const Options& options, ProgressWriter& progress)
 {
     using namespace pdal;
 
+    double millionPoints = 0;
     BOX3D totalBounds;
 
     if (pdal::FileUtils::fileExists(options.tempDir + "/" + MetadataFilename))

--- a/external/untwine/epf/Grid.cpp
+++ b/external/untwine/epf/Grid.cpp
@@ -42,6 +42,8 @@ int Grid::calcLevel()
 {
     int level = 0;
     double mp = (double)m_millionPoints;
+    double limit = (MaxPointsPerNode / 1000000.0);
+
     double xside = m_bounds.maxx - m_bounds.minx;
     double yside = m_bounds.maxy - m_bounds.miny;
     double zside = m_bounds.maxz - m_bounds.minz;

--- a/external/untwine/untwine/Common.hpp
+++ b/external/untwine/untwine/Common.hpp
@@ -22,6 +22,7 @@ struct Options
     int level;
     int progressFd;
     StringList dimNames;
+    bool stats;
 };
 
 const std::string MetadataFilename {"info2.txt"};

--- a/external/untwine/untwine/Untwine.cpp
+++ b/external/untwine/untwine/Untwine.cpp
@@ -45,6 +45,8 @@ void addArgs(pdal::ProgramArgs& programArgs, Options& options, pdal::Arg * &temp
         options.progressFd);
     programArgs.add("dims", "Dimensions to load. Note that X, Y and Z are always "
         "loaded.", options.dimNames);
+    programArgs.add("stats", "Generate statistics for dimensions in the manner of Entwine.",
+        options.stats);
 }
 
 bool handleOptions(pdal::StringList& arglist, Options& options)
@@ -115,11 +117,18 @@ int main(int argc, char *argv[])
 
     ProgressWriter progress(options.progressFd);
 
-    epf::Epf preflight;
-    preflight.run(options, progress);
+    try
+    {
+        epf::Epf preflight;
+        preflight.run(options, progress);
 
-    bu::BuPyramid builder;
-    builder.run(options, progress);
+        bu::BuPyramid builder;
+        builder.run(options, progress);
+    }
+    catch (const char *s)
+    {
+        std::cerr << "Error: " << s << "\n";
+    }
 
     return 0;
 }

--- a/src/providers/pdal/CMakeLists.txt
+++ b/src/providers/pdal/CMakeLists.txt
@@ -35,6 +35,7 @@ set(UNTWINE_SRCS
   ${CMAKE_SOURCE_DIR}/external/untwine/bu/BuPyramid.cpp
   ${CMAKE_SOURCE_DIR}/external/untwine/bu/Processor.cpp
   ${CMAKE_SOURCE_DIR}/external/untwine/bu/PyramidManager.cpp
+  ${CMAKE_SOURCE_DIR}/external/untwine/bu/Stats.cpp
 
   ${CMAKE_SOURCE_DIR}/external/untwine/epf/BufferCache.cpp
   ${CMAKE_SOURCE_DIR}/external/untwine/epf/Cell.cpp
@@ -58,6 +59,7 @@ set(UNTWINE_HDRS
   ${CMAKE_SOURCE_DIR}/external/untwine/bu/PointAccessor.hpp
   ${CMAKE_SOURCE_DIR}/external/untwine/bu/Processor.hpp
   ${CMAKE_SOURCE_DIR}/external/untwine/bu/PyramidManager.hpp
+  ${CMAKE_SOURCE_DIR}/external/untwine/bu/Stats.hpp
   ${CMAKE_SOURCE_DIR}/external/untwine/bu/VoxelInfo.hpp
 
   ${CMAKE_SOURCE_DIR}/external/untwine/epf/BufferCache.hpp

--- a/src/providers/pdal/qgspdaleptgenerationtask.cpp
+++ b/src/providers/pdal/qgspdaleptgenerationtask.cpp
@@ -77,8 +77,13 @@ bool QgsPdalEptGenerationTask::runUntwine()
 
   untwine::QgisUntwine untwineProcess( mUntwineExecutableBinary.toStdString() );
 
+  untwine::QgisUntwine::Options options;
+  // By default Untwine does not calculate stats for attributes, but they are very useful for us:
+  // we can use them to set automatically set valid range for the data without having to scan the points again.
+  options.push_back( { "stats", std::string() } );
+
   std::vector<std::string> files = {mFile.toStdString()};
-  untwineProcess.start( files, mOutputDir.toStdString() );
+  untwineProcess.start( files, mOutputDir.toStdString(), options );
   int lastPercent = 0;
   while ( true )
   {


### PR DESCRIPTION
Without stats we don't know valid ranges of input data, so let's get them calculated when the data gets indexed by untwine.

This simply pulls the recent work from https://github.com/hobu/untwine/pull/38 and enables stats on QGIS side.