### PR TITLE
Project load freezes QWebkit-less QGIS builds when a layout contains an HTML item

### DIFF
--- a/src/core/qgswebframe.h
+++ b/src/core/qgswebframe.h
@@ -61,6 +61,7 @@ class CORE_EXPORT QWebFrame : public QObject
     {
       Q_UNUSED( html )
       Q_UNUSED( url )
+      emit loadFinished( true );
     }
 
     QSize contentsSize() const
@@ -84,6 +85,8 @@ class CORE_EXPORT QWebFrame : public QObject
     }
 
   signals:
+    void loadFinished( bool ok );
+
     void javaScriptWindowObjectCleared();
 /// @endcond
 };

--- a/src/core/qgswebpage.h
+++ b/src/core/qgswebpage.h
@@ -125,6 +125,7 @@ class CORE_EXPORT QWebPage : public QObject
       , mSettings( new QWebSettings() )
       , mFrame( new QWebFrame() )
     {
+      connect( mFrame, &QWebFrame::loadFinished, this, &QWebPage::loadFinished );
     }
 
     ~QWebPage()


### PR DESCRIPTION
## Description

This PR fixes a QGIS complete freeze when loading a project that has a layout containing an HTML item. The freeze happens when QGIS is compiled with WITH_QTWEBKIT=OFF.

This impacts for e.g., QGIS libraries built on platforms where webkit isn't available such as Android. This was reported by a QField user here (https://github.com/opengisch/QField/issues/970)