### PR TITLE
Prevent and hide collapse/expand in Dynamic SVG parameters table in layer symbology

### DIFF
--- a/src/ui/symbollayer/widget_svgselector.ui
+++ b/src/ui/symbollayer/widget_svgselector.ui
@@ -174,7 +174,14 @@
        </widget>
       </item>
       <item row="0" column="0" colspan="5">
-       <widget class="QTreeView" name="mParametersTreeView"/>
+       <widget class="QTreeView" name="mParametersTreeView">
+        <property name="rootIsDecorated">
+         <bool>false</bool>
+        </property>
+        <property name="itemsExpandable">
+         <bool>false</bool>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
## Description

Fix #42183

This prevents the tree column to be expanded/collapsed. That was causing the crash.

I've hidden also the small triangle decoration.

Proposal:

![no handlers](https://user-images.githubusercontent.com/163681/110680272-4b36df00-81d0-11eb-9b64-1b3005d73774.png)

Before:

![handlers](https://user-images.githubusercontent.com/163681/110679933-f09d8300-81cf-11eb-8f07-ffd529f094fa.png)

