### PR TITLE
Cleanup add part tool and fix #41294

### DIFF
--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -68,25 +68,13 @@ void QgsMapToolAddPart::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     return;
   }
 
-  bool isGeometryEmpty = false;
-  if ( vlayer->selectedFeatureCount() > 0 )
-  {
-    // be efficient here - only grab the first selected feature if there's a selection, don't
-    // fetch all the other features which we don't require.
-    QgsFeatureIterator selectedFeatures = vlayer->getSelectedFeatures();
-    QgsFeature firstSelectedFeature;
-    if ( selectedFeatures.nextFeature( firstSelectedFeature ) )
-      if ( firstSelectedFeature.geometry().isNull() )
-        isGeometryEmpty = true;
-  }
-
   if ( !checkSelection() )
   {
     stopCapturing();
     return;
   }
 
-  int errorCode = 0;
+  QgsGeometry::OperationResult errorCode = QgsGeometry::Success;
   switch ( mode() )
   {
     case CapturePoint:
@@ -177,7 +165,7 @@ void QgsMapToolAddPart::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
           case QgsProject::AvoidIntersectionsMode::AllowIntersections:
             break;
         }
-        if ( avoidIntersectionsLayers.size() > 0 )
+        if ( !avoidIntersectionsLayers.isEmpty() )
         {
           geom->avoidIntersections( avoidIntersectionsLayers );
         }
@@ -203,14 +191,14 @@ void QgsMapToolAddPart::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     break;
     default:
       Q_ASSERT( !"invalid capture mode" );
-      errorCode = 6;
+      errorCode = QgsGeometry::OperationResult::AddPartSelectedGeometryNotFound;
       break;
   }
 
   QString errorMessage;
   switch ( errorCode )
   {
-    case 0:
+    case QgsGeometry::OperationResult::Success:
     {
       // remove previous message
       emit messageDiscarded();
@@ -226,37 +214,41 @@ void QgsMapToolAddPart::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
 
       vlayer->triggerRepaint();
 
-      if ( ( !isGeometryEmpty ) && QgsWkbTypes::isSingleType( vlayer->wkbType() ) )
-      {
-        emit messageEmitted( tr( "Add part: Feature geom is single part and you've added more than one" ), Qgis::Warning );
-      }
-
       return;
     }
 
-    case 1:
+    case QgsGeometry::OperationResult::InvalidInputGeometryType:
+      errorMessage = tr( "New part's geometry is empty or invalid." );
+      break;
+
+    case QgsGeometry::OperationResult::AddPartNotMultiGeometry:
       errorMessage = tr( "Selected feature is not multi part." );
       break;
 
-    case 2:
+    case QgsGeometry::OperationResult::AddRingNotValid:
       errorMessage = tr( "New part's geometry is not valid." );
       break;
 
-    case 3:
+    case QgsGeometry::OperationResult::AddRingCrossesExistingRings:
       errorMessage = tr( "New polygon ring not disjoint with existing polygons." );
       break;
 
-    case 4:
-      errorMessage = tr( "No feature selected. Please select a feature with the selection tool or in the attribute table" );
+    case QgsGeometry::OperationResult::SelectionIsEmpty:
+      errorMessage = tr( "No feature selected. Please select a feature with the selection tool or in the attribute table." );
       break;
 
-    case 5:
+    case QgsGeometry::OperationResult::SelectionIsGreaterThanOne:
       errorMessage = tr( "Several features are selected. Please select only one feature to which an island should be added." );
       break;
 
-    case 6:
+    case QgsGeometry::OperationResult::AddPartSelectedGeometryNotFound:
       errorMessage = tr( "Selected geometry could not be found" );
       break;
+
+    default:
+      // Should not reach here
+      // Other OperationResults should not be returned by addPart
+      errorMessage = tr( "Unexpected OperationResult: %1" ).arg( errorCode );
   }
 
   emit messageEmitted( errorMessage, Qgis::Warning );
