### PR TITLE
Add queue for loading multiple point clouds

### DIFF
--- a/src/providers/pdal/qgspdaleptgenerationtask.cpp
+++ b/src/providers/pdal/qgspdaleptgenerationtask.cpp
@@ -28,8 +28,8 @@
 #include "qgsmessagelog.h"
 #include "qgis.h"
 
-QgsPdalEptGenerationTask::QgsPdalEptGenerationTask( const QString &file, const QString &outputDir )
-  : QgsTask( tr( "Generate EPT Index" ) )
+QgsPdalEptGenerationTask::QgsPdalEptGenerationTask( const QString &file, const QString &outputDir, const QString &name )
+  : QgsTask( tr( "Generate EPT Index " ) + name )
   , mOutputDir( outputDir )
   , mFile( file )
 {

--- a/src/providers/pdal/qgspdaleptgenerationtask.cpp
+++ b/src/providers/pdal/qgspdaleptgenerationtask.cpp
@@ -29,7 +29,7 @@
 #include "qgis.h"
 
 QgsPdalEptGenerationTask::QgsPdalEptGenerationTask( const QString &file, const QString &outputDir, const QString &name )
-  : QgsTask( tr( "Generate EPT Index " ) + name )
+  : QgsTask( tr( "Indexing Point Cloud (%1)" ).arg( name ) )
   , mOutputDir( outputDir )
   , mFile( file )
 {

--- a/src/providers/pdal/qgspdaleptgenerationtask.h
+++ b/src/providers/pdal/qgspdaleptgenerationtask.h
@@ -24,7 +24,7 @@ class QgsPdalEptGenerationTask: public QgsTask
     Q_OBJECT
 
   public:
-    QgsPdalEptGenerationTask( const QString &file, const QString &outputDir );
+    QgsPdalEptGenerationTask( const QString &file, const QString &outputDir, const QString &name = QString() );
     bool run() override;
 
     QString untwineExecutableBinary() const;

--- a/src/providers/pdal/qgspdalprovider.cpp
+++ b/src/providers/pdal/qgspdalprovider.cpp
@@ -35,6 +35,8 @@
 #define PROVIDER_KEY QStringLiteral( "pdal" )
 #define PROVIDER_DESCRIPTION QStringLiteral( "PDAL point cloud data provider" )
 
+QQueue<QgsPdalProvider *> QgsPdalProvider::mIndexingQueue;
+
 QgsPdalProvider::QgsPdalProvider(
   const QString &uri,
   const QgsDataProvider::ProviderOptions &options,
@@ -93,6 +95,7 @@ void QgsPdalProvider::generateIndex()
   if ( anyIndexingTaskExists() )
   {
     QgsMessageLog::logMessage( tr( "EPT generation task is already running" ), QObject::tr( "Point clouds" ), Qgis::Info );
+    mIndexingQueue.push_back( this );
     return;
   }
 
@@ -146,6 +149,8 @@ void QgsPdalProvider::onGenerateIndexFinished()
     mRunningIndexingTask = nullptr;
     emit indexGenerationStateChanged( PointCloudIndexGenerationState::Indexed );
   }
+  if ( !mIndexingQueue.empty() )
+    mIndexingQueue.takeFirst()->generateIndex();
 }
 
 void QgsPdalProvider::onGenerateIndexFailed()
@@ -157,6 +162,8 @@ void QgsPdalProvider::onGenerateIndexFailed()
     mRunningIndexingTask = nullptr;
     emit indexGenerationStateChanged( PointCloudIndexGenerationState::NotIndexed );
   }
+  if ( !mIndexingQueue.empty() )
+    mIndexingQueue.takeFirst()->generateIndex();
 }
 
 bool QgsPdalProvider::anyIndexingTaskExists()

--- a/src/providers/pdal/qgspdalprovider.cpp
+++ b/src/providers/pdal/qgspdalprovider.cpp
@@ -101,7 +101,7 @@ void QgsPdalProvider::generateIndex()
 
   const QString outputDir = _outdir( dataSourceUri() );
 
