### PR TITLE
Fix primary key issues in HANA

### DIFF
--- a/src/providers/hana/qgshanaconnection.h
+++ b/src/providers/hana/qgshanaconnection.h
@@ -66,7 +66,7 @@ class QgsHanaConnection : public QObject
       bool userTablesOnly = true );
     void readLayerInfo( QgsHanaLayerProperty &layerProperty );
     QVector<QgsHanaSchemaProperty> getSchemas( const QString &ownerName );
-    QStringList getLayerPrimaryeKey( const QString &schemaName, const QString &tableName );
+    QStringList getLayerPrimaryKey( const QString &schemaName, const QString &tableName );
     QgsWkbTypes::Type getColumnGeometryType( const QString &schemaName, const QString &tableName, const QString &columnName );
     QString getColumnDataType( const QString &schemaName, const QString &tableName, const QString &columnName );
     int getColumnSrid( const QString &schemaName, const QString &tableName, const QString &columnName );
@@ -82,7 +82,7 @@ class QgsHanaConnection : public QObject
   private:
     QgsHanaConnection( odbc::ConnectionRef connection, const QgsDataSourceUri &uri );
 
-    QStringList getPrimaryeKeyCandidates( const QgsHanaLayerProperty &layerProperty );
+    QStringList getPrimaryKeyCandidates( const QgsHanaLayerProperty &layerProperty );
 
     odbc::PreparedStatementRef createPreparedStatement( const QString &sql, const QVariantList &args );
 

--- a/src/providers/hana/qgshanaprovider.cpp
+++ b/src/providers/hana/qgshanaprovider.cpp
@@ -1407,7 +1407,7 @@ void QgsHanaProvider::determinePrimaryKey()
     QgsHanaConnectionRef conn( mUri );
     if ( conn->isTable( mSchemaName, mTableName ) )
     {
-      QStringList layerPrimaryKey = conn->getLayerPrimaryeKey( mSchemaName, mTableName );
+      QStringList layerPrimaryKey = conn->getLayerPrimaryKey( mSchemaName, mTableName );
       primaryKey = QgsHanaPrimaryKeyUtils::determinePrimaryKeyFromColumns( layerPrimaryKey, mAttributeFields );
     }
     else

--- a/src/providers/hana/qgshanaproviderconnection.cpp
+++ b/src/providers/hana/qgshanaproviderconnection.cpp
@@ -335,7 +335,7 @@ QList<QgsHanaProviderConnection::TableProperty> QgsHanaProviderConnection::table
         }
         else  // Fetch and set the real pks
         {
-          QStringList pks = conn->getLayerPrimaryeKey( layerInfo.schemaName, layerInfo.tableName );
+          QStringList pks = conn->getLayerPrimaryKey( layerInfo.schemaName, layerInfo.tableName );
           property.setPrimaryKeyColumns( pks );
         }
         tables.push_back( property );

--- a/src/providers/hana/qgshanasettings.h
+++ b/src/providers/hana/qgshanasettings.h
@@ -183,6 +183,16 @@ class QgsHanaSettings
     QString port() const;
 
     /**
+     * Gets the key columns for the given database object.
+     */
+    QStringList keyColumns( const QString &schemaName, const QString &objectName ) const;
+
+    /**
+     * Sets the key columns for the given database object.
+     */
+    void setKeyColumns( const QString &schemaName, const QString &objectName, const QStringList &columnNames );
+
+    /**
      * Sets values from a RDBMS data source URI.
      */
     void setFromDataSourceUri( const QgsDataSourceUri &uri );
@@ -234,6 +244,7 @@ class QgsHanaSettings
     QString mSslTrustStore;
     bool mSslValidateCertificate = false;
     QString mSslHostNameInCertificate;
+    QMap<QString, QMap<QString, QStringList>> mKeyColumns;
 };
 
 #endif // QGSHANAPSETTINGS_H

--- a/src/providers/hana/qgshanasourceselect.cpp
+++ b/src/providers/hana/qgshanasourceselect.cpp
@@ -457,7 +457,7 @@ void QgsHanaSourceSelect::mSearchModeComboBox_currentIndexChanged( const QString
 
 void QgsHanaSourceSelect::setLayerType( const QgsHanaLayerProperty &layerProperty )
 {
-  mTableModel.addTableEntry( layerProperty );
+  mTableModel.addTableEntry( mConnectionName, layerProperty );
 }
 
 QgsHanaSourceSelect::~QgsHanaSourceSelect()
@@ -495,6 +495,16 @@ void QgsHanaSourceSelect::populateConnectionList()
   cmbConnections->setDisabled( cmbConnections->count() == 0 );
 }
 
