### PR TITLE
[Oracle] Don't reset srid to -1 when there is no geometry

### DIFF
--- a/src/providers/oracle/qgsoracleconn.cpp
+++ b/src/providers/oracle/qgsoracleconn.cpp
@@ -628,7 +628,7 @@ void QgsOracleConn::retrieveLayerTypes( QgsOracleLayerProperty &layerProperty, b
   if ( !onlyExistingTypes )
   {
     layerProperty.types << QgsWkbTypes::Unknown;
-    layerProperty.srids << ( srids.size() == 1 ? *srids.constBegin() : 0 );
+    layerProperty.srids << ( detectedSrid > 0 ? detectedSrid : ( srids.size() == 1 ? *srids.constBegin() : 0 ) );
   }
 }
 

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -2704,7 +2704,6 @@ bool QgsOracleProvider::getGeometryDetails()
       }
 
       detectedType = QgsWkbTypes::Unknown;
-      detectedSrid = -1;
     }
     else
     {
@@ -2721,7 +2720,6 @@ bool QgsOracleProvider::getGeometryDetails()
         {
           // we need to filter
           detectedType = QgsWkbTypes::Unknown;
-          detectedSrid = -1;
         }
       }
       else
@@ -2729,7 +2727,6 @@ bool QgsOracleProvider::getGeometryDetails()
         // geometry type undetermined or not unrequested
         QgsMessageLog::logMessage( tr( "Feature type or srid for %1 of %2 could not be determined or was not requested." ).arg( mGeometryColumn ).arg( mQuery ) );
         detectedType = QgsWkbTypes::Unknown;
-        detectedSrid = -1;
       }
     }
   }


### PR DESCRIPTION
With Oracle database, there is no way to detect the geometry type of a layer when there is no rows in the table.
But the srid can be found in the metadata table. 

This PR allows to keep the srid even if we don't detect geometry type (and set it in the URI for instance) so the later added feature have a correctly specified srid.