### PR TITLE
Correctly populate all available temporal ranges for WMS-T services  which report available times using ISO8601 style duration strings

### DIFF
--- a/python/core/auto_generated/qgstemporalutils.sip.in
+++ b/python/core/auto_generated/qgstemporalutils.sip.in
@@ -119,6 +119,7 @@ Calculates a complete list of datetimes between ``start`` and ``end``, using the
 .. versionadded:: 3.20
 %End
 
+
     static QList< QDateTime > calculateDateTimesFromISO8601( const QString &string, bool &ok /Out/, bool &maxValuesExceeded /Out/, int maxValues = -1 );
 %Docstring
 Calculates a complete list of datetimes from a ISO8601 ``string`` containing a duration (eg "2021-03-23T00:00:00Z/2021-03-24T12:00:00Z/PT12H").

--- a/python/core/auto_generated/qgstemporalutils.sip.in
+++ b/python/core/auto_generated/qgstemporalutils.sip.in
@@ -10,6 +10,8 @@
 
 
 
+
+
 class QgsTemporalUtils
 {
 %Docstring(signature="appended")
@@ -100,6 +102,37 @@ the number of days in the current month.
 
 .. versionadded:: 3.18
 %End
+
+    static QList< QDateTime > calculateDateTimesUsingDuration( const QDateTime &start, const QDateTime &end, const QString &duration, bool &ok /Out/, bool &maxValuesExceeded /Out/, int maxValues = -1 );
+%Docstring
+Calculates a complete list of datetimes between ``start`` and ``end``, using the specified ISO8601 ``duration`` string (eg "PT12H").
+
+:param start: start date time
+:param end: end date time
+:param duration: ISO8601 duration string
+:param maxValues: maximum number of values to return, or -1 to return all values
+
+:return: - calculated list of date times
+         - ok: will be set to ``True`` if ``duration`` was successfully parsed and date times could be calculated
+         - maxValuesExceeded: will be set to ``True`` if the maximum number of values to return was exceeded
+
+.. versionadded:: 3.20
+%End
+
+    static QList< QDateTime > calculateDateTimesFromISO8601( const QString &string, bool &ok /Out/, bool &maxValuesExceeded /Out/, int maxValues = -1 );
+%Docstring
+Calculates a complete list of datetimes from a ISO8601 ``string`` containing a duration (eg "2021-03-23T00:00:00Z/2021-03-24T12:00:00Z/PT12H").
+
+:param string: ISO8601 compatible string
+:param maxValues: maximum number of values to return, or -1 to return all values
+
+:return: - calculated list of date times
+         - ok: will be set to ``True`` if ``string`` was successfully parsed and date times could be calculated
+         - maxValuesExceeded: will be set to ``True`` if the maximum number of values to return was exceeded
+
+.. versionadded:: 3.20
+%End
+
 };
 
 

--- a/python/core/auto_generated/raster/qgsrasterdataprovidertemporalcapabilities.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovidertemporalcapabilities.sip.in
@@ -122,6 +122,26 @@ Returns the requested temporal range.
 Intended to be used by the provider in fetching data.
 %End
 
