### PR TITLE
[Vector] Use XML Extent even if data provider has metadata

### DIFF
--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -846,7 +846,7 @@ QgsRectangle QgsVectorLayer::extent() const
   if ( !isSpatial() )
     return rect;
 
-  if ( !mValidExtent && mLazyExtent && mDataProvider && !mDataProvider->hasMetadata() && mReadExtentFromXml && !mXmlExtent.isNull() )
+  if ( !mValidExtent && mLazyExtent && mReadExtentFromXml && !mXmlExtent.isNull() )
   {
     updateExtent( mXmlExtent );
     mValidExtent = true;

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2046,13 +2046,23 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(vl1.extent(), originalExtent)
 
         # read xml with custom extent with readExtent option. Extent read from
-        # xml document should NOT be used because we don't have a view or a
+        # xml document should be used even if we don't have a view or a
         # materialized view
         vl2 = QgsVectorLayer()
         vl2.setReadExtentFromXml(True)
         vl2.readLayerXml(elem, QgsReadWriteContext())
         self.assertTrue(vl2.isValid())
 
+        self.assertEqual(vl2.extent(), customExtent)
+
+        # but a force update on extent should allow retrieveing the data
+        # provider extent
+        vl2.updateExtents()
+        vl2.readLayerXml(elem, QgsReadWriteContext())
+        self.assertEqual(vl2.extent(), customExtent)
+
+        vl2.updateExtents(force=True)
+        vl2.readLayerXml(elem, QgsReadWriteContext())
         self.assertEqual(vl2.extent(), originalExtent)
 
     def testDeterminePkey(self):


### PR DESCRIPTION
## Description

The XML extent was only used if the data provider has no metadata.
This means that only PostGIS views and materialized views can benefit from the use of the XML Extent.

This commit removes this constraint