### PR TITLE
[Backport 3.16] Update widget state when scale locked state is changed from API

### DIFF
--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -989,6 +989,18 @@ Emits current mouse position
 Emitted when the scale of the map changes
 %End
 
+    void scaleLockChanged( bool locked );
+%Docstring
+Emitted when the scale locked state of the map changes
+
+:param locked: true if the scale is locked
+
+.. seealso:: :py:func:`setScaleLocked`
+
+.. versionadded:: 3.16
+%End
+
+
     void extentsChanged();
 %Docstring
 Emitted when the extents of the map change

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3818,9 +3818,9 @@ void QgisApp::createStatusBar()
   mMagnifierWidget->setObjectName( QStringLiteral( "mMagnifierWidget" ) );
   mMagnifierWidget->setFont( statusBarFont );
   connect( mMapCanvas, &QgsMapCanvas::magnificationChanged, mMagnifierWidget, &QgsStatusBarMagnifierWidget::updateMagnification );
+  connect( mMapCanvas, &QgsMapCanvas::scaleLockChanged, mMagnifierWidget, &QgsStatusBarMagnifierWidget::updateScaleLock );
   connect( mMagnifierWidget, &QgsStatusBarMagnifierWidget::magnificationChanged, mMapCanvas, [ = ]( double factor ) { mMapCanvas->setMagnificationFactor( factor ); } );
   connect( mMagnifierWidget, &QgsStatusBarMagnifierWidget::scaleLockChanged, mMapCanvas, &QgsMapCanvas::setScaleLocked );
-  connect( mMagnifierWidget, &QgsStatusBarMagnifierWidget::scaleLockChanged, mScaleWidget, &QgsStatusBarScaleWidget::setLocked );
   mMagnifierWidget->updateMagnification( QSettings().value( QStringLiteral( "/qgis/magnifier_factor_default" ), 1.0 ).toDouble() );
   mStatusBar->addPermanentWidget( mMagnifierWidget, 0 );
 

--- a/src/app/qgsstatusbarmagnifierwidget.cpp
+++ b/src/app/qgsstatusbarmagnifierwidget.cpp
@@ -93,6 +93,11 @@ void QgsStatusBarMagnifierWidget::updateMagnification( double factor )
   mSpinBox->setValue( factor * 100 );
 }
 
+void QgsStatusBarMagnifierWidget::updateScaleLock( bool locked )
+{
+  mLockButton->setChecked( locked );
+}
+
 void QgsStatusBarMagnifierWidget::setMagnification( double value )
 {
   emit magnificationChanged( value / 100 );

--- a/src/app/qgsstatusbarmagnifierwidget.h
+++ b/src/app/qgsstatusbarmagnifierwidget.h
@@ -56,6 +56,12 @@ class APP_EXPORT QgsStatusBarMagnifierWidget : public QWidget
     //! will be triggered from map canvas changes (from mouse wheel, zoom)
     void updateMagnification( double factor );
 
+    /**
+     * Will be triggered from map canvas API changes
+     * \param locked true if the scale is locked
+     * \since 3.16
+     */
+    void updateScaleLock( bool locked );
 
   private slots:
     //! will be triggered form user input in spin box

--- a/src/app/qgsstatusbarscalewidget.cpp
+++ b/src/app/qgsstatusbarscalewidget.cpp
@@ -60,6 +60,7 @@ QgsStatusBarScaleWidget::QgsStatusBarScaleWidget( QgsMapCanvas *canvas, QWidget 
   setLayout( mLayout );
 
   connect( mScale, &QgsScaleComboBox::scaleChanged, this, &QgsStatusBarScaleWidget::userScale );
+  connect( mMapCanvas, &QgsMapCanvas::scaleLockChanged, this, &QgsStatusBarScaleWidget::setLocked );
 }
 
 void QgsStatusBarScaleWidget::setScale( double scale )

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1968,7 +1968,11 @@ void QgsMapCanvas::zoomWithCenter( int x, int y, bool zoomIn )
 
 void QgsMapCanvas::setScaleLocked( bool isLocked )
 {
-  mScaleLocked = isLocked;
+  if ( mScaleLocked != isLocked )
+  {
+    mScaleLocked = isLocked;
+    emit scaleLockChanged( mScaleLocked );
+  }
 }
 
 void QgsMapCanvas::mouseMoveEvent( QMouseEvent *e )

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -908,6 +908,15 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! Emitted when the scale of the map changes
     void scaleChanged( double );
 
+    /**
+     * Emitted when the scale locked state of the map changes
+     * \param locked true if the scale is locked
+     * \see setScaleLocked
+     * \since QGIS 3.16
+     */
+    void scaleLockChanged( bool locked );
+
+
     //! Emitted when the extents of the map change
     void extentsChanged();
 


### PR DESCRIPTION
## Description

Even if there is a new signal *scaleLockChanged* signal in QgsMapCanvas API , I would like to backport #42101 to release-3_16

If OK, I will then update #42146 and master to change the `\since 3.18` to `\since 3.16`