### PR TITLE
fix open form button not always enabled in relation reference widget

### DIFF
--- a/python/core/auto_generated/qgsfeaturepickermodelbase.sip.in
+++ b/python/core/auto_generated/qgsfeaturepickermodelbase.sip.in
@@ -154,6 +154,13 @@ If set to 0, no limit is applied when fetching
 
   signals:
 
+    void currentFeatureChanged();
+%Docstring
+Emitted when the current feature in the model has changed
+
+.. versionadded:: 3.16.5
+%End
+
     void sourceLayerChanged();
 %Docstring
 The source layer from which features will be fetched.

--- a/python/core/auto_generated/qgsfeaturepickermodelbase.sip.in
+++ b/python/core/auto_generated/qgsfeaturepickermodelbase.sip.in
@@ -158,7 +158,7 @@ If set to 0, no limit is applied when fetching
 %Docstring
 Emitted when the current feature in the model has changed
 This emitted both when the extra value changes and when the extra value status changes.
-It allows to be aware when the feature is fetched after the extra value has been set.
+It allows being notified when the feature is fetched after the extra value has been set.
 
 .. versionadded:: 3.16.5
 %End

--- a/python/core/auto_generated/qgsfeaturepickermodelbase.sip.in
+++ b/python/core/auto_generated/qgsfeaturepickermodelbase.sip.in
@@ -157,6 +157,8 @@ If set to 0, no limit is applied when fetching
     void currentFeatureChanged();
 %Docstring
 Emitted when the current feature in the model has changed
+This emitted both when the extra value changes and when the extra value status changes.
+It allows to be aware when the feature is fetched after the extra value has been set.
 
 .. versionadded:: 3.16.5
 %End

--- a/python/gui/auto_generated/qgsfeaturelistcombobox.sip.in
+++ b/python/gui/auto_generated/qgsfeaturelistcombobox.sip.in
@@ -223,6 +223,13 @@ Normally the primary key of the layer.
 Determines if a NULL value should be available in the list.
 %End
 
+    void currentFeatureChanged();
+%Docstring
+Emitted when the current feature changes
+
+.. versionadded:: 3.16.5
+%End
+
 };
 
 

--- a/src/core/qgsfeaturepickermodelbase.cpp
+++ b/src/core/qgsfeaturepickermodelbase.cpp
@@ -31,7 +31,7 @@ QgsFeaturePickerModelBase::QgsFeaturePickerModelBase( QObject *parent )
 
   // The fact that the feature changed is a combination of the 2 signals:
   // If the extra value is set to a feature currently not fetched, it will go through an intermediate step while the extra value does not exist (as it call reloadFeature)
-  connect( this, &QgsFeaturePickerModelBase::extraIdentifierValueIndexChanged, this, &QgsFeaturePickerModelBase::currentFeatureChanged );
+  connect( this, &QgsFeaturePickerModelBase::extraIdentifierValueChanged, this, &QgsFeaturePickerModelBase::currentFeatureChanged );
   connect( this, &QgsFeaturePickerModelBase::extraValueDoesNotExistChanged, this, &QgsFeaturePickerModelBase::currentFeatureChanged );
 }
 

--- a/src/core/qgsfeaturepickermodelbase.cpp
+++ b/src/core/qgsfeaturepickermodelbase.cpp
@@ -28,6 +28,11 @@ QgsFeaturePickerModelBase::QgsFeaturePickerModelBase( QObject *parent )
   mReloadTimer.setInterval( 100 );
   mReloadTimer.setSingleShot( true );
   connect( &mReloadTimer, &QTimer::timeout, this, &QgsFeaturePickerModelBase::scheduledReload );
+
+  // The fact that the feature changed is a combination of the 2 signals:
+  // If the extra value is set to a feature currently not fetched, it will go through an intermediate step while the extra value does not exist (as it call reloadFeature)
+  connect( this, &QgsFeaturePickerModelBase::extraIdentifierValueIndexChanged, this, &QgsFeaturePickerModelBase::currentFeatureChanged );
+  connect( this, &QgsFeaturePickerModelBase::extraValueDoesNotExistChanged, this, &QgsFeaturePickerModelBase::currentFeatureChanged );
 }
 
 

