### PR TITLE
Add message for overlap maptool

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1921,7 +1921,8 @@ Modifies geometry to avoid intersections with the layers specified in project pr
 :return: 0 in case of success,
          1 if geometry is not of polygon type,
          2 if avoid intersection would change the geometry type,
-         3 other error during intersection removal
+         3 other error during intersection removal,
+         4 in case of success but at least one geometry intersected was invalid and fixed to perform the operation
 
 .. versionadded:: 1.5
 %End

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1921,8 +1921,7 @@ Modifies geometry to avoid intersections with the layers specified in project pr
 :return: 0 in case of success,
          1 if geometry is not of polygon type,
          2 if avoid intersection would change the geometry type,
-         3 other error during intersection removal,
-         4 in case of success but at least one geometry intersected was invalid and fixed to perform the operation
+         3 at least one geometry intersected is invalid. The algorithm may not work and return the same geometry as the input. You must fix your intersecting geometries.
 
 .. versionadded:: 1.5
 %End

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -1322,7 +1322,7 @@ void QgsGpsInformationWidget::mBtnCloseFeature_clicked()
         }
         else if ( avoidIntersectionsReturn == 3 )
         {
-          QgisApp::instance()->messageBar()->pushCritical( tr( "Add Feature" ), tr( "The feature has been added, but at least one geometry intersected is invalid. You should fix geometries." ) );
+          QgisApp::instance()->messageBar()->pushCritical( tr( "Add Feature" ), tr( "The feature has been added, but at least one geometry intersected is invalid. These geometries must be manually repaired." ) );
           connectGpsSlot();
           return;
         }

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -1322,7 +1322,7 @@ void QgsGpsInformationWidget::mBtnCloseFeature_clicked()
         }
         else if ( avoidIntersectionsReturn == 3 )
         {
-          QgisApp::instance()->messageBar()->pushCritical( tr( "Add Feature" ), tr( "An error was reported during intersection removal." ) );
+          QgisApp::instance()->messageBar()->pushCritical( tr( "Add Feature" ), tr( "The feature has been added, but at least one geometry intersected is invalid. You should fix geometries." ) );
           connectGpsSlot();
           return;
         }

--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -175,9 +175,11 @@ void QgsMapToolReshape::reshape( QgsVectorLayer *vlayer )
             case QgsProject::AvoidIntersectionsMode::AllowIntersections:
               break;
           }
+          int res = -1;
           if ( avoidIntersectionsLayers.size() > 0 )
           {
-            if ( geom.avoidIntersections( QgsProject::instance()->avoidIntersectionsLayers(), ignoreFeatures ) != 0 )
+            res = geom.avoidIntersections( QgsProject::instance()->avoidIntersectionsLayers(), ignoreFeatures );
+            if ( res == 1 || res == 3 )
             {
               emit messageEmitted( tr( "An error was reported during intersection removal" ), Qgis::Critical );
               vlayer->destroyEditCommand();
@@ -191,6 +193,10 @@ void QgsMapToolReshape::reshape( QgsVectorLayer *vlayer )
             emit messageEmitted( tr( "The feature cannot be reshaped because the resulting geometry is empty" ), Qgis::Critical );
             vlayer->destroyEditCommand();
             return;
+          }
+          if ( res == 2 || res == 4 )
+          {
+            emit messageEmitted( tr( "At least one geometry intersected is invalid. You should fix geometries." ), Qgis::Warning );
           }
         }
 

--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -196,7 +196,7 @@ void QgsMapToolReshape::reshape( QgsVectorLayer *vlayer )
           }
           if ( res == 3 )
           {
-            emit messageEmitted( tr( "At least one geometry intersected is invalid. You should fix geometries." ), Qgis::Warning );
+            emit messageEmitted( tr( "At least one geometry intersected is invalid. These geometries must be manually repaired." ), Qgis::Warning );
           }
         }
 

