### PR TITLE
Custom Label checkbox in the Legend Item Properties (fixes #41384)

### DIFF
--- a/src/gui/layout/qgslayoutlegendwidget.h
+++ b/src/gui/layout/qgslayoutlegendwidget.h
@@ -198,6 +198,7 @@ class GUI_EXPORT QgsLayoutLegendNodeWidget: public QgsPanelWidget, private Ui::Q
     void patchChanged();
     void insertExpression();
     void sizeChanged( double );
+    void customLabelChanged();
     void customSymbolChanged();
     void colorRampLegendChanged();
     void columnBreakToggled( bool checked );

--- a/src/ui/layout/qgslayoutlegendnodewidgetbase.ui
+++ b/src/ui/layout/qgslayoutlegendnodewidgetbase.ui
@@ -29,7 +29,10 @@
    <item row="0" column="0" colspan="2">
     <widget class="QGroupBox" name="mLabelGroup">
      <property name="title">
-      <string>Label</string>
+      <string>Custom Label</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="0">


### PR DESCRIPTION
Here is a proposition to add a "Custom Label" checkbox in the Legend Item Properties for layers and legend nodes.

As described in the issue #41384, there's not really an intuitive way to revert to NOT using a custom label. Deleting the custom label for a legend node will revert to its original value, but not for layers. You just end up with a blank line and a symbol. Also, it could be nice to avoid deleting the custom label to get back to the original layer/node value. Personally, since the "Custom label" exists in the Legend Item Properties, I always thought it was missing a checkbox to enable/disable the custom label and add to the awesomeness of this feature.

I also think the "Custom Label" checkbox blends in very well in the UI, specially considering there's the same option for "Custom Symbol".

The feature is built on the already existing Custom Label feature so it stores the values in the project file as custom properties (one for the custom label value when the box is disabled and another for the state of the checkbox).

(fixes #41384)

![Peek 2021-02-27 14-53](https://user-images.githubusercontent.com/59714546/109399061-738c2700-790e-11eb-8921-114345ceeb10.gif)
