### PR TITLE
Smarter Map Redraws [grant 2020]

### DIFF
--- a/python/core/auto_generated/qgsmaplayerrenderer.sip.in
+++ b/python/core/auto_generated/qgsmaplayerrenderer.sip.in
@@ -96,7 +96,17 @@ Returns the render context associated with the renderer.
 %End
 
 
+    bool isReadyToCompose() const;
+%Docstring
+Returns whether the renderer already drawn (at
+least partially) some data to resulting image
+
+.. versionadded:: 3.18
+%End
+
   protected:
+
+
 
 };
 

--- a/python/core/auto_generated/qgsmaplayerrenderer.sip.in
+++ b/python/core/auto_generated/qgsmaplayerrenderer.sip.in
@@ -98,8 +98,8 @@ Returns the render context associated with the renderer.
 
     bool isReadyToCompose() const;
 %Docstring
-Returns whether the renderer already drawn (at
-least partially) some data to resulting image
+Returns whether the renderer has already drawn (at
+least partially) some data
 
 .. versionadded:: 3.18
 %End

--- a/python/core/auto_generated/qgsmaprenderercache.sip.in
+++ b/python/core/auto_generated/qgsmaprenderercache.sip.in
@@ -21,6 +21,10 @@ the cache listens to :py:func:`~repaintRequested` signals from dependent layers.
 If triggered, the cache removes the rendered image (and disconnects from the
 layers).
 
+When user pans/zooms the canvas, the cache is also used in rendering period
+for particular layer after first render update and moment layer actually
+partially rendered something in the resulting image
+
 The class is thread-safe (multiple classes can access the same instance safely).
 
 .. versionadded:: 2.4
@@ -40,15 +44,28 @@ Invalidates the cache contents, clearing all cached images.
 .. seealso:: :py:func:`clearCacheImage`
 %End
 
-    bool init( const QgsRectangle &extent, double scale );
+    bool init( const QgsRectangle &extent, double scale ) /Deprecated/;
 %Docstring
-Initialize cache: set new parameters and clears the cache if any
+Initialize cache: sets extent and scale parameters and clears the cache if any
 parameters have changed since last initialization.
+
+Deprecated, use :py:func:`~QgsMapRendererCache.updateParameters` and :py:func:`~QgsMapRendererCache.clear`
 
 :return: flag whether the parameters are the same as last time
 %End
 
-    void setCacheImage( const QString &cacheKey, const QImage &image, const QList< QgsMapLayer * > &dependentLayers = QList< QgsMapLayer * >() );
+    bool updateParameters( const QgsRectangle &extent, const QgsMapToPixel &mtp );
+%Docstring
+Sets extent and scale parameters
+
+:return: flag whether the parameters are the same as last time
+
+.. versionadded:: 3.18
+%End
+
+    void setCacheImage( const QString &cacheKey,
+                        const QImage &image,
+                        const QList< QgsMapLayer * > &dependentLayers = QList< QgsMapLayer * >() );
 %Docstring
 Set the cached ``image`` for a particular ``cacheKey``. The ``cacheKey`` usually
 matches the :py:func:`QgsMapLayer.id()` which the image is a render of.
@@ -61,11 +78,22 @@ repaint then the cache image will be cleared.
 
     bool hasCacheImage( const QString &cacheKey ) const;
 %Docstring
-Returns ``True`` if the cache contains an image with the specified ``cacheKey``.
+Returns ``True`` if the cache contains an image with the specified ``cacheKey``
+that has the same extent and scale as the cache's global extent and scale
 
 .. seealso:: :py:func:`cacheImage`
 
 .. versionadded:: 3.0
+%End
+
+    bool hasAnyCacheImage( const QString &cacheKey ) const;
+%Docstring
+Returns ``True`` if the cache contains an image with the specified ``cacheKey``
+with any cache's parameters (extent and scale)
+
+.. seealso:: :py:func:`transformedCacheImage`
+
+.. versionadded:: 3.18
 %End
 
     QImage cacheImage( const QString &cacheKey ) const;
@@ -77,6 +105,22 @@ Returns a null image if it is not cached.
 .. seealso:: :py:func:`setCacheImage`
 
 .. seealso:: :py:func:`hasCacheImage`
