### PR TITLE
[OTB] Fixes empty string parameters

### DIFF
--- a/python/plugins/processing/algs/otb/OtbAlgorithm.py
+++ b/python/plugins/processing/algs/otb/OtbAlgorithm.py
@@ -204,7 +204,7 @@ class OtbAlgorithm(QgsProcessingAlgorithm):
         command = '"{}" {} {}'.format(app_launcher_path, self.name(), OtbUtils.appFolder())
         outputPixelType = None
         for k, v in parameters.items():
-            # if value is None or en empty string for a parameter we don't have any businees with this key
+            # if value is None or en empty string for a parameter then we don't want to pass that value to OTB (see https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/issues/2130)
             if v == '' or v is None:
                 continue
             # for 'outputpixeltype' parameter we find the pixeltype string from self.pixelTypes

--- a/python/plugins/processing/algs/otb/OtbAlgorithm.py
+++ b/python/plugins/processing/algs/otb/OtbAlgorithm.py
@@ -204,8 +204,8 @@ class OtbAlgorithm(QgsProcessingAlgorithm):
         command = '"{}" {} {}'.format(app_launcher_path, self.name(), OtbUtils.appFolder())
         outputPixelType = None
         for k, v in parameters.items():
-            # if value is None for a parameter we don't have any businees with this key
-            if v is None:
+            # if value is None or en empty string for a parameter we don't have any businees with this key
+            if v == '' or v is None:
                 continue
             # for 'outputpixeltype' parameter we find the pixeltype string from self.pixelTypes
             if k == 'outputpixeltype':

--- a/python/plugins/processing/tests/testdata/otb_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/otb_algorithm_tests.yaml
@@ -64,3 +64,19 @@ tests:
       out:
         hash: 987b1488daaa16d09ad6f40039ee85101c557354a4d821d3f31ad235
         type: rasterhash
+
+  - algorithm: otb:Rasterization
+    name: Test empty string and zero integer parameters (otb:Rasterization)
+    params:
+      in:
+        name: polys.gml
+        type: file
+      epsg: EPSG:4326
+      spx: 1
+      spy: 1
+      mode.attribute.field: ""
+      outputpixeltype: 0
+    results:
+      out:
+        hash: c898326f9327dd0a111532fdacc5f43fc485ae3e10f1238b5da04dde
+        type: rasterhash


### PR DESCRIPTION
Fixes OTB/QGIS [issue](https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/issues/2130) issue, consequence of #39939.

to sum up, we don't have to pass *None* parameters or empty string parameters to OTB, but we have to take care of the zero integer value (my previous fix). 

I added some tests for non regression.