### PR TITLE
Fix broken relations when loading an embedded layer

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -670,11 +670,8 @@ void QgisApp::onActiveLayerChanged( QgsMapLayer *layer )
   emit activeLayerChanged( layer );
 }
 
-void QgisApp::vectorLayerStyleLoaded( QgsMapLayer::StyleCategories categories )
+void QgisApp::vectorLayerStyleLoaded( QgsVectorLayer *vl, QgsMapLayer::StyleCategories categories )
 {
-
-  QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( sender() );
-
   if ( vl && vl->isValid( ) )
   {
 
@@ -13014,6 +13011,14 @@ void QgisApp::embedLayers()
           QgsProject::instance()->createEmbeddedLayer( selId, projectFile, brokenNodes );
       }
     }
+
+    // fix broken relations and dependencies
+    for ( const QString &id : constSortedIds )
+    {
+      QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( id ) );
+      if ( vlayer )
+        vectorLayerStyleLoaded( vlayer, QgsMapLayer::AllStyleCategories );
+    }
   }
 }
 
@@ -14151,7 +14156,7 @@ void QgisApp::layersWereAdded( const QList<QgsMapLayer *> &layers )
       connect( vlayer, &QgsVectorLayer::editingStopped, this, &QgisApp::layerEditStateChanged );
       connect( vlayer, &QgsVectorLayer::readOnlyChanged, this, &QgisApp::layerEditStateChanged );
       connect( vlayer, &QgsVectorLayer::raiseError, this, &QgisApp::onLayerError );
-      connect( vlayer, &QgsVectorLayer::styleLoaded, this, &QgisApp::vectorLayerStyleLoaded );
+      connect( vlayer, &QgsVectorLayer::styleLoaded, [this, vlayer]( QgsMapLayer::StyleCategories categories ) { vectorLayerStyleLoaded( vlayer, categories ); } );
 
       provider = vProvider;
     }
@@ -17015,4 +17020,3 @@ QgsAttributeEditorContext QgisApp::createAttributeEditorContext()
   context.setMainMessageBar( messageBar() );
   return context;
 }
-

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1951,7 +1951,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * \param categories style categories
      * \since QGIS 3.12
      */
-    void vectorLayerStyleLoaded( const QgsMapLayer::StyleCategories categories );
+    void vectorLayerStyleLoaded( QgsVectorLayer *vl, const QgsMapLayer::StyleCategories categories );
 
     //! Enable or disable event tracing (for debugging)
     void toggleEventTracing();


### PR DESCRIPTION
## Description

Fix #38955 : When embedding a layer, relations are not imported. 

At first, I thought it was a Feature Request but it seems to me that it's more a bug fix because there is everything necessary since the introduction of `QgsWeakRelation` in #33283

@elpaso I'm interested in your opinion here

**Funded by** Lille Metropole
cc @Jean-Roc 