### PR TITLE
Enable actions Zoom/Pan to Selection and Zoom to Layers. Fixes #40647

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -14628,13 +14628,8 @@ bool QgisApp::selectedLayersHaveSelection()
   // If no selected layers, use active layer
   if ( layers.size() == 0 )
   {
-    QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( activeLayer() );
-
-    if ( layer && layer->selectedFeatureCount() == 0 )
-      return false;
-
-    if ( layer && layer->selectedFeatureCount() > 0 )
-      return true;
+    if ( QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( activeLayer() ) )
+      return layer->selectedFeatureCount() > 0;
   }
 
   for ( QgsMapLayer *mapLayer : layers )
@@ -14671,9 +14666,12 @@ bool QgisApp::selectedLayersHaveSpatial()
 
 void QgisApp::activateDeactivateMultipleLayersRelatedActions()
 {
-  mActionZoomToLayers->setEnabled( selectedLayersHaveSpatial() );
-  mActionZoomToSelected->setEnabled( selectedLayersHaveSelection() );
-  mActionPanToSelected->setEnabled( selectedLayersHaveSelection() );
+  const bool hasSpatial = selectedLayersHaveSpatial();
+  const bool hasSelection = selectedLayersHaveSelection();
+
+  mActionZoomToLayers->setEnabled( hasSpatial );
+  mActionZoomToSelected->setEnabled( hasSelection );
+  mActionPanToSelected->setEnabled( hasSpatial );
 }
 
 void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1727,6 +1727,15 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Update the label toolbar buttons
     void updateLabelToolButtons();
 
+    //! Returns true if at least one selected layer in layer panel has a selection (returns false if none).
+    bool selectedLayersHaveSelection();
+
+    //! Returns true if at least one selected layer in layer panel is spatial (returns false if none).
+    bool selectedLayersHaveSpatial();
+
+    //! Activates or deactivates actions depending on the selected layers in the layer panel.
+    void activateDeactivateMultipleLayersRelatedActions();
+
     /**
      * Activates or deactivates actions depending on the current maplayer type.
      * Is called from the legend when the current legend item has changed.


### PR DESCRIPTION
## Description

Enable or disable `mActionZoomToLayers`, `mActionZoomToSelected` and `mActionPanToSelected` actions according to the selected layers in the layer panel. It fixes the issue and represents better the new zooming and panning behavior using multiple layers.

The function `activateDeactivateMultipleLayersRelatedActions()` has been created to enable/disable the actions and is fired  
when changing the selection in the layer panel or when selected/deselecting features in any map layers.

`selectedLayersHaveSpatial()` and `selectedLayersHaveSelection()` functions have been created to check if any of the selected layers in the layer panel (or active layer if no selected layer) is spatial or has a selection.

Fixes https://github.com/qgis/QGIS/issues/40647

![Peek 2021-01-31 18-43](https://user-images.githubusercontent.com/59714546/106401849-85080f00-63f4-11eb-91c7-7b478ef87525.gif)

