### PR TITLE
Refresh snapping index on vector data provider notify

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1971,12 +1971,12 @@ void QgsMapLayer::setRefreshOnNotifyEnabled( bool enabled )
   if ( enabled && !isRefreshOnNotifyEnabled() )
   {
     lDataProvider->setListening( enabled );
-    connect( lDataProvider, &QgsVectorDataProvider::notify, this, &QgsMapLayer::onNotifiedTriggerRepaint );
+    connect( lDataProvider, &QgsVectorDataProvider::notify, this, &QgsMapLayer::onNotified );
   }
   else if ( !enabled && isRefreshOnNotifyEnabled() )
   {
     // we don't want to disable provider listening because someone else could need it (e.g. actions)
-    disconnect( lDataProvider, &QgsVectorDataProvider::notify, this, &QgsMapLayer::onNotifiedTriggerRepaint );
+    disconnect( lDataProvider, &QgsVectorDataProvider::notify, this, &QgsMapLayer::onNotified );
   }
   mIsRefreshOnNofifyEnabled = enabled;
 }
@@ -1990,8 +1990,11 @@ QgsProject *QgsMapLayer::project() const
   return nullptr;
 }
 
-void QgsMapLayer::onNotifiedTriggerRepaint( const QString &message )
+void QgsMapLayer::onNotified( const QString &message )
 {
   if ( refreshOnNotifyMessage().isEmpty() || refreshOnNotifyMessage() == message )
+  {
     triggerRepaint();
+    emit dataChanged();
+  }
 }

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1501,7 +1501,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
   private slots:
 
-    void onNotifiedTriggerRepaint( const QString &message );
+    void onNotified( const QString &message );
 
   protected:
 

--- a/tests/src/core/testqgsmaplayer.cpp
+++ b/tests/src/core/testqgsmaplayer.cpp
@@ -61,6 +61,7 @@ class TestQgsMapLayer : public QObject
 
     void styleCategories();
 
+    void notify();
 
   private:
     QgsVectorLayer *mpLayer = nullptr;
@@ -353,6 +354,36 @@ void TestQgsMapLayer::styleCategories()
 
     QVERIFY( allStyleCategories.testFlag( category ) );
   }
+}
+
+void TestQgsMapLayer::notify()
+{
+  QgsVectorLayer *vl = new QgsVectorLayer( QStringLiteral( "Point" ), QStringLiteral( "name" ), QStringLiteral( "memory" ) );
+  QVERIFY( vl->dataProvider() );
+
+  QSignalSpy spyRepaint( vl, &QgsMapLayer::repaintRequested );
+  QSignalSpy spyDataChanged( vl, &QgsMapLayer::dataChanged );
+
+  vl->setRefreshOnNotifyEnabled( true );
+  emit vl->dataProvider()->notify( "test" );
+  QCOMPARE( spyRepaint.count(), 1 );
+  QCOMPARE( spyDataChanged.count(), 1 );
+
+  vl->setRefreshOnNotifyEnabled( false );
+  emit vl->dataProvider()->notify( "test" );
+  QCOMPARE( spyRepaint.count(), 1 );
+  QCOMPARE( spyDataChanged.count(), 1 );
+
+  vl->setRefreshOnNotifyEnabled( true );
+  vl->setRefreshOnNofifyMessage( "test" );
+  emit vl->dataProvider()->notify( "test" );
+  QCOMPARE( spyRepaint.count(), 2 );
+  QCOMPARE( spyDataChanged.count(), 2 );
+
+  vl->setRefreshOnNofifyMessage( "test" );
+  emit vl->dataProvider()->notify( "nottest" );
+  QCOMPARE( spyRepaint.count(), 2 );
+  QCOMPARE( spyDataChanged.count(), 2 );
 }
 
 QGSTEST_MAIN( TestQgsMapLayer )


### PR DESCRIPTION
## Description

Fixes #40720

When provider raise a notify message (PostGres PG_NOTIFY for instance), we have to trigger a repaint and fire a *dataChanged* signal so the snapping index is updated. 

