### PR TITLE
Use the lowest version in wms negotiation

### DIFF
--- a/python/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/server/auto_generated/qgsserverparameters.sip.in
@@ -348,7 +348,7 @@ defined.
 :return: filename
 %End
 
-    QString version() const;
+    virtual QString version() const;
 %Docstring
 Returns VERSION parameter as a string or an empty string if not
 defined.

--- a/python/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/server/auto_generated/qgsserverparameters.sip.in
@@ -324,7 +324,7 @@ defined.
 :return: service
 %End
 
-    QString request() const;
+    virtual QString request() const;
 %Docstring
 Returns REQUEST parameter as a string or an empty string if not
 defined.

--- a/python/server/auto_generated/qgsserverrequest.sip.in
+++ b/python/server/auto_generated/qgsserverrequest.sip.in
@@ -63,6 +63,7 @@ Constructor
 Copy constructor.
 %End
 
+
     virtual ~QgsServerRequest();
 
     static QString methodToString( const Method &method );

--- a/python/server/auto_generated/qgsserverrequest.sip.in
+++ b/python/server/auto_generated/qgsserverrequest.sip.in
@@ -59,6 +59,9 @@ Constructor
 %End
 
     QgsServerRequest( const QgsServerRequest &other );
+%Docstring
+Copy constructor.
+%End
 
     virtual ~QgsServerRequest();
 

--- a/python/server/auto_generated/qgsserverrequest.sip.in
+++ b/python/server/auto_generated/qgsserverrequest.sip.in
@@ -58,6 +58,8 @@ Constructor
 :param headers:
 %End
 
+    QgsServerRequest( const QgsServerRequest &other );
+
     virtual ~QgsServerRequest();
 
     static QString methodToString( const Method &method );
@@ -94,7 +96,7 @@ to uppercase
 Returns parameters
 %End
 
-    void setParameter( const QString &key, const QString &value );
+    virtual void setParameter( const QString &key, const QString &value );
 %Docstring
 Set a parameter
 %End
@@ -104,7 +106,7 @@ Set a parameter
 Gets a parameter value
 %End
 
-    void removeParameter( const QString &key );
+    virtual void removeParameter( const QString &key );
 %Docstring
 Remove a parameter
 %End
@@ -147,7 +149,7 @@ Check for QByteArray.isNull() to check if data
 is available.
 %End
 
-    void setUrl( const QUrl &url );
+    virtual void setUrl( const QUrl &url );
 %Docstring
 Set the request url
 %End

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -302,7 +302,7 @@ class SERVER_EXPORT QgsServerParameters
      * defined.
      * \returns request
      */
-    QString request() const;
+    virtual QString request() const;
 
     /**
      * Returns MAP parameter as a string or an empty string if not

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -323,7 +323,7 @@ class SERVER_EXPORT QgsServerParameters
      * defined.
      * \returns version
      */
-    QString version() const;
+    virtual QString version() const;
 
   protected:
 

--- a/src/server/qgsserverrequest.cpp
+++ b/src/server/qgsserverrequest.cpp
@@ -34,6 +34,15 @@ QgsServerRequest::QgsServerRequest( const QUrl &url, Method method, const Header
   mParams.load( QUrlQuery( url ) );
 }
 
