### PR TITLE
fixes use of QgsAbstractRelationEditorWidget in binding

### DIFF
--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -219,11 +219,37 @@ Unlinks the features with ``fids``
 
   private:
     virtual void updateUi();
+%Docstring
+A hook called every time the state of the relation editor widget has changed via calling its `set*` methods or slots,
+e.g. changed relation, added feature, etc.
+Should be used to refresh the UI regarding the new data.
+Check QgsRealationEditorWidget as an example.
+%End
     virtual void setTitle( const QString &title );
+%Docstring
+Sets the title of the widget, if it is wrapped within a :py:class:`QgsCollapsibleGroupBox`
+Check QgsRealationEditorWidget as an example.
+%End
     virtual void beforeSetRelationFeature( const QgsRelation &newRelation, const QgsFeature &newFeature );
+%Docstring
+A hook called right before :py:func:`~QgsAbstractRelationEditorWidget.setRelationFeature` is executed. Used to update the UI once setting the relation feature is done.
+Check QgsRealationEditorWidget as an example.
+%End
     virtual void afterSetRelationFeature();
+%Docstring
+A hook called right after :py:func:`~QgsAbstractRelationEditorWidget.setRelationFeature` is executed, but before :py:func:`~QgsAbstractRelationEditorWidget.updateUi` is called. Used to update the UI once setting the relation feature is done.
+Check QgsRealationEditorWidget as an example.
+%End
     virtual void beforeSetRelations( const QgsRelation &newRelation, const QgsRelation &newNmRelation );
+%Docstring
+A hook called right before :py:func:`~QgsAbstractRelationEditorWidget.setRelations` is executed. Used to manipulate UI once setting the relations is done.
+Check QgsRealationEditorWidget as an example.
+%End
     virtual void afterSetRelations();
+%Docstring
+A hook called right after :py:func:`~QgsAbstractRelationEditorWidget.setRelations` is executed, but before :py:func:`~QgsAbstractRelationEditorWidget.updateUi` is called. Used to update the UI once setting the relations is done.
+Check QgsRealationEditorWidget as an example.
+%End
 };
 
 

--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -48,13 +48,20 @@ Sets the ``relation`` and the ``feature``
 
     void setRelations( const QgsRelation &relation, const QgsRelation &nmrelation );
 %Docstring
-Set the relation(s) for this widget
+Sets the relation(s) for this widget
 If only one relation is set, it will act as a simple 1:N relation widget
 If both relations are set, it will act as an N:M relation widget
 inserting and deleting entries on the intermediate table as required.
 
 :param relation: Relation referencing the edited table
 :param nmrelation: Optional reference from the referencing table to a 3rd N:M table
+%End
+
+    QgsRelation relation() const;
+%Docstring
+Returns the relation
+
+.. versionadded:: 3.18
 %End
 
     void setFeature( const QgsFeature &feature, bool update = true );

--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -217,7 +217,6 @@ Unlinks the features with ``fids``
 %End
 
 
-  private:
     virtual void updateUi();
 %Docstring
 A hook called every time the state of the relation editor widget has changed via calling its `set*` methods or slots,
@@ -225,26 +224,31 @@ e.g. changed relation, added feature, etc.
 Should be used to refresh the UI regarding the new data.
 Check QgsRealationEditorWidget as an example.
 %End
+
     virtual void setTitle( const QString &title );
 %Docstring
 Sets the title of the widget, if it is wrapped within a :py:class:`QgsCollapsibleGroupBox`
 Check QgsRealationEditorWidget as an example.
 %End
+
     virtual void beforeSetRelationFeature( const QgsRelation &newRelation, const QgsFeature &newFeature );
 %Docstring
 A hook called right before :py:func:`~QgsAbstractRelationEditorWidget.setRelationFeature` is executed. Used to update the UI once setting the relation feature is done.
 Check QgsRealationEditorWidget as an example.
 %End
