### PR TITLE
Allow point clouds, mesh, vector tiles to be exported to qlr and qml files

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8916,6 +8916,8 @@ void QgisApp::saveStyleFile( QgsMapLayer *layer )
 
     case QgsMapLayerType::RasterLayer:
     case QgsMapLayerType::MeshLayer:
+    case QgsMapLayerType::PointCloudLayer:
+    case QgsMapLayerType::VectorTileLayer:
     {
       QgsSettings settings;
       QString lastUsedDir = settings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
@@ -8938,10 +8940,8 @@ void QgisApp::saveStyleFile( QgsMapLayer *layer )
       break;
     }
 
-    case QgsMapLayerType::VectorTileLayer:
     case QgsMapLayerType::AnnotationLayer:
     case QgsMapLayerType::PluginLayer:
-    case QgsMapLayerType::PointCloudLayer:
       break;
 
   }

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -432,57 +432,90 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
       menu->addSeparator();
 
-      if ( vlayer )
+      // export menu
+      if ( layer )
       {
-        if ( vlayer->isTemporary() )
+        switch ( layer->type() )
         {
-          QAction *actionMakePermanent = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "mActionFileSave.svg" ) ), tr( "Make Permanent…" ), menu );
-          connect( actionMakePermanent, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->makeMemoryLayerPermanent( vlayer ); } );
-          menu->addAction( actionMakePermanent );
-        }
-        // save as vector file
-        QMenu *menuExportVector = new QMenu( tr( "E&xport" ), menu );
-        QAction *actionSaveAs = new QAction( tr( "Save Features &As…" ), menuExportVector );
-        connect( actionSaveAs, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveAsFile(); } );
-        actionSaveAs->setEnabled( vlayer->isValid() );
-        menuExportVector->addAction( actionSaveAs );
-        QAction *actionSaveSelectedFeaturesAs = new QAction( tr( "Save &Selected Features As…" ), menuExportVector );
-        connect( actionSaveSelectedFeaturesAs, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveAsFile( nullptr, true ); } );
-        actionSaveSelectedFeaturesAs->setEnabled( vlayer->isValid() && vlayer->selectedFeatureCount() > 0 );
-        menuExportVector->addAction( actionSaveSelectedFeaturesAs );
-        QAction *actionSaveAsDefinitionLayer = new QAction( tr( "Save as Layer &Definition File…" ), menuExportVector );
-        connect( actionSaveAsDefinitionLayer, &QAction::triggered, QgisApp::instance(), &QgisApp::saveAsLayerDefinition );
-        menuExportVector->addAction( actionSaveAsDefinitionLayer );
-        if ( vlayer->isSpatial() )
-        {
-          QAction *actionSaveStyle = new QAction( tr( "Save as &QGIS Layer Style File…" ), menuExportVector );
-          connect( actionSaveStyle, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveStyleFile(); } );
-          menuExportVector->addAction( actionSaveStyle );
-        }
-        menu->addMenu( menuExportVector );
-      }
-      else if ( rlayer )
-      {
-        QMenu *menuExportRaster = new QMenu( tr( "E&xport" ), menu );
-        QAction *actionSaveAs = new QAction( tr( "Save &As…" ), menuExportRaster );
-        QAction *actionSaveAsDefinitionLayer = new QAction( tr( "Save as Layer &Definition File…" ), menuExportRaster );
-        QAction *actionSaveStyle = new QAction( tr( "Save as &QGIS Layer Style File…" ), menuExportRaster );
-        connect( actionSaveAs, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveAsFile(); } );
-        menuExportRaster->addAction( actionSaveAs );
-        actionSaveAs->setEnabled( rlayer->isValid() );
-        connect( actionSaveAsDefinitionLayer, &QAction::triggered, QgisApp::instance(), &QgisApp::saveAsLayerDefinition );
-        menuExportRaster->addAction( actionSaveAsDefinitionLayer );
-        connect( actionSaveStyle, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveStyleFile(); } );
-        menuExportRaster->addAction( actionSaveStyle );
-        menu->addMenu( menuExportRaster );
-      }
-      else if ( layer && layer->type() == QgsMapLayerType::PluginLayer && mView->selectedLayerNodes().count() == 1 )
-      {
-        // disable duplication of plugin layers
-        duplicateLayersAction->setEnabled( false );
-      }
+          case QgsMapLayerType::VectorLayer:
+            if ( vlayer )
+            {
+              if ( vlayer->isTemporary() )
+              {
+                QAction *actionMakePermanent = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "mActionFileSave.svg" ) ), tr( "Make Permanent…" ), menu );
+                connect( actionMakePermanent, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->makeMemoryLayerPermanent( vlayer ); } );
+                menu->addAction( actionMakePermanent );
+              }
+              // save as vector file
+              QMenu *menuExportVector = new QMenu( tr( "E&xport" ), menu );
+              QAction *actionSaveAs = new QAction( tr( "Save Features &As…" ), menuExportVector );
+              connect( actionSaveAs, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveAsFile(); } );
+              actionSaveAs->setEnabled( vlayer->isValid() );
+              menuExportVector->addAction( actionSaveAs );
+              QAction *actionSaveSelectedFeaturesAs = new QAction( tr( "Save &Selected Features As…" ), menuExportVector );
+              connect( actionSaveSelectedFeaturesAs, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveAsFile( nullptr, true ); } );
+              actionSaveSelectedFeaturesAs->setEnabled( vlayer->isValid() && vlayer->selectedFeatureCount() > 0 );
+              menuExportVector->addAction( actionSaveSelectedFeaturesAs );
+              QAction *actionSaveAsDefinitionLayer = new QAction( tr( "Save as Layer &Definition File…" ), menuExportVector );
+              connect( actionSaveAsDefinitionLayer, &QAction::triggered, QgisApp::instance(), &QgisApp::saveAsLayerDefinition );
+              menuExportVector->addAction( actionSaveAsDefinitionLayer );
+              if ( vlayer->isSpatial() )
+              {
+                QAction *actionSaveStyle = new QAction( tr( "Save as &QGIS Layer Style File…" ), menuExportVector );
+                connect( actionSaveStyle, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveStyleFile(); } );
+                menuExportVector->addAction( actionSaveStyle );
+              }
+              menu->addMenu( menuExportVector );
+            }
+            break;
 
