### PR TITLE
[locators] Add a bounding box property to the abstract geocoder locator filter base class

### DIFF
--- a/python/core/auto_generated/geocoding/qgsabstractgeocoderlocatorfilter.sip.in
+++ b/python/core/auto_generated/geocoding/qgsabstractgeocoderlocatorfilter.sip.in
@@ -34,7 +34,8 @@ filter from a geocoder.
 
     QgsAbstractGeocoderLocatorFilter( const QString &name, const QString &displayName,
                                       const QString &prefix,
-                                      QgsGeocoderInterface *geocoder );
+                                      QgsGeocoderInterface *geocoder,
+                                      const QgsRectangle &boundingBox = QgsRectangle() );
 %Docstring
 Constructor for QgsAbstractGeocoderLocatorFilter.
 
@@ -50,6 +51,9 @@ The ``prefix`` must consist of at least three characters.
 The ``geocoder`` must specify an instance of a class which implements the :py:class:`QgsGeocoderInterface`
 interface. Ownership of ``geocoder`` is not transferred, and the caller must ensure that ``geocoder``
 exists for the lifetime of this filter.
+
+The ``boundingBox`` argument specifies the geographic bounding box, in WGS84, covered by the
+filter.
 %End
 
     virtual QString name() const;
@@ -66,6 +70,11 @@ exists for the lifetime of this filter.
     QgsGeocoderInterface *geocoder() const;
 %Docstring
 Returns the geocoder attached to the filter.
+%End
+
+    const QgsRectangle boundingBox();
+%Docstring
+Returns the WGS84 bounding box attached to the filter.
 %End
 
     QgsGeocoderResult locatorResultToGeocoderResult( const QgsLocatorResult &result ) const;

--- a/python/gui/auto_generated/qgsgeocoderlocatorfilter.sip.in
+++ b/python/gui/auto_generated/qgsgeocoderlocatorfilter.sip.in
@@ -29,7 +29,8 @@ filter from a geocoder.
     QgsGeocoderLocatorFilter( const QString &name, const QString &displayName,
                               const QString &prefix,
                               QgsGeocoderInterface *geocoder,
-                              QgsMapCanvas *canvas );
+                              QgsMapCanvas *canvas,
+                              const QgsRectangle &boundingBox = QgsRectangle() );
 %Docstring
 Constructor for QgsGeocoderLocatorFilter.
 
@@ -45,6 +46,9 @@ The ``prefix`` must consist of at least three characters.
 The ``geocoder`` must specify an instance of a class which implements the :py:class:`QgsGeocoderInterface`
 interface. Ownership of ``geocoder`` is not transferred, and the caller must ensure that ``geocoder``
 exists for the lifetime of this filter.
+
+The ``boundingBox`` argument specifies the geographic bounding box, in WGS84, covered by the
+filter.
 %End
 
     virtual QgsLocatorFilter *clone() const /Factory/;

--- a/src/core/geocoding/qgsabstractgeocoderlocatorfilter.cpp
+++ b/src/core/geocoding/qgsabstractgeocoderlocatorfilter.cpp
@@ -17,11 +17,12 @@
 #include "qgsgeocoder.h"
 #include "qgsgeocodercontext.h"
 
-QgsAbstractGeocoderLocatorFilter::QgsAbstractGeocoderLocatorFilter( const QString &name, const QString &displayName, const QString &prefix, QgsGeocoderInterface *geocoder )
+QgsAbstractGeocoderLocatorFilter::QgsAbstractGeocoderLocatorFilter( const QString &name, const QString &displayName, const QString &prefix, QgsGeocoderInterface *geocoder, const QgsRectangle &boundingBox )
   : mName( name )
   , mDisplayName( displayName )
   , mPrefix( prefix )
   , mGeocoder( geocoder )
+  , mBoundingBox( boundingBox )
 {
 
 }

--- a/src/core/geocoding/qgsabstractgeocoderlocatorfilter.h
+++ b/src/core/geocoding/qgsabstractgeocoderlocatorfilter.h
@@ -57,10 +57,14 @@ class CORE_EXPORT QgsAbstractGeocoderLocatorFilter : public QgsLocatorFilter SIP
      * The \a geocoder must specify an instance of a class which implements the QgsGeocoderInterface
      * interface. Ownership of \a geocoder is not transferred, and the caller must ensure that \a geocoder
      * exists for the lifetime of this filter.
