### PR TITLE
add qgsvectortilewriter.cpp to list of sources requiring PROTOBUF_USE_DLLS

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1631,7 +1631,7 @@ protobuf_generate_cpp(VECTOR_TILE_PROTO_SRCS VECTOR_TILE_PROTO_HDRS vectortile/v
 set(QGIS_CORE_SRCS ${QGIS_CORE_SRCS} ${VECTOR_TILE_PROTO_SRCS})
 set(QGIS_CORE_HDRS ${QGIS_CORE_HDRS} ${VECTOR_TILE_PROTO_HDRS})
 if (MSVC)
-  set_source_files_properties(${VECTOR_TILE_PROTO_SRCS} vectortile/qgsvectortilemvtdecoder.cpp vectortile/qgsvectortilemvtencoder.cpp PROPERTIES COMPILE_DEFINITIONS PROTOBUF_USE_DLLS)
+  set_source_files_properties(${VECTOR_TILE_PROTO_SRCS} vectortile/qgsvectortilemvtdecoder.cpp vectortile/qgsvectortilemvtencoder.cpp vectortile/qgsvectortilewriter.cpp PROPERTIES COMPILE_DEFINITIONS PROTOBUF_USE_DLLS)
 else()
   # automatically generated file produces warnings (unused-parameter, unused-variable, misleading-indentation)
   set_source_files_properties(${VECTOR_TILE_PROTO_SRCS} PROPERTIES COMPILE_FLAGS -w)


### PR DESCRIPTION
Another patch from conda-forge (https://github.com/conda-forge/qgis-feedstock). Without this Windows builds fail with:
```
libprotobuf-lite.lib(libprotobuf-lite.dll) : error LNK2005: "public: class google::protobuf::Arena * __cdecl google::protobuf::MessageLite::GetArena(void)const " (?GetArena@MessageLite@protobuf@google@@QEBAPEAVArena@23@XZ) already defined in qgsvectortilewriter.cpp.obj
```
I think this is because `vectortile/qgsvectortilewriter.cpp` does include `libprotobuf` via the various other files that are included (like much of the vectortile sources) and GetArena() is not correctly marked as DllImport without this define.

I'm not sure why the QGIS CI succeeds without this, but I am assuming that you have an older version of `libprotobuf` and this issue doesn't happen with that version. I'm hoping adding this doesn't break your build....
