### PR TITLE
Fix typo in replacement string for Doxygen FILE_PATTERNS option

### DIFF
--- a/cmake_templates/Doxyfile.in
+++ b/cmake_templates/Doxyfile.in
@@ -800,7 +800,7 @@ INPUT_ENCODING         = UTF-8
 # *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
 # *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf and *.qsf.
 
-FILE_PATTERNS          = @DOXYGEN_FILE_PATTERN@
+FILE_PATTERNS          = @DOXYGEN_FILE_PATTERNS@
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -149,6 +149,9 @@ if(WITH_APIDOC)
 
     string(REPLACE ";" " " DOXYGEN_INPUT "${DOXYGEN_INPUT}")
 
+    # Doxyfile requires comma separated list of patterns for FILE_PATTERNS option
+    string(REPLACE ";" "," DOXYGEN_FILE_PATTERNS "${DOXYGEN_FILE_PATTERNS}")
+
     if(WERROR)
       set (DOXYGEN_WARN_AS_ERROR "YES")
     else()


### PR DESCRIPTION
This was causing FILE_PATTERNS to always be set to blank, which
in newer doxygen versions meant that *.txt files were being included
alongside *.h, *.cpp etc. Accordingly doxygen was trying to parse
the various CMakeLists.txt files and choking and raising warnings.
