### PR TITLE
[process] Set the PROJECT_PATH project as  QgsProject singleton to fix aggregate expression (and more)

### DIFF
--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -899,6 +899,7 @@ int QgsProcessingExec::execute( const QString &id, const QVariantMap &params, co
       std::cerr << QStringLiteral( "Could not load the QGIS project \"%1\"\n" ).arg( projectPath ).toLocal8Bit().constData();
       return 1;
     }
+    QgsProject::setInstance( project.get() );
   }
 
   if ( !useJson )


### PR DESCRIPTION
## Description

ATM, when using qgis_process's --PROJECT_PATH, some expressions, such as aggregate function, fail because those function are computing against QgsProject::instance(). 

This PR fixes that by setting the singleton to the loaded PROJECT_PATH project.