### PR TITLE
Correctly expose QgsLayoutItemAttributeTable::getTableContents to sip,

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitemattributetable.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemattributetable.sip.in
@@ -289,6 +289,15 @@ be replaced by a line break.
 .. seealso:: :py:func:`setWrapString`
 %End
 
+    virtual bool getTableContents( QgsLayoutTableContents &contents );
+
+%Docstring
+Queries the attribute table's vector layer for attributes to show in the table.
+
+:param contents: table content
+
+:return: ``True`` if attributes were successfully fetched
+%End
 
     virtual QgsExpressionContext createExpressionContext() const;
 

--- a/src/core/layout/qgslayoutitemattributetable.h
+++ b/src/core/layout/qgslayoutitemattributetable.h
@@ -284,9 +284,8 @@ class CORE_EXPORT QgsLayoutItemAttributeTable: public QgsLayoutTable
      * Queries the attribute table's vector layer for attributes to show in the table.
      * \param contents table content
      * \returns TRUE if attributes were successfully fetched
-     * \note not available in Python bindings
      */
-    bool getTableContents( QgsLayoutTableContents &contents ) override SIP_SKIP;
+    bool getTableContents( QgsLayoutTableContents &contents ) override;
 
     QgsExpressionContext createExpressionContext() const override;
     void finalizeRestoreFromXml() override;


### PR DESCRIPTION
so that this class can be reused from Python classes

Fixes https://github.com/gltn/stdm/issues/411

(cherry picked from commit a8c3b02cddbce1f13eb99d4cca9bfa93981d7e19)