+
     virtual void afterSetRelationFeature();
 %Docstring
 A hook called right after :py:func:`~QgsAbstractRelationEditorWidget.setRelationFeature` is executed, but before :py:func:`~QgsAbstractRelationEditorWidget.updateUi` is called. Used to update the UI once setting the relation feature is done.
 Check QgsRealationEditorWidget as an example.
 %End
+
     virtual void beforeSetRelations( const QgsRelation &newRelation, const QgsRelation &newNmRelation );
 %Docstring
 A hook called right before :py:func:`~QgsAbstractRelationEditorWidget.setRelations` is executed. Used to manipulate UI once setting the relations is done.
 Check QgsRealationEditorWidget as an example.
 %End
+
     virtual void afterSetRelations();
 %Docstring
 A hook called right after :py:func:`~QgsAbstractRelationEditorWidget.setRelations` is executed, but before :py:func:`~QgsAbstractRelationEditorWidget.updateUi` is called. Used to update the UI once setting the relations is done.

--- a/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
@@ -145,8 +145,17 @@ Sets the title of the root groupbox
     virtual void parentFormValueChanged( const QString &attribute, const QVariant &newValue );
 
 
-  private:
+  protected:
     virtual void updateUi();
+    virtual void beforeSetRelationFeature( const QgsRelation &newRelation, const QgsFeature &newFeature );
+
+    virtual void afterSetRelationFeature();
+
+    virtual void beforeSetRelations( const QgsRelation &newRelation, const QgsRelation &newNmRelation );
+
+    virtual void afterSetRelations();
+
+
 };
 
 

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -244,8 +244,7 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
      */
     void unlinkFeatures( const QgsFeatureIds &fids );
 
-
-  private:
+    // Following virtual methods need to be protected so they can be overridden in bindings
 
     /**
      * A hook called every time the state of the relation editor widget has changed via calling its `set*` methods or slots,
@@ -253,37 +252,37 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
      * Should be used to refresh the UI regarding the new data.
      * Check QgsRealationEditorWidget as an example.
      */
-    virtual void updateUi() SIP_FORCE;
+    virtual void updateUi();
 
     /**
      * Sets the title of the widget, if it is wrapped within a QgsCollapsibleGroupBox
      * Check QgsRealationEditorWidget as an example.
      */
-    virtual void setTitle( const QString &title ) SIP_FORCE;
+    virtual void setTitle( const QString &title );
 
     /**
      * A hook called right before setRelationFeature() is executed. Used to update the UI once setting the relation feature is done.
      * Check QgsRealationEditorWidget as an example.
      */
-    virtual void beforeSetRelationFeature( const QgsRelation &newRelation, const QgsFeature &newFeature ) SIP_FORCE;
+    virtual void beforeSetRelationFeature( const QgsRelation &newRelation, const QgsFeature &newFeature );
 
     /**
      * A hook called right after setRelationFeature() is executed, but before updateUi() is called. Used to update the UI once setting the relation feature is done.
      * Check QgsRealationEditorWidget as an example.
      */
-    virtual void afterSetRelationFeature() SIP_FORCE;
+    virtual void afterSetRelationFeature();
 
     /**
      * A hook called right before setRelations() is executed. Used to manipulate UI once setting the relations is done.
      * Check QgsRealationEditorWidget as an example.
      */
-    virtual void beforeSetRelations( const QgsRelation &newRelation, const QgsRelation &newNmRelation ) SIP_FORCE;
+    virtual void beforeSetRelations( const QgsRelation &newRelation, const QgsRelation &newNmRelation );
 
     /**
      * A hook called right after setRelations() is executed, but before updateUi() is called. Used to update the UI once setting the relations is done.
      * Check QgsRealationEditorWidget as an example.
      */
-    virtual void afterSetRelations() SIP_FORCE;
+    virtual void afterSetRelations();
 };
 
 

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -246,11 +246,43 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
 
 
   private:
