### PR TITLE
Move classes representing GCP based transformations from app to analysis

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -110,6 +110,7 @@ if(WITH_APIDOC)
       ${CMAKE_SOURCE_DIR}/src/gui/vectortile
       ${CMAKE_SOURCE_DIR}/src/analysis
       ${CMAKE_SOURCE_DIR}/src/analysis/mesh
+      ${CMAKE_SOURCE_DIR}/src/analysis/georeferencing
       ${CMAKE_SOURCE_DIR}/src/analysis/interpolation
       ${CMAKE_SOURCE_DIR}/src/analysis/network
       ${CMAKE_SOURCE_DIR}/src/analysis/processing

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -245,6 +245,7 @@ if(WITH_ANALYSIS)
   include_directories(BEFORE
 
     ${CMAKE_BINARY_DIR}/src/analysis/processing
+    ${CMAKE_BINARY_DIR}/src/analysis/georeferencing
     ${CMAKE_BINARY_DIR}/src/analysis/vector
     ${CMAKE_BINARY_DIR}/src/analysis/mesh
     ${CMAKE_BINARY_DIR}/src/analysis/raster

--- a/python/analysis/analysis_auto.sip
+++ b/python/analysis/analysis_auto.sip
@@ -1,5 +1,6 @@
 // Include auto-generated SIP files
 %Include auto_generated/qgsanalysis.sip
+%Include auto_generated/georeferencing/qgsgcpgeometrytransformer.sip
 %Include auto_generated/georeferencing/qgsgcptransformer.sip
 %Include auto_generated/interpolation/qgsgridfilewriter.sip
 %Include auto_generated/interpolation/qgsidwinterpolator.sip

--- a/python/analysis/analysis_auto.sip
+++ b/python/analysis/analysis_auto.sip
@@ -1,5 +1,6 @@
 // Include auto-generated SIP files
 %Include auto_generated/qgsanalysis.sip
+%Include auto_generated/georeferencing/qgsgcptransformer.sip
 %Include auto_generated/interpolation/qgsgridfilewriter.sip
 %Include auto_generated/interpolation/qgsidwinterpolator.sip
 %Include auto_generated/interpolation/qgsinterpolator.sip

--- a/python/analysis/auto_additions/qgsgcptransformer.py
+++ b/python/analysis/auto_additions/qgsgcptransformer.py
@@ -1,0 +1,12 @@
+# The following has been generated automatically from src/analysis/georeferencing/qgsgcptransformer.h
+# monkey patching scoped based enum
+QgsGcpTransformerInterface.TransformMethod.Linear.__doc__ = "Linear transform"
+QgsGcpTransformerInterface.TransformMethod.Helmert.__doc__ = "Helmert transform"
+QgsGcpTransformerInterface.TransformMethod.PolynomialOrder1.__doc__ = "Polynomial order 1"
+QgsGcpTransformerInterface.TransformMethod.PolynomialOrder2.__doc__ = "Polyonmial order 2"
+QgsGcpTransformerInterface.TransformMethod.PolynomialOrder3.__doc__ = "Polynomial order"
+QgsGcpTransformerInterface.TransformMethod.ThinPlateSpline.__doc__ = "Thin plate splines"
+QgsGcpTransformerInterface.TransformMethod.Projective.__doc__ = "Projective"
+QgsGcpTransformerInterface.TransformMethod.InvalidTransform.__doc__ = "Invalid transform"
+QgsGcpTransformerInterface.TransformMethod.__doc__ = 'Available transformation methods.\n\n' + '* ``Linear``: ' + QgsGcpTransformerInterface.TransformMethod.Linear.__doc__ + '\n' + '* ``Helmert``: ' + QgsGcpTransformerInterface.TransformMethod.Helmert.__doc__ + '\n' + '* ``PolynomialOrder1``: ' + QgsGcpTransformerInterface.TransformMethod.PolynomialOrder1.__doc__ + '\n' + '* ``PolynomialOrder2``: ' + QgsGcpTransformerInterface.TransformMethod.PolynomialOrder2.__doc__ + '\n' + '* ``PolynomialOrder3``: ' + QgsGcpTransformerInterface.TransformMethod.PolynomialOrder3.__doc__ + '\n' + '* ``ThinPlateSpline``: ' + QgsGcpTransformerInterface.TransformMethod.ThinPlateSpline.__doc__ + '\n' + '* ``Projective``: ' + QgsGcpTransformerInterface.TransformMethod.Projective.__doc__ + '\n' + '* ``InvalidTransform``: ' + QgsGcpTransformerInterface.TransformMethod.InvalidTransform.__doc__
+# --

--- a/python/analysis/auto_generated/georeferencing/qgsgcpgeometrytransformer.sip.in
+++ b/python/analysis/auto_generated/georeferencing/qgsgcpgeometrytransformer.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsGcpGeometryTransformer : QgsAbstractGeometryTransformer
 {
 %Docstring
@@ -44,6 +45,18 @@ list of source and destination coordinates to transform geometries.
 
 %Docstring
 QgsGcpGeometryTransformer cannot be copied
+%End
+
+    QgsGeometry transform( const QgsGeometry &geometry, bool &ok /Out/, QgsFeedback *feedback = 0 );
+%Docstring
+Transforms the specified input ``geometry`` using the GCP based transform.
+
+:param geometry: Input geometry to transform
+:param feedback: This optional argument can be used to cancel the transformation before it completes.
+                 If this is done, the geometry will be left in a semi-transformed state.
+
+:return: - transformed geometry
+         - ok: will be set to ``True`` if geometry was successfully transformed, or ``False`` if an error occurred
 %End
 
     QgsGcpTransformerInterface *gcpTransformer() const;

--- a/python/analysis/auto_generated/georeferencing/qgsgcpgeometrytransformer.sip.in
+++ b/python/analysis/auto_generated/georeferencing/qgsgcpgeometrytransformer.sip.in
@@ -1,0 +1,75 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/analysis/georeferencing/qgsgcpgeometrytransformer.h              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsGcpGeometryTransformer : QgsAbstractGeometryTransformer
+{
+%Docstring
+A geometry transformer which uses an underlying Ground Control Points (GCP) based transformation to modify geometries.
+
+.. versionadded:: 3.18
+%End
+
+%TypeHeaderCode
+#include "qgsgcpgeometrytransformer.h"
+%End
+  public:
+
+    QgsGcpGeometryTransformer( QgsGcpTransformerInterface *gcpTransformer /Transfer/ );
+%Docstring
+Constructor for QgsGcpGeometryTransformer, which uses the specified ``gcpTransformer`` to
+modify geometries.
+
+Ownership of ``gcpTransformer`` is transferred to the geometry transformer.
+%End
+
+    QgsGcpGeometryTransformer( QgsGcpTransformerInterface::TransformMethod method, const QVector<QgsPointXY> &sourceCoordinates, const QVector<QgsPointXY> &destinationCoordinates );
+%Docstring
+Constructor for QgsGcpGeometryTransformer, which uses the specified transform ``method`` and
+list of source and destination coordinates to transform geometries.
+%End
+
+    ~QgsGcpGeometryTransformer();
+
+
+
+    virtual bool transformPoint( double &x /In,Out/, double &y /In,Out/, double &z /In,Out/, double &m /In,Out/ );
+
+%Docstring
+QgsGcpGeometryTransformer cannot be copied
+%End
+
+    QgsGcpTransformerInterface *gcpTransformer() const;
+%Docstring
+Returns the underlying GCP transformer used to transform geometries.
+
+.. seealso:: :py:func:`setGcpTransformer`
+%End
+
+    void setGcpTransformer( QgsGcpTransformerInterface *transformer /Transfer/ );
+%Docstring
+Sets the underlying GCP ``transformer`` used to transform geometries.
+
+Ownership is transferred to this object.
+
+.. seealso:: :py:func:`gcpTransformer`
+%End
+
+  private:
+    QgsGcpGeometryTransformer( const QgsGcpGeometryTransformer &other );
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/analysis/georeferencing/qgsgcpgeometrytransformer.h              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
+++ b/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
@@ -59,6 +59,11 @@ Returns the minimum number of Ground Control Points (GCPs) required for paramete
 Returns the transformation method.
 %End
 
+    static QString methodToString( TransformMethod method );
+%Docstring
+Returns a translated string representing the specified transform ``method``.
+%End
+
 
   private:
     QgsGcpTransformerInterface( const QgsGcpTransformerInterface &other );

--- a/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
+++ b/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
@@ -67,6 +67,15 @@ Returns the minimum number of Ground Control Points (GCPs) required for paramete
 Returns the transformation method.
 %End
 
+    bool transform( double &x /In,Out/, double &y /In,Out/, bool inverseTransform = false ) const;
+%Docstring
+Transforms the point (``x``, ``y``) from source to destination coordinates.
+
+If ``inverseTransform`` is set to ``True``, the point will be transformed from the destination to the source.
+
+:return: ``True`` if transformation was successful.
+%End
+
     static QString methodToString( TransformMethod method );
 %Docstring
 Returns a translated string representing the specified transform ``method``.

--- a/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
+++ b/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
@@ -37,6 +37,9 @@ based on a transformation method and a list of GCPs.
     };
 
     QgsGcpTransformerInterface();
+%Docstring
+Constructor for QgsGcpTransformerInterface
+%End
 
     virtual ~QgsGcpTransformerInterface();
 
@@ -50,9 +53,12 @@ parameters as this one.
 Caller takes ownership of the returned object.
 %End
 
-    virtual bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoordinates, const QVector<QgsPointXY> &layerCoordinates ) = 0;
+    virtual bool updateParametersFromGcps( const QVector<QgsPointXY> &sourceCoordinates, const QVector<QgsPointXY> &destinationCoordinates, bool invertYAxis = false ) = 0;
 %Docstring
-Fits transformation parameters using the specified Ground Control Points (GCPs) lists of map coordinates and layer coordinates.
+Fits transformation parameters using the specified Ground Control Points (GCPs) lists of source and destination coordinates.
+
+If ``invertYAxis`` is set to ``True`` then the y-axis of source coordinates will be inverted, e.g. to allow for transformation of raster layers
+with ascending top-to-bottom vertical axis coordinates.
 
 :return: ``True`` on success, ``False`` on failure
 %End
@@ -88,10 +94,10 @@ Creates a new QgsGcpTransformerInterface subclass representing the specified tra
 Caller takes ownership of the returned object.
 %End
 
-    static QgsGcpTransformerInterface *createFromParameters( TransformMethod method, const QVector<QgsPointXY> &mapCoordinates, const QVector<QgsPointXY> &layerCoordinates ) /Factory/;
+    static QgsGcpTransformerInterface *createFromParameters( TransformMethod method, const QVector<QgsPointXY> &sourceCoordinates, const QVector<QgsPointXY> &destinationCoordinates ) /Factory/;
 %Docstring
 Creates a new QgsGcpTransformerInterface subclass representing the specified transform ``method``, initialized
-using the given lists of map and layer coordinates.
+using the given lists of source and destination coordinates.
 
 If the parameters cannot be fit to a transform ``None`` will be returned.
 

--- a/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
+++ b/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
@@ -71,6 +71,16 @@ Creates a new QgsGcpTransformerInterface subclass representing the specified tra
 Caller takes ownership of the returned object.
 %End
 
+    static QgsGcpTransformerInterface *createFromParameters( TransformMethod method, const QVector<QgsPointXY> &mapCoordinates, const QVector<QgsPointXY> &pixelCoordinates ) /Factory/;
+%Docstring
+Creates a new QgsGcpTransformerInterface subclass representing the specified transform ``method``, initialized
+using the given lists of map and pixel coordinates.
+
+If the parameters cannot be fit to a transform ``None`` will be returned.
+
+Caller takes ownership of the returned object.
+%End
+
 
   private:
     QgsGcpTransformerInterface( const QgsGcpTransformerInterface &other );

--- a/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
+++ b/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
@@ -42,6 +42,14 @@ based on a transformation method and a list of GCPs.
 
 
 
+    virtual QgsGcpTransformerInterface *clone() const = 0 /Factory/;
+%Docstring
+Clones the transformer, returning a new copy of the transformer with the same
+parameters as this one.
+
+Caller takes ownership of the returned object.
+%End
+
     virtual bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoordinates, const QVector<QgsPointXY> &layerCoordinates ) = 0;
 %Docstring
 Fits transformation parameters using the specified Ground Control Points (GCPs) lists of map coordinates and layer coordinates.

--- a/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
+++ b/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
@@ -64,6 +64,13 @@ Returns the transformation method.
 Returns a translated string representing the specified transform ``method``.
 %End
 
+    static QgsGcpTransformerInterface *create( TransformMethod method ) /Factory/;
+%Docstring
+Creates a new QgsGcpTransformerInterface subclass representing the specified transform ``method``.
+
+Caller takes ownership of the returned object.
+%End
+
 
   private:
     QgsGcpTransformerInterface( const QgsGcpTransformerInterface &other );

--- a/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
+++ b/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
@@ -24,6 +24,18 @@ based on a transformation method and a list of GCPs.
 %End
   public:
 
+    enum class TransformMethod
+    {
+      Linear,
+      Helmert,
+      PolynomialOrder1,
+      PolynomialOrder2,
+      PolynomialOrder3,
+      ThinPlateSpline,
+      Projective,
+      InvalidTransform
+    };
+
     QgsGcpTransformerInterface();
 
     virtual ~QgsGcpTransformerInterface();
@@ -40,6 +52,11 @@ Fits transformation parameters using the specified Ground Control Points (GCPs) 
     virtual int minimumGcpCount() const = 0;
 %Docstring
 Returns the minimum number of Ground Control Points (GCPs) required for parameter fitting.
+%End
+
+    virtual TransformMethod method() const = 0;
+%Docstring
+Returns the transformation method.
 %End
 
 

--- a/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
+++ b/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
@@ -1,0 +1,60 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/analysis/georeferencing/qgsgcptransformer.h                      *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsGcpTransformerInterface /Abstract/
+{
+%Docstring
+An interface for Ground Control Points (GCP) based transformations.
+
+:py:class:`QgsGcpTransformerInterface` implementations are able to transform point locations
+based on a transformation method and a list of GCPs.
+
+.. versionadded:: 3.20
+%End
+
+%TypeHeaderCode
+#include "qgsgcptransformer.h"
+%End
+  public:
+
+    QgsGcpTransformerInterface();
+
+    virtual ~QgsGcpTransformerInterface();
+
+
+
+    virtual bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoordinates, const QVector<QgsPointXY> &pixelCoordinates ) = 0;
+%Docstring
+Fits transformation parameters using the specified Ground Control Points (GCPs) lists of map coordinates and pixel coordinates.
+
+:return: ``True`` on success, ``False`` on failure
+%End
+
+    virtual int minimumGcpCount() const = 0;
+%Docstring
+Returns the minimum number of Ground Control Points (GCPs) required for parameter fitting.
+%End
+
+
+  private:
+    QgsGcpTransformerInterface( const QgsGcpTransformerInterface &other );
+};
+
+
+
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/analysis/georeferencing/qgsgcptransformer.h                      *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
+++ b/python/analysis/auto_generated/georeferencing/qgsgcptransformer.sip.in
@@ -42,9 +42,9 @@ based on a transformation method and a list of GCPs.
 
 
 
-    virtual bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoordinates, const QVector<QgsPointXY> &pixelCoordinates ) = 0;
+    virtual bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoordinates, const QVector<QgsPointXY> &layerCoordinates ) = 0;
 %Docstring
-Fits transformation parameters using the specified Ground Control Points (GCPs) lists of map coordinates and pixel coordinates.
+Fits transformation parameters using the specified Ground Control Points (GCPs) lists of map coordinates and layer coordinates.
 
 :return: ``True`` on success, ``False`` on failure
 %End
@@ -71,10 +71,10 @@ Creates a new QgsGcpTransformerInterface subclass representing the specified tra
 Caller takes ownership of the returned object.
 %End
 
-    static QgsGcpTransformerInterface *createFromParameters( TransformMethod method, const QVector<QgsPointXY> &mapCoordinates, const QVector<QgsPointXY> &pixelCoordinates ) /Factory/;
+    static QgsGcpTransformerInterface *createFromParameters( TransformMethod method, const QVector<QgsPointXY> &mapCoordinates, const QVector<QgsPointXY> &layerCoordinates ) /Factory/;
 %Docstring
 Creates a new QgsGcpTransformerInterface subclass representing the specified transform ``method``, initialized
