### PR TITLE
Server accesscontrol getfeatureifo rules clear

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1036,6 +1036,10 @@ namespace QgsWms
     // add layers to map settings
     mapSettings.setLayers( layers );
 
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
+    mContext.accessControl()->resolveFilterFeatures( mapSettings.layers() );
+#endif
+
     QDomDocument result = featureInfoDocument( layers, mapSettings, outputImage.get(), version );
 
     QByteArray ba;


### PR DESCRIPTION
This fixes and unreported bug where access control rules
were not reset in case of getfeatureinfo calls.

Funded by Gis3W https://www.gis3w.it
