### PR TITLE
New SAP HANA Icon

### DIFF
--- a/images/themes/default/mActionAddHanaLayer.svg
+++ b/images/themes/default/mActionAddHanaLayer.svg
@@ -1,130 +1,37 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   height="24"
-   width="24"
-   version="1.1"
-   id="svg3873"
-   sodipodi:docname="mActionAddHanaLayer.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata3879">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
-     id="defs3877" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1331"
-     inkscape:window-height="866"
-     id="namedview3875"
-     showgrid="false"
-     inkscape:zoom="1.2265984"
-     inkscape:cx="263.28519"
-     inkscape:cy="-195.25954"
-     inkscape:window-x="432"
-     inkscape:window-y="227"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg3873" />
-  <filter
-     id="a"
-     color-interpolation-filters="sRGB"
-     height="1.5"
-     width="1.5"
-     x="-.25"
-     y="-.25">
-    <feGaussianBlur
-       in="SourceAlpha"
-       result="blur"
-       stdDeviation="2"
-       id="feGaussianBlur3830" />
-    <feColorMatrix
-       result="bluralpha"
-       type="matrix"
-       values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0.351000 0"
-       id="feColorMatrix3832" />
-    <feOffset
-       dx="7.5"
-       dy="7.5"
-       in="bluralpha"
-       result="offsetBlur"
-       id="feOffset3834" />
-    <feMerge
-       id="feMerge3840">
-      <feMergeNode
-         in="offsetBlur"
-         id="feMergeNode3836" />
-      <feMergeNode
-         in="SourceGraphic"
-         id="feMergeNode3838" />
-    </feMerge>
-  </filter>
-  <path
-     inkscape:connector-curvature="0"
-     style="fill:#6d97c4;stroke-width:3.77952743"
-     d="m 6.5490565,0.07094656 c -5.66173201,0 -6.48189001,0.81259846 -6.48189001,6.47055114 v 7.0412603 c 0,5.665512 0.820158,6.481889 6.48189001,6.481889 h 7.0374795 c 5.68063,0 6.48189,-0.816377 6.48189,-6.47811 V 6.5452772 c 0,-5.65795265 -0.80126,-6.47433064 -6.48189,-6.47433064 z"
-     id="path3903" />
-  <g
-     style="fill:none;stroke:#415a75;filter:url(#a)"
-     id="g3843"
-     transform="matrix(0.05336966,0,0,0.05336966,-25.394738,-6.8986587)" />
-  <g
-     id="g3869"
-     transform="matrix(0.69230769,0,0,0.69230769,1.8461539,1.8461539)">
-    <rect
-       style="fill:#5a8c5a"
-       id="rect3861"
-       y="19"
-       x="19"
-       width="13"
-       ry="2.6149368"
-       rx="2.6149371"
-       height="13" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path3863"
-       style="overflow:visible;fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.5999999;stroke-linecap:round;stroke-linejoin:round"
-       d="m 21.6,25.499999 h 7.8" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path3865"
-       style="overflow:visible;fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.5999999;stroke-linecap:round;stroke-linejoin:round"
-       d="M 25.5,29.399999 V 21.6" />
-    <path
-       style="opacity:0.3;fill:#fcffff;fill-rule:evenodd"
-       inkscape:connector-curvature="0"
-       id="path3867"
-       d="m 20.3,25.499999 h 10.4 c 0,0 0,0 0,-2.6 C 30.7,20.3 30.05,20.3 25.5,20.3 c -4.55,0 -5.2,0 -5.2,2.599999 0,2.6 0,2.6 0,2.6 z" />
-  </g>
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.80375957px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.4836466"
-     x="0.43264881"
-     y="12.17761"
-     id="text4784"><tspan
-       sodipodi:role="line"
-       id="tspan4782"
-       x="0.43264881"
-       y="12.17761"
-       style="stroke-width:0.4836466">HANA</tspan></text>
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 11 11">
+
+<g transform="matrix(0.75 0 0 0.75 0 0)">
+<rect x="1.7" y="1.7" width="7.6" height="7.6" fill="none" stroke="#425a75" stroke-width="0.1" />
+<rect x="2" y="2" width="7" height="7" fill="#6e97c4" />
+
+<rect x="2" y="0" width="1" height="1" fill="#425a75" />
+<rect x="4" y="0" width="1" height="1" fill="#425a75" />
+<rect x="6" y="0" width="1" height="1" fill="#425a75" />
+<rect x="8" y="0" width="1" height="1" fill="#425a75" />
+
+<rect x="2" y="10" width="1" height="1" fill="#425a75" />
+<rect x="4" y="10" width="1" height="1" fill="#425a75" />
+<rect x="6" y="10" width="1" height="1" fill="#425a75" />
+<rect x="8" y="10" width="1" height="1" fill="#425a75" />
+
+<rect x="0" y="2" width="1" height="1" fill="#425a75" />
+<rect x="0" y="4" width="1" height="1" fill="#425a75" />
+<rect x="0" y="6" width="1" height="1" fill="#425a75" />
+<rect x="0" y="8" width="1" height="1" fill="#425a75" />
+
+<rect x="10" y="2" width="1" height="1" fill="#425a75" />
+<rect x="10" y="4" width="1" height="1" fill="#425a75" />
+<rect x="10" y="6" width="1" height="1" fill="#425a75" />
+<rect x="10" y="8" width="1" height="1" fill="#425a75" />
+</g>
+
+<g transform="matrix(0.34375 0 0 0.34375 0 0)">
+<rect fill="#5a8c5a" height="13" rx="2.614937" width="13" x="19" y="19"/>
+<g fill-rule="evenodd">
+<path d="m21.6 25.499999h7.8" fill="#fff" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.6"/>
+<path d="m25.5 29.399999v-7.799999" fill="#fff" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.6"/>
+<path d="m20.3 25.499999h10.4s0 0 0-2.6c0-2.599999-.65-2.599999-5.2-2.599999s-5.2 0-5.2 2.599999z" fill="#fcffff" opacity=".3"/>
+</g>
+</g>
+
 </svg>

