### PR TITLE
[VertexTool] fixes avoid intersections

### DIFF
--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -35,6 +35,7 @@
 #include "qgslayertreeview.h"
 #include "qgsmapcanvas.h"
 #include "qgsmaplayer.h"
+#include "qgsmessagebar.h"
 #include "qgsproject.h"
 #include "qgssnappingconfig.h"
 #include "qgssnappinglayertreemodel.h"
@@ -530,12 +531,20 @@ void QgsSnappingWidget::projectAvoidIntersectionModeChanged()
       mAllowIntersectionsAction->setChecked( false );
       mAvoidIntersectionsCurrentLayerAction->setChecked( true );
       mAvoidIntersectionsLayersAction->setChecked( false );
+      if ( mProject->topologicalEditing() )
+      {
+        QgisApp::instance()->messageBar()->pushWarning( tr( "Digitizing Warning" ), tr( "By using both avoid intersections and topological editing, geometries can be transformed automatically. Be careful with your modifications." ) );
+      }
       break;
     case QgsProject::AvoidIntersectionsMode::AvoidIntersectionsLayers:
       mAvoidIntersectionsModeButton->setDefaultAction( mAvoidIntersectionsLayersAction );
       mAllowIntersectionsAction->setChecked( false );
       mAvoidIntersectionsCurrentLayerAction->setChecked( false );
       mAvoidIntersectionsLayersAction->setChecked( true );
+      if ( mProject->topologicalEditing() )
+      {
+        QgisApp::instance()->messageBar()->pushWarning( tr( "Digitizing Warning" ), tr( "By using both avoid intersections and topological editing, geometries can be transformed automatically. Be careful with your modifications." ) );
+      }
       break;
   }
 }

--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -35,7 +35,6 @@
 #include "qgslayertreeview.h"
 #include "qgsmapcanvas.h"
 #include "qgsmaplayer.h"
-#include "qgsmessagebar.h"
 #include "qgsproject.h"
 #include "qgssnappingconfig.h"
 #include "qgssnappinglayertreemodel.h"
@@ -531,20 +530,12 @@ void QgsSnappingWidget::projectAvoidIntersectionModeChanged()
       mAllowIntersectionsAction->setChecked( false );
       mAvoidIntersectionsCurrentLayerAction->setChecked( true );
       mAvoidIntersectionsLayersAction->setChecked( false );
-      if ( mProject->topologicalEditing() )
-      {
-        QgisApp::instance()->messageBar()->pushWarning( tr( "Digitizing Warning" ), tr( "By using both avoid intersections and topological editing, geometries can be transformed automatically. Be careful with your modifications." ) );
-      }
       break;
     case QgsProject::AvoidIntersectionsMode::AvoidIntersectionsLayers:
       mAvoidIntersectionsModeButton->setDefaultAction( mAvoidIntersectionsLayersAction );
       mAllowIntersectionsAction->setChecked( false );
       mAvoidIntersectionsCurrentLayerAction->setChecked( false );
       mAvoidIntersectionsLayersAction->setChecked( true );
-      if ( mProject->topologicalEditing() )
-      {
-        QgisApp::instance()->messageBar()->pushWarning( tr( "Digitizing Warning" ), tr( "By using both avoid intersections and topological editing, geometries can be transformed automatically. Be careful with your modifications." ) );
-      }
       break;
   }
 }

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2200,6 +2200,21 @@ void QgsVertexTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocato
     }
   }
 
+  if ( QgsProject::instance()->topologicalEditing() && QgsProject::instance()->avoidIntersectionsMode() != QgsProject::AvoidIntersectionsMode::AllowIntersections )
+  {
+    const auto editKeys = edits.keys();
+    for ( QgsVectorLayer *layer : editKeys )
+    {
+      const auto editGeom = edits[layer].values();
+      for ( QgsGeometry g : editGeom )
+      {
+        QgsGeometry pts = g.convertToType( QgsWkbTypes::PointGeometry, true );
+        for ( const auto &p : pts.asMultiPoint() )
+          QgsMapToolEdit::addTopologicalPoints( pts.asMultiPoint() );
+      }
+    }
+  }
+
   updateLockedFeatureVertices();
   if ( mVertexEditor )
     mVertexEditor->updateEditor( mLockedFeature.get() );

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2349,8 +2349,18 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
         id.insert( it2.key() );
         ignoreFeatures.insert( layer, id );
         int avoidIntersectionsReturn = featGeom.avoidIntersections( avoidIntersectionsLayers, ignoreFeatures );
