### PR TITLE
fix mesh legend

### DIFF
--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -63,9 +63,9 @@ QgsMeshLayer::QgsMeshLayer( const QString &meshLayerPath,
     ok = setDataProvider( providerKey, providerOptions, flags );
   }
 
+  setLegend( QgsMapLayerLegend::defaultMeshLegend( this ) );
   if ( ok )
   {
-    setLegend( QgsMapLayerLegend::defaultMeshLegend( this ) );
     setDefaultRendererSettings( mDatasetGroupStore->datasetGroupIndexes() );
 
     if ( mDataProvider )


### PR DESCRIPTION
When an existing project with a mesh layer is open, the legend is not here anymore. This PR fixes this issue.
could fix https://github.com/qgis/QGIS/issues/41317
