### PR TITLE
When an algorithm is run in place through the 'ef' locator auto remove the progress bar on completion

### DIFF
--- a/python/plugins/processing/gui/AlgorithmLocatorFilter.py
+++ b/python/plugins/processing/gui/AlgorithmLocatorFilter.py
@@ -227,3 +227,4 @@ class InPlaceAlgorithmLocatorFilter(QgsLocatorFilter):
                 feedback = MessageBarProgress(algname=alg.displayName())
                 parameters = {}
                 execute_in_place(alg, parameters, feedback=feedback)
+                feedback.close()


### PR DESCRIPTION
When an algorithm is run in place through the 'ef' locator filter, ensure the progress bar is removed when the algorithm
finishes

Otherwise it hangs around in the message bar until it's manually dismissed, unlike the behavior when you run an in-place operation through the toolbox.
