### PR TITLE
Added a connection to QgsMapLayer::nameChanged (fixes #40824)

### DIFF
--- a/src/core/qgsmaplayerlegend.cpp
+++ b/src/core/qgsmaplayerlegend.cpp
@@ -350,6 +350,7 @@ QgsDefaultVectorLayerLegend::QgsDefaultVectorLayerLegend( QgsVectorLayer *vl )
   : mLayer( vl )
 {
   connect( mLayer, &QgsMapLayer::rendererChanged, this, &QgsMapLayerLegend::itemsChanged );
+  connect( mLayer, &QgsMapLayer::nameChanged, this, &QgsMapLayerLegend::itemsChanged );
 }
 
 QList<QgsLayerTreeModelLegendNode *> QgsDefaultVectorLayerLegend::createLayerTreeModelLegendNodes( QgsLayerTreeLayer *nodeLayer )


### PR DESCRIPTION
Added a connection for signal QgsMapLayer::nameChanged and slot QgsMapLayerLegend::itemsChanged in QgsMapLayerLegend.

I think it can be backported.

Fixes #40824