### PR TITLE
Ellipse marker symbol layer fixes and code improvements

### DIFF
--- a/python/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
@@ -51,7 +51,7 @@ Creates the symbol layer
     void setSymbolName( const QString &name );
     QString symbolName() const;
 
-    bool shapeIsFilled( const QString &symbolName ) const;
+    static bool shapeIsFilled( const QString &symbolName );
 %Docstring
 Returns ``True`` if a shape has a fill.
 

--- a/python/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
@@ -19,6 +19,35 @@ A symbol layer for rendering objects with major and minor axis (e.g. ellipse, re
 #include "qgsellipsesymbollayer.h"
 %End
   public:
+
+    enum Shape
+    {
+      Circle,
+      Rectangle,
+      Diamond,
+      Cross,
+      Arrow,
+      HalfArc,
+      Triangle,
+      RightHalfTriangle,
+      LeftHalfTriangle,
+      SemiCircle,
+    };
+
+    static QList< QgsEllipseSymbolLayer::Shape > availableShapes();
+%Docstring
+Returns a list of all available shape types.
+%End
+
+    static bool shapeIsFilled( const QgsEllipseSymbolLayer::Shape &shape );
+%Docstring
+Returns ``True`` if a ``shape`` has a fill.
+
+:return: ``True`` if shape uses a fill, or ``False`` if shape uses lines only
+
+.. versionadded:: 3.20
+%End
+
     QgsEllipseSymbolLayer();
 
     static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
@@ -48,16 +77,72 @@ Creates the symbol layer
     virtual bool writeDxf( QgsDxfExport &e, double mmMapUnitScaleFactor, const QString &layerName, QgsSymbolRenderContext &context, QPointF shift = QPointF( 0.0, 0.0 ) ) const;
 
 
-    void setSymbolName( const QString &name );
-    QString symbolName() const;
-
-    static bool shapeIsFilled( const QString &symbolName );
+ void setSymbolName( const QString &name ) /Deprecated/;
 %Docstring
-Returns ``True`` if a shape has a fill.
+Sets the rendered ellipse marker shape using a symbol ``name``.
 
-:param symbolName: name of shape to test
+.. seealso:: :py:func:`setShape`
 
-:return: ``True`` if shape uses a fill, or ``False`` if shape uses lines only
+.. seealso:: :py:func:`shape`
+
+.. deprecated:: QGIS 3.20
+%End
+
+ QString symbolName() const /Deprecated/;
+%Docstring
+Returns the shape name for the rendered ellipse marker symbol.
+
+.. seealso:: :py:func:`shape`
+
+.. seealso:: :py:func:`setShape`
+
+.. deprecated:: QGIS 3.20
+%End
+
+    QgsEllipseSymbolLayer::Shape shape() const;
+%Docstring
+Returns the shape for the rendered ellipse marker symbol.
+
+.. seealso:: :py:func:`setShape`
+
+.. versionadded:: 3.20
+%End
+
+    void setShape( QgsEllipseSymbolLayer::Shape shape );
+%Docstring
+Sets the rendered ellipse marker shape.
+
+:param shape: new ellipse marker shape
+
+.. seealso:: :py:func:`shape`
+
+.. versionadded:: 3.20
+%End
+
+    static QgsEllipseSymbolLayer::Shape decodeShape( const QString &name, bool *ok = 0 );
+%Docstring
+Attempts to decode a string representation of a shape name to the corresponding
+shape.
+
+:param name: encoded shape name
+:param ok: if specified, will be set to ``True`` if shape was successfully decoded
+
+:return: decoded name
+
+.. seealso:: :py:func:`encodeShape`
+
+.. versionadded:: 3.20
+%End
+
+    static QString encodeShape( QgsEllipseSymbolLayer::Shape shape );
+%Docstring
+Encodes a shape to its string representation.
+
+:param shape: shape to encode
+
+:return: encoded string
+
+.. seealso:: :py:func:`decodeShape`
 
 .. versionadded:: 3.20
 %End

--- a/src/core/symbology/qgsellipsesymbollayer.cpp
+++ b/src/core/symbology/qgsellipsesymbollayer.cpp
@@ -669,7 +669,7 @@ void QgsEllipseSymbolLayer::preparePath( const QString &symbolName, QgsSymbolRen
   }
 }
 
-bool QgsEllipseSymbolLayer::shapeIsFilled( const QString &symbolName ) const
+bool QgsEllipseSymbolLayer::shapeIsFilled( const QString &symbolName )
 {
   return symbolName == QLatin1String( "cross" ) || symbolName == QLatin1String( "arrow" ) || symbolName == QLatin1String( "half_arc" ) ? false : true;
 }

--- a/src/core/symbology/qgsellipsesymbollayer.cpp
+++ b/src/core/symbology/qgsellipsesymbollayer.cpp
@@ -29,8 +29,7 @@
 #include <QDomElement>
 
 QgsEllipseSymbolLayer::QgsEllipseSymbolLayer()
-  : mSymbolName( QStringLiteral( "circle" ) )
-  , mStrokeColor( QColor( 35, 35, 35 ) )
+  : mStrokeColor( QColor( 35, 35, 35 ) )
 {
   mColor = Qt::white;
   mPen.setColor( mStrokeColor );
@@ -48,7 +47,7 @@ QgsSymbolLayer *QgsEllipseSymbolLayer::create( const QVariantMap &properties )
   QgsEllipseSymbolLayer *layer = new QgsEllipseSymbolLayer();
   if ( properties.contains( QStringLiteral( "symbol_name" ) ) )
   {
-    layer->setSymbolName( properties[ QStringLiteral( "symbol_name" )].toString() );
+    layer->setShape( decodeShape( properties[ QStringLiteral( "symbol_name" )].toString() ) );
   }
   if ( properties.contains( QStringLiteral( "size" ) ) )
   {
@@ -249,16 +248,16 @@ void QgsEllipseSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContext &
     mPen.setColor( penColor );
   }
 
+  QgsEllipseSymbolLayer::Shape shape = mShape;
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::PropertyWidth ) || mDataDefinedProperties.isActive( QgsSymbolLayer::PropertyHeight ) || mDataDefinedProperties.isActive( QgsSymbolLayer::PropertyName ) )
   {
-    QString symbolName = mSymbolName;
-    context.setOriginalValueVariable( mSymbolName );
+    context.setOriginalValueVariable( encodeShape( shape ) );
     QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyName, context.renderContext().expressionContext() );
     if ( exprVal.isValid() )
     {
-      symbolName = exprVal.toString();
+      shape = decodeShape( exprVal.toString() );
     }
