### PR TITLE
WFS connections XML import dialog: deal properly with duplicate conne…

### DIFF
--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -1002,10 +1002,17 @@ void QgsManageConnectionsDialog::loadWfsConnections( const QDomDocument &doc, co
       }
     }
 
-    if ( keys.contains( connectionName ) && !overwrite )
+    if ( keys.contains( connectionName ) )
     {
-      child = child.nextSiblingElement();
-      continue;
+      if ( !overwrite )
+      {
+        child = child.nextSiblingElement();
+        continue;
+      }
+    }
+    else
+    {
+      keys << connectionName;
     }
 
     // no dups detected or overwrite is allowed


### PR DESCRIPTION
https://github.com/qgis/QGIS/pull/41145 didn't fix the WFS part of #39758, so this PR implements @rouault's fix (thanks!) also for `loadWfsConnections`.

Maybe this fix is needed also for other connections XML imports, I'll have look.