### PR TITLE
[processing] Add 'thiessen' tag to QGIS' voronoi polygons algorithm

### DIFF
--- a/python/plugins/processing/algs/qgis/VoronoiPolygons.py
+++ b/python/plugins/processing/algs/qgis/VoronoiPolygons.py
@@ -85,6 +85,9 @@ class VoronoiPolygons(QgisAlgorithm):
     def displayName(self):
         return self.tr('Voronoi polygons')
 
+    def tags(self):
+        return self.tr('thiessen').split(',')
+
     def processAlgorithm(self, parameters, context, feedback):
         source = self.parameterAsSource(parameters, self.INPUT, context)
         if source is None:


### PR DESCRIPTION
## Description

Someone reached out to me yesterday "QGIS processing killed my UTF-8 strings and it can't save as geopackage!!". Long story short, he had the misfortune to use a SAGA algorithm. He wanted a thiessen polygon algorithm, and missed the voronoi polygons one while searching for 'thiessen'. This PR adds a tag to our algorithm.