### PR TITLE
Add information about matching number of fields condition

### DIFF
--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -204,13 +204,19 @@ Returns the number of attributes attached to the feature.
     void setAttributes( const QgsAttributes &attrs );
 %Docstring
 Sets the feature's attributes.
-The feature will be valid after.
+The feature will be valid after. The number of provided attributes need to match exactly the number of the feature's fields.
 
-:param attrs: attribute list
+:param attrs: List of attribute values
 
 .. seealso:: :py:func:`setAttribute`
 
 .. seealso:: :py:func:`attributes`
+
+.. warning::
+
+   Method will return false if the number of provided attributes does not exactly match
+   the number of the feature's fields and it will not be possible to add this feature to the data 
+   provider.
 %End
 
     bool setAttribute( int field, const QVariant &attr /GetWrapper/ );

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -216,7 +216,7 @@ number of the feature's fields.
 .. warning::
 
    Method will return false if the number of provided attributes does not exactly match
-   the number of the feature's fields and it will not be possible to add this feature to the data 
+   the number of the feature's fields and it will not be possible to add this feature to the data
    provider.
 %End
 

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -204,7 +204,8 @@ Returns the number of attributes attached to the feature.
     void setAttributes( const QgsAttributes &attrs );
 %Docstring
 Sets the feature's attributes.
-The feature will be valid after. The number of provided attributes need to match exactly the number of the feature's fields.
+The feature will be valid after. The number of provided attributes need to match exactly the
+number of the feature's fields.
 
 :param attrs: List of attribute values
 

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -245,10 +245,14 @@ class CORE_EXPORT QgsFeature
 
     /**
      * Sets the feature's attributes.
-     * The feature will be valid after.
-     * \param attrs attribute list
+     * The feature will be valid after. The number of provided attributes need to match exactly the
+     * number of the feature's fields.
+     * \param attrs List of attribute values
      * \see setAttribute
      * \see attributes
+     * \warning Method will return false if the number of provided attributes does not exactly match
+     * the number of the feature's fields and it will not be possible to add this feature to the data 
+     * provider.
      */
     void setAttributes( const QgsAttributes &attrs );
 

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -251,7 +251,7 @@ class CORE_EXPORT QgsFeature
      * \see setAttribute
      * \see attributes
      * \warning Method will return false if the number of provided attributes does not exactly match
-     * the number of the feature's fields and it will not be possible to add this feature to the data 
+     * the number of the feature's fields and it will not be possible to add this feature to the data
      * provider.
      */
     void setAttributes( const QgsAttributes &attrs );


### PR DESCRIPTION
Improve setAttributes() description providing information about the importance and consequences when a wrong number of fields is set as discussed in https://github.com/qgis/QGIS/issues/41389 with @nyalldawson:
