### PR TITLE
fix shadow and EDL not being exported with 3D animation tool

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -1000,10 +1000,7 @@ void Qgs3DMapScene::onSkyboxSettingsChanged()
 
 void Qgs3DMapScene::onShadowSettingsChanged()
 {
-  QgsWindow3DEngine *windowEngine = dynamic_cast<QgsWindow3DEngine *>( mEngine );
-  if ( windowEngine == nullptr )
-    return;
-  QgsShadowRenderingFrameGraph *shadowRenderingFrameGraph = windowEngine->shadowRenderingFrameGraph();
+  QgsShadowRenderingFrameGraph *shadowRenderingFrameGraph = mEngine->frameGraph();
 
   QList<QgsDirectionalLightSettings> directionalLights = mMap.directionalLights();
   QgsShadowSettings shadowSettings = mMap.shadowSettings();
@@ -1022,28 +1019,19 @@ void Qgs3DMapScene::onShadowSettingsChanged()
 
 void Qgs3DMapScene::onDebugShadowMapSettingsChanged()
 {
-  QgsWindow3DEngine *windowEngine = dynamic_cast<QgsWindow3DEngine *>( mEngine );
-  if ( windowEngine == nullptr )
-    return;
-  QgsShadowRenderingFrameGraph *shadowRenderingFrameGraph = windowEngine->shadowRenderingFrameGraph();
+  QgsShadowRenderingFrameGraph *shadowRenderingFrameGraph = mEngine->frameGraph();
   shadowRenderingFrameGraph->setupShadowMapDebugging( mMap.debugShadowMapEnabled(), mMap.debugShadowMapCorner(), mMap.debugShadowMapSize() );
 }
 
 void Qgs3DMapScene::onDebugDepthMapSettingsChanged()
 {
-  QgsWindow3DEngine *windowEngine = dynamic_cast<QgsWindow3DEngine *>( mEngine );
-  if ( windowEngine == nullptr )
-    return;
-  QgsShadowRenderingFrameGraph *shadowRenderingFrameGraph = windowEngine->shadowRenderingFrameGraph();
+  QgsShadowRenderingFrameGraph *shadowRenderingFrameGraph = mEngine->frameGraph();
   shadowRenderingFrameGraph->setupDepthMapDebugging( mMap.debugDepthMapEnabled(), mMap.debugDepthMapCorner(), mMap.debugDepthMapSize() );
 }
 
 void Qgs3DMapScene::onEyeDomeShadingSettingsChanged()
 {
-  QgsWindow3DEngine *windowEngine = dynamic_cast<QgsWindow3DEngine *>( mEngine );
-  if ( windowEngine == nullptr )
-    return;
-  QgsShadowRenderingFrameGraph *shadowRenderingFrameGraph = windowEngine->shadowRenderingFrameGraph();
+  QgsShadowRenderingFrameGraph *shadowRenderingFrameGraph = mEngine->frameGraph();
 
   bool edlEnabled = mMap.eyeDomeLightingEnabled();
   double edlStrength = mMap.eyeDomeLightingStrength();

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -153,10 +153,6 @@ bool Qgs3DUtils::exportAnimation( const Qgs3DAnimationSettings &animationSetting
     fileName.replace( token, frameNoPaddedLeft );
     const QString path = QDir( outputDirectory ).filePath( fileName );
 
-    // It would initially return empty rendered image.
-    // Capturing the initial image and throwing it away fixes that.
-    // Hopefully we will find a better fix in the future.
-    Qgs3DUtils::captureSceneImage( engine, scene );
     QImage img = Qgs3DUtils::captureSceneImage( engine, scene );
 
     img.save( path );

--- a/src/3d/qgsabstract3dengine.cpp
+++ b/src/3d/qgsabstract3dengine.cpp
@@ -35,3 +35,13 @@ void QgsAbstract3DEngine::requestCaptureImage()
     captureReply->deleteLater();
   } );
 }
+
+void QgsAbstract3DEngine::setRenderCaptureEnabled( bool enabled )
+{
+  mFrameGraph->setRenderCaptureEnabled( enabled );
+}
+
+bool QgsAbstract3DEngine::renderCaptureEnabled() const
+{
+  return mFrameGraph->renderCaptureEnabled();
+}

--- a/src/3d/qgsabstract3dengine.cpp
+++ b/src/3d/qgsabstract3dengine.cpp
@@ -15,8 +15,23 @@
 
 #include "qgsabstract3dengine.h"
 
+#include "qgsshadowrenderingframegraph.h"
+
+#include <Qt3DRender/QRenderCapture>
+
 QgsAbstract3DEngine::QgsAbstract3DEngine( QObject *parent )
   : QObject( parent )
 {
 
+}
+
+void QgsAbstract3DEngine::requestCaptureImage()
+{
+  Qt3DRender::QRenderCaptureReply *captureReply;
+  captureReply = mFrameGraph->renderCapture()->requestCapture();
+  connect( captureReply, &Qt3DRender::QRenderCaptureReply::completed, this, [ = ]
+  {
+    emit imageCaptured( captureReply->image() );
+    captureReply->deleteLater();
+  } );
 }

--- a/src/3d/qgsabstract3dengine.h
+++ b/src/3d/qgsabstract3dengine.h
@@ -87,7 +87,7 @@ class _3D_EXPORT QgsAbstract3DEngine : public QObject
      * The function does not block - when the rendered image is captured, it is returned in imageCaptured() signal.
      * Only one image request can be active at a time.
      */
-    virtual void requestCaptureImage() = 0;
+    void requestCaptureImage();
 
     /**
      * Returns the surface of the engine
@@ -101,11 +101,14 @@ class _3D_EXPORT QgsAbstract3DEngine : public QObject
      *
      * \since QGIS 3.18
      */
-    virtual QgsShadowRenderingFrameGraph *frameGraph() = 0;
+    QgsShadowRenderingFrameGraph *frameGraph() { return mFrameGraph; }
 
   signals:
     //! Emitted after a call to requestCaptureImage() to return the captured image.
     void imageCaptured( const QImage &image );
+
+  protected:
+    QgsShadowRenderingFrameGraph *mFrameGraph = nullptr;
 };
 
 

--- a/src/3d/qgsabstract3dengine.h
+++ b/src/3d/qgsabstract3dengine.h
@@ -96,6 +96,11 @@ class _3D_EXPORT QgsAbstract3DEngine : public QObject
      */
     virtual QSurface *surface() const = 0;
 
+    /**
+     * Returns the shadow rendering frame graph object used to render the scene
+     *
+     * \since QGIS 3.18
+     */
     virtual QgsShadowRenderingFrameGraph *frameGraph() = 0;
 
   signals:

--- a/src/3d/qgsabstract3dengine.h
+++ b/src/3d/qgsabstract3dengine.h
@@ -38,6 +38,8 @@ namespace Qt3DRender
   class QFrameGraphNode;
 }
 
+class QgsShadowRenderingFrameGraph;
+
 /**
  * \ingroup 3d
  * \brief Base class for 3D engine implementation. A 3D engine is responsible for setting up
@@ -93,6 +95,8 @@ class _3D_EXPORT QgsAbstract3DEngine : public QObject
      * \since QGIS 3.14
      */
     virtual QSurface *surface() const = 0;