@@ -284,11 +276,24 @@ bool QgsMapToolAddPart::checkSelection()
   QString selectionErrorMsg;
   if ( nSelectedFeatures < 1 )
   {
-    selectionErrorMsg = tr( "No feature selected. Please select a feature with the selection tool or in the attribute table" );
+    selectionErrorMsg = tr( "No feature selected. Please select a feature with the selection tool or in the attribute table." );
   }
   else if ( nSelectedFeatures > 1 )
   {
-    selectionErrorMsg = tr( "Several features are selected. Please select only one feature to which an part should be added." );
+    selectionErrorMsg = tr( "Several features are selected. Please select only one feature to which a part should be added." );
+  }
+  else
+  {
+    // Only one selected feature
+    // For single-type layers only allow feaetures without geometry
+    QgsFeatureIterator selectedFeatures = vlayer->getSelectedFeatures();
+    QgsFeature selectedFeature;
+    selectedFeatures.nextFeature( selectedFeature );
+    if ( QgsWkbTypes::isSingleType( vlayer->wkbType() ) &&
+         selectedFeature.geometry().constGet() )
+    {
+      selectionErrorMsg = tr( "This layer does not support multipart geometries." );
+    }
   }
 
   if ( !selectionErrorMsg.isEmpty() )

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -281,7 +281,7 @@ bool QgsMapToolAddPart::checkSelection()
   else
   {
     // Only one selected feature
-    // For single-type layers only allow feaetures without geometry
+    // For single-type layers only allow features without geometry
     QgsFeatureIterator selectedFeatures = vlayer->getSelectedFeatures();
     QgsFeature selectedFeature;
     selectedFeatures.nextFeature( selectedFeature );

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -225,14 +225,6 @@ void QgsMapToolAddPart::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       errorMessage = tr( "Selected feature is not multi part." );
       break;
 
-    case QgsGeometry::OperationResult::AddRingNotValid:
-      errorMessage = tr( "New part's geometry is not valid." );
-      break;
-
-    case QgsGeometry::OperationResult::AddRingCrossesExistingRings:
-      errorMessage = tr( "New polygon ring not disjoint with existing polygons." );
-      break;
-
     case QgsGeometry::OperationResult::SelectionIsEmpty:
       errorMessage = tr( "No feature selected. Please select a feature with the selection tool or in the attribute table." );
       break;
@@ -242,7 +234,11 @@ void QgsMapToolAddPart::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       break;
 
     case QgsGeometry::OperationResult::AddPartSelectedGeometryNotFound:
-      errorMessage = tr( "Selected geometry could not be found" );
+      errorMessage = tr( "Selected geometry could not be found." );
+      break;
+
+    case QgsGeometry::OperationResult::InvalidBaseGeometry:
+      errorMessage = tr( "Base geometry is not valid." );
       break;
 
     default:

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -241,7 +241,14 @@ void QgsMapToolAddPart::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       errorMessage = tr( "Base geometry is not valid." );
       break;
 
-    default:
+    case QgsGeometry::OperationResult::AddRingCrossesExistingRings:
+    case QgsGeometry::OperationResult::AddRingNotClosed:
+    case QgsGeometry::OperationResult::AddRingNotInExistingFeature:
+    case QgsGeometry::OperationResult::AddRingNotValid:
+    case QgsGeometry::OperationResult::GeometryEngineError:
+    case QgsGeometry::OperationResult::LayerNotEditable:
+    case QgsGeometry::OperationResult::NothingHappened:
+    case QgsGeometry::OperationResult::SplitCannotSplitPoint:
       // Should not reach here
       // Other OperationResults should not be returned by addPart
       errorMessage = tr( "Unexpected OperationResult: %1" ).arg( errorCode );

--- a/src/app/qgsmaptooladdpart.h
+++ b/src/app/qgsmaptooladdpart.h
@@ -31,6 +31,6 @@ class APP_EXPORT QgsMapToolAddPart : public QgsMapToolCapture
     void activate() override;
 
   private:
-    //! Check if there is any feature selected
+    //! Check if there is any feature selected and the layer supports adding the part
     bool checkSelection();
 };


### PR DESCRIPTION
## Description
Properly handle `QgsGeometry::OperationResult` return values in *add Part* tool.

Also properly return `QgsGeometry::OperationResult::AddPartNotMultiGeometry` when running `QgsGeometry::addPart()` on a single type geometry.

Fixes #41294
<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
