### PR TITLE
Fix GUI on layout attributetable widget enabling/disabling geometry filter options

### DIFF
--- a/src/gui/layout/qgslayoutattributetablewidget.cpp
+++ b/src/gui/layout/qgslayoutattributetablewidget.cpp
@@ -404,12 +404,14 @@ void QgsLayoutAttributeTableWidget::updateGuiElements()
       mShowOnlyVisibleFeaturesCheckBox->setEnabled( false );
       mComposerMapComboBox->setEnabled( false );
       mComposerMapLabel->setEnabled( false );
+      mIntersectAtlasCheckBox->setEnabled( false );
     }
     else
     {
       mShowOnlyVisibleFeaturesCheckBox->setEnabled( true );
       mComposerMapComboBox->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
       mComposerMapLabel->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
+      mIntersectAtlasCheckBox->setEnabled( mSourceComboBox->findData( QgsLayoutItemAttributeTable::AtlasFeature ) != -1  && mTable->layout()->reportContext().layer() && mTable->layout()->reportContext().layer()->geometryType() != QgsWkbTypes::NullGeometry );
     }
   }
 
@@ -552,7 +554,7 @@ void QgsLayoutAttributeTableWidget::toggleAtlasSpecificControls( const bool atla
     //add relations for coverage layer
     updateRelationsCombo();
     mRelationsComboBox->setEnabled( true );
-    mIntersectAtlasCheckBox->setEnabled( true );
+    mIntersectAtlasCheckBox->setEnabled( mTable->layout()->reportContext().layer() && mTable->layout()->reportContext().layer()->geometryType() != QgsWkbTypes::NullGeometry );
   }
 }
 
@@ -785,12 +787,14 @@ void QgsLayoutAttributeTableWidget::changeLayer( QgsMapLayer *layer )
     mShowOnlyVisibleFeaturesCheckBox->setEnabled( false );
     mComposerMapComboBox->setEnabled( false );
     mComposerMapLabel->setEnabled( false );
+    mIntersectAtlasCheckBox->setEnabled( false );
   }
   else
   {
     mShowOnlyVisibleFeaturesCheckBox->setEnabled( true );
     mComposerMapComboBox->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
     mComposerMapLabel->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
+    mIntersectAtlasCheckBox->setEnabled( mSourceComboBox->findData( QgsLayoutItemAttributeTable::AtlasFeature ) != -1  && mTable->layout()->reportContext().layer() && mTable->layout()->reportContext().layer()->geometryType() != QgsWkbTypes::NullGeometry );
   }
 }
 
@@ -948,6 +952,8 @@ void QgsLayoutAttributeTableWidget::toggleSourceControls()
       mShowOnlyVisibleFeaturesCheckBox->setChecked( mTable->vectorLayer() && mTable->vectorLayer()->geometryType() != QgsWkbTypes::NullGeometry && mTable->displayOnlyVisibleFeatures() );
       mComposerMapComboBox->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
       mComposerMapLabel->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
+      mIntersectAtlasCheckBox->setEnabled( mTable->vectorLayer() && mTable->vectorLayer()->geometryType() != QgsWkbTypes::NullGeometry
+                                           && mSourceComboBox->findData( QgsLayoutItemAttributeTable::AtlasFeature ) != -1 && mTable->layout()->reportContext().layer() && mTable->layout()->reportContext().layer()->geometryType() != QgsWkbTypes::NullGeometry );
       break;
     case QgsLayoutItemAttributeTable::AtlasFeature:
       mLayerComboBox->setEnabled( false );
@@ -963,6 +969,7 @@ void QgsLayoutAttributeTableWidget::toggleSourceControls()
       mShowOnlyVisibleFeaturesCheckBox->setChecked( mTable->sourceLayer() && mTable->sourceLayer()->geometryType() != QgsWkbTypes::NullGeometry && mTable->displayOnlyVisibleFeatures() );
       mComposerMapComboBox->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
       mComposerMapLabel->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
+      mIntersectAtlasCheckBox->setEnabled( false );
       break;
     case QgsLayoutItemAttributeTable::RelationChildren:
       mLayerComboBox->setEnabled( false );
@@ -974,9 +981,11 @@ void QgsLayoutAttributeTableWidget::toggleSourceControls()
       mRelationLabel->setVisible( true );
       mMaximumRowsSpinBox->setEnabled( true );
       mMaxNumFeaturesLabel->setEnabled( true );
+      //it's missing the check for null geometry of the referencing layer
       mShowOnlyVisibleFeaturesCheckBox->setEnabled( true );
       mComposerMapComboBox->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
       mComposerMapLabel->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