-    preparePath( symbolName, context, &scaledWidth, &scaledHeight, context.feature() );
+    preparePath( shape, context, &scaledWidth, &scaledHeight, context.feature() );
   }
 
   //offset and rotation
@@ -280,7 +279,7 @@ void QgsEllipseSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContext &
     transform.rotate( angle );
   }
 
-  if ( shapeIsFilled( mSymbolName ) )
+  if ( shapeIsFilled( shape ) )
   {
     p->setPen( context.selected() ? mSelPen : mPen );
     p->setBrush( context.selected() ? mSelBrush : mBrush );
@@ -351,7 +350,7 @@ void QgsEllipseSymbolLayer::startRender( QgsSymbolRenderContext &context )
   QgsMarkerSymbolLayer::startRender( context ); // get anchor point expressions
   if ( !context.feature() || !dataDefinedProperties().hasActiveProperties() )
   {
-    preparePath( mSymbolName, context );
+    preparePath( mShape, context );
   }
   mPen.setColor( mStrokeColor );
   mPen.setStyle( mStrokeStyle );
@@ -368,7 +367,7 @@ void QgsEllipseSymbolLayer::startRender( QgsSymbolRenderContext &context )
     selPenColor.setAlphaF( context.opacity() );
   }
   mSelBrush = QBrush( selBrushColor );
-  mSelPen = QPen( !shapeIsFilled( mSymbolName ) ? selBrushColor : selPenColor );
+  mSelPen = QPen( !shapeIsFilled( mShape ) ? selBrushColor : selPenColor );
   mSelPen.setStyle( mStrokeStyle );
   mSelPen.setWidthF( context.renderContext().convertToPainterUnits( mStrokeWidth, mStrokeWidthUnit, mStrokeWidthMapUnitScale ) );
 }
