### PR TITLE
[gdal] Enable ALL_CPUS multi-threaded overviews building

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -346,6 +346,13 @@ void QgsApplication::init( QString profileFolder )
   }
   *sSystemEnvVars() = systemEnvVarMap;
 
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,2,0)
+  if ( CPLGetConfigOption( "GDAL_NUM_THREADS", nullptr ) == nullptr )
+  {
+    CPLSetConfigOption( "GDAL_NUM_THREADS", "ALL_CPUS" );
+  }
+#endif
+
 #if PROJ_VERSION_MAJOR>=6
   // append local user-writable folder as a proj search path
   QStringList currentProjSearchPaths = QgsProjUtils::searchPaths();


### PR DESCRIPTION
## Description

A three-line change to speed up GDAL's pyramid overviews building. On a large dataset which normally takes 2min13sec to build pyramids, it goes down to 1min48sec using this PR.

@rouault , is there any downside to setting this config option? 