### PR TITLE
Fix GDAL command line generation, failing tests

### DIFF
--- a/python/plugins/processing/algs/gdal/AssignProjection.py
+++ b/python/plugins/processing/algs/gdal/AssignProjection.py
@@ -71,7 +71,7 @@ class AssignProjection(GdalAlgorithm):
         return 'rasterprojections'
 
     def commandName(self):
-        return 'gdal_edit.bat' if isWindows() else 'gdal_edit.py'
+        return 'gdal_edit'
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
         inLayer = self.parameterAsRasterLayer(parameters, self.INPUT, context)
@@ -91,7 +91,7 @@ class AssignProjection(GdalAlgorithm):
 
         self.setOutputValue(self.OUTPUT, fileName)
 
-        return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
+        return [self.commandName() + ('.bat' if isWindows() else '.py'), GdalUtils.escapeAndJoin(arguments)]
 
     def postProcessAlgorithm(self, context, feedback):
         # get output value

--- a/python/plugins/processing/algs/gdal/fillnodata.py
+++ b/python/plugins/processing/algs/gdal/fillnodata.py
@@ -109,7 +109,7 @@ class fillnodata(GdalAlgorithm):
         return 'rasteranalysis'
 
     def commandName(self):
-        return 'gdal_fillnodata.bat' if isWindows() else 'gdal_fillnodata.py'
+        return 'gdal_fillnodata'
 
     def flags(self):
         return super().flags() | QgsProcessingAlgorithm.FlagDisplayNameIsLiteral
@@ -156,4 +156,4 @@ class fillnodata(GdalAlgorithm):
         arguments.append(raster.source())
         arguments.append(out)
 
