### PR TITLE
move the config to QgsAttributeEditorRelation + fix cloning

### DIFF
--- a/python/core/auto_generated/qgsattributeeditorelement.sip.in
+++ b/python/core/auto_generated/qgsattributeeditorelement.sip.in
@@ -115,20 +115,6 @@ Controls if this element should be labeled with a title (field, relation or grou
 .. versionadded:: 2.18
 %End
 
-    QVariantMap config() const;
-%Docstring
-Returns the editor configuration
-
-.. versionadded:: 3.18
-%End
-
-    void setConfig( const QVariantMap &config );
-%Docstring
-Sets the editor configuration
-
-.. versionadded:: 3.18
-%End
-
   protected:
 
 };
@@ -421,6 +407,20 @@ Returns the current relation widget type id
     void setRelationWidgetTypeId( const QString &relationWidgetTypeId );
 %Docstring
 Sets the relation widget type
+
+.. versionadded:: 3.18
+%End
+
+    QVariantMap relationEditorConfiguration() const;
+%Docstring
+Returns the relation editor widget configuration
+
+.. versionadded:: 3.18
+%End
+
+    void setRelationEditorConfiguration( const QVariantMap &config );
+%Docstring
+Sets the relation editor configuration
 
 .. versionadded:: 3.18
 %End

--- a/src/core/qgsattributeeditorelement.cpp
+++ b/src/core/qgsattributeeditorelement.cpp
@@ -107,8 +107,9 @@ QgsAttributeEditorElement *QgsAttributeEditorContainer::clone( QgsAttributeEdito
   return element;
 }
 
-void QgsAttributeEditorContainer::saveConfiguration( QDomElement &elem ) const
+void QgsAttributeEditorContainer::saveConfiguration( QDomElement &elem, QDomDocument &doc ) const
 {
+  Q_UNUSED( doc )
   elem.setAttribute( QStringLiteral( "columnCount" ), mColumnCount );
   elem.setAttribute( QStringLiteral( "groupBox" ), mIsGroupBox ? 1 : 0 );
   elem.setAttribute( QStringLiteral( "visibilityExpressionEnabled" ), mVisibilityExpression.enabled() ? 1 : 0 );
@@ -150,11 +151,13 @@ QgsAttributeEditorElement *QgsAttributeEditorRelation::clone( QgsAttributeEditor
   element->mForceSuppressFormPopup = mForceSuppressFormPopup;
   element->mNmRelationId = mNmRelationId;
   element->mLabel = mLabel;
+  element->mRelationEditorConfig = mRelationEditorConfig;
 
   return element;
 }
-void QgsAttributeEditorField::saveConfiguration( QDomElement &elem ) const
+void QgsAttributeEditorField::saveConfiguration( QDomElement &elem, QDomDocument &doc ) const
 {
+  Q_UNUSED( doc )
   elem.setAttribute( QStringLiteral( "index" ), mIdx );
 }
 
@@ -168,12 +171,7 @@ QDomElement QgsAttributeEditorElement::toDomElement( QDomDocument &doc ) const
   QDomElement elem = doc.createElement( typeIdentifier() );
   elem.setAttribute( QStringLiteral( "name" ), mName );
   elem.setAttribute( QStringLiteral( "showLabel" ), mShowLabel );
-
-  QDomElement elemConfig = QgsXmlUtils::writeVariant( mConfig, doc );
-  elemConfig.setTagName( QStringLiteral( "config" ) );
-  elem.appendChild( elemConfig );
-
-  saveConfiguration( elem );
+  saveConfiguration( elem, doc );
   return elem;
 }
 
@@ -187,24 +185,17 @@ void QgsAttributeEditorElement::setShowLabel( bool showLabel )
   mShowLabel = showLabel;
 }
 
-QVariantMap QgsAttributeEditorElement::config() const
-{
-  return mConfig;
-}
-
-void QgsAttributeEditorElement::setConfig( const QVariantMap &config )
-{
-  mConfig = config;
-}
-
-void QgsAttributeEditorRelation::saveConfiguration( QDomElement &elem ) const
+void QgsAttributeEditorRelation::saveConfiguration( QDomElement &elem, QDomDocument &doc ) const
 {
   elem.setAttribute( QStringLiteral( "relation" ), mRelation.id() );
-  elem.setAttribute( QStringLiteral( "buttons" ), mConfig.value( QStringLiteral( "buttons" ) ).toString() );
   elem.setAttribute( QStringLiteral( "forceSuppressFormPopup" ), mForceSuppressFormPopup );
   elem.setAttribute( QStringLiteral( "nmRelationId" ), mNmRelationId.toString() );
   elem.setAttribute( QStringLiteral( "label" ), mLabel );
   elem.setAttribute( QStringLiteral( "relationWidgetTypeId" ), mRelationWidgetTypeId );
+
+  QDomElement elemConfig = QgsXmlUtils::writeVariant( mRelationEditorConfig, doc );
+  elemConfig.setTagName( QStringLiteral( "editor_configuration" ) );
+  elem.appendChild( elemConfig );
 }
 
 QString QgsAttributeEditorRelation::typeIdentifier() const
