### PR TITLE
[georeferencer] NEVER load raster file being referenced into the current project

### DIFF
--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -76,12 +76,6 @@ QgsGeorefDockWidget::QgsGeorefDockWidget( const QString &title, QWidget *parent,
 
 QgsGeoreferencerMainWindow::QgsGeoreferencerMainWindow( QWidget *parent, Qt::WindowFlags fl )
   : QMainWindow( parent, fl )
-  , mMousePrecisionDecimalPlaces( 0 )
-  , mTransformParam( QgsGeorefTransform::InvalidTransform )
-  , mAgainAddRaster( false )
-  , mMapCoordsDialog( nullptr )
-  , mUseZeroForTrans( false )
-  , mLoadInQgis( false )
 {
   setupUi( this );
   QgsGui::instance()->enableAutoGeometryRestore( this );
@@ -285,7 +279,9 @@ void QgsGeoreferencerMainWindow::openRaster( const QString &fileName )
   mGCPpointsFileName = mRasterFileName + ".points";
   ( void )loadGCPs();
 
-  mCanvas->setExtent( mLayer->extent() );
+  if ( mLayer )
+    mCanvas->setExtent( mLayer->extent() );
+
   mCanvas->refresh();
   QgisApp::instance()->mapCanvas()->refresh();
 
@@ -689,7 +685,7 @@ void QgsGeoreferencerMainWindow::showRasterPropertiesDialog()
 {
   if ( mLayer )
   {
-    QgisApp::instance()->showLayerProperties( mLayer );
+    QgisApp::instance()->showLayerProperties( mLayer.get() );
   }
   else
   {
@@ -734,7 +730,7 @@ void QgsGeoreferencerMainWindow::fullHistogramStretch()
 
 void QgsGeoreferencerMainWindow::localHistogramStretch()
 {
-  QgsRectangle rectangle = QgisApp::instance()->mapCanvas()->mapSettings().outputExtentToLayerExtent( mLayer, QgisApp::instance()->mapCanvas()->extent() );
+  QgsRectangle rectangle = QgisApp::instance()->mapCanvas()->mapSettings().outputExtentToLayerExtent( mLayer.get(), QgisApp::instance()->mapCanvas()->extent() );
 
   mLayer->setContrastEnhancement( QgsContrastEnhancement::StretchToMinimumMaximum, QgsRasterMinMaxOrigin::MinMax, rectangle );
   mCanvas->refresh();
@@ -865,28 +861,6 @@ void QgsGeoreferencerMainWindow::updateMouseCoordinatePrecision()
     dp = 0;
 
   mMousePrecisionDecimalPlaces = dp;
-}
-
-void QgsGeoreferencerMainWindow::extentsChanged()
-{
-  if ( mAgainAddRaster )
-  {
-    if ( QFile::exists( mRasterFileName ) )
-    {
-      addRaster( mRasterFileName );
-    }
-    else
-    {
-      mLayer = nullptr;
-      mAgainAddRaster = false;
-    }
-  }
-}
-
-// Registry layer QGis
-void QgsGeoreferencerMainWindow::layerWillBeRemoved( const QString &layerId )
-{
-  mAgainAddRaster = mLayer && mLayer->id().compare( layerId ) == 0;
 }
 
 // ------------------------------ private ---------------------------------- //
@@ -1173,11 +1147,6 @@ void QgsGeoreferencerMainWindow::setupConnections()
   // Connect status from ZoomLast/ZoomNext to corresponding action
   connect( mCanvas, &QgsMapCanvas::zoomLastStatusChanged, mActionZoomLast, &QAction::setEnabled );
   connect( mCanvas, &QgsMapCanvas::zoomNextStatusChanged, mActionZoomNext, &QAction::setEnabled );
-  // Connect when one Layer is removed - Case where change the Projetct in QGIS
-  connect( QgsProject::instance(), static_cast<void ( QgsProject::* )( const QString & )>( &QgsProject::layerWillBeRemoved ), this, &QgsGeoreferencerMainWindow::layerWillBeRemoved );
-
-  // Connect extents changed - Use for need add again Raster
-  connect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsGeoreferencerMainWindow::extentsChanged );
 
   // Connect mapCanvas rotation widget
   connect( mRotationEdit, static_cast < void ( QgsDoubleSpinBox::* )( double ) > ( &QgsDoubleSpinBox::valueChanged ), this, &QgsGeoreferencerMainWindow::updateCanvasRotation );
@@ -1186,13 +1155,8 @@ void QgsGeoreferencerMainWindow::setupConnections()
 
 void QgsGeoreferencerMainWindow::removeOldLayer()
 {
-  // delete layer (and don't signal it as it's our private layer)
-  if ( mLayer )
-  {
-    QgsProject::instance()->removeMapLayers(
-      ( QStringList() << mLayer->id() ) );
-    mLayer = nullptr;
-  }
+  mLayer.reset();
+
   mCanvas->setLayers( QList<QgsMapLayer *>() );
   mCanvas->clearCache();
   mRotationEdit->clear();
@@ -1202,16 +1166,11 @@ void QgsGeoreferencerMainWindow::removeOldLayer()
 // Mapcanvas Plugin
 void QgsGeoreferencerMainWindow::addRaster( const QString &file )
 {
-  mLayer = new QgsRasterLayer( file, QStringLiteral( "Raster" ) );
-
-  // so layer is not added to legend
-  QgsProject::instance()->addMapLayers(
-    QList<QgsMapLayer *>() << mLayer, false, false );
+  QgsRasterLayer::LayerOptions options;
+  mLayer = qgis::make_unique< QgsRasterLayer >( file, QStringLiteral( "Raster" ), QStringLiteral( "gdal" ), options );
 
   // add layer to map canvas
-  mCanvas->setLayers( QList<QgsMapLayer *>() << mLayer );
-
-  mAgainAddRaster = false;
+  mCanvas->setLayers( QList<QgsMapLayer *>() << mLayer.get() );
 
   mActionLocalHistogramStretch->setEnabled( true );
   mActionFullHistogramStretch->setEnabled( true );

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -1167,6 +1167,8 @@ void QgsGeoreferencerMainWindow::removeOldLayer()
 void QgsGeoreferencerMainWindow::addRaster( const QString &file )
 {
   QgsRasterLayer::LayerOptions options;
+  // never prompt for a crs selection for the input raster!
+  options.skipCrsValidation = true;
   mLayer = qgis::make_unique< QgsRasterLayer >( file, QStringLiteral( "Raster" ), QStringLiteral( "gdal" ), options );
 
   // add layer to map canvas

--- a/src/app/georeferencer/qgsgeorefmainwindow.h
+++ b/src/app/georeferencer/qgsgeorefmainwindow.h
@@ -19,6 +19,8 @@
 #include "qgsimagewarper.h"
 #include "qgscoordinatereferencesystem.h"
 
+#include <memory>
+
 #include <QPointer>
 
 class QAction;
@@ -118,11 +120,6 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     void localHistogramStretch();
     void fullHistogramStretch();
 
-
-    // when one Layer is removed
-    void layerWillBeRemoved( const QString &layerId );
-    void extentsChanged(); // Use for need add again Raster (case above)
-
     bool updateGeorefTransform();
     void invalidateCanvasCoords();
 
@@ -218,7 +215,7 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     QLabel *mEPSG = nullptr;
     QLabel *mRotationLabel = nullptr;
     QgsDoubleSpinBox *mRotationEdit = nullptr;
-    unsigned int mMousePrecisionDecimalPlaces;
+    unsigned int mMousePrecisionDecimalPlaces = 0;
 
     QString mRasterFileName;
     QString mModifiedRasterFileName;
@@ -232,7 +229,7 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     QString mSaveGcp;
     double  mUserResX, mUserResY;  // User specified target scale
 
-    QgsGeorefTransform::TransformParametrisation mTransformParam;
+    QgsGeorefTransform::TransformParametrisation mTransformParam = QgsGeorefTransform::InvalidTransform;
     QgsImageWarper::ResamplingMethod mResamplingMethod;
     QgsGeorefTransform mGeorefTransform;
     QString mCompressionMethod;
@@ -240,8 +237,7 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     QgsGCPList mPoints;
     QgsGCPList mInitialPoints;
     QgsMapCanvas *mCanvas = nullptr;
-    QgsRasterLayer *mLayer = nullptr;
-    bool mAgainAddRaster;
+    std::unique_ptr< QgsRasterLayer > mLayer;
 
     QgsMapTool *mToolZoomIn = nullptr;
     QgsMapTool *mToolZoomOut = nullptr;
@@ -256,10 +252,10 @@ class QgsGeoreferencerMainWindow : public QMainWindow, private Ui::QgsGeorefPlug
     QgsGeorefDataPoint *mMovingPointQgis = nullptr;
     QPointer<QgsMapCoordsDialog> mMapCoordsDialog;
 
-    bool mUseZeroForTrans;
+    bool mUseZeroForTrans = false;
     bool mExtentsChangedRecursionGuard;
     bool mGCPsDirty;
-    bool mLoadInQgis;
+    bool mLoadInQgis = false;
 
 
     QgsDockWidget *mDock = nullptr;


### PR DESCRIPTION
This was likely a decades old hack in order to get the layer to
show in the georeferencer canvas, but it's not needed now
and definitely not wanted.

Loading into the project as a hidden layer just complicates things,
and runs into all sorts of issues such as users saving a project
while a georeference is in project leaves around hidden ghost
layers in the project...