-        if ( avoidIntersectionsReturn == 3 )
-          emit messageEmitted( tr( "At least one geometry intersected is invalid. These geometries must be manually repaired." ), Qgis::Warning );
+        switch ( avoidIntersectionsReturn )
+        {
+          case 2:
+            emit messageEmitted( tr( "The operation would change the geometry type." ), Qgis::Warning );
+            break;
+
+          case 3:
+            emit messageEmitted( tr( "At least one geometry intersected is invalid. These geometries must be manually repaired." ), Qgis::Warning );
+            break;
+          default:
+            break;
+        }
       }
       layer->changeGeometry( it2.key(), featGeom );
       edits[layer][it2.key()] = featGeom;

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2187,10 +2187,11 @@ void QgsVertexTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocato
         const auto editGeom = edits[layer].values();
         for ( QgsGeometry g : editGeom )
         {
-          if ( !layerPoint.is3D() )
-            layerPoint.addZValue( defaultZValue() );
-          if ( QgsGeometry( layerPoint.clone() ).touches( g ) )
+          QgsGeometry p = QgsGeometry::fromPointXY( QgsPointXY( layerPoint.x(), layerPoint.y() ) );
+          if ( g.contains( p ) )
           {
+            if ( !layerPoint.is3D() )
+              layerPoint.addZValue( defaultZValue() );
             layer->addTopologicalPoints( layerPoint );
             mapPointMatch->layer()->addTopologicalPoints( layerPoint );
           }

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2186,10 +2186,9 @@ void QgsVertexTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocato
       for ( QgsGeometry g : editGeom )
       {
         QgsGeometry p = QgsGeometry::fromPointXY( QgsPointXY( layerPoint.x(), layerPoint.y() ) );
-        QgsGeometry pts = g.convertToType( QgsWkbTypes::PointGeometry, true );
         if ( ( mapPointMatch->hasEdge() || mapPointMatch->hasMiddleSegment() ) && mapPointMatch->layer() && ( layer->crs() == mapPointMatch->layer()->crs() ) )
         {
-          if ( pts.contains( p ) )
+          if ( g.convertToType( QgsWkbTypes::PointGeometry, true ).contains( p ) )
           {
             if ( !layerPoint.is3D() )
               layerPoint.addZValue( defaultZValue() );
@@ -2198,7 +2197,12 @@ void QgsVertexTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocato
           }
         }
         if ( QgsProject::instance()->avoidIntersectionsMode() != QgsProject::AvoidIntersectionsMode::AllowIntersections )
-          QgsMapToolEdit::addTopologicalPoints( pts.asMultiPoint() );
+        {
+          for ( QgsAbstractGeometry::vertex_iterator it = g.vertices_begin() ; it != g.vertices_end() ; it++ )
+          {
+            layer->addTopologicalPoints( *it );
+          }
+        }
       }
     }
   }

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2188,17 +2188,13 @@ void QgsVertexTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocato
         for ( QgsGeometry g : editGeom )
         {
           QgsGeometry p = QgsGeometry::fromPointXY( QgsPointXY( layerPoint.x(), layerPoint.y() ) );
-          if ( g.contains( p ) )
+          if ( g.convertToType( QgsWkbTypes::PointGeometry, true ).contains( p ) )
           {
             if ( !layerPoint.is3D() )
               layerPoint.addZValue( defaultZValue() );
             layer->addTopologicalPoints( layerPoint );
             mapPointMatch->layer()->addTopologicalPoints( layerPoint );
           }
-          /*
-          * layer->addTopologicalPoints( g );
-           * mapPointMatch->layer()->addTopologicalPoints( g );
-          */
         }
       }
     }

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2316,15 +2316,8 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
         id.insert( it2.key() );
         ignoreFeatures.insert( layer, id );
         int avoidIntersectionsReturn = featGeom.avoidIntersections( avoidIntersectionsLayers, ignoreFeatures );
