### PR TITLE
QgsMapLayer::ReadFlag::FlagReadExtentFromXml to extend vector layer read capabilities to other layer types

### DIFF
--- a/python/core/auto_generated/providers/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/providers/qgsdataprovider.sip.in
@@ -75,6 +75,7 @@ Abstract base class for spatial data provider implementations.
       FlagTrustDataSource,
       SkipFeatureCount,
       FlagLoadDefaultStyle,
+      SkipGetExtent,
     };
     typedef QFlags<QgsDataProvider::ReadFlag> ReadFlags;
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -579,6 +579,7 @@ or layer with temporary data (as temporary mesh layer dataset)
     {
       FlagDontResolveLayers,
       FlagTrustLayerMetadata,
+      FlagReadExtentFromXml,
     };
     typedef QFlags<QgsMapLayer::ReadFlag> ReadFlags;
 

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -30,6 +30,7 @@
 #include "qgspointcloudrendererregistry.h"
 #include "qgspointcloudlayerelevationproperties.h"
 #include "qgsmaplayerlegend.h"
+#include "qgsxmlutils.h"
 #include "qgsmaplayerfactory.h"
 #include <QUrl>
 
@@ -108,6 +109,22 @@ bool QgsPointCloudLayer::readXml( const QDomNode &layerNode, QgsReadWriteContext
   {
     QgsDataProvider::ProviderOptions providerOptions { context.transformContext() };
     QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags();
+    // read extent
+    if ( mReadFlags & QgsMapLayer::FlagReadExtentFromXml )
+    {
+      const QDomNode extentNode = layerNode.namedItem( QStringLiteral( "extent" ) );
+      if ( !extentNode.isNull() )
+      {
+        // get the extent
+        const QgsRectangle mbr = QgsXmlUtils::readRectangle( extentNode.toElement() );
+
+        // store the extent
+        setExtent( mbr );
+
+        // skip get extent
+        flags |= QgsDataProvider::SkipGetExtent;
+      }
+    }
     if ( mReadFlags & QgsMapLayer::FlagTrustLayerMetadata )
     {
       flags |= QgsDataProvider::FlagTrustDataSource;
@@ -325,7 +342,10 @@ void QgsPointCloudLayer::setDataSourcePrivate( const QString &dataSource, const 
 
   // Load initial extent, crs and renderer
   setCrs( mDataProvider->crs() );
-  setExtent( mDataProvider->extent() );
+  if ( !( flags & QgsDataProvider::SkipGetExtent ) )
+  {
+    setExtent( mDataProvider->extent() );
+  }
 
   bool loadDefaultStyleFlag = false;
   if ( flags & QgsDataProvider::FlagLoadDefaultStyle )

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -49,7 +49,7 @@ QgsPointCloudLayer::QgsPointCloudLayer( const QString &uri,
     {
       providerFlags |= QgsDataProvider::FlagLoadDefaultStyle;
     }
-    setDataSourcePrivate( uri, baseName, providerLib, providerOptions, providerFlags );
+    setDataSource( uri, baseName, providerLib, providerOptions, providerFlags );
 
     if ( !options.skipIndexGeneration && mDataProvider && mDataProvider->isValid() )
       mDataProvider.get()->generateIndex();
@@ -129,7 +129,7 @@ bool QgsPointCloudLayer::readXml( const QDomNode &layerNode, QgsReadWriteContext
     {
       flags |= QgsDataProvider::FlagTrustDataSource;
     }
-    setDataSourcePrivate( mDataSource, mLayerName, mProviderKey, providerOptions, flags );
+    setDataSource( mDataSource, mLayerName, mProviderKey, providerOptions, flags );
   }
 
   if ( !isValid() )

--- a/src/core/providers/qgsdataprovider.h
+++ b/src/core/providers/qgsdataprovider.h
@@ -123,6 +123,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
       FlagTrustDataSource = 1 << 0, //!< Trust datasource config (primary key unicity, geometry type and srid, etc). Improves provider load time by skipping expensive checks like primary key unicity, geometry type and srid and by using estimated metadata on data load. Since QGIS 3.16
       SkipFeatureCount = 1 << 1, //!< Make featureCount() return -1 to indicate unknown, and subLayers() to return a unknown feature count as well. Since QGIS 3.18. Only implemented by OGR provider at time of writing.
       FlagLoadDefaultStyle = 1 << 2, //!< Reset the layer's style to the default for the datasource
+      SkipGetExtent = 1 << 3, //!< Skip the extent from provider
     };
     Q_DECLARE_FLAGS( ReadFlags, ReadFlag )
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -416,6 +416,16 @@ bool QgsMapLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &cont
   Q_UNUSED( context )
   // NOP by default; children will over-ride with behavior specific to them
 
+  // read Extent
+  if ( mReadFlags & QgsMapLayer::FlagReadExtentFromXml )
+  {
+    const QDomNode extentNode = layer_node.namedItem( QStringLiteral( "extent" ) );
+    if ( !extentNode.isNull() )
+    {
+      mExtent = QgsXmlUtils::readRectangle( extentNode.toElement() );
+    }
+  }
+
   return true;
 } // void QgsMapLayer::readXml
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -579,6 +579,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     {
       FlagDontResolveLayers = 1 << 0, //!< Don't resolve layer paths or create data providers for layers.
       FlagTrustLayerMetadata = 1 << 1, //!< Trust layer metadata. Improves layer load time by skipping expensive checks like primary key unicity, geometry type and srid and by using estimated metadata on layer load. Since QGIS 3.16
+      FlagReadExtentFromXml = 1 << 2, //!< Read extent from xml and skip get extent from provider.
     };
     Q_DECLARE_FLAGS( ReadFlags, ReadFlag )
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -132,7 +132,7 @@ QgsRasterLayer::QgsRasterLayer( const QString &uri,
   {
     providerFlags |= QgsDataProvider::FlagLoadDefaultStyle;
   }
-  setDataSourcePrivate( uri, baseName, providerKey, providerOptions, providerFlags );
+  setDataSource( uri, baseName, providerKey, providerOptions, providerFlags );
 
   if ( isValid() )
   {

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -43,6 +43,7 @@ email                : tim at linfiniti.com
 #include "qgsrasterresamplefilter.h"
 #include "qgsrastershader.h"
 #include "qgsreadwritecontext.h"
+#include "qgsxmlutils.h"
 #include "qgsrectangle.h"
 #include "qgsrendercontext.h"
 #include "qgssinglebandcolordatarenderer.h"
@@ -673,13 +674,14 @@ void QgsRasterLayer::setDataProvider( QString const &provider, const QgsDataProv
     mDataSource = mDataProvider->dataSourceUri();
   }
 
-  // get the extent
-  QgsRectangle mbr = mDataProvider->extent();
+  if ( !( flags & QgsDataProvider::SkipGetExtent ) )
+  {
+    // get the extent
+    const QgsRectangle mbr = mDataProvider->extent();
 
-  // show the extent
-  QgsDebugMsgLevel( "Extent of layer: " + mbr.toString(), 4 );
-  // store the extent
-  setExtent( mbr );
+    // store the extent
+    setExtent( mbr );
+  }
 
   // upper case the first letter of the layer name
   QgsDebugMsgLevel( "mLayerName: " + name(), 4 );
@@ -2030,6 +2032,22 @@ bool QgsRasterLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
     if ( mReadFlags & QgsMapLayer::FlagTrustLayerMetadata )
     {
       flags |= QgsDataProvider::FlagTrustDataSource;
+    }
+    // read extent
+    if ( mReadFlags & QgsMapLayer::FlagReadExtentFromXml )
+    {
+      const QDomNode extentNode = layer_node.namedItem( QStringLiteral( "extent" ) );
+      if ( !extentNode.isNull() )
+      {
+        // get the extent
+        const QgsRectangle mbr = QgsXmlUtils::readRectangle( extentNode.toElement() );
+
+        // store the extent
+        setExtent( mbr );
+
+        // skip get extent
+        flags |= QgsDataProvider::SkipGetExtent;
+      }
     }
     setDataProvider( mProviderKey, providerOptions, flags );
   }

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -188,8 +188,7 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
     {
       providerFlags |= QgsDataProvider::FlagLoadDefaultStyle;
     }
-    setDataSourcePrivate( vectorLayerPath, baseName, providerKey, providerOptions, providerFlags );
-    emit dataSourceChanged();
+    setDataSource( vectorLayerPath, baseName, providerKey, providerOptions, providerFlags );
   }
 
   for ( const QgsField &field : std::as_const( mFields ) )

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -189,6 +189,7 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
       providerFlags |= QgsDataProvider::FlagLoadDefaultStyle;
     }
     setDataSourcePrivate( vectorLayerPath, baseName, providerKey, providerOptions, providerFlags );
+    emit dataSourceChanged();
   }
 
   for ( const QgsField &field : std::as_const( mFields ) )
@@ -1611,9 +1612,13 @@ bool QgsVectorLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
     setLegend( QgsMapLayerLegend::defaultVectorLegend( this ) );
 
   // read extent
+  if ( mReadFlags & QgsMapLayer::FlagReadExtentFromXml )
+  {
+    mReadExtentFromXml = true;
+  }
   if ( mReadExtentFromXml )
   {
-    QDomNode extentNode = layer_node.namedItem( QStringLiteral( "extent" ) );
+    const QDomNode extentNode = layer_node.namedItem( QStringLiteral( "extent" ) );
     if ( !extentNode.isNull() )
     {
       mXmlExtent = QgsXmlUtils::readRectangle( extentNode.toElement() );
@@ -1634,6 +1639,7 @@ bool QgsVectorLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
   return isValid();               // should be true if read successfully
 
 } // void QgsVectorLayer::readXml
+
 
 void QgsVectorLayer::setDataSourcePrivate( const QString &dataSource, const QString &baseName, const QString &provider,
     const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags )


### PR DESCRIPTION
## Description

In `QgsVectorLayer`, it is possible through the flag trust layer metadata to use extent read in XML instead of extent provided by the provider.

The `QgsMapLayer::ReadFlag::FlagReadExtentFromXml` can be used in layer readXML to read Extent from XML for raster, point cloud and other layers.

This is a refactoring of https://github.com/qgis/QGIS/pull/38662

Funded by Ifremer
