### PR TITLE
Use QRegularExpression::UseUnicodePropertiesOption in regular expressions 

### DIFF
--- a/resources/function_help/json/regexp_match
+++ b/resources/function_help/json/regexp_match
@@ -2,7 +2,7 @@
   "name": "regexp_match",
   "type": "function",
   "groups": ["Conditionals", "String"],
-  "description": "Return the first matching position matching a regular expression (QRegularExpression) within an unicode string, or 0 if the substring is not found.",
+  "description": "Return the first matching position matching a regular expression within an unicode string, or 0 if the substring is not found.",
   "arguments": [ {"arg":"input_string","description":"the string to test against the regular expression"},
   {"arg":"regex","description":"The regular expression to test against. Backslash characters must be double escaped (e.g., \"\\\\\\\\s\" to match a white space character or  \"\\\\\\\\b\" to a match word boundary)."}
   ],

--- a/resources/function_help/json/regexp_match
+++ b/resources/function_help/json/regexp_match
@@ -2,9 +2,9 @@
   "name": "regexp_match",
   "type": "function",
   "groups": ["Conditionals", "String"],
-  "description": "Return the first matching position matching a regular expression within a string, or 0 if the substring is not found.",
+  "description": "Return the first matching position matching a regular expression (QRegularExpression) within an unicode string, or 0 if the substring is not found.",
   "arguments": [ {"arg":"input_string","description":"the string to test against the regular expression"},
-  {"arg":"regex","description":"The regular expression to test against. Backslash characters must be double escaped (e.g., \"\\\\\\\\s\" to match a white space character)."}
+  {"arg":"regex","description":"The regular expression to test against. Backslash characters must be double escaped (e.g., \"\\\\\\\\s\" to match a white space character or  \"\\\\\\\\b\" to a match word boundary)."}
   ],