@@ -380,7 +379,7 @@ void QgsEllipseSymbolLayer::stopRender( QgsSymbolRenderContext & )
 QgsEllipseSymbolLayer *QgsEllipseSymbolLayer::clone() const
 {
   QgsEllipseSymbolLayer *m = new QgsEllipseSymbolLayer();
-  m->setSymbolName( mSymbolName );
+  m->setShape( mShape );
   m->setSymbolWidth( mSymbolWidth );
   m->setSymbolHeight( mSymbolHeight );
   m->setStrokeStyle( mStrokeStyle );
@@ -429,7 +428,7 @@ void QgsEllipseSymbolLayer::writeSldMarker( QDomDocument &doc, QDomElement &elem
 
   double strokeWidth = QgsSymbolLayerUtils::rescaleUom( mStrokeWidth, mStrokeWidthUnit, props );
   double symbolWidth = QgsSymbolLayerUtils::rescaleUom( mSymbolWidth, mSymbolWidthUnit, props );
-  QgsSymbolLayerUtils::wellKnownMarkerToSld( doc, graphicElem, mSymbolName, mColor, mStrokeColor, mStrokeStyle, strokeWidth, symbolWidth );
+  QgsSymbolLayerUtils::wellKnownMarkerToSld( doc, graphicElem, encodeShape( mShape ), mColor, mStrokeColor, mStrokeStyle, strokeWidth, symbolWidth );
 
   // <Rotation>
   QgsProperty ddRotation = mDataDefinedProperties.property( QgsSymbolLayer::PropertyAngle );
@@ -523,7 +522,7 @@ QgsSymbolLayer *QgsEllipseSymbolLayer::createFromSld( QDomElement &element )
 
   QgsEllipseSymbolLayer *m = new QgsEllipseSymbolLayer();
   m->setOutputUnit( QgsUnitTypes::RenderUnit::RenderPixels );
-  m->setSymbolName( name );
+  m->setShape( decodeShape( name ) );
   m->setFillColor( fillColor );
   m->setStrokeColor( strokeColor );
   m->setStrokeStyle( strokeStyle );
@@ -537,7 +536,7 @@ QgsSymbolLayer *QgsEllipseSymbolLayer::createFromSld( QDomElement &element )
 QVariantMap QgsEllipseSymbolLayer::properties() const
 {
   QVariantMap map;
-  map[QStringLiteral( "symbol_name" )] = mSymbolName;
+  map[QStringLiteral( "symbol_name" )] = encodeShape( mShape );
   map[QStringLiteral( "symbol_width" )] = QString::number( mSymbolWidth );
   map[QStringLiteral( "symbol_width_unit" )] = QgsUnitTypes::encodeUnit( mSymbolWidthUnit );
   map[QStringLiteral( "symbol_width_map_unit_scale" )] = QgsSymbolLayerUtils::encodeMapUnitScale( mSymbolWidthMapUnitScale );
@@ -601,77 +600,96 @@ QSizeF QgsEllipseSymbolLayer::calculateSize( QgsSymbolRenderContext &context, do
   return QSizeF( width, height );
 }
 
-void QgsEllipseSymbolLayer::preparePath( const QString &symbolName, QgsSymbolRenderContext &context, double *scaledWidth, double *scaledHeight, const QgsFeature * )
+void QgsEllipseSymbolLayer::preparePath( const QgsEllipseSymbolLayer::Shape &shape, QgsSymbolRenderContext &context, double *scaledWidth, double *scaledHeight, const QgsFeature * )
 {
   mPainterPath = QPainterPath();
 
   QSizeF size = calculateSize( context, scaledWidth, scaledHeight );
 
-  if ( symbolName == QLatin1String( "circle" ) )
+  switch ( shape )
   {
-    mPainterPath.addEllipse( QRectF( -size.width() / 2.0, -size.height() / 2.0, size.width(), size.height() ) );
-  }
-  else if ( symbolName == QLatin1String( "semi_circle" ) )
-  {
-    mPainterPath.arcTo( -size.width() / 2.0, -size.height() / 2.0, size.width(), size.height(), 0, 180 );
-    mPainterPath.lineTo( 0, 0 );
-  }
-  else if ( symbolName == QLatin1String( "rectangle" ) )
-  {
-    mPainterPath.addRect( QRectF( -size.width() / 2.0, -size.height() / 2.0, size.width(), size.height() ) );
-  }
-  else if ( symbolName == QLatin1String( "diamond" ) )
-  {
-    mPainterPath.moveTo( -size.width() / 2.0, 0 );
-    mPainterPath.lineTo( 0, size.height() / 2.0 );
-    mPainterPath.lineTo( size.width() / 2.0, 0 );
-    mPainterPath.lineTo( 0, -size.height() / 2.0 );
-    mPainterPath.lineTo( -size.width() / 2.0, 0 );
-  }
-  else if ( symbolName == QLatin1String( "cross" ) )
-  {
-    mPainterPath.moveTo( 0, -size.height() / 2.0 );
-    mPainterPath.lineTo( 0, size.height() / 2.0 );
-    mPainterPath.moveTo( -size.width() / 2.0, 0 );
-    mPainterPath.lineTo( size.width() / 2.0, 0 );
-  }
-  else if ( symbolName == QLatin1String( "arrow" ) )
-  {
-    mPainterPath.moveTo( -size.width() / 2.0, size.height() / 2.0 );
-    mPainterPath.lineTo( 0, -size.height() / 2.0 );
-    mPainterPath.lineTo( size.width() / 2.0, size.height() / 2.0 );
-  }
-  else if ( symbolName == QLatin1String( "half_arc" ) )
-  {
-    mPainterPath.moveTo( size.width() / 2.0, 0 );
-    mPainterPath.arcTo( -size.width() / 2.0, -size.height() / 2.0, size.width(), size.height(), 0, 180 );
-  }
-  else if ( symbolName == QLatin1String( "triangle" ) )
-  {
-    mPainterPath.moveTo( 0, -size.height() / 2.0 );
-    mPainterPath.lineTo( -size.width() / 2.0, size.height() / 2.0 );
-    mPainterPath.lineTo( size.width() / 2.0, size.height() / 2.0 );
-    mPainterPath.lineTo( 0, -size.height() / 2.0 );
-  }
-  else if ( symbolName == QLatin1String( "left_half_triangle" ) )
-  {
-    mPainterPath.moveTo( 0, size.height() / 2.0 );
-    mPainterPath.lineTo( size.width() / 2.0, size.height() / 2.0 );
-    mPainterPath.lineTo( 0, -size.height() / 2.0 );
-    mPainterPath.lineTo( 0, size.height() / 2.0 );
-  }
-  else if ( symbolName == QLatin1String( "right_half_triangle" ) )
-  {
-    mPainterPath.moveTo( -size.width() / 2.0, size.height() / 2.0 );
-    mPainterPath.lineTo( 0, size.height() / 2.0 );
-    mPainterPath.lineTo( 0, -size.height() / 2.0 );
-    mPainterPath.lineTo( -size.width() / 2.0, size.height() / 2.0 );
+    case Circle:
+      mPainterPath.addEllipse( QRectF( -size.width() / 2.0, -size.height() / 2.0, size.width(), size.height() ) );
+      return;
+
+    case SemiCircle:
+      mPainterPath.arcTo( -size.width() / 2.0, -size.height() / 2.0, size.width(), size.height(), 0, 180 );
+      mPainterPath.lineTo( 0, 0 );
+      return;
+
+    case Rectangle:
+      mPainterPath.addRect( QRectF( -size.width() / 2.0, -size.height() / 2.0, size.width(), size.height() ) );
+      return;
+
+    case Diamond:
+      mPainterPath.moveTo( -size.width() / 2.0, 0 );
+      mPainterPath.lineTo( 0, size.height() / 2.0 );
+      mPainterPath.lineTo( size.width() / 2.0, 0 );
+      mPainterPath.lineTo( 0, -size.height() / 2.0 );
+      mPainterPath.lineTo( -size.width() / 2.0, 0 );
+      return;
+
+    case Cross:
+      mPainterPath.moveTo( 0, -size.height() / 2.0 );
+      mPainterPath.lineTo( 0, size.height() / 2.0 );
+      mPainterPath.moveTo( -size.width() / 2.0, 0 );
+      mPainterPath.lineTo( size.width() / 2.0, 0 );
+      return;
+
+    case Arrow:
+      mPainterPath.moveTo( -size.width() / 2.0, size.height() / 2.0 );
+      mPainterPath.lineTo( 0, -size.height() / 2.0 );
+      mPainterPath.lineTo( size.width() / 2.0, size.height() / 2.0 );
+      return;
+
+    case HalfArc:
+      mPainterPath.moveTo( size.width() / 2.0, 0 );
+      mPainterPath.arcTo( -size.width() / 2.0, -size.height() / 2.0, size.width(), size.height(), 0, 180 );
+      return;
+
+    case Triangle:
+      mPainterPath.moveTo( 0, -size.height() / 2.0 );
+      mPainterPath.lineTo( -size.width() / 2.0, size.height() / 2.0 );
+      mPainterPath.lineTo( size.width() / 2.0, size.height() / 2.0 );
+      mPainterPath.lineTo( 0, -size.height() / 2.0 );
+      return;
+
+    case LeftHalfTriangle:
+      mPainterPath.moveTo( 0, size.height() / 2.0 );
+      mPainterPath.lineTo( size.width() / 2.0, size.height() / 2.0 );
+      mPainterPath.lineTo( 0, -size.height() / 2.0 );
+      mPainterPath.lineTo( 0, size.height() / 2.0 );
+      return;
+
+    case RightHalfTriangle:
+      mPainterPath.moveTo( -size.width() / 2.0, size.height() / 2.0 );
+      mPainterPath.lineTo( 0, size.height() / 2.0 );
+      mPainterPath.lineTo( 0, -size.height() / 2.0 );
+      mPainterPath.lineTo( -size.width() / 2.0, size.height() / 2.0 );
+      return;
   }
 }
 
-bool QgsEllipseSymbolLayer::shapeIsFilled( const QString &symbolName )
+bool QgsEllipseSymbolLayer::shapeIsFilled( const QgsEllipseSymbolLayer::Shape &shape )
 {
-  return symbolName == QLatin1String( "cross" ) || symbolName == QLatin1String( "arrow" ) || symbolName == QLatin1String( "half_arc" ) ? false : true;
+  switch ( shape )
+  {
+    case Circle:
+    case Rectangle:
+    case Diamond:
+    case Triangle:
+    case RightHalfTriangle:
+    case LeftHalfTriangle:
+    case SemiCircle:
+      return true;
+
+    case Cross:
+    case Arrow:
+    case HalfArc:
+      return false;
+  }
+
+  return true;
 }
 
 void QgsEllipseSymbolLayer::setSize( double size )
@@ -865,11 +883,11 @@ bool QgsEllipseSymbolLayer::writeDxf( QgsDxfExport &e, double mmMapUnitScaleFact
   }
 
   //symbol name
-  QString symbolName = mSymbolName;
+  QgsEllipseSymbolLayer::Shape shape = mShape;
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::PropertyName ) )
   {
-    context.setOriginalValueVariable( mSymbolName );
-    symbolName = mDataDefinedProperties.valueAsString( QgsSymbolLayer::PropertyName, context.renderContext().expressionContext(), mSymbolName );
+    context.setOriginalValueVariable( encodeShape( shape ) );
+    shape = decodeShape( mDataDefinedProperties.valueAsString( QgsSymbolLayer::PropertyName, context.renderContext().expressionContext(), encodeShape( shape ) ) );
   }
 
   //offset
@@ -902,76 +920,168 @@ bool QgsEllipseSymbolLayer::writeDxf( QgsDxfExport &e, double mmMapUnitScaleFact
   double halfWidth = symbolWidth / 2.0;
   double halfHeight = symbolHeight / 2.0;
 
-  if ( symbolName == QLatin1String( "circle" ) )
+  switch ( shape )
   {
-    if ( qgsDoubleNear( halfWidth, halfHeight ) )
+    case Circle:
     {
-      QgsPoint pt( t.map( QPointF( 0, 0 ) ) );
-      e.writeFilledCircle( layerName, oc, pt, halfWidth );
-    }
-    else
-    {
-      QgsPointSequence line;
-
-      double stepsize = 2 * M_PI / 40;
-      for ( int i = 0; i < 39; ++i )
+      if ( qgsDoubleNear( halfWidth, halfHeight ) )
       {
-        double angle = stepsize * i;
-        double x = halfWidth * std::cos( angle );
-        double y = halfHeight * std::sin( angle );
-        line << QgsPoint( t.map( QPointF( x, y ) ) );
+        QgsPoint pt( t.map( QPointF( 0, 0 ) ) );
+        e.writeFilledCircle( layerName, oc, pt, halfWidth );
       }
-      //close ellipse with first point
-      line << line.at( 0 );
+      else
+      {
+        QgsPointSequence line;
+
+        double stepsize = 2 * M_PI / 40;
+        for ( int i = 0; i < 39; ++i )
+        {
+          double angle = stepsize * i;
+          double x = halfWidth * std::cos( angle );
+          double y = halfHeight * std::sin( angle );
+          line << QgsPoint( t.map( QPointF( x, y ) ) );
+        }
+        //close ellipse with first point
+        line << line.at( 0 );
+
+        if ( mBrush.style() != Qt::NoBrush )
+          e.writePolygon( QgsRingSequence() << line, layerName, QStringLiteral( "SOLID" ), fc );
+        if ( mPen.style() != Qt::NoPen )
+          e.writePolyline( line, layerName, QStringLiteral( "CONTINUOUS" ), oc, strokeWidth );
+      }
+      return true;
+    }
+
+    case Rectangle:
+    {
+      QgsPointSequence p;
+      p << QgsPoint( t.map( QPointF( -halfWidth, -halfHeight ) ) )
+        << QgsPoint( t.map( QPointF( halfWidth, -halfHeight ) ) )
+        << QgsPoint( t.map( QPointF( halfWidth, halfHeight ) ) )
+        << QgsPoint( t.map( QPointF( -halfWidth, halfHeight ) ) );
+      p << p[0];
 
       if ( mBrush.style() != Qt::NoBrush )
-        e.writePolygon( QgsRingSequence() << line, layerName, QStringLiteral( "SOLID" ), fc );
+        e.writePolygon( QgsRingSequence() << p, layerName, QStringLiteral( "SOLID" ), fc );
       if ( mPen.style() != Qt::NoPen )
-        e.writePolyline( line, layerName, QStringLiteral( "CONTINUOUS" ), oc, strokeWidth );
+        e.writePolyline( p, layerName, QStringLiteral( "CONTINUOUS" ), oc, strokeWidth );
+      return true;
     }
-  }
-  else if ( symbolName == QLatin1String( "rectangle" ) )
-  {
-    QgsPointSequence p;
-    p << QgsPoint( t.map( QPointF( -halfWidth, -halfHeight ) ) )
-      << QgsPoint( t.map( QPointF( halfWidth, -halfHeight ) ) )
-      << QgsPoint( t.map( QPointF( halfWidth, halfHeight ) ) )
-      << QgsPoint( t.map( QPointF( -halfWidth, halfHeight ) ) );
-    p << p[0];
+    case Cross:
+    {
+      if ( mPen.style() != Qt::NoPen )
+      {
+        e.writePolyline( QgsPointSequence()
+                         << QgsPoint( t.map( QPointF( -halfWidth, 0 ) ) )
+                         << QgsPoint( t.map( QPointF( halfWidth, 0 ) ) ),
+                         layerName, QStringLiteral( "CONTINUOUS" ), oc, strokeWidth );
+        e.writePolyline( QgsPointSequence()
+                         << QgsPoint( t.map( QPointF( 0, halfHeight ) ) )
+                         << QgsPoint( t.map( QPointF( 0, -halfHeight ) ) ),
+                         layerName, QStringLiteral( "CONTINUOUS" ), oc, strokeWidth );
+        return true;
+      }
+      break;
+    }
 
-    if ( mBrush.style() != Qt::NoBrush )
-      e.writePolygon( QgsRingSequence() << p, layerName, QStringLiteral( "SOLID" ), fc );
-    if ( mPen.style() != Qt::NoPen )
-      e.writePolyline( p, layerName, QStringLiteral( "CONTINUOUS" ), oc, strokeWidth );
-    return true;
-  }
-  else if ( symbolName == QLatin1String( "cross" ) && mPen.style() != Qt::NoPen )
-  {
-    e.writePolyline( QgsPointSequence()
-                     << QgsPoint( t.map( QPointF( -halfWidth, 0 ) ) )
-                     << QgsPoint( t.map( QPointF( halfWidth, 0 ) ) ),
-                     layerName, QStringLiteral( "CONTINUOUS" ), oc, strokeWidth );
-    e.writePolyline( QgsPointSequence()
-                     << QgsPoint( t.map( QPointF( 0, halfHeight ) ) )
-                     << QgsPoint( t.map( QPointF( 0, -halfHeight ) ) ),
-                     layerName, QStringLiteral( "CONTINUOUS" ), oc, strokeWidth );
-    return true;
-  }
-  else if ( symbolName == QLatin1String( "triangle" ) )
-  {
-    QgsPointSequence p;
-    p << QgsPoint( t.map( QPointF( -halfWidth, -halfHeight ) ) )
-      << QgsPoint( t.map( QPointF( halfWidth, -halfHeight ) ) )
-      << QgsPoint( t.map( QPointF( 0, halfHeight ) ) );
-    p << p[0];
-    if ( mBrush.style() != Qt::NoBrush )
-      e.writePolygon( QgsRingSequence() << p, layerName, QStringLiteral( "SOLID" ), fc );
-    if ( mPen.style() != Qt::NoPen )
-      e.writePolyline( p, layerName, QStringLiteral( "CONTINUOUS" ), oc, strokeWidth );
-    return true;
+    case Triangle:
+    {
+      QgsPointSequence p;
+      p << QgsPoint( t.map( QPointF( -halfWidth, -halfHeight ) ) )
+        << QgsPoint( t.map( QPointF( halfWidth, -halfHeight ) ) )
+        << QgsPoint( t.map( QPointF( 0, halfHeight ) ) );
+      p << p[0];
+      if ( mBrush.style() != Qt::NoBrush )
+        e.writePolygon( QgsRingSequence() << p, layerName, QStringLiteral( "SOLID" ), fc );
+      if ( mPen.style() != Qt::NoPen )
+        e.writePolyline( p, layerName, QStringLiteral( "CONTINUOUS" ), oc, strokeWidth );
+      return true;
+    }
+
+    case Diamond:
+    case Arrow:
+    case HalfArc:
+    case RightHalfTriangle:
+    case LeftHalfTriangle:
+    case SemiCircle:
+      return false;
   }
 
-  return false; //soon...
+  return false;
 }
 
+QgsEllipseSymbolLayer::Shape QgsEllipseSymbolLayer::decodeShape( const QString &name, bool *ok )
+{
+  if ( ok )
+    *ok = true;
+  QString cleaned = name.toLower().trimmed();
 
+  if ( cleaned == QLatin1String( "circle" ) )
+    return Circle;
+  else if ( cleaned == QLatin1String( "square" ) || cleaned == QLatin1String( "rectangle" ) )
+    return Rectangle;
+  else if ( cleaned == QLatin1String( "diamond" ) )
+    return Diamond;
+  else if ( cleaned == QLatin1String( "cross" ) )
+    return Cross;
+  else if ( cleaned == QLatin1String( "arrow" ) )
+    return Arrow;
+  else if ( cleaned == QLatin1String( "half_arc" ) )
+    return HalfArc;
+  else if ( cleaned == QLatin1String( "triangle" ) )
+    return Triangle;
+  else if ( cleaned == QLatin1String( "right_half_triangle" ) )
+    return RightHalfTriangle;
+  else if ( cleaned == QLatin1String( "left_half_triangle" ) )
+    return LeftHalfTriangle;
+  else if ( cleaned == QLatin1String( "semi_circle" ) )
+    return SemiCircle;
+
+  if ( ok )
+    *ok = false;
+  return Circle;
+}
+
+QString QgsEllipseSymbolLayer::encodeShape( QgsEllipseSymbolLayer::Shape shape )
+{
+  switch ( shape )
+  {
+    case Circle:
+      return QStringLiteral( "circle" );
+    case Rectangle:
+      return QStringLiteral( "rectangle" );
+    case Diamond:
+      return QStringLiteral( "diamond" );
+    case Cross:
+      return QStringLiteral( "cross" );
+    case Arrow:
+      return QStringLiteral( "arrow" );
+    case HalfArc:
+      return QStringLiteral( "half_arc" );
+    case Triangle:
+      return QStringLiteral( "triangle" );
+    case RightHalfTriangle:
+      return QStringLiteral( "right_half_triangle" );
+    case LeftHalfTriangle:
+      return QStringLiteral( "left_half_triangle" );
+    case SemiCircle:
+      return QStringLiteral( "semi_circle" );
+  }
+  return QString();
+}
+
+QList<QgsEllipseSymbolLayer::Shape> QgsEllipseSymbolLayer::availableShapes()
+{
+  QList< Shape > shapes;
+  shapes << Circle
+         << Rectangle
+         << Diamond
+         << Cross
+         << Arrow
+         << HalfArc
+         << Triangle
+         << LeftHalfTriangle
+         << RightHalfTriangle
+         << SemiCircle;
+  return shapes;
+}

--- a/src/core/symbology/qgsellipsesymbollayer.cpp
+++ b/src/core/symbology/qgsellipsesymbollayer.cpp
@@ -368,7 +368,7 @@ void QgsEllipseSymbolLayer::startRender( QgsSymbolRenderContext &context )
     selPenColor.setAlphaF( context.opacity() );
   }
   mSelBrush = QBrush( selBrushColor );
