### PR TITLE
[Server][Feature][needs-docs] Make service URL configurable

### DIFF
--- a/python/server/auto_additions/qgsserverrequest.py
+++ b/python/server/auto_additions/qgsserverrequest.py
@@ -1,2 +1,3 @@
 # The following has been generated automatically from src/server/qgsserverrequest.h
 QgsServerRequest.Method.baseClass = QgsServerRequest
+QgsServerRequest.RequestHeader.baseClass = QgsServerRequest

--- a/python/server/auto_generated/qgsaccesscontrol.sip.in
+++ b/python/server/auto_generated/qgsaccesscontrol.sip.in
@@ -134,8 +134,6 @@ Are we authorized to modify the following geometry
 Fill the capabilities caching key
 
 :param cacheKey: the list to fill with a cache variant
-
-:return: ``False`` if we can't create a cache
 %End
 
     void registerAccessControl( QgsAccessControlFilter *accessControl, int priority = 0 );

--- a/python/server/auto_generated/qgsfcgiserverrequest.sip.in
+++ b/python/server/auto_generated/qgsfcgiserverrequest.sip.in
@@ -32,6 +32,18 @@ Class defining fcgi request
 Returns ``True`` if an error occurred during initialization
 %End
 
+    virtual QString header( const QString &name ) const;
+
+%Docstring
+Returns the header value
+
+:param name: of the header
+
+:return: the header value or an empty string
+
+.. versionadded:: 3.20
+%End
+
 };
 
 /************************************************************************

--- a/python/server/auto_generated/qgsservercachemanager.sip.in
+++ b/python/server/auto_generated/qgsservercachemanager.sip.in
@@ -22,10 +22,9 @@ A helper class that centralizes caches accesses given by all the server cache fi
 
 %TypeHeaderCode
 #include "qgsservercachemanager.h"
-#include "qgsservercachefilter.h"
 %End
   public:
-    QgsServerCacheManager();
+    QgsServerCacheManager( const QgsServerSettings &settings = QgsServerSettings() );
 %Docstring
 Constructor
 %End

--- a/python/server/auto_generated/qgsserverprojectutils.sip.in
+++ b/python/server/auto_generated/qgsserverprojectutils.sip.in
@@ -355,13 +355,16 @@ Returns the restricted composer list.
 :return: the restricted composer list if defined in project.
 %End
 
-  QString wmsServiceUrl( const QgsProject &project );
+  QString wmsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 %Docstring
-Returns the WMS service url defined in a QGIS project.
+Returns the WMS service url.
+The URL defined in the project or if not defined the URL from serviceUrl.
 
 :param project: the QGIS project
+:param request: the request
+:param settings: the server settings
 
-:return: url if defined in project, an empty string otherwise.
+:return: url to use for this service
 %End
 
   QString wmsRootName( const QgsProject &project );
@@ -370,7 +373,7 @@ Returns the WMS root layer name defined in a QGIS project.
 
 :param project: the QGIS project
 
-:return: root layer name if defined in project, an empty string otherwise.
+:return: root layer name to use for this service
 %End
 
   QStringList wmsRestrictedLayers( const QgsProject &project );
@@ -400,13 +403,16 @@ Returns the WMS Extent restriction.
 :return: the WMS Extent restriction.
 %End
 
-  QString wfsServiceUrl( const QgsProject &project );
+  QString wfsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 %Docstring
-Returns the WFS service url defined in a QGIS project.
+Returns the WFS service url.
+The URL defined in the project or if not defined the URL from serviceUrl.
 
 :param project: the QGIS project
+:param request: the request
+:param settings: the server settings
 
-:return: url if defined in project, an empty string otherwise.
+:return: url to use for this service
 %End
 
   QStringList wfsLayerIds( const QgsProject &project );
@@ -456,13 +462,16 @@ Returns the Layer ids list defined in a QGIS project as published as WFS-T with 
 :return: the Layer ids list.
 %End
 
-  QString wcsServiceUrl( const QgsProject &project );
+  QString wcsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 %Docstring
-Returns the WCS service url defined in a QGIS project.
+Returns the WCS service url.
+The URL defined in the project or if not defined the URL from serviceUrl.
 
 :param project: the QGIS project
+:param request: the request
+:param settings: the server settings
 
-:return: url if defined in project, an empty string otherwise.
+:return: url to use for this service
 %End
 
   QStringList wcsLayerIds( const QgsProject &project );
@@ -474,15 +483,42 @@ Returns the Layer ids list defined in a QGIS project as published in WCS.
 :return: the Layer ids list.
 %End
 
-  QString wmtsServiceUrl( const QgsProject &project );
+  QString wmtsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 %Docstring
-Returns the WMTS service url defined in a QGIS project.
+Returns the WMTS service url.
+The URL defined in the project or if not defined the URL from serviceUrl.
 
 :param project: the QGIS project
+:param request: the request
+:param settings: the server settings
 
-:return: url if defined in project, an empty string otherwise.
+:return: url to use for this service
 
 .. versionadded:: 3.4
+%End
+
+  QString serviceUrl( const QString &service, const QgsServerRequest &request, const QgsServerSettings &settings );
+%Docstring
+Returns the service url defined in the environment variable or with HTTP header.
+The is calculated from, in the order:
+
+- Value defined in the project per service.
+- The ``<service>_SERVICE_URL`` environment variable.
+- The ``SERVICE_URL`` environment variable.
+- The custom ``X-Qgis-<service>-Servcie-Url`` header.
+- The custom ``X-Qgis-Service-Url`` header.
+- Build form the standard ``Forwarded`` header.
+- Build form the pseudo standard ``X-Forwarded-Host`` and ``X-Forwarded-Proto`` headers.
+- Build form the standard ``Host`` header and the server protocol.
+- Build form the server name and the server protocol.
+
+:param request: the request
+:param service: the used service
+:param settings: the server settings
+
+:return: url to use for this service
+
+.. versionadded:: 3.20
 %End
 };
 

--- a/python/server/auto_generated/qgsserverrequest.sip.in
+++ b/python/server/auto_generated/qgsserverrequest.sip.in
@@ -34,6 +34,30 @@ class QgsServerRequest
       PatchMethod
     };
 
+    enum RequestHeader
+    {
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
+      HOST,
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+      // https://tools.ietf.org/html/rfc7239
+      FORWARDED,
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+      X_FORWARDED_FOR,
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
+      X_FORWARDED_HOST,
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
+      X_FORWARDED_PROTO,
+      // The QGIS service URL
+      X_QGIS_SERVICE_URL,
+      // The QGIS WMS service URL
+      X_QGIS_WMS_SERVICE_URL,
+      // The QGIS WFS service URL
+      X_QGIS_WFS_SERVICE_URL,
+      // The QGIS WCS service URL
+      X_QGIS_WCS_SERVICE_URL,
+      // The QGIS WMTS service URL
+      X_QGIS_WMTS_SERVICE_URL,
+    };
 
     QgsServerRequest();
 %Docstring
@@ -115,11 +139,20 @@ Gets a parameter value
 Remove a parameter
 %End
 
-    QString header( const QString &name ) const;
+    virtual QString header( const QString &name ) const;
 %Docstring
 Returns the header value
 
 :param name: of the header
+
+:return: the header value or an empty string
+%End
+
+    virtual QString header( const RequestHeader &headerEnum ) const;
+%Docstring
+Returns the header value
+
+:param headerEnum: of the header
 
 :return: the header value or an empty string
 %End
@@ -144,6 +177,8 @@ Returns the header map
 Remove an header
 
 :param name:
+
+.. versionadded:: 3.20
 %End
 
     virtual QByteArray data() const;
@@ -166,6 +201,16 @@ by default this is equal to the url seen by QGIS server
 .. seealso:: :py:func:`url`
 
 .. versionadded:: 3.6
+%End
+
+    QUrl baseUrl() const;
+%Docstring
+Returns the base URL of QGIS server
+
+E.g. if we call QGIS server with 'http://example.com/folder?REQUEST=WMS&...'
+the base URL will be 'http://example.com/folder'
+
+.. versionadded:: 3.20
 %End
 
     void setMethod( QgsServerRequest::Method method );
@@ -191,6 +236,12 @@ Set the request original ``url`` (the request url as seen by the web server)
 .. versionadded:: 3.6
 %End
 
+    void setBaseUrl( const QUrl &url );
+%Docstring
+Set the base URL of QGIS server
+
+.. versionadded:: 3.20
+%End
 
 };
 

--- a/python/server/auto_generated/qgsserversettings.sip.in
+++ b/python/server/auto_generated/qgsserversettings.sip.in
@@ -53,6 +53,11 @@ Provides some enum describing the environment currently supported for configurat
       QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES,
       QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS,
       QGIS_SERVER_LOG_PROFILE,
+      QGIS_SERVER_SERVICE_URL,
+      QGIS_SERVER_WMS_SERVICE_URL,
+      QGIS_SERVER_WFS_SERVICE_URL,
+      QGIS_SERVER_WCS_SERVICE_URL,
+      QGIS_SERVER_WMTS_SERVICE_URL,
     };
 };
 
@@ -273,6 +278,13 @@ The default value is ``False``, this value can be changed by setting the environ
 variable QGIS_SERVER_DISABLE_GETPRINT.
 
 .. versionadded:: 3.16
+%End
+
+    QString serviceUrl( const QString &service ) const;
+%Docstring
+Returns the service URL from the setting.
+
+.. versionadded:: 3.20
 %End
 
     static QString name( QgsServerSettingsEnv::EnvVar env );

--- a/src/server/qgsaccesscontrol.cpp
+++ b/src/server/qgsaccesscontrol.cpp
@@ -190,12 +190,11 @@ bool QgsAccessControl::fillCacheKey( QStringList &cacheKey ) const
   for ( acIterator = mPluginsAccessControls->constBegin(); acIterator != mPluginsAccessControls->constEnd(); ++acIterator )
   {
     QString newKey = acIterator.value()->cacheKey();
-    if ( newKey.length() == 0 )
+    if ( ! newKey.isEmpty() )
     {
       cacheKey.clear();
       return false;
     }
-    cacheKey << newKey;
   }
   return true;
 }

--- a/src/server/qgsaccesscontrol.h
+++ b/src/server/qgsaccesscontrol.h
@@ -147,7 +147,6 @@ class SERVER_EXPORT QgsAccessControl : public QgsFeatureFilterProvider
     /**
      * Fill the capabilities caching key
      * \param cacheKey the list to fill with a cache variant
-     * \returns FALSE if we can't create a cache
      */
     bool fillCacheKey( QStringList &cacheKey ) const;
 

--- a/src/server/qgsfcgiserverrequest.cpp
+++ b/src/server/qgsfcgiserverrequest.cpp
@@ -26,9 +26,7 @@
 
 QgsFcgiServerRequest::QgsFcgiServerRequest()
 {
-
   // Get the REQUEST_URI from the environment
-  QUrl url;
   QString uri = getenv( "REQUEST_URI" );
 
   if ( uri.isEmpty() )
@@ -36,45 +34,32 @@ QgsFcgiServerRequest::QgsFcgiServerRequest()
     uri = getenv( "SCRIPT_NAME" );
   }
 
+  QUrl url;
   url.setUrl( uri );
-
-  // Check if host is defined
-  if ( url.host().isEmpty() )
-  {
-    url.setHost( getenv( "SERVER_NAME" ) );
-  }
-
-  // Port ?
-  if ( url.port( -1 ) == -1 )
-  {
-    QString portString = getenv( "SERVER_PORT" );
-    if ( !portString.isEmpty() )
-    {
-      bool portOk;
-      int portNumber = portString.toInt( &portOk );
-      if ( portOk && portNumber != 80 )
-      {
-        url.setPort( portNumber );
-      }
-    }
-  }
-
-  // scheme
-  if ( url.scheme().isEmpty() )
-  {
-    QString( getenv( "HTTPS" ) ).compare( QLatin1String( "on" ), Qt::CaseInsensitive ) == 0
-    ? url.setScheme( QStringLiteral( "https" ) )
-    : url.setScheme( QStringLiteral( "http" ) );
-  }
-
+  fillUrl( url );
   // Store the URL before the server rewrite that could have been set in QUERY_STRING
   setOriginalUrl( url );
