### PR TITLE
[gdal] Add open options support to gain dataset flexibility / fixes

### DIFF
--- a/src/core/providers/gdal/qgsgdalproviderbase.cpp
+++ b/src/core/providers/gdal/qgsgdalproviderbase.cpp
@@ -20,6 +20,7 @@
 
 #define CPL_SUPRESS_CPLUSPLUS  //#spellok
 #include <cpl_conv.h>
+#include <cpl_string.h>
 
 #include "qgsapplication.h"
 #include "qgslogger.h"
@@ -254,14 +255,29 @@ QgsRectangle QgsGdalProviderBase::extent( GDALDatasetH gdalDataset )const
   return extent;
 }
 
-GDALDatasetH QgsGdalProviderBase::gdalOpen( const char *pszFilename, GDALAccess eAccess )
+GDALDatasetH QgsGdalProviderBase::gdalOpen( const QString &uri, unsigned int nOpenFlags )
 {
+  QVariantMap parts = decodeGdalUri( uri );
+  QString filePath = parts.value( QStringLiteral( "path" ) ).toString();
+  const QStringList openOptions = parts.value( QStringLiteral( "openOptions" ) ).toStringList();
+  parts.remove( QStringLiteral( "openOptions" ) );
+
+  char **papszOpenOptions = nullptr;
+  for ( const QString &option : openOptions )
+  {
+    papszOpenOptions = CSLAddString( papszOpenOptions,
+                                     option.toUtf8().constData() );
+  }
+
   bool modify_OGR_GPKG_FOREIGN_KEY_CHECK = !CPLGetConfigOption( "OGR_GPKG_FOREIGN_KEY_CHECK", nullptr );
   if ( modify_OGR_GPKG_FOREIGN_KEY_CHECK )
   {
     CPLSetThreadLocalConfigOption( "OGR_GPKG_FOREIGN_KEY_CHECK", "NO" );
   }
-  GDALDatasetH hDS = GDALOpen( pszFilename, eAccess );
+
+  GDALDatasetH hDS = GDALOpenEx( encodeGdalUri( parts ).toUtf8().constData(), nOpenFlags, nullptr, papszOpenOptions, nullptr );
+  CSLDestroy( papszOpenOptions );
+
   if ( modify_OGR_GPKG_FOREIGN_KEY_CHECK )
   {
     CPLSetThreadLocalConfigOption( "OGR_GPKG_FOREIGN_KEY_CHECK", nullptr );
@@ -302,6 +318,76 @@ int QgsGdalProviderBase::gdalGetOverviewCount( GDALRasterBandH hBand )
 {
   int count = GDALGetOverviewCount( hBand );
   return count;
+}
+
+QVariantMap QgsGdalProviderBase::decodeGdalUri( const QString &uri )
+{
+  QString path = uri;
+  QString layerName;
+  QStringList openOptions;
+
+  QString vsiPrefix = qgsVsiPrefix( path );
+  if ( !path.isEmpty() )
+    path = path.mid( vsiPrefix.count() );
+
+  if ( path.indexOf( ':' ) != -1 )
+  {
+    QStringList parts = path.split( ':' );
+    if ( parts[0].toLower() == QLatin1String( "gpkg" ) )
+    {
+      parts.removeFirst();
+      // Handle windows paths - which has an extra colon - and unix paths
+      if ( ( parts[0].length() > 1 && parts.count() > 1 ) || parts.count() > 2 )
+      {
+        layerName = parts[parts.length() - 1];
+        parts.removeLast();
+      }
+      path  = parts.join( ':' );
+    }
+  }
+
+  if ( path.contains( '|' ) )
+  {
+    const QRegularExpression openOptionRegex( QStringLiteral( "\\|option:([^|]*)" ) );
+
+    while ( true )
+    {
+      QRegularExpressionMatch match = openOptionRegex.match( path );
+      if ( match.hasMatch() )
+      {
+        openOptions << match.captured( 1 );
+        path = path.remove( match.capturedStart( 0 ), match.capturedLength( 0 ) );
+      }
+      else
+      {
+        break;
+      }
+    }
+  }
+
+  QVariantMap uriComponents;
+  uriComponents.insert( QStringLiteral( "path" ), path );
+  uriComponents.insert( QStringLiteral( "layerName" ), layerName );
+  if ( !openOptions.isEmpty() )
+    uriComponents.insert( QStringLiteral( "openOptions" ), openOptions );
+  return uriComponents;
+}
+
+QString QgsGdalProviderBase::encodeGdalUri( const QVariantMap &parts )
+{
+  QString path = parts.value( QStringLiteral( "path" ) ).toString();
+  QString layerName = parts.value( QStringLiteral( "layerName" ) ).toString();
+  QString uri = path + ( !layerName.isEmpty() ? QStringLiteral( "|%1" ).arg( layerName ) : QString() );
+
+  const QStringList openOptions = parts.value( QStringLiteral( "openOptions" ) ).toStringList();
+
+  for ( const QString &openOption : openOptions )
+  {
+    uri += QStringLiteral( "|option:" );
+    uri += openOption;
+  }
+
+  return uri;
 }
 
 ///@endcond

--- a/src/core/providers/gdal/qgsgdalproviderbase.cpp
+++ b/src/core/providers/gdal/qgsgdalproviderbase.cpp
@@ -377,7 +377,12 @@ QString QgsGdalProviderBase::encodeGdalUri( const QVariantMap &parts )
 {
   QString path = parts.value( QStringLiteral( "path" ) ).toString();
   QString layerName = parts.value( QStringLiteral( "layerName" ) ).toString();
-  QString uri = path + ( !layerName.isEmpty() ? QStringLiteral( "|%1" ).arg( layerName ) : QString() );
+  QString uri;
+
+  if ( !layerName.isEmpty() && path.endsWith( QStringLiteral( "gpkg" ) ) )
+    uri = QStringLiteral( "GPKG:%1:%2" ).arg( path, layerName );
+  else
+    uri = path + ( !layerName.isEmpty() ? QStringLiteral( "|%1" ).arg( layerName ) : QString() );
 
   const QStringList openOptions = parts.value( QStringLiteral( "openOptions" ) ).toStringList();
 

--- a/src/core/providers/gdal/qgsgdalproviderbase.h
+++ b/src/core/providers/gdal/qgsgdalproviderbase.h
@@ -42,13 +42,18 @@ class QgsGdalProviderBase
     static void registerGdalDrivers();
 
     //! Wrapper function for GDALOpen to get around possible bugs in GDAL
-    static GDALDatasetH  gdalOpen( const char *pszFilename, GDALAccess eAccess );
+    static GDALDatasetH  gdalOpen( const QString &uri, unsigned int nOpenFlags );
 
     //! Wrapper function for GDALRasterIO to get around possible bugs in GDAL
     static CPLErr gdalRasterIO( GDALRasterBandH hBand, GDALRWFlag eRWFlag, int nXOff, int nYOff, int nXSize, int nYSize, void *pData, int nBufXSize, int nBufYSize, GDALDataType eBufType, int nPixelSpace, int nLineSpace, QgsRasterBlockFeedback *feedback = nullptr );
 
     //! Wrapper function for GDALRasterIO to get around possible bugs in GDAL
     static int gdalGetOverviewCount( GDALRasterBandH hBand );
+
+    static QVariantMap decodeGdalUri( const QString &uri );
+
+    static QString encodeGdalUri( const QVariantMap &parts );
+
   protected:
 
     Qgis::DataType dataTypeFromGdal( GDALDataType gdalDataType ) const;

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -24,6 +24,7 @@
 #include "ogr/qgsogrhelperfunctions.h"
 
 #include <gdal.h>
+#include <cpl_minixml.h>
 
 QgsGdalSourceSelect::QgsGdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode ):
   QgsAbstractDataSourceWidget( parent, fl, widgetMode )
@@ -54,17 +55,26 @@ QgsGdalSourceSelect::QgsGdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
   connect( protocolURI, &QLineEdit::textChanged, this, [ = ]( const QString & text )
   {
     if ( radioSrcProtocol->isChecked() )
+    {
       emit enableButtons( !text.isEmpty() );
+      fillOpenOptions();
+    }
   } );
   connect( mBucket, &QLineEdit::textChanged, this, [ = ]( const QString & text )
   {
     if ( radioSrcProtocol->isChecked() )
+    {
       emit enableButtons( !text.isEmpty() && !mKey->text().isEmpty() );
+      fillOpenOptions();
+    }
   } );
   connect( mKey, &QLineEdit::textChanged, this, [ = ]( const QString & text )
   {
     if ( radioSrcProtocol->isChecked() )
+    {
       emit enableButtons( !text.isEmpty() && !mBucket->text().isEmpty() );
+      fillOpenOptions();
+    }
   } );
 
   mFileWidget->setDialogTitle( tr( "Open GDAL Supported Raster Dataset(s)" ) );
@@ -75,7 +85,9 @@ QgsGdalSourceSelect::QgsGdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
   {
     mRasterPath = path;
     emit enableButtons( ! mRasterPath.isEmpty() );
+    fillOpenOptions();
   } );
+  mOpenOptionsGroupBox->setVisible( false );
 }
 
 bool QgsGdalSourceSelect::isProtocolCloudType()
