### PR TITLE
fix caching of deps in mac workflow

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -75,7 +75,7 @@ jobs:
         uses: pat-s/always-upload-cache@v2.1.3
         with:
           path: ${{ env.DEPS_CACHE_DIR }}/Qt/${{ env.QT_VERSION }}
-          key: mac-qt-v3-${{ env.QT_VERSION }}
+          key: mac-qt-v4-${{ env.QT_VERSION }}
 
       - name: Restore Qt
         if: steps.cache-qt.outputs.cache-hit == 'true'
@@ -86,7 +86,11 @@ jobs:
 
       - name: Download Qt
         if: steps.cache-qt.outputs.cache-hit != 'true'
-        run: wget https://qgis.org/downloads/macos/deps/qt-${QT_VERSION}.tar.gz
+        run: |
+          wget https://qgis.org/downloads/macos/deps/qt-${QT_VERSION}.tar.gz
+          mkdir -p ${DEPS_CACHE_DIR}
+          mkdir -p ${DEPS_CACHE_DIR}/Qt
+
 
 
       # QGIS-deps caching
@@ -95,7 +99,7 @@ jobs:
         uses: pat-s/always-upload-cache@v2.1.3
         with:
           path: ${{ env.DEPS_CACHE_DIR }}/QGIS/qgis-deps-${{ env.QGIS_DEPS_VERSION }}
-          key: mac-qgis-deps-v3-${{ env.QGIS_DEPS_VERSION }}
+          key: mac-qgis-deps-v4-${{ env.QGIS_DEPS_VERSION }}
 
       - name: Restore qgis-deps
         if: steps.cache-deps.outputs.cache-hit == 'true'
@@ -106,7 +110,11 @@ jobs:
 
       - name: Download qgis-deps
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: wget https://qgis.org/downloads/macos/deps/qgis-deps-${QGIS_DEPS_VERSION}.tar.gz
+        run: |
+          wget https://qgis.org/downloads/macos/deps/qgis-deps-${QGIS_DEPS_VERSION}.tar.gz
+          mkdir -p ${DEPS_CACHE_DIR}
+          mkdir -p ${DEPS_CACHE_DIR}/QGIS
+
 
 
       - name: Install Qt and deps

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -129,7 +129,7 @@ jobs:
           ccache --set-config=max_size=2.0G
           ccache -s
 
-      - name: create build system
+      - name: Run cmake
         run: |
           mkdir -p ${BUILD_DIR}
           cd ${BUILD_DIR}
@@ -144,7 +144,7 @@ jobs:
                -DWITH_EPT=TRUE \
                ../QGIS
 
-      - name: build QGIS
+      - name: Build QGIS
         run: |
           cd ${BUILD_DIR}
           make -j $(sysctl -n hw.ncpu)

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -75,7 +75,7 @@ jobs:
         uses: pat-s/always-upload-cache@v2.1.3
         with:
           path: ${{ env.DEPS_CACHE_DIR }}/Qt/${{ env.QT_VERSION }}
-          key: mac-qt-v2-${{ env.QT_VERSION }}
+          key: mac-qt-v3-${{ env.QT_VERSION }}
 
       - name: Restore Qt
         if: steps.cache-qt.outputs.cache-hit == 'true'
@@ -95,7 +95,7 @@ jobs:
         uses: pat-s/always-upload-cache@v2.1.3
         with:
           path: ${{ env.DEPS_CACHE_DIR }}/QGIS/qgis-deps-${{ env.QGIS_DEPS_VERSION }}
-          key: mac-qgis-deps-v2-${{ env.QGIS_DEPS_VERSION }}
+          key: mac-qgis-deps-v3-${{ env.QGIS_DEPS_VERSION }}
 
       - name: Restore qgis-deps
         if: steps.cache-deps.outputs.cache-hit == 'true'

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -80,8 +80,8 @@ jobs:
       - name: Restore Qt
         if: steps.cache-qt.outputs.cache-hit == 'true'
         run: |