--- a/src/core/qgsfeaturepickermodelbase.cpp
+++ b/src/core/qgsfeaturepickermodelbase.cpp
@@ -513,11 +513,13 @@ void QgsFeaturePickerModelBase::setExtraIdentifierValueUnguarded( const QVariant
       if ( !isNull )
       {
         mEntries.prepend( createEntry( identifierValue ) );
+        setExtraValueDoesNotExist( true );
         reloadCurrentFeature();
       }
       else
       {
         mEntries.prepend( QgsFeatureExpressionValuesGatherer::nullEntry( mSourceLayer ) );
+        setExtraValueDoesNotExist( false );
       }
       endInsertRows();
 

--- a/src/core/qgsfeaturepickermodelbase.h
+++ b/src/core/qgsfeaturepickermodelbase.h
@@ -180,6 +180,8 @@ class CORE_EXPORT QgsFeaturePickerModelBase : public QAbstractItemModel SIP_ABST
 
     /**
      * Emitted when the current feature in the model has changed
+     * This emitted both when the extra value changes and when the extra value status changes.
+     * It allows to be aware when the feature is fetched after the extra value has been set.
      * \since QGIS 3.16.5
      */
     void currentFeatureChanged();

--- a/src/core/qgsfeaturepickermodelbase.h
+++ b/src/core/qgsfeaturepickermodelbase.h
@@ -179,6 +179,12 @@ class CORE_EXPORT QgsFeaturePickerModelBase : public QAbstractItemModel SIP_ABST
   signals:
 
     /**
+     * Emitted when the current feature in the model has changed
+     * \since QGIS 3.16.5
+     */
+    void currentFeatureChanged();
+
+    /**
      * The source layer from which features will be fetched.
      */
     void sourceLayerChanged();

--- a/src/core/qgsfeaturepickermodelbase.h
+++ b/src/core/qgsfeaturepickermodelbase.h
@@ -181,7 +181,7 @@ class CORE_EXPORT QgsFeaturePickerModelBase : public QAbstractItemModel SIP_ABST
     /**
      * Emitted when the current feature in the model has changed
      * This emitted both when the extra value changes and when the extra value status changes.
-     * It allows to be aware when the feature is fetched after the extra value has been set.
+     * It allows being notified when the feature is fetched after the extra value has been set.
      * \since QGIS 3.16.5
      */
     void currentFeatureChanged();

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -725,7 +725,6 @@ void QgsRelationReferenceWidget::mapIdentification()
 
 void QgsRelationReferenceWidget::comboReferenceChanged()
 {
-  Q_UNUSED( index )
   mReferencedLayer->getFeatures( mComboBox->currentFeatureRequest() ).nextFeature( mFeature );
   highlightFeature( mFeature );
   updateAttributeEditorFrame( mFeature );

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -599,7 +599,7 @@ void QgsRelationReferenceWidget::init()
     }
 
     // Only connect after iterating, to have only one iterator on the referenced table at once
-    connect( mComboBox, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, &QgsRelationReferenceWidget::comboReferenceChanged );
+    connect( mComboBox, &QgsFeatureListComboBox::currentFeatureChanged, this, &QgsRelationReferenceWidget::comboReferenceChanged );
 
     QApplication::restoreOverrideCursor();
 
@@ -723,7 +723,7 @@ void QgsRelationReferenceWidget::mapIdentification()
   }
 }
 
-void QgsRelationReferenceWidget::comboReferenceChanged( int index )
+void QgsRelationReferenceWidget::comboReferenceChanged()
 {
   Q_UNUSED( index )
   mReferencedLayer->getFeatures( mComboBox->currentFeatureRequest() ).nextFeature( mFeature );

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -287,7 +287,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
   private slots:
     void highlightActionTriggered( QAction *action );
     void deleteHighlight();
-    void comboReferenceChanged( int index );
+    void comboReferenceChanged();
     void featureIdentified( const QgsFeature &feature );
     void setMapTool( QgsMapTool *mapTool );
     void unsetMapTool();

--- a/src/gui/qgsfeaturelistcombobox.cpp
+++ b/src/gui/qgsfeaturelistcombobox.cpp
@@ -61,6 +61,9 @@ QgsFeatureListComboBox::QgsFeatureListComboBox( QWidget *parent )
 
   connect( mLineEdit, &QgsFilterLineEdit::textEdited, this, &QgsFeatureListComboBox::onCurrentTextChanged );
 
+  connect( this, static_cast<void( QgsFeatureListComboBox::* )( int )>( &QgsFeatureListComboBox::currentIndexChanged ), this, &QgsFeatureListComboBox::currentFeatureChanged );
+  connect( mModel, &QgsFeatureFilterModel::extraValueDoesNotExistChanged, this, &QgsFeatureListComboBox::currentFeatureChanged );
+
   setToolTip( tr( "Just start typing what you are looking for." ) );
 }
 

--- a/src/gui/qgsfeaturelistcombobox.cpp
+++ b/src/gui/qgsfeaturelistcombobox.cpp
@@ -61,8 +61,7 @@ QgsFeatureListComboBox::QgsFeatureListComboBox( QWidget *parent )
 
   connect( mLineEdit, &QgsFilterLineEdit::textEdited, this, &QgsFeatureListComboBox::onCurrentTextChanged );
 
