### PR TITLE
[ogr] Fix absence of proper feature ID when adding features to CSV, ODS, and XLSX datasets

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.h
+++ b/src/core/providers/ogr/qgsogrprovider.h
@@ -310,10 +310,12 @@ class QgsOgrProvider final: public QgsVectorDataProvider
 
     mutable QStringList mSubLayerList;
 
-    //! converts \a value from json QVariant to QString
+    //! Converts \a value from json QVariant to QString
     QString jsonStringValue( const QVariant &value ) const;
 
-    bool addFeaturePrivate( QgsFeature &f, QgsFeatureSink::Flags flags );
+    //! The \a incrementalFeatureId will generally be -1, except for a few OGR drivers where QGIS will pass on a value when OGR doesn't set it
+    bool addFeaturePrivate( QgsFeature &f, QgsFeatureSink::Flags flags, QgsFeatureId incrementalFeatureId = -1 );
+
     //! Deletes one feature
     bool deleteFeature( QgsFeatureId id );
 


### PR DESCRIPTION
## Description

This PR fixes the absence of a proper/valid feature ID when adding new features to preexisting [CSV,ODS,XLSX] datasets. 

@rouault , @nyalldawson , @suricactus , as discussed here (https://github.com/OSGeo/gdal/issues/3552).