### PR TITLE
fix open form button not always enabled in relation reference widget

### DIFF
--- a/src/core/qgsfeaturepickermodelbase.cpp
+++ b/src/core/qgsfeaturepickermodelbase.cpp
@@ -28,6 +28,7 @@ QgsFeaturePickerModelBase::QgsFeaturePickerModelBase( QObject *parent )
   mReloadTimer.setInterval( 100 );
   mReloadTimer.setSingleShot( true );
   connect( &mReloadTimer, &QTimer::timeout, this, &QgsFeaturePickerModelBase::scheduledReload );
+  connect( this, &QgsFeaturePickerModelBase::extraValueDoesNotExistChanged, this, &QgsFeaturePickerModelBase::extraIdentifierValueChanged );
 }
 
 
@@ -513,6 +514,7 @@ void QgsFeaturePickerModelBase::setExtraIdentifierValueUnguarded( const QVariant
       if ( !isNull )
       {
         mEntries.prepend( createEntry( identifierValue ) );
+        setExtraValueDoesNotExist( true );
         reloadCurrentFeature();
       }
       else

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -599,7 +599,7 @@ void QgsRelationReferenceWidget::init()
     }
 
     // Only connect after iterating, to have only one iterator on the referenced table at once
-    connect( mComboBox, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, &QgsRelationReferenceWidget::comboReferenceChanged );
+    connect( mComboBox, &QgsFeatureListComboBox::identifierValueChanged, this, &QgsRelationReferenceWidget::comboReferenceChanged );
 
     QApplication::restoreOverrideCursor();
 
@@ -723,9 +723,8 @@ void QgsRelationReferenceWidget::mapIdentification()
   }
 }
 
-void QgsRelationReferenceWidget::comboReferenceChanged( int index )
+void QgsRelationReferenceWidget::comboReferenceChanged( )
 {
-  Q_UNUSED( index )
   mReferencedLayer->getFeatures( mComboBox->currentFeatureRequest() ).nextFeature( mFeature );
   highlightFeature( mFeature );
   updateAttributeEditorFrame( mFeature );

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -287,7 +287,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
   private slots:
     void highlightActionTriggered( QAction *action );
     void deleteHighlight();
-    void comboReferenceChanged( int index );
+    void comboReferenceChanged();
     void featureIdentified( const QgsFeature &feature );
     void setMapTool( QgsMapTool *mapTool );
     void unsetMapTool();


### PR DESCRIPTION
when the underlying model has more feature than what the model fetches by default (100),
the feature is not fetched yet when the combobox has its index changed

This bug only happened when the widget is shown within an embed form in a relation editor.

Two fixes here:
- the relation reference widget uses the proper signal
- when the model has to fetch feature for new extra value, it correctly changes the property (ExtraValueDoesNotExist).

I failed at implementing a test for this.

This supersedes #42144. 