### PR TITLE
[Bug] update point cloud 3D automatically after untwining

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -852,6 +852,8 @@ void Qgs3DMapScene::addLayerEntity( QgsMapLayer *layer )
     connect( layer, &QgsMapLayer::rendererChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
   }
 
+  if ( layer->type() == QgsMapLayerType::PointCloudLayer )
+    connect( layer, &QgsMapLayer::renderer3DChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
 }
 
 void Qgs3DMapScene::removeLayerEntity( QgsMapLayer *layer )
@@ -880,6 +882,9 @@ void Qgs3DMapScene::removeLayerEntity( QgsMapLayer *layer )
   {
     disconnect( layer, &QgsMapLayer::rendererChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
   }
+
+  if ( layer->type() == QgsMapLayerType::PointCloudLayer )
+    disconnect( layer, &QgsMapLayer::renderer3DChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
 }
 
 void Qgs3DMapScene::finalizeNewEntity( Qt3DCore::QEntity *newEntity )

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -368,6 +368,8 @@ void QgsPointCloudLayer::onPointCloudIndexGenerationStateChanged( QgsPointCloudD
       setRenderer( QgsApplication::pointCloudRendererRegistry()->defaultRenderer( mDataProvider.get() ) );
     }
     triggerRepaint();
+
+    emit renderer3DChanged();
   }
 }
 


### PR DESCRIPTION
## Description

The 2D rendering is updated automatically, this adds the automatic 3D update after untwining the .laz point cloud.