### PR TITLE
[qt6] Use RecursiveMutex instead of QMutex( QMutex::Recursive )

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -99,7 +99,7 @@ Required build tools:
 
 Required build dependencies:
 
-* Qt >= 5.9.0
+* Qt >= 5.12.0
 * Proj >= 4.9.3
 * GEOS >= 3.4
 * Sqlite3 >= 3.0.0

--- a/python/core/auto_generated/auth/qgsauthmethod.sip.in
+++ b/python/core/auto_generated/auth/qgsauthmethod.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsAuthMethod : QObject
 {
 %Docstring(signature="appended")
@@ -153,7 +154,6 @@ Construct a default authentication method
    Non-public since this is an abstract base class
 %End
 
-
     static QString authMethodTag();
 %Docstring
 Tag signifying that this is an authentcation method (e.g. for use as title in message log panel output)
@@ -172,7 +172,6 @@ Sets the support expansions (points in providers where the authentication is inj
 %Docstring
 Sets list of data providers this auth method supports
 %End
-
 
 };
 QFlags<QgsAuthMethod::Expansion> operator|(QgsAuthMethod::Expansion f1, QFlags<QgsAuthMethod::Expansion> f2);

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -136,6 +136,7 @@ set(QGIS_CORE_SRCS
   auth/qgsauthconfig.cpp
   auth/qgsauthcrypto.cpp
   auth/qgsauthmanager.cpp
+  auth/qgsauthmethod.cpp
   auth/qgsauthmethodmetadata.cpp
   auth/qgsauthmethodregistry.cpp
 

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -100,8 +100,13 @@ QgsAuthManager *QgsAuthManager::instance()
 
 QgsAuthManager::QgsAuthManager()
 {
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
   mMutex.reset( new QMutex( QMutex::Recursive ) );
   mMasterPasswordMutex.reset( new QMutex( QMutex::Recursive ) );
+#else
+  mMutex = std::make_unique<QRecursiveMutex>();
+  mMasterPasswordMutex = std::make_unique<QRecursiveMutex>();
+#endif
   connect( this, &QgsAuthManager::messageOut,
            this, &QgsAuthManager::writeToConsole );
 }

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -20,7 +20,11 @@
 #include "qgis_core.h"
 #include "qgis_sip.h"
 #include <QObject>
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
 #include <QMutex>
+#else
+#include <QRecursiveMutex>
+#endif
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QSqlDatabase>
@@ -870,9 +874,13 @@ class CORE_EXPORT QgsAuthManager : public QObject
     bool mScheduledDbEraseRequestEmitted = false;
     int mScheduledDbEraseRequestCount = 0;
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     std::unique_ptr<QMutex> mMutex;
     std::unique_ptr<QMutex> mMasterPasswordMutex;
-
+#else
+    std::unique_ptr<QRecursiveMutex> mMutex;
+    std::unique_ptr<QRecursiveMutex> mMasterPasswordMutex;
+#endif
 #ifndef QT_NO_SSL
     // mapping of sha1 digest and cert source and cert
     // appending removes duplicates

--- a/src/core/auth/qgsauthmethod.cpp
+++ b/src/core/auth/qgsauthmethod.cpp
@@ -1,0 +1,23 @@
+/***************************************************************************
+    qgsauthmethod.cpp
+    ---------------------
+    begin                : March 2021
+    copyright            : (C) 2021
+    author               : Matthias Khn
+    email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsauthmethod.h"
+
+QgsAuthMethod::QgsAuthMethod()
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+  : mMutex( QMutex::RecursionMode::Recursive )
+#endif
+{}

--- a/src/core/auth/qgsauthmethod.h
+++ b/src/core/auth/qgsauthmethod.h
@@ -23,7 +23,12 @@
 #include <QNetworkRequest>
 #include <QStringList>
 #include <QUrl>
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
 #include <QMutex>
+#else
+#include <QRecursiveMutex>
+#endif
+
 
 #include "qgis_core.h"
 
@@ -172,10 +177,7 @@ class CORE_EXPORT QgsAuthMethod : public QObject
      * Construct a default authentication method
      * \note Non-public since this is an abstract base class
      */
-    explicit QgsAuthMethod()
-      : mMutex( QMutex::RecursionMode::Recursive )
-    {}
-
+    explicit QgsAuthMethod();
 
     //! Tag signifying that this is an authentcation method (e.g. for use as title in message log panel output)
     static QString authMethodTag() { return QObject::tr( "Authentication method" ); }
@@ -191,8 +193,11 @@ class CORE_EXPORT QgsAuthMethod : public QObject
     QgsAuthMethod::Expansions mExpansions = QgsAuthMethod::Expansions();
     QStringList mDataProviders;
     int mVersion = 0;
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     QMutex mMutex;
-
+#else
+    QRecursiveMutex mMutex;
+#endif
 };
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsAuthMethod::Expansions )
 

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6328,8 +6328,13 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
   // crashes in the WFS provider may occur, since it can parse expressions
   // in parallel.
   // The mutex needs to be recursive.
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
   static QMutex sFunctionsMutex( QMutex::Recursive );
   QMutexLocker locker( &sFunctionsMutex );
