### PR TITLE
Correctly expose QgsLayoutItemAttributeTable::getTableContents to sip

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitemattributetable.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemattributetable.sip.in
@@ -288,6 +288,15 @@ be replaced by a line break.
 .. seealso:: :py:func:`setWrapString`
 %End
 
+    virtual bool getTableContents( QgsLayoutTableContents &contents );
+
+%Docstring
+Queries the attribute table's vector layer for attributes to show in the table.
+
+:param contents: table content
+
+:return: ``True`` if attributes were successfully fetched
+%End
 
     virtual QgsConditionalStyle conditionalCellStyle( int row, int column ) const;
 

--- a/src/core/layout/qgslayoutitemattributetable.h
+++ b/src/core/layout/qgslayoutitemattributetable.h
@@ -275,9 +275,8 @@ class CORE_EXPORT QgsLayoutItemAttributeTable: public QgsLayoutTable
      * Queries the attribute table's vector layer for attributes to show in the table.
      * \param contents table content
      * \returns TRUE if attributes were successfully fetched
-     * \note not available in Python bindings
      */
-    bool getTableContents( QgsLayoutTableContents &contents ) override SIP_SKIP;
+    bool getTableContents( QgsLayoutTableContents &contents ) override;
 
     QgsConditionalStyle conditionalCellStyle( int row, int column ) const override;
     QgsExpressionContextScope *scopeForCell( int row, int column ) const override SIP_FACTORY;


### PR DESCRIPTION
so that this class can be reused from Python classes

Fixes https://github.com/gltn/stdm/issues/411

I'm not sure what the original intention behind hiding this from sip was -- I suspect it was a pure oversight