+
+    virtual QgsShadowRenderingFrameGraph *frameGraph() = 0;
 
   signals:
     //! Emitted after a call to requestCaptureImage() to return the captured image.

--- a/src/3d/qgsabstract3dengine.h
+++ b/src/3d/qgsabstract3dengine.h
@@ -103,6 +103,20 @@ class _3D_EXPORT QgsAbstract3DEngine : public QObject
      */
     QgsShadowRenderingFrameGraph *frameGraph() { return mFrameGraph; }
 
+    /**
+     * Sets whether it will be possible to render to an image
+     *
+     * \note for QgsWindow3DEngine render capture will be disabled by default
+     *  and for QgsOffscreen3DEngine it is enabled by default
+     * \since QGIS 3.18
+     */
+    void setRenderCaptureEnabled( bool enabled );
+
+    /**
+     * Returns whether it will be possible to render to an image
+     * \since QGIS 3.18
+     */
+    bool renderCaptureEnabled() const;
   signals:
     //! Emitted after a call to requestCaptureImage() to return the captured image.
     void imageCaptured( const QImage &image );

--- a/src/3d/qgsoffscreen3dengine.cpp
+++ b/src/3d/qgsoffscreen3dengine.cpp
@@ -160,14 +160,3 @@ QSurface *QgsOffscreen3DEngine::surface() const
 {
   return mOffscreenSurface;
 }
-
-void QgsOffscreen3DEngine::requestCaptureImage()
-{
-  Qt3DRender::QRenderCaptureReply *captureReply;
-  captureReply = mFrameGraph->renderCapture()->requestCapture();
-  connect( captureReply, &Qt3DRender::QRenderCaptureReply::completed, this, [ = ]
-  {
-    emit imageCaptured( captureReply->image() );
-    captureReply->deleteLater();
-  } );
-}

--- a/src/3d/qgsoffscreen3dengine.cpp
+++ b/src/3d/qgsoffscreen3dengine.cpp
@@ -92,6 +92,7 @@ QgsOffscreen3DEngine::QgsOffscreen3DEngine()
   mOffscreenSurface->create();
 
   mFrameGraph = new QgsShadowRenderingFrameGraph( mOffscreenSurface, mSize, mCamera, mRoot );
+  mFrameGraph->setRenderCaptureEnabled( true );
   mFrameGraph->setShadowRenderingEnabled( false );
   // Set this frame graph to be in use.
   // the render settings also sets itself as the parent of mSurfaceSelector