+
+  const QString qs = getenv( "QUERY_STRING" );
+  const QString questionMark = qs.isEmpty() ? QString() : QChar( '?' );
+  const QString extraPath = QStringLiteral( "%1%2%3" ).arg( getenv( "PATH_INFO" ) ).arg( questionMark ).arg( qs );
+
+  QUrl baseUrl;
+  if ( uri.endsWith( extraPath ) )
+  {
+    baseUrl.setUrl( uri.left( uri.length() -  extraPath.length() ) );
+  }
+  else
+  {
+    baseUrl.setUrl( uri );
+  }
+  fillUrl( baseUrl );
+  setBaseUrl( url );
 
   // OGC parameters are passed with the query string, which is normally part of
   // the REQUEST_URI, we override the query string url in case it is defined
   // independently of REQUEST_URI
-  const char *qs = getenv( "QUERY_STRING" );
-  if ( qs )
+  if ( ! qs.isEmpty() )
   {
     url.setQuery( qs );
   }
@@ -133,6 +118,38 @@ QgsFcgiServerRequest::QgsFcgiServerRequest()
   if ( logLevel <= Qgis::Info )
   {
     printRequestInfos( url );
+  }
+}
+
+void QgsFcgiServerRequest::fillUrl( QUrl &url ) const
+{
+  // Check if host is defined
+  if ( url.host().isEmpty() )
+  {
+    url.setHost( getenv( "SERVER_NAME" ) );
+  }
+
+  // Port ?
+  if ( url.port( -1 ) == -1 )
+  {
+    const QString portString = getenv( "SERVER_PORT" );
+    if ( !portString.isEmpty() )
+    {
+      bool portOk;
+      const int portNumber = portString.toInt( &portOk );
+      if ( portOk && portNumber != 80 )
+      {
+        url.setPort( portNumber );
+      }
+    }
+  }
+
+  // scheme
+  if ( url.scheme().isEmpty() )
+  {
+    QString( getenv( "HTTPS" ) ).compare( QLatin1String( "on" ), Qt::CaseInsensitive ) == 0
+    ? url.setScheme( QStringLiteral( "https" ) )
+    : url.setScheme( QStringLiteral( "http" ) );
   }
 }
 
@@ -195,6 +212,7 @@ void QgsFcgiServerRequest::printRequestInfos( const QUrl &url )
     QStringLiteral( "SERVER_NAME" ),
     QStringLiteral( "REQUEST_URI" ),
     QStringLiteral( "SCRIPT_NAME" ),
+    QStringLiteral( "PATH_INFO" ),
     QStringLiteral( "HTTPS" ),
     QStringLiteral( "REMOTE_ADDR" ),
     QStringLiteral( "REMOTE_HOST" ),
@@ -211,7 +229,22 @@ void QgsFcgiServerRequest::printRequestInfos( const QUrl &url )
     QStringLiteral( "NO_PROXY" ),
     QStringLiteral( "HTTP_AUTHORIZATION" ),
     QStringLiteral( "QGIS_PROJECT_FILE" ),
-    QStringLiteral( "QGIS_SERVER_IGNORE_BAD_LAYERS" )
+    QStringLiteral( "QGIS_SERVER_IGNORE_BAD_LAYERS" ),
+    QStringLiteral( "QGIS_SERVER_SERVICE_URL" ),
+    QStringLiteral( "QGIS_SERVER_WMS_SERVICE_URL" ),
+    QStringLiteral( "QGIS_SERVER_WFS_SERVICE_URL" ),
+    QStringLiteral( "QGIS_SERVER_WMTS_SERVICE_URL" ),
+    QStringLiteral( "QGIS_SERVER_WCS_SERVICE_URL" ),
+    QStringLiteral( "HTTP_X_QGIS_SERVICE_URL" ),
+    QStringLiteral( "HTTP_X_QGIS_WMS_SERVICE_URL" ),
+    QStringLiteral( "HTTP_X_QGIS_WFS_SERVICE_URL" ),
+    QStringLiteral( "HTTP_X_QGIS_WCS_SERVICE_URL" ),
+    QStringLiteral( "HTTP_X_QGIS_WMTS_SERVICE_URL" ),
+    QStringLiteral( "HTTP_FORWARDED" ),
+    QStringLiteral( "HTTP_X_FORWARDED_HOST" ),
+    QStringLiteral( "HTTP_X_FORWARDED_PROTO" ),
+    QStringLiteral( "HTTP_HOST" ),
+    QStringLiteral( "SERVER_PROTOCOL" )
   };
 
   QgsMessageLog::logMessage( QStringLiteral( "Request URL: %2" ).arg( url.url() ), QStringLiteral( "Server" ), Qgis::Info );
@@ -225,4 +258,19 @@ void QgsFcgiServerRequest::printRequestInfos( const QUrl &url )
       QgsMessageLog::logMessage( QStringLiteral( "%1: %2" ).arg( envVar ).arg( QString( getenv( envVar.toStdString().c_str() ) ) ), QStringLiteral( "Server" ), Qgis::Info );
     }
   }
+}
+
+QString QgsFcgiServerRequest::header( const QString &name ) const
+{
+  // Get from internal dictionary
+  QString result = QgsServerRequest::header( name );
+
+  // Or from standard environment variable
+  // https://tools.ietf.org/html/rfc3875#section-4.1.18
+  if ( result.isEmpty() )
+  {
+    result = qgetenv( QStringLiteral( "HTTP_%1" ).arg(
+                        name.toUpper().replace( QLatin1Char( '-' ), QLatin1Char( '_' ) ) ).toStdString().c_str() );
+  }
+  return result;
 }

--- a/src/server/qgsfcgiserverrequest.h
+++ b/src/server/qgsfcgiserverrequest.h
@@ -41,6 +41,14 @@ class SERVER_EXPORT QgsFcgiServerRequest: public QgsServerRequest
      */
     bool hasError() const { return mHasError; }
 
+    /**
+     * Returns the header value
+     * \param name of the header
+     * \return the header value or an empty string
+     * \since QGIS 3.20
+     */
+    QString header( const QString &name ) const override;
+
   private:
     void readData();
 
@@ -48,6 +56,9 @@ class SERVER_EXPORT QgsFcgiServerRequest: public QgsServerRequest
     // about the request
     void printRequestInfos( const QUrl &url );
 
+    // Fill the url given in argument with
+    // the server name, the server port and the schema (calculated from HTTPS)
+    void fillUrl( QUrl &url ) const;
 
     QByteArray mData;
     bool       mHasError = false;

--- a/src/server/qgsservercachemanager.h
+++ b/src/server/qgsservercachemanager.h
@@ -26,6 +26,7 @@
 #include <QDomDocument>
 #include "qgis_server.h"
 #include "qgis_sip.h"
+#include "qgsserversettings.h"
 
 class QgsProject;
 
@@ -39,13 +40,13 @@ SIP_IF_MODULE( HAVE_SERVER_PYTHON_PLUGINS )
  */
 class SERVER_EXPORT QgsServerCacheManager
 {
-#ifdef SIP_RUN
+#ifdef   SIP_RUN
 #include "qgsservercachefilter.h"
 #endif
 
   public:
     //! Constructor
-    QgsServerCacheManager();
+    QgsServerCacheManager( const QgsServerSettings &settings = QgsServerSettings() );
 
     //! Copy constructor
     QgsServerCacheManager( const QgsServerCacheManager &copy );
@@ -135,9 +136,10 @@ class SERVER_EXPORT QgsServerCacheManager
     void registerServerCache( QgsServerCacheFilter *serverCache, int priority = 0 );
 
   private:
-    QString getCacheKey( bool &cache, QgsAccessControl *accessControl ) const;
+    QString getCacheKey( bool &cache, QgsAccessControl *accessControl, const QgsServerRequest &request ) const;
     //! The ServerCache plugins registry
     std::unique_ptr<QgsServerCacheFilterMap> mPluginsServerCaches = nullptr;
+    const QgsServerSettings &mSettings;
 };
 
 #endif

--- a/src/server/qgsserverinterfaceimpl.cpp
+++ b/src/server/qgsserverinterfaceimpl.cpp
@@ -29,7 +29,7 @@ QgsServerInterfaceImpl::QgsServerInterfaceImpl( QgsCapabilitiesCache *capCache, 
   mRequestHandler = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
   mAccessControls = new QgsAccessControl();
-  mCacheManager = new QgsServerCacheManager();
+  mCacheManager = new QgsServerCacheManager( *settings );
 #endif
 }
 

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsserverprojectutils.h"
 #include "qgsproject.h"
+#include "qgsmessagelog.h"
 
 double  QgsServerProjectUtils::ceilWithPrecision( double number, int places )
 {
@@ -314,9 +315,120 @@ QStringList QgsServerProjectUtils::wmsOutputCrsList( const QgsProject &project )
   return crsList;
 }
 
-QString QgsServerProjectUtils::wmsServiceUrl( const QgsProject &project )
+QString QgsServerProjectUtils::serviceUrl( const QString &service, const QgsServerRequest &request, const QgsServerSettings &settings )
 {
-  return project.readEntry( QStringLiteral( "WMSUrl" ), QStringLiteral( "/" ), "" );
+  const QString serviceUpper = service.toUpper();
+  QString url = settings.serviceUrl( serviceUpper );
+  if ( ! url.isEmpty() )
+  {
+    return url;
+  }
+
+  QgsServerRequest::RequestHeader header = QgsServerRequest::RequestHeader::X_QGIS_SERVICE_URL;
+  if ( serviceUpper == QStringLiteral( "WMS" ) )
+  {
+    header = QgsServerRequest::RequestHeader::X_QGIS_WMS_SERVICE_URL;
+  }
+  else if ( serviceUpper == QStringLiteral( "WFS" ) )
+  {
+    header = QgsServerRequest::RequestHeader::X_QGIS_WFS_SERVICE_URL;
+  }
+  else if ( serviceUpper == QStringLiteral( "WCS" ) )
+  {
+    header = QgsServerRequest::RequestHeader::X_QGIS_WCS_SERVICE_URL;
+  }
+  else if ( serviceUpper == QStringLiteral( "WMTS" ) )
+  {
+    header = QgsServerRequest::RequestHeader::X_QGIS_WMTS_SERVICE_URL;
+  }
+  url = request.header( header );
+  if ( ! url.isEmpty() )
+  {
+    return url;
+  }
+  url = request.header( QgsServerRequest::RequestHeader::X_QGIS_SERVICE_URL );
+  if ( ! url.isEmpty() )
+  {
+    return url;
+  }
+
+  QString proto;
+  QString host;
+
+  QString  forwarded = request.header( QgsServerRequest::FORWARDED );
+  if ( ! forwarded.isEmpty() )
+  {
+    forwarded = forwarded.split( QLatin1Char( ',' ) )[0];
+    QStringList elements = forwarded.split( ';' );
+    for ( const QString &element : elements )
+    {
+      QStringList splited_element = element.trimmed().split( QLatin1Char( '=' ) );
+      if ( splited_element[0] == "host" )
+      {
+        host = splited_element[1];
+      }
+      if ( splited_element[0] == "proto" )
+      {
+        proto = splited_element[1];
+      }
+    }
+  }
+
+  if ( host.isEmpty() )
+  {
+    host = request.header( QgsServerRequest::RequestHeader::X_FORWARDED_HOST );
+    proto = request.header( QgsServerRequest::RequestHeader::X_FORWARDED_PROTO );
+  }
+
+  if ( host.isEmpty() )
+  {
+    host = request.header( QgsServerRequest::RequestHeader::HOST );
+  }
+
+  QUrl urlQUrl = request.baseUrl();
+  if ( ! proto.isEmpty() )
+  {
+    urlQUrl.setScheme( proto );
+  }
+
+  if ( ! host.isEmpty() )
+  {
+    QStringList hostPort = host.split( QLatin1Char( ':' ) );
+    if ( hostPort.length() == 1 )
+    {
+      urlQUrl.setHost( hostPort[0] );
+      urlQUrl.setPort( -1 );
+    }
+    if ( hostPort.length() == 2 )
+    {
+      urlQUrl.setHost( hostPort[0] );
+      urlQUrl.setPort( hostPort[1].toInt() );
+    }
+  }
+
+  // https://docs.qgis.org/3.16/en/docs/server_manual/services.html#wms-map
+  const QString map = request.parameter( QStringLiteral( "MAP" ) );
+  if ( ! map.isEmpty() )
+  {
+    QUrlQuery query;
+    query.setQueryItems( {{"MAP", map}} );
+    urlQUrl.setQuery( query );
+  }
+  else
+  {
+    urlQUrl.setQuery( NULL );
+  }
+  return urlQUrl.url();
+}
+
+QString QgsServerProjectUtils::wmsServiceUrl( const QgsProject &project, const  QgsServerRequest &request, const QgsServerSettings &settings )
+{
+  QString url = project.readEntry( QStringLiteral( "WMSUrl" ), QStringLiteral( "/" ), "" );
+  if ( url.isEmpty() )
+  {
+    url = serviceUrl( QStringLiteral( "WMS" ), request, settings );
+  }
+  return url;
 }
 
 QString QgsServerProjectUtils::wmsRootName( const QgsProject &project )
