### PR TITLE
Cleanup and simplify WMS-T settings and make it easier to select the desired time for some providers

### DIFF
--- a/python/core/__init__.py.in
+++ b/python/core/__init__.py.in
@@ -38,6 +38,7 @@ from .additions.qgstaskwrapper import QgsTaskWrapper
 from .additions.readwritecontextentercategory import ReadWriteContextEnterCategory
 from .additions.runtimeprofiler import ScopedRuntimeProfileContextManager
 from .additions.validitycheck import check
+from .additions.ranges import datetime_range_repr, date_range_repr
 
 # Injections into classes
 QgsFeature.__geo_interface__ = property(mapping_feature)
@@ -53,6 +54,8 @@ QgsSettings.enumValue = _qgssettings_enum_value
 QgsSettings.setEnumValue = _qgssettings_set_enum_value
 QgsSettings.flagValue = _qgssettings_flag_value
 QgsTask.fromFunction = fromFunction
+QgsDateTimeRange.__repr__ = datetime_range_repr
+QgsDateRange.__repr__ = date_range_repr
 
 # Classes patched using a derived class
 QgsProviderMetadata = PyProviderMetadata

--- a/python/core/additions/ranges.py
+++ b/python/core/additions/ranges.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+"""
+***************************************************************************
+    ranges.py
+    ---------------------
+    Date                 : Mar 2021
+    Copyright            : (C) 2021 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+from qgis.PyQt.QtCore import Qt
+
+
+# add some __repr__ methods to QGIS range classes. We can't do this via sip because they are template based classes
+
+
+def datetime_range_repr(self):
+    return f"<QgsDateTimeRange:{'[' if self.includeBeginning() else '('}{self.begin().toString(Qt.ISODate)}, {self.end().toString(Qt.ISODate)}{']' if self.includeEnd() else ')'}>"
+
+
+def date_range_repr(self):
+    return f"<QgsDateTimeRange:{'[' if self.includeBeginning() else '('}{self.begin().toString(Qt.ISODate)}, {self.end().toString(Qt.ISODate)}{']' if self.includeEnd() else ')'}>"

--- a/python/core/auto_generated/qgsrange.sip.in
+++ b/python/core/auto_generated/qgsrange.sip.in
@@ -396,6 +396,7 @@ typedef QgsTemporalRange< QDate > QgsDateRange;
 @DOCSTRINGSTEMPLATE@.. versionadded:: 3.0
 @DOCSTRINGSTEMPLATE@%End
 
+
 typedef QgsTemporalRange< QDateTime > QgsDateTimeRange;
 @DOCSTRINGSTEMPLATE@%Docstring
 @DOCSTRINGSTEMPLATE@:py:class:`QgsRange` which stores a range of date times.
@@ -409,6 +410,7 @@ typedef QgsTemporalRange< QDateTime > QgsDateTimeRange;
 @DOCSTRINGSTEMPLATE@
 @DOCSTRINGSTEMPLATE@.. versionadded:: 3.0
 @DOCSTRINGSTEMPLATE@%End
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/auto_generated/raster/qgsrasterdataprovidertemporalcapabilities.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovidertemporalcapabilities.sip.in
@@ -60,16 +60,44 @@ layers or bands in the data provider.
 
     void setAvailableTemporalRange( const QgsDateTimeRange &range );
 %Docstring
-Sets the datetime ``range`` extent from which temporal data is available from the provider.
+Sets the overall datetime ``range`` extent from which temporal data is available from the provider.
 
 .. seealso:: :py:func:`availableTemporalRange`
 %End
 
     const QgsDateTimeRange &availableTemporalRange() const;
 %Docstring
-Returns the datetime range extent from which temporal data is available from the provider.
+Returns the overall datetime range extent from which temporal data is available from the provider.
 
 .. seealso:: :py:func:`setAvailableTemporalRange`
+%End
+
+    void setAllAvailableTemporalRanges( const QList< QgsDateTimeRange > &ranges );
+%Docstring
+Sets a list of all valid datetime ``ranges`` for which temporal data is available from the provider.
+
+As opposed to :py:func:`~QgsRasterDataProviderTemporalCapabilities.setAvailableTemporalRange`, this method is useful when a provider
+contains a set of non-contiguous datetime ranges.
+
+.. seealso:: :py:func:`allAvailableTemporalRanges`
+
+.. seealso:: :py:func:`setAvailableTemporalRange`
+
+.. versionadded:: 3.20
+%End
+
+    QList< QgsDateTimeRange > allAvailableTemporalRanges() const;
+%Docstring
+Returns a list of all valid datetime ranges for which temporal data is available from the provider.
+
+As opposed to :py:func:`~QgsRasterDataProviderTemporalCapabilities.availableTemporalRange`, this method is useful when a provider
+contains a set of non-contiguous datetime ranges.
+
+.. seealso:: :py:func:`setAllAvailableTemporalRanges`
+
+.. seealso:: :py:func:`availableTemporalRange`
+
+.. versionadded:: 3.20
 %End
 
     void setAvailableReferenceTemporalRange( const QgsDateTimeRange &range );

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -261,6 +261,8 @@ void QgsApplication::init( QString profileFolder )
     QMetaType::registerComparators<QgsProcessingModelChildDependency>();
     QMetaType::registerEqualsComparator<QgsProcessingFeatureSourceDefinition>();
     QMetaType::registerEqualsComparator<QgsProperty>();
+    QMetaType::registerEqualsComparator<QgsDateTimeRange>();
+    QMetaType::registerEqualsComparator<QgsDateRange>();
     qRegisterMetaType<QPainter::CompositionMode>( "QPainter::CompositionMode" );
     qRegisterMetaType<QgsDateTimeRange>( "QgsDateTimeRange" );
   } );

--- a/src/core/qgsrange.h
+++ b/src/core/qgsrange.h
@@ -633,6 +633,8 @@ class QgsTemporalRange
  */
 typedef QgsTemporalRange< QDate > QgsDateRange SIP_DOC_TEMPLATE;
 
+Q_DECLARE_METATYPE( QgsDateRange )
+
 /**
  * QgsRange which stores a range of date times.
  *
@@ -644,5 +646,7 @@ typedef QgsTemporalRange< QDate > QgsDateRange SIP_DOC_TEMPLATE;
  * \since QGIS 3.0
  */
 typedef QgsTemporalRange< QDateTime > QgsDateTimeRange SIP_DOC_TEMPLATE;
+
+Q_DECLARE_METATYPE( QgsDateTimeRange )
 
 #endif // QGSRANGE_H

--- a/src/core/raster/qgsrasterdataprovidertemporalcapabilities.cpp
+++ b/src/core/raster/qgsrasterdataprovidertemporalcapabilities.cpp
@@ -35,6 +35,16 @@ const QgsDateTimeRange &QgsRasterDataProviderTemporalCapabilities::availableTemp
   return mAvailableTemporalRange;
 }
 
+void QgsRasterDataProviderTemporalCapabilities::setAllAvailableTemporalRanges( const QList<QgsDateTimeRange> &ranges )
+{
+  mAllAvailableTemporalRanges = ranges;
+}
+
+QList<QgsDateTimeRange> QgsRasterDataProviderTemporalCapabilities::allAvailableTemporalRanges() const
+{
+  return mAllAvailableTemporalRanges;
+}
+
 void QgsRasterDataProviderTemporalCapabilities::setAvailableReferenceTemporalRange( const QgsDateTimeRange &dateTimeRange )
 {
   if ( !hasTemporalCapabilities() )

--- a/src/core/raster/qgsrasterdataprovidertemporalcapabilities.h
+++ b/src/core/raster/qgsrasterdataprovidertemporalcapabilities.h
@@ -75,18 +75,42 @@ class CORE_EXPORT QgsRasterDataProviderTemporalCapabilities : public QgsDataProv
     void setIntervalHandlingMethod( IntervalHandlingMethod method );
 
     /**
-     * Sets the datetime \a range extent from which temporal data is available from the provider.
+     * Sets the overall datetime \a range extent from which temporal data is available from the provider.
      *
      * \see availableTemporalRange()
     */
     void setAvailableTemporalRange( const QgsDateTimeRange &range );
 
     /**
-     * Returns the datetime range extent from which temporal data is available from the provider.
+     * Returns the overall datetime range extent from which temporal data is available from the provider.
      *
      * \see setAvailableTemporalRange()
     */
     const QgsDateTimeRange &availableTemporalRange() const;
+
+    /**
+     * Sets a list of all valid datetime \a ranges for which temporal data is available from the provider.
+     *
+     * As opposed to setAvailableTemporalRange(), this method is useful when a provider
+     * contains a set of non-contiguous datetime ranges.
+     *
+     * \see allAvailableTemporalRanges()
+     * \see setAvailableTemporalRange()
+     * \since QGIS 3.20
+    */
+    void setAllAvailableTemporalRanges( const QList< QgsDateTimeRange > &ranges );
+
+    /**
+     * Returns a list of all valid datetime ranges for which temporal data is available from the provider.
+     *
+     * As opposed to availableTemporalRange(), this method is useful when a provider
+     * contains a set of non-contiguous datetime ranges.
+     *
+     * \see setAllAvailableTemporalRanges()
+     * \see availableTemporalRange()
+     * \since QGIS 3.20
+    */
+    QList< QgsDateTimeRange > allAvailableTemporalRanges() const;
 
     /**
      * Sets the available reference datetime \a range. This is to be used for
@@ -133,6 +157,12 @@ class CORE_EXPORT QgsRasterDataProviderTemporalCapabilities : public QgsDataProv
      *
      */
     QgsDateTimeRange mAvailableTemporalRange;
+
+    /**
+     * A list of all valid temporal ranges for the provider. Used when a provider
+     * has a non-contiguous set of available temporal ranges.
+     */
+    QList< QgsDateTimeRange > mAllAvailableTemporalRanges;
 
     //! Represents the requested temporal range.
     QgsDateTimeRange mRequestedRange;

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -88,7 +88,7 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
     mTemporalExtent = uri.param( QStringLiteral( "timeDimensionExtent" ) );
     mTimeDimensionExtent = parseTemporalExtent( mTemporalExtent );
 
-    if ( mTimeDimensionExtent.datesResolutionList.constFirst().dates.dateTimes.size() > 0 )
+    if ( !mTimeDimensionExtent.datesResolutionList.constFirst().dates.dateTimes.empty() )
     {
       QDateTime begin = mTimeDimensionExtent.datesResolutionList.constFirst().dates.dateTimes.first();
       QDateTime end = mTimeDimensionExtent.datesResolutionList.constLast().dates.dateTimes.last();
@@ -97,6 +97,18 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
     }
     else
       mFixedRange = QgsDateTimeRange();
+
+    mAllRanges.clear();
+    mAllRanges.reserve( mTimeDimensionExtent.datesResolutionList.size() );
+    for ( const QgsWmstExtentPair &extent : std::as_const( mTimeDimensionExtent.datesResolutionList ) )
+    {
+      if ( extent.dates.dateTimes.empty() )
+        continue;
+
+      const QDateTime begin = extent.dates.dateTimes.first();
+      const QDateTime end = extent.dates.dateTimes.last();
+      mAllRanges.append( QgsDateTimeRange( begin, end ) );
+    }
 
     if ( uri.param( QStringLiteral( "referenceTimeDimensionExtent" ) ) != QString() )
     {

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -884,6 +884,9 @@ class QgsWmsSettings
     //! Fixed temporal range for the data provider
     QgsDateTimeRange mFixedRange;
 
+    //! All available temporal ranges
+    QList< QgsDateTimeRange > mAllRanges;
+
     //! Fixed reference temporal range for the data provider
     QgsDateTimeRange mFixedReferenceRange;
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -172,6 +172,8 @@ QgsWmsProvider::QgsWmsProvider( QString const &uri, const ProviderOptions &optio
       Q_ASSERT_X( temporalCapabilities(), "QgsWmsProvider::QgsWmsProvider()", "Data provider temporal capabilities object does not exist" );
       temporalCapabilities()->setHasTemporalCapabilities( true );
       temporalCapabilities()->setAvailableTemporalRange( mSettings.mFixedRange );
+      temporalCapabilities()->setAllAvailableTemporalRanges( mSettings.mAllRanges );
+
       temporalCapabilities()->setIntervalHandlingMethod(
         QgsRasterDataProviderTemporalCapabilities::MatchExactUsingStartOfRange );
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1116,7 +1116,7 @@ void QgsWmsProvider::addWmstParameters( QUrlQuery &query )
   QString format { QStringLiteral( "yyyy-MM-ddThh:mm:ssZ" ) };
   bool dateOnly = false;
 
-  QgsProviderMetadata *metadata = QgsProviderRegistry::instance()->providerMetadata( "wms" );
+  QgsProviderMetadata *metadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "wms" ) );
 
   QVariantMap uri = metadata->decodeUri( dataSourceUri() );
 
@@ -1141,7 +1141,7 @@ void QgsWmsProvider::addWmstParameters( QUrlQuery &query )
 
   if ( !uri.value( QStringLiteral( "enableTime" ), true ).toBool() )
   {
-    format = "yyyy-MM-dd";
+    format = QStringLiteral( "yyyy-MM-dd" );
     dateOnly = true;
   }
 

--- a/src/providers/wms/qgswmstsettingswidget.cpp
+++ b/src/providers/wms/qgswmstsettingswidget.cpp
@@ -87,11 +87,13 @@ void QgsWmstSettingsWidget::syncToLayer( QgsMapLayer *layer )
       {
         mStaticWmstRangeCombo->addItem( range.begin().toString( Qt::ISODate ), QVariant::fromValue( range ) );
       }
+      mStaticTemporalRangeRadio->setText( tr( "Predefined date" ) );
     }
     else
     {
       mStaticWmstRangeFrame->show();
       mStaticWmstChoiceFrame->hide();
+      mStaticTemporalRangeRadio->setText( tr( "Predefined range" ) );
     }
 
     QgsProviderMetadata *metadata = QgsProviderRegistry::instance()->providerMetadata(

--- a/src/providers/wms/qgswmstsettingswidget.cpp
+++ b/src/providers/wms/qgswmstsettingswidget.cpp
@@ -184,7 +184,7 @@ void QgsWmstSettingsWidget::syncToLayer( QgsMapLayer *layer )
       mStaticWmstStackedWidget->setCurrentIndex( 0 );
       // why do we hide this widget? well, the second page of the stacked widget is considerably higher
       // then the first and we don't want to show a whole bunch of empty vertical space which Qt will give
-      // in order to accomodate the vertical height of the non-visible second page!
+      // in order to accommodate the vertical height of the non-visible second page!
       mStaticStackedWidgetFrame->hide();
     }
     else
@@ -270,7 +270,7 @@ void QgsWmstSettingsWidget::temporalPropertiesChange()
     mStaticWmstStackedWidget->setCurrentIndex( 0 );
     // why do we hide this widget? well, the second page of the stacked widget is considerably higher
     // then the first and we don't want to show a whole bunch of empty vertical space which Qt will give
-    // in order to accomodate the vertical height of the non-visible second page!
+    // in order to accommodate the vertical height of the non-visible second page!
     mStaticStackedWidgetFrame->hide();
   }
   else

--- a/src/providers/wms/qgswmstsettingswidget.cpp
+++ b/src/providers/wms/qgswmstsettingswidget.cpp
@@ -180,11 +180,17 @@ void QgsWmstSettingsWidget::syncToLayer( QgsMapLayer *layer )
     if ( mRasterLayer->temporalProperties()->isActive() )
     {
       mStaticWmstStackedWidget->setCurrentIndex( 0 );
+      // why do we hide this widget? well, the second page of the stacked widget is considerably higher
+      // then the first and we don't want to show a whole bunch of empty vertical space which Qt will give
+      // in order to accomodate the vertical height of the non-visible second page!
+      mStaticStackedWidgetFrame->hide();
     }
     else
     {
       mStaticWmstStackedWidget->setCurrentIndex( 1 );
+      mStaticStackedWidgetFrame->show();
     }
+    mStaticWmstStackedWidget->updateGeometry();
   }
 }
 
@@ -258,9 +264,19 @@ void QgsWmstSettingsWidget::apply()
 void QgsWmstSettingsWidget::temporalPropertiesChange()
 {
   if ( mRasterLayer->temporalProperties()->isActive() )
+  {
     mStaticWmstStackedWidget->setCurrentIndex( 0 );
+    // why do we hide this widget? well, the second page of the stacked widget is considerably higher
+    // then the first and we don't want to show a whole bunch of empty vertical space which Qt will give
+    // in order to accomodate the vertical height of the non-visible second page!
+    mStaticStackedWidgetFrame->hide();
+  }
   else
+  {
     mStaticWmstStackedWidget->setCurrentIndex( 1 );
+    mStaticStackedWidgetFrame->show();
+  }
+  mStaticWmstStackedWidget->updateGeometry();
 }
 
 

--- a/src/providers/wms/qgswmstsettingswidget.h
+++ b/src/providers/wms/qgswmstsettingswidget.h
@@ -34,7 +34,6 @@ class QgsWmstSettingsWidget : public QgsMapLayerConfigWidget, private Ui::QgsWms
     void syncToLayer( QgsMapLayer *layer ) override;
     void apply() override;
   private slots:
-    void passProjectTemporalRange_toggled( bool checked );
     void temporalPropertiesChange();
 
   private:

--- a/src/ui/qgswmstsettingswidgetbase.ui
+++ b/src/ui/qgswmstsettingswidgetbase.ui
@@ -44,7 +44,7 @@
       <item row="1" column="0">
        <widget class="QStackedWidget" name="mStaticWmstStackedWidget">
         <property name="currentIndex">
-         <number>0</number>
+         <number>1</number>
         </property>
         <widget class="QWidget" name="page">
          <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/src/ui/qgswmstsettingswidgetbase.ui
+++ b/src/ui/qgswmstsettingswidgetbase.ui
@@ -78,7 +78,7 @@
        <widget class="QgsDateTimeEdit" name="mReferenceDateTimeEdit">
         <property name="dateTime">
          <datetime>
-          <hour>14</hour>
+          <hour>4</hour>
           <minute>20</minute>
           <second>36</second>
           <year>2020</year>
@@ -187,7 +187,7 @@
            <number>0</number>
           </property>
           <item row="2" column="0">
-           <widget class="QFrame" name="mStaticWmstFrame">
+           <widget class="QFrame" name="mStaticWmstRangeFrame">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -210,10 +210,20 @@
              <property name="bottomMargin">
               <number>0</number>
              </property>
-             <item row="2" column="1" colspan="2">
-              <widget class="QPushButton" name="mSetEndAsStartStaticButton">
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_13">
                <property name="text">
-                <string>Set end same as start</string>
+                <string>Start date</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0" colspan="3">
+              <widget class="QLabel" name="label_10">
+               <property name="text">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;If the capabilities of this layer move out of this time range the range will be reset to layer's advertised default layer time range.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -221,7 +231,7 @@
               <widget class="QgsDateTimeEdit" name="mStartStaticDateTimeEdit">
                <property name="dateTime">
                 <datetime>
-                 <hour>17</hour>
+                 <hour>7</hour>
                  <minute>3</minute>
                  <second>57</second>
                  <year>2020</year>
@@ -243,20 +253,6 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_13">
-               <property name="text">
-                <string>Start date</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="label_4">
-               <property name="text">
-                <string>End date</string>
-               </property>
-              </widget>
-             </item>
              <item row="1" column="1" colspan="2">
               <widget class="QgsDateTimeEdit" name="mEndStaticDateTimeEdit">
                <property name="displayFormat">
@@ -270,13 +266,17 @@
                </property>
               </widget>
              </item>
-             <item row="3" column="0" colspan="3">
-              <widget class="QLabel" name="label_10">
+             <item row="2" column="1" colspan="2">
+              <widget class="QPushButton" name="mSetEndAsStartStaticButton">
                <property name="text">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;If the capabilities of this layer move out of this time range the range will be reset to layer's advertised default layer time range.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>Set end same as start</string>
                </property>
-               <property name="wordWrap">
-                <bool>true</bool>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_4">
+               <property name="text">
+                <string>End date</string>
                </property>
               </widget>
              </item>
@@ -336,6 +336,33 @@
             <property name="text">
              <string>Predefined range</string>
             </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QFrame" name="mStaticWmstChoiceFrame">
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Raised</enum>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_4">
+             <property name="leftMargin">
+              <number>20</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QComboBox" name="mStaticWmstRangeCombo"/>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>

--- a/src/ui/qgswmstsettingswidgetbase.ui
+++ b/src/ui/qgswmstsettingswidgetbase.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>QgsWmstSettingsWidgetBase</class>
  <widget class="QWidget" name="QgsWmstSettingsWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>327</width>
+    <height>564</height>
+   </rect>
+  </property>
   <property name="windowTitle">
    <string>WMS-T Settings</string>
   </property>
@@ -19,6 +27,93 @@
     <number>0</number>
    </property>
    <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>WMS-T Settings</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+      <item row="1" column="1">
+       <widget class="QComboBox" name="mFetchModeComboBox"/>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="mDisableTime">
+        <property name="toolTip">
+         <string>If checked the time component of temporal queries will be discarded and only the data component will be used in server requests</string>
+        </property>
+        <property name="text">
+         <string>Ignore time components (use dates only)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_16">
+        <property name="text">
+         <string>Time slice mode</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="mReferenceTimeGroupBox">
+     <property name="title">
+      <string>WMS-T Reference Time</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="mReferenceTimeExtentLabel">
+        <property name="text">
+         <string>No reference time is reported in the layer's capabilities.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QgsDateTimeEdit" name="mReferenceDateTimeEdit">
+        <property name="dateTime">
+         <datetime>
+          <hour>14</hour>
+          <minute>20</minute>
+          <second>36</second>
+          <year>2020</year>
+          <month>1</month>
+          <day>23</day>
+         </datetime>
+        </property>
+        <property name="date">
+         <date>
+          <year>2020</year>
+          <month>1</month>
+          <day>23</day>
+         </date>
+        </property>
+        <property name="currentSection">
+         <enum>QDateTimeEdit::MonthSection</enum>
+        </property>
+        <property name="displayFormat">
+         <string>M/d/yyyy H:mm:ss AP</string>
+        </property>
+        <property name="calendarPopup">
+         <bool>false</bool>
+        </property>
+        <property name="timeSpec">
+         <enum>Qt::UTC</enum>
+        </property>
+        <property name="allowNull" stdset="0">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="mWmstGroup">
      <property name="enabled">
       <bool>true</bool>
@@ -33,95 +128,7 @@
       <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_15">
-      <item row="0" column="0" colspan="3">
-       <widget class="QLabel" name="mLabel">
-        <property name="text">
-         <string/>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1" rowspan="2" colspan="2">
-       <widget class="QComboBox" name="mFetchModeComboBox"/>
-      </item>
-      <item row="3" column="0">
-       <widget class="QCheckBox" name="mDisableTime">
-        <property name="text">
-         <string>Use dates only</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_16">
-        <property name="text">
-         <string>Time slice mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="0">
-       <widget class="QFrame" name="mWmstReferenceTimeFrame">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_17">
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <item row="1" column="0">
-          <widget class="QLabel" name="mReferenceTimeLabel">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QgsDateTimeEdit" name="mReferenceDateTimeEdit">
-           <property name="dateTime">
-            <datetime>
-             <hour>0</hour>
-             <minute>20</minute>
-             <second>36</second>
-             <year>2020</year>
-             <month>1</month>
-             <day>24</day>
-            </datetime>
-           </property>
-           <property name="date">
-            <date>
-             <year>2020</year>
-             <month>1</month>
-             <day>24</day>
-            </date>
-           </property>
-           <property name="currentSection">
-            <enum>QDateTimeEdit::MonthSection</enum>
-           </property>
-           <property name="displayFormat">
-            <string>M/d/yyyy H:mm:ss AP</string>
-           </property>
-           <property name="calendarPopup">
-            <bool>false</bool>
-           </property>
-           <property name="timeSpec">
-            <enum>Qt::UTC</enum>
-           </property>
-           <property name="allowNull" stdset="0">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="3">
+      <item row="1" column="0" colspan="2">
        <widget class="QLabel" name="mWmstOptionsLabel">
         <property name="text">
          <string/>
@@ -131,14 +138,7 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="0">
-       <widget class="QCheckBox" name="mReferenceTime">
-        <property name="text">
-         <string>Reference time</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0" colspan="3">
+      <item row="2" column="0" colspan="2">
        <widget class="QFrame" name="mWmstOptions">
         <property name="frameShape">
          <enum>QFrame::NoFrame</enum>
@@ -216,12 +216,12 @@
              <widget class="QgsDateTimeEdit" name="mStartStaticDateTimeEdit">
               <property name="dateTime">
                <datetime>
-                <hour>3</hour>
+                <hour>17</hour>
                 <minute>3</minute>
                 <second>57</second>
                 <year>2020</year>
                 <month>4</month>
-                <day>28</day>
+                <day>27</day>
                </datetime>
               </property>
               <property name="currentSection">

--- a/src/ui/qgswmstsettingswidgetbase.ui
+++ b/src/ui/qgswmstsettingswidgetbase.ui
@@ -32,7 +32,7 @@
       <bool>true</bool>
      </property>
      <property name="title">
-      <string>WMS-T Temporal Range</string>
+      <string>Static WMS-T Temporal Range</string>
      </property>
      <property name="checkable">
       <bool>false</bool>

--- a/src/ui/qgswmstsettingswidgetbase.ui
+++ b/src/ui/qgswmstsettingswidgetbase.ui
@@ -27,6 +27,273 @@
     <number>0</number>
    </property>
    <item>
+    <widget class="QGroupBox" name="mWmstGroup">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="title">
+      <string>WMS-T Temporal Range</string>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_15">
+      <item row="1" column="0">
+       <widget class="QStackedWidget" name="mStaticWmstStackedWidget">
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <widget class="QWidget" name="page">
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="mWmstOptionsLabel">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The static WMS-T options are disabled because the layer is set to &lt;span style=&quot; font-weight:600;&quot;&gt;Dynamic Temporal Control&lt;/span&gt;. To enable them first disable &lt;span style=&quot; font-weight:600;&quot;&gt;Dynamic Temporal Control&lt;/span&gt; and click Apply.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="page_3">
+         <layout class="QGridLayout" name="gridLayout_3">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QFrame" name="mStaticStackedWidgetFrame">
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Raised</enum>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_4">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item row="3" column="0">
+              <widget class="QFrame" name="mStaticWmstChoiceFrame">
+               <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+               </property>
+               <property name="frameShadow">
+                <enum>QFrame::Raised</enum>
+               </property>
+               <layout class="QVBoxLayout" name="verticalLayout_4">
+                <property name="leftMargin">
+                 <number>20</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QComboBox" name="mStaticWmstRangeCombo"/>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QRadioButton" name="mDefaultRadio">
+               <property name="text">
+                <string>Server default</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QRadioButton" name="mStaticTemporalRangeRadio">
+               <property name="text">
+                <string>Predefined range</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="0">
+              <widget class="QRadioButton" name="mProjectTemporalRangeRadio">
+               <property name="text">
+                <string>Follow project's temporal range</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QFrame" name="mStaticWmstRangeFrame">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+               </property>
+               <property name="frameShadow">
+                <enum>QFrame::Raised</enum>
+               </property>
+               <layout class="QGridLayout" name="gridLayout_16">
+                <property name="leftMargin">
+                 <number>20</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item row="0" column="0">
+                 <widget class="QLabel" name="label_13">
+                  <property name="text">
+                   <string>Start date</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="0" colspan="3">
+                 <widget class="QLabel" name="label_10">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;If the capabilities of this layer move out of this time range the range will be reset to layer's advertised default layer time range.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="wordWrap">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="1" colspan="2">
+                 <widget class="QgsDateTimeEdit" name="mStartStaticDateTimeEdit">
+                  <property name="dateTime">
+                   <datetime>
+                    <hour>21</hour>
+                    <minute>3</minute>
+                    <second>57</second>
+                    <year>2020</year>
+                    <month>4</month>
+                    <day>26</day>
+                   </datetime>
+                  </property>
+                  <property name="currentSection">
+                   <enum>QDateTimeEdit::MonthSection</enum>
+                  </property>
+                  <property name="displayFormat">
+                   <string>M/d/yyyy H:mm:ss AP</string>
+                  </property>
+                  <property name="timeSpec">
+                   <enum>Qt::UTC</enum>
+                  </property>
+                  <property name="allowNull" stdset="0">
+                   <bool>false</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="1" colspan="2">
+                 <widget class="QgsDateTimeEdit" name="mEndStaticDateTimeEdit">
+                  <property name="displayFormat">
+                   <string>M/d/yyyy H:mm:ss AP</string>
+                  </property>
+                  <property name="timeSpec">
+                   <enum>Qt::UTC</enum>
+                  </property>
+                  <property name="allowNull" stdset="0">
+                   <bool>false</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="1" colspan="2">
+                 <widget class="QPushButton" name="mSetEndAsStartStaticButton">
+                  <property name="text">
+                   <string>Set end same as start</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QLabel" name="label_4">
+                  <property name="text">
+                   <string>End date</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item row="5" column="0">
+              <widget class="QFrame" name="frame">
+               <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+               </property>
+               <property name="frameShadow">
+                <enum>QFrame::Plain</enum>
+               </property>
+               <layout class="QVBoxLayout" name="verticalLayout_3">
+                <property name="leftMargin">
+                 <number>20</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="mProjectTemporalRangeLabel">
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="wordWrap">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>WMS-T Settings</string>
@@ -78,19 +345,19 @@
        <widget class="QgsDateTimeEdit" name="mReferenceDateTimeEdit">
         <property name="dateTime">
          <datetime>
-          <hour>4</hour>
+          <hour>18</hour>
           <minute>20</minute>
           <second>36</second>
           <year>2020</year>
           <month>1</month>
-          <day>23</day>
+          <day>22</day>
          </datetime>
         </property>
         <property name="date">
          <date>
           <year>2020</year>
           <month>1</month>
-          <day>23</day>
+          <day>22</day>
          </date>
         </property>
         <property name="currentSection">
@@ -108,265 +375,6 @@
         <property name="allowNull" stdset="0">
          <bool>false</bool>
         </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="mWmstGroup">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="title">
-      <string>WMS-T Temporal Range</string>
-     </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_15">
-      <item row="1" column="0">
-       <widget class="QStackedWidget" name="mStaticWmstStackedWidget">
-        <property name="currentIndex">
-         <number>1</number>
-        </property>
-        <widget class="QWidget" name="page">
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="mWmstOptionsLabel">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The static WMS-T options are disabled because the layer is set to &lt;span style=&quot; font-weight:600;&quot;&gt;Dynamic Temporal Control&lt;/span&gt;. To enable them first disable &lt;span style=&quot; font-weight:600;&quot;&gt;Dynamic Temporal Control&lt;/span&gt; and click Apply.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="page_3">
-         <layout class="QGridLayout" name="gridLayout_3">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item row="2" column="0">
-           <widget class="QFrame" name="mStaticWmstRangeFrame">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="frameShape">
-             <enum>QFrame::NoFrame</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Raised</enum>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_16">
-             <property name="leftMargin">
-              <number>20</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_13">
-               <property name="text">
-                <string>Start date</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0" colspan="3">
-              <widget class="QLabel" name="label_10">
-               <property name="text">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;If the capabilities of this layer move out of this time range the range will be reset to layer's advertised default layer time range.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1" colspan="2">
-              <widget class="QgsDateTimeEdit" name="mStartStaticDateTimeEdit">
-               <property name="dateTime">
-                <datetime>
-                 <hour>7</hour>
-                 <minute>3</minute>
-                 <second>57</second>
-                 <year>2020</year>
-                 <month>4</month>
-                 <day>27</day>
-                </datetime>
-               </property>
-               <property name="currentSection">
-                <enum>QDateTimeEdit::MonthSection</enum>
-               </property>
-               <property name="displayFormat">
-                <string>M/d/yyyy H:mm:ss AP</string>
-               </property>
-               <property name="timeSpec">
-                <enum>Qt::UTC</enum>
-               </property>
-               <property name="allowNull" stdset="0">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1" colspan="2">
-              <widget class="QgsDateTimeEdit" name="mEndStaticDateTimeEdit">
-               <property name="displayFormat">
-                <string>M/d/yyyy H:mm:ss AP</string>
-               </property>
-               <property name="timeSpec">
-                <enum>Qt::UTC</enum>
-               </property>
-               <property name="allowNull" stdset="0">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1" colspan="2">
-              <widget class="QPushButton" name="mSetEndAsStartStaticButton">
-               <property name="text">
-                <string>Set end same as start</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="label_4">
-               <property name="text">
-                <string>End date</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QFrame" name="frame">
-            <property name="frameShape">
-             <enum>QFrame::NoFrame</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Plain</enum>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_3">
-             <property name="leftMargin">
-              <number>20</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QLabel" name="mProjectTemporalRangeLabel">
-               <property name="text">
-                <string/>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QRadioButton" name="mDefaultRadio">
-            <property name="text">
-             <string>Server default</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QRadioButton" name="mProjectTemporalRangeRadio">
-            <property name="text">
-             <string>Follow project's temporal range</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QRadioButton" name="mStaticTemporalRangeRadio">
-            <property name="text">
-             <string>Predefined range</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QFrame" name="mStaticWmstChoiceFrame">
-            <property name="frameShape">
-             <enum>QFrame::NoFrame</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Raised</enum>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_4">
-             <property name="leftMargin">
-              <number>20</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QComboBox" name="mStaticWmstRangeCombo"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
        </widget>
       </item>
      </layout>

--- a/src/ui/qgswmstsettingswidgetbase.ui
+++ b/src/ui/qgswmstsettingswidgetbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>327</width>
-    <height>564</height>
+    <width>343</width>
+    <height>570</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -58,7 +58,7 @@
    <item>
     <widget class="QGroupBox" name="mReferenceTimeGroupBox">
      <property name="title">
-      <string>WMS-T Reference Time</string>
+      <string>Use Specific WMS-T Reference Time</string>
      </property>
      <property name="checkable">
       <bool>true</bool>
@@ -119,156 +119,227 @@
       <bool>true</bool>
      </property>
      <property name="title">
-      <string>Use static WMS-T capabilities</string>
+      <string>WMS-T Temporal Range</string>
      </property>
      <property name="checkable">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="checked">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_15">
-      <item row="1" column="0" colspan="2">
-       <widget class="QLabel" name="mWmstOptionsLabel">
-        <property name="text">
-         <string/>
+      <item row="1" column="0">
+       <widget class="QStackedWidget" name="mStaticWmstStackedWidget">
+        <property name="currentIndex">
+         <number>1</number>
         </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QFrame" name="mWmstOptions">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_22">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QRadioButton" name="mStaticTemporalRange">
-           <property name="text">
-            <string>Use static WMS-T temporal range</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QFrame" name="mStaticWmstFrame">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_16">
-            <property name="topMargin">
-             <number>0</number>
+        <widget class="QWidget" name="page">
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="mWmstOptionsLabel">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The static WMS-T options are disabled because the layer is set to &lt;span style=&quot; font-weight:600;&quot;&gt;Dynamic Temporal Control&lt;/span&gt;. To enable them first disable &lt;span style=&quot; font-weight:600;&quot;&gt;Dynamic Temporal Control&lt;/span&gt; and click Apply.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
-            <property name="bottomMargin">
-             <number>0</number>
+            <property name="wordWrap">
+             <bool>true</bool>
             </property>
-            <item row="2" column="1" colspan="2">
-             <widget class="QPushButton" name="mSetEndAsStartStaticButton">
-              <property name="text">
-               <string>Set end same as start</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_13">
-              <property name="text">
-               <string>Start date</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1" colspan="2">
-             <widget class="QgsDateTimeEdit" name="mEndStaticDateTimeEdit">
-              <property name="displayFormat">
-               <string>M/d/yyyy H:mm:ss AP</string>
-              </property>
-              <property name="timeSpec">
-               <enum>Qt::UTC</enum>
-              </property>
-              <property name="allowNull" stdset="0">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_4">
-              <property name="text">
-               <string>End date</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1" colspan="2">
-             <widget class="QgsDateTimeEdit" name="mStartStaticDateTimeEdit">
-              <property name="dateTime">
-               <datetime>
-                <hour>17</hour>
-                <minute>3</minute>
-                <second>57</second>
-                <year>2020</year>
-                <month>4</month>
-                <day>27</day>
-               </datetime>
-              </property>
-              <property name="currentSection">
-               <enum>QDateTimeEdit::MonthSection</enum>
-              </property>
-              <property name="displayFormat">
-               <string>M/d/yyyy H:mm:ss AP</string>
-              </property>
-              <property name="timeSpec">
-               <enum>Qt::UTC</enum>
-              </property>
-              <property name="allowNull" stdset="0">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_10">
-           <property name="text">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: If the capabilities of this layer move out of this time range, the range will be reset to layer's advertised default layer time range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="mProjectTemporalRangeLabel">
-           <property name="text">
-            <string/>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QRadioButton" name="mProjectTemporalRange">
-           <property name="text">
-            <string>Pass project temporal range to provider</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="page_3">
+         <layout class="QGridLayout" name="gridLayout_3">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="2" column="0">
+           <widget class="QFrame" name="mStaticWmstFrame">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Raised</enum>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_16">
+             <property name="leftMargin">
+              <number>20</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item row="2" column="1" colspan="2">
+              <widget class="QPushButton" name="mSetEndAsStartStaticButton">
+               <property name="text">
+                <string>Set end same as start</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1" colspan="2">
+              <widget class="QgsDateTimeEdit" name="mStartStaticDateTimeEdit">
+               <property name="dateTime">
+                <datetime>
+                 <hour>17</hour>
+                 <minute>3</minute>
+                 <second>57</second>
+                 <year>2020</year>
+                 <month>4</month>
+                 <day>27</day>
+                </datetime>
+               </property>
+               <property name="currentSection">
+                <enum>QDateTimeEdit::MonthSection</enum>
+               </property>
+               <property name="displayFormat">
+                <string>M/d/yyyy H:mm:ss AP</string>
+               </property>
+               <property name="timeSpec">
+                <enum>Qt::UTC</enum>
+               </property>
+               <property name="allowNull" stdset="0">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_13">
+               <property name="text">
+                <string>Start date</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_4">
+               <property name="text">
+                <string>End date</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1" colspan="2">
+              <widget class="QgsDateTimeEdit" name="mEndStaticDateTimeEdit">
+               <property name="displayFormat">
+                <string>M/d/yyyy H:mm:ss AP</string>
+               </property>
+               <property name="timeSpec">
+                <enum>Qt::UTC</enum>
+               </property>
+               <property name="allowNull" stdset="0">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0" colspan="3">
+              <widget class="QLabel" name="label_10">
+               <property name="text">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;If the capabilities of this layer move out of this time range the range will be reset to layer's advertised default layer time range.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QFrame" name="frame">
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Plain</enum>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_3">
+             <property name="leftMargin">
+              <number>20</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="mProjectTemporalRangeLabel">
+               <property name="text">
+                <string/>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QRadioButton" name="mDefaultRadio">
+            <property name="text">
+             <string>Server default</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QRadioButton" name="mProjectTemporalRangeRadio">
+            <property name="text">
+             <string>Follow project's temporal range</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QRadioButton" name="mStaticTemporalRangeRadio">
+            <property name="text">
+             <string>Predefined range</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </widget>
       </item>
      </layout>

--- a/src/ui/raster/qgsrasterlayertemporalpropertieswidgetbase.ui
+++ b/src/ui/raster/qgsrasterlayertemporalpropertieswidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>611</width>
+    <width>577</width>
     <height>413</height>
    </rect>
   </property>
@@ -48,7 +48,7 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>611</width>
+        <width>577</width>
         <height>413</height>
        </rect>
       </property>
@@ -124,7 +124,7 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
             <property name="lineWidth">
              <number>0</number>
             </property>
-            <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0,0">
+            <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,2,0,3">
              <property name="topMargin">
               <number>0</number>
              </property>


### PR DESCRIPTION
(Temporarily includes the commits from the pre-requisite https://github.com/qgis/QGIS/pull/42372 PR)

This PR reworks how WMS-T settings are exposed to users, in order to:
1. Make it clearer exactly what each of the settings controls
2. Make the interplay between the settings clearer
3. Make it obvious which settings apply regardless of whether the layer is controlled by the temporal controller vs the settings which relate only to static wms-t layers
4. And lastly, for servers which expose a non-contiguous set of date time instances (instead of a range of dates) we now present the available options as a combobox of valid choices instead of requiring users to manually enter the valid dates themselves.

Here's how things look with a server exposing a range of available dates:

![Peek 2021-03-23 16-03](https://user-images.githubusercontent.com/1829991/112100723-4c650480-8bf1-11eb-81ab-5d4630c66d97.gif)

(this also shows the improved display of reference time, where users can see the valid range of reference time extent in a label)

And here's how things look when the server offers a list of available datetime instances only:

![Peek 2021-03-23 16-04](https://user-images.githubusercontent.com/1829991/112100887-8930fb80-8bf1-11eb-8e4e-7c2844327816.gif)

Refs Natural resources Canada Contract: 3000720707

