### PR TITLE
Prevent prefetching of surrounding images for WMS

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2010,9 +2010,10 @@ int QgsWmsProvider::capabilities() const
     }
   }
 
-  // Prevent prefetch of XYZ openstreetmap images
-  // See: https://github.com/qgis/QGIS/issues/34813
-  if ( !( mSettings.mTiled && mSettings.mXyz && dataSourceUri().contains( QStringLiteral( "openstreetmap.org" ) ) ) )
+  // Prevent prefetch of XYZ openstreetmap images, see: https://github.com/qgis/QGIS/issues/34813
+  // But also prevent prefetching if service is a true WMS (mSettings.mTiled = True)
+  // See https://github.com/qgis/QGIS/issues/34813
+  if ( mSettings.mTiled && !( mSettings.mXyz && dataSourceUri().contains( QStringLiteral( "openstreetmap.org" ) ) ) )
   {
     capability |= Capability::Prefetch;
   }


### PR DESCRIPTION
For a true WMS it is not needed to prefetch surrounding tiles,
because:
- a WMS does not have fixed scales, so the re-using of cached images is
not very likely
- a WMS should always serve fresh data
- Creation of WMS images can be very resourcefull (on serverside) in
case of higher zoom levels or complex styling

IF prefetching is preferred, the service should show itself as WMTS, TMS or WMS-C

See https://github.com/qgis/QGIS/issues/41691

I tested, also the openstreetmap.org xyz service is still falling in the 'do not prefetch' category now.

To be honest I'm NOT aware how a WMS-C presents itself nowadays 
(and IF QGIS is able to distinguish between a WMS and a WMS-C)