### PR TITLE
Don't search for C++ GEOS lib with MSVC - get C library instead

### DIFF
--- a/cmake/FindGEOS.cmake
+++ b/cmake/FindGEOS.cmake
@@ -24,7 +24,7 @@ IF(WIN32)
 
   IF (MSVC)
     FIND_PATH(GEOS_INCLUDE_DIR geos_c.h $ENV{LIB_DIR}/include $ENV{INCLUDE})
-    FIND_LIBRARY(GEOS_LIBRARY NAMES geos geos_c_i geos_c PATHS
+    FIND_LIBRARY(GEOS_LIBRARY NAMES geos_c_i geos_c PATHS
       "$ENV{LIB_DIR}/lib"
       $ENV{LIB}
       )


### PR DESCRIPTION
## Description

Another patch from [conda-forge](https://github.com/conda-forge/qgis-feedstock).

QGIS uses the GEOS C library (geos_c). FindGEOS.cmake looks for geos_c on all platforms/compilers apart from Windows with MSVC where it looks for the C++ library first (geos). This is generally available so it doesn't then search for the C library listed afterwards.

This results in linking errors because the C functions aren't found in the C++ library. This PR removes the search for the C++ lib and now matches all other platforms/compilers.