### PR TITLE
Fix crashes in QgsHighlight if layer is removed before highlight (3.16)

### DIFF
--- a/src/gui/qgshighlight.h
+++ b/src/gui/qgshighlight.h
@@ -184,7 +184,7 @@ class GUI_EXPORT QgsHighlight : public QgsMapCanvasItem
     QBrush mBrush;
     QPen mPen;
     QgsGeometry *mGeometry = nullptr;
-    QgsMapLayer *mLayer = nullptr;
+    QPointer< QgsMapLayer > mLayer;
     QgsFeature mFeature;
     double mBuffer = 0; // line / stroke buffer in pixels
     double mMinWidth = 0; // line / stroke minimum width in pixels


### PR DESCRIPTION
(cherry picked from commit e89d7158a004cfbb742b65ed0a0aa0be25085e2e)
Manual backport of https://github.com/qgis/QGIS/pull/41848