-        return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
+        return [self.commandName() + ('.bat' if isWindows() else '.py'), GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/algs/gdal/gdal2tiles.py
+++ b/python/plugins/processing/algs/gdal/gdal2tiles.py
@@ -151,7 +151,7 @@ class gdal2tiles(GdalAlgorithm):
         return 'rastermiscellaneous'
 
     def commandName(self):
-        return 'gdal2tiles.bat' if isWindows() else 'gdal2tiles.py'
+        return 'gdal2tiles'
 
     def flags(self):
         return super().flags() | QgsProcessingAlgorithm.FlagDisplayNameIsLiteral
@@ -224,4 +224,4 @@ class gdal2tiles(GdalAlgorithm):
         arguments.append(inLayer.source())
         arguments.append(self.parameterAsString(parameters, self.OUTPUT, context))
 
-        return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
+        return [self.commandName() + ('.bat' if isWindows() else '.py'), GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/algs/gdal/gdal2xyz.py
+++ b/python/plugins/processing/algs/gdal/gdal2xyz.py
@@ -69,7 +69,7 @@ class gdal2xyz(GdalAlgorithm):
         return 'rasterconversion'
 
     def commandName(self):
-        return 'gdal2xyz.bat' if isWindows() else 'gdal2xyz.py'
+        return 'gdal2xyz'
 
     def flags(self):
         return super().flags() | QgsProcessingAlgorithm.FlagDisplayNameIsLiteral
@@ -89,4 +89,4 @@ class gdal2xyz(GdalAlgorithm):
         arguments.append(raster.source())
         arguments.append(self.parameterAsFileOutput(parameters, self.OUTPUT, context))
 
-        return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
+        return [self.commandName() + ('.bat' if isWindows() else '.py'), GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -179,7 +179,7 @@ class gdalcalc(GdalAlgorithm):
         return 'rastermiscellaneous'
 
     def commandName(self):
-        return 'gdal_calc.bat' if isWindows() else 'gdal_calc'
+        return 'gdal_calc'
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
@@ -267,4 +267,4 @@ class gdalcalc(GdalAlgorithm):
         arguments.append('--outfile')
         arguments.append(out)
 
-        return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
+        return [self.commandName() + ('.bat' if isWindows() else '.py'), GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/algs/gdal/merge.py
+++ b/python/plugins/processing/algs/gdal/merge.py
@@ -127,7 +127,7 @@ class merge(GdalAlgorithm):
         return QIcon(os.path.join(pluginPath, 'images', 'gdaltools', 'merge.png'))
 
     def commandName(self):
-        return 'gdal_merge.bat' if isWindows() else 'gdal_merge.py'
+        return 'gdal_merge'
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
@@ -173,4 +173,4 @@ class merge(GdalAlgorithm):
         arguments.append('--optfile')
         arguments.append(list_file)
 
-        return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
+        return [self.commandName() + ('.bat' if isWindows() else '.py'), GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/algs/gdal/pansharp.py
+++ b/python/plugins/processing/algs/gdal/pansharp.py
@@ -104,7 +104,7 @@ class pansharp(GdalAlgorithm):
         return 'rastermiscellaneous'
 
     def commandName(self):
-        return 'gdal_pansharpen.bat' if isWindows() else 'gdal_pansharpen.py'
+        return 'gdal_pansharpen'
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
         spectral = self.parameterAsRasterLayer(parameters, self.SPECTRAL, context)
@@ -136,4 +136,4 @@ class pansharp(GdalAlgorithm):
             extra = self.parameterAsString(parameters, self.EXTRA, context)
             arguments.append(extra)
 
-        return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
+        return [self.commandName() + ('.bat' if isWindows() else '.py'), GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/algs/gdal/pct2rgb.py
+++ b/python/plugins/processing/algs/gdal/pct2rgb.py
@@ -74,7 +74,7 @@ class pct2rgb(GdalAlgorithm):
         return QIcon(os.path.join(pluginPath, 'images', 'gdaltools', '8-to-24-bits.png'))
 
     def commandName(self):
-        return 'pct2rgb.bat' if isWindows() else 'pct2rgb.py'
+        return 'pct2rgb'
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
         inLayer = self.parameterAsRasterLayer(parameters, self.INPUT, context)
@@ -96,4 +96,4 @@ class pct2rgb(GdalAlgorithm):
         if self.parameterAsBoolean(parameters, self.RGBA, context):
             arguments.append('-rgba')
 
-        return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
+        return [self.commandName() + ('.bat' if isWindows() else '.py'), GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/algs/gdal/polygonize.py
+++ b/python/plugins/processing/algs/gdal/polygonize.py
@@ -91,7 +91,7 @@ class polygonize(GdalAlgorithm):
         return QIcon(os.path.join(pluginPath, 'images', 'gdaltools', 'polygonize.png'))
 
     def commandName(self):
-        return 'gdal_polygonize.bat' if isWindows() else 'gdal_polygonize.py'
+        return 'gdal_polygonize'
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
         arguments = []
@@ -124,4 +124,4 @@ class polygonize(GdalAlgorithm):
             arguments.append(layerName)
         arguments.append(self.parameterAsString(parameters, self.FIELD, context))
 
-        return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
+        return [self.commandName() + ('.bat' if isWindows() else '.py'), GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/algs/gdal/proximity.py
+++ b/python/plugins/processing/algs/gdal/proximity.py
@@ -139,7 +139,7 @@ class proximity(GdalAlgorithm):
         return 'rasteranalysis'
 
     def commandName(self):
-        return 'gdal_proximity.bat' if isWindows() else 'gdal_proximity.py'
+        return 'gdal_proximity'
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
         inLayer = self.parameterAsRasterLayer(parameters, self.INPUT, context)
@@ -197,4 +197,4 @@ class proximity(GdalAlgorithm):
         arguments.append(inLayer.source())
         arguments.append(out)
 
-        return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
+        return [self.commandName() + ('.bat' if isWindows() else '.py'), GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/algs/gdal/retile.py
+++ b/python/plugins/processing/algs/gdal/retile.py
@@ -161,7 +161,7 @@ class retile(GdalAlgorithm):
         return 'rastermiscellaneous'
 
     def commandName(self):
-        return "gdal_retile.bat" if isWindows() else "gdal_retile.py"
+        return "gdal_retile"
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
         arguments = [
@@ -216,4 +216,4 @@ class retile(GdalAlgorithm):
         layers = [l.source() for l in self.parameterAsLayerList(parameters, self.INPUT, context)]
         arguments.extend(layers)
 
-        return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
+        return [self.commandName() + ('.bat' if isWindows() else '.py'), GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/algs/gdal/rgb2pct.py
+++ b/python/plugins/processing/algs/gdal/rgb2pct.py
@@ -72,7 +72,7 @@ class rgb2pct(GdalAlgorithm):
         return QIcon(os.path.join(pluginPath, 'images', 'gdaltools', '24-to-8-bits.png'))
 
     def commandName(self):
-        return 'rgb2pct.bat' if isWindows() else 'rgb2pct.py'
+        return 'rgb2pct'
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
@@ -91,4 +91,4 @@ class rgb2pct(GdalAlgorithm):
             out
         ]
 
-        return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
+        return [self.commandName() + ('.bat' if isWindows() else '.py'), GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/algs/gdal/sieve.py
+++ b/python/plugins/processing/algs/gdal/sieve.py
@@ -94,7 +94,7 @@ class sieve(GdalAlgorithm):
         return QIcon(os.path.join(pluginPath, 'images', 'gdaltools', 'sieve.png'))
 
     def commandName(self):
-        return 'gdal_sieve.bat' if isWindows() else 'gdal_sieve.py'
+        return 'gdal_sieve'
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
         arguments = [
@@ -131,4 +131,4 @@ class sieve(GdalAlgorithm):
         arguments.append(raster.source())
         arguments.append(out)
 
-        return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
+        return [self.commandName() + ('.bat' if isWindows() else '.py'), GdalUtils.escapeAndJoin(arguments)]


### PR DESCRIPTION
Partially revert 570972b22707533

- gdal_calc command is gdal_calc.py, not gdal_calc
- commandName() method is used for more than just the command line
generation, so move extension handling to getConsoleCommands() only
