### PR TITLE
Don't silently swallow exceptions in python context managers

### DIFF
--- a/python/core/additions/projectdirtyblocker.py
+++ b/python/core/additions/projectdirtyblocker.py
@@ -44,4 +44,4 @@ class ProjectDirtyBlocker():
 
     def __exit__(self, ex_type, ex_value, traceback):
         del self.blocker
-        return True
+        return ex_type is None

--- a/python/core/additions/readwritecontextentercategory.py
+++ b/python/core/additions/readwritecontextentercategory.py
@@ -43,4 +43,4 @@ class ReadWriteContextEnterCategory():
 
     def __exit__(self, ex_type, ex_value, traceback):
         del self.popper
-        return True
+        return ex_type is None

--- a/python/core/additions/runtimeprofiler.py
+++ b/python/core/additions/runtimeprofiler.py
@@ -43,4 +43,4 @@ class ScopedRuntimeProfileContextManager():
 
     def __exit__(self, ex_type, ex_value, traceback):
         del self.profiler
-        return True
+        return ex_type is None

--- a/python/plugins/db_manager/db_plugins/vlayers/connector.py
+++ b/python/plugins/db_manager/db_plugins/vlayers/connector.py
@@ -45,8 +45,9 @@ class sqlite3_connection(object):
     def __enter__(self):
         return self.conn
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, ex_type, value, traceback):
         self.conn.close()
+        return ex_type is None
 
 
 def getQueryGeometryName(sqlite_file):

--- a/python/utils.py
+++ b/python/utils.py
@@ -716,6 +716,7 @@ class OverrideCursor():
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         QApplication.restoreOverrideCursor()
+        return exc_type is None
 
 
 #######################


### PR DESCRIPTION
Notably this causes processing modules to silently fail to load
without any warnings if the required dependancies (such as pyscopg2)
are not installed

Fixes https://github.com/qgis/QGIS/issues/41984