+      mIntersectAtlasCheckBox->setEnabled( mSourceComboBox->findData( QgsLayoutItemAttributeTable::AtlasFeature ) != -1 && mTable->layout()->reportContext().layer() && mTable->layout()->reportContext().layer()->geometryType() != QgsWkbTypes::NullGeometry );
       break;
   }
 }

--- a/src/gui/layout/qgslayoutattributetablewidget.cpp
+++ b/src/gui/layout/qgslayoutattributetablewidget.cpp
@@ -402,10 +402,14 @@ void QgsLayoutAttributeTableWidget::updateGuiElements()
       //layer has no geometry, so uncheck & disable controls which require geometry
       mShowOnlyVisibleFeaturesCheckBox->setChecked( false );
       mShowOnlyVisibleFeaturesCheckBox->setEnabled( false );
+      mComposerMapComboBox->setEnabled( false );
+      mComposerMapLabel->setEnabled( false );
     }
     else
     {
       mShowOnlyVisibleFeaturesCheckBox->setEnabled( true );
+      mComposerMapComboBox->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
+      mComposerMapLabel->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
     }
   }
 
@@ -779,10 +783,14 @@ void QgsLayoutAttributeTableWidget::changeLayer( QgsMapLayer *layer )
     //layer has no geometry, so uncheck & disable controls which require geometry
     mShowOnlyVisibleFeaturesCheckBox->setChecked( false );
     mShowOnlyVisibleFeaturesCheckBox->setEnabled( false );
+    mComposerMapComboBox->setEnabled( false );
+    mComposerMapLabel->setEnabled( false );
   }
   else
   {
     mShowOnlyVisibleFeaturesCheckBox->setEnabled( true );
+    mComposerMapComboBox->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
+    mComposerMapLabel->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
   }
 }
 
@@ -966,8 +974,8 @@ void QgsLayoutAttributeTableWidget::toggleSourceControls()
       mMaximumRowsSpinBox->setEnabled( true );
       mMaxNumFeaturesLabel->setEnabled( true );
       mShowOnlyVisibleFeaturesCheckBox->setEnabled( true );
-      mComposerMapComboBox->setEnabled( true );
-      mComposerMapLabel->setEnabled( true );
+      mComposerMapComboBox->setEnabled( mTable->displayOnlyVisibleFeatures() );
+      mComposerMapLabel->setEnabled( mTable->displayOnlyVisibleFeatures() );
       break;
   }
 }

--- a/src/gui/layout/qgslayoutattributetablewidget.cpp
+++ b/src/gui/layout/qgslayoutattributetablewidget.cpp
@@ -944,8 +944,8 @@ void QgsLayoutAttributeTableWidget::toggleSourceControls()
       mRelationLabel->setVisible( false );
       mMaximumRowsSpinBox->setEnabled( true );
       mMaxNumFeaturesLabel->setEnabled( true );
-      mShowOnlyVisibleFeaturesCheckBox->setEnabled( mTable->vectorLayer()->geometryType() != QgsWkbTypes::NullGeometry );
-      mShowOnlyVisibleFeaturesCheckBox->setChecked( mTable->vectorLayer()->geometryType() != QgsWkbTypes::NullGeometry &&  mTable->displayOnlyVisibleFeatures() );
+      mShowOnlyVisibleFeaturesCheckBox->setEnabled( mTable->vectorLayer() && mTable->vectorLayer()->geometryType() != QgsWkbTypes::NullGeometry );
+      mShowOnlyVisibleFeaturesCheckBox->setChecked( mTable->vectorLayer() && mTable->vectorLayer()->geometryType() != QgsWkbTypes::NullGeometry && mTable->displayOnlyVisibleFeatures() );
       mComposerMapComboBox->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
       mComposerMapLabel->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
       break;

--- a/src/gui/layout/qgslayoutattributetablewidget.cpp
+++ b/src/gui/layout/qgslayoutattributetablewidget.cpp
@@ -959,10 +959,10 @@ void QgsLayoutAttributeTableWidget::toggleSourceControls()
       mRelationLabel->setVisible( false );
       mMaximumRowsSpinBox->setEnabled( false );
       mMaxNumFeaturesLabel->setEnabled( false );
-      mShowOnlyVisibleFeaturesCheckBox->setChecked( false );
-      mShowOnlyVisibleFeaturesCheckBox->setEnabled( false );
-      mComposerMapComboBox->setEnabled( false );
-      mComposerMapLabel->setEnabled( false );
+      mShowOnlyVisibleFeaturesCheckBox->setEnabled( mTable->sourceLayer() && mTable->sourceLayer()->geometryType() != QgsWkbTypes::NullGeometry );
+      mShowOnlyVisibleFeaturesCheckBox->setChecked( mTable->sourceLayer() && mTable->sourceLayer()->geometryType() != QgsWkbTypes::NullGeometry && mTable->displayOnlyVisibleFeatures() );
+      mComposerMapComboBox->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
+      mComposerMapLabel->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
       break;
     case QgsLayoutItemAttributeTable::RelationChildren:
       mLayerComboBox->setEnabled( false );

