### PR TITLE
Fix crashes in QgsHighlight if layer is removed before highlight

### DIFF
--- a/src/gui/qgshighlight.h
+++ b/src/gui/qgshighlight.h
@@ -195,7 +195,7 @@ class GUI_EXPORT QgsHighlight : public QgsMapCanvasItem
     QPen mPen;
     QgsGeometry mOriginalGeometry;
     QgsGeometry mGeometry;
-    QgsMapLayer *mLayer = nullptr;
+    QPointer< QgsMapLayer > mLayer;
     QgsFeature mFeature;
     double mBuffer = 0; // line / stroke buffer in pixels
     double mMinWidth = 0; // line / stroke minimum width in pixels


### PR DESCRIPTION
Don't think this happens in qgis core code, but I've a plugin here which crashes because of it