### PR TITLE
Fix use of TAB to explore dialogs

### DIFF
--- a/src/ui/3d/animation3dwidget.ui
+++ b/src/ui/3d/animation3dwidget.ui
@@ -295,9 +295,11 @@
   <tabstop>btnRemoveKeyframe</tabstop>
   <tabstop>btnEditKeyframe</tabstop>
   <tabstop>btnDuplicateKeyframe</tabstop>
+  <tabstop>btnExportAnimation</tabstop>
   <tabstop>cboInterpolation</tabstop>
   <tabstop>btnPlayPause</tabstop>
   <tabstop>sliderTime</tabstop>
+  <tabstop>mLoopingCheckBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/3d/goochmaterialwidget.ui
+++ b/src/ui/3d/goochmaterialwidget.ui
@@ -197,22 +197,26 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>btnDiffuse</tabstop>
+  <tabstop>mDiffuseDataDefinedButton</tabstop>
   <tabstop>btnWarm</tabstop>
+  <tabstop>mWarmDataDefinedButton</tabstop>
   <tabstop>btnCool</tabstop>
+  <tabstop>mCoolDataDefinedButton</tabstop>
   <tabstop>btnSpecular</tabstop>
+  <tabstop>mSpecularDataDefinedButton</tabstop>
   <tabstop>spinShininess</tabstop>
   <tabstop>spinAlpha</tabstop>
   <tabstop>spinBeta</tabstop>

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -179,7 +179,7 @@
        <item>
         <widget class="QStackedWidget" name="m3DOptionsStackedWidget">
          <property name="currentIndex">
-          <number>3</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="mPageTerrain">
           <layout class="QVBoxLayout" name="verticalLayout_61">
@@ -205,8 +205,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>341</width>
-                <height>301</height>
+                <width>710</width>
+                <height>604</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutTerrain">
@@ -410,8 +410,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>77</width>
-                <height>47</height>
+                <width>710</width>
+                <height>604</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutLight">
@@ -494,8 +494,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>151</width>
-                <height>47</height>
+                <width>710</width>
+                <height>604</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutShadow">
@@ -584,7 +584,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>709</width>
+                <width>710</width>
                 <height>604</height>
                </rect>
               </property>
@@ -724,8 +724,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>304</width>
-                <height>701</height>
+                <width>696</width>
+                <height>661</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutAdvanced">
@@ -1041,19 +1041,30 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsmaplayercombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsMessageBar</class>
+   <extends>QWidget</extends>
+   <header>qgsmessagebar.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -1063,32 +1074,32 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsMapLayerComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsmaplayercombobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsLightsWidget</class>
    <extends>QWidget</extends>
    <header>qgslightswidget.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>QgsMessageBar</class>
-   <extends>QWidget</extends>
-   <header>qgsmessagebar.h</header>
-   <container>1</container>
-  </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>spinCameraFieldOfView</tabstop>
+  <tabstop>m3DOptionsListWidget</tabstop>
+  <tabstop>scrollAreaTerrain</tabstop>
   <tabstop>cboTerrainType</tabstop>
   <tabstop>cboTerrainLayer</tabstop>
   <tabstop>spinTerrainScale</tabstop>
   <tabstop>spinTerrainResolution</tabstop>
   <tabstop>spinTerrainSkirtHeight</tabstop>
+  <tabstop>terrainElevationOffsetSpinBox</tabstop>
   <tabstop>groupTerrainShading</tabstop>
+  <tabstop>scrollAreaLight</tabstop>
+  <tabstop>scrollAreaShadow</tabstop>
+  <tabstop>groupShadowRendering</tabstop>
+  <tabstop>scrollAreaCameraSkybox</tabstop>
+  <tabstop>cboCameraProjectionType</tabstop>
+  <tabstop>spinCameraFieldOfView</tabstop>
+  <tabstop>mCameraNavigationModeCombo</tabstop>
+  <tabstop>mCameraMovementSpeed</tabstop>
   <tabstop>groupSkyboxSettings</tabstop>
+  <tabstop>scrollAreaAdvanced</tabstop>
   <tabstop>spinMapResolution</tabstop>
   <tabstop>spinScreenError</tabstop>
   <tabstop>spinGroundError</tabstop>
@@ -1097,6 +1108,16 @@
   <tabstop>chkShowBoundingBoxes</tabstop>
   <tabstop>chkShowCameraViewCenter</tabstop>
   <tabstop>chkShowLightSourceOrigins</tabstop>
+  <tabstop>mFpsCounterCheckBox</tabstop>
+  <tabstop>edlGroupBox</tabstop>
+  <tabstop>edlStrengthSpinBox</tabstop>
+  <tabstop>edlDistanceSpinBox</tabstop>
+  <tabstop>mDebugShadowMapGroupBox</tabstop>
+  <tabstop>mDebugShadowMapCornerComboBox</tabstop>
+  <tabstop>mDebugShadowMapSizeSpinBox</tabstop>
+  <tabstop>mDebugDepthMapGroupBox</tabstop>
+  <tabstop>mDebugDepthMapCornerComboBox</tabstop>
+  <tabstop>mDebugDepthMapSizeSpinBox</tabstop>
  </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>

--- a/src/ui/3d/phongmaterialwidget.ui
+++ b/src/ui/3d/phongmaterialwidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>394</width>
-    <height>133</height>
+    <height>134</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -127,21 +127,24 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>btnDiffuse</tabstop>
+  <tabstop>mDiffuseDataDefinedButton</tabstop>
   <tabstop>btnAmbient</tabstop>
+  <tabstop>mAmbientDataDefinedButton</tabstop>
   <tabstop>btnSpecular</tabstop>
+  <tabstop>mSpecularDataDefinedButton</tabstop>
   <tabstop>spinShininess</tabstop>
  </tabstops>
  <resources/>

--- a/src/ui/3d/polygon3dsymbolwidget.ui
+++ b/src/ui/3d/polygon3dsymbolwidget.ui
@@ -278,9 +278,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsMaterialWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsmaterialwidget.h</header>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -289,20 +289,20 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <class>QgsMaterialWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsmaterialwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -314,8 +314,12 @@
   <tabstop>cboAltClamping</tabstop>
   <tabstop>cboAltBinding</tabstop>
   <tabstop>cboCullingMode</tabstop>
+  <tabstop>cboRenderedFacade</tabstop>
   <tabstop>chkAddBackFaces</tabstop>
   <tabstop>chkInvertNormals</tabstop>
+  <tabstop>groupEdges</tabstop>
+  <tabstop>spinEdgeWidth</tabstop>
+  <tabstop>btnEdgeColor</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/3d/qgs3drendererrulepropswidget.ui
+++ b/src/ui/3d/qgs3drendererrulepropswidget.ui
@@ -169,9 +169,11 @@
  <tabstops>
   <tabstop>scrollArea</tabstop>
   <tabstop>editDescription</tabstop>
+  <tabstop>mFilterRadio</tabstop>
   <tabstop>editFilter</tabstop>
   <tabstop>btnExpressionBuilder</tabstop>
   <tabstop>btnTestFilter</tabstop>
+  <tabstop>mElseRadio</tabstop>
   <tabstop>groupSymbol</tabstop>
  </tabstops>
  <resources>

--- a/src/ui/3d/qgslightswidget.ui
+++ b/src/ui/3d/qgslightswidget.ui
@@ -494,6 +494,9 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>mLightsListView</tabstop>
+  <tabstop>btnAddLight</tabstop>
+  <tabstop>btnRemoveLight</tabstop>
   <tabstop>spinPositionX</tabstop>
   <tabstop>spinPositionY</tabstop>
   <tabstop>spinPositionZ</tabstop>
@@ -502,6 +505,10 @@
   <tabstop>spinA0</tabstop>
   <tabstop>spinA1</tabstop>
   <tabstop>spinA2</tabstop>
+  <tabstop>dialAzimuth</tabstop>
+  <tabstop>spinBoxAzimuth</tabstop>
+  <tabstop>spinBoxAltitude</tabstop>
+  <tabstop>sliderAltitude</tabstop>
   <tabstop>btnDirectionalColor</tabstop>
   <tabstop>spinDirectionalIntensity</tabstop>
  </tabstops>

--- a/src/ui/3d/qgsmesh3dpropswidget.ui
+++ b/src/ui/3d/qgsmesh3dpropswidget.ui
@@ -407,6 +407,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
@@ -415,12 +421,6 @@
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -435,6 +435,7 @@
   <tabstop>mGroupBoxWireframe</tabstop>
   <tabstop>mSpinBoxWireframeLineWidth</tabstop>
   <tabstop>mColorButtonWireframe</tabstop>
+  <tabstop>mLodSlider</tabstop>
   <tabstop>mSpinBoxVerticaleScale</tabstop>
   <tabstop>mComboBoxDatasetVertical</tabstop>
   <tabstop>mCheckBoxVerticalMagnitudeRelative</tabstop>

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>573</width>
+    <width>581</width>
     <height>491</height>
    </rect>
   </property>
@@ -542,9 +542,10 @@ enhancement</string>
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsPointCloudAttributeComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgspointcloudattributecombobox.h</header>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsColorRampShaderWidget</class>
@@ -553,12 +554,33 @@ enhancement</string>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
+   <class>QgsPointCloudAttributeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgspointcloudattributecombobox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mRenderingStyleComboBox</tabstop>
+  <tabstop>mSingleColorBtn</tabstop>
+  <tabstop>mPointSizeSpinBox</tabstop>
+  <tabstop>mMaxScreenErrorSpinBox</tabstop>
+  <tabstop>mPointBudgetSpinBox</tabstop>
+  <tabstop>mShowBoundingBoxesCheckBox</tabstop>
+  <tabstop>mRenderingParameterComboBox</tabstop>
+  <tabstop>mColorRampShaderMinEdit</tabstop>
+  <tabstop>mColorRampShaderMaxEdit</tabstop>
+  <tabstop>mScalarRecalculateMinMaxButton</tabstop>
+  <tabstop>mContrastEnhancementAlgorithmComboBox</tabstop>
+  <tabstop>mRedMinLineEdit</tabstop>
+  <tabstop>mRedAttributeComboBox</tabstop>
+  <tabstop>mGreenAttributeComboBox</tabstop>
+  <tabstop>mBlueAttributeComboBox</tabstop>
+  <tabstop>mRedMaxLineEdit</tabstop>
+  <tabstop>mGreenMinLineEdit</tabstop>
+  <tabstop>mBlueMinLineEdit</tabstop>
+  <tabstop>mBlueMaxLineEdit</tabstop>
+  <tabstop>mGreenMaxLineEdit</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/3d/qgsvectorlayer3dpropertieswidget.ui
+++ b/src/ui/3d/qgsvectorlayer3dpropertieswidget.ui
@@ -81,6 +81,10 @@
    <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>spinZoomLevelsCount</tabstop>
+  <tabstop>chkShowBoundingBoxes</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
+++ b/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
@@ -58,7 +58,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
-       <widget class="QgsFieldExpressionWidget" name="mVisibilityExpressionWidget"/>
+       <widget class="QgsFieldExpressionWidget" name="mVisibilityExpressionWidget" native="true"/>
       </item>
      </layout>
     </widget>
@@ -112,11 +112,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
@@ -125,8 +120,23 @@
    <class>QgsFieldExpressionWidget</class>
    <extends>QWidget</extends>
    <header>qgsfieldexpressionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mShowLabelCheckBox</tabstop>
+  <tabstop>mShowAsGroupBoxCheckBox</tabstop>
+  <tabstop>mTitleLineEdit</tabstop>
+  <tabstop>mColumnCountSpinBox</tabstop>
+  <tabstop>mControlVisibilityGroupBox</tabstop>
+  <tabstop>mBackgroundColorButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/attributeformconfig/qgsattributetypeedit.ui
+++ b/src/ui/attributeformconfig/qgsattributetypeedit.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>751</width>
+    <width>752</width>
     <height>620</height>
    </rect>
   </property>
@@ -300,19 +300,23 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsExpressionLineEdit</class>
    <extends>QWidget</extends>
    <header>qgsexpressionlineedit.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>mAlias</tabstop>
+  <tabstop>mAliasExpressionButton</tabstop>
   <tabstop>isFieldEditableCheckBox</tabstop>
+  <tabstop>reuseLastValuesCheckBox</tabstop>
+  <tabstop>labelOnTopCheckBox</tabstop>
   <tabstop>mWidgetTypeComboBox</tabstop>
   <tabstop>notNullCheckBox</tabstop>
   <tabstop>mCheckBoxEnforceNotNull</tabstop>
@@ -322,6 +326,7 @@
   <tabstop>leConstraintExpressionDescription</tabstop>
   <tabstop>mCheckBoxEnforceExpression</tabstop>
   <tabstop>mExpressionWidget</tabstop>
+  <tabstop>mApplyDefaultValueOnUpdateCheckBox</tabstop>
  </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>

--- a/src/ui/callouts/widget_curvedlinecallout.ui
+++ b/src/ui/callouts/widget_curvedlinecallout.ui
@@ -516,14 +516,14 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsPropertyOverrideButton</class>
    <extends>QToolButton</extends>
    <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>
@@ -534,6 +534,11 @@
  </customwidgets>
  <tabstops>
   <tabstop>mCalloutLineStyleButton</tabstop>
+  <tabstop>mCurvatureSlider</tabstop>
+  <tabstop>mCurvatureSpinBox</tabstop>
+  <tabstop>mCalloutCurvatureDDBtn</tabstop>
+  <tabstop>mOrientationComboBox</tabstop>
+  <tabstop>mCalloutOrientationDDBtn</tabstop>
   <tabstop>mMinCalloutLengthSpin</tabstop>
   <tabstop>mMinCalloutWidthUnitWidget</tabstop>
   <tabstop>mMinCalloutLengthDDBtn</tabstop>
@@ -549,6 +554,10 @@
   <tabstop>mAnchorPointDDBtn</tabstop>
   <tabstop>mLabelAnchorPointComboBox</tabstop>
   <tabstop>mLabelAnchorPointDDBtn</tabstop>
+  <tabstop>mOriginXDDBtn</tabstop>
+  <tabstop>mOriginYDDBtn</tabstop>
+  <tabstop>mDestXDDBtn</tabstop>
+  <tabstop>mDestYDDBtn</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/callouts/widget_simplelinecallout.ui
+++ b/src/ui/callouts/widget_simplelinecallout.ui
@@ -449,14 +449,14 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsPropertyOverrideButton</class>
    <extends>QToolButton</extends>
    <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>
@@ -482,6 +482,10 @@
   <tabstop>mAnchorPointDDBtn</tabstop>
   <tabstop>mLabelAnchorPointComboBox</tabstop>
   <tabstop>mLabelAnchorPointDDBtn</tabstop>
+  <tabstop>mOriginXDDBtn</tabstop>
+  <tabstop>mOriginYDDBtn</tabstop>
+  <tabstop>mDestXDDBtn</tabstop>
+  <tabstop>mDestYDDBtn</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/editorwidgets/qgscheckboxconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgscheckboxconfigdlgbase.ui
@@ -102,6 +102,11 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>leCheckedState</tabstop>
+  <tabstop>leUncheckedState</tabstop>
+  <tabstop>mDisplayAsTextComboBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/editorwidgets/qgsexternalresourceconfigdlg.ui
+++ b/src/ui/editorwidgets/qgsexternalresourceconfigdlg.ui
@@ -46,8 +46,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>467</width>
-        <height>715</height>
+        <width>481</width>
+        <height>690</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -479,15 +479,15 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsPropertyOverrideButton</class>
@@ -498,6 +498,9 @@
  <tabstops>
   <tabstop>scrollArea</tabstop>
   <tabstop>mRootPath</tabstop>
+  <tabstop>mRootPathExpression</tabstop>
+  <tabstop>mRootPathButton</tabstop>
+  <tabstop>mRootPathPropertyOverrideButton</tabstop>
   <tabstop>mRelativeGroupBox</tabstop>
   <tabstop>mRelativeProject</tabstop>
   <tabstop>mRelativeDefault</tabstop>
@@ -508,13 +511,16 @@
   <tabstop>mFileWidgetFilterLineEdit</tabstop>
   <tabstop>mUseLink</tabstop>
   <tabstop>mFullUrl</tabstop>
-  <tabstop>mDocumentViewerGroupBox</tabstop>
   <tabstop>mDocumentViewerContentComboBox</tabstop>
+  <tabstop>mDocumentViewerContentExpression</tabstop>
+  <tabstop>mDocumentViewerContentPropertyOverrideButton</tabstop>
+  <tabstop>mDocumentViewerWidth</tabstop>
+  <tabstop>mDocumentViewerHeight</tabstop>
  </tabstops>
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="mRelativeButtonGroup"/>
   <buttongroup name="mStorageButtonGroup"/>
+  <buttongroup name="mRelativeButtonGroup"/>
  </buttongroups>
 </ui>

--- a/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>470</width>
-    <height>502</height>
+    <height>540</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -82,11 +82,11 @@
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Display expression Ⓘ</string>
-     </property>
      <property name="toolTip">
       <string>This setting is not saved in the style. It is changing the display name on the referenced layer.</string>
+     </property>
+     <property name="text">
+      <string>Display expression Ⓘ</string>
      </property>
     </widget>
    </item>
