### PR TITLE
Reorder expression operators

### DIFF
--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -706,21 +706,22 @@ int QgsExpressionNodeBinaryOperator::precedence() const
     case boIsNot:
       return 3;
 
+    case boConcat:
+      return 4;
+
     case boPlus:
     case boMinus:
-      return 4;
+      return 5;
 
     case boMul:
     case boDiv:
     case boIntDiv:
     case boMod:
-      return 5;
-
-    case boPow:
       return 6;
 
-    case boConcat:
+    case boPow:
       return 7;
+
   }
   Q_ASSERT( false && "unexpected binary operator" );
   return -1;

--- a/src/core/qgsexpressionparser.yy
+++ b/src/core/qgsexpressionparser.yy
@@ -158,10 +158,10 @@ void addParserLocation(YYLTYPE* yyloc, QgsExpressionNode *node)
 %left AND
 %right NOT
 %left EQ NE LE GE LT GT REGEXP LIKE IS IN
+%left CONCAT
 %left PLUS MINUS
 %left MUL DIV INTDIV MOD
 %right POW
-%left CONCAT
 
 %right UMINUS  // fictitious symbol (for unary minus)
 
@@ -200,6 +200,7 @@ expression:
     | expression REGEXP expression    { $$ = BINOP($2, $1, $3); }
     | expression LIKE expression      { $$ = BINOP($2, $1, $3); }
     | expression IS expression        { $$ = BINOP($2, $1, $3); }
+    | expression CONCAT expression    { $$ = BINOP($2, $1, $3); }
     | expression PLUS expression      { $$ = BINOP($2, $1, $3); }
     | expression MINUS expression     { $$ = BINOP($2, $1, $3); }
     | expression MUL expression       { $$ = BINOP($2, $1, $3); }
@@ -207,7 +208,6 @@ expression:
     | expression DIV expression       { $$ = BINOP($2, $1, $3); }
     | expression MOD expression       { $$ = BINOP($2, $1, $3); }
     | expression POW expression       { $$ = BINOP($2, $1, $3); }
-    | expression CONCAT expression    { $$ = BINOP($2, $1, $3); }
     | NOT expression                  { $$ = new QgsExpressionNodeUnaryOperator($1, $2); }
     | '(' expression ')'              { $$ = $2; }
     | NAME '(' exp_list ')'

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -4195,6 +4195,17 @@ class TestQgsExpression: public QObject
       QCOMPARE( exp2.referencedVariables(), QSet<QString>() << QStringLiteral( "field_name_part_var" ) << QStringLiteral( "static_feature" ) );
     }
 
+    void testOperationOrder()
+    {
+      QgsExpression exp1( QStringLiteral( " 'lead' || 5.22 * 0.9 ^ 5" ) );
+      QVariant v1 = exp1.evaluate();
+      QVERIFY( !exp1.hasEvalError() );
+      QVERIFY( v1.toString() == "lead3.0823578" );
+      QgsExpression exp2( QStringLiteral( " 5.22 / 0.9 ^ 5 - 4" ) );
+      QVariant v2 = exp2.evaluate();
+      QVERIFY( !exp2.hasEvalError() );
+      QVERIFY( v2.toDouble() >= 4.83 && v2.toDouble() <= 4.85 );
+    }
 };
 
 QGSTEST_MAIN( TestQgsExpression )


### PR DESCRIPTION
## Description

This is a proposal to reduce the importance of the concatenate operator in expressions.

Currently the '||' operator is evaluated first. This means that any numerical value is converted to text and bricks any related mathematical operator.

This fix proposes to evaluate mathematical operators first and then do the one-way string transformation.
