### PR TITLE
Fix MXE build for python bump and EPT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -917,6 +917,11 @@ endif()
 
 find_package(PythonLibrary REQUIRED)
 
+set(MIN_PYTHON_VERSION "3.6")
+if(${PYTHON_SHORT_VERSION} VERSION_LESS ${MIN_PYTHON_VERSION})
+    message(FATAL_ERROR "Python version ${PYTHON_SHORT_VERSION} is too old. Minimum Python version is ${MIN_PYTHON_VERSION}.")
+endif()
+
 #############################################################
 # Python bindings
 

--- a/external/laz-perf/common/types.hpp
+++ b/external/laz-perf/common/types.hpp
@@ -53,7 +53,7 @@ typedef long long          I64;
 typedef float              F32;
 typedef double             F64;
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined (__MINGW32__)
 typedef int                BOOL;
 #else
 typedef bool               BOOL;

--- a/ms-windows/mxe/build-mxe.sh
+++ b/ms-windows/mxe/build-mxe.sh
@@ -35,7 +35,7 @@ PYDEPLOY=${DIR}/deploy.py
 # Configuration: change this!
 
 # Location of mxe install dir
-MXE=${MXE:-/mxe/}
+MXE=${MXE:-/usr/lib/mxe/}
 
 # Directory for build
 BUILD_DIR=${PWD}/build-mxe
@@ -45,10 +45,10 @@ RELEASE_DIR=${PWD}/qgis-mxe-release
 # End configuration
 
 # Windows 64 bit with posix threads
-TARGET=x86_64-w64-mingw32.shared.posix
+TARGET=x86_64-w64-mingw32.shared
 
 # Set base path for all tools
-export PATH=${PATH}:/mxe/usr/bin
+export PATH=${PATH}:${MXE}/usr/bin
 
 # Fix CCACHE directory
 export CCACHE_DIR=${PWD}/.ccache
@@ -79,7 +79,6 @@ if [[ "$COMMAND" != *"package"* ]]; then
         -DENABLE_TESTS=OFF \
         -DWITH_QSPATIALITE=ON \
         -DWITH_APIDOC=OFF \
-        -DWITH_EPT=OFF \
         -DWITH_QWTPOLAR=ON \
         -DWITH_ASTYLE=OFF \
         -DWITH_SERVER=OFF \

--- a/ms-windows/mxe/mxe.Dockerfile
+++ b/ms-windows/mxe/mxe.Dockerfile
@@ -1,27 +1,41 @@
-FROM buildpack-deps:stretch
+# Build deps for QGIS Windows binaries using MXE cross compile environment
+# Author: Alessandro Pasotti
+
+FROM ubuntu:focal
 
 RUN chown root:root /tmp && chmod ugo+rwXt /tmp
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends autopoint bison flex gperf libtool ruby scons unzip p7zip-full intltool libtool libtool-bin nsis lzip zip
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    dirmngr \
+    software-properties-common \
+    lsb-release \
+    gpg-agent \
+    python3-distutils
 
-WORKDIR /mxe
+RUN apt-key adv \
+    --keyserver keyserver.ubuntu.com \
+    --recv-keys 86B72ED9 && \
+    add-apt-repository \
+    "deb [arch=amd64] https://pkg.mxe.cc/repos/apt `lsb_release -sc` main" && \
+    apt-get update
 
-RUN git clone https://github.com/mxe/mxe . || git pull origin master
-RUN make MXE_TARGETS=x86_64-w64-mingw32.shared.posix -j 16 \
-    qca \
-    qtlocation  \
-    qscintilla2  \
-    qwt  \
-    gdal  \
-    qtkeychain  \
-    qtserialport  \
-    qtwebkit \
-    qtwinextras \
-    libzip \
-    gsl \
-    libspatialindex \
-    exiv2 \
-    protobuf
+RUN DEBIAN_FRONTEND=noninteractive apt install -y \
+    mxe-x86-64-w64-mingw32.shared-gdal \
+    mxe-x86-64-w64-mingw32.shared-qca \
+    mxe-x86-64-w64-mingw32.shared-qtlocation \
+    mxe-x86-64-w64-mingw32.shared-qscintilla2 \
+    mxe-x86-64-w64-mingw32.shared-qwt \
+    mxe-x86-64-w64-mingw32.shared-qtkeychain \
+    mxe-x86-64-w64-mingw32.shared-qtserialport \
+    mxe-x86-64-w64-mingw32.shared-qtwebkit \
+    mxe-x86-64-w64-mingw32.shared-qtwinextras \
+    mxe-x86-64-w64-mingw32.shared-exiv2 \
+    mxe-x86-64-w64-mingw32.shared-protobuf \
+    mxe-x86-64-w64-mingw32.shared-zlib \
+    mxe-x86-64-w64-mingw32.shared-libzip \
+    mxe-x86-64-w64-mingw32.shared-libspatialindex \
+    mxe-x86-64-w64-mingw32.shared-gsl \
+    mxe-x86-64-w64-mingw32.shared-zstd
 
-RUN chmod -R a+rw /mxe/usr/x86_64-w64-mingw32.shared.posix
-
+# For QT SQL driver installation as an unprivileged user
+RUN chmod -R 777 /usr/lib/mxe/usr/x86_64-w64-mingw32.shared/qt5/plugins/


### PR DESCRIPTION
This should fix: https://github.com/qgis/QGIS/commit/afff8ba7be2794fe521a462feaf83b1a5d7cce63 and allow to go forward with https://github.com/qgis/QGIS/pull/40923

There is a new docker image with dependencies for MXE QGIS builds at elpaso/mxe-qt5-builder:latest
