### PR TITLE
Increase zoom to feature margin to 50%

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1444,8 +1444,7 @@ void QgsMapCanvas::zoomToFeatureExtent( QgsRectangle &rect )
   {
     // Expand rect to give a bit of space around the selected
     // objects so as to keep them clear of the map boundaries
-    // The same 5% should apply to all margins.
-    rect.scale( 1.05 );
+    rect.scale( 1.15 );
   }
 
   setExtent( rect );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1444,7 +1444,7 @@ void QgsMapCanvas::zoomToFeatureExtent( QgsRectangle &rect )
   {
     // Expand rect to give a bit of space around the selected
     // objects so as to keep them clear of the map boundaries
-    rect.scale( 1.15 );
+    rect.scale( 1.5 );
   }
 
   setExtent( rect );


### PR DESCRIPTION
When using "zoom to feature", 5% is very little to see it in context. Increase it to 15%.
I would say for "zoom to layer extent" 5% is still enough (reason to delete the comment that 5% should always be the margin).