### PR TITLE
Initializing a QString with an enum is nonsense

### DIFF
--- a/src/core/qgssqlexpressioncompiler.cpp
+++ b/src/core/qgssqlexpressioncompiler.cpp
@@ -19,8 +19,7 @@
 #include "qgsexpression.h"
 
 QgsSqlExpressionCompiler::QgsSqlExpressionCompiler( const QgsFields &fields, Flags flags, bool ignoreStaticNodes )
-  : mResult( None )
-  , mFields( fields )
+  : mFields( fields )
   , mFlags( flags )
   , mIgnoreStaticNodes( ignoreStaticNodes )
 {


### PR DESCRIPTION
Thanks for pointing this out, Qt6
Qt5 has been interpreting this as QChar if I'm reading this correctly