### PR TITLE
Review the help string about translated project

### DIFF
--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -2639,9 +2639,11 @@ void QgsProjectProperties::onGenerateTsFileButton() const
   QMessageBox::information( nullptr, tr( "General TS file generated" ), tr( "TS file generated with source language %1.\n"
                             "- open it with Qt Linguist\n"
                             "- translate strings\n"
-                            "- save it with the postfix of the target language (eg. de)\n"
-                            "- release to get qm file including postfix (eg. aproject_de.qm)\n"
-                            "When you open it again in QGIS having set the target language (de), the project will be translated and saved with postfix (eg. aproject_de.qgs)." ).arg( l ) ) ;
+                            "- save the TS file with the suffix of the target language (eg. _de.ts)\n"
+                            "- release to get the QM file including the suffix (eg. aproject_de.qm)\n"
+                            "- open the original QGIS file (eg aproject.qgs)\n"
+                            "- if your QGIS is set to use a specific language and the QM file for that language is found, the translated QGIS project will be generated on the fly.\n"
+                            "- you will be redirected to this new project (eg. aproject_de.qgs)." ).arg( l ) ) ;
 }
 
 void QgsProjectProperties::customizeBearingFormat()

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -2639,11 +2639,11 @@ void QgsProjectProperties::onGenerateTsFileButton() const
   QMessageBox::information( nullptr, tr( "General TS file generated" ), tr( "TS file generated with source language %1.\n"
                             "- open it with Qt Linguist\n"
                             "- translate strings\n"
-                            "- save the TS file with the suffix of the target language (eg. _de.ts)\n"
-                            "- release to get the QM file including the suffix (eg. aproject_de.qm)\n"
-                            "- open the original QGIS file (eg aproject.qgs)\n"
+                            "- save the TS file with the suffix of the target language (e.g. _de.ts)\n"
+                            "- release to get the QM file including the suffix (e.g. aproject_de.qm)\n"
+                            "- open the original QGIS file (e.g. aproject.qgs)\n"
                             "- if your QGIS is set to use a specific language and the QM file for that language is found, the translated QGIS project will be generated on the fly.\n"
-                            "- you will be redirected to this new project (eg. aproject_de.qgs)." ).arg( l ) ) ;
+                            "- you will be redirected to this new project (e.g. aproject_de.qgs)." ).arg( l ) ) ;
 }
 
 void QgsProjectProperties::customizeBearingFormat()


### PR DESCRIPTION
@signedav I just used this feature now. It's very nice.
I have just rephrased a little bit the help string according to what I understand.

Can you confirm that the translation step **only** happens when you open the original QGIS file (without the `_lang.qgs`). So then you only distribute, in the plugin, the `project_lang.qgs` and not the `project.qgs` + `project_lang.qm` ?
This looks a little bit weird to me if you have 10 languages for instance, the GIS officer needs to open the project 10 times to generate each language after an update in the `project.qgs`, right ?
It's just a question, not a feature request or a bug ;-) Just to be sure.