### PR TITLE
Extend "smooth" rendering of map canvas to include vector layers, labeling

### DIFF
--- a/python/core/auto_generated/qgsmaplayerrenderer.sip.in
+++ b/python/core/auto_generated/qgsmaplayerrenderer.sip.in
@@ -104,6 +104,7 @@ least partially) some data
 .. versionadded:: 3.18
 %End
 
+
   protected:
 
 

--- a/python/core/auto_generated/qgsmaprendererjob.sip.in
+++ b/python/core/auto_generated/qgsmaprendererjob.sip.in
@@ -145,6 +145,7 @@ Returns the total time it took to finish the job (in milliseconds).
 %End
 
 
+
     const QgsMapSettings &mapSettings() const;
 %Docstring
 Returns map settings with which this job was started.
@@ -172,6 +173,7 @@ emitted when asynchronous rendering is finished (or canceled).
 %End
 
   protected:
+
 
 
 

--- a/python/core/auto_generated/qgsmaprendererjob.sip.in
+++ b/python/core/auto_generated/qgsmaprendererjob.sip.in
@@ -156,6 +156,7 @@ Returns map settings with which this job was started.
 %End
 
 
+
   signals:
 
     void renderingLayersFinished();

--- a/src/core/qgsmaplayerrenderer.h
+++ b/src/core/qgsmaplayerrenderer.h
@@ -118,6 +118,18 @@ class CORE_EXPORT QgsMapLayerRenderer
      */
     bool isReadyToCompose() const { return mReadyToCompose; }
 
+    /**
+     * Sets approximate render \a time (in ms) for the layer to render.
+     *
+     * This can be used to specifies a hint at the expected render times for the layer, so that
+     * the individual layer renderer subclasses can apply heuristics and determine appropriate update
+     * intervals during the render operation.
+     *
+     * \note Not available in Python bindings.
+     * \since QGIS 3.18
+     */
+    virtual void setLayerRenderingTimeHint( int time ) SIP_SKIP { Q_UNUSED( time ) }
+
   protected:
     QStringList mErrors;
     QString mLayerID;

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -47,6 +47,7 @@
 ///@cond PRIVATE
 
 const QString QgsMapRendererJob::LABEL_CACHE_ID = QStringLiteral( "_labels_" );