--- a/images/themes/default/mIconHana.svg
+++ b/images/themes/default/mIconHana.svg
@@ -1,102 +1,26 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   height="24"
-   width="24"
-   version="1.1"
-   id="svg4819"
-   sodipodi:docname="mIconHana.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata4825">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
-     id="defs4823" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1137"
-     id="namedview4821"
-     showgrid="false"
-     inkscape:zoom="101.80312"
-     inkscape:cx="19.028187"
-     inkscape:cy="3.1714231"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4819" />
-  <filter
-     id="a"
-     color-interpolation-filters="sRGB"
-     height="1.5"
-     width="1.5"
-     x="-.25"
-     y="-.25">
-    <feGaussianBlur
-       in="SourceAlpha"
-       result="blur"
-       stdDeviation="2"
-       id="feGaussianBlur4786" />
-    <feColorMatrix
-       result="bluralpha"
-       type="matrix"
-       values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0.351000 0"
-       id="feColorMatrix4788" />
-    <feOffset
-       dx="7.5"
-       dy="7.5"
-       in="bluralpha"
-       result="offsetBlur"
-       id="feOffset4790" />
-    <feMerge
-       id="feMerge4796">
-      <feMergeNode
-         in="offsetBlur"
-         id="feMergeNode4792" />
-      <feMergeNode
-         in="SourceGraphic"
-         id="feMergeNode4794" />
-    </feMerge>
-  </filter>
-  <g
-     id="g4940"
-     transform="matrix(1.0053553,0,0,1.0053553,-0.05929699,-0.0303089)">
-    <path
-       id="path3903"
-       d="m 7.7976585,0.04081074 c -6.7523475,0 -7.73049192,0.96912886 -7.73049192,7.71696886 v 8.3976114 c 0,6.756856 0.97814442,7.730491 7.73049192,7.730491 h 8.3931045 c 6.774886,0 7.730492,-0.973635 7.730492,-7.725984 V 7.7622872 c 0,-6.7478401 -0.955606,-7.72147646 -7.730492,-7.72147646 z"
-       style="fill:#6d97c4;stroke-width:4.50757504"
-       inkscape:connector-curvature="0" />
-    <text
-       id="text4784"
-       y="14.479572"
-       x="0.50305146"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:6.92173386px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.57681113"
-       xml:space="preserve"><tspan
-         style="stroke-width:0.57681113"
-         y="14.479572"
-         x="0.50305146"
-         id="tspan4782"
-         sodipodi:role="line">HANA</tspan></text>
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 11 11">
+
+<rect x="1.7" y="1.7" width="7.6" height="7.6" fill="none" stroke="#425a75" stroke-width="0.1" />
+<rect x="2" y="2" width="7" height="7" fill="#6e97c4" />
+
+<rect x="2" y="0" width="1" height="1" fill="#425a75" />
+<rect x="4" y="0" width="1" height="1" fill="#425a75" />
+<rect x="6" y="0" width="1" height="1" fill="#425a75" />
+<rect x="8" y="0" width="1" height="1" fill="#425a75" />
+
+<rect x="2" y="10" width="1" height="1" fill="#425a75" />
+<rect x="4" y="10" width="1" height="1" fill="#425a75" />
+<rect x="6" y="10" width="1" height="1" fill="#425a75" />
+<rect x="8" y="10" width="1" height="1" fill="#425a75" />
+
+<rect x="0" y="2" width="1" height="1" fill="#425a75" />
+<rect x="0" y="4" width="1" height="1" fill="#425a75" />
+<rect x="0" y="6" width="1" height="1" fill="#425a75" />
+<rect x="0" y="8" width="1" height="1" fill="#425a75" />
+
+<rect x="10" y="2" width="1" height="1" fill="#425a75" />
+<rect x="10" y="4" width="1" height="1" fill="#425a75" />
+<rect x="10" y="6" width="1" height="1" fill="#425a75" />
+<rect x="10" y="8" width="1" height="1" fill="#425a75" />
+
 </svg>