@@ -246,6 +246,8 @@
   <tabstop>mRemoveFilterButton</tabstop>
   <tabstop>mFilterFieldsList</tabstop>
   <tabstop>mCbxChainFilters</tabstop>
+  <tabstop>mEditExpression</tabstop>
+  <tabstop>mFilterExpression</tabstop>
  </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>

--- a/src/ui/editorwidgets/qgsvaluerelationconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsvaluerelationconfigdlgbase.ui
@@ -153,25 +153,25 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsFieldComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsfieldcombobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsMapLayerComboBox</class>
+   <class>QgsFieldComboBox</class>
    <extends>QComboBox</extends>
-   <header>qgsmaplayercombobox.h</header>
+   <header>qgsfieldcombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsFieldExpressionWidget</class>
    <extends>QWidget</extends>
    <header>qgsfieldexpressionwidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsmaplayercombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -181,6 +181,7 @@
   <tabstop>mAllowNull</tabstop>
   <tabstop>mOrderByValue</tabstop>
   <tabstop>mAllowMulti</tabstop>
+  <tabstop>mNofColumns</tabstop>
   <tabstop>mUseCompleter</tabstop>
   <tabstop>mEditExpression</tabstop>
   <tabstop>mFilterExpression</tabstop>

--- a/src/ui/effects/widget_blur.ui
+++ b/src/ui/effects/widget_blur.ui
@@ -141,14 +141,15 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsUnitSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsunitselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsBlendModeComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsblendmodecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsEffectDrawModeComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgseffectdrawmodecombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsOpacityWidget</class>
@@ -156,10 +157,16 @@
    <header>qgsopacitywidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsEffectDrawModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgseffectdrawmodecombobox.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mBlurTypeCombo</tabstop>
   <tabstop>mBlurStrengthSpnBx</tabstop>
+  <tabstop>mBlurUnitWidget</tabstop>
   <tabstop>mOpacityWidget</tabstop>
   <tabstop>mBlendCmbBx</tabstop>
   <tabstop>mDrawModeComboBox</tabstop>

--- a/src/ui/effects/widget_glow.ui
+++ b/src/ui/effects/widget_glow.ui
@@ -217,36 +217,15 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsBlendModeComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsblendmodecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsEffectDrawModeComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgseffectdrawmodecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsOpacityWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsopacitywidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>
@@ -255,16 +234,33 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsBlendModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsblendmodecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsOpacityWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsopacitywidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsColorRampButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorrampbutton.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsEffectDrawModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgseffectdrawmodecombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mSpreadSpnBx</tabstop>
   <tabstop>mSpreadUnitWidget</tabstop>
   <tabstop>mBlurRadiusSpnBx</tabstop>
+  <tabstop>mBlurUnitWidget</tabstop>
   <tabstop>mOpacityWidget</tabstop>
   <tabstop>radioSingleColor</tabstop>
   <tabstop>mColorBtn</tabstop>

--- a/src/ui/effects/widget_shadoweffect.ui
+++ b/src/ui/effects/widget_shadoweffect.ui
@@ -251,25 +251,31 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
+   <class>QgsUnitSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsunitselectionwidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsBlendModeComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsblendmodecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsEffectDrawModeComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgseffectdrawmodecombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsOpacityWidget</class>
@@ -278,15 +284,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsUnitSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsunitselectionwidget.h</header>
-   <container>1</container>
+   <class>QgsEffectDrawModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgseffectdrawmodecombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -295,6 +295,7 @@
   <tabstop>mShadowOffsetSpnBx</tabstop>
   <tabstop>mOffsetUnitWidget</tabstop>
   <tabstop>mShadowRadiuSpnBx</tabstop>
+  <tabstop>mBlurUnitWidget</tabstop>
   <tabstop>mOpacityWidget</tabstop>
   <tabstop>mShadowColorBtn</tabstop>
   <tabstop>mShadowBlendCmbBx</tabstop>

--- a/src/ui/georeferencer/qgstransformsettingsdialogbase.ui
+++ b/src/ui/georeferencer/qgstransformsettingsdialogbase.ui
@@ -340,15 +340,14 @@
   <tabstop>cmbTransformType</tabstop>
   <tabstop>cmbResampling</tabstop>
   <tabstop>mCrsSelector</tabstop>
-  <tabstop>mOutputRaster</tabstop>
   <tabstop>cmbCompressionComboBox</tabstop>
+  <tabstop>saveGcpCheckBox</tabstop>
   <tabstop>mWorldFileCheckBox</tabstop>
   <tabstop>cbxZeroAsTrans</tabstop>
   <tabstop>cbxUserResolution</tabstop>
   <tabstop>dsbHorizRes</tabstop>
   <tabstop>dsbVerticalRes</tabstop>
-  <tabstop>mPdfMap</tabstop>
-  <tabstop>mPdfReport</tabstop>
+  <tabstop>cbxLoadInQgisWhenDone</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/labeling/qgslabelingrulepropswidget.ui
+++ b/src/ui/labeling/qgslabelingrulepropswidget.ui
@@ -119,7 +119,7 @@
                </sizepolicy>
               </property>
               <property name="icon">
-               <iconset resource="../../images/images.qrc">
+               <iconset resource="../../../images/images.qrc">
                 <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
               </property>
              </widget>
@@ -185,23 +185,25 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsScaleRangeWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsscalerangewidget.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsScaleRangeWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalerangewidget.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
   <tabstop>editDescription</tabstop>
+  <tabstop>mFilterRadio</tabstop>
   <tabstop>editFilter</tabstop>
   <tabstop>btnExpressionBuilder</tabstop>
   <tabstop>btnTestFilter</tabstop>
+  <tabstop>mElseRadio</tabstop>
   <tabstop>groupScale</tabstop>
   <tabstop>groupSettings</tabstop>
  </tabstops>

--- a/src/ui/labeling/qgslabellineanchorwidgetbase.ui
+++ b/src/ui/labeling/qgslabellineanchorwidgetbase.ui
@@ -111,6 +111,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsPropertyOverrideButton</class>
    <extends>QToolButton</extends>
    <header>qgspropertyoverridebutton.h</header>
@@ -121,12 +126,13 @@
    <header>qgspanelwidget.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mPercentPlacementComboBox</tabstop>
+  <tabstop>mLinePlacementDDBtn</tabstop>
+  <tabstop>mCustomPlacementSpinBox</tabstop>
+  <tabstop>mAnchorTypeComboBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/labeling/qgslabelobstaclesettingswidgetbase.ui
+++ b/src/ui/labeling/qgslabelobstaclesettingswidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>237</width>
+    <width>249</width>
     <height>225</height>
    </rect>
   </property>
@@ -140,6 +140,11 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mObstacleFactorSlider</tabstop>
+  <tabstop>mObstacleFactorDDBtn</tabstop>
+  <tabstop>mObstacleTypeComboBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/labeling/qgslabelpropertydialogbase.ui
+++ b/src/ui/labeling/qgslabelpropertydialogbase.ui
@@ -40,7 +40,7 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-108</y>
+        <y>0</y>
         <width>419</width>
         <height>731</height>
        </rect>
@@ -679,26 +679,26 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsScaleWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsscalewidget.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScaleWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalewidget.h</header>
   </customwidget>
   <customwidget>
    <class>QgsColorButton</class>
@@ -722,14 +722,18 @@
   <tabstop>mFontItalicBtn</tabstop>
   <tabstop>mFontSizeSpinBox</tabstop>
   <tabstop>mFontColorButton</tabstop>
+  <tabstop>mMultiLineAlignComboBox</tabstop>
+  <tabstop>mBufferDrawChkbx</tabstop>
   <tabstop>mBufferSizeSpinBox</tabstop>
   <tabstop>mBufferColorButton</tabstop>
+  <tabstop>mShowCalloutChkbx</tabstop>
   <tabstop>mLabelDistanceSpinBox</tabstop>
   <tabstop>mXCoordSpinBox</tabstop>
   <tabstop>mYCoordSpinBox</tabstop>
   <tabstop>mHaliComboBox</tabstop>
   <tabstop>mValiComboBox</tabstop>
   <tabstop>mRotationSpinBox</tabstop>
+  <tabstop>mLabelAllPartsCheckBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/layout/qgslayout3dmapwidgetbase.ui
+++ b/src/ui/layout/qgslayout3dmapwidgetbase.ui
@@ -54,9 +54,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-128</y>
-        <width>510</width>
-        <height>698</height>
+        <y>0</y>
+        <width>538</width>
+        <height>590</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -222,6 +222,17 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>mCopySettingsButton</tabstop>
+  <tabstop>mCenterXSpinBox</tabstop>
+  <tabstop>mCenterYSpinBox</tabstop>
+  <tabstop>mCenterZSpinBox</tabstop>
+  <tabstop>mDistanceToCenterSpinBox</tabstop>
+  <tabstop>mPitchAngleSpinBox</tabstop>
+  <tabstop>mHeadingAngleSpinBox</tabstop>
+  <tabstop>mPoseFromViewButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/layout/qgslayoutatlaswidgetbase.ui
+++ b/src/ui/layout/qgslayoutatlaswidgetbase.ui
@@ -109,10 +109,10 @@
          </property>
          <property name="geometry">
           <rect>
-           <x>-122</x>
-           <y>-223</y>
-           <width>525</width>
-           <height>673</height>
+           <x>0</x>
+           <y>0</y>
+           <width>417</width>
+           <height>354</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="mainLayout">
@@ -326,30 +326,32 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsMapLayerComboBox</class>
-   <extends>QComboBox</extends>
-   <header location="global">qgsmaplayercombobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsFieldExpressionWidget</class>
    <extends>QWidget</extends>
    <header>qgsfieldexpressionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsmaplayercombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mUseAtlasCheckBox</tabstop>
+  <tabstop>scrollArea</tabstop>
   <tabstop>mConfigurationGroup</tabstop>
   <tabstop>mAtlasCoverageLayerComboBox</tabstop>
   <tabstop>mAtlasHideCoverageCheckBox</tabstop>
@@ -357,41 +359,14 @@
   <tabstop>mAtlasFeatureFilterEdit</tabstop>
   <tabstop>mAtlasFeatureFilterButton</tabstop>
   <tabstop>mAtlasSortFeatureCheckBox</tabstop>
-  <tabstop>mAtlasSortExpressionWidget</tabstop>
   <tabstop>mAtlasSortFeatureDirectionButton</tabstop>
   <tabstop>mOutputGroup</tabstop>
   <tabstop>mAtlasFilenamePatternEdit</tabstop>
   <tabstop>mAtlasFilenameExpressionButton</tabstop>
   <tabstop>mAtlasSingleFileCheckBox</tabstop>
-  <tabstop>scrollArea</tabstop>
+  <tabstop>mAtlasFileFormat</tabstop>
  </tabstops>
  <resources>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/src/ui/layout/qgslayoutattributeselectiondialogbase.ui
+++ b/src/ui/layout/qgslayoutattributeselectiondialogbase.ui
@@ -243,11 +243,12 @@
   <tabstop>mAddColumnPushButton</tabstop>
   <tabstop>mRemoveColumnPushButton</tabstop>
   <tabstop>mResetColumnsPushButton</tabstop>
+  <tabstop>mClearColumnsPushButton</tabstop>
   <tabstop>mSortColumnTableView</tabstop>
   <tabstop>mSortColumnUpPushButton</tabstop>
   <tabstop>mSortColumnDownPushButton</tabstop>
+  <tabstop>mAddSortColumnPushButton</tabstop>
   <tabstop>mRemoveSortColumnPushButton</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>

--- a/src/ui/layout/qgslayoutattributetablewidgetbase.ui
+++ b/src/ui/layout/qgslayoutattributetablewidgetbase.ui
@@ -54,9 +54,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-629</y>
+        <y>-551</y>
         <width>394</width>
-        <height>1419</height>
+        <height>1343</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -686,10 +686,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
-   <container>1</container>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsScrollArea</class>
@@ -698,9 +702,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsMapLayerComboBox</class>
-   <extends>QComboBox</extends>
-   <header location="global">qgsmaplayercombobox.h</header>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsColorButton</class>
@@ -709,29 +713,25 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsFontButton</class>
    <extends>QToolButton</extends>
    <header>qgsfontbutton.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsmaplayercombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsLayoutItemComboBox</class>
    <extends>QComboBox</extends>
    <header>qgslayoutitemcombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -760,6 +760,7 @@
   <tabstop>mEmptyMessageLineEdit</tabstop>
   <tabstop>mBackgroundColorButton</tabstop>
   <tabstop>mAdvancedCustomizationButton</tabstop>
+  <tabstop>mUseConditionalStylingCheckBox</tabstop>
   <tabstop>mWrapStringLineEdit</tabstop>
   <tabstop>mWrapBehaviorComboBox</tabstop>
   <tabstop>mShowGridGroupCheckBox</tabstop>

--- a/src/ui/layout/qgslayoutlabelwidgetbase.ui
+++ b/src/ui/layout/qgslayoutlabelwidgetbase.ui
@@ -62,7 +62,7 @@
         <x>0</x>
         <y>0</y>
         <width>358</width>
-        <height>680</height>
+        <height>682</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -374,6 +374,11 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
@@ -386,20 +391,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsFontButton</class>
    <extends>QToolButton</extends>
    <header>qgsfontbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -408,6 +408,7 @@
   <tabstop>mTextEdit</tabstop>
   <tabstop>mHtmlCheckBox</tabstop>
   <tabstop>mInsertExpressionButton</tabstop>
+  <tabstop>mDynamicTextButton</tabstop>
   <tabstop>mAppearanceGroup</tabstop>
   <tabstop>mFontButton</tabstop>
   <tabstop>mFontColorButton</tabstop>
@@ -416,6 +417,7 @@
   <tabstop>mLeftRadioButton</tabstop>
   <tabstop>mCenterRadioButton</tabstop>
   <tabstop>mRightRadioButton</tabstop>
+  <tabstop>mJustifyRadioButton</tabstop>
   <tabstop>mTopRadioButton</tabstop>
   <tabstop>mMiddleRadioButton</tabstop>
   <tabstop>mBottomRadioButton</tabstop>
@@ -423,7 +425,7 @@
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="buttonGroup_2"/>
   <buttongroup name="buttonGroup"/>
+  <buttongroup name="buttonGroup_2"/>
  </buttongroups>
 </ui>

--- a/src/ui/layout/qgslayoutlegendnodewidgetbase.ui
+++ b/src/ui/layout/qgslayoutlegendnodewidgetbase.ui
@@ -194,15 +194,15 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsPanelWidget</class>
    <extends>QWidget</extends>
    <header>qgspanelwidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsLegendPatchShapeButton</class>
@@ -222,6 +222,10 @@
   <tabstop>mPatchShapeButton</tabstop>
   <tabstop>mWidthSpinBox</tabstop>
   <tabstop>mHeightSpinBox</tabstop>
+  <tabstop>mCustomSymbolCheckBox</tabstop>
+  <tabstop>mCustomSymbolButton</tabstop>
+  <tabstop>mColumnBreakBeforeCheckBox</tabstop>
+  <tabstop>mColumnSplitBehaviorComboBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/layout/qgslayoutlegendwidgetbase.ui
+++ b/src/ui/layout/qgslayoutlegendwidgetbase.ui
@@ -63,9 +63,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-1031</y>
-        <width>387</width>
-        <height>2728</height>
+        <y>0</y>
+        <width>367</width>
+        <height>2191</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -1315,10 +1315,14 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsScrollArea</class>
@@ -1327,9 +1331,25 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFontButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsfontbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsAlignmentComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsalignmentcombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>
@@ -1338,9 +1358,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
+   <class>QgsLayerTreeView</class>
+   <extends>QTreeView</extends>
+   <header>qgslayertreeview.h</header>
   </customwidget>
   <customwidget>
    <class>QgsLayoutItemComboBox</class>
@@ -1348,29 +1368,9 @@
    <header>qgslayoutitemcombobox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsFontButton</class>
-   <extends>QToolButton</extends>
-   <header>qgsfontbutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsLayerTreeView</class>
-   <extends>QTreeView</extends>
-   <header>qgslayertreeview.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsLegendFilterButton</class>
    <extends>QToolButton</extends>
    <header location="global">qgslegendfilterbutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsAlignmentComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsalignmentcombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -1392,6 +1392,7 @@
   <tabstop>mAddToolButton</tabstop>
   <tabstop>mRemoveToolButton</tabstop>
   <tabstop>mEditPushButton</tabstop>
+  <tabstop>mLayerExpressionButton</tabstop>
   <tabstop>mCountToolButton</tabstop>
   <tabstop>mExpressionFilterButton</tabstop>
   <tabstop>mFilterByMapCheckBox</tabstop>
@@ -1414,6 +1415,8 @@
   <tabstop>mSymbolsColGroupBox</tabstop>
   <tabstop>mSymbolWidthSpinBox</tabstop>
   <tabstop>mSymbolHeightSpinBox</tabstop>
+  <tabstop>mMinSymbolSizeSpinBox</tabstop>
+  <tabstop>mMaxSymbolSizeSpinBox</tabstop>
   <tabstop>mRasterStrokeGroupBox</tabstop>
   <tabstop>mRasterStrokeColorButton</tabstop>
   <tabstop>mRasterStrokeWidthSpinBox</tabstop>
