### PR TITLE
Make primary key requirements less restrictive in HANA

### DIFF
--- a/src/providers/hana/qgshanaconnection.cpp
+++ b/src/providers/hana/qgshanaconnection.cpp
@@ -762,7 +762,7 @@ QgsHanaResultSetRef QgsHanaConnection::getColumns( const QString &schemaName, co
 
 bool  QgsHanaConnection::isTable( const QString &schemaName, const QString &tableName )
 {
-  QString sql = "SELECT COUNT(*) FROM SYS.TABLES WHERE SCHEMA_NAME = ? AND TABLE_NAME = ?";
+  QString sql = QStringLiteral( "SELECT COUNT(*) FROM SYS.TABLES WHERE SCHEMA_NAME = ? AND TABLE_NAME = ?" );
   return executeCountQuery( sql, {schemaName, tableName } ) == 1;
 }
 

--- a/src/providers/hana/qgshanaconnection.cpp
+++ b/src/providers/hana/qgshanaconnection.cpp
@@ -760,6 +760,12 @@ QgsHanaResultSetRef QgsHanaConnection::getColumns( const QString &schemaName, co
   }
 }
 
+bool  QgsHanaConnection::isTable( const QString &schemaName, const QString &tableName )
+{
+  QString sql = "SELECT COUNT(*) FROM SYS.TABLES WHERE SCHEMA_NAME = ? AND TABLE_NAME = ?";
+  return executeCountQuery( sql, {schemaName, tableName } ) == 1;
+}
+
 PreparedStatementRef QgsHanaConnection::createPreparedStatement( const QString &sql, const QVariantList &args )
 {
   PreparedStatementRef stmt = mConnection->prepareStatement( QgsHanaUtils::toUtf16( sql ) );

--- a/src/providers/hana/qgshanaconnection.h
+++ b/src/providers/hana/qgshanaconnection.h
@@ -71,6 +71,7 @@ class QgsHanaConnection : public QObject
     QString getColumnDataType( const QString &schemaName, const QString &tableName, const QString &columnName );
     int getColumnSrid( const QString &schemaName, const QString &tableName, const QString &columnName );
     QgsHanaResultSetRef getColumns( const QString &schemaName, const QString &tableName, const QString &fieldName );
+    bool isTable( const QString &schemaName, const QString &tableName );
 
     static QgsHanaConnection *createConnection( const QgsDataSourceUri &uri );
     static QgsHanaConnection *createConnection( const QgsDataSourceUri &uri, bool *canceled );

--- a/src/providers/hana/qgshanaprimarykeys.cpp
+++ b/src/providers/hana/qgshanaprimarykeys.cpp
@@ -155,7 +155,7 @@ QPair<QgsHanaPrimaryKeyType, QList<int>> QgsHanaPrimaryKeyUtils::determinePrimar
   if ( !attrs.isEmpty() )
     keyType = ( attrs.size() == 1 ) ? getPrimaryKeyType( fields.at( attrs[0] ) ) : PktFidMap;
   else
-    QgsMessageLog::logMessage( QObject::tr( "Keys for view/query undefined." ), QObject::tr( "SAP HANA" ) );
+    QgsMessageLog::logMessage( QObject::tr( "Keys for view/query undefined. Some functionality might not be available." ), QObject::tr( "SAP HANA" ) );
 
   return qMakePair( keyType, attrs );
 }


### PR DESCRIPTION
This change allows creating a valid HANA provider with undefined primary key.
