### PR TITLE
fix discovering relation when a table has relation with several layers

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -5036,10 +5036,9 @@ QList<QgsRelation> QgsPostgresProvider::discoverRelations( const QgsVectorLayer 
     {
       // multi reference field => add the field pair to all the referenced layers found
       const QList<QgsVectorLayer *> foundLayers = searchLayers( layers, mUri.connectionInfo( false ), refSchema, refTable );
-      const auto constFoundLayers = foundLayers;
       for ( int i = 0; i < nbFound; ++i )
       {
-        for ( const QgsVectorLayer *foundLayer : constFoundLayers )
+        for ( const QgsVectorLayer *foundLayer : foundLayers )
         {
           if ( result[result.size() - 1 - i].referencedLayerId() == foundLayer->id() )
           {

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -5035,9 +5035,17 @@ QList<QgsRelation> QgsPostgresProvider::discoverRelations( const QgsVectorLayer 
     else
     {
       // multi reference field => add the field pair to all the referenced layers found
+      const QList<QgsVectorLayer *> foundLayers = searchLayers( layers, mUri.connectionInfo( false ), refSchema, refTable );
+      const auto constFoundLayers = foundLayers;
       for ( int i = 0; i < nbFound; ++i )
       {
-        result[result.size() - 1 - i].addFieldPair( fkColumn, refColumn );
+        for ( const QgsVectorLayer *foundLayer : constFoundLayers )
+        {
+          if ( result[result.size() - 1 - i].referencedLayerId() == foundLayer->id() )
+          {
+            result[result.size() - 1 - i].addFieldPair( fkColumn, refColumn );
+          }
+        }
       }
     }
   }

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -4989,6 +4989,7 @@ QList<QgsRelation> QgsPostgresProvider::discoverRelations( const QgsVectorLayer 
   }
 
   int nbFound = 0;
+  QList<QString> refTableFound;
   for ( int row = 0; row < sqlResult.PQntuples(); ++row )
   {
     const QString name = sqlResult.PQgetvalue( row, 0 );
@@ -5006,7 +5007,7 @@ QList<QgsRelation> QgsPostgresProvider::discoverRelations( const QgsVectorLayer 
     }
     const QString refColumn = sqlResult.PQgetvalue( row, 4 );
     const QString position = sqlResult.PQgetvalue( row, 5 );
-    if ( ( position == QLatin1String( "1" ) ) || ( nbFound == 0 ) )
+    if ( ( position == QLatin1String( "1" ) ) || ( nbFound == 0 ) || ( !refTableFound.contains( refTable ) ) )
     {
       // first reference field => try to find if we have layers for the referenced table
       const QList<QgsVectorLayer *> foundLayers = searchLayers( layers, mUri.connectionInfo( false ), refSchema, refTable );
@@ -5023,6 +5024,7 @@ QList<QgsRelation> QgsPostgresProvider::discoverRelations( const QgsVectorLayer 
         {
           result.append( relation );
           ++nbFound;
+          refTableFound.append( refTable );
         }
         else
         {

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2273,6 +2273,9 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         _test(vl, [1, 3])
 
     def testValidLayerDiscoverRelationsNone(self):
+        """
+        Test checks that discover relation feature can be used on a layer that has no relation.
+        """
         vl = QgsVectorLayer(
             self.dbconn +
             ' sslmode=disable key=\'pk\' srid=4326 type=POINT table="qgis_test"."someData" (geom) sql=',
@@ -2281,12 +2284,19 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(vl.dataProvider().discoverRelations(vl, []), [])
 
     def testInvalidLayerDiscoverRelations(self):
+        """
+        Test that discover relations feature can be used on invalid layer.
+        """
         vl = QgsVectorLayer('{} table="qgis_test"."invalid_layer" sql='.format(self.dbconn), "invalid_layer",
                             "postgres")
         self.assertFalse(vl.isValid())
         self.assertEqual(vl.dataProvider().discoverRelations(vl, []), [])
 
     def testValidLayerDiscoverRelations(self):
+        """
+        Test implicit relations that can be discovers between tables, based on declared foreign keys.
+        The test also checks that two distinct relations can be discovered when two foreign keys are declared (see #41138).
+        """
         vl = QgsVectorLayer(
             self.dbconn +
             ' sslmode=disable key=\'pk\' checkPrimaryKeyUnicity=\'1\' table="qgis_test"."referencing_layer"',

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2286,6 +2286,31 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertFalse(vl.isValid())
         self.assertEqual(vl.dataProvider().discoverRelations(vl, []), [])
 
+    def testValidLayerDiscoverRelations(self):
+        vl = QgsVectorLayer(
+            self.dbconn +
+            ' sslmode=disable key=\'pk\' checkPrimaryKeyUnicity=\'1\' table="qgis_test"."referencing_layer"',
+            'referencing_layer', 'postgres')
+        vls = [
+            QgsVectorLayer(
+                self.dbconn +
+                ' sslmode=disable key=\'pk_ref_1\' checkPrimaryKeyUnicity=\'1\' table="qgis_test"."referenced_layer_1"',
+                'referenced_layer_1', 'postgres'),
+            QgsVectorLayer(
+                self.dbconn +
+                ' sslmode=disable key=\'pk_ref_2\' checkPrimaryKeyUnicity=\'1\' table="qgis_test"."referenced_layer_2"',
+                'referenced_layer_2', 'postgres'),
+            vl
+        ]
+
+        for lyr in vls:
+            self.assertTrue(lyr.isValid())
+            QgsProject.instance().addMapLayer(lyr)
+        relations = vl.dataProvider().discoverRelations(vl, vls)
+        self.assertEqual(len(relations), 2)
+        for i, r in enumerate(relations):
+            self.assertEqual(r.referencedLayer(), vls[i])
+
     def testCheckTidPkOnViews(self):
         """Test vector layer based on a view with `ctid` as a key"""
 

--- a/tests/src/python/test_qgsrelationpostgres.py
+++ b/tests/src/python/test_qgsrelationpostgres.py
@@ -61,7 +61,9 @@ class TestQgsRelationPostgresql(unittest.TestCase):
             QgsProject.instance().addMapLayer(vl_tables[i])
 
         relations = self.relMgr.discoverRelations([], vl_tables)
-        self.assertEqual(len(relations), 10)
+        for r in relations:
+            self.assertTrue(r.isValid())
+        self.assertEqual(len(relations), 18)
         self.assertEqual(sum([len(r.referencingFields()) for r in relations]), 18)
         self.assertEqual(sum([len(r.referencedFields()) for r in relations]), 18)
 

--- a/tests/testdata/provider/testdata_pg.sql
+++ b/tests/testdata/provider/testdata_pg.sql
@@ -721,3 +721,27 @@ CREATE TABLE IF NOT EXISTS "test_check_constraint" (
 INSERT INTO test_check_constraint (geom, i_will_fail_on_no_name)
 VALUES ('SRID=4326;POINT(9 45)'::geometry, 'I have a name'), ('SRID=4326;POINT(10 46)'::geometry, 'I have a name too');
 
+---------------------------------------------
+--
+-- Tables to check tables relation in project
+--
+
+CREATE TABLE qgis_test.referenced_layer_1(
+  pk_ref_1 serial primary key 
+);
+
+CREATE TABLE qgis_test.referenced_layer_2(
+  pk_ref_2 serial primary key 
+);
+
+CREATE TABLE qgis_test.referencing_layer(
+  pk serial primary key,
+  fk_ref_1 integer,
+  fk_ref_2 integer,
+    CONSTRAINT fk_ref_1
+      FOREIGN KEY(fk_ref_1) 
+    REFERENCES qgis_test.referenced_layer_1(pk_ref_1),
+    CONSTRAINT fk_ref_2
+      FOREIGN KEY(fk_ref_2) 
+    REFERENCES qgis_test.referenced_layer_2(pk_ref_2)
+);


### PR DESCRIPTION
## Bug :  discovering relation when a table has relation with several layers

related to #37833

When a layer has relations with more than one layer, the discoversRelations function in postgresql provider doesn't work as expected. @lbartoletti has already fixed the most part of it in #37833. But using the provided dataset, discoversRelations returns relations as the following :

| Name | Referencing layer | Referencing Field | Referenced Layer | Referenced Field|
|------|-------------------|-------------------|------------------|-----------------|
c_amgmt_amgmt_lot_fk | c_amgmt_amgmt_lot_fk | id_amgmt, id_amgmt_lot |t_amgmt | id_amgmt, id_amgmt_lot|

with two referencing fields. In fact, the second field does not exist in `t_amgmt` table, but it exists in `t_amgmt_lot` (see [sql code](https://github.com/lbartoletti/QGIS/blob/d969caba7c67ba92bd84807aff778d3d149cf36e/tests/testdata/provider/testdata_pg_relations.sql#L710)), so it should return : 

| Name | Referencing layer | Referencing Field | Referenced Layer | Referenced Field|
|------|-------------------|-------------------|------------------|-----------------|
c_amgmt_amgmt_lot_fk | c_amgmt_amgmt_lot_fk | id_amgmt |t_amgmt | id_amgmt|
c_amgmt_amgmt_lot_fk_amgt_lot | c_amgmt_amgmt_lot_fk | id_amgmt_lot |t_amgmt_lot | id_amgmt_lot|

There is the following check in postgres provider : 

```cpp
if ( ( position == QLatin1String( "1" ) ) || ( nbFound == 0 ) )
    // new relation will be created
else
    // a key pair is added to the previous relation
```
The bug appends because the ordinal position of the fk columns are not 1 (not sure why it checks this), so the second relation is not considered and only a key pair is added to the first relation.

I changed the condition to check if the second relation is related to a table that has already been registered in a relation. 

```cpp
if ( ( position == QLatin1String( "1" ) ) || ( nbFound == 0 ) || ( !refTableFound.contains( refTable ) ) )
    // new relation will be created
else
    // a key pair is added to the previous relation that has the same referenced layer
```