-  mSelPen = QPen( selPenColor );
+  mSelPen = QPen( !shapeIsFilled( mSymbolName ) ? selBrushColor : selPenColor );
   mSelPen.setStyle( mStrokeStyle );
   mSelPen.setWidthF( context.renderContext().convertToPainterUnits( mStrokeWidth, mStrokeWidthUnit, mStrokeWidthMapUnitScale ) );
 }

--- a/src/core/symbology/qgsellipsesymbollayer.h
+++ b/src/core/symbology/qgsellipsesymbollayer.h
@@ -58,7 +58,7 @@ class CORE_EXPORT QgsEllipseSymbolLayer: public QgsMarkerSymbolLayer
      * \returns TRUE if shape uses a fill, or FALSE if shape uses lines only
      * \since QGIS 3.20
      */
-    bool shapeIsFilled( const QString &symbolName ) const;
+    static bool shapeIsFilled( const QString &symbolName );
 
     void setSize( double size ) override;
 

--- a/src/core/symbology/qgsellipsesymbollayer.h
+++ b/src/core/symbology/qgsellipsesymbollayer.h
@@ -31,6 +31,32 @@ class QgsExpression;
 class CORE_EXPORT QgsEllipseSymbolLayer: public QgsMarkerSymbolLayer
 {
   public:
+
+    //! Marker symbol shapes
+    enum Shape
+    {
+      Circle, //!< Circle
+      Rectangle, //!< Rectangle
+      Diamond, //!< Diamond
+      Cross, //!< Stroke-only cross
+      Arrow, //!< Stroke-only arrow (since QGIS 3.20)
+      HalfArc, //!< Stroke-only half arc (since QGIS 3.20)
+      Triangle, //!< Triangle
+      RightHalfTriangle, //!< Right half of a triangle
+      LeftHalfTriangle, //!< Left half of a triangle
+      SemiCircle, //!< Semi circle
+    };
+
+    //! Returns a list of all available shape types.
+    static QList< QgsEllipseSymbolLayer::Shape > availableShapes();
+
+    /**
+     * Returns TRUE if a \a shape has a fill.
+     * \returns TRUE if shape uses a fill, or FALSE if shape uses lines only
+     * \since QGIS 3.20
+     */
+    static bool shapeIsFilled( const QgsEllipseSymbolLayer::Shape &shape );
+
     QgsEllipseSymbolLayer();
 
     //! Creates the symbol layer
@@ -49,16 +75,56 @@ class CORE_EXPORT QgsEllipseSymbolLayer: public QgsMarkerSymbolLayer
 
     bool writeDxf( QgsDxfExport &e, double mmMapUnitScaleFactor, const QString &layerName, QgsSymbolRenderContext &context, QPointF shift = QPointF( 0.0, 0.0 ) ) const override;
 
-    void setSymbolName( const QString &name ) { mSymbolName = name; }
-    QString symbolName() const { return mSymbolName; }
+    /**
+     * Sets the rendered ellipse marker shape using a symbol \a name.
+     * \see setShape()
+     * \see shape()
+     * \deprecated since QGIS 3.20
+     */
+    Q_DECL_DEPRECATED void setSymbolName( const QString &name ) SIP_DEPRECATED { mShape = decodeShape( name ); }
 
     /**
-     * Returns TRUE if a shape has a fill.
-     * \param symbolName name of shape to test
-     * \returns TRUE if shape uses a fill, or FALSE if shape uses lines only
+     * Returns the shape name for the rendered ellipse marker symbol.
+     * \see shape()
+     * \see setShape()
+     * \deprecated since QGIS 3.20
+     */
+    Q_DECL_DEPRECATED QString symbolName() const SIP_DEPRECATED { return encodeShape( mShape ); }
+
+    /**
+     * Returns the shape for the rendered ellipse marker symbol.
+     * \see setShape()
      * \since QGIS 3.20
      */
-    static bool shapeIsFilled( const QString &symbolName );
+    QgsEllipseSymbolLayer::Shape shape() const { return mShape; }
+
+    /**
+     * Sets the rendered ellipse marker shape.
+     * \param shape new ellipse marker shape
+     * \see shape()
+     * \since QGIS 3.20
+     */
+    void setShape( QgsEllipseSymbolLayer::Shape shape ) { mShape = shape; }
+
+    /**
+     * Attempts to decode a string representation of a shape name to the corresponding
+     * shape.
+     * \param name encoded shape name
+     * \param ok if specified, will be set to TRUE if shape was successfully decoded
+     * \returns decoded name
+     * \see encodeShape()
+     * \since QGIS 3.20
+     */
+    static QgsEllipseSymbolLayer::Shape decodeShape( const QString &name, bool *ok = nullptr );
+
+    /**
+     * Encodes a shape to its string representation.
+     * \param shape shape to encode
+     * \returns encoded string
+     * \see decodeShape()
+     * \since QGIS 3.20
+     */
+    static QString encodeShape( QgsEllipseSymbolLayer::Shape shape );
 
     void setSize( double size ) override;
 
@@ -174,7 +240,7 @@ class CORE_EXPORT QgsEllipseSymbolLayer: public QgsMarkerSymbolLayer
     QRectF bounds( QPointF point, QgsSymbolRenderContext &context ) override;
 
   private:
-    QString mSymbolName;
+    Shape mShape = Circle;
     double mSymbolWidth = 4;
     QgsUnitTypes::RenderUnit mSymbolWidthUnit = QgsUnitTypes::RenderMillimeters;
     QgsMapUnitScale mSymbolWidthMapUnitScale;
@@ -200,13 +266,13 @@ class CORE_EXPORT QgsEllipseSymbolLayer: public QgsMarkerSymbolLayer
 
     /**
      * Setup mPainterPath
-     * \param symbolName name of symbol
+     * \param shape name of symbol
      * \param context render context
      * \param scaledWidth optional width
      * \param scaledHeight optional height
      * \param f optional feature to render (0 if no data defined rendering)
      */
-    void preparePath( const QString &symbolName, QgsSymbolRenderContext &context, double *scaledWidth = nullptr, double *scaledHeight = nullptr, const QgsFeature *f = nullptr );
+    void preparePath( const QgsEllipseSymbolLayer::Shape &shape, QgsSymbolRenderContext &context, double *scaledWidth = nullptr, double *scaledHeight = nullptr, const QgsFeature *f = nullptr );
     QSizeF calculateSize( QgsSymbolRenderContext &context, double *scaledWidth = nullptr, double *scaledHeight = nullptr );
     void calculateOffsetAndRotation( QgsSymbolRenderContext &context, double scaledWidth, double scaledHeight, bool &hasDataDefinedRotation, QPointF &offset, double &angle ) const;
 };

