### PR TITLE
EPT parser: fix precision loss when parsing offset and scale

### DIFF
--- a/src/core/pointcloud/qgseptpointcloudindex.cpp
+++ b/src/core/pointcloud/qgseptpointcloudindex.cpp
@@ -141,11 +141,11 @@ bool QgsEptPointCloudIndex::loadSchema( QFile &f )
       return false;
     }
 
-    float scale = 1.f;
+    double scale = 1.f;
     if ( schemaObj.contains( QLatin1String( "scale" ) ) )
       scale = schemaObj.value( QLatin1String( "scale" ) ).toDouble();
 
-    float offset = 0.f;
+    double offset = 0.f;
     if ( schemaObj.contains( QLatin1String( "offset" ) ) )
       offset = schemaObj.value( QLatin1String( "offset" ) ).toDouble();
 


### PR DESCRIPTION
Parsing a double to float and then passing back to double was loosing some precision (mainly for offset).