### PR TITLE
Fix mimeUri when ogr/gdal has mixed raster+vector types

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2105,7 +2105,12 @@ void QgisApp::handleDropUriList( const QgsMimeDataUtils::UriList &lst )
 
     QString uri = crsAndFormatAdjustedLayerUri( u.uri, u.supportedCrs, u.supportedFormats );
 
-    if ( u.layerType == QLatin1String( "vector" ) )
+    if ( u.layerType == QLatin1String( "vector+raster" ) )
+    {
+      addVectorLayer( uri, u.name, u.providerKey );
+      addRasterLayer( uri, u.name, u.providerKey == QLatin1String( "ogr" ) ? QLatin1String( "gdal" ) : u.providerKey );
+    }
+    else if ( u.layerType == QLatin1String( "vector" ) )
     {
       addVectorLayer( uri, u.name, u.providerKey );
     }

--- a/src/core/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/core/providers/ogr/qgsgeopackagedataitems.cpp
@@ -400,6 +400,6 @@ QgsMimeDataUtils::Uri QgsGeoPackageCollectionItem::mimeUri() const
   QgsMimeDataUtils::Uri u;
   u.providerKey = QStringLiteral( "ogr" );
   u.uri = path();
-  u.layerType = QStringLiteral( "vector" );
+  u.layerType = QStringLiteral( "vector+raster" );
   return u;
 }

--- a/src/core/providers/ogr/qgsogrdataitems.cpp
+++ b/src/core/providers/ogr/qgsogrdataitems.cpp
@@ -457,7 +457,7 @@ QgsMimeDataUtils::Uri QgsOgrDataCollectionItem::mimeUri() const
   QgsMimeDataUtils::Uri u;
   u.providerKey = QStringLiteral( "ogr" );
   u.uri = path();
-  u.layerType = QStringLiteral( "vector" );
+  u.layerType = QStringLiteral( "vector+raster" );
   return u;
 }
 

--- a/src/core/qgsmimedatautils.h
+++ b/src/core/qgsmimedatautils.h
@@ -99,6 +99,7 @@ class CORE_EXPORT QgsMimeDataUtils
        *
        * - "vector": vector layers
        * - "raster": raster layers
+       * - "vector+raster": OGR/GDAL layer collections (GPKG, SpatiaLite etc.) may contain both types
        * - "mesh": mesh layers
        * - "plugin": plugin layers
        * - "custom": custom types


### PR DESCRIPTION
Formats such as GPKG or SpatiaLite can contain both layer types.

I've considered the alternatives (reporting multiple mime types from
DB containers but this looks like a more straightforward approach).

GDAL/OGR should eventually be unified from a provider's point of view
but I guess it won't happen before QGIS 6.

Fixes #41563

A bit late for the release, sorry.
