### PR TITLE
Fix Topological editing when CRS are different

### DIFF
--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -98,7 +98,10 @@ void QgsMapToolAddFeature::digitized( const QgsFeature &f )
       {
         if ( sm.at( i ).layer() )
         {
-          sm.at( i ).layer()->addTopologicalPoints( f.geometry().vertexAt( i ) );
+          // transform geometry to vlayer crs and add topological point
+          QgsGeometry geom( f.geometry() );
+          geom.transform( QgsCoordinateTransform( vlayer->crs(), sm.at( i ).layer()->crs(), sm.at( i ).layer()->transformContext() ) );
+          sm.at( i ).layer()->addTopologicalPoints( geom.vertexAt( i ) );
         }
       }
       vlayer->addTopologicalPoints( f.geometry() );

--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -100,8 +100,17 @@ void QgsMapToolAddFeature::digitized( const QgsFeature &f )
         {
           // transform geometry to vlayer crs and add topological point
           QgsGeometry geom( f.geometry() );
-          geom.transform( QgsCoordinateTransform( vlayer->crs(), sm.at( i ).layer()->crs(), sm.at( i ).layer()->transformContext() ) );
-          sm.at( i ).layer()->addTopologicalPoints( geom.vertexAt( i ) );
+          try
+          {
+            geom.transform( QgsCoordinateTransform( vlayer->crs(), sm.at( i ).layer()->crs(), sm.at( i ).layer()->transformContext() ) );
+            sm.at( i ).layer()->addTopologicalPoints( geom.vertexAt( i ) );
+          }
+          catch ( QgsCsException &cse )
+          {
+            Q_UNUSED( cse )
+            QgsDebugMsg( QStringLiteral( "transformation to layer coordinate failed" ) );
+          }
+
         }
       }
       vlayer->addTopologicalPoints( f.geometry() );

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -462,8 +462,8 @@ int QgsMapToolCapture::fetchLayerPoint( const QgsPointLocator::Match &match, Qgs
 {
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mCanvas->currentLayer() );
   QgsVectorLayer *sourceLayer = match.layer();
-  if ( match.isValid() && ( match.hasVertex() || ( QgsProject::instance()->topologicalEditing() && ( match.hasEdge() || match.hasMiddleSegment() ) ) ) && sourceLayer &&
-       ( sourceLayer->crs() == vlayer->crs() ) )
+  if ( match.isValid() && ( match.hasVertex() || ( QgsProject::instance()->topologicalEditing() && ( match.hasEdge() || match.hasMiddleSegment() ) ) ) && sourceLayer )
+
   {
     QgsFeature f;
     QgsFeatureRequest request;
@@ -483,7 +483,34 @@ int QgsMapToolCapture::fetchLayerPoint( const QgsPointLocator::Match &match, Qgs
           return 2;
         QgsLineString line( geom.constGet()->vertexAt( vId ), geom.constGet()->vertexAt( vId2 ) );
 
-        layerPoint = QgsGeometryUtils::closestPoint( line,  QgsPoint( match.point() ) );
+        QgsPoint pt( match.point() );
+        // Transform point to sourceLayer crs, since vId and vId2 coordinates are in sourceLayer crs
+        if ( sourceLayer->crs() != QgsProject::instance()->crs() )
+        {
+          try
+          {
+            pt.transform( QgsCoordinateTransform( QgsProject::instance()->crs(), sourceLayer->crs(), sourceLayer->transformContext() ) );
+          }
+          catch ( QgsCsException &cse )
+          {
+            Q_UNUSED( cse )
+            QgsDebugMsg( QStringLiteral( "transformation to layer coordinate failed" ) );
+            return 2;
+          }
+        }
+        layerPoint = QgsGeometryUtils::closestPoint( line,  pt );
+        // (re)Transform layerPoint to vlayer crs
+        try
+        {
+          layerPoint.transform( QgsCoordinateTransform( sourceLayer->crs(), vlayer->crs(), vlayer->transformContext() ) );
+        }
+        catch ( QgsCsException &cse )
+        {
+          Q_UNUSED( cse )
+          QgsDebugMsg( QStringLiteral( "transformation to layer coordinate failed" ) );
+          return 2;
+        }
+
       }
       else
       {

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -73,6 +73,7 @@ class TestQgsMapToolAddFeatureLine : public QObject
     void testTopologicalEditingZ();
     void testCloseLine();
     void testSelfSnapping();
+    void testDifferentCrs();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -89,6 +90,8 @@ class TestQgsMapToolAddFeatureLine : public QObject
     QgsVectorLayer *mLayerLine2D = nullptr;
     QgsVectorLayer *mLayerCloseLine = nullptr;
     QgsVectorLayer *mLayerSelfSnapLine = nullptr;
+    QgsVectorLayer *mLayerCRS3946Line = nullptr;
+    QgsVectorLayer *mLayerCRS3945Line = nullptr;
     QgsFeatureId mFidLineF1 = 0;
     QgsFeatureId mFidCurvedF1 = 0;
 };
@@ -235,8 +238,19 @@ void TestQgsMapToolAddFeatureLine::initTestCase()
   QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mLayerSelfSnapLine );
   mLayerSelfSnapLine->startEditing();
 
+  // make layers with different CRS
+  mLayerCRS3946Line = new QgsVectorLayer( QStringLiteral( "LineString?crs=EPSG:3946" ), QStringLiteral( "layer line" ), QStringLiteral( "memory" ) );
+  QVERIFY( mLayerCRS3946Line ->isValid() );
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mLayerCRS3946Line );
+  mLayerCRS3946Line->startEditing();
+
+  mLayerCRS3945Line = new QgsVectorLayer( QStringLiteral( "LineString?crs=EPSG:3945" ), QStringLiteral( "layer line" ), QStringLiteral( "memory" ) );
+  QVERIFY( mLayerCRS3945Line ->isValid() );
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mLayerCRS3945Line );
+  mLayerCRS3945Line->startEditing();
+
   // add layers to canvas
