### PR TITLE
Minor cleanup of INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -161,7 +161,7 @@ to you.
 The packages QGIS depends on to build are available in the "universe" component
 of Ubuntu. This is not activated by default, so you need to activate it:
 
-1. Edit your /etc/apt/sources.list file.
+1. Edit your `/etc/apt/sources.list` file.
 2. Uncomment all the lines starting with "deb"
 
 Also you will need a recent enough distribution in order for all dependencies
@@ -170,19 +170,19 @@ to be met. The supported distributions are listed in the following section.
 Now update your local sources database:
 
 ```bash
-    sudo apt-get update
+sudo apt-get update
 ```
 
 ## 3.3. Install build dependencies
 
 |Distribution|Install command for packages|
 |------------|----------------------------|
-| buster | ``apt-get install bison ca-certificates ccache cmake cmake-curses-gui dh-python doxygen expect flex flip gdal-bin git graphviz grass-dev libexiv2-dev libexpat1-dev libfcgi-dev libgdal-dev libgeos-dev libgsl-dev libpdal-dev libpq-dev libproj-dev libprotobuf-dev libqca-qt5-2-dev libqca-qt5-2-plugins libqscintilla2-qt5-dev libqt5opengl5-dev libqt5serialport5-dev libqt5sql5-sqlite libqt5svg5-dev libqt5webkit5-dev libqt5xmlpatterns5-dev libqwt-qt5-dev libspatialindex-dev libspatialite-dev libsqlite3-dev libsqlite3-mod-spatialite libyaml-tiny-perl libzip-dev libzstd-dev lighttpd locales ninja-build ocl-icd-opencl-dev opencl-headers pdal pkg-config poppler-utils protobuf-compiler pyqt5-dev pyqt5-dev-tools pyqt5.qsci-dev python3-all-dev python3-autopep8 python3-dateutil python3-dev python3-future python3-gdal python3-httplib2 python3-jinja2 python3-lxml python3-markupsafe python3-mock python3-nose2 python3-owslib python3-plotly python3-psycopg2 python3-pygments python3-pyproj python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtsql python3-pyqt5.qtsvg python3-pyqt5.qtwebkit python3-requests python3-sip python3-sip-dev python3-six python3-termcolor python3-tz python3-yaml qt3d-assimpsceneimport-plugin qt3d-defaultgeometryloader-plugin qt3d-gltfsceneio-plugin qt3d-scene2d-plugin qt3d5-dev qt5-default qt5keychain-dev qtbase5-dev qtbase5-private-dev qtpositioning5-dev qttools5-dev qttools5-dev-tools saga spawn-fcgi xauth xfonts-100dpi xfonts-75dpi xfonts-base xfonts-scalable xvfb`` |
-| bullseye | ``apt-get install bison ca-certificates ccache cmake cmake-curses-gui dh-python doxygen expect flex flip gdal-bin git graphviz grass-dev libexiv2-dev libexpat1-dev libfcgi-dev libgdal-dev libgeos-dev libgsl-dev libpdal-dev libpq-dev libproj-dev libprotobuf-dev libqca-qt5-2-dev libqca-qt5-2-plugins libqscintilla2-qt5-dev libqt5opengl5-dev libqt5serialport5-dev libqt5sql5-sqlite libqt5svg5-dev libqt5webkit5-dev libqt5xmlpatterns5-dev libqwt-qt5-dev libspatialindex-dev libspatialite-dev libsqlite3-dev libsqlite3-mod-spatialite libyaml-tiny-perl libzip-dev libzstd-dev lighttpd locales ninja-build ocl-icd-opencl-dev opencl-headers pdal pkg-config poppler-utils protobuf-compiler pyqt5-dev pyqt5-dev-tools pyqt5.qsci-dev python3-all-dev python3-autopep8 python3-dateutil python3-dev python3-future python3-gdal python3-httplib2 python3-jinja2 python3-lxml python3-markupsafe python3-mock python3-nose2 python3-owslib python3-plotly python3-psycopg2 python3-pygments python3-pyproj python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtsql python3-pyqt5.qtsvg python3-pyqt5.qtwebkit python3-requests python3-sip python3-sip-dev python3-six python3-termcolor python3-tz python3-yaml qt3d-assimpsceneimport-plugin qt3d-defaultgeometryloader-plugin qt3d-gltfsceneio-plugin qt3d-scene2d-plugin qt3d5-dev qt5-default qt5keychain-dev qtbase5-dev qtbase5-private-dev qtpositioning5-dev qttools5-dev qttools5-dev-tools saga spawn-fcgi xauth xfonts-100dpi xfonts-75dpi xfonts-base xfonts-scalable xvfb`` |
-| bionic | ``apt-get install bison ca-certificates ccache cmake cmake-curses-gui dh-python doxygen expect flex flip gdal-bin git graphviz grass-dev libexiv2-dev libexpat1-dev libfcgi-dev libgdal-dev libgeos-dev libgsl-dev libpdal-dev libpq-dev libproj-dev libprotobuf-dev libqca-qt5-2-dev libqca-qt5-2-plugins libqscintilla2-qt5-dev libqt5opengl5-dev libqt5serialport5-dev libqt5sql5-sqlite libqt5svg5-dev libqt5webkit5-dev libqt5xmlpatterns5-dev libqwt-qt5-dev libspatialindex-dev libspatialite-dev libsqlite3-dev libsqlite3-mod-spatialite libyaml-tiny-perl libzip-dev libzstd-dev lighttpd locales ninja-build ocl-icd-opencl-dev opencl-headers pdal pkg-config poppler-utils protobuf-compiler pyqt5-dev pyqt5-dev-tools pyqt5.qsci-dev python3-all-dev python3-autopep8 python3-dateutil python3-dev python3-future python3-gdal python3-httplib2 python3-jinja2 python3-lxml python3-markupsafe python3-mock python3-nose2 python3-owslib python3-plotly python3-psycopg2 python3-pygments python3-pyproj python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtsql python3-pyqt5.qtsvg python3-pyqt5.qtwebkit python3-requests python3-sip python3-sip-dev python3-six python3-termcolor python3-tz python3-yaml qt3d-assimpsceneimport-plugin qt3d-defaultgeometryloader-plugin qt3d-gltfsceneio-plugin qt3d-scene2d-plugin qt3d5-dev qt5-default qt5keychain-dev qtbase5-dev qtbase5-private-dev qtpositioning5-dev qttools5-dev qttools5-dev-tools saga spawn-fcgi xauth xfonts-100dpi xfonts-75dpi xfonts-base xfonts-scalable xvfb`` |
-| focal | ``apt-get install bison ca-certificates ccache cmake cmake-curses-gui dh-python doxygen expect flex flip gdal-bin git graphviz grass-dev libexiv2-dev libexpat1-dev libfcgi-dev libgdal-dev libgeos-dev libgsl-dev libpdal-dev libpq-dev libproj-dev libprotobuf-dev libqca-qt5-2-dev libqca-qt5-2-plugins libqscintilla2-qt5-dev libqt5opengl5-dev libqt5serialport5-dev libqt5sql5-sqlite libqt5svg5-dev libqt5webkit5-dev libqt5xmlpatterns5-dev libqwt-qt5-dev libspatialindex-dev libspatialite-dev libsqlite3-dev libsqlite3-mod-spatialite libyaml-tiny-perl libzip-dev libzstd-dev lighttpd locales ninja-build ocl-icd-opencl-dev opencl-headers pdal pkg-config poppler-utils protobuf-compiler pyqt5-dev pyqt5-dev-tools pyqt5.qsci-dev python3-all-dev python3-autopep8 python3-dateutil python3-dev python3-future python3-gdal python3-httplib2 python3-jinja2 python3-lxml python3-markupsafe python3-mock python3-nose2 python3-owslib python3-plotly python3-psycopg2 python3-pygments python3-pyproj python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtsql python3-pyqt5.qtsvg python3-pyqt5.qtwebkit python3-requests python3-sip python3-sip-dev python3-six python3-termcolor python3-tz python3-yaml qt3d-assimpsceneimport-plugin qt3d-defaultgeometryloader-plugin qt3d-gltfsceneio-plugin qt3d-scene2d-plugin qt3d5-dev qt5-default qt5keychain-dev qtbase5-dev qtbase5-private-dev qtpositioning5-dev qttools5-dev qttools5-dev-tools saga spawn-fcgi xauth xfonts-100dpi xfonts-75dpi xfonts-base xfonts-scalable xvfb`` |
-| groovy | ``apt-get install bison ca-certificates ccache cmake cmake-curses-gui dh-python doxygen expect flex flip gdal-bin git graphviz grass-dev libexiv2-dev libexpat1-dev libfcgi-dev libgdal-dev libgeos-dev libgsl-dev libpdal-dev libpq-dev libproj-dev libprotobuf-dev libqca-qt5-2-dev libqca-qt5-2-plugins libqscintilla2-qt5-dev libqt5opengl5-dev libqt5serialport5-dev libqt5sql5-sqlite libqt5svg5-dev libqt5webkit5-dev libqt5xmlpatterns5-dev libqwt-qt5-dev libspatialindex-dev libspatialite-dev libsqlite3-dev libsqlite3-mod-spatialite libyaml-tiny-perl libzip-dev libzstd-dev lighttpd locales ninja-build ocl-icd-opencl-dev opencl-headers pdal pkg-config poppler-utils protobuf-compiler pyqt5-dev pyqt5-dev-tools pyqt5.qsci-dev python3-all-dev python3-autopep8 python3-dateutil python3-dev python3-future python3-gdal python3-httplib2 python3-jinja2 python3-lxml python3-markupsafe python3-mock python3-nose2 python3-owslib python3-plotly python3-psycopg2 python3-pygments python3-pyproj python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtsql python3-pyqt5.qtsvg python3-pyqt5.qtwebkit python3-requests python3-sip python3-sip-dev python3-six python3-termcolor python3-tz python3-yaml qt3d-assimpsceneimport-plugin qt3d-defaultgeometryloader-plugin qt3d-gltfsceneio-plugin qt3d-scene2d-plugin qt3d5-dev qt5-default qt5keychain-dev qtbase5-dev qtbase5-private-dev qtpositioning5-dev qttools5-dev qttools5-dev-tools saga spawn-fcgi xauth xfonts-100dpi xfonts-75dpi xfonts-base xfonts-scalable xvfb`` |
-| sid | ``apt-get install bison ca-certificates ccache cmake cmake-curses-gui dh-python doxygen expect flex flip gdal-bin git graphviz grass-dev libexiv2-dev libexpat1-dev libfcgi-dev libgdal-dev libgeos-dev libgsl-dev libpdal-dev libpq-dev libproj-dev libprotobuf-dev libqca-qt5-2-dev libqca-qt5-2-plugins libqscintilla2-qt5-dev libqt5opengl5-dev libqt5serialport5-dev libqt5sql5-sqlite libqt5svg5-dev libqt5webkit5-dev libqt5xmlpatterns5-dev libqwt-qt5-dev libspatialindex-dev libspatialite-dev libsqlite3-dev libsqlite3-mod-spatialite libyaml-tiny-perl libzip-dev libzstd-dev lighttpd locales ninja-build ocl-icd-opencl-dev opencl-headers pdal pkg-config poppler-utils protobuf-compiler pyqt5-dev pyqt5-dev-tools pyqt5.qsci-dev python3-all-dev python3-autopep8 python3-dateutil python3-dev python3-future python3-gdal python3-httplib2 python3-jinja2 python3-lxml python3-markupsafe python3-mock python3-nose2 python3-owslib python3-plotly python3-psycopg2 python3-pygments python3-pyproj python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtsql python3-pyqt5.qtsvg python3-pyqt5.qtwebkit python3-requests python3-sip python3-six python3-termcolor python3-tz python3-yaml qt3d-assimpsceneimport-plugin qt3d-defaultgeometryloader-plugin qt3d-gltfsceneio-plugin qt3d-scene2d-plugin qt3d5-dev qt5-default qt5keychain-dev qtbase5-dev qtbase5-private-dev qtpositioning5-dev qttools5-dev qttools5-dev-tools saga sip5-tools spawn-fcgi xauth xfonts-100dpi xfonts-75dpi xfonts-base xfonts-scalable xvfb`` |
+| buster | `apt-get install bison ca-certificates ccache cmake cmake-curses-gui dh-python doxygen expect flex flip gdal-bin git graphviz grass-dev libexiv2-dev libexpat1-dev libfcgi-dev libgdal-dev libgeos-dev libgsl-dev libpdal-dev libpq-dev libproj-dev libprotobuf-dev libqca-qt5-2-dev libqca-qt5-2-plugins libqscintilla2-qt5-dev libqt5opengl5-dev libqt5serialport5-dev libqt5sql5-sqlite libqt5svg5-dev libqt5webkit5-dev libqt5xmlpatterns5-dev libqwt-qt5-dev libspatialindex-dev libspatialite-dev libsqlite3-dev libsqlite3-mod-spatialite libyaml-tiny-perl libzip-dev libzstd-dev lighttpd locales ninja-build ocl-icd-opencl-dev opencl-headers pdal pkg-config poppler-utils protobuf-compiler pyqt5-dev pyqt5-dev-tools pyqt5.qsci-dev python3-all-dev python3-autopep8 python3-dateutil python3-dev python3-future python3-gdal python3-httplib2 python3-jinja2 python3-lxml python3-markupsafe python3-mock python3-nose2 python3-owslib python3-plotly python3-psycopg2 python3-pygments python3-pyproj python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtsql python3-pyqt5.qtsvg python3-pyqt5.qtwebkit python3-requests python3-sip python3-sip-dev python3-six python3-termcolor python3-tz python3-yaml qt3d-assimpsceneimport-plugin qt3d-defaultgeometryloader-plugin qt3d-gltfsceneio-plugin qt3d-scene2d-plugin qt3d5-dev qt5-default qt5keychain-dev qtbase5-dev qtbase5-private-dev qtpositioning5-dev qttools5-dev qttools5-dev-tools saga spawn-fcgi xauth xfonts-100dpi xfonts-75dpi xfonts-base xfonts-scalable xvfb` |
+| bullseye | `apt-get install bison ca-certificates ccache cmake cmake-curses-gui dh-python doxygen expect flex flip gdal-bin git graphviz grass-dev libexiv2-dev libexpat1-dev libfcgi-dev libgdal-dev libgeos-dev libgsl-dev libpdal-dev libpq-dev libproj-dev libprotobuf-dev libqca-qt5-2-dev libqca-qt5-2-plugins libqscintilla2-qt5-dev libqt5opengl5-dev libqt5serialport5-dev libqt5sql5-sqlite libqt5svg5-dev libqt5webkit5-dev libqt5xmlpatterns5-dev libqwt-qt5-dev libspatialindex-dev libspatialite-dev libsqlite3-dev libsqlite3-mod-spatialite libyaml-tiny-perl libzip-dev libzstd-dev lighttpd locales ninja-build ocl-icd-opencl-dev opencl-headers pdal pkg-config poppler-utils protobuf-compiler pyqt5-dev pyqt5-dev-tools pyqt5.qsci-dev python3-all-dev python3-autopep8 python3-dateutil python3-dev python3-future python3-gdal python3-httplib2 python3-jinja2 python3-lxml python3-markupsafe python3-mock python3-nose2 python3-owslib python3-plotly python3-psycopg2 python3-pygments python3-pyproj python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtsql python3-pyqt5.qtsvg python3-pyqt5.qtwebkit python3-requests python3-sip python3-sip-dev python3-six python3-termcolor python3-tz python3-yaml qt3d-assimpsceneimport-plugin qt3d-defaultgeometryloader-plugin qt3d-gltfsceneio-plugin qt3d-scene2d-plugin qt3d5-dev qt5-default qt5keychain-dev qtbase5-dev qtbase5-private-dev qtpositioning5-dev qttools5-dev qttools5-dev-tools saga spawn-fcgi xauth xfonts-100dpi xfonts-75dpi xfonts-base xfonts-scalable xvfb` |
+| bionic | `apt-get install bison ca-certificates ccache cmake cmake-curses-gui dh-python doxygen expect flex flip gdal-bin git graphviz grass-dev libexiv2-dev libexpat1-dev libfcgi-dev libgdal-dev libgeos-dev libgsl-dev libpdal-dev libpq-dev libproj-dev libprotobuf-dev libqca-qt5-2-dev libqca-qt5-2-plugins libqscintilla2-qt5-dev libqt5opengl5-dev libqt5serialport5-dev libqt5sql5-sqlite libqt5svg5-dev libqt5webkit5-dev libqt5xmlpatterns5-dev libqwt-qt5-dev libspatialindex-dev libspatialite-dev libsqlite3-dev libsqlite3-mod-spatialite libyaml-tiny-perl libzip-dev libzstd-dev lighttpd locales ninja-build ocl-icd-opencl-dev opencl-headers pdal pkg-config poppler-utils protobuf-compiler pyqt5-dev pyqt5-dev-tools pyqt5.qsci-dev python3-all-dev python3-autopep8 python3-dateutil python3-dev python3-future python3-gdal python3-httplib2 python3-jinja2 python3-lxml python3-markupsafe python3-mock python3-nose2 python3-owslib python3-plotly python3-psycopg2 python3-pygments python3-pyproj python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtsql python3-pyqt5.qtsvg python3-pyqt5.qtwebkit python3-requests python3-sip python3-sip-dev python3-six python3-termcolor python3-tz python3-yaml qt3d-assimpsceneimport-plugin qt3d-defaultgeometryloader-plugin qt3d-gltfsceneio-plugin qt3d-scene2d-plugin qt3d5-dev qt5-default qt5keychain-dev qtbase5-dev qtbase5-private-dev qtpositioning5-dev qttools5-dev qttools5-dev-tools saga spawn-fcgi xauth xfonts-100dpi xfonts-75dpi xfonts-base xfonts-scalable xvfb` |
+| focal | `apt-get install bison ca-certificates ccache cmake cmake-curses-gui dh-python doxygen expect flex flip gdal-bin git graphviz grass-dev libexiv2-dev libexpat1-dev libfcgi-dev libgdal-dev libgeos-dev libgsl-dev libpdal-dev libpq-dev libproj-dev libprotobuf-dev libqca-qt5-2-dev libqca-qt5-2-plugins libqscintilla2-qt5-dev libqt5opengl5-dev libqt5serialport5-dev libqt5sql5-sqlite libqt5svg5-dev libqt5webkit5-dev libqt5xmlpatterns5-dev libqwt-qt5-dev libspatialindex-dev libspatialite-dev libsqlite3-dev libsqlite3-mod-spatialite libyaml-tiny-perl libzip-dev libzstd-dev lighttpd locales ninja-build ocl-icd-opencl-dev opencl-headers pdal pkg-config poppler-utils protobuf-compiler pyqt5-dev pyqt5-dev-tools pyqt5.qsci-dev python3-all-dev python3-autopep8 python3-dateutil python3-dev python3-future python3-gdal python3-httplib2 python3-jinja2 python3-lxml python3-markupsafe python3-mock python3-nose2 python3-owslib python3-plotly python3-psycopg2 python3-pygments python3-pyproj python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtsql python3-pyqt5.qtsvg python3-pyqt5.qtwebkit python3-requests python3-sip python3-sip-dev python3-six python3-termcolor python3-tz python3-yaml qt3d-assimpsceneimport-plugin qt3d-defaultgeometryloader-plugin qt3d-gltfsceneio-plugin qt3d-scene2d-plugin qt3d5-dev qt5-default qt5keychain-dev qtbase5-dev qtbase5-private-dev qtpositioning5-dev qttools5-dev qttools5-dev-tools saga spawn-fcgi xauth xfonts-100dpi xfonts-75dpi xfonts-base xfonts-scalable xvfb` |
+| groovy | `apt-get install bison ca-certificates ccache cmake cmake-curses-gui dh-python doxygen expect flex flip gdal-bin git graphviz grass-dev libexiv2-dev libexpat1-dev libfcgi-dev libgdal-dev libgeos-dev libgsl-dev libpdal-dev libpq-dev libproj-dev libprotobuf-dev libqca-qt5-2-dev libqca-qt5-2-plugins libqscintilla2-qt5-dev libqt5opengl5-dev libqt5serialport5-dev libqt5sql5-sqlite libqt5svg5-dev libqt5webkit5-dev libqt5xmlpatterns5-dev libqwt-qt5-dev libspatialindex-dev libspatialite-dev libsqlite3-dev libsqlite3-mod-spatialite libyaml-tiny-perl libzip-dev libzstd-dev lighttpd locales ninja-build ocl-icd-opencl-dev opencl-headers pdal pkg-config poppler-utils protobuf-compiler pyqt5-dev pyqt5-dev-tools pyqt5.qsci-dev python3-all-dev python3-autopep8 python3-dateutil python3-dev python3-future python3-gdal python3-httplib2 python3-jinja2 python3-lxml python3-markupsafe python3-mock python3-nose2 python3-owslib python3-plotly python3-psycopg2 python3-pygments python3-pyproj python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtsql python3-pyqt5.qtsvg python3-pyqt5.qtwebkit python3-requests python3-sip python3-sip-dev python3-six python3-termcolor python3-tz python3-yaml qt3d-assimpsceneimport-plugin qt3d-defaultgeometryloader-plugin qt3d-gltfsceneio-plugin qt3d-scene2d-plugin qt3d5-dev qt5-default qt5keychain-dev qtbase5-dev qtbase5-private-dev qtpositioning5-dev qttools5-dev qttools5-dev-tools saga spawn-fcgi xauth xfonts-100dpi xfonts-75dpi xfonts-base xfonts-scalable xvfb` |
+| sid | `apt-get install bison ca-certificates ccache cmake cmake-curses-gui dh-python doxygen expect flex flip gdal-bin git graphviz grass-dev libexiv2-dev libexpat1-dev libfcgi-dev libgdal-dev libgeos-dev libgsl-dev libpdal-dev libpq-dev libproj-dev libprotobuf-dev libqca-qt5-2-dev libqca-qt5-2-plugins libqscintilla2-qt5-dev libqt5opengl5-dev libqt5serialport5-dev libqt5sql5-sqlite libqt5svg5-dev libqt5webkit5-dev libqt5xmlpatterns5-dev libqwt-qt5-dev libspatialindex-dev libspatialite-dev libsqlite3-dev libsqlite3-mod-spatialite libyaml-tiny-perl libzip-dev libzstd-dev lighttpd locales ninja-build ocl-icd-opencl-dev opencl-headers pdal pkg-config poppler-utils protobuf-compiler pyqt5-dev pyqt5-dev-tools pyqt5.qsci-dev python3-all-dev python3-autopep8 python3-dateutil python3-dev python3-future python3-gdal python3-httplib2 python3-jinja2 python3-lxml python3-markupsafe python3-mock python3-nose2 python3-owslib python3-plotly python3-psycopg2 python3-pygments python3-pyproj python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtsql python3-pyqt5.qtsvg python3-pyqt5.qtwebkit python3-requests python3-sip python3-six python3-termcolor python3-tz python3-yaml qt3d-assimpsceneimport-plugin qt3d-defaultgeometryloader-plugin qt3d-gltfsceneio-plugin qt3d-scene2d-plugin qt3d5-dev qt5-default qt5keychain-dev qtbase5-dev qtbase5-private-dev qtpositioning5-dev qttools5-dev qttools5-dev-tools saga sip5-tools spawn-fcgi xauth xfonts-100dpi xfonts-75dpi xfonts-base xfonts-scalable xvfb`` |
 
 (extracted from the control.in file in `debian/`)
 
@@ -195,9 +195,9 @@ and we build with GDAL2 from ubuntugis).
 You should also setup ccache to speed up compile times:
 
 ```bash