-using the given lists of map and pixel coordinates.
+using the given lists of map and layer coordinates.
 
 If the parameters cannot be fit to a transform ``None`` will be returned.
 

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 set(QGIS_ANALYSIS_SRCS
   qgsanalysis.cpp
+
+  georeferencing/qgsgcpgeometrytransformer.cpp
   georeferencing/qgsgcptransformer.cpp
   georeferencing/qgsleastsquares.cpp
 
@@ -285,6 +287,7 @@ set(QGIS_ANALYSIS_SRCS
 set(QGIS_ANALYSIS_HDRS
   qgsanalysis.h
 
+  georeferencing/qgsgcpgeometrytransformer.h
   georeferencing/qgsgcptransformer.h
 
   interpolation/Bezier3D.h

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 set(QGIS_ANALYSIS_SRCS
   qgsanalysis.cpp
+  georeferencing/qgsgcptransformer.cpp
+  georeferencing/qgsleastsquares.cpp
 
   interpolation/qgsgridfilewriter.cpp
   interpolation/qgsidwinterpolator.cpp
@@ -283,6 +285,8 @@ set(QGIS_ANALYSIS_SRCS
 set(QGIS_ANALYSIS_HDRS
   qgsanalysis.h
 
+  georeferencing/qgsgcptransformer.h
+
   interpolation/Bezier3D.h
   interpolation/CloughTocherInterpolator.h
   interpolation/qgsdualedgetriangulation.h
@@ -391,6 +395,7 @@ find_package(EXIV2 REQUIRED)
 include_directories(SYSTEM ${SPATIALITE_INCLUDE_DIR})
 include_directories(SYSTEM ${SPATIALINDEX_INCLUDE_DIR})
 include_directories(SYSTEM ${SQLITE3_INCLUDE_DIR})
+include_directories(SYSTEM ${GSL_INCLUDE_DIR})
 include_directories(BEFORE raster)
 include_directories(BEFORE mesh)
 
@@ -437,6 +442,7 @@ add_library(qgis_analysis ${LIBRARY_TYPE} ${QGIS_ANALYSIS_SRCS} ${QGIS_ANALYSIS_
 
 target_include_directories(qgis_analysis PUBLIC
   ${CMAKE_SOURCE_DIR}/src/analysis
+  ${CMAKE_SOURCE_DIR}/src/analysis/georeferencing
   ${CMAKE_SOURCE_DIR}/src/analysis/interpolation
   ${CMAKE_SOURCE_DIR}/src/analysis/mesh
   ${CMAKE_SOURCE_DIR}/src/analysis/network
@@ -497,6 +503,7 @@ target_link_libraries(
   qgis_analysis
   qgis_core
   ${EXIV2_LIBRARY}
+  ${GSL_LIBRARIES}
   )
 
 if(HAVE_OPENCL)

--- a/src/analysis/georeferencing/qgsgcpgeometrytransformer.cpp
+++ b/src/analysis/georeferencing/qgsgcpgeometrytransformer.cpp
@@ -1,0 +1,48 @@
+/***************************************************************************
+                             qgsgcpgeometrytransformer.cpp
+                             ----------------------
+    begin                : February 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsgcpgeometrytransformer.h"
+
+
+QgsGcpGeometryTransformer::QgsGcpGeometryTransformer( QgsGcpTransformerInterface *gcpTransformer )
+  : mGcpTransformer( gcpTransformer )
+{
+
+}
+
+QgsGcpGeometryTransformer::QgsGcpGeometryTransformer( QgsGcpTransformerInterface::TransformMethod method, const QVector<QgsPointXY> &sourceCoordinates, const QVector<QgsPointXY> &destinationCoordinates )
+  : mGcpTransformer( QgsGcpTransformerInterface::createFromParameters( method, sourceCoordinates, destinationCoordinates ) )
+{
+
+}
+
+QgsGcpGeometryTransformer::~QgsGcpGeometryTransformer() = default;
+
+bool QgsGcpGeometryTransformer::transformPoint( double &x, double &y, double &, double & )
+{
+  return mGcpTransformer->transform( x, y );
+}
+
+QgsGcpTransformerInterface *QgsGcpGeometryTransformer::gcpTransformer() const
+{
+  return mGcpTransformer.get();
+}
+
+void QgsGcpGeometryTransformer::setGcpTransformer( QgsGcpTransformerInterface *gcpTransformer )
+{
+  mGcpTransformer.reset( gcpTransformer );
+}

--- a/src/analysis/georeferencing/qgsgcpgeometrytransformer.cpp
+++ b/src/analysis/georeferencing/qgsgcpgeometrytransformer.cpp
@@ -42,8 +42,12 @@ bool QgsGcpGeometryTransformer::transformPoint( double &x, double &y, double &, 
 
 QgsGeometry QgsGcpGeometryTransformer::transform( const QgsGeometry &geometry, bool &ok, QgsFeedback *feedback )
 {
+  ok = false;
   if ( geometry.isNull() )
+  {
+    ok = true;
     return QgsGeometry();
+  }
 
   std::unique_ptr< QgsAbstractGeometry > res( geometry.constGet()->clone() );
 

--- a/src/analysis/georeferencing/qgsgcpgeometrytransformer.cpp
+++ b/src/analysis/georeferencing/qgsgcpgeometrytransformer.cpp
@@ -16,7 +16,7 @@
  ***************************************************************************/
 
 #include "qgsgcpgeometrytransformer.h"
-
+#include "qgsgeometry.h"
 
 QgsGcpGeometryTransformer::QgsGcpGeometryTransformer( QgsGcpTransformerInterface *gcpTransformer )
   : mGcpTransformer( gcpTransformer )
@@ -34,7 +34,22 @@ QgsGcpGeometryTransformer::~QgsGcpGeometryTransformer() = default;
 
 bool QgsGcpGeometryTransformer::transformPoint( double &x, double &y, double &, double & )
 {
+  if ( !mGcpTransformer )
+    return false;
+
   return mGcpTransformer->transform( x, y );
+}
+
+QgsGeometry QgsGcpGeometryTransformer::transform( const QgsGeometry &geometry, bool &ok, QgsFeedback *feedback )
+{
+  if ( geometry.isNull() )
+    return QgsGeometry();
+
+  std::unique_ptr< QgsAbstractGeometry > res( geometry.constGet()->clone() );
+
+  ok = res->transform( this, feedback );
+
+  return QgsGeometry( std::move( res ) );
 }
 
 QgsGcpTransformerInterface *QgsGcpGeometryTransformer::gcpTransformer() const

--- a/src/analysis/georeferencing/qgsgcpgeometrytransformer.h
+++ b/src/analysis/georeferencing/qgsgcpgeometrytransformer.h
@@ -28,7 +28,7 @@ class QgsGeometry;
 /**
  * \class QgsGcpGeometryTransformer
  * \ingroup analysis
- * A geometry transformer which uses an underlying Ground Control Points (GCP) based transformation to modify geometries.
+ * \brief A geometry transformer which uses an underlying Ground Control Points (GCP) based transformation to modify geometries.
  *
  * \since QGIS 3.18
  */

--- a/src/analysis/georeferencing/qgsgcpgeometrytransformer.h
+++ b/src/analysis/georeferencing/qgsgcpgeometrytransformer.h
@@ -23,6 +23,8 @@
 #include "qgsgcptransformer.h"
 #include <memory>
 
+class QgsGeometry;
+
 /**
  * \class QgsGcpGeometryTransformer
  * \ingroup analysis
@@ -57,6 +59,18 @@ class ANALYSIS_EXPORT QgsGcpGeometryTransformer : public QgsAbstractGeometryTran
     QgsGcpGeometryTransformer &operator=( const QgsGcpGeometryTransformer &other ) = delete;
 
     bool transformPoint( double &x SIP_INOUT, double &y SIP_INOUT, double &z SIP_INOUT, double &m SIP_INOUT ) override;
+
+    /**
+     * Transforms the specified input \a geometry using the GCP based transform.
+     *
+     * \param geometry Input geometry to transform
+     * \param ok will be set to TRUE if geometry was successfully transformed, or FALSE if an error occurred
+     * \param feedback This optional argument can be used to cancel the transformation before it completes.
+     * If this is done, the geometry will be left in a semi-transformed state.
+     *
+     * \returns transformed geometry
+     */
+    QgsGeometry transform( const QgsGeometry &geometry, bool &ok SIP_OUT, QgsFeedback *feedback = nullptr );
 
     /**
      * Returns the underlying GCP transformer used to transform geometries.

--- a/src/analysis/georeferencing/qgsgcpgeometrytransformer.h
+++ b/src/analysis/georeferencing/qgsgcpgeometrytransformer.h
@@ -1,0 +1,86 @@
+/***************************************************************************
+                             qgsgcpgeometrytransformer.h
+                             ----------------------
+    begin                : February 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSGCPGEOMETRYTRANSFORMER_H
+#define QGSGCPGEOMETRYTRANSFORMER_H
+
+#include "qgis_analysis.h"
+#include "qgsgeometrytransformer.h"
+#include "qgsgcptransformer.h"
+#include <memory>
+
+/**
+ * \class QgsGcpGeometryTransformer
+ * \ingroup analysis
+ * A geometry transformer which uses an underlying Ground Control Points (GCP) based transformation to modify geometries.
+ *
+ * \since QGIS 3.18
+ */
+class ANALYSIS_EXPORT QgsGcpGeometryTransformer : public QgsAbstractGeometryTransformer
+{
+  public:
+
+    /**
+     * Constructor for QgsGcpGeometryTransformer, which uses the specified \a gcpTransformer to
+     * modify geometries.
+     *
+     * Ownership of \a gcpTransformer is transferred to the geometry transformer.
+     */
+    QgsGcpGeometryTransformer( QgsGcpTransformerInterface *gcpTransformer SIP_TRANSFER );
+
+    /**
+     * Constructor for QgsGcpGeometryTransformer, which uses the specified transform \a method and
+     * list of source and destination coordinates to transform geometries.
+     */
+    QgsGcpGeometryTransformer( QgsGcpTransformerInterface::TransformMethod method, const QVector<QgsPointXY> &sourceCoordinates, const QVector<QgsPointXY> &destinationCoordinates );
+
+    ~QgsGcpGeometryTransformer() override;
+
+    //! QgsGcpGeometryTransformer cannot be copied
+    QgsGcpGeometryTransformer( const QgsGcpGeometryTransformer &other ) = delete;
+
+    //! QgsGcpGeometryTransformer cannot be copied
+    QgsGcpGeometryTransformer &operator=( const QgsGcpGeometryTransformer &other ) = delete;
+
+    bool transformPoint( double &x SIP_INOUT, double &y SIP_INOUT, double &z SIP_INOUT, double &m SIP_INOUT ) override;
+
+    /**
+     * Returns the underlying GCP transformer used to transform geometries.
+     *
+     * \see setGcpTransformer()
+     */
+    QgsGcpTransformerInterface *gcpTransformer() const;
+
+    /**
+     * Sets the underlying GCP \a transformer used to transform geometries.
+     *
+     * Ownership is transferred to this object.
+     *
+     * \see gcpTransformer()
+     */
+    void setGcpTransformer( QgsGcpTransformerInterface *transformer SIP_TRANSFER );
+
+  private:
+#ifdef SIP_RUN
+    QgsGcpGeometryTransformer( const QgsGcpGeometryTransformer &other );
+#endif
+
+    std::unique_ptr< QgsGcpTransformerInterface > mGcpTransformer;
+
+};
+
+#endif // QGSGCPGEOMETRYTRANSFORMER_H

--- a/src/analysis/georeferencing/qgsgcptransformer.cpp
+++ b/src/analysis/georeferencing/qgsgcptransformer.cpp
@@ -60,6 +60,11 @@ void *QgsLinearGeorefTransform::GDALTransformerArgs() const
   return ( void * )&mParameters;
 }
 
+QgsGcpTransformerInterface::TransformMethod QgsLinearGeorefTransform::method() const
+{
+  return TransformMethod::Linear;
+}
+
 int QgsLinearGeorefTransform::linearTransform( void *pTransformerArg, int bDstToSrc, int nPointCount,
     double *x, double *y, double *z, int *panSuccess )
 {
@@ -126,6 +131,11 @@ GDALTransformerFunc QgsHelmertGeorefTransform::GDALTransformer() const
 void *QgsHelmertGeorefTransform::GDALTransformerArgs() const
 {
   return ( void * )&mHelmertParameters;
+}
+
+QgsGcpTransformerInterface::TransformMethod QgsHelmertGeorefTransform::method() const
+{
+  return TransformMethod::Helmert;
 }
 
 bool QgsHelmertGeorefTransform::getOriginScaleRotation( QgsPointXY &origin, double &scale, double &rotation ) const
@@ -266,6 +276,23 @@ void *QgsGDALGeorefTransform::GDALTransformerArgs() const
   return mGDALTransformerArgs;
 }
 
+QgsGcpTransformerInterface::TransformMethod QgsGDALGeorefTransform::method() const
+{
+  if ( mIsTPSTransform )
+    return TransformMethod::ThinPlateSpline;
+
+  switch ( mPolynomialOrder )
+  {
+    case 1:
+      return TransformMethod::PolynomialOrder1;
+    case 2:
+      return TransformMethod::PolynomialOrder2;
+    case 3:
+      return TransformMethod::PolynomialOrder3;
+  }
+  return TransformMethod::InvalidTransform;
+}
+
 void QgsGDALGeorefTransform::destroyGdalArgs()
 {
   if ( mGDALTransformerArgs )
@@ -347,6 +374,11 @@ GDALTransformerFunc QgsProjectiveGeorefTransform::GDALTransformer() const
 void *QgsProjectiveGeorefTransform::GDALTransformerArgs() const
 {
   return ( void * )&mParameters;
+}
+
+QgsGcpTransformerInterface::TransformMethod QgsProjectiveGeorefTransform::method() const
+{
+  return TransformMethod::Projective;
 }
 
 int QgsProjectiveGeorefTransform::projectiveTransform( void *pTransformerArg, int bDstToSrc, int nPointCount,

--- a/src/analysis/georeferencing/qgsgcptransformer.cpp
+++ b/src/analysis/georeferencing/qgsgcptransformer.cpp
@@ -1,0 +1,398 @@
+/***************************************************************************
+    qgsgcptransformer.cpp
+     --------------------------------------
+    Date                 : 18-Feb-2009
+    Copyright            : (c) 2009 by Manuel Massing
+    Email                : m.massing at warped-space.de
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsgcptransformer.h"
+
+#include <gdal.h>
+#include <gdal_alg.h>
+
+#include "qgsleastsquares.h"
+
+#include <cmath>
+
+#include <cassert>
+#include <limits>
+
+//
+// QgsLinearGeorefTransform
+//
+
+bool QgsLinearGeorefTransform::getOriginScale( QgsPointXY &origin, double &scaleX, double &scaleY ) const
+{
+  origin = mParameters.origin;
+  scaleX = mParameters.scaleX;
+  scaleY = mParameters.scaleY;
+  return true;
+}
+
+bool QgsLinearGeorefTransform::updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords )
+{
+  if ( mapCoords.size() < minimumGcpCount() )
+    return false;
+  QgsLeastSquares::linear( mapCoords, pixelCoords, mParameters.origin, mParameters.scaleX, mParameters.scaleY );
+  return true;
+}
+
+int QgsLinearGeorefTransform::minimumGcpCount() const
+{
+  return 2;
+}
+
+GDALTransformerFunc QgsLinearGeorefTransform::GDALTransformer() const
+{
+  return QgsLinearGeorefTransform::linearTransform;
+}
+
+void *QgsLinearGeorefTransform::GDALTransformerArgs() const
+{
+  return ( void * )&mParameters;
+}
+
+int QgsLinearGeorefTransform::linearTransform( void *pTransformerArg, int bDstToSrc, int nPointCount,
+    double *x, double *y, double *z, int *panSuccess )
+{
+  Q_UNUSED( z )
+  LinearParameters *t = static_cast<LinearParameters *>( pTransformerArg );
+  if ( !t )
+    return false;
+
+  if ( !bDstToSrc )
+  {
+    for ( int i = 0; i < nPointCount; ++i )
+    {
+      x[i] = x[i] * t->scaleX + t->origin.x();
+      y[i] = -y[i] * t->scaleY + t->origin.y();
+      panSuccess[i] = true;
+    }
+  }
+  else
+  {
+    // Guard against division by zero
+    if ( std::fabs( t->scaleX ) < std::numeric_limits<double>::epsilon() ||
+         std::fabs( t->scaleY ) < std::numeric_limits<double>::epsilon() )
+    {
+      for ( int i = 0; i < nPointCount; ++i )
+      {
+        panSuccess[i] = false;
+      }
+      return false;
+    }
+    for ( int i = 0; i < nPointCount; ++i )
+    {
+      x[i] = ( x[i] - t->origin.x() ) / t->scaleX;
+      y[i] = ( y[i] - t->origin.y() ) / ( -t->scaleY );
+      panSuccess[i] = true;
+    }
+  }
+
+  return true;
+}
+
+//
+// QgsHelmertGeorefTransform
+//
+bool QgsHelmertGeorefTransform::updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords )
+{
+  if ( mapCoords.size() < minimumGcpCount() )
+    return false;
+
+  QgsLeastSquares::helmert( mapCoords, pixelCoords, mHelmertParameters.origin, mHelmertParameters.scale, mHelmertParameters.angle );
+  return true;
+}
+
+int QgsHelmertGeorefTransform::minimumGcpCount() const
+{
+  return 2;
+}
+
+
+GDALTransformerFunc QgsHelmertGeorefTransform::GDALTransformer() const
+{
+  return QgsHelmertGeorefTransform::helmert_transform;
+}
+
+void *QgsHelmertGeorefTransform::GDALTransformerArgs() const
+{
+  return ( void * )&mHelmertParameters;
+}
+
+bool QgsHelmertGeorefTransform::getOriginScaleRotation( QgsPointXY &origin, double &scale, double &rotation ) const
+{
+  origin = mHelmertParameters.origin;
+  scale = mHelmertParameters.scale;
+  rotation = mHelmertParameters.angle;
+  return true;
+}
+
+int QgsHelmertGeorefTransform::helmert_transform( void *pTransformerArg, int bDstToSrc, int nPointCount,
+    double *x, double *y, double *z, int *panSuccess )
+{
+  Q_UNUSED( z )
+  HelmertParameters *t = static_cast<HelmertParameters *>( pTransformerArg );
+  if ( !t )
+    return false;
+
+  double a = std::cos( t->angle ), b = std::sin( t->angle ), x0 = t->origin.x(), y0 = t->origin.y(), s = t->scale;
+  if ( !bDstToSrc )
+  {
+    a *= s;
+    b *= s;
+    for ( int i = 0; i < nPointCount; ++i )
+    {
+      double xT = x[i], yT = y[i];
+      // Because rotation parameters where estimated in a CS with negative y-axis ^= down.
+      // we need to apply the rotation matrix and a change of base:
+      // |cos a,-sin a| |1, 0|   | std::cos a,  std::sin a|
+      // |sin a, std::cos a| |0,-1| = | std::sin a, -cos a|
+      x[i] = x0 + ( a * xT + b * yT );
+      y[i] = y0 + ( b * xT - a * yT );
+      panSuccess[i] = true;
+    }
+  }
+  else
+  {
+    // Guard against division by zero
+    if ( std::fabs( s ) < std::numeric_limits<double>::epsilon() )
+    {
+      for ( int i = 0; i < nPointCount; ++i )
+      {
+        panSuccess[i] = false;
+      }
+      return false;
+    }
+    a /= s;
+    b /= s;
+    for ( int i = 0; i < nPointCount; ++i )
+    {
+      double xT = x[i], yT = y[i];
+      xT -= x0;
+      yT -= y0;
+      // | std::cos a,  std::sin a |^-1   |cos a,  std::sin a|
+      // | std::sin a, -cos a |    = |sin a, -cos a|
+      x[i] = a * xT + b * yT;
+      y[i] = b * xT - a * yT;
+      panSuccess[i] = true;
+    }
+  }
+  return true;
+}
+
+//
+// QgsGDALGeorefTransform
+//
+
+QgsGDALGeorefTransform::QgsGDALGeorefTransform( bool useTPS, unsigned int polynomialOrder )
+  : mPolynomialOrder( std::min( 3u, polynomialOrder ) )
+  , mIsTPSTransform( useTPS )
+{
+  mGDALTransformer     = nullptr;
+  mGDALTransformerArgs = nullptr;
+}
+
+QgsGDALGeorefTransform::~QgsGDALGeorefTransform()
+{
+  destroyGdalArgs();
+}
+
+bool QgsGDALGeorefTransform::updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords )
+{
+  assert( mapCoords.size() == pixelCoords.size() );
+  if ( mapCoords.size() != pixelCoords.size() )
+    return false;
+  int n = mapCoords.size();
+
+  GDAL_GCP *GCPList = new GDAL_GCP[n];
+  for ( int i = 0; i < n; i++ )
+  {
+    GCPList[i].pszId = new char[20];
+    snprintf( GCPList[i].pszId, 19, "gcp%i", i );
+    GCPList[i].pszInfo = nullptr;
+    GCPList[i].dfGCPPixel = pixelCoords[i].x();
+    GCPList[i].dfGCPLine  = -pixelCoords[i].y();
+    GCPList[i].dfGCPX = mapCoords[i].x();
+    GCPList[i].dfGCPY = mapCoords[i].y();
+    GCPList[i].dfGCPZ = 0;
+  }
+  destroyGdalArgs();
+
+  if ( mIsTPSTransform )
+    mGDALTransformerArgs = GDALCreateTPSTransformer( n, GCPList, false );
+  else
+    mGDALTransformerArgs = GDALCreateGCPTransformer( n, GCPList, mPolynomialOrder, false );
+
+  for ( int i = 0; i < n; i++ )
+  {
+    delete [] GCPList[i].pszId;
+  }
+  delete [] GCPList;
+
+  return nullptr != mGDALTransformerArgs;
+}
+
+int QgsGDALGeorefTransform::minimumGcpCount() const
+{
+  if ( mIsTPSTransform )
+    return 1;
+  else
+    return ( ( mPolynomialOrder + 2 ) * ( mPolynomialOrder + 1 ) ) / 2;
+}
+
+GDALTransformerFunc QgsGDALGeorefTransform::GDALTransformer() const
+{
+  // Fail if no arguments were calculated through updateParametersFromGCP
+  if ( !mGDALTransformerArgs )
+    return nullptr;
+
+  if ( mIsTPSTransform )
+    return GDALTPSTransform;
+  else
+    return GDALGCPTransform;
+}
+
+void *QgsGDALGeorefTransform::GDALTransformerArgs() const
+{
+  return mGDALTransformerArgs;
+}
+
+void QgsGDALGeorefTransform::destroyGdalArgs()
+{
+  if ( mGDALTransformerArgs )
+  {
+    if ( mIsTPSTransform )
+      GDALDestroyTPSTransformer( mGDALTransformerArgs );
+    else
+      GDALDestroyGCPTransformer( mGDALTransformerArgs );
+  }
+}
+
+//
+// QgsProjectiveGeorefTransform
+//
+
+QgsProjectiveGeorefTransform::QgsProjectiveGeorefTransform()
+  : mParameters()
+{}
+
+bool QgsProjectiveGeorefTransform::updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords )
+{
+  if ( mapCoords.size() < minimumGcpCount() )
+    return false;
+
+  // HACK: flip y coordinates, because georeferencer and gdal use different conventions
+  QVector<QgsPointXY> flippedPixelCoords;
+  flippedPixelCoords.reserve( pixelCoords.size() );
+  for ( const QgsPointXY &coord : pixelCoords )
+  {
+    flippedPixelCoords << QgsPointXY( coord.x(), -coord.y() );
+  }
+
+  QgsLeastSquares::projective( mapCoords, flippedPixelCoords, mParameters.H );
+
+  // Invert the homography matrix using adjoint matrix
+  double *H = mParameters.H;
+
+  double adjoint[9];
+  adjoint[0] = H[4] * H[8] - H[5] * H[7];
+  adjoint[1] = -H[1] * H[8] + H[2] * H[7];
+  adjoint[2] = H[1] * H[5] - H[2] * H[4];
+
+  adjoint[3] = -H[3] * H[8] + H[5] * H[6];
+  adjoint[4] = H[0] * H[8] - H[2] * H[6];
+  adjoint[5] = -H[0] * H[5] + H[2] * H[3];
+
+  adjoint[6] = H[3] * H[7] - H[4] * H[6];
+  adjoint[7] = -H[0] * H[7] + H[1] * H[6];
+  adjoint[8] = H[0] * H[4] - H[1] * H[3];
+
+  double det = H[0] * adjoint[0] + H[3] * adjoint[1] + H[6] * adjoint[2];
+
+  if ( std::fabs( det ) < 1024.0 * std::numeric_limits<double>::epsilon() )
+  {
+    mParameters.hasInverse = false;
+  }
+  else
+  {
+    mParameters.hasInverse = true;
+    double oo_det = 1.0 / det;
+    for ( int i = 0; i < 9; i++ )
+    {
+      mParameters.Hinv[i] = adjoint[i] * oo_det;
+    }
+  }
+  return true;
+}
+
+int QgsProjectiveGeorefTransform::minimumGcpCount() const
+{
+  return 4;
+}
+
+GDALTransformerFunc QgsProjectiveGeorefTransform::GDALTransformer() const
+{
+  return QgsProjectiveGeorefTransform::projectiveTransform;
+}
+
+void *QgsProjectiveGeorefTransform::GDALTransformerArgs() const
+{
+  return ( void * )&mParameters;
+}
+
+int QgsProjectiveGeorefTransform::projectiveTransform( void *pTransformerArg, int bDstToSrc, int nPointCount,
+    double *x, double *y, double *z, int *panSuccess )
+{
+  Q_UNUSED( z )
+  ProjectiveParameters *t = static_cast<ProjectiveParameters *>( pTransformerArg );
+  if ( !t )
+    return false;
+
+  double *H = nullptr;
+  if ( !bDstToSrc )
+  {
+    H = t->H;
+  }
+  else
+  {
+    if ( !t->hasInverse )
+    {
+      for ( int i = 0; i < nPointCount; ++i )
+      {
+        panSuccess[i] = false;
+      }
+      return false;
+    }
+    H = t->Hinv;
+  }
+
+
+  for ( int i = 0; i < nPointCount; ++i )
+  {
+    double Z = x[i] * H[6] + y[i] * H[7] + H[8];
+    // Projects to infinity?
+    if ( std::fabs( Z ) < 1024.0 * std::numeric_limits<double>::epsilon() )
+    {
+      panSuccess[i] = false;
+      continue;
+    }
+    double X = ( x[i] * H[0] + y[i] * H[1] + H[2] ) / Z;
+    double Y = ( x[i] * H[3] + y[i] * H[4] + H[5] ) / Z;
+
+    x[i] = X;
+    y[i] = Y;
+
+    panSuccess[i] = true;
+  }
+
+  return true;
+}

--- a/src/analysis/georeferencing/qgsgcptransformer.cpp
+++ b/src/analysis/georeferencing/qgsgcptransformer.cpp
@@ -49,6 +49,29 @@ QString QgsGcpTransformerInterface::methodToString( QgsGcpTransformerInterface::
   }
 }
 
+QgsGcpTransformerInterface *QgsGcpTransformerInterface::create( QgsGcpTransformerInterface::TransformMethod method )
+{
+  switch ( method )
+  {
+    case TransformMethod::Linear:
+      return new QgsLinearGeorefTransform;
+    case TransformMethod::Helmert:
+      return new QgsHelmertGeorefTransform;
+    case TransformMethod::PolynomialOrder1:
+      return new QgsGDALGeorefTransform( false, 1 );
+    case TransformMethod::PolynomialOrder2:
+      return new QgsGDALGeorefTransform( false, 2 );
+    case TransformMethod::PolynomialOrder3:
+      return new QgsGDALGeorefTransform( false, 3 );
+    case TransformMethod::ThinPlateSpline:
+      return new QgsGDALGeorefTransform( true, 0 );
+    case TransformMethod::Projective:
+      return new QgsProjectiveGeorefTransform;
+    default:
+      return nullptr;
+  }
+}
+
 
 //
 // QgsLinearGeorefTransform

--- a/src/analysis/georeferencing/qgsgcptransformer.cpp
+++ b/src/analysis/georeferencing/qgsgcptransformer.cpp
@@ -97,6 +97,13 @@ bool QgsLinearGeorefTransform::getOriginScale( QgsPointXY &origin, double &scale
   return true;
 }
 
+QgsGcpTransformerInterface *QgsLinearGeorefTransform::clone() const
+{
+  std::unique_ptr< QgsLinearGeorefTransform > res = qgis::make_unique< QgsLinearGeorefTransform >();
+  res->mParameters = mParameters;
+  return res.release();
+}
+
 bool QgsLinearGeorefTransform::updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &layerCoords )
 {
   if ( mapCoords.size() < minimumGcpCount() )
@@ -206,6 +213,13 @@ bool QgsHelmertGeorefTransform::getOriginScaleRotation( QgsPointXY &origin, doub
   return true;
 }
 
+QgsGcpTransformerInterface *QgsHelmertGeorefTransform::clone() const
+{
+  std::unique_ptr< QgsHelmertGeorefTransform > res = qgis::make_unique< QgsHelmertGeorefTransform >();
+  res->mHelmertParameters = mHelmertParameters;
+  return res.release();
+}
+
 int QgsHelmertGeorefTransform::helmert_transform( void *pTransformerArg, int bDstToSrc, int nPointCount,
     double *x, double *y, double *z, int *panSuccess )
 {
@@ -267,8 +281,6 @@ QgsGDALGeorefTransform::QgsGDALGeorefTransform( bool useTPS, unsigned int polyno
   : mPolynomialOrder( std::min( 3u, polynomialOrder ) )
   , mIsTPSTransform( useTPS )
 {
-  mGDALTransformer     = nullptr;
-  mGDALTransformerArgs = nullptr;
 }
 
 QgsGDALGeorefTransform::~QgsGDALGeorefTransform()
@@ -276,8 +288,18 @@ QgsGDALGeorefTransform::~QgsGDALGeorefTransform()
   destroyGdalArgs();
 }
 
+QgsGcpTransformerInterface *QgsGDALGeorefTransform::clone() const
+{
+  std::unique_ptr< QgsGDALGeorefTransform > res = qgis::make_unique< QgsGDALGeorefTransform >( mIsTPSTransform, mPolynomialOrder );
+  res->updateParametersFromGcps( mMapCoords, mLayerCoords );
+  return res.release();
+}
+
 bool QgsGDALGeorefTransform::updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &layerCoords )
 {
+  mMapCoords = mapCoords;
+  mLayerCoords = layerCoords;
+
   assert( mapCoords.size() == layerCoords.size() );
   if ( mapCoords.size() != layerCoords.size() )
     return false;
@@ -371,6 +393,13 @@ void QgsGDALGeorefTransform::destroyGdalArgs()
 QgsProjectiveGeorefTransform::QgsProjectiveGeorefTransform()
   : mParameters()
 {}
+
+QgsGcpTransformerInterface *QgsProjectiveGeorefTransform::clone() const
+{
+  std::unique_ptr< QgsProjectiveGeorefTransform > res = qgis::make_unique< QgsProjectiveGeorefTransform >();
+  res->mParameters = mParameters;
+  return res.release();
+}
 
 bool QgsProjectiveGeorefTransform::updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &layerCoords )
 {

--- a/src/analysis/georeferencing/qgsgcptransformer.cpp
+++ b/src/analysis/georeferencing/qgsgcptransformer.cpp
@@ -26,6 +26,24 @@
 #include <limits>
 
 
+bool QgsGcpTransformerInterface::transform( double &x, double &y, bool inverseTransform ) const
+{
+  GDALTransformerFunc t = GDALTransformer();
+  // Fail if no transformer function was returned
+  if ( !t )
+    return false;
+
+  double z = 0.0;
+  int success = 0;
+
+  // Call GDAL transform function
+  ( *t )( GDALTransformerArgs(), inverseTransform ? 1 : 0, 1,  &x, &y, &z, &success );
+  if ( !success )
+    return false;
+
+  return true;
+}
+
 QString QgsGcpTransformerInterface::methodToString( QgsGcpTransformerInterface::TransformMethod method )
 {
   switch ( method )

--- a/src/analysis/georeferencing/qgsgcptransformer.cpp
+++ b/src/analysis/georeferencing/qgsgcptransformer.cpp
@@ -25,6 +25,31 @@
 #include <cassert>
 #include <limits>
 
+
+QString QgsGcpTransformerInterface::methodToString( QgsGcpTransformerInterface::TransformMethod method )
+{
+  switch ( method )
+  {
+    case QgsGcpTransformerInterface::TransformMethod::Linear:
+      return QObject::tr( "Linear" );
+    case QgsGcpTransformerInterface::TransformMethod::Helmert:
+      return QObject::tr( "Helmert" );
+    case QgsGcpTransformerInterface::TransformMethod::PolynomialOrder1:
+      return QObject::tr( "Polynomial 1" );
+    case QgsGcpTransformerInterface::TransformMethod::PolynomialOrder2:
+      return QObject::tr( "Polynomial 2" );
+    case QgsGcpTransformerInterface::TransformMethod::PolynomialOrder3:
+      return QObject::tr( "Polynomial 3" );
+    case QgsGcpTransformerInterface::TransformMethod::ThinPlateSpline:
+      return QObject::tr( "Thin Plate Spline (TPS)" );
+    case QgsGcpTransformerInterface::TransformMethod::Projective:
+      return QObject::tr( "Projective" );
+    default:
+      return QObject::tr( "Not set" );
+  }
+}
+
+
 //
 // QgsLinearGeorefTransform
 //

--- a/src/analysis/georeferencing/qgsgcptransformer.cpp
+++ b/src/analysis/georeferencing/qgsgcptransformer.cpp
@@ -72,6 +72,18 @@ QgsGcpTransformerInterface *QgsGcpTransformerInterface::create( QgsGcpTransforme
   }
 }
 
+QgsGcpTransformerInterface *QgsGcpTransformerInterface::createFromParameters( QgsGcpTransformerInterface::TransformMethod method, const QVector<QgsPointXY> &mapCoordinates, const QVector<QgsPointXY> &pixelCoordinates )
+{
+  std::unique_ptr< QgsGcpTransformerInterface > transformer( create( method ) );
+  if ( !transformer )
+    return nullptr;
+
+  if ( !transformer->updateParametersFromGcps( mapCoordinates, pixelCoordinates ) )
+    return nullptr;
+
+  return transformer.release();
+}
+
 
 //
 // QgsLinearGeorefTransform

--- a/src/analysis/georeferencing/qgsgcptransformer.h
+++ b/src/analysis/georeferencing/qgsgcptransformer.h
@@ -1,0 +1,206 @@
+/***************************************************************************
+    qgsgcptransformer.h
+     --------------------------------------
+    Date                 : 18-Feb-2009
+    Copyright            : (c) 2009 by Manuel Massing
+    Email                : m.massing at warped-space.de
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSGCPTRANSFORMER_H
+#define QGSGCPTRANSFORMER_H
+
+#include <gdal_alg.h>
+#include "qgspoint.h"
+#include "qgis_analysis.h"
+#include "qgis_sip.h"
+
+/**
+ * \ingroup analysis
+ * An interface for Ground Control Points (GCP) based transformations.
+ *
+ * QgsGcpTransformerInterface implementations are able to transform point locations
+ * based on a transformation method and a list of GCPs.
+ *
+ * \since QGIS 3.20
+*/
+class ANALYSIS_EXPORT QgsGcpTransformerInterface SIP_ABSTRACT
+{
+  public:
+
+    QgsGcpTransformerInterface() = default;
+
+    virtual ~QgsGcpTransformerInterface() = default;
+
+    //! QgsGcpTransformerInterface cannot be copied
+    QgsGcpTransformerInterface( const QgsGcpTransformerInterface &other ) = delete;
+
+    //! QgsGcpTransformerInterface cannot be copied
+    QgsGcpTransformerInterface &operator=( const QgsGcpTransformerInterface &other ) = delete;
+
+    /**
+     * Fits transformation parameters using the specified Ground Control Points (GCPs) lists of map coordinates and pixel coordinates.
+     *
+     * \returns TRUE on success, FALSE on failure
+     */
+    virtual bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoordinates, const QVector<QgsPointXY> &pixelCoordinates ) = 0;
+
+    /**
+     * Returns the minimum number of Ground Control Points (GCPs) required for parameter fitting.
+     */
+    virtual int minimumGcpCount() const = 0;
+
+#ifndef SIP_RUN
+
+    /**
+     * Returns function pointer to the GDALTransformer function.
+     */
+    virtual GDALTransformerFunc GDALTransformer() const = 0;
+
+    /**
+     * Returns pointer to the GDALTransformer arguments.
+     */
+    virtual void *GDALTransformerArgs() const = 0;
+#endif
+
+  private:
+
+#ifdef SIP_RUN
+    QgsGcpTransformerInterface( const QgsGcpTransformerInterface &other )
+#endif
+};
+
+/**
+ * A simple transform which is parametrized by a translation and anistotropic scale.
+ * \ingroup analysis
+ * \note Not available in Python bindings
+ * \since QGIS 3.20
+ */
+class ANALYSIS_EXPORT QgsLinearGeorefTransform : public QgsGcpTransformerInterface SIP_SKIP
+{
+  public:
+    QgsLinearGeorefTransform() = default;
+
+    /**
+     * Returns the origin and scale for the transform.
+     */
+    bool getOriginScale( QgsPointXY &origin, double &scaleX, double &scaleY ) const;
+
+    bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords ) override;
+    int minimumGcpCount() const override;
+    GDALTransformerFunc GDALTransformer() const override;
+    void *GDALTransformerArgs() const override;
+
+  private:
+    struct LinearParameters
+    {
+      QgsPointXY origin;
+      double scaleX, scaleY;
+    } mParameters;
+
+    static int linearTransform( void *pTransformerArg, int bDstToSrc, int nPointCount,
+                                double *x, double *y, double *z, int *panSuccess );
+
+};
+
+/**
+ * 2-dimensional helmert transform, parametrised by isotropic scale, rotation angle and translation.
+ * \ingroup analysis
+ * \note Not available in Python bindings
+ * \since QGIS 3.20
+ */
+class ANALYSIS_EXPORT QgsHelmertGeorefTransform : public QgsGcpTransformerInterface SIP_SKIP
+{
+  public:
+    QgsHelmertGeorefTransform() = default;
+
+    /**
+     * Returns the origin, scale and rotation for the transform.
+     */
+    bool getOriginScaleRotation( QgsPointXY &origin, double &scale, double &rotation ) const;
+
+    bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords ) override;
+    int minimumGcpCount() const override;
+    GDALTransformerFunc GDALTransformer() const override;
+    void *GDALTransformerArgs() const override;
+
+  private:
+
+    struct HelmertParameters
+    {
+      QgsPointXY origin;
+      double scale;
+      double angle;
+    };
+    HelmertParameters mHelmertParameters;
+
+    static int helmert_transform( void *pTransformerArg, int bDstToSrc, int nPointCount,
+                                  double *x, double *y, double *z, int *panSuccess );
+
+};
+
+/**
+ * Interface to gdal thin plate splines and 1st/2nd/3rd order polynomials.
+ * \ingroup analysis
+ * \note Not available in Python bindings
+ * \since QGIS 3.20
+ */
+class ANALYSIS_EXPORT QgsGDALGeorefTransform : public QgsGcpTransformerInterface SIP_SKIP
+{
+  public:
+    QgsGDALGeorefTransform( bool useTPS, unsigned int polynomialOrder );
+    ~QgsGDALGeorefTransform() override;
+
+    bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords ) override;
+    int minimumGcpCount() const override;
+    GDALTransformerFunc GDALTransformer() const override;
+    void *GDALTransformerArgs() const override;
+  private:
+    void destroyGdalArgs();
+
+    const int  mPolynomialOrder;
+    const bool mIsTPSTransform;
+
+    GDALTransformerFunc  mGDALTransformer;
+    void                *mGDALTransformerArgs = nullptr;
+
+};
+
+/**
+ * A planar projective transform, expressed by a homography.
+ *
+ * Implements model fitting which minimizes algebraic error using total least squares.
+ *
+ * \ingroup analysis
+ * \note Not available in Python bindings
+ * \since QGIS 3.20
+ */
+class ANALYSIS_EXPORT QgsProjectiveGeorefTransform : public QgsGcpTransformerInterface SIP_SKIP
+{
+  public:
+    QgsProjectiveGeorefTransform();
+
+    bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords ) override;
+    int minimumGcpCount() const override;
+    GDALTransformerFunc GDALTransformer() const override;
+    void *GDALTransformerArgs() const override;
+  private:
+    struct ProjectiveParameters
+    {
+      double H[9];        // Homography
+      double Hinv[9];     // Inverted homography
+      bool hasInverse;  // Could the inverted homography be calculated?
+    } mParameters;
+
+    static int projectiveTransform( void *pTransformerArg, int bDstToSrc, int nPointCount,
+                                    double *x, double *y, double *z, int *panSuccess );
+
+};
+
+#endif //QGSGCPTRANSFORMER_H

--- a/src/analysis/georeferencing/qgsgcptransformer.h
+++ b/src/analysis/georeferencing/qgsgcptransformer.h
@@ -60,11 +60,11 @@ class ANALYSIS_EXPORT QgsGcpTransformerInterface SIP_ABSTRACT
     QgsGcpTransformerInterface &operator=( const QgsGcpTransformerInterface &other ) = delete;
 
     /**
-     * Fits transformation parameters using the specified Ground Control Points (GCPs) lists of map coordinates and pixel coordinates.
+     * Fits transformation parameters using the specified Ground Control Points (GCPs) lists of map coordinates and layer coordinates.
      *
      * \returns TRUE on success, FALSE on failure
      */
-    virtual bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoordinates, const QVector<QgsPointXY> &pixelCoordinates ) = 0;
+    virtual bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoordinates, const QVector<QgsPointXY> &layerCoordinates ) = 0;
 
     /**
      * Returns the minimum number of Ground Control Points (GCPs) required for parameter fitting.
@@ -90,13 +90,13 @@ class ANALYSIS_EXPORT QgsGcpTransformerInterface SIP_ABSTRACT
 
     /**
      * Creates a new QgsGcpTransformerInterface subclass representing the specified transform \a method, initialized
-     * using the given lists of map and pixel coordinates.
+     * using the given lists of map and layer coordinates.
      *
      * If the parameters cannot be fit to a transform NULLPTR will be returned.
      *
      * Caller takes ownership of the returned object.
      */
-    static QgsGcpTransformerInterface *createFromParameters( TransformMethod method, const QVector<QgsPointXY> &mapCoordinates, const QVector<QgsPointXY> &pixelCoordinates ) SIP_FACTORY;
+    static QgsGcpTransformerInterface *createFromParameters( TransformMethod method, const QVector<QgsPointXY> &mapCoordinates, const QVector<QgsPointXY> &layerCoordinates ) SIP_FACTORY;
 
 #ifndef SIP_RUN
 
@@ -134,7 +134,7 @@ class ANALYSIS_EXPORT QgsLinearGeorefTransform : public QgsGcpTransformerInterfa
      */
     bool getOriginScale( QgsPointXY &origin, double &scaleX, double &scaleY ) const;
 
-    bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords ) override;
+    bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &layerCoords ) override;
     int minimumGcpCount() const override;
     GDALTransformerFunc GDALTransformer() const override;
     void *GDALTransformerArgs() const override;
@@ -168,7 +168,7 @@ class ANALYSIS_EXPORT QgsHelmertGeorefTransform : public QgsGcpTransformerInterf
      */
     bool getOriginScaleRotation( QgsPointXY &origin, double &scale, double &rotation ) const;
 
-    bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords ) override;
+    bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &layerCoords ) override;
     int minimumGcpCount() const override;
     GDALTransformerFunc GDALTransformer() const override;
     void *GDALTransformerArgs() const override;