+QStringList QgsHanaSourceSelect::selectedTables()
+{
+  return mSelectedTables;
+}
+
+QString QgsHanaSourceSelect::connectionInfo()
+{
+  return mConnectionInfo;
+}
+
 // Slot for performing action when the Add button is clicked
 void QgsHanaSourceSelect::addButtonClicked()
 {
@@ -506,7 +516,7 @@ void QgsHanaSourceSelect::addButtonClicked()
     if ( idx.column() != QgsHanaTableModel::DbtmTable )
       continue;
 
-    QString uri = mTableModel.layerURI( mProxyModel.mapToSource( idx ), QgsHanaUtils::connectionInfo( mDataSrcUri ) );
+    QString uri = mTableModel.layerURI( mProxyModel.mapToSource( idx ), mConnectionName, mConnectionInfo );
     if ( uri.isNull() )
       continue;
 
@@ -536,10 +546,11 @@ void QgsHanaSourceSelect::btnConnect_clicked()
     return;
   }
 
+  const QString connName = cmbConnections->currentText();
+
   QModelIndex rootItemIndex = mTableModel.indexFromItem( mTableModel.invisibleRootItem() );
   mTableModel.removeRows( 0, mTableModel.rowCount( rootItemIndex ), rootItemIndex );
 
-  const QString connName = cmbConnections->currentText();
   QgsHanaSettings settings( connName, true );
   settings.setAllowGeometrylessTables( cbxAllowGeometrylessTables->isChecked() );
 
@@ -554,12 +565,13 @@ void QgsHanaSourceSelect::btnConnect_clicked()
     return;
   }
 
-  mDataSrcUri = uri;
+  mConnectionName = connName;
+  mConnectionInfo = QgsHanaUtils::connectionInfo( uri );
 
   QApplication::setOverrideCursor( Qt::BusyCursor );
 
-  mColumnTypeThread = qgis::make_unique<QgsHanaColumnTypeThread>( settings.name(), uri, settings.allowGeometrylessTables(), settings.userTablesOnly() );
-  mColumnTypeTask = qgis::make_unique<QgsProxyProgressTask>( tr( "Scanning tables for %1" ).arg( cmbConnections->currentText() ) );
+  mColumnTypeThread = qgis::make_unique<QgsHanaColumnTypeThread>( mConnectionName, uri, settings.allowGeometrylessTables(), settings.userTablesOnly() );
+  mColumnTypeTask = qgis::make_unique<QgsProxyProgressTask>( tr( "Scanning tables for %1" ).arg( mConnectionName ) );
   QgsApplication::taskManager()->addTask( mColumnTypeTask.get() );
 
   connect( mColumnTypeThread.get(), &QgsHanaColumnTypeThread::setLayerType,
@@ -597,16 +609,6 @@ void QgsHanaSourceSelect::columnThreadFinished()
   finishList();
 }
 
-QStringList QgsHanaSourceSelect::selectedTables()
-{
-  return mSelectedTables;
-}
-
-QString QgsHanaSourceSelect::connectionInfo()
-{
-  return QgsHanaUtils::connectionInfo( mDataSrcUri );
-}
-
 void QgsHanaSourceSelect::refresh()
 {
   populateConnectionList();
@@ -621,7 +623,7 @@ void QgsHanaSourceSelect::setSql( const QModelIndex &index )
   }
 
   QModelIndex idx = mProxyModel.mapToSource( index );
-  QString uri = mTableModel.layerURI( idx, QgsHanaUtils::connectionInfo( mDataSrcUri ) );
+  QString uri = mTableModel.layerURI( idx, mConnectionName, mConnectionInfo );
   if ( uri.isNull() )
   {
     QgsDebugMsg( "no uri" );

--- a/src/providers/hana/qgshanasourceselect.h
+++ b/src/providers/hana/qgshanasourceselect.h
@@ -144,7 +144,8 @@ class QgsHanaSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsD
     void finishList();
     void showHelp();
 
-    QgsDataSourceUri mDataSrcUri;
+    QString mConnectionName;
+    QString mConnectionInfo;
     // A thread for detecting geometry types
     std::unique_ptr<QgsHanaColumnTypeThread> mColumnTypeThread;
     std::unique_ptr<QgsProxyProgressTask> mColumnTypeTask;

--- a/src/providers/hana/qgshanatablemodel.h
+++ b/src/providers/hana/qgshanatablemodel.h
@@ -66,7 +66,7 @@ class QgsHanaTableModel : public QStandardItemModel
     QgsHanaTableModel();
 
     //! Adds entry for one database table to the model
-    void addTableEntry( const QgsHanaLayerProperty &property );
+    void addTableEntry( const QString &connName, const QgsHanaLayerProperty &property );
 
     //! Sets an sql statement that belongs to a cell specified by a model index
     void setSql( const QModelIndex &index, const QString &sql );
@@ -90,7 +90,7 @@ class QgsHanaTableModel : public QStandardItemModel
 
     bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
 
-    QString layerURI( const QModelIndex &index, const QString &connInfo );
+    QString layerURI( const QModelIndex &index, const QString &connName, const QString &connInfo );
 
     static QIcon iconForWkbType( QgsWkbTypes::Type type );
 


### PR DESCRIPTION
This pull request contains the following changes:
1. Fix: User cannot select/add a layer when he/she selected several columns in the "feature id" column.
2. Save selected "feature id" columns in the connection settings.
3. Exclude GEOMETRY and LOB columns from primary key candidates.
4. In Data Source Browser, use primary key candidates only if the user already confirm them in DbSourceSelect dialog.