### PR TITLE
Followup #41109: fix algorithms

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/join_by_location_summary_date.gml
+++ b/python/plugins/processing/tests/testdata/expected/join_by_location_summary_date.gml
@@ -18,7 +18,7 @@
       <ogr:intval>33</ogr:intval>
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:date_count>4</ogr:date_count>
-      <ogr:date_unique>3</ogr:date_unique>
+      <ogr:date_unique>4</ogr:date_unique>
       <ogr:date_empty>1</ogr:date_empty>
       <ogr:date_filled>3</ogr:date_filled>
       <ogr:date_min>2005/09/13</ogr:date_min>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests2.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests2.yaml
@@ -1115,7 +1115,7 @@ tests:
         rules:
           - 'Analyzed field: date_time'
           - 'Count: 4'
-          - 'Unique values: 3'
+          - 'Unique values: 4'
           - 'Minimum value: 2014-11-30T14:30:02'
           - 'Maximum value: 2016-11-30T14:29:22'
           - 'NULL \(missing\) values: 1'
@@ -1134,7 +1134,7 @@ tests:
         rules:
           - 'Analyzed field: date'
           - 'Count: 4'
-          - 'Unique values: 3'
+          - 'Unique values: 4'
           - 'Minimum value: 2014-11-30T00:00:00'
           - 'Maximum value: 2016-11-30T00:00:00'
           - 'NULL \(missing\) values: 1'
@@ -1153,7 +1153,7 @@ tests:
         rules:
           - 'Analyzed field: time'
           - 'Count: 4'
-          - 'Unique values: 3'
+          - 'Unique values: 4'
           - 'Minimum value: 03:29:40'
           - 'Maximum value: 15:29:22'
           - 'NULL \(missing\) values: 1'

