### PR TITLE
[processing] Fix output raster extensions list for GdalAlgorithmProvider

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -209,7 +209,7 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
             self.addAlgorithm(a)
 
     def supportedOutputRasterLayerExtensions(self):
-        return GdalUtils.getSupportedRasterExtensions()
+        return GdalUtils.getSupportedOutputRasterExtensions()
 
     def supportsNonFileBasedOutput(self):
         """

--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -183,8 +183,8 @@ class GdalUtils:
                     or metadata[gdal.DCAP_RASTER] != 'YES':
                 continue
 
-            if gdal.DMD_EXTENSION in metadata:
-                extensions = metadata[gdal.DMD_EXTENSION].split('/')
+            if gdal.DMD_EXTENSIONS in metadata:
+                extensions = metadata[gdal.DMD_EXTENSIONS].split(' ')
                 if extensions:
                     GdalUtils.supportedRasters[shortName] = extensions
                     # Only creatable rasters can be referenced in output rasters

--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -170,8 +170,8 @@ class GdalUtils:
 
         GdalUtils.supportedRasters = {}
         GdalUtils.supportedOutputRasters = {}
-        GdalUtils.supportedRasters['GTiff'] = ['tif']
-        GdalUtils.supportedOutputRasters['GTiff'] = ['tif']
+        GdalUtils.supportedRasters['GTiff'] = ['tif', 'tiff']
+        GdalUtils.supportedOutputRasters['GTiff'] = ['tif', 'tiff']
 
         for i in range(gdal.GetDriverCount()):
             driver = gdal.GetDriver(i)
@@ -210,20 +210,24 @@ class GdalUtils:
 
     @staticmethod
     def getSupportedRasterExtensions():
-        allexts = ['tif']
+        allexts = []
         for exts in list(GdalUtils.getSupportedRasters().values()):
             for ext in exts:
-                if ext not in allexts and ext != '':
+                if ext not in allexts and ext not in ['', 'tif', 'tiff']:
                     allexts.append(ext)
+        allexts.sort()
+        allexts[0:0] = ['tif', 'tiff']
         return allexts
 
     @staticmethod
     def getSupportedOutputRasterExtensions():
-        allexts = ['tif']
+        allexts = []
         for exts in list(GdalUtils.getSupportedOutputRasters().values()):
             for ext in exts:
-                if ext not in allexts and ext != '':
+                if ext not in allexts and ext not in ['', 'tif', 'tiff']:
                     allexts.append(ext)
+        allexts.sort()
+        allexts[0:0] = ['tif', 'tiff']
         return allexts
 
     @staticmethod


### PR DESCRIPTION
## Description

Fixes previously unreported bugs in the list of available extensions in the "Save to File" window of the GDAL provider algorithms.

The current list of output raster layer extensions:
- incorrectly contains also extensions of read only GDAL drivers: `GdalAlgorithmProvider supportedOutputRasterLayerExtensions(self)` incorrectly returns `GdalUtils.getSupportedRasterExtensions()` instead of `GdalUtils.getSupportedOutputRasterExtensions()`
- is missing of some output raster extensions: `GdalUtils.getSupportedRasters()` incorrectly checks `DMD_EXTENSION` driver metadata instead of the "new" (since GDAL 2) `DMD_EXTENSIONS` driver metadata (see [[1](https://gdal.org/api/raster_c_api.html#c.GDAL_DMD_EXTENSIONS)], [[2](https://gdal.org/development/rfc/rfc46_gdal_ogr_unification.html#drivers-and-driver-registration)])
- is long and unsorted and it is very difficult to find a driver extension in it.
![image](https://user-images.githubusercontent.com/16253859/109117704-a1bd0b80-7742-11eb-967a-3005e81b9440.png)


With this PR:
- `GdalAlgorithmProvider supportedOutputRasterLayerExtensions(self)` will return `GdalUtils.getSupportedOutputRasterExtensions()`
- `GdalUtils.getSupportedRasters()` will check `DMD_EXTENSIONS` driver metadata and retrieve the list of space separated extensions handled by the driver
- the list will have "tif" (like the previous behaviour) and "tiff" extensions to the top and further extensions will be sorted.

![image](https://user-images.githubusercontent.com/16253859/109117110-daa8b080-7741-11eb-8de9-818def0e05f8.png)
