### PR TITLE
QgsProjectLayerGroupDialog: accept an existing project

### DIFF
--- a/src/app/qgsprojectlayergroupdialog.cpp
+++ b/src/app/qgsprojectlayergroupdialog.cpp
@@ -81,6 +81,33 @@ QgsProjectLayerGroupDialog::QgsProjectLayerGroupDialog( QWidget *parent, const Q
   connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsProjectLayerGroupDialog::showHelp );
 }
 
+QgsProjectLayerGroupDialog::QgsProjectLayerGroupDialog( const QgsProject *project, QWidget *parent, Qt::WindowFlags f )
+  : QDialog( parent, f )
+{
+
+  // Preconditions
+  Q_ASSERT( project );
+  Q_ASSERT( project->layerTreeRoot() );
+
+  setupUi( this );
+  QgsGui::enableAutoGeometryRestore( this );
+
+  mRootGroup = project->layerTreeRoot()->clone();
+  QgsEmbeddedLayerTreeModel *model = new QgsEmbeddedLayerTreeModel( mRootGroup, this );
+  mTreeView->setModel( model );
+
+  mProjectFileWidget->hide();
+  mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( true );
+
+  removeEmbeddedNodes( mRootGroup );
+
+  connect( mTreeView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsProjectLayerGroupDialog::onTreeViewSelectionChanged );
+  connect( mButtonBox, &QDialogButtonBox::accepted, this, &QgsProjectLayerGroupDialog::mButtonBox_accepted );
+  connect( mButtonBox, &QDialogButtonBox::rejected, this, &QDialog::reject );
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsProjectLayerGroupDialog::showHelp );
+
+}
+
 QgsProjectLayerGroupDialog::~QgsProjectLayerGroupDialog()
 {
   delete mRootGroup;

--- a/src/app/qgsprojectlayergroupdialog.h
+++ b/src/app/qgsprojectlayergroupdialog.h
@@ -43,13 +43,34 @@ class QgsEmbeddedLayerTreeModel : public QgsLayerTreeModel
     QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
 };
 
-//! A dialog to select layers and groups from a qgs project
+/**
+ *  A dialog to select layers and groups from a QGIS project.
+ *
+ *  The dialog can be used in two different ways by using the corresponding
+ *  constructor:
+ *
+ * - use a QGIS project selected from the file system
+ * - use an already loaded QGIS project object passed in the constructor
+ *
+ * In the second case, the file selection dialog is hidden.
+ */
 class APP_EXPORT QgsProjectLayerGroupDialog: public QDialog, private Ui::QgsProjectLayerGroupDialogBase
 {
     Q_OBJECT
   public:
+
     //! Constructor. If a project file is given, the groups/layers are displayed directly and the file selection hidden
     QgsProjectLayerGroupDialog( QWidget *parent = nullptr, const QString &projectFile = QString(), Qt::WindowFlags f = Qt::WindowFlags() );
+
+    /**
+     * Constructs a QgsProjectLayerGroupDialog from an existing \a project and an optional \a parent.
+     *
+     * \warning The project must not be NULL and it must contain a valid layer tree root.
+     * \since QGIS 3.18
+     */
+    QgsProjectLayerGroupDialog( const QgsProject *project, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
+
+
     ~QgsProjectLayerGroupDialog() override;
 
     QStringList selectedGroups() const;

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -1910,7 +1910,7 @@ void QgsProjectProperties::mRemoveWMSPrintLayoutButton_clicked()
 
 void QgsProjectProperties::mAddLayerRestrictionButton_clicked()
 {
-  QgsProjectLayerGroupDialog d( this, QgsProject::instance()->fileName() );
+  QgsProjectLayerGroupDialog d( QgsProject::instance(), this );
   d.setWindowTitle( tr( "Select Restricted Layers and Groups" ) );
   if ( d.exec() == QDialog::Accepted )
   {


### PR DESCRIPTION
in an overloaded constructor.

Fixes #40552
