### PR TITLE
This allows building against QT 5.15.2.

### DIFF
--- a/src/quickgui/qgsquickutils.h
+++ b/src/quickgui/qgsquickutils.h
@@ -21,6 +21,7 @@
 #include <QString>
 #include <QUrl>
 #include <QtPositioning/QGeoCoordinate>
+#include <QModelIndex>
 
 #include <limits>
 


### PR DESCRIPTION
[trivial] Build against Qt 5.15.2 on Gentoo. #42143
cherry-pick dcf97f2d68f1641c35daba690bb2a1c7ec6140d2 from _master_ to _release-3_18_
@nyalldawson as requested you get this as a PR