+    QgsInterval defaultInterval() const;
+%Docstring
+Returns the default time step interval corresponding to the available
+datetime values for the provider.
+
+.. seealso:: :py:func:`setDefaultInterval`
+
+.. versionadded:: 3.20
+%End
+
+    void setDefaultInterval( const QgsInterval &interval );
+%Docstring
+Sets the default time step ``interval`` corresponding to the available
+datetime values for the provider.
+
+.. seealso:: :py:func:`defaultInterval`
+
+.. versionadded:: 3.20
+%End
+
 };
 
 /************************************************************************

--- a/src/core/qgstemporalutils.cpp
+++ b/src/core/qgstemporalutils.cpp
@@ -278,6 +278,11 @@ QList<QDateTime> QgsTemporalUtils::calculateDateTimesFromISO8601( const QString 
 // QgsTimeDuration
 //
 
+QgsInterval QgsTimeDuration::toInterval() const
+{
+  return QgsInterval( years, months, weeks, days, hours, minutes, seconds );
+}
+
 QString QgsTimeDuration::toString() const
 {
   QString text( "P" );

--- a/src/core/qgstemporalutils.cpp
+++ b/src/core/qgstemporalutils.cpp
@@ -368,13 +368,13 @@ QgsTimeDuration QgsTimeDuration::fromString( const QString &string, bool &ok )
   if ( match.hasMatch() )
   {
     ok = true;
-    duration.years = match.capturedView( 1 ).toInt();
-    duration.months = match.capturedView( 2 ).toInt();
-    duration.weeks = match.capturedView( 3 ).toInt();
-    duration.days = match.capturedView( 4 ).toInt();
-    duration.hours = match.capturedView( 5 ).toInt();
-    duration.minutes = match.capturedView( 6 ).toInt();
-    duration.seconds = match.capturedView( 7 ).toDouble();
+    duration.years = match.captured( 1 ).toInt();
+    duration.months = match.captured( 2 ).toInt();
+    duration.weeks = match.captured( 3 ).toInt();
+    duration.days = match.captured( 4 ).toInt();
+    duration.hours = match.captured( 5 ).toInt();
+    duration.minutes = match.captured( 6 ).toInt();
+    duration.seconds = match.captured( 7 ).toDouble();
   }
   return duration;
 }

--- a/src/core/qgstemporalutils.h
+++ b/src/core/qgstemporalutils.h
@@ -25,6 +25,46 @@ class QgsMapSettings;
 class QgsFeedback;
 class QgsMapDecoration;
 
+#ifndef SIP_RUN
+
+/**
+ * \ingroup core
+ * \class QgsTimeDuration
+ * \brief Contains utility methods for working with temporal layers and projects.
+ *
+ * Designed for storage of ISO8601 duration values.
+ *
+ * \note Not available in Python bindings
+ * \since QGIS 3.20
+ */
+class CORE_EXPORT QgsTimeDuration
+{
+  public:
+
+    //! Years
+    int years = 0;
+    //! Months
+    int months = 0;
+    //! Weeks
+    int weeks = 0;
+    //! Days
+    int days = 0;
+    //! Hours
+    int hours = 0;
+    //! Minutes
+    int minutes = 0;
+    //! Seconds
+    double seconds = 0;
+
+    /**
+     * Creates a QgsTimeDuration from a \a string value.
+     */
+    static QgsTimeDuration fromString( const QString &string, bool &ok );
+
+};
+#endif
+
+
 /**
  * \ingroup core
  * \class QgsTemporalUtils
@@ -125,6 +165,31 @@ class CORE_EXPORT QgsTemporalUtils
      * \since QGIS 3.18
      */
     static QDateTime calculateFrameTime( const QDateTime &start, const long long frame, const QgsInterval interval );
+
+    /**
+     * Calculates a complete list of datetimes between \a start and \a end, using the specified ISO8601 \a duration string (eg "PT12H").
+     * \param start start date time
+     * \param end end date time
+     * \param duration ISO8601 duration string
+     * \param ok will be set to TRUE if \a duration was successfully parsed and date times could be calculated
+     * \param maxValuesExceeded will be set to TRUE if the maximum number of values to return was exceeded
+     * \param maxValues maximum number of values to return, or -1 to return all values
+     * \returns calculated list of date times
+     * \since QGIS 3.20
+     */
+    static QList< QDateTime > calculateDateTimesUsingDuration( const QDateTime &start, const QDateTime &end, const QString &duration, bool &ok SIP_OUT, bool &maxValuesExceeded SIP_OUT, int maxValues = -1 );
+
+    /**
+     * Calculates a complete list of datetimes from a ISO8601 \a string containing a duration (eg "2021-03-23T00:00:00Z/2021-03-24T12:00:00Z/PT12H").
+     * \param string ISO8601 compatible string
+     * \param ok will be set to TRUE if \a string was successfully parsed and date times could be calculated
+     * \param maxValuesExceeded will be set to TRUE if the maximum number of values to return was exceeded
+     * \param maxValues maximum number of values to return, or -1 to return all values
+     * \returns calculated list of date times
+     * \since QGIS 3.20
+     */
+    static QList< QDateTime > calculateDateTimesFromISO8601( const QString &string, bool &ok SIP_OUT, bool &maxValuesExceeded SIP_OUT, int maxValues = -1 );
+
 };
 
 

