### PR TITLE
Do not run stale pr/issues checks on fork repo

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   stale:
+    if: github.repository_owner == 'qgis'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v3
@@ -26,7 +27,7 @@ jobs:
 
 
         close-issue-message: >
-          While we hate to see this happen, this Issue has been automatically closed because
+          While we hate to see this happen, this issue has been automatically closed because
           it has not had any activity in the last 42 days despite being marked as feedback.
           If this issue should be reconsidered, please follow the guidelines in the previous
           comment and reopen this issue.

--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   stale:
+    if: github.repository_owner == 'qgis'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v3


### PR DESCRIPTION
Side questions:
- the stale issue bot announces that the issue report will be closed in a week but actually this happen almost a month later. Should the duration be fixed or do we keep the 7 days to stress a bit the reporter :smiling_imp: ?
- the stale PR is closed 7 days after the first notification. I think a PR deserves more consideration before getting closed and that duration should be extended. Any suggestion?