--- a/src/3d/qgsoffscreen3dengine.cpp
+++ b/src/3d/qgsoffscreen3dengine.cpp
@@ -38,6 +38,27 @@
 
 QgsOffscreen3DEngine::QgsOffscreen3DEngine()
 {
+  // Set up the default OpenGL surface format.
+  QSurfaceFormat format;
+
+  // by default we get just some older version of OpenGL from the system,
+  // but for 3D lines we use "primitive restart" functionality supported in OpenGL >= 3.1
+  // Qt3DWindow uses this - requesting OpenGL 4.3 - so let's request the same version.
+  qDebug() << "QOpenGLContext::openGLModuleType: " << QOpenGLContext::openGLModuleType();
+#ifdef QT_OPENGL_ES_2
+  format.setRenderableType( QSurfaceFormat::OpenGLES );
+#else
+  if ( QOpenGLContext::openGLModuleType() == QOpenGLContext::LibGL )
+  {
+    format.setVersion( 4, 3 );
+    format.setProfile( QSurfaceFormat::CoreProfile );
+  }
+#endif
+
+  format.setMajorVersion( 3 );
+  format.setDepthBufferSize( 32 ); // TODO: or 24?  (used by QWindow3D)
+  format.setSamples( 8 );
+  QSurfaceFormat::setDefaultFormat( format );
 
   // Set up a camera to point at the shapes.
   mCamera = new Qt3DRender::QCamera;
@@ -68,6 +89,7 @@ QgsOffscreen3DEngine::QgsOffscreen3DEngine()
   // Create the offscreen frame graph, which will manage all of the resources required
   // for rendering without a QWindow.
   mOffscreenSurface = new QOffscreenSurface();
+  mOffscreenSurface->setFormat( QSurfaceFormat::defaultFormat() );
   mOffscreenSurface->create();
 
   mFrameGraph = new QgsShadowRenderingFrameGraph( mOffscreenSurface, mSize, mCamera, mRoot );

--- a/src/3d/qgsoffscreen3dengine.cpp
+++ b/src/3d/qgsoffscreen3dengine.cpp
@@ -36,29 +36,8 @@
 #include <Qt3DRender/QViewport>
 #include <QtGui/QOpenGLContext>
 
-
 QgsOffscreen3DEngine::QgsOffscreen3DEngine()
 {
-  // Set up the default OpenGL surface format.
-  QSurfaceFormat format;
-
-  // by default we get just some older version of OpenGL from the system,
-  // but for 3D lines we use "primitive restart" functionality supported in OpenGL >= 3.1
-  // Qt3DWindow uses this - requesting OpenGL 4.3 - so let's request the same version.
-#ifdef QT_OPENGL_ES_2
-  format.setRenderableType( QSurfaceFormat::OpenGLES );
-#else
-  if ( QOpenGLContext::openGLModuleType() == QOpenGLContext::LibGL )
-  {
-    format.setVersion( 4, 3 );
-    format.setProfile( QSurfaceFormat::CoreProfile );
-  }
-#endif
-
-  format.setMajorVersion( 3 );
-  format.setDepthBufferSize( 32 ); // TODO: or 24?  (used by QWindow3D)
-  format.setSamples( 8 );
-  QSurfaceFormat::setDefaultFormat( format );
 
   // Set up a camera to point at the shapes.
   mCamera = new Qt3DRender::QCamera;
@@ -80,7 +59,7 @@ QgsOffscreen3DEngine::QgsOffscreen3DEngine()
   // component must be held by the root of the QEntity tree,
   // so it is added to this one. The 3D scene is added as a subtree later,
   // in setRootEntity().
-  mRoot = new Qt3DCore::QEntity();
+  mRoot = new Qt3DCore::QEntity;
   mRenderSettings = new Qt3DRender::QRenderSettings( mRoot );
   mRoot->addComponent( mRenderSettings );
 
@@ -88,11 +67,15 @@ QgsOffscreen3DEngine::QgsOffscreen3DEngine()
 
   // Create the offscreen frame graph, which will manage all of the resources required
   // for rendering without a QWindow.
-  createFrameGraph();
+  mOffscreenSurface = new QOffscreenSurface();
+  mOffscreenSurface->create();
 
+  mFrameGraph = new QgsShadowRenderingFrameGraph( mOffscreenSurface, mSize, mCamera, mRoot );
+  mFrameGraph->renderSurfaceSelector()->setExternalRenderTargetSize( mSize );
+  mFrameGraph->setShadowRenderingEnabled( false );
   // Set this frame graph to be in use.
   // the render settings also sets itself as the parent of mSurfaceSelector
-  mRenderSettings->setActiveFrameGraph( mSurfaceSelector );
+  mRenderSettings->setActiveFrameGraph( mFrameGraph->frameGraphRoot() );
 
   // Set the root entity of the engine. This causes the engine to begin running.
   mAspectEngine->setRootEntity( Qt3DCore::QEntityPtr( mRoot ) );
@@ -109,98 +92,18 @@ void QgsOffscreen3DEngine::setSize( QSize s )
 {
   mSize = s;
 
-  mTexture->setSize( mSize.width(), mSize.height() );
-  mDepthTexture->setSize( mSize.width(), mSize.height() );
-  mSurfaceSelector->setExternalRenderTargetSize( mSize );
-
+  mFrameGraph->setSize( mSize );
   mCamera->setAspectRatio( float( mSize.width() ) / float( mSize.height() ) );
 }
 
 void QgsOffscreen3DEngine::setClearColor( const QColor &color )
 {
-  mClearBuffers->setClearColor( color );
+  mFrameGraph->setClearColor( color );
 }
 
 void QgsOffscreen3DEngine::setFrustumCullingEnabled( bool enabled )
 {
-  // TODO
-  Q_UNUSED( enabled )
-}
-
-void QgsOffscreen3DEngine::createRenderTarget()
-{
-  mTextureTarget = new Qt3DRender::QRenderTarget;
-
-  // The lifetime of the objects created here is managed
-  // automatically, as they become children of this object.
-
-  // Create a render target output for rendering color.
-  mTextureOutput = new Qt3DRender::QRenderTargetOutput( mTextureTarget );
-  mTextureOutput->setAttachmentPoint( Qt3DRender::QRenderTargetOutput::Color0 );
-
-  // Create a texture to render into.
-  mTexture = new Qt3DRender::QTexture2D( mTextureOutput );
-  mTexture->setSize( mSize.width(), mSize.height() );
-  mTexture->setFormat( Qt3DRender::QAbstractTexture::RGB8_UNorm );
-  mTexture->setMinificationFilter( Qt3DRender::QAbstractTexture::Linear );
-  mTexture->setMagnificationFilter( Qt3DRender::QAbstractTexture::Linear );
-
-  // Hook the texture up to our output, and the output up to this object.
-  mTextureOutput->setTexture( mTexture );
-  mTextureTarget->addOutput( mTextureOutput );
-
-  mDepthTextureOutput = new Qt3DRender::QRenderTargetOutput( mTextureTarget );
-  mDepthTextureOutput->setAttachmentPoint( Qt3DRender::QRenderTargetOutput::Depth );
-  mDepthTexture = new Qt3DRender::QTexture2D( mDepthTextureOutput );
-  mDepthTexture->setSize( mSize.width(), mSize.height() );
-  mDepthTexture->setFormat( Qt3DRender::QAbstractTexture::DepthFormat );
-  mDepthTexture->setMinificationFilter( Qt3DRender::QAbstractTexture::Linear );
-  mDepthTexture->setMagnificationFilter( Qt3DRender::QAbstractTexture::Linear );
-  mDepthTexture->setComparisonFunction( Qt3DRender::QAbstractTexture::CompareLessEqual );
-  mDepthTexture->setComparisonMode( Qt3DRender::QAbstractTexture::CompareRefToTexture );
-  // Hook up the depth texture
-  mDepthTextureOutput->setTexture( mDepthTexture );
-  mTextureTarget->addOutput( mDepthTextureOutput );
-}
-
-void QgsOffscreen3DEngine::createFrameGraph()
-{
-  // Firstly, create the offscreen surface. This will take the place
-  // of a QWindow, allowing us to render our scene without one.
-  mOffscreenSurface = new QOffscreenSurface();
-  mOffscreenSurface->setFormat( QSurfaceFormat::defaultFormat() );
-  mOffscreenSurface->create();
-
-  // Hook it up to the frame graph.
-  mSurfaceSelector = new Qt3DRender::QRenderSurfaceSelector( mRenderSettings );
-  mSurfaceSelector->setSurface( mOffscreenSurface );
-  mSurfaceSelector->setExternalRenderTargetSize( mSize );
-
-  // Create a texture to render into. This acts as the buffer that
-  // holds the rendered image.
-  mRenderTargetSelector = new Qt3DRender::QRenderTargetSelector( mSurfaceSelector );
-  createRenderTarget();
-  // the target selector also sets itself as the parent of mTextureTarget
-  mRenderTargetSelector->setTarget( mTextureTarget );
-
-  // Create a node used for clearing the required buffers.
-  mClearBuffers = new Qt3DRender::QClearBuffers( mRenderTargetSelector );
-  mClearBuffers->setClearColor( QColor( 100, 100, 100, 255 ) );
-  mClearBuffers->setBuffers( Qt3DRender::QClearBuffers::ColorDepthBuffer );
-
-  // Create a viewport node. The viewport here just covers the entire render area.
-  mViewport = new Qt3DRender::QViewport( mRenderTargetSelector );
-  mViewport->setNormalizedRect( QRectF( 0.0, 0.0, 1.0, 1.0 ) );
-
-  // Create a camera selector node, and tell it to use the camera we've ben given.
-  mCameraSelector = new Qt3DRender::QCameraSelector( mViewport );
-  mCameraSelector->setCamera( mCamera );
-
-  // Add a render capture node to the frame graph.
-  // This is set as the next child of the render target selector node,
-  // so that the capture will be taken from the specified render target
-  // once all other rendering operations have taken place.
-  mRenderCapture = new Qt3DRender::QRenderCapture( mRenderTargetSelector );
+  mFrameGraph->setFrustumCullingEnabled( false );
 }
 
 void QgsOffscreen3DEngine::setRootEntity( Qt3DCore::QEntity *root )
@@ -213,7 +116,9 @@ void QgsOffscreen3DEngine::setRootEntity( Qt3DCore::QEntity *root )
 
   // Parent the incoming scene root to our current root entity.
   mSceneRoot = root;
-  mSceneRoot->setParent( mAspectEngine->rootEntity().data() );
+  mSceneRoot->setParent( mRoot );
+  root->addComponent( mFrameGraph->forwardRenderLayer() );
+  root->addComponent( mFrameGraph->castShadowsLayer() );
 }
 
 Qt3DRender::QRenderSettings *QgsOffscreen3DEngine::renderSettings()
@@ -238,17 +143,11 @@ QSurface *QgsOffscreen3DEngine::surface() const
 
 void QgsOffscreen3DEngine::requestCaptureImage()
 {
-  if ( mReply )
+  Qt3DRender::QRenderCaptureReply *captureReply;
+  captureReply = mFrameGraph->renderCapture()->requestCapture();
+  connect( captureReply, &Qt3DRender::QRenderCaptureReply::completed, this, [ = ]
   {
-    QgsDebugMsgLevel( QStringLiteral( "already having a pending capture, skipping" ), 2 );
-    return;
-  }
-  mReply = mRenderCapture->requestCapture();
-  connect( mReply, &Qt3DRender::QRenderCaptureReply::completed, this, [ = ]
-  {
-    QImage image = mReply->image();
-    mReply->deleteLater();
-    mReply = nullptr;
-    emit imageCaptured( image );
+    emit imageCaptured( captureReply->image() );
+    captureReply->deleteLater();
   } );
 }

--- a/src/3d/qgsoffscreen3dengine.cpp
+++ b/src/3d/qgsoffscreen3dengine.cpp
@@ -44,7 +44,6 @@ QgsOffscreen3DEngine::QgsOffscreen3DEngine()
   // by default we get just some older version of OpenGL from the system,
   // but for 3D lines we use "primitive restart" functionality supported in OpenGL >= 3.1
   // Qt3DWindow uses this - requesting OpenGL 4.3 - so let's request the same version.
-  qDebug() << "QOpenGLContext::openGLModuleType: " << QOpenGLContext::openGLModuleType();
 #ifdef QT_OPENGL_ES_2
   format.setRenderableType( QSurfaceFormat::OpenGLES );
 #else

--- a/src/3d/qgsoffscreen3dengine.cpp
+++ b/src/3d/qgsoffscreen3dengine.cpp
@@ -103,7 +103,7 @@ void QgsOffscreen3DEngine::setClearColor( const QColor &color )
 
 void QgsOffscreen3DEngine::setFrustumCullingEnabled( bool enabled )
 {
-  mFrameGraph->setFrustumCullingEnabled( false );
+  mFrameGraph->setFrustumCullingEnabled( enabled );
 }
 
 void QgsOffscreen3DEngine::setRootEntity( Qt3DCore::QEntity *root )

--- a/src/3d/qgsoffscreen3dengine.cpp
+++ b/src/3d/qgsoffscreen3dengine.cpp
@@ -71,7 +71,6 @@ QgsOffscreen3DEngine::QgsOffscreen3DEngine()
   mOffscreenSurface->create();
 
   mFrameGraph = new QgsShadowRenderingFrameGraph( mOffscreenSurface, mSize, mCamera, mRoot );
-  mFrameGraph->renderSurfaceSelector()->setExternalRenderTargetSize( mSize );
   mFrameGraph->setShadowRenderingEnabled( false );
   // Set this frame graph to be in use.
   // the render settings also sets itself as the parent of mSurfaceSelector

--- a/src/3d/qgsoffscreen3dengine.h
+++ b/src/3d/qgsoffscreen3dengine.h
@@ -80,10 +80,9 @@ class _3D_EXPORT QgsOffscreen3DEngine : public QgsAbstract3DEngine
     Qt3DRender::QCamera *camera() override;
     QSize size() const override;
     QSurface *surface() const override;
-
-    void requestCaptureImage() override;
-
-    QgsShadowRenderingFrameGraph *frameGraph() override { return mFrameGraph; }
+  signals:
+    //! Emitted after a call to requestCaptureImage() to return the captured image.
+    void imageCaptured( const QImage &image );
   private:
 
     QSize mSize = QSize( 640, 480 );
@@ -98,8 +97,7 @@ class _3D_EXPORT QgsOffscreen3DEngine : public QgsAbstract3DEngine
     Qt3DCore::QNode *mSceneRoot = nullptr;                         // The scene root, which becomes a child of the engine's root entity.
     Qt3DCore::QEntity *mRoot = nullptr;
 
-    QgsShadowRenderingFrameGraph *mFrameGraph = nullptr;
-
+//    QgsShadowRenderingFrameGraph *mFrameGraph = nullptr;
 };
 
 #endif // QGSOFFSCREEN3DENGINE_H

--- a/src/3d/qgsoffscreen3dengine.h
+++ b/src/3d/qgsoffscreen3dengine.h
@@ -48,6 +48,8 @@ namespace Qt3DLogic
   class QLogicAspect;
 }
 
