### PR TITLE
Make move label tool an advanced map tool

### DIFF
--- a/src/app/labeling/qgsmaptoolchangelabelproperties.cpp
+++ b/src/app/labeling/qgsmaptoolchangelabelproperties.cpp
@@ -24,7 +24,8 @@
 #include "qgisapp.h"
 #include "qgsmessagebar.h"
 
-QgsMapToolChangeLabelProperties::QgsMapToolChangeLabelProperties( QgsMapCanvas *canvas ): QgsMapToolLabel( canvas )
+QgsMapToolChangeLabelProperties::QgsMapToolChangeLabelProperties( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDock )
+  : QgsMapToolLabel( canvas, cadDock )
 {
   mPalProperties << QgsPalLayerSettings::PositionX;
   mPalProperties << QgsPalLayerSettings::PositionY;

--- a/src/app/labeling/qgsmaptoolchangelabelproperties.h
+++ b/src/app/labeling/qgsmaptoolchangelabelproperties.h
@@ -26,7 +26,7 @@ class APP_EXPORT QgsMapToolChangeLabelProperties: public QgsMapToolLabel
     Q_OBJECT
 
   public:
-    QgsMapToolChangeLabelProperties( QgsMapCanvas *canvas );
+    QgsMapToolChangeLabelProperties( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDock );
 
     void canvasPressEvent( QgsMapMouseEvent *e ) override;
     void canvasReleaseEvent( QgsMapMouseEvent *e ) override;

--- a/src/app/labeling/qgsmaptoollabel.cpp
+++ b/src/app/labeling/qgsmaptoollabel.cpp
@@ -30,12 +30,14 @@
 #include "qgsauxiliarystorage.h"
 #include "qgsgui.h"
 #include "qgstextrenderer.h"
-
+#include "qgisapp.h"
+#include "qgsmapmouseevent.h"
+#include "qgsadvanceddigitizingdockwidget.h"
 
 #include <QMouseEvent>
 
-QgsMapToolLabel::QgsMapToolLabel( QgsMapCanvas *canvas )
-  : QgsMapTool( canvas )
+QgsMapToolLabel::QgsMapToolLabel( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDock )
+  : QgsMapToolAdvancedDigitizing( canvas, cadDock )
 
 {
 }
@@ -181,8 +183,9 @@ void QgsMapToolLabel::deleteRubberBands()
   mFeatureRubberBand = nullptr;
   delete mFixPointRubberBand;
   mFixPointRubberBand = nullptr;
+  cadDockWidget()->clear();
+  cadDockWidget()->clearPoints();
 }
