### PR TITLE
Create class QgsAbstractGeometryTransformer, which can be used to transform the vertices of a QgsAbstractGeometry

### DIFF
--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -707,6 +707,21 @@ Checks validity of the geometry, and returns ``True`` if the geometry is valid.
 .. versionadded:: 3.8
 %End
 
+    virtual bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = 0 ) = 0;
+%Docstring
+Transforms the vertices from the geometry in place, using the specified geometry ``transformer``
+object.
+
+Depending on the ``transformer`` used, this may result in an invalid geometry.
+
+The optional ``feedback`` argument can be used to cancel the transformation before it completes.
+If this is done, the geometry will be left in a semi-transformed state.
+
+:return: ``True`` if the geometry was successfully transformed.
+
+.. versionadded:: 3.18
+%End
+
 
     QgsGeometryPartIterator parts();
 %Docstring

--- a/python/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -163,6 +163,9 @@ Sets the circular string's points
     virtual double yAt( int index ) const /HoldGIL/;
 
 
+    virtual bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = 0 );
+
+
 
     virtual QgsCircularString *createEmptyWithSameType() const /Factory/;
 

--- a/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
@@ -168,6 +168,9 @@ Appends first point if not already closed.
     virtual double yAt( int index ) const /HoldGIL/;
 
 
+    virtual bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = 0 );
+
+
 
     virtual QgsCompoundCurve *createEmptyWithSameType() const /Factory/;
 

--- a/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -272,6 +272,9 @@ Returns approximate rotation angle for a vertex. Usually average angle between a
     virtual QgsCurvePolygon *toCurveType() const /Factory/;
 
 
+    virtual bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = 0 );
+
+
 
     virtual QgsCurvePolygon *createEmptyWithSameType() const /Factory/;
 

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -243,6 +243,9 @@ Returns a geometry without curves. Caller takes ownership
     virtual QgsGeometryCollection *toCurveType() const /Factory/;
 
 
+    virtual bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = 0 );
+
+
 
 
 

--- a/python/core/auto_generated/geometry/qgsgeometrytransformer.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrytransformer.sip.in
@@ -1,0 +1,61 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/geometry/qgsgeometrytransformer.h                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsAbstractGeometryTransformer
+{
+%Docstring
+An abstract base class for classes which transform geometries by transforming
+input points to output points.
+
+.. versionadded:: 3.18
+%End
+
+%TypeHeaderCode
+#include "qgsgeometrytransformer.h"
+%End
+  public:
+
+    virtual ~QgsAbstractGeometryTransformer();
+
+    virtual bool transformPoint( double &x /In,Out/, double &y /In,Out/, double &z /In,Out/, double &m  /In,Out/ ) = 0;
+%Docstring
+Transforms the point defined by the coordinates (``x``, ``y``, ``z``) and the specified ``m`` value.
+
+:param x: point x coordinate
+:param y: point y coordinate
+:param z: point z coordinate, or NaN if the input point is 2D only
+:param m: point m value, or NaN if not available
+
+:return: ``True`` if point was transformed (or no transformation was required), or ``False`` if point could not be transformed successfully.
+
+Example
+-------
+
+A transformer which multiples the x coordinate by 3 and adds 10 to the y coordinate:
+
+.. code-block:: python
+
+       class MyTransformer(QgsAbstractGeometryTransformer):
+
+         def transformPoint(self, x, y, z, m):
+           # returns a tuple of True to indicate success, then the modified x/y/z/m values
+           return True, x*3, y+10, z, m
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/geometry/qgsgeometrytransformer.h                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -543,6 +543,9 @@ of the curve.
     virtual bool convertTo( QgsWkbTypes::Type type );
 
 
+    virtual bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = 0 );
+
+
 
     virtual QgsLineString *createEmptyWithSameType() const /Factory/;
 

