### PR TITLE
Support vector and raster mime URIs at the same time

### DIFF
--- a/python/core/auto_generated/qgsdataitem.sip.in
+++ b/python/core/auto_generated/qgsdataitem.sip.in
@@ -246,7 +246,7 @@ A draggable item has to implement :py:func:`~QgsDataItem.mimeUri` that will be u
 .. versionadded:: 3.0
 %End
 
- virtual QgsMimeDataUtils::Uri mimeUri() const;
+ virtual QgsMimeDataUtils::Uri mimeUri() const /Deprecated/;
 %Docstring
 Returns mime URI for the data item.
 Items that return valid URI will be returned in mime data when dragging a selection from browser model.

--- a/python/core/auto_generated/qgsdataitem.sip.in
+++ b/python/core/auto_generated/qgsdataitem.sip.in
@@ -239,9 +239,9 @@ double-click behavior for items.
 %Docstring
 Returns ``True`` if the item may be dragged.
 Default implementation returns ``False``.
-A draggable item has to implement :py:func:`~QgsDataItem.mimeUri` that will be used to pass data.
+A draggable item has to implement :py:func:`~QgsDataItem.mimeUris` that will be used to pass data.
 
-.. seealso:: :py:func:`mimeUri`
+.. seealso:: :py:func:`mimeUris`
 
 .. versionadded:: 3.0
 %End
@@ -551,7 +551,7 @@ Item that represents a layer that can be opened with one of the providers
 
     virtual bool hasDragEnabled() const;
 
-    virtual QgsMimeDataUtils::Uri mimeUri() const;
+    virtual QgsMimeDataUtils::UriList mimeUris() const;
 
 
 
@@ -856,7 +856,7 @@ Returns the full path to the directory the item represents.
  virtual QWidget *paramWidget() /Factory,Deprecated/;
 
     virtual bool hasDragEnabled() const;
-    virtual QgsMimeDataUtils::Uri mimeUri() const;
+    virtual QgsMimeDataUtils::UriList mimeUris() const;
 
 
     static bool hiddenPath( const QString &path );
@@ -897,7 +897,7 @@ A data item holding a reference to a QGIS project file.
 
     virtual bool hasDragEnabled() const;
 
-    virtual QgsMimeDataUtils::Uri mimeUri() const;
+    virtual QgsMimeDataUtils::UriList mimeUris() const;
 
 
 };

--- a/python/core/auto_generated/qgsdataitem.sip.in
+++ b/python/core/auto_generated/qgsdataitem.sip.in
@@ -246,14 +246,28 @@ A draggable item has to implement :py:func:`~QgsDataItem.mimeUri` that will be u
 .. versionadded:: 3.0
 %End
 
-    virtual QgsMimeDataUtils::Uri mimeUri() const;
+ virtual QgsMimeDataUtils::Uri mimeUri() const;
 %Docstring
 Returns mime URI for the data item.
 Items that return valid URI will be returned in mime data when dragging a selection from browser model.
 
 .. seealso:: :py:func:`hasDragEnabled`
 
+.. deprecated:: QGIS 3.18
+  use :py:func:`~QgsDataItem.mimeUris` instead
+
 .. versionadded:: 3.0
+%End
+
+    virtual QgsMimeDataUtils::UriList mimeUris() const;
+%Docstring
+Returns mime URIs for the data item, most data providers will only return a single URI
+but some data collection items (e.g. GPKG, OGR) may report multiple URIs (e.g. for vector and
+raster layer types).
+
+Items that return valid URI will be returned in mime data when dragging a selection from browser model.
+
+.. versionadded:: 3.18
 %End
 
     enum Capability

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -602,7 +602,7 @@ void QgsLayerItemGuiProvider::addLayersFromItems( const QList<QgsDataItem *> &it
     if ( item && item->type() == QgsDataItem::Layer )
     {
       if ( QgsLayerItem *layerItem = qobject_cast<QgsLayerItem *>( item ) )
-        layerUriList << layerItem->mimeUri();
+        layerUriList.append( layerItem->mimeUris() );
     }
   }
   if ( !layerUriList.isEmpty() )

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -566,7 +566,7 @@ bool QgsLayerItemGuiProvider::handleDoubleClick( QgsDataItem *item, QgsDataItemG
 
   if ( QgsLayerItem *layerItem = qobject_cast<QgsLayerItem *>( item ) )
   {
-    const QgsMimeDataUtils::UriList layerUriList = QgsMimeDataUtils::UriList() << layerItem->mimeUri();
+    const QgsMimeDataUtils::UriList layerUriList = layerItem->mimeUris();
     QgisApp::instance()->handleDropUriList( layerUriList );
     return true;
   }

--- a/src/core/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/core/providers/ogr/qgsgeopackagedataitems.cpp
@@ -375,8 +375,7 @@ bool QgsGeoPackageVectorLayerItem::executeDeleteLayer( QString &errCause )
   else
   {
     errCause = QObject::tr( "There was an error deleting '%1' on '%2'!" )
-               .arg( tableName )
-               .arg( parent()->path() );
+               .arg( tableName, parent()->path() );
     return false;
   }
   return true;
@@ -395,11 +394,14 @@ bool QgsGeoPackageCollectionItem::hasDragEnabled() const
   return true;
 }
 
