### PR TITLE
Fix comparison sort order for points to path test

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/points_to_path_grouped.gml
+++ b/python/plugins/processing/tests/testdata/expected/points_to_path_grouped.gml
@@ -12,14 +12,6 @@
   </gml:boundedBy>
 
   <gml:featureMember>
-    <ogr:points_to_path_grouped fid="points_to_path_grouped.0">
-      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>1,1 5,2</gml:coordinates></gml:LineString></ogr:geometryProperty>
-      <ogr:id2>2</ogr:id2>
-      <ogr:begin>1</ogr:begin>
-      <ogr:end>4</ogr:end>
-    </ogr:points_to_path_grouped>
-  </gml:featureMember>
-  <gml:featureMember>
     <ogr:points_to_path_grouped fid="points_to_path_grouped.1">
       <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>2,2 0,-5 8,-1 7,-1 0,-1</gml:coordinates></gml:LineString></ogr:geometryProperty>
       <ogr:id2>0</ogr:id2>
@@ -33,6 +25,14 @@
       <ogr:id2>1</ogr:id2>
       <ogr:begin>2</ogr:begin>
       <ogr:end>5</ogr:end>
+    </ogr:points_to_path_grouped>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:points_to_path_grouped fid="points_to_path_grouped.0">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>1,1 5,2</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:id2>2</ogr:id2>
+      <ogr:begin>1</ogr:begin>
+      <ogr:end>4</ogr:end>
     </ogr:points_to_path_grouped>
   </gml:featureMember>
 

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests2.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests2.yaml
@@ -1598,6 +1598,10 @@ tests:
         name:
           - expected/points_to_path_grouped.gml
         type: vector
+        pk: id2
+        compare:
+          fields:
+            fid: skip
 
   - algorithm: qgis:pointstopath
     name: Points to path (close path)


### PR DESCRIPTION
@uclaros this should fix the randomly failing test -- the "pk" option allows you to specify a sort order to use when comparing the resultant features, and then we skip the "fid" field during comparison as that one will also vary depending on the feature output order