### PR TITLE
Never ever show .txt files as datasets in browser

### DIFF
--- a/src/core/providers/gdal/qgsgdaldataitems.cpp
+++ b/src/core/providers/gdal/qgsgdaldataitems.cpp
@@ -183,6 +183,14 @@ QgsDataItem *QgsGdalDataItemProvider::createDataItem( const QString &pathIn, Qgs
     tmpPath.chop( 3 );
   QFileInfo info( tmpPath );
   QString suffix = info.suffix().toLower();
+
+  if ( suffix == QLatin1String( "txt" ) )
+  {
+    // never ever show .txt files as datasets in browser -- they are only used for geospatial data in extremely rare cases
+    // and are predominantly just noise in the browser
+    return nullptr;
+  }
+
   // extract basename with extension
   info.setFile( path );
   QString name = info.fileName();

--- a/src/core/providers/ogr/qgsogrdataitems.cpp
+++ b/src/core/providers/ogr/qgsogrdataitems.cpp
@@ -577,7 +577,14 @@ QgsDataItem *QgsOgrDataItemProvider::createDataItem( const QString &pathIn, QgsD
   QFileInfo info( tmpPath );
   QString suffix = info.suffix().toLower();
 
-// GDAL 3.1 Shapefile driver directly handles .shp.zip files
+  if ( suffix == QLatin1String( "txt" ) )
+  {
+    // never ever show .txt files as datasets in browser -- they are only used for geospatial data in extremely rare cases
+    // and are predominantly just noise in the browser
+    return nullptr;
+  }
+
+  // GDAL 3.1 Shapefile driver directly handles .shp.zip files
   if ( path.endsWith( QLatin1String( ".shp.zip" ), Qt::CaseInsensitive ) &&
        GDALIdentifyDriver( path.toUtf8().constData(), nullptr ) )
   {


### PR DESCRIPTION
They are only used for geospatial data in extremely rare cases and are predominantly just noise in the browser
