### PR TITLE
Use more robust layer CRS equality test in processing test suite

### DIFF
--- a/python/core/auto_generated/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/qgscoordinatereferencesystem.sip.in
@@ -860,7 +860,8 @@ Returns auth id of related geographic CRS
 
     SIP_PYOBJECT __repr__();
 %MethodCode
-    QString str = QStringLiteral( "<QgsCoordinateReferenceSystem: %1>" ).arg( sipCpp->authid() );
+    const QString str = sipCpp->isValid() ? QStringLiteral( "<QgsCoordinateReferenceSystem: %1>" ).arg( !sipCpp->authid().isEmpty() ? sipCpp->authid() : sipCpp->toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ) )
+                        : QStringLiteral( "<QgsCoordinateReferenceSystem: invalid>" );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 

--- a/python/testing/__init__.py
+++ b/python/testing/__init__.py
@@ -29,7 +29,13 @@ import filecmp
 import tempfile
 
 from qgis.PyQt.QtCore import QVariant
-from qgis.core import QgsApplication, QgsFeatureRequest, NULL
+from qgis.core import (
+    QgsApplication,
+    QgsFeatureRequest,
+    QgsCoordinateReferenceSystem,
+    NULL
+)
+
 import unittest
 
 # Get a backup, we will patch this one later
@@ -86,9 +92,12 @@ class TestCase(_TestCase):
 
         # Compare CRS
         if 'ignore_crs_check' not in compare or not compare['ignore_crs_check']:
+            expected_wkt = layer_expected.dataProvider().crs().toWkt(QgsCoordinateReferenceSystem.WKT_PREFERRED)
+            result_wkt = layer_result.dataProvider().crs().toWkt(QgsCoordinateReferenceSystem.WKT_PREFERRED)
+
             if use_asserts:
-                _TestCase.assertEqual(self, layer_expected.dataProvider().crs().authid(), layer_result.dataProvider().crs().authid())
-            elif not layer_expected.dataProvider().crs().authid() == layer_result.dataProvider().crs().authid():
+                _TestCase.assertEqual(self, layer_expected.dataProvider().crs(), layer_result.dataProvider().crs())
+            elif layer_expected.dataProvider().crs() != layer_result.dataProvider().crs():
                 return False
 
         # Compare features

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -792,7 +792,8 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();
     % MethodCode
-    QString str = QStringLiteral( "<QgsCoordinateReferenceSystem: %1>" ).arg( sipCpp->authid() );
+    const QString str = sipCpp->isValid() ? QStringLiteral( "<QgsCoordinateReferenceSystem: %1>" ).arg( !sipCpp->authid().isEmpty() ? sipCpp->authid() : sipCpp->toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ) )
+                        : QStringLiteral( "<QgsCoordinateReferenceSystem: invalid>" );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif

--- a/tests/src/python/test_python_repr.py
+++ b/tests/src/python/test_python_repr.py
@@ -182,6 +182,8 @@ class TestPython__repr__(unittest.TestCase):
         self.assertEqual(g.__repr__(), '<QgsReferencedGeometry: Point (1 2) (EPSG:4326)>')
 
     def testQgsCoordinateReferenceSystem(self):
+        crs = QgsCoordinateReferenceSystem()
+        self.assertEqual(crs.__repr__(), '<QgsCoordinateReferenceSystem: invalid>')
         crs = QgsCoordinateReferenceSystem('EPSG:4326')
         self.assertEqual(crs.__repr__(), '<QgsCoordinateReferenceSystem: EPSG:4326>')
         crs = QgsCoordinateReferenceSystem('EPSG:3111')


### PR DESCRIPTION
Don't use authid to compare layer CRSes, but instead of QgsCoordinateReferenceSystem == operator, so that we can correctly test equality of non-standard CRSes