### PR TITLE
Update qgsfirstrundialog.ui

### DIFF
--- a/src/ui/qgsfirstrundialog.ui
+++ b/src/ui/qgsfirstrundialog.ui
@@ -68,7 +68,7 @@
         </font>
        </property>
        <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://changelog.qgis.org/en/qgis/version/3.4-LTR/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2a76c6;&quot;&gt;Check out &lt;/span&gt;&lt;/a&gt;the change log for all the new stuff.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://changelog.qgis.org/en/qgis/version/3.16/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2a76c6;&quot;&gt;Check out &lt;/span&gt;&lt;/a&gt;the change log for all the new stuff.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>


### PR DESCRIPTION
The changelog link was still pointing to the 3.4-LTR changelog. Edited to point to 3.16.

Fix #41028