### PR TITLE
Nonimatim locator filter & processing batch georeferencer

### DIFF
--- a/python/core/auto_generated/geocoding/qgsnominatimgeocoder.sip.in
+++ b/python/core/auto_generated/geocoding/qgsnominatimgeocoder.sip.in
@@ -56,7 +56,7 @@ Returns the URL generated for geocoding the specified ``address``.
 
     QgsGeocoderResult jsonToResult( const QVariantMap &json ) const;
 %Docstring
-Converts a JSON result returned from the Google Maps service to a geocoder result object.
+Converts a JSON result returned from the Nominatim service to a geocoder result object.
 %End
 
     QString endpoint() const;

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -37,6 +37,7 @@ set(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmassignprojection.cpp
   processing/qgsalgorithmattributeindex.cpp
   processing/qgsalgorithmbatchgeocode.cpp
+  processing/qgsalgorithmbatchnominatimgeocode.cpp
   processing/qgsalgorithmboundary.cpp
   processing/qgsalgorithmboundingbox.cpp
   processing/qgsalgorithmbuffer.cpp
@@ -321,6 +322,7 @@ set(QGIS_ANALYSIS_HDRS
   network/qgsvectorlayerdirector.h
 
   processing/qgsalgorithmbatchgeocode.h
+  processing/qgsalgorithmbatchnominatimgeocode.h
   processing/qgsalgorithmfiledownloader.h
   processing/qgsalgorithmimportphotos.h
   processing/qgsnativealgorithms.h

--- a/src/analysis/processing/qgsalgorithmbatchnominatimgeocode.cpp
+++ b/src/analysis/processing/qgsalgorithmbatchnominatimgeocode.cpp
@@ -41,12 +41,18 @@ QString QgsBatchNominatimGeocodeAlgorithm::displayName() const
 
 QStringList QgsBatchNominatimGeocodeAlgorithm::tags() const
 {
-  return QObject::tr( "geocode,nominatim,batch" ).split( ',' );
+  return QObject::tr( "geocode,nominatim,batch,bulk,address,match" ).split( ',' );
 }
 
 QgsBatchNominatimGeocodeAlgorithm *QgsBatchNominatimGeocodeAlgorithm::createInstance() const
 {
   return new QgsBatchNominatimGeocodeAlgorithm();
+}
+
+QString QgsBatchNominatimGeocodeAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm performs batch geocoding using the <a href=\"#\">Nominatim</a> service against an input layer string field.\n\n"
+                      "The output layer will have a point geometry reflecting the geocoded location as well as a number of attributes associated to the geocoded location." );
 }
 
 bool QgsBatchNominatimGeocodeAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )

