### PR TITLE
Use parent symbol type instead of layer geometry type to decide which line symbol layer settings to show

### DIFF
--- a/python/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
@@ -120,6 +120,8 @@ Creates a new QgsSimpleLineSymbolLayerWidget.
 
     virtual QgsSymbolLayer *symbolLayer();
 
+    virtual void setContext( const QgsSymbolWidgetContext &context );
+
 
   protected:
 
@@ -366,6 +368,8 @@ Creates a new QgsMarkerLineSymbolLayerWidget.
 
     virtual QgsSymbolLayer *symbolLayer();
 
+    virtual void setContext( const QgsSymbolWidgetContext &context );
+
 
   public slots:
 
@@ -411,6 +415,8 @@ Creates a new QgsHashedLineSymbolLayerWidget.
     virtual void setSymbolLayer( QgsSymbolLayer *layer );
 
     virtual QgsSymbolLayer *symbolLayer();
+
+    virtual void setContext( const QgsSymbolWidgetContext &context );
 
 
 };

--- a/python/gui/auto_generated/symbology/qgssymbolwidgetcontext.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbolwidgetcontext.sip.in
@@ -119,6 +119,26 @@ Ownership is transferred to the caller.
 .. versionadded:: 3.0
 %End
 
+    QgsSymbol::SymbolType symbolType() const;
+%Docstring
+Returns the associated symbol type, if the widget is being shown as a subcomponent
+of a parent symbol configuration widget.
+
+.. seealso:: :py:func:`setSymbolType`
+
+.. versionadded:: 3.18
+%End
+
+    void setSymbolType( QgsSymbol::SymbolType type );
+%Docstring
+Sets the associated symbol ``type``, if the widget is being shown as a subcomponent
+of a parent symbol configuration widget.
+
+.. seealso:: :py:func:`symbolType`
+
+.. versionadded:: 3.18
+%End
+
 };
 
 /************************************************************************

--- a/src/gui/symbology/qgslayerpropertieswidget.cpp
+++ b/src/gui/symbology/qgslayerpropertieswidget.cpp
@@ -151,6 +151,8 @@ QgsLayerPropertiesWidget::QgsLayerPropertiesWidget( QgsSymbolLayer *layer, const
 void QgsLayerPropertiesWidget::setContext( const QgsSymbolWidgetContext &context )
 {
   mContext = context;
+  if ( mSymbol )
+    mContext.setSymbolType( mSymbol->type() );
 
   QgsSymbolLayerWidget *w = dynamic_cast< QgsSymbolLayerWidget * >( stackedWidget->currentWidget() );
   if ( w )

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -252,14 +252,6 @@ QgsSimpleLineSymbolLayerWidget::QgsSimpleLineSymbolLayerWidget( QgsVectorLayer *
   spinOffset->setClearValue( 0.0 );
   spinPatternOffset->setClearValue( 0.0 );
 
-  if ( vl && vl->geometryType() != QgsWkbTypes::PolygonGeometry )
-  {
-    //draw inside polygon checkbox only makes sense for polygon layers
-    mDrawInsideCheckBox->hide();
-    mRingFilterComboBox->hide();
-    mRingsLabel->hide();
-  }
-
   //make a temporary symbol for the size assistant preview
   mAssistantPreviewSymbol.reset( new QgsLineSymbol() );
 
@@ -379,6 +371,26 @@ void QgsSimpleLineSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer *layer )
 QgsSymbolLayer *QgsSimpleLineSymbolLayerWidget::symbolLayer()
 {
   return mLayer;
+}
+
+void QgsSimpleLineSymbolLayerWidget::setContext( const QgsSymbolWidgetContext &context )
+{
+  QgsSymbolLayerWidget::setContext( context );
+
+  switch ( context.symbolType() )
+  {
+    case QgsSymbol::Marker:
+    case QgsSymbol::Line:
+      //these settings only have an effect when the symbol layers is part of a fill symbol
+      mDrawInsideCheckBox->hide();
+      mRingFilterComboBox->hide();
+      mRingsLabel->hide();
+      break;
+
+    case QgsSymbol::Fill:
+    case QgsSymbol::Hybrid:
+      break;
+  }
 }
 
 void QgsSimpleLineSymbolLayerWidget::penWidthChanged()
@@ -1845,13 +1857,6 @@ QgsMarkerLineSymbolLayerWidget::QgsMarkerLineSymbolLayerWidget( QgsVectorLayer *
 
   spinOffset->setClearValue( 0.0 );
 
-
-  if ( vl && vl->geometryType() != QgsWkbTypes::PolygonGeometry )
-  {
-    mRingFilterComboBox->hide();
-    mRingsLabel->hide();
-  }
-
   mSpinAverageAngleLength->setClearValue( 4.0 );
 
   connect( spinInterval, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsMarkerLineSymbolLayerWidget::setInterval );
@@ -1936,6 +1941,25 @@ void QgsMarkerLineSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer *layer )
 QgsSymbolLayer *QgsMarkerLineSymbolLayerWidget::symbolLayer()
 {
   return mLayer;
+}
+
+void QgsMarkerLineSymbolLayerWidget::setContext( const QgsSymbolWidgetContext &context )
+{
+  QgsSymbolLayerWidget::setContext( context );
+
+  switch ( context.symbolType() )
+  {
+    case QgsSymbol::Marker:
+    case QgsSymbol::Line:
+      //these settings only have an effect when the symbol layers is part of a fill symbol
+      mRingFilterComboBox->hide();
+      mRingsLabel->hide();
+      break;
+
+    case QgsSymbol::Fill:
+    case QgsSymbol::Hybrid:
+      break;
+  }
 }
 
 void QgsMarkerLineSymbolLayerWidget::setInterval( double val )
@@ -2080,13 +2104,6 @@ QgsHashedLineSymbolLayerWidget::QgsHashedLineSymbolLayerWidget( QgsVectorLayer *
 
   spinOffset->setClearValue( 0.0 );
 
-
-  if ( vl && vl->geometryType() != QgsWkbTypes::PolygonGeometry )
-  {
-    mRingFilterComboBox->hide();
-    mRingsLabel->hide();
-  }
-
   mHashRotationSpinBox->setClearValue( 0 );
   mSpinAverageAngleLength->setClearValue( 4.0 );
 
@@ -2179,6 +2196,25 @@ void QgsHashedLineSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer *layer )
 QgsSymbolLayer *QgsHashedLineSymbolLayerWidget::symbolLayer()
 {
   return mLayer;
+}
+
+void QgsHashedLineSymbolLayerWidget::setContext( const QgsSymbolWidgetContext &context )
+{
+  QgsSymbolLayerWidget::setContext( context );
+
+  switch ( context.symbolType() )
+  {
+    case QgsSymbol::Marker:
+    case QgsSymbol::Line:
+      //these settings only have an effect when the symbol layers is part of a fill symbol
+      mRingFilterComboBox->hide();
+      mRingsLabel->hide();
+      break;
+
+    case QgsSymbol::Fill:
+    case QgsSymbol::Hybrid:
+      break;
+  }
 }
 
 void QgsHashedLineSymbolLayerWidget::setInterval( double val )

--- a/src/gui/symbology/qgssymbollayerwidget.h
+++ b/src/gui/symbology/qgssymbollayerwidget.h
@@ -146,6 +146,7 @@ class GUI_EXPORT QgsSimpleLineSymbolLayerWidget : public QgsSymbolLayerWidget, p
     // from base class
     void setSymbolLayer( QgsSymbolLayer *layer ) override;
     QgsSymbolLayer *symbolLayer() override;
+    void setContext( const QgsSymbolWidgetContext &context ) override;
 
   protected:
     QgsSimpleLineSymbolLayer *mLayer = nullptr;
@@ -485,6 +486,7 @@ class GUI_EXPORT QgsMarkerLineSymbolLayerWidget : public QgsSymbolLayerWidget, p
     // from base class
     void setSymbolLayer( QgsSymbolLayer *layer ) override;
     QgsSymbolLayer *symbolLayer() override;
+    void setContext( const QgsSymbolWidgetContext &context ) override;
 
   public slots:
 
@@ -540,6 +542,7 @@ class GUI_EXPORT QgsHashedLineSymbolLayerWidget : public QgsSymbolLayerWidget, p
     // from base class
     void setSymbolLayer( QgsSymbolLayer *layer ) override;
     QgsSymbolLayer *symbolLayer() override;
+    void setContext( const QgsSymbolWidgetContext &context ) override;
 
   private slots:
 

--- a/src/gui/symbology/qgssymbolwidgetcontext.cpp
+++ b/src/gui/symbology/qgssymbolwidgetcontext.cpp
@@ -114,3 +114,13 @@ QList<QgsExpressionContextScope *> QgsSymbolWidgetContext::globalProjectAtlasMap
     scopes << QgsExpressionContextUtils::layerScope( layer );
   return scopes;
 }
+
+QgsSymbol::SymbolType QgsSymbolWidgetContext::symbolType() const
+{
+  return mSymbolType;
+}
+
+void QgsSymbolWidgetContext::setSymbolType( QgsSymbol::SymbolType type )
+{
+  mSymbolType = type;
+}

--- a/src/gui/symbology/qgssymbolwidgetcontext.h
+++ b/src/gui/symbology/qgssymbolwidgetcontext.h
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include "qgsexpressioncontext.h"
+#include "qgssymbol.h"
 #include "qgis_gui.h"
 
 
@@ -116,12 +117,31 @@ class GUI_EXPORT QgsSymbolWidgetContext // clazy:exclude=rule-of-three
      */
     QList<QgsExpressionContextScope *> globalProjectAtlasMapLayerScopes( const QgsMapLayer *layer ) const SIP_FACTORY;
 
+    /**
+     * Returns the associated symbol type, if the widget is being shown as a subcomponent
+     * of a parent symbol configuration widget.
+     *
+     * \see setSymbolType()
+     * \since QGIS 3.18
+     */
+    QgsSymbol::SymbolType symbolType() const;
+
+    /**
+     * Sets the associated symbol \a type, if the widget is being shown as a subcomponent
+     * of a parent symbol configuration widget.
+     *
+     * \see symbolType()
+     * \since QGIS 3.18
+     */
+    void setSymbolType( QgsSymbol::SymbolType type );
+
   private:
 
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsMessageBar *mMessageBar = nullptr;
     std::unique_ptr< QgsExpressionContext > mExpressionContext;
     QList< QgsExpressionContextScope > mAdditionalScopes;
+    QgsSymbol::SymbolType mSymbolType = QgsSymbol::Hybrid;
 
 };
 


### PR DESCRIPTION
Fixes fill symbol only related properties (like ring filters) show
for line symbols in some contexts.

Fixes #33398
Fixes #24131