-  mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerLine << mLayerLineCurved << mLayerLineCurvedOffset << mLayerLineZ << mLayerPointZM << mLayerTopoZ << mLayerLine2D << mLayerSelfSnapLine );
+  mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerLine << mLayerLineCurved << mLayerLineCurvedOffset << mLayerLineZ << mLayerPointZM << mLayerTopoZ << mLayerLine2D << mLayerSelfSnapLine << mLayerCRS3946Line << mLayerCRS3945Line );
   mCanvas->setSnappingUtils( new QgsMapCanvasSnappingUtils( mCanvas, this ) );
 
   // create the tool
@@ -784,6 +798,80 @@ void TestQgsMapToolAddFeatureLine::testSelfSnapping()
   QCOMPARE( mLayerSelfSnapLine->getFeature( newFid2 ).geometry(), QgsGeometry::fromWkt( targetWkt ) );
   mLayerSelfSnapLine->undoStack()->undo();
 
+}
+
+void TestQgsMapToolAddFeatureLine::testDifferentCrs()
+{
+
+  TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
+  QSet<QgsFeatureId> oldFids = utils.existingFeatureIds();
+  mCanvas->setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3946" ) ) );
+
+  // Prepare geometries
+  QgsPolylineXY line1;
+  line1 << QgsPointXY( 0, 0 ) << QgsPointXY( 0, 10 );
+  QgsFeature lineF1;
+  lineF1.setGeometry( QgsGeometry::fromPolylineXY( line1 ) );
+
+  mLayerCRS3946Line->startEditing();
+  mLayerCRS3946Line->addFeature( lineF1 );
+  QgsFeatureId mFidLine3946 = lineF1.id();
+  QCOMPARE( mLayerCRS3946Line->featureCount(), ( long )1 );
+  // just one added feature
+  QCOMPARE( mLayerCRS3946Line->undoStack()->index(), 1 );
+
+  // Draw the line to avoid some error with the projections
+  mLayerCRS3945Line->startEditing();
+  mCanvas->setCurrentLayer( mLayerCRS3945Line );
+  utils.mouseClick( 8, 2, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 8, 8, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 8, 8, Qt::RightButton );
+  QgsFeatureId mFidLine3945 = utils.newFeatureId( oldFids );
+  QCOMPARE( mLayerCRS3945Line->featureCount(), ( long )1 );
+  // just one added feature
+  QCOMPARE( mLayerCRS3945Line->undoStack()->index(), 1 );
+
+
+  mCanvas->setCurrentLayer( mLayerCRS3946Line );
+
+  QgsSnappingConfig cfg = mCanvas->snappingUtils()->config();
+  cfg.setEnabled( true );
+  cfg.setMode( QgsSnappingConfig::AllLayers );
+  cfg.setTypeFlag( QgsSnappingConfig::SegmentFlag );
+  cfg.setTolerance( 50 );
+  cfg.setUnits( QgsTolerance::Pixels );
+
+  bool topologicalEditing = cfg.project()->topologicalEditing();
+  cfg.project()->setTopologicalEditing( true );
+
+  mCanvas->snappingUtils()->setConfig( cfg );
+
+  utils.mouseClick( -2, 4, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 0, 4, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 2, 4, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 2, 4, Qt::RightButton );
+
+  QgsFeatureId newFid = utils.newFeatureId( oldFids );
+  QString newWkt = "LineString (-2 4, 0 4, 2 4)";
+  QString new3946Wkt = "LineString (0 0, 0 4, 0 10)";
+
+  QCOMPARE( mLayerCRS3946Line->getFeature( mFidLine3946 ).geometry().asWkt( 0 ), new3946Wkt ); // use wkt to avoid float rounding errors
+  mLayerCRS3946Line->undoStack()->undo();
+
+  // same test with a layer with a different CRS
+  mCanvas->setCurrentLayer( mLayerCRS3945Line );
+  utils.mouseClick( 0, 4, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 8, 4, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 8, 4, Qt::RightButton );
+
+  newFid = utils.newFeatureId( oldFids );
+  // (2 2, 8 2, 8 4, 8 8) transformed from 3946 to 3945
+  QString new3945Wkt = "LineString (17441.5859966475982219 -862119.21677098423242569, 17441.58100318093784153 -862117.23846332356333733, 17441.57101624645292759 -862113.28184797242283821)";
+  QCOMPARE( mLayerCRS3945Line->getFeature( mFidLine3945 ).geometry().asWkt( 2 ), QgsGeometry::fromWkt( new3945Wkt ).asWkt( 2 ) );
+  mLayerCRS3945Line->undoStack()->undo();
+
+  cfg.project()->setTopologicalEditing( topologicalEditing );
+  mCanvas->setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:27700" ) ) );
 }
 
 QGSTEST_MAIN( TestQgsMapToolAddFeatureLine )

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -851,8 +851,6 @@ void TestQgsMapToolAddFeatureLine::testDifferentCrs()
   utils.mouseClick( 2, 4, Qt::LeftButton, Qt::KeyboardModifiers(), true );
   utils.mouseClick( 2, 4, Qt::RightButton );
 