+QgsServerRequest::QgsServerRequest( const QgsServerRequest &other )
+  : mUrl( other.mUrl )
+  , mOriginalUrl( other.mOriginalUrl )
+  , mMethod( other.mMethod )
+  , mHeaders( other.mHeaders )
+  , mParams( other.mParams )
+{
+}
+
 QString QgsServerRequest::methodToString( const QgsServerRequest::Method &method )
 {
   static QMetaEnum metaEnum = QMetaEnum::fromType<QgsServerRequest::Method>();

--- a/src/server/qgsserverrequest.h
+++ b/src/server/qgsserverrequest.h
@@ -86,6 +86,7 @@ class SERVER_EXPORT QgsServerRequest
      * Copy constructor.
      */
     QgsServerRequest( const QgsServerRequest &other );
+    QgsServerRequest &operator=( const QgsServerRequest & ) = delete;
 
     //! destructor
     virtual ~QgsServerRequest() = default;

--- a/src/server/qgsserverrequest.h
+++ b/src/server/qgsserverrequest.h
@@ -82,6 +82,9 @@ class SERVER_EXPORT QgsServerRequest
      */
     QgsServerRequest( const QUrl &url, QgsServerRequest::Method method = QgsServerRequest::GetMethod, const QgsServerRequest::Headers &headers = QgsServerRequest::Headers() );
 
+    /**
+     * Copy constructor.
+     */
     QgsServerRequest( const QgsServerRequest &other );
 
     //! destructor

--- a/src/server/qgsserverrequest.h
+++ b/src/server/qgsserverrequest.h
@@ -86,7 +86,8 @@ class SERVER_EXPORT QgsServerRequest
      * Copy constructor.
      */
     QgsServerRequest( const QgsServerRequest &other );
-    QgsServerRequest &operator=( const QgsServerRequest & ) = delete;
+
+    QgsServerRequest &operator=( const QgsServerRequest & ) = default;
 
     //! destructor
     virtual ~QgsServerRequest() = default;

--- a/src/server/qgsserverrequest.h
+++ b/src/server/qgsserverrequest.h
@@ -82,6 +82,8 @@ class SERVER_EXPORT QgsServerRequest
      */
     QgsServerRequest( const QUrl &url, QgsServerRequest::Method method = QgsServerRequest::GetMethod, const QgsServerRequest::Headers &headers = QgsServerRequest::Headers() );
 
+    QgsServerRequest( const QgsServerRequest &other );
+
     //! destructor
     virtual ~QgsServerRequest() = default;
 
@@ -119,7 +121,7 @@ class SERVER_EXPORT QgsServerRequest
     /**
      * Set a parameter
      */
-    void setParameter( const QString &key, const QString &value );
+    virtual void setParameter( const QString &key, const QString &value );
 
     /**
      * Gets a parameter value
@@ -129,7 +131,7 @@ class SERVER_EXPORT QgsServerRequest
     /**
      * Remove a parameter
      */
-    void removeParameter( const QString &key );
+    virtual void removeParameter( const QString &key );
 
     /**
      * Returns the header value
@@ -167,7 +169,7 @@ class SERVER_EXPORT QgsServerRequest
     /**
      * Set the request url
      */
-    void setUrl( const QUrl &url );
+    virtual void setUrl( const QUrl &url );
 
     /**
      * Returns the request url as seen by the web server,

--- a/src/server/services/wms/CMakeLists.txt
+++ b/src/server/services/wms/CMakeLists.txt
@@ -21,6 +21,7 @@ set (WMS_SRCS
   qgswmsparameters.cpp
   qgswmsrestorer.cpp
   qgswmsrendercontext.cpp
+  qgswmsrequest.cpp
 )
 
 set (WMS_HDRS

--- a/src/server/services/wms/qgsdxfwriter.cpp
+++ b/src/server/services/wms/qgsdxfwriter.cpp
@@ -22,24 +22,21 @@ email                : david dot marteau at 3liz dot com
 namespace QgsWms
 {
   void writeAsDxf( QgsServerInterface *serverIface, const QgsProject *project,
-                   const QString &,  const QgsServerRequest &request,
+                   const QgsWmsRequest &request,
                    QgsServerResponse &response )
   {
-    // get wms parameters from query
-    const QgsWmsParameters parameters( request.serverParameters() );
-
     // prepare render context
     QgsWmsRenderContext context( project, serverIface );
     context.setFlag( QgsWmsRenderContext::UseWfsLayersOnly );
     context.setFlag( QgsWmsRenderContext::UseOpacity );
     context.setFlag( QgsWmsRenderContext::UseFilter );
     context.setFlag( QgsWmsRenderContext::SetAccessControl );
-    context.setParameters( parameters );
+    context.setParameters( request.wmsParameters() );
 
     // Write output
     QgsRenderer renderer( context );
     std::unique_ptr<QgsDxfExport> dxf = renderer.getDxf();
     response.setHeader( "Content-Type", "application/dxf" );
-    dxf->writeToFile( response.io(), parameters.dxfCodec() );
+    dxf->writeToFile( response.io(), request.wmsParameters().dxfCodec() );
   }
 } // namespace QgsWms

--- a/src/server/services/wms/qgsdxfwriter.h
+++ b/src/server/services/wms/qgsdxfwriter.h
@@ -15,6 +15,8 @@ email                : david dot marteau at 3liz dot com
  *                                                                         *
  ***************************************************************************/
 
+#include "qgswmsrequest.h"
+
 namespace QgsWms
 {
 
@@ -22,7 +24,7 @@ namespace QgsWms
    * Output GetMap response in DXF format
    */
   void writeAsDxf( QgsServerInterface *serverIface, const QgsProject *project,
-                   const QString &version,  const QgsServerRequest &request,
+                   const QgsWmsRequest &request,
                    QgsServerResponse &response );
 
 } // namespace QgsWms

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -91,6 +91,8 @@ namespace QgsWms
 
         // Get the request
         const QString req = parameters.request();
+        const QString version = parameters.version();
+
         if ( req.isEmpty() )
         {
           throw QgsServiceException( QgsServiceException::OGC_OperationNotSupported,
@@ -106,8 +108,7 @@ namespace QgsWms
         else if ( QSTR_COMPARE( req, "GetProjectSettings" ) )
         {
           //getProjectSettings extends WMS 1.3.0 capabilities
-          version = QStringLiteral( "1.3.0" );
-          writeGetCapabilities( mServerIface, project, version, request, response, true );
+          writeGetCapabilities( mServerIface, project, QStringLiteral( "1.3.0" ), request, response, true );
         }
         else if ( QSTR_COMPARE( req, "GetMap" ) )
         {

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -126,7 +126,7 @@ namespace QgsWms
         }
         else if ( QSTR_COMPARE( req, "GetContext" ) )
         {
-          writeGetContext( mServerIface, project, version, request, response );
+          writeGetContext( mServerIface, project, request, response );
         }
         else if ( QSTR_COMPARE( req, "GetSchemaExtension" ) )
         {

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -66,34 +66,9 @@ namespace QgsWms
       void executeRequest( const QgsServerRequest &request, QgsServerResponse &response,
                            const QgsProject *project ) override
       {
-        const QgsWmsParameters parameters( request.serverParameters() );
-
-        QString version = parameters.version();
-        if ( version.isEmpty() )
-        {
-          // WMTVER needs to be supported by WMS 1.1.1 for backwards
-          // compatibility with WMS 1.0.0
-          version = parameters.wmtver();
-        }
-
-        // Set the default version
-        if ( version.isEmpty() || !parameters.versionIsValid( version ) )
-        {
-          version = mVersion;
-        }
-
-        // WMS 1.3.0 specification: If a version lower than any of those known
-        // to the server is requested, then the server shall send the lowest
-        // version it supports.
-        if ( QgsProjectVersion( 1, 1, 1 ) > parameters.versionAsNumber() )
-        {
-          version = "1.1.1";
-        }
-
         // Get the request
         const QgsWmsRequest wmsRequest( request );
-        const QString req = parameters.request();
-        const QString version = parameters.version();
+        const QString req = wmsRequest.wmsParameters().request();
 
         if ( req.isEmpty() )
         {
@@ -111,7 +86,7 @@ namespace QgsWms
         }
         else if ( QSTR_COMPARE( req, "GetMap" ) )
         {
-          if QSTR_COMPARE( parameters.formatAsString(), "application/dxf" )
+          if QSTR_COMPARE( wmsRequest.wmsParameters().formatAsString(), "application/dxf" )
           {
             writeAsDxf( mServerIface, project, request, response );
           }
@@ -153,7 +128,7 @@ namespace QgsWms
             throw QgsServiceException( QgsServiceException::OGC_OperationNotSupported,
                                        QStringLiteral( "Request %1 is not supported" ).arg( req ), 501 );
           }
-          writeGetPrint( mServerIface, project, version, request, response );
+          writeGetPrint( mServerIface, project, request, response );
         }
         else
         {

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -101,7 +101,7 @@ namespace QgsWms
 
         if ( QSTR_COMPARE( req, "GetCapabilities" ) )
         {
-          writeGetCapabilities( mServerIface, project, version, request, response, false );
+          writeGetCapabilities( mServerIface, project, version, request, response );
         }
         else if ( QSTR_COMPARE( req, "GetProjectSettings" ) )
         {
@@ -109,8 +109,7 @@ namespace QgsWms
         }
         else if ( QSTR_COMPARE( req, "GetMap" ) )
         {
-          QString format = parameters.formatAsString();
-          if QSTR_COMPARE( format, "application/dxf" )
+          if QSTR_COMPARE( parameters.formatAsString(), "application/dxf" )
           {
             writeAsDxf( mServerIface, project, version, request, response );
           }

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -117,7 +117,7 @@ namespace QgsWms
           }
           else
           {
-            writeGetMap( mServerIface, project, version, request, response );
+            writeGetMap( mServerIface, project, request, response );
           }
         }
         else if ( QSTR_COMPARE( req, "GetFeatureInfo" ) )

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -138,7 +138,7 @@ namespace QgsWms
         }
         else if ( QSTR_COMPARE( req, "DescribeLayer" ) )
         {
-          writeDescribeLayer( mServerIface, project, version, request, response );
+          writeDescribeLayer( mServerIface, project, request, response );
         }
         else if ( QSTR_COMPARE( req, "GetLegendGraphic" ) || QSTR_COMPARE( req, "GetLegendGraphics" ) )
         {

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -142,7 +142,7 @@ namespace QgsWms
         }
         else if ( QSTR_COMPARE( req, "GetLegendGraphic" ) || QSTR_COMPARE( req, "GetLegendGraphics" ) )
         {
-          writeGetLegendGraphics( mServerIface, project, version, request, response );
+          writeGetLegendGraphics( mServerIface, project, request, response );
         }
         else if ( QSTR_COMPARE( req, "GetPrint" ) )
         {

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -107,8 +107,7 @@ namespace QgsWms
         }
         else if ( QSTR_COMPARE( req, "GetProjectSettings" ) )
         {
-          //getProjectSettings extends WMS 1.3.0 capabilities
-          writeGetCapabilities( mServerIface, project, QStringLiteral( "1.3.0" ), request, response, true );
+          writeGetCapabilities( mServerIface, project, version, request, response, true );
         }
         else if ( QSTR_COMPARE( req, "GetMap" ) )
         {

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -81,6 +81,14 @@ namespace QgsWms
           version = mVersion;
         }
 
+        // WMS 1.3.0 specification: If a version lower than any of those known
+        // to the server is requested, then the server shall send the lowest
+        // version it supports.
+        if ( QgsProjectVersion( 1, 1, 1 ) > parameters.versionAsNumber() )
+        {
+          version = "1.1.1";
+        }
+
         // Get the request
         const QString req = parameters.request();
         if ( req.isEmpty() )

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -113,7 +113,7 @@ namespace QgsWms
         {
           if QSTR_COMPARE( parameters.formatAsString(), "application/dxf" )
           {
-            writeAsDxf( mServerIface, project, version, request, response );
+            writeAsDxf( mServerIface, project, request, response );
           }
           else
           {

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -122,7 +122,7 @@ namespace QgsWms
         }
         else if ( QSTR_COMPARE( req, "GetFeatureInfo" ) )
         {
-          writeGetFeatureInfo( mServerIface, project, version, request, response );
+          writeGetFeatureInfo( mServerIface, project, request, response );
         }
         else if ( QSTR_COMPARE( req, "GetContext" ) )
         {

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -32,6 +32,7 @@
 #include "qgswmsdescribelayer.h"
 #include "qgswmsgetlegendgraphics.h"
 #include "qgswmsparameters.h"
+#include "qgswmsrequest.h"
 
 #define QSTR_COMPARE( str, lit )\
   (str.compare( QLatin1String( lit ), Qt::CaseInsensitive ) == 0)
@@ -90,6 +91,7 @@ namespace QgsWms
         }
 
         // Get the request
+        const QgsWmsRequest wmsRequest( request );
         const QString req = parameters.request();
         const QString version = parameters.version();
 
@@ -101,11 +103,11 @@ namespace QgsWms
 
         if ( QSTR_COMPARE( req, "GetCapabilities" ) )
         {
-          writeGetCapabilities( mServerIface, project, version, request, response );
+          writeGetCapabilities( mServerIface, project, wmsRequest, response );
         }
         else if ( QSTR_COMPARE( req, "GetProjectSettings" ) )
         {
-          writeGetCapabilities( mServerIface, project, version, request, response, true );
+          writeGetCapabilities( mServerIface, project, request, response, true );
         }
         else if ( QSTR_COMPARE( req, "GetMap" ) )
         {

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -107,7 +107,7 @@ namespace QgsWms
         {
           writeGetSchemaExtension( response );
         }
-        else if ( QSTR_COMPARE( req, "GetStyle" ) or QSTR_COMPARE( req, "GetStyles" ) )
+        else if ( QSTR_COMPARE( req, "GetStyle" ) || QSTR_COMPARE( req, "GetStyles" ) )
         {
           writeGetStyles( mServerIface, project, request, response );
         }

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -99,9 +99,7 @@ namespace QgsWms
                                      QStringLiteral( "Please add or check the value of the REQUEST parameter" ), 501 );
         }
 
-        if ( ( mVersion.compare( QLatin1String( "1.1.1" ) ) == 0 \
-               && QSTR_COMPARE( req, "capabilities" ) )
-             || QSTR_COMPARE( req, "GetCapabilities" ) )
+        if ( QSTR_COMPARE( req, "GetCapabilities" ) )
         {
           writeGetCapabilities( mServerIface, project, version, request, response, false );
         }

--- a/src/server/services/wms/qgswmsdescribelayer.cpp
+++ b/src/server/services/wms/qgswmsdescribelayer.cpp
@@ -20,6 +20,7 @@
  ***************************************************************************/
 
 #include "qgswmsutils.h"
+#include "qgswmsrequest.h"
 #include "qgswmsserviceexception.h"
 #include "qgswmsdescribelayer.h"
 #include "qgsserverprojectutils.h"
@@ -28,21 +29,19 @@
 namespace QgsWms
 {
 
-  void writeDescribeLayer( QgsServerInterface *serverIface, const QgsProject *project, const QString &version,
-                           const QgsServerRequest &request, QgsServerResponse &response )
+  void writeDescribeLayer( QgsServerInterface *serverIface, const QgsProject *project,
+                           const QgsWmsRequest &request, QgsServerResponse &response )
   {
-    QDomDocument doc = describeLayer( serverIface, project, version, request );
+    QDomDocument doc = describeLayer( serverIface, project, request );
     response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "text/xml; charset=utf-8" ) );
     response.write( doc.toByteArray() );
   }
 
   // DescribeLayer is defined for WMS1.1.1/SLD1.0 and in WMS 1.3.0 SLD Extension
-  QDomDocument describeLayer( QgsServerInterface *serverIface, const QgsProject *project, const QString &version,
-                              const QgsServerRequest &request )
+  QDomDocument describeLayer( QgsServerInterface *serverIface, const QgsProject *project,
+                              const QgsWmsRequest &request )
   {
-    Q_UNUSED( version )
-
-    QgsServerRequest::Parameters parameters = request.parameters();
+    const QgsServerRequest::Parameters parameters = request.parameters();
 
     if ( !parameters.contains( QStringLiteral( "SLD_VERSION" ) ) )
     {

--- a/src/server/services/wms/qgswmsdescribelayer.h
+++ b/src/server/services/wms/qgswmsdescribelayer.h
@@ -26,13 +26,13 @@ namespace QgsWms
    * Output GetMap response in DXF format
    */
   void writeDescribeLayer( QgsServerInterface *serverIface, const QgsProject *project,
-                           const QString &version, const QgsServerRequest &request,
+                           const QgsWmsRequest &request,
                            QgsServerResponse &response );
 
   /**
    *  DescribeLayer is defined for WMS1.1.1/SLD1.0 and in WMS 1.3.0 SLD Extension
    */
   QDomDocument describeLayer( QgsServerInterface *serverIface, const QgsProject *project,
-                              const QString &version, const QgsServerRequest &request );
+                              const QgsWmsRequest &request );
 
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsgetcapabilities.h
+++ b/src/server/services/wms/qgswmsgetcapabilities.h
@@ -26,15 +26,19 @@
 #include "qgslayertreelayer.h"
 #include "qgslayertree.h"
 
+#include "qgswmsrequest.h"
+
 namespace QgsWms
 {
 
   /**
    * Create element for get capabilities document
    */
-  QDomElement getLayersAndStylesCapabilitiesElement( QDomDocument &doc, QgsServerInterface *serverIface,
-      const QgsProject *project, const QString &version,
-      const QgsServerRequest &request, bool projectSettings );
+  QDomElement getLayersAndStylesCapabilitiesElement( QDomDocument &doc,
+      QgsServerInterface *serverIface,
+      const QgsProject *project,
+      const QgsWmsRequest &request,
+      bool projectSettings );
 
   /**
    * Create WFSLayers element for get capabilities document
@@ -54,34 +58,35 @@ namespace QgsWms
   /**
    * Create Capability element for get capabilities document
    */
-  QDomElement getCapabilityElement( QDomDocument &doc, const QgsProject *project, const QString &version,
-                                    const QgsServerRequest &request, bool projectSettings,
+  QDomElement getCapabilityElement( QDomDocument &doc, const QgsProject *project,
+                                    const QgsWmsRequest &request, bool projectSettings,
                                     QgsServerInterface *serverIface );
 
   /**
    * Create Service element for get capabilities document
    */
-  QDomElement getServiceElement( QDomDocument &doc, const QgsProject *project, const QString &version,
-                                 const QgsServerRequest &request );
+  QDomElement getServiceElement( QDomDocument &doc, const QgsProject *project,
+                                 const QgsWmsRequest &request );
 
   /**
    * Output GetCapabilities response
    */
-  void writeGetCapabilities( QgsServerInterface *serverIface, const QgsProject *project,
-                             const QString &version, const QgsServerRequest &request,
-                             QgsServerResponse &response, bool projectSettings = false );
+  void writeGetCapabilities( QgsServerInterface *serverIface,
+                             const QgsProject *project,
+                             const QgsWmsRequest &request,
+                             QgsServerResponse &response,
+                             bool projectSettings = false );
 
   /**
    * Creates the WMS GetCapabilities XML document.
    * \param serverIface Interface for plugins
    * \param project Project
-   * \param version WMS version
    * \param request WMS request
    * \param projectSettings If TRUE, adds extended project information (does not validate against WMS schema)
    * \returns GetCapabilities XML document
    */
   QDomDocument getCapabilities( QgsServerInterface *serverIface, const QgsProject *project,
-                                const QString &version, const QgsServerRequest &request,
+                                const QgsWmsRequest &request,
                                 bool projectSettings );
 
   bool hasQueryableChildren( const QgsLayerTreeNode *childNode, const QStringList &wmsRestrictedLayers );

--- a/src/server/services/wms/qgswmsgetcontext.cpp
+++ b/src/server/services/wms/qgswmsgetcontext.cpp
@@ -19,6 +19,7 @@
  *                                                                         *
  ***************************************************************************/
 #include "qgswmsutils.h"
+#include "qgswmsrequest.h"
 #include "qgswmsgetcontext.h"
 #include "qgsserverprojectutils.h"
 
@@ -40,18 +41,18 @@ namespace QgsWms
                                        QDomElement &parentLayer,
                                        QgsServerInterface *serverIface,
                                        const QgsProject *project,
-                                       const QgsServerRequest &request,
+                                       const QgsWmsRequest &request,
                                        const QgsLayerTreeGroup *layerTreeGroup,
                                        QgsRectangle &combinedBBox,
                                        const QString &strGroup );
 
     void appendOwsGeneralAndResourceList( QDomDocument &doc, QDomElement &parentElement,
                                           QgsServerInterface *serverIface, const QgsProject *project,
-                                          const QgsServerRequest &request );
+                                          const QgsWmsRequest &request );
   }
 
   void writeGetContext( QgsServerInterface *serverIface, const QgsProject *project,
-                        const QString &version, const QgsServerRequest &request,
+                        const QgsWmsRequest &request,
                         QgsServerResponse &response )
   {
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
@@ -69,7 +70,7 @@ namespace QgsWms
     }
     else //context xml not in cache. Create a new one
     {
-      doc = getContext( serverIface, project, version, request );
+      doc = getContext( serverIface, project, request );
 
       if ( cacheManager )
       {
@@ -78,7 +79,7 @@ namespace QgsWms
       contextDocument = &doc;
     }
 #else
-    doc = getContext( serverIface, project, version, request );
+    doc = getContext( serverIface, project, request );
     contextDocument = &doc;
 #endif
     response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "text/xml; charset=utf-8" ) );
@@ -86,11 +87,10 @@ namespace QgsWms
   }
 
 
