### PR TITLE
Change default search completion mode in the attribute table for string based fields

### DIFF
--- a/src/gui/qgsfieldvalueslineedit.cpp
+++ b/src/gui/qgsfieldvalueslineedit.cpp
@@ -28,6 +28,7 @@ QgsFieldValuesLineEdit::QgsFieldValuesLineEdit( QWidget *parent )
   QCompleter *c = new QCompleter( this );
   c->setCaseSensitivity( Qt::CaseInsensitive );
   c->setFilterMode( Qt::MatchContains );
+  c->setCompletionMode( QCompleter::UnfilteredPopupCompletion );
   setCompleter( c );
   connect( this, &QgsFieldValuesLineEdit::textEdited, this, &QgsFieldValuesLineEdit::requestCompleterUpdate );
   mShowPopupTimer.setSingleShot( true );


### PR DESCRIPTION
## Description

This PR tries to overcome a current limitation of the default [QCompleter mode](https://doc.qt.io/qt-5/qcompleter.html#CompletionMode-enum). In the default mode `QCompleter::PopupCompletion`, the user is not able to enter accented characters while the dropdown combo is displayed.

Changing the default mode to `QCompleter::UnfilteredPopupCompletion` solves this issue.

Fix #42349