### PR TITLE
Update layer variables for expression builder

### DIFF
--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -286,9 +286,16 @@ void QgsExpressionBuilderWidget::setLayer( QgsVectorLayer *layer )
   if ( mLayer )
   {
     mExpressionContext << QgsExpressionContextUtils::layerScope( mLayer );
-
+    expressionContextUpdated();
     txtExpressionString->setFields( mLayer->fields() );
   }
+}
+
+void QgsExpressionBuilderWidget::expressionContextUpdated()
+{
+  txtExpressionString->setExpressionContext( mExpressionContext );
+  mExpressionTreeView->setExpressionContext( mExpressionContext );
+  mExpressionPreviewWidget->setExpressionContext( mExpressionContext );
 }
 
 QgsVectorLayer *QgsExpressionBuilderWidget::layer() const
@@ -627,9 +634,7 @@ void QgsExpressionBuilderWidget::setExpectedOutputFormat( const QString &expecte
 void QgsExpressionBuilderWidget::setExpressionContext( const QgsExpressionContext &context )
 {
   mExpressionContext = context;
-  txtExpressionString->setExpressionContext( mExpressionContext );
-  mExpressionTreeView->setExpressionContext( context );
-  mExpressionPreviewWidget->setExpressionContext( context );
+  expressionContextUpdated();
 }
 
 void QgsExpressionBuilderWidget::txtExpressionString_textChanged()

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -417,6 +417,9 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     QString loadFunctionHelp( QgsExpressionItem *functionName );
     QString helpStylesheet() const;
 
+    // To be called whenever expression context has been updated
+    void expressionContextUpdated();
+
     // Will hold items with
     // * a display string that matches the represented field values
     // * custom data in Qt::UserRole + 1 that contains a ready to use expression literal ('quoted string' or NULL or a plain number )

--- a/tests/src/python/test_qgsexpressionbuilderwidget.py
+++ b/tests/src/python/test_qgsexpressionbuilderwidget.py
@@ -212,6 +212,8 @@ class TestQgsExpressionBuilderWidget(unittest.TestCase):
         items = m.findItems("layer_name", Qt.MatchRecursive)
         self.assertEqual(len(items), 1)
 
+        p.removeMapLayer(layer)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsexpressionbuilderwidget.py
+++ b/tests/src/python/test_qgsexpressionbuilderwidget.py
@@ -194,6 +194,24 @@ class TestQgsExpressionBuilderWidget(unittest.TestCase):
         items = w.findExpressions('Stored Expression Number One')
         self.assertEqual(len(items), 0)
 
+    def testLayerVariables(self):
+        """ check through widget model to ensure it is populated with layer variables """
+        w = QgsExpressionBuilderWidget()
+        m = w.model()
+
+        p = QgsProject.instance()
+        layer = QgsVectorLayer("Point", "layer1", "memory")
+        p.addMapLayers([layer])
+
+        w.setLayer(layer)
+
+        items = m.findItems("layer", Qt.MatchRecursive)
+        self.assertEqual(len(items), 1)
+        items = m.findItems("layer_id", Qt.MatchRecursive)
+        self.assertEqual(len(items), 1)
+        items = m.findItems("layer_name", Qt.MatchRecursive)
+        self.assertEqual(len(items), 1)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #40255 : When setting layer for expression builder, we need to update widgets accordingly. 