--- a/src/gui/symbology/qgsellipsesymbollayerwidget.cpp
+++ b/src/gui/symbology/qgsellipsesymbollayerwidget.cpp
@@ -65,30 +65,27 @@ QgsEllipseSymbolLayerWidget::QgsEllipseSymbolLayerWidget( QgsVectorLayer *vl, QW
   spinOffsetY->setClearValue( 0.0 );
   mRotationSpinBox->setClearValue( 0.0 );
 
-  QStringList names;
-  names << QStringLiteral( "circle" ) << QStringLiteral( "rectangle" ) << QStringLiteral( "diamond" ) << QStringLiteral( "cross" ) << QStringLiteral( "arrow" ) << QStringLiteral( "half_arc" ) << QStringLiteral( "triangle" ) << QStringLiteral( "right_half_triangle" ) << QStringLiteral( "left_half_triangle" ) << QStringLiteral( "semi_circle" );
-
   int size = mShapeListWidget->iconSize().width();
   size = std::max( 30, static_cast< int >( std::round( Qgis::UI_SCALE_FACTOR * fontMetrics().horizontalAdvance( 'X' ) * 3 ) ) );
   mShapeListWidget->setGridSize( QSize( size * 1.2, size * 1.2 ) );
   mShapeListWidget->setIconSize( QSize( size, size ) );
 
   double markerSize = size * 0.8;
-  const auto constNames = names;
-  for ( const QString &name : constNames )
+  const auto shapes = QgsEllipseSymbolLayer::availableShapes();
+  for ( QgsEllipseSymbolLayer::Shape shape : shapes )
   {
     QgsEllipseSymbolLayer *lyr = new QgsEllipseSymbolLayer();
     lyr->setSymbolWidthUnit( QgsUnitTypes::RenderPixels );
     lyr->setSymbolHeightUnit( QgsUnitTypes::RenderPixels );
-    lyr->setSymbolName( name );
+    lyr->setShape( shape );
     lyr->setStrokeColor( QColor( 0, 0, 0 ) );
     lyr->setFillColor( QColor( 200, 200, 200 ) );
     lyr->setSymbolWidth( markerSize );
     lyr->setSymbolHeight( markerSize * 0.75 );
     QIcon icon = QgsSymbolLayerUtils::symbolLayerPreviewIcon( lyr, QgsUnitTypes::RenderPixels, QSize( size, size ) );
     QListWidgetItem *item = new QListWidgetItem( icon, QString(), mShapeListWidget );
-    item->setToolTip( name );
-    item->setData( Qt::UserRole, name );
+    item->setData( Qt::UserRole, static_cast< int >( shape ) );
+    item->setToolTip( QgsEllipseSymbolLayer::encodeShape( shape ) );
     delete lyr;
   }
   // show at least 2 rows (only 1 row is required, but looks too cramped)
@@ -116,12 +113,16 @@ void QgsEllipseSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer *layer )
   btnChangeColorStroke->setColor( mLayer->strokeColor() );
   btnChangeColorFill->setColor( mLayer->fillColor() );
 