--- a/python/core/auto_generated/geometry/qgspoint.sip.in
+++ b/python/core/auto_generated/geometry/qgspoint.sip.in
@@ -450,6 +450,9 @@ Angle undefined. Always returns 0.0
     virtual bool convertTo( QgsWkbTypes::Type type );
 
 
+    virtual bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = 0 );
+
+
 
     virtual QgsPoint *createEmptyWithSameType() const /Factory/;
 

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -301,6 +301,7 @@
 %Include auto_generated/geometry/qgsgeometry.sip
 %Include auto_generated/geometry/qgsgeometrycollection.sip
 %Include auto_generated/geometry/qgsgeometryengine.sip
+%Include auto_generated/geometry/qgsgeometrytransformer.sip
 %Include auto_generated/geometry/qgsgeometryutils.sip
 %Include auto_generated/geometry/qgslinesegment.sip
 %Include auto_generated/geometry/qgslinestring.sip

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1183,6 +1183,7 @@ set(QGIS_CORE_HDRS
   geometry/qgsgeometryeditutils.h
   geometry/qgsgeometryengine.h
   geometry/qgsgeometryfactory.h
+  geometry/qgsgeometrytransformer.h
   geometry/qgsgeometryutils.h
   geometry/qgsgeos.h
   geometry/qgsinternalgeometryengine.h

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -45,6 +45,8 @@ class QgsGeometryPartIterator;
 class QgsGeometryConstPartIterator;
 class QgsConstWkbPtr;
 class QPainterPath;
+class QgsAbstractGeometryTransformer;
+class QgsFeedback;
 
 typedef QVector< QgsPoint > QgsPointSequence;
 #ifndef SIP_RUN
@@ -688,6 +690,21 @@ class CORE_EXPORT QgsAbstractGeometry
      * \since QGIS 3.8
      */
     virtual bool isValid( QString &error SIP_OUT, int flags = 0 ) const = 0;
+
+    /**
+     * Transforms the vertices from the geometry in place, using the specified geometry \a transformer
+     * object.
+     *
+     * Depending on the \a transformer used, this may result in an invalid geometry.
+     *
+     * The optional \a feedback argument can be used to cancel the transformation before it completes.
+     * If this is done, the geometry will be left in a semi-transformed state.
+     *
+     * \returns TRUE if the geometry was successfully transformed.
+     *
+     * \since QGIS 3.18
+     */
+    virtual bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = nullptr ) = 0;
 
 #ifndef SIP_RUN
 

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -129,6 +129,8 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
     double xAt( int index ) const override SIP_HOLDGIL;
     double yAt( int index ) const override SIP_HOLDGIL;
 
+    bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = nullptr ) override;
+
 #ifndef SIP_RUN
     void filterVertices( const std::function< bool( const QgsPoint & ) > &filter ) override;
     void transformVertices( const std::function< QgsPoint( const QgsPoint & ) > &transform ) override;

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -21,6 +21,7 @@
 #include "qgsgeometryutils.h"
 #include "qgslinestring.h"
 #include "qgswkbptr.h"
+#include "qgsfeedback.h"
 
 #include <QJsonObject>
 #include <QPainter>
@@ -813,6 +814,27 @@ double QgsCompoundCurve::yAt( int index ) const
     currentVertexId += ( nCurvePoints - 1 );
   }
   return 0.0;
+}
+
+bool QgsCompoundCurve::transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback )
+{
+  bool res = true;
+  for ( QgsCurve *curve : qgis::as_const( mCurves ) )
+  {
+    if ( !curve->transform( transformer ) )
+    {
+      res = false;
+      break;
+    }
+
+    if ( feedback && feedback->isCanceled() )
+    {
+      res = false;
+      break;
+    }
+  }
+  clearCache();
+  return res;
 }
 
 void QgsCompoundCurve::filterVertices( const std::function<bool ( const QgsPoint & )> &filter )

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -131,6 +131,8 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
     double xAt( int index ) const override SIP_HOLDGIL;
     double yAt( int index ) const override SIP_HOLDGIL;
 
