### PR TITLE
Gdal algorithms can now be canceled, support progress reports

### DIFF
--- a/python/core/auto_generated/qgsrunprocess.sip.in
+++ b/python/core/auto_generated/qgsrunprocess.sip.in
@@ -121,6 +121,11 @@ The optional ``feedback`` argument can be used to specify a feedback object for 
 After execution completes, the process' result code will be returned.
 %End
 
+    QProcess::ExitStatus exitStatus() const;
+%Docstring
+After a call to :py:func:`~QgsBlockingProcess.run`, returns the process' exit status.
+%End
+
 };
 
 

--- a/python/plugins/processing/algs/gdal/GdalAlgorithm.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithm.py
@@ -63,9 +63,6 @@ class GdalAlgorithm(QgsProcessingAlgorithm):
     def createCustomParametersWidget(self, parent):
         return GdalAlgorithmDialog(self, parent=parent)
 
-    def flags(self):
-        return QgsProcessingAlgorithm.FlagSupportsBatch  # cannot cancel!
-
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
         return None
 

--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -254,7 +254,7 @@ class GdalUtils:
             if not isinstance(s, str):
                 s = str(s)
             if s and s[0] != '-' and any(c in s for c in escChars):
-                escaped = '"' + s.replace('\\', '\\\\').replace('"', '\\"') \
+                escaped = '"' + s.replace('\\', '\\\\').replace('"', '"""') \
                           + '"'
             else:
                 escaped = s

--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -105,6 +105,17 @@ class GdalUtils:
 
         def on_stdout(ba):
             val = ba.data().decode('UTF-8')
+            # catch progress reports
+            if val == '100 - done.':
+                on_stdout.progress = 100
+                feedback.setProgress(on_stdout.progress)
+            elif val in ('0', '10', '20', '30', '40', '50', '60', '70', '80', '90'):
+                on_stdout.progress = int(val)
+                feedback.setProgress(on_stdout.progress)
+            elif val == '.':
+                on_stdout.progress += 2.5
+                feedback.setProgress(on_stdout.progress)
+
             on_stdout.buffer += val
             if on_stdout.buffer.endswith('\n') or on_stdout.buffer.endswith('\r'):
                 # flush buffer
@@ -112,6 +123,7 @@ class GdalUtils:
                 loglines.append(on_stdout.buffer.rstrip())
                 on_stdout.buffer = ''
 
+        on_stdout.progress = 0
         on_stdout.buffer = ''
 
         def on_stderr(ba):

--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -97,8 +97,7 @@ class GdalUtils:
         success = False
         retry_count = 0
         while not success:
-            loglines = []
-            loglines.append(GdalUtils.tr('GDAL execution console output'))
+            loglines = [GdalUtils.tr('GDAL execution console output')]
             try:
                 with subprocess.Popen(
                     fused_command,
@@ -121,11 +120,7 @@ class GdalUtils:
                             len(loglines), u'\n'.join(loglines[-10:])))
 
             QgsMessageLog.logMessage('\n'.join(loglines), 'Processing', Qgis.Info)
-            GdalUtils.consoleOutput = loglines
-
-    @staticmethod
-    def getConsoleOutput():
-        return GdalUtils.consoleOutput
+        return loglines
 
     @staticmethod
     def getSupportedRasters():

--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -44,6 +44,9 @@ from qgis.core import (Qgis,
                        QgsDataSourceUri,
                        QgsProjUtils,
                        QgsCoordinateReferenceSystem)
+
+from qgis.PyQt.QtCore import QCoreApplication
+
 from processing.core.ProcessingConfig import ProcessingConfig
 from processing.tools.system import isWindows, isMac
 
@@ -88,14 +91,14 @@ class GdalUtils:
 
         fused_command = ' '.join([str(c) for c in commands])
         QgsMessageLog.logMessage(fused_command, 'Processing', Qgis.Info)