-  QDomDocument getContext( QgsServerInterface *serverIface, const QgsProject *project,
-                           const QString &version, const QgsServerRequest &request )
+  QDomDocument getContext( QgsServerInterface *serverIface,
+                           const QgsProject *project,
+                           const QgsWmsRequest &request )
   {
-    Q_UNUSED( version )
-
     QDomDocument doc;
     QDomProcessingInstruction xmlDeclaration = doc.createProcessingInstruction( QStringLiteral( "xml" ),
         QStringLiteral( "version=\"1.0\" encoding=\"utf-8\"" ) );
@@ -121,7 +121,7 @@ namespace QgsWms
   {
     void appendOwsGeneralAndResourceList( QDomDocument &doc, QDomElement &parentElement,
                                           QgsServerInterface *serverIface, const QgsProject *project,
-                                          const QgsServerRequest &request )
+                                          const QgsWmsRequest &request )
     {
       parentElement.setAttribute( QStringLiteral( "id" ), "ows-context-" + project->baseName() );
 
@@ -219,7 +219,7 @@ namespace QgsWms
                                        QDomElement &parentLayer,
                                        QgsServerInterface *serverIface,
                                        const QgsProject *project,
-                                       const QgsServerRequest &request,
+                                       const QgsWmsRequest &request,
                                        const QgsLayerTreeGroup *layerTreeGroup,
                                        QgsRectangle &combinedBBox,
                                        const QString &strGroup )

--- a/src/server/services/wms/qgswmsgetcontext.h
+++ b/src/server/services/wms/qgswmsgetcontext.h
@@ -25,15 +25,17 @@ namespace QgsWms
   /**
    * Output GetContext response
    */
-  void writeGetContext( QgsServerInterface *serverIface, const QgsProject *project,
-                        const QString &version, const QgsServerRequest &request,
+  void writeGetContext( QgsServerInterface *serverIface,
+                        const QgsProject *project,
+                        const QgsWmsRequest &request,
                         QgsServerResponse &response );
 
   /**
    * Returns XML document for the 'GetContext' request
    */
-  QDomDocument getContext( QgsServerInterface *serverIface, const QgsProject *project,
-                           const QString &version, const QgsServerRequest &request );
+  QDomDocument getContext( QgsServerInterface *serverIface,
+                           const QgsProject *project,
+                           const QgsWmsRequest &request );
 
 } // namespace QgsWms
 

--- a/src/server/services/wms/qgswmsgetfeatureinfo.cpp
+++ b/src/server/services/wms/qgswmsgetfeatureinfo.cpp
@@ -24,12 +24,12 @@
 
 namespace QgsWms
 {
-  void writeGetFeatureInfo( QgsServerInterface *serverIface, const QgsProject *project,
-                            const QString &version, const QgsServerRequest &request,
+  void writeGetFeatureInfo( QgsServerInterface *serverIface,
+                            const QgsProject *project,
+                            const QgsWmsRequest &request,
                             QgsServerResponse &response )
   {
-    // get wms parameters from query
-    QgsWmsParameters parameters( request.serverParameters() );
+    QgsWmsParameters parameters = request.wmsParameters();
 
     // WIDTH and HEIGHT are not mandatory, but we need to set a default size
     if ( ( parameters.widthAsInt() <= 0
@@ -62,6 +62,6 @@ namespace QgsWms
     response.setHeader( QStringLiteral( "Content-Type" ), infoFormat + QStringLiteral( "; charset=utf-8" ) );
 
     QgsRenderer renderer( context );
-    response.write( renderer.getFeatureInfo( version ) );
+    response.write( renderer.getFeatureInfo( parameters.version() ) );
   }
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsgetfeatureinfo.h
+++ b/src/server/services/wms/qgswmsgetfeatureinfo.h
@@ -19,6 +19,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgswmsrequest.h"
+
 namespace QgsWms
 {
 
@@ -26,7 +28,7 @@ namespace QgsWms
    * Output GetFeatureInfo response
    */
   void writeGetFeatureInfo( QgsServerInterface *serverIface, const QgsProject *project,
-                            const QString &version, const QgsServerRequest &request,
+                            const QgsWmsRequest &request,
                             QgsServerResponse &response );
 
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsgetlegendgraphics.cpp
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.cpp
@@ -26,6 +26,7 @@
 #include "qgsmaplayerlegend.h"
 
 #include "qgswmsutils.h"
+#include "qgswmsrequest.h"
 #include "qgswmsserviceexception.h"
 #include "qgswmsgetlegendgraphics.h"
 #include "qgswmsrenderer.h"
@@ -37,11 +38,11 @@
 namespace QgsWms
 {
   void writeGetLegendGraphics( QgsServerInterface *serverIface, const QgsProject *project,
-                               const QString &, const QgsServerRequest &request,
+                               const QgsWmsRequest &request,
                                QgsServerResponse &response )
   {
     // get parameters from query
-    QgsWmsParameters parameters( request.serverParameters() );
+    QgsWmsParameters parameters = request.wmsParameters();
 
     // check parameters validity
     // FIXME fail with png + mode

--- a/src/server/services/wms/qgswmsgetlegendgraphics.h
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.h
@@ -29,7 +29,7 @@ namespace QgsWms
    * Output GetLegendGRaphics response
    */
   void writeGetLegendGraphics( QgsServerInterface *serverIface, const QgsProject *project,
-                               const QString &version, const QgsServerRequest &request,
+                               const QgsWmsRequest &request,
                                QgsServerResponse &response );
 
   /**

--- a/src/server/services/wms/qgswmsgetmap.cpp
+++ b/src/server/services/wms/qgswmsgetmap.cpp
@@ -29,12 +29,9 @@ namespace QgsWms
 {
 
   void writeGetMap( QgsServerInterface *serverIface, const QgsProject *project,
-                    const QString &, const QgsServerRequest &request,
+                    const QgsWmsRequest &request,
                     QgsServerResponse &response )
   {
-    // get wms parameters from query
-    const QgsWmsParameters parameters( request.serverParameters() );
-
     // prepare render context
     QgsWmsRenderContext context( project, serverIface );
     context.setFlag( QgsWmsRenderContext::UpdateExtent );
@@ -45,7 +42,7 @@ namespace QgsWms
     context.setFlag( QgsWmsRenderContext::AddExternalLayers );
     context.setFlag( QgsWmsRenderContext::SetAccessControl );
     context.setFlag( QgsWmsRenderContext::UseTileBuffer );
-    context.setParameters( parameters );
+    context.setParameters( request.wmsParameters() );
 
     // rendering
     QgsRenderer renderer( context );

--- a/src/server/services/wms/qgswmsgetmap.h
+++ b/src/server/services/wms/qgswmsgetmap.h
@@ -19,6 +19,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgswmsrequest.h"
+
 namespace QgsWms
 {
 
@@ -26,7 +28,7 @@ namespace QgsWms
    * Output GetMap response in DXF format
    */
   void writeGetMap( QgsServerInterface *serverIface, const QgsProject *project,
-                    const QString &version,  const QgsServerRequest &request,
+                    const QgsWmsRequest &request,
                     QgsServerResponse &response );
 
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsgetprint.cpp
+++ b/src/server/services/wms/qgswmsgetprint.cpp
@@ -19,6 +19,7 @@
  *                                                                         *
  ***************************************************************************/
 #include "qgswmsutils.h"
+#include "qgswmsrequest.h"
 #include "qgswmsgetprint.h"
 #include "qgswmsrenderer.h"
 #include "qgswmsserviceexception.h"
@@ -26,11 +27,10 @@
 namespace QgsWms
 {
   void writeGetPrint( QgsServerInterface *serverIface, const QgsProject *project,
-                      const QString &, const QgsServerRequest &request,
+                      const QgsWmsRequest &request,
                       QgsServerResponse &response )
   {
-    // get wms parameters from query
-    const QgsWmsParameters parameters( request.serverParameters() );
+    const QgsWmsParameters parameters = request.wmsParameters();
 
     // GetPrint supports svg/png/pdf
     const QgsWmsParameters::Format format = parameters.format();

--- a/src/server/services/wms/qgswmsgetprint.h
+++ b/src/server/services/wms/qgswmsgetprint.h
@@ -26,7 +26,7 @@ namespace QgsWms
    * Output GetPrint response
    */
   void writeGetPrint( QgsServerInterface *serverIface, const QgsProject *project,
-                      const QString &version, const QgsServerRequest &request,
+                      const QgsWmsRequest &request,
                       QgsServerResponse &response );
 
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsgetstyles.cpp
+++ b/src/server/services/wms/qgswmsgetstyles.cpp
@@ -39,7 +39,7 @@ namespace QgsWms
 
   namespace
   {
-    QDomDocument getStyledLayerDescriptorDocument( QgsServerInterface *serverIface, const QgsProject *project, const QgsServerRequest &request );
+    QDomDocument getStyledLayerDescriptorDocument( QgsServerInterface *serverIface, const QgsProject *project, const QgsWmsRequest &request );
   }
 
   void writeGetStyles( QgsServerInterface *serverIface, const QgsProject *project,
@@ -51,7 +51,7 @@ namespace QgsWms
   }
 
   QDomDocument getStyles( QgsServerInterface *serverIface, const QgsProject *project,
-                          const QgsServerRequest &request )
+                          const QgsWmsRequest &request )
   {
     return getStyledLayerDescriptorDocument( serverIface, project, request );
   }

--- a/src/server/services/wms/qgswmsgetstyles.cpp
+++ b/src/server/services/wms/qgswmsgetstyles.cpp
@@ -21,6 +21,7 @@
 
 
 #include "qgswmsutils.h"
+#include "qgswmsrequest.h"
 #include "qgswmsserviceexception.h"
 #include "qgswmsgetstyles.h"
 #include "qgswmsrendercontext.h"
@@ -42,7 +43,7 @@ namespace QgsWms
   }
 
   void writeGetStyles( QgsServerInterface *serverIface, const QgsProject *project,
-                       const QgsServerRequest &request, QgsServerResponse &response )
+                       const QgsWmsRequest &request, QgsServerResponse &response )
   {
     QDomDocument doc = getStyles( serverIface, project, request );
     response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "text/xml; charset=utf-8" ) );
@@ -57,10 +58,10 @@ namespace QgsWms
 
   namespace
   {
-    QDomDocument getStyledLayerDescriptorDocument( QgsServerInterface *serverIface, const QgsProject *project, const QgsServerRequest &request )
+    QDomDocument getStyledLayerDescriptorDocument( QgsServerInterface *serverIface, const QgsProject *project,   const QgsWmsRequest &request )
     {
       // init WMS parameters and context
-      const QgsWmsParameters parameters( request.serverParameters() );
+      const QgsWmsParameters parameters = request.wmsParameters();
 
       QgsWmsRenderContext context( project, serverIface );
       context.setFlag( QgsWmsRenderContext::SetAccessControl );

--- a/src/server/services/wms/qgswmsgetstyles.h
+++ b/src/server/services/wms/qgswmsgetstyles.h
@@ -26,13 +26,13 @@ namespace QgsWms
    * Output GetStyles response
    */
   void writeGetStyles( QgsServerInterface *serverIface, const QgsProject *project,
-                       const QgsServerRequest &request, QgsServerResponse &response );
+                       const QgsWmsRequest &request, QgsServerResponse &response );
 
 
   /**
    * Returns an SLD file with the styles of the requested layers. Exception is raised in case of troubles :-)
    */
   QDomDocument getStyles( QgsServerInterface *serverIface, const QgsProject *project,
-                          const QgsServerRequest &request );
+                          const QgsWmsRequest &request );
 
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -757,7 +757,7 @@ namespace QgsWms
   {
     QString version = QgsServerParameters::version();
 
-    if ( request().compare( QLatin1String( "GetProjectSettings" ), Qt::CaseInsensitive ) == 0 )
+    if ( QgsServerParameters::request().compare( QLatin1String( "GetProjectSettings" ), Qt::CaseInsensitive ) == 0 )
     {
       version = QStringLiteral( "1.3.0" );
     }
@@ -788,6 +788,19 @@ namespace QgsWms
     }
 
     return version;
+  }
+
+  QString QgsWmsParameters::request() const
+  {
+    QString req = QgsServerParameters::request();
+
+    if ( version().compare( QLatin1String( "1.1.1" ) ) == 0
+         && req.compare( QLatin1String( "capabilities" ), Qt::CaseInsensitive ) == 0 )
+    {
+      req = QStringLiteral( "GetCapabilities" );
+    }
+
+    return req;
   }
 
   QgsProjectVersion QgsWmsParameters::versionAsNumber() const

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -753,22 +753,44 @@ namespace QgsWms
     return mWmsParameters[ QgsWmsParameter::DPI ].toDouble();
   }
 
-  QgsProjectVersion QgsWmsParameters::versionAsNumber() const
+  QString QgsWmsParameters::version() const
   {
-    const QString vStr = version();
+    QString vStr = QgsServerParameters::version();
 
     QgsProjectVersion version;
 
     if ( vStr.isEmpty() )
     {
-      version = QgsProjectVersion( 1, 3, 0 ); // default value
+      if ( ! wmtver().isEmpty() )
+      {
+        vStr = wmtver();
+      }
+      else
+      {
+        vStr = QStringLiteral( "1.3.0" );
+      }
     }
-    else if ( mVersions.contains( QgsProjectVersion( vStr ) ) )
+    else if ( !mVersions.contains( QgsProjectVersion( vStr ) ) )
     {
-      version = QgsProjectVersion( vStr );
+      // WMS 1.3.0 specification: If a version lower than any of those
+      // known to the server is requested, then the server shall send the
+      // lowest version it supports.
+      if ( QgsProjectVersion( 1, 1, 1 ) > QgsProjectVersion( vStr ) )
+      {
+        vStr = QStringLiteral( "1.1.1" );
+      }
+      else
+      {
+        vStr = QStringLiteral( "1.3.0" );
+      }
     }
 
-    return version;
+    return vStr;
+  }
+
+  QgsProjectVersion QgsWmsParameters::versionAsNumber() const
+  {
+    return QgsProjectVersion( version() );
   }
 
   bool QgsWmsParameters::versionIsValid( const QString version ) const

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -755,37 +755,39 @@ namespace QgsWms
 
   QString QgsWmsParameters::version() const
   {
-    QString vStr = QgsServerParameters::version();
+    QString version = QgsServerParameters::version();
 
-    QgsProjectVersion version;
-
-    if ( vStr.isEmpty() )
+    if ( request().compare( QLatin1String( "GetProjectSettings" ), Qt::CaseInsensitive ) == 0 )
+    {
+      version = QStringLiteral( "1.3.0" );
+    }
+    else if ( version.isEmpty() )
     {
       if ( ! wmtver().isEmpty() )
       {
-        vStr = wmtver();
+        version = wmtver();
       }
       else
       {
-        vStr = QStringLiteral( "1.3.0" );
+        version = QStringLiteral( "1.3.0" );
       }
     }
-    else if ( !mVersions.contains( QgsProjectVersion( vStr ) ) )
+    else if ( !mVersions.contains( QgsProjectVersion( version ) ) )
     {
       // WMS 1.3.0 specification: If a version lower than any of those
       // known to the server is requested, then the server shall send the
       // lowest version it supports.
-      if ( QgsProjectVersion( 1, 1, 1 ) > QgsProjectVersion( vStr ) )
+      if ( QgsProjectVersion( 1, 1, 1 ) > QgsProjectVersion( version ) )
       {
-        vStr = QStringLiteral( "1.1.1" );
+        version = QStringLiteral( "1.1.1" );
       }
       else
       {
-        vStr = QStringLiteral( "1.3.0" );
+        version = QStringLiteral( "1.3.0" );
       }
     }
 
-    return vStr;
+    return version;
   }
 
   QgsProjectVersion QgsWmsParameters::versionAsNumber() const

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -1327,6 +1327,8 @@ namespace QgsWms
        */
       bool isForce2D() const;
 
+      QString version() const override;
+
     private:
       static bool isExternalLayer( const QString &name );
 

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -1329,6 +1329,8 @@ namespace QgsWms
 
       QString version() const override;
 
+      QString request() const override;
+
     private:
       static bool isExternalLayer( const QString &name );
 

--- a/src/server/services/wms/qgswmsrequest.cpp
+++ b/src/server/services/wms/qgswmsrequest.cpp
@@ -52,6 +52,6 @@ namespace QgsWms
 
   void QgsWmsRequest::init()
   {
-    mWmsParams = QgsWmsParameters( QUrlQuery( url() ) );
+    mWmsParams = QgsWmsParameters( serverParameters() );
   }
 }

--- a/src/server/services/wms/qgswmsrequest.cpp
+++ b/src/server/services/wms/qgswmsrequest.cpp
@@ -1,0 +1,57 @@
+/***************************************************************************
+                          qgswmsrequest.cpp
+
+  Define request class for getting request contents for WMS service
+  -------------------
+  begin                : 2021-02-10
+  copyright            : (C) 2021 by Paul Blottiere
+  email                : blottiere.paul@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgswmsrequest.h"
+
+namespace QgsWms
+{
+  QgsWmsRequest::QgsWmsRequest( const QgsServerRequest &other )
+    : QgsServerRequest( other )
+  {
+    init();
+  }
+
+  const QgsWmsParameters &QgsWmsRequest::wmsParameters() const
+  {
+    return mWmsParams;
+  }
+
+  void QgsWmsRequest::setParameter( const QString &key, const QString &value )
+  {
+    QgsServerRequest::setParameter( key, value );
+    init();
+  }
+
+  void QgsWmsRequest::removeParameter( const QString &key )
+  {
+    QgsServerRequest::removeParameter( key );
+    init();
+  }
+
+  void QgsWmsRequest::setUrl( const QUrl &url )
+  {
+    QgsServerRequest::setUrl( url );
+    init();
+  }
+
+  void QgsWmsRequest::init()
+  {
+    mWmsParams = QgsWmsParameters( QUrlQuery( url() ) );
+  }
+}

--- a/src/server/services/wms/qgswmsrequest.h
+++ b/src/server/services/wms/qgswmsrequest.h
@@ -1,0 +1,68 @@
+/***************************************************************************
+                          qgswmsrequest.h
+
+  Define request class for getting request contents for WMS service
+  -------------------
+  begin                : 2021-02-10
+  copyright            : (C) 2021 by Paul Blottiere
+  email                : blottiere.paul@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSWMSREQUEST_H
+#define QGSWMSREQUEST_H
+
+#include "qgsserverrequest.h"
+#include "qgswmsparameters.h"
+
+namespace QgsWms
+{
+
+  /**
+   * \ingroup server
+   * QgsWmsServerRequest
+   * Class defining request interface passed to WMS service
+   * QgsService::executeRequest() method.
+   *
+   * \since QGIS 3.20
+   */
+
+  class QgsWmsRequest : public QgsServerRequest
+  {
+      Q_GADGET
+
+    public:
+
+      /**
+       * Copy onstructor
+       */
+      QgsWmsRequest( const QgsServerRequest &other );
+
+      /**
+       * Destructor.
+       */
+      ~QgsWmsRequest() override = default;
+
+      const QgsWmsParameters &wmsParameters() const;
+
+      void setParameter( const QString &key, const QString &value ) override;
+
+      void removeParameter( const QString &key ) override;
+
+      void setUrl( const QUrl &url ) override;
+
+    private:
+      void init();
+
+      QgsWmsParameters mWmsParams;
+  };
+}
+
+#endif

--- a/src/server/services/wms/qgswmsrequest.h
+++ b/src/server/services/wms/qgswmsrequest.h
@@ -41,7 +41,7 @@ namespace QgsWms
     public:
 
       /**
-       * Copy onstructor
+       * Copy constructor
        */
       QgsWmsRequest( const QgsServerRequest &other );
 
@@ -50,6 +50,9 @@ namespace QgsWms
        */
       ~QgsWmsRequest() override = default;
 
+      /**
+       * Returns the parameters interpreted for the WMS service.
+       */
       const QgsWmsParameters &wmsParameters() const;
 
       void setParameter( const QString &key, const QString &value ) override;

--- a/src/server/services/wms/qgswmsrequest.h
+++ b/src/server/services/wms/qgswmsrequest.h
@@ -27,13 +27,10 @@ namespace QgsWms
 
   /**
    * \ingroup server
-   * QgsWmsServerRequest
-   * Class defining request interface passed to WMS service
-   * QgsService::executeRequest() method.
-   *
+   * \class QgsWmsRequest
+   * \brief Class defining request interface passed to WMS service
    * \since QGIS 3.20
    */
-
   class QgsWmsRequest : public QgsServerRequest
   {
       Q_GADGET

--- a/tests/src/server/wms/CMakeLists.txt
+++ b/tests/src/server/wms/CMakeLists.txt
@@ -21,6 +21,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}
 #No relinking and full RPATH for the install tree
 #See: http://www.cmake.org/Wiki/CMake_RPATH_handling#No_relinking_and_full_RPATH_for_the_install_tree
 set(MODULE_WMS_SRCS
+  ${CMAKE_SOURCE_DIR}/src/server/services/wms/qgswmsrequest.cpp
   ${CMAKE_SOURCE_DIR}/src/server/services/wms/qgswmsrenderer.cpp
   ${CMAKE_SOURCE_DIR}/src/server/services/wms/qgswmsrestorer.cpp
   ${CMAKE_SOURCE_DIR}/src/server/services/wms/qgsmaprendererjobproxy.cpp
@@ -61,6 +62,7 @@ endmacro (ADD_QGIS_TEST)
 
 set(TESTS
   test_qgsserver_wms_dxf.cpp
+  test_qgsserver_wms_request.cpp
   test_qgsserver_wms_restorer.cpp
   test_qgsserver_wms_exceptions.cpp
   test_qgsserver_wms_parameters.cpp

--- a/tests/src/server/wms/test_qgsserver_wms_parameters.cpp
+++ b/tests/src/server/wms/test_qgsserver_wms_parameters.cpp
@@ -30,7 +30,7 @@ class TestQgsServerWmsParameters : public QObject
 
     void external_layers();
     void percent_encoding();
-    void version_negociation();
+    void version_negotiation();
 };
 
 void TestQgsServerWmsParameters::initTestCase()
@@ -85,7 +85,7 @@ void TestQgsServerWmsParameters::percent_encoding()
   QCOMPARE( wmsParams.value( "MYPARAM" ), QString( "my+value" ) );
 }
 
-void TestQgsServerWmsParameters::version_negociation()
+void TestQgsServerWmsParameters::version_negotiation()
 {
   QUrlQuery query;
 

--- a/tests/src/server/wms/test_qgsserver_wms_parameters.cpp
+++ b/tests/src/server/wms/test_qgsserver_wms_parameters.cpp
@@ -112,6 +112,28 @@ void TestQgsServerWmsParameters::version_negotiation()
   query.addQueryItem( "VERSION", "33.33.33" );
   parameters = QgsWms::QgsWmsParameters( query );
   QCOMPARE( parameters.version(), QStringLiteral( "1.3.0" ) );
+
+  query.clear();
+  query.addQueryItem( "VERSION", "1.1.1" );
+  query.addQueryItem( "REQUEST", "GetProjectSettings" );
+  parameters = QgsWms::QgsWmsParameters( query );
+  QCOMPARE( parameters.version(), QStringLiteral( "1.3.0" ) );
+
+  query.clear();
+  query.addQueryItem( "REQUEST", "GetProjectSettings" );
+  parameters = QgsWms::QgsWmsParameters( query );
+  QCOMPARE( parameters.version(), QStringLiteral( "1.3.0" ) );
+
+  query.clear();
+  query.addQueryItem( "WMTVER", "1.1.1" );
+  parameters = QgsWms::QgsWmsParameters( query );
+  QCOMPARE( parameters.version(), QStringLiteral( "1.1.1" ) );
+
+  query.clear();
+  query.addQueryItem( "WMTVER", "1.1.1" );
+  query.addQueryItem( "VERSION", "1.3.0" );
+  parameters = QgsWms::QgsWmsParameters( query );
+  QCOMPARE( parameters.version(), QStringLiteral( "1.3.0" ) );
 }
 
 QGSTEST_MAIN( TestQgsServerWmsParameters )

--- a/tests/src/server/wms/test_qgsserver_wms_parameters.cpp
+++ b/tests/src/server/wms/test_qgsserver_wms_parameters.cpp
@@ -30,6 +30,7 @@ class TestQgsServerWmsParameters : public QObject
 
     void external_layers();
     void percent_encoding();
+    void version_negociation();
 };
 
 void TestQgsServerWmsParameters::initTestCase()
@@ -82,6 +83,35 @@ void TestQgsServerWmsParameters::percent_encoding()
 
   QgsWms::QgsWmsParameters wmsParams( params );
   QCOMPARE( wmsParams.value( "MYPARAM" ), QString( "my+value" ) );
+}
+
+void TestQgsServerWmsParameters::version_negociation()
+{
+  QUrlQuery query;
+
+  query.addQueryItem( "VERSION", "1.3.0" );
+  QgsWms::QgsWmsParameters parameters( query );
+  QCOMPARE( parameters.version(), QStringLiteral( "1.3.0" ) );
+
+  query.clear();
+  query.addQueryItem( "VERSION", "1.1.1" );
+  parameters = QgsWms::QgsWmsParameters( query );
+  QCOMPARE( parameters.version(), QStringLiteral( "1.1.1" ) );
+
+  query.clear();
+  query.addQueryItem( "VERSION", "1.1.0" );
+  parameters = QgsWms::QgsWmsParameters( query );
+  QCOMPARE( parameters.version(), QStringLiteral( "1.1.1" ) );
+
+  query.clear();
+  query.addQueryItem( "VERSION", "" );
+  parameters = QgsWms::QgsWmsParameters( query );
+  QCOMPARE( parameters.version(), QStringLiteral( "1.3.0" ) );
+
+  query.clear();
+  query.addQueryItem( "VERSION", "33.33.33" );
+  parameters = QgsWms::QgsWmsParameters( query );
+  QCOMPARE( parameters.version(), QStringLiteral( "1.3.0" ) );
 }
 
 QGSTEST_MAIN( TestQgsServerWmsParameters )

