### PR TITLE
Mark db2 provider as deprecated, and hide from QGIS UI by default

### DIFF
--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -181,6 +181,13 @@ critical=#c80000
 helpSearchPath=https://docs.qgis.org/$qgis_short_version/$qgis_locale/docs/user_manual/
 
 [providers]
+# Whether deprecated data providers should be shown in the QGIS UI (e.g. db2)
+# Warning: these providers are NOT supported and they will be dropped in a future QGIS
+# version. Commercial users requiring on these providers should contact the QGIS
+# project ASAP and arrange for ongoing funding of the provider to prevent their
+# removal and restore them to fully supported status.
+showDeprecated=false
+
 # Default timeout for PostgreSQL servers (seconds)
 PostgreSQL\default_timeout=30
 

--- a/src/providers/db2/qgsdb2dataitems.cpp
+++ b/src/providers/db2/qgsdb2dataitems.cpp
@@ -494,11 +494,7 @@ QgsDataItem *QgsDb2DataItemProvider::createDataItem( const QString &pathIn, QgsD
   Q_UNUSED( pathIn );
   QgsDebugMsgLevel( QStringLiteral( "DB2: Browser Panel; data item detected." ), 2 );
   return new QgsDb2RootItem( parentItem,
-#ifdef QGISDEBUG
-                             QObject::tr( "DB2 (considered for removal)" ),
-#else
-                             QObject::tr( "DB2" ),
-#endif
+                             QObject::tr( "DB2 (deprecated)" ),
                              QStringLiteral( "DB2:" ) );
 }
 

--- a/src/providers/db2/qgsdb2providergui.cpp
+++ b/src/providers/db2/qgsdb2providergui.cpp
@@ -20,6 +20,7 @@
 #include "qgsdb2dataitemguiprovider.h"
 #include "qgsdb2provider.h"
 #include "qgsdb2sourceselect.h"
+#include "qgssettings.h"
 
 
 //! Provider for DB2 source select
@@ -28,11 +29,7 @@ class QgsDb2SourceSelectProvider : public QgsSourceSelectProvider
   public:
 
     QString providerKey() const override { return QgsDb2Provider::DB2_PROVIDER_KEY; }
-#ifdef QGISDEBUG
-    QString text() const override { return QObject::tr( "DB2 (considered for removal)" ); }
-#else
-    QString text() const override { return QObject::tr( "DB2" ); }
-#endif
+    QString text() const override { return QObject::tr( "DB2 (deprecated)" ); }
     int ordering() const override { return QgsSourceSelectProvider::OrderDatabaseProvider + 50; }
     QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddDb2Layer.svg" ) ); }
     QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
@@ -53,14 +50,23 @@ class QgsDb2ProviderGuiMetadata: public QgsProviderGuiMetadata
     QList<QgsDataItemGuiProvider *> dataItemGuiProviders() override
     {
       QList<QgsDataItemGuiProvider *> providers;
-      providers << new QgsDb2DataItemGuiProvider;
+
+      QgsSettings settings;
+      if ( settings.value( QStringLiteral( "showDeprecated" ), false, QgsSettings::Providers ).toBool() )
+      {
+        providers << new QgsDb2DataItemGuiProvider;
+      }
       return providers;
     }
 
     QList<QgsSourceSelectProvider *> sourceSelectProviders() override
     {
       QList<QgsSourceSelectProvider *> providers;
-      providers << new QgsDb2SourceSelectProvider;
+      QgsSettings settings;
+      if ( settings.value( QStringLiteral( "showDeprecated" ), false, QgsSettings::Providers ).toBool() )
+      {
+        providers << new QgsDb2SourceSelectProvider;
+      }
       return providers;
     }
 };


### PR DESCRIPTION
To enable deprecated providers users must set the hidden
"providers/showDeprecated" settings key to true

This gives us a gentle approach to removing unmaintained core
providers.

Alternative approach to https://github.com/qgis/QGIS/pull/41142