### PR TITLE
Processing.initialize() automatically adds native and 3d providers

### DIFF
--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -42,6 +42,7 @@ from qgis.core import (QgsMessageLog,
                        QgsProcessingOutputMultipleLayers,
                        QgsProcessingFeedback,
                        QgsRuntimeProfiler)
+from qgis.analysis import QgsNativeAlgorithms
 
 import processing
 from processing.core.ProcessingConfig import ProcessingConfig
@@ -99,6 +100,20 @@ class Processing(object):
             return
 
         with QgsRuntimeProfiler.profile('Initialize'):
+
+            # add native provider if not already added
+            if "native" not in [p.id() for p in QgsApplication.processingRegistry().providers()]:
+                QgsApplication.processingRegistry().addProvider(QgsNativeAlgorithms(QgsApplication.processingRegistry()))
+
+            # add 3d provider if available and not already added
+            if "3d" not in [p.id() for p in QgsApplication.processingRegistry().providers()]:
+                try:
+                    from qgis._3d import Qgs3DAlgorithms
+                    QgsApplication.processingRegistry().addProvider(Qgs3DAlgorithms(QgsApplication.processingRegistry()))
+                except ImportError:
+                    # no 3d library available
+                    pass
+
             # Add the basic providers
             for c in [
                 QgisAlgorithmProvider,

--- a/python/plugins/processing/tests/AlgorithmsTestBase.py
+++ b/python/plugins/processing/tests/AlgorithmsTestBase.py
@@ -404,7 +404,6 @@ class GenericAlgorithmsTest(unittest.TestCase):
         start_app()
         from processing.core.Processing import Processing
         Processing.initialize()
-        QgsApplication.processingRegistry().addProvider(QgsNativeAlgorithms())
         cls.cleanup_paths = []
 
     @classmethod

--- a/python/plugins/processing/tests/CheckValidityAlgorithm.py
+++ b/python/plugins/processing/tests/CheckValidityAlgorithm.py
@@ -54,7 +54,6 @@ class TestQgsProcessingCheckValidity(unittest.TestCase):
             "QGIS_TestPyQgsProcessingCheckValidity")
         QgsSettings().clear()
         Processing.initialize()
-        QgsApplication.processingRegistry().addProvider(QgsNativeAlgorithms())
         cls.registry = QgsApplication.instance().processingRegistry()
 
     def _make_layer(self, layer_wkb_name):

--- a/python/plugins/processing/tests/ProcessingGeneralTest.py
+++ b/python/plugins/processing/tests/ProcessingGeneralTest.py
@@ -44,7 +44,6 @@ class TestProcessingGeneral(unittest.TestCase):
         start_app()
         from processing.core.Processing import Processing
         Processing.initialize()
-        QgsApplication.processingRegistry().addProvider(QgsNativeAlgorithms())
         cls.cleanup_paths = []
         cls.in_place_layers = {}
         cls.vector_layer_params = {}

--- a/python/plugins/processing/tests/QgisAlgorithmsTest1.py
+++ b/python/plugins/processing/tests/QgisAlgorithmsTest1.py
@@ -67,12 +67,9 @@ class TestQgisAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
         start_app()
         from processing.core.Processing import Processing
         Processing.initialize()
-        ProcessingConfig.setSettingValue(ModelerUtils.MODELS_FOLDER, os.path.join(os.path.dirname(__file__), 'models'))
-        QgsApplication.processingRegistry().addProvider(QgsNativeAlgorithms())
         cls.cleanup_paths = []
         cls.in_place_layers = {}
         cls.vector_layer_params = {}
-        cls._original_models_folder = ProcessingConfig.getSetting(ModelerUtils.MODELS_FOLDER)
 
     @classmethod
     def tearDownClass(cls):
@@ -80,7 +77,6 @@ class TestQgisAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
         Processing.deinitialize()
         for path in cls.cleanup_paths:
             shutil.rmtree(path)
