### PR TITLE
Fix the Profile From Lines SAGA tool

### DIFF
--- a/python/plugins/processing/algs/saga/description/ProfilesfromLines.txt
+++ b/python/plugins/processing/algs/saga/description/ProfilesfromLines.txt
@@ -4,6 +4,4 @@ QgsProcessingParameterRasterLayer|DEM|DEM|None|False
 QgsProcessingParameterMultipleLayers|VALUES|Values|3|None|True
 QgsProcessingParameterFeatureSource|LINES|Lines|1|None|False
 QgsProcessingParameterField|NAME|Name|None|LINES|-1|False|False
-QgsProcessingParameterBoolean|SPLIT         |Each Line as new Profile|True
 QgsProcessingParameterVectorDestination|PROFILE|Profiles
-QgsProcessingParameterVectorDestination|PROFILES|Profiles


### PR DESCRIPTION
Fixes https://github.com/qgis/QGIS/issues/29112

The description file was wrong because it had incompatible parameters mixed together.