### PR TITLE
Followup "Show user-friendly explanation if las/laz files cannot be used on their QGIS install"

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7648,8 +7648,9 @@ bool QgisApp::openLayer( const QString &fileName, bool allowInteractive )
     ok = static_cast< bool >( addMeshLayerPrivate( fileName, fileInfo.completeBaseName(), QStringLiteral( "mdal" ), false ) );
   }
 
-  // maybe a known file type, which couldn't be opened due to a missing dependency... (eg. las for a non-pdal-enabled build)
+  if ( !ok )
   {
+    // maybe a known file type, which couldn't be opened due to a missing dependency... (eg. las for a non-pdal-enabled build)
     QgsProviderRegistry::UnusableUriDetails details;
     if ( QgsProviderRegistry::instance()->handleUnusableUri( fileName, details ) )
     {


### PR DESCRIPTION
Fix logic error