### PR TITLE
Add temporal navigation step for "source timestamps"

### DIFF
--- a/python/core/auto_generated/qgsmaplayertemporalproperties.sip.in
+++ b/python/core/auto_generated/qgsmaplayertemporalproperties.sip.in
@@ -81,6 +81,17 @@ Sets the layers temporal settings to appropriate defaults based on
 a provider's temporal ``capabilities``.
 %End
 
+
+    virtual QList< QgsDateTimeRange > allTemporalRanges( QgsMapLayer *layer ) const;
+%Docstring
+Attempts to calculate the overall list of all temporal extents which are contained in the specified ``layer``, using
+the settings defined by the temporal properties object.
+
+May return an empty list if the ranges could not be calculated.
+
+.. versionadded:: 3.20
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/qgsrange.sip.in
+++ b/python/core/auto_generated/qgsrange.sip.in
@@ -375,6 +375,7 @@ If the range is empty and ``other`` is not, the range is changed and set to ``ot
 .. versionadded:: 3.12
 %End
 
+
     bool operator==( const QgsTemporalRange<T> &other ) const;
 
     bool operator!=( const QgsTemporalRange<T> &other ) const;

--- a/python/core/auto_generated/qgstemporalnavigationobject.sip.in
+++ b/python/core/auto_generated/qgstemporalnavigationobject.sip.in
@@ -92,6 +92,30 @@ and latest date time possible in the animation.
 .. seealso:: :py:func:`setTemporalExtents`
 %End
 
+    void setAvailableTemporalRanges( const QList< QgsDateTimeRange > &ranges );
+%Docstring
+Sets the list of all available temporal ``ranges`` which have data available.
+
+The ``ranges`` list can be a list of non-contiguous ranges (i.e. containing gaps)
+which together describe the complete range of times which contain data.
+
+.. seealso:: :py:func:`availableTemporalRanges`
+
+.. versionadded:: 3.20
+%End
+
+    QList< QgsDateTimeRange > availableTemporalRanges() const;
+%Docstring
+Returns the list of all available temporal ranges which have data available.
+
+The ranges list can be a list of non-contiguous ranges (i.e. containing gaps)
+which together describe the complete range of times which contain data.
+
+.. seealso:: :py:func:`setAvailableTemporalRanges`
+
+.. versionadded:: 3.20
+%End
+
     void setCurrentFrameNumber( long long frame );
 %Docstring
 Sets the current animation ``frame`` number.

--- a/python/core/auto_generated/qgstemporalnavigationobject.sip.in
+++ b/python/core/auto_generated/qgstemporalnavigationobject.sip.in
@@ -133,7 +133,7 @@ Returns the current frame number.
 .. seealso:: :py:func:`setCurrentFrameNumber`
 %End
 
-    void setFrameDuration( QgsInterval duration );
+    void setFrameDuration( const QgsInterval &duration );
 %Docstring
 Sets the frame ``duration``, which dictates the temporal length of each frame in the animation.
 

--- a/python/core/auto_generated/qgstemporalutils.sip.in
+++ b/python/core/auto_generated/qgstemporalutils.sip.in
@@ -31,6 +31,19 @@ This method considers the temporal range available from layers contained within 
 returns the maximal combined temporal extent of these layers.
 %End
 
+    static QList< QgsDateTimeRange > usedTemporalRangesForProject( QgsProject *project );
+%Docstring
+Calculates all temporal ranges which are in use for a ``project``.
+
+This method considers the temporal range available from layers contained within the project and
+returns a list of ranges which cover only the temporal ranges which are actually in use by layers
+in the project.
+
+The returned list may be non-contiguous and have gaps in the ranges. The ranges are sorted in ascending order.
+
+.. versionadded:: 3.20
+%End
+
     struct AnimationExportSettings
     {
       QgsDateTimeRange animationRange;

--- a/python/core/auto_generated/qgsunittypes.sip.in
+++ b/python/core/auto_generated/qgsunittypes.sip.in
@@ -120,6 +120,7 @@ Helper functions for various unit types.
       TemporalYears,
       TemporalDecades,
       TemporalCenturies,
+      TemporalIrregularStep,
       TemporalUnknownUnit
     };
 

--- a/python/core/auto_generated/raster/qgsrasterlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayertemporalproperties.sip.in
@@ -32,6 +32,8 @@ The ``enabled`` argument specifies whether the temporal properties are initially
 
     virtual bool isVisibleInTemporalRange( const QgsDateTimeRange &range ) const;
 
+    virtual QList< QgsDateTimeRange > allTemporalRanges( QgsMapLayer *layer ) const;
+
 
     enum TemporalMode
     {

--- a/src/core/qgsmaplayertemporalproperties.cpp
+++ b/src/core/qgsmaplayertemporalproperties.cpp
@@ -31,3 +31,8 @@ QgsDateTimeRange QgsMapLayerTemporalProperties::calculateTemporalExtent( QgsMapL
 {
   return QgsDateTimeRange();
 }
+
+QList<QgsDateTimeRange> QgsMapLayerTemporalProperties::allTemporalRanges( QgsMapLayer *layer ) const
+{
+  return { calculateTemporalExtent( layer ) };
+}

--- a/src/core/qgsmaplayertemporalproperties.h
+++ b/src/core/qgsmaplayertemporalproperties.h
@@ -117,6 +117,17 @@ class CORE_EXPORT QgsMapLayerTemporalProperties : public QgsTemporalProperty
      */
     virtual QgsDateTimeRange calculateTemporalExtent( QgsMapLayer *layer ) const;
 #endif
+
+    /**
+     * Attempts to calculate the overall list of all temporal extents which are contained in the specified \a layer, using
+     * the settings defined by the temporal properties object.
+     *
+     * May return an empty list if the ranges could not be calculated.
+     *
+     * \since QGIS 3.20
+     */
+    virtual QList< QgsDateTimeRange > allTemporalRanges( QgsMapLayer *layer ) const;
+
 };
 
 #endif // QGSMAPLAYERTEMPORALPROPERTIES_H

--- a/src/core/qgsrange.h
+++ b/src/core/qgsrange.h
@@ -599,6 +599,53 @@ class QgsTemporalRange
       return changed;
     }
 