--- a/src/core/qgstemporalutils.h
+++ b/src/core/qgstemporalutils.h
@@ -57,6 +57,45 @@ class CORE_EXPORT QgsTimeDuration
     double seconds = 0;
 
     /**
+     * Returns TRUE if the duration is null, i.e. an empty duration.
+     */
+    bool isNull() const
+    {
+      return !years && !months && !days &&
+             !hours && !minutes && !seconds;
+    }
+
+    bool operator==( const QgsTimeDuration &other ) const
+    {
+      return years == other.years && months == other.months &&
+             days == other.days && hours == other.hours &&
+             minutes == other.minutes && seconds == other.seconds;
+    }
+
+    bool operator!=( const QgsTimeDuration &other ) const
+    {
+      return !( *this == other );
+    }
+
+    /**
+     * Converts the duration to an ISO8601 duration string.
+     */
+    QString toString() const;
+
+    /**
+     * Returns the total duration in seconds.
+     *
+     * \warning If the duration contains year or month intervals then the returned
+     * value is approximate only, due to the variable length of these intervals.
+     */
+    long long toSeconds() const;
+
+    /**
+     * Adds this duration to a starting \a dateTime value.
+     */
+    QDateTime addToDateTime( const QDateTime &dateTime );
+
+    /**
      * Creates a QgsTimeDuration from a \a string value.
      */
     static QgsTimeDuration fromString( const QString &string, bool &ok );
@@ -178,6 +217,22 @@ class CORE_EXPORT QgsTemporalUtils
      * \since QGIS 3.20
      */
     static QList< QDateTime > calculateDateTimesUsingDuration( const QDateTime &start, const QDateTime &end, const QString &duration, bool &ok SIP_OUT, bool &maxValuesExceeded SIP_OUT, int maxValues = -1 );
+
+#ifndef SIP_RUN
+
+    /**
+     * Calculates a complete list of datetimes between \a start and \a end, using the specified ISO8601 \a duration string (eg "PT12H").
+     * \param start start date time
+     * \param end end date time
+     * \param duration ISO8601 duration
+     * \param maxValuesExceeded will be set to TRUE if the maximum number of values to return was exceeded
+     * \param maxValues maximum number of values to return, or -1 to return all values
+     * \returns calculated list of date times
+     * \note Not available in Python bindings
+     * \since QGIS 3.20
+     */
+    static QList< QDateTime > calculateDateTimesUsingDuration( const QDateTime &start, const QDateTime &end, const QgsTimeDuration &duration, bool &maxValuesExceeded SIP_OUT, int maxValues = -1 );
+#endif
 
     /**
      * Calculates a complete list of datetimes from a ISO8601 \a string containing a duration (eg "2021-03-23T00:00:00Z/2021-03-24T12:00:00Z/PT12H").

--- a/src/core/qgstemporalutils.h
+++ b/src/core/qgstemporalutils.h
@@ -78,6 +78,11 @@ class CORE_EXPORT QgsTimeDuration
     }
 
     /**
+     * Converts the duration to an interval value.
+     */
+    QgsInterval toInterval() const;
+
+    /**
      * Converts the duration to an ISO8601 duration string.
      */
     QString toString() const;

--- a/src/core/raster/qgsrasterdataprovidertemporalcapabilities.cpp
+++ b/src/core/raster/qgsrasterdataprovidertemporalcapabilities.cpp
@@ -63,6 +63,16 @@ void QgsRasterDataProviderTemporalCapabilities::setRequestedTemporalRange( const
   mRequestedRange = dateTimeRange;
 }
 
