### PR TITLE
Implement FPS navigation / flying mode in the 3D viewer

### DIFF
--- a/python/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -554,19 +554,6 @@ Sets the camera lens' field of view
 
 
 
-    QgsCameraController::NavigationMode cameraNavigationMode() const;
-%Docstring
-Returns the navigation mode used by the camera
-
-.. versionadded:: 3.18
-%End
-
-    void setCameraNavigationMode( QgsCameraController::NavigationMode navigationMode );
-%Docstring
-Sets the navigation mode for the camera
-
-.. versionadded:: 3.18
-%End
 
     double cameraMovementSpeed() const;
 %Docstring

--- a/python/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -554,6 +554,20 @@ Sets the camera lens' field of view
 
 
 
+    QgsCameraController::NavigationMode cameraNavigationMode() const;
+%Docstring
+Returns the navigation mode used by the camera
+
+.. versionadded:: 3.18
+%End
+
+    void setCameraNavigationMode( QgsCameraController::NavigationMode navigationMode );
+%Docstring
+Sets the navigation mode for the camera
+
+.. versionadded:: 3.18
+%End
+
     void setOutputDpi( const double dpi );
 %Docstring
 Sets DPI used for conversion between real world units (e.g. mm) and pixels
@@ -782,6 +796,13 @@ Emitted when the camera lens field of view changes
     void projectionTypeChanged();
 %Docstring
 Emitted when the camera lens projection type changes
+
+.. versionadded:: 3.18
+%End
+
+    void cameraNavigationModeChanged();
+%Docstring
+Emitted when the camera navigation mode was changed
 
 .. versionadded:: 3.18
 %End

--- a/python/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -568,6 +568,20 @@ Sets the navigation mode for the camera
 .. versionadded:: 3.18
 %End
 
+    double cameraMovementSpeed() const;
+%Docstring
+Returns the camera movement speed
+
+.. versionadded:: 3.18
+%End
+
+    void setCameraMovementSpeed( double movementSpeed );
+%Docstring
+Sets the camera movement speed
+
+.. versionadded:: 3.18
+%End
+
     void setOutputDpi( const double dpi );
 %Docstring
 Sets DPI used for conversion between real world units (e.g. mm) and pixels
@@ -803,6 +817,13 @@ Emitted when the camera lens projection type changes
     void cameraNavigationModeChanged();
 %Docstring
 Emitted when the camera navigation mode was changed