+#include "qgsshadowrenderingframegraph.h"
+
 #define SIP_NO_FILE
 
 /**
@@ -81,16 +83,12 @@ class _3D_EXPORT QgsOffscreen3DEngine : public QgsAbstract3DEngine
 
     void requestCaptureImage() override;
 
-  private:
-    void createRenderTarget();
-    void createFrameGraph();
-
+    QgsShadowRenderingFrameGraph *frameGraph() override { return mFrameGraph; }
   private:
 
     QSize mSize = QSize( 640, 480 );
     Qt3DRender::QCamera *mCamera = nullptr;
     QOffscreenSurface *mOffscreenSurface = nullptr;
-    Qt3DRender::QRenderCaptureReply *mReply = nullptr;
 
     // basic Qt3D stuff
     Qt3DCore::QAspectEngine *mAspectEngine = nullptr;              // The aspect engine, which holds the scene and related aspects.
@@ -100,20 +98,7 @@ class _3D_EXPORT QgsOffscreen3DEngine : public QgsAbstract3DEngine
     Qt3DCore::QNode *mSceneRoot = nullptr;                         // The scene root, which becomes a child of the engine's root entity.
     Qt3DCore::QEntity *mRoot = nullptr;
 
-    // render target stuff
-    Qt3DRender::QRenderTarget *mTextureTarget = nullptr;
-    Qt3DRender::QRenderTargetOutput *mTextureOutput = nullptr;
-    Qt3DRender::QTexture2D *mTexture = nullptr;
-    Qt3DRender::QRenderTargetOutput *mDepthTextureOutput = nullptr;
-    Qt3DRender::QTexture2D *mDepthTexture = nullptr;
-
-    // frame graph stuff
-    Qt3DRender::QRenderSurfaceSelector *mSurfaceSelector = nullptr;
-    Qt3DRender::QRenderTargetSelector *mRenderTargetSelector = nullptr;
-    Qt3DRender::QViewport *mViewport = nullptr;
-    Qt3DRender::QClearBuffers *mClearBuffers = nullptr;
-    Qt3DRender::QCameraSelector *mCameraSelector = nullptr;
-    Qt3DRender::QRenderCapture *mRenderCapture = nullptr;          // The render capture node, which is appended to the frame graph.
+    QgsShadowRenderingFrameGraph *mFrameGraph = nullptr;
 
 };
 

--- a/src/3d/qgsoffscreen3dengine.h
+++ b/src/3d/qgsoffscreen3dengine.h
@@ -96,8 +96,6 @@ class _3D_EXPORT QgsOffscreen3DEngine : public QgsAbstract3DEngine
     Qt3DRender::QRenderSettings *mRenderSettings = nullptr;        // The render settings, which control the general rendering behavior.
     Qt3DCore::QNode *mSceneRoot = nullptr;                         // The scene root, which becomes a child of the engine's root entity.
     Qt3DCore::QEntity *mRoot = nullptr;
-
-//    QgsShadowRenderingFrameGraph *mFrameGraph = nullptr;
 };
 
 #endif // QGSOFFSCREEN3DENGINE_H

--- a/src/3d/qgsshadowrenderingframegraph.cpp
+++ b/src/3d/qgsshadowrenderingframegraph.cpp
@@ -450,3 +450,14 @@ void QgsShadowRenderingFrameGraph::setSize( QSize s )
   mRenderCaptureDepthTexture->setSize( mSize.width(), mSize.height() );
   mRenderSurfaceSelector->setExternalRenderTargetSize( mSize );
 }
+
+void QgsShadowRenderingFrameGraph::setRenderCaptureEnabled( bool enabled )
+{
+  if ( enabled == mRenderCaptureEnabled )
+    return;
+  mRenderCaptureEnabled = enabled;
+  if ( mRenderCaptureEnabled )
+    mRenderCaptureTargetSelector->setParent( mPostprocessPassLayerFilter );
+  else
+    mRenderCaptureTargetSelector->setParent( ( Qt3DCore::QNode * ) nullptr );
+}

--- a/src/3d/qgsshadowrenderingframegraph.cpp
+++ b/src/3d/qgsshadowrenderingframegraph.cpp
@@ -456,8 +456,5 @@ void QgsShadowRenderingFrameGraph::setRenderCaptureEnabled( bool enabled )
   if ( enabled == mRenderCaptureEnabled )
     return;
   mRenderCaptureEnabled = enabled;
-  if ( mRenderCaptureEnabled )
-    mRenderCaptureTargetSelector->setParent( mPostprocessPassLayerFilter );
-  else
-    mRenderCaptureTargetSelector->setParent( ( Qt3DCore::QNode * ) nullptr );
+  mRenderCaptureTargetSelector->setEnabled( mRenderCaptureEnabled );
 }

--- a/src/3d/qgsshadowrenderingframegraph.cpp
+++ b/src/3d/qgsshadowrenderingframegraph.cpp
@@ -39,15 +39,13 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructTexturesPrev
 
 Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRenderPass()
 {
-  mForwardRenderLayerFilter = new Qt3DRender::QLayerFilter( mMainCameraSelector );
+  mForwardRenderLayerFilter = new Qt3DRender::QLayerFilter;
   mForwardRenderLayerFilter->addLayer( mForwardRenderLayer );
-
-  mRenderCapture = new Qt3DRender::QRenderCapture( mForwardRenderLayerFilter );
 
   mForwardColorTexture = new Qt3DRender::QTexture2D;
   mForwardColorTexture->setWidth( mSize.width() );
   mForwardColorTexture->setHeight( mSize.height() );
-  mForwardColorTexture->setFormat( Qt3DRender::QTexture2D::TextureFormat::RGBA16F );
+  mForwardColorTexture->setFormat( Qt3DRender::QAbstractTexture::RGBA16F );
   mForwardColorTexture->setGenerateMipMaps( false );
   mForwardColorTexture->setMagnificationFilter( Qt3DRender::QTexture2D::Linear );
   mForwardColorTexture->setMinificationFilter( Qt3DRender::QTexture2D::Linear );
@@ -81,8 +79,10 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRende
   mForwardClearBuffers->setClearColor( QColor::fromRgbF( 0.0, 1.0, 0.0, 1.0 ) );
   mForwardClearBuffers->setBuffers( Qt3DRender::QClearBuffers::ColorDepthBuffer );
 
-  mFrustumCulling = new Qt3DRender::QFrustumCulling;
-  mFrustumCulling->setParent( mForwardClearBuffers );
+  mFrustumCulling = new Qt3DRender::QFrustumCulling( mForwardClearBuffers );
+
+  // mMainCameraSelector = new Qt3DRender::QCameraSelector( mForwardRenderTargetSelector );
+  // mMainCameraSelector->setCamera( mMainCamera );
 
   return mForwardRenderLayerFilter;
 }
@@ -133,11 +133,54 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructPostprocessi
   mPostprocessClearBuffers = new Qt3DRender::QClearBuffers( mPostprocessPassLayerFilter );
   mPostprocessClearBuffers->setClearColor( QColor::fromRgbF( 0.0f, 0.0f, 0.0f ) );
 
+  //
+  {
+    mRenderCaptureTargetSelector = new Qt3DRender::QRenderTargetSelector( mPostprocessPassLayerFilter );
+
+    Qt3DRender::QRenderTarget *renderTarget = new Qt3DRender::QRenderTarget( mRenderCaptureTargetSelector );
+
+    // The lifetime of the objects created here is managed
+    // automatically, as they become children of this object.
+
+    // Create a render target output for rendering color.
+    Qt3DRender::QRenderTargetOutput *colorOutput = new Qt3DRender::QRenderTargetOutput( renderTarget );
+    colorOutput->setAttachmentPoint( Qt3DRender::QRenderTargetOutput::Color0 );
+
+    // Create a texture to render into.
+    mRenderCaptureColorTexture = new Qt3DRender::QTexture2D( colorOutput );
+    mRenderCaptureColorTexture->setSize( mSize.width(), mSize.height() );
+    mRenderCaptureColorTexture->setFormat( Qt3DRender::QAbstractTexture::RGB8_UNorm );
+    mRenderCaptureColorTexture->setMinificationFilter( Qt3DRender::QAbstractTexture::Linear );
+    mRenderCaptureColorTexture->setMagnificationFilter( Qt3DRender::QAbstractTexture::Linear );
+
+    // Hook the texture up to our output, and the output up to this object.
+    colorOutput->setTexture( mRenderCaptureColorTexture );
+    renderTarget->addOutput( colorOutput );
+
+    Qt3DRender::QRenderTargetOutput *depthOutput = new Qt3DRender::QRenderTargetOutput( renderTarget );
+
+    depthOutput->setAttachmentPoint( Qt3DRender::QRenderTargetOutput::Depth );
+    mRenderCaptureDepthTexture = new Qt3DRender::QTexture2D( depthOutput );
+    mRenderCaptureDepthTexture->setSize( mSize.width(), mSize.height() );
+    mRenderCaptureDepthTexture->setFormat( Qt3DRender::QAbstractTexture::DepthFormat );
+    mRenderCaptureDepthTexture->setMinificationFilter( Qt3DRender::QAbstractTexture::Linear );
+    mRenderCaptureDepthTexture->setMagnificationFilter( Qt3DRender::QAbstractTexture::Linear );
+    mRenderCaptureDepthTexture->setComparisonFunction( Qt3DRender::QAbstractTexture::CompareLessEqual );
+    mRenderCaptureDepthTexture->setComparisonMode( Qt3DRender::QAbstractTexture::CompareRefToTexture );
+
+    depthOutput->setTexture( mRenderCaptureDepthTexture );
+    renderTarget->addOutput( depthOutput );
+
+    mRenderCaptureTargetSelector->setTarget( renderTarget );
+  }
+  //
+
+  mRenderCapture = new Qt3DRender::QRenderCapture( mRenderCaptureTargetSelector );
 
   return mPostprocessPassLayerFilter;
 }
 
-QgsShadowRenderingFrameGraph::QgsShadowRenderingFrameGraph( QWindow *window, QSize s, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *root )
+QgsShadowRenderingFrameGraph::QgsShadowRenderingFrameGraph( QSurface *surface, QSize s, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *root )
   : Qt3DCore::QEntity( root )
 {
   mSize = s;
@@ -157,7 +200,11 @@ QgsShadowRenderingFrameGraph::QgsShadowRenderingFrameGraph( QWindow *window, QSi
   mForwardRenderLayer->setRecursive( true );
 
   mRenderSurfaceSelector = new Qt3DRender::QRenderSurfaceSelector;
-  mRenderSurfaceSelector->setSurface( window );
+
+  QObject *surfaceObj = dynamic_cast< QObject *  >( surface );
+  Q_ASSERT( surfaceObj );
+
+  mRenderSurfaceSelector->setSurface( surfaceObj );
 
   mMainViewPort = new Qt3DRender::QViewport( mRenderSurfaceSelector );
   mMainViewPort->setNormalizedRect( QRectF( 0.0f, 0.0f, 1.0f, 1.0f ) );
@@ -185,7 +232,7 @@ QgsShadowRenderingFrameGraph::QgsShadowRenderingFrameGraph( QWindow *window, QSi
 
   // textures preview pass
   Qt3DRender::QFrameGraphNode *previewPass = constructTexturesPreviewPass();
-  previewPass->setParent( mMainViewPort );
+  previewPass->setParent( mRenderSurfaceSelector );
 
 
   mDebugDepthMapPreviewQuad = this->addTexturePreviewOverlay( mForwardDepthTexture, QPointF( 0.8f, 0.8f ), QSizeF( 0.2f, 0.2f ) );
@@ -406,4 +453,7 @@ void QgsShadowRenderingFrameGraph::setSize( QSize s )
   mSize = s;
   mForwardColorTexture->setSize( mSize.width(), mSize.height() );
   mForwardDepthTexture->setSize( mSize.width(), mSize.height() );
+  mRenderCaptureColorTexture->setSize( mSize.width(), mSize.height() );
+  mRenderCaptureDepthTexture->setSize( mSize.width(), mSize.height() );
+  mRenderSurfaceSelector->setExternalRenderTargetSize( mSize );
 }

--- a/src/3d/qgsshadowrenderingframegraph.cpp
+++ b/src/3d/qgsshadowrenderingframegraph.cpp
@@ -81,9 +81,6 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRende
 
   mFrustumCulling = new Qt3DRender::QFrustumCulling( mForwardClearBuffers );
 
-  // mMainCameraSelector = new Qt3DRender::QCameraSelector( mForwardRenderTargetSelector );
-  // mMainCameraSelector->setCamera( mMainCamera );
-
   return mForwardRenderLayerFilter;
 }
 
@@ -133,47 +130,43 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructPostprocessi
   mPostprocessClearBuffers = new Qt3DRender::QClearBuffers( mPostprocessPassLayerFilter );
   mPostprocessClearBuffers->setClearColor( QColor::fromRgbF( 0.0f, 0.0f, 0.0f ) );
 
-  //
-  {
-    mRenderCaptureTargetSelector = new Qt3DRender::QRenderTargetSelector( mPostprocessPassLayerFilter );
+  mRenderCaptureTargetSelector = new Qt3DRender::QRenderTargetSelector( mPostprocessPassLayerFilter );
 
-    Qt3DRender::QRenderTarget *renderTarget = new Qt3DRender::QRenderTarget( mRenderCaptureTargetSelector );
+  Qt3DRender::QRenderTarget *renderTarget = new Qt3DRender::QRenderTarget( mRenderCaptureTargetSelector );
 
-    // The lifetime of the objects created here is managed
-    // automatically, as they become children of this object.
+  // The lifetime of the objects created here is managed
+  // automatically, as they become children of this object.
 
-    // Create a render target output for rendering color.
-    Qt3DRender::QRenderTargetOutput *colorOutput = new Qt3DRender::QRenderTargetOutput( renderTarget );
-    colorOutput->setAttachmentPoint( Qt3DRender::QRenderTargetOutput::Color0 );
+  // Create a render target output for rendering color.
+  Qt3DRender::QRenderTargetOutput *colorOutput = new Qt3DRender::QRenderTargetOutput( renderTarget );
+  colorOutput->setAttachmentPoint( Qt3DRender::QRenderTargetOutput::Color0 );
 
-    // Create a texture to render into.
-    mRenderCaptureColorTexture = new Qt3DRender::QTexture2D( colorOutput );
-    mRenderCaptureColorTexture->setSize( mSize.width(), mSize.height() );
-    mRenderCaptureColorTexture->setFormat( Qt3DRender::QAbstractTexture::RGB8_UNorm );
-    mRenderCaptureColorTexture->setMinificationFilter( Qt3DRender::QAbstractTexture::Linear );
-    mRenderCaptureColorTexture->setMagnificationFilter( Qt3DRender::QAbstractTexture::Linear );
+  // Create a texture to render into.
+  mRenderCaptureColorTexture = new Qt3DRender::QTexture2D( colorOutput );
+  mRenderCaptureColorTexture->setSize( mSize.width(), mSize.height() );
+  mRenderCaptureColorTexture->setFormat( Qt3DRender::QAbstractTexture::RGB8_UNorm );
+  mRenderCaptureColorTexture->setMinificationFilter( Qt3DRender::QAbstractTexture::Linear );
+  mRenderCaptureColorTexture->setMagnificationFilter( Qt3DRender::QAbstractTexture::Linear );
 
-    // Hook the texture up to our output, and the output up to this object.
-    colorOutput->setTexture( mRenderCaptureColorTexture );
-    renderTarget->addOutput( colorOutput );
+  // Hook the texture up to our output, and the output up to this object.
+  colorOutput->setTexture( mRenderCaptureColorTexture );
+  renderTarget->addOutput( colorOutput );
 
-    Qt3DRender::QRenderTargetOutput *depthOutput = new Qt3DRender::QRenderTargetOutput( renderTarget );
+  Qt3DRender::QRenderTargetOutput *depthOutput = new Qt3DRender::QRenderTargetOutput( renderTarget );
 
-    depthOutput->setAttachmentPoint( Qt3DRender::QRenderTargetOutput::Depth );
-    mRenderCaptureDepthTexture = new Qt3DRender::QTexture2D( depthOutput );
-    mRenderCaptureDepthTexture->setSize( mSize.width(), mSize.height() );
-    mRenderCaptureDepthTexture->setFormat( Qt3DRender::QAbstractTexture::DepthFormat );
-    mRenderCaptureDepthTexture->setMinificationFilter( Qt3DRender::QAbstractTexture::Linear );
-    mRenderCaptureDepthTexture->setMagnificationFilter( Qt3DRender::QAbstractTexture::Linear );
-    mRenderCaptureDepthTexture->setComparisonFunction( Qt3DRender::QAbstractTexture::CompareLessEqual );
-    mRenderCaptureDepthTexture->setComparisonMode( Qt3DRender::QAbstractTexture::CompareRefToTexture );
+  depthOutput->setAttachmentPoint( Qt3DRender::QRenderTargetOutput::Depth );
+  mRenderCaptureDepthTexture = new Qt3DRender::QTexture2D( depthOutput );
+  mRenderCaptureDepthTexture->setSize( mSize.width(), mSize.height() );
+  mRenderCaptureDepthTexture->setFormat( Qt3DRender::QAbstractTexture::DepthFormat );
+  mRenderCaptureDepthTexture->setMinificationFilter( Qt3DRender::QAbstractTexture::Linear );
+  mRenderCaptureDepthTexture->setMagnificationFilter( Qt3DRender::QAbstractTexture::Linear );
+  mRenderCaptureDepthTexture->setComparisonFunction( Qt3DRender::QAbstractTexture::CompareLessEqual );
+  mRenderCaptureDepthTexture->setComparisonMode( Qt3DRender::QAbstractTexture::CompareRefToTexture );
 
-    depthOutput->setTexture( mRenderCaptureDepthTexture );
-    renderTarget->addOutput( depthOutput );
+  depthOutput->setTexture( mRenderCaptureDepthTexture );
+  renderTarget->addOutput( depthOutput );
 
-    mRenderCaptureTargetSelector->setTarget( renderTarget );
-  }
-  //
+  mRenderCaptureTargetSelector->setTarget( renderTarget );
 
   mRenderCapture = new Qt3DRender::QRenderCapture( mRenderCaptureTargetSelector );
 
@@ -182,9 +175,8 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructPostprocessi
 
 QgsShadowRenderingFrameGraph::QgsShadowRenderingFrameGraph( QSurface *surface, QSize s, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *root )
   : Qt3DCore::QEntity( root )
+  , mSize( s )
 {
-  mSize = s;
-
   mRootEntity = root;
   mMainCamera = mainCamera;
   mLightCamera = new Qt3DRender::QCamera;
@@ -205,6 +197,7 @@ QgsShadowRenderingFrameGraph::QgsShadowRenderingFrameGraph( QSurface *surface, Q
   Q_ASSERT( surfaceObj );
 
   mRenderSurfaceSelector->setSurface( surfaceObj );
+  mRenderSurfaceSelector->setExternalRenderTargetSize( mSize );
 
   mMainViewPort = new Qt3DRender::QViewport( mRenderSurfaceSelector );
   mMainViewPort->setNormalizedRect( QRectF( 0.0f, 0.0f, 1.0f, 1.0f ) );

--- a/src/3d/qgsshadowrenderingframegraph.h
+++ b/src/3d/qgsshadowrenderingframegraph.h
@@ -62,8 +62,6 @@ class QgsShadowRenderingFrameGraph : public Qt3DCore::QEntity
     //! Returns the root of the frame graph object
     Qt3DRender::QFrameGraphNode *frameGraphRoot() { return mRenderSurfaceSelector; }
 
-    Qt3DRender::QRenderSurfaceSelector *renderSurfaceSelector() { return mRenderSurfaceSelector; }
-
     //! Returns the color texture of the forward rendering pass
     Qt3DRender::QTexture2D *forwardRenderColorTexture() { return mForwardColorTexture; }
     //! Returns the depth texture of the forward rendering pass

--- a/src/3d/qgsshadowrenderingframegraph.h
+++ b/src/3d/qgsshadowrenderingframegraph.h
@@ -124,6 +124,18 @@ class QgsShadowRenderingFrameGraph : public Qt3DCore::QEntity
     void setupDepthMapDebugging( bool enabled, Qt::Corner corner, double size );
     //! Sets the size of the buffers used for rendering
     void setSize( QSize s );
+
+    /**
+     * Sets whether it will be possible to render to an image
+     * \since QGIS 3.18
+     */
+    void setRenderCaptureEnabled( bool enabled );
+
+    /**
+     * Returns whether it will be possible to render to an image
+     * \since QGIS 3.18
+     */
+    bool renderCaptureEnabled() const { return mRenderCaptureEnabled; }
   private:
     Qt3DRender::QRenderSurfaceSelector *mRenderSurfaceSelector = nullptr;
     Qt3DRender::QViewport *mMainViewPort = nullptr;
