### PR TITLE
Allow auto-creation of callout auxiliary fields when attempting to move a callout start or end point interactively

### DIFF
--- a/python/core/auto_generated/qgsauxiliarystorage.sip.in
+++ b/python/core/auto_generated/qgsauxiliarystorage.sip.in
@@ -192,6 +192,19 @@ activates this property in settings.
 :return: The index of the auxiliary field or -1
 %End
 
+    static int createProperty( QgsCallout::Property property, QgsVectorLayer *vlayer );
+%Docstring
+Creates if necessary a new auxiliary field for a callout's property and
+activates this property in settings.
+
+:param property: The property to create
+:param vlayer: The vector layer
+
+:return: The index of the auxiliary field or -1
+
+.. versionadded:: 3.20
+%End
+
     static QgsField createAuxiliaryField( const QgsPropertyDefinition &definition );
 %Docstring
 Creates a new auxiliary field from a property definition.

--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -106,9 +106,12 @@ Resets the ``flags`` for the canvas' map settings.
 .. versionadded:: 3.0
 %End
 
-    const QgsLabelingResults *labelingResults() const;
+    const QgsLabelingResults *labelingResults( bool allowOutdatedResults = true ) const;
 %Docstring
-Gets access to the labeling results (may be ``None``)
+Gets access to the labeling results (may be ``None``).
+
+Since QGIS 3.20, if the ``allowOutdatedResults`` flag is ``False`` then outdated labeling results (e.g.
+as a result of an ongoing canvas render) will not be returned, and instead ``None`` will be returned.
 
 .. versionadded:: 2.4
 %End

--- a/src/app/labeling/qgsmaptoollabel.cpp
+++ b/src/app/labeling/qgsmaptoollabel.cpp
@@ -987,7 +987,7 @@ void QgsMapToolLabel::updateHoveredLabel( QgsMapMouseEvent *e )
 
   QgsCalloutPosition calloutPosition;
   bool isOrigin = false;
