### PR TITLE
Add map_credits function

### DIFF
--- a/resources/function_help/json/map_credits
+++ b/resources/function_help/json/map_credits
@@ -1,0 +1,12 @@
+{
+  "name": "map_credits",
+  "type": "function",
+  "groups": ["Layout"],
+  "description": "Returns a list of credit (usage rights) strings for the layers shown in a layout map item.",
+  "arguments": [ {"arg":"id","description":"map item ID"},
+                 {"arg":"include_layer_names","description":"Set to true to include layer names before their credit strings", "optional": true, "default": "false"},
+                 {"arg":"layer_name_separator","description":"String to insert between layer names and their credit strings, if include_layer_names is true", "optional": true, "default": "': '"} ],
+  "examples": [ { "expression":"array_to_string( map_credits( 'Main Map' ) )", "returns":"comma separated list of layer credits for layers shown in the 'Main Map' layout item, e.g 'CC-BY-NC, CC-BY-SA'" },
+  { "expression":"array_to_string( map_credits( 'Main Map', include_layer_names := true, layer_name_separator := ': ' ) )", "returns":"comma separated list of layer names and their credits for layers shown in the 'Main Map' layout item, e.g. 'Railway lines: CC-BY-NC, Basemap: CC-BY-SA'" }
+  ]
+}


### PR DESCRIPTION
This function collates a list of all the layer metadata attribution
strings for the layers shown inside a specified map item.

For example:

    array_to_string( map_credits( 'Main Map' ) )

Returns a comma separated list of layer credits for layers shown in the
'Main Map' layout item, e.g 'CC-BY-NC, CC-BY-SA'

There's an optional include_layer_names argument you can use
to include layer names before their attribution:

    array_to_string( map_credits( 'Main Map',
       include_layer_names := true,
       layer_name_separator := ': ' ) )

Returns a comma separated list of layer names and their credits for layers
shown in the 'Main Map' layout item,
e.g. 'Railway lines: CC-BY-NC, Basemap: CC-BY-SA'"

This was previously possible using only an unholy mash of array_foreach, item_variables, array_distinct and layer_properties functions, but that wasn't user friendly at all :laughing: 

Sponsored by SLYR