### PR TITLE
Make map capture tool technique handling api more generic

### DIFF
--- a/python/gui/auto_generated/qgsmaptoolcapture.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolcapture.sip.in
@@ -29,6 +29,12 @@ class QgsMapToolCapture : QgsMapToolAdvancedDigitizing
       CapturePolygon
     };
 
+    enum CaptureTechnique
+    {
+      StraightSegments,
+      CircularString,
+    };
+
     enum Capability
     {
       NoCapabilities,
@@ -48,6 +54,13 @@ constructor
     virtual QgsMapToolCapture::Capabilities capabilities() const;
 %Docstring
 Returns flags containing the supported capabilities
+%End
+
+    virtual bool supportsTechnique( CaptureTechnique technique ) const;
+%Docstring
+Returns ``True`` if the tool supports the specified capture ``technique``.
+
+.. versionadded:: 3.20
 %End
 
     virtual void activate();

--- a/python/gui/auto_generated/qgsmaptooldigitizefeature.sip.in
+++ b/python/gui/auto_generated/qgsmaptooldigitizefeature.sip.in
@@ -34,6 +34,8 @@ QgsMapToolDigitizeFeature is a map tool to digitize a feature geometry
 
     virtual QgsMapToolCapture::Capabilities capabilities() const;
 
+    virtual bool supportsTechnique( CaptureTechnique technique ) const;
+
 
     virtual void cadCanvasReleaseEvent( QgsMapMouseEvent *e );
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -71,6 +71,7 @@ class QgsMapLayerConfigWidgetFactory;
 class QgsMapOverviewCanvas;
 class QgsMapTip;
 class QgsMapTool;
+class QgsMapToolCapture;
 class QgsMapToolAddFeature;
 class QgsMapToolDigitizeFeature;
 class QgsMapToolAdvancedDigitizing;
@@ -1966,9 +1967,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     /**
      * Enables the action that toggles digitizing with curve
-     * \since QGIS 3.16
      */
-    void enableDigitizeWithCurveAction( bool enable );
+    void enableDigitizeTechniqueActions( bool enable, QAction *triggeredFromToolAction = nullptr );
 
 #ifdef HAVE_GEOREFERENCER
     void showGeoreferencer();
@@ -2394,6 +2394,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
       public:
 
         Tools() = default;
+
+        /**
+         * Returns a list of all QgsMapToolCapture derived tools.
+         */
+        QList< QgsMapToolCapture * > captureTools() const;
 
         QgsMapTool *mZoomIn = nullptr;
         QgsMapTool *mZoomOut = nullptr;

--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -81,6 +81,17 @@ void QgsMapToolReshape::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   }
 }
 
+bool QgsMapToolReshape::supportsTechnique( QgsMapToolCapture::CaptureTechnique technique ) const
+{
+  switch ( technique )
+  {
+    case QgsMapToolCapture::StraightSegments:
+    case QgsMapToolCapture::CircularString:
+      return true;
+  }
+  return false;
+}
+
 bool QgsMapToolReshape::isBindingLine( QgsVectorLayer *vlayer, const QgsRectangle &bbox ) const
 {
   if ( vlayer->geometryType() != QgsWkbTypes::LineGeometry )
@@ -121,9 +132,18 @@ void QgsMapToolReshape::reshape( QgsVectorLayer *vlayer )
     bbox.combineExtentWith( pointsZM().at( i ).x(), pointsZM().at( i ).y() );
   }
 
-
+  const bool hasCurvedSegments = captureCurve()->hasCurvedSegments();
   QgsPointSequence pts;
-  captureCurve()->points( pts );
+  if ( !hasCurvedSegments )
+  {
+    captureCurve()->points( pts );
+  }
+  else
+  {
+    std::unique_ptr< QgsLineString > segmented( captureCurve()->curveToLine() );
+    segmented->points( pts );
+  }
+
   QgsLineString reshapeLineString( pts );
 
   //query all the features that intersect bounding box of capture line

--- a/src/app/qgsmaptoolreshape.h
+++ b/src/app/qgsmaptoolreshape.h
@@ -27,6 +27,7 @@ class APP_EXPORT QgsMapToolReshape: public QgsMapToolCapture
   public:
     QgsMapToolReshape( QgsMapCanvas *canvas );
     void cadCanvasReleaseEvent( QgsMapMouseEvent *e ) override;
+    bool supportsTechnique( CaptureTechnique technique ) const override;
 
   private:
     void reshape( QgsVectorLayer *vlayer );

