### PR TITLE
Expose additional GDAL supported resampling methods as options for "early" raster resampling

### DIFF
--- a/python/core/auto_additions/qgsrasterdataprovider.py
+++ b/python/core/auto_additions/qgsrasterdataprovider.py
@@ -1,7 +1,12 @@
 # The following has been generated automatically from src/core/raster/qgsrasterdataprovider.h
 # monkey patching scoped based enum
-QgsRasterDataProvider.ResamplingMethod.Nearest.__doc__ = "Nearest-neighbour resamplikng"
-QgsRasterDataProvider.ResamplingMethod.Bilinear.__doc__ = "Bilinear resamplikng"
-QgsRasterDataProvider.ResamplingMethod.Cubic.__doc__ = "Bicubic resamplikng"
-QgsRasterDataProvider.ResamplingMethod.__doc__ = 'Resampling method for provider-level resampling.\n\n.. versionadded:: 3.16\n\n' + '* ``Nearest``: ' + QgsRasterDataProvider.ResamplingMethod.Nearest.__doc__ + '\n' + '* ``Bilinear``: ' + QgsRasterDataProvider.ResamplingMethod.Bilinear.__doc__ + '\n' + '* ``Cubic``: ' + QgsRasterDataProvider.ResamplingMethod.Cubic.__doc__
+QgsRasterDataProvider.ResamplingMethod.Nearest.__doc__ = "Nearest-neighbour resampling"
+QgsRasterDataProvider.ResamplingMethod.Bilinear.__doc__ = "Bilinear (2x2 kernel) resampling"
+QgsRasterDataProvider.ResamplingMethod.Cubic.__doc__ = "Cubic Convolution Approximation (4x4 kernel) resampling"
+QgsRasterDataProvider.ResamplingMethod.CubicSpline.__doc__ = "Cubic B-Spline Approximation (4x4 kernel)"
+QgsRasterDataProvider.ResamplingMethod.Lanczos.__doc__ = "Lanczos windowed sinc interpolation (6x6 kernel)"
+QgsRasterDataProvider.ResamplingMethod.Average.__doc__ = "Average resampling"
+QgsRasterDataProvider.ResamplingMethod.Mode.__doc__ = "Mode (selects the value which appears most often of all the sampled points)"
+QgsRasterDataProvider.ResamplingMethod.Gauss.__doc__ = "Gauss blurring"
+QgsRasterDataProvider.ResamplingMethod.__doc__ = 'Resampling method for provider-level resampling.\n\n.. versionadded:: 3.16\n\n' + '* ``Nearest``: ' + QgsRasterDataProvider.ResamplingMethod.Nearest.__doc__ + '\n' + '* ``Bilinear``: ' + QgsRasterDataProvider.ResamplingMethod.Bilinear.__doc__ + '\n' + '* ``Cubic``: ' + QgsRasterDataProvider.ResamplingMethod.Cubic.__doc__ + '\n' + '* ``CubicSpline``: ' + QgsRasterDataProvider.ResamplingMethod.CubicSpline.__doc__ + '\n' + '* ``Lanczos``: ' + QgsRasterDataProvider.ResamplingMethod.Lanczos.__doc__ + '\n' + '* ``Average``: ' + QgsRasterDataProvider.ResamplingMethod.Average.__doc__ + '\n' + '* ``Mode``: ' + QgsRasterDataProvider.ResamplingMethod.Mode.__doc__ + '\n' + '* ``Gauss``: ' + QgsRasterDataProvider.ResamplingMethod.Gauss.__doc__
 # --

--- a/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -559,6 +559,11 @@ Returns whether provider-level resampling is enabled.
       Nearest,
       Bilinear,
       Cubic,
+      CubicSpline,
+      Lanczos,
+      Average,
+      Mode,
+      Gauss
     };
 
     virtual bool setZoomedInResamplingMethod( ResamplingMethod method );

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -802,6 +802,26 @@ static GDALRIOResampleAlg getGDALResamplingAlg( QgsGdalProvider::ResamplingMetho
     case QgsGdalProvider::ResamplingMethod::Cubic:
       eResampleAlg = GRIORA_Cubic;
       break;
+
+    case QgsRasterDataProvider::ResamplingMethod::CubicSpline:
+      eResampleAlg = GRIORA_CubicSpline;
+      break;
+
+    case QgsRasterDataProvider::ResamplingMethod::Lanczos:
+      eResampleAlg = GRIORA_Lanczos;
+      break;
+
+    case QgsRasterDataProvider::ResamplingMethod::Average:
+      eResampleAlg = GRIORA_Average;
+      break;
+
+    case QgsRasterDataProvider::ResamplingMethod::Mode:
+      eResampleAlg = GRIORA_Mode;
+      break;
+
+    case QgsRasterDataProvider::ResamplingMethod::Gauss:
+      eResampleAlg = GRIORA_Gauss;
+      break;
   }
 
   return eResampleAlg;

