### PR TITLE
Added docs for the virtual private methods in QgsAbstractRelationEditorWidget

### DIFF
--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -212,11 +212,37 @@ Unlinks the features with ``fids``
 
   private:
     virtual void updateUi();
+%Docstring
+A hook called every time the state of the relation editor widget has changed via calling its `set*` methods or slots,
+e.g. changed relation, added feature, etc.
+Should be used to refresh the UI regarding the new data.
+Check QgsRealationEditorWidget as an example.
+%End
     virtual void setTitle( const QString &title );
+%Docstring
+Sets the title of the widget, if it is wrapped within a :py:class:`QgsCollapsibleGroupBox`
+Check QgsRealationEditorWidget as an example.
+%End
     virtual void beforeSetRelationFeature( const QgsRelation &newRelation, const QgsFeature &newFeature );
+%Docstring
+A hook called right before :py:func:`~QgsAbstractRelationEditorWidget.setRelationFeature` is executed. Used to update the UI once setting the relation feature is done.
+Check QgsRealationEditorWidget as an example.
+%End
     virtual void afterSetRelationFeature();
+%Docstring
+A hook called right after :py:func:`~QgsAbstractRelationEditorWidget.setRelationFeature` is executed, but before :py:func:`~QgsAbstractRelationEditorWidget.updateUi` is called. Used to update the UI once setting the relation feature is done.
+Check QgsRealationEditorWidget as an example.
+%End
     virtual void beforeSetRelations( const QgsRelation &newRelation, const QgsRelation &newNmRelation );
+%Docstring
+A hook called right before :py:func:`~QgsAbstractRelationEditorWidget.setRelations` is executed. Used to manipulate UI once setting the relations is done.
+Check QgsRealationEditorWidget as an example.
+%End
     virtual void afterSetRelations();
+%Docstring
+A hook called right after :py:func:`~QgsAbstractRelationEditorWidget.setRelations` is executed, but before :py:func:`~QgsAbstractRelationEditorWidget.updateUi` is called. Used to update the UI once setting the relations is done.
+Check QgsRealationEditorWidget as an example.
+%End
 };
 
 

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -240,11 +240,43 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
 
 
   private:
+
+    /**
+     * A hook called every time the state of the relation editor widget has changed via calling its `set*` methods or slots,
+     * e.g. changed relation, added feature, etc.
+     * Should be used to refresh the UI regarding the new data.
+     * Check QgsRealationEditorWidget as an example.
+     */
     virtual void updateUi() SIP_FORCE;
+
+    /**
+     * Sets the title of the widget, if it is wrapped within a QgsCollapsibleGroupBox
+     * Check QgsRealationEditorWidget as an example.
+     */
     virtual void setTitle( const QString &title ) SIP_FORCE;
+
+    /**
+     * A hook called right before setRelationFeature() is executed. Used to update the UI once setting the relation feature is done.
+     * Check QgsRealationEditorWidget as an example.
+     */
     virtual void beforeSetRelationFeature( const QgsRelation &newRelation, const QgsFeature &newFeature ) SIP_FORCE;
+
+    /**
+     * A hook called right after setRelationFeature() is executed, but before updateUi() is called. Used to update the UI once setting the relation feature is done.
+     * Check QgsRealationEditorWidget as an example.
+     */
     virtual void afterSetRelationFeature() SIP_FORCE;
+
+    /**
+     * A hook called right before setRelations() is executed. Used to manipulate UI once setting the relations is done.
+     * Check QgsRealationEditorWidget as an example.
+     */
     virtual void beforeSetRelations( const QgsRelation &newRelation, const QgsRelation &newNmRelation ) SIP_FORCE;
+
+    /**
+     * A hook called right after setRelations() is executed, but before updateUi() is called. Used to update the UI once setting the relations is done.
+     * Check QgsRealationEditorWidget as an example.
+     */
     virtual void afterSetRelations() SIP_FORCE;
 };
 


### PR DESCRIPTION
They are a requirement when creating a new relation editor widget, but were never documented. 