### PR TITLE
[Backport 3.16] More connections XML import dialoges: deal properly with duplicate connection names

### DIFF
--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -1030,10 +1030,17 @@ void QgsManageConnectionsDialog::loadPgConnections( const QDomDocument &doc, con
       }
     }
 
-    if ( keys.contains( connectionName ) && !overwrite )
+    if ( keys.contains( connectionName ) )
     {
-      child = child.nextSiblingElement();
-      continue;
+      if ( !overwrite )
+      {
+        child = child.nextSiblingElement();
+        continue;
+      }
+    }
+    else
+    {
+      keys << connectionName;
     }
 
     //no dups detected or overwrite is allowed
@@ -1120,10 +1127,17 @@ void QgsManageConnectionsDialog::loadMssqlConnections( const QDomDocument &doc, 
       }
     }
 
-    if ( keys.contains( connectionName ) && !overwrite )
+    if ( keys.contains( connectionName ) )
     {
-      child = child.nextSiblingElement();
-      continue;
+      if ( !overwrite )
+      {
+        child = child.nextSiblingElement();
+        continue;
+      }
+    }
+    else
+    {
+      keys << connectionName;
     }
 
     //no dups detected or overwrite is allowed
@@ -1210,10 +1224,17 @@ void QgsManageConnectionsDialog::loadOracleConnections( const QDomDocument &doc,
       }
     }
 
-    if ( keys.contains( connectionName ) && !overwrite )
+    if ( keys.contains( connectionName ) )
     {
-      child = child.nextSiblingElement();
-      continue;
+      if ( !overwrite )
+      {
+        child = child.nextSiblingElement();
+        continue;
+      }
+    }
+    else
+    {
+      keys << connectionName;
     }
 
     //no dups detected or overwrite is allowed
@@ -1297,10 +1318,17 @@ void QgsManageConnectionsDialog::loadDb2Connections( const QDomDocument &doc, co
       }
     }
 
-    if ( keys.contains( connectionName ) && !overwrite )
+    if ( keys.contains( connectionName ) )
     {
-      child = child.nextSiblingElement();
-      continue;
+      if ( !overwrite )
+      {
+        child = child.nextSiblingElement();
+        continue;
+      }
+    }
+    else
+    {
+      keys << connectionName;
     }
 
     //no dups detected or overwrite is allowed
@@ -1387,10 +1415,17 @@ void QgsManageConnectionsDialog::loadGeonodeConnections( const QDomDocument &doc
       }
     }
 
-    if ( keys.contains( connectionName ) && !overwrite )
+    if ( keys.contains( connectionName ) )
     {
-      child = child.nextSiblingElement();
-      continue;
+      if ( !overwrite )
+      {
+        child = child.nextSiblingElement();
+        continue;
+      }
+    }
+    else
+    {
+      keys << connectionName;
     }
 
     // no dups detected or overwrite is allowed
@@ -1467,10 +1502,17 @@ void QgsManageConnectionsDialog::loadXyzTilesConnections( const QDomDocument &do
       }
     }
 
-    if ( keys.contains( connectionName ) && !overwrite )
+    if ( keys.contains( connectionName ) )
     {
-      child = child.nextSiblingElement();
-      continue;
+      if ( !overwrite )
+      {
+        child = child.nextSiblingElement();
+        continue;
+      }
+    }
+    else
+    {
+      keys << connectionName;
     }
 
     settings.beginGroup( "qgis/connections-xyz/" + connectionName );
@@ -1546,10 +1588,17 @@ void QgsManageConnectionsDialog::loadArcgisConnections( const QDomDocument &doc,
       }
     }
 
-    if ( keys.contains( connectionName ) && !overwrite )
+    if ( keys.contains( connectionName ) )
     {
-      child = child.nextSiblingElement();
-      continue;
+      if ( !overwrite )
+      {
+        child = child.nextSiblingElement();
+        continue;
+      }
+    }
+    else
+    {
+      keys << connectionName;
     }
 
     // no dups detected or overwrite is allowed
@@ -1626,10 +1675,17 @@ void QgsManageConnectionsDialog::loadVectorTileConnections( const QDomDocument &
       }
     }
 
-    if ( keys.contains( connectionName ) && !overwrite )
+    if ( keys.contains( connectionName ) )
     {
-      child = child.nextSiblingElement();
-      continue;
+      if ( !overwrite )
+      {
+        child = child.nextSiblingElement();
+        continue;
+      }
+    }
+    else
+    {
+      keys << connectionName;
     }
 
     settings.beginGroup( "qgis/connections-vector-tile/" + connectionName );


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/41262

The backport didn't work automatically, because of code related to the HANA connections which has been removed for this backport PR.