+QgsInterval QgsRasterDataProviderTemporalCapabilities::defaultInterval() const
+{
+  return mDefaultInterval;
+}
+
+void QgsRasterDataProviderTemporalCapabilities::setDefaultInterval( const QgsInterval &defaultInterval )
+{
+  mDefaultInterval = defaultInterval;
+}
+
 const QgsDateTimeRange &QgsRasterDataProviderTemporalCapabilities::requestedTemporalRange() const
 {
   return mRequestedRange;

--- a/src/core/raster/qgsrasterdataprovidertemporalcapabilities.h
+++ b/src/core/raster/qgsrasterdataprovidertemporalcapabilities.h
@@ -21,6 +21,7 @@
 #include "qgis_core.h"
 #include "qgis_sip.h"
 #include "qgsrange.h"
+#include "qgsinterval.h"
 #include "qgsdataprovidertemporalcapabilities.h"
 
 /**
@@ -134,6 +135,24 @@ class CORE_EXPORT QgsRasterDataProviderTemporalCapabilities : public QgsDataProv
     */
     const QgsDateTimeRange &requestedTemporalRange() const;
 
+    /**
+     * Returns the default time step interval corresponding to the available
+     * datetime values for the provider.
+     *
+     * \see setDefaultInterval()
+     * \since QGIS 3.20
+     */
+    QgsInterval defaultInterval() const;
+
+    /**
+     * Sets the default time step \a interval corresponding to the available
+     * datetime values for the provider.
+     *
+     * \see defaultInterval()
+     * \since QGIS 3.20
+     */
+    void setDefaultInterval( const QgsInterval &interval );
+
   private:
 
     /**
@@ -171,6 +190,8 @@ class CORE_EXPORT QgsRasterDataProviderTemporalCapabilities : public QgsDataProv
      * Stores the available reference temporal range
      */
     QgsDateTimeRange mAvailableReferenceRange;
+
+    QgsInterval mDefaultInterval;
 
     //! Interval handling method
     IntervalHandlingMethod mIntervalMatchMethod = MatchUsingWholeRange;

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -112,9 +112,18 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
       if ( !extent.resolution.isNull() )
       {
         bool maxValuesExceeded = false;
-        const QList< QDateTime > dates = QgsTemporalUtils::calculateDateTimesUsingDuration( begin, end, extent.resolution, maxValuesExceeded );
-        for ( const QDateTime &dt : dates )
-          mAllRanges.append( QgsDateTimeRange( dt, dt ) );
+        const QList< QDateTime > dates = QgsTemporalUtils::calculateDateTimesUsingDuration( begin, end, extent.resolution, maxValuesExceeded, 1000 );
+        // if we have a manageable number of distinct dates, then we'll use those. If not we just use the overall range.
+        // (some servers eg may have data for every minute for decades!)
+        if ( !maxValuesExceeded )
+        {
+          for ( const QDateTime &dt : dates )
+            mAllRanges.append( QgsDateTimeRange( dt, dt ) );
+        }
+        else
+        {
+          mAllRanges.append( QgsDateTimeRange( begin, end ) );
+        }
       }
       else
       {

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -124,10 +124,13 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
         {
           mAllRanges.append( QgsDateTimeRange( begin, end ) );
         }
+
+        mDefaultInterval = extent.resolution.toInterval();
       }
       else
       {
         mAllRanges.append( QgsDateTimeRange( begin, end ) );
+        mDefaultInterval = QgsInterval( 1, QgsUnitTypes::TemporalIrregularStep );
       }
     }
 

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -786,6 +786,8 @@ class QgsWmsSettings
     //! All available temporal ranges
     QList< QgsDateTimeRange > mAllRanges;
 
+    QgsInterval mDefaultInterval;
+
     //! Fixed reference temporal range for the data provider
     QgsDateTimeRange mFixedReferenceRange;
 

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -525,7 +525,10 @@ struct QgsWmstExtentPair
   {
   }
 
-  QgsWmstExtentPair( QgsWmstDates otherDates, QgsWmstResolution otherResolution )
+  QgsWmstExtentPair( QgsWmstDates otherDates, QgsWmstResolution otherResolution, const QString &originalString )
+    : dates( otherDates )
+    , resolution( otherResolution )
+    , originalString( originalString )
   {
     dates = otherDates;
     resolution = otherResolution;
@@ -539,6 +542,8 @@ struct QgsWmstExtentPair
 
   QgsWmstDates dates;
   QgsWmstResolution resolution;
+  QString originalString;
+
 };
 
 

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -28,7 +28,7 @@
 #include "qgsapplication.h"
 #include "qgsdataprovider.h"
 #include "qgsinterval.h"
-
+#include "qgstemporalutils.h"
 
 class QNetworkReply;
 
