### PR TITLE
[locators] Add a description property to locator filter base class

### DIFF
--- a/python/core/auto_generated/locator/qgslocatorfilter.sip.in
+++ b/python/core/auto_generated/locator/qgslocatorfilter.sip.in
@@ -140,6 +140,13 @@ Returns a translated, user-friendly name for the filter.
 .. seealso:: :py:func:`name`
 %End
 
+    virtual QString description() const;
+%Docstring
+Returns a translated, description for the filter.
+
+.. versionadded:: 3.20
+%End
+
     virtual QgsLocatorFilter::Flags flags() const;
 %Docstring
 Returns flags which specify the filter's behavior.

--- a/src/core/locator/qgslocatorfilter.h
+++ b/src/core/locator/qgslocatorfilter.h
@@ -199,6 +199,12 @@ class CORE_EXPORT QgsLocatorFilter : public QObject
     virtual QString displayName() const = 0;
 
     /**
+     * Returns a translated, description for the filter.
+     * \since QGIS 3.20
+     */
+    virtual QString description() const { return QString(); }
+
+    /**
      * Returns flags which specify the filter's behavior.
      */
     virtual QgsLocatorFilter::Flags flags() const;

--- a/tests/src/python/test_qgslocator.py
+++ b/tests/src/python/test_qgslocator.py
@@ -47,6 +47,9 @@ class test_filter(QgsLocatorFilter):
     def displayName(self):
         return 'test_' + self.identifier
 
+    def description(self):
+        return 'test_description'
+
     def prefix(self):
         return self._prefix
 


### PR DESCRIPTION
## Description

This PR adds a description property to the locator filter base class. It can be useful for plugin authors to add a description to their locator filters.

@nyalldawson , as discussed.