### PR TITLE
[processing] Fix file download algorithm's temporary file missing proper extension

### DIFF
--- a/python/core/auto_generated/network/qgsfiledownloader.sip.in
+++ b/python/core/auto_generated/network/qgsfiledownloader.sip.in
@@ -38,13 +38,20 @@ An optional authentication configuration can be specified.
 %Docstring
 QgsFileDownloader
 
-:param url: the download url
+:param url: the download URL
 :param outputFileName: file name where the downloaded content will be stored
 :param authcfg: optionally apply this authentication configuration
 :param delayStart: if ``True``, the download will not be commenced immediately and must
                    be triggered by a later call to :py:func:`~QgsFileDownloader.startDownload`. This can be useful if connections need
                    to be made to the downloader and there's a chance the download will emit
                    signals before these connections have been made.
+%End
+
+    const QUrl downloadedUrl() const;
+%Docstring
+Returns the downloaded URL, which can differ from the original URL if redirects occurred.
+
+.. versionadded:: 3.18
 %End
 
   signals:

--- a/src/analysis/processing/qgsalgorithmfiledownloader.cpp
+++ b/src/analysis/processing/qgsalgorithmfiledownloader.cpp
@@ -93,6 +93,21 @@ QVariantMap QgsFileDownloaderAlgorithm::processAlgorithm( const QVariantMap &par
   if ( !feedback->isCanceled() && !exists )
     throw QgsProcessingException( tr( "Output file doesn't exist." ) );
 
+  if ( outputFile.startsWith( QgsProcessingUtils::tempFolder() ) )
+  {
+    // the output is temporary and its file name automatically generated, try to add a file extension
+    const QString downloadedUrl = downloader->downloadedUrl().toDisplayString();
+    const int length = downloadedUrl.size();
+    const int lastDotIndex = downloadedUrl.lastIndexOf( "." );
+    const int lastSlashIndex = downloadedUrl.lastIndexOf( "/" );
+    if ( lastDotIndex > -1 && lastDotIndex > lastSlashIndex && length - lastDotIndex <= 6 )
+    {
+      QFile tmpFile( outputFile );
+      tmpFile.rename( tmpFile.fileName() + downloadedUrl.mid( lastDotIndex ) );
+      outputFile += downloadedUrl.mid( lastDotIndex );
+    }
+  }
+
   QVariantMap outputs;
   outputs.insert( QStringLiteral( "OUTPUT" ), exists ? outputFile : QString() );
   return outputs;

--- a/src/core/network/qgsfiledownloader.cpp
+++ b/src/core/network/qgsfiledownloader.cpp
@@ -45,6 +45,10 @@ QgsFileDownloader::~QgsFileDownloader()
   }
 }
 
+const QUrl QgsFileDownloader::downloadedUrl() const
+{
+  return mReply ? mReply->url() : QUrl();
+}
 
 void QgsFileDownloader::startDownload()
 {

--- a/src/core/network/qgsfiledownloader.h
+++ b/src/core/network/qgsfiledownloader.h
@@ -47,7 +47,7 @@ class CORE_EXPORT QgsFileDownloader : public QObject
 
     /**
      * QgsFileDownloader
-     * \param url the download url
+     * \param url the download URL
      * \param outputFileName file name where the downloaded content will be stored
      * \param authcfg optionally apply this authentication configuration
      * \param delayStart if TRUE, the download will not be commenced immediately and must
@@ -56,6 +56,12 @@ class CORE_EXPORT QgsFileDownloader : public QObject
      * signals before these connections have been made.
      */
     QgsFileDownloader( const QUrl &url, const QString &outputFileName, const QString &authcfg = QString(), bool delayStart = false );
+
+    /**
+     * Returns the downloaded URL, which can differ from the original URL if redirects occurred.
+     * \since QGIS 3.18
+     */
+    const QUrl downloadedUrl() const;
 
   signals:
     //! Emitted when the download has completed successfully

--- a/tests/src/analysis/testqgsprocessingalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingalgs.cpp
@@ -176,6 +176,8 @@ class TestQgsProcessingAlgs: public QObject
     void exportMeshCrossSection();
     void exportMeshTimeSeries();
 
+    void fileDownloader();
+
   private:
 
     bool imageCheck( const QString &testName, const QString &renderedImage );
@@ -6464,6 +6466,26 @@ void TestQgsProcessingAlgs::exportMeshCrossSection()
   }
 
   QVERIFY( i == expectedLines.count() );
+}
+
+void TestQgsProcessingAlgs::fileDownloader()
+{
+  std::unique_ptr< QgsProcessingAlgorithm > alg( QgsApplication::processingRegistry()->createAlgorithmById( QStringLiteral( "native:filedownloader" ) ) );
+  QVERIFY( alg != nullptr );
+
+  QVariantMap parameters;
+  parameters.insert( QStringLiteral( "URL" ), QStringLiteral( "https://version.qgis.org/version.txt" ) );
+  parameters.insert( QStringLiteral( "OUTPUT" ), QgsProcessing::TEMPORARY_OUTPUT );
+
+  std::unique_ptr< QgsProcessingContext > context = qgis::make_unique< QgsProcessingContext >();
+  QgsProcessingFeedback feedback;
+  QVariantMap results;
+  bool ok = false;
+
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( ok );
+  // verify that temporary outputs have the URL file extension appended
+  QVERIFY( results.value( QStringLiteral( "OUTPUT" ) ).toString().endsWith( QStringLiteral( ".txt" ) ) );
 }
 
 void TestQgsProcessingAlgs::exportMeshTimeSeries()


### PR DESCRIPTION
## Description

This PR fixes and issue with the file download algorithm whereas temporary outputs did not (try to) match the download file extension. Instead, the file temporary file extension would always be .file, breaking file association by extension when the algorithm was used as part of a model. E.g., you could be downloading 'https://www.my.com/places.kml' and not able to add this downloaded file as a layer due to its temporary name having a .file extension.

