### PR TITLE
WMS cascading: fix unreported issue wih missing fids

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3493,7 +3493,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
             // Try to parse and set feature id if matches "<some string>.<integer>"
             if ( f.value( QLatin1String( "id" ) ).isString() )
             {
-              static const QRegularExpression re{ R"raw(\.(\d+)$)raw" };
+             const thread_local QRegularExpression re{ R"raw(\.(\d+)$)raw" };
               const QString idVal { f.value( QLatin1String( "id" ) ).toString() };
               const QRegularExpressionMatch match { re.match( idVal ) };
               if ( match.hasMatch() )

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3493,7 +3493,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
             // Try to parse and set feature id if matches "<some string>.<integer>"
             if ( f.value( QLatin1String( "id" ) ).isString() )
             {
-             const thread_local QRegularExpression re{ R"raw(\.(\d+)$)raw" };
+              const thread_local QRegularExpression re{ R"raw(\.(\d+)$)raw" };
               const QString idVal { f.value( QLatin1String( "id" ) ).toString() };
               const QRegularExpressionMatch match { re.match( idVal ) };
               if ( match.hasMatch() )

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3490,6 +3490,23 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
             params.insert( QStringLiteral( "getFeatureInfoUrl" ), requestUrl.toString() );
             featureStore.setParams( params );
 
+            // Try to parse and set feature id if matches "<some string>.<integer>"
+            if ( f.value( QLatin1String( "id" ) ).isString() )
+            {
+              static const QRegularExpression re{ R"raw(\.(\d+)$)raw" };
+              const QString idVal { f.value( QLatin1String( "id" ) ).toString() };
+              const QRegularExpressionMatch match { re.match( idVal ) };
+              if ( match.hasMatch() )
+              {
+                bool ok;
+                QgsFeatureId id { match.captured( 1 ).toLongLong( &ok ) };
+                if ( ok )
+                {
+                  feature.setId( id );
+                }
+              }
+            }
+
             feature.setValid( true );
             featureStore.addFeature( feature );
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2508,7 +2508,7 @@ namespace QgsWms
     if ( layer && layer->dataProvider() )
       fid = QgsServerFeatureId::getServerFid( *feat, layer->dataProvider()->pkAttributeIndexes() );
     else
-      fid = feat->id();
+      fid = QString::number( feat->id() );
 
     typeNameElement.setAttribute( QStringLiteral( "fid" ), QStringLiteral( "%1.%2" ).arg( typeName, fid ) );
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2508,7 +2508,7 @@ namespace QgsWms
     if ( layer && layer->dataProvider() )
       fid = QgsServerFeatureId::getServerFid( *feat, layer->dataProvider()->pkAttributeIndexes() );
     else
-      fid = QString::number( feat->id() );
+      fid = FID_TO_STRING( feat->id() );
 
     typeNameElement.setAttribute( QStringLiteral( "fid" ), QStringLiteral( "%1.%2" ).arg( typeName, fid ) );
 


### PR DESCRIPTION
1. in WMS provider try to set fid from external getFeatureInfo JSON response
2. in WMS server, make sure we transform integer FID to string

This fixes an unreported issue where getFeatureInfo from cascaded WMS in
JSON format have no feature IDs.

Funded by Gis3W https://www.gis3w.it
