### PR TITLE
Fix crash when setting value for relation widget wrapper

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -220,7 +220,7 @@ void QgsRelationReferenceWidgetWrapper::setEnabled( bool enabled )
 
 void QgsRelationReferenceWidgetWrapper::foreignKeysChanged( const QVariantList &values )
 {
-  if ( mBlockChanges ) // initial value is being set, we can ignore this signal
+  if ( mBlockChanges != 0  ) // initial value is being set, we can ignore this signal
     return;
 
   QVariant mainValue = QVariant( field().type() );

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -204,8 +204,10 @@ void QgsRelationReferenceWidgetWrapper::updateValues( const QVariant &val, const
   }
   Q_ASSERT( values.count() == fieldPairs.count() );
 
+  mBlockChanges++;
   mWidget->setForeignKeys( values );
   mWidget->setFormFeature( formFeature() );
+  mBlockChanges--;
 }
 
 void QgsRelationReferenceWidgetWrapper::setEnabled( bool enabled )
@@ -218,6 +220,9 @@ void QgsRelationReferenceWidgetWrapper::setEnabled( bool enabled )
 
 void QgsRelationReferenceWidgetWrapper::foreignKeysChanged( const QVariantList &values )
 {
+  if ( mBlockChanges ) // initial value is being set, we can ignore this signal
+    return;
+
   QVariant mainValue = QVariant( field().type() );
 
   if ( !mWidget || !mWidget->relation().isValid() )

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -220,7 +220,7 @@ void QgsRelationReferenceWidgetWrapper::setEnabled( bool enabled )
 
 void QgsRelationReferenceWidgetWrapper::foreignKeysChanged( const QVariantList &values )
 {
-  if ( mBlockChanges != 0  ) // initial value is being set, we can ignore this signal
+  if ( mBlockChanges != 0 ) // initial value is being set, we can ignore this signal
     return;
 
   QVariant mainValue = QVariant( field().type() );

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
@@ -79,6 +79,7 @@ class GUI_EXPORT QgsRelationReferenceWidgetWrapper : public QgsEditorWidgetWrapp
     QgsMapCanvas *mCanvas = nullptr;
     QgsMessageBar *mMessageBar = nullptr;
     bool mIndeterminateState;
+    int mBlockChanges = 0;
 
 };
 


### PR DESCRIPTION
Calling setForeignKeys during updateValues would result in the
widget wrapper catching the relation widget's changed signal,
triggering an assert as the foreign keys don't match the form's
feature's key (since that hasn't yet been set).

In any case, setting the initial value for a editor widget wrapper
must NOT be treated as a user-induced value change.
