### PR TITLE
Fix the issue of points depending on window's aspect ratio

### DIFF
--- a/src/3d/qgsabstract3dengine.h
+++ b/src/3d/qgsabstract3dengine.h
@@ -77,6 +77,8 @@ class _3D_EXPORT QgsAbstract3DEngine : public QObject
     virtual Qt3DRender::QCamera *camera() = 0;
     //! Returns size of the engine's rendering area in pixels
     virtual QSize size() const = 0;
+    //! Sets the size of the rendering area (in pixels)
+    virtual void setSize( QSize s ) = 0;
 
     /**
      * Starts a request for an image rendered by the engine.

--- a/src/3d/qgsoffscreen3dengine.h
+++ b/src/3d/qgsoffscreen3dengine.h
@@ -68,8 +68,7 @@ class _3D_EXPORT QgsOffscreen3DEngine : public QgsAbstract3DEngine
     QgsOffscreen3DEngine();
     ~QgsOffscreen3DEngine() override;
 
-    //! Sets the size of the rendering area (in pixels)
-    void setSize( QSize s );
+    void setSize( QSize s ) override;
 
     void setClearColor( const QColor &color ) override;
     void setFrustumCullingEnabled( bool enabled ) override;

--- a/src/3d/qgsshadowrenderingframegraph.cpp
+++ b/src/3d/qgsshadowrenderingframegraph.cpp
@@ -45,8 +45,8 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRende
   mRenderCapture = new Qt3DRender::QRenderCapture( mForwardRenderLayerFilter );
 
   mForwardColorTexture = new Qt3DRender::QTexture2D;
-  mForwardColorTexture->setWidth( mWidth );
-  mForwardColorTexture->setHeight( mWidth );
+  mForwardColorTexture->setWidth( mSize.width() );
+  mForwardColorTexture->setHeight( mSize.height() );
   mForwardColorTexture->setFormat( Qt3DRender::QTexture2D::TextureFormat::RGBA16F );
   mForwardColorTexture->setGenerateMipMaps( false );
   mForwardColorTexture->setMagnificationFilter( Qt3DRender::QTexture2D::Linear );
@@ -55,8 +55,8 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRende
   mForwardColorTexture->wrapMode()->setY( Qt3DRender::QTextureWrapMode::ClampToEdge );
 
   mForwardDepthTexture = new Qt3DRender::QTexture2D;
-  mForwardDepthTexture->setWidth( mWidth );
-  mForwardDepthTexture->setHeight( mHeight );
+  mForwardDepthTexture->setWidth( mSize.width() );
+  mForwardDepthTexture->setHeight( mSize.height() );
   mForwardDepthTexture->setFormat( Qt3DRender::QTexture2D::TextureFormat::DepthFormat );
   mForwardDepthTexture->setGenerateMipMaps( false );
   mForwardDepthTexture->setMagnificationFilter( Qt3DRender::QTexture2D::Linear );
@@ -137,11 +137,10 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructPostprocessi
   return mPostprocessPassLayerFilter;
 }
 
-QgsShadowRenderingFrameGraph::QgsShadowRenderingFrameGraph( QWindow *window, int width, int height, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *root )
+QgsShadowRenderingFrameGraph::QgsShadowRenderingFrameGraph( QWindow *window, QSize s, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *root )
   : Qt3DCore::QEntity( root )
 {
-  mWidth = width;
-  mHeight = height;
+  mSize = s;
 
   mRootEntity = root;
   mMainCamera = mainCamera;
@@ -404,10 +403,9 @@ void QgsShadowRenderingFrameGraph::setupDepthMapDebugging( bool enabled, Qt::Cor
   }
 }
 
-void QgsShadowRenderingFrameGraph::setSize( int width, int height )
+void QgsShadowRenderingFrameGraph::setSize( QSize s )
 {
-  mWidth = width;
-  mHeight = height;
-  mForwardColorTexture->setSize( mWidth, mHeight );
-  mForwardDepthTexture->setSize( mWidth, mHeight );
+  mSize = s;
+  mForwardColorTexture->setSize( mSize.width(), mSize.height() );
+  mForwardDepthTexture->setSize( mSize.width(), mSize.height() );
 }

--- a/src/3d/qgsshadowrenderingframegraph.cpp
+++ b/src/3d/qgsshadowrenderingframegraph.cpp
@@ -44,13 +44,9 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRende
 
   mRenderCapture = new Qt3DRender::QRenderCapture( mForwardRenderLayerFilter );
 
-  // TODO: make the width and height change dynamically as the 3D viewer is resized
-  int width = 1024;
-  int height = 768;
-
   mForwardColorTexture = new Qt3DRender::QTexture2D;
-  mForwardColorTexture->setWidth( width );
-  mForwardColorTexture->setHeight( height );
+  mForwardColorTexture->setWidth( mWidth );
+  mForwardColorTexture->setHeight( mWidth );
   mForwardColorTexture->setFormat( Qt3DRender::QTexture2D::TextureFormat::RGBA16F );
   mForwardColorTexture->setGenerateMipMaps( false );
   mForwardColorTexture->setMagnificationFilter( Qt3DRender::QTexture2D::Linear );
@@ -59,8 +55,8 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRende
   mForwardColorTexture->wrapMode()->setY( Qt3DRender::QTextureWrapMode::ClampToEdge );
 
   mForwardDepthTexture = new Qt3DRender::QTexture2D;
-  mForwardDepthTexture->setWidth( width );
-  mForwardDepthTexture->setHeight( height );
+  mForwardDepthTexture->setWidth( mWidth );
+  mForwardDepthTexture->setHeight( mHeight );
   mForwardDepthTexture->setFormat( Qt3DRender::QTexture2D::TextureFormat::DepthFormat );
   mForwardDepthTexture->setGenerateMipMaps( false );
   mForwardDepthTexture->setMagnificationFilter( Qt3DRender::QTexture2D::Linear );
@@ -141,9 +137,12 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructPostprocessi
   return mPostprocessPassLayerFilter;
 }
 
-QgsShadowRenderingFrameGraph::QgsShadowRenderingFrameGraph( QWindow *window, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *root )
+QgsShadowRenderingFrameGraph::QgsShadowRenderingFrameGraph( QWindow *window, int width, int height, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *root )
   : Qt3DCore::QEntity( root )
 {
+  mWidth = width;
+  mHeight = height;
+
   mRootEntity = root;
   mMainCamera = mainCamera;
   mLightCamera = new Qt3DRender::QCamera;
@@ -403,4 +402,12 @@ void QgsShadowRenderingFrameGraph::setupDepthMapDebugging( bool enabled, Qt::Cor
         break;
     }
   }
+}
+
+void QgsShadowRenderingFrameGraph::setSize( int width, int height )
+{
+  mWidth = width;
+  mHeight = height;
+  mForwardColorTexture->setSize( mWidth, mHeight );
+  mForwardDepthTexture->setSize( mWidth, mHeight );
 }

--- a/src/3d/qgsshadowrenderingframegraph.h
+++ b/src/3d/qgsshadowrenderingframegraph.h
@@ -57,7 +57,7 @@ class QgsShadowRenderingFrameGraph : public Qt3DCore::QEntity
 {
   public:
     //! Constructor
-    QgsShadowRenderingFrameGraph( QWindow *window, int width, int height, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *root );
+    QgsShadowRenderingFrameGraph( QWindow *window, QSize s, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *root );
 
     //! Returns the root of the frame graph object
     Qt3DRender::QFrameGraphNode *getFrameGraphRoot() { return mRenderSurfaceSelector; }
@@ -123,7 +123,7 @@ class QgsShadowRenderingFrameGraph : public Qt3DCore::QEntity
     //! Sets the depth map debugging view port
     void setupDepthMapDebugging( bool enabled, Qt::Corner corner, double size );
     //! Sets the size of the buffers used for rendering
-    void setSize( int width, int height );
+    void setSize( QSize s );
   private:
     Qt3DRender::QRenderSurfaceSelector *mRenderSurfaceSelector = nullptr;
     Qt3DRender::QViewport *mMainViewPort = nullptr;
@@ -161,8 +161,7 @@ class QgsShadowRenderingFrameGraph : public Qt3DCore::QEntity
     float mShadowBias = 0.00001f;
     int mShadowMapResolution = 2048;
 
-    int mWidth = 1024;
-    int mHeight = 768;
+    QSize mSize = QSize( 1024, 768 );
 
     bool mEyeDomeLightingEnabled = false;
     double mEyeDomeLightingStrength = 1000.0;

--- a/src/3d/qgsshadowrenderingframegraph.h
+++ b/src/3d/qgsshadowrenderingframegraph.h
@@ -57,7 +57,7 @@ class QgsShadowRenderingFrameGraph : public Qt3DCore::QEntity
 {
   public:
     //! Constructor
-    QgsShadowRenderingFrameGraph( QWindow *window, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *root );
+    QgsShadowRenderingFrameGraph( QWindow *window, int width, int height, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *root );
 
     //! Returns the root of the frame graph object
     Qt3DRender::QFrameGraphNode *getFrameGraphRoot() { return mRenderSurfaceSelector; }
@@ -122,7 +122,8 @@ class QgsShadowRenderingFrameGraph : public Qt3DCore::QEntity
     void setupShadowMapDebugging( bool enabled, Qt::Corner corner, double size );
     //! Sets the depth map debugging view port
     void setupDepthMapDebugging( bool enabled, Qt::Corner corner, double size );
-
+    //! Sets the size of the buffers used for rendering
+    void setSize( int width, int height );
   private:
     Qt3DRender::QRenderSurfaceSelector *mRenderSurfaceSelector = nullptr;
     Qt3DRender::QViewport *mMainViewPort = nullptr;
@@ -159,6 +160,9 @@ class QgsShadowRenderingFrameGraph : public Qt3DCore::QEntity
     bool mShadowRenderingEnabled = false;
     float mShadowBias = 0.00001f;
     int mShadowMapResolution = 2048;
+
+    int mWidth = 1024;
+    int mHeight = 768;
 
     bool mEyeDomeLightingEnabled = false;
     double mEyeDomeLightingStrength = 1000.0;

--- a/src/3d/qgswindow3dengine.cpp
+++ b/src/3d/qgswindow3dengine.cpp
@@ -30,7 +30,7 @@ QgsWindow3DEngine::QgsWindow3DEngine( QObject *parent )
   mRoot = new Qt3DCore::QEntity;
   mWindow3D->setRootEntity( mRoot );
 
-  mShadowRenderingFrameGraph = new QgsShadowRenderingFrameGraph( mWindow3D, 1024, 768, mWindow3D->camera(), mRoot );
+  mShadowRenderingFrameGraph = new QgsShadowRenderingFrameGraph( mWindow3D, QSize( 1024, 768 ), mWindow3D->camera(), mRoot );
 
   mWindow3D->setActiveFrameGraph( mShadowRenderingFrameGraph->getFrameGraphRoot() );
 
@@ -99,9 +99,16 @@ QSurface *QgsWindow3DEngine::surface() const
   return mWindow3D;
 }
 
-void QgsWindow3DEngine::setSize( int width, int height )
+void QgsWindow3DEngine::setSize( QSize s )
 {
-  mWindow3D->setWidth( width );
-  mWindow3D->setHeight( height );
-  mShadowRenderingFrameGraph->setSize( width, height );
+  mSize = s;
+
+//  mTexture->setSize( mSize.width(), mSize.height() );
+//  mDepthTexture->setSize( mSize.width(), mSize.height() );
+//  mSurfaceSelector->setExternalRenderTargetSize( mSize );
+
+  mWindow3D->setWidth( mSize.width() );
+  mWindow3D->setHeight( mSize.height() );
+  mShadowRenderingFrameGraph->setSize( mSize );
+  camera()->setAspectRatio( float( mSize.width() ) / float( mSize.height() ) );
 }

--- a/src/3d/qgswindow3dengine.cpp
+++ b/src/3d/qgswindow3dengine.cpp
@@ -30,7 +30,7 @@ QgsWindow3DEngine::QgsWindow3DEngine( QObject *parent )
   mRoot = new Qt3DCore::QEntity;
   mWindow3D->setRootEntity( mRoot );
 
-  mShadowRenderingFrameGraph = new QgsShadowRenderingFrameGraph( mWindow3D, mWindow3D->camera(), mRoot );
+  mShadowRenderingFrameGraph = new QgsShadowRenderingFrameGraph( mWindow3D, 1024, 768, mWindow3D->camera(), mRoot );
 
   mWindow3D->setActiveFrameGraph( mShadowRenderingFrameGraph->getFrameGraphRoot() );
 
@@ -97,4 +97,11 @@ QSize QgsWindow3DEngine::size() const
 QSurface *QgsWindow3DEngine::surface() const
 {
   return mWindow3D;
+}
+
+void QgsWindow3DEngine::setSize( int width, int height )
+{
+  mWindow3D->setWidth( width );
+  mWindow3D->setHeight( height );
+  mShadowRenderingFrameGraph->setSize( width, height );
 }

--- a/src/3d/qgswindow3dengine.cpp
+++ b/src/3d/qgswindow3dengine.cpp
@@ -103,10 +103,6 @@ void QgsWindow3DEngine::setSize( QSize s )
 {
   mSize = s;
 
-//  mTexture->setSize( mSize.width(), mSize.height() );
-//  mDepthTexture->setSize( mSize.width(), mSize.height() );
-//  mSurfaceSelector->setExternalRenderTargetSize( mSize );
-
   mWindow3D->setWidth( mSize.width() );
   mWindow3D->setHeight( mSize.height() );
   mShadowRenderingFrameGraph->setSize( mSize );

--- a/src/3d/qgswindow3dengine.h
+++ b/src/3d/qgswindow3dengine.h
@@ -78,8 +78,7 @@ class _3D_EXPORT QgsWindow3DEngine : public QgsAbstract3DEngine
     QSize size() const override;
     QSurface *surface() const override;
 
-    //! Sets the size of the window (useful to fix frame graph parameters)
-    void setSize( int width, int height );
+    void setSize( QSize s ) override;
   private:
     //! 3D window with all the 3D magic inside
     Qt3DExtras::Qt3DWindow *mWindow3D = nullptr;
@@ -91,6 +90,7 @@ class _3D_EXPORT QgsWindow3DEngine : public QgsAbstract3DEngine
     Qt3DCore::QEntity *mSceneRoot = nullptr;
 
     QgsPreviewQuad *mPreviewQuad = nullptr;
+    QSize mSize = QSize( 1024, 768 );
 };
 
 #endif // QGSWINDOW3DENGINE_H

--- a/src/3d/qgswindow3dengine.h
+++ b/src/3d/qgswindow3dengine.h
@@ -78,6 +78,8 @@ class _3D_EXPORT QgsWindow3DEngine : public QgsAbstract3DEngine
     QSize size() const override;
     QSurface *surface() const override;
 
+    //! Sets the size of the window (useful to fix frame graph parameters)
+    void setSize( int width, int height );
   private:
     //! 3D window with all the 3D magic inside
     Qt3DExtras::Qt3DWindow *mWindow3D = nullptr;

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -62,8 +62,7 @@ Qgs3DMapCanvas::Qgs3DMapCanvas( QWidget *parent )
   mEngine->window()->setCursor( Qt::OpenHandCursor );
   mEngine->window()->installEventFilter( this );
 
-  if (QgsWindow3DEngine *window = dynamic_cast< QgsWindow3DEngine * >( mEngine ))
-    window->setSize( mContainer->width(), mContainer->height() );
+  mEngine->setSize( mContainer->size() );
 }
 
 Qgs3DMapCanvas::~Qgs3DMapCanvas()
@@ -86,8 +85,8 @@ void Qgs3DMapCanvas::resizeEvent( QResizeEvent *ev )
 
   QRect viewportRect( QPoint( 0, 0 ), size() );
   mScene->cameraController()->setViewport( viewportRect );
-  if (QgsWindow3DEngine *window = dynamic_cast< QgsWindow3DEngine * >( mEngine ))
-    window->setSize( viewportRect.width(), viewportRect.height() );
+
+  mEngine->setSize( viewportRect.size() );
 }
 
 void Qgs3DMapCanvas::setMap( Qgs3DMapSettings *map )

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -95,9 +95,10 @@ void Qgs3DMapCanvas::setMap( Qgs3DMapSettings *map )
   Q_ASSERT( !mMap );
   Q_ASSERT( !mScene );
 
-  //QRect viewportRect( QPoint( 0, 0 ), size() );
+  QRect viewportRect( QPoint( 0, 0 ), size() );
   Qgs3DMapScene *newScene = new Qgs3DMapScene( *map, mEngine );
 
+  mEngine->setSize( viewportRect.size() );
   mEngine->setRootEntity( newScene );
 
   if ( mScene )

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -61,6 +61,9 @@ Qgs3DMapCanvas::Qgs3DMapCanvas( QWidget *parent )
 
   mEngine->window()->setCursor( Qt::OpenHandCursor );
   mEngine->window()->installEventFilter( this );
+
+  if (QgsWindow3DEngine *window = dynamic_cast< QgsWindow3DEngine * >( mEngine ))
+    window->setSize( mContainer->width(), mContainer->height() );
 }
 
 Qgs3DMapCanvas::~Qgs3DMapCanvas()
@@ -83,6 +86,8 @@ void Qgs3DMapCanvas::resizeEvent( QResizeEvent *ev )
 
   QRect viewportRect( QPoint( 0, 0 ), size() );
   mScene->cameraController()->setViewport( viewportRect );
+  if (QgsWindow3DEngine *window = dynamic_cast< QgsWindow3DEngine * >( mEngine ))
+    window->setSize( viewportRect.width(), viewportRect.height() );
 }
 
 void Qgs3DMapCanvas::setMap( Qgs3DMapSettings *map )


### PR DESCRIPTION
## Description
When the 3D window is more or less square shaped, the points look circular (e.g. see the isolated points on the left side)
![bug1](https://user-images.githubusercontent.com/29183781/105364324-540e2a00-5bfd-11eb-803b-2be5c25d80fd.png)

When the 3D window has rectangular shape, the points have elliptic shape
![bug2](https://user-images.githubusercontent.com/29183781/105364557-959ed500-5bfd-11eb-88ef-619da92a34b9.png)


This PR fixes the issue and the points look much sharper now