+#ifndef SIP_RUN
+
+    /**
+     * Merges a list of temporal ranges.
+     *
+     * Any overlapping ranges will be converted to a single range which covers the entire
+     * range of the input ranges.
+     *
+     * The returned value will be a list of non-contiguous ranges which completely encompass
+     * the input \a ranges, sorted in ascending order.
+     *
+     * \note Not available in Python bindings
+     *
+     * \since QGIS 3.20
+     */
+    static QList< QgsTemporalRange<T> > mergeRanges( const QList< QgsTemporalRange<T> > &ranges )
+    {
+      QList< QgsTemporalRange<T > > res;
+
+      QList< QgsTemporalRange<T> > queue = ranges;
+      while ( !queue.empty() )
+      {
+        QgsTemporalRange<T> range = queue.back();
+        queue.pop_back();
+
+        bool extended = false;
+        for ( int i = 0; i < res.count(); ++i )
+        {
+          if ( res[i].overlaps( range ) )
+          {
+            QgsTemporalRange< T > other = res.takeAt( i );
+            other.extend( range );
+            queue.push_back( other );
+            extended = true;
+            break;
+          }
+        }
+
+        if ( !extended )
+          res.push_back( range );
+      }
+
+      std::sort( res.begin(), res.end(), []( const QgsTemporalRange< T > &a, const QgsTemporalRange< T > &b ) -> bool { return a.begin() < b.begin(); } );
+      return res;
+    }
+#endif
+
     bool operator==( const QgsTemporalRange<T> &other ) const
     {
       return mLower == other.mLower &&

--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -169,6 +169,16 @@ QgsDateTimeRange QgsTemporalNavigationObject::temporalExtents() const
   return mTemporalExtents;
 }
 