-    cd /usr/local/bin
-    sudo ln -s /usr/bin/ccache gcc
-    sudo ln -s /usr/bin/ccache g++
+cd /usr/local/bin
+sudo ln -s /usr/bin/ccache gcc
+sudo ln -s /usr/bin/ccache g++
 ```
 
 or simply add `/usr/lib/ccache` to your `PATH`.
@@ -209,8 +209,8 @@ this case we will create a work environment for C++ development work like
 this:
 
 ```bash
-    mkdir -p ${HOME}/dev/cpp
-    cd ${HOME}/dev/cpp
+mkdir -p ${HOME}/dev/cpp
+cd ${HOME}/dev/cpp
 ```
 
 This directory path will be assumed for all instructions that follow.
@@ -219,21 +219,21 @@ This directory path will be assumed for all instructions that follow.
 
 There are two ways the source can be checked out. Use the anonymous method
 if you do not have edit privileges for the QGIS source repository, or use
-  the developer checkout if you have permissions to commit source code
-  changes.
+the developer checkout if you have permissions to commit source code
+changes.
 
 1. Anonymous Checkout
 
 ```bash
-    cd ${HOME}/dev/cpp
-    git clone git://github.com/qgis/QGIS.git
+cd ${HOME}/dev/cpp
+git clone git://github.com/qgis/QGIS.git
 ```
 
 2. Developer Checkout
 
 ```bash
