### PR TITLE
[layouts] Always update label after text changes (3.16 backport)

### DIFF
--- a/src/core/layout/qgslayoutitemlabel.cpp
+++ b/src/core/layout/qgslayoutitemlabel.cpp
@@ -198,6 +198,7 @@ void QgsLayoutItemLabel::contentChanged()
       break;
     }
     case ModeFont:
+      invalidateCache();
       break;
   }
 }


### PR DESCRIPTION
Fixes label shows old text when opacity settings are changed

Fixes #40203

Backport from https://github.com/qgis/QGIS/pull/41090