### PR TITLE
Bugfix gh41477 editbuffer passthrough

### DIFF
--- a/python/core/auto_generated/vector/qgsvectorlayereditbuffer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayereditbuffer.sip.in
@@ -208,6 +208,7 @@ Returns ``True`` if the specified feature ID has been deleted but not committed.
 %End
 
 
+
   protected slots:
     void undoIndexChanged( int index );
 
@@ -268,8 +269,6 @@ Emitted after committing an attribute rename
 %Docstring
 Constructor for QgsVectorLayerEditBuffer
 %End
-
-    void updateFields( QgsFields &fields );
 
     void updateFeatureGeometry( QgsFeature &f );
 %Docstring

--- a/python/core/auto_generated/vector/qgsvectorlayerundocommand.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerundocommand.sip.in
@@ -124,8 +124,7 @@ Constructor for QgsVectorLayerUndoCommandChangeGeometry
     virtual void redo();
 
     virtual int id() const;
-
-    virtual bool mergeWith( const QUndoCommand * );
+    virtual bool mergeWith( const QUndoCommand *other );
 
 
 };

--- a/python/core/auto_generated/vector/qgsvectorlayerundopassthroughcommand.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerundopassthroughcommand.sip.in
@@ -169,6 +169,10 @@ Constructor for QgsVectorLayerUndoPassthroughCommandChangeGeometry
     virtual void redo();
 
 
+    virtual int id() const;
+    virtual bool mergeWith( const QUndoCommand  *other );
+
+
 };
 
 

--- a/src/core/qgstransaction.cpp
+++ b/src/core/qgstransaction.cpp
@@ -219,7 +219,6 @@ QString QgsTransaction::createSavepoint( QString &error SIP_OUT )
 
   if ( !mLastSavePointIsDirty && !mSavepoints.isEmpty() )
   {
-    qDebug() << "Returning TOP >>>>> " << mSavepoints.top();
     return mSavepoints.top();
   }
 
@@ -263,7 +262,10 @@ bool QgsTransaction::rollbackToSavepoint( const QString &name, QString &error SI
     return false;
 
   mSavepoints.resize( idx );
-  mLastSavePointIsDirty = false;
+  // Rolling back always dirties the previous savepoint because
+  // the status of the DB has changed between the previous savepoint and the
+  // one we are rolling back to.
+  mLastSavePointIsDirty = true;
   return executeSql( QStringLiteral( "ROLLBACK TO SAVEPOINT %1" ).arg( QgsExpression::quotedColumnRef( name ) ), error );
 }
 

--- a/src/core/qgstransaction.cpp
+++ b/src/core/qgstransaction.cpp
@@ -218,7 +218,10 @@ QString QgsTransaction::createSavepoint( QString &error SIP_OUT )
     return QString();
 
   if ( !mLastSavePointIsDirty && !mSavepoints.isEmpty() )
+  {
+    qDebug() << "Returning TOP >>>>> " << mSavepoints.top();
     return mSavepoints.top();
+  }
 
   const QString name( QStringLiteral( "qgis" ) + ( QUuid::createUuid().toString().mid( 1, 24 ).replace( '-', QString() ) ) );
 

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -874,7 +874,7 @@ QgsRectangle QgsVectorLayer::extent() const
   }
 
   if ( !mEditBuffer ||
-       ( mEditBuffer->mDeletedFeatureIds.isEmpty() && mEditBuffer->mChangedGeometries.isEmpty() ) ||
+       ( !mDataProvider->transaction() && ( mEditBuffer->deletedFeatureIds().isEmpty() && mEditBuffer->changedGeometries().isEmpty() ) ) ||
        QgsDataSourceUri( mDataProvider->dataSourceUri() ).useEstimatedMetadata() )
   {
     mDataProvider->updateExtents();
@@ -887,9 +887,10 @@ QgsRectangle QgsVectorLayer::extent() const
       rect.combineExtentWith( r );
     }
 
