### PR TITLE
Fix text edit widget wrapper incorrectly shows "NULL" string for indeterminate state

### DIFF
--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -195,7 +195,6 @@ bool QgsTextEditWrapper::valid() const
 
 void QgsTextEditWrapper::showIndeterminateState()
 {
-  //note - this is deliberately a zero length string, not a null string!
   if ( mTextEdit )
     mTextEdit->blockSignals( true );
   if ( mPlainTextEdit )
@@ -208,7 +207,8 @@ void QgsTextEditWrapper::showIndeterminateState()
     mLineEdit->setPlaceholderText( QString() );
   }
 
-  setWidgetValue( QString() );
+  //note - this is deliberately a zero length string, not a null string!
+  setWidgetValue( QStringLiteral( "" ) );  // skip-keyword-check
 
   if ( mTextEdit )
     mTextEdit->blockSignals( false );

--- a/tests/src/python/test_qgseditwidgets.py
+++ b/tests/src/python/test_qgseditwidgets.py
@@ -93,6 +93,22 @@ class TestQgsTextEditWidget(unittest.TestCase):
 
         QgsProject.instance().removeAllMapLayers()
 
+    def test_indeterminate_state(self):
+        """
+        Test the indeterminate state for the wrapper
+        """
+        layer = QgsVectorLayer("none?field=fld:string", "layer", "memory")
+        reg = QgsGui.editorWidgetRegistry()
+        configWdg = reg.createConfigWidget('TextEdit', layer, 0, None)
+        config = configWdg.config()
+        editwidget = reg.create('TextEdit', layer, 0, config, None, None)
+
+        editwidget.setValue('value')
+        self.assertEqual(editwidget.value(), 'value')
+        editwidget.showIndeterminateState()
+        self.assertFalse(editwidget.value())
+        self.assertFalse(editwidget.widget().toPlainText())
+
 
 class TestQgsValueRelationWidget(unittest.TestCase):
 


### PR DESCRIPTION
When editing multiple features with differing values for a text edit widget field, the widget should show an empty line edit and not a widget showing "NULL".