-    cd ${HOME}/dev/cpp
-    git clone git@github.com:qgis/QGIS.git
+cd ${HOME}/dev/cpp
+git clone git@github.com:qgis/QGIS.git
 ```
 
 ## 3.7. Starting the compile
@@ -244,16 +244,16 @@ you can use the binary packages of QGIS on your system along side with your
 development version. I suggest you do something similar:
 
 ```bash
-    mkdir -p ${HOME}/apps
+mkdir -p ${HOME}/apps
 ```
 
 Now we create a build directory and run ccmake:
 
 ```bash
-    cd QGIS
-    mkdir build-master
-    cd build-master
-    ccmake ..
+cd QGIS
+mkdir build-master
+cd build-master
+ccmake ..
 ```
 
 When you run ccmake (note the .. is required!), a menu will appear where
@@ -277,7 +277,7 @@ the empty build directory once before starting to use the interactive tools.
 
 Now on with the build:
 ```bash
-    make -jX
+make -jX
 ```
 
 where X is the number of available cores. Depending on your platform,
@@ -285,59 +285,59 @@ this can speed up the build time considerably.
 
 Then you can directly run from the build directory:
 ```bash
-    ./output/bin/qgis
+./output/bin/qgis
 ```
 Another option is to install to your system:
 ```bash
