### PR TITLE
 Don't crash when a relation is created where the field names defined in the relation differs from layer field name case

### DIFF
--- a/python/core/auto_generated/qgsrelation.sip.in
+++ b/python/core/auto_generated/qgsrelation.sip.in
@@ -321,7 +321,7 @@ Will be called internally whenever a member is changed.
 .. versionadded:: 3.6
 %End
 
-    void setPolymorphicRelationId( const QString polymorphicRelationId );
+    void setPolymorphicRelationId( const QString &polymorphicRelationId );
 %Docstring
 Sets the parent polymorphic relation id.
 

--- a/src/core/qgsrelation.cpp
+++ b/src/core/qgsrelation.cpp
@@ -317,7 +317,7 @@ QList<QgsRelation::FieldPair> QgsRelation::fieldPairs() const
 QgsAttributeList QgsRelation::referencedFields() const
 {
   QgsAttributeList attrs;
-
+  attrs.reserve( d->mFieldPairs.size() );
   for ( const FieldPair &pair : qgis::as_const( d->mFieldPairs ) )
   {
     attrs << d->mReferencedLayer->fields().lookupField( pair.second );
@@ -421,7 +421,7 @@ void QgsRelation::updateRelationStatus()
   }
 }
 
-void QgsRelation::setPolymorphicRelationId( const QString polymorphicRelationId )
+void QgsRelation::setPolymorphicRelationId( const QString &polymorphicRelationId )
 {
   d.detach();
   d->mPolymorphicRelationId = polymorphicRelationId;

--- a/src/core/qgsrelation.cpp
+++ b/src/core/qgsrelation.cpp
@@ -233,7 +233,7 @@ QgsFeatureRequest QgsRelation::getReferencedFeatureRequest( const QgsAttributes 
 
   for ( const FieldPair &pair : qgis::as_const( d->mFieldPairs ) )
   {
-    int referencingIdx = referencingLayer()->fields().indexFromName( pair.referencingField() );
+    int referencingIdx = referencingLayer()->fields().lookupField( pair.referencingField() );
     conditions << QgsExpression::createFieldEqualityExpression( pair.referencedField(), attributes.at( referencingIdx ) );
   }
 

--- a/src/core/qgsrelation.h
+++ b/src/core/qgsrelation.h
@@ -398,7 +398,7 @@ class CORE_EXPORT QgsRelation
      * Sets the parent polymorphic relation id.
      * \since QGIS 3.18
      */
-    void setPolymorphicRelationId( const QString polymorphicRelationId );
+    void setPolymorphicRelationId( const QString &polymorphicRelationId );
 
     /**
      * Returns the parent polymorphic relation id. If the relation is a normal relation, a null string is returned.

--- a/tests/src/python/test_qgsrelation.py
+++ b/tests/src/python/test_qgsrelation.py
@@ -147,6 +147,21 @@ class TestQgsRelation(unittest.TestCase):
         assert f.isValid()
         assert f[0] == 'foo'
 
+        # try mixing up the field pair field name cases -- we should be tolerant to this
+        rel2 = QgsRelation()
+        rel2.setId('rel1')
+        rel2.setName('Relation Number One')
+        rel2.setReferencingLayer(self.referencingLayer.id())
+        rel2.setReferencedLayer(self.referencedLayer.id())
+        rel2.addFieldPair('ForeignKey', 'Y')
+
+        feat = next(self.referencingLayer.getFeatures())
+
+        f = rel2.getReferencedFeature(feat)
+
+        assert f.isValid()
+        assert f[0] == 'foo'
+
     def test_fieldPairs(self):
         rel = QgsRelation()
 

--- a/tests/src/python/test_qgsrelation.py
+++ b/tests/src/python/test_qgsrelation.py
@@ -85,22 +85,22 @@ class TestQgsRelation(unittest.TestCase):
 
     def test_isValid(self):
         rel = QgsRelation()
-        assert not rel.isValid()
+        self.assertFalse(rel.isValid())
 
         rel.setId('rel1')
-        assert not rel.isValid()
+        self.assertFalse(rel.isValid())
 
         rel.setName('Relation Number One')
-        assert not rel.isValid()
+        self.assertFalse(rel.isValid())
 
         rel.setReferencingLayer(self.referencingLayer.id())
-        assert not rel.isValid()
+        self.assertFalse(rel.isValid())
 
         rel.setReferencedLayer(self.referencedLayer.id())
-        assert not rel.isValid()
+        self.assertFalse(rel.isValid())
 
         rel.addFieldPair('foreignkey', 'y')
-        assert rel.isValid()
+        self.assertTrue(rel.isValid())
 
     def test_getRelatedFeatures(self):
         rel = QgsRelation()
@@ -116,7 +116,7 @@ class TestQgsRelation(unittest.TestCase):
         self.assertEqual(rel.getRelatedFeaturesFilter(feat), '"foreignkey" = 123')
 
         it = rel.getRelatedFeatures(feat)
-        assert [a.attributes() for a in it] == [['test1', 123], ['test2', 123]]
+        self.assertEqual([a.attributes() for a in it], [['test1', 123], ['test2', 123]])
 
     def test_getRelatedFeaturesWithQuote(self):
         rel = QgsRelation()
@@ -130,7 +130,7 @@ class TestQgsRelation(unittest.TestCase):
         feat = self.referencedLayer.getFeature(3)
 
         it = rel.getRelatedFeatures(feat)
-        assert next(it).attributes() == ["foobar'bar", 124]
+        self.assertEqual(next(it).attributes(), ["foobar'bar", 124])
 
     def test_getReferencedFeature(self):
         rel = QgsRelation()
@@ -144,8 +144,8 @@ class TestQgsRelation(unittest.TestCase):
 
         f = rel.getReferencedFeature(feat)
 
-        assert f.isValid()
-        assert f[0] == 'foo'
+        self.assertTrue(f.isValid())
+        self.assertEqual(f[0], 'foo')
 
         # try mixing up the field pair field name cases -- we should be tolerant to this
         rel2 = QgsRelation()
@@ -159,8 +159,8 @@ class TestQgsRelation(unittest.TestCase):
 
         f = rel2.getReferencedFeature(feat)
 
-        assert f.isValid()
-        assert f[0] == 'foo'
+        self.assertTrue(f.isValid())
+        self.assertEqual(f[0], 'foo')
 
     def test_fieldPairs(self):
         rel = QgsRelation()
@@ -171,7 +171,7 @@ class TestQgsRelation(unittest.TestCase):
         rel.setReferencedLayer(self.referencedLayer.id())
         rel.addFieldPair('foreignkey', 'y')
 
-        assert (rel.fieldPairs() == {'foreignkey': 'y'})
+        self.assertEqual(rel.fieldPairs(), {'foreignkey': 'y'})
 
     def testValidRelationAfterChangingStyle(self):
         # load project


### PR DESCRIPTION
And some related clean ups