+
+.. versionadded:: 3.18
+%End
+
+    void cameraMovementSpeedChanged();
+%Docstring
+Emitted when the camera movement speed was changed
 
 .. versionadded:: 3.18
 %End

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -142,6 +142,7 @@ Qgs3DMapScene::Qgs3DMapScene( const Qgs3DMapSettings &map, QgsAbstract3DEngine *
   connect( &map, &Qgs3DMapSettings::debugShadowMapSettingsChanged, this, &Qgs3DMapScene::onDebugShadowMapSettingsChanged );
   connect( &map, &Qgs3DMapSettings::debugDepthMapSettingsChanged, this, &Qgs3DMapScene::onDebugDepthMapSettingsChanged );
   connect( &map, &Qgs3DMapSettings::fpsCounterEnabledChanged, this, &Qgs3DMapScene::fpsCounterEnabledChanged );
+  connect( &map, &Qgs3DMapSettings::cameraNavigationModeChanged, this, &Qgs3DMapScene::onCameraNavigationModeChanged );
 
   connect( QgsApplication::instance()->sourceCache(), &QgsSourceCache::remoteSourceFetched, this, [ = ]( const QString & url )
   {
@@ -230,6 +231,8 @@ Qgs3DMapScene::Qgs3DMapScene( const Qgs3DMapSettings &map, QgsAbstract3DEngine *
   // force initial update of debugging setting of preview quads
   onDebugShadowMapSettingsChanged();
   onDebugDepthMapSettingsChanged();
+
+  onCameraNavigationModeChanged();
 }
 
 void Qgs3DMapScene::viewZoomFull()
@@ -1053,6 +1056,11 @@ void Qgs3DMapScene::onEyeDomeShadingSettingsChanged()
   double edlStrength = mMap.eyeDomeLightingStrength();
   double edlDistance = mMap.eyeDomeLightingDistance();
   shadowRenderingFrameGraph->setupEyeDomeLighting( edlEnabled, edlStrength, edlDistance );
+}
+
+void Qgs3DMapScene::onCameraNavigationModeChanged()
+{
+  mCameraController->setCameraNavigationMode( mMap.cameraNavigationMode() );
 }
 
 void Qgs3DMapScene::exportScene( const Qgs3DMapExportSettings &exportSettings )

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -142,7 +142,6 @@ Qgs3DMapScene::Qgs3DMapScene( const Qgs3DMapSettings &map, QgsAbstract3DEngine *
   connect( &map, &Qgs3DMapSettings::debugShadowMapSettingsChanged, this, &Qgs3DMapScene::onDebugShadowMapSettingsChanged );
   connect( &map, &Qgs3DMapSettings::debugDepthMapSettingsChanged, this, &Qgs3DMapScene::onDebugDepthMapSettingsChanged );
   connect( &map, &Qgs3DMapSettings::fpsCounterEnabledChanged, this, &Qgs3DMapScene::fpsCounterEnabledChanged );
-  connect( &map, &Qgs3DMapSettings::cameraNavigationModeChanged, this, &Qgs3DMapScene::onCameraNavigationModeChanged );
   connect( &map, &Qgs3DMapSettings::cameraMovementSpeedChanged, this, &Qgs3DMapScene::onCameraMovementSpeedChanged );
 
   connect( QgsApplication::instance()->sourceCache(), &QgsSourceCache::remoteSourceFetched, this, [ = ]( const QString & url )
@@ -197,6 +196,7 @@ Qgs3DMapScene::Qgs3DMapScene( const Qgs3DMapSettings &map, QgsAbstract3DEngine *
 
   connect( mCameraController, &QgsCameraController::cameraChanged, this, &Qgs3DMapScene::onCameraChanged );
   connect( mCameraController, &QgsCameraController::viewportChanged, this, &Qgs3DMapScene::onCameraChanged );
+  connect( mCameraController, &QgsCameraController::navigationModeHotKeyPressed, this, &Qgs3DMapScene::navigationModeHotKeyPressed );
 
 #if 0
   // experiments with loading of existing 3D models.
@@ -233,7 +233,7 @@ Qgs3DMapScene::Qgs3DMapScene( const Qgs3DMapSettings &map, QgsAbstract3DEngine *
   onDebugShadowMapSettingsChanged();
   onDebugDepthMapSettingsChanged();
 
-  onCameraNavigationModeChanged();
+  mCameraController->setCameraNavigationMode( mMap.cameraNavigationMode() );
   onCameraMovementSpeedChanged();
 }
 
@@ -1058,11 +1058,6 @@ void Qgs3DMapScene::onEyeDomeShadingSettingsChanged()
   double edlStrength = mMap.eyeDomeLightingStrength();
   double edlDistance = mMap.eyeDomeLightingDistance();
   shadowRenderingFrameGraph->setupEyeDomeLighting( edlEnabled, edlStrength, edlDistance );
-}
-
-void Qgs3DMapScene::onCameraNavigationModeChanged()
-{
-  mCameraController->setCameraNavigationMode( mMap.cameraNavigationMode() );
 }
 
 void Qgs3DMapScene::onCameraMovementSpeedChanged()

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -143,6 +143,7 @@ Qgs3DMapScene::Qgs3DMapScene( const Qgs3DMapSettings &map, QgsAbstract3DEngine *
   connect( &map, &Qgs3DMapSettings::debugDepthMapSettingsChanged, this, &Qgs3DMapScene::onDebugDepthMapSettingsChanged );
   connect( &map, &Qgs3DMapSettings::fpsCounterEnabledChanged, this, &Qgs3DMapScene::fpsCounterEnabledChanged );
   connect( &map, &Qgs3DMapSettings::cameraNavigationModeChanged, this, &Qgs3DMapScene::onCameraNavigationModeChanged );
+  connect( &map, &Qgs3DMapSettings::cameraMovementSpeedChanged, this, &Qgs3DMapScene::onCameraMovementSpeedChanged );
 
   connect( QgsApplication::instance()->sourceCache(), &QgsSourceCache::remoteSourceFetched, this, [ = ]( const QString & url )
   {
@@ -233,6 +234,7 @@ Qgs3DMapScene::Qgs3DMapScene( const Qgs3DMapSettings &map, QgsAbstract3DEngine *
   onDebugDepthMapSettingsChanged();
 
   onCameraNavigationModeChanged();
+  onCameraMovementSpeedChanged();
 }
 
 void Qgs3DMapScene::viewZoomFull()
@@ -1061,6 +1063,11 @@ void Qgs3DMapScene::onEyeDomeShadingSettingsChanged()
 void Qgs3DMapScene::onCameraNavigationModeChanged()
 {
   mCameraController->setCameraNavigationMode( mMap.cameraNavigationMode() );
+}
+
+void Qgs3DMapScene::onCameraMovementSpeedChanged()
+{
+  mCameraController->setCameraMovementSpeed( mMap.cameraMovementSpeed() );
 }
 
 void Qgs3DMapScene::exportScene( const Qgs3DMapExportSettings &exportSettings )

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -162,6 +162,7 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     void onDebugShadowMapSettingsChanged();
     void onDebugDepthMapSettingsChanged();
     void onCameraNavigationModeChanged();
+    void onCameraMovementSpeedChanged();
 
   private:
     void addLayerEntity( QgsMapLayer *layer );

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -161,6 +161,7 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     void onEyeDomeShadingSettingsChanged();
     void onDebugShadowMapSettingsChanged();
     void onDebugDepthMapSettingsChanged();
+    void onCameraNavigationModeChanged();
 
   private:
     void addLayerEntity( QgsMapLayer *layer );

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -23,6 +23,7 @@
 #include "qgsfeatureid.h"
 #include "qgsshadowrenderingframegraph.h"
 #include "qgsray3d.h"
+#include "qgscameracontroller.h"
 
 namespace Qt3DRender
 {
@@ -46,7 +47,6 @@ namespace Qt3DExtras
 class QgsAbstract3DEngine;
 class QgsAbstract3DRenderer;
 class QgsMapLayer;
-class QgsCameraController;
 class Qgs3DMapScenePickHandler;
 class Qgs3DMapSettings;
 class QgsTerrainEntity;
@@ -139,6 +139,8 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     void fpsCountChanged( float fpsCount );
     //! Emitted when the FPS counter is activated or deactivated
     void fpsCounterEnabledChanged( bool fpsCounterEnabled );
+    //! Emitted when the navigation mode is changed using the hotkey ctrl + ~
+    void navigationModeHotKeyPressed( QgsCameraController::NavigationMode mode );
 
   public slots:
     //! Updates the temporale entities
@@ -161,7 +163,6 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     void onEyeDomeShadingSettingsChanged();
     void onDebugShadowMapSettingsChanged();
     void onDebugDepthMapSettingsChanged();
-    void onCameraNavigationModeChanged();
     void onCameraMovementSpeedChanged();
 
   private:

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -55,6 +55,8 @@ Qgs3DMapSettings::Qgs3DMapSettings( const Qgs3DMapSettings &other )
   , mDirectionalLights( other.mDirectionalLights )
   , mFieldOfView( other.mFieldOfView )
   , mProjectionType( other.mProjectionType )
+  , mCameraNavigationMode( other.mCameraNavigationMode )
+  , mCameraMovementSpeed( other.mCameraMovementSpeed )
   , mLayers( other.mLayers )
   , mTerrainLayers( other.mTerrainLayers )
   , mRenderers() // initialized in body
@@ -105,6 +107,7 @@ void Qgs3DMapSettings::readXml( const QDomElement &elem, const QgsReadWriteConte
       mCameraNavigationMode = QgsCameraController::NavigationMode::BasicNavigation;
     else if ( cameraNavigationMode == QStringLiteral( "fps-navigation" ) )
       mCameraNavigationMode = QgsCameraController::NavigationMode::FPSNavigation;
+    mCameraMovementSpeed = elemCamera.attribute( QStringLiteral( "camera-movement-speed" ), QStringLiteral( "5.0" ) ).toDouble();
   }
 
   QDomElement elemColor = elem.firstChildElement( QStringLiteral( "color" ) );
@@ -298,10 +301,16 @@ QDomElement Qgs3DMapSettings::writeXml( QDomDocument &doc, const QgsReadWriteCon
   QDomElement elemCamera = doc.createElement( QStringLiteral( "camera" ) );
   elemCamera.setAttribute( QStringLiteral( "field-of-view" ), mFieldOfView );
   elemCamera.setAttribute( QStringLiteral( "projection-type" ), static_cast< int >( mProjectionType ) );
-  if ( mCameraNavigationMode == QgsCameraController::BasicNavigation )
-    elemCamera.setAttribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "basic-navigation" ) );
-  else if ( mCameraNavigationMode == QgsCameraController::FPSNavigation )
-    elemCamera.setAttribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "fps-navigation" ) );
+  switch ( mCameraNavigationMode )
+  {
+    case QgsCameraController::BasicNavigation:
+      elemCamera.setAttribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "basic-navigation" ) );
+      break;
+    case QgsCameraController::FPSNavigation:
+      elemCamera.setAttribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "fps-navigation" ) );
+      break;
+  }
+  elemCamera.setAttribute( QStringLiteral( "camera-movement-speed" ), mCameraMovementSpeed );
   elem.appendChild( elemCamera );
 
   QDomElement elemColor = doc.createElement( QStringLiteral( "color" ) );
@@ -773,6 +782,15 @@ void Qgs3DMapSettings::setCameraNavigationMode( QgsCameraController::NavigationM
 
   mCameraNavigationMode = navigationMode;
   emit cameraNavigationModeChanged();
+}
+
+void Qgs3DMapSettings::setCameraMovementSpeed( double movementSpeed )
+{
+  if ( mCameraMovementSpeed == movementSpeed )
+    return;
+
+  mCameraMovementSpeed = movementSpeed;
+  emit cameraMovementSpeedChanged();
 }
 
 void Qgs3DMapSettings::setSkyboxSettings( const QgsSkyboxSettings &skyboxSettings )

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -103,10 +103,10 @@ void Qgs3DMapSettings::readXml( const QDomElement &elem, const QgsReadWriteConte
     mFieldOfView = elemCamera.attribute( QStringLiteral( "field-of-view" ), QStringLiteral( "45" ) ).toFloat();
     mProjectionType = static_cast< Qt3DRender::QCameraLens::ProjectionType >( elemCamera.attribute( QStringLiteral( "projection-type" ), QStringLiteral( "1" ) ).toInt() );
     QString cameraNavigationMode = elemCamera.attribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "basic-navigation" ) );
