### PR TITLE
QGIS crashes when trying to link existing child features

### DIFF
--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -476,7 +476,7 @@ void QgsAbstractRelationEditorWidget::onLinkFeatureDlgAccepted()
     for ( QgsFeatureId fid : constSelectedFeatures )
     {
       QgsVectorLayer *referencingLayer = mRelation.referencingLayer();
-      if ( mRelation.type() == QgsRelation::Normal )
+      if ( mRelation.type() == QgsRelation::Generated )
       {
         QgsPolymorphicRelation polyRel = mRelation.polymorphicRelation();
 


### PR DESCRIPTION


## Description

Described by @uclaros in #41314

It seems like a it's just a little mistake. There is a check on the link action (qgsabstractrelationeditorwidget.cpp) that verifies if the relation is polymorphic or not... but it leads to polymorphic check if the relation is not polymorphic :)

```cpp
      if ( mRelation.type() == QgsRelation::Normal ) // should be QgsRelation::Generated
      {
        QgsPolymorphicRelation polyRel = mRelation.polymorphicRelation();

        Q_ASSERT( mRelation.polymorphicRelation().isValid() );
```