### PR TITLE
[server] Just skip any broken projects on the landing page, instead of blocking the whole landing page

### DIFF
--- a/src/server/services/landingpage/qgslandingpagehandlers.cpp
+++ b/src/server/services/landingpage/qgslandingpagehandlers.cpp
@@ -65,17 +65,16 @@ const QString QgsLandingPageHandler::templatePath( const QgsServerApiContext &co
 json QgsLandingPageHandler::projectsData() const
 {
   json j = json::array();
-  const auto availableProjects { QgsLandingPageUtils::projects( *mSettings ) };
-  const auto constProjectKeys { availableProjects.keys() };
-  for ( const auto &p : constProjectKeys )
+  const QMap<QString, QString> availableProjects = QgsLandingPageUtils::projects( *mSettings );
+  for ( auto it = availableProjects.constBegin(); it != availableProjects.constEnd(); ++it )
   {
     try
     {
-      j.push_back( QgsLandingPageUtils::projectInfo( availableProjects[ p ] ) );
+      j.push_back( QgsLandingPageUtils::projectInfo( it.value() ) );
     }
     catch ( QgsServerException & )
     {
-      // skip broken projects!
+      QgsMessageLog::logMessage( QStringLiteral( "Could not open project '%1': skipping." ).arg( it.value() ), QStringLiteral( "Landing Page" ), Qgis::MessageLevel::Critical );
     }
   }
   return j;

--- a/src/server/services/landingpage/qgslandingpagehandlers.cpp
+++ b/src/server/services/landingpage/qgslandingpagehandlers.cpp
@@ -69,7 +69,14 @@ json QgsLandingPageHandler::projectsData() const
   const auto constProjectKeys { availableProjects.keys() };
   for ( const auto &p : constProjectKeys )
   {
-    j.push_back( QgsLandingPageUtils::projectInfo( availableProjects[ p ] ) );
+    try
+    {
+      j.push_back( QgsLandingPageUtils::projectInfo( availableProjects[ p ] ) );
+    }
+    catch ( QgsServerException & )
+    {
+      // skip broken projects!
+    }
   }
   return j;
 }


### PR DESCRIPTION
If the landing page encountered ANY projects with broken layers, it would block the whole landing page. Instead, just skip over broken projects so that the others can still be used.