-    if ( cameraNavigationMode == QStringLiteral( "basic-navigation" ) )
-      mCameraNavigationMode = QgsCameraController::NavigationMode::BasicNavigation;
-    else if ( cameraNavigationMode == QStringLiteral( "fps-navigation" ) )
-      mCameraNavigationMode = QgsCameraController::NavigationMode::FPSNavigation;
+    if ( cameraNavigationMode == QStringLiteral( "terrain-based-navigation" ) )
+      mCameraNavigationMode = QgsCameraController::NavigationMode::TerrainBasedNavigation;
+    else if ( cameraNavigationMode == QStringLiteral( "fly-navigation" ) )
+      mCameraNavigationMode = QgsCameraController::NavigationMode::FlyNavigation;
     mCameraMovementSpeed = elemCamera.attribute( QStringLiteral( "camera-movement-speed" ), QStringLiteral( "5.0" ) ).toDouble();
   }
 
@@ -303,11 +303,11 @@ QDomElement Qgs3DMapSettings::writeXml( QDomDocument &doc, const QgsReadWriteCon
   elemCamera.setAttribute( QStringLiteral( "projection-type" ), static_cast< int >( mProjectionType ) );
   switch ( mCameraNavigationMode )
   {
-    case QgsCameraController::BasicNavigation:
-      elemCamera.setAttribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "basic-navigation" ) );
+    case QgsCameraController::TerrainBasedNavigation:
+      elemCamera.setAttribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "terrain-based-navigation" ) );
       break;
-    case QgsCameraController::FPSNavigation:
-      elemCamera.setAttribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "fps-navigation" ) );
+    case QgsCameraController::FlyNavigation:
+      elemCamera.setAttribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "fly-navigation" ) );
       break;
   }
   elemCamera.setAttribute( QStringLiteral( "camera-movement-speed" ), mCameraMovementSpeed );

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -100,6 +100,11 @@ void Qgs3DMapSettings::readXml( const QDomElement &elem, const QgsReadWriteConte
   {
     mFieldOfView = elemCamera.attribute( QStringLiteral( "field-of-view" ), QStringLiteral( "45" ) ).toFloat();
     mProjectionType = static_cast< Qt3DRender::QCameraLens::ProjectionType >( elemCamera.attribute( QStringLiteral( "projection-type" ), QStringLiteral( "1" ) ).toInt() );
+    QString cameraNavigationMode = elemCamera.attribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "basic-navigation" ) );
+    if ( cameraNavigationMode == QStringLiteral( "basic-navigation" ) )
+      mCameraNavigationMode = QgsCameraController::NavigationMode::BasicNavigation;
+    else if ( cameraNavigationMode == QStringLiteral( "fps-navigation" ) )
+      mCameraNavigationMode = QgsCameraController::NavigationMode::FPSNavigation;
   }
 
   QDomElement elemColor = elem.firstChildElement( QStringLiteral( "color" ) );
@@ -293,6 +298,10 @@ QDomElement Qgs3DMapSettings::writeXml( QDomDocument &doc, const QgsReadWriteCon
   QDomElement elemCamera = doc.createElement( QStringLiteral( "camera" ) );
   elemCamera.setAttribute( QStringLiteral( "field-of-view" ), mFieldOfView );
   elemCamera.setAttribute( QStringLiteral( "projection-type" ), static_cast< int >( mProjectionType ) );
+  if ( mCameraNavigationMode == QgsCameraController::BasicNavigation )
+    elemCamera.setAttribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "basic-navigation" ) );
+  else if ( mCameraNavigationMode == QgsCameraController::FPSNavigation )
+    elemCamera.setAttribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "fps-navigation" ) );
   elem.appendChild( elemCamera );
 
   QDomElement elemColor = doc.createElement( QStringLiteral( "color" ) );
@@ -755,6 +764,15 @@ void Qgs3DMapSettings::setProjectionType( const Qt3DRender::QCameraLens::Project
 
   mProjectionType = projectionType;
   emit projectionTypeChanged();
+}
+
+void Qgs3DMapSettings::setCameraNavigationMode( QgsCameraController::NavigationMode navigationMode )
+{
+  if ( mCameraNavigationMode == navigationMode )
+    return;
+
+  mCameraNavigationMode = navigationMode;
+  emit cameraNavigationModeChanged();
 }
 
 void Qgs3DMapSettings::setSkyboxSettings( const QgsSkyboxSettings &skyboxSettings )

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -33,6 +33,7 @@
 #include "qgsvector3d.h"
 #include "qgsskyboxsettings.h"
 #include "qgsshadowsettings.h"
+#include "qgscameracontroller.h"
 
 class QgsMapLayer;
 class QgsRasterLayer;
@@ -477,6 +478,18 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     void setProjectionType( const Qt3DRender::QCameraLens::ProjectionType projectionType ) SIP_SKIP;
 
     /**
+     * Returns the navigation mode used by the camera
+     * \since QGIS 3.18
+     */
+    QgsCameraController::NavigationMode cameraNavigationMode() const { return mCameraNavigationMode; }
+
+    /**
+     * Sets the navigation mode for the camera
+     * \since QGIS 3.18
+     */
+    void setCameraNavigationMode( QgsCameraController::NavigationMode navigationMode );
+
+    /**
      * Sets DPI used for conversion between real world units (e.g. mm) and pixels
      * \param dpi the number of dot per inch
      * \since QGIS 3.10
@@ -679,6 +692,12 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     void projectionTypeChanged();
 
     /**
+     * Emitted when the camera navigation mode was changed
+     * \since QGIS 3.18
+     */
+    void cameraNavigationModeChanged();
+
+    /**
      * Emitted when skybox settings are changed
      * \since QGIS 3.16
      */
@@ -726,6 +745,7 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     QList<QgsDirectionalLightSettings> mDirectionalLights;  //!< List of directional lights defined for the scene
     float mFieldOfView = 45.0f; //<! Camera lens field of view value
     Qt3DRender::QCameraLens::ProjectionType mProjectionType = Qt3DRender::QCameraLens::PerspectiveProjection;  //<! Camera lens projection type
+    QgsCameraController::NavigationMode mCameraNavigationMode = QgsCameraController::NavigationMode::BasicNavigation;
     QList<QgsMapLayerRef> mLayers;   //!< Layers to be rendered
     QList<QgsMapLayerRef> mTerrainLayers;   //!< Terrain layers to be rendered
     QList<QgsAbstract3DRenderer *> mRenderers;  //!< Extra stuff to render as 3D object

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -477,6 +477,8 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
      */
     void setProjectionType( const Qt3DRender::QCameraLens::ProjectionType projectionType ) SIP_SKIP;
 
+#ifndef SIP_RUN
+
     /**
      * Returns the navigation mode used by the camera
      * \since QGIS 3.18
@@ -488,6 +490,7 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
      * \since QGIS 3.18
      */
     void setCameraNavigationMode( QgsCameraController::NavigationMode navigationMode );
