### PR TITLE
Prevent double expensive calls to loadFields in OGR

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -2359,9 +2359,7 @@ bool QgsOgrProvider::_setSubsetString( const QString &theSQL, bool updateFeature
   // check the validity of the layer if subset string has changed
   if ( subsetStringHasChanged )
   {
-    QgsDebugMsgLevel( QStringLiteral( "checking validity" ), 4 );
     loadFields();
-    QgsDebugMsgLevel( QStringLiteral( "Done checking validity" ), 4 );
   }
 
   invalidateCachedExtent( false );
@@ -7128,4 +7126,3 @@ QgsProviderMetadata::ProviderCapabilities QgsOgrProviderMetadata::providerCapabi
   return FileBasedUris;
 }
 ///@endcond
-

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -2273,6 +2273,8 @@ bool QgsOgrProvider::_setSubsetString( const QString &theSQL, bool updateFeature
   if ( theSQL == mSubsetString && mFeaturesCounted != QgsVectorDataProvider::Uncounted )
     return true;
 
+  const bool subsetStringHasChanged { theSQL != mSubsetString };
+
   if ( !theSQL.isEmpty() )
   {
     QMutex *mutex = nullptr;
@@ -2354,10 +2356,13 @@ bool QgsOgrProvider::_setSubsetString( const QString &theSQL, bool updateFeature
 
   mRefreshFeatureCount = updateFeatureCount;
 
-  // check the validity of the layer
-  QgsDebugMsgLevel( QStringLiteral( "checking validity" ), 4 );
-  loadFields();
-  QgsDebugMsgLevel( QStringLiteral( "Done checking validity" ), 4 );
+  // check the validity of the layer if subset string has changed
+  if ( subsetStringHasChanged )
+  {
+    QgsDebugMsgLevel( QStringLiteral( "checking validity" ), 4 );
+    loadFields();
+    QgsDebugMsgLevel( QStringLiteral( "Done checking validity" ), 4 );
+  }
 
   invalidateCachedExtent( false );
 


### PR DESCRIPTION
With OGR GPKG/Spatialite unique fields detection can be expensive, this patch prevents the double call to `loadFields` (that triggers a call to the slow detection logic) when the layer is initally loaded.

Followup https://github.com/qgis/QGIS/issues/42177