### PR TITLE
Fix wmts handling of static time lists

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -88,10 +88,10 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
     mTemporalExtent = uri.param( QStringLiteral( "timeDimensionExtent" ) );
     mTimeDimensionExtent = parseTemporalExtent( mTemporalExtent );
 
-    if ( mTimeDimensionExtent.datesResolutionList.first().dates.dateTimes.size() > 0 )
+    if ( mTimeDimensionExtent.datesResolutionList.constFirst().dates.dateTimes.size() > 0 )
     {
-      QDateTime begin = mTimeDimensionExtent.datesResolutionList.first().dates.dateTimes.first();
-      QDateTime end = mTimeDimensionExtent.datesResolutionList.last().dates.dateTimes.last();
+      QDateTime begin = mTimeDimensionExtent.datesResolutionList.constFirst().dates.dateTimes.first();
+      QDateTime end = mTimeDimensionExtent.datesResolutionList.constLast().dates.dateTimes.last();
 
       mFixedRange =  QgsDateTimeRange( begin, end );
     }
@@ -104,10 +104,10 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
 
       mReferenceTimeDimensionExtent = parseTemporalExtent( referenceExtent );
 
-      if ( mReferenceTimeDimensionExtent.datesResolutionList.first().dates.dateTimes.size() > 0 )
+      if ( mReferenceTimeDimensionExtent.datesResolutionList.constFirst().dates.dateTimes.size() > 0 )
       {
-        QDateTime begin = mReferenceTimeDimensionExtent.datesResolutionList.first().dates.dateTimes.first();
-        QDateTime end = mReferenceTimeDimensionExtent.datesResolutionList.last().dates.dateTimes.last();
+        QDateTime begin = mReferenceTimeDimensionExtent.datesResolutionList.constFirst().dates.dateTimes.first();
+        QDateTime end = mReferenceTimeDimensionExtent.datesResolutionList.constLast().dates.dateTimes.last();
 
         mFixedReferenceRange =  QgsDateTimeRange( begin, end );
       }
@@ -188,7 +188,7 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
   if ( uri.hasParam( QStringLiteral( "tileDimensions" ) ) )
   {
     mTiled = true;
-    const auto tileDimensions = uri.param( "tileDimensions" ).split( ';' );
+    const auto tileDimensions = uri.param( QStringLiteral( "tileDimensions" ) ).split( ';' );
     for ( const QString &param : tileDimensions )
     {
       QStringList kv = param.split( '=' );
@@ -217,7 +217,7 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
   return true;
 }
 
-QgsWmstDimensionExtent QgsWmsSettings::parseTemporalExtent( QString extent )
+QgsWmstDimensionExtent QgsWmsSettings::parseTemporalExtent( const QString &extent )
 {
   QgsWmstDimensionExtent dimensionExtent;
   if ( extent.isNull() )
@@ -299,7 +299,7 @@ QgsWmstDimensionExtent QgsWmsSettings::parseTemporalExtent( QString extent )
   return dimensionExtent;
 }
 
-void QgsWmsSettings::setTimeDimensionExtent( QgsWmstDimensionExtent timeDimensionExtent )
+void QgsWmsSettings::setTimeDimensionExtent( const QgsWmstDimensionExtent &timeDimensionExtent )
 {
   mTimeDimensionExtent = timeDimensionExtent;
 }
@@ -309,7 +309,7 @@ QgsWmstDimensionExtent QgsWmsSettings::timeDimensionExtent() const
   return mTimeDimensionExtent;
 }
 
