### PR TITLE
Set missing nm relation for QgsAbstractRelationEditorConfigWidget

### DIFF
--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -320,7 +320,7 @@ Returns the relation for which this configuration widget applies
 %Docstring
 Set the nm relation for this widget.
 
-:param config: The nm relation
+:param nmRelation: The nm relation
 %End
 
     virtual QgsRelation nmRelation() const;

--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -316,6 +316,19 @@ Returns the relation for which this configuration widget applies
 :return: The relation
 %End
 
+    virtual void setNmRelation( const QgsRelation &nmRelation );
+%Docstring
+Set the nm relation for this widget.
+
+:param config: The nm relation
+%End
+
+    virtual QgsRelation nmRelation() const;
+%Docstring
+Returns the nm relation for which this configuration widget applies
+
+:return: The nm relation
+%End
 
 };
 

--- a/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
+++ b/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
@@ -100,11 +100,14 @@ QgsAttributeWidgetRelationEditWidget::QgsAttributeWidgetRelationEditWidget( QWid
     it.next();
     mWidgetTypeComboBox->addItem( it.value()->name(), it.key() );
   }
+
+  connect( mRelationCardinalityCombo, QOverload<int>::of( &QComboBox::currentIndexChanged ), this, &QgsAttributeWidgetRelationEditWidget::relationCardinalityComboCurrentIndexChanged );
 }
 
 void QgsAttributeWidgetRelationEditWidget::setRelationEditorConfiguration( const QgsAttributesFormProperties::RelationEditorConfiguration &config, const QString &relationId )
 {
   //load the combo mRelationCardinalityCombo
+  mRelationCardinalityCombo->clear();
   setCardinalityCombo( tr( "Many to one relation" ) );
 
   QgsRelation relation = QgsProject::instance()->relationManager()->relation( relationId );
@@ -161,6 +164,18 @@ QgsAttributesFormProperties::RelationEditorConfiguration QgsAttributeWidgetRelat
   relEdCfg.forceSuppressFormPopup = mRelationForceSuppressFormPopupCheckBox->isChecked();
   relEdCfg.label = mRelationLabelEdit->text();
   return relEdCfg;
+}
+
+void QgsAttributeWidgetRelationEditWidget::relationCardinalityComboCurrentIndexChanged( int index )
+{
+  if ( index < 0 )
+    return;
+
+  if ( !mConfigWidget )
+    return;
+
+  QgsRelation nmRelation = QgsProject::instance()->relationManager()->relation( mRelationCardinalityCombo->currentData().toString() );
+  mConfigWidget->setNmRelation( nmRelation );
 }
 
 void QgsAttributeWidgetRelationEditWidget::setCardinalityCombo( const QString &cardinalityComboItem, const QVariant &auserData )

--- a/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
+++ b/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
@@ -101,7 +101,7 @@ QgsAttributeWidgetRelationEditWidget::QgsAttributeWidgetRelationEditWidget( QWid
     mWidgetTypeComboBox->addItem( it.value()->name(), it.key() );
   }
 
-  connect( mRelationCardinalityCombo, QOverload<int>::of( &QComboBox::currentIndexChanged ), this, &QgsAttributeWidgetRelationEditWidget::relationCardinalityComboCurrentIndexChanged );
+  connect( mRelationCardinalityCombo, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsAttributeWidgetRelationEditWidget::relationCardinalityComboCurrentIndexChanged );
 }
 
 void QgsAttributeWidgetRelationEditWidget::setRelationEditorConfiguration( const QgsAttributesFormProperties::RelationEditorConfiguration &config, const QString &relationId )

--- a/src/gui/attributeformconfig/qgsattributewidgetedit.h
+++ b/src/gui/attributeformconfig/qgsattributewidgetedit.h
@@ -70,6 +70,9 @@ class GUI_EXPORT QgsAttributeWidgetRelationEditWidget : public QWidget, private 
 
     static QString title() { return tr( "Relation" ); }
 
+  private slots:
+    void relationCardinalityComboCurrentIndexChanged( int index );
+
   private:
     void setCardinalityCombo( const QString &cardinalityComboItem, const QVariant &auserData = QVariant() );
     void setNmRelationId( const QVariant &auserData = QVariant() );

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -651,6 +651,16 @@ QgsRelation QgsAbstractRelationEditorConfigWidget::relation() const
   return mRelation;
 }
 
+void QgsAbstractRelationEditorConfigWidget::setNmRelation( const QgsRelation &nmRelation )
+{
+  mNmRelation = nmRelation;
+}
+
+QgsRelation QgsAbstractRelationEditorConfigWidget::nmRelation() const
+{
+  return mNmRelation;
+}
+
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -349,7 +349,7 @@ class GUI_EXPORT QgsAbstractRelationEditorConfigWidget : public QWidget
     /**
      * \brief Set the nm relation for this widget.
      *
-     * \param config The nm relation
+     * \param nmRelation The nm relation
      */
     virtual void setNmRelation( const QgsRelation &nmRelation );
 

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -346,10 +346,24 @@ class GUI_EXPORT QgsAbstractRelationEditorConfigWidget : public QWidget
      */
     QgsRelation relation() const;
 
+    /**
+     * \brief Set the nm relation for this widget.
+     *
+     * \param config The nm relation
+     */
+    virtual void setNmRelation( const QgsRelation &nmRelation );
+
+    /**
+     * Returns the nm relation for which this configuration widget applies
+     *
+     * \returns The nm relation
+     */
+    virtual QgsRelation nmRelation() const;
 
   private:
     QgsVectorLayer *mLayer = nullptr;
     QgsRelation mRelation;
+    QgsRelation mNmRelation;
 };
 
 


### PR DESCRIPTION
This is needed to let QgsAbstractRelationEditorConfigWidget
implementations know which nm cardinality is choosen if any.