@@ -252,6 +243,16 @@ void QgsAttributeEditorRelation::setRelationWidgetTypeId( const QString &relatio
   mRelationWidgetTypeId = relationWidgetTypeId;
 }
 
+QVariantMap QgsAttributeEditorRelation::relationEditorConfiguration() const
+{
+  return mRelationEditorConfig;
+}
+
+void QgsAttributeEditorRelation::setRelationEditorConfiguration( const QVariantMap &config )
+{
+  mRelationEditorConfig = config;
+}
+
 QgsAttributeEditorElement *QgsAttributeEditorQmlElement::clone( QgsAttributeEditorElement *parent ) const
 {
   QgsAttributeEditorQmlElement *element = new QgsAttributeEditorQmlElement( name(), parent );
@@ -270,9 +271,9 @@ void QgsAttributeEditorQmlElement::setQmlCode( const QString &qmlCode )
   mQmlCode = qmlCode;
 }
 
-void QgsAttributeEditorQmlElement::saveConfiguration( QDomElement &elem ) const
+void QgsAttributeEditorQmlElement::saveConfiguration( QDomElement &elem, QDomDocument &doc ) const
 {
-  QDomText codeElem = elem.ownerDocument().createTextNode( mQmlCode );
+  QDomText codeElem = doc.createTextNode( mQmlCode );
   elem.appendChild( codeElem );
 }
 
@@ -299,9 +300,9 @@ void QgsAttributeEditorHtmlElement::setHtmlCode( const QString &htmlCode )
   mHtmlCode = htmlCode;
 }
 
-void QgsAttributeEditorHtmlElement::saveConfiguration( QDomElement &elem ) const
+void QgsAttributeEditorHtmlElement::saveConfiguration( QDomElement &elem, QDomDocument &doc ) const
 {
-  QDomText codeElem = elem.ownerDocument().createTextNode( mHtmlCode );
+  QDomText codeElem = doc.createTextNode( mHtmlCode );
   elem.appendChild( codeElem );
 }
 

--- a/src/core/qgsattributeeditorelement.h
+++ b/src/core/qgsattributeeditorelement.h
@@ -135,27 +135,12 @@ class CORE_EXPORT QgsAttributeEditorElement SIP_ABSTRACT
      */
     void setShowLabel( bool showLabel );
 
-    /**
-     * Returns the editor configuration
-     *
-     * \since QGIS 3.18
-     */
-    QVariantMap config() const;
-
-    /**
-     * Sets the editor configuration
-     *
-     * \since QGIS 3.18
-     */
-    void setConfig( const QVariantMap &config );
-
   protected:
 #ifndef SIP_RUN
     AttributeEditorType mType;
     QString mName;
     QgsAttributeEditorElement *mParent = nullptr;
     bool mShowLabel;
-    QVariantMap mConfig;
 #endif
 
   private:
@@ -165,7 +150,7 @@ class CORE_EXPORT QgsAttributeEditorElement SIP_ABSTRACT
      *
      * \since QGIS 2.18
      */
-    virtual void saveConfiguration( QDomElement &elem ) const = 0;
+    virtual void saveConfiguration( QDomElement &elem, QDomDocument &doc ) const = 0;
 
     /**
      * All subclasses need to overwrite this method and return a type specific identifier.
@@ -299,7 +284,7 @@ class CORE_EXPORT QgsAttributeEditorContainer : public QgsAttributeEditorElement
     void setBackgroundColor( const QColor &backgroundColor );
 
   private:
-    void saveConfiguration( QDomElement &elem ) const override;
+    void saveConfiguration( QDomElement &elem, QDomDocument &doc ) const override;
     QString typeIdentifier() const override;
 
     bool mIsGroupBox;
@@ -337,7 +322,7 @@ class CORE_EXPORT QgsAttributeEditorField : public QgsAttributeEditorElement
     QgsAttributeEditorElement *clone( QgsAttributeEditorElement *parent ) const override SIP_FACTORY;
 
   private:
-    void saveConfiguration( QDomElement &elem ) const override;
+    void saveConfiguration( QDomElement &elem, QDomDocument &doc ) const override;
     QString typeIdentifier() const override;
     int mIdx;
 };
@@ -480,8 +465,22 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
      */
     void setRelationWidgetTypeId( const QString &relationWidgetTypeId );
 
+    /**
+     * Returns the relation editor widget configuration
+     *
+     * \since QGIS 3.18
+     */
+    QVariantMap relationEditorConfiguration() const;
+
+    /**
+     * Sets the relation editor configuration
+     *
+     * \since QGIS 3.18
+     */
+    void setRelationEditorConfiguration( const QVariantMap &config );
+
   private:
-    void saveConfiguration( QDomElement &elem ) const override;
+    void saveConfiguration( QDomElement &elem, QDomDocument &doc ) const override;
     QString typeIdentifier() const override;
     QString mRelationId;
     QgsRelation mRelation;
@@ -490,6 +489,7 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
     QVariant mNmRelationId;
     QString mLabel;
     QString mRelationWidgetTypeId;
