### PR TITLE
Capital 'V' to Layer visibility submenu

### DIFF
--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -124,7 +124,7 @@
     </widget>
     <widget class="QMenu" name="mMenuLayerVisibility">
      <property name="title">
-      <string>Layer visibility</string>
+      <string>Layer Visibility</string>
      </property>
      <addaction name="mActionShowAllLayers"/>
      <addaction name="mActionHideAllLayers"/>


### PR DESCRIPTION
Just a little adjustment to https://github.com/qgis/QGIS/pull/40812.

The new "Layer visibility" submenu in the "View" menu didn't have a capital 'V' to 'visibility'.