@@ -1434,7 +1437,6 @@
   <tabstop>mBoxSpaceSpinBox</tabstop>
   <tabstop>mColumnSpaceSpinBox</tabstop>
   <tabstop>mLineSpacingSpinBox</tabstop>
-  <tabstop>mLayerExpressionButton</tabstop>
  </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>

--- a/src/ui/layout/qgslayoutmanualtablewidgetbase.ui
+++ b/src/ui/layout/qgslayoutmanualtablewidgetbase.ui
@@ -54,9 +54,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
+        <y>-76</y>
         <width>394</width>
-        <height>914</height>
+        <height>868</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -464,10 +464,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
-   <container>1</container>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsScrollArea</class>
@@ -482,14 +481,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsFontButton</class>
    <extends>QToolButton</extends>
    <header>qgsfontbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -499,6 +499,7 @@
   <tabstop>groupBox_6</tabstop>
   <tabstop>mDrawEmptyCheckBox</tabstop>
   <tabstop>mMarginSpinBox</tabstop>
+  <tabstop>mHeaderModeComboBox</tabstop>
   <tabstop>mBackgroundColorButton</tabstop>
   <tabstop>mAdvancedCustomizationButton</tabstop>
   <tabstop>mWrapBehaviorComboBox</tabstop>
@@ -507,6 +508,9 @@
   <tabstop>mGridColorButton</tabstop>
   <tabstop>mDrawHorizontalGrid</tabstop>
   <tabstop>mDrawVerticalGrid</tabstop>
+  <tabstop>mHeaderFontToolButton</tabstop>
+  <tabstop>mHeaderHAlignmentComboBox</tabstop>
+  <tabstop>mContentFontToolButton</tabstop>
   <tabstop>frameGroupBox</tabstop>
   <tabstop>mResizeModeComboBox</tabstop>
   <tabstop>mAddFramePushButton</tabstop>

--- a/src/ui/layout/qgslayoutmapgridwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapgridwidgetbase.ui
@@ -48,8 +48,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>492</width>
-        <height>1225</height>
+        <width>493</width>
+        <height>1620</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -1111,14 +1111,19 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -1128,19 +1133,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsFontButton</class>
-   <extends>QToolButton</extends>
-   <header>qgsfontbutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsPropertyOverrideButton</class>
    <extends>QToolButton</extends>
    <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsSymbolButton</class>
@@ -1148,20 +1149,19 @@
    <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsBlendModeComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsblendmodecombobox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsProjectionSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsprojectionselectionwidget.h</header>
+   <class>QgsFontButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsfontbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -1198,6 +1198,14 @@
   <tabstop>mGridFramePenColorButton</tabstop>
   <tabstop>mGridFrameFill1ColorButton</tabstop>
   <tabstop>mGridFrameFill2ColorButton</tabstop>
+  <tabstop>mFrameDivisionsLeftComboBox</tabstop>
+  <tabstop>mFrameDivisionsLeftDDBtn</tabstop>
+  <tabstop>mFrameDivisionsRightComboBox</tabstop>
+  <tabstop>mFrameDivisionsRightDDBtn</tabstop>
+  <tabstop>mFrameDivisionsTopComboBox</tabstop>
+  <tabstop>mFrameDivisionsTopDDBtn</tabstop>
+  <tabstop>mFrameDivisionsBottomComboBox</tabstop>
+  <tabstop>mFrameDivisionsBottomDDBtn</tabstop>
   <tabstop>mCheckGridLeftSide</tabstop>
   <tabstop>mCheckGridRightSide</tabstop>
   <tabstop>mCheckGridTopSide</tabstop>
@@ -1209,12 +1217,20 @@
   <tabstop>mDrawAnnotationGroupBox</tabstop>
   <tabstop>mAnnotationFormatComboBox</tabstop>
   <tabstop>mAnnotationFormatButton</tabstop>
+  <tabstop>mAnnotationDisplayLeftComboBox</tabstop>
+  <tabstop>mAnnotationDisplayLeftDDBtn</tabstop>
   <tabstop>mAnnotationPositionLeftComboBox</tabstop>
   <tabstop>mAnnotationDirectionComboBoxLeft</tabstop>
+  <tabstop>mAnnotationDisplayRightComboBox</tabstop>
+  <tabstop>mAnnotationDisplayRightDDBtn</tabstop>
   <tabstop>mAnnotationPositionRightComboBox</tabstop>
   <tabstop>mAnnotationDirectionComboBoxRight</tabstop>
+  <tabstop>mAnnotationDisplayTopComboBox</tabstop>
+  <tabstop>mAnnotationDisplayTopDDBtn</tabstop>
   <tabstop>mAnnotationPositionTopComboBox</tabstop>
   <tabstop>mAnnotationDirectionComboBoxTop</tabstop>
+  <tabstop>mAnnotationDisplayBottomComboBox</tabstop>
+  <tabstop>mAnnotationDisplayBottomDDBtn</tabstop>
   <tabstop>mAnnotationPositionBottomComboBox</tabstop>
   <tabstop>mAnnotationDirectionComboBoxBottom</tabstop>
   <tabstop>mAnnotationFontButton</tabstop>

--- a/src/ui/layout/qgslayoutmaplabelingwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmaplabelingwidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>211</width>
+    <width>318</width>
     <height>408</height>
    </rect>
   </property>
@@ -147,19 +147,19 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>
    <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <header location="global">qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -168,6 +168,14 @@
    <header>qgslayoutunitscombobox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mLabelBoundarySpinBox</tabstop>
+  <tabstop>mLabelBoundaryUnitsCombo</tabstop>
+  <tabstop>mLabelMarginDDBtn</tabstop>
+  <tabstop>mShowPartialLabelsCheckBox</tabstop>
+  <tabstop>mBlockingItemsListView</tabstop>
+  <tabstop>mShowUnplacedCheckBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/layout/qgslayoutmapwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapwidgetbase.ui
@@ -90,7 +90,7 @@
         <x>0</x>
         <y>0</y>
         <width>548</width>
-        <height>1284</height>
+        <height>1336</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -1011,10 +1011,9 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
@@ -1022,9 +1021,36 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsBlendModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsblendmodecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsmaplayercombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>
@@ -1037,32 +1063,6 @@
    <extends>QComboBox</extends>
    <header>qgslayoutitemcombobox.h</header>
   </customwidget>
-  <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsMapLayerComboBox</class>
-   <extends>QComboBox</extends>
-   <header location="global">qgsmaplayercombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsBlendModeComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsblendmodecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsProjectionSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsprojectionselectionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
-  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
@@ -1072,6 +1072,7 @@
   <tabstop>mMapRotationSpinBox</tabstop>
   <tabstop>mMapRotationDDBtn</tabstop>
   <tabstop>mCrsSelector</tabstop>
+  <tabstop>mCRSDDBtn</tabstop>
   <tabstop>mDrawCanvasItemsCheckBox</tabstop>
   <tabstop>mFollowVisibilityPresetCheckBox</tabstop>
   <tabstop>mFollowVisibilityPresetCombo</tabstop>
@@ -1089,6 +1090,11 @@
   <tabstop>mXMaxDDBtn</tabstop>
   <tabstop>mYMaxLineEdit</tabstop>
   <tabstop>mYMaxDDBtn</tabstop>
+  <tabstop>mTemporalCheckBox</tabstop>
+  <tabstop>mStartDateTime</tabstop>
+  <tabstop>mStartDateTimeDDBtn</tabstop>
+  <tabstop>mEndDateTime</tabstop>
+  <tabstop>mEndDateTimeDDBtn</tabstop>
   <tabstop>mAtlasCheckBox</tabstop>
   <tabstop>mAtlasMarginRadio</tabstop>
   <tabstop>mAtlasMarginSpinBox</tabstop>

--- a/src/ui/layout/qgslayoutmarkerwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmarkerwidgetbase.ui
@@ -56,7 +56,7 @@
         <x>0</x>
         <y>0</y>
         <width>306</width>
-        <height>247</height>
+        <height>249</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -167,26 +167,26 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsSymbolButton</class>
    <extends>QToolButton</extends>
    <header>qgssymbolbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsLayoutItemComboBox</class>
@@ -195,9 +195,14 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>groupBox</tabstop>
   <tabstop>scrollArea</tabstop>
+  <tabstop>groupBox</tabstop>
   <tabstop>mShapeStyleButton</tabstop>
+  <tabstop>mRotationGroupBox</tabstop>
+  <tabstop>mRotationFromMapCheckBox</tabstop>
+  <tabstop>mMapComboBox</tabstop>
+  <tabstop>mNorthTypeComboBox</tabstop>
+  <tabstop>mNorthOffsetSpinBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/layout/qgslayoutpagepropertieswidget.ui
+++ b/src/ui/layout/qgslayoutpagepropertieswidget.ui
@@ -256,6 +256,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsRatioLockButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsratiolockbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
@@ -266,20 +272,14 @@
    <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsRatioLockButton</class>
+   <class>QgsSymbolButton</class>
    <extends>QToolButton</extends>
-   <header>qgsratiolockbutton.h</header>
-   <container>1</container>
+   <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsLayoutUnitsComboBox</class>
    <extends>QComboBox</extends>
    <header>qgslayoutunitscombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -289,9 +289,9 @@
   <tabstop>mOrientationDDBtn</tabstop>
   <tabstop>mWidthSpin</tabstop>
   <tabstop>mWidthDDBtn</tabstop>
-  <tabstop>mLockAspectRatio</tabstop>
   <tabstop>mHeightSpin</tabstop>
   <tabstop>mHeightDDBtn</tabstop>
+  <tabstop>mLockAspectRatio</tabstop>
   <tabstop>mSizeUnitsComboBox</tabstop>
   <tabstop>mExcludePageCheckBox</tabstop>
   <tabstop>mExcludePageDDBtn</tabstop>

--- a/src/ui/layout/qgslayoutpicturewidgetbase.ui
+++ b/src/ui/layout/qgslayoutpicturewidgetbase.ui
@@ -60,9 +60,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-4</y>
+        <y>-368</y>
         <width>520</width>
-        <height>881</height>
+        <height>845</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -557,10 +557,20 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsColorButton</class>
@@ -571,29 +581,19 @@
   <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>
    <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <header location="global">qgscollapsiblegroupbox.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsLayoutItemComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgslayoutitemcombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsImageSourceLineEdit</class>
    <extends>QWidget</extends>
    <header>qgsfilecontentsourcelineedit.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsLayoutItemComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgslayoutitemcombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsSvgSourceLineEdit</class>
@@ -607,6 +607,7 @@
   <tabstop>mRadioSVG</tabstop>
   <tabstop>mRadioRaster</tabstop>
   <tabstop>mImageSourceLineEdit</tabstop>
+  <tabstop>mSourceDDBtn</tabstop>
   <tabstop>viewGroups</tabstop>
   <tabstop>viewImages</tabstop>
   <tabstop>mSvgSourceLineEdit</tabstop>

--- a/src/ui/layout/qgslayoutpolylinewidgetbase.ui
+++ b/src/ui/layout/qgslayoutpolylinewidgetbase.ui
@@ -54,9 +54,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-83</y>
+        <y>0</y>
         <width>318</width>
-        <height>459</height>
+        <height>426</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -330,21 +330,15 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsColorButton</class>
@@ -353,15 +347,36 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
   <tabstop>groupBox</tabstop>
   <tabstop>mLineStyleButton</tabstop>
+  <tabstop>mArrowMarkersGroupBox</tabstop>
+  <tabstop>mRadioStartNoMarker</tabstop>
+  <tabstop>mRadioStartArrow</tabstop>
+  <tabstop>mRadioStartSVG</tabstop>
+  <tabstop>mStartMarkerLineEdit</tabstop>
+  <tabstop>mStartMarkerToolButton</tabstop>
+  <tabstop>mRadioEndNoMarker</tabstop>
+  <tabstop>mRadioEndArrow</tabstop>
+  <tabstop>mRadioEndSvg</tabstop>
+  <tabstop>mEndMarkerLineEdit</tabstop>
+  <tabstop>mEndMarkerToolButton</tabstop>
+  <tabstop>mArrowHeadStrokeColorButton</tabstop>
+  <tabstop>mArrowHeadFillColorButton</tabstop>
+  <tabstop>mStrokeWidthSpinBox</tabstop>
+  <tabstop>mArrowHeadWidthSpinBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/layout/qgsreportorganizerwidgetbase.ui
+++ b/src/ui/layout/qgsreportorganizerwidgetbase.ui
@@ -109,8 +109,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>687</width>
-        <height>207</height>
+        <width>302</width>
+        <height>232</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -130,33 +130,13 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>mViewSections</tabstop>
+  <tabstop>mButtonAddSection</tabstop>
+  <tabstop>mButtonRemoveSection</tabstop>
+  <tabstop>scrollArea</tabstop>
+ </tabstops>
  <resources>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/src/ui/mesh/qgsmeshcalculatordialogbase.ui
+++ b/src/ui/mesh/qgsmeshcalculatordialogbase.ui
@@ -621,30 +621,64 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsMapLayerComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsmaplayercombobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsFileWidget</class>
    <extends>QWidget</extends>
    <header>qgsfilewidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsmaplayercombobox.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>mDatasetsListWidget</tabstop>
+  <tabstop>mOutputOnFileRadioButton</tabstop>
+  <tabstop>mOutputVirtualRadioButton</tabstop>
+  <tabstop>mOutputFormatComboBox</tabstop>
+  <tabstop>mOutputGroupNameLineEdit</tabstop>
+  <tabstop>useExtentCb</tabstop>
+  <tabstop>useMaskCb</tabstop>
+  <tabstop>cboLayerMask</tabstop>
+  <tabstop>mCurrentLayerExtentButton</tabstop>
   <tabstop>mXMinSpinBox</tabstop>
   <tabstop>mXMaxSpinBox</tabstop>
   <tabstop>mYMinSpinBox</tabstop>
   <tabstop>mYMaxSpinBox</tabstop>
+  <tabstop>mAllTimesButton</tabstop>
+  <tabstop>mStartTimeComboBox</tabstop>
+  <tabstop>mEndTimeComboBox</tabstop>
   <tabstop>mPlusPushButton</tabstop>
   <tabstop>mMultiplyPushButton</tabstop>
+  <tabstop>mOpenBracketPushButton</tabstop>
+  <tabstop>mMinButton</tabstop>
+  <tabstop>mIfButton</tabstop>
+  <tabstop>mSumAggrButton</tabstop>
   <tabstop>mMinusPushButton</tabstop>
   <tabstop>mDividePushButton</tabstop>
+  <tabstop>mCloseBracketPushButton</tabstop>
+  <tabstop>mMaxButton</tabstop>
+  <tabstop>mAndButton</tabstop>
+  <tabstop>mMaxAggrButton</tabstop>
+  <tabstop>mLessButton</tabstop>
+  <tabstop>mGreaterButton</tabstop>
+  <tabstop>mEqualButton</tabstop>
+  <tabstop>mAbsButton</tabstop>
+  <tabstop>mOrButton</tabstop>
+  <tabstop>mMinAggrButton</tabstop>
+  <tabstop>mLesserEqualButton</tabstop>
+  <tabstop>mGreaterEqualButton</tabstop>
+  <tabstop>mNotEqualButton</tabstop>
+  <tabstop>mPowButton</tabstop>
+  <tabstop>mNotButton</tabstop>
+  <tabstop>mAverageAggrButton</tabstop>
+  <tabstop>mNoDataButton</tabstop>
   <tabstop>mExpressionTextEdit</tabstop>
  </tabstops>
  <resources/>

--- a/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
+++ b/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
@@ -260,8 +260,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>470</width>
-                <height>383</height>
+                <width>661</width>
+                <height>508</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -473,8 +473,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>100</width>
-                <height>30</height>
+                <width>661</width>
+                <height>508</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -845,21 +845,20 @@ border-radius: 2px;</string>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsFilterLineEdit</class>
@@ -873,9 +872,16 @@ border-radius: 2px;</string>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsMeshStaticDatasetWidget</class>
@@ -889,20 +895,27 @@ border-radius: 2px;</string>
    <header>qgsmeshdatasetgrouptreewidget.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mSearchLineEdit</tabstop>
   <tabstop>mOptionsListWidget</tabstop>
   <tabstop>mInformationTextBrowser</tabstop>
   <tabstop>scrollArea_3</tabstop>
+  <tabstop>mLayerOrigNameLineEd</tabstop>
+  <tabstop>leDisplayName</tabstop>
+  <tabstop>mCrsGroupBox</tabstop>
   <tabstop>mCrsSelector</tabstop>
+  <tabstop>mTemporalStaticDatasetCheckBox</tabstop>
   <tabstop>scrollArea</tabstop>
+  <tabstop>mSimplifyMeshGroupBox</tabstop>
+  <tabstop>mSimplifyReductionFactorSpinBox</tabstop>
+  <tabstop>mSimplifyMeshResolutionSpinBox</tabstop>
+  <tabstop>mTemporalDateTimeReference</tabstop>
+  <tabstop>mTemporalReloadButton</tabstop>
+  <tabstop>mTemporalDateTimeStart</tabstop>
+  <tabstop>mTemporalDateTimeEnd</tabstop>
+  <tabstop>mComboBoxTemporalDatasetMatchingMethod</tabstop>
+  <tabstop>mTemporalProviderTimeUnitComboBox</tabstop>
  </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>