+    QVariantMap mRelationEditorConfig;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsAttributeEditorRelation::Buttons )
@@ -530,7 +530,7 @@ class CORE_EXPORT QgsAttributeEditorQmlElement : public QgsAttributeEditorElemen
     void setQmlCode( const QString &qmlCode );
 
   private:
-    void saveConfiguration( QDomElement &elem ) const override;
+    void saveConfiguration( QDomElement &elem, QDomDocument &doc ) const override;
     QString typeIdentifier() const override;
     QString mQmlCode;
 };
@@ -571,7 +571,7 @@ class CORE_EXPORT QgsAttributeEditorHtmlElement : public QgsAttributeEditorEleme
     void setHtmlCode( const QString &htmlCode );
 
   private:
-    void saveConfiguration( QDomElement &elem ) const override;
+    void saveConfiguration( QDomElement &elem, QDomDocument &doc ) const override;
     QString typeIdentifier() const override;
     QString mHtmlCode;
 };

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -543,15 +543,12 @@ void QgsEditFormConfig::writeXml( QDomNode &node, const QgsReadWriteContext &con
   if ( !tabs().empty() && d->mConfiguredRootContainer )
   {
     QDomElement tabsElem = doc.createElement( QStringLiteral( "attributeEditorForm" ) );
-
     QDomElement rootElem = d->mInvisibleRootContainer->toDomElement( doc );
     QDomNodeList elemList = rootElem.childNodes();
-
     while ( !elemList.isEmpty() )
     {
       tabsElem.appendChild( elemList.at( 0 ) );
     }
-
     node.appendChild( tabsElem );
   }
 
@@ -661,11 +658,11 @@ QgsAttributeEditorElement *QgsEditFormConfig::attributeEditorElementFromDomEleme
     // At this time, the relations are not loaded
     // So we only grab the id and delegate the rest to onRelationsLoaded()
     QgsAttributeEditorRelation *relElement = new QgsAttributeEditorRelation( elem.attribute( QStringLiteral( "relation" ), QStringLiteral( "[None]" ) ), parent );
-    QVariantMap config = QgsXmlUtils::readVariant( elem.firstChildElement( "config" ) ).toMap();
+    QVariantMap config = QgsXmlUtils::readVariant( elem.firstChildElement( "editor_configuration" ) ).toMap();
 
     // load defaults
     if ( config.isEmpty() )
-      config = relElement->config();
+      config = relElement->relationEditorConfiguration();
 
     // pre QGIS 3.18 compatibility
     if ( ! config.contains( QStringLiteral( "buttons" ) ) )
@@ -686,7 +683,7 @@ QgsAttributeEditorElement *QgsEditFormConfig::attributeEditorElementFromDomEleme
       }
     }
 
-    relElement->setConfig( config );
+    relElement->setRelationEditorConfiguration( config );
 
     if ( elem.hasAttribute( QStringLiteral( "forceSuppressFormPopup" ) ) )
     {

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1956,7 +1956,7 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
       // This needs to be after QgsAttributeFormRelationEditorWidget creation, because the widget
       // does not exists yet until QgsAttributeFormRelationEditorWidget is created and the setters
       // below directly alter the widget and check for it.
-      rww->setWidgetConfig( relDef->config() );
+      rww->setWidgetConfig( relDef->relationEditorConfiguration() );
       rww->setShowLabel( relDef->showLabel() );
       rww->setNmRelationId( relDef->nmRelationId() );
       rww->setForceSuppressFormPopup( relDef->forceSuppressFormPopup() );

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -413,7 +413,7 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       RelationEditorConfiguration relEdConfig;
 //      relEdConfig.buttons = relationEditor->visibleButtons();
       relEdConfig.mRelationWidgetType = relationEditor->relationWidgetTypeId();
-      relEdConfig.mRelationWidgetConfig = relationEditor->config();
+      relEdConfig.mRelationWidgetConfig = relationEditor->relationEditorConfiguration();
       relEdConfig.nmRelationId = relationEditor->nmRelationId();
       relEdConfig.forceSuppressFormPopup = relationEditor->forceSuppressFormPopup();
       relEdConfig.label = relationEditor->label();
@@ -662,7 +662,7 @@ QgsAttributeEditorElement *QgsAttributesFormProperties::createAttributeEditorWid
       QgsAttributeEditorRelation *relDef = new QgsAttributeEditorRelation( relation, parent );
       QgsAttributesFormProperties::RelationEditorConfiguration relationEditorConfig = itemData.relationEditorConfiguration();
       relDef->setRelationWidgetTypeId( relationEditorConfig.mRelationWidgetType );
-      relDef->setConfig( relationEditorConfig.mRelationWidgetConfig );
+      relDef->setRelationEditorConfiguration( relationEditorConfig.mRelationWidgetConfig );
       relDef->setNmRelationId( relationEditorConfig.nmRelationId );
       relDef->setForceSuppressFormPopup( relationEditorConfig.forceSuppressFormPopup );
       relDef->setLabel( relationEditorConfig.label );


### PR DESCRIPTION
The variant map for the config is really specific to the relation element, so move the variable + setter/getter to the proper class

There is an API break in the virtual private method saveConfiguration but since it was never added to SIP bindings, this was unusable.