### PR TITLE
OGC workflow triggering

### DIFF
--- a/.github/workflows/ogc.yml
+++ b/.github/workflows/ogc.yml
@@ -6,10 +6,10 @@ on:
       - master
       - release-**
     paths:
-    - 'src/core'
-    - 'src/auth'
-    - 'src/providers'
-    - 'src/server'
+    - 'src/core/**'
+    - 'src/auth/**'
+    - 'src/providers/**'
+    - 'src/server/**'
     - 'src/CMakeLists.txt'
     - 'external/**'
     - 'CMakeLists.txt'
@@ -19,10 +19,10 @@ on:
       - master
       - release-**
     paths:
-    - 'src/core'
-    - 'src/auth'
-    - 'src/providers'
-    - 'src/server'
+    - 'src/core/**'
+    - 'src/auth/**'
+    - 'src/providers/**'
+    - 'src/server/**'
     - 'src/CMakeLists.txt'
     - 'external/**'
     - 'CMakeLists.txt'


### PR DESCRIPTION
## Description

It'd seem that since https://github.com/qgis/QGIS/pull/41553, the OGC workflow is not triggered on master even in valid cases.

For example, the workflow is not triggered on this PR https://github.com/qgis/QGIS/pull/41333.

I'm currently just testing the CI to see if adding `/**` in path definition fixes the issue.