--- a/src/analysis/processing/qgsalgorithmbatchnominatimgeocode.cpp
+++ b/src/analysis/processing/qgsalgorithmbatchnominatimgeocode.cpp
@@ -1,0 +1,59 @@
+/***************************************************************************
+                         qgsalgorithmbatchnominatimgeocode.cpp
+                         ------------------
+    begin                : December 2020
+    copyright            : (C) 2020 by Mathieu Pellerin
+    email                : nirvn dot asia at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmbatchgeocode.h"
+#include "qgsalgorithmbatchnominatimgeocode.h"
+#include "qgsgeocoder.h"
+#include "qgsgeocoderresult.h"
+#include "qgsgeocodercontext.h"
+#include "qgsvectorlayer.h"
+
+///@cond PRIVATE
+
+QgsBatchNominatimGeocodeAlgorithm::QgsBatchNominatimGeocodeAlgorithm()
+  : QgsBatchGeocodeAlgorithm( &mNominatimGeocoder )
+{
+}
+
+QString QgsBatchNominatimGeocodeAlgorithm::name() const
+{
+  return QStringLiteral( "batchnominatimgeocoder" );
+}
+
+QString QgsBatchNominatimGeocodeAlgorithm::displayName() const
+{
+  return QObject::tr( "Batch Nominatim geocoder" );
+}
+
+QStringList QgsBatchNominatimGeocodeAlgorithm::tags() const
+{
+  return QObject::tr( "geocode,nominatim,batch" ).split( ',' );
+}
+
+QgsBatchNominatimGeocodeAlgorithm *QgsBatchNominatimGeocodeAlgorithm::createInstance() const
+{
+  return new QgsBatchNominatimGeocodeAlgorithm();
+}
+
+bool QgsBatchNominatimGeocodeAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  feedback->pushInfo( QObject::tr( "The Nominatim geocoder data is made available by OpenStreetMap Foundation and contributors. "
+                                   "It is provided under the ODbL license which requires to share alike. Visit https://nominatim.org/ to learn more." ) );
+  return QgsBatchGeocodeAlgorithm::prepareAlgorithm( parameters, context, feedback );
+}
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmbatchnominatimgeocode.h
+++ b/src/analysis/processing/qgsalgorithmbatchnominatimgeocode.h
@@ -1,0 +1,62 @@
+/***************************************************************************
+                         qgsalgorithmbatchnominatimgeocode.h
+                         ------------------
+    begin                : December 2020
+    copyright            : (C) 2020 by Mathieu Pellerin
+    email                : nirvn dot asia at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMBATCHNOMINATIMGEOCODE_H
+#define QGSALGORITHMBATCHNOMINATIMGEOCODE_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgis_analysis.h"
+#include "qgsprocessingalgorithm.h"
+#include "qgsalgorithmbatchgeocode.h"
+#include "qgsnominatimgeocoder.h"
+
+///@cond PRIVATE
+
+/**
+ * Native batch Nominatim geocoder.
+ */
+class QgsBatchNominatimGeocodeAlgorithm : public QgsBatchGeocodeAlgorithm
+{
+
+  public:
+
+    /**
+     * Constructor for QgsBatchNominatimGeocodeAlgorithm.
+     */
+    QgsBatchNominatimGeocodeAlgorithm();
+
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QgsBatchNominatimGeocodeAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+  private:
+
+    QgsNominatimGeocoder mNominatimGeocoder;
+
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMBATCHNOMINATIMGEOCODE_H
+
+

--- a/src/analysis/processing/qgsalgorithmbatchnominatimgeocode.h
+++ b/src/analysis/processing/qgsalgorithmbatchnominatimgeocode.h
@@ -44,6 +44,7 @@ class QgsBatchNominatimGeocodeAlgorithm : public QgsBatchGeocodeAlgorithm
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;
+    QString shortHelpString() const override;
     QgsBatchNominatimGeocodeAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -28,6 +28,7 @@
 #include "qgsalgorithmaspect.h"
 #include "qgsalgorithmassignprojection.h"
 #include "qgsalgorithmattributeindex.h"
+#include "qgsalgorithmbatchnominatimgeocode.h"
 #include "qgsalgorithmboundary.h"
 #include "qgsalgorithmboundingbox.h"
 #include "qgsalgorithmbuffer.h"
@@ -259,6 +260,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsAspectAlgorithm() );
   addAlgorithm( new QgsAssignProjectionAlgorithm() );
   addAlgorithm( new QgsAttributeIndexAlgorithm() );
+  addAlgorithm( new QgsBatchNominatimGeocodeAlgorithm() );
   addAlgorithm( new QgsBookmarksToLayerAlgorithm() );
   addAlgorithm( new QgsBoundaryAlgorithm() );
   addAlgorithm( new QgsBoundingBoxAlgorithm() );

--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -1194,7 +1194,7 @@ void QgsGotoLocatorFilter::triggerResult( const QgsLocatorResult &result )
 }
 
 QgsNominatimLocatorFilter::QgsNominatimLocatorFilter( QgsGeocoderInterface *geocoder, QgsMapCanvas *canvas )
-  : QgsGeocoderLocatorFilter( QStringLiteral( "nominatimgeocoder" ), tr( "Nominatim Geocoder" ), QStringLiteral( "nom" ), geocoder, canvas )
+  : QgsGeocoderLocatorFilter( QStringLiteral( "nominatimgeocoder" ), tr( "Nominatim Geocoder" ), QStringLiteral( ">" ), geocoder, canvas )
 {
   setFetchResultsDelay( 1000 );
   setUseWithoutPrefix( false );

--- a/src/app/locator/qgsinbuiltlocatorfilters.h
+++ b/src/app/locator/qgsinbuiltlocatorfilters.h
@@ -20,6 +20,7 @@
 
 #include "qgis_app.h"
 #include "qgslocatorfilter.h"
+#include "qgsgeocoderlocatorfilter.h"
 #include "qgsexpressioncontext.h"
 #include "qgsfeatureiterator.h"
 #include "qgsvectorlayerfeatureiterator.h"
@@ -255,6 +256,18 @@ class APP_EXPORT QgsGotoLocatorFilter : public QgsLocatorFilter
     QgsLocatorFilter::Flags flags() const override { return QgsLocatorFilter::FlagFast; }
 
     void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
+    void triggerResult( const QgsLocatorResult &result ) override;
+
+};
+
+class APP_EXPORT QgsNominatimLocatorFilter : public QgsGeocoderLocatorFilter
+{
+    Q_OBJECT
+
+  public:
+
+    QgsNominatimLocatorFilter( QgsGeocoderInterface *geocoder, QgsMapCanvas *canvas );
+
     void triggerResult( const QgsLocatorResult &result ) override;
 
 };

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3918,7 +3918,7 @@ void QgisApp::createStatusBar()
   mLocatorWidget->locator()->registerFilter( new QgsSettingsLocatorFilter() );
   mLocatorWidget->locator()->registerFilter( new QgsGotoLocatorFilter() );
 
