### PR TITLE
ui filter schema on new mssql connection widget

### DIFF
--- a/src/providers/mssql/qgsmssqlconnection.cpp
+++ b/src/providers/mssql/qgsmssqlconnection.cpp
@@ -469,7 +469,7 @@ QList<QgsVectorDataProvider::NativeType> QgsMssqlConnection::nativeTypes()
          ;
 }
 
-QString QgsMssqlConnection::buildQueryForSchemas( const QString &connName )
+QString QgsMssqlConnection::buildQueryForSchemas( const QString &connName, bool allowTablesWithNoGeometry )
 {
   QgsSettings settings;
 
@@ -524,7 +524,7 @@ QString QgsMssqlConnection::buildQueryForSchemas( const QString &connName )
       query += QStringLiteral( " AND (sys.schemas.name IN %1)" ).arg( selectedSchemas );
   }
 
-  if ( allowGeometrylessTables( connName ) )
+  if ( allowTablesWithNoGeometry )
   {
     query += QStringLiteral( "UNION ALL \n"
                              "SELECT sys.schemas.name, sys.objects.name, null, null, 'NONE', case when sys.objects.type = 'V' THEN 1 ELSE 0 END \n"
@@ -535,6 +535,11 @@ QString QgsMssqlConnection::buildQueryForSchemas( const QString &connName )
   }
 
   return query;
+}
+
+QString QgsMssqlConnection::buildQueryForSchemas( const QString &connName )
+{
+  return buildQueryForSchemas( connName, allowGeometrylessTables( connName ) );
 }
 
 QString QgsMssqlConnection::dbConnectionName( const QString &name )

