### PR TITLE
[Quick] Fix ios build by adding new component

### DIFF
--- a/src/quickgui/attributes/qgsquickattributeformmodel.cpp
+++ b/src/quickgui/attributes/qgsquickattributeformmodel.cpp
@@ -57,6 +57,11 @@ bool QgsQuickAttributeFormModel::constraintsSoftValid() const
   return mSourceModel->constraintsSoftValid();
 }
 
+bool QgsQuickAttributeFormModel::rememberValuesAllowed() const
+{
+  return mSourceModel->rememberValuesAllowed();
+}
+
 void QgsQuickAttributeFormModel::save()
 {
   mSourceModel->save();

--- a/src/quickgui/attributes/qgsquickattributeformmodel.h
+++ b/src/quickgui/attributes/qgsquickattributeformmodel.h
@@ -56,7 +56,7 @@ class QUICK_EXPORT QgsQuickAttributeFormModel : public QSortFilterProxyModel
     Q_PROPERTY( bool constraintsSoftValid READ constraintsSoftValid NOTIFY constraintsSoftValidChanged )
 
     //! Returns TRUE if remembering values is allowed
-    Q_PROPERTY( bool rememberValuesAllowed WRITE setRememberValuesAllowed )
+    Q_PROPERTY( bool rememberValuesAllowed READ rememberValuesAllowed WRITE setRememberValuesAllowed )
 
   public:
 
@@ -102,6 +102,9 @@ class QUICK_EXPORT QgsQuickAttributeFormModel : public QSortFilterProxyModel
 
     //! \copydoc QgsQuickAttributeFormModel::constraintsSoftValid
     bool constraintsSoftValid() const;
+
+    //! Whether attribute models remembers or not last entered values
+    bool rememberValuesAllowed() const;
 
     //! Updates QgsFeature based on changes
     Q_INVOKABLE void save();

--- a/src/quickgui/attributes/qgsquickattributeformmodelbase.cpp
+++ b/src/quickgui/attributes/qgsquickattributeformmodelbase.cpp
@@ -393,6 +393,11 @@ bool QgsQuickAttributeFormModelBase::constraintsSoftValid() const
   return mConstraintsSoftValid;
 }
 
+bool QgsQuickAttributeFormModelBase::rememberValuesAllowed() const
+{
+  return mAttributeModel->rememberValuesAllowed();
+}
+
 QVariant QgsQuickAttributeFormModelBase::attribute( const QString &name ) const
 {
   if ( !mLayer )

--- a/src/quickgui/attributes/qgsquickattributeformmodelbase.h
+++ b/src/quickgui/attributes/qgsquickattributeformmodelbase.h
@@ -92,6 +92,9 @@ class QgsQuickAttributeFormModelBase : public QStandardItemModel
     //! \copydoc QgsQuickAttributeFormModelBase::constraintsSoftValid
     bool constraintsSoftValid() const;
 
+    //! Attribute model remembers or not last entered values
+    bool rememberValuesAllowed() const;
+
     /**
      * Gets the value of attribute of the feature in the model
      *

--- a/src/quickgui/plugin/ios/qgsquick.qrc
+++ b/src/quickgui/plugin/ios/qgsquick.qrc
@@ -16,6 +16,7 @@
         <file>qgsquickphotopanel.qml</file>
         <file>qgsquickpositionmarker.qml</file>
         <file>qgsquickicontextitem.qml</file>
+        <file>qgsquickcheckboxcomponent.qml</file>
         <file>qgsquickscalebar.qml</file>
     </qresource>
 </RCC>

--- a/src/quickgui/plugin/ios/qmldir
+++ b/src/quickgui/plugin/ios/qmldir
@@ -15,6 +15,7 @@ module QgsQuick
 # suppose to be used only internally in QgsQuick plugin
 EditorWidgetComboBox  0.1 qgsquickeditorwidgetcombobox.qml
 IconTextItem 0.1 qgsquickicontextitem.qml
+CheckboxComponent 0.1 qgsquickcheckboxcomponent.qml
 
 MapCanvas 0.1 qgsquickmapcanvas.qml
 FeatureForm 0.1 qgsquickfeatureform.qml


### PR DESCRIPTION
## Fixes iOS qgsquick build

`CheckboxComponent` was not defined in qmldir and qrc files for ios. 

Also fixes invalid property rememberValues in `qgsquickattributeformmodel` due to missing READ accessor.

cc @PeterPetrik 