@@ -201,7 +201,7 @@ class ANALYSIS_EXPORT QgsGDALGeorefTransform : public QgsGcpTransformerInterface
     QgsGDALGeorefTransform( bool useTPS, unsigned int polynomialOrder );
     ~QgsGDALGeorefTransform() override;
 
-    bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords ) override;
+    bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &layerCoords ) override;
     int minimumGcpCount() const override;
     GDALTransformerFunc GDALTransformer() const override;
     void *GDALTransformerArgs() const override;
@@ -232,7 +232,7 @@ class ANALYSIS_EXPORT QgsProjectiveGeorefTransform : public QgsGcpTransformerInt
   public:
     QgsProjectiveGeorefTransform();
 
-    bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords ) override;
+    bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &layerCoords ) override;
     int minimumGcpCount() const override;
     GDALTransformerFunc GDALTransformer() const override;
     void *GDALTransformerArgs() const override;

--- a/src/analysis/georeferencing/qgsgcptransformer.h
+++ b/src/analysis/georeferencing/qgsgcptransformer.h
@@ -88,6 +88,16 @@ class ANALYSIS_EXPORT QgsGcpTransformerInterface SIP_ABSTRACT
      */
     static QgsGcpTransformerInterface *create( TransformMethod method ) SIP_FACTORY;
 
