### PR TITLE
Use invalidate() instead of invalidateFilter()

### DIFF
--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -333,7 +333,7 @@ void QgsAttributeTableFilterModel::setFilterMode( FilterMode filterMode )
     disconnectFilterModeConnections();
     connectFilterModeConnections( filterMode );
     mFilterMode = filterMode;
-    invalidateFilter();
+    invalidate();
   }
 }
 


### PR DESCRIPTION
Using `invalidate()`  instead of `invalidateFilter()` in `src/gui/attributetable/qgsattributetablefiltermodel.cpp `

For some reason, using invalidate() solves the issue (at least on Linux). I'm not 100% certain if it's a correct fix for the issue. 

Fixes https://github.com/qgis/QGIS/issues/42246