### PR TITLE
Disable the prefetching of images from OWS services, and add advanced setting to enable it

### DIFF
--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -191,11 +191,6 @@ showDeprecated=false
 # Default timeout for PostgreSQL servers (seconds)
 PostgreSQL\default_timeout=30
 
-# If the wmsprovider (WMS, WMTS, XYZ) is allowed to prefetch surrounding tiles and images
-# Defaults to false to minimize the amount of requests to services
-# Set to true if you want some more visible candy (as in prefetching the surrounding images)
-wmsprovider\prefetch_allowed=false
-
 [gui]
 # Maximum number of entries to show in Relation Reference widgets. Too large a number here can
 # cause performance issues, as the records must all be loaded from the related table on display.

--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -191,6 +191,11 @@ showDeprecated=false
 # Default timeout for PostgreSQL servers (seconds)
 PostgreSQL\default_timeout=30
 
+# If the wmsprovider (WMS, WMTS, XYZ) is allowed to prefetch surrounding tiles and images
+# Defaults to false to minimize the amount of requests to services
+# Set to true if you want some more visible candy (as in prefetching the surrounding images)
+wmsprovider\prefetch_allowed=false
+
 [gui]
 # Maximum number of entries to show in Relation Reference widgets. Too large a number here can
 # cause performance issues, as the records must all be loaded from the related table on display.

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2015,7 +2015,8 @@ int QgsWmsProvider::capabilities() const
   // See https://github.com/qgis/QGIS/issues/34813
   if ( mSettings.mTiled && !( mSettings.mXyz && dataSourceUri().contains( QStringLiteral( "openstreetmap.org" ) ) ) )
   {
-    capability |= Capability::Prefetch;
+    // March 2021: *never* prefetch tile based layers, see: https://github.com/qgis/QGIS/pull/41953
+    // capability |= Capability::Prefetch;
   }
 
   QgsDebugMsgLevel( QStringLiteral( "capability = %1" ).arg( capability ), 2 );

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2015,7 +2015,12 @@ int QgsWmsProvider::capabilities() const
   // See https://github.com/qgis/QGIS/issues/34813
   if ( mSettings.mTiled && !( mSettings.mXyz && dataSourceUri().contains( QStringLiteral( "openstreetmap.org" ) ) ) )
   {
-    capability |= Capability::Prefetch;
+    // but only if the user explicitly set prefetching to allowed
+    QgsSettings settings;
+    if ( settings.value( QStringLiteral( "providers/wmsprovider/prefetch_allowed" ), false ).toBool() )
+    {
+      capability |= Capability::Prefetch;
+    }
   }
 
   QgsDebugMsgLevel( QStringLiteral( "capability = %1" ).arg( capability ), 2 );

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2015,12 +2015,7 @@ int QgsWmsProvider::capabilities() const
   // See https://github.com/qgis/QGIS/issues/34813
   if ( mSettings.mTiled && !( mSettings.mXyz && dataSourceUri().contains( QStringLiteral( "openstreetmap.org" ) ) ) )
   {
-    // but only if the user explicitly set prefetching to allowed
-    QgsSettings settings;
-    if ( settings.value( QStringLiteral( "providers/wmsprovider/prefetch_allowed" ), false ).toBool() )
-    {
-      capability |= Capability::Prefetch;
-    }
+    capability |= Capability::Prefetch;
   }
 
   QgsDebugMsgLevel( QStringLiteral( "capability = %1" ).arg( capability ), 2 );


### PR DESCRIPTION
See:
https://lists.osgeo.org/pipermail/qgis-developer/2021-February/063165.html
and a followup of
https://github.com/qgis/QGIS/pull/41832
I think the prefetching of OWS services should be defaulting to False
and only be done if explicitly set by the user

I think we should not deliberatly stress OWS services or burn cpu cycles
just to have a slightly better user experience.

As an example:
Load the 'opentopo' WMTS layer from:
https://geodata.nationaalgeoregister.nl/wmts?VERSION=1.0.0&request=GetCapabilities&SERVICE=WMS&REQUEST=GetCapabilities
and zoom in and out (especially shift-mouse-drag is a request eater)...
Before and after setting the "providers/wmsprovider/prefetch_allowed" to true or false in the Advanced Settings Editor