-        switch ( avoidIntersectionsReturn )
-        {
-          case 3:
-            emit messageEmitted( tr( "The feature has been added, but at least one geometry intersected is invalid and cannot be fixed automatically. The geometry added may overlap another geometry. You should fix geometries." ), Qgis::Warning );
-            break;
-          case 4:
-            emit messageEmitted( tr( "The feature has been added, but at least one geometry intersected is invalid and has been modified to perform the operation. You should fix geometries." ), Qgis::Warning );
-            break;
-        }
+        if ( avoidIntersectionsReturn == 3 )
+          emit messageEmitted( tr( "At least one geometry intersected is invalid. These geometries must be manually repaired." ), Qgis::Warning );
       }
       layer->changeGeometry( it2.key(), featGeom );
     }

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2307,6 +2307,24 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
     QHash<QgsFeatureId, QgsGeometry>::iterator it2 = layerEdits.begin();
     for ( ; it2 != layerEdits.end(); ++it2 )
     {
+      QgsGeometry featGeom = it2.value();
+      layer->changeGeometry( it2.key(), featGeom );
+      edits[layer][it2.key()] = featGeom;
+    }
+
+    if ( mVertexEditor )
+      mVertexEditor->updateEditor( mLockedFeature.get() );
+  }
+
+
+
+  for ( it = edits.begin() ; it != edits.end(); ++it )
+  {
+    QgsVectorLayer *layer = it.key();
+    QHash<QgsFeatureId, QgsGeometry> &layerEdits = it.value();
+    QHash<QgsFeatureId, QgsGeometry>::iterator it2 = layerEdits.begin();
+    for ( ; it2 != layerEdits.end(); ++it2 )
+    {
       QList<QgsVectorLayer *>  avoidIntersectionsLayers;
       switch ( QgsProject::instance()->avoidIntersectionsMode() )
       {
@@ -2340,6 +2358,7 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
     if ( mVertexEditor )
       mVertexEditor->updateEditor( mLockedFeature.get() );
   }
+
 }
 
 

--- a/tests/src/app/testqgsvertextool.cpp
+++ b/tests/src/app/testqgsvertextool.cpp
@@ -70,6 +70,7 @@ class TestQgsVertexTool : public QObject
     void testAddVertexAtEndpoint();
     void testAddVertexDoubleClick();
     void testAddVertexDoubleClickWithShift();
+    void testAvoidIntersections();
     void testDeleteVertex();
     void testMoveMultipleVertices();
     void testMoveMultipleVertices2();
@@ -160,6 +161,7 @@ class TestQgsVertexTool : public QObject
     QgsFeatureId mFidMultiLineF1 = 0;
     QgsFeatureId mFidLineF13857 = 0;
     QgsFeatureId mFidPolygonF1 = 0;
+    QgsFeatureId mFidPolygonF2 = 0;
     QgsFeatureId mFidMultiPolygonF1 = 0;
     QgsFeatureId mFidPointF1 = 0;
     QgsFeatureId mFidCompoundCurveF1 = 0;
@@ -229,6 +231,13 @@ void TestQgsVertexTool::initTestCase()
   QgsFeature polygonF1;
   polygonF1.setGeometry( QgsGeometry::fromPolygonXY( polygon1 ) );
 
+  QgsPolygonXY polygon2;
+  QgsPolylineXY polygon2exterior;
+  polygon2exterior << QgsPointXY( 8, 1 ) << QgsPointXY( 9, 1 ) << QgsPointXY( 9, 4 ) << QgsPointXY( 8, 4 ) << QgsPointXY( 8, 1 );
+  polygon2 << polygon2exterior;
+  QgsFeature polygonF2;
+  polygonF2.setGeometry( QgsGeometry::fromPolygonXY( polygon2 ) );
+
   QgsFeature multiPolygonF1;
   multiPolygonF1.setGeometry( QgsGeometry::fromWkt( "MultiPolygon (((1 5, 2 5, 2 6.5, 2 8, 1 8, 1 6.5, 1 5),(1.25 5.5, 1.25 6, 1.75 6, 1.75 5.5, 1.25 5.5),(1.25 7, 1.75 7, 1.75 7.5, 1.25 7.5, 1.25 7)),((3 5, 3 6.5, 3 8, 4 8, 4 6.5, 4 5, 3 5),(3.25 5.5, 3.75 5.5, 3.75 6, 3.25 6, 3.25 5.5),(3.25 7, 3.75 7, 3.75 7.5, 3.25 7.5, 3.25 7)))" ) );
 
@@ -277,6 +286,10 @@ void TestQgsVertexTool::initTestCase()
   mFidPolygonF1 = polygonF1.id();
   QCOMPARE( mLayerPolygon->featureCount(), ( long )1 );
 
+  mLayerPolygon->addFeature( polygonF2 );
+  mFidPolygonF2 = polygonF2.id();
+  QCOMPARE( mLayerPolygon->featureCount(), ( long )2 );
+
   mLayerMultiPolygon->startEditing();
   mLayerMultiPolygon->addFeature( multiPolygonF1 );
   mFidMultiPolygonF1 = multiPolygonF1.id();
@@ -304,7 +317,7 @@ void TestQgsVertexTool::initTestCase()
   // just one added feature in each undo stack
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
   QCOMPARE( mLayerMultiLine->undoStack()->index(), 1 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 1 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
   QCOMPARE( mLayerMultiPolygon->undoStack()->index(), 1 );
   QCOMPARE( mLayerPoint->undoStack()->index(), 1 );
   // except for layerLineZ
@@ -439,7 +452,7 @@ void TestQgsVertexTool::testMoveVertex()
   mouseClick( 4, 1, Qt::LeftButton );
   mouseClick( 5, 2, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((5 2, 7 1, 7 4, 4 4, 5 2))" ) );
 
   mLayerPolygon->undoStack()->undo();
@@ -449,7 +462,7 @@ void TestQgsVertexTool::testMoveVertex()
   mouseClick( 4, 4, Qt::LeftButton );
   mouseClick( 5, 5, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 7 4, 5 5, 4 1))" ) );
 
   mLayerPolygon->undoStack()->undo();
@@ -469,7 +482,7 @@ void TestQgsVertexTool::testMoveVertex()
 
   // no other unexpected changes happened
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 1 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
   QCOMPARE( mLayerPoint->undoStack()->index(), 1 );
 }
 
@@ -493,7 +506,7 @@ void TestQgsVertexTool::testMoveEdge()
   mouseClick( 5, 1, Qt::LeftButton );
   mouseClick( 6, 1, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((5 1, 8 1, 7 4, 4 4, 5 1))" ) );
 
   mLayerPolygon->undoStack()->undo();
@@ -502,7 +515,7 @@ void TestQgsVertexTool::testMoveEdge()
 
   // no other unexpected changes happened
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 1 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
   QCOMPARE( mLayerPoint->undoStack()->index(), 1 );
 }
 
@@ -526,7 +539,7 @@ void TestQgsVertexTool::testAddVertex()
   mouseClick( 4, 2.5, Qt::LeftButton );
   mouseClick( 3, 2.5, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 7 4, 4 4, 3 2.5, 4 1))" ) );
 
   mLayerPolygon->undoStack()->undo();
