### PR TITLE
fix Select Features by wrong Rectangle/Polygon

### DIFF
--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -243,7 +243,7 @@ QgsFeatureIds QgsMapToolSelectUtils::getMatchingFeatures( QgsMapCanvas *canvas, 
   {
     // a zero width buffer is safer than calling make valid here!
     selectGeomTrans = selectGeomTrans.buffer( 0, 1 );
-    if ( selectGeomTrans.isNull() || selectGeomTrans.isEmpty() )
+    if ( selectGeomTrans.isEmpty() )
       return newSelectedFeatures;
   }
 

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -243,6 +243,8 @@ QgsFeatureIds QgsMapToolSelectUtils::getMatchingFeatures( QgsMapCanvas *canvas, 
   {
     // a zero width buffer is safer than calling make valid here!
     selectGeomTrans = selectGeomTrans.buffer( 0, 1 );
+    if ( selectGeomTrans.isNull() || selectGeomTrans.isEmpty() )
+      return newSelectedFeatures;
   }
 
   std::unique_ptr< QgsGeometryEngine > selectionGeometryEngine( QgsGeometry::createGeometryEngine( selectGeomTrans.constGet() ) );


### PR DESCRIPTION
If we select Features by wrong Rectangle/Polygon, we will start fetching all the objects in the layer from the data provider.
In some cases, the function GEOS geom.buffer(...) may return empty Polygon.
Python code example:
```
>>> testPoly = QgsGeometry.fromPolygonXY([[QgsPointXY(1, 1), QgsPointXY(2, 2), QgsPointXY(2, 2)]])
>>> print(testPoly.buffer( 0, 1 ))
<QgsGeometry: Polygon EMPTY>
```