### PR TITLE
extent smooth rendering to mesh layer

### DIFF
--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -60,6 +60,8 @@ QgsMeshLayerRenderer::QgsMeshLayerRenderer(
   // cppcheck-suppress assertWithSideEffect
   Q_ASSERT( layer->dataProvider() );
 
+  mReadyToCompose = false;
+
   // copy native mesh
   mNativeMesh = *( layer->nativeMesh() );
   mLayerExtent = layer->extent();
@@ -287,6 +289,7 @@ void QgsMeshLayerRenderer::copyVectorDatasetValues( QgsMeshLayer *layer )
 
 bool QgsMeshLayerRenderer::render()
 {
+  mReadyToCompose = false;
   QgsScopedQPainterState painterState( renderContext()->painter() );
   if ( !mClippingRegions.empty() )
   {
@@ -297,6 +300,7 @@ bool QgsMeshLayerRenderer::render()
   }
 
   renderScalarDataset();
+  mReadyToCompose = true;
   renderMesh();
   renderVectorDataset();
 


### PR DESCRIPTION
As for raster layers (https://github.com/qgis/QGIS/pull/40960) and vector layers (https://github.com/qgis/QGIS/pull/41198), this PR allows the "smooth" rendering aka "smart map redraw" working also for mesh layer. 
Quite straight forward after the work of @PeterPetrik  and @nyalldawson.
This smooth navigation is also extended for the temporal dimension. 

