### PR TITLE
[temporal] Fix setting restoration regression (fixes #41225)

### DIFF
--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -203,7 +203,7 @@ void QgsTemporalNavigationObject::setFrameDuration( QgsInterval frameDuration )
   // forcing an update of our views
   QgsDateTimeRange range = dateTimeRangeForFrameNumber( mCurrentFrameNumber );
 
-  if ( !mBlockUpdateTemporalRangeSignal && mNavigationMode != NavigationOff )
+  if ( !mBlockUpdateTemporalRangeSignal && mNavigationMode == Animated )
     emit updateTemporalRange( range );
 }
 


### PR DESCRIPTION
When setting the frame duration, only emit updateTemporalRange when in the animated mode.