@@ -535,7 +548,7 @@ void TestQgsVertexTool::testAddVertex()
 
   // no other unexpected changes happened
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 1 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
   QCOMPARE( mLayerPoint->undoStack()->index(), 1 );
 }
 
@@ -614,7 +627,7 @@ void TestQgsVertexTool::testAddVertexDoubleClick()
   mouseDoubleClick( 4, 2, Qt::LeftButton );
   mouseClick( 3, 2.5, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 7 4, 4 4, 3 2.5, 4 1))" ) );
 
   mLayerPolygon->undoStack()->undo();
@@ -623,7 +636,7 @@ void TestQgsVertexTool::testAddVertexDoubleClick()
 
   // no other unexpected changes happened
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 1 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
   QCOMPARE( mLayerPoint->undoStack()->index(), 1 );
 
 }
@@ -645,7 +658,7 @@ void TestQgsVertexTool::testAddVertexDoubleClickWithShift()
   // add vertex in polygon
   mouseDoubleClick( 4, 2, Qt::LeftButton, Qt::ShiftModifier );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 7 4, 4 4, 4 2, 4 1))" ) );
 
   mLayerPolygon->undoStack()->undo();
@@ -654,7 +667,7 @@ void TestQgsVertexTool::testAddVertexDoubleClickWithShift()
 
   // no other unexpected changes happened
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 1 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
   QCOMPARE( mLayerPoint->undoStack()->index(), 1 );
 
 }
@@ -679,7 +692,7 @@ void TestQgsVertexTool::testDeleteVertex()
   mouseClick( 7, 4, Qt::LeftButton );
   keyClick( Qt::Key_Delete );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 4 4, 4 1))" ) );
 
   mLayerPolygon->undoStack()->undo();
@@ -793,7 +806,7 @@ void TestQgsVertexTool::testDeleteVertex()
 
   // no other unexpected changes happened
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 1 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
   QCOMPARE( mLayerPoint->undoStack()->index(), 1 );
 }
 
@@ -861,7 +874,7 @@ void TestQgsVertexTool::testMoveVertexTopo()
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((3 3, 7 1, 7 4, 4 4, 3 3))" ) );
 
   QCOMPARE( mLayerLine->undoStack()->index(), 2 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );  // one more move of vertex from earlier
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 4 );  // one more move of vertex from earlier
   mLayerLine->undoStack()->undo();
   mLayerPolygon->undoStack()->undo();
   mLayerPolygon->undoStack()->undo();
