### PR TITLE
Fixed Skybox settings dialog individual walls labels

### DIFF
--- a/src/ui/3d/skyboxrenderingsettingswidget.ui
+++ b/src/ui/3d/skyboxrenderingsettingswidget.ui
@@ -52,7 +52,7 @@
      <item row="0" column="0">
       <widget class="QLabel" name="negXImageSourceLabel">
        <property name="text">
-        <string>Left (-X)</string>
+        <string>Right (-X)</string>
        </property>
       </widget>
      </item>
@@ -62,7 +62,7 @@
      <item row="1" column="0">
       <widget class="QLabel" name="negYImageSourceLabel">
        <property name="text">
-        <string>Down (-Y)</string>
+        <string>Back (-Y)</string>
        </property>
       </widget>
      </item>
@@ -72,7 +72,7 @@
      <item row="2" column="0">
       <widget class="QLabel" name="negZImageSourceLabel">
        <property name="text">
-        <string>Back (-Z)</string>
+        <string>Down (-Z)</string>
        </property>
       </widget>
      </item>
@@ -82,7 +82,7 @@
      <item row="3" column="0">
       <widget class="QLabel" name="posXImageSourceLabel">
        <property name="text">
-        <string>Right (+X)</string>
+        <string>Left (+X)</string>
        </property>
       </widget>
      </item>

--- a/src/ui/3d/skyboxrenderingsettingswidget.ui
+++ b/src/ui/3d/skyboxrenderingsettingswidget.ui
@@ -52,7 +52,7 @@
      <item row="0" column="0">
       <widget class="QLabel" name="negXImageSourceLabel">
        <property name="text">
-        <string>Right (-X)</string>
+        <string>Left (-X)</string>
        </property>
       </widget>
      </item>
@@ -82,7 +82,7 @@
      <item row="3" column="0">
       <widget class="QLabel" name="posXImageSourceLabel">
        <property name="text">
-        <string>Left (+X)</string>
+        <string>Right (+X)</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
## Description

The 3D View Skybox settings dialog for individual walls had mismatched labels for some walls. This PR fixes those labels. The walls are named as follows (as seen from inside of the box):

![obraz](https://user-images.githubusercontent.com/3106699/106582925-d32c2800-6544-11eb-85db-f9f2e7c1b979.png)