-      menu->addSeparator();
+          case QgsMapLayerType::RasterLayer:
+            if ( rlayer )
+            {
+              QMenu *menuExportRaster = new QMenu( tr( "E&xport" ), menu );
+              QAction *actionSaveAs = new QAction( tr( "Save &As…" ), menuExportRaster );
+              QAction *actionSaveAsDefinitionLayer = new QAction( tr( "Save as Layer &Definition File…" ), menuExportRaster );
+              QAction *actionSaveStyle = new QAction( tr( "Save as &QGIS Layer Style File…" ), menuExportRaster );
+              connect( actionSaveAs, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveAsFile(); } );
+              menuExportRaster->addAction( actionSaveAs );
+              actionSaveAs->setEnabled( rlayer->isValid() );
+              connect( actionSaveAsDefinitionLayer, &QAction::triggered, QgisApp::instance(), &QgisApp::saveAsLayerDefinition );
+              menuExportRaster->addAction( actionSaveAsDefinitionLayer );
+              connect( actionSaveStyle, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveStyleFile(); } );
+              menuExportRaster->addAction( actionSaveStyle );
+              menu->addMenu( menuExportRaster );
+            }
+            break;
+
+          case QgsMapLayerType::MeshLayer:
+          case QgsMapLayerType::VectorTileLayer:
+          case QgsMapLayerType::PointCloudLayer:
+          {
+            QMenu *menuExportRaster = new QMenu( tr( "E&xport" ), menu );
+            QAction *actionSaveAsDefinitionLayer = new QAction( tr( "Save as Layer &Definition File…" ), menuExportRaster );
+            QAction *actionSaveStyle = new QAction( tr( "Save as &QGIS Layer Style File…" ), menuExportRaster );
+            connect( actionSaveAsDefinitionLayer, &QAction::triggered, QgisApp::instance(), &QgisApp::saveAsLayerDefinition );
+            menuExportRaster->addAction( actionSaveAsDefinitionLayer );
+            connect( actionSaveStyle, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveStyleFile(); } );
+            menuExportRaster->addAction( actionSaveStyle );
+            menu->addMenu( menuExportRaster );
+          }
+          break;
+
+          case QgsMapLayerType::AnnotationLayer:
+            break;
+
+          case QgsMapLayerType::PluginLayer:
+            if ( mView->selectedLayerNodes().count() == 1 )
+            {
+              // disable duplication of plugin layers
+              duplicateLayersAction->setEnabled( false );
+            }
+            break;
+
+        }
+        menu->addSeparator();
+      }
 
       // style-related actions
       if ( layer && mView->selectedLayerNodes().count() == 1 )


### PR DESCRIPTION
through layer tree menu, and ensure that the styles can be reapplied to the layer

Fixes #42111
Fixes #42112