--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -179,7 +179,7 @@ void QgsMapToolReshape::reshape( QgsVectorLayer *vlayer )
           if ( avoidIntersectionsLayers.size() > 0 )
           {
             res = geom.avoidIntersections( QgsProject::instance()->avoidIntersectionsLayers(), ignoreFeatures );
-            if ( res == 1 || res == 3 )
+            if ( res == 1 )
             {
               emit messageEmitted( tr( "An error was reported during intersection removal" ), Qgis::Critical );
               vlayer->destroyEditCommand();
@@ -194,7 +194,7 @@ void QgsMapToolReshape::reshape( QgsVectorLayer *vlayer )
             vlayer->destroyEditCommand();
             return;
           }
-          if ( res == 2 || res == 4 )
+          if ( res == 3 )
           {
             emit messageEmitted( tr( "At least one geometry intersected is invalid. You should fix geometries." ), Qgis::Warning );
           }

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2602,6 +2602,8 @@ int QgsGeometry::avoidIntersections( const QList<QgsVectorLayer *> &avoidInterse
     return 1;
   }
 
+  QgsWkbTypes::Type geomTypeBeforeModification = wkbType();
+
   bool haveGeometryError = false;
   bool hadInvalidGeometry = false;
   std::unique_ptr< QgsAbstractGeometry > diffGeom = QgsGeometryEditUtils::avoidIntersections( *( d->geometry ), avoidIntersectionsLayers, hadInvalidGeometry, haveGeometryError, ignoreFeatures );
@@ -2610,6 +2612,8 @@ int QgsGeometry::avoidIntersections( const QList<QgsVectorLayer *> &avoidInterse
     reset( std::move( diffGeom ) );
   }
 
+  if ( geomTypeBeforeModification != wkbType() )
+    return 2;
   if ( haveGeometryError )
     return 3;
   if ( hadInvalidGeometry )

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2604,9 +2604,8 @@ int QgsGeometry::avoidIntersections( const QList<QgsVectorLayer *> &avoidInterse
 
   QgsWkbTypes::Type geomTypeBeforeModification = wkbType();
 
-  bool haveGeometryError = false;
-  bool hadInvalidGeometry = false;
-  std::unique_ptr< QgsAbstractGeometry > diffGeom = QgsGeometryEditUtils::avoidIntersections( *( d->geometry ), avoidIntersectionsLayers, hadInvalidGeometry, haveGeometryError, ignoreFeatures );
+  bool haveInvalidGeometry = false;
+  std::unique_ptr< QgsAbstractGeometry > diffGeom = QgsGeometryEditUtils::avoidIntersections( *( d->geometry ), avoidIntersectionsLayers, haveInvalidGeometry, ignoreFeatures );
   if ( diffGeom )
   {
     reset( std::move( diffGeom ) );
@@ -2614,9 +2613,7 @@ int QgsGeometry::avoidIntersections( const QList<QgsVectorLayer *> &avoidInterse
 
   if ( geomTypeBeforeModification != wkbType() )
     return 2;
-  if ( haveGeometryError )
-    return 3;
-  if ( hadInvalidGeometry )
+  if ( haveInvalidGeometry )
     return 4;
 
   return 0;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2603,12 +2603,19 @@ int QgsGeometry::avoidIntersections( const QList<QgsVectorLayer *> &avoidInterse
   }
 
   bool haveGeometryError = false;
-  std::unique_ptr< QgsAbstractGeometry > diffGeom = QgsGeometryEditUtils::avoidIntersections( *( d->geometry ), avoidIntersectionsLayers, haveGeometryError, ignoreFeatures );
+  bool hadInvalidGeometry = false;
+  std::unique_ptr< QgsAbstractGeometry > diffGeom = QgsGeometryEditUtils::avoidIntersections( *( d->geometry ), avoidIntersectionsLayers, hadInvalidGeometry, haveGeometryError, ignoreFeatures );
   if ( diffGeom )
   {
     reset( std::move( diffGeom ) );
   }
-  return haveGeometryError ? 3 : 0;
+
+  if ( haveGeometryError )
+    return 3;
+  if ( hadInvalidGeometry )
+    return 4;
+
+  return 0;
 }
 
 

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2602,12 +2602,13 @@ int QgsGeometry::avoidIntersections( const QList<QgsVectorLayer *> &avoidInterse
     return 1;
   }
 
-  std::unique_ptr< QgsAbstractGeometry > diffGeom = QgsGeometryEditUtils::avoidIntersections( *( d->geometry ), avoidIntersectionsLayers, ignoreFeatures );
+  bool haveGeometryError = false;
+  std::unique_ptr< QgsAbstractGeometry > diffGeom = QgsGeometryEditUtils::avoidIntersections( *( d->geometry ), avoidIntersectionsLayers, haveGeometryError, ignoreFeatures );
   if ( diffGeom )
   {
     reset( std::move( diffGeom ) );
   }
-  return 0;
+  return haveGeometryError ? 3 : 0;
 }
 
 

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -2016,7 +2016,8 @@ class CORE_EXPORT QgsGeometry
      * \returns 0 in case of success,
      *          1 if geometry is not of polygon type,
      *          2 if avoid intersection would change the geometry type,
-     *          3 other error during intersection removal
+     *          3 other error during intersection removal,
+     *          4 in case of success but at least one geometry intersected was invalid and fixed to perform the operation
      * \since QGIS 1.5
      */
     int avoidIntersections( const QList<QgsVectorLayer *> &avoidIntersectionsLayers,

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -2016,8 +2016,7 @@ class CORE_EXPORT QgsGeometry
      * \returns 0 in case of success,
      *          1 if geometry is not of polygon type,
      *          2 if avoid intersection would change the geometry type,
-     *          3 other error during intersection removal,
-     *          4 in case of success but at least one geometry intersected was invalid and fixed to perform the operation
+     *          3 at least one geometry intersected is invalid. The algorithm may not work and return the same geometry as the input. You must fix your intersecting geometries.
      * \since QGIS 1.5
      */
     int avoidIntersections( const QList<QgsVectorLayer *> &avoidIntersectionsLayers,

--- a/src/core/geometry/qgsgeometryeditutils.cpp
+++ b/src/core/geometry/qgsgeometryeditutils.cpp
@@ -224,14 +224,12 @@ bool QgsGeometryEditUtils::deletePart( QgsAbstractGeometry *geom, int partNum )
 
 std::unique_ptr<QgsAbstractGeometry> QgsGeometryEditUtils::avoidIntersections( const QgsAbstractGeometry &geom,
     const QList<QgsVectorLayer *> &avoidIntersectionsLayers,
-    bool &hadInvalidGeometry,
-    bool &haveGeometryError,
+    bool &haveInvalidGeometry,
     const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > &ignoreFeatures
                                                                              )
 {
 
-  haveGeometryError = false;
-  hadInvalidGeometry = false;
+  haveInvalidGeometry = false;
   std::unique_ptr<QgsGeometryEngine> geomEngine( QgsGeometry::createGeometryEngine( &geom ) );
   if ( !geomEngine )
   {
@@ -272,14 +270,9 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeometryEditUtils::avoidIntersections( c
         continue;
 
       if ( !f.geometry().isGeosValid() )
-        hadInvalidGeometry = true;
+        haveInvalidGeometry = true;
 
-      QgsGeometry geomValid = f.geometry().makeValid();
-      if ( geomValid.isNull() )
-        haveGeometryError = true;
-
-      nearGeometries << geomValid;
-
+      nearGeometries << f.geometry();
     }
   }
 

--- a/src/core/geometry/qgsgeometryeditutils.cpp
+++ b/src/core/geometry/qgsgeometryeditutils.cpp
@@ -265,7 +265,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeometryEditUtils::avoidIntersections( c
       if ( !f.hasGeometry() )
         continue;
 
-      nearGeometries << f.geometry();
+      nearGeometries << f.geometry().makeValid();
     }
   }
 

--- a/src/core/geometry/qgsgeometryeditutils.cpp
+++ b/src/core/geometry/qgsgeometryeditutils.cpp
@@ -224,10 +224,14 @@ bool QgsGeometryEditUtils::deletePart( QgsAbstractGeometry *geom, int partNum )
 
 std::unique_ptr<QgsAbstractGeometry> QgsGeometryEditUtils::avoidIntersections( const QgsAbstractGeometry &geom,
     const QList<QgsVectorLayer *> &avoidIntersectionsLayers,
+    bool &hadInvalidGeometry,
     bool &haveGeometryError,
     const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > &ignoreFeatures
                                                                              )
 {
+
+  haveGeometryError = false;
+  hadInvalidGeometry = false;
   std::unique_ptr<QgsGeometryEngine> geomEngine( QgsGeometry::createGeometryEngine( &geom ) );
   if ( !geomEngine )
   {
@@ -267,9 +271,13 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeometryEditUtils::avoidIntersections( c
       if ( !f.hasGeometry() )
         continue;
 
+      if ( !f.geometry().isGeosValid() )
+        hadInvalidGeometry = true;
+
       QgsGeometry geomValid = f.geometry().makeValid();
       if ( geomValid.isNull() )
         haveGeometryError = true;
+
       nearGeometries << geomValid;
 
     }

--- a/src/core/geometry/qgsgeometryeditutils.cpp
+++ b/src/core/geometry/qgsgeometryeditutils.cpp
@@ -224,7 +224,9 @@ bool QgsGeometryEditUtils::deletePart( QgsAbstractGeometry *geom, int partNum )
 
 std::unique_ptr<QgsAbstractGeometry> QgsGeometryEditUtils::avoidIntersections( const QgsAbstractGeometry &geom,
     const QList<QgsVectorLayer *> &avoidIntersectionsLayers,
-    const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > &ignoreFeatures )
+    bool &haveGeometryError,
+    const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > &ignoreFeatures
+                                                                             )
 {
   std::unique_ptr<QgsGeometryEngine> geomEngine( QgsGeometry::createGeometryEngine( &geom ) );
   if ( !geomEngine )
@@ -265,7 +267,11 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeometryEditUtils::avoidIntersections( c
       if ( !f.hasGeometry() )
         continue;
 
-      nearGeometries << f.geometry().makeValid();
+      QgsGeometry geomValid = f.geometry().makeValid();
+      if ( geomValid.isNull() )
+        haveGeometryError = true;
+      nearGeometries << geomValid;
+
     }
   }
 

--- a/src/core/geometry/qgsgeometryeditutils.h
+++ b/src/core/geometry/qgsgeometryeditutils.h
@@ -71,14 +71,12 @@ class QgsGeometryEditUtils
      * Alters a geometry so that it avoids intersections with features from all open vector layers.
      * \param geom geometry to alter
      * \param avoidIntersectionsLayers list of layers to check for intersections
-     * \param hadInvalidGeometry returns true if at least one geometry intersected was invalid.
-     * \param haveGeometryError the method will use GEOS to fix the geometries, if at least one geometry cannot be fixed, it returns false (The geometry, may not be modified.)
+     * \param haveInvalidGeometry returns true if at least one geometry intersected is invalid. In this case, the algorithm may not work and return the same geometry as the input. You must fix your intersecting geometries.
      * \param ignoreFeatures map of layer to feature id of features to ignore
      */
     static std::unique_ptr< QgsAbstractGeometry > avoidIntersections( const QgsAbstractGeometry &geom,
         const QList<QgsVectorLayer *> &avoidIntersectionsLayers,
-        bool &hadInvalidGeometry,
-        bool &haveGeometryError,
+        bool &haveInvalidGeometry,
         const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > &ignoreFeatures = ( QHash<QgsVectorLayer *, QSet<QgsFeatureId> >() ) );
 };
 

--- a/src/core/geometry/qgsgeometryeditutils.h
+++ b/src/core/geometry/qgsgeometryeditutils.h
@@ -71,10 +71,12 @@ class QgsGeometryEditUtils
      * Alters a geometry so that it avoids intersections with features from all open vector layers.
      * \param geom geometry to alter
      * \param avoidIntersectionsLayers list of layers to check for intersections
+     * \param haveGeometryError the method will use GEOS to fix the geometries, if at least one geometry cannot be fixed, it returns false (The geometry, may not be modified.)
      * \param ignoreFeatures map of layer to feature id of features to ignore
      */
     static std::unique_ptr< QgsAbstractGeometry > avoidIntersections( const QgsAbstractGeometry &geom,
         const QList<QgsVectorLayer *> &avoidIntersectionsLayers,
+        bool &haveGeometryError,
         const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > &ignoreFeatures = ( QHash<QgsVectorLayer *, QSet<QgsFeatureId> >() ) );
 };
 

--- a/src/core/geometry/qgsgeometryeditutils.h
+++ b/src/core/geometry/qgsgeometryeditutils.h
@@ -71,11 +71,13 @@ class QgsGeometryEditUtils
      * Alters a geometry so that it avoids intersections with features from all open vector layers.
      * \param geom geometry to alter
      * \param avoidIntersectionsLayers list of layers to check for intersections
+     * \param hadInvalidGeometry returns true if at least one geometry intersected was invalid.
      * \param haveGeometryError the method will use GEOS to fix the geometries, if at least one geometry cannot be fixed, it returns false (The geometry, may not be modified.)
      * \param ignoreFeatures map of layer to feature id of features to ignore
      */
     static std::unique_ptr< QgsAbstractGeometry > avoidIntersections( const QgsAbstractGeometry &geom,
         const QList<QgsVectorLayer *> &avoidIntersectionsLayers,
+        bool &hadInvalidGeometry,
         bool &haveGeometryError,
         const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > &ignoreFeatures = ( QHash<QgsVectorLayer *, QSet<QgsFeatureId> >() ) );
 };

--- a/src/gui/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/qgsmaptooldigitizefeature.cpp
@@ -341,9 +341,14 @@ void QgsMapToolDigitizeFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
           QgsGeometry featGeom = f->geometry();
           int avoidIntersectionsReturn = featGeom.avoidIntersections( avoidIntersectionsLayers );
           f->setGeometry( featGeom );
-          if ( avoidIntersectionsReturn == 3 )
+          switch ( avoidIntersectionsReturn )
           {
-            emit messageEmitted( tr( "The feature has been added, but at least one geometry intersected is invalid and cannot be fixed automaticaly. The geometry added may overlap another geometry. You should fix geometries." ), Qgis::Warning );
+            case 3:
+              emit messageEmitted( tr( "The feature has been added, but at least one geometry intersected is invalid and cannot be fixed automaticaly. The geometry added may overlap another geometry. You should fix geometries." ), Qgis::Warning );
+              break;
+            case 4:
+              emit messageEmitted( tr( "The feature has been added, but at least one geometry intersected is invalid and has been modified to perform the operation. You should fix geometries." ), Qgis::Warning );
+              break;
           }
           if ( f->geometry().isEmpty() ) //avoid intersection might have removed the whole geometry
           {

--- a/src/gui/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/qgsmaptooldigitizefeature.cpp
@@ -343,7 +343,7 @@ void QgsMapToolDigitizeFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
           f->setGeometry( featGeom );
           if ( avoidIntersectionsReturn == 3 )
           {
-            emit messageEmitted( tr( "The feature has been added, but at least one geometry intersected is invalid. You should fix geometries." ), Qgis::Warning );
+            emit messageEmitted( tr( "The feature has been added, but at least one geometry intersected is invalid. These geometries must be manually repaired." ), Qgis::Warning );
           }
           if ( f->geometry().isEmpty() ) //avoid intersection might have removed the whole geometry
           {

--- a/src/gui/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/qgsmaptooldigitizefeature.cpp
@@ -341,9 +341,9 @@ void QgsMapToolDigitizeFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
           QgsGeometry featGeom = f->geometry();
           int avoidIntersectionsReturn = featGeom.avoidIntersections( avoidIntersectionsLayers );
           f->setGeometry( featGeom );
-          if ( avoidIntersectionsReturn == 1 )
+          if ( avoidIntersectionsReturn == 3 )
           {
-            //not a polygon type. Impossible to get there
+            emit messageEmitted( tr( "The feature has been added, but at least one geometry intersected is invalid and cannot be fixed automaticaly. The geometry added may overlap another geometry. You should fix geometries." ), Qgis::Warning );
           }
           if ( f->geometry().isEmpty() ) //avoid intersection might have removed the whole geometry
           {

--- a/src/gui/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/qgsmaptooldigitizefeature.cpp
@@ -344,7 +344,7 @@ void QgsMapToolDigitizeFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
           switch ( avoidIntersectionsReturn )
           {
             case 3:
-              emit messageEmitted( tr( "The feature has been added, but at least one geometry intersected is invalid and cannot be fixed automaticaly. The geometry added may overlap another geometry. You should fix geometries." ), Qgis::Warning );
+              emit messageEmitted( tr( "The feature has been added, but at least one geometry intersected is invalid and cannot be fixed automatically. The geometry added may overlap another geometry. You should fix geometries." ), Qgis::Warning );
               break;
             case 4:
               emit messageEmitted( tr( "The feature has been added, but at least one geometry intersected is invalid and has been modified to perform the operation. You should fix geometries." ), Qgis::Warning );

--- a/src/gui/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/qgsmaptooldigitizefeature.cpp
@@ -341,14 +341,9 @@ void QgsMapToolDigitizeFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
           QgsGeometry featGeom = f->geometry();
           int avoidIntersectionsReturn = featGeom.avoidIntersections( avoidIntersectionsLayers );
           f->setGeometry( featGeom );
-          switch ( avoidIntersectionsReturn )
+          if ( avoidIntersectionsReturn == 3 )
           {
-            case 3:
-              emit messageEmitted( tr( "The feature has been added, but at least one geometry intersected is invalid and cannot be fixed automatically. The geometry added may overlap another geometry. You should fix geometries." ), Qgis::Warning );
-              break;
-            case 4:
-              emit messageEmitted( tr( "The feature has been added, but at least one geometry intersected is invalid and has been modified to perform the operation. You should fix geometries." ), Qgis::Warning );
-              break;
+            emit messageEmitted( tr( "The feature has been added, but at least one geometry intersected is invalid. You should fix geometries." ), Qgis::Warning );
           }
           if ( f->geometry().isEmpty() ) //avoid intersection might have removed the whole geometry
           {

--- a/tests/src/python/test_qgsgeometry_avoid_intersections.py
+++ b/tests/src/python/test_qgsgeometry_avoid_intersections.py
@@ -60,7 +60,7 @@ class TestQgsGeometryAvoidIntersections(unittest.TestCase):
         # create a geometry and remove its intersections with other geometries
 
         g = QgsGeometry.fromWkt(newg_wkt)
-        assert g.avoidIntersections([l]) == 0
+        assert g.avoidIntersections([l]) == 2
 
         # the resulting multi-polygon must have exactly three parts
         # (in QGIS 2.0 it has one more tiny part that appears at the border between two of the original polygons)


### PR DESCRIPTION
## Description

The avoidIntersection method uses GEOS as backend to perform the operations.
However, our avoidIntersection method does not check if the geometries are valid.
Geos does not perform this verification either, so the resulting geometry may
still overlap a polygon that is to be avoided.

before

![overlap mkv](https://user-images.githubusercontent.com/7521540/107245777-d2f1c800-6a2f-11eb-8eb6-7a792305382e.gif)

after
![overlap_after mkv](https://user-images.githubusercontent.com/7521540/107245921-fd438580-6a2f-11eb-8307-de84ba0a55c5.gif)


First, I use `makeValid` to try to fix the geometry (as used for selectedFeature for example).
Sedonc, I add a new parameter to return if there was an error after convert a geometry to a valid one.

If there was an unfixable error, a message is raised. Maybe, we should also indicate that the operation was performed with an invalid geometry and QGIS used a modified geometry @gioman? 