-        feedback.pushInfo('GDAL command:')
+        feedback.pushInfo(GdalUtils.tr('GDAL command:'))
         feedback.pushCommandInfo(fused_command)
-        feedback.pushInfo('GDAL command output:')
+        feedback.pushInfo(GdalUtils.tr('GDAL command output:'))
         success = False
         retry_count = 0
         while not success:
             loglines = []
-            loglines.append('GDAL execution console output')
+            loglines.append(GdalUtils.tr('GDAL execution console output'))
             try:
                 with subprocess.Popen(
                     fused_command,
@@ -444,3 +447,9 @@ class GdalUtils:
 
         # fallback to proj4 string, stripping out newline characters
         return crs.toProj().replace('\n', ' ').replace('\r', ' ')
+
+    @classmethod
+    def tr(cls, string, context=''):
+        if context == '':
+            context = cls.__name__
+        return QCoreApplication.translate(context, string)

--- a/python/plugins/processing/algs/gdal/gdalinfo.py
+++ b/python/plugins/processing/algs/gdal/gdalinfo.py
@@ -115,11 +115,11 @@ class gdalinfo(GdalAlgorithm):
         return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
 
     def processAlgorithm(self, parameters, context, feedback):
-        GdalUtils.runGdal(self.getConsoleCommands(parameters, context, feedback), feedback)
+        console_output = GdalUtils.runGdal(self.getConsoleCommands(parameters, context, feedback), feedback)
         output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
         with open(output, 'w') as f:
             f.write('<pre>')
-            for s in GdalUtils.getConsoleOutput()[1:]:
+            for s in console_output[1:]:
                 f.write(str(s))
             f.write('</pre>')
 

--- a/python/plugins/processing/algs/gdal/ogrinfo.py
+++ b/python/plugins/processing/algs/gdal/ogrinfo.py
@@ -85,11 +85,11 @@ class ogrinfo(GdalAlgorithm):
         return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
 
     def processAlgorithm(self, parameters, context, feedback):
-        GdalUtils.runGdal(self.getConsoleCommands(parameters, context, feedback), feedback)
+        console_output = GdalUtils.runGdal(self.getConsoleCommands(parameters, context, feedback), feedback)
         output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
         with open(output, 'w') as f:
             f.write('<pre>')
-            for s in GdalUtils.getConsoleOutput()[1:]:
+            for s in console_output[1:]:
                 f.write(str(s))
             f.write('</pre>')
 

--- a/python/plugins/processing/tests/GdalAlgorithmsVectorTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsVectorTest.py
@@ -158,7 +158,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_Buffer(geometry, 5.0) AS geometry,* FROM \\"polys2\\"" ' +
+                 '-dialect sqlite -sql "SELECT ST_Buffer(geometry, 5.0) AS geometry,* FROM """polys2"""" ' +
                  '-f "ESRI Shapefile"'])
 
             self.assertEqual(
@@ -169,7 +169,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_Union(ST_Buffer(geometry, 5.0)) AS geometry,* FROM \\"polys2\\"" ' +
+                 '-dialect sqlite -sql "SELECT ST_Union(ST_Buffer(geometry, 5.0)) AS geometry,* FROM """polys2"""" ' +
                  '-f "ESRI Shapefile"'])
 
             self.assertEqual(
@@ -180,7 +180,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_Buffer(geometry, 5.0) AS geometry,* FROM \\"polys2\\"" ' +
+                 '-dialect sqlite -sql "SELECT ST_Buffer(geometry, 5.0) AS geometry,* FROM """polys2"""" ' +
                  '-explodecollections -f "ESRI Shapefile"'])
 
             self.assertEqual(
@@ -192,7 +192,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_Union(ST_Buffer(geometry, 5.0)) AS geometry,* FROM \\"polys2\\" GROUP BY \\"total population\\"" ' +
+                 '-dialect sqlite -sql "SELECT ST_Union(ST_Buffer(geometry, 5.0)) AS geometry,* FROM """polys2""" GROUP BY """total population"""" ' +
                  '-explodecollections -f "ESRI Shapefile"'])
 
     def testDissolve(self):
