### PR TITLE
Revert "[gdal] Enable multi-threaded whenever possible"

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -345,13 +345,6 @@ void QgsApplication::init( QString profileFolder )
   }
   *sSystemEnvVars() = systemEnvVarMap;
 
-#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,2,0)
-  if ( CPLGetConfigOption( "GDAL_NUM_THREADS", nullptr ) == nullptr )
-  {
-    CPLSetConfigOption( "GDAL_NUM_THREADS", "ALL_CPUS" );
-  }
-#endif
-
   // append local user-writable folder as a proj search path
   QStringList currentProjSearchPaths = QgsProjUtils::searchPaths();
   currentProjSearchPaths.append( qgisSettingsDirPath() + QStringLiteral( "proj" ) );


### PR DESCRIPTION
## Description

Without that, the georeferencer issue still lives on. We can revisit whenever we find a way to fix the georeferencer.