-        ProcessingConfig.setSettingValue(ModelerUtils.MODELS_FOLDER, cls._original_models_folder)
 
     def test_definition_file(self):
         return 'qgis_algorithm_tests1.yaml'

--- a/python/plugins/processing/tests/QgisAlgorithmsTest2.py
+++ b/python/plugins/processing/tests/QgisAlgorithmsTest2.py
@@ -42,12 +42,9 @@ class TestQgisAlgorithms2(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
         start_app()
         from processing.core.Processing import Processing
         Processing.initialize()
-        ProcessingConfig.setSettingValue(ModelerUtils.MODELS_FOLDER, os.path.join(os.path.dirname(__file__), 'models'))
-        QgsApplication.processingRegistry().addProvider(QgsNativeAlgorithms())
         cls.cleanup_paths = []
         cls.in_place_layers = {}
         cls.vector_layer_params = {}
-        cls._original_models_folder = ProcessingConfig.getSetting(ModelerUtils.MODELS_FOLDER)
 
     @classmethod
     def tearDownClass(cls):
@@ -55,7 +52,6 @@ class TestQgisAlgorithms2(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
         Processing.deinitialize()
         for path in cls.cleanup_paths:
             shutil.rmtree(path)
-        ProcessingConfig.setSettingValue(ModelerUtils.MODELS_FOLDER, cls._original_models_folder)
 
     def test_definition_file(self):
         return 'qgis_algorithm_tests2.yaml'

--- a/python/plugins/processing/tests/QgisAlgorithmsTest3.py
+++ b/python/plugins/processing/tests/QgisAlgorithmsTest3.py
@@ -42,12 +42,9 @@ class TestQgisAlgorithms3(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
         start_app()
         from processing.core.Processing import Processing
         Processing.initialize()
-        ProcessingConfig.setSettingValue(ModelerUtils.MODELS_FOLDER, os.path.join(os.path.dirname(__file__), 'models'))
-        QgsApplication.processingRegistry().addProvider(QgsNativeAlgorithms())
         cls.cleanup_paths = []
         cls.in_place_layers = {}
         cls.vector_layer_params = {}
-        cls._original_models_folder = ProcessingConfig.getSetting(ModelerUtils.MODELS_FOLDER)
 
     @classmethod
     def tearDownClass(cls):
@@ -55,7 +52,6 @@ class TestQgisAlgorithms3(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
         Processing.deinitialize()
         for path in cls.cleanup_paths:
             shutil.rmtree(path)
-        ProcessingConfig.setSettingValue(ModelerUtils.MODELS_FOLDER, cls._original_models_folder)
 
     def test_definition_file(self):
         return 'qgis_algorithm_tests3.yaml'

--- a/python/plugins/processing/tests/QgisAlgorithmsTest4.py
+++ b/python/plugins/processing/tests/QgisAlgorithmsTest4.py
@@ -42,8 +42,13 @@ class TestQgisAlgorithms4(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
         start_app()
         from processing.core.Processing import Processing
         Processing.initialize()
+
+        # change the model provider folder so that it looks in the test directory for models
         ProcessingConfig.setSettingValue(ModelerUtils.MODELS_FOLDER, os.path.join(os.path.dirname(__file__), 'models'))
-        QgsApplication.processingRegistry().addProvider(QgsNativeAlgorithms())
+        for p in QgsApplication.processingRegistry().providers():
+            if p.id() == "model":
+                p.refreshAlgorithms()
+
         cls.cleanup_paths = []
         cls.in_place_layers = {}
         cls.vector_layer_params = {}


### PR DESCRIPTION
Automatically load the native and 3d providers when a script calls Processing.initialize() if they are not
already loaded

This means the following ugly code can be avoided:

    Processing.initialize()
    QgsApplication.processingRegistry().addProvider(QgsNativeAlgorithms(QgsApplication.processingRegistry()))
    QgsApplication.processingRegistry().addProvider(Qgs3DAlgorithms(QgsApplication.processingRegistry()))

and instead the call to `Processing.initialize()` alone is sufficient to load
ALL providers

Fixes #41310