@@ -119,8 +131,10 @@ void QgsGdalSourceSelect::radioSrcFile_toggled( bool checked )
   {
     fileGroupBox->show();
     protocolGroupBox->hide();
+    clearOpenOptions();
 
     emit enableButtons( !mFileWidget->filePath().isEmpty() );
+
   }
 }
 
@@ -130,8 +144,8 @@ void QgsGdalSourceSelect::radioSrcProtocol_toggled( bool checked )
   {
     fileGroupBox->hide();
     protocolGroupBox->show();
-
     setProtocolWidgetsVisibility();
+    clearOpenOptions();
 
     emit enableButtons( !protocolURI->text().isEmpty() );
   }
@@ -141,24 +155,61 @@ void QgsGdalSourceSelect::cmbProtocolTypes_currentIndexChanged( const QString &t
 {
   Q_UNUSED( text )
   setProtocolWidgetsVisibility();
+  clearOpenOptions();
 }
 
 void QgsGdalSourceSelect::addButtonClicked()
 {
+  computeDataSources();
+
+  if ( mDataSources.isEmpty() )
+  {
+    QMessageBox::information( this,
+                              tr( "Add raster layer" ),
+                              tr( "No layers selected." ) );
+    return;
+  }
+
+  for ( const QString &dataSource : mDataSources )
+  {
+    if ( QFile::exists( dataSource ) )
+      emit addRasterLayer( dataSource, QFileInfo( dataSource ).completeBaseName(), QStringLiteral( "gdal" ) );
+    else
+      emit addRasterLayer( dataSource, dataSource, QStringLiteral( "gdal" ) );
+  }
+}
+
+void QgsGdalSourceSelect::computeDataSources()
+{
+  mDataSources.clear();
+
+  QStringList openOptions;
+  for ( QWidget *control : mOpenOptionsWidgets )
+  {
+    QString value;
+    if ( QComboBox *cb = qobject_cast<QComboBox *>( control ) )
+    {
+      value = cb->itemData( cb->currentIndex() ).toString();
+    }
+    else if ( QLineEdit *le = qobject_cast<QLineEdit *>( control ) )
+    {
+      value = le->text();
+    }
+    if ( !value.isEmpty() )
+    {
+      openOptions << QStringLiteral( "%1=%2" ).arg( control->objectName() ).arg( value );
+    }
+  }
+
   if ( radioSrcFile->isChecked() )
   {
-    if ( mRasterPath.isEmpty() )
+    for ( const auto &filePath : QgsFileWidget::splitFilePaths( mRasterPath ) )
     {
-      QMessageBox::information( this,
-                                tr( "Add raster layer" ),
-                                tr( "No layers selected." ) );
-      return;
-    }
-
-    const QStringList paths = QgsFileWidget::splitFilePaths( mRasterPath );
-    for ( const QString &path : paths )
-    {
-      emit addRasterLayer( path, QFileInfo( path ).completeBaseName(), QStringLiteral( "gdal" ) );
+      QVariantMap parts;
+      if ( !openOptions.isEmpty() )
+        parts.insert( QStringLiteral( "openOptions" ), openOptions );
+      parts.insert( QStringLiteral( "path" ), filePath );
+      mDataSources << QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "gdal" ), parts );
     }
   }
   else if ( radioSrcProtocol->isChecked() )
