### PR TITLE
Fix building QGIS when WITH_GUI is false

### DIFF
--- a/src/providers/spatialite/qgsspatialitedataitems.cpp
+++ b/src/providers/spatialite/qgsspatialitedataitems.cpp
@@ -26,6 +26,9 @@
 #include "qgsvectorlayerexporter.h"
 #include "qgsvectorlayer.h"
 
+#include <QDir>
+#include <QFileInfo>
+
 
 bool SpatiaLiteUtils::deleteLayer( const QString &dbPath, const QString &tableName, QString &errCause )
 {


### PR DESCRIPTION
## Description

@nyalldawson , follow up to your header optimization work, which lead to build failure when WITH_GUI was not built. 