### PR TITLE
Restore attribute table column sizes in the Merge Attributes dialog

### DIFF
--- a/src/app/qgsmergeattributesdialog.h
+++ b/src/app/qgsmergeattributesdialog.h
@@ -29,6 +29,7 @@ class QgsMapCanvas;
 class QgsRubberBand;
 class QgsVectorLayer;
 class QComboBox;
+class QgsAttributeTableConfig;
 
 
 //! A dialog to insert the merge behavior for attributes (e.g. for the union features editing tool)
@@ -72,6 +73,8 @@ class APP_EXPORT QgsMergeAttributesDialog: public QDialog, private Ui::QgsMergeA
   private:
     QgsMergeAttributesDialog(); //default constructor forbidden
     void createTableWidgetContents();
+    void setAttributeTableConfig( const QgsAttributeTableConfig &config );
+
     //! Create new combo box with the options for featureXX / mean / min / max
     QComboBox *createMergeComboBox( QVariant::Type columnType ) const;
 
@@ -106,6 +109,7 @@ class APP_EXPORT QgsMergeAttributesDialog: public QDialog, private Ui::QgsMergeA
 
     QgsFields mFields;
     QSet<int> mHiddenAttributes;
+    QMap< QString, int > mFieldToColumnMap;
     bool mUpdating = false;
 
     static const QList< QgsStatisticalSummary::Statistic > DISPLAY_STATS;


### PR DESCRIPTION
Otherwise the columns all get set to a minimal default width,
which quickly gets very frustrating if you're merging a lot of
features and have to keep manually resizing columns to see cell content...
