### PR TITLE
Don't identify active layer if flag disabled

### DIFF
--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -143,6 +143,8 @@ QList<QgsMapToolIdentify::IdentifyResult> QgsMapToolIdentify::identify( const Qg
       emit identifyMessage( tr( "No active layer. To identify features, you must choose an active layer." ) );
       return results;
     }
+    if ( !layer->flags().testFlag( QgsMapLayer::Identifiable ) )
+      return results;
 
     QApplication::setOverrideCursor( Qt::WaitCursor );
 


### PR DESCRIPTION
Fixes #40357

## Description

I am not sure if skipping the flag on active layer was intended or not. If it is intended to always return information on the active layer regardless of flag, I'll close this.