@@ -345,9 +457,14 @@ QgsRectangle QgsServerProjectUtils::wmsExtent( const QgsProject &project )
   return QgsRectangle( xmin, ymin, xmax, ymax );
 }
 
-QString QgsServerProjectUtils::wfsServiceUrl( const QgsProject &project )
+QString QgsServerProjectUtils::wfsServiceUrl( const QgsProject &project, const QgsServerRequest &request, const QgsServerSettings &settings )
 {
-  return project.readEntry( QStringLiteral( "WFSUrl" ), QStringLiteral( "/" ), "" );
+  QString url = project.readEntry( QStringLiteral( "WFSUrl" ), QStringLiteral( "/" ), "" );
+  if ( url.isEmpty() )
+  {
+    url = serviceUrl( QStringLiteral( "WFS" ), request, settings );
+  }
+  return url;
 }
 
 QStringList QgsServerProjectUtils::wfsLayerIds( const QgsProject &project )
@@ -375,9 +492,14 @@ QStringList QgsServerProjectUtils::wfstDeleteLayerIds( const QgsProject &project
   return project.readListEntry( QStringLiteral( "WFSTLayers" ), QStringLiteral( "Delete" ) );
 }
 
-QString QgsServerProjectUtils::wcsServiceUrl( const QgsProject &project )
+QString QgsServerProjectUtils::wcsServiceUrl( const QgsProject &project, const QgsServerRequest &request, const QgsServerSettings &settings )
 {
-  return project.readEntry( QStringLiteral( "WCSUrl" ), QStringLiteral( "/" ), "" );
+  QString url = project.readEntry( QStringLiteral( "WCSUrl" ), QStringLiteral( "/" ), "" );
+  if ( url.isEmpty() )
+  {
+    url = serviceUrl( QStringLiteral( "WCS" ), request, settings );
+  }
+  return url;
 }
 
 QStringList QgsServerProjectUtils::wcsLayerIds( const QgsProject &project )
@@ -385,9 +507,14 @@ QStringList QgsServerProjectUtils::wcsLayerIds( const QgsProject &project )
   return project.readListEntry( QStringLiteral( "WCSLayers" ), QStringLiteral( "/" ) );
 }
 
-QString QgsServerProjectUtils::wmtsServiceUrl( const QgsProject &project )
+QString QgsServerProjectUtils::wmtsServiceUrl( const QgsProject &project, const QgsServerRequest &request, const QgsServerSettings &settings )
 {
-  return project.readEntry( QStringLiteral( "WMTSUrl" ), QStringLiteral( "/" ), "" );
+  QString url = project.readEntry( QStringLiteral( "WMTSUrl" ), QStringLiteral( "/" ), "" );
+  if ( url.isEmpty() )
+  {
+    url = serviceUrl( QStringLiteral( "WMTS" ), request, settings );
+  }
+  return url;
 }
 
 bool QgsServerProjectUtils::wmsRenderMapTiles( const QgsProject &project )

--- a/src/server/qgsserverprojectutils.h
+++ b/src/server/qgsserverprojectutils.h
@@ -24,6 +24,8 @@
 
 #include "qgis_server.h"
 #include "qgis_sip.h"
+#include "qgsserverrequest.h"
+#include "qgsserversettings.h"
 
 class QgsProject;
 class QgsRectangle;
@@ -320,16 +322,20 @@ namespace QgsServerProjectUtils
   SERVER_EXPORT QStringList wmsRestrictedComposers( const QgsProject &project );
 
   /**
-   * Returns the WMS service url defined in a QGIS project.
+   * Returns the WMS service url.
+   * The URL defined in the project or if not defined the URL from serviceUrl.
+   *
    * \param project the QGIS project
-   * \returns url if defined in project, an empty string otherwise.
+   * \param request the request
+   * \param settings the server settings
+   * \returns url to use for this service
    */
-  SERVER_EXPORT QString wmsServiceUrl( const QgsProject &project );
+  SERVER_EXPORT QString wmsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 
   /**
    * Returns the WMS root layer name defined in a QGIS project.
    * \param project the QGIS project
-   * \returns root layer name if defined in project, an empty string otherwise.
+   * \returns root layer name to use for this service
    */
   SERVER_EXPORT QString wmsRootName( const QgsProject &project );
 
@@ -355,11 +361,15 @@ namespace QgsServerProjectUtils
   SERVER_EXPORT  QgsRectangle wmsExtent( const QgsProject &project );
 
   /**
-   * Returns the WFS service url defined in a QGIS project.
+   * Returns the WFS service url.
+   * The URL defined in the project or if not defined the URL from serviceUrl.
+   *
    * \param project the QGIS project
-   * \returns url if defined in project, an empty string otherwise.
+   * \param request the request
+   * \param settings the server settings
+   * \returns url to use for this service
    */
-  SERVER_EXPORT QString wfsServiceUrl( const QgsProject &project );
+  SERVER_EXPORT QString wfsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 
   /**
    * Returns the Layer ids list defined in a QGIS project as published in WFS.
@@ -399,11 +409,15 @@ namespace QgsServerProjectUtils
   SERVER_EXPORT QStringList wfstDeleteLayerIds( const QgsProject &project );
 
   /**
-   * Returns the WCS service url defined in a QGIS project.
+   * Returns the WCS service url.
+   * The URL defined in the project or if not defined the URL from serviceUrl.
+   *
    * \param project the QGIS project
-   * \returns url if defined in project, an empty string otherwise.
+   * \param request the request
+   * \param settings the server settings
+   * \returns url to use for this service
    */
-  SERVER_EXPORT QString wcsServiceUrl( const QgsProject &project );
+  SERVER_EXPORT QString wcsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
 
   /**
    * Returns the Layer ids list defined in a QGIS project as published in WCS.
@@ -413,12 +427,38 @@ namespace QgsServerProjectUtils
   SERVER_EXPORT QStringList wcsLayerIds( const QgsProject &project );
 
   /**
-   * Returns the WMTS service url defined in a QGIS project.
+   * Returns the WMTS service url.
+   * The URL defined in the project or if not defined the URL from serviceUrl.
+   *
    * \param project the QGIS project
-   * \returns url if defined in project, an empty string otherwise.
+   * \param request the request
+   * \param settings the server settings
+   * \returns url to use for this service
    * \since QGIS 3.4
    */
-  SERVER_EXPORT QString wmtsServiceUrl( const QgsProject &project );
+  SERVER_EXPORT QString wmtsServiceUrl( const QgsProject &project, const QgsServerRequest &request = QgsServerRequest(), const QgsServerSettings &settings = QgsServerSettings() );
+
+  /**
+   * Returns the service url defined in the environment variable or with HTTP header.
+   * The is calculated from, in the order:
+   *
+   * - Value defined in the project per service.
+   * - The ``<service>_SERVICE_URL`` environment variable.
+   * - The ``SERVICE_URL`` environment variable.
+   * - The custom ``X-Qgis-<service>-Servcie-Url`` header.
+   * - The custom ``X-Qgis-Service-Url`` header.
+   * - Build form the standard ``Forwarded`` header.
+   * - Build form the pseudo standard ``X-Forwarded-Host`` and ``X-Forwarded-Proto`` headers.
+   * - Build form the standard ``Host`` header and the server protocol.
+   * - Build form the server name and the server protocol.
+   *
+   * \param request the request
+   * \param service the used service
+   * \param settings the server settings
+   * \returns url to use for this service
+   * \since QGIS 3.20
+   */
+  SERVER_EXPORT QString serviceUrl( const QString &service, const QgsServerRequest &request, const QgsServerSettings &settings );
 };
 
 #endif

--- a/src/server/qgsserverrequest.cpp
+++ b/src/server/qgsserverrequest.cpp
@@ -20,6 +20,7 @@
 #include "qgsserverrequest.h"
 #include <QUrlQuery>
 
