### PR TITLE
Document management system a.k.a. polymorphic relations GUI

### DIFF
--- a/python/core/auto_additions/qgsrelation.py
+++ b/python/core/auto_additions/qgsrelation.py
@@ -1,2 +1,3 @@
 # The following has been generated automatically from src/core/qgsrelation.h
+QgsRelation.RelationType.baseClass = QgsRelation
 QgsRelation.RelationStrength.baseClass = QgsRelation

--- a/python/core/auto_generated/qgspolymorphicrelation.sip.in
+++ b/python/core/auto_generated/qgspolymorphicrelation.sip.in
@@ -229,6 +229,16 @@ Returns a list of generated relations, based on the currently set :py:func:`~Qgs
 Returns layer representation as evaluated string
 %End
 
+    QgsRelation::RelationStrength strength() const;
+%Docstring
+Returns the relation strength for all the generated normal relations
+%End
+
+    void setRelationStrength( QgsRelation::RelationStrength relationStrength );
+%Docstring
+Sets the relation strength for all the generated normal relations
+%End
+
 };
 
 

--- a/python/core/auto_generated/qgsrelation.sip.in
+++ b/python/core/auto_generated/qgsrelation.sip.in
@@ -22,6 +22,12 @@ class QgsRelation
 
   public:
 
+    enum RelationType
+    {
+      Normal,
+      Generated,
+    };
+
     enum RelationStrength
     {
       Association,
@@ -332,6 +338,13 @@ Returns the parent polymorphic relation id. If the relation is a normal relation
     QgsPolymorphicRelation polymorphicRelation() const;
 %Docstring
 Returns the parent polymorphic relation. If the relation is a normal relation, an invalid polymorphic relation is returned.
+
+.. versionadded:: 3.18
+%End
+
+    RelationType type() const;
+%Docstring
+Returns the type of the relation
 
 .. versionadded:: 3.18
 %End

--- a/python/gui/auto_generated/qgsmaptool.sip.in
+++ b/python/gui/auto_generated/qgsmaptool.sip.in
@@ -20,6 +20,7 @@
 #include <qgsmaptoolpan.h>
 #include <qgsmaptoolemitpoint.h>
 #include <qgsmaptoolidentify.h>
+#include <qgsmaptooldigitizefeature.h>
 %End
 
 class QgsMapTool : QObject
@@ -43,6 +44,8 @@ implemented as map tools.
       sipType = sipType_QgsMapToolEmitPoint;
     else if ( dynamic_cast<QgsMapToolIdentify *>( sipCpp ) != NULL )
       sipType = sipType_QgsMapToolIdentify;
+    else if ( dynamic_cast<QgsMapToolDigitizeFeature *>( sipCpp ) != NULL )
+      sipType = sipType_QgsMapToolDigitizeFeature;
     else
       sipType = NULL;
 %End

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -140,6 +140,7 @@ set(QGIS_APP_SRCS
   qgsrastercalcdialog.cpp
   qgsrelationmanagerdialog.cpp
   qgsrelationadddlg.cpp
+  qgsrelationaddpolymorphicdlg.cpp
   qgsselectbyformdialog.cpp
   qgsstatisticalsummarydockwidget.cpp
   qgstextannotationdialog.cpp

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -1586,6 +1586,7 @@ void QgsProjectProperties::apply()
   QgsProject::instance()->writeEntry( QStringLiteral( "Macros" ), QStringLiteral( "/pythonCode" ), pythonMacros );
 
   QgsProject::instance()->relationManager()->setRelations( mRelationManagerDlg->relations() );
+  QgsProject::instance()->relationManager()->setPolymorphicRelations( mRelationManagerDlg->polymorphicRelations() );
 
   //save variables
   QgsProject::instance()->setCustomVariables( mVariableEditor->variablesInActiveScope() );

--- a/src/app/qgsrelationadddlg.cpp
+++ b/src/app/qgsrelationadddlg.cpp
@@ -30,156 +30,32 @@
 #include "qgsmaplayerproxymodel.h"
 #include "qgsapplication.h"
 #include "qgshelp.h"
+#include "qgsproject.h"
+#include "qgsrelationmanager.h"
+#include "qgsfieldexpressionwidget.h"
 
-
-
-QgsFieldPairWidget::QgsFieldPairWidget( int index, QWidget *parent )
-  : QWidget( parent )
-  , mIndex( index )
-  , mEnabled( index == 0 )
-{
-  mLayout = new QHBoxLayout();
-  mLayout->setContentsMargins( 0, 0, 0, 0 );
-
-  mAddButton = new QToolButton( this );
-  mAddButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/symbologyAdd.svg" ) ) );
-  mAddButton->setMinimumWidth( 30 );
-  mAddButton->setToolTip( tr( "Add new field pair as part of a composite foreign key" ) );
-  mLayout->addWidget( mAddButton, 0, Qt::AlignLeft );
-
-  mRemoveButton = new QToolButton( this );
-  mRemoveButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/symbologyRemove.svg" ) ) );
-  mRemoveButton->setMinimumWidth( 30 );
-  mRemoveButton->setToolTip( tr( "Remove the last pair of fields" ) );
-  mLayout->addWidget( mRemoveButton, 0, Qt::AlignLeft );
-
-  mSpacerItem = new QSpacerItem( 30, 30, QSizePolicy::Minimum, QSizePolicy::Maximum );
-  mLayout->addSpacerItem( mSpacerItem );
-
-  mReferencedFieldCombobox = new QgsFieldComboBox( this );
-  connect( mReferencedFieldCombobox, &QgsFieldComboBox::fieldChanged, this, &QgsFieldPairWidget::configChanged );
-  mLayout->addWidget( mReferencedFieldCombobox, 1 );
-
-  mReferencingFieldCombobox = new QgsFieldComboBox( this );
-  connect( mReferencingFieldCombobox, &QgsFieldComboBox::fieldChanged, this, &QgsFieldPairWidget::configChanged );
-  mLayout->addWidget( mReferencingFieldCombobox, 1 );
-
-  setLayout( mLayout );
-  updateWidgetVisibility();
-
-  connect( mAddButton, &QToolButton::clicked, this, &QgsFieldPairWidget::changeEnable );
-  connect( mRemoveButton, &QToolButton::clicked, this, &QgsFieldPairWidget::changeEnable );
-  connect( mAddButton, &QToolButton::clicked, this, &QgsFieldPairWidget::pairEnabled );
-  connect( mRemoveButton, &QToolButton::clicked, this, &QgsFieldPairWidget::pairDisabled );
-}
-
-void QgsFieldPairWidget::setReferencingLayer( QgsMapLayer *layer )
-{
-  mReferencingFieldCombobox->setLayer( layer );
-}
-
-void QgsFieldPairWidget::setReferencedLayer( QgsMapLayer *layer )
-{
-  mReferencedFieldCombobox->setLayer( layer );
-}
-
-QString QgsFieldPairWidget::referencingField() const
-{
-  return mReferencingFieldCombobox->currentField();
-}
-
-QString QgsFieldPairWidget::referencedField() const
-{
-  return mReferencedFieldCombobox->currentField();
-}
-
-bool QgsFieldPairWidget::isPairEnabled() const
-{
-  return mEnabled;
-}
-
-void QgsFieldPairWidget::updateWidgetVisibility()
-{
-  mAddButton->setVisible( !mEnabled );
-  mRemoveButton->setVisible( mIndex > 0 && mEnabled );
-  mReferencingFieldCombobox->setVisible( mEnabled );
-  mReferencedFieldCombobox->setVisible( mEnabled );
-  int spacerSize = 0;
-  if ( !mRemoveButton->isVisible() && !mAddButton->isVisible() )
-    spacerSize = mRemoveButton->minimumWidth() + mLayout->spacing();
-  mSpacerItem->changeSize( spacerSize, spacerSize );
-}
-
-void QgsFieldPairWidget::changeEnable()
-{
-  mEnabled = !mEnabled || ( mIndex == 0 );
-  updateWidgetVisibility();
-  emit configChanged();
-}
-
-////////////////////
-// QgsRelationAddDlg
 
 QgsRelationAddDlg::QgsRelationAddDlg( QWidget *parent )
   : QDialog( parent )
+  , Ui::QgsRelationManagerAddDialogBase()
 {
+  setupUi( this );
   setWindowTitle( tr( "Add New Relation" ) );
-  QGridLayout *layout = new QGridLayout(); // column 0 is kept free for alignment purpose
 
-  // row 0: name
-  // col 1
-  QLabel *nameLabel = new QLabel( tr( "Name" ), this );
-  layout->addWidget( nameLabel, 0, 1 );
-  // col 2
-  mNameLineEdit = new QLineEdit( this );
-  layout->addWidget( mNameLineEdit, 0, 2 );
-
-  // row 1: labels
-  // col 1
-  QLabel *referencedLabel = new QLabel( tr( "Referenced layer (parent)" ), this );
-  layout->addWidget( referencedLabel, 1, 1 );
-  // col 2
-  QLabel *referencingLabel = new QLabel( tr( "Referencing layer (child)" ), this );
-  layout->addWidget( referencingLabel, 1, 2 );
-
-  // row 2: layer comboboxes
-  // col 1
   mReferencedLayerCombobox = new QgsMapLayerComboBox( this );
   mReferencedLayerCombobox->setFilters( QgsMapLayerProxyModel::VectorLayer );
-  layout->addWidget( mReferencedLayerCombobox, 2, 1 );
-  // col 2
+  mFieldsMappingTable->setCellWidget( 0, 0, mReferencedLayerCombobox );
+
   mReferencingLayerCombobox = new QgsMapLayerComboBox( this );
   mReferencingLayerCombobox->setFilters( QgsMapLayerProxyModel::VectorLayer );
-  layout->addWidget( mReferencingLayerCombobox, 2, 2 );
+  mFieldsMappingTable->setCellWidget( 0, 1, mReferencingLayerCombobox );
 
-  // row 3: field pairs layout
-  mFieldPairsLayout = new QVBoxLayout();
-  layout->addLayout( mFieldPairsLayout, 3, 0, 1, 3 );
+  mRelationStrengthComboBox->addItem( tr( "Association" ), QVariant::fromValue( QgsRelation::RelationStrength::Association ) );
+  mRelationStrengthComboBox->addItem( tr( "Composition" ), QVariant::fromValue( QgsRelation::RelationStrength::Composition ) );
+  mRelationStrengthComboBox->setToolTip( tr( "When composition is selected the child features will be duplicated too.\n"
+                                         "Duplications are made by the feature duplication action.\n"
+                                         "The default actions are activated in the Action section of the layer properties." ) );
 
-  // row 4: id
-  // row 1
-  QLabel *idLabel = new QLabel( tr( "Id" ), this );
-  layout->addWidget( idLabel, 4, 1 );
-  // col 2
-  mIdLineEdit = new QLineEdit( this );
-  mIdLineEdit->setPlaceholderText( tr( "[Generated automatically]" ) );
-  layout->addWidget( mIdLineEdit, 4, 2 );
-
-  // row 5: strength
-  QLabel *strengthLabel = new QLabel( tr( "Relationship strength" ), this );
-  layout->addWidget( strengthLabel, 5, 1 );
-  // col 2
-  mStrengthCombobox = new QComboBox( this );
-  mStrengthCombobox->addItem( tr( "Association" ), QVariant::fromValue( QgsRelation::RelationStrength::Association ) );
-  mStrengthCombobox->addItem( tr( "Composition" ), QVariant::fromValue( QgsRelation::RelationStrength::Composition ) );
-  mStrengthCombobox->setToolTip( tr( "When composition is selected the child features will be duplicated too.\n"
-                                     "Duplications are made by the feature duplication action.\n"
-                                     "The default actions are activated in the Action section of the layer properties." ) );
-  layout->addWidget( mStrengthCombobox, 5, 2 );
-
-  // row 6: button box
-  mButtonBox = new QDialogButtonBox( this );
-  mButtonBox->setOrientation( Qt::Horizontal );
   mButtonBox->setStandardButtons( QDialogButtonBox::Cancel | QDialogButtonBox::Help | QDialogButtonBox::Ok );
   connect( mButtonBox, &QDialogButtonBox::accepted, this, &QgsRelationAddDlg::accept );
   connect( mButtonBox, &QDialogButtonBox::rejected, this, &QgsRelationAddDlg::reject );
@@ -187,49 +63,83 @@ QgsRelationAddDlg::QgsRelationAddDlg( QWidget *parent )
   {
     QgsHelp::openHelp( QStringLiteral( "working_with_vector/attribute_table.html#defining-1-n-relations" ) );
   } );
-  layout->addWidget( mButtonBox, 7, 1, 1, 2 );
 
-  // set layout
-  layout->setColumnMinimumWidth( 0, 30 );
-  layout->setColumnStretch( 1, 1 );
-  layout->setColumnStretch( 2, 1 );
-  layout->setRowStretch( 6, 2 );
-  setLayout( layout );
+  addFieldsRow();
+  updateDialogButtons();
 
-  addFieldPairWidget();
-  addFieldPairWidget();
-
-  checkDefinitionValid();
-
-  connect( mReferencingLayerCombobox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddDlg::checkDefinitionValid );
-  connect( mReferencedLayerCombobox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddDlg::checkDefinitionValid );
+  connect( mFieldsMappingTable, &QTableWidget::itemSelectionChanged, this, &QgsRelationAddDlg::updateFieldsMappingButtons );
+  connect( mFieldsMappingAddButton, &QToolButton::clicked, this, &QgsRelationAddDlg::addFieldsRow );
+  connect( mFieldsMappingRemoveButton, &QToolButton::clicked, this, &QgsRelationAddDlg::removeFieldsRow );
+  connect( mReferencedLayerCombobox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddDlg::updateDialogButtons );
+  connect( mReferencedLayerCombobox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddDlg::updateReferencedFieldsComboBoxes );
+  connect( mReferencingLayerCombobox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddDlg::updateDialogButtons );
+  connect( mReferencingLayerCombobox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddDlg::updateChildRelationsComboBox );
+  connect( mReferencingLayerCombobox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddDlg::updateReferencingFieldsComboBoxes );
 }
 
-void QgsRelationAddDlg::addFieldPairWidget()
+void QgsRelationAddDlg::addFieldsRow()
 {
-  int index = mFieldPairWidgets.count();
-  QgsFieldPairWidget *w = new QgsFieldPairWidget( index, this );
-  w->setReferencingLayer( mReferencingLayerCombobox->currentLayer() );
-  w->setReferencedLayer( mReferencedLayerCombobox->currentLayer() );
-  mFieldPairsLayout->addWidget( w );
-  mFieldPairWidgets << w;
+  QgsFieldComboBox *referencedField = new QgsFieldComboBox( this );
+  QgsFieldComboBox *referencingField = new QgsFieldComboBox( this );
+  int index = mFieldsMappingTable->rowCount();
 
-  connect( w, &QgsFieldPairWidget::configChanged, this, &QgsRelationAddDlg::checkDefinitionValid );
-  connect( w, &QgsFieldPairWidget::pairDisabled, this, [ = ]() {emit fieldPairRemoved( w );} );
-  connect( w, &QgsFieldPairWidget::pairEnabled, this, &QgsRelationAddDlg::addFieldPairWidget );
-  connect( mReferencingLayerCombobox, &QgsMapLayerComboBox::layerChanged, w, &QgsFieldPairWidget::setReferencingLayer );
-  connect( mReferencedLayerCombobox, &QgsMapLayerComboBox::layerChanged, w, &QgsFieldPairWidget::setReferencedLayer );
+  referencedField->setLayer( mReferencedLayerCombobox->currentLayer() );
+  referencingField->setLayer( mReferencingLayerCombobox->currentLayer() );
+
+  mFieldsMappingTable->insertRow( index );
+  mFieldsMappingTable->setCellWidget( index, 0, referencedField );
+  mFieldsMappingTable->setCellWidget( index, 1, referencingField );
+
+  connect( referencedField, &QgsFieldComboBox::fieldChanged, this, &QgsRelationAddDlg::updateDialogButtons );
+  connect( referencingField, &QgsFieldComboBox::fieldChanged, this, &QgsRelationAddDlg::updateDialogButtons );
+
+  updateFieldsMappingButtons();
+  updateFieldsMappingHeaders();
+  updateDialogButtons();
 }
 
-void QgsRelationAddDlg::fieldPairRemoved( QgsFieldPairWidget *fieldPairWidget )
+void QgsRelationAddDlg::removeFieldsRow()
 {
-  // remove widget only if not the first one, last one should always be disabled
-  int index = mFieldPairWidgets.indexOf( fieldPairWidget );
-  if ( index > 0 && index < mFieldPairWidgets.count() )
+  if ( mFieldsMappingTable->selectionModel()->hasSelection() )
   {
-    mFieldPairWidgets.removeAt( index );
-    fieldPairWidget->deleteLater();
+    for ( const QModelIndex &index : mFieldsMappingTable->selectionModel()->selectedRows() )
+    {
+      if ( index.row() == 0 )
+        continue;
+
+      if ( mFieldsMappingTable->rowCount() > 2 )
+        mFieldsMappingTable->removeRow( index.row() );
+    }
   }
+  else
+  {
+    mFieldsMappingTable->removeRow( mFieldsMappingTable->rowCount() - 1 );
+  }
+
+  updateFieldsMappingButtons();
+  updateFieldsMappingHeaders();
+  updateDialogButtons();
+}
+
+void QgsRelationAddDlg::updateFieldsMappingButtons()
+{
+  int rowsCount = mFieldsMappingTable->rowCount();
+  int selectedRowsCount = mFieldsMappingTable->selectionModel()->selectedRows().count();
+  bool isLayersRowSelected = mFieldsMappingTable->selectionModel()->isRowSelected( 0, QModelIndex() );
+  bool isRemoveButtonEnabled = !isLayersRowSelected && selectedRowsCount <= rowsCount - 2;
+
+  mFieldsMappingRemoveButton->setEnabled( isRemoveButtonEnabled );
+}
+
+void QgsRelationAddDlg::updateFieldsMappingHeaders()
+{
+  int rowsCount = mFieldsMappingTable->rowCount();
+  QStringList verticalHeaderLabels( {tr( "Layer" )} );
+
+  for ( int i = 0; i < rowsCount; i++ )
+    verticalHeaderLabels << tr( "Field %1" ).arg( i + 1 );
+
+  mFieldsMappingTable->setVerticalHeaderLabels( verticalHeaderLabels );
 }
 
 QString QgsRelationAddDlg::referencingLayerId()
@@ -245,14 +155,17 @@ QString QgsRelationAddDlg::referencedLayerId()
 QList< QPair< QString, QString > > QgsRelationAddDlg::references()
 {
   QList< QPair< QString, QString > > references;
-  for ( int i = 0; i < mFieldPairWidgets.count(); i++ )
+  for ( int i = 0, l = mFieldsMappingTable->rowCount(); i < l; i++ )
   {
-    if ( !mFieldPairWidgets.at( i )->isPairEnabled() )
+    // ignore the layers row
+    if ( i == 0 )
       continue;
-    QString referencingField = mFieldPairWidgets.at( i )->referencingField();
-    QString referencedField = mFieldPairWidgets.at( i )->referencedField();
+
+    QString referencedField = static_cast<QgsFieldComboBox *>( mFieldsMappingTable->cellWidget( i, 0 ) )->currentField();
+    QString referencingField = static_cast<QgsFieldComboBox *>( mFieldsMappingTable->cellWidget( i, 1 ) )->currentField();
     references << qMakePair( referencingField, referencedField );
   }
+
   return references;
 }
 
@@ -268,17 +181,86 @@ QString QgsRelationAddDlg::relationName()
 
 QgsRelation::RelationStrength QgsRelationAddDlg::relationStrength()
 {
-  return mStrengthCombobox->currentData().value<QgsRelation::RelationStrength>();
+  return mRelationStrengthComboBox->currentData().value<QgsRelation::RelationStrength>();
 }
 
-void QgsRelationAddDlg::checkDefinitionValid()
+void QgsRelationAddDlg::updateDialogButtons()
 {
-  bool valid = mReferencingLayerCombobox->currentLayer() && mReferencedLayerCombobox->currentLayer();
-  for ( const QgsFieldPairWidget *fieldPairWidget : qgis::as_const( mFieldPairWidgets ) )
+  mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( isDefinitionValid() );
+}
+
+bool QgsRelationAddDlg::isDefinitionValid()
+{
+  bool isValid = true;
+  QgsMapLayer *referencedLayer = mReferencedLayerCombobox->currentLayer();
+  isValid &= referencedLayer && referencedLayer->isValid();
+  QgsMapLayer *referencingLayer = mReferencingLayerCombobox->currentLayer();
+  isValid &= referencingLayer && referencingLayer->isValid();
+
+  for ( int i = 0, l = mFieldsMappingTable->rowCount(); i < l; i++ )
   {
-    if ( !fieldPairWidget->isPairEnabled() )
+    // ignore the layers row
+    if ( i == 0 )
       continue;
-    valid &= !fieldPairWidget->referencingField().isNull() && !fieldPairWidget->referencedField().isNull();
+
+    isValid &= !static_cast<QgsFieldComboBox *>( mFieldsMappingTable->cellWidget( i, 0 ) )->currentField().isNull();
+    isValid &= !static_cast<QgsFieldComboBox *>( mFieldsMappingTable->cellWidget( i, 1 ) )->currentField().isNull();
   }
-  mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( valid );
+
+  return isValid;
+}
+
+void QgsRelationAddDlg::updateChildRelationsComboBox()
+{
+  QgsVectorLayer *vl = static_cast<QgsVectorLayer *>( mReferencedLayerCombobox->currentLayer() );
+  if ( !vl || !vl->isValid() )
+    return;
+
+  QStringList relationIdsList;
+
+  const QList<QgsRelation> relations = QgsProject::instance()->relationManager()->referencedRelations( vl );
+  for ( const QgsRelation &relation : relations )
+  {
+    if ( !relation.isValid() )
+      continue;
+
+    if ( relation.referencingLayer() != vl )
+      continue;
+
+    relationIdsList << relationName();
+  }
+}
+
+void QgsRelationAddDlg::updateReferencedFieldsComboBoxes()
+{
+  QgsMapLayer *vl = mReferencedLayerCombobox->currentLayer();
+  if ( !vl || !vl->isValid() )
+    return;
+
+  for ( int i = 0, l = mFieldsMappingTable->rowCount(); i < l; i++ )
+  {
+    // ignore the layers row
+    if ( i == 0 )
+      continue;
+
+    auto fieldComboBox = static_cast<QgsFieldComboBox *>( mFieldsMappingTable->cellWidget( i, 0 ) );
+    fieldComboBox->setLayer( vl );
+  }
+}
+
+void QgsRelationAddDlg::updateReferencingFieldsComboBoxes()
+{
+  QgsMapLayer *vl = mReferencingLayerCombobox->currentLayer();
+  if ( !vl || !vl->isValid() )
+    return;
+
+  for ( int i = 0, l = mFieldsMappingTable->rowCount(); i < l; i++ )
+  {
+    // ignore the layers row
+    if ( i == 0 )
+      continue;
+
+    auto fieldComboBox = static_cast<QgsFieldComboBox *>( mFieldsMappingTable->cellWidget( i, 1 ) );
+    fieldComboBox->setLayer( vl );
+  }
 }

--- a/src/app/qgsrelationadddlg.cpp
+++ b/src/app/qgsrelationadddlg.cpp
@@ -40,7 +40,6 @@ QgsRelationAddDlg::QgsRelationAddDlg( QWidget *parent )
   , Ui::QgsRelationManagerAddDialogBase()
 {
   setupUi( this );
-  setWindowTitle( tr( "Add New Relation" ) );
 
   mReferencedLayerCombobox = new QgsMapLayerComboBox( this );
   mReferencedLayerCombobox->setFilters( QgsMapLayerProxyModel::VectorLayer );

--- a/src/app/qgsrelationaddpolymorphicdlg.cpp
+++ b/src/app/qgsrelationaddpolymorphicdlg.cpp
@@ -76,7 +76,7 @@ QgsRelationAddPolymorphicDlg::QgsRelationAddPolymorphicDlg( bool isEditDialog, Q
   connect( mFieldsMappingAddButton, &QToolButton::clicked, this, &QgsRelationAddPolymorphicDlg::addFieldsRow );
   connect( mFieldsMappingRemoveButton, &QToolButton::clicked, this, &QgsRelationAddPolymorphicDlg::removeFieldsRow );
   connect( mReferencingLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddPolymorphicDlg::updateDialogButtons );
-  connect( mRelationStrengthComboBox, QOverload<int>::of( &QComboBox::currentIndexChanged ), this, [ = ]( int index ) { Q_UNUSED( index ); updateDialogButtons(); } );
+  connect( mRelationStrengthComboBox, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, [ = ]( int index ) { Q_UNUSED( index ); updateDialogButtons(); } );
   connect( mReferencedLayerExpressionWidget, static_cast<void ( QgsFieldExpressionWidget::* )( const QString & )>( &QgsFieldExpressionWidget::fieldChanged ), this, &QgsRelationAddPolymorphicDlg::updateDialogButtons );
   connect( mReferencingLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddPolymorphicDlg::updateChildRelationsComboBox );
   connect( mReferencingLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddPolymorphicDlg::updateReferencingFieldsComboBoxes );

--- a/src/app/qgsrelationaddpolymorphicdlg.cpp
+++ b/src/app/qgsrelationaddpolymorphicdlg.cpp
@@ -33,12 +33,16 @@
 #include "qgsrelationmanager.h"
 #include "qgsfieldexpressionwidget.h"
 
-QgsRelationAddPolymorphicDlg::QgsRelationAddPolymorphicDlg( QWidget *parent )
+QgsRelationAddPolymorphicDlg::QgsRelationAddPolymorphicDlg( bool isEditDialog, QWidget *parent )
   : QDialog( parent )
   , Ui::QgsRelationManagerAddPolymorphicDialogBase()
+  , mIsEditDialog( isEditDialog )
 {
   setupUi( this );
-  setWindowTitle( tr( "Add New Polymorphic Relation" ) );
+
+  setWindowTitle( mIsEditDialog
+                  ? tr( "Edit Polymorphic Relation" )
+                  : tr( "Add Polymorphic Relation" ) );
 
   mButtonBox->setStandardButtons( QDialogButtonBox::Cancel | QDialogButtonBox::Help | QDialogButtonBox::Ok );
   connect( mButtonBox, &QDialogButtonBox::accepted, this, &QgsRelationAddPolymorphicDlg::accept );

--- a/src/app/qgsrelationaddpolymorphicdlg.cpp
+++ b/src/app/qgsrelationaddpolymorphicdlg.cpp
@@ -1,0 +1,244 @@
+/***************************************************************************
+    qgsrelationaddpolymorphicdlg.cpp
+    ---------------------
+    begin                : December 2020
+    copyright            : (C) 2020 by Ivan Ivanov
+    email                : ivan at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QToolButton>
+#include <QPushButton>
+#include <QComboBox>
+#include <QLineEdit>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+
+#include "qgsrelationaddpolymorphicdlg.h"
+#include "qgsvectorlayer.h"
+#include "qgsmaplayercombobox.h"
+#include "qgsfieldcombobox.h"
+#include "qgsmaplayerproxymodel.h"
+#include "qgsapplication.h"
+#include "qgshelp.h"
+#include "qgsproject.h"
+#include "qgsrelationmanager.h"
+#include "qgsfieldexpressionwidget.h"
+
+
+QgsRelationAddPolymorphicDlg::QgsRelationAddPolymorphicDlg( QWidget *parent )
+  : QDialog( parent )
+  , Ui::QgsRelationManagerAddPolymorphicDialogBase()
+{
+  setupUi( this );
+  setWindowTitle( tr( "Add New Polymorphic Relation" ) );
+
+  mButtonBox->setStandardButtons( QDialogButtonBox::Cancel | QDialogButtonBox::Help | QDialogButtonBox::Ok );
+  connect( mButtonBox, &QDialogButtonBox::accepted, this, &QgsRelationAddPolymorphicDlg::accept );
+  connect( mButtonBox, &QDialogButtonBox::rejected, this, &QgsRelationAddPolymorphicDlg::reject );
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, [ = ]
+  {
+    QgsHelp::openHelp( QStringLiteral( "working_with_vector/attribute_table.html#defining-polymorphic-relations" ) );
+  } );
+
+  const QVector<QgsVectorLayer *> layers = QgsProject::instance()->layers<QgsVectorLayer *>();
+  for ( const QgsMapLayer *vl : layers )
+  {
+    if ( !vl || !vl->isValid() )
+      continue;
+
+    mReferencedLayersComboBox->addItem( vl->name(), vl->id() );
+  }
+
+  addFieldsRow();
+  updateTypeConfigWidget();
+  updateDialogButtons();
+  updateReferencedLayerFieldComboBox();
+
+  connect( mFieldsMappingTable, &QTableWidget::itemSelectionChanged, this, &QgsRelationAddPolymorphicDlg::updateFieldsMappingButtons );
+  connect( mFieldsMappingAddButton, &QToolButton::clicked, this, &QgsRelationAddPolymorphicDlg::addFieldsRow );
+  connect( mFieldsMappingRemoveButton, &QToolButton::clicked, this, &QgsRelationAddPolymorphicDlg::removeFieldsRow );
+  connect( mReferencingLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddPolymorphicDlg::updateDialogButtons );
+//  connect( mReferencedLayerExpressionWidget, &QgsFieldExpressionWidget::fieldChanged, this, &QgsRelationAddPolymorphicDlg::updateDialogButtons );
+//  connect( mReferencedLayerFieldLayer, &QgsQ::layerChanged, this, &QgsRelationAddPolymorphicDlg::updateDialogButtons );
+  connect( mReferencingLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddPolymorphicDlg::updateChildRelationsComboBox );
+  connect( mReferencingLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddPolymorphicDlg::updateReferencingFieldsComboBoxes );
+  connect( mReferencingLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddPolymorphicDlg::updateReferencedLayerFieldComboBox );
+}
+
+void QgsRelationAddPolymorphicDlg::updateTypeConfigWidget()
+{
+  updateDialogButtons();
+}
+
+void QgsRelationAddPolymorphicDlg::addFieldsRow()
+{
+  QgsFieldComboBox *referencingField = new QgsFieldComboBox( this );
+  QLineEdit *referencedPolymorphicField = new QLineEdit( this );
+  int index = mFieldsMappingTable->rowCount();
+
+  referencingField->setLayer( mReferencingLayerComboBox->currentLayer() );
+
+  mFieldsMappingTable->insertRow( index );
+  mFieldsMappingTable->setCellWidget( index, 0, referencedPolymorphicField );
+  mFieldsMappingTable->setCellWidget( index, 1, referencingField );
+
+  updateFieldsMappingButtons();
+  updateFieldsMappingHeaders();
+  updateDialogButtons();
+}
+
+void QgsRelationAddPolymorphicDlg::removeFieldsRow()
+{
+  if ( mFieldsMappingTable->selectionModel()->hasSelection() )
+  {
+    for ( const QModelIndex &index : mFieldsMappingTable->selectionModel()->selectedRows() )
+    {
+      if ( index.row() == 0 )
+        continue;
+
+      if ( mFieldsMappingTable->rowCount() > 1 )
+        mFieldsMappingTable->removeRow( index.row() );
+    }
+  }
+  else
+  {
+    mFieldsMappingTable->removeRow( mFieldsMappingTable->rowCount() - 1 );
+  }
+
+  updateFieldsMappingButtons();
+  updateFieldsMappingHeaders();
+  updateDialogButtons();
+}
+
+void QgsRelationAddPolymorphicDlg::updateFieldsMappingButtons()
+{
+  int rowsCount = mFieldsMappingTable->rowCount();
+  int selectedRowsCount = mFieldsMappingTable->selectionModel()->selectedRows().count();
+  bool isRemoveButtonEnabled = selectedRowsCount <= rowsCount - 2;
+
+  mFieldsMappingRemoveButton->setEnabled( isRemoveButtonEnabled );
+}
+
+void QgsRelationAddPolymorphicDlg::updateFieldsMappingHeaders()
+{
+  int rowsCount = mFieldsMappingTable->rowCount();
+  QStringList verticalHeaderLabels;
+
+  for ( int i = 0; i < rowsCount; i++ )
+    verticalHeaderLabels << tr( "Field %1" ).arg( i + 1 );
+
+  mFieldsMappingTable->setVerticalHeaderLabels( verticalHeaderLabels );
+}
+
+QString QgsRelationAddPolymorphicDlg::referencingLayerId()
+{
+  return mReferencingLayerComboBox->currentLayer()->id();
+}
+
+QString QgsRelationAddPolymorphicDlg::referencedLayerField()
+{
+  return mReferencedLayerFieldComboBox->currentField();
+}
+
+QString QgsRelationAddPolymorphicDlg::referencedLayerExpression()
+{
+  return mReferencedLayerExpressionWidget->expression();
+}
+
+QStringList QgsRelationAddPolymorphicDlg::referencedLayerIds()
+{
+  return QVariant( mReferencedLayersComboBox->checkedItemsData() ).toStringList();
+}
+
+QList< QPair< QString, QString > > QgsRelationAddPolymorphicDlg::references()
+{
+  QList< QPair< QString, QString > > references;
+  for ( int i = 0, l = mFieldsMappingTable->rowCount(); i < l; i++ )
+  {
+    QString referencedField = static_cast<QLineEdit *>( mFieldsMappingTable->cellWidget( i, 0 ) )->text();
+    QString referencingField = static_cast<QgsFieldComboBox *>( mFieldsMappingTable->cellWidget( i, 1 ) )->currentField();
+    references << qMakePair( referencingField, referencedField );
+  }
+
+  return references;
+}
+
+QString QgsRelationAddPolymorphicDlg::relationId()
+{
+  return mIdLineEdit->text();
+}
+
+QString QgsRelationAddPolymorphicDlg::relationName()
+{
+  QgsVectorLayer *vl = static_cast<QgsVectorLayer *>( mReferencingLayerComboBox->currentLayer() );
+  return tr( "Polymorphic relations for \"%1\"" ).arg( vl ? vl->name() : QStringLiteral( "<NO LAYER>" ) );
+}
+
+void QgsRelationAddPolymorphicDlg::updateDialogButtons()
+{
+  mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( isDefinitionValid() );
+}
+
+bool QgsRelationAddPolymorphicDlg::isDefinitionValid()
+{
+  bool isValid = true;
+  return isValid;
+  QgsMapLayer *referencedLayer = mReferencingLayerComboBox->currentLayer();
+  isValid &= referencedLayer && referencedLayer->isValid();
+
+  for ( int i = 0, l = mFieldsMappingTable->rowCount(); i < l; i++ )
+  {
+    isValid &= !static_cast<QLineEdit *>( mFieldsMappingTable->cellWidget( i, 0 ) )->text().isNull();
+    isValid &= !static_cast<QgsFieldComboBox *>( mFieldsMappingTable->cellWidget( i, 1 ) )->currentField().isNull();
+  }
+
+  return isValid;
+}
+
+void QgsRelationAddPolymorphicDlg::updateChildRelationsComboBox()
+{
+  QgsVectorLayer *vl = static_cast<QgsVectorLayer *>( mReferencingLayerComboBox->currentLayer() );
+  if ( !vl || !vl->isValid() )
+    return;
+
+  QStringList relationIdsList;
+
+  const QList<QgsRelation> relations = QgsProject::instance()->relationManager()->referencedRelations( vl );
+  for ( const QgsRelation &relation : relations )
+  {
+    if ( !relation.isValid() )
+      continue;
+
+    if ( relation.referencingLayer() != vl )
+      continue;
+
+    relationIdsList << relationName();
+  }
+}
+
+void QgsRelationAddPolymorphicDlg::updateReferencingFieldsComboBoxes()
+{
+  QgsMapLayer *vl = mReferencingLayerComboBox->currentLayer();
+  if ( !vl || !vl->isValid() )
+    return;
+
+  for ( int i = 0, l = mFieldsMappingTable->rowCount(); i < l; i++ )
+  {
+    auto fieldComboBox = static_cast<QgsFieldComboBox *>( mFieldsMappingTable->cellWidget( i, 1 ) );
+    fieldComboBox->setLayer( vl );
+  }
+}
+
+void QgsRelationAddPolymorphicDlg::updateReferencedLayerFieldComboBox()
+{
+  mReferencedLayerFieldComboBox->setLayer( mReferencingLayerComboBox->currentLayer() );
+}

--- a/src/app/qgsrelationaddpolymorphicdlg.h
+++ b/src/app/qgsrelationaddpolymorphicdlg.h
@@ -79,6 +79,11 @@ class APP_EXPORT QgsRelationAddPolymorphicDlg : public QDialog, private Ui::QgsR
     QStringList referencedLayerIds();
 
     /**
+      * Return the relation strength for the generated normal relations
+      */
+    QgsRelation::RelationStrength relationStrength();
+
+    /**
      * Sets the values of form fields in the dialog with the values of the passed \a polyRel
      */
     void setPolymorphicRelation( const QgsPolymorphicRelation polyRel );

--- a/src/app/qgsrelationaddpolymorphicdlg.h
+++ b/src/app/qgsrelationaddpolymorphicdlg.h
@@ -1,9 +1,9 @@
 /***************************************************************************
-    qgsrelationadddlg.h
+    qgsrelationaddpolymorphicdlg.h
     ---------------------
-    begin                : December 2015
-    copyright            : (C) 2015 by Matthias Kuhn
-    email                : matthias at opengis dot ch
+    begin                : December 2020
+    copyright            : (C) 2020 by Ivan Ivanov
+    email                : ivan at opengis dot ch
  ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -12,12 +12,12 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-#ifndef QGSRELATIONADDDLG_H
-#define QGSRELATIONADDDLG_H
+#ifndef QGSRELATIONADDPOLYMORPHICDLG_H
+#define QGSRELATIONADDPOLYMORPHICDLG_H
 
 #include <QDialog>
 #include "qgis_app.h"
-#include "ui_qgsrelationmanageradddialogbase.h"
+#include "ui_qgsrelationmanageraddpolymorphicdialogbase.h"
 #include "qgsrelation.h"
 
 class QDialogButtonBox;
@@ -36,37 +36,46 @@ class QgsMapLayerComboBox;
  * QgsRelationAddDlg allows configuring a new relation.
  * Multiple field pairs can be set.
  */
-class APP_EXPORT QgsRelationAddDlg : public QDialog, private Ui::QgsRelationManagerAddDialogBase
+class APP_EXPORT QgsRelationAddPolymorphicDlg : public QDialog, private Ui::QgsRelationManagerAddPolymorphicDialogBase
 {
     Q_OBJECT
 
   public:
-    explicit QgsRelationAddDlg( QWidget *parent = nullptr );
+    explicit QgsRelationAddPolymorphicDlg( QWidget *parent = nullptr );
 
     QString referencingLayerId();
-    QString referencedLayerId();
+    QString referencedLayerField();
+    QString referencedLayerExpression();
     QList< QPair< QString, QString > > references();
     QString relationId();
     QString relationName();
+    QStringList referencedLayerIds();
     QgsRelation::RelationStrength relationStrength();
 
   private slots:
     void addFieldsRow();
     void removeFieldsRow();
+    void updateTypeConfigWidget();
     void updateFieldsMappingButtons();
     void updateFieldsMappingHeaders();
     void updateDialogButtons();
     void updateChildRelationsComboBox();
-    void updateReferencedFieldsComboBoxes();
     void updateReferencingFieldsComboBoxes();
+    void updateReferencedLayerFieldComboBox();
 
   private:
     bool isDefinitionValid();
     void updateFieldsMapping();
+//    QList<QgsFieldPairWidget *> mFieldPairWidgets;
 
-    QgsMapLayerComboBox *mReferencedLayerCombobox = nullptr;
-    QgsMapLayerComboBox *mReferencingLayerCombobox = nullptr;
+//    QDialogButtonBox *mButtonBox = nullptr;
+//    QVBoxLayout *mFieldPairsLayout = nullptr;
+//    QLineEdit *mNameLineEdit = nullptr;
+//    QComboBox *mTypeComboBox = nullptr;
+//    QLineEdit *mIdLineEdit = nullptr;
+//    QLineEdit *mReferencedLayerExpressionLineEdit = nullptr;
+//    QComboBox *mStrengthCombobox = nullptr;
 
 };
 
-#endif // QGSRELATIONADDDLG_H
+#endif // QGSRELATIONADDPOLYMORPHICDLG_H

--- a/src/app/qgsrelationaddpolymorphicdlg.h
+++ b/src/app/qgsrelationaddpolymorphicdlg.h
@@ -41,7 +41,7 @@ class APP_EXPORT QgsRelationAddPolymorphicDlg : public QDialog, private Ui::QgsR
     Q_OBJECT
 
   public:
-    explicit QgsRelationAddPolymorphicDlg( QWidget *parent = nullptr );
+    explicit QgsRelationAddPolymorphicDlg( bool isEditDialog, QWidget *parent = nullptr );
 
     /**
      * Returns the id of the referencing layer
@@ -102,6 +102,8 @@ class APP_EXPORT QgsRelationAddPolymorphicDlg : public QDialog, private Ui::QgsR
   private:
     bool isDefinitionValid();
     void updateFieldsMapping();
+
+    bool mIsEditDialog = false;
 
 };
 

--- a/src/app/qgsrelationaddpolymorphicdlg.h
+++ b/src/app/qgsrelationaddpolymorphicdlg.h
@@ -43,14 +43,45 @@ class APP_EXPORT QgsRelationAddPolymorphicDlg : public QDialog, private Ui::QgsR
   public:
     explicit QgsRelationAddPolymorphicDlg( QWidget *parent = nullptr );
 
+    /**
+     * Returns the id of the referencing layer
+     */
     QString referencingLayerId();
+
+    /**
+     * Returns the field in the referencing layer that stores the referenced layer representation
+     */
     QString referencedLayerField();
+
+    /**
+     * Returns the expression used to generate the referenced layer representation
+     */
     QString referencedLayerExpression();
-    QList< QPair< QString, QString > > references();
+
+    /**
+     * Returns field pairs
+     */
+    QList< QPair< QString, QString > > fieldPairs();
+
+    /**
+     * Returns the polymorphic relation id
+     */
     QString relationId();
+
+    /**
+     * Returns the polymorphic relation name
+     */
     QString relationName();
+
+    /**
+     * Returns a list of layer ids used as referenced layers and stored in the referencing layers
+     */
     QStringList referencedLayerIds();
-    QgsRelation::RelationStrength relationStrength();
+
+    /**
+     * Sets the values of form fields in the dialog with the values of the passed \a polyRel
+     */
+    void setPolymorphicRelation( const QgsPolymorphicRelation polyRel );
 
   private slots:
     void addFieldsRow();
@@ -66,15 +97,6 @@ class APP_EXPORT QgsRelationAddPolymorphicDlg : public QDialog, private Ui::QgsR
   private:
     bool isDefinitionValid();
     void updateFieldsMapping();
-//    QList<QgsFieldPairWidget *> mFieldPairWidgets;
-
-//    QDialogButtonBox *mButtonBox = nullptr;
-//    QVBoxLayout *mFieldPairsLayout = nullptr;
-//    QLineEdit *mNameLineEdit = nullptr;
-//    QComboBox *mTypeComboBox = nullptr;
-//    QLineEdit *mIdLineEdit = nullptr;
-//    QLineEdit *mReferencedLayerExpressionLineEdit = nullptr;
-//    QComboBox *mStrengthCombobox = nullptr;
 
 };
 

--- a/src/app/qgsrelationmanagerdialog.cpp
+++ b/src/app/qgsrelationmanagerdialog.cpp
@@ -79,7 +79,7 @@ void QgsRelationManagerDialog::setLayers( const QList< QgsVectorLayer * > &layer
     if ( rel.type() == QgsRelation::Generated )
       continue;
 
-    addRelation( rel );
+    addRelationPrivate( rel );
   }
   const QList<QgsPolymorphicRelation> &polymorphicRelations = mRelationManager->polymorphicRelations().values();
   for ( const QgsPolymorphicRelation &polymorphicRel : polymorphicRelations )

--- a/src/app/qgsrelationmanagerdialog.cpp
+++ b/src/app/qgsrelationmanagerdialog.cpp
@@ -280,7 +280,8 @@ void QgsRelationManagerDialog::mActionEditPolymorphicRelation_triggered()
   if ( rows.size() != 1 )
     return;
 
-  addDlg.setPolymorphicRelation( mRelationsTree->topLevelItem( rows[0].row() )->data( 0, Qt::UserRole ).value<QgsPolymorphicRelation>() );
+  const QgsPolymorphicRelation polyRel = mRelationsTree->topLevelItem( rows[0].row() )->data( 0, Qt::UserRole ).value<QgsPolymorphicRelation>();
+  addDlg.setPolymorphicRelation( polyRel );
 
   if ( addDlg.exec() )
   {
@@ -301,6 +302,19 @@ void QgsRelationManagerDialog::mActionEditPolymorphicRelation_triggered()
       relation.generateId();
     else
       relation.setId( relationId );
+
+    for ( int i = 0, l = mRelationsTree->topLevelItemCount(); i < l; i++ )
+    {
+      mRelationsTree->topLevelItem( i )->data( 0, Qt::UserRole );
+      QgsPolymorphicRelation currentPolyRel = mRelationsTree->topLevelItem( i )->data( 0, Qt::UserRole ).value<QgsPolymorphicRelation>();
+
+      if ( currentPolyRel.id() == polyRel.id() )
+      {
+        // we safely assume that polymorphic relations are always a top level item
+        mRelationsTree->takeTopLevelItem( i );
+        break;
+      }
+    }
 
     addPolymorphicRelation( relation );
   }

--- a/src/app/qgsrelationmanagerdialog.cpp
+++ b/src/app/qgsrelationmanagerdialog.cpp
@@ -76,7 +76,7 @@ void QgsRelationManagerDialog::setLayers( const QList< QgsVectorLayer * > &layer
   {
     // the generated relations for polymorphic relations should be ignored,
     // they are generated when the polymorphic relation is added to the table
-    if ( !rel.polymorphicRelationId().isEmpty() )
+    if ( rel.type() == QgsRelation::Generated )
       continue;
 
     addRelation( rel );

--- a/src/app/qgsrelationmanagerdialog.cpp
+++ b/src/app/qgsrelationmanagerdialog.cpp
@@ -148,15 +148,15 @@ void QgsRelationManagerDialog::addRelation( const QgsRelation &rel )
   mRelationsTree->setSortingEnabled( true );
 }
 
-void QgsRelationManagerDialog::addPolymorphicRelation( const QgsPolymorphicRelation &relation )
+void QgsRelationManagerDialog::addPolymorphicRelation( const QgsPolymorphicRelation &polyRel )
 {
-  if ( ! relation.isValid() )
+  if ( ! polyRel.isValid() )
     return;
 
   QString referencingFields;
   QString referencedFields;
 
-  for ( int i = 0; i < relation.fieldPairs().count(); i++ )
+  for ( int i = 0; i < polyRel.fieldPairs().count(); i++ )
   {
     if ( i != 0 )
     {
@@ -164,8 +164,8 @@ void QgsRelationManagerDialog::addPolymorphicRelation( const QgsPolymorphicRelat
       referencedFields += QStringLiteral( ", " );
     }
 
-    referencingFields += relation.fieldPairs().at( i ).referencingField();
-    referencedFields += relation.fieldPairs().at( i ).referencedField();
+    referencingFields += polyRel.fieldPairs().at( i ).referencingField();
+    referencedFields += polyRel.fieldPairs().at( i ).referencedField();
   }
 
   mRelationsTree->setSortingEnabled( false );
@@ -177,15 +177,18 @@ void QgsRelationManagerDialog::addPolymorphicRelation( const QgsPolymorphicRelat
   // Save relation in first column's item
   item->setExpanded( true );
   item->setFlags( item->flags() | Qt::ItemIsEditable );
-  item->setData( 0, Qt::UserRole, QVariant::fromValue<QgsPolymorphicRelation>( relation ) );
-  item->setText( 0, relation.name() );
-  item->setText( 1, relation.referencingLayer()->name() );
+  item->setData( 0, Qt::UserRole, QVariant::fromValue<QgsPolymorphicRelation>( polyRel ) );
+  item->setText( 0, polyRel.name() );
+  item->setText( 1, polyRel.referencingLayer()->name() );
   item->setText( 2, referencedFields );
-  item->setText( 3, QStringLiteral( "as in \"%1\".\"%2\"" ).arg( relation.referencingLayer()->name(), relation.referencedLayerField() ) );
+  item->setText( 3, QStringLiteral( "as in \"%1\".\"%2\"" ).arg( polyRel.referencingLayer()->name(), polyRel.referencedLayerField() ) );
   item->setText( 4, referencingFields );
-  item->setText( 5, relation.id() );
+  item->setText( 5, polyRel.id() );
+  item->setText( 6, polyRel.strength() == QgsRelation::RelationStrength::Composition
+                 ? QStringLiteral( "Composition" )
+                 : QStringLiteral( "Association" ) );
 
-  const QList<QgsRelation> generatedRelations = relation.generateRelations();
+  const QList<QgsRelation> generatedRelations = polyRel.generateRelations();
   for ( const QgsRelation &generatedRelation : generatedRelations )
   {
     if ( !generatedRelation.isValid() )
@@ -252,6 +255,7 @@ void QgsRelationManagerDialog::mActionAddPolymorphicRelation_triggered()
     relation.setReferencedLayerField( addDlg.referencedLayerField() );
     relation.setReferencedLayerExpression( addDlg.referencedLayerExpression() );
     relation.setReferencedLayerIds( addDlg.referencedLayerIds() );
+    relation.setRelationStrength( addDlg.relationStrength() );
 
     const auto references = addDlg.fieldPairs();
     for ( const auto &reference : references )
@@ -285,6 +289,7 @@ void QgsRelationManagerDialog::mActionEditPolymorphicRelation_triggered()
     relation.setReferencedLayerField( addDlg.referencedLayerField() );
     relation.setReferencedLayerExpression( addDlg.referencedLayerExpression() );
     relation.setReferencedLayerIds( addDlg.referencedLayerIds() );
+    relation.setRelationStrength( addDlg.relationStrength() );
 
     const auto references = addDlg.fieldPairs();
     for ( const auto &reference : references )

--- a/src/app/qgsrelationmanagerdialog.cpp
+++ b/src/app/qgsrelationmanagerdialog.cpp
@@ -164,18 +164,18 @@ bool QgsRelationManagerDialog::addRelationPrivate( const QgsRelation &rel, QTree
   mRelationsTree->setSortingEnabled( false );
   QTreeWidgetItem *item = new QTreeWidgetItem();
 
-  if ( parentItem )
+  switch ( rel.type() )
   {
-    item->setFlags( item->flags() & ~Qt::ItemIsSelectable );
+    case QgsRelation::Normal:
+      item->setFlags( item->flags() | Qt::ItemIsEditable );
+      mRelationsTree->invisibleRootItem()->addChild( item );
+      break;
+    case QgsRelation::Generated:
+      Q_ASSERT( parentItem );
+      item->setFlags( item->flags() & ~Qt::ItemIsSelectable );
+      parentItem->addChild( item );
+      break;
   }
-  else
-  {
-    Q_ASSERT( rel.type() != QgsRelation::Generated );
-    item->setFlags( item->flags() | Qt::ItemIsEditable );
-    parentItem = mRelationsTree->invisibleRootItem();
-  }
-
-  parentItem->addChild( item );
 
   // Save relation in first column's item
   item->setData( 0, Qt::UserRole, QVariant::fromValue<QgsRelation>( rel ) );

--- a/src/app/qgsrelationmanagerdialog.cpp
+++ b/src/app/qgsrelationmanagerdialog.cpp
@@ -15,9 +15,33 @@
 
 #include "qgsdiscoverrelationsdialog.h"
 #include "qgsrelationadddlg.h"
+#include "qgsrelationaddpolymorphicdlg.h"
 #include "qgsrelationmanagerdialog.h"
 #include "qgsrelationmanager.h"
+#include "qgspolymorphicrelation.h"
 #include "qgsvectorlayer.h"
+
+
+#ifndef SIP_RUN
+class RelationNameEditorDelegate: public QStyledItemDelegate
+{
+  public:
+    RelationNameEditorDelegate( const QList<int> &editableColumns, QObject *parent = nullptr )
+      : QStyledItemDelegate( parent )
+      , mEditableColumns( editableColumns )
+    {}
+
+    virtual QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index ) const
+    {
+      if ( mEditableColumns.contains( index.column() ) )
+        return QStyledItemDelegate::createEditor( parent, option, index );
+
+      return nullptr;
+    }
+  private:
+    QList<int> mEditableColumns;
+};
+#endif
 
 QgsRelationManagerDialog::QgsRelationManagerDialog( QgsRelationManager *relationMgr, QWidget *parent )
   : QWidget( parent )
@@ -25,12 +49,20 @@ QgsRelationManagerDialog::QgsRelationManagerDialog( QgsRelationManager *relation
   , mRelationManager( relationMgr )
 {
   setupUi( this );
+
+  mRelationsTree->header()->setSectionResizeMode( QHeaderView::ResizeToContents );
+  mRelationsTree->setItemDelegate( new RelationNameEditorDelegate( QList<int>( {0} ), this ) );
+
   connect( mBtnAddRelation, &QPushButton::clicked, this, &QgsRelationManagerDialog::mBtnAddRelation_clicked );
+  connect( mActionAddPolymorphicRelation, &QAction::triggered, this, &QgsRelationManagerDialog::mActionAddPolymorphicRelation_triggered );
   connect( mBtnDiscoverRelations, &QPushButton::clicked, this, &QgsRelationManagerDialog::mBtnDiscoverRelations_clicked );
   connect( mBtnRemoveRelation, &QPushButton::clicked, this, &QgsRelationManagerDialog::mBtnRemoveRelation_clicked );
 
   mBtnRemoveRelation->setEnabled( false );
-  connect( mRelationsTable->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsRelationManagerDialog::onSelectionChanged );
+  mBtnAddRelation->setPopupMode( QToolButton::MenuButtonPopup );
+  mBtnAddRelation->addAction( mActionAddPolymorphicRelation );
+
+  connect( mRelationsTree->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsRelationManagerDialog::onSelectionChanged );
 }
 
 void QgsRelationManagerDialog::setLayers( const QList< QgsVectorLayer * > &layers )
@@ -38,14 +70,22 @@ void QgsRelationManagerDialog::setLayers( const QList< QgsVectorLayer * > &layer
   mLayers = layers;
 
   const QList<QgsRelation> &relations = mRelationManager->relations().values();
-
-  const auto constRelations = relations;
-  for ( const QgsRelation &rel : constRelations )
+  for ( const QgsRelation &rel : relations )
   {
+    // the generated relations for polymorphic relations should be ignored,
+    // they are generated when the polymorphic relation is added to the table
+    if ( !rel.polymorphicRelationId().isEmpty() )
+      continue;
+
     addRelation( rel );
   }
+  const QList<QgsPolymorphicRelation> &polymorphicRelations = mRelationManager->polymorphicRelations().values();
+  for ( const QgsPolymorphicRelation &polymorphicRel : polymorphicRelations )
+  {
+    addPolymorphicRelation( polymorphicRel );
+  }
 
-  mRelationsTable->sortByColumn( 0, Qt::AscendingOrder );
+  mRelationsTree->sortByColumn( 0, Qt::AscendingOrder );
 }
 
 void QgsRelationManagerDialog::addRelation( const QgsRelation &rel )
@@ -61,47 +101,97 @@ void QgsRelationManagerDialog::addRelation( const QgsRelation &rel )
     referencedFields.append( QStringLiteral( ", %1" ).arg( rel.fieldPairs().at( i ).referencedField() ) );
   }
 
-  mRelationsTable->setSortingEnabled( false );
-  int row = mRelationsTable->rowCount();
-  mRelationsTable->insertRow( row );
+  mRelationsTree->setSortingEnabled( false );
+  int row = mRelationsTree->topLevelItemCount();
+  QTreeWidgetItem *item = new QTreeWidgetItem();
 
-  QTableWidgetItem *item = new QTableWidgetItem( rel.name() );
-  // Save relation in first column's item
-  item->setData( Qt::UserRole, QVariant::fromValue<QgsRelation>( rel ) );
-  mRelationsTable->setItem( row, 0, item );
-
-  item = new QTableWidgetItem( rel.referencedLayer()->name() );
-  item->setFlags( Qt::ItemIsEnabled );
-  mRelationsTable->setItem( row, 1, item );
-
-  item = new QTableWidgetItem( referencedFields );
-  item->setFlags( Qt::ItemIsEnabled );
-  mRelationsTable->setItem( row, 2, item );
-
-  item = new QTableWidgetItem( rel.referencingLayer()->name() );
-  item->setFlags( Qt::ItemIsEnabled );
-  mRelationsTable->setItem( row, 3, item );
-
-  item = new QTableWidgetItem( referencingFields );
-  item->setFlags( Qt::ItemIsEnabled );
-  mRelationsTable->setItem( row, 4, item );
-
-  item = new QTableWidgetItem( rel.id() );
-  item->setFlags( Qt::ItemIsEnabled );
-  mRelationsTable->setItem( row, 5, item );
-
-  if ( rel.strength() == QgsRelation::RelationStrength::Composition )
+  if ( rel.polymorphicRelationId().isEmpty() )
   {
-    item = new QTableWidgetItem( QStringLiteral( "Composition" ) );
+    mRelationsTree->insertTopLevelItem( row, item );
   }
   else
   {
-    item = new QTableWidgetItem( QStringLiteral( "Association" ) );
-  }
-  item->setFlags( Qt::ItemIsEnabled );
-  mRelationsTable->setItem( row, 6, item );
+    for ( int i = 0, l = mRelationsTree->topLevelItemCount(); i < l; i++ )
+    {
+      QTreeWidgetItem *parentItem = mRelationsTree->topLevelItem( i );
 
-  mRelationsTable->setSortingEnabled( true );
+      if ( parentItem->data( 0, Qt::UserRole ).typeName() != QStringLiteral( "QgsPolymorphicRelation" ) )
+        continue;
+
+      QgsPolymorphicRelation polymorphicRelation = parentItem->data( 0, Qt::UserRole ).value<QgsPolymorphicRelation>();
+
+      if ( polymorphicRelation.id() != rel.polymorphicRelationId() )
+        continue;
+
+      parentItem->addChild( item );
+      break;
+    }
+  }
+
+  // Save relation in first column's item
+  item->setData( 0, Qt::UserRole, QVariant::fromValue<QgsRelation>( rel ) );
+  item->setFlags( item->flags() | Qt::ItemIsEditable );
+
+  item->setText( 0, rel.name() );
+  item->setText( 1, rel.referencedLayer()->name() );
+  item->setText( 2, referencedFields );
+  item->setText( 3, rel.referencingLayer()->name() );
+  item->setText( 4, referencingFields );
+  item->setText( 5, rel.id() );
+  item->setText( 6, rel.strength() == QgsRelation::RelationStrength::Composition
+                 ? QStringLiteral( "Composition" )
+                 : QStringLiteral( "Association" ) );
+
+  mRelationsTree->setSortingEnabled( true );
+}
+
+void QgsRelationManagerDialog::addPolymorphicRelation( const QgsPolymorphicRelation &relation )
+{
+  if ( ! relation.isValid() )
+    return;
+
+  QString referencingFields;
+  QString referencedFields;
+
+  for ( int i = 0; i < relation.fieldPairs().count(); i++ )
+  {
+    if ( i != 0 )
+    {
+      referencingFields += QStringLiteral( ", " );
+      referencedFields += QStringLiteral( ", " );
+    }
+
+    referencingFields += relation.fieldPairs().at( i ).referencingField();
+    referencedFields += relation.fieldPairs().at( i ).referencedField();
+  }
+
+  mRelationsTree->setSortingEnabled( false );
+  int row = mRelationsTree->topLevelItemCount();
+  QTreeWidgetItem *item = new QTreeWidgetItem();
+
+  mRelationsTree->insertTopLevelItem( row, item );
+
+  // Save relation in first column's item
+  item->setExpanded( true );
+  item->setFlags( item->flags() | Qt::ItemIsEditable );
+  item->setData( 0, Qt::UserRole, QVariant::fromValue<QgsPolymorphicRelation>( relation ) );
+  item->setText( 0, relation.name() );
+  item->setText( 1, relation.referencingLayer()->name() );
+  item->setText( 2, referencedFields );
+  item->setText( 3, QStringLiteral( "as in \"%1\".\"%2\"" ).arg( relation.referencingLayer()->name(), relation.referencedLayerField() ) );
+  item->setText( 4, referencingFields );
+  item->setText( 5, relation.id() );
+
+  const QList<QgsRelation> generatedRelations = relation.generateRelations();
+  for ( const QgsRelation &generatedRelation : generatedRelations )
+  {
+    if ( !generatedRelation.isValid() )
+      continue;
+
+    addRelation( generatedRelation );
+  }
+
+  mRelationsTree->setSortingEnabled( true );
 }
 
 void QgsRelationManagerDialog::mBtnAddRelation_clicked()
@@ -148,6 +238,33 @@ void QgsRelationManagerDialog::mBtnAddRelation_clicked()
   }
 }
 
+void QgsRelationManagerDialog::mActionAddPolymorphicRelation_triggered()
+{
+  QgsRelationAddPolymorphicDlg addDlg;
+
+  if ( addDlg.exec() )
+  {
+    QgsPolymorphicRelation relation;
+    relation.setReferencingLayer( addDlg.referencingLayerId() );
+    relation.setReferencedLayerField( addDlg.referencedLayerField() );
+    relation.setReferencedLayerExpression( addDlg.referencedLayerExpression() );
+    relation.setReferencedLayerIds( addDlg.referencedLayerIds() );
+
+    const auto references = addDlg.references();
+    for ( const auto &reference : references )
+      relation.addFieldPair( reference.first, reference.second );
+
+    QString relationId = addDlg.relationId();
+
+    if ( relationId.isEmpty() )
+      relation.generateId();
+    else
+      relation.setId( relationId );
+
+    addPolymorphicRelation( relation );
+  }
+}
+
 void QgsRelationManagerDialog::mBtnDiscoverRelations_clicked()
 {
   QgsDiscoverRelationsDialog discoverDlg( relations(), mLayers, this );
@@ -163,10 +280,10 @@ void QgsRelationManagerDialog::mBtnDiscoverRelations_clicked()
 
 void QgsRelationManagerDialog::mBtnRemoveRelation_clicked()
 {
-  const QModelIndexList rows = mRelationsTable->selectionModel()->selectedRows();
+  const QModelIndexList rows = mRelationsTree->selectionModel()->selectedRows();
   for ( int i = rows.size() - 1; i >= 0; --i )
   {
-    mRelationsTable->removeRow( rows[i].row() );
+    mRelationsTree->takeTopLevelItem( rows[i].row() );
   }
 }
 
@@ -174,13 +291,40 @@ QList< QgsRelation > QgsRelationManagerDialog::relations()
 {
   QList< QgsRelation > relations;
 
-  int rows = mRelationsTable->rowCount();
+  int rows = mRelationsTree->topLevelItemCount();
   relations.reserve( rows );
   for ( int i = 0; i < rows; ++i )
   {
-    QgsRelation relation = mRelationsTable->item( i, 0 )->data( Qt::UserRole ).value<QgsRelation>();
+    QTreeWidgetItem *item = mRelationsTree->topLevelItem( i );
+
+    if ( item->data( 0, Qt::UserRole ).typeName() != QStringLiteral( "QgsRelation" ) )
+      continue;
+
+    QgsRelation relation = item->data( 0, Qt::UserRole ).value<QgsRelation>();
     // The name can be edited in the table, so apply this one
-    relation.setName( mRelationsTable->item( i, 0 )->data( Qt::DisplayRole ).toString() );
+    relation.setName( item->data( 0, Qt::DisplayRole ).toString() );
+    relations << relation;
+  }
+
+  return relations;
+}
+
+QList< QgsPolymorphicRelation > QgsRelationManagerDialog::polymorphicRelations()
+{
+  QList< QgsPolymorphicRelation > relations;
+
+  int rows = mRelationsTree->topLevelItemCount();
+  relations.reserve( rows );
+  for ( int i = 0; i < rows; ++i )
+  {
+    QTreeWidgetItem *item = mRelationsTree->topLevelItem( i );
+
+    if ( item->data( 0, Qt::UserRole ).typeName() != QStringLiteral( "QgsPolymorphicRelation" ) )
+      continue;
+
+    QgsPolymorphicRelation relation = item->data( 0, Qt::UserRole ).value<QgsPolymorphicRelation>();
+    // The name can be edited in the table, so apply this one
+    relation.setName( item->data( 0, Qt::DisplayRole ).toString() );
     relations << relation;
   }
 
@@ -189,5 +333,5 @@ QList< QgsRelation > QgsRelationManagerDialog::relations()
 
 void QgsRelationManagerDialog::onSelectionChanged()
 {
-  mBtnRemoveRelation->setEnabled( mRelationsTable->selectionModel()->hasSelection() );
+  mBtnRemoveRelation->setEnabled( mRelationsTree->selectionModel()->hasSelection() );
 }

--- a/src/app/qgsrelationmanagerdialog.cpp
+++ b/src/app/qgsrelationmanagerdialog.cpp
@@ -50,7 +50,6 @@ QgsRelationManagerDialog::QgsRelationManagerDialog( QgsRelationManager *relation
 {
   setupUi( this );
 
-  mRelationsTree->header()->setSectionResizeMode( QHeaderView::ResizeToContents );
   mRelationsTree->setItemDelegate( new RelationNameEditorDelegate( QList<int>( {0} ), mRelationsTree ) );
 
   connect( mBtnAddRelation, &QPushButton::clicked, this, &QgsRelationManagerDialog::mBtnAddRelation_clicked );

--- a/src/app/qgsrelationmanagerdialog.cpp
+++ b/src/app/qgsrelationmanagerdialog.cpp
@@ -246,7 +246,7 @@ void QgsRelationManagerDialog::mBtnAddRelation_clicked()
 
 void QgsRelationManagerDialog::mActionAddPolymorphicRelation_triggered()
 {
-  QgsRelationAddPolymorphicDlg addDlg;
+  QgsRelationAddPolymorphicDlg addDlg( false );
 
   if ( addDlg.exec() )
   {
@@ -274,7 +274,7 @@ void QgsRelationManagerDialog::mActionAddPolymorphicRelation_triggered()
 
 void QgsRelationManagerDialog::mActionEditPolymorphicRelation_triggered()
 {
-  QgsRelationAddPolymorphicDlg addDlg;
+  QgsRelationAddPolymorphicDlg addDlg( true );
   const QModelIndexList rows = mRelationsTree->selectionModel()->selectedRows();
 
   if ( rows.size() != 1 )

--- a/src/app/qgsrelationmanagerdialog.h
+++ b/src/app/qgsrelationmanagerdialog.h
@@ -35,8 +35,8 @@ class APP_EXPORT QgsRelationManagerDialog : public QWidget, private Ui::QgsRelat
 
     void setLayers( const QList<QgsVectorLayer *> & );
 
-    void addRelation( const QgsRelation &rel );
-    void addPolymorphicRelation( const QgsPolymorphicRelation &relation );
+    bool addRelation( const QgsRelation &rel );
+    int addPolymorphicRelation( const QgsPolymorphicRelation &relation );
     QList< QgsRelation > relations();
     QList< QgsPolymorphicRelation > polymorphicRelations();
 
@@ -49,6 +49,8 @@ class APP_EXPORT QgsRelationManagerDialog : public QWidget, private Ui::QgsRelat
     void onSelectionChanged();
 
   private:
+    bool addRelationPrivate( const QgsRelation &rel, QTreeWidgetItem *parentItem = nullptr );
+
     QgsRelationManager *mRelationManager = nullptr;
     QList< QgsVectorLayer * > mLayers;
     QString getUniqueId( const QString &idTmpl, const QString &ids ) const;

--- a/src/app/qgsrelationmanagerdialog.h
+++ b/src/app/qgsrelationmanagerdialog.h
@@ -21,6 +21,7 @@
 #include "qgis_app.h"
 
 class QgsRelation;
+class QgsPolymorphicRelation;
 class QgsRelationManager;
 class QgsRelationManagerTreeModel;
 class QgsVectorLayer;
@@ -35,10 +36,13 @@ class APP_EXPORT QgsRelationManagerDialog : public QWidget, private Ui::QgsRelat
     void setLayers( const QList<QgsVectorLayer *> & );
 
     void addRelation( const QgsRelation &rel );
+    void addPolymorphicRelation( const QgsPolymorphicRelation &relation );
     QList< QgsRelation > relations();
+    QList< QgsPolymorphicRelation > polymorphicRelations();
 
   private slots:
     void mBtnAddRelation_clicked();
+    void mActionAddPolymorphicRelation_triggered();
     void mBtnDiscoverRelations_clicked();
     void mBtnRemoveRelation_clicked();
     void onSelectionChanged();
@@ -46,6 +50,7 @@ class APP_EXPORT QgsRelationManagerDialog : public QWidget, private Ui::QgsRelat
   private:
     QgsRelationManager *mRelationManager = nullptr;
     QList< QgsVectorLayer * > mLayers;
+    QString getUniqueId( const QString &idTmpl, const QString &ids ) const;
 };
 
 #endif // QGSRELATIONMANAGERDIALOG_H

--- a/src/app/qgsrelationmanagerdialog.h
+++ b/src/app/qgsrelationmanagerdialog.h
@@ -43,6 +43,7 @@ class APP_EXPORT QgsRelationManagerDialog : public QWidget, private Ui::QgsRelat
   private slots:
     void mBtnAddRelation_clicked();
     void mActionAddPolymorphicRelation_triggered();
+    void mActionEditPolymorphicRelation_triggered();
     void mBtnDiscoverRelations_clicked();
     void mBtnRemoveRelation_clicked();
     void onSelectionChanged();

--- a/src/core/qgspolymorphicrelation.h
+++ b/src/core/qgspolymorphicrelation.h
@@ -274,6 +274,16 @@ class CORE_EXPORT QgsPolymorphicRelation
      */
     QString layerRepresentation( const QgsVectorLayer *layer ) const;
 
+    /**
+     * Returns the relation strength for all the generated normal relations
+     */
+    QgsRelation::RelationStrength strength() const;
+
+    /**
+     * Sets the relation strength for all the generated normal relations
+     */
+    void setRelationStrength( QgsRelation::RelationStrength relationStrength );
+
   private:
 
     QExplicitlySharedDataPointer<QgsPolymorphicRelationPrivate> d;

--- a/src/core/qgspolymorphicrelation_p.h
+++ b/src/core/qgspolymorphicrelation_p.h
@@ -67,6 +67,9 @@ class QgsPolymorphicRelationPrivate : public QSharedData
     //! A map of the layerIds and the respective layers
     QMap<QString, QgsVectorLayer *> mReferencedLayersMap;
 
+    //! The relation strength for all the generated normal relations
+    QgsRelation::RelationStrength mRelationStrength;
+
     //! Whether the polymorphic relation is valid
     bool mValid = false;
 };

--- a/src/core/qgsrelation.cpp
+++ b/src/core/qgsrelation.cpp
@@ -435,3 +435,11 @@ QgsPolymorphicRelation QgsRelation::polymorphicRelation() const
 
   return mContext.project()->relationManager()->polymorphicRelation( d->mPolymorphicRelationId );
 }
+
+QgsRelation::RelationType QgsRelation::type() const
+{
+  if ( d->mPolymorphicRelationId.isNull() )
+    return QgsRelation::Normal;
+  else
+    return QgsRelation::Generated;
+}

--- a/src/core/qgsrelation.h
+++ b/src/core/qgsrelation.h
@@ -54,9 +54,9 @@ class CORE_EXPORT QgsRelation
   public:
 
     /**
-     * enum for the relation strength
-     * Association, Composition
-     */
+    * enum for the relation strength
+    * Association, Composition
+    */
     enum RelationStrength
     {
       Association, //!< Loose relation, related elements are not part of the parent and a parent copy will not copy any children.
@@ -407,6 +407,7 @@ class CORE_EXPORT QgsRelation
     mutable QExplicitlySharedDataPointer<QgsRelationPrivate> d;
 
     QgsRelationContext mContext;
+    QString mPolymorphicRelationId;
 };
 
 // Register QgsRelation for usage with QVariant

--- a/src/core/qgsrelation.h
+++ b/src/core/qgsrelation.h
@@ -407,7 +407,6 @@ class CORE_EXPORT QgsRelation
     mutable QExplicitlySharedDataPointer<QgsRelationPrivate> d;
 
     QgsRelationContext mContext;
-    QString mPolymorphicRelationId;
 };
 
 // Register QgsRelation for usage with QVariant

--- a/src/core/qgsrelation.h
+++ b/src/core/qgsrelation.h
@@ -54,6 +54,16 @@ class CORE_EXPORT QgsRelation
   public:
 
     /**
+     * Enum holding the relations type
+     */
+    enum RelationType
+    {
+      Normal, //! A normal relation
+      Generated, //! A generated relation is a child of a polymorphic relation
+    };
+    Q_ENUM( RelationType )
+
+    /**
     * enum for the relation strength
     * Association, Composition
     */
@@ -401,6 +411,12 @@ class CORE_EXPORT QgsRelation
      * \since QGIS 3.18
      */
     QgsPolymorphicRelation polymorphicRelation() const;
+
+    /**
+     * Returns the type of the relation
+     * \since QGIS 3.18
+     */
+    RelationType type() const;
 
   private:
 

--- a/src/core/qgsrelation.h
+++ b/src/core/qgsrelation.h
@@ -58,8 +58,8 @@ class CORE_EXPORT QgsRelation
      */
     enum RelationType
     {
-      Normal, //! A normal relation
-      Generated, //! A generated relation is a child of a polymorphic relation
+      Normal, //!< A normal relation
+      Generated, //!< A generated relation is a child of a polymorphic relation
     };
     Q_ENUM( RelationType )
 

--- a/src/core/qgsrelationmanager.cpp
+++ b/src/core/qgsrelationmanager.cpp
@@ -235,8 +235,8 @@ void QgsRelationManager::writeProject( QDomDocument &doc )
   for ( const QgsRelation &relation : qgis::as_const( mRelations ) )
   {
     // the generated relations for polymorphic relations should be ignored,
-    // they are generated when a polymorphic relation is added
-    if ( !relation.polymorphicRelationId().isEmpty() )
+    // they are generated every time when a polymorphic relation is added
+    if ( relation.type() == QgsRelation::Generated )
       continue;
 
     relation.writeXml( relationsNode, doc );

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -2640,7 +2640,10 @@ bool QgsVectorLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString 
     const auto constReferencingRelations { QgsProject::instance()->relationManager()->referencingRelations( this ) };
     for ( const auto &rel : constReferencingRelations )
     {
-      QgsWeakRelation::writeXml( this, QgsWeakRelation::Referencing, rel, referencedLayersElement, doc );
+      if ( rel.polymorphicRelationId().isNull() )
+      {
+        QgsWeakRelation::writeXml( this, QgsWeakRelation::Referencing, rel, referencedLayersElement, doc );
+      }
     }
 
     // Store referencing layers: relations where "this" is the parent layer (the referenced part, that holds the FK)
@@ -2650,7 +2653,10 @@ bool QgsVectorLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString 
     const auto constReferencedRelations { QgsProject::instance()->relationManager()->referencedRelations( this ) };
     for ( const auto &rel : constReferencedRelations )
     {
-      QgsWeakRelation::writeXml( this, QgsWeakRelation::Referenced, rel, referencingLayersElement, doc );
+      if ( rel.polymorphicRelationId().isNull() )
+      {
+        QgsWeakRelation::writeXml( this, QgsWeakRelation::Referenced, rel, referencingLayersElement, doc );
+      }
     }
 
   }

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -2640,7 +2640,7 @@ bool QgsVectorLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString 
     const auto constReferencingRelations { QgsProject::instance()->relationManager()->referencingRelations( this ) };
     for ( const auto &rel : constReferencingRelations )
     {
-      if ( rel.polymorphicRelationId().isNull() )
+      if ( rel.type() == QgsRelation::Normal )
       {
         QgsWeakRelation::writeXml( this, QgsWeakRelation::Referencing, rel, referencedLayersElement, doc );
       }
@@ -2653,7 +2653,7 @@ bool QgsVectorLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString 
     const auto constReferencedRelations { QgsProject::instance()->relationManager()->referencedRelations( this ) };
     for ( const auto &rel : constReferencedRelations )
     {
-      if ( rel.polymorphicRelationId().isNull() )
+      if ( rel.type() == QgsRelation::Normal )
       {
         QgsWeakRelation::writeXml( this, QgsWeakRelation::Referenced, rel, referencingLayersElement, doc );
       }

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -38,13 +38,17 @@ QgsRelationReferenceConfigDlg::QgsRelationReferenceConfigDlg( QgsVectorLayer *vl
   const auto constReferencingRelations = vl->referencingRelations( fieldIdx );
   for ( const QgsRelation &relation : constReferencingRelations )
   {
-    if ( relation.type() == QgsRelation::Generated )
-      continue;
-
     if ( relation.name().isEmpty() )
       mComboRelation->addItem( QStringLiteral( "%1 (%2)" ).arg( relation.id(), relation.referencedLayerId() ), relation.id() );
     else
       mComboRelation->addItem( QStringLiteral( "%1 (%2)" ).arg( relation.name(), relation.referencedLayerId() ), relation.id() );
+
+    QStandardItemModel *model = qobject_cast<QStandardItemModel *>( mComboRelation->model() );
+    QStandardItem *item = model->item( model->rowCount() - 1 );
+    item->setFlags( relation.type() == QgsRelation::Generated
+                    ? item->flags() & ~Qt::ItemIsEnabled
+                    : item->flags() | Qt::ItemIsEnabled );
+
     if ( auto *lReferencedLayer = relation.referencedLayer() )
     {
       mExpressionWidget->setField( lReferencedLayer->displayExpression() );

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -38,6 +38,9 @@ QgsRelationReferenceConfigDlg::QgsRelationReferenceConfigDlg( QgsVectorLayer *vl
   const auto constReferencingRelations = vl->referencingRelations( fieldIdx );
   for ( const QgsRelation &relation : constReferencingRelations )
   {
+    if ( !relation.polymorphicRelationId().isNull() )
+      continue;
+
     if ( relation.name().isEmpty() )
       mComboRelation->addItem( QStringLiteral( "%1 (%2)" ).arg( relation.id(), relation.referencedLayerId() ), relation.id() );
     else

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -38,7 +38,7 @@ QgsRelationReferenceConfigDlg::QgsRelationReferenceConfigDlg( QgsVectorLayer *vl
   const auto constReferencingRelations = vl->referencingRelations( fieldIdx );
   for ( const QgsRelation &relation : constReferencingRelations )
   {
-    if ( !relation.polymorphicRelationId().isNull() )
+    if ( relation.type() == QgsRelation::Generated )
       continue;
 
     if ( relation.name().isEmpty() )

--- a/src/gui/editorwidgets/qgsrelationreferencefactory.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencefactory.cpp
@@ -56,13 +56,13 @@ QHash<const char *, int> QgsRelationReferenceFactory::supportedWidgetTypes()
 
 unsigned int QgsRelationReferenceFactory::fieldScore( const QgsVectorLayer *vl, int fieldIdx ) const
 {
-  int nonGeneratedRelationsCount = 0;
+  int normalRelationsCount = 0;
   const QList<QgsRelation> relations = vl->referencingRelations( fieldIdx );
   for ( const QgsRelation &rel : relations )
   {
-    if ( rel.polymorphicRelationId().isNull() )
-      nonGeneratedRelationsCount++;
+    if ( rel.type() == QgsRelation::Normal )
+      normalRelationsCount++;
   }
   // generated relations should not be used for relation reference widget
-  return nonGeneratedRelationsCount > 0 ? 21 /*A bit stronger than the range widget*/ : 5;
+  return normalRelationsCount > 0 ? 21 /*A bit stronger than the range widget*/ : 5;
 }

--- a/src/gui/editorwidgets/qgsrelationreferencefactory.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencefactory.cpp
@@ -56,6 +56,13 @@ QHash<const char *, int> QgsRelationReferenceFactory::supportedWidgetTypes()
 
 unsigned int QgsRelationReferenceFactory::fieldScore( const QgsVectorLayer *vl, int fieldIdx ) const
 {
+  int nonGeneratedRelationsCount = 0;
   const QList<QgsRelation> relations = vl->referencingRelations( fieldIdx );
-  return !relations.isEmpty() ? 21 /*A bit stronger than the range widget*/ : 5;
+  for ( const QgsRelation &rel : relations )
+  {
+    if ( rel.polymorphicRelationId().isNull() )
+      nonGeneratedRelationsCount++;
+  }
+  // generated relations should not be used for relation reference widget
+  return nonGeneratedRelationsCount > 0 ? 21 /*A bit stronger than the range widget*/ : 5;
 }

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -260,7 +260,8 @@ void QgsAbstractRelationEditorWidget::addFeature( const QgsGeometry &geometry )
       keyAttrs.insert( fields.indexFromName( fieldPair.referencingField() ), mFeature.attribute( fieldPair.referencedField() ) );
     }
 
-    Q_ASSERT( vlTools->addFeature( mRelation.referencingLayer(), keyAttrs, geometry ) );
+    bool result = vlTools->addFeature( mRelation.referencingLayer(), keyAttrs, geometry );
+    Q_ASSERT( result );
   }
 }
 

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -27,7 +27,6 @@
 #include "qgsproject.h"
 #include "qgstransactiongroup.h"
 #include "qgsvectorlayerutils.h"
-#include "qgsmessagelog.h"
 
 #include <QMessageBox>
 #include <QPushButton>
@@ -259,17 +258,8 @@ void QgsAbstractRelationEditorWidget::addFeature( const QgsGeometry &geometry )
     for ( const QgsRelation::FieldPair &fieldPair : constFieldPairs )
     {
       keyAttrs.insert( fields.indexFromName( fieldPair.referencingField() ), mFeature.attribute( fieldPair.referencedField() ) );
+      Q_ASSERT( vlTools->addFeature( mRelation.referencingLayer(), keyAttrs, geometry ) );
     }
-
-    QgsMessageLog::logMessage( QStringLiteral( "ADDED FEATURES1 %1 %2" ).arg( mRelation.referencingLayer()->name() ).arg( mRelation.referencingLayer()->featureCount() ) );
-
-    bool success = vlTools->addFeature( mRelation.referencingLayer(), keyAttrs, geometry );
-    Q_ASSERT( success );
-    QgsMessageLog::logMessage( QStringLiteral( "SUCESS??? %1" ).arg( success ) );
-
-    QgsMessageLog::logMessage( QStringLiteral( "ADDED FEATURES2 %1 %2" ).arg( mRelation.referencingLayer()->name() ).arg( mRelation.referencingLayer()->featureCount() ) );
-    mRelation.referencingLayer()->dataProvider()->reloadData();
-    QgsMessageLog::logMessage( QStringLiteral( "ADDED FEATURES3 %1 %2" ).arg( mRelation.referencingLayer()->name() ).arg( mRelation.referencingLayer()->featureCount() ) );
   }
 }
 

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -261,7 +261,7 @@ void QgsAbstractRelationEditorWidget::addFeature( const QgsGeometry &geometry )
   else
   {
     QgsFields fields = mRelation.referencingLayer()->fields();
-    if ( mRelation.type() == QgsRelation::Normal )
+    if ( mRelation.type() == QgsRelation::Generated )
     {
       QgsPolymorphicRelation polyRel = mRelation.polymorphicRelation();
       keyAttrs.insert( fields.indexFromName( polyRel.referencedLayerField() ), polyRel.layerRepresentation( mRelation.referencedLayer() ) );
@@ -271,7 +271,7 @@ void QgsAbstractRelationEditorWidget::addFeature( const QgsGeometry &geometry )
     for ( const QgsRelation::FieldPair &fieldPair : constFieldPairs )
     {
       keyAttrs.insert( fields.indexFromName( fieldPair.referencingField() ), mFeature.attribute( fieldPair.referencedField() ) );
-      vlTools->addFeature( mRelation.referencingLayer(), keyAttrs, geometry );
+      Q_ASSERT( vlTools->addFeature( mRelation.referencingLayer(), keyAttrs, geometry ) );
     }
   }
 }

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -27,6 +27,7 @@
 #include "qgsproject.h"
 #include "qgstransactiongroup.h"
 #include "qgsvectorlayerutils.h"
+#include "qgsmessagelog.h"
 
 #include <QMessageBox>
 #include <QPushButton>
@@ -258,8 +259,15 @@ void QgsAbstractRelationEditorWidget::addFeature( const QgsGeometry &geometry )
     for ( const QgsRelation::FieldPair &fieldPair : constFieldPairs )
     {
       keyAttrs.insert( fields.indexFromName( fieldPair.referencingField() ), mFeature.attribute( fieldPair.referencedField() ) );
-      Q_ASSERT( vlTools->addFeature( mRelation.referencingLayer(), keyAttrs, geometry ) );
     }
+
+    QgsMessageLog::logMessage( QStringLiteral( "ADDED FEATURES1 %1 %2" ).arg( mRelation.referencingLayer()->name() ).arg( mRelation.referencingLayer()->featureCount() ) );
+
+    Q_ASSERT( vlTools->addFeature( mRelation.referencingLayer(), keyAttrs, geometry ) );
+
+    QgsMessageLog::logMessage( QStringLiteral( "ADDED FEATURES2 %1 %2" ).arg( mRelation.referencingLayer()->name() ).arg( mRelation.referencingLayer()->featureCount() ) );
+    mRelation.referencingLayer()->dataProvider()->reloadData();
+    QgsMessageLog::logMessage( QStringLiteral( "ADDED FEATURES3 %1 %2" ).arg( mRelation.referencingLayer()->name() ).arg( mRelation.referencingLayer()->featureCount() ) );
   }
 }
 

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -223,8 +223,8 @@ void QgsAbstractRelationEditorWidget::addFeature( const QgsGeometry &geometry )
 
   if ( mNmRelation.isValid() )
   {
-    // there is no such case where we have polymorphic relations and m:n relation
-    Q_ASSERT( mNmRelation.polymorphicRelationId().isNull() );
+    // only normal relations support m:n relation
+    Q_ASSERT( mNmRelation.type() == QgsRelation::Normal );
 
     // n:m Relation: first let the user create a new feature on the other table
     // and autocreate a new linking feature.
@@ -261,7 +261,7 @@ void QgsAbstractRelationEditorWidget::addFeature( const QgsGeometry &geometry )
   else
   {
     QgsFields fields = mRelation.referencingLayer()->fields();
-    if ( ! mRelation.polymorphicRelationId().isNull() )
+    if ( mRelation.type() == QgsRelation::Normal )
     {
       QgsPolymorphicRelation polyRel = mRelation.polymorphicRelation();
       keyAttrs.insert( fields.indexFromName( polyRel.referencedLayerField() ), polyRel.layerRepresentation( mRelation.referencedLayer() ) );
@@ -288,8 +288,8 @@ void QgsAbstractRelationEditorWidget::deleteFeatures( const QgsFeatureIds &fids 
   QgsVectorLayer *layer;
   if ( mNmRelation.isValid() )
   {
-    // there is no such case where we have polymorphic relations and m:n relation
-    Q_ASSERT( mNmRelation.polymorphicRelationId().isNull() );
+    // only normal relations support m:n relation
+    Q_ASSERT( mNmRelation.type() == QgsRelation::Normal );
 
     layer = mNmRelation.referencedLayer();
 
@@ -404,8 +404,8 @@ void QgsAbstractRelationEditorWidget::linkFeature()
 
   if ( mNmRelation.isValid() )
   {
-    // there is no such case where we have polymorphic relations and m:n relation
-    Q_ASSERT( mNmRelation.polymorphicRelationId().isNull() );
+    // only normal relations support m:n relation
+    Q_ASSERT( mNmRelation.type() == QgsRelation::Normal );
 
     layer = mNmRelation.referencedLayer();
   }
@@ -427,8 +427,8 @@ void QgsAbstractRelationEditorWidget::onLinkFeatureDlgAccepted()
   QgsFeatureSelectionDlg *selectionDlg = qobject_cast<QgsFeatureSelectionDlg *>( sender() );
   if ( mNmRelation.isValid() )
   {
-    // there is no such case where we have polymorphic relations and m:n relation
-    Q_ASSERT( mNmRelation.polymorphicRelationId().isNull() );
+    // only normal relations support m:n relation
+    Q_ASSERT( mNmRelation.type() == QgsRelation::Normal );
 
     QgsFeatureIterator it = mNmRelation.referencedLayer()->getFeatures(
                               QgsFeatureRequest()
@@ -488,7 +488,7 @@ void QgsAbstractRelationEditorWidget::onLinkFeatureDlgAccepted()
     for ( QgsFeatureId fid : constSelectedFeatures )
     {
       QgsVectorLayer *referencingLayer = mRelation.referencingLayer();
-      if ( ! mRelation.polymorphicRelationId().isNull() )
+      if ( mRelation.type() == QgsRelation::Normal )
       {
         QgsPolymorphicRelation polyRel = mRelation.polymorphicRelation();
 
@@ -520,8 +520,8 @@ void QgsAbstractRelationEditorWidget::unlinkFeatures( const QgsFeatureIds &fids 
 {
   if ( mNmRelation.isValid() )
   {
-    // there is no such case where we have polymorphic relations and m:n relation
-    Q_ASSERT( mNmRelation.polymorphicRelationId().isNull() );
+    // only normal relations support m:n relation
+    Q_ASSERT( mNmRelation.type() == QgsRelation::Normal );
 
     QgsFeatureIterator selectedIterator = mNmRelation.referencedLayer()->getFeatures(
                                             QgsFeatureRequest()
@@ -577,7 +577,7 @@ void QgsAbstractRelationEditorWidget::unlinkFeatures( const QgsFeatureIds &fids 
     for ( QgsFeatureId fid : constFeatureids )
     {
       QgsVectorLayer *referencingLayer = mRelation.referencingLayer();
-      if ( ! mRelation.polymorphicRelationId().isNull() )
+      if ( mRelation.type() == QgsRelation::Normal )
       {
         QgsPolymorphicRelation polyRel = mRelation.polymorphicRelation();
 

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -263,7 +263,9 @@ void QgsAbstractRelationEditorWidget::addFeature( const QgsGeometry &geometry )
 
     QgsMessageLog::logMessage( QStringLiteral( "ADDED FEATURES1 %1 %2" ).arg( mRelation.referencingLayer()->name() ).arg( mRelation.referencingLayer()->featureCount() ) );
 
-    Q_ASSERT( vlTools->addFeature( mRelation.referencingLayer(), keyAttrs, geometry ) );
+    bool success = vlTools->addFeature( mRelation.referencingLayer(), keyAttrs, geometry );
+    Q_ASSERT( success );
+    QgsMessageLog::logMessage( QStringLiteral( "SUCESS??? %1" ).arg( success ) );
 
     QgsMessageLog::logMessage( QStringLiteral( "ADDED FEATURES2 %1 %2" ).arg( mRelation.referencingLayer()->name() ).arg( mRelation.referencingLayer()->featureCount() ) );
     mRelation.referencingLayer()->dataProvider()->reloadData();

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -258,8 +258,9 @@ void QgsAbstractRelationEditorWidget::addFeature( const QgsGeometry &geometry )
     for ( const QgsRelation::FieldPair &fieldPair : constFieldPairs )
     {
       keyAttrs.insert( fields.indexFromName( fieldPair.referencingField() ), mFeature.attribute( fieldPair.referencedField() ) );
-      Q_ASSERT( vlTools->addFeature( mRelation.referencingLayer(), keyAttrs, geometry ) );
     }
+
+    Q_ASSERT( vlTools->addFeature( mRelation.referencingLayer(), keyAttrs, geometry ) );
   }
 }
 

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -17,30 +17,17 @@
 
 #include "qgsabstractrelationeditorwidget.h"
 
-#include "qgsapplication.h"
-#include "qgsdistancearea.h"
 #include "qgsfeatureiterator.h"
-#include "qgsvectordataprovider.h"
 #include "qgsexpression.h"
 #include "qgsfeature.h"
 #include "qgsfeatureselectiondlg.h"
-#include "qgsgenericfeatureselectionmanager.h"
 #include "qgsrelation.h"
 #include "qgspolymorphicrelation.h"
 #include "qgsvectorlayertools.h"
 #include "qgsproject.h"
 #include "qgstransactiongroup.h"
-#include "qgslogger.h"
 #include "qgsvectorlayerutils.h"
-#include "qgsmapcanvas.h"
-#include "qgsvectorlayerselectionmanager.h"
-#include "qgsmaptooldigitizefeature.h"
-#include "qgsexpressioncontextutils.h"
-#include "qgsmessagebar.h"
-#include "qgsmessagebaritem.h"
 
-#include <QHBoxLayout>
-#include <QLabel>
 #include <QMessageBox>
 #include <QPushButton>
 

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -19,15 +19,9 @@
 #define QGSABSTRACTRELATIONEDITORWIDGET_H
 
 #include <QWidget>
-#include <QToolButton>
-#include <QButtonGroup>
-#include <QGridLayout>
 #include "qobjectuniqueptr.h"
 
-#include "qobjectuniqueptr.h"
 #include "qgsattributeeditorcontext.h"
-#include "qgscollapsiblegroupbox.h"
-#include "qgsdualview.h"
 #include "qgsrelation.h"
 #include "qgis_sip.h"
 #include "qgis_gui.h"
@@ -41,11 +35,6 @@
 
 class QgsFeature;
 class QgsVectorLayer;
-class QgsVectorLayerTools;
-class QgsMapTool;
-class QgsMapToolDigitizeFeature;
-class QgsBaseRelationWidget;
-class QgsPropertyOverrideButton;
 
 /**
  * Base class to build new relation widgets.

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -51,6 +51,7 @@ class QMenu;
 #include <qgsmaptoolpan.h>
 #include <qgsmaptoolemitpoint.h>
 #include <qgsmaptoolidentify.h>
+#include <qgsmaptooldigitizefeature.h>
 % End
 #endif
 
@@ -74,6 +75,8 @@ class GUI_EXPORT QgsMapTool : public QObject
       sipType = sipType_QgsMapToolEmitPoint;
     else if ( dynamic_cast<QgsMapToolIdentify *>( sipCpp ) != NULL )
       sipType = sipType_QgsMapToolIdentify;
+    else if ( dynamic_cast<QgsMapToolDigitizeFeature *>( sipCpp ) != NULL )
+      sipType = sipType_QgsMapToolDigitizeFeature;
     else
       sipType = NULL;
     SIP_END

--- a/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
@@ -30,6 +30,9 @@
    </item>
    <item row="1" column="1">
     <widget class="QComboBox" name="mComboRelation">
+     <property name="toolTip">
+      <string>The generated relations for a polymorphic relation cannot be used.</string>
+     </property>
      <property name="sizeAdjustPolicy">
       <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
      </property>

--- a/src/ui/qgsrelationmanageradddialogbase.ui
+++ b/src/ui/qgsrelationmanageradddialogbase.ui
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsRelationManagerAddDialogBase</class>
+ <widget class="QWidget" name="QgsRelationManagerAddDialogBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>450</width>
+    <height>400</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout" columnstretch="1,2,0">
+   <item row="3" column="0">
+    <widget class="QLabel" name="mRelationStrengthLabel">
+     <property name="text">
+      <string>Relationship strength</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
+    <widget class="QTableWidget" name="mFieldsMappingTable">
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="rowCount">
+      <number>1</number>
+     </property>
+     <attribute name="horizontalHeaderDefaultSectionSize">
+      <number>180</number>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <row>
+      <property name="text">
+       <string>Layer</string>
+      </property>
+     </row>
+     <column>
+      <property name="text">
+       <string comment="static relations">Referenced (parent)</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Referencing (child)</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="mIdLabel">
+     <property name="text">
+      <string>Id</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="mNameLabel">
+     <property name="text">
+      <string>Name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="2">
+    <widget class="QComboBox" name="mRelationStrengthComboBox"/>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QLineEdit" name="mIdLineEdit">
+     <property name="placeholderText">
+      <string>[Generated automatically]</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="3">
+    <widget class="QDialogButtonBox" name="mButtonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="2">
+    <widget class="QLineEdit" name="mNameLineEdit"/>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QLabel" name="mFieldsMappingLabel">
+     <property name="text">
+      <string>Layer and fields mapping</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <layout class="QVBoxLayout" name="mFieldsMappingButtonsVBoxLayout">
+     <item>
+      <widget class="QToolButton" name="mFieldsMappingAddButton">
+       <property name="toolTip">
+        <string>Add new field pair as part of a composite foreign key</string>
+       </property>
+       <property name="icon">
+        <iconset theme="add">
+         <normaloff>../../../../../../.designer/backup</normaloff>../../../../../../.designer/backup</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mFieldsMappingRemoveButton">
+       <property name="toolTip">
+        <string>Remove the select or last pair of fields</string>
+       </property>
+       <property name="icon">
+        <iconset theme="remove">
+         <normaloff>../../../../../../.designer/backup</normaloff>../../../../../../.designer/backup</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="mFieldsMappingVSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/qgsrelationmanageradddialogbase.ui
+++ b/src/ui/qgsrelationmanageradddialogbase.ui
@@ -30,7 +30,7 @@
       <number>1</number>
      </property>
      <attribute name="horizontalHeaderDefaultSectionSize">
-      <number>180</number>
+      <number>150</number>
      </attribute>
      <attribute name="horizontalHeaderStretchLastSection">
       <bool>true</bool>

--- a/src/ui/qgsrelationmanageradddialogbase.ui
+++ b/src/ui/qgsrelationmanageradddialogbase.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Add Relation</string>
   </property>
   <layout class="QGridLayout" name="gridLayout" columnstretch="1,2,0">
    <item row="3" column="0">

--- a/src/ui/qgsrelationmanageraddpolymorphicdialogbase.ui
+++ b/src/ui/qgsrelationmanageraddpolymorphicdialogbase.ui
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsRelationManagerAddPolymorphicDialogBase</class>
+ <widget class="QWidget" name="QgsRelationManagerAddPolymorphicDialogBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>450</width>
+    <height>400</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout" columnstretch="1,2,0">
+   <item row="2" column="0">
+    <widget class="QLabel" name="mReferencedLayerFieldLayer">
+     <property name="text">
+      <string>Layer field</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="mIdLabel">
+     <property name="text">
+      <string>Id</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1" colspan="2">
+    <widget class="QgsCheckableComboBox" name="mReferencedLayersComboBox"/>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QLabel" name="mFieldsMappingLabel">
+     <property name="text">
+      <string>Fields mapping</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="2">
+    <layout class="QVBoxLayout" name="mFieldsMappingButtonsVBoxLayout">
+     <item>
+      <widget class="QToolButton" name="mFieldsMappingAddButton">
+       <property name="toolTip">
+        <string>Add new field pair as part of a composite foreign key</string>
+       </property>
+       <property name="icon">
+        <iconset theme="add">
+         <normaloff>../../../../../../.designer/backup</normaloff>../../../../../../.designer/backup</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mFieldsMappingRemoveButton">
+       <property name="toolTip">
+        <string>Remove the select or last pair of fields</string>
+       </property>
+       <property name="icon">
+        <iconset theme="remove">
+         <normaloff>../../../../../../.designer/backup</normaloff>../../../../../../.designer/backup</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="mFieldsMappingVSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="mReferencingLayerLabel">
+     <property name="text">
+      <string>Referencing layer</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QTableWidget" name="mFieldsMappingTable">
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="rowCount">
+      <number>0</number>
+     </property>
+     <attribute name="horizontalHeaderDefaultSectionSize">
+      <number>180</number>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string comment="polymorphic relations">Referenced (parent)</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Referencing (child)</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="2">
+    <widget class="QgsMapLayerComboBox" name="mReferencingLayerComboBox"/>
+   </item>
+   <item row="3" column="1" colspan="2">
+    <widget class="QgsFieldExpressionWidget" name="mReferencedLayerExpressionWidget"/>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="mReferencedLayersLabel">
+     <property name="text">
+      <string>Referenced layers</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="mReferencedLayerExpressionLabel">
+     <property name="text">
+      <string>Layer field expression</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="2">
+    <widget class="QgsFieldComboBox" name="mReferencedLayerFieldComboBox"/>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QLineEdit" name="mIdLineEdit">
+     <property name="placeholderText">
+      <string>[Generated automatically]</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0" colspan="3">
+    <widget class="QLabel" name="mPolymorphicRelationHelpLabel">
+     <property name="text">
+      <string>Polymorphic relations are for advanced usage where a set of standard relations have the same referencing layer but the referenced layer is calculated from an expression.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0" colspan="3">
+    <widget class="QDialogButtonBox" name="mButtonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCheckableComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgscheckablecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFieldComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsfieldcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFieldExpressionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfieldexpressionwidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsmaplayercombobox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/qgsrelationmanageraddpolymorphicdialogbase.ui
+++ b/src/ui/qgsrelationmanageraddpolymorphicdialogbase.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Add Polymorphic Relation</string>
   </property>
   <layout class="QGridLayout" name="gridLayout" columnstretch="1,2,0">
    <item row="1" column="0">
@@ -155,7 +155,7 @@
     </widget>
    </item>
    <item row="3" column="1" colspan="2">
-    <widget class="QgsFieldExpressionWidget" name="mReferencedLayerExpressionWidget"/>
+    <widget class="QgsFieldExpressionWidget" name="mReferencedLayerExpressionWidget" native="true"/>
    </item>
    <item row="6" column="0">
     <widget class="QLabel" name="mRelationStrengthLabel">

--- a/src/ui/qgsrelationmanageraddpolymorphicdialogbase.ui
+++ b/src/ui/qgsrelationmanageraddpolymorphicdialogbase.ui
@@ -130,7 +130,7 @@
       <number>0</number>
      </property>
      <attribute name="horizontalHeaderDefaultSectionSize">
-      <number>180</number>
+      <number>150</number>
      </attribute>
      <attribute name="horizontalHeaderStretchLastSection">
       <bool>true</bool>
@@ -155,7 +155,7 @@
     </widget>
    </item>
    <item row="3" column="1" colspan="2">
-    <widget class="QgsFieldExpressionWidget" name="mReferencedLayerExpressionWidget" native="true"/>
+    <widget class="QgsFieldExpressionWidget" name="mReferencedLayerExpressionWidget"/>
    </item>
    <item row="6" column="0">
     <widget class="QLabel" name="mRelationStrengthLabel">

--- a/src/ui/qgsrelationmanageraddpolymorphicdialogbase.ui
+++ b/src/ui/qgsrelationmanageraddpolymorphicdialogbase.ui
@@ -14,6 +14,20 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout" columnstretch="1,2,0">
+   <item row="1" column="0">
+    <widget class="QLabel" name="mReferencingLayerLabel">
+     <property name="text">
+      <string>Referencing layer</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0" colspan="3">
+    <widget class="QDialogButtonBox" name="mButtonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0">
     <widget class="QLabel" name="mReferencedLayerFieldLabel">
      <property name="text">
@@ -28,17 +42,27 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="1" colspan="2">
-    <widget class="QgsCheckableComboBox" name="mReferencedLayersComboBox"/>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QLabel" name="mFieldsMappingLabel">
+   <item row="10" column="0">
+    <widget class="QLabel" name="mReferencedLayersLabel">
      <property name="text">
-      <string>Fields mapping</string>
+      <string>Referenced layers</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="2">
+   <item row="1" column="1" colspan="2">
+    <widget class="QgsMapLayerComboBox" name="mReferencingLayerComboBox"/>
+   </item>
+   <item row="11" column="0" colspan="3">
+    <widget class="QLabel" name="mPolymorphicRelationHelpLabel">
+     <property name="text">
+      <string>Polymorphic relations are for advanced usage where a set of standard relations have the same referencing layer but the referenced layer is calculated from an expression.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="2">
     <layout class="QVBoxLayout" name="mFieldsMappingButtonsVBoxLayout">
      <item>
       <widget class="QToolButton" name="mFieldsMappingAddButton">
@@ -77,14 +101,27 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="mReferencingLayerLabel">
+   <item row="8" column="0" colspan="2">
+    <widget class="QLabel" name="mFieldsMappingLabel">
      <property name="text">
-      <string>Referencing layer</string>
+      <string>Fields mapping</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="0" colspan="2">
+   <item row="2" column="1" colspan="2">
+    <widget class="QgsFieldComboBox" name="mReferencedLayerFieldComboBox"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="mReferencedLayerExpressionLabel">
+     <property name="text">
+      <string>Layer field expression</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1" colspan="2">
+    <widget class="QgsCheckableComboBox" name="mReferencedLayersComboBox"/>
+   </item>
+   <item row="9" column="0" colspan="2">
     <widget class="QTableWidget" name="mFieldsMappingTable">
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
@@ -110,29 +147,6 @@
      </column>
     </widget>
    </item>
-   <item row="1" column="1" colspan="2">
-    <widget class="QgsMapLayerComboBox" name="mReferencingLayerComboBox"/>
-   </item>
-   <item row="3" column="1" colspan="2">
-    <widget class="QgsFieldExpressionWidget" name="mReferencedLayerExpressionWidget" native="true"/>
-   </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="mReferencedLayersLabel">
-     <property name="text">
-      <string>Referenced layers</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="mReferencedLayerExpressionLabel">
-     <property name="text">
-      <string>Layer field expression</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1" colspan="2">
-    <widget class="QgsFieldComboBox" name="mReferencedLayerFieldComboBox"/>
-   </item>
    <item row="0" column="1" colspan="2">
     <widget class="QLineEdit" name="mIdLineEdit">
      <property name="placeholderText">
@@ -140,22 +154,18 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="0" colspan="3">
-    <widget class="QLabel" name="mPolymorphicRelationHelpLabel">
+   <item row="3" column="1" colspan="2">
+    <widget class="QgsFieldExpressionWidget" name="mReferencedLayerExpressionWidget"/>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="mRelationStrengthLabel">
      <property name="text">
-      <string>Polymorphic relations are for advanced usage where a set of standard relations have the same referencing layer but the referenced layer is calculated from an expression.</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
+      <string>Relationship strength</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="0" colspan="3">
-    <widget class="QDialogButtonBox" name="mButtonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
+   <item row="6" column="1" colspan="2">
+    <widget class="QComboBox" name="mRelationStrengthComboBox"/>
    </item>
   </layout>
  </widget>

--- a/src/ui/qgsrelationmanageraddpolymorphicdialogbase.ui
+++ b/src/ui/qgsrelationmanageraddpolymorphicdialogbase.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout" columnstretch="1,2,0">
    <item row="2" column="0">
-    <widget class="QLabel" name="mReferencedLayerFieldLayer">
+    <widget class="QLabel" name="mReferencedLayerFieldLabel">
      <property name="text">
       <string>Layer field</string>
      </property>
@@ -114,7 +114,7 @@
     <widget class="QgsMapLayerComboBox" name="mReferencingLayerComboBox"/>
    </item>
    <item row="3" column="1" colspan="2">
-    <widget class="QgsFieldExpressionWidget" name="mReferencedLayerExpressionWidget"/>
+    <widget class="QgsFieldExpressionWidget" name="mReferencedLayerExpressionWidget" native="true"/>
    </item>
    <item row="8" column="0">
     <widget class="QLabel" name="mReferencedLayersLabel">

--- a/src/ui/qgsrelationmanagerdialogbase.ui
+++ b/src/ui/qgsrelationmanagerdialogbase.ui
@@ -15,19 +15,10 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QTableWidget" name="mRelationsTable">
+    <widget class="QTreeWidget" name="mRelationsTree">
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
      </property>
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-     <attribute name="verticalHeaderShowSortIndicator" stdset="0">
-      <bool>true</bool>
-     </attribute>
      <column>
       <property name="text">
        <string>Name</string>
@@ -35,49 +26,31 @@
      </column>
      <column>
       <property name="text">
-       <string>Referenced Layer</string>
-      </property>
-      <property name="toolTip">
-       <string>Referenced Layer (Parent)</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Referenced Field</string>
-      </property>
-      <property name="toolTip">
-       <string>Referenced Field</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
        <string>Referencing Layer</string>
       </property>
-      <property name="toolTip">
-       <string>Referencing Layer (Child)</string>
+     </column>
+     <column>
+      <property name="text">
+       <string>Referencing Field(s)</string>
       </property>
      </column>
      <column>
       <property name="text">
-       <string>Referencing Field</string>
+       <string>Referenced Layer</string>
       </property>
-      <property name="toolTip">
-       <string>Referencing Field</string>
+     </column>
+     <column>
+      <property name="text">
+       <string>Referenced Field(s)</string>
       </property>
      </column>
      <column>
       <property name="text">
        <string>Id</string>
       </property>
-      <property name="toolTip">
-       <string>Id</string>
-      </property>
      </column>
      <column>
       <property name="text">
-       <string>Strength</string>
-      </property>
-      <property name="toolTip">
        <string>Strength</string>
       </property>
      </column>
@@ -99,13 +72,16 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="mBtnAddRelation">
+      <widget class="QToolButton" name="mBtnAddRelation">
        <property name="text">
         <string>Add Relation</string>
        </property>
        <property name="icon">
         <iconset resource="../../images/images.qrc">
          <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonTextBesideIcon</enum>
        </property>
       </widget>
      </item>
@@ -147,6 +123,14 @@
     </layout>
    </item>
   </layout>
+  <action name="mActionAddPolymorphicRelation">
+   <property name="text">
+    <string>Add Polymorphic Relation</string>
+   </property>
+   <property name="toolTip">
+    <string>Polymorphic relations are for advanced usage where a set of standard relations have the same referencing layer but the referenced layer is calculated from an expression.</string>
+   </property>
+  </action>
  </widget>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsrelationmanagerdialogbase.ui
+++ b/src/ui/qgsrelationmanagerdialogbase.ui
@@ -73,6 +73,15 @@
      </item>
      <item>
       <widget class="QToolButton" name="mBtnAddRelation">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
        <property name="text">
         <string>Add Relation</string>
        </property>
@@ -126,6 +135,17 @@
   <action name="mActionAddPolymorphicRelation">
    <property name="text">
     <string>Add Polymorphic Relation</string>
+   </property>
+   <property name="toolTip">
+    <string>Polymorphic relations are for advanced usage where a set of standard relations have the same referencing layer but the referenced layer is calculated from an expression.</string>
+   </property>
+  </action>
+  <action name="mActionEditPolymorphicRelation">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Edit Polymorphic Relation</string>
    </property>
    <property name="toolTip">
     <string>Polymorphic relations are for advanced usage where a set of standard relations have the same referencing layer but the referenced layer is calculated from an expression.</string>

--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -330,9 +330,6 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         table_view = widget.findChild(QTableView)
         self.assertEqual(table_view.model().rowCount(), 1)
 
-        vl_leaks.raiseError.connect(TestQgsRelationEditWidget.error_raised)
-        vl_leaks.featureAdded.connect(TestQgsRelationEditWidget.feature_added)
-
         btn = widget.findChild(QToolButton, 'mAddFeatureGeometryButton')
         self.assertTrue(btn.isVisible())
         self.assertTrue(btn.isEnabled())
@@ -340,11 +337,7 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         self.assertTrue(self.mapCanvas.mapTool())
         feature = QgsFeature(vl_leaks.fields())
         feature.setGeometry(QgsGeometry.fromWkt('POINT(0 0.8)'))
-        for f in vl_leaks.getFeatures():
-            print('FEATURE_ID ONE: ', f.id(), f.geometry())
         self.mapCanvas.mapTool().digitizingCompleted.emit(feature)
-        for f in vl_leaks.getFeatures():
-            print('FEATURE_ID TWO: ', f.id(), f.geometry())
         self.assertEqual(table_view.model().rowCount(), 2)
         self.assertEqual(vl_leaks.featureCount(), 4)
         request = QgsFeatureRequest()
@@ -356,14 +349,6 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         self.assertTrue(feat.geometry().equals(QgsGeometry.fromWkt('POINT(0 0.8)')))
 
         vl_leaks.rollBack()
-
-    @classmethod
-    def error_raised(cls, msg):
-        print("LAYER ERROR RAISED: ", len(msg), msg)
-
-    @classmethod
-    def feature_added(cls, fid):
-        print("LAYER FEATURE ADDDED: ", fid)
 
     def startTransaction(self):
         """

--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -330,6 +330,9 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         table_view = widget.findChild(QTableView)
         self.assertEqual(table_view.model().rowCount(), 1)
 
+        vl_leaks.raiseError.connect(TestQgsRelationEditWidget.error_raised)
+        vl_leaks.featureAdded.connect(TestQgsRelationEditWidget.feature_added)
+
         btn = widget.findChild(QToolButton, 'mAddFeatureGeometryButton')
         self.assertTrue(btn.isVisible())
         self.assertTrue(btn.isEnabled())
@@ -353,6 +356,14 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         self.assertTrue(feat.geometry().equals(QgsGeometry.fromWkt('POINT(0 0.8)')))
 
         vl_leaks.rollBack()
+
+    @classmethod
+    def error_raised(cls, msg):
+        print("LAYER ERROR RAISED: ", len(msg), msg)
+
+    @classmethod
+    def feature_added(cls, fid):
+        print("LAYER FEATURE ADDDED: ", fid)
 
     def startTransaction(self):
         """

--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -337,7 +337,11 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         self.assertTrue(self.mapCanvas.mapTool())
         feature = QgsFeature(vl_leaks.fields())
         feature.setGeometry(QgsGeometry.fromWkt('POINT(0 0.8)'))
+        for f in vl_leaks.getFeatures():
+            print('FEATURE_ID ONE: ', f.id(), f.geometry())
         self.mapCanvas.mapTool().digitizingCompleted.emit(feature)
+        for f in vl_leaks.getFeatures():
+            print('FEATURE_ID TWO: ', f.id(), f.geometry())
         self.assertEqual(table_view.model().rowCount(), 2)
         self.assertEqual(vl_leaks.featureCount(), 4)
         request = QgsFeatureRequest()


### PR DESCRIPTION
Adds GUI to manage polymorphic relations, last followup of my previous two PRs related to implementing https://github.com/qgis/QGIS-Enhancement-Proposals/issues/79 , see https://github.com/qgis/QGIS/pull/40721 and  https://github.com/qgis/QGIS/pull/40914 .

The "Add relation" button in the relation manager screen now has additional option to add/edit polymorphic relations:
![image](https://user-images.githubusercontent.com/2820439/104571876-551ee480-565c-11eb-8b3a-2cf38f588ff1.png)

The "Add polymorphic relation" and "Edit polymorphic relation" open the same dialog, in the latter case with predefined values:
![image](https://user-images.githubusercontent.com/2820439/104571564-eb063f80-565b-11eb-8189-9beae3de587b.png)

The "Add relation" dialog has been updated, now it uses the same table with buttons on the right layout as most of the QGIS UI. Other than UI, there are no other changes here.
![image](https://user-images.githubusercontent.com/2820439/104571757-26a10980-565c-11eb-9220-312bdb7f1e55.png)

Once saved, the list of relations appear as a tree widget, where the generated normal relations for a polymorphic relation appear as children. The names of the generated relations cannot be changed.
![image](https://user-images.githubusercontent.com/2820439/104571664-07a27780-565c-11eb-8c7a-3ab2ed045218.png)

When saving the `.qml` style of the layer, the generated relations are not stored, since they are generated from their polymorphic relation every time the project is opened. The polymorphic relations are not exported either, at least for now.