-  QgsPdalEptGenerationTask *generationTask = new QgsPdalEptGenerationTask( dataSourceUri(), outputDir );
+  QgsPdalEptGenerationTask *generationTask = new QgsPdalEptGenerationTask( dataSourceUri(), outputDir, QStringLiteral( "( " ) + QFileInfo( dataSourceUri() ).fileName() + QStringLiteral( " )" ) );
 
   connect( generationTask, &QgsPdalEptGenerationTask::taskTerminated, this, &QgsPdalProvider::onGenerateIndexFailed );
   connect( generationTask, &QgsPdalEptGenerationTask::taskCompleted, this, &QgsPdalProvider::onGenerateIndexFinished );

--- a/src/providers/pdal/qgspdalprovider.cpp
+++ b/src/providers/pdal/qgspdalprovider.cpp
@@ -35,7 +35,7 @@
 #define PROVIDER_KEY QStringLiteral( "pdal" )
 #define PROVIDER_DESCRIPTION QStringLiteral( "PDAL point cloud data provider" )
 
-QQueue<QgsPdalProvider *> QgsPdalProvider::mIndexingQueue;
+QQueue<QgsPdalProvider *> QgsPdalProvider::sIndexingQueue;
 
 QgsPdalProvider::QgsPdalProvider(
   const QString &uri,
@@ -94,8 +94,7 @@ void QgsPdalProvider::generateIndex()
 
   if ( anyIndexingTaskExists() )
   {
-    QgsMessageLog::logMessage( tr( "EPT generation task is already running" ), QObject::tr( "Point clouds" ), Qgis::Info );
-    mIndexingQueue.push_back( this );
+    sIndexingQueue.push_back( this );
     return;
   }
 
@@ -149,8 +148,8 @@ void QgsPdalProvider::onGenerateIndexFinished()
     mRunningIndexingTask = nullptr;
     emit indexGenerationStateChanged( PointCloudIndexGenerationState::Indexed );
   }
-  if ( !mIndexingQueue.empty() )
-    mIndexingQueue.takeFirst()->generateIndex();
+  if ( !sIndexingQueue.empty() )
+    sIndexingQueue.takeFirst()->generateIndex();
 }
 
 void QgsPdalProvider::onGenerateIndexFailed()
@@ -162,8 +161,8 @@ void QgsPdalProvider::onGenerateIndexFailed()
     mRunningIndexingTask = nullptr;
     emit indexGenerationStateChanged( PointCloudIndexGenerationState::NotIndexed );
   }
-  if ( !mIndexingQueue.empty() )
-    mIndexingQueue.takeFirst()->generateIndex();
+  if ( !sIndexingQueue.empty() )
+    sIndexingQueue.takeFirst()->generateIndex();
 }
 
 bool QgsPdalProvider::anyIndexingTaskExists()

--- a/src/providers/pdal/qgspdalprovider.h
+++ b/src/providers/pdal/qgspdalprovider.h
@@ -66,7 +66,7 @@ class QgsPdalProvider: public QgsPointCloudDataProvider
     QVariantMap mOriginalMetadata;
     std::unique_ptr<QgsEptPointCloudIndex> mIndex;
     QgsPdalEptGenerationTask *mRunningIndexingTask = nullptr;
-    static QQueue<QgsPdalProvider *> mIndexingQueue;
+    static QQueue<QgsPdalProvider *> sIndexingQueue;
 };
 
 class QgsPdalProviderMetadata : public QgsProviderMetadata

--- a/src/providers/pdal/qgspdalprovider.h
+++ b/src/providers/pdal/qgspdalprovider.h
@@ -66,6 +66,7 @@ class QgsPdalProvider: public QgsPointCloudDataProvider
     QVariantMap mOriginalMetadata;
     std::unique_ptr<QgsEptPointCloudIndex> mIndex;
     QgsPdalEptGenerationTask *mRunningIndexingTask = nullptr;
+    static QQueue<QgsPdalProvider *> mIndexingQueue;
 };
 
 class QgsPdalProviderMetadata : public QgsProviderMetadata


### PR DESCRIPTION
## Description
Previously when the user tries to open multiple point clouds only one will be indexed.
Now the generation tasks will be queued and indexed one after another.