### PR TITLE
[Oracle] Fix Oracle empty layer creation when there is no geometry

### DIFF
--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -2994,7 +2994,7 @@ QgsVectorLayerExporter::ExportError QgsOracleProvider::createEmptyLayer(
 
   const bool hasPrimaryKey = !primaryKey.isEmpty() && !primaryKeyType.isEmpty();
 
-  // Oracle doesn't allow to create a table without any column, so we add a fake one
+  // It's not possible to create a table without any column, so we add a fake one
   // if needed, and will remove it later
   const QString fakeColumn = geometryColumn.isEmpty() && !hasPrimaryKey ?
                              QString( "fake_column_%1" ).arg( QUuid::createUuid().toString( QUuid::Id128 ) ) : QString();

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -2997,7 +2997,7 @@ QgsVectorLayerExporter::ExportError QgsOracleProvider::createEmptyLayer(
   // It's not possible to create a table without any column, so we add a fake one
   // if needed, and will remove it later
   const QString fakeColumn = geometryColumn.isEmpty() && !hasPrimaryKey ?
-                             QString( "fake_column_%1" ).arg( QUuid::createUuid().toString( QUuid::Id128 ) ) : QString();
+                             QString( "fake_column_%1" ).arg( QUuid::createUuid().toString() ) : QString();
 
   try
   {

--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -202,6 +202,13 @@ class QgsOracleProvider final: public QgsVectorDataProvider
     static QgsCoordinateReferenceSystem lookupCrs( QgsOracleConn *conn, int srsid );
 
     /**
+     * Insert \a geometryColumn column from table \a tableName in Oracle geometry metadata table with given \a srs coordinate
+     * reference system, using \a conn connection
+     * Throws OracleException if an error occured.
+     */
+    static void insertGeomMetadata( QgsOracleConn *conn, const QString &tableName, const QString &geometryColumn, const QgsCoordinateReferenceSystem &srs );
+
+    /**
      * Evaluates the given expression string server-side and convert the result to the given type
      */
     QVariant evaluateDefaultExpression( const QString &value, const QVariant::Type &fieldType ) const;

--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -204,7 +204,7 @@ class QgsOracleProvider final: public QgsVectorDataProvider
     /**
      * Insert \a geometryColumn column from table \a tableName in Oracle geometry metadata table with given \a srs coordinate
      * reference system, using \a conn connection
-     * Throws OracleException if an error occured.
+     * Throws OracleException if an error occurred.
      */
     static void insertGeomMetadata( QgsOracleConn *conn, const QString &tableName, const QString &geometryColumn, const QgsCoordinateReferenceSystem &srs );
 

--- a/tests/src/python/test_provider_oracle.py
+++ b/tests/src/python/test_provider_oracle.py
@@ -26,6 +26,7 @@ from qgis.core import (
     QgsWkbTypes,
     QgsDataProvider,
     QgsVectorLayerExporter,
+    QgsField,
     QgsFields,
     QgsCoordinateReferenceSystem
 )
@@ -848,6 +849,42 @@ class TestPyQgsOracleProvider(unittest.TestCase, ProviderTestCase):
             self.dbconn + ' sslmode=disable table="QGIS"."EMPTY_LAYER" sql=',
             'test', 'oracle')
         self.assertTrue(vl.isValid())
+
+    def testCreateAspatialLayer(self):
+        """
+        Test creation of a non-spatial layer
+        """
+
+        # cleanup (it seems overwrite option doesn't clean the sdo_geom_metadata table)
+        self.execSQLCommand('DROP TABLE "QGIS"."ASPATIAL_LAYER"', ignore_errors=True)
+
+        fields = QgsFields()
+        fields.append(QgsField("INTEGER_T", QVariant.Int))
+
+        uri = self.dbconn + "table=\"ASPATIAL_LAYER\""
+        exporter = QgsVectorLayerExporter(uri=uri, provider='oracle', fields=fields, geometryType=QgsWkbTypes.NoGeometry, crs=QgsCoordinateReferenceSystem(), overwrite=True)
+        self.assertEqual(exporter.errorCount(), 0)
+        self.assertEqual(exporter.errorCode(), 0)
+
+        self.execSQLCommand('SELECT count(*) FROM "QGIS"."ASPATIAL_LAYER"')
+        vl = QgsVectorLayer(self.dbconn + ' sslmode=disable table="QGIS"."ASPATIAL_LAYER" sql=', 'test', 'oracle')
+        self.assertTrue(vl.isValid())
+
+        self.assertEqual(vl.fields().names(), ["INTEGER_T"])
+
+    def testCreateInvalidLayer(self):
+        """
+        Test creation of an invalid layer (no geometry, no column)
+        """
+
+        # cleanup (it seems overwrite option doesn't clean the sdo_geom_metadata table)
+        self.execSQLCommand('DROP TABLE "QGIS"."INVALID_LAYER"', ignore_errors=True)
+
+        fields = QgsFields()
+
+        uri = self.dbconn + "table=\"INVALID_LAYER\""
+        exporter = QgsVectorLayerExporter(uri=uri, provider='oracle', fields=fields, geometryType=QgsWkbTypes.NoGeometry, crs=QgsCoordinateReferenceSystem(), overwrite=True)
+        self.assertEqual(exporter.errorCode(), QgsVectorLayerExporter.ErrCreateDataSource)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix Oracle create empty layer when there is no geometry

- Don't insert in geom metadata table when there is no geometry
- Use a temporary column when there is no geom to create the table and later add the fields, because it's not possible to create a table with no columns in Oracle
- add a method to insert in geom metadata table for better readability

