### PR TITLE
Allow loading GPKG layers with GEOMETRY type

### DIFF
--- a/python/plugins/db_manager/db_plugins/gpkg/plugin.py
+++ b/python/plugins/db_manager/db_plugins/gpkg/plugin.py
@@ -209,11 +209,20 @@ class GPKGTable(Table):
         # QGIS has no provider to load Geopackage vectors, let's use OGR
         return u"vector:ogr:%s:%s" % (self.name, self.ogrUri())
 
-    def toMapLayer(self):
+    def toMapLayer(self, geometryType=None, crs=None):
         from qgis.core import QgsVectorLayer
 
         provider = "ogr"
         uri = self.ogrUri()
+
+        if geometryType:
+            geom_mapping = {
+                'POINT': 'Point',
+                'LINESTRING': 'LineString',
+                'POLYGON': 'Polygon',
+            }
+            geometryType = geom_mapping[geometryType]
+            uri = "{}|geometrytype={}".format(uri, geometryType)
 
         return QgsVectorLayer(uri, self.name, provider)
 


### PR DESCRIPTION
## Description
Currently trying to add a GPKG which has a layer with a GEOMETRY type results in QGIS giving an error due to an out of date signature of `toMapLayer` in https://github.com/qgis/QGIS/blob/master/python/plugins/db_manager/db_plugins/gpkg/plugin.py#L212 
vs the newer signature of the superclass
https://github.com/qgis/QGIS/blob/master/python/plugins/db_manager/db_plugins/plugin.py#L765

this PR allows loading GPKG layers as POINT, LINESTRING or POLYGON.
![image](https://user-images.githubusercontent.com/233663/111213180-c9c8bd80-85d0-11eb-92ae-5561c00a3864.png)
 The *ZM counterparts are still not working. I've already coded the support but it seems that `demo.gpkg|layername=test|geometrytype=PointZM` is not a valid string.

For reference here my code I used to try loading Z and M values:

```
uri = "/home/marco/Downloads/test.gpkg|layername=demo"

geometryType = 'POINTZM'

m, z = '', ''
if geometryType[-1] == 'M':
    m = 'M'
    geometryType = geometryType[:-1]
if geometryType[-1] == 'Z':
    z = 'Z'
    geometryType = geometryType[:-1]
suffix = '{}{}'.format(z, m)

geom_mapping = {
    'POINT': 'Point',
    'LINESTRING': 'LineString',
    'POLYGON': 'Polygon',
    }
geometryType = '{}{}'.format(geom_mapping[geometryType], suffix)

uri = "{}|geometrytype={}".format(uri, geometryType)
print (uri)

l = QgsVectorLayer(uri, 'berna', 'ogr')
QgsProject.instance().addMapLayer(l)
```

