### PR TITLE
[processing] Don't default to input field for optional expression parameters (3.16 backport)

### DIFF
--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -1948,6 +1948,9 @@ QWidget *QgsProcessingExpressionWidgetWrapper::createWidget()
           mFieldExpWidget->setToolTip( parameterDefinition()->toolTip() );
           mFieldExpWidget->setExpressionDialogTitle( parameterDefinition()->description() );
           mFieldExpWidget->registerExpressionContextGenerator( this );
+          if ( expParam->flags() & QgsProcessingParameterDefinition::FlagOptional )
+            mFieldExpWidget->setAllowEmptyFieldName( true );
+
           connect( mFieldExpWidget, static_cast < void ( QgsFieldExpressionWidget::* )( const QString & ) >( &QgsFieldExpressionWidget::fieldChanged ), this, [ = ]( const QString & )
           {
             emit widgetValueHasChanged( this );


### PR DESCRIPTION
Backport of https://github.com/qgis/QGIS/pull/41089

Fixes #41063