-  if ( calloutAtPosition( e, calloutPosition, isOrigin ) )
+  if ( !mCalloutProperties.isEmpty() && calloutAtPosition( e, calloutPosition, isOrigin ) )
   {
     if ( !mCalloutOtherPointsRubberBand )
     {

--- a/src/app/labeling/qgsmaptoollabel.cpp
+++ b/src/app/labeling/qgsmaptoollabel.cpp
@@ -62,7 +62,7 @@ void QgsMapToolLabel::deactivate()
 bool QgsMapToolLabel::labelAtPosition( QMouseEvent *e, QgsLabelPosition &p )
 {
   QgsPointXY pt = toMapCoordinates( e->pos() );
-  const QgsLabelingResults *labelingResults = mCanvas->labelingResults();
+  const QgsLabelingResults *labelingResults = mCanvas->labelingResults( false );
   if ( !labelingResults )
     return false;
 
@@ -123,7 +123,7 @@ bool QgsMapToolLabel::labelAtPosition( QMouseEvent *e, QgsLabelPosition &p )
 bool QgsMapToolLabel::calloutAtPosition( QMouseEvent *e, QgsCalloutPosition &p, bool &isOrigin )
 {
   QgsPointXY pt = toMapCoordinates( e->pos() );
-  const QgsLabelingResults *labelingResults = mCanvas->labelingResults();
+  const QgsLabelingResults *labelingResults = mCanvas->labelingResults( false );
   if ( !labelingResults )
     return false;
 

--- a/src/app/labeling/qgsmaptoollabel.h
+++ b/src/app/labeling/qgsmaptoollabel.h
@@ -23,12 +23,14 @@
 #include "qgsnewauxiliarylayerdialog.h"
 #include "qgsauxiliarystorage.h"
 #include "qgscalloutposition.h"
+#include "qgscallout.h"
 #include "qgis_app.h"
 
 class QgsRubberBand;
 
 typedef QMap<QgsPalLayerSettings::Property, int> QgsPalIndexes;
 typedef QMap<QgsDiagramLayerSettings::Property, int> QgsDiagramIndexes;
+typedef QMap<QgsCallout::Property, int> QgsCalloutIndexes;
 
 //! Base class for map tools that modify label properties
 class APP_EXPORT QgsMapToolLabel: public QgsMapToolAdvancedDigitizing
@@ -111,6 +113,8 @@ class APP_EXPORT QgsMapToolLabel: public QgsMapToolAdvancedDigitizing
 
     //! Currently hovered label position
     LabelDetails mCurrentHoverLabel;
+
+    QgsCalloutPosition mCurrentCallout;
 
     /**
      * Returns label position for mouse click location
@@ -220,6 +224,8 @@ class APP_EXPORT QgsMapToolLabel: public QgsMapToolAdvancedDigitizing
     bool createAuxiliaryFields( LabelDetails &details, QgsPalIndexes &palIndexes, bool overwriteExpression = true ) const;
     bool createAuxiliaryFields( QgsDiagramIndexes &diagIndexes, bool overwriteExpression = true );
     bool createAuxiliaryFields( LabelDetails &details, QgsDiagramIndexes &diagIndexes, bool overwriteExpression = true );
+    bool createAuxiliaryFields( QgsCalloutIndexes &calloutIndexes, bool overwriteExpression = true );
+    bool createAuxiliaryFields( QgsCalloutPosition &details, QgsCalloutIndexes &calloutIndexes, bool overwriteExpression = true );
 
     void updateHoveredLabel( QgsMapMouseEvent *e );
     void clearHoveredLabel();
@@ -228,6 +234,7 @@ class APP_EXPORT QgsMapToolLabel: public QgsMapToolAdvancedDigitizing
 
     QList<QgsPalLayerSettings::Property> mPalProperties;
     QList<QgsDiagramLayerSettings::Property> mDiagramProperties;
+    QList<QgsCallout::Property> mCalloutProperties;
 
     friend class TestQgsMapToolLabel;
 };

--- a/src/app/labeling/qgsmaptoolmovelabel.cpp
+++ b/src/app/labeling/qgsmaptoolmovelabel.cpp
@@ -37,6 +37,11 @@ QgsMapToolMoveLabel::QgsMapToolMoveLabel( QgsMapCanvas *canvas, QgsAdvancedDigit
 
   mDiagramProperties << QgsDiagramLayerSettings::PositionX;
   mDiagramProperties << QgsDiagramLayerSettings::PositionY;
+
+  mCalloutProperties << QgsCallout::OriginX;
+  mCalloutProperties << QgsCallout::OriginY;
+  mCalloutProperties << QgsCallout::DestinationX;
+  mCalloutProperties << QgsCallout::DestinationY;
 }
 
 QgsMapToolMoveLabel::~QgsMapToolMoveLabel()
@@ -100,8 +105,19 @@ void QgsMapToolMoveLabel::cadCanvasPressEvent( QgsMapMouseEvent *e )
 
     int xCol = 0;
     int yCol = 0;
-    if ( calloutAtPosition( e, calloutPosition, mCurrentCalloutMoveOrigin ) && canModifyCallout( calloutPosition, mCurrentCalloutMoveOrigin, xCol, yCol ) )
+    if ( calloutAtPosition( e, calloutPosition, mCurrentCalloutMoveOrigin ) )
     {
+      if ( !canModifyCallout( calloutPosition, mCurrentCalloutMoveOrigin, xCol, yCol ) )
+      {
+        QgsCalloutIndexes indexes;
+
+        if ( createAuxiliaryFields( calloutPosition, indexes ) )
+          return;
+
+        if ( !canModifyCallout( calloutPosition, mCurrentCalloutMoveOrigin, xCol, yCol ) )
+          return;
+      }
+
       // callouts are a smaller target, so they take precedence over labels
       mCurrentLabel = LabelDetails();
       mCurrentCallout = calloutPosition;

--- a/src/app/labeling/qgsmaptoolmovelabel.h
+++ b/src/app/labeling/qgsmaptoolmovelabel.h
@@ -43,7 +43,6 @@ class APP_EXPORT QgsMapToolMoveLabel: public QgsMapToolLabel
 
     bool canModifyCallout( const QgsCalloutPosition &position, bool isOrigin, int &xCol, int &yCol ) override;
 
-    QgsCalloutPosition mCurrentCallout;
     bool mCurrentCalloutMoveOrigin = false;
 
     QgsRubberBand *mCalloutMoveRubberBand = nullptr;

--- a/src/app/labeling/qgsmaptoolpinlabels.cpp
+++ b/src/app/labeling/qgsmaptoolpinlabels.cpp
@@ -167,10 +167,9 @@ void QgsMapToolPinLabels::highlightPinnedLabels()
   QgsDebugMsg( QStringLiteral( "Highlighting pinned labels" ) );
 
   // get list of all drawn labels from all layers within given extent
-  const QgsLabelingResults *labelingResults = mCanvas->labelingResults();
+  const QgsLabelingResults *labelingResults = mCanvas->labelingResults( false );
   if ( !labelingResults )
   {
-    QgsDebugMsg( QStringLiteral( "No labeling engine" ) );
     return;
   }
 
@@ -238,10 +237,9 @@ void QgsMapToolPinLabels::pinUnpinLabels( const QgsRectangle &ext, QMouseEvent *
   bool toggleUnpinOrPin = e->modifiers() & Qt::ControlModifier;
 
   // get list of all drawn labels from all layers within, or touching, chosen extent
-  const QgsLabelingResults *labelingResults = mCanvas->labelingResults();
+  const QgsLabelingResults *labelingResults = mCanvas->labelingResults( false );
   if ( !labelingResults )
   {
-    QgsDebugMsg( QStringLiteral( "No labeling engine" ) );
     return;
   }
 

--- a/src/app/labeling/qgsmaptoolshowhidelabels.cpp
+++ b/src/app/labeling/qgsmaptoolshowhidelabels.cpp
@@ -284,10 +284,9 @@ bool QgsMapToolShowHideLabels::selectedLabelFeatures( QgsVectorLayer *vlayer,
   listPos.clear();
 
   // get list of all drawn labels from current layer that intersect rubberband
-  const QgsLabelingResults *labelingResults = mCanvas->labelingResults();
+  const QgsLabelingResults *labelingResults = mCanvas->labelingResults( false );
   if ( !labelingResults )
   {
-    QgsDebugMsg( QStringLiteral( "No labeling engine" ) );
     return false;
   }
 

--- a/src/core/qgsauxiliarystorage.h
+++ b/src/core/qgsauxiliarystorage.h
@@ -26,6 +26,7 @@
 #include "qgsproperty.h"
 #include "qgsspatialiteutils.h"
 #include "qgsvectorlayer.h"
+#include "qgscallout.h"
 #include <QString>
 
 class QgsProject;
@@ -217,6 +218,18 @@ class CORE_EXPORT QgsAuxiliaryLayer : public QgsVectorLayer
      * \returns The index of the auxiliary field or -1
      */
     static int createProperty( QgsDiagramLayerSettings::Property property, QgsVectorLayer *vlayer );
+
+    /**
+     * Creates if necessary a new auxiliary field for a callout's property and
+     * activates this property in settings.
+     *
+     * \param property The property to create
+     * \param vlayer The vector layer
+     *
+     * \returns The index of the auxiliary field or -1
+     * \since QGIS 3.20
+     */
+    static int createProperty( QgsCallout::Property property, QgsVectorLayer *vlayer );
 
     /**
      * Creates a new auxiliary field from a property definition.

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -469,8 +469,11 @@ void QgsMapCanvas::setMapSettingsFlags( QgsMapSettings::Flags flags )
   refresh();
 }
 
-const QgsLabelingResults *QgsMapCanvas::labelingResults() const
+const QgsLabelingResults *QgsMapCanvas::labelingResults( bool allowOutdatedResults ) const
 {
+  if ( !allowOutdatedResults && mLabelingResultsOutdated )
+    return nullptr;
+
   return mLabelingResults.get();
 }
 
@@ -567,6 +570,8 @@ void QgsMapCanvas::refresh()
 
   // schedule a refresh
   mRefreshTimer->start( 1 );
+
+  mLabelingResultsOutdated = true;
 }
 
 void QgsMapCanvas::refreshMap()
@@ -692,6 +697,7 @@ void QgsMapCanvas::rendererJobFinished()
     {
       mLabelingResults.reset( mJob->takeLabelingResults() );
     }
+    mLabelingResultsOutdated = false;
 
     QImage img = mJob->renderedImage();
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -161,10 +161,14 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     void setMapSettingsFlags( QgsMapSettings::Flags flags );
 
     /**
-     * Gets access to the labeling results (may be NULLPTR)
+     * Gets access to the labeling results (may be NULLPTR).
+     *
+     * Since QGIS 3.20, if the \a allowOutdatedResults flag is FALSE then outdated labeling results (e.g.
+     * as a result of an ongoing canvas render) will not be returned, and instead NULLPTR will be returned.
+     *
      * \since QGIS 2.4
      */
-    const QgsLabelingResults *labelingResults() const;
+    const QgsLabelingResults *labelingResults( bool allowOutdatedResults = true ) const;
 
     /**
      * Set whether to cache images of rendered layers
@@ -1254,6 +1258,9 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     //! Labeling results from the recently rendered map
     std::unique_ptr< QgsLabelingResults > mLabelingResults;
+
+    //! TRUE if the labeling results stored in mLabelingResults are outdated (e.g. as a result of an ongoing canvas render)
+    bool mLabelingResultsOutdated = false;
 
     //! Whether layers are rendered sequentially or in parallel
     bool mUseParallelRendering = false;


### PR DESCRIPTION
Makes the user experience for moving a callout follow the exact same behavior as that of moving a label, where aux fields are
immediately created for users whenever required instead of forcing them to create them themselves in advance.