--- a/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
@@ -108,7 +108,7 @@
        </widget>
       </item>
       <item row="0" column="4" rowspan="3">
-       <widget class="QgsUnitSelectionWidget" name="mScalarEdgeStrokeWidthUnitSelectionWidget"/>
+       <widget class="QgsUnitSelectionWidget" name="mScalarEdgeStrokeWidthUnitSelectionWidget" native="true"/>
       </item>
       <item row="0" column="1" rowspan="3">
        <spacer name="horizontalSpacer">
@@ -207,8 +207,13 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsUnitSelectionWidget</class>
-   <extends>QComboBox</extends>
+   <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
   </customwidget>
@@ -225,16 +230,22 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsMeshVariableStrokeWidthButton</class>
    <extends>QPushButton</extends>
    <header>qgsmeshvariablestrokewidthwidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mOpacityWidget</tabstop>
+  <tabstop>mScalarEdgeStrokeWidthFixedRadioButton</tabstop>
+  <tabstop>mScalarEdgeStrokeWidthVariableRadioButton</tabstop>
+  <tabstop>mScalarEdgeStrokeWidthSpinBox</tabstop>
+  <tabstop>mScalarEdgeStrokeWidthVariablePushButton</tabstop>
+  <tabstop>mScalarMinLineEdit</tabstop>
+  <tabstop>mScalarMaxLineEdit</tabstop>
+  <tabstop>mScalarRecalculateMinMaxButton</tabstop>
+  <tabstop>mScalarInterpolationTypeComboBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/mesh/qgsmeshvariablestrokewidthwidgetbase.ui
+++ b/src/ui/mesh/qgsmeshvariablestrokewidthwidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>340</width>
+    <width>395</width>
     <height>220</height>
    </rect>
   </property>
@@ -152,6 +152,8 @@
   <tabstop>mValueMinimumLineEdit</tabstop>
   <tabstop>mValueMaximumLineEdit</tabstop>
   <tabstop>mDefaultMinMaxButton</tabstop>
+  <tabstop>mIgnoreOutOfRangecheckBox</tabstop>
+  <tabstop>mUseAbsoluteValueCheckBox</tabstop>
   <tabstop>mWidthMinimumSpinBox</tabstop>
   <tabstop>mWidthMaximumSpinBox</tabstop>
  </tabstops>

--- a/src/ui/numericformats/qgsbasicnumericformatwidgetbase.ui
+++ b/src/ui/numericformats/qgsbasicnumericformatwidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>221</width>
+    <width>224</width>
     <height>285</height>
    </rect>
   </property>
@@ -120,12 +120,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsPanelWidget</class>
-   <extends>QWidget</extends>
-   <header>qgspanelwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
@@ -135,7 +129,23 @@
    <extends>QLineEdit</extends>
    <header>qgsfilterlineedit.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsPanelWidget</class>
+   <extends>QWidget</extends>
+   <header>qgspanelwidget.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mDecimalsSpinBox</tabstop>
+  <tabstop>mRadDecimalPlaces</tabstop>
+  <tabstop>mRadSignificantFigures</tabstop>
+  <tabstop>mShowThousandsCheckBox</tabstop>
+  <tabstop>mShowPlusCheckBox</tabstop>
+  <tabstop>mShowTrailingZerosCheckBox</tabstop>
+  <tabstop>mThousandsLineEdit</tabstop>
+  <tabstop>mDecimalLineEdit</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/numericformats/qgsbearingnumericformatwidgetbase.ui
+++ b/src/ui/numericformats/qgsbearingnumericformatwidgetbase.ui
@@ -73,6 +73,11 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mFormatComboBox</tabstop>
+  <tabstop>mDecimalsSpinBox</tabstop>
+  <tabstop>mShowTrailingZerosCheckBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/numericformats/qgscurrencynumericformatwidgetbase.ui
+++ b/src/ui/numericformats/qgscurrencynumericformatwidgetbase.ui
@@ -104,6 +104,14 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mPrefixLineEdit</tabstop>
+  <tabstop>mSuffixLineEdit</tabstop>
+  <tabstop>mDecimalsSpinBox</tabstop>
+  <tabstop>mShowThousandsCheckBox</tabstop>
+  <tabstop>mShowPlusCheckBox</tabstop>
+  <tabstop>mShowTrailingZerosCheckBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/numericformats/qgspercentagenumericformatwidgetbase.ui
+++ b/src/ui/numericformats/qgspercentagenumericformatwidgetbase.ui
@@ -90,6 +90,13 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mDecimalsSpinBox</tabstop>
+  <tabstop>mShowThousandsCheckBox</tabstop>
+  <tabstop>mShowPlusCheckBox</tabstop>
+  <tabstop>mShowTrailingZerosCheckBox</tabstop>
+  <tabstop>mScalingComboBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/pointcloud/qgspointcloudclassifiedrendererwidgetbase.ui
+++ b/src/ui/pointcloud/qgspointcloudclassifiedrendererwidgetbase.ui
@@ -136,6 +136,7 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>mAttributeComboBox</tabstop>
   <tabstop>viewCategories</tabstop>
   <tabstop>btnAddCategories</tabstop>
   <tabstop>btnAddCategory</tabstop>

--- a/src/ui/pointcloud/qgspointcloudelevationpropertieswidgetbase.ui
+++ b/src/ui/pointcloud/qgspointcloudelevationpropertieswidgetbase.ui
@@ -145,17 +145,23 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mCrsGroupBox_2</tabstop>
+  <tabstop>mScaleZSpinBox</tabstop>
+  <tabstop>mOffsetZSpinBox</tabstop>
+  <tabstop>mShifPointCloudZAxisButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
+++ b/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
@@ -109,7 +109,7 @@
              <number>3</number>
             </property>
             <item row="0" column="3">
-             <widget class="QgsUnitSelectionWidget" name="mPointSizeUnitWidget">
+             <widget class="QgsUnitSelectionWidget" name="mPointSizeUnitWidget" native="true">
               <property name="minimumSize">
                <size>
                 <width>0</width>
@@ -207,7 +207,7 @@
              </widget>
             </item>
             <item row="0" column="3">
-             <widget class="QgsUnitSelectionWidget" name="mMaxErrorUnitWidget">
+             <widget class="QgsUnitSelectionWidget" name="mMaxErrorUnitWidget" native="true">
               <property name="minimumSize">
                <size>
                 <width>0</width>
@@ -251,15 +251,15 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsUnitSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsunitselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsBlendModeComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsblendmodecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsUnitSelectionWidget</class>
-   <extends>QComboBox</extends>
-   <header>qgsunitselectionwidget.h</header>
-   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsOpacityWidget</class>
@@ -276,7 +276,13 @@
  </customwidgets>
  <tabstops>
   <tabstop>cboRenderers</tabstop>
+  <tabstop>mPointSizeSpinBox</tabstop>
+  <tabstop>mPointSizeUnitWidget</tabstop>
+  <tabstop>mPointStyleComboBox</tabstop>
+  <tabstop>mMaxErrorSpinBox</tabstop>
+  <tabstop>mMaxErrorUnitWidget</tabstop>
   <tabstop>mOpacityWidget</tabstop>
+  <tabstop>mBlendModeComboBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/processing/qgsprocessingenummodelerwidgetbase.ui
+++ b/src/ui/processing/qgsprocessingenummodelerwidgetbase.ui
@@ -103,6 +103,13 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>mButtonAdd</tabstop>
+  <tabstop>mButtonRemove</tabstop>
+  <tabstop>mButtonClear</tabstop>
+  <tabstop>mItemList</tabstop>
+  <tabstop>mAllowMultiple</tabstop>
+ </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>
  </resources>

--- a/src/ui/processing/qgsprocessingmatrixmodelerwidgetbase.ui
+++ b/src/ui/processing/qgsprocessingmatrixmodelerwidgetbase.ui
@@ -128,6 +128,15 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>mTableView</tabstop>
+  <tabstop>mButtonAddColumn</tabstop>
+  <tabstop>mButtonRemoveColumn</tabstop>
+  <tabstop>mButtonAddRow</tabstop>
+  <tabstop>mButtonRemoveRow</tabstop>
+  <tabstop>mButtonClear</tabstop>
+  <tabstop>mFixedRows</tabstop>
+ </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>
  </resources>

--- a/src/ui/processing/qgsprocessingmeshdatasettimewidget.ui
+++ b/src/ui/processing/qgsprocessingmeshdatasettimewidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>465</width>
-    <height>122</height>
+    <width>535</width>
+    <height>129</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -67,6 +67,13 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>radioButtonCurrentCanvasTime</tabstop>
+  <tabstop>radioButtonDefinedDateTime</tabstop>
+  <tabstop>radioButtonDatasetGroupTimeStep</tabstop>
+  <tabstop>comboBoxDatasetTimeStep</tabstop>
+  <tabstop>dateTimeEdit</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/processing/qgsprocessingtinmeshdatawidgetbase.ui
+++ b/src/ui/processing/qgsprocessingtinmeshdatawidgetbase.ui
@@ -132,17 +132,25 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsFieldComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsfieldcombobox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsMapLayerComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsmaplayercombobox.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>QgsFieldComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsfieldcombobox.h</header>
-  </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mComboLayers</tabstop>
+  <tabstop>mComboFields</tabstop>
+  <tabstop>mCheckBoxUseZCoordinate</tabstop>
+  <tabstop>mButtonAdd</tabstop>
+  <tabstop>mButtonRemove</tabstop>
+  <tabstop>mTableView</tabstop>
+ </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>
  </resources>

--- a/src/ui/qgsadvanceddigitizingfloaterbase.ui
+++ b/src/ui/qgsadvanceddigitizingfloaterbase.ui
@@ -187,6 +187,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>mDistanceLineEdit</tabstop>
+  <tabstop>mAngleLineEdit</tabstop>
+  <tabstop>mXLineEdit</tabstop>
+  <tabstop>mYLineEdit</tabstop>
+ </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>

--- a/src/ui/qgsanimationexportdialogbase.ui
+++ b/src/ui/qgsanimationexportdialogbase.ui
@@ -298,6 +298,19 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mTemplateLineEdit</tabstop>
+  <tabstop>mExtentGroupBox</tabstop>
+  <tabstop>mOutputWidthSpinBox</tabstop>
+  <tabstop>mOutputHeightSpinBox</tabstop>
+  <tabstop>mLockAspectRatio</tabstop>
+  <tabstop>mDrawDecorations</tabstop>
+  <tabstop>mStartDateTime</tabstop>
+  <tabstop>mEndDateTime</tabstop>
+  <tabstop>mSetToProjectTimeButton</tabstop>
+  <tabstop>mFrameDurationSpinBox</tabstop>
+  <tabstop>mTimeStepsComboBox</tabstop>
+ </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>

--- a/src/ui/qgsattributesformproperties.ui
+++ b/src/ui/qgsattributesformproperties.ui
@@ -223,7 +223,7 @@ Use this function to add extra logic to your forms.</string>
          <x>0</x>
          <y>0</y>
          <width>598</width>
-         <height>480</height>
+         <height>492</height>
         </rect>
        </property>
        <layout class="QGridLayout" name="gridLayout_4">
@@ -239,6 +239,17 @@ Use this function to add extra logic to your forms.</string>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>mEditorLayoutComboBox</tabstop>
+  <tabstop>mTbInitCode</tabstop>
+  <tabstop>mFormSuppressCmbBx</tabstop>
+  <tabstop>mEditFormLineEdit</tabstop>
+  <tabstop>pbnSelectEditForm</tabstop>
+  <tabstop>mAddTabOrGroupButton</tabstop>
+  <tabstop>mRemoveTabOrGroupButton</tabstop>
+  <tabstop>mInvertSelectionButton</tabstop>
+  <tabstop>scrollArea_2</tabstop>
+ </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>

--- a/src/ui/qgscolorrampshaderwidgetbase.ui
+++ b/src/ui/qgscolorrampshaderwidgetbase.ui
@@ -315,6 +315,7 @@ Negative rounds to powers of 10</string>
   <tabstop>mColorInterpolationComboBox</tabstop>
   <tabstop>btnColorRamp</tabstop>
   <tabstop>mUnitLineEdit</tabstop>
+  <tabstop>mLabelPrecisionSpinBox</tabstop>
   <tabstop>mColormapTreeWidget</tabstop>
   <tabstop>mClassificationModeComboBox</tabstop>
   <tabstop>mNumberOfEntriesSpinBox</tabstop>
@@ -324,6 +325,7 @@ Negative rounds to powers of 10</string>
   <tabstop>mLoadFromBandButton</tabstop>
   <tabstop>mLoadFromFileButton</tabstop>
   <tabstop>mExportToFileButton</tabstop>
+  <tabstop>mLegendSettingsButton</tabstop>
   <tabstop>mClipCheckBox</tabstop>
  </tabstops>
  <resources>

--- a/src/ui/qgscoordinateoperationwidgetbase.ui
+++ b/src/ui/qgscoordinateoperationwidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>651</width>
+    <width>1000</width>
     <height>433</height>
    </rect>
   </property>
@@ -196,7 +196,10 @@ file are transformed).</string>
  </customwidgets>
  <tabstops>
   <tabstop>mCoordinateOperationTableWidget</tabstop>
+  <tabstop>mInstallGridButton</tabstop>
   <tabstop>mHideDeprecatedCheckBox</tabstop>
+  <tabstop>mShowSupersededCheckBox</tabstop>
+  <tabstop>mAllowFallbackCheckBox</tabstop>
   <tabstop>mMakeDefaultCheckBox</tabstop>
  </tabstops>
  <resources/>

--- a/src/ui/qgscredentialdialog.ui
+++ b/src/ui/qgscredentialdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>358</width>
+    <width>387</width>
     <height>293</height>
    </rect>
   </property>
@@ -269,7 +269,11 @@ font-style: italic;
   <tabstop>lePassword</tabstop>
   <tabstop>leMasterPass</tabstop>
   <tabstop>leMasterPassVerify</tabstop>
+  <tabstop>chkbxPasswordHelperEnable</tabstop>
   <tabstop>chkbxEraseAuthDb</tabstop>
+  <tabstop>mOkButton</tabstop>
+  <tabstop>mIgnoreButton</tabstop>
+  <tabstop>mCancelButton</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/qgsdatadefinedsizelegendwidget.ui
+++ b/src/ui/qgsdatadefinedsizelegendwidget.ui
@@ -213,6 +213,7 @@
   <tabstop>btnRemoveClass</tabstop>
   <tabstop>viewSizeClasses</tabstop>
   <tabstop>cboAlignSymbols</tabstop>
+  <tabstop>mLineSymbolButton</tabstop>
   <tabstop>viewLayerTree</tabstop>
  </tabstops>
  <resources>

--- a/src/ui/qgsdecorationlayoutextentdialog.ui
+++ b/src/ui/qgsdecorationlayoutextentdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>377</width>
-    <height>148</height>
+    <height>152</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -121,7 +121,8 @@
  <tabstops>
   <tabstop>grpEnable</tabstop>
   <tabstop>mSymbolButton</tabstop>
-  <tabstop>buttonBox</tabstop>
+  <tabstop>mCheckBoxLabelExtents</tabstop>
+  <tabstop>mButtonFontStyle</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/qgsdecorationscalebardialog.ui
+++ b/src/ui/qgsdecorationscalebardialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>565</width>
+    <width>596</width>
     <height>337</height>
    </rect>
   </property>
@@ -197,7 +197,7 @@
         <property name="text">
          <string>Font of bar</string>
         </property>
-       </widget>      
+       </widget>
       </item>
       <item row="4" column="1">
        <widget class="QgsFontButton" name="mButtonFontStyle">
@@ -210,7 +210,7 @@
         <property name="text">
          <string>Font</string>
         </property>
-       </widget>      
+       </widget>
       </item>
       <item row="5" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -417,7 +417,7 @@
         </property>
        </widget>
       </item>
-      <item row="9" colspan="2">
+      <item row="9" column="0" colspan="2">
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -428,7 +428,7 @@
           <height>40</height>
          </size>
         </property>
-       </spacer>       
+       </spacer>
       </item>
      </layout>
     </widget>
@@ -438,20 +438,15 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsFontButton</class>
-   <extends>QToolButton</extends>
-   <header>qgsfontbutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>
@@ -459,19 +454,24 @@
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsFontButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsfontbutton.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>grpEnable</tabstop>
   <tabstop>cboStyle</tabstop>
   <tabstop>pbnChangeColor</tabstop>
   <tabstop>pbnChangeOutlineColor</tabstop>
+  <tabstop>mButtonFontStyle</tabstop>
   <tabstop>spnSize</tabstop>
   <tabstop>chkSnapping</tabstop>
   <tabstop>cboPlacement</tabstop>
   <tabstop>spnHorizontal</tabstop>
   <tabstop>spnVertical</tabstop>
   <tabstop>wgtUnitSelection</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/qgsdecorationtitledialog.ui
