### PR TITLE
Use the GeographicLib routines exposed through PROJ for all ellipsoidal calculations

### DIFF
--- a/python/core/auto_generated/qgsdistancearea.sip.in
+++ b/python/core/auto_generated/qgsdistancearea.sip.in
@@ -28,6 +28,8 @@ of all measured geometries must first be specified using :py:func:`~setSourceCrs
 Usually, the measurements returned by :py:class:`QgsDistanceArea` are in meters. If no valid
 ellipsoid is set, then the units may not be meters. The units can be retrieved
 by calling :py:func:`~lengthUnits` and :py:func:`~areaUnits`.
+
+Internally, the GeographicLib library is used to calculate all ellipsoid based measurements.
 %End
 
 %TypeHeaderCode
@@ -38,6 +40,12 @@ by calling :py:func:`~lengthUnits` and :py:func:`~areaUnits`.
     QgsDistanceArea();
 %Docstring
 Constructor
+%End
+    ~QgsDistanceArea();
+
+    QgsDistanceArea( const QgsDistanceArea &other );
+%Docstring
+Copy constructor
 %End
 
     bool willUseEllipsoid() const;
@@ -348,25 +356,13 @@ different areal unit.
     QgsPointXY computeSpheroidProject( const QgsPointXY &p1, double distance = 1, double azimuth = M_PI_2 ) const;
 %Docstring
 Given a location, an azimuth and a distance, computes the
-location of the projected point. Based on Vincenty's formula
-for the geodetic direct problem as described in "Geocentric
-Datum of Australia Technical Manual", Chapter 4.
+location of the projected point.
 
 :param p1: - location of first geographic (latitude/longitude) point as degrees.
 :param distance: - distance in meters.
 :param azimuth: - azimuth in radians, clockwise from North
 
 :return: p2 - location of projected point as longitude/latitude.
-
-.. note::
-
-   code (and documentation) taken from rttopo project
-   https://git.osgeo.org/gogs/rttopo/librttopo
-
-- spheroid_project.spheroid_project(...)
-- Valid bounds checking for degrees (latitude=+- 85.05115) is based values used for
--> 'WGS84 Web Mercator (Auxiliary Sphere)' calculations
---> latitudes outside these bounds cause the calculations to become unstable and can return invalid results
 
 .. versionadded:: 3.0
 %End

--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -307,6 +307,7 @@ double QgsDistanceArea::measureLine( const QVector<QgsPointXY> &points ) const
   {
     if ( !mGeod )
       computeAreaInit();
+    Q_ASSERT_X( static_cast<bool>( mGeod ), "QgsDistanceArea::measureLine()", "Error creating geod_geodesic object" );
     if ( !mGeod )
       return 0;
   }
@@ -358,6 +359,7 @@ double QgsDistanceArea::measureLine( const QgsPointXY &p1, const QgsPointXY &p2 
   {
     if ( !mGeod )
       computeAreaInit();
+    Q_ASSERT_X( static_cast<bool>( mGeod ), "QgsDistanceArea::measureLine()", "Error creating geod_geodesic object" );
     if ( !mGeod )
       return 0;
   }
@@ -480,6 +482,7 @@ double QgsDistanceArea::latitudeGeodesicCrossesAntimeridian( const QgsPointXY &p
 
   if ( !mGeod )
     computeAreaInit();
+  Q_ASSERT_X( static_cast<bool>( mGeod ), "QgsDistanceArea::latitudeGeodesicCrossesAntimeridian()", "Error creating geod_geodesic object" );
   if ( !mGeod )
     return 0;
 
@@ -849,6 +852,7 @@ double QgsDistanceArea::bearing( const QgsPointXY &p1, const QgsPointXY &p2 ) co
 
     if ( !mGeod )
       computeAreaInit();
+    Q_ASSERT_X( static_cast<bool>( mGeod ), "QgsDistanceArea::bearing()", "Error creating geod_geodesic object" );
     if ( !mGeod )
       return 0;
 
@@ -913,6 +917,7 @@ double QgsDistanceArea::computePolygonArea( const QVector<QgsPointXY> &points ) 
 
   if ( !mGeod )
     computeAreaInit();
+  Q_ASSERT_X( static_cast<bool>( mGeod ), "QgsDistanceArea::computePolygonArea()", "Error creating geod_geodesic object" );
   if ( !mGeod )
     return 0;
 

--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -930,7 +930,7 @@ double QgsDistanceArea::computePolygonArea( const QVector<QgsPointXY> &points ) 
   double perimeter = 0;
   geod_polygon_compute( mGeod.get(), &p, 0, 1, &area, &perimeter );
 
-  return area;
+  return std::fabs( area );
 }
 
 double QgsDistanceArea::computePolygonFlatArea( const QVector<QgsPointXY> &points ) const

--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -919,11 +919,13 @@ double QgsDistanceArea::computePolygonArea( const QVector<QgsPointXY> &points ) 
   struct geod_polygon p;
   geod_polygon_init( &p, 0 );
 
+  const bool isClosed = points.constFirst() == points.constLast();
+
   /* GeographicLib does not need a closed ring,
    * see example for geod_polygonarea() in geodesic.h */
   /* add points in reverse order */
   int i = points.size();
-  while ( --i )
+  while ( ( isClosed && --i ) || ( !isClosed && --i >= 0 ) )
     geod_polygon_addpoint( mGeod.get(), &p, points.at( i ).y(), points.at( i ).x() );
 
   double area = 0;

--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -52,6 +52,29 @@ QgsDistanceArea::QgsDistanceArea()
   setEllipsoid( geoNone() );
 }
 
+QgsDistanceArea::~QgsDistanceArea() = default;
+
+QgsDistanceArea::QgsDistanceArea( const QgsDistanceArea &other )
+  : mCoordTransform( other.mCoordTransform )
+  , mEllipsoid( other.mEllipsoid )
+  , mSemiMajor( other.mSemiMajor )
+  , mSemiMinor( other.mSemiMinor )
+  , mInvFlattening( other.mInvFlattening )
+{
+  computeAreaInit();
+}
+
+QgsDistanceArea &QgsDistanceArea::operator=( const QgsDistanceArea &other )
+{
+  mCoordTransform = other.mCoordTransform;
+  mEllipsoid = other.mEllipsoid;
+  mSemiMajor = other.mSemiMajor;
+  mSemiMinor = other.mSemiMinor;
+  mInvFlattening = other.mInvFlattening;
+  computeAreaInit();
+  return *this;
+}
+
 bool QgsDistanceArea::willUseEllipsoid() const
 {
   return mEllipsoid != geoNone();
@@ -69,12 +92,14 @@ bool QgsDistanceArea::setEllipsoid( const QString &ellipsoid )
   if ( ellipsoid == geoNone() )
   {
     mEllipsoid = geoNone();
+    mGeod.reset();
     return true;
   }
 
   QgsEllipsoidUtils::EllipsoidParameters params = QgsEllipsoidUtils::ellipsoidParameters( ellipsoid );
   if ( !params.valid )
   {
+    mGeod.reset();
     return false;
   }
   else
@@ -278,6 +303,14 @@ double QgsDistanceArea::measureLine( const QVector<QgsPointXY> &points ) const
   double total = 0;
   QgsPointXY p1, p2;
 
+  if ( willUseEllipsoid() )
+  {
+    if ( !mGeod )
+      computeAreaInit();
+    if ( !mGeod )
+      return 0;
+  }
+
   try
   {
     if ( willUseEllipsoid() )
@@ -290,7 +323,12 @@ double QgsDistanceArea::measureLine( const QVector<QgsPointXY> &points ) const
       if ( willUseEllipsoid() )
       {
         p2 = mCoordTransform.transform( *i );
-        total += computeDistanceBearing( p1, p2 );
+
+        double distance = 0;
+        double azimuth1 = 0;
+        double azimuth2 = 0;
+        geod_inverse( mGeod.get(), p1.y(), p1.x(), p2.y(), p2.x(), &distance, &azimuth1, &azimuth2 );
+        total += distance;
       }
       else
       {
@@ -316,6 +354,14 @@ double QgsDistanceArea::measureLine( const QgsPointXY &p1, const QgsPointXY &p2 
 {
   double result;
 
+  if ( willUseEllipsoid() )
+  {
+    if ( !mGeod )
+      computeAreaInit();
+    if ( !mGeod )
+      return 0;
+  }
+
   try
   {
     QgsPointXY pp1 = p1, pp2 = p2;
@@ -329,7 +375,10 @@ double QgsDistanceArea::measureLine( const QgsPointXY &p1, const QgsPointXY &p2 
       pp1 = mCoordTransform.transform( p1 );
       pp2 = mCoordTransform.transform( p2 );
       QgsDebugMsgLevel( QStringLiteral( "New points are %1 and %2, calculating..." ).arg( pp1.toString( 4 ), pp2.toString( 4 ) ), 4 );
-      result = computeDistanceBearing( pp1, pp2 );
+
+      double azimuth1 = 0;
+      double azimuth2 = 0;
+      geod_inverse( mGeod.get(), pp1.y(), pp1.x(), pp2.y(), pp2.x(), &result, &azimuth1, &azimuth2 );
     }
     else
     {
@@ -386,75 +435,20 @@ double QgsDistanceArea::measureLineProjected( const QgsPointXY &p1, double dista
   return result;
 }
 
-/*
- *  From original rttopo documentation:
- *  Tested against:
- *   http://mascot.gdbc.gov.bc.ca/mascot/util1b.html
- *  and
- *   http://www.ga.gov.au/nmd/geodesy/datums/vincenty_direct.jsp
- */
 QgsPointXY QgsDistanceArea::computeSpheroidProject(
   const QgsPointXY &p1, double distance, double azimuth ) const
 {
-  // ellipsoid
-  double a = mSemiMajor;
-  double b = mSemiMinor;
-  double f = 1 / mInvFlattening;
-  if ( ( ( a < 0 ) && ( b < 0 ) ) ||
-       ( ( p1.x() < -180.0 ) || ( p1.x() > 180.0 ) || ( p1.y() < -85.05115 ) || ( p1.y() > 85.05115 ) ) )
-  {
-    // latitudes outside these bounds cause the calculations to become unstable and can return invalid results
-    return QgsPoint( 0, 0 );
+  if ( !mGeod )
+    computeAreaInit();
+  if ( !mGeod )
+    return QgsPointXY();
 
-  }
-  double radians_lat = DEG2RAD( p1.y() );
-  double radians_long = DEG2RAD( p1.x() );
-  double b2 = POW2( b ); // spheroid_mu2
-  double omf = 1 - f;
-  double tan_u1 = omf * std::tan( radians_lat );
-  double u1 = std::atan( tan_u1 );
-  double sigma, last_sigma, delta_sigma, two_sigma_m;
-  double sigma1, sin_alpha, alpha, cos_alphasq;
-  double u2, A, B;
-  double lat2, lambda, lambda2, C, omega;
-  int i = 0;
-  if ( azimuth < 0.0 )
-  {
-    azimuth = azimuth + M_PI * 2.0;
-  }
-  if ( azimuth > ( M_PI * 2.0 ) )
-  {
-    azimuth = azimuth - M_PI * 2.0;
-  }
-  sigma1 = std::atan2( tan_u1, std::cos( azimuth ) );
-  sin_alpha = std::cos( u1 ) * std::sin( azimuth );
-  alpha = std::asin( sin_alpha );
-  cos_alphasq = 1.0 - POW2( sin_alpha );
-  u2 = POW2( std::cos( alpha ) ) * ( POW2( a ) - b2 ) / b2; // spheroid_mu2
-  A = 1.0 + ( u2 / 16384.0 ) * ( 4096.0 + u2 * ( -768.0 + u2 * ( 320.0 - 175.0 * u2 ) ) );
-  B = ( u2 / 1024.0 ) * ( 256.0 + u2 * ( -128.0 + u2 * ( 74.0 - 47.0 * u2 ) ) );
-  sigma = ( distance / ( b * A ) );
-  do
-  {
-    two_sigma_m = 2.0 * sigma1 + sigma;
-    delta_sigma = B * std::sin( sigma ) * ( std::cos( two_sigma_m ) + ( B / 4.0 ) * ( std::cos( sigma ) * ( -1.0 + 2.0 * POW2( std::cos( two_sigma_m ) ) - ( B / 6.0 ) * std::cos( two_sigma_m ) * ( -3.0 + 4.0 * POW2( std::sin( sigma ) ) ) * ( -3.0 + 4.0 * POW2( std::cos( two_sigma_m ) ) ) ) ) );
-    last_sigma = sigma;
-    sigma = ( distance / ( b * A ) ) + delta_sigma;
-    i++;
-  }
-  while ( i < 999 && std::fabs( ( last_sigma - sigma ) / sigma ) > 1.0e-9 );
+  double lat2 = 0;
+  double lon2 = 0;
+  double azimuth2 = 0;
+  geod_direct( mGeod.get(), p1.y(), p1.x(), RAD2DEG( azimuth ), distance, &lat2, &lon2, &azimuth2 );
 
-  lat2 = std::atan2( ( std::sin( u1 ) * std::cos( sigma ) + std::cos( u1 ) * std::sin( sigma ) *
-                       std::cos( azimuth ) ), ( omf * std::sqrt( POW2( sin_alpha ) +
-                           POW2( std::sin( u1 ) * std::sin( sigma ) - std::cos( u1 ) * std::cos( sigma ) *
-                                 std::cos( azimuth ) ) ) ) );
-  lambda = std::atan2( ( std::sin( sigma ) * std::sin( azimuth ) ), ( std::cos( u1 ) * std::cos( sigma ) -
-                       std::sin( u1 ) * std::sin( sigma ) * std::cos( azimuth ) ) );
-  C = ( f / 16.0 ) * cos_alphasq * ( 4.0 + f * ( 4.0 - 3.0 * cos_alphasq ) );
-  omega = lambda - ( 1.0 - C ) * f * sin_alpha * ( sigma + C * std::sin( sigma ) *
-          ( std::cos( two_sigma_m ) + C * std::cos( sigma ) * ( -1.0 + 2.0 * POW2( std::cos( two_sigma_m ) ) ) ) );
-  lambda2 = radians_long + omega;
-  return QgsPointXY( RAD2DEG( lambda2 ), RAD2DEG( lat2 ) );
+  return QgsPointXY( lon2, lat2 );
 }
 
 double QgsDistanceArea::latitudeGeodesicCrossesAntimeridian( const QgsPointXY &pp1, const QgsPointXY &pp2, double &fractionAlongLine ) const
@@ -484,11 +478,13 @@ double QgsDistanceArea::latitudeGeodesicCrossesAntimeridian( const QgsPointXY &p
     return p1y + ( 180 - p1x ) / ( p2x - p1x ) * ( p2y - p1y );
   }
 
-  geod_geodesic geod;
-  geod_init( &geod, mSemiMajor, 1 / mInvFlattening );
+  if ( !mGeod )
+    computeAreaInit();
+  if ( !mGeod )
+    return 0;
 
   geod_geodesicline line;
-  geod_inverseline( &line, &geod, p1y, p1x, p2y, p2x, GEOD_ALL );
+  geod_inverseline( &line, mGeod.get(), p1y, p1x, p2y, p2x, GEOD_ALL );
 
   const double totalDist = line.s13;
   double intersectionDist = line.s13;
@@ -513,7 +509,7 @@ double QgsDistanceArea::latitudeGeodesicCrossesAntimeridian( const QgsPointXY &p
       }
       QgsDebugMsgLevel( QStringLiteral( "Narrowed window to %1, %2 - %3, %4" ).arg( p1x ).arg( p1y ).arg( p2x ).arg( p2y ), 4 );
 
-      geod_inverseline( &line, &geod, p1y, p1x, p2y, p2x, GEOD_ALL );
+      geod_inverseline( &line, mGeod.get(), p1y, p1x, p2y, p2x, GEOD_ALL );
       intersectionDist = line.s13 * 0.5;
     }
     else
@@ -677,8 +673,10 @@ QVector< QVector<QgsPointXY> > QgsDistanceArea::geodesicLine( const QgsPointXY &
     return QVector< QVector< QgsPointXY > >() << ( QVector< QgsPointXY >() << p1 << p2 );
   }
 
-  geod_geodesic geod;
-  geod_init( &geod, mSemiMajor, 1 / mInvFlattening );
+  if ( !mGeod )
+    computeAreaInit();
+  if ( !mGeod )
+    return QVector< QVector< QgsPointXY > >();
 
   QgsPointXY pp1, pp2;
   try
@@ -693,7 +691,7 @@ QVector< QVector<QgsPointXY> > QgsDistanceArea::geodesicLine( const QgsPointXY &
   }
 
   geod_geodesicline line;
-  geod_inverseline( &line, &geod, pp1.y(), pp1.x(), pp2.y(), pp2.x(), GEOD_ALL );
+  geod_inverseline( &line, mGeod.get(), pp1.y(), pp1.x(), pp2.y(), pp2.x(), GEOD_ALL );
   const double totalDist = line.s13;
 
   QVector< QVector< QgsPointXY > > res;
@@ -848,7 +846,18 @@ double QgsDistanceArea::bearing( const QgsPointXY &p1, const QgsPointXY &p2 ) co
   {
     pp1 = mCoordTransform.transform( p1 );
     pp2 = mCoordTransform.transform( p2 );
-    computeDistanceBearing( pp1, pp2, &bearing );
+
+    if ( !mGeod )
+      computeAreaInit();
+    if ( !mGeod )
+      return 0;
+
+    double distance = 0;
+    double azimuth1 = 0;
+    double azimuth2 = 0;
+    geod_inverse( mGeod.get(), pp1.y(), pp1.x(), pp2.x(), pp2.y(), &distance, &azimuth1, &azimuth2 );
+
+    bearing = DEG2RAD( azimuth1 );
   }
   else //compute simple planar azimuth
   {
@@ -860,146 +869,17 @@ double QgsDistanceArea::bearing( const QgsPointXY &p1, const QgsPointXY &p2 ) co
   return bearing;
 }
 
-
-///////////////////////////////////////////////////////////
-// distance calculation
-
-double QgsDistanceArea::computeDistanceBearing(
-  const QgsPointXY &p1, const QgsPointXY &p2,
-  double *course1, double *course2 ) const
-{
-  if ( qgsDoubleNear( p1.x(), p2.x() ) && qgsDoubleNear( p1.y(), p2.y() ) )
-    return 0;
-
-  // ellipsoid
-  double a = mSemiMajor;
-  double b = mSemiMinor;
-  double f = 1 / mInvFlattening;
-
-  double p1_lat = DEG2RAD( p1.y() ), p1_lon = DEG2RAD( p1.x() );
-  double p2_lat = DEG2RAD( p2.y() ), p2_lon = DEG2RAD( p2.x() );
-
-  double L = p2_lon - p1_lon;
-  double U1 = std::atan( ( 1 - f ) * std::tan( p1_lat ) );
-  double U2 = std::atan( ( 1 - f ) * std::tan( p2_lat ) );
-  double sinU1 = std::sin( U1 ), cosU1 = std::cos( U1 );
-  double sinU2 = std::sin( U2 ), cosU2 = std::cos( U2 );
-  double lambda = L;
-  double lambdaP = 2 * M_PI;
-
-  double sinLambda = 0;
-  double cosLambda = 0;
-  double sinSigma = 0;
-  double cosSigma = 0;
-  double sigma = 0;
-  double alpha = 0;
-  double cosSqAlpha = 0;
-  double cos2SigmaM = 0;
-  double C = 0;
-  double tu1 = 0;
-  double tu2 = 0;
-
-  int iterLimit = 20;
-  while ( std::fabs( lambda - lambdaP ) > 1e-12 && --iterLimit > 0 )
-  {
-    sinLambda = std::sin( lambda );
-    cosLambda = std::cos( lambda );
-    tu1 = ( cosU2 * sinLambda );
-    tu2 = ( cosU1 * sinU2 - sinU1 * cosU2 * cosLambda );
-    sinSigma = std::sqrt( tu1 * tu1 + tu2 * tu2 );
-    cosSigma = sinU1 * sinU2 + cosU1 * cosU2 * cosLambda;
-    sigma = std::atan2( sinSigma, cosSigma );
-    alpha = std::asin( cosU1 * cosU2 * sinLambda / sinSigma );
-    cosSqAlpha = std::cos( alpha ) * std::cos( alpha );
-    cos2SigmaM = cosSigma - 2 * sinU1 * sinU2 / cosSqAlpha;
-    C = f / 16 * cosSqAlpha * ( 4 + f * ( 4 - 3 * cosSqAlpha ) );
-    lambdaP = lambda;
-    lambda = L + ( 1 - C ) * f * std::sin( alpha ) *
-             ( sigma + C * sinSigma * ( cos2SigmaM + C * cosSigma * ( -1 + 2 * cos2SigmaM * cos2SigmaM ) ) );
-  }
-
-  if ( iterLimit == 0 )
-    return -1;  // formula failed to converge
-
-  double uSq = cosSqAlpha * ( a * a - b * b ) / ( b * b );
-  double A = 1 + uSq / 16384 * ( 4096 + uSq * ( -768 + uSq * ( 320 - 175 * uSq ) ) );
-  double B = uSq / 1024 * ( 256 + uSq * ( -128 + uSq * ( 74 - 47 * uSq ) ) );
-  double deltaSigma = B * sinSigma * ( cos2SigmaM + B / 4 * ( cosSigma * ( -1 + 2 * cos2SigmaM * cos2SigmaM ) -
-                                       B / 6 * cos2SigmaM * ( -3 + 4 * sinSigma * sinSigma ) * ( -3 + 4 * cos2SigmaM * cos2SigmaM ) ) );
-  double s = b * A * ( sigma - deltaSigma );
-
-  if ( course1 )
-  {
-    *course1 = std::atan2( tu1, tu2 );
-  }
-  if ( course2 )
-  {
-    // PI is added to return azimuth from P2 to P1
-    *course2 = std::atan2( cosU1 * sinLambda, -sinU1 * cosU2 + cosU1 * sinU2 * cosLambda ) + M_PI;
-  }
-
-  return s;
-}
-
-///////////////////////////////////////////////////////////
-// stuff for measuring areas - copied from GRASS
-// don't know how does it work, but it's working .)
-// see G_begin_ellipsoid_polygon_area() in area_poly1.c
-
-double QgsDistanceArea::getQ( double x ) const
-{
-  double sinx, sinx2;
-
-  sinx = std::sin( x );
-  sinx2 = sinx * sinx;
-
-  return sinx * ( 1 + sinx2 * ( m_QA + sinx2 * ( m_QB + sinx2 * m_QC ) ) );
-}
-
-
-double QgsDistanceArea::getQbar( double x ) const
-{
-  double cosx, cosx2;
-
-  cosx = std::cos( x );
-  cosx2 = cosx * cosx;
-
-  return cosx * ( m_QbarA + cosx2 * ( m_QbarB + cosx2 * ( m_QbarC + cosx2 * m_QbarD ) ) );
-}
-
-
-void QgsDistanceArea::computeAreaInit()
+void QgsDistanceArea::computeAreaInit() const
 {
   //don't try to perform calculations if no ellipsoid
   if ( mEllipsoid == geoNone() )
   {
+    mGeod.reset();
     return;
   }
 
-  double a2 = ( mSemiMajor * mSemiMajor );
-  double e2 = 1 - ( ( mSemiMinor * mSemiMinor ) / a2 );
-  double e4, e6;
-
-  m_TwoPI = M_PI + M_PI;
-
-  e4 = e2 * e2;
-  e6 = e4 * e2;
-
-  m_AE = a2 * ( 1 - e2 );
-
-  m_QA = ( 2.0 / 3.0 ) * e2;
-  m_QB = ( 3.0 / 5.0 ) * e4;
-  m_QC = ( 4.0 / 7.0 ) * e6;
-
-  m_QbarA = -1.0 - ( 2.0 / 3.0 ) * e2 - ( 3.0 / 5.0 ) * e4  - ( 4.0 / 7.0 ) * e6;
-  m_QbarB = ( 2.0 / 9.0 ) * e2 + ( 2.0 / 5.0 ) * e4  + ( 4.0 / 7.0 ) * e6;
-  m_QbarC = - ( 3.0 / 25.0 ) * e4 - ( 12.0 / 35.0 ) * e6;
-  m_QbarD = ( 4.0 / 49.0 ) * e6;
-
-  m_Qp = getQ( M_PI_2 );
-  m_E  = 4 * M_PI * m_Qp * m_AE;
-  if ( m_E < 0.0 )
-    m_E = -m_E;
+  mGeod.reset( new geod_geodesic() );
+  geod_init( mGeod.get(), mSemiMajor, 1 / mInvFlattening );
 }
 
 void QgsDistanceArea::setFromParams( const QgsEllipsoidUtils::EllipsoidParameters &params )
@@ -1014,7 +894,6 @@ void QgsDistanceArea::setFromParams( const QgsEllipsoidUtils::EllipsoidParameter
     mSemiMinor = params.semiMinor;
     mInvFlattening = params.inverseFlattening;
     mCoordTransform.setDestinationCrs( params.crs );
-    // precalculate some values for area calculations
     computeAreaInit();
   }
 }
@@ -1026,84 +905,30 @@ double QgsDistanceArea::computePolygonArea( const QVector<QgsPointXY> &points ) 
     return 0;
   }
 
-  // IMPORTANT
-  // don't change anything here without reporting the changes to upstream (GRASS)
-  // let's all be good opensource citizens and share the improvements!
-
-  double x1, y1, x2, y2, dx, dy;
-  double Qbar1, Qbar2;
-  double area;
-
-  /* GRASS comment: threshold for dy, should be between 1e-4 and 1e-7
-   * See relevant discussion at https://trac.osgeo.org/grass/ticket/3369
-  */
-  const double thresh = 1e-6;
-
   QgsDebugMsgLevel( "Ellipsoid: " + mEllipsoid, 3 );
   if ( !willUseEllipsoid() )
   {
     return computePolygonFlatArea( points );
   }
-  int n = points.size();
-  x2 = DEG2RAD( points[n - 1].x() );
-  y2 = DEG2RAD( points[n - 1].y() );
-  Qbar2 = getQbar( y2 );
 
-  area = 0.0;
+  if ( !mGeod )
+    computeAreaInit();
+  if ( !mGeod )
+    return 0;
 
-  for ( int i = 0; i < n; i++ )
-  {
-    x1 = x2;
-    y1 = y2;
-    Qbar1 = Qbar2;
+  struct geod_polygon p;
+  geod_polygon_init( &p, 0 );
 
-    x2 = DEG2RAD( points[i].x() );
-    y2 = DEG2RAD( points[i].y() );
-    Qbar2 = getQbar( y2 );
+  /* GeographicLib does not need a closed ring,
+   * see example for geod_polygonarea() in geodesic.h */
+  /* add points in reverse order */
+  int i = points.size();
+  while ( --i )
+    geod_polygon_addpoint( mGeod.get(), &p, points.at( i ).y(), points.at( i ).x() );
 
-    if ( x1 > x2 )
-      while ( x1 - x2 > M_PI )
-        x2 += m_TwoPI;
-    else if ( x2 > x1 )
-      while ( x2 - x1 > M_PI )
-        x1 += m_TwoPI;
-
-    dx = x2 - x1;
-    dy = y2 - y1;
-    if ( std::fabs( dy ) > thresh )
-    {
-      /* account for different latitudes y1, y2 */
-      area += dx * ( m_Qp - ( Qbar2 - Qbar1 ) / dy );
-    }
-    else
-    {
-      /* latitudes y1, y2 are (nearly) identical */
-
-      /* if y2 becomes similar to y1, i.e. y2 -> y1
-       * Qbar2 - Qbar1 -> 0 and dy -> 0
-       * (Qbar2 - Qbar1) / dy -> ?
-       * (Qbar2 - Qbar1) / dy should approach Q((y1 + y2) / 2)
-       * Metz 2017
-       */
-      area += dx * ( m_Qp - getQ( ( y1 + y2 ) / 2.0 ) );
-
-      /* original:
-       * area += dx * getQ( y2 ) - ( dx / dy ) * ( Qbar2 - Qbar1 );
-       */
-    }
-  }
-  if ( ( area *= m_AE ) < 0.0 )
-    area = -area;
-
-  /* kludge - if polygon circles the south pole the area will be
-  * computed as if it cirlced the north pole. The correction is
-  * the difference between total surface area of the earth and
-  * the "north pole" area.
-  */
-  if ( area > m_E )
-    area = m_E;
-  if ( area > m_E / 2 )
-    area = m_E - area;
+  double area = 0;
+  double perimeter = 0;
+  geod_polygon_compute( mGeod.get(), &p, 0, 1, &area, &perimeter );
 
   return area;
 }

--- a/src/core/qgsdistancearea.h
+++ b/src/core/qgsdistancearea.h
@@ -26,6 +26,7 @@
 class QgsGeometry;
 class QgsAbstractGeometry;
 class QgsCurve;
+class geod_geodesic;
 
 /**
  * \ingroup core
@@ -45,6 +46,8 @@ class QgsCurve;
  * Usually, the measurements returned by QgsDistanceArea are in meters. If no valid
  * ellipsoid is set, then the units may not be meters. The units can be retrieved
  * by calling lengthUnits() and areaUnits().
+ *
+ * Internally, the GeographicLib library is used to calculate all ellipsoid based measurements.
 */
 class CORE_EXPORT QgsDistanceArea
 {
@@ -52,6 +55,11 @@ class CORE_EXPORT QgsDistanceArea
 
     //! Constructor
     QgsDistanceArea();
+    ~QgsDistanceArea();
+
+    //! Copy constructor
+    QgsDistanceArea( const QgsDistanceArea &other );
+    QgsDistanceArea &operator=( const QgsDistanceArea &other );
 
     /**
      * Returns whether calculations will use the ellipsoid. Calculations will only use the
@@ -281,20 +289,12 @@ class CORE_EXPORT QgsDistanceArea
 
     /**
      * Given a location, an azimuth and a distance, computes the
-     * location of the projected point. Based on Vincenty's formula
-     * for the geodetic direct problem as described in "Geocentric
-     * Datum of Australia Technical Manual", Chapter 4.
+     * location of the projected point.
+     *
      * \param p1 - location of first geographic (latitude/longitude) point as degrees.
      * \param distance - distance in meters.
      * \param azimuth - azimuth in radians, clockwise from North
      * \return p2 - location of projected point as longitude/latitude.
-     * \note code (and documentation) taken from rttopo project
-     * https://git.osgeo.org/gogs/rttopo/librttopo
-     *
-     * - spheroid_project.spheroid_project(...)
-     * - Valid bounds checking for degrees (latitude=+- 85.05115) is based values used for
-     *   -> 'WGS84 Web Mercator (Auxiliary Sphere)' calculations
-     *   --> latitudes outside these bounds cause the calculations to become unstable and can return invalid results
      *
      * \since QGIS 3.0
      */
@@ -367,19 +367,6 @@ class CORE_EXPORT QgsDistanceArea
   private:
 
     /**
-     * Calculates distance from two points on ellipsoid
-     * based on inverse Vincenty's formulae
-     *
-     * Points \a p1 and \a p2 are expected to be in degrees and in currently used ellipsoid
-     *
-     * \returns distance in meters
-     * \note if course1 is not NULLPTR, bearing (in radians) from first point is calculated
-     * (the same for course2)
-     */
-    double computeDistanceBearing( const QgsPointXY &p1, const QgsPointXY &p2,
-                                   double *course1 = nullptr, double *course2 = nullptr ) const;
-
-    /**
      * Calculates area of polygon on ellipsoid
      * algorithm has been taken from GRASS: gis/area_poly1.c
      */
@@ -391,7 +378,7 @@ class CORE_EXPORT QgsDistanceArea
      * Precalculates some values
      * (must be called always when changing ellipsoid)
      */
-    void computeAreaInit();
+    void computeAreaInit() const;
 
     void setFromParams( const QgsEllipsoidUtils::EllipsoidParameters &params );
 
@@ -411,23 +398,13 @@ class CORE_EXPORT QgsDistanceArea
     //! ellipsoid parameters
     double mSemiMajor, mSemiMinor, mInvFlattening;
 
-    // utility functions for polygon area measurement
+    mutable std::unique_ptr< geod_geodesic > mGeod;
 
-    double getQ( double x ) const;
-    double getQbar( double x ) const;
+    // utility functions for polygon area measurement
 
     double measure( const QgsAbstractGeometry *geomV2, MeasureType type = Default ) const;
     double measureLine( const QgsCurve *curve ) const;
     double measurePolygon( const QgsCurve *curve ) const;
-
-    // temporary area measurement stuff
-
-    double m_QA, m_QB, m_QC;
-    double m_QbarA, m_QbarB, m_QbarC, m_QbarD;
-    double m_AE;  /* a^2(1-e^2) */
-    double m_Qp;  /* Q at the north pole */
-    double m_E;   /* area of the earth */
-    double m_TwoPI;
 
 };
 

--- a/src/test/qgstest.h
+++ b/src/test/qgstest.h
@@ -41,7 +41,7 @@
     bool _xxxresult = qgsDoubleNear( value, expected, epsilon ); \
     if ( !_xxxresult  ) \
     { \
-      qDebug( "Expecting %f got %f (diff %f > %f)", static_cast< double >( expected ), static_cast< double >( value ), std::fabs( static_cast< double >( expected ) - value ), static_cast< double >( epsilon ) ); \
+      qDebug( "Expecting %.10f got %.10f (diff %.10f > %.10f)", static_cast< double >( expected ), static_cast< double >( value ), std::fabs( static_cast< double >( expected ) - value ), static_cast< double >( epsilon ) ); \
     } \
     QVERIFY( qgsDoubleNear( value, expected, epsilon ) ); \
   }(void)(0)

--- a/tests/src/analysis/testqgsprocessingalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingalgs.cpp
@@ -2133,7 +2133,7 @@ void TestQgsProcessingAlgs::lineDensity()
       {
         double expectedValue = expectedRasterBlock->value( row, column );
         double outputValue = outputRasterBlock->value( row, column );
-        QGSCOMPARENEAR( outputValue, expectedValue, 0.000000000015 );
+        QGSCOMPARENEAR( outputValue, expectedValue, 0.0000000002 );
       }
     }
   }

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -165,7 +165,7 @@ void TestQgsAttributeTable::testFieldCalculationArea()
   QgsFeatureIterator fit = tempLayer->dataProvider()->getFeatures();
   QgsFeature f;
   QVERIFY( fit.nextFeature( f ) );
-  double expected = 1005721496.78008;
+  double expected = 1005755617.819130;
   QGSCOMPARENEAR( f.attribute( "col1" ).toDouble(), expected, 1.0 );
 
   // change project area unit, check calculation respects unit
@@ -177,7 +177,7 @@ void TestQgsAttributeTable::testFieldCalculationArea()
   // check result
   fit = tempLayer->dataProvider()->getFeatures();
   QVERIFY( fit.nextFeature( f ) );
-  expected = 388.311240;
+  expected = 388.324420;
   QGSCOMPARENEAR( f.attribute( "col1" ).toDouble(), expected, 0.001 );
 }
 

--- a/tests/src/app/testqgsfieldcalculator.cpp
+++ b/tests/src/app/testqgsfieldcalculator.cpp
@@ -164,7 +164,7 @@ void TestQgsFieldCalculator::testAreaCalculations()
   QgsFeatureIterator fit = tempLayer->dataProvider()->getFeatures();
   QgsFeature f;
   QVERIFY( fit.nextFeature( f ) );
-  double expected = 1005721496.780080;
+  double expected = 1005755617.819130;
   QGSCOMPARENEAR( f.attribute( "col1" ).toDouble(), expected, 1.0 );
 
   // change project area unit, check calculation respects unit
@@ -179,7 +179,7 @@ void TestQgsFieldCalculator::testAreaCalculations()
   // check result
   fit = tempLayer->dataProvider()->getFeatures();
   QVERIFY( fit.nextFeature( f ) );
-  expected = 388.311240;
+  expected = 388.324420;
   QGSCOMPARENEAR( f.attribute( "col1" ).toDouble(), expected, 0.001 );
 }
 

--- a/tests/src/app/testqgsmaptoolidentifyaction.cpp
+++ b/tests/src/app/testqgsmaptoolidentifyaction.cpp
@@ -474,7 +474,7 @@ void TestQgsMapToolIdentifyAction::areaCalculation()
   QCOMPARE( result.length(), 1 );
   QString derivedArea = result.at( 0 ).mDerivedAttributes[tr( "Area (Ellipsoidal — WGS84)" )];
   double area = derivedArea.remove( ',' ).split( ' ' ).at( 0 ).toDouble();
-  QGSCOMPARENEAR( area, 1005721496.780000, 1.0 );
+  QGSCOMPARENEAR( area, 1005755617.819000, 1.0 );
   derivedArea = result.at( 0 ).mDerivedAttributes[tr( "Area (Cartesian)" )];
   area = derivedArea.remove( ',' ).split( ' ' ).at( 0 ).toDouble();
   QGSCOMPARENEAR( area, 1005640568.0, 1.0 );
@@ -485,7 +485,7 @@ void TestQgsMapToolIdentifyAction::areaCalculation()
   QCOMPARE( result.length(), 1 );
   derivedArea = result.at( 0 ).mDerivedAttributes[tr( "Area (Ellipsoidal — WGS84)" )];
   area = derivedArea.remove( ',' ).split( ' ' ).at( 0 ).toDouble();
-  QGSCOMPARENEAR( area, 388.311000, 0.001 );
+  QGSCOMPARENEAR( area, 388.324000, 0.001 );
   derivedArea = result.at( 0 ).mDerivedAttributes[tr( "Area (Cartesian)" )];
   area = derivedArea.remove( ',' ).split( ' ' ).at( 0 ).toDouble();
   QGSCOMPARENEAR( area, 388.280000, 0.001 );
@@ -497,7 +497,7 @@ void TestQgsMapToolIdentifyAction::areaCalculation()
   QCOMPARE( result.length(), 1 );
   derivedArea = result.at( 0 ).mDerivedAttributes[tr( "Area (Ellipsoidal — WGS84)" )];
   area = derivedArea.remove( ',' ).split( ' ' ).at( 0 ).toDouble();
-  QGSCOMPARENEAR( area, 388.311000, 0.001 );
+  QGSCOMPARENEAR( area, 388.324000, 0.001 );
   derivedArea = result.at( 0 ).mDerivedAttributes[tr( "Area (Cartesian)" )];
   area = derivedArea.remove( ',' ).split( ' ' ).at( 0 ).toDouble();
   QGSCOMPARENEAR( area, 388.280000, 0.001 );

--- a/tests/src/app/testqgsmeasuretool.cpp
+++ b/tests/src/app/testqgsmeasuretool.cpp
@@ -329,7 +329,7 @@ void TestQgsMeasureTool::testAreaCalculationProjected()
   // check result
   QString measureString = dlg->editTotal->text();
   double measured = measureString.remove( ',' ).split( ' ' ).at( 0 ).toDouble();
-  double expected = 1005721496.780000;
+  double expected = 1005755617.8190000057;
   QGSCOMPARENEAR( measured, expected, 1.0 );
 
   // change project area unit, check calculation respects unit
@@ -350,7 +350,7 @@ void TestQgsMeasureTool::testAreaCalculationProjected()
   // check result
   measureString = dlg2->editTotal->text();
   measured = measureString.remove( ',' ).split( ' ' ).at( 0 ).toDouble();
-  expected = 388.311000;
+  expected = 388.3240000000;
   QGSCOMPARENEAR( measured, expected, 0.001 );
 }
 

--- a/tests/src/core/testqgsdistancearea.cpp
+++ b/tests/src/core/testqgsdistancearea.cpp
@@ -321,12 +321,12 @@ void TestQgsDistanceArea::measureAreaAndUnits()
   units = da.areaUnits();
   QgsDebugMsg( QStringLiteral( "measured %1 in %2" ).arg( area ).arg( QgsUnitTypes::toString( units ) ) );
   // should always be in Meters Squared
-  QGSCOMPARENEAR( area, 36918093794.1, 0.1 );
+  QGSCOMPARENEAR( area, 36922805935.961571, 0.1 );
   QCOMPARE( units, QgsUnitTypes::AreaSquareMeters );
 
   // test converting the resultant area
   area = da.convertAreaMeasurement( area, QgsUnitTypes::AreaSquareMiles );
-  QGSCOMPARENEAR( area, 14254.155703, 0.001 );
+  QGSCOMPARENEAR( area, 14255.975071, 0.001 );
 
   // now try with a source CRS which is in feet
   ring.clear();
@@ -363,13 +363,13 @@ void TestQgsDistanceArea::measureAreaAndUnits()
   area = da.measureArea( polygon );
   units = da.areaUnits();
   QgsDebugMsg( QStringLiteral( "measured %1 in %2" ).arg( area ).arg( QgsUnitTypes::toString( units ) ) );
-  QGSCOMPARENEAR( area, 185818.590966, 1.0 );
+  QGSCOMPARENEAR( area, 185825.206903, 1.0 );
   QCOMPARE( units, QgsUnitTypes::AreaSquareMeters );
 
   // test converting the resultant area
   area = da.convertAreaMeasurement( area, QgsUnitTypes::AreaSquareYards );
   QgsDebugMsg( QStringLiteral( "measured %1 in sq yrds" ).arg( area ) );
-  QGSCOMPARENEAR( area, 222237.185213, 1.0 );
+  QGSCOMPARENEAR( area, 222245.097808, 1.0 );
 }
 
 void TestQgsDistanceArea::emptyPolygon()
@@ -389,8 +389,7 @@ void TestQgsDistanceArea::regression14675()
   calc.setEllipsoid( QStringLiteral( "GRS80" ) );
   calc.setSourceCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:2154" ) ), QgsProject::instance()->transformContext() );
   QgsGeometry geom( QgsGeometryFactory::geomFromWkt( QStringLiteral( "Polygon ((917593.5791854317067191 6833700.00807378999888897, 917596.43389983859378844 6833700.67099479306489229, 917599.53056440979707986 6833700.78673478215932846, 917593.5791854317067191 6833700.00807378999888897))" ) ).release() );
-  //lots of tolerance here - the formulas get quite unstable with small areas due to division by very small floats
-  QGSCOMPARENEAR( calc.measureArea( geom ), 0.833010, 0.03 );
+  QGSCOMPARENEAR( calc.measureArea( geom ), 0.861747, 0.001 );
 }
 
 void TestQgsDistanceArea::regression16820()
@@ -399,8 +398,7 @@ void TestQgsDistanceArea::regression16820()
   calc.setEllipsoid( QStringLiteral( "WGS84" ) );
   calc.setSourceCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:32634" ) ), QgsProject::instance()->transformContext() );
   QgsGeometry geom( QgsGeometryFactory::geomFromWkt( QStringLiteral( "Polygon ((110250.54038314701756462 5084495.57398066483438015, 110243.46975068224128336 5084507.17200060561299324, 110251.23908144699817058 5084506.68309532757848501, 110251.2394439501222223 5084506.68307251576334238, 110250.54048078990308568 5084495.57553235255181789, 110250.54038314701756462 5084495.57398066483438015))" ) ).release() );
-  //lots of tolerance here - the formulas get quite unstable with small areas due to division by very small floats
-  QGSCOMPARENEAR( calc.measureArea( geom ), 43.3280029296875, 0.2 );
+  QGSCOMPARENEAR( calc.measureArea( geom ), 43.201092, 0.001 );
 }
 
 QGSTEST_MAIN( TestQgsDistanceArea )

--- a/tests/src/core/testqgsdistancearea.cpp
+++ b/tests/src/core/testqgsdistancearea.cpp
@@ -248,9 +248,21 @@ void TestQgsDistanceArea::collections()
   QGSCOMPARENEAR( result, 0, 4 * std::numeric_limits<double>::epsilon() );
 
   //collection of polygons
+
+  QgsGeometry poly1 = QgsGeometry::fromWkt( QStringLiteral( "Polygon((0 36.53, 5.76 -48.16, 0 25.54, 0 36.53))" ) );
+  result = myDa.measureArea( poly1 );
+  QGSCOMPARENEAR( result, 439881520607.079712, 1 );
+  result = myDa.measureLength( poly1 );
+  QGSCOMPARENEAR( result, 0, 4 * std::numeric_limits<double>::epsilon() );
+  QgsGeometry poly2 = QgsGeometry::fromWkt( QStringLiteral( "Polygon((10 20, 15 20, 15 10, 10 20))" ) );
+  result = myDa.measureArea( poly2 );
+  QGSCOMPARENEAR( result, 290350317025.906982, 1 );
+  result = myDa.measureLength( poly2 );
+  QGSCOMPARENEAR( result, 0, 4 * std::numeric_limits<double>::epsilon() );
+
   QgsGeometry polys( QgsGeometryFactory::geomFromWkt( QStringLiteral( "GeometryCollection( Polygon((0 36.53, 5.76 -48.16, 0 25.54, 0 36.53)), Polygon((10 20, 15 20, 15 10, 10 20)) )" ) ).release() );
   result = myDa.measureArea( polys );
-  QGSCOMPARENEAR( result, 663136985074LL, 1 );
+  QGSCOMPARENEAR( result, 730231837632.98669, 1 );
   result = myDa.measureLength( polys );
   QGSCOMPARENEAR( result, 0, 4 * std::numeric_limits<double>::epsilon() );
 
@@ -258,7 +270,7 @@ void TestQgsDistanceArea::collections()
   QgsGeometry mixed( QgsGeometryFactory::geomFromWkt( QStringLiteral( "GeometryCollection( LineString(0 36.53, 5.76 -48.16), LineString(0 25.54, 24.20 36.70), Polygon((0 36.53, 5.76 -48.16, 0 25.54, 0 36.53)), Polygon((10 20, 15 20, 15 10, 10 20)) )" ) ).release() );
   //measure area specifically
   result = myDa.measureArea( mixed );
-  QGSCOMPARENEAR( result, 663136985075LL, 1 );
+  QGSCOMPARENEAR( result, 730231837632.98669, 1 );
   //measure length
   result = myDa.measureLength( mixed );
   QGSCOMPARENEAR( result, 12006159, 1 );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2940,7 +2940,7 @@ class TestQgsExpression: public QObject
       QgsExpression expArea2( QStringLiteral( "$area" ) );
       expArea2.setGeomCalculator( &da );
       vArea = expArea2.evaluate( &context );
-      expected = 1005721496.780085;
+      expected = 1005755617.819134;
       QGSCOMPARENEAR( vArea.toDouble(), expected, 1.0 );
       // test unit conversion
       expArea2.setAreaUnits( QgsUnitTypes::AreaSquareMeters ); //default units should be square meters
@@ -2950,7 +2950,7 @@ class TestQgsExpression: public QObject
       vArea = expArea2.evaluate( &context );
       QGSCOMPARENEAR( vArea.toDouble(), expected, 1.0 );
       expArea2.setAreaUnits( QgsUnitTypes::AreaSquareMiles );
-      expected = 388.311241;
+      expected = 388.324415;
       vArea = expArea2.evaluate( &context );
       QGSCOMPARENEAR( vArea.toDouble(), expected, 0.001 );
 

--- a/tests/src/python/test_qgsdistancearea.py
+++ b/tests/src/python/test_qgsdistancearea.py
@@ -712,12 +712,12 @@ class TestQgsDistanceArea(unittest.TestCase):
 
         print(("measured {} in {}".format(area, QgsUnitTypes.toString(units))))
         # should always be in Meters Squared
-        self.assertAlmostEqual(area, 36918093794.121284, delta=0.1)
+        self.assertAlmostEqual(area, 36922805935.96157, delta=0.1)
         self.assertEqual(units, QgsUnitTypes.AreaSquareMeters)
 
         # test converting the resultant area
         area = da.convertAreaMeasurement(area, QgsUnitTypes.AreaSquareMiles)
-        self.assertAlmostEqual(area, 14254.155703182701, delta=0.001)
+        self.assertAlmostEqual(area, 14255.975071318593, delta=0.001)
 
         # now try with a source CRS which is in feet
         polygon = QgsGeometry.fromPolygonXY(
@@ -745,12 +745,12 @@ class TestQgsDistanceArea(unittest.TestCase):
         area = da.measureArea(polygon)
         units = da.areaUnits()
         print(("measured {} in {}".format(area, QgsUnitTypes.toString(units))))
-        self.assertAlmostEqual(area, 185818.59096575077, delta=1.0)
+        self.assertAlmostEqual(area, 185825.2069028169, delta=1.0)
         self.assertEqual(units, QgsUnitTypes.AreaSquareMeters)
 
         # test converting the resultant area
         area = da.convertAreaMeasurement(area, QgsUnitTypes.AreaSquareYards)
-        self.assertAlmostEqual(area, 222237.18521272976, delta=1.0)
+        self.assertAlmostEqual(area, 222245.0978076078, delta=1.0)
 
     def testFormatDistance(self):
         """Test formatting distances"""


### PR DESCRIPTION
Since GRASS upstream is moving away from the previous calculations which
all of QGIS' ellipsoidal distance/areas formulas are based on, let's
follow suit and delegate all these calculations to the GeographicLib
routines exposed through the PROJ api.

Refs https://github.com/OSGeo/grass/pull/1283