-QDateTime QgsWmsSettings::addTime( QDateTime dateTime, QgsWmstResolution resolution )
+QDateTime QgsWmsSettings::addTime( const QDateTime &dateTime, const QgsWmstResolution &resolution )
 {
   QDateTime resultDateTime = QDateTime( dateTime );
 
@@ -329,7 +329,7 @@ QDateTime QgsWmsSettings::addTime( QDateTime dateTime, QgsWmstResolution resolut
   return resultDateTime;
 }
 
-QDateTime QgsWmsSettings::findLeastClosestDateTime( QDateTime dateTime, bool dateOnly ) const
+QDateTime QgsWmsSettings::findLeastClosestDateTime( const QDateTime &dateTime, bool dateOnly ) const
 {
   QDateTime closest = dateTime;
 
@@ -367,8 +367,9 @@ QDateTime QgsWmsSettings::findLeastClosestDateTime( QDateTime dateTime, bool dat
   return closest;
 }
 
-QgsWmstResolution QgsWmsSettings::parseWmstResolution( QString item )
+QgsWmstResolution QgsWmsSettings::parseWmstResolution( const QString &itemText )
 {
+  QString item = itemText;
   QgsWmstResolution resolution;
   bool found = false;
 
@@ -447,7 +448,7 @@ QgsWmstResolution QgsWmsSettings::parseWmstResolution( QString item )
   return resolution;
 }
 
-QDateTime QgsWmsSettings::parseWmstDateTimes( QString item )
+QDateTime QgsWmsSettings::parseWmstDateTimes( const QString &item )
 {
   // Standard item will have YYYY-MM-DDTHH:mm:ss.SSSZ
   //  format a Qt::ISODateWithMs

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -316,26 +316,40 @@ QDateTime QgsWmsSettings::findLeastClosestDateTime( const QDateTime &dateTime, b
 
   for ( const QgsWmstExtentPair &pair : mTimeDimensionExtent.datesResolutionList )
   {
-    if ( pair.dates.dateTimes.size() < 2 )
+    if ( pair.dates.dateTimes.empty() )
+    {
       continue;
+    }
+    else if ( pair.dates.dateTimes.size() == 1 )
+    {
+      long long startSeconds = pair.dates.dateTimes.at( 0 ).toSecsSinceEpoch();
 
-    long long startSeconds = pair.dates.dateTimes.at( 0 ).toSecsSinceEpoch();
-    long long endSeconds = pair.dates.dateTimes.at( 1 ).toSecsSinceEpoch();
+      // if out of bounds
+      if ( seconds < startSeconds )
+        continue;
 
-    // if out of bounds
-    if ( seconds < startSeconds || seconds > endSeconds )
-      continue;
-    if ( seconds == endSeconds )
-      break;
+      closest = pair.dates.dateTimes.at( 0 );
+    }
+    else
+    {
+      long long startSeconds = pair.dates.dateTimes.at( 0 ).toSecsSinceEpoch();
+      long long endSeconds = pair.dates.dateTimes.at( 1 ).toSecsSinceEpoch();
 
-    long long resolutionSeconds = pair.resolution.interval();
+      // if out of bounds
+      if ( seconds < startSeconds || seconds > endSeconds )
+        continue;
+      if ( seconds == endSeconds )
+        break;
 
-    if ( resolutionSeconds <= 0 )
-      continue;
-    long long step = std::floor( ( seconds - startSeconds ) / resolutionSeconds );
-    long long resultSeconds = startSeconds + ( step * resolutionSeconds );
+      long long resolutionSeconds = pair.resolution.interval();
 
-    closest.setSecsSinceEpoch( resultSeconds );
+      if ( resolutionSeconds <= 0 )
+        continue;
+      long long step = std::floor( ( seconds - startSeconds ) / resolutionSeconds );
+      long long resultSeconds = startSeconds + ( step * resolutionSeconds );
+
+      closest.setSecsSinceEpoch( resultSeconds );
+    }
   }
 
   return closest;

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -444,7 +444,7 @@ QDateTime QgsWmsSettings::parseWmstDateTimes( const QString &item )
 
   // Check if it does not have time part
   if ( !item.contains( 'T' ) )
-    return QDateTime::fromString( item, "yyyy-MM-dd" );
+    return QDateTime::fromString( item, QStringLiteral( "yyyy-MM-dd" ) );
   else if ( item.contains( '.' ) )
     return QDateTime::fromString( item, Qt::ISODateWithMs );
   else

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -223,37 +223,26 @@ QgsWmstDimensionExtent QgsWmsSettings::parseTemporalExtent( const QString &exten
   if ( extent.isNull() )
     return dimensionExtent;
 
-  bool containResolution = false;
+  const QStringList parts = extent.split( ',' );
 
-  QStringList parts;
-
-  if ( extent.contains( ',' ) )
-    parts = extent.split( ',' );
-  else
-    parts.append( extent );
-
-  QStringListIterator iter( parts );
-
-  while ( iter.hasNext() )
+  for ( const QString &part : parts )
   {
-    QString item = iter.next();
-    QStringList itemParts;
+    const QString item = part;
 
     // If item contain '/' content separator, it is an interval
     if ( item.contains( '/' ) )
     {
-      itemParts = item.split( '/' );
-      QStringListIterator itemIter( itemParts );
-      QgsWmstExtentPair itemPair;
+      const QStringList itemParts = item.split( '/' );
 
+      QgsWmstExtentPair itemPair;
       QgsWmstResolution itemResolution = itemPair.resolution;
       QgsWmstDates itemDatesList = itemPair.dates;
 
       bool itemContainResolution = false;
 
-      while ( itemIter.hasNext() )
+      for ( const QString &itemPart : itemParts )
       {
-        QString itemContent = itemIter.next();
+        QString itemContent = itemPart;
 
         if ( itemContent.startsWith( 'P' ) )
         {
@@ -340,7 +329,7 @@ QDateTime QgsWmsSettings::findLeastClosestDateTime( const QDateTime &dateTime, b
   else
     seconds = closest.toSecsSinceEpoch();
 
-  for ( QgsWmstExtentPair pair : mTimeDimensionExtent.datesResolutionList )
+  for ( const QgsWmstExtentPair &pair : mTimeDimensionExtent.datesResolutionList )
   {
     if ( pair.dates.dateTimes.size() < 2 )
       continue;

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -325,7 +325,7 @@ QDateTime QgsWmsSettings::findLeastClosestDateTime( const QDateTime &dateTime, b
   long long seconds;
 
   if ( dateOnly )
-    seconds = QDateTime::fromString( closest.date().toString() ).toSecsSinceEpoch();
+    seconds = QDateTime( closest.date(), QTime( 0, 0, 0 ) ).toSecsSinceEpoch();
   else
     seconds = closest.toSecsSinceEpoch();
 

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -220,34 +220,30 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
 QgsWmstDimensionExtent QgsWmsSettings::parseTemporalExtent( const QString &extent )
 {
   QgsWmstDimensionExtent dimensionExtent;
-  if ( extent.isNull() )
+  if ( extent.isEmpty() )
     return dimensionExtent;
 
   const QStringList parts = extent.split( ',' );
 
   for ( const QString &part : parts )
   {
-    const QString item = part;
+    const QString item = part.trimmed();
 
     // If item contain '/' content separator, it is an interval
     if ( item.contains( '/' ) )
     {
       const QStringList itemParts = item.split( '/' );
 
-      QgsWmstExtentPair itemPair;
-      QgsWmstResolution itemResolution = itemPair.resolution;
-      QgsWmstDates itemDatesList = itemPair.dates;
-
-      bool itemContainResolution = false;
+      QgsWmstResolution itemResolution;
+      QgsWmstDates itemDatesList;
 
       for ( const QString &itemPart : itemParts )
       {
-        QString itemContent = itemPart;
+        QString itemContent = itemPart.trimmed();
 
         if ( itemContent.startsWith( 'P' ) )
         {
           itemResolution = parseWmstResolution( itemContent );
-          itemContainResolution = true;
         }
         else
         {
@@ -255,34 +251,23 @@ QgsWmstDimensionExtent QgsWmsSettings::parseTemporalExtent( const QString &exten
         }
       }
 
-      if ( itemContainResolution )
-        dimensionExtent.datesResolutionList.append( QgsWmstExtentPair( itemDatesList, itemResolution ) );
+      dimensionExtent.datesResolutionList.append( QgsWmstExtentPair( itemDatesList, itemResolution ) );
+    }
+    else
+    {
+      QgsWmstResolution resolution;
+      QgsWmstDates datesList;
+      if ( item.startsWith( 'P' ) )
+      {
+        resolution = parseWmstResolution( item );
+      }
       else
-        dimensionExtent.datesResolutionList.append( QgsWmstExtentPair( itemDatesList, QgsWmstResolution() ) );
-      itemContainResolution = false;
-      continue;
-    }
+      {
+        datesList.dateTimes.append( parseWmstDateTimes( item ) );
+      }
 
-    QgsWmstExtentPair pair;
-
-    QgsWmstResolution resolution = pair.resolution;
-    QgsWmstDates datesList = pair.dates;
-
-    if ( item.startsWith( 'P' ) )
-    {
-      resolution = parseWmstResolution( item );
-      containResolution = true;
-    }
-    else
-    {
-      datesList.dateTimes.append( parseWmstDateTimes( item ) );
-    }
-
-    if ( containResolution )
       dimensionExtent.datesResolutionList.append( QgsWmstExtentPair( datesList, resolution ) );
-    else
-      dimensionExtent.datesResolutionList.append( QgsWmstExtentPair( datesList, QgsWmstResolution() ) );
-    containResolution = false;
+    }
   }
 
   return dimensionExtent;

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -436,7 +436,7 @@ struct QgsWmstResolution
   int minutes = -1;
   int seconds = -1;
 
-  long long interval()
+  long long interval() const
   {
     long long secs = 0.0;
 
@@ -456,13 +456,13 @@ struct QgsWmstResolution
     return secs;
   }
 
-  bool active()
+  bool active() const
   {
     return year != -1 || month != -1 || day != -1 ||
            hour != -1 || minutes != -1 || seconds != -1;
   }
 
-  QString text()
+  QString text() const
   {
     QString text( "P" );
 
@@ -506,7 +506,7 @@ struct QgsWmstResolution
     return text;
   }
 
-  bool operator== ( const QgsWmstResolution &other )
+  bool operator==( const QgsWmstResolution &other ) const
   {
     return year == other.year && month == other.month &&
            day == other.day && hour == other.hour &&
@@ -815,7 +815,7 @@ class QgsWmsSettings
      *
      * \since QGIS 3.14
      */
-    QgsWmstDimensionExtent parseTemporalExtent( QString extent );
+    QgsWmstDimensionExtent parseTemporalExtent( const QString &extent );
 
     /**
      * Sets the dimension extent property
@@ -823,7 +823,7 @@ class QgsWmsSettings
      * \see timeDimensionExtent()
      * \since QGIS 3.14
      */
-    void setTimeDimensionExtent( QgsWmstDimensionExtent timeDimensionExtent );
+    void setTimeDimensionExtent( const QgsWmstDimensionExtent &timeDimensionExtent );
 
     /**
      * Returns the dimension extent property.
@@ -838,21 +838,21 @@ class QgsWmsSettings
      *
      * \since QGIS 3.14
      */
-    QgsWmstResolution parseWmstResolution( QString item );
+    QgsWmstResolution parseWmstResolution( const QString &item );
 
     /**
      * Parse the given string item into QDateTime instant.
      *
      * \since QGIS 3.14
      */
-    QDateTime parseWmstDateTimes( QString item );
+    QDateTime parseWmstDateTimes( const QString &item );
 
     /**
      * Returns the datetime with the sum of passed \a dateTime and the \a resolution time.
      *
      * \since QGIS 3.14
      */
-    QDateTime addTime( QDateTime dateTime, QgsWmstResolution resolution );
+    QDateTime addTime( const QDateTime &dateTime, const QgsWmstResolution &resolution );
 
     /**
      * Finds the least closest datetime from list of available dimension temporal ranges
@@ -862,7 +862,7 @@ class QgsWmsSettings
      *
      * \since QGIS 3.14
      */
-    QDateTime findLeastClosestDateTime( QDateTime dateTime, bool dateOnly = false ) const;
+    QDateTime findLeastClosestDateTime( const QDateTime &dateTime, bool dateOnly = false ) const;
 
   protected:
     QgsWmsParserSettings    mParserSettings;

--- a/tests/src/providers/testqgswmscapabilities.cpp
+++ b/tests/src/providers/testqgswmscapabilities.cpp
@@ -201,6 +201,34 @@ class TestQgsWmsCapabilities: public QObject
       QCOMPARE( prop.dimensions.at( 0 ).units, QStringLiteral( "ISO8601" ) );
     }
 
+    void wmstListOfTimeExtents()
+    {
+      // test parsing a fixed list of time extents
+      QgsWmsSettings settings;
+
+      QgsWmstDimensionExtent extent = settings.parseTemporalExtent( QStringLiteral( "1932-01-01T00:00:00Z, 1947-01-01T00:00:00Z, 1950-01-01T00:00:00Z, 1959-01-01T00:00:00Z, 1960-01-01T00:00:00Z, 1967-01-01T00:00:00Z, 1972-01-01T00:00:00Z, 1974-01-01T00:00:00Z" ) );
+      settings.setTimeDimensionExtent( extent );
+
+      QCOMPARE( extent.datesResolutionList.size(), 8 );
+      QCOMPARE( extent.datesResolutionList.at( 0 ).dates.dateTimes.size(), 1 );
+      QCOMPARE( extent.datesResolutionList.at( 0 ).dates.dateTimes.at( 0 ), QDateTime( QDate( 1932, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( extent.datesResolutionList.at( 1 ).dates.dateTimes.size(), 1 );
+      QCOMPARE( extent.datesResolutionList.at( 1 ).dates.dateTimes.at( 0 ), QDateTime( QDate( 1947, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( extent.datesResolutionList.at( 2 ).dates.dateTimes.size(), 1 );
+      QCOMPARE( extent.datesResolutionList.at( 2 ).dates.dateTimes.at( 0 ), QDateTime( QDate( 1950, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( extent.datesResolutionList.at( 3 ).dates.dateTimes.size(), 1 );
+      QCOMPARE( extent.datesResolutionList.at( 3 ).dates.dateTimes.at( 0 ), QDateTime( QDate( 1959, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( extent.datesResolutionList.at( 4 ).dates.dateTimes.size(), 1 );
+      QCOMPARE( extent.datesResolutionList.at( 4 ).dates.dateTimes.at( 0 ), QDateTime( QDate( 1960, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( extent.datesResolutionList.at( 5 ).dates.dateTimes.size(), 1 );
+      QCOMPARE( extent.datesResolutionList.at( 5 ).dates.dateTimes.at( 0 ), QDateTime( QDate( 1967, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( extent.datesResolutionList.at( 6 ).dates.dateTimes.size(), 1 );
+      QCOMPARE( extent.datesResolutionList.at( 6 ).dates.dateTimes.at( 0 ), QDateTime( QDate( 1972, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( extent.datesResolutionList.at( 7 ).dates.dateTimes.size(), 1 );
+      QCOMPARE( extent.datesResolutionList.at( 7 ).dates.dateTimes.at( 0 ), QDateTime( QDate( 1974, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+    }
+
+
     void wmsTemporalDimension_data()
     {
       QTest::addColumn<QString>( "dimension" );

--- a/tests/src/providers/testqgswmscapabilities.cpp
+++ b/tests/src/providers/testqgswmscapabilities.cpp
@@ -226,8 +226,20 @@ class TestQgsWmsCapabilities: public QObject
       QCOMPARE( extent.datesResolutionList.at( 6 ).dates.dateTimes.at( 0 ), QDateTime( QDate( 1972, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
       QCOMPARE( extent.datesResolutionList.at( 7 ).dates.dateTimes.size(), 1 );
       QCOMPARE( extent.datesResolutionList.at( 7 ).dates.dateTimes.at( 0 ), QDateTime( QDate( 1974, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
-    }
 
+      QCOMPARE( settings.findLeastClosestDateTime( QDateTime( QDate( 1930, 1, 2 ), QTime( 0, 0, 0 ), Qt::UTC ) ),  QDateTime( QDate( 1930, 1, 2 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( settings.findLeastClosestDateTime( QDateTime( QDate( 1932, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) ),  QDateTime( QDate( 1932, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( settings.findLeastClosestDateTime( QDateTime( QDate( 1932, 1, 2 ), QTime( 0, 0, 0 ), Qt::UTC ) ),  QDateTime( QDate( 1932, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( settings.findLeastClosestDateTime( QDateTime( QDate( 1933, 1, 2 ), QTime( 0, 0, 0 ), Qt::UTC ) ),  QDateTime( QDate( 1932, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( settings.findLeastClosestDateTime( QDateTime( QDate( 1947, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) ),  QDateTime( QDate( 1947, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( settings.findLeastClosestDateTime( QDateTime( QDate( 1949, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) ),  QDateTime( QDate( 1947, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( settings.findLeastClosestDateTime( QDateTime( QDate( 1950, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) ),  QDateTime( QDate( 1950, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( settings.findLeastClosestDateTime( QDateTime( QDate( 1950, 1, 2 ), QTime( 0, 0, 0 ), Qt::UTC ) ),  QDateTime( QDate( 1950, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( settings.findLeastClosestDateTime( QDateTime( QDate( 1973, 12, 31 ), QTime( 0, 0, 0 ), Qt::UTC ) ),  QDateTime( QDate( 1972, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( settings.findLeastClosestDateTime( QDateTime( QDate( 1974, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) ),  QDateTime( QDate( 1974, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( settings.findLeastClosestDateTime( QDateTime( QDate( 1974, 1, 2 ), QTime( 0, 0, 0 ), Qt::UTC ) ),  QDateTime( QDate( 1974, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QCOMPARE( settings.findLeastClosestDateTime( QDateTime( QDate( 2000, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) ),  QDateTime( QDate( 1974, 1, 1 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+    }
 
     void wmsTemporalDimension_data()
     {


### PR DESCRIPTION
Fixes issues accessing https://datacube.services.geo.ca/ows/aerial?service=wms using the temporal framework, where previously the list of available times could not be parsed 