@@ -422,101 +422,6 @@ struct QgsWmstDates
 };
 
 /**
- * Stores resolution part of the WMS-T dimension extent.
- *
- * If resolution does not exist, active() will return false;
- */
-struct QgsWmstResolution
-{
-  int year = -1;
-  int month = -1;
-  int day = -1;
-
-  int hour = -1;
-  int minutes = -1;
-  int seconds = -1;
-
-  long long interval() const
-  {
-    long long secs = 0.0;
-
-    if ( year != -1 )
-      secs += year * QgsInterval::YEARS ;
-    if ( month != -1 )
-      secs += month * QgsInterval::MONTHS;
-    if ( day != -1 )
-      secs += day * QgsInterval::DAY;
-    if ( hour != -1 )
-      secs += hour * QgsInterval::HOUR;
-    if ( minutes != -1 )
-      secs += minutes * QgsInterval::MINUTE;
-    if ( seconds != -1 )
-      secs += seconds;
-
-    return secs;
-  }
-
-  bool active() const
-  {
-    return year != -1 || month != -1 || day != -1 ||
-           hour != -1 || minutes != -1 || seconds != -1;
-  }
-
-  QString text() const
-  {
-    QString text( "P" );
-
-    if ( year != -1 )
-    {
-      text.append( QString::number( year ) );
-      text.append( 'Y' );
-    }
-    if ( month != -1 )
-    {
-      text.append( QString::number( month ) );
-      text.append( 'M' );
-    }
-    if ( day != -1 )
-    {
-      text.append( QString::number( day ) );
-      text.append( 'D' );
-    }
-
-    if ( hour != -1 )
-    {
-      if ( !text.contains( 'T' ) )
-        text.append( 'T' );
-      text.append( QString::number( hour ) );
-      text.append( 'H' );
-    }
-    if ( minutes != -1 )
-    {
-      if ( !text.contains( 'T' ) )
-        text.append( 'T' );
-      text.append( QString::number( minutes ) );
-      text.append( 'M' );
-    }
-    if ( seconds != -1 )
-    {
-      if ( !text.contains( 'T' ) )
-        text.append( 'T' );
-      text.append( QString::number( seconds ) );
-      text.append( 'S' );
-    }
-    return text;
-  }
-
-  bool operator==( const QgsWmstResolution &other ) const
-  {
-    return year == other.year && month == other.month &&
-           day == other.day && hour == other.hour &&
-           minutes == other.minutes && seconds == other.seconds;
-  }
-
-};
-
-
-/**
  * Stores dates and resolution structure pair.
  */
 struct QgsWmstExtentPair
@@ -525,13 +430,10 @@ struct QgsWmstExtentPair
   {
   }
 
-  QgsWmstExtentPair( QgsWmstDates otherDates, QgsWmstResolution otherResolution, const QString &originalString )
-    : dates( otherDates )
-    , resolution( otherResolution )
-    , originalString( originalString )
+  QgsWmstExtentPair( QgsWmstDates dates, QgsTimeDuration resolution )
+    : dates( dates )
+    , resolution( resolution )
   {
-    dates = otherDates;
-    resolution = otherResolution;
   }
 
   bool operator ==( const QgsWmstExtentPair &other )
@@ -541,8 +443,7 @@ struct QgsWmstExtentPair
   }
 
   QgsWmstDates dates;
-  QgsWmstResolution resolution;
-  QString originalString;
+  QgsTimeDuration resolution;
 
 };
 
@@ -843,7 +744,7 @@ class QgsWmsSettings
      *
      * \since QGIS 3.14
      */
-    QgsWmstResolution parseWmstResolution( const QString &item );
+    QgsTimeDuration parseWmstResolution( const QString &item );
 
     /**
      * Parse the given string item into QDateTime instant.
@@ -851,13 +752,6 @@ class QgsWmsSettings
      * \since QGIS 3.14
      */
     QDateTime parseWmstDateTimes( const QString &item );
