### PR TITLE
Improve mssql loading with predefined extent/pkey

### DIFF
--- a/src/providers/mssql/qgsmssqlconnection.cpp
+++ b/src/providers/mssql/qgsmssqlconnection.cpp
@@ -167,6 +167,30 @@ void QgsMssqlConnection::setGeometryColumnsOnly( const QString &name, bool enabl
   settings.setValue( "/MSSQL/connections/" + name + "/geometryColumnsOnly", enabled );
 }
 
+bool QgsMssqlConnection::extentInGeometryColumns( const QString &name )
+{
+  QgsSettings settings;
+  return settings.value( "/MSSQL/connections/" + name + "/extentInGeometryColumns", false ).toBool();
+}
+
+void QgsMssqlConnection::setExtentInGeometryColumns( const QString &name, bool enabled )
+{
+  QgsSettings settings;
+  settings.setValue( "/MSSQL/connections/" + name + "/extentInGeometryColumns", enabled );
+}
+
+bool QgsMssqlConnection::primaryKeyInGeometryColumns( const QString &name )
+{
+  QgsSettings settings;
+  return settings.value( "/MSSQL/connections/" + name + "/primaryKeyInGeometryColumns", false ).toBool();
+}
+
+void QgsMssqlConnection::setPrimaryKeyInGeometryColumns( const QString &name, bool enabled )
+{
+  QgsSettings settings;
+  settings.setValue( "/MSSQL/connections/" + name + "/primaryKeyInGeometryColumns", enabled );
+}
+
 bool QgsMssqlConnection::allowGeometrylessTables( const QString &name )
 {
   QgsSettings settings;

--- a/src/providers/mssql/qgsmssqlconnection.h
+++ b/src/providers/mssql/qgsmssqlconnection.h
@@ -64,6 +64,51 @@ class QgsMssqlConnection
     static void setGeometryColumnsOnly( const QString &name, bool enabled );
 
     /**
+     * Returns whether the connection with matching \a name should,
+     * use the extent manually specified in the geometry_columns table using additional
+     * QGIS-specific columns: qgis_xmin, qgis_xmax, qgis_ymin, qgis_ymax.
+     *
+     * This is an optional optimization that allows QGIS to skip extent calculation when loading
+     * layers and thus lowering the amount of time needed to load them. The disadvantage
+     * is that the extent needs to be manually set and updated by database admins and it requires
+     * adding custom columns to the geometry_columns table.
+     *
+     * \see setExtentInGeometryColumns()
+     */
+    static bool extentInGeometryColumns( const QString &name );
+
+    /**
+     * Sets whether the connection with matching \a name should
+     *
+     * \see extentInGeometryColumns()
+     */
+    static void setExtentInGeometryColumns( const QString &name, bool enabled );
+
+    /**
+     * Returns whether the connection with matching \a name should
+     * determine primary key's column name from a manually specified value in the geometry_columns table using
+     * an additional QGIS-specific column called "qgis_pkey". If more than one column is used for the primary key,
+     * value of "qgis_pkey" can contain multiple column names separated by comma.
+     *
+     * Note: this option only applies to views: for tables the primary key is automatically fetched from table definition.
+     *
+     * This is an optional optimization that allows QGIS to skip primary key calculation for views when loading
+     * layers and thus lowering the amount of time needed to load them. The disadvantage
+     * is that the primary key column name needs to be manually set and updated by database admins
+     * and it requires adding a custom column to the geometry_columns table.
+     *
+     * \see setPrimaryKeyInGeometryColumn()
+     */
+    static bool primaryKeyInGeometryColumns( const QString &name );
+
+    /**
+     * Sets whether the connection with matching \a name should
+     *
+     * \see primaryKeyInGeometryColumns()
+     */
+    static void setPrimaryKeyInGeometryColumns( const QString &name, bool enabled );
+
+    /**
      * Returns true if the connection with matching \a name should
      * show geometryless tables when scanning for tables.
      *

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -509,6 +509,12 @@ QString QgsMssqlLayerItem::createUri()
   uri.setUseEstimatedMetadata( QgsMssqlConnection::useEstimatedMetadata( connItem->name() ) );
   mDisableInvalidGeometryHandling = QgsMssqlConnection::isInvalidGeometryHandlingDisabled( connItem->name() );
   uri.setParam( QStringLiteral( "disableInvalidGeometryHandling" ), mDisableInvalidGeometryHandling ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
+  if ( QgsMssqlConnection::geometryColumnsOnly( connItem->name() ) )
+  {
+    uri.setParam( QStringLiteral( "extentInGeometryColumns" ), QgsMssqlConnection::extentInGeometryColumns( connItem->name() ) ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
+  }
+  if ( mLayerProperty.isView )
+    uri.setParam( QStringLiteral( "primaryKeyInGeometryColumns" ), QgsMssqlConnection::primaryKeyInGeometryColumns( connItem->name() ) ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
 
   QgsDebugMsgLevel( QStringLiteral( "layer uri: %1" ).arg( uri.uri() ), 3 );
   return uri.uri();

--- a/src/providers/mssql/qgsmssqlnewconnection.h
+++ b/src/providers/mssql/qgsmssqlnewconnection.h
@@ -21,6 +21,8 @@
 #include "qgshelp.h"
 #include <QAbstractListModel>
 
+#include <QSqlDatabase>
+
 /**
  * \class QgsMssqlNewConnection
  * \brief Dialog to allow the user to configure and save connection
@@ -50,6 +52,10 @@ class QgsMssqlNewConnection : public QDialog, private Ui::QgsMssqlNewConnectionB
     //! Updates state of the OK button depending of the filled fields
     void updateOkButtonState();
     void onCurrentDataBaseChange();
+
+    void onExtentFromGeometryToggled( bool checked );
+    void onPrimaryKeyFromGeometryToggled( bool checked );
+
   private:
     //! Class that reprents a model to display available schemas on a database and choose which will be displayed in QGIS
     class SchemaModel: public QAbstractListModel
@@ -87,6 +93,11 @@ class QgsMssqlNewConnection : public QDialog, private Ui::QgsMssqlNewConnectionB
     QVariantMap mSchemaSettings; //store the schema settings edited during this QDialog life time
     SchemaModel mSchemaModel;
 
+    QSqlDatabase getDatabase( const QString &name = QString() ) const;
+
+    bool testExtentInGeometryColumns() const;
+
+    bool testPrimaryKeyInGeometryColumns() const;
 };
 
 #endif //  QGSMSSQLNEWCONNECTION_H

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -90,7 +90,7 @@ class QgsMssqlProvider final: public QgsVectorDataProvider
     long featureCount() const override;
 
     //! Update the extent, feature count, wkb type and srid for this layer
-    void UpdateStatistics( bool estimate, QgsError &error ) const;
+    void UpdateStatistics( bool estimate ) const;
 
     QgsFields fields() const override;
 

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -90,7 +90,7 @@ class QgsMssqlProvider final: public QgsVectorDataProvider
     long featureCount() const override;
 
     //! Update the extent, feature count, wkb type and srid for this layer
-    void UpdateStatistics( bool estimate ) const;
+    void UpdateStatistics( bool estimate, QgsError &error ) const;
 
     QgsFields fields() const override;
 
@@ -179,11 +179,12 @@ class QgsMssqlProvider final: public QgsVectorDataProvider
     //! Layer extent
     mutable QgsRectangle mExtent;
 
-    bool mValid;
+    bool mValid = false;
 
-    bool mUseWkb;
-    bool mUseEstimatedMetadata;
-    bool mSkipFailures;
+    bool mUseWkb = false;
+    bool mUseEstimatedMetadata = false;
+    bool mSkipFailures = false;
+    bool mUseGeometryColumnsTableForExtent = false;
 
     long mNumberFeatures = 0;
 
@@ -251,6 +252,11 @@ class QgsMssqlProvider final: public QgsVectorDataProvider
     QString whereClauseFid( QgsFeatureId fid );
 
     static QStringList parseUriKey( const QString &key );
+
+    //! Extract the extent from the geometry_columns table, returns false if fails
+    bool getExtentFromGeometryColumns( QgsRectangle &extent ) const;
+    //! Extract primary key(s) from the geometry_columns table, returns false if fails
+    bool getPrimaryKeyFromGeometryColumns( QStringList &primaryKeys );
 
     std::shared_ptr<QgsMssqlSharedData> mShared;
 

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -473,6 +473,7 @@ void QgsMssqlSourceSelect::btnConnect_clicked()
   QModelIndex rootItemIndex = mTableModel.indexFromItem( mTableModel.invisibleRootItem() );
   mTableModel.removeRows( 0, mTableModel.rowCount( rootItemIndex ), rootItemIndex );
 
+  mTableModel.setConnectionName( cmbConnections->currentText() );
   // populate the table list
   QgsSettings settings;
   QString key = "/MSSQL/connections/" + cmbConnections->currentText();

--- a/src/providers/mssql/qgsmssqltablemodel.h
+++ b/src/providers/mssql/qgsmssqltablemodel.h
@@ -75,6 +75,7 @@ class QgsMssqlTableModel : public QStandardItemModel
       DbtmPkCol,
       DbtmSelectAtId,
       DbtmSql,
+      DbtmView,
       DbtmColumns
     };
 
@@ -84,9 +85,12 @@ class QgsMssqlTableModel : public QStandardItemModel
 
     static QgsWkbTypes::Type wkbTypeFromMssql( QString dbType );
 
+    void setConnectionName( const QString &connectionName );
+
   private:
     //! Number of tables in the model
     int mTableCount = 0;
+    QString mConnectionName;
 };
 
 #endif

--- a/src/ui/qgsmssqlnewconnectionbase.ui
+++ b/src/ui/qgsmssqlnewconnectionbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>772</width>
-    <height>687</height>
+    <width>810</width>
+    <height>765</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -223,19 +223,49 @@ Untick save if you don't wish to be the case.</string>
        <widget class="QListWidget" name="listDatabase"/>
       </item>
       <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="cb_geometryColumns">
-        <property name="toolTip">
-         <string>If checked, only tables which are present in the &quot;geometry_columns&quot; metadata table will be available. This speeds up table scanning, but requires users to manually manage the geometry_columns table and ensure that layers are correctly represented in the table.</string>
-        </property>
-        <property name="text">
+       <widget class="QGroupBox" name="groupBoxGeometryColumns">
+        <property name="title">
          <string>Only look in the geometry_columns metadata table</string>
         </property>
-        <property name="checked">
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="flat">
          <bool>false</bool>
         </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>8</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QCheckBox" name="checkBoxExtentFromGeometryColumns">
+           <property name="text">
+            <string>Use layer extent from geometry_columns table</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
+      <item row="4" column="0" colspan="2">
        <widget class="QCheckBox" name="cb_allowGeometrylessTables">
         <property name="toolTip">
          <string>If checked, tables without a geometry column attached will also be shown in the available table lists.</string>
@@ -245,7 +275,7 @@ Untick save if you don't wish to be the case.</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="2">
+      <item row="5" column="0" colspan="2">
        <widget class="QCheckBox" name="cb_useEstimatedMetadata">
         <property name="toolTip">
          <string>If checked, only estimated table metadata will be used. This avoids a slow table scan, but may result in incorrect layer properties such as layer extent.</string>
@@ -258,7 +288,7 @@ Untick save if you don't wish to be the case.</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="0" colspan="2">
+      <item row="6" column="0" colspan="2">
        <widget class="QCheckBox" name="mCheckNoInvalidGeometryHandling">
         <property name="toolTip">
          <string>If checked, all handling of records with invalid geometry will be disabled. This speeds up the provider, however, if any invalid geometries are present in a table then the result is unpredictable and may include missing records. Only check this option if you are certain that all geometries present in the database are valid, and any newly added geometries or tables will also be valid.</string>
@@ -271,7 +301,20 @@ Untick save if you don't wish to be the case.</string>
         </property>
        </widget>
       </item>
-      <item row="7" column="0" colspan="2">
+      <item row="8" column="0" colspan="2">
+       <widget class="Line" name="line">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0" colspan="2">
        <widget class="QgsCollapsibleGroupBoxBasic" name="groupBoxSchemasFilter">
         <property name="title">
          <string>Use Only a Subset of Schemas</string>
@@ -304,10 +347,17 @@ Untick save if you don't wish to be the case.</string>
         </layout>
        </widget>
       </item>
-      <item row="8" column="0" colspan="2">
+      <item row="10" column="0" colspan="2">
        <widget class="QPushButton" name="btnConnect">
         <property name="text">
          <string>Test Connection</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="checkBoxPKFromGeometryColumns">
+        <property name="text">
+         <string>Use primary key from geometry_columns table</string>
         </property>
        </widget>
       </item>
@@ -354,7 +404,6 @@ Untick save if you don't wish to be the case.</string>
   <tabstop>chkStorePassword</tabstop>
   <tabstop>btnListDatabase</tabstop>
   <tabstop>listDatabase</tabstop>
-  <tabstop>cb_geometryColumns</tabstop>
   <tabstop>cb_allowGeometrylessTables</tabstop>
   <tabstop>cb_useEstimatedMetadata</tabstop>
   <tabstop>mCheckNoInvalidGeometryHandling</tabstop>

--- a/tests/src/python/test_provider_mssql.py
+++ b/tests/src/python/test_provider_mssql.py
@@ -713,10 +713,13 @@ class TestPyQgsMssqlProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(extent.toString(1),
                          QgsRectangle(1.0, 2.0, 4.0, 3.0).toString(1))
 
-        # Load with flag extent in geometry_columns table and check if the layer is not valid (no extent yet in geometry_columns)
+        # Load with flag extent in geometry_columns table and check if the layer is still valid and extent doesn't change
         layerUri.setParam('extentInGeometryColumns', '1')
         loadedLayer = QgsVectorLayer(layerUri.uri(), "invalid", "mssql")
-        self.assertFalse(loadedLayer.isValid())
+        self.assertTrue(loadedLayer.isValid())
+        extent = loadedLayer.extent()
+        self.assertEqual(extent.toString(1),
+                         QgsRectangle(1.0, 2.0, 4.0, 3.0).toString(1))
 
         md = QgsProviderRegistry.instance().providerMetadata('mssql')
         conn = md.createConnection(self.dbconn, {})
@@ -728,7 +731,11 @@ class TestPyQgsMssqlProvider(unittest.TestCase, ProviderTestCase):
         # try with empty attribute
         layerUri.setParam('extentInGeometryColumns', '1')
         loadedLayer = QgsVectorLayer(layerUri.uri(), "invalid", "mssql")
-        self.assertFalse(loadedLayer.isValid())
+        self.assertTrue(loadedLayer.isValid())
+        self.assertTrue(loadedLayer.isValid())
+        extent = loadedLayer.extent()
+        self.assertEqual(extent.toString(1),
+                         QgsRectangle(1.0, 2.0, 4.0, 3.0).toString(1))
 
         conn.execSql('UPDATE dbo.geometry_columns SET qgis_xmin=0, qgis_xmax=5.5, qgis_ymin=0.5, qgis_ymax=6 WHERE f_table_name=\'layer_extent_in_geometry_table\'')
 

--- a/tests/src/python/test_provider_mssql.py
+++ b/tests/src/python/test_provider_mssql.py
@@ -707,12 +707,11 @@ class TestPyQgsMssqlProvider(unittest.TestCase, ProviderTestCase):
 
         layerUri = QgsDataSourceUri(uri)
         # Load and check if the layer is valid
-        loadedLayer = QgsVectorLayer(layerUri.uri(),"valid","mssql")
+        loadedLayer = QgsVectorLayer(layerUri.uri(), "valid", "mssql")
         self.assertTrue(loadedLayer.isValid())
         extent = loadedLayer.extent()
         self.assertEqual(extent.toString(1),
                          QgsRectangle(1.0, 2.0, 4.0, 3.0).toString(1))
-
 
         # Load with flag extent in geometry_columns table and check if the layer is not valid (no extent yet in geometry_columns)
         layerUri.setParam('extentInGeometryColumns', '1')
@@ -740,6 +739,7 @@ class TestPyQgsMssqlProvider(unittest.TestCase, ProviderTestCase):
         extent = loadedLayer.extent()
         self.assertEqual(extent.toString(1),
                          QgsRectangle(0.0, 0.5, 5.5, 6.0).toString(1))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Most of the time during layer loading is spent by determining map layer extent and by determining primary key(s) for views. The idea is to allow database administrators to optionally specify these pieces of information so that QGIS does not need to scan data which may take too long.

This is done by extending dbo.geometry_columns tables and adding extra columns: 
* for extent : qgis_xmin, qgis_xmax, qgis_ymin, qgis_ymax
* for primary key :  qgis_pkey

In database connection configuration widget, there is two extra checkboxes:
* to use layer extent from the extra columns
* to use the primary key from the extra column

Names of the extra expected column names in geometry_columns is hardcoded, to make the configuration simpler.

The warnings show up during the connection settings if corresponding columns are not present. Loading a layer (e.g. from an existing QGIS project) with missing columns in geometry_columns table results in ~~an invalid~~ a valid layer with default way to obtains extent/primary key and the issue is logged as warning in QGIS logs (accessible to the user).

![mssql_1](https://user-images.githubusercontent.com/7416892/104206261-b1d49200-5405-11eb-8022-2f913f6bf58f.gif)

![mssql_2](https://user-images.githubusercontent.com/7416892/104206277-b5681900-5405-11eb-9e38-804684d11a41.gif)

Work funded by ms.GIS