-    make install
+make install
 ```
 
 After that you can try to run QGIS:
 ```bash
-    $HOME/apps/bin/qgis
+$HOME/apps/bin/qgis
 ```
 If all has worked properly the QGIS application should start up and appear
 on your screen. If you get the error message "error while loading shared libraries",
 execute this command in your shell.
 ```bash
-    sudo ldconfig
+sudo ldconfig
 ```
 If that doesn't help add the install path to LD_LIBRARY_PATH:
 ```bash
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${HOME}/apps/lib/
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${HOME}/apps/lib/
 ```
 Optionally, if you already know what aspects you want in your custom build
 then you can skip the interactive ccmake .. part by using the cmake -D
 option for each aspect, e.g.:
 ```bash
-    cmake -D CMAKE_BUILD_TYPE=Debug -D CMAKE_INSTALL_PREFIX=${HOME}/apps ..
+cmake -D CMAKE_BUILD_TYPE=Debug -D CMAKE_INSTALL_PREFIX=${HOME}/apps ..
 ```
 Also, if you want to speed your build times, you can easily do it with ninja,
 an alternative to make with similar build options.
 
 For example, to configure your build you can do either one of:
 ```bash
-    ccmake -G Ninja ..
-    cmake -G Ninja -D CMAKE_BUILD_TYPE=Debug -D CMAKE_INSTALL_PREFIX=${HOME}/apps ..
+ccmake -G Ninja ..
+cmake -G Ninja -D CMAKE_BUILD_TYPE=Debug -D CMAKE_INSTALL_PREFIX=${HOME}/apps ..
 ```
 Build and install with ninja:
 ```bash
-    ninja (uses all cores by default; also supports the above described -jX option)
-    ninja install
+ninja   # (uses all cores by default; also supports the above described -jX option)
+ninja install
 ```
 To build even faster, you can build just the targets you need using, for example:
 ```bash
-    ninja qgis
-    ninja pycore
-    # if it's on desktop related code only:
-    ninja qgis_desktop
+ninja qgis
+ninja pycore
+# if it's on desktop related code only:
+ninja qgis_desktop
 ```
 
 ## 3.8. Compiling with 3D
 
 In the cmake, you need to enable:
 ```bash
-    WITH_3D=True
+WITH_3D=True
 ```
 
 ### 3.8.1. Compiling with 3D on Debian based distributions
@@ -348,9 +348,9 @@ QGIS repository in `external/qt3dextra-headers`.
 To compile with 3D enabled, you need to add some cmake options:
 
 ```bash
-    CMAKE_PREFIX_PATH={path to QGIS Git repo}/external/qt3dextra-headers/cmake
-    QT5_3DEXTRA_INCLUDE_DIR={path to QGIS Git repo}/external/qt3dextra-headers
-    QT5_3DEXTRA_LIBRARY=/usr/lib/x86_64-linux-gnu/libQt53DExtras.so
+CMAKE_PREFIX_PATH={path to QGIS Git repo}/external/qt3dextra-headers/cmake
+QT5_3DEXTRA_INCLUDE_DIR={path to QGIS Git repo}/external/qt3dextra-headers
+QT5_3DEXTRA_LIBRARY=/usr/lib/x86_64-linux-gnu/libQt53DExtras.so
 ```
 
 ## 3.9. Building different branches
@@ -360,13 +360,13 @@ several sources in parallel, based on the same Git configuration.
 We recommend you to read the documentation about this Git command:
 
 ```bash
-    git commit
-    git worktree add ../my_new_functionality
-    cd ../my_new_functionality
-    git fetch qgis/master
-    git rebase -i qgis/master
-    # only keep the commits to be pushed
-    git push -u my_own_repo my_new_functionality
+git commit
+git worktree add ../my_new_functionality
+cd ../my_new_functionality
+git fetch qgis/master
+git rebase -i qgis/master
+# only keep the commits to be pushed
+git push -u my_own_repo my_new_functionality
 ```
 
 ## 3.10. Building Debian packages
@@ -378,20 +378,20 @@ you'll find a debian directory.
 First you need to install the debian packaging tools once:
 
 ```bash
