### PR TITLE
WIP: Qml widget resize

### DIFF
--- a/python/core/auto_generated/editform/qgsattributeeditorqmlelement.sip.in
+++ b/python/core/auto_generated/editform/qgsattributeeditorqmlelement.sip.in
@@ -43,6 +43,20 @@ The QML code that will be represented within this widget.
 Sets the QML code that will be represented within this widget to ``qmlCode``.
 %End
 
+    bool resize() const;
+%Docstring
+The resize gehaviout of the widget.
+
+.. versionadded:: 3.18
+%End
+
+    void setResize( const bool resize );
+%Docstring
+Sets the resize behavior of the widget.
+
+.. versionadded:: 3.18
+%End
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/editorwidgets/qgsqmlwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsqmlwidgetwrapper.sip.in
@@ -38,6 +38,11 @@ Create a qml widget wrapper
     virtual void initWidget( QWidget *editor );
 
 
+    void resizeWidget( bool mode );
+%Docstring
+Change widget resize behavior
+%End
+
     void reinitWidget();
 %Docstring
 Clears the content and makes new initialization
@@ -46,6 +51,11 @@ Clears the content and makes new initialization
     void setQmlCode( const QString &qmlCode );
 %Docstring
 writes the ``qmlCode`` into a temporary file
+%End
+
+    void setResizeFlag( const bool resize );
+%Docstring
+Sets the behavior when resizing the widget
 %End
 
   public slots:

--- a/src/core/editform/qgsattributeeditorqmlelement.cpp
+++ b/src/core/editform/qgsattributeeditorqmlelement.cpp
@@ -21,8 +21,19 @@ QgsAttributeEditorElement *QgsAttributeEditorQmlElement::clone( QgsAttributeEdit
 {
   QgsAttributeEditorQmlElement *element = new QgsAttributeEditorQmlElement( name(), parent );
   element->setQmlCode( mQmlCode );
+  element->setResize( mResize );
 
   return element;
+}
+
+bool QgsAttributeEditorQmlElement::resize() const
+{
+  return mResize;
+}
+
+void QgsAttributeEditorQmlElement::setResize( const bool resize )
+{
+  mResize = resize;
 }
 
 QString QgsAttributeEditorQmlElement::qmlCode() const
@@ -37,7 +48,8 @@ void QgsAttributeEditorQmlElement::setQmlCode( const QString &qmlCode )
 
 void QgsAttributeEditorQmlElement::saveConfiguration( QDomElement &elem, QDomDocument &doc ) const
 {
-  QDomText codeElem = doc.createTextNode( mQmlCode );
+  QDomText codeElem = doc.createTextNode( mQmlCode );  
+  elem.setAttribute( QStringLiteral( "resize" ), mResize ? 1 : 0 );
   elem.appendChild( codeElem );
 }
 
@@ -46,7 +58,13 @@ void QgsAttributeEditorQmlElement::loadConfiguration( const QDomElement &element
   Q_UNUSED( layerId )
   Q_UNUSED( context )
   Q_UNUSED( fields )
+  bool ok;
   setQmlCode( element.text() );
+  bool resizable = element.attribute( QStringLiteral( "resize" ) ).toInt( &ok );
+  if ( ok )
+    setResize( resizable );
+  else
+    setResize( false );
 }
 
 QString QgsAttributeEditorQmlElement::typeIdentifier() const

--- a/src/core/editform/qgsattributeeditorqmlelement.cpp
+++ b/src/core/editform/qgsattributeeditorqmlelement.cpp
@@ -48,7 +48,7 @@ void QgsAttributeEditorQmlElement::setQmlCode( const QString &qmlCode )
 
 void QgsAttributeEditorQmlElement::saveConfiguration( QDomElement &elem, QDomDocument &doc ) const
 {
-  QDomText codeElem = doc.createTextNode( mQmlCode );  
+  QDomText codeElem = doc.createTextNode( mQmlCode );
   elem.setAttribute( QStringLiteral( "resize" ), mResize ? 1 : 0 );
   elem.appendChild( codeElem );
 }

--- a/src/core/editform/qgsattributeeditorqmlelement.h
+++ b/src/core/editform/qgsattributeeditorqmlelement.h
@@ -53,11 +53,26 @@ class CORE_EXPORT QgsAttributeEditorQmlElement : public QgsAttributeEditorElemen
      */
     void setQmlCode( const QString &qmlCode );
 
+    /**
+     * The resize gehaviout of the widget.
+     *
+     * \since QGIS 3.18
+     */
+    bool resize() const;
+
+    /**
+     * Sets the resize gehaviout of the widget.
+     *
+     * \since QGIS 3.18
+     */
+    void setResize( const bool resize );
+
   private:
     void saveConfiguration( QDomElement &elem, QDomDocument &doc ) const override;
     void loadConfiguration( const QDomElement &element,  const QString &layerId, const QgsReadWriteContext &context, const QgsFields &fields ) override;
     QString typeIdentifier() const override;
     QString mQmlCode;
+    bool mResize;
 };
 
 #endif // QGSATTRIBUTEEDITORQMLELEMENT_H

