### PR TITLE
AdvancedDigitizing add Z/M support

### DIFF
--- a/python/core/auto_generated/qgscadutils.sip.in
+++ b/python/core/auto_generated/qgscadutils.sip.in
@@ -39,7 +39,9 @@ The :py:class:`QgsCadUtils` class provides routines for CAD editing.
 
       QgsCadUtils::AlignMapPointConstraint xConstraint;
       QgsCadUtils::AlignMapPointConstraint yConstraint;
+
       QgsCadUtils::AlignMapPointConstraint zConstraint;
+
       QgsCadUtils::AlignMapPointConstraint mConstraint;
       QgsCadUtils::AlignMapPointConstraint distanceConstraint;
       QgsCadUtils::AlignMapPointConstraint angleConstraint;

--- a/python/core/auto_generated/qgscadutils.sip.in
+++ b/python/core/auto_generated/qgscadutils.sip.in
@@ -32,25 +32,6 @@ The :py:class:`QgsCadUtils` class provides routines for CAD editing.
       double value;
     };
 
-    struct AlignMapPointContext
-    {
-      QgsSnappingUtils *snappingUtils;
-      double mapUnitsPerPixel;
-
-      QgsCadUtils::AlignMapPointConstraint xConstraint;
-      QgsCadUtils::AlignMapPointConstraint yConstraint;
-
-      QgsCadUtils::AlignMapPointConstraint zConstraint;
-
-      QgsCadUtils::AlignMapPointConstraint mConstraint;
-      QgsCadUtils::AlignMapPointConstraint distanceConstraint;
-      QgsCadUtils::AlignMapPointConstraint angleConstraint;
-      QgsCadUtils::AlignMapPointConstraint commonAngleConstraint;
-
-      QList<QgsPoint> cadPointList;
-
-    };
-
     struct AlignMapPointOutput
     {
       bool valid;
@@ -62,6 +43,61 @@ The :py:class:`QgsCadUtils` class provides routines for CAD editing.
       QgsPointLocator::Match edgeMatch;
 
       double softLockCommonAngle;
+    };
+
+    class AlignMapPointContext
+{
+%Docstring(signature="appended")
+Class defining all constraints for :py:func:`~QgsCadUtils.alignMapPoint` method
+
+This class was a structure before QGIS 3.22.
+
+mCadPointList is now a private QList< :py:class:`QgsPoint` >.
+Use getters/setters.
+
+.. seealso:: :py:func:`cadPoints`
+
+.. seealso:: :py:func:`setCadPoints`
+
+.. versionadded:: 3.22
+%End
+
+%TypeHeaderCode
+#include "qgscadutils.h"
+%End
+      public:
+        QgsSnappingUtils *snappingUtils;
+        double mapUnitsPerPixel;
+
+        QgsCadUtils::AlignMapPointConstraint xConstraint;
+        QgsCadUtils::AlignMapPointConstraint yConstraint;
+
+        QgsCadUtils::AlignMapPointConstraint zConstraint;
+
+        QgsCadUtils::AlignMapPointConstraint mConstraint;
+        QgsCadUtils::AlignMapPointConstraint distanceConstraint;
+        QgsCadUtils::AlignMapPointConstraint angleConstraint;
+        QgsCadUtils::AlignMapPointConstraint commonAngleConstraint;
+
+
+        QList< QgsPoint > cadPoints() const;
+%Docstring
+Returns a list of points from mCadPointList.
+
+.. versionadded:: 3.22
+%End
+        void setCadPoints( const QList< QgsPoint> &list );
+%Docstring
+Set points to mCadPointList
+
+:param list: points to mCadPointList
+
+.. versionadded:: 3.22
+%End
+%Property( name = cadPointList, get = _cadPointList, set = _setCadPointList )
+        void _setCadPointList( const QList< QgsPointXY > &list );
+        QList< QgsPointXY > _cadPointList() const;
+
     };
 
     static QgsCadUtils::AlignMapPointOutput alignMapPoint( const QgsPointXY &originalMapPoint, const QgsCadUtils::AlignMapPointContext &ctx );

--- a/python/core/auto_generated/qgscadutils.sip.in
+++ b/python/core/auto_generated/qgscadutils.sip.in
@@ -94,6 +94,19 @@ Set points to mCadPointList
 
 .. versionadded:: 3.22
 %End
+        void setCadPoint( const QgsPoint &point, int index );
+%Docstring
+Set ``point`` at ``index`` to mCadPointList
+
+.. versionadded:: 3.22
+%End
+        QgsPoint cadPoint( int index ) const;
+%Docstring
+Get ``point`` at ``index`` from mCadPointList
+
+.. versionadded:: 3.22
+%End
+
 %Property( name = cadPointList, get = _cadPointList, set = _setCadPointList )
         void _setCadPointList( const QList< QgsPointXY > &list );
         QList< QgsPointXY > _cadPointList() const;

--- a/python/core/auto_generated/qgscadutils.sip.in
+++ b/python/core/auto_generated/qgscadutils.sip.in
@@ -39,11 +39,13 @@ The :py:class:`QgsCadUtils` class provides routines for CAD editing.
 
       QgsCadUtils::AlignMapPointConstraint xConstraint;
       QgsCadUtils::AlignMapPointConstraint yConstraint;
+      QgsCadUtils::AlignMapPointConstraint zConstraint;
+      QgsCadUtils::AlignMapPointConstraint mConstraint;
       QgsCadUtils::AlignMapPointConstraint distanceConstraint;
       QgsCadUtils::AlignMapPointConstraint angleConstraint;
       QgsCadUtils::AlignMapPointConstraint commonAngleConstraint;
 
-      QList<QgsPointXY> cadPointList;
+      QList<QgsPoint> cadPointList;
 
     };
 

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -218,7 +218,7 @@ determines if CAD tools are enabled or if map tools behaves "nomally"
 %Docstring
 Determines if Z or M will be enabled.
 
-.. versionadded:: 3.20
+.. versionadded:: 3.22
 %End
 
     bool constructionMode() const;
@@ -252,14 +252,14 @@ Returns the ``CadConstraint`` on the Y coordinate
 %Docstring
 Returns the ``CadConstraint`` on the Z coordinate
 
-.. versionadded:: 3.20
+.. versionadded:: 3.22
 %End
 
     const CadConstraint *constraintM() const;
 %Docstring
 Returns the ``CadConstraint`` on the M coordinate
 
-.. versionadded:: 3.20
+.. versionadded:: 3.22
 %End
     bool commonAngleConstraint() const;
 %Docstring
@@ -407,7 +407,7 @@ Can be used to set constraints by external widgets.
 
    unstable API (will likely change)
 
-.. versionadded:: 3.20
+.. versionadded:: 3.22
 %End
 
     void setM( const QString &value, WidgetSetMode mode );
@@ -422,7 +422,7 @@ Can be used to set constraints by external widgets.
 
    unstable API (will likely change)
 
-.. versionadded:: 3.20
+.. versionadded:: 3.22
 %End
 
     void setAngle( const QString &value, WidgetSetMode mode );
@@ -538,7 +538,7 @@ Could be used by widgets that must reflect the current advanced digitizing state
 
    unstable API (will likely change)
 
-.. versionadded:: 3.20
+.. versionadded:: 3.22
 %End
 
     void valueMChanged( const QString &value );
@@ -550,7 +550,7 @@ Could be used by widgets that must reflect the current advanced digitizing state
 
    unstable API (will likely change)
 
-.. versionadded:: 3.20
+.. versionadded:: 3.22
 %End
 
     void valueAngleChanged( const QString &value );
@@ -610,7 +610,7 @@ Could be used by widgets that must reflect the current advanced digitizing state
 
    unstable API (will likely change)
 
-.. versionadded:: 3.20
+.. versionadded:: 3.22
 %End
 
     void lockMChanged( bool locked );
@@ -622,7 +622,7 @@ Could be used by widgets that must reflect the current advanced digitizing state
 
    unstable API (will likely change)
 
-.. versionadded:: 3.20
+.. versionadded:: 3.22
 %End
 
     void lockAngleChanged( bool locked );
@@ -688,7 +688,7 @@ Could be used by widgets that must reflect the current advanced digitizing state
 
    unstable API (will likely change)
 
-.. versionadded:: 3.20
+.. versionadded:: 3.22
 %End
 
     void relativeMChanged( bool relative );
@@ -702,7 +702,7 @@ Could be used by widgets that must reflect the current advanced digitizing state
 
    unstable API (will likely change)
 
-.. versionadded:: 3.20
+.. versionadded:: 3.22
 %End
 
     void relativeAngleChanged( bool relative );
@@ -762,7 +762,7 @@ Could be used by widgets that must reflect the current advanced digitizing state
 
    unstable API (will likely change)
 
-.. versionadded:: 3.20
+.. versionadded:: 3.22
 %End
 
     void enabledChangedM( bool enabled );
@@ -777,7 +777,7 @@ Could be used by widgets that must reflect the current advanced digitizing state
 
    unstable API (will likely change)
 
-.. versionadded:: 3.20
+.. versionadded:: 3.22
 %End
 
     void enabledChangedAngle( bool enabled );
@@ -843,7 +843,7 @@ Could be used by widgets to capture the focus when a field is being edited.
 
    unstable API (will likely change)
 
-.. versionadded:: 3.20
+.. versionadded:: 3.22
 %End
 
     void focusOnMRequested();
@@ -855,7 +855,7 @@ Could be used by widgets to capture the focus when a field is being edited.
 
    unstable API (will likely change)
 
-.. versionadded:: 3.20
+.. versionadded:: 3.22
 %End
 
     void focusOnAngleRequested();

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -214,7 +214,7 @@ Clear any cached previous clicks and helper lines
 determines if CAD tools are enabled or if map tools behaves "nomally"
 %End
 
-    void switchZM( void );
+    void switchZM( );
 %Docstring
 Determines if Z or M will be enabled.
 

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -214,7 +214,7 @@ Clear any cached previous clicks and helper lines
 determines if CAD tools are enabled or if map tools behaves "nomally"
 %End
 
-    void switchZM( );
+    void switchZM( void );
 %Docstring
 Determines if Z or M will be enabled.
 

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -240,6 +240,20 @@ Returns the ``CadConstraint`` on the X coordinate
 %Docstring
 Returns the ``CadConstraint`` on the Y coordinate
 %End
+
+    const CadConstraint *constraintZ() const;
+%Docstring
+Returns the ``CadConstraint`` on the Z coordinate
+
+.. versionadded:: 3.20
+%End
+
+    const CadConstraint *constraintM() const;
+%Docstring
+Returns the ``CadConstraint`` on the M coordinate
+
+.. versionadded:: 3.20
+%End
     bool commonAngleConstraint() const;
 %Docstring
 Returns ``True`` if a constraint on a common angle is active
@@ -283,21 +297,21 @@ automatically populated when user clicks with left mouse button on map canvas.
 .. versionadded:: 3.0
 %End
 
-    QgsPointXY currentPoint( bool *exists  = 0 ) const;
+    QgsPoint currentPoint( bool *exists  = 0 ) const;
 %Docstring
 The last point.
 Helper for the CAD point list. The CAD point list is the list of points
 currently digitized. It contains both  "normal" points and intermediate points (construction mode).
 %End
 
-    QgsPointXY previousPoint( bool *exists = 0 ) const;
+    QgsPoint previousPoint( bool *exists = 0 ) const;
 %Docstring
 The previous point.
 Helper for the CAD point list. The CAD point list is the list of points
 currently digitized. It contains both  "normal" points and intermediate points (construction mode).
 %End
 
-    QgsPointXY penultimatePoint( bool *exists = 0 ) const;
+    QgsPoint penultimatePoint( bool *exists = 0 ) const;
 %Docstring
 The penultimate point.
 Helper for the CAD point list. The CAD point list is the list of points
@@ -374,6 +388,36 @@ Can be used to set constraints by external widgets.
 .. versionadded:: 3.8
 %End
 
