### PR TITLE
Fix retrieval of sql results from geopackages

### DIFF
--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -423,7 +423,7 @@ QgsAbstractDatabaseProviderConnection::QueryResult QgsGeoPackageProviderConnecti
 
 QVariantList QgsGeoPackageProviderResultIterator::nextRowPrivate()
 {
-  const QVariantList currentRow { mNextRow };
+  const QVariantList currentRow = mNextRow;
   mNextRow = nextRowInternal();
   return currentRow;
 }
@@ -439,10 +439,10 @@ QVariantList QgsGeoPackageProviderResultIterator::nextRowInternal()
       if ( ! mFields.isEmpty() )
       {
         QgsFeature f { QgsOgrUtils::readOgrFeature( fet.get(), mFields, QTextCodec::codecForName( "UTF-8" ) ) };
-        const QgsAttributes &constAttrs { f.attributes() };
-        for ( int i = 0; i < constAttrs.length(); i++ )
+        const QgsAttributes constAttrs  = f.attributes();
+        for ( const QVariant &attribute : constAttrs )
         {
-          row.push_back( constAttrs.at( i ) );
+          row.push_back( attribute );
         }
       }
       else // Fallback to strings

--- a/src/core/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/qgsabstractdatabaseproviderconnection.cpp
@@ -509,7 +509,7 @@ QgsAbstractDatabaseProviderConnection::QueryResult::QueryResult( std::shared_ptr
 QVariantList QgsAbstractDatabaseProviderConnection::QueryResult::QueryResultIterator::nextRow()
 {
   QMutexLocker lock( &mMutex );
-  const QVariantList row { nextRowPrivate() };
+  const QVariantList row = nextRowPrivate();
   if ( ! row.isEmpty() )
   {
     mFetchedRowCount++;

--- a/src/providers/mssql/qgsmssqlproviderconnection.cpp
+++ b/src/providers/mssql/qgsmssqlproviderconnection.cpp
@@ -282,7 +282,7 @@ QgsAbstractDatabaseProviderConnection::QueryResult QgsMssqlProviderConnection::e
 
 QVariantList QgssMssqlProviderResultIterator::nextRowPrivate()
 {
-  const QVariantList currentRow( mNextRow );
+  const QVariantList currentRow = mNextRow;
   mNextRow = nextRowInternal();
   return currentRow;
 }

--- a/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
@@ -478,7 +478,7 @@ QgsSpatialiteProviderResultIterator::~QgsSpatialiteProviderResultIterator()
 
 QVariantList QgsSpatialiteProviderResultIterator::nextRowPrivate()
 {
-  const QVariantList currentRow { mNextRow };
+  const QVariantList currentRow = mNextRow;
   mNextRow = nextRowInternal();
   return currentRow;
 }
@@ -494,10 +494,10 @@ QVariantList QgsSpatialiteProviderResultIterator::nextRowInternal()
       if ( ! mFields.isEmpty() )
       {
         QgsFeature f { QgsOgrUtils::readOgrFeature( fet.get(), mFields, QTextCodec::codecForName( "UTF-8" ) ) };
-        const QgsAttributes &constAttrs { f.attributes() };
-        for ( int i = 0; i < constAttrs.length(); i++ )
+        const QgsAttributes constAttrs  = f.attributes();
+        for ( const QVariant &attribute : constAttrs )
         {
-          row.push_back( constAttrs.at( i ) );
+          row.push_back( attribute );
         }
       }
       else // Fallback to strings


### PR DESCRIPTION
Fixes #40856

@elpaso I had a few minutes this morning to investigate this -- turns out it's that same old brace list initialization issue we've hit time and time again.

Can I humbly suggest that we avoid using this form in QGIS code moving forward? I realise it's supposed to be the modern approach, but it's also been a steady stream of very subtle and difficult to track down issues.