### PR TITLE
Simplify use of aux field for callout properties

### DIFF
--- a/src/gui/callouts/qgscalloutwidget.cpp
+++ b/src/gui/callouts/qgscalloutwidget.cpp
@@ -97,14 +97,8 @@ void QgsCalloutWidget::createAuxiliaryField()
   // create property in auxiliary storage if necessary
   if ( !mVectorLayer->auxiliaryLayer()->exists( def ) )
   {
-    QgsNewAuxiliaryFieldDialog dlg( def, mVectorLayer, true, this );
-    if ( dlg.exec() == QDialog::Accepted )
-      def = dlg.propertyDefinition();
+    mVectorLayer->auxiliaryLayer()->addAuxiliaryField( def );
   }
-
-  // return if still not exist
-  if ( !mVectorLayer->auxiliaryLayer()->exists( def ) )
-    return;
 
   // update property with join field name from auxiliary storage
   QgsProperty property = button->toProperty();


### PR DESCRIPTION
Instead of prompting users for an aux field name and type, just
immediately create the field when the option is selected (like
we do for other label properties)