-  QList<QListWidgetItem *> symbolItemList = mShapeListWidget->findItems( mLayer->symbolName(), Qt::MatchExactly );
-  if ( !symbolItemList.isEmpty() )
+  QgsEllipseSymbolLayer::Shape shape = mLayer->shape();
+  for ( int i = 0; i < mShapeListWidget->count(); ++i )
   {
-    mShapeListWidget->setCurrentItem( symbolItemList.at( 0 ) );
+    if ( static_cast< QgsEllipseSymbolLayer::Shape >( mShapeListWidget->item( i )->data( Qt::UserRole ).toInt() ) == shape )
+    {
+      mShapeListWidget->setCurrentRow( i );
+      break;
+    }
   }
-  btnChangeColorFill->setEnabled( QgsEllipseSymbolLayer::shapeIsFilled( mLayer->symbolName() ) );
+  btnChangeColorFill->setEnabled( QgsEllipseSymbolLayer::shapeIsFilled( mLayer->shape() ) );
 
   //set combo entries to current values
   blockComboSignals( true );
@@ -167,13 +168,9 @@ void QgsEllipseSymbolLayerWidget::mShapeListWidget_itemSelectionChanged()
 {
   if ( mLayer )
   {
-    QListWidgetItem *item = mShapeListWidget->currentItem();
-    if ( item )
-    {
-      mLayer->setSymbolName( item->data( Qt::UserRole ).toString() );
-      btnChangeColorFill->setEnabled( QgsEllipseSymbolLayer::shapeIsFilled( mLayer->symbolName() ) );
-      emit changed();
-    }
+    mLayer->setShape( static_cast< QgsEllipseSymbolLayer::Shape>( mShapeListWidget->currentItem()->data( Qt::UserRole ).toInt() ) );
+    btnChangeColorFill->setEnabled( QgsEllipseSymbolLayer::shapeIsFilled( mLayer->shape() ) );
+    emit changed();
   }
 }
 