@@ -166,16 +217,10 @@ void QgsGdalSourceSelect::addButtonClicked()
     bool cloudType = isProtocolCloudType();
     if ( !cloudType && protocolURI->text().isEmpty() )
     {
-      QMessageBox::information( this,
-                                tr( "Add raster layer" ),
-                                tr( "No protocol URI entered." ) );
       return;
     }
     else if ( cloudType && ( mBucket->text().isEmpty() || mKey->text().isEmpty() ) )
     {
-      QMessageBox::information( this,
-                                tr( "Add raster layer" ),
-                                tr( "No protocol bucket and/or key entered." ) );
       return;
     }
 
@@ -189,13 +234,157 @@ void QgsGdalSourceSelect::addButtonClicked()
       uri = protocolURI->text();
     }
 
-    QString dataSource = createProtocolURI( cmbProtocolTypes->currentText(),
-                                            uri,
-                                            mAuthSettingsProtocol->configId(),
-                                            mAuthSettingsProtocol->username(),
-                                            mAuthSettingsProtocol->password() );
-    emit addRasterLayer( dataSource, dataSource, QStringLiteral( "gdal" ) );
+    QVariantMap parts;
+    if ( !openOptions.isEmpty() )
+      parts.insert( QStringLiteral( "openOptions" ), openOptions );
+    parts.insert( QStringLiteral( "path" ),
+                  createProtocolURI( cmbProtocolTypes->currentText(),
+                                     uri,
+                                     mAuthSettingsProtocol->configId(),
+                                     mAuthSettingsProtocol->username(),
+                                     mAuthSettingsProtocol->password() ) );
+    mDataSources << QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "gdal" ), parts );
   }
