### PR TITLE
[Quick] Add "Reuse last value option"

### DIFF
--- a/src/quickgui/attributes/qgsquickattributeformmodel.cpp
+++ b/src/quickgui/attributes/qgsquickattributeformmodel.cpp
@@ -77,6 +77,11 @@ void QgsQuickAttributeFormModel::forceClean()
   mSourceModel->forceClean();
 }
 
+void QgsQuickAttributeFormModel::setRememberValuesAllowed( bool rememberValuesAllowed )
+{
+  mSourceModel->setRememberValuesAllowed( rememberValuesAllowed );
+}
+
 bool QgsQuickAttributeFormModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
 {
   return mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), CurrentlyVisible ).toBool();

--- a/src/quickgui/attributes/qgsquickattributeformmodel.h
+++ b/src/quickgui/attributes/qgsquickattributeformmodel.h
@@ -51,8 +51,12 @@ class QUICK_EXPORT QgsQuickAttributeFormModel : public QSortFilterProxyModel
 
     //! Returns TRUE if all hard constraints defined on fields are satisfied with the current attribute values
     Q_PROPERTY( bool constraintsHardValid READ constraintsHardValid NOTIFY constraintsHardValidChanged )
+
     //! Returns TRUE if all soft constraints defined on fields are satisfied with the current attribute values
     Q_PROPERTY( bool constraintsSoftValid READ constraintsSoftValid NOTIFY constraintsSoftValidChanged )
+
+    //! Returns TRUE if remembering values is allowed
+    Q_PROPERTY( bool rememberValuesAllowed WRITE setRememberValuesAllowed )
 
   public:
 
@@ -110,6 +114,10 @@ class QUICK_EXPORT QgsQuickAttributeFormModel : public QSortFilterProxyModel
 
     //! Resets the model
     Q_INVOKABLE void forceClean();
+
+  public slots:
+    //! Allows or forbids attribute model to reuse last entered values
+    void setRememberValuesAllowed( bool rememberValuesAllowed );
 
   signals:
     //! \copydoc QgsQuickAttributeFormModel::attributeModel

--- a/src/quickgui/attributes/qgsquickattributeformmodelbase.cpp
+++ b/src/quickgui/attributes/qgsquickattributeformmodelbase.cpp
@@ -252,6 +252,10 @@ void QgsQuickAttributeFormModelBase::flatten( QgsAttributeEditorContainer *conta
 
         QgsField field = mLayer->fields().at( fieldIndex );
 
+        Qt::CheckState rememberFlag = Qt::Unchecked;
+        if ( mAttributeModel->rememberValuesAllowed() && mAttributeModel->isFieldRemembered( fieldIndex ) )
+          rememberFlag = Qt::Checked;
+
         QStandardItem *item = new QStandardItem();
         item->setData( mLayer->attributeDisplayName( fieldIndex ), QgsQuickAttributeFormModel::Name );
         item->setData( mAttributeModel->featureLayerPair().feature().attribute( fieldIndex ), QgsQuickAttributeFormModel::AttributeValue );
@@ -259,7 +263,7 @@ void QgsQuickAttributeFormModelBase::flatten( QgsAttributeEditorContainer *conta
         QgsEditorWidgetSetup setup = mLayer->editorWidgetSetup( fieldIndex );
         item->setData( setup.type(), QgsQuickAttributeFormModel::EditorWidget );
         item->setData( setup.config(), QgsQuickAttributeFormModel::EditorWidgetConfig );
-        item->setData( mAttributeModel->rememberedAttributes().at( fieldIndex ) ? Qt::Checked : Qt::Unchecked, QgsQuickAttributeFormModel::RememberValue );
+        item->setData( rememberFlag, QgsQuickAttributeFormModel::RememberValue );
         item->setData( mLayer->fields().at( fieldIndex ), QgsQuickAttributeFormModel::Field );
         item->setData( QStringLiteral( "field" ), QgsQuickAttributeFormModel::ElementType );
         item->setData( fieldIndex, QgsQuickAttributeFormModel::FieldIndex );
@@ -426,6 +430,11 @@ void QgsQuickAttributeFormModelBase::forceClean()
   mExpressionContext = QgsExpressionContext();
   mConstraintsHardValid = false;
   mConstraintsSoftValid = false;
+}
+
+void QgsQuickAttributeFormModelBase::setRememberValuesAllowed( bool rememberValuesAllowed )
+{
+  mAttributeModel->setRememberValuesAllowed( rememberValuesAllowed );
 }
 
 bool QgsQuickAttributeFormModelBase::hasTabs() const

--- a/src/quickgui/attributes/qgsquickattributeformmodelbase.h
+++ b/src/quickgui/attributes/qgsquickattributeformmodelbase.h
@@ -108,6 +108,9 @@ class QgsQuickAttributeFormModelBase : public QStandardItemModel
     //! Resets the model
     Q_INVOKABLE void forceClean();
 
+    //! Allows or forbids attribute model to reuse last entered values
+    void setRememberValuesAllowed( bool rememberValuesAllowed );
+
   signals:
     //! \copydoc QgsQuickAttributeFormModelBase::attributeModel
     void attributeModelChanged();

--- a/src/quickgui/attributes/qgsquickattributemodel.h
+++ b/src/quickgui/attributes/qgsquickattributemodel.h
@@ -33,10 +33,10 @@
  * related to layer and feature pair.
  *
  * On top of the QgsFeature attributes, support for "remember"
- * attribute is added. Remember attribute is used for
- * quick addition of the multiple features to the same layer.
- * A new feature can use "remembered" attribute values from
- * the last feature added.
+ * values is added. When model is allowed to remember values, it reuses
+ * values for last created features. However, this only work for attributes
+ * that passes filter (\see RememberedValues struct). This feature is used for quick addition
+ * of multiple features to the same layer.
  *
  *
  * \note QML Type: AttributeModel
@@ -65,6 +65,13 @@ class QUICK_EXPORT QgsQuickAttributeModel : public QAbstractListModel
       AttributeValue,                    //!< Value of the feature's attribute
       Field,                             //!< Field definition (QgsField)
       RememberAttribute                  //!< Remember attribute value for next feature
+    };
+
+    //! Remembered values struct contains last created feature instance and a boolean vector masking attributes that should be remembered
+    struct RememberedValues
+    {
+      QgsFeature feature;
+      QVector<bool> attributeFilter;
     };
 
     //! Creates a new feature attribute model
