### PR TITLE
Ignore getLegendGraphic URL if GetMap url is ignored

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3723,7 +3723,15 @@ QUrl QgsWmsProvider::getLegendGraphicFullURL( double scale, const QgsRectangle &
 {
   bool useContextualWMSLegend = mSettings.mEnableContextualLegend;
 
-  QString lurl = getLegendGraphicUrl();
+  QString lurl;
+  if ( mSettings.mIgnoreGetMapUrl )
+  {
+    lurl = mSettings.mBaseUrl;
+  }
+  else
+  {
+    lurl = getLegendGraphicUrl();
+  }
 
   if ( lurl.isEmpty() )
   {

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -119,7 +119,7 @@
          <item row="1" column="0" colspan="2">
           <widget class="QCheckBox" name="cbxIgnoreGetMapURI">
            <property name="text">
-            <string>Ignore GetMap/GetTile URI reported in capabilities</string>
+            <string>Ignore GetMap/GetTile/GetLegendGraphic URI reported in capabilities</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
This PR goes has the same purpose as https://github.com/qgis/QGIS/pull/39231 , but uses a simpler approach.
In many WMS Servers, the urls advertisedin the GetCapabilities-Document are wrong or they are some internal urls not reachable from outside. In this case, it should be possible to ignore the advertised urls. Currently, the urls for GetMap and GetFeatureInfo can be ignored, but not the GetLegendGraphic url.
This PR ignores the GetLegendGraphic url, if the  GetMap url is ignored (as in PR 39231). Another possibility would be to introduce a new mIgnoreGetLegendGraphicUrl setting and add a checkbox into the WMS connection dialog.What do you think?