### PR TITLE
Fix naming confusion in relations (project properties)

### DIFF
--- a/src/ui/qgsrelationmanagerdialogbase.ui
+++ b/src/ui/qgsrelationmanagerdialogbase.ui
@@ -26,22 +26,22 @@
      </column>
      <column>
       <property name="text">
-       <string>Referencing Layer</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Referencing Field(s)</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
        <string>Referenced Layer</string>
       </property>
      </column>
      <column>
       <property name="text">
        <string>Referenced Field(s)</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Referencing Layer</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Referencing Field(s)</string>
       </property>
      </column>
      <column>


### PR DESCRIPTION
In the relation properties there has been a confusion with the referencing (child) vs referenced (parent) layer and fields.

This is the fixed version:
![image](https://user-images.githubusercontent.com/28384354/106815616-66b04680-6674-11eb-99f7-dc315c528fb1.png)