### PR TITLE
Fix use of Sum Line Length and Count Points in Polygons in in-place mode

### DIFF
--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -72,7 +72,11 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
             self.buttonBox().addButton(self.runAsBatchButton,
                                        QDialogButtonBox.ResetRole)  # reset role to ensure left alignment
         else:
-            self.mainWidget().setParameters({'INPUT': self.active_layer})
+            in_place_input_parameter_name = 'INPUT'
+            if hasattr(alg, 'inputParameterName'):
+                in_place_input_parameter_name = alg.inputParameterName()
+
+            self.mainWidget().setParameters({in_place_input_parameter_name: self.active_layer})
 
             self.runAsBatchButton = None
             has_selection = self.active_layer and (self.active_layer.selectedFeatureCount() > 0)

--- a/python/plugins/processing/gui/AlgorithmLocatorFilter.py
+++ b/python/plugins/processing/gui/AlgorithmLocatorFilter.py
@@ -204,8 +204,12 @@ class InPlaceAlgorithmLocatorFilter(QgsLocatorFilter):
                 dlg.exec_()
                 return
 
+            in_place_input_parameter_name = 'INPUT'
+            if hasattr(alg, 'inputParameterName'):
+                in_place_input_parameter_name = alg.inputParameterName()
+
             if [d for d in alg.parameterDefinitions() if
-                    d.name() not in ('INPUT', 'OUTPUT')]:
+                    d.name() not in (in_place_input_parameter_name, 'OUTPUT')]:
                 dlg = alg.createCustomParametersWidget(parent=iface.mainWindow())
                 if not dlg:
                     dlg = AlgorithmDialog(alg, True, parent=iface.mainWindow())

--- a/python/plugins/processing/gui/AlgorithmLocatorFilter.py
+++ b/python/plugins/processing/gui/AlgorithmLocatorFilter.py
@@ -193,7 +193,8 @@ class InPlaceAlgorithmLocatorFilter(QgsLocatorFilter):
                 self.resultFetched.emit(result)
 
     def triggerResult(self, result):
-        alg = QgsApplication.processingRegistry().createAlgorithmById(result.userData)
+        config = {'IN_PLACE': True}
+        alg = QgsApplication.processingRegistry().createAlgorithmById(result.userData, config)
         if alg:
             ok, message = alg.canExecute()
             if not ok:

--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -94,6 +94,10 @@ class ParametersPanel(QgsProcessingParametersWidget):
         if isinstance(self.algorithm(), QgsProcessingModelAlgorithm):
             widget_context.setModel(self.algorithm())
 
+        in_place_input_parameter_name = 'INPUT'
+        if hasattr(self.algorithm(), 'inputParameterName'):
+            in_place_input_parameter_name = self.algorithm().inputParameterName()
+
         # Create widgets and put them in layouts
         for param in self.algorithm().parameterDefinitions():
             if param.flags() & QgsProcessingParameterDefinition.FlagHidden:
@@ -102,7 +106,7 @@ class ParametersPanel(QgsProcessingParametersWidget):
             if param.isDestination():
                 continue
             else:
-                if self.in_place and param.name() in ('INPUT', 'OUTPUT'):
+                if self.in_place and param.name() in (in_place_input_parameter_name, 'OUTPUT'):
                     # don't show the input/output parameter widgets in in-place mode
                     # we still need to CREATE them, because other wrappers may need to interact
                     # with them (e.g. those parameters which need the input layer for field
@@ -155,7 +159,7 @@ class ParametersPanel(QgsProcessingParametersWidget):
             if output.flags() & QgsProcessingParameterDefinition.FlagHidden:
                 continue
 
-            if self.in_place and output.name() in ('INPUT', 'OUTPUT'):
+            if self.in_place and output.name() in (in_place_input_parameter_name, 'OUTPUT'):
                 continue
 
             wrapper = QgsGui.processingGuiRegistry().createParameterWidgetWrapper(output, QgsProcessingGui.Standard)

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -248,7 +248,11 @@ class ProcessingToolbox(QgsDockWidget, WIDGET):
                 dlg.exec_()
                 return
 