@@ -115,8 +122,8 @@ class QUICK_EXPORT QgsQuickAttributeModel : public QAbstractListModel
     //! Resets remembered attributes
     Q_INVOKABLE virtual void resetAttributes();
 
-    //! Gets remembered attributes
-    QVector<bool> rememberedAttributes() const;
+    //! Gives information whether field with given index is remembered or not
+    bool isFieldRemembered( const int fieldIndex ) const;
 
     //! Gets current featureLayerPair
     QgsQuickFeatureLayerPair featureLayerPair() const;
@@ -127,7 +134,19 @@ class QUICK_EXPORT QgsQuickAttributeModel : public QAbstractListModel
     //! Resets the model
     Q_INVOKABLE void forceClean();
 
+    //! Allows or forbids model to reuse last entered values
+    void setRememberValuesAllowed( bool allowed );
+
+    //! Returns whether model is remembering last entered values
+    bool rememberValuesAllowed() const;
+
   public slots:
+
+    //! Handles feature creation
+    void onFeatureCreated( const QgsFeature &feature );
+
+    //! Handles changing allowance of reusing last entered values
+    void onRememberValuesAllowChanged();
 
   signals:
     //! Feature or layer changed in feature layer pair
@@ -139,6 +158,12 @@ class QUICK_EXPORT QgsQuickAttributeModel : public QAbstractListModel
     //! Layer changed, feature is the same
     void layerChanged();
 
+    //! Feature has been created
+    void featureCreated( const QgsFeature &feature );
+
+    //! Emitted when user allows reusing last entered values
+    void rememberValuesAllowChanged();
+
   protected:
     //! Commits model changes
     bool commit();
@@ -146,10 +171,18 @@ class QUICK_EXPORT QgsQuickAttributeModel : public QAbstractListModel
     bool startEditing();
 
     QgsQuickFeatureLayerPair mFeatureLayerPair;
-    QVector<bool> mRememberedAttributes;
+
   private:
     void setFeature( const QgsFeature &feature );
     void setVectorLayer( QgsVectorLayer *layer );
+
+    //! Fills remembered attributes from last created feature (mRememberedValues) to current feature (mFeatureLayerPair)
+    void prefillRememberedValues();
+
+    //! Remembered last created feature for each layer (key)
+    QHash<QString, RememberedValues> mRememberedValues;
+
+    bool mRememberValuesAllowed;
 };
 
 #endif // QGSQUICKATTRIBUTEMODEL_H