-  mNominatimGeocoder = qgis::make_unique< QgsNominatimGeocoder>();
+  mNominatimGeocoder = std::make_unique< QgsNominatimGeocoder>();
   mLocatorWidget->locator()->registerFilter( new QgsNominatimLocatorFilter( mNominatimGeocoder.get(), mMapCanvas ) );
 }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -267,6 +267,8 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgslocatorwidget.h"
 #include "qgslocator.h"
 #include "qgsinbuiltlocatorfilters.h"
+#include "qgsgeocoderlocatorfilter.h"
+#include "qgsnominatimgeocoder.h"
 #include "qgslogger.h"
 #include "qgsmapcanvas.h"
 #include "qgsmapcanvasdockwidget.h"
@@ -3915,6 +3917,9 @@ void QgisApp::createStatusBar()
   mLocatorWidget->locator()->registerFilter( new QgsBookmarkLocatorFilter() );
   mLocatorWidget->locator()->registerFilter( new QgsSettingsLocatorFilter() );
   mLocatorWidget->locator()->registerFilter( new QgsGotoLocatorFilter() );
+
+  mNominatimGeocoder.reset( new QgsNominatimGeocoder() );
+  mLocatorWidget->locator()->registerFilter( new QgsNominatimLocatorFilter( mNominatimGeocoder.get(), mMapCanvas ) );
 }
 
 void QgisApp::setIconSizes( int size )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3918,7 +3918,7 @@ void QgisApp::createStatusBar()
   mLocatorWidget->locator()->registerFilter( new QgsSettingsLocatorFilter() );
   mLocatorWidget->locator()->registerFilter( new QgsGotoLocatorFilter() );
 
-  mNominatimGeocoder.reset( new QgsNominatimGeocoder() );
+  mNominatimGeocoder = qgis::make_unique< QgsNominatimGeocoder>();
   mLocatorWidget->locator()->registerFilter( new QgsNominatimLocatorFilter( mNominatimGeocoder.get(), mMapCanvas ) );
 }
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -139,6 +139,7 @@ class QgsLabelingWidget;
 class QgsLayerStylingWidget;
 class QgsDiagramProperties;
 class QgsLocatorWidget;
+class QgsNominatimGeocoder;
 class QgsDataSourceManagerDialog;
 class QgsBrowserGuiModel;
 class QgsBrowserModel;
@@ -2682,6 +2683,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void tapAndHoldTriggered( QTapAndHoldGesture *gesture );
 
     QgsLocatorWidget *mLocatorWidget = nullptr;
+    std::unique_ptr<QgsNominatimGeocoder> mNominatimGeocoder;
 
     QgsStatusBar *mStatusBar = nullptr;
 

--- a/src/core/geocoding/qgsnominatimgeocoder.cpp
+++ b/src/core/geocoding/qgsnominatimgeocoder.cpp
@@ -26,6 +26,7 @@
 #include <QJsonDocument>
 #include <QJsonArray>
 
+QMutex QgsNominatimGeocoder::sMutex;
 typedef QMap< QUrl, QList< QgsGeocoderResult > > CachedGeocodeResult;
 Q_GLOBAL_STATIC( CachedGeocodeResult, sCachedResults )
 qint64 QgsNominatimGeocoder::sLastRequestTimestamp = 0;

--- a/src/core/geocoding/qgsnominatimgeocoder.cpp
+++ b/src/core/geocoding/qgsnominatimgeocoder.cpp
@@ -26,8 +26,8 @@
 #include <QJsonDocument>
 #include <QJsonArray>
 
-QMutex QgsNominatimGeocoder::sMutex;
-QMap< QUrl, QList< QgsGeocoderResult > > QgsNominatimGeocoder::sCachedResults;
+typedef QMap< QUrl, QList< QgsGeocoderResult > > CachedGeocodeResult;
+Q_GLOBAL_STATIC( CachedGeocodeResult, sCachedResults )
 qint64 QgsNominatimGeocoder::sLastRequestTimestamp = 0;
 
 QgsNominatimGeocoder::QgsNominatimGeocoder( const QString &countryCodes, const QString &endpoint )
