### PR TITLE
fix: replace comma with point in wms boundingBox

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -1220,11 +1220,13 @@ void QgsWmsCapabilities::parseLayer( const QDomElement &element, QgsWmsLayerProp
       }
       else if ( tagName == QLatin1String( "LatLonBoundingBox" ) )    // legacy from earlier versions of WMS
       {
+        // boundingBox element can conatain comma as decimal separator and layer extent is not
+        // calculated at all. Fixing by replacing comma with point.
         layerProperty.ex_GeographicBoundingBox = QgsRectangle(
-              nodeElement.attribute( QStringLiteral( "minx" ) ).replace( ",", "." ).toDouble(),
-              nodeElement.attribute( QStringLiteral( "miny" ) ).replace( ",", "." ).toDouble(),
-              nodeElement.attribute( QStringLiteral( "maxx" ) ).replace( ",", "." ).toDouble(),
-              nodeElement.attribute( QStringLiteral( "maxy" ) ).replace( ",", "." ).toDouble()
+              nodeElement.attribute( QStringLiteral( "minx" ) ).replace( ',', '.' ).toDouble(),
+              nodeElement.attribute( QStringLiteral( "miny" ) ).replace( ',', '.' ).toDouble(),
+              nodeElement.attribute( QStringLiteral( "maxx" ) ).replace( ',', '.' ).toDouble(),
+              nodeElement.attribute( QStringLiteral( "maxy" ) ).replace( ',', '.' ).toDouble()
             );
 
         if ( nodeElement.hasAttribute( QStringLiteral( "SRS" ) ) && nodeElement.attribute( QStringLiteral( "SRS" ) ) != DEFAULT_LATLON_CRS )
@@ -1263,10 +1265,12 @@ void QgsWmsCapabilities::parseLayer( const QDomElement &element, QgsWmsLayerProp
 
         double wBLong, eBLong, sBLat, nBLat;
         bool wBOk, eBOk, sBOk, nBOk;
-        wBLong = wBoundLongitudeElem.text().toDouble( &wBOk );
-        eBLong = eBoundLongitudeElem.text().toDouble( &eBOk );
-        sBLat = sBoundLatitudeElem.text().toDouble( &sBOk );
-        nBLat = nBoundLatitudeElem.text().toDouble( &nBOk );
+        // boundingBox element can conatain comma as decimal separator and layer extent is not
+        // calculated at all. Fixing by replacing comma with point.
+        wBLong = wBoundLongitudeElem.text().replace( ',', '.' ).toDouble( &wBOk );
+        eBLong = eBoundLongitudeElem.text().replace( ',', '.' ).toDouble( &eBOk );
+        sBLat = sBoundLatitudeElem.text().replace( ',', '.' ).toDouble( &sBOk );
+        nBLat = nBoundLatitudeElem.text().replace( ',', '.' ).toDouble( &nBOk );
         if ( wBOk && eBOk && sBOk && nBOk )
         {
           layerProperty.ex_GeographicBoundingBox = QgsRectangle( wBLong, sBLat, eBLong, nBLat );
@@ -1275,10 +1279,10 @@ void QgsWmsCapabilities::parseLayer( const QDomElement &element, QgsWmsLayerProp
       else if ( tagName == QLatin1String( "BoundingBox" ) )
       {
         QgsWmsBoundingBoxProperty bbox;
-        bbox.box = QgsRectangle( nodeElement.attribute( QStringLiteral( "minx" ) ).replace( ",", "." ).toDouble(),
-                                 nodeElement.attribute( QStringLiteral( "miny" ) ).replace( ",", "." ).toDouble(),
-                                 nodeElement.attribute( QStringLiteral( "maxx" ) ).replace( ",", "." ).toDouble(),
-                                 nodeElement.attribute( QStringLiteral( "maxy" ) ).replace( ",", "." ).toDouble()
+        bbox.box = QgsRectangle( nodeElement.attribute( QStringLiteral( "minx" ) ).replace( ',', '.' ).toDouble(),
+                                 nodeElement.attribute( QStringLiteral( "miny" ) ).replace( ',', '.' ).toDouble(),
+                                 nodeElement.attribute( QStringLiteral( "maxx" ) ).replace( ',', '.' ).toDouble(),
+                                 nodeElement.attribute( QStringLiteral( "maxy" ) ).replace( ',', '.' ).toDouble()
                                );
         if ( nodeElement.hasAttribute( QStringLiteral( "CRS" ) ) || nodeElement.hasAttribute( QStringLiteral( "SRS" ) ) )
         {
@@ -1626,11 +1630,13 @@ void QgsWmsCapabilities::parseTileSetProfile( const QDomElement &element )
       else if ( tagName == QLatin1String( "BoundingBox" ) )
       {
         QgsWmsBoundingBoxProperty boundingBoxProperty;
+        // boundingBox element can conatain comma as decimal separator and layer extent is not
+        // calculated at all. Fixing by replacing comma with point.
         boundingBoxProperty.box = QgsRectangle(
-                                    nodeElement.attribute( QStringLiteral( "minx" ) ).replace( ",", "." ).toDouble(),
-                                    nodeElement.attribute( QStringLiteral( "miny" ) ).replace( ",", "." ).toDouble(),
-                                    nodeElement.attribute( QStringLiteral( "maxx" ) ).replace( ",", "." ).toDouble(),
-                                    nodeElement.attribute( QStringLiteral( "maxy" ) ).replace( ",", "." ).toDouble()
+                                    nodeElement.attribute( QStringLiteral( "minx" ) ).replace( ',', '.' ).toDouble(),
+                                    nodeElement.attribute( QStringLiteral( "miny" ) ).replace( ',', '.' ).toDouble(),
+                                    nodeElement.attribute( QStringLiteral( "maxx" ) ).replace( ',', '.' ).toDouble(),
+                                    nodeElement.attribute( QStringLiteral( "maxy" ) ).replace( ',', '.' ).toDouble()
                                   );
         if ( nodeElement.hasAttribute( QStringLiteral( "SRS" ) ) )
           boundingBoxProperty.crs = nodeElement.attribute( QStringLiteral( "SRS" ) );

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -1221,10 +1221,10 @@ void QgsWmsCapabilities::parseLayer( const QDomElement &element, QgsWmsLayerProp
       else if ( tagName == QLatin1String( "LatLonBoundingBox" ) )    // legacy from earlier versions of WMS
       {
         layerProperty.ex_GeographicBoundingBox = QgsRectangle(
-              nodeElement.attribute( QStringLiteral( "minx" ) ).toDouble(),
-              nodeElement.attribute( QStringLiteral( "miny" ) ).toDouble(),
-              nodeElement.attribute( QStringLiteral( "maxx" ) ).toDouble(),
-              nodeElement.attribute( QStringLiteral( "maxy" ) ).toDouble()
+              nodeElement.attribute( QStringLiteral( "minx" ) ).replace( ",", "." ).toDouble(),
+              nodeElement.attribute( QStringLiteral( "miny" ) ).replace( ",", "." ).toDouble(),
+              nodeElement.attribute( QStringLiteral( "maxx" ) ).replace( ",", "." ).toDouble(),
+              nodeElement.attribute( QStringLiteral( "maxy" ) ).replace( ",", "." ).toDouble()
             );
 
         if ( nodeElement.hasAttribute( QStringLiteral( "SRS" ) ) && nodeElement.attribute( QStringLiteral( "SRS" ) ) != DEFAULT_LATLON_CRS )
@@ -1275,10 +1275,10 @@ void QgsWmsCapabilities::parseLayer( const QDomElement &element, QgsWmsLayerProp
       else if ( tagName == QLatin1String( "BoundingBox" ) )
       {
         QgsWmsBoundingBoxProperty bbox;
-        bbox.box = QgsRectangle( nodeElement.attribute( QStringLiteral( "minx" ) ).toDouble(),
-                                 nodeElement.attribute( QStringLiteral( "miny" ) ).toDouble(),
-                                 nodeElement.attribute( QStringLiteral( "maxx" ) ).toDouble(),
-                                 nodeElement.attribute( QStringLiteral( "maxy" ) ).toDouble()
+        bbox.box = QgsRectangle( nodeElement.attribute( QStringLiteral( "minx" ) ).replace( ",", "." ).toDouble(),
+                                 nodeElement.attribute( QStringLiteral( "miny" ) ).replace( ",", "." ).toDouble(),
+                                 nodeElement.attribute( QStringLiteral( "maxx" ) ).replace( ",", "." ).toDouble(),
+                                 nodeElement.attribute( QStringLiteral( "maxy" ) ).replace( ",", "." ).toDouble()
                                );
         if ( nodeElement.hasAttribute( QStringLiteral( "CRS" ) ) || nodeElement.hasAttribute( QStringLiteral( "SRS" ) ) )
         {
@@ -1627,10 +1627,10 @@ void QgsWmsCapabilities::parseTileSetProfile( const QDomElement &element )
       {
         QgsWmsBoundingBoxProperty boundingBoxProperty;
         boundingBoxProperty.box = QgsRectangle(
-                                    nodeElement.attribute( QStringLiteral( "minx" ) ).toDouble(),
-                                    nodeElement.attribute( QStringLiteral( "miny" ) ).toDouble(),
-                                    nodeElement.attribute( QStringLiteral( "maxx" ) ).toDouble(),
-                                    nodeElement.attribute( QStringLiteral( "maxy" ) ).toDouble()
+                                    nodeElement.attribute( QStringLiteral( "minx" ) ).replace( ",", "." ).toDouble(),
+                                    nodeElement.attribute( QStringLiteral( "miny" ) ).replace( ",", "." ).toDouble(),
+                                    nodeElement.attribute( QStringLiteral( "maxx" ) ).replace( ",", "." ).toDouble(),
+                                    nodeElement.attribute( QStringLiteral( "maxy" ) ).replace( ",", "." ).toDouble()
                                   );
         if ( nodeElement.hasAttribute( QStringLiteral( "SRS" ) ) )
           boundingBoxProperty.crs = nodeElement.attribute( QStringLiteral( "SRS" ) );


### PR DESCRIPTION
## Description

is this fix reasonable to cover cases like the link below too?

(GetCapabilities) http://sgi2.isprambiente.it/arcgis/services/servizi/Geologia25k/MapServer/WmsServer?Request=GetCapabilities&service=WMS

replacing comma with point in boundingBox coordinates.

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
