### PR TITLE
[wfs server] Adjust MultiSurface and MultiCurve geometry type strings

### DIFF
--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -237,14 +237,14 @@ namespace QgsWfs
           geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:MultiPointPropertyType" ) );
           break;
         case QgsWkbTypes::MultiCurve:
-          geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:MultiCurveType" ) );
+          geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:MultiCurvePropertyType" ) );
           break;
         case QgsWkbTypes::MultiLineString25D:
         case QgsWkbTypes::MultiLineString:
           geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:MultiLineStringPropertyType" ) );
           break;
         case QgsWkbTypes::MultiSurface:
-          geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:MultiSurfaceType" ) );
+          geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:MultiSurfacePropertyType" ) );
           break;
         case QgsWkbTypes::MultiPolygon25D:
         case QgsWkbTypes::MultiPolygon:


### PR DESCRIPTION
The wfs server introduced inconsistent geometry type strings for MultiSurface and MultiCurve in #36352.
This pull requests aligns these two geometry types with the rest of the geometry types. QGIS servers running with this patch will be able to provide MultiSurface and MultiCurve type layers to any QGIS wfs client out there.

See also discussion in https://github.com/qgis/QGIS/pull/41162