### PR TITLE
[layout] Add legend item scope to render context

### DIFF
--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -181,6 +181,8 @@ void QgsLayoutItemLegend::draw( QgsLayoutItemRenderContext &context )
   QgsRenderContext rc = mMap ? QgsLayoutUtils::createRenderContextForMap( mMap, painter, context.renderContext().scaleFactor() * 25.4 )
                         : QgsLayoutUtils::createRenderContextForLayout( mLayout, painter, context.renderContext().scaleFactor() * 25.4 );
 
+  rc.expressionContext().appendScopes( createExpressionContext().takeScopes() );
+
   QgsScopedQPainterState painterState( painter );
 
   // painter is scaled to dots, so scale back to layout units


### PR DESCRIPTION
This enables us to render symbols differently in different legends

A beautiful example of the possibilities follows:

![image](https://user-images.githubusercontent.com/588407/110150738-e3ebea00-7ddf-11eb-85f5-8ec366de7ccc.png)