+#endif
 
     /**
      * Returns the camera movement speed

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -763,7 +763,7 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     QList<QgsDirectionalLightSettings> mDirectionalLights;  //!< List of directional lights defined for the scene
     float mFieldOfView = 45.0f; //<! Camera lens field of view value
     Qt3DRender::QCameraLens::ProjectionType mProjectionType = Qt3DRender::QCameraLens::PerspectiveProjection;  //<! Camera lens projection type
-    QgsCameraController::NavigationMode mCameraNavigationMode = QgsCameraController::NavigationMode::BasicNavigation;
+    QgsCameraController::NavigationMode mCameraNavigationMode = QgsCameraController::NavigationMode::TerrainBasedNavigation;
     double mCameraMovementSpeed = 5.0;
     QList<QgsMapLayerRef> mLayers;   //!< Layers to be rendered
     QList<QgsMapLayerRef> mTerrainLayers;   //!< Terrain layers to be rendered

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -490,6 +490,18 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     void setCameraNavigationMode( QgsCameraController::NavigationMode navigationMode );
 
     /**
+     * Returns the camera movement speed
+     * \since QGIS 3.18
+     */
+    double cameraMovementSpeed() const { return mCameraMovementSpeed; }
+
+    /**
+     * Sets the camera movement speed
+     * \since QGIS 3.18
+     */
+    void setCameraMovementSpeed( double movementSpeed );
+
+    /**
      * Sets DPI used for conversion between real world units (e.g. mm) and pixels
      * \param dpi the number of dot per inch
      * \since QGIS 3.10
@@ -698,6 +710,12 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     void cameraNavigationModeChanged();
 
     /**
+     * Emitted when the camera movement speed was changed
+     * \since QGIS 3.18
+     */
+    void cameraMovementSpeedChanged();
+
+    /**
      * Emitted when skybox settings are changed
      * \since QGIS 3.16
      */
@@ -746,6 +764,7 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     float mFieldOfView = 45.0f; //<! Camera lens field of view value
     Qt3DRender::QCameraLens::ProjectionType mProjectionType = Qt3DRender::QCameraLens::PerspectiveProjection;  //<! Camera lens projection type
     QgsCameraController::NavigationMode mCameraNavigationMode = QgsCameraController::NavigationMode::BasicNavigation;
+    double mCameraMovementSpeed = 5.0;
     QList<QgsMapLayerRef> mLayers;   //!< Layers to be rendered
     QList<QgsMapLayerRef> mTerrainLayers;   //!< Terrain layers to be rendered
     QList<QgsAbstract3DRenderer *> mRenderers;  //!< Extra stuff to render as 3D object

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -520,11 +520,11 @@ void QgsCameraController::onKeyPressedFlyNavigation( Qt3DInput::QKeyEvent *event
 
     case Qt::Key_PageUp:
     case Qt::Key_Q:
-      cameraPosDiff = mCameraMovementSpeed * cameraUp;
+      cameraPosDiff = mCameraMovementSpeed * QVector3D( 0.0f, 1.0f, 0.0f );
       break;
     case Qt::Key_PageDown:
     case Qt::Key_E:
-      cameraPosDiff = - mCameraMovementSpeed * cameraUp;
+      cameraPosDiff = - mCameraMovementSpeed * QVector3D( 0.0f, 1.0f, 0.0f );
       break;
   }
 

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -551,13 +551,13 @@ void QgsCameraController::onKeyPressedFlyNavigation()
     cameraPosDiff += - mCameraMovementSpeed * cameraFront;
   }
 
-  if ( mDepressedKeys.contains( Qt::Key_PageUp ) || mDepressedKeys.contains( Qt::Key_Q ) )
+  if ( mDepressedKeys.contains( Qt::Key_PageUp ) || mDepressedKeys.contains( Qt::Key_E ) )
   {
     changed = true;
     cameraPosDiff += mCameraMovementSpeed * QVector3D( 0.0f, 1.0f, 0.0f );
   }
 
