### PR TITLE
Add symbol button to allow users to customise the line symbol used in collapsed data defined size legends

### DIFF
--- a/src/core/qgsdatadefinedsizelegend.cpp
+++ b/src/core/qgsdatadefinedsizelegend.cpp
@@ -300,7 +300,6 @@ void QgsDataDefinedSizeLegend::drawCollapsedLegend( QgsRenderContext &context, Q
 
   if ( mLineSymbol )
   {
-    mLineSymbol->setColor( mTextColor );
     mLineSymbol->startRender( context );
   }
 
@@ -375,10 +374,10 @@ QgsDataDefinedSizeLegend *QgsDataDefinedSizeLegend::readXml( const QDomElement &
     ddsLegend->setSymbol( QgsSymbolLayerUtils::loadSymbol<QgsMarkerSymbol>( elemSymbol, context ) );
   }
 
-  QDomElement lineSymbol = elem.firstChildElement( QStringLiteral( "lineSymbol" ) );
-  if ( !lineSymbol.isNull() )
+  const QDomElement lineSymbolElem = elem.firstChildElement( QStringLiteral( "lineSymbol" ) );
+  if ( !lineSymbolElem.isNull() )
   {
-    ddsLegend->setLineSymbol( QgsSymbolLayerUtils::loadSymbol<QgsLineSymbol>( lineSymbol, context ) );
+    ddsLegend->setLineSymbol( QgsSymbolLayerUtils::loadSymbol<QgsLineSymbol>( lineSymbolElem.firstChildElement(), context ) );
   }
 
   QgsSizeScaleTransformer *transformer = nullptr;
@@ -435,8 +434,9 @@ void QgsDataDefinedSizeLegend::writeXml( QDomElement &elem, const QgsReadWriteCo
 
   if ( mLineSymbol )
   {
-    QDomElement elemSymbol = QgsSymbolLayerUtils::saveSymbol( QStringLiteral( "lineSymbol" ), mLineSymbol.get(), doc, context );
-    elem.appendChild( elemSymbol );
+    QDomElement lineSymbolElem = doc.createElement( QStringLiteral( "lineSymbol" ) );
+    lineSymbolElem.appendChild( QgsSymbolLayerUtils::saveSymbol( QStringLiteral( "lineSymbol" ), mLineSymbol.get(), doc, context ) );
+    elem.appendChild( lineSymbolElem );
   }
 
   if ( mSizeScaleTransformer )

--- a/src/gui/symbology/qgsdatadefinedsizelegendwidget.cpp
+++ b/src/gui/symbology/qgsdatadefinedsizelegendwidget.cpp
@@ -39,6 +39,8 @@ QgsDataDefinedSizeLegendWidget::QgsDataDefinedSizeLegendWidget( const QgsDataDef
   setupUi( this );
   setPanelTitle( tr( "Data-defined Size Legend" ) );
 
+  mLineSymbolButton->setSymbolType( QgsSymbol::Line );
+
   QgsMarkerSymbol *symbol = nullptr;
 
   if ( !ddsLegend )
@@ -56,6 +58,9 @@ QgsDataDefinedSizeLegendWidget::QgsDataDefinedSizeLegendWidget( const QgsDataDef
       cboAlignSymbols->setCurrentIndex( 0 );
     else
       cboAlignSymbols->setCurrentIndex( 1 );
+
+    if ( ddsLegend->lineSymbol() )
+      mLineSymbolButton->setSymbol( ddsLegend->lineSymbol()->clone() );
 
     symbol = ddsLegend->symbol() ? ddsLegend->symbol()->clone() : nullptr;  // may be null (undefined)
   }
@@ -120,6 +125,7 @@ QgsDataDefinedSizeLegendWidget::QgsDataDefinedSizeLegendWidget( const QgsDataDef
   connect( groupManualSizeClasses, &QGroupBox::clicked, this, &QgsPanelWidget::widgetChanged );
   connect( btnChangeSymbol, &QPushButton::clicked, this, &QgsDataDefinedSizeLegendWidget::changeSymbol );
   connect( editTitle, &QLineEdit::textChanged, this, &QgsPanelWidget::widgetChanged );
+  connect( mLineSymbolButton, &QgsSymbolButton::changed, this, &QgsPanelWidget::widgetChanged );
   connect( this, &QgsPanelWidget::widgetChanged, this, &QgsDataDefinedSizeLegendWidget::updatePreview );
   updatePreview();
 }
@@ -157,6 +163,8 @@ QgsDataDefinedSizeLegend *QgsDataDefinedSizeLegendWidget::dataDefinedSizeLegend(
     }
     ddsLegend->setClasses( classes );
   }
+
+  ddsLegend->setLineSymbol( mLineSymbolButton->clonedSymbol< QgsLineSymbol >() );
   return ddsLegend;
 }
 

--- a/src/ui/qgsdatadefinedsizelegendwidget.ui
+++ b/src/ui/qgsdatadefinedsizelegendwidget.ui
@@ -133,15 +133,8 @@
        <property name="title">
         <string>Options (collapsed only)</string>
        </property>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Align symbols</string>
-          </property>
-         </widget>
-        </item>
-        <item>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="1">
          <widget class="QComboBox" name="cboAlignSymbols">
           <item>
            <property name="text">
@@ -153,6 +146,33 @@
             <string>Center</string>
            </property>
           </item>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Align symbols</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QgsSymbolButton" name="mLineSymbolButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Change…</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Line symbol</string>
+          </property>
          </widget>
         </item>
        </layout>
@@ -175,6 +195,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>radDisabled</tabstop>
   <tabstop>radSeparated</tabstop>


### PR DESCRIPTION
While it was possible to set the symbol style via api, there was
no UI to allow users to set this themselves, which meant that you
were stuck with the default black solid line symbol (which could
be totally unreadable on dark backgrounds...)