+void QgsTemporalNavigationObject::setAvailableTemporalRanges( const QList<QgsDateTimeRange> &ranges )
+{
+  mAllRanges = ranges;
+}
+
+QList<QgsDateTimeRange> QgsTemporalNavigationObject::availableTemporalRanges() const
+{
+  return mAllRanges;
+}
+
 void QgsTemporalNavigationObject::setCurrentFrameNumber( long long frameNumber )
 {
   if ( mCurrentFrameNumber != frameNumber )

--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -93,8 +93,20 @@ QgsDateTimeRange QgsTemporalNavigationObject::dateTimeRangeForFrameNumber( long 
 
   const long long nextFrame = frame + 1;
 
-  const QDateTime begin = QgsTemporalUtils::calculateFrameTime( start, frame, mFrameDuration );
-  const QDateTime end = QgsTemporalUtils::calculateFrameTime( start, nextFrame, mFrameDuration );
+  QDateTime begin;
+  QDateTime end;
+  if ( mFrameDuration.originalUnit() == QgsUnitTypes::TemporalIrregularStep )
+  {
+    if ( mAllRanges.empty() )
+      return QgsDateTimeRange();
+
+    return frame < mAllRanges.size() ? mAllRanges.at( frame ) : mAllRanges.constLast();
+  }
+  else
+  {
+    begin = QgsTemporalUtils::calculateFrameTime( start, frame, mFrameDuration );
+    end = QgsTemporalUtils::calculateFrameTime( start, nextFrame, mFrameDuration );
+  }
 
   QDateTime frameStart = begin;
 
@@ -196,12 +208,13 @@ long long QgsTemporalNavigationObject::currentFrameNumber() const
   return mCurrentFrameNumber;
 }
 
-void QgsTemporalNavigationObject::setFrameDuration( QgsInterval frameDuration )
+void QgsTemporalNavigationObject::setFrameDuration( const QgsInterval &frameDuration )
 {
   if ( mFrameDuration == frameDuration )
   {
     return;
   }
+
   QgsDateTimeRange oldFrame = dateTimeRangeForFrameNumber( currentFrameNumber() );
   mFrameDuration = frameDuration;
 
@@ -302,8 +315,15 @@ void QgsTemporalNavigationObject::skipToEnd()
 
 long long QgsTemporalNavigationObject::totalFrameCount() const
 {
-  QgsInterval totalAnimationLength = mTemporalExtents.end() - mTemporalExtents.begin();
-  return std::floor( totalAnimationLength.seconds() / mFrameDuration.seconds() ) + 1;
+  if ( mFrameDuration.originalUnit() == QgsUnitTypes::TemporalIrregularStep )
+  {
+    return mAllRanges.count();
+  }
+  else
+  {
+    QgsInterval totalAnimationLength = mTemporalExtents.end() - mTemporalExtents.begin();
+    return std::floor( totalAnimationLength.seconds() / mFrameDuration.seconds() ) + 1;
+  }
 }
 
 void QgsTemporalNavigationObject::setAnimationState( AnimationState mode )
@@ -323,30 +343,46 @@ QgsTemporalNavigationObject::AnimationState QgsTemporalNavigationObject::animati
 long long QgsTemporalNavigationObject::findBestFrameNumberForFrameStart( const QDateTime &frameStart ) const
 {
   long long bestFrame = 0;
-  QgsDateTimeRange testFrame = QgsDateTimeRange( frameStart, frameStart ); // creating an 'instant' Range
-  // Earlier we looped from frame 0 till totalFrameCount() here, but this loop grew potentially gigantic
-  long long roughFrameStart = 0;
-  long long roughFrameEnd = totalFrameCount();
-  // For the smaller step frames we calculate an educated guess, to prevent the loop becoming too
-  // large, freezing the ui (eg having a mTemporalExtents of several months and the user selects milliseconds)
-  if ( mFrameDuration.originalUnit() != QgsUnitTypes::TemporalMonths && mFrameDuration.originalUnit() != QgsUnitTypes::TemporalYears && mFrameDuration.originalUnit() != QgsUnitTypes::TemporalDecades && mFrameDuration.originalUnit() != QgsUnitTypes::TemporalCenturies )
+  if ( mFrameDuration.originalUnit() == QgsUnitTypes::TemporalIrregularStep )
   {
-    // Only if we receive a valid frameStart, that is within current mTemporalExtents
-    // We tend to receive a framestart of 'now()' upon startup for example
-    if ( mTemporalExtents.contains( frameStart ) )
+    for ( const QgsDateTimeRange &range : mAllRanges )
     {
-      roughFrameStart = std::floor( ( frameStart - mTemporalExtents.begin() ).seconds() / mFrameDuration.seconds() );
+      if ( range.contains( frameStart ) )
+        return bestFrame;
+      else if ( range.begin() > frameStart )
+        // if we've gone past the target date, go back one frame if possible
+        return std::max( 0LL, bestFrame - 1 );
+      bestFrame++;
     }
-    roughFrameEnd = roughFrameStart + 100; // just in case we miss the guess
+    return mAllRanges.count() - 1;
   }
-  for ( long long i = roughFrameStart; i < roughFrameEnd; ++i )
+  else
   {
-    QgsDateTimeRange range = dateTimeRangeForFrameNumber( i );
-    if ( range.overlaps( testFrame ) )
+    QgsDateTimeRange testFrame = QgsDateTimeRange( frameStart, frameStart ); // creating an 'instant' Range
+    // Earlier we looped from frame 0 till totalFrameCount() here, but this loop grew potentially gigantic
+    long long roughFrameStart = 0;
+    long long roughFrameEnd = totalFrameCount();
+    // For the smaller step frames we calculate an educated guess, to prevent the loop becoming too
+    // large, freezing the ui (eg having a mTemporalExtents of several months and the user selects milliseconds)
+    if ( mFrameDuration.originalUnit() != QgsUnitTypes::TemporalMonths && mFrameDuration.originalUnit() != QgsUnitTypes::TemporalYears && mFrameDuration.originalUnit() != QgsUnitTypes::TemporalDecades && mFrameDuration.originalUnit() != QgsUnitTypes::TemporalCenturies )
     {
-      bestFrame = i;
-      break;
+      // Only if we receive a valid frameStart, that is within current mTemporalExtents
+      // We tend to receive a framestart of 'now()' upon startup for example
+      if ( mTemporalExtents.contains( frameStart ) )
+      {
+        roughFrameStart = std::floor( ( frameStart - mTemporalExtents.begin() ).seconds() / mFrameDuration.seconds() );
+      }
+      roughFrameEnd = roughFrameStart + 100; // just in case we miss the guess
     }
+    for ( long long i = roughFrameStart; i < roughFrameEnd; ++i )
+    {
+      QgsDateTimeRange range = dateTimeRangeForFrameNumber( i );
+      if ( range.overlaps( testFrame ) )
+      {
+        bestFrame = i;
+        break;
+      }
+    }
+    return bestFrame;
   }
-  return bestFrame;
 }

--- a/src/core/qgstemporalnavigationobject.h
+++ b/src/core/qgstemporalnavigationobject.h
@@ -155,7 +155,7 @@ class CORE_EXPORT QgsTemporalNavigationObject : public QgsTemporalController, pu
      *
      * \see frameDuration()
      */
-    void setFrameDuration( QgsInterval duration );
+    void setFrameDuration( const QgsInterval &duration );
 
     /**
      * Returns the current set frame duration, which dictates the temporal length of each frame in the animation.

--- a/src/core/qgstemporalnavigationobject.h
+++ b/src/core/qgstemporalnavigationobject.h
@@ -110,6 +110,28 @@ class CORE_EXPORT QgsTemporalNavigationObject : public QgsTemporalController, pu
     QgsDateTimeRange temporalExtents() const;
 
     /**
+     * Sets the list of all available temporal \a ranges which have data available.
+     *
+     * The \a ranges list can be a list of non-contiguous ranges (i.e. containing gaps)
+     * which together describe the complete range of times which contain data.
+     *
+     * \see availableTemporalRanges()
+     * \since QGIS 3.20
+     */
+    void setAvailableTemporalRanges( const QList< QgsDateTimeRange > &ranges );
+
+    /**
+     * Returns the list of all available temporal ranges which have data available.
+     *
+     * The ranges list can be a list of non-contiguous ranges (i.e. containing gaps)
+     * which together describe the complete range of times which contain data.
+     *
+     * \see setAvailableTemporalRanges()
+     * \since QGIS 3.20
+     */
+    QList< QgsDateTimeRange > availableTemporalRanges() const;
+
+    /**
      * Sets the current animation \a frame number.
      *
      * Caling this method will change the controllers current datetime range to match, based on the
@@ -297,6 +319,9 @@ class CORE_EXPORT QgsTemporalNavigationObject : public QgsTemporalController, pu
 
     //! The controller temporal navigation extent range.
     QgsDateTimeRange mTemporalExtents;
+
+    //! Complete list of time ranges with data available
+    QList< QgsDateTimeRange > mAllRanges;
 
     NavigationMode mNavigationMode = NavigationOff;
 

--- a/src/core/qgstemporalutils.cpp
+++ b/src/core/qgstemporalutils.cpp
@@ -30,15 +30,13 @@
 
 QgsDateTimeRange QgsTemporalUtils::calculateTemporalRangeForProject( QgsProject *project )
 {
-  const QMap<QString, QgsMapLayer *> &mapLayers = project->mapLayers();
-  QgsMapLayer *currentLayer = nullptr;
-
+  QMap<QString, QgsMapLayer *> mapLayers = project->mapLayers();
   QDateTime minDate;
   QDateTime maxDate;
 
-  for ( QMap<QString, QgsMapLayer *>::const_iterator it = mapLayers.constBegin(); it != mapLayers.constEnd(); ++it )
+  for ( auto it = mapLayers.constBegin(); it != mapLayers.constEnd(); ++it )
   {
-    currentLayer = it.value();
+    QgsMapLayer *currentLayer = it.value();
 
     if ( !currentLayer->temporalProperties() || !currentLayer->temporalProperties()->isActive() )
       continue;
@@ -51,6 +49,24 @@ QgsDateTimeRange QgsTemporalUtils::calculateTemporalRangeForProject( QgsProject 
   }
 
   return QgsDateTimeRange( minDate, maxDate );
+}
+
+QList< QgsDateTimeRange > QgsTemporalUtils::usedTemporalRangesForProject( QgsProject *project )
+{
+  QMap<QString, QgsMapLayer *> mapLayers = project->mapLayers();
+
+  QList< QgsDateTimeRange > ranges;
+  for ( auto it = mapLayers.constBegin(); it != mapLayers.constEnd(); ++it )
+  {
+    QgsMapLayer *currentLayer = it.value();
+
+    if ( !currentLayer->temporalProperties() || !currentLayer->temporalProperties()->isActive() )
+      continue;
+
+    ranges.append( currentLayer->temporalProperties()->allTemporalRanges( currentLayer ) );
+  }
+
+  return QgsDateTimeRange::mergeRanges( ranges );
 }
 
 bool QgsTemporalUtils::exportAnimation( const QgsMapSettings &mapSettings, const QgsTemporalUtils::AnimationExportSettings &settings, QString &error, QgsFeedback *feedback )

--- a/src/core/qgstemporalutils.h
+++ b/src/core/qgstemporalutils.h
@@ -45,6 +45,19 @@ class CORE_EXPORT QgsTemporalUtils
      */
     static QgsDateTimeRange calculateTemporalRangeForProject( QgsProject *project );
 
+    /**
+     * Calculates all temporal ranges which are in use for a \a project.
+     *
+     * This method considers the temporal range available from layers contained within the project and
+     * returns a list of ranges which cover only the temporal ranges which are actually in use by layers
+     * in the project.
+     *
+     * The returned list may be non-contiguous and have gaps in the ranges. The ranges are sorted in ascending order.
+     *
+     * \since QGIS 3.20
+     */
+    static QList< QgsDateTimeRange > usedTemporalRangesForProject( QgsProject *project );
+
     //! Contains settings relating to exporting animations
     struct AnimationExportSettings
     {

--- a/src/core/qgsunittypes.cpp
+++ b/src/core/qgsunittypes.cpp
@@ -1275,6 +1275,8 @@ QString QgsUnitTypes::encodeUnit( QgsUnitTypes::TemporalUnit unit )
       return QStringLiteral( "dec" );
     case TemporalCenturies:
       return QStringLiteral( "c" );
+    case TemporalIrregularStep:
+      return QStringLiteral( "xxx" );
     case TemporalUnknownUnit:
       return QStringLiteral( "<unknown>" );
   }
@@ -1308,6 +1310,8 @@ QgsUnitTypes::TemporalUnit QgsUnitTypes::decodeTemporalUnit( const QString &stri
     return TemporalDecades;
   if ( normalized == encodeUnit( TemporalCenturies ) )
     return TemporalCenturies;
+  if ( normalized == encodeUnit( TemporalIrregularStep ) )
+    return TemporalIrregularStep;
   if ( normalized == encodeUnit( TemporalUnknownUnit ) )
     return TemporalUnknownUnit;
 
@@ -1341,6 +1345,8 @@ QString QgsUnitTypes::toString( QgsUnitTypes::TemporalUnit unit )
       return QObject::tr( "decades", "temporal" );
     case TemporalCenturies:
       return QObject::tr( "centuries", "temporal" );
+    case TemporalIrregularStep:
+      return QObject::tr( "steps", "temporal" );
     case TemporalUnknownUnit:
       return QObject::tr( "<unknown>", "temporal" );
   }
@@ -1371,6 +1377,8 @@ QString QgsUnitTypes::toAbbreviatedString( QgsUnitTypes::TemporalUnit unit )
       return QObject::tr( "dec", "temporal" );
     case TemporalCenturies:
       return QObject::tr( "cen", "temporal" );
+    case TemporalIrregularStep:
+      return QObject::tr( "steps", "temporal" );
     case TemporalUnknownUnit:
       return QObject::tr( "<unknown>", "temporal" );
   }
@@ -1404,6 +1412,8 @@ QgsUnitTypes::TemporalUnit QgsUnitTypes::stringToTemporalUnit( const QString &st
     return TemporalDecades;
   if ( normalized == toString( TemporalCenturies ) )
     return TemporalCenturies;
+  if ( normalized == toString( TemporalIrregularStep ) )
+    return TemporalIrregularStep;
   if ( normalized == toString( TemporalUnknownUnit ) )
     return TemporalUnknownUnit;
 
@@ -1442,6 +1452,7 @@ double QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalUnit fromUnit, 
         case TemporalCenturies:
           return 1 / 3155760000.0;
         case TemporalUnknownUnit:
+        case TemporalIrregularStep:
           return 1.0;
       }
       break;
@@ -1471,6 +1482,7 @@ double QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalUnit fromUnit, 
         case TemporalCenturies:
           return 1 / 315576000000.0;
         case TemporalUnknownUnit:
+        case TemporalIrregularStep:
           return 1.0;
       }
       break;
