### PR TITLE
Fix crash in point cloud layer properties

### DIFF
--- a/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
+++ b/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
@@ -40,7 +40,7 @@ QgsPointCloudLayer3DRendererWidget::QgsPointCloudLayer3DRendererWidget( QgsPoint
   connect( mWidgetPointCloudSymbol, &QgsPointCloud3DSymbolWidget::changed, this, &QgsPointCloudLayer3DRendererWidget::widgetChanged );
 }
 
-void QgsPointCloudLayer3DRendererWidget::setRenderer( const QgsPointCloudLayer3DRenderer *renderer )
+void QgsPointCloudLayer3DRendererWidget::setRenderer( const QgsPointCloudLayer3DRenderer *renderer, QgsPointCloudLayer *layer )
 {
   if ( renderer != nullptr )
   {
@@ -48,8 +48,9 @@ void QgsPointCloudLayer3DRendererWidget::setRenderer( const QgsPointCloudLayer3D
     mWidgetPointCloudSymbol->setPointBudget( renderer->pointRenderingBudget() );
     mWidgetPointCloudSymbol->setMaximumScreenError( renderer->maximumScreenError() );
     mWidgetPointCloudSymbol->setShowBoundingBoxes( renderer->showBoundingBoxes() );
-    mWidgetPointCloudSymbol->setPointCloudSize( renderer->layer()->pointCount() );
   }
+  if ( layer )
+    mWidgetPointCloudSymbol->setPointCloudSize( layer->pointCount() );
 }
 
 QgsPointCloudLayer3DRenderer *QgsPointCloudLayer3DRendererWidget::renderer()
@@ -84,7 +85,7 @@ void QgsPointCloudLayer3DRendererWidget::syncToLayer( QgsMapLayer *layer )
     pointCloudRenderer = static_cast<QgsPointCloudLayer3DRenderer *>( r );
     pointCloudRenderer->setSymbol( mWidgetPointCloudSymbol->symbol() );
   }
-  setRenderer( pointCloudRenderer );
+  setRenderer( pointCloudRenderer, qobject_cast< QgsPointCloudLayer * >( layer ) );
   mWidgetPointCloudSymbol->setEnabled( true );
 }
 
@@ -111,7 +112,7 @@ QgsMapLayerConfigWidget *QgsPointCloudLayer3DRendererWidgetFactory::createWidget
     return nullptr;
   QgsPointCloudLayer3DRendererWidget *widget = new QgsPointCloudLayer3DRendererWidget( pointCloudLayer, canvas, parent );
   if ( pointCloudLayer )
-    widget->setRenderer( dynamic_cast<QgsPointCloudLayer3DRenderer *>( pointCloudLayer->renderer3D() ) );
+    widget->setRenderer( dynamic_cast<QgsPointCloudLayer3DRenderer *>( pointCloudLayer->renderer3D() ), pointCloudLayer );
   return widget;
 }
 

--- a/src/app/3d/qgspointcloudlayer3drendererwidget.h
+++ b/src/app/3d/qgspointcloudlayer3drendererwidget.h
@@ -40,7 +40,7 @@ class QgsPointCloudLayer3DRendererWidget : public QgsMapLayerConfigWidget
     void setDockMode( bool dockMode ) override;
 
     //! no transfer of ownership
-    void setRenderer( const QgsPointCloudLayer3DRenderer *renderer );
+    void setRenderer( const QgsPointCloudLayer3DRenderer *renderer, QgsPointCloudLayer *layer );
     //! no transfer of ownership
     QgsPointCloudLayer3DRenderer *renderer();
 


### PR DESCRIPTION
Don't assume that 3d renderer has a layer ref -- this is usually
only set by Qgs3DMapScene

Fixes #41722
