### PR TITLE
Point cloud UI small improvements

### DIFF
--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -622,6 +622,11 @@ int QgsPointCloud3DSymbolWidget::pointBudget() const
   return mPointBudgetSpinBox->value();
 }
 
+void QgsPointCloud3DSymbolWidget::setPointCloudSize( int size )
+{
+  mPointCloudSizeLabel->setText( QStringLiteral( "%1 points" ).arg( size ) );
+}
+
 double QgsPointCloud3DSymbolWidget::showBoundingBoxes() const
 {
   return mShowBoundingBoxesCheckBox->isChecked();

--- a/src/app/3d/qgspointcloud3dsymbolwidget.h
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.h
@@ -45,6 +45,8 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
     void setPointBudget( int budget );
     int pointBudget() const;
 
+    void setPointCloudSize( int size );
+
     void connectChildPanels( QgsPanelWidget *parent );
 
   private slots:

--- a/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
+++ b/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
@@ -48,6 +48,7 @@ void QgsPointCloudLayer3DRendererWidget::setRenderer( const QgsPointCloudLayer3D
     mWidgetPointCloudSymbol->setPointBudget( renderer->pointRenderingBudget() );
     mWidgetPointCloudSymbol->setMaximumScreenError( renderer->maximumScreenError() );
     mWidgetPointCloudSymbol->setShowBoundingBoxes( renderer->showBoundingBoxes() );
+    mWidgetPointCloudSymbol->setPointCloudSize( renderer->layer()->pointCount() );
   }
 }
 

--- a/src/app/pointcloud/qgspointcloudelevationpropertieswidget.cpp
+++ b/src/app/pointcloud/qgspointcloudelevationpropertieswidget.cpp
@@ -33,6 +33,7 @@ QgsPointCloudElevationPropertiesWidget::QgsPointCloudElevationPropertiesWidget( 
 
   connect( mOffsetZSpinBox, qgis::overload<double >::of( &QDoubleSpinBox::valueChanged ), this, &QgsPointCloudElevationPropertiesWidget::onChanged );
   connect( mScaleZSpinBox, qgis::overload<double >::of( &QDoubleSpinBox::valueChanged ), this, &QgsPointCloudElevationPropertiesWidget::onChanged );
+  connect( mShifPointCloudZAxisButton, &QPushButton::clicked, this, &QgsPointCloudElevationPropertiesWidget::shiftPointCloudZAxis );
 }
 
 void QgsPointCloudElevationPropertiesWidget::syncToLayer( QgsMapLayer *layer )
@@ -61,6 +62,15 @@ void QgsPointCloudElevationPropertiesWidget::onChanged()
 {
   if ( !mBlockUpdates )
     emit widgetChanged();
+}
+
+void QgsPointCloudElevationPropertiesWidget::shiftPointCloudZAxis()
+{
+  QgsDoubleRange range = mLayer->elevationProperties()->calculateZRange( mLayer );
+  if ( !range.isEmpty() )
+  {
+    mOffsetZSpinBox->setValue( -range.lower() + mOffsetZSpinBox->value() );
+  }
 }
 
 //

--- a/src/app/pointcloud/qgspointcloudelevationpropertieswidget.h
+++ b/src/app/pointcloud/qgspointcloudelevationpropertieswidget.h
@@ -38,7 +38,7 @@ class QgsPointCloudElevationPropertiesWidget : public QgsMapLayerConfigWidget, p
   private slots:
 
     void onChanged();
-
+    void shiftPointCloudZAxis();
   private:
 
     QgsPointCloudLayer *mLayer = nullptr;

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -43,26 +43,33 @@
       </property>
       <item row="1" column="0">
        <layout class="QGridLayout" name="gridLayout_7">
-        <item row="2" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Point budget</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1" colspan="2">
-         <widget class="QgsDoubleSpinBox" name="mPointSizeSpinBox">
+        <item row="0" column="0">
+         <widget class="QLabel" name="lblTransparency_4">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="text">
+           <string>Point size</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Maximum screen space error</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1" colspan="2">
+         <widget class="QgsDoubleSpinBox" name="mMaxScreenErrorSpinBox">
           <property name="maximum">
-           <double>10.000000000000000</double>
+           <double>100000.000000000000000</double>
           </property>
           <property name="value">
-           <double>2.000000000000000</double>
+           <double>1.000000000000000</double>
           </property>
          </widget>
         </item>
@@ -82,33 +89,40 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Maximum screen space error</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="lblTransparency_4">
+        <item row="0" column="1" colspan="2">
+         <widget class="QgsDoubleSpinBox" name="mPointSizeSpinBox">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="text">
-           <string>Point size</string>
+          <property name="maximum">
+           <double>10.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>2.000000000000000</double>
           </property>
          </widget>
         </item>
-        <item row="1" column="1" colspan="2">
-         <widget class="QgsDoubleSpinBox" name="mMaxScreenErrorSpinBox">
-          <property name="maximum">
-           <double>100000.000000000000000</double>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Point budget</string>
           </property>
-          <property name="value">
-           <double>1.000000000000000</double>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Point cloud size:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1" colspan="2">
+         <widget class="QLabel" name="mPointCloudSizeLabel">
+          <property name="text">
+           <string>10000</string>
           </property>
          </widget>
         </item>

--- a/src/ui/pointcloud/qgspointcloudelevationpropertieswidgetbase.ui
+++ b/src/ui/pointcloud/qgspointcloudelevationpropertieswidgetbase.ui
@@ -57,6 +57,16 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Elevation scaling and offset can be used to manually correct elevation values in the point cloud at render time.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;The scale is applied to the point cloud elevation values before adding the offset.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
@@ -84,20 +94,20 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="Line" name="line_3">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
         </property>
        </widget>
       </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Elevation scaling and offset can be used to manually correct elevation values in the point cloud at render time.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;The scale is applied to the point cloud elevation values before adding the offset.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <item row="3" column="0" colspan="2">
+       <widget class="QPushButton" name="mShifPointCloudZAxisButton">
+        <property name="toolTip">
+         <string/>
         </property>
-        <property name="wordWrap">
-         <bool>true</bool>
+        <property name="text">
+         <string>Shift point cloud Z axis</string>
         </property>
        </widget>
       </item>
@@ -121,15 +131,15 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
## Description
- Added a button to move the point cloud up/down so that the lowest point will be at Z=0
![Screenshot from 2021-02-16 15-28-16](https://user-images.githubusercontent.com/29183781/108083502-6bf99200-7073-11eb-8e8f-776b1abd1903.png)
- Added a label below the point budget spin box that tells the user how many points are in the point cloud:
![Screenshot from 2021-02-16 16-22-29](https://user-images.githubusercontent.com/29183781/108083604-8fbcd800-7073-11eb-93a6-4e66b516a5dd.png)
 