### PR TITLE
fixed QgsPluginInstaller.installFromZipFile

### DIFF
--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -570,8 +570,13 @@ class QgsPluginInstaller(QObject):
         settings.setValue(settingsGroup + '/lastZipDirectory',
                           QFileInfo(filePath).absoluteDir().absolutePath())
 
+        pluginName = None
         with zipfile.ZipFile(filePath, 'r') as zf:
-            pluginName = os.path.split(zf.namelist()[0])[0]
+            # search for metadata.txt. In case of multiple files, we can assume that
+            # the shortest path relates <pluginname>/metadata.txt
+            metadatafiles = sorted(f for f in zf.namelist() if f.endswith('metadata.txt'))
+            if len(metadatafiles) > 0:
+                pluginName = os.path.split(metadatafiles[0])[0]
 
         pluginFileName = os.path.splitext(os.path.basename(filePath))[0]
 


### PR DESCRIPTION
## Description

To install a QGIS plugin from a zip file, QgsPluginInstaller.installFromzipFile needs read the plugin name from the zip's internal file list. In case the 1st file in this list is located in a plugins's subfolder, e.g. `mypluginname/subfolder/file.xyz`,  the installFromzipFile() method would have assumed th pluginname `mypluginname/subfolder`:

````
        with zipfile.ZipFile(filePath, 'r') as zf:
            pluginName = os.path.split(zf.namelist()[0])[0]
````
This can lead to errors like in this screenshot, where a file in `spectral_libraries/core` is the first in the zipfile.

![grafik](https://user-images.githubusercontent.com/1404870/109165538-f5981680-777b-11eb-8b1a-13b46eeb8b8b.png)


This PR ensures that the plugin name is retrieve from the location of the `<plugin folder>/metadata.txt` file instead.








