### PR TITLE
[layouts] When adding a new map item, auto-assign a real unique id to the item

### DIFF
--- a/src/gui/layout/qgslayoutguiutils.cpp
+++ b/src/gui/layout/qgslayoutguiutils.cpp
@@ -129,6 +129,34 @@ void QgsLayoutGuiUtils::registerGuiForKnownItemTypes( QgsMapCanvas *mapCanvas )
     {
       map->zoomToExtent( mapCanvas->mapSettings().visibleExtent() );
     }
+
+    // auto assign a unique id to map items
+    QList<QgsLayoutItemMap *> mapsList;
+    if ( map->layout() )
+      map->layout()->layoutItems( mapsList );
+
+    int counter = mapsList.size() + 1;
+    bool existing = false;
+    while ( true )
+    {
+      existing = false;
+      for ( QgsLayoutItemMap *otherMap : qgis::as_const( mapsList ) )
+      {
+        if ( map == otherMap )
+          continue;
+
+        if ( otherMap->id() == QObject::tr( "Map %1" ).arg( counter ) )
+        {
+          existing = true;
+          break;
+        }
+      }
+      if ( existing )
+        counter++;
+      else
+        break;
+    }
+    map->setId( QObject::tr( "Map %1" ).arg( counter ) );
   } );
   registry->addLayoutItemGuiMetadata( mapItemMetadata.release() );
 


### PR DESCRIPTION
Previously we auto assigned an internal quasi-id to these items,
but that was rather confusing because they still had an empty
id and couldn't be referred to as "Map 1", etc when using
expressions.

There's a little more to do here -- eg I think we also should auto assign a real id to map items which don't have one when restoring a layout from xml too, but I need to think through the consequences of that a bit more first.