+
 QgsServerRequest::QgsServerRequest( const QString &url, Method method, const Headers &headers )
   : QgsServerRequest( QUrl( url ), method, headers )
 {
@@ -28,18 +29,33 @@ QgsServerRequest::QgsServerRequest( const QString &url, Method method, const Hea
 QgsServerRequest::QgsServerRequest( const QUrl &url, Method method, const Headers &headers )
   : mUrl( url )
   , mOriginalUrl( url )
+  , mBaseUrl( url )
   , mMethod( method )
   , mHeaders( headers )
+  , mRequestHeaderConv()
 {
+  mRequestHeaderConv.insert( HOST, QStringLiteral( "Host" ) );
+  mRequestHeaderConv.insert( FORWARDED, QStringLiteral( "Forwarded" ) );
+  mRequestHeaderConv.insert( X_FORWARDED_FOR, QStringLiteral( "X-Forwarded-For" ) );
+  mRequestHeaderConv.insert( X_FORWARDED_HOST, QStringLiteral( "X-Forwarded-Host" ) );
+  mRequestHeaderConv.insert( X_FORWARDED_PROTO, QStringLiteral( "X-Forwarded-Proto" ) );
+  mRequestHeaderConv.insert( X_QGIS_SERVICE_URL, QStringLiteral( "X-Qgis-Service-Url" ) );
+  mRequestHeaderConv.insert( X_QGIS_WMS_SERVICE_URL, QStringLiteral( "X-Qgis-Wms-Service-Url" ) );
+  mRequestHeaderConv.insert( X_QGIS_WFS_SERVICE_URL, QStringLiteral( "X-Qgis-Wfs-Service-Url" ) );
+  mRequestHeaderConv.insert( X_QGIS_WCS_SERVICE_URL, QStringLiteral( "X-Qgis-Wcs-Service-Url" ) );
+  mRequestHeaderConv.insert( X_QGIS_WMTS_SERVICE_URL, QStringLiteral( "X-Qgis-Wmts-Service-Url" ) );
+
   mParams.load( QUrlQuery( url ) );
 }
 
 QgsServerRequest::QgsServerRequest( const QgsServerRequest &other )
   : mUrl( other.mUrl )
   , mOriginalUrl( other.mOriginalUrl )
+  , mBaseUrl( other.mBaseUrl )
   , mMethod( other.mMethod )
   , mHeaders( other.mHeaders )
   , mParams( other.mParams )
+  , mRequestHeaderConv( other.mRequestHeaderConv )
 {
 }
 
@@ -55,6 +71,11 @@ QString QgsServerRequest::header( const QString &name ) const
 }
 
 
+QString QgsServerRequest::header( const QgsServerRequest::RequestHeader &headerEnum ) const
+{
+  return header( mRequestHeaderConv[ headerEnum ] );
+}
+
 void QgsServerRequest::setHeader( const QString &name, const QString &value )
 {
   mHeaders.insert( name, value );
@@ -64,7 +85,6 @@ QMap<QString, QString> QgsServerRequest::headers() const
 {
   return mHeaders;
 }
-
 
 void QgsServerRequest::removeHeader( const QString &name )
 {
@@ -84,6 +104,16 @@ QUrl QgsServerRequest::originalUrl() const
 void QgsServerRequest::setOriginalUrl( const QUrl &url )
 {
   mOriginalUrl = url;
+}
+
+QUrl QgsServerRequest::baseUrl() const
+{
+  return mBaseUrl;
+}
+
+void QgsServerRequest::setBaseUrl( const QUrl &url )
+{
+  mBaseUrl = url;
 }
 
 QgsServerRequest::Method QgsServerRequest::method() const
@@ -148,4 +178,3 @@ const QString QgsServerRequest::queryParameter( const QString &name, const QStri
   }
   return QUrl::fromPercentEncoding( QUrlQuery( mUrl ).queryItemValue( name ).toUtf8() );
 }
-

--- a/src/server/qgsserverrequest.h
+++ b/src/server/qgsserverrequest.h
@@ -58,6 +58,34 @@ class SERVER_EXPORT QgsServerRequest
     };
     Q_ENUM( Method )
 
+    /**
+     * The internal HTTP Header used for the request as enum
+     */
+    enum RequestHeader
+    {
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
+      HOST,
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+      // https://tools.ietf.org/html/rfc7239
+      FORWARDED,
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+      X_FORWARDED_FOR,
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
+      X_FORWARDED_HOST,
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
+      X_FORWARDED_PROTO,
+      // The QGIS service URL
+      X_QGIS_SERVICE_URL,
+      // The QGIS WMS service URL
+      X_QGIS_WMS_SERVICE_URL,
+      // The QGIS WFS service URL
+      X_QGIS_WFS_SERVICE_URL,
+      // The QGIS WCS service URL
+      X_QGIS_WCS_SERVICE_URL,
+      // The QGIS WMTS service URL
+      X_QGIS_WMTS_SERVICE_URL,
+    };
+    Q_ENUM( RequestHeader )
 
     /**
      * Constructor
@@ -143,7 +171,14 @@ class SERVER_EXPORT QgsServerRequest
      * \param name of the header
      * \return the header value or an empty string
      */
-    QString header( const QString &name ) const;
+    virtual QString header( const QString &name ) const;
+
+    /**
+     * Returns the header value
+     * \param headerEnum of the header
+     * \return the header value or an empty string
+     */
+    virtual QString header( const RequestHeader &headerEnum ) const;
 
     /**
      * Set an header
@@ -159,9 +194,10 @@ class SERVER_EXPORT QgsServerRequest
     QMap<QString, QString> headers() const;
 
     /**
-    * Remove an header
-    * \param name
-    */
+     * Remove an header
+     * \param name
+     * \since QGIS 3.20
+     */
     void removeHeader( const QString &name );
 
     /**
@@ -186,6 +222,16 @@ class SERVER_EXPORT QgsServerRequest
     QUrl originalUrl() const;
 
     /**
+     * Returns the base URL of QGIS server
+     *
+     * E.g. if we call QGIS server with 'http://example.com/folder?REQUEST=WMS&...'
+     * the base URL will be 'http://example.com/folder'
+     *
+     * \since QGIS 3.20
+     */
+    QUrl baseUrl() const;
+
+    /**
      * Set the request method
      */
     void setMethod( QgsServerRequest::Method method );
@@ -206,17 +252,25 @@ class SERVER_EXPORT QgsServerRequest
      */
     void setOriginalUrl( const QUrl &url );
 
+    /**
+     * Set the base URL of QGIS server
+     *
+     * \since QGIS 3.20
+     */
+    void setBaseUrl( const QUrl &url );
 
   private:
     // Url as seen by QGIS server after web server rewrite
     QUrl       mUrl;
     // Unrewritten url as seen by the web server
     QUrl       mOriginalUrl;
+    QUrl       mBaseUrl;
     Method     mMethod = GetMethod;
     // We mark as mutable in order
     // to support lazy initialization
     mutable Headers mHeaders;
     QgsServerParameters mParams;
+    QMap<RequestHeader, QString> mRequestHeaderConv;
 };
 
 #endif

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -267,6 +267,60 @@ void QgsServerSettings::initSettings()
 
   mSettings[ sLogProfile.envVar ] = sLogProfile;
 
+  // the default service URL.
+  const Setting sServiceUrl = { QgsServerSettingsEnv::QGIS_SERVER_SERVICE_URL,
+                                QgsServerSettingsEnv::DEFAULT_VALUE,
+                                QStringLiteral( "The default service URL" ),
+                                QStringLiteral( "/qgis/server_service_url" ),
+                                QVariant::String,
+                                QVariant( "" ),
+                                QVariant()
+                              };
+  mSettings[ sServiceUrl.envVar ] = sServiceUrl;
+
+  // the default WMS service URL.
+  const Setting sWmsServiceUrl = { QgsServerSettingsEnv::QGIS_SERVER_WMS_SERVICE_URL,
+                                   QgsServerSettingsEnv::DEFAULT_VALUE,
+                                   QStringLiteral( "The default WMS service URL" ),
+                                   QStringLiteral( "/qgis/server_wms_service_url" ),
+                                   QVariant::String,
+                                   QVariant( "" ),
+                                   QVariant()
+                                 };
+  mSettings[ sServiceUrl.envVar ] = sWmsServiceUrl;
+
+  // the default WFS service URL.
+  const Setting sWfsServiceUrl = { QgsServerSettingsEnv::QGIS_SERVER_WFS_SERVICE_URL,
+                                   QgsServerSettingsEnv::DEFAULT_VALUE,
+                                   QStringLiteral( "The default WFS service URL" ),
+                                   QStringLiteral( "/qgis/server_wfs_service_url" ),
+                                   QVariant::String,
+                                   QVariant( "" ),
+                                   QVariant()
+                                 };
+  mSettings[ sServiceUrl.envVar ] = sWfsServiceUrl;
+
+  // the default WCS service URL.
+  const Setting sWcsServiceUrl = { QgsServerSettingsEnv::QGIS_SERVER_WCS_SERVICE_URL,
+                                   QgsServerSettingsEnv::DEFAULT_VALUE,
+                                   QStringLiteral( "The default WcS service URL" ),
+                                   QStringLiteral( "/qgis/server_wcs_service_url" ),
+                                   QVariant::String,
+                                   QVariant( "" ),
+                                   QVariant()
+                                 };
+  mSettings[ sServiceUrl.envVar ] = sWfsServiceUrl;
+
+  // the default WMTS service URL.
+  const Setting sWmtsServiceUrl = { QgsServerSettingsEnv::QGIS_SERVER_WMTS_SERVICE_URL,
+                                    QgsServerSettingsEnv::DEFAULT_VALUE,
+                                    QStringLiteral( "The default WMTS service URL" ),
+                                    QStringLiteral( "/qgis/server_wmts_service_url" ),
+                                    QVariant::String,
+                                    QVariant( "" ),
+                                    QVariant()
+                                  };
+  mSettings[ sServiceUrl.envVar ] = sWmtsServiceUrl;
 }
 
 void QgsServerSettings::load()
@@ -515,4 +569,32 @@ bool QgsServerSettings::getPrintDisabled() const
 bool QgsServerSettings::logProfile()
 {
   return value( QgsServerSettingsEnv::QGIS_SERVER_LOG_PROFILE, false ).toBool();
+}
+
+QString QgsServerSettings::serviceUrl( const QString &service ) const
+{
+  QString result;
+  if ( service.compare( QStringLiteral( "WMS" ) ) )
+  {
+    result = value( QgsServerSettingsEnv::QGIS_SERVER_WMS_SERVICE_URL ).toString();
+  }
+  else if ( service.compare( QStringLiteral( "WFS" ) ) )
+  {
+    result = value( QgsServerSettingsEnv::QGIS_SERVER_WFS_SERVICE_URL ).toString();
+  }
+  else if ( service.compare( QStringLiteral( "WCS" ) ) )
+  {
+    result = value( QgsServerSettingsEnv::QGIS_SERVER_WCS_SERVICE_URL ).toString();
+  }
+  else if ( service.compare( QStringLiteral( "WMTS" ) ) )
+  {
+    result = value( QgsServerSettingsEnv::QGIS_SERVER_WMTS_SERVICE_URL ).toString();
+  }
+
+  if ( result.isEmpty() )
+  {
+    result = value( QgsServerSettingsEnv::QGIS_SERVER_SERVICE_URL ).toString();
+  }
+
+  return result;
 }

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -71,6 +71,11 @@ class SERVER_EXPORT QgsServerSettingsEnv : public QObject
       QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES, //!< Directories used by the landing page service to find .qgs and .qgz projects (since QGIS 3.16)
       QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS, //!< PostgreSQL connection strings used by the landing page service to find projects (since QGIS 3.16)
       QGIS_SERVER_LOG_PROFILE, //!< When QGIS_SERVER_LOG_LEVEL is 0 this flag adds to the logs detailed information about the time taken by the different processing steps inside the QGIS Server request (since QGIS 3.16)
+      QGIS_SERVER_SERVICE_URL, //!< To set the service URL if it's not present in the project. (since QGIS 3.20).
+      QGIS_SERVER_WMS_SERVICE_URL, //!< To set the WMS service URL if it's not present in the project. (since QGIS 3.20).
+      QGIS_SERVER_WFS_SERVICE_URL, //!< To set the WFS service URL if it's not present in the project. (since QGIS 3.20).
+      QGIS_SERVER_WCS_SERVICE_URL, //!< To set the WCS service URL if it's not present in the project. (since QGIS 3.20).
+      QGIS_SERVER_WMTS_SERVICE_URL, //!< To set the WMTS service URL if it's not present in the project. (since QGIS 3.20).
     };
     Q_ENUM( EnvVar )
 };
@@ -275,6 +280,12 @@ class SERVER_EXPORT QgsServerSettings
      * \since QGIS 3.16
      */
     bool getPrintDisabled() const;
