### PR TITLE
[Bug] Don't impose format on arc map layer from browser

### DIFF
--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -321,7 +321,7 @@ void QgsArcGisRestQueryUtils::addLayerItems( const std::function<void ( const QS
 {
   const QString authid = QgsArcGisRestUtils::convertSpatialReference( serviceData.value( QStringLiteral( "spatialReference" ) ).toMap() ).authid();
 
-  QString format = QStringLiteral( "jpg" );
+  QString format = QStringLiteral( "" );
   bool found = false;
   const QList<QByteArray> supportedFormats = QImageReader::supportedImageFormats();
   const QStringList supportedImageFormatTypes = serviceData.value( QStringLiteral( "supportedImageFormatTypes" ) ).toString().split( ',' );

--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -321,7 +321,7 @@ void QgsArcGisRestQueryUtils::addLayerItems( const std::function<void ( const QS
 {
   const QString authid = QgsArcGisRestUtils::convertSpatialReference( serviceData.value( QStringLiteral( "spatialReference" ) ).toMap() ).authid();
 
-  QString format = QStringLiteral( "" );
+  QString format = QString();
   bool found = false;
   const QList<QByteArray> supportedFormats = QImageReader::supportedImageFormats();
   const QStringList supportedImageFormatTypes = serviceData.value( QStringLiteral( "supportedImageFormatTypes" ) ).toString().split( ',' );


### PR DESCRIPTION
## Description

Fixes #41126 

Now, @elpaso I'm not sure if you are the one most familiar with this provider, but is there any downsides to not coercing and output format when making a request? It may be mandatory for WMS but for esri servers it seems to optimised the output or use any one. Which seems like a fine solution.

I tried to find a better way but the URI related code is all over the place and this was the easiest solution I could find.