-          mkdir -p /opt
-          mkdir -p /opt/Qt
+          sudo mkdir -p /opt
+          sudo mkdir -p /opt/Qt
           sudo cp -r ${DEPS_CACHE_DIR}/Qt/${QT_VERSION} /opt/Qt/${QT_VERSION}
 
       - name: Download Qt
@@ -100,8 +100,8 @@ jobs:
       - name: Restore qgis-deps
         if: steps.cache-deps.outputs.cache-hit == 'true'
         run: |
-          mkdir -p /opt
-          mkdir -p /opt/QGIS
+          sudo mkdir -p /opt
+          sudo mkdir -p /opt/QGIS
           sudo cp -r ${DEPS_CACHE_DIR}/QGIS/qgis-deps-${QGIS_DEPS_VERSION} /opt/QGIS/qgis-deps-${QGIS_DEPS_VERSION}
 
       - name: Download qgis-deps

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           mkdir -p /opt
           mkdir -p /opt/Qt
-          sudo cp ${DEPS_CACHE_DIR}/Qt/${QT_VERSION} /opt/Qt/${QT_VERSION}
+          sudo cp -r ${DEPS_CACHE_DIR}/Qt/${QT_VERSION} /opt/Qt/${QT_VERSION}
 
       - name: Download Qt
         if: steps.cache-qt.outputs.cache-hit != 'true'
@@ -102,7 +102,7 @@ jobs:
         run: |
           mkdir -p /opt
           mkdir -p /opt/QGIS
-          sudo cp ${DEPS_CACHE_DIR}/QGIS/qgis-deps-${QGIS_DEPS_VERSION} /opt/QGIS/qgis-deps-${QGIS_DEPS_VERSION}
+          sudo cp -r ${DEPS_CACHE_DIR}/QGIS/qgis-deps-${QGIS_DEPS_VERSION} /opt/QGIS/qgis-deps-${QGIS_DEPS_VERSION}
 
       - name: Download qgis-deps
         if: steps.cache-deps.outputs.cache-hit != 'true'
@@ -116,9 +116,11 @@ jobs:
         run: |
           wget https://qgis.org/downloads/macos/deps/install_qgis_deps-${QGIS_DEPS_VERSION}.bash
           chmod +x ./install_qgis_deps-${QGIS_DEPS_VERSION}.bash
+          echo ::group::Install deps
           sudo ./install_qgis_deps-${QGIS_DEPS_VERSION}.bash
-          [[ ${QT_ALREADY_CACHED} != "true" ]] && cp /opt/Qt/${QT_VERSION} ${DEPS_CACHE_DIR}/Qt/${QT_VERSION} || true
-          [[ ${QGIS_DEPS_ALREADY_CACHED} != "true" ]] && cp /opt/QGIS/qgis-deps-${QGIS_DEPS_VERSION} ${DEPS_CACHE_DIR}/QGIS/qgis-deps-${QGIS_DEPS_VERSION} || true
+          echo ::endgroup::
+          [[ ${QT_ALREADY_CACHED} != "true" ]] && cp -r /opt/Qt/${QT_VERSION} ${DEPS_CACHE_DIR}/Qt/${QT_VERSION} || true
+          [[ ${QGIS_DEPS_ALREADY_CACHED} != "true" ]] && cp -r /opt/QGIS/qgis-deps-${QGIS_DEPS_VERSION} ${DEPS_CACHE_DIR}/QGIS/qgis-deps-${QGIS_DEPS_VERSION} || true
 
       - name: Install ccache
         run: |

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -92,7 +92,6 @@ jobs:
           mkdir -p ${DEPS_CACHE_DIR}/Qt
 
 
-
       # QGIS-deps caching
       - name: Cache qgis-deps
         id: cache-deps

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -32,6 +32,9 @@ env:
   QGIS_DEPS_VERSION: 0.6.0
   CCACHE_DIR: /Users/runner/work/ccache
   BUILD_DIR: /Users/runner/work/QGIS/build-QGIS