+    bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = nullptr ) override;
+
 #ifndef SIP_RUN
     void filterVertices( const std::function< bool( const QgsPoint & ) > &filter ) override;
     void transformVertices( const std::function< QgsPoint( const QgsPoint & ) > &transform ) override;

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -261,6 +261,8 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
 
     QgsCurvePolygon *toCurveType() const override SIP_FACTORY;
 
+    bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = nullptr ) override;
+
 #ifndef SIP_RUN
     void filterVertices( const std::function< bool( const QgsPoint & ) > &filter ) override;
     void transformVertices( const std::function< QgsPoint( const QgsPoint & ) > &transform ) override;

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -27,6 +27,7 @@ email                : marco.hugentobler at sourcepole dot com
 #include "qgsmultipolygon.h"
 #include "qgswkbptr.h"
 #include "qgsgeos.h"
+#include "qgsfeedback.h"
 
 #include <nlohmann/json.hpp>
 #include <memory>
@@ -976,6 +977,27 @@ QgsGeometryCollection *QgsGeometryCollection::toCurveType() const
     newCollection->addGeometry( geom->toCurveType() );
   }
   return newCollection.release();
+}
+
+bool QgsGeometryCollection::transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback )
+{
+  if ( !transformer )
+    return false;
+
+  bool res = true;
+  for ( QgsAbstractGeometry *geom : qgis::as_const( mGeometries ) )
+  {
+    if ( geom )
+      res = geom->transform( transformer, feedback );
+
+    if ( feedback && feedback->isCanceled() )
+      res = false;
+
+    if ( !res )
+      break;
+  }
+  clearCache();
+  return res;
 }
 
 bool QgsGeometryCollection::wktOmitChildType() const

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -236,6 +236,8 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
     void swapXy() override;
     QgsGeometryCollection *toCurveType() const override SIP_FACTORY;
 
+    bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = nullptr ) override;
+
 #ifndef SIP_RUN
     void filterVertices( const std::function< bool( const QgsPoint & ) > &filter ) override;
     void transformVertices( const std::function< QgsPoint( const QgsPoint & ) > &transform ) override;

--- a/src/core/geometry/qgsgeometrytransformer.h
+++ b/src/core/geometry/qgsgeometrytransformer.h
@@ -1,0 +1,64 @@
+/***************************************************************************
+                             qgsgeometrytransformer.h
+                             ----------------------
+    begin                : February 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSGEOMETRYTRANSFORMER_H
+#define QGSGEOMETRYTRANSFORMER_H
+
+#include "qgis_core.h"
+#include "qgis_sip.h"
+
+/**
+ * \class QgsAbstractGeometryTransformer
+ * \ingroup core
+ * An abstract base class for classes which transform geometries by transforming
+ * input points to output points.
+ *
+ * \since QGIS 3.18
+ */
+class CORE_EXPORT QgsAbstractGeometryTransformer
+{
+  public:
+
+    virtual ~QgsAbstractGeometryTransformer() = default;
+
+    /**
+     * Transforms the point defined by the coordinates (\a x, \a y, \a z) and the specified \a m value.
+     *
+     * \param x point x coordinate
+     * \param y point y coordinate
+     * \param z point z coordinate, or NaN if the input point is 2D only
+     * \param m point m value, or NaN if not available
+     *
+     * \returns TRUE if point was transformed (or no transformation was required), or FALSE if point could not be transformed successfully.
+     *
+     * ### Example
+     *
+     * A transformer which multiples the x coordinate by 3 and adds 10 to the y coordinate:
+     *
+     * \code{.py}
+     *   class MyTransformer(QgsAbstractGeometryTransformer):
+     *
+     *     def transformPoint(self, x, y, z, m):
+     *       # returns a tuple of True to indicate success, then the modified x/y/z/m values
+     *       return True, x*3, y+10, z, m
+     * \endcode
+     */
+    virtual bool transformPoint( double &x SIP_INOUT, double &y SIP_INOUT, double &z SIP_INOUT, double &m  SIP_INOUT ) = 0;
+
+};
+
+#endif // QGSGEOMETRYTRANSFORMER_H

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -23,6 +23,8 @@
 #include "qgsmaptopixel.h"
 #include "qgswkbptr.h"
 #include "qgslinesegment.h"
