### PR TITLE
Respect static precalculated nodes during expression filter compilation

### DIFF
--- a/python/core/auto_generated/expression/qgsexpressionnode.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressionnode.sip.in
@@ -242,6 +242,24 @@ work like for example resolving a column name to an attribute index.
 
     int parserLastColumn;
 
+    bool hasCachedStaticValue() const;
+%Docstring
+Returns ``True`` if the node can be replaced by a static cached value.
+
+.. seealso:: :py:func:`cachedStaticValue`
+
+.. versionadded:: 3.18
+%End
+
+    QVariant cachedStaticValue() const;
+%Docstring
+Returns the node's static cached value. Only valid if :py:func:`~QgsExpressionNode.hasCachedStaticValue` is ``True``.
+
+.. seealso:: :py:func:`hasCachedStaticValue`
+
+.. versionadded:: 3.18
+%End
+
   protected:
 
 

--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -63,7 +63,8 @@ Examples:
       NoFlags,
       NoGeometry,
       SubsetOfAttributes,
-      ExactIntersect
+      ExactIntersect,
+      IgnoreStaticNodesDuringExpressionCompilation,
     };
     typedef QFlags<QgsFeatureRequest::Flag> Flags;
 

--- a/src/core/expression/qgsexpressionnode.h
+++ b/src/core/expression/qgsexpressionnode.h
@@ -299,6 +299,22 @@ class CORE_EXPORT QgsExpressionNode SIP_ABSTRACT
      */
     int parserLastColumn = 0;
 
+    /**
+     * Returns TRUE if the node can be replaced by a static cached value.
+     *
+     * \see cachedStaticValue()
+     * \since QGIS 3.18
+     */
+    bool hasCachedStaticValue() const { return mHasCachedValue; }
+
+    /**
+     * Returns the node's static cached value. Only valid if hasCachedStaticValue() is TRUE.
+     *
+     * \see hasCachedStaticValue()
+     * \since QGIS 3.18
+     */
+    QVariant cachedStaticValue() const { return mCachedStaticValue; }
+
   protected:
 
     /**

--- a/src/core/providers/ogr/qgsogrexpressioncompiler.cpp
+++ b/src/core/providers/ogr/qgsogrexpressioncompiler.cpp
@@ -19,9 +19,9 @@
 #include "qgsexpressionnodeimpl.h"
 #include "qgsogrprovider.h"
 
-QgsOgrExpressionCompiler::QgsOgrExpressionCompiler( QgsOgrFeatureSource *source )
+QgsOgrExpressionCompiler::QgsOgrExpressionCompiler( QgsOgrFeatureSource *source, bool ignoreStaticNodes )
   : QgsSqlExpressionCompiler( source->mFields, QgsSqlExpressionCompiler::CaseInsensitiveStringMatch | QgsSqlExpressionCompiler::NoNullInBooleanLogic
-                              | QgsSqlExpressionCompiler::NoUnaryMinus | QgsSqlExpressionCompiler::IntegerDivisionResultsInInteger )
+                              | QgsSqlExpressionCompiler::NoUnaryMinus | QgsSqlExpressionCompiler::IntegerDivisionResultsInInteger, ignoreStaticNodes )
   , mSource( source )
 {
 }
@@ -50,6 +50,10 @@ QgsSqlExpressionCompiler::Result QgsOgrExpressionCompiler::compile( const QgsExp
 
 QgsSqlExpressionCompiler::Result QgsOgrExpressionCompiler::compileNode( const QgsExpressionNode *node, QString &result )
 {
+  QgsSqlExpressionCompiler::Result staticRes = replaceNodeByStaticCachedValueIfPossible( node, result );
+  if ( staticRes != Fail )
+    return staticRes;
+
   switch ( node->nodeType() )
   {
     case QgsExpressionNode::ntBinaryOperator:

--- a/src/core/providers/ogr/qgsogrexpressioncompiler.h
+++ b/src/core/providers/ogr/qgsogrexpressioncompiler.h
@@ -30,7 +30,7 @@ class QgsOgrExpressionCompiler : public QgsSqlExpressionCompiler
 {
   public:
 
-    explicit QgsOgrExpressionCompiler( QgsOgrFeatureSource *source );
+    explicit QgsOgrExpressionCompiler( QgsOgrFeatureSource *source, bool ignoreStaticNodes = false );
 
     Result compile( const QgsExpression *exp ) override;
 

--- a/src/core/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/core/providers/ogr/qgsogrfeatureiterator.cpp
@@ -201,11 +201,11 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
     QgsSqlExpressionCompiler *compiler = nullptr;
     if ( source->mDriverName == QLatin1String( "SQLite" ) || source->mDriverName == QLatin1String( "GPKG" ) )
     {
-      compiler = new QgsSQLiteExpressionCompiler( source->mFields );
+      compiler = new QgsSQLiteExpressionCompiler( source->mFields, request.flags() & QgsFeatureRequest::IgnoreStaticNodesDuringExpressionCompilation );
     }
     else
     {
-      compiler = new QgsOgrExpressionCompiler( source );
+      compiler = new QgsOgrExpressionCompiler( source, request.flags() & QgsFeatureRequest::IgnoreStaticNodesDuringExpressionCompilation );
     }
 
     QgsSqlExpressionCompiler::Result result = compiler->compile( request.filterExpression() );

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -80,7 +80,8 @@ class CORE_EXPORT QgsFeatureRequest
       NoFlags            = 0,
       NoGeometry         = 1,  //!< Geometry is not required. It may still be returned if e.g. required for a filter condition.
       SubsetOfAttributes = 2,  //!< Fetch only a subset of attributes (setSubsetOfAttributes sets this flag)
-      ExactIntersect     = 4   //!< Use exact geometry intersection (slower) instead of bounding boxes
+      ExactIntersect     = 4,   //!< Use exact geometry intersection (slower) instead of bounding boxes
+      IgnoreStaticNodesDuringExpressionCompilation = 8, //!< If a feature request uses a filter expression which can be partially precalculated due to static nodes in the expression, setting this flag will prevent these precalculated values from being utilized during compilation of the filter for the backend provider. This flag significantly slows down feature requests and should be used for debugging purposes only. (Since QGIS 3.18)
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 

--- a/src/core/qgssqlexpressioncompiler.h
+++ b/src/core/qgssqlexpressioncompiler.h
@@ -67,8 +67,11 @@ class CORE_EXPORT QgsSqlExpressionCompiler
      * Constructor for expression compiler.
      * \param fields fields from provider
      * \param flags flags which control how expression is compiled
+     * \param ignoreStaticNodes If an expression has been partially precalculated due to static nodes in the expression, setting this argument to FALSE
+     * will prevent these precalculated values from being utilized during compilation of the expression. This flag significantly limits the effectiveness
+     * of compilation and should be used for debugging purposes only. (Since QGIS 3.18)
      */
