### PR TITLE
[Processing] Remove PointsInPolygon and SumLineLength algorithms from Edit in Place list

### DIFF
--- a/src/analysis/processing/qgsalgorithmpointsinpolygon.cpp
+++ b/src/analysis/processing/qgsalgorithmpointsinpolygon.cpp
@@ -158,6 +158,13 @@ bool QgsPointsInPolygonAlgorithm::prepareAlgorithm( const QVariantMap &parameter
   return true;
 }
 
+QgsProcessingAlgorithm::Flags QgsPointsInPolygonAlgorithm::flags() const
+{
+  Flags f = QgsProcessingFeatureBasedAlgorithm::flags();
+  f &= ~QgsProcessingAlgorithm::FlagSupportsInPlaceEdits;
+  return f;
+}
+
 QgsFeatureList QgsPointsInPolygonAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QgsFeature outputFeature = feature;
@@ -244,8 +251,4 @@ QgsFields QgsPointsInPolygonAlgorithm::outputFields( const QgsFields &inputField
   return outFields;
 }
 
-
 ///@endcond
-
-
-

--- a/src/analysis/processing/qgsalgorithmpointsinpolygon.h
+++ b/src/analysis/processing/qgsalgorithmpointsinpolygon.h
@@ -48,6 +48,7 @@ class QgsPointsInPolygonAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QList<int> inputLayerTypes() const override;
     QgsProcessing::SourceType outputLayerType() const override;
     QgsCoordinateReferenceSystem outputCrs( const QgsCoordinateReferenceSystem &inputCrs ) const override;
+    QgsProcessingAlgorithm::Flags flags() const override;
 
 
   protected:

--- a/src/analysis/processing/qgsalgorithmsumlinelength.cpp
+++ b/src/analysis/processing/qgsalgorithmsumlinelength.cpp
@@ -211,4 +211,11 @@ QgsFeatureList QgsSumLineLengthAlgorithm::processFeature( const QgsFeature &feat
   }
 }
 
+QgsProcessingAlgorithm::Flags QgsSumLineLengthAlgorithm::flags() const
+{
+  Flags f = QgsProcessingFeatureBasedAlgorithm::flags();
+  f &= ~QgsProcessingAlgorithm::FlagSupportsInPlaceEdits;
+  return f;
+}
+
 ///@endcond

--- a/src/analysis/processing/qgsalgorithmsumlinelength.h
+++ b/src/analysis/processing/qgsalgorithmsumlinelength.h
@@ -47,6 +47,7 @@ class QgsSumLineLengthAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QList<int> inputLayerTypes() const override;
     QgsProcessing::SourceType outputLayerType() const override;
     QgsCoordinateReferenceSystem outputCrs( const QgsCoordinateReferenceSystem &inputCrs ) const override;
+    QgsProcessingAlgorithm::Flags flags() const override;
 
 
   protected:


### PR DESCRIPTION
## Description
According to the [doc](https://docs.qgis.org/3.16/en/docs/user_manual/working_with_vector/editing_geometry_attributes.html#the-processing-in-place-layer-modifier) these algorithms can not edit in-place.

Fixes #39807