### PR TITLE
[Quick] Update models to fix invalid references

### DIFF
--- a/src/quickgui/CMakeLists.txt
+++ b/src/quickgui/CMakeLists.txt
@@ -56,6 +56,8 @@ include_directories(
   ${CMAKE_SOURCE_DIR}/src/core/annotations
   ${CMAKE_SOURCE_DIR}/src/core/auth
   ${CMAKE_SOURCE_DIR}/src/core/composer
+  ${CMAKE_SOURCE_DIR}/src/core/effects
+  ${CMAKE_SOURCE_DIR}/src/core/expression
   ${CMAKE_SOURCE_DIR}/src/core/fieldformatter
   ${CMAKE_SOURCE_DIR}/src/core/geometry
   ${CMAKE_SOURCE_DIR}/src/core/labeling
@@ -63,14 +65,13 @@ include_directories(
   ${CMAKE_SOURCE_DIR}/src/core/layout
   ${CMAKE_SOURCE_DIR}/src/core/locator
   ${CMAKE_SOURCE_DIR}/src/core/metadata
+  ${CMAKE_SOURCE_DIR}/src/core/project
   ${CMAKE_SOURCE_DIR}/src/core/providers/memory
   ${CMAKE_SOURCE_DIR}/src/core/raster
   ${CMAKE_SOURCE_DIR}/src/core/scalebar
   ${CMAKE_SOURCE_DIR}/src/core/symbology
   ${CMAKE_SOURCE_DIR}/src/core/textrenderer
-  ${CMAKE_SOURCE_DIR}/src/core/effects
-  ${CMAKE_SOURCE_DIR}/src/core/metadata
-  ${CMAKE_SOURCE_DIR}/src/core/expression
+  ${CMAKE_SOURCE_DIR}/src/core/vector
   ${CMAKE_SOURCE_DIR}/external
   ${CMAKE_SOURCE_DIR}/external/nlohmann
 

--- a/src/quickgui/attributes/qgsquickattributeformmodel.cpp
+++ b/src/quickgui/attributes/qgsquickattributeformmodel.cpp
@@ -72,6 +72,11 @@ QVariant QgsQuickAttributeFormModel::attribute( const QString &name ) const
   return mSourceModel->attribute( name );
 }
 
+void QgsQuickAttributeFormModel::forceClean()
+{
+  mSourceModel->forceClean();
+}
+
 bool QgsQuickAttributeFormModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
 {
   return mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), CurrentlyVisible ).toBool();

--- a/src/quickgui/attributes/qgsquickattributeformmodel.h
+++ b/src/quickgui/attributes/qgsquickattributeformmodel.h
@@ -108,6 +108,9 @@ class QUICK_EXPORT QgsQuickAttributeFormModel : public QSortFilterProxyModel
     //! Returns attribute value with name
     Q_INVOKABLE QVariant attribute( const QString &name ) const;
 
+    //! Resets the model
+    Q_INVOKABLE void forceClean();
+
   signals:
     //! \copydoc QgsQuickAttributeFormModel::attributeModel
     void attributeModelChanged();

--- a/src/quickgui/attributes/qgsquickattributeformmodelbase.cpp
+++ b/src/quickgui/attributes/qgsquickattributeformmodelbase.cpp
@@ -414,6 +414,18 @@ void QgsQuickAttributeFormModelBase::setConstraintsSoftValid( bool constraintsSo
   emit constraintsSoftValidChanged();
 }
 
