### PR TITLE
mActionZoomToLayers does something using selected or active layer

### DIFF
--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -304,8 +304,6 @@ void QgsLayerTreeViewDefaultActions::zoomToLayer( QgsMapCanvas *canvas )
 void QgsLayerTreeViewDefaultActions::zoomToLayers( QgsMapCanvas *canvas )
 {
   const QList<QgsMapLayer *> layers = mView->selectedLayers();
-//  if ( layers.isEmpty() )
-//    return;
 
   zoomToLayers( canvas, layers );
 }
@@ -375,7 +373,7 @@ void QgsLayerTreeViewDefaultActions::zoomToLayers( QgsMapCanvas *canvas, const Q
   QgsRectangle extent;
   extent.setMinimal();
 
-  if ( layers.size() >= 1 )
+  if ( !layers.empty() )
   {
     for ( int i = 0; i < layers.size(); ++i )
     {
@@ -406,7 +404,7 @@ void QgsLayerTreeViewDefaultActions::zoomToLayers( QgsMapCanvas *canvas, const Q
   }
 
   // If no layer is selected, use current layer
-  else
+  else if ( mView->currentLayer() )
   {
     QgsRectangle layerExtent = mView->currentLayer()->extent();
     layerExtent = canvas->mapSettings().layerExtentToOutputExtent( mView->currentLayer(), layerExtent );


### PR DESCRIPTION
mActionZoomToLayers now does something using the current layer's extent if no layer is selected in the layer panel.

![Peek 2021-01-31 21-30](https://user-images.githubusercontent.com/59714546/106408042-8b55b580-640b-11eb-91a2-a7bfd3357b82.gif)


Fixes #41288