### PR TITLE
Fix broken transparency when loading ImageServer layers through browser

### DIFF
--- a/external/o2/src/o0baseauth.cpp
+++ b/external/o2/src/o0baseauth.cpp
@@ -28,12 +28,12 @@ void O0BaseAuth::setStore(O0AbstractStore *store) {
 bool O0BaseAuth::linked() {
     QString key = QString(O2_KEY_LINKED).arg(clientId_);
     bool result = !store_->value(key).isEmpty();
-    qDebug() << "O0BaseAuth::linked:" << (result? "Yes": "No");
+    //qDebug() << "O0BaseAuth::linked:" << (result? "Yes": "No");
     return result;
 }
 
 void O0BaseAuth::setLinked(bool v) {
-    qDebug() << "O0BaseAuth::setLinked:" << (v? "true": "false");
+    //qDebug() << "O0BaseAuth::setLinked:" << (v? "true": "false");
     bool oldValue = linked();
     QString key = QString(O2_KEY_LINKED).arg(clientId_);
     store_->setValue(key, v? "1": "");
@@ -87,7 +87,7 @@ int O0BaseAuth::localPort() {
 }
 
 void O0BaseAuth::setLocalPort(int value) {
-    qDebug() << "O0BaseAuth::setLocalPort:" << value;
+    //qDebug() << "O0BaseAuth::setLocalPort:" << value;
     localPort_ = value;
     Q_EMIT localPortChanged();
 }

--- a/external/o2/src/o2.cpp
+++ b/external/o2/src/o2.cpp
@@ -152,10 +152,10 @@ void O2::setRefreshTokenUrl(const QString &value) {
 }
 
 void O2::link() {
-    qDebug() << "O2::link";
+    //qDebug() << "O2::link";
 
     if (linked()) {
-        qDebug() << "O2::link: Linked already";
+        //qDebug() << "O2::link: Linked already";
         Q_EMIT linkingSucceeded();
         return;
     }
@@ -171,7 +171,7 @@ void O2::link() {
         // Start listening to authentication replies
         if (!replyServer_->isListening()) {
 	        if (replyServer_->listen(QHostAddress::Any, localPort_)) {
-	            qDebug() << "O2::link: Reply server listening on port" << localPort();
+                //qDebug() << "O2::link: Reply server listening on port" << localPort();
 	        } else {
 	            qWarning() << "O2::link: Reply server failed to start listening on port" << localPort();
 	            Q_EMIT linkingFailed();
@@ -197,7 +197,7 @@ void O2::link() {
         // Show authentication URL with a web browser
         QUrl url(requestUrl_);
         addQueryParametersToUrl(url, parameters);
-        qDebug() << "O2::link: Emit openBrowser" << url.toString();
+        //qDebug() << "O2::link: Emit openBrowser" << url.toString();
         Q_EMIT openBrowser(url);
     } else if (grantFlow_ == GrantFlowResourceOwnerPasswordCredentials) {
         QList<O0RequestParameter> parameters;
@@ -215,7 +215,7 @@ void O2::link() {
         }
         QByteArray payload = O0BaseAuth::createQueryParameters(parameters);
 
-        qDebug() << "O2::link: Sending token request for resource owner flow";
+        //qDebug() << "O2::link: Sending token request for resource owner flow";
         QUrl url(tokenUrl_);
         QNetworkRequest tokenRequest(url);
         tokenRequest.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
@@ -227,7 +227,7 @@ void O2::link() {
 }
 
 void O2::unlink() {
-    qDebug() << "O2::unlink";
+    //() << "O2::unlink";
     setLinked(false);
     setToken(QString());
     setRefreshToken(QString());
@@ -237,8 +237,8 @@ void O2::unlink() {
 }
 
 void O2::onVerificationReceived(const QMap<QString, QString> response) {
-    qDebug() << "O2::onVerificationReceived:" << response;
-    qDebug() << "O2::onVerificationReceived: Emitting closeBrowser()";
+    //qDebug() << "O2::onVerificationReceived:" << response;
+    //qDebug() << "O2::onVerificationReceived: Emitting closeBrowser()";
     Q_EMIT closeBrowser();
 
     if (response.contains("error")) {
@@ -266,7 +266,7 @@ void O2::onVerificationReceived(const QMap<QString, QString> response) {
         parameters.insert(O2_OAUTH2_GRANT_TYPE, O2_AUTHORIZATION_CODE);
         QByteArray data = buildRequestBody(parameters);
 
-        qDebug() << QString("O2::onVerificationReceived: Exchange access code data:\n%1").arg(QString(data));
+        //qDebug() << QString("O2::onVerificationReceived: Exchange access code data:\n%1").arg(QString(data));
 
         QNetworkReply *tokenReply = getManager()->post(tokenRequest, data);
         timedReplies_.add(tokenReply);
@@ -275,13 +275,13 @@ void O2::onVerificationReceived(const QMap<QString, QString> response) {
     } else if (grantFlow_ == GrantFlowImplicit) {
       // Check for mandatory tokens
       if (response.contains(O2_OAUTH2_ACCESS_TOKEN)) {
-          qDebug() << "O2::onVerificationReceived: Access token returned for implicit flow";
+          //qDebug() << "O2::onVerificationReceived: Access token returned for implicit flow";
           setToken(response.value(O2_OAUTH2_ACCESS_TOKEN));
           if (response.contains(O2_OAUTH2_EXPIRES_IN)) {
             bool ok = false;
             int expiresIn = response.value(O2_OAUTH2_EXPIRES_IN).toInt(&ok);
             if (ok) {
-                qDebug() << "O2::onVerificationReceived: Token expires in" << expiresIn << "seconds";
+                //qDebug() << "O2::onVerificationReceived: Token expires in" << expiresIn << "seconds";
                 setExpires(QDateTime::currentMSecsSinceEpoch() / 1000 + expiresIn);
             }
           }
@@ -308,7 +308,7 @@ void O2::setCode(const QString &c) {
 }
 
 void O2::onTokenReplyFinished() {
-    qDebug() << "O2::onTokenReplyFinished";
+    //qDebug() << "O2::onTokenReplyFinished";
     QNetworkReply *tokenReply = qobject_cast<QNetworkReply *>(sender());
     if (!tokenReply)
     {
@@ -326,20 +326,20 @@ void O2::onTokenReplyFinished() {
         QVariantMap tokens = parseTokenResponse(replyData);
 
         // Dump tokens
-        qDebug() << "O2::onTokenReplyFinished: Tokens returned:\n";
-        foreach (QString key, tokens.keys()) {
+        //qDebug() << "O2::onTokenReplyFinished: Tokens returned:\n";
+        //foreach (QString key, tokens.keys()) {
             // SENSITIVE DATA in RelWithDebInfo or Debug builds, so it is truncated first
-            qDebug() << key << ": "<< tokens.value( key ).toString().left( 3 ) << "...";
-        }
+            //qDebug() << key << ": "<< tokens.value( key ).toString().left( 3 ) << "...";
+        //}
 
         // Check for mandatory tokens
         if (tokens.contains(O2_OAUTH2_ACCESS_TOKEN)) {
-            qDebug() << "O2::onTokenReplyFinished: Access token returned";
+            // qDebug() << "O2::onTokenReplyFinished: Access token returned";
             setToken(tokens.take(O2_OAUTH2_ACCESS_TOKEN).toString());
             bool ok = false;
             int expiresIn = tokens.take(O2_OAUTH2_EXPIRES_IN).toInt(&ok);
             if (ok) {
-                qDebug() << "O2::onTokenReplyFinished: Token expires in" << expiresIn << "seconds";
+                // qDebug() << "O2::onTokenReplyFinished: Token expires in" << expiresIn << "seconds";
                 setExpires(QDateTime::currentMSecsSinceEpoch() / 1000 + expiresIn);
             }
             setRefreshToken(tokens.take(O2_OAUTH2_REFRESH_TOKEN).toString());
@@ -358,7 +358,7 @@ void O2::onTokenReplyFinished() {
 void O2::onTokenReplyError(QNetworkReply::NetworkError error) {
     QNetworkReply *tokenReply = qobject_cast<QNetworkReply *>(sender());
     qWarning() << "O2::onTokenReplyError: " << error << ": " << tokenReply->errorString();
-    qDebug() << "O2::onTokenReplyError: " << tokenReply->readAll();
+    // qDebug() << "O2::onTokenReplyError: " << tokenReply->readAll();
     setToken(QString());
     setRefreshToken(QString());
     timedReplies_.remove(tokenReply);
@@ -401,13 +401,13 @@ QString O2::refreshToken() {
 }
 
 void O2::setRefreshToken(const QString &v) {
-    qDebug() << "O2::setRefreshToken" << v.left(4) << "...";
+    //qDebug() << "O2::setRefreshToken" << v.left(4) << "...";
     QString key = QString(O2_KEY_REFRESH_TOKEN).arg(clientId_);
     store_->setValue(key, v);
 }
 
 void O2::refresh() {
-    qDebug() << "O2::refresh: Token: ..." << refreshToken().right(7);
+    // qDebug() << "O2::refresh: Token: ..." << refreshToken().right(7);
 
     if (refreshToken().isEmpty()) {
         qWarning() << "O2::refresh: No refresh token";
@@ -452,7 +452,7 @@ void O2::onRefreshFinished() {
           if ( !refreshToken.isEmpty() )
             setRefreshToken(refreshToken);
           setLinked(true);
-          qDebug() << " New token expires in" << expires() << "seconds";
+          //qDebug() << " New token expires in" << expires() << "seconds";
           Q_EMIT linkingSucceeded();
         }
         timedReplies_.remove(refreshReply);

--- a/external/o2/src/o2replyserver.cpp
+++ b/external/o2/src/o2replyserver.cpp
@@ -16,13 +16,13 @@
 
 O2ReplyServer::O2ReplyServer(QObject *parent): QTcpServer(parent),
   timeout_(15), maxtries_(3), tries_(0) {
-    qDebug() << "O2ReplyServer: Starting";
+    //qDebug() << "O2ReplyServer: Starting";
     connect(this, SIGNAL(newConnection()), this, SLOT(onIncomingConnection()));
     replyContent_ = "<HTML></HTML>";
 }
 
 void O2ReplyServer::onIncomingConnection() {
-    qDebug() << "O2ReplyServer::onIncomingConnection: Receiving...";
+    //qDebug() << "O2ReplyServer::onIncomingConnection: Receiving...";
     QTcpSocket *socket = nextPendingConnection();
     connect(socket, SIGNAL(readyRead()), this, SLOT(onBytesReady()), Qt::UniqueConnection);
     connect(socket, SIGNAL(disconnected()), socket, SLOT(deleteLater()));
@@ -44,7 +44,7 @@ void O2ReplyServer::onBytesReady() {
         // server has been closed, stop processing queued connections
         return;
     }
-    qDebug() << "O2ReplyServer::onBytesReady: Processing request";
+    //qDebug() << "O2ReplyServer::onBytesReady: Processing request";
     // NOTE: on first call, the timeout timer is started
     QTcpSocket *socket = qobject_cast<QTcpSocket *>(sender());
     if (!socket) {
@@ -57,13 +57,13 @@ void O2ReplyServer::onBytesReady() {
     reply.append(QString("Content-Length: %1\r\n\r\n").arg(replyContent_.size()).toLatin1());
     reply.append(replyContent_);
     socket->write(reply);
-    qDebug() << "O2ReplyServer::onBytesReady: Sent reply";
+    //qDebug() << "O2ReplyServer::onBytesReady: Sent reply";
 
     QByteArray data = socket->readAll();
     QMap<QString, QString> queryParams = parseQueryParams(&data);
     if (queryParams.isEmpty()) {
         if (tries_ < maxtries_ ) {
-            qDebug() << "O2ReplyServer::onBytesReady: No query params found, waiting for more callbacks";
+            //qDebug() << "O2ReplyServer::onBytesReady: No query params found, waiting for more callbacks";
             ++tries_;
             return;
         } else {
@@ -73,13 +73,13 @@ void O2ReplyServer::onBytesReady() {
             return;
         }
     }
-    qDebug() << "O2ReplyServer::onBytesReady: Query params found, closing server";
+    //qDebug() << "O2ReplyServer::onBytesReady: Query params found, closing server";
     closeServer(socket, true);
     Q_EMIT verificationReceived(queryParams);
 }
 
 QMap<QString, QString> O2ReplyServer::parseQueryParams(QByteArray *data) {
-    qDebug() << "O2ReplyServer::parseQueryParams";
+    //qDebug() << "O2ReplyServer::parseQueryParams";
 
     //qDebug() << QString("O2ReplyServer::parseQueryParams data:\n%1").arg(QString(*data));
 
@@ -114,13 +114,13 @@ void O2ReplyServer::closeServer(QTcpSocket *socket, bool hasparameters)
       return;
   }
 
-  qDebug() << "O2ReplyServer::closeServer: Initiating";
-  int port = serverPort();
+  //qDebug() << "O2ReplyServer::closeServer: Initiating";
+  //int port = serverPort();
 
   if (!socket && sender()) {
       QTimer *timer = qobject_cast<QTimer*>(sender());
       if (timer) {
-          qWarning() << "O2ReplyServer::closeServer: Closing due to timeout";
+          //qWarning() << "O2ReplyServer::closeServer: Closing due to timeout";
           timer->stop();
           socket = qobject_cast<QTcpSocket *>(timer->parent());
           timer->deleteLater();
@@ -129,13 +129,13 @@ void O2ReplyServer::closeServer(QTcpSocket *socket, bool hasparameters)
   if (socket) {
       QTimer *timer = socket->findChild<QTimer*>("timeoutTimer");
       if (timer) {
-          qDebug() << "O2ReplyServer::closeServer: Stopping socket's timeout timer";
+          //qDebug() << "O2ReplyServer::closeServer: Stopping socket's timeout timer";
           timer->stop();
       }
       socket->disconnectFromHost();
   }
   close();
-  qDebug() << "O2ReplyServer::closeServer: Closed, no longer listening on port" << port;
+  //qDebug() << "O2ReplyServer::closeServer: Closed, no longer listening on port" << port;
   Q_EMIT serverClosed(hasparameters);
 }
 

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -171,7 +171,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mSettings = new QgsSettings();
 
   double identifyValue = mSettings->value( QStringLiteral( "/Map/searchRadiusMM" ), Qgis::DEFAULT_SEARCH_RADIUS_MM ).toDouble();
-  QgsDebugMsg( QStringLiteral( "Standard Identify radius setting read from settings file: %1" ).arg( identifyValue ) );
+  QgsDebugMsgLevel( QStringLiteral( "Standard Identify radius setting read from settings file: %1" ).arg( identifyValue ), 3 );
   if ( identifyValue <= 0.0 )
     identifyValue = Qgis::DEFAULT_SEARCH_RADIUS_MM;
   spinBoxIdentifyValue->setMinimum( 0.0 );
@@ -2347,7 +2347,7 @@ void QgsOptions::loadGdalDriverList()
       driversType[myGdalDriverDescription] = QgsMapLayerType::VectorLayer;
     }
 
-    QgsDebugMsg( QStringLiteral( "driver #%1 - %2" ).arg( i ).arg( myGdalDriverDescription ) );
+    QgsDebugMsgLevel( QStringLiteral( "driver #%1 - %2" ).arg( i ).arg( myGdalDriverDescription ), 2 );
 
     // get driver R/W flags, adopted from GDALGeneralCmdLineProcessor()
     QString driverFlags = "";

--- a/src/auth/oauth2/qgsauthoauth2method.cpp
+++ b/src/auth/oauth2/qgsauthoauth2method.cpp
@@ -328,7 +328,7 @@ void QgsAuthOAuth2Method::onLinkedChanged()
 {
   // Linking (login) state has changed.
   // Use o2->linked() to get the actual state
-  QgsDebugMsg( QStringLiteral( "Link state changed" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Link state changed" ), 2 );
 }
 
 void QgsAuthOAuth2Method::onLinkingFailed()
@@ -371,7 +371,7 @@ void QgsAuthOAuth2Method::onLinkingSucceeded()
       // don't expose the values in a log (unless they are only 3 chars long, of course)
       msg += QStringLiteral( "    %1:%2…\n" ).arg( key, extraTokens.value( key ).toString().left( 3 ) );
     }
-    QgsDebugMsg( msg );
+    QgsDebugMsgLevel( msg, 2 );
   }
 }
 
@@ -381,7 +381,7 @@ void QgsAuthOAuth2Method::onOpenBrowser( const QUrl &url )
   // The user will interact with this browser window to
   // enter login name, password, and authorize your application
   // to access the Twitter account
-  QgsMessageLog::logMessage( tr( "Open browser requested" ), AUTH_METHOD_KEY, Qgis::MessageLevel::Info );
+  QgsDebugMsgLevel( QStringLiteral( "Open browser requested %1" ), 2 );
 
   QDesktopServices::openUrl( url );
 }
@@ -389,7 +389,7 @@ void QgsAuthOAuth2Method::onOpenBrowser( const QUrl &url )
 void QgsAuthOAuth2Method::onCloseBrowser()
 {
   // Close the browser window opened in openBrowser()
-  QgsMessageLog::logMessage( tr( "Close browser requested" ), AUTH_METHOD_KEY, Qgis::MessageLevel::Info );
+  QgsDebugMsgLevel( QStringLiteral( "Close browser requested %1" ), 2 );
 
   // Bring focus back to QGIS app
   if ( qApp )
@@ -537,7 +537,7 @@ void QgsAuthOAuth2Method::updateMethodConfig( QgsAuthMethodConfig &mconfig )
 {
   if ( mconfig.hasConfig( QStringLiteral( "oldconfigstyle" ) ) )
   {
-    QgsDebugMsg( QStringLiteral( "Updating old style auth method config" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Updating old style auth method config" ), 2 );
   }
 
   // NOTE: add updates as method version() increases due to config storage changes
@@ -555,7 +555,7 @@ QgsO2 *QgsAuthOAuth2Method::getOAuth2Bundle( const QString &authcfg, bool fullco
   // check if it is cached
   if ( sOAuth2ConfigCache.contains( authcfg ) )
   {
-    QgsDebugMsg( QStringLiteral( "Retrieving OAuth bundle for authcfg: %1" ).arg( authcfg ) );
+    QgsDebugMsgLevel( QStringLiteral( "Retrieving OAuth bundle for authcfg: %1" ).arg( authcfg ), 2 );
     return sOAuth2ConfigCache.value( authcfg );
   }
 
@@ -662,8 +662,8 @@ QgsO2 *QgsAuthOAuth2Method::getOAuth2Bundle( const QString &authcfg, bool fullco
 
   // TODO: instantiate particular QgsO2 subclassed authenticators relative to config ???
 
-  QgsDebugMsg( QStringLiteral( "Loading authenticator object with %1 flow properties of OAuth2 config: %2" )
-               .arg( QgsAuthOAuth2Config::grantFlowString( config->grantFlow() ), authcfg ) );
+  QgsDebugMsgLevel( QStringLiteral( "Loading authenticator object with %1 flow properties of OAuth2 config: %2" )
+                    .arg( QgsAuthOAuth2Config::grantFlowString( config->grantFlow() ), authcfg ), 2 );
 
   QgsO2 *o2 = new QgsO2( authcfg, config, nullptr, QgsNetworkAccessManager::instance() );
 
@@ -675,7 +675,7 @@ QgsO2 *QgsAuthOAuth2Method::getOAuth2Bundle( const QString &authcfg, bool fullco
 
 void QgsAuthOAuth2Method::putOAuth2Bundle( const QString &authcfg, QgsO2 *bundle )
 {
-  QgsDebugMsg( QStringLiteral( "Putting oauth2 bundle for authcfg: %1" ).arg( authcfg ) );
+  QgsDebugMsgLevel( QStringLiteral( "Putting oauth2 bundle for authcfg: %1" ).arg( authcfg ), 2 );
   sOAuth2ConfigCache.insert( authcfg, bundle );
 }
 
@@ -685,7 +685,7 @@ void QgsAuthOAuth2Method::removeOAuth2Bundle( const QString &authcfg )
   {
     sOAuth2ConfigCache.value( authcfg )->deleteLater();
     sOAuth2ConfigCache.remove( authcfg );
-    QgsDebugMsg( QStringLiteral( "Removed oauth2 bundle for authcfg: %1" ).arg( authcfg ) );
+    QgsDebugMsgLevel( QStringLiteral( "Removed oauth2 bundle for authcfg: %1" ).arg( authcfg ), 2 );
   }
 }
 

--- a/src/auth/oauth2/qgso2.cpp
+++ b/src/auth/oauth2/qgso2.cpp
@@ -68,7 +68,7 @@ void QgsO2::initOAuthConfig()
 
   // common properties to all grant flows
   QString localpolicy = QStringLiteral( "http://127.0.0.1:% 1/%1" ).arg( mOAuth2Config->redirectUrl() ).replace( QLatin1String( "% 1" ), QLatin1String( "%1" ) );
-  QgsDebugMsg( QStringLiteral( "localpolicy(w/port): %1" ).arg( localpolicy.arg( mOAuth2Config->redirectPort() ) ) );
+  QgsDebugMsgLevel( QStringLiteral( "localpolicy(w/port): %1" ).arg( localpolicy.arg( mOAuth2Config->redirectPort() ) ), 2 );
   setLocalhostPolicy( localpolicy );
   setLocalPort( mOAuth2Config->redirectPort() );
   mIsLocalHost = isLocalHost( QUrl( localpolicy.arg( mOAuth2Config->redirectPort() ) ) );

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -501,16 +501,16 @@ bool QgsAuthManager::setMasterPassword( bool verify )
 
   if ( mMasterPass.isEmpty() )
   {
-    QgsDebugMsg( QStringLiteral( "Master password is not yet set by user" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Master password is not yet set by user" ), 2 );
     if ( !masterPasswordInput() )
     {
-      QgsDebugMsg( QStringLiteral( "Master password input canceled by user" ) );
+      QgsDebugMsgLevel( QStringLiteral( "Master password input canceled by user" ), 2 );
       return false;
     }
   }
   else
   {
-    QgsDebugMsg( QStringLiteral( "Master password is set" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Master password is set" ), 2 );
     if ( !verify )
       return true;
   }
@@ -518,7 +518,7 @@ bool QgsAuthManager::setMasterPassword( bool verify )
   if ( !verifyMasterPassword() )
     return false;
 
-  QgsDebugMsg( QStringLiteral( "Master password is set and verified" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Master password is set and verified" ), 2 );
   return true;
 }
 
@@ -543,7 +543,7 @@ bool QgsAuthManager::setMasterPassword( const QString &pass, bool verify )
     return false;
   }
 
-  QgsDebugMsg( QStringLiteral( "Master password set: SUCCESS%1" ).arg( verify ? " and verified" : "" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Master password set: SUCCESS%1" ).arg( verify ? " and verified" : "" ), 2 );
   return true;
 }
 
@@ -563,7 +563,7 @@ bool QgsAuthManager::verifyMasterPassword( const QString &compare )
     return false;
   }
 
-  QgsDebugMsg( QStringLiteral( "Master password: %1 rows in database" ).arg( rows ) );
+  QgsDebugMsgLevel( QStringLiteral( "Master password: %1 rows in database" ).arg( rows ), 2 );
 
   if ( rows > 1 )
   {
@@ -600,7 +600,7 @@ bool QgsAuthManager::verifyMasterPassword( const QString &compare )
     }
     else
     {
-      QgsDebugMsg( QStringLiteral( "Master password: verified against hash in database" ) );
+      QgsDebugMsgLevel( QStringLiteral( "Master password: verified against hash in database" ), 2 );
       if ( compare.isNull() )
         emit masterPasswordVerified( true );
     }
@@ -618,7 +618,7 @@ bool QgsAuthManager::verifyMasterPassword( const QString &compare )
     }
     else
     {
-      QgsDebugMsg( QStringLiteral( "Master password: hash stored in database" ) );
+      QgsDebugMsgLevel( QStringLiteral( "Master password: hash stored in database" ), 2 );
     }
     // double-check storing
     if ( !masterPasswordCheckAgainstDb() )
@@ -633,7 +633,7 @@ bool QgsAuthManager::verifyMasterPassword( const QString &compare )
     }
     else
     {
-      QgsDebugMsg( QStringLiteral( "Master password: verified against hash in database" ) );
+      QgsDebugMsgLevel( QStringLiteral( "Master password: verified against hash in database" ), 2 );
       emit masterPasswordVerified( true );
     }
   }
@@ -666,7 +666,7 @@ bool QgsAuthManager::resetMasterPassword( const QString &newpass, const QString 
   if ( !backupAuthenticationDatabase( &dbbackup ) )
     return false;
 
-  QgsDebugMsg( QStringLiteral( "Master password reset: backed up current database" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Master password reset: backed up current database" ), 2 );
 
   // create new database and connection
   authDatabaseConnection();
@@ -688,7 +688,7 @@ bool QgsAuthManager::resetMasterPassword( const QString &newpass, const QString 
   }
   if ( ok )
   {
-    QgsDebugMsg( QStringLiteral( "Master password reset: cleared current password from database" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Master password reset: cleared current password from database" ), 2 );
   }
 
   // mMasterPass empty, set new password (don't verify, since not stored yet)
@@ -704,7 +704,7 @@ bool QgsAuthManager::resetMasterPassword( const QString &newpass, const QString 
   }
   if ( ok )
   {
-    QgsDebugMsg( QStringLiteral( "Master password reset: stored new password in database" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Master password reset: stored new password in database" ), 2 );
   }
 
   // verify it stored password properly
@@ -726,7 +726,7 @@ bool QgsAuthManager::resetMasterPassword( const QString &newpass, const QString 
   }
   if ( ok )
   {
-    QgsDebugMsg( QStringLiteral( "Master password reset: re-encrypted configs in database" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Master password reset: re-encrypted configs in database" ), 2 );
   }
 
   // verify it all worked
@@ -788,12 +788,12 @@ bool QgsAuthManager::resetMasterPassword( const QString &newpass, const QString 
 
   if ( keepbackup )
   {
-    QgsDebugMsg( QStringLiteral( "Master password reset: backed up previous db at %1" ).arg( dbbackup ) );
+    QgsDebugMsgLevel( QStringLiteral( "Master password reset: backed up previous db at %1" ).arg( dbbackup ), 2 );
     if ( backuppath )
       *backuppath = dbbackup;
   }
 
-  QgsDebugMsg( QStringLiteral( "Master password reset: SUCCESS" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Master password reset: SUCCESS" ), 2 );
   emit authDatabaseChanged();
   return true;
 }
@@ -888,7 +888,7 @@ const QString QgsAuthManager::uniqueConfigId() const
       break;
     }
   }
-  QgsDebugMsg( QStringLiteral( "Generated unique ID: %1" ).arg( id ) );
+  QgsDebugMsgLevel( QStringLiteral( "Generated unique ID: %1" ).arg( id ), 2 );
   return id;
 }
 
@@ -1141,7 +1141,7 @@ bool QgsAuthManager::storeAuthenticationConfig( QgsAuthMethodConfig &mconfig )
 
   updateConfigAuthMethods();
 
-  QgsDebugMsg( QStringLiteral( "Store config SUCCESS for authcfg: %1" ).arg( uid ) );
+  QgsDebugMsgLevel( QStringLiteral( "Store config SUCCESS for authcfg: %1" ).arg( uid ), 2 );
   return true;
 
 }
@@ -1212,7 +1212,7 @@ bool QgsAuthManager::updateAuthenticationConfig( const QgsAuthMethodConfig &conf
 
   updateConfigAuthMethods();
 
-  QgsDebugMsg( QStringLiteral( "Update config SUCCESS for authcfg: %1" ).arg( config.id() ) );
+  QgsDebugMsgLevel( QStringLiteral( "Update config SUCCESS for authcfg: %1" ).arg( config.id() ), 2 );
 
   return true;
 }
@@ -1272,7 +1272,7 @@ bool QgsAuthManager::loadAuthenticationConfig( const QString &authcfg, QgsAuthMe
         QgsDebugMsg( QStringLiteral( "Update of authcfg %1 FAILED for auth method %2" ).arg( authcfg, authMethodKey ) );
       }
 
-      QgsDebugMsg( QStringLiteral( "Load %1 config SUCCESS for authcfg: %2" ).arg( full ? "full" : "base", authcfg ) );
+      QgsDebugMsgLevel( QStringLiteral( "Load %1 config SUCCESS for authcfg: %2" ).arg( full ? "full" : "base", authcfg ), 2 );
       return true;
     }
     if ( query.next() )
@@ -1313,7 +1313,7 @@ bool QgsAuthManager::removeAuthenticationConfig( const QString &authcfg )
 
   updateConfigAuthMethods();
 
-  QgsDebugMsg( QStringLiteral( "REMOVED config for authcfg: %1" ).arg( authcfg ) );
+  QgsDebugMsgLevel( QStringLiteral( "REMOVED config for authcfg: %1" ).arg( authcfg ), 2 );
 
   return true;
 }
@@ -1334,7 +1334,7 @@ bool QgsAuthManager::removeAllAuthenticationConfigs()
     updateConfigAuthMethods();
   }
 
-  QgsDebugMsg( QStringLiteral( "Remove configs from database: %1" ).arg( res ? "SUCCEEDED" : "FAILED" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Remove configs from database: %1" ).arg( res ? "SUCCEEDED" : "FAILED" ), 2 );
 
   return res;
 }
@@ -1371,7 +1371,7 @@ bool QgsAuthManager::backupAuthenticationDatabase( QString *backuppath )
   if ( backuppath )
     *backuppath = dbbackup;
 
-  QgsDebugMsg( QStringLiteral( "Backed up auth database at %1" ).arg( dbbackup ) );
+  QgsDebugMsgLevel( QStringLiteral( "Backed up auth database at %1" ).arg( dbbackup ), 2 );
   return true;
 }
 
@@ -1419,7 +1419,7 @@ bool QgsAuthManager::eraseAuthenticationDatabase( bool backup, QString *backuppa
 
   mMasterPass = QString();
 
-  QgsDebugMsg( QStringLiteral( "Creating Auth db through QSqlDatabase initial connection" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Creating Auth db through QSqlDatabase initial connection" ), 2 );
 
   QSqlDatabase authConn = authDatabaseConnection();
   if ( !authConn.isValid() || !authConn.isOpen() )
@@ -1551,7 +1551,7 @@ bool QgsAuthManager::updateNetworkProxy( QNetworkProxy &proxy, const QString &au
       authmethod->clearCachedConfig( authcfg );
       return false;
     }
-    QgsDebugMsg( QStringLiteral( "Proxy updated successfully from authcfg: %1" ).arg( authcfg ) );
+    QgsDebugMsgLevel( QStringLiteral( "Proxy updated successfully from authcfg: %1" ).arg( authcfg ), 2 );
     return true;
   }
 
@@ -1595,7 +1595,7 @@ bool QgsAuthManager::storeAuthSetting( const QString &key, const QVariant &value
   if ( !authDbCommit() )
     return false;
 
-  QgsDebugMsg( QStringLiteral( "Store setting SUCCESS for key: %1" ).arg( key ) );
+  QgsDebugMsgLevel( QStringLiteral( "Store setting SUCCESS for key: %1" ).arg( key ), 2 );
   return true;
 }
 
@@ -1630,7 +1630,7 @@ QVariant QgsAuthManager::authSetting( const QString &key, const QVariant &defaul
       {
         value = query.value( 0 );
       }
-      QgsDebugMsg( QStringLiteral( "Authentication setting retrieved for key: %1" ).arg( key ) );
+      QgsDebugMsgLevel( QStringLiteral( "Authentication setting retrieved for key: %1" ).arg( key ), 2 );
     }
     if ( query.next() )
     {
@@ -1662,7 +1662,7 @@ bool QgsAuthManager::existsAuthSetting( const QString &key )
   {
     if ( query.first() )
     {
-      QgsDebugMsg( QStringLiteral( "Authentication setting exists for key: %1" ).arg( key ) );
+      QgsDebugMsgLevel( QStringLiteral( "Authentication setting exists for key: %1" ).arg( key ), 2 );
       res = true;
     }
     if ( query.next() )
@@ -1696,7 +1696,7 @@ bool QgsAuthManager::removeAuthSetting( const QString &key )
   if ( !authDbCommit() )
     return false;
 
-  QgsDebugMsg( QStringLiteral( "REMOVED setting for key: %1" ).arg( key ) );
+  QgsDebugMsgLevel( QStringLiteral( "REMOVED setting for key: %1" ).arg( key ), 2 );
 
   return true;
 }
@@ -1790,7 +1790,7 @@ const QSslCertificate QgsAuthManager::certIdentity( const QString &id )
     if ( query.first() )
     {
       cert = QSslCertificate( query.value( 0 ).toByteArray(), QSsl::Pem );
-      QgsDebugMsg( QStringLiteral( "Certificate identity retrieved for id: %1" ).arg( id ) );
+      QgsDebugMsgLevel( QStringLiteral( "Certificate identity retrieved for id: %1" ).arg( id ), 2 );
     }
     if ( query.next() )
     {
@@ -1844,7 +1844,7 @@ const QPair<QSslCertificate, QSslKey> QgsAuthManager::certIdentityBundle( const 
         emit messageOut( tr( err ), authManTag(), WARNING );
         return bundle;
       }
-      QgsDebugMsg( QStringLiteral( "Certificate identity bundle retrieved for id: %1" ).arg( id ) );
+      QgsDebugMsgLevel( QStringLiteral( "Certificate identity bundle retrieved for id: %1" ).arg( id ), 2 );
     }
     if ( query.next() )
     {
@@ -1936,7 +1936,7 @@ bool QgsAuthManager::existsCertIdentity( const QString &id )
   {
     if ( query.first() )
     {
-      QgsDebugMsg( QStringLiteral( "Certificate bundle exists for id: %1" ).arg( id ) );
+      QgsDebugMsgLevel( QStringLiteral( "Certificate bundle exists for id: %1" ).arg( id ), 2 );
       res = true;
     }
     if ( query.next() )
@@ -1973,7 +1973,7 @@ bool QgsAuthManager::removeCertIdentity( const QString &id )
   if ( !authDbCommit() )
     return false;
 
-  QgsDebugMsg( QStringLiteral( "REMOVED certificate identity for id: %1" ).arg( id ) );
+  QgsDebugMsgLevel( QStringLiteral( "REMOVED certificate identity for id: %1" ).arg( id ), 2 );
   return true;
 }
 
@@ -2011,8 +2011,8 @@ bool QgsAuthManager::storeSslCertCustomConfig( const QgsAuthConfigSslServer &con
   if ( !authDbCommit() )
     return false;
 
-  QgsDebugMsg( QStringLiteral( "Store SSL cert custom config SUCCESS for host:port, id: %1, %2" )
-               .arg( config.sslHostPort().trimmed(), id ) );
+  QgsDebugMsgLevel( QStringLiteral( "Store SSL cert custom config SUCCESS for host:port, id: %1, %2" )
+                    .arg( config.sslHostPort().trimmed(), id ), 2 );
 
   updateIgnoredSslErrorsCacheFromConfig( config );
   mHasCheckedIfCustomConfigByHostExists = false;
@@ -2049,7 +2049,7 @@ const QgsAuthConfigSslServer QgsAuthManager::sslCertCustomConfig( const QString 
       config.setSslCertificate( QSslCertificate( query.value( 2 ).toByteArray(), QSsl::Pem ) );
       config.setSslHostPort( query.value( 1 ).toString().trimmed() );
       config.loadConfigString( query.value( 3 ).toString() );
-      QgsDebugMsg( QStringLiteral( "SSL cert custom config retrieved for host:port, id: %1, %2" ).arg( hostport, id ) );
+      QgsDebugMsgLevel( QStringLiteral( "SSL cert custom config retrieved for host:port, id: %1, %2" ).arg( hostport, id ), 2 );
     }
     if ( query.next() )
     {
@@ -2120,7 +2120,7 @@ const QgsAuthConfigSslServer QgsAuthManager::sslCertCustomConfigByHost( const QS
       config.setSslCertificate( QSslCertificate( query.value( 2 ).toByteArray(), QSsl::Pem ) );
       config.setSslHostPort( query.value( 1 ).toString().trimmed() );
       config.loadConfigString( query.value( 3 ).toString() );
-      QgsDebugMsg( QStringLiteral( "SSL cert custom config retrieved for host:port: %1" ).arg( hostport ) );
+      QgsDebugMsgLevel( QStringLiteral( "SSL cert custom config retrieved for host:port: %1" ).arg( hostport ), 2 );
     }
     if ( query.next() )
     {
@@ -2188,7 +2188,7 @@ bool QgsAuthManager::existsSslCertCustomConfig( const QString &id, const QString
   {
     if ( query.first() )
     {
-      QgsDebugMsg( QStringLiteral( "SSL cert custom config exists for host:port, id: %1, %2" ).arg( hostport, id ) );
+      QgsDebugMsgLevel( QStringLiteral( "SSL cert custom config exists for host:port, id: %1, %2" ).arg( hostport, id ), 2 );
       res = true;
     }
     if ( query.next() )
@@ -2236,7 +2236,7 @@ bool QgsAuthManager::removeSslCertCustomConfig( const QString &id, const QString
     mIgnoredSslErrorsCache.remove( shahostport );
   }
 
-  QgsDebugMsg( QStringLiteral( "REMOVED SSL cert custom config for host:port, id: %1, %2" ).arg( hostport, id ) );
+  QgsDebugMsgLevel( QStringLiteral( "REMOVED SSL cert custom config for host:port, id: %1, %2" ).arg( hostport, id ), 2 );
   dumpIgnoredSslErrorsCache_();
   return true;
 }
@@ -2285,12 +2285,12 @@ bool QgsAuthManager::updateIgnoredSslErrorsCacheFromConfig( const QgsAuthConfigS
   if ( !errenums.isEmpty() )
   {
     mIgnoredSslErrorsCache.insert( shahostport, qgis::listToSet( errenums ) );
-    QgsDebugMsg( QStringLiteral( "Update of ignored SSL errors cache SUCCEEDED for sha:host:port = %1" ).arg( shahostport ) );
+    QgsDebugMsgLevel( QStringLiteral( "Update of ignored SSL errors cache SUCCEEDED for sha:host:port = %1" ).arg( shahostport ), 2 );
     dumpIgnoredSslErrorsCache_();
     return true;
   }
 
-  QgsDebugMsg( QStringLiteral( "No ignored SSL errors to cache for sha:host:port = %1" ).arg( shahostport ) );
+  QgsDebugMsgLevel( QStringLiteral( "No ignored SSL errors to cache for sha:host:port = %1" ).arg( shahostport ), 2 );
   return true;
 }
 
@@ -2333,7 +2333,7 @@ bool QgsAuthManager::updateIgnoredSslErrorsCache( const QString &shahostport, co
 
   mIgnoredSslErrorsCache.insert( shahostport, errs );
 
-  QgsDebugMsg( QStringLiteral( "Update of ignored SSL errors cache SUCCEEDED for sha:host:port = %1" ).arg( shahostport ) );
+  QgsDebugMsgLevel( QStringLiteral( "Update of ignored SSL errors cache SUCCEEDED for sha:host:port = %1" ).arg( shahostport ), 2 );
   dumpIgnoredSslErrorsCache_();
   return true;
 }
@@ -2449,7 +2449,7 @@ bool QgsAuthManager::storeCertAuthority( const QSslCertificate &cert )
   if ( !authDbCommit() )
     return false;
 
-  QgsDebugMsg( QStringLiteral( "Store certificate authority SUCCESS for id: %1" ).arg( id ) );
+  QgsDebugMsgLevel( QStringLiteral( "Store certificate authority SUCCESS for id: %1" ).arg( id ), 2 );
   return true;
 }
 
@@ -2475,7 +2475,7 @@ const QSslCertificate QgsAuthManager::certAuthority( const QString &id )
     if ( query.first() )
     {
       cert = QSslCertificate( query.value( 0 ).toByteArray(), QSsl::Pem );
-      QgsDebugMsg( QStringLiteral( "Certificate authority retrieved for id: %1" ).arg( id ) );
+      QgsDebugMsgLevel( QStringLiteral( "Certificate authority retrieved for id: %1" ).arg( id ), 2 );
     }
     if ( query.next() )
     {
@@ -2512,7 +2512,7 @@ bool QgsAuthManager::existsCertAuthority( const QSslCertificate &cert )
   {
     if ( query.first() )
     {
-      QgsDebugMsg( QStringLiteral( "Certificate authority exists for id: %1" ).arg( id ) );
+      QgsDebugMsgLevel( QStringLiteral( "Certificate authority exists for id: %1" ).arg( id ), 2 );
       res = true;
     }
     if ( query.next() )
@@ -2551,7 +2551,7 @@ bool QgsAuthManager::removeCertAuthority( const QSslCertificate &cert )
   if ( !authDbCommit() )
     return false;
 
-  QgsDebugMsg( QStringLiteral( "REMOVED authority for id: %1" ).arg( id ) );
+  QgsDebugMsgLevel( QStringLiteral( "REMOVED authority for id: %1" ).arg( id ), 2 );
   return true;
 }
 
@@ -2675,7 +2675,7 @@ bool QgsAuthManager::storeCertTrustPolicy( const QSslCertificate &cert, QgsAuthC
   if ( !authDbCommit() )
     return false;
 
-  QgsDebugMsg( QStringLiteral( "Store certificate trust policy SUCCESS for id: %1" ).arg( id ) );
+  QgsDebugMsgLevel( QStringLiteral( "Store certificate trust policy SUCCESS for id: %1" ).arg( id ), 2 );
   return true;
 }
 
@@ -2705,7 +2705,7 @@ QgsAuthCertUtils::CertTrustPolicy QgsAuthManager::certTrustPolicy( const QSslCer
     if ( query.first() )
     {
       policy = static_cast< QgsAuthCertUtils::CertTrustPolicy >( query.value( 0 ).toInt() );
-      QgsDebugMsg( QStringLiteral( "Authentication cert trust policy retrieved for id: %1" ).arg( id ) );
+      QgsDebugMsgLevel( QStringLiteral( "Authentication cert trust policy retrieved for id: %1" ).arg( id ), 2 );
     }
     if ( query.next() )
     {
@@ -2760,7 +2760,7 @@ bool QgsAuthManager::removeCertTrustPolicy( const QSslCertificate &cert )
   if ( !authDbCommit() )
     return false;
 
-  QgsDebugMsg( QStringLiteral( "REMOVED cert trust policy for id: %1" ).arg( id ) );
+  QgsDebugMsgLevel( QStringLiteral( "REMOVED cert trust policy for id: %1" ).arg( id ), 2 );
 
   return true;
 }
@@ -2999,13 +2999,13 @@ void QgsAuthManager::tryToStartDbErase()
   if ( mScheduledDbEraseRequestCount >= trycutoff )
   {
     setScheduledAuthDatabaseErase( false );
-    QgsDebugMsg( QStringLiteral( "authDatabaseEraseRequest emitting/scheduling canceled" ) );
+    QgsDebugMsgLevel( QStringLiteral( "authDatabaseEraseRequest emitting/scheduling canceled" ), 2 );
     return;
   }
   else
   {
-    QgsDebugMsg( QStringLiteral( "authDatabaseEraseRequest attempt (%1 of %2)" )
-                 .arg( mScheduledDbEraseRequestCount ).arg( trycutoff ) );
+    QgsDebugMsgLevel( QStringLiteral( "authDatabaseEraseRequest attempt (%1 of %2)" )
+                      .arg( mScheduledDbEraseRequestCount ).arg( trycutoff ), 2 );
   }
 
   if ( scheduledAuthDatabaseErase() && !mScheduledDbEraseRequestEmitted && mMutex->tryLock() )
@@ -3016,10 +3016,10 @@ void QgsAuthManager::tryToStartDbErase()
 
     mMutex->unlock();
 
-    QgsDebugMsg( QStringLiteral( "authDatabaseEraseRequest emitted" ) );
+    QgsDebugMsgLevel( QStringLiteral( "authDatabaseEraseRequest emitted" ), 2 );
     return;
   }
-  QgsDebugMsg( QStringLiteral( "authDatabaseEraseRequest emit skipped" ) );
+  QgsDebugMsgLevel( QStringLiteral( "authDatabaseEraseRequest emit skipped" ), 2 );
 }
 
 
@@ -3455,7 +3455,7 @@ bool QgsAuthManager::verifyPasswordCanDecryptConfigs() const
     }
   }
 
-  QgsDebugMsg( QStringLiteral( "Verify password can decrypt configs SUCCESS (checked %1 configs)" ).arg( checked ) );
+  QgsDebugMsgLevel( QStringLiteral( "Verify password can decrypt configs SUCCESS (checked %1 configs)" ).arg( checked ), 2 );
   return true;
 }
 
@@ -3525,7 +3525,7 @@ bool QgsAuthManager::reencryptAuthenticationConfig( const QString &authcfg, cons
     if ( !authDbCommit() )
       return false;
 
-    QgsDebugMsg( QStringLiteral( "Reencrypt SUCCESS for authcfg: %2" ).arg( authcfg ) );
+    QgsDebugMsgLevel( QStringLiteral( "Reencrypt SUCCESS for authcfg: %2" ).arg( authcfg ), 2 );
     return true;
   }
   else
@@ -3690,7 +3690,7 @@ bool QgsAuthManager::reencryptAuthenticationIdentity(
     if ( !authDbCommit() )
       return false;
 
-    QgsDebugMsg( QStringLiteral( "Reencrypt SUCCESS for identity id: %2" ).arg( identid ) );
+    QgsDebugMsgLevel( QStringLiteral( "Reencrypt SUCCESS for identity id: %2" ).arg( identid ), 2 );
     return true;
   }
   else

--- a/src/core/auth/qgsauthmethodregistry.cpp
+++ b/src/core/auth/qgsauthmethodregistry.cpp
@@ -330,7 +330,7 @@ QFunctionPointer QgsAuthMethodRegistry::function( QString const &authMethodKey,
 {
   QLibrary myLib( library( authMethodKey ) );
 
-  QgsDebugMsg( "Library name is " + myLib.fileName() );
+  QgsDebugMsgLevel( "Library name is " + myLib.fileName(), 2 );
 
   if ( myLib.load() )
   {
@@ -347,7 +347,7 @@ std::unique_ptr<QLibrary> QgsAuthMethodRegistry::authMethodLibrary( const QStrin
 {
   std::unique_ptr< QLibrary > myLib( new QLibrary( library( authMethodKey ) ) );
 
-  QgsDebugMsg( "Library name is " + myLib->fileName() );
+  QgsDebugMsgLevel( "Library name is " + myLib->fileName(), 2 );
 
   if ( myLib->load() )
     return myLib;

--- a/src/core/providers/arcgis/qgsarcgisrestquery.h
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.h
@@ -93,12 +93,12 @@ class CORE_EXPORT QgsArcGisRestQueryUtils
     /**
      * Calls the specified \a visitor function on all service items found within the given service data.
      */
-    static void visitServiceItems( const std::function<void ( const QString &serviceName, const QString &url, ServiceTypeFilter serviceType )> &visitor, const QVariantMap &serviceData, const QString &baseUrl, const ServiceTypeFilter filter = AllTypes );
+    static void visitServiceItems( const std::function<void ( const QString &serviceName, const QString &url, const QString &service, ServiceTypeFilter serviceType )> &visitor, const QVariantMap &serviceData, const QString &baseUrl );
 
     /**
      * Calls the specified \a visitor function on all layer items found within the given service data.
      */
-    static void addLayerItems( const std::function<void ( const QString &parentLayerId, ServiceTypeFilter serviceType, QgsWkbTypes::GeometryType geometryType, const QString &layerId, const QString &name, const QString &description, const QString &url, bool isParentLayer, const QString &authid, const QString &format )> &visitor, const QVariantMap &serviceData, const QString &parentUrl, const ServiceTypeFilter filter = AllTypes );
+    static void addLayerItems( const std::function<void ( const QString &parentLayerId, ServiceTypeFilter serviceType, QgsWkbTypes::GeometryType geometryType, const QString &layerId, const QString &name, const QString &description, const QString &url, bool isParentLayer, const QString &authid, const QString &format )> &visitor, const QVariantMap &serviceData, const QString &parentUrl, const QString &parentSupportedFormats, const ServiceTypeFilter filter = AllTypes );
 
   private:
 

--- a/src/gui/auth/qgsauthconfigedit.cpp
+++ b/src/gui/auth/qgsauthconfigedit.cpp
@@ -167,8 +167,8 @@ void QgsAuthConfigEdit::loadConfig()
 
   QString authMethodKey = QgsApplication::authManager()->configAuthMethodKey( mAuthCfg );
 
-  QgsDebugMsg( QStringLiteral( "Loading authcfg: %1" ).arg( mAuthCfg ) );
-  QgsDebugMsg( QStringLiteral( "Loading auth method: %1" ).arg( authMethodKey ) );
+  QgsDebugMsgLevel( QStringLiteral( "Loading authcfg: %1" ).arg( mAuthCfg ), 2 );
+  QgsDebugMsgLevel( QStringLiteral( "Loading auth method: %1" ).arg( authMethodKey ), 2 );
 
   if ( authMethodKey.isEmpty() )
   {

--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -435,7 +435,7 @@ QString QgsFileWidget::toUrl( const QString &path ) const
   QUrl url = QUrl::fromUserInput( urlStr );
   if ( !url.isValid() || !url.isLocalFile() )
   {
-    QgsDebugMsg( QStringLiteral( "URL: %1 is not valid or not a local file!" ).arg( path ) );
+    QgsDebugMsgLevel( QStringLiteral( "URL: %1 is not valid or not a local file!" ).arg( path ), 2 );
     rep = path;
   }
 

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -349,8 +349,8 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
     mPostgresRasterTemporalGroup->setVisible( false );
   }
 
-  QgsDebugMsg( "Setting crs to " + mRasterLayer->crs().toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ) );
-  QgsDebugMsg( "Setting crs to " + mRasterLayer->crs().userFriendlyIdentifier() );
+  QgsDebugMsgLevel( "Setting crs to " + mRasterLayer->crs().toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ), 2 );
+  QgsDebugMsgLevel( "Setting crs to " + mRasterLayer->crs().userFriendlyIdentifier(), 2 );
   mCrsSelector->setCrs( mRasterLayer->crs() );
 
   // Set text for pyramid info box
@@ -642,7 +642,7 @@ void QgsRasterLayerProperties::populateTransparencyTable( QgsRasterRenderer *ren
 
 void QgsRasterLayerProperties::setRendererWidget( const QString &rendererName )
 {
-  QgsDebugMsg( "rendererName = " + rendererName );
+  QgsDebugMsgLevel( "rendererName = " + rendererName, 3 );
   QgsRasterRendererWidget *oldWidget = mRendererWidget;
   QgsRasterRenderer *oldRenderer = mRasterLayer->renderer();
 
@@ -662,7 +662,7 @@ void QgsRasterLayerProperties::setRendererWidget( const QString &rendererName )
   {
     if ( rendererEntry.widgetCreateFunction ) //single band color data renderer e.g. has no widget
     {
-      QgsDebugMsg( QStringLiteral( "renderer has widgetCreateFunction" ) );
+      QgsDebugMsgLevel( QStringLiteral( "renderer has widgetCreateFunction" ), 3 );
       // Current canvas extent (used to calc min/max) in layer CRS
       QgsRectangle myExtent = mMapCanvas->mapSettings().outputExtentToLayerExtent( mRasterLayer, mMapCanvas->extent() );
       if ( oldWidget && ( !oldRenderer || rendererName != oldRenderer->type() ) )
@@ -776,7 +776,7 @@ void QgsRasterLayerProperties::sync()
     }
   }
 
-  QgsDebugMsg( QStringLiteral( "populate transparency tab" ) );
+  QgsDebugMsgLevel( QStringLiteral( "populate transparency tab" ), 3 );
 
   /*
    * Style tab
@@ -842,7 +842,7 @@ void QgsRasterLayerProperties::sync()
   lblSrcNoDataValue->setEnabled( enableSrcNoData );
 
   QgsRasterRangeList noDataRangeList = provider->userNoDataValues( 1 );
-  QgsDebugMsg( QStringLiteral( "noDataRangeList.size = %1" ).arg( noDataRangeList.size() ) );
+  QgsDebugMsgLevel( QStringLiteral( "noDataRangeList.size = %1" ).arg( noDataRangeList.size() ), 3 );
   if ( !noDataRangeList.isEmpty() )
   {
     leNoDataValue->insert( QgsRasterBlock::printValue( noDataRangeList.value( 0 ).min() ) );
@@ -858,12 +858,12 @@ void QgsRasterLayerProperties::sync()
 
   populateTransparencyTable( mRasterLayer->renderer() );
 
-  QgsDebugMsg( QStringLiteral( "populate colormap tab" ) );
+  QgsDebugMsgLevel( QStringLiteral( "populate colormap tab" ), 3 );
   /*
    * Transparent Pixel Tab
    */
 
-  QgsDebugMsg( QStringLiteral( "populate general tab" ) );
+  QgsDebugMsgLevel( QStringLiteral( "populate general tab" ), 3 );
   /*
    * General Tab
    */
@@ -952,7 +952,7 @@ void QgsRasterLayerProperties::apply()
    */
   mLegendConfigEmbeddedWidget->applyToLayer();
 
-  QgsDebugMsg( QStringLiteral( "apply processing symbology tab" ) );
+  QgsDebugMsgLevel( QStringLiteral( "apply processing symbology tab" ), 3 );
   /*
    * Symbology Tab
    */
@@ -964,7 +964,7 @@ void QgsRasterLayerProperties::apply()
   mRasterLayer->brightnessFilter()->setContrast( mSliderContrast->value() );
   mRasterLayer->brightnessFilter()->setGamma( mGammaSpinBox->value() );
 
-  QgsDebugMsg( QStringLiteral( "processing transparency tab" ) );
+  QgsDebugMsgLevel( QStringLiteral( "processing transparency tab" ), 3 );
   /*
    * Transparent Pixel Tab
    */
@@ -1042,7 +1042,7 @@ void QgsRasterLayerProperties::apply()
     rasterRenderer->setOpacity( mOpacityWidget->opacity() );
   }
 
-  QgsDebugMsg( QStringLiteral( "processing general tab" ) );
+  QgsDebugMsgLevel( QStringLiteral( "processing general tab" ), 3 );
   /*
    * General Tab
    */
@@ -1603,7 +1603,7 @@ void QgsRasterLayerProperties::pbnDefaultValues_clicked()
 
 void QgsRasterLayerProperties::setTransparencyCell( int row, int column, double value )
 {
-  QgsDebugMsg( QStringLiteral( "value = %1" ).arg( value, 0, 'g', 17 ) );
+  QgsDebugMsgLevel( QStringLiteral( "value = %1" ).arg( value, 0, 'g', 17 ), 3 );
   QgsRasterDataProvider *provider = mRasterLayer->dataProvider();
   if ( !provider ) return;
 
@@ -1740,7 +1740,7 @@ void QgsRasterLayerProperties::pbnExportTransparentPixelValues_clicked()
 void QgsRasterLayerProperties::transparencyCellTextEdited( const QString &text )
 {
   Q_UNUSED( text )
-  QgsDebugMsg( QStringLiteral( "text = %1" ).arg( text ) );
+  QgsDebugMsgLevel( QStringLiteral( "text = %1" ).arg( text ), 3 );
   QgsRasterRenderer *renderer = mRendererWidget->renderer();
   if ( !renderer )
   {
@@ -1766,14 +1766,14 @@ void QgsRasterLayerProperties::transparencyCellTextEdited( const QString &text )
       }
       if ( row != -1 ) break;
     }
-    QgsDebugMsg( QStringLiteral( "row = %1 column =%2" ).arg( row ).arg( column ) );
+    QgsDebugMsgLevel( QStringLiteral( "row = %1 column =%2" ).arg( row ).arg( column ), 3 );
 
     if ( column == 0 )
     {
       QLineEdit *toLineEdit = dynamic_cast<QLineEdit *>( tableTransparency->cellWidget( row, 1 ) );
       if ( !toLineEdit ) return;
       bool toChanged = mTransparencyToEdited.value( row );
-      QgsDebugMsg( QStringLiteral( "toChanged = %1" ).arg( toChanged ) );
+      QgsDebugMsgLevel( QStringLiteral( "toChanged = %1" ).arg( toChanged ), 3 );
       if ( !toChanged )
       {
         toLineEdit->setText( lineEdit->text() );
@@ -1992,7 +1992,7 @@ void QgsRasterLayerProperties::pixelSelected( const QgsPointXY &canvasPoint, con
           return; // Don't add nodata, transparent anyway
         }
         double value = myPixelMap.value( bandNo ).toDouble();
-        QgsDebugMsg( QStringLiteral( "value = %1" ).arg( value, 0, 'g', 17 ) );
+        QgsDebugMsgLevel( QStringLiteral( "value = %1" ).arg( value, 0, 'g', 17 ), 3 );
         values.append( value );
       }
     }

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.h
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.h
@@ -190,7 +190,7 @@ class QgsArcGisMapServiceItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsArcGisMapServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsStringMap &headers );
+    QgsArcGisMapServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsStringMap &headers, const QString &serviceType );
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
 
@@ -199,6 +199,7 @@ class QgsArcGisMapServiceItem : public QgsDataCollectionItem
     QString mBaseUrl;
     QString mAuthCfg;
     QgsStringMap mHeaders;
+    QString mServiceType;
 };
 
 /**

--- a/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
@@ -315,8 +315,8 @@ void QgsArcGisRestSourceSelect::addButtonClicked()
     try
     {
       extent = QgsCoordinateTransform( canvasCrs, pCrs, QgsProject::instance()->transformContext() ).transform( extent );
-      QgsDebugMsg( QStringLiteral( "canvas transform: Canvas CRS=%1, Provider CRS=%2, BBOX=%3" )
-                   .arg( canvasCrs.authid(), pCrs.authid(), extent.asWktCoordinates() ) );
+      QgsDebugMsgLevel( QStringLiteral( "canvas transform: Canvas CRS=%1, Provider CRS=%2, BBOX=%3" )
+                        .arg( canvasCrs.authid(), pCrs.authid(), extent.asWktCoordinates() ), 3 );
     }
     catch ( const QgsCsException & )
     {
@@ -422,7 +422,7 @@ void QgsArcGisRestSourceSelect::cmbConnections_activated( int index )
 void QgsArcGisRestSourceSelect::treeWidgetCurrentRowChanged( const QModelIndex &current, const QModelIndex &previous )
 {
   Q_UNUSED( previous )
-  QgsDebugMsg( QStringLiteral( "treeWidget_currentRowChanged called" ) );
+  QgsDebugMsgLevel( QStringLiteral( "treeWidget_currentRowChanged called" ), 3 );
   updateCrsLabel();
   updateImageEncodings();
 


### PR DESCRIPTION
Hardcode a list of supported image formats for ImageServer services, to ensure that we always have a valid list of available
formats when layers from a ImageServer are selected in data source manager/browser

This also ensures that we select the default JPGPNG format when an ImageServer layer is added via browser

Fixes #41126
Supersedes https://github.com/qgis/QGIS/pull/41146