--- a/src/providers/hana/qgshanaconnection.cpp
+++ b/src/providers/hana/qgshanaconnection.cpp
@@ -65,7 +65,7 @@ QgsHanaConnection::~QgsHanaConnection()
   }
   catch ( const Exception &ex )
   {
-    QgsMessageLog::logMessage( QgsHanaUtils::formatErrorMessage( ex.what() ), tr( "HANA" ) );
+    QgsMessageLog::logMessage( QgsHanaUtils::formatErrorMessage( ex.what() ), tr( "SAP HANA" ) );
   }
 }
 
@@ -104,7 +104,7 @@ QgsHanaConnection *QgsHanaConnection::createConnection( const QgsDataSourceUri &
       {
         errorMessage = QObject::tr( "Connection to database failed" ) + '\n' + QgsHanaUtils::formatErrorMessage( ex.what() );
         QgsDebugMsg( errorMessage );
-        QgsMessageLog::logMessage( errorMessage, tr( "HANA" ) );
+        QgsMessageLog::logMessage( errorMessage, tr( "SAP HANA" ) );
       }
 
       return conn->connected();

--- a/src/providers/hana/qgshanadataitemguiprovider.h
+++ b/src/providers/hana/qgshanadataitemguiprovider.h
@@ -27,7 +27,7 @@ class QgsHanaDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
     Q_OBJECT
   public:
 
-    QString name() override { return QStringLiteral( "HANA" ); }
+    QString name() override { return QStringLiteral( "SAP HANA" ); }
 
     void populateContextMenu( QgsDataItem *item, QMenu *menu,
                               const QList<QgsDataItem *> &selectedItems, QgsDataItemGuiContext context ) override;

--- a/src/providers/hana/qgshanadataitems.cpp
+++ b/src/providers/hana/qgshanadataitems.cpp
@@ -174,7 +174,7 @@ bool QgsHanaConnectionItem::handleDrop( const QMimeData *data, const QString &to
         connect( exportTask.get(), &QgsVectorLayerExporterTask::exportComplete, this,
                  [ = ]()
         {
-          QMessageBox::information( nullptr, tr( "Import to HANA database" ), tr( "Import was successful." ) );
+          QMessageBox::information( nullptr, tr( "Import to SAP HANA database" ), tr( "Import was successful." ) );
           refreshSchema( toSchema );
         } );
 
@@ -185,7 +185,7 @@ bool QgsHanaConnectionItem::handleDrop( const QMimeData *data, const QString &to
           if ( error != QgsVectorLayerExporter::ErrUserCanceled )
           {
             QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
-            output->setTitle( tr( "Import to HANA database" ) );
+            output->setTitle( tr( "Import to SAP HANA database" ) );
             output->setMessage( tr( "Failed to import some layers!\n\n" ) +
                                 errorMessage, QgsMessageOutput::MessageText );
             output->showMessage();
@@ -211,7 +211,7 @@ bool QgsHanaConnectionItem::handleDrop( const QMimeData *data, const QString &to
   if ( hasError )
   {
     QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
-    output->setTitle( tr( "Import to HANA database" ) );
+    output->setTitle( tr( "Import to SAP HANA database" ) );
     output->setMessage( tr( "Failed to import some layers!\n\n" ) +
                         importResults.join( QLatin1Char( '\n' ) ), QgsMessageOutput::MessageText );
     output->showMessage();
@@ -381,5 +381,5 @@ QgsDataItem *QgsHanaDataItemProvider::createDataItem(
   const QString &pathIn, QgsDataItem *parentItem )
 {
   Q_UNUSED( pathIn );
-  return new QgsHanaRootItem( parentItem, QStringLiteral( "HANA" ), QStringLiteral( "hana:" ) );
+  return new QgsHanaRootItem( parentItem, QStringLiteral( "SAP HANA" ), QStringLiteral( "hana:" ) );
 }

--- a/src/providers/hana/qgshanadataitems.h
+++ b/src/providers/hana/qgshanadataitems.h
@@ -103,7 +103,7 @@ class QgsHanaLayerItem : public QgsLayerItem
 class QgsHanaDataItemProvider : public QgsDataItemProvider
 {
   public:
-    QString name() override { return QStringLiteral( "HANA" ); }
+    QString name() override { return QStringLiteral( "SAP HANA" ); }
     int capabilities() const override { return QgsDataProvider::Database; }
     QgsDataItem *createDataItem( const QString &pathIn, QgsDataItem *parentItem ) override;
 };

--- a/src/providers/hana/qgshanafeatureiterator.cpp
+++ b/src/providers/hana/qgshanafeatureiterator.cpp
@@ -278,7 +278,7 @@ QString QgsHanaFeatureIterator::buildSqlQuery( const QgsFeatureRequest &request 
     filterRect = mSource->mSrsExtent.intersect( filterRect );
 
   if ( !filterRect.isFinite() )
-    QgsMessageLog::logMessage( QObject::tr( "Infinite filter rectangle specified" ), QObject::tr( "HANA" ) );
+    QgsMessageLog::logMessage( QObject::tr( "Infinite filter rectangle specified" ), QObject::tr( "SAP HANA" ) );
 
   QStringList orderByParts;
 #if 0

--- a/src/providers/hana/qgshananewconnection.cpp
+++ b/src/providers/hana/qgshananewconnection.cpp
@@ -58,14 +58,14 @@ QgsHanaNewConnection::QgsHanaNewConnection(
 
   txtDriver->setText( QgsHanaDriver::instance()->driver() );
 #if defined(Q_OS_WIN)
-  txtDriver->setToolTip( tr( "The name of the HANA ODBC driver.\r\n\r\n"
-                             "The HANA ODBC driver is a part of the SAP HANA Client,\r\n"
+  txtDriver->setToolTip( tr( "The name of the SAP HANA ODBC driver.\r\n\r\n"
+                             "The SAP HANA ODBC driver is a part of the SAP HANA Client,\r\n"
                              "which can be found at https://tools.hana.ondemand.com/#hanatools." ) );
 #else
-  txtDriver->setToolTip( tr( "The name or path to the HANA ODBC driver.\r\n\r\n"
+  txtDriver->setToolTip( tr( "The name or path to the SAP HANA ODBC driver.\r\n\r\n"
                              "If the driver is registered in odbcinst.ini, enter the driver's name.\r\n"
                              "Otherwise, enter the path to the driver (libodbcHDB.so).\r\n\r\n"
-                             "The HANA ODBC driver is a part of the SAP HANA Client,\r\n"
+                             "The SAP HANA ODBC driver is a part of the SAP HANA Client,\r\n"
                              "which can be found at https://tools.hana.ondemand.com/#hanatools." ) );
 #endif
 
@@ -334,7 +334,7 @@ void QgsHanaNewConnection::testConnection()
         if ( !QgsHanaDriver::isValidPath( driver ) )
         {
           if ( QFileInfo::exists( driver ) )
-            warningMsg = tr( "Specified driver '%1' cannot be used to connect to HANA." ).arg( driver );
+            warningMsg = tr( "Specified driver '%1' cannot be used to connect to SAP HANA." ).arg( driver );
           else
             warningMsg = tr( "Driver with name/path '%1' was not found." ).arg( driver );
         }

--- a/src/providers/hana/qgshanaprimarykeys.cpp
+++ b/src/providers/hana/qgshanaprimarykeys.cpp
@@ -146,7 +146,7 @@ QPair<QgsHanaPrimaryKeyType, QList<int>> QgsHanaPrimaryKeyUtils::determinePrimar
     if ( idx < 0 )
     {
       attrs.clear();
-      QgsMessageLog::logMessage( QObject::tr( "Key field '%1' for view/query not found." ).arg( clmName ), QObject::tr( "HANA" ) );
+      QgsMessageLog::logMessage( QObject::tr( "Key field '%1' for view/query not found." ).arg( clmName ), QObject::tr( "SAP HANA" ) );
       break;
     }
     attrs << idx;
@@ -155,7 +155,7 @@ QPair<QgsHanaPrimaryKeyType, QList<int>> QgsHanaPrimaryKeyUtils::determinePrimar
   if ( !attrs.isEmpty() )
     keyType = ( attrs.size() == 1 ) ? getPrimaryKeyType( fields.at( attrs[0] ) ) : PktFidMap;
   else
-    QgsMessageLog::logMessage( QObject::tr( "Keys for view/query undefined." ), QObject::tr( "HANA" ) );
+    QgsMessageLog::logMessage( QObject::tr( "Keys for view/query undefined." ), QObject::tr( "SAP HANA" ) );
 
   return qMakePair( keyType, attrs );
 }
@@ -164,7 +164,7 @@ QPair<QgsHanaPrimaryKeyType, QList<int>> QgsHanaPrimaryKeyUtils::determinePrimar
 {
   if ( primaryKey.isEmpty() )
   {
-    QgsMessageLog::logMessage( QObject::tr( "No key field for view/query given." ), QObject::tr( "HANA" ) );
+    QgsMessageLog::logMessage( QObject::tr( "No key field for view/query given." ), QObject::tr( "SAP HANA" ) );
     return qMakePair( PktUnknown, QList<int>() );
   }
 

--- a/src/providers/hana/qgshanaprovider.cpp
+++ b/src/providers/hana/qgshanaprovider.cpp
@@ -278,7 +278,7 @@ namespace
 static const size_t MAXIMUM_BATCH_DATA_SIZE = 4 * 1024 * 1024;
 
 const QString QgsHanaProvider::HANA_KEY = QStringLiteral( "hana" );
-const QString QgsHanaProvider::HANA_DESCRIPTION = QStringLiteral( "HANA spatial data provider" );
+const QString QgsHanaProvider::HANA_DESCRIPTION = QStringLiteral( "SAP HANA spatial data provider" );
 
 QgsHanaProvider::QgsHanaProvider(
   const QString &uri,
@@ -299,14 +299,14 @@ QgsHanaProvider::QgsHanaProvider(
 
   if ( mSchemaName.isEmpty() || mTableName.isEmpty() )
   {
-    QgsMessageLog::logMessage( QObject::tr( "Schema or table name cannot be empty" ), QObject::tr( "HANA" ) );
+    QgsMessageLog::logMessage( QObject::tr( "Schema or table name cannot be empty" ), QObject::tr( "SAP HANA" ) );
     return;
   }
 
   QgsHanaConnectionRef conn( mUri );
   if ( conn.isNull() )
   {
-    QgsMessageLog::logMessage( QObject::tr( "Failed to connect to database" ), QObject::tr( "HANA" ) );
+    QgsMessageLog::logMessage( QObject::tr( "Failed to connect to database" ), QObject::tr( "SAP HANA" ) );
     return;
   }
 
@@ -326,7 +326,7 @@ QgsHanaProvider::QgsHanaProvider(
   {
     if ( !checkPermissionsAndSetCapabilities() )
     {
-      QgsMessageLog::logMessage( QObject::tr( "Provider does not have enough permissions" ), QObject::tr( "HANA" ) );
+      QgsMessageLog::logMessage( QObject::tr( "Provider does not have enough permissions" ), QObject::tr( "SAP HANA" ) );
       return;
     }
 
@@ -684,7 +684,7 @@ bool QgsHanaProvider::addFeatures( QgsFeatureList &flist, Flags flags )
   }
   catch ( const exception &ex )
   {
-    pushError( tr( "HANA error while adding features: %1" )
+    pushError( tr( "SAP HANA error while adding features: %1" )
                .arg( QgsHanaUtils::formatErrorMessage( ex.what(), false ) ) );
     conn->rollback();
   }
@@ -713,7 +713,7 @@ bool QgsHanaProvider::deleteFeatures( const QgsFeatureIds &ids )
   const QString featureIdsWhereClause = QgsHanaPrimaryKeyUtils::buildWhereClause( ids, mAttributeFields,  mPrimaryKeyType, mPrimaryKeyAttrs, *mPrimaryKeyCntx );
   if ( featureIdsWhereClause.isEmpty() )
   {
-    pushError( tr( "HANA failed to delete features: Unable to find feature ids" ) );
+    pushError( tr( "SAP HANA failed to delete features: Unable to find feature ids" ) );
     return false;
   }
 
@@ -728,7 +728,7 @@ bool QgsHanaProvider::deleteFeatures( const QgsFeatureIds &ids )
   }
   catch ( const QgsHanaException &ex )
   {
-    pushError( tr( "HANA failed to delete features: %1" )
+    pushError( tr( "SAP HANA failed to delete features: %1" )
                .arg( QgsHanaUtils::formatErrorMessage( ex.what(), false ) ) );
     conn->rollback();
     return false;
@@ -761,7 +761,7 @@ bool QgsHanaProvider::truncate()
   }
   catch ( const QgsHanaException &ex )
   {
-    pushError( tr( "HANA failed to truncate: %1" ).arg( QgsHanaUtils::formatErrorMessage( ex.what() ) ) );
+    pushError( tr( "SAP HANA failed to truncate: %1" ).arg( QgsHanaUtils::formatErrorMessage( ex.what() ) ) );
     conn->rollback();
     return false;
   }
@@ -800,7 +800,7 @@ bool QgsHanaProvider::addAttributes( const QList<QgsField> &attributes )
   }
   catch ( const QgsHanaException &ex )
   {
-    pushError( tr( "HANA failed to add feature: %1" )
+    pushError( tr( "SAP HANA failed to add feature: %1" )
                .arg( QgsHanaUtils::formatErrorMessage( ex.what(), false ) ) );
     conn->rollback();
     return false;
@@ -839,7 +839,7 @@ bool QgsHanaProvider::deleteAttributes( const QgsAttributeIds &attributes )
   }
   catch ( const QgsHanaException &ex )
   {
-    pushError( tr( "HANA error while deleting attributes: %1" )
+    pushError( tr( "SAP HANA error while deleting attributes: %1" )
                .arg( QgsHanaUtils::formatErrorMessage( ex.what(), false ) ) );
     conn->rollback();
     return false;
@@ -926,7 +926,7 @@ bool QgsHanaProvider::renameAttributes( const QgsFieldNameMap &fieldMap )
   }
   catch ( const QgsHanaException &ex )
   {
-    pushError( tr( "HANA error while renaming attributes: %1" )
+    pushError( tr( "SAP HANA error while renaming attributes: %1" )
                .arg( QgsHanaUtils::formatErrorMessage( ex.what(), false ) ) );
     conn->rollback();
     return false;
@@ -982,7 +982,7 @@ bool QgsHanaProvider::changeGeometryValues( const QgsGeometryMap &geometryMap )
   }
   catch ( const exception &ex )
   {
-    pushError( tr( "HANA failed to change feature geometry: %1" )
+    pushError( tr( "SAP HANA failed to change feature geometry: %1" )
                .arg( QgsHanaUtils::formatErrorMessage( ex.what(), false ) ) );
     conn->rollback();
     return false;
@@ -1079,7 +1079,7 @@ bool QgsHanaProvider::changeAttributeValues( const QgsChangedAttributesMap &attr
   }
   catch ( const exception &ex )
   {
-    pushError( tr( "HANA failed to change feature attributes: %1" )
+    pushError( tr( "SAP HANA failed to change feature attributes: %1" )
                .arg( QgsHanaUtils::formatErrorMessage( ex.what(), false ) ) );
     conn->rollback();
     return false;

--- a/src/providers/hana/qgshanaprovidergui.cpp
+++ b/src/providers/hana/qgshanaprovidergui.cpp
@@ -28,7 +28,7 @@ class QgsHanaSourceSelectProvider : public QgsSourceSelectProvider
   public:
     QString providerKey() const override { return QgsHanaProvider::HANA_KEY; }
 
-    QString text() const override { return QObject::tr( "HANA" ); }
+    QString text() const override { return QObject::tr( "SAP HANA" ); }
 
     int ordering() const override { return QgsSourceSelectProvider::OrderDatabaseProvider + 70; }
 

--- a/src/providers/hana/qgshanasourceselect.cpp
+++ b/src/providers/hana/qgshanasourceselect.cpp
@@ -222,7 +222,7 @@ QgsHanaSourceSelect::QgsHanaSourceSelect(
   if ( widgetMode() != QgsProviderRegistry::WidgetMode::None )
     mHoldDialogOpen->hide();
   else
-    setWindowTitle( tr( "Add HANA Table(s)" ) );
+    setWindowTitle( tr( "Add SAP HANA Table(s)" ) );
 
   mBuildQueryButton = new QPushButton( tr( "&Set Filter" ) );
   mBuildQueryButton->setToolTip( tr( "Set Filter" ) );
@@ -550,7 +550,7 @@ void QgsHanaSourceSelect::btnConnect_clicked()
   if ( !conn )
   {
     if ( !canceled )
-      QMessageBox::warning( this, tr( "HANA" ), tr( "Unable to connect to a database" ) );
+      QMessageBox::warning( this, tr( "SAP HANA" ), tr( "Unable to connect to a database" ) );
     return;
   }
 

--- a/src/providers/hana/qgshanautils.cpp
+++ b/src/providers/hana/qgshanautils.cpp
@@ -504,6 +504,6 @@ QString QgsHanaUtils::formatErrorMessage( const char *message, bool withPrefix )
   if ( pos != -1 )
     ret = ret.remove( 0, pos + mark.length() );
   if ( withPrefix && ret.indexOf( QLatin1String( "HANA" ) ) == -1 )
-    return QStringLiteral( "HANA: " ) + ret;
+    return QStringLiteral( "SAP HANA: " ) + ret;
   return ret;
 }

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1650,7 +1650,7 @@
      <normaloff>:/images/themes/default/mActionAddHanaLayer.svg</normaloff>:/images/themes/default/mActionAddHanaLayer.svg</iconset>
    </property>
    <property name="text">
-    <string>Add HANA Spatial Layer…</string>
+    <string>Add SAP HANA Spatial Layer…</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+G</string>

--- a/src/ui/qgshananewconnectionbase.ui
+++ b/src/ui/qgshananewconnectionbase.ui
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>Create a New HANA Connection</string>
+   <string>Create a New SAP HANA Connection</string>
   </property>
   <property name="sizeGripEnabled">
    <bool>true</bool>


### PR DESCRIPTION
Replaces the SAP HANA icon with an icon without text.

In the browser it looks like this:
![browser](https://user-images.githubusercontent.com/10857909/105158917-ce13b580-5b0e-11eb-8906-e07487c516a8.png)

The add-layer icon looks like this:
![addlayer](https://user-images.githubusercontent.com/10857909/105159010-e5eb3980-5b0e-11eb-9cd6-5757475965b1.png)

Furthermore, we renamed "HANA" to "SAP HANA" in the UI because "SAP HANA" is the official product name and because there are other things called HANA.