@@ -890,7 +903,7 @@ void TestQgsVertexTool::testDeleteVertexTopo()
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((7 1, 7 4, 4 4, 7 1))" ) );
 
   QCOMPARE( mLayerLine->undoStack()->index(), 2 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );  // one more move of vertex from earlier
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 4 );  // one more move of vertex from earlier
   mLayerLine->undoStack()->undo();
   mLayerPolygon->undoStack()->undo();
   mLayerPolygon->undoStack()->undo();
@@ -912,14 +925,14 @@ void TestQgsVertexTool::testAddVertexTopo()
   QVERIFY( resAdd );
   QgsFeatureId fTmpId = fTmp.id();
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
 
   QgsProject::instance()->setTopologicalEditing( true );
 
   mouseClick( 5.5, 4, Qt::LeftButton );
   mouseClick( 5, 5, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 4 );
 
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 7 4, 5 5, 4 4, 4 1))" ) );
   QCOMPARE( mLayerPolygon->getFeature( fTmpId ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 4, 5 5, 7 4, 7 6, 4 6, 4 4))" ) );
@@ -943,7 +956,7 @@ void TestQgsVertexTool::testMoveEdgeTopo()
   QVERIFY( resAdd );
   QgsFeatureId fTmpId = fTmp.id();
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
 
   QgsProject::instance()->setTopologicalEditing( true );
 
@@ -951,7 +964,7 @@ void TestQgsVertexTool::testMoveEdgeTopo()
   mouseClick( 6, 4, Qt::LeftButton );
   mouseClick( 6, 5, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 4 );
 
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 7 5, 4 5, 4 1))" ) );
   QCOMPARE( mLayerPolygon->getFeature( fTmpId ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 5, 7 5, 7 6, 4 6, 4 5))" ) );
@@ -973,7 +986,7 @@ void TestQgsVertexTool::testMoveEdgeTopo()
   mouseClick( 4, 4, Qt::LeftButton );
   mouseClick( 4, 3, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 4 );
 
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 7 3, 4 3, 4 1))" ) );
   QCOMPARE( mLayerPolygon->getFeature( fTmpId ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 3, 7 3, 7 6, 4 6, 4 3))" ) );
@@ -999,7 +1012,7 @@ void TestQgsVertexTool::testAddVertexTopoFirstSegment()
   mouseClick( 5.5, 1, Qt::LeftButton );
   mouseClick( 5, 2, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
 
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 5 2, 7 1, 7 4, 4 4, 4 1))" ) );
 
@@ -1010,6 +1023,29 @@ void TestQgsVertexTool::testAddVertexTopoFirstSegment()
   QgsProject::instance()->setTopologicalEditing( false );
 }
 
