### PR TITLE
Fix suppressed Windows linker errors

### DIFF
--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -215,9 +215,6 @@ GENERATE_EXPORT_HEADER(
    BASE_NAME 3D
    EXPORT_FILE_NAME qgis_3d.h
 )
-if(MSVC)
-  set_target_properties(qgis_3d PROPERTIES LINK_FLAGS "/FORCE:MULTIPLE")
-endif()
 
 set(QGIS_3D_HDRS ${QGIS_3D_HDRS} ${CMAKE_CURRENT_BINARY_DIR}/qgis_3d.h)
 

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -456,9 +456,6 @@ GENERATE_EXPORT_HEADER(
    BASE_NAME ANALYSIS
    EXPORT_FILE_NAME qgis_analysis.h
 )
-if(MSVC)
-  set_target_properties(qgis_analysis PROPERTIES LINK_FLAGS "/FORCE:MULTIPLE")
-endif()
 
 set(QGIS_ANALYSIS_HDRS ${QGIS_ANALYSIS_HDRS} ${CMAKE_CURRENT_BINARY_DIR}/qgis_analysis.h)
 

--- a/src/core/qgsattributes.h
+++ b/src/core/qgsattributes.h
@@ -54,7 +54,7 @@ typedef QMap<int, QgsField> QgsFieldMap;
  * \note QgsAttributes is implemented as a Python list of Python objects.
  */
 #ifndef SIP_RUN
-class CORE_EXPORT QgsAttributes : public QVector<QVariant>
+class QgsAttributes : public QVector<QVariant>
 {
   public:
 
@@ -115,7 +115,7 @@ class CORE_EXPORT QgsAttributes : public QVector<QVariant>
      * \note not available in Python bindings
      * \since QGIS 3.0
      */
-    QgsAttributeMap toMap() const SIP_SKIP;
+    CORE_EXPORT QgsAttributeMap toMap() const SIP_SKIP;
 
     inline bool operator!=( const QgsAttributes &v ) const { return !( *this == v ); }
 };


### PR DESCRIPTION
Deriving `QgsAttributes` from `QVector<QVariant>` and then exporting the
whole `QgsAttributes` class also exports symbols of `QVector<QVariant>`.
This leads to linker issues with object files using `QVector<QVariant>`
if a library/executable links against `qgis_core`.

Just exporting the only function of `QgsAttributes` that is not inline is
sufficient and solves the linker errors.
