### PR TITLE
Use QObjectUniquePtr instead of std::unique_ptr in vertex tool

### DIFF
--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -24,7 +24,7 @@
 #include "qgsmaptooladvanceddigitizing.h"
 #include "qgsgeometry.h"
 #include "qgspointlocator.h"
-
+#include "qobjectuniqueptr.h"
 
 class QRubberBand;
 
@@ -444,7 +444,7 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
     // support for vertex editor
 
     //! Locked feature for the vertex editor
-    std::unique_ptr<QgsLockedFeature> mLockedFeature;
+    QObjectUniquePtr<QgsLockedFeature> mLockedFeature;
     //! Dock widget which allows editing vertices
     QPointer<QgsVertexEditor> mVertexEditor;
 


### PR DESCRIPTION
Why?

1. Because it's the right thing to do
2. Because I didn't find any explanation for the trace below

```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0 org.qt-project.QtCore 0x00000001125c0216 QMetaObjectPrivate::disconnect(QObject const*, int, QMetaObject const*, QObject
const*, int, void**, QMetaObjectPrivate::DisconnectType) + 134
1 org.qt-project.QtCore 0x00000001125c5b85 QObject::disconnectImpl(QObject const*, void**, QObject const*, void**,
QMetaObject const*) + 341
2 libqgis_app.3.16.1.dylib 0x000000010fcc2cd5 QgsVertexTool::setHighlightedVertices(QList<Vertex> const&,
QgsVertexTool::HighlightMode) + 901
3 libqgis_app.3.16.1.dylib 0x000000010fcc25f3 QgsVertexTool::deactivate() + 51
4 org.qgis.qgis3_gui 0x0000000110c755d0 QgsMapCanvas::setMapTool(QgsMapTool*, bool) + 128
5 org.qt-project.QtCore 0x00000001125c2a95 void doActivate<false>(QObject*, int, void**) + 1157
6 org.qt-project.QtWidgets 0x00000001116e0716 QAction::activate(QAction::ActionEvent) + 310
7 org.qt-project.QtWidgets 0x00000001117d3560 QAbstractButtonPrivate::click() + 144
8 org.qt-project.QtWidgets 0x00000001117d46ef QAbstractButton::mouseReleaseEvent(QMouseEvent*) + 271
9 org.qt-project.QtWidgets 0x00000001118cd83f QToolButton::mouseReleaseEvent(QMouseEvent*) + 15
10 org.qt-project.QtWidgets 0x000000011172499d QWidget::event(QEvent*) + 445
11 org.qt-project.QtWidgets 0x00000001118cddcf QToolButton::event(QEvent*) + 319
12 org.qt-project.QtWidgets 0x00000001116e9f5a QApplicationPrivate::notify_helper(QObject*, QEvent*) + 266
13 org.qt-project.QtWidgets 0x00000001116ece32 QApplication::notify(QObject*, QEvent*) + 7330
14 org.qgis.qgis3_core 0x00000001146ad183 QgsApplication::notify(QObject*, QEvent*) + 67
15 org.qt-project.QtCore 0x000000011258f9f4 QCoreApplication::notifyInternal2(QObject*, QEvent*) + 212
16 org.qt-project.QtWidgets 0x00000001116ea880 QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*,
QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) + 896
17 org.qt-project.QtWidgets 0x0000000111743908 QWidgetWindow::handleMouseEvent(QMouseEvent*) + 1704
18 org.qt-project.QtWidgets 0x00000001117425f5 QWidgetWindow::event(QEvent*) + 229
19 org.qt-project.QtWidgets 0x00000001116e9f5a QApplicationPrivate::notify_helper(QObject*, QEvent*) + 266
20 org.qt-project.QtWidgets 0x00000001116eb3e6 QApplication::notify(QObject*, QEvent*) + 598
21 org.qgis.qgis3_core 0x00000001146ad183 QgsApplication::notify(QObject*, QEvent*) + 67
22 org.qt-project.QtCore 0x000000011258f9f4 QCoreApplication::notifyInternal2(QObject*, QEvent*) + 212
23 org.qt-project.QtGui 0x0000000111d52895
QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) + 3397
24 org.qt-project.QtGui 0x0000000111d3815b
QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) + 219
25 libqcocoa.dylib 0x000000012115a0f0 QCocoaEventDispatcherPrivate::processPostedEvents() + 320
26 libqcocoa.dylib 0x000000012115a858 QCocoaEventDispatcherPrivate::postedEventsSourceCallback(void*) + 40
27 com.apple.CoreFoundation 0x00007fff4b8c5d13
__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17
28 com.apple.CoreFoundation 0x00007fff4b8c5cb9 __CFRunLoopDoSource0 + 108
29 com.apple.CoreFoundation 0x00007fff4b8a95af __CFRunLoopDoSources0 + 195
30 com.apple.CoreFoundation 0x00007fff4b8a8b79 __CFRunLoopRun + 1189
31 com.apple.CoreFoundation 0x00007fff4b8a8482 CFRunLoopRunSpecific + 455
32 com.apple.HIToolbox 0x00007fff4ab071ab RunCurrentEventLoopInMode + 292
33 com.apple.HIToolbox 0x00007fff4ab06ded ReceiveNextEventCommon + 355
34 com.apple.HIToolbox 0x00007fff4ab06c76 _BlockUntilNextEventMatchingListInModeWithFilter + 64
35 com.apple.AppKit 0x00007fff48e9e77d _DPSNextEvent + 1135
36 com.apple.AppKit 0x00007fff48e9d46b -[NSApplication(NSEvent)
_nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1361
37 com.apple.AppKit 0x00007fff48e97588 -[NSApplication run] + 699
38 libqcocoa.dylib 0x00000001211595d3
QCocoaEventDispatcher::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) + 2579
39 org.qt-project.QtCore 0x000000011258ba7f QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) + 431
40 org.qt-project.QtCore 0x0000000112590002 QCoreApplication::exec() + 130
41 org.qgis.qgis3 0x000000010f9faf28 main + 24792
42 libdyld.dylib 0x00007fff7782d3d5 start + 1
```