--- a/src/providers/mssql/qgsmssqlconnection.cpp
+++ b/src/providers/mssql/qgsmssqlconnection.cpp
@@ -526,7 +526,7 @@ QString QgsMssqlConnection::buildQueryForSchemas( const QString &connName, bool 
 
   if ( allowTablesWithNoGeometry )
   {
-    query += QStringLiteral( "UNION ALL \n"
+    query += QStringLiteral( " UNION ALL \n"
                              "SELECT sys.schemas.name, sys.objects.name, null, null, 'NONE', case when sys.objects.type = 'V' THEN 1 ELSE 0 END \n"
                              "FROM  sys.objects JOIN sys.schemas ON sys.objects.schema_id = sys.schemas.schema_id "
                              "WHERE NOT EXISTS (SELECT * FROM sys.columns sc1 JOIN sys.types ON sc1.system_type_id = sys.types.system_type_id WHERE (sys.types.name = 'geometry' OR sys.types.name = 'geography') AND sys.objects.object_id = sc1.object_id) AND (sys.objects.type = 'U' or sys.objects.type = 'V')" );

--- a/src/providers/mssql/qgsmssqlconnection.cpp
+++ b/src/providers/mssql/qgsmssqlconnection.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgsmssqlconnection.h"
+#include "qgsmssqlprovider.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
 #include "qgsdatasourceuri.h"
@@ -324,16 +325,21 @@ QStringList QgsMssqlConnection::schemas( const QString &uri, QString *errorMessa
 // connect to database
   QSqlDatabase db = getDatabase( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
 
-  if ( !openDatabase( db ) )
+  return schemas( db, errorMessage );
+}
+
+QStringList QgsMssqlConnection::schemas( QSqlDatabase &dataBase, QString *errorMessage )
+{
+  if ( !openDatabase( dataBase ) )
   {
     if ( errorMessage )
-      *errorMessage = db.lastError().text();
+      *errorMessage = dataBase.lastError().text();
     return QStringList();
   }
 
   const QString sql = QStringLiteral( "select s.name as schema_name from sys.schemas s" );
 
-  QSqlQuery q = QSqlQuery( db );
+  QSqlQuery q = QSqlQuery( dataBase );
   q.setForwardOnly( true );
   if ( !q.exec( sql ) )
   {
@@ -461,6 +467,74 @@ QList<QgsVectorDataProvider::NativeType> QgsMssqlConnection::nativeTypes()
          << QgsVectorDataProvider::NativeType( QObject::tr( "Text, unlimited length (text)" ), QStringLiteral( "text" ), QVariant::String )
          << QgsVectorDataProvider::NativeType( QObject::tr( "Text, unlimited length unicode (ntext)" ), QStringLiteral( "text" ), QVariant::String )
          ;
+}
+
+QString QgsMssqlConnection::buildQueryForSchemas( const QString &connName )
+{
+  QgsSettings settings;
+
+  QString selectedSchemas;
+
+  QString databaseName = settings.value( QStringLiteral( "/MSSQL/connections/" ) + connName + "/database" ).toString();
+
+  bool schemaFilteringEnabled = settings.value( QStringLiteral( "/MSSQL/connections/" ) + connName + "/schemasFiltering" ).toBool();
+
+  if ( schemaFilteringEnabled )
+  {
+    QVariant schemaSettingsVariant = settings.value( QStringLiteral( "/MSSQL/connections/" ) + connName + "/schemasFiltered" );
+
+    if ( schemaSettingsVariant.type() == QVariant::Map )
+    {
+      QVariantMap schemaSettings = schemaSettingsVariant.toMap();
+      QVariantMap schemaSettingsForDatabase = schemaSettings.value( databaseName ).toMap();
+      //schema filter
+
+
+      QStringList schemaNames;
+      for ( const QString &schemaName : schemaSettingsForDatabase.keys() )
+      {
+        if ( schemaSettingsForDatabase.value( schemaName ).toBool() )
+        {
+          schemaNames.append( QgsMssqlProvider::quotedValue( schemaName ) );
+        }
+      }
+      if ( !schemaNames.empty() )
+        selectedSchemas = schemaNames.join( ',' );
+
+      selectedSchemas.prepend( QStringLiteral( "( " ) );
+      selectedSchemas.append( QStringLiteral( " )" ) );
+
+    }
+  }
+
+  // build sql statement
+  QString query( QStringLiteral( "SELECT " ) );
+  if ( geometryColumnsOnly( connName ) )
+  {
+    query += QStringLiteral( "f_table_schema, f_table_name, f_geometry_column, srid, geometry_type, 0 FROM geometry_columns" );
+    if ( !selectedSchemas.isEmpty() )
+      query += QStringLiteral( " WHERE f_table_schema IN %1" ).arg( selectedSchemas );
+  }
+  else
+  {
+    query += QStringLiteral( "sys.schemas.name, sys.objects.name, sys.columns.name, null, 'GEOMETRY', CASE when sys.objects.type = 'V' THEN 1 ELSE 0 END \n"
+                             "FROM sys.columns JOIN sys.types ON sys.columns.system_type_id = sys.types.system_type_id AND sys.columns.user_type_id = sys.types.user_type_id JOIN sys.objects ON sys.objects.object_id = sys.columns.object_id JOIN sys.schemas ON sys.objects.schema_id = sys.schemas.schema_id \n"
+                             "WHERE (sys.types.name = 'geometry' OR sys.types.name = 'geography') AND (sys.objects.type = 'U' OR sys.objects.type = 'V')" );
+    if ( !selectedSchemas.isEmpty() )
+      query += QStringLiteral( " AND (sys.schemas.name IN %1)" ).arg( selectedSchemas );
+  }
+
+  if ( allowGeometrylessTables( connName ) )
+  {
+    query += QStringLiteral( "UNION ALL \n"
+                             "SELECT sys.schemas.name, sys.objects.name, null, null, 'NONE', case when sys.objects.type = 'V' THEN 1 ELSE 0 END \n"
+                             "FROM  sys.objects JOIN sys.schemas ON sys.objects.schema_id = sys.schemas.schema_id "
+                             "WHERE NOT EXISTS (SELECT * FROM sys.columns sc1 JOIN sys.types ON sc1.system_type_id = sys.types.system_type_id WHERE (sys.types.name = 'geometry' OR sys.types.name = 'geography') AND sys.objects.object_id = sc1.object_id) AND (sys.objects.type = 'U' or sys.objects.type = 'V')" );
+    if ( !selectedSchemas.isEmpty() )
+      query += QStringLiteral( " AND sys.schemas.name IN %1" ).arg( selectedSchemas );
+  }
+
+  return query;
 }
 
 QString QgsMssqlConnection::dbConnectionName( const QString &name )

--- a/src/providers/mssql/qgsmssqlconnection.h
+++ b/src/providers/mssql/qgsmssqlconnection.h
@@ -150,6 +150,11 @@ class QgsMssqlConnection
     static QStringList schemas( const QString &uri, QString *errorMessage );
 
     /**
+     * Returns a list of all schemas on the \a dataBase.
+     */
+    static QStringList schemas( QSqlDatabase &dataBase, QString *errorMessage );
+
+    /**
      * Returns true if the given \a schema is a system schema.
      */
     static bool isSystemSchema( const QString &schema );
@@ -170,6 +175,11 @@ class QgsMssqlConnection
      */
     static QList<QgsVectorDataProvider::NativeType> nativeTypes();
 
+    /**
+     * Builds and returns a sql query string to obtain schemas list depending on settings
+     * \since QGIS 3.18
+     */
+    static QString buildQueryForSchemas( const QString &connName );
 
   private:
 

--- a/src/providers/mssql/qgsmssqlconnection.h
+++ b/src/providers/mssql/qgsmssqlconnection.h
@@ -45,7 +45,6 @@ class QgsMssqlConnection
      */
     static QSqlDatabase getDatabase( const QString &service, const QString &host, const QString &database, const QString &username, const QString &password );
 
-
     static bool openDatabase( QSqlDatabase &db );
 
     /**
@@ -151,6 +150,7 @@ class QgsMssqlConnection
 
     /**
      * Returns a list of all schemas on the \a dataBase.
+     * \since QGIS 3.18
      */
     static QStringList schemas( QSqlDatabase &dataBase, QString *errorMessage );
 
@@ -176,16 +176,47 @@ class QgsMssqlConnection
     static QList<QgsVectorDataProvider::NativeType> nativeTypes();
 
     /**
-     * Builds and returns a sql query string to obtain schemas list depending on settings and \a allowTablesWithNoGeometry
+     * Returns a list of excluded schemas for connection \a connName depending on settings, returns empty list if nothing is set for this connection
      * \since QGIS 3.18
      */
-    static QString buildQueryForSchemas( const QString &connName, bool allowTablesWithNoGeometry );
+    static QStringList excludedSchemasList( const QString &connName );
+
+    /**
+     * Returns a list of excluded schemas for connection \a connName for a specific \a database depending on settings, returns empty list if nothing is set for this connection
+     * \since QGIS 3.18
+     */
+    static QStringList excludedSchemasList( const QString &connName, const QString &database );
+
+    /**
+     * Sets a list of excluded schemas for connection \a connName depending on settings, returns empty list if nothing is set for this connection
+     * \since QGIS 3.18
+     */
+    static void setExcludedSchemasList( const QString &connName, const QStringList &excludedSchemas );
+
+    /**
+     * Sets a list of excluded schemas for connection \a connName for a specific \a database depending on settings, returns empty list if nothing is set for this connection
+     * \since QGIS 3.18
+     */
+    static void setExcludedSchemasList( const QString &connName, const QString &database, const QStringList &excludedSchemas );
+
+    /**
+     * Builds and returns a sql query string to obtain tables list depending on \a allowTablesWithNoGeometry, \a geometryColumnOnly and on \a notSelectedSchemasList
+     * \since QGIS 3.18
+     */
+    static QString buildQueryForTables( bool allowTablesWithNoGeometry, bool geometryColumnOnly, const QStringList &excludedSchemaList = QStringList() );
+
+
+    /**
+     * Builds and returns a sql query string to obtain tables list depending on settings and \a allowTablesWithNoGeometry
+     * \since QGIS 3.18
+     */
+    static QString buildQueryForTables( const QString &connName, bool allowTablesWithNoGeometry );
 
     /**
      * Builds and returns a sql query string to obtain schemas list depending only on settings
      * \since QGIS 3.18
      */
-    static QString buildQueryForSchemas( const QString &connName );
+    static QString buildQueryForTables( const QString &connName );
 
   private:
 

--- a/src/providers/mssql/qgsmssqlconnection.h
+++ b/src/providers/mssql/qgsmssqlconnection.h
@@ -176,7 +176,13 @@ class QgsMssqlConnection
     static QList<QgsVectorDataProvider::NativeType> nativeTypes();
 
     /**
-     * Builds and returns a sql query string to obtain schemas list depending on settings
+     * Builds and returns a sql query string to obtain schemas list depending on settings and \a allowTablesWithNoGeometry
+     * \since QGIS 3.18
+     */
+    static QString buildQueryForSchemas( const QString &connName, bool allowTablesWithNoGeometry );
+
+    /**
+     * Builds and returns a sql query string to obtain schemas list depending only on settings
      * \since QGIS 3.18
      */
     static QString buildQueryForSchemas( const QString &connName );

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
@@ -171,6 +171,7 @@ void QgsMssqlDataItemGuiProvider::editConnection( QgsDataItem *item )
   {
     // the parent should be updated
     item->parent()->refreshConnections();
+    item->refresh();
   }
 }
 

--- a/src/providers/mssql/qgsmssqldataitems.h
+++ b/src/providers/mssql/qgsmssqldataitems.h
@@ -91,6 +91,8 @@ class QgsMssqlConnectionItem : public QgsDataCollectionItem
     bool mUseEstimatedMetadata;
     bool mAllowGeometrylessTables;
     QgsMssqlGeomColumnTypeThread *mColumnTypeThread = nullptr;
+    QVariantMap mSchemaSettings;
+    bool mSchemasFilteringEnabled = false;
 
     void readConnectionSettings();
     void stop();

--- a/src/providers/mssql/qgsmssqlnewconnection.cpp
+++ b/src/providers/mssql/qgsmssqlnewconnection.cpp
@@ -302,7 +302,7 @@ void QgsMssqlNewConnection::updateOkButtonState()
 
 void QgsMssqlNewConnection::onCurrentDataBaseChange()
 {
-  //Fisrt store the schema settings for the previous dataBase
+  //First store the schema settings for the previous dataBase
   QVariantMap vm = mSchemaModel.schemasSettings();
   if ( !mSchemaModel.dataBaseName().isEmpty() )
     mSchemaSettings.insert( mSchemaModel.dataBaseName(), mSchemaModel.schemasSettings() );

--- a/src/providers/mssql/qgsmssqlnewconnection.h
+++ b/src/providers/mssql/qgsmssqlnewconnection.h
@@ -19,7 +19,7 @@
 #include "ui_qgsmssqlnewconnectionbase.h"
 #include "qgsguiutils.h"
 #include "qgshelp.h"
-
+#include <QAbstractListModel>
 
 /**
  * \class QgsMssqlNewConnection
@@ -49,9 +49,42 @@ class QgsMssqlNewConnection : public QDialog, private Ui::QgsMssqlNewConnectionB
   private slots:
     //! Updates state of the OK button depending of the filled fields
     void updateOkButtonState();
+    void onCurrentDataBaseChange();
   private:
+    //! Class that reprents a model to display available schemas on a database and choose which will be diplayed in QGIS
+    class SchemaModel: public QAbstractListModel
+    {
+      public:
+        SchemaModel( QObject *parent = nullptr );
+
+        int rowCount( const QModelIndex &parent ) const override;
+        QVariant data( const QModelIndex &index, int role ) const override;
+        bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
+        Qt::ItemFlags flags( const QModelIndex &index ) const override;
+
+        //! Sets the schema settings (keyd : schema names, value : bool that represnts wheter the schema is checked)
+        void setSchemasSetting( const QVariantMap &schemas );
+
+        //! Returns the schema settings (keyd : schema names, value : bool that represnts wheter the schema is checked)
+        QVariantMap schemasSettings() const;
+
+        //! Returns the database nale represented by the model
+        QString dataBaseName() const;
+
+        //! Sets the database nale represented by the model
+        void setDataBaseName( const QString &dataBaseName );
+
+      private:
+        QVariantMap mSchemas;
+        QString mDataBaseName;
+
+    };
+
     QString mOriginalConnName; //store initial name to delete entry in case of rename
     void showHelp();
+
+    QVariantMap mSchemaSettings; //store the schema settings edited during this QDialog life time
+    SchemaModel mSchemaModel;
 
 };
 

--- a/src/providers/mssql/qgsmssqlnewconnection.h
+++ b/src/providers/mssql/qgsmssqlnewconnection.h
@@ -51,7 +51,7 @@ class QgsMssqlNewConnection : public QDialog, private Ui::QgsMssqlNewConnectionB
     void updateOkButtonState();
     void onCurrentDataBaseChange();
   private:
-    //! Class that reprents a model to display available schemas on a database and choose which will be diplayed in QGIS
+    //! Class that reprents a model to display available schemas on a database and choose which will be displayed in QGIS
     class SchemaModel: public QAbstractListModel
     {
       public:
@@ -62,10 +62,10 @@ class QgsMssqlNewConnection : public QDialog, private Ui::QgsMssqlNewConnectionB
         bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
         Qt::ItemFlags flags( const QModelIndex &index ) const override;
 
-        //! Sets the schema settings (keyd : schema names, value : bool that represnts wheter the schema is checked)
+        //! Sets the schema settings (keyd : schema names, value : bool that represents whether the schema is checked)
         void setSchemasSetting( const QVariantMap &schemas );
 
-        //! Returns the schema settings (keyd : schema names, value : bool that represnts wheter the schema is checked)
+        //! Returns the schema settings (keyd : schema names, value : bool that represents whether the schema is checked)
         QVariantMap schemasSettings() const;
 
         //! Returns the database nale represented by the model

--- a/src/providers/mssql/qgsmssqlnewconnection.h
+++ b/src/providers/mssql/qgsmssqlnewconnection.h
@@ -62,11 +62,8 @@ class QgsMssqlNewConnection : public QDialog, private Ui::QgsMssqlNewConnectionB
         bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
         Qt::ItemFlags flags( const QModelIndex &index ) const override;
 
-        //! Sets the schema settings (keyd : schema names, value : bool that represents whether the schema is checked)
-        void setSchemasSetting( const QVariantMap &schemas );
-
-        //! Returns the schema settings (keyd : schema names, value : bool that represents whether the schema is checked)
-        QVariantMap schemasSettings() const;
+        //! Returns the unchecked schemas
+        QStringList uncheckedSchemas() const;
 
         //! Returns the database nale represented by the model
         QString dataBaseName() const;
@@ -74,9 +71,13 @@ class QgsMssqlNewConnection : public QDialog, private Ui::QgsMssqlNewConnectionB
         //! Sets the database nale represented by the model
         void setDataBaseName( const QString &dataBaseName );
 
+        //! Sets the settings for \a database
+        void setSettings( const QString &database, const QStringList &schemas, const QStringList &excludedSchemas );
+
       private:
-        QVariantMap mSchemas;
         QString mDataBaseName;
+        QStringList mSchemas;
+        QStringList mExcludedSchemas;
 
     };
 

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -540,21 +540,7 @@ void QgsMssqlSourceSelect::btnConnect_clicked()
   // Read supported layers from database
   QApplication::setOverrideCursor( Qt::WaitCursor );
 
-  // build sql statement
-  QString query( QStringLiteral( "select " ) );
-  if ( useGeometryColumns )
-  {
-    query += QLatin1String( "f_table_schema, f_table_name, f_geometry_column, srid, geometry_type, 0 from geometry_columns" );
-  }
-  else
-  {
-    query += QLatin1String( "sys.schemas.name, sys.objects.name, sys.columns.name, null, 'GEOMETRY', case when sys.objects.type = 'V' then 1 else 0 end from sys.columns join sys.types on sys.columns.system_type_id = sys.types.system_type_id and sys.columns.user_type_id = sys.types.user_type_id join sys.objects on sys.objects.object_id = sys.columns.object_id join sys.schemas on sys.objects.schema_id = sys.schemas.schema_id where (sys.types.name = 'geometry' or sys.types.name = 'geography') and (sys.objects.type = 'U' or sys.objects.type = 'V')" );
-  }
-
-  if ( allowGeometrylessTables )
-  {
-    query += QLatin1String( " union all select sys.schemas.name, sys.objects.name, null, null, 'NONE', case when sys.objects.type = 'V' then 1 else 0 end from sys.objects join sys.schemas on sys.objects.schema_id = sys.schemas.schema_id where not exists (select * from sys.columns sc1 join sys.types on sc1.system_type_id = sys.types.system_type_id where (sys.types.name = 'geometry' or sys.types.name = 'geography') and sys.objects.object_id = sc1.object_id) and (sys.objects.type = 'U' or sys.objects.type = 'V')" );
-  }
+  QString query = QgsMssqlConnection::buildQueryForSchemas( cmbConnections->currentText() );
 
   // issue the sql query
   q = QSqlQuery( db );

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -540,7 +540,7 @@ void QgsMssqlSourceSelect::btnConnect_clicked()
   // Read supported layers from database
   QApplication::setOverrideCursor( Qt::WaitCursor );
 
-  QString query = QgsMssqlConnection::buildQueryForSchemas( cmbConnections->currentText() );
+  QString query = QgsMssqlConnection::buildQueryForSchemas( cmbConnections->currentText(), allowGeometrylessTables );
 
   // issue the sql query
   q = QSqlQuery( db );

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -540,7 +540,7 @@ void QgsMssqlSourceSelect::btnConnect_clicked()
   // Read supported layers from database
   QApplication::setOverrideCursor( Qt::WaitCursor );
 
-  QString query = QgsMssqlConnection::buildQueryForSchemas( cmbConnections->currentText(), allowGeometrylessTables );
+  QString query = QgsMssqlConnection::buildQueryForTables( cmbConnections->currentText(), allowGeometrylessTables );
 
   // issue the sql query
   q = QSqlQuery( db );

--- a/src/ui/qgsmssqlnewconnectionbase.ui
+++ b/src/ui/qgsmssqlnewconnectionbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>772</width>
-    <height>691</height>
+    <height>687</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -272,19 +272,6 @@ Untick save if you don't wish to be the case.</string>
        </widget>
       </item>
       <item row="7" column="0" colspan="2">
-       <widget class="Line" name="line">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="0" colspan="2">
        <widget class="QgsCollapsibleGroupBoxBasic" name="groupBoxSchemasFilter">
         <property name="title">
          <string>Use Only a Subset of Schemas</string>
@@ -317,7 +304,7 @@ Untick save if you don't wish to be the case.</string>
         </layout>
        </widget>
       </item>
-      <item row="9" column="0" colspan="2">
+      <item row="8" column="0" colspan="2">
        <widget class="QPushButton" name="btnConnect">
         <property name="text">
          <string>Test Connection</string>

--- a/src/ui/qgsmssqlnewconnectionbase.ui
+++ b/src/ui/qgsmssqlnewconnectionbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>772</width>
-    <height>575</height>
+    <height>691</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -205,8 +205,35 @@ Untick save if you don't wish to be the case.</string>
       <string>Database Details</string>
      </property>
      <layout class="QFormLayout" name="formLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="TextLabel2">
+        <property name="text">
+         <string>Database</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="btnListDatabase">
+        <property name="text">
+         <string>List Databases</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="1">
        <widget class="QListWidget" name="listDatabase"/>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="cb_geometryColumns">
+        <property name="toolTip">
+         <string>If checked, only tables which are present in the &quot;geometry_columns&quot; metadata table will be available. This speeds up table scanning, but requires users to manually manage the geometry_columns table and ensure that layers are correctly represented in the table.</string>
+        </property>
+        <property name="text">
+         <string>Only look in the geometry_columns metadata table</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
       </item>
       <item row="3" column="0" colspan="2">
        <widget class="QCheckBox" name="cb_allowGeometrylessTables">
@@ -231,40 +258,6 @@ Untick save if you don't wish to be the case.</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="cb_geometryColumns">
-        <property name="toolTip">
-         <string>If checked, only tables which are present in the &quot;geometry_columns&quot; metadata table will be available. This speeds up table scanning, but requires users to manually manage the geometry_columns table and ensure that layers are correctly represented in the table.</string>
-        </property>
-        <property name="text">
-         <string>Only look in the geometry_columns metadata table</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0" colspan="2">
-       <widget class="QPushButton" name="btnConnect">
-        <property name="text">
-         <string>Test Connection</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QPushButton" name="btnListDatabase">
-        <property name="text">
-         <string>List Databases</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="TextLabel2">
-        <property name="text">
-         <string>Database</string>
-        </property>
-       </widget>
-      </item>
       <item row="5" column="0" colspan="2">
        <widget class="QCheckBox" name="mCheckNoInvalidGeometryHandling">
         <property name="toolTip">
@@ -275,6 +268,59 @@ Untick save if you don't wish to be the case.</string>
         </property>
         <property name="checked">
          <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0" colspan="2">
+       <widget class="Line" name="line">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0" colspan="2">
+       <widget class="QgsCollapsibleGroupBoxBasic" name="groupBoxSchemasFilter">
+        <property name="title">
+         <string>Use Only a Subset of Schemas</string>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QListView" name="schemaView"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="9" column="0" colspan="2">
+       <widget class="QPushButton" name="btnConnect">
+        <property name="text">
+         <string>Test Connection</string>
         </property>
        </widget>
       </item>
@@ -302,6 +348,12 @@ Untick save if you don't wish to be the case.</string>
    <class>QgsPasswordLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qgspasswordlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/tests/src/python/test_qgsproviderconnection_mssql.py
+++ b/tests/src/python/test_qgsproviderconnection_mssql.py
@@ -102,6 +102,30 @@ class TestPyQgsProviderConnectionMssql(unittest.TestCase, TestPyQgsProviderConne
         fields = conn.fields('qgis_test', 'someData')
         self.assertEqual(fields.names(), ['pk', 'cnt', 'name', 'name2', 'num_char', 'dt', 'date', 'time'])
 
+    def test_schemas_filtering(self):
+        """Test schemas filtering"""
+
+        md = QgsProviderRegistry.instance().providerMetadata('mssql')
+
+        conn = md.createConnection(self.uri, {})
+        schemas = conn.schemas()
+        self.assertEqual(len(schemas), 2)
+        self.assertEqual(schemas, ['dbo', 'qgis_test'])
+        filterUri = QgsDataSourceUri(self.uri)
+        filterUri.setParam('excludedSchemas', 'dbo')
+        conn = md.createConnection(filterUri.uri(), {})
+        schemas = conn.schemas()
+        self.assertEqual(len(schemas), 1)
+        self.assertEqual(schemas, ['qgis_test'])
+
+        # Store the connection
+        conn.store('filteredConnection')
+
+        otherConn = md.createConnection('filteredConnection')
+        schemas = otherConn.schemas()
+        self.assertEqual(len(schemas), 1)
+        self.assertEqual(schemas, ['qgis_test'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR allows the user to filter schemas for MS SQL  connection. If filter is activated, only selected schemas will be displayed.


![mssql_schema_filter](https://user-images.githubusercontent.com/7416892/103355731-61fcdf00-4a85-11eb-8e38-f745046f3730.gif)

Work funded by ms.GIS