--- a/src/gui/symbology/qgsellipsesymbollayerwidget.cpp
+++ b/src/gui/symbology/qgsellipsesymbollayerwidget.cpp
@@ -121,6 +121,7 @@ void QgsEllipseSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer *layer )
   {
     mShapeListWidget->setCurrentItem( symbolItemList.at( 0 ) );
   }
+  btnChangeColorFill->setEnabled( QgsEllipseSymbolLayer::shapeIsFilled( mLayer->symbolName() ) );
 
   //set combo entries to current values
   blockComboSignals( true );
@@ -170,6 +171,7 @@ void QgsEllipseSymbolLayerWidget::mShapeListWidget_itemSelectionChanged()
     if ( item )
     {
       mLayer->setSymbolName( item->data( Qt::UserRole ).toString() );
+      btnChangeColorFill->setEnabled( QgsEllipseSymbolLayer::shapeIsFilled( mLayer->symbolName() ) );
       emit changed();
     }
   }

--- a/tests/src/core/testqgsellipsemarker.cpp
+++ b/tests/src/core/testqgsellipsemarker.cpp
@@ -135,7 +135,7 @@ void TestQgsEllipseMarkerSymbol::ellipseMarkerSymbol()
 
   mEllipseMarkerLayer->setFillColor( Qt::blue );
   mEllipseMarkerLayer->setStrokeColor( Qt::black );
-  mEllipseMarkerLayer->setSymbolName( QStringLiteral( "circle" ) );
+  mEllipseMarkerLayer->setShape( QgsEllipseSymbolLayer::Circle );
   mEllipseMarkerLayer->setSymbolHeight( 3 );
   mEllipseMarkerLayer->setSymbolWidth( 6 );
   mEllipseMarkerLayer->setStrokeWidth( 0.8 );
@@ -163,7 +163,7 @@ void TestQgsEllipseMarkerSymbol::ellipseMarkerSymbolBevelJoin()
 
   mEllipseMarkerLayer->setFillColor( Qt::blue );
   mEllipseMarkerLayer->setStrokeColor( Qt::black );
