### PR TITLE
Explicitly state in temporal controller dock that the visible time range is lower < t <= upper

### DIFF
--- a/src/ui/qgstemporalcontrollerwidgetbase.ui
+++ b/src/ui/qgstemporalcontrollerwidgetbase.ui
@@ -193,11 +193,43 @@
           </widget>
          </item>
          <item>
+          <spacer name="horizontalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>5</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
           <widget class="QLabel" name="mFixedRangeRangeToLabel">
            <property name="text">
-            <string>to </string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;≤ &lt;span style=&quot; font-style:italic;&quot;&gt;t&lt;/span&gt; &amp;lt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
           </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>5</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
          <item>
           <widget class="QDateTimeEdit" name="mFixedRangeEndDateTime">
@@ -421,11 +453,43 @@
           </widget>
          </item>
          <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>5</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
           <widget class="QLabel" name="mRangeToLabel">
            <property name="text">
-            <string>to </string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;≤ &lt;span style=&quot; font-style:italic;&quot;&gt;t&lt;/span&gt; &amp;lt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
           </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>5</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
          <item>
           <widget class="QDateTimeEdit" name="mEndDateTime">


### PR DESCRIPTION
Provides explicit clarification to users that the upper time in the current filter time range is NOT visible in the canvas

Follows on from the length discussion in https://github.com/qgis/QGIS/pull/40989 and is designed to make the situation obvious to users.

Instead of the ambiguous range:

![image](https://user-images.githubusercontent.com/1829991/111926117-4c80d980-8af7-11eb-8d92-3d8d4207d7d5.png)

we now show:

![image](https://user-images.githubusercontent.com/1829991/111926161-720de300-8af7-11eb-80b2-a090741d578c.png)

so that there's absolutely no room for misinterpretation
