### PR TITLE
Update rasterize.py

### DIFF
--- a/python/plugins/processing/algs/gdal/rasterize.py
+++ b/python/plugins/processing/algs/gdal/rasterize.py
@@ -84,9 +84,9 @@ class rasterize(GdalAlgorithm):
                                                        defaultValue=0.0,
                                                        optional=True))
         self.addParameter(QgsProcessingParameterBoolean(self.USE_Z,
-                                                       self.tr('Burn value extracted from the "Z" values of the feature'),
-                                                       defaultValue=False,
-                                                       optional=True))
+                                                        self.tr('Burn value extracted from the "Z" values of the feature'),
+                                                        defaultValue=False,
+                                                        optional=True))
         self.addParameter(QgsProcessingParameterEnum(self.UNITS,
                                                      self.tr('Output raster size units'),
                                                      self.units))

--- a/python/plugins/processing/algs/gdal/rasterize.py
+++ b/python/plugins/processing/algs/gdal/rasterize.py
@@ -47,6 +47,7 @@ class rasterize(GdalAlgorithm):
     INPUT = 'INPUT'
     FIELD = 'FIELD'
     BURN = 'BURN'
+    USE_Z = 'USE_Z'
     WIDTH = 'WIDTH'
     HEIGHT = 'HEIGHT'
     UNITS = 'UNITS'
@@ -81,6 +82,10 @@ class rasterize(GdalAlgorithm):
                                                        self.tr('A fixed value to burn'),
                                                        type=QgsProcessingParameterNumber.Double,
                                                        defaultValue=0.0,
+                                                       optional=True))
+        self.addParameter(QgsProcessingParameterBoolean(self.USE_Z,
+                                                       self.tr('Burn value extracted from the "Z" values of the feature'),
+                                                       defaultValue=False,
                                                        optional=True))
         self.addParameter(QgsProcessingParameterEnum(self.UNITS,
                                                      self.tr('Output raster size units'),
@@ -171,7 +176,10 @@ class rasterize(GdalAlgorithm):
             layerName
         ]
         fieldName = self.parameterAsString(parameters, self.FIELD, context)
-        if fieldName:
+        use_z = self.parameterAsBoolean(parameters, self.USE_Z, context)
+        if use_z:
+            arguments.append('-3d')
+        elif fieldName:
             arguments.append('-a')
             arguments.append(fieldName)
         else:

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -1610,9 +1610,9 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'USE_Z': True,
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
                 ['gdal_rasterize',
-                '-l pointsz -3d -ts 0.0 0.0 -ot Float32 -of JPEG' +
-                source + ' ' +
-                outdir + '/check.jpg'])
+                 '-l pointsz -3d -ts 0.0 0.0 -ot Float32 -of JPEG ' +
+                 sourceZ + ' ' +
+                 outdir + '/check.jpg'])
 
     def testRasterizeOver(self):
         context = QgsProcessingContext()

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -1538,6 +1538,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
         context = QgsProcessingContext()
         feedback = QgsProcessingFeedback()
         source = os.path.join(testDataPath, 'polys.gml')
+        sourceZ = os.path.join(testDataPath, 'pointsz.gml')
         alg = rasterize()
         alg.initAlgorithm()
 
@@ -1591,6 +1592,27 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                  '-l polys2 -a id -ts 0.0 0.0 -ot Float32 -of JPEG -at -add ' +
                  source + ' ' +
                  outdir + '/check.jpg'])
+
+            # use_Z selected with no field
+            self.asserEqual(
+                alg.getConsoleCommands({'INPUT': sourceZ,
+                                        'USE_Z': True,
+                                        'OUTPUT': outdir + '/check.jpg'}, context, feedback),
+                ['gdal_rasterize',
+                '-l pointsz -3d -ts 0.0 0.0 -ot Float32 -of JPEG' +
+                source + ' ' +
+                outdir + '/check.jpg'])
+
+            # use_Z selected with field indicated (should prefer use_Z)
+            self.asserEqual(
+                alg.getConsoleCommands({'INPUT': sourceZ,
+                                        'FIELD': 'elev',
+                                        'USE_Z': True,
+                                        'OUTPUT': outdir + '/check.jpg'}, context, feedback),
+                ['gdal_rasterize',
+                '-l pointsz -3d -ts 0.0 0.0 -ot Float32 -of JPEG' +
+                source + ' ' +
+                outdir + '/check.jpg'])
 
     def testRasterizeOver(self):
         context = QgsProcessingContext()

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -1599,9 +1599,9 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'USE_Z': True,
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
                 ['gdal_rasterize',
-                '-l pointsz -3d -ts 0.0 0.0 -ot Float32 -of JPEG' +
-                source + ' ' +
-                outdir + '/check.jpg'])
+                 '-l pointsz -3d -ts 0.0 0.0 -ot Float32 -of JPEG ' +
+                 sourceZ + ' ' +
+                 outdir + '/check.jpg'])
 
             # use_Z selected with field indicated (should prefer use_Z)
             self.assertEqual(

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -1594,7 +1594,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                  outdir + '/check.jpg'])
 
             # use_Z selected with no field
-            self.asserEqual(
+            self.assertEqual(
                 alg.getConsoleCommands({'INPUT': sourceZ,
                                         'USE_Z': True,
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
@@ -1604,7 +1604,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 outdir + '/check.jpg'])
 
             # use_Z selected with field indicated (should prefer use_Z)
-            self.asserEqual(
+            self.assertEqual(
                 alg.getConsoleCommands({'INPUT': sourceZ,
                                         'FIELD': 'elev',
                                         'USE_Z': True,


### PR DESCRIPTION
## Description

Included the possibility to use Z of feature to extract burn values (fixes issue reported in  #41896)

## Detailed description

Referring to latest documentation available [here](https://docs.qgis.org/3.16/en/docs/user_manual/processing_algs/gdal/vectorconversion.html#rasterize-vector-to-raster), this PR includes a new parameter to the plugin.

The PR affects [rasterize (vector to layer)](https://github.com/qgis/QGIS-Documentation/blob/master/docs/user_manual/processing_algs/gdal/vectorconversion.rst#parameters-3) with the user having the possibility to specify of using Z value of features to extract burn values:

The description of the parameter (to be inserted after the parameter [BURN]) is:

**Label**: Burn value extracted from the "Z" values of the feature [Optional]
**Name**: USE_Z
**Type**: [boolean] Default False
**Description**: Indicates that a burn value should be extracted from the “Z” values of the feature. Works with points and lines (linear interpolation along each segment). For polygons, works properly only if the are flat (same Z value for all vertices)