### PR TITLE
[processing] Allow for short description to have hyperlinks open in external browser

### DIFF
--- a/src/ui/processing/qgsprocessingalgorithmdialogbase.ui
+++ b/src/ui/processing/qgsprocessingalgorithmdialogbase.ui
@@ -177,6 +177,9 @@
       <property name="openLinks">
        <bool>false</bool>
       </property>
+      <property name="openExternalLinks">
+       <bool>true</bool>
+      </property>
      </widget>
     </widget>
    </item>


### PR DESCRIPTION
Fix processing algorithm's short description hyperlink(s) not opening in external  browser.