### PR TITLE
follow up ab0eba2 : crash-free implementation

### DIFF
--- a/python/core/auto_generated/network/qgsfiledownloader.sip.in
+++ b/python/core/auto_generated/network/qgsfiledownloader.sip.in
@@ -47,15 +47,8 @@ QgsFileDownloader
                    signals before these connections have been made.
 %End
 
-    const QUrl downloadedUrl() const;
-%Docstring
-Returns the downloaded URL, which can differ from the original URL if redirects occurred.
-
-.. versionadded:: 3.18
-%End
-
   signals:
-    void downloadCompleted();
+    void downloadCompleted( const QUrl &url );
 %Docstring
 Emitted when the download has completed successfully
 %End

--- a/src/analysis/processing/qgsalgorithmfiledownloader.cpp
+++ b/src/analysis/processing/qgsalgorithmfiledownloader.cpp
@@ -77,10 +77,12 @@ QVariantMap QgsFileDownloaderAlgorithm::processAlgorithm( const QVariantMap &par
 
   QEventLoop loop;
   QTimer timer;
+  QUrl downloadedUrl;
   QgsFileDownloader *downloader = new QgsFileDownloader( QUrl( url ), outputFile, QString(), true );
   connect( mFeedback, &QgsFeedback::canceled, downloader, &QgsFileDownloader::cancelDownload );
   connect( downloader, &QgsFileDownloader::downloadError, this, &QgsFileDownloaderAlgorithm::reportErrors );
   connect( downloader, &QgsFileDownloader::downloadProgress, this, &QgsFileDownloaderAlgorithm::receiveProgressFromDownloader );
+  connect( downloader, &QgsFileDownloader::downloadCompleted, this, [&downloadedUrl]( const QUrl url ) { downloadedUrl = url; } );
   connect( downloader, &QgsFileDownloader::downloadExited, &loop, &QEventLoop::quit );
   connect( &timer, &QTimer::timeout, this, &QgsFileDownloaderAlgorithm::sendProgressFeedback );
   downloader->startDownload();
@@ -96,15 +98,15 @@ QVariantMap QgsFileDownloaderAlgorithm::processAlgorithm( const QVariantMap &par
   if ( outputFile.startsWith( QgsProcessingUtils::tempFolder() ) )
   {
     // the output is temporary and its file name automatically generated, try to add a file extension
-    const QString downloadedUrl = downloader->downloadedUrl().toDisplayString();
-    const int length = downloadedUrl.size();
-    const int lastDotIndex = downloadedUrl.lastIndexOf( "." );
-    const int lastSlashIndex = downloadedUrl.lastIndexOf( "/" );
+    url = downloadedUrl.toDisplayString();
+    const int length = url.size();
+    const int lastDotIndex = url.lastIndexOf( "." );
+    const int lastSlashIndex = url.lastIndexOf( "/" );
     if ( lastDotIndex > -1 && lastDotIndex > lastSlashIndex && length - lastDotIndex <= 6 )
     {
       QFile tmpFile( outputFile );
-      tmpFile.rename( tmpFile.fileName() + downloadedUrl.mid( lastDotIndex ) );
-      outputFile += downloadedUrl.mid( lastDotIndex );
+      tmpFile.rename( tmpFile.fileName() + url.mid( lastDotIndex ) );
+      outputFile += url.mid( lastDotIndex );
     }
   }
 

--- a/src/core/network/qgsfiledownloader.cpp
+++ b/src/core/network/qgsfiledownloader.cpp
@@ -45,11 +45,6 @@ QgsFileDownloader::~QgsFileDownloader()
   }
 }
 
-const QUrl QgsFileDownloader::downloadedUrl() const
-{
-  return mReply ? mReply->url() : QUrl();
-}
-
 void QgsFileDownloader::startDownload()
 {
   QgsNetworkAccessManager *nam = QgsNetworkAccessManager::instance();
@@ -198,7 +193,7 @@ void QgsFileDownloader::onFinished()
     }
     else
     {
-      emit downloadCompleted();
+      emit downloadCompleted( mReply->url() );
     }
   }
   emit downloadExited();

--- a/src/core/network/qgsfiledownloader.h
+++ b/src/core/network/qgsfiledownloader.h
@@ -57,15 +57,9 @@ class CORE_EXPORT QgsFileDownloader : public QObject
      */
     QgsFileDownloader( const QUrl &url, const QString &outputFileName, const QString &authcfg = QString(), bool delayStart = false );
 
-    /**
-     * Returns the downloaded URL, which can differ from the original URL if redirects occurred.
-     * \since QGIS 3.18
-     */
-    const QUrl downloadedUrl() const;
-
   signals:
     //! Emitted when the download has completed successfully
-    void downloadCompleted();
+    void downloadCompleted( const QUrl &url );
     //! Emitted always when the downloader exits
     void downloadExited();
 


### PR DESCRIPTION
## Description

I hadn't realized that QgsFileDownload was deleting itself upon download exit (see https://github.com/qgis/QGIS/blob/master/src/core/network/qgsfiledownloader.cpp#L205) -- this means the original fix in the referenced commit would often try to fetch a deleted object. This PR implements an alternative, crash-free approach.