--- a/src/analysis/processing/qgsalgorithmpointslayerfromtable.cpp
+++ b/src/analysis/processing/qgsalgorithmpointslayerfromtable.cpp
@@ -132,14 +132,14 @@ QVariantMap QgsPointsLayerFromTableAlgorithm::processAlgorithm( const QVariantMa
     double x = attrs.at( xFieldIndex ).toDouble( &xOk );
     double y = attrs.at( yFieldIndex ).toDouble( &yOk );
 
-    if ( xOk && yOk )
+    if ( ! attrs.at( xFieldIndex ).isNull() && ! attrs.at( yFieldIndex ).isNull() && xOk && yOk )
     {
       QgsPoint point( x, y );
 
-      if ( zFieldIndex >= 0 )
+      if ( zFieldIndex >= 0 && ! attrs.at( zFieldIndex ).isNull() )
         point.addZValue( attrs.at( zFieldIndex ).toDouble() );
 
-      if ( mFieldIndex >= 0 )
+      if ( mFieldIndex >= 0 && ! attrs.at( mFieldIndex ).isNull() )
         point.addMValue( attrs.at( mFieldIndex ).toDouble() );
 
       f.setGeometry( QgsGeometry( point.clone() ) );

--- a/src/core/qgsdatetimestatisticalsummary.cpp
+++ b/src/core/qgsdatetimestatisticalsummary.cpp
@@ -65,14 +65,14 @@ void QgsDateTimeStatisticalSummary::addValue( const QVariant &value )
   else if ( value.type() == QVariant::Date )
   {
     QDate date = value.toDate();
-    testDateTime( date.isValid() ? QDateTime( date, QTime( 0, 0, 0 ) )
+    testDateTime( ! date.isNull() ? QDateTime( date, QTime( 0, 0, 0 ) )
                   : QDateTime() );
   }
   else if ( value.type() == QVariant::Time )
   {
     mIsTimes = true;
     QTime time = value.toTime();
-    testDateTime( time.isValid() ? QDateTime( QDate::fromJulianDay( 0 ), time )
+    testDateTime( ! time.isNull() ? QDateTime( QDate::fromJulianDay( 0 ), time )
                   : QDateTime() );
   }
   else //not a date

--- a/src/core/qgsdatetimestatisticalsummary.cpp
+++ b/src/core/qgsdatetimestatisticalsummary.cpp
@@ -58,27 +58,35 @@ void QgsDateTimeStatisticalSummary::calculate( const QVariantList &values )
 
 void QgsDateTimeStatisticalSummary::addValue( const QVariant &value )
 {
-  if ( value.type() == QVariant::DateTime )
-  {
-    testDateTime( value.toDateTime() );
-  }
-  else if ( value.type() == QVariant::Date )
-  {
-    QDate date = value.toDate();
-    testDateTime( ! date.isNull() ? QDateTime( date, QTime( 0, 0, 0 ) )
-                  : QDateTime() );
-  }
-  else if ( value.type() == QVariant::Time )
-  {
-    mIsTimes = true;
-    QTime time = value.toTime();
-    testDateTime( ! time.isNull() ? QDateTime( QDate::fromJulianDay( 0 ), time )
-                  : QDateTime() );
-  }
-  else //not a date
+  if ( value.isNull() )
   {
     mCountMissing++;
     mCount++;
+  }
+  else
+  {
+    if ( value.type() == QVariant::DateTime )
+    {
+      testDateTime( value.toDateTime() );
+    }
+    else if ( value.type() == QVariant::Date )
+    {
+      QDate date = value.toDate();
+      testDateTime( date.isValid() ? QDateTime( date, QTime( 0, 0, 0 ) )
+                    : QDateTime() );
+    }
+    else if ( value.type() == QVariant::Time )
+    {
+      mIsTimes = true;
+      QTime time = value.toTime();
+      testDateTime( time.isValid() ? QDateTime( QDate::fromJulianDay( 0 ), time )
+                    : QDateTime() );
+    }
+    else //not a date
+    {
+      mCountMissing++;
+      mCount++;
+    }
   }
   // QTime?
 }

--- a/src/core/qgsdatetimestatisticalsummary.cpp
+++ b/src/core/qgsdatetimestatisticalsummary.cpp
@@ -58,36 +58,30 @@ void QgsDateTimeStatisticalSummary::calculate( const QVariantList &values )
 
 void QgsDateTimeStatisticalSummary::addValue( const QVariant &value )
 {
-  if ( value.isNull() )
+
+  if ( value.type() == QVariant::DateTime )
+  {
+    testDateTime( value.toDateTime(), value.isNull() );
+  }
+  else if ( value.type() == QVariant::Date )
+  {
+    QDate date = value.toDate();
+    testDateTime( date.isValid() ? QDateTime( date, QTime( 0, 0, 0 ) )
+                  : QDateTime(), value.isNull() );
+  }
+  else if ( value.type() == QVariant::Time )
+  {
+    mIsTimes = true;
+    QTime time = value.toTime();
+    testDateTime( time.isValid() ? QDateTime( QDate::fromJulianDay( 0 ), time )
+                  : QDateTime(), value.isNull() );
+  }
+  else //not a date
   {
     mCountMissing++;
     mCount++;
   }
-  else
-  {
-    if ( value.type() == QVariant::DateTime )
-    {
-      testDateTime( value.toDateTime() );
-    }
-    else if ( value.type() == QVariant::Date )
-    {
-      QDate date = value.toDate();
-      testDateTime( date.isValid() ? QDateTime( date, QTime( 0, 0, 0 ) )
-                    : QDateTime() );
-    }
-    else if ( value.type() == QVariant::Time )
-    {
-      mIsTimes = true;
-      QTime time = value.toTime();
-      testDateTime( time.isValid() ? QDateTime( QDate::fromJulianDay( 0 ), time )
-                    : QDateTime() );
-    }
-    else //not a date
-    {
-      mCountMissing++;
-      mCount++;
-    }
-  }
+
   // QTime?
 }
 
@@ -97,11 +91,11 @@ void QgsDateTimeStatisticalSummary::finalize()
   //if statistics are implemented which require a post-calculation step
 }
 
-void QgsDateTimeStatisticalSummary::testDateTime( const QDateTime &dateTime )
+void QgsDateTimeStatisticalSummary::testDateTime( const QDateTime &dateTime, bool isNull )
 {
   mCount++;
 
-  if ( !dateTime.isValid() )
+  if ( !dateTime.isValid() || isNull )
     mCountMissing++;
 
   if ( mStatistics & CountDistinct )

--- a/src/core/qgsdatetimestatisticalsummary.h
+++ b/src/core/qgsdatetimestatisticalsummary.h
@@ -174,7 +174,7 @@ class CORE_EXPORT QgsDateTimeStatisticalSummary
     QDateTime mMax;
     bool mIsTimes;
 
-    void testDateTime( const QDateTime &dateTime );
+    void testDateTime( const QDateTime &dateTime, bool isNull );
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsDateTimeStatisticalSummary::Statistics )


### PR DESCRIPTION
Check for NULL instead of valid (because NULL is valid).

The old behavior was relying on the fact that a NULL attribute was
stored by OGR as an empty string instead of a NULL QVariant of the
corresponding field type, the conversion of the QVariant( QString())
to a numeric field was checked (and it was failing) so everything
worked (at least for non-string types).

This should make Travis happy for the processing alg tests recently failing.
