### PR TITLE
Fix misleading error message when an attribute form fails to save changes (3.16)

### DIFF
--- a/python/gui/auto_generated/qgsattributeform.sip.in
+++ b/python/gui/auto_generated/qgsattributeform.sip.in
@@ -279,6 +279,18 @@ Save all the values from the editors to the layer.
 :return: ``True`` if successful
 %End
 
+    bool saveWithDetails( QString *error /Out/ = 0 );
+%Docstring
+Save all the values from the editors to the layer.
+
+
+:return: - ``True`` if save was successful
+         - error: will be set to an explanatory error message if an error occurs while saving the form.
+
+
+.. versionadded:: 3.18
+%End
+
     void resetValues();
 %Docstring
 Sets all values to the values of the current feature

--- a/src/gui/qgsattributedialog.cpp
+++ b/src/gui/qgsattributedialog.cpp
@@ -66,15 +66,19 @@ void QgsAttributeDialog::setHighlight( QgsHighlight *h )
 
 void QgsAttributeDialog::accept()
 {
-  bool didSave = mAttributeForm->save();
+  QString error;
+  const bool didSave = mAttributeForm->saveWithDetails( &error );
   if ( didSave )
   {
     QDialog::accept();
   }
   else
   {
+    if ( error.isEmpty() )
+      error = tr( "An unknown error was encountered saving attributes" );
+
     mMessageBar->pushMessage( QString(),
-                              tr( "Your JSON value is invalid and has not been saved" ),
+                              error,
                               Qgis::MessageLevel::Critical,
                               5 );
   }

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -320,7 +320,7 @@ void QgsAttributeForm::setFeature( const QgsFeature &feature )
   mIsSettingFeature = false;
 }
 
-bool QgsAttributeForm::saveEdits()
+bool QgsAttributeForm::saveEdits( QString *error )
 {
   bool success = true;
   bool changedLayer = false;
@@ -344,9 +344,11 @@ bool QgsAttributeForm::saveEdits()
       if ( eww )
       {
         // check for invalid JSON values
-        QgsTextEditWrapper *text_edit = qobject_cast<QgsTextEditWrapper *>( eww );
-        if ( text_edit && text_edit->isInvalidJSON() )
+        QgsTextEditWrapper *textEdit = qobject_cast<QgsTextEditWrapper *>( eww );
+        if ( textEdit && textEdit->isInvalidJSON() )
         {
+          if ( error )
+            *error = tr( "JSON value for %1 is invalid and has not been saved" ).arg( eww->field().name() );
           return false;
         }
         QVariantList dstVars = QVariantList() << dst.at( eww->fieldIdx() );
@@ -737,6 +739,14 @@ bool QgsAttributeForm::saveMultiEdits()
 
 bool QgsAttributeForm::save()
 {
+  return saveWithDetails( nullptr );
+}
+
+bool QgsAttributeForm::saveWithDetails( QString *error )
+{
+  if ( error )
+    error->clear();
+
   if ( mIsSaving )
     return true;
 
@@ -782,7 +792,7 @@ bool QgsAttributeForm::save()
     case QgsAttributeEditorContext::FixAttributeMode:
     case QgsAttributeEditorContext::SearchMode:
     case QgsAttributeEditorContext::AggregateSearchMode:
-      success = saveEdits();
+      success = saveEdits( error );
       break;
 
     case QgsAttributeEditorContext::MultiEditMode:
@@ -796,6 +806,7 @@ bool QgsAttributeForm::save()
 
   return success;
 }
+
 
 void QgsAttributeForm::resetValues()
 {

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -294,6 +294,17 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     bool save();
 
     /**
+     * Save all the values from the editors to the layer.
+     *
+     * \param error if specified, will be set to an explanatory error message if an error occurs while saving the form.
+     *
+     * \returns TRUE if save was successful
+     *
+     * \since QGIS 3.18
+     */
+    bool saveWithDetails( QString *error SIP_OUT = nullptr );
+
+    /**
      * Sets all values to the values of the current feature
      */
     void resetValues();
@@ -388,7 +399,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void scanForEqualAttributes( QgsFeatureIterator &fit, QSet< int > &mixedValueFields, QHash< int, QVariant > &fieldSharedValues ) const;
 
     //! Save single feature or add feature edits
-    bool saveEdits();
+    bool saveEdits( QString *error );
 
     //! fill up dependency map for default values
     void createDefaultValueDependencies();


### PR DESCRIPTION
Regardless of the reason why the saving failed, a message about
invalid JSON was always shown... which is totally confusing for
users when a table has NO json fields or values (ﾉ｀Д´)ﾉ

Backport of https://github.com/qgis/QGIS/pull/41555

