### PR TITLE
[themes] Fix combo box and menu items left spacing/padding issue

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -148,17 +148,22 @@ QMenu
     padding-right: 0em;
 }
 
+QMenu::icon
+{
+    padding-left: 0.3em;
+}
+
 QMenu::item
 {
     background: transparent;
-    padding: 0.2em 1.3em 0.2em 1.3em;
+    padding: 0.2em 1.3em 0.2em 0.4em;
 }
 
 QMenu::item:disabled
 {
     color: #555;
     background: transparent;
-    padding: 0.2em 1.3em 0.2em 1.3em;
+    padding: 0.2em 1.3em 0.2em 0.4em;
 }
 
 QMenu::item:selected
@@ -170,6 +175,11 @@ QMenu::item:selected
 QMenu::item:checked
 {
     text-decoration:underline;
+}
+
+QMenu::indicator
+{
+    width: 0em;
 }
 
 QWidget:disabled, QWidget:editable:disabled
@@ -335,15 +345,15 @@ QComboBox::down-arrow
 }
 
 QComboBox:item {
-    padding-left: 1.3em;
+    padding-left: 0.1em;
     height:1.25em;
 }
 QComboBox:item:selected {
-    padding-left: 1.3em;
+    padding-left: 0.1em;
     height:1.25em;
 }
 QComboBox:item:checked {
-    padding-left: 1.3em;
+    padding-left: 0.1em;
     height:1.25em;
     text-decoration:underline;
 }

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -148,17 +148,22 @@ QMenu
     padding-right: 0em;
 }
 
+QMenu::icon
+{
+    padding-left: 0.3em;
+}
+
 QMenu::item
 {
     background: transparent;
-    padding: 0.2em 1.3em 0.2em 1.3em;
+    padding: 0.2em 1.3em 0.2em 0.4em;
 }
 
 QMenu::item:disabled
 {
     color: #555;
     background: transparent;
-    padding: 0.2em 1.3em 0.2em 1.3em;
+    padding: 0.2em 1.3em 0.2em 0.4em;
 }
 
 QMenu::item:selected
@@ -170,6 +175,11 @@ QMenu::item:selected
 QMenu::item:checked
 {
     text-decoration:underline;
+}
+
+QMenu::indicator
+{
+    width: 0em;
 }
 
 QWidget:disabled, QWidget:editable:disabled
@@ -347,15 +357,15 @@ QComboBox::down-arrow
 }
 
 QComboBox:item {
-    padding-left: 1.3em;
+    padding-left: 0.1em;
     height:1.25em;
 }
 QComboBox:item:selected {
-    padding-left: 1.3em;
+    padding-left: 0.1em;
     height:1.25em;
 }
 QComboBox:item:checked {
-    padding-left: 1.3em;
+    padding-left: 0.1em;
     height:1.25em;
     text-decoration:underline;
 }


### PR DESCRIPTION
## Description
Setting the minimum Qt version to 5.12 allow us to fix an outstanding issue with non-default themes having bad left padding for menu items and combo box pop up items. The fix would have broken the look of things badly on pre 5.12 builds.

Before(left) vs. PR (right):
![image](https://user-images.githubusercontent.com/1728657/108804012-c001fa80-75ce-11eb-8aa5-80b91cb5292a.png)

![image](https://user-images.githubusercontent.com/1728657/108804016-c3958180-75ce-11eb-8b8a-6af25551cbcf.png)