--- a/tests/src/server/wms/test_qgsserver_wms_parameters.cpp
+++ b/tests/src/server/wms/test_qgsserver_wms_parameters.cpp
@@ -31,6 +31,7 @@ class TestQgsServerWmsParameters : public QObject
     void external_layers();
     void percent_encoding();
     void version_negotiation();
+    void get_capabilities_version();
 };
 
 void TestQgsServerWmsParameters::initTestCase()
@@ -134,6 +135,28 @@ void TestQgsServerWmsParameters::version_negotiation()
   query.addQueryItem( "VERSION", "1.3.0" );
   parameters = QgsWms::QgsWmsParameters( query );
   QCOMPARE( parameters.version(), QStringLiteral( "1.3.0" ) );
+}
+
+void TestQgsServerWmsParameters::get_capabilities_version()
+{
+  QUrlQuery query;
+
+  query.addQueryItem( "VERSION", "1.3.0" );
+  query.addQueryItem( "REQUEST", "capabilities" );
+  QgsWms::QgsWmsParameters parameters( query );
+  QCOMPARE( parameters.request(), QStringLiteral( "capabilities" ) );
+
+  query.clear();
+  query.addQueryItem( "VERSION", "1.1.1" );
+  query.addQueryItem( "REQUEST", "capabilities" );
+  parameters = QgsWms::QgsWmsParameters( query );
+  QCOMPARE( parameters.request(), QStringLiteral( "GetCapabilities" ) );
+
+  query.clear();
+  query.addQueryItem( "VERSION", "1.1.0" );
+  query.addQueryItem( "REQUEST", "capabilities" );
+  parameters = QgsWms::QgsWmsParameters( query );
+  QCOMPARE( parameters.request(), QStringLiteral( "GetCapabilities" ) );
 }
 
 QGSTEST_MAIN( TestQgsServerWmsParameters )

