### PR TITLE
Switch 3D render policy from "Always" to "On Demand"

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -91,9 +91,10 @@ Qgs3DMapScene::Qgs3DMapScene( const Qgs3DMapSettings &map, QgsAbstract3DEngine *
   connect( &map, &Qgs3DMapSettings::backgroundColorChanged, this, &Qgs3DMapScene::onBackgroundColorChanged );
   onBackgroundColorChanged();
 
-  // TODO: strange - setting OnDemand render policy still keeps QGIS busy (Qt 5.9.0)
-  // actually it is more busy than with the default "Always" policy although there are no changes in the scene.
-  //mRenderer->renderSettings()->setRenderPolicy( Qt3DRender::QRenderSettings::OnDemand );
+  // The default render policy in Qt3D is "Always" - i.e. the 3D map scene gets refreshed up to 60 fps
+  // even if there's no change. Switching to "on demand" should only re-render when something has changed
+  // and we save quite a lot of resources
+  mEngine->renderSettings()->setRenderPolicy( Qt3DRender::QRenderSettings::OnDemand );
 
   // we want precise picking of terrain (also bounding volume picking does not seem to work - not sure why)
   mEngine->renderSettings()->pickingSettings()->setPickMethod( Qt3DRender::QPickingSettings::TrianglePicking );

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -38,11 +38,15 @@
 #include "qgspolygon3dsymbol.h"
 
 #include <Qt3DExtras/QPhongMaterial>
+#include <Qt3DRender/QRenderSettings>
 
 QImage Qgs3DUtils::captureSceneImage( QgsAbstract3DEngine &engine, Qgs3DMapScene *scene )
 {
   QImage resImage;
   QEventLoop evLoop;
+
+  // We need to change render policy to RenderPolicy::Always, since otherwise render capture node won't work
+  engine.renderSettings()->setRenderPolicy( Qt3DRender::QRenderSettings::RenderPolicy::Always );
 
   auto requestImageFcn = [&engine, scene]
   {
@@ -77,6 +81,7 @@ QImage Qgs3DUtils::captureSceneImage( QgsAbstract3DEngine &engine, Qgs3DMapScene
   if ( conn2 )
     QObject::disconnect( conn2 );
 
+  engine.renderSettings()->setRenderPolicy( Qt3DRender::QRenderSettings::RenderPolicy::OnDemand );
   return resImage;
 }
 
@@ -94,6 +99,8 @@ bool Qgs3DUtils::exportAnimation( const Qgs3DAnimationSettings &animationSetting
   engine.setSize( outputSize );
   Qgs3DMapScene *scene = new Qgs3DMapScene( mapSettings, &engine );
   engine.setRootEntity( scene );
+  // We need to change render policy to RenderPolicy::Always, since otherwise render capture node won't work
+  engine.renderSettings()->setRenderPolicy( Qt3DRender::QRenderSettings::RenderPolicy::Always );
 
   if ( animationSettings.keyFrames().size() < 2 )
   {

--- a/src/3d/qgsabstract3dengine.cpp
+++ b/src/3d/qgsabstract3dengine.cpp
@@ -18,6 +18,7 @@
 #include "qgsshadowrenderingframegraph.h"
 
 #include <Qt3DRender/QRenderCapture>
+#include <Qt3DRender/QRenderSettings>
 
 QgsAbstract3DEngine::QgsAbstract3DEngine( QObject *parent )
   : QObject( parent )
@@ -29,9 +30,12 @@ void QgsAbstract3DEngine::requestCaptureImage()
 {
   Qt3DRender::QRenderCaptureReply *captureReply;
   captureReply = mFrameGraph->renderCapture()->requestCapture();
+  // We need to change render policy to RenderPolicy::Always, since otherwise render capture node won't work
+  this->renderSettings()->setRenderPolicy( Qt3DRender::QRenderSettings::RenderPolicy::Always );
   connect( captureReply, &Qt3DRender::QRenderCaptureReply::completed, this, [ = ]
   {
     emit imageCaptured( captureReply->image() );
+    this->renderSettings()->setRenderPolicy( Qt3DRender::QRenderSettings::RenderPolicy::OnDemand );
     captureReply->deleteLater();
   } );
 }


### PR DESCRIPTION
Fixes #25390

The on demand policy lowers the load quite significantly (top on my laptop show the %cpu went from ~300% to ~50% when the 3D scene is idle).

Previously when I tried to enable the on demand policy in Qt 5.9.0, things were not getting any better, but it seems things got fixed later in Qt 5.9.5: https://bugreports.qt.io/browse/QTBUG-55109

I have not found any negative effects in my testing - but we should do some more extensive tests before backporting to 3.18 and 3.16.