### PR TITLE
Make georeferencer canvas nice and smooth

### DIFF
--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -995,6 +995,10 @@ void QgsGeoreferencerMainWindow::createMapCanvas()
   mCanvas->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
   mCanvas->setCanvasColor( Qt::white );
   mCanvas->setMinimumWidth( 400 );
+  mCanvas->setCachingEnabled( true );
+  mCanvas->setParallelRenderingEnabled( true );
+  mCanvas->setPreviewJobsEnabled( true );
+
   mCentralLayout->addWidget( mCanvas, 0, 0, 2, 1 );
 
   // set up map tools


### PR DESCRIPTION
It's so painful to see the flashy white redraws in georeferencer window after getting used to how smooth it is in main canvas now!