### PR TITLE
[WMSProvider] remove duplicates in CRS list

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -1215,7 +1215,8 @@ void QgsWmsCapabilities::parseLayer( const QDomElement &element, QgsWmsLayerProp
         const QStringList crsList = nodeElement.text().split( QRegExp( "\\s+" ) );
         for ( const QString &srs : crsList )
         {
-          layerProperty.crs.push_back( srs );
+          if ( !layerProperty.crs.contains( srs ) )
+            layerProperty.crs.push_back( srs );
         }
       }
       else if ( tagName == QLatin1String( "LatLonBoundingBox" ) )    // legacy from earlier versions of WMS

--- a/tests/src/providers/testqgswmscapabilities.cpp
+++ b/tests/src/providers/testqgswmscapabilities.cpp
@@ -77,6 +77,8 @@ class TestQgsWmsCapabilities: public QObject
       QCOMPARE( capabilities.supportedLayers()[0].style[1].legendUrl.size(), 1 );
       QCOMPARE( capabilities.supportedLayers()[0].style[1].legendUrl[0].onlineResource.xlinkHref,
                 QString( "http://www.example.com/fb.png" ) );
+
+      QCOMPARE( capabilities.supportedLayers()[0].crs, QStringList() << QStringLiteral( "EPSG:2056" ) );
     }
 
     void guessCrs()


### PR DESCRIPTION
Fixes #40318 : In case of nested layer, child layer inherits parent CRS ( see [specification](http://cite.opengeospatial.org/OGCTestData/wms/1.1.1/spec/wms1.1.1.html#table.layer_property_inheritance) ), so the same CRS is defined in both child and parent layers, it appears twice (or more). This PR avoids duplicates.
