### PR TITLE
[processing] Fix exception in algorithm locator filter if an algorithm has no group set (3.16 backport)

### DIFF
--- a/python/plugins/processing/gui/AlgorithmLocatorFilter.py
+++ b/python/plugins/processing/gui/AlgorithmLocatorFilter.py
@@ -87,7 +87,9 @@ class AlgorithmLocatorFilter(QgsLocatorFilter):
 
             string = string.lower()
             tagScore = 0
-            tags = [*a.tags(), a.provider().name(), a.group()]
+            tags = [*a.tags(), a.provider().name()]
+            if a.group():
+                tags.append(a.group())
 
             for t in tags:
                 if string in t.lower():


### PR DESCRIPTION
The group isn't mandatory

(cherry picked from commit 46dbd8b2d6275256779c14938de7424ab1053d7a)