-            if self.in_place_mode and not [d for d in alg.parameterDefinitions() if d.name() not in ('INPUT', 'OUTPUT')]:
+            in_place_input_parameter_name = 'INPUT'
+            if hasattr(alg, 'inputParameterName'):
+                in_place_input_parameter_name = alg.inputParameterName()
+
+            if self.in_place_mode and not [d for d in alg.parameterDefinitions() if d.name() not in (in_place_input_parameter_name, 'OUTPUT')]:
                 parameters = {}
                 feedback = MessageBarProgress(algname=alg.displayName())
                 ok, results = execute_in_place(alg, parameters, feedback=feedback)

--- a/src/analysis/processing/qgsalgorithmpointsinpolygon.h
+++ b/src/analysis/processing/qgsalgorithmpointsinpolygon.h
@@ -57,9 +57,10 @@ class QgsPointsInPolygonAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFields outputFields( const QgsFields &inputFields ) const override;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   private:
-
+    bool mIsInPlace = false;
     QString mFieldName;
     QString mWeightFieldName;
     QString mClassFieldName;

--- a/src/analysis/processing/qgsalgorithmsumlinelength.cpp
+++ b/src/analysis/processing/qgsalgorithmsumlinelength.cpp
@@ -106,14 +106,26 @@ QString QgsSumLineLengthAlgorithm::outputName() const
   return QObject::tr( "Line length" );
 }
 
-void QgsSumLineLengthAlgorithm::initParameters( const QVariantMap & )
+void QgsSumLineLengthAlgorithm::initParameters( const QVariantMap &configuration )
 {
+  mIsInPlace = configuration.value( QStringLiteral( "IN_PLACE" ) ).toBool();
+
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "LINES" ),
                 QObject::tr( "Lines" ), QList< int > () << QgsProcessing::TypeVectorLine ) );
-  addParameter( new QgsProcessingParameterString( QStringLiteral( "LEN_FIELD" ),
-                QObject::tr( "Lines length field name" ), QStringLiteral( "LENGTH" ) ) );
-  addParameter( new QgsProcessingParameterString( QStringLiteral( "COUNT_FIELD" ),
-                QObject::tr( "Lines count field name" ), QStringLiteral( "COUNT" ) ) );
+  if ( mIsInPlace )
+  {
+    addParameter( new QgsProcessingParameterField( QStringLiteral( "LEN_FIELD" ),
+                  QObject::tr( "Lines length field name" ), QStringLiteral( "LENGTH" ), inputParameterName(), QgsProcessingParameterField::Any, false, true ) );
+    addParameter( new QgsProcessingParameterField( QStringLiteral( "COUNT_FIELD" ),
+                  QObject::tr( "Lines count field name" ), QStringLiteral( "COUNT" ), inputParameterName(), QgsProcessingParameterField::Any, false, true ) );
+  }
+  else
+  {
+    addParameter( new QgsProcessingParameterString( QStringLiteral( "LEN_FIELD" ),
+                  QObject::tr( "Lines length field name" ), QStringLiteral( "LENGTH" ) ) );
+    addParameter( new QgsProcessingParameterString( QStringLiteral( "COUNT_FIELD" ),
+                  QObject::tr( "Lines count field name" ), QStringLiteral( "COUNT" ) ) );
+  }
 }
 
 bool QgsSumLineLengthAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