+    /**
+     * Creates a new QgsGcpTransformerInterface subclass representing the specified transform \a method, initialized
+     * using the given lists of map and pixel coordinates.
+     *
+     * If the parameters cannot be fit to a transform NULLPTR will be returned.
+     *
+     * Caller takes ownership of the returned object.
+     */
+    static QgsGcpTransformerInterface *createFromParameters( TransformMethod method, const QVector<QgsPointXY> &mapCoordinates, const QVector<QgsPointXY> &pixelCoordinates ) SIP_FACTORY;
+
 #ifndef SIP_RUN
 
     /**

--- a/src/analysis/georeferencing/qgsgcptransformer.h
+++ b/src/analysis/georeferencing/qgsgcptransformer.h
@@ -81,6 +81,13 @@ class ANALYSIS_EXPORT QgsGcpTransformerInterface SIP_ABSTRACT
      */
     static QString methodToString( TransformMethod method );
 
+    /**
+     * Creates a new QgsGcpTransformerInterface subclass representing the specified transform \a method.
+     *
+     * Caller takes ownership of the returned object.
+     */
+    static QgsGcpTransformerInterface *create( TransformMethod method ) SIP_FACTORY;
+
 #ifndef SIP_RUN
 
     /**

--- a/src/analysis/georeferencing/qgsgcptransformer.h
+++ b/src/analysis/georeferencing/qgsgcptransformer.h
@@ -76,6 +76,11 @@ class ANALYSIS_EXPORT QgsGcpTransformerInterface SIP_ABSTRACT
      */
     virtual TransformMethod method() const = 0;
 
+    /**
+     * Returns a translated string representing the specified transform \a method.
+     */
+    static QString methodToString( TransformMethod method );
+
 #ifndef SIP_RUN
 
     /**

--- a/src/analysis/georeferencing/qgsgcptransformer.h
+++ b/src/analysis/georeferencing/qgsgcptransformer.h
@@ -34,6 +34,21 @@ class ANALYSIS_EXPORT QgsGcpTransformerInterface SIP_ABSTRACT
 {
   public:
 
+    /**
+     * Available transformation methods.
+     */
+    enum class TransformMethod : int
+    {
+      Linear, //!< Linear transform
+      Helmert, //!< Helmert transform
+      PolynomialOrder1, //!< Polynomial order 1
+      PolynomialOrder2, //!< Polyonmial order 2
+      PolynomialOrder3, //!< Polynomial order
+      ThinPlateSpline, //!< Thin plate splines
+      Projective, //!< Projective
+      InvalidTransform = 65535 //!< Invalid transform
+    };
+
     QgsGcpTransformerInterface() = default;
 
     virtual ~QgsGcpTransformerInterface() = default;
@@ -55,6 +70,11 @@ class ANALYSIS_EXPORT QgsGcpTransformerInterface SIP_ABSTRACT
      * Returns the minimum number of Ground Control Points (GCPs) required for parameter fitting.
      */
     virtual int minimumGcpCount() const = 0;
+
+    /**
+     * Returns the transformation method.
+     */
+    virtual TransformMethod method() const = 0;
 
 #ifndef SIP_RUN
 
@@ -96,6 +116,7 @@ class ANALYSIS_EXPORT QgsLinearGeorefTransform : public QgsGcpTransformerInterfa
     int minimumGcpCount() const override;
     GDALTransformerFunc GDALTransformer() const override;
     void *GDALTransformerArgs() const override;
+    TransformMethod method() const override;
 
   private:
     struct LinearParameters
@@ -129,6 +150,7 @@ class ANALYSIS_EXPORT QgsHelmertGeorefTransform : public QgsGcpTransformerInterf
     int minimumGcpCount() const override;
     GDALTransformerFunc GDALTransformer() const override;
     void *GDALTransformerArgs() const override;
+    TransformMethod method() const override;
 
   private:
 
@@ -161,14 +183,16 @@ class ANALYSIS_EXPORT QgsGDALGeorefTransform : public QgsGcpTransformerInterface
     int minimumGcpCount() const override;
     GDALTransformerFunc GDALTransformer() const override;
     void *GDALTransformerArgs() const override;
+    TransformMethod method() const override;
+
   private:
     void destroyGdalArgs();
 
-    const int  mPolynomialOrder;
+    const int mPolynomialOrder;
     const bool mIsTPSTransform;
 
-    GDALTransformerFunc  mGDALTransformer;
-    void                *mGDALTransformerArgs = nullptr;
+    GDALTransformerFunc mGDALTransformer;
+    void *mGDALTransformerArgs = nullptr;
 
 };
 
@@ -190,6 +214,8 @@ class ANALYSIS_EXPORT QgsProjectiveGeorefTransform : public QgsGcpTransformerInt
     int minimumGcpCount() const override;
     GDALTransformerFunc GDALTransformer() const override;
     void *GDALTransformerArgs() const override;
+    TransformMethod method() const override;
+
   private:
     struct ProjectiveParameters
     {

--- a/src/analysis/georeferencing/qgsgcptransformer.h
+++ b/src/analysis/georeferencing/qgsgcptransformer.h
@@ -23,7 +23,7 @@
 
 /**
  * \ingroup analysis
- * An interface for Ground Control Points (GCP) based transformations.
+ * \brief An interface for Ground Control Points (GCP) based transformations.
  *
  * QgsGcpTransformerInterface implementations are able to transform point locations
  * based on a transformation method and a list of GCPs.
@@ -140,7 +140,7 @@ class ANALYSIS_EXPORT QgsGcpTransformerInterface SIP_ABSTRACT
 };
 
 /**
- * A simple transform which is parametrized by a translation and anistotropic scale.
+ * \brief A simple transform which is parametrized by a translation and anistotropic scale.
  * \ingroup analysis
  * \note Not available in Python bindings
  * \since QGIS 3.20
@@ -179,7 +179,7 @@ class ANALYSIS_EXPORT QgsLinearGeorefTransform : public QgsGcpTransformerInterfa
 };
 
 /**
- * 2-dimensional helmert transform, parametrised by isotropic scale, rotation angle and translation.
+ * \brief 2-dimensional helmert transform, parametrised by isotropic scale, rotation angle and translation.
  * \ingroup analysis
  * \note Not available in Python bindings
  * \since QGIS 3.20
@@ -220,7 +220,7 @@ class ANALYSIS_EXPORT QgsHelmertGeorefTransform : public QgsGcpTransformerInterf
 };
 
 /**
- * Interface to gdal thin plate splines and 1st/2nd/3rd order polynomials.
+ * \brief Interface to gdal thin plate splines and 1st/2nd/3rd order polynomials.
  * \ingroup analysis
  * \note Not available in Python bindings
  * \since QGIS 3.20
@@ -255,7 +255,7 @@ class ANALYSIS_EXPORT QgsGDALGeorefTransform : public QgsGcpTransformerInterface
 };
 
 /**
- * A planar projective transform, expressed by a homography.
+ * \brief A planar projective transform, expressed by a homography.
  *
  * Implements model fitting which minimizes algebraic error using total least squares.
  *

--- a/src/analysis/georeferencing/qgsgcptransformer.h
+++ b/src/analysis/georeferencing/qgsgcptransformer.h
@@ -53,11 +53,19 @@ class ANALYSIS_EXPORT QgsGcpTransformerInterface SIP_ABSTRACT
 
     virtual ~QgsGcpTransformerInterface() = default;
 
-    //! QgsGcpTransformerInterface cannot be copied
+    //! QgsGcpTransformerInterface cannot be copied - use clone() instead.
     QgsGcpTransformerInterface( const QgsGcpTransformerInterface &other ) = delete;
 
-    //! QgsGcpTransformerInterface cannot be copied
+    //! QgsGcpTransformerInterface cannot be copied - use clone() instead.
     QgsGcpTransformerInterface &operator=( const QgsGcpTransformerInterface &other ) = delete;
+
+    /**
+     * Clones the transformer, returning a new copy of the transformer with the same
+     * parameters as this one.
+     *
+     * Caller takes ownership of the returned object.
+     */
+    virtual QgsGcpTransformerInterface *clone() const = 0 SIP_FACTORY;
 
     /**
      * Fits transformation parameters using the specified Ground Control Points (GCPs) lists of map coordinates and layer coordinates.
@@ -134,6 +142,7 @@ class ANALYSIS_EXPORT QgsLinearGeorefTransform : public QgsGcpTransformerInterfa
      */
     bool getOriginScale( QgsPointXY &origin, double &scaleX, double &scaleY ) const;
 
+    QgsGcpTransformerInterface *clone() const override;
     bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &layerCoords ) override;
     int minimumGcpCount() const override;
     GDALTransformerFunc GDALTransformer() const override;
@@ -168,6 +177,7 @@ class ANALYSIS_EXPORT QgsHelmertGeorefTransform : public QgsGcpTransformerInterf
      */
     bool getOriginScaleRotation( QgsPointXY &origin, double &scale, double &rotation ) const;
 
+    QgsGcpTransformerInterface *clone() const override;
     bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &layerCoords ) override;
     int minimumGcpCount() const override;
     GDALTransformerFunc GDALTransformer() const override;
@@ -201,6 +211,7 @@ class ANALYSIS_EXPORT QgsGDALGeorefTransform : public QgsGcpTransformerInterface
     QgsGDALGeorefTransform( bool useTPS, unsigned int polynomialOrder );
     ~QgsGDALGeorefTransform() override;
 
+    QgsGcpTransformerInterface *clone() const override;
     bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &layerCoords ) override;
     int minimumGcpCount() const override;
     GDALTransformerFunc GDALTransformer() const override;
@@ -210,10 +221,13 @@ class ANALYSIS_EXPORT QgsGDALGeorefTransform : public QgsGcpTransformerInterface
   private:
     void destroyGdalArgs();
 
+    QVector<QgsPointXY> mMapCoords;
+    QVector<QgsPointXY> mLayerCoords;
+
     const int mPolynomialOrder;
     const bool mIsTPSTransform;
 
-    GDALTransformerFunc mGDALTransformer;
+    GDALTransformerFunc mGDALTransformer = nullptr;
     void *mGDALTransformerArgs = nullptr;
 
 };
@@ -232,6 +246,7 @@ class ANALYSIS_EXPORT QgsProjectiveGeorefTransform : public QgsGcpTransformerInt
   public:
     QgsProjectiveGeorefTransform();
 
+    QgsGcpTransformerInterface *clone() const override;
     bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &layerCoords ) override;
     int minimumGcpCount() const override;
     GDALTransformerFunc GDALTransformer() const override;

--- a/src/analysis/georeferencing/qgsgcptransformer.h
+++ b/src/analysis/georeferencing/qgsgcptransformer.h
@@ -85,6 +85,15 @@ class ANALYSIS_EXPORT QgsGcpTransformerInterface SIP_ABSTRACT
     virtual TransformMethod method() const = 0;
 
     /**
+     * Transforms the point (\a x, \a y) from source to destination coordinates.
+     *
+     * If \a inverseTransform is set to TRUE, the point will be transformed from the destination to the source.
+     *
+     * \returns TRUE if transformation was successful.
+     */
+    bool transform( double &x SIP_INOUT, double &y SIP_INOUT, bool inverseTransform = false ) const;
+
+    /**
      * Returns a translated string representing the specified transform \a method.
      */
     static QString methodToString( TransformMethod method );

--- a/src/analysis/georeferencing/qgsleastsquares.cpp
+++ b/src/analysis/georeferencing/qgsleastsquares.cpp
@@ -118,7 +118,7 @@ void QgsLeastSquares::helmert( const QVector<QgsPointXY> &mapCoords,
   rotation = std::atan2( gsl_vector_get( x, 1 ), gsl_vector_get( x, 0 ) );
 }
 
-
+#if 0
 void QgsLeastSquares::affine( QVector<QgsPointXY> mapCoords,
                               QVector<QgsPointXY> pixelCoords )
 {
@@ -171,7 +171,7 @@ void QgsLeastSquares::affine( QVector<QgsPointXY> mapCoords,
   gsl_permutation_free( p );
 
 }
-
+#endif
 
 /**
  * Scales the given coordinates so that the center of gravity is at the origin and the mean distance to the origin is sqrt(2).

--- a/src/analysis/georeferencing/qgsleastsquares.h
+++ b/src/analysis/georeferencing/qgsleastsquares.h
@@ -34,17 +34,17 @@ class ANALYSIS_EXPORT QgsLeastSquares
   public:
 
     /**
-     * Transforms the point at \a origin in-place, using a linear transformation calculated from the list of map and pixel Ground Control Points (GCPs).
+     * Transforms the point at \a origin in-place, using a linear transformation calculated from the list of source and destination Ground Control Points (GCPs).
      */
-    static void linear( const QVector<QgsPointXY> &mapCoords,
-                        const QVector<QgsPointXY> &pixelCoords,
+    static void linear( const QVector<QgsPointXY> &sourceCoordinates,
+                        const QVector<QgsPointXY> &destinationCoordinates,
                         QgsPointXY &origin, double &pixelXSize, double &pixelYSize );
 
     /**
-     * Transforms the point at \a origin in-place, using a helmert transformation calculated from the list of map and pixel Ground Control Points (GCPs).
+     * Transforms the point at \a origin in-place, using a helmert transformation calculated from the list of source and destination Ground Control Points (GCPs).
      */
-    static void helmert( const QVector<QgsPointXY> &mapCoords,
-                         const QVector<QgsPointXY> &pixelCoords,
+    static void helmert( const QVector<QgsPointXY> &sourceCoordinates,
+                         const QVector<QgsPointXY> &destinationCoordinates,
                          QgsPointXY &origin, double &pixelSize, double &rotation );
 
 #if 0
@@ -54,10 +54,10 @@ class ANALYSIS_EXPORT QgsLeastSquares
 #endif
 
     /**
-     * Calculates projective parameters from the list of map and pixel Ground Control Points (GCPs).
+     * Calculates projective parameters from the list of source and destination Ground Control Points (GCPs).
      */
-    static void projective( QVector<QgsPointXY> mapCoords,
-                            QVector<QgsPointXY> pixelCoords,
+    static void projective( const QVector<QgsPointXY> &sourceCoordinates,
+                            const QVector<QgsPointXY> &destinationCoordinates,
                             double H[9] );
 
 };

--- a/src/analysis/georeferencing/qgsleastsquares.h
+++ b/src/analysis/georeferencing/qgsleastsquares.h
@@ -24,7 +24,7 @@
 
 /**
  * \ingroup analysis
- * Utilities for calculation of least squares based transformations.
+ * \brief Utilities for calculation of least squares based transformations.
  *
  * \note Not available in Python bindings.
  * \since QGIS 3.20

--- a/src/analysis/georeferencing/qgsleastsquares.h
+++ b/src/analysis/georeferencing/qgsleastsquares.h
@@ -16,30 +16,50 @@
 #define QGSLEASTSQUARES_H
 
 #include <QVector>
-#include <cstdarg>
-#include <stdexcept>
 
+#include "qgis_analysis.h"
 #include "qgspointxy.h"
 
+#define SIP_NO_FILE
 
-class QgsLeastSquares
+/**
+ * \ingroup analysis
+ * Utilities for calculation of least squares based transformations.
+ *
+ * \note Not available in Python bindings.
+ * \since QGIS 3.20
+*/
+class ANALYSIS_EXPORT QgsLeastSquares
 {
   public:
+
+    /**
+     * Transforms the point at \a origin in-place, using a linear transformation calculated from the list of map and pixel Ground Control Points (GCPs).
+     */
     static void linear( const QVector<QgsPointXY> &mapCoords,
                         const QVector<QgsPointXY> &pixelCoords,
                         QgsPointXY &origin, double &pixelXSize, double &pixelYSize );
 
+    /**
+     * Transforms the point at \a origin in-place, using a helmert transformation calculated from the list of map and pixel Ground Control Points (GCPs).
+     */
     static void helmert( const QVector<QgsPointXY> &mapCoords,
                          const QVector<QgsPointXY> &pixelCoords,
                          QgsPointXY &origin, double &pixelSize, double &rotation );
 
+#if 0
     static void affine( QVector<QgsPointXY> mapCoords,
                         QVector<QgsPointXY> pixelCoords );
 
+#endif
+
+    /**
+     * Calculates projective parameters from the list of map and pixel Ground Control Points (GCPs).
+     */
     static void projective( QVector<QgsPointXY> mapCoords,
                             QVector<QgsPointXY> pixelCoords,
                             double H[9] );
+
 };
 
-
-#endif
+#endif // QGSLEASTSQUARES_H

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -243,7 +243,6 @@ if (WITH_GEOREFERENCER)
     georeferencer/qgsgeoreftooldeletepoint.cpp
     georeferencer/qgsgeoreftoolmovepoint.cpp
     georeferencer/qgsgeorefvalidators.cpp
-    georeferencer/qgsleastsquares.cpp
     georeferencer/qgsmapcoordsdialog.cpp
     georeferencer/qgsresidualplotitem.cpp
     georeferencer/qgstransformsettingsdialog.cpp

--- a/src/app/georeferencer/qgsgcplistmodel.cpp
+++ b/src/app/georeferencer/qgsgcplistmodel.cpp
@@ -89,7 +89,7 @@ void QgsGCPListModel::updateModel()
 
   if ( mGeorefTransform )
   {
-    bTransformUpdated = mGeorefTransform->updateParametersFromGcps( mapCoords, pixelCoords );
+    bTransformUpdated = mGeorefTransform->updateParametersFromGcps( pixelCoords, mapCoords, true );
     mapUnitsPossible = mGeorefTransform->providesAccurateInverseTransformation();
   }
 

--- a/src/app/georeferencer/qgsgcplistmodel.cpp
+++ b/src/app/georeferencer/qgsgcplistmodel.cpp
@@ -89,7 +89,7 @@ void QgsGCPListModel::updateModel()
 
   if ( mGeorefTransform )
   {
-    bTransformUpdated = mGeorefTransform->updateParametersFromGCPs( mapCoords, pixelCoords );
+    bTransformUpdated = mGeorefTransform->updateParametersFromGcps( mapCoords, pixelCoords );
     mapUnitsPossible = mGeorefTransform->providesAccurateInverseTransformation();
   }
 

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -377,7 +377,7 @@ bool QgsGeoreferencerMainWindow::getTransformSettings()
 
   d.getTransformSettings( mTransformParam, mResamplingMethod, mCompressionMethod,
                           mModifiedRasterFileName, mProjection, mPdfOutputMapFile, mPdfOutputFile, mSaveGcp, mUseZeroForTrans, mLoadInQgis, mUserResX, mUserResY );
-  mTransformParamLabel->setText( tr( "Transform: " ) + convertTransformEnumToString( mTransformParam ) );
+  mTransformParamLabel->setText( tr( "Transform: " ) + QgsGcpTransformerInterface::methodToString( mTransformParam ) );
   mGeorefTransform.selectTransformParametrisation( mTransformParam );
   mGCPListWidget->setGeorefTransform( &mGeorefTransform );
   mWorldFileName = guessWorldFileName( mRasterFileName );
@@ -433,7 +433,7 @@ void QgsGeoreferencerMainWindow::generateGDALScript()
     FALLTHROUGH
     default:
       mMessageBar->pushMessage( tr( "Invalid Transform" ), tr( "GDAL scripting is not supported for %1 transformation." )
-                                .arg( convertTransformEnumToString( mTransformParam ) )
+                                .arg( QgsGcpTransformerInterface::methodToString( mTransformParam ) )
                                 , Qgis::Critical );
   }
 }
@@ -1136,7 +1136,7 @@ void QgsGeoreferencerMainWindow::createStatusBar()
   statusBar()->addPermanentWidget( mRotationEdit, 0 );
 
   mTransformParamLabel = createBaseLabelStatus();
-  mTransformParamLabel->setText( tr( "Transform: " ) + convertTransformEnumToString( mTransformParam ) );
+  mTransformParamLabel->setText( tr( "Transform: " ) + QgsGcpTransformerInterface::methodToString( mTransformParam ) );
   mTransformParamLabel->setToolTip( tr( "Current transform parametrisation" ) );
   statusBar()->addPermanentWidget( mTransformParamLabel, 0 );
 
@@ -1695,7 +1695,7 @@ bool QgsGeoreferencerMainWindow::writePDFReportFile( const QString &fileName, co
   QGraphicsRectItem *previousItem = layoutMap;
   if ( wldTransform )
   {
-    QString parameterTitle = tr( "Transformation parameters" ) + QStringLiteral( " (" ) + convertTransformEnumToString( transform.transformParametrisation() ) + QStringLiteral( ")" );
+    QString parameterTitle = tr( "Transformation parameters" ) + QStringLiteral( " (" ) + QgsGcpTransformerInterface::methodToString( transform.transformParametrisation() ) + QStringLiteral( ")" );
     parameterLabel = new QgsLayoutItemLabel( &layout );
     parameterLabel->setFont( titleFont );
     parameterLabel->setText( parameterTitle );
@@ -1822,7 +1822,7 @@ void QgsGeoreferencerMainWindow::updateTransformParamLabel()
     return;
   }
 
-  QString transformName = convertTransformEnumToString( mGeorefTransform.transformParametrisation() );
+  QString transformName = QgsGcpTransformerInterface::methodToString( mGeorefTransform.transformParametrisation() );
   QString labelString = tr( "Transform: " ) + transformName;
 
   QgsPointXY origin;
@@ -1979,7 +1979,7 @@ bool QgsGeoreferencerMainWindow::checkReadyGeoref()
   if ( mPoints.count() < static_cast<int>( mGeorefTransform.minimumGcpCount() ) )
   {
     mMessageBar->pushMessage( tr( "Not Enough GCPs" ), tr( "%1 transformation requires at least %2 GCPs. Please define more." )
-                              .arg( convertTransformEnumToString( mTransformParam ) ).arg( mGeorefTransform.minimumGcpCount() )
+                              .arg( QgsGcpTransformerInterface::methodToString( mTransformParam ) ).arg( mGeorefTransform.minimumGcpCount() )
                               , Qgis::Critical );
     return false;
   }
@@ -2059,29 +2059,6 @@ QgsRectangle QgsGeoreferencerMainWindow::transformViewportBoundingBox( const Qgs
     }
   }
   return QgsRectangle( minX, minY, maxX, maxY );
-}
-
-QString QgsGeoreferencerMainWindow::convertTransformEnumToString( QgsGeorefTransform::TransformMethod transform )
-{
-  switch ( transform )
-  {
-    case QgsGcpTransformerInterface::TransformMethod::Linear:
-      return tr( "Linear" );
-    case QgsGcpTransformerInterface::TransformMethod::Helmert:
-      return tr( "Helmert" );
-    case QgsGcpTransformerInterface::TransformMethod::PolynomialOrder1:
-      return tr( "Polynomial 1" );
-    case QgsGcpTransformerInterface::TransformMethod::PolynomialOrder2:
-      return tr( "Polynomial 2" );
-    case QgsGcpTransformerInterface::TransformMethod::PolynomialOrder3:
-      return tr( "Polynomial 3" );
-    case QgsGcpTransformerInterface::TransformMethod::ThinPlateSpline:
-      return tr( "Thin plate spline (TPS)" );
-    case QgsGcpTransformerInterface::TransformMethod::Projective:
-      return tr( "Projective" );
-    default:
-      return tr( "Not set" );
-  }
 }
 
 QString QgsGeoreferencerMainWindow::convertResamplingEnumToString( QgsImageWarper::ResamplingMethod resampling )

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -59,7 +59,6 @@
 #include "qgsgeoreftoolmovepoint.h"
 #include "qgsgcpcanvasitem.h"
 
