### PR TITLE
[locator] Fix broken parsing of google maps URL Z values

### DIFF
--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -1100,9 +1100,9 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
 
           if ( okX && okY )
           {
-            if ( match.captured( 2 ) == QChar( 'z' ) && scales.contains( params.at( 2 ).toInt() ) )
+            if ( match.captured( 2 ) == QChar( 'z' ) && scales.contains( static_cast<int>( params.at( 2 ).toDouble() ) ) )
             {
-              scale = scales.value( params.at( 2 ).toInt() );
+              scale = scales.value( static_cast<int>( params.at( 2 ).toDouble() ) );
             }
             else if ( match.captured( 2 ) == QChar( 'm' ) )
             {

--- a/tests/src/app/testqgsapplocatorfilters.cpp
+++ b/tests/src/app/testqgsapplocatorfilters.cpp
@@ -391,7 +391,7 @@ void TestQgsAppLocatorFilters::testGoto()
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "scale" )].toDouble(), 22569.0 );
 
   // Google Maps
-  results = gatherResults( &filter, QStringLiteral( "https://www.google.com/maps/@44.5546,6.4936,15z" ), QgsLocatorContext() );
+  results = gatherResults( &filter, QStringLiteral( "https://www.google.com/maps/@44.5546,6.4936,15.25z" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
   QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 6.4936° 44.5546° at scale 1:22569 (EPSG:4326 - WGS 84)" ) );
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 6.4936, 44.5546 ) );


### PR DESCRIPTION
## Description

This fixes google maps URL Z value parsing when the value isn't a whole number, e.g. https://www.google.com/maps/place/Inda+Aba+Guna,+Ethiopia/@13.9385747,38.1827951,13.5z/data=!4m5!3m4!1s0x166910fb8da74ae9:0xcb3c762191d55acd!8m2!3d13.9488338!4d38.1820581