### PR TITLE
Reformat elapsed time in processing to express time in hours, minutes and seconds 

### DIFF
--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -178,9 +178,9 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                 minutes = int((delta_t % 3600) / 60)
                 seconds = delta_t - hours*3600 - minutes*60
 
-                str_hours = ["hour", "hours"][hours > 1]
-                str_minutes = ["minute", "minutes"][minutes > 1]
-                str_seconds = ["second", "seconds"][seconds != 1]
+                str_hours = [self.tr("hour"), self.tr("hours")][hours > 1]
+                str_minutes = [self.tr("minute"), self.tr("minutes")][minutes > 1]
+                str_seconds = [self.tr("second"), self.tr("seconds"])[seconds != 1]
 
                 if hours > 0:
                     elapsed = '{0} {1:0.2f} {2} ({3} {4} {5} {6} {7:0.0f} {2})'.format(

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -179,7 +179,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
 
                 str_hours = [self.tr("hour"), self.tr("hours")][hours > 1]
                 str_minutes = [self.tr("minute"), self.tr("minutes")][minutes > 1]
-                str_seconds = [self.tr("second"), self.tr("seconds"])[seconds != 1]
+                str_seconds = [self.tr("second"), self.tr("seconds")][seconds != 1]
 
                 if hours > 0:
                     elapsed = '{0} {1:0.2f} {2} ({3} {4} {5} {6} {7:0.0f} {2})'.format(

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -171,6 +171,29 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
             self.feedback.pushInfo('')
             start_time = time.time()
 
+            # Formating elapsed time
+            def elapsed_time(start_time, result):
+                delta_t = time.time() - start_time
+                hours = int(delta_t / 3600)
+                minutes = int((delta_t % 3600) / 60)
+                seconds = delta_t - hours*3600 - minutes*60
+
+                str_hours = ["hour", "hours"][hours > 1]
+                str_minutes = ["minute", "minutes"][minutes > 1]
+                str_seconds = ["second", "seconds"][seconds != 1]
+
+                if hours > 0:
+                    elapsed = '{0} {1:0.2f} {2} ({3} {4} {5} {6} {7:0.0f} {2})'.format(
+                        result, delta_t, str_seconds, hours, str_hours, minutes, str_minutes, seconds) 
+                elif minutes > 0:
+                    elapsed = '{0} {1:0.2f} {2} ({3} {4} {5:0.0f} {2})'.format(
+                        result, delta_t, str_seconds, minutes, str_minutes, seconds) 
+                else:
+                    elapsed = '{0} {1:0.2f} {2}'.format(result, delta_t, str_seconds) 
+
+                return(elapsed)
+
+
             if self.iterateParam:
                 # Make sure the Log tab is visible before executing the algorithm
                 try:
@@ -182,7 +205,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                 self.cancelButton().setEnabled(self.algorithm().flags() & QgsProcessingAlgorithm.FlagCanCancel)
                 if executeIterating(self.algorithm(), parameters, self.iterateParam, self.context, self.feedback):
                     self.feedback.pushInfo(
-                        self.tr('Execution completed in {0:0.2f} seconds').format(time.time() - start_time))
+                        self.tr(elapsed_time(start_time, 'Execution completed in')))
                     self.cancelButton().setEnabled(False)
                     self.finish(True, parameters, self.context, self.feedback)
                 else:
@@ -198,13 +221,13 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                 def on_complete(ok, results):
                     if ok:
                         self.feedback.pushInfo(
-                            self.tr('Execution completed in {0:0.2f} seconds').format(time.time() - start_time))
+                            self.tr(elapsed_time(start_time, 'Execution completed in')))
                         self.feedback.pushInfo(self.tr('Results:'))
                         r = {k: v for k, v in results.items() if k not in ('CHILD_RESULTS', 'CHILD_INPUTS')}
                         self.feedback.pushCommandInfo(pformat(r))
                     else:
                         self.feedback.reportError(
-                            self.tr('Execution failed after {0:0.2f} seconds').format(time.time() - start_time))
+                            self.tr(elapsed_time(start_time, 'Execution failed after')))
                     self.feedback.pushInfo('')
 
                     if self.feedback_dialog is not None:

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -171,12 +171,11 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
             self.feedback.pushInfo('')
             start_time = time.time()
 
-            # Formating elapsed time
             def elapsed_time(start_time, result):
                 delta_t = time.time() - start_time
                 hours = int(delta_t / 3600)
                 minutes = int((delta_t % 3600) / 60)
-                seconds = delta_t - hours*3600 - minutes*60
+                seconds = delta_t - hours * 3600 - minutes * 60
 
                 str_hours = [self.tr("hour"), self.tr("hours")][hours > 1]
                 str_minutes = [self.tr("minute"), self.tr("minutes")][minutes > 1]
@@ -184,15 +183,15 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
 
                 if hours > 0:
                     elapsed = '{0} {1:0.2f} {2} ({3} {4} {5} {6} {7:0.0f} {2})'.format(
-                        result, delta_t, str_seconds, hours, str_hours, minutes, str_minutes, seconds) 
+                        result, delta_t, str_seconds, hours, str_hours, minutes, str_minutes, seconds)
                 elif minutes > 0:
                     elapsed = '{0} {1:0.2f} {2} ({3} {4} {5:0.0f} {2})'.format(
-                        result, delta_t, str_seconds, minutes, str_minutes, seconds) 
+                        result, delta_t, str_seconds, minutes, str_minutes, seconds)
                 else:
-                    elapsed = '{0} {1:0.2f} {2}'.format(result, delta_t, str_seconds) 
+                    elapsed = '{0} {1:0.2f} {2}'.format(
+                        result, delta_t, str_seconds)
 
                 return(elapsed)
-
 
             if self.iterateParam:
                 # Make sure the Log tab is visible before executing the algorithm


### PR DESCRIPTION
When appropriate, express the elapsed time in hours, minutes and seconds in addition to cumulative seconds. It keeps the current way in first position. I often find myself trying to figure out exactly how long 27620.43 seconds is after a lengthy processing. This way, it will save a few seconds of brain processing...

Before:
`Execution completed in 27620.43 seconds`

After:
`Execution completed in 27620.43 seconds (7 hours 40 minutes 20 seconds)`
