### PR TITLE
[delimitedtext] Fix regression opening files with unicode characters

### DIFF
--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -1262,7 +1262,7 @@ QString  QgsDelimitedTextProvider::description() const
 
 QVariantMap QgsDelimitedTextProviderMetadata::decodeUri( const QString &uri ) const
 {
-  const QUrl url( uri );
+  const QUrl url = QUrl::fromEncoded( uri.toLatin1() );
   const QUrlQuery queryItems( url.query() );
 
   QString subset;
@@ -1309,7 +1309,7 @@ QString QgsDelimitedTextProviderMetadata::encodeUri( const QVariantMap &parts ) 
     queryItems.addQueryItem( QStringLiteral( "subset" ), parts.value( QStringLiteral( "subset" ) ).toString() );
   url.setQuery( queryItems );
 
-  return url.toString();
+  return QString::fromLatin1( url.toEncoded() );
 }
 
 QgsDataProvider *QgsDelimitedTextProviderMetadata::createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags )

--- a/tests/src/python/test_qgsdelimitedtextprovider.py
+++ b/tests/src/python/test_qgsdelimitedtextprovider.py
@@ -951,13 +951,22 @@ class TestQgsDelimitedTextProviderOther(unittest.TestCase):
         vl.dataProvider().createSpatialIndex()
         self.assertEqual(vl.hasSpatialIndex(), QgsFeatureSource.SpatialIndexPresent)
 
-    def testEncodeuri(self):
+    def testEncodeDecodeUri(self):
+        registry = QgsProviderRegistry.instance()
+
         # URI decoding
         filename = '/home/to/path/test.csv'
-        registry = QgsProviderRegistry.instance()
         parts = {'path': filename}
         uri = registry.encodeUri('delimitedtext', parts)
         self.assertEqual(uri, 'file://' + filename)
+
+        # URI encoding / decoding with unicode characters
+        filename = '/höme/to/path/pöints.txt'
+        parts = {'path': filename}
+        uri = registry.encodeUri('delimitedtext', parts)
+        self.assertEqual(uri, 'file:///h%C3%B6me/to/path/p%C3%B6ints.txt')
+        parts = registry.decodeUri('delimitedtext', uri)
+        self.assertEqual(parts['path'], filename)
 
     def testCREndOfLineAndWorkingBuffer(self):
         # Test CSV file with \r (CR) endings


### PR DESCRIPTION
## Description

This fixes #41948, a serious delimited text provider regression that had file paths with non-latin unicode characters fail to open (ouch).