### PR TITLE
Adds a critical message if GDAL is not built with GPKG support

### DIFF
--- a/src/app/dwg/qgsdwgimportdialog.cpp
+++ b/src/app/dwg/qgsdwgimportdialog.cpp
@@ -88,6 +88,11 @@ QgsDwgImportDialog::QgsDwgImportDialog( QWidget *parent, Qt::WindowFlags f )
   mCrsSelector->setMessage( tr( "Select the coordinate reference system for the dxf file. "
                                 "The data points will be transformed from the layer coordinate reference system." ) );
 
+
+  if ( ! QgsVectorFileWriter::supportedFormatExtensions().contains( QStringLiteral( "gpkg" ) ) )
+  {
+    bar->pushMessage( tr( "GDAL/OGR not built with GPKG (sqlite3) support. You will not be able to export the DWG in a GPKG." ), Qgis::Critical );
+  }
   pbLoadDatabase_clicked();
   updateUI();
 }


### PR DESCRIPTION
## Description
The GPKG format is not built by default by GDAL/OGR since it requires a SQLITE dependency and can be disabled at build time.

The DWG import tool requires the GPKG driver to be supported. Rather than disabling the tool, I prefer a message like the one below when opening the dialog widget.

![import_dwg_without_gpkg_driver](https://user-images.githubusercontent.com/7521540/107530511-3dd00a00-6bbc-11eb-90c4-cba7b020de68.png)
