### PR TITLE
Reactivate documentation bot

### DIFF
--- a/.github/workflows/pr-needs-docs-message.yml
+++ b/.github/workflows/pr-needs-docs-message.yml
@@ -1,7 +1,7 @@
 name: Ping PR author about documentation
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - labeled


### PR DESCRIPTION
I have no idea whether it's the fix nor means to test it elsewhere... but this tool is broken for weeks (#41339) - just testing the message trigger (not the issue report part, yet)