+void TestQgsVertexTool::testAvoidIntersections()
+{
+  // check that when adding a vertex to the first segment of a polygon's ring with topo editing
+  // enabled, the geometry does not get corrupted (#20774)
+
+  QgsProject::instance()->setTopologicalEditing( true );
+  QgsProject::AvoidIntersectionsMode mode( QgsProject::instance()->avoidIntersectionsMode() );
+  QgsProject::instance()->setAvoidIntersectionsMode( QgsProject::AvoidIntersectionsMode::AvoidIntersectionsCurrentLayer );
+
+  mouseClick( 6.5, 1, Qt::LeftButton );
+  mouseClick( 9, 2, Qt::LeftButton );
+
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
+
+  QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry().asWkt( 1 ), "MultiPolygon (((4 4, 7 4, 8 3.2, 8 2, 6.5 2, 4 4)),((9 2.4, 9.5 2, 9 2, 9 2.4)))" );
+
+  mLayerPolygon->undoStack()->undo();
+
+  QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 7 4, 4 4, 4 1))" ) );
+
+  QgsProject::instance()->setTopologicalEditing( false );
+  QgsProject::instance()->setAvoidIntersectionsMode( mode );
+}
 void TestQgsVertexTool::testActiveLayerPriority()
 {
   // check that features from current layer get priority when picking points

--- a/tests/src/app/testqgsvertextool.cpp
+++ b/tests/src/app/testqgsvertextool.cpp
@@ -161,7 +161,6 @@ class TestQgsVertexTool : public QObject
     QgsFeatureId mFidMultiLineF1 = 0;
     QgsFeatureId mFidLineF13857 = 0;
     QgsFeatureId mFidPolygonF1 = 0;
-    QgsFeatureId mFidPolygonF2 = 0;
     QgsFeatureId mFidMultiPolygonF1 = 0;
     QgsFeatureId mFidPointF1 = 0;
     QgsFeatureId mFidCompoundCurveF1 = 0;
@@ -231,13 +230,6 @@ void TestQgsVertexTool::initTestCase()
   QgsFeature polygonF1;
   polygonF1.setGeometry( QgsGeometry::fromPolygonXY( polygon1 ) );
 
-  QgsPolygonXY polygon2;
-  QgsPolylineXY polygon2exterior;
-  polygon2exterior << QgsPointXY( 8, 1 ) << QgsPointXY( 9, 1 ) << QgsPointXY( 9, 4 ) << QgsPointXY( 8, 4 ) << QgsPointXY( 8, 1 );
-  polygon2 << polygon2exterior;
-  QgsFeature polygonF2;
-  polygonF2.setGeometry( QgsGeometry::fromPolygonXY( polygon2 ) );
-
   QgsFeature multiPolygonF1;
   multiPolygonF1.setGeometry( QgsGeometry::fromWkt( "MultiPolygon (((1 5, 2 5, 2 6.5, 2 8, 1 8, 1 6.5, 1 5),(1.25 5.5, 1.25 6, 1.75 6, 1.75 5.5, 1.25 5.5),(1.25 7, 1.75 7, 1.75 7.5, 1.25 7.5, 1.25 7)),((3 5, 3 6.5, 3 8, 4 8, 4 6.5, 4 5, 3 5),(3.25 5.5, 3.75 5.5, 3.75 6, 3.25 6, 3.25 5.5),(3.25 7, 3.75 7, 3.75 7.5, 3.25 7.5, 3.25 7)))" ) );
 
@@ -286,10 +278,6 @@ void TestQgsVertexTool::initTestCase()
   mFidPolygonF1 = polygonF1.id();
   QCOMPARE( mLayerPolygon->featureCount(), ( long )1 );
 
-  mLayerPolygon->addFeature( polygonF2 );
-  mFidPolygonF2 = polygonF2.id();
-  QCOMPARE( mLayerPolygon->featureCount(), ( long )2 );
-
   mLayerMultiPolygon->startEditing();
   mLayerMultiPolygon->addFeature( multiPolygonF1 );
   mFidMultiPolygonF1 = multiPolygonF1.id();
@@ -317,7 +305,7 @@ void TestQgsVertexTool::initTestCase()
   // just one added feature in each undo stack
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
   QCOMPARE( mLayerMultiLine->undoStack()->index(), 1 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 1 );
   QCOMPARE( mLayerMultiPolygon->undoStack()->index(), 1 );
   QCOMPARE( mLayerPoint->undoStack()->index(), 1 );
   // except for layerLineZ
@@ -452,7 +440,7 @@ void TestQgsVertexTool::testMoveVertex()
   mouseClick( 4, 1, Qt::LeftButton );
   mouseClick( 5, 2, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((5 2, 7 1, 7 4, 4 4, 5 2))" ) );
 
   mLayerPolygon->undoStack()->undo();
@@ -462,7 +450,7 @@ void TestQgsVertexTool::testMoveVertex()
   mouseClick( 4, 4, Qt::LeftButton );
   mouseClick( 5, 5, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 7 4, 5 5, 4 1))" ) );
 
   mLayerPolygon->undoStack()->undo();
@@ -482,7 +470,7 @@ void TestQgsVertexTool::testMoveVertex()
 
   // no other unexpected changes happened
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 1 );
   QCOMPARE( mLayerPoint->undoStack()->index(), 1 );
 }
 
@@ -506,7 +494,7 @@ void TestQgsVertexTool::testMoveEdge()
   mouseClick( 5, 1, Qt::LeftButton );
   mouseClick( 6, 1, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((5 1, 8 1, 7 4, 4 4, 5 1))" ) );
 
   mLayerPolygon->undoStack()->undo();
@@ -515,7 +503,7 @@ void TestQgsVertexTool::testMoveEdge()
 
   // no other unexpected changes happened
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 1 );
   QCOMPARE( mLayerPoint->undoStack()->index(), 1 );
 }
 
@@ -539,7 +527,7 @@ void TestQgsVertexTool::testAddVertex()
   mouseClick( 4, 2.5, Qt::LeftButton );
   mouseClick( 3, 2.5, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 7 4, 4 4, 3 2.5, 4 1))" ) );
 
   mLayerPolygon->undoStack()->undo();
@@ -548,7 +536,7 @@ void TestQgsVertexTool::testAddVertex()
 
   // no other unexpected changes happened
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 1 );
   QCOMPARE( mLayerPoint->undoStack()->index(), 1 );
 }
 