-  mEllipseMarkerLayer->setSymbolName( QStringLiteral( "triangle" ) );
+  mEllipseMarkerLayer->setShape( QgsEllipseSymbolLayer::Triangle );
   mEllipseMarkerLayer->setSymbolHeight( 25 );
   mEllipseMarkerLayer->setSymbolWidth( 20 );
   mEllipseMarkerLayer->setStrokeWidth( 3 );
@@ -177,7 +177,7 @@ void TestQgsEllipseMarkerSymbol::ellipseMarkerSymbolMiterJoin()
 
   mEllipseMarkerLayer->setFillColor( Qt::blue );
   mEllipseMarkerLayer->setStrokeColor( Qt::black );
-  mEllipseMarkerLayer->setSymbolName( QStringLiteral( "triangle" ) );
+  mEllipseMarkerLayer->setShape( QgsEllipseSymbolLayer::Triangle );
   mEllipseMarkerLayer->setSymbolHeight( 25 );
   mEllipseMarkerLayer->setSymbolWidth( 20 );
   mEllipseMarkerLayer->setStrokeWidth( 3 );
@@ -191,7 +191,7 @@ void TestQgsEllipseMarkerSymbol::ellipseMarkerSymbolRoundJoin()
 
   mEllipseMarkerLayer->setFillColor( Qt::blue );
   mEllipseMarkerLayer->setStrokeColor( Qt::black );
-  mEllipseMarkerLayer->setSymbolName( QStringLiteral( "triangle" ) );
+  mEllipseMarkerLayer->setShape( QgsEllipseSymbolLayer::Triangle );
   mEllipseMarkerLayer->setSymbolHeight( 25 );
   mEllipseMarkerLayer->setSymbolWidth( 20 );
   mEllipseMarkerLayer->setStrokeWidth( 3 );
@@ -205,7 +205,7 @@ void TestQgsEllipseMarkerSymbol::ellipseMarkerSymbolCapStyle()
 
   mEllipseMarkerLayer->setColor( Qt::blue );
   mEllipseMarkerLayer->setStrokeColor( Qt::black );
-  mEllipseMarkerLayer->setSymbolName( QStringLiteral( "cross" ) );
+  mEllipseMarkerLayer->setShape( QgsEllipseSymbolLayer::Cross );
   mEllipseMarkerLayer->setSymbolWidth( 35 );
   mEllipseMarkerLayer->setSymbolHeight( 15 );
   mEllipseMarkerLayer->setStrokeWidth( 3 );
@@ -217,7 +217,7 @@ void TestQgsEllipseMarkerSymbol::selected()
 {
   mEllipseMarkerLayer->setFillColor( Qt::blue );
   mEllipseMarkerLayer->setStrokeColor( Qt::black );
-  mEllipseMarkerLayer->setSymbolName( QStringLiteral( "triangle" ) );
+  mEllipseMarkerLayer->setShape( QgsEllipseSymbolLayer::Triangle );
   mEllipseMarkerLayer->setSymbolHeight( 25 );
   mEllipseMarkerLayer->setSymbolWidth( 20 );
   mEllipseMarkerLayer->setStrokeWidth( 3 );
@@ -233,7 +233,7 @@ void TestQgsEllipseMarkerSymbol::bounds()
 {
   mEllipseMarkerLayer->setFillColor( Qt::blue );
   mEllipseMarkerLayer->setStrokeColor( Qt::black );
-  mEllipseMarkerLayer->setSymbolName( QStringLiteral( "circle" ) );
+  mEllipseMarkerLayer->setShape( QgsEllipseSymbolLayer::Circle );
   mEllipseMarkerLayer->setSymbolHeight( 3 );
   mEllipseMarkerLayer->setSymbolWidth( 6 );
   mEllipseMarkerLayer->setDataDefinedProperty( QgsSymbolLayer::PropertySize, QgsProperty::fromExpression( QStringLiteral( "min(\"importance\" * 2, 6)" ) ) );
@@ -249,8 +249,7 @@ void TestQgsEllipseMarkerSymbol::opacityWithDataDefinedColor()
 {
   mEllipseMarkerLayer->setColor( QColor( 200, 200, 200 ) );
   mEllipseMarkerLayer->setStrokeColor( QColor( 0, 0, 0 ) );
-  mEllipseMarkerLayer->setSymbolName( QStringLiteral( "circle" ) );
-  mEllipseMarkerLayer->setSymbolName( QStringLiteral( "circle" ) );
+  mEllipseMarkerLayer->setShape( QgsEllipseSymbolLayer::Circle );
   mEllipseMarkerLayer->setSymbolHeight( 3 );
   mEllipseMarkerLayer->setSymbolWidth( 6 );
   mEllipseMarkerLayer->setDataDefinedProperty( QgsSymbolLayer::PropertyFillColor, QgsProperty::fromExpression( QStringLiteral( "if(importance > 2, 'red', 'green')" ) ) );
@@ -269,8 +268,7 @@ void TestQgsEllipseMarkerSymbol::dataDefinedOpacity()
 {
   mEllipseMarkerLayer->setColor( QColor( 200, 200, 200 ) );
   mEllipseMarkerLayer->setStrokeColor( QColor( 0, 0, 0 ) );
-  mEllipseMarkerLayer->setSymbolName( QStringLiteral( "circle" ) );
-  mEllipseMarkerLayer->setSymbolName( QStringLiteral( "circle" ) );
+  mEllipseMarkerLayer->setShape( QgsEllipseSymbolLayer::Circle );
   mEllipseMarkerLayer->setSymbolHeight( 3 );
   mEllipseMarkerLayer->setSymbolWidth( 6 );
   mEllipseMarkerLayer->setDataDefinedProperty( QgsSymbolLayer::PropertyFillColor, QgsProperty::fromExpression( QStringLiteral( "if(importance > 2, 'red', 'green')" ) ) );


### PR DESCRIPTION
## Description

Giving a bit of :heart: to this under-maintained marker symbol layer. 

The chunk of the PR upgrades the ellipse marker symbol layer away from using strings into using an enum to identify shape type. This does us a couple of favors: i) it's faster code, ii) it allows us to use switch( shape ) and be warned of missing code addition when adding new shapes, and iii) it harmonizes code styling with that of the simple marker symbol layer, enabling easier porting of feature from one marker type to the other.