### PR TITLE
DXF export: fix crash when opening dialog

### DIFF
--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -29,6 +29,7 @@
 
 class QgsLayerTreeGroup;
 class QgsLayerTreeNode;
+class QgsVectorLayerAndAttributeModel;
 
 class FieldSelectorDelegate : public QItemDelegate
 {
@@ -39,6 +40,10 @@ class FieldSelectorDelegate : public QItemDelegate
     QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
     void setEditorData( QWidget *editor, const QModelIndex &index ) const override;
     void setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const override;
+
+  private:
+    static QgsVectorLayerAndAttributeModel *sourceModelAndIndex( QAbstractItemModel *model, const QModelIndex &proxyIndex, QModelIndex &srcIndex );
+    static const QgsVectorLayerAndAttributeModel *sourceModelAndIndex( const QAbstractItemModel *model, const QModelIndex &proxyIndex, QModelIndex &srcIndex );
 };
 
 class QgsVectorLayerAndAttributeModel : public QgsLayerTreeModel
@@ -106,6 +111,8 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
 
   private:
     void cleanGroup( QgsLayerTreeNode *node );
+    QgsVectorLayerAndAttributeModel *layerTreeModel();
+    const QgsVectorLayerAndAttributeModel *layerTreeModel() const;
     QgsLayerTree *mLayerTreeGroup = nullptr;
     FieldSelectorDelegate *mFieldSelectorDelegate = nullptr;
 


### PR DESCRIPTION
This is due to the changes done in https://github.com/qgis/QGIS/pull/39577
in which QgsLayerTreeView no longer uses the model set with setModel(),
but wraps it in a QgsLayerTreeProxyModel.
QgsDxfExportDialog expected QgsLayerTreeView::model() to return the model
it provided.

Note: the fix is probably incomplete. I noticed that when using
Select all/Unselect all, the view isn't automatically refreshed. One must
trigger a redraw (like resizing the dialog) to see the effect.

@nyalldawson @elpaso You might want to follow-up for the remaining issue I mention above