### PR TITLE
[Feature] Add full rendering support in QgsLayoutItemLabel

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitemlabel.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemlabel.sip.in
@@ -204,14 +204,14 @@ contents, in layout units.
 .. seealso:: :py:func:`setMarginX`
 %End
 
-    void setFontColor( const QColor &color );
+    void setFontColor( const QColor &color ) /Deprecated/;
 %Docstring
 Sets the label font ``color``.
 
 .. seealso:: :py:func:`fontColor`
 %End
 
-    QColor fontColor() const;
+    QColor fontColor() const /Deprecated/;
 %Docstring
 Returns the label font color.
 
@@ -226,6 +226,25 @@ Returns the label font color.
 
     virtual void setFrameStrokeWidth( QgsLayoutMeasurement strokeWidth );
 
+
+
+    QgsTextFormat textFormat() const;
+%Docstring
+Returns the text format used for drawing text in the scalebar.
+
+.. seealso:: :py:func:`setTextFormat`
+
+.. versionadded:: 3.20
+%End
+
+    void setTextFormat( const QgsTextFormat &format );
+%Docstring
+Sets the text ``format`` used for drawing text in the scalebar.
+
+.. seealso:: :py:func:`textFormat`
+
+.. versionadded:: 3.20
+%End
 
   public slots:
 

--- a/src/core/layout/qgslayoutitemlabel.cpp
+++ b/src/core/layout/qgslayoutitemlabel.cpp
@@ -26,6 +26,8 @@
 #include "qgsproject.h"
 #include "qgsdistancearea.h"
 #include "qgsfontutils.h"
+#include "qgstextformat.h"
+#include "qgstextrenderer.h"
 #include "qgsexpressioncontext.h"
 #include "qgsmapsettings.h"
 #include "qgslayoutitemmap.h"
@@ -53,11 +55,11 @@ QgsLayoutItemLabel::QgsLayoutItemLabel( QgsLayout *layout )
   QString defaultFontString = settings.value( QStringLiteral( "LayoutDesigner/defaultFont" ), QVariant(), QgsSettings::Gui ).toString();
   if ( !defaultFontString.isEmpty() )
   {
-    mFont.setFamily( defaultFontString );
+    mFormat.font().setFamily( defaultFontString );
   }
 
   //default to a 10 point font size
-  mFont.setPointSizeF( 10 );
+  mFormat.font().setPointSizeF( 10 );
 
   //default to no background
   setBackgroundEnabled( false );
@@ -114,12 +116,22 @@ void QgsLayoutItemLabel::draw( QgsLayoutItemRenderContext &context )
   QgsScopedQPainterState painterState( painter );
 
   // painter is scaled to dots, so scale back to layout units
-  painter->scale( context.renderContext().scaleFactor(), context.renderContext().scaleFactor() );
 
+  float scale;
+  if ( mMode == QgsLayoutItemLabel::ModeFont )
+    scale = context.renderContext().scaleFactor();
+  else
+  {
+    scale = 1.0;
+    painter->scale( context.renderContext().scaleFactor(), context.renderContext().scaleFactor() );
+  }
   double penWidth = frameEnabled() ? ( pen().widthF() / 2.0 ) : 0;
   double xPenAdjust = mMarginX < 0 ? -penWidth : penWidth;
   double yPenAdjust = mMarginY < 0 ? -penWidth : penWidth;