-QgsMimeDataUtils::Uri QgsGeoPackageCollectionItem::mimeUri() const
+QgsMimeDataUtils::UriList QgsGeoPackageCollectionItem::mimeUris() const
 {
-  QgsMimeDataUtils::Uri u;
-  u.providerKey = QStringLiteral( "ogr" );
-  u.uri = path();
-  u.layerType = QStringLiteral( "vector" );
-  return u;
+  QgsMimeDataUtils::Uri vectorUri;
+  vectorUri.providerKey = QStringLiteral( "ogr" );
+  vectorUri.uri = path();
+  vectorUri.layerType = QStringLiteral( "vector" );
+  QgsMimeDataUtils::Uri rasterUri { vectorUri };
+  rasterUri.layerType = QStringLiteral( "raster" );
+  rasterUri.providerKey = QStringLiteral( "gdal" );
+  return { vectorUri, rasterUri };
 }

--- a/src/core/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/core/providers/ogr/qgsgeopackagedataitems.h
@@ -66,7 +66,7 @@ class CORE_EXPORT QgsGeoPackageCollectionItem : public QgsDataCollectionItem
   public:
     bool layerCollection() const override;
     bool hasDragEnabled() const override;
-    QgsMimeDataUtils::Uri mimeUri() const override;
+    QgsMimeDataUtils::UriList mimeUris() const override;
 };
 
 

--- a/src/core/providers/ogr/qgsogrdataitems.cpp
+++ b/src/core/providers/ogr/qgsogrdataitems.cpp
@@ -452,13 +452,16 @@ bool QgsOgrDataCollectionItem::hasDragEnabled() const
   return true;
 }
 
-QgsMimeDataUtils::Uri QgsOgrDataCollectionItem::mimeUri() const
+QgsMimeDataUtils::UriList QgsOgrDataCollectionItem::mimeUris() const
 {
-  QgsMimeDataUtils::Uri u;
-  u.providerKey = QStringLiteral( "ogr" );
-  u.uri = path();
-  u.layerType = QStringLiteral( "vector" );
-  return u;
+  QgsMimeDataUtils::Uri vectorUri;
+  vectorUri.providerKey = QStringLiteral( "ogr" );
+  vectorUri.uri = path();
+  vectorUri.layerType = QStringLiteral( "vector" );
+  QgsMimeDataUtils::Uri rasterUri { vectorUri };
+  rasterUri.layerType = QStringLiteral( "raster" );
+  rasterUri.providerKey = QStringLiteral( "gdal" );
+  return { vectorUri, rasterUri };
 }
 
 QgsAbstractDatabaseProviderConnection *QgsOgrDataCollectionItem::databaseConnection() const

--- a/src/core/providers/ogr/qgsogrdataitems.h
+++ b/src/core/providers/ogr/qgsogrdataitems.h
@@ -131,7 +131,7 @@ class CORE_EXPORT QgsOgrDataCollectionItem final: public QgsDataCollectionItem
     static bool createConnection( const QString &name, const QString &extensions, const QString &ogrDriverName );
 
     bool hasDragEnabled() const override;
-    QgsMimeDataUtils::Uri mimeUri() const override;
+    QgsMimeDataUtils::UriList mimeUris() const override;
 
     QgsAbstractDatabaseProviderConnection *databaseConnection() const override;
 

--- a/src/core/qgsbrowsermodel.cpp
+++ b/src/core/qgsbrowsermodel.cpp
@@ -633,9 +633,11 @@ QMimeData *QgsBrowserModel::mimeData( const QModelIndexList &indexes ) const
     if ( index.isValid() )
     {
       QgsDataItem *ptr = reinterpret_cast< QgsDataItem * >( index.internalPointer() );
-      QgsMimeDataUtils::Uri uri = ptr->mimeUri();
-      if ( uri.isValid() )
+      const QgsMimeDataUtils::UriList uris = ptr->mimeUris();
+      for ( const auto &uri : qgis::as_const( uris ) )
+      {
         lst.append( uri );
+      }
     }
   }
   return QgsMimeDataUtils::encodeUriList( lst );

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -817,6 +817,11 @@ bool QgsDataItem::handleDoubleClick()
   return false;
 }
 
