### PR TITLE
Correctly set data defined html url or attribute table source property on the parent multiframe object, not the child frame

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutobject.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutobject.sip.in
@@ -187,6 +187,18 @@ A base class for objects which belong to a layout.
 Returns the layout object property definitions.
 %End
 
+    static bool propertyAssociatesWithParentMultiframe( DataDefinedProperty property );
+%Docstring
+Returns ``True`` if the specified ``property`` key is normally associated with the parent
+:py:class:`QgsLayoutMultiFrame` object instead of a child :py:class:`QgsLayoutFrame` object.
+
+While some properties like QgsLayoutObject.DataDefinedProperty.PositionX and QgsLayoutObject.DataDefinedProperty.ItemWidth
+are typically associated with a direct :py:class:`QgsLayoutItem` subclass (including :py:class:`QgsLayoutFrame` objects), other properties
+are instead associated with a :py:class:`QgsLayoutMultiFrame` object (such as :py:class:`QgsLayoutObject`.DataDefinedProperty.SourceUrl or :py:class:`QgsLayoutObject`.DataDefinedProperty.AttributeTableSourceLayer).
+
+.. versionadded:: 3.18.1
+%End
+
     explicit QgsLayoutObject( QgsLayout *layout );
 %Docstring
 Constructor for QgsLayoutObject, with the specified parent ``layout``.

--- a/src/core/layout/qgslayoutobject.cpp
+++ b/src/core/layout/qgslayoutobject.cpp
@@ -110,6 +110,80 @@ const QgsPropertiesDefinition &QgsLayoutObject::propertyDefinitions()
   return sPropertyDefinitions;
 }
 
+bool QgsLayoutObject::propertyAssociatesWithParentMultiframe( QgsLayoutObject::DataDefinedProperty property )
+{
+  switch ( property )
+  {
+    case QgsLayoutObject::SourceUrl:
+    case QgsLayoutObject::AttributeTableSourceLayer:
+      return true;
+
+    case QgsLayoutObject::NoProperty:
+    case QgsLayoutObject::AllProperties:
+    case QgsLayoutObject::TestProperty:
+    case QgsLayoutObject::PresetPaperSize:
+    case QgsLayoutObject::PaperWidth:
+    case QgsLayoutObject::PaperHeight:
+    case QgsLayoutObject::NumPages:
+    case QgsLayoutObject::PaperOrientation:
+    case QgsLayoutObject::PageNumber:
+    case QgsLayoutObject::PositionX:
+    case QgsLayoutObject::PositionY:
+    case QgsLayoutObject::ItemWidth:
+    case QgsLayoutObject::ItemHeight:
+    case QgsLayoutObject::ItemRotation:
+    case QgsLayoutObject::Transparency:
+    case QgsLayoutObject::Opacity:
+    case QgsLayoutObject::BlendMode:
+    case QgsLayoutObject::ExcludeFromExports:
+    case QgsLayoutObject::FrameColor:
+    case QgsLayoutObject::BackgroundColor:
+    case QgsLayoutObject::MapRotation:
+    case QgsLayoutObject::MapScale:
+    case QgsLayoutObject::MapXMin:
+    case QgsLayoutObject::MapYMin:
+    case QgsLayoutObject::MapXMax:
+    case QgsLayoutObject::MapYMax:
+    case QgsLayoutObject::MapAtlasMargin:
+    case QgsLayoutObject::MapLayers:
+    case QgsLayoutObject::MapStylePreset:
+    case QgsLayoutObject::MapLabelMargin:
+    case QgsLayoutObject::MapGridEnabled:
+    case QgsLayoutObject::MapGridIntervalX:
+    case QgsLayoutObject::MapGridIntervalY:
+    case QgsLayoutObject::MapGridOffsetX:
+    case QgsLayoutObject::MapGridOffsetY:
+    case QgsLayoutObject::MapGridFrameSize:
+    case QgsLayoutObject::MapGridFrameMargin:
+    case QgsLayoutObject::MapGridLabelDistance:
+    case QgsLayoutObject::MapGridCrossSize:
+    case QgsLayoutObject::MapGridFrameLineThickness:
+    case QgsLayoutObject::MapGridAnnotationDisplayLeft:
+    case QgsLayoutObject::MapGridAnnotationDisplayRight:
+    case QgsLayoutObject::MapGridAnnotationDisplayTop:
+    case QgsLayoutObject::MapGridAnnotationDisplayBottom:
+    case QgsLayoutObject::MapGridFrameDivisionsLeft:
+    case QgsLayoutObject::MapGridFrameDivisionsRight:
+    case QgsLayoutObject::MapGridFrameDivisionsTop:
+    case QgsLayoutObject::MapGridFrameDivisionsBottom:
+    case QgsLayoutObject::PictureSource:
+    case QgsLayoutObject::PictureSvgBackgroundColor:
+    case QgsLayoutObject::PictureSvgStrokeColor:
+    case QgsLayoutObject::PictureSvgStrokeWidth:
+    case QgsLayoutObject::LegendTitle:
+    case QgsLayoutObject::LegendColumnCount:
+    case QgsLayoutObject::ScalebarFillColor:
+    case QgsLayoutObject::ScalebarFillColor2:
+    case QgsLayoutObject::ScalebarLineColor:
+    case QgsLayoutObject::ScalebarLineWidth:
+    case QgsLayoutObject::MapCrs:
+    case QgsLayoutObject::StartDateTime:
+    case QgsLayoutObject::EndDateTime:
+      return false;
+  }
+  return false;
+}
+
 QgsLayoutObject::QgsLayoutObject( QgsLayout *layout )
   : QObject( nullptr )
   , mLayout( layout )