+}
+
+void QgsGdalSourceSelect::clearOpenOptions()
+{
+  mOpenOptionsWidgets.clear();
+  mOpenOptionsGroupBox->setVisible( false );
+  mOpenOptionsLabel->clear();
+  while ( mOpenOptionsLayout->count() )
+  {
+    QLayoutItem *item = mOpenOptionsLayout->takeAt( 0 );
+    delete item->widget();
+    delete item;
+  }
+}
+
+void QgsGdalSourceSelect::fillOpenOptions()
+{
+  clearOpenOptions();
+  computeDataSources();
+  if ( mDataSources.isEmpty() )
+    return;
+
+  GDALDriverH hDriver;
+  if ( STARTS_WITH_CI( mDataSources[0].toUtf8().toStdString().c_str(), "PG:" ) )
+    hDriver = GDALGetDriverByName( "PostgreSQL" ); // otherwise the PostgisRaster driver gets identified
+  else
+    hDriver = GDALIdentifyDriver( mDataSources[0].toUtf8().toStdString().c_str(), nullptr );
+  if ( hDriver == nullptr )
+    return;
+
+  const char *pszOpenOptionList = GDALGetMetadataItem( hDriver, GDAL_DMD_OPENOPTIONLIST, nullptr );
+  if ( pszOpenOptionList == nullptr )
+    return;
+
+  CPLXMLNode *psDoc = CPLParseXMLString( pszOpenOptionList );
+  if ( psDoc == nullptr )
+    return;
+  CPLXMLNode *psOpenOptionList = CPLGetXMLNode( psDoc, "=OpenOptionList" );
+  if ( psOpenOptionList == nullptr )
+  {
+    CPLDestroyXMLNode( psDoc );
+    return;
+  }
+
+  const bool bIsGPKG = EQUAL( GDALGetDriverShortName( hDriver ), "GPKG" );
+
+  for ( auto psItem = psOpenOptionList->psChild; psItem != nullptr; psItem = psItem->psNext )
+  {
+    if ( psItem->eType != CXT_Element || !EQUAL( psItem->pszValue, "Option" ) )
+      continue;
+
+    const char *pszOptionName = CPLGetXMLValue( psItem, "name", nullptr );
+    if ( pszOptionName == nullptr )
+      continue;
+
+    // Exclude options that are not of raster scope
+    const char *pszScope = CPLGetXMLValue( psItem, "scope", nullptr );
+    if ( pszScope != nullptr && strstr( pszScope, "raster" ) == nullptr )
+      continue;
+
+    // The GPKG driver list a lot of options that are only for rasters
+    if ( bIsGPKG && strstr( pszOpenOptionList, "scope=" ) == nullptr &&
+         !EQUAL( pszOptionName, "LIST_ALL_TABLES" ) &&
+         !EQUAL( pszOptionName, "PRELUDE_STATEMENTS" ) )
+      continue;
+
+    const char *pszType = CPLGetXMLValue( psItem, "type", nullptr );
+    QStringList options;
+    if ( pszType && EQUAL( pszType, "string-select" ) )
+    {
+      for ( auto psOption = psItem->psChild; psOption != nullptr; psOption = psOption->psNext )
+      {
+        if ( psOption->eType != CXT_Element ||
+             !EQUAL( psOption->pszValue, "Value" ) ||
+             psOption->psChild == nullptr )
+        {
+          continue;
+        }
+        options << psOption->psChild->pszValue;
+      }
+    }
+
+    QLabel *label = new QLabel( pszOptionName );
+    QWidget *control = nullptr;
+    if ( pszType && EQUAL( pszType, "boolean" ) )
+    {
+      QComboBox *cb = new QComboBox();
+      cb->addItem( tr( "Yes" ), "YES" );
+      cb->addItem( tr( "No" ), "NO" );
+      cb->addItem( tr( "<Default>" ), QVariant( QVariant::String ) );
+      int idx = cb->findData( QVariant( QVariant::String ) );
+      cb->setCurrentIndex( idx );
+      control = cb;
+    }
+    else if ( !options.isEmpty() )
+    {
+      QComboBox *cb = new QComboBox();
+      for ( const QString &val : qgis::as_const( options ) )
+      {
+        cb->addItem( val, val );
+      }
+      cb->addItem( tr( "<Default>" ), QVariant( QVariant::String ) );
+      int idx = cb->findData( QVariant( QVariant::String ) );
+      cb->setCurrentIndex( idx );
+      control = cb;
+    }
+    else
+    {
+      QLineEdit *le = new QLineEdit( );
+      control = le;
+    }
+    control->setObjectName( pszOptionName );
+    mOpenOptionsWidgets.push_back( control );
+
+    const char *pszDescription = CPLGetXMLValue( psItem, "description", nullptr );
+    if ( pszDescription )
+    {
+      label->setToolTip( QStringLiteral( "<p>%1</p>" ).arg( pszDescription ) );
+      control->setToolTip( QStringLiteral( "<p>%1</p>" ).arg( pszDescription ) );
+    }
+    mOpenOptionsLayout->addRow( label, control );
+  }
+
+  CPLDestroyXMLNode( psDoc );
+
+  // Set label to point to driver help page
+  const char *pszHelpTopic = GDALGetMetadataItem( hDriver, GDAL_DMD_HELPTOPIC, nullptr );
+  if ( pszHelpTopic )
+  {
+    mOpenOptionsLabel->setText( tr( "Consult <a href=\"https://gdal.org/%1\">%2 driver help page</a> for detailed explanations on options" ).arg( pszHelpTopic ).arg( GDALGetDriverShortName( hDriver ) ) );
+    mOpenOptionsLabel->setTextInteractionFlags( Qt::TextBrowserInteraction );
+    mOpenOptionsLabel->setOpenExternalLinks( true );
+    mOpenOptionsLabel->setVisible( true );
+  }
+  else
+  {
+    mOpenOptionsLabel->setVisible( false );
+  }
+
+  mOpenOptionsGroupBox->setVisible( !mOpenOptionsWidgets.empty() );
 }
 
 ///@endcond

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -268,10 +268,7 @@ void QgsGdalSourceSelect::fillOpenOptions()
     return;
 
   GDALDriverH hDriver;