+
+    /**
+     * Returns the service URL from the setting.
+     * \since QGIS 3.20
+     */
+    QString serviceUrl( const QString &service ) const;
 
     /**
      * Returns the string representation of a setting.

--- a/src/server/services/landingpage/qgslandingpagehandlers.cpp
+++ b/src/server/services/landingpage/qgslandingpagehandlers.cpp
@@ -44,7 +44,7 @@ void QgsLandingPageHandler::handleRequest( const QgsServerApiContext &context ) 
   }
   else
   {
-    const json projects = projectsData( ) ;
+    const json projects = projectsData( *context.request() ) ;
     json data
     {
       { "links", links( context ) },
@@ -62,7 +62,7 @@ const QString QgsLandingPageHandler::templatePath( const QgsServerApiContext &co
   return path;
 }
 
-json QgsLandingPageHandler::projectsData() const
+json QgsLandingPageHandler::projectsData( const QgsServerRequest &request ) const
 {
   json j = json::array();
   const QMap<QString, QString> availableProjects = QgsLandingPageUtils::projects( *mSettings );
@@ -70,7 +70,7 @@ json QgsLandingPageHandler::projectsData() const
   {
     try
     {
-      j.push_back( QgsLandingPageUtils::projectInfo( it.value() ) );
+      j.push_back( QgsLandingPageUtils::projectInfo( it.value(), mSettings, request ) );
     }
     catch ( QgsServerException & )
     {
@@ -96,7 +96,7 @@ void QgsLandingPageMapHandler::handleRequest( const QgsServerApiContext &context
   {
     throw QgsServerApiNotFoundError( QStringLiteral( "Requested project hash not found!" ) );
   }
-  data[ "project" ] = QgsLandingPageUtils::projectInfo( projectPath, mSettings );
+  data[ "project" ] = QgsLandingPageUtils::projectInfo( projectPath, mSettings, *context.request() );
   write( data, context, {{ "pageTitle", linkTitle() }, { "navigation", json::array() }} );
 }
 

--- a/src/server/services/landingpage/qgslandingpagehandlers.h
+++ b/src/server/services/landingpage/qgslandingpagehandlers.h
@@ -21,6 +21,7 @@
 #include "qgsserversettings.h"
 #include "qgsserverogcapihandler.h"
 #include "qgsfields.h"
+#include "qgsserverrequest.h"
 
 class QgsFeatureRequest;
 class QgsServerOgcApi;
@@ -56,7 +57,7 @@ class QgsLandingPageHandler: public QgsServerOgcApiHandler
   private:
 
 
-    json projectsData() const;
+    json projectsData( const QgsServerRequest &request ) const;
 
     const QgsServerSettings *mSettings = nullptr;
 };

--- a/src/server/services/landingpage/qgslandingpageutils.cpp
+++ b/src/server/services/landingpage/qgslandingpageutils.cpp
@@ -147,7 +147,7 @@ QMap<QString, QString> QgsLandingPageUtils::projects( const QgsServerSettings &s
   return AVAILABLE_PROJECTS;
 }
 
-json QgsLandingPageUtils::projectInfo( const QString &projectUri, const QgsServerSettings *serverSettings )
+json QgsLandingPageUtils::projectInfo( const QString &projectUri, const QgsServerSettings *serverSettings, const QgsServerRequest &request )
 {
   // Helper for QStringList
   auto jList = [ ]( const QStringList & l ) -> json
@@ -398,9 +398,9 @@ json QgsLandingPageUtils::projectInfo( const QString &projectUri, const QgsServe
     capabilities["owsServiceOnlineResource"] = QgsServerProjectUtils::owsServiceOnlineResource( *p ).toStdString();
     capabilities["owsServiceTitle"] = QgsServerProjectUtils::owsServiceTitle( *p ).toStdString();
     capabilities["wcsLayerIds"] = jList( QgsServerProjectUtils::wcsLayerIds( *p ) );
-    capabilities["wcsServiceUrl"] = QgsServerProjectUtils::wcsServiceUrl( *p ).toStdString();
+    capabilities["wcsServiceUrl"] = QgsServerProjectUtils::wcsServiceUrl( *p, request, *serverSettings ).toStdString();
     capabilities["wfsLayerIds"] = jList( QgsServerProjectUtils::wfsLayerIds( *p ) );
-    capabilities["wfsServiceUrl"] = QgsServerProjectUtils::wfsServiceUrl( *p ).toStdString();
+    capabilities["wfsServiceUrl"] = QgsServerProjectUtils::wfsServiceUrl( *p, request, *serverSettings ).toStdString();
     capabilities["wfstDeleteLayerIds"] = jList( QgsServerProjectUtils::wfstDeleteLayerIds( *p ) );
     capabilities["wfstInsertLayerIds"] = jList( QgsServerProjectUtils::wfstInsertLayerIds( *p ) );
     capabilities["wfstUpdateLayerIds"] = jList( QgsServerProjectUtils::wfstUpdateLayerIds( *p ) );
@@ -428,10 +428,10 @@ json QgsLandingPageUtils::projectInfo( const QString &projectUri, const QgsServe
     capabilities["wmsRestrictedComposers"] = jList( QgsServerProjectUtils::wmsRestrictedComposers( *p ) );
     capabilities["wmsRestrictedLayers"] = jList( QgsServerProjectUtils::wmsRestrictedLayers( *p ) );
     capabilities["wmsRootName"] = QgsServerProjectUtils::wmsRootName( *p ).toStdString();
-    capabilities["wmsServiceUrl"] = QgsServerProjectUtils::wmsServiceUrl( *p ).toStdString();
+    capabilities["wmsServiceUrl"] = QgsServerProjectUtils::wmsServiceUrl( *p, request, *serverSettings ).toStdString();
     capabilities["wmsTileBuffer"] = QgsServerProjectUtils::wmsTileBuffer( *p );
     capabilities["wmsUseLayerIds"] = QgsServerProjectUtils::wmsUseLayerIds( *p );
-    capabilities["wmtsServiceUrl" ] = QgsServerProjectUtils::wmtsServiceUrl( *p ).toStdString();
+    capabilities["wmtsServiceUrl" ] = QgsServerProjectUtils::wmtsServiceUrl( *p, request, *serverSettings ).toStdString();
     info["capabilities"] = capabilities;
     // WMS layers
     info[ "wms_root_name" ] = QgsServerProjectUtils::wmsRootName( *p ).toStdString();

--- a/src/server/services/landingpage/qgslandingpageutils.h
+++ b/src/server/services/landingpage/qgslandingpageutils.h
@@ -22,6 +22,7 @@
 
 #include "nlohmann/json_fwd.hpp"
 #include "qgsserversettings.h"
+#include "qgsserverrequest.h"
 
 #ifndef SIP_RUN
 using namespace nlohmann;
@@ -49,9 +50,9 @@ struct QgsLandingPageUtils
   static QMap<QString, QString> projects( const QgsServerSettings &settings );
 
   /**
-   * Returns project information for a given \a projectPath and optional \a serverSettings
+   * Returns project information for a given \a projectPath, optional \a serverSettings and \a request
    */
-  static json projectInfo( const QString &projectPath, const QgsServerSettings *serverSettings = nullptr );
+  static json projectInfo( const QString &projectPath, const QgsServerSettings *serverSettings = nullptr, const QgsServerRequest &request = QgsServerRequest() );
 
   /**
    * Returns the layer tree information for the given \a project

--- a/src/server/services/wcs/qgswcsgetcapabilities.cpp
+++ b/src/server/services/wcs/qgswcsgetcapabilities.cpp
@@ -102,7 +102,7 @@ namespace QgsWcs
     dcpTypeElement.appendChild( httpElement );
 
     //Prepare url
-    QString hrefString = serviceUrl( request, project );
+    QString hrefString = serviceUrl( request, project, *serverIface->serverSettings() );
 
     QDomElement getElement = doc.createElement( QStringLiteral( "Get" )/*wcs:Get*/ );
     httpElement.appendChild( getElement );

--- a/src/server/services/wcs/qgswcsutils.cpp
+++ b/src/server/services/wcs/qgswcsutils.cpp
@@ -251,7 +251,7 @@ namespace QgsWcs
   }
 
 
-  QString serviceUrl( const QgsServerRequest &request, const QgsProject *project )
+  QString serviceUrl( const QgsServerRequest &request, const QgsProject *project, const QgsServerSettings &settings )
   {
     static QSet< QString > sFilter
     {
@@ -261,11 +261,7 @@ namespace QgsWcs
       QStringLiteral( "_DC" )
     };
 
-    QString href;
-    if ( project )
-    {
-      href = QgsServerProjectUtils::wcsServiceUrl( *project );
-    }
+    QString href = QgsServerProjectUtils::wcsServiceUrl( project ? *project : *QgsProject::instance(), request, settings );
 
     // Build default url
     if ( href.isEmpty() )

--- a/src/server/services/wcs/qgswcsutils.h
+++ b/src/server/services/wcs/qgswcsutils.h
@@ -23,6 +23,7 @@
 
 #include "qgsmodule.h"
 #include "qgswcsserviceexception.h"
+#include "qgsserversettings.h"
 
 #include "qgsrasterlayer.h"
 
@@ -50,7 +51,7 @@ namespace QgsWcs
   /**
    * Service URL string
    */
-  QString serviceUrl( const QgsServerRequest &request, const QgsProject *project );
+  QString serviceUrl( const QgsServerRequest &request, const QgsProject *project, const QgsServerSettings &settings );
 
   /**
    * Parse bounding box

--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -96,7 +96,7 @@ namespace QgsWfs
     wfsCapabilitiesElement.appendChild( getServiceProviderElement( doc, project ) );
 
     //wfs:OperationsMetadata
-    wfsCapabilitiesElement.appendChild( getOperationsMetadataElement( doc, project, request ) );
+    wfsCapabilitiesElement.appendChild( getOperationsMetadataElement( doc, project, request, serverIface->serverSettings() ) );
 
     //wfs:FeatureTypeList
     wfsCapabilitiesElement.appendChild( getFeatureTypeListElement( doc, serverIface, project ) );
@@ -344,12 +344,12 @@ namespace QgsWfs
     return parameterElement;
   }
 
-  QDomElement getOperationsMetadataElement( QDomDocument &doc, const QgsProject *project, const QgsServerRequest &request )
+  QDomElement getOperationsMetadataElement( QDomDocument &doc, const QgsProject *project, const QgsServerRequest &request, const QgsServerSettings *settings )
   {
     QDomElement oprationsElement = doc.createElement( QStringLiteral( "ows:OperationsMetadata" ) );
 
-    //Prepare url
-    QString hrefString = serviceUrl( request, project );
+    // Prepare url
+    QString hrefString = serviceUrl( request, project, *settings );
 
     QDomElement operationElement = doc.createElement( QStringLiteral( "ows:Operation" ) );
     QDomElement dcpElement = doc.createElement( QStringLiteral( "ows:DCP" ) );

--- a/src/server/services/wfs/qgswfsgetcapabilities.h
+++ b/src/server/services/wfs/qgswfsgetcapabilities.h
@@ -40,7 +40,7 @@ namespace QgsWfs
   /**
    * Create OperationsMetadata element for get capabilities document
    */
-  QDomElement getOperationsMetadataElement( QDomDocument &doc, const QgsProject *project, const QgsServerRequest &request );
+  QDomElement getOperationsMetadataElement( QDomDocument &doc, const QgsProject *project, const QgsServerRequest &request, const QgsServerSettings *settings );
 
   /**
    * Create Service Provider element for get capabilities document

--- a/src/server/services/wfs/qgswfsgetcapabilities_1_0_0.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities_1_0_0.cpp
@@ -94,7 +94,7 @@ namespace QgsWfs
       wfsCapabilitiesElement.appendChild( getServiceElement( doc, project ) );
 
       //wfs:Capability
-      wfsCapabilitiesElement.appendChild( getCapabilityElement( doc, project, request ) );
+      wfsCapabilitiesElement.appendChild( getCapabilityElement( doc, project, request, serverIface->serverSettings() ) );
 
       //wfs:FeatureTypeList
       wfsCapabilitiesElement.appendChild( getFeatureTypeListElement( doc, serverIface, project ) );
@@ -198,7 +198,7 @@ namespace QgsWfs
 
     }
 
-    QDomElement getCapabilityElement( QDomDocument &doc, const QgsProject *project, const QgsServerRequest &request )
+    QDomElement getCapabilityElement( QDomDocument &doc, const QgsProject *project, const QgsServerRequest &request, const QgsServerSettings *settings )
     {
       //wfs:Capability element
       QDomElement capabilityElement = doc.createElement( QStringLiteral( "Capability" )/*wfs:Capability*/ );
@@ -216,7 +216,7 @@ namespace QgsWfs
       dcpTypeElement.appendChild( httpElement );
 
       //Prepare url
-      QString hrefString = serviceUrl( request, project );
+      QString hrefString = serviceUrl( request, project, *settings );
 
       //only Get supported for the moment
       QDomElement getElement = doc.createElement( QStringLiteral( "Get" )/*wfs:Get*/ );

--- a/src/server/services/wfs/qgswfsgetcapabilities_1_0_0.h
+++ b/src/server/services/wfs/qgswfsgetcapabilities_1_0_0.h
@@ -37,7 +37,7 @@ namespace QgsWfs
     /**
      * Create Capability element for get capabilities document
      */
