### PR TITLE
add QGIS_INSTALL_SYS_LIBS cmake option to control installation of MSVC libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -911,6 +911,8 @@ if (DISABLE_DEPRECATED)
   add_definitions(-DQGIS_DISABLE_DEPRECATED)
 endif()
 
+# whether to install required system libs in the output package
+set(QGIS_INSTALL_SYS_LIBS TRUE CACHE BOOL "If set to TRUE install all required system libs in the output package")
 
 #############################################################
 # Python build dependency
@@ -1073,7 +1075,10 @@ if (WITH_CORE)
   if(NOT DEFINED CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_NO_WARNINGS)
     set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_NO_WARNINGS ON)
   endif()
-  include(InstallRequiredSystemLibraries)
+
+  if(QGIS_INSTALL_SYS_LIBS)
+    include(InstallRequiredSystemLibraries)
+  endif()
 
   set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "QGIS")
   set(CPACK_PACKAGE_VENDOR "Open Source Geospatial Foundation")


### PR DESCRIPTION
## Description

Another [conda-forge](https://github.com/conda-forge/qgis-feedstock) derived patch. 

Currently the QGIS cmake includes [InstallRequiredSystemLibraries](https://cmake.org/cmake/help/latest/module/InstallRequiredSystemLibraries.html) which packages the MSVC runtime libraries on Windows.

Conda and other package managers already handle distributing the MSVC packages and other required system libs so it would be good to have a way of disabling this to prevent conflicts.

This PR adds a `QGIS_INSTALL_SYS_LIBS` cmake option which defaults to `TRUE` (the current behaviour) but can be set to `FALSE` by package managers to prevent system libs being installed.