+++ b/src/ui/qgsdecorationtitledialog.ui
@@ -45,7 +45,7 @@
      <property name="checked">
       <bool>false</bool>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0,0">
+     <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0,0,0,0">
       <item row="0" column="0" colspan="2">
        <widget class="QLabel" name="label_2">
         <property name="text">
@@ -133,8 +133,7 @@
        </widget>
       </item>
       <item row="1" column="0" colspan="3">
-       <widget class="QTextEdit" name="txtTitleText">
-       </widget>
+       <widget class="QTextEdit" name="txtTitleText"/>
       </item>
       <item row="5" column="0">
        <widget class="QLabel" name="textLabel16">
@@ -206,7 +205,7 @@
       </item>
       <item row="3" column="1" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout">
-        <item row="3" column="1" colspan="2">
+        <item>
          <widget class="QgsFontButton" name="mButtonFontStyle">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -242,20 +241,15 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>
@@ -263,17 +257,22 @@
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsFontButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsfontbutton.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>grpEnable</tabstop>
   <tabstop>txtTitleText</tabstop>
   <tabstop>mInsertExpressionButton</tabstop>
   <tabstop>mButtonFontStyle</tabstop>
+  <tabstop>pbnBackgroundColor</tabstop>
   <tabstop>cboPlacement</tabstop>
   <tabstop>spnHorizontal</tabstop>
   <tabstop>spnVertical</tabstop>
   <tabstop>wgtUnitSelection</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/qgseditconditionalformatrulewidget.ui
+++ b/src/ui/qgseditconditionalformatrulewidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>328</width>
+    <width>384</width>
     <height>331</height>
    </rect>
   </property>
@@ -317,7 +317,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QFontComboBox" name="mFontFamilyCmbBx" />
+         <widget class="QFontComboBox" name="mFontFamilyCmbBx"/>
         </item>
        </layout>
       </item>
@@ -437,19 +437,36 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
+  </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mNameEdit</tabstop>
+  <tabstop>mRuleEdit</tabstop>
+  <tabstop>btnBuildExpression</tabstop>
+  <tabstop>mPresetsList</tabstop>
+  <tabstop>btnBackgroundColor</tabstop>
+  <tabstop>btnTextColor</tabstop>
+  <tabstop>checkIcon</tabstop>
+  <tabstop>btnChangeIcon</tabstop>
+  <tabstop>mFontBoldBtn</tabstop>
+  <tabstop>mFontItalicBtn</tabstop>
+  <tabstop>mFontUnderlineBtn</tabstop>
+  <tabstop>mFontStrikethroughBtn</tabstop>
+  <tabstop>mFontFamilyCmbBx</tabstop>
+  <tabstop>mSaveRule</tabstop>
+  <tabstop>mCancelButton</tabstop>
+  <tabstop>mDeleteButton</tabstop>
+ </tabstops>
  <resources>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -905,8 +905,39 @@ Saved scripts are auto loaded on QGIS startup.</string>
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>btnClearEditor</tabstop>
+  <tabstop>btnSaveExpression</tabstop>
+  <tabstop>btnEditExpression</tabstop>
+  <tabstop>btnRemoveExpression</tabstop>
+  <tabstop>btnImportExpressions</tabstop>
+  <tabstop>btnExportExpressions</tabstop>
+  <tabstop>btnEqualPushButton</tabstop>
+  <tabstop>btnPlusPushButton</tabstop>
+  <tabstop>btnMinusPushButton</tabstop>
+  <tabstop>btnDividePushButton</tabstop>
+  <tabstop>btnMultiplyPushButton</tabstop>
+  <tabstop>btnExpButton</tabstop>
+  <tabstop>btnConcatButton</tabstop>
+  <tabstop>btnOpenBracketPushButton</tabstop>
+  <tabstop>btnCloseBracketPushButton</tabstop>
+  <tabstop>btnNewLinePushButton</tabstop>
+  <tabstop>txtSearchEdit</tabstop>
+  <tabstop>mShowHelpButton</tabstop>
+  <tabstop>mExpressionTreeView</tabstop>
+  <tabstop>txtHelpText</tabstop>
+  <tabstop>txtSearchEditValues</tabstop>
+  <tabstop>btnLoadAll</tabstop>
+  <tabstop>btnLoadSample</tabstop>
+  <tabstop>cbxValuesInUse</tabstop>
+  <tabstop>mValuesListView</tabstop>
+  <tabstop>cmbFileNames</tabstop>
+  <tabstop>btnNewFile</tabstop>
+  <tabstop>btnRemoveFile</tabstop>
+  <tabstop>btnRun</tabstop>
+ </tabstops>
  <resources>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/src/ui/qgsfieldconditionalformatwidget.ui
+++ b/src/ui/qgsfieldconditionalformatwidget.ui
@@ -108,15 +108,15 @@
    <header>qgsfieldcombobox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>fieldRadio</tabstop>
+  <tabstop>mFieldCombo</tabstop>
+  <tabstop>rowRadio</tabstop>
+  <tabstop>mNewButton</tabstop>
+  <tabstop>listView</tabstop>
+ </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>
- <buttongroups>
-  <buttongroup name="mFontButtons">
-   <property name="exclusive">
-    <bool>false</bool>
-   </property>
-  </buttongroup>
- </buttongroups>
 </ui>

--- a/src/ui/qgsgeometryvalidationdockbase.ui
+++ b/src/ui/qgsgeometryvalidationdockbase.ui
@@ -153,6 +153,13 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mPreviousButton</tabstop>
+  <tabstop>mZoomToFeatureButton</tabstop>
+  <tabstop>mZoomToProblemButton</tabstop>
+  <tabstop>mNextButton</tabstop>
+  <tabstop>mErrorListView</tabstop>
+ </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>

--- a/src/ui/qgsgpsinformationwidgetbase.ui
+++ b/src/ui/qgsgpsinformationwidgetbase.ui
@@ -157,8 +157,8 @@ gray = no data
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>565</width>
-            <height>724</height>
+            <width>579</width>
+            <height>744</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_2">
@@ -601,8 +601,8 @@ gray = no data
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>354</width>
-            <height>1346</height>
+            <width>565</width>
+            <height>1126</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_7">
@@ -1485,15 +1485,31 @@ gray = no data
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFieldComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsfieldcombobox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -1502,35 +1518,19 @@ gray = no data
    <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsFieldComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsfieldcombobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsPanelWidget</class>
    <extends>QWidget</extends>
    <header>qgspanelwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>mBtnCloseFeature</tabstop>
   <tabstop>mBtnAddVertex</tabstop>
   <tabstop>mBtnResetFeature</tabstop>
   <tabstop>mBtnPosition</tabstop>
@@ -1538,6 +1538,7 @@ gray = no data
   <tabstop>mBtnSatellites</tabstop>
   <tabstop>mBtnOptions</tabstop>
   <tabstop>mBtnDebug</tabstop>
+  <tabstop>mRecenterButton</tabstop>
   <tabstop>mConnectButton</tabstop>
   <tabstop>scrollArea</tabstop>
   <tabstop>mRadAutodetect</tabstop>
@@ -1550,9 +1551,15 @@ gray = no data
   <tabstop>mGpsdPort</tabstop>
   <tabstop>mGpsdDevice</tabstop>
   <tabstop>mCbxAutoCommit</tabstop>
+  <tabstop>mCboTimestampField</tabstop>
+  <tabstop>mCboTimestampFormat</tabstop>
+  <tabstop>mCboTimeZones</tabstop>
+  <tabstop>mCbxLeapSeconds</tabstop>
+  <tabstop>mLeapSeconds</tabstop>
   <tabstop>mCbxAutoAddVertices</tabstop>
   <tabstop>mSpinTrackWidth</tabstop>
   <tabstop>mBtnTrackColor</tabstop>
+  <tabstop>mTravelBearingCheckBox</tabstop>
   <tabstop>mGroupShowMarker</tabstop>
   <tabstop>mSliderMarkerSize</tabstop>
   <tabstop>mCboAcquisitionInterval</tabstop>
@@ -1562,6 +1569,9 @@ gray = no data
   <tabstop>mSpinMapExtentMultiplier</tabstop>
   <tabstop>radNeverRecenter</tabstop>
   <tabstop>mRotateMapCheckBox</tabstop>
+  <tabstop>mSpinMapRotateInterval</tabstop>
+  <tabstop>mShowBearingLineCheck</tabstop>
+  <tabstop>mBearingLineStyleButton</tabstop>
   <tabstop>mLogFileGroupBox</tabstop>
   <tabstop>mTxtLogFile</tabstop>
   <tabstop>mBtnLogFile</tabstop>
@@ -1570,6 +1580,7 @@ gray = no data
   <tabstop>mTxtLatitude</tabstop>
   <tabstop>mTxtLongitude</tabstop>
   <tabstop>mTxtAltitude</tabstop>
+  <tabstop>mTxtAltitudeDiff</tabstop>
   <tabstop>mTxtDateTime</tabstop>
   <tabstop>mTxtSpeed</tabstop>
   <tabstop>mTxtDirection</tabstop>
@@ -1578,16 +1589,13 @@ gray = no data
   <tabstop>mTxtPdop</tabstop>
   <tabstop>mTxtHacc</tabstop>
   <tabstop>mTxtVacc</tabstop>
+  <tabstop>mTxt3Dacc</tabstop>
   <tabstop>mTxtFixMode</tabstop>
   <tabstop>mTxtFixType</tabstop>
   <tabstop>mTxtQuality</tabstop>
   <tabstop>mTxtStatus</tabstop>
   <tabstop>mTxtSatellitesUsed</tabstop>
-  <tabstop>mCboTimestampField</tabstop>
-  <tabstop>mCboTimestampFormat</tabstop>
-  <tabstop>mCboTimeZones</tabstop>
-  <tabstop>mLeapSeconds</tabstop>
-  <tabstop>mCbxLeapSeconds</tabstop>
+  <tabstop>mBtnCloseFeature</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsgradientcolorrampdialogbase.ui
+++ b/src/ui/qgsgradientcolorrampdialogbase.ui
@@ -148,7 +148,7 @@
         <x>0</x>
         <y>0</y>
         <width>850</width>
-        <height>494</height>
+        <height>498</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
@@ -331,10 +331,21 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QwtPlot</class>
+   <extends>QFrame</extends>
+   <header>qwt_plot.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsScrollArea</class>
@@ -346,17 +357,6 @@
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QwtPlot</class>
-   <extends>QFrame</extends>
-   <header>qwt_plot.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -377,17 +377,15 @@
   <tabstop>btnColor2</tabstop>
   <tabstop>cboType</tabstop>
   <tabstop>mStopEditor</tabstop>
-  <tabstop>groupBox_2</tabstop>
+  <tabstop>scrollArea</tabstop>
   <tabstop>mPositionSpinBox</tabstop>
   <tabstop>mDeleteStopButton</tabstop>
   <tabstop>mColorWidget</tabstop>
-  <tabstop>mPlotGroupBox</tabstop>
   <tabstop>mPlotHueCheckbox</tabstop>
   <tabstop>mPlotSaturationCheckbox</tabstop>
   <tabstop>mPlotLightnessCheckbox</tabstop>
   <tabstop>mPlotAlphaCheckbox</tabstop>
   <tabstop>btnInformation</tabstop>
-  <tabstop>scrollArea</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsgraduatedsymbolrendererwidget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererwidget.ui
@@ -503,20 +503,30 @@ Negative rounds to powers of 10</string>
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsUnitSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsunitselectionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsFieldExpressionWidget</class>
    <extends>QWidget</extends>
    <header>qgsfieldexpressionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsUnitSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsunitselectionwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -526,26 +536,16 @@ Negative rounds to powers of 10</string>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsGraduatedHistogramWidget</class>
    <extends>QWidget</extends>
    <header>qgsgraduatedhistogramwidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -563,6 +563,9 @@ Negative rounds to powers of 10</string>
   <tabstop>viewGraduated</tabstop>
   <tabstop>cboGraduatedMode</tabstop>
   <tabstop>spinGraduatedClasses</tabstop>
+  <tabstop>mGroupBoxSymmetric</tabstop>
+  <tabstop>cboSymmetryPoint</tabstop>
+  <tabstop>cbxAstride</tabstop>
   <tabstop>btnGraduatedClassify</tabstop>
   <tabstop>btnGraduatedAdd</tabstop>
   <tabstop>btnGraduatedDelete</tabstop>

--- a/src/ui/qgsjoindialogbase.ui
+++ b/src/ui/qgsjoindialogbase.ui
@@ -191,6 +191,10 @@
   <tabstop>mTargetFieldComboBox</tabstop>
   <tabstop>mCacheInMemoryCheckBox</tabstop>
   <tabstop>mCreateIndexCheckBox</tabstop>
+  <tabstop>mDynamicFormCheckBox</tabstop>
+  <tabstop>mEditableJoinLayer</tabstop>
+  <tabstop>mUpsertOnEditCheckBox</tabstop>
+  <tabstop>mDeleteCascadeCheckBox</tabstop>
   <tabstop>mUseJoinFieldsSubset</tabstop>
   <tabstop>mJoinFieldsSubsetView</tabstop>
   <tabstop>mUseCustomPrefix</tabstop>

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0,0,0">
+    <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0,0,0,0">
      <item row="2" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
@@ -374,20 +374,9 @@ Rasterizing the map is recommended when such effects are used.</string>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsScaleWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsscalewidget.h</header>
   </customwidget>
   <customwidget>
    <class>QgsExtentGroupBox</class>
@@ -401,6 +390,17 @@ Rasterizing the map is recommended when such effects are used.</string>
    <header>qgsratiolockbutton.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsScaleWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mExtentGroupBox</tabstop>
@@ -411,9 +411,9 @@ Rasterizing the map is recommended when such effects are used.</string>
   <tabstop>mDrawDecorations</tabstop>
   <tabstop>mDrawAnnotations</tabstop>
   <tabstop>mSaveWorldFile</tabstop>
+  <tabstop>mExportMetadataCheckBox</tabstop>
   <tabstop>mGeoPDFGroupBox</tabstop>
   <tabstop>mGeoPdfFormatComboBox</tabstop>
-  <tabstop>mExportMetadataCheckBox</tabstop>
   <tabstop>mExportGeoPdfFeaturesCheckBox</tabstop>
   <tabstop>mSaveAsRaster</tabstop>
   <tabstop>mSimplifyGeometriesCheckbox</tabstop>

--- a/src/ui/qgsmetadatawidget.ui
+++ b/src/ui/qgsmetadatawidget.ui
@@ -68,7 +68,7 @@
             <x>0</x>
             <y>0</y>
             <width>786</width>
-            <height>721</height>
+            <height>670</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_15">
@@ -1492,15 +1492,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsExtentGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgsextentgroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsExtentGroupBox</class>
+   <extends>QgsCollapsibleGroupBox</extends>
+   <header>qgsextentgroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsDateTimeEdit</class>
@@ -1512,7 +1512,6 @@
   <tabstop>tabWidget</tabstop>
   <tabstop>scrollArea</tabstop>
   <tabstop>lineEditParentId</tabstop>
-  <tabstop>comboEncoding</tabstop>
   <tabstop>lineEditIdentifier</tabstop>
   <tabstop>btnAutoSource</tabstop>
   <tabstop>lineEditTitle</tabstop>
@@ -1521,6 +1520,7 @@
   <tabstop>mCreationDateTimeEdit</tabstop>
   <tabstop>comboLanguage</tabstop>
   <tabstop>textEditAbstract</tabstop>
+  <tabstop>comboEncoding</tabstop>
   <tabstop>btnAutoEncoding</tabstop>
   <tabstop>listDefaultCategories</tabstop>
   <tabstop>btnAddDefaultCategory</tabstop>

--- a/src/ui/qgsmssqlnewconnectionbase.ui
+++ b/src/ui/qgsmssqlnewconnectionbase.ui
@@ -376,6 +376,12 @@ Untick save if you don't wish to be the case.</string>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsMessageBar</class>
    <extends>QWidget</extends>
    <header>qgsmessagebar.h</header>
@@ -385,12 +391,6 @@ Untick save if you don't wish to be the case.</string>
    <class>QgsPasswordLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qgspasswordlineedit.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -404,9 +404,14 @@ Untick save if you don't wish to be the case.</string>
   <tabstop>chkStorePassword</tabstop>
   <tabstop>btnListDatabase</tabstop>
   <tabstop>listDatabase</tabstop>
+  <tabstop>groupBoxGeometryColumns</tabstop>
+  <tabstop>checkBoxExtentFromGeometryColumns</tabstop>
+  <tabstop>checkBoxPKFromGeometryColumns</tabstop>
   <tabstop>cb_allowGeometrylessTables</tabstop>
   <tabstop>cb_useEstimatedMetadata</tabstop>
   <tabstop>mCheckNoInvalidGeometryHandling</tabstop>
+  <tabstop>groupBoxSchemasFilter</tabstop>
+  <tabstop>schemaView</tabstop>
   <tabstop>btnConnect</tabstop>
  </tabstops>
  <resources/>

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>448</width>
-    <height>815</height>
+    <width>567</width>
+    <height>821</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -333,15 +333,15 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsFilterLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgsfilterlineedit.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
    <header>auth/qgsauthsettingswidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -355,10 +355,12 @@
   <tabstop>txtPageSize</tabstop>
   <tabstop>cbxWfsIgnoreAxisOrientation</tabstop>
   <tabstop>cbxWfsInvertAxisOrientation</tabstop>
