### PR TITLE
[gdal][ui] Fix opening of gdal rasters within ZIP containers in the data source manager dialog

### DIFF
--- a/python/gui/auto_generated/qgsabstractdatasourcewidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractdatasourcewidget.sip.in
@@ -87,6 +87,15 @@ Emitted when a DB layer has been selected for addition
 Emitted when a raster layer has been selected for addition
 %End
 
+    void addRasterLayers( const QStringList &layersList );
+%Docstring
+Emitted when one or more GDAL supported layers are selected for addition
+
+:param layersList: list of layers protocol URIs
+
+.. versionadded:: 3.20
+%End
+
     void addVectorLayer( const QString &uri, const QString &layerName, const QString &providerKey = QString() );
 %Docstring
 Emitted when a vector layer has been selected for addition.

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -168,13 +168,7 @@ void QgsGdalSourceSelect::addButtonClicked()
     return;
   }
 
-  for ( const QString &dataSource : mDataSources )
-  {
-    if ( QFile::exists( dataSource ) )
-      emit addRasterLayer( dataSource, QFileInfo( dataSource ).completeBaseName(), QStringLiteral( "gdal" ) );
-    else
-      emit addRasterLayer( dataSource, dataSource, QStringLiteral( "gdal" ) );
-  }
+  emit addRasterLayers( mDataSources );
 }
 
 void QgsGdalSourceSelect::computeDataSources()

--- a/src/gui/qgsabstractdatasourcewidget.h
+++ b/src/gui/qgsabstractdatasourcewidget.h
@@ -101,6 +101,13 @@ class GUI_EXPORT QgsAbstractDataSourceWidget : public QDialog
     void addRasterLayer( const QString &rasterLayerPath, const QString &baseName, const QString &providerKey );
 
     /**
+     * Emitted when one or more GDAL supported layers are selected for addition
+     * \param layersList list of layers protocol URIs
+     * \since 3.20
+     */
+    void addRasterLayers( const QStringList &layersList );
+
+    /**
      * Emitted when a vector layer has been selected for addition.
      *
      * If \a providerKey is not specified, the default provider key associated with the source

--- a/src/gui/qgsdatasourcemanagerdialog.cpp
+++ b/src/gui/qgsdatasourcemanagerdialog.cpp
@@ -136,6 +136,11 @@ void QgsDataSourceManagerDialog::rasterLayerAdded( const QString &uri, const QSt
   emit addRasterLayer( uri, baseName, providerKey );
 }
 
+void QgsDataSourceManagerDialog::rasterLayersAdded( const QStringList &layersList )
+{
+  emit addRasterLayers( layersList );
+}
+
 void QgsDataSourceManagerDialog::vectorLayerAdded( const QString &vectorLayerPath, const QString &baseName, const QString &providerKey )
 {
   emit addVectorLayer( vectorLayerPath, baseName, providerKey );
@@ -188,6 +193,8 @@ void QgsDataSourceManagerDialog::makeConnections( QgsAbstractDataSourceWidget *d
   {
     addRasterLayer( uri, baseName, providerKey );
   } );
+  connect( dlg, &QgsAbstractDataSourceWidget::addRasterLayers,
+           this, &QgsDataSourceManagerDialog::rasterLayersAdded );
   // Mesh
   connect( dlg, &QgsAbstractDataSourceWidget::addMeshLayer, this, &QgsDataSourceManagerDialog::addMeshLayer );
   // Vector tile

--- a/src/gui/qgsdatasourcemanagerdialog.h
+++ b/src/gui/qgsdatasourcemanagerdialog.h
@@ -77,10 +77,14 @@ class GUI_EXPORT QgsDataSourceManagerDialog : public QgsOptionsDialogBase, priva
 
     // TODO: use this with an internal source select dialog instead of forwarding the whole raster selection to app
 
-    /**
-     * A raster layer was added: for signal forwarding to QgisApp
-     */
+    //! A raster layer was added: for signal forwarding to QgisApp
     void rasterLayerAdded( QString const &uri, QString const &baseName, QString const &providerKey );
+
+    /**
+     * One or more raster layer were added: for signal forwarding to QgisApp
+     * \since QGIS 3.20
+     */
+    void rasterLayersAdded( const QStringList &layersList );
     //! A vector layer was added: for signal forwarding to QgisApp
     void vectorLayerAdded( const QString &vectorLayerPath, const QString &baseName, const QString &providerKey );
     //! One or more vector layer were added: for signal forwarding to QgisApp
@@ -103,10 +107,17 @@ class GUI_EXPORT QgsDataSourceManagerDialog : public QgsOptionsDialogBase, priva
     void showEvent( QShowEvent *event ) override;
 
   signals:
+
+    /**
+     * Emitted when a one or more layer were selected for addition: for signal forwarding to QgisApp
+     * \since QGIS 3.20
+     */
+    void addRasterLayers( const QStringList &layersList );
     //! Emitted when a raster layer was selected for addition: for signal forwarding to QgisApp
     void addRasterLayer( const QString &uri, const QString &baseName, const QString &providerKey );
     //! Emitted when the user wants to select a raster layer: for signal forwarding to QgisApp
     void addRasterLayer();
+
     //! Emitted when a vector layer was selected for addition: for signal forwarding to QgisApp
     void addVectorLayer( const QString &vectorLayerPath, const QString &baseName, const QString &providerKey );
 


### PR DESCRIPTION
## Description

Stumbled on this UI/UX gap: using the data source manager dialog's raster (i.e. GDAL) panel, it was not possible to open a ZIP file to select raster dataset(s) embedded within the archived container.

This PR fixes that.