+
+    /**
+     * A hook called every time the state of the relation editor widget has changed via calling its `set*` methods or slots,
+     * e.g. changed relation, added feature, etc.
+     * Should be used to refresh the UI regarding the new data.
+     * Check QgsRealationEditorWidget as an example.
+     */
     virtual void updateUi() SIP_FORCE;
+
+    /**
+     * Sets the title of the widget, if it is wrapped within a QgsCollapsibleGroupBox
+     * Check QgsRealationEditorWidget as an example.
+     */
     virtual void setTitle( const QString &title ) SIP_FORCE;
+
+    /**
+     * A hook called right before setRelationFeature() is executed. Used to update the UI once setting the relation feature is done.
+     * Check QgsRealationEditorWidget as an example.
+     */
     virtual void beforeSetRelationFeature( const QgsRelation &newRelation, const QgsFeature &newFeature ) SIP_FORCE;
+
+    /**
+     * A hook called right after setRelationFeature() is executed, but before updateUi() is called. Used to update the UI once setting the relation feature is done.
+     * Check QgsRealationEditorWidget as an example.
+     */
     virtual void afterSetRelationFeature() SIP_FORCE;
+
+    /**
+     * A hook called right before setRelations() is executed. Used to manipulate UI once setting the relations is done.
+     * Check QgsRealationEditorWidget as an example.
+     */
     virtual void beforeSetRelations( const QgsRelation &newRelation, const QgsRelation &newNmRelation ) SIP_FORCE;
+
+    /**
+     * A hook called right after setRelations() is executed, but before updateUi() is called. Used to update the UI once setting the relations is done.
+     * Check QgsRealationEditorWidget as an example.
+     */
     virtual void afterSetRelations() SIP_FORCE;
 };
 

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -70,7 +70,7 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
     void setRelationFeature( const QgsRelation &relation, const QgsFeature &feature );
 
     /**
-     * Set the relation(s) for this widget
+     * Sets the relation(s) for this widget
      * If only one relation is set, it will act as a simple 1:N relation widget
      * If both relations are set, it will act as an N:M relation widget
      * inserting and deleting entries on the intermediate table as required.
@@ -79,6 +79,12 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
      * \param nmrelation  Optional reference from the referencing table to a 3rd N:M table
      */
     void setRelations( const QgsRelation &relation, const QgsRelation &nmrelation );
+
+    /**
+     * Returns the relation
+     * \since QGIS 3.18
+     */
+    QgsRelation relation() const {return mRelation;}
 
     /**
      * Sets the \a feature being edited and updates the UI unless \a update is set to FALSE

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -193,6 +193,13 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
   public slots:
     void parentFormValueChanged( const QString &attribute, const QVariant &newValue ) override;
 
+  protected:
+    virtual void updateUi() override;
+    void beforeSetRelationFeature( const QgsRelation &newRelation, const QgsFeature &newFeature ) override;
+    void afterSetRelationFeature() override;
+    void beforeSetRelations( const QgsRelation &newRelation, const QgsRelation &newNmRelation ) override;
+    void afterSetRelations() override;
+
   private slots:
     void setViewMode( int mode ) {setViewMode( static_cast<QgsDualView::ViewMode>( mode ) );}
     void updateButtons();
@@ -206,7 +213,6 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
     void onDigitizingCompleted( const QgsFeature &feature );
 
   private:
-    virtual void updateUi() override SIP_FORCE;
     void initDualView( QgsVectorLayer *layer, const QgsFeatureRequest &request );
     void setMapTool( QgsMapTool *mapTool );
     void unsetMapTool();
@@ -234,11 +240,6 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
 
     Buttons mButtonsVisibility = Button::AllButtons;
     bool mVisible = true;
-
-    void beforeSetRelationFeature( const QgsRelation &newRelation, const QgsFeature &newFeature ) override;
-    void afterSetRelationFeature() override;
-    void beforeSetRelations( const QgsRelation &newRelation, const QgsRelation &newNmRelation ) override;
-    void afterSetRelations() override;
 };
 
 


### PR DESCRIPTION
Virtual methods need to be protected so they can be overridden in Python implementation.