--- a/src/quickgui/plugin/CMakeLists.txt
+++ b/src/quickgui/plugin/CMakeLists.txt
@@ -11,6 +11,7 @@ set(QGIS_QUICK_PLUGIN_SRC
 
 set(QGIS_QUICK_PLUGIN_RESOURCES
   components/qgsquickicontextitem.qml
+  components/qgsquickcheckboxcomponent.qml
   editor/qgsquickeditorwidgetcombobox.qml
   editor/qgsquickcheckbox.qml
   editor/qgsquickdatetime.qml

--- a/src/quickgui/plugin/components/qgsquickcheckboxcomponent.qml
+++ b/src/quickgui/plugin/components/qgsquickcheckboxcomponent.qml
@@ -1,0 +1,89 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+import QtQuick 2.8
+import QtQuick.Templates 2.1 as T
+
+T.CheckBox {
+    id: control
+
+    signal checkboxClicked( var buttonState )
+
+    property var spaceWidth: height / 4.0
+    property var baseSize: height / 5.5
+    property var baseColor: "black"
+
+    implicitHeight: indicator.implicitHeight + topPadding + bottomPadding
+    implicitWidth: indicator.implicitWidth + leftPadding + rightPadding
+
+    leftPadding: spaceWidth
+
+    onClicked: control.checkboxClicked( control.checkState )
+
+    indicator: Rectangle {
+        id: checkboxHandle
+        implicitWidth: baseSize * 2.6
+        implicitHeight: baseSize * 2.6
+        x: control.leftPadding
+        anchors.verticalCenter: parent.verticalCenter
+        radius: 2
+        border.color: baseColor
+
+        Rectangle {
+            id: rectangle
+            width: baseSize * 1.4
+            height: baseSize * 1.4
+            x: baseSize * 0.6
+            y: baseSize * 0.6
+            radius: baseSize * 0.4
+            visible: false
+            color: baseColor
+        }
+
+        states: [
+            State {
+                name: "unchecked"
+                when: !control.checked && !control.down
+            },
+            State {
+                name: "checked"
+                when: control.checked && !control.down
+
+                PropertyChanges {
+                    target: rectangle
+                    visible: true
+                }
+            },
+            State {
+                name: "unchecked_down"
+                when: !control.checked && control.down
+
+                PropertyChanges {
+                    target: rectangle
+                    color: baseColor
+                }
+
+                PropertyChanges {
+                    target: checkboxHandle
+                    border.color: baseColor
+                }
+            },
+            State {
+                name: "checked_down"
+                extend: "unchecked_down"
+                when: control.checked && control.down
+
+                PropertyChanges {
+                    target: rectangle
+                    visible: true
+                }
+            }
+        ]
+    }
+}

--- a/src/quickgui/plugin/qgsquickfeatureform.qml
+++ b/src/quickgui/plugin/qgsquickfeatureform.qml
@@ -194,6 +194,11 @@ Item {
   }
 
   /**
+    * Forward change about remembering values to model
+    */
+  onAllowRememberAttributeChanged: form.model.rememberValuesAllowed = allowRememberAttribute
+
+  /**
    * This is a relay to forward private signals to internal components.
    */
   QtObject {
@@ -415,7 +420,7 @@ Item {
       Item {
         id: placeholder
         height: childrenRect.height
-        anchors { left: parent.left; right: rememberCheckbox.left; top: constraintDescriptionLabel.bottom }
+        anchors { left: parent.left; right: rememberCheckboxContainer.left; top: constraintDescriptionLabel.bottom }
 
         Loader {
           id: attributeEditorLoader
@@ -488,17 +493,35 @@ Item {
         }
       }
 
-      CheckBox {
-        id: rememberCheckbox
-        checked: RememberValue ? true : false
-
+      Item {
+        id: rememberCheckboxContainer
         visible: form.allowRememberAttribute && form.state === "Add" && EditorWidget !== "Hidden"
-        width: visible ? undefined : 0
 
-        anchors { right: parent.right; top: fieldLabel.bottom }
+        implicitWidth: visible ? 40 * QgsQuick.Utils.dp : 0
+        implicitHeight: placeholder.height
 
-        onCheckedChanged: {
-          RememberValue = checked
+        anchors {
+          top: constraintDescriptionLabel.bottom
+          right: parent.right
+        }
+
+        QgsQuick.CheckboxComponent {
+          id: rememberCheckbox
+          visible: rememberCheckboxContainer.visible
+          baseColor: form.style.checkboxComponent.baseColor
+
+          implicitWidth: 40 * QgsQuick.Utils.dp
+          implicitHeight: width
+          x: -5 // hack to get over placeholder spacing
+          y: rememberCheckboxContainer.height/2 - rememberCheckbox.height/2
+
+          onCheckboxClicked: RememberValue = buttonState
+          checked: RememberValue ? true : false
+        }
+
+        MouseArea {
+          anchors.fill: parent
+          onClicked: rememberCheckbox.checkboxClicked( !rememberCheckbox.checkState )
         }
       }
     }

--- a/src/quickgui/plugin/qgsquickfeatureformstyling.qml
+++ b/src/quickgui/plugin/qgsquickfeatureformstyling.qml
@@ -83,4 +83,7 @@ QtObject {
     property var back: QgsQuick.Utils.getThemeIcon("ic_back")
   }
 
+  property QtObject checkboxComponent: QtObject {
+    property color baseColor: "black"
+  }
 }

--- a/src/quickgui/plugin/qmldir
+++ b/src/quickgui/plugin/qmldir
@@ -16,6 +16,7 @@ plugin qgis_quick_plugin
 # suppose to be used only internally in QgsQuick plugin
 EditorWidgetComboBox  0.1 qgsquickeditorwidgetcombobox.qml
 IconTextItem 0.1 qgsquickicontextitem.qml
+CheckboxComponent 0.1 qgsquickcheckboxcomponent.qml
 
 MapCanvas 0.1 qgsquickmapcanvas.qml
 FeatureForm 0.1 qgsquickfeatureform.qml


### PR DESCRIPTION
## Reuse last value option

Added possibility to reuse last value option for `QgsQuickAttributeModel.cpp`. While creating features it is now possible to reuse last values across layers. 

This functionality needs to be allowed via `AttributeModel::setRememberValuesAllowed( true )`. Upon allowing, checkbox will be visible next to each field in feature form. When feature is created (commited), its copy is saved and desired attributes will have its values prefilled in next feature form. 

cc @wonder-sk 