-  connect( this, static_cast<void( QgsFeatureListComboBox::* )( int )>( &QgsFeatureListComboBox::currentIndexChanged ), this, &QgsFeatureListComboBox::currentFeatureChanged );
-  connect( mModel, &QgsFeatureFilterModel::extraValueDoesNotExistChanged, this, &QgsFeatureListComboBox::currentFeatureChanged );
+  connect( mModel, &QgsFeatureFilterModel::currentFeatureChanged, this, &QgsFeatureListComboBox::currentFeatureChanged );
 
   setToolTip( tr( "Just start typing what you are looking for." ) );
 }

--- a/src/gui/qgsfeaturelistcombobox.h
+++ b/src/gui/qgsfeaturelistcombobox.h
@@ -234,6 +234,12 @@ class GUI_EXPORT QgsFeatureListComboBox : public QComboBox
      */
     void allowNullChanged();
 
+    /**
+     * Emitted when the current feature changes
+     * \since QGIS 3.16.5
+     */
+    void currentFeatureChanged();
+
   private slots:
     void onCurrentTextChanged( const QString &text );
     void onFilterUpdateCompleted();

--- a/src/gui/qgsfeaturelistcombobox.h
+++ b/src/gui/qgsfeaturelistcombobox.h
@@ -259,6 +259,7 @@ class GUI_EXPORT QgsFeatureListComboBox : public QComboBox
     bool mIsCurrentlyEdited = false;
 
     friend class TestQgsFeatureListComboBox;
+    friend class TestQgsRelationReferenceWidget;
 };
 
 

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -69,7 +69,6 @@ class TestQgsRelationReferenceWidget : public QObject
     void testDependencies(); // Test relation datasource, id etc. config storage
     void testSetFilterExpression();
     void testSetFilterExpressionWithOrClause();
-    void testOpenFormButton();
 
   private:
     std::unique_ptr<QgsVectorLayer> mLayer1;
@@ -748,6 +747,7 @@ void TestQgsRelationReferenceWidget::testSetFilterExpression()
 
 void TestQgsRelationReferenceWidget::testSetFilterExpressionWithOrClause()
 {
+
   // init a relation reference widget
   QStringList filterFields = { "material", "diameter", "raccord" };
 
@@ -778,45 +778,6 @@ void TestQgsRelationReferenceWidget::testSetFilterExpressionWithOrClause()
   QCOMPARE( w.mComboBox->currentText(), QStringLiteral( "NULL" ) );
   // in case there is no field filter, the number of filtered features will be 2
   QCOMPARE( w.mComboBox->count(), 1 );
-}
-
-void TestQgsRelationReferenceWidget::testOpenFormButton()
-{
-
-  for ( int i = 1000; i < 1200; i++ )
-  {
-    QgsFeature fti( mLayer2->fields() );
-    fti.setAttribute( QStringLiteral( "pk" ), i );
-    fti.setAttribute( QStringLiteral( "material" ), "steel" );
-    fti.setAttribute( QStringLiteral( "diameter" ), i );
-    fti.setAttribute( QStringLiteral( "raccord" ), "collar" );
-    mLayer2->startEditing();
-    mLayer2->addFeature( fti );
-    mLayer2->commitChanges();
-  }
-
-  // init a relation reference widget
-  QStringList filterFields = { "material", "diameter", "raccord" };
-
-  QWidget parentWidget;
-  QgsRelationReferenceWidget w( &parentWidget );
-
-  QEventLoop loop;
-  connect( qobject_cast<QgsFeatureFilterModel *>( w.mComboBox->model() ), &QgsFeatureFilterModel::filterJobCompleted, &loop, &QEventLoop::quit );
-
-  // be sure that the limit is smaller than the number of features in the layer
-  w.mComboBox->mModel->setFetchLimit( 100 );
-  w.setChainFilters( true );
-  w.setFilterFields( filterFields );
-  w.setRelation( *mRelation, true );
-  w.init();
-
-  QCOMPARE( w.mOpenFormButton->isEnabled(), true );
-  w.setForeignKeys( {"steel", 1190, "collar" } );
-  // if the feature is not yet loaded (further than the fetch limit, we have an intermediate step with no feature)
-  QCOMPARE( w.mOpenFormButton->isEnabled(), false );
-  QSignalSpy spy( w.mComboBox, &QgsFeatureListComboBox::currentFeatureChanged );
-  QCOMPARE( w.mOpenFormButton->isEnabled(), true );
 }
 
 QGSTEST_MAIN( TestQgsRelationReferenceWidget )


### PR DESCRIPTION
when the underlying model has more feature than what the model fetches by default (100),
the feature is not fetched yet when the combobox has its index changed

the new signal allows to be aware when the feature is ready to be used

with unit-test 💪 