### PR TITLE
[ui] Add map layer icons in the expression builder's tree view

### DIFF
--- a/resources/function_help/json/layer_property
+++ b/resources/function_help/json/layer_property
@@ -1,7 +1,7 @@
 {
   "name": "layer_property",
   "type": "function",
-  "groups": ["General"],
+  "groups": ["Map Layers"],
   "description": "Returns a matching layer property or metadata value.",
   "arguments": [
 	{"arg":"layer", "description":"a string, representing either a layer name or layer ID"},

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -7146,7 +7146,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
     functions
         << new QgsStaticExpressionFunction( QStringLiteral( "layer_property" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "layer" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "property" ) ),
-                                            fcnGetLayerProperty, QStringLiteral( "General" ) )
+                                            fcnGetLayerProperty, QStringLiteral( "Map Layers" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "decode_uri" ),
                                             QgsExpressionFunction::ParameterList()
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "layer" ) )

--- a/src/gui/qgsexpressiontreeview.cpp
+++ b/src/gui/qgsexpressiontreeview.cpp
@@ -413,7 +413,7 @@ void QgsExpressionTreeView::loadLayers()
   for ( ; layerIt != layers.constEnd(); ++layerIt )
   {
     QIcon icon = QgsMapLayerModel::iconForLayer( layerIt.value() );
-    registerItem( QStringLiteral( "Map Layers" ), layerIt.value()->name(), QStringLiteral( "'%1'" ).arg( layerIt.key() ), formatLayerHelp( layerIt.value() ), QgsExpressionItem::ExpressionNode, false, 1, icon );
+    registerItem( QStringLiteral( "Map Layers" ), layerIt.value()->name(), QStringLiteral( "'%1'" ).arg( layerIt.key() ), formatLayerHelp( layerIt.value() ), QgsExpressionItem::ExpressionNode, false, 99, icon );
   }
 }
 

--- a/src/gui/qgsexpressiontreeview.cpp
+++ b/src/gui/qgsexpressiontreeview.cpp
@@ -25,6 +25,7 @@
 #include "qgssettings.h"
 #include "qgsrelationmanager.h"
 #include "qgsapplication.h"
+#include "qgsmaplayermodel.h"
 
 
 //! Returns a HTML formatted string for use as a \a relation item help.
@@ -411,7 +412,8 @@ void QgsExpressionTreeView::loadLayers()
   QMap<QString, QgsMapLayer *>::const_iterator layerIt = layers.constBegin();
   for ( ; layerIt != layers.constEnd(); ++layerIt )
   {
-    registerItemForAllGroups( QStringList() << tr( "Map Layers" ), layerIt.value()->name(), QStringLiteral( "'%1'" ).arg( layerIt.key() ), formatLayerHelp( layerIt.value() ) );
+    QIcon icon = QgsMapLayerModel::iconForLayer( layerIt.value() );
+    registerItem( QStringLiteral( "Map Layers" ), layerIt.value()->name(), QStringLiteral( "'%1'" ).arg( layerIt.key() ), formatLayerHelp( layerIt.value() ), QgsExpressionItem::ExpressionNode, false, 1, icon );
   }
 }
 


### PR DESCRIPTION
## Description

This PR adds map layer icons in the expression builder's tree view. We do this for fields and does help quickly skipping through the list for that {point,line,polygon,mesh,point cloud,raster} layer you're looking for.

Screenshot:
![image](https://user-images.githubusercontent.com/1728657/110591128-40b61e80-81ab-11eb-8db5-28b656872b77.png)

