### PR TITLE
Auto comment and close issues when needed using GH Actions

### DIFF
--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -1,0 +1,16 @@
+comment:
+  header: Hi, there.
+  footer: Thanks
+
+labels:
+  - name: "Won't fix"
+    labeled:
+      issue:
+        body: >
+          Please read the provided text when opening the issue.
+
+          A issue related to a QGIS plugin can't be fixed by QGIS itself, but only by the plugin author.
+          Please report the issue to the plugin issue tracker.
+
+          For any questions, please use dedicated tools such as gis.stackexchange.com or mailing lists.
+        action: close

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -1,0 +1,18 @@
+name: Label Commenter
+
+on:
+  issues:
+    types:
+      - labeled
+      - unlabeled
+
+jobs:
+  comment:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: master # Set your default branch
+
+      - name: Label Commenter
+        uses: peaceiris/actions-label-commenter@v1


### PR DESCRIPTION
## Description

Trying this GH Actions : https://github.com/marketplace/actions/auto-close-issues

For now `Won't fix` will trigger the auto comment and auto close of the ticket.

@gioman @roya0045 @m-kuhn  What do you think ? 

If we want to go this way, we can add two specific labels for plugins and questions, so we can make a specific comment for each explaining the reasons ?

We can also review the template...

Just thinking,
@gioman For crash report, we could add a specific label so we can add a specific comment (and not close the issue) like
```
Please check the list below : 
* [ ] I have included dataset if needed
* [ ] I have included detailed steps to reproduce the bug
* [ ] I have download the latest QGIS version according to the roadmap
```

I'm personally not a big fan of these automated answers, but somehow, our manpower is also limited, often answering the same kind of requests, especially you @gioman ;-)