--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -570,6 +570,26 @@ static QgsRasterDataProvider::ResamplingMethod resamplingMethodFromString( const
   {
     return QgsRasterDataProvider::ResamplingMethod::Cubic;
   }
+  else if ( str == QLatin1String( "cubicSpline" ) )
+  {
+    return QgsRasterDataProvider::ResamplingMethod::CubicSpline;
+  }
+  else if ( str == QLatin1String( "lanczos" ) )
+  {
+    return QgsRasterDataProvider::ResamplingMethod::Lanczos;
+  }
+  else if ( str == QLatin1String( "average" ) )
+  {
+    return QgsRasterDataProvider::ResamplingMethod::Average;
+  }
+  else if ( str == QLatin1String( "mode" ) )
+  {
+    return QgsRasterDataProvider::ResamplingMethod::Mode;
+  }
+  else if ( str == QLatin1String( "gauss" ) )
+  {
+    return QgsRasterDataProvider::ResamplingMethod::Gauss;
+  }
   return  QgsRasterDataProvider::ResamplingMethod::Nearest;
 }
 
@@ -594,9 +614,22 @@ static QString resamplingMethodToString( QgsRasterDataProvider::ResamplingMethod
 {
   switch ( method )
   {
-    case QgsRasterDataProvider::ResamplingMethod::Nearest : return QStringLiteral( "nearestNeighbour" );
-    case QgsRasterDataProvider::ResamplingMethod::Bilinear : return QStringLiteral( "bilinear" );
-    case QgsRasterDataProvider::ResamplingMethod::Cubic : return QStringLiteral( "cubic" );
+    case QgsRasterDataProvider::ResamplingMethod::Nearest:
+      return QStringLiteral( "nearestNeighbour" );
+    case QgsRasterDataProvider::ResamplingMethod::Bilinear:
+      return QStringLiteral( "bilinear" );
+    case QgsRasterDataProvider::ResamplingMethod::Cubic:
+      return QStringLiteral( "cubic" );
+    case QgsRasterDataProvider::ResamplingMethod::CubicSpline:
+      return QStringLiteral( "cubicSpline" );
+    case QgsRasterDataProvider::ResamplingMethod::Lanczos:
+      return QStringLiteral( "lanczos" );
+    case QgsRasterDataProvider::ResamplingMethod::Average:
+      return QStringLiteral( "average" );
+    case QgsRasterDataProvider::ResamplingMethod::Mode:
+      return QStringLiteral( "mode" );
+    case QgsRasterDataProvider::ResamplingMethod::Gauss:
+      return QStringLiteral( "gauss" );
   }
   // should not happen
   return QStringLiteral( "nearestNeighbour" );

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -607,9 +607,14 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
      */
     enum class ResamplingMethod
     {
-      Nearest,      //!< Nearest-neighbour resamplikng
-      Bilinear,     //!< Bilinear resamplikng
-      Cubic,     //!< Bicubic resamplikng
+      Nearest, //!< Nearest-neighbour resampling
+      Bilinear, //!< Bilinear (2x2 kernel) resampling
+      Cubic,//!< Cubic Convolution Approximation (4x4 kernel) resampling
+      CubicSpline, //!< Cubic B-Spline Approximation (4x4 kernel)
+      Lanczos, //!< Lanczos windowed sinc interpolation (6x6 kernel)
+      Average, //!< Average resampling
+      Mode, //!< Mode (selects the value which appears most often of all the sampled points)
+      Gauss //!< Gauss blurring
     };
 
     /**

--- a/src/gui/raster/qgsresamplingutils.h
+++ b/src/gui/raster/qgsresamplingutils.h
@@ -18,6 +18,8 @@
 #ifndef QGSRESAMPLINGUTILS_H
 #define QGSRESAMPLINGUTILS_H
 
+#include "qgis_gui.h"
+#include <QObject>
 
 class QgsRasterLayer;
 class QComboBox;
@@ -32,8 +34,10 @@ class QCheckBox;
  * QgsRenderedRasterPropertiesWidget to deal with widgets related to
  * resampling settings.
  */
-class QgsResamplingUtils
+class GUI_EXPORT QgsResamplingUtils : public QObject
 {
+    Q_OBJECT
+
     QgsRasterLayer *mRasterLayer = nullptr;
     QComboBox *mZoomedInResamplingComboBox = nullptr;
     QComboBox *mZoomedOutResamplingComboBox = nullptr;
@@ -59,6 +63,12 @@ class QgsResamplingUtils
 
     //! Synchronize QgsRasterLayer state from widgets
     void refreshLayerFromWidgets();
+
+  private:
+
+    void addExtraEarlyResamplingMethodsToCombos();
+    void removeExtraEarlyResamplingMethodsFromCombos();
+
 };
 
 ///@endcond PRIVATE


### PR DESCRIPTION
Notably, this adds the "Average" resampling as an option for
early resampling methods. (A nice side effect is that we also
get mode, cubic spline, Lanczos, ... for free!)

Fixes #40746
