### PR TITLE
[Oracle] Fix create layer with lowercase and large field names

### DIFF
--- a/src/core/vector/qgsvectorlayerexporter.cpp
+++ b/src/core/vector/qgsvectorlayerexporter.cpp
@@ -139,6 +139,13 @@ QgsVectorLayerExporter::QgsVectorLayerExporter( const QString &uri,
     }
   }
 
+  // Oracle specific HACK: we cannot guess the geometry type when there is no rows, so we need
+  // to force it in the uri
+  if ( providerKey == QLatin1String( "oracle" ) )
+  {
+    uriUpdated += QStringLiteral( " type=%1" ).arg( QgsWkbTypes::displayString( geometryType ) );
+  }
+
   QgsDataProvider::ProviderOptions providerOptions;
   QgsVectorDataProvider *vectorProvider = qobject_cast< QgsVectorDataProvider * >( pReg->createProvider( providerKey, uriUpdated, providerOptions ) );
   if ( !vectorProvider || !vectorProvider->isValid() || ( vectorProvider->capabilities() & QgsVectorDataProvider::AddFeatures ) == 0 )

--- a/tests/src/python/test_provider_oracle.py
+++ b/tests/src/python/test_provider_oracle.py
@@ -951,6 +951,69 @@ class TestPyQgsOracleProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(vl.dataProvider().addFeatures([feature])[0])
         self.assertEqual(countFeature('EMPTYFEATURE_NOGEOM_LAYER'), 1)
 
+    def testCreateLayerLongFieldNames(self):
+        """
+        Test to create an empty layer with long field names
+        """
+
+        # cleanup (it seems overwrite option doesn't clean the sdo_geom_metadata table)
+        self.execSQLCommand('DROP TABLE "QGIS"."LONGFIELD_LAYER"', ignore_errors=True)
+
+        long_name = "this_is_a_very_long_field_name_more_than_30_characters"
+
+        fields = QgsFields()
+        fields.append(QgsField(long_name, QVariant.Int))
+
+        uri = self.dbconn + "table=\"LONGFIELD_LAYER\""
+        exporter = QgsVectorLayerExporter(uri=uri, provider='oracle', fields=fields, geometryType=QgsWkbTypes.Point, crs=QgsCoordinateReferenceSystem("EPSG:4326"), overwrite=True)
+        self.assertEqual(exporter.errorCount(), 0)
+        self.assertEqual(exporter.errorCode(), 0)
+
+        self.execSQLCommand('SELECT count(*) FROM "QGIS"."LONGFIELD_LAYER"')
+        vl = QgsVectorLayer(self.dbconn + ' sslmode=disable table="QGIS"."LONGFIELD_LAYER" sql=', 'test', 'oracle')
+        self.assertTrue(vl.isValid())
+
+        self.assertEqual(vl.fields().names(), [long_name])
+
+    def testCreateGeomLowercase(self):
+        """
+        Test to create an empty layer with either table or geometry column in lower case. It has to fail
+        """
+
+        # table is lower case -> fails
+        self.execSQLCommand('DROP TABLE "QGIS"."lowercase_layer"', ignore_errors=True)
+
+        fields = QgsFields()
+        fields.append(QgsField("test", QVariant.Int))
+
+        uri = self.dbconn + "table=\"lowercase_layer\" (GEOM)"
+        exporter = QgsVectorLayerExporter(uri=uri, provider='oracle', fields=fields, geometryType=QgsWkbTypes.Point, crs=QgsCoordinateReferenceSystem("EPSG:4326"), overwrite=True)
+        self.assertEqual(exporter.errorCode(), 2)
+
+        # geom column is lower case -> fails
+        self.execSQLCommand('DROP TABLE "QGIS"."LOWERCASEGEOM_LAYER"', ignore_errors=True)
+
+        fields = QgsFields()
+        fields.append(QgsField("test", QVariant.Int))
+
+        uri = self.dbconn + "table=\"LOWERCASEGEOM\" (geom)"
+        exporter = QgsVectorLayerExporter(uri=uri, provider='oracle', fields=fields, geometryType=QgsWkbTypes.Point, crs=QgsCoordinateReferenceSystem("EPSG:4326"), overwrite=True)
+        self.assertEqual(exporter.errorCode(), 2)
+
+        # table and geom column are uppercase -> success
+        self.execSQLCommand('DROP TABLE "QGIS"."UPPERCASEGEOM_LAYER"', ignore_errors=True)
+        self.execSQLCommand("""DELETE FROM user_sdo_geom_metadata  where TABLE_NAME = 'UPPERCASEGEOM_LAYER'""")
+
+        fields = QgsFields()
+        fields.append(QgsField("test", QVariant.Int))
+
+        uri = self.dbconn + "table=\"UPPERCASEGEOM_LAYER\" (GEOM)"
+
+        exporter = QgsVectorLayerExporter(uri=uri, provider='oracle', fields=fields, geometryType=QgsWkbTypes.Point, crs=QgsCoordinateReferenceSystem("EPSG:4326"), overwrite=True)
+        print(exporter.errorMessage())
+        self.assertEqual(exporter.errorCount(), 0)
+        self.assertEqual(exporter.errorCode(), 0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In Oracle provider, this PR allows to create field in lowercase and which size is larger than 30. 

I had to add a **Oracle specific HACK** for oracle in *QgsVectorLayerExporter* because it's impossible to guess the geometry type when the table is empty. It's far from being pretty, but there is already a specific branch for OGR and I can't see other way to manage that. 

It also warns correctly the user when he uses lowercase for its geometry table or field name because Oracle doesn't support it well:

https://viswaug.wordpress.com/2011/02/11/oracle-spatial-and-the-web-mercator-spatial-reference-system/

> Oracle makes all the table names and the field names all upper case by default even when you specify the names in lower case in the SQL statements. We can force Oracle to use lower cases alphabets in the table/field names by specifying the table/field names in the SQL statements by enclosing them in quotes.
If you use the technique above to use table/field names in lower case for the spatial tables, you will not be able to register the geometry metadata for the table with Oracle. This is because Oracle expects the spatial table/field name to be in all upper case for insertion into the geometry metadata table. This is just a crazy crazy thing and i can’t imagine this requirement being intentional.

https://docs.oracle.com/database/121/SPATL/geometry-metadata-views.htm#SPATL545

> All letters in the names are converted to uppercase before the names are stored in geometry metadata views or before the tables are accessed. This conversion also applies to any schema name specified with the table name.

