### PR TITLE
Add mapRefreshCanceled() signal to QgsMapCanvas

### DIFF
--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -1089,6 +1089,13 @@ Emitted when canvas finished a refresh request.
 Emitted when the canvas is about to be rendered.
 %End
 
+    void mapRefreshCanceled();
+%Docstring
+Emitted when the pending map refresh has been canceled
+
+.. versionadded:: 3.18
+%End
+
     void layersChanged();
 %Docstring
 Emitted when a new set of layers has been received

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1000,6 +1000,7 @@ void QgsMapCanvas::stopRendering()
     connect( mJob, &QgsMapRendererQImageJob::finished, mJob, &QgsMapRendererQImageJob::deleteLater );
     mJob->cancelWithoutBlocking();
     mJob = nullptr;
+    emit mapRefreshCanceled();
   }
   stopPreviewJobs();
 }

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -996,6 +996,12 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! Emitted when the canvas is about to be rendered.
     void renderStarting();
 
+    /**
+     * Emitted when the pending map refresh has been canceled
+     * \since QGIS 3.18
+     */
+    void mapRefreshCanceled();
+
     //! Emitted when a new set of layers has been received
     void layersChanged();
 


### PR DESCRIPTION
This is useful when one wants to follow what exactly is happening with map canvas rendering. We already have renderStarting() signal when a job is started and mapCanvasRefreshed() signal when a job has finished, but there was no notification if the pending job got cancelled (for example because used moved/zoomed the map).