-
-    /**
-     * Returns the datetime with the sum of passed \a dateTime and the \a resolution time.
-     *
-     * \since QGIS 3.14
-     */
-    QDateTime addTime( const QDateTime &dateTime, const QgsWmstResolution &resolution );
 
     /**
      * Finds the least closest datetime from list of available dimension temporal ranges

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -173,6 +173,7 @@ QgsWmsProvider::QgsWmsProvider( QString const &uri, const ProviderOptions &optio
       temporalCapabilities()->setHasTemporalCapabilities( true );
       temporalCapabilities()->setAvailableTemporalRange( mSettings.mFixedRange );
       temporalCapabilities()->setAllAvailableTemporalRanges( mSettings.mAllRanges );
+      temporalCapabilities()->setDefaultInterval( mSettings.mDefaultInterval );
 
       temporalCapabilities()->setIntervalHandlingMethod(
         QgsRasterDataProviderTemporalCapabilities::MatchExactUsingStartOfRange );

--- a/src/providers/wms/qgswmstsettingswidget.cpp
+++ b/src/providers/wms/qgswmstsettingswidget.cpp
@@ -78,7 +78,7 @@ void QgsWmstSettingsWidget::syncToLayer( QgsMapLayer *layer )
 
     const QList< QgsDateTimeRange > allAvailableRanges = mRasterLayer->dataProvider()->temporalCapabilities()->allAvailableTemporalRanges();
     // determine if available ranges are a set of non-contiguous instants, and if so, we show a combobox to users instead of the free-form date widgets
-    if ( std::all_of( allAvailableRanges.cbegin(), allAvailableRanges.cend(), []( const QgsDateTimeRange & range ) { return range.isInstant(); } ) )
+    if ( allAvailableRanges.size() < 50 && std::all_of( allAvailableRanges.cbegin(), allAvailableRanges.cend(), []( const QgsDateTimeRange & range ) { return range.isInstant(); } ) )
     {
       mStaticWmstRangeFrame->hide();
       mStaticWmstChoiceFrame->show();

--- a/src/ui/qgswmstsettingswidgetbase.ui
+++ b/src/ui/qgswmstsettingswidgetbase.ui
@@ -197,7 +197,7 @@
                  <widget class="QgsDateTimeEdit" name="mStartStaticDateTimeEdit">
                   <property name="dateTime">
                    <datetime>
-                    <hour>21</hour>
+                    <hour>11</hour>
                     <minute>3</minute>
                     <second>57</second>
                     <year>2020</year>
@@ -331,21 +331,11 @@
       <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="mReferenceTimeExtentLabel">
-        <property name="text">
-         <string>No reference time is reported in the layer's capabilities.</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0" colspan="2">
        <widget class="QgsDateTimeEdit" name="mReferenceDateTimeEdit">
         <property name="dateTime">
          <datetime>
-          <hour>18</hour>
+          <hour>8</hour>
           <minute>20</minute>
           <second>36</second>
           <year>2020</year>
@@ -376,6 +366,19 @@
          <bool>false</bool>
         </property>
        </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="mReferenceTimeExtentLabel">
+        <property name="text">
+         <string>No reference time is reported in the layer's capabilities.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QComboBox" name="mReferenceTimeCombo"/>
       </item>
      </layout>
     </widget>

--- a/tests/src/providers/testqgswmscapabilities.cpp
+++ b/tests/src/providers/testqgswmscapabilities.cpp
@@ -120,10 +120,10 @@ class TestQgsWmsCapabilities: public QObject
         "P1Y1DT3S", "P1MT1M", "PT23H3M", "P26DT23H3M", "PT30S"
       };
 
-      for ( QString resolutionText : resolutionList )
+      for ( const QString &resolutionText : resolutionList )
       {
-        QgsWmstResolution resolution = settings.parseWmstResolution( resolutionText );
-        QCOMPARE( resolution.text(), resolutionText );
+        QgsTimeDuration resolution = settings.parseWmstResolution( resolutionText );
+        QCOMPARE( resolution.toString(), resolutionText );
       }
 
       QgsWmstDimensionExtent extent = settings.parseTemporalExtent( QStringLiteral( "2020-01-02T00:00:00.000Z/2020-01-09T00:00:00.000Z/P1D" ) );
@@ -132,14 +132,14 @@ class TestQgsWmsCapabilities: public QObject
       QDateTime start = QDateTime( QDate( 2020, 1, 2 ), QTime( 0, 0, 0 ), Qt::UTC );
       QDateTime end = QDateTime( QDate( 2020, 1, 9 ), QTime( 0, 0, 0 ), Qt::UTC );
 
-      QgsWmstResolution res;
-      res.day = 1;
-      QgsWmstResolution extentResolution = extent.datesResolutionList.at( 0 ).resolution;
+      QgsTimeDuration res;
+      res.days = 1;
+      QgsTimeDuration extentResolution = extent.datesResolutionList.at( 0 ).resolution;
 
       QCOMPARE( extent.datesResolutionList.at( 0 ).dates.dateTimes.at( 0 ), start );
       QCOMPARE( extent.datesResolutionList.at( 0 ).dates.dateTimes.at( 1 ), end );
 
-      QCOMPARE( extentResolution.text(), res.text() );
+      QCOMPARE( extentResolution.toString(), res.toString() );
 
       QDateTime firstClosest = settings.findLeastClosestDateTime( QDateTime( QDate( 2020, 1, 3 ), QTime( 16, 0, 0 ), Qt::UTC ) );
       QDateTime firstExpected = QDateTime( QDate( 2020, 1, 3 ), QTime( 0, 0, 0 ), Qt::UTC );


### PR DESCRIPTION
Allows these services to be used with the new step mode introduced in https://github.com/qgis/QGIS/pull/42424