+%End
+
+    QImage transformedCacheImage( const QString &cacheKey, const QgsMapToPixel &mtp ) const;
+%Docstring
+Returns the cached image for the specified ``cacheKey`` transformed
+to the particular extent and scale.
+
+The ``cacheKey`` usually matches the :py:func:`QgsMapLayer.id()` which
+the image is a render of.
+Returns a null image if it is not cached.
+
+.. seealso:: :py:func:`setCacheImage`
+
+.. seealso:: :py:func:`hasCacheImageWithAnyParameters`
+
+.. versionadded:: 3.18
 %End
 
     QList< QgsMapLayer * > dependentLayers( const QString &cacheKey ) const;

--- a/python/core/auto_generated/qgsmaprenderercache.sip.in
+++ b/python/core/auto_generated/qgsmaprenderercache.sip.in
@@ -22,8 +22,8 @@ If triggered, the cache removes the rendered image (and disconnects from the
 layers).
 
 When user pans/zooms the canvas, the cache is also used in rendering period
-for particular layer after first render update and moment layer actually
-partially rendered something in the resulting image
+for particular layers between the first render update and the moment the layer
+actually has partially rendered something in the resulting image.
 
 The class is thread-safe (multiple classes can access the same instance safely).
 
@@ -49,9 +49,10 @@ Invalidates the cache contents, clearing all cached images.
 Initialize cache: sets extent and scale parameters and clears the cache if any
 parameters have changed since last initialization.
 
-Deprecated, use :py:func:`~QgsMapRendererCache.updateParameters` and :py:func:`~QgsMapRendererCache.clear`
-
 :return: flag whether the parameters are the same as last time
+
+.. deprecated:: QGIS 3.18
+   - will be removed in QGIS 4.0. Use the updateParameters() and clear()
 %End
 
     bool updateParameters( const QgsRectangle &extent, const QgsMapToPixel &mtp );

--- a/python/core/auto_generated/qgsmaprenderercache.sip.in
+++ b/python/core/auto_generated/qgsmaprenderercache.sip.in
@@ -117,9 +117,7 @@ The ``cacheKey`` usually matches the :py:func:`QgsMapLayer.id()` which
 the image is a render of.
 Returns a null image if it is not cached.
 
-.. seealso:: :py:func:`setCacheImage`
-
-.. seealso:: :py:func:`hasCacheImageWithAnyParameters`
+.. seealso:: :py:func:`hasAnyCacheImage`
 
 .. versionadded:: 3.18
 %End

--- a/python/core/auto_generated/qgsmaprendererjob.sip.in
+++ b/python/core/auto_generated/qgsmaprendererjob.sip.in
@@ -190,6 +190,7 @@ emitted when asynchronous rendering is finished (or canceled).
 
 
 
+
 };
 
 

--- a/src/core/qgsmaplayerrenderer.h
+++ b/src/core/qgsmaplayerrenderer.h
@@ -111,8 +111,8 @@ class CORE_EXPORT QgsMapLayerRenderer
     const QgsRenderContext *renderContext() const SIP_SKIP { return mContext; }
 
     /**
-     * Returns whether the renderer already drawn (at
-     * least partially) some data to resulting image
+     * Returns whether the renderer has already drawn (at
+     * least partially) some data
      *
      * \since QGIS 3.18
      */

--- a/src/core/qgsmaplayerrenderer.h
+++ b/src/core/qgsmaplayerrenderer.h
@@ -110,9 +110,35 @@ class CORE_EXPORT QgsMapLayerRenderer
      */
     const QgsRenderContext *renderContext() const SIP_SKIP { return mContext; }
 
+    /**
+     * Returns whether the renderer already drawn (at
+     * least partially) some data to resulting image
+     *
+     * \since QGIS 3.18
+     */
+    bool isReadyToCompose() const { return mReadyToCompose; }
+
   protected:
     QStringList mErrors;
     QString mLayerID;
+
+    // TODO QGIS 4.0 - make false as default
+
+    /**
+     * The flag must be set to false in renderer's constructor
+     * if wants to use the smarter map redraws functionality
+     * https://github.com/qgis/QGIS-Enhancement-Proposals/issues/181
+     *
+     * The flag must be set to true by renderer when
+     * the data is fetched and the renderer actually
+     * started to update the destination image.
+     *
+     * When the flag is set to false, the image from
+     * QgsMapRendererCache is used instead to avoid flickering.
+     *
+     * \since QGIS 3.18
+     */
+    bool mReadyToCompose = true;
 
   private:
 

--- a/src/core/qgsmaprenderercache.h
+++ b/src/core/qgsmaprenderercache.h
@@ -36,8 +36,8 @@
  * layers).
  *
  * When user pans/zooms the canvas, the cache is also used in rendering period