+  <tabstop>cbxWfsUseGml2EncodingForTransactions</tabstop>
   <tabstop>cmbDpiMode</tabstop>
   <tabstop>cbxIgnoreGetMapURI</tabstop>
   <tabstop>cbxIgnoreGetFeatureInfoURI</tabstop>
   <tabstop>cbxWmsIgnoreAxisOrientation</tabstop>
+  <tabstop>cbxWmsIgnoreReportedLayerExtents</tabstop>
   <tabstop>cbxWmsInvertAxisOrientation</tabstop>
   <tabstop>cbxSmoothPixmapTransform</tabstop>
   <tabstop>mTestConnectionButton</tabstop>

--- a/src/ui/qgsnewogrconnectionbase.ui
+++ b/src/ui/qgsnewogrconnectionbase.ui
@@ -180,11 +180,12 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>cmbDatabaseTypes</tabstop>
   <tabstop>txtName</tabstop>
   <tabstop>txtHost</tabstop>
   <tabstop>txtDatabase</tabstop>
   <tabstop>txtPort</tabstop>
-  <tabstop>buttonBox</tabstop>
+  <tabstop>btnConnect</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsogrsourceselectbase.ui
+++ b/src/ui/qgsogrsourceselectbase.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>480</width>
-    <height>735</height>
+    <width>521</width>
+    <height>775</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -358,20 +358,20 @@
         <string>Options</string>
        </property>
        <layout class="QVBoxLayout" name="openOptionsVBoxLayout">
-         <item>
-           <widget class="QLabel" name="mOpenOptionsLabel">
-            <property name="text">
-             <string></string>
-            </property>
-           </widget>
-         </item>
-         <item>
-            <layout class="QFormLayout" name="mOpenOptionsLayout">
-                <property name="fieldGrowthPolicy">
-                <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-                </property>
-            </layout>
-         </item>
+        <item>
+         <widget class="QLabel" name="mOpenOptionsLabel">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QFormLayout" name="mOpenOptionsLayout">
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+          </property>
+         </layout>
+        </item>
        </layout>
       </widget>
      </item>
@@ -402,6 +402,12 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsFileWidget</class>
    <extends>QWidget</extends>
    <header>qgsfilewidget.h</header>
@@ -422,11 +428,11 @@
   <tabstop>cmbEncodings</tabstop>
   <tabstop>cmbProtocolTypes</tabstop>
   <tabstop>protocolURI</tabstop>
+  <tabstop>mBucket</tabstop>
+  <tabstop>mKey</tabstop>
   <tabstop>cmbDirectoryTypes</tabstop>
-  <tabstop>mFileWidget</tabstop>
   <tabstop>cmbDatabaseTypes</tabstop>
   <tabstop>cmbConnections</tabstop>
-  <tabstop>mOpenOptionsGroupBox</tabstop>
   <tabstop>btnNew</tabstop>
   <tabstop>btnEdit</tabstop>
   <tabstop>btnDelete</tabstop>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -332,7 +332,7 @@
        <item>
         <widget class="QStackedWidget" name="mOptionsStackedWidget">
          <property name="currentIndex">
-          <number>4</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="mOptionsPageGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -361,8 +361,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>848</width>
-                <height>987</height>
+                <width>843</width>
+                <height>959</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -1133,8 +1133,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>848</width>
-                <height>1102</height>
+                <width>843</width>
+                <height>1068</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -1672,8 +1672,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>848</width>
-                <height>678</height>
+                <width>857</width>
+                <height>695</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -1864,8 +1864,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>848</width>
-                <height>678</height>
+                <width>596</width>
+                <height>105</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_47">
@@ -1947,8 +1947,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>848</width>
-                <height>760</height>
+                <width>637</width>
+                <height>717</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -2339,8 +2339,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>848</width>
-                <height>1154</height>
+                <width>719</width>
+                <height>1132</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_22">
@@ -3144,8 +3144,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>848</width>
-                <height>678</height>
+                <width>508</width>
+                <height>357</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -3589,8 +3589,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>848</width>
-                <height>729</height>
+                <width>630</width>
+                <height>686</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
@@ -4106,8 +4106,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>848</width>
-                <height>678</height>
+                <width>147</width>
+                <height>251</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_46">
@@ -4286,8 +4286,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>848</width>
-                <height>939</height>
+                <width>555</width>
+                <height>968</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -4960,8 +4960,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>848</width>
-                <height>678</height>
+                <width>494</width>
+                <height>539</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_39">
@@ -5241,8 +5241,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>848</width>
-                <height>678</height>
+                <width>457</width>
+                <height>419</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -5513,8 +5513,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>848</width>
-                <height>708</height>
+                <width>657</width>
+                <height>669</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_33">
@@ -6112,9 +6112,30 @@ p, li { white-space: pre-wrap; }
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsAuthSettingsWidget</class>
+   <extends>QWidget</extends>
+   <header>auth/qgsauthsettingswidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -6124,20 +6145,26 @@ p, li { white-space: pre-wrap; }
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsFilterLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgsfilterlineedit.h</header>
+   <class>QgsVariableEditorWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">qgsvariableeditorwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScaleComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsscalecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsColorSchemeList</class>
    <extends>QWidget</extends>
    <header location="global">qgscolorschemelist.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsVariableEditorWidget</class>
-   <extends>QWidget</extends>
-   <header location="global">qgsvariableeditorwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -6147,37 +6174,10 @@ p, li { white-space: pre-wrap; }
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsProjectionSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsprojectionselectionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsScaleComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsscalecombobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsAuthEditorWidgets</class>
    <extends>QTabWidget</extends>
    <header>qgsautheditorwidgets.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsAuthSettingsWidget</class>
-   <extends>QWidget</extends>
-   <header>auth/qgsauthsettingswidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgspgnewconnectionbase.ui
+++ b/src/ui/qgspgnewconnectionbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>447</width>
-    <height>554</height>
+    <width>448</width>
+    <height>556</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -255,18 +255,33 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsMessageBar</class>
-   <extends>QWidget</extends>
-   <header>qgsmessagebar.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
    <header>auth/qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsMessageBar</class>
+   <extends>QWidget</extends>
+   <header>qgsmessagebar.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>txtName</tabstop>
+  <tabstop>txtService</tabstop>
+  <tabstop>txtHost</tabstop>
+  <tabstop>txtPort</tabstop>
+  <tabstop>txtDatabase</tabstop>
+  <tabstop>cbxSSLmode</tabstop>
+  <tabstop>btnConnect</tabstop>
+  <tabstop>cb_geometryColumnsOnly</tabstop>
+  <tabstop>cb_dontResolveType</tabstop>
+  <tabstop>cb_publicSchemaOnly</tabstop>
+  <tabstop>cb_allowGeometrylessTables</tabstop>
+  <tabstop>cb_useEstimatedMetadata</tabstop>
+  <tabstop>cb_projectsInDatabase</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/ui/qgspointdisplacementrendererwidgetbase.ui
+++ b/src/ui/qgspointdisplacementrendererwidgetbase.ui
@@ -57,7 +57,7 @@
        </widget>
       </item>
       <item row="5" column="2">
-       <widget class="QgsScaleWidget" name="mMinLabelScaleWidget">
+       <widget class="QgsScaleWidget" name="mMinLabelScaleWidget" native="true">
         <property name="focusPolicy">
          <enum>Qt::StrongFocus</enum>
         </property>
@@ -308,20 +308,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsFontButton</class>
-   <extends>QToolButton</extends>
-   <header>qgsfontbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsScaleWidget</class>
@@ -329,20 +318,31 @@
    <header>qgsscalewidget.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsSymbolButton</class>
    <extends>QToolButton</extends>
    <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsUnitSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFontButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsfontbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -359,7 +359,9 @@
   <tabstop>mLabelFieldComboBox</tabstop>
   <tabstop>mLabelFontButton</tabstop>
   <tabstop>mLabelColorButton</tabstop>
+  <tabstop>mLabelDistanceFactorSpinBox</tabstop>
   <tabstop>mScaleDependentLabelsCheckBox</tabstop>
+  <tabstop>mMinLabelScaleWidget</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -298,8 +298,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>671</width>
-                <height>821</height>
+                <width>685</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout">
@@ -954,8 +954,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>692</width>
-                <height>673</height>
+                <width>685</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -1007,8 +1007,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>692</width>
-                <height>673</height>
+                <width>685</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -1067,8 +1067,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>692</width>
-                <height>673</height>
+                <width>685</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1643,8 +1643,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>692</width>
-                <height>673</height>
+                <width>685</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_17">
@@ -1705,8 +1705,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>685</width>
-                <height>3591</height>
+                <width>671</width>
+                <height>3119</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -3156,15 +3156,20 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsExtentGroupBox</class>
+   <extends>QgsCollapsibleGroupBox</extends>
+   <header>qgsextentgroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -3173,9 +3178,20 @@
    <header>qgsfilterlineedit.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsProjectionSelectionTreeWidget</class>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDateTimeEdit</class>
+   <extends>QDateTimeEdit</extends>
+   <header>qgsdatetimeedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsVariableEditorWidget</class>
    <extends>QWidget</extends>
-   <header>qgsprojectionselectiontreewidget.h</header>
+   <header location="global">qgsvariableeditorwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -3184,9 +3200,21 @@
    <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsOpacityWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsopacitywidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsProjectionSelectionTreeWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectiontreewidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -3196,32 +3224,10 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsVariableEditorWidget</class>
-   <extends>QWidget</extends>
-   <header location="global">qgsvariableeditorwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsDatumTransformTableWidget</class>
    <extends>QWidget</extends>
    <header>qgsdatumtransformtablewidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDateTimeEdit</class>
-   <extends>QDateTimeEdit</extends>
-   <header>qgsdatetimeedit.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsOpacityWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsopacitywidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsCodeEditorPython</class>
@@ -3229,14 +3235,9 @@
    <header>qgscodeeditorpython.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>QgsExtentGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgsextentgroupbox.h</header>
-   <container>1</container>
-  </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>mSearchLineEdit</tabstop>
   <tabstop>mOptionsListWidget</tabstop>
   <tabstop>scrollArea_2</tabstop>
   <tabstop>mProjectFileLineEdit</tabstop>
@@ -3257,7 +3258,19 @@
   <tabstop>radAutomatic</tabstop>
   <tabstop>radManual</tabstop>
   <tabstop>spinBoxDP</tabstop>
+  <tabstop>mCustomizeBearingFormatButton</tabstop>
+  <tabstop>cbtsLocale</tabstop>
+  <tabstop>generateTsFileButton</tabstop>
+  <tabstop>grpProjectScales</tabstop>
+  <tabstop>lstScales</tabstop>
+  <tabstop>pbnAddScale</tabstop>
+  <tabstop>pbnRemoveScale</tabstop>
+  <tabstop>pbnImportScales</tabstop>
+  <tabstop>pbnExportScales</tabstop>
+  <tabstop>mExtentGroupBox</tabstop>
   <tabstop>scrollArea</tabstop>
+  <tabstop>scrollArea_3</tabstop>
+  <tabstop>mShowDatumTransformDialogCheckBox</tabstop>
   <tabstop>scrollArea_4</tabstop>
   <tabstop>cboStyleMarker</tabstop>
   <tabstop>pbtnStyleMarker</tabstop>
@@ -3279,6 +3292,10 @@
   <tabstop>mAutoTransaction</tabstop>
   <tabstop>mEvaluateDefaultValues</tabstop>
   <tabstop>mTrustProjectCheckBox</tabstop>
+  <tabstop>mLayerCapabilitiesTree</tabstop>
+  <tabstop>mLayerCapabilitiesToggleSelectionButton</tabstop>
+  <tabstop>mShowSpatialLayersCheckBox</tabstop>
+  <tabstop>mLayerCapabilitiesTreeFilterLineEdit</tabstop>
   <tabstop>scrollArea_6</tabstop>
   <tabstop>grpPythonMacros</tabstop>
   <tabstop>scrollArea_5</tabstop>
@@ -3286,6 +3303,8 @@
   <tabstop>mWMSName</tabstop>
   <tabstop>mWMSTitle</tabstop>
   <tabstop>mWMSContactOrganization</tabstop>
+  <tabstop>mWMSOnlineResourceLineEdit</tabstop>
+  <tabstop>mWMSOnlineResourceExpressionButton</tabstop>
   <tabstop>mWMSContactPerson</tabstop>
   <tabstop>mWMSContactPositionCb</tabstop>
   <tabstop>mWMSContactMail</tabstop>
@@ -3301,7 +3320,6 @@
   <tabstop>mWMSExtMaxY</tabstop>
   <tabstop>pbnWMSExtCanvas</tabstop>
   <tabstop>grpWMSList</tabstop>
-  <tabstop>mSearchLineEdit</tabstop>
   <tabstop>pbnWMSAddSRS</tabstop>
   <tabstop>pbnWMSRemoveSRS</tabstop>
   <tabstop>pbnWMSSetUsedSRS</tabstop>
@@ -3323,6 +3341,7 @@
   <tabstop>mWMSInspireTemporalReference</tabstop>
   <tabstop>mWMSInspireMetadataDate</tabstop>
   <tabstop>mWmsUseLayerIDs</tabstop>
+  <tabstop>mUseAttributeFormSettingsCheckBox</tabstop>
   <tabstop>mAddWktGeometryCheckBox</tabstop>
   <tabstop>mSegmentizeFeatureInfoGeometryCheckBox</tabstop>
   <tabstop>mWMSPrecisionSpinBox</tabstop>
@@ -3330,6 +3349,10 @@
   <tabstop>mMaxWidthLineEdit</tabstop>
   <tabstop>mMaxHeightLineEdit</tabstop>
   <tabstop>mWMSImageQualitySpinBox</tabstop>
+  <tabstop>mWMSMaxAtlasFeaturesSpinBox</tabstop>
+  <tabstop>mWMSTileBufferSpinBox</tabstop>
+  <tabstop>twWmtsLayers</tabstop>
+  <tabstop>twWmtsGrids</tabstop>
   <tabstop>mWMTSMinScaleSpinBox</tabstop>
   <tabstop>mWMTSUrlLineEdit</tabstop>
   <tabstop>twWFSLayers</tabstop>
@@ -3342,6 +3365,9 @@
   <tabstop>mWCSUrlLineEdit</tabstop>
   <tabstop>pbnLaunchOWSChecker</tabstop>
   <tabstop>teOWSChecker</tabstop>
+  <tabstop>mStartDateTimeEdit</tabstop>
+  <tabstop>mEndDateTimeEdit</tabstop>
+  <tabstop>mCalculateFromLayerButton</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgspropertyassistantwidgetbase.ui
+++ b/src/ui/qgspropertyassistantwidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>525</width>
+    <width>545</width>
     <height>426</height>
    </rect>
   </property>
@@ -247,6 +247,9 @@
   <tabstop>minValueSpinBox</tabstop>
   <tabstop>maxValueSpinBox</tabstop>
   <tabstop>computeValuesButton</tabstop>
+  <tabstop>mTransformCurveCheckBox</tabstop>
+  <tabstop>mCurveEditor</tabstop>
+  <tabstop>mLegendPreview</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/qgsquerybuilderbase.ui
+++ b/src/ui/qgsquerybuilderbase.ui
@@ -347,15 +347,15 @@ p, li { white-space: pre-wrap; }
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsFilterLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgsfilterlineedit.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
   </customwidget>
   <customwidget>
    <class>QgsCodeEditorSQL</class>
@@ -366,11 +366,11 @@ p, li { white-space: pre-wrap; }
  </customwidgets>
  <tabstops>
   <tabstop>lstFields</tabstop>
+  <tabstop>mFilterLineEdit</tabstop>
   <tabstop>lstValues</tabstop>
   <tabstop>btnSampleValues</tabstop>
   <tabstop>btnGetAllValues</tabstop>
   <tabstop>mUseUnfilteredLayer</tabstop>
-  <tabstop>groupBox4</tabstop>
   <tabstop>btnEqual</tabstop>
   <tabstop>btnLessThan</tabstop>
   <tabstop>btnGreaterThan</tabstop>

--- a/src/ui/qgsrastercalcdialogbase.ui
+++ b/src/ui/qgsrastercalcdialogbase.ui
@@ -520,9 +520,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsFileWidget</class>
    <extends>QWidget</extends>
    <header>qgsfilewidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
@@ -535,15 +541,9 @@
    <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mRasterBandsListWidget</tabstop>
-  <tabstop>mOutputLayer</tabstop>
   <tabstop>mOutputFormatComboBox</tabstop>
   <tabstop>mCurrentLayerExtentButton</tabstop>
   <tabstop>mXMinSpinBox</tabstop>
@@ -554,7 +554,6 @@
   <tabstop>mNRowsSpinBox</tabstop>
   <tabstop>mCrsSelector</tabstop>
   <tabstop>mAddResultToProjectCheckBox</tabstop>
-  <tabstop>mOperatorsGroupBox</tabstop>
   <tabstop>mPlusPushButton</tabstop>
   <tabstop>mMultiplyPushButton</tabstop>
   <tabstop>mSqrtButton</tabstop>
