### PR TITLE
Handle exact distances in curveSubstring

### DIFF
--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -1288,12 +1288,12 @@ QgsCircularString *QgsCircularString::curveSubstring( double startDistance, doub
 
   endDistance = std::max( startDistance, endDistance );
 
-  double distanceTraversed = 0;
   const int totalPoints = numPoints();
   if ( totalPoints == 0 )
     return clone();
 
   QVector< QgsPoint > substringPoints;
+  substringPoints.reserve( totalPoints );
 
   QgsWkbTypes::Type pointType = QgsWkbTypes::Point;
   if ( is3D() )
@@ -1306,19 +1306,15 @@ QgsCircularString *QgsCircularString::curveSubstring( double startDistance, doub
   const double *z = is3D() ? mZ.constData() : nullptr;
   const double *m = isMeasure() ? mM.constData() : nullptr;
 
+  double distanceTraversed = 0;
   double prevX = *x++;
   double prevY = *y++;
   double prevZ = z ? *z++ : 0.0;
   double prevM = m ? *m++ : 0.0;
   bool foundStart = false;
 
-  if ( qgsDoubleNear( startDistance, 0.0 ) || startDistance < 0 )
-  {
-    substringPoints << QgsPoint( pointType, prevX, prevY, prevZ, prevM );
-    foundStart = true;
-  }
-
-  substringPoints.reserve( totalPoints );
+  if ( startDistance < 0 )
+    startDistance = 0;
 
   for ( int i = 0; i < ( totalPoints - 2 ) ; i += 2 )
   {
@@ -1339,7 +1335,7 @@ QgsCircularString *QgsCircularString::curveSubstring( double startDistance, doub
 
     bool addedSegmentEnd = false;
     const double segmentLength = QgsGeometryUtils::circleLength( x1, y1, x2, y2, x3, y3 );
-    if ( distanceTraversed < startDistance && distanceTraversed + segmentLength > startDistance )
+    if ( distanceTraversed <= startDistance && startDistance < distanceTraversed + segmentLength )
     {
       // start point falls on this segment
       const double distanceToStart = startDistance - distanceTraversed;
@@ -1393,14 +1389,21 @@ QgsCircularString *QgsCircularString::curveSubstring( double startDistance, doub
                       << QgsPoint( pointType, x3, y3, z3, m3 );
     }
 
-    distanceTraversed += segmentLength;
-    if ( distanceTraversed > endDistance )
-      break;
-
     prevX = x3;
     prevY = y3;
     prevZ = z3;
     prevM = m3;
+    distanceTraversed += segmentLength;
+    if ( distanceTraversed >= endDistance )
+      break;
+  }
+
+  // start point is the last node
+  if ( !foundStart && qgsDoubleNear( distanceTraversed, startDistance ) )
+  {
+    substringPoints << QgsPoint( pointType, prevX, prevY, prevZ, prevM )
+                    << QgsPoint( pointType, prevX, prevY, prevZ, prevM )
+                    << QgsPoint( pointType, prevX, prevY, prevZ, prevM );
   }
 
   std::unique_ptr< QgsCircularString > result = qgis::make_unique< QgsCircularString >();

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -2873,6 +2873,8 @@ void TestQgsGeometry::circularString()
   QCOMPARE( substringResult->asWkt( 2 ), QStringLiteral( "CircularStringZM (13.51 -0.98 13 14, 14.01 -1 13.03 14.03, 14.5 -0.9 14.65 15.65)" ) );
   substringResult.reset( substring.curveSubstring( 5, 1000 ) );
   QCOMPARE( substringResult->asWkt( 2 ), QStringLiteral( "CircularStringZM (13.51 -0.98 13 14, 15.19 -0.53 17.2 18.2, 16 1 23 24)" ) );
+  substringResult.reset( substring.curveSubstring( QgsGeometryUtils::distanceToVertex( substring, QgsVertexId( 0, 0, 2 ) ), QgsGeometryUtils::distanceToVertex( substring, QgsVertexId( 0, 0, 4 ) ) ) );
+  QCOMPARE( substringResult->asWkt( 2 ), QStringLiteral( "CircularStringZM (12 0 13 14, 14.36 -0.94 14.19 15.19, 16 1 23 24)" ) );
 
   substring.setPoints( QgsPointSequence() << QgsPoint( 10, 0, 1 ) <<  QgsPoint( 11, 1, 3 ) <<  QgsPoint( 12, 0, 13 )
                        <<  QgsPoint( 14, -1, 13 ) <<  QgsPoint( 16, 1, 23 ) );
@@ -4955,6 +4957,8 @@ void TestQgsGeometry::lineString()
   QCOMPARE( substringResult->asWkt( 2 ), QStringLiteral( "LineStringZM (11 3 4 5, 11 12 13 14, 111 12 23 24)" ) );
   substringResult.reset( substring.curveSubstring( 1, 20 ) );
   QCOMPARE( substringResult->asWkt( 2 ), QStringLiteral( "LineStringZM (11 3 4 5, 11 12 13 14, 21 12 14 15)" ) );
+  substringResult.reset( substring.curveSubstring( QgsGeometryUtils::distanceToVertex( substring, QgsVertexId( 0, 0, 1 ) ), QgsGeometryUtils::distanceToVertex( substring, QgsVertexId( 0, 0, 2 ) ) ) );
+  QCOMPARE( substringResult->asWkt( 2 ), QStringLiteral( "LineStringZM (11 12 13 14, 111 12 23 24)" ) );
   substring.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 0, QgsWkbTypes::PointZ ) << QgsPoint( 11, 12, 13, 0, QgsWkbTypes::PointZ ) << QgsPoint( 111, 12, 23, 0, QgsWkbTypes::PointZ ) );
   substringResult.reset( substring.curveSubstring( 1, 20 ) );
   QCOMPARE( substringResult->asWkt( 2 ), QStringLiteral( "LineStringZ (11 3 4, 11 12 13, 21 12 14)" ) );


### PR DESCRIPTION
These exact distances may be obtained with `distance_to_vertex`.

## Description

Before this change, the code considered the line segments as open intervals, so that vertices could not ever be considered as the start of a substring.  This change considers them as semi-open intervals (closed at the beginning) instead. (With a special case when starting the substring at the last vertex)

Before this change, vertices could not be considered as the end of a substring, so an other loop was required, adding a duplicate node.

Similar behaviour is observed for `QgsCircularString` and corrected similarly.

Double equality is performed as exact equality, because it does not matter on which segment the start of the substring is. Except where `startDistance` is -0.0, which is already handled before the for loop, or when `startDistance` is at the last vertex.

Because this change removes the first point added to the substring, memory reservation can go anywhere without behaviour change, so I moved it closer to the initialization. I also moved the declaration of distanceTraversed closer to the other loop variables.

I flipped the inequality `distanceTraversed + segmentLength > startDistance` to highlight that the segment is semi-open.

New unit/regression tests, other tests still pass. I used `QgsGeometryUtils::distanceToVertex` because the bug was exhibited with it, but then the test is not so unitary. Also, I am not very good at 3D geometry computations.

I tested the change on linestrings, but not on circularstrings.

This changeset introduces visible behaviour change, it may not qualify for being backported.

I'm a junior developer, do not hesitate to reject and give advice.

Fixes #41081

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