+    void setZ( const QString &value, WidgetSetMode mode );
+%Docstring
+Set the Z value on the widget.
+Can be used to set constraints by external widgets.
+
+:param mode: What type of interaction to emulate
+:param value: The value (as a QString, as it could be an expression)
+
+.. note::
+
+   unstable API (will likely change)
+
+.. versionadded:: 3.20
+%End
+
+    void setM( const QString &value, WidgetSetMode mode );
+%Docstring
+Set the M value on the widget.
+Can be used to set constraints by external widgets.
+
+:param mode: What type of interaction to emulate
+:param value: The value (as a QString, as it could be an expression)
+
+.. note::
+
+   unstable API (will likely change)
+
+.. versionadded:: 3.20
+%End
+
     void setAngle( const QString &value, WidgetSetMode mode );
 %Docstring
 Set the angle value on the widget.
@@ -404,8 +448,6 @@ Can be used to set constraints by external widgets.
 .. versionadded:: 3.8
 %End
 
-
-
   signals:
 
     void pushWarning( const QString &message );
@@ -420,7 +462,7 @@ Push a warning
 Remove any previously emitted warnings (if any)
 %End
 
-    void pointChanged( const QgsPointXY &point );
+    void pointChanged( const QgsPoint &point );
 %Docstring
 Sometimes a constraint may change the current point out of a mouse event. This happens normally
 when a constraint is toggled.
@@ -464,6 +506,30 @@ Could be used by widgets that must reflect the current advanced digitizing state
    unstable API (will likely change)
 
 .. versionadded:: 3.8
+%End
+
+    void valueZChanged( const QString &value );
+%Docstring
+Emitted whenever the Z ``value`` changes (either the mouse moved, or the user changed the input).
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+.. note::
+
+   unstable API (will likely change)
+
+.. versionadded:: 3.20
+%End
+
+    void valueMChanged( const QString &value );
+%Docstring
+Emitted whenever the M ``value`` changes (either the mouse moved, or the user changed the input).
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+.. note::
+
+   unstable API (will likely change)
+
+.. versionadded:: 3.20
 %End
 
     void valueAngleChanged( const QString &value );
@@ -512,6 +578,30 @@ Could be used by widgets that must reflect the current advanced digitizing state
    unstable API (will likely change)
 
 .. versionadded:: 3.8
+%End
+
+    void lockZChanged( bool locked );
+%Docstring
+Emitted whenever the Z parameter is ``locked``.
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+.. note::
+
+   unstable API (will likely change)
+
+.. versionadded:: 3.20
+%End
+
+    void lockMChanged( bool locked );
+%Docstring
+Emitted whenever the M parameter is ``locked``.
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+.. note::
+
+   unstable API (will likely change)
+
+.. versionadded:: 3.20
 %End
 
     void lockAngleChanged( bool locked );
@@ -566,6 +656,34 @@ Could be used by widgets that must reflect the current advanced digitizing state
 .. versionadded:: 3.8
 %End
 
+    void relativeZChanged( bool relative );
+%Docstring
+Emitted whenever the Z parameter is toggled between absolute and relative.
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+:param relative: Whether the Z parameter is relative or not.
+
+.. note::
+
+   unstable API (will likely change)
+
+.. versionadded:: 3.20
+%End
+
+    void relativeMChanged( bool relative );
+%Docstring
+Emitted whenever the M parameter is toggled between absolute and relative.
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+:param relative: Whether the M parameter is relative or not.
+
+.. note::
+
+   unstable API (will likely change)
+
+.. versionadded:: 3.20
+%End
+
     void relativeAngleChanged( bool relative );
 %Docstring
 Emitted whenever the angleX parameter is toggled between absolute and relative.
@@ -609,6 +727,36 @@ Could be used by widgets that must reflect the current advanced digitizing state
    unstable API (will likely change)
 
 .. versionadded:: 3.8
+%End
+
+    void enabledChangedZ( bool enabled );
+%Docstring
+Emitted whenever the Z field is enabled or disabled. Depending on the context, some parameters
+do not make sense (e.g. you need a previous point to define a distance).
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+:param enabled: Whether the Z parameter is enabled or not.
+
+.. note::
+
+   unstable API (will likely change)
+
+.. versionadded:: 3.20
+%End
+
+    void enabledChangedM( bool enabled );
+%Docstring
+Emitted whenever the M field is enabled or disabled. Depending on the context, some parameters
+do not make sense (e.g. you need a previous point to define a distance).
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+:param enabled: Whether the M parameter is enabled or not.
+
+.. note::
+
+   unstable API (will likely change)
+
+.. versionadded:: 3.20
 %End
 
     void enabledChangedAngle( bool enabled );
@@ -663,6 +811,30 @@ Could be used by widgets to capture the focus when a field is being edited.
    unstable API (will likely change)
 
 .. versionadded:: 3.8
+%End
+
+    void focusOnZRequested();
+%Docstring
+Emitted whenever the Z field should get the focus using the shortcuts (Z).
+Could be used by widgets to capture the focus when a field is being edited.
+
+.. note::
+
+   unstable API (will likely change)
+
+.. versionadded:: 3.20
+%End
+
+    void focusOnMRequested();
+%Docstring
+Emitted whenever the M field should get the focus using the shortcuts (M).
+Could be used by widgets to capture the focus when a field is being edited.
+
+.. note::
+
+   unstable API (will likely change)
+
+.. versionadded:: 3.20
 %End
 
     void focusOnAngleRequested();

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -214,6 +214,13 @@ Clear any cached previous clicks and helper lines
 determines if CAD tools are enabled or if map tools behaves "nomally"
 %End
 
+    void switchZM( void );
+%Docstring
+Determines if Z or M will be enabled.
+
+.. versionadded:: 3.20
+%End
+
     bool constructionMode() const;
 %Docstring
 construction mode is used to draw intermediate points. These points won't be given any further (i.e. to the map tools)

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -304,27 +304,54 @@ automatically populated when user clicks with left mouse button on map canvas.
 .. versionadded:: 3.0
 %End
 
-    QgsPoint currentPoint( bool *exists  = 0 ) const;
+    QgsPoint currentPointV2( bool *exists  = 0 ) const;
 %Docstring
 The last point.
 Helper for the CAD point list. The CAD point list is the list of points
 currently digitized. It contains both  "normal" points and intermediate points (construction mode).
 %End
 
-    QgsPoint previousPoint( bool *exists = 0 ) const;
+ QgsPointXY currentPoint( bool *exists  = 0 ) const /Deprecated/;
+%Docstring
+The last point.
+Helper for the CAD point list. The CAD point list is the list of points
+currently digitized. It contains both  "normal" points and intermediate points (construction mode).
+
+.. deprecated:: QGIS 3.22
+   - will be removed in QGIS 4.0. Use the variant which returns :py:class:`QgsPoint` object instead of :py:class:`QgsPointXY`.
+%End
+    QgsPoint previousPointV2( bool *exists = 0 ) const;
 %Docstring
 The previous point.
 Helper for the CAD point list. The CAD point list is the list of points
 currently digitized. It contains both  "normal" points and intermediate points (construction mode).
 %End
 
-    QgsPoint penultimatePoint( bool *exists = 0 ) const;
+ QgsPointXY previousPoint( bool *exists = 0 ) const /Deprecated/;
+%Docstring
+The previous point.
+Helper for the CAD point list. The CAD point list is the list of points
+currently digitized. It contains both  "normal" points and intermediate points (construction mode).
+
+.. deprecated:: QGIS 3.22
+   - will be removed in QGIS 4.0. Use the variant which returns :py:class:`QgsPoint` object instead of :py:class:`QgsPointXY`.
+%End
+    QgsPoint penultimatePointV2( bool *exists = 0 ) const;
 %Docstring
 The penultimate point.
 Helper for the CAD point list. The CAD point list is the list of points
 currently digitized. It contains both  "normal" points and intermediate points (construction mode).
 %End
 
+ QgsPointXY penultimatePoint( bool *exists = 0 ) const /Deprecated/;
+%Docstring
+The penultimate point.
+Helper for the CAD point list. The CAD point list is the list of points
+currently digitized. It contains both  "normal" points and intermediate points (construction mode).
+
+.. deprecated:: QGIS 3.22
+   - will be removed in QGIS 4.0. Use the variant which returns :py:class:`QgsPoint` object instead of :py:class:`QgsPointXY`.
+%End
     int pointsCount() const;
 %Docstring
 The number of points in the CAD point helper list

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -510,12 +510,25 @@ Push a warning
 Remove any previously emitted warnings (if any)
 %End
 
-    void pointChanged( const QgsPoint &point );
+    void pointChangedV2( const QgsPoint &point );
 %Docstring
 Sometimes a constraint may change the current point out of a mouse event. This happens normally
 when a constraint is toggled.
 
 :param point: The last known digitizing point. Can be used to emulate a mouse event.
+
+.. versionadded:: 3.22
+%End
+
+ void pointChanged( const QgsPointXY &point ) /Deprecated/;
+%Docstring
+Sometimes a constraint may change the current point out of a mouse event. This happens normally
+when a constraint is toggled.
+
+:param point: The last known digitizing point. Can be used to emulate a mouse event.
+
+.. deprecated:: QGIS 3.22
+   - No longer used, will be removed in QGIS 4.0. Use the variant which emits :py:class:`QgsPoint` object instead of :py:class:`QgsPointXY`.
 %End
 
 

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -455,6 +455,20 @@ Can be used to set constraints by external widgets.
 .. versionadded:: 3.8
 %End
 
+    double getLineZ( ) const;
+%Docstring
+Convenient method to get the Z value from the line edit wiget
+
+.. versionadded:: 3.22
+%End
+
+    double getLineM( ) const;
+%Docstring
+Convenient method to get the M value from the line edit wiget
+
+.. versionadded:: 3.22
+%End
+
   signals:
 
     void pushWarning( const QString &message );

--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -58,9 +58,9 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
 
   QgsPointXY previousPt, penultimatePt;
   if ( ctx.cadPoints().count() >= 2 )
-    previousPt = ctx.cadPoints().at( 1 );
+    previousPt = ctx.cadPoint( 1 );
   if ( ctx.cadPoints().count() >= 3 )
-    penultimatePt = ctx.cadPoints().at( 2 );
+    penultimatePt = ctx.cadPoint( 2 );
 
   // *****************************
   // ---- X constraint

--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -57,10 +57,10 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
   }
 
   QgsPointXY previousPt, penultimatePt;
-  if ( ctx.cadPointList.count() >= 2 )
-    previousPt = ctx.cadPointList.at( 1 );
-  if ( ctx.cadPointList.count() >= 3 )
-    penultimatePt = ctx.cadPointList.at( 2 );
+  if ( ctx.cadPoints().count() >= 2 )
+    previousPt = ctx.cadPoints().at( 1 );
+  if ( ctx.cadPoints().count() >= 3 )
+    penultimatePt = ctx.cadPoints().at( 2 );
 
   // *****************************
   // ---- X constraint
@@ -70,7 +70,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
     {
       point.setX( ctx.xConstraint.value );
     }
-    else if ( ctx.cadPointList.count() >= 2 )
+    else if ( ctx.cadPoints().count() >= 2 )
     {
       point.setX( previousPt.x() + ctx.xConstraint.value );
     }
@@ -98,7 +98,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
     {
       point.setY( ctx.yConstraint.value );
     }
-    else if ( ctx.cadPointList.count() >= 2 )
+    else if ( ctx.cadPoints().count() >= 2 )
     {
       point.setY( previousPt.y() + ctx.yConstraint.value );
     }
@@ -120,7 +120,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
 
   // *****************************
   // ---- Common Angle constraint