@@ -579,6 +578,9 @@
   <tabstop>mGreaterEqualButton</tabstop>
   <tabstop>mAndButton</tabstop>
   <tabstop>mOrButton</tabstop>
+  <tabstop>mAbsButton</tabstop>
+  <tabstop>mMinButton</tabstop>
+  <tabstop>mMaxButton</tabstop>
   <tabstop>mExpressionTextEdit</tabstop>
  </tabstops>
  <resources/>

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -169,7 +169,7 @@
            <string>Temporal Settings</string>
           </property>
           <property name="icon">
-           <iconset>
+           <iconset resource="../../images/images.qrc">
             <normaloff>:/images/themes/default/propertyicons/temporal.svg</normaloff>:/images/themes/default/propertyicons/temporal.svg</iconset>
           </property>
          </item>
@@ -303,7 +303,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>629</width>
-                <height>1168</height>
+                <height>1109</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -760,8 +760,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>619</width>
-                <height>383</height>
+                <width>643</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -1296,8 +1296,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>343</width>
-                <height>474</height>
+                <width>643</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -1649,8 +1649,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>86</width>
-                <height>41</height>
+                <width>643</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_16">
@@ -1867,8 +1867,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>577</width>
-                <height>190</height>
+                <width>643</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -2097,8 +2097,8 @@ p, li { white-space: pre-wrap; }
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>343</width>
-                <height>684</height>
+                <width>643</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_12">
@@ -2549,36 +2549,9 @@ p, li { white-space: pre-wrap; }
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsFilterLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgsfilterlineedit.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsDateTimeEdit</class>
-   <extends>QDateTimeEdit</extends>
-   <header>qgsdatetimeedit.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -2587,10 +2560,14 @@ p, li { white-space: pre-wrap; }
    <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsOpacityWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsopacitywidget.h</header>
-   <container>1</container>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
   </customwidget>
   <customwidget>
    <class>QgsProjectionSelectionWidget</class>
@@ -2599,9 +2576,26 @@ p, li { white-space: pre-wrap; }
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsRasterBandComboBox</class>
+   <class>QgsFieldComboBox</class>
    <extends>QComboBox</extends>
-   <header>qgsrasterbandcombobox.h</header>
+   <header>qgsfieldcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsWebView</class>
+   <extends>QWidget</extends>
+   <header>qgswebview.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDateTimeEdit</class>
+   <extends>QDateTimeEdit</extends>
+   <header>qgsdatetimeedit.h</header>
   </customwidget>
   <customwidget>
    <class>QgsScaleRangeWidget</class>
@@ -2615,32 +2609,53 @@ p, li { white-space: pre-wrap; }
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsBlendModeComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsblendmodecombobox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsWebView</class>
+   <class>QgsOpacityWidget</class>
    <extends>QWidget</extends>
-   <header>qgswebview.h</header>
+   <header>qgsopacitywidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsFieldComboBox</class>
+   <class>QgsRasterBandComboBox</class>
    <extends>QComboBox</extends>
-   <header>qgsfieldcombobox.h</header>
+   <header>raster/qgsrasterbandcombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mSearchLineEdit</tabstop>
   <tabstop>mOptionsListWidget</tabstop>
+  <tabstop>scrollArea_3</tabstop>
   <tabstop>mLayerOrigNameLineEd</tabstop>
   <tabstop>leDisplayName</tabstop>
+  <tabstop>mCrsGroupBox</tabstop>
   <tabstop>mCrsSelector</tabstop>
+  <tabstop>mWmstGroup</tabstop>
+  <tabstop>mFetchModeComboBox</tabstop>
+  <tabstop>mDisableTime</tabstop>
+  <tabstop>mStaticTemporalRange</tabstop>
+  <tabstop>mStartStaticDateTimeEdit</tabstop>
+  <tabstop>mEndStaticDateTimeEdit</tabstop>
+  <tabstop>mSetEndAsStartStaticButton</tabstop>
+  <tabstop>mProjectTemporalRange</tabstop>
+  <tabstop>mReferenceTime</tabstop>
+  <tabstop>mReferenceDateTimeEdit</tabstop>
+  <tabstop>mPostgresRasterTemporalGroup</tabstop>
+  <tabstop>mPostgresRasterTemporalFieldComboBox</tabstop>
+  <tabstop>mPostgresRasterDefaultTime</tabstop>
+  <tabstop>mResetColorRenderingBtn</tabstop>
   <tabstop>scrollArea</tabstop>
   <tabstop>mRenderTypeComboBox</tabstop>
   <tabstop>mBlendModeComboBox</tabstop>
-  <tabstop>mResetColorRenderingBtn</tabstop>
   <tabstop>mSliderBrightness</tabstop>
   <tabstop>mBrightnessSpinBox</tabstop>
   <tabstop>mSliderContrast</tabstop>
@@ -2657,6 +2672,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>mZoomedInResamplingComboBox</tabstop>
   <tabstop>mZoomedOutResamplingComboBox</tabstop>
   <tabstop>mMaximumOversamplingSpinBox</tabstop>
+  <tabstop>mCbEarlyResampling</tabstop>
   <tabstop>scrollArea_2</tabstop>
   <tabstop>mOpacityWidget</tabstop>
   <tabstop>mSrcNoDataValueCheckBox</tabstop>
@@ -2669,10 +2685,10 @@ p, li { white-space: pre-wrap; }
   <tabstop>pbnDefaultValues</tabstop>
   <tabstop>pbnImportTransparentPixelValues</tabstop>
   <tabstop>pbnExportTransparentPixelValues</tabstop>
+  <tabstop>scrollArea_6</tabstop>
   <tabstop>chkUseScaleDependentRendering</tabstop>
   <tabstop>mRefreshLayerCheckBox</tabstop>
   <tabstop>mRefreshLayerIntervalSpinBox</tabstop>
-  <tabstop>scrollArea_6</tabstop>
   <tabstop>scrollArea_5</tabstop>
   <tabstop>tePyramidDescription</tabstop>
   <tabstop>lbxPyramidResolutions</tabstop>
@@ -2696,20 +2712,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>mWMSPrintLayerLineEdit</tabstop>
   <tabstop>mPublishDataSourceUrlCheckBox</tabstop>
   <tabstop>mBackgroundLayerCheckBox</tabstop>
-  <tabstop>scrollArea_3</tabstop>
-  <tabstop>mWmstGroup</tabstop>
-  <tabstop>mFetchModeComboBox</tabstop>
-  <tabstop>mDisableTime</tabstop>
-  <tabstop>mReferenceDateTimeEdit</tabstop>
-  <tabstop>mReferenceTime</tabstop>
-  <tabstop>mStaticTemporalRange</tabstop>
-  <tabstop>mSetEndAsStartStaticButton</tabstop>
-  <tabstop>mEndStaticDateTimeEdit</tabstop>
-  <tabstop>mStartStaticDateTimeEdit</tabstop>
-  <tabstop>mProjectTemporalRange</tabstop>
-  <tabstop>mPostgresRasterTemporalGroup</tabstop>
-  <tabstop>mPostgresRasterTemporalFieldComboBox</tabstop>
-  <tabstop>mPostgresRasterDefaultTime</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsrelationmanageradddialogbase.ui
+++ b/src/ui/qgsrelationmanageradddialogbase.ui
@@ -134,6 +134,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>mIdLineEdit</tabstop>
+  <tabstop>mNameLineEdit</tabstop>
+  <tabstop>mRelationStrengthComboBox</tabstop>
+  <tabstop>mFieldsMappingTable</tabstop>
+  <tabstop>mFieldsMappingAddButton</tabstop>
+  <tabstop>mFieldsMappingRemoveButton</tabstop>
+ </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>

--- a/src/ui/qgsrelationmanageraddpolymorphicdialogbase.ui
+++ b/src/ui/qgsrelationmanageraddpolymorphicdialogbase.ui
@@ -171,11 +171,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsCheckableComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgscheckablecombobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsFieldComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsfieldcombobox.h</header>
@@ -184,13 +179,29 @@
    <class>QgsFieldExpressionWidget</class>
    <extends>QWidget</extends>
    <header>qgsfieldexpressionwidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsMapLayerComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsmaplayercombobox.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsCheckableComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgscheckablecombobox.h</header>
+  </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mIdLineEdit</tabstop>
+  <tabstop>mReferencingLayerComboBox</tabstop>
+  <tabstop>mReferencedLayerFieldComboBox</tabstop>
+  <tabstop>mRelationStrengthComboBox</tabstop>
+  <tabstop>mFieldsMappingTable</tabstop>
+  <tabstop>mFieldsMappingAddButton</tabstop>
+  <tabstop>mFieldsMappingRemoveButton</tabstop>
+  <tabstop>mReferencedLayersComboBox</tabstop>
+ </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>

--- a/src/ui/qgssourcefieldsproperties.ui
+++ b/src/ui/qgssourcefieldsproperties.ui
@@ -111,6 +111,13 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>mFieldsList</tabstop>
+  <tabstop>mAddAttributeButton</tabstop>
+  <tabstop>mDeleteAttributeButton</tabstop>
+  <tabstop>mToggleEditingButton</tabstop>
+  <tabstop>mCalculateFieldButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -718,7 +718,7 @@
                        <x>0</x>
                        <y>0</y>
                        <width>485</width>
-                       <height>429</height>
+                       <height>433</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
@@ -1280,8 +1280,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>374</width>
-                       <height>708</height>
+                       <width>471</width>
+                       <height>666</height>
                       </rect>
                      </property>
                      <layout class="QGridLayout" name="gridLayout_42">
@@ -2164,8 +2164,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>299</width>
-                       <height>308</height>
+                       <width>485</width>
+                       <height>433</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -2510,8 +2510,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>296</width>
-                       <height>291</height>
+                       <width>485</width>
+                       <height>433</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_121">
@@ -2788,8 +2788,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>444</width>
-                       <height>786</height>
+                       <width>471</width>
+                       <height>740</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -3549,8 +3549,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>324</width>
-                       <height>457</height>
+                       <width>485</width>
+                       <height>433</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -3977,8 +3977,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>159</width>
-                       <height>211</height>
+                       <width>485</width>
+                       <height>433</height>
                       </rect>
                      </property>
                      <layout class="QGridLayout" name="gridLayout_46">
@@ -4127,8 +4127,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>472</width>
-                       <height>1686</height>
+                       <width>474</width>
+                       <height>1599</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -5826,9 +5826,9 @@ font-style: italic;</string>
                      <property name="geometry">
                       <rect>
                        <x>0</x>
-                       <y>-304</y>
+                       <y>0</y>
                        <width>471</width>
-                       <height>708</height>
+                       <height>666</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -6578,20 +6578,9 @@ font-style: italic;</string>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -6605,14 +6594,9 @@ font-style: italic;</string>
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -6622,15 +6606,31 @@ font-style: italic;</string>
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsScaleWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsUnitSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsScaleWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsscalewidget.h</header>
   </customwidget>
   <customwidget>
    <class>QgsEffectStackCompactWidget</class>
@@ -6674,6 +6674,7 @@ font-style: italic;</string>
  </customwidgets>
  <tabstops>
   <tabstop>mFieldExpressionWidget</tabstop>
+  <tabstop>scrollArea_mPreview</tabstop>
   <tabstop>mPreviewTextEdit</tabstop>
   <tabstop>mPreviewTextBtn</tabstop>
   <tabstop>mPreviewScaleComboBox</tabstop>
@@ -6703,6 +6704,19 @@ font-style: italic;</string>
   <tabstop>mFontOpacityDDBtn</tabstop>
   <tabstop>mHtmlFormattingCheckBox</tabstop>
   <tabstop>scrollArea_5</tabstop>
+  <tabstop>mFontCapitalsComboBox</tabstop>
+  <tabstop>mFontCaseDDBtn</tabstop>
+  <tabstop>mFontLetterSpacingSpinBox</tabstop>
+  <tabstop>mFontLetterSpacingDDBtn</tabstop>
+  <tabstop>mFontWordSpacingSpinBox</tabstop>
+  <tabstop>mFontWordSpacingDDBtn</tabstop>
+  <tabstop>mKerningCheckBox</tabstop>
+  <tabstop>mTextOrientationComboBox</tabstop>
+  <tabstop>mTextOrientationDDBtn</tabstop>
+  <tabstop>comboBlendMode</tabstop>
+  <tabstop>mFontBlendModeDDBtn</tabstop>
+  <tabstop>mCheckBoxSubstituteText</tabstop>
+  <tabstop>mToolButtonConfigureSubstitutes</tabstop>
   <tabstop>wrapCharacterEdit</tabstop>
   <tabstop>mWrapCharDDBtn</tabstop>
   <tabstop>mAutoWrapLengthSpinBox</tabstop>
@@ -6733,8 +6747,8 @@ font-style: italic;</string>
   <tabstop>mFormatNumPlusSignChkBx</tabstop>
   <tabstop>mFormatNumPlusSignDDBtn</tabstop>
   <tabstop>scrollArea_7</tabstop>
-  <tabstop>mEnableMaskChkBx</tabstop>
-  <tabstop>mEnableMaskDDBtn</tabstop>
+  <tabstop>mBufferDrawChkBx</tabstop>
+  <tabstop>mBufferDrawDDBtn</tabstop>
   <tabstop>spinBufferSize</tabstop>
   <tabstop>mBufferSizeDDBtn</tabstop>
   <tabstop>mBufferUnitWidget</tabstop>
@@ -6748,6 +6762,17 @@ font-style: italic;</string>
   <tabstop>mBufferJoinStyleDDBtn</tabstop>
   <tabstop>comboBufferBlendMode</tabstop>
   <tabstop>mBufferBlendModeDDBtn</tabstop>
+  <tabstop>scrollArea_71</tabstop>
+  <tabstop>mEnableMaskChkBx</tabstop>
+  <tabstop>mEnableMaskDDBtn</tabstop>
+  <tabstop>mMaskBufferSizeSpinBox</tabstop>
+  <tabstop>mMaskBufferSizeDDBtn</tabstop>
+  <tabstop>mMaskBufferUnitWidget</tabstop>
+  <tabstop>mMaskBufferUnitsDDBtn</tabstop>
+  <tabstop>mMaskOpacityWidget</tabstop>
+  <tabstop>mMaskOpacityDDBtn</tabstop>
+  <tabstop>mMaskJoinStyleComboBox</tabstop>
+  <tabstop>mMaskJoinStyleDDBtn</tabstop>
   <tabstop>scrollArea_2</tabstop>
   <tabstop>mShapeDrawChkBx</tabstop>
   <tabstop>mShapeDrawDDBtn</tabstop>
@@ -6820,15 +6845,19 @@ font-style: italic;</string>
   <tabstop>mShadowColorDDBtn</tabstop>
   <tabstop>mShadowBlendCmbBx</tabstop>
   <tabstop>mShadowBlendDDBtn</tabstop>
+  <tabstop>scrollArea_6</tabstop>
+  <tabstop>mCalloutsDrawCheckBox</tabstop>
+  <tabstop>mCalloutDrawDDBtn</tabstop>
+  <tabstop>mCalloutStyleComboBox</tabstop>
   <tabstop>scrollArea_3</tabstop>
   <tabstop>mPlacementModeComboBox</tabstop>
   <tabstop>chkLineAbove</tabstop>
   <tabstop>chkLineOn</tabstop>
   <tabstop>chkLineBelow</tabstop>
+  <tabstop>mLinePlacementFlagsDDBtn</tabstop>
   <tabstop>chkLineOrientationDependent</tabstop>
   <tabstop>mCheckAllowLabelsOutsidePolygons</tabstop>
   <tabstop>mAllowOutsidePolygonsDDBtn</tabstop>
-  <tabstop>mLinePlacementFlagsDDBtn</tabstop>
   <tabstop>mCentroidRadioVisible</tabstop>
   <tabstop>mCentroidRadioWhole</tabstop>
   <tabstop>mCentroidDDBtn</tabstop>
@@ -6855,9 +6884,20 @@ font-style: italic;</string>
   <tabstop>mPointOffsetUnitWidget</tabstop>
   <tabstop>mPointOffsetUnitsDDBtn</tabstop>
   <tabstop>mPointAngleSpinBox</tabstop>
+  <tabstop>mRepeatDistanceSpinBox</tabstop>
+  <tabstop>mRepeatDistanceDDBtn</tabstop>
+  <tabstop>mRepeatDistanceUnitWidget</tabstop>
+  <tabstop>mRepeatDistanceUnitDDBtn</tabstop>
+  <tabstop>mOverrunDistanceUnitWidget</tabstop>
+  <tabstop>mOverrunDistanceSpinBox</tabstop>
+  <tabstop>mOverrunDistanceDDBtn</tabstop>
+  <tabstop>mLineAnchorSettingsButton</tabstop>
   <tabstop>mMaxCharAngleInDSpinBox</tabstop>
   <tabstop>mMaxCharAngleOutDSpinBox</tabstop>
   <tabstop>mMaxCharAngleDDBtn</tabstop>
