### PR TITLE
A horizontal mouse wheel scroll over the canvas "scrubs" the temporal slider back and forward

### DIFF
--- a/python/gui/auto_generated/qgstemporalcontrollerwidget.sip.in
+++ b/python/gui/auto_generated/qgstemporalcontrollerwidget.sip.in
@@ -29,7 +29,7 @@ A widget for controlling playback properties of a :py:class:`QgsTemporalControll
 Constructor for QgsTemporalControllerWidget, with the specified ``parent`` widget.
 %End
 
-    QgsTemporalController *temporalController();
+    QgsTemporalNavigationObject *temporalController();
 %Docstring
 Returns the temporal controller object used by this object in navigation.
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1226,6 +1226,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   mTemporalControllerWidget->setToggleVisibilityAction( mActionTemporalController );
 
   mMapCanvas->setTemporalController( mTemporalControllerWidget->temporalController() );
+  mTemporalControllerWidget->setMapCanvas( mMapCanvas );
 
   QgsGui::instance()->dataItemGuiProviderRegistry()->addProvider( new QgsAppDirectoryItemGuiProvider() );
   QgsGui::instance()->dataItemGuiProviderRegistry()->addProvider( new QgsProjectHomeItemGuiProvider() );

--- a/src/app/qgstemporalcontrollerdockwidget.cpp
+++ b/src/app/qgstemporalcontrollerdockwidget.cpp
@@ -51,6 +51,28 @@ QgsTemporalController *QgsTemporalControllerDockWidget::temporalController()
   return mControllerWidget->temporalController();
 }
 
+void QgsTemporalControllerDockWidget::setMapCanvas( QgsMapCanvas *canvas )
+{
+  if ( canvas && canvas->viewport() )
+    canvas->viewport()->installEventFilter( this );
+}
+
+bool QgsTemporalControllerDockWidget::eventFilter( QObject *object, QEvent *event )
+{
+  if ( event->type() == QEvent::Wheel )
+  {
+    QWheelEvent *wheelEvent = dynamic_cast< QWheelEvent * >( event );
+    // handle horizontal wheel events by scrubbing timeline
+    if ( wheelEvent->angleDelta().x() != 0 )
+    {
+      const int step = -wheelEvent->angleDelta().x() / 120.0;
+      mControllerWidget->temporalController()->setCurrentFrameNumber( mControllerWidget->temporalController()->currentFrameNumber() + step );
+      return true;
+    }
+  }
+  return QgsDockWidget::eventFilter( object, event );
+}
+
 void QgsTemporalControllerDockWidget::exportAnimation()
 {
   QgsAnimationExportDialog *dlg = new QgsAnimationExportDialog( this, QgisApp::instance()->mapCanvas(), QgisApp::instance()->activeDecorations() );

--- a/src/app/qgstemporalcontrollerdockwidget.h
+++ b/src/app/qgstemporalcontrollerdockwidget.h
@@ -23,6 +23,7 @@
 
 class QgsTemporalControllerWidget;
 class QgsTemporalController;
+class QgsMapCanvas;
 
 /**
  * \ingroup app
@@ -46,6 +47,12 @@ class APP_EXPORT QgsTemporalControllerDockWidget : public QgsDockWidget
      * The dock widget retains ownership of the returned object.
      */
     QgsTemporalController *temporalController();
+
+    void setMapCanvas( QgsMapCanvas *canvas );
+
+  protected:
+
+    bool eventFilter( QObject *object, QEvent *event ) override;
 
   private slots:
 

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -480,7 +480,7 @@ void QgsTemporalControllerWidget::updateRangeLabel( const QgsDateTimeRange &rang
   }
 }
 
-QgsTemporalController *QgsTemporalControllerWidget::temporalController()
+QgsTemporalNavigationObject *QgsTemporalControllerWidget::temporalController()
 {
   return mNavigationObject;
 }

--- a/src/gui/qgstemporalcontrollerwidget.h
+++ b/src/gui/qgstemporalcontrollerwidget.h
@@ -51,7 +51,7 @@ class GUI_EXPORT QgsTemporalControllerWidget : public QgsPanelWidget, private Ui
      *
      * The dock widget retains ownership of the returned object.
      */
-    QgsTemporalController *temporalController();
+    QgsTemporalNavigationObject *temporalController();
 
 #ifndef SIP_RUN
 


### PR DESCRIPTION
We haven't done anything with horizontal mouse wheel scrolls in QGIS, and this seems like the perfect use for them!