--- a/src/gui/layout/qgslayoutattributetablewidget.cpp
+++ b/src/gui/layout/qgslayoutattributetablewidget.cpp
@@ -944,9 +944,10 @@ void QgsLayoutAttributeTableWidget::toggleSourceControls()
       mRelationLabel->setVisible( false );
       mMaximumRowsSpinBox->setEnabled( true );
       mMaxNumFeaturesLabel->setEnabled( true );
-      mShowOnlyVisibleFeaturesCheckBox->setEnabled( true );
-      mComposerMapComboBox->setEnabled( mTable->displayOnlyVisibleFeatures() );
-      mComposerMapLabel->setEnabled( mTable->displayOnlyVisibleFeatures() );
+      mShowOnlyVisibleFeaturesCheckBox->setEnabled( mTable->vectorLayer()->geometryType() != QgsWkbTypes::NullGeometry );
+      mShowOnlyVisibleFeaturesCheckBox->setChecked( mTable->vectorLayer()->geometryType() != QgsWkbTypes::NullGeometry &&  mTable->displayOnlyVisibleFeatures() );
+      mComposerMapComboBox->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
+      mComposerMapLabel->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
       break;
     case QgsLayoutItemAttributeTable::AtlasFeature:
       mLayerComboBox->setEnabled( false );
@@ -974,8 +975,8 @@ void QgsLayoutAttributeTableWidget::toggleSourceControls()
       mMaximumRowsSpinBox->setEnabled( true );
       mMaxNumFeaturesLabel->setEnabled( true );
       mShowOnlyVisibleFeaturesCheckBox->setEnabled( true );
-      mComposerMapComboBox->setEnabled( mTable->displayOnlyVisibleFeatures() );
-      mComposerMapLabel->setEnabled( mTable->displayOnlyVisibleFeatures() );
+      mComposerMapComboBox->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
+      mComposerMapLabel->setEnabled( mShowOnlyVisibleFeaturesCheckBox->isChecked() );
       break;
   }
 }

--- a/src/gui/layout/qgslayoutattributetablewidget.cpp
+++ b/src/gui/layout/qgslayoutattributetablewidget.cpp
@@ -950,6 +950,7 @@ void QgsLayoutAttributeTableWidget::toggleSourceControls()
       mRelationLabel->setVisible( false );
       mMaximumRowsSpinBox->setEnabled( false );
       mMaxNumFeaturesLabel->setEnabled( false );
+      mShowOnlyVisibleFeaturesCheckBox->setChecked( false );
       mShowOnlyVisibleFeaturesCheckBox->setEnabled( false );
       mComposerMapComboBox->setEnabled( false );
       mComposerMapLabel->setEnabled( false );


### PR DESCRIPTION
On the attribute table property we can select the source that is "Layer Features", "Current report Feature" and "Relation Children".
On "Layer Features" and "Relation Children" we can filter according to geometry properties like "Show only features visible within a map" etc.

**The issue was:**
"Show only features visible within a map" turned to not editable when changing source from "Layer Features" to "Current report Feature" but keeps to be checked (so this setting is taken over). It's okay when it keeps to be checked but it's not okay, that the setting is considered even when it's inactive - since it influences the filter then - even when it's not crashing anymore since this #41532

![attr](https://user-images.githubusercontent.com/28384354/107972626-6c7f2380-6fb4-11eb-943a-83cda55a5545.png)

There would be the possibility to consider the enable state of a widget on the setting (means on turning the widget editable or not fires a signal changing the setting) but I decided against that behavior. I think it's clearer when the widget turns unchecked when it's disabled. 

**So the first idea for a fix was:** 
That the "Show only features visible within a map" (mShowOnlyVisibleFeaturesCheckBox) turns unchecked when the source changes to "Current report feature".

**But then we thought we might want change it completely and allow this function**
So "Show only features visible within a map" keeps it's setting and does not change to disabled.

**Additionally fixes/improvements:** 
Visual behaviors where not nice, but not critical like e.g. changing layer to one without geometry, then "Show only features visible within a map" turned unchecked and inactive but the linked map was still enabled or when changing source from "Current report Feature" to "Layer Features" then "Show only features visible within a map" turned enabled even on layers without geometry.

**_So now it ensures that this two (three with the label) widgets get disabled on layers without geometry. And it does not get disabled on  "Current report Feature" (if it has a geometry)_**

Btw. there might be the need to have this logic for the "Relation Children" source as well checking the referencingLayers geometry. But this is not part of this PR.