@@ -210,7 +210,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry FROM \\"polys2\\"" ' +
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry FROM """polys2"""" ' +
                  '-f "ESRI Shapefile"'])
 
             self.assertEqual(
@@ -220,8 +220,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\" FROM \\"polys2\\" ' +
-                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, """my_field""" FROM """polys2""" ' +
+                 'GROUP BY """my_field"""" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -230,8 +230,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"total population\\" FROM \\"polys2\\" ' +
-                 'GROUP BY \\"total population\\"" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, """total population""" FROM """polys2""" ' +
+                 'GROUP BY """total population"""" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source_with_space,
@@ -240,8 +240,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  '"' + source_with_space + '" ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\" FROM \\"filename_with_spaces\\" ' +
-                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, """my_field""" FROM """filename_with_spaces""" ' +
+                 'GROUP BY """my_field"""" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -251,8 +251,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, \\"my_field\\" FROM \\"polys2\\" ' +
-                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, """my_field""" FROM """polys2""" ' +
+                 'GROUP BY """my_field"""" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -262,8 +262,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\" FROM \\"polys2\\" ' +
-                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, """my_field""" FROM """polys2""" ' +
+                 'GROUP BY """my_field"""" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -272,7 +272,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry FROM \\"polys2\\"" ' +
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry FROM """polys2"""" ' +
                  '-f "ESRI Shapefile"'])
 
             self.assertEqual(
@@ -283,8 +283,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\" FROM \\"polys2\\" ' +
-                 'GROUP BY \\"my_field\\"" -explodecollections -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, """my_field""" FROM """polys2""" ' +
+                 'GROUP BY """my_field"""" -explodecollections -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -294,8 +294,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\", COUNT(geometry) AS count FROM \\"polys2\\" ' +
-                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, """my_field""", COUNT(geometry) AS count FROM """polys2""" ' +
+                 'GROUP BY """my_field"""" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -306,8 +306,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, \\"my_field\\", COUNT(the_geom) AS count FROM \\"polys2\\" ' +
-                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, """my_field""", COUNT(the_geom) AS count FROM """polys2""" ' +
+                 'GROUP BY """my_field"""" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -317,9 +317,9 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\", SUM(ST_Area(geometry)) AS area, ' +
-                 'ST_Perimeter(ST_Union(geometry)) AS perimeter FROM \\"polys2\\" ' +
-                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, """my_field""", SUM(ST_Area(geometry)) AS area, ' +
+                 'ST_Perimeter(ST_Union(geometry)) AS perimeter FROM """polys2""" ' +
+                 'GROUP BY """my_field"""" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -330,9 +330,9 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, \\"my_field\\", SUM(ST_Area(the_geom)) AS area, ' +
-                 'ST_Perimeter(ST_Union(the_geom)) AS perimeter FROM \\"polys2\\" ' +
-                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, """my_field""", SUM(ST_Area(the_geom)) AS area, ' +
+                 'ST_Perimeter(ST_Union(the_geom)) AS perimeter FROM """polys2""" ' +
+                 'GROUP BY """my_field"""" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -343,9 +343,9 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\", ' +
-                 'SUM(\\"my_val\\") AS sum, MIN(\\"my_val\\") AS min, MAX(\\"my_val\\") AS max, AVG(\\"my_val\\") AS avg FROM \\"polys2\\" ' +
-                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, """my_field""", ' +
+                 'SUM("""my_val""") AS sum, MIN("""my_val""") AS min, MAX("""my_val""") AS max, AVG("""my_val""") AS avg FROM """polys2""" ' +
+                 'GROUP BY """my_field"""" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -356,10 +356,10 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"test field\\", ' +
-                 'SUM(\\"total population\\") AS sum, MIN(\\"total population\\") AS min, MAX(\\"total population\\") AS max, ' +
-                 'AVG(\\"total population\\") AS avg FROM \\"polys2\\" ' +
-                 'GROUP BY \\"test field\\"" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, """test field""", ' +
+                 'SUM("""total population""") AS sum, MIN("""total population""") AS min, MAX("""total population""") AS max, ' +
+                 'AVG("""total population""") AS avg FROM """polys2""" ' +
+                 'GROUP BY """test field"""" -f "ESRI Shapefile"'])
 
             # compute stats without stats attribute, and vice versa (should be ignored)
             self.assertEqual(
@@ -370,8 +370,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\" FROM \\"polys2\\" ' +
-                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, """my_field""" FROM """polys2""" ' +
+                 'GROUP BY """my_field"""" -f "ESRI Shapefile"'])
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
                                         'FIELD': 'my_field',
