### PR TITLE
Fix UI hang when selecting vertices from complex features when releasing the mouse button after a drag operation

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -601,9 +601,10 @@ void QgsVertexTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
 
         bool isFeatureSelected = vlayer->selectedFeatureIds().contains( f.id() );
         QgsGeometry g = f.geometry();
-        for ( int i = 0; i < g.constGet()->nCoordinates(); ++i )
+        int i = 0;
+        for ( auto it = g.constGet()->vertices_begin(); it != g.constGet()->vertices_end(); ++it )
         {
-          QgsPoint pt = g.vertexAt( i );
+          QgsPoint pt = *it;
           if ( layerRubberBandEngine->contains( &pt ) )
           {
             // we don't want to select invisible features,
@@ -618,6 +619,7 @@ void QgsVertexTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
             if ( isFeatureSelected )
               selectedVertices << Vertex( vlayer, f.id(), i );
           }
+          i++;
         }
       }
       if ( r )


### PR DESCRIPTION
For large geometries the total vertex count was being calculated once per vertex, resulting in a lot of unnecessary extra work
