### PR TITLE
[Backport 3.16] QgsAttributeWidgetRelationEditWidget::setRelationEditorConfiguration(): avoid crash on corrupted relation (fix #40495)

### DIFF
--- a/src/core/qgsrelation.cpp
+++ b/src/core/qgsrelation.cpp
@@ -261,11 +261,15 @@ QString QgsRelation::id() const
 
 void QgsRelation::generateId()
 {
-  d->mRelationId = QStringLiteral( "%1_%2_%3_%4" )
-                   .arg( referencingLayerId(),
-                         d->mFieldPairs.at( 0 ).referencingField(),
-                         referencedLayerId(),
-                         d->mFieldPairs.at( 0 ).referencedField() );
+  if ( !d->mFieldPairs.isEmpty() )
+  {
+    const QgsRelation::FieldPair fieldPair = d->mFieldPairs.at( 0 );
+    d->mRelationId = QStringLiteral( "%1_%2_%3_%4" )
+                     .arg( referencingLayerId(),
+                           fieldPair.referencingField(),
+                           referencedLayerId(),
+                           fieldPair.referencedField() );
+  }
   updateRelationStatus();
 }
 

--- a/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
+++ b/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
@@ -109,10 +109,17 @@ void QgsAttributeWidgetRelationEditWidget::setRelationEditorConfiguration( const
 
   QgsRelation relation = QgsProject::instance()->relationManager()->relation( relationId );
   const QList<QgsRelation> relations = QgsProject::instance()->relationManager()->referencingRelations( relation.referencingLayer() );
-  for ( const QgsRelation &nmrel : relations )
+  if ( !relation.fieldPairs().isEmpty() )
   {
-    if ( nmrel.fieldPairs().at( 0 ).referencingField() != relation.fieldPairs().at( 0 ).referencingField() )
-      setCardinalityCombo( QStringLiteral( "%1 (%2)" ).arg( nmrel.referencedLayer()->name(), nmrel.fieldPairs().at( 0 ).referencedField() ), nmrel.id() );
+    const QgsRelation::FieldPair relationFirstFieldPair = relation.fieldPairs().at( 0 );
+    for ( const QgsRelation &nmrel : relations )
+    {
+      if ( !nmrel.fieldPairs().isEmpty() &&
+           nmrel.fieldPairs().at( 0 ).referencingField() != relationFirstFieldPair.referencingField() )
+      {
+        setCardinalityCombo( QStringLiteral( "%1 (%2)" ).arg( nmrel.referencedLayer()->name(), nmrel.fieldPairs().at( 0 ).referencedField() ), nmrel.id() );
+      }
+    }
   }
 
   mRelationCardinalityCombo->setToolTip( tr( "For a many to many (N:M) relation, the direct link has to be selected. The in-between table will be hidden." ) );

--- a/tests/src/python/test_qgsrelation.py
+++ b/tests/src/python/test_qgsrelation.py
@@ -197,6 +197,11 @@ class TestQgsRelation(unittest.TestCase):
                     valid = t.relation().isValid()
         self.assertTrue(valid)
 
+    def test_generateId_empty_relation(self):
+        rel = QgsRelation()
+        # Check that it does not crash
+        rel.generateId()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Backport of #41147