### PR TITLE
Fix QgsAbstractRelationEditorWidget inconsistency NmRelation / NmRelationId

### DIFF
--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -64,6 +64,13 @@ Returns the relation
 .. versionadded:: 3.18
 %End
 
+    QgsRelation nmRelation() const;
+%Docstring
+Returns the nm relation
+
+.. versionadded:: 3.18
+%End
+
     void setFeature( const QgsFeature &feature, bool update = true );
 %Docstring
 Sets the ``feature`` being edited and updates the UI unless ``update`` is set to ``False``

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -268,8 +268,6 @@ void QgsRelationWidgetWrapper::setNmRelationId( const QVariant &nmRelationId )
 {
   if ( mWidget )
   {
-    mWidget->setNmRelationId( nmRelationId );
-
     mNmRelation = QgsProject::instance()->relationManager()->relation( nmRelationId.toString() );
 
     // If this widget is already embedded by the same relation, reduce functionality

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -120,6 +120,8 @@ void QgsAbstractRelationEditorWidget::setNmRelationId( const QVariant &nmRelatio
   QgsRelation nmrelation = QgsProject::instance()->relationManager()->relation( nmRelationId.toString() );
   beforeSetRelations( mRelation, nmrelation );
   mNmRelation = nmrelation;
+  afterSetRelations();
+  updateUi();
 }
 
 QVariant QgsAbstractRelationEditorWidget::nmRelationId() const

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -22,6 +22,7 @@
 #include "qgsfeature.h"
 #include "qgsfeatureselectiondlg.h"
 #include "qgsrelation.h"
+#include "qgsrelationmanager.h"
 #include "qgspolymorphicrelation.h"
 #include "qgsvectorlayertools.h"
 #include "qgsproject.h"
@@ -116,12 +117,14 @@ void QgsAbstractRelationEditorWidget::setFeature( const QgsFeature &feature, boo
 
 void QgsAbstractRelationEditorWidget::setNmRelationId( const QVariant &nmRelationId )
 {
-  mNmRelationId = nmRelationId;
+  QgsRelation nmrelation = QgsProject::instance()->relationManager()->relation( nmRelationId.toString() );
+  beforeSetRelations( mRelation, nmrelation );
+  mNmRelation = nmrelation;
 }
 
 QVariant QgsAbstractRelationEditorWidget::nmRelationId() const
 {
-  return mNmRelationId;
+  return mNmRelation.id();
 }
 
 QString QgsAbstractRelationEditorWidget::label() const

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -87,6 +87,12 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
     QgsRelation relation() const {return mRelation;}
 
     /**
+     * Returns the nm relation
+     * \since QGIS 3.18
+     */
+    QgsRelation nmRelation() const {return mNmRelation;}
+
+    /**
      * Sets the \a feature being edited and updates the UI unless \a update is set to FALSE
      */
     void setFeature( const QgsFeature &feature, bool update = true );
@@ -226,7 +232,6 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
     bool mLayerInSameTransactionGroup = false;
 
     bool mForceSuppressFormPopup = false;
-    QVariant mNmRelationId;
     QString mLabel;
 
     /**


### PR DESCRIPTION
QgsAbstractRelationEditorWidget members mNmRelation and mNmRelationId represent the same QgsRelation instance but it was possible to set them to different values which lead to inconsistency.
Also added method nmRelation() to access the nmRelation directly.