-  if ( mDepressedKeys.contains( Qt::Key_PageDown ) || mDepressedKeys.contains( Qt::Key_E ) )
+  if ( mDepressedKeys.contains( Qt::Key_PageDown ) || mDepressedKeys.contains( Qt::Key_Q ) )
   {
     changed = true;
     cameraPosDiff += - mCameraMovementSpeed * QVector3D( 0.0f, 1.0f, 0.0f );

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -65,6 +65,11 @@ void QgsCameraController::setCameraNavigationMode( QgsCameraController::Navigati
   mCameraNavigationMode = navigationMode;
 }
 
+void QgsCameraController::setCameraMovementSpeed( double movementSpeed )
+{
+  mCameraMovementSpeed = movementSpeed;
+}
+
 void QgsCameraController::setTerrainEntity( QgsTerrainEntity *te )
 {
   mTerrainEntity = te;
@@ -492,35 +497,34 @@ void QgsCameraController::onKeyPressedFPSNavigation( Qt3DInput::QKeyEvent *event
   QVector3D cameraLeft = QVector3D::crossProduct( cameraUp, cameraFront );
 
   QVector3D cameraPosDiff( 0.0f, 0.0f, 0.0f );
-  float movementSpeed = 5.0f;
 
   switch ( event->key() )
   {
     case Qt::Key_Left:
     case Qt::Key_A:
-      cameraPosDiff = movementSpeed * cameraLeft;
+      cameraPosDiff = mCameraMovementSpeed * cameraLeft;
       break;
     case Qt::Key_Right:
     case Qt::Key_D:
-      cameraPosDiff = - movementSpeed * cameraLeft;
+      cameraPosDiff = - mCameraMovementSpeed * cameraLeft;
       break;
 
     case Qt::Key_Up:
     case Qt::Key_W:
-      cameraPosDiff = movementSpeed * cameraFront;
+      cameraPosDiff = mCameraMovementSpeed * cameraFront;
       break;
     case Qt::Key_Down:
     case Qt::Key_S:
-      cameraPosDiff = - movementSpeed * cameraFront;
+      cameraPosDiff = - mCameraMovementSpeed * cameraFront;
       break;
 
     case Qt::Key_PageUp:
     case Qt::Key_Q:
-      cameraPosDiff = movementSpeed * cameraUp;
+      cameraPosDiff = mCameraMovementSpeed * cameraUp;
       break;
     case Qt::Key_PageDown:
     case Qt::Key_E:
-      cameraPosDiff = - movementSpeed * cameraUp;
+      cameraPosDiff = - mCameraMovementSpeed * cameraUp;
       break;
   }
 

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -454,6 +454,8 @@ void QgsCameraController::onKeyPressed( Qt3DInput::QKeyEvent *event )
     if ( event->isAutoRepeat() )
       return;
 
+    event->setAccepted( true );
+
     mDepressedKeys.insert( event->key() );
     onKeyPressedFlyNavigation();
     return;
@@ -597,14 +599,7 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
     moveCameraPositionBy( 5.0 * mCameraMovementSpeed * cameraPosDiff );
   }
 
-  if ( mCaptureFpsMouseMovements )
-  {
-    QCursor::setPos( QCursor::pos().x() - dx, QCursor::pos().y() - dy );
-  }
-  else
-  {
-    mMousePos = QPoint( mouse->x(), mouse->y() );
-  }
+  mMousePos = QPoint( mouse->x(), mouse->y() );
 }
 
 void QgsCameraController::onKeyReleased( Qt3DInput::QKeyEvent *event )

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -454,8 +454,6 @@ void QgsCameraController::onKeyPressed( Qt3DInput::QKeyEvent *event )
     if ( event->isAutoRepeat() )
       return;
 
-    event->setAccepted( true );
-
     mDepressedKeys.insert( event->key() );
     onKeyPressedFlyNavigation();
     return;
@@ -574,6 +572,28 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
   if ( !mMousePressed && !mCaptureFpsMouseMovements )
     return;
 
+  if ( mCaptureFpsMouseMovements )
+  {
+    if ( mIgnoreNextMouseMove )
+    {
+      mIgnoreNextMouseMove = false;
+      return;
+    }
+    double dx = QCursor::pos().x() - mMousePos.x();
+    double dy = QCursor::pos().y() - mMousePos.y();
+    if ( mCaptureFpsMouseMovements && mPressedButton != Qt3DInput::QMouseEvent::RightButton )
+    {
+      float diffPitch = ( mCaptureFpsMouseMovements ? -1 : 1 ) * 0.2f * dy;
+      float diffYaw = - 0.2f * dx;
+      rotateCamera( diffPitch, diffYaw );
+      updateCameraFromPose( false );
+    }
+    mIgnoreNextMouseMove = true;
+    QCursor::setPos( mViewport.width(), mViewport.height() );
+    mMousePos = QCursor::pos();
+    return;
+  }
+
   if ( mIgnoreNextMouseMove )
   {
     mMousePos = QPoint( mouse->x(), mouse->y() );
@@ -583,7 +603,7 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
 
   double dx = mouse->x() - mMousePos.x();
   double dy = mouse->y() - mMousePos.y();
-  if ( mPressedButton ==  Qt3DInput::QMouseEvent::LeftButton || mPressedButton ==  Qt3DInput::QMouseEvent::MiddleButton || ( mCaptureFpsMouseMovements && mPressedButton != Qt3DInput::QMouseEvent::RightButton ) )
+  if ( mPressedButton ==  Qt3DInput::QMouseEvent::LeftButton || mPressedButton ==  Qt3DInput::QMouseEvent::MiddleButton )
   {
     float diffPitch = ( mCaptureFpsMouseMovements ? -1 : 1 ) * 0.2f * dy;
     float diffYaw = - 0.2f * dx;

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -436,9 +436,15 @@ void QgsCameraController::onKeyPressed( Qt3DInput::QKeyEvent *event )
     {
       mCaptureFpsMouseMovements = !mCaptureFpsMouseMovements;
       if ( mCaptureFpsMouseMovements )
+      {
+        mIgnoreNextMouseMove = true;
         qApp->setOverrideCursor( QCursor( Qt::BlankCursor ) );
+      }
       else
+      {
+        mIgnoreNextMouseMove = false;
         qApp->restoreOverrideCursor();
+      }
       return;
     }
   }
@@ -565,6 +571,13 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
 {
   if ( !mMousePressed && !mCaptureFpsMouseMovements )
     return;
+
+  if ( mIgnoreNextMouseMove )
+  {
+    mMousePos = QPoint( mouse->x(), mouse->y() );
+    mIgnoreNextMouseMove = false;
+    return;
+  }
 
   double dx = mouse->x() - mMousePos.x();
   double dy = mouse->y() - mMousePos.y();

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -430,6 +430,19 @@ void QgsCameraController::onMouseReleased( Qt3DInput::QMouseEvent *mouse )
 
 void QgsCameraController::onKeyPressed( Qt3DInput::QKeyEvent *event )
 {
+  if ( event->key() == Qt::Key_QuoteLeft )
+  {
+    if ( mCameraNavigationMode == NavigationMode::FlyNavigation )
+    {
+      mCaptureFpsMouseMovements = !mCaptureFpsMouseMovements;
+      if ( mCaptureFpsMouseMovements )
+        qApp->setOverrideCursor( QCursor( Qt::BlankCursor ) );
+      else
+        qApp->restoreOverrideCursor();
+      return;
+    }
+  }
+
   if ( mCameraNavigationMode == NavigationMode::FlyNavigation )
   {
     if ( event->isAutoRepeat() )
@@ -550,11 +563,12 @@ void QgsCameraController::onKeyPressedFlyNavigation()
 
 void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent *mouse )
 {
-  if ( !mMousePressed )
+  if ( !mMousePressed && !mCaptureFpsMouseMovements )
     return;
+
   double dx = mouse->x() - mMousePos.x();
   double dy = mouse->y() - mMousePos.y();
-  if ( mPressedButton ==  Qt3DInput::QMouseEvent::LeftButton || mPressedButton ==  Qt3DInput::QMouseEvent::MiddleButton )
+  if ( mPressedButton ==  Qt3DInput::QMouseEvent::LeftButton || mPressedButton ==  Qt3DInput::QMouseEvent::MiddleButton || ( mCaptureFpsMouseMovements && mPressedButton != Qt3DInput::QMouseEvent::RightButton ) )
   {
     float diffPitch = 0.2f * dy;
     float diffYaw = - 0.2f * dx;
@@ -570,7 +584,14 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
     moveCameraPositionBy( 5.0 * mCameraMovementSpeed * cameraPosDiff );
   }
 
-  mMousePos = QPoint( mouse->x(), mouse->y() );
+  if ( mCaptureFpsMouseMovements )
+  {
+    QCursor::setPos( QCursor::pos().x() - dx, QCursor::pos().y() - dy );
+  }
+  else
+  {
+    mMousePos = QPoint( mouse->x(), mouse->y() );
+  }
 }
 
 void QgsCameraController::onKeyReleased( Qt3DInput::QKeyEvent *event )

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -319,9 +319,9 @@ void QgsCameraController::moveCameraPositionBy( const QVector3D &posDiff )
 
 void QgsCameraController::onPositionChanged( Qt3DInput::QMouseEvent *mouse )
 {
-  if ( mCameraNavigationMode == FPSNavigation )
+  if ( mCameraNavigationMode == NavigationMode::FlyNavigation )
   {
-    onPositionChangedFPSNavigation( mouse );
+    onPositionChangedFlyNavigation( mouse );
     return;
   }
   int dx = mouse->x() - mMousePos.x();
@@ -375,7 +375,7 @@ void QgsCameraController::onPositionChanged( Qt3DInput::QMouseEvent *mouse )
   mMousePos = QPoint( mouse->x(), mouse->y() );
 }
 
-void QgsCameraController::onPositionChangedFPSNavigation( Qt3DInput::QMouseEvent *mouse )
+void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent *mouse )
 {
   if ( !mMousePressed )
     return;
@@ -425,9 +425,9 @@ void QgsCameraController::onMouseReleased( Qt3DInput::QMouseEvent *mouse )
 
 void QgsCameraController::onKeyPressed( Qt3DInput::QKeyEvent *event )
 {
-  if ( mCameraNavigationMode == NavigationMode::FPSNavigation )
+  if ( mCameraNavigationMode == NavigationMode::FlyNavigation )
   {
-    onKeyPressedFPSNavigation( event );
+    onKeyPressedFlyNavigation( event );
     return;
   }
 
@@ -490,7 +490,7 @@ void QgsCameraController::onKeyPressed( Qt3DInput::QKeyEvent *event )
   }
 }
 
-void QgsCameraController::onKeyPressedFPSNavigation( Qt3DInput::QKeyEvent *event )
+void QgsCameraController::onKeyPressedFlyNavigation( Qt3DInput::QKeyEvent *event )
 {
   QVector3D cameraUp = mCamera->upVector().normalized();
   QVector3D cameraFront = ( QVector3D( mCameraPose.centerPoint().x(), mCameraPose.centerPoint().y(), mCameraPose.centerPoint().z() ) - mCamera->position() ).normalized();

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -583,7 +583,7 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
   double dy = mouse->y() - mMousePos.y();
   if ( mPressedButton ==  Qt3DInput::QMouseEvent::LeftButton || mPressedButton ==  Qt3DInput::QMouseEvent::MiddleButton || ( mCaptureFpsMouseMovements && mPressedButton != Qt3DInput::QMouseEvent::RightButton ) )
   {
-    float diffPitch = 0.2f * dy;
+    float diffPitch = ( mCaptureFpsMouseMovements ? -1 : 1 ) * 0.2f * dy;
     float diffYaw = - 0.2f * dx;
     rotateCamera( diffPitch, diffYaw );
     updateCameraFromPose( false );

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -430,6 +430,24 @@ void QgsCameraController::onMouseReleased( Qt3DInput::QMouseEvent *mouse )
 
 void QgsCameraController::onKeyPressed( Qt3DInput::QKeyEvent *event )
 {
+  bool hasShift = ( event->modifiers() & Qt::ShiftModifier );
+  bool hasCtrl = ( event->modifiers() & Qt::ControlModifier );
+
+  if ( hasCtrl && event->key() == Qt::Key_QuoteLeft )
+  {
+    switch ( mCameraNavigationMode )
+    {
+      case NavigationMode::FlyNavigation:
+        mCameraNavigationMode = NavigationMode::TerrainBasedNavigation;
+        break;
+      case NavigationMode::TerrainBasedNavigation:
+        mCameraNavigationMode = NavigationMode::FlyNavigation;
+        break;
+    }
+    emit navigationModeHotKeyPressed( mCameraNavigationMode );
+    return;
+  }
+
   if ( event->key() == Qt::Key_QuoteLeft )
   {
     if ( mCameraNavigationMode == NavigationMode::FlyNavigation )
@@ -458,9 +476,6 @@ void QgsCameraController::onKeyPressed( Qt3DInput::QKeyEvent *event )
     onKeyPressedFlyNavigation();
     return;
   }
-
-  bool hasShift = ( event->modifiers() & Qt::ShiftModifier );
-  bool hasCtrl = ( event->modifiers() & Qt::ControlModifier );
 
   int tx = 0, ty = 0, tElev = 0;
   switch ( event->key() )

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -26,6 +26,7 @@
 #include <Qt3DRender/QPickEvent>
 #include <Qt3DInput>
 
+#include "qgslogger.h"
 
 QgsCameraController::QgsCameraController( Qt3DCore::QNode *parent )
   : Qt3DCore::QEntity( parent )
@@ -393,11 +394,19 @@ void QgsCameraController::zoom( float factor )
 
 void QgsCameraController::onWheel( Qt3DInput::QWheelEvent *wheel )
 {
-  float scaling = ( ( wheel->modifiers() & Qt::ControlModifier ) ? 0.1f : 1.0f ) / 1000.f;
-  float dist = mCameraPose.distanceFromCenterPoint();
-  dist -= dist * scaling * wheel->angleDelta().y();
-  mCameraPose.setDistanceFromCenterPoint( dist );
-  updateCameraFromPose();
+  if ( mCameraNavigationMode == QgsCameraController::FlyNavigation )
+  {
+    float scaling = ( ( wheel->modifiers() & Qt::ControlModifier ) ? 0.1f : 1.0f ) / 1000.f;
+    mCameraMovementSpeed += mCameraMovementSpeed * scaling * wheel->angleDelta().y();
+  }
+  else
+  {
+    float scaling = ( ( wheel->modifiers() & Qt::ControlModifier ) ? 0.1f : 1.0f ) / 1000.f;
+    float dist = mCameraPose.distanceFromCenterPoint();
+    dist -= dist * scaling * wheel->angleDelta().y();
+    mCameraPose.setDistanceFromCenterPoint( dist );
+    updateCameraFromPose();
+  }
 }
 
 void QgsCameraController::onMousePressed( Qt3DInput::QMouseEvent *mouse )

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -192,6 +192,8 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     void cameraChanged();
     //! Emitted when viewport rectangle has been updated
     void viewportChanged();
+    //! Emitted when the navigation mode is changed using the hotkey ctrl + ~
+    void navigationModeHotKeyPressed( QgsCameraController::NavigationMode mode );
 
   private slots:
     void onPositionChanged( Qt3DInput::QMouseEvent *mouse );

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -62,10 +62,11 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     Q_PROPERTY( Qt3DRender::QCamera *camera READ camera WRITE setCamera NOTIFY cameraChanged )
     Q_PROPERTY( QRect viewport READ viewport WRITE setViewport NOTIFY viewportChanged )
   public:
+    //! The navigation mode used by the camera
     enum NavigationMode
     {
-      BasicNavigation,
-      FPSNavigation
+      TerrainBasedNavigation, //! The default navigation based on the terrain
+      FlyNavigation //! uses WASD keys or arrows to navigate in flying manner
     };
 
   public:
@@ -201,8 +202,8 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     void onPickerMousePressed( Qt3DRender::QPickEvent *pick );
 
   private:
-    void onKeyPressedFPSNavigation( Qt3DInput::QKeyEvent *mouse );
-    void onPositionChangedFPSNavigation( Qt3DInput::QMouseEvent *mouse );
+    void onKeyPressedFlyNavigation( Qt3DInput::QKeyEvent *mouse );
+    void onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent *mouse );
 
   private:
     //! Camera that is being controlled
@@ -227,7 +228,7 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
 
     Qt3DInput::QMouseHandler *mMouseHandler = nullptr;
     Qt3DInput::QKeyboardHandler *mKeyboardHandler = nullptr;
-    NavigationMode mCameraNavigationMode = NavigationMode::BasicNavigation;
+    NavigationMode mCameraNavigationMode = NavigationMode::TerrainBasedNavigation;
     double mCameraMovementSpeed = 5.0;
 };
 

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -21,6 +21,7 @@
 #include <QPointer>
 #include <QRect>
 #include <Qt3DCore/QEntity>
+#include <Qt3DInput/QMouseEvent>
 
 namespace Qt3DInput
 {
@@ -221,6 +222,7 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     //! Last mouse position recorded
     QPoint mMousePos;
     bool mMousePressed = false;
+    Qt3DInput::QMouseEvent::Buttons mPressedButton = Qt3DInput::QMouseEvent::Buttons::NoButton;
 
     //! Delegates mouse events to the attached MouseHandler objects
     Qt3DInput::QMouseDevice *mMouseDevice = nullptr;

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -203,7 +203,7 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     void onPickerMousePressed( Qt3DRender::QPickEvent *pick );
 
   private:
-    void onKeyPressedFlyNavigation( Qt3DInput::QKeyEvent *mouse );
+    void onKeyPressedFlyNavigation();
     void onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent *mouse );
 
   private:
@@ -232,6 +232,9 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     Qt3DInput::QKeyboardHandler *mKeyboardHandler = nullptr;
     NavigationMode mCameraNavigationMode = NavigationMode::TerrainBasedNavigation;
     double mCameraMovementSpeed = 5.0;
+
+    QSet< int > mDepressedKeys;
+    QTimer *mFpsNavTimer = nullptr;
 };
 
 #endif // QGSCAMERACONTROLLER_H

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -235,6 +235,7 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
 
     QSet< int > mDepressedKeys;
     bool mCaptureFpsMouseMovements = false;
+    bool mIgnoreNextMouseMove = false;
     QTimer *mFpsNavTimer = nullptr;
 };
 

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -234,6 +234,7 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     double mCameraMovementSpeed = 5.0;
 
     QSet< int > mDepressedKeys;
+    bool mCaptureFpsMouseMovements = false;
     QTimer *mFpsNavTimer = nullptr;
 };
 

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -81,13 +81,25 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
      * Returns the nvigtion mode used by the camera controller
      * \since QGIS 3.18
      */
-    QgsCameraController::NavigationMode cameraNavigationMode() { return mCameraNavigationMode; }
+    QgsCameraController::NavigationMode cameraNavigationMode() const { return mCameraNavigationMode; }
 
     /**
      * Sets the nvigtion mode used by the camera controller
      * \since QGIS 3.18
      */
     void setCameraNavigationMode( QgsCameraController::NavigationMode navigationMode );
+
+    /**
+     * Returns the camera movement speed
+     * \since QGIS 3.18
+     */
+    double cameraMovementSpeed() const { return mCameraMovementSpeed; }
+
+    /**
+     * Sets the camera movement speed
+     * \since QGIS 3.18
+     */
+    void setCameraMovementSpeed( double movementSpeed );
 
     /**
      * Connects to object picker attached to terrain entity. Called internally from 3D scene.
@@ -216,9 +228,7 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     Qt3DInput::QMouseHandler *mMouseHandler = nullptr;
     Qt3DInput::QKeyboardHandler *mKeyboardHandler = nullptr;
     NavigationMode mCameraNavigationMode = NavigationMode::BasicNavigation;
-    double mDeltaTime = 0.0f;
-    QVector<double> mPastDeltaTime;
-    double mDeltaTimeAverage = 0.0f;
+    double mCameraMovementSpeed = 5.0;
 };
 
 #endif // QGSCAMERACONTROLLER_H

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -99,11 +99,13 @@ void Qgs3DMapCanvas::setMap( Qgs3DMapSettings *map )
   {
     disconnect( mScene, &Qgs3DMapScene::fpsCountChanged, this, &Qgs3DMapCanvas::fpsCountChanged );
     disconnect( mScene, &Qgs3DMapScene::fpsCounterEnabledChanged, this, &Qgs3DMapCanvas::fpsCounterEnabledChanged );
+    disconnect( mScene, &Qgs3DMapScene::navigationModeHotKeyPressed, this, &Qgs3DMapCanvas::onNavigationModeHotKeyPressed );
     mScene->deleteLater();
   }
   mScene = newScene;
   connect( mScene, &Qgs3DMapScene::fpsCountChanged, this, &Qgs3DMapCanvas::fpsCountChanged );
   connect( mScene, &Qgs3DMapScene::fpsCounterEnabledChanged, this, &Qgs3DMapCanvas::fpsCounterEnabledChanged );
+  connect( mScene, &Qgs3DMapScene::navigationModeHotKeyPressed, this, &Qgs3DMapCanvas::onNavigationModeHotKeyPressed );
 
   delete mMap;
   mMap = map;
@@ -259,4 +261,10 @@ void Qgs3DMapCanvas::updateTemporalRange( const QgsDateTimeRange &temporalrange 
 QSize Qgs3DMapCanvas::windowSize() const
 {
   return mEngine->size();
+}
+
+void Qgs3DMapCanvas::onNavigationModeHotKeyPressed( QgsCameraController::NavigationMode mode )
+{
+  mMap->setCameraNavigationMode( mode );
+  mScene->cameraController()->setCameraNavigationMode( mode );
 }

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -20,6 +20,7 @@
 #include <Qt3DRender/QRenderCapture>
 
 #include "qgsrange.h"
+#include "qgscameracontroller.h"
 
 namespace Qt3DExtras
 {
@@ -30,7 +31,6 @@ class Qgs3DMapSettings;
 class Qgs3DMapScene;
 class Qgs3DMapTool;
 class QgsWindow3DEngine;
-class QgsCameraController;
 class QgsPointXY;
 class Qgs3DNavigationWidget;
 class QgsTemporalController;
@@ -106,6 +106,7 @@ class Qgs3DMapCanvas : public QWidget
     void fpsCounterEnabledChanged( bool enabled );
   private slots:
     void updateTemporalRange( const QgsDateTimeRange &timeRange );
+    void onNavigationModeHotKeyPressed( QgsCameraController::NavigationMode mode );
 
   protected:
     void resizeEvent( QResizeEvent *ev ) override;

--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -307,7 +307,7 @@ void Qgs3DMapCanvasDockWidget::configure()
   QgsGui::instance()->enableAutoGeometryRestore( &dlg );
 
   Qgs3DMapSettings *map = mCanvas->map();
-  Qgs3DMapConfigWidget *w = new Qgs3DMapConfigWidget( map, mMainCanvas, &dlg );
+  Qgs3DMapConfigWidget *w = new Qgs3DMapConfigWidget( map, mMainCanvas, mCanvas, &dlg );
   QDialogButtonBox *buttons = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Apply | QDialogButtonBox::Cancel | QDialogButtonBox::Help, &dlg );
 
   auto applyConfig = [ = ]()

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -135,6 +135,7 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
   spinCameraFieldOfView->setValue( mMap->fieldOfView() );
   cboCameraProjectionType->setCurrentIndex( cboCameraProjectionType->findData( mMap->projectionType() ) );
   mCameraNavigationMode->setCurrentIndex( mMap->cameraNavigationMode() );
+  mCameraMovementSpeed->setValue( mMap->cameraMovementSpeed() );
   spinTerrainScale->setValue( mMap->terrainVerticalScale() );
   spinMapResolution->setValue( mMap->mapTileResolution() );
   spinScreenError->setValue( mMap->maxTerrainScreenError() );
@@ -319,6 +320,7 @@ void Qgs3DMapConfigWidget::apply()
   mMap->setFieldOfView( spinCameraFieldOfView->value() );
   mMap->setProjectionType( cboCameraProjectionType->currentData().value< Qt3DRender::QCameraLens::ProjectionType >() );
   mMap->setCameraNavigationMode( static_cast<QgsCameraController::NavigationMode>( mCameraNavigationMode->currentIndex() ) );
+  mMap->setCameraMovementSpeed( mCameraMovementSpeed->value() );
   mMap->setTerrainVerticalScale( spinTerrainScale->value() );
   mMap->setMapTileResolution( spinMapResolution->value() );
   mMap->setMaxTerrainScreenError( spinScreenError->value() );

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -134,6 +134,7 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
 
   spinCameraFieldOfView->setValue( mMap->fieldOfView() );
   cboCameraProjectionType->setCurrentIndex( cboCameraProjectionType->findData( mMap->projectionType() ) );
+  mCameraNavigationMode->setCurrentIndex( mMap->cameraNavigationMode() );
   spinTerrainScale->setValue( mMap->terrainVerticalScale() );
   spinMapResolution->setValue( mMap->mapTileResolution() );
   spinScreenError->setValue( mMap->maxTerrainScreenError() );
@@ -317,6 +318,7 @@ void Qgs3DMapConfigWidget::apply()
 
   mMap->setFieldOfView( spinCameraFieldOfView->value() );
   mMap->setProjectionType( cboCameraProjectionType->currentData().value< Qt3DRender::QCameraLens::ProjectionType >() );
+  mMap->setCameraNavigationMode( static_cast<QgsCameraController::NavigationMode>( mCameraNavigationMode->currentIndex() ) );
   mMap->setTerrainVerticalScale( spinTerrainScale->value() );
   mMap->setMapTileResolution( spinMapResolution->value() );
   mMap->setMaxTerrainScreenError( spinScreenError->value() );

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -36,10 +36,11 @@
 #include "qgs3dmapcanvas.h"
 #include "qgs3dmapscene.h"
 
-Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas *mainCanvas, QWidget *parent )
+Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas *mainCanvas, Qgs3DMapCanvas *mapCanvas3D, QWidget *parent )
   : QWidget( parent )
   , mMap( map )
   , mMainCanvas( mainCanvas )
+  , m3DMapCanvas( mapCanvas3D )
 {
   setupUi( this );
 
@@ -320,6 +321,7 @@ void Qgs3DMapConfigWidget::apply()
   mMap->setFieldOfView( spinCameraFieldOfView->value() );
   mMap->setProjectionType( cboCameraProjectionType->currentData().value< Qt3DRender::QCameraLens::ProjectionType >() );
   mMap->setCameraNavigationMode( static_cast<QgsCameraController::NavigationMode>( mCameraNavigationMode->currentIndex() ) );
+  m3DMapCanvas->scene()->cameraController()->setCameraNavigationMode( static_cast<QgsCameraController::NavigationMode>( mCameraNavigationMode->currentIndex() ) );
   mMap->setCameraMovementSpeed( mCameraMovementSpeed->value() );
   mMap->setTerrainVerticalScale( spinTerrainScale->value() );
   mMap->setMapTileResolution( spinMapResolution->value() );

--- a/src/app/3d/qgs3dmapconfigwidget.h
+++ b/src/app/3d/qgs3dmapconfigwidget.h
@@ -33,7 +33,7 @@ class Qgs3DMapConfigWidget : public QWidget, private Ui::Map3DConfigWidget
     Q_OBJECT
   public:
     //! construct widget. does not take ownership of the passed map.
-    explicit Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas *mainCanvas, QWidget *parent = nullptr );
+    explicit Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas *mainCanvas, Qgs3DMapCanvas *mapCanvas3D, QWidget *parent = nullptr );
 
     ~Qgs3DMapConfigWidget() override;
 

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -179,7 +179,7 @@
        <item>
         <widget class="QStackedWidget" name="m3DOptionsStackedWidget">
          <property name="currentIndex">
-          <number>0</number>
+          <number>3</number>
          </property>
          <widget class="QWidget" name="mPageTerrain">
           <layout class="QVBoxLayout" name="verticalLayout_61">
@@ -205,7 +205,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>709</width>
+                <width>704</width>
                 <height>604</height>
                </rect>
               </property>
@@ -410,7 +410,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>709</width>
+                <width>704</width>
                 <height>604</height>
                </rect>
               </property>
@@ -584,8 +584,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>201</width>
-                <height>161</height>
+                <width>704</width>
+                <height>604</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutCameraSkybox">
@@ -607,20 +607,20 @@
                   <string>Camera</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout">
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="labelCameraProjectionType">
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="labelFieldofView">
                     <property name="text">
-                     <string>Projection type</string>
+                     <string>Field of View</string>
                     </property>
                    </widget>
                   </item>
                   <item row="1" column="1" colspan="2">
                    <widget class="QComboBox" name="cboCameraProjectionType"/>
                   </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="label_3">
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="labelCameraProjectionType">
                     <property name="text">
-                     <string>Field of View</string>
+                     <string>Projection type</string>
                     </property>
                    </widget>
                   </item>
@@ -631,6 +631,27 @@
                     </property>
                     <property name="maximum">
                      <number>180</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="1" colspan="2">
+                   <widget class="QComboBox" name="mCameraNavigationMode">
+                    <item>
+                     <property name="text">
+                      <string>Basic navigation</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Fly navigation</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="labelCameraNavigationMode">
+                    <property name="text">
+                     <string>Navigation mode</string>
                     </property>
                    </widget>
                   </item>
@@ -694,7 +715,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>690</width>
+                <width>277</width>
                 <height>681</height>
                </rect>
               </property>

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -205,8 +205,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>704</width>
-                <height>604</height>
+                <width>309</width>
+                <height>292</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutTerrain">
@@ -410,8 +410,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>704</width>
-                <height>604</height>
+                <width>77</width>
+                <height>45</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutLight">
@@ -607,16 +607,6 @@
                   <string>Camera</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout">
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="labelFieldofView">
-                    <property name="text">
-                     <string>Field of View</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1" colspan="2">
-                   <widget class="QComboBox" name="cboCameraProjectionType"/>
-                  </item>
                   <item row="1" column="0">
                    <widget class="QLabel" name="labelCameraProjectionType">
                     <property name="text">
@@ -634,6 +624,23 @@
                     </property>
                    </widget>
                   </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="labelFieldofView">
+                    <property name="text">
+                     <string>Field of View</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1" colspan="2">
+                   <widget class="QComboBox" name="cboCameraProjectionType"/>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="labelCameraNavigationMode">
+                    <property name="text">
+                     <string>Navigation mode</string>
+                    </property>
+                   </widget>
+                  </item>
                   <item row="3" column="1" colspan="2">
                    <widget class="QComboBox" name="mCameraNavigationMode">
                     <item>
@@ -648,10 +655,23 @@
                     </item>
                    </widget>
                   </item>
-                  <item row="3" column="0">
-                   <widget class="QLabel" name="labelCameraNavigationMode">
+                  <item row="4" column="1" colspan="2">
+                   <widget class="QDoubleSpinBox" name="mCameraMovementSpeed">
+                    <property name="minimum">
+                     <double>0.010000000000000</double>
+                    </property>
+                    <property name="singleStep">
+                     <double>1.000000000000000</double>
+                    </property>
+                    <property name="value">
+                     <double>5.000000000000000</double>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="0">
+                   <widget class="QLabel" name="labelMovementSpeed">
                     <property name="text">
-                     <string>Navigation mode</string>
+                     <string>Movement speed</string>
                     </property>
                    </widget>
                   </item>

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -645,12 +645,12 @@
                    <widget class="QComboBox" name="mCameraNavigationMode">
                     <item>
                      <property name="text">
-                      <string>Basic navigation</string>
+                      <string>Terrain Based Navigation</string>
                      </property>
                     </item>
                     <item>
                      <property name="text">
-                      <string>Fly navigation</string>
+                      <string>Fly Navigation</string>
                      </property>
                     </item>
                    </widget>


### PR DESCRIPTION
## Description

This implements a new camera navigation mode with the WASD / arrow keys and the mouse to control the angles of the camera.
W / Up arrow : move forward 
S / Down arrow : move back
A / Left arrow : move left
D / right arrow : move right
Q / Page up : move up 
E / Page down : move down 

And the clicking and moving the camera cursor changes the angle of the camera

Any feedback is welcome

