### PR TITLE
add support for OGC API Records to metasearch

### DIFF
--- a/python/plugins/MetaSearch/resources/templates/oarec_service_metadata.html
+++ b/python/plugins/MetaSearch/resources/templates/oarec_service_metadata.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ language }}">
+    <head>
+        <meta charset="utf-8"/>
+        <title>{{ gettext('Service Metadata') }}</title>
+        <style type="text/css">
+            body,h3, h4 {
+                background-color: #ffffff;
+                font-family: arial, verdana, sans-serif;
+                text-align: left;
+                float: left;
+            }
+            header {
+                display: inline-block;
+            }
+        </style>
+    </head>
+    <body>
+        <header>
+            <h3>{{ gettext('Service Metadata') }} {{ obj.url }}</h3>
+        </header>
+
+        <h4>Conformance</h4><br/>
+        {% for i in obj.conformance()['conformsTo'] %}
+        <a href="{{ i }}">{{ i }}</a><br/>
+        {% endfor %}
+
+        <h4>Collections</h4><br/>
+        {% for i in obj.collections()['collections'] %}
+        <p><b>{{ i.title }}</b><br/>{{ i.description }}</p>
+        {% endfor %}
+
+        {% if obj.links %}
+            <h4>Links</h4><br/>
+            {% for i in obj.links %}
+                <a href="{{ i.href }}">{{ i.title or i.href }}</a><br/>
+            {% endfor %}
+        {% endif %}
+
+    </body>
+</html>

--- a/python/plugins/MetaSearch/resources/templates/record_metadata_oarec.html
+++ b/python/plugins/MetaSearch/resources/templates/record_metadata_oarec.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="{{ language }}">
+    <head>
+        <meta charset="utf-8"/>
+        <title>{{ gettext('Record Metadata') }}</title>
+        <style type="text/css">
+            body, h3 {
+                background-color: #ffffff;
+                font-family: arial, verdana, sans-serif;
+                text-align: left;
+                float: left;
+            }
+            header {
+                display: inline-block;
+            }
+        </style>
+    </head>
+    <body>
+        <header>
+            <h3>{{ gettext('Record Metadata') }}</h3>
+        </header>
+        <section id="record-metadata">
+            <table>
+                <tr>
+                    <td>Identifier</td>
+                    <td>{{ obj['id'] }}</td>
+                </tr>
+                {% for a,b in obj['properties'].items() %}
+                    {% if a not in ['extent'] %}
+                        <tr>
+                            <td>{{ a }}</td>
+                            <td>{{ b }}</td>
+                        </tr>
+                  {% endif %}
+                {% endfor %}
+
+            </table>
+        </section>
+    </body>
+</html>


### PR DESCRIPTION
!!early implementation!!

## Description

This adds support for OGC API Records to metasearch. You can now either enter a CSW or a OGC API Records url in the service configuration. Try for example https://demo.pygeoapi.io/master.

![image](https://user-images.githubusercontent.com/299829/108609235-fe2fcc00-73cc-11eb-9294-8d4071573071.png)

Then search for records. Notice that when you select a record, a box is displayed in the map.

![image](https://user-images.githubusercontent.com/299829/108609357-9c239680-73cd-11eb-9f4e-4ca395b11b9e.png)

Currently the link relations (to wms, wfs) have not been implemented, due to limitation in the pygeoapi demo server.

Double click a record for more details

![image](https://user-images.githubusercontent.com/299829/108609383-cd03cb80-73cd-11eb-9b12-1dd9b7b4969d.png)


This requires owslib v0.20 (which is not in 3.16)
I've introduced shapely, it seems available by default in qgis
fixes #41566