### PR TITLE
[gdal] Fix loading of rasters using a vsi prefix and add test

### DIFF
--- a/src/core/providers/gdal/qgsgdalproviderbase.cpp
+++ b/src/core/providers/gdal/qgsgdalproviderbase.cpp
@@ -349,7 +349,6 @@ QVariantMap QgsGdalProviderBase::decodeGdalUri( const QString &uri )
   if ( path.contains( '|' ) )
   {
     const QRegularExpression openOptionRegex( QStringLiteral( "\\|option:([^|]*)" ) );
-
     while ( true )
     {
       QRegularExpressionMatch match = openOptionRegex.match( path );
@@ -370,19 +369,24 @@ QVariantMap QgsGdalProviderBase::decodeGdalUri( const QString &uri )
   uriComponents.insert( QStringLiteral( "layerName" ), layerName );
   if ( !openOptions.isEmpty() )
     uriComponents.insert( QStringLiteral( "openOptions" ), openOptions );
+  if ( !vsiPrefix.isEmpty() )
+    uriComponents.insert( QStringLiteral( "vsiPrefix" ), vsiPrefix );
   return uriComponents;
 }
 
 QString QgsGdalProviderBase::encodeGdalUri( const QVariantMap &parts )
 {
-  QString path = parts.value( QStringLiteral( "path" ) ).toString();
-  QString layerName = parts.value( QStringLiteral( "layerName" ) ).toString();
-  QString uri;
+  const QString vsiPrefix = parts.value( QStringLiteral( "vsiPrefix" ) ).toString();
+  const QString path = parts.value( QStringLiteral( "path" ) ).toString();
+  const QString layerName = parts.value( QStringLiteral( "layerName" ) ).toString();
 
+  QString uri;
   if ( !layerName.isEmpty() && path.endsWith( QLatin1String( "gpkg" ) ) )
     uri = QStringLiteral( "GPKG:%1:%2" ).arg( path, layerName );
+  else if ( !layerName.isEmpty() )
+    uri = path + QStringLiteral( "|%1" ).arg( layerName );
   else
-    uri = path + ( !layerName.isEmpty() ? QStringLiteral( "|%1" ).arg( layerName ) : QString() );
+    uri = path;
 
   const QStringList openOptions = parts.value( QStringLiteral( "openOptions" ) ).toStringList();
 
@@ -392,7 +396,7 @@ QString QgsGdalProviderBase::encodeGdalUri( const QVariantMap &parts )
     uri += openOption;
   }
 
-  return uri;
+  return !vsiPrefix.isEmpty() ? vsiPrefix + uri : uri;
 }
 
 ///@endcond

--- a/tests/src/core/testqgsgdalprovider.cpp
+++ b/tests/src/core/testqgsgdalprovider.cpp
@@ -103,6 +103,11 @@ void TestQgsGdalProvider::decodeUri()
   QCOMPARE( components[QStringLiteral( "path" )].toString(), QStringLiteral( "/home/to/path/my_file.gpkg" ) );
   QCOMPARE( components[QStringLiteral( "layerName" )].toString(), QStringLiteral( "layer_name" ) );
 
+  uri = QStringLiteral( "/vsizip//home/to/path/file.zip/my.tif" );
+  components = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "gdal" ), uri );
+  QCOMPARE( components[QStringLiteral( "path" )].toString(), QStringLiteral( "/home/to/path/file.zip/my.tif" ) );
+  QCOMPARE( components[QStringLiteral( "vsiPrefix" )].toString(), QStringLiteral( "/vsizip/" ) );
+
   //test windows path
   uri = QStringLiteral( "gpkg:c:/home/to/path/my_file.gpkg:layer_name" );
   components = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "gdal" ), uri );
@@ -118,6 +123,11 @@ void TestQgsGdalProvider::encodeUri()
 
   parts.insert( QStringLiteral( "layerName" ), QStringLiteral( "layername" ) );
   QCOMPARE( QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "gdal" ), parts ), QStringLiteral( "GPKG:/home/user/test.gpkg:layername" ) );
+
+  parts.clear();
+  parts.insert( QStringLiteral( "path" ), QStringLiteral( "/home/user/test.zip/my.tif" ) );
+  parts.insert( QStringLiteral( "vsiPrefix" ), QStringLiteral( "/vsizip/" ) );
+  QCOMPARE( QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "gdal" ), parts ), QStringLiteral( "/vsizip//home/user/test.zip/my.tif" ) );
 }
 
 void TestQgsGdalProvider::scaleDataType()


### PR DESCRIPTION
This PR fixes a 3.18 regression whereas /vsi*/ prefixed gdal URIs (e.g. /vsizip/my/file.zip/raster.tif) wouldn't load anymore :fear:

I've also added an encodeUri/decodeUri test case to insure that's not regressing anymore.