### PR TITLE
Add 2 new actions to the attribute table header context menu.

### DIFF
--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -990,7 +990,7 @@ void QgsDualView::autosizeColumn()
 
 void QgsDualView::autosizeAllColumns()
 {
-    mTableView->resizeColumnsToContents();
+  mTableView->resizeColumnsToContents();
 }
 
 bool QgsDualView::modifySort()

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -964,7 +964,7 @@ void QgsDualView::resizeAllColumns()
   QgsAttributeTableConfig config = mConfig;
 
   bool ok = false;
-  int width = QInputDialog::getInt( this, tr( "Set column width" ), tr( "Enter column width" ),
+  int width = QInputDialog::getInt( this, tr( "Set Column Width" ), tr( "Enter column width" ),
                                       mTableView->columnWidth( col ),
                                       1, 1000, 10, &ok );
   if ( ok )

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -970,7 +970,7 @@ void QgsDualView::resizeAllColumns()
   if ( ok )
   {
     const int colCount = mTableView->model()->columnCount();
-    if ( colCount > 0)
+    if ( colCount > 0 )
     {
       for ( int i = 0; i < colCount; i++ )
       {

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -865,10 +865,21 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
   connect( setWidth, &QAction::triggered, this, &QgsDualView::resizeColumn );
   setWidth->setData( col );
   mHorizontalHeaderMenu->addAction( setWidth );
+
+  QAction *setWidthAllColumns = new QAction( tr( "&Set Width All..." ), mHorizontalHeaderMenu );
+  connect( setWidthAllColumns, &QAction::triggered, this, &QgsDualView::resizeAllColumns );
+  setWidthAllColumns->setData( col );
+  mHorizontalHeaderMenu->addAction( setWidthAllColumns );
+
   QAction *optimizeWidth = new QAction( tr( "&Autosize" ), mHorizontalHeaderMenu );
   connect( optimizeWidth, &QAction::triggered, this, &QgsDualView::autosizeColumn );
   optimizeWidth->setData( col );
   mHorizontalHeaderMenu->addAction( optimizeWidth );
+
+  QAction *optimizeWidthAllColumns = new QAction( tr( "&Autosize All Columns" ), mHorizontalHeaderMenu );
+  connect( optimizeWidthAllColumns, &QAction::triggered, this, &QgsDualView::autosizeAllColumns );
+  mHorizontalHeaderMenu->addAction( optimizeWidthAllColumns );
+
 
   mHorizontalHeaderMenu->addSeparator();
   QAction *organize = new QAction( tr( "&Organize Columns…" ), mHorizontalHeaderMenu );
@@ -943,11 +954,43 @@ void QgsDualView::resizeColumn()
   }
 }
 
+void QgsDualView::resizeAllColumns()
+{
+  QAction *action = qobject_cast<QAction *>( sender() );
+  int col = action->data().toInt();
+  if ( col < 0 )
+    return;
+
+  QgsAttributeTableConfig config = mConfig;
+
+  bool ok = false;
+  int width = QInputDialog::getInt( this, tr( "Set column width" ), tr( "Enter column width" ),
+                                      mTableView->columnWidth( col ),
+                                      1, 1000, 10, &ok );
+  if ( ok )
+  {
+    int col_count = mTableView->model()->columnCount();
+    if ( col_count > 0)
+    {
+      for ( int i=0; i<col_count; i++ )
+      {
+        config.setColumnWidth( i, width );
+      }
+      setAttributeTableConfig( config );
+    }
+  }
+}
+
 void QgsDualView::autosizeColumn()
 {
   QAction *action = qobject_cast<QAction *>( sender() );
   int col = action->data().toInt();
   mTableView->resizeColumnToContents( col );
+}
+
+void QgsDualView::autosizeAllColumns()
+{
+    mTableView->resizeColumnsToContents();
 }
 
 bool QgsDualView::modifySort()

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -866,7 +866,7 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
   setWidth->setData( col );
   mHorizontalHeaderMenu->addAction( setWidth );
 
-  QAction *setWidthAllColumns = new QAction( tr( "&Set Width All..." ), mHorizontalHeaderMenu );
+  QAction *setWidthAllColumns = new QAction( tr( "&Set All Column Widths…" ), mHorizontalHeaderMenu );
   connect( setWidthAllColumns, &QAction::triggered, this, &QgsDualView::resizeAllColumns );
   setWidthAllColumns->setData( col );
   mHorizontalHeaderMenu->addAction( setWidthAllColumns );

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -969,10 +969,10 @@ void QgsDualView::resizeAllColumns()
                                       1, 1000, 10, &ok );
   if ( ok )
   {
-    int col_count = mTableView->model()->columnCount();
-    if ( col_count > 0)
+    const int colCount = mTableView->model()->columnCount();
+    if ( colCount > 0)
     {
-      for ( int i=0; i<col_count; i++ )
+      for ( int i = 0; i < colCount; i++ )
       {
         config.setColumnWidth( i, width );
       }

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -965,8 +965,8 @@ void QgsDualView::resizeAllColumns()
 
   bool ok = false;
   int width = QInputDialog::getInt( this, tr( "Set Column Width" ), tr( "Enter column width" ),
-                                      mTableView->columnWidth( col ),
-                                      1, 1000, 10, &ok );
+                                    mTableView->columnWidth( col ),
+                                    1, 1000, 10, &ok );
   if ( ok )
   {
     const int colCount = mTableView->model()->columnCount();

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -344,7 +344,11 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
 
     void resizeColumn();
 
+    void resizeAllColumns();
+
     void autosizeColumn();
+
+    void autosizeAllColumns();
 
     void previewExpressionChanged( const QString &expression );
 


### PR DESCRIPTION
This pull request adds 2 new actions to the attribute table header context menu.
The first allows setting a width to be applied to all columns,
the second optimizes column width for all columns by auto-sizing all
columns to contents.

These actions complement the existing actions "Set Width" and "Autosize"
but are applied to all columns instead of only the column in which the user
right-clicks the header to show the context menu.

Addresses feature request #41108

The new functionality is demonstrated in the gifs below.

Autosize All Columns:

![Peek 2021-01-29 20-57](https://user-images.githubusercontent.com/47767794/106375751-cdb2ce80-63da-11eb-9ffb-963a69b5d56a.gif)

Set Width All:

![Peek 2021-01-31 11-35](https://user-images.githubusercontent.com/47767794/106375787-0488e480-63db-11eb-81a9-2a379ffe9145.gif)
