### PR TITLE
Don't loop through all selected features multiple times (once per field) when the attribute form is opened (3.16)

### DIFF
--- a/python/core/auto_generated/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerutils.sip.in
@@ -288,11 +288,35 @@ Optionally, ``sinkFlags`` can be specified to further refine the compatibility l
 
     static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature );
 %Docstring
+Tests whether a field is editable for a particular ``feature``.
 
-:return: ``True`` if the:param feature: field at index:param fieldIndex: from:param layer:
-          is editable, ``False`` if the field is readonly
+:return: ``True`` if the field at index ``fieldIndex`` from ``layer``
+         is editable, ``False`` if the field is read only.
 
 .. versionadded:: 3.10
+%End
+
+    static bool fieldIsReadOnly( const QgsVectorLayer *layer, int fieldIndex );
+%Docstring
+
+:return: ``True`` if the field at index ``fieldIndex`` from ``layer``
+         is editable, ``False`` if the field is read only.
+
+If this function returns ``True`` then the editability of the field may still vary feature by
+feature. See :py:func:`~QgsVectorLayerUtils.fieldIsEditable` to determine this on a feature by feature basis.
+
+.. versionadded:: 3.18
+%End
+
+    static bool fieldEditabilityDependsOnFeature( const QgsVectorLayer *layer, int fieldIndex );
+%Docstring
+Returns ``True`` if the editability of the field at index ``fieldIndex`` from ``layer`` may vary
+feature by feature.
+
+I.e. if the field is taken from a joined layer, the value may or may not be editable for any individual
+feature depending on the join's "upsert on edit" capabilities.
+
+.. versionadded:: 3.18
 %End
 
 

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -298,12 +298,36 @@ class CORE_EXPORT QgsVectorLayerUtils
     static QgsFeatureList makeFeaturesCompatible( const QgsFeatureList &features, const QgsVectorLayer *layer, QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags() );
 
     /**
-     * \return TRUE if the \param feature field at index \param fieldIndex from \param layer
-     * is editable, FALSE if the field is readonly
+     * Tests whether a field is editable for a particular \a feature.
+     *
+     * \returns TRUE if the field at index \a fieldIndex from \a layer
+     * is editable, FALSE if the field is read only.
      *
      * \since QGIS 3.10
      */
     static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature );
+
+    /**
+     * \returns TRUE if the field at index \a fieldIndex from \a layer
+     * is editable, FALSE if the field is read only.
+     *
+     * If this function returns TRUE then the editability of the field may still vary feature by
+     * feature. See fieldIsEditable() to determine this on a feature by feature basis.
+     *
+     * \since QGIS 3.18
+     */
+    static bool fieldIsReadOnly( const QgsVectorLayer *layer, int fieldIndex );
+
+    /**
+     * Returns TRUE if the editability of the field at index \a fieldIndex from \a layer may vary
+     * feature by feature.
+     *
+     * I.e. if the field is taken from a joined layer, the value may or may not be editable for any individual
+     * feature depending on the join's "upsert on edit" capabilities.
+     *
+     * \since QGIS 3.18
+     */
+    static bool fieldEditabilityDependsOnFeature( const QgsVectorLayer *layer, int fieldIndex );
 
     /**
       * Returns masks defined in labeling options of a layer.

--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -230,30 +230,59 @@ void QgsAttributeFormEditorWidget::updateWidgets()
   //first update the tool buttons
   bool hasMultiEditButton = ( editPage()->layout()->indexOf( mMultiEditButton ) >= 0 );
 
-  const int fieldIndex = mEditorWidget->fieldIdx();
-
-  bool fieldReadOnly = false;
-  QgsFeature feature;
-  auto it = layer()->getSelectedFeatures();
-  while ( it.nextFeature( feature ) )
+  bool shouldShowMultiEditButton = false;
+  switch ( mode() )
   {
-    fieldReadOnly |= !QgsVectorLayerUtils::fieldIsEditable( layer(), fieldIndex, feature );
+    case QgsAttributeFormWidget::DefaultMode:
+    case QgsAttributeFormWidget::SearchMode:
+    case QgsAttributeFormWidget::AggregateSearchMode:
+      // in these modes we don't show the multi edit button
+      shouldShowMultiEditButton = false;
+      break;
+
+    case QgsAttributeFormWidget::MultiEditMode:
+    {
+      // in multi-edit mode we need to know upfront whether or not to allow add the multiedit buttons
+      // for this field.
+      // if the field is always read only regardless of the feature, no need to dig further. But otherwise
+      // we may need to test editability for the actual selected features...
+      const int fieldIndex = mEditorWidget->fieldIdx();
+      shouldShowMultiEditButton = !QgsVectorLayerUtils::fieldIsReadOnly( layer(), fieldIndex );
+      if ( shouldShowMultiEditButton )
+      {
+        // depending on the field type, the editability of the field may vary feature by feature (e.g. for joined
+        // fields coming from joins without the upsert on edit capabilities).
+        // But this feature-by-feature check is EXPENSIVE!!! (see https://github.com/qgis/QGIS/issues/41366), so
+        // avoid it whenever we can...
+        const bool fieldEditabilityDependsOnFeature = QgsVectorLayerUtils::fieldEditabilityDependsOnFeature( layer(), fieldIndex );
+        if ( fieldEditabilityDependsOnFeature )
+        {
+          QgsFeature feature;
+          QgsFeatureIterator it = layer()->getSelectedFeatures();
+          while ( it.nextFeature( feature ) )
+          {
+            const bool isEditable = QgsVectorLayerUtils::fieldIsEditable( layer(), fieldIndex, feature );
+            if ( !isEditable )
+            {
+              // as soon as we find one read-only feature for the field, we can break early...
+              shouldShowMultiEditButton = false;
+              break;
+            }
+          }
+        }
+      }
+    }
+    break;
   }
 
-  if ( hasMultiEditButton )
+  if ( hasMultiEditButton && !shouldShowMultiEditButton )
   {
-    if ( mode() != MultiEditMode || fieldReadOnly )
-    {
-      editPage()->layout()->removeWidget( mMultiEditButton );
-      mMultiEditButton->setParent( nullptr );
-    }
+    editPage()->layout()->removeWidget( mMultiEditButton );
+    mMultiEditButton->setParent( nullptr );
   }
-  else
+  else if ( !hasMultiEditButton && shouldShowMultiEditButton )
   {
-    if ( mode() == MultiEditMode && !fieldReadOnly )
-    {
-      editPage()->layout()->addWidget( mMultiEditButton );
-    }
+    editPage()->layout()->addWidget( mMultiEditButton );
   }
 
   switch ( mode() )
@@ -262,9 +291,7 @@ void QgsAttributeFormEditorWidget::updateWidgets()
     case MultiEditMode:
     {
       stack()->setCurrentWidget( editPage() );
-
       editPage()->layout()->addWidget( mConstraintResultLabel );
-
       break;
     }
 


### PR DESCRIPTION
This is incredibly expensive, yet only required in a very very small
corner case (field is from a joined layer without the upsert on edit
capabilities).

Refine logic to avoid the scan wherever we can.

Fixes #41366
Fixes #36863

(cherry picked from commit c6613593c72ac0411417d5a9aacf0335d52c4e66)

## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
