### PR TITLE
Use QDesktopServices instead of deprecated iface.openUrl in qgis.utils

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -532,7 +532,7 @@ def showPluginHelp(packageName: str = None, filename: str = "index", section: st
         url = "file://" + helpfile
         if section != "":
             url = url + "#" + section
-        QDesktopServices.openUrl .openUrl(url, False)
+        QDesktopServices.openUrl(QUrl(url))
 
 
 def pluginDirectory(packageName):

--- a/python/utils.py
+++ b/python/utils.py
@@ -502,7 +502,7 @@ def reloadPlugin(packageName):
 
 def showPluginHelp(packageName: str = None, filename: str = "index", section: str = ""):
     """Open help in the user's html browser. The help file should be named index-ll_CC.html or index-ll.html or index.html.
-    
+
     :param str packageName: name of package folder, if None it's using the current file package. Defaults to None. Optional.
     :param str filename: name of file to open. It can be a path like 'doc/index' for example. Defaults to 'index'.
     :param str section: URL path to open. Defaults to empty string.

--- a/python/utils.py
+++ b/python/utils.py
@@ -26,7 +26,8 @@ QGIS utilities module
 
 """
 
-from qgis.PyQt.QtCore import QCoreApplication, QLocale, QThread, qDebug
+from qgis.PyQt.QtCore import QCoreApplication, QLocale, QThread, qDebug, QUrl
+from qgis.PyQt.QtGui import QDesktopServices
 from qgis.PyQt.QtWidgets import QPushButton, QApplication
 from qgis.core import Qgis, QgsMessageLog, qgsfunction, QgsMessageOutput
 from qgis.gui import QgsMessageBar
@@ -499,8 +500,13 @@ def reloadPlugin(packageName):
     startPlugin(packageName)
 
 
-def showPluginHelp(packageName=None, filename="index", section=""):
-    """ show a help in the user's html browser. The help file should be named index-ll_CC.html or index-ll.html"""
+def showPluginHelp(packageName: str = None, filename: str = "index", section: str = ""):
+    """Open help in the user's html browser. The help file should be named index-ll_CC.html or index-ll.html or index.html.
+    
+    :param str packageName: name of package folder, if None it's using the current file package. Defaults to None. Optional.
+    :param str filename: name of file to open. It can be a path like 'doc/index' for example. Defaults to 'index'.
+    :param str section: URL path to open. Defaults to empty string.
+    """
     try:
         source = ""
         if packageName is None:
@@ -526,7 +532,7 @@ def showPluginHelp(packageName=None, filename="index", section=""):
         url = "file://" + helpfile
         if section != "":
             url = url + "#" + section
-        iface.openURL(url, False)
+        QDesktopServices.openUrl .openUrl(url, False)
 
 
 def pluginDirectory(packageName):


### PR DESCRIPTION
# Introduction (skippable)

Hi there,

Because this is my first commit to the project, let me quickly introduce myself.

My name is Julien, I'm actually a new member or [Oslandia](https://oslandia.com/en/) team. If you're French, maybe you crossed my lifeline on [Twitter](https://twitter.com/geojulien) or [Geotribu](https://static.geotribu.fr/). On the technical side, if C++ is something strange for me, I write Python for a few years. Not a developer profesional, just one more GIS guy.

On the plugins side, I've contributed/developed/maintained some plugins: [Isogeo](https://plugins.qgis.org/plugins/isogeo_search_engine/), [GMLAS](https://github.com/BRGM/gml_application_schema_toolbox/), [Resource Sharing](https://github.com/QGIS-Contribution/QGIS-ResourceSharing), [Layers menu from project](https://github.com/xcaeag/MenuFromProject-Qgis-Plugin).

It's a really small contribution but, please, feel free to tell me if I didn't do it right.

# Deprecated message

Following the [PyQGIS Cookbook](https://docs.qgis.org/3.16/en/docs/pyqgis_developer_cookbook/plugins/plugins.html#documentation), I use `qgis.utils.showPluginHelp()` to show the HTML help to the end-user. But I noticed that it'as actually raising a deprecation warning in Python tab:

```log
2021-01-08T18:02:24     WARNING    warning:/usr/lib/python3/dist-packages/qgis/utils.py:529: DeprecationWarning: QgisInterface.openURL() is deprecated
              iface.openURL(url, False)
             
             traceback: File "/home/jmo/Git/Oslandia/Projects/BRGM/gml_application_schema_toolbox/gml_application_schema_toolbox/main.py", line 82, in 
              self.helpAction.triggered.connect(lambda: showPluginHelp(filename="doc/index"))
              File "/usr/lib/python3/dist-packages/qgis/utils.py", line 529, in showPluginHelp
              iface.openURL(url, False)
```

Looking at the [source of the function](https://github.com/qgis/QGIS/blob/master/python/utils.py#L502-L530), it's mapping to `iface.openUrl` which is, indeed, flagged as deprecated: <https://qgis.org/api/3.16/classQgisInterface.html#a43b37128cf3e6d4ed4cecb7a74cbe09e>.

# Changes

So, following the deprecation advice, I just replaced `iface.openUrl` by `QDesktopServices.openUrl`.


<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
