### PR TITLE
Fix: Server WMS Dimension nearestValue and multipleValues

### DIFF
--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1271,8 +1271,8 @@ namespace QgsWms
               {
                 dimElem.setAttribute( QStringLiteral( "default" ), dim.referenceValue.toString() );
               }
-              dimElem.setAttribute( QStringLiteral( "multipleValue" ), '1' );
-              dimElem.setAttribute( QStringLiteral( "nearestValue" ), '0' );
+              dimElem.setAttribute( QStringLiteral( "multipleValues" ), QStringLiteral( "1" ) );
+              dimElem.setAttribute( QStringLiteral( "nearestValue" ), QStringLiteral( "0" ) );
               // values list
               QStringList strValues;
               for ( const QVariant &v : values )

--- a/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
+++ b/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
@@ -142,7 +142,7 @@ Content-Type: text/xml; charset=utf-8
       <OnlineResource xlink:href="https://www.qgis.org/?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server_accesscontrol/project_with_dimensions.qgs&amp;SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetLegendGraphic&amp;LAYER=Contours&amp;FORMAT=image/png&amp;STYLE=default&amp;SLD_VERSION=1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple"/>
      </LegendURL>
     </Style>
-    <Dimension name="elevation" units="meters" unitSymbol="m" nearestValue="48" multipleValue="49">0, 500, 1000, 1500, 2000, 2500, 3000, 3500, 4000</Dimension>
+    <Dimension name="elevation" units="meters" unitSymbol="m" nearestValue="0" multipleValues="1">0, 500, 1000, 1500, 2000, 2500, 3000, 3500, 4000</Dimension>
    </Layer>
    <Layer queryable="1">
     <Name>Slopes</Name>
@@ -166,7 +166,7 @@ Content-Type: text/xml; charset=utf-8
       <OnlineResource xlink:href="https://www.qgis.org/?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server_accesscontrol/project_with_dimensions.qgs&amp;SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetLegendGraphic&amp;LAYER=Slopes&amp;FORMAT=image/png&amp;STYLE=default&amp;SLD_VERSION=1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple"/>
      </LegendURL>
     </Style>
-    <Dimension name="range_elevation" units="meters" unitSymbol="m" nearestValue="48" multipleValue="49">0, 500, 1000, 1500, 2000, 2500, 3000</Dimension>
+    <Dimension name="range_elevation" units="meters" unitSymbol="m" nearestValue="0" multipleValues="1">0, 500, 1000, 1500, 2000, 2500, 3000</Dimension>
    </Layer>
    <Layer queryable="1">
     <Name>dem</Name>


### PR DESCRIPTION
## Description

* The WMS Dimension GetCapabilities nearestValue attribute has to be 0 or 1 and not 48.
* The WMS Dimension GetCapabilities multipleValue attribute does not exist.
* The WMS Dimension GetCapabilities multipleValues attribute has to be 0 or 1 and not 49.

Funded by Ifremer