### PR TITLE
[Feature] Add Vector support to Georeferencer

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -277,13 +277,15 @@ if (HAVE_GEOREFERENCER)
     georeferencer/qgsgeorefvalidators.cpp
     georeferencer/qgsmapcoordsdialog.cpp
     georeferencer/qgsresidualplotitem.cpp
-    georeferencer/qgstransformsettingsdialog.cpp
+    georeferencer/qgsrastertransformsettingsdialog.cpp
+    georeferencer/qgsvectortransformsettingsdialog.cpp
     georeferencer/qgsgcplist.cpp
     georeferencer/qgsgcplistmodel.cpp
     georeferencer/qgsimagewarper.cpp
     georeferencer/qgsgeoreftransform.cpp
     georeferencer/qgsgcplistwidget.cpp
     georeferencer/qgsrasterchangecoords.cpp
+    georeferencer/qgsvectorwarper.cpp
   )
 endif()
 

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -37,6 +37,7 @@
 #include "qgsgui.h"
 #include "qgisapp.h"
 
+#include "qgsfeedback.h"
 #include "qgslayout.h"
 #include "qgslayoutitemlabel.h"
 #include "qgslayoutitemmap.h"
@@ -1369,7 +1370,7 @@ void QgsGeoreferencerMainWindow::addRaster( const QString &file )
 
 void QgsGeoreferencerMainWindow::addVector( const QString &file )
 {
-   std::unique_ptr< QgsVectorLayer > VLayer = std::make_unique< QgsVectorLayer >( file, QStringLiteral( "Vector" ) );
+  std::unique_ptr< QgsVectorLayer > VLayer = std::make_unique< QgsVectorLayer >( file, QStringLiteral( "Vector" ) );
 
   // add layer to map canvas
   mCanvas->setLayers( QList<QgsMapLayer *>() << VLayer.get() );
@@ -1557,10 +1558,11 @@ bool QgsGeoreferencerMainWindow::georeference()
   {
     bool success;
     QgsVectorWarper warper( mTransformParam, mPoints, mProjection );
+    QgsFeedback *feedback = new QgsFeedback();
     if ( mModifiedFileName.isEmpty() )
-      success = warper.executeTransformInplace( qobject_cast<QgsVectorLayer *>( mLayer.get() ) );
+      success = warper.executeTransformInplace( qobject_cast<QgsVectorLayer *>( mLayer.get() ), feedback );
     else
-      success = warper.executeTransform( qobject_cast<QgsVectorLayer *>( mLayer.get() ), mModifiedFileName );
+      success = warper.executeTransform( qobject_cast<QgsVectorLayer *>( mLayer.get() ), mModifiedFileName, feedback );
 
     if ( !mPdfOutputFile.isEmpty() )
     {

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -544,7 +544,7 @@ void QgsGeoreferencerMainWindow::generateGDALScript()
       case QgsGcpTransformerInterface::TransformMethod::PolynomialOrder2:
       case QgsGcpTransformerInterface::TransformMethod::PolynomialOrder3:
       case QgsGcpTransformerInterface::TransformMethod::ThinPlateSpline:
-        QString vectorCommand = generateGDALogr2ogrCommand( mTransformParam );
+        showGDALScript(QStringList() << generateGDALogr2ogrCommand( mTransformParam ) );
         break;
       default:
         mMessageBar->pushMessage( tr( "Invalid Transform" ), tr( "GDAL scripting is not supported for %1 transformation." )
@@ -1031,31 +1031,6 @@ void QgsGeoreferencerMainWindow::updateMouseCoordinatePrecision()
     dp = 0;
 
   mMousePrecisionDecimalPlaces = dp;
-}
-
-void QgsGeoreferencerMainWindow::extentsChanged()
-{
-  if ( mAgainAddLayer )
-  {
-    if ( mDataType == QgsGeoreferencerMainWindow::RASTER && QFile::exists( mFileName ) )
-    {
-      addRaster( mFileName );
-    }
-    else if ( mDataType == QgsGeoreferencerMainWindow::VECTOR && QFile::exists( mFileName ) )
-      addVector( mFileName );
-    else
-    {
-      mRLayer = nullptr;
-      mVLayer = nullptr;
-      mAgainAddLayer = false;
-    }
-  }
-}
-
-// Registry layer QGis
-void QgsGeoreferencerMainWindow::layerWillBeRemoved( const QString &layerId )
-{
-  mAgainAddLayer = mRLayer && mRLayer->id().compare( layerId ) == 0;
 }
 
 // ------------------------------ private ---------------------------------- //
@@ -1601,7 +1576,7 @@ bool QgsGeoreferencerMainWindow::georeference()
   if ( mDataType == QgsGeoreferencerMainWindow::VECTOR && mVLayer )
   {
     bool success;
-    QgsVectorWarper warper = QgsVectorWarper( mTransformParam, mPoints, mProjection );
+    QgsVectorWarper warper( mTransformParam, mPoints, mProjection );
     if ( mModifiedFileName.isEmpty() )
       success = warper.executeTransformInplace( mVLayer );
     else

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -1380,7 +1380,7 @@ void QgsGeoreferencerMainWindow::addVector( const QString &file )
 
   // so layer is not added to legend
   QgsProject::instance()->addMapLayers(
-    QList<QgsMapLayer *>() << mVLayer, false, false );
+    QList<QgsMapLayer *>() << mVLayer.get(), false, false );
 
   // add layer to map canvas
   mCanvas->setLayers( QList<QgsMapLayer *>() << mVLayer.get() );
@@ -1570,9 +1570,9 @@ bool QgsGeoreferencerMainWindow::georeference()
     bool success;
     QgsVectorWarper warper( mTransformParam, mPoints, mProjection );
     if ( mModifiedFileName.isEmpty() )
-      success = warper.executeTransformInplace( mVLayer );
+      success = warper.executeTransformInplace( mVLayer.get() );
     else
-      success = warper.executeTransform( mVLayer, mModifiedFileName );
+      success = warper.executeTransform( mVLayer.get(), mModifiedFileName );
 
     if ( !mPdfOutputFile.isEmpty() )
     {

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -544,7 +544,7 @@ void QgsGeoreferencerMainWindow::generateGDALScript()
       case QgsGcpTransformerInterface::TransformMethod::PolynomialOrder2:
       case QgsGcpTransformerInterface::TransformMethod::PolynomialOrder3:
       case QgsGcpTransformerInterface::TransformMethod::ThinPlateSpline:
-        showGDALScript(QStringList() << generateGDALogr2ogrCommand( mTransformParam ) );
+        showGDALScript( QStringList() << generateGDALogr2ogrCommand( mTransformParam ) );
         break;
       default:
         mMessageBar->pushMessage( tr( "Invalid Transform" ), tr( "GDAL scripting is not supported for %1 transformation." )
@@ -1384,7 +1384,7 @@ void QgsGeoreferencerMainWindow::addRaster( const QString &file )
 
 void QgsGeoreferencerMainWindow::addVector( const QString &file )
 {
-  mVLayer = new QgsVectorLayer( file, QStringLiteral( "Vector" ) );
+  mVLayer = std::make_unique< QgsVectorLayer >( file, QStringLiteral( "Vector" ) );
 
   // so layer is not added to legend
   QgsProject::instance()->addMapLayers(

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -845,11 +845,11 @@ void QgsGeoreferencerMainWindow::showLayerPropertiesDialog()
 {
   if ( mDataType == QgsGeoreferencerMainWindow::RASTER && mRLayer )
   {
-    QgisApp::instance()->showLayerProperties( mRLayer );
+    QgisApp::instance()->showLayerProperties( mRLayer.get() );
   }
   else if ( mDataType == QgsGeoreferencerMainWindow::VECTOR && mVLayer )
   {
-    QgisApp::instance()->showLayerProperties( mVLayer );
+    QgisApp::instance()->showLayerProperties( mVLayer.get() );
   }
   else
   {
@@ -899,7 +899,7 @@ void QgsGeoreferencerMainWindow::localHistogramStretch()
 {
   if ( mRLayer && mCanvas )
   {
-    QgsRectangle rectangle = QgisApp::instance()->mapCanvas()->mapSettings().outputExtentToLayerExtent( mRLayer, QgisApp::instance()->mapCanvas()->extent() );
+    QgsRectangle rectangle = QgisApp::instance()->mapCanvas()->mapSettings().outputExtentToLayerExtent( mRLayer.get(), QgisApp::instance()->mapCanvas()->extent() );
 
     mRLayer->setContrastEnhancement( QgsContrastEnhancement::StretchToMinimumMaximum, QgsRasterMinMaxOrigin::MinMax, rectangle );
     mCanvas->refresh();
@@ -1330,17 +1330,9 @@ void QgsGeoreferencerMainWindow::removeOldLayer()
 {
   // delete layer (and don't signal it as it's our private layer)
   if ( mRLayer )
-  {
-    QgsProject::instance()->removeMapLayers(
-      ( QStringList() << mRLayer->id() ) );
-    mRLayer = nullptr;
-  }
+    mRLayer.reset();
   if ( mVLayer )
-  {
-    QgsProject::instance()->removeMapLayers(
-      ( QStringList() << mVLayer->id() ) );
-    mVLayer = nullptr;
-  }
+    mVLayer.reset();
   mCanvas->setLayers( QList<QgsMapLayer *>() );
   mCanvas->clearCache();
   mRotationEdit->clear();
@@ -1358,10 +1350,10 @@ void QgsGeoreferencerMainWindow::addRaster( const QString &file )
 
   // so layer is not added to legend
   QgsProject::instance()->addMapLayers(
-    QList<QgsMapLayer *>() << mRLayer, false, false );
+    QList<QgsMapLayer *>() << mRLayer.get(), false, false );
 
   // add layer to map canvas
-  mCanvas->setLayers( QList<QgsMapLayer *>() << mRLayer );
+  mCanvas->setLayers( QList<QgsMapLayer *>() << mRLayer.get() );
 
   mAgainAddLayer = false;
 
@@ -1391,7 +1383,7 @@ void QgsGeoreferencerMainWindow::addVector( const QString &file )
     QList<QgsMapLayer *>() << mVLayer, false, false );
 
   // add layer to map canvas
-  mCanvas->setLayers( QList<QgsMapLayer *>() << mVLayer );
+  mCanvas->setLayers( QList<QgsMapLayer *>() << mVLayer.get() );
 
   mAgainAddLayer = false;
 

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -285,7 +285,7 @@ void QgsGeoreferencerMainWindow::openRaster( const QString &fileName )
   ( void )loadGCPs();
 
   if ( mRLayer )
-    mCanvas->setExtent( mLayer->extent() );
+    mCanvas->setExtent( mRLayer->extent() );
 
   mCanvas->refresh();
   QgisApp::instance()->mapCanvas()->refresh();
@@ -492,7 +492,7 @@ bool QgsGeoreferencerMainWindow::getTransformSettings()
     }
     d.getTransformSettings( mTransformParam, mModifiedFileName, mProjection,
                             mPdfOutputMapFile, mPdfOutputFile, mSaveGcp,
-                            mUseZeroForTrans, mLoadInQgis, mUserResX, mUserResY );
+                            mLoadInQgis );
   }
   else
   {
@@ -503,7 +503,8 @@ bool QgsGeoreferencerMainWindow::getTransformSettings()
     }
 
     d.getTransformSettings( mTransformParam, mResamplingMethod, mCompressionMethod,
-                            mModifiedFileName, mProjection, mPdfOutputMapFile, mPdfOutputFile, mSaveGcp, mUseZeroForTrans, mLoadInQgis, mUserResX, mUserResY );
+                            mModifiedFileName, mProjection, mPdfOutputMapFile, mPdfOutputFile,
+                            mSaveGcp, mUseZeroForTrans, mLoadInQgis, mUserResX, mUserResY );
   }
   mTransformParamLabel->setText( tr( "Transform: " ) + QgsGcpTransformerInterface::methodToString( mTransformParam ) );
   mGeorefTransform.selectTransformParametrisation( mTransformParam );
@@ -544,7 +545,7 @@ void QgsGeoreferencerMainWindow::generateGDALScript()
       case QgsGcpTransformerInterface::TransformMethod::PolynomialOrder3:
       case QgsGcpTransformerInterface::TransformMethod::ThinPlateSpline:
         QString vectorCommand = generateGDALogr2ogrCommand( mTransformParam );
-        FALLTHROUGH
+        break;
       default:
         mMessageBar->pushMessage( tr( "Invalid Transform" ), tr( "GDAL scripting is not supported for %1 transformation." )
                                   .arg( QgsGcpTransformerInterface::methodToString( mTransformParam ) )
@@ -1600,7 +1601,7 @@ bool QgsGeoreferencerMainWindow::georeference()
   if ( mDataType == QgsGeoreferencerMainWindow::VECTOR && mVLayer )
   {
     bool success;
-    QgsVectorWarper warper = QgsVectorWarper( mTransformParam, mPoints, mProjection, );
+    QgsVectorWarper warper = QgsVectorWarper( mTransformParam, mPoints, mProjection );
     if ( mModifiedFileName.isEmpty() )
       success = warper.executeTransformInplace( mVLayer );
     else
@@ -2210,10 +2211,13 @@ QString QgsGeoreferencerMainWindow::generateGDALogr2ogrCommand( const QgsGeorefT
   {
     case QgsGcpTransformerInterface::TransformMethod::PolynomialOrder1:
       gdalCommand << QStringLiteral( "-order" ) << QString::number( 1 );
+      break;
     case QgsGcpTransformerInterface::TransformMethod::PolynomialOrder2:
       gdalCommand << QStringLiteral( "-order" ) << QString::number( 2 );
+      break;
     case QgsGcpTransformerInterface::TransformMethod::PolynomialOrder3:
       gdalCommand << QStringLiteral( "-order" ) << QString::number( 3 );
+      break;
     default:
       gdalCommand << QStringLiteral( "-tps" );
   }

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -2179,7 +2179,7 @@ QString QgsGeoreferencerMainWindow::generateGDALogr2ogrCommand( const QgsGeorefT
       gdalCommand << QStringLiteral( "-tps" );
   }
 
-  for ( QgsGeorefDataPoint *pt : qgis::as_const( mPoints ) )
+  for ( QgsGeorefDataPoint *pt : std::as_const( mPoints ) )
   {
     gdalCommand << QStringLiteral( "-gcp %1 %2 %3 %4" ).arg( pt->pixelCoords().x() ).arg( -pt->pixelCoords().y() )
                 .arg( pt->transCoords().x() ).arg( pt->transCoords().y() );

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -450,11 +450,11 @@ void QgsGeoreferencerMainWindow::doGeoreference()
       {
         if ( mModifiedFileName.isEmpty() )
         {
-          QgisApp::instance()->addRasterLayer( mFileName, QFileInfo( mFileName ).completeBaseName() );
+          QgisApp::instance()->addRasterLayer( mFileName, QFileInfo( mFileName ).completeBaseName(), QStringLiteral( "gdal" ) );
         }
         else
         {
-          QgisApp::instance()->addRasterLayer( mModifiedFileName, QFileInfo( mModifiedFileName ).completeBaseName() );
+          QgisApp::instance()->addRasterLayer( mModifiedFileName, QFileInfo( mModifiedFileName ).completeBaseName(), QStringLiteral( "gdal" ) );
         }
       }
       else if ( mDataType == QgsMapLayerType::VectorLayer )

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -189,7 +189,7 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
      * For values in the range 1 to 3, the parameter "order" prescribes the degree of the interpolating polynomials to use,
      * a value of -1 indicates that thin plate spline interpolation should be used for warping.
     */
-    QString generateGDALogr2ogrCommand( int order );
+    QString generateGDALogr2ogrCommand( const QgsGeorefTransform::TransformMethod &method );
 
     // utils
     bool checkReadyGeoref();

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -196,7 +196,7 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     QgsRectangle transformViewportBoundingBox( const QgsRectangle &canvasExtent, QgsGeorefTransform &t,
         bool rasterToWorld = true, uint numSamples = 4 );
     QString convertResamplingEnumToString( QgsImageWarper::ResamplingMethod resampling );
-    int polynomialOrder( QgsGeorefTransform::TransformParametrisation transform );
+    int polynomialOrder( QgsGeorefTransform::TransformMethod transform );
     QString guessWorldFileName( const QString &fileName );
     bool checkFileExisting( const QString &fileName, const QString &title, const QString &question );
     bool equalGCPlists( const QgsGCPList &list1, const QgsGCPList &list2 );

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -18,6 +18,7 @@
 #include "qgsmapcoordsdialog.h"
 #include "qgsimagewarper.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgsmaplayer.h"
 
 #include <memory>
 
@@ -135,11 +136,7 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
       GCPCANCEL
     };
 
-    enum DataType
-    {
-      RASTER,
-      VECTOR
-    };
+    QgsMapLayerType  mDataType;
 
     // gui
     void createActions();
@@ -253,9 +250,7 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     QgsGCPList mPoints;
     QgsGCPList mInitialPoints;
     QgsMapCanvas *mCanvas = nullptr;
-    std::unique_ptr< QgsRasterLayer > mRLayer;
-    std::unique_ptr< QgsVectorLayer > mVLayer;
-    bool mAgainAddLayer;
+    std::unique_ptr< QgsMapLayer > mLayer;
 
     QgsMapTool *mToolZoomIn = nullptr;
     QgsMapTool *mToolZoomOut = nullptr;
@@ -276,8 +271,6 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     bool mExtentsChangedRecursionGuard;
     bool mGCPsDirty;
     bool mLoadInQgis = false;
-
-    DataType mDataType;
 
 
     QgsDockWidget *mDock = nullptr;

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -253,8 +253,8 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     QgsGCPList mPoints;
     QgsGCPList mInitialPoints;
     QgsMapCanvas *mCanvas = nullptr;
-    QgsRasterLayer *mRLayer = nullptr;
-    QgsVectorLayer *mVLayer = nullptr;
+    std::unique_ptr< QgsRasterLayer > mRLayer = nullptr;
+    std::unique_ptr< QgsVectorLayer > mVLayer = nullptr;
     bool mAgainAddLayer;
 
     QgsMapTool *mToolZoomIn = nullptr;

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -253,8 +253,8 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     QgsGCPList mPoints;
     QgsGCPList mInitialPoints;
     QgsMapCanvas *mCanvas = nullptr;
-    std::unique_ptr< QgsRasterLayer > mRLayer = nullptr;
-    std::unique_ptr< QgsVectorLayer > mVLayer = nullptr;
+    std::unique_ptr< QgsRasterLayer > mRLayer;
+    std::unique_ptr< QgsVectorLayer > mVLayer;
     bool mAgainAddLayer;
 
     QgsMapTool *mToolZoomIn = nullptr;

--- a/src/app/georeferencer/qgsrastertransformsettingsdialog.cpp
+++ b/src/app/georeferencer/qgsrastertransformsettingsdialog.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-     qgstransformsettingsdialog.cpp
+     qgsrastertransformsettingsdialog.cpp
      --------------------------------------
     Date                 : 14-Feb-2010
     Copyright            : (C) 2010 by Jack R, Maxim Dubinin (GIS-Lab)
@@ -22,12 +22,12 @@
 #include "qgsapplication.h"
 #include "qgsfilewidget.h"
 #include "qgsrasterlayer.h"
-#include "qgstransformsettingsdialog.h"
+#include "qgsrastertransformsettingsdialog.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsgui.h"
 #include "qgshelp.h"
 
-QgsTransformSettingsDialog::QgsTransformSettingsDialog( const QString &raster, const QString &output,
+QgsRasterTransformSettingsDialog::QgsRasterTransformSettingsDialog( const QString &raster, const QString &output,
     int countGCPpoints, QWidget *parent )
   : QDialog( parent )
   , mSourceRasterFile( raster )
@@ -79,8 +79,8 @@ QgsTransformSettingsDialog::QgsTransformSettingsDialog( const QString &raster, c
     settings.setValue( QStringLiteral( "Plugin-GeoReferencer/lastPDFReportDir" ), tmplFileInfo.absolutePath() );
   } );
 
-  connect( cmbTransformType, &QComboBox::currentTextChanged, this, &QgsTransformSettingsDialog::cmbTransformType_currentIndexChanged );
-  connect( mWorldFileCheckBox, &QCheckBox::stateChanged, this, &QgsTransformSettingsDialog::mWorldFileCheckBox_stateChanged );
+  connect( cmbTransformType, &QComboBox::currentTextChanged, this, &QgsRasterTransformSettingsDialog::cmbTransformType_currentIndexChanged );
+  connect( mWorldFileCheckBox, &QCheckBox::stateChanged, this, &QgsRasterTransformSettingsDialog::mWorldFileCheckBox_stateChanged );
 
   cmbTransformType->addItem( tr( "Linear" ), static_cast<int>( QgsGcpTransformerInterface::TransformMethod::Linear ) );
   cmbTransformType->addItem( tr( "Helmert" ), static_cast<int>( QgsGcpTransformerInterface::TransformMethod::Helmert ) );
@@ -125,10 +125,10 @@ QgsTransformSettingsDialog::QgsTransformSettingsDialog( const QString &raster, c
   cbxLoadInQgisWhenDone->setChecked( settings.value( QStringLiteral( "/Plugin-GeoReferencer/loadinqgis" ), false ).toBool() );
   saveGcpCheckBox->setChecked( settings.value( QStringLiteral( "/Plugin-GeoReferencer/save_gcp_points" ), false ).toBool() );
 
-  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsTransformSettingsDialog::showHelp );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsRasterTransformSettingsDialog::showHelp );
 }
 
-void QgsTransformSettingsDialog::getTransformSettings( QgsGeorefTransform::TransformMethod &tp,
+void QgsRasterTransformSettingsDialog::getTransformSettings( QgsGeorefTransform::TransformMethod &tp,
     QgsImageWarper::ResamplingMethod &rm,
     QString &comprMethod, QString &raster,
     QgsCoordinateReferenceSystem &proj, QString &pdfMapFile, QString &pdfReportFile, QString &gcpPoints, bool &zt, bool &loadInQgis,
@@ -167,7 +167,7 @@ void QgsTransformSettingsDialog::getTransformSettings( QgsGeorefTransform::Trans
   }
 }
 
-void QgsTransformSettingsDialog::resetSettings()
+void QgsRasterTransformSettingsDialog::resetSettings()
 {
   QgsSettings s;
   s.setValue( QStringLiteral( "/Plugin-GeoReferencer/lasttransformation" ), -1 );
@@ -184,7 +184,7 @@ void QgsTransformSettingsDialog::resetSettings()
   s.setValue( QStringLiteral( "/Plugin-GeoReferencer/lastPDFReportDir" ), QDir::homePath() );
 }
 
-void QgsTransformSettingsDialog::changeEvent( QEvent *e )
+void QgsRasterTransformSettingsDialog::changeEvent( QEvent *e )
 {
   QDialog::changeEvent( e );
   switch ( e->type() )
@@ -197,7 +197,7 @@ void QgsTransformSettingsDialog::changeEvent( QEvent *e )
   }
 }
 
-void QgsTransformSettingsDialog::accept()
+void QgsRasterTransformSettingsDialog::accept()
 {
   if ( !mOutputRaster->filePath().isEmpty() )
   {
@@ -237,7 +237,7 @@ void QgsTransformSettingsDialog::accept()
   QDialog::accept();
 }
 
-void QgsTransformSettingsDialog::cmbTransformType_currentIndexChanged( const QString &text )
+void QgsRasterTransformSettingsDialog::cmbTransformType_currentIndexChanged( const QString &text )
 {
   if ( text == tr( "Linear" ) )
   {
@@ -251,7 +251,7 @@ void QgsTransformSettingsDialog::cmbTransformType_currentIndexChanged( const QSt
   }
 }
 
-void QgsTransformSettingsDialog::mWorldFileCheckBox_stateChanged( int state )
+void QgsRasterTransformSettingsDialog::mWorldFileCheckBox_stateChanged( int state )
 {
   bool enableOutputRaster = true;
   if ( state == Qt::Checked )
@@ -262,7 +262,7 @@ void QgsTransformSettingsDialog::mWorldFileCheckBox_stateChanged( int state )
   mOutputRaster->setEnabled( enableOutputRaster );
 }
 
-bool QgsTransformSettingsDialog::checkGCPpoints( int count, int &minGCPpoints )
+bool QgsRasterTransformSettingsDialog::checkGCPpoints( int count, int &minGCPpoints )
 {
   QgsGeorefTransform georefTransform;
   georefTransform.selectTransformParametrisation( ( QgsGeorefTransform::TransformMethod )count );
@@ -270,7 +270,7 @@ bool QgsTransformSettingsDialog::checkGCPpoints( int count, int &minGCPpoints )
   return ( mCountGCPpoints >= minGCPpoints );
 }
 
-QString QgsTransformSettingsDialog::generateModifiedRasterFileName( const QString &raster )
+QString QgsRasterTransformSettingsDialog::generateModifiedRasterFileName( const QString &raster )
 {
   if ( raster.isEmpty() )
     return QString();
@@ -288,7 +288,7 @@ QString QgsTransformSettingsDialog::generateModifiedRasterFileName( const QStrin
 
 // Note this code is duplicated from qgisapp.cpp because
 // I didn't want to make plugins on qgsapplication [TS]
-QIcon QgsTransformSettingsDialog::getThemeIcon( const QString &name )
+QIcon QgsRasterTransformSettingsDialog::getThemeIcon( const QString &name )
 {
   if ( QFile::exists( QgsApplication::activeThemePath() + name ) )
   {
@@ -313,7 +313,7 @@ QIcon QgsTransformSettingsDialog::getThemeIcon( const QString &name )
   }
 }
 
-void QgsTransformSettingsDialog::showHelp()
+void QgsRasterTransformSettingsDialog::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "working_with_raster/georeferencer.html#defining-the-transformation-settings" ) );
 }

--- a/src/app/georeferencer/qgsrastertransformsettingsdialog.h
+++ b/src/app/georeferencer/qgsrastertransformsettingsdialog.h
@@ -1,0 +1,60 @@
+/***************************************************************************
+     qgsrastertransformsettingsdialog.h
+     --------------------------------------
+    Date                 : 14-Feb-2010
+    Copyright            : (C) 2010 by Jack R, Maxim Dubinin (GIS-Lab)
+    Email                : sim@gis-lab.info
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSRASTERTRANSFORMSETTINGSDIALOG_H
+#define QGSRASTER TRANSFORMSETTINGSDIALOG_H
+
+#include <QDialog>
+
+#include "qgsgeorefmainwindow.h"
+
+#include "ui_qgSrastertransformsettingsdialogbase.h"
+
+class QgsRasterTransformSettingsDialog : public QDialog, private Ui::QgsRasterTransformSettingsDialog
+{
+    Q_OBJECT
+
+  public:
+    QgsRasterTransformSettingsDialog( const QString &raster, const QString &output,
+                                int countGCPpoints, QWidget *parent = nullptr );
+
+    void getTransformSettings( QgsGeorefTransform::TransformMethod &tp,
+                               QgsImageWarper::ResamplingMethod &rm, QString &comprMethod,
+                               QString &raster, QgsCoordinateReferenceSystem &proj, QString &pdfMapFile, QString &pdfReportFile, QString &gcpPoints, bool &zt, bool &loadInQgis,
+                               double &resX, double &resY );
+    static void resetSettings();
+
+  protected:
+    void changeEvent( QEvent *e ) override;
+    void accept() override;
+
+  private slots:
+    void cmbTransformType_currentIndexChanged( const QString &text );
+    void mWorldFileCheckBox_stateChanged( int state );
+    QIcon getThemeIcon( const QString &name );
+    void showHelp();
+
+  private:
+    bool checkGCPpoints( int count, int &minGCPpoints );
+    QString generateModifiedRasterFileName( const QString &raster );
+
+    QString mSourceRasterFile;
+
+    int mCountGCPpoints;
+
+    QStringList mListCompression;
+};
+
+#endif // QGSRASTERTRANSFORMSETTINGSDIALOG_H

--- a/src/app/georeferencer/qgsrastertransformsettingsdialog.h
+++ b/src/app/georeferencer/qgsrastertransformsettingsdialog.h
@@ -14,13 +14,13 @@
  ***************************************************************************/
 
 #ifndef QGSRASTERTRANSFORMSETTINGSDIALOG_H
-#define QGSRASTER TRANSFORMSETTINGSDIALOG_H
+#define QGSRASTERTRANSFORMSETTINGSDIALOG_H
 
 #include <QDialog>
 
 #include "qgsgeorefmainwindow.h"
 
-#include "ui_qgSrastertransformsettingsdialogbase.h"
+#include "ui_qgsrastertransformsettingsdialogbase.h"
 
 class QgsRasterTransformSettingsDialog : public QDialog, private Ui::QgsRasterTransformSettingsDialog
 {

--- a/src/app/georeferencer/qgsvectortransformsettingsdialog.cpp
+++ b/src/app/georeferencer/qgsvectortransformsettingsdialog.cpp
@@ -1,0 +1,274 @@
+/***************************************************************************
+     qgsvectortransformsettingsdialog.cpp
+     --------------------------------------
+    Date                 : 14-Feb-2010
+    Copyright            : (C) 2010 by Jack R, Maxim Dubinin (GIS-Lab)
+    Email                : sim@gis-lab.info
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QMessageBox>
+
+#include "qgssettings.h"
+#include "qgsprojectionselectiontreewidget.h"
+#include "qgsapplication.h"
+#include "qgsfilewidget.h"
+#include "qgsrasterlayer.h"
+#include "qgsvectortransformsettingsdialog.h"
+#include "qgscoordinatereferencesystem.h"
+#include "qgsgui.h"
+#include "qgshelp.h"
+
+QgsVectorTransformSettingsDialog::QgsVectorTransformSettingsDialog( const QString &input, const QString &output,
+    int countGCPpoints, const QString &outputFilters, QWidget *parent )
+  : QDialog( parent )
+  , mSourceFile( input )
+  , mCountGCPpoints( countGCPpoints )
+{
+  setupUi( this );
+  QgsSettings settings;
+  QgsGui::instance()->enableAutoGeometryRestore( this );
+
+
+  mOutputVector->setStorageMode( QgsFileWidget::SaveFile );
+  if ( output.isEmpty() )
+  {
+    mOutputVector->setFilePath( generateModifiedOutputFileName( mSourceFile ) );
+  }
+  else
+  {
+    mOutputVector->setFilePath( output );
+  }
+
+  mOutputVector->setStorageMode( QgsFileWidget::SaveFile );
+  mOutputVector->setFilter( outputFilters );
+  mOutputVector->setConfirmOverwrite( false );
+  mOutputVector->setDialogTitle( tr( "Destination" ) );
+  mOutputVector->setDefaultRoot( settings.value( QStringLiteral( "UI/lastVectorFileFilterDir" ), QDir::homePath() ).toString() );
+  connect( mOutputVector, &QgsFileWidget::fileChanged, this, [ = ]
+  {
+    QgsSettings settings;
+    QFileInfo tmplFileInfo( mOutputVector->filePath() );
+    settings.setValue( QStringLiteral( "UI/lastVectorFileFilterDir" ), tmplFileInfo.absolutePath() );
+  } );
+
+  mPdfMap->setStorageMode( QgsFileWidget::SaveFile );
+  mPdfMap->setFilter( tr( "PDF files" ) + " (*.pdf *.PDF)" );
+  mPdfMap->setDialogTitle( tr( "Save Map File As" ) );
+  mPdfMap->setDefaultRoot( settings.value( QStringLiteral( "/Plugin-GeoReferencer/lastPDFReportDir" ), QDir::homePath() ).toString() );
+  connect( mPdfMap, &QgsFileWidget::fileChanged, this, [ = ]
+  {
+    QgsSettings settings;
+    QFileInfo tmplFileInfo( mPdfMap->filePath() );
+    settings.setValue( QStringLiteral( "Plugin-GeoReferencer/lastPDFReportDir" ), tmplFileInfo.absolutePath() );
+  } );
+
+  mPdfReport->setStorageMode( QgsFileWidget::SaveFile );
+  mPdfReport->setFilter( tr( "PDF files" ) + " (*.pdf *.PDF)" );
+  mPdfReport->setDialogTitle( tr( "Save Report File As" ) );
+  mPdfReport->setDefaultRoot( settings.value( QStringLiteral( "/Plugin-GeoReferencer/lastPDFReportDir" ), QDir::homePath() ).toString() );
+  connect( mPdfReport, &QgsFileWidget::fileChanged, this, [ = ]
+  {
+    QgsSettings settings;
+    QFileInfo tmplFileInfo( mPdfReport->filePath() );
+    settings.setValue( QStringLiteral( "Plugin-GeoReferencer/lastPDFReportDir" ), tmplFileInfo.absolutePath() );
+  } );
+
+  connect( cmbTransformType, &QComboBox::currentTextChanged, this, &QgsVectorTransformSettingsDialog::cmbTransformType_currentIndexChanged );
+  connect( mWorldFileCheckBox, &QCheckBox::stateChanged, this, &QgsVectorTransformSettingsDialog::mWorldFileCheckBox_stateChanged );
+
+  cmbTransformType->addItem( tr( "Linear" ), static_cast<int>( QgsGcpTransformerInterface::TransformMethod::Linear ) );
+  cmbTransformType->addItem( tr( "Helmert" ), static_cast<int>( QgsGcpTransformerInterface::TransformMethod::Helmert ) );
+  cmbTransformType->addItem( tr( "Polynomial 1" ), static_cast<int>( QgsGcpTransformerInterface::TransformMethod::PolynomialOrder1 ) );
+  cmbTransformType->addItem( tr( "Polynomial 2" ), static_cast<int>( QgsGcpTransformerInterface::TransformMethod::PolynomialOrder2 ) );
+  cmbTransformType->addItem( tr( "Polynomial 3" ), static_cast<int>( QgsGcpTransformerInterface::TransformMethod::PolynomialOrder3 ) );
+  cmbTransformType->addItem( tr( "Thin Plate Spline" ), static_cast<int>( QgsGcpTransformerInterface::TransformMethod::ThinPlateSpline ) );
+  cmbTransformType->addItem( tr( "Projective" ), static_cast<int>( QgsGcpTransformerInterface::TransformMethod::Projective ) );
+
+
+  QString targetCRSString = settings.value( QStringLiteral( "/Plugin-GeoReferencer/targetsrs" ) ).toString();
+  QgsCoordinateReferenceSystem targetCRS = QgsCoordinateReferenceSystem::fromOgcWmsCrs( targetCRSString );
+  mCrsSelector->setCrs( targetCRS );
+
+  mWorldFileCheckBox->setChecked( settings.value( QStringLiteral( "/Plugin-Georeferencer/word_file_checkbox" ), false ).toBool() );
+
+  cbxLoadInQgisWhenDone->setChecked( settings.value( QStringLiteral( "/Plugin-GeoReferencer/loadinqgis" ), false ).toBool() );
+  saveGcpCheckBox->setChecked( settings.value( QStringLiteral( "/Plugin-GeoReferencer/save_gcp_points" ), false ).toBool() );
+
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsVectorTransformSettingsDialog::showHelp );
+}
+
+void QgsVectorTransformSettingsDialog::getTransformSettings( QgsGeorefTransform::TransformMethod &tp,
+    QString &output, QgsCoordinateReferenceSystem &proj, QString &pdfMapFile,
+    QString &pdfReportFile, QString &gcpPoints, bool &zt, bool &loadInQgis,
+    double &resX, double &resY )
+{
+  if ( cmbTransformType->currentIndex() == -1 )
+    tp = QgsGcpTransformerInterface::TransformMethod::InvalidTransform;
+  else
+    tp = static_cast< QgsGcpTransformerInterface::TransformMethod >( QgsGeorefTransform::TransformMethod )cmbTransformType->currentData().toInt() );
+
+  if ( mWorldFileCheckBox->isChecked() )
+  {
+    output.clear();
+  }
+  else
+  {
+    output = mOutputVector->filePath();
+  }
+  proj = mCrsSelector->crs();
+  pdfMapFile = mPdfMap->filePath();
+  pdfReportFile = mPdfReport->filePath();
+  loadInQgis = cbxLoadInQgisWhenDone->isChecked();
+
+  if ( saveGcpCheckBox->isChecked() )
+  {
+    gcpPoints = mOutputVector->filePath();
+  }
+}
+
+void QgsVectorTransformSettingsDialog::resetSettings()
+{
+  QgsSettings s;
+  s.setValue( QStringLiteral( "/Plugin-GeoReferencer/lastvectortransformation" ), -1 );
+  s.setValue( QStringLiteral( "/Plugin-GeoReferencer/targetsrs" ), QString() );
+  s.setValue( QStringLiteral( "/Plugin-GeoReferencer/loadinqgis" ), false );
+  s.setValue( QStringLiteral( "/Plugin-GeoReferencer/save_gcp_points" ), false );
+  s.setValue( QStringLiteral( "/Plugin-GeoReferencer/word_file_checkbox" ), false );
+  s.setValue( QStringLiteral( "/Plugin-GeoReferencer/lastPDFReportDir" ), QDir::homePath() );
+}
+
+void QgsVectorTransformSettingsDialog::changeEvent( QEvent *e )
+{
+  QDialog::changeEvent( e );
+  switch ( e->type() )
+  {
+    case QEvent::LanguageChange:
+      retranslateUi( this );
+      break;
+    default:
+      break;
+  }
+}
+
+void QgsVectorTransformSettingsDialog::accept()
+{
+  if ( !mOutputVector->filePath().isEmpty() )
+  {
+    //if the file path is relative, make it relative to the  file directory
+    QString outputVectorName = mOutputVector->filePath();
+    QFileInfo FileInfo( mSourceFile );
+    QFileInfo outputFileInfo( FileInfo.absoluteDir(), outputVectorName );
+
+    if ( outputFileInfo.fileName().isEmpty() || !outputFileInfo.dir().exists() )
+    {
+      QMessageBox::warning( this, tr( "Destination" ), tr( "Invalid output file name." ) );
+      return;
+    }
+    if ( outputFileInfo.filePath() == mSourceFile )
+    {
+      //can't overwrite input file
+      QMessageBox::warning( this, tr( "Destination" ), tr( "Input file can not be overwritten." ) );
+      return;
+    }
+    mOutputVector->setFilePath( outputFileInfo.absoluteFilePath() );
+  }
+
+  QgsSettings settings;
+  settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/lasttransformation" ), cmbTransformType->currentIndex() );
+  settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/targetsrs" ), mCrsSelector->crs().authid() );
+  settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/loadinqgis" ), cbxLoadInQgisWhenDone->isChecked() );
+  settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/word_file_checkbox" ), mWorldFileCheckBox->isChecked() );
+  settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/save_gcp_points" ), saveGcpCheckBox->isChecked() );
+
+
+  QDialog::accept();
+}
+
+void QgsVectorTransformSettingsDialog::cmbTransformType_currentIndexChanged( const QString &text )
+{
+  if ( text == tr( "Linear" ) )
+  {
+    mWorldFileCheckBox->setEnabled( true );
+  }
+  else
+  {
+    mWorldFileCheckBox->setEnabled( false );
+    // reset world file checkbox when transformation differ from Linear
+    mWorldFileCheckBox->setChecked( false );
+  }
+}
+
+void QgsVectorTransformSettingsDialog::mWorldFileCheckBox_stateChanged( int state )
+{
+  bool enableOutput = true;
+  if ( state == Qt::Checked )
+  {
+    enableOutput = false;
+  }
+  label_2->setEnabled( enableOutput );
+  mOutputVector->setEnabled( enableOutput );
+}
+
+bool QgsVectorTransformSettingsDialog::checkGCPpoints( int count, int &minGCPpoints )
+{
+  QgsGeorefTransform georefTransform;
+  georefTransform.selectTransformParametrisation( ( QgsGeorefTransform::TransformMethod )count );
+  minGCPpoints = georefTransform.minimumGCPCount();
+  return ( mCountGCPpoints >= minGCPpoints );
+}
+
+QString QgsVectorTransformSettingsDialog::generateModifiedOutputFileName( const QString &filename )
+{
+  if ( filename.isEmpty() )
+    return QString();
+
+  QString modifiedFileName = filename;
+  int lastDot = filename.lastIndexOf( "." );
+  if ( filename.length() - lastDot <= 4 )
+    modifiedFileName = modifiedFileName.insert( lastDot, tr( "_modified" ) );
+  else
+    modifiedFileName.append( tr( "_modified" ) );
+
+  return modifiedFileName;
+}
+
+// Note this code is duplicated from qgisapp.cpp because
+// I didn't want to make plugins on qgsapplication [TS]
+QIcon QgsVectorTransformSettingsDialog::getThemeIcon( const QString &name )
+{
+  if ( QFile::exists( QgsApplication::activeThemePath() + name ) )
+  {
+    return QIcon( QgsApplication::activeThemePath() + name );
+  }
+  else if ( QFile::exists( QgsApplication::defaultThemePath() + name ) )
+  {
+    return QIcon( QgsApplication::defaultThemePath() + name );
+  }
+  else
+  {
+    QgsSettings settings;
+    QString themePath = ":/icons/" + settings.value( QStringLiteral( "Themes" ) ).toString() + name;
+    if ( QFile::exists( themePath ) )
+    {
+      return QIcon( themePath );
+    }
+    else
+    {
+      return QIcon( ":/icons/default" + name );
+    }
+  }
+}
+
+void QgsVectorTransformSettingsDialog::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "working_with_raster/georeferencer.html#defining-the-transformation-settings" ) );
+}

--- a/src/app/georeferencer/qgsvectortransformsettingsdialog.cpp
+++ b/src/app/georeferencer/qgsvectortransformsettingsdialog.cpp
@@ -50,7 +50,7 @@ QgsVectorTransformSettingsDialog::QgsVectorTransformSettingsDialog( const QStrin
 
   mOutputVector->setStorageMode( QgsFileWidget::SaveFile );
   mOutputVector->setFilter( outputFilters );
-  mOutputVector->setConfirmOverwrite( false );
+  mOutputVector->setConfirmOverwrite( true );
   mOutputVector->setDialogTitle( tr( "Destination" ) );
   mOutputVector->setDefaultRoot( settings.value( QStringLiteral( "UI/lastVectorFileFilterDir" ), QDir::homePath() ).toString() );
   connect( mOutputVector, &QgsFileWidget::fileChanged, this, [ = ]
@@ -232,7 +232,7 @@ QString QgsVectorTransformSettingsDialog::generateModifiedOutputFileName( const 
 
   QString modifiedFileName = filename;
   int lastDot = filename.lastIndexOf( "." );
-  if ( filename.length() - lastDot <= 4 )
+  if ( filename.length() - lastDot <= 8 )
     modifiedFileName = modifiedFileName.insert( lastDot, tr( "_modified" ) );
   else
     modifiedFileName.append( tr( "_modified" ) );

--- a/src/app/georeferencer/qgsvectortransformsettingsdialog.cpp
+++ b/src/app/georeferencer/qgsvectortransformsettingsdialog.cpp
@@ -114,7 +114,7 @@ void QgsVectorTransformSettingsDialog::getTransformSettings( QgsGeorefTransform:
   if ( cmbTransformType->currentIndex() == -1 )
     tp = QgsGcpTransformerInterface::TransformMethod::InvalidTransform;
   else
-    tp = static_cast< QgsGcpTransformerInterface::TransformMethod >( QgsGeorefTransform::TransformMethod )cmbTransformType->currentData().toInt() );
+    tp = static_cast< QgsGcpTransformerInterface::TransformMethod >( cmbTransformType->currentData().toInt() );
 
   if ( mWorldFileCheckBox->isChecked() )
   {

--- a/src/app/georeferencer/qgsvectortransformsettingsdialog.cpp
+++ b/src/app/georeferencer/qgsvectortransformsettingsdialog.cpp
@@ -108,8 +108,7 @@ QgsVectorTransformSettingsDialog::QgsVectorTransformSettingsDialog( const QStrin
 
 void QgsVectorTransformSettingsDialog::getTransformSettings( QgsGeorefTransform::TransformMethod &tp,
     QString &output, QgsCoordinateReferenceSystem &proj, QString &pdfMapFile,
-    QString &pdfReportFile, QString &gcpPoints, bool &zt, bool &loadInQgis,
-    double &resX, double &resY )
+    QString &pdfReportFile, QString &gcpPoints, bool &loadInQgis )
 {
   if ( cmbTransformType->currentIndex() == -1 )
     tp = QgsGcpTransformerInterface::TransformMethod::InvalidTransform;
@@ -222,7 +221,7 @@ bool QgsVectorTransformSettingsDialog::checkGCPpoints( int count, int &minGCPpoi
 {
   QgsGeorefTransform georefTransform;
   georefTransform.selectTransformParametrisation( ( QgsGeorefTransform::TransformMethod )count );
-  minGCPpoints = georefTransform.minimumGCPCount();
+  minGCPpoints = georefTransform.minimumGcpCount();
   return ( mCountGCPpoints >= minGCPpoints );
 }
 

--- a/src/app/georeferencer/qgsvectortransformsettingsdialog.h
+++ b/src/app/georeferencer/qgsvectortransformsettingsdialog.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-     qgstransformsettingsdialog.h
+     QgsVectorTransformSettingsDialog.h
      --------------------------------------
     Date                 : 14-Feb-2010
     Copyright            : (C) 2010 by Jack R, Maxim Dubinin (GIS-Lab)
@@ -13,26 +13,27 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef QGSTRANSFORMSETTINGSDIALOG_H
-#define QGSTRANSFORMSETTINGSDIALOG_H
+#ifndef QGSVECTORTRANSFORMSETTINGSDIALOG_H
+#define QGSVECTORTRANSFORMSETTINGSDIALOG_H
 
 #include <QDialog>
 
 #include "qgsgeorefmainwindow.h"
 
-#include "ui_qgstransformsettingsdialogbase.h"
+#include "ui_qgsvectortransformsettingsdialogbase.h"
 
-class QgsTransformSettingsDialog : public QDialog, private Ui::QgsTransformSettingsDialog
+class QgsVectorTransformSettingsDialog : public QDialog, private Ui::QgsVectorTransformSettingsDialog
 {
     Q_OBJECT
 
   public:
-    QgsTransformSettingsDialog( const QString &raster, const QString &output,
-                                int countGCPpoints, QWidget *parent = nullptr );
+    QgsVectorTransformSettingsDialog( const QString &input, const QString &output,
+                                      int countGCPpoints, const QString &outputFilters,
+                                      QWidget *parent = nullptr );
 
     void getTransformSettings( QgsGeorefTransform::TransformMethod &tp,
-                               QgsImageWarper::ResamplingMethod &rm, QString &comprMethod,
-                               QString &raster, QgsCoordinateReferenceSystem &proj, QString &pdfMapFile, QString &pdfReportFile, QString &gcpPoints, bool &zt, bool &loadInQgis,
+                               QString &output, QgsCoordinateReferenceSystem &proj, QString &pdfMapFile,
+                               QString &pdfReportFile, QString &gcpPoints, bool &zt, bool &loadInQgis,
                                double &resX, double &resY );
     static void resetSettings();
 
@@ -48,13 +49,12 @@ class QgsTransformSettingsDialog : public QDialog, private Ui::QgsTransformSetti
 
   private:
     bool checkGCPpoints( int count, int &minGCPpoints );
-    QString generateModifiedRasterFileName( const QString &raster );
+    QString generateModifiedOutputFileName( const QString &output );
 
-    QString mSourceRasterFile;
+    QString mSourceFile;
 
     int mCountGCPpoints;
 
-    QStringList mListCompression;
 };
 
-#endif // QGSTRANSFORMSETTINGSDIALOG_H
+#endif // QGSVECTORTRANSFORMSETTINGSDIALOG_H

--- a/src/app/georeferencer/qgsvectortransformsettingsdialog.h
+++ b/src/app/georeferencer/qgsvectortransformsettingsdialog.h
@@ -33,8 +33,7 @@ class QgsVectorTransformSettingsDialog : public QDialog, private Ui::QgsVectorTr
 
     void getTransformSettings( QgsGeorefTransform::TransformMethod &tp,
                                QString &output, QgsCoordinateReferenceSystem &proj, QString &pdfMapFile,
-                               QString &pdfReportFile, QString &gcpPoints, bool &zt, bool &loadInQgis,
-                               double &resX, double &resY );
+                               QString &pdfReportFile, QString &gcpPoints, bool &loadInQgis );
     static void resetSettings();
 
   protected:

--- a/src/app/georeferencer/qgsvectorwarper.cpp
+++ b/src/app/georeferencer/qgsvectorwarper.cpp
@@ -37,7 +37,7 @@ QgsVectorWarper::QgsVectorWarper( QgsGcpTransformerInterface::TransformMethod &m
 {
   QVector<QgsPointXY> srcPts;
   QVector<QgsPointXY> destPts;
-  for ( QgsGeorefDataPoint *pt : qgis::as_const( points ) )
+  for ( QgsGeorefDataPoint *pt : std::as_const( points ) )
   {
     srcPts << pt->pixelCoords();
     destPts << pt->transCoords();

--- a/src/app/georeferencer/qgsvectorwarper.cpp
+++ b/src/app/georeferencer/qgsvectorwarper.cpp
@@ -88,7 +88,7 @@ bool QgsVectorWarper::executeTransform( const QgsVectorLayer *layer, const QStri
     return false;
   QgsVectorFileWriter::SaveVectorOptions saveOptions;
   std::unique_ptr< QgsVectorFileWriter > exporter( QgsVectorFileWriter::create( outputName, layer->fields(), layer->wkbType(), mDestCRS, QgsCoordinateTransformContext(), saveOptions ) );
-  if ( !exporter->hasError() )
+  if ( exporter->hasError() )
     return false;
 
   QgsFeature outputFeature;
@@ -120,7 +120,7 @@ bool QgsVectorWarper::executeTransform( const QgsVectorLayer *layer, const QStri
     {
       outputFeature.setGeometry( transformed );
       exporter->addFeature( outputFeature, QgsFeatureSink::FastInsert );
-      if ( !exporter->hasError() )
+      if ( exporter->hasError() )
       {
         allGood = false;
         QgsMessageLog::logMessage( QObject::tr( "Error performing transformation: {}" ).arg( exporter->errorMessage() ) );

--- a/src/app/georeferencer/qgsvectorwarper.cpp
+++ b/src/app/georeferencer/qgsvectorwarper.cpp
@@ -30,8 +30,8 @@
 
 #include "qgsvectorwarper.h"
 
-QgsVectorWarper::QgsVectorWarper( QgsGcpTransformerInterface::TransformMethod& method, const QgsGCPList& points,
-                                  const QgsCoordinateReferenceSystem& destCrs )
+QgsVectorWarper::QgsVectorWarper( QgsGcpTransformerInterface::TransformMethod &method, const QgsGCPList &points,
+                                  const QgsCoordinateReferenceSystem &destCrs )
   : mDestCRS( destCrs )
 {
   QVector<QgsPointXY> srcPts;
@@ -89,7 +89,7 @@ bool QgsVectorWarper::executeTransform( const QgsVectorLayer *layer, const QStri
       outputFeature.setGeometry( transformed );
       exporter->addFeature( outputFeature, QgsFeatureSink::FastInsert );
       if ( !exporter->lastError().isEmpty() )
-          allGood = false;
+        allGood = false;
     }
   }
   return allGood;

--- a/src/app/georeferencer/qgsvectorwarper.cpp
+++ b/src/app/georeferencer/qgsvectorwarper.cpp
@@ -1,0 +1,57 @@
+/***************************************************************************
+     qgsvectorwarper.cpp
+     --------------------------------------
+    Date                 :
+    Copyright            :
+    Email                :
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include <cmath>
+#include <cstdio>
+
+#include <cpl_conv.h>
+#include <cpl_string.h>
+#include <gdal.h>
+#include <ogr_spatialref.h>
+
+#include <QFile>
+#include <QProgressDialog>
+
+#include "qgsvectorwarper.h"
+#include "qgsrunprocess.h"
+
+
+
+
+QgsVectorWarper::QgsVectorWarper()
+{
+}
+
+bool QgsVectorWarper::executeGDALCommand( const QString &fused_command )
+{
+  QString command;
+  QStringList arguments;
+  command, arguments = QgsRunProcess::splitCommand( fused_command );
+  if ( arguments.length() == 1 )
+    arguments.replace( 0, arguments.first().replace( "ogr2ogr ","") );
+  else if ( arguments.first() == QString( "ogr2ogr" ) )
+    arguments.removeFirst();
+
+  if ( command.isEmpty() )
+    command = QString( "ogr2ogr" );
+
+  QgsBlockingProcess *proc = new QgsBlockingProcess( command, arguments );
+  //proc.setStdOutHandler(on_stdout);
+  //proc.setStdErrHandler(on_stderr);
+  proc->run();
+  if ( proc->exitStatus() == QProcess::NormalExit )
+    return true;
+  else
+    return false;
+}

--- a/src/app/georeferencer/qgsvectorwarper.cpp
+++ b/src/app/georeferencer/qgsvectorwarper.cpp
@@ -15,43 +15,70 @@
 #include <cmath>
 #include <cstdio>
 
-#include <cpl_conv.h>
-#include <cpl_string.h>
-#include <gdal.h>
-#include <ogr_spatialref.h>
+#include "qgsgcpgeometrytransformer.h"
+#include "qgsgcplist.h"
+#include "qgsgeorefdatapoint.h"
+#include "qgscoordinatereferencesystem.h"
+#include "qgsvectorlayer.h"
+#include "qgsgeometry.h"
+#include "qgsvectorlayerexporter.h"
+#include "qgsprocessingfeaturesource.h"
 
 #include <QFile>
 #include <QProgressDialog>
 
 #include "qgsvectorwarper.h"
-#include "qgsrunprocess.h"
 
 
 
 
-QgsVectorWarper::QgsVectorWarper()
+QgsVectorWarper::QgsVectorWarper( QgsGcpTransformerInterface::TransformMethod method, const QgsGCPList points,
+                                  const QgsCoordinateReferenceSystem destCrs )
+  : mDestCRS( destCrs )
 {
+  QVector<QgsPointXY> srcPts;
+  QVector<QgsPointXY> destPts;
+  for ( QgsGeorefDataPoint *pt : qgis::as_const( mPoints ) )
+  {
+    srcPts << pt->pixelCoords();
+    destPts << pt->transCoords();
+  }
+  mTransformer = QgsGcpGeometryTransformer( method, srcPts, destPts );
 }
 
-bool QgsVectorWarper::executeGDALCommand( const QString &fused_command )
+bool QgsVectorWarper::executeTransformInplace( QgsVectorLayer *layer )
 {
-  QString command;
-  QStringList arguments;
-  command, arguments = QgsRunProcess::splitCommand( fused_command );
-  if ( arguments.length() == 1 )
-    arguments.replace( 0, arguments.first().replace( "ogr2ogr ","") );
-  else if ( arguments.first() == QString( "ogr2ogr" ) )
-    arguments.removeFirst();
-
-  if ( command.isEmpty() )
-    command = QString( "ogr2ogr" );
-
-  QgsBlockingProcess *proc = new QgsBlockingProcess( command, arguments );
-  //proc.setStdOutHandler(on_stdout);
-  //proc.setStdErrHandler(on_stderr);
-  proc->run();
-  if ( proc->exitStatus() == QProcess::NormalExit )
-    return true;
-  else
+  if ( !layer )
     return false;
+  if ( layer->sourceCrs() != mDestCRS )
+    layer.setCoordinateSystem( mDestCRS );
+
+  QgsFeatureIterator it = layer->getFeatures( QgsFeatureRequest(), QgsProcessingFeatureSource::FlagSkipGeometryValidityChecks );
+  QgsFeature f;
+  while ( it.nextFeature( f ) )
+  {
+    f.setGeometry( mTransofrmer.transform( f.geometry() );
+  }
+  return true;
+}
+
+bool QgsVectorWarper::executeTransform( const QgsVectorLayer *layer, const QString outputName )
+{
+  if ( !layer )
+    return false;
+  exporter = QgsVectorLayerExporter( ouputName, "OGR", layer->fields(), layer->geometryType(), mDestCRS, true );
+  if ( exporter.errorCode() != QgsVectorLayerExporter::NoError )
+    return false;
+
+  QgsFeature outputFeature;
+  QgsFeatureIterator it = layer->getFeatures( QgsFeatureRequest(), QgsProcessingFeatureSource::FlagSkipGeometryValidityChecks );
+  QgsFeature f;
+  while ( it.nextFeature( f ) )
+  {
+    outputFeature = QgsFeature( f );
+    outputFeature.setGeometry( mTransofrmer.transform( f.geometry() ) );
+    exporter.addFeature( outputFeature, QgsFeatureSink.FastInsert );
+  }
+  exporter.flushBuffer();
+  return true;
 }

--- a/src/app/georeferencer/qgsvectorwarper.h
+++ b/src/app/georeferencer/qgsvectorwarper.h
@@ -24,6 +24,7 @@
 class QgsCoordinateReferenceSystem;
 class QgsGCPList;
 class QWidget;
+class QgsFeedback;
 
 /**
  * Base implementation of QgsVectorWarper.
@@ -42,18 +43,20 @@ class QgsVectorWarper
     /**
      * Functions to reproject features of the vector layer
      * \param layer source vector layer
+     * \param feedback feedback instance for reporting and cancelling
      * \return True if operation finished properly, otherwise false.
      * \since QGIS 3.20
      */
-    bool executeTransformInplace( QgsVectorLayer *layer );
+    bool executeTransformInplace( QgsVectorLayer *layer, QgsFeedback* feedback = nullptr  );
 
     /**
      * Functions to reproject features of the vector layer to a new source
      * \param layer source vector layer
+     * \param feedback feedback instance for reporting and cancelling
      * \return True if operation finished properly, otherwise false.
      * \since QGIS 3.20
      */
-    bool executeTransform( const QgsVectorLayer *layer, const QString outputName );
+    bool executeTransform( const QgsVectorLayer *layer, const QString outputName, QgsFeedback* feedback = nullptr );
 
   private:
     QgsGcpGeometryTransformer *mTransformer;

--- a/src/app/georeferencer/qgsvectorwarper.h
+++ b/src/app/georeferencer/qgsvectorwarper.h
@@ -20,25 +20,44 @@
 
 #include <vector>
 
+class QgsGcpGeometryTransformer;
+class QgsCoordinateReferenceSystem;
+class QgsGCPList;
 class QWidget;
 
 /**
  * Base implementation of QgsVectorWarper.
- * Creates the process to perform the ogr2ogr call.
+ * \param method QgsGcpTransofmer method, based on gdal transformation methods
+ * \param points data points used in the georeferencer
+ * \param destCrs destination projection of the vector layer
  * \since QGIS 3.20
  */
 class QgsVectorWarper
 {
   public:
-    explicit QgsVectorWarper();
+    explicit QgsVectorWarper( QgsGcpTransformerInterface::TransformMethod method, const QgsGCPList points,
+                              const QgsCoordinateReferenceSystem destCrs );
 
     /**
-     * Functions that creates a QgsBlockingProcess to call ogr2ogr.
-     * \param command command string to use for the process.
+     * Functions to reproject features of the vector layer
+     * \param layer source vector layer
      * \return True if operation finished properly, otherwise false.
      * \since QGIS 3.20
      */
-    bool executeGDALCommand( const QString &fused_command );
+    bool executeTransformInplace( QgsVectorLayer *layer );
+
+    /**
+     * Functions to reproject features of the vector layer to a new source
+     * \param layer source vector layer
+     * \return True if operation finished properly, otherwise false.
+     * \since QGIS 3.20
+     */
+    bool executeTransform( const QgsVectorLayer *layer, const QString outputName );
+
+  private:
+    QgsGcpGeometryTransformer mTransformer;
+    const QgsCoordinateReferenceSystem mSrcCRS;
+    const QgsCoordinateReferenceSystem mDestCRS;
 
 };
 

--- a/src/app/georeferencer/qgsvectorwarper.h
+++ b/src/app/georeferencer/qgsvectorwarper.h
@@ -47,7 +47,7 @@ class QgsVectorWarper
      * \return True if operation finished properly, otherwise false.
      * \since QGIS 3.20
      */
-    bool executeTransformInplace( QgsVectorLayer *layer, QgsFeedback *feedback = nullptr  );
+    bool executeTransformInplace( QgsVectorLayer *layer, QgsFeedback *feedback = nullptr );
 
     /**
      * Functions to reproject features of the vector layer to a new source

--- a/src/app/georeferencer/qgsvectorwarper.h
+++ b/src/app/georeferencer/qgsvectorwarper.h
@@ -43,20 +43,20 @@ class QgsVectorWarper
     /**
      * Functions to reproject features of the vector layer
      * \param layer source vector layer
-     * \param feedback feedback instance for reporting and cancelling
+     * \param feedback optional qgsfeedback instance
      * \return True if operation finished properly, otherwise false.
      * \since QGIS 3.20
      */
-    bool executeTransformInplace( QgsVectorLayer *layer, QgsFeedback* feedback = nullptr  );
+    bool executeTransformInplace( QgsVectorLayer *layer, QgsFeedback *feedback = nullptr  );
 
     /**
      * Functions to reproject features of the vector layer to a new source
      * \param layer source vector layer
-     * \param feedback feedback instance for reporting and cancelling
+     * \param feedback optional qgsfeedback instance
      * \return True if operation finished properly, otherwise false.
      * \since QGIS 3.20
      */
-    bool executeTransform( const QgsVectorLayer *layer, const QString outputName, QgsFeedback* feedback = nullptr );
+    bool executeTransform( const QgsVectorLayer *layer, const QString outputName, QgsFeedback *feedback = nullptr );
 
   private:
     QgsGcpGeometryTransformer *mTransformer;

--- a/src/app/georeferencer/qgsvectorwarper.h
+++ b/src/app/georeferencer/qgsvectorwarper.h
@@ -34,9 +34,10 @@ class QWidget;
  */
 class QgsVectorWarper
 {
+
   public:
-    explicit QgsVectorWarper( QgsGcpTransformerInterface::TransformMethod method, const QgsGCPList points,
-                              const QgsCoordinateReferenceSystem destCrs );
+    explicit QgsVectorWarper( QgsGcpTransformerInterface::TransformMethod &method, const QgsGCPList &points,
+                              const QgsCoordinateReferenceSystem &destCrs );
 
     /**
      * Functions to reproject features of the vector layer
@@ -55,9 +56,8 @@ class QgsVectorWarper
     bool executeTransform( const QgsVectorLayer *layer, const QString outputName );
 
   private:
-    QgsGcpGeometryTransformer mTransformer;
-    const QgsCoordinateReferenceSystem mSrcCRS;
-    const QgsCoordinateReferenceSystem mDestCRS;
+    QgsGcpGeometryTransformer *mTransformer;
+    QgsCoordinateReferenceSystem mDestCRS;
 
 };
 

--- a/src/app/georeferencer/qgsvectorwarper.h
+++ b/src/app/georeferencer/qgsvectorwarper.h
@@ -17,10 +17,10 @@
 
 #include <QCoreApplication>
 #include <QString>
+#include "qgsgcpgeometrytransformer.h"
 
 #include <vector>
 
-class QgsGcpGeometryTransformer;
 class QgsCoordinateReferenceSystem;
 class QgsGCPList;
 class QWidget;

--- a/src/app/georeferencer/qgsvectorwarper.h
+++ b/src/app/georeferencer/qgsvectorwarper.h
@@ -1,0 +1,46 @@
+/***************************************************************************
+     qgsvectorwarper.h
+     --------------------------------------
+    Date                 :
+    Copyright            :
+    Email                :
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSVECTORWARPER_H
+#define QGSVECTORWARPER_H
+
+#include <QCoreApplication>
+#include <QString>
+
+#include <vector>
+
+class QWidget;
+
+/**
+ * Base implementation of QgsVectorWarper.
+ * Creates the process to perform the ogr2ogr call.
+ * \since QGIS 3.20
+ */
+class QgsVectorWarper
+{
+  public:
+    explicit QgsVectorWarper();
+
+    /**
+     * Functions that creates a QgsBlockingProcess to call ogr2ogr.
+     * \param command command string to use for the process.
+     * \return True if operation finished properly, otherwise false.
+     * \since QGIS 3.20
+     */
+    bool executeGDALCommand( const QString &fused_command );
+
+};
+
+
+#endif

--- a/src/app/georeferencer/qgsvectorwarper.h
+++ b/src/app/georeferencer/qgsvectorwarper.h
@@ -31,7 +31,7 @@ class QgsFeedback;
  * \param method QgsGcpTransofmer method, based on gdal transformation methods
  * \param points data points used in the georeferencer
  * \param destCrs destination projection of the vector layer
- * \since QGIS 3.20
+ * \since QGIS 3.24
  */
 class QgsVectorWarper
 {
@@ -45,7 +45,7 @@ class QgsVectorWarper
      * \param layer source vector layer
      * \param feedback optional qgsfeedback instance
      * \return True if operation finished properly, otherwise false.
-     * \since QGIS 3.20
+     * \since QGIS 3.24
      */
     bool executeTransformInplace( QgsVectorLayer *layer, QgsFeedback *feedback = nullptr );
 
@@ -54,7 +54,7 @@ class QgsVectorWarper
      * \param layer source vector layer
      * \param feedback optional qgsfeedback instance
      * \return True if operation finished properly, otherwise false.
-     * \since QGIS 3.20
+     * \since QGIS 3.24
      */
     bool executeTransform( const QgsVectorLayer *layer, const QString outputName, QgsFeedback *feedback = nullptr );
 

--- a/src/ui/georeferencer/qgsgeorefpluginguibase.ui
+++ b/src/ui/georeferencer/qgsgeorefpluginguibase.ui
@@ -20,7 +20,7 @@
      <x>0</x>
      <y>0</y>
      <width>872</width>
-     <height>25</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -91,6 +91,7 @@
     <bool>false</bool>
    </attribute>
    <addaction name="mActionOpenRaster"/>
+   <addaction name="mActionOpenVector"/>
    <addaction name="separator"/>
    <addaction name="mActionStartGeoref"/>
    <addaction name="mActionGDALScript"/>
@@ -154,7 +155,7 @@
     <string>GCP table</string>
    </property>
    <attribute name="dockWidgetArea">
-    <number>8</number>
+   <number>8</number>
    </attribute>
    <widget class="QWidget" name="dockWidgetContents">
     <layout class="QHBoxLayout" name="horizontalLayout_2"/>
@@ -340,9 +341,9 @@
     <string>Ctrl+P</string>
    </property>
   </action>
-  <action name="mActionRasterProperties">
+  <action name="mActionLayerProperties">
    <property name="text">
-    <string>Raster Properties…</string>
+    <string>Layer Properties…</string>
    </property>
   </action>
   <action name="mActionMoveGCPPoint">
@@ -380,6 +381,24 @@
    </property>
    <property name="text">
     <string>Reset Georeferencer</string>
+   </property>
+  </action>
+  <action name="mActionOpenVector">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionAddOgrLayer.svg</normaloff>:/images/themes/default/mActionAddOgrLayer.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Open Vector…</string>
+   </property>
+   <property name="toolTip">
+    <string>Open Vector…</string>
+   </property>
+   <property name="statusTip">
+    <string>Open raster</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+O</string>
    </property>
   </action>
  </widget>

--- a/src/ui/georeferencer/qgsrastertransformsettingsdialogbase.ui
+++ b/src/ui/georeferencer/qgsrastertransformsettingsdialogbase.ui
@@ -1,0 +1,388 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsRasterTransformSettingsDialog</class>
+ <widget class="QDialog" name="QgsRasterTransformSettingsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>438</width>
+    <height>702</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Transformation Settings</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="7" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Output Settings</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="mWorldFileCheckBox">
+        <property name="text">
+         <string>Create world file only (linear transforms)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Output raster</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsFileWidget" name="mOutputRaster"/>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QCheckBox" name="cbxZeroAsTrans">
+        <property name="text">
+         <string>Use 0 for transparency when needed</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="mCompressionLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Compression</string>
+        </property>
+        <property name="buddy">
+         <cstring>cmbCompressionComboBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="cmbCompressionComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QGroupBox" name="cbxUserResolution">
+        <property name="title">
+         <string>Set target resolution</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_3">
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="1" column="1">
+          <widget class="QgsValidatedDoubleSpinBox" name="dsbVerticalRes">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="frame">
+            <bool>true</bool>
+           </property>
+           <property name="decimals">
+            <number>5</number>
+           </property>
+           <property name="minimum">
+            <double>-999999.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>0.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>Horizontal</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>Vertical</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QgsValidatedDoubleSpinBox" name="dsbHorizRes">
+           <property name="decimals">
+            <number>5</number>
+           </property>
+           <property name="minimum">
+            <double>0.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>999999.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="saveGcpCheckBox">
+        <property name="text">
+         <string>Save GCP points</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Reports</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_6">
+      <item row="0" column="1">
+       <widget class="QgsFileWidget" name="mPdfMap"/>
+      </item>
+      <item row="1" column="1">
+       <widget class="QgsFileWidget" name="mPdfReport"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Generate PDF report</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Generate PDF map</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Transformation Parameters</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Transformation type</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="cmbTransformType">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="cmbResampling">
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <item>
+         <property name="text">
+          <string>Nearest neighbour</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Linear</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Cubic</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Cubic Spline</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Lanczos</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="textLabel1">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Resampling method</string>
+        </property>
+        <property name="buddy">
+         <cstring>cmbResampling</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Target SRS</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QCheckBox" name="cbxLoadInQgisWhenDone">
+     <property name="text">
+      <string>Load in QGIS when done</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsValidatedDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header location="global">georeferencer/qgsvalidateddoublespinbox.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>cmbTransformType</tabstop>
+  <tabstop>cmbResampling</tabstop>
+  <tabstop>mCrsSelector</tabstop>
+  <tabstop>mOutputRaster</tabstop>
+  <tabstop>cmbCompressionComboBox</tabstop>
+  <tabstop>mWorldFileCheckBox</tabstop>
+  <tabstop>cbxZeroAsTrans</tabstop>
+  <tabstop>cbxUserResolution</tabstop>
+  <tabstop>dsbHorizRes</tabstop>
+  <tabstop>dsbVerticalRes</tabstop>
+  <tabstop>mPdfMap</tabstop>
+  <tabstop>mPdfReport</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QgsRasterTransformSettingsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsRasterTransformSettingsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/georeferencer/qgsvectortransformsettingsdialogbase.ui
+++ b/src/ui/georeferencer/qgsvectortransformsettingsdialogbase.ui
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsVectorTransformSettingsDialog</class>
+ <widget class="QDialog" name="QgsVectorTransformSettingsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>438</width>
+    <height>374</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Transformation Settings</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="9" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="7" column="0">
+    <widget class="QCheckBox" name="cbxLoadInQgisWhenDone">
+     <property name="text">
+      <string>Load in QGIS when done</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Reports</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_6">
+      <item row="0" column="1">
+       <widget class="QgsFileWidget" name="mPdfMap"/>
+      </item>
+      <item row="1" column="1">
+       <widget class="QgsFileWidget" name="mPdfReport"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Generate PDF report</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Generate PDF map</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Transformation Parameters</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="1" column="1">
+       <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Target SRS</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Transformation type</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="cmbTransformType">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Output Settings</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="1">
+       <widget class="QgsFileWidget" name="mOutputVector"/>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="mWorldFileCheckBox">
+        <property name="text">
+         <string>Create world file only (linear transforms)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Output vector</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="saveGcpCheckBox">
+        <property name="text">
+         <string>Save GCP points</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>cmbTransformType</tabstop>
+  <tabstop>mCrsSelector</tabstop>
+  <tabstop>mOutputVector</tabstop>
+  <tabstop>mWorldFileCheckBox</tabstop>
+  <tabstop>mPdfMap</tabstop>
+  <tabstop>mPdfReport</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QgsVectorTransformSettingsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsVectorTransformSettingsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
## Description

This feature aims to add support for georeferencing vector files in the current georeferencer code.

To do this I have simply generalised some code in the main window and added an enum to track the data type and change the behavior accordingly.

Transformation should be handled by ogr2ogr as GRASS isn't always enabled. To do so we only need to pass the gcp points in the request.

Now the only part that I need to work on is properly calling ogr2ogr with the generated arguments. 

Fixes #41300