### PR TITLE
Silence OpenType support missing Qt warning

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -400,7 +400,8 @@ void myMessageOutput( QtMsgType type, const QMessageLogContext &, const QString 
        * - QtSVG warnings with regards to lack of implementation beyond Tiny SVG 1.2
        */
       if ( msg.startsWith( QLatin1String( "libpng warning: iCCP: known incorrect sRGB profile" ), Qt::CaseInsensitive ) ||
-           msg.contains( QLatin1String( "Could not add child element to parent element because the types are incorrect" ), Qt::CaseInsensitive ) )
+           msg.contains( QLatin1String( "Could not add child element to parent element because the types are incorrect" ), Qt::CaseInsensitive ) ||
+           msg.contains( QLatin1String( "OpenType support missing for" ), Qt::CaseInsensitive ) )
         break;
 
       myPrint( "Warning: %s\n", msg.toLocal8Bit().constData() );


### PR DESCRIPTION
## Description

This PR kills a OpenType support missing Qt warning, which merely spams the console and triggers a message bar when QGIS is compiled in debug mode:
![image](https://user-images.githubusercontent.com/1728657/104268398-6635ed00-54c6-11eb-8cd5-310a0d80ed38.png)

This warning had been forcing me to ignore startup errors in the message bar, which is bad .