### PR TITLE
[FEATURE]: consider settings from attribute drag and drop form in WMS feature info

### DIFF
--- a/doc/CONTRIBUTORS
+++ b/doc/CONTRIBUTORS
@@ -12,6 +12,7 @@ Anita Graser
 Arthur Nanni
 Arunmozhi
 Baba Yoshihiko
+Belgacem Nedjima
 Bernhard Ströbl
 Brent Wood
 Brook Milligan

--- a/external/libdxfrw/CMakeLists.txt
+++ b/external/libdxfrw/CMakeLists.txt
@@ -24,6 +24,11 @@ add_library(libdxfrw STATIC
     intern/dxfwriter.cpp
     intern/rscodec.cpp
 )
+
+target_include_directories(libdxfrw PUBLIC
+  ${CMAKE_SOURCE_DIR}/external/libdxfrw
+)
+
 set_property(TARGET libdxfrw PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_link_libraries(libdxfrw

--- a/external/mdal/mdal.cpp
+++ b/external/mdal/mdal.cpp
@@ -21,7 +21,7 @@ static const char *EMPTY_STR = "";
 
 const char *MDAL_Version()
 {
-  return "0.7.91";
+  return "0.8.0";
 }
 
 MDAL_Status MDAL_LastStatus()

--- a/python/server/auto_generated/qgsserverprojectutils.sip.in
+++ b/python/server/auto_generated/qgsserverprojectutils.sip.in
@@ -214,6 +214,15 @@ Returns if the geometry is displayed as Well Known Text in GetFeatureInfo reques
 :return: if the geometry is displayed as Well Known Text in GetFeatureInfo request.
 %End
 
+  bool wmsFeatureInfoUseAttributeFormSettings( const QgsProject &project );
+%Docstring
+Returns if feature form settings should be considered for the format of the feature info response
+
+:param project: the QGIS project
+
+:return: true if the feature form settings shall be considered for the feature info response
+%End
+
   bool wmsFeatureInfoSegmentizeWktGeometry( const QgsProject &project );
 %Docstring
 Returns if the geometry has to be segmentize in GetFeatureInfo request.

--- a/resources/data/contributors.json
+++ b/resources/data/contributors.json
@@ -1009,6 +1009,23 @@
           16.26555
         ]
       }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Belgacem Nedjima",
+        "Committer": "No",
+        "First Commit Message": "[Bug fix] load 3D view symbol configuration widget (Single symbol/Rule-based/No symbol) automatically in the layer properties window",
+        "First Commit Date": "15-05-2020",
+        "GIT Nickname": "NEDJIMAbelgacem"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          3.154434,
+          36.717145
+        ]
+      }
     }
   ]
 }

--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -191,7 +191,7 @@ set (QGIS_3D_RCCS  shaders.qrc  ../../resources/3d/textures/textures.qrc)
 
 add_library(qgis_3d SHARED ${QGIS_3D_SRCS} ${QGIS_3D_HDRS} ${QGIS_3D_RCCS} ${QGIS_3D_PRIVATE_HDRS})
 
-target_include_directories(qgis_3d SYSTEM PRIVATE
+target_include_directories(qgis_3d SYSTEM PUBLIC
   ${QT5_3DEXTRA_INCLUDE_DIR}
 )
 

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -105,8 +105,8 @@ void Qgs3DMapSettings::readXml( const QDomElement &elem, const QgsReadWriteConte
     QString cameraNavigationMode = elemCamera.attribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "basic-navigation" ) );
     if ( cameraNavigationMode == QStringLiteral( "terrain-based-navigation" ) )
       mCameraNavigationMode = QgsCameraController::NavigationMode::TerrainBasedNavigation;
-    else if ( cameraNavigationMode == QStringLiteral( "fly-navigation" ) )
-      mCameraNavigationMode = QgsCameraController::NavigationMode::FlyNavigation;
+    else if ( cameraNavigationMode == QStringLiteral( "walk-navigation" ) )
+      mCameraNavigationMode = QgsCameraController::NavigationMode::WalkNavigation;
     mCameraMovementSpeed = elemCamera.attribute( QStringLiteral( "camera-movement-speed" ), QStringLiteral( "5.0" ) ).toDouble();
   }
 
@@ -306,8 +306,8 @@ QDomElement Qgs3DMapSettings::writeXml( QDomDocument &doc, const QgsReadWriteCon
     case QgsCameraController::TerrainBasedNavigation:
       elemCamera.setAttribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "terrain-based-navigation" ) );
       break;