-    explicit QgsSqlExpressionCompiler( const QgsFields &fields, QgsSqlExpressionCompiler::Flags flags = Flags() );
+    explicit QgsSqlExpressionCompiler( const QgsFields &fields, QgsSqlExpressionCompiler::Flags flags = Flags(), bool ignoreStaticNodes = false );
     virtual ~QgsSqlExpressionCompiler() = default;
 
     /**
@@ -173,12 +176,21 @@ class CORE_EXPORT QgsSqlExpressionCompiler
      */
     virtual QString castToInt( const QString &value ) const;
 
+    /**
+     * Tries to replace a node by its static cached value where possible.
+     *
+     * \since QGIS 3.18
+     */
+    virtual Result replaceNodeByStaticCachedValueIfPossible( const QgsExpressionNode *node, QString &str );
+
     QString mResult;
     QgsFields mFields;
 
   private:
 
     Flags mFlags;
+
+    bool mIgnoreStaticNodes = false;
 
     bool nodeIsNullLiteral( const QgsExpressionNode *node ) const;
 

--- a/src/core/qgssqliteexpressioncompiler.cpp
+++ b/src/core/qgssqliteexpressioncompiler.cpp
@@ -22,13 +22,17 @@
 #include "qgsexpression.h"
 #include "qgssqliteutils.h"
 
