### PR TITLE
Load min-max values when the selected attribute is changed

### DIFF
--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -75,12 +75,9 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
   mGreenAttributeComboBox->setLayer( layer );
   mBlueAttributeComboBox->setLayer( layer );
 
-  connect( mRedAttributeComboBox, &QgsPointCloudAttributeComboBox::attributeChanged,
-           this, &QgsPointCloud3DSymbolWidget::redAttributeChanged );
-  connect( mGreenAttributeComboBox, &QgsPointCloudAttributeComboBox::attributeChanged,
-           this, &QgsPointCloud3DSymbolWidget::greenAttributeChanged );
-  connect( mBlueAttributeComboBox, &QgsPointCloudAttributeComboBox::attributeChanged,
-           this, &QgsPointCloud3DSymbolWidget::blueAttributeChanged );
+  connect( mRedAttributeComboBox, &QgsPointCloudAttributeComboBox::attributeChanged, this, &QgsPointCloud3DSymbolWidget::redAttributeChanged );
+  connect( mGreenAttributeComboBox, &QgsPointCloudAttributeComboBox::attributeChanged, this, &QgsPointCloud3DSymbolWidget::greenAttributeChanged );
+  connect( mBlueAttributeComboBox, &QgsPointCloudAttributeComboBox::attributeChanged, this, &QgsPointCloud3DSymbolWidget::blueAttributeChanged );
   connect( mContrastEnhancementAlgorithmComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsPointCloud3DSymbolWidget::emitChangedSignal );
 
   // set nice initial values
@@ -100,8 +97,7 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
   connect( mScalarRecalculateMinMaxButton, &QPushButton::clicked, this, &QgsPointCloud3DSymbolWidget::setMinMaxFromLayer );
   connect( mColorRampShaderWidget, &QgsColorRampShaderWidget::widgetChanged, this, &QgsPointCloud3DSymbolWidget::emitChangedSignal );
   connect( mSingleColorBtn, &QgsColorButton::colorChanged, this, &QgsPointCloud3DSymbolWidget::emitChangedSignal );
-  connect( mRenderingParameterComboBox, &QgsPointCloudAttributeComboBox::attributeChanged,
-           this, &QgsPointCloud3DSymbolWidget::rampAttributeChanged );
+  connect( mRenderingParameterComboBox, &QgsPointCloudAttributeComboBox::attributeChanged, this, &QgsPointCloud3DSymbolWidget::rampAttributeChanged );
   connect( mColorRampShaderMinEdit, qgis::overload<double>::of( &QDoubleSpinBox::valueChanged ), this, &QgsPointCloud3DSymbolWidget::minMaxChanged );
   connect( mColorRampShaderMaxEdit, qgis::overload<double>::of( &QDoubleSpinBox::valueChanged ), this, &QgsPointCloud3DSymbolWidget::minMaxChanged );
 
@@ -476,6 +472,7 @@ void QgsPointCloud3DSymbolWidget::rampAttributeChanged()
       mProviderMax = mProviderMax * zScale + zOffset;
     }
   }
+  setMinMaxFromLayer();
   mScalarRecalculateMinMaxButton->setEnabled( !std::isnan( mProviderMin ) && !std::isnan( mProviderMax ) );
   emitChangedSignal();
 }

--- a/src/gui/pointcloud/qgspointcloudattributebyramprendererwidget.cpp
+++ b/src/gui/pointcloud/qgspointcloudattributebyramprendererwidget.cpp
@@ -117,6 +117,7 @@ void QgsPointCloudAttributeByRampRendererWidget::attributeChanged()
     }
 
   }
+  setMinMaxFromLayer();
   mScalarRecalculateMinMaxButton->setEnabled( !std::isnan( mProviderMin ) && !std::isnan( mProviderMax ) );
   emitWidgetChanged();
 }


### PR DESCRIPTION
When the color ramp selected attribute is changed we need to get the min max of that attribute and apply classification automatically