### PR TITLE
Cap pdal provider at c++14

### DIFF
--- a/src/providers/pdal/CMakeLists.txt
+++ b/src/providers/pdal/CMakeLists.txt
@@ -115,8 +115,8 @@ target_include_directories(untwine PRIVATE ${UNTWINE_INCLUDE_DIRS})
 
 add_library (pdalprovider MODULE ${PDAL_SRCS} ${PDAL_HDRS} ${PDAL_GUI_SRCS} ${PDAL_GUI_HDRS})
 
-# require c++17
-target_compile_features(pdalprovider PRIVATE cxx_std_17)
+# require c++14 only -- untwine is not compatible with c++17
+target_compile_features(pdalprovider PRIVATE cxx_std_14)
 
 target_link_libraries (pdalprovider
   qgis_core


### PR DESCRIPTION
The untwine/pdal dependancies use deprecated c++ removed in c++17

@PeterPetrik should fix the mac nightly builds