-  QRectF painterRect( xPenAdjust + mMarginX, yPenAdjust + mMarginY, rect().width() - 2 * xPenAdjust - 2 * mMarginX, rect().height() - 2 * yPenAdjust - 2 * mMarginY );
+  QRectF painterRect( xPenAdjust + mMarginX,
+                      yPenAdjust + mMarginY,
+                      scale * ( rect().width() - 2 * xPenAdjust - 2 * mMarginX ),
+                      scale * ( rect().height() - 2 * yPenAdjust - 2 * mMarginY ) );
 
   switch ( mMode )
   {
@@ -143,9 +155,11 @@ void QgsLayoutItemLabel::draw( QgsLayoutItemRenderContext &context )
 
     case ModeFont:
     {
-      const QString textToDraw = currentText();
-      painter->setFont( mFont );
-      QgsLayoutUtils::drawText( painter, painterRect, textToDraw, mFont, mFontColor, mHAlignment, mVAlignment, Qt::TextWordWrap );
+      painter->setFont( mFormat.font() );
+      QStringList texts = QgsTextRenderer::wrapText( currentText(),
+                          mFormat.orientation() == QgsTextFormat::HorizontalOrientation ? painterRect.width() : painterRect.height(),
+                          context.renderContext(), mFormat, QgsTextRenderer::convertQtHAlignment( mHAlignment ) );
+      QgsTextRenderer::drawText( painterRect, 0, QgsTextRenderer::convertQtHAlignment( mHAlignment ), texts, context.renderContext(), mFormat, true, QgsTextRenderer::convertQtVAlignment( mVAlignment ) );
       break;
     }
   }
@@ -314,7 +328,25 @@ void QgsLayoutItemLabel::replaceDateText( QString &text ) const
 
 void QgsLayoutItemLabel::setFont( const QFont &f )
 {
-  mFont = f;
+  Q_NOWARN_DEPRECATED_PUSH
+  mFormat.setFont( f );
+  if ( f.pointSizeF() != -1 )
+    mFormat.setSize( f.pointSizeF() );
+  Q_NOWARN_DEPRECATED_POP
+  refreshItemSize();
+  emit changed();
+}
+
+QgsTextFormat QgsLayoutItemLabel::textFormat() const
+{
+  return mFormat;
+}
+
+void QgsLayoutItemLabel::setTextFormat( const QgsTextFormat &format )
+{
+  mFormat = format;
+  refreshItemSize();
+  emit changed();
 }
 
 void QgsLayoutItemLabel::setMargin( const double m )
