### PR TITLE
findLayers vs findGroups minor inconsistency: allow findGroups to recursively get all groups from the layer tree

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
@@ -129,14 +129,9 @@ Find layer IDs used in all layer nodes. Searches recursively the whole sub-tree.
 Find group node with specified name. Searches recursively the whole sub-tree.
 %End
 
-    QList<QgsLayerTreeGroup *> findGroups() const;
+    QList<QgsLayerTreeGroup *> findGroups( bool recursive = false ) const;
 %Docstring
-Find child group layer nodes. Does not search recursively the whole sub-tree.
-%End
-
-    QList<QgsLayerTreeGroup *> findAllGroups() const;
-%Docstring
-Find all group layer nodes. Searches recursively the whole sub-tree.
+Find group layer nodes. Searches recursively the whole sub-tree, is recursive is set.
 %End
 
     static QgsLayerTreeGroup *readXml( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;

--- a/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
@@ -131,7 +131,7 @@ Find group node with specified name. Searches recursively the whole sub-tree.
 
     QList<QgsLayerTreeGroup *> findGroups( bool recursive = false ) const;
 %Docstring
-Find group layer nodes. Searches recursively the whole sub-tree, is recursive is set.
+Find group layer nodes. Searches recursively the whole sub-tree, if recursive is set.
 %End
 
     static QgsLayerTreeGroup *readXml( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;

--- a/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
@@ -131,7 +131,12 @@ Find group node with specified name. Searches recursively the whole sub-tree.
 
     QList<QgsLayerTreeGroup *> findGroups() const;
 %Docstring
-Find all group layer nodes
+Find child group layer nodes. Does not search recursively the whole sub-tree.
+%End
+
+    QList<QgsLayerTreeGroup *> findAllGroups() const;
+%Docstring
+Find all group layer nodes. Searches recursively the whole sub-tree.
 %End
 
     static QgsLayerTreeGroup *readXml( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;

--- a/src/core/layertree/qgslayertreegroup.cpp
+++ b/src/core/layertree/qgslayertreegroup.cpp
@@ -253,29 +253,18 @@ QgsLayerTreeGroup *QgsLayerTreeGroup::findGroup( const QString &name )
   return nullptr;
 }
 
-QList<QgsLayerTreeGroup *> QgsLayerTreeGroup::findGroups() const
+QList<QgsLayerTreeGroup *> QgsLayerTreeGroup::findGroups( bool recursive ) const
 {
   QList<QgsLayerTreeGroup *> list;
 
   for ( QgsLayerTreeNode *child : mChildren )
   {
     if ( QgsLayerTree::isGroup( child ) )
-      list << QgsLayerTree::toGroup( child );
-  }
-  return list;
-}
-
-QList<QgsLayerTreeGroup *> QgsLayerTreeGroup::findAllGroups() const
-{
-  QList<QgsLayerTreeGroup *> list;
-
-  for ( QgsLayerTreeNode *child : std::as_const( mChildren ) )
-  {
-    if ( QgsLayerTree::isGroup( child ) )
     {
       QgsLayerTreeGroup *childGroup = QgsLayerTree::toGroup( child );
       list << childGroup;
-      list << childGroup->findAllGroups( );
+      if ( recursive )
+        list << childGroup->findGroups( recursive );
     }
   }
   return list;

--- a/src/core/layertree/qgslayertreegroup.cpp
+++ b/src/core/layertree/qgslayertreegroup.cpp
@@ -265,6 +265,22 @@ QList<QgsLayerTreeGroup *> QgsLayerTreeGroup::findGroups() const
   return list;
 }
 
+QList<QgsLayerTreeGroup *> QgsLayerTreeGroup::findAllGroups() const
+{
+  QList<QgsLayerTreeGroup *> list;
+
+  for ( QgsLayerTreeNode *child : std::as_const( mChildren ) )
+  {
+    if ( QgsLayerTree::isGroup( child ) )
+    {
+      QgsLayerTreeGroup *childGroup = QgsLayerTree::toGroup( child );
+      list << childGroup;
+      list << childGroup->findAllGroups( );
+    }
+  }
+  return list;
+}
+
 QgsLayerTreeGroup *QgsLayerTreeGroup::readXml( QDomElement &element, const QgsReadWriteContext &context )
 {
   if ( element.tagName() != QLatin1String( "layer-tree-group" ) )

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -142,14 +142,9 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
     QgsLayerTreeGroup *findGroup( const QString &name );
 
     /**
-     * Find child group layer nodes. Does not search recursively the whole sub-tree.
+     * Find group layer nodes. Searches recursively the whole sub-tree, is recursive is set.
     */
-    QList<QgsLayerTreeGroup *> findGroups() const;
-
-    /**
-     * Find all group layer nodes. Searches recursively the whole sub-tree.
-    */
-    QList<QgsLayerTreeGroup *> findAllGroups() const;
+    QList<QgsLayerTreeGroup *> findGroups( bool recursive = false ) const;
 
     /**
      * Read group (tree) from XML element <layer-tree-group> and return the newly created group (or NULLPTR on error).

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -142,9 +142,14 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
     QgsLayerTreeGroup *findGroup( const QString &name );
 
     /**
-     * Find all group layer nodes
+     * Find child group layer nodes. Does not search recursively the whole sub-tree.
     */
     QList<QgsLayerTreeGroup *> findGroups() const;
+
+    /**
+     * Find all group layer nodes. Searches recursively the whole sub-tree.
+    */
+    QList<QgsLayerTreeGroup *> findAllGroups() const;
 
     /**
      * Read group (tree) from XML element <layer-tree-group> and return the newly created group (or NULLPTR on error).

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -142,7 +142,7 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
     QgsLayerTreeGroup *findGroup( const QString &name );
 
     /**
-     * Find group layer nodes. Searches recursively the whole sub-tree, is recursive is set.
+     * Find group layer nodes. Searches recursively the whole sub-tree, if recursive is set.
     */
     QList<QgsLayerTreeGroup *> findGroups( bool recursive = false ) const;
 

--- a/tests/src/core/testqgslayertree.cpp
+++ b/tests/src/core/testqgslayertree.cpp
@@ -732,7 +732,7 @@ void TestQgsLayerTree::testFindNestedGroups()
   QVERIFY( groups.contains( group2 ) == 0 );
   QVERIFY( groups.contains( group3 ) == 0 );
 
-  QList<QgsLayerTreeGroup *> all = project.layerTreeRoot()->findAllGroups();
+  QList<QgsLayerTreeGroup *> all = project.layerTreeRoot()->findGroups( true );
 
   QVERIFY( all.contains( group1 ) );
   QVERIFY( all.contains( group2 ) );

--- a/tests/src/core/testqgslayertree.cpp
+++ b/tests/src/core/testqgslayertree.cpp
@@ -55,6 +55,7 @@ class TestQgsLayerTree : public QObject
     void testFindLayer();
     void testLayerDeleted();
     void testFindGroups();
+    void testFindNestedGroups();
     void testUtilsCollectMapLayers();
     void testUtilsCountMapLayers();
     void testSymbolText();
@@ -713,6 +714,29 @@ void TestQgsLayerTree::testFindGroups()
   QVERIFY( groups.contains( group1 ) );
   QVERIFY( groups.contains( group2 ) );
   QVERIFY( groups.contains( group3 ) );
+}
+
+void TestQgsLayerTree::testFindNestedGroups()
+{
+  QgsProject project;
+  QgsLayerTreeGroup *group1 = project.layerTreeRoot()->addGroup( QStringLiteral( "Group_One" ) );
+  QVERIFY( group1 );
+  QgsLayerTreeGroup *group2 = group1->addGroup( QStringLiteral( "Group_Two" ) );
+  QVERIFY( group2 );
+  QgsLayerTreeGroup *group3 = group2->addGroup( QStringLiteral( "Group_Three" ) );
+  QVERIFY( group3 );
+
+  QList<QgsLayerTreeGroup *> groups = project.layerTreeRoot()->findGroups();
+
+  QVERIFY( groups.contains( group1 ) );
+  QVERIFY( groups.contains( group2 ) == 0 );
+  QVERIFY( groups.contains( group3 ) == 0 );
+
+  QList<QgsLayerTreeGroup *> all = project.layerTreeRoot()->findAllGroups();
+
+  QVERIFY( all.contains( group1 ) );
+  QVERIFY( all.contains( group2 ) );
+  QVERIFY( all.contains( group3 ) );
 }
 
 void TestQgsLayerTree::testUtilsCollectMapLayers()


### PR DESCRIPTION
## Description

The API description for `findGroups()` is misleading. Right now `findGroups()` returns only groups at the same hierarchical level, not all groups in the tree. The equivalent function `findLayers()` recursively gets all layers from the layer tree.

### Proposal

The current proposal (after @m-kuhn comment) is to use an optional parameter in `findGroups()`. This does not break the current API and users can have the same recursive behaviour as we already have in `findLayers()`.

New signature:
```cpp
QList<QgsLayerTreeGroup *> findGroups( bool recursive = false ) const;
```

A  unit test was added.

PyQGIS usage example, to print all groups used:

```python
tree = QgsProject.instance().layerTreeRoot()
for g in tree.findGroups( True ):
  print(g.name())
```