### PR TITLE
Fix some ArcGis VectorTileServer urls cannot be directly loaded

### DIFF
--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -34,6 +34,7 @@
 #include "qgsmaplayerfactory.h"
 
 #include <QUrl>
+#include <QUrlQuery>
 
 QgsVectorTileLayer::QgsVectorTileLayer( const QString &uri, const QString &baseName )
   : QgsMapLayer( QgsMapLayerType::VectorTileLayer, baseName )
@@ -123,9 +124,16 @@ bool QgsVectorTileLayer::loadDataSource()
 
 bool QgsVectorTileLayer::setupArcgisVectorTileServiceConnection( const QString &uri, const QgsDataSourceUri &dataSourceUri )
 {
-  QNetworkRequest request = QNetworkRequest( QUrl( uri ) );
+  QUrl url( uri );
+  // some services don't default to json format, while others do... so let's explicitly request it!
+  // (refs https://github.com/qgis/QGIS/issues/4231)
+  QUrlQuery query;
+  query.addQueryItem( QStringLiteral( "f" ), QStringLiteral( "pjson" ) );
+  url.setQuery( query );
 
-  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsVectorTileLayer" ) );
+  QNetworkRequest request = QNetworkRequest( url );
+
+  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsVectorTileLayer" ) )
 
   QgsBlockingNetworkRequest networkRequest;
   switch ( networkRequest.get( request ) )
@@ -417,7 +425,7 @@ bool QgsVectorTileLayer::loadDefaultStyle( QString &error, QStringList &warnings
       for ( int resolution = 2; resolution > 0; resolution-- )
       {
         QNetworkRequest request = QNetworkRequest( QUrl( spriteUriBase + QStringLiteral( "%1.json" ).arg( resolution > 1 ? QStringLiteral( "@%1x" ).arg( resolution ) : QString() ) ) );
-        QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsVectorTileLayer" ) );
+        QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsVectorTileLayer" ) )
         QgsBlockingNetworkRequest networkRequest;
         switch ( networkRequest.get( request ) )
         {
@@ -429,7 +437,7 @@ bool QgsVectorTileLayer::loadDefaultStyle( QString &error, QStringList &warnings
             // retrieve sprite images
             QNetworkRequest request = QNetworkRequest( QUrl( spriteUriBase + QStringLiteral( "%1.png" ).arg( resolution > 1 ? QStringLiteral( "@%1x" ).arg( resolution ) : QString() ) ) );
 
-            QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsVectorTileLayer" ) );
+            QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsVectorTileLayer" ) )
 
             QgsBlockingNetworkRequest networkRequest;
             switch ( networkRequest.get( request ) )


### PR DESCRIPTION
Some services don't default to returning JSON for the capabilities,
so explicitly request it

Fixes #42314