-  if ( !ctx.angleConstraint.locked && ctx.cadPointList.count() >= 2 && ctx.commonAngleConstraint.locked && ctx.commonAngleConstraint.value != 0 )
+  if ( !ctx.angleConstraint.locked && ctx.cadPoints().count() >= 2 && ctx.commonAngleConstraint.locked && ctx.commonAngleConstraint.value != 0 )
   {
     const double commonAngle = ctx.commonAngleConstraint.value * M_PI / 180;
     // see if soft common angle constraint should be performed
@@ -128,7 +128,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
     double softAngle = std::atan2( point.y() - previousPt.y(),
                                    point.x() - previousPt.x() );
     double deltaAngle = 0;
-    if ( ctx.commonAngleConstraint.relative && ctx.cadPointList.count() >= 3 )
+    if ( ctx.commonAngleConstraint.relative && ctx.cadPoints().count() >= 3 )
     {
       // compute the angle relative to the last segment (0° is aligned with last segment)
       deltaAngle = std::atan2( previousPt.y() - penultimatePt.y(),
@@ -175,7 +175,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
   if ( angleLocked )
   {
     double angleValue = angleValueDeg * M_PI / 180;
-    if ( angleRelative && ctx.cadPointList.count() >= 3 )
+    if ( angleRelative && ctx.cadPoints().count() >= 3 )
     {
       // compute the angle relative to the last segment (0° is aligned with last segment)
       angleValue += std::atan2( previousPt.y() - penultimatePt.y(),
@@ -256,7 +256,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
 
   // *****************************
   // ---- Distance constraint
-  if ( ctx.distanceConstraint.locked && ctx.cadPointList.count() >= 2 )
+  if ( ctx.distanceConstraint.locked && ctx.cadPoints().count() >= 2 )
   {
     if ( ctx.xConstraint.locked || ctx.yConstraint.locked )
     {

--- a/src/core/qgscadutils.h
+++ b/src/core/qgscadutils.h
@@ -77,7 +77,7 @@ class CORE_EXPORT QgsCadUtils
 
     /**
      * \ingroup core
-     * Class defining all constraints for alignMapPoint() method
+     * \brief Class defining all constraints for alignMapPoint() method
      *
      * This class was a structure before QGIS 3.22.
      *

--- a/src/core/qgscadutils.h
+++ b/src/core/qgscadutils.h
@@ -50,51 +50,6 @@ class CORE_EXPORT QgsCadUtils
       double value;
     };
 
-    //! Structure defining all constraints for alignMapPoint() method
-    struct AlignMapPointContext
-    {
-      //! Snapping utils that will be used to snap point to map. Must not be NULLPTR.
-      QgsSnappingUtils *snappingUtils = nullptr;
-      //! Map units/pixel ratio from map canvas. Needed for
-      double mapUnitsPerPixel;
-
-      //! Constraint for X coordinate
-      QgsCadUtils::AlignMapPointConstraint xConstraint;
-      //! Constraint for Y coordinate
-      QgsCadUtils::AlignMapPointConstraint yConstraint;
-
-      /**
-       * Constraint for Z coordinate
-       * \since QGIS 3.22
-       */
-      QgsCadUtils::AlignMapPointConstraint zConstraint;
-
-      /**
-       * Constraint for M coordinate
-       * \since QGIS 3.22
-       */
-      QgsCadUtils::AlignMapPointConstraint mConstraint;
-      //! Constraint for distance
-      QgsCadUtils::AlignMapPointConstraint distanceConstraint;
-      //! Constraint for angle
-      QgsCadUtils::AlignMapPointConstraint angleConstraint;
-      //! Constraint for soft lock to a common angle
-      QgsCadUtils::AlignMapPointConstraint commonAngleConstraint;
-
-      /**
-       * List of recent CAD points in map coordinates. These are used to turn relative constraints to absolute.
-       * First point is the most recent point. Currently using only "previous" point (index 1) and "penultimate"
-       * point (index 2) for alignment purposes.
-       */
-      QList<QgsPoint> cadPointList;
-
-      /**
-       * Dumps the context's properties, for debugging.
-       * \note Not available in Python bindings.
-       */
-      SIP_SKIP void dump() const;
-    };
-
     //! Structure returned from alignMapPoint() method
     struct AlignMapPointOutput
     {
@@ -118,6 +73,88 @@ class CORE_EXPORT QgsCadUtils
 
       //! Angle (in degrees) to which we have soft-locked ourselves (if not set it is -1)
       double softLockCommonAngle;
+    };
+
+    /**
+     * Class defining all constraints for alignMapPoint() method
+     *
+     * This class was a structure before QGIS 3.22.
+     *
+     * mCadPointList is now a private QList< QgsPoint >.
+     * Use getters/setters.
+     *
+     * \see cadPoints
+     * \see setCadPoints
+     *
+     * \since QGIS 3.22
+     */
+    class AlignMapPointContext
+    {
+      public:
+        //! Snapping utils that will be used to snap point to map. Must not be NULLPTR.
+        QgsSnappingUtils *snappingUtils = nullptr;
+        //! Map units/pixel ratio from map canvas. Needed for
+        double mapUnitsPerPixel;
+
+        //! Constraint for X coordinate
+        QgsCadUtils::AlignMapPointConstraint xConstraint;
+        //! Constraint for Y coordinate
+        QgsCadUtils::AlignMapPointConstraint yConstraint;
+
+        /**
+         * Constraint for Z coordinate
+         * \since QGIS 3.22
+         */
+        QgsCadUtils::AlignMapPointConstraint zConstraint;
+
+        /**
+         * Constraint for M coordinate
+         * \since QGIS 3.22
+         */
+        QgsCadUtils::AlignMapPointConstraint mConstraint;
+        //! Constraint for distance
+        QgsCadUtils::AlignMapPointConstraint distanceConstraint;
+        //! Constraint for angle
+        QgsCadUtils::AlignMapPointConstraint angleConstraint;
+        //! Constraint for soft lock to a common angle
+        QgsCadUtils::AlignMapPointConstraint commonAngleConstraint;
+
+        /**
+         * Dumps the context's properties, for debugging.
+         * \note Not available in Python bindings.
+         */
+        SIP_SKIP void dump() const;
+
+        /**
+         * Returns a list of points from mCadPointList.
+         * \since QGIS 3.22
+         */
+        QList< QgsPoint > cadPoints() const { return mCadPointList; } ;
+
+        /**
+         * Set points to mCadPointList
+         * \param list points to mCadPointList
+         * \since QGIS 3.22
+         */
+        void setCadPoints( const QList< QgsPoint> &list ) { mCadPointList = list; };
+
+#ifdef SIP_RUN
+        SIP_PROPERTY( name = cadPointList, get = _cadPointList, set = _setCadPointList )
+#endif
+        ///@cond PRIVATE
+        void _setCadPointList( const QList< QgsPointXY > &list ) { mCadPointList.clear(); for ( const auto &pointxy : list ) { mCadPointList.append( QgsPoint( pointxy ) );} }
+        QList< QgsPointXY > _cadPointList() const { QList< QgsPointXY> list; for ( const auto &point : mCadPointList ) { list.append( QgsPointXY( point.x(), point.y() ) ); }; return list; }
+        ///@endcond PRIVATE
+
+      private:
+
+        /**
+         * List of recent CAD points in map coordinates. These are used to turn relative constraints to absolute.
+         * First point is the most recent point. Currently using only "previous" point (index 1) and "penultimate"
+         * point (index 2) for alignment purposes.
+         */
+        QList<QgsPoint> mCadPointList;
+
     };
 
     /**

--- a/src/core/qgscadutils.h
+++ b/src/core/qgscadutils.h
@@ -76,6 +76,7 @@ class CORE_EXPORT QgsCadUtils
     };
 
     /**
+     * \ingroup core
      * Class defining all constraints for alignMapPoint() method
      *
      * This class was a structure before QGIS 3.22.
@@ -137,6 +138,19 @@ class CORE_EXPORT QgsCadUtils
          * \since QGIS 3.22
          */
         void setCadPoints( const QList< QgsPoint> &list ) { mCadPointList = list; };
+
+        /**
+         * Set \a point at \a index to mCadPointList
+         * \since QGIS 3.22
+         */
+        void setCadPoint( const QgsPoint &point, int index ) { mCadPointList[index] = point; };
+
+        /**
+         * Get \a point at \a index from mCadPointList
+         * \since QGIS 3.22
+         */
+        QgsPoint cadPoint( int index ) const { return mCadPointList[index]; };
+
 
 #ifdef SIP_RUN
         SIP_PROPERTY( name = cadPointList, get = _cadPointList, set = _setCadPointList )

--- a/src/core/qgscadutils.h
+++ b/src/core/qgscadutils.h
@@ -62,6 +62,10 @@ class CORE_EXPORT QgsCadUtils
       QgsCadUtils::AlignMapPointConstraint xConstraint;
       //! Constraint for Y coordinate
       QgsCadUtils::AlignMapPointConstraint yConstraint;
+      //! Constraint for Z coordinate
+      QgsCadUtils::AlignMapPointConstraint zConstraint;
+      //! Constraint for M coordinate
+      QgsCadUtils::AlignMapPointConstraint mConstraint;
       //! Constraint for distance
       QgsCadUtils::AlignMapPointConstraint distanceConstraint;
       //! Constraint for angle
@@ -74,7 +78,7 @@ class CORE_EXPORT QgsCadUtils
        * First point is the most recent point. Currently using only "previous" point (index 1) and "penultimate"
        * point (index 2) for alignment purposes.
        */
-      QList<QgsPointXY> cadPointList;
+      QList<QgsPoint> cadPointList;
 
       /**
        * Dumps the context's properties, for debugging.

--- a/src/core/qgscadutils.h
+++ b/src/core/qgscadutils.h
@@ -62,9 +62,17 @@ class CORE_EXPORT QgsCadUtils
       QgsCadUtils::AlignMapPointConstraint xConstraint;
       //! Constraint for Y coordinate
       QgsCadUtils::AlignMapPointConstraint yConstraint;
-      //! Constraint for Z coordinate
+
+      /**
+       * Constraint for Z coordinate
+       * \since QGIS 3.22
+       */
       QgsCadUtils::AlignMapPointConstraint zConstraint;
-      //! Constraint for M coordinate
+
+      /**
+       * Constraint for M coordinate
+       * \since QGIS 3.22
+       */
       QgsCadUtils::AlignMapPointConstraint mConstraint;
       //! Constraint for distance
       QgsCadUtils::AlignMapPointConstraint distanceConstraint;

--- a/src/gui/qgsadvanceddigitizingcanvasitem.cpp
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.cpp
@@ -55,9 +55,9 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     return;
 
   bool previousPointExist, penulPointExist;
-  const QgsPointXY curPoint = mAdvancedDigitizingDockWidget->currentPoint();
-  const QgsPointXY prevPoint = mAdvancedDigitizingDockWidget->previousPoint( &previousPointExist );
-  const QgsPointXY penulPoint = mAdvancedDigitizingDockWidget->penultimatePoint( &penulPointExist );
+  const QgsPointXY curPoint = mAdvancedDigitizingDockWidget->currentPointV2();
+  const QgsPointXY prevPoint = mAdvancedDigitizingDockWidget->previousPointV2( &previousPointExist );
+  const QgsPointXY penulPoint = mAdvancedDigitizingDockWidget->penultimatePointV2( &penulPointExist );
   const bool snappedToVertex = mAdvancedDigitizingDockWidget->snappedToVertex();
   const QList<QgsPointXY> snappedSegment = mAdvancedDigitizingDockWidget->snappedSegment();
   const bool hasSnappedSegment = snappedSegment.count() == 2;

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -317,7 +317,7 @@ void QgsAdvancedDigitizingDockWidget::setCadEnabled( bool enabled )
 }
 
 
-void QgsAdvancedDigitizingDockWidget::switchZM( void )
+void QgsAdvancedDigitizingDockWidget::switchZM( )
 {
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mMapCanvas->currentLayer() );
   if ( vlayer )

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -859,11 +859,12 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
     e->snapPoint();
     point = mSnapMatch.interpolatedPoint();
   }
-  else
-  {
-    point.setZ( QgsMapToolEdit( mMapCanvas ).defaultZValue() );
-    point.setM( QgsMapToolEdit( mMapCanvas ).defaultMValue() );
-  }
+  /*
+   * Ensure that Z and M are passed
+   * It will be dropped as needed later.
+   */
+  point.addZValue( QgsMapToolEdit( mMapCanvas ).defaultZValue() );
+  point.addMValue( QgsMapToolEdit( mMapCanvas ).defaultMValue() );
 
   /*
    * And if M or Z lock button is activated get the value of the input.
@@ -874,7 +875,6 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
   }
   if ( mLockMButton->isChecked() )
   {
-
     point.setM( mMLineEdit->text().toFloat() );
   }
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -812,7 +812,6 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
 
   const QgsCadUtils::AlignMapPointOutput output = QgsCadUtils::alignMapPoint( e->originalMapPoint(), context );
 
-
   const bool res = output.valid;
   QgsPoint point = pointXYToPoint( output.finalMapPoint );
   mSnappedSegment.clear();
@@ -1377,6 +1376,24 @@ void QgsAdvancedDigitizingDockWidget::enable()
     mEnableAction->setEnabled( true );
     mErrorLabel->hide();
     mCadWidget->show();
+
+    QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mMapCanvas->currentLayer() );
+    if ( vlayer )
+    {
+
+      const QgsWkbTypes::Type type = vlayer->wkbType();
+      mRelativeZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
+      mZLabel->setEnabled( QgsWkbTypes::hasZ( type ) );
+      mZLineEdit->setEnabled( QgsWkbTypes::hasZ( type ) );
+      mLockZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
+      mRepeatingLockZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
+
+      mRelativeMButton->setEnabled( QgsWkbTypes::hasM( type ) );
+      mMLabel->setEnabled( QgsWkbTypes::hasM( type ) );
+      mMLineEdit->setEnabled( QgsWkbTypes::hasM( type ) );
+      mLockMButton->setEnabled( QgsWkbTypes::hasM( type ) );
+      mRepeatingLockMButton->setEnabled( QgsWkbTypes::hasM( type ) );
+    }
 
     mCurrentMapToolSupportsCad = true;
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -338,7 +338,7 @@ void QgsAdvancedDigitizingDockWidget::switchZM( )
     mMLabel->setEnabled( QgsWkbTypes::hasM( type ) );
     mMLineEdit->setEnabled( QgsWkbTypes::hasM( type ) );
     if ( mMLineEdit->isEnabled() )
-      mMLineEdit->setText( QLocale().toString( 0.0, 'f', 6 ) );
+      mZLineEdit->setText( QLocale().toString( QgsMapToolEdit( mMapCanvas ).defaultMValue(), 'f', 6 ) );
     else
       mMLineEdit->clear();
     mLockMButton->setEnabled( QgsWkbTypes::hasM( type ) );
@@ -862,7 +862,7 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
   else
   {
     point.setZ( QgsMapToolEdit( mMapCanvas ).defaultZValue() );
-    point.setM( 0.0 );
+    point.setM( QgsMapToolEdit( mMapCanvas ).defaultMValue() );
   }
   // update the point list
   updateCurrentPoint( point );
@@ -955,7 +955,7 @@ void QgsAdvancedDigitizingDockWidget::updateUnlockedConstraintValues( const QgsP
     }
     else
     {
-      mMConstraint->setValue( 0.0 );
+      mMConstraint->setValue( point.m() );
     }
   }
 }

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -898,8 +898,8 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
 void QgsAdvancedDigitizingDockWidget::updateUnlockedConstraintValues( const QgsPoint &point )
 {
   bool previousPointExist, penulPointExist;
-  const QgsPoint previousPt = previousPoint( &previousPointExist );
-  const QgsPoint penultimatePt = penultimatePoint( &penulPointExist );
+  const QgsPoint previousPt = previousPointV2( &previousPointExist );
+  const QgsPoint penultimatePt = penultimatePointV2( &penulPointExist );
 
   // --- angle
   if ( !mAngleConstraint->isLocked() && previousPointExist )
@@ -1015,8 +1015,8 @@ bool QgsAdvancedDigitizingDockWidget::alignToSegment( QgsMapMouseEvent *e, CadCo
   }
 
   bool previousPointExist, penulPointExist, snappedSegmentExist;
-  const QgsPoint previousPt = previousPoint( &previousPointExist );
-  const QgsPoint penultimatePt = penultimatePoint( &penulPointExist );
+  const QgsPoint previousPt = previousPointV2( &previousPointExist );
+  const QgsPoint penultimatePt = penultimatePointV2( &penulPointExist );
   mSnappedSegment = snapSegmentToAllLayers( e->originalMapPoint(), &snappedSegmentExist );
 
   if ( !previousPointExist || !snappedSegmentExist )
@@ -1527,7 +1527,7 @@ void QgsAdvancedDigitizingDockWidget::CadConstraint::toggleRelative()
   setRelative( !mRelative );
 }
 
-QgsPoint QgsAdvancedDigitizingDockWidget::currentPoint( bool *exist ) const
+QgsPoint QgsAdvancedDigitizingDockWidget::currentPointV2( bool *exist ) const
 {
   if ( exist )
     *exist = pointsCount() > 0;
@@ -1537,7 +1537,7 @@ QgsPoint QgsAdvancedDigitizingDockWidget::currentPoint( bool *exist ) const
     return QgsPoint();
 }
 
-QgsPoint QgsAdvancedDigitizingDockWidget::previousPoint( bool *exist ) const
+QgsPoint QgsAdvancedDigitizingDockWidget::previousPointV2( bool *exist ) const
 {
   if ( exist )
     *exist = pointsCount() > 1;
@@ -1547,7 +1547,7 @@ QgsPoint QgsAdvancedDigitizingDockWidget::previousPoint( bool *exist ) const
     return QgsPoint();
 }
 
-QgsPoint QgsAdvancedDigitizingDockWidget::penultimatePoint( bool *exist ) const
+QgsPoint QgsAdvancedDigitizingDockWidget::penultimatePointV2( bool *exist ) const
 {
   if ( exist )
     *exist = pointsCount() > 2;

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -864,6 +864,20 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
     point.setZ( QgsMapToolEdit( mMapCanvas ).defaultZValue() );
     point.setM( QgsMapToolEdit( mMapCanvas ).defaultMValue() );
   }
+
+  /*
+   * And if M or Z lock button is activated get the value of the input.
+   */
+  if ( mLockZButton->isChecked() )
+  {
+    point.setZ( mZLineEdit->text().toFloat() );
+  }
+  if ( mLockMButton->isChecked() )
+  {
+
+    point.setM( mMLineEdit->text().toFloat() );
+  }
+
   // update the point list
   updateCurrentPoint( point );
 
@@ -1546,5 +1560,15 @@ QgsPoint QgsAdvancedDigitizingDockWidget::penultimatePoint( bool *exist ) const
 
 QgsPoint QgsAdvancedDigitizingDockWidget::pointXYToPoint( const QgsPointXY &point ) const
 {
-  return QgsPoint( point.x(), point.y(), mZLineEdit->isEnabled() ? mZLineEdit->text().toFloat() : std::numeric_limits<double>::quiet_NaN(), mMLineEdit->isEnabled() ? mMLineEdit->text().toFloat() : std::numeric_limits<double>::quiet_NaN() );
+  return QgsPoint( point.x(), point.y(), getLineZ(), getLineM() );
+}
+
+double QgsAdvancedDigitizingDockWidget::getLineZ( ) const
+{
+  return mZLineEdit->isEnabled() ? mZLineEdit->text().toFloat() : std::numeric_limits<double>::quiet_NaN();
+}
+
+double QgsAdvancedDigitizingDockWidget::getLineM( ) const
+{
+  return mMLineEdit->isEnabled() ? mMLineEdit->text().toFloat() : std::numeric_limits<double>::quiet_NaN();
 }

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -1248,7 +1248,7 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
     }
     case Qt::Key_M:
     {
-      // modifier+y ONLY caught for ShortcutOverride events...
+      // modifier+m ONLY caught for ShortcutOverride events...
       if ( type == QEvent::ShortcutOverride && ( e->modifiers() == Qt::AltModifier || e->modifiers() == Qt::ControlModifier ) )
       {
         mMConstraint->toggleLocked();

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -312,7 +312,39 @@ void QgsAdvancedDigitizingDockWidget::setCadEnabled( bool enabled )
   clear();
   setConstructionMode( false );
 
+  switchZM();
   emit cadEnabledChanged( enabled );
+}
+
+
+void QgsAdvancedDigitizingDockWidget::switchZM( void )
+{
+  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mMapCanvas->currentLayer() );
+  if ( vlayer )
+  {
+
+    const QgsWkbTypes::Type type = vlayer->wkbType();
+    mRelativeZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
+    mZLabel->setEnabled( QgsWkbTypes::hasZ( type ) );
+    mZLineEdit->setEnabled( QgsWkbTypes::hasZ( type ) );
+    if ( mZLineEdit->isEnabled() )
+      mZLineEdit->setText( QLocale().toString( QgsMapToolEdit( mMapCanvas ).defaultZValue(), 'f', 6 ) );
+    else
+      mZLineEdit->clear();
+    mLockZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
+    mRepeatingLockZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
+
+    mRelativeMButton->setEnabled( QgsWkbTypes::hasM( type ) );
+    mMLabel->setEnabled( QgsWkbTypes::hasM( type ) );
+    mMLineEdit->setEnabled( QgsWkbTypes::hasM( type ) );
+    if ( mMLineEdit->isEnabled() )
+      mMLineEdit->setText( QLocale().toString( 0.0, 'f', 6 ) );
+    else
+      mMLineEdit->clear();
+    mLockMButton->setEnabled( QgsWkbTypes::hasM( type ) );
+    mRepeatingLockMButton->setEnabled( QgsWkbTypes::hasM( type ) );
+  }
+
 }
 
 void QgsAdvancedDigitizingDockWidget::activateCad( bool enabled )
@@ -1345,24 +1377,6 @@ void QgsAdvancedDigitizingDockWidget::enable()
     mEnableAction->setEnabled( true );
     mErrorLabel->hide();
     mCadWidget->show();
-
-    QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mMapCanvas->currentLayer() );
-    if ( vlayer )
-    {
-
-      const QgsWkbTypes::Type type = vlayer->wkbType();
-      mRelativeZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
-      mZLabel->setEnabled( QgsWkbTypes::hasZ( type ) );
-      mZLineEdit->setEnabled( QgsWkbTypes::hasZ( type ) );
-      mLockZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
-      mRepeatingLockZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
-
-      mRelativeMButton->setEnabled( QgsWkbTypes::hasM( type ) );
-      mMLabel->setEnabled( QgsWkbTypes::hasM( type ) );
-      mMLineEdit->setEnabled( QgsWkbTypes::hasM( type ) );
-      mLockMButton->setEnabled( QgsWkbTypes::hasM( type ) );
-      mRepeatingLockMButton->setEnabled( QgsWkbTypes::hasM( type ) );
-    }
 
     mCurrentMapToolSupportsCad = true;
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -319,10 +319,9 @@ void QgsAdvancedDigitizingDockWidget::setCadEnabled( bool enabled )
 
 void QgsAdvancedDigitizingDockWidget::switchZM( )
 {
-  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mMapCanvas->currentLayer() );
-  if ( vlayer )
-  {
 
+  if ( QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mMapCanvas->currentLayer() ) )
+  {
     const QgsWkbTypes::Type type = vlayer->wkbType();
     mRelativeZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
     mZLabel->setEnabled( QgsWkbTypes::hasZ( type ) );

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -591,7 +591,7 @@ void QgsAdvancedDigitizingDockWidget::updateConstraintValue( CadConstraint *cons
 
   constraint->setValue( value, convertExpression );
   // run a fake map mouse event to update the paint item
-  emit pointChanged( mCadPointList.value( 0 ) );
+  emit pointChangedV2( mCadPointList.value( 0 ) );
 }
 
 void QgsAdvancedDigitizingDockWidget::lockConstraint( bool activate /* default true */ )
@@ -659,7 +659,7 @@ void QgsAdvancedDigitizingDockWidget::lockConstraint( bool activate /* default t
     }
 
     // run a fake map mouse event to update the paint item
-    emit pointChanged( mCadPointList.value( 0 ) );
+    emit pointChangedV2( mCadPointList.value( 0 ) );
   }
 }
 
@@ -1162,7 +1162,7 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
       {
         mXConstraint->toggleLocked();
         emit lockXChanged( mXConstraint->isLocked() );
-        emit pointChanged( mCadPointList.value( 0 ) );
+        emit pointChangedV2( mCadPointList.value( 0 ) );
         e->accept();
       }
       else if ( type == QEvent::ShortcutOverride && e->modifiers() == Qt::ShiftModifier )
@@ -1171,7 +1171,7 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
         {
           mXConstraint->toggleRelative();
           emit relativeXChanged( mXConstraint->relative() );
-          emit pointChanged( mCadPointList.value( 0 ) );
+          emit pointChangedV2( mCadPointList.value( 0 ) );
           e->accept();
         }
       }
@@ -1192,7 +1192,7 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
       {
         mYConstraint->toggleLocked();
         emit lockYChanged( mYConstraint->isLocked() );
-        emit pointChanged( mCadPointList.value( 0 ) );
+        emit pointChangedV2( mCadPointList.value( 0 ) );
         e->accept();
       }
       else if ( type == QEvent::ShortcutOverride &&  e->modifiers() == Qt::ShiftModifier )
@@ -1201,7 +1201,7 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
         {
           mYConstraint->toggleRelative();
           emit relativeYChanged( mYConstraint->relative() );
-          emit pointChanged( mCadPointList.value( 0 ) );
+          emit pointChangedV2( mCadPointList.value( 0 ) );
           e->accept();
         }
       }
@@ -1222,7 +1222,7 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
       {
         mZConstraint->toggleLocked();
         emit lockZChanged( mZConstraint->isLocked() );
-        emit pointChanged( mCadPointList.value( 0 ) );
+        emit pointChangedV2( mCadPointList.value( 0 ) );
         e->accept();
       }
       else if ( type == QEvent::ShortcutOverride &&  e->modifiers() == Qt::ShiftModifier )
@@ -1231,7 +1231,7 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
         {
           mZConstraint->toggleRelative();
           emit relativeZChanged( mZConstraint->relative() );
-          emit pointChanged( mCadPointList.value( 0 ) );
+          emit pointChangedV2( mCadPointList.value( 0 ) );
           e->accept();
         }
       }
@@ -1252,7 +1252,7 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
       {
         mMConstraint->toggleLocked();
         emit lockMChanged( mMConstraint->isLocked() );
-        emit pointChanged( mCadPointList.value( 0 ) );
+        emit pointChangedV2( mCadPointList.value( 0 ) );
         e->accept();
       }
       else if ( type == QEvent::ShortcutOverride &&  e->modifiers() == Qt::ShiftModifier )
@@ -1261,7 +1261,7 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
         {
           mMConstraint->toggleRelative();
           emit relativeMChanged( mMConstraint->relative() );
-          emit pointChanged( mCadPointList.value( 0 ) );
+          emit pointChangedV2( mCadPointList.value( 0 ) );
           e->accept();
         }
       }
@@ -1284,7 +1284,7 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
         {
           mAngleConstraint->toggleLocked();
           emit lockAngleChanged( mAngleConstraint->isLocked() );
-          emit pointChanged( mCadPointList.value( 0 ) );
+          emit pointChangedV2( mCadPointList.value( 0 ) );
           e->accept();
         }
       }
@@ -1294,7 +1294,7 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
         {
           mAngleConstraint->toggleRelative();
           emit relativeAngleChanged( mAngleConstraint->relative() );
-          emit pointChanged( mCadPointList.value( 0 ) );
+          emit pointChangedV2( mCadPointList.value( 0 ) );
           e->accept();
         }
       }
@@ -1317,7 +1317,7 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
         {
           mDistanceConstraint->toggleLocked();
           emit lockDistanceChanged( mDistanceConstraint->isLocked() );
-          emit pointChanged( mCadPointList.value( 0 ) );
+          emit pointChangedV2( mCadPointList.value( 0 ) );
           e->accept();
         }
       }
@@ -1362,7 +1362,7 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
         e->accept();
 
         // run a fake map mouse event to update the paint item
-        emit pointChanged( mCadPointList.value( 0 ) );
+        emit pointChangedV2( mCadPointList.value( 0 ) );
       }
       break;
     }

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -317,7 +317,7 @@ void QgsAdvancedDigitizingDockWidget::setCadEnabled( bool enabled )
 }
 
 
-void QgsAdvancedDigitizingDockWidget::switchZM( )
+void QgsAdvancedDigitizingDockWidget::switchZM( void )
 {
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mMapCanvas->currentLayer() );
   if ( vlayer )
@@ -1376,24 +1376,6 @@ void QgsAdvancedDigitizingDockWidget::enable()
     mEnableAction->setEnabled( true );
     mErrorLabel->hide();
     mCadWidget->show();
-
-    QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mMapCanvas->currentLayer() );
-    if ( vlayer )
-    {
-
-      const QgsWkbTypes::Type type = vlayer->wkbType();
-      mRelativeZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
-      mZLabel->setEnabled( QgsWkbTypes::hasZ( type ) );
-      mZLineEdit->setEnabled( QgsWkbTypes::hasZ( type ) );
-      mLockZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
-      mRepeatingLockZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
-
-      mRelativeMButton->setEnabled( QgsWkbTypes::hasM( type ) );
-      mMLabel->setEnabled( QgsWkbTypes::hasM( type ) );
-      mMLineEdit->setEnabled( QgsWkbTypes::hasM( type ) );
-      mLockMButton->setEnabled( QgsWkbTypes::hasM( type ) );
-      mRepeatingLockMButton->setEnabled( QgsWkbTypes::hasM( type ) );
-    }
 
     mCurrentMapToolSupportsCad = true;
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -803,7 +803,7 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
   context.mConstraint = _constraint( mMConstraint.get() );
   context.distanceConstraint = _constraint( mDistanceConstraint.get() );
   context.angleConstraint = _constraint( mAngleConstraint.get() );
-  context.cadPointList = mCadPointList;
+  context.setCadPoints( mCadPointList );
 
   context.commonAngleConstraint.locked = true;
   context.commonAngleConstraint.relative = context.angleConstraint.relative;

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -338,7 +338,7 @@ void QgsAdvancedDigitizingDockWidget::switchZM( )
     mMLabel->setEnabled( QgsWkbTypes::hasM( type ) );
     mMLineEdit->setEnabled( QgsWkbTypes::hasM( type ) );
     if ( mMLineEdit->isEnabled() )
-      mZLineEdit->setText( QLocale().toString( QgsMapToolEdit( mMapCanvas ).defaultMValue(), 'f', 6 ) );
+      mMLineEdit->setText( QLocale().toString( QgsMapToolEdit( mMapCanvas ).defaultMValue(), 'f', 6 ) );
     else
       mMLineEdit->clear();
     mLockMButton->setEnabled( QgsWkbTypes::hasM( type ) );

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -1218,8 +1218,8 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
     }
     case Qt::Key_Z:
     {
-      // modifier+y ONLY caught for ShortcutOverride events...
-      if ( type == QEvent::ShortcutOverride && ( e->modifiers() == Qt::AltModifier || e->modifiers() == Qt::ControlModifier ) )
+      // modifier+z ONLY caught for ShortcutOverride events...
+      if ( type == QEvent::ShortcutOverride && e->modifiers() == Qt::AltModifier )
       {
         mZConstraint->toggleLocked();
         emit lockZChanged( mZConstraint->isLocked() );

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -250,6 +250,12 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     //! determines if CAD tools are enabled or if map tools behaves "nomally"
     bool cadEnabled() const { return mCadEnabled; }
 
+    /**
+     * Determines if Z or M will be enabled.
+      * \since QgIS 3.20
+      */
+    void switchZM( void );
+
     //! construction mode is used to draw intermediate points. These points won't be given any further (i.e. to the map tools)
     bool constructionMode() const { return mConstructionMode; }
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -254,7 +254,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      * Determines if Z or M will be enabled.
       * \since QgIS 3.20
       */
-    void switchZM( void );
+    void switchZM( );
 
     //! construction mode is used to draw intermediate points. These points won't be given any further (i.e. to the map tools)
     bool constructionMode() const { return mConstructionMode; }

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -266,6 +266,18 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     const CadConstraint *constraintX() const { return mXConstraint.get(); }
     //! Returns the \a CadConstraint on the Y coordinate
     const CadConstraint *constraintY() const { return mYConstraint.get(); }
+
+    /**
+     * Returns the \a CadConstraint on the Z coordinate
+     * \since QGIS 3.20
+     */
+    const CadConstraint *constraintZ() const { return mZConstraint.get(); }
+
+    /**
+     * Returns the \a CadConstraint on the M coordinate
+     * \since QGIS 3.20
+     */
+    const CadConstraint *constraintM() const { return mMConstraint.get(); }
     //! Returns TRUE if a constraint on a common angle is active
     bool commonAngleConstraint() const { return !qgsDoubleNear( mCommonAngleConstraint, 0.0 ); }
 
@@ -307,21 +319,21 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      * Helper for the CAD point list. The CAD point list is the list of points
      * currently digitized. It contains both  "normal" points and intermediate points (construction mode).
      */
-    QgsPointXY currentPoint( bool *exists  = nullptr ) const;
+    QgsPoint currentPoint( bool *exists  = nullptr ) const;
 
     /**
      * The previous point.
      * Helper for the CAD point list. The CAD point list is the list of points
      * currently digitized. It contains both  "normal" points and intermediate points (construction mode).
      */
-    QgsPointXY previousPoint( bool *exists = nullptr ) const;
+    QgsPoint previousPoint( bool *exists = nullptr ) const;
 
     /**
      * The penultimate point.
      * Helper for the CAD point list. The CAD point list is the list of points
      * currently digitized. It contains both  "normal" points and intermediate points (construction mode).
      */
-    QgsPointXY penultimatePoint( bool *exists = nullptr ) const;
+    QgsPoint penultimatePoint( bool *exists = nullptr ) const;
 
     /**
      * The number of points in the CAD point helper list
@@ -381,6 +393,26 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     void setY( const QString &value, WidgetSetMode mode );
 
     /**
+    * Set the Z value on the widget.
+    * Can be used to set constraints by external widgets.
+    * \param mode What type of interaction to emulate
+    * \param value The value (as a QString, as it could be an expression)
+    * \note unstable API (will likely change)
+    * \since QGIS 3.20
+    */
+    void setZ( const QString &value, WidgetSetMode mode );
+
+    /**
+    * Set the M value on the widget.
+    * Can be used to set constraints by external widgets.
+    * \param mode What type of interaction to emulate
+    * \param value The value (as a QString, as it could be an expression)
+    * \note unstable API (will likely change)
+    * \since QGIS 3.20
+    */
+    void setM( const QString &value, WidgetSetMode mode );
+
+    /**
     * Set the angle value on the widget.
     * Can be used to set constraints by external widgets.
     * \param mode What type of interaction to emulate
@@ -399,8 +431,6 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * \since QGIS 3.8
     */
     void setDistance( const QString &value, WidgetSetMode mode );
-
-
 
   signals:
 
@@ -422,7 +452,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      *
      * \param point The last known digitizing point. Can be used to emulate a mouse event.
      */
-    void pointChanged( const QgsPointXY &point );
+    void pointChanged( const QgsPoint &point );
 
     //! Signals for external widgets that need to update according to current values
 
@@ -450,6 +480,22 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * \since QGIS 3.8
     */
     void valueYChanged( const QString &value );
+
+    /**
+    * Emitted whenever the Z \a value changes (either the mouse moved, or the user changed the input).
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \note unstable API (will likely change)
+    * \since QGIS 3.20
+    */
+    void valueZChanged( const QString &value );
+
+    /**
+    * Emitted whenever the M \a value changes (either the mouse moved, or the user changed the input).
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \note unstable API (will likely change)
+    * \since QGIS 3.20
+    */
+    void valueMChanged( const QString &value );
 
     /**
     * Emitted whenever the angle \a value changes (either the mouse moved, or the user changed the input).
@@ -482,6 +528,22 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * \since QGIS 3.8
     */
     void lockYChanged( bool locked );
+
+    /**
+    * Emitted whenever the Z parameter is \a locked.
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \note unstable API (will likely change)
+    * \since QGIS 3.20
+    */
+    void lockZChanged( bool locked );
+
+    /**
+    * Emitted whenever the M parameter is \a locked.
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \note unstable API (will likely change)
+    * \since QGIS 3.20
+    */
+    void lockMChanged( bool locked );
 
     /**
     * Emitted whenever the angle parameter is \a locked.
@@ -520,6 +582,26 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     void relativeYChanged( bool relative );
 
     /**
+    * Emitted whenever the Z parameter is toggled between absolute and relative.
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    *
+    * \param relative Whether the Z parameter is relative or not.
+    * \note unstable API (will likely change)
+    * \since QGIS 3.20
+    */
+    void relativeZChanged( bool relative );
+
+    /**
+    * Emitted whenever the M parameter is toggled between absolute and relative.
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    *
+    * \param relative Whether the M parameter is relative or not.
+    * \note unstable API (will likely change)
+    * \since QGIS 3.20
+    */
+    void relativeMChanged( bool relative );
+
+    /**
     * Emitted whenever the angleX parameter is toggled between absolute and relative.
     * Could be used by widgets that must reflect the current advanced digitizing state.
     *
@@ -552,6 +634,28 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * \since QGIS 3.8
     */
     void enabledChangedY( bool enabled );
+
+    /**
+    * Emitted whenever the Z field is enabled or disabled. Depending on the context, some parameters
+    * do not make sense (e.g. you need a previous point to define a distance).
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    *
+    * \param enabled Whether the Z parameter is enabled or not.
+    * \note unstable API (will likely change)
+    * \since QGIS 3.20
+    */
+    void enabledChangedZ( bool enabled );
+
+    /**
+    * Emitted whenever the M field is enabled or disabled. Depending on the context, some parameters
+    * do not make sense (e.g. you need a previous point to define a distance).
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    *
+    * \param enabled Whether the M parameter is enabled or not.
+    * \note unstable API (will likely change)
+    * \since QGIS 3.20
+    */
+    void enabledChangedM( bool enabled );
 
     /**
     * Emitted whenever the angle field is enabled or disabled. Depending on the context, some parameters
@@ -590,6 +694,22 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * \since QGIS 3.8
     */
     void focusOnYRequested();
+
+    /**
+    * Emitted whenever the Z field should get the focus using the shortcuts (Z).
+    * Could be used by widgets to capture the focus when a field is being edited.
+    * \note unstable API (will likely change)
+    * \since QGIS 3.20
+    */
+    void focusOnZRequested();
+
+    /**
+    * Emitted whenever the M field should get the focus using the shortcuts (M).
+    * Could be used by widgets to capture the focus when a field is being edited.
+    * \note unstable API (will likely change)
+    * \since QGIS 3.20
+    */
+    void focusOnMRequested();
 
     /**
     * Emitted whenever the angle field should get the focus using the shortcuts (A).
@@ -666,7 +786,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     QList<QgsPointXY> snapSegmentToAllLayers( const QgsPointXY &originalMapPoint, bool *snapped = nullptr ) const;
 
     //! update the current point in the CAD point list
-    void updateCurrentPoint( const QgsPointXY &point );
+    void updateCurrentPoint( const QgsPoint &point );
 
 
     /**
@@ -699,7 +819,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     void updateConstraintValue( CadConstraint *constraint, const QString &textValue, bool convertExpression = false );
 
     //! Updates values of constraints that are not locked based on the current point
-    void updateUnlockedConstraintValues( const QgsPointXY &point );
+    void updateUnlockedConstraintValues( const QgsPoint &point );
 
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsAdvancedDigitizingCanvasItem *mCadPaintItem = nullptr;
@@ -723,11 +843,13 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     std::unique_ptr< CadConstraint > mDistanceConstraint;
     std::unique_ptr< CadConstraint > mXConstraint;
     std::unique_ptr< CadConstraint > mYConstraint;
+    std::unique_ptr< CadConstraint > mZConstraint;
+    std::unique_ptr< CadConstraint > mMConstraint;
     AdditionalConstraint mAdditionalConstraint;
     double mCommonAngleConstraint; // if 0: do not snap to common angles
 
     // point list and current snap point / segment
-    QList<QgsPointXY> mCadPointList;
+    QList<QgsPoint> mCadPointList;
     QList<QgsPointXY> mSnappedSegment;
 
     bool mSessionActive = false;
@@ -746,6 +868,8 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     //! event filter for line edits in the dock UI (angle/distance/x/y line edits)
     bool eventFilter( QObject *obj, QEvent *event );
 #endif
+    //! Convenient method to convert a 2D Point to a QgsPoint
+    QgsPoint pointXYToPoint( const QgsPointXY &point ) const;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsAdvancedDigitizingDockWidget::CadCapacities )

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -252,7 +252,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
 
     /**
      * Determines if Z or M will be enabled.
-     * \since QGIS 3.20
+     * \since QGIS 3.22
      */
     void switchZM( );
 
@@ -275,13 +275,13 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
 
     /**
      * Returns the \a CadConstraint on the Z coordinate
-     * \since QGIS 3.20
+     * \since QGIS 3.22
      */
     const CadConstraint *constraintZ() const { return mZConstraint.get(); }
 
     /**
      * Returns the \a CadConstraint on the M coordinate
-     * \since QGIS 3.20
+     * \since QGIS 3.22
      */
     const CadConstraint *constraintM() const { return mMConstraint.get(); }
     //! Returns TRUE if a constraint on a common angle is active
@@ -404,7 +404,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * \param mode What type of interaction to emulate
     * \param value The value (as a QString, as it could be an expression)
     * \note unstable API (will likely change)
-    * \since QGIS 3.20
+    * \since QGIS 3.22
     */
     void setZ( const QString &value, WidgetSetMode mode );
 
@@ -414,7 +414,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * \param mode What type of interaction to emulate
     * \param value The value (as a QString, as it could be an expression)
     * \note unstable API (will likely change)
-    * \since QGIS 3.20
+    * \since QGIS 3.22
     */
     void setM( const QString &value, WidgetSetMode mode );
 
@@ -503,7 +503,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * Emitted whenever the Z \a value changes (either the mouse moved, or the user changed the input).
     * Could be used by widgets that must reflect the current advanced digitizing state.
     * \note unstable API (will likely change)
-    * \since QGIS 3.20
+    * \since QGIS 3.22
     */
     void valueZChanged( const QString &value );
 
@@ -511,7 +511,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * Emitted whenever the M \a value changes (either the mouse moved, or the user changed the input).
     * Could be used by widgets that must reflect the current advanced digitizing state.
     * \note unstable API (will likely change)
-    * \since QGIS 3.20
+    * \since QGIS 3.22
     */
     void valueMChanged( const QString &value );
 
@@ -551,7 +551,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * Emitted whenever the Z parameter is \a locked.
     * Could be used by widgets that must reflect the current advanced digitizing state.
     * \note unstable API (will likely change)
-    * \since QGIS 3.20
+    * \since QGIS 3.22
     */
     void lockZChanged( bool locked );
 
@@ -559,7 +559,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * Emitted whenever the M parameter is \a locked.
     * Could be used by widgets that must reflect the current advanced digitizing state.
     * \note unstable API (will likely change)
-    * \since QGIS 3.20
+    * \since QGIS 3.22
     */
     void lockMChanged( bool locked );
 
@@ -605,7 +605,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     *
     * \param relative Whether the Z parameter is relative or not.
     * \note unstable API (will likely change)
-    * \since QGIS 3.20
+    * \since QGIS 3.22
     */
     void relativeZChanged( bool relative );
 
@@ -615,7 +615,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     *
     * \param relative Whether the M parameter is relative or not.
     * \note unstable API (will likely change)
-    * \since QGIS 3.20
+    * \since QGIS 3.22
     */
     void relativeMChanged( bool relative );
 
@@ -660,7 +660,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     *
     * \param enabled Whether the Z parameter is enabled or not.
     * \note unstable API (will likely change)
-    * \since QGIS 3.20
+    * \since QGIS 3.22
     */
     void enabledChangedZ( bool enabled );
 
@@ -671,7 +671,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     *
     * \param enabled Whether the M parameter is enabled or not.
     * \note unstable API (will likely change)
-    * \since QGIS 3.20
+    * \since QGIS 3.22
     */
     void enabledChangedM( bool enabled );
 
@@ -717,7 +717,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * Emitted whenever the Z field should get the focus using the shortcuts (Z).
     * Could be used by widgets to capture the focus when a field is being edited.
     * \note unstable API (will likely change)
-    * \since QGIS 3.20
+    * \since QGIS 3.22
     */
     void focusOnZRequested();
 
@@ -725,7 +725,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * Emitted whenever the M field should get the focus using the shortcuts (M).
     * Could be used by widgets to capture the focus when a field is being edited.
     * \note unstable API (will likely change)
-    * \since QGIS 3.20
+    * \since QGIS 3.22
     */
     void focusOnMRequested();
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -325,21 +325,45 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      * Helper for the CAD point list. The CAD point list is the list of points
      * currently digitized. It contains both  "normal" points and intermediate points (construction mode).
      */
-    QgsPoint currentPoint( bool *exists  = nullptr ) const;
+    QgsPoint currentPointV2( bool *exists  = nullptr ) const;
+
+    /**
+     * The last point.
+     * Helper for the CAD point list. The CAD point list is the list of points
+     * currently digitized. It contains both  "normal" points and intermediate points (construction mode).
+     * \deprecated since QGIS 3.22 - will be removed in QGIS 4.0. Use the variant which returns QgsPoint object instead of QgsPointXY.
+     */
+    Q_DECL_DEPRECATED QgsPointXY currentPoint( bool *exists  = nullptr ) const SIP_DEPRECATED { return currentPointV2( exists ); };
 
     /**
      * The previous point.
      * Helper for the CAD point list. The CAD point list is the list of points
      * currently digitized. It contains both  "normal" points and intermediate points (construction mode).
      */
-    QgsPoint previousPoint( bool *exists = nullptr ) const;
+    QgsPoint previousPointV2( bool *exists = nullptr ) const;
+
+    /**
+     * The previous point.
+     * Helper for the CAD point list. The CAD point list is the list of points
+     * currently digitized. It contains both  "normal" points and intermediate points (construction mode).
+     * \deprecated since QGIS 3.22 - will be removed in QGIS 4.0. Use the variant which returns QgsPoint object instead of QgsPointXY.
+     */
+    Q_DECL_DEPRECATED QgsPointXY previousPoint( bool *exists = nullptr ) const SIP_DEPRECATED { return previousPointV2( exists ); };
 
     /**
      * The penultimate point.
      * Helper for the CAD point list. The CAD point list is the list of points
      * currently digitized. It contains both  "normal" points and intermediate points (construction mode).
      */
-    QgsPoint penultimatePoint( bool *exists = nullptr ) const;
+    QgsPoint penultimatePointV2( bool *exists = nullptr ) const;
+
+    /**
+     * The penultimate point.
+     * Helper for the CAD point list. The CAD point list is the list of points
+     * currently digitized. It contains both  "normal" points and intermediate points (construction mode).
+     * \deprecated since QGIS 3.22 - will be removed in QGIS 4.0. Use the variant which returns QgsPoint object instead of QgsPointXY.
+     */
+    Q_DECL_DEPRECATED QgsPointXY penultimatePoint( bool *exists = nullptr ) const SIP_DEPRECATED { return penultimatePointV2( exists ); };
 
     /**
      * The number of points in the CAD point helper list

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -254,7 +254,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      * Determines if Z or M will be enabled.
       * \since QgIS 3.20
       */
-    void switchZM( );
+    void switchZM( void );
 
     //! construction mode is used to draw intermediate points. These points won't be given any further (i.e. to the map tools)
     bool constructionMode() const { return mConstructionMode; }

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -252,8 +252,8 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
 
     /**
      * Determines if Z or M will be enabled.
-      * \since QgIS 3.20
-      */
+     * \since QGIS 3.20
+     */
     void switchZM( );
 
     //! construction mode is used to draw intermediate points. These points won't be given any further (i.e. to the map tools)

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -438,6 +438,18 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     */
     void setDistance( const QString &value, WidgetSetMode mode );
 
+    /**
+     * Convenient method to get the Z value from the line edit wiget
+     * \since QGIS 3.22
+     */
+    double getLineZ( ) const;
+
+    /**
+     * Convenient method to get the M value from the line edit wiget
+     * \since QGIS 3.22
+     */
+    double getLineM( ) const;
+
   signals:
 
     /**

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -493,8 +493,18 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      * when a constraint is toggled.
      *
      * \param point The last known digitizing point. Can be used to emulate a mouse event.
+     * \since QGIS 3.22
      */
-    void pointChanged( const QgsPoint &point );
+    void pointChangedV2( const QgsPoint &point );
+
+    /**
+     * Sometimes a constraint may change the current point out of a mouse event. This happens normally
+     * when a constraint is toggled.
+     *
+     * \param point The last known digitizing point. Can be used to emulate a mouse event.
+     * \deprecated since QGIS 3.22 - No longer used, will be removed in QGIS 4.0. Use the variant which emits QgsPoint object instead of QgsPointXY.
+     */
+    Q_DECL_DEPRECATED void pointChanged( const QgsPointXY &point ) SIP_DEPRECATED;
 
     //! Signals for external widgets that need to update according to current values
 

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -121,7 +121,7 @@ void QgsMapToolAdvancedDigitizing::canvasMoveEvent( QgsMapMouseEvent *e )
 void QgsMapToolAdvancedDigitizing::activate()
 {
   QgsMapToolEdit::activate();
-  connect( mCadDockWidget, &QgsAdvancedDigitizingDockWidget::pointChanged, this, &QgsMapToolAdvancedDigitizing::cadPointChanged );
+  connect( mCadDockWidget, &QgsAdvancedDigitizingDockWidget::pointChangedV2, this, &QgsMapToolAdvancedDigitizing::cadPointChanged );
   mCadDockWidget->enable();
   mSnapToGridCanvasItem = new QgsSnapToGridCanvasItem( mCanvas );
   QgsVectorLayer *layer = currentVectorLayer();
@@ -136,7 +136,7 @@ void QgsMapToolAdvancedDigitizing::activate()
 void QgsMapToolAdvancedDigitizing::deactivate()
 {
   QgsMapToolEdit::deactivate();
-  disconnect( mCadDockWidget, &QgsAdvancedDigitizingDockWidget::pointChanged, this, &QgsMapToolAdvancedDigitizing::cadPointChanged );
+  disconnect( mCadDockWidget, &QgsAdvancedDigitizingDockWidget::pointChangedV2, this, &QgsMapToolAdvancedDigitizing::cadPointChanged );
   mCadDockWidget->disable();
   delete mSnapToGridCanvasItem;
   mSnapToGridCanvasItem = nullptr;

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -458,9 +458,9 @@ int QgsMapToolCapture::nextPoint( const QgsPoint &mapPoint, QgsPoint &layerPoint
       const QgsPointXY mapP( mapPoint.x(), mapPoint.y() );  //#spellok
       layerPoint = QgsPoint( toLayerCoordinates( vlayer, mapP ) ); //transform snapped point back to layer crs  //#spellok
       if ( QgsWkbTypes::hasZ( vlayer->wkbType() ) && !layerPoint.is3D() )
-        layerPoint.addZValue( mCadDockWidget && mCadDockWidget->cadEnabled() ? mCadDockWidget->currentPoint().z() : defaultZValue() );
+        layerPoint.addZValue( mCadDockWidget && mCadDockWidget->cadEnabled() ? mCadDockWidget->currentPointV2().z() : defaultZValue() );
       if ( QgsWkbTypes::hasM( vlayer->wkbType() ) && !layerPoint.isMeasure() )
-        layerPoint.addMValue( mCadDockWidget && mCadDockWidget->cadEnabled() ? mCadDockWidget->currentPoint().m() : defaultMValue() );
+        layerPoint.addMValue( mCadDockWidget && mCadDockWidget->cadEnabled() ? mCadDockWidget->currentPointV2().m() : defaultMValue() );
     }
     catch ( QgsCsException & )
     {
@@ -488,7 +488,7 @@ int QgsMapToolCapture::fetchLayerPoint( const QgsPointLocator::Match &match, Qgs
   QgsVectorLayer *sourceLayer = match.layer();
   if ( mCadDockWidget && mCadDockWidget->cadEnabled() )
   {
-    layerPoint = mCadDockWidget->currentPoint();
+    layerPoint = mCadDockWidget->currentPointV2();
     return 0;
   }
   else

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -151,6 +151,7 @@ void QgsMapToolCapture::currentLayerChanged( QgsMapLayer *layer )
     mTempRubberBand->setRubberBandGeometryType( mCaptureMode == CapturePolygon ? QgsWkbTypes::PolygonGeometry : QgsWkbTypes::LineGeometry );
 
   resetRubberBand();
+  cadDockWidget()->switchZM();
 }
 
 

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -512,7 +512,7 @@ int QgsMapToolCapture::fetchLayerPoint( const QgsPointLocator::Match &match, Qgs
       {
         layerPoint = geom.constGet()->vertexAt( vId );
         if ( QgsWkbTypes::hasZ( vlayer->wkbType() ) && !layerPoint.is3D() )
-          layerPoint.addZValue( defaultZValue() );
+          layerPoint.addZValue( mCadDockWidget && mCadDockWidget->cadEnabled() ? mCadDockWidget->currentPoint().z() : defaultZValue() );
         if ( QgsWkbTypes::hasM( vlayer->wkbType() ) && !layerPoint.isMeasure() )
           layerPoint.addMValue( defaultMValue() );
       }
@@ -1017,7 +1017,7 @@ QgsPoint QgsMapToolCapture::mapPoint( const QgsPointXY &point ) const
   // set z value if necessary
   if ( QgsWkbTypes::hasZ( newPoint.wkbType() ) )
   {
-    newPoint.setZ( defaultZValue() );
+    newPoint.setZ( mCadDockWidget && mCadDockWidget->cadEnabled() ? mCadDockWidget->currentPoint().z() : defaultZValue() );
   }
   // set m value if necessary
   if ( QgsWkbTypes::hasM( newPoint.wkbType() ) )

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -457,10 +457,10 @@ int QgsMapToolCapture::nextPoint( const QgsPoint &mapPoint, QgsPoint &layerPoint
     {
       const QgsPointXY mapP( mapPoint.x(), mapPoint.y() );  //#spellok
       layerPoint = QgsPoint( toLayerCoordinates( vlayer, mapP ) ); //transform snapped point back to layer crs  //#spellok
-      if ( QgsWkbTypes::hasZ( vlayer->wkbType() ) )
-        layerPoint.addZValue( defaultZValue() );
-      if ( QgsWkbTypes::hasM( vlayer->wkbType() ) )
-        layerPoint.addMValue( defaultMValue() );
+      if ( QgsWkbTypes::hasZ( vlayer->wkbType() ) && !layerPoint.is3D() )
+        layerPoint.addZValue( mCadDockWidget && mCadDockWidget->cadEnabled() ? mCadDockWidget->currentPoint().z() : defaultZValue() );
+      if ( QgsWkbTypes::hasM( vlayer->wkbType() ) && !layerPoint.isMeasure() )
+        layerPoint.addMValue( mCadDockWidget && mCadDockWidget->cadEnabled() ? mCadDockWidget->currentPoint().m() : defaultMValue() );
     }
     catch ( QgsCsException & )
     {

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -515,7 +515,7 @@ int QgsMapToolCapture::fetchLayerPoint( const QgsPointLocator::Match &match, Qgs
         if ( QgsWkbTypes::hasZ( vlayer->wkbType() ) && !layerPoint.is3D() )
           layerPoint.addZValue( mCadDockWidget && mCadDockWidget->cadEnabled() ? mCadDockWidget->currentPoint().z() : defaultZValue() );
         if ( QgsWkbTypes::hasM( vlayer->wkbType() ) && !layerPoint.isMeasure() )
-          layerPoint.addMValue( defaultMValue() );
+          layerPoint.addMValue( mCadDockWidget && mCadDockWidget->cadEnabled() ? mCadDockWidget->currentPoint().m() : defaultMValue() );
       }
 
       // ZM support depends on the target layer
@@ -1023,7 +1023,7 @@ QgsPoint QgsMapToolCapture::mapPoint( const QgsPointXY &point ) const
   // set m value if necessary
   if ( QgsWkbTypes::hasM( newPoint.wkbType() ) )
   {
-    newPoint.setM( defaultMValue() );
+    newPoint.setM( mCadDockWidget && mCadDockWidget->cadEnabled() ? mCadDockWidget->currentPoint().m() : defaultMValue() );
   }
 
   return newPoint;

--- a/src/ui/qgsadvanceddigitizingdockwidgetbase.ui
+++ b/src/ui/qgsadvanceddigitizingdockwidgetbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>208</width>
-    <height>220</height>
+    <width>252</width>
+    <height>250</height>
    </rect>
   </property>
   <property name="maximumSize">
@@ -112,60 +112,6 @@
             <property name="spacing">
              <number>3</number>
             </property>
-            <item row="3" column="1">
-             <widget class="QLabel" name="label_4">
-              <property name="text">
-               <string>y</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="2">
-             <widget class="QLineEdit" name="mYLineEdit">
-              <property name="toolTip">
-               <string/>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="3">
-             <widget class="QToolButton" name="mLockYButton">
-              <property name="toolTip">
-               <string/>
-              </property>
-              <property name="text">
-               <string>…</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-              <property name="autoRaise">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="3">
-             <widget class="QToolButton" name="mLockXButton">
-              <property name="toolTip">
-               <string/>
-              </property>
-              <property name="text">
-               <string>…</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-              <property name="autoRaise">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
             <item row="3" column="0">
              <widget class="QToolButton" name="mRelativeYButton">
               <property name="toolTip">
@@ -186,37 +132,10 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="3">
-             <widget class="QToolButton" name="mLockAngleButton">
-              <property name="toolTip">
-               <string/>
-              </property>
+            <item row="0" column="1">
+             <widget class="QLabel" name="label">
               <property name="text">
-               <string>…</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-              <property name="autoRaise">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="2">
-             <widget class="QLineEdit" name="mXLineEdit">
-              <property name="toolTip">
-               <string/>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QLabel" name="label_2">
-              <property name="text">
-               <string>a</string>
+               <string>d</string>
               </property>
              </widget>
             </item>
@@ -243,56 +162,8 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="2">
-             <widget class="QLineEdit" name="mAngleLineEdit">
-              <property name="toolTip">
-               <string/>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QLabel" name="label_3">
-              <property name="text">
-               <string>x</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QLabel" name="label">
-              <property name="text">
-               <string>d</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="3">
-             <widget class="QToolButton" name="mLockDistanceButton">
-              <property name="toolTip">
-               <string/>
-              </property>
-              <property name="text">
-               <string>…</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-              <property name="autoRaise">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="2">
-             <widget class="QLineEdit" name="mDistanceLineEdit">
-              <property name="toolTip">
-               <string/>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QToolButton" name="mRelativeXButton">
+            <item row="5" column="0">
+             <widget class="QToolButton" name="mRelativeMButton">
               <property name="toolTip">
                <string/>
               </property>
@@ -311,28 +182,22 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="4">
-             <widget class="QToolButton" name="mRepeatingLockDistanceButton">
+            <item row="5" column="2">
+             <widget class="QLineEdit" name="mMLineEdit">
               <property name="toolTip">
                <string/>
               </property>
-              <property name="text">
-               <string>…</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/locked_repeating.svg</normaloff>:/images/themes/default/locked_repeating.svg</iconset>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-              <property name="autoRaise">
-               <bool>true</bool>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QLineEdit" name="mDistanceLineEdit">
+              <property name="toolTip">
+               <string/>
               </property>
              </widget>
             </item>
-            <item row="1" column="4">
-             <widget class="QToolButton" name="mRepeatingLockAngleButton">
+            <item row="5" column="4">
+             <widget class="QToolButton" name="mRepeatingLockMButton">
               <property name="toolTip">
                <string/>
               </property>
@@ -371,6 +236,282 @@
               </property>
              </widget>
             </item>
+            <item row="0" column="4">
+             <widget class="QToolButton" name="mRepeatingLockDistanceButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/locked_repeating.svg</normaloff>:/images/themes/default/locked_repeating.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QLabel" name="mZLabel">
+              <property name="text">
+               <string>z</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="QLineEdit" name="mAngleLineEdit">
+              <property name="toolTip">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="3">
+             <widget class="QToolButton" name="mLockXButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QToolButton" name="mRelativeZButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/cadtools/delta.svg</normaloff>:/images/themes/default/cadtools/delta.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLabel" name="label_2">
+              <property name="text">
+               <string>a</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="3">
+             <widget class="QToolButton" name="mLockAngleButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="2">
+             <widget class="QLineEdit" name="mXLineEdit">
+              <property name="toolTip">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLabel" name="label_3">
+              <property name="text">
+               <string>x</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="3">
+             <widget class="QToolButton" name="mLockMButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="3">
+             <widget class="QToolButton" name="mLockZButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="2">
+             <widget class="QLineEdit" name="mYLineEdit">
+              <property name="toolTip">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLabel" name="label_4">
+              <property name="text">
+               <string>y</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="4">
+             <widget class="QToolButton" name="mRepeatingLockZButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/locked_repeating.svg</normaloff>:/images/themes/default/locked_repeating.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="3">
+             <widget class="QToolButton" name="mLockDistanceButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="4">
+             <widget class="QToolButton" name="mRepeatingLockAngleButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/locked_repeating.svg</normaloff>:/images/themes/default/locked_repeating.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QToolButton" name="mRelativeXButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/cadtools/delta.svg</normaloff>:/images/themes/default/cadtools/delta.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="2">
+             <widget class="QLineEdit" name="mZLineEdit">
+              <property name="toolTip">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="3">
+             <widget class="QToolButton" name="mLockYButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
             <item row="3" column="4">
              <widget class="QToolButton" name="mRepeatingLockYButton">
               <property name="toolTip">
@@ -391,7 +532,14 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="0">
+            <item row="5" column="1">
+             <widget class="QLabel" name="mMLabel">
+              <property name="text">
+               <string>m</string>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="0">
              <spacer name="verticalSpacer">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
@@ -414,57 +562,57 @@
     </item>
    </layout>
    <action name="mEnableAction">
+    <property name="checkable">
+     <bool>true</bool>
+    </property>
+    <property name="icon">
+     <iconset resource="../../images/images.qrc">
+      <normaloff>:/images/themes/default/cadtools/cad.svg</normaloff>:/images/themes/default/cadtools/cad.svg</iconset>
+    </property>
     <property name="toolTip">
      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable advanced digitizing tools&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
     </property>
-    <property name="icon">
-     <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/cadtools/cad.svg</normaloff>:/images/themes/default/cadtools/cad.svg</iconset>
-    </property>
-    <property name="checkable">
-     <bool>true</bool>
-    </property>
    </action>
    <action name="mConstructionModeAction">
-    <property name="toolTip">
-     <string/>
+    <property name="checkable">
+     <bool>true</bool>
     </property>
     <property name="icon">
      <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/cadtools/construction.svg</normaloff>:/images/themes/default/cadtools/construction.svg</iconset>
+      <normaloff>:/images/themes/default/cadtools/construction.svg</normaloff>:/images/themes/default/cadtools/construction.svg</iconset>
     </property>
-    <property name="checkable">
-     <bool>true</bool>
+    <property name="toolTip">
+     <string/>
     </property>
    </action>
    <action name="mParallelAction">
-    <property name="toolTip">
-     <string/>
+    <property name="checkable">
+     <bool>true</bool>
     </property>
     <property name="icon">
      <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/cadtools/parallel.svg</normaloff>:/images/themes/default/cadtools/parallel.svg</iconset>
+      <normaloff>:/images/themes/default/cadtools/parallel.svg</normaloff>:/images/themes/default/cadtools/parallel.svg</iconset>
     </property>
-    <property name="checkable">
-     <bool>true</bool>
+    <property name="toolTip">
+     <string/>
     </property>
    </action>
    <action name="mPerpendicularAction">
-    <property name="toolTip">
-     <string/>
+    <property name="checkable">
+     <bool>true</bool>
     </property>
     <property name="icon">
      <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/cadtools/perpendicular.svg</normaloff>:/images/themes/default/cadtools/perpendicular.svg</iconset>
+      <normaloff>:/images/themes/default/cadtools/perpendicular.svg</normaloff>:/images/themes/default/cadtools/perpendicular.svg</iconset>
     </property>
-    <property name="checkable">
-     <bool>true</bool>
+    <property name="toolTip">
+     <string/>
     </property>
    </action>
    <action name="mSettingsAction">
     <property name="icon">
      <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/propertyicons/settings.svg</normaloff>:/images/themes/default/propertyicons/settings.svg</iconset>
+      <normaloff>:/images/themes/default/propertyicons/settings.svg</normaloff>:/images/themes/default/propertyicons/settings.svg</iconset>
     </property>
    </action>
   </widget>
@@ -505,36 +653,16 @@
   <tabstop>mYLineEdit</tabstop>
   <tabstop>mLockYButton</tabstop>
   <tabstop>mRepeatingLockYButton</tabstop>
+  <tabstop>mRelativeZButton</tabstop>
+  <tabstop>mZLineEdit</tabstop>
+  <tabstop>mLockZButton</tabstop>
+  <tabstop>mRepeatingLockZButton</tabstop>
+  <tabstop>mRelativeMButton</tabstop>
+  <tabstop>mMLineEdit</tabstop>
+  <tabstop>mLockMButton</tabstop>
+  <tabstop>mRepeatingLockMButton</tabstop>
  </tabstops>
  <resources>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/tests/src/core/testqgscadutils.cpp
+++ b/tests/src/core/testqgscadutils.cpp
@@ -53,7 +53,7 @@ class TestQgsCadUtils : public QObject
       QgsCadUtils::AlignMapPointContext context;
       context.snappingUtils = mSnappingUtils;
       context.mapUnitsPerPixel = mMapSettings.mapUnitsPerPixel();
-      context.cadPointList << QgsPointXY() << QgsPointXY( 30, 20 ) << QgsPointXY( 30, 30 );
+      context.cadPointList << QgsPoint() << QgsPoint( 30, 20 ) << QgsPoint( 30, 30 );
       return context;
     }
 
@@ -231,8 +231,8 @@ void TestQgsCadUtils::testCommonAngle()
   // common angle rel
   context.angleConstraint = QgsCadUtils::AlignMapPointConstraint();
   context.commonAngleConstraint = QgsCadUtils::AlignMapPointConstraint( true, true, 90 );
-  context.cadPointList[1] = QgsPointXY( 40, 20 );
-  const QgsCadUtils::AlignMapPointOutput res3 = QgsCadUtils::alignMapPoint( QgsPointXY( 50.1, 29.9 ), context );
+  context.cadPointList[1] = QgsPoint( 40, 20 );
+  QgsCadUtils::AlignMapPointOutput res3 = QgsCadUtils::alignMapPoint( QgsPointXY( 50.1, 29.9 ), context );
   QVERIFY( res3.valid );
   QCOMPARE( res3.softLockCommonAngle, 90.0 );
   QCOMPARE( res3.finalMapPoint, QgsPointXY( 50, 30 ) );
@@ -293,7 +293,7 @@ void TestQgsCadUtils::testDistance()
 void TestQgsCadUtils::testEdge()
 {
   QgsCadUtils::AlignMapPointContext context( baseContext() );
-  context.cadPointList = QList<QgsPointXY>() << QgsPointXY() << QgsPointXY( 40, 30 ) << QgsPointXY( 40, 40 );
+  context.cadPointList = QList<QgsPoint>() << QgsPoint() << QgsPoint( 40, 30 ) << QgsPoint( 40, 40 );
 
   const QgsPointXY edgePt( 20, 15 );  // in the middle of the triangle polygon's edge
 

--- a/tests/src/core/testqgscadutils.cpp
+++ b/tests/src/core/testqgscadutils.cpp
@@ -53,7 +53,7 @@ class TestQgsCadUtils : public QObject
       QgsCadUtils::AlignMapPointContext context;
       context.snappingUtils = mSnappingUtils;
       context.mapUnitsPerPixel = mMapSettings.mapUnitsPerPixel();
-      context.cadPointList << QgsPoint() << QgsPoint( 30, 20 ) << QgsPoint( 30, 30 );
+      context.cadPoints() << QgsPoint() << QgsPoint( 30, 20 ) << QgsPoint( 30, 30 );
       return context;
     }
 
@@ -231,7 +231,7 @@ void TestQgsCadUtils::testCommonAngle()
   // common angle rel
   context.angleConstraint = QgsCadUtils::AlignMapPointConstraint();
   context.commonAngleConstraint = QgsCadUtils::AlignMapPointConstraint( true, true, 90 );
-  context.cadPointList[1] = QgsPoint( 40, 20 );
+  context.cadPoints()[1] = QgsPoint( 40, 20 );
   QgsCadUtils::AlignMapPointOutput res3 = QgsCadUtils::alignMapPoint( QgsPointXY( 50.1, 29.9 ), context );
   QVERIFY( res3.valid );
   QCOMPARE( res3.softLockCommonAngle, 90.0 );
@@ -293,7 +293,7 @@ void TestQgsCadUtils::testDistance()
 void TestQgsCadUtils::testEdge()
 {
   QgsCadUtils::AlignMapPointContext context( baseContext() );
-  context.cadPointList = QList<QgsPoint>() << QgsPoint() << QgsPoint( 40, 30 ) << QgsPoint( 40, 40 );
+  context.setCadPoints( QList<QgsPoint>() << QgsPoint() << QgsPoint( 40, 30 ) << QgsPoint( 40, 40 ) );
 
   const QgsPointXY edgePt( 20, 15 );  // in the middle of the triangle polygon's edge
 

--- a/tests/src/core/testqgscadutils.cpp
+++ b/tests/src/core/testqgscadutils.cpp
@@ -53,7 +53,7 @@ class TestQgsCadUtils : public QObject
       QgsCadUtils::AlignMapPointContext context;
       context.snappingUtils = mSnappingUtils;
       context.mapUnitsPerPixel = mMapSettings.mapUnitsPerPixel();
-      context.cadPoints() << QgsPoint() << QgsPoint( 30, 20 ) << QgsPoint( 30, 30 );
+      context.setCadPoints( QList<QgsPoint>() << QgsPoint() << QgsPoint( 30, 20 ) << QgsPoint( 30, 30 ) );
       return context;
     }
 
@@ -231,7 +231,7 @@ void TestQgsCadUtils::testCommonAngle()
   // common angle rel
   context.angleConstraint = QgsCadUtils::AlignMapPointConstraint();
   context.commonAngleConstraint = QgsCadUtils::AlignMapPointConstraint( true, true, 90 );
-  context.cadPoints()[1] = QgsPoint( 40, 20 );
+  context.setCadPoint( QgsPoint( 40, 20 ), 1 );
   QgsCadUtils::AlignMapPointOutput res3 = QgsCadUtils::alignMapPoint( QgsPointXY( 50.1, 29.9 ), context );
   QVERIFY( res3.valid );
   QCOMPARE( res3.softLockCommonAngle, 90.0 );


### PR DESCRIPTION
## Description


Drawing directly vertices with a Z other than the default one is not possible today in QGIS. We proceed as follows:

![advanced_zm_before mkv](https://user-images.githubusercontent.com/7521540/109980025-c8a9ad80-7cff-11eb-8281-3f29913bec4f.gif)

There have been several requests to add the Z and M in this panel. At least by @saberraz and @DelazJ in https://github.com/qgis/QGIS/issues/25865 and https://github.com/qgis/QGIS/issues/29415 

Some people need more and more to draw networks with 3D vertices : it is particularly interesting to propose the addition of the Z (and M) in this one.

I simply propose the addition of these two lines in the panel to remain in the same logic as today:

![advanced_zm_after mkv](https://user-images.githubusercontent.com/7521540/109979970-bb8cbe80-7cff-11eb-8fa7-a56dccd0e78b.gif)

There have been several developments to fix Z snapping on vertices and segments (but, for this one, only when topological editing is activated) and this PR will not break this logic. The weight of the snapping is higher than the value given in the widget.

![advanced_zm_snap mkv](https://user-images.githubusercontent.com/7521540/109980128-de1ed780-7cff-11eb-8945-e6c2133b4d1c.gif)

About the code, it is mainly a copy and paste of existing functions for X/Y with adaptation to get the Z (and M)

Still in WIP state since I have to continue some tests. Feedbacks are appreciated.

Sponsored by: Métropole Européenne de Lille @Jean-Roc