-    QDomElement getCapabilityElement( QDomDocument &doc, const QgsProject *project, const QgsServerRequest &request );
+    QDomElement getCapabilityElement( QDomDocument &doc, const QgsProject *project, const QgsServerRequest &request, const QgsServerSettings *settings );
 
     /**
      * Create Service element for get capabilities document

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -72,11 +72,11 @@ namespace QgsWfs
     QDomElement createFeatureGML3( const QgsFeature &feature, QDomDocument &doc, const createFeatureParams &params, const QgsProject *project, const QgsAttributeList &pkAttributes );
 
     void hitGetFeature( const QgsServerRequest &request, QgsServerResponse &response, const QgsProject *project,
-                        QgsWfsParameters::Format format, int numberOfFeatures, const QStringList &typeNames );
+                        QgsWfsParameters::Format format, int numberOfFeatures, const QStringList &typeNames, const QgsServerSettings *serverSettings );
 
     void startGetFeature( const QgsServerRequest &request, QgsServerResponse &response, const QgsProject *project,
                           QgsWfsParameters::Format format, int prec, QgsCoordinateReferenceSystem &crs,
-                          QgsRectangle *rect, const QStringList &typeNames );
+                          QgsRectangle *rect, const QStringList &typeNames, const QgsServerSettings *settings );
 
     void setGetFeature( QgsServerResponse &response, QgsWfsParameters::Format format, const QgsFeature &feature, int featIdx,
                         const createFeatureParams &params, const QgsProject *project, const QgsAttributeList &pkAttributes = QgsAttributeList() );
@@ -436,7 +436,7 @@ namespace QgsWfs
         while ( fit.nextFeature( feature ) && ( aRequest.maxFeatures == -1 || sentFeatures < aRequest.maxFeatures ) )
         {
           if ( iteratedFeatures == aRequest.startIndex )
-            startGetFeature( request, response, project, aRequest.outputFormat, requestPrecision, requestCrs, &requestRect, typeNameList );
+            startGetFeature( request, response, project, aRequest.outputFormat, requestPrecision, requestCrs, &requestRect, typeNameList, serverIface->serverSettings() );
 
           if ( iteratedFeatures >= aRequest.startIndex )
           {
@@ -455,13 +455,13 @@ namespace QgsWfs
 
     if ( mWfsParameters.resultType() == QgsWfsParameters::ResultType::HITS )
     {
-      hitGetFeature( request, response, project, aRequest.outputFormat, sentFeatures, typeNameList );
+      hitGetFeature( request, response, project, aRequest.outputFormat, sentFeatures, typeNameList, serverIface->serverSettings() );
     }
     else
     {
       // End of GetFeature
       if ( iteratedFeatures <= aRequest.startIndex )
-        startGetFeature( request, response, project, aRequest.outputFormat, requestPrecision, requestCrs, &requestRect, typeNameList );
+        startGetFeature( request, response, project, aRequest.outputFormat, requestPrecision, requestCrs, &requestRect, typeNameList, serverIface->serverSettings() );
       endGetFeature( response, aRequest.outputFormat );
     }
 
@@ -1013,7 +1013,7 @@ namespace QgsWfs
 
 
     void hitGetFeature( const QgsServerRequest &request, QgsServerResponse &response, const QgsProject *project, QgsWfsParameters::Format format,
-                        int numberOfFeatures, const QStringList &typeNames )
+                        int numberOfFeatures, const QStringList &typeNames, const QgsServerSettings *settings )
     {
       QDateTime now = QDateTime::currentDateTime();
       QString fcString;
@@ -1034,7 +1034,7 @@ namespace QgsWfs
           response.setHeader( "Content-Type", "text/xml; subtype=gml/3.1.1; charset=utf-8" );
 
         //Prepare url
-        QString hrefString = serviceUrl( request, project );
+        QString hrefString = serviceUrl( request, project, *settings );
 
         QUrl mapUrl( hrefString );
 
@@ -1091,7 +1091,7 @@ namespace QgsWfs
     }
 
     void startGetFeature( const QgsServerRequest &request, QgsServerResponse &response, const QgsProject *project, QgsWfsParameters::Format format,
-                          int prec, QgsCoordinateReferenceSystem &crs, QgsRectangle *rect, const QStringList &typeNames )
+                          int prec, QgsCoordinateReferenceSystem &crs, QgsRectangle *rect, const QStringList &typeNames, const QgsServerSettings *settings )
     {
       QString fcString;
 
@@ -1136,7 +1136,7 @@ namespace QgsWfs
           response.setHeader( "Content-Type", "text/xml; subtype=gml/3.1.1; charset=utf-8" );
 
         //Prepare url
-        QString hrefString = serviceUrl( request, project );
+        QString hrefString = serviceUrl( request, project, *settings );
 
         QUrl mapUrl( hrefString );
 

--- a/src/server/services/wfs/qgswfsutils.cpp
+++ b/src/server/services/wfs/qgswfsutils.cpp
@@ -34,13 +34,10 @@ namespace QgsWfs
     return QStringLiteral( "1.1.0" );
   }
 
-  QString serviceUrl( const QgsServerRequest &request, const QgsProject *project )
+  QString serviceUrl( const QgsServerRequest &request, const QgsProject *project, const QgsServerSettings &settings )
   {
     QUrl href;
-    if ( project )
-    {
-      href.setUrl( QgsServerProjectUtils::wfsServiceUrl( *project ) );
-    }
+    href.setUrl( QgsServerProjectUtils::wfsServiceUrl( project ? *project : *QgsProject::instance(), request, settings ) );
 
     // Build default url
     if ( href.isEmpty() )

--- a/src/server/services/wfs/qgswfsutils.h
+++ b/src/server/services/wfs/qgswfsutils.h
@@ -27,6 +27,7 @@
 #include "qgsmodule.h"
 #include "qgsfeaturerequest.h"
 #include "qgswfsserviceexception.h"
+#include "qgsserversettings.h"
 
 /**
  * \ingroup server
@@ -45,7 +46,7 @@ namespace QgsWfs
   /**
    * Service URL string
    */
-  QString serviceUrl( const QgsServerRequest &request, const QgsProject *project );
+  QString serviceUrl( const QgsServerRequest &request, const QgsProject *project, const QgsServerSettings &settings );
 
   /**
    * Returns typename from vector layer

--- a/src/server/services/wms/qgswmsdescribelayer.cpp
+++ b/src/server/services/wms/qgswmsdescribelayer.cpp
@@ -90,11 +90,11 @@ namespace QgsWms
 
     // get the wms service url defined in project or keep the one from the
     // request url
-    QString wmsHrefString = serviceUrl( request, project ).toString();
+    QString wmsHrefString = serviceUrl( request, project, *serverIface->serverSettings() ).toString();
 
     // get the wfs service url defined in project or take the same as the
     // wms service url
-    QString wfsHrefString = QgsServerProjectUtils::wfsServiceUrl( *project );
+    QString wfsHrefString = QgsServerProjectUtils::wfsServiceUrl( *project, request, *serverIface->serverSettings() );
     if ( wfsHrefString.isEmpty() )
     {
       wfsHrefString = wmsHrefString;
@@ -102,7 +102,7 @@ namespace QgsWms
 
     // get the wcs service url defined in project or take the same as the
     // wms service url
-    QString wcsHrefString = QgsServerProjectUtils::wcsServiceUrl( *project );
+    QString wcsHrefString = QgsServerProjectUtils::wcsServiceUrl( *project, request, *serverIface->serverSettings() );
     if ( wcsHrefString.isEmpty() )
     {
       wcsHrefString = wmsHrefString;

--- a/src/server/services/wms/qgswmsgetcapabilities.h
+++ b/src/server/services/wms/qgswmsgetcapabilities.h
@@ -66,7 +66,7 @@ namespace QgsWms
    * Create Service element for get capabilities document
    */
   QDomElement getServiceElement( QDomDocument &doc, const QgsProject *project,
-                                 const QgsWmsRequest &request );
+                                 const QgsWmsRequest &request, const QgsServerSettings *serverSettings );
 
   /**
    * Output GetCapabilities response

--- a/src/server/services/wms/qgswmsgetcontext.cpp
+++ b/src/server/services/wms/qgswmsgetcontext.cpp
@@ -332,7 +332,7 @@ namespace QgsWms
           layerElem.appendChild( formatElem );
 
           // Get WMS service URL for Server Element
-          QUrl href = serviceUrl( request, project );
+          QUrl href = serviceUrl( request, project, *serverIface->serverSettings() );
 
           //href needs to be a prefix
           QString hrefString = href.toString();

--- a/src/server/services/wms/qgswmsutils.cpp
+++ b/src/server/services/wms/qgswmsutils.cpp
@@ -26,16 +26,14 @@
 #include "qgsmediancut.h"
 #include "qgsserverprojectutils.h"
 #include "qgswmsserviceexception.h"
+#include "qgsproject.h"
 
 namespace QgsWms
 {
-  QUrl serviceUrl( const QgsServerRequest &request, const QgsProject *project )
+  QUrl serviceUrl( const QgsServerRequest &request, const QgsProject *project, const QgsServerSettings &settings )
   {
     QUrl href;
-    if ( project )
-    {
-      href.setUrl( QgsServerProjectUtils::wmsServiceUrl( *project ) );
-    }
+    href.setUrl( QgsServerProjectUtils::wmsServiceUrl( project ? *project : *QgsProject::instance(), request, settings ) );
 
     // Build default url
     if ( href.isEmpty() )

--- a/src/server/services/wms/qgswmsutils.h
+++ b/src/server/services/wms/qgswmsutils.h
@@ -24,6 +24,7 @@
 #define QGSWMSUTILS_H
 
 #include "qgsmodule.h"
+#include "qgsserversettings.h"
 
 class QgsRectangle;
 
@@ -50,7 +51,7 @@ namespace QgsWms
   /**
    * Returns WMS service URL
    */
-  QUrl serviceUrl( const QgsServerRequest &request, const QgsProject *project );
+  QUrl serviceUrl( const QgsServerRequest &request, const QgsProject *project, const QgsServerSettings &settings );
 
   /**
    * Parse image format parameter

--- a/src/server/services/wmts/qgswmtsgetcapabilities.cpp
+++ b/src/server/services/wmts/qgswmtsgetcapabilities.cpp
@@ -96,7 +96,7 @@ namespace QgsWmts
     wmtsCapabilitiesElement.appendChild( getServiceProviderElement( doc, project ) );
 
     //INSERT OperationsMetadata
-    wmtsCapabilitiesElement.appendChild( getOperationsMetadataElement( doc, project, request ) );
+    wmtsCapabilitiesElement.appendChild( getOperationsMetadataElement( doc, project, request, serverIface->serverSettings() ) );
 
     //INSERT Contents
     wmtsCapabilitiesElement.appendChild( getContentsElement( doc, serverIface, project ) );
@@ -256,7 +256,7 @@ namespace QgsWmts
     return serviceElem;
   }
 
-  QDomElement getOperationsMetadataElement( QDomDocument &doc, const QgsProject *project, const QgsServerRequest &request )
+  QDomElement getOperationsMetadataElement( QDomDocument &doc, const QgsProject *project, const QgsServerRequest &request, const QgsServerSettings *settings )
   {
     //ows:OperationsMetadata element
     QDomElement operationsMetadataElement = doc.createElement( QStringLiteral( "ows:OperationsMetadata" )/*ows:OperationsMetadata*/ );
@@ -273,7 +273,7 @@ namespace QgsWmts
     dcpElement.appendChild( httpElement );
 
     // Get service URL
-    const QUrl href = serviceUrl( request, project );
+    const QUrl href = serviceUrl( request, project, *settings );
 
     //href needs to be a prefix
     QString hrefString = href.toString();

--- a/src/server/services/wmts/qgswmtsgetcapabilities.h
+++ b/src/server/services/wmts/qgswmtsgetcapabilities.h
@@ -30,7 +30,7 @@ namespace QgsWmts
   /**
    * Create OperationsMetadata element for get capabilities document
    */
