### PR TITLE
Fix calculation info in Measure Line tool

### DIFF
--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -461,12 +461,12 @@ void QgsMeasureDialog::updateUi()
       toolTip += "<br> * ";
       if ( mCartesian->isChecked() )
       {
-        toolTip += tr( "Cartesian calculation selected, so area is calculated using Cartesian calculations." );
+        toolTip += tr( "Cartesian calculation selected, so distance is calculated using Cartesian calculations." );
         mConvertToDisplayUnits = true;
       }
       else
       {
-        toolTip += tr( "No map projection set, so area is calculated using Cartesian calculations." );
+        toolTip += tr( "No map projection set, so distance is calculated using Cartesian calculations." );
         toolTip += "<br> * " + tr( "Units are unknown." );
         mConvertToDisplayUnits = false;
       }


### PR DESCRIPTION
## Description

Fixes an unreported typo in the **Measure Line** tool calculation info

![image](https://user-images.githubusercontent.com/16253859/107888652-0344d500-6f0e-11eb-98dc-91a54574a0c9.png)

where "**area** is calculated" is used instead of "**distance** is calculated".

This affects the 3.16 branch too.

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