--- a/src/core/editform/qgsattributeeditorqmlelement.h
+++ b/src/core/editform/qgsattributeeditorqmlelement.h
@@ -61,7 +61,7 @@ class CORE_EXPORT QgsAttributeEditorQmlElement : public QgsAttributeEditorElemen
     bool resize() const;
 
     /**
-     * Sets the resize gehaviout of the widget.
+     * Sets the resize behavior of the widget.
      *
      * \since QGIS 3.18
      */

--- a/src/gui/editorwidgets/qgsqmlwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsqmlwidgetwrapper.cpp
@@ -45,6 +45,8 @@ void QgsQmlWidgetWrapper::initWidget( QWidget *editor )
   if ( !mWidget )
     return;
 
+  if (mResizeFlag)
+    mWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
 
   if ( !mQmlFile.open() )
   {
@@ -57,6 +59,21 @@ void QgsQmlWidgetWrapper::initWidget( QWidget *editor )
   mQmlFile.close();
 }
 
+void QgsQmlWidgetWrapper::resizeWidget( bool mode )
+{
+  if ( !mWidget )
+    return;
+
+  if ( mode )
+    mWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
+  else
+    mWidget->setResizeMode(QQuickWidget::SizeViewToRootObject);
+}
+
+void QgsQmlWidgetWrapper::setResizeFlag(const bool resize)
+{
+  mResizeFlag = resize;
+}
 
 void QgsQmlWidgetWrapper::reinitWidget( )
 {

--- a/src/gui/editorwidgets/qgsqmlwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsqmlwidgetwrapper.cpp
@@ -45,8 +45,8 @@ void QgsQmlWidgetWrapper::initWidget( QWidget *editor )
   if ( !mWidget )
     return;
 
-  if (mResizeFlag)
-    mWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
+  if ( mResizeFlag )
+    mWidget->setResizeMode( QQuickWidget::SizeRootObjectToView );
 
   if ( !mQmlFile.open() )
   {
@@ -65,12 +65,12 @@ void QgsQmlWidgetWrapper::resizeWidget( bool mode )
     return;
 
   if ( mode )
-    mWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
+    mWidget->setResizeMode( QQuickWidget::SizeRootObjectToView );
   else
-    mWidget->setResizeMode(QQuickWidget::SizeViewToRootObject);
+    mWidget->setResizeMode( QQuickWidget::SizeViewToRootObject );
 }
 
-void QgsQmlWidgetWrapper::setResizeFlag(const bool resize)
+void QgsQmlWidgetWrapper::setResizeFlag( const bool resize )
 {
   mResizeFlag = resize;
 }

--- a/src/gui/editorwidgets/qgsqmlwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsqmlwidgetwrapper.h
@@ -47,7 +47,7 @@ class GUI_EXPORT QgsQmlWidgetWrapper : public QgsWidgetWrapper
 
     void initWidget( QWidget *editor ) override;
 
-    //! Change widget resize behaviour
+    //! Change widget resize behavior
     void resizeWidget( bool mode );
 
     //! Clears the content and makes new initialization
@@ -56,6 +56,7 @@ class GUI_EXPORT QgsQmlWidgetWrapper : public QgsWidgetWrapper
     //! writes the \a qmlCode into a temporary file
     void setQmlCode( const QString &qmlCode );
 
+    //! Sets the behavior when resizing the widget
     void setResizeFlag( const bool resize );
 
   public slots:

--- a/src/gui/editorwidgets/qgsqmlwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsqmlwidgetwrapper.h
@@ -47,11 +47,16 @@ class GUI_EXPORT QgsQmlWidgetWrapper : public QgsWidgetWrapper
 
     void initWidget( QWidget *editor ) override;
 
+    //! Change widget resize behaviour
+    void resizeWidget( bool mode );
+
     //! Clears the content and makes new initialization
     void reinitWidget();
 
     //! writes the \a qmlCode into a temporary file
     void setQmlCode( const QString &qmlCode );
+
+    void setResizeFlag( const bool resize );
 
   public slots:
     void setFeature( const QgsFeature &feature ) override;
@@ -62,6 +67,7 @@ class GUI_EXPORT QgsQmlWidgetWrapper : public QgsWidgetWrapper
 
   private:
     QTemporaryFile mQmlFile;
+    bool mResizeFlag = true;
     QQuickWidget *mWidget = nullptr;
     QgsFeature mFeature;
 };

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -50,8 +50,6 @@
 #include "qgstexteditwrapper.h"
 #include "qgsfieldmodel.h"
 