+QgsMimeDataUtils::Uri QgsDataItem::mimeUri() const
+{
+  return mimeUris().isEmpty() ? QgsMimeDataUtils::Uri() : mimeUris().first();
+}
+
 bool QgsDataItem::rename( const QString & )
 {
   return false;

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -1009,7 +1009,7 @@ bool QgsLayerItem::equal( const QgsDataItem *other )
   return ( mPath == o->mPath && mName == o->mName && mUri == o->mUri && mProviderKey == o->mProviderKey );
 }
 
-QgsMimeDataUtils::Uri QgsLayerItem::mimeUri() const
+QgsMimeDataUtils::UriList QgsLayerItem::mimeUris() const
 {
   QgsMimeDataUtils::Uri u;
 
@@ -1069,7 +1069,7 @@ QgsMimeDataUtils::Uri QgsLayerItem::mimeUri() const
   u.uri = uri();
   u.supportedCrs = supportedCrs();
   u.supportedFormats = supportedFormats();
-  return u;
+  return { u };
 }
 
 // ---------------------------------------------------------------------
@@ -1352,13 +1352,13 @@ QWidget *QgsDirectoryItem::paramWidget()
   return new QgsDirectoryParamWidget( mPath );
 }
 
-QgsMimeDataUtils::Uri QgsDirectoryItem::mimeUri() const
+QgsMimeDataUtils::UriList QgsDirectoryItem::mimeUris() const
 {
   QgsMimeDataUtils::Uri u;
   u.layerType = QStringLiteral( "directory" );
   u.name = mName;
   u.uri = mDirPath;
-  return u;
+  return { u };
 }
 
 QgsDirectoryParamWidget::QgsDirectoryParamWidget( const QString &path, QWidget *parent )
@@ -1510,13 +1510,13 @@ QgsProjectItem::QgsProjectItem( QgsDataItem *parent, const QString &name,
   setState( Populated ); // no more children
 }
 
-QgsMimeDataUtils::Uri QgsProjectItem::mimeUri() const
+QgsMimeDataUtils::UriList QgsProjectItem::mimeUris() const
 {
   QgsMimeDataUtils::Uri u;
   u.layerType = QStringLiteral( "project" );
   u.name = mName;
   u.uri = mPath;
-  return u;
+  return { u };
 }
 
 QgsErrorItem::QgsErrorItem( QgsDataItem *parent, const QString &error, const QString &path )

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -250,8 +250,8 @@ class CORE_EXPORT QgsDataItem : public QObject
     /**
      * Returns TRUE if the item may be dragged.
      * Default implementation returns FALSE.
-     * A draggable item has to implement mimeUri() that will be used to pass data.
-     * \see mimeUri()
+     * A draggable item has to implement mimeUris() that will be used to pass data.
+     * \see mimeUris()
      * \since QGIS 3.0
      */
     virtual bool hasDragEnabled() const { return false; }
@@ -582,7 +582,7 @@ class CORE_EXPORT QgsLayerItem : public QgsDataItem
 
     bool hasDragEnabled() const override { return true; }
 
-    QgsMimeDataUtils::Uri mimeUri() const override;
+    QgsMimeDataUtils::UriList mimeUris() const override;
 
     // --- New virtual methods for layer item derived classes ---
 
@@ -852,7 +852,7 @@ class CORE_EXPORT QgsDirectoryItem : public QgsDataCollectionItem
     QIcon icon() override;
     Q_DECL_DEPRECATED QWidget *paramWidget() override SIP_FACTORY SIP_DEPRECATED;
     bool hasDragEnabled() const override { return true; }
-    QgsMimeDataUtils::Uri mimeUri() const override;
+    QgsMimeDataUtils::UriList mimeUris() const override;
 
     //! Check if the given path is hidden from the browser model
     static bool hiddenPath( const QString &path );
@@ -891,7 +891,7 @@ class CORE_EXPORT QgsProjectItem : public QgsDataItem
 
     bool hasDragEnabled() const override { return true; }
 
-    QgsMimeDataUtils::Uri mimeUri() const override;
+    QgsMimeDataUtils::UriList mimeUris() const override;
 
 };
 

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -260,9 +260,23 @@ class CORE_EXPORT QgsDataItem : public QObject
      * Returns mime URI for the data item.
      * Items that return valid URI will be returned in mime data when dragging a selection from browser model.
      * \see hasDragEnabled()
+     * \deprecated since QGIS 3.18, use mimeUris() instead
      * \since QGIS 3.0
      */
