### PR TITLE
Add option to use the old legend style

### DIFF
--- a/python/core/auto_generated/layertree/qgscolorramplegendnodesettings.sip.in
+++ b/python/core/auto_generated/layertree/qgscolorramplegendnodesettings.sip.in
@@ -208,11 +208,11 @@ Returns ``True`` if a continuous gradient legend will be used.
 
     void setUseContinuousLegend( bool useContinuousLegend );
 %Docstring
-Sets the flag to use a continuos legend to ``useContinuousLegend``.
+Sets the flag to use a continuos gradient legend to ``useContinuousLegend``.
 
-When this flag is set the legend will be rendered using a single color ramp with
+When this flag is set the legend will be rendered using a continuous color ramp with
 min and max values, when it is not set the legend will be rendered using separate
-items for each item entry.
+items for each entry.
 
 .. seealso:: :py:func:`setOrientation`
 

--- a/python/core/auto_generated/layertree/qgscolorramplegendnodesettings.sip.in
+++ b/python/core/auto_generated/layertree/qgscolorramplegendnodesettings.sip.in
@@ -199,6 +199,26 @@ Sets the ramp ``orientation`` (i.e. horizontal or vertical).
 .. seealso:: :py:func:`setDirection`
 %End
 
+    bool useContinuousLegend() const;
+%Docstring
+Returns the ``True`` if the flag to use continuous legend is set.
+
+.. seealso:: :py:func:`setUseContinuousLegend`
+%End
+
+    void setUseContinuousLegend( bool useContinuousLegend );
+%Docstring
+Sets the flag to use a continuos legend to ``useContinuousLegend``.
+
+When this flag is set the legend will be rendered using a single color ramp with
+min and max values, when it is not set the legend will be rendered using separate
+items for each item entry.
+
+.. seealso:: :py:func:`setOrientation`
+
+.. seealso:: :py:func:`direction`
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/layertree/qgscolorramplegendnodesettings.sip.in
+++ b/python/core/auto_generated/layertree/qgscolorramplegendnodesettings.sip.in
@@ -201,7 +201,7 @@ Sets the ramp ``orientation`` (i.e. horizontal or vertical).
 
     bool useContinuousLegend() const;
 %Docstring
-Returns the ``True`` if the flag to use continuous legend is set.
+Returns ``True`` if a continuous gradient legend will be used.
 
 .. seealso:: :py:func:`setUseContinuousLegend`
 %End

--- a/python/gui/auto_generated/qgscolorramplegendnodewidget.sip.in
+++ b/python/gui/auto_generated/qgscolorramplegendnodewidget.sip.in
@@ -49,6 +49,15 @@ Sets the settings to show in the widget.
 .. seealso:: :py:func:`settings`
 %End
 
+    void setUseContinuousRampCheckBoxVisibility( bool visible );
+%Docstring
+Sets visibility for the "Use Continuous Legend" checkbox to ``visible``.
+
+This widget is visible and checked by default but in a few cases it does not
+need to be visible because disabling it would not make sense (for instance
+when using single band gray renderer).
+%End
+
 };
 
 class QgsColorRampLegendNodeDialog : QDialog
@@ -77,6 +86,15 @@ Returns the legend node settings as defined by the dialog.
     QDialogButtonBox *buttonBox() const;
 %Docstring
 Returns a reference to the dialog's button box.
+%End
+
+    void setUseContinuousRampCheckBoxVisibility( bool visible );
+%Docstring
+Sets visibility for the "Use Continuous Legend" checkbox in the legend settings dialog to ``visible``.
+
+This widget is visible and checked by default but in a few cases it does not
+need to be visible because disabling it would not make sense (for instance
+when using single band gray renderer).
 %End
 
 };

--- a/src/core/layertree/qgscolorramplegendnodesettings.cpp
+++ b/src/core/layertree/qgscolorramplegendnodesettings.cpp
@@ -26,7 +26,8 @@ QgsColorRampLegendNodeSettings::QgsColorRampLegendNodeSettings()
 }
 
 QgsColorRampLegendNodeSettings::QgsColorRampLegendNodeSettings( const QgsColorRampLegendNodeSettings &other )
-  : mMinimumLabel( other.mMinimumLabel )
+  : mUseContinuousLegend( other.mUseContinuousLegend )
+  , mMinimumLabel( other.mMinimumLabel )
   , mMaximumLabel( other.mMaximumLabel )
   , mPrefix( other.mPrefix )
   , mSuffix( other.mSuffix )
