### PR TITLE
Revert "Fix snapping on segment when layer CRS is different from project CRS

### DIFF
--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -462,8 +462,8 @@ int QgsMapToolCapture::fetchLayerPoint( const QgsPointLocator::Match &match, Qgs
 {
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mCanvas->currentLayer() );
   QgsVectorLayer *sourceLayer = match.layer();
-  if ( match.isValid() && ( match.hasVertex() || ( QgsProject::instance()->topologicalEditing() && ( match.hasEdge() || match.hasMiddleSegment() ) ) ) && sourceLayer )
-
+  if ( match.isValid() && ( match.hasVertex() || ( QgsProject::instance()->topologicalEditing() && ( match.hasEdge() || match.hasMiddleSegment() ) ) ) && sourceLayer &&
+       ( sourceLayer->crs() == vlayer->crs() ) )
   {
     QgsFeature f;
     QgsFeatureRequest request;
@@ -483,34 +483,7 @@ int QgsMapToolCapture::fetchLayerPoint( const QgsPointLocator::Match &match, Qgs
           return 2;
         QgsLineString line( geom.constGet()->vertexAt( vId ), geom.constGet()->vertexAt( vId2 ) );
 
-        QgsPoint pt( match.point() );
-        // Transform point to sourceLayer crs, since vId and vId2 coordinates are in sourceLayer crs
-        if ( sourceLayer->crs() != QgsProject::instance()->crs() )
-        {
-          try
-          {
-            pt.transform( QgsCoordinateTransform( QgsProject::instance()->crs(), sourceLayer->crs(), sourceLayer->transformContext() ) );
-          }
-          catch ( QgsCsException &cse )
-          {
-            Q_UNUSED( cse )
-            QgsDebugMsg( QStringLiteral( "transformation to layer coordinate failed" ) );
-            return 2;
-          }
-        }
-        layerPoint = QgsGeometryUtils::closestPoint( line,  pt );
-        // (re)Transform layerPoint to vlayer crs
-        try
-        {
-          layerPoint.transform( QgsCoordinateTransform( sourceLayer->crs(), vlayer->crs(), vlayer->transformContext() ) );
-        }
-        catch ( QgsCsException &cse )
-        {
-          Q_UNUSED( cse )
-          QgsDebugMsg( QStringLiteral( "transformation to layer coordinate failed" ) );
-          return 2;
-        }
-
+        layerPoint = QgsGeometryUtils::closestPoint( line,  QgsPoint( match.point() ) );
       }
       else
       {


### PR DESCRIPTION
This reverts commit e11b21e954301c1fe317652be36b67da0ff932af.

This change TOTALLY broke digitizing using snapping to features in other layers