-
 
 QString QgsMapToolLabel::currentLabelText( int trunc )
 {

--- a/src/app/labeling/qgsmaptoollabel.h
+++ b/src/app/labeling/qgsmaptoollabel.h
@@ -18,7 +18,7 @@
 #ifndef QGSMAPTOOLLABEL_H
 #define QGSMAPTOOLLABEL_H
 
-#include "qgsmaptool.h"
+#include "qgsmaptooladvanceddigitizing.h"
 #include "qgspallabeling.h"
 #include "qgsnewauxiliarylayerdialog.h"
 #include "qgsauxiliarystorage.h"
@@ -30,12 +30,12 @@ typedef QMap<QgsPalLayerSettings::Property, int> QgsPalIndexes;
 typedef QMap<QgsDiagramLayerSettings::Property, int> QgsDiagramIndexes;
 
 //! Base class for map tools that modify label properties
-class APP_EXPORT QgsMapToolLabel: public QgsMapTool
+class APP_EXPORT QgsMapToolLabel: public QgsMapToolAdvancedDigitizing
 {
     Q_OBJECT
 
   public:
-    QgsMapToolLabel( QgsMapCanvas *canvas );
+    QgsMapToolLabel( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDock );
     ~QgsMapToolLabel() override;
 
     /**

--- a/src/app/labeling/qgsmaptoolmovelabel.cpp
+++ b/src/app/labeling/qgsmaptoolmovelabel.cpp
@@ -22,9 +22,10 @@
 #include "qgsmapmouseevent.h"
 #include "qgisapp.h"
 #include "qgsmessagebar.h"
+#include "qgsadvanceddigitizingdockwidget.h"
 
-QgsMapToolMoveLabel::QgsMapToolMoveLabel( QgsMapCanvas *canvas )
-  : QgsMapToolLabel( canvas )
+QgsMapToolMoveLabel::QgsMapToolMoveLabel( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDock )
+  : QgsMapToolLabel( canvas, cadDock )
 {
   mToolName = tr( "Move label" );
 
@@ -35,13 +36,13 @@ QgsMapToolMoveLabel::QgsMapToolMoveLabel( QgsMapCanvas *canvas )
   mDiagramProperties << QgsDiagramLayerSettings::PositionY;
 }
 
-void QgsMapToolMoveLabel::canvasMoveEvent( QgsMapMouseEvent *e )
+void QgsMapToolMoveLabel::cadCanvasMoveEvent( QgsMapMouseEvent *e )
 {
   if ( mLabelRubberBand )
   {
-    QgsPointXY pointCanvasCoords = toMapCoordinates( e->pos() );
-    double offsetX = pointCanvasCoords.x() - mStartPointMapCoords.x();
-    double offsetY = pointCanvasCoords.y() - mStartPointMapCoords.y();
+    QgsPointXY pointMapCoords = e->mapPoint();
+    double offsetX = pointMapCoords.x() - mStartPointMapCoords.x();
+    double offsetY = pointMapCoords.y() - mStartPointMapCoords.y();
     mLabelRubberBand->setTranslationOffset( offsetX, offsetY );
     mLabelRubberBand->updatePosition();
     mLabelRubberBand->update();
@@ -51,7 +52,7 @@ void QgsMapToolMoveLabel::canvasMoveEvent( QgsMapMouseEvent *e )
   }
 }
 
-void QgsMapToolMoveLabel::canvasPressEvent( QgsMapMouseEvent *e )
+void QgsMapToolMoveLabel::cadCanvasPressEvent( QgsMapMouseEvent *e )
 {
   if ( !mLabelRubberBand )
   {
@@ -122,7 +123,7 @@ void QgsMapToolMoveLabel::canvasPressEvent( QgsMapMouseEvent *e )
         }
       }
 
-      mStartPointMapCoords = toMapCoordinates( e->pos() );
+      mStartPointMapCoords = e->mapPoint();
       QgsPointXY referencePoint;
       if ( !currentLabelRotationPoint( referencePoint, !currentLabelPreserveRotation(), false ) )
       {
@@ -155,7 +156,7 @@ void QgsMapToolMoveLabel::canvasPressEvent( QgsMapMouseEvent *e )
           return;
         }
 
-        QgsPointXY releaseCoords = toMapCoordinates( e->pos() );
+        QgsPointXY releaseCoords = e->mapPoint();
         double xdiff = releaseCoords.x() - mStartPointMapCoords.x();
         double ydiff = releaseCoords.y() - mStartPointMapCoords.y();
 
@@ -238,6 +239,15 @@ void QgsMapToolMoveLabel::canvasPressEvent( QgsMapMouseEvent *e )
       default:
         break;
     }
+  }
+}
+
+void QgsMapToolMoveLabel::cadCanvasReleaseEvent( QgsMapMouseEvent * )
+{
+  if ( !mLabelRubberBand )
+  {
+    // this tool doesn't collect points -- we want the angle constraints to be reset whenever we drop a label
+    cadDockWidget()->clearPoints();
   }
 }
 

--- a/src/app/labeling/qgsmaptoolmovelabel.h
+++ b/src/app/labeling/qgsmaptoolmovelabel.h
@@ -27,10 +27,11 @@ class APP_EXPORT QgsMapToolMoveLabel: public QgsMapToolLabel
     Q_OBJECT
 
   public:
-    QgsMapToolMoveLabel( QgsMapCanvas *canvas );
+    QgsMapToolMoveLabel( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDock );
 
-    void canvasMoveEvent( QgsMapMouseEvent *e ) override;
-    void canvasPressEvent( QgsMapMouseEvent *e ) override;
+    void cadCanvasMoveEvent( QgsMapMouseEvent *e ) override;
+    void cadCanvasPressEvent( QgsMapMouseEvent *e ) override;
+    void cadCanvasReleaseEvent( QgsMapMouseEvent *e ) override;
     void keyReleaseEvent( QKeyEvent *e ) override;
 
   protected:

--- a/src/app/labeling/qgsmaptoolpinlabels.cpp
+++ b/src/app/labeling/qgsmaptoolpinlabels.cpp
@@ -28,8 +28,8 @@
 #include "qgslogger.h"
 
 
-QgsMapToolPinLabels::QgsMapToolPinLabels( QgsMapCanvas *canvas )
-  : QgsMapToolLabel( canvas )
+QgsMapToolPinLabels::QgsMapToolPinLabels( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDock )
+  : QgsMapToolLabel( canvas, cadDock )
   , mDragging( false )
   , mShowPinned( false )
 

--- a/src/app/labeling/qgsmaptoolpinlabels.h
+++ b/src/app/labeling/qgsmaptoolpinlabels.h
@@ -30,7 +30,7 @@ class APP_EXPORT QgsMapToolPinLabels: public QgsMapToolLabel
     Q_OBJECT
 
   public:
-    QgsMapToolPinLabels( QgsMapCanvas *canvas );
+    QgsMapToolPinLabels( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDock );
     ~QgsMapToolPinLabels() override;
 
     //! Overridden mouse move event

--- a/src/app/labeling/qgsmaptoolrotatelabel.cpp
+++ b/src/app/labeling/qgsmaptoolrotatelabel.cpp
@@ -27,8 +27,8 @@
 #include "qgsmessagebar.h"
 #include "qgsapplication.h"
 
-QgsMapToolRotateLabel::QgsMapToolRotateLabel( QgsMapCanvas *canvas )
-  : QgsMapToolLabel( canvas )
+QgsMapToolRotateLabel::QgsMapToolRotateLabel( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDock )
+  : QgsMapToolLabel( canvas, cadDock )
   , mStartRotation( 0.0 )
   , mCurrentRotation( 0.0 )
   , mCurrentMouseAzimuth( 0.0 )

--- a/src/app/labeling/qgsmaptoolrotatelabel.h
+++ b/src/app/labeling/qgsmaptoolrotatelabel.h
@@ -27,7 +27,7 @@ class APP_EXPORT QgsMapToolRotateLabel: public QgsMapToolLabel
     Q_OBJECT
 
   public:
-    QgsMapToolRotateLabel( QgsMapCanvas *canvas );
+    QgsMapToolRotateLabel( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDock );
     ~QgsMapToolRotateLabel() override;
 
     void canvasMoveEvent( QgsMapMouseEvent *e ) override;

--- a/src/app/labeling/qgsmaptoolshowhidelabels.cpp
+++ b/src/app/labeling/qgsmaptoolshowhidelabels.cpp
@@ -28,8 +28,8 @@
 #include "qgslogger.h"
 
 
-QgsMapToolShowHideLabels::QgsMapToolShowHideLabels( QgsMapCanvas *canvas )
-  : QgsMapToolLabel( canvas )
+QgsMapToolShowHideLabels::QgsMapToolShowHideLabels( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDock )
+  : QgsMapToolLabel( canvas, cadDock )
   , mDragging( false )
 {
   mToolName = tr( "Show/hide labels" );

--- a/src/app/labeling/qgsmaptoolshowhidelabels.h
+++ b/src/app/labeling/qgsmaptoolshowhidelabels.h
@@ -29,7 +29,7 @@ class APP_EXPORT QgsMapToolShowHideLabels : public QgsMapToolLabel
     Q_OBJECT
 
   public:
-    QgsMapToolShowHideLabels( QgsMapCanvas *canvas );
+    QgsMapToolShowHideLabels( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDock );
     ~QgsMapToolShowHideLabels() override;
 
     //! Overridden mouse move event

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4433,16 +4433,16 @@ void QgisApp::createCanvasTools()
   mMapTools.mTrimExtendFeature = new QgsMapToolTrimExtendFeature( mMapCanvas );
   mMapTools.mTrimExtendFeature->setAction( mActionTrimExtendFeature );
 
-  mMapTools.mPinLabels = new QgsMapToolPinLabels( mMapCanvas );
+  mMapTools.mPinLabels = new QgsMapToolPinLabels( mMapCanvas, mAdvancedDigitizingDockWidget );
   mMapTools.mPinLabels->setAction( mActionPinLabels );
-  mMapTools.mShowHideLabels = new QgsMapToolShowHideLabels( mMapCanvas );
+  mMapTools.mShowHideLabels = new QgsMapToolShowHideLabels( mMapCanvas, mAdvancedDigitizingDockWidget );
   mMapTools.mShowHideLabels->setAction( mActionShowHideLabels );
-  mMapTools.mMoveLabel = new QgsMapToolMoveLabel( mMapCanvas );
+  mMapTools.mMoveLabel = new QgsMapToolMoveLabel( mMapCanvas, mAdvancedDigitizingDockWidget );
   mMapTools.mMoveLabel->setAction( mActionMoveLabel );
 
-  mMapTools.mRotateLabel = new QgsMapToolRotateLabel( mMapCanvas );
+  mMapTools.mRotateLabel = new QgsMapToolRotateLabel( mMapCanvas, mAdvancedDigitizingDockWidget );
   mMapTools.mRotateLabel->setAction( mActionRotateLabel );
-  mMapTools.mChangeLabelProperties = new QgsMapToolChangeLabelProperties( mMapCanvas );
+  mMapTools.mChangeLabelProperties = new QgsMapToolChangeLabelProperties( mMapCanvas, mAdvancedDigitizingDockWidget );
   mMapTools.mChangeLabelProperties->setAction( mActionChangeLabelProperties );
 //ensure that non edit tool is initialized or we will get crashes in some situations
   mNonEditMapTool = mMapTools.mPan;

--- a/tests/src/app/testqgsmaptoollabel.cpp
+++ b/tests/src/app/testqgsmaptoollabel.cpp
@@ -27,6 +27,7 @@
 #include "qgsfontutils.h"
 #include "qgsvectorlayerlabelprovider.h"
 #include "qgsvectorlayerlabeling.h"
+#include "qgsadvanceddigitizingdockwidget.h"
 
 class TestQgsMapToolLabel : public QObject
 {
@@ -78,6 +79,7 @@ class TestQgsMapToolLabel : public QObject
       std::unique_ptr< QgsMapCanvas > canvas = qgis::make_unique< QgsMapCanvas >();
       canvas->setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3946" ) ) );
       canvas->setLayers( QList<QgsMapLayer *>() << vl1.get() << vl2.get() );
+      std::unique_ptr< QgsAdvancedDigitizingDockWidget > advancedDigitizingDockWidget = qgis::make_unique< QgsAdvancedDigitizingDockWidget >( canvas.get() );
 
       QgsMapSettings mapSettings;
       mapSettings.setOutputSize( QSize( 500, 500 ) );
@@ -94,7 +96,7 @@ class TestQgsMapToolLabel : public QObject
       QCOMPARE( canvas->mapSettings().outputSize(), QSize( 500, 500 ) );
       QCOMPARE( canvas->mapSettings().visibleExtent(), QgsRectangle( -1, -1, 4, 4 ) );
 
-      std::unique_ptr< QgsMapToolLabel > tool( new QgsMapToolLabel( canvas.get() ) );
+      std::unique_ptr< QgsMapToolLabel > tool( new QgsMapToolLabel( canvas.get(), advancedDigitizingDockWidget.get() ) );
 
       // no labels yet
       QgsPointXY pt;
@@ -241,6 +243,7 @@ class TestQgsMapToolLabel : public QObject
       std::unique_ptr< QgsMapCanvas > canvas = qgis::make_unique< QgsMapCanvas >();
       canvas->setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3946" ) ) );
       canvas->setLayers( QList<QgsMapLayer *>() << vl1 );
+      std::unique_ptr< QgsAdvancedDigitizingDockWidget > advancedDigitizingDockWidget = qgis::make_unique< QgsAdvancedDigitizingDockWidget >( canvas.get() );
 
       QgsMapSettings mapSettings;
       mapSettings.setOutputSize( QSize( 500, 500 ) );
@@ -257,7 +260,7 @@ class TestQgsMapToolLabel : public QObject
       QCOMPARE( canvas->mapSettings().outputSize(), QSize( 500, 500 ) );
       QCOMPARE( canvas->mapSettings().visibleExtent(), QgsRectangle( -1, -1, 4, 4 ) );
 
-      std::unique_ptr< QgsMapToolLabel > tool( new QgsMapToolLabel( canvas.get() ) );
+      std::unique_ptr< QgsMapToolLabel > tool( new QgsMapToolLabel( canvas.get(), advancedDigitizingDockWidget.get() ) );
 
       // add some labels
       QgsPalLayerSettings pls1;


### PR DESCRIPTION
So that CAD dock constraints are applied while moving labels.

Among other benefits, it makes it easy to move labels in a purely vertical or horizontal direction. I seriously struggled trying to do this on a map yesterday, and this is a super-easy solution to it...

![Peek 2021-02-10 09-44](https://user-images.githubusercontent.com/1829991/107443446-95eb1a00-6b84-11eb-82f7-430302377354.gif)