-    apt-get install build-essential
+apt-get install build-essential
 ```
 
 First you need to create an changelog entry for your distribution. For example
 for Ubuntu Precise:
 
 ```bash
-    dch -l ~precise --force-distribution --distribution precise "precise build"
+dch -l ~precise --force-distribution --distribution precise "precise build"
 ```
 
 The QGIS packages will be created with:
 
 ```bash
-    dpkg-buildpackage -us -uc -b
+dpkg-buildpackage -us -uc -b
 ```
 
 **Note:** Install `devscripts` to get `dch`.
@@ -405,14 +405,14 @@ build conflict.
 
 **Note:** By default tests are run in the process of building and their
 results are uploaded to https://cdash.orfeo-toolbox.org/index.php?project=QGIS.
-You can turn the tests off using DEB_BUILD_OPTIONS=nocheck in front of the
-build command. The upload of results can be avoided with DEB_TEST_TARGET=test.
+You can turn the tests off using `DEB_BUILD_OPTIONS=nocheck` in front of the
+build command. The upload of results can be avoided with `DEB_TEST_TARGET=test`.
 
 The packages are created in the parent directory (ie. one level up).
-Install them using dpkg.  E.g.:
+Install them using `dpkg`.  E.g.:
 
 ```bash
-    sudo debi
+sudo debi
 ```
 
 ## 3.11. On Fedora Linux
@@ -424,13 +424,13 @@ new subdirectory called `build` or `build-qt5` in it.
 
 |Install command for dependencies|
 |--------------------------------|
-|dnf install qt5-qtbase-private-devel qt5-qtwebkit-devel qt5-qtlocation-devel qt5-qttools-static qca-qt5-devel qca-qt5-ossl qt5-qt3d-devel python3-qt5-devel python3-qscintilla-qt5-devel qscintilla-qt5-devel python3-qscintilla-devel python3-qscintilla-qt5 clang flex bison geos-devel gdal-devel sqlite-devel libspatialite-devel qt5-qtsvg-devel spatialindex-devel expat-devel proj-devel qwt-qt5-devel gsl-devel postgresql-devel cmake python3-future gdal-python3 python3-psycopg2 python3-PyYAML python3-pygments python3-jinja2 python3-OWSLib qca-qt5-ossl qwt-qt5-devel qtkeychain-qt5-devel qwt-devel sip-devel libzip-devel exiv2-devel|
+|`dnf install qt5-qtbase-private-devel qt5-qtwebkit-devel qt5-qtlocation-devel qt5-qttools-static qca-qt5-devel qca-qt5-ossl qt5-qt3d-devel python3-qt5-devel python3-qscintilla-qt5-devel qscintilla-qt5-devel python3-qscintilla-devel python3-qscintilla-qt5 clang flex bison geos-devel gdal-devel sqlite-devel libspatialite-devel qt5-qtsvg-devel spatialindex-devel expat-devel proj-devel qwt-qt5-devel gsl-devel postgresql-devel cmake python3-future gdal-python3 python3-psycopg2 python3-PyYAML python3-pygments python3-jinja2 python3-OWSLib qca-qt5-ossl qwt-qt5-devel qtkeychain-qt5-devel qwt-devel sip-devel libzip-devel exiv2-devel`|
 
 
 To build QGIS server additional dependencies are required:
 
 ```bash
-    dnf install fcgi-devel
+dnf install fcgi-devel
 ```
 
 Make sure that your build directory is completely empty when you enter the
@@ -440,27 +440,27 @@ command in the empty build directory once before starting to use the interactive
 tools.
 
 ```bash
-    cmake ..
+cmake ..
 ```
 
-If everything went OK you can finally start to compile. (As usual append a -jX
+If everything went OK you can finally start to compile. (As usual append a `-jX`
 where X is the number of available cores option to make to speed up your build
 process)
 
 ```bash
-    make
+make
 ```
 
 Run from the build directory
 
 ```bash
-    ./output/bin/qgis
+./output/bin/qgis
 ```
 
 Or install to your system
 
 ```bash
-    make install
+make install
 ```
 
 ### 3.11.2. Suggested system tweaks
@@ -471,10 +471,10 @@ the useful debug output which is normally printed when running the unit tests.
 To enable debug prints for the current user, execute:
 
 ```bash
-    cat > ~/.config/QtProject/qtlogging.ini << EOL
-    [Rules]
-    default.debug=true
-    EOL
+cat > ~/.config/QtProject/qtlogging.ini << EOL
+[Rules]
+default.debug=true
+EOL
 ```
 
 # 4. Building on Windows
@@ -503,7 +503,7 @@ Download and install following packages:
 * [CMake](https://cmake.org/files/v3.12/cmake-3.12.3-win64-x64.msi)
 * GNU flex, GNU bison and GIT with cygwin [32bit](https://cygwin.com/setup-x86.exe) or [64bit](https://cygwin.com/setup-x86_64.exe)
 * OSGeo4W [32bit](https://download.osgeo.org/osgeo4w/osgeo4w-setup-x86.exe) or [64bit](https://download.osgeo.org/osgeo4w/osgeo4w-setup-x86_64.exe)
-* [ninja](https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip)
+* [ninja](https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip): Copy the `ninja.exe` to `C:\OSGeo4W64\bin\`
 
 For the QGIS build you need to install following packages from cygwin:
 
@@ -515,19 +515,16 @@ and from OSGeo4W (select *Advanced Install*):
 
 * qgis-dev-deps
 
-This will also select packages the above packages depend on.
+  * This will also select packages the above packages depend on.
 
-  If you install other packages, this might cause issues. Particularly, make sure
-  **not** to install the msinttypes package. It installs a stdint.h file in
-  OSGeo4W[64]\include, that conflicts with Visual Studio own stdint.h, which for
-  example breaks the build of the virtual layer provider.
+  * Note: If you install other packages, this might cause issues. Particularly, make sure
+    **not** to install the msinttypes package. It installs a stdint.h file in
+    OSGeo4W[64]\include, that conflicts with Visual Studio own stdint.h, which for
+    example breaks the build of the virtual layer provider.
 
 Earlier versions of this document also covered how to build all above
 dependencies.  If you're interested in that, check the history of this page in the Wiki
 or the SVN repository.
-
-ninja:
-  copy ninja.exe to C:\OSGeo4W64\bin\
 
 ### 4.1.3. Clone the QGIS Source Code
 
@@ -535,7 +532,7 @@ Choose a directory to store the QGIS source code.
 For example, to put it in the OSGeo4W64 install, navigate there:
 
 ```cmd
-    cd C:\OSGeo4W64
+cd C:\OSGeo4W64
 ```
 
 This directory will be assumed for all instructions
@@ -545,7 +542,7 @@ On the command prompt clone the QGIS source from
 git to the source directory `QGIS`:
 
 ```cmd
-    git clone git://github.com/qgis/QGIS.git
+git clone git://github.com/qgis/QGIS.git
 ```
 
 This requires Git. If you have Git for Windows on your PATH already,
@@ -556,8 +553,8 @@ a Cygwin[64] Terminal
 And, to avoid Git in Windows reporting changes to files not actually modified:
 
 ```cmd
-    cd QGIS
-    git config core.filemode false
+cd QGIS
+git config core.filemode false
 ```
 
 ### 4.1.4. Configure and build with CMake from command line
@@ -572,96 +569,95 @@ variables create the following batch file (assuming the above packages were
 installed in the default locations):
 
 ```cmd
