### PR TITLE
Fix misleading "cancel" label shown for "close" button

### DIFF
--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -83,8 +83,6 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
             self.buttonBox().button(QDialogButtonBox.Ok).setText(
                 QCoreApplication.translate("AlgorithmDialog", "Modify Selected Features")
                 if has_selection else QCoreApplication.translate("AlgorithmDialog", "Modify All Features"))
-            self.buttonBox().button(QDialogButtonBox.Close).setText(
-                QCoreApplication.translate("AlgorithmDialog", "Cancel"))
             self.setWindowTitle(self.windowTitle() + ' | ' + self.active_layer.name())
 
         self.updateRunButtonVisibility()


### PR DESCRIPTION
This button isn't a cancel button - it just closes the dialog, and
doesn't abort any changes which have already been made as a result
of running the algorithm through the dialog.
