### PR TITLE
[processing] add r.quantile algorithm with plain text output

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.quantile.plain.txt
+++ b/python/plugins/processing/algs/grass7/description/r.quantile.plain.txt
@@ -1,0 +1,9 @@
+r.quantile
+r.quantile.plain - Compute quantiles using two passes and save them as plain text.
+Raster (r.*)
+QgsProcessingParameterRasterLayer|input|Input raster layer|None|False
+QgsProcessingParameterNumber|quantiles|Number of quantiles|QgsProcessingParameterNumber.Integer|4|True|2|None
+QgsProcessingParameterString|percentiles|List of percentiles|None|False|True
+QgsProcessingParameterNumber|bins|Number of bins to use|QgsProcessingParameterNumber.Integer|1000000|True|1|None
+*QgsProcessingParameterBoolean|-r|Generate recode rules based on quantile-defined intervals|False
+QgsProcessingParameterFileDestination|file|Quantiles|TXT files (*.txt)|report.txt|False


### PR DESCRIPTION
## Description
Current `r.quantile` algorithm in GRASS provider outputs HTML file which can not be used directly with other GRASS tools, namely `r.recode`. This PR adds another version of the `r.quantile` tool which produces plain text output suitable for use with other tools.

New tool was added as some people may rely on the behaviour of the existing algorithm, e.g. publish HTML results on the web servers.