### PR TITLE
[Backport 3.18] fix shadow and EDL not being exported with 3D animation tool

### DIFF
--- a/src/3d/qgsoffscreen3dengine.h
+++ b/src/3d/qgsoffscreen3dengine.h
@@ -99,22 +99,6 @@ class _3D_EXPORT QgsOffscreen3DEngine : public QgsAbstract3DEngine
     Qt3DRender::QRenderSettings *mRenderSettings = nullptr;        // The render settings, which control the general rendering behavior.
     Qt3DCore::QNode *mSceneRoot = nullptr;                         // The scene root, which becomes a child of the engine's root entity.
     Qt3DCore::QEntity *mRoot = nullptr;
-
-    // render target stuff
-    Qt3DRender::QRenderTarget *mTextureTarget = nullptr;
-    Qt3DRender::QRenderTargetOutput *mTextureOutput = nullptr;
-    Qt3DRender::QTexture2D *mTexture = nullptr;
-    Qt3DRender::QRenderTargetOutput *mDepthTextureOutput = nullptr;
-    Qt3DRender::QTexture2D *mDepthTexture = nullptr;
-
-    // frame graph stuff
-    Qt3DRender::QRenderSurfaceSelector *mSurfaceSelector = nullptr;
-    Qt3DRender::QRenderTargetSelector *mRenderTargetSelector = nullptr;
-    Qt3DRender::QViewport *mViewport = nullptr;
-    Qt3DRender::QClearBuffers *mClearBuffers = nullptr;
-    Qt3DRender::QCameraSelector *mCameraSelector = nullptr;
-    Qt3DRender::QRenderCapture *mRenderCapture = nullptr;          // The render capture node, which is appended to the frame graph.
-
 };
 
 #endif // QGSOFFSCREEN3DENGINE_H

--- a/src/3d/qgsshadowrenderingframegraph.cpp
+++ b/src/3d/qgsshadowrenderingframegraph.cpp
@@ -408,4 +408,15 @@ void QgsShadowRenderingFrameGraph::setSize( QSize s )
   mSize = s;
   mForwardColorTexture->setSize( mSize.width(), mSize.height() );
   mForwardDepthTexture->setSize( mSize.width(), mSize.height() );
+  mRenderCaptureColorTexture->setSize( mSize.width(), mSize.height() );
+  mRenderCaptureDepthTexture->setSize( mSize.width(), mSize.height() );
+  mRenderSurfaceSelector->setExternalRenderTargetSize( mSize );
+}
+
+void QgsShadowRenderingFrameGraph::setRenderCaptureEnabled( bool enabled )
+{
+  if ( enabled == mRenderCaptureEnabled )
+    return;
+  mRenderCaptureEnabled = enabled;
+  mRenderCaptureTargetSelector->setEnabled( mRenderCaptureEnabled );
 }

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -18,6 +18,7 @@
 #include <QBoxLayout>
 #include <Qt3DExtras/Qt3DWindow>
 #include <Qt3DRender/QRenderCapture>
+#include <Qt3DLogic/QFrameAction>
 #include <QMouseEvent>
 
 
@@ -42,9 +43,10 @@ Qgs3DMapCanvas::Qgs3DMapCanvas( QWidget *parent )
   QgsSettings setting;
   mEngine = new QgsWindow3DEngine( this );
 
-  connect( mEngine, &QgsAbstract3DEngine::imageCaptured, this, [ = ]( const QImage & image )
+  connect( mEngine, &QgsAbstract3DEngine::imageCaptured, [ = ]( const QImage & image )
   {
     image.save( mCaptureFileName, mCaptureFileFormat.toLocal8Bit().data() );
+    mEngine->setRenderCaptureEnabled( false );
     emit savedAsImage( mCaptureFileName );
   } );
 
@@ -179,7 +181,17 @@ void Qgs3DMapCanvas::saveAsImage( const QString fileName, const QString fileForm
   {
     mCaptureFileName = fileName;
     mCaptureFileFormat = fileFormat;
-    mEngine->requestCaptureImage();
+    mEngine->setRenderCaptureEnabled( true );
+    // Setup a frame action that is used to wait until next frame
+    Qt3DLogic::QFrameAction *screenCaptureFrameAction = new Qt3DLogic::QFrameAction;
+    mScene->addComponent( screenCaptureFrameAction );
+    // Wait to have the render capture enabled in the next frame
+    connect( screenCaptureFrameAction, &Qt3DLogic::QFrameAction::triggered, [ = ]( float )
+    {
+      mEngine->requestCaptureImage();
+      mScene->removeComponent( screenCaptureFrameAction );
+      screenCaptureFrameAction->deleteLater();
+    } );
   }
 }
 

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -27,6 +27,11 @@ namespace Qt3DExtras
   class Qt3DWindow;
 }
 
+namespace Qt3DLogic
+{
+  class QFrameAction;
+}
+
 class Qgs3DMapSettings;
 class Qgs3DMapScene;
 class Qgs3DMapTool;
@@ -95,7 +100,7 @@ class Qgs3DMapCanvas : public QWidget
 
   signals:
     //! Emitted when the 3D map canvas was successfully saved as image
-    void savedAsImage( QString fileName );
+    void savedAsImage( const QString &fileName );
 
     //! Emitted when the the map setting is changed
     void mapSettingsChanged();
@@ -135,6 +140,9 @@ class Qgs3DMapCanvas : public QWidget
 
     //! Active map tool that receives events (if NULLPTR then mouse/keyboard events are used for camera manipulation)
     Qgs3DMapTool *mMapTool = nullptr;
+
+    QString mCaptureFileName;
+    QString mCaptureFileFormat;
 
     //! On-Screen Navigation widget.
     Qgs3DNavigationWidget *mNavigationWidget = nullptr;


### PR DESCRIPTION
## Description
Backports https://github.com/qgis/QGIS/pull/41773 to QGIS 3.18