### PR TITLE
Add support for showing custom plugin widgets in the raster layer properties dialog

### DIFF
--- a/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
+++ b/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
@@ -39,6 +39,8 @@ Constructor
     void addPropertiesPageFactory( QgsMapLayerConfigWidgetFactory *factory );
 %Docstring
 Adds a properties page factory to the raster layer properties dialog.
+
+.. versionadded:: 3.18
 %End
 
   protected slots:

--- a/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
+++ b/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
@@ -36,6 +36,11 @@ Constructor
 :param fl: windows flag
 %End
 
+    void addPropertiesPageFactory( QgsMapLayerConfigWidgetFactory *factory );
+%Docstring
+Adds a properties page factory to the raster layer properties dialog.
+%End
+
   protected slots:
 
 };

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -16230,6 +16230,12 @@ void QgisApp::showLayerProperties( QgsMapLayer *mapLayer, const QString &page )
     case QgsMapLayerType::RasterLayer:
     {
       QgsRasterLayerProperties *rasterLayerPropertiesDialog = new QgsRasterLayerProperties( mapLayer, mMapCanvas, this );
+
+      for ( QgsMapLayerConfigWidgetFactory *factory : qgis::as_const( mMapLayerPanelFactories ) )
+      {
+        rasterLayerPropertiesDialog->addPropertiesPageFactory( factory );
+      }
+
       if ( !page.isEmpty() )
         rasterLayerPropertiesDialog->setCurrentPage( page );
 

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -949,8 +949,7 @@ void QgsRasterLayerProperties::sync()
 
   mTemporalWidget->syncToLayer();
 
-  const auto constMLayerPropertiesPages = mLayerPropertiesPages;
-  for ( QgsMapLayerConfigWidget *page : constMLayerPropertiesPages )
+  for ( QgsMapLayerConfigWidget *page : qgis::as_const( mLayerPropertiesPages ) )
   {
     page->syncToLayer( mRasterLayer );
   }

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -79,7 +79,10 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
      */
     QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *canvas, QWidget *parent = nullptr, Qt::WindowFlags = QgsGuiUtils::ModalDialogFlags );
 
-    //! Adds a properties page factory to the raster layer properties dialog.
+    /**
+     * Adds a properties page factory to the raster layer properties dialog.
+     * \since QGIS 3.18
+     */
     void addPropertiesPageFactory( QgsMapLayerConfigWidgetFactory *factory );
 
   protected slots:

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -41,6 +41,8 @@ class QgsRasterHistogramWidget;
 class QgsRasterLayerTemporalPropertiesWidget;
 class QgsWebView;
 class QgsProviderSourceWidget;
+class QgsMapLayerConfigWidgetFactory;
+class QgsMapLayerConfigWidget;
 
 
 /**
@@ -76,6 +78,9 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
      * \param fl windows flag
      */
     QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *canvas, QWidget *parent = nullptr, Qt::WindowFlags = QgsGuiUtils::ModalDialogFlags );
+
+    //! Adds a properties page factory to the raster layer properties dialog.
+    void addPropertiesPageFactory( QgsMapLayerConfigWidgetFactory *factory );
 
   protected slots:
     //! \brief auto slot executed when the active page in the main widget stack is changed
@@ -190,6 +195,9 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     QPushButton *mBtnMetadata = nullptr;
     QAction *mActionLoadMetadata = nullptr;
     QAction *mActionSaveMetadataAs = nullptr;
+
+    //! A list of additional pages provided by plugins
+    QList<QgsMapLayerConfigWidget *> mLayerPropertiesPages;
 
     //! \brief  A constant that signals property not used
     const QString TRSTRING_NOT_SET;


### PR DESCRIPTION
Fixes https://github.com/qgis/QGIS/issues/28060.

Enables loading of plugin provided widgets in the raster layer properties dialog, using the same approach that was implemented for the similar functionality in the vector layer properties dialog.

Screenshot using the [QFieldSync plugin](https://qfield.org/docs/synchronise/qfieldsync.html) which create a custom map layer widget when installed.
![raster_layer_properties_custom_widgets_2](https://user-images.githubusercontent.com/2663775/107934233-d71e6800-6f90-11eb-83ef-3bf3934007eb.gif)


