### PR TITLE
[processing] Improve atlas exporting feedback

### DIFF
--- a/src/analysis/processing/qgsalgorithmlayoutatlastoimage.cpp
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastoimage.cpp
@@ -217,30 +217,38 @@ QVariantMap QgsLayoutAtlasToImageAlgorithm::processAlgorithm( const QVariantMap 
     }
   }
 
-  switch ( exporter.exportToImage( atlas, fileName, extension, settings, error, feedback ) )
+  if ( atlas->updateFeatures() )
   {
-    case QgsLayoutExporter::Success:
+    feedback->pushInfo( QObject::tr( "Exporting %n atlas feature(s)", "", atlas->count() ) );
+    switch ( exporter.exportToImage( atlas, fileName, extension, settings, error, feedback ) )
     {
-      feedback->pushInfo( QObject::tr( "Successfully exported layout to %1" ).arg( QDir::toNativeSeparators( directory ) ) );
-      break;
+      case QgsLayoutExporter::Success:
+      {
+        feedback->pushInfo( QObject::tr( "Successfully exported layout to %1" ).arg( QDir::toNativeSeparators( directory ) ) );
+        break;
+      }
+
+      case QgsLayoutExporter::FileError:
+        throw QgsProcessingException( QObject::tr( "Cannot write to %1.\n\nThis file may be open in another application." ).arg( QDir::toNativeSeparators( directory ) ) );
+
+      case QgsLayoutExporter::MemoryError:
+        throw QgsProcessingException( QObject::tr( "Trying to create the image "
+                                      "resulted in a memory overflow.\n\n"
+                                      "Please try a lower resolution or a smaller paper size." ) );
+
+      case QgsLayoutExporter::IteratorError:
+        throw QgsProcessingException( QObject::tr( "Error encountered while exporting atlas." ) );
+
+      case QgsLayoutExporter::SvgLayerError:
+      case QgsLayoutExporter::PrintError:
+      case QgsLayoutExporter::Canceled:
+        // no meaning for imageexports, will not be encountered
+        break;
     }
-
-    case QgsLayoutExporter::FileError:
-      throw QgsProcessingException( QObject::tr( "Cannot write to %1.\n\nThis file may be open in another application." ).arg( QDir::toNativeSeparators( directory ) ) );
-
-    case QgsLayoutExporter::MemoryError:
-      throw QgsProcessingException( QObject::tr( "Trying to create the image "
-                                    "resulted in a memory overflow.\n\n"
-                                    "Please try a lower resolution or a smaller paper size." ) );
-
-    case QgsLayoutExporter::IteratorError:
-      throw QgsProcessingException( QObject::tr( "Error encountered while exporting atlas." ) );
-
-    case QgsLayoutExporter::SvgLayerError:
-    case QgsLayoutExporter::PrintError:
-    case QgsLayoutExporter::Canceled:
-      // no meaning for imageexports, will not be encountered
-      break;
+  }
+  else
+  {
+    feedback->reportError( QObject::tr( "No atlas features found" ) );
   }
 
   feedback->setProgress( 100 );

--- a/src/analysis/processing/qgsalgorithmlayoutatlastopdf.cpp
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastopdf.cpp
@@ -201,32 +201,40 @@ QVariantMap QgsLayoutAtlasToPdfAlgorithm::processAlgorithm( const QVariantMap &p
   }
 
   const QString dest = parameterAsFileOutput( parameters, QStringLiteral( "OUTPUT" ), context );
-  switch ( exporter.exportToPdf( atlas, dest, settings, error, feedback ) )
+  if ( atlas->updateFeatures() )
   {
-    case QgsLayoutExporter::Success:
+    feedback->pushInfo( QObject::tr( "Exporting %n atlas feature(s)", "", atlas->count() ) );
+    switch ( exporter.exportToPdf( atlas, dest, settings, error, feedback ) )
     {
-      feedback->pushInfo( QObject::tr( "Successfully exported layout to %1" ).arg( QDir::toNativeSeparators( dest ) ) );
-      break;
+      case QgsLayoutExporter::Success:
+      {
+        feedback->pushInfo( QObject::tr( "Successfully exported layout to %1" ).arg( QDir::toNativeSeparators( dest ) ) );
+        break;
+      }
+
+      case QgsLayoutExporter::FileError:
+        throw QgsProcessingException( QObject::tr( "Cannot write to %1.\n\nThis file may be open in another application." ).arg( QDir::toNativeSeparators( dest ) ) );
+
+      case QgsLayoutExporter::PrintError:
+        throw QgsProcessingException( QObject::tr( "Could not create print device." ) );
+
+      case QgsLayoutExporter::MemoryError:
+        throw QgsProcessingException( QObject::tr( "Trying to create the image "
+                                      "resulted in a memory overflow.\n\n"
+                                      "Please try a lower resolution or a smaller paper size." ) );
+
+      case QgsLayoutExporter::IteratorError:
+        throw QgsProcessingException( QObject::tr( "Error encountered while exporting atlas." ) );
+
+      case QgsLayoutExporter::SvgLayerError:
+      case QgsLayoutExporter::Canceled:
+        // no meaning for imageexports, will not be encountered
+        break;
     }
-
-    case QgsLayoutExporter::FileError:
-      throw QgsProcessingException( QObject::tr( "Cannot write to %1.\n\nThis file may be open in another application." ).arg( QDir::toNativeSeparators( dest ) ) );
-
-    case QgsLayoutExporter::PrintError:
-      throw QgsProcessingException( QObject::tr( "Could not create print device." ) );
-
-    case QgsLayoutExporter::MemoryError:
-      throw QgsProcessingException( QObject::tr( "Trying to create the image "
-                                    "resulted in a memory overflow.\n\n"
-                                    "Please try a lower resolution or a smaller paper size." ) );
-
-    case QgsLayoutExporter::IteratorError:
-      throw QgsProcessingException( QObject::tr( "Error encountered while exporting atlas." ) );
-
-    case QgsLayoutExporter::SvgLayerError:
-    case QgsLayoutExporter::Canceled:
-      // no meaning for imageexports, will not be encountered
-      break;
+  }
+  else
+  {
+    feedback->reportError( QObject::tr( "No atlas features found" ) );
   }
 
   feedback->setProgress( 100 );


### PR DESCRIPTION
## Description

This PR adds an information message in the export atlas to image/PDF algorithm printed in the console to let users know whether they are about to wait for two or 200 atlas layouts to export.

It also moves away from throwing a fatal error when no atlas features are present. Instead, a non fatal error is reported to the console. 