@@ -199,6 +211,8 @@ class QgsShadowRenderingFrameGraph : public Qt3DCore::QEntity
     Qt3DRender::QFrameGraphNode *constructForwardRenderPass();
     Qt3DRender::QFrameGraphNode *constructTexturesPreviewPass();
     Qt3DRender::QFrameGraphNode *constructPostprocessingPass();
+
+    bool mRenderCaptureEnabled = true;
 
     Q_DISABLE_COPY( QgsShadowRenderingFrameGraph )
 };

--- a/src/3d/qgsshadowrenderingframegraph.h
+++ b/src/3d/qgsshadowrenderingframegraph.h
@@ -57,10 +57,12 @@ class QgsShadowRenderingFrameGraph : public Qt3DCore::QEntity
 {
   public:
     //! Constructor
-    QgsShadowRenderingFrameGraph( QWindow *window, QSize s, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *root );
+    QgsShadowRenderingFrameGraph( QSurface *surface, QSize s, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *root );
 
     //! Returns the root of the frame graph object
-    Qt3DRender::QFrameGraphNode *getFrameGraphRoot() { return mRenderSurfaceSelector; }
+    Qt3DRender::QFrameGraphNode *frameGraphRoot() { return mRenderSurfaceSelector; }
+
+    Qt3DRender::QRenderSurfaceSelector *renderSurfaceSelector() { return mRenderSurfaceSelector; }
 
     //! Returns the color texture of the forward rendering pass
     Qt3DRender::QTexture2D *forwardRenderColorTexture() { return mForwardColorTexture; }
@@ -157,6 +159,11 @@ class QgsShadowRenderingFrameGraph : public Qt3DCore::QEntity
     Qt3DRender::QClearBuffers *mShadowClearBuffers = nullptr;
     Qt3DRender::QCamera *mLightCamera = nullptr;
     Qt3DRender::QCameraSelector *mLightCameraSelector = nullptr;
+
+    Qt3DRender::QRenderTargetSelector *mRenderCaptureTargetSelector = nullptr;
+    Qt3DRender::QTexture2D *mRenderCaptureColorTexture = nullptr;
+    Qt3DRender::QTexture2D *mRenderCaptureDepthTexture = nullptr;
+
     bool mShadowRenderingEnabled = false;
     float mShadowBias = 0.00001f;
     int mShadowMapResolution = 2048;

--- a/src/3d/qgswindow3dengine.cpp
+++ b/src/3d/qgswindow3dengine.cpp
@@ -31,7 +31,7 @@ QgsWindow3DEngine::QgsWindow3DEngine( QObject *parent )
   mWindow3D->setRootEntity( mRoot );
 
   mFrameGraph = new QgsShadowRenderingFrameGraph( mWindow3D, QSize( 1024, 768 ), mWindow3D->camera(), mRoot );
-
+  mFrameGraph->setRenderCaptureEnabled( false );
   mWindow3D->setActiveFrameGraph( mFrameGraph->frameGraphRoot() );
 
   // force switching to no shadow rendering

--- a/src/3d/qgswindow3dengine.cpp
+++ b/src/3d/qgswindow3dengine.cpp
@@ -32,7 +32,7 @@ QgsWindow3DEngine::QgsWindow3DEngine( QObject *parent )
 
   mShadowRenderingFrameGraph = new QgsShadowRenderingFrameGraph( mWindow3D, QSize( 1024, 768 ), mWindow3D->camera(), mRoot );
 
-  mWindow3D->setActiveFrameGraph( mShadowRenderingFrameGraph->getFrameGraphRoot() );
+  mWindow3D->setActiveFrameGraph( mShadowRenderingFrameGraph->frameGraphRoot() );
 
   // force switching to no shadow rendering
   setShadowRenderingEnabled( false );

--- a/src/3d/qgswindow3dengine.cpp
+++ b/src/3d/qgswindow3dengine.cpp
@@ -30,9 +30,9 @@ QgsWindow3DEngine::QgsWindow3DEngine( QObject *parent )
   mRoot = new Qt3DCore::QEntity;
   mWindow3D->setRootEntity( mRoot );
 
-  mShadowRenderingFrameGraph = new QgsShadowRenderingFrameGraph( mWindow3D, QSize( 1024, 768 ), mWindow3D->camera(), mRoot );
+  mFrameGraph = new QgsShadowRenderingFrameGraph( mWindow3D, QSize( 1024, 768 ), mWindow3D->camera(), mRoot );
 
-  mWindow3D->setActiveFrameGraph( mShadowRenderingFrameGraph->frameGraphRoot() );
+  mWindow3D->setActiveFrameGraph( mFrameGraph->frameGraphRoot() );
 
   // force switching to no shadow rendering
   setShadowRenderingEnabled( false );
@@ -43,40 +43,29 @@ QWindow *QgsWindow3DEngine::window()
   return mWindow3D;
 }
 
