### PR TITLE
Optimise QgsGeometry::asMultiPolygon/asPolygon

### DIFF
--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -2489,7 +2489,6 @@ class CORE_EXPORT QgsGeometry
      */
     void reset( std::unique_ptr< QgsAbstractGeometry > newGeometry );
 
-    static void convertToPolyline( const QgsPointSequence &input, QgsPolylineXY &output );
     static void convertPolygon( const QgsPolygon &input, QgsPolygonXY &output );
 
     //! Try to convert the geometry to a point


### PR DESCRIPTION
These methods were very expensive, involving a temporary allocation of list of lists of temporary points

Rework with direct iteration of input points instead to speed up this conversion.
