### PR TITLE
move projVersionMajor to cpp

### DIFF
--- a/src/core/qgsprojutils.cpp
+++ b/src/core/qgsprojutils.cpp
@@ -294,6 +294,11 @@ QStringList QgsProjUtils::nonAvailableGrids( const QString &projDef )
 }
 #endif
 
+int QgsProjUtils::projVersionMajor()
+{
+  return PROJ_VERSION_MAJOR;
+}
+
 QStringList QgsProjUtils::searchPaths()
 {
   const QString path( proj_info().searchpath );

--- a/src/core/qgsprojutils.h
+++ b/src/core/qgsprojutils.h
@@ -47,10 +47,7 @@ class CORE_EXPORT QgsProjUtils
     /**
      * Returns the proj library major version number.
      */
-    static int projVersionMajor()
-    {
-      return PROJ_VERSION_MAJOR;
-    }
+    static int projVersionMajor();
 
     /**
      * Returns the current list of Proj file search paths.


### PR DESCRIPTION
To allow calling to method of this class through the qgis core lib from third stand alone application.

Not sure because maybe there are some reasons to have the definition in the header... 

backport to 3.18 ? (could be appreciate)
