### PR TITLE
add system dependency to correctly run qgis_testrunner.sh

### DIFF
--- a/.docker/qgis.dockerfile
+++ b/.docker/qgis.dockerfile
@@ -57,7 +57,7 @@ RUN SUCCESS=OK \
   && echo "$SUCCESS" > /QGIS/build_exit_value
 
 # Additional run-time dependencies
-RUN pip3 install jinja2 pygments pexpect
+RUN pip3 install jinja2 pygments pexpect && apt install -y expect
 
 ################################################################################
 # Python testing environment setup


### PR DESCRIPTION
Adds system dependency `expect` that is needed to run `qgis_testrunner.sh`.

I am not sure if I added the code to the best place, but it is a runtime dep for the tests, so this place seems reasonable.

It is a follow up to #41183 .