@@ -1500,6 +1512,7 @@ double QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalUnit fromUnit, 
         case TemporalCenturies:
           return 1 / 52596000.0;
         case TemporalUnknownUnit:
+        case TemporalIrregularStep:
           return 1.0;
       }
       break;
@@ -1529,6 +1542,7 @@ double QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalUnit fromUnit, 
         case TemporalCenturies:
           return 1 / 876600.0;
         case TemporalUnknownUnit:
+        case TemporalIrregularStep:
           return 1.0;
       }
       break;
@@ -1558,6 +1572,7 @@ double QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalUnit fromUnit, 
         case TemporalCenturies:
           return 1 / 36525.0;
         case TemporalUnknownUnit:
+        case TemporalIrregularStep:
           return 1.0;
       }
       break;
@@ -1587,6 +1602,7 @@ double QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalUnit fromUnit, 
         case TemporalCenturies:
           return 7 / 36525.0;
         case TemporalUnknownUnit:
+        case TemporalIrregularStep:
           return 1.0;
       }
       break;
@@ -1616,6 +1632,7 @@ double QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalUnit fromUnit, 
         case TemporalCenturies:
           return 30 / 36525.0;
         case TemporalUnknownUnit:
+        case TemporalIrregularStep:
           return 1.0;
       }
       break;
@@ -1645,6 +1662,7 @@ double QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalUnit fromUnit, 
         case TemporalCenturies:
           return 0.01;
         case TemporalUnknownUnit:
+        case TemporalIrregularStep:
           return 1.0;
       }
       break;
@@ -1674,6 +1692,7 @@ double QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalUnit fromUnit, 
         case TemporalCenturies:
           return 0.1;
         case TemporalUnknownUnit:
+        case TemporalIrregularStep:
           return 1.0;
       }
       break;
@@ -1704,12 +1723,14 @@ double QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::TemporalUnit fromUnit, 
         case TemporalCenturies:
           return 1;
         case TemporalUnknownUnit:
+        case TemporalIrregularStep:
           return 1.0;
       }
       break;
     }
 
     case TemporalUnknownUnit:
+    case TemporalIrregularStep:
     {
       return 1.0;
     }

--- a/src/core/qgsunittypes.h
+++ b/src/core/qgsunittypes.h
@@ -158,6 +158,7 @@ class CORE_EXPORT QgsUnitTypes
       TemporalYears, //!< Years
       TemporalDecades, //!< Decades
       TemporalCenturies, //!< Centuries
