### PR TITLE
Remove "stale" label when a comment is added

### DIFF
--- a/.github/workflows/unstale.yml
+++ b/.github/workflows/unstale.yml
@@ -1,0 +1,16 @@
+name: Remove Labels
+
+on: [issue_comment]
+
+jobs:
+  remove_labels:
+    if: contains(github.event.issue.labels.*.name, 'stale')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-remove-labels@v1
+        if: ${{ github.event.comment.user.url != 'https://github.com/apps/github-actions' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            stale

--- a/.github/workflows/unstale.yml
+++ b/.github/workflows/unstale.yml
@@ -7,7 +7,6 @@ jobs:
     if: contains(github.event.issue.labels.*.name, 'stale')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions-ecosystem/action-remove-labels@v1
         if: ${{ github.event.comment.user.url != 'https://github.com/apps/github-actions' }}
         with:


### PR DESCRIPTION
This means, someone still cares.
We will still need to take care of manually removing the "feedback" label