+#else
+  static QRecursiveMutex sFunctionsMutex;
+  QMutexLocker locker( &sFunctionsMutex );
+#endif
 
   QList<QgsExpressionFunction *> &functions = *sFunctions();
 

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -71,7 +71,11 @@
 #define PROVIDER_DESCRIPTION QStringLiteral( "GDAL data provider" )
 
 // To avoid potential races when destroying related instances ("main" and clones)
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
 Q_GLOBAL_STATIC_WITH_ARGS( QMutex, sGdalProviderMutex, ( QMutex::Recursive ) )
+#else
+Q_GLOBAL_STATIC( QRecursiveMutex, sGdalProviderMutex )
+#endif
 
 QHash< QgsGdalProvider *, QVector<QgsGdalProvider::DatasetPair> > QgsGdalProvider::mgDatasetCache;
 
@@ -146,7 +150,11 @@ QgsGdalProvider::QgsGdalProvider( const QString &uri, const QgsError &error )
 QgsGdalProvider::QgsGdalProvider( const QString &uri, const ProviderOptions &options, bool update, GDALDatasetH dataset )
   : QgsRasterDataProvider( uri, options )
   , mpRefCounter( new QAtomicInt( 1 ) )
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
   , mpMutex( new QMutex( QMutex::Recursive ) )
+#else
+  , mpMutex( new QRecursiveMutex() )
+#endif
   , mpParent( new QgsGdalProvider * ( this ) )
   , mpLightRefCounter( new QAtomicInt( 1 ) )
   , mUpdate( update )
@@ -238,7 +246,12 @@ QgsGdalProvider::QgsGdalProvider( const QgsGdalProvider &other )
 
     mpRefCounter = new QAtomicInt( 1 );
     mpLightRefCounter = other.mpLightRefCounter;
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     mpMutex = new QMutex( QMutex::Recursive );
+#else
+    mpMutex = new QRecursiveMutex();
+#endif
+
     mpParent = other.mpParent;
 
     if ( getCachedGdalHandles( const_cast<QgsGdalProvider *>( &other ), mGdalBaseDataset, mGdalDataset ) )

--- a/src/core/providers/gdal/qgsgdalprovider.h
+++ b/src/core/providers/gdal/qgsgdalprovider.h
@@ -235,7 +235,12 @@ class QgsGdalProvider final: public QgsRasterDataProvider, QgsGdalProviderBase
     QAtomicInt *mpRefCounter = nullptr;
 
     // mutex to protect access to mGdalDataset among main and shared provider instances
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     QMutex *mpMutex = nullptr;
+#else
+    QRecursiveMutex *mpMutex = nullptr;
+#endif
+
 
     // pointer to a QgsGdalProvider* that is the parent. Note when *mpParent == this, we are the parent.
     QgsGdalProvider **mpParent = nullptr;

