### PR TITLE
Fix: Processing Modeler help parameter

### DIFF
--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -1427,6 +1427,10 @@ bool QgsProcessingModelAlgorithm::loadVariant( const QVariant &model )
       if ( param->name() == QLatin1String( "VERBOSE_LOG" ) )
         return; // internal parameter -- some versions of QGIS incorrectly stored this in the model definition file
 
+      // set parameter help from help content
+      param->setHelp( mHelpContent.value( param->name() ).toString() );
+
+      // add parameter
       addParameter( param.release() );
     }
     else


### PR DESCRIPTION
## Description

The help parameter is set in the modeler help part.
The commit use it to set the help parameter.

Funded by Ifremer
