### PR TITLE
fix mdal linking with MSVC and shared HDF5

### DIFF
--- a/src/providers/mdal/CMakeLists.txt
+++ b/src/providers/mdal/CMakeLists.txt
@@ -194,6 +194,7 @@ endif()
 if (HDF5_FOUND)
   target_include_directories(mdalprovider PRIVATE ${HDF5_INCLUDE_DIRS})
   target_link_libraries(mdalprovider ${HDF5_C_LIBRARIES} )
+  target_compile_definitions(mdalprovider PRIVATE ${HDF5_DEFINITIONS})
 endif()
 
 if (GDAL_FOUND)


### PR DESCRIPTION
## Description

Another fix from [conda-forge](https://github.com/conda-forge/qgis-feedstock). When linking against a shared HDF5 with MSVC, the `H5_BUILT_AS_DYNAMIC_LIB` define should be set during the compile. This is set by [FindHDF5.cmake](https://cmake.org/cmake/help/latest/module/FindHDF5.html) into the `HDF5_DEFINITIONS` cmake variable for shared MSVC builds. This PR adds `HDF5_DEFINITIONS` to the compile definitions for `mdal` which should have no effect on other platforms/compilers as it will be empty.