+  # apparently we cannot cache /opt directory as it fails to restore
+  # so we copy the deps in the home directory
+  DEPS_CACHE_DIR: /Users/runner/work/deps-cache
 
 jobs:
   mac_os_build:
@@ -65,33 +68,57 @@ jobs:
             build-mac-ccache-${{ github.ref }}-
             build-mac-ccache-refs/heads/master-
 
+
+      # Qt caching
       - name: Cache Qt
         id: cache-qt
         uses: pat-s/always-upload-cache@v2.1.3
         with:
-          path: /opt/Qt/${{ env.QT_VERSION }}
-          key: mac-qt-${{ env.QT_VERSION }}
+          path: ${{ env.DEPS_CACHE_DIR }}/Qt/${{ env.QT_VERSION }}
+          key: mac-qt-v2-${{ env.QT_VERSION }}
+
+      - name: Restore Qt
+        if: steps.cache-qt.outputs.cache-hit == 'true'
+        run: |
+          mkdir -p /opt
+          mkdir -p /opt/Qt
+          sudo cp ${DEPS_CACHE_DIR}/Qt/${QT_VERSION} /opt/Qt/${QT_VERSION}
 
       - name: Download Qt
         if: steps.cache-qt.outputs.cache-hit != 'true'
         run: wget https://qgis.org/downloads/macos/deps/qt-${QT_VERSION}.tar.gz
 
+
+      # QGIS-deps caching
       - name: Cache qgis-deps
         id: cache-deps
         uses: pat-s/always-upload-cache@v2.1.3
         with:
-          path: /opt/QGIS/qgis-deps-${{ env.QGIS_DEPS_VERSION }}
-          key: mac-qgis-deps-${{ env.QGIS_DEPS_VERSION }}
+          path: ${{ env.DEPS_CACHE_DIR }}/QGIS/qgis-deps-${{ env.QGIS_DEPS_VERSION }}
+          key: mac-qgis-deps-v2-${{ env.QGIS_DEPS_VERSION }}
 
-      - name: Download deps
+      - name: Restore qgis-deps
+        if: steps.cache-deps.outputs.cache-hit == 'true'
+        run: |
+          mkdir -p /opt
+          mkdir -p /opt/QGIS
+          sudo cp ${DEPS_CACHE_DIR}/QGIS/qgis-deps-${QGIS_DEPS_VERSION} /opt/QGIS/qgis-deps-${QGIS_DEPS_VERSION}
+
+      - name: Download qgis-deps
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: wget https://qgis.org/downloads/macos/deps/qgis-deps-${QGIS_DEPS_VERSION}.tar.gz
 
+
       - name: Install Qt and deps
+        env:
+          QT_ALREADY_CACHED: ${{ steps.cache-qt.outputs.cache-hit }}
+          QGIS_DEPS_ALREADY_CACHED: ${{ steps.cache-deps.outputs.cache-hit }}
         run: |
           wget https://qgis.org/downloads/macos/deps/install_qgis_deps-${QGIS_DEPS_VERSION}.bash
           chmod +x ./install_qgis_deps-${QGIS_DEPS_VERSION}.bash
           sudo ./install_qgis_deps-${QGIS_DEPS_VERSION}.bash
+          [[ ${QT_ALREADY_CACHED} != "true" ]] && cp /opt/Qt/${QT_VERSION} ${DEPS_CACHE_DIR}/Qt/${QT_VERSION} || true
+          [[ ${QGIS_DEPS_ALREADY_CACHED} != "true" ]] && cp /opt/QGIS/qgis-deps-${QGIS_DEPS_VERSION} ${DEPS_CACHE_DIR}/QGIS/qgis-deps-${QGIS_DEPS_VERSION} || true
 
       - name: Install ccache
         run: |


### PR DESCRIPTION
apparently, restoring to /opt doesn't work
so we copy the deps to the runner directory to cache and restore them

