### PR TITLE
Vector tiles: fix crash in gsMapBoxGlStyleConverter::parseFillLayer()…

### DIFF
--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -309,8 +309,9 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
     }
   }
 
-  std::unique_ptr< QgsSymbol > symbol( QgsSymbol::defaultSymbol( QgsWkbTypes::PolygonGeometry ) );
+  std::unique_ptr< QgsSymbol > symbol( qgis::make_unique< QgsFillSymbol >() );
   QgsSimpleFillSymbolLayer *fillSymbol = dynamic_cast< QgsSimpleFillSymbolLayer * >( symbol->symbolLayer( 0 ) );
+  Q_ASSERT( fillSymbol ); // should not fail since QgsFillSymbol() constructor instantiates a QgsSimpleFillSymbolLayer
 
   // set render units
   symbol->setOutputUnit( context.targetUnit() );
@@ -588,8 +589,9 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
     }
   }
 
-  std::unique_ptr< QgsSymbol > symbol( QgsSymbol::defaultSymbol( QgsWkbTypes::LineGeometry ) );
+  std::unique_ptr< QgsSymbol > symbol( qgis::make_unique< QgsLineSymbol >() );
   QgsSimpleLineSymbolLayer *lineSymbol = dynamic_cast< QgsSimpleLineSymbolLayer * >( symbol->symbolLayer( 0 ) );
+  Q_ASSERT( lineSymbol ); // should not fail since QgsLineSymbol() constructor instantiates a QgsSimpleLineSymbolLayer
 
   // set render units
   symbol->setOutputUnit( context.targetUnit() );


### PR DESCRIPTION
… (fixes #41401)

and also a potential similar one in parseLineLayer()
    
Use default QgsFillSymbol and QgsLineSymbol objects, instead of the default symbols
of the project that might lack a QgsSimpleFillSymbolLayer / QgsSimpleLineSymbolLayer.