--- a/tests/src/server/wms/test_qgsserver_wms_request.cpp
+++ b/tests/src/server/wms/test_qgsserver_wms_request.cpp
@@ -29,6 +29,7 @@ class TestQgsServerWmsRequest : public QObject
     void cleanupTestCase();
 
     void cst();
+    void update();
 };
 
 void TestQgsServerWmsRequest::initTestCase()
@@ -54,6 +55,33 @@ void TestQgsServerWmsRequest::cst()
   // WMS context
   QgsWms::QgsWmsRequest wmsRequest( request );
   QCOMPARE( wmsRequest.wmsParameters().version(), "1.1.1" );
+}
+
+void TestQgsServerWmsRequest::update()
+{
+  // init request with parameters
+  QgsServerRequest request;
+  request.setParameter( "PARAM_0", "0" );
+  request.setParameter( "PARAM_1", "1" );
+
+  QgsWms::QgsWmsRequest wmsRequest( request );
+  QCOMPARE( wmsRequest.wmsParameters().value( "PARAM_0" ), "0" );
+
+  wmsRequest.setParameter( "PARAM_3", "3" );
+  QCOMPARE( wmsRequest.wmsParameters().value( "PARAM_3" ), "3" );
+
+  // init request by loading a query
+  QUrl url( "http://qgisserver?PARAM_0=0&PARAM_1=1" );
+
+  QgsServerRequest request2( url );
+
+  QCOMPARE( request2.serverParameters().value( "PARAM_0" ), "0" );
+
+  QgsWms::QgsWmsRequest wmsRequest2( request2 );
+  QCOMPARE( wmsRequest2.wmsParameters().value( "PARAM_0" ), "0" );
+
+  wmsRequest2.setParameter( "PARAM_3", "3" );
+  QCOMPARE( wmsRequest2.wmsParameters().value( "PARAM_3" ), "3" );
 }
 
 QGSTEST_MAIN( TestQgsServerWmsRequest )