--- a/src/core/layout/qgslayoutobject.h
+++ b/src/core/layout/qgslayoutobject.h
@@ -221,6 +221,18 @@ class CORE_EXPORT QgsLayoutObject: public QObject, public QgsExpressionContextGe
     static const QgsPropertiesDefinition &propertyDefinitions();
 
     /**
+     * Returns TRUE if the specified \a property key is normally associated with the parent
+     * QgsLayoutMultiFrame object instead of a child QgsLayoutFrame object.
+     *
+     * While some properties like QgsLayoutObject::DataDefinedProperty::PositionX and QgsLayoutObject::DataDefinedProperty::ItemWidth
+     * are typically associated with a direct QgsLayoutItem subclass (including QgsLayoutFrame objects), other properties
+     * are instead associated with a QgsLayoutMultiFrame object (such as QgsLayoutObject::DataDefinedProperty::SourceUrl or QgsLayoutObject::DataDefinedProperty::AttributeTableSourceLayer).
+     *
+     * \since QGIS 3.18.1
+     */
+    static bool propertyAssociatesWithParentMultiframe( DataDefinedProperty property );
+
+    /**
      * Constructor for QgsLayoutObject, with the specified parent \a layout.
      * \note While ownership of a QgsLayoutObject is not passed to the layout,
      * classes which are derived from QgsLayoutObject (such as QgsLayoutItem)

--- a/src/gui/layout/qgslayoutitemwidget.cpp
+++ b/src/gui/layout/qgslayoutitemwidget.cpp
@@ -26,6 +26,7 @@
 #include "qgsfontbutton.h"
 #include "qgslayoutdesignerinterface.h"
 #include "qgslayoutpagecollection.h"
+#include "qgslayoutmultiframe.h"
 #include <QButtonGroup>
 
 //
@@ -65,8 +66,26 @@ void QgsLayoutConfigObject::updateDataDefinedProperty()
     return;
   }
 
+  const bool propertyAssociatesWithMultiFrame = QgsLayoutObject::propertyAssociatesWithParentMultiframe( key );
+
   //set the data defined property and refresh the item
-  if ( mLayoutObject )
+  if ( propertyAssociatesWithMultiFrame )
+  {
+    if ( QgsLayoutFrame *frame = dynamic_cast< QgsLayoutFrame * >( mLayoutObject.data() ) )
+    {
+      if ( QgsLayoutMultiFrame *multiFrame = frame->multiFrame() )
+      {
+        multiFrame->dataDefinedProperties().setProperty( key, ddButton->toProperty() );
+        multiFrame->refresh();
+      }
+    }
+    else if ( QgsLayoutMultiFrame *multiFrame = dynamic_cast< QgsLayoutMultiFrame * >( mLayoutObject.data() ) )
+    {
+      multiFrame->dataDefinedProperties().setProperty( key, ddButton->toProperty() );
+      multiFrame->refresh();
+    }
+  }
+  else if ( mLayoutObject )
   {
     mLayoutObject->dataDefinedProperties().setProperty( key, ddButton->toProperty() );
     mLayoutObject->refresh();


### PR DESCRIPTION
Fixes #41590
Fixes #36647
