### PR TITLE
[Fix] modeler skip defaults

### DIFF
--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -106,7 +106,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
     def setParameters(self, parameters):
         self.mainWidget().setParameters(parameters)
 
-    def createProcessingParameters(self):
+    def createProcessingParameters(self, **kwargs):
         if self.mainWidget() is None:
             return {}
         else:


### PR DESCRIPTION
## Description

Catch kwargs and does nothing with them if in the algorithm dialog and not in the parametr dialog.

Fixes #40907 

@rduivenvoorde can you do the change in AlgorithmDialog.py and confirm if all works fine?