### PR TITLE
Atlas scope variables are all static

### DIFF
--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -650,18 +650,18 @@ QgsExpressionContextScope *QgsExpressionContextUtils::atlasScope( const QgsLayou
   {
     //add some dummy atlas variables. This is done so that as in certain contexts we want to show
     //users that these variables are available even if they have no current value
-    scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "atlas_pagename" ), QString(), true ) );
-    scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "atlas_feature" ), QVariant::fromValue( QgsFeature() ), true ) );
-    scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "atlas_featureid" ), QVariant(), true ) );
-    scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "atlas_geometry" ), QVariant::fromValue( QgsGeometry() ), true ) );
+    scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "atlas_pagename" ), QString(), true, true ) );
+    scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "atlas_feature" ), QVariant::fromValue( QgsFeature() ), true, true ) );
+    scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "atlas_featureid" ), QVariant(), true, true ) );
+    scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "atlas_geometry" ), QVariant::fromValue( QgsGeometry() ), true, true ) );
     return scope;
   }
 
   //add known atlas variables
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "atlas_totalfeatures" ), atlas->count(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "atlas_featurenumber" ), atlas->currentFeatureNumber() + 1, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "atlas_filename" ), atlas->currentFilename(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "atlas_pagename" ), atlas->nameForPage( atlas->currentFeatureNumber() ), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "atlas_totalfeatures" ), atlas->count(), true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "atlas_featurenumber" ), atlas->currentFeatureNumber() + 1, true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "atlas_filename" ), atlas->currentFilename(), true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "atlas_pagename" ), atlas->nameForPage( atlas->currentFeatureNumber() ), true, true ) );
 
   if ( atlas->enabled() && atlas->coverageLayer() )
   {

--- a/src/core/layout/qgslayoutatlas.cpp
+++ b/src/core/layout/qgslayoutatlas.cpp
@@ -536,17 +536,17 @@ bool QgsLayoutAtlas::updateFilenameExpression( QString &error )
 
   if ( !mFilenameExpressionString.isEmpty() )
   {
-    mFilenameExpression = QgsExpression( mFilenameExpressionString );
+    QgsExpression filenameExpression( mFilenameExpressionString );
     // expression used to evaluate each filename
     // test for evaluation errors
-    if ( mFilenameExpression.hasParserError() )
+    if ( filenameExpression.hasParserError() )
     {
-      error = mFilenameExpression.parserErrorString();
+      error = filenameExpression.parserErrorString();
       return false;
     }
 
     // prepare the filename expression
-    evalResult = mFilenameExpression.prepare( &expressionContext );
+    evalResult = filenameExpression.prepare( &expressionContext );
   }
 
   // regenerate current filename
@@ -557,7 +557,7 @@ bool QgsLayoutAtlas::updateFilenameExpression( QString &error )
 
   if ( ! evalResult )
   {
-    error = mFilenameExpression.evalErrorString();
+    error = mFilenameExpressionError;
   }
 
   return evalResult;
@@ -566,12 +566,16 @@ bool QgsLayoutAtlas::updateFilenameExpression( QString &error )
 bool QgsLayoutAtlas::evalFeatureFilename( const QgsExpressionContext &context )
 {
   //generate filename for current atlas feature
-  if ( !mFilenameExpressionString.isEmpty() && mFilenameExpression.isValid() )
+  mFilenameExpressionError.clear();
+  if ( !mFilenameExpressionString.isEmpty() )
   {
-    QVariant filenameRes = mFilenameExpression.evaluate( &context );
-    if ( mFilenameExpression.hasEvalError() )
+    QgsExpression filenameExpression( mFilenameExpressionString );
+    filenameExpression.prepare( &context );
+    QVariant filenameRes = filenameExpression.evaluate( &context );
+    if ( filenameExpression.hasEvalError() )
     {
-      QgsMessageLog::logMessage( tr( "Atlas filename evaluation error: %1" ).arg( mFilenameExpression.evalErrorString() ), tr( "Layout" ) );
+      mFilenameExpressionError = filenameExpression.evalErrorString();
+      QgsMessageLog::logMessage( tr( "Atlas filename evaluation error: %1" ).arg( filenameExpression.evalErrorString() ), tr( "Layout" ) );
       return false;
     }
 

--- a/src/core/layout/qgslayoutatlas.h
+++ b/src/core/layout/qgslayoutatlas.h
@@ -366,8 +366,8 @@ class CORE_EXPORT QgsLayoutAtlas : public QObject, public QgsAbstractLayoutItera
     bool mEnabled = false;
     bool mHideCoverage = false;
     QString mFilenameExpressionString;
+    QString mFilenameExpressionError;
 
-    QgsExpression mFilenameExpression;
     QgsVectorLayerRef mCoverageLayer;
 
     QString mCurrentFilename;


### PR DESCRIPTION
These won't be changed in the lifetime of the scope, which will
only ever be used for a single atlas feature only

Marking them as static means that the expression preparation
of atlas related expressions can replace any use of @atlas* vars
with static precalculated nodes, resulting in a nice performance
boost when working with complex atlas setups.
