### PR TITLE
Add subLayerCount for GPKG file instead of returning 0

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -951,6 +951,19 @@ void QgsOgrProvider::addSubLayerDetailsToSubLayerList( int i, QgsOgrLayer *layer
   }
 }
 
+uint QgsOgrProvider::subLayerCount() const
+{
+  uint count = layerCount();
+
+  QString errCause;
+  QgsOgrLayerUniquePtr layerStyles = QgsOgrProviderUtils::getLayer( mFilePath, "layer_styles", errCause );
+  if ( layerStyles )
+  {
+    count--;
+  }
+  return count;
+}
+
 QStringList QgsOgrProvider::subLayers() const
 {
   const bool withFeatureCount = ( mReadFlags & QgsDataProvider::SkipFeatureCount ) == 0;

--- a/src/core/providers/ogr/qgsogrprovider.h
+++ b/src/core/providers/ogr/qgsogrprovider.h
@@ -105,6 +105,13 @@ class QgsOgrProvider final: public QgsVectorDataProvider
     QgsAbstractFeatureSource *featureSource() const override;
 
     QgsCoordinateReferenceSystem crs() const override;
+
+    /**
+     * Gets the number of sublayer in the OGR datasource.
+     * layer_styles is not counted.
+     * \since QGIS 3.16
+     */
+    uint subLayerCount() const override;
     QStringList subLayers() const override;
     QgsLayerMetadata layerMetadata() const override;
     QStringList subLayersWithoutFeatureCount() const;

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 """QGIS Unit tests for the OGR/GPKG provider.
 
+From build dir, run:
+ctest -R PyQgsOGRProviderGpkg -V
+
 .. note:: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
@@ -328,6 +331,7 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         ds = None
 
         vl = QgsVectorLayer('{}'.format(tmpfile), 'test', 'ogr')
+        self.assertEqual(1, vl.dataProvider().subLayerCount())
         self.assertEqual(vl.dataProvider().subLayers(),
                          [QgsDataProvider.SUBLAYER_SEPARATOR.join(['0', 'test', '0', 'CurvePolygon', 'geom', ''])])
         f = QgsFeature()
@@ -683,6 +687,7 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         # Check that layers_style table is not list in subLayers()
         vl = QgsVectorLayer(tmpfile, 'test', 'ogr')
         sublayers = vl.dataProvider().subLayers()
+        self.assertEqual(2, vl.dataProvider().subLayerCount())
         self.assertEqual(len(sublayers), 2, sublayers)
 
     def testDisablewalForSqlite3(self):
@@ -960,6 +965,7 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         f = None
 
         vl = QgsVectorLayer(u'{}'.format(tmpfile), u'layer', u'ogr')
+        self.assertEqual(1, vl.dataProvider().subLayerCount())
         self.assertEqual(vl.dataProvider().subLayers(),
                          [QgsDataProvider.SUBLAYER_SEPARATOR.join(['0', 'layer1:', '1', 'Point', 'geom:', ''])])
 
@@ -1032,6 +1038,7 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         ds = None
 
         vl2 = QgsVectorLayer(u'{}'.format(tmpfile), 'test', u'ogr')
+        self.assertEqual(2, vl2.dataProvider().subLayerCount())
         vl2.subLayers()
         self.assertEqual(vl2.dataProvider().subLayers(),
                          [QgsDataProvider.SUBLAYER_SEPARATOR.join(['0', 'test', '0', 'Point', 'geom', '']),


### PR DESCRIPTION
## Description

Add `subLayerCount` for GPKG file instead of always returning 0
https://github.com/qgis/QGIS/blob/master/src/core/qgsdataprovider.h#L311