+const QString QgsMapRendererJob::LABEL_PREVIEW_CACHE_ID = QStringLiteral( "_preview_labels_" );
 
 bool LayerRenderJob::imageCanBeComposed() const
 {
@@ -750,6 +751,7 @@ void QgsMapRendererJob::cleanupLabelJob( LabelRenderJob &job )
     {
       QgsDebugMsgLevel( QStringLiteral( "caching label result image" ), 2 );
       mCache->setCacheImage( LABEL_CACHE_ID, *job.img, _qgis_listQPointerToRaw( job.participatingLayers ) );
+      mCache->setCacheImage( LABEL_PREVIEW_CACHE_ID, *job.img, _qgis_listQPointerToRaw( job.participatingLayers ) );
     }
 
     delete job.img;
@@ -815,6 +817,13 @@ QImage QgsMapRendererJob::composeImage(
     painter.setCompositionMode( QPainter::CompositionMode_SourceOver );
     painter.setOpacity( 1.0 );
     painter.drawImage( 0, 0, *labelJob.img );
+  }
+  else if ( cache && cache->hasAnyCacheImage( LABEL_PREVIEW_CACHE_ID ) )
+  {
+    const QImage labelCacheImage = cache->transformedCacheImage( LABEL_PREVIEW_CACHE_ID, settings.mapToPixel() );
+    painter.setCompositionMode( QPainter::CompositionMode_SourceOver );
+    painter.setOpacity( 1.0 );
+    painter.drawImage( 0, 0, labelCacheImage );
   }
 
   // render any layers with the renderAboveLabels flag now

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -96,7 +96,7 @@ QHash<QgsMapLayer *, int> QgsMapRendererJob::perLayerRenderingTime() const
   QHash<QgsMapLayer *, int> result;
   for ( auto it = mPerLayerRenderingTime.constBegin(); it != mPerLayerRenderingTime.constEnd(); ++it )
   {
-    if ( auto && lKey = it.key() )
+    if ( auto &&lKey = it.key() )
       result.insert( lKey, it.value() );
   }
   return result;

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -686,6 +686,7 @@ void QgsMapRendererJob::cleanupJobs( LayerRenderJobs &jobs )
       {
         QgsDebugMsgLevel( QStringLiteral( "caching image for %1" ).arg( job.layerId ), 2 );
         mCache->setCacheImage( job.layerId, *job.img, QList< QgsMapLayer * >() << job.layer );
+        mCache->setCacheImage( job.layerId + QStringLiteral( "_preview" ), *job.img, QList< QgsMapLayer * >() << job.layer );
       }
 
       delete job.img;
@@ -864,9 +865,9 @@ QImage QgsMapRendererJob::layerImageToBeComposed(
   }
   else
   {
-    if ( cache && cache->hasAnyCacheImage( job.layerId ) )
+    if ( cache && cache->hasAnyCacheImage( job.layerId + QStringLiteral( "_preview" ) ) )
     {
-      return cache->transformedCacheImage( job.layerId, settings.mapToPixel() );
+      return cache->transformedCacheImage( job.layerId + QStringLiteral( "_preview" ), settings.mapToPixel() );
     }
     else
       return QImage();

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -95,10 +95,15 @@ QHash<QgsMapLayer *, int> QgsMapRendererJob::perLayerRenderingTime() const
   QHash<QgsMapLayer *, int> result;
   for ( auto it = mPerLayerRenderingTime.constBegin(); it != mPerLayerRenderingTime.constEnd(); ++it )
   {
-    if ( auto &&lKey = it.key() )
+    if ( auto && lKey = it.key() )
       result.insert( lKey, it.value() );
   }
   return result;
+}
+
+void QgsMapRendererJob::setLayerRenderingTimeHints( const QHash<QString, int> &hints )
+{
+  mLayerRenderingTimeHints = hints;
 }
 
 const QgsMapSettings &QgsMapRendererJob::mapSettings() const
@@ -399,6 +404,7 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter *painter, QgsLabelingEn
     job.img = nullptr;
     job.layer = ml;
     job.layerId = ml->id();
+    job.estimatedRenderingTime = mLayerRenderingTimeHints.value( ml->id(), 0 );
     job.renderingTime = -1;
 
     job.context = QgsRenderContext::fromMapSettings( mSettings );
@@ -438,6 +444,8 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter *painter, QgsLabelingEn
     QElapsedTimer layerTime;
     layerTime.start();
     job.renderer = ml->createMapRenderer( job.context );
+    if ( job.renderer )
+      job.renderer->setLayerRenderingTimeHint( job.estimatedRenderingTime );
 
     // If we are drawing with an alternative blending mode then we need to render to a separate image
     // before compositing this on the map. This effectively flattens the layer and prevents

--- a/src/core/qgsmaprendererjob.h
+++ b/src/core/qgsmaprendererjob.h
@@ -65,6 +65,18 @@ struct LayerRenderJob
   bool cached;
   QgsWeakMapLayerPointer layer;
   int renderingTime; //!< Time it took to render the layer in ms (it is -1 if not rendered or still rendering)
+
+  /**
+   * Estimated time for the layer to render, in ms.
+   *
+   * This can be used to specifies hints at the expected render times for the layer, so that
+   * the corresponding layer renderer can apply heuristics and determine appropriate update
+   * intervals during the render operation.
+   *
+   * \since QGIS 3.18
+   */
+  int estimatedRenderingTime = 0;
+
   QStringList errors; //!< Rendering errors
 
   /**
@@ -287,6 +299,20 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
     QHash< QgsMapLayer *, int > perLayerRenderingTime() const SIP_SKIP;
 
     /**
+     * Sets approximate render times (in ms) for map layers.
+     *
+     * This can be used to specifies hints at the expected render times for layers, so that
+     * the individual layer renderers can apply heuristics and determine appropriate update
+     * intervals during the render operation.
+     *
+     * The keys for \a hints must be set to the corresponding layer IDs.
+     *
+     * \note Not available in Python bindings.
+     * \since QGIS 3.18
+     */
+    void setLayerRenderingTimeHints( const QHash< QString, int > &hints ) SIP_SKIP;
+
+    /**
      * Returns map settings with which this job was started.
      * \returns A QgsMapSettings instance with render settings
      * \since QGIS 2.8
@@ -325,6 +351,13 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
 
     //! Render time (in ms) per layer, by layer ID
     QHash< QgsWeakMapLayerPointer, int > mPerLayerRenderingTime;
+
+    /**
+     * Approximate expected layer rendering time per layer, by layer ID
+     *
+     * \since QGIS 3.18
+     */
+    QHash< QString, int > mLayerRenderingTimeHints;
 
     /**
      * TRUE if layer rendering time should be recorded.

--- a/src/core/qgsmaprendererjob.h
+++ b/src/core/qgsmaprendererjob.h
@@ -325,6 +325,13 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
      */
     static const QString LABEL_CACHE_ID SIP_SKIP;
 
+    /**
+     * QgsMapRendererCache ID string for cached label image during preview compositions only.
+     * \note not available in Python bindings
+     * \since QGIS 3.18
+     */
+    static const QString LABEL_PREVIEW_CACHE_ID SIP_SKIP;
+
   signals:
 
     /**

--- a/src/core/qgsmaprendererparalleljob.cpp
+++ b/src/core/qgsmaprendererparalleljob.cpp
@@ -231,7 +231,7 @@ void QgsMapRendererParallelJob::renderLayersFinished()
   // compose final image for labeling
   if ( mSecondPassLayerJobs.isEmpty() )
   {
-    mFinalImage = composeImage( mSettings, mLayerJobs, mLabelJob );
+    mFinalImage = composeImage( mSettings, mLayerJobs, mLabelJob, mCache );
   }
 
   QgsDebugMsgLevel( QStringLiteral( "PARALLEL layers finished" ), 2 );

--- a/src/core/vector/qgsvectorlayerrenderer.cpp
+++ b/src/core/vector/qgsvectorlayerrenderer.cpp
@@ -44,6 +44,7 @@
 
 #include <QPicture>
 
+constexpr int MAX_TIME_TO_USE_CACHED_PREVIEW_IMAGE = 3000;
 
 QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer *layer, QgsRenderContext &context )
   : QgsMapLayerRenderer( layer->id(), &context )
@@ -178,9 +179,16 @@ QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer *layer, QgsRender
     //layer properties require rasterization
     mForceRasterRender = true;
   }
+
+  mReadyToCompose = false;
 }
 
 QgsVectorLayerRenderer::~QgsVectorLayerRenderer() = default;
+
+void QgsVectorLayerRenderer::setLayerRenderingTimeHint( int time )
+{
+  mRenderTimeHint = time;
+}
 
 QgsFeedback *QgsVectorLayerRenderer::feedback() const
 {
@@ -195,12 +203,24 @@ bool QgsVectorLayerRenderer::forceRasterRender() const
 bool QgsVectorLayerRenderer::render()
 {
   if ( mGeometryType == QgsWkbTypes::NullGeometry || mGeometryType == QgsWkbTypes::UnknownGeometry )
+  {
+    mReadyToCompose = true;
     return true;
+  }
 
   if ( mRenderers.empty() )
   {
+    mReadyToCompose = true;
     mErrors.append( QObject::tr( "No renderer for drawing." ) );
     return false;
+  }
+
+  // if the previous layer render was relatively quick (e.g. less than 3 seconds), the we show any previously
+  // cached version of the layer during rendering instead of the usual progressive updates
+  if ( mRenderTimeHint > 0 && mRenderTimeHint <= MAX_TIME_TO_USE_CACHED_PREVIEW_IMAGE )
+  {
+    mBlockRenderUpdates = true;
+    mElapsedTimer.start();
   }
 
   bool res = true;
@@ -208,6 +228,8 @@ bool QgsVectorLayerRenderer::render()
   {
     res = renderInternal( renderer.get() ) && res;
   }
+
+  mReadyToCompose = true;
   return res;
 }
 
@@ -440,6 +462,14 @@ void QgsVectorLayerRenderer::drawRenderer( QgsFeatureRenderer *renderer, QgsFeat
       // labeling - register feature
       if ( rendered )
       {
+        // as soon as first feature is rendered, we can start showing layer updates.
+        // but if we are blocking render updates (so that a previously cached image is being shown), we wait
+        // at most e.g. 3 seconds before we start forcing progressive updates.
+        if ( !mBlockRenderUpdates || mElapsedTimer.elapsed() > MAX_TIME_TO_USE_CACHED_PREVIEW_IMAGE )
+        {
+          mReadyToCompose = true;
+        }
+
         // new labeling engine
         if ( isMainRenderer && context.labelingEngine() && ( mLabelProvider || mDiagramProvider ) )
         {
@@ -640,6 +670,14 @@ void QgsVectorLayerRenderer::drawRendererLevels( QgsFeatureRenderer *renderer, Q
         try
         {
           renderer->renderFeature( *fit, context, layer, sel, drawMarker );
+
+          // as soon as first feature is rendered, we can start showing layer updates.
+          // but if we are blocking render updates (so that a previously cached image is being shown), we wait
+          // at most e.g. 3 seconds before we start forcing progressive updates.
+          if ( !mBlockRenderUpdates || mElapsedTimer.elapsed() > MAX_TIME_TO_USE_CACHED_PREVIEW_IMAGE )
+          {
+            mReadyToCompose = true;
+          }
         }
         catch ( const QgsCsException &cse )
         {

--- a/src/core/vector/qgsvectorlayerrenderer.h
+++ b/src/core/vector/qgsvectorlayerrenderer.h
@@ -32,6 +32,7 @@ class QgsMapClippingRegion;
 
 #include <QList>
 #include <QPainter>
+#include <QElapsedTimer>
 
 typedef QList<int> QgsAttributeList;
 
@@ -88,6 +89,8 @@ class QgsVectorLayerRenderer : public QgsMapLayerRenderer
     QgsFeatureRenderer *featureRenderer() SIP_SKIP { return mRenderer; }
 
     bool render() override;
+
+    void setLayerRenderingTimeHint( int time ) override;
 
   private:
 
@@ -171,6 +174,10 @@ class QgsVectorLayerRenderer : public QgsMapLayerRenderer
     QgsGeometry mLabelClipFeatureGeom;
     bool mApplyLabelClipGeometries = false;
     bool mForceRasterRender = false;
+
+    int mRenderTimeHint = 0;
+    bool mBlockRenderUpdates = false;
+    QElapsedTimer mElapsedTimer;
 
 };
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -604,8 +604,10 @@ void QgsMapCanvas::refreshMap()
     mJob = new QgsMapRendererParallelJob( renderSettings );
   else
     mJob = new QgsMapRendererSequentialJob( renderSettings );
+
   connect( mJob, &QgsMapRendererJob::finished, this, &QgsMapCanvas::rendererJobFinished );
   mJob->setCache( mCache );
+  mJob->setLayerRenderingTimeHints( mLastLayerRenderTime );
 
   mJob->start();
 


### PR DESCRIPTION
This PR extends @PeterPetrik's recent work at enabling "smooth" redraws of raster layers from https://github.com/qgis/QGIS/pull/40960, by:

- Using previously rendered versions of vector layers during temporary composition ONLY if previous renders of the layers were relatively fast (<3 seconds). Otherwise we use the previously rendered version only until we've rendered at least one feature, after which we switch to the progressive update style of rendering.
- Unlock composition using transformed previewed cache image of labeling results as well as map layers. This extends the recent addition of smooth map updates for raster layers to also apply to map labels. Now you'll see a scaled/transformed
version of the previous map render's labels while the new labeling results are being generated in the background.
 (Avoids "flashy" redraws of map labels where the labels disappear and then reappear after moving the map)
