### PR TITLE
Server standalone threaded version

### DIFF
--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -27,6 +27,7 @@ while QGIS server internal logging is printed to stderr.
 #include <thread>
 #include <string>
 #include <chrono>
+#include <condition_variable>
 
 //for CMAKE_INSTALL_PREFIX
 #include "qgsconfig.h"
@@ -44,6 +45,7 @@ while QGIS server internal logging is printed to stderr.
 #include <QCommandLineParser>
 #include <QObject>
 #include <QQueue>
+#include <QThread>
 
 
 #ifndef Q_OS_WIN
@@ -152,7 +154,7 @@ class TcpServerWorker: public QObject
         mIsListening = true;
 
         // Incoming connection handler
-        mTcpServer.connect( &mTcpServer, &QTcpServer::newConnection, [ & ]
+        mTcpServer.connect( &mTcpServer, &QTcpServer::newConnection, [ = ]
         {
           QTcpSocket *clientConnection = mTcpServer.nextPendingConnection();
 
@@ -285,7 +287,7 @@ class TcpServerWorker: public QObject
                 // Take Host header if defined
                 if ( headers.contains( QStringLiteral( "Host" ) ) )
                 {
-                  url = QStringLiteral( "http://%1%2" ).arg( headers.value( QStringLiteral( "Host" ) ) ).arg( path );
+                  url = QStringLiteral( "http://%1%2" ).arg( headers.value( QStringLiteral( "Host" ) ), path );
                 }
                 else
                 {

--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -357,7 +357,7 @@ class TcpServerWorker: public QObject
   public slots:
 
     // Outgoing connection handler
-    void responseReady( RequestContext *requestContext )
+    void responseReady( RequestContext *requestContext )  //#spellok
     {
       std::unique_ptr<RequestContext> request { requestContext };
       auto elapsedTime { std::chrono::steady_clock::now() - request->startTime };
@@ -426,10 +426,10 @@ class TcpServerThread: public QThread
     {
     }
 
-    void emitResponseReady( RequestContext *requestContext )
+    void emitResponseReady( RequestContext *requestContext )  //#spellok
     {
       if ( requestContext->clientConnection )
-        emit responseReady( requestContext );
+        emit responseReady( requestContext );  //#spellok
     }
 
     void run( )
@@ -442,14 +442,14 @@ class TcpServerThread: public QThread
       else
       {
         // Forward signal to worker
-        connect( this, &TcpServerThread::responseReady, &worker, &TcpServerWorker::responseReady );
+        connect( this, &TcpServerThread::responseReady, &worker, &TcpServerWorker::responseReady );  //#spellok
         QThread::run();
       }
     }
 
   signals:
 
-    void responseReady( RequestContext *requestContext );
+    void responseReady( RequestContext *requestContext );  //#spellok
     void serverError( );
 
   private:
@@ -638,7 +638,7 @@ int main( int argc, char *argv[] )
       return;
     }
     if ( requestContext->clientConnection && requestContext->clientConnection->isValid() )
-      tcpServerThread.emitResponseReady( requestContext );
+      tcpServerThread.emitResponseReady( requestContext );  //#spellok
     else
       delete requestContext;
   } );

--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -11,7 +11,7 @@ while QGIS server internal logging is printed to stderr.
 
                               -------------------
   begin                : Jan 17 2020
-  copyright            : (C) 2020by Alessandro Pasotti
+  copyright            : (C) 2020 by Alessandro Pasotti
   email                : elpaso at itopen dot it
  ***************************************************************************/
 
@@ -340,7 +340,10 @@ class TcpServerWorker: public QObject
       mTcpServer.close();
     }
 
-    bool isListening() const;
+    bool isListening() const
+    {
+      return mIsListening;
+    }
 
   public slots:
 
@@ -651,7 +654,4 @@ int main( int argc, char *argv[] )
 
 /// @endcond
 
-bool TcpServerWorker::isListening() const
-{
-  return mIsListening;
-}
+

--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -55,13 +55,6 @@ while QGIS server internal logging is printed to stderr.
 // For the signal exit handler
 QAtomicInt IS_RUNNING = 1;
 