+#include "qgsgeometrytransformer.h"
+#include "qgsfeedback.h"
 
 #include <nlohmann/json.hpp>
 #include <cmath>
@@ -1720,6 +1722,50 @@ bool QgsLineString::convertTo( QgsWkbTypes::Type type )
   {
     return QgsCurve::convertTo( type );
   }
+}
+
+bool QgsLineString::transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback )
+{
+  if ( !transformer )
+    return false;
+
+  bool hasZ = is3D();
+  bool hasM = isMeasure();
+  int size = mX.size();
+
+  double *srcX = mX.data();
+  double *srcY = mY.data();
+  double *srcM = hasM ? mM.data() : nullptr;
+  double *srcZ = hasZ ? mZ.data() : nullptr;
+
+  bool res = true;
+  for ( int i = 0; i < size; ++i )
+  {
+    double x = *srcX;
+    double y = *srcY;
+    double z = hasZ ? *srcZ : std::numeric_limits<double>::quiet_NaN();
+    double m = hasM ? *srcM : std::numeric_limits<double>::quiet_NaN();
+    if ( !transformer->transformPoint( x, y, z, m ) )
+    {
+      res = false;
+      break;
+    }
+
+    *srcX++ = x;
+    *srcY++ = y;
+    if ( hasM )
+      *srcM++ = m;
+    if ( hasZ )
+      *srcZ++ = z;
+
+    if ( feedback && feedback->isCanceled() )
+    {
+      res = false;
+      break;
+    }
+  }
+  clearCache();
+  return res;
 }
 
 void QgsLineString::filterVertices( const std::function<bool ( const QgsPoint & )> &filter )

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -670,6 +670,8 @@ class CORE_EXPORT QgsLineString: public QgsCurve
 
     bool convertTo( QgsWkbTypes::Type type ) override;
 
+    bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = nullptr ) override;
+
 #ifndef SIP_RUN
     void filterVertices( const std::function< bool( const QgsPoint & ) > &filter ) override;
     void transformVertices( const std::function< QgsPoint( const QgsPoint & ) > &transform ) override;

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -22,6 +22,7 @@
 #include "qgsgeometryutils.h"
 #include "qgsmaptopixel.h"
 #include "qgswkbptr.h"
+#include "qgsgeometrytransformer.h"
 
 #include <cmath>
 #include <QPainter>
@@ -638,6 +639,16 @@ bool QgsPoint::convertTo( QgsWkbTypes::Type type )
   }
 
   return false;
+}
+
+bool QgsPoint::transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback * )
+{
+  if ( !transformer )
+    return false;
+
+  const bool res = transformer->transformPoint( mX, mY, mZ, mM );
+  clearCache();
+  return res;
 }
 
 void QgsPoint::filterVertices( const std::function<bool ( const QgsPoint & )> & )

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -537,6 +537,8 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
     void swapXy() override;
     bool convertTo( QgsWkbTypes::Type type ) override;
 
+    bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = nullptr ) override;
+
 #ifndef SIP_RUN
 
     void filterVertices( const std::function< bool( const QgsPoint & ) > &filter ) override;


### PR DESCRIPTION
A small API addition which allows flexibility in manipulating geometries:

E.g.

        class Transformer(QgsAbstractGeometryTransformer):

            def transformPoint(self, x, y, z, m):
                return True, x * 2, y + 1, z, m

        transformer = Transformer()
        g = QgsGeometry.fromWkt('LineString(3 0, 10 0, 10 10)')
        g.get().transform(transformer)
        print(g.asWkt()) # 'LineString (6 1, 20 1, 20 11)'