@@ -136,17 +148,35 @@ bool QgsSumLineLengthAlgorithm::prepareAlgorithm( const QVariantMap &parameters,
 
 QgsFields QgsSumLineLengthAlgorithm::outputFields( const QgsFields &inputFields ) const
 {
-  QgsFields outFields = inputFields;
-  mLengthFieldIndex = inputFields.lookupField( mLengthFieldName );
-  if ( mLengthFieldIndex < 0 )
-    outFields.append( QgsField( mLengthFieldName, QVariant::Double ) );
+  if ( mIsInPlace )
+  {
+    mLengthFieldIndex = mLengthFieldName.isEmpty() ? -1 : inputFields.lookupField( mLengthFieldName );
+    mCountFieldIndex = mCountFieldName.isEmpty() ? -1 :  inputFields.lookupField( mCountFieldName );
+    return inputFields;
+  }
+  else
+  {
+    QgsFields outFields = inputFields;
+    mLengthFieldIndex = inputFields.lookupField( mLengthFieldName );
+    if ( mLengthFieldIndex < 0 )
+      outFields.append( QgsField( mLengthFieldName, QVariant::Double ) );
 
-  mCountFieldIndex = inputFields.lookupField( mCountFieldName );
-  if ( mCountFieldIndex < 0 )
-    outFields.append( QgsField( mCountFieldName, QVariant::Double ) );
+    mCountFieldIndex = inputFields.lookupField( mCountFieldName );
+    if ( mCountFieldIndex < 0 )
+      outFields.append( QgsField( mCountFieldName, QVariant::Double ) );
 
-  mFields = outFields;
-  return outFields;
+    mFields = outFields;
+    return outFields;
+  }
+}
+
+bool QgsSumLineLengthAlgorithm::supportInPlaceEdit( const QgsMapLayer *layer ) const
+{
+  if ( const QgsVectorLayer *vl = qobject_cast< const QgsVectorLayer * >( layer ) )
+  {
+    return vl->geometryType() == QgsWkbTypes::PolygonGeometry;
+  }
+  return false;
 }
 
 QgsFeatureList QgsSumLineLengthAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
@@ -155,14 +185,14 @@ QgsFeatureList QgsSumLineLengthAlgorithm::processFeature( const QgsFeature &feat
   if ( !feature.hasGeometry() )
   {
     QgsAttributes attrs = feature.attributes();
-    if ( mLengthFieldIndex < 0 )
+    if ( !mIsInPlace && mLengthFieldIndex < 0 )
       attrs.append( 0 );
-    else
+    else if ( mLengthFieldIndex >= 0 )
       attrs[mLengthFieldIndex] = 0;
 
-    if ( mCountFieldIndex < 0 )
+    if ( !mIsInPlace && mCountFieldIndex < 0 )
       attrs.append( 0 );
-    else
+    else if ( mCountFieldIndex >= 0 )
       attrs[mCountFieldIndex] = 0;
 
     outputFeature.setAttributes( attrs );
@@ -196,14 +226,14 @@ QgsFeatureList QgsSumLineLengthAlgorithm::processFeature( const QgsFeature &feat
     }
 
     QgsAttributes attrs = feature.attributes();
-    if ( mLengthFieldIndex < 0 )
+    if ( !mIsInPlace && mLengthFieldIndex < 0 )
       attrs.append( length );
-    else
+    else if ( mLengthFieldIndex >= 0 )
       attrs[mLengthFieldIndex] = length;
 
-    if ( mCountFieldIndex < 0 )
+    if ( !mIsInPlace && mCountFieldIndex < 0 )
       attrs.append( count );
-    else
+    else if ( mCountFieldIndex >= 0 )
       attrs[mCountFieldIndex] = count;
 
     outputFeature.setAttributes( attrs );

--- a/src/analysis/processing/qgsalgorithmsumlinelength.h
+++ b/src/analysis/processing/qgsalgorithmsumlinelength.h
@@ -56,9 +56,10 @@ class QgsSumLineLengthAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFields outputFields( const QgsFields &inputFields ) const override;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 
   private:
-
+    bool mIsInPlace = false;
     QString mLengthFieldName;
     QString mCountFieldName;
     mutable int mLengthFieldIndex = -1;


### PR DESCRIPTION
Supersedes https://github.com/qgis/QGIS/pull/41315 -- instead of disabling in-place mode for these algorithms, make the algorithms fully compatible with in-place edit modes.