### PR TITLE
QGIS expressions are not sensitive to the case of field names

### DIFF
--- a/src/core/qgssqlexpressioncompiler.cpp
+++ b/src/core/qgssqlexpressioncompiler.cpp
@@ -325,11 +325,14 @@ QgsSqlExpressionCompiler::Result QgsSqlExpressionCompiler::compileNode( const Qg
     {
       const QgsExpressionNodeColumnRef *n = static_cast<const QgsExpressionNodeColumnRef *>( node );
 
-      if ( mFields.indexFromName( n->name() ) == -1 )
+      // QGIS expressions don't care about case sensitive field naming, so we match case insensitively here to the
+      // layer's fields and then retrieve the actual case of the field name for use in the compilation
+      const int fieldIndex = mFields.lookupField( n->name() );
+      if ( fieldIndex == -1 )
         // Not a provider field
         return Fail;
 
-      result = quotedIdentifier( n->name() );
+      result = quotedIdentifier( mFields.at( fieldIndex ).name() );
 
       return Complete;
     }

--- a/tests/src/python/featuresourcetestbase.py
+++ b/tests/src/python/featuresourcetestbase.py
@@ -168,6 +168,8 @@ class FeatureSourceTestCase(object):
         self.assert_query(source, '"name" NOT ILIKE \'QGIS\'', [1, 2, 3, 4])
         self.assert_query(source, '"name" NOT ILIKE \'pEAR\'', [1, 2, 4])
         self.assert_query(source, 'name = \'Apple\'', [2])
+        # field names themselves are NOT case sensitive -- QGIS expressions don't care about this
+        self.assert_query(source, '\"NaMe\" = \'Apple\'', [2])
         self.assert_query(source, 'name <> \'Apple\'', [1, 3, 4])
         self.assert_query(source, 'name = \'apple\'', [])
         self.assert_query(source, '"name" <> \'apple\'', [1, 2, 3, 4])

--- a/tests/src/python/test_provider_mssql.py
+++ b/tests/src/python/test_provider_mssql.py
@@ -133,6 +133,7 @@ class TestPyQgsMssqlProvider(unittest.TestCase, ProviderTestCase):
         filters = set([
             'name ILIKE \'QGIS\'',
             'name = \'Apple\'',
+            '\"NaMe\" = \'Apple\'',
             'name = \'apple\'',
             'name LIKE \'Apple\'',
             'name LIKE \'aPple\'',

--- a/tests/src/python/test_provider_shapefile.py
+++ b/tests/src/python/test_provider_shapefile.py
@@ -229,6 +229,7 @@ class TestPyQgsShapefileProvider(unittest.TestCase, ProviderTestCase):
     def partiallyCompiledFilters(self):
         return set(['name = \'Apple\'',
                     'name = \'apple\'',
+                    '\"NaMe\" = \'Apple\'',
                     'name LIKE \'Apple\'',
                     'name LIKE \'aPple\'',
                     'name LIKE \'Ap_le\'',


### PR DESCRIPTION
..so mimic this same insensitivity when compiling expressions for providers

Avoids the expression compilation failing whenever a referenced field in an expression does not exactly match the layer's field
name case, causing super-slow client side iteration of all features.