-  if ( STARTS_WITH_CI( mDataSources[0].toUtf8().toStdString().c_str(), "PG:" ) )
-    hDriver = GDALGetDriverByName( "PostgreSQL" ); // otherwise the PostgisRaster driver gets identified
-  else
-    hDriver = GDALIdentifyDriver( mDataSources[0].toUtf8().toStdString().c_str(), nullptr );
+  hDriver = GDALIdentifyDriver( mDataSources[0].toUtf8().toStdString().c_str(), nullptr );
   if ( hDriver == nullptr )
     return;
 
@@ -289,8 +286,6 @@ void QgsGdalSourceSelect::fillOpenOptions()
     return;
   }
 
-  const bool bIsGPKG = EQUAL( GDALGetDriverShortName( hDriver ), "GPKG" );
-
   for ( auto psItem = psOpenOptionList->psChild; psItem != nullptr; psItem = psItem->psNext )
   {
     if ( psItem->eType != CXT_Element || !EQUAL( psItem->pszValue, "Option" ) )
@@ -303,12 +298,6 @@ void QgsGdalSourceSelect::fillOpenOptions()
     // Exclude options that are not of raster scope
     const char *pszScope = CPLGetXMLValue( psItem, "scope", nullptr );
     if ( pszScope != nullptr && strstr( pszScope, "raster" ) == nullptr )
-      continue;
-
-    // The GPKG driver list a lot of options that are only for rasters
-    if ( bIsGPKG && strstr( pszOpenOptionList, "scope=" ) == nullptr &&
-         !EQUAL( pszOptionName, "LIST_ALL_TABLES" ) &&
-         !EQUAL( pszOptionName, "PRELUDE_STATEMENTS" ) )
       continue;
 
     const char *pszType = CPLGetXMLValue( psItem, "type", nullptr );

--- a/src/gui/providers/gdal/qgsgdalsourceselect.h
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.h
@@ -52,7 +52,13 @@ class QgsGdalSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsG
 
   private:
 
+    void computeDataSources();
+    void clearOpenOptions();
+    void fillOpenOptions();
+    std::vector<QWidget *> mOpenOptionsWidgets;
+
     QString mRasterPath;
+    QStringList mDataSources;
 
 };
 