-  QgsFeatureId newFid = utils.newFeatureId( oldFids );
-  QString newWkt = "LineString (-2 4, 0 4, 2 4)";
   QString new3946Wkt = "LineString (0 0, 0 4, 0 10)";
 
   QCOMPARE( mLayerCRS3946Line->getFeature( mFidLine3946 ).geometry().asWkt( 0 ), new3946Wkt ); // use wkt to avoid float rounding errors
@@ -864,7 +862,6 @@ void TestQgsMapToolAddFeatureLine::testDifferentCrs()
   utils.mouseClick( 8, 4, Qt::LeftButton, Qt::KeyboardModifiers(), true );
   utils.mouseClick( 8, 4, Qt::RightButton );
 
-  newFid = utils.newFeatureId( oldFids );
   // (2 2, 8 2, 8 4, 8 8) transformed from 3946 to 3945
   QString new3945Wkt = "LineString (17441.5859966475982219 -862119.21677098423242569, 17441.58100318093784153 -862117.23846332356333733, 17441.57101624645292759 -862113.28184797242283821)";
   QCOMPARE( mLayerCRS3945Line->getFeature( mFidLine3945 ).geometry().asWkt( 2 ), QgsGeometry::fromWkt( new3945Wkt ).asWkt( 2 ) );


### PR DESCRIPTION
## Description

The addTopologicalPoints methods attempt to add points without checking the CRS -- which makes sense. So, Topology editing does not work when layers have different CRS.

There are several problems when we use on-the-fly projection, the first is that points are not added when a layer has a different CRS. fix 1

The second one is that when we want to snap to a segment of a layer with a different CRS, it will snap to a vertex (the calculation is done with different coordinates), this is the original request of #29648

## Fix 1. Add topological points on layer with a different CRS
before

![topo_snap_diff_crs_before mkv](https://user-images.githubusercontent.com/7521540/106516081-dbe61500-64d6-11eb-8adb-bf062917a760.gif)

after

![topo_snap_diff_crs_after mkv](https://user-images.githubusercontent.com/7521540/106516049-d12b8000-64d6-11eb-82bb-5e1ff2d34540.gif)

## Fix 2. Fix topological editing when CRS are different

before

![topo_snap_segment_diff_crs_before mkv](https://user-images.githubusercontent.com/7521540/106569861-63627100-6535-11eb-9823-1140f36149c6.gif)

after

![topo_snap_segment_diff_crs_after mkv](https://user-images.githubusercontent.com/7521540/106569753-3f069480-6535-11eb-896a-aabf3a79be45.gif)

TODO:

- ~~other tools~~ will be fixed in dedicated PR to avoid some confusion
- [X] fix other issue pointed by #29648
- [x] test