### PR TITLE
QgsDataProvider::ReadFlags is not used in QgsGdalProvider

### DIFF
--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -2379,7 +2379,8 @@ bool QgsGdalProviderMetadata::uriIsBlocklisted( const QString &uri ) const
 
 QgsGdalProvider *QgsGdalProviderMetadata::createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags )
 {
-  return new QgsGdalProvider( uri, options, flags );
+  Q_UNUSED( flags );
+  return new QgsGdalProvider( uri, options );
 }
 
 /**


### PR DESCRIPTION
## Description

`QgsDataProvider::ReadFlags` is not used in `QgsGdalProvider`. In `QgsGdalProviderMetadata::createProvider`, the `readflags` has not to be passed to the `QgsGdalProvider` constructor. The third parameter in the `QgsGdalProvider` provider is a boolean to activte raster update. So if `readflags` is not empty, the update parameter becomes true and the `QgsGdalProvider` try to get update capabilities, if it has not update capabilities like for NETCDF file, the provider is invalid.

To fix #41209 just not used `readflags`