### PR TITLE
Fix very slow RGB rendering when RGB values are out of range

### DIFF
--- a/src/core/pointcloud/qgspointcloudrgbrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudrgbrenderer.cpp
@@ -153,6 +153,10 @@ void QgsPointCloudRgbRenderer::renderBlock( const QgsPointCloudBlock *block, Qgs
         blue = mBlueContrastEnhancement->enhanceContrast( blue );
       }
 
+      red = std::max( 0, std::min( 255, red ) );
+      green = std::max( 0, std::min( 255, green ) );
+      blue = std::max( 0, std::min( 255, blue ) );
+
       drawPoint( x, y, QColor( red, green, blue ), context );
       rendered++;
     }


### PR DESCRIPTION
## Description

When incorrect RGB values are submitted to the renderer we get a lot of warnings from Qt and it makes rendering very slow.
So before rendering we restrict RGB values to the range [0-255]