-void QgsWindow3DEngine::requestCaptureImage()
-{
-  Qt3DRender::QRenderCaptureReply *captureReply;
-  captureReply = mShadowRenderingFrameGraph->renderCapture()->requestCapture();
-  connect( captureReply, &Qt3DRender::QRenderCaptureReply::completed, this, [ = ]
-  {
-    emit imageCaptured( captureReply->image() );
-    captureReply->deleteLater();
-  } );
-}
-
 void QgsWindow3DEngine::setShadowRenderingEnabled( bool enabled )
 {
   mShadowRenderingEnabled = enabled;
-  mShadowRenderingFrameGraph->setShadowRenderingEnabled( mShadowRenderingEnabled );
+  mFrameGraph->setShadowRenderingEnabled( mShadowRenderingEnabled );
 }
 
 void QgsWindow3DEngine::setClearColor( const QColor &color )
 {
-  mShadowRenderingFrameGraph->setClearColor( color );
+  mFrameGraph->setClearColor( color );
 }
 
 void QgsWindow3DEngine::setFrustumCullingEnabled( bool enabled )
 {
   // Not sure if this works properly
-  mShadowRenderingFrameGraph->setFrustumCullingEnabled( enabled );
+  mFrameGraph->setFrustumCullingEnabled( enabled );
 }
 
 void QgsWindow3DEngine::setRootEntity( Qt3DCore::QEntity *root )
 {
   mSceneRoot = root;
   mSceneRoot->setParent( mRoot );
-  mSceneRoot->addComponent( mShadowRenderingFrameGraph->forwardRenderLayer() );
-  mSceneRoot->addComponent( mShadowRenderingFrameGraph->castShadowsLayer() );
+  mSceneRoot->addComponent( mFrameGraph->forwardRenderLayer() );
+  mSceneRoot->addComponent( mFrameGraph->castShadowsLayer() );
 }
 
 Qt3DRender::QRenderSettings *QgsWindow3DEngine::renderSettings()