-  QDomElement getOperationsMetadataElement( QDomDocument &doc, const QgsProject *project, const QgsServerRequest &request );
+  QDomElement getOperationsMetadataElement( QDomDocument &doc, const QgsProject *project, const QgsServerRequest &request, const QgsServerSettings *settings );
 
   /**
    * Create ServiceProvider element for get capabilities document

--- a/src/server/services/wmts/qgswmtsutils.cpp
+++ b/src/server/services/wmts/qgswmtsutils.cpp
@@ -48,13 +48,9 @@ namespace QgsWmts
   }
 
 
-  QString serviceUrl( const QgsServerRequest &request, const QgsProject *project )
+  QString serviceUrl( const QgsServerRequest &request, const QgsProject *project, const QgsServerSettings &settings )
   {
-    QString href;
-    if ( project )
-    {
-      href = QgsServerProjectUtils::wmtsServiceUrl( *project );
-    }
+    QString href = QgsServerProjectUtils::wmtsServiceUrl( project ? *project : *QgsProject::instance(), request, settings );
 
     // Build default url
     if ( href.isEmpty() )

--- a/src/server/services/wmts/qgswmtsutils.h
+++ b/src/server/services/wmts/qgswmtsutils.h
@@ -22,6 +22,7 @@
 #include "qgsmodule.h"
 #include "qgswmtsparameters.h"
 #include "qgswmtsserviceexception.h"
+#include "qgsserversettings.h"
 
 #include <QDomDocument>
 
@@ -125,7 +126,7 @@ namespace QgsWmts
   /**
    * Service URL string
    */
-  QString serviceUrl( const QgsServerRequest &request, const QgsProject *project );
+  QString serviceUrl( const QgsServerRequest &request, const QgsProject *project, const QgsServerSettings &settings );
 
   // Define namespaces used in WMTS documents
   const QString WMTS_NAMESPACE = QStringLiteral( "http://www.opengis.net/wmts/1.0" );

--- a/tests/src/python/test_qgsserver.py
+++ b/tests/src/python/test_qgsserver.py
@@ -256,8 +256,8 @@ class QgsServerTestBase(unittest.TestCase):
 
         self.assertTrue(test, message)
 
-    def _execute_request(self, qs, requestMethod=QgsServerRequest.GetMethod, data=None):
-        request = QgsBufferServerRequest(qs, requestMethod, {}, data)
+    def _execute_request(self, qs, requestMethod=QgsServerRequest.GetMethod, data=None, request_headers=None):
+        request = QgsBufferServerRequest(qs, requestMethod, request_headers or {}, data)
         response = QgsBufferServerResponse()
         self.server.handleRequest(request, response)
         headers = []
@@ -452,6 +452,56 @@ class TestQgsServer(QgsServerTestBase):
                 self.assertEqual("\"my_wcs_advertised_url" in item, True)
                 item_found = True
         self.assertTrue(item_found)
+
+        # Service URL in header
+        for header_name, header_value in (("X-Qgis-Service-Url", "http://test1"), ("X-Qgis-Wcs-Service-Url", "http://test2")):
+            # empty url in project
+            project = os.path.join(self.testdata_path, "test_project_without_urls.qgs")
+            qs = "?" + "&".join(["%s=%s" % i for i in list({
+                "MAP": urllib.parse.quote(project),
+                "SERVICE": "WCS",
+                "VERSION": "1.0.0",
+                "REQUEST": "GetCapabilities",
+                "STYLES": ""
+            }.items())])
+
+            r, h = self._result(self._execute_request(qs, request_headers={header_name: header_value}))
+
+            item_found = False
+            for item in str(r).split("\\n"):
+                if "OnlineResource" in item:
+                    print(item)
+                    print(header_name)
+                    print(header_value)
+                    self.assertEqual(header_value in item, True)
+                    item_found = True
+            self.assertTrue(item_found)
+
+        # Other headers combinaison
+        for headers, online_resource in (
+            ({"Forwarded": "host=test3;proto=https"}, "https://test3"),
+            ({"Forwarded": "host=test4;proto=https, host=test5;proto=https"}, "https://test4"),
+            ({"X-Forwarded-Host": "test6", "X-Forwarded-Proto": "https"}, "https://test6"),
+            ({"Host": "test7"}, "test7"),
+        ):
+            # empty url in project
+            project = os.path.join(self.testdata_path, "test_project_without_urls.qgs")
+            qs = "?" + "&".join(["%s=%s" % i for i in list({
+                "MAP": urllib.parse.quote(project),
+                "SERVICE": "WCS",
+                "VERSION": "1.0.0",
+                "REQUEST": "GetCapabilities",
+                "STYLES": ""
+            }.items())])
+
+            r, h = self._result(self._execute_request(qs, request_headers=headers))
+
+            item_found = False
+            for item in str(r).split("\\n"):
+                if "OnlineResource" in item:
+                    self.assertEqual(online_resource in item, True)
+                    item_found = True
+            self.assertTrue(item_found)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsserver_landingpage.py
+++ b/tests/src/python/test_qgsserver_landingpage.py
@@ -123,6 +123,7 @@ class QgsServerLandingPageTest(QgsServerAPITestBase):
         """Test landing page in JSON format"""
 
         request = QgsBufferServerRequest('http://server.qgis.org/index.json')
+        request.setBaseUrl(QtCore.QUrl('http://server.qgis.org/'))
         response = QgsBufferServerResponse()
         self.server.handleRequest(request, response)
         j_actual = 'Content-Type: application/json\n\n'

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -35,7 +35,7 @@ from test_qgsserver import QgsServerTestBase
 from qgis.core import QgsProject
 
 # Strip path and content length because path may vary
-RE_STRIP_UNCHECKABLE = b'MAP=[^"]+|Content-Length: \\d+'
+RE_STRIP_UNCHECKABLE = b'MAP=[^"]+|SERVICE=[^"]+|Content-Length: \\d+'
 RE_STRIP_EXTENTS = b'<(north|east|south|west)Bound(Lat|Long)itude>.*</(north|east|south|west)Bound(Lat|Long)itude>|<BoundingBox .*/>'
 RE_ATTRIBUTES = b'[^>\\s]+=[^>\\s]+'
 
@@ -93,11 +93,11 @@ class TestQgsServerWMS(TestQgsServerWMSTestBase):
     """QGIS Server WMS Tests"""
 
     def test_getcapabilities(self):
-        self.wms_request_compare('GetCapabilities')
+        self.wms_request_compare('GetCapabilities', reference_file="getcapabilities-map")
 
     def test_getcapabilities_case_insensitive(self):
-        self.wms_request_compare('getcapabilities')
-        self.wms_request_compare('GETCAPABILITIES')
+        self.wms_request_compare('getcapabilities', reference_file="getcapabilities-map")
+        self.wms_request_compare('GETCAPABILITIES', reference_file="getcapabilities-map")
 
     def test_getprojectsettings(self):
         self.wms_request_compare('GetProjectSettings')

--- a/tests/testdata/qgis_server/getcapabilities-map.txt
+++ b/tests/testdata/qgis_server/getcapabilities-map.txt
@@ -10,7 +10,7 @@ Content-Type: text/xml; charset=utf-8
   <KeywordList>
    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
   </KeywordList>
-  <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+  <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?*****" xmlns:xlink="http://www.w3.org/1999/xlink"/>
   <ContactInformation>
    <ContactPersonPrimary>
     <ContactPerson>Alessandro Pasotti</ContactPerson>
@@ -28,7 +28,7 @@ Content-Type: text/xml; charset=utf-8
     <DCPType>
      <HTTP>
       <Get>
-       <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+       <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?*****" xmlns:xlink="http://www.w3.org/1999/xlink"/>
       </Get>
      </HTTP>
     </DCPType>
@@ -43,7 +43,7 @@ Content-Type: text/xml; charset=utf-8
     <DCPType>
      <HTTP>
       <Get>
-       <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+       <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?*****" xmlns:xlink="http://www.w3.org/1999/xlink"/>
       </Get>
      </HTTP>
     </DCPType>
@@ -59,7 +59,7 @@ Content-Type: text/xml; charset=utf-8
     <DCPType>
      <HTTP>
       <Get>
-       <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+       <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?*****" xmlns:xlink="http://www.w3.org/1999/xlink"/>
       </Get>
      </HTTP>
     </DCPType>
@@ -71,7 +71,7 @@ Content-Type: text/xml; charset=utf-8
     <DCPType>
      <HTTP>
       <Get>
-       <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+       <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?*****" xmlns:xlink="http://www.w3.org/1999/xlink"/>
       </Get>
      </HTTP>
     </DCPType>
@@ -81,7 +81,7 @@ Content-Type: text/xml; charset=utf-8
     <DCPType>
      <HTTP>
       <Get>
-       <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+       <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?*****" xmlns:xlink="http://www.w3.org/1999/xlink"/>
       </Get>
      </HTTP>
     </DCPType>
@@ -91,7 +91,7 @@ Content-Type: text/xml; charset=utf-8
     <DCPType>
      <HTTP>
       <Get>
-       <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+       <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?*****" xmlns:xlink="http://www.w3.org/1999/xlink"/>
       </Get>
      </HTTP>
     </DCPType>

--- a/tests/testdata/qgis_server/getcapabilities_without_map_param.txt
+++ b/tests/testdata/qgis_server/getcapabilities_without_map_param.txt
@@ -10,7 +10,7 @@ Content-Type: text/xml; charset=utf-8
   <KeywordList>
    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
   </KeywordList>
-  <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+  <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?" xmlns:xlink="http://www.w3.org/1999/xlink"/>
   <ContactInformation>
    <ContactPersonPrimary>
     <ContactPerson>Alessandro Pasotti</ContactPerson>

--- a/tests/testdata/qgis_server/landingpage/test_landing_page_with_pg_index.json
+++ b/tests/testdata/qgis_server/landingpage/test_landing_page_with_pg_index.json
@@ -34,9 +34,9 @@ Content-Type: application/json
         "owsServiceOnlineResource": "Service Capabilities Oline Resource",
         "owsServiceTitle": "Service Capabilities Title",
         "wcsLayerIds": [],
-        "wcsServiceUrl": "",
+        "wcsServiceUrl": "http://server.qgis.org/",
         "wfsLayerIds": [],
-        "wfsServiceUrl": "",
+        "wfsServiceUrl": "http://server.qgis.org/",
         "wfstDeleteLayerIds": [],
         "wfstInsertLayerIds": [],
         "wfstUpdateLayerIds": [],
@@ -68,10 +68,10 @@ Content-Type: application/json
           "points restricted"
         ],
         "wmsRootName": "ShortNameForRootLayer",
-        "wmsServiceUrl": "",
+        "wmsServiceUrl": "http://server.qgis.org/",
         "wmsTileBuffer": 0,
         "wmsUseLayerIds": true,
-        "wmtsServiceUrl": ""
+        "wmtsServiceUrl": "http://server.qgis.org/"
       },
       "crs": "EPSG:4326",
       "description": "Metadata abstract lorem ipsum...",
@@ -267,9 +267,9 @@ Content-Type: application/json
         "owsServiceOnlineResource": "Service Capabilities Oline Resource",
         "owsServiceTitle": "Service Capabilities Title",
         "wcsLayerIds": [],
-        "wcsServiceUrl": "",
+        "wcsServiceUrl": "http://server.qgis.org/",
         "wfsLayerIds": [],
-        "wfsServiceUrl": "",
+        "wfsServiceUrl": "http://server.qgis.org/",
         "wfstDeleteLayerIds": [],
         "wfstInsertLayerIds": [],
         "wfstUpdateLayerIds": [],
@@ -301,10 +301,10 @@ Content-Type: application/json
           "points restricted"
         ],
         "wmsRootName": "ShortNameForRootLayer",
-        "wmsServiceUrl": "",
+        "wmsServiceUrl": "http://server.qgis.org/",
         "wmsTileBuffer": 0,
         "wmsUseLayerIds": true,
-        "wmtsServiceUrl": ""
+        "wmtsServiceUrl": "http://server.qgis.org/"
       },
       "crs": "EPSG:4326",
       "description": "Metadata abstract lorem ipsum...",
