### PR TITLE
Fix #41977

### DIFF
--- a/src/analysis/processing/qgsalgorithmcellstatistics.cpp
+++ b/src/analysis/processing/qgsalgorithmcellstatistics.cpp
@@ -163,7 +163,7 @@ QString QgsCellStatisticsAlgorithm::displayName() const
 
 QString QgsCellStatisticsAlgorithm::name() const
 {
-  return QObject::tr( "cellstatistics" );
+  return QStringLiteral( "cellstatistics" );
 }
 
 QStringList QgsCellStatisticsAlgorithm::tags() const

--- a/src/analysis/processing/qgsalgorithmcellstatistics.cpp
+++ b/src/analysis/processing/qgsalgorithmcellstatistics.cpp
@@ -377,7 +377,7 @@ QString QgsCellStatisticsPercentileAlgorithm::displayName() const
 
 QString QgsCellStatisticsPercentileAlgorithm::name() const
 {
-  return QObject::tr( "cellstackpercentile" );
+  return QStringLiteral( "cellstackpercentile" );
 }
 
 QStringList QgsCellStatisticsPercentileAlgorithm::tags() const
@@ -520,7 +520,7 @@ QString QgsCellStatisticsPercentRankFromValueAlgorithm::displayName() const
 
 QString QgsCellStatisticsPercentRankFromValueAlgorithm::name() const
 {
-  return QObject::tr( "cellstackpercentrankfromvalue" );
+  return QStringLiteral( "cellstackpercentrankfromvalue" );
 }
 
 QStringList QgsCellStatisticsPercentRankFromValueAlgorithm::tags() const
@@ -656,7 +656,7 @@ QString QgsCellStatisticsPercentRankFromRasterAlgorithm::displayName() const
 
 QString QgsCellStatisticsPercentRankFromRasterAlgorithm::name() const
 {
-  return QObject::tr( "cellstackpercentrankfromrasterlayer" );
+  return QStringLiteral( "cellstackpercentrankfromrasterlayer" );
 }
 
 QStringList QgsCellStatisticsPercentRankFromRasterAlgorithm::tags() const

--- a/src/analysis/processing/qgsalgorithmrasterfrequencybycomparisonoperator.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterfrequencybycomparisonoperator.cpp
@@ -234,7 +234,7 @@ QString QgsRasterFrequencyByEqualOperatorAlgorithm::displayName() const
 
 QString QgsRasterFrequencyByEqualOperatorAlgorithm::name() const
 {
-  return QObject::tr( "equaltofrequency" );
+  return QStringLiteral( "equaltofrequency" );
 }
 
 QStringList QgsRasterFrequencyByEqualOperatorAlgorithm::tags() const
@@ -277,7 +277,7 @@ QString QgsRasterFrequencyByGreaterThanOperatorAlgorithm::displayName() const
 
 QString QgsRasterFrequencyByGreaterThanOperatorAlgorithm::name() const
 {
-  return QObject::tr( "greaterthanfrequency" );
+  return QStringLiteral( "greaterthanfrequency" );
 }
 
 QStringList QgsRasterFrequencyByGreaterThanOperatorAlgorithm::tags() const
@@ -320,7 +320,7 @@ QString QgsRasterFrequencyByLessThanOperatorAlgorithm::displayName() const
 
 QString QgsRasterFrequencyByLessThanOperatorAlgorithm::name() const
 {
-  return QObject::tr( "lessthanfrequency" );
+  return QStringLiteral( "lessthanfrequency" );
 }
 
 QStringList QgsRasterFrequencyByLessThanOperatorAlgorithm::tags() const

--- a/src/analysis/processing/qgsalgorithmrasterstackposition.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterstackposition.cpp
@@ -212,7 +212,7 @@ QString QgsRasterStackLowestPositionAlgorithm::displayName() const
 
 QString QgsRasterStackLowestPositionAlgorithm::name() const
 {
-  return QObject::tr( "lowestpositioninrasterstack" );
+  return QStringLiteral( "lowestpositioninrasterstack" );
 }
 
 QStringList QgsRasterStackLowestPositionAlgorithm::tags() const
@@ -315,7 +315,7 @@ QString QgsRasterStackHighestPositionAlgorithm::displayName() const
 
 QString QgsRasterStackHighestPositionAlgorithm::name() const
 {
-  return QObject::tr( "highestpositioninrasterstack" );
+  return QStringLiteral( "highestpositioninrasterstack" );
 }
 
 QStringList QgsRasterStackHighestPositionAlgorithm::tags() const


### PR DESCRIPTION
QgsCellStatisticsAlgorithm::name() should not return a translatable string.