@@ -105,6 +94,6 @@ void QgsWindow3DEngine::setSize( QSize s )
 
   mWindow3D->setWidth( mSize.width() );
   mWindow3D->setHeight( mSize.height() );
-  mShadowRenderingFrameGraph->setSize( mSize );
+  mFrameGraph->setSize( mSize );
   camera()->setAspectRatio( float( mSize.width() ) / float( mSize.height() ) );
 }

--- a/src/3d/qgswindow3dengine.h
+++ b/src/3d/qgswindow3dengine.h
@@ -60,7 +60,7 @@ class _3D_EXPORT QgsWindow3DEngine : public QgsAbstract3DEngine
     QWindow *window();
 
     //! Returns the frame graph object
-    QgsShadowRenderingFrameGraph *shadowRenderingFrameGraph() { return mShadowRenderingFrameGraph; }
+    QgsShadowRenderingFrameGraph *frameGraph() override { return mShadowRenderingFrameGraph; }
 
     void requestCaptureImage() override;
 

--- a/src/3d/qgswindow3dengine.h
+++ b/src/3d/qgswindow3dengine.h
@@ -59,11 +59,6 @@ class _3D_EXPORT QgsWindow3DEngine : public QgsAbstract3DEngine
     //! Returns the internal 3D window where all the rendered output is displayed
     QWindow *window();
 
