### PR TITLE
Fix `QComboBox::currentIndexChanged()` warnings

### DIFF
--- a/src/gui/qgsnewvectortabledialog.cpp
+++ b/src/gui/qgsnewvectortabledialog.cpp
@@ -88,7 +88,7 @@ QgsNewVectorTableDialog::QgsNewVectorTableDialog( QgsAbstractDatabaseProviderCon
   if ( mConnection->capabilities().testFlag( QgsAbstractDatabaseProviderConnection::Capability::Schemas ) )
   {
     mSchemaCbo->addItems( mConnection->schemas() );
-    connect( mSchemaCbo, qgis::overload<const QString &>::of( &QComboBox::currentIndexChanged ), this, [ = ]( const QString & schema )
+    connect( mSchemaCbo, &QComboBox::currentTextChanged, this, [ = ]( const QString &schema )
     {
       updateTableNames( schema );
     } );

--- a/src/gui/qgsnewvectortabledialog.cpp
+++ b/src/gui/qgsnewvectortabledialog.cpp
@@ -88,7 +88,7 @@ QgsNewVectorTableDialog::QgsNewVectorTableDialog( QgsAbstractDatabaseProviderCon
   if ( mConnection->capabilities().testFlag( QgsAbstractDatabaseProviderConnection::Capability::Schemas ) )
   {
     mSchemaCbo->addItems( mConnection->schemas() );
-    connect( mSchemaCbo, &QComboBox::currentTextChanged, this, [ = ]( const QString &schema )
+    connect( mSchemaCbo, &QComboBox::currentTextChanged, this, [ = ]( const QString & schema )
     {
       updateTableNames( schema );
     } );

--- a/src/providers/hana/qgshanasourceselect.cpp
+++ b/src/providers/hana/qgshanasourceselect.cpp
@@ -30,6 +30,7 @@
 #include "qgsvectorlayer.h"
 #include "qgssettings.h"
 
+#include <QComboBox>
 #include <QFileDialog>
 #include <QHeaderView>
 #include <QInputDialog>
@@ -211,10 +212,8 @@ QgsHanaSourceSelect::QgsHanaSourceSelect(
   connect( btnLoad, &QPushButton::clicked, this, &QgsHanaSourceSelect::btnLoad_clicked );
   connect( mSearchGroupBox, &QGroupBox::toggled, this, &QgsHanaSourceSelect::mSearchGroupBox_toggled );
   connect( mSearchTableEdit, &QLineEdit::textChanged, this, &QgsHanaSourceSelect::mSearchTableEdit_textChanged );
-  connect( mSearchColumnComboBox, static_cast<void ( QComboBox::* )( const QString & )>( &QComboBox::currentIndexChanged ),
-           this, &QgsHanaSourceSelect::mSearchColumnComboBox_currentIndexChanged );
-  connect( mSearchModeComboBox, static_cast<void ( QComboBox::* )( const QString & )>( &QComboBox::currentIndexChanged ),
-           this, &QgsHanaSourceSelect::mSearchModeComboBox_currentIndexChanged );
+  connect( mSearchColumnComboBox, &QComboBox::currentTextChanged, this, &QgsHanaSourceSelect::mSearchColumnComboBox_currentTextChanged );
+  connect( mSearchModeComboBox, &QComboBox::currentTextChanged, this, &QgsHanaSourceSelect::mSearchModeComboBox_currentTextChanged );
   connect( cmbConnections, static_cast<void ( QComboBox::* )( int )>( &QComboBox::activated ),
            this, &QgsHanaSourceSelect::cmbConnections_activated );
   connect( mTablesTreeView, &QTreeView::clicked, this, &QgsHanaSourceSelect::mTablesTreeView_clicked );
@@ -412,7 +411,7 @@ void QgsHanaSourceSelect::mSearchTableEdit_textChanged( const QString &text )
     mProxyModel._setFilterRegExp( text );
 }
 
-void QgsHanaSourceSelect::mSearchColumnComboBox_currentIndexChanged( const QString &text )
+void QgsHanaSourceSelect::mSearchColumnComboBox_currentTextChanged( const QString &text )
 {
   if ( text == tr( "All" ) )
   {
@@ -452,7 +451,7 @@ void QgsHanaSourceSelect::mSearchColumnComboBox_currentIndexChanged( const QStri
   }
 }
 
-void QgsHanaSourceSelect::mSearchModeComboBox_currentIndexChanged( const QString &text )
+void QgsHanaSourceSelect::mSearchModeComboBox_currentTextChanged( const QString &text )
 {
   Q_UNUSED( text );
   mSearchTableEdit_textChanged( mSearchTableEdit->text() );

--- a/src/providers/hana/qgshanasourceselect.h
+++ b/src/providers/hana/qgshanasourceselect.h
@@ -116,8 +116,8 @@ class QgsHanaSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsD
     void btnLoad_clicked();
     void mSearchGroupBox_toggled( bool );
     void mSearchTableEdit_textChanged( const QString &text );
-    void mSearchColumnComboBox_currentIndexChanged( const QString &text );
-    void mSearchModeComboBox_currentIndexChanged( const QString &text );
+    void mSearchColumnComboBox_currentTextChanged( const QString &text );
+    void mSearchModeComboBox_currentTextChanged( const QString &text );
     void setSql( const QModelIndex &index );
     //! Store the selected database
     void cmbConnections_activated( int );


### PR DESCRIPTION
Use `QComboBox::currentTextChanged()` instead of deprecated `QComboBox::currentIndexChanged( const QString & )`.