-#include "qgsleastsquares.h"
 #include "qgsgcplistwidget.h"
 
 #include "qgsgeorefconfigdialog.h"
@@ -1496,12 +1495,12 @@ bool QgsGeoreferencerMainWindow::calculateMeanError( double &error ) const
     }
   }
 
-  if ( nPointsEnabled == mGeorefTransform.getMinimumGCPCount() )
+  if ( nPointsEnabled == mGeorefTransform.minimumGcpCount() )
   {
     error = 0;
     return true;
   }
-  else if ( nPointsEnabled < mGeorefTransform.getMinimumGCPCount() )
+  else if ( nPointsEnabled < mGeorefTransform.minimumGcpCount() )
   {
     return false;
   }
@@ -1521,7 +1520,7 @@ bool QgsGeoreferencerMainWindow::calculateMeanError( double &error ) const
 
   // Calculate the root mean square error, adjusted for degrees of freedom of the transform
   // Caveat: The number of DoFs is assumed to be even (as each control point fixes two degrees of freedom).
-  error = std::sqrt( ( sumVxSquare + sumVySquare ) / ( nPointsEnabled - mGeorefTransform.getMinimumGCPCount() ) );
+  error = std::sqrt( ( sumVxSquare + sumVySquare ) / ( nPointsEnabled - mGeorefTransform.minimumGcpCount() ) );
   return true;
 }
 
@@ -1977,10 +1976,10 @@ bool QgsGeoreferencerMainWindow::checkReadyGeoref()
     return false;
   }
 
-  if ( mPoints.count() < static_cast<int>( mGeorefTransform.getMinimumGCPCount() ) )
+  if ( mPoints.count() < static_cast<int>( mGeorefTransform.minimumGcpCount() ) )
   {
     mMessageBar->pushMessage( tr( "Not Enough GCPs" ), tr( "%1 transformation requires at least %2 GCPs. Please define more." )
-                              .arg( convertTransformEnumToString( mTransformParam ) ).arg( mGeorefTransform.getMinimumGCPCount() )
+                              .arg( convertTransformEnumToString( mTransformParam ) ).arg( mGeorefTransform.minimumGcpCount() )
                               , Qgis::Critical );
     return false;
   }
@@ -2005,7 +2004,7 @@ bool QgsGeoreferencerMainWindow::updateGeorefTransform()
     return false;
 
   // Parametrize the transform with GCPs
-  if ( !mGeorefTransform.updateParametersFromGCPs( mapCoords, pixelCoords ) )
+  if ( !mGeorefTransform.updateParametersFromGcps( mapCoords, pixelCoords ) )
   {
     return false;
   }
