### PR TITLE
[ui] Format status bar coordinate widget's extent using project settings

### DIFF
--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -345,10 +345,9 @@ void QgsStatusBarCoordinatesWidget::showExtent()
     return;
   }
 
-  // update the statusbar with the current extents.
-  QgsRectangle myExtents = mMapCanvas->extent();
   mLabel->setText( tr( "Extents" ) );
-  mLineEdit->setText( myExtents.toString( true ) );
+  mLineEdit->setText( QgsCoordinateUtils::formatExtentForProject( QgsProject::instance(), mMapCanvas->extent(), mMapCanvas->mapSettings().destinationCrs(),
+                      mMousePrecisionDecimalPlaces ) );
 
   ensureCoordinatesVisible();
 }

--- a/src/core/qgscoordinateutils.cpp
+++ b/src/core/qgscoordinateutils.cpp
@@ -22,6 +22,7 @@
 #include "qgis.h"
 #include "qgsexception.h"
 #include "qgscoordinateformatter.h"
+#include "qgsrectangle.h"
 ///@cond NOT_STABLE_API
 
 int QgsCoordinateUtils::calculateCoordinatePrecision( double mapUnitsPerPixel, const QgsCoordinateReferenceSystem &mapCrs, QgsProject *project )
@@ -129,6 +130,14 @@ QString QgsCoordinateUtils::formatCoordinateForProject( QgsProject *project, con
     // coordinates in map units
     return QgsCoordinateFormatter::asPair( point.x(), point.y(), precision );
   }
+}
+
+QString QgsCoordinateUtils::formatExtentForProject( QgsProject *project, const QgsRectangle &extent, const QgsCoordinateReferenceSystem &destCrs, int precision )
+{
+  const QgsPointXY p1( extent.xMinimum(), extent.yMinimum() );
+  const QgsPointXY p2( extent.xMaximum(), extent.yMaximum() );
+  return QStringLiteral( "%1 : %2" ).arg( QgsCoordinateUtils::formatCoordinateForProject( project, p1, destCrs, precision ),
+                                          QgsCoordinateUtils::formatCoordinateForProject( project, p2, destCrs, precision ) );
 }
 
 double QgsCoordinateUtils::dmsToDecimal( const QString &string, bool *ok, bool *isEasting )

--- a/src/core/qgscoordinateutils.h
+++ b/src/core/qgscoordinateutils.h
@@ -28,6 +28,7 @@
 class QgsPointXY;
 class QgsCoordinateReferenceSystem;
 class QgsProject;
+class QgsRectangle;
 
 //not stable api - I plan on reworking this when QgsCoordinateFormatter lands in 2.16
 ///@cond NOT_STABLE_API
@@ -75,6 +76,13 @@ class CORE_EXPORT QgsCoordinateUtils
      * \since QGIS 3.2
      */
     Q_INVOKABLE static QString formatCoordinateForProject( QgsProject *project, const QgsPointXY &point, const QgsCoordinateReferenceSystem &destCrs, int precision );
+
+    /**
+     * Formats an \a extent for use with the specified \a project, respecting the project's
+     * coordinate display settings.
+     * \since QGIS 3.18
+     */
+    Q_INVOKABLE static QString formatExtentForProject( QgsProject *project, const QgsRectangle &extent, const QgsCoordinateReferenceSystem &destCrs, int precision );
 
     /**
      * Converts a degree minute second coordinate string to its decimal equivalent.


### PR DESCRIPTION
## Description

This PR insures that the status bar coordinate widget respects the project coordinate display settings:
![image](https://user-images.githubusercontent.com/1728657/104082203-df370980-5266-11eb-85bf-ed72ae3a0b3c.png)

Without this PR, we end up showing mouse pointer coordinate in WGS84 degrees and extent in a different CRS/format when the project's CRS isn't WGS84.