@@ -380,8 +380,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\" FROM \\"polys2\\" ' +
-                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, """my_field""" FROM """polys2""" ' +
+                 'GROUP BY """my_field"""" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -391,8 +391,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\" FROM \\"polys2\\" ' +
-                 'GROUP BY \\"my_field\\"" "my opts" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, """my_field""" FROM """polys2""" ' +
+                 'GROUP BY """my_field"""" "my opts" -f "ESRI Shapefile"'])
 
     def testOgr2PostGis(self):
         context = QgsProcessingContext()
@@ -749,7 +749,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_OffsetCurve(geometry, 5.0) AS geometry,* FROM \\"polys2\\"" ' +
+                 '-dialect sqlite -sql "SELECT ST_OffsetCurve(geometry, 5.0) AS geometry,* FROM """polys2"""" ' +
                  '-f "ESRI Shapefile"'])
 
     def testOneSidedBuffer(self):
@@ -768,7 +768,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_SingleSidedBuffer(geometry, 5.0, 0) AS geometry,* FROM \\"polys2\\"" ' +
+                 '-dialect sqlite -sql "SELECT ST_SingleSidedBuffer(geometry, 5.0, 0) AS geometry,* FROM """polys2"""" ' +
                  '-f "ESRI Shapefile"'])
 
             self.assertEqual(
@@ -779,7 +779,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_Union(ST_SingleSidedBuffer(geometry, 5.0, 0)) AS geometry,* FROM \\"polys2\\"" ' +
+                 '-dialect sqlite -sql "SELECT ST_Union(ST_SingleSidedBuffer(geometry, 5.0, 0)) AS geometry,* FROM """polys2"""" ' +
                  '-f "ESRI Shapefile"'])
 
             self.assertEqual(
@@ -790,7 +790,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_SingleSidedBuffer(geometry, 5.0, 0) AS geometry,* FROM \\"polys2\\"" ' +
+                 '-dialect sqlite -sql "SELECT ST_SingleSidedBuffer(geometry, 5.0, 0) AS geometry,* FROM """polys2"""" ' +
                  '-explodecollections -f "ESRI Shapefile"'])
 
             self.assertEqual(
@@ -802,7 +802,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                  outdir + '/check.shp ' +
                  source + ' ' +
                  '-dialect sqlite -sql "SELECT ST_Union(ST_SingleSidedBuffer(geometry, 5.0, 0)) AS geometry,* ' +
-                 'FROM \\"polys2\\" GROUP BY \\"total population\\"" -f "ESRI Shapefile"'])
+                 'FROM """polys2""" GROUP BY """total population"""" -f "ESRI Shapefile"'])
 
     def testPointsAlongLines(self):
         context = QgsProcessingContext()
@@ -820,7 +820,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_Line_Interpolate_Point(geometry, 0.2) AS geometry,* FROM \\"polys2\\"" ' +
+                 '-dialect sqlite -sql "SELECT ST_Line_Interpolate_Point(geometry, 0.2) AS geometry,* FROM """polys2"""" ' +
                  '-f "ESRI Shapefile"'])
 
 

