### PR TITLE
Fix to_date* functions links to qt doc

### DIFF
--- a/resources/function_help/json/to_date
+++ b/resources/function_help/json/to_date
@@ -2,7 +2,7 @@
   "name": "to_date",
   "type": "function",
   "groups": ["Conversions", "Date and Time"],
-  "description": "Converts a string into a date object. An optional format string can be provided to parse the string; see <a href='https://doc.qt.io/qt-5/qdate.html#fromString-1'>QDate::fromString</a> for additional documentation on the format.",
+  "description": "Converts a string into a date object. An optional format string can be provided to parse the string; see <a href='https://doc.qt.io/qt-5/qdate.html#fromString-2'>QDate::fromString</a> for additional documentation on the format.",
   "arguments": [
    {"arg":"string","description":"string representing a date value"},
    {"arg":"format","optional":true,"description":"format used to convert the string into a date"},

--- a/resources/function_help/json/to_datetime
+++ b/resources/function_help/json/to_datetime
@@ -2,7 +2,7 @@
   "name": "to_datetime",
   "type": "function",
   "groups": ["Conversions", "Date and Time"],
-  "description": "Converts a string into a datetime object. An optional format string can be provided to parse the string; see <a href='https://doc.qt.io/qt-5/qdatetime.html#fromString-1'>QDateTime::fromString</a> for additional documentation on the format.",
+  "description": "Converts a string into a datetime object. An optional format string can be provided to parse the string; see <a href='https://doc.qt.io/qt-5/qdate.html#fromString-2'>QDate::fromString</a> and <a href='https://doc.qt.io/qt-5/qtime.html#fromString-1'>QTime::fromString</a> for additional documentation on the format.",
   "arguments": [
    {"arg":"string","description":"string representing a datetime value"},
    {"arg":"format","optional":true,"description":"format used to convert the string into a datetime"},


### PR DESCRIPTION
QDateTime::fromString documentation no longer lists all the expressions to construct the format, so we point to each component doc

(cherry picked from commit 1444ce3a342d5967ed53d16aec4a83a8fe150612)

Backports #40908