### PR TITLE
Add a shortcut action to toggle labels in the vector layer right click menu

### DIFF
--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -189,7 +189,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         const QString iconName = vlayer && vlayer->labeling() && vlayer->labeling()->type() == QLatin1String( "rule-based" )
                                  ? QStringLiteral( "labelingRuleBased.svg" )
                                  : QStringLiteral( "labelingSingle.svg" );
-        QAction *actionShowLabels = new QAction( QgsApplication::getThemeIcon( iconName ), tr( "Show Labels" ), menu );
+        QAction *actionShowLabels = new QAction( QgsApplication::getThemeIcon( iconName ), tr( "Show &Labels" ), menu );
         actionShowLabels->setCheckable( true );
         actionShowLabels->setChecked( vlayer->labelsEnabled() );
         const QString layerId = vlayer->id();
@@ -362,7 +362,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         if ( !layer->isInScaleRange( mCanvas->scale() ) )
           menu->addAction( tr( "Zoom to &Visible Scale" ), QgisApp::instance(), &QgisApp::zoomToLayerScale );
 
-        QMenu *menuSetCRS = new QMenu( tr( "&Layer CRS" ), menu );
+        QMenu *menuSetCRS = new QMenu( tr( "La&yer CRS" ), menu );
 
         const QList<QgsLayerTreeNode *> selectedNodes = mView->selectedNodes();
         QgsCoordinateReferenceSystem layerCrs;

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -358,7 +358,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         if ( !layer->isInScaleRange( mCanvas->scale() ) )
           menu->addAction( tr( "Zoom to &Visible Scale" ), QgisApp::instance(), &QgisApp::zoomToLayerScale );
 
-        QMenu *menuSetCRS = new QMenu( tr( "La&yer CRS" ), menu );
+        QMenu *menuSetCRS = new QMenu( tr( "Layer CRS" ), menu );
 
         const QList<QgsLayerTreeNode *> selectedNodes = mView->selectedNodes();
         QgsCoordinateReferenceSystem layerCrs;

--- a/src/app/qgsapplayertreeviewmenuprovider.h
+++ b/src/app/qgsapplayertreeviewmenuprovider.h
@@ -72,7 +72,7 @@ class QgsAppLayerTreeViewMenuProvider : public QObject, public QgsLayerTreeViewM
     void pasteSymbolLegendNodeSymbol( const QString &layerId, const QString &ruleKey );
     void setSymbolLegendNodeColor( const QColor &color );
     void setLayerCrs( const QgsCoordinateReferenceSystem &crs );
-    void toggleLabels( const QString &layerId, bool enabled );
+    void toggleLabels( bool enabled );
   private:
     bool removeActionEnabled();
 };

--- a/src/app/qgsapplayertreeviewmenuprovider.h
+++ b/src/app/qgsapplayertreeviewmenuprovider.h
@@ -72,6 +72,7 @@ class QgsAppLayerTreeViewMenuProvider : public QObject, public QgsLayerTreeViewM
     void pasteSymbolLegendNodeSymbol( const QString &layerId, const QString &ruleKey );
     void setSymbolLegendNodeColor( const QColor &color );
     void setLayerCrs( const QgsCoordinateReferenceSystem &crs );
+    void toggleLabels( const QString &layerId, bool enabled );
   private:
     bool removeActionEnabled();
 };


### PR DESCRIPTION
Allows for labels to be quickly switched on or off, without losing the label configuration. If a layer has never had labeling configured and the action is checked then a default simple labeling is added to the layer.

Refs Natural resources Canada Contract: 3000720707

![Peek 2021-03-01 16-05](https://user-images.githubusercontent.com/1829991/109458119-eed51080-7aa7-11eb-9af6-9519c3afd398.gif)

