### PR TITLE
Don't clear the x and y values in the CAD canvas dock immediately after a mouse click

### DIFF
--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -364,6 +364,19 @@ void QgsAdvancedDigitizingDockWidget::releaseLocks( bool releaseRepeatingLocks )
     mYConstraint->setLockMode( CadConstraint::NoLock );
     emit lockYChanged( false );
   }
+
+  if ( !mCadPointList.empty() )
+  {
+    if ( !mXConstraint->isLocked() && !mXConstraint->relative() )
+    {
+      mXConstraint->setValue( mCadPointList.constLast().x(), true );
+    }
+    if ( !mYConstraint->isLocked() && !mYConstraint->relative() )
+    {
+      mYConstraint->setValue( mCadPointList.constLast().y(), true );
+    }
+  }
+
 }
 
 #if 0


### PR DESCRIPTION
Otherwise the only way to see these is by moving the mouse a tiny bit,
which changes the values.
