### PR TITLE
Fix Postgres NOTIFY Listener crash and db login procedure

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1968,7 +1968,8 @@ bool QgsMapLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
 void QgsMapLayer::setRefreshOnNotifyEnabled( bool enabled )
 {
   QgsDataProvider *lDataProvider = dataProvider();
-  if ( !lDataProvider )
+
+  if ( !lDataProvider || !lDataProvider->isValid() || !( providerType() == QStringLiteral("postgres") ) )
     return;
 
   if ( enabled && !isRefreshOnNotifyEnabled() )

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1969,18 +1969,18 @@ void QgsMapLayer::setRefreshOnNotifyEnabled( bool enabled )
 {
   QgsDataProvider *lDataProvider = dataProvider();
 
-  if ( !lDataProvider || !lDataProvider->isValid() || !( providerType() == QStringLiteral("postgres") ) )
+  if ( !lDataProvider || !lDataProvider->isValid() )
     return;
 
   if ( enabled && !isRefreshOnNotifyEnabled() )
   {
     lDataProvider->setListening( enabled );
-    connect( lDataProvider, &QgsVectorDataProvider::notify, this, &QgsMapLayer::onNotified );
+    connect( lDataProvider, &QgsDataProvider::notify, this, &QgsMapLayer::onNotified );
   }
   else if ( !enabled && isRefreshOnNotifyEnabled() )
   {
     // we don't want to disable provider listening because someone else could need it (e.g. actions)
-    disconnect( lDataProvider, &QgsVectorDataProvider::notify, this, &QgsMapLayer::onNotified );
+    disconnect( lDataProvider, &QgsDataProvider::notify, this, &QgsMapLayer::onNotified );
   }
   mIsRefreshOnNofifyEnabled = enabled;
 }

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1969,7 +1969,7 @@ void QgsMapLayer::setRefreshOnNotifyEnabled( bool enabled )
 {
   QgsDataProvider *lDataProvider = dataProvider();
 
-  if ( !lDataProvider || !lDataProvider->isValid() )
+  if ( !lDataProvider )
     return;
 
   if ( enabled && !isRefreshOnNotifyEnabled() )

--- a/src/providers/postgres/qgspostgreslistener.cpp
+++ b/src/providers/postgres/qgspostgreslistener.cpp
@@ -16,7 +16,8 @@
  ***************************************************************************/
 
 #include "qgspostgreslistener.h"
-
+#include "qgsdatasourceuri.h"
+#include "qgscredentials.h"
 #include "qgslogger.h"
 
 #ifdef Q_OS_WIN
@@ -58,7 +59,42 @@ QgsPostgresListener::~QgsPostgresListener()
 void QgsPostgresListener::run()
 {
   PGconn *conn = nullptr;
-  conn = PQconnectdb( mConnString.toLocal8Bit() );
+
+  conn = PQconnectdb( mConnString.toUtf8() );
+
+  if ( PQstatus( conn ) != CONNECTION_OK )
+  {
+    QgsDataSourceUri uri( mConnString );
+    QString username = uri.username();
+    QString password = uri.password();
+
+    PQfinish( conn );
+
+    QgsCredentials::instance()->lock();
+
+    if ( QgsCredentials::instance()->get( mConnString, username, password, PQerrorMessage( conn ) ) )
+    {
+      if ( !username.isEmpty() )
+        uri.setUsername( username );
+
+      if ( !password.isEmpty() )
+        uri.setPassword( password );
+
+      QString connectString = uri.connectionInfo( false );
+      conn = PQconnectdb( connectString.toUtf8() );
+      if ( PQstatus( conn ) == CONNECTION_OK )
+        QgsCredentials::instance()->put( mConnString, username, password );
+    }
+
+    QgsCredentials::instance()->unlock();
+
+    if ( PQstatus( conn ) != CONNECTION_OK )
+    {
+      QgsDebugMsg( QStringLiteral( "LISTENer not started" ) );
+      return;
+    }
+  }
+
 
   PGresult *res = PQexec( conn, "LISTEN qgis" );
   if ( PQresultStatus( res ) != PGRES_COMMAND_OK )
@@ -94,7 +130,6 @@ void QgsPostgresListener::run()
     timeout.tv_sec = 1;
     timeout.tv_usec = 0;
 
-    QgsDebugMsg( QStringLiteral( "select in the loop" ) );
     if ( select( sock + 1, &input_mask, nullptr, nullptr, &timeout ) < 0 )
     {
       QgsDebugMsg( QStringLiteral( "error in select" ) );
@@ -109,10 +144,6 @@ void QgsPostgresListener::run()
       emit notify( msg );
       QgsDebugMsg( "notify " + msg );
       PQfreemem( n );
-    }
-    else
-    {
-      QgsDebugMsg( QStringLiteral( "not a notify" ) );
     }
 
     if ( mStop )

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -294,6 +294,9 @@ QgsPostgresConn *QgsPostgresProvider::connectionRO() const
 
 void QgsPostgresProvider::setListening( bool isListening )
 {
+  if ( !mValid )
+    return;
+
   if ( isListening && !mListener )
   {
     mListener.reset( QgsPostgresListener::create( mUri.connectionInfo( false ) ).release() );


### PR DESCRIPTION
At this moment Postgres NOTIFY Listener is using simple login to db procedure. 
https://github.com/qgis/QGIS/blob/42db258cab1894c72c34ba6613a529640be3981a/src/providers/postgres/qgspostgreslistener.cpp#L60-L63
As a result Postgres NOTIFY Listener can start only if layer data source includes username and password. That is why some issues occur, such as #25917 and #38986 .
This PR makes some fixes:
- crash when DataProvider is invalid;
- login procedure when layer data source uri does not contain username and password;
- prevent debug spam;

Well known bugs:
- config setting does not save if layer is temporary unavailable;
- no procedure resuming connection to db if broken;