### PR TITLE
QGIS Server fix: When generating WMTS GetCapabilities, wrong axis order was written in bounding boxes for some CRSes

### DIFF
--- a/src/server/services/wmts/qgswmtsgetcapabilities.cpp
+++ b/src/server/services/wmts/qgswmtsgetcapabilities.cpp
@@ -419,24 +419,24 @@ namespace QgsWmts
           QDomElement lowerCornerElement = doc.createElement( QStringLiteral( "ows:LowerCorner" ) );
           if (invert)
           {
-            QDomText lowerCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.yMinimum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.xMinimum(), precision ), precision ));
+            QDomText lowerCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.yMinimum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.xMinimum(), precision ), precision ) );
             lowerCornerElement.appendChild( lowerCornerText );
           }
           else
           {
-            QDomText lowerCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.xMinimum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.yMinimum(), precision ), precision ));
+            QDomText lowerCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.xMinimum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.yMinimum(), precision ), precision ) );
             lowerCornerElement.appendChild( lowerCornerText );
           }
           bboxElement.appendChild( lowerCornerElement );
           QDomElement upperCornerElement = doc.createElement( QStringLiteral( "ows:UpperCorner" ) );
           if (invert)
           {
-            QDomText upperCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.yMaximum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.xMaximum(), precision ), precision ));
+            QDomText upperCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.yMaximum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.xMaximum(), precision ), precision ) );
             upperCornerElement.appendChild( upperCornerText );
           }
           else
           {
-            QDomText upperCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.xMaximum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.yMaximum(), precision ), precision ));
+            QDomText upperCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.xMaximum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.yMaximum(), precision ), precision ) );
             upperCornerElement.appendChild( upperCornerText );
           }
           bboxElement.appendChild( upperCornerElement );

--- a/src/server/services/wmts/qgswmtsgetcapabilities.cpp
+++ b/src/server/services/wmts/qgswmtsgetcapabilities.cpp
@@ -412,15 +412,33 @@ namespace QgsWmts
             precision = 6;
           }
 
+          bool invert = crs.hasAxisInverted();
+
           QDomElement bboxElement = doc.createElement( QStringLiteral( "ows:BoundingBox" ) );
           bboxElement.setAttribute( QStringLiteral( "crs" ), tms.ref );
           QDomElement lowerCornerElement = doc.createElement( QStringLiteral( "ows:LowerCorner" ) );
-          QDomText lowerCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.xMinimum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.yMinimum(), precision ), precision ) );
-          lowerCornerElement.appendChild( lowerCornerText );
+          if (invert)
+          {
+            QDomText lowerCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.yMinimum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.xMinimum(), precision ), precision ));
+            lowerCornerElement.appendChild( lowerCornerText );
+          }
+          else
+          {
+            QDomText lowerCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.xMinimum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.yMinimum(), precision ), precision ));
+            lowerCornerElement.appendChild( lowerCornerText );
+          }
           bboxElement.appendChild( lowerCornerElement );
           QDomElement upperCornerElement = doc.createElement( QStringLiteral( "ows:UpperCorner" ) );
-          QDomText upperCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.xMaximum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.yMaximum(), precision ), precision ) );
-          upperCornerElement.appendChild( upperCornerText );
+          if (invert)
+          {
+            QDomText upperCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.yMaximum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.xMaximum(), precision ), precision ));
+            upperCornerElement.appendChild( upperCornerText );
+          }
+          else
+          {
+            QDomText upperCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.xMaximum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.yMaximum(), precision ), precision ));
+            upperCornerElement.appendChild( upperCornerText );
+          }
           bboxElement.appendChild( upperCornerElement );
           layerElem.appendChild( bboxElement );
         }

--- a/src/server/services/wmts/qgswmtsgetcapabilities.cpp
+++ b/src/server/services/wmts/qgswmtsgetcapabilities.cpp
@@ -417,7 +417,7 @@ namespace QgsWmts
           QDomElement bboxElement = doc.createElement( QStringLiteral( "ows:BoundingBox" ) );
           bboxElement.setAttribute( QStringLiteral( "crs" ), tms.ref );
           QDomElement lowerCornerElement = doc.createElement( QStringLiteral( "ows:LowerCorner" ) );
-          if (invert)
+          if ( invert )
           {
             QDomText lowerCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.yMinimum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.xMinimum(), precision ), precision ) );
             lowerCornerElement.appendChild( lowerCornerText );
@@ -429,7 +429,7 @@ namespace QgsWmts
           }
           bboxElement.appendChild( lowerCornerElement );
           QDomElement upperCornerElement = doc.createElement( QStringLiteral( "ows:UpperCorner" ) );
-          if (invert)
+          if ( invert )
           {
             QDomText upperCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.yMaximum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.xMaximum(), precision ), precision ) );
             upperCornerElement.appendChild( upperCornerText );


### PR DESCRIPTION
## Description

In QGIS Server, when the GetCapabilities document was created, the ordinates in the bounding boxes LowerCorner and UpperCorner was not written in the correct order with respect to the CRS axis order. This caused WMTS not to function properly for CRSes with different axis order than default (E/N vs N/E).

This pull request corrects this by checking the "hasAxisInverted" property of the CRS to write the ordinates in correct order.

Fixes the axis order part of issue #34826