@@ -40,6 +41,7 @@ QgsColorRampLegendNodeSettings::QgsColorRampLegendNodeSettings( const QgsColorRa
 
 QgsColorRampLegendNodeSettings &QgsColorRampLegendNodeSettings::operator=( const QgsColorRampLegendNodeSettings &other )
 {
+  mUseContinuousLegend = other.mUseContinuousLegend;
   mMinimumLabel = other.mMinimumLabel;
   mMaximumLabel = other.mMaximumLabel;
   mPrefix = other.mPrefix;
@@ -97,6 +99,7 @@ void QgsColorRampLegendNodeSettings::writeXml( QDomDocument &doc, QDomElement &e
 {
   QDomElement settingsElement = doc.createElement( QStringLiteral( "rampLegendSettings" ) );
 
+  settingsElement.setAttribute( QStringLiteral( "useContinuousLegend" ),  mUseContinuousLegend );
   settingsElement.setAttribute( QStringLiteral( "minimumLabel" ), mMinimumLabel );
   settingsElement.setAttribute( QStringLiteral( "maximumLabel" ), mMaximumLabel );
   settingsElement.setAttribute( QStringLiteral( "prefix" ), mPrefix );
@@ -121,6 +124,7 @@ void QgsColorRampLegendNodeSettings::readXml( const QDomElement &element, const 
   const QDomElement settingsElement = element.firstChildElement( QStringLiteral( "rampLegendSettings" ) );
   if ( !settingsElement.isNull() )
   {
+    mUseContinuousLegend = settingsElement.attribute( QStringLiteral( "useContinuousLegend" ), QStringLiteral( "1" ) ).toInt( );
     mMinimumLabel = settingsElement.attribute( QStringLiteral( "minimumLabel" ) );
     mMaximumLabel = settingsElement.attribute( QStringLiteral( "maximumLabel" ) );
     mPrefix = settingsElement.attribute( QStringLiteral( "prefix" ) );
@@ -184,4 +188,14 @@ Qt::Orientation QgsColorRampLegendNodeSettings::orientation() const
 void QgsColorRampLegendNodeSettings::setOrientation( Qt::Orientation orientation )
 {
   mOrientation = orientation;
+}
+
+bool QgsColorRampLegendNodeSettings::useContinuousLegend() const
+{
+  return mUseContinuousLegend;
+}
+
+void QgsColorRampLegendNodeSettings::setUseContinuousLegend( bool useContinuousLegend )
+{
+  mUseContinuousLegend = useContinuousLegend;
 }

--- a/src/core/layertree/qgscolorramplegendnodesettings.h
+++ b/src/core/layertree/qgscolorramplegendnodesettings.h
@@ -202,7 +202,27 @@ class CORE_EXPORT QgsColorRampLegendNodeSettings
      */
     void setOrientation( Qt::Orientation orientation );
 
+    /**
+     * Returns the TRUE if the flag to use continuous legend is set.
+     *
+     * \see setUseContinuousLegend()
+     */
+    bool useContinuousLegend() const;
+
+    /**
+     * Sets the flag to use a continuos legend to \a useContinuousLegend.
+     *
+     * When this flag is set the legend will be rendered using a single color ramp with
+     * min and max values, when it is not set the legend will be rendered using separate
+     * items for each item entry.
+     *
+     * \see setOrientation()
+     * \see direction()
+     */
+    void setUseContinuousLegend( bool useContinuousLegend );
+
   private:
+    bool mUseContinuousLegend = true;
     QString mMinimumLabel;
     QString mMaximumLabel;
     QString mPrefix;

--- a/src/core/layertree/qgscolorramplegendnodesettings.h
+++ b/src/core/layertree/qgscolorramplegendnodesettings.h
@@ -203,7 +203,7 @@ class CORE_EXPORT QgsColorRampLegendNodeSettings
     void setOrientation( Qt::Orientation orientation );
 
     /**
-     * Returns the TRUE if the flag to use continuous legend is set.
+     * Returns TRUE if a continuous gradient legend will be used.
      *
      * \see setUseContinuousLegend()
      */

--- a/src/core/layertree/qgscolorramplegendnodesettings.h
+++ b/src/core/layertree/qgscolorramplegendnodesettings.h
@@ -210,11 +210,11 @@ class CORE_EXPORT QgsColorRampLegendNodeSettings
     bool useContinuousLegend() const;
 
     /**
-     * Sets the flag to use a continuos legend to \a useContinuousLegend.
+     * Sets the flag to use a continuos gradient legend to \a useContinuousLegend.
      *
-     * When this flag is set the legend will be rendered using a single color ramp with
+     * When this flag is set the legend will be rendered using a continuous color ramp with
      * min and max values, when it is not set the legend will be rendered using separate
-     * items for each item entry.
+     * items for each entry.
      *
      * \see setOrientation()
      * \see direction()

--- a/src/core/pointcloud/qgspointcloudattributebyramprenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudattributebyramprenderer.cpp
@@ -179,13 +179,17 @@ QList<QgsLayerTreeModelLegendNode *> QgsPointCloudAttributeByRampRenderer::creat
   switch ( mColorRampShader.colorRampType() )
   {
     case QgsColorRampShader::Interpolated:
-      // for interpolated shaders we use a ramp legend node
-      res << new QgsColorRampLegendNode( nodeLayer, mColorRampShader.sourceColorRamp()->clone(),
-                                         mColorRampShader.legendSettings() ? *mColorRampShader.legendSettings() : QgsColorRampLegendNodeSettings(),
-                                         mColorRampShader.minimumValue(),
-                                         mColorRampShader.maximumValue() );
-      break;
-
+      // for interpolated shaders we use a ramp legend node unless the settings flag
+      // to use the continuous legend is not set, in that case we fall through
+      if ( ! mColorRampShader.legendSettings() || mColorRampShader.legendSettings()->useContinuousLegend() )
+      {
+        res << new QgsColorRampLegendNode( nodeLayer, mColorRampShader.sourceColorRamp()->clone(),
+                                           mColorRampShader.legendSettings() ? *mColorRampShader.legendSettings() : QgsColorRampLegendNodeSettings(),
+                                           mColorRampShader.minimumValue(),
+                                           mColorRampShader.maximumValue() );
+        break;
+      }
+      Q_FALLTHROUGH();
     case QgsColorRampShader::Discrete:
     case QgsColorRampShader::Exact:
     {

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
@@ -444,15 +444,19 @@ QList<QgsLayerTreeModelLegendNode *> QgsSingleBandPseudoColorRenderer::createLeg
   switch ( rampShader->colorRampType() )
   {
     case QgsColorRampShader::Interpolated:
-      // for interpolated shaders we use a ramp legend node
-      if ( !rampShader->colorRampItemList().isEmpty() )
+      // for interpolated shaders we use a ramp legend node unless the settings flag
+      // to use the continuous legend is not set, in that case we fall through
+      if ( ! rampShader->legendSettings() || rampShader->legendSettings()->useContinuousLegend() )
       {
-        res << new QgsColorRampLegendNode( nodeLayer, rampShader->createColorRamp(),
-                                           rampShader->legendSettings() ? *rampShader->legendSettings() : QgsColorRampLegendNodeSettings(),
-                                           rampShader->minimumValue(), rampShader->maximumValue() );
+        if ( !rampShader->colorRampItemList().isEmpty() )
+        {
+          res << new QgsColorRampLegendNode( nodeLayer, rampShader->createColorRamp(),
+                                             rampShader->legendSettings() ? *rampShader->legendSettings() : QgsColorRampLegendNodeSettings(),
+                                             rampShader->minimumValue(), rampShader->maximumValue() );
+        }
+        break;
       }
-      break;
-
+      Q_FALLTHROUGH();
     case QgsColorRampShader::Discrete:
     case QgsColorRampShader::Exact:
     {

--- a/src/gui/qgscolorramplegendnodewidget.cpp
+++ b/src/gui/qgscolorramplegendnodewidget.cpp
@@ -38,6 +38,13 @@ QgsColorRampLegendNodeWidget::QgsColorRampLegendNodeWidget( QWidget *parent )
   mFontButton->setShowNullFormat( true );
   mFontButton->setNoFormatString( tr( "Default" ) );
 
+  connect( mUseContinuousLegendCheckBox, &QCheckBox::stateChanged, this, [ = ]( bool checked )
+  {
+    mLayoutGroup->setEnabled( checked );
+    mLabelsGroup->setEnabled( checked );
+    onChanged();
+  } );
+
   connect( mMinLabelLineEdit, &QLineEdit::textChanged, this, &QgsColorRampLegendNodeWidget::onChanged );
   connect( mMaxLabelLineEdit, &QLineEdit::textChanged, this, &QgsColorRampLegendNodeWidget::onChanged );
   connect( mPrefixLineEdit, &QLineEdit::textChanged, this, &QgsColorRampLegendNodeWidget::onChanged );
@@ -51,6 +58,7 @@ QgsColorRampLegendNodeWidget::QgsColorRampLegendNodeWidget( QWidget *parent )
 QgsColorRampLegendNodeSettings QgsColorRampLegendNodeWidget::settings() const
 {
   QgsColorRampLegendNodeSettings settings;
+  settings.setUseContinuousLegend( mUseContinuousLegendCheckBox->isChecked() );
   settings.setDirection( static_cast< QgsColorRampLegendNodeSettings::Direction >( mDirectionComboBox->currentData().toInt() ) );
   settings.setOrientation( static_cast< Qt::Orientation >( mOrientationComboBox->currentData().toInt() ) );
   settings.setMinimumLabel( mMinLabelLineEdit->text() );
@@ -67,6 +75,7 @@ void QgsColorRampLegendNodeWidget::setSettings( const QgsColorRampLegendNodeSett
   mBlockSignals = true;
 
   mSettings = settings;
+  mUseContinuousLegendCheckBox->setChecked( settings.useContinuousLegend() );
   mMinLabelLineEdit->setText( settings.minimumLabel() );
   mMaxLabelLineEdit->setText( settings.maximumLabel() );
   mPrefixLineEdit->setText( settings.prefix() );
@@ -76,6 +85,11 @@ void QgsColorRampLegendNodeWidget::setSettings( const QgsColorRampLegendNodeSett
   mFontButton->setTextFormat( settings.textFormat() );
   onOrientationChanged();
   mBlockSignals = false;
+}
+
+void QgsColorRampLegendNodeWidget::setUseContinuousRampCheckBoxVisibility( bool visible )
+{
+  mUseContinuousLegendCheckBox->setVisible( visible );
 }
 
 void QgsColorRampLegendNodeWidget::changeNumberFormat()
@@ -147,4 +161,9 @@ QgsColorRampLegendNodeSettings QgsColorRampLegendNodeDialog::settings() const
 QDialogButtonBox *QgsColorRampLegendNodeDialog::buttonBox() const
 {
   return mButtonBox;
+}
+
+void QgsColorRampLegendNodeDialog::setUseContinuousRampCheckBoxVisibility( bool visible )
+{
+  mWidget->setUseContinuousRampCheckBoxVisibility( visible );
 }

--- a/src/gui/qgscolorramplegendnodewidget.h
+++ b/src/gui/qgscolorramplegendnodewidget.h
@@ -63,6 +63,15 @@ class GUI_EXPORT QgsColorRampLegendNodeWidget: public QgsPanelWidget, private Ui
      */
     void setSettings( const QgsColorRampLegendNodeSettings &settings );
 
+    /**
+     * Sets visibility for the "Use Continuous Legend" checkbox to \a visible.
+     *
+     * This widget is visible and checked by default but in a few cases it does not
+     * need to be visible because disabling it would not make sense (for instance
+     * when using single band gray renderer).
+     */
+    void setUseContinuousRampCheckBoxVisibility( bool visible );
+
   private slots:
 
     void onChanged();
@@ -101,6 +110,15 @@ class GUI_EXPORT QgsColorRampLegendNodeDialog : public QDialog
      * Returns a reference to the dialog's button box.
      */
     QDialogButtonBox *buttonBox() const;
+
+    /**
+     * Sets visibility for the "Use Continuous Legend" checkbox in the legend settings dialog to \a visible.
+     *
+     * This widget is visible and checked by default but in a few cases it does not
+     * need to be visible because disabling it would not make sense (for instance
+     * when using single band gray renderer).
+     */
+    void setUseContinuousRampCheckBoxVisibility( bool visible );
 
   private:
 

--- a/src/gui/raster/qgssinglebandgrayrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandgrayrendererwidget.cpp
@@ -229,6 +229,7 @@ void QgsSingleBandGrayRendererWidget::showLegendSettings()
   if ( panel && panel->dockMode() )
   {
     QgsColorRampLegendNodeWidget *legendPanel = new QgsColorRampLegendNodeWidget();
+    legendPanel->setUseContinuousRampCheckBoxVisibility( false );
     legendPanel->setPanelTitle( tr( "Legend Settings" ) );
     legendPanel->setSettings( mLegendSettings );
     connect( legendPanel, &QgsColorRampLegendNodeWidget::widgetChanged, this, [ = ]
@@ -241,6 +242,7 @@ void QgsSingleBandGrayRendererWidget::showLegendSettings()
   else
   {
     QgsColorRampLegendNodeDialog dialog( mLegendSettings, this );
+    dialog.setUseContinuousRampCheckBoxVisibility( false );
     dialog.setWindowTitle( tr( "Legend Settings" ) );
     if ( dialog.exec() )
     {

--- a/src/ui/qgscolorramplegendnodewidgetbase.ui
+++ b/src/ui/qgscolorramplegendnodewidgetbase.ui
@@ -33,22 +33,25 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QGroupBox" name="groupBox_2">
+    <widget class="QCheckBox" name="mUseContinuousLegendCheckBox">
+     <property name="text">
+      <string>Use continuous legend</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="mLabelsGroup">
      <property name="title">
       <string>Labels</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Prefix</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QgsFilterLineEdit" name="mMaxLabelLineEdit"/>
       </item>
-      <item row="5" column="1">
+      <item row="6" column="1">
        <widget class="QgsFontButton" name="mFontButton">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -61,21 +64,48 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_5">
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_7">
         <property name="text">
-         <string>Suffix</string>
+         <string>Text format</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="1">
+       <widget class="QgsFilterLineEdit" name="mMinLabelLineEdit"/>
+      </item>
+      <item row="1" column="1">
+       <widget class="QgsFilterLineEdit" name="mPrefixLineEdit"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Prefix</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Minimum</string>
         </property>
        </widget>
       </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Suffix</string>
+        </property>
+       </widget>
+      </item>
       <item row="4" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Maximum</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
        <widget class="QLabel" name="mUnitLabelLabel_2">
         <property name="text">
          <string>Number format</string>
@@ -85,17 +115,14 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QgsFilterLineEdit" name="mPrefixLineEdit"/>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_7">
+      <item row="7" column="1">
+       <widget class="QLabel" name="label_6">
         <property name="text">
-         <string>Text format</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;(Applies to print layout legends only)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="5" column="1">
        <widget class="QPushButton" name="mNumberFormatPushButton">
         <property name="text">
          <string>Customize</string>
@@ -103,30 +130,13 @@
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="QgsFilterLineEdit" name="mMinLabelLineEdit"/>
-      </item>
-      <item row="1" column="1">
        <widget class="QgsFilterLineEdit" name="mSuffixLineEdit"/>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Maximum</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;(Applies to print layout legends only)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-       </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="mPatchGroup">
+    <widget class="QGroupBox" name="mLayoutGroup">
      <property name="title">
       <string>Layout</string>
      </property>

--- a/tests/src/python/test_qgscolorramplegendnode.py
+++ b/tests/src/python/test_qgscolorramplegendnode.py
@@ -77,6 +77,10 @@ class TestQgsColorRampLegendNode(unittest.TestCase):
         self.assertEqual(settings.orientation(), Qt.Vertical)
         settings.setOrientation(Qt.Horizontal)
         self.assertEqual(settings.orientation(), Qt.Horizontal)
+        # Test default
+        self.assertTrue(settings.useContinuousLegend())
+        settings.setUseContinuousLegend(False)
+        self.assertFalse(settings.useContinuousLegend())
 
         self.assertFalse(settings.textFormat().isValid())
         tf = QgsTextFormat()
@@ -116,6 +120,7 @@ class TestQgsColorRampLegendNode(unittest.TestCase):
         self.assertEqual(settings3.suffix(), 'suff')
         self.assertEqual(settings3.textFormat().size(), 13)
         self.assertEqual(settings3.orientation(), Qt.Horizontal)
+        self.assertFalse(settings3.useContinuousLegend())
 
         # no text format
         elem = doc.createElement('test2')


### PR DESCRIPTION
Makes it possible to use the "old" legend style (separate items for each value).

The addition to the "Legend Settings" dialog is the top checkbox, when unchecked the other widget elements are disabled.

![immagine](https://user-images.githubusercontent.com/142164/110767615-bc20da00-8256-11eb-82a7-2e1a787575e6.png)
