### PR TITLE
[processing] Fix feedback confusion with multiple download file alg by adding a successfully downloaded URL information message

### DIFF
--- a/src/analysis/processing/qgsalgorithmfiledownloader.cpp
+++ b/src/analysis/processing/qgsalgorithmfiledownloader.cpp
@@ -95,10 +95,12 @@ QVariantMap QgsFileDownloaderAlgorithm::processAlgorithm( const QVariantMap &par
   if ( !feedback->isCanceled() && !exists )
     throw QgsProcessingException( tr( "Output file doesn't exist." ) );
 
+  url = downloadedUrl.toDisplayString();
+  feedback->pushInfo( QObject::tr( "Successfully downloaded %1" ).arg( url ) );
+
   if ( outputFile.startsWith( QgsProcessingUtils::tempFolder() ) )
   {
     // the output is temporary and its file name automatically generated, try to add a file extension
-    url = downloadedUrl.toDisplayString();
     const int length = url.size();
     const int lastDotIndex = url.lastIndexOf( "." );
     const int lastSlashIndex = url.lastIndexOf( "/" );


### PR DESCRIPTION
## Description

When using multiple download file algorithm within a model, the status feedback is extremely confusing (i.e., we get 'x of X downloaded', which tents to blend with one another when file sizes are similar). This PR improves the situation by pushing a 'successfully downloaded X' information message when the download has been ... successful. As a nice bonus, it'll actually print the resolved URL if the input URL was redirecting.