### PR TITLE
Fix timestep UI handling in temporal controller widget

### DIFF
--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -59,7 +59,7 @@ QgsTemporalControllerWidget::QgsTemporalControllerWidget( QWidget *parent )
       return;
 
     mBlockFrameDurationUpdates++;
-    setTimeStep( timeStep );
+    updateTimeStepInputs( timeStep );
     mBlockFrameDurationUpdates--;
   } );
   connect( mNavigationOff, &QPushButton::clicked, this, &QgsTemporalControllerWidget::mNavigationOff_clicked );
@@ -534,6 +534,53 @@ void QgsTemporalControllerWidget::mRangeSetToAllLayersAction_triggered()
 }
 
 void QgsTemporalControllerWidget::setTimeStep( const QgsInterval &timeStep )
+{
+  if ( ! timeStep.isValid() || timeStep.seconds() <= 0 )
+    return;
+
+  // Search the time unit the most appropriate :
+  // the one that gives the smallest time step value for double spin box with round value (if possible) and/or the less signifiant digits
+
+  int selectedUnit = -1;
+  int stringSize = std::numeric_limits<int>::max();
+  int precision = mStepSpinBox->decimals();
+  double selectedValue = std::numeric_limits<double>::max();
+  for ( int i = 0; i < mTimeStepsComboBox->count(); ++i )
+  {
+    QgsUnitTypes::TemporalUnit unit = static_cast<QgsUnitTypes::TemporalUnit>( mTimeStepsComboBox->itemData( i ).toInt() );
+    double value = timeStep.seconds() * QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalSeconds, unit );
+    QString string = QString::number( value, 'f', precision );
+    string.remove( QRegExp( "0+$" ) ); //remove trailing zero
+    string.remove( QRegExp( "[.]+$" ) ); //remove last point if present
+
+    if ( value >= 1
+         && string.size() <= stringSize // less significant digit than currently selected
+         && value < selectedValue ) // less than currently selected
+    {
+      selectedUnit = i;
+      selectedValue = value;
+      stringSize = string.size();
+    }
+    else if ( string != '0'
+              && string.size() < precision + 2 //round value (ex: 0.xx with precision=3)
+              && string.size() < stringSize ) //less significant digit than currently selected
+    {
+      selectedUnit = i ;
+      selectedValue = value ;
+      stringSize = string.size();
+    }
+  }
+
+  if ( selectedUnit >= 0 )
+  {
+    mStepSpinBox->setValue( selectedValue );
+    mTimeStepsComboBox->setCurrentIndex( selectedUnit );
+  }
+
+  updateFrameDuration();
+}
+
+void QgsTemporalControllerWidget::updateTimeStepInputs( const QgsInterval &timeStep )
 {
   if ( ! timeStep.isValid() || timeStep.seconds() <= 0 )
     return;

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -538,43 +538,15 @@ void QgsTemporalControllerWidget::setTimeStep( const QgsInterval &timeStep )
   if ( ! timeStep.isValid() || timeStep.seconds() <= 0 )
     return;
 
-  // Search the time unit the most appropriate :
-  // the one that gives the smallest time step value for double spin box with round value (if possible) and/or the less signifiant digits
+  // Only update ui when the intervals are different
+  if ( timeStep == QgsInterval( mStepSpinBox->value(),
+                                static_cast< QgsUnitTypes::TemporalUnit>( mTimeStepsComboBox->currentData().toInt() ) ) )
+    return;
 
-  int selectedUnit = -1;
-  int stringSize = std::numeric_limits<int>::max();
-  int precision = mStepSpinBox->decimals();
-  double selectedValue = std::numeric_limits<double>::max();
-  for ( int i = 0; i < mTimeStepsComboBox->count(); ++i )
+  if ( timeStep.originalUnit() != QgsUnitTypes::TemporalUnknownUnit )
   {
-    QgsUnitTypes::TemporalUnit unit = static_cast<QgsUnitTypes::TemporalUnit>( mTimeStepsComboBox->itemData( i ).toInt() );
-    double value = timeStep.seconds() * QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalSeconds, unit );
-    QString string = QString::number( value, 'f', precision );
-    string.remove( QRegExp( "0+$" ) ); //remove trailing zero
-    string.remove( QRegExp( "[.]+$" ) ); //remove last point if present
-
-    if ( value >= 1
-         && string.size() <= stringSize // less significant digit than currently selected
-         && value < selectedValue ) // less than currently selected
-    {
-      selectedUnit = i;
-      selectedValue = value;
-      stringSize = string.size();
-    }
-    else if ( string != '0'
-              && string.size() < precision + 2 //round value (ex: 0.xx with precision=3)
-              && string.size() < stringSize ) //less significant digit than currently selected
-    {
-      selectedUnit = i ;
-      selectedValue = value ;
-      stringSize = string.size();
-    }
-  }
-
-  if ( selectedUnit >= 0 )
-  {
-    mStepSpinBox->setValue( selectedValue );
-    mTimeStepsComboBox->setCurrentIndex( selectedUnit );
+    mStepSpinBox->setValue( timeStep.originalDuration() );
+    mTimeStepsComboBox->setCurrentIndex( timeStep.originalUnit() );
   }
 
   updateFrameDuration();

--- a/src/gui/qgstemporalcontrollerwidget.h
+++ b/src/gui/qgstemporalcontrollerwidget.h
@@ -93,6 +93,23 @@ class GUI_EXPORT QgsTemporalControllerWidget : public QgsPanelWidget, private Ui
     void firstTemporalLayerLoaded( QgsMapLayer *layer );
     void setTimeStep( const QgsInterval &timeStep );
 
+    /**
+     * Updates the widget timestep and timestep unit inputs using the passed
+     * interval \a timeStep original duration and original unit.
+     *
+     * If the passed interval \a timeStep has different values of original duration
+     * and original unit compared to the widget input values for timestep and
+     * timestep unit then the corresponding widget input values will be updated
+     * to match the \a timeStep original duration and unit.
+     *
+     * After updating the widget inputs, an update to the frame duration is executed.
+     *
+     * \note Updates will only be made if the \a timeStep is valid.
+     *
+     * \since 3.18
+     */
+    void updateTimeStepInputs( const QgsInterval &timeStep );
+
   private slots:
 
     /**


### PR DESCRIPTION
Fixes https://github.com/qgis/QGIS/issues/40894

Recent changes in https://github.com/qgis/QGIS/pull/40654  has made QgsInterval support storing timestep and timestep unit and accessing them via "originalDuration()" and "originalUnit()", now we can use those functions to directly set the temporal controller widget timestep and timestep unit.