@@ -352,8 +384,8 @@ void QgsLayoutItemLabel::adjustSizeToText()
 
 QSizeF QgsLayoutItemLabel::sizeForText() const
 {
-  double textWidth = QgsLayoutUtils::textWidthMM( mFont, currentText() );
-  double fontHeight = QgsLayoutUtils::fontHeightMM( mFont );
+  double textWidth = QgsLayoutUtils::textWidthMM( mFormat.font(), currentText() );
+  double fontHeight = QgsLayoutUtils::fontHeightMM( mFormat.font() );
 
   double penWidth = frameEnabled() ? ( pen().widthF() / 2.0 ) : 0;
 
@@ -365,10 +397,10 @@ QSizeF QgsLayoutItemLabel::sizeForText() const
 
 QFont QgsLayoutItemLabel::font() const
 {
-  return mFont;
+  return mFormat.font();
 }
 
-bool QgsLayoutItemLabel::writePropertiesToElement( QDomElement &layoutLabelElem, QDomDocument &doc, const QgsReadWriteContext & ) const
+bool QgsLayoutItemLabel::writePropertiesToElement( QDomElement &layoutLabelElem, QDomDocument &doc, const QgsReadWriteContext &rwContext ) const
 {
   layoutLabelElem.setAttribute( QStringLiteral( "htmlState" ), static_cast< int >( mMode ) );
 
@@ -379,21 +411,21 @@ bool QgsLayoutItemLabel::writePropertiesToElement( QDomElement &layoutLabelElem,
   layoutLabelElem.setAttribute( QStringLiteral( "valign" ), mVAlignment );
 
   //font
-  QDomElement labelFontElem = QgsFontUtils::toXmlElement( mFont, doc, QStringLiteral( "LabelFont" ) );
-  layoutLabelElem.appendChild( labelFontElem );
+  QDomElement textElem = mFormat.writeXml( doc, rwContext );
+  layoutLabelElem.appendChild( textElem );
 
   //font color
   QDomElement fontColorElem = doc.createElement( QStringLiteral( "FontColor" ) );
-  fontColorElem.setAttribute( QStringLiteral( "red" ), mFontColor.red() );
-  fontColorElem.setAttribute( QStringLiteral( "green" ), mFontColor.green() );
-  fontColorElem.setAttribute( QStringLiteral( "blue" ), mFontColor.blue() );
-  fontColorElem.setAttribute( QStringLiteral( "alpha" ), mFontColor.alpha() );
+  fontColorElem.setAttribute( QStringLiteral( "red" ), mFormat.color().red() );
+  fontColorElem.setAttribute( QStringLiteral( "green" ), mFormat.color().green() );
+  fontColorElem.setAttribute( QStringLiteral( "blue" ), mFormat.color().blue() );
+  fontColorElem.setAttribute( QStringLiteral( "alpha" ), mFormat.color().alpha() );
   layoutLabelElem.appendChild( fontColorElem );
 
   return true;
 }
 
-bool QgsLayoutItemLabel::readPropertiesFromElement( const QDomElement &itemElem, const QDomDocument &, const QgsReadWriteContext & )
+bool QgsLayoutItemLabel::readPropertiesFromElement( const QDomElement &itemElem, const QDomDocument &, const QgsReadWriteContext &context )
 {
   //restore label specific properties
 
@@ -423,9 +455,32 @@ bool QgsLayoutItemLabel::readPropertiesFromElement( const QDomElement &itemElem,
   mVAlignment = static_cast< Qt::AlignmentFlag >( itemElem.attribute( QStringLiteral( "valign" ) ).toInt() );
 
   //font
-  QgsFontUtils::setFromXmlChildNode( mFont, itemElem, QStringLiteral( "LabelFont" ) );
+  QDomNodeList textFormatNodeList = itemElem.elementsByTagName( QStringLiteral( "text-style" ) );
+  if ( !textFormatNodeList.isEmpty() )
+  {
+    QDomElement textFormatElem = textFormatNodeList.at( 0 ).toElement();
+    mFormat.readXml( textFormatElem, context );
+  }
+  else
+  {
+    QFont f;
+    if ( !QgsFontUtils::setFromXmlChildNode( f, itemElem, QStringLiteral( "LabelFont" ) ) )
+    {
+      f.fromString( itemElem.attribute( QStringLiteral( "font" ), QString() ) );
+    }
+    mFormat.setFont( f );
+    if ( f.pointSizeF() > 0 )
+    {
+      mFormat.setSize( f.pointSizeF() );
+      mFormat.setSizeUnit( QgsUnitTypes::RenderPoints );
+    }
+    else if ( f.pixelSize() > 0 )
+    {
+      mFormat.setSize( f.pixelSize() );
+      mFormat.setSizeUnit( QgsUnitTypes::RenderPixels );
+    }
+  }
 
-  //font color
   QDomNodeList fontColorList = itemElem.elementsByTagName( QStringLiteral( "FontColor" ) );
   if ( !fontColorList.isEmpty() )
   {
@@ -434,11 +489,15 @@ bool QgsLayoutItemLabel::readPropertiesFromElement( const QDomElement &itemElem,
     int green = fontColorElem.attribute( QStringLiteral( "green" ), QStringLiteral( "0" ) ).toInt();
     int blue = fontColorElem.attribute( QStringLiteral( "blue" ), QStringLiteral( "0" ) ).toInt();
     int alpha = fontColorElem.attribute( QStringLiteral( "alpha" ), QStringLiteral( "255" ) ).toInt();
-    mFontColor = QColor( red, green, blue, alpha );
+    QColor fontColor = QColor( red, green, blue, alpha );
+
+    mFormat.setColor( fontColor );
   }
-  else
+  else if ( itemElem.hasAttribute( QStringLiteral( "fontColor" ) ) )
   {
-    mFontColor = QColor( 0, 0, 0 );
+    QColor c;
+    c.setNamedColor( itemElem.attribute( QStringLiteral( "fontColor" ), QStringLiteral( "#000000" ) ) );
+    mFormat.setColor( c );
   }
 
   return true;
@@ -606,8 +665,8 @@ QUrl QgsLayoutItemLabel::createStylesheetUrl() const
 {
   QString stylesheet;
   stylesheet += QStringLiteral( "body { margin: %1 %2;" ).arg( std::max( mMarginY * mHtmlUnitsToLayoutUnits, 0.0 ) ).arg( std::max( mMarginX * mHtmlUnitsToLayoutUnits, 0.0 ) );
-  stylesheet += QgsFontUtils::asCSS( mFont, 0.352778 * mHtmlUnitsToLayoutUnits );
-  stylesheet += QStringLiteral( "color: rgba(%1,%2,%3,%4);" ).arg( mFontColor.red() ).arg( mFontColor.green() ).arg( mFontColor.blue() ).arg( QString::number( mFontColor.alphaF(), 'f', 4 ) );
+  stylesheet += QgsFontUtils::asCSS( mFormat.font(), 0.352778 * mHtmlUnitsToLayoutUnits );
+  stylesheet += QStringLiteral( "color: rgba(%1,%2,%3,%4);" ).arg( mFormat.color().red() ).arg( mFormat.color().green() ).arg( mFormat.color().blue() ).arg( QString::number( mFormat.color().alphaF(), 'f', 4 ) );
   stylesheet += QStringLiteral( "text-align: %1; }" ).arg( mHAlignment == Qt::AlignLeft ? QStringLiteral( "left" ) : mHAlignment == Qt::AlignRight ? QStringLiteral( "right" ) : mHAlignment == Qt::AlignHCenter ? QStringLiteral( "center" ) : QStringLiteral( "justify" ) );
 
   QByteArray ba;

--- a/src/core/layout/qgslayoutitemlabel.h
+++ b/src/core/layout/qgslayoutitemlabel.h
@@ -20,6 +20,7 @@
 #include "qgis_core.h"
 #include "qgslayoutitem.h"
 #include "qgswebpage.h"
+#include "qgstextformat.h"
 #include <QFont>
 
 class QgsVectorLayer;
@@ -195,13 +196,13 @@ class CORE_EXPORT QgsLayoutItemLabel: public QgsLayoutItem
      * Sets the label font \a color.
      * \see fontColor()
      */
-    void setFontColor( const QColor &color ) { mFontColor = color; }
+    void setFontColor( const QColor &color ) SIP_DEPRECATED { mFormat.setColor( color ); }
 
     /**
      * Returns the label font color.
      * \see setFontColor()
      */
-    QColor fontColor() const { return mFontColor; }
+    QColor fontColor() const SIP_DEPRECATED { return mFormat.color(); }
 
     // In case of negative margins, the bounding rect may be larger than the
     // label's frame
@@ -212,6 +213,21 @@ class CORE_EXPORT QgsLayoutItemLabel: public QgsLayoutItem
 
     // Reimplemented to call prepareGeometryChange after changing stroke width
     void setFrameStrokeWidth( QgsLayoutMeasurement strokeWidth ) override;
+
+
+    /**
+     * Returns the text format used for drawing text in the scalebar.
+     * \see setTextFormat()
+     * \since QGIS 3.20
+     */
+    QgsTextFormat textFormat() const;
+
+    /**
+     * Sets the text \a format used for drawing text in the scalebar.
+     * \see textFormat()
+     * \since QGIS 3.20
+     */
+    void setTextFormat( const QgsTextFormat &format );
 
   public slots:
 
@@ -246,16 +262,13 @@ class CORE_EXPORT QgsLayoutItemLabel: public QgsLayoutItem
     //! Called when the content is changed to handle HTML loading
     void contentChanged();
 
-    //! Font
-    QFont mFont;
+    //! Format
+    QgsTextFormat mFormat;
 
     //! Horizontal margin between contents and frame (in mm)
     double mMarginX = 0.0;
     //! Vertical margin between contents and frame (in mm)
     double mMarginY = 0.0;
-
-    //! Font color
-    QColor mFontColor = QColor( 0, 0, 0 );
 
     //! Horizontal Alignment
     Qt::AlignmentFlag mHAlignment = Qt::AlignJustify;

--- a/src/gui/layout/qgslayoutlabelwidget.cpp
+++ b/src/gui/layout/qgslayoutlabelwidget.cpp
@@ -50,7 +50,7 @@ QgsLayoutLabelWidget::QgsLayoutLabelWidget( QgsLayoutItemLabel *label )
   connect( mMiddleRadioButton, &QRadioButton::clicked, this, &QgsLayoutLabelWidget::mMiddleRadioButton_clicked );
   setPanelTitle( tr( "Label Properties" ) );
 
-  mFontButton->setMode( QgsFontButton::ModeQFont );
+  mFontButton->setMode( QgsFontButton::ModeTextRenderer );
 
   //add widget for general composer item properties
   mItemPropertiesWidget = new QgsLayoutItemPropertiesWidget( this, label );
@@ -277,11 +277,27 @@ void QgsLayoutLabelWidget::fontChanged()
 {
   if ( mLabel )
   {
-    QFont newFont = mFontButton->currentFont();
     mLabel->beginCommand( tr( "Change Label Font" ), QgsLayoutItem::UndoLabelFont );
-    mLabel->setFont( newFont );
+    //disconnectUpdateSignal();
+    mLabel->setTextFormat( mFontButton->textFormat() );
+    //connectUpdateSignal();
     mLabel->update();
     mLabel->endCommand();
+  }
+}
+void QgsLayoutLabelWidget::connectUpdateSignal()
+{
+  if ( mLabel )
+  {
+    connect( mLabel, &QgsLayoutObject::changed, this, &QgsLayoutLabelWidget::setGuiElementValues );
+  }
+}
+
+void QgsLayoutLabelWidget::disconnectUpdateSignal()
+{
+  if ( mLabel )
+  {
+    disconnect( mLabel, &QgsLayoutObject::changed, this, &QgsLayoutLabelWidget::setGuiElementValues );
   }
 }
 
@@ -448,7 +464,7 @@ void QgsLayoutLabelWidget::setGuiElementValues()
   mCenterRadioButton->setChecked( mLabel->hAlign() == Qt::AlignHCenter );
   mRightRadioButton->setChecked( mLabel->hAlign() == Qt::AlignRight );
   mFontColorButton->setColor( mLabel->fontColor() );
-  mFontButton->setCurrentFont( mLabel->font() );
+  mFontButton->setTextFormat( mLabel->textFormat() );
   mVerticalAlignementLabel->setDisabled( mLabel->mode() == QgsLayoutItemLabel::ModeHtml );
   mTopRadioButton->setDisabled( mLabel->mode() == QgsLayoutItemLabel::ModeHtml );
   mMiddleRadioButton->setDisabled( mLabel->mode() == QgsLayoutItemLabel::ModeHtml );

--- a/src/gui/layout/qgslayoutlabelwidget.h
+++ b/src/gui/layout/qgslayoutlabelwidget.h
@@ -78,6 +78,8 @@ class GUI_EXPORT QgsLayoutLabelWidget: public QgsLayoutItemBaseWidget, private U
     void setGuiElementValues();
     void fontChanged();
     void justifyClicked();
+    void connectUpdateSignal();
+    void disconnectUpdateSignal();
 
   private:
     QPointer< QgsLayoutItemLabel > mLabel = nullptr;


### PR DESCRIPTION
## Description

Supersedes #41192 
Fixes #40879

![label_effects_currentv2](https://user-images.githubusercontent.com/12854129/107131917-e58dc500-68a8-11eb-8eef-0877f36808dd.gif)

This enables users to use more rendering effects in layout labels.

To do this justification related code was moved from qgslayouttable in qgstextrenderer for reusability.

Existing code was improved in some places to handle justified text and keep background effect in line with the text.

Though when using vertical text. the justification doesn't work. I'm unsure if it should spread out vertically or stack on the vertical alignment setting. Nevertheless I think this work is sufficient for now.
