### PR TITLE
[pointclouds] Don't regenerate ramp classes automatically when restoring previous renderer settings 

### DIFF
--- a/src/app/3d/qgspointcloud3dsymbolwidget.h
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.h
@@ -74,6 +74,7 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
     QgsPointCloudLayer *mLayer = nullptr;
 
     bool mBlockMinMaxChanged = false;
+    bool mBlockSetMinMaxFromLayer = false;
 
     double mProviderMin = std::numeric_limits< double >::quiet_NaN();
     double mProviderMax = std::numeric_limits< double >::quiet_NaN();

--- a/src/gui/pointcloud/qgspointcloudattributebyramprendererwidget.cpp
+++ b/src/gui/pointcloud/qgspointcloudattributebyramprendererwidget.cpp
@@ -50,8 +50,6 @@ QgsPointCloudAttributeByRampRendererWidget::QgsPointCloudAttributeByRampRenderer
 
   connect( mScalarColorRampShaderWidget, &QgsColorRampShaderWidget::widgetChanged, this, &QgsPointCloudAttributeByRampRendererWidget::emitWidgetChanged );
   connect( mScalarRecalculateMinMaxButton, &QPushButton::clicked, this, &QgsPointCloudAttributeByRampRendererWidget::setMinMaxFromLayer );
-
-  attributeChanged();
 }
 
 QgsPointCloudRendererWidget *QgsPointCloudAttributeByRampRendererWidget::create( QgsPointCloudLayer *layer, QgsStyle *style, QgsPointCloudRenderer * )
@@ -117,7 +115,9 @@ void QgsPointCloudAttributeByRampRendererWidget::attributeChanged()
     }
 
   }
-  setMinMaxFromLayer();
+  if ( !mBlockSetMinMaxFromLayer )
+    setMinMaxFromLayer();
+
   mScalarRecalculateMinMaxButton->setEnabled( !std::isnan( mProviderMin ) && !std::isnan( mProviderMax ) );
   emitWidgetChanged();
 }
@@ -141,6 +141,9 @@ void QgsPointCloudAttributeByRampRendererWidget::setFromRenderer( const QgsPoint
   const QgsPointCloudAttributeByRampRenderer *mbcr = dynamic_cast<const QgsPointCloudAttributeByRampRenderer *>( r );
   if ( mbcr )
   {
+    // we will be restoring the existing ramp classes -- we don't want to regenerate any automatically!
+    mBlockSetMinMaxFromLayer = true;
+
     mAttributeComboBox->setAttribute( mbcr->attribute() );
 
     mMinSpin->setValue( mbcr->minimum() );
@@ -162,6 +165,7 @@ void QgsPointCloudAttributeByRampRendererWidget::setFromRenderer( const QgsPoint
   }
   attributeChanged();
   mBlockChangedSignal = false;
+  mBlockSetMinMaxFromLayer = false;
 }
 
 ///@endcond

--- a/src/gui/pointcloud/qgspointcloudattributebyramprendererwidget.h
+++ b/src/gui/pointcloud/qgspointcloudattributebyramprendererwidget.h
@@ -52,6 +52,7 @@ class GUI_EXPORT QgsPointCloudAttributeByRampRendererWidget: public QgsPointClou
 
     bool mBlockChangedSignal = false;
     bool mBlockMinMaxChanged = false;
+    bool mBlockSetMinMaxFromLayer = false;
 
     double mProviderMin = std::numeric_limits< double >::quiet_NaN();
     double mProviderMax = std::numeric_limits< double >::quiet_NaN();


### PR DESCRIPTION
Otherwise we lose the previously set user classes and always reset to autogenerated ones.