-    virtual QgsMimeDataUtils::Uri mimeUri() const { return QgsMimeDataUtils::Uri(); }
+    Q_DECL_DEPRECATED virtual QgsMimeDataUtils::Uri mimeUri() const
+    {
+      return mimeUris().isEmpty() ? QgsMimeDataUtils::Uri() : mimeUris().first();
+    }
+
+    /**
+     * Returns mime URIs for the data item, most data providers will only return a single URI
+     * but some data collection items (e.g. GPKG, OGR) may report multiple URIs (e.g. for vector and
+     * raster layer types).
+     *
+     * Items that return valid URI will be returned in mime data when dragging a selection from browser model.
+     * \since QGIS 3.18
+     */
+    virtual QgsMimeDataUtils::UriList mimeUris() const { return QgsMimeDataUtils::UriList(); }
 
     enum Capability
     {

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -263,10 +263,7 @@ class CORE_EXPORT QgsDataItem : public QObject
      * \deprecated since QGIS 3.18, use mimeUris() instead
      * \since QGIS 3.0
      */
-    Q_DECL_DEPRECATED virtual QgsMimeDataUtils::Uri mimeUri() const
-    {
-      return mimeUris().isEmpty() ? QgsMimeDataUtils::Uri() : mimeUris().first();
-    }
+    Q_DECL_DEPRECATED virtual QgsMimeDataUtils::Uri mimeUri() const SIP_DEPRECATED;
 
     /**
      * Returns mime URIs for the data item, most data providers will only return a single URI

--- a/src/gui/qgsbrowserdockwidget.cpp
+++ b/src/gui/qgsbrowserdockwidget.cpp
@@ -356,9 +356,7 @@ void QgsBrowserDockWidget::addLayer( QgsLayerItem *layerItem )
   if ( !layerItem )
     return;
 
-  QgsMimeDataUtils::UriList list;
-  list << layerItem->mimeUri();
-  emit handleDropUriList( list );
+  emit handleDropUriList( layerItem->mimeUris() );
 }
 
 bool QgsBrowserDockWidget::addLayerAtIndex( const QModelIndex &index )

--- a/src/gui/qgsdatasourceselectdialog.cpp
+++ b/src/gui/qgsdatasourceselectdialog.cpp
@@ -286,7 +286,7 @@ void QgsDataSourceSelectWidget::onLayerSelected( const QModelIndex &index )
                           ( layerItem->mapLayerType() == mBrowserProxyModel.layerType() ) ) )
       {
         isLayerCompatible = true;
-        mUri = layerItem->mimeUri();
+        mUri = layerItem->mimeUris().isEmpty() ? QgsMimeDataUtils::Uri() : layerItem->mimeUris().first();
         // Store last viewed item
         QgsSettings().setValue( QStringLiteral( "datasourceSelectLastSelectedItem" ),  mBrowserProxyModel.data( index, QgsBrowserGuiModel::PathRole ).toString(), QgsSettings::Section::Gui );
       }

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -416,7 +416,8 @@ bool QgsWMSLayerCollectionItem::hasDragEnabled() const
   return false;
 }
 
-QgsMimeDataUtils::Uri QgsWMSLayerCollectionItem::mimeUri() const
+
+QgsMimeDataUtils::UriList QgsWMSLayerCollectionItem::mimeUris() const
 {
   QgsMimeDataUtils::Uri u;
 
@@ -427,7 +428,7 @@ QgsMimeDataUtils::Uri QgsWMSLayerCollectionItem::mimeUri() const
   u.supportedCrs = mLayerProperty.crs;
   u.supportedFormats = mCapabilitiesProperty.capability.request.getMap.format;
 
-  return u;
+  return { u };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/providers/wms/qgswmsdataitems.h
+++ b/src/providers/wms/qgswmsdataitems.h
@@ -98,7 +98,7 @@ class QgsWMSLayerCollectionItem : public QgsDataCollectionItem, public QgsWMSIte
 
     bool hasDragEnabled() const override;
 
-    QgsMimeDataUtils::Uri mimeUri() const override;
+    QgsMimeDataUtils::UriList mimeUris() const override;
 
   protected:
     //! The URI

--- a/tests/src/core/testqgsdataitem.cpp
+++ b/tests/src/core/testqgsdataitem.cpp
@@ -118,7 +118,7 @@ void TestQgsDataItem::testDirItem()
   QCOMPARE( dirItem->name(), QStringLiteral( "Test" ) );
 
   QVERIFY( dirItem->hasDragEnabled() );
-  QgsMimeDataUtils::Uri mime = dirItem->mimeUri();
+  QgsMimeDataUtils::Uri mime = dirItem->mimeUris().isEmpty() ? QgsMimeDataUtils::Uri() : dirItem->mimeUris().first();
   QVERIFY( mime.isValid() );
   QCOMPARE( mime.uri, QStringLiteral( TEST_DATA_DIR ) );
   QCOMPARE( mime.layerType, QStringLiteral( "directory" ) );


### PR DESCRIPTION
Fixes #41563

This is the alternate approach for solving #41563, instead of  https://github.com/qgis/QGIS/pull/41693.

There are pros and cons in both cases, I think I like this better despite being a kind of API break (deprecating the singular form).
 