--- a/src/core/qgsrunprocess.cpp
+++ b/src/core/qgsrunprocess.cpp
@@ -291,7 +291,14 @@ int QgsBlockingProcess::run( QgsFeedback *feedback )
     if ( feedback )
       QObject::connect( feedback, &QgsFeedback::canceled, &p, [ &p]
     {
+#ifdef Q_OS_WIN
+      // From the qt docs:
+      // "Console applications on Windows that do not run an event loop, or whose
+      // event loop does not handle the WM_CLOSE message, can only be terminated by calling kill()."
+      p.kill();
+#else
       p.terminate();
+#endif
     } );
     connect( &p, qgis::overload< int, QProcess::ExitStatus >::of( &QProcess::finished ), this, [&loop, &result, &exitStatus]( int res, QProcess::ExitStatus st )
     {

--- a/src/core/qgsrunprocess.cpp
+++ b/src/core/qgsrunprocess.cpp
@@ -270,9 +270,9 @@ int QgsBlockingProcess::run( QgsFeedback *feedback )
   const bool requestMadeFromMainThread = QThread::currentThread() == QCoreApplication::instance()->thread();
 
   int result = 0;
-  QProcess::ExitStatus status = QProcess::NormalExit;
+  QProcess::ExitStatus exitStatus = QProcess::NormalExit;
 
-  std::function<void()> runFunction = [ this, &result, &status, feedback]()
+  std::function<void()> runFunction = [ this, &result, &exitStatus, feedback]()
   {
     // this function will always be run in worker threads -- either the blocking call is being made in a worker thread,
     // or the blocking call has been made from the main thread and we've fired up a new thread for this function
@@ -293,10 +293,10 @@ int QgsBlockingProcess::run( QgsFeedback *feedback )
     {
       p.terminate();
     } );
-    connect( &p, qgis::overload< int, QProcess::ExitStatus >::of( &QProcess::finished ), this, [&loop, &result, &status]( int res, QProcess::ExitStatus st )
+    connect( &p, qgis::overload< int, QProcess::ExitStatus >::of( &QProcess::finished ), this, [&loop, &result, &exitStatus]( int res, QProcess::ExitStatus st )
     {
       result = res;
-      status = st;
+      exitStatus = st;
       loop.quit();
     }, Qt::DirectConnection );
 
@@ -330,6 +330,12 @@ int QgsBlockingProcess::run( QgsFeedback *feedback )
     runFunction();
   }
 
+  mExitStatus = exitStatus;
   return result;
+}
+
+QProcess::ExitStatus QgsBlockingProcess::exitStatus() const
+{
+  return mExitStatus;
 };
 

--- a/src/core/qgsrunprocess.h
+++ b/src/core/qgsrunprocess.h
@@ -172,12 +172,19 @@ class CORE_EXPORT QgsBlockingProcess : public QObject
      */
     int run( QgsFeedback *feedback = nullptr );
 
+    /**
+     * After a call to run(), returns the process' exit status.
+     */
+    QProcess::ExitStatus exitStatus() const;
+
   private:
 
     QString mProcess;
     QStringList mArguments;
     std::function< void( const QByteArray & ) > mStdoutHandler;
     std::function< void( const QByteArray & ) > mStderrHandler;
+
+    QProcess::ExitStatus mExitStatus = QProcess::NormalExit;
 
 };
 


### PR DESCRIPTION
This PR ports execution of GDAL algorithms to the new QgsBlockingProcess class, and adds support for responsive termination of the process and for capturing progress reports:

![Peek 2021-01-05 12-25](https://user-images.githubusercontent.com/1829991/103960104-2bb61280-519d-11eb-9977-b0913d2d689e.gif)

I'm sure I'm not the only one who's accidentally messed up the parameters of a GDAL algorithm and ended up with one or more endless GDAL algorithms running in the background of a QGIS session! :rofl: 

There's likely to be some fallout from this, so I'll keep on eye on the issue tracker and I'm prepared to revert if we can't get it in shape prior to release. But if we DO get it working nicely, then we should use the same process for running GRASS, SAGA and OTB algorithms too...


