### PR TITLE
qgsdualview was not initiated with attributes config

### DIFF
--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -124,6 +124,7 @@ void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const Qg
     return;
 
   mLayer = layer;
+  mConfig.update( mLayer->fields() );
   mEditorContext = context;
 
   initLayerCache( !( request.flags() & QgsFeatureRequest::NoGeometry ) || !request.filterRect().isNull() );


### PR DESCRIPTION
## Description

Bug described by @jdugge #39523 and @jonnyforestGIS  #37252

Hide and Resize column actions don't work in the qgsdualview

![Peek 2020-06-16 20-59](https://user-images.githubusercontent.com/2399255/84816205-6ba48500-b014-11ea-9453-db06ccd34ac3.gif)

It's because the QgsDualView::init function doesn't initiate mConfig attribute from the layer fields. It is only possible to use this actions after using the organizeColumns action, because mConfig is updated with the QgsOrganizeTableColumnsDialog config.

To fix it, I wrote the following line in the QgsDualView::init function to initiate mConfig :

```cpp
 mConfig.update( mLayer->fields() );
```