@@ -497,14 +497,14 @@ Content-Type: application/json
         "owsServiceOnlineResource": "",
         "owsServiceTitle": "QGIS Server - Grouped Nested Layer",
         "wcsLayerIds": [],
-        "wcsServiceUrl": "",
+        "wcsServiceUrl": "http://server.qgis.org/",
         "wfsLayerIds": [
           "as_areas_bbe3c71b_356c_49f5_9fc2_ae771bcdd467",
           "as_symbols_3a1cdeef_9082_4d07_be5c_47c956bd7e76",
           "cdb_labels_8ee74af8_e7ba_4d80_9e0d_5b0b956d3daf",
           "cdb_lines_3f5c3c6d_db6d_4681_9291_7109f8d69f8b"
         ],
-        "wfsServiceUrl": "",
+        "wfsServiceUrl": "http://server.qgis.org/",
         "wfstDeleteLayerIds": [
           "as_areas_bbe3c71b_356c_49f5_9fc2_ae771bcdd467",
           "as_symbols_3a1cdeef_9082_4d07_be5c_47c956bd7e76",
@@ -550,10 +550,10 @@ Content-Type: application/json
         "wmsRestrictedComposers": [],
         "wmsRestrictedLayers": [],
         "wmsRootName": "",
-        "wmsServiceUrl": "",
+        "wmsServiceUrl": "http://server.qgis.org/",
         "wmsTileBuffer": 0,
         "wmsUseLayerIds": false,
-        "wmtsServiceUrl": ""
+        "wmtsServiceUrl": "http://server.qgis.org/"
       },
       "crs": "EPSG:4326",
       "description": "",
@@ -2970,11 +2970,11 @@ Content-Type: application/json
         "owsServiceOnlineResource": "Service Capabilities Oline Resource",
         "owsServiceTitle": "Service Capabilities Title",
         "wcsLayerIds": [],
-        "wcsServiceUrl": "",
+        "wcsServiceUrl": "http://server.qgis.org/",
         "wfsLayerIds": [
           "points_842425df_7f45_4091_a6c9_086e1dc1edd1"
         ],
-        "wfsServiceUrl": "",
+        "wfsServiceUrl": "http://server.qgis.org/",
         "wfstDeleteLayerIds": [],
         "wfstInsertLayerIds": [],
         "wfstUpdateLayerIds": [
@@ -3006,10 +3006,10 @@ Content-Type: application/json
         "wmsRestrictedComposers": [],
         "wmsRestrictedLayers": [],
         "wmsRootName": "ShortNameForRootLayer",
-        "wmsServiceUrl": "",
+        "wmsServiceUrl": "http://server.qgis.org/",
         "wmsTileBuffer": 0,
         "wmsUseLayerIds": false,
-        "wmtsServiceUrl": ""
+        "wmtsServiceUrl": "http://server.qgis.org/"
       },
       "crs": "EPSG:4326",
       "description": "Metadata abstract lorem ipsum...",

--- a/tests/testdata/qgis_server/landingpage/test_project_Project1_Title.json
+++ b/tests/testdata/qgis_server/landingpage/test_project_Project1_Title.json
@@ -20,11 +20,11 @@ Content-Type: application/json
       "owsServiceOnlineResource": "Service Capabilities Oline Resource",
       "owsServiceTitle": "Service Capabilities Title",
       "wcsLayerIds": [],
-      "wcsServiceUrl": "",
+      "wcsServiceUrl": "http://server.qgis.org/map/FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
       "wfsLayerIds": [
         "points_842425df_7f45_4091_a6c9_086e1dc1edd1"
       ],
-      "wfsServiceUrl": "",
+      "wfsServiceUrl": "http://server.qgis.org/map/FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
       "wfstDeleteLayerIds": [],
       "wfstInsertLayerIds": [],
       "wfstUpdateLayerIds": [
@@ -56,10 +56,10 @@ Content-Type: application/json
       "wmsRestrictedComposers": [],
       "wmsRestrictedLayers": [],
       "wmsRootName": "ShortNameForRootLayer",
-      "wmsServiceUrl": "",
+      "wmsServiceUrl": "http://server.qgis.org/map/FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
       "wmsTileBuffer": 0,
       "wmsUseLayerIds": false,
-      "wmtsServiceUrl": ""
+      "wmtsServiceUrl": "http://server.qgis.org/map/FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
     },
     "crs": "EPSG:4326",
     "description": "Metadata abstract lorem ipsum...",

--- a/tests/testdata/qgis_server/landingpage/test_project_Project2_Title.json
+++ b/tests/testdata/qgis_server/landingpage/test_project_Project2_Title.json
@@ -20,9 +20,9 @@ Content-Type: application/json
       "owsServiceOnlineResource": "Service Capabilities Oline Resource",
       "owsServiceTitle": "Service Capabilities Title",
       "wcsLayerIds": [],
-      "wcsServiceUrl": "",
+      "wcsServiceUrl": "http://server.qgis.org/map/FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
       "wfsLayerIds": [],
-      "wfsServiceUrl": "",
+      "wfsServiceUrl": "http://server.qgis.org/map/FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
       "wfstDeleteLayerIds": [],
       "wfstInsertLayerIds": [],
       "wfstUpdateLayerIds": [],
@@ -54,10 +54,10 @@ Content-Type: application/json
         "points restricted"
       ],
       "wmsRootName": "ShortNameForRootLayer",
-      "wmsServiceUrl": "",
+      "wmsServiceUrl": "http://server.qgis.org/map/FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
       "wmsTileBuffer": 0,
       "wmsUseLayerIds": true,
-      "wmtsServiceUrl": ""
+      "wmtsServiceUrl": "http://server.qgis.org/map/FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
     },
     "crs": "EPSG:4326",
     "description": "Metadata abstract lorem ipsum...",

--- a/tests/testdata/qgis_server/landingpage/test_project_Project3_Title.json
+++ b/tests/testdata/qgis_server/landingpage/test_project_Project3_Title.json
@@ -20,9 +20,9 @@ Content-Type: application/json
       "owsServiceOnlineResource": "Service Capabilities Oline Resource",
       "owsServiceTitle": "Service Capabilities Title",
       "wcsLayerIds": [],
-      "wcsServiceUrl": "",
+      "wcsServiceUrl": "http://server.qgis.org/map/FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
       "wfsLayerIds": [],
-      "wfsServiceUrl": "",
+      "wfsServiceUrl": "http://server.qgis.org/map/FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
       "wfstDeleteLayerIds": [],
       "wfstInsertLayerIds": [],
       "wfstUpdateLayerIds": [],
@@ -54,10 +54,10 @@ Content-Type: application/json
         "points restricted"
       ],
       "wmsRootName": "ShortNameForRootLayer",
-      "wmsServiceUrl": "",
+      "wmsServiceUrl": "http://server.qgis.org/map/FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
       "wmsTileBuffer": 0,
       "wmsUseLayerIds": true,
-      "wmtsServiceUrl": ""
+      "wmtsServiceUrl": "http://server.qgis.org/map/FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
     },
     "crs": "EPSG:4326",
     "description": "Metadata abstract lorem ipsum...",

--- a/tests/testdata/qgis_server/landingpage/test_project_QGIS_Server_-_Grouped_Nested_Layer.json
+++ b/tests/testdata/qgis_server/landingpage/test_project_QGIS_Server_-_Grouped_Nested_Layer.json
@@ -17,14 +17,14 @@ Content-Type: application/json
       "owsServiceOnlineResource": "",
       "owsServiceTitle": "QGIS Server - Grouped Nested Layer",
       "wcsLayerIds": [],
-      "wcsServiceUrl": "",
+      "wcsServiceUrl": "http://server.qgis.org/map/FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
       "wfsLayerIds": [
         "as_areas_bbe3c71b_356c_49f5_9fc2_ae771bcdd467",
         "as_symbols_3a1cdeef_9082_4d07_be5c_47c956bd7e76",
         "cdb_labels_8ee74af8_e7ba_4d80_9e0d_5b0b956d3daf",
         "cdb_lines_3f5c3c6d_db6d_4681_9291_7109f8d69f8b"
       ],
-      "wfsServiceUrl": "",
+      "wfsServiceUrl": "http://server.qgis.org/map/FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
       "wfstDeleteLayerIds": [
         "as_areas_bbe3c71b_356c_49f5_9fc2_ae771bcdd467",
         "as_symbols_3a1cdeef_9082_4d07_be5c_47c956bd7e76",
@@ -70,10 +70,10 @@ Content-Type: application/json
       "wmsRestrictedComposers": [],
       "wmsRestrictedLayers": [],
       "wmsRootName": "",
-      "wmsServiceUrl": "",
+      "wmsServiceUrl": "http://server.qgis.org/map/FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
       "wmsTileBuffer": 0,
       "wmsUseLayerIds": false,
-      "wmtsServiceUrl": ""
+      "wmtsServiceUrl": "http://server.qgis.org/map/FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
     },
     "crs": "EPSG:4326",
     "description": "",

--- a/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
@@ -128,7 +128,7 @@ Content-Type: text/xml; charset=utf-8
      <Title>default</Title>
      <LegendURL>
       <Format>image/png</Format>
-      <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?&amp;SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetLegendGraphic&amp;LAYER=bug_gh30264_empty_layer_wrong_bbox&amp;FORMAT=image/png&amp;STYLE=default&amp;SLD_VERSION=1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+      <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?*****" xmlns:xlink="http://www.w3.org/1999/xlink"/>
      </LegendURL>
     </Style>
    </Layer>

--- a/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
+++ b/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
@@ -139,7 +139,7 @@ Content-Type: text/xml; charset=utf-8
      <Title>default</Title>
      <LegendURL>
       <Format>image/png</Format>
-      <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?*****" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+      <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.qgis.org/?MAP=/root/QGIS/tests/testdata/qgis_server_accesscontrol/project_with_dimensions.qgs&amp;*****" xlink:type="simple"/>
      </LegendURL>
     </Style>
     <Dimension unitSymbol="m" name="elevation" units="meters" multipleValues="1" nearestValue="0">0, 500, 1000, 1500, 2000, 2500, 3000, 3500, 4000</Dimension>
@@ -163,7 +163,7 @@ Content-Type: text/xml; charset=utf-8
      <Title>default</Title>
      <LegendURL>
       <Format>image/png</Format>
-      <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?*****" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+      <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.qgis.org/?MAP=/root/QGIS/tests/testdata/qgis_server_accesscontrol/project_with_dimensions.qgs&amp;*****" xlink:type="simple"/>
      </LegendURL>
     </Style>
     <Dimension unitSymbol="m" name="range_elevation" units="meters" multipleValues="1" nearestValue="0">0, 500, 1000, 1500, 2000, 2500, 3000</Dimension>
@@ -187,7 +187,7 @@ Content-Type: text/xml; charset=utf-8
      <Title>default</Title>
      <LegendURL>
       <Format>image/png</Format>
-      <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?*****" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+      <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.qgis.org/?MAP=/root/QGIS/tests/testdata/qgis_server_accesscontrol/project_with_dimensions.qgs&amp;*****" xlink:type="simple"/>
      </LegendURL>
     </Style>
    </Layer>


### PR DESCRIPTION
## Description

The goals are:
* To have better result in the GetCapabilities URL without having to fill it in the Project configuration
* Be able to be set by an integrator with environment variable or by providing headers from a proxy

The server resolution will use the following order:
 - Value defined in the project per service.
 - The ``<service>_SERVICE_URL`` environment variable.
 - The ``SERVICE_URL`` environment variable.
 - The custom ``X-Qgis-<service>-Servcie-Url`` header.
 - The custom ``X-Qgis-Service-Url`` header.
 - Build form the standard ``Forwarded`` header.
 - Build form the pseudo standard ``X-Forwarded-Host`` and ``X-Forwarded-Proto`` headers.
 - Build form the standard ``Host`` header and the server protocol.
 - Build form the server name and the server protocol.

## Remark

If it globally looks good, I think that I should move the `header` function to `QgsServerRequest` as a method named `headerEnv` (I don't found a better name).