-  "examples": [ { "expression":"regexp_match('QGIS ROCKS','\\\\\\\\sROCKS')", "returns":"5"}]
+  "examples": [ { "expression":"regexp_match('QGIS ROCKS','\\\\\\\\sROCKS')", "returns":"5"}, { "expression":"regexp_match('Budač','udač\\\\\\\\b')", "returns":"2"}]
 }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1421,7 +1421,7 @@ static QVariant fcnRegexpReplace( const QVariantList &values, const QgsExpressio
   QString regexp = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
   QString after = QgsExpressionUtils::getStringValue( values.at( 2 ), parent );
 
-  QRegularExpression re( regexp );
+  QRegularExpression re( regexp, QRegularExpression::UseUnicodePropertiesOption );
   if ( !re.isValid() )
   {
     parent->setEvalErrorString( QObject::tr( "Invalid regular expression '%1': %2" ).arg( regexp, re.errorString() ) );
@@ -1435,7 +1435,7 @@ static QVariant fcnRegexpMatch( const QVariantList &values, const QgsExpressionC
   QString str = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QString regexp = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
 
-  QRegularExpression re( regexp );
+  QRegularExpression re( regexp, QRegularExpression::UseUnicodePropertiesOption );
   if ( !re.isValid() )
   {
     parent->setEvalErrorString( QObject::tr( "Invalid regular expression '%1': %2" ).arg( regexp, re.errorString() ) );
@@ -1450,7 +1450,7 @@ static QVariant fcnRegexpMatches( const QVariantList &values, const QgsExpressio
   QString regexp = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
   QString empty = QgsExpressionUtils::getStringValue( values.at( 2 ), parent );
 
-  QRegularExpression re( regexp );
+  QRegularExpression re( regexp, QRegularExpression::UseUnicodePropertiesOption );
   if ( !re.isValid() )
   {
     parent->setEvalErrorString( QObject::tr( "Invalid regular expression '%1': %2" ).arg( regexp, re.errorString() ) );
@@ -1482,7 +1482,7 @@ static QVariant fcnRegexpSubstr( const QVariantList &values, const QgsExpression
   QString str = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QString regexp = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
 
-  QRegularExpression re( regexp );
+  QRegularExpression re( regexp, QRegularExpression::UseUnicodePropertiesOption );
   if ( !re.isValid() )
   {
     parent->setEvalErrorString( QObject::tr( "Invalid regular expression '%1': %2" ).arg( regexp, re.errorString() ) );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1405,6 +1405,11 @@ class TestQgsExpression: public QObject
       QTest::newRow( "nullif substitute double" ) << "nullif(3.3, 3.3)" << false << QVariant();
       QTest::newRow( "nullif substitute int" ) << "nullif(0, 0)" << false << QVariant();
       QTest::newRow( "regexp match" ) << "regexp_match('abc','.b.')" << false << QVariant( 1 );
+      // testing unicode and \b, see #41453. \b tests for a 'word boundary'
+      QTest::newRow( "regexp match unicode" ) << "regexp_match('Budač','Buda\\\\b')" << false << QVariant( 0 );
+      QTest::newRow( "regexp match unicode 2" ) << "regexp_match('Buda','Buda\\\\b')" << false << QVariant( 1 );
+      QTest::newRow( "regexp match unicode 3" ) << "regexp_match('Budač','Budač\\\\b')" << false << QVariant( 1 );
+
       QTest::newRow( "regexp match invalid" ) << "regexp_match('abc DEF','[[[')" << true << QVariant();
       QTest::newRow( "regexp match escaped" ) << "regexp_match('abc DEF','\\\\s[A-Z]+')" << false << QVariant( 4 );
       QTest::newRow( "regexp match false" ) << "regexp_match('abc DEF','\\\\s[a-z]+')" << false << QVariant( 0 );


### PR DESCRIPTION
@nirvn do you think this is OK?

Should fix: #41453 in which values holding UTF diacritics were not handled.
Because these expressions functions are off course used in (international) text values, they should also be usable with Unicode (instead of ASCII only)

To test: go to expression (eg the selection by expression) and use the following as expression:

```
regexp_match('Budač', '[Bb]ud[ay]\\b')
```
that should return `0` as there is a `č` after the 'a' so NOT a 'word boundary'..

In current master it returns `1` because apparently it fails to handle Unicode chars:

See:
https://doc.qt.io/qt-5/qregularexpression.html
and:
https://doc.qt.io/qt-5/qregularexpression.html#PatternOption-enum

My plan is to add some tests using the values in the  #41453 issue en add those also to the expression function help

BUT: grepping on QRegularExpression in QGIS sources, I see it is used on a lot of places (most notably in all kind of providers).

So while THIS pr fixes this for the expression functions, I want to ask dev's if we should use QRegularExpression::UseUnicodePropertiesOption in other places. This would need a thorough check then probably IF it is needed, as in: "how valid is it that there will show up some non ASCII text as value in the regexp".

Willing to add more tests, but on my machine qgis_expressiontest  already fails:

```
./qgis_expressiontest | grep FAIL
Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
FAIL!  : TestQgsExpression::evaluation(tapered_buffer line) Compared values are not the same
FAIL!  : TestQgsExpression::evaluation(tapered_buffer line) Compared values are not the same
FAIL!  : TestQgsExpression::evaluation(tapered_buffer line) Compared values are not the same
FAIL!  : TestQgsExpression::evaluation(tapered_buffer line) Compared values are not the same
FAIL!  : TestQgsExpression::evaluation(tapered_buffer line 2) Compared values are not the same
FAIL!  : TestQgsExpression::evaluation(tapered_buffer line 2) Compared values are not the same
FAIL!  : TestQgsExpression::evaluation(tapered_buffer line 2) Compared values are not the same
FAIL!  : TestQgsExpression::evaluation(tapered_buffer line 2) Compared values are not the same
FAIL!  : TestQgsExpression::evaluation(buffer_by_m linem) Compared values are not the same
FAIL!  : TestQgsExpression::evaluation(buffer_by_m linem) Compared values are not the same
FAIL!  : TestQgsExpression::evaluation(buffer_by_m linem) Compared values are not the same
FAIL!  : TestQgsExpression::evaluation(buffer_by_m linem) Compared values are not the same
FAIL!  : TestQgsExpression::eval_geometry_method(intersection) 'compareWkt( outGeom.asWkt(), result.asWkt() )' returned FALSE. ()
FAIL!  : TestQgsExpression::eval_geometry_method(symDifference) 'compareWkt( outGeom.asWkt(), result.asWkt() )' returned FALSE. ()
```

Any input or help?