@@ -627,7 +615,7 @@ void TestQgsVertexTool::testAddVertexDoubleClick()
   mouseDoubleClick( 4, 2, Qt::LeftButton );
   mouseClick( 3, 2.5, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 7 4, 4 4, 3 2.5, 4 1))" ) );
 
   mLayerPolygon->undoStack()->undo();
@@ -636,7 +624,7 @@ void TestQgsVertexTool::testAddVertexDoubleClick()
 
   // no other unexpected changes happened
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 1 );
   QCOMPARE( mLayerPoint->undoStack()->index(), 1 );
 
 }
@@ -658,7 +646,7 @@ void TestQgsVertexTool::testAddVertexDoubleClickWithShift()
   // add vertex in polygon
   mouseDoubleClick( 4, 2, Qt::LeftButton, Qt::ShiftModifier );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 7 4, 4 4, 4 2, 4 1))" ) );
 
   mLayerPolygon->undoStack()->undo();
@@ -667,7 +655,7 @@ void TestQgsVertexTool::testAddVertexDoubleClickWithShift()
 
   // no other unexpected changes happened
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 1 );
   QCOMPARE( mLayerPoint->undoStack()->index(), 1 );
 
 }
@@ -692,7 +680,7 @@ void TestQgsVertexTool::testDeleteVertex()
   mouseClick( 7, 4, Qt::LeftButton );
   keyClick( Qt::Key_Delete );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 4 4, 4 1))" ) );
 
   mLayerPolygon->undoStack()->undo();
@@ -806,7 +794,7 @@ void TestQgsVertexTool::testDeleteVertex()
 
   // no other unexpected changes happened
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 1 );
   QCOMPARE( mLayerPoint->undoStack()->index(), 1 );
 }
 
@@ -874,7 +862,7 @@ void TestQgsVertexTool::testMoveVertexTopo()
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((3 3, 7 1, 7 4, 4 4, 3 3))" ) );
 
   QCOMPARE( mLayerLine->undoStack()->index(), 2 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 4 );  // one more move of vertex from earlier
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );  // one more move of vertex from earlier
   mLayerLine->undoStack()->undo();
   mLayerPolygon->undoStack()->undo();
   mLayerPolygon->undoStack()->undo();
@@ -903,7 +891,7 @@ void TestQgsVertexTool::testDeleteVertexTopo()
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((7 1, 7 4, 4 4, 7 1))" ) );
 
   QCOMPARE( mLayerLine->undoStack()->index(), 2 );
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 4 );  // one more move of vertex from earlier
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );  // one more move of vertex from earlier
   mLayerLine->undoStack()->undo();
   mLayerPolygon->undoStack()->undo();
   mLayerPolygon->undoStack()->undo();
@@ -925,14 +913,14 @@ void TestQgsVertexTool::testAddVertexTopo()
   QVERIFY( resAdd );
   QgsFeatureId fTmpId = fTmp.id();
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
 
   QgsProject::instance()->setTopologicalEditing( true );
 
   mouseClick( 5.5, 4, Qt::LeftButton );
   mouseClick( 5, 5, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 4 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
 
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 7 4, 5 5, 4 4, 4 1))" ) );
   QCOMPARE( mLayerPolygon->getFeature( fTmpId ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 4, 5 5, 7 4, 7 6, 4 6, 4 4))" ) );
@@ -956,7 +944,7 @@ void TestQgsVertexTool::testMoveEdgeTopo()
   QVERIFY( resAdd );
   QgsFeatureId fTmpId = fTmp.id();
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
 
   QgsProject::instance()->setTopologicalEditing( true );
 
@@ -964,7 +952,7 @@ void TestQgsVertexTool::testMoveEdgeTopo()
   mouseClick( 6, 4, Qt::LeftButton );
   mouseClick( 6, 5, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 4 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
 
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 7 5, 4 5, 4 1))" ) );
   QCOMPARE( mLayerPolygon->getFeature( fTmpId ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 5, 7 5, 7 6, 4 6, 4 5))" ) );
@@ -986,7 +974,7 @@ void TestQgsVertexTool::testMoveEdgeTopo()
   mouseClick( 4, 4, Qt::LeftButton );
   mouseClick( 4, 3, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 4 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
 
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 7 3, 4 3, 4 1))" ) );
   QCOMPARE( mLayerPolygon->getFeature( fTmpId ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 3, 7 3, 7 6, 4 6, 4 3))" ) );
