### PR TITLE
[qt6] QDesktopWidget is gone

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -81,7 +81,9 @@
 
 #include "layout/qgspagesizeregistry.h"
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
 #include <QDesktopWidget>
+#endif
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
@@ -99,6 +101,7 @@
 #include <QStandardPaths>
 #include <QRegularExpression>
 #include <QTextStream>
+#include <QScreen>
 
 #ifndef Q_OS_WIN
 #include <netinet/in.h>
@@ -1853,8 +1856,13 @@ int QgsApplication::scaleIconSize( int standardSize, bool applyDevicePixelRatio 
   QFontMetrics fm( ( QFont() ) );
   const double scale = 1.1 * standardSize / 24;
   int scaledIconSize = static_cast< int >( std::floor( std::max( Qgis::UI_SCALE_FACTOR * fm.height() * scale, static_cast< double >( standardSize ) ) ) );
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
   if ( applyDevicePixelRatio && QApplication::desktop() )
     scaledIconSize *= QApplication::desktop()->devicePixelRatio();
+#else
+  if ( applyDevicePixelRatio && !QApplication::topLevelWidgets().isEmpty() )
+    scaledIconSize *= QApplication::topLevelWidgets().first()->screen()->devicePixelRatio();
+#endif
   return scaledIconSize;
 }
 

--- a/src/core/textrenderer/qgstextformat.cpp
+++ b/src/core/textrenderer/qgstextformat.cpp
@@ -23,8 +23,12 @@
 #include "qgstextrendererutils.h"
 #include "qgspallabeling.h"
 #include <QFontDatabase>
-#include <QDesktopWidget>
 #include <QMimeData>
+#include <QWidget>
+#include <QScreen>
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+#include <QDesktopWidget>
+#endif
 
 QgsTextFormat::QgsTextFormat()
 {
@@ -956,7 +960,13 @@ QPixmap QgsTextFormat::textFormatPreviewPixmap( const QgsTextFormat &format, QSi
   newCoordXForm.setParameters( 1, 0, 0, 0, 0, 0 );
   context.setMapToPixel( newCoordXForm );
 
-  context.setScaleFactor( QgsApplication::desktop()->logicalDpiX() / 25.4 );
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+  const double logicalDpiX = QgsApplication::desktop()->logicalDpiX();
+#else
+  const double logicalDpiX = QApplication::topLevelWidgets().first()->screen()->devicePixelRatio();
+#endif
+  context.setScaleFactor( logicalDpiX / 25.4 );
+
   context.setUseAdvancedEffects( true );
   context.setFlag( QgsRenderContext::Antialiasing, true );
   context.setPainter( &painter );


### PR DESCRIPTION
QScreen takes over.
We are randomly picking a top level widget to get the dpi as we have always been doing.