-QgsSQLiteExpressionCompiler::QgsSQLiteExpressionCompiler( const QgsFields &fields )
-  : QgsSqlExpressionCompiler( fields, QgsSqlExpressionCompiler::LikeIsCaseInsensitive | QgsSqlExpressionCompiler::IntegerDivisionResultsInInteger )
+QgsSQLiteExpressionCompiler::QgsSQLiteExpressionCompiler( const QgsFields &fields, bool ignoreStaticNodes )
+  : QgsSqlExpressionCompiler( fields, QgsSqlExpressionCompiler::LikeIsCaseInsensitive | QgsSqlExpressionCompiler::IntegerDivisionResultsInInteger, ignoreStaticNodes )
 {
 }
 
 QgsSqlExpressionCompiler::Result QgsSQLiteExpressionCompiler::compileNode( const QgsExpressionNode *node, QString &result )
 {
+  QgsSqlExpressionCompiler::Result staticRes = replaceNodeByStaticCachedValueIfPossible( node, result );
+  if ( staticRes != Fail )
+    return staticRes;
+
   switch ( node->nodeType() )
   {
     case QgsExpressionNode::ntBinaryOperator:

--- a/src/core/qgssqliteexpressioncompiler.h
+++ b/src/core/qgssqliteexpressioncompiler.h
@@ -41,8 +41,11 @@ class CORE_EXPORT QgsSQLiteExpressionCompiler : public QgsSqlExpressionCompiler
     /**
      * Constructor for expression compiler.
      * \param fields fields from provider
+     * \param ignoreStaticNodes If an expression has been partially precalculated due to static nodes in the expression, setting this argument to FALSE
+     * will prevent these precalculated values from being utilized during compilation of the expression. This flag significantly limits the effectiveness
+     * of compilation and should be used for debugging purposes only. (Since QGIS 3.18)
      */
-    explicit QgsSQLiteExpressionCompiler( const QgsFields &fields );
+    explicit QgsSQLiteExpressionCompiler( const QgsFields &fields, bool ignoreStaticNodes = false );
 
   protected:
 

--- a/src/providers/db2/qgsdb2expressioncompiler.cpp
+++ b/src/providers/db2/qgsdb2expressioncompiler.cpp
@@ -20,9 +20,8 @@
 #include "qgsexpressionnodeimpl.h"
 #include "qgslogger.h"
 
-QgsDb2ExpressionCompiler::QgsDb2ExpressionCompiler( QgsDb2FeatureSource *source )
-  : QgsSqlExpressionCompiler( source->mFields
-                            )
+QgsDb2ExpressionCompiler::QgsDb2ExpressionCompiler( QgsDb2FeatureSource *source, bool ignoreStaticNodes )
+  : QgsSqlExpressionCompiler( source->mFields, Flags(), ignoreStaticNodes )
 {
 
 }
@@ -54,6 +53,10 @@ QString resultType( QgsSqlExpressionCompiler::Result result )
 
 QgsSqlExpressionCompiler::Result QgsDb2ExpressionCompiler::compileNode( const QgsExpressionNode *node, QString &result )
 {
+  QgsSqlExpressionCompiler::Result staticRes = replaceNodeByStaticCachedValueIfPossible( node, result );
+  if ( staticRes != Fail )
+    return staticRes;
+
   QgsDebugMsg( QStringLiteral( "nodeType: %1" ).arg( nodeType( node ) ) );
   if ( node->nodeType() == QgsExpressionNode::ntColumnRef )
   {

--- a/src/providers/db2/qgsdb2expressioncompiler.h
+++ b/src/providers/db2/qgsdb2expressioncompiler.h
@@ -26,7 +26,7 @@ class QgsDb2ExpressionCompiler : public QgsSqlExpressionCompiler
 {
   public:
 
-    explicit QgsDb2ExpressionCompiler( QgsDb2FeatureSource *source );
+    explicit QgsDb2ExpressionCompiler( QgsDb2FeatureSource *source, bool ignoreStaticNodes = false );
 
   protected:
     Result compileNode( const QgsExpressionNode *node, QString &result ) override;

--- a/src/providers/db2/qgsdb2featureiterator.cpp
+++ b/src/providers/db2/qgsdb2featureiterator.cpp
@@ -191,7 +191,7 @@ void QgsDb2FeatureIterator::BuildStatement( const QgsFeatureRequest &request )
   mCompileStatus = NoCompilation;
   if ( request.filterType() == QgsFeatureRequest::FilterExpression )
   {
-    QgsDb2ExpressionCompiler compiler = QgsDb2ExpressionCompiler( mSource );
+    QgsDb2ExpressionCompiler compiler = QgsDb2ExpressionCompiler( mSource, request.flags() & QgsFeatureRequest::IgnoreStaticNodesDuringExpressionCompilation );
     QgsDebugMsg( "expression dump: " + request.filterExpression()->dump() );
     QgsDebugMsg( "expression expression: " + request.filterExpression()->expression() );
     QgsSqlExpressionCompiler::Result result = compiler.compile( request.filterExpression() );
@@ -232,7 +232,7 @@ void QgsDb2FeatureIterator::BuildStatement( const QgsFeatureRequest &request )
         break;
       }
 
-      QgsDb2ExpressionCompiler compiler = QgsDb2ExpressionCompiler( mSource );
+      QgsDb2ExpressionCompiler compiler = QgsDb2ExpressionCompiler( mSource, request.flags() & QgsFeatureRequest::IgnoreStaticNodesDuringExpressionCompilation );
       QgsExpression expression = clause.expression();
       QgsDebugMsg( "expression: " + expression.dump() );
       if ( compiler.compile( &expression ) == QgsSqlExpressionCompiler::Complete )

--- a/src/providers/hana/qgshanaexpressioncompiler.cpp
+++ b/src/providers/hana/qgshanaexpressioncompiler.cpp
@@ -19,9 +19,9 @@
 #include "qgshanautils.h"
 #include "qgssqlexpressioncompiler.h"
 
-QgsHanaExpressionCompiler::QgsHanaExpressionCompiler( QgsHanaFeatureSource *source )
+QgsHanaExpressionCompiler::QgsHanaExpressionCompiler( QgsHanaFeatureSource *source, bool ignoreStaticNodes )
   : QgsSqlExpressionCompiler( source->mFields, QgsSqlExpressionCompiler::IntegerDivisionResultsInInteger |
-                              QgsSqlExpressionCompiler::NoNullInBooleanLogic )
+                              QgsSqlExpressionCompiler::NoNullInBooleanLogic, ignoreStaticNodes )
   , mGeometryColumn( source->mGeometryColumn )
 {
 }
@@ -90,6 +90,10 @@ QString QgsHanaExpressionCompiler::castToText( const QString &value ) const
 QgsSqlExpressionCompiler::Result QgsHanaExpressionCompiler::compileNode(
   const QgsExpressionNode *node, QString &result )
 {
+  QgsSqlExpressionCompiler::Result staticRes = replaceNodeByStaticCachedValueIfPossible( node, result );
+  if ( staticRes != Fail )
+    return staticRes;
+
   switch ( node->nodeType() )
   {
     case QgsExpressionNode::ntFunction:

--- a/src/providers/hana/qgshanaexpressioncompiler.h
+++ b/src/providers/hana/qgshanaexpressioncompiler.h
@@ -24,7 +24,7 @@
 class QgsHanaExpressionCompiler : public QgsSqlExpressionCompiler
 {
   public:
-    explicit QgsHanaExpressionCompiler( QgsHanaFeatureSource *source );
+    explicit QgsHanaExpressionCompiler( QgsHanaFeatureSource *source, bool ignoreStaticNodes = false );
 
   protected:
     QString quotedIdentifier( const QString &identifier ) override;

--- a/src/providers/hana/qgshanafeatureiterator.cpp
+++ b/src/providers/hana/qgshanafeatureiterator.cpp
@@ -398,7 +398,7 @@ QString QgsHanaFeatureIterator::buildSqlQuery( const QgsFeatureRequest &request 
   {
     if ( QgsSettings().value( QStringLiteral( "qgis/compileExpressions" ), true ).toBool() )
     {
-      QgsHanaExpressionCompiler compiler = QgsHanaExpressionCompiler( mSource );
+      QgsHanaExpressionCompiler compiler = QgsHanaExpressionCompiler( mSource, request.flags() & QgsFeatureRequest::IgnoreStaticNodesDuringExpressionCompilation );
       QgsSqlExpressionCompiler::Result result = compiler.compile( request.filterExpression() );
       switch ( result )
       {

--- a/src/providers/mssql/qgsmssqlexpressioncompiler.cpp
+++ b/src/providers/mssql/qgsmssqlexpressioncompiler.cpp
@@ -16,16 +16,20 @@
 #include "qgsmssqlexpressioncompiler.h"
 #include "qgsexpressionnodeimpl.h"
 
-QgsMssqlExpressionCompiler::QgsMssqlExpressionCompiler( QgsMssqlFeatureSource *source )
+QgsMssqlExpressionCompiler::QgsMssqlExpressionCompiler( QgsMssqlFeatureSource *source, bool ignoreStaticNodes )
   : QgsSqlExpressionCompiler( source->mFields,
                               QgsSqlExpressionCompiler::LikeIsCaseInsensitive |
                               QgsSqlExpressionCompiler::CaseInsensitiveStringMatch |
-                              QgsSqlExpressionCompiler::IntegerDivisionResultsInInteger )
+                              QgsSqlExpressionCompiler::IntegerDivisionResultsInInteger, ignoreStaticNodes )
 {
 }
 
 QgsSqlExpressionCompiler::Result QgsMssqlExpressionCompiler::compileNode( const QgsExpressionNode *node, QString &result )
 {
+  QgsSqlExpressionCompiler::Result staticRes = replaceNodeByStaticCachedValueIfPossible( node, result );
+  if ( staticRes != Fail )
+    return staticRes;
+
   switch ( node->nodeType() )
   {
     case QgsExpressionNode::ntBinaryOperator:

--- a/src/providers/mssql/qgsmssqlexpressioncompiler.h
+++ b/src/providers/mssql/qgsmssqlexpressioncompiler.h
@@ -24,7 +24,7 @@ class QgsMssqlExpressionCompiler : public QgsSqlExpressionCompiler
 {
   public:
 
-    explicit QgsMssqlExpressionCompiler( QgsMssqlFeatureSource *source );
+    explicit QgsMssqlExpressionCompiler( QgsMssqlFeatureSource *source, bool ignoreStaticNodes = false );
 
   protected:
     Result compileNode( const QgsExpressionNode *node, QString &result ) override;

--- a/src/providers/mssql/qgsmssqlfeatureiterator.cpp
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.cpp
@@ -330,7 +330,7 @@ void QgsMssqlFeatureIterator::BuildStatement( const QgsFeatureRequest &request )
   mCompileStatus = NoCompilation;
   if ( request.filterType() == QgsFeatureRequest::FilterExpression )
   {
-    QgsMssqlExpressionCompiler compiler = QgsMssqlExpressionCompiler( mSource );
+    QgsMssqlExpressionCompiler compiler = QgsMssqlExpressionCompiler( mSource, request.flags() & QgsFeatureRequest::IgnoreStaticNodesDuringExpressionCompilation );
     QgsSqlExpressionCompiler::Result result = compiler.compile( request.filterExpression() );
     if ( result == QgsSqlExpressionCompiler::Complete || result == QgsSqlExpressionCompiler::Partial )
     {
@@ -364,7 +364,7 @@ void QgsMssqlFeatureIterator::BuildStatement( const QgsFeatureRequest &request )
       break;
     }
 
-    QgsMssqlExpressionCompiler compiler = QgsMssqlExpressionCompiler( mSource );
+    QgsMssqlExpressionCompiler compiler = QgsMssqlExpressionCompiler( mSource, request.flags() & QgsFeatureRequest::IgnoreStaticNodesDuringExpressionCompilation );
     QgsExpression expression = clause.expression();
     if ( compiler.compile( &expression ) == QgsSqlExpressionCompiler::Complete )
     {

--- a/src/providers/oracle/qgsoracleexpressioncompiler.cpp
+++ b/src/providers/oracle/qgsoracleexpressioncompiler.cpp
@@ -17,13 +17,17 @@
 #include "qgssqlexpressioncompiler.h"
 #include "qgsexpressionnodeimpl.h"
 
-QgsOracleExpressionCompiler::QgsOracleExpressionCompiler( QgsOracleFeatureSource *source )
-  : QgsSqlExpressionCompiler( source->mFields )
+QgsOracleExpressionCompiler::QgsOracleExpressionCompiler( QgsOracleFeatureSource *source, bool ignoreStaticNodes )
+  : QgsSqlExpressionCompiler( source->mFields, Flags(), ignoreStaticNodes )
 {
 }
 
 QgsSqlExpressionCompiler::Result QgsOracleExpressionCompiler::compileNode( const QgsExpressionNode *node, QString &result )
 {
+  QgsSqlExpressionCompiler::Result staticRes = replaceNodeByStaticCachedValueIfPossible( node, result );
+  if ( staticRes != Fail )
+    return staticRes;
+
   switch ( node->nodeType() )
   {
     case QgsExpressionNode::ntBinaryOperator:

--- a/src/providers/oracle/qgsoracleexpressioncompiler.h
+++ b/src/providers/oracle/qgsoracleexpressioncompiler.h
@@ -24,7 +24,7 @@ class QgsOracleExpressionCompiler : public QgsSqlExpressionCompiler
 {
   public:
 
-    explicit QgsOracleExpressionCompiler( QgsOracleFeatureSource *source );
+    explicit QgsOracleExpressionCompiler( QgsOracleFeatureSource *source, bool ignoreStaticNodes = false );
 
   protected:
     Result compileNode( const QgsExpressionNode *node, QString &result ) override;

--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -199,7 +199,7 @@ QgsOracleFeatureIterator::QgsOracleFeatureIterator( QgsOracleFeatureSource *sour
   bool useFallback = false;
   if ( request.filterType() == QgsFeatureRequest::FilterExpression )
   {
-    QgsOracleExpressionCompiler compiler( mSource );
+    QgsOracleExpressionCompiler compiler( mSource, request.flags() & QgsFeatureRequest::IgnoreStaticNodesDuringExpressionCompilation );
     QgsSqlExpressionCompiler::Result result = compiler.compile( mRequest.filterExpression() );
     if ( result == QgsSqlExpressionCompiler::Complete || result == QgsSqlExpressionCompiler::Partial )
     {

--- a/src/providers/postgres/qgspostgresexpressioncompiler.cpp
+++ b/src/providers/postgres/qgspostgresexpressioncompiler.cpp
@@ -17,8 +17,8 @@
 #include "qgssqlexpressioncompiler.h"
 #include "qgsexpressionnodeimpl.h"
 
-QgsPostgresExpressionCompiler::QgsPostgresExpressionCompiler( QgsPostgresFeatureSource *source )
-  : QgsSqlExpressionCompiler( source->mFields, QgsSqlExpressionCompiler::IntegerDivisionResultsInInteger )
+QgsPostgresExpressionCompiler::QgsPostgresExpressionCompiler( QgsPostgresFeatureSource *source, bool ignoreStaticNodes )
+  : QgsSqlExpressionCompiler( source->mFields, QgsSqlExpressionCompiler::IntegerDivisionResultsInInteger, ignoreStaticNodes )
   , mGeometryColumn( source->mGeometryColumn )
   , mSpatialColType( source->mSpatialColType )
   , mDetectedGeomType( source->mDetectedGeomType )
@@ -166,6 +166,10 @@ QString QgsPostgresExpressionCompiler::castToText( const QString &value ) const
 
 QgsSqlExpressionCompiler::Result QgsPostgresExpressionCompiler::compileNode( const QgsExpressionNode *node, QString &result )
 {
+  QgsSqlExpressionCompiler::Result staticRes = replaceNodeByStaticCachedValueIfPossible( node, result );
+  if ( staticRes != Fail )
+    return staticRes;
+
   switch ( node->nodeType() )
   {
     case QgsExpressionNode::ntFunction:

--- a/src/providers/postgres/qgspostgresexpressioncompiler.h
+++ b/src/providers/postgres/qgspostgresexpressioncompiler.h
@@ -25,7 +25,7 @@ class QgsPostgresExpressionCompiler : public QgsSqlExpressionCompiler
 {
   public:
 
-    explicit QgsPostgresExpressionCompiler( QgsPostgresFeatureSource *source );
+    explicit QgsPostgresExpressionCompiler( QgsPostgresFeatureSource *source, bool ignoreStaticNodes = false );
 
   protected:
 

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -114,7 +114,7 @@ QgsPostgresFeatureIterator::QgsPostgresFeatureIterator( QgsPostgresFeatureSource
     mFilterRequiresGeometry = request.filterExpression()->needsGeometry();
 
     //IMPORTANT - this MUST be the last clause added!
-    QgsPostgresExpressionCompiler compiler = QgsPostgresExpressionCompiler( source );
+    QgsPostgresExpressionCompiler compiler = QgsPostgresExpressionCompiler( source, request.flags() & QgsFeatureRequest::IgnoreStaticNodesDuringExpressionCompilation );
 
     if ( compiler.compile( request.filterExpression() ) == QgsSqlExpressionCompiler::Complete )
     {

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -123,7 +123,7 @@ QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeature
       mFetchGeometry = true;
     }
 
-    QgsSQLiteExpressionCompiler compiler = QgsSQLiteExpressionCompiler( source->mFields );
+    QgsSQLiteExpressionCompiler compiler = QgsSQLiteExpressionCompiler( source->mFields, request.flags() & QgsFeatureRequest::IgnoreStaticNodesDuringExpressionCompilation );
     QgsSqlExpressionCompiler::Result result = compiler.compile( request.filterExpression() );
     if ( result == QgsSqlExpressionCompiler::Complete || result == QgsSqlExpressionCompiler::Partial )
     {
@@ -157,7 +157,7 @@ QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeature
     const auto constOrderBy = request.orderBy();
     for ( const QgsFeatureRequest::OrderByClause &clause : constOrderBy )
     {
-      QgsSQLiteExpressionCompiler compiler = QgsSQLiteExpressionCompiler( source->mFields );
+      QgsSQLiteExpressionCompiler compiler = QgsSQLiteExpressionCompiler( source->mFields, request.flags() & QgsFeatureRequest::IgnoreStaticNodesDuringExpressionCompilation );
       QgsExpression expression = clause.expression();
       if ( compiler.compile( &expression ) == QgsSqlExpressionCompiler::Complete )
       {

--- a/tests/src/core/testqgssqliteexpressioncompiler.cpp
+++ b/tests/src/core/testqgssqliteexpressioncompiler.cpp
@@ -93,7 +93,7 @@ void TestQgsSQLiteExpressionCompiler::testMakeExpression()
 
 void TestQgsSQLiteExpressionCompiler::testCompiler()
 {
-  QgsSQLiteExpressionCompiler compiler = QgsSQLiteExpressionCompiler( mPointsLayer->fields() );
+  QgsSQLiteExpressionCompiler compiler = QgsSQLiteExpressionCompiler( mPointsLayer->fields(), true );
   QgsExpression exp( makeExpression( 1 ) );
   QCOMPARE( compiler.compile( &exp ), QgsSqlExpressionCompiler::Result::Complete );
   QCOMPARE( compiler.result(), QString( exp ) );

--- a/tests/src/python/featuresourcetestbase.py
+++ b/tests/src/python/featuresourcetestbase.py
@@ -141,7 +141,7 @@ class FeatureSourceTestCase(object):
                 self.assertFalse(geometries[pk], 'Expected null geometry for {}'.format(pk))
 
     def assert_query(self, source, expression, expected):
-        request = QgsFeatureRequest().setFilterExpression(expression).setFlags(QgsFeatureRequest.NoGeometry)
+        request = QgsFeatureRequest().setFilterExpression(expression).setFlags(QgsFeatureRequest.NoGeometry | QgsFeatureRequest.IgnoreStaticNodesDuringExpressionCompilation)
         result = set([f['pk'] for f in source.getFeatures(request)])
         assert set(expected) == result, 'Expected {} and got {} when testing expression "{}"'.format(set(expected),
                                                                                                      result, expression)
@@ -149,13 +149,13 @@ class FeatureSourceTestCase(object):
 
         # Also check that filter works when referenced fields are not being retrieved by request
         result = set([f['pk'] for f in source.getFeatures(
-            QgsFeatureRequest().setFilterExpression(expression).setSubsetOfAttributes(['pk'], self.source.fields()))])
+            QgsFeatureRequest().setFilterExpression(expression).setSubsetOfAttributes(['pk'], self.source.fields()).setFlags(QgsFeatureRequest.IgnoreStaticNodesDuringExpressionCompilation))])
         assert set(
             expected) == result, 'Expected {} and got {} when testing expression "{}" using empty attribute subset'.format(
             set(expected), result, expression)
 
         # test that results match QgsFeatureRequest.acceptFeature
-        request = QgsFeatureRequest().setFilterExpression(expression)
+        request = QgsFeatureRequest().setFilterExpression(expression).setFlags(QgsFeatureRequest.IgnoreStaticNodesDuringExpressionCompilation)
         for f in source.getFeatures():
             self.assertEqual(request.acceptFeature(f), f['pk'] in expected)
 
@@ -614,14 +614,14 @@ class FeatureSourceTestCase(object):
         """
         request = QgsFeatureRequest().setFilterExpression(
             'attribute($currentfeature,\'cnt\')>200 and $x>=-70 and $x<=-60').setSubsetOfAttributes([]).setFlags(
-            QgsFeatureRequest.NoGeometry)
+            QgsFeatureRequest.NoGeometry | QgsFeatureRequest.IgnoreStaticNodesDuringExpressionCompilation)
         result = set([f['pk'] for f in self.source.getFeatures(request)])
         all_valid = (all(f.isValid() for f in self.source.getFeatures(request)))
         self.assertEqual(result, {4})
         self.assertTrue(all_valid)
 
         request = QgsFeatureRequest().setFilterExpression(
-            'attribute($currentfeature,\'cnt\')>200 and $x>=-70 and $x<=-60')
+            'attribute($currentfeature,\'cnt\')>200 and $x>=-70 and $x<=-60').setFlags(QgsFeatureRequest.IgnoreStaticNodesDuringExpressionCompilation)
         result = set([f['pk'] for f in self.source.getFeatures(request)])
         all_valid = (all(f.isValid() for f in self.source.getFeatures(request)))
         self.assertEqual(result, {4})

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -83,7 +83,7 @@ class ProviderTestCase(FeatureSourceTestCase):
 
         if self.compiled:
             # Check compilation status
-            it = source.getFeatures(QgsFeatureRequest().setFilterExpression(expression))
+            it = source.getFeatures(QgsFeatureRequest().setFilterExpression(expression).setFlags(QgsFeatureRequest.IgnoreStaticNodesDuringExpressionCompilation))
 
             if expression in self.uncompiledFilters():
                 self.assertEqual(it.compileStatus(), QgsAbstractFeatureIterator.NoCompilation)
@@ -104,7 +104,7 @@ class ProviderTestCase(FeatureSourceTestCase):
 
         request = QgsFeatureRequest()
         request.setExpressionContext(context)
-        request.setFilterExpression('"pk" = attribute(@parent, \'pk\')')
+        request.setFilterExpression('"pk" = attribute(@parent, \'pk\')').setFlags(QgsFeatureRequest.IgnoreStaticNodesDuringExpressionCompilation)
         request.setLimit(1)
 
         values = [f[self.pk_name] for f in self.vl.getFeatures(request)]
@@ -1095,12 +1095,12 @@ class ProviderTestCase(FeatureSourceTestCase):
                 '15 NOT LIKE \'5\'',
                 '15 NOT ILIKE \'5\'',
                 '5 ~ \'5\''):
-            iterator = self.source.getFeatures(QgsFeatureRequest().setFilterExpression('5 LIKE \'5\''))
+            iterator = self.source.getFeatures(QgsFeatureRequest().setFilterExpression('5 LIKE \'5\'').setFlags(QgsFeatureRequest.IgnoreStaticNodesDuringExpressionCompilation))
             count = len([f for f in iterator])
             self.assertEqual(count, 5)
             self.assertFalse(iterator.compileFailed())
             if self.enableCompiler():
-                iterator = self.source.getFeatures(QgsFeatureRequest().setFilterExpression('5 LIKE \'5\''))
+                iterator = self.source.getFeatures(QgsFeatureRequest().setFilterExpression('5 LIKE \'5\'').setFlags(QgsFeatureRequest.IgnoreStaticNodesDuringExpressionCompilation))
                 self.assertEqual(count, 5)
                 self.assertFalse(iterator.compileFailed())
                 self.disableCompiler()


### PR DESCRIPTION
When we are compiling expressions to handoff to backend providers,
check if a node has already been determined to evaluate to a static,
precalculated value, and if so, use this value for the node instead
of attempting to compile the actual contents of the node itself

If we are certain that a node is static and will never change,
the this potentially allows us to short-cut a large part of the
filter expressions content. We already use this short-cut when
evaluating expressions on the QGIS side since years, and its
proven to be stable and reliable. By respecting this during
expression compilation we can offer a huge speed up to certain
filter expressions, especially those which utilise QGIS variables
which are known to be static (such as atlas variables, map scales,
etc). Previously ANY use of a qgis variable would always cause
expression compilation to fail and require a full set of feature
fetching from the provider.

(Resulted in orders of magnitude faster atlas export for a complex
atlas.)