@@ -1012,7 +1000,7 @@ void TestQgsVertexTool::testAddVertexTopoFirstSegment()
   mouseClick( 5.5, 1, Qt::LeftButton );
   mouseClick( 5, 2, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
+  QCOMPARE( mLayerPolygon->undoStack()->index(), 2 );
 
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 5 2, 7 1, 7 4, 4 4, 4 1))" ) );
 
@@ -1032,14 +1020,25 @@ void TestQgsVertexTool::testAvoidIntersections()
   QgsProject::AvoidIntersectionsMode mode( QgsProject::instance()->avoidIntersectionsMode() );
   QgsProject::instance()->setAvoidIntersectionsMode( QgsProject::AvoidIntersectionsMode::AvoidIntersectionsCurrentLayer );
 
+  QgsPolygonXY polygon2;
+  QgsPolylineXY polygon2exterior;
+  polygon2exterior << QgsPointXY( 8, 1 ) << QgsPointXY( 9, 1 ) << QgsPointXY( 9, 4 ) << QgsPointXY( 8, 4 ) << QgsPointXY( 8, 1 );
+  polygon2 << polygon2exterior;
+  QgsFeature polygonF2;
+  polygonF2.setGeometry( QgsGeometry::fromPolygonXY( polygon2 ) );
+
+  mLayerPolygon->addFeature( polygonF2 );
+  QCOMPARE( mLayerPolygon->featureCount(), ( long )2 );
+
   mouseClick( 6.5, 1, Qt::LeftButton );
   mouseClick( 9, 2, Qt::LeftButton );
 
   QCOMPARE( mLayerPolygon->undoStack()->index(), 3 );
 
-  QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry().asWkt( 1 ), "MultiPolygon (((4 4, 7 4, 8 3.2, 8 2, 6.5 2, 4 4)),((9 2.4, 9.5 2, 9 2, 9 2.4)))" );
+  QCOMPARE( QgsGeometry::fromWkt( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry().asWkt( 1 ) ), QgsGeometry::fromWkt( "MultiPolygon (((4 4, 7 4, 8 3.2, 8 2, 6.5 2, 4 4)),((9 2.4, 9.5 2, 9 2, 9 2.4)))" ) ); // avoid rounding errors
 
   mLayerPolygon->undoStack()->undo();
+  mLayerPolygon->undoStack()->undo(); // delete feature
 
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF1 ).geometry(), QgsGeometry::fromWkt( "POLYGON((4 1, 7 1, 7 4, 4 4, 4 1))" ) );
 

--- a/tests/src/app/testqgsvertextool.cpp
+++ b/tests/src/app/testqgsvertextool.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsadvanceddigitizingdockwidget.h"
 #include "qgsgeometry.h"
+#include "qgsgeos.h"
 #include "qgsmapcanvas.h"
 #include "qgsmapcanvassnappingutils.h"
 #include "qgsproject.h"
@@ -1088,7 +1089,14 @@ void TestQgsVertexTool::testAvoidIntersections()
   mouseClick( 5, 15, Qt::LeftButton );
   mouseClick( 12.5, 15, Qt::LeftButton );
 
-  QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF_topo1 ).geometry().asWkt( 1 ), "Polygon ((0 20, 10.7 15.7, 10 15, 10.7 14.3, 0 10, 0 20))" );
+  if ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR < 9 )
+  {
+    QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF_topo1 ).geometry().asWkt( 1 ), "Polygon ((0 10, 0 20, 10.7 15.7, 10 15, 10.7 14.3, 0 10))" );
+  }
+  else
+  {
+    QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF_topo1 ).geometry().asWkt( 1 ), "Polygon ((0 20, 10.7 15.7, 10 15, 10.7 14.3, 0 10, 0 20))" );
+  }
   QCOMPARE( mLayerPolygon->getFeature( mFidPolygonF_topo2 ).geometry().asWkt( 1 ), "Polygon ((10 15, 10.7 14.3, 15 10, 15 20, 10.7 15.7, 10 15))" );
 
   mLayerPolygon->undoStack()->undo(); // undo topological points


### PR DESCRIPTION
## Description

Followup #41424 vertex tool doesn't honor the avoid intersections settings.

before:

![overlap_vertextool_before mkv](https://user-images.githubusercontent.com/7521540/108326139-31eed400-71ca-11eb-91a7-917af6b5ac56.gif)

after:
![overlap_vertextool_after mkv](https://user-images.githubusercontent.com/7521540/108326090-200d3100-71ca-11eb-906f-9d0814618abb.gif)

Sponsored by: Métropole Européenne de Lille @Jean-Roc 