--- a/src/ui/qgsgdalsourceselectbase.ui
+++ b/src/ui/qgsgdalsourceselectbase.ui
@@ -207,6 +207,29 @@
        </layout>
       </widget>
      </item>
+     <item>
+      <widget class="QgsCollapsibleGroupBox" name="mOpenOptionsGroupBox">
+       <property name="title">
+        <string>Options</string>
+       </property>
+       <layout class="QVBoxLayout" name="openOptionsVBoxLayout">
+         <item>
+           <widget class="QLabel" name="mOpenOptionsLabel">
+            <property name="text">
+             <string></string>
+            </property>
+           </widget>
+         </item>
+         <item>
+            <layout class="QFormLayout" name="mOpenOptionsLayout">
+                <property name="fieldGrowthPolicy">
+                <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                </property>
+            </layout>
+         </item>
+       </layout>
+      </widget>
+     </item>
     </layout>
    </item>
    <item row="1" column="0">
@@ -246,6 +269,7 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>mOpenOptionsGroupBox</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>

--- a/tests/src/core/testqgsgdalprovider.cpp
+++ b/tests/src/core/testqgsgdalprovider.cpp
@@ -117,7 +117,7 @@ void TestQgsGdalProvider::encodeUri()
   QCOMPARE( QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "gdal" ), parts ), QStringLiteral( "/home/user/test.gpkg" ) );
 
   parts.insert( QStringLiteral( "layerName" ), QStringLiteral( "layername" ) );
-  QCOMPARE( QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "gdal" ), parts ), QStringLiteral( "/home/user/test.gpkg|layername" ) );
+  QCOMPARE( QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "gdal" ), parts ), QStringLiteral( "GPKG:/home/user/test.gpkg:layername" ) );
 }
 
 void TestQgsGdalProvider::scaleDataType()