-    //! Returns the frame graph object
-    QgsShadowRenderingFrameGraph *frameGraph() override { return mShadowRenderingFrameGraph; }
-
-    void requestCaptureImage() override;
-
     //! Sets whether shadow rendering is enabled
     void setShadowRenderingEnabled( bool enabled );
     //! Returns whether shadow rendering is enabled
@@ -84,8 +79,6 @@ class _3D_EXPORT QgsWindow3DEngine : public QgsAbstract3DEngine
     Qt3DExtras::Qt3DWindow *mWindow3D = nullptr;
     //! Frame graph node for render capture
     bool mShadowRenderingEnabled = false;
-    QgsShadowRenderingFrameGraph *mShadowRenderingFrameGraph = nullptr;
-    Qt3DExtras::QForwardRenderer *mDefaultForwardRenderer = nullptr;
     Qt3DCore::QEntity *mRoot = nullptr;
     Qt3DCore::QEntity *mSceneRoot = nullptr;
 

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -123,9 +123,6 @@ class Qgs3DMapCanvas : public QWidget
   private:
     QgsWindow3DEngine *mEngine = nullptr;
 
-    QString mCaptureFileName;
-    QString mCaptureFileFormat;
-
     //! Container QWidget that encapsulates mWindow3D so we can use it embedded in ordinary widgets app
     QWidget *mContainer = nullptr;
     //! Description of the 3D scene

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -27,6 +27,11 @@ namespace Qt3DExtras
   class Qt3DWindow;
 }
 
+namespace Qt3DLogic
+{
+  class QFrameAction;
+}
+
 class Qgs3DMapSettings;
 class Qgs3DMapScene;
 class Qgs3DMapTool;
@@ -95,7 +100,7 @@ class Qgs3DMapCanvas : public QWidget
 
   signals:
     //! Emitted when the 3D map canvas was successfully saved as image
-    void savedAsImage( QString fileName );
+    void savedAsImage( const QString &fileName );
 
     //! Emitted when the the map setting is changed
     void mapSettingsChanged();
@@ -132,6 +137,9 @@ class Qgs3DMapCanvas : public QWidget
 
     //! Active map tool that receives events (if NULLPTR then mouse/keyboard events are used for camera manipulation)
     Qgs3DMapTool *mMapTool = nullptr;
+
+    QString mCaptureFileName;
+    QString mCaptureFileFormat;
 
     //! On-Screen Navigation widget.
     Qgs3DNavigationWidget *mNavigationWidget = nullptr;

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -724,11 +724,6 @@ void TestQgs3DRendering::testMesh()
 
 void TestQgs3DRendering::testMeshSimplified()
 {
-  if ( QgsTest::isCIRun() )
-  {
-    QSKIP( "Intermittently fails on CI" );
-  }
-
   QgsMeshSimplificationSettings simplificationSettings;
   simplificationSettings.setEnabled( true );
   simplificationSettings.setReductionFactor( 3 );


### PR DESCRIPTION
## Description
Fixes the issue submitted here: https://github.com/qgis/QGIS/issues/41648

A sample of exported animation of point cloud with shadows enabled:
https://user-images.githubusercontent.com/29183781/108865375-7aa3f400-75f3-11eb-9ca0-09a6e35fc3eb.mp4