+void QgsQuickAttributeFormModelBase::forceClean()
+{
+  mLayer = nullptr;
+  mTemporaryContainer = nullptr;
+  mHasTabs = false;
+  mVisibilityExpressions.clear();
+  mConstraints.clear();
+  mExpressionContext = QgsExpressionContext();
+  mConstraintsHardValid = false;
+  mConstraintsSoftValid = false;
+}
+
 bool QgsQuickAttributeFormModelBase::hasTabs() const
 {
   return mHasTabs;

--- a/src/quickgui/attributes/qgsquickattributeformmodelbase.h
+++ b/src/quickgui/attributes/qgsquickattributeformmodelbase.h
@@ -104,6 +104,9 @@ class QgsQuickAttributeFormModelBase : public QStandardItemModel
     //! \copydoc QgsQuickAttributeFormModelBase::constraintsSoftValid
     void setConstraintsSoftValid( bool constraintsSoftValid );
 
+    //! Resets the model
+    Q_INVOKABLE void forceClean();
+
   signals:
     //! \copydoc QgsQuickAttributeFormModelBase::attributeModel
     void attributeModelChanged();

--- a/src/quickgui/attributes/qgsquickattributemodel.cpp
+++ b/src/quickgui/attributes/qgsquickattributemodel.cpp
@@ -38,6 +38,12 @@ void QgsQuickAttributeModel::setFeatureLayerPair( const QgsQuickFeatureLayerPair
   setFeature( pair.feature() );
 }
 
+void QgsQuickAttributeModel::forceClean()
+{
+  mRememberedAttributes.clear();
+  mFeatureLayerPair = QgsQuickFeatureLayerPair();
+}
+
 
 void QgsQuickAttributeModel::setVectorLayer( QgsVectorLayer *layer )
 {
@@ -48,7 +54,7 @@ void QgsQuickAttributeModel::setVectorLayer( QgsVectorLayer *layer )
   mFeatureLayerPair = QgsQuickFeatureLayerPair( mFeatureLayerPair.feature(), layer );
 
 
-  if ( auto *lLayer = mFeatureLayerPair.layer() )
+  if ( const QgsVectorLayer *lLayer = mFeatureLayerPair.layer() )
   {
     mRememberedAttributes.resize( lLayer->fields().size() );
     mRememberedAttributes.fill( false );

--- a/src/quickgui/attributes/qgsquickattributemodel.h
+++ b/src/quickgui/attributes/qgsquickattributemodel.h
@@ -118,11 +118,14 @@ class QUICK_EXPORT QgsQuickAttributeModel : public QAbstractListModel
     //! Gets remembered attributes
     QVector<bool> rememberedAttributes() const;
 
-    //!\copydoc QgsQuickAttributeModel::featureLayerPair
+    //! Gets current featureLayerPair
     QgsQuickFeatureLayerPair featureLayerPair() const;
 
-    //!\copydoc QgsQuickAttributeModel::featureLayerPair
+    //! Sets current featureLayerPair
     void setFeatureLayerPair( const QgsQuickFeatureLayerPair &pair );
+
+    //! Resets the model
+    Q_INVOKABLE void forceClean();
 
   public slots:
 

--- a/src/quickgui/attributes/qgsquicksubmodel.cpp
+++ b/src/quickgui/attributes/qgsquicksubmodel.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgsquicksubmodel.h"
+#include <QDebug>
 
 QgsQuickSubModel::QgsQuickSubModel( QObject *parent )
   : QAbstractItemModel( parent )
@@ -62,7 +63,14 @@ QVariant QgsQuickSubModel::data( const QModelIndex &index, int role ) const
   if ( !mModel )
     return QVariant();
 
-  return mModel->data( mapToSource( index ), role );
+  QModelIndex sourceIndex = mapToSource( index );
+  if ( sourceIndex.isValid() )
+    return mModel->data( sourceIndex, role );
+  else
+  {
+    qDebug() << "Warning: QgsQuickSubModel::data invalid index" << index << "role: " << role << "root: " << mRootIndex;
+    return QVariant();
+  }
 }
 
 bool QgsQuickSubModel::setData( const QModelIndex &index, const QVariant &value, int role )
@@ -70,7 +78,14 @@ bool QgsQuickSubModel::setData( const QModelIndex &index, const QVariant &value,
   if ( !mModel )
     return false;
 
-  return mModel->setData( mapToSource( index ), value, role );
+  QModelIndex sourceIndex = mapToSource( index );
+  if ( sourceIndex.isValid() )
+    return mModel->setData( sourceIndex, value, role );
+  else
+  {
+    qDebug() << "Warning: QgsQuickSubModel::setData invalid index" << index << "value: " << value << "role: " << role << "root: " << mRootIndex;
+    return false;
+  }
 }
 
 QHash<int, QByteArray> QgsQuickSubModel::roleNames() const


### PR DESCRIPTION
## Description

There are situations when Quick models, mainly `Submodel` contain invalid references. This results into random crashes. This PR fixes some of these situations.

cc @PeterPetrik @wonder-sk 