### PR TITLE
Add mechanism for temporarily disabling all network caching to QgsNetworkAccessManager

### DIFF
--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -250,6 +250,7 @@ need to be handled on the main thread. See in-depth discussion in the documentat
 for the constructor of this class.
 %End
 
+
     bool useSystemProxy() const;
 %Docstring
 Returns whether the system proxy should be used.

--- a/src/app/devtools/networklogger/qgsnetworkloggerpanelwidget.cpp
+++ b/src/app/devtools/networklogger/qgsnetworkloggerpanelwidget.cpp
@@ -27,6 +27,7 @@
 #include <QMessageBox>
 #include <QScrollBar>
 #include <QToolButton>
+#include <QCheckBox>
 
 #include <nlohmann/json.hpp>
 
@@ -217,4 +218,16 @@ QgsNetworkLoggerPanelWidget::QgsNetworkLoggerPanelWidget( QgsNetworkLogger *logg
 
   settingsMenu->addAction( mActionShowSuccessful );
   settingsMenu->addAction( mActionShowTimeouts );
+
+  mToolbar->addSeparator();
+  QCheckBox *disableCacheCheck = new QCheckBox( tr( "Disable cache" ) );
+  connect( disableCacheCheck, &QCheckBox::toggled, this, [ = ]( bool checked )
+  {
+    // note -- we deliberately do NOT store this as a permanent setting in QSettings
+    // as it is designed to be a temporary debugging tool only and we don't want
+    // users to accidentally leave this enabled and cause unnecessary server load...
+    QgsNetworkAccessManager::instance()->setCacheDisabled( checked );
+  } );
+
+  mToolbar->addWidget( disableCacheCheck );
 }

--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -127,7 +127,10 @@ QgsNetworkAccessManager *QgsNetworkAccessManager::instance( Qt::ConnectionType c
     sMainNAM = nam;
 
   if ( !nam->mInitialized )
+  {
     nam->setupDefaultProxyAndCache( connectionType );
+    nam->setCacheDisabled( sMainNAM->cacheDisabled() );
+  }
 
   return nam;
 }
@@ -248,6 +251,13 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
     pReq->setSslConfiguration( sslconfig );
   }
 #endif
+
+  if ( sMainNAM->mCacheDisabled )
+  {
+    // if caching is disabled then we override whatever the request actually has set!
+    pReq->setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork );
+    pReq->setAttribute( QNetworkRequest::CacheSaveControlAttribute, false );
+  }
 
   static QAtomicInt sRequestId = 0;
   const int requestId = ++sRequestId;

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -409,6 +409,30 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
      */
     void setupDefaultProxyAndCache( Qt::ConnectionType connectionType = Qt::BlockingQueuedConnection );
 
+#ifndef SIP_RUN
+
+    /**
+     * Returns TRUE if all network caching is disabled.
+     *
+     * \see setCacheDisabled()
+     * \note Not available in Python bindings.
+     * \since QGIS 3.18
+     */
+    bool cacheDisabled() const { return mCacheDisabled; }
+
+    /**
+     * Sets whether all network caching should be disabled.
+     *
+     * If \a disabled is TRUE then all caching will be disabled, causing all requests
+     * to be retrieved from the network regardless of the request's attributes.
+     *
+     * \see cacheDisabled()
+     * \note Not available in Python bindings.
+     * \since QGIS 3.18
+     */
+    void setCacheDisabled( bool disabled ) { mCacheDisabled = disabled; }
+#endif
+
     /**
      * Returns whether the system proxy should be used.
      */
@@ -655,6 +679,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     QStringList mNoProxyURLs;
     bool mUseSystemProxy = false;
     bool mInitialized = false;
+    bool mCacheDisabled = false;
     static QgsNetworkAccessManager *sMainNAM;
     // ssl error handler, will be set for main thread ONLY
     std::unique_ptr< QgsSslErrorHandler > mSslErrorHandler;


### PR DESCRIPTION
...and add a checkbox in the network logger panel to allow users to temporarily disable the network cache

This can be VERY useful when debugging QGIS network activity, or when using QGIS to test server side changes.

This is a transient setting only, and is forgotten as soon as QGIS is closed. That's by design -- we don't want users to accidentally
leave this enabled and cause unnecessary server load.

![image](https://user-images.githubusercontent.com/1829991/104995182-9b67af80-5a71-11eb-89cc-e6443b8850b3.png)
