### PR TITLE
Make FindBestFrameNumberForFramestart a lot faster

### DIFF
--- a/python/core/auto_generated/qgstemporalnavigationobject.sip.in
+++ b/python/core/auto_generated/qgstemporalnavigationobject.sip.in
@@ -188,7 +188,7 @@ Sets whether the animation should ``loop`` after hitting the end or start frame.
 .. seealso:: :py:func:`isLooping`
 %End
 
-    long findBestFrameNumberForFrameStart( const QDateTime &frameStart ) const;
+    long long findBestFrameNumberForFrameStart( const QDateTime &frameStart ) const;
 %Docstring
 Returns the best suited frame number for the specified datetime, based on the start of the corresponding temporal range.
 %End

--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -317,9 +317,11 @@ long long QgsTemporalNavigationObject::findBestFrameNumberForFrameStart( const Q
   long long bestFrame = 0;
   QgsDateTimeRange testFrame = QgsDateTimeRange( frameStart, frameStart ); // creating an 'instant' Range here
   // earlier we looped from frame 0 till totalFrameCount() here, but this loop grew gigantic if you switched to for example milliseconds
-  // that is why now we calculate a rough framestart here
+  // that is why now we calculate a rough framestart here, by taking the old frameStart and calculate a rough frameNumber here:
+  // because of the 'fluidity' of the DateTime units (notable months and years), there seems to be a theoretical chance
+  // to overshoot. So in that case fail and return to startFrame (so max number of loops is just 10)
   long long roughFrameStart = std::floor( ( frameStart - mTemporalExtents.begin() ).seconds() / mFrameDuration.seconds() );
-  for ( long long i = roughFrameStart; i < totalFrameCount(); ++i )
+  for ( long long i = roughFrameStart; i < roughFrameStart + 10; ++i )
   {
     QgsDateTimeRange range = dateTimeRangeForFrameNumber( i );
     if ( range.overlaps( testFrame ) )

--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -319,7 +319,7 @@ long long QgsTemporalNavigationObject::findBestFrameNumberForFrameStart( const Q
   long long roughFrameEnd = totalFrameCount();
   // For the smaller step frames we calculate an educated guess, to prevent the loop becoming too
   // large, freezing the ui (eg having a mTemporalExtents of several months and the user selects milliseconds)
-  if ( mFrameDuration.seconds() < QgsInterval::MONTHS )
+  if ( mFrameDuration.originalUnit() != QgsUnitTypes::TemporalMonths && mFrameDuration.originalUnit() != QgsUnitTypes::TemporalYears && mFrameDuration.originalUnit() != QgsUnitTypes::TemporalDecades && mFrameDuration.originalUnit() != QgsUnitTypes::TemporalCenturies )
   {
     // Only if we receive a valid frameStart, that is within current mTemporalExtents
     // We tend to receive a framestart of 'now()' upon startup for example

--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -321,7 +321,7 @@ long long QgsTemporalNavigationObject::findBestFrameNumberForFrameStart( const Q
   // because of the 'fluidity' of the DateTime units (notable months and years), there seems to be a theoretical chance
   // to overshoot. So in that case fail and return to startFrame (so max number of loops is just 10)
   long long roughFrameStart = std::floor( ( frameStart - mTemporalExtents.begin() ).seconds() / mFrameDuration.seconds() );
-  for ( long long i = roughFrameStart; i < roughFrameStart + 10; ++i )
+  for ( long long i = roughFrameStart; i < roughFrameStart + 100; ++i )
   {
     QgsDateTimeRange range = dateTimeRangeForFrameNumber( i );
     if ( range.overlaps( testFrame ) )

--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -312,11 +312,14 @@ QgsTemporalNavigationObject::AnimationState QgsTemporalNavigationObject::animati
   return mPlayBackMode;
 }
 
-long QgsTemporalNavigationObject::findBestFrameNumberForFrameStart( const QDateTime &frameStart ) const
+long long QgsTemporalNavigationObject::findBestFrameNumberForFrameStart( const QDateTime &frameStart ) const
 {
-  long bestFrame = 0;
-  QgsDateTimeRange testFrame = QgsDateTimeRange( frameStart, frameStart ); // creatng an 'instant' Range here
-  for ( long i = 0; i < totalFrameCount(); ++i )
+  long long bestFrame = 0;
+  QgsDateTimeRange testFrame = QgsDateTimeRange( frameStart, frameStart ); // creating an 'instant' Range here
+  // earlier we looped from frame 0 till totalFrameCount() here, but this loop grew gigantic if you switched to for example milliseconds
+  // that is why now we calculate a rough framestart here
+  long long roughFrameStart = std::floor( ( frameStart - mTemporalExtents.begin() ).seconds() / mFrameDuration.seconds() );
+  for ( long long i = roughFrameStart; i < totalFrameCount(); ++i )
   {
     QgsDateTimeRange range = dateTimeRangeForFrameNumber( i );
     if ( range.overlaps( testFrame ) )

--- a/src/core/qgstemporalnavigationobject.h
+++ b/src/core/qgstemporalnavigationobject.h
@@ -206,7 +206,7 @@ class CORE_EXPORT QgsTemporalNavigationObject : public QgsTemporalController, pu
     /**
      * Returns the best suited frame number for the specified datetime, based on the start of the corresponding temporal range.
      */
-    long findBestFrameNumberForFrameStart( const QDateTime &frameStart ) const;
+    long long findBestFrameNumberForFrameStart( const QDateTime &frameStart ) const;
 
     QgsExpressionContextScope *createExpressionContextScope() const override SIP_FACTORY;
 

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -301,6 +301,7 @@ void QgsTemporalControllerWidget::updateFrameDuration()
     mSlider->setValue( mNavigationObject->currentFrameNumber() );
   }
   mSlider->setRange( 0, mNavigationObject->totalFrameCount() - 1 );
+  mSlider->setValue( mNavigationObject->currentFrameNumber() );
 }
 
 void QgsTemporalControllerWidget::setWidgetStateFromProject()


### PR DESCRIPTION
This fixes #40786 in which the logic to find a new frame number based on an earlier frame was not very efficient, by NOT starting at frame zero and go up, but first do a calculated guess and start from there.

This also fixed the return type, as 'mCurrentFrameNumber' is of type 'long long', so should findBestFrameNumberForFrameStart.

@Samweli what do you think?