-// Request sync
-//QWaitCondition SERVER_WAIT_CONDITION;
-//QMutex SERVER_MUTEX;
-// Server sync
-//QWaitCondition REQUEST_WAIT_CONDITION;
-//QMutex REQUEST_QUEUE_MUTEX;
-
 QString ipAddress;
 QString serverPort;
 
@@ -315,17 +308,14 @@ class TcpServerWorker: public QObject
                 } ;
                 REQUEST_QUEUE_MUTEX.lock();
                 REQUEST_QUEUE.enqueue( requestContext );
-                REQUEST_WAIT_CONDITION.notify_one();
                 REQUEST_QUEUE_MUTEX.unlock();
+                REQUEST_WAIT_CONDITION.notify_one();
               }
             }
             catch ( HttpException &ex )
             {
-
               if ( clientConnection->state() == QAbstractSocket::SocketState::ConnectedState )
               {
-
-
                 // Output stream: send error
                 clientConnection->write( QStringLiteral( "HTTP/1.0 %1 %2\r\n" ).arg( 500 ).arg( knownStatuses.value( 500 ) ).toUtf8() );
                 clientConnection->write( QStringLiteral( "Server: QGIS\r\n" ).toUtf8() );
@@ -342,7 +332,6 @@ class TcpServerWorker: public QObject
             }
           } );
         } );
-
       }
     }
 

--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -160,7 +160,7 @@ class TcpServerWorker: public QObject
 
           mConnectionCounter++;
 
-          qDebug() << "Active connections: " << mConnectionCounter;
+          //qDebug() << "Active connections: " << mConnectionCounter;
 
           QString *incomingData = new QString();
 
@@ -176,16 +176,14 @@ class TcpServerWorker: public QObject
           };
 
           // This will delete the connection
-          clientConnection->connect( clientConnection, &QAbstractSocket::disconnected, clientConnection, [ = ] {
-            connectionDeleter();
-            qDebug() << "Socket disconnected";
-          }, Qt::QueuedConnection );
+          clientConnection->connect( clientConnection, &QAbstractSocket::disconnected, clientConnection, connectionDeleter, Qt::QueuedConnection );
 
-          // Debugging output
+#if 0     // Debugging output
           clientConnection->connect( clientConnection, &QAbstractSocket::errorOccurred, clientConnection, [ = ]( QAbstractSocket::SocketError socketError )
           {
             qDebug() << "Socket error #" << socketError;
           }, Qt::QueuedConnection );
+#endif
 
           // Incoming connection parser
           clientConnection->connect( clientConnection, &QIODevice::readyRead, context, [ = ] {
@@ -333,7 +331,7 @@ class TcpServerWorker: public QObject
                 clientConnection->write( "\r\n" );
                 clientConnection->write( ex.message().toUtf8() );
 
-                std::cout << QStringLiteral( "%1 [%2] \"%3\" - - 500" )
+                std::cout << QStringLiteral( "\033[1;31m%1 [%2] \"%3\" - - 500\033[0m" )
                           .arg( clientConnection->peerAddress().toString() )
                           .arg( QDateTime::currentDateTime().toString() )
                           .arg( ex.message() ).toStdString() << std::endl;
@@ -393,7 +391,7 @@ class TcpServerWorker: public QObject
       clientConnection->write( body );
 
       // 10.185.248.71 [09/Jan/2015:19:12:06 +0000] 808840 <time> "GET / HTTP/1.1" 500"
-      std::cout << QStringLiteral( "%1 [%2] %3 %4ms \"%5\" %6" )
+      std::cout << QStringLiteral( "\033[1;92m%1 [%2] %3 %4ms \"%5\" %6\033[0m" )
                 .arg( clientConnection->peerAddress().toString(),
                       QDateTime::currentDateTime().toString(),
                       QString::number( body.size() ),


### PR DESCRIPTION
A threaded version of the standalone development server.

The threads were introduced to handle the incoming connections and serialize the server processing (which remains single-threaded) still avoiding the ugly sleep that we have in the current implementation.

According to my measurements, this version is slightly but consistently faster than the current one.

The core issue with event loops in WMS still remains.

