### PR TITLE
Fix output from Snap Geometries algorithms cannot be plugged into algorithm inputs requiring a point or line geometry type

### DIFF
--- a/src/analysis/processing/qgsalgorithmsnapgeometries.cpp
+++ b/src/analysis/processing/qgsalgorithmsnapgeometries.cpp
@@ -99,7 +99,7 @@ void QgsSnapGeometriesAlgorithm::initAlgorithm( const QVariantMap & )
                         << QObject::tr( "Snap to anchor nodes (single layer only)" );
   addParameter( new QgsProcessingParameterEnum( QStringLiteral( "BEHAVIOR" ), QObject::tr( "Behavior" ), options, false, QVariantList() << 0 ) );
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ),
-                QObject::tr( "Snapped geometry" ), QgsProcessing::TypeVectorPolygon ) );
+                QObject::tr( "Snapped geometry" ), QgsProcessing::TypeVectorAnyGeometry ) );
 }
 
 QgsSnapGeometriesAlgorithm *QgsSnapGeometriesAlgorithm::createInstance() const


### PR DESCRIPTION
Fixes #42200