-    @echo off
-    call C:\OSGeo4W64\QGIS\ms-windows\osgeo4w\msvc-env.bat x86_64
-    @cmd
+@echo off
+call C:\OSGeo4W64\QGIS\ms-windows\osgeo4w\msvc-env.bat x86_64
+@cmd
 ```
 
 Save the batch file as `C:\OSGeo4W64\OSGeo4W-dev.bat` and run it.
 
 #### 4.1.4.1 Using configonly.bat to create the MSVC solution file
-  We will be using the file `ms-windows/osgeo4w/configonly.bat` to create an MSVC solution file.
-  There are two supported CMake generators for creating a solution file: Ninja, and native MSVC.
-  The advantage of using native MSVC solution is that you can find the root of build problems much more easily.
-  configonly.bat is meant to create a configured build directory with a MSVC solution file:
+We will be using the file `ms-windows/osgeo4w/configonly.bat` to create an MSVC solution file.
+There are two supported CMake generators for creating a solution file: Ninja, and native MSVC.
+The advantage of using native MSVC solution is that you can find the root of build problems much more easily.
+configonly.bat is meant to create a configured build directory with a MSVC solution file:
 
 ```cmd
-    cd C:\OSGeo4W64\QGIS\ms-windows\osgeo4w
-    configonly.bat
+cd C:\OSGeo4W64\QGIS\ms-windows\osgeo4w
+configonly.bat
 ```
 
 #### 4.1.4.2 Compiling QGIS with MSVC
-  We will need to run MSVC with all the environment variables set, thus we will run it as follows:
-  Run the batch file OSGeo4W-dev.bat you created before.
-  On the command prompt run `call gdal-dev-env.bat` to add the release gdal and proj libraries to your PATH.
-  On the command prompt run `devenv` to open MSVC.
-  From MSVC, open the solution file
-  `C:\OSGeo4W64\QGIS\ms-windows\osgeo4w\build-qgis-test-x86_64\qgis.sln`.
-  Try to build the solution (go grab a cup of tea, it may take a while).
-  If it fails, run it again and again until there are (hopefully) no errors.
+We will need to run MSVC with all the environment variables set, thus we will run it as follows:
+* Run the batch file OSGeo4W-dev.bat you created before.
+* On the command prompt run `call gdal-dev-env.bat` to add the release gdal and proj libraries to your PATH.
+* On the command prompt run `devenv` to open MSVC.
+* From MSVC, open the solution file `C:\OSGeo4W64\QGIS\ms-windows\osgeo4w\build-qgis-test-x86_64\qgis.sln`.
+* Try to build the solution (go grab a cup of tea, it may take a while).
+* If it fails, run it again and again until there are (hopefully) no errors.
 
 Running QGIS from within MSVC:
-  Edit the properties of the project ALL_BUILD to include the path to the executable:
-  Debugging -> Command -> `C:\OSGeo4W64\QGIS\ms-windows\osgeo4w\build-qgis-test-x86_64\output\bin\RelWithDebInfo\qgis.exe`.
-  To run, use the menu commands: Debug -> Start Debugging (F5) or Start Without Debugging (Ctrl+F5).
-  Ignore the "These projects are out of date" message, it appears even if no files were changed.
+* Edit the properties of the project ALL_BUILD to include the path to the executable:
+* Debugging -> Command -> `C:\OSGeo4W64\QGIS\ms-windows\osgeo4w\build-qgis-test-x86_64\output\bin\RelWithDebInfo\qgis.exe`.
+* To run, use the menu commands: Debug -> Start Debugging (F5) or Start Without Debugging (Ctrl+F5).
+* Ignore the "These projects are out of date" message, it appears even if no files were changed.
 
 ### 4.1.5 Old alternative method that might still work using cmake-gui
-  Create a 'build' directory somewhere. This will be where all the build output
-  will be generated.
+Create a 'build' directory somewhere. This will be where all the build output
+will be generated.
 
-  Now run `cmake-gui` (still from `cmd`) and in the *Where is the source code:*
-  box, browse to the top level QGIS directory.
+Now run `cmake-gui` (still from `cmd`) and in the *Where is the source code:*
+box, browse to the top level QGIS directory.
 
-  In the *Where to build the binaries:* box, browse to the 'build' directory you
-  created.
+In the *Where to build the binaries:* box, browse to the `build` directory you
+created.
 
-  If the path to bison and flex contains blanks, you need to use the short name
-  for the directory (i.e. `C:\Program Files` should be rewritten to
-  `C:\Progra~n`, where `n` is the number as shown in `dir /x C:\``).
+If the path to bison and flex contains blanks, you need to use the short name
+for the directory (i.e. `C:\Program Files` should be rewritten to
+`C:\Progra~n`, where `n` is the number as shown in `dir /x C:\`).
 
-  Verify that the 'BINDINGS_GLOBAL_INSTALL' option is not checked, so that python
-  bindings are placed into the output directory when you run the INSTALL target.
+Verify that the `BINDINGS_GLOBAL_INSTALL` option is not checked, so that python
+bindings are placed into the output directory when you run the `INSTALL` target.
 
-  Hit `Configure` to start the configuration and select `Visual Studio 9 2008`
-  and keep `native compilers` and click `Finish`.
+Hit `Configure` to start the configuration and select `Visual Studio 9 2008`
+and keep `native compilers` and click `Finish`.
 
-  The configuration should complete without any further questions and allow you to
-  click `Generate`.
+The configuration should complete without any further questions and allow you to
+click `Generate`.
 
-  Now close `cmake-gui` and continue on the command prompt by starting
-  `vcexpress`.  Use File / Open / Project/Solutions and open the
-  qgis-x.y.z.sln File in your project directory.
+Now close `cmake-gui` and continue on the command prompt by starting
+`vcexpress`.  Use File / Open / Project/Solutions and open the
+qgis-x.y.z.sln File in your project directory.
 
-  Change `Solution Configuration` from `Debug` to `RelWithDebInfo` (Release
-  with Debug Info)  or `Release` before you build QGIS using the ALL_BUILD
-  target (otherwise you need debug libraries that are not included).
+Change `Solution Configuration` from `Debug` to `RelWithDebInfo` (Release
+with Debug Info)  or `Release` before you build QGIS using the `ALL_BUILD`
+target (otherwise you need debug libraries that are not included).
 
-  After the build completed you should install QGIS using the INSTALL target.
+After the build completed you should install QGIS using the `INSTALL` target.
 
-  Install QGIS by building the INSTALL project. By default this will install to
-  c:\Program Files\qgis<version> (this can be changed by changing the
-  CMAKE_INSTALL_PREFIX variable in cmake-gui).
+Install QGIS by building the `INSTALL` project. By default this will install to
+`C:\Program Files\qgis<version>` (this can be changed by changing the
+`CMAKE_INSTALL_PREFIX` variable in `cmake-gui`).
 
-  You will also either need to add all the dependency DLLs to the QGIS install
-  directory or add their respective directories to your PATH.
+You will also either need to add all the dependency DLLs to the QGIS install
+directory or add their respective directories to your `PATH`.
 
 ### 4.1.6. Packaging
 
-To create a standalone installer there is a perl script named 'creatensis.pl'
-in 'qgis/ms-windows/osgeo4w'.  It downloads all required packages from OSGeo4W
+To create a standalone installer there is a perl script named `creatensis.pl`
+in `qgis/ms-windows/osgeo4w`.  It downloads all required packages from OSGeo4W
 and repackages them into an installer using NSIS.
 
 The script can be run on both Windows and Linux.
 
-On Debian/Ubuntu you can just install the 'nsis' package.
+On Debian/Ubuntu you can just install the `nsis` package.
 
 NSIS for Windows can be downloaded at:
 
 https://nsis.sourceforge.io/Main_Page
 
-And Perl for Windows (including other requirements like 'wget', 'unzip', 'tar'
-and 'bzip2') is available at:
+And Perl for Windows (including other requirements like `wget`, `unzip`, `tar`
+and `bzip2`) is available at:
 
 https://cygwin.com
 
@@ -673,15 +669,15 @@ windows installation into the ms-windows file tree created by the creatensis
 script.
 
 ```cmd
-    cd ms-windows/
-    rm -rf osgeo4w/unpacked/apps/qgis/*
-    cp -r /tmp/qgis1.7.0/* osgeo4w/unpacked/apps/qgis/
+cd ms-windows/
+rm -rf osgeo4w/unpacked/apps/qgis/*
+cp -r /tmp/qgis1.7.0/* osgeo4w/unpacked/apps/qgis/
 ```
 
 Now create a package.
 
 ```cmd
-    ./quickpackage.sh
+./quickpackage.sh
 ```
 
 After this you should now have a nsis installer containing your own build
@@ -701,7 +697,7 @@ in a Docker container.
 To build on Linux from your QGIS sources directory, launch:
 
 ```cmd
-    ms-windows/mingw/build.sh
+ms-windows/mingw/build.sh
 ```
 
 After a successful build, you will find two packages in the QGIS sources
@@ -767,14 +763,14 @@ speed up compilation, but it's not automatic.  Whenever you type "make" (but
 NOT "make install"), instead type:
 
 ```bash
-    make -j [#cpus]
+make -j [#cpus]
 ```
 
 Replace [#cpus] with the number of cores and/or processors your Mac has.
 To find out how many CPUs you have available, run the following in Terminal:
 
 ```bash
-    /usr/sbin/sysctl -n hw.ncpu
+/usr/sbin/sysctl -n hw.ncpu
 ```
 
 ## 5.1. Install Developer Tools
@@ -783,7 +779,7 @@ Developer tools are not a part of a standard OS X installation.
 As minimum you require command line tools
 
 ```bash
-    sudo xcode-select --install
+sudo xcode-select --install
 ```
 
 but installation of Xcode from the App Store is recommended too.
@@ -793,7 +789,7 @@ but installation of Xcode from the App Store is recommended too.
 For example install Homebrew
 
 ```bash
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 ```
 
 and these development/build tools
@@ -843,7 +839,7 @@ select Download .tar.gz. Double-click the tarball to unzip it.
 
 *Alternatively*, use git and clone the repository by
 ```bash
-    git clone git://github.com/qgis/QGIS.git
+git clone git://github.com/qgis/QGIS.git
 ```
 
 ## 5.5. Configure the build
@@ -857,19 +853,19 @@ below assume you are building into a ${HOME}/Applications directory.
 In a Terminal cd to the qgis source folder previously downloaded, then:
 
 ```bash
-    cd ..
-    mkdir build
-    cd build
+cd ..
+mkdir build
+cd build
 
-    QGIS_DEPS_VERSION=0.3.0;\
-    QT_VERSION=5.14.1;\
-    PATH=/opt/QGIS/qgis-deps-${QGIS_DEPS_VERSION}/stage/bin:$PATH;\
-    cmake \
-      -DCMAKE_INSTALL_PREFIX=~/Applications \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DQGIS_MAC_DEPS_DIR=/opt/QGIS/qgis-deps-${QGIS_DEPS_VERSION}/stage \
-      -DCMAKE_PREFIX_PATH=/opt/Qt/${QT_VERSION}/clang_64 \
-      ../QGIS
+QGIS_DEPS_VERSION=0.3.0;\
+QT_VERSION=5.14.1;\
+PATH=/opt/QGIS/qgis-deps-${QGIS_DEPS_VERSION}/stage/bin:$PATH;\
+cmake \
+  -DCMAKE_INSTALL_PREFIX=~/Applications \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DQGIS_MAC_DEPS_DIR=/opt/QGIS/qgis-deps-${QGIS_DEPS_VERSION}/stage \
+  -DCMAKE_PREFIX_PATH=/opt/Qt/${QT_VERSION}/clang_64 \
+  ../QGIS
 ```
 
 Note: Don't forget the `../QGIS` on the last line, which tells CMake to look for the source files.
@@ -881,8 +877,8 @@ Especially check Proj, GDAL, sqlite3 and Python paths.
 After the initial Terminal configure, you can use ccmake to make further changes:
 
 ```bash
-    cd build
-    ccmake ../QGIS
+cd build
+ccmake ../QGIS
 ```
 
 ## 5.6. Building
@@ -891,7 +887,7 @@ Now we can start the build process (remember the parallel compilation note at
 the beginning, this is a good place to use it, if you can):
 
 ```bash
-    make -j [#cpus]
+make -j [#cpus]
 ```
 
 Now you can run the QGIS from build directory by `./output/bin/QGIS.app/Contents/MacOS/QGIS`
@@ -899,13 +895,13 @@ Now you can run the QGIS from build directory by `./output/bin/QGIS.app/Contents
 If all built without errors you can then install it:
 
 ```bash
-    make install
+make install
 ```
 
 or, for an /Applications build:
 
 ```bash
-    sudo make install
+sudo make install
 ```
 
 For running the installed QGIS, you need to keep the dependencies in `/opt/` folder in place.
@@ -926,106 +922,107 @@ Note the git repo below will change to the default QGIS repo once this work
 is integrated into master.
 
 ```bash
-  git remote add blazek git://github.com/blazek/Quantum-GIS.git
-  git fetch blazek
-  git branch --track wcs2 blazek/wcs2
-  git checkout wcs2
-  cd /var/www/
-  sudo mkdir wcs
-  sudo chown timlinux wcs
-  cd wcs/
-  mkdir cgi-bin
-  cd cgi-bin/
+git remote add blazek git://github.com/blazek/Quantum-GIS.git
+git fetch blazek
+git branch --track wcs2 blazek/wcs2
+git checkout wcs2
+cd /var/www/
+sudo mkdir wcs
+sudo chown timlinux wcs
+cd wcs/
+mkdir cgi-bin
+cd cgi-bin/
 ```
 
 ## 6.2. Setup mapserver
 
 ```bash
-    sudo apt-get install cgi-mapserver
+sudo apt-get install cgi-mapserver
 ```
 
-Set the contents of cgi-bin/wcstest-1.9.0 to:
+Set the contents of `/var/www/wcs/cgi-bin/wcstest-1.9.0` to:
 
 ```bash
-      #! /bin/sh
-      MS_MAPFILE=/var/www/wcs/testdata/qgis-1.9.0/raster/wcs.map
-      export MS_MAPFILE
-      /usr/lib/cgi-bin/mapserv
+#! /bin/sh
+MS_MAPFILE=/var/www/wcs/testdata/qgis-1.9.0/raster/wcs.map
+export MS_MAPFILE
+/usr/lib/cgi-bin/mapserv
 ```
 
 Then do:
 
 ```bash
-      chmod +x cgi-bin/wcstest-1.9.0
-      mkdir -p /var/www/wcs/testdata/qgis-1.9.0/raster/
-      cd /var/www/wcs/testdata/qgis-1.9.0/raster/
-      cp -r /home/timlinux/QGIS/tests/testdata/raster/* .
+chmod +x var/www/wcs/cgi-bin/wcstest-1.9.0
+mkdir -p /var/www/wcs/testdata/qgis-1.9.0/raster/
+cd /var/www/wcs/testdata/qgis-1.9.0/raster/
+cp -r /home/timlinux/QGIS/tests/testdata/raster/* .
 ```
 
-Edit wcs.map and set the shapepath to this:
+Edit `/var/www/wcs/testdata/qgis-1.9.0/raster/wcs.map` and set the shapepath to this:
 
 ```bash
-      SHAPEPATH "/var/www/wcs/testdata/qgis-1.9.0/raster"
+SHAPEPATH "/var/www/wcs/testdata/qgis-1.9.0/raster"
 ```
 
-Then create /var/www/wcs/7-wcs.qgis.org.conf setting the contents to this:
+Then create `/var/www/wcs/7-wcs.example.com.conf` setting the contents to this:
 
 ```bash
-      <VirtualHost*:80>
-      ServerName wcs.qgis.org
-      ServerAdmin tim@linfiniti.com
+<VirtualHost*:80>
+ServerName wcs.example.com
+ServerAdmin wcs-admin@example.com
 
-      LogLevel warn
-      LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" \"%{forensic-id}n\"" combined
-      CustomLog /var/log/apache2/wcs_qgis.org/access.log combined
-      ErrorLog /var/log/apache2/wcs_qgis.org/error.log
+LogLevel warn
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" \"%{forensic-id}n\"" combined
+CustomLog /var/log/apache2/wcs_example.com/access.log combined
+ErrorLog /var/log/apache2/wcs_example.com/error.log
 
-      DocumentRoot /var/www/wcs/html
+DocumentRoot /var/www/wcs/html
 
-      ScriptAlias /cgi-bin/ /var/www/wcs/cgi-bin/
-      <Directory "/var/www/wcs/cgi-bin">
-            AllowOverride None
-            Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
-            Order allow,deny
-            Allow from all
-      </Directory>
+ScriptAlias /cgi-bin/ /var/www/wcs/cgi-bin/
+<Directory "/var/www/wcs/cgi-bin">
+	AllowOverride None
+	Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
+	Order allow,deny
+	Allow from all
+</Directory>
 
-      RewriteEngine on
-      RewriteRule /1.9.0/wcs /cgi-bin/wcstest-1.9.0 [PT]
+RewriteEngine on
+RewriteRule /1.9.0/wcs /cgi-bin/wcstest-1.9.0 [PT]
 
-      </VirtualHost>
+</VirtualHost>
 ```
 
 
 ## 6.3. Create a home page
 
 ```bash
-      mkdir html
-      vim html/index.html
+mkdir html
+vim html/index.html
 ```
 
 Set the contents to:
-
-      This is the test platform for QGIS' wcs client. You can use these services
-      from QGIS directly (to try out WCS for example) by pointing your QGIS to:
-      http://wcs.qgis.org/1.9.0/wcs
+```
+This is the test platform for QGIS' wcs client. You can use these services
+from QGIS directly (to try out WCS for example) by pointing your QGIS to:
+http://wcs.example.com/1.9.0/wcs
+```
 
 ## 6.4. Now deploy it
 
 ```bash
-      sudo mkdir /var/log/apache2/wcs_qgis.org
-      sudo chown www-data /var/log/apache2/wcs_qgis.org
-      cd /etc/apache2/sites-available/
-      sudo ln -s /var/www/wcs/7-wcs.qgis.org.conf .
-      cd /var/www/wcs/
-      sudo a2ensite 7-wcs.qgis.org.conf
-      sudo /etc/init.d/apache2 reload
+sudo mkdir /var/log/apache2/wcs_example.com
+sudo chown www-data /var/log/apache2/wcs_example.com
+cd /etc/apache2/sites-available/
+sudo ln -s /var/www/wcs/7-wcs.example.com.conf .
+cd /var/www/wcs/
+sudo a2ensite 7-wcs.example.com.conf
+sudo /etc/init.d/apache2 reload
 ```
 
 ## 6.5. Debugging
 
 ```bash
-      sudo tail -f /var/log/apache2/wcs_qgis.org/error.log
+sudo tail -f /var/log/apache2/wcs_example.com/error.log
 ```
 
 # 7. Setting up a Jenkins Build Server
@@ -1074,26 +1071,23 @@ Jenkins security to per project settings)
   * Set the github project to https://github.com/qgis/QGIS/
   * Set source code management to Git
   * Set repository url to git://github.com/qgis/QGIS.git
-  * In advanced repository url settings set refspec to :
-
-    +refs/heads/master:refs/remotes/origin/master
-
+  * In advanced repository url settings set refspec to `+refs/heads/master:refs/remotes/origin/master`
   * Set branch to build to master
   * Repository Browser: Auto
   * Build triggers: set to Poll SCM and set schedule to `*****` (polls every minute)
   * Build - Execute shell and set shell script to:
 
 ```bash
-      cd build
-      cmake ..
-      xvfb-run --auto-servernum --server-num=1 \
-               --server-args="-screen 0 1024x768x24" \
-               make Experimental || true
-      if [ -f Testing/TAG ] ; then
-         xsltproc ../tests/ctest2junix.xsl \
-           Testing/`head -n 1 < Testing/TAG`/Test.xml > \
-           CTestResults.xml
-      fi
+cd build
+cmake ..
+xvfb-run --auto-servernum --server-num=1 \
+  --server-args="-screen 0 1024x768x24" \
+  make Experimental || true
+if [ -f Testing/TAG ] ; then
+  xsltproc ../tests/ctest2junix.xsl \
+    Testing/`head -n 1 < Testing/TAG`/Test.xml > \
+    CTestResults.xml
+fi
 ```
 
   * Add Junit post build action and set 'Publish Junit test result report' to:
@@ -1120,7 +1114,7 @@ If you are interested in seeing embedded debug output, change the following
 CMake option:
 
 ```bash
-    -D CMAKE_BUILD_TYPE=DEBUG (or RELWITHDEBINFO)
+-D CMAKE_BUILD_TYPE=DEBUG  # (or RELWITHDEBINFO)
 ```
 
 This will flood your terminal or system log with lots of useful output from
@@ -1131,39 +1125,39 @@ directory, as it will not work with the installed/bundled app. First set the
 CMake option to enable tests:
 
 ```bash
-    -D ENABLE_TESTS=TRUE
+-D ENABLE_TESTS=TRUE
 ```
 
 Then run all tests from build directory:
 
 ```bash
-    cd build
-    make test
+cd build
+make test
 ```
 
 To run all tests and report to http://cdash.orfeo-toolbox.org/index.php?project=QGIS
 
 ```bash
-    cd build
-    make Experimental
+cd build
+make Experimental
 ```
 
 You can define the host name reported via 'make Experimental' by setting a CMake
 option:
 
 ```bash
-    -D SITE="my.domain.org"
+-D SITE="my.domain.org"
 ```
 
 To run specific test(s) (see 'man ctest'):
 
 ```bash
-    cd build
-    # show listing of tests, without running them
-    ctest --show-only
+cd build
+# show listing of tests, without running them
+ctest --show-only
 
-    # run specific C++ or Python test(s) matching a regular expression
-    ctest --verbose --tests-regex SomeTestName
+# run specific C++ or Python test(s) matching a regular expression
+ctest --verbose --tests-regex SomeTestName
 ```
 
 # 9. Authors and Acknowledgments


### PR DESCRIPTION
I noticed that copy and paste was including four extra spaces for all the code lines so I fixed that. Then I took the opportunity to fix other things as well:

- Remove extra indentation of code blocks that made copy'n'pasting ugly
	- Probably fixed in indentation bug for `~/.config/QtProject/qtlogging.ini`
- Some homogenization of code markup, didn't look through all parts of the document though
- Turn inline comments into actual `#` comments
- In Server part:
  - Use "example.com" for example domains
  - Be more explicite about paths
- I also tried to fix some formatting markup

# Open-ish questions I could continue with
- Is editing the server domain to a "proper" example domain ok or is this deployment documentation for a qgis.org server?
- Not sure about the ninja.exe edit, did I interpret that correctly?
- The three ninja options (Ctrl+F for "if it's on desktop related code only:"), are they all separate approaches or does pycore follow qgis?
- There is a stray heading I cannot interpret: "=== Building without Docker ===="