-    if ( mEditBuffer )
+    if ( mEditBuffer && !mDataProvider->transaction() )
     {
-      for ( QgsFeatureMap::const_iterator it = mEditBuffer->mAddedFeatures.constBegin(); it != mEditBuffer->mAddedFeatures.constEnd(); ++it )
+      const auto addedFeatures = mEditBuffer->addedFeatures();
+      for ( QgsFeatureMap::const_iterator it = addedFeatures.constBegin(); it != addedFeatures.constEnd(); ++it )
       {
         if ( it->hasGeometry() )
         {
@@ -3363,13 +3364,13 @@ long QgsVectorLayer::featureCount() const
   if ( ! mDataProvider )
     return -1;
   return mDataProvider->featureCount() +
-         ( mEditBuffer ? mEditBuffer->mAddedFeatures.size() - mEditBuffer->mDeletedFeatureIds.size() : 0 );
+         ( mEditBuffer && ! mDataProvider->transaction() ? mEditBuffer->addedFeatures().size() - mEditBuffer->deletedFeatureIds().size() : 0 );
 }
 
 QgsFeatureSource::FeatureAvailability QgsVectorLayer::hasFeatures() const
 {
-  const QgsFeatureIds deletedFeatures( mEditBuffer ? mEditBuffer->deletedFeatureIds() : QgsFeatureIds() );
-  const QgsFeatureMap addedFeatures( mEditBuffer ? mEditBuffer->addedFeatures() : QgsFeatureMap() );
+  const QgsFeatureIds deletedFeatures( mEditBuffer && ! mDataProvider->transaction() ? mEditBuffer->deletedFeatureIds() : QgsFeatureIds() );
+  const QgsFeatureMap addedFeatures( mEditBuffer && ! mDataProvider->transaction() ? mEditBuffer->addedFeatures() : QgsFeatureMap() );
 
   if ( mEditBuffer && !deletedFeatures.empty() )
   {
@@ -3453,9 +3454,9 @@ bool QgsVectorLayer::rollBack( bool deleteBuffer )
     return false;
   }
 
-  bool rollbackExtent = !mEditBuffer->mDeletedFeatureIds.isEmpty() ||
-                        !mEditBuffer->mAddedFeatures.isEmpty() ||
-                        !mEditBuffer->mChangedGeometries.isEmpty();
+  bool rollbackExtent = !mDataProvider->transaction() && ( !mEditBuffer->deletedFeatureIds().isEmpty() ||
+                        !mEditBuffer->addedFeatures().isEmpty() ||
+                        !mEditBuffer->changedGeometries().isEmpty() );
 
   emit beforeRollBack();
 
@@ -4040,7 +4041,7 @@ QSet<QVariant> QgsVectorLayer::uniqueValues( int index, int limit ) const
     {
       uniqueValues = mDataProvider->uniqueValues( index, limit );
 
-      if ( mEditBuffer )
+      if ( mEditBuffer && ! mDataProvider->transaction() )
       {
         QSet<QString> vals;
         const auto constUniqueValues = uniqueValues;
@@ -4088,10 +4089,11 @@ QSet<QVariant> QgsVectorLayer::uniqueValues( int index, int limit ) const
 
     case QgsFields::OriginEdit:
       // the layer is editable, but in certain cases it can still be avoided going through all features
-      if ( mEditBuffer->mDeletedFeatureIds.isEmpty() &&
-           mEditBuffer->mAddedFeatures.isEmpty() &&
-           !mEditBuffer->mDeletedAttributeIds.contains( index ) &&
-           mEditBuffer->mChangedAttributeValues.isEmpty() )
+      if ( mDataProvider->transaction() || (
+             mEditBuffer->deletedFeatureIds().isEmpty() &&
+             mEditBuffer->addedFeatures().isEmpty() &&
+             !mEditBuffer->deletedAttributeIds().contains( index ) &&
+             mEditBuffer->changedAttributeValues().isEmpty() ) )
       {
         uniqueValues = mDataProvider->uniqueValues( index, limit );
         return uniqueValues;
@@ -4147,7 +4149,7 @@ QStringList QgsVectorLayer::uniqueStringsMatching( int index, const QString &sub
     {
       results = mDataProvider->uniqueStringsMatching( index, substring, limit, feedback );
 
-      if ( mEditBuffer )
+      if ( mEditBuffer && ! mDataProvider->transaction() )
       {
         QgsFeatureMap added = mEditBuffer->addedFeatures();
         QMapIterator< QgsFeatureId, QgsFeature > addedIt( added );
@@ -4186,10 +4188,10 @@ QStringList QgsVectorLayer::uniqueStringsMatching( int index, const QString &sub
 
     case QgsFields::OriginEdit:
       // the layer is editable, but in certain cases it can still be avoided going through all features
-      if ( mEditBuffer->mDeletedFeatureIds.isEmpty() &&
-           mEditBuffer->mAddedFeatures.isEmpty() &&
-           !mEditBuffer->mDeletedAttributeIds.contains( index ) &&
-           mEditBuffer->mChangedAttributeValues.isEmpty() )
+      if ( mDataProvider->transaction() || ( mEditBuffer->deletedFeatureIds().isEmpty() &&
+                                             mEditBuffer->addedFeatures().isEmpty() &&
+                                             !mEditBuffer->deletedAttributeIds().contains( index ) &&
+                                             mEditBuffer->changedAttributeValues().isEmpty() ) )
       {
         return mDataProvider->uniqueStringsMatching( index, substring, limit, feedback );
       }
@@ -4257,7 +4259,7 @@ QVariant QgsVectorLayer::minimumOrMaximumValue( int index, bool minimum ) const
     case QgsFields::OriginProvider: //a provider field
     {
       QVariant val = minimum ? mDataProvider->minimumValue( index ) : mDataProvider->maximumValue( index );
-      if ( mEditBuffer )
+      if ( mEditBuffer && ! mDataProvider->transaction() )
       {
         QgsFeatureMap added = mEditBuffer->addedFeatures();
         QMapIterator< QgsFeatureId, QgsFeature > addedIt( added );
@@ -4290,10 +4292,10 @@ QVariant QgsVectorLayer::minimumOrMaximumValue( int index, bool minimum ) const
     case QgsFields::OriginEdit:
     {
       // the layer is editable, but in certain cases it can still be avoided going through all features
-      if ( mEditBuffer->mDeletedFeatureIds.isEmpty() &&
-           mEditBuffer->mAddedFeatures.isEmpty() &&
-           !mEditBuffer->mDeletedAttributeIds.contains( index ) &&
-           mEditBuffer->mChangedAttributeValues.isEmpty() )
+      if ( mDataProvider->transaction() || ( mEditBuffer->deletedFeatureIds().isEmpty() &&
+                                             mEditBuffer->addedFeatures().isEmpty() &&
+                                             !mEditBuffer->deletedAttributeIds().contains( index ) &&
+                                             mEditBuffer->changedAttributeValues().isEmpty() ) )
       {
         return minimum ? mDataProvider->minimumValue( index ) : mDataProvider->maximumValue( index );
       }

--- a/src/core/vector/qgsvectorlayereditbuffer.h
+++ b/src/core/vector/qgsvectorlayereditbuffer.h
@@ -184,6 +184,13 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
      */
     bool isFeatureDeleted( QgsFeatureId id ) const { return mDeletedFeatureIds.contains( id ); }
 
+    /**
+     * Updates \a fields
+     * \note Not available in Python bindings
+     * \since QGIS 3.18
+     */
+    void updateFields( QgsFields &fields ) SIP_SKIP;
+
     //QString dumpEditBuffer();
 
   protected slots:
@@ -236,8 +243,6 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     //! Constructor for QgsVectorLayerEditBuffer
     QgsVectorLayerEditBuffer() = default;
 
-    void updateFields( QgsFields &fields );
-
     //! Update feature with uncommitted geometry updates
     void updateFeatureGeometry( QgsFeature &f );
 
@@ -257,7 +262,6 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
 
   protected:
     QgsVectorLayer *L = nullptr;
-    friend class QgsVectorLayer;
 
     friend class QgsVectorLayerUndoCommand;
     friend class QgsVectorLayerUndoCommandAddFeature;

--- a/src/core/vector/qgsvectorlayereditpassthrough.cpp
+++ b/src/core/vector/qgsvectorlayereditpassthrough.cpp
@@ -32,7 +32,7 @@ bool QgsVectorLayerEditPassthrough::isModified() const
 
 bool QgsVectorLayerEditPassthrough::modify( QgsVectorLayerUndoPassthroughCommand *cmd )
 {
-  L->undoStack()->push( cmd ); // push takes owneship -> no need for cmd to be a smart ptr
+  L->undoStack()->push( cmd ); // push takes ownership -> no need for cmd to be a smart ptr
   if ( cmd->hasError() )
     return false;
 
@@ -109,6 +109,11 @@ bool QgsVectorLayerEditPassthrough::renameAttribute( int attr, const QString &ne
 bool QgsVectorLayerEditPassthrough::commitChanges( QStringList & /*commitErrors*/ )
 {
   mModified = false;
+  for ( int i = 0; i < L->undoStack()->count(); ++i )
+  {
+    const QgsVectorLayerUndoPassthroughCommand *cmdPrt = static_cast<const QgsVectorLayerUndoPassthroughCommand *>( L->undoStack()->command( i ) );
+    qDebug() << cmdPrt->text();
+  }
   return true;
 }
 

--- a/src/core/vector/qgsvectorlayereditpassthrough.cpp
+++ b/src/core/vector/qgsvectorlayereditpassthrough.cpp
@@ -109,11 +109,6 @@ bool QgsVectorLayerEditPassthrough::renameAttribute( int attr, const QString &ne
 bool QgsVectorLayerEditPassthrough::commitChanges( QStringList & /*commitErrors*/ )
 {
   mModified = false;
-  for ( int i = 0; i < L->undoStack()->count(); ++i )
-  {
-    const QgsVectorLayerUndoPassthroughCommand *cmdPrt = static_cast<const QgsVectorLayerUndoPassthroughCommand *>( L->undoStack()->command( i ) );
-    qDebug() << cmdPrt->text();
-  }
   return true;
 }
 

--- a/src/core/vector/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.cpp
@@ -71,12 +71,16 @@ QgsVectorLayerFeatureSource::QgsVectorLayerFeatureSource( const QgsVectorLayer *
     else
     {
 #endif
-      mAddedFeatures = QgsFeatureMap( layer->editBuffer()->addedFeatures() );
-      mChangedGeometries = QgsGeometryMap( layer->editBuffer()->changedGeometries() );
-      mDeletedFeatureIds = QgsFeatureIds( layer->editBuffer()->deletedFeatureIds() );
-      mChangedAttributeValues = QgsChangedAttributesMap( layer->editBuffer()->changedAttributeValues() );
-      mAddedAttributes = QList<QgsField>( layer->editBuffer()->addedAttributes() );
-      mDeletedAttributeIds = QgsAttributeList( layer->editBuffer()->deletedAttributeIds() );
+      // If we are inside a transaction the iterator "sees" the current status
+      if ( layer->dataProvider() && ! layer->dataProvider()->transaction() )
+      {
+        mAddedFeatures = QgsFeatureMap( layer->editBuffer()->addedFeatures() );
+        mChangedGeometries = QgsGeometryMap( layer->editBuffer()->changedGeometries() );
+        mDeletedFeatureIds = QgsFeatureIds( layer->editBuffer()->deletedFeatureIds() );
+        mChangedAttributeValues = QgsChangedAttributesMap( layer->editBuffer()->changedAttributeValues() );
+        mAddedAttributes = QList<QgsField>( layer->editBuffer()->addedAttributes() );
+        mDeletedAttributeIds = QgsAttributeList( layer->editBuffer()->deletedAttributeIds() );
+      }
 #if 0
     }
 #endif

--- a/src/core/vector/qgsvectorlayerundocommand.cpp
+++ b/src/core/vector/qgsvectorlayerundocommand.cpp
@@ -122,10 +122,7 @@ QgsVectorLayerUndoCommandChangeGeometry::QgsVectorLayerUndoCommandChangeGeometry
   }
 }
 
-int QgsVectorLayerUndoCommandChangeGeometry::id() const
-{
-  return 1;
-}
+
 
 bool QgsVectorLayerUndoCommandChangeGeometry::mergeWith( const QUndoCommand *other )
 {

--- a/src/core/vector/qgsvectorlayerundocommand.h
+++ b/src/core/vector/qgsvectorlayerundocommand.h
@@ -131,8 +131,8 @@ class CORE_EXPORT QgsVectorLayerUndoCommandChangeGeometry : public QgsVectorLaye
 
     void undo() override;
     void redo() override;
-    int id() const override;
-    bool mergeWith( const QUndoCommand * ) override;
+    int id() const override { return 1; }
+    bool mergeWith( const QUndoCommand *other ) override;
 
   private:
     QgsFeatureId mFid;

--- a/src/core/vector/qgsvectorlayerundopassthroughcommand.h
+++ b/src/core/vector/qgsvectorlayerundopassthroughcommand.h
@@ -145,6 +145,8 @@ class CORE_EXPORT QgsVectorLayerUndoPassthroughCommandDeleteFeatures : public Qg
 
   private:
     const QgsFeatureIds mFids;
+    // Keeps track of the deleted features that belong to the added pool
+    QgsFeatureMap mDeletedNewFeatures;
 };
 
 /**
@@ -169,10 +171,13 @@ class CORE_EXPORT QgsVectorLayerUndoPassthroughCommandChangeGeometry : public Qg
     void undo() override;
     void redo() override;
 
+    int id() const override { return 1; }
+    bool mergeWith( const QUndoCommand  *other ) override;
+
   private:
     QgsFeatureId mFid;
-    const QgsGeometry mNewGeom;
-    const QgsGeometry mOldGeom;
+    mutable QgsGeometry mNewGeom;
+    QgsGeometry mOldGeom;
 };
 
 /**

--- a/src/core/vector/qgsvectorlayerundopassthroughcommand.h
+++ b/src/core/vector/qgsvectorlayerundopassthroughcommand.h
@@ -200,9 +200,10 @@ class CORE_EXPORT QgsVectorLayerUndoPassthroughCommandChangeAttribute: public Qg
 
   private:
     QgsFeatureId mFid;
-    const int mField;
+    const int mFieldIndex;
     const QVariant mNewValue;
-    const QVariant mOldValue;
+    QVariant mOldValue;
+    bool mFirstChange;
 };
 
 /**

--- a/tests/src/python/test_qgsvectorlayereditbuffer.py
+++ b/tests/src/python/test_qgsvectorlayereditbuffer.py
@@ -565,12 +565,15 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
             field = QgsField('attr1', QVariant.String)
             self.assertTrue(layer_a.addAttribute(field))
             self.assertNotEqual(layer_a.fields().lookupField(field.name()), -1)
+            self.assertEqual(buffer.addedAttributes(), [field])
 
             layer_a.undoStack().undo()
             self.assertEqual(layer_a.fields().lookupField(field.name()), -1)
+            self.assertEqual(buffer.addedAttributes(), [])
 
             layer_a.undoStack().redo()
             self.assertNotEqual(layer_a.fields().lookupField(field.name()), -1)
+            self.assertEqual(buffer.addedAttributes(), [field])
 
             self.assertTrue(layer_a.commitChanges())
 
@@ -578,17 +581,21 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
             # Remove attribute
 
             self.assertTrue(layer_a.startEditing())
+            buffer = layer_a.editBuffer()
 
             attr_idx = layer_a.fields().lookupField(field.name())
             self.assertNotEqual(attr_idx, -1)
 
             self.assertTrue(layer_a.deleteAttribute(attr_idx))
+            self.assertEqual(buffer.deletedAttributeIds(), [2])
             self.assertEqual(layer_a.fields().lookupField(field.name()), -1)
 
             layer_a.undoStack().undo()
+            self.assertEqual(buffer.deletedAttributeIds(), [])
             self.assertEqual(layer_a.fields().lookupField(field.name()), attr_idx)
 
             layer_a.undoStack().redo()
+            self.assertEqual(buffer.deletedAttributeIds(), [2])
             self.assertEqual(layer_a.fields().lookupField(field.name()), -1)
 
             self.assertTrue(layer_a.rollBack())

--- a/tests/src/python/test_qgsvectorlayereditbuffer.py
+++ b/tests/src/python/test_qgsvectorlayereditbuffer.py
@@ -395,51 +395,223 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         self.assertEqual(layer.editBuffer().addedAttributes()[1].name(), 'new2')
 
     def testTransactionGroup(self):
-        """Test that the buffer works as expected when in transaction"""
-
-        ml = QgsVectorLayer('Point?field=int:integer&crs=epsg:4326', 'test', 'memory')
-        self.assertTrue(ml.isValid())
-
-        d = QTemporaryDir()
-        options = QgsVectorFileWriter.SaveVectorOptions()
-        options.driverName = 'GPKG'
-        options.layerName = 'layer_a'
-        err, _ = QgsVectorFileWriter.writeAsVectorFormatV2(ml, os.path.join(d.path(), 'transaction_test.gpkg'), QgsCoordinateTransformContext(), options)
-
-        self.assertEqual(err, QgsVectorFileWriter.NoError)
-        self.assertTrue(os.path.isfile(os.path.join(d.path(), 'transaction_test.gpkg')))
-
-        options.layerName = 'layer_b'
-        options.actionOnExistingFile = QgsVectorFileWriter.CreateOrOverwriteLayer
-        err, _ = QgsVectorFileWriter.writeAsVectorFormatV2(ml, os.path.join(d.path(), 'transaction_test.gpkg'), QgsCoordinateTransformContext(), options)
+        """Test that the buffer works the same when used in transaction and when not"""
 
         def _test(autoTransaction):
+            """Test buffer methods within and without transactions
+
+            - create a feature
+            - save
+            - retrieve the feature
+            - change geom and attrs
+            - test changes are seen in the buffer
+            """
+
+            def _check_feature(wkt):
+
+                f = next(layer_a.getFeatures())
+                self.assertEqual(f.geometry().asWkt().upper(), wkt)
+                f = list(buffer.addedFeatures().values())[0]
+                self.assertEqual(f.geometry().asWkt().upper(), wkt)
+
+            ml = QgsVectorLayer('Point?crs=epsg:4326&field=int:integer', 'test', 'memory')
+            self.assertTrue(ml.isValid())
+
+            d = QTemporaryDir()
+            options = QgsVectorFileWriter.SaveVectorOptions()
+            options.driverName = 'GPKG'
+            options.layerName = 'layer_a'
+            err, _ = QgsVectorFileWriter.writeAsVectorFormatV2(ml, os.path.join(d.path(), 'transaction_test.gpkg'), QgsCoordinateTransformContext(), options)
+
+            self.assertEqual(err, QgsVectorFileWriter.NoError)
+            self.assertTrue(os.path.isfile(os.path.join(d.path(), 'transaction_test.gpkg')))
+
+            options.layerName = 'layer_b'
+            options.actionOnExistingFile = QgsVectorFileWriter.CreateOrOverwriteLayer
+            err, _ = QgsVectorFileWriter.writeAsVectorFormatV2(ml, os.path.join(d.path(), 'transaction_test.gpkg'), QgsCoordinateTransformContext(), options)
 
             layer_a = QgsVectorLayer(os.path.join(d.path(), 'transaction_test.gpkg|layername=layer_a'))
-            layer_b = QgsVectorLayer(os.path.join(d.path(), 'transaction_test.gpkg|layername=layer_b'))
 
             self.assertTrue(layer_a.isValid())
-            self.assertTrue(layer_b.isValid())
 
             project = QgsProject()
             project.setAutoTransaction(autoTransaction)
-            project.addMapLayers([layer_a, layer_b])
+            project.addMapLayers([layer_a])
 
-            self.assertFalse(layer_b.isEditable())
+            ###########################################
+            # Tests with a new feature
+
             self.assertTrue(layer_a.startEditing())
-
-            if not autoTransaction:
-                self.assertTrue(layer_b.startEditing())
-
-            self.assertTrue(layer_b.isEditable())
+            buffer = layer_a.editBuffer()
 
             f = QgsFeature(layer_a.fields())
+            f.setAttribute('int', 123)
             f.setGeometry(QgsGeometry.fromWkt('point(7 45)'))
-
             self.assertTrue(layer_a.addFeatures([f]))
 
+            _check_feature('POINT (7 45)')
+
+            # Need to fetch the feature because its ID is NULL (-9223372036854775808)
+            f = next(layer_a.getFeatures())
+
+            self.assertEqual(len(buffer.addedFeatures()), 1)
+            layer_a.undoStack().undo()
+            self.assertEqual(len(buffer.addedFeatures()), 0)
+            layer_a.undoStack().redo()
+            self.assertEqual(len(buffer.addedFeatures()), 1)
+            f = list(buffer.addedFeatures().values())[0]
+            self.assertEqual(f.attribute('int'), 123)
+
+            # Now change attribute
+            self.assertEqual(buffer.changedAttributeValues(), {})
+            layer_a.changeAttributeValue(f.id(), 1, 321)
+
+            self.assertEqual(len(buffer.addedFeatures()), 1)
+            # This is surprising: because it was a new feature it has been changed directly
+            self.assertEqual(buffer.changedAttributeValues(), {})
+            f = list(buffer.addedFeatures().values())[0]
+            self.assertEqual(f.attribute('int'), 321)
+
+            layer_a.undoStack().undo()
+            self.assertEqual(buffer.changedAttributeValues(), {})
+            f = list(buffer.addedFeatures().values())[0]
+            self.assertEqual(f.attribute('int'), 123)
+            f = next(layer_a.getFeatures())
+            self.assertEqual(f.attribute('int'), 123)
+
+            # Change geometry
+            f = next(layer_a.getFeatures())
+            self.assertTrue(layer_a.changeGeometry(f.id(), QgsGeometry.fromWkt('point(9 43)')))
+
+            _check_feature('POINT (9 43)')
+            self.assertEqual(buffer.changedGeometries(), {})
+
+            layer_a.undoStack().undo()
+
+            _check_feature('POINT (7 45)')
+            self.assertEqual(buffer.changedGeometries(), {})
+
+            self.assertTrue(layer_a.changeGeometry(f.id(), QgsGeometry.fromWkt('point(9 43)')))
+            _check_feature('POINT (9 43)')
+
+            self.assertTrue(layer_a.changeGeometry(f.id(), QgsGeometry.fromWkt('point(10 44)')))
+            _check_feature('POINT (10 44)')
+
+            # This is anothr surprise: geometry edits get collapsed into a single
+            # one because they have the same hardcoded id
+            layer_a.undoStack().undo()
+            _check_feature('POINT (7 45)')
+
+            self.assertTrue(layer_a.commitChanges())
+
+            ###########################################
+            # Tests with the existing feature
+
+            # Get the feature
+            f = next(layer_a.getFeatures())
+            self.assertTrue(f.isValid())
+            self.assertEqual(f.attribute('int'), 123)
+            self.assertEqual(f.geometry().asWkt().upper(), 'POINT (7 45)')
+
+            self.assertTrue(layer_a.startEditing())
+            layer_a.changeAttributeValue(f.id(), 1, 321)
             buffer = layer_a.editBuffer()
-            self.assertTrue(len(buffer.addedFeatures()) > 0)
+            self.assertEqual(buffer.changedAttributeValues(), {1: {1: 321}})
+            layer_a.undoStack().undo()
+            self.assertEqual(buffer.changedAttributeValues(), {})
+
+            # Change geometry
+            self.assertTrue(layer_a.changeGeometry(f.id(), QgsGeometry.fromWkt('point(9 43)')))
+            f = next(layer_a.getFeatures())
+            self.assertEqual(f.geometry().asWkt().upper(), 'POINT (9 43)')
+            self.assertEqual(buffer.changedGeometries()[1].asWkt().upper(), 'POINT (9 43)')
+            layer_a.undoStack().undo()
+            self.assertEqual(buffer.changedGeometries(), {})
+            f = next(layer_a.getFeatures())
+
+            self.assertEqual(f.geometry().asWkt().upper(), 'POINT (7 45)')
+            self.assertEqual(buffer.changedGeometries(), {})
+
+            # Delete an existing feature
+            self.assertTrue(layer_a.deleteFeature(f.id()))
+            with self.assertRaises(StopIteration):
+                next(layer_a.getFeatures())
+            self.assertEqual(buffer.deletedFeatureIds(), [f.id()])
+
+            layer_a.undoStack().undo()
+            self.assertTrue(layer_a.getFeature(f.id()).isValid())
+            self.assertEqual(buffer.deletedFeatureIds(), [])
+
+            ###########################################
+            # Test delete
+
+            # Delete a new feature
+            f = QgsFeature(layer_a.fields())
+            f.setAttribute('int', 555)
+            f.setGeometry(QgsGeometry.fromWkt('point(8 46)'))
+            self.assertTrue(layer_a.addFeatures([f]))
+            f = [f for f in layer_a.getFeatures() if f.attribute('int') == 555][0]
+            self.assertTrue(f.id() in buffer.addedFeatures())
+            self.assertTrue(layer_a.deleteFeature(f.id()))
+            self.assertFalse(f.id() in buffer.addedFeatures())
+            self.assertFalse(f.id() in buffer.deletedFeatureIds())
+
+            layer_a.undoStack().undo()
+            self.assertTrue(f.id() in buffer.addedFeatures())
+
+            ###########################################
+            # Add attribute
+
+            field = QgsField('attr1', QVariant.String)
+            self.assertTrue(layer_a.addAttribute(field))
+            self.assertNotEqual(layer_a.fields().lookupField(field.name()), -1)
+
+            layer_a.undoStack().undo()
+            self.assertEqual(layer_a.fields().lookupField(field.name()), -1)
+
+            layer_a.undoStack().redo()
+            self.assertNotEqual(layer_a.fields().lookupField(field.name()), -1)
+
+            self.assertTrue(layer_a.commitChanges())
+
+            ###########################################
+            # Remove attribute
+
+            self.assertTrue(layer_a.startEditing())
+
+            attr_idx = layer_a.fields().lookupField(field.name())
+            self.assertNotEqual(attr_idx, -1)
+
+            self.assertTrue(layer_a.deleteAttribute(attr_idx))
+            self.assertEqual(layer_a.fields().lookupField(field.name()), -1)
+
+            layer_a.undoStack().undo()
+            self.assertEqual(layer_a.fields().lookupField(field.name()), attr_idx)
+
+            layer_a.undoStack().redo()
+            self.assertEqual(layer_a.fields().lookupField(field.name()), -1)
+
+            self.assertTrue(layer_a.rollBack())
+
+            ###########################################
+            # Rename attribute
+
+            self.assertTrue(layer_a.startEditing())
+
+            attr_idx = layer_a.fields().lookupField(field.name())
+            self.assertNotEqual(attr_idx, -1)
+
+            self.assertEqual(layer_a.fields().lookupField('new_name'), -1)
+            self.assertTrue(layer_a.renameAttribute(attr_idx, 'new_name'))
+            self.assertEqual(layer_a.fields().lookupField('new_name'), attr_idx)
+
+            layer_a.undoStack().undo()
+            self.assertEqual(layer_a.fields().lookupField(field.name()), attr_idx)
+            self.assertEqual(layer_a.fields().lookupField('new_name'), -1)
+
+            layer_a.undoStack().redo()
+            self.assertEqual(layer_a.fields().lookupField('new_name'), attr_idx)
+            self.assertEqual(layer_a.fields().lookupField(field.name()), -1)
 
         _test(False)
         _test(True)


### PR DESCRIPTION
This started as a fix for #41477 but ended up with quite a refactoring.

The basic idea is to make the pass through buffer that we use in transactions to behave like the standard buffer from an API point of view.

I wrote a new test that covers all the cases and expects the same results for transactional and standard buffers:
- add/remove features
- add/remove fields
- change geometry
- change attribute

The test also checks the return values of `QgsVectorLayerEditBuffer`:
- `changedAttributeValues`
- `deletedAttributeIds`
- `addedAttributes`
- `changedGeometries`
- `deletedFeatureIds`
- `addedFeatures`