+     *
+     * The \a boundingBox argument specifies the geographic bounding box, in WGS84, covered by the
+     * filter.
      */
     QgsAbstractGeocoderLocatorFilter( const QString &name, const QString &displayName,
                                       const QString &prefix,
-                                      QgsGeocoderInterface *geocoder );
+                                      QgsGeocoderInterface *geocoder,
+                                      const QgsRectangle &boundingBox = QgsRectangle() );
 
     QString name() const override;
     QString displayName() const override;
@@ -72,6 +76,11 @@ class CORE_EXPORT QgsAbstractGeocoderLocatorFilter : public QgsLocatorFilter SIP
      * Returns the geocoder attached to the filter.
      */
     QgsGeocoderInterface *geocoder() const;
+
+    /**
+     * Returns the WGS84 bounding box attached to the filter.
+     */
+    const QgsRectangle boundingBox() { return mBoundingBox; }
 
     /**
      * Converts a locator \a result to a geocoder result.
@@ -98,6 +107,7 @@ class CORE_EXPORT QgsAbstractGeocoderLocatorFilter : public QgsLocatorFilter SIP
     QString mDisplayName;
     QString mPrefix;
     QgsGeocoderInterface *mGeocoder = nullptr;
+    QgsRectangle mBoundingBox;
 
 };
 

--- a/src/gui/qgsgeocoderlocatorfilter.cpp
+++ b/src/gui/qgsgeocoderlocatorfilter.cpp
@@ -18,8 +18,8 @@
 #include "qgsmessagelog.h"
 #include "qgsgeocoderresult.h"
 
-QgsGeocoderLocatorFilter::QgsGeocoderLocatorFilter( const QString &name, const QString &displayName, const QString &prefix, QgsGeocoderInterface *geocoder, QgsMapCanvas *canvas )
-  : QgsAbstractGeocoderLocatorFilter( name, displayName, prefix, geocoder )
+QgsGeocoderLocatorFilter::QgsGeocoderLocatorFilter( const QString &name, const QString &displayName, const QString &prefix, QgsGeocoderInterface *geocoder, QgsMapCanvas *canvas, const QgsRectangle &boundingBox )
+  : QgsAbstractGeocoderLocatorFilter( name, displayName, prefix, geocoder, boundingBox )
   , mCanvas( canvas )
 {
 

--- a/src/gui/qgsgeocoderlocatorfilter.h
+++ b/src/gui/qgsgeocoderlocatorfilter.h
@@ -53,11 +53,15 @@ class GUI_EXPORT QgsGeocoderLocatorFilter : public QgsAbstractGeocoderLocatorFil
      * The \a geocoder must specify an instance of a class which implements the QgsGeocoderInterface
      * interface. Ownership of \a geocoder is not transferred, and the caller must ensure that \a geocoder
      * exists for the lifetime of this filter.
+     *
+     * The \a boundingBox argument specifies the geographic bounding box, in WGS84, covered by the
+     * filter.
      */
     QgsGeocoderLocatorFilter( const QString &name, const QString &displayName,
                               const QString &prefix,
                               QgsGeocoderInterface *geocoder,
-                              QgsMapCanvas *canvas );
+                              QgsMapCanvas *canvas,
+                              const QgsRectangle &boundingBox = QgsRectangle() );
 
     QgsLocatorFilter *clone() const override SIP_FACTORY;
 

--- a/tests/src/python/test_qgsgeocoderlocatorfilter.py
+++ b/tests/src/python/test_qgsgeocoderlocatorfilter.py
@@ -69,12 +69,13 @@ class TestQgsGeocoderLocatorFilter(unittest.TestCase):
     def test_geocode(self):
         geocoder = TestGeocoder()
         canvas = QgsMapCanvas()
-        filter = QgsGeocoderLocatorFilter('testgeocoder', 'my geocoder', 'pref', geocoder, canvas)
+        filter = QgsGeocoderLocatorFilter('testgeocoder', 'my geocoder', 'pref', geocoder, canvas, QgsRectangle(-1, -1, 1, 1))
 
         self.assertEqual(filter.name(), 'testgeocoder')
         self.assertEqual(filter.displayName(), 'my geocoder')
         self.assertEqual(filter.prefix(), 'pref')
         self.assertEqual(filter.geocoder(), geocoder)
+        self.assertEqual(filter.boundingBox(), QgsRectangle(-1, -1, 1, 1))
 
         spy = QSignalSpy(filter.resultFetched)
 


### PR DESCRIPTION
## Description

This PR adds a bounding box property to the geocoder locator filter base classes. While the property itself doesn't impact on result fetching, it's useful to have it in there to build UI around the area of coverage for specific filters.

@nyalldawson , as discussed.