--- a/tests/src/server/wms/test_qgsserver_wms_request.cpp
+++ b/tests/src/server/wms/test_qgsserver_wms_request.cpp
@@ -1,0 +1,60 @@
+/***************************************************************************
+     test_qgsserver_wms_parameters.cpp
+     ---------------------------------
+    Date                 : 02 Sept 2020
+    Copyright            : (C) 2020 by Paul Blottiere
+    Email                : paul dot blottiere @ gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+#include "qgswmsrequest.h"
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test for the WMS parameters class
+ */
+class TestQgsServerWmsRequest : public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();
+    void cleanupTestCase();
+
+    void cst();
+};
+
+void TestQgsServerWmsRequest::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+}
+
+void TestQgsServerWmsRequest::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsServerWmsRequest::cst()
+{
+  QgsServerRequest request;
+  request.setParameter( "VERSION", "1.0.0" );
+
+  // the base class for parameters provides raw values...
+  QCOMPARE( request.serverParameters().version(), "1.0.0" );
+
+  // ...whereas the wms parameters class interprets values to be valid in the
+  // WMS context
+  QgsWms::QgsWmsRequest wmsRequest( request );
+  QCOMPARE( wmsRequest.wmsParameters().version(), "1.1.1" );
+}
+
+QGSTEST_MAIN( TestQgsServerWmsRequest )
+#include "test_qgsserver_wms_request.moc"

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_notvisible.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_notvisible.txt
@@ -7,7 +7,7 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="3" name="id"/>
    <Attribute value="three" name="name"/>
    <Attribute value="three èé↓" name="utf8nameè"/>
-   <BoundingBox maxy="44.9014" maxx="8.2035" miny="44.9014" CRS="EPSG:4326" minx="8.2035"/>
+   <BoundingBox maxy="44.9014" maxx="8.2035" miny="44.9014" SRS="EPSG:4326" minx="8.2035"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>


### PR DESCRIPTION
## Description

The WMS 1.3.0 specification about version number negotiation:

*If a version lower than any of those known to the server is requested, then the server shall send the lowest version it supports*

Partial fix of https://github.com/qgis/QGIS/issues/41051.