### PR TITLE
[locator] Fix broken parsing northing,easting DMS coordinates

### DIFF
--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -972,13 +972,16 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
   if ( !match.hasMatch() )
   {
     // Check if the string is a pair of degree minute second
-    separatorRx = QRegularExpression( QStringLiteral( "^((?:([-+nsew])\\s*)?\\d{1,3}(?:[^0-9.]+[0-5]?\\d)?[^0-9.]+[0-5]?\\d(?:\\.\\d+)?[^0-9.]*[-+nsew]?)\\s+((?:([-+nsew])\\s*)?\\d{1,3}(?:[^0-9.]+[0-5]?\\d)?[^0-9.]+[0-5]?\\d(?:\\.\\d+)?[^0-9.]*[-+nsew]?)$" ) );
+    separatorRx = QRegularExpression( QStringLiteral( "^((?:([-+nsew])\\s*)?\\d{1,3}(?:[^0-9.]+[0-5]?\\d)?[^0-9.]+[0-5]?\\d(?:\\.\\d+)?[^0-9.,]*[-+nsew]?)[,\\s]+((?:([-+nsew])\\s*)?\\d{1,3}(?:[^0-9.]+[0-5]?\\d)?[^0-9.]+[0-5]?\\d(?:\\.\\d+)?[^0-9.,]*[-+nsew]?)$" ) );
     match = separatorRx.match( string.trimmed() );
     if ( match.hasMatch() )
     {
       posIsDms = true;
-      posX = QgsCoordinateUtils::dmsToDecimal( match.captured( 1 ), &okX );
+      bool isEasting = false;
+      posX = QgsCoordinateUtils::dmsToDecimal( match.captured( 1 ), &okX, &isEasting );
       posY = QgsCoordinateUtils::dmsToDecimal( match.captured( 3 ), &okY );
+      if ( !isEasting )
+        std::swap( posX, posY );
     }
   }
 

--- a/src/core/qgscoordinateutils.cpp
+++ b/src/core/qgscoordinateutils.cpp
@@ -131,9 +131,10 @@ QString QgsCoordinateUtils::formatCoordinateForProject( QgsProject *project, con
   }
 }
 
-double QgsCoordinateUtils::dmsToDecimal( const QString &string, bool *ok )
+double QgsCoordinateUtils::dmsToDecimal( const QString &string, bool *ok, bool *isEasting )
 {
   const QString negative( QStringLiteral( "swSW-" ) );
+  const QString easting( QStringLiteral( "eEwW" ) );
   double value = 0.0;
   bool okValue = false;
 
@@ -146,7 +147,7 @@ double QgsCoordinateUtils::dmsToDecimal( const QString &string, bool *ok )
     ok = &okValue;
   }
 
-  QRegularExpression dms( "^\\s*(?:([-+nsew])\\s*)?(\\d{1,3})(?:[^0-9.]+([0-5]?\\d))?[^0-9.]+([0-5]?\\d(?:\\.\\d+)?)[^0-9.]*?([-+nsew])?\\s*$", QRegularExpression::CaseInsensitiveOption );
+  QRegularExpression dms( "^\\s*(?:([-+nsew])\\s*)?(\\d{1,3})(?:[^0-9.]+([0-5]?\\d))?[^0-9.]+([0-5]?\\d(?:\\.\\d+)?)[^0-9.,]*?([-+nsew])?\\s*$", QRegularExpression::CaseInsensitiveOption );
   QRegularExpressionMatch match = dms.match( string.trimmed() );
   if ( match.hasMatch() )
   {
@@ -174,10 +175,18 @@ double QgsCoordinateUtils::dmsToDecimal( const QString &string, bool *ok )
     if ( sign1.isEmpty() )
     {
       value = !sign2.isEmpty() && negative.contains( sign2 ) ? -v : v;
+      if ( isEasting )
+      {
+        *isEasting = easting.contains( sign2 );
+      }
     }
     else if ( sign2.isEmpty() )
     {
       value = !sign1.isEmpty() && negative.contains( sign1 ) ? -v : v;
+      if ( isEasting )
+      {
+        *isEasting = easting.contains( sign2 );
+      }
     }
     else
     {

--- a/src/core/qgscoordinateutils.h
+++ b/src/core/qgscoordinateutils.h
@@ -82,7 +82,7 @@ class CORE_EXPORT QgsCoordinateUtils
      * \returns Double decimal value
      * \since QGIS 3.16
      */
-    Q_INVOKABLE static double dmsToDecimal( const QString &string, bool *ok );
+    Q_INVOKABLE static double dmsToDecimal( const QString &string, bool *ok = nullptr, bool *isEasting = nullptr );
 
 };
 

--- a/tests/src/app/testqgsapplocatorfilters.cpp
+++ b/tests/src/app/testqgsapplocatorfilters.cpp
@@ -365,10 +365,23 @@ void TestQgsAppLocatorFilters::testGoto()
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 1234.56, 789.012 ) );
 
   // degree/minuste/second coordinates goto
+  // easting northing
   results = gatherResults( &filter, QStringLiteral( "40deg 1' 0\" E 11deg  55' 0\" S" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
   QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 40.01666667° -11.91666667° (EPSG:4326 - WGS 84)" ) );
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 40.0166666667, -11.9166666667 ) );
+
+  // northing easting
+  results = gatherResults( &filter, QStringLiteral( "14°49′48″N 01°48′45″E" ), QgsLocatorContext() );
+  QCOMPARE( results.count(), 1 );
+  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 1.8125° 14.83° (EPSG:4326 - WGS 84)" ) );
+  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 1.8125, 14.83 ) );
+
+  // northing, esting (comma separated)
+  results = gatherResults( &filter, QStringLiteral( "14°49′48″N, 01°48′45″E" ), QgsLocatorContext() );
+  QCOMPARE( results.count(), 1 );
+  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 1.8125° 14.83° (EPSG:4326 - WGS 84)" ) );
+  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 1.8125, 14.83 ) );
 
   // OSM/Leaflet/OpenLayers
   results = gatherResults( &filter, QStringLiteral( "https://www.openstreetmap.org/#map=15/44.5546/6.4936" ), QgsLocatorContext() );


### PR DESCRIPTION
## Description

This PR fixes two issues with DMS parsing in the goto locator:
- DMS coordinates providing the Northing first weren't handled properly
- comma-separated DMS coordinates, e.g. 01°48′45″E,14°49′48″N, weren't recognized as valid