-#include "qgsmessagelog.h"
-
 #include <QDir>
 #include <QTextStream>
 #include <QFileInfo>

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -2131,9 +2131,6 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
       const QgsAttributeEditorQmlElement *elementDef = static_cast<const QgsAttributeEditorQmlElement *>( widgetDef );
 
       QgsQmlWidgetWrapper *qmlWrapper = new QgsQmlWidgetWrapper( mLayer, nullptr, this );
-      // does not work before: no resize
-      // qmlWrapper->resizeWidget( elementDef->resize() );
-      // QgsMessageLog::logMessage( QStringLiteral( "------jgr----:createWidgetFromDef: %1" ).arg( elementDef->resize() ) );
 
       qmlWrapper->setResizeFlag( elementDef->resize() );
       qmlWrapper->setQmlCode( elementDef->qmlCode() );
@@ -2143,14 +2140,16 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
 
       mWidgets.append( qmlWrapper );
 
-      newWidgetInfo.widget = qmlWrapper->widget();
+      // newWidgetInfo.widget = qmlWrapper->widget();
+      QgsScrollArea *scrollArea = new QgsScrollArea( parent );
+      scrollArea->setWidgetResizable( true );
+      scrollArea->setMinimumWidth( 400 );
+      scrollArea->setMinimumHeight( 400 );
+      scrollArea->setWidget( qmlWrapper->widget() );
+      newWidgetInfo.widget = scrollArea;
       newWidgetInfo.labelText = elementDef->name();
       newWidgetInfo.labelOnTop = true;
       newWidgetInfo.showLabel = widgetDef->showLabel();
-
-      // does nor work after: expression is invalid
-//      qmlWrapper->resizeWidget( elementDef->resize() );
-//      QgsMessageLog::logMessage( QStringLiteral( "------jgr----:createWidgetFromDef: %1" ).arg( elementDef->resize() ) );
 
       break;
     }

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -2138,12 +2138,12 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
 
       mWidgets.append( qmlWrapper );
 
-      // newWidgetInfo.widget = qmlWrapper->widget();
+      QSizePolicy sizePolicy( QSizePolicy::Preferred, QSizePolicy::Preferred );
       QgsScrollArea *scrollArea = new QgsScrollArea( parent );
       scrollArea->setWidgetResizable( true );
-      scrollArea->setMinimumWidth( 400 );
-      scrollArea->setMinimumHeight( 400 );
+      scrollArea->setSizePolicy( sizePolicy );
       scrollArea->setWidget( qmlWrapper->widget() );
+      // newWidgetInfo.widget = qmlWrapper->widget();
       newWidgetInfo.widget = scrollArea;
       newWidgetInfo.labelText = elementDef->name();
       newWidgetInfo.labelOnTop = true;

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -50,6 +50,8 @@
 #include "qgstexteditwrapper.h"
 #include "qgsfieldmodel.h"
 
+#include "qgsmessagelog.h"
+
 #include <QDir>
 #include <QTextStream>
 #include <QFileInfo>
@@ -2129,7 +2131,13 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
       const QgsAttributeEditorQmlElement *elementDef = static_cast<const QgsAttributeEditorQmlElement *>( widgetDef );
 
       QgsQmlWidgetWrapper *qmlWrapper = new QgsQmlWidgetWrapper( mLayer, nullptr, this );
+      // does not work before: no resize
+      // qmlWrapper->resizeWidget( elementDef->resize() );
+      // QgsMessageLog::logMessage( QStringLiteral( "------jgr----:createWidgetFromDef: %1" ).arg( elementDef->resize() ) );
+
+      qmlWrapper->setResizeFlag( elementDef->resize() );
       qmlWrapper->setQmlCode( elementDef->qmlCode() );
+
       context.setAttributeFormMode( mMode );
       qmlWrapper->setContext( context );
 
@@ -2139,6 +2147,11 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
       newWidgetInfo.labelText = elementDef->name();
       newWidgetInfo.labelOnTop = true;
       newWidgetInfo.showLabel = widgetDef->showLabel();
+
+      // does nor work after: expression is invalid
+//      qmlWrapper->resizeWidget( elementDef->resize() );
+//      QgsMessageLog::logMessage( QStringLiteral( "------jgr----:createWidgetFromDef: %1" ).arg( elementDef->resize() ) );
+
       break;
     }
 

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -1272,11 +1272,11 @@ void QgsAttributesDnDTree::onItemDoubleClicked( QTreeWidgetItem *item, int colum
         qmlCode->insertPlainText( QStringLiteral( "expression.evaluate(\"%1\")" ).arg( expressionWidget->expression().replace( '"', QLatin1String( "\\\"" ) ) ) );
       } );
 
