### PR TITLE
qgsimagewarper.cpp: multithreaded image warp

### DIFF
--- a/src/app/georeferencer/qgsimagewarper.cpp
+++ b/src/app/georeferencer/qgsimagewarper.cpp
@@ -244,8 +244,8 @@ int QgsImageWarper::warpFile( const QString &input,
   progressDialog->raise();
   progressDialog->activateWindow();
 
-  eErr = oOperation.ChunkAndWarpImage( 0, 0, destPixels, destLines );
-//  eErr = oOperation.ChunkAndWarpMulti(0, 0, destPixels, destLines);
+//  eErr = oOperation.ChunkAndWarpImage( 0, 0, destPixels, destLines );
+  eErr = oOperation.ChunkAndWarpMulti(0, 0, destPixels, destLines);
 
   destroyGeoToPixelTransform( psWarpOptions->pTransformerArg );
   delete progressDialog;

--- a/src/app/georeferencer/qgsimagewarper.cpp
+++ b/src/app/georeferencer/qgsimagewarper.cpp
@@ -245,7 +245,7 @@ int QgsImageWarper::warpFile( const QString &input,
   progressDialog->activateWindow();
 
 //  eErr = oOperation.ChunkAndWarpImage( 0, 0, destPixels, destLines );
-  eErr = oOperation.ChunkAndWarpMulti(0, 0, destPixels, destLines);
+  eErr = oOperation.ChunkAndWarpMulti( 0, 0, destPixels, destLines );
 
   destroyGeoToPixelTransform( psWarpOptions->pTransformerArg );
   delete progressDialog;

--- a/src/app/georeferencer/qgsimagewarper.cpp
+++ b/src/app/georeferencer/qgsimagewarper.cpp
@@ -244,7 +244,6 @@ int QgsImageWarper::warpFile( const QString &input,
   progressDialog->raise();
   progressDialog->activateWindow();
 
-//  eErr = oOperation.ChunkAndWarpImage( 0, 0, destPixels, destLines );
   eErr = oOperation.ChunkAndWarpMulti( 0, 0, destPixels, destLines );
 
   destroyGeoToPixelTransform( psWarpOptions->pTransformerArg );


### PR DESCRIPTION
Use GDALWarpOperation::ChunkAndWarpMulti() to use multithreading during the compute-intensive image warp stage of georeferencing

## Description

Georeferencing is currently done single-threaded, which can take a long time for large image files. But GDAL has had a multi-threaded image warper function for over a decade. It's time to use it. (The call to the multithreaded function has even been present, commented out, ever since qgsimagewarper was created in 2010.)

[GDAL documentation](https://gdal.org/tutorials/warp_tut.html#performance-optimization) implies that ChunkAndWarpMulti is a drop-in replacement for ChunkAndWarpImage, as long as GDAL is made with multithreading (the default).

Fixes #41101