### PR TITLE
Server: Opacity should also be considered for external layers

### DIFF
--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1576,6 +1576,9 @@ namespace QgsWms
       QgsWmsParametersLayer param;
       param.mNickname = layer;
 
+      if ( i < opacities.count() )
+        param.mOpacity = opacities[i];
+
       if ( isExternalLayer( layer ) )
       {
         const QgsWmsParametersExternalLayer extParam = externalLayerParameter( layer );
@@ -1586,9 +1589,6 @@ namespace QgsWms
       {
         if ( i < styles.count() )
           param.mStyle = styles[i];
-
-        if ( i < opacities.count() )
-          param.mOpacity = opacities[i];
 
         if ( filters.contains( layer ) )
         {

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -3285,6 +3285,11 @@ namespace QgsWms
         continue;
       }
 
+      if ( mContext.testFlag( QgsWmsRenderContext::UseOpacity ) )
+      {
+        setLayerOpacity( layer, param.mOpacity );
+      }
+
       if ( mContext.isExternalLayer( param.mNickname ) )
       {
         continue;
@@ -3297,11 +3302,6 @@ namespace QgsWms
       else
       {
         setLayerStyle( layer, mContext.style( *layer ) );
-      }
-
-      if ( mContext.testFlag( QgsWmsRenderContext::UseOpacity ) )
-      {
-        setLayerOpacity( layer, param.mOpacity );
       }
 
       if ( mContext.testFlag( QgsWmsRenderContext::UseFilter ) )

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -3285,13 +3285,12 @@ namespace QgsWms
         continue;
       }
 
-      if ( mContext.testFlag( QgsWmsRenderContext::UseOpacity ) )
-      {
-        setLayerOpacity( layer, param.mOpacity );
-      }
-
       if ( mContext.isExternalLayer( param.mNickname ) )
       {
+        if ( mContext.testFlag( QgsWmsRenderContext::UseOpacity ) )
+        {
+          setLayerOpacity( layer, param.mOpacity );
+        }
         continue;
       }
 
@@ -3302,6 +3301,11 @@ namespace QgsWms
       else
       {
         setLayerStyle( layer, mContext.style( *layer ) );
+      }
+
+      if ( mContext.testFlag( QgsWmsRenderContext::UseOpacity ) )
+      {
+        setLayerOpacity( layer, param.mOpacity );
       }
 
       if ( mContext.testFlag( QgsWmsRenderContext::UseFilter ) )

--- a/tests/src/server/wms/test_qgsserver_wms_parameters.cpp
+++ b/tests/src/server/wms/test_qgsserver_wms_parameters.cpp
@@ -53,6 +53,7 @@ void TestQgsServerWmsParameters::external_layers()
   query.addQueryItem( "external_layer_1:layers", "layer_1_name" );
   query.addQueryItem( "external_layer_2:url", "http://url_2" );
   query.addQueryItem( "external_layer_2:layers", "layer_2_name" );
+  query.addQueryItem( "external_layer_2:opacities", "100" );
   query.addQueryItem( "OPACITIES", "255,200,125" );
 
   QgsWms::QgsWmsParameters parameters( query );
@@ -69,7 +70,7 @@ void TestQgsServerWmsParameters::external_layers()
 
   layer_params = layers_params[2];
   QCOMPARE( layer_params.mNickname, QString( "external_layer_2" ) );
-  QCOMPARE( layer_params.mExternalUri, QString( "layers=layer_2_name&url=http://url_2" ) );
+  QCOMPARE( layer_params.mExternalUri, QString( "layers=layer_2_name&opacities=100&url=http://url_2" ) );
 
   //test if opacities are also applied to external layers
   QCOMPARE( layers_params[0].mOpacity, 255 );

--- a/tests/src/server/wms/test_qgsserver_wms_parameters.cpp
+++ b/tests/src/server/wms/test_qgsserver_wms_parameters.cpp
@@ -53,6 +53,7 @@ void TestQgsServerWmsParameters::external_layers()
   query.addQueryItem( "external_layer_1:layers", "layer_1_name" );
   query.addQueryItem( "external_layer_2:url", "http://url_2" );
   query.addQueryItem( "external_layer_2:layers", "layer_2_name" );
+  query.addQueryItem( "OPACITIES", "255,200,125" );
 
   QgsWms::QgsWmsParameters parameters( query );
 
@@ -69,6 +70,11 @@ void TestQgsServerWmsParameters::external_layers()
   layer_params = layers_params[2];
   QCOMPARE( layer_params.mNickname, QString( "external_layer_2" ) );
   QCOMPARE( layer_params.mExternalUri, QString( "layers=layer_2_name&url=http://url_2" ) );
+
+  //test if opacities are also applied to external layers
+  QCOMPARE( layers_params[0].mOpacity, 255 );
+  QCOMPARE( layers_params[1].mOpacity, 200 );
+  QCOMPARE( layers_params[2].mOpacity, 125 );
 }
 
 void TestQgsServerWmsParameters::percent_encoding()


### PR DESCRIPTION
At the moment, the opacities-Parameters are ignored for external layers. However it can also be usefull for external layers (in contrast to the other ignored parameters which are not relevant for external layers).