--- a/src/core/qgsabstractcontentcache.h
+++ b/src/core/qgsabstractcontentcache.h
@@ -27,7 +27,11 @@
 #include "qgsnetworkcontentfetchertask.h"
 
 #include <QObject>
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
 #include <QMutex>
+#else
+#include <QRecursiveMutex>
+#endif
 #include <QCache>
 #include <QSet>
 #include <QDateTime>
@@ -210,7 +214,9 @@ class CORE_EXPORT QgsAbstractContentCache : public QgsAbstractContentCacheBase
                              long maxCacheSize = 20000000,
                              int fileModifiedCheckTimeout = 30000 )
       : QgsAbstractContentCacheBase( parent )
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
       , mMutex( QMutex::Recursive )
+#endif
       , mMaxCacheSize( maxCacheSize )
       , mFileModifiedCheckTimeout( fileModifiedCheckTimeout )
       , mTypeString( typeString.isEmpty() ? QObject::tr( "Content" ) : typeString )
@@ -548,8 +554,11 @@ class CORE_EXPORT QgsAbstractContentCache : public QgsAbstractContentCacheBase
 
       return currentEntry;
     }
-
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     mutable QMutex mMutex;
+#else
+    mutable QRecursiveMutex mMutex;
+#endif
     //! Estimated total size of all cached content
     long mTotalSize = 0;
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -102,6 +102,9 @@
 #include <QRegularExpression>
 #include <QTextStream>
 #include <QScreen>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+#include <QRecursiveMutex>
+#endif
 
 #ifndef Q_OS_WIN
 #include <netinet/in.h>
@@ -2570,7 +2573,11 @@ QgsApplication::ApplicationMembers *QgsApplication::members()
   }
   else
   {
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     static QMutex sMemberMutex( QMutex::Recursive );
+#else
+    static QRecursiveMutex sMemberMutex;
+#endif
     QMutexLocker lock( &sMemberMutex );
     if ( !sApplicationMembers )
       sApplicationMembers = new ApplicationMembers();

--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -389,7 +389,11 @@ class QgsTaskRunnableWrapper : public QRunnable
 
 QgsTaskManager::QgsTaskManager( QObject *parent )
   : QObject( parent )
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
   , mTaskMutex( new QMutex( QMutex::Recursive ) )
+#else
+  , mTaskMutex( new QRecursiveMutex() )
+#endif
 {
 
 }

--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -597,7 +597,11 @@ class CORE_EXPORT QgsTaskManager : public QObject
 
     bool mInitialized = false;
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     mutable QMutex *mTaskMutex;
+#else
+    mutable QRecursiveMutex *mTaskMutex;
+#endif
 
     QMap< long, TaskInfo > mTasks;
     QMap< long, QgsTaskList > mTaskDependencies;

--- a/src/core/qgstiledownloadmanager.cpp
+++ b/src/core/qgstiledownloadmanager.cpp
@@ -144,7 +144,9 @@ void QgsTileDownloadManagerReplyWorkerObject::replyFinished()
 
 
 QgsTileDownloadManager::QgsTileDownloadManager()
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
   : mMutex( QMutex::Recursive )
+#endif
 {
 }
 

--- a/src/core/qgstiledownloadmanager.h
+++ b/src/core/qgstiledownloadmanager.h
@@ -281,7 +281,11 @@ class CORE_EXPORT QgsTileDownloadManager
 
     QList<QueueEntry> mQueue;
     bool mShuttingDown = false;
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     mutable QMutex mMutex;
+#else
+    mutable QRecursiveMutex mMutex;
+#endif
     QThread *mWorkerThread = nullptr;
     QgsTileDownloadManagerWorker *mWorker = nullptr;
     Stats mStats;


### PR DESCRIPTION
QMutex::Recursive will be gone.
The replacement only entered the stage with Qt 5.14
