### PR TITLE
Fix config qgsdualview

### DIFF
--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -124,6 +124,7 @@ void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const Qg
     return;
 
   mLayer = layer;
+  mConfig.update( mLayer->fields() );
   mEditorContext = context;
 
   initLayerCache( !( request.flags() & QgsFeatureRequest::NoGeometry ) || !request.filterRect().isNull() );

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -148,7 +148,7 @@ void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const Qg
     mAttributeEditor->layout()->addWidget( mAttributeForm );
   }
 
-  setAttributeTableConfig( mConfig );
+  setAttributeTableConfig( mLayer->attributeTableConfig() );
 
   connect( mAttributeForm, &QgsAttributeForm::widgetValueChanged, this, &QgsDualView::featureFormAttributeChanged );
   connect( mAttributeForm, &QgsAttributeForm::modeChanged, this, &QgsDualView::formModeChanged );

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -124,7 +124,6 @@ void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const Qg
     return;
 
   mLayer = layer;
-  mConfig.update( mLayer->fields() );
   mEditorContext = context;
 
   initLayerCache( !( request.flags() & QgsFeatureRequest::NoGeometry ) || !request.filterRect().isNull() );
@@ -148,6 +147,8 @@ void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const Qg
   {
     mAttributeEditor->layout()->addWidget( mAttributeForm );
   }
+
+  setAttributeTableConfig( mConfig );
 
   connect( mAttributeForm, &QgsAttributeForm::widgetValueChanged, this, &QgsDualView::featureFormAttributeChanged );
   connect( mAttributeForm, &QgsAttributeForm::modeChanged, this, &QgsDualView::formModeChanged );

--- a/tests/src/gui/testqgsdualview.cpp
+++ b/tests/src/gui/testqgsdualview.cpp
@@ -106,6 +106,7 @@ void TestQgsDualView::cleanup()
 
 void TestQgsDualView::testColumnCount()
 {
+  QCOMPARE( mDualView->attributeTableConfig().columns().count(), mPointsLayer->fields().count() );
   QCOMPARE( mDualView->tableView()->model()->columnCount(), mPointsLayer->fields().count() );
 }
 

--- a/tests/src/gui/testqgsdualview.cpp
+++ b/tests/src/gui/testqgsdualview.cpp
@@ -47,6 +47,7 @@ class TestQgsDualView : public QObject
     void testColumnHeaders();
 
     void testData();
+    void testAttributeTableConfig();
     void testFilterSelected();
 
     void testSelectAll();
@@ -106,7 +107,6 @@ void TestQgsDualView::cleanup()
 
 void TestQgsDualView::testColumnCount()
 {
-  QCOMPARE( mDualView->attributeTableConfig().columns().count(), mPointsLayer->fields().count() );
   QCOMPARE( mDualView->tableView()->model()->columnCount(), mPointsLayer->fields().count() );
 }
 
@@ -131,6 +131,11 @@ void TestQgsDualView::testData()
     QModelIndex index = mDualView->tableView()->model()->index( 0, i );
     QCOMPARE( mDualView->tableView()->model()->data( index ).toString(), fld.displayString( feature.attribute( i ) ) );
   }
+}
+
+void TestQgsDualView::testAttributeTableConfig()
+{
+  QCOMPARE( mDualView->attributeTableConfig().columns().count(), mPointsLayer->attributeTableConfig().columns().count() );
 }
 
 void TestQgsDualView::testFilterSelected()


### PR DESCRIPTION
## Description

Follows #41479

Hide and Resize column actions don't work in the qgsdualview

![Peek 2020-06-16 20-59](https://user-images.githubusercontent.com/2399255/84816205-6ba48500-b014-11ea-9453-db06ccd34ac3.gif)

It's because the QgsDualView::init function doesn't initiate mConfig attribute from the layer fields. It is only possible to use this actions after using the organizeColumns action, because mConfig is updated with the QgsOrganizeTableColumnsDialog config.

To fix it, I wrote the following line in the QgsDualView::init function to initiate mConfig (after @nyalldawson advice) :

```cpp
setAttributeTableConfig( mConfig );
```
