### PR TITLE
[Bug] Display message on overly big images

### DIFF
--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -27,6 +27,7 @@
 #include "qgsfeedback.h"
 #include "qgslayoutgeopdfexporter.h"
 #include "qgslinestring.h"
+#include "qgsmessagelog.h"
 #include <QImageWriter>
 #include <QSize>
 #include <QSvgGenerator>
@@ -292,6 +293,8 @@ QImage QgsLayoutExporter::renderRegionToImage( const QRectF &region, QSize image
   QImage image( QSize( width, height ), QImage::Format_ARGB32 );
   if ( !image.isNull() )
   {
+    if ( ( width * height ) > 32768 )
+      QgsMessageLog::logMessage( QObject::tr( "Error: output is bigger than 32768 pixel, result will be clipped" ) );
     image.setDotsPerMeterX( static_cast< int >( std::round( resolution / 25.4 * 1000 ) ) );
     image.setDotsPerMeterY( static_cast< int>( std::round( resolution / 25.4 * 1000 ) ) );
     image.fill( Qt::transparent );

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -293,8 +293,9 @@ QImage QgsLayoutExporter::renderRegionToImage( const QRectF &region, QSize image
   QImage image( QSize( width, height ), QImage::Format_ARGB32 );
   if ( !image.isNull() )
   {
-    if ( ( width * height ) > 32768 )
-      QgsMessageLog::logMessage( QObject::tr( "Error: output is bigger than 32768 pixel, result will be clipped" ) );
+    // see https://doc.qt.io/qt-5/qpainter.html#limitations
+    if ( width > 32768 || height > 32768 )
+      QgsMessageLog::logMessage( QObject::tr( "Error: output width or height is larger than 32768 pixel, result will be clipped" ) );
     image.setDotsPerMeterX( static_cast< int >( std::round( resolution / 25.4 * 1000 ) ) );
     image.setDotsPerMeterY( static_cast< int>( std::round( resolution / 25.4 * 1000 ) ) );
     image.fill( Qt::transparent );


### PR DESCRIPTION
Fixes #41045

## Description

This simply adds a message if the output size exceeds the maximum supported size for a qpainter as stated in https://doc.qt.io/qt-5/qpainter.html#limitations .

I'm not sure if this should be added elsewhere. Maybe there could be a workaround to this issue, but as a simple solution, this should prevent any surprises.