--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -30,6 +30,17 @@ QgsMapToolSplitFeatures::QgsMapToolSplitFeatures( QgsMapCanvas *canvas )
   setSnapToLayerGridEnabled( false );
 }
 
+bool QgsMapToolSplitFeatures::supportsTechnique( QgsMapToolCapture::CaptureTechnique technique ) const
+{
+  switch ( technique )
+  {
+    case QgsMapToolCapture::StraightSegments:
+    case QgsMapToolCapture::CircularString:
+      return true;
+  }
+  return false;
+}
+
 void QgsMapToolSplitFeatures::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
 {
   //check if we operate on a vector layer

--- a/src/app/qgsmaptoolsplitfeatures.h
+++ b/src/app/qgsmaptoolsplitfeatures.h
@@ -25,6 +25,7 @@ class APP_EXPORT QgsMapToolSplitFeatures: public QgsMapToolCapture
     Q_OBJECT
   public:
     QgsMapToolSplitFeatures( QgsMapCanvas *canvas );
+    bool supportsTechnique( CaptureTechnique technique ) const override;
     void cadCanvasReleaseEvent( QgsMapMouseEvent *e ) override;
 };
 

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -93,6 +93,11 @@ QgsMapToolCapture::Capabilities QgsMapToolCapture::capabilities() const
   return QgsMapToolCapture::NoCapabilities;
 }
 
+bool QgsMapToolCapture::supportsTechnique( QgsMapToolCapture::CaptureTechnique technique ) const
+{
+  return technique == StraightSegments;
+}
+
 void QgsMapToolCapture::activate()
 {
   if ( mTempRubberBand )

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -134,6 +134,17 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
       CapturePolygon  //!< Capture polygons
     };
 
+    /**
+     * Capture technique.
+     *
+     * \since QGIS 3.20
+     */
+    enum CaptureTechnique
+    {
+      StraightSegments, //!< Default capture mode - capture occurs with straight line segments
+      CircularString, //!< Capture in circular strings
+    };
+
     //! Specific capabilities of the tool
     enum Capability
     {
@@ -152,6 +163,13 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
      * Returns flags containing the supported capabilities
      */
     virtual QgsMapToolCapture::Capabilities capabilities() const;
+
+    /**
+     * Returns TRUE if the tool supports the specified capture \a technique.
+     *
+     * \since QGIS 3.20
+     */
+    virtual bool supportsTechnique( CaptureTechnique technique ) const;
 
     void activate() override;
     void deactivate() override;
@@ -390,6 +408,8 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
   private:
     //! The capture mode in which this tool operates
     CaptureMode mCaptureMode;
+
+
 
     //! Flag to indicate a map canvas capture operation is taking place
     bool mCapturing = false;

--- a/src/gui/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/qgsmaptooldigitizefeature.cpp
@@ -48,6 +48,18 @@ QgsMapToolCapture::Capabilities QgsMapToolDigitizeFeature::capabilities() const
   return QgsMapToolCapture::SupportsCurves;
 }
 
+bool QgsMapToolDigitizeFeature::supportsTechnique( QgsMapToolCapture::CaptureTechnique technique ) const
+{
+  switch ( technique )
+  {
+    case QgsMapToolCapture::StraightSegments:
+      return true;
+    case QgsMapToolCapture::CircularString:
+      return mode() != QgsMapToolCapture::CapturePoint;
+  }
+  return false;
+}
+
 void QgsMapToolDigitizeFeature::digitized( const QgsFeature &f )
 {
   emit digitizingCompleted( f );

--- a/src/gui/qgsmaptooldigitizefeature.h
+++ b/src/gui/qgsmaptooldigitizefeature.h
@@ -43,6 +43,7 @@ class GUI_EXPORT QgsMapToolDigitizeFeature : public QgsMapToolCapture
     QgsMapToolDigitizeFeature( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode = QgsMapToolCapture::CaptureNone );
 
     QgsMapToolCapture::Capabilities capabilities() const override;
+    bool supportsTechnique( CaptureTechnique technique ) const override;
 
     void cadCanvasReleaseEvent( QgsMapMouseEvent *e ) override;
 


### PR DESCRIPTION
Intended to allow easier exposure of the existing circular string capture technique to other map tools, and also easier addition of more capture modes in follow up PRs (specifically, a streaming digitizing mode).

Also exposes the draw circular string tool to the reshape tool as a test of the new api, but also semi-useful in its own right