### PR TITLE
Fix broken manual rotation anchor point setting via ctrl+click

### DIFF
--- a/python/gui/auto_generated/qgsvertexmarker.sip.in
+++ b/python/gui/auto_generated/qgsvertexmarker.sip.in
@@ -46,6 +46,20 @@ A class for marking vertices of features using e.g. circles or 'x'.
     QgsVertexMarker( QgsMapCanvas *mapCanvas /TransferThis/ );
 
     void setCenter( const QgsPointXY &point );
+%Docstring
+Sets the center ``point`` of the marker, in map coordinates.
+
+.. seealso:: :py:func:`center`
+%End
+
+    QgsPointXY center() const;
+%Docstring
+Returns the center point of the marker, in map coordinates.
+
+.. seealso:: :py:func:`setCenter`
+
+.. versionadded:: 3.18
+%End
 
     void setIconType( int iconType );
 

--- a/src/gui/qgsvertexmarker.h
+++ b/src/gui/qgsvertexmarker.h
@@ -61,7 +61,20 @@ class GUI_EXPORT QgsVertexMarker : public QgsMapCanvasItem
 
     QgsVertexMarker( QgsMapCanvas *mapCanvas SIP_TRANSFERTHIS );
 
+    /**
+     * Sets the center \a point of the marker, in map coordinates.
+     *
+     * \see center()
+     */
     void setCenter( const QgsPointXY &point );
+
+    /**
+     * Returns the center point of the marker, in map coordinates.
+     *
+     * \see setCenter()
+     * \since QGIS 3.18
+     */
+    QgsPointXY center() const { return mCenter; }
 
     void setIconType( int iconType );
 

--- a/tests/src/app/testqgsmaptoolrotatefeature.cpp
+++ b/tests/src/app/testqgsmaptoolrotatefeature.cpp
@@ -44,6 +44,9 @@ class TestQgsMapToolRotateFeature: public QObject
     void cleanupTestCase();// will be called after the last testfunction was executed.
 
     void testRotateFeature();
+    void testRotateFeatureManualAnchor();
+    void testCancelManualAnchor();
+    void testRotateFeatureManualAnchorAfterStartRotate();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -135,6 +138,68 @@ void TestQgsMapToolRotateFeature::testRotateFeature()
   utils.mouseClick( 2, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
 
   QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), QStringLiteral( "Polygon ((0.72 -0.17, 0.28 1.17, 1.17 0.72, 0.72 -0.17))" ) );
+  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), QStringLiteral( "Polygon ((1.1 0, 1.1 5, 2.1 5, 2.1 0))" ) );
+
+  mLayerBase->undoStack()->undo();
+}
+
+void TestQgsMapToolRotateFeature::testRotateFeatureManualAnchor()
+{
+  // test rotating around a fixed anchor point
+  TestQgsMapToolUtils utils( mRotateTool );
+
+  // set anchor point
+  utils.mouseClick( 0, 5, Qt::LeftButton, Qt::ControlModifier, true );
+
+  utils.mouseClick( 1, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseMove( 2, 1 );
+  utils.mouseClick( 2, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+
+  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), QStringLiteral( "Polygon ((2.06 0.34, 0.87 1.1, 1.84 1.31, 2.06 0.34))" ) );
+  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), QStringLiteral( "Polygon ((1.1 0, 1.1 5, 2.1 5, 2.1 0))" ) );
+
+  mLayerBase->undoStack()->undo();
+}
+
+void TestQgsMapToolRotateFeature::testCancelManualAnchor()
+{
+  // test canceling rotation around a fixed anchor point
+  TestQgsMapToolUtils utils( mRotateTool );
+
+  // set anchor point
+  utils.mouseClick( 0, 5, Qt::LeftButton, Qt::ControlModifier, true );
+
+  // right click = remove anchor point
+  utils.mouseClick( 10, 15, Qt::RightButton, Qt::KeyboardModifiers(), true );
+
+  // now rotate -- should be around feature center, not anchor point
+  utils.mouseClick( 1, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseMove( 2, 1 );
+  utils.mouseClick( 2, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+
+  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), QStringLiteral( "Polygon ((0.72 -0.17, 0.28 1.17, 1.17 0.72, 0.72 -0.17))" ) );
+  QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), QStringLiteral( "Polygon ((1.1 0, 1.1 5, 2.1 5, 2.1 0))" ) );
+
+  mLayerBase->undoStack()->undo();
+}
+
+void TestQgsMapToolRotateFeature::testRotateFeatureManualAnchorAfterStartRotate()
+{
+  // test rotating around a fixed anchor point, where the fixed anchor point is placed after rotation begins
+  TestQgsMapToolUtils utils( mRotateTool );
+
+  // start rotation
+  utils.mouseClick( 1, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+
+  // set anchor point
+  utils.mouseMove( 0, 5 );
+  utils.mouseClick( 0, 5, Qt::LeftButton, Qt::ControlModifier, true );
+
+  // complete rotation
+  utils.mouseMove( 2, 1 );
+  utils.mouseClick( 2, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+
+  QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt( 2 ), QStringLiteral( "Polygon ((-5.06 5.63, -3.79 6.26, -4.11 5.32, -5.06 5.63))" ) );
   QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt( 2 ), QStringLiteral( "Polygon ((1.1 0, 1.1 5, 2.1 5, 2.1 0))" ) );
 
   mLayerBase->undoStack()->undo();


### PR DESCRIPTION
Ctrl+clicking to set the manual rotation point had no effect, and the selected rotation point was always reset as soon as the rotation action started.

Apparently this has been broken for some time (confirmed broken since 3.4 at least!).

Also add tests.