+  <tabstop>mGeometryGeneratorGroupBox</tabstop>
+  <tabstop>mGeometryGeneratorExpressionButton</tabstop>
+  <tabstop>mGeometryGeneratorType</tabstop>
   <tabstop>mCoordXDDBtn</tabstop>
   <tabstop>mCoordYDDBtn</tabstop>
   <tabstop>mCoordAlignmentHDDBtn</tabstop>
@@ -6866,6 +6906,9 @@ font-style: italic;</string>
   <tabstop>chkPreserveRotation</tabstop>
   <tabstop>mPrioritySlider</tabstop>
   <tabstop>mPriorityDDBtn</tabstop>
+  <tabstop>mChkNoObstacle</tabstop>
+  <tabstop>mIsObstacleDDBtn</tabstop>
+  <tabstop>mObstacleSettingsButton</tabstop>
   <tabstop>scrollArea_4</tabstop>
   <tabstop>mScaleBasedVisibilityChkBx</tabstop>
   <tabstop>mScaleBasedVisibilityDDBtn</tabstop>
@@ -6894,42 +6937,6 @@ font-style: italic;</string>
   <tabstop>mLimitLabelSpinBox</tabstop>
   <tabstop>mMinSizeSpinBox</tabstop>
   <tabstop>mFitInsidePolygonCheckBox</tabstop>
-  <tabstop>scrollArea_mPreview</tabstop>
-  <tabstop>mGeometryGeneratorGroupBox</tabstop>
-  <tabstop>mGeometryGeneratorExpressionButton</tabstop>
-  <tabstop>mGeometryGeneratorType</tabstop>
-  <tabstop>mFontWordSpacingSpinBox</tabstop>
-  <tabstop>mFontCaseDDBtn</tabstop>
-  <tabstop>mFontLetterSpacingSpinBox</tabstop>
-  <tabstop>comboBlendMode</tabstop>
-  <tabstop>mToolButtonConfigureSubstitutes</tabstop>
-  <tabstop>mFontBlendModeDDBtn</tabstop>
-  <tabstop>mFontCapitalsComboBox</tabstop>
-  <tabstop>mFontLetterSpacingDDBtn</tabstop>
-  <tabstop>mCheckBoxSubstituteText</tabstop>
-  <tabstop>mFontWordSpacingDDBtn</tabstop>
-  <tabstop>mTextOrientationComboBox</tabstop>
-  <tabstop>mTextOrientationDDBtn</tabstop>
-  <tabstop>mKerningCheckBox</tabstop>
-  <tabstop>mBufferDrawDDBtn</tabstop>
-  <tabstop>mBufferDrawChkBx</tabstop>
-  <tabstop>scrollArea_71</tabstop>
-  <tabstop>mMaskJoinStyleComboBox</tabstop>
-  <tabstop>mMaskOpacityDDBtn</tabstop>
-  <tabstop>mMaskBufferUnitWidget</tabstop>
-  <tabstop>mMaskJoinStyleDDBtn</tabstop>
-  <tabstop>mMaskBufferUnitsDDBtn</tabstop>
-  <tabstop>mMaskBufferSizeSpinBox</tabstop>
-  <tabstop>mMaskBufferSizeDDBtn</tabstop>
-  <tabstop>mMaskOpacityWidget</tabstop>
-  <tabstop>scrollArea_6</tabstop>
-  <tabstop>mCalloutsDrawCheckBox</tabstop>
-  <tabstop>mCalloutDrawDDBtn</tabstop>
-  <tabstop>mCalloutStyleComboBox</tabstop>
-  <tabstop>mChkNoObstacle</tabstop>
-  <tabstop>mIsObstacleDDBtn</tabstop>
-  <tabstop>mObstacleSettingsButton</tabstop>
-  <tabstop>mLineAnchorSettingsButton</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgstilesourceselectbase.ui
+++ b/src/ui/qgstilesourceselectbase.ui
@@ -122,6 +122,11 @@
  </widget>
  <tabstops>
   <tabstop>cmbConnections</tabstop>
+  <tabstop>btnNew</tabstop>
+  <tabstop>btnEdit</tabstop>
+  <tabstop>btnDelete</tabstop>
+  <tabstop>btnLoad</tabstop>
+  <tabstop>btnSave</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -440,7 +440,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>653</width>
-                <height>679</height>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -756,8 +756,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>100</width>
-                <height>30</height>
+                <width>653</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_18">
@@ -973,8 +973,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>104</width>
-                <height>102</height>
+                <width>653</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -1368,8 +1368,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>100</width>
-                <height>30</height>
+                <width>653</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -1570,8 +1570,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>689</width>
-                <height>356</height>
+                <width>695</width>
+                <height>667</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -2062,8 +2062,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>343</width>
-                <height>797</height>
+                <width>639</width>
+                <height>769</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -2567,14 +2567,26 @@ border-radius: 2px;</string>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsFilterLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgsfilterlineedit.h</header>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsScrollArea</class>
@@ -2583,21 +2595,15 @@ border-radius: 2px;</string>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <class>QgsFieldExpressionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfieldexpressionwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsVariableEditorWidget</class>
    <extends>QWidget</extends>
    <header location="global">qgsvariableeditorwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsProjectionSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -2623,12 +2629,6 @@ border-radius: 2px;</string>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsFieldExpressionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsfieldexpressionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsCodeEditorHTML</class>
    <extends>QWidget</extends>
    <header>qgscodeeditorhtml.h</header>
@@ -2648,10 +2648,11 @@ border-radius: 2px;</string>
   <tabstop>mLayerOrigNameLineEdit</tabstop>
   <tabstop>txtDisplayName</tabstop>
   <tabstop>cboProviderEncoding</tabstop>
+  <tabstop>mCrsGroupBox</tabstop>
   <tabstop>mCrsSelector</tabstop>
+  <tabstop>mGeomGroupBox</tabstop>
   <tabstop>pbnIndex</tabstop>
   <tabstop>pbnUpdateExtents</tabstop>
-  <tabstop>txtSubsetSQL</tabstop>
   <tabstop>pbnQueryBuilder</tabstop>
   <tabstop>scrollArea_3</tabstop>
   <tabstop>mJoinTreeWidget</tabstop>
@@ -2699,6 +2700,10 @@ border-radius: 2px;</string>
   <tabstop>mLayerMetadataUrlFormatComboBox</tabstop>
   <tabstop>mLayerLegendUrlLineEdit</tabstop>
   <tabstop>mLayerLegendUrlFormatComboBox</tabstop>
+  <tabstop>mWmsDimensionsTreeWidget</tabstop>
+  <tabstop>mButtonAddWmsDimension</tabstop>
+  <tabstop>mButtonEditWmsDimension</tabstop>
+  <tabstop>mButtonRemoveWmsDimension</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgswmsdimensiondialogbase.ui
+++ b/src/ui/qgswmsdimensiondialogbase.ui
@@ -151,6 +151,15 @@
    <header>qgsfieldcombobox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mNameComboBox</tabstop>
+  <tabstop>mFieldComboBox</tabstop>
+  <tabstop>mEndFieldComboBox</tabstop>
+  <tabstop>mUnitsLineEdit</tabstop>
+  <tabstop>mUnitSymbolLineEdit</tabstop>
+  <tabstop>mDefaultDisplayComboBox</tabstop>
+  <tabstop>mReferenceValueComboBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/qgsxyzsourcewidgetbase.ui
+++ b/src/ui/qgsxyzsourcewidgetbase.ui
@@ -157,6 +157,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
    <header>auth/qgsauthsettingswidget.h</header>
@@ -168,12 +173,16 @@
    <header>qgsprovidersourcewidget.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mEditUrl</tabstop>
+  <tabstop>mCheckBoxZMin</tabstop>
+  <tabstop>mSpinZMin</tabstop>
+  <tabstop>mCheckBoxZMax</tabstop>
+  <tabstop>mSpinZMax</tabstop>
+  <tabstop>mEditReferer</tabstop>
+  <tabstop>mComboTileResolution</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/raster/qgsrasterlayertemporalpropertieswidgetbase.ui
+++ b/src/ui/raster/qgsrasterlayertemporalpropertieswidgetbase.ui
@@ -212,10 +212,11 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
  </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
+  <tabstop>mTemporalGroupBox</tabstop>
+  <tabstop>mModeAutomaticRadio</tabstop>
   <tabstop>mModeFixedRangeRadio</tabstop>
   <tabstop>mStartTemporalDateTimeEdit</tabstop>
   <tabstop>mEndTemporalDateTimeEdit</tabstop>
-  <tabstop>mTemporalGroupBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/symbollayer/widget_fontmarker.ui
+++ b/src/ui/symbollayer/widget_fontmarker.ui
@@ -550,9 +550,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -561,9 +566,10 @@
    <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>
@@ -576,16 +582,12 @@
    <extends>QComboBox</extends>
    <header>qgspenstylecombobox.h</header>
   </customwidget>
-  <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
-  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>cboFont</tabstop>
+  <tabstop>mFontFamilyDDBtn</tabstop>
   <tabstop>mFontStyleComboBox</tabstop>
+  <tabstop>mFontStyleDDBtn</tabstop>
   <tabstop>spinSize</tabstop>
   <tabstop>mSizeUnitWidget</tabstop>
   <tabstop>mSizeDDBtn</tabstop>
@@ -609,7 +611,9 @@
   <tabstop>mHorizontalAnchorComboBox</tabstop>
   <tabstop>mHorizontalAnchorDDBtn</tabstop>
   <tabstop>scrollArea</tabstop>
+  <tabstop>mCharLineEdit</tabstop>
   <tabstop>mCharDDBtn</tabstop>
+  <tabstop>mCharPreview</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/symbollayer/widget_randommarkerfill.ui
+++ b/src/ui/symbollayer/widget_randommarkerfill.ui
@@ -92,7 +92,7 @@
         <number>6</number>
        </property>
        <property name="minimum">
-        <double>0.0</double>
+        <double>0.000000000000000</double>
        </property>
        <property name="maximum">
         <double>99999999.989999994635582</double>
@@ -113,7 +113,7 @@
        <property name="focusPolicy">
         <enum>Qt::StrongFocus</enum>
        </property>
-      </widget>     
+      </widget>
      </item>
     </layout>
    </item>
@@ -165,11 +165,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
@@ -179,9 +174,29 @@
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsUnitSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsunitselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>mCountMethodComboBox</tabstop>
+  <tabstop>mPointCountSpinBox</tabstop>
   <tabstop>mPointCountDdbtn</tabstop>
+  <tabstop>mDensityAreaSpinBox</tabstop>
+  <tabstop>mDensityAreaUnitWidget</tabstop>
+  <tabstop>mDensityAreaDdbtn</tabstop>
+  <tabstop>mSeedSpinBox</tabstop>
+  <tabstop>mSeedDdbtn</tabstop>
+  <tabstop>mClipPointsCheckBox</tabstop>
+  <tabstop>mClipPointsDdbtn</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/symbollayer/widget_rastermarker.ui
+++ b/src/ui/symbollayer/widget_rastermarker.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>338</width>
-    <height>439</height>
+    <width>372</width>
+    <height>485</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -177,7 +177,7 @@
         <number>2</number>
        </property>
        <item>
-        <widget class="QgsRatioLockButton" name="mLockAspectRatio" native="true">
+        <widget class="QgsRatioLockButton" name="mLockAspectRatio">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
            <horstretch>0</horstretch>
@@ -451,6 +451,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsRatioLockButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsratiolockbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
@@ -465,11 +471,6 @@
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsRatioLockButton</class>
-   <extends>QWidget</extends>
-   <header>qgsratiolockbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsOpacityWidget</class>
@@ -488,8 +489,9 @@
   <tabstop>mImageSourceLineEdit</tabstop>
   <tabstop>mFilenameDDBtn</tabstop>
   <tabstop>mWidthSpinBox</tabstop>
-  <tabstop>mWidthDDBtn</tabstop>
   <tabstop>mHeightSpinBox</tabstop>
+  <tabstop>mLockAspectRatio</tabstop>
+  <tabstop>mWidthDDBtn</tabstop>
   <tabstop>mHeightDDBtn</tabstop>
   <tabstop>mSizeUnitWidget</tabstop>
   <tabstop>mOpacityWidget</tabstop>

--- a/src/ui/symbollayer/widget_simpleline.ui
+++ b/src/ui/symbollayer/widget_simpleline.ui
@@ -509,15 +509,15 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>
@@ -531,9 +531,10 @@
    <header>qgspenstylecombobox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsPenStyleComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgspenstylecombobox.h</header>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsPenCapStyleComboBox</class>
@@ -541,10 +542,9 @@
    <header>qgspenstylecombobox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
-   <container>1</container>
+   <class>QgsPenStyleComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgspenstylecombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -569,6 +569,14 @@
   <tabstop>spinPatternOffset</tabstop>
   <tabstop>mPatternOffsetUnitWidget</tabstop>
   <tabstop>mPatternOffsetDDBtn</tabstop>
+  <tabstop>mCheckAlignDash</tabstop>
+  <tabstop>mCheckDashCorners</tabstop>
+  <tabstop>mTrimStartDistanceSpin</tabstop>
+  <tabstop>mTrimDistanceStartUnitWidget</tabstop>
+  <tabstop>mTrimDistanceStartDDBtn</tabstop>
+  <tabstop>mTrimDistanceEndSpin</tabstop>
+  <tabstop>mTrimDistanceEndUnitWidget</tabstop>
+  <tabstop>mTrimDistanceEndDDBtn</tabstop>
   <tabstop>mDrawInsideCheckBox</tabstop>
   <tabstop>mRingFilterComboBox</tabstop>
  </tabstops>

--- a/src/ui/symbollayer/widget_svgmarker.ui
+++ b/src/ui/symbollayer/widget_svgmarker.ui
@@ -152,7 +152,7 @@
         <number>2</number>
        </property>
        <item>
-        <widget class="QgsRatioLockButton" name="mLockAspectRatio" native="true">
+        <widget class="QgsRatioLockButton" name="mLockAspectRatio">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
            <horstretch>0</horstretch>
@@ -486,9 +486,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QPushButton</extends>
-   <header>qgscolorbutton.h</header>
+   <class>QgsRatioLockButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsratiolockbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -502,15 +502,16 @@
    <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsUnitSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsRatioLockButton</class>
-   <extends>QWidget</extends>
-   <header>qgsratiolockbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsSvgSelectorWidget</class>
@@ -522,9 +523,10 @@
  <tabstops>
   <tabstop>spinWidth</tabstop>
   <tabstop>spinHeight</tabstop>
-  <tabstop>mSizeUnitWidget</tabstop>
+  <tabstop>mLockAspectRatio</tabstop>
   <tabstop>mWidthDDBtn</tabstop>
   <tabstop>mHeightDDBtn</tabstop>
+  <tabstop>mSizeUnitWidget</tabstop>
   <tabstop>mChangeColorButton</tabstop>
   <tabstop>mFillColorDDBtn</tabstop>
   <tabstop>mChangeStrokeColorButton</tabstop>

--- a/src/ui/symbollayer/widget_svgselector.ui
+++ b/src/ui/symbollayer/widget_svgselector.ui
@@ -209,18 +209,26 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsSvgSourceLineEdit</class>
    <extends>QWidget</extends>
    <header>qgsfilecontentsourcelineedit.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mSvgSourceLineEdit</tabstop>
+  <tabstop>mGroupsTreeView</tabstop>
+  <tabstop>mImagesListView</tabstop>
+  <tabstop>mParametersTreeView</tabstop>
+  <tabstop>mAddParameterButton</tabstop>
+  <tabstop>mRemoveParameterButton</tabstop>
+ </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>
  </resources>

--- a/src/ui/symbollayer/widget_symbolslist.ui
+++ b/src/ui/symbollayer/widget_symbolslist.ui
@@ -444,9 +444,14 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsOpacityWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsopacitywidget.h</header>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -456,15 +461,10 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
+   <class>QgsOpacityWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsopacitywidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsStyleItemsListWidget</class>
@@ -480,12 +480,21 @@
   <tabstop>mRotationDDBtn</tabstop>
   <tabstop>spinWidth</tabstop>
   <tabstop>mWidthDDBtn</tabstop>
+  <tabstop>btnMarkerColor</tabstop>
+  <tabstop>mMarkerOpacityWidget</tabstop>
+  <tabstop>mMarkerOpacityDDBtn</tabstop>
   <tabstop>spinSize</tabstop>
   <tabstop>mSizeDDBtn</tabstop>
   <tabstop>spinAngle</tabstop>
   <tabstop>mRotationDDBtn</tabstop>
+  <tabstop>btnLineColor</tabstop>
+  <tabstop>mLineOpacityWidget</tabstop>
+  <tabstop>mLineOpacityDDBtn</tabstop>
   <tabstop>spinWidth</tabstop>
   <tabstop>mWidthDDBtn</tabstop>
+  <tabstop>btnFillColor</tabstop>
+  <tabstop>mFillOpacityWidget</tabstop>
+  <tabstop>mFillOpacityDDBtn</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
A walk trough src/ui files in Qt Designer to check and fix tab navigation (and sometimes default tab to show). Also remove some duplicates theme files include with text editor. All the other changes (dimensions, classes includes) in the files are triggered while saving in Qt. I assume they are not an issue so left them in.
Should fix #42329 (though I'm unable to follow what happens in the vid)