### PR TITLE
When running "point on surface" with "create point for each part" option enabled, discard incoming fid fields and regenerate

### DIFF
--- a/src/analysis/processing/qgsalgorithmpointonsurface.cpp
+++ b/src/analysis/processing/qgsalgorithmpointonsurface.cpp
@@ -94,7 +94,7 @@ QgsFeatureList QgsPointOnSurfaceAlgorithm::processFeature( const QgsFeature &f, 
 {
   QgsFeatureList list;
   QgsFeature feature = f;
-  if ( feature.hasGeometry() )
+  if ( feature.hasGeometry() && !feature.geometry().isEmpty() )
   {
     QgsGeometry geom = feature.geometry();
 
@@ -106,13 +106,15 @@ QgsFeatureList QgsPointOnSurfaceAlgorithm::processFeature( const QgsFeature &f, 
     {
       const QgsGeometryCollection *geomCollection = static_cast<const QgsGeometryCollection *>( geom.constGet() );
 
-      for ( int i = 0; i < geomCollection->partCount(); ++i )
+      const int partCount = geomCollection->partCount();
+      list.reserve( partCount );
+      for ( int i = 0; i < partCount; ++i )
       {
         QgsGeometry partGeometry( geomCollection->geometryN( i )->clone() );
         QgsGeometry outputGeometry = partGeometry.pointOnSurface();
         if ( outputGeometry.isNull() )
         {
-          feedback->pushInfo( QObject::tr( "Error calculating point on surface for feature %1 part %2: %3" ).arg( feature.id() ).arg( i ).arg( outputGeometry.lastError() ) );
+          feedback->reportError( QObject::tr( "Error calculating point on surface for feature %1 part %2: %3" ).arg( feature.id() ).arg( i ).arg( outputGeometry.lastError() ) );
         }
         feature.setGeometry( outputGeometry );
         list << feature;
@@ -123,7 +125,7 @@ QgsFeatureList QgsPointOnSurfaceAlgorithm::processFeature( const QgsFeature &f, 
       QgsGeometry outputGeometry = feature.geometry().pointOnSurface();
       if ( outputGeometry.isNull() )
       {
-        feedback->pushInfo( QObject::tr( "Error calculating point on surface for feature %1: %2" ).arg( feature.id() ).arg( outputGeometry.lastError() ) );
+        feedback->reportError( QObject::tr( "Error calculating point on surface for feature %1: %2" ).arg( feature.id() ).arg( outputGeometry.lastError() ) );
       }
       feature.setGeometry( outputGeometry );
       list << feature;

--- a/src/analysis/processing/qgsalgorithmpointonsurface.cpp
+++ b/src/analysis/processing/qgsalgorithmpointonsurface.cpp
@@ -50,6 +50,14 @@ QString QgsPointOnSurfaceAlgorithm::outputName() const
   return QObject::tr( "Point" );
 }
 
+QgsFeatureSink::SinkFlags QgsPointOnSurfaceAlgorithm::sinkFlags() const
+{
+  if ( mAllParts )
+    return QgsProcessingFeatureBasedAlgorithm::sinkFlags() | QgsFeatureSink::RegeneratePrimaryKey;
+  else
+    return QgsProcessingFeatureBasedAlgorithm::sinkFlags();
+}
+
 QString QgsPointOnSurfaceAlgorithm::shortHelpString() const
 {
   return QObject::tr( "Returns a point guaranteed to lie on the surface of a geometry." );

--- a/src/analysis/processing/qgsalgorithmpointonsurface.h
+++ b/src/analysis/processing/qgsalgorithmpointonsurface.h
@@ -51,6 +51,7 @@ class QgsPointOnSurfaceAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString outputName() const override;
     QgsProcessing::SourceType outputLayerType() const override { return QgsProcessing::TypeVectorPoint; }
     QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type inputWkbType ) const override { Q_UNUSED( inputWkbType ) return QgsWkbTypes::Point; }
+    QgsFeatureSink::SinkFlags sinkFlags() const override;
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;


### PR DESCRIPTION
Because we are potentially outputing multiple features per input
feature when this option is enabled, we can't guarantee that the
existing fid values will be unique.

Fixes #42350
