### PR TITLE
Allow some derived attributes in non single click identify on vector layers

### DIFF
--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -651,8 +651,10 @@ bool QgsMapToolIdentify::identifyVectorLayer( QList<QgsMapToolIdentify::Identify
 
     featureCount++;
 
-    if ( isSingleClick )
-      derivedAttributes.unite( featureDerivedAttributes( feature, layer, toLayerCoordinates( layer, point ) ) );
+    // When not single click identify, pass an empty point so some derived attributes may still be computed
+    if ( !isSingleClick )
+      point = QgsPointXY();
+    derivedAttributes.unite( featureDerivedAttributes( feature, layer, toLayerCoordinates( layer, point ) ) );
 
     derivedAttributes.insert( tr( "Feature ID" ), fid < 0 ? tr( "new feature" ) : FID_TO_STRING( fid ) );
 
@@ -770,8 +772,11 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
   {
     geometryType = feature.geometry().type();
     wkbType = feature.geometry().wkbType();
-    //find closest vertex to clicked point
-    closestPoint = QgsGeometryUtils::closestVertex( *feature.geometry().constGet(), QgsPoint( layerPoint ), vId );
+    if ( !layerPoint.isEmpty() )
+    {
+      //find closest vertex to clicked point
+      closestPoint = QgsGeometryUtils::closestVertex( *feature.geometry().constGet(), QgsPoint( layerPoint ), vId );
+    }
   }
 
 
@@ -780,8 +785,11 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
   {
     QString str = QLocale().toString( static_cast<const QgsGeometryCollection *>( feature.geometry().constGet() )->numGeometries() );
     derivedAttributes.insert( tr( "Parts" ), str );
-    str = QLocale().toString( vId.part + 1 );
-    derivedAttributes.insert( tr( "Part number" ), str );
+    if ( !layerPoint.isEmpty() )
+    {
+      str = QLocale().toString( vId.part + 1 );
+      derivedAttributes.insert( tr( "Part number" ), str );
+    }
   }
 
   QgsUnitTypes::DistanceUnit cartesianDistanceUnits = QgsUnitTypes::unitType( layer->crs().mapUnits() ) == QgsUnitTypes::unitType( displayDistanceUnits() )
@@ -817,9 +825,12 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
     {
       str = QLocale().toString( geom->nCoordinates() );
       derivedAttributes.insert( tr( "Vertices" ), str );
-      //add details of closest vertex to identify point
-      closestVertexAttributes( *geom, vId, layer, derivedAttributes );
-      closestPointAttributes( *geom, layerPoint, derivedAttributes );
+      if ( !layerPoint.isEmpty() )
+      {
+        //add details of closest vertex to identify point
+        closestVertexAttributes( *geom, vId, layer, derivedAttributes );
+        closestPointAttributes( *geom, layerPoint, derivedAttributes );
+      }
 
       if ( const QgsCurve *curve = qgsgeometry_cast< const QgsCurve * >( geom ) )
       {
@@ -865,9 +876,12 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
     str = QLocale().toString( feature.geometry().constGet()->nCoordinates() );
     derivedAttributes.insert( tr( "Vertices" ), str );
 
-    //add details of closest vertex to identify point
-    closestVertexAttributes( *feature.geometry().constGet(), vId, layer, derivedAttributes );
-    closestPointAttributes( *feature.geometry().constGet(), layerPoint, derivedAttributes );
+    if ( !layerPoint.isEmpty() )
+    {
+      //add details of closest vertex to identify point
+      closestVertexAttributes( *feature.geometry().constGet(), vId, layer, derivedAttributes );
+      closestPointAttributes( *feature.geometry().constGet(), layerPoint, derivedAttributes );
+    }
   }
   else if ( geometryType == QgsWkbTypes::PointGeometry )
   {
@@ -895,9 +909,10 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
     {
       //multipart
 
-      //add details of closest vertex to identify point
-      const QgsAbstractGeometry *geom = feature.geometry().constGet();
+      if ( !layerPoint.isEmpty() )
       {
+        //add details of closest vertex to identify point
+        const QgsAbstractGeometry *geom = feature.geometry().constGet();
         closestVertexAttributes( *geom, vId, layer, derivedAttributes );
       }
     }


### PR DESCRIPTION
## Description
When identifying vector layers by rectangle, polygon, freehand or radius, the derived attributes only show the Feature ID.
This PR allows the derived attributes that do not depend on a single identify point to be populated, ie all but *Clicked coordinates*, *Closest ...* ones and *Part number*.

Fixes: #40296
<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