+      TemporalIrregularStep, //!< Special "irregular step" time unit, used for temporal data which uses irregular, non-real-world unit steps (since QGIS 3.20)
       TemporalUnknownUnit //!< Unknown time unit
     };
     Q_ENUM( TemporalUnit )

--- a/src/core/raster/qgsrasterlayertemporalproperties.cpp
+++ b/src/core/raster/qgsrasterlayertemporalproperties.cpp
@@ -58,6 +58,27 @@ QgsDateTimeRange QgsRasterLayerTemporalProperties::calculateTemporalExtent( QgsM
   return QgsDateTimeRange();
 }
 
+QList<QgsDateTimeRange> QgsRasterLayerTemporalProperties::allTemporalRanges( QgsMapLayer *layer ) const
+{
+  QgsRasterLayer *rasterLayer = qobject_cast< QgsRasterLayer *>( layer );
+  if ( !rasterLayer )
+    return {};
+
+  switch ( mMode )
+  {
+    case QgsRasterLayerTemporalProperties::ModeFixedTemporalRange:
+      return { mFixedRange };
+
+    case QgsRasterLayerTemporalProperties::ModeTemporalRangeFromDataProvider:
+    {
+      QList< QgsDateTimeRange > ranges = rasterLayer->dataProvider()->temporalCapabilities()->allAvailableTemporalRanges();
+      return ranges.empty() ? QList< QgsDateTimeRange > { rasterLayer->dataProvider()->temporalCapabilities()->availableTemporalRange() } : ranges;
+    }
+  }
+
+  return {};
+}
+
 QgsRasterLayerTemporalProperties::TemporalMode QgsRasterLayerTemporalProperties::mode() const
 {
   return mMode;

--- a/src/core/raster/qgsrasterlayertemporalproperties.h
+++ b/src/core/raster/qgsrasterlayertemporalproperties.h
@@ -47,6 +47,7 @@ class CORE_EXPORT QgsRasterLayerTemporalProperties : public QgsMapLayerTemporalP
 
     bool isVisibleInTemporalRange( const QgsDateTimeRange &range ) const override;
     QgsDateTimeRange calculateTemporalExtent( QgsMapLayer *layer ) const override SIP_SKIP;
+    QList< QgsDateTimeRange > allTemporalRanges( QgsMapLayer *layer ) const override;
 
     /**
      * Mode of the raster temporal properties

--- a/src/core/vector/qgsvectorlayertemporalproperties.cpp
+++ b/src/core/vector/qgsvectorlayertemporalproperties.cpp
@@ -494,6 +494,7 @@ QString QgsVectorLayerTemporalProperties::createFilterString( const QgsVectorLay
           break;
 
         case QgsUnitTypes::TemporalUnknownUnit:
+        case QgsUnitTypes::TemporalIrregularStep:
           return QString();
       }
       return QStringLiteral( "(%1 %2 %3 OR %1 IS NULL) AND ((%1 + %4 %5 %6) OR %7 IS NULL)" ).arg( QgsExpression::quotedColumnRef( mStartFieldName ),

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -410,6 +410,7 @@ void QgsTemporalControllerWidget::onLayersAdded( const QList<QgsMapLayer *> &lay
             {
               mHasTemporalLayersLoaded = true;
               firstTemporalLayerLoaded( layer );
+              mNavigationObject->setAvailableTemporalRanges( QgsTemporalUtils::usedTemporalRangesForProject( QgsProject::instance() ) );
             }
           } );
         }
@@ -418,6 +419,8 @@ void QgsTemporalControllerWidget::onLayersAdded( const QList<QgsMapLayer *> &lay
       }
     }
   }
+
+  mNavigationObject->setAvailableTemporalRanges( QgsTemporalUtils::usedTemporalRangesForProject( QgsProject::instance() ) );
 }
 
 void QgsTemporalControllerWidget::firstTemporalLayerLoaded( QgsMapLayer *layer )
@@ -636,6 +639,8 @@ void QgsTemporalControllerWidget::setDatesToAllLayers()
 {
   QgsDateTimeRange range;
   range = QgsTemporalUtils::calculateTemporalRangeForProject( QgsProject::instance() );
+  mNavigationObject->setAvailableTemporalRanges( QgsTemporalUtils::usedTemporalRangesForProject( QgsProject::instance() ) );
+
   setDates( range );
 }
 
@@ -652,6 +657,8 @@ void QgsTemporalControllerWidget::setDatesToProjectTime()
   {
     range = QgsTemporalUtils::calculateTemporalRangeForProject( QgsProject::instance() );
   }
+
+  mNavigationObject->setAvailableTemporalRanges( QgsTemporalUtils::usedTemporalRangesForProject( QgsProject::instance() ) );
 
   setDates( range );
 }

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -171,6 +171,7 @@ set(TESTS
  testqgsproperty.cpp
  testqgsprovidermetadata.cpp
  testqgis.cpp
+ testqgsrange.cpp
  testqgsrasterfilewriter.cpp
  testqgsrasterfill.cpp
  testqgsrastermarker.cpp

--- a/tests/src/core/testqgsrange.cpp
+++ b/tests/src/core/testqgsrange.cpp
@@ -1,0 +1,92 @@
+/***************************************************************************
+     testqgsrange.cpp
+     -------------------
+    Date                 : March 2021
+    Copyright            : (C) 2021 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstest.h"
+#include <QObject>
+
+#include "qgsrange.h"
+
+class TestQgsRange: public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init();// will be called before each testfunction is executed.
+    void cleanup();// will be called after every testfunction.
+    void testMergeRangesDate();
+    void testMergeRangesDateTime();
+
+  private:
+
+};
+
+void TestQgsRange::initTestCase()
+{
+}
+
+void TestQgsRange::cleanupTestCase()
+{
+}
+
+void TestQgsRange::init()
+{
+
+}
+
+void TestQgsRange::cleanup()
+{
+
+}
+
+void TestQgsRange::testMergeRangesDate()
+{
+  QList< QgsDateRange > ranges { QgsDateRange( QDate( 2020, 1, 10 ), QDate( 2020, 1, 15 ) ),
+                                 QgsDateRange( QDate( 2020, 1, 20 ), QDate( 2020, 1, 25 ) ),
+                                 QgsDateRange( QDate( 2020, 1, 9 ), QDate( 2020, 1, 11 ) ),
+                                 QgsDateRange( QDate( 2020, 1, 19 ), QDate( 2020, 1, 27 ) ),
+                                 QgsDateRange( QDate( 2020, 1, 1 ), QDate( 2020, 1, 3 ) ) };
+
+  QList< QgsDateRange > res = QgsDateRange::mergeRanges( ranges );
+  QCOMPARE( res.size(), 3 );
+  QCOMPARE( res.at( 0 ).begin(), QDate( 2020, 1, 1 ) );
+  QCOMPARE( res.at( 0 ).end(), QDate( 2020, 1, 3 ) );
+  QCOMPARE( res.at( 1 ).begin(), QDate( 2020, 1, 9 ) );
+  QCOMPARE( res.at( 1 ).end(), QDate( 2020, 1, 15 ) );
+  QCOMPARE( res.at( 2 ).begin(), QDate( 2020, 1, 19 ) );
+  QCOMPARE( res.at( 2 ).end(), QDate( 2020, 1, 27 ) );
+}
+
+void TestQgsRange::testMergeRangesDateTime()
+{
+  QList< QgsDateTimeRange > ranges { QgsDateTimeRange( QDateTime( QDate( 2020, 1, 10 ), QTime( 0, 0, 0 ) ), QDateTime( QDate( 2020, 1, 15 ), QTime( 0, 0, 0 ) ) ),
+                                     QgsDateTimeRange( QDateTime( QDate( 2020, 1, 20 ), QTime( 0, 0, 0 ) ), QDateTime( QDate( 2020, 1, 25 ), QTime( 0, 0, 0 ) ) ),
+                                     QgsDateTimeRange( QDateTime( QDate( 2020, 1, 9 ), QTime( 0, 0, 0 ) ), QDateTime( QDate( 2020, 1, 11 ), QTime( 0, 0, 0 ) ) ),
+                                     QgsDateTimeRange( QDateTime( QDate( 2020, 1, 19 ), QTime( 0, 0, 0 ) ), QDateTime( QDate( 2020, 1, 27 ), QTime( 0, 0, 0 ) ) ),
+                                     QgsDateTimeRange( QDateTime( QDate( 2020, 1, 1 ), QTime( 0, 0, 0 ) ), QDateTime( QDate( 2020, 1, 3 ), QTime( 0, 0, 0 ) ) ) };
+
+  QList< QgsDateTimeRange > res = QgsDateTimeRange::mergeRanges( ranges );
+  QCOMPARE( res.size(), 3 );
+  QCOMPARE( res.at( 0 ).begin(), QDateTime( QDate( 2020, 1, 1 ), QTime( 0, 0, 0 ) ) );
+  QCOMPARE( res.at( 0 ).end(), QDateTime( QDate( 2020, 1, 3 ), QTime( 0, 0, 0 ) ) );
+  QCOMPARE( res.at( 1 ).begin(), QDateTime( QDate( 2020, 1, 9 ), QTime( 0, 0, 0 ) ) );
+  QCOMPARE( res.at( 1 ).end(), QDateTime( QDate( 2020, 1, 15 ), QTime( 0, 0, 0 ) ) );
+  QCOMPARE( res.at( 2 ).begin(), QDateTime( QDate( 2020, 1, 19 ), QTime( 0, 0, 0 ) ) );
+  QCOMPARE( res.at( 2 ).end(), QDateTime( QDate( 2020, 1, 27 ), QTime( 0, 0, 0 ) ) );
+}
+
+
+QGSTEST_MAIN( TestQgsRange )
+#include "testqgsrange.moc"

--- a/tests/src/core/testqgstemporalnavigationobject.cpp
+++ b/tests/src/core/testqgstemporalnavigationobject.cpp
@@ -44,6 +44,7 @@ class TestQgsTemporalNavigationObject : public QObject
     void frameSettings();
     void navigationMode();
     void expressionContext();
+    void testIrregularStep();
 
   private:
     QgsTemporalNavigationObject *navigationObject = nullptr;
@@ -260,6 +261,60 @@ void TestQgsTemporalNavigationObject::expressionContext()
   QCOMPARE( scope->variable( QStringLiteral( "animation_start_time" ) ).toDateTime(), range.begin() );
   QCOMPARE( scope->variable( QStringLiteral( "animation_end_time" ) ).toDateTime(), range.end() );
   QCOMPARE( scope->variable( QStringLiteral( "animation_interval" ) ).value< QgsInterval >(), range.end() - range.begin() );
+}
+
+void TestQgsTemporalNavigationObject::testIrregularStep()
+{
+  // test using the navigation in irregular step mode
+  QgsTemporalNavigationObject object;
+  QList< QgsDateTimeRange > ranges{  QgsDateTimeRange(
+                                       QDateTime( QDate( 2020, 1, 10 ), QTime( 0, 0, 0 ) ),
+                                       QDateTime( QDate( 2020, 1, 11 ), QTime( 0, 0, 0 ) ) ),
+                                     QgsDateTimeRange(
+                                       QDateTime( QDate( 2020, 1, 15 ), QTime( 0, 0, 0 ) ),
+                                       QDateTime( QDate( 2020, 1, 20 ), QTime( 0, 0, 0 ) ) ),
+                                     QgsDateTimeRange(
+                                       QDateTime( QDate( 2020, 3, 1 ), QTime( 0, 0, 0 ) ),
+                                       QDateTime( QDate( 2020, 4, 5 ), QTime( 0, 0, 0 ) ) )
+                                  };
+  object.setAvailableTemporalRanges( ranges );
+
+  object.setFrameDuration( QgsInterval( 1, QgsUnitTypes::TemporalIrregularStep ) );
+
+  QCOMPARE( object.totalFrameCount(), 3LL );
+
+  QCOMPARE( object.dateTimeRangeForFrameNumber( 0 ), QgsDateTimeRange(
+              QDateTime( QDate( 2020, 1, 10 ), QTime( 0, 0, 0 ) ),
+              QDateTime( QDate( 2020, 1, 11 ), QTime( 0, 0, 0 ) ) ) );
+  // negative should return first frame range
+  QCOMPARE( object.dateTimeRangeForFrameNumber( -1 ), QgsDateTimeRange(
+              QDateTime( QDate( 2020, 1, 10 ), QTime( 0, 0, 0 ) ),
+              QDateTime( QDate( 2020, 1, 11 ), QTime( 0, 0, 0 ) ) ) );
+  QCOMPARE( object.dateTimeRangeForFrameNumber( 1 ), QgsDateTimeRange(
+              QDateTime( QDate( 2020, 1, 15 ), QTime( 0, 0, 0 ) ),
+              QDateTime( QDate( 2020, 1, 20 ), QTime( 0, 0, 0 ) ) ) );
+  QCOMPARE( object.dateTimeRangeForFrameNumber( 2 ), QgsDateTimeRange(
+              QDateTime( QDate( 2020, 3, 1 ), QTime( 0, 0, 0 ) ),
+              QDateTime( QDate( 2020, 4, 5 ), QTime( 0, 0, 0 ) ) ) );
+  QCOMPARE( object.dateTimeRangeForFrameNumber( 5 ), QgsDateTimeRange(
+              QDateTime( QDate( 2020, 3, 1 ), QTime( 0, 0, 0 ) ),
+              QDateTime( QDate( 2020, 4, 5 ), QTime( 0, 0, 0 ) ) ) );
+
+  QCOMPARE( object.findBestFrameNumberForFrameStart( QDateTime( QDate( 2019, 1, 1 ), QTime() ) ), 0LL );
+  QCOMPARE( object.findBestFrameNumberForFrameStart( QDateTime( QDate( 2020, 1, 10 ), QTime( 0, 0, 0 ) ) ), 0LL );
+  QCOMPARE( object.findBestFrameNumberForFrameStart( QDateTime( QDate( 2020, 1, 11 ), QTime( 0, 0, 0 ) ) ), 0LL );
+  // in between available ranges, go back a frame
+  QCOMPARE( object.findBestFrameNumberForFrameStart( QDateTime( QDate( 2020, 1, 12 ), QTime( 0, 0, 0 ) ) ), 0LL );
+
+  QCOMPARE( object.findBestFrameNumberForFrameStart( QDateTime( QDate( 2020, 1, 15 ), QTime( 0, 0, 0 ) ) ), 1LL );
+  QCOMPARE( object.findBestFrameNumberForFrameStart( QDateTime( QDate( 2020, 1, 16 ), QTime( 0, 0, 0 ) ) ), 1LL );
+  QCOMPARE( object.findBestFrameNumberForFrameStart( QDateTime( QDate( 2020, 1, 20 ), QTime( 0, 0, 0 ) ) ), 1LL );
+  QCOMPARE( object.findBestFrameNumberForFrameStart( QDateTime( QDate( 2020, 2, 15 ), QTime( 0, 0, 0 ) ) ), 1LL );
+
+  QCOMPARE( object.findBestFrameNumberForFrameStart( QDateTime( QDate( 2020, 3, 1 ), QTime( 0, 0, 0 ) ) ), 2LL );
+  QCOMPARE( object.findBestFrameNumberForFrameStart( QDateTime( QDate( 2020, 3, 2 ), QTime( 0, 0, 0 ) ) ), 2LL );
+  QCOMPARE( object.findBestFrameNumberForFrameStart( QDateTime( QDate( 2020, 4, 5 ), QTime( 0, 0, 0 ) ) ), 2LL );
+  QCOMPARE( object.findBestFrameNumberForFrameStart( QDateTime( QDate( 2020, 5, 6 ), QTime( 0, 0, 0 ) ) ), 2LL );
 }
 
 QGSTEST_MAIN( TestQgsTemporalNavigationObject )

--- a/tests/src/python/test_qgsunittypes.py
+++ b/tests/src/python/test_qgsunittypes.py
@@ -287,6 +287,7 @@ class TestQgsUnitTypes(unittest.TestCase):
                  QgsUnitTypes.TemporalYears,
                  QgsUnitTypes.TemporalDecades,
                  QgsUnitTypes.TemporalCenturies,
+                 QgsUnitTypes.TemporalIrregularStep,
                  QgsUnitTypes.TemporalUnknownUnit]
 
         for u in units:
@@ -316,6 +317,7 @@ class TestQgsUnitTypes(unittest.TestCase):
                  QgsUnitTypes.TemporalYears,
                  QgsUnitTypes.TemporalDecades,
                  QgsUnitTypes.TemporalCenturies,
+                 QgsUnitTypes.TemporalIrregularStep,
                  QgsUnitTypes.TemporalUnknownUnit]
 
         for u in units:
@@ -892,7 +894,8 @@ class TestQgsUnitTypes(unittest.TestCase):
                 QgsUnitTypes.TemporalYears: 3.170980821917834278e-11,
                 QgsUnitTypes.TemporalDecades: 3.170980821917834117e-12,
                 QgsUnitTypes.TemporalCenturies: 3.170980821917834319e-13,
-                QgsUnitTypes.TemporalUnknownUnit: 1.0
+                QgsUnitTypes.TemporalUnknownUnit: 1.0,
+                QgsUnitTypes.TemporalIrregularStep: 1.0,
             },
             QgsUnitTypes.TemporalSeconds: {
                 QgsUnitTypes.TemporalMilliseconds: 1000.0,
@@ -905,7 +908,8 @@ class TestQgsUnitTypes(unittest.TestCase):
                 QgsUnitTypes.TemporalYears: 3.170980821917834046e-8,
                 QgsUnitTypes.TemporalDecades: 3.170980821917834046e-9,
                 QgsUnitTypes.TemporalCenturies: 3.170980821917834149e-10,
-                QgsUnitTypes.TemporalUnknownUnit: 1.0
+                QgsUnitTypes.TemporalUnknownUnit: 1.0,
+                QgsUnitTypes.TemporalIrregularStep: 1.0,
             },
             QgsUnitTypes.TemporalMinutes: {
                 QgsUnitTypes.TemporalMilliseconds: 60000.0,
@@ -918,7 +922,8 @@ class TestQgsUnitTypes(unittest.TestCase):
                 QgsUnitTypes.TemporalYears: 1.902828841643645226e-6,
                 QgsUnitTypes.TemporalDecades: 1.902828841643645332e-7,
                 QgsUnitTypes.TemporalCenturies: 1.9028288416436452e-8,
-                QgsUnitTypes.TemporalUnknownUnit: 1.0
+                QgsUnitTypes.TemporalUnknownUnit: 1.0,
+                QgsUnitTypes.TemporalIrregularStep: 1.0,
             },
             QgsUnitTypes.TemporalHours: {
                 QgsUnitTypes.TemporalMilliseconds: 3600000.0,
@@ -931,7 +936,8 @@ class TestQgsUnitTypes(unittest.TestCase):
                 QgsUnitTypes.TemporalYears: 0.00011407711613050422,
                 QgsUnitTypes.TemporalDecades: 1.141553424664109737e-5,
                 QgsUnitTypes.TemporalCenturies: 1.141553424664109737e-6,
-                QgsUnitTypes.TemporalUnknownUnit: 1.0
+                QgsUnitTypes.TemporalUnknownUnit: 1.0,
+                QgsUnitTypes.TemporalIrregularStep: 1.0,
             },
             QgsUnitTypes.TemporalDays: {
                 QgsUnitTypes.TemporalMilliseconds: 8.64e+7,
@@ -944,7 +950,8 @@ class TestQgsUnitTypes(unittest.TestCase):
                 QgsUnitTypes.TemporalYears: 0.0027378507871321013,
                 QgsUnitTypes.TemporalDecades: 0.0002737850787132101,
                 QgsUnitTypes.TemporalCenturies: 2.739723287683189167e-5,
-                QgsUnitTypes.TemporalUnknownUnit: 1.0
+                QgsUnitTypes.TemporalUnknownUnit: 1.0,
+                QgsUnitTypes.TemporalIrregularStep: 1.0,
             },
             QgsUnitTypes.TemporalWeeks: {
                 QgsUnitTypes.TemporalMilliseconds: 6.048e+8,
@@ -957,7 +964,8 @@ class TestQgsUnitTypes(unittest.TestCase):
                 QgsUnitTypes.TemporalYears: 0.019164955509924708,
                 QgsUnitTypes.TemporalDecades: 0.0019164955509924709,
                 QgsUnitTypes.TemporalCenturies: 0.0001916495550992471,
-                QgsUnitTypes.TemporalUnknownUnit: 1.0
+                QgsUnitTypes.TemporalUnknownUnit: 1.0,
+                QgsUnitTypes.TemporalIrregularStep: 1.0,
             },
             QgsUnitTypes.TemporalMonths: {
                 QgsUnitTypes.TemporalMilliseconds: 2592000000.0,
@@ -970,7 +978,8 @@ class TestQgsUnitTypes(unittest.TestCase):
                 QgsUnitTypes.TemporalYears: 0.08213552361396304,
                 QgsUnitTypes.TemporalDecades: 0.008213552361396304,
                 QgsUnitTypes.TemporalCenturies: 0.0008213552361396304,
-                QgsUnitTypes.TemporalUnknownUnit: 1.0
+                QgsUnitTypes.TemporalUnknownUnit: 1.0,
+                QgsUnitTypes.TemporalIrregularStep: 1.0,
             },
             QgsUnitTypes.TemporalYears: {
                 QgsUnitTypes.TemporalMilliseconds: 31557600000.0,
@@ -983,7 +992,8 @@ class TestQgsUnitTypes(unittest.TestCase):
                 QgsUnitTypes.TemporalYears: 1,
                 QgsUnitTypes.TemporalDecades: 0.1,
                 QgsUnitTypes.TemporalCenturies: 0.01,
-                QgsUnitTypes.TemporalUnknownUnit: 1.0
+                QgsUnitTypes.TemporalUnknownUnit: 1.0,
+                QgsUnitTypes.TemporalIrregularStep: 1.0,
             },
             QgsUnitTypes.TemporalDecades: {
                 QgsUnitTypes.TemporalMilliseconds: 315576000000.0,
@@ -996,7 +1006,8 @@ class TestQgsUnitTypes(unittest.TestCase):
                 QgsUnitTypes.TemporalYears: 10,
                 QgsUnitTypes.TemporalDecades: 1,
                 QgsUnitTypes.TemporalCenturies: 0.1,
-                QgsUnitTypes.TemporalUnknownUnit: 1.0
+                QgsUnitTypes.TemporalUnknownUnit: 1.0,
+                QgsUnitTypes.TemporalIrregularStep: 1.0,
             },
             QgsUnitTypes.TemporalCenturies: {
                 QgsUnitTypes.TemporalMilliseconds: 3155760000000.0,
@@ -1009,7 +1020,8 @@ class TestQgsUnitTypes(unittest.TestCase):
                 QgsUnitTypes.TemporalYears: 100,
                 QgsUnitTypes.TemporalDecades: 10,
                 QgsUnitTypes.TemporalCenturies: 1,
-                QgsUnitTypes.TemporalUnknownUnit: 1.0
+                QgsUnitTypes.TemporalUnknownUnit: 1.0,
+                QgsUnitTypes.TemporalIrregularStep: 1.0,
             }
         }
 
@@ -1024,6 +1036,10 @@ class TestQgsUnitTypes(unittest.TestCase):
                                                                                                                 QgsUnitTypes.toString(to_unit)))
                 # test conversion to unknown units
                 res = QgsUnitTypes.fromUnitToUnitFactor(from_unit, QgsUnitTypes.TemporalUnknownUnit)
+                self.assertAlmostEqual(res,
+                                       1.0,
+                                       msg='got {:.7f}, expected 1.0 when converting from {} to unknown units'.format(res, QgsUnitTypes.toString(from_unit)))
+                res = QgsUnitTypes.fromUnitToUnitFactor(from_unit, QgsUnitTypes.TemporalIrregularStep)
                 self.assertAlmostEqual(res,
                                        1.0,
                                        msg='got {:.7f}, expected 1.0 when converting from {} to unknown units'.format(res, QgsUnitTypes.toString(from_unit)))


### PR DESCRIPTION
(Includes https://github.com/qgis/QGIS/pull/42399, and by extension includes #42372)

When selected, this causes the temporal navigation to step between all available time ranges from layers in the project.

It's useful when a project contains layers with non-contiguous available times, e.g. from a WMS-T which images available at
irregular dates, and you want to only step between time ranges where the next available image is shown.

Refs Natural resources Canada Contract: 3000720707

The screencast below shows this in action -- note how after switching to the "source timestamps" mode the time jumps become irregular steps, corresponding to each available image time from the loaded WMST services

![Peek 2021-03-24 15-15](https://user-images.githubusercontent.com/1829991/112259304-c958b280-8cb3-11eb-9e51-a17db90c4eca.gif)


