### PR TITLE
Fix elevation offset application bug and add color ramp missing attributes

### DIFF
--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -40,7 +40,7 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
   mColorRampShaderMaxEdit->setShowClearButton( false );
 
   mRenderingParameterComboBox->setLayer( layer );
-  mRenderingParameterComboBox->setFilters( QgsPointCloudAttributeProxyModel::Numeric );
+  mRenderingParameterComboBox->setFilters( QgsPointCloudAttributeProxyModel::AllTypes );
   mRenderingParameterComboBox->setAllowEmptyAttributeName( false );
 
   mSingleColorBtn->setAllowOpacity( false );

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -468,10 +468,13 @@ void QgsPointCloud3DSymbolWidget::rampAttributeChanged()
       mProviderMax = std::numeric_limits< double >::quiet_NaN();
     }
 
-    const double zScale = static_cast< const QgsPointCloudLayerElevationProperties * >( mLayer->elevationProperties() )->zScale();
-    const double zOffset = static_cast< const QgsPointCloudLayerElevationProperties * >( mLayer->elevationProperties() )->zOffset();
-    mProviderMin = mProviderMin * zScale + zOffset;
-    mProviderMax = mProviderMax * zScale + zOffset;
+    if ( mRenderingParameterComboBox->currentAttribute() == QStringLiteral( "Z" ) )
+    {
+      const double zScale = static_cast< const QgsPointCloudLayerElevationProperties * >( mLayer->elevationProperties() )->zScale();
+      const double zOffset = static_cast< const QgsPointCloudLayerElevationProperties * >( mLayer->elevationProperties() )->zOffset();
+      mProviderMin = mProviderMin * zScale + zOffset;
+      mProviderMax = mProviderMax * zScale + zOffset;
+    }
   }
   mScalarRecalculateMinMaxButton->setEnabled( !std::isnan( mProviderMin ) && !std::isnan( mProviderMax ) );
   emitChangedSignal();

--- a/src/gui/pointcloud/qgspointcloudattributebyramprendererwidget.cpp
+++ b/src/gui/pointcloud/qgspointcloudattributebyramprendererwidget.cpp
@@ -31,7 +31,7 @@ QgsPointCloudAttributeByRampRendererWidget::QgsPointCloudAttributeByRampRenderer
   setupUi( this );
 
   mAttributeComboBox->setAllowEmptyAttributeName( false );
-  mAttributeComboBox->setFilters( QgsPointCloudAttributeProxyModel::Numeric );
+  mAttributeComboBox->setFilters( QgsPointCloudAttributeProxyModel::AllTypes );
 
   mMinSpin->setShowClearButton( false );
   mMaxSpin->setShowClearButton( false );


### PR DESCRIPTION
## Description

- Fix the bug where the elvation offset and scale is applied to all attributes in 3D color ramp
- Use Char attribute types because it can mean a value from 0 to 255.