-    case QgsCameraController::FlyNavigation:
-      elemCamera.setAttribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "fly-navigation" ) );
+    case QgsCameraController::WalkNavigation:
+      elemCamera.setAttribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "walk-navigation" ) );
       break;
   }
   elemCamera.setAttribute( QStringLiteral( "camera-movement-speed" ), mCameraMovementSpeed );

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -325,7 +325,7 @@ void QgsCameraController::moveCameraPositionBy( const QVector3D &posDiff )
 
 void QgsCameraController::onPositionChanged( Qt3DInput::QMouseEvent *mouse )
 {
-  if ( mCameraNavigationMode == NavigationMode::FlyNavigation )
+  if ( mCameraNavigationMode == NavigationMode::WalkNavigation )
   {
     onPositionChangedFlyNavigation( mouse );
     return;
@@ -394,7 +394,7 @@ void QgsCameraController::zoom( float factor )
 
 void QgsCameraController::onWheel( Qt3DInput::QWheelEvent *wheel )
 {
-  if ( mCameraNavigationMode == QgsCameraController::FlyNavigation )
+  if ( mCameraNavigationMode == QgsCameraController::WalkNavigation )
   {
     float scaling = ( ( wheel->modifiers() & Qt::ControlModifier ) ? 0.1f : 1.0f ) / 1000.f;
     mCameraMovementSpeed += mCameraMovementSpeed * scaling * wheel->angleDelta().y();
@@ -437,11 +437,11 @@ void QgsCameraController::onKeyPressed( Qt3DInput::QKeyEvent *event )
   {
     switch ( mCameraNavigationMode )
     {
-      case NavigationMode::FlyNavigation:
+      case NavigationMode::WalkNavigation:
         mCameraNavigationMode = NavigationMode::TerrainBasedNavigation;
         break;
       case NavigationMode::TerrainBasedNavigation:
-        mCameraNavigationMode = NavigationMode::FlyNavigation;
+        mCameraNavigationMode = NavigationMode::WalkNavigation;
         break;
     }
     emit navigationModeHotKeyPressed( mCameraNavigationMode );
@@ -450,7 +450,7 @@ void QgsCameraController::onKeyPressed( Qt3DInput::QKeyEvent *event )
 
   if ( event->key() == Qt::Key_QuoteLeft )
   {
-    if ( mCameraNavigationMode == NavigationMode::FlyNavigation )
+    if ( mCameraNavigationMode == NavigationMode::WalkNavigation )
     {
       mCaptureFpsMouseMovements = !mCaptureFpsMouseMovements;
       if ( mCaptureFpsMouseMovements )
@@ -467,7 +467,7 @@ void QgsCameraController::onKeyPressed( Qt3DInput::QKeyEvent *event )
     }
   }
 
-  if ( mCameraNavigationMode == NavigationMode::FlyNavigation )
+  if ( mCameraNavigationMode == NavigationMode::WalkNavigation )
   {
     if ( event->isAutoRepeat() )
       return;

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -76,6 +76,11 @@ void QgsCameraController::setCameraMovementSpeed( double movementSpeed )
   mCameraMovementSpeed = movementSpeed;
 }
 
+void QgsCameraController::setVerticalAxisInversion( QgsCameraController::VerticalAxisInversion inversion )
+{
+  mVerticalAxisInversion = inversion;
+}
+
 void QgsCameraController::setTerrainEntity( QgsTerrainEntity *te )
 {
   mTerrainEntity = te;
@@ -626,7 +631,18 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
 
     if ( mPressedButton != Qt3DInput::QMouseEvent::RightButton )
     {
-      float diffPitch = -1 * 0.2f * dy;
+      float diffPitch = -0.2f * dy;
+      switch ( mVerticalAxisInversion )
+      {
+        case Always:
+          diffPitch *= -1;
+          break;
+
+        case WhenDragging:
+        case Never:
+          break;
+      }
+
       float diffYaw = - 0.2f * dx;
       rotateCamera( diffPitch, diffYaw );
       updateCameraFromPose( false );
@@ -651,7 +667,17 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
 
     if ( mPressedButton ==  Qt3DInput::QMouseEvent::LeftButton || mPressedButton ==  Qt3DInput::QMouseEvent::MiddleButton )
     {
-      float diffPitch = 0.2f * dy;
+      float diffPitch = -0.2f * dy;
+      switch ( mVerticalAxisInversion )
+      {
+        case Always:
+        case WhenDragging:
+          diffPitch *= -1;
+          break;
+
+        case Never:
+          break;
+      }
       float diffYaw = - 0.2f * dx;
       rotateCamera( diffPitch, diffYaw );
       updateCameraFromPose( false );

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -571,29 +571,35 @@ void QgsCameraController::onKeyPressedFlyNavigation()
 
   QVector3D cameraPosDiff( 0.0f, 0.0f, 0.0f );
 
+  // shift = "run", ctrl = "slow walk"
+  const bool shiftPressed = mDepressedKeys.contains( Qt::Key_Shift );
+  const bool ctrlPressed = mDepressedKeys.contains( Qt::Key_Control );
+
+  double movementSpeed = mCameraMovementSpeed * ( shiftPressed ? 2 : 1 ) * ( ctrlPressed ? 0.1 : 1 );
+
   bool changed = false;
   if ( mDepressedKeys.contains( Qt::Key_Left ) || mDepressedKeys.contains( Qt::Key_A ) )
   {
     changed = true;
-    cameraPosDiff += mCameraMovementSpeed * cameraLeft;
+    cameraPosDiff += movementSpeed * cameraLeft;
   }
 
   if ( mDepressedKeys.contains( Qt::Key_Right ) || mDepressedKeys.contains( Qt::Key_D ) )
   {
     changed = true;
-    cameraPosDiff += - mCameraMovementSpeed * cameraLeft;
+    cameraPosDiff += - movementSpeed * cameraLeft;
   }
 
   if ( mDepressedKeys.contains( Qt::Key_Up ) || mDepressedKeys.contains( Qt::Key_W ) )
   {
     changed = true;
-    cameraPosDiff += mCameraMovementSpeed * cameraFront;
+    cameraPosDiff += movementSpeed * cameraFront;
   }
 
   if ( mDepressedKeys.contains( Qt::Key_Down ) || mDepressedKeys.contains( Qt::Key_S ) )
   {
     changed = true;
-    cameraPosDiff += - mCameraMovementSpeed * cameraFront;
+    cameraPosDiff += - movementSpeed * cameraFront;
   }
 
   // note -- vertical axis movements are slower by default then horizontal ones, as GIS projects
@@ -602,13 +608,13 @@ void QgsCameraController::onKeyPressedFlyNavigation()
   if ( mDepressedKeys.contains( Qt::Key_PageUp ) || mDepressedKeys.contains( Qt::Key_E ) )
   {
     changed = true;
-    cameraPosDiff += ELEVATION_MOVEMENT_SCALE * mCameraMovementSpeed * QVector3D( 0.0f, 1.0f, 0.0f );
+    cameraPosDiff += ELEVATION_MOVEMENT_SCALE * movementSpeed * QVector3D( 0.0f, 1.0f, 0.0f );
   }
 
   if ( mDepressedKeys.contains( Qt::Key_PageDown ) || mDepressedKeys.contains( Qt::Key_Q ) )
   {
     changed = true;
-    cameraPosDiff += ELEVATION_MOVEMENT_SCALE * - mCameraMovementSpeed * QVector3D( 0.0f, 1.0f, 0.0f );
+    cameraPosDiff += ELEVATION_MOVEMENT_SCALE * - movementSpeed * QVector3D( 0.0f, 1.0f, 0.0f );
   }
 
   if ( changed )

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -596,16 +596,19 @@ void QgsCameraController::onKeyPressedFlyNavigation()
     cameraPosDiff += - mCameraMovementSpeed * cameraFront;
   }
 
+  // note -- vertical axis movements are slower by default then horizontal ones, as GIS projects
+  // tend to have much more limited elevation range vs ground range
+  static constexpr double ELEVATION_MOVEMENT_SCALE = 0.5;
   if ( mDepressedKeys.contains( Qt::Key_PageUp ) || mDepressedKeys.contains( Qt::Key_E ) )
   {
     changed = true;
-    cameraPosDiff += mCameraMovementSpeed * QVector3D( 0.0f, 1.0f, 0.0f );
+    cameraPosDiff += ELEVATION_MOVEMENT_SCALE * mCameraMovementSpeed * QVector3D( 0.0f, 1.0f, 0.0f );
   }
 
   if ( mDepressedKeys.contains( Qt::Key_PageDown ) || mDepressedKeys.contains( Qt::Key_Q ) )
   {
     changed = true;
-    cameraPosDiff += - mCameraMovementSpeed * QVector3D( 0.0f, 1.0f, 0.0f );
+    cameraPosDiff += ELEVATION_MOVEMENT_SCALE * - mCameraMovementSpeed * QVector3D( 0.0f, 1.0f, 0.0f );
   }
 
   if ( changed )

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -73,7 +73,11 @@ void QgsCameraController::setCameraNavigationMode( QgsCameraController::Navigati
 
 void QgsCameraController::setCameraMovementSpeed( double movementSpeed )
 {
+  if ( movementSpeed == mCameraMovementSpeed )
+    return;
+
   mCameraMovementSpeed = movementSpeed;
+  emit cameraMovementSpeedChanged( mCameraMovementSpeed );
 }
 
 void QgsCameraController::setVerticalAxisInversion( QgsCameraController::VerticalAxisInversion inversion )
@@ -413,7 +417,7 @@ void QgsCameraController::onWheel( Qt3DInput::QWheelEvent *wheel )
     case QgsCameraController::WalkNavigation:
     {
       float scaling = ( ( wheel->modifiers() & Qt::ControlModifier ) ? 0.1f : 1.0f ) / 1000.f;
-      mCameraMovementSpeed += mCameraMovementSpeed * scaling * wheel->angleDelta().y();
+      setCameraMovementSpeed( mCameraMovementSpeed + mCameraMovementSpeed * scaling * wheel->angleDelta().y() );
       break;
     }
 

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -614,14 +614,16 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
 
   if ( mCaptureFpsMouseMovements )
   {
+    const double dx = QCursor::pos().x() - mMousePos.x();
+    const double dy = QCursor::pos().y() - mMousePos.y();
+    mMousePos = QCursor::pos();
+
     if ( mIgnoreNextMouseMove )
     {
       mIgnoreNextMouseMove = false;
       return;
     }
 
-    double dx = QCursor::pos().x() - mMousePos.x();
-    double dy = QCursor::pos().y() - mMousePos.y();
     if ( mPressedButton != Qt3DInput::QMouseEvent::RightButton )
     {
       float diffPitch = -1 * 0.2f * dy;
@@ -629,21 +631,24 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
       rotateCamera( diffPitch, diffYaw );
       updateCameraFromPose( false );
     }
+
     mIgnoreNextMouseMove = true;
-    QCursor::setPos( mViewport.width(), mViewport.height() );
-    mMousePos = QCursor::pos();
+
+    // reset cursor back to center of map widget
+    emit setCursorPosition( QPoint( mViewport.width() / 2, mViewport.height() / 2 ) );
   }
   else
   {
+    const double dx = mouse->x() - mMousePos.x();
+    const double dy = mouse->y() - mMousePos.y();
+    mMousePos = QPoint( mouse->x(), mouse->y() );
+
     if ( mIgnoreNextMouseMove )
     {
-      mMousePos = QPoint( mouse->x(), mouse->y() );
       mIgnoreNextMouseMove = false;
       return;
     }
 
-    double dx = mouse->x() - mMousePos.x();
-    double dy = mouse->y() - mMousePos.y();
     if ( mPressedButton ==  Qt3DInput::QMouseEvent::LeftButton || mPressedButton ==  Qt3DInput::QMouseEvent::MiddleButton )
     {
       float diffPitch = 0.2f * dy;
@@ -659,8 +664,6 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
       QVector3D cameraPosDiff = dx / mViewport.width() * cameraLeft + dy / mViewport.height() * cameraUp;
       moveCameraPositionBy( 5.0 * mCameraMovementSpeed * cameraPosDiff );
     }
-
-    mMousePos = QPoint( mouse->x(), mouse->y() );
   }
 }
 

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -17,6 +17,7 @@
 #include "qgsraycastingutils_p.h"
 #include "qgsterrainentity_p.h"
 #include "qgsvector3d.h"
+#include "qgssettings.h"
 
 #include "qgis.h"
 
@@ -35,7 +36,6 @@ QgsCameraController::QgsCameraController( Qt3DCore::QNode *parent )
   , mMouseHandler( new Qt3DInput::QMouseHandler )
   , mKeyboardHandler( new Qt3DInput::QKeyboardHandler )
 {
-
   mMouseHandler->setSourceDevice( mMouseDevice );
   connect( mMouseHandler, &Qt3DInput::QMouseHandler::positionChanged,
            this, &QgsCameraController::onPositionChanged );

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -63,11 +63,12 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     Q_PROPERTY( Qt3DRender::QCamera *camera READ camera WRITE setCamera NOTIFY cameraChanged )
     Q_PROPERTY( QRect viewport READ viewport WRITE setViewport NOTIFY viewportChanged )
   public:
+
     //! The navigation mode used by the camera
     enum NavigationMode
     {
       TerrainBasedNavigation, //! The default navigation based on the terrain
-      FlyNavigation //! uses WASD keys or arrows to navigate in flying manner
+      WalkNavigation //! Uses WASD keys or arrows to navigate in walking (first person) manner
     };
 
   public:

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -70,6 +70,7 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
       TerrainBasedNavigation, //! The default navigation based on the terrain
       WalkNavigation //! Uses WASD keys or arrows to navigate in walking (first person) manner
     };
+    Q_ENUM( NavigationMode )
 
   public:
     //! Constructs the camera controller with optional parent node that will take ownership

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -196,6 +196,12 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     //! Emitted when the navigation mode is changed using the hotkey ctrl + ~
     void navigationModeHotKeyPressed( QgsCameraController::NavigationMode mode );
 
+    /**
+     * Emitted when the mouse cursor position should be moved to the specified \a point
+     * on the map viewport.
+     */
+    void setCursorPosition( QPoint point );
+
   private slots:
     void onPositionChanged( Qt3DInput::QMouseEvent *mouse );
     void onWheel( Qt3DInput::QWheelEvent *wheel );

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -207,7 +207,9 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
 
   private:
     void onKeyPressedFlyNavigation();
+    void onKeyPressedTerrainNavigation( Qt3DInput::QKeyEvent *mouse );
     void onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent *mouse );
+    void onPositionChangedTerrainNavigation( Qt3DInput::QMouseEvent *mouse );
 
   private:
     //! Camera that is being controlled

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -219,6 +219,11 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     void navigationModeHotKeyPressed( QgsCameraController::NavigationMode mode );
 
     /**
+     * Emitted whenever the camera movement speed is changed by the controller.
+     */
+    void cameraMovementSpeedChanged( double speed );
+
+    /**
      * Emitted when the mouse cursor position should be moved to the specified \a point
      * on the map viewport.
      */

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -67,10 +67,19 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     //! The navigation mode used by the camera
     enum NavigationMode
     {
-      TerrainBasedNavigation, //! The default navigation based on the terrain
-      WalkNavigation //! Uses WASD keys or arrows to navigate in walking (first person) manner
+      TerrainBasedNavigation, //!< The default navigation based on the terrain
+      WalkNavigation //!< Uses WASD keys or arrows to navigate in walking (first person) manner
     };
     Q_ENUM( NavigationMode )
+
+    //! Vertical axis inversion options
+    enum VerticalAxisInversion
+    {
+      Never, //!< Never invert vertical axis movements
+      WhenDragging, //!< Invert vertical axis movements when dragging in first person modes
+      Always, //!< Always invert vertical axis movements
+    };
+    Q_ENUM( VerticalAxisInversion )
 
   public:
     //! Constructs the camera controller with optional parent node that will take ownership
@@ -82,13 +91,13 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     QRect viewport() const { return mViewport; }
 
     /**
-     * Returns the nvigtion mode used by the camera controller
+     * Returns the navigation mode used by the camera controller.
      * \since QGIS 3.18
      */
     QgsCameraController::NavigationMode cameraNavigationMode() const { return mCameraNavigationMode; }
 
     /**
-     * Sets the nvigtion mode used by the camera controller
+     * Sets the navigation mode used by the camera controller.
      * \since QGIS 3.18
      */
     void setCameraNavigationMode( QgsCameraController::NavigationMode navigationMode );
@@ -104,6 +113,18 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
      * \since QGIS 3.18
      */
     void setCameraMovementSpeed( double movementSpeed );
+
+    /**
+     * Returns the vertical axis inversion behavior.
+     * \since QGIS 3.18
+     */
+    QgsCameraController::VerticalAxisInversion verticalAxisInversion() const { return mVerticalAxisInversion; }
+
+    /**
+     * Sets the vertical axis \a inversion behavior.
+     * \since QGIS 3.18
+     */
+    void setVerticalAxisInversion( QgsCameraController::VerticalAxisInversion inversion );
 
     /**
      * Connects to object picker attached to terrain entity. Called internally from 3D scene.
@@ -243,6 +264,7 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     Qt3DInput::QMouseHandler *mMouseHandler = nullptr;
     Qt3DInput::QKeyboardHandler *mKeyboardHandler = nullptr;
     NavigationMode mCameraNavigationMode = NavigationMode::TerrainBasedNavigation;
+    VerticalAxisInversion mVerticalAxisInversion = WhenDragging;
     double mCameraMovementSpeed = 5.0;
 
     QSet< int > mDepressedKeys;

--- a/src/analysis/processing/qgsalgorithmcellstatistics.cpp
+++ b/src/analysis/processing/qgsalgorithmcellstatistics.cpp
@@ -533,7 +533,7 @@ QString QgsCellStatisticsPercentRankFromValueAlgorithm::shortHelpString() const
   return QObject::tr( "The Cell stack percentrank from value algorithm calculates the cell-wise percentrank value of a stack of rasters based on a single input value "
                       "and writes them to an output raster.\n\n"
                       "At each cell location, the specified value is ranked among the respective values in the stack of all overlaid and sorted cell values from the input rasters. "
-                      "For values outside of the the stack value distribution, the algorithm returns NoData because the value cannot be ranked among the cell values.\n\n"
+                      "For values outside of the stack value distribution, the algorithm returns NoData because the value cannot be ranked among the cell values.\n\n"
                       "There are two methods for percentile calculation:"
                       "<ul> "
                       "   <li>Inclusive linearly interpolated percent rank (PERCENTRANK.INC)</li>"
@@ -543,7 +543,7 @@ QString QgsCellStatisticsPercentRankFromValueAlgorithm::shortHelpString() const
                       "methods follow their counterpart methods implemented by LibreOffice or Microsoft Excel. \n\n"
                       "The output raster's extent and resolution is defined by a reference "
                       "raster. If the input raster layers that do not match the cell size of the reference raster layer will be "
-                      "resampled using nearest neighbor resampling.  NoData values in any of the input layers will result in a NoData cell output if the Ignore NoData parameter is not set. "
+                      "resampled using nearest neighbor resampling. NoData values in any of the input layers will result in a NoData cell output if the Ignore NoData parameter is not set. "
                       "The output raster data type will always be Float32." );
 }
 

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -118,6 +118,7 @@ void Qgs3DMapCanvas::setMap( Qgs3DMapSettings *map )
   {
     QCursor::setPos( mapToGlobal( point ) );
   } );
+  connect( cameraController(), &QgsCameraController::cameraMovementSpeedChanged, mMap, &Qgs3DMapSettings::setCameraMovementSpeed );
 
   emit mapSettingsChanged();
 }

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -113,15 +113,11 @@ void Qgs3DMapCanvas::setMap( Qgs3DMapSettings *map )
   resetView();
 
   // Connect the camera to the navigation widget.
-  QObject::connect(
-    this->cameraController(),
-    &QgsCameraController::cameraChanged,
-    mNavigationWidget,
-    [ = ]
+  connect( cameraController(), &QgsCameraController::cameraChanged, mNavigationWidget, &Qgs3DNavigationWidget::updateFromCamera );
+  connect( cameraController(), &QgsCameraController::setCursorPosition, this, [ = ]( QPoint point )
   {
-    mNavigationWidget->updateFromCamera();
-  }
-  );
+    QCursor::setPos( mapToGlobal( point ) );
+  } );
 
   emit mapSettingsChanged();
 }

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -52,6 +52,9 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
   const int iconSize = QgsGuiUtils::scaleIconSize( 20 );
   m3DOptionsListWidget->setIconSize( QSize( iconSize, iconSize ) ) ;
 
+  mCameraNavigationModeCombo->addItem( tr( "Terrain Based" ), QgsCameraController::TerrainBasedNavigation );
+  mCameraNavigationModeCombo->addItem( tr( "Walk Mode (First Person)" ), QgsCameraController::WalkNavigation );
+
   // get rid of annoying outer focus rect on Mac
   m3DOptionsListWidget->setAttribute( Qt::WA_MacShowFocusRect, false );
   m3DOptionsListWidget->setCurrentRow( settings.value( QStringLiteral( "Windows/3DMapConfig/Tab" ), 0 ).toInt() );
@@ -135,7 +138,7 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
 
   spinCameraFieldOfView->setValue( mMap->fieldOfView() );
   cboCameraProjectionType->setCurrentIndex( cboCameraProjectionType->findData( mMap->projectionType() ) );
-  mCameraNavigationMode->setCurrentIndex( mMap->cameraNavigationMode() );
+  mCameraNavigationModeCombo->setCurrentIndex( mCameraNavigationModeCombo->findData( mMap->cameraNavigationMode() ) );
   mCameraMovementSpeed->setValue( mMap->cameraMovementSpeed() );
   spinTerrainScale->setValue( mMap->terrainVerticalScale() );
   spinMapResolution->setValue( mMap->mapTileResolution() );
@@ -320,8 +323,8 @@ void Qgs3DMapConfigWidget::apply()
 
   mMap->setFieldOfView( spinCameraFieldOfView->value() );
   mMap->setProjectionType( cboCameraProjectionType->currentData().value< Qt3DRender::QCameraLens::ProjectionType >() );
-  mMap->setCameraNavigationMode( static_cast<QgsCameraController::NavigationMode>( mCameraNavigationMode->currentIndex() ) );
-  m3DMapCanvas->scene()->cameraController()->setCameraNavigationMode( static_cast<QgsCameraController::NavigationMode>( mCameraNavigationMode->currentIndex() ) );
+  mMap->setCameraNavigationMode( static_cast<QgsCameraController::NavigationMode>( mCameraNavigationModeCombo->currentData().toInt() ) );
+  m3DMapCanvas->scene()->cameraController()->setCameraNavigationMode( mMap->cameraNavigationMode() );
   mMap->setCameraMovementSpeed( mCameraMovementSpeed->value() );
   mMap->setTerrainVerticalScale( spinTerrainScale->value() );
   mMap->setMapTileResolution( spinMapResolution->value() );

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -73,13 +73,14 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
   mMeshSymbolWidget = new QgsMesh3dSymbolWidget( nullptr, groupMeshTerrainShading );
   mMeshSymbolWidget->configureForTerrain();
 
-  cboCameraProjectionType->addItem( tr( "Perspective projection" ), Qt3DRender::QCameraLens::PerspectiveProjection );
-  cboCameraProjectionType->addItem( tr( "Orthogonal projection" ), Qt3DRender::QCameraLens::OrthographicProjection );
+  cboCameraProjectionType->addItem( tr( "Perspective Projection" ), Qt3DRender::QCameraLens::PerspectiveProjection );
+  cboCameraProjectionType->addItem( tr( "Orthogonal Projection" ), Qt3DRender::QCameraLens::OrthographicProjection );
   connect( cboCameraProjectionType, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, [ = ]()
   {
     spinCameraFieldOfView->setEnabled( cboCameraProjectionType->currentIndex() == cboCameraProjectionType->findData( Qt3DRender::QCameraLens::PerspectiveProjection ) );
   } );
 
+  mCameraMovementSpeed->setClearValue( 4 );
   spinCameraFieldOfView->setClearValue( 45.0 );
   spinTerrainScale->setClearValue( 1.0 );
   spinTerrainResolution->setClearValue( 16 );

--- a/src/app/3d/qgs3dnavigationwidget.h
+++ b/src/app/3d/qgs3dnavigationwidget.h
@@ -31,14 +31,12 @@ class Qgs3DNavigationWidget : public QWidget
   public:
     Qgs3DNavigationWidget( Qgs3DMapCanvas *parent = nullptr );
 
+  public slots:
+
     /**
      * Update the state of navigation widget from camera's state
      */
     void updateFromCamera();
-
-  signals:
-
-  public slots:
 
   private:
     Qgs3DMapCanvas *mParent3DMapCanvas = nullptr;

--- a/src/app/3d/qgs3doptions.cpp
+++ b/src/app/3d/qgs3doptions.cpp
@@ -38,12 +38,19 @@ Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
   cboCameraProjectionType->addItem( tr( "Perspective Projection" ), Qt3DRender::QCameraLens::PerspectiveProjection );
   cboCameraProjectionType->addItem( tr( "Orthogonal Projection" ), Qt3DRender::QCameraLens::OrthographicProjection );
 
+  mInvertVerticalAxisCombo->addItem( tr( "Never" ), QgsCameraController::Never );
+  mInvertVerticalAxisCombo->addItem( tr( "Only When Dragging" ), QgsCameraController::WhenDragging );
+  mInvertVerticalAxisCombo->addItem( tr( "Always" ), QgsCameraController::Always );
+
   mCameraMovementSpeed->setClearValue( 4 );
   spinCameraFieldOfView->setClearValue( 45.0 );
 
   QgsSettings settings;
   const QgsCameraController::NavigationMode defaultNavMode = settings.enumValue( QStringLiteral( "map3d/defaultNavigation" ), QgsCameraController::TerrainBasedNavigation, QgsSettings::App );
   mCameraNavigationModeCombo->setCurrentIndex( mCameraNavigationModeCombo->findData( static_cast< int >( defaultNavMode ) ) );
+
+  const QgsCameraController::VerticalAxisInversion axisInversion = settings.enumValue( QStringLiteral( "map3d/axisInversion" ), QgsCameraController::WhenDragging, QgsSettings::App );
+  mInvertVerticalAxisCombo->setCurrentIndex( mInvertVerticalAxisCombo->findData( static_cast< int >( axisInversion ) ) );
 
   const Qt3DRender::QCameraLens::ProjectionType defaultProjection = settings.enumValue( QStringLiteral( "map3d/defaultProjection" ), Qt3DRender::QCameraLens::PerspectiveProjection, QgsSettings::App );
   cboCameraProjectionType->setCurrentIndex( cboCameraProjectionType->findData( static_cast< int >( defaultProjection ) ) );
@@ -56,6 +63,7 @@ void Qgs3DOptionsWidget::apply()
 {
   QgsSettings settings;
   settings.setValue( QStringLiteral( "map3d/defaultNavigation" ), static_cast< QgsCameraController::NavigationMode >( mCameraNavigationModeCombo->currentData().toInt() ), QgsSettings::App );
+  settings.setValue( QStringLiteral( "map3d/axisInversion" ), static_cast< QgsCameraController::VerticalAxisInversion >( mInvertVerticalAxisCombo->currentData().toInt() ), QgsSettings::App );
   settings.setValue( QStringLiteral( "map3d/defaultProjection" ), static_cast< Qt3DRender::QCameraLens::ProjectionType >( cboCameraProjectionType->currentData().toInt() ), QgsSettings::App );
   settings.setValue( QStringLiteral( "map3d/defaultMovementSpeed" ), mCameraMovementSpeed->value(), QgsSettings::App );
   settings.setValue( QStringLiteral( "map3d/defaultFieldOfView" ), spinCameraFieldOfView->value(), QgsSettings::App );

--- a/src/app/3d/qgs3doptions.cpp
+++ b/src/app/3d/qgs3doptions.cpp
@@ -1,0 +1,82 @@
+/***************************************************************************
+    qgs3doptions.cpp
+    -------------------------
+    begin                : January 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgs3doptions.h"
+#include "qgsapplication.h"
+#include "qgssettings.h"
+#include "qgis.h"
+#include "qgsgui.h"
+#include "qgscameracontroller.h"
+#include <Qt3DRender/QCamera>
+
+//
+// QgsCodeEditorOptionsWidget
+//
+
+Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
+  : QgsOptionsPageWidget( parent )
+{
+  setupUi( this );
+
+  layout()->setContentsMargins( 0, 0, 0, 0 );
+
+  mCameraNavigationModeCombo->addItem( tr( "Terrain Based" ), QgsCameraController::TerrainBasedNavigation );
+  mCameraNavigationModeCombo->addItem( tr( "Walk Mode (First Person)" ), QgsCameraController::WalkNavigation );
+
+  cboCameraProjectionType->addItem( tr( "Perspective Projection" ), Qt3DRender::QCameraLens::PerspectiveProjection );
+  cboCameraProjectionType->addItem( tr( "Orthogonal Projection" ), Qt3DRender::QCameraLens::OrthographicProjection );
+
+  mCameraMovementSpeed->setClearValue( 4 );
+  spinCameraFieldOfView->setClearValue( 45.0 );
+
+  QgsSettings settings;
+  const QgsCameraController::NavigationMode defaultNavMode = settings.enumValue( QStringLiteral( "map3d/defaultNavigation" ), QgsCameraController::TerrainBasedNavigation, QgsSettings::App );
+  mCameraNavigationModeCombo->setCurrentIndex( mCameraNavigationModeCombo->findData( static_cast< int >( defaultNavMode ) ) );
+
+  const Qt3DRender::QCameraLens::ProjectionType defaultProjection = settings.enumValue( QStringLiteral( "map3d/defaultProjection" ), Qt3DRender::QCameraLens::PerspectiveProjection, QgsSettings::App );
+  cboCameraProjectionType->setCurrentIndex( cboCameraProjectionType->findData( static_cast< int >( defaultProjection ) ) );
+
+  mCameraMovementSpeed->setValue( settings.value( QStringLiteral( "map3d/defaultMovementSpeed" ), 5, QgsSettings::App ).toDouble() );
+  spinCameraFieldOfView->setValue( settings.value( QStringLiteral( "map3d/defaultFieldOfView" ), 45, QgsSettings::App ).toInt() );
+}
+
+void Qgs3DOptionsWidget::apply()
+{
+  QgsSettings settings;
+  settings.setValue( QStringLiteral( "map3d/defaultNavigation" ), static_cast< QgsCameraController::NavigationMode >( mCameraNavigationModeCombo->currentData().toInt() ), QgsSettings::App );
+  settings.setValue( QStringLiteral( "map3d/defaultProjection" ), static_cast< Qt3DRender::QCameraLens::ProjectionType >( cboCameraProjectionType->currentData().toInt() ), QgsSettings::App );
+  settings.setValue( QStringLiteral( "map3d/defaultMovementSpeed" ), mCameraMovementSpeed->value(), QgsSettings::App );
+  settings.setValue( QStringLiteral( "map3d/defaultFieldOfView" ), spinCameraFieldOfView->value(), QgsSettings::App );
+}
+
+
+//
+// Qgs3DOptionsFactory
+//
+Qgs3DOptionsFactory::Qgs3DOptionsFactory()
+  : QgsOptionsWidgetFactory( tr( "3D" ), QIcon() )
+{
+
+}
+
+QIcon Qgs3DOptionsFactory::icon() const
+{
+  return QgsApplication::getThemeIcon( QStringLiteral( "/3d.svg" ) );
+}
+
+QgsOptionsPageWidget *Qgs3DOptionsFactory::createWidget( QWidget *parent ) const
+{
+  return new Qgs3DOptionsWidget( parent );
+}

--- a/src/app/3d/qgs3doptions.h
+++ b/src/app/3d/qgs3doptions.h
@@ -1,0 +1,59 @@
+/***************************************************************************
+    qgs3doptions.h
+    -------------------------
+    begin                : January 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGS3DOPTIONS_H
+#define QGS3DOPTIONS_H
+
+#include "ui_qgs3doptionsbase.h"
+#include "qgsoptionswidgetfactory.h"
+#include "qgscodeeditor.h"
+
+/**
+ * \ingroup app
+ * \class Qgs3DOptionsWidget
+ * \brief An options widget showing 3D settings.
+ *
+ * \since QGIS 3.18
+ */
+class Qgs3DOptionsWidget : public QgsOptionsPageWidget, private Ui::Qgs3DOptionsBase
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for Qgs3DOptionsWidget with the specified \a parent widget.
+     */
+    Qgs3DOptionsWidget( QWidget *parent );
+
+    void apply() override;
+
+};
+
+
+class Qgs3DOptionsFactory : public QgsOptionsWidgetFactory
+{
+    Q_OBJECT
+
+  public:
+
+    Qgs3DOptionsFactory();
+
+    QIcon icon() const override;
+    QgsOptionsPageWidget *createWidget( QWidget *parent = nullptr ) const override;
+
+};
+
+
+#endif // QGS3DOPTIONS_H

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -412,99 +412,6 @@ set_source_files_properties(
   PROPERTIES COMPILE_FLAGS -wd4091)
 endif()
 
-include_directories(
-  ${CMAKE_SOURCE_DIR}/external/libdxfrw
-  ${CMAKE_SOURCE_DIR}/external/nmea
-
-  ${CMAKE_SOURCE_DIR}/src/app
-  ${CMAKE_SOURCE_DIR}/src/app/decorations
-  ${CMAKE_SOURCE_DIR}/src/app/devtools/networklogger
-  ${CMAKE_SOURCE_DIR}/src/app/labeling
-  ${CMAKE_SOURCE_DIR}/src/app/layout
-  ${CMAKE_SOURCE_DIR}/src/app/pluginmanager
-  ${CMAKE_SOURCE_DIR}/src/app/gps
-  ${CMAKE_SOURCE_DIR}/src/app/dwg
-  ${CMAKE_SOURCE_DIR}/src/app/mesh
-  ${CMAKE_SOURCE_DIR}/src/app/locator
-  ${CMAKE_SOURCE_DIR}/src/app/pointcloud
-  ${CMAKE_SOURCE_DIR}/src/app/vectortile
-  ${CMAKE_SOURCE_DIR}/src/plugins
-  ${CMAKE_SOURCE_DIR}/src/python
-  ${CMAKE_SOURCE_DIR}/src/native
-
-  ${CMAKE_BINARY_DIR}/src/python
-  ${CMAKE_BINARY_DIR}/src/analysis
-  ${CMAKE_BINARY_DIR}/src/app
-  ${CMAKE_BINARY_DIR}/src/ui
-  ${CMAKE_BINARY_DIR}/src/native
-)
-
-if (WITH_3D)
-  include_directories(
-    ${CMAKE_SOURCE_DIR}/src/app/3d
-  )
-  include_directories(SYSTEM
-    ${QT5_3DEXTRA_INCLUDE_DIR}
-  )
-endif()
-
-include_directories(SYSTEM
-  ${QT_QTUITOOLS_INCLUDE_DIR}
-  ${CMAKE_SOURCE_DIR}/external/qt-unix-signals
-)
-include_directories(
-  ../analysis/processing
-  ../analysis/raster
-  ../analysis/vector/geometry_checker
-  ../core
-  ../core/annotations
-  ../core/auth
-  ../core/gps
-  ../core/dxf
-  ../core/geometry
-  ../core/geocms/geonode
-  ../core/layout
-  ../core/metadata
-  ../core/layertree
-  ../core/processing
-  ../core/providers/memory
-  ../core/raster
-  ../core/mesh
-  ../core/scalebar
-  ../core/symbology
-  ../core/textrenderer
-  ../gui
-  ../gui/symbology
-  ../gui/attributetable
-  ../gui/auth
-  ../gui/effects
-  ../gui/ogr
-  ../gui/raster
-  ../gui/editorwidgets
-  ../gui/editorwidgets/core
-  ../gui/layertree
-  ../gui/layout
-  ../gui/tableeditor
-  ../plugins
-  ../python
-  gps
-  dwg
-  ${CMAKE_SOURCE_DIR}/external/libdxfrw
-  ${CMAKE_SOURCE_DIR}/src/native
-
-  ${CMAKE_BINARY_DIR}/src/native
-)
-include_directories(SYSTEM
-  ${PROJ_INCLUDE_DIR}
-  ${GDAL_INCLUDE_DIR}
-  ${SPATIALITE_INCLUDE_DIR}
-  ${SQLITE3_INCLUDE_DIR}
-  ${GEOS_INCLUDE_DIR}
-  ${QWTPOLAR_INCLUDE_DIR}
-  ${QCA_INCLUDE_DIR}
-  ${QTKEYCHAIN_INCLUDE_DIR}
-)
-
 if(HAVE_OPENCL)
     include_directories(SYSTEM ${OpenCL_INCLUDE_DIRS})
 endif()
@@ -542,6 +449,42 @@ endif()
 # loaded (by plugin for example) in test unit (qgis_layoutpicturetest).
 add_library(qgis_app SHARED ${QGIS_APP_SRCS})
 
+target_include_directories(qgis_app PUBLIC
+  ${CMAKE_SOURCE_DIR}/external/nmea
+
+  ${CMAKE_SOURCE_DIR}/src/app
+  ${CMAKE_SOURCE_DIR}/src/app/decorations
+  ${CMAKE_SOURCE_DIR}/src/app/devtools/networklogger
+  ${CMAKE_SOURCE_DIR}/src/app/labeling
+  ${CMAKE_SOURCE_DIR}/src/app/layout
+  ${CMAKE_SOURCE_DIR}/src/app/pluginmanager
+  ${CMAKE_SOURCE_DIR}/src/app/gps
+  ${CMAKE_SOURCE_DIR}/src/app/dwg
+  ${CMAKE_SOURCE_DIR}/src/app/mesh
+  ${CMAKE_SOURCE_DIR}/src/app/locator
+  ${CMAKE_SOURCE_DIR}/src/app/pointcloud
+  ${CMAKE_SOURCE_DIR}/src/app/vectortile
+  ${CMAKE_SOURCE_DIR}/src/plugins
+  ${CMAKE_SOURCE_DIR}/src/python
+  ${CMAKE_SOURCE_DIR}/src/native
+
+  ${CMAKE_BINARY_DIR}/src/app
+)
+
+if (WITH_3D)
+  target_include_directories(qgis_app PUBLIC
+    ${CMAKE_SOURCE_DIR}/src/app/3d
+  )
+endif()
+
+target_include_directories(qgis_app SYSTEM PUBLIC
+  ${QT_QTUITOOLS_INCLUDE_DIR}
+  ${QWTPOLAR_INCLUDE_DIR}
+  ${CMAKE_SOURCE_DIR}/external/qt-unix-signals
+)
+
+add_dependencies(qgis_gui ui)
+
 target_link_libraries(qgis_app
   ${QWT_LIBRARY}
   ${Qt5Sql_LIBRARIES}
@@ -549,8 +492,6 @@ target_link_libraries(qgis_app
   ${OPTIONAL_QTWEBKIT}
   #should only be needed for win
   ${QT_QTMAIN_LIBRARY}
-  ${QWTPOLAR_LIBRARY}
-  ${GDAL_LIBRARY}
   qgis_core
   qgis_gui
   qgis_analysis
@@ -560,14 +501,16 @@ target_link_libraries(qgis_app
 
 target_compile_definitions(qgis_app PRIVATE "-DQT_NO_FOREACH")
 
+if (WITH_BINDINGS)
+  target_link_libraries(qgis_app qgispython)
+endif()
+
 if(ENABLE_MODELTEST)
   target_link_libraries(qgis_app ${Qt5Test_LIBRARIES})
 endif()
 
 if (WITH_3D)
-  target_link_libraries(qgis_app
-    qgis_3d
-  )
+  target_link_libraries(qgis_app qgis_3d)
 endif()
 
 if (WITH_GEOREFERENCER)

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -271,6 +271,7 @@ if (WITH_3D)
     3d/qgs3dmeasuredialog.cpp
     3d/qgs3dmodelsourcelineedit.cpp
     3d/qgs3dnavigationwidget.cpp
+    3d/qgs3doptions.cpp
     3d/qgsgoochmaterialwidget.cpp
     3d/qgslightswidget.cpp
     3d/qgsline3dsymbolwidget.cpp

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13315,6 +13315,7 @@ void QgisApp::new3DMapCanvas()
 
     const QgsCameraController::NavigationMode defaultNavMode = settings.enumValue( QStringLiteral( "map3d/defaultNavigation" ), QgsCameraController::TerrainBasedNavigation, QgsSettings::App );
     map->setCameraNavigationMode( defaultNavMode );
+
     map->setCameraMovementSpeed( settings.value( QStringLiteral( "map3d/defaultMovementSpeed" ), 5, QgsSettings::App ).toDouble() );
     const Qt3DRender::QCameraLens::ProjectionType defaultProjection = settings.enumValue( QStringLiteral( "map3d/defaultProjection" ), Qt3DRender::QCameraLens::PerspectiveProjection, QgsSettings::App );
     map->setProjectionType( defaultProjection );
@@ -13342,6 +13343,10 @@ void QgisApp::new3DMapCanvas()
     QgsRectangle extent = mMapCanvas->extent();
     float dist = static_cast< float >( std::max( extent.width(), extent.height() ) );
     dock->mapCanvas3D()->setViewFromTop( mMapCanvas->extent().center(), dist, static_cast< float >( mMapCanvas->rotation() ) );
+
+    const QgsCameraController::VerticalAxisInversion axisInversion = settings.enumValue( QStringLiteral( "map3d/axisInversion" ), QgsCameraController::WhenDragging, QgsSettings::App );
+    if ( dock->mapCanvas3D()->cameraController() )
+      dock->mapCanvas3D()->cameraController()->setVerticalAxisInversion( axisInversion );
   }
 #endif
 }

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2705,6 +2705,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsScopedDevToolWidgetFactory mStartupProfilerWidgetFactory;
 
     QgsScopedOptionsWidgetFactory mCodeEditorWidgetFactory;
+    QgsScopedOptionsWidgetFactory m3DOptionsWidgetFactory;
 
     class QgsCanvasRefreshBlocker
     {

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -665,6 +665,9 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
     mLayerRestrictionsListWidget->addItems( values );
   }
 
+  bool useAttributeFormSettings = QgsProject::instance()->readBoolEntry( QStringLiteral( "WMSFeatureInfoUseAttributeFormSettings" ), QStringLiteral( "/" ) );
+  mUseAttributeFormSettingsCheckBox->setChecked( useAttributeFormSettings );
+
   bool addWktGeometry = QgsProject::instance()->readBoolEntry( QStringLiteral( "WMSAddWktGeometry" ), QStringLiteral( "/" ) );
   mAddWktGeometryCheckBox->setChecked( addWktGeometry );
 
@@ -1393,6 +1396,7 @@ void QgsProjectProperties::apply()
     QgsProject::instance()->removeEntry( QStringLiteral( "WMSRestrictedLayers" ), QStringLiteral( "/" ) );
   }
 
+  QgsProject::instance()->writeEntry( QStringLiteral( "WMSFeatureInfoUseAttributeFormSettings" ), QStringLiteral( "/" ), mUseAttributeFormSettingsCheckBox->isChecked() );
   QgsProject::instance()->writeEntry( QStringLiteral( "WMSAddWktGeometry" ), QStringLiteral( "/" ), mAddWktGeometryCheckBox->isChecked() );
   QgsProject::instance()->writeEntry( QStringLiteral( "WMSSegmentizeFeatureInfoGeometry" ), QStringLiteral( "/" ), mSegmentizeFeatureInfoGeometryCheckBox->isChecked() );
   QgsProject::instance()->writeEntry( QStringLiteral( "WMSUseLayerIDs" ), QStringLiteral( "/" ), mWmsUseLayerIDs->isChecked() );

--- a/src/auth/basic/CMakeLists.txt
+++ b/src/auth/basic/CMakeLists.txt
@@ -11,11 +11,6 @@ set(AUTH_BASIC_HDRS
 set(AUTH_BASIC_UIS qgsauthbasicedit.ui)
 
 include_directories (
-)
-
-include_directories (
-  ../../gui
-  ../../gui/auth
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 

--- a/src/crssync/CMakeLists.txt
+++ b/src/crssync/CMakeLists.txt
@@ -1,14 +1,5 @@
 add_executable(crssync main.cpp)
 
-include_directories(
-  ../core
-  ../core/geometry
-)
-include_directories(SYSTEM
-  ${GDAL_INCLUDE_DIR}
-  ${PROJ_INCLUDE_DIR}
-)
-
 target_link_libraries(crssync
   qgis_core
   ${PROJ_LIBRARY}

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -107,6 +107,10 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   metadataFrame->setLayout( layout );
   mOptsPage_Metadata->setContentsMargins( 0, 0, 0, 0 );
 
+  mTemporalDateTimeStart->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
+  mTemporalDateTimeEnd->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
+  mTemporalDateTimeReference->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
+
   // update based on lyr's current state
   syncToLayer();
 

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
@@ -86,10 +86,14 @@ void QgsMssqlDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu 
   }
   else if ( QgsMssqlLayerItem *layerItem = qobject_cast< QgsMssqlLayerItem * >( item ) )
   {
+    QMenu *maintainMenu = new QMenu( tr( "Table Operations" ), menu );
+
     // truncate
     QAction *actionTruncateLayer = new QAction( tr( "Truncate Table" ), menu );
     connect( actionTruncateLayer, &QAction::triggered, this, [layerItem] { truncateTable( layerItem ); } );
-    menu->addAction( actionTruncateLayer );
+    maintainMenu->addAction( actionTruncateLayer );
+
+    menu->addMenu( maintainMenu );
   }
 }
 

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -76,13 +76,17 @@ void QgsPostgresDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMe
 
     menu->addSeparator();
 
+    QMenu *maintainMenu = new QMenu( tr( "Schema Operations" ), menu );
+
     QAction *actionRename = new QAction( tr( "Rename Schema…" ), this );
     connect( actionRename, &QAction::triggered, this, [schemaItem, context] { renameSchema( schemaItem, context ); } );
-    menu->addAction( actionRename );
+    maintainMenu->addAction( actionRename );
 
     QAction *actionDelete = new QAction( tr( "Delete Schema…" ), this );
     connect( actionDelete, &QAction::triggered, this, [schemaItem, context] { deleteSchema( schemaItem, context ); } );
-    menu->addAction( actionDelete );
+    maintainMenu->addAction( actionDelete );
+
+    menu->addMenu( maintainMenu );
   }
 
   if ( QgsPGLayerItem *layerItem = qobject_cast< QgsPGLayerItem * >( item ) )
@@ -90,23 +94,26 @@ void QgsPostgresDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMe
     const QgsPostgresLayerProperty &layerInfo = layerItem->layerInfo();
     QString typeName = layerInfo.isView ? tr( "View" ) : tr( "Table" );
 
+    QMenu *maintainMenu = new QMenu( tr( "%1 Operations" ).arg( typeName ), menu );
+
     QAction *actionRenameLayer = new QAction( tr( "Rename %1…" ).arg( typeName ), this );
     connect( actionRenameLayer, &QAction::triggered, this, [layerItem, context] { renameLayer( layerItem, context ); } );
-    menu->addAction( actionRenameLayer );
+    maintainMenu->addAction( actionRenameLayer );
 
     if ( !layerInfo.isView )
     {
       QAction *actionTruncateLayer = new QAction( tr( "Truncate %1…" ).arg( typeName ), this );
       connect( actionTruncateLayer, &QAction::triggered, this, [layerItem, context] { truncateTable( layerItem, context ); } );
-      menu->addAction( actionTruncateLayer );
+      maintainMenu->addAction( actionTruncateLayer );
     }
 
     if ( layerInfo.isMaterializedView )
     {
       QAction *actionRefreshMaterializedView = new QAction( tr( "Refresh Materialized View…" ), this );
       connect( actionRefreshMaterializedView, &QAction::triggered, this, [layerItem, context] { refreshMaterializedView( layerItem, context ); } );
-      menu->addAction( actionRefreshMaterializedView );
+      maintainMenu->addAction( actionRefreshMaterializedView );
     }
+    menu->addMenu( maintainMenu );
   }
 }
 

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -470,7 +470,7 @@ bool QgsPostgresProviderConnection::spatialIndexExists( const QString &schema, c
                                                                   AND i.oid=ix.indexrelid
                                                                   AND a.attrelid=t.oid
                                                                   AND a.attnum=ANY(ix.indkey)
-                                                                  AND t.relkind='r'
+                                                                  AND t.relkind IN ('r', 'm')
                                                                   AND ns.nspname=%1
                                                                   AND t.relname=%2
                                                                   AND a.attname=%3;

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -172,6 +172,13 @@ bool QgsServerProjectUtils::wmsFeatureInfoAddWktGeometry( const QgsProject &proj
          || wktGeom.compare( QLatin1String( "true" ), Qt::CaseInsensitive ) == 0;
 }
 
+bool QgsServerProjectUtils::wmsFeatureInfoUseAttributeFormSettings( const QgsProject &project )
+{
+  QString useFormSettings = project.readEntry( QStringLiteral( "WMSFeatureInfoUseAttributeFormSettings" ), QStringLiteral( "/" ), "" );
+  return useFormSettings.compare( QLatin1String( "enabled" ), Qt::CaseInsensitive ) == 0
+         || useFormSettings.compare( QLatin1String( "true" ), Qt::CaseInsensitive ) == 0;
+}
+
 bool QgsServerProjectUtils::wmsFeatureInfoSegmentizeWktGeometry( const QgsProject &project )
 {
   QString segmGeom = project.readEntry( QStringLiteral( "WMSSegmentizeFeatureInfoGeometry" ), QStringLiteral( "/" ), "" );

--- a/src/server/qgsserverprojectutils.h
+++ b/src/server/qgsserverprojectutils.h
@@ -208,6 +208,13 @@ namespace QgsServerProjectUtils
   SERVER_EXPORT bool wmsFeatureInfoAddWktGeometry( const QgsProject &project );
 
   /**
+    * Returns if feature form settings should be considered for the format of the feature info response
+    * \param project the QGIS project
+    * \returns true if the feature form settings shall be considered for the feature info response
+   */
+  SERVER_EXPORT bool wmsFeatureInfoUseAttributeFormSettings( const QgsProject &project );
+
+  /**
    * Returns if the geometry has to be segmentize in GetFeatureInfo request.
    * \param project the QGIS project
    * \returns if the geometry has to be segmentize in GetFeatureInfo request.

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1466,6 +1466,8 @@ namespace QgsWms
       fReq.setFilterExpression( QString( "intersects( $geometry, geom_from_wkt('%1') )" ).arg( layerFilterGeom->asWkt() ) );
     }
 
+    mFeatureFilter.filterFeatures( layer, fReq );
+
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     mContext.accessControl()->filterFeatures( layer, fReq );
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -64,6 +64,8 @@
 #include "qgsserverexception.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsfeaturestore.h"
+#include "qgsattributeeditorelement.h"
+#include "qgseditformconfig.h"
 
 #include <QImage>
 #include <QPainter>

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -64,6 +64,9 @@
 #include "qgsserverexception.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsfeaturestore.h"
+#include "qgsattributeeditorcontainer.h"
+#include "qgsattributeeditorelement.h"
+#include "qgsattributeeditorfield.h"
 
 #include <QImage>
 #include <QPainter>

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -64,8 +64,6 @@
 #include "qgsserverexception.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsfeaturestore.h"
-#include "qgsattributeeditorelement.h"
-#include "qgseditformconfig.h"
 
 #include <QImage>
 #include <QPainter>

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1566,33 +1566,7 @@ namespace QgsWms
         featureAttributes = feature.attributes();
         for ( int i = 0; i < featureAttributes.count(); ++i )
         {
-          //skip attribute if it is explicitly excluded from WMS publication
-          if ( fields.at( i ).configurationFlags().testFlag( QgsField::ConfigurationFlag::HideFromWms ) )
-          {
-            continue;
-          }
-#ifdef HAVE_SERVER_PYTHON_PLUGINS
-          //skip attribute if it is excluded by access control
-          if ( !attributes.contains( fields.at( i ).name() ) )
-          {
-            continue;
-          }
-#endif
-
-          //replace attribute name if there is an attribute alias?
-          QString attributeName = layer->attributeDisplayName( i );
-
-          QDomElement attributeElement = infoDocument.createElement( QStringLiteral( "Attribute" ) );
-          attributeElement.setAttribute( QStringLiteral( "name" ), attributeName );
-          const QgsEditorWidgetSetup setup = layer->editorWidgetSetup( i );
-          attributeElement.setAttribute( QStringLiteral( "value" ),
-                                         QgsExpression::replaceExpressionText(
-                                           replaceValueMapAndRelation(
-                                             layer, i,
-                                             featureAttributes[i] ),
-                                           &renderContext.expressionContext() )
-                                       );
-          featureElement.appendChild( attributeElement );
+          writeVectorLayerAttribute( i, layer, fields, featureAttributes, infoDocument, featureElement, renderContext );
         }
 
         //add maptip attribute based on html/expression (in case there is no maptip attribute)
@@ -1658,6 +1632,41 @@ namespace QgsWms
     }
 
     return true;
+  }
+
+
+  void QgsRenderer::writeVectorLayerAttribute( int attributeIndex,  QgsVectorLayer *layer, const QgsFields &fields, QgsAttributes &featureAttributes, QDomDocument &doc, QDomElement &featureElem, QgsRenderContext &renderContext ) const
+  {
+    if ( !layer )
+    {
+      return;
+    }
+
+    //skip attribute if it is explicitly excluded from WMS publication
+    if ( fields.at( attributeIndex ).configurationFlags().testFlag( QgsField::ConfigurationFlag::HideFromWms ) )
+    {
+      return;
+    }
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
+    //skip attribute if it is excluded by access control
+    if ( !attributes.contains( fields.at( i ).name() ) )
+    {
+      return;
+    }
+#endif
+
+    QString attributeName = layer->attributeDisplayName( attributeIndex );
+    QDomElement attributeElement = doc.createElement( QStringLiteral( "Attribute" ) );
+    attributeElement.setAttribute( QStringLiteral( "name" ), attributeName );
+    const QgsEditorWidgetSetup setup = layer->editorWidgetSetup( attributeIndex );
+    attributeElement.setAttribute( QStringLiteral( "value" ),
+                                   QgsExpression::replaceExpressionText(
+                                     replaceValueMapAndRelation(
+                                       layer, attributeIndex,
+                                       featureAttributes[attributeIndex] ),
+                                     &renderContext.expressionContext() )
+                                 );
+    featureElem.appendChild( attributeElement );
   }
 
   bool QgsRenderer::featureInfoFromRasterLayer( QgsRasterLayer *layer,

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1566,7 +1566,7 @@ namespace QgsWms
 
         featureAttributes = feature.attributes();
         QgsEditFormConfig editConfig = layer->editFormConfig();
-        if ( editConfig.layout() == QgsEditFormConfig::TabLayout )
+        if ( QgsServerProjectUtils::wmsFeatureInfoUseAttributeFormSettings( *mProject ) && editConfig.layout() == QgsEditFormConfig::TabLayout )
         {
           writeAttributesTabLayout( editConfig, layer, fields, featureAttributes, infoDocument, featureElement, renderContext );
         }

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1564,7 +1564,7 @@ namespace QgsWms
 
         featureAttributes = feature.attributes();
         QgsEditFormConfig editConfig = layer->editFormConfig();
-        if ( editConfig.layout() == QgsEditFormConfig::TabLayout )
+        if ( QgsServerProjectUtils::wmsFeatureInfoUseAttributeFormSettings( *mProject ) && editConfig.layout() == QgsEditFormConfig::TabLayout )
         {
           writeAttributesTabLayout( editConfig, layer, fields, featureAttributes, infoDocument, featureElement, renderContext );
         }

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1564,11 +1564,18 @@ namespace QgsWms
         featureElement.setAttribute( QStringLiteral( "id" ), QgsServerFeatureId::getServerFid( feature, layer->dataProvider()->pkAttributeIndexes() ) );
         layerElement.appendChild( featureElement );
 
-        //read all attribute values from the feature
         featureAttributes = feature.attributes();
-        for ( int i = 0; i < featureAttributes.count(); ++i )
+        QgsEditFormConfig editConfig = layer->editFormConfig();
+        if ( editConfig.layout() == QgsEditFormConfig::TabLayout )
         {
-          writeVectorLayerAttribute( i, layer, fields, featureAttributes, infoDocument, featureElement, renderContext );
+          writeAttributesTabLayout( editConfig, layer, fields, featureAttributes, infoDocument, featureElement, renderContext );
+        }
+        else
+        {
+          for ( int i = 0; i < featureAttributes.count(); ++i )
+          {
+            writeVectorLayerAttribute( i, layer, fields, featureAttributes, infoDocument, featureElement, renderContext );
+          }
         }
 
         //add maptip attribute based on html/expression (in case there is no maptip attribute)
@@ -1636,6 +1643,49 @@ namespace QgsWms
     return true;
   }
 
+  void QgsRenderer::writeAttributesTabGroup( const QgsAttributeEditorElement *group, QgsVectorLayer *layer, const QgsFields &fields, QgsAttributes &featureAttributes, QDomDocument &doc, QDomElement &parentElem, QgsRenderContext &renderContext ) const
+  {
+    const QgsAttributeEditorContainer *container = dynamic_cast<const QgsAttributeEditorContainer *>( group );
+    if ( container )
+    {
+      QString groupName = container->name();
+      QDomElement nameElem;
+
+      if ( !groupName.isEmpty() )
+      {
+        nameElem = doc.createElement( groupName );
+        parentElem.appendChild( nameElem );
+      }
+
+      QList<QgsAttributeEditorElement *> children =  container->children();
+      foreach ( const QgsAttributeEditorElement *child, children )
+      {
+        if ( child->type() == QgsAttributeEditorElement::AeTypeContainer )
+        {
+          writeAttributesTabGroup( child, layer, fields, featureAttributes, doc, nameElem.isNull() ? parentElem : nameElem, renderContext );
+        }
+        else if ( child->type() == QgsAttributeEditorElement::AeTypeField )
+        {
+          const QgsAttributeEditorField *editorField = dynamic_cast<const QgsAttributeEditorField *>( child );
+          if ( editorField )
+          {
+            writeVectorLayerAttribute( editorField->idx(), layer, fields, featureAttributes, doc, nameElem.isNull() ? parentElem : nameElem, renderContext );
+          }
+        }
+      }
+    }
+  }
+
+  void QgsRenderer::writeAttributesTabLayout( QgsEditFormConfig &config, QgsVectorLayer *layer, const QgsFields &fields, QgsAttributes &featureAttributes, QDomDocument &doc, QDomElement &featureElem, QgsRenderContext &renderContext ) const
+  {
+    QgsAttributeEditorContainer *editorContainer = config.invisibleRootContainer();
+    if ( !editorContainer )
+    {
+      return;
+    }
+
+    writeAttributesTabGroup( editorContainer, layer, fields, featureAttributes, doc, featureElem, renderContext );
+  }
 
   void QgsRenderer::writeVectorLayerAttribute( int attributeIndex,  QgsVectorLayer *layer, const QgsFields &fields, QgsAttributes &featureAttributes, QDomDocument &doc, QDomElement &featureElem, QgsRenderContext &renderContext ) const
   {

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -223,11 +223,40 @@ namespace QgsWms
                                        QgsRectangle *featureBBox = nullptr,
                                        QgsGeometry *filterGeom = nullptr ) const;
 
-      //!Recursively called to write tab layout groups to XML
+      /**
+       * Recursively called to write tab layout groups to XML
+       * \param group the tab layout group
+       * \param layer The vector layer
+       * \param fields attribute fields
+       * \param featureAttributes the feature attributes
+       * \param doc Feature info XML document
+       * \param featureElem the feature XML element
+       * \param renderContext Context to use for feature rendering
+       */
       void writeAttributesTabGroup( const QgsAttributeEditorElement *group, QgsVectorLayer *layer, const QgsFields &fields, QgsAttributes &featureAttributes, QDomDocument &doc, QDomElement &featureElem, QgsRenderContext &renderContext ) const;
-      //!Writes attributes to XML document using the group/attribute layout defined in the tab layout
+
+      /**
+       * Writes attributes to XML document using the group/attribute layout defined in the tab layout
+       * \param config editor config object
+       * \param layer The vector layer
+       * \param fields attribute fields
+       * \param featureAttributes the feature attributes
+       * \param doc Feature info XML document
+       * \param featureElem the feature XML element
+       * \param renderContext Context to use for feature rendering
+       */
       void writeAttributesTabLayout( QgsEditFormConfig &config, QgsVectorLayer *layer, const QgsFields &fields, QgsAttributes &featureAttributes, QDomDocument &doc, QDomElement &featureElem, QgsRenderContext &renderContext ) const;
-      //! Writes a vectorlayer attribute into the XML document
+
+      /**
+       * Writes a vectorlayer attribute into the XML document
+       * \param index of attribute to be written
+       * \param layer The vector layer
+       * \param fields attribute fields
+       * \param featureAttributes the feature attributes
+       * \param doc Feature info XML document
+       * \param featureElem the feature XML element
+       * \param renderContext Context to use for feature rendering
+       */
       void writeVectorLayerAttribute( int attributeIndex, QgsVectorLayer *layer, const QgsFields &fields, QgsAttributes &featureAttributes, QDomDocument &doc, QDomElement &featureElem, QgsRenderContext &renderContext ) const;
 
       //! Appends feature info xml for the layer to the layer element of the dom document

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -249,7 +249,7 @@ namespace QgsWms
 
       /**
        * Writes a vectorlayer attribute into the XML document
-       * \param attributeindex of attribute to be written
+       * \param attributeIndex of attribute to be written
        * \param layer The vector layer
        * \param fields attribute fields
        * \param featureAttributes the feature attributes

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -25,6 +25,8 @@
 #include "qgswmsrendercontext.h"
 #include "qgsfeaturefilter.h"
 #include "qgslayertreemodellegendnode.h"
+#include "qgsattributeeditorelement.h"
+#include "qgseditformconfig.h"
 #include <QDomDocument>
 #include <QMap>
 #include <QString>
@@ -50,8 +52,6 @@ class QImage;
 class QPaintDevice;
 class QPainter;
 class QgsLayerTreeGroup;
-class QgsEditFormConfig;
-class QgsAttributeEditorElement;
 
 namespace QgsWms
 {

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -25,7 +25,6 @@
 #include "qgswmsrendercontext.h"
 #include "qgsfeaturefilter.h"
 #include "qgslayertreemodellegendnode.h"
-#include "qgsattributeeditorelement.h"
 #include "qgseditformconfig.h"
 #include <QDomDocument>
 #include <QMap>
@@ -47,6 +46,8 @@ class QgsDxfExport;
 class QgsLayerTreeModel;
 class QgsLayerTree;
 class QgsServerInterface;
+class QgsAttributeEditorElement;
+class QgsEditFormConfig;
 
 class QImage;
 class QPaintDevice;

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -50,6 +50,8 @@ class QImage;
 class QPaintDevice;
 class QPainter;
 class QgsLayerTreeGroup;
+class QgsEditFormConfig;
+class QgsAttributeEditorElement;
 
 namespace QgsWms
 {
@@ -221,6 +223,11 @@ namespace QgsWms
                                        QgsRectangle *featureBBox = nullptr,
                                        QgsGeometry *filterGeom = nullptr ) const;
 
+      //!Recursively called to write tab layout groups to XML
+      void writeAttributesTabGroup( const QgsAttributeEditorElement *group, QgsVectorLayer *layer, const QgsFields &fields, QgsAttributes &featureAttributes, QDomDocument &doc, QDomElement &featureElem, QgsRenderContext &renderContext ) const;
+      //!Writes attributes to XML document using the group/attribute layout defined in the tab layout
+      void writeAttributesTabLayout( QgsEditFormConfig &config, QgsVectorLayer *layer, const QgsFields &fields, QgsAttributes &featureAttributes, QDomDocument &doc, QDomElement &featureElem, QgsRenderContext &renderContext ) const;
+      //! Writes a vectorlayer attribute into the XML document
       void writeVectorLayerAttribute( int attributeIndex, QgsVectorLayer *layer, const QgsFields &fields, QgsAttributes &featureAttributes, QDomDocument &doc, QDomElement &featureElem, QgsRenderContext &renderContext ) const;
 
       //! Appends feature info xml for the layer to the layer element of the dom document

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -249,7 +249,7 @@ namespace QgsWms
 
       /**
        * Writes a vectorlayer attribute into the XML document
-       * \param index of attribute to be written
+       * \param attributeindex of attribute to be written
        * \param layer The vector layer
        * \param fields attribute fields
        * \param featureAttributes the feature attributes

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -221,6 +221,8 @@ namespace QgsWms
                                        QgsRectangle *featureBBox = nullptr,
                                        QgsGeometry *filterGeom = nullptr ) const;
 
+      void writeVectorLayerAttribute( int attributeIndex, QgsVectorLayer *layer, const QgsFields &fields, QgsAttributes &featureAttributes, QDomDocument &doc, QDomElement &featureElem, QgsRenderContext &renderContext ) const;
+
       //! Appends feature info xml for the layer to the layer element of the dom document
       bool featureInfoFromRasterLayer( QgsRasterLayer *layer,
                                        const QgsMapSettings &mapSettings,

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -410,7 +410,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>98</width>
+                <width>77</width>
                 <height>47</height>
                </rect>
               </property>
@@ -584,7 +584,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>710</width>
+                <width>709</width>
                 <height>604</height>
                </rect>
               </property>
@@ -645,7 +645,7 @@
                    <widget class="QComboBox" name="mCameraNavigationModeCombo"/>
                   </item>
                   <item row="4" column="1" colspan="2">
-                   <widget class="QDoubleSpinBox" name="mCameraMovementSpeed">
+                   <widget class="QgsDoubleSpinBox" name="mCameraMovementSpeed">
                     <property name="minimum">
                      <double>0.010000000000000</double>
                     </property>

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -205,8 +205,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>309</width>
-                <height>292</height>
+                <width>341</width>
+                <height>301</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutTerrain">
@@ -410,8 +410,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>77</width>
-                <height>45</height>
+                <width>98</width>
+                <height>47</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutLight">
@@ -494,8 +494,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>140</width>
-                <height>45</height>
+                <width>151</width>
+                <height>47</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutShadow">
@@ -584,7 +584,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>704</width>
+                <width>710</width>
                 <height>604</height>
                </rect>
               </property>
@@ -642,18 +642,7 @@
                    </widget>
                   </item>
                   <item row="3" column="1" colspan="2">
-                   <widget class="QComboBox" name="mCameraNavigationMode">
-                    <item>
-                     <property name="text">
-                      <string>Terrain Based Navigation</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Fly Navigation</string>
-                     </property>
-                    </item>
-                   </widget>
+                   <widget class="QComboBox" name="mCameraNavigationModeCombo"/>
                   </item>
                   <item row="4" column="1" colspan="2">
                    <widget class="QDoubleSpinBox" name="mCameraMovementSpeed">
@@ -735,8 +724,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>277</width>
-                <height>681</height>
+                <width>304</width>
+                <height>701</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutAdvanced">

--- a/src/ui/3d/qgs3doptionsbase.ui
+++ b/src/ui/3d/qgs3doptionsbase.ui
@@ -69,12 +69,8 @@
            <string>Default Camera Settings</string>
           </property>
           <layout class="QGridLayout" name="gridLayout">
-           <item row="1" column="0">
-            <widget class="QLabel" name="labelCameraProjectionType">
-             <property name="text">
-              <string>Projection type</string>
-             </property>
-            </widget>
+           <item row="1" column="1" colspan="2">
+            <widget class="QComboBox" name="cboCameraProjectionType"/>
            </item>
            <item row="2" column="1" colspan="2">
             <widget class="QgsSpinBox" name="spinCameraFieldOfView">
@@ -86,20 +82,17 @@
              </property>
             </widget>
            </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="labelCameraProjectionType">
+             <property name="text">
+              <string>Projection type</string>
+             </property>
+            </widget>
+           </item>
            <item row="2" column="0">
             <widget class="QLabel" name="labelFieldofView">
              <property name="text">
               <string>Field of View</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1" colspan="2">
-            <widget class="QComboBox" name="cboCameraProjectionType"/>
-           </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="labelCameraNavigationMode">
-             <property name="text">
-              <string>Navigation mode</string>
              </property>
             </widget>
            </item>
@@ -119,12 +112,29 @@
              </property>
             </widget>
            </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="labelCameraNavigationMode">
+             <property name="text">
+              <string>Navigation mode</string>
+             </property>
+            </widget>
+           </item>
            <item row="4" column="0">
             <widget class="QLabel" name="labelMovementSpeed">
              <property name="text">
               <string>Movement speed</string>
              </property>
             </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="labelCameraNavigationMode_2">
+             <property name="text">
+              <string>Invert vertical axis</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1" colspan="2">
+            <widget class="QComboBox" name="mInvertVerticalAxisCombo"/>
            </item>
           </layout>
          </widget>

--- a/src/ui/3d/qgs3doptionsbase.ui
+++ b/src/ui/3d/qgs3doptionsbase.ui
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Qgs3DOptionsBase</class>
+ <widget class="QWidget" name="Qgs3DOptionsBase">
+  <property name="modal" stdset="0">
+   <bool>false</bool>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>677</width>
+    <height>298</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>3D Options</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_6">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QSplitter" name="mSplitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QScrollArea" name="scrollArea">
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="widgetResizable">
+       <bool>true</bool>
+      </property>
+      <widget class="QWidget" name="scrollAreaWidgetContents">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>677</width>
+         <height>298</height>
+        </rect>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item row="0" column="0">
+         <widget class="QGroupBox" name="cameraTerrain">
+          <property name="title">
+           <string>Default Camera Settings</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout">
+           <item row="1" column="0">
+            <widget class="QLabel" name="labelCameraProjectionType">
+             <property name="text">
+              <string>Projection type</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1" colspan="2">
+            <widget class="QgsSpinBox" name="spinCameraFieldOfView">
+             <property name="suffix">
+              <string>°</string>
+             </property>
+             <property name="maximum">
+              <number>180</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="labelFieldofView">
+             <property name="text">
+              <string>Field of View</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1" colspan="2">
+            <widget class="QComboBox" name="cboCameraProjectionType"/>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="labelCameraNavigationMode">
+             <property name="text">
+              <string>Navigation mode</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1" colspan="2">
+            <widget class="QComboBox" name="mCameraNavigationModeCombo"/>
+           </item>
+           <item row="4" column="1" colspan="2">
+            <widget class="QgsDoubleSpinBox" name="mCameraMovementSpeed">
+             <property name="minimum">
+              <double>0.010000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>1.000000000000000</double>
+             </property>
+             <property name="value">
+              <double>5.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="labelMovementSpeed">
+             <property name="text">
+              <string>Movement speed</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>scrollArea</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
+++ b/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
@@ -654,9 +654,6 @@ border-radius: 2px;</string>
                 <property name="toolTip">
                  <string>Reference time used to render mesh dataset when using temporal range or temporal animation</string>
                 </property>
-                <property name="displayFormat">
-                 <string>dd/MM/yyyy HH:mm:ss</string>
-                </property>
                 <property name="calendarPopup">
                  <bool>true</bool>
                 </property>
@@ -703,9 +700,6 @@ border-radius: 2px;</string>
                 <property name="buttonSymbols">
                  <enum>QAbstractSpinBox::NoButtons</enum>
                 </property>
-                <property name="displayFormat">
-                 <string>dd/MM/yyyy HH:mm:ss</string>
-                </property>
                </widget>
               </item>
               <item row="2" column="0">
@@ -737,9 +731,6 @@ border-radius: 2px;</string>
                 </property>
                 <property name="showGroupSeparator" stdset="0">
                  <bool>false</bool>
-                </property>
-                <property name="displayFormat">
-                 <string>dd/MM/yyyy HH:mm:ss</string>
                 </property>
                 <property name="timeSpec">
                  <enum>Qt::UTC</enum>

--- a/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
+++ b/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
@@ -654,6 +654,9 @@ border-radius: 2px;</string>
                 <property name="toolTip">
                  <string>Reference time used to render mesh dataset when using temporal range or temporal animation</string>
                 </property>
+                <property name="displayFormat">
+                 <string>dd/MM/yyyy HH:mm:ss</string>
+                </property>
                 <property name="calendarPopup">
                  <bool>true</bool>
                 </property>
@@ -700,6 +703,9 @@ border-radius: 2px;</string>
                 <property name="buttonSymbols">
                  <enum>QAbstractSpinBox::NoButtons</enum>
                 </property>
+                <property name="displayFormat">
+                 <string>dd/MM/yyyy HH:mm:ss</string>
+                </property>
                </widget>
               </item>
               <item row="2" column="0">
@@ -731,6 +737,9 @@ border-radius: 2px;</string>
                 </property>
                 <property name="showGroupSeparator" stdset="0">
                  <bool>false</bool>
+                </property>
+                <property name="displayFormat">
+                 <string>dd/MM/yyyy HH:mm:ss</string>
                 </property>
                 <property name="timeSpec">
                  <enum>Qt::UTC</enum>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -269,7 +269,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>2</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="mProjOptsGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -297,9 +297,9 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>-16</y>
+                <y>0</y>
                 <width>671</width>
-                <height>695</height>
+                <height>821</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout">
@@ -954,8 +954,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>337</width>
-                <height>74</height>
+                <width>692</width>
+                <height>673</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -1007,8 +1007,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>604</width>
-                <height>105</height>
+                <width>692</width>
+                <height>673</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -1067,8 +1067,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>291</width>
-                <height>563</height>
+                <width>692</width>
+                <height>673</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1643,8 +1643,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>179</width>
-                <height>56</height>
+                <width>692</width>
+                <height>673</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_17">
@@ -1705,8 +1705,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>653</width>
-                <height>3187</height>
+                <width>685</width>
+                <height>3591</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -2037,72 +2037,79 @@
                   <string notr="true">projowsserver</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_13">
-                  <item row="1" column="2">
-                   <widget class="QgsCollapsibleGroupBox" name="mLayerRestrictionsGroupBox">
-                    <property name="title">
-                     <string>Exclude layers</string>
+                  <item row="5" column="0" colspan="2">
+                   <widget class="QCheckBox" name="mAddWktGeometryCheckBox">
+                    <property name="text">
+                     <string>Add geometry to feature response</string>
                     </property>
-                    <property name="checkable">
-                     <bool>true</bool>
-                    </property>
-                    <property name="checked">
-                     <bool>false</bool>
-                    </property>
-                    <property name="collapsed" stdset="0">
-                     <bool>false</bool>
-                    </property>
-                    <property name="saveCollapsedState" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                    <layout class="QGridLayout" name="gridLayout">
-                     <item row="0" column="0" colspan="3">
-                      <widget class="QListWidget" name="mLayerRestrictionsListWidget"/>
-                     </item>
-                     <item row="1" column="0">
-                      <widget class="QToolButton" name="mAddLayerRestrictionButton">
-                       <property name="toolTip">
-                        <string>Add layer to exclude</string>
-                       </property>
-                       <property name="text">
-                        <string/>
-                       </property>
-                       <property name="icon">
-                        <iconset resource="../../images/images.qrc">
-                         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="1">
-                      <widget class="QToolButton" name="mRemoveLayerRestrictionButton">
-                       <property name="toolTip">
-                        <string>Remove selected layer</string>
-                       </property>
-                       <property name="text">
-                        <string/>
-                       </property>
-                       <property name="icon">
-                        <iconset resource="../../images/images.qrc">
-                         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="2">
-                      <spacer name="horizontalSpacer_3">
-                       <property name="orientation">
-                        <enum>Qt::Horizontal</enum>
-                       </property>
-                       <property name="sizeHint" stdset="0">
-                        <size>
-                         <width>0</width>
-                         <height>20</height>
-                        </size>
-                       </property>
-                      </spacer>
-                     </item>
-                    </layout>
                    </widget>
                   </item>
-                  <item row="8" column="0" colspan="3">
+                  <item row="10" column="0" colspan="3">
+                   <layout class="QHBoxLayout" name="horizontalLayout_10">
+                    <item>
+                     <widget class="QLabel" name="mWMSImageQualityLabel">
+                      <property name="text">
+                       <string>Quality for JPEG images ( 10 : smaller image - 100 : best quality )</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QgsSpinBox" name="mWMSImageQualitySpinBox">
+                      <property name="minimum">
+                       <number>10</number>
+                      </property>
+                      <property name="maximum">
+                       <number>100</number>
+                      </property>
+                      <property name="singleStep">
+                       <number>5</number>
+                      </property>
+                      <property name="value">
+                       <number>90</number>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="11" column="0" colspan="3">
+                   <layout class="QHBoxLayout" name="horizontalLayout_17">
+                    <item>
+                     <widget class="QLabel" name="mWMSMaxAtlasFeaturesLabel">
+                      <property name="text">
+                       <string>Maximum features for Atlas print requests</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QgsSpinBox" name="mWMSMaxAtlasFeaturesSpinBox">
+                      <property name="maximum">
+                       <number>9999999</number>
+                      </property>
+                      <property name="value">
+                       <number>1</number>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="12" column="0" colspan="3">
+                   <layout class="QHBoxLayout" name="horizontalLayout_18">
+                    <item>
+                     <widget class="QLabel" name="label_33">
+                      <property name="toolTip">
+                       <string>When using tiles set this to the size of the larger symbols to avoid cut symbols at tile boundaries. This works by drawing features that are outside the tile extent.</string>
+                      </property>
+                      <property name="text">
+                       <string>Tile buffer in pixels</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QgsSpinBox" name="mWMSTileBufferSpinBox"/>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="9" column="0" colspan="3">
                    <layout class="QGridLayout" name="gridLayout_3">
                     <item row="1" column="1">
                      <widget class="QLabel" name="mMaxWidthLabel">
@@ -2148,241 +2155,6 @@
                      </widget>
                     </item>
                    </layout>
-                  </item>
-                  <item row="0" column="2">
-                   <widget class="QgsCollapsibleGroupBox" name="grpWMSList">
-                    <property name="title">
-                     <string>CRS restrictions</string>
-                    </property>
-                    <property name="checkable">
-                     <bool>true</bool>
-                    </property>
-                    <property name="checked">
-                     <bool>false</bool>
-                    </property>
-                    <property name="collapsed" stdset="0">
-                     <bool>false</bool>
-                    </property>
-                    <property name="saveCollapsedState" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                    <layout class="QGridLayout" name="gridLayout_5">
-                     <item row="1" column="1">
-                      <widget class="QToolButton" name="pbnWMSRemoveSRS">
-                       <property name="toolTip">
-                        <string>Remove selected CRS</string>
-                       </property>
-                       <property name="icon">
-                        <iconset resource="../../images/images.qrc">
-                         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="0" colspan="4">
-                      <widget class="QListWidget" name="mWMSList"/>
-                     </item>
-                     <item row="1" column="2">
-                      <widget class="QPushButton" name="pbnWMSSetUsedSRS">
-                       <property name="toolTip">
-                        <string>Fetch all CRS's from layers</string>
-                       </property>
-                       <property name="text">
-                        <string>Used</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="0">
-                      <widget class="QToolButton" name="pbnWMSAddSRS">
-                       <property name="toolTip">
-                        <string>Add new CRS</string>
-                       </property>
-                       <property name="icon">
-                        <iconset resource="../../images/images.qrc">
-                         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item row="10" column="0" colspan="3">
-                   <layout class="QHBoxLayout" name="horizontalLayout_17">
-                    <item>
-                     <widget class="QLabel" name="mWMSMaxAtlasFeaturesLabel">
-                      <property name="text">
-                       <string>Maximum features for Atlas print requests</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QgsSpinBox" name="mWMSMaxAtlasFeaturesSpinBox">
-                      <property name="maximum">
-                       <number>9999999</number>
-                      </property>
-                      <property name="value">
-                       <number>1</number>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QCheckBox" name="mWmsUseLayerIDs">
-                    <property name="text">
-                     <string>Use layer ids as names</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="0" colspan="3">
-                   <layout class="QHBoxLayout" name="grpWMSPrecision">
-                    <item>
-                     <widget class="QLabel" name="label_5">
-                      <property name="text">
-                       <string>GetFeatureInfo geometry precision (decimal places)</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QgsSpinBox" name="mWMSPrecisionSpinBox">
-                      <property name="minimum">
-                       <number>1</number>
-                      </property>
-                      <property name="maximum">
-                       <number>17</number>
-                      </property>
-                      <property name="value">
-                       <number>8</number>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="12" column="0" colspan="3">
-                   <layout class="QHBoxLayout" name="mWMSDefaultMapUnitsPerMmLayout">
-                    <item>
-                     <widget class="QLabel" name="mWMSDefaultMapUnitsPerMmLabel">
-                      <property name="text">
-                       <string>Default map units per mm in legend</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="0" column="0" colspan="2">
-                   <widget class="QgsCollapsibleGroupBox" name="grpWMSExt">
-                    <property name="title">
-                     <string>Ad&amp;vertised extent</string>
-                    </property>
-                    <property name="checkable">
-                     <bool>true</bool>
-                    </property>
-                    <property name="checked">
-                     <bool>false</bool>
-                    </property>
-                    <property name="collapsed" stdset="0">
-                     <bool>false</bool>
-                    </property>
-                    <property name="saveCollapsedState" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                    <layout class="QGridLayout" name="gridLayout_4">
-                     <item row="0" column="1">
-                      <widget class="QLineEdit" name="mWMSExtMinX">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="0">
-                      <widget class="QLabel" name="label_17">
-                       <property name="text">
-                        <string>Min. &amp;Y</string>
-                       </property>
-                       <property name="buddy">
-                        <cstring>mWMSExtMinY</cstring>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="5" column="0" colspan="2">
-                      <spacer name="verticalSpacer_3">
-                       <property name="orientation">
-                        <enum>Qt::Vertical</enum>
-                       </property>
-                       <property name="sizeHint" stdset="0">
-                        <size>
-                         <width>20</width>
-                         <height>40</height>
-                        </size>
-                       </property>
-                      </spacer>
-                     </item>
-                     <item row="0" column="0">
-                      <widget class="QLabel" name="label_16">
-                       <property name="text">
-                        <string>Min. &amp;X</string>
-                       </property>
-                       <property name="buddy">
-                        <cstring>mWMSExtMinX</cstring>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="1">
-                      <widget class="QLineEdit" name="mWMSExtMinY">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="0">
-                      <widget class="QLabel" name="label_18">
-                       <property name="text">
-                        <string>Max. X</string>
-                       </property>
-                       <property name="buddy">
-                        <cstring>mWMSExtMaxX</cstring>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="4" column="0" colspan="2">
-                      <widget class="QPushButton" name="pbnWMSExtCanvas">
-                       <property name="text">
-                        <string>Use Current Canvas Extent</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="3" column="0">
-                      <widget class="QLabel" name="label_19">
-                       <property name="text">
-                        <string>Max. Y</string>
-                       </property>
-                       <property name="buddy">
-                        <cstring>mWMSExtMaxY</cstring>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="3" column="1">
-                      <widget class="QLineEdit" name="mWMSExtMaxY">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="1">
-                      <widget class="QLineEdit" name="mWMSExtMaxX">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item row="4" column="0" colspan="2">
-                   <widget class="QCheckBox" name="mAddWktGeometryCheckBox">
-                    <property name="text">
-                     <string>Add geometry to feature response</string>
-                    </property>
-                   </widget>
                   </item>
                   <item row="2" column="0" colspan="3">
                    <widget class="QgsCollapsibleGroupBox" name="mWMSInspire">
@@ -2516,12 +2288,201 @@
                     </layout>
                    </widget>
                   </item>
-                  <item row="5" column="0" colspan="2">
+                  <item row="0" column="2">
+                   <widget class="QgsCollapsibleGroupBox" name="grpWMSList">
+                    <property name="title">
+                     <string>CRS restrictions</string>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <property name="checked">
+                     <bool>false</bool>
+                    </property>
+                    <property name="collapsed" stdset="0">
+                     <bool>false</bool>
+                    </property>
+                    <property name="saveCollapsedState" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_5">
+                     <item row="1" column="1">
+                      <widget class="QToolButton" name="pbnWMSRemoveSRS">
+                       <property name="toolTip">
+                        <string>Remove selected CRS</string>
+                       </property>
+                       <property name="icon">
+                        <iconset resource="../../images/images.qrc">
+                         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="0" colspan="4">
+                      <widget class="QListWidget" name="mWMSList"/>
+                     </item>
+                     <item row="1" column="2">
+                      <widget class="QPushButton" name="pbnWMSSetUsedSRS">
+                       <property name="toolTip">
+                        <string>Fetch all CRS's from layers</string>
+                       </property>
+                       <property name="text">
+                        <string>Used</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="0">
+                      <widget class="QToolButton" name="pbnWMSAddSRS">
+                       <property name="toolTip">
+                        <string>Add new CRS</string>
+                       </property>
+                       <property name="icon">
+                        <iconset resource="../../images/images.qrc">
+                         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item row="0" column="0" colspan="2">
+                   <widget class="QgsCollapsibleGroupBox" name="grpWMSExt">
+                    <property name="title">
+                     <string>Ad&amp;vertised extent</string>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <property name="checked">
+                     <bool>false</bool>
+                    </property>
+                    <property name="collapsed" stdset="0">
+                     <bool>false</bool>
+                    </property>
+                    <property name="saveCollapsedState" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_4">
+                     <item row="0" column="1">
+                      <widget class="QLineEdit" name="mWMSExtMinX">
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="0">
+                      <widget class="QLabel" name="label_17">
+                       <property name="text">
+                        <string>Min. &amp;Y</string>
+                       </property>
+                       <property name="buddy">
+                        <cstring>mWMSExtMinY</cstring>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="5" column="0" colspan="2">
+                      <spacer name="verticalSpacer_3">
+                       <property name="orientation">
+                        <enum>Qt::Vertical</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>20</width>
+                         <height>40</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item row="0" column="0">
+                      <widget class="QLabel" name="label_16">
+                       <property name="text">
+                        <string>Min. &amp;X</string>
+                       </property>
+                       <property name="buddy">
+                        <cstring>mWMSExtMinX</cstring>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="1">
+                      <widget class="QLineEdit" name="mWMSExtMinY">
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="2" column="0">
+                      <widget class="QLabel" name="label_18">
+                       <property name="text">
+                        <string>Max. X</string>
+                       </property>
+                       <property name="buddy">
+                        <cstring>mWMSExtMaxX</cstring>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="4" column="0" colspan="2">
+                      <widget class="QPushButton" name="pbnWMSExtCanvas">
+                       <property name="text">
+                        <string>Use Current Canvas Extent</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="3" column="0">
+                      <widget class="QLabel" name="label_19">
+                       <property name="text">
+                        <string>Max. Y</string>
+                       </property>
+                       <property name="buddy">
+                        <cstring>mWMSExtMaxY</cstring>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="3" column="1">
+                      <widget class="QLineEdit" name="mWMSExtMaxY">
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="2" column="1">
+                      <widget class="QLineEdit" name="mWMSExtMaxX">
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item row="6" column="0" colspan="2">
                    <widget class="QCheckBox" name="mSegmentizeFeatureInfoGeometryCheckBox">
                     <property name="text">
                      <string>Segmentize feature info geometry</string>
                     </property>
                    </widget>
+                  </item>
+                  <item row="7" column="0" colspan="3">
+                   <layout class="QHBoxLayout" name="grpWMSPrecision">
+                    <item>
+                     <widget class="QLabel" name="label_5">
+                      <property name="text">
+                       <string>GetFeatureInfo geometry precision (decimal places)</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QgsSpinBox" name="mWMSPrecisionSpinBox">
+                      <property name="minimum">
+                       <number>1</number>
+                      </property>
+                      <property name="maximum">
+                       <number>17</number>
+                      </property>
+                      <property name="value">
+                       <number>8</number>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
                   </item>
                   <item row="1" column="0" colspan="2">
                    <widget class="QgsCollapsibleGroupBox" name="mWMSPrintLayoutGroupBox">
@@ -2588,7 +2549,7 @@
                     </layout>
                    </widget>
                   </item>
-                  <item row="7" column="0" colspan="2">
+                  <item row="8" column="0" colspan="2">
                    <layout class="QHBoxLayout" name="horizontalLayout_2">
                     <item>
                      <widget class="QLabel" name="mWMSUrlLabel">
@@ -2602,49 +2563,95 @@
                     </item>
                    </layout>
                   </item>
-                  <item row="9" column="0" colspan="3">
-                   <layout class="QHBoxLayout" name="horizontalLayout_10">
+                  <item row="3" column="0">
+                   <widget class="QCheckBox" name="mWmsUseLayerIDs">
+                    <property name="text">
+                     <string>Use layer ids as names</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="13" column="0" colspan="3">
+                   <layout class="QHBoxLayout" name="mWMSDefaultMapUnitsPerMmLayout">
                     <item>
-                     <widget class="QLabel" name="mWMSImageQualityLabel">
+                     <widget class="QLabel" name="mWMSDefaultMapUnitsPerMmLabel">
                       <property name="text">
-                       <string>Quality for JPEG images ( 10 : smaller image - 100 : best quality )</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QgsSpinBox" name="mWMSImageQualitySpinBox">
-                      <property name="minimum">
-                       <number>10</number>
-                      </property>
-                      <property name="maximum">
-                       <number>100</number>
-                      </property>
-                      <property name="singleStep">
-                       <number>5</number>
-                      </property>
-                      <property name="value">
-                       <number>90</number>
+                       <string>Default map units per mm in legend</string>
                       </property>
                      </widget>
                     </item>
                    </layout>
                   </item>
-                  <item row="11" column="0" colspan="3">
-                   <layout class="QHBoxLayout" name="horizontalLayout_18">
-                    <item>
-                     <widget class="QLabel" name="label_33">
-                      <property name="toolTip">
-                       <string>When using tiles set this to the size of the larger symbols to avoid cut symbols at tile boundaries. This works by drawing features that are outside the tile extent.</string>
-                      </property>
-                      <property name="text">
-                       <string>Tile buffer in pixels</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QgsSpinBox" name="mWMSTileBufferSpinBox"/>
-                    </item>
-                   </layout>
+                  <item row="1" column="2">
+                   <widget class="QgsCollapsibleGroupBox" name="mLayerRestrictionsGroupBox">
+                    <property name="title">
+                     <string>Exclude layers</string>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <property name="checked">
+                     <bool>false</bool>
+                    </property>
+                    <property name="collapsed" stdset="0">
+                     <bool>false</bool>
+                    </property>
+                    <property name="saveCollapsedState" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout">
+                     <item row="0" column="0" colspan="3">
+                      <widget class="QListWidget" name="mLayerRestrictionsListWidget"/>
+                     </item>
+                     <item row="1" column="0">
+                      <widget class="QToolButton" name="mAddLayerRestrictionButton">
+                       <property name="toolTip">
+                        <string>Add layer to exclude</string>
+                       </property>
+                       <property name="text">
+                        <string/>
+                       </property>
+                       <property name="icon">
+                        <iconset resource="../../images/images.qrc">
+                         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="1">
+                      <widget class="QToolButton" name="mRemoveLayerRestrictionButton">
+                       <property name="toolTip">
+                        <string>Remove selected layer</string>
+                       </property>
+                       <property name="text">
+                        <string/>
+                       </property>
+                       <property name="icon">
+                        <iconset resource="../../images/images.qrc">
+                         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="2">
+                      <spacer name="horizontalSpacer_3">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>0</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item row="4" column="0">
+                   <widget class="QCheckBox" name="mUseAttributeFormSettingsCheckBox">
+                    <property name="text">
+                     <string>Use attribute form settings for GetFeatureInfo response</string>
+                    </property>
+                   </widget>
                   </item>
                  </layout>
                 </widget>

--- a/tests/src/3d/CMakeLists.txt
+++ b/tests/src/3d/CMakeLists.txt
@@ -8,9 +8,6 @@ set (util_SRCS)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/tests/core #for render checker class
   ${CMAKE_SOURCE_DIR}/src/test
-  ${CMAKE_SOURCE_DIR}/src/native
-
-
   ${CMAKE_BINARY_DIR}/src/ui
   ${CMAKE_BINARY_DIR}/src/native
   ${CMAKE_CURRENT_BINARY_DIR}
@@ -44,7 +41,8 @@ macro (ADD_QGIS_TEST testname testsrc)
     ${GEOS_LIBRARY}
     ${GDAL_LIBRARY}
     qgis_core
-    qgis_3d)
+    qgis_3d
+    qgis_native)
   add_test(qgis_${testname} ${CMAKE_CURRENT_BINARY_DIR}/../../../output/bin/qgis_${testname} -maxwarnings 10000)
   target_link_libraries(qgis_${testname} qgis_native)
   add_test(qgis_${testname} ${CMAKE_CURRENT_BINARY_DIR}/../../../output/bin/qgis_${testname})

--- a/tests/src/analysis/CMakeLists.txt
+++ b/tests/src/analysis/CMakeLists.txt
@@ -8,8 +8,6 @@ set (util_SRCS)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_SOURCE_DIR}/src/test
-
-  ${CMAKE_BINARY_DIR}/src/analysis
 )
 
 if(HAVE_OPENCL)

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -2,21 +2,7 @@
 # Don't forget to include output directory, otherwise
 # the UI file won't be wrapped!
 include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_SOURCE_DIR}/src/ui
-  ${CMAKE_SOURCE_DIR}/src/python
-  ${CMAKE_SOURCE_DIR}/src/app
-  ${CMAKE_SOURCE_DIR}/src/app/attributeformconfig
-  ${CMAKE_SOURCE_DIR}/src/app/labeling
-  ${CMAKE_SOURCE_DIR}/src/app/mesh
-  ${CMAKE_SOURCE_DIR}/src/app/pluginmanager
   ${CMAKE_SOURCE_DIR}/src/test
-  ${CMAKE_SOURCE_DIR}/external/nmea
-
-  ${CMAKE_BINARY_DIR}/src/analysis
-  ${CMAKE_BINARY_DIR}/src/python
-  ${CMAKE_BINARY_DIR}/src/app
-  ${CMAKE_BINARY_DIR}/src/ui
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -5,15 +5,10 @@ set (util_SRCS)
 #####################################################
 # Don't forget to include output directory, otherwise
 # the UI file won't be wrapped!
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_SOURCE_DIR}/tests/core #for render checker class
+include_directories(
+  ${CMAKE_SOURCE_DIR}/tests/src/core #for render checker class
   ${CMAKE_SOURCE_DIR}/src/test
-  ${CMAKE_SOURCE_DIR}/src/native
 
-  ${CMAKE_BINARY_DIR}/src/analysis
-  ${CMAKE_BINARY_DIR}/src/ui
-  ${CMAKE_BINARY_DIR}/src/ui/auth
-  ${CMAKE_BINARY_DIR}/src/native
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
@@ -69,7 +64,8 @@ macro (ADD_QGIS_TEST testname testsrc)
     ${QWT_LIBRARY}
     qgis_analysis
     qgis_core
-    qgis_gui)
+    qgis_gui
+    qgis_native)
   add_test(qgis_${testname} ${CMAKE_CURRENT_BINARY_DIR}/../../../output/bin/qgis_${testname} -maxwarnings 10000)
   target_link_libraries(qgis_${testname} qgis_native)
   add_test(qgis_${testname} ${CMAKE_CURRENT_BINARY_DIR}/../../../output/bin/qgis_${testname})

--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
@@ -356,6 +356,87 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  urllib.parse.quote(':"NAME" = \'two\''),
                                  'wms_getfeatureinfo_filter_no_crs')
 
+    def testGetFeatureInfoOGCfilterJSON(self):
+        # OGC Filter test with info_format=application/json
+
+        # Test OGC filter with I/J and BBOX
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&LAYERS=testlayer%20%C3%A8%C3%A9&' +
+                                 'INFO_FORMAT=application%2Fjson&' +
+                                 'WIDTH=1266&HEIGHT=531&' +
+                                 'QUERY_LAYERS=testlayer%20%C3%A8%C3%A9&' +
+                                 'FEATURE_COUNT=10&' +
+                                 'CRS=EPSG:4326&' +
+                                 'BBOX=44.90139177500000045,8.20339159915254967,44.90148522499999473,8.20361440084745297&' +
+                                 'I=882&J=282&'
+                                 'FILTER=<Filter><PropertyIsEqualTo><PropertyName>id</PropertyName><Literal>2</Literal></PropertyIsEqualTo></Filter>', 'wms_getfeatureinfo_filter_ogc')
+
+        # Test OGC filter with I/J and BBOX, filter id 3: empty result
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&LAYERS=testlayer%20%C3%A8%C3%A9&' +
+                                 'INFO_FORMAT=application%2Fjson&' +
+                                 'WIDTH=1266&HEIGHT=531&' +
+                                 'QUERY_LAYERS=testlayer%20%C3%A8%C3%A9&' +
+                                 'FEATURE_COUNT=10&' +
+                                 'CRS=EPSG:4326&' +
+                                 'BBOX=44.90139177500000045,8.20339159915254967,44.90148522499999473,8.20361440084745297&' +
+                                 'I=882&J=282&'
+                                 'FILTER=<Filter><PropertyIsEqualTo><PropertyName>id</PropertyName><Literal>3</Literal></PropertyIsEqualTo></Filter>', 'wms_getfeatureinfo_filter_ogc_empty')
+
+        # Test OGC filter with no I/J and BBOX
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&LAYERS=testlayer%20%C3%A8%C3%A9&' +
+                                 'INFO_FORMAT=application%2Fjson&' +
+                                 'WIDTH=1266&HEIGHT=531&' +
+                                 'QUERY_LAYERS=testlayer%20%C3%A8%C3%A9&' +
+                                 'FEATURE_COUNT=10&' +
+                                 'CRS=EPSG:4326&' +
+                                 'FILTER=<Filter><PropertyIsEqualTo><PropertyName>id</PropertyName><Literal>2</Literal></PropertyIsEqualTo></Filter>', 'wms_getfeatureinfo_filter_ogc')
+
+        # Test OGC filter with no I/J and wrong BBOX
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&LAYERS=testlayer%20%C3%A8%C3%A9&' +
+                                 'INFO_FORMAT=application%2Fjson&' +
+                                 'WIDTH=1266&HEIGHT=531&' +
+                                 'QUERY_LAYERS=testlayer%20%C3%A8%C3%A9&' +
+                                 'FEATURE_COUNT=10&' +
+                                 'CRS=EPSG:4326&' +
+                                 'BBOX=46,9,47,10&' +
+                                 'FILTER=<Filter><PropertyIsEqualTo><PropertyName>id</PropertyName><Literal>2</Literal></PropertyIsEqualTo></Filter>', 'wms_getfeatureinfo_filter_ogc_empty')
+
+        # Test OGC filter with no I/J and BBOX plus complex OR filter
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&LAYERS=testlayer%20%C3%A8%C3%A9&' +
+                                 'INFO_FORMAT=application%2Fjson&' +
+                                 'WIDTH=1266&HEIGHT=531&' +
+                                 'QUERY_LAYERS=testlayer%20%C3%A8%C3%A9&' +
+                                 'FEATURE_COUNT=10&' +
+                                 'CRS=EPSG:4326&' +
+                                 'FILTER=<Filter><Or><PropertyIsEqualTo><PropertyName>id</PropertyName><Literal>2</Literal></PropertyIsEqualTo>' +
+                                 '<PropertyIsEqualTo><PropertyName>id</PropertyName><Literal>3</Literal></PropertyIsEqualTo></Or></Filter>', 'wms_getfeatureinfo_filter_ogc_complex')
+
+        # Test OGC filter with no I/J and BBOX plus complex AND filter
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&LAYERS=testlayer%20%C3%A8%C3%A9&' +
+                                 'INFO_FORMAT=application%2Fjson&' +
+                                 'WIDTH=1266&HEIGHT=531&' +
+                                 'QUERY_LAYERS=testlayer%20%C3%A8%C3%A9&' +
+                                 'FEATURE_COUNT=10&' +
+                                 'CRS=EPSG:4326&' +
+                                 'FILTER=<Filter><And><PropertyIsEqualTo><PropertyName>id</PropertyName><Literal>2</Literal></PropertyIsEqualTo>' +
+                                 '<PropertyIsEqualTo><PropertyName>id</PropertyName><Literal>3</Literal></PropertyIsEqualTo></And></Filter>', 'wms_getfeatureinfo_filter_ogc_empty')
+
+        # Test OGC filter with no I/J and BBOX plus complex AND filter
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&LAYERS=testlayer%20%C3%A8%C3%A9&' +
+                                 'INFO_FORMAT=application%2Fjson&' +
+                                 'WIDTH=1266&HEIGHT=531&' +
+                                 'QUERY_LAYERS=testlayer%20%C3%A8%C3%A9&' +
+                                 'FEATURE_COUNT=10&' +
+                                 'CRS=EPSG:4326&' +
+                                 'FILTER=<Filter><And><PropertyIsEqualTo><PropertyName>id</PropertyName><Literal>2</Literal></PropertyIsEqualTo>' +
+                                 '<PropertyIsEqualTo><PropertyName>name</PropertyName><Literal>two</Literal></PropertyIsEqualTo></And></Filter>', 'wms_getfeatureinfo_filter_ogc')
+
     def testGetFeatureInfoTolerance(self):
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=layer3&styles=&' +

--- a/tests/testdata/provider/testdata_pg.sh
+++ b/tests/testdata/provider/testdata_pg.sh
@@ -16,6 +16,7 @@ SCRIPTS="
   tests/testdata/provider/testdata_pg_json.sql
   tests/testdata/provider/testdata_pg_pointcloud.sql
   tests/testdata/provider/testdata_pg_bigint_pk.sql
+  tests/testdata/provider/testdata_pg_hasspatialindex.sql
 "
 
 SCRIPTS12="

--- a/tests/testdata/provider/testdata_pg_hasspatialindex.sql
+++ b/tests/testdata/provider/testdata_pg_hasspatialindex.sql
@@ -1,0 +1,16 @@
+--CREATE SCHEMA IF NOT EXISTS qgis_test;
+
+
+DROP TABLE IF EXISTS qgis_test.hspi_table;
+
+CREATE TABLE qgis_test.hspi_table
+(
+  id serial PRIMARY KEY,
+  geom_without_index geometry(Polygon,4326),
+  geom_with_index geometry(Polygon,4326)
+);
+CREATE INDEX hspi_index_1 ON qgis_test.hspi_table USING GIST (geom_with_index);
+
+CREATE MATERIALIZED view qgis_test.hspi_materialized_view AS SELECT * FROM qgis_test.hspi_table;
+CREATE INDEX hspi_index_2 ON qgis_test.hspi_materialized_view USING GIST (geom_with_index);
+

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_ogc.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_ogc.txt
@@ -1,0 +1,18 @@
+Content-Length: 250
+Content-Type: application/json; charset=utf-8
+
+{
+  "features": [
+    {
+      "geometry": null,
+      "id": "testlayer èé.1",
+      "properties": {
+        "id": 2,
+        "name": "two",
+        "utf8nameè": "two àò"
+      },
+      "type": "Feature"
+    }
+  ],
+  "type": "FeatureCollection"
+}

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_ogc_complex.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_ogc_complex.txt
@@ -1,0 +1,28 @@
+Content-Length: 454
+Content-Type: application/json; charset=utf-8
+
+{
+  "features": [
+    {
+      "geometry": null,
+      "id": "testlayer èé.1",
+      "properties": {
+        "id": 2,
+        "name": "two",
+        "utf8nameè": "two àò"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": null,
+      "id": "testlayer èé.2",
+      "properties": {
+        "id": 3,
+        "name": "three",
+        "utf8nameè": "three èé↓"
+      },
+      "type": "Feature"
+    }
+  ],
+  "type": "FeatureCollection"
+}

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_ogc_empty.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_ogc_empty.txt
@@ -1,0 +1,7 @@
+Content-Length: 51
+Content-Type: application/json; charset=utf-8
+
+{
+  "features": [],
+  "type": "FeatureCollection"
+}


### PR DESCRIPTION
With the drag and drop editor form, it  is possible to redorder attributes and/or add groups and subgroups  in the edit form. This  PR adds the feature that these settings can  also be used to  format the WMS GetFeatureInfo response. E.g. if we have Group1 with attributes 'id','text' and Subgroup1 with attribute 'description', the XML response will be:

GetFeatureInfoResponse&gt;
&lt;Layer name="test"&gt;
  &lt;Feature id="658"&gt;
    &lt;Group1&gt;
      &lt;Attribute name="id" value="658"/&gt;
      &lt;Attribute name="text" value="bla"/&gt;
      &lt;Subgroup1&gt;
        &lt;Attribute name="description" value="bla, bla, bla"/&gt;
      &lt;/Subgroup1&gt;
    &lt;/Group1&gt;
&lt;/Feature&gt;
&lt;/Layer&gt;
&lt;/GetFeatureInfoResponse&gt;

I'll also add a unit test later on.