### PR TITLE
display seconds in mesh layer properties

### DIFF
--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -107,6 +107,10 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   metadataFrame->setLayout( layout );
   mOptsPage_Metadata->setContentsMargins( 0, 0, 0, 0 );
 
+  mTemporalDateTimeStart->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
+  mTemporalDateTimeEnd->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
+  mTemporalDateTimeReference->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
+
   // update based on lyr's current state
   syncToLayer();
 

--- a/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
+++ b/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
@@ -654,9 +654,6 @@ border-radius: 2px;</string>
                 <property name="toolTip">
                  <string>Reference time used to render mesh dataset when using temporal range or temporal animation</string>
                 </property>
-                <property name="displayFormat">
-                 <string>dd/MM/yyyy HH:mm:ss</string>
-                </property>
                 <property name="calendarPopup">
                  <bool>true</bool>
                 </property>
@@ -703,9 +700,6 @@ border-radius: 2px;</string>
                 <property name="buttonSymbols">
                  <enum>QAbstractSpinBox::NoButtons</enum>
                 </property>
-                <property name="displayFormat">
-                 <string>dd/MM/yyyy HH:mm:ss</string>
-                </property>
                </widget>
               </item>
               <item row="2" column="0">
@@ -737,9 +731,6 @@ border-radius: 2px;</string>
                 </property>
                 <property name="showGroupSeparator" stdset="0">
                  <bool>false</bool>
-                </property>
-                <property name="displayFormat">
-                 <string>dd/MM/yyyy HH:mm:ss</string>
                 </property>
                 <property name="timeSpec">
                  <enum>Qt::UTC</enum>

--- a/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
+++ b/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
@@ -654,6 +654,9 @@ border-radius: 2px;</string>
                 <property name="toolTip">
                  <string>Reference time used to render mesh dataset when using temporal range or temporal animation</string>
                 </property>
+                <property name="displayFormat">
+                 <string>dd/MM/yyyy HH:mm:ss</string>
+                </property>
                 <property name="calendarPopup">
                  <bool>true</bool>
                 </property>
@@ -700,6 +703,9 @@ border-radius: 2px;</string>
                 <property name="buttonSymbols">
                  <enum>QAbstractSpinBox::NoButtons</enum>
                 </property>
+                <property name="displayFormat">
+                 <string>dd/MM/yyyy HH:mm:ss</string>
+                </property>
                </widget>
               </item>
               <item row="2" column="0">
@@ -731,6 +737,9 @@ border-radius: 2px;</string>
                 </property>
                 <property name="showGroupSeparator" stdset="0">
                  <bool>false</bool>
+                </property>
+                <property name="displayFormat">
+                 <string>dd/MM/yyyy HH:mm:ss</string>
                 </property>
                 <property name="timeSpec">
                  <enum>Qt::UTC</enum>


### PR DESCRIPTION
Seconds was not displayed in the temporal tab of the mesh layer properties widget. As some datasets could have this precision, with this PR, seconds are now displayed...
Also make the format time consistent with the temporal controller.