### PR TITLE
Fix crash when using GEOS to calculate shortest distance to an empty geometry

### DIFF
--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -2274,7 +2274,7 @@ QgsGeometry QgsGeos::closestPoint( const QgsGeometry &other, QString *errorMsg )
 
 QgsGeometry QgsGeos::shortestLine( const QgsGeometry &other, QString *errorMsg ) const
 {
-  if ( !mGeos || other.isNull() )
+  if ( !mGeos || other.isEmpty() )
   {
     return QgsGeometry();
   }
@@ -2284,6 +2284,9 @@ QgsGeometry QgsGeos::shortestLine( const QgsGeometry &other, QString *errorMsg )
 
 QgsGeometry QgsGeos::shortestLine( const QgsAbstractGeometry *other, QString *errorMsg ) const
 {
+  if ( !other || other->isEmpty() )
+    return QgsGeometry();
+
   geos::unique_ptr otherGeom( asGeos( other, mPrecision ) );
   if ( !otherGeom )
   {
@@ -2297,6 +2300,13 @@ QgsGeometry QgsGeos::shortestLine( const QgsAbstractGeometry *other, QString *er
   try
   {
     geos::coord_sequence_unique_ptr nearestCoord( GEOSNearestPoints_r( geosinit()->ctxt, mGeos.get(), otherGeom.get() ) );
+
+    if ( !nearestCoord )
+    {
+      if ( errorMsg )
+        *errorMsg = QStringLiteral( "GEOS returned no nearest points" );
+      return QgsGeometry();
+    }
 
     ( void )GEOSCoordSeq_getX_r( geosinit()->ctxt, nearestCoord.get(), 0, &nx1 );
     ( void )GEOSCoordSeq_getY_r( geosinit()->ctxt, nearestCoord.get(), 0, &ny1 );

--- a/src/core/geometry/qgsinternalgeometryengine.cpp
+++ b/src/core/geometry/qgsinternalgeometryengine.cpp
@@ -260,14 +260,12 @@ QgsGeometry QgsInternalGeometryEngine::poleOfInaccessibility( double precision, 
     int numGeom = gc->numGeometries();
     double maxDist = 0;
     QgsPoint bestPoint;
-    bool found = false;
     for ( int i = 0; i < numGeom; ++i )
     {
       const QgsSurface *surface = qgsgeometry_cast< const QgsSurface * >( gc->geometryN( i ) );
       if ( !surface )
         continue;
 
-      found = true;
       double dist = std::numeric_limits<double>::max();
       QgsPoint p = surfacePoleOfInaccessibility( surface, precision, dist );
       if ( dist > maxDist )
@@ -277,7 +275,7 @@ QgsGeometry QgsInternalGeometryEngine::poleOfInaccessibility( double precision, 
       }
     }
 
-    if ( !found )
+    if ( bestPoint.isEmpty() )
       return QgsGeometry();
 
     if ( distanceFromBoundary )
@@ -292,6 +290,9 @@ QgsGeometry QgsInternalGeometryEngine::poleOfInaccessibility( double precision, 
 
     double dist = std::numeric_limits<double>::max();
     QgsPoint p = surfacePoleOfInaccessibility( surface, precision, dist );
+    if ( p.isEmpty() )
+      return QgsGeometry();
+
     if ( distanceFromBoundary )
       *distanceFromBoundary = dist;
     return QgsGeometry( new QgsPoint( p ) );

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -168,6 +168,7 @@ class TestQgsGeometry : public QObject
     void differenceCheck2();
     void bufferCheck();
     void smoothCheck();
+    void shortestLineEmptyGeometry();
 
     void unaryUnion();
 
@@ -17370,6 +17371,16 @@ void TestQgsGeometry::smoothCheck()
   geom = QgsGeometry::fromWkt( wkt );
   result = geom.smooth( 3 );
   QCOMPARE( result.wkbType(), QgsWkbTypes::Polygon );
+}
+
+void TestQgsGeometry::shortestLineEmptyGeometry()
+{
+  // test calculating distance to an empty geometry
+  // refs https://github.com/qgis/QGIS/issues/41968
+  QgsGeometry geom1( QgsGeometry::fromWkt( QStringLiteral( "Polygon ((0 0, 10 0, 10 10, 0 10, 0 0 ))" ) ) );
+  QgsGeometry geom2( new QgsPoint() );
+  QgsGeos geos( geom1.constGet() );
+  QVERIFY( geos.shortestLine( geom2.constGet() ).isNull() );
 }
 
 void TestQgsGeometry::unaryUnion()


### PR DESCRIPTION
Fixes #41968