--- a/tests/src/python/test_provider_gdal.py
+++ b/tests/src/python/test_provider_gdal.py
@@ -81,6 +81,15 @@ class PyQgsGdalProvider(unittest.TestCase):
             block = raster_layer.dataProvider().block(1, extent, 3, 1)
             self.checkBlockContents(block, full_content[row * 3:row * 3 + 3])
 
+    def testDecodeEncodeUriOptions(self):
+        """Test decodeUri/encodeUri options support"""
+
+        uri = '/my/raster.pdf|option:DPI=300|option:GIVEME=TWO'
+        parts = QgsProviderRegistry.instance().decodeUri('gdal', uri)
+        self.assertEqual(parts, {'path': '/my/raster.pdf', 'layerName': None, 'openOptions': ['DPI=300', 'GIVEME=TWO']})
+        encodedUri = QgsProviderRegistry.instance().encodeUri('gdal', parts)
+        self.assertEqual(encodedUri, uri)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_provider_gdal.py
+++ b/tests/src/python/test_provider_gdal.py
@@ -81,6 +81,27 @@ class PyQgsGdalProvider(unittest.TestCase):
             block = raster_layer.dataProvider().block(1, extent, 3, 1)
             self.checkBlockContents(block, full_content[row * 3:row * 3 + 3])
 
+    def testDecodeEncodeUriGpkg(self):
+        """Test decodeUri/encodeUri geopackage support"""
+
+        uri = '/my/raster.gpkg'
+        parts = QgsProviderRegistry.instance().decodeUri('gdal', uri)
+        self.assertEqual(parts, {'path': '/my/raster.gpkg', 'layerName': None})
+        encodedUri = QgsProviderRegistry.instance().encodeUri('gdal', parts)
+        self.assertEqual(encodedUri, uri)
+
+        uri = 'GPKG:/my/raster.gpkg'
+        parts = QgsProviderRegistry.instance().decodeUri('gdal', uri)
+        self.assertEqual(parts, {'path': '/my/raster.gpkg', 'layerName': None})
+        encodedUri = QgsProviderRegistry.instance().encodeUri('gdal', parts)
+        self.assertEqual(encodedUri, '/my/raster.gpkg')
+
+        uri = 'GPKG:/my/raster.gpkg:mylayer'
+        parts = QgsProviderRegistry.instance().decodeUri('gdal', uri)
+        self.assertEqual(parts, {'path': '/my/raster.gpkg', 'layerName': 'mylayer'})
+        encodedUri = QgsProviderRegistry.instance().encodeUri('gdal', parts)
+        self.assertEqual(encodedUri, uri)
+
     def testDecodeEncodeUriOptions(self):
         """Test decodeUri/encodeUri options support"""
 


### PR DESCRIPTION
This PR adds open options support to the gdal provider. While it might look like a lot of code, most of it is actually copy / pasted from @rouault 's implementation for the ogr provider which has been in QGIS since 3.16.

The primary motivation here is to fix a situation with GeoPDFs whereas those would open at very bad resolution within QGIS even though the GeoPDF itself had been exported using a DPI of 300. There's been related issues filed on this both in QGIS (https://github.com/qgis/QGIS/issues/33465) and GDAL (https://github.com/OSGeo/gdal/pull/2961). 

Here's a bad resolution vs. fixed resolution comparison for GeoPDFs:

https://user-images.githubusercontent.com/1728657/106376211-a56ca500-63c5-11eb-834f-a1a9ce1f257b.mp4

 Yep, that bad.

UI wise, this PR re-implements what was in the OGR source select. It looks like this:
![image](https://user-images.githubusercontent.com/1728657/106376220-bddcbf80-63c5-11eb-8df2-178b41de2465.png)

Acknowledging that while I see this as a significant fix, it definitively encroaches into feature territory. As such, I would like to request a freeze exemption on the basis of the code fixing a bad situation as well as it having bee tested via the ogr provider for a while now.