-      QCheckBox *resizeToParent = new QCheckBox( tr( "Resize to parent") );
-      connect(resizeToParent, &QCheckBox::toggled, this, [ = ]( bool active )
+      QCheckBox *resizeToParent = new QCheckBox( tr( "Resize to parent" ) );
+      connect( resizeToParent, &QCheckBox::toggled, this, [ = ]( bool active )
       {
-         qmlWrapper->resizeWidget( active );
-      });
+        qmlWrapper->resizeWidget( active );
+      } );
 
       layout->addWidget( new QLabel( tr( "Title" ) ) );
       layout->addWidget( title );
@@ -1295,7 +1295,7 @@ void QgsAttributesDnDTree::onItemDoubleClicked( QTreeWidgetItem *item, int colum
       qmlPreviewBox->setLayout( new QGridLayout );
       qmlPreviewBox->setMinimumWidth( 400 );
       qmlPreviewBox->layout()->addWidget( qmlWrapper->widget() );
-      resizeToParent->setChecked(resize);
+      resizeToParent->setChecked( resize );
       //emit to load preview for the first time
       emit qmlCode->textChanged();
       qmlLayout->addWidget( qmlPreviewBox );

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -31,8 +31,6 @@
 #include "qgsattributeeditorqmlelement.h"
 #include "qgsattributeeditorhtmlelement.h"
 
-#include "qgsmessagelog.h"
-
 QgsAttributesFormProperties::QgsAttributesFormProperties( QgsVectorLayer *layer, QWidget *parent )
   : QWidget( parent )
   , mLayer( layer )
@@ -1166,10 +1164,8 @@ void QgsAttributesDnDTree::onItemDoubleClicked( QTreeWidgetItem *item, int colum
       QPlainTextEdit *qmlCode = new QPlainTextEdit( itemData.qmlElementEditorConfiguration().qmlCode );
       qmlCode->setPlaceholderText( tr( "Insert QML code here…" ) );
 
-      // resize behaviour
+      // resize behavior
       bool resize = itemData.qmlElementEditorConfiguration().resizeFlag ;
-
-      QgsMessageLog::logMessage( QStringLiteral( "------jgr----:resize:onItemDoubleClicked: %1" ).arg( resize ) );
 
       QgsQmlWidgetWrapper *qmlWrapper = new QgsQmlWidgetWrapper( mLayer, nullptr, this );
       QgsFeature previewFeature;

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -82,7 +82,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     struct QmlElementEditorConfiguration
     {
       QString qmlCode;
-      bool resizeFlag;
+      bool resizeFlag = false;
     };
 
     struct HtmlElementEditorConfiguration

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -82,6 +82,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     struct QmlElementEditorConfiguration
     {
       QString qmlCode;
+      bool resizeFlag;
     };
 
     struct HtmlElementEditorConfiguration


### PR DESCRIPTION
## Description

This PR enhances the QML Widget with an additional option to resize its contents, when the user resizes the form. 

My use case it to render images stored as blobs on Postgresql, but this enhancement could be useful for other use cases.

![resize to parent](https://user-images.githubusercontent.com/163681/106538169-bca9b080-64f3-11eb-8569-fea60f0d98ca.png)

This shouldn't break any existent usage of the widget. It's an additional option.

The user can enable this option and fine tune the image display using QML options, like `fillMode: Image.PreserveAspectFit`.
![resize to parent with preserve aspect ratio](https://user-images.githubusercontent.com/163681/106538480-32158100-64f4-11eb-967e-cb5086162870.png)

## WIP Status

At editing time, the widget preview works great, as expected.

When displayed on the feature form, the widget must be included in some other widget. If not, the expressions don't work. For some reason, the context is lost.

I'm using a `QgsScrollArea` to overcome the limitation, but it is not rendering properly yet. It is not occupying all the area vertically. I need some help to display it properly (file `src/gui/qgsattributeform.cpp`).

## Test dataset

I'm attaching a Geopackage (zipped) with photos stores as blogs for the layer `Photos`. This layer can be used to display the images with the following qml code:
```
import QtQuick 2.0
    
Image {
    source:   "data:image/png;base64," + expression.evaluate(" to_base64(\"photo\") ")
}
```

[Retortelo e Arcela GPKG.zip](https://github.com/qgis/QGIS/files/5908042/Retortelo.e.Arcela.GPKG.zip)