- * for particular layer after first render update and moment layer actually
- * partially rendered something in the resulting image
+ * for particular layers between the first render update and the moment the layer
+ * actually has partially rendered something in the resulting image.
  *
  * The class is thread-safe (multiple classes can access the same instance safely).
  *
@@ -60,9 +60,8 @@ class CORE_EXPORT QgsMapRendererCache : public QObject
      * Initialize cache: sets extent and scale parameters and clears the cache if any
      * parameters have changed since last initialization.
      *
-     * Deprecated, use updateParameters() and clear()
-     *
      * \returns flag whether the parameters are the same as last time
+     * \deprecated since QGIS 3.18 - will be removed in QGIS 4.0. Use the updateParameters() and clear()
      */
     bool Q_DECL_DEPRECATED init( const QgsRectangle &extent, double scale ) SIP_DEPRECATED;
 

--- a/src/core/qgsmaprenderercache.h
+++ b/src/core/qgsmaprenderercache.h
@@ -121,8 +121,8 @@ class CORE_EXPORT QgsMapRendererCache : public QObject
      * The \a cacheKey usually matches the QgsMapLayer::id() which
      * the image is a render of.
      * Returns a null image if it is not cached.
-     * \see setCacheImage()
-     * \see hasCacheImageWithAnyParameters()
+     *
+     * \see hasAnyCacheImage()
      *
      * \since QGIS 3.18
      */

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -792,7 +792,7 @@ QImage QgsMapRendererJob::composeImage(
     painter.setOpacity( job.opacity );
 
 #if DEBUG_RENDERING
-    img->save( QString( "/tmp/final_%1.png" ).arg( i ) );
+    img.save( QString( "/tmp/final_%1.png" ).arg( i ) );
     i++;
 #endif
 
@@ -847,9 +847,9 @@ QImage QgsMapRendererJob::layerImageToBeComposed(
   }
   else
   {
-    if ( cache && cache->hasAnyCacheImage( job.layer->id() ) )
+    if ( cache && cache->hasAnyCacheImage( job.layerId ) )
     {
-      return cache->transformedCacheImage( job.layer->id(), settings.mapToPixel() );
+      return cache->transformedCacheImage( job.layerId, settings.mapToPixel() );
     }
     else
       return QImage();

--- a/src/core/qgsmaprendererjob.h
+++ b/src/core/qgsmaprendererjob.h
@@ -53,8 +53,11 @@ struct LayerRenderJob
    * May be NULLPTR if it is not necessary to draw to separate image (e.g. sequential rendering).
    */
   QImage *img;
-  //! TRUE when img has been initialized (filled with transparent pixels) and is safe to compose
+  //! TRUE when img has been initialized (filled with transparent pixels)
   bool imageInitialized = false;
+
+  bool imageCanBeComposed() const;
+
   QgsMapLayerRenderer *renderer; // must be deleted
   QPainter::CompositionMode blendMode;
   double opacity;
@@ -366,7 +369,13 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
     LayerRenderJobs prepareSecondPassJobs( LayerRenderJobs &firstPassJobs, LabelRenderJob &labelJob ) SIP_SKIP;
 
     //! \note not available in Python bindings
-    static QImage composeImage( const QgsMapSettings &settings, const LayerRenderJobs &jobs, const LabelRenderJob &labelJob ) SIP_SKIP;
+    static QImage composeImage( const QgsMapSettings &settings,
+                                const LayerRenderJobs &jobs,
+                                const LabelRenderJob &labelJob,
+                                const QgsMapRendererCache *cache = nullptr ) SIP_SKIP;
+
+    //! \note not available in Python bindings
+    static QImage layerImageToBeComposed( const QgsMapSettings &settings, const LayerRenderJob &job, const QgsMapRendererCache *cache ) SIP_SKIP;
 
     /**
      * Compose second pass images into first pass images.

--- a/src/core/qgsmaprendererparalleljob.cpp
+++ b/src/core/qgsmaprendererparalleljob.cpp
@@ -210,7 +210,7 @@ QgsLabelingResults *QgsMapRendererParallelJob::takeLabelingResults()
 QImage QgsMapRendererParallelJob::renderedImage()
 {
   if ( mStatus == RenderingLayers )
-    return composeImage( mSettings, mLayerJobs, mLabelJob );
+    return composeImage( mSettings, mLayerJobs, mLabelJob, mCache );
   else
     return mFinalImage; // when rendering labels or idle
 }
@@ -331,6 +331,12 @@ void QgsMapRendererParallelJob::renderLayersSecondPassFinished()
   emit finished();
 }
 
+/*
+ * See section "Smarter Map Redraws"
+ * in https://github.com/qgis/QGIS-Enhancement-Proposals/issues/181
+ */
+// #define SIMULATE_SLOW_RENDERER
+
 void QgsMapRendererParallelJob::renderLayerStatic( LayerRenderJob &job )
 {
   if ( job.context.renderingStopped() )
@@ -350,6 +356,9 @@ void QgsMapRendererParallelJob::renderLayerStatic( LayerRenderJob &job )
   QgsDebugMsgLevel( QStringLiteral( "job %1 start (layer %2)" ).arg( reinterpret_cast< quint64 >( &job ), 0, 16 ).arg( job.layerId ), 2 );
   try
   {
+#ifdef SIMULATE_SLOW_RENDERER
+    QThread::sleep( 1 );
+#endif
     job.renderer->render();
   }
   catch ( QgsException &e )

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -68,6 +68,7 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   , mProviderCapabilities( static_cast<QgsRasterDataProvider::Capability>( layer->dataProvider()->capabilities() ) )
   , mFeedback( new QgsRasterLayerRendererFeedback( this ) )
 {
+  mReadyToCompose = false;
   QgsMapToPixel mapToPixel = rendererContext.mapToPixel();
   if ( rendererContext.mapToPixel().mapRotation() )
   {

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -57,6 +57,7 @@ void QgsRasterLayerRendererFeedback::onNewData()
   QgsRasterIterator iterator( mR->mPipe->last() );
   QgsRasterDrawer drawer( &iterator );
   drawer.draw( mR->renderContext()->painter(), mR->mRasterViewPort, &mR->renderContext()->mapToPixel(), &feedback );
+  mR->mReadyToCompose = true;
   QgsDebugMsgLevel( QStringLiteral( "total raster preview time: %1 ms" ).arg( t.elapsed() ), 3 );
   mLastPreview = QTime::currentTime();
 }

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -231,7 +231,9 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   if ( rasterRenderer
        && !( rendererContext.flags() & QgsRenderContext::RenderPreviewJob )
        && !( rendererContext.flags() & QgsRenderContext::Render3DMap ) )
+  {
     layer->refreshRendererIfNeeded( rasterRenderer, rendererContext.extent() );
+  }
 
   const QgsRasterLayerTemporalProperties *temporalProperties = qobject_cast< const QgsRasterLayerTemporalProperties * >( layer->temporalProperties() );
   if ( temporalProperties->isActive() && renderContext()->isTemporal() )
@@ -330,6 +332,7 @@ bool QgsRasterLayerRenderer::render()
   }
 
   QgsDebugMsgLevel( QStringLiteral( "total raster draw time (ms):     %1" ).arg( time.elapsed(), 5 ), 4 );
+  mReadyToCompose = true;
 
   return true;
 }

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -183,6 +183,7 @@ set(TESTS
  testqgsmaplayerstylemanager.cpp
  testqgsmaplayer.cpp
  testqgsmaprendererjob.cpp
+ testqgsmaprenderercache.cpp
  testqgsmaprotation.cpp
  testqgsmapsettings.cpp
  testqgsmapsettingsutils.cpp

--- a/tests/src/core/testqgsmaprenderercache.cpp
+++ b/tests/src/core/testqgsmaprenderercache.cpp
@@ -1,0 +1,130 @@
+/***************************************************************************
+     testqgsmaprenderercache.cpp
+     --------------------------------------
+    Date                 : January 2021
+    Copyright            : (C) 2021 by Peter Petrik
+    Email                : zilolv at gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstest.h"
+
+#include <QImage>
+
+#include "qgsmaprenderercache.h"
+#include "qgsmaptopixel.h"
+#include "qgsrectangle.h"
+
+class TestQgsMapRendereCache: public QObject
+{
+    Q_OBJECT
+
+  public:
+    TestQgsMapRendereCache();
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init(); // will be called before each testfunction is executed.
+    void cleanup(); // will be called after every testfunction.
+
+    void testCache();
+};
+
+
+TestQgsMapRendereCache::TestQgsMapRendereCache() = default;
+
+void TestQgsMapRendereCache::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+}
+
+void TestQgsMapRendereCache::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsMapRendereCache::init()
+{
+}
+
+void TestQgsMapRendereCache::cleanup()
+{
+}
+
+void TestQgsMapRendereCache::testCache()
+{
+  QgsMapRendererCache cache;
+  QImage imgRed( 100, 100, QImage::Format::Format_ARGB32_Premultiplied );
+  imgRed.fill( Qt::red );
+  const QString imgRedKey( "red" );
+
+  QImage imgBlue( 50, 50, QImage::Format::Format_ARGB32_Premultiplied );
+  imgBlue.fill( Qt::blue );
+  const QString imgBlueKey( "blue" );
+
+  /* the cache images are same as inserted */
+  QgsRectangle extent1( 0, 0, 100, 200 );
+  QgsMapToPixel mtp1( 1, 50, 50, 100, 100, 0.0 );
+  cache.updateParameters( extent1, mtp1 );
+
+  QVERIFY( !cache.hasCacheImage( imgBlueKey ) );
+
+  cache.setCacheImage( imgBlueKey, imgBlue );
+  QVERIFY( !cache.hasCacheImage( imgRedKey ) );
+  QVERIFY( cache.hasCacheImage( imgBlueKey ) );
+  QVERIFY( cache.hasAnyCacheImage( imgBlueKey ) );
+
+  cache.setCacheImage( imgRedKey, imgRed );
+  QVERIFY( cache.hasCacheImage( imgRedKey ) );
+  QVERIFY( cache.hasCacheImage( imgBlueKey ) );
+  QVERIFY( cache.hasAnyCacheImage( imgBlueKey ) );
+  QVERIFY( cache.hasAnyCacheImage( imgRedKey ) );
+
+  {
+    QImage img = cache.cacheImage( imgBlueKey );
+    QVERIFY( img.size() == imgBlue.size() );
+    QVERIFY( img.pixelColor( 10, 20 ) == Qt::blue );
+
+    QImage transformed = cache.transformedCacheImage( imgBlueKey, mtp1 );
+    QVERIFY( transformed.size() == imgBlue.size() );
+    QVERIFY( img.pixelColor( 10, 20 ) == Qt::blue );
+  }
+
+  /* the cache images are transformed */
+  QgsRectangle extent2( 20, 0, 120, 200 );
+  QgsMapToPixel mtp2( 1, 70, 50, 100, 100, 0.0 ); // move by 20
+  cache.updateParameters( extent2, mtp2 );
+  QVERIFY( !cache.hasCacheImage( imgRedKey ) );
+  QVERIFY( !cache.hasCacheImage( imgBlueKey ) );
+  QVERIFY( cache.hasAnyCacheImage( imgBlueKey ) );
+  QVERIFY( cache.hasAnyCacheImage( imgRedKey ) );
+
+  QImage transformed = cache.transformedCacheImage( imgBlueKey, mtp2 );
+  QVERIFY( transformed.pixelColor( 30, 20 ) == Qt::transparent );
+  QVERIFY( transformed.pixelColor( 10, 20 ) == Qt::blue );
+
+  /* we can replace the cache image */
+  cache.setCacheImage( imgBlueKey, transformed );
+  QVERIFY( cache.hasCacheImage( imgBlueKey ) );
+  QVERIFY( cache.hasAnyCacheImage( imgBlueKey ) );
+
+  /* clear the cache */
+  cache.clearCacheImage( imgBlueKey );
+  QVERIFY( !cache.hasCacheImage( imgBlueKey ) );
+  QVERIFY( !cache.hasAnyCacheImage( imgBlueKey ) );
+
+  cache.clear();
+  QVERIFY( !cache.hasCacheImage( imgRedKey ) );
+  QVERIFY( !cache.hasAnyCacheImage( imgRedKey ) );
+}
+
+
+QGSTEST_MAIN( TestQgsMapRendereCache )
+#include "testqgsmaprenderercache.moc"


### PR DESCRIPTION
https://github.com/qgis/QGIS-Enhancement-Proposals/issues/181

- only for RasterLayers so far, should be easily extensible for other types
- there is developer define in QgsMapRendererParallelJob `SIMULATE_SLOW_RENDERER`, line 338, you can uncomment it to force very slow renderers (for testing)

general overview of the implementation: The `QgsMapLayerRenderer` has flag `mReadyToCompose`. To use the "smart map redraws" for the particular renderer, the flag must be set to `false` in the constructor and set to `true` once there is something to show to user (so the renderer actually drawn some data to resulting/destination image already). The rule now is that whenever the flag is set to `false`, the rendering job tries to fetch the cached image from the `QgsMapRenderingCache` for particular layer and transform it to the current drawn extent instead of showing QImage with all transparent pixels

Work funded by QGIS grant 2020.