### PR TITLE
Fps navigation improvements

### DIFF
--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -676,18 +676,20 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
     return;
   }
 
-  if ( hasRightButton )
+  if ( hasMiddleButton )
   {
+    // middle button drag = pan camera in place (strafe)
     QVector3D cameraUp = mCamera->upVector().normalized();
     QVector3D cameraFront = ( QVector3D( mCameraPose.centerPoint().x(), mCameraPose.centerPoint().y(), mCameraPose.centerPoint().z() ) - mCamera->position() ).normalized();
     QVector3D cameraLeft = QVector3D::crossProduct( cameraUp, cameraFront );
     QVector3D cameraPosDiff = -dx * cameraLeft - dy * cameraUp;
     moveCameraPositionBy( mCameraMovementSpeed * cameraPosDiff / 10.0 );
   }
-  else if ( hasMiddleButton )
+  else if ( hasRightButton )
   {
+    // right button drag = camera dolly
     QVector3D cameraFront = ( QVector3D( mCameraPose.centerPoint().x(), mCameraPose.centerPoint().y(), mCameraPose.centerPoint().z() ) - mCamera->position() ).normalized();
-    QVector3D cameraPosDiff = -dy * cameraFront;
+    QVector3D cameraPosDiff = dy * cameraFront;
     moveCameraPositionBy( mCameraMovementSpeed * cameraPosDiff / 5.0 );
   }
   else

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -116,6 +116,7 @@ void Qgs3DMapCanvas::setMap( Qgs3DMapSettings *map )
     QCursor::setPos( mapToGlobal( point ) );
   } );
   connect( cameraController(), &QgsCameraController::cameraMovementSpeedChanged, mMap, &Qgs3DMapSettings::setCameraMovementSpeed );
+  connect( cameraController(), &QgsCameraController::cameraMovementSpeedChanged, this, &Qgs3DMapCanvas::cameraNavigationSpeedChanged );
   connect( cameraController(), &QgsCameraController::navigationModeHotKeyPressed, this, &Qgs3DMapCanvas::onNavigationModeHotKeyPressed );
 
   emit mapSettingsChanged();

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -104,6 +104,14 @@ class Qgs3DMapCanvas : public QWidget
     void fpsCountChanged( float fpsCount );
     //! Emitted when the FPS counter is enabled or disabeld
     void fpsCounterEnabledChanged( bool enabled );
+
+    /**
+     * Emitted when the camera navigation \a speed is changed.
+     *
+     * \since QGIS 3.18
+     */
+    void cameraNavigationSpeedChanged( double speed );
+
   private slots:
     void updateTemporalRange( const QgsDateTimeRange &timeRange );
     void onNavigationModeHotKeyPressed( QgsCameraController::NavigationMode mode );

--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -178,6 +178,7 @@ Qgs3DMapCanvasDockWidget::Qgs3DMapCanvasDockWidget( QWidget *parent )
   mProgressPendingJobs = new QProgressBar( this );
   mProgressPendingJobs->setRange( 0, 0 );
   mLabelFpsCounter = new QLabel( this );
+  mLabelNavigationSpeed = new QLabel( this );
 
   mAnimationWidget = new Qgs3DAnimationWidget( this );
   mAnimationWidget->setVisible( false );
@@ -189,7 +190,17 @@ Qgs3DMapCanvasDockWidget::Qgs3DMapCanvasDockWidget( QWidget *parent )
   topLayout->addStretch( 1 );
   topLayout->addWidget( mLabelPendingJobs );
   topLayout->addWidget( mProgressPendingJobs );
+  topLayout->addWidget( mLabelNavigationSpeed );
+  mLabelNavigationSpeed->hide();
   topLayout->addWidget( mLabelFpsCounter );
+
+  mLabelNavSpeedHideTimeout = new QTimer( this );
+  mLabelNavSpeedHideTimeout->setInterval( 1000 );
+  connect( mLabelNavSpeedHideTimeout, &QTimer::timeout, this, [ = ]
+  {
+    mLabelNavigationSpeed->hide();
+    mLabelNavSpeedHideTimeout->stop();
+  } );
 
   QVBoxLayout *layout = new QVBoxLayout;
   layout->setContentsMargins( 0, 0, 0, 0 );
@@ -283,6 +294,8 @@ void Qgs3DMapCanvasDockWidget::setMapSettings( Qgs3DMapSettings *map )
   // Disable button for switching the map theme if the terrain generator is a mesh
   mBtnMapThemes->setDisabled( mCanvas->map()->terrainGenerator()->type() == QgsTerrainGenerator::Mesh );
   mLabelFpsCounter->setVisible( map->isFpsCounterEnabled() );
+
+  connect( mCanvas, &Qgs3DMapCanvas::cameraNavigationSpeedChanged, this, &Qgs3DMapCanvasDockWidget::cameraNavigationSpeedChanged );
 }
 
 void Qgs3DMapCanvasDockWidget::setMainCanvas( QgsMapCanvas *canvas )
@@ -410,6 +423,13 @@ void Qgs3DMapCanvasDockWidget::onTotalPendingJobsCountChanged()
 void Qgs3DMapCanvasDockWidget::updateFpsCount( float fpsCount )
 {
   mLabelFpsCounter->setText( QStringLiteral( "%1 fps" ).arg( fpsCount, 10, 'f', 2, QLatin1Char( ' ' ) ) );
+}
+
+void Qgs3DMapCanvasDockWidget::cameraNavigationSpeedChanged( double speed )
+{
+  mLabelNavigationSpeed->setText( QStringLiteral( "Speed: %1 ×" ).arg( QString::number( speed, 'f', 2 ) ) );
+  mLabelNavigationSpeed->show();
+  mLabelNavSpeedHideTimeout->start();
 }
 
 void Qgs3DMapCanvasDockWidget::mapThemeMenuAboutToShow()

--- a/src/app/3d/qgs3dmapcanvasdockwidget.h
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.h
@@ -67,6 +67,7 @@ class APP_EXPORT Qgs3DMapCanvasDockWidget : public QgsDockWidget
     void onMainCanvasColorChanged();
     void onTotalPendingJobsCountChanged();
     void updateFpsCount( float fpsCount );
+    void cameraNavigationSpeedChanged( double speed );
     void mapThemeMenuAboutToShow();
     //! Renames the active map theme called \a theme to \a newTheme
     void currentMapThemeRenamed( const QString &theme, const QString &newTheme );
@@ -78,6 +79,8 @@ class APP_EXPORT Qgs3DMapCanvasDockWidget : public QgsDockWidget
     QProgressBar *mProgressPendingJobs = nullptr;
     QLabel *mLabelPendingJobs = nullptr;
     QLabel *mLabelFpsCounter = nullptr;
+    QLabel *mLabelNavigationSpeed = nullptr;
+    QTimer *mLabelNavSpeedHideTimeout = nullptr;
     Qgs3DMapToolIdentify *mMapToolIdentify = nullptr;
     Qgs3DMapToolMeasureLine *mMapToolMeasureLine = nullptr;
     QMenu *mMapThemeMenu = nullptr;


### PR DESCRIPTION
Make right and middle mouse drag while in fly mode behavior consistent with other parts of qgis

Now
- right click+drag = camera dolly, to match the same behavior
as when in terrain navigation mode
- middle click+drag = pan camera left/right/up/down, which matches
the middle click+drag behavior for 2d maps

Also show a movement speed label temporarily after the movement speed is changed in 3d views via scroll wheel, to expose to users what the scroll wheel is actually doing in this mode