### PR TITLE
[georeferencer] Show a temporary marker at the clicked point after adding a point

### DIFF
--- a/src/app/georeferencer/qgsgcpcanvasitem.cpp
+++ b/src/app/georeferencer/qgsgcpcanvasitem.cpp
@@ -223,6 +223,11 @@ void QgsGCPCanvasItem::checkBoundingRectChange()
   prepareGeometryChange();
 }
 
+void QgsGCPCanvasItem::setPointColor( const QColor &color )
+{
+  mPointBrush.setColor( color );
+}
+
 double QgsGCPCanvasItem::fontSizePainterUnits( double points, const QgsRenderContext &c )
 {
   return points * 0.3527 * c.scaleFactor();

--- a/src/app/georeferencer/qgsgcpcanvasitem.h
+++ b/src/app/georeferencer/qgsgcpcanvasitem.h
@@ -41,6 +41,8 @@ class QgsGCPCanvasItem : public QgsMapCanvasItem
 
     QgsMapCanvas *canvas() const { return mMapCanvas; }
 
+    void setPointColor( const QColor &color );
+
   private:
 
     QgsGeorefDataPoint *mDataPoint = nullptr;

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -42,6 +42,7 @@ class QgsGeorefToolAddPoint;
 class QgsGeorefToolDeletePoint;
 class QgsGeorefToolMovePoint;
 class QgsGeorefToolMovePoint;
+class QgsGCPCanvasItem;
 
 class QgsGeorefDockWidget : public QgsDockWidget
 {
@@ -251,6 +252,8 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     QgsGeorefToolDeletePoint *mToolDeletePoint = nullptr;
     QgsGeorefToolMovePoint *mToolMovePoint = nullptr;
     QgsGeorefToolMovePoint *mToolMovePointQgis = nullptr;
+
+    QgsGCPCanvasItem *mNewlyAddedPointItem = nullptr;
 
     QgsGeorefDataPoint *mMovingPoint = nullptr;
     QgsGeorefDataPoint *mMovingPointQgis = nullptr;

--- a/src/app/georeferencer/qgsmapcoordsdialog.cpp
+++ b/src/app/georeferencer/qgsmapcoordsdialog.cpp
@@ -24,6 +24,7 @@
 #include "qgsapplication.h"
 #include "qgsprojectionselectionwidget.h"
 #include "qgsproject.h"
+#include "qgsgcpcanvasitem.h"
 
 QgsMapCoordsDialog::QgsMapCoordsDialog( QgsMapCanvas *qgisCanvas, const QgsPointXY &pixelCoords, QgsCoordinateReferenceSystem &rasterCrs, QWidget *parent )
   : QDialog( parent, Qt::Dialog )
@@ -72,6 +73,9 @@ QgsMapCoordsDialog::~QgsMapCoordsDialog()
 {
   delete mToolEmitPoint;
 
+  delete mNewlyAddedPointItem;
+  mNewlyAddedPointItem = nullptr;
+
   QgsSettings settings;
   settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/Config/Minimize" ), mMinimizeWindowCheckBox->isChecked() );
 }
@@ -114,6 +118,14 @@ void QgsMapCoordsDialog::maybeSetXY( const QgsPointXY &xy, Qt::MouseButton butto
     leYCoord->clear();
     leXCoord->setText( qgsDoubleToString( mapCoordPoint.x() ) );
     leYCoord->setText( qgsDoubleToString( mapCoordPoint.y() ) );
+
+    delete mNewlyAddedPointItem;
+    mNewlyAddedPointItem = nullptr;
+
+    // show a temporary marker at the clicked source point
+    mNewlyAddedPointItem = new QgsGCPCanvasItem( mQgisCanvas, nullptr, true );
+    mNewlyAddedPointItem->setPointColor( QColor( 0, 200, 0 ) );
+    mNewlyAddedPointItem->setPos( mNewlyAddedPointItem->toCanvasCoordinates( mapCoordPoint ) );
   }
 
   // only restore window if it was minimized

--- a/src/app/georeferencer/qgsmapcoordsdialog.h
+++ b/src/app/georeferencer/qgsmapcoordsdialog.h
@@ -23,8 +23,9 @@
 #include "qgsprojectionselectionwidget.h"
 #include "qgscoordinatereferencesystem.h"
 
-
 #include "ui_qgsmapcoordsdialogbase.h"
+
+class QgsGCPCanvasItem;
 
 class QPushButton;
 
@@ -84,6 +85,8 @@ class QgsMapCoordsDialog : public QDialog, private Ui::QgsMapCoordsDialogBase
     QgsGeorefMapToolEmitPoint *mToolEmitPoint = nullptr;
     QgsMapTool *mPrevMapTool = nullptr;
     QgsMapCanvas *mQgisCanvas = nullptr;
+
+    QgsGCPCanvasItem *mNewlyAddedPointItem = nullptr;
 
     QgsCoordinateReferenceSystem mRasterCrs;
 


### PR DESCRIPTION
...while the dialog for entering the map coordinates is open

This allows users to see the raster point they clicked while they search the map canvas for the corresponding point. Helps for people like me with goldfish memories who forget where they clicked on the raster and are trying to locate!

![Peek 2021-02-17 10-46](https://user-images.githubusercontent.com/1829991/108140315-9435cf00-710d-11eb-898a-31f3138c4b45.gif)