@@ -2180,14 +2179,14 @@ bool QgsGeoreferencerMainWindow::equalGCPlists( const QgsGCPList &list1, const Q
 //
 //void QgsGeorefPluginGui::logRequaredGCPs()
 //{
-//  if (mGeorefTransform.getMinimumGCPCount() != 0)
+//  if (mGeorefTransform.minimumGcpCount() != 0)
 //  {
-//    if ((uint)mPoints.size() >= mGeorefTransform.getMinimumGCPCount())
+//    if ((uint)mPoints.size() >= mGeorefTransform.minimumGcpCount())
 //      showMessageInLog(tr("Info"), tr("For georeferencing requared at least %1 GCP points")
-//                       .arg(mGeorefTransform.getMinimumGCPCount()));
+//                       .arg(mGeorefTransform.minimumGcpCount()));
 //    else
 //      showMessageInLog(tr("Critical"), tr("For georeferencing requared at least %1 GCP points")
-//                       .arg(mGeorefTransform.getMinimumGCPCount()));
+//                       .arg(mGeorefTransform.minimumGcpCount()));
 //  }
 //}
 

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -2004,7 +2004,7 @@ bool QgsGeoreferencerMainWindow::updateGeorefTransform()
     return false;
 
   // Parametrize the transform with GCPs
-  if ( !mGeorefTransform.updateParametersFromGcps( mapCoords, pixelCoords ) )
+  if ( !mGeorefTransform.updateParametersFromGcps( pixelCoords, mapCoords, true ) )
   {
     return false;
   }

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -179,7 +179,6 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     bool checkReadyGeoref();
     QgsRectangle transformViewportBoundingBox( const QgsRectangle &canvasExtent, QgsGeorefTransform &t,
         bool rasterToWorld = true, uint numSamples = 4 );
-    QString convertTransformEnumToString( QgsGeorefTransform::TransformMethod transform );
     QString convertResamplingEnumToString( QgsImageWarper::ResamplingMethod resampling );
     int polynomialOrder( QgsGeorefTransform::TransformMethod transform );
     QString guessWorldFileName( const QString &rasterFileName );

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -229,7 +229,7 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     QString mSaveGcp;
     double  mUserResX, mUserResY;  // User specified target scale
 
-    QgsGeorefTransform::TransformMethod mTransformParam = QgsGeorefTransform::InvalidTransform;
+    QgsGcpTransformerInterface::TransformMethod mTransformParam = QgsGcpTransformerInterface::TransformMethod::InvalidTransform;
     QgsImageWarper::ResamplingMethod mResamplingMethod;
     QgsGeorefTransform mGeorefTransform;
     QString mCompressionMethod;

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -179,9 +179,9 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     bool checkReadyGeoref();
     QgsRectangle transformViewportBoundingBox( const QgsRectangle &canvasExtent, QgsGeorefTransform &t,
         bool rasterToWorld = true, uint numSamples = 4 );
-    QString convertTransformEnumToString( QgsGeorefTransform::TransformParametrisation transform );
+    QString convertTransformEnumToString( QgsGeorefTransform::TransformMethod transform );
     QString convertResamplingEnumToString( QgsImageWarper::ResamplingMethod resampling );
-    int polynomialOrder( QgsGeorefTransform::TransformParametrisation transform );
+    int polynomialOrder( QgsGeorefTransform::TransformMethod transform );
     QString guessWorldFileName( const QString &rasterFileName );
     bool checkFileExisting( const QString &fileName, const QString &title, const QString &question );
     bool equalGCPlists( const QgsGCPList &list1, const QgsGCPList &list2 );
@@ -230,7 +230,7 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     QString mSaveGcp;
     double  mUserResX, mUserResY;  // User specified target scale
 
-    QgsGeorefTransform::TransformParametrisation mTransformParam = QgsGeorefTransform::InvalidTransform;
+    QgsGeorefTransform::TransformMethod mTransformParam = QgsGeorefTransform::InvalidTransform;
     QgsImageWarper::ResamplingMethod mResamplingMethod;
     QgsGeorefTransform mGeorefTransform;
     QString mCompressionMethod;

--- a/src/app/georeferencer/qgsgeoreftransform.cpp
+++ b/src/app/georeferencer/qgsgeoreftransform.cpp
@@ -19,117 +19,10 @@
 #include <gdal.h>
 #include <gdal_alg.h>
 
-#include "qgsleastsquares.h"
-
 #include <cmath>
 
 #include <cassert>
 #include <limits>
-
-/**
- * A simple transform which is paremetrized by a translation and anistotropic scale.
- */
-class QgsLinearGeorefTransform : public QgsGeorefTransformInterface
-{
-  public:
-    QgsLinearGeorefTransform() = default;
-
-    bool getOriginScale( QgsPointXY &origin, double &scaleX, double &scaleY ) const;
-
-    bool updateParametersFromGCPs( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords ) override;
-    int getMinimumGCPCount() const override;
-
-    GDALTransformerFunc  GDALTransformer()     const override { return QgsLinearGeorefTransform::linear_transform; }
-    void                *GDALTransformerArgs() const override { return ( void * )&mParameters; }
-  private:
-    struct LinearParameters
-    {
-      QgsPointXY origin;
-      double scaleX, scaleY;
-    } mParameters;
-
-    static int linear_transform( void *pTransformerArg, int bDstToSrc, int nPointCount,
-                                 double *x, double *y, double *z, int *panSuccess );
-};
-
-/**
- * 2-dimensional helmert transform, parametrised by isotropic scale, rotation angle and translation.
- */
-class QgsHelmertGeorefTransform : public QgsGeorefTransformInterface
-{
-  public:
-    QgsHelmertGeorefTransform() = default;
-    struct HelmertParameters
-    {
-      QgsPointXY origin;
-      double   scale;
-      double   angle;
-    };
-
-    bool getOriginScaleRotation( QgsPointXY &origin, double &scale, double &rotation ) const;
-    bool updateParametersFromGCPs( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords ) override;
-    int getMinimumGCPCount() const override;
-
-    GDALTransformerFunc  GDALTransformer()     const override;
-    void                *GDALTransformerArgs() const override;
-  private:
-    HelmertParameters mHelmertParameters;
-
-    static int helmert_transform( void *pTransformerArg, int bDstToSrc, int nPointCount,
-                                  double *x, double *y, double *z, int *panSuccess );
-};
-
-/**
- * Interface to gdal thin plate splines and 1st/2nd/3rd order polynomials.
- */
-class QgsGDALGeorefTransform : public QgsGeorefTransformInterface
-{
-  public:
-    QgsGDALGeorefTransform( bool useTPS, unsigned int polynomialOrder );
-    ~QgsGDALGeorefTransform() override;
-
-    bool updateParametersFromGCPs( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords ) override;
-    int getMinimumGCPCount() const override;
-
-    GDALTransformerFunc  GDALTransformer()     const override;
-    void                *GDALTransformerArgs() const override;
-  private:
-    void destroy_gdal_args();
-
-    const int  mPolynomialOrder;
-    const bool mIsTPSTransform;
-
-    GDALTransformerFunc  mGDALTransformer;
-    void                *mGDALTransformerArgs = nullptr;
-};
-
-/**
- * A planar projective transform, expressed by a homography.
- *
- * Implements model fitting which minimizes algebraic error using total least squares.
- */
-class QgsProjectiveGeorefTransform : public QgsGeorefTransformInterface
-{
-  public:
-    QgsProjectiveGeorefTransform() : mParameters() {}
-
-    bool updateParametersFromGCPs( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords ) override;
-    int getMinimumGCPCount() const override;
-
-    GDALTransformerFunc  GDALTransformer()     const override { return QgsProjectiveGeorefTransform::projective_transform; }
-    void                *GDALTransformerArgs() const override { return ( void * )&mParameters; }
-  private:
-    struct ProjectiveParameters
-    {
-      double H[9];        // Homography
-      double Hinv[9];     // Inverted homography
-      bool   hasInverse;  // Could the inverted homography be calculated?
-    } mParameters;
-
-    static int projective_transform( void *pTransformerArg, int bDstToSrc, int nPointCount,
-                                     double *x, double *y, double *z, int *panSuccess );
-};
-
 
 QgsGeorefTransform::QgsGeorefTransform( const QgsGeorefTransform &other )
 {
@@ -190,7 +83,7 @@ bool QgsGeorefTransform::parametersInitialized() const
   return mParametersInitialized;
 }
 
-bool QgsGeorefTransform::updateParametersFromGCPs( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords )
+bool QgsGeorefTransform::updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords )
 {
   if ( !mGeorefTransformImplementation )
   {
@@ -200,26 +93,26 @@ bool QgsGeorefTransform::updateParametersFromGCPs( const QVector<QgsPointXY> &ma
   {
     throw ( std::domain_error( "Internal error: GCP mapping is not one-to-one" ) );
   }
-  if ( mapCoords.size() < getMinimumGCPCount() )
+  if ( mapCoords.size() < minimumGcpCount() )
   {
     return false;
   }
   if ( mRasterChangeCoords.hasCrs() )
   {
     QVector<QgsPointXY> pixelCoordsCorrect = mRasterChangeCoords.getPixelCoords( pixelCoords );
-    mParametersInitialized = mGeorefTransformImplementation->updateParametersFromGCPs( mapCoords, pixelCoordsCorrect );
+    mParametersInitialized = mGeorefTransformImplementation->updateParametersFromGcps( mapCoords, pixelCoordsCorrect );
     pixelCoordsCorrect.clear();
   }
   else
   {
-    mParametersInitialized = mGeorefTransformImplementation->updateParametersFromGCPs( mapCoords, pixelCoords );
+    mParametersInitialized = mGeorefTransformImplementation->updateParametersFromGcps( mapCoords, pixelCoords );
   }
   return mParametersInitialized;
 }
 
-int QgsGeorefTransform::getMinimumGCPCount() const
+int QgsGeorefTransform::minimumGcpCount() const
 {
-  return mGeorefTransformImplementation ? mGeorefTransformImplementation->getMinimumGCPCount() : 0;
+  return mGeorefTransformImplementation ? mGeorefTransformImplementation->minimumGcpCount() : 0;
 }
 
 GDALTransformerFunc QgsGeorefTransform::GDALTransformer() const
@@ -232,7 +125,7 @@ void *QgsGeorefTransform::GDALTransformerArgs() const
   return mGeorefTransformImplementation ? mGeorefTransformImplementation->GDALTransformerArgs() : nullptr;
 }
 
-QgsGeorefTransformInterface *QgsGeorefTransform::createImplementation( TransformParametrisation parametrisation )
+QgsGcpTransformerInterface *QgsGeorefTransform::createImplementation( TransformParametrisation parametrisation )
 {
   switch ( parametrisation )
   {
@@ -338,335 +231,3 @@ bool QgsGeorefTransform::gdal_transform( const QgsPointXY &src, QgsPointXY &dst,
 }
 
 
-bool QgsLinearGeorefTransform::getOriginScale( QgsPointXY &origin, double &scaleX, double &scaleY ) const
-{
-  origin = mParameters.origin;
-  scaleX = mParameters.scaleX;
-  scaleY = mParameters.scaleY;
-  return true;
-}
-
-bool QgsLinearGeorefTransform::updateParametersFromGCPs( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords )
-{
-  if ( mapCoords.size() < getMinimumGCPCount() )
-    return false;
-  QgsLeastSquares::linear( mapCoords, pixelCoords, mParameters.origin, mParameters.scaleX, mParameters.scaleY );
-  return true;
-}
-
-int QgsLinearGeorefTransform::getMinimumGCPCount() const
-{
-  return 2;
-}
-
-int QgsLinearGeorefTransform::linear_transform( void *pTransformerArg, int bDstToSrc, int nPointCount,
-    double *x, double *y, double *z, int *panSuccess )
-{
-  Q_UNUSED( z )
-  LinearParameters *t = static_cast<LinearParameters *>( pTransformerArg );
-  if ( !t )
-    return false;
-
-  if ( !bDstToSrc )
-  {
-    for ( int i = 0; i < nPointCount; ++i )
-    {
-      x[i] = x[i] * t->scaleX + t->origin.x();
-      y[i] = -y[i] * t->scaleY + t->origin.y();
-      panSuccess[i] = true;
-    }
-  }
-  else
-  {
-    // Guard against division by zero
-    if ( std::fabs( t->scaleX ) < std::numeric_limits<double>::epsilon() ||
-         std::fabs( t->scaleY ) < std::numeric_limits<double>::epsilon() )
-    {
-      for ( int i = 0; i < nPointCount; ++i )
-      {
-        panSuccess[i] = false;
-      }
-      return false;
-    }
-    for ( int i = 0; i < nPointCount; ++i )
-    {
-      x[i] = ( x[i] - t->origin.x() ) / t->scaleX;
-      y[i] = ( y[i] - t->origin.y() ) / ( -t->scaleY );
-      panSuccess[i] = true;
-    }
-  }
-
-  return true;
-}
-
-bool QgsHelmertGeorefTransform::updateParametersFromGCPs( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords )
-{
-  if ( mapCoords.size() < getMinimumGCPCount() )
-    return false;
-
-  QgsLeastSquares::helmert( mapCoords, pixelCoords, mHelmertParameters.origin, mHelmertParameters.scale, mHelmertParameters.angle );
-  return true;
-}
-
-int QgsHelmertGeorefTransform::getMinimumGCPCount() const
-{
-  return 2;
-}
-
-
-GDALTransformerFunc QgsHelmertGeorefTransform::GDALTransformer() const
-{
-  return QgsHelmertGeorefTransform::helmert_transform;
-}
-
-void *QgsHelmertGeorefTransform::GDALTransformerArgs() const
-{
-  return ( void * )&mHelmertParameters;
-}
-
-bool QgsHelmertGeorefTransform::getOriginScaleRotation( QgsPointXY &origin, double &scale, double &rotation ) const
-{
-  origin = mHelmertParameters.origin;
-  scale = mHelmertParameters.scale;
-  rotation = mHelmertParameters.angle;
-  return true;
-}
-
-int QgsHelmertGeorefTransform::helmert_transform( void *pTransformerArg, int bDstToSrc, int nPointCount,
-    double *x, double *y, double *z, int *panSuccess )
-{
-  Q_UNUSED( z )
-  HelmertParameters *t = static_cast<HelmertParameters *>( pTransformerArg );
-  if ( !t )
-    return false;
-
-  double a = std::cos( t->angle ), b = std::sin( t->angle ), x0 = t->origin.x(), y0 = t->origin.y(), s = t->scale;
-  if ( !bDstToSrc )
-  {
-    a *= s;
-    b *= s;
-    for ( int i = 0; i < nPointCount; ++i )
-    {
-      double xT = x[i], yT = y[i];
-      // Because rotation parameters where estimated in a CS with negative y-axis ^= down.
-      // we need to apply the rotation matrix and a change of base:
-      // |cos a,-sin a| |1, 0|   | std::cos a,  std::sin a|
-      // |sin a, std::cos a| |0,-1| = | std::sin a, -cos a|
-      x[i] = x0 + ( a * xT + b * yT );
-      y[i] = y0 + ( b * xT - a * yT );
-      panSuccess[i] = true;
-    }
-  }
-  else
-  {
-    // Guard against division by zero
-    if ( std::fabs( s ) < std::numeric_limits<double>::epsilon() )
-    {
-      for ( int i = 0; i < nPointCount; ++i )
-      {
-        panSuccess[i] = false;
-      }
-      return false;
-    }
-    a /= s;
-    b /= s;
-    for ( int i = 0; i < nPointCount; ++i )
-    {
-      double xT = x[i], yT = y[i];
-      xT -= x0;
-      yT -= y0;
-      // | std::cos a,  std::sin a |^-1   |cos a,  std::sin a|
-      // | std::sin a, -cos a |    = |sin a, -cos a|
-      x[i] = a * xT + b * yT;
-      y[i] = b * xT - a * yT;
-      panSuccess[i] = true;
-    }
-  }
-  return true;
-}
-
-QgsGDALGeorefTransform::QgsGDALGeorefTransform( bool useTPS, unsigned int polynomialOrder )
-  : mPolynomialOrder( std::min( 3u, polynomialOrder ) )
-  , mIsTPSTransform( useTPS )
-{
-  mGDALTransformer     = nullptr;
-  mGDALTransformerArgs = nullptr;
-}
-
-QgsGDALGeorefTransform::~QgsGDALGeorefTransform()
-{
-  destroy_gdal_args();
-}
-
-bool QgsGDALGeorefTransform::updateParametersFromGCPs( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords )
-{
-  assert( mapCoords.size() == pixelCoords.size() );
-  if ( mapCoords.size() != pixelCoords.size() )
-    return false;
-  int n = mapCoords.size();
-
-  GDAL_GCP *GCPList = new GDAL_GCP[n];
-  for ( int i = 0; i < n; i++ )
-  {
-    GCPList[i].pszId = new char[20];
-    snprintf( GCPList[i].pszId, 19, "gcp%i", i );
-    GCPList[i].pszInfo = nullptr;
-    GCPList[i].dfGCPPixel = pixelCoords[i].x();
-    GCPList[i].dfGCPLine  = -pixelCoords[i].y();
-    GCPList[i].dfGCPX = mapCoords[i].x();
-    GCPList[i].dfGCPY = mapCoords[i].y();
-    GCPList[i].dfGCPZ = 0;
-  }
-  destroy_gdal_args();
-
-  if ( mIsTPSTransform )
-    mGDALTransformerArgs = GDALCreateTPSTransformer( n, GCPList, false );
-  else
-    mGDALTransformerArgs = GDALCreateGCPTransformer( n, GCPList, mPolynomialOrder, false );
-
-  for ( int i = 0; i < n; i++ )
-  {
-    delete [] GCPList[i].pszId;
-  }
-  delete [] GCPList;
-
-  return nullptr != mGDALTransformerArgs;
-}
-
-int QgsGDALGeorefTransform::getMinimumGCPCount() const
-{
-  if ( mIsTPSTransform )
-    return 1;
-  else
-    return ( ( mPolynomialOrder + 2 ) * ( mPolynomialOrder + 1 ) ) / 2;
-}
-
-GDALTransformerFunc QgsGDALGeorefTransform::GDALTransformer() const
-{
-  // Fail if no arguments were calculated through updateParametersFromGCP
-  if ( !mGDALTransformerArgs )
-    return nullptr;
-
-  if ( mIsTPSTransform )
-    return GDALTPSTransform;
-  else
-    return GDALGCPTransform;
-}
-
-void *QgsGDALGeorefTransform::GDALTransformerArgs() const
-{
-  return mGDALTransformerArgs;
-}
-
-void QgsGDALGeorefTransform::destroy_gdal_args()
-{
-  if ( mGDALTransformerArgs )
-  {
-    if ( mIsTPSTransform )
-      GDALDestroyTPSTransformer( mGDALTransformerArgs );
-    else
-      GDALDestroyGCPTransformer( mGDALTransformerArgs );
-  }
-}
-
-bool QgsProjectiveGeorefTransform::updateParametersFromGCPs( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords )
-{
-  if ( mapCoords.size() < getMinimumGCPCount() )
-    return false;
-
-  // HACK: flip y coordinates, because georeferencer and gdal use different conventions
-  QVector<QgsPointXY> flippedPixelCoords;
-  flippedPixelCoords.reserve( pixelCoords.size() );
-  for ( const QgsPointXY &coord : pixelCoords )
-  {
-    flippedPixelCoords << QgsPointXY( coord.x(), -coord.y() );
-  }
-
-  QgsLeastSquares::projective( mapCoords, flippedPixelCoords, mParameters.H );
-
-  // Invert the homography matrix using adjoint matrix
-  double *H = mParameters.H;
-
-  double adjoint[9];
-  adjoint[0] = H[4] * H[8] - H[5] * H[7];
-  adjoint[1] = -H[1] * H[8] + H[2] * H[7];
-  adjoint[2] = H[1] * H[5] - H[2] * H[4];
-
-  adjoint[3] = -H[3] * H[8] + H[5] * H[6];
-  adjoint[4] = H[0] * H[8] - H[2] * H[6];
-  adjoint[5] = -H[0] * H[5] + H[2] * H[3];
-
-  adjoint[6] = H[3] * H[7] - H[4] * H[6];
-  adjoint[7] = -H[0] * H[7] + H[1] * H[6];
-  adjoint[8] = H[0] * H[4] - H[1] * H[3];
-
-  double det = H[0] * adjoint[0] + H[3] * adjoint[1] + H[6] * adjoint[2];
-
-  if ( std::fabs( det ) < 1024.0 * std::numeric_limits<double>::epsilon() )
-  {
-    mParameters.hasInverse = false;
-  }
-  else
-  {
-    mParameters.hasInverse = true;
-    double oo_det = 1.0 / det;
-    for ( int i = 0; i < 9; i++ )
-    {
-      mParameters.Hinv[i] = adjoint[i] * oo_det;
-    }
-  }
-  return true;
-}
-
-int QgsProjectiveGeorefTransform::getMinimumGCPCount() const
-{
-  return 4;
-}
-
-int QgsProjectiveGeorefTransform::projective_transform( void *pTransformerArg, int bDstToSrc, int nPointCount,
-    double *x, double *y, double *z, int *panSuccess )
-{
-  Q_UNUSED( z )
-  ProjectiveParameters *t = static_cast<ProjectiveParameters *>( pTransformerArg );
-  if ( !t )
-    return false;
-
-  double *H = nullptr;
-  if ( !bDstToSrc )
-  {
-    H = t->H;
-  }
-  else
-  {
-    if ( !t->hasInverse )
-    {
-      for ( int i = 0; i < nPointCount; ++i )
-      {
-        panSuccess[i] = false;
-      }
-      return false;
-    }
-    H = t->Hinv;
-  }
-
-
-  for ( int i = 0; i < nPointCount; ++i )
-  {
-    double Z = x[i] * H[6] + y[i] * H[7] + H[8];
-    // Projects to infinity?
-    if ( std::fabs( Z ) < 1024.0 * std::numeric_limits<double>::epsilon() )
-    {
-      panSuccess[i] = false;
-      continue;
-    }
-    double X = ( x[i] * H[0] + y[i] * H[1] + H[2] ) / Z;
-    double Y = ( x[i] * H[3] + y[i] * H[4] + H[5] ) / Z;
-
-    x[i] = X;
-    y[i] = Y;
-
-    panSuccess[i] = true;
-  }
-
-  return true;
-}

--- a/src/app/georeferencer/qgsgeoreftransform.cpp
+++ b/src/app/georeferencer/qgsgeoreftransform.cpp
@@ -70,8 +70,18 @@ bool QgsGeorefTransform::parametersInitialized() const
   return mParametersInitialized;
 }
 
+QgsGcpTransformerInterface *QgsGeorefTransform::clone() const
+{
+  std::unique_ptr< QgsGeorefTransform > res( new QgsGeorefTransform( *this ) );
+  res->updateParametersFromGcps( mMapCoords, mLayerCoords );
+  return res.release();
+}
+
 bool QgsGeorefTransform::updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords )
 {
+  mMapCoords = mapCoords;
+  mLayerCoords = pixelCoords;
+
   if ( !mGeorefTransformImplementation )
   {
     return false;

--- a/src/app/georeferencer/qgsgeoreftransform.cpp
+++ b/src/app/georeferencer/qgsgeoreftransform.cpp
@@ -73,36 +73,36 @@ bool QgsGeorefTransform::parametersInitialized() const
 QgsGcpTransformerInterface *QgsGeorefTransform::clone() const
 {
   std::unique_ptr< QgsGeorefTransform > res( new QgsGeorefTransform( *this ) );
-  res->updateParametersFromGcps( mMapCoords, mLayerCoords );
+  res->updateParametersFromGcps( mSourceCoordinates, mDestinationCoordinates, mInvertYAxis );
   return res.release();
 }
 
-bool QgsGeorefTransform::updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords )
+bool QgsGeorefTransform::updateParametersFromGcps( const QVector<QgsPointXY> &sourceCoordinates, const QVector<QgsPointXY> &destinationCoordinates, bool invertYAxis )
 {
-  mMapCoords = mapCoords;
-  mLayerCoords = pixelCoords;
+  mSourceCoordinates = sourceCoordinates;
+  mDestinationCoordinates = destinationCoordinates;
+  mInvertYAxis = invertYAxis;
 
   if ( !mGeorefTransformImplementation )
   {
     return false;
   }
-  if ( mapCoords.size() != pixelCoords.size() ) // Defensive sanity check
+  if ( sourceCoordinates.size() != destinationCoordinates.size() ) // Defensive sanity check
   {
     throw ( std::domain_error( "Internal error: GCP mapping is not one-to-one" ) );
   }
-  if ( mapCoords.size() < minimumGcpCount() )
+  if ( sourceCoordinates.size() < minimumGcpCount() )
   {
     return false;
   }
   if ( mRasterChangeCoords.hasCrs() )
   {
-    QVector<QgsPointXY> pixelCoordsCorrect = mRasterChangeCoords.getPixelCoords( pixelCoords );
-    mParametersInitialized = mGeorefTransformImplementation->updateParametersFromGcps( mapCoords, pixelCoordsCorrect );
-    pixelCoordsCorrect.clear();
+    QVector<QgsPointXY> pixelCoordsCorrect = mRasterChangeCoords.getPixelCoords( sourceCoordinates );
+    mParametersInitialized = mGeorefTransformImplementation->updateParametersFromGcps( sourceCoordinates, pixelCoordsCorrect, invertYAxis );
   }
   else
   {
-    mParametersInitialized = mGeorefTransformImplementation->updateParametersFromGcps( mapCoords, pixelCoords );
+    mParametersInitialized = mGeorefTransformImplementation->updateParametersFromGcps( sourceCoordinates, destinationCoordinates, invertYAxis );
   }
   return mParametersInitialized;
 }

--- a/src/app/georeferencer/qgsgeoreftransform.cpp
+++ b/src/app/georeferencer/qgsgeoreftransform.cpp
@@ -188,20 +188,11 @@ bool QgsGeorefTransform::getOriginScaleRotation( QgsPointXY &origin, double &sca
 
 bool QgsGeorefTransform::gdal_transform( const QgsPointXY &src, QgsPointXY &dst, int dstToSrc ) const
 {
-  GDALTransformerFunc t = GDALTransformer();
-  // Fail if no transformer function was returned
-  if ( !t )
-    return false;
-
   // Copy the source coordinate for inplace transform
   double x = src.x();
   double y = src.y();
-  double z = 0.0;
-  int success = 0;
 
-  // Call GDAL transform function
-  ( *t )( GDALTransformerArgs(), dstToSrc, 1,  &x, &y, &z, &success );
-  if ( !success )
+  if ( !QgsGcpTransformerInterface::transform( x, y, dstToSrc == 1 ) )
     return false;
 
   dst.setX( x );

--- a/src/app/georeferencer/qgsgeoreftransform.h
+++ b/src/app/georeferencer/qgsgeoreftransform.h
@@ -36,27 +36,15 @@
 class QgsGeorefTransform : public QgsGcpTransformerInterface
 {
   public:
-    // GCP based transform methods implemented by subclasses
-    enum TransformParametrisation
-    {
-      Linear,
-      Helmert,
-      PolynomialOrder1,
-      PolynomialOrder2,
-      PolynomialOrder3,
-      ThinPlateSpline,
-      Projective,
-      InvalidTransform = 65535
-    };
 
-    explicit QgsGeorefTransform( TransformParametrisation parametrisation );
+    explicit QgsGeorefTransform( TransformMethod parametrisation );
     QgsGeorefTransform();
     ~QgsGeorefTransform() override;
 
     /**
      * Switches the used transform type to the given parametrisation.
      */
-    void selectTransformParametrisation( TransformParametrisation parametrisation );
+    void selectTransformParametrisation( TransformMethod parametrisation );
 
     /**
      * Setting the mRasterChangeCoords for change type coordinate(map for pixel).
@@ -73,7 +61,7 @@ class QgsGeorefTransform : public QgsGcpTransformerInterface
     QgsRectangle getBoundingBox( const QgsRectangle &rect, bool toPixel ) { return mRasterChangeCoords.getBoundingBox( rect, toPixel ); }
 
     //! \brief The transform parametrisation currently in use.
-    TransformParametrisation transformParametrisation() const;
+    TransformMethod transformParametrisation() const;
 
     //! True for linear, Helmert, first order polynomial
     bool providesAccurateInverseTransformation() const;
@@ -83,16 +71,9 @@ class QgsGeorefTransform : public QgsGcpTransformerInterface
 
     bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords ) override;
     int minimumGcpCount() const override;
-
-    /**
-     * Returns function pointer to the GDALTransformer function.
-     *
-     * Used by the transform routines \ref transform, \ref transformRasterToWorld
-     * \ref transformWorldToRaster and by the GDAL warping code
-     * in \ref QgsImageWarper::warpFile.
-     */
-    GDALTransformerFunc  GDALTransformer()     const override;
-    void                *GDALTransformerArgs() const override;
+    TransformMethod method() const override;
+    GDALTransformerFunc GDALTransformer() const override;
+    void *GDALTransformerArgs() const override;
 
     /**
      * \brief Transform from pixel coordinates to georeferenced coordinates.
@@ -128,13 +109,13 @@ class QgsGeorefTransform : public QgsGcpTransformerInterface
     QgsGeorefTransform &operator= ( const QgsGeorefTransform & ) = delete;
 
     //! Factory function which creates an implementation for the given parametrisation.
-    static QgsGcpTransformerInterface *createImplementation( TransformParametrisation parametrisation );
+    static QgsGcpTransformerInterface *createImplementation( TransformMethod parametrisation );
 
     // convenience wrapper around GDALTransformerFunc
     bool gdal_transform( const QgsPointXY &src, QgsPointXY &dst, int dstToSrc ) const;
 
     QgsGcpTransformerInterface *mGeorefTransformImplementation = nullptr;
-    TransformParametrisation     mTransformParametrisation;
+    TransformMethod     mTransformParametrisation;
     bool                         mParametersInitialized;
     QgsRasterChangeCoords        mRasterChangeCoords;
 };

--- a/src/app/georeferencer/qgsgeoreftransform.h
+++ b/src/app/georeferencer/qgsgeoreftransform.h
@@ -108,16 +108,14 @@ class QgsGeorefTransform : public QgsGcpTransformerInterface
     QgsGeorefTransform( const QgsGeorefTransform &other );
     QgsGeorefTransform &operator= ( const QgsGeorefTransform & ) = delete;
 
-    //! Factory function which creates an implementation for the given parametrisation.
-    static QgsGcpTransformerInterface *createImplementation( TransformMethod parametrisation );
-
     // convenience wrapper around GDALTransformerFunc
     bool gdal_transform( const QgsPointXY &src, QgsPointXY &dst, int dstToSrc ) const;
 
-    QgsGcpTransformerInterface *mGeorefTransformImplementation = nullptr;
-    TransformMethod     mTransformParametrisation;
-    bool                         mParametersInitialized;
-    QgsRasterChangeCoords        mRasterChangeCoords;
+    std::unique_ptr< QgsGcpTransformerInterface > mGeorefTransformImplementation;
+
+    TransformMethod mTransformParametrisation = TransformMethod::InvalidTransform;
+    bool mParametersInitialized = false;
+    QgsRasterChangeCoords mRasterChangeCoords;
 };
 
 #endif //QGSGEOREFTRANSFORM_H

--- a/src/app/georeferencer/qgsgeoreftransform.h
+++ b/src/app/georeferencer/qgsgeoreftransform.h
@@ -70,7 +70,7 @@ class QgsGeorefTransform : public QgsGcpTransformerInterface
     bool parametersInitialized() const;
 
     QgsGcpTransformerInterface *clone() const override;
-    bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords ) override;
+    bool updateParametersFromGcps( const QVector<QgsPointXY> &sourceCoordinates, const QVector<QgsPointXY> &destinationCoordinates, bool invertYAxis = false ) override;
     int minimumGcpCount() const override;
     TransformMethod method() const override;
     GDALTransformerFunc GDALTransformer() const override;
@@ -112,8 +112,9 @@ class QgsGeorefTransform : public QgsGcpTransformerInterface
     // convenience wrapper around GDALTransformerFunc
     bool gdal_transform( const QgsPointXY &src, QgsPointXY &dst, int dstToSrc ) const;
 
-    QVector<QgsPointXY> mMapCoords;
-    QVector<QgsPointXY> mLayerCoords;
+    QVector<QgsPointXY> mSourceCoordinates;
+    QVector<QgsPointXY> mDestinationCoordinates;
+    bool mInvertYAxis = false;
 
     std::unique_ptr< QgsGcpTransformerInterface > mGeorefTransformImplementation;
 

--- a/src/app/georeferencer/qgsgeoreftransform.h
+++ b/src/app/georeferencer/qgsgeoreftransform.h
@@ -69,6 +69,7 @@ class QgsGeorefTransform : public QgsGcpTransformerInterface
     //! \returns whether the parameters of this transform have been initialized by \ref updateParametersFromGCPs
     bool parametersInitialized() const;
 
+    QgsGcpTransformerInterface *clone() const override;
     bool updateParametersFromGcps( const QVector<QgsPointXY> &mapCoords, const QVector<QgsPointXY> &pixelCoords ) override;
     int minimumGcpCount() const override;
     TransformMethod method() const override;
@@ -110,6 +111,9 @@ class QgsGeorefTransform : public QgsGcpTransformerInterface
 
     // convenience wrapper around GDALTransformerFunc
     bool gdal_transform( const QgsPointXY &src, QgsPointXY &dst, int dstToSrc ) const;
+
+    QVector<QgsPointXY> mMapCoords;
+    QVector<QgsPointXY> mLayerCoords;
 
     std::unique_ptr< QgsGcpTransformerInterface > mGeorefTransformImplementation;
 

--- a/src/app/georeferencer/qgstransformsettingsdialog.cpp
+++ b/src/app/georeferencer/qgstransformsettingsdialog.cpp
@@ -266,7 +266,7 @@ bool QgsTransformSettingsDialog::checkGCPpoints( int count, int &minGCPpoints )
 {
   QgsGeorefTransform georefTransform;
   georefTransform.selectTransformParametrisation( ( QgsGeorefTransform::TransformParametrisation )count );
-  minGCPpoints = georefTransform.getMinimumGCPCount();
+  minGCPpoints = georefTransform.minimumGcpCount();
   return ( mCountGCPpoints >= minGCPpoints );
 }
 

--- a/src/app/georeferencer/qgstransformsettingsdialog.cpp
+++ b/src/app/georeferencer/qgstransformsettingsdialog.cpp
@@ -82,13 +82,13 @@ QgsTransformSettingsDialog::QgsTransformSettingsDialog( const QString &raster, c
   connect( cmbTransformType, &QComboBox::currentTextChanged, this, &QgsTransformSettingsDialog::cmbTransformType_currentIndexChanged );
   connect( mWorldFileCheckBox, &QCheckBox::stateChanged, this, &QgsTransformSettingsDialog::mWorldFileCheckBox_stateChanged );
 
-  cmbTransformType->addItem( tr( "Linear" ), static_cast<int>( QgsGeorefTransform::Linear ) );
-  cmbTransformType->addItem( tr( "Helmert" ), static_cast<int>( QgsGeorefTransform::Helmert ) );
-  cmbTransformType->addItem( tr( "Polynomial 1" ), static_cast<int>( QgsGeorefTransform::PolynomialOrder1 ) );
-  cmbTransformType->addItem( tr( "Polynomial 2" ), static_cast<int>( QgsGeorefTransform::PolynomialOrder2 ) );
-  cmbTransformType->addItem( tr( "Polynomial 3" ), static_cast<int>( QgsGeorefTransform::PolynomialOrder3 ) );
-  cmbTransformType->addItem( tr( "Thin Plate Spline" ), static_cast<int>( QgsGeorefTransform::ThinPlateSpline ) );
-  cmbTransformType->addItem( tr( "Projective" ), static_cast<int>( QgsGeorefTransform::Projective ) );
+  cmbTransformType->addItem( tr( "Linear" ), static_cast<int>( QgsGcpTransformerInterface::TransformMethod::Linear ) );
+  cmbTransformType->addItem( tr( "Helmert" ), static_cast<int>( QgsGcpTransformerInterface::TransformMethod::Helmert ) );
+  cmbTransformType->addItem( tr( "Polynomial 1" ), static_cast<int>( QgsGcpTransformerInterface::TransformMethod::PolynomialOrder1 ) );
+  cmbTransformType->addItem( tr( "Polynomial 2" ), static_cast<int>( QgsGcpTransformerInterface::TransformMethod::PolynomialOrder2 ) );
+  cmbTransformType->addItem( tr( "Polynomial 3" ), static_cast<int>( QgsGcpTransformerInterface::TransformMethod::PolynomialOrder3 ) );
+  cmbTransformType->addItem( tr( "Thin Plate Spline" ), static_cast<int>( QgsGcpTransformerInterface::TransformMethod::ThinPlateSpline ) );
+  cmbTransformType->addItem( tr( "Projective" ), static_cast<int>( QgsGcpTransformerInterface::TransformMethod::Projective ) );
 
   // Populate CompressionComboBox
   mListCompression.append( QStringLiteral( "None" ) );
@@ -128,16 +128,16 @@ QgsTransformSettingsDialog::QgsTransformSettingsDialog( const QString &raster, c
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsTransformSettingsDialog::showHelp );
 }
 
-void QgsTransformSettingsDialog::getTransformSettings( QgsGeorefTransform::TransformParametrisation &tp,
+void QgsTransformSettingsDialog::getTransformSettings( QgsGeorefTransform::TransformMethod &tp,
     QgsImageWarper::ResamplingMethod &rm,
     QString &comprMethod, QString &raster,
     QgsCoordinateReferenceSystem &proj, QString &pdfMapFile, QString &pdfReportFile, QString &gcpPoints, bool &zt, bool &loadInQgis,
     double &resX, double &resY )
 {
   if ( cmbTransformType->currentIndex() == -1 )
-    tp = QgsGeorefTransform::InvalidTransform;
+    tp = QgsGcpTransformerInterface::TransformMethod::InvalidTransform;
   else
-    tp = ( QgsGeorefTransform::TransformParametrisation )cmbTransformType->currentData().toInt();
+    tp = static_cast< QgsGcpTransformerInterface::TransformMethod >( cmbTransformType->currentData().toInt() );
 
   rm = ( QgsImageWarper::ResamplingMethod )cmbResampling->currentIndex();
   comprMethod = mListCompression.at( cmbCompressionComboBox->currentIndex() ).toUpper();
@@ -265,7 +265,7 @@ void QgsTransformSettingsDialog::mWorldFileCheckBox_stateChanged( int state )
 bool QgsTransformSettingsDialog::checkGCPpoints( int count, int &minGCPpoints )
 {
   QgsGeorefTransform georefTransform;
-  georefTransform.selectTransformParametrisation( ( QgsGeorefTransform::TransformParametrisation )count );
+  georefTransform.selectTransformParametrisation( ( QgsGeorefTransform::TransformMethod )count );
   minGCPpoints = georefTransform.minimumGcpCount();
   return ( mCountGCPpoints >= minGCPpoints );
 }

--- a/src/app/georeferencer/qgstransformsettingsdialog.h
+++ b/src/app/georeferencer/qgstransformsettingsdialog.h
@@ -30,7 +30,7 @@ class QgsTransformSettingsDialog : public QDialog, private Ui::QgsTransformSetti
     QgsTransformSettingsDialog( const QString &raster, const QString &output,
                                 int countGCPpoints, QWidget *parent = nullptr );
 
-    void getTransformSettings( QgsGeorefTransform::TransformParametrisation &tp,
+    void getTransformSettings( QgsGeorefTransform::TransformMethod &tp,
                                QgsImageWarper::ResamplingMethod &rm, QString &comprMethod,
                                QString &raster, QgsCoordinateReferenceSystem &proj, QString &pdfMapFile, QString &pdfReportFile, QString &gcpPoints, bool &zt, bool &loadInQgis,
                                double &resX, double &resY );

--- a/tests/src/analysis/CMakeLists.txt
+++ b/tests/src/analysis/CMakeLists.txt
@@ -46,6 +46,7 @@ endmacro (ADD_QGIS_TEST)
 #############################################################
 # Tests:
 set(TESTS
+ testqgsgcptransformer.cpp
  testqgsgeometrysnapper.cpp
  testqgsinterpolator.cpp
  testqgsprocessing.cpp

--- a/tests/src/analysis/testqgsgcptransformer.cpp
+++ b/tests/src/analysis/testqgsgcptransformer.cpp
@@ -19,6 +19,8 @@
 #include "qgsapplication.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsrectangle.h"
+#include "qgsgcpgeometrytransformer.h"
+#include "qgsgeometry.h"
 
 #include <QDir>
 
@@ -1523,6 +1525,40 @@ class TestQgsGcpTransformer : public QObject
       QGSCOMPARENEAR( x, 321800, 1 );
       QGSCOMPARENEAR( y, 186514, 1 );
     }
+
+
+    // geometry transformer
+    void testGeometryTransfomer()
+    {
+      QgsGcpGeometryTransformer transformer( QgsGcpTransformerInterface::TransformMethod::Projective,
+                                             QVector< QgsPointXY >() << QgsPointXY( 288, 1126 )
+                                             << QgsPointXY( 2352, 716 )
+                                             << QgsPointXY( 2067, 2398 )
+                                             << QgsPointXY( 1102, 2209 ),
+                                             QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                             << QgsPointXY( 322698, 129979 )
+                                             << QgsPointXY( 322501, 192061 )
+                                             << QgsPointXY( 321803, 192198 ) );
+
+      QgsGeometry geom = QgsGeometry::fromWkt( QStringLiteral( "LineString(288 1000, 2352 1150, 2067 2500, 1102 2300)" ) );
+      bool ok = false;
+      QCOMPARE( transformer.transform( geom, ok ).asWkt( 0 ), QStringLiteral( "LineString (321256 123764, 322688 142909, 322495 197069, 321782 198051)" ) );
+      QVERIFY( ok );
+
+      // invalid parameters -- not enough GCPs
+      QgsGcpGeometryTransformer transformer2( QgsGcpTransformerInterface::TransformMethod::PolynomialOrder2,
+                                              QVector< QgsPointXY >() << QgsPointXY( 288, 1126 )
+                                              << QgsPointXY( 2352, 716 )
+                                              << QgsPointXY( 2067, 2398 )
+                                              << QgsPointXY( 1102, 2209 ),
+                                              QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                              << QgsPointXY( 322698, 129979 )
+                                              << QgsPointXY( 322501, 192061 )
+                                              << QgsPointXY( 321803, 192198 ) );
+      QCOMPARE( transformer2.transform( geom, ok ).asWkt( 0 ), QStringLiteral( "LineString (288 1000, 2352 1150, 2067 2500, 1102 2300)" ) );
+      QVERIFY( !ok );
+    }
+
 
 };
 

--- a/tests/src/analysis/testqgsgcptransformer.cpp
+++ b/tests/src/analysis/testqgsgcptransformer.cpp
@@ -1,0 +1,96 @@
+/***************************************************************************
+  testqgsgcptransformer.cpp
+  --------------------------------------
+  Date                 : February 2021
+  Copyright            : (C) 2021 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+
+#include "qgsgcptransformer.h"
+#include "qgsapplication.h"
+#include "qgscoordinatereferencesystem.h"
+#include "qgsrectangle.h"
+
+#include <QDir>
+
+#include <gdal.h>
+
+class TestQgsGcpTransformer : public QObject
+{
+    Q_OBJECT
+
+    QString SRC_FILE;
+  private slots:
+
+    void initTestCase()
+    {
+      GDALAllRegister();
+
+      SRC_FILE = QStringLiteral( TEST_DATA_DIR ) + "/float1-16.tif";
+
+      QgsApplication::init(); // needed for CRS database
+    }
+
+    void testLinear()
+    {
+      QgsLinearGeorefTransform transform;
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 129198 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 288, -716 )
+                                          << QgsPointXY( 2352, -1126 )
+                                          << QgsPointXY( 2067, -2398 )
+                                          << QgsPointXY( 1102, -2209 ) );
+
+      double x = 288;
+      double y = -71;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 108597, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 288, 1 );
+      QGSCOMPARENEAR( y, -71, 1 );
+
+      x = 2352;
+      y = -1126;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 133775, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2352, 1 );
+      QGSCOMPARENEAR( y, -1126, 1 );
+
+      x = 2067;
+      y = -2398;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 164131, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2067, 1 );
+      QGSCOMPARENEAR( y, -2398, 1 );
+
+      x = 1102;
+      y = -2209;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 159620, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 1102, 1 );
+      QGSCOMPARENEAR( y, -2209, 1 );
+    }
+
+};
+
+QGSTEST_MAIN( TestQgsGcpTransformer )
+
+#include "testqgsgcptransformer.moc"

--- a/tests/src/analysis/testqgsgcptransformer.cpp
+++ b/tests/src/analysis/testqgsgcptransformer.cpp
@@ -43,29 +43,78 @@ class TestQgsGcpTransformer : public QObject
     void testLinear()
     {
       QgsLinearGeorefTransform transform;
-      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 288, 1126 )
+                                          << QgsPointXY( 2352, 716 )
+                                          << QgsPointXY( 2067, 2398 )
+                                          << QgsPointXY( 1102, 2209 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
                                           << QgsPointXY( 322698, 129979 )
                                           << QgsPointXY( 322501, 192061 )
-                                          << QgsPointXY( 321803, 129198 ),
-                                          QVector< QgsPointXY >() << QgsPointXY( 288, -716 )
-                                          << QgsPointXY( 2352, -1126 )
-                                          << QgsPointXY( 2067, -2398 )
-                                          << QgsPointXY( 1102, -2209 ) );
+                                          << QgsPointXY( 321803, 192198 ) );
 
       double x = 288;
-      double y = -71;
+      double y = 1000;
       QVERIFY( transform.transform( x, y ) );
       QGSCOMPARENEAR( x, 321212, 1 );
-      QGSCOMPARENEAR( y, 108597, 1 );
+      QGSCOMPARENEAR( y, 135047, 1 );
       QVERIFY( transform.transform( x, y, true ) );
       QGSCOMPARENEAR( x, 288, 1 );
-      QGSCOMPARENEAR( y, -71, 1 );
+      QGSCOMPARENEAR( y, 1000, 1 );
+
+      x = 2352;
+      y = 1150;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 141437, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2352, 1 );
+      QGSCOMPARENEAR( y, 1150, 1 );
+
+      x = 2067;
+      y = 2500;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 198947, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2067, 1 );
+      QGSCOMPARENEAR( y, 2500, 1 );
+
+      x = 1102;
+      y = 2300;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 190427, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 1102, 1 );
+      QGSCOMPARENEAR( y, 2300, 1 );
+    }
+
+    void testLinearRasterYAxis()
+    {
+      QgsLinearGeorefTransform transform;
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 288, -716 )
+                                          << QgsPointXY( 2352, -1126 )
+                                          << QgsPointXY( 2067, -2398 )
+                                          << QgsPointXY( 1102, -2209 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ), true );
+
+      double x = 288;
+      double y = -716;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 288, 1 );
+      QGSCOMPARENEAR( y, -716, 1 );
 
       x = 2352;
       y = -1126;
       QVERIFY( transform.transform( x, y ) );
       QGSCOMPARENEAR( x, 322702, 1 );
-      QGSCOMPARENEAR( y, 133775, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
       QVERIFY( transform.transform( x, y, true ) );
       QGSCOMPARENEAR( x, 2352, 1 );
       QGSCOMPARENEAR( y, -1126, 1 );
@@ -74,7 +123,7 @@ class TestQgsGcpTransformer : public QObject
       y = -2398;
       QVERIFY( transform.transform( x, y ) );
       QGSCOMPARENEAR( x, 322496, 1 );
-      QGSCOMPARENEAR( y, 164131, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
       QVERIFY( transform.transform( x, y, true ) );
       QGSCOMPARENEAR( x, 2067, 1 );
       QGSCOMPARENEAR( y, -2398, 1 );
@@ -83,10 +132,1396 @@ class TestQgsGcpTransformer : public QObject
       y = -2209;
       QVERIFY( transform.transform( x, y ) );
       QGSCOMPARENEAR( x, 321800, 1 );
-      QGSCOMPARENEAR( y, 159620, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
       QVERIFY( transform.transform( x, y, true ) );
       QGSCOMPARENEAR( x, 1102, 1 );
       QGSCOMPARENEAR( y, -2209, 1 );
+    }
+
+    void testLinearExact()
+    {
+      QgsLinearGeorefTransform transform;
+      //this is a identity transform!
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ) );
+
+      double x = 321212;
+      double y = 123003;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+
+      x = 322702;
+      y = 140444;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+
+      x = 322496;
+      y = 194554;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+
+      x = 321800;
+      y = 186514;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+    }
+
+    void testLinearExactRasterYAxis()
+    {
+      QgsLinearGeorefTransform transform;
+      //this is a identity transform!
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ), true );
+
+      double x = 321212;
+      double y = 123003;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, -123003, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+
+      x = 322702;
+      y = 140444;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, -140444, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+
+      x = 322496;
+      y = 194554;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, -194554, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+
+      x = 321800;
+      y = 186514;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, -186514, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+    }
+
+
+    //
+    // Helmert
+    //
+
+    void testHelmert()
+    {
+      QgsHelmertGeorefTransform transform;
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 288, 1126 )
+                                          << QgsPointXY( 2352, 716 )
+                                          << QgsPointXY( 2067, 2398 )
+                                          << QgsPointXY( 1102, 2209 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ) );
+
+      double x = 288;
+      double y = 1000;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 302325, 1 );
+      QGSCOMPARENEAR( y, 145676, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 288, 1 );
+      QGSCOMPARENEAR( y, 1000, 1 );
+
+      x = 2352;
+      y = 1150;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 340495, 1 );
+      QGSCOMPARENEAR( y, 155540, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2352, 1 );
+      QGSCOMPARENEAR( y, 1150, 1 );
+
+      x = 2067;
+      y = 2500;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 330540, 1 );
+      QGSCOMPARENEAR( y, 179867, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2067, 1 );
+      QGSCOMPARENEAR( y, 2500, 1 );
+
+      x = 1102;
+      y = 2300;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 313138, 1 );
+      QGSCOMPARENEAR( y, 172822, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 1102, 1 );
+      QGSCOMPARENEAR( y, 2300, 1 );
+    }
+
+    void testHelmertRasterYAxis()
+    {
+      QgsHelmertGeorefTransform transform;
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 288, -716 )
+                                          << QgsPointXY( 2352, -1126 )
+                                          << QgsPointXY( 2067, -2398 )
+                                          << QgsPointXY( 1102, -2209 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ), true );
+
+      double x = 288;
+      double y = -716;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 334590, 1 );
+      QGSCOMPARENEAR( y, 115324, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 288, 1 );
+      QGSCOMPARENEAR( y, -716, 1 );
+
+      x = 2352;
+      y = -1126;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 296200, 1 );
+      QGSCOMPARENEAR( y, 115340, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2352, 1 );
+      QGSCOMPARENEAR( y, -1126, 1 );
+
+      x = 2067;
+      y = -2398;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 296768, 1 );
+      QGSCOMPARENEAR( y, 91566, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2067, 1 );
+      QGSCOMPARENEAR( y, -2398, 1 );
+
+      x = 1102;
+      y = -2209;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 314707, 1 );
+      QGSCOMPARENEAR( y, 91510, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 1102, 1 );
+      QGSCOMPARENEAR( y, -2209, 1 );
+    }
+
+    void testHelmertExact()
+    {
+      QgsHelmertGeorefTransform transform;
+      //this is a identity transform!
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ) );
+
+      double x = 321212;
+      double y = 123003;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+
+      x = 322702;
+      y = 140444;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+
+      x = 322496;
+      y = 194554;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+
+      x = 321800;
+      y = 186514;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+    }
+
+    void testHelmertExactRasterYAxis()
+    {
+      QgsHelmertGeorefTransform transform;
+      //this is a identity transform!
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ), true );
+
+      double x = 321212;
+      double y = 123003;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, -123003, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+
+      x = 322702;
+      y = 140444;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, -140444, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+
+      x = 322496;
+      y = 194554;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, -194554, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+
+      x = 321800;
+      y = 186514;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, -186514, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+    }
+
+
+
+    //
+    // Polynomial order 1
+    //
+
+    void testPolyOrder1()
+    {
+      QgsGDALGeorefTransform transform( false, 1 );
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 288, 1126 )
+                                          << QgsPointXY( 2352, 716 )
+                                          << QgsPointXY( 2067, 2398 )
+                                          << QgsPointXY( 1102, 2209 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ) );
+
+      double x = 288;
+      double y = 1000;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321209, 1 );
+      QGSCOMPARENEAR( y, 128732, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 288, 1 );
+      QGSCOMPARENEAR( y, 1017, 1 );
+
+      x = 2352;
+      y = 1150;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322700, 1 );
+      QGSCOMPARENEAR( y, 146403, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2352, 1 );
+      QGSCOMPARENEAR( y, 1164, 1 );
+
+      x = 2067;
+      y = 2500;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322501, 1 );
+      QGSCOMPARENEAR( y, 202230, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2067, 1 );
+      QGSCOMPARENEAR( y, 2474, 1 );
+
+      x = 1102;
+      y = 2300;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321803, 1 );
+      QGSCOMPARENEAR( y, 188448, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 1102, 1 );
+      QGSCOMPARENEAR( y, 2279, 1 );
+    }
+
+    void testPolyOrder1RasterYAxis()
+    {
+      QgsGDALGeorefTransform transform( false, 1 );
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 288, -716 )
+                                          << QgsPointXY( 2352, -1126 )
+                                          << QgsPointXY( 2067, -2398 )
+                                          << QgsPointXY( 1102, -2209 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ), true );
+
+      double x = 288;
+      double y = -716;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321201, 1 );
+      QGSCOMPARENEAR( y, 63463, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 288, 1 );
+      QGSCOMPARENEAR( y, -716, 1 );
+
+      x = 2352;
+      y = -1126;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322686, 1 );
+      QGSCOMPARENEAR( y, 24965, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2352, 1 );
+      QGSCOMPARENEAR( y, -1126, 1 );
+
+      x = 2067;
+      y = -2398;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322474, 1 );
+      QGSCOMPARENEAR( y, -31687, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2067, 1 );
+      QGSCOMPARENEAR( y, -2398, 1 );
+
+      x = 1102;
+      y = -2209;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321780, 1 );
+      QGSCOMPARENEAR( y, -13813, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 1102, 1 );
+      QGSCOMPARENEAR( y, -2209, 1 );
+    }
+
+    void testPolyOrder1Exact()
+    {
+      QgsGDALGeorefTransform transform( false, 1 );
+      //this is a identity transform!
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ) );
+
+      double x = 321212;
+      double y = 123003;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+
+      x = 322702;
+      y = 140444;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+
+      x = 322496;
+      y = 194554;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+
+      x = 321800;
+      y = 186514;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+    }
+
+    void testPolyOrder1ExactRasterYAxis()
+    {
+      QgsGDALGeorefTransform transform( false, 1 );
+      //this is a identity transform!
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ), true );
+
+      double x = 321212;
+      double y = 123003;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, -123003, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+
+      x = 322702;
+      y = 140444;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, -140444, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+
+      x = 322496;
+      y = 194554;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, -194554, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+
+      x = 321800;
+      y = 186514;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, -186514, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+    }
+
+
+    //
+    // Polynomial order 2
+    //
+
+    void testPolyOrder2()
+    {
+      QgsGDALGeorefTransform transform( false, 2 );
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 288, 1126 )
+                                          << QgsPointXY( 2352, 716 )
+                                          << QgsPointXY( 2067, 2398 )
+                                          << QgsPointXY( 2100, 1500 )
+                                          << QgsPointXY( 1102, 2209 )
+                                          << QgsPointXY( 300, 1550 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 322550, 149979 )
+                                          << QgsPointXY( 321803, 192198 )
+                                          << QgsPointXY( 321310, 145979 ) );
+
+      double x = 288;
+      double y = 1000;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321175, 1 );
+      QGSCOMPARENEAR( y, 126837, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 265, 1 );
+      QGSCOMPARENEAR( y, 1025, 1 );
+
+      x = 2352;
+      y = 1150;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322763, 1 );
+      QGSCOMPARENEAR( y, 135026, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2336, 1 );
+      QGSCOMPARENEAR( y, 936, 1 );
+
+      x = 2067;
+      y = 2500;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322489, 1 );
+      QGSCOMPARENEAR( y, 198409, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2097, 1 );
+      QGSCOMPARENEAR( y, 2445, 1 );
+
+      x = 1102;
+      y = 2300;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321803, 1 );
+      QGSCOMPARENEAR( y, 197778, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 1123, 1 );
+      QGSCOMPARENEAR( y, 2225, 1 );
+    }
+
+    void testPolyOrder2RasterYAxis()
+    {
+      QgsGDALGeorefTransform transform( false, 2 );
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 288, -1126 )
+                                          << QgsPointXY( 2352, -716 )
+                                          << QgsPointXY( 2067, -2398 )
+                                          << QgsPointXY( 2100, -1500 )
+                                          << QgsPointXY( 1102, -2209 )
+                                          << QgsPointXY( 300, -1550 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 322550, 149979 )
+                                          << QgsPointXY( 321803, 192198 )
+                                          << QgsPointXY( 321310, 145979 ), true );
+
+      double x = 288;
+      double y = -716;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 320404, 1 );
+      QGSCOMPARENEAR( y, 131061, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, -1913, 1 );
+      QGSCOMPARENEAR( y, 1625, 1 );
+
+      x = 2352;
+      y = -1126;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322022, 1 );
+      QGSCOMPARENEAR( y, 176342, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 1435, 1 );
+      QGSCOMPARENEAR( y, 2087, 1 );
+
+      x = 2067;
+      y = -2398;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 320831, 1 );
+      QGSCOMPARENEAR( y, 273376, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, -310, 1 );
+      QGSCOMPARENEAR( y, 134, 1 );
+
+      x = 1102;
+      y = -2209;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 319958, 1 );
+      QGSCOMPARENEAR( y, 243375, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, -3994, 1 );
+      QGSCOMPARENEAR( y, 1158, 1 );
+    }
+
+    void testPolyOrder2Exact()
+    {
+      QgsGDALGeorefTransform transform( false, 2 );
+      //this is a identity transform!
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 322501, 152061 )
+                                          << QgsPointXY( 321803, 192198 )
+                                          << QgsPointXY( 321210, 152061 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 322501, 152061 )
+                                          << QgsPointXY( 321803, 192198 )
+                                          << QgsPointXY( 321210, 152061 ) );
+
+      double x = 321212;
+      double y = 123003;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+
+      x = 322702;
+      y = 140444;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+
+      x = 322496;
+      y = 194554;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+
+      x = 321800;
+      y = 186514;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+    }
+
+    void testPolyOrder2ExactRasterYAxis()
+    {
+      QgsGDALGeorefTransform transform( false, 2 );
+      //this is a identity transform!
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 322501, 152061 )
+                                          << QgsPointXY( 321803, 192198 )
+                                          << QgsPointXY( 321210, 152061 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 322501, 152061 )
+                                          << QgsPointXY( 321803, 192198 )
+                                          << QgsPointXY( 321210, 152061 ), true );
+
+      double x = 321212;
+      double y = 123003;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, -123003, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+
+      x = 322702;
+      y = 140444;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, -140444, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+
+      x = 322496;
+      y = 194554;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, -194554, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+
+      x = 321800;
+      y = 186514;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, -186514, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+    }
+
+
+    //
+    // Polynomial order 3
+    //
+
+    void testPolyOrder3()
+    {
+      QgsGDALGeorefTransform transform( false, 3 );
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 288, 1126 )
+                                          << QgsPointXY( 2352, 716 )
+                                          << QgsPointXY( 2067, 2398 )
+                                          << QgsPointXY( 2100, 1500 )
+                                          << QgsPointXY( 1102, 2209 )
+                                          << QgsPointXY( 300, 1550 )
+                                          << QgsPointXY( 300, 850 )
+                                          << QgsPointXY( 1000, 830 )
+                                          << QgsPointXY( 900, 1450 )
+                                          << QgsPointXY( 700, 1550 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 322550, 149979 )
+                                          << QgsPointXY( 321803, 192198 )
+                                          << QgsPointXY( 321310, 145979 )
+                                          << QgsPointXY( 321310, 131979 )
+                                          << QgsPointXY( 321703, 131579 )
+                                          << QgsPointXY( 321603, 145979 )
+                                          << QgsPointXY( 321003, 146179 )
+                                        );
+
+      double x = 288;
+      double y = 1000;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321202, 1 );
+      QGSCOMPARENEAR( y, 129364, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 237, 1 );
+      QGSCOMPARENEAR( y, 1319, 1 );
+
+      x = 2352;
+      y = 1150;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 318595, 1 );
+      QGSCOMPARENEAR( y, 101765, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 138412, 1 );
+      QGSCOMPARENEAR( y, 15444, 1 );
+
+      x = 2067;
+      y = 2500;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321488, 1 );
+      QGSCOMPARENEAR( y, 185766, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, -1237, 1 );
+      QGSCOMPARENEAR( y, 5315, 1 );
+
+      x = 1102;
+      y = 2300;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 320879, 1 );
+      QGSCOMPARENEAR( y, 189391, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, -4000, 1 );
+      QGSCOMPARENEAR( y, 2621, 1 );
+    }
+
+    void testPolyOrder3RasterYAxis()
+    {
+      QgsGDALGeorefTransform transform( false, 3 );
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 288, -1126 )
+                                          << QgsPointXY( 2352, -716 )
+                                          << QgsPointXY( 2067, -2398 )
+                                          << QgsPointXY( 2100, -1500 )
+                                          << QgsPointXY( 1102, -2209 )
+                                          << QgsPointXY( 300, -1550 )
+                                          << QgsPointXY( 300, -850 )
+                                          << QgsPointXY( 1000, -830 )
+                                          << QgsPointXY( 900, -1450 )
+                                          << QgsPointXY( 700, -1550 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 322550, 149979 )
+                                          << QgsPointXY( 321803, 192198 )
+                                          << QgsPointXY( 321310, 145979 )
+                                          << QgsPointXY( 321310, 131979 )
+                                          << QgsPointXY( 321703, 131579 )
+                                          << QgsPointXY( 321603, 145979 )
+                                          << QgsPointXY( 321003, 146179 ), true );
+
+      // these values look like nonsense... I can't verify them, except to say that at the time
+      // these tests were written the raster georeferencer worked correctly with polynomial order 3, so I can
+      // only assume they are correct...!
+      double x = 288;
+      double y = -716;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 368688, 1 );
+      QGSCOMPARENEAR( y, 828425, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, -476460174, 1 );
+      QGSCOMPARENEAR( y, -43384555, 1 );
+
+      x = 2352;
+      y = -1126;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 456596, 1 );
+      QGSCOMPARENEAR( y, 1609794, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, -11099349683, 1 );
+      QGSCOMPARENEAR( y, -130456708, 1 );
+
+      x = 2067;
+      y = -2398;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 731809, 1 );
+      QGSCOMPARENEAR( y, 4861338, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, -313632670265, 1 );
+      QGSCOMPARENEAR( y, -7338651765, 1 );
+
+      x = 1102;
+      y = -2209;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 620013, 1 );
+      QGSCOMPARENEAR( y, 3875762, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, -121400397631, 1 );
+      QGSCOMPARENEAR( y, -5274501643, 1 );
+    }
+
+    void testPolyOrder3Exact()
+    {
+      QgsGDALGeorefTransform transform( false, 3 );
+      //this is a identity transform!
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 322501, 152061 )
+                                          << QgsPointXY( 321803, 192198 )
+                                          << QgsPointXY( 321210, 152061 )
+                                          << QgsPointXY( 322010, 182061 )
+                                          << QgsPointXY( 322010, 132061 )
+                                          << QgsPointXY( 321050, 162061 )
+                                          << QgsPointXY( 321050, 172061 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 322501, 152061 )
+                                          << QgsPointXY( 321803, 192198 )
+                                          << QgsPointXY( 321210, 152061 )
+                                          << QgsPointXY( 322010, 182061 )
+                                          << QgsPointXY( 322010, 132061 )
+                                          << QgsPointXY( 321050, 162061 )
+                                          << QgsPointXY( 321050, 172061 ) );
+
+      double x = 321212;
+      double y = 123003;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+
+      x = 322702;
+      y = 140444;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+
+      x = 322496;
+      y = 194554;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+
+      x = 321800;
+      y = 186514;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+    }
+
+    void testPolyOrder3ExactRasterYAxis()
+    {
+      QgsGDALGeorefTransform transform( false, 3 );
+      //this is a identity transform!
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 322501, 152061 )
+                                          << QgsPointXY( 321803, 192198 )
+                                          << QgsPointXY( 321210, 152061 )
+                                          << QgsPointXY( 322010, 182061 )
+                                          << QgsPointXY( 322010, 132061 )
+                                          << QgsPointXY( 321050, 162061 )
+                                          << QgsPointXY( 321050, 172061 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 322501, 152061 )
+                                          << QgsPointXY( 321803, 192198 )
+                                          << QgsPointXY( 321210, 152061 )
+                                          << QgsPointXY( 322010, 182061 )
+                                          << QgsPointXY( 322010, 132061 )
+                                          << QgsPointXY( 321050, 162061 )
+                                          << QgsPointXY( 321050, 172061 ), true );
+
+      double x = 321212;
+      double y = 123003;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, -123003, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+
+      x = 322702;
+      y = 140444;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, -140444, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+
+      x = 322496;
+      y = 194554;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, -194554, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+
+      x = 321800;
+      y = 186514;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, -186514, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+    }
+
+
+    //
+    // Thin plate spline
+    //
+
+    void testTPSReports()
+    {
+      QgsGDALGeorefTransform transform( true, 1 );
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 288, 1126 )
+                                          << QgsPointXY( 2352, 716 )
+                                          << QgsPointXY( 2067, 2398 )
+                                          << QgsPointXY( 1102, 2209 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ) );
+
+      double x = 288;
+      double y = 1000;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321209, 1 );
+      QGSCOMPARENEAR( y, 124248, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 290, 1 );
+      QGSCOMPARENEAR( y, 680, 1 );
+
+      x = 2352;
+      y = 1150;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322700, 1 );
+      QGSCOMPARENEAR( y, 146609, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2347, 1 );
+      QGSCOMPARENEAR( y, 1636, 1 );
+
+      x = 2067;
+      y = 2500;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322501, 1 );
+      QGSCOMPARENEAR( y, 196160, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2068, 1 );
+      QGSCOMPARENEAR( y, 2273, 1 );
+
+      x = 1102;
+      y = 2300;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321803, 1 );
+      QGSCOMPARENEAR( y, 195999, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 1103, 1 );
+      QGSCOMPARENEAR( y, 2177, 1 );
+    }
+
+    void testTPSRasterYAxis()
+    {
+      QgsGDALGeorefTransform transform( true, 1 );
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 288, -716 )
+                                          << QgsPointXY( 2352, -1126 )
+                                          << QgsPointXY( 2067, -2398 )
+                                          << QgsPointXY( 1102, -2209 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ), true );
+
+      double x = 288;
+      double y = -716;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321202, 1 );
+      QGSCOMPARENEAR( y, 63505, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 297, 1 );
+      QGSCOMPARENEAR( y, -705, 1 );
+
+      x = 2352;
+      y = -1126;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322686, 1 );
+      QGSCOMPARENEAR( y, 24959, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2361, 1 );
+      QGSCOMPARENEAR( y, -1116, 1 );
+
+      x = 2067;
+      y = -2398;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322474, 1 );
+      QGSCOMPARENEAR( y, -31676, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2078, 1 );
+      QGSCOMPARENEAR( y, -2385, 1 );
+
+      x = 1102;
+      y = -2209;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321780, 1 );
+      QGSCOMPARENEAR( y, -13787, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 1114, 1 );
+      QGSCOMPARENEAR( y, -2195, 1 );
+    }
+
+    void testTPSExact()
+    {
+      QgsGDALGeorefTransform transform( true, 1 );
+      //this is a identity transform!
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ) );
+
+      double x = 321212;
+      double y = 123003;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+
+      x = 322702;
+      y = 140444;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+
+      x = 322496;
+      y = 194554;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+
+      x = 321800;
+      y = 186514;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+    }
+
+    void testTPSExactRasterYAxis()
+    {
+      QgsGDALGeorefTransform transform( true, 1 );
+      //this is a identity transform!
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ), true );
+
+      double x = 321212;
+      double y = 123003;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, -123003, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+
+      x = 322702;
+      y = 140444;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, -140444, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+
+      x = 322496;
+      y = 194554;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, -194554, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+
+      x = 321800;
+      y = 186514;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, -186514, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+    }
+
+    //
+    // Projective
+    //
+
+    void testProjective()
+    {
+      QgsProjectiveGeorefTransform transform;
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 288, 1126 )
+                                          << QgsPointXY( 2352, 716 )
+                                          << QgsPointXY( 2067, 2398 )
+                                          << QgsPointXY( 1102, 2209 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ) );
+
+      double x = 288;
+      double y = 1000;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321256, 1 );
+      QGSCOMPARENEAR( y, 123764, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 288, 1 );
+      QGSCOMPARENEAR( y, 1000, 1 );
+
+      x = 2352;
+      y = 1150;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322687, 1 );
+      QGSCOMPARENEAR( y, 142908, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2352, 1 );
+      QGSCOMPARENEAR( y, 1150, 1 );
+
+      x = 2067;
+      y = 2500;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322494, 1 );
+      QGSCOMPARENEAR( y, 197069, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2067, 1 );
+      QGSCOMPARENEAR( y, 2500, 1 );
+
+      x = 1102;
+      y = 2300;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321781, 1 );
+      QGSCOMPARENEAR( y, 198051, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 1102, 1 );
+      QGSCOMPARENEAR( y, 2300, 1 );
+    }
+
+    void testProjectiveRasterYAxis()
+    {
+      QgsProjectiveGeorefTransform transform;
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 288, -716 )
+                                          << QgsPointXY( 2352, -1126 )
+                                          << QgsPointXY( 2067, -2398 )
+                                          << QgsPointXY( 1102, -2209 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ), true );
+
+      double x = 288;
+      double y = -716;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321203, 1 );
+      QGSCOMPARENEAR( y, 63965, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 288, 1 );
+      QGSCOMPARENEAR( y, -716, 1 );
+
+      x = 2352;
+      y = -1126;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322681, 1 );
+      QGSCOMPARENEAR( y, 25366, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2352, 1 );
+      QGSCOMPARENEAR( y, -1126, 1 );
+
+      x = 2067;
+      y = -2398;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322467, 1 );
+      QGSCOMPARENEAR( y, -30635, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 2067, 1 );
+      QGSCOMPARENEAR( y, -2398, 1 );
+
+      x = 1102;
+      y = -2209;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321777, 1 );
+      QGSCOMPARENEAR( y, -12647, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 1102, 1 );
+      QGSCOMPARENEAR( y, -2209, 1 );
+    }
+
+    void testProjectiveExact()
+    {
+      QgsProjectiveGeorefTransform transform;
+      //this is a identity transform!
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ) );
+
+      double x = 321212;
+      double y = 123003;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+
+      x = 322702;
+      y = 140444;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+
+      x = 322496;
+      y = 194554;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+
+      x = 321800;
+      y = 186514;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
+    }
+
+    void testProjectiveExactRasterYAxis()
+    {
+      QgsProjectiveGeorefTransform transform;
+      //this is a identity transform!
+      transform.updateParametersFromGcps( QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ),
+                                          QVector< QgsPointXY >() << QgsPointXY( 321210, 130280 )
+                                          << QgsPointXY( 322698, 129979 )
+                                          << QgsPointXY( 322501, 192061 )
+                                          << QgsPointXY( 321803, 192198 ), true );
+
+      double x = 321212;
+      double y = 123003;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, -123003, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321212, 1 );
+      QGSCOMPARENEAR( y, 123003, 1 );
+
+      x = 322702;
+      y = 140444;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, -140444, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322702, 1 );
+      QGSCOMPARENEAR( y, 140444, 1 );
+
+      x = 322496;
+      y = 194554;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, -194554, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 322496, 1 );
+      QGSCOMPARENEAR( y, 194554, 1 );
+
+      x = 321800;
+      y = 186514;
+      QVERIFY( transform.transform( x, y ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, -186514, 1 );
+      QVERIFY( transform.transform( x, y, true ) );
+      QGSCOMPARENEAR( x, 321800, 1 );
+      QGSCOMPARENEAR( y, 186514, 1 );
     }
 
 };

--- a/tests/src/analysis/testqgsgcptransformer.cpp
+++ b/tests/src/analysis/testqgsgcptransformer.cpp
@@ -1528,7 +1528,7 @@ class TestQgsGcpTransformer : public QObject
 
 
     // geometry transformer
-    void testGeometryTransfomer()
+    void testGeometryTransformer()
     {
       QgsGcpGeometryTransformer transformer( QgsGcpTransformerInterface::TransformMethod::Projective,
                                              QVector< QgsPointXY >() << QgsPointXY( 288, 1126 )


### PR DESCRIPTION
And clean these up so that they are fit for inclusion in the stable public API.

This is the first step to exposing these useful transformations to different parts of QGIS for reuse, eg. for vector layer georeferencing (see https://github.com/qgis/QGIS/pull/41386), potential future processing algorithms, etc. (I've also done this refactoring with potential for moving the raster georefencing op to a background task in future!)

Also makes these transformations available for Python plugins and scripts to utilise.

~~Before merge I'd like to extend the tests and ensure that all transformation methods are covered by some form of tests.~~ Done!

Refs Natural resources Canada Contract: 3000720411