@@ -89,8 +89,8 @@ QList<QgsGeocoderResult> QgsNominatimGeocoder::geocodeString( const QString &str
   const QUrl url = requestUrl( string, bounds );
 
   QMutexLocker locker( &sMutex );
-  auto it = sCachedResults.constFind( url );
-  if ( it != sCachedResults.constEnd() )
+  auto it = sCachedResults()->constFind( url );
+  if ( it != sCachedResults()->constEnd() )
   {
     return *it;
   }
@@ -126,7 +126,7 @@ QList<QgsGeocoderResult> QgsNominatimGeocoder::geocodeString( const QString &str
   const QVariantList results = doc.array().toVariantList();
   if ( results.isEmpty() )
   {
-    sCachedResults.insert( url, QList<QgsGeocoderResult>() );
+    sCachedResults()->insert( url, QList<QgsGeocoderResult>() );
     return QList<QgsGeocoderResult>();
   }
 
@@ -137,7 +137,7 @@ QList<QgsGeocoderResult> QgsNominatimGeocoder::geocodeString( const QString &str
     matches << jsonToResult( result.toMap() );
   }
 
-  sCachedResults.insert( url, matches );
+  sCachedResults()->insert( url, matches );
 
   return matches;
 }

--- a/src/core/geocoding/qgsnominatimgeocoder.h
+++ b/src/core/geocoding/qgsnominatimgeocoder.h
@@ -59,7 +59,7 @@ class CORE_EXPORT QgsNominatimGeocoder : public QgsGeocoderInterface
     QUrl requestUrl( const QString &address, const QgsRectangle &bounds = QgsRectangle() ) const;
 
     /**
-     * Converts a JSON result returned from the Google Maps service to a geocoder result object.
+     * Converts a JSON result returned from the Nominatim service to a geocoder result object.
      */
     QgsGeocoderResult jsonToResult( const QVariantMap &json ) const;
 
@@ -116,7 +116,6 @@ class CORE_EXPORT QgsNominatimGeocoder : public QgsGeocoderInterface
     double mRequestsPerSecond = 1;
 
     static QMutex sMutex;
-    static QMap< QUrl, QList< QgsGeocoderResult > > sCachedResults;
 
     static qint64 sLastRequestTimestamp;
 


### PR DESCRIPTION
## Description

This PR integrates Nominatim geocoding with QGIS through two features:

A new *Nominatim geocoder locator filter*, activated using the ‘nom’ prefix in the locator widget at the bottom-left corner of the QGIS main window. To insure QGIS users respect the usage policy of the  OpenStreetMap Foundation (OSMF)-maintained Nominatim endpoint, the filter does the following:
- In contrast to all of our current locator filter, the Nominatim filter delays its fetching of results of 1 second. This behavior is to avoid querying the API at every keystroke (which would be auto-completion search, explicitly prohibited by the policy).
- In addition to Qt’s network query caching mechanism, the Nominatim geocoder class has its own caching mechanism to minimize remote fetching.
- Upon triggering the first Nominatim result (by hitting enter), a one-time message bar will pop up and acknowledge the origin of the data and offer a link to Nominatim’s homepage.

![Peek 2020-12-18 08-54](https://user-images.githubusercontent.com/1728657/102679153-24c06380-41e0-11eb-91e9-f5a2956e0795.gif)
_Screencast showcasing the one-time data origin acknowledgement_

A new *Batch Nominatim geocoder algorithm* found in the Vector tools section of QGIS’ processing toolbox. Once again, to insure our users do not breach the usage policy, the algorithm does the following:
- Caps the number of queries/requests sent to the Nominatim to one per second (by forcing a 1,000ms wait in-between queries).
- As mentioned above, the Nominatim geocoder class has its own caching mechanism to minimize remote fetching. The cache will remember its content across multiple executions of the algorithm.
- A information message is printed in the algorithm’s log at every run reminding users of the ODbl license under which the data is provided.

![image](https://user-images.githubusercontent.com/1728657/102679168-44578c00-41e0-11eb-93af-fed481b94c96.png)
_Information message appears in the log every time the algorithm is executed_

In addition, as required by the usage policy, all of our queries to the OSM-maintained Nominatim endpoint are identifiable via a User-Agent string ending with “ QGIS/{version_number}”. 

I believe that all of allows for QGIS to offer out-of-the-box geocoding to its users that is compliant with OSMF’s usage policy, as well as insuring a fair visibility of the data’s origin and license. This also prevents users from adopting alternatives (home-made scripts, QGIS plugins, etc.) that wouldn’t be as good as citizen as we are :wink:.

(For more details on the Nominatim geocoder class itself, see PR #40580) 