### PR TITLE
Don't force users to hit apply to setup static wms-t settings after toggling dynamic temporal control

### DIFF
--- a/python/gui/auto_generated/qgsmaplayerconfigwidget.sip.in
+++ b/python/gui/auto_generated/qgsmaplayerconfigwidget.sip.in
@@ -60,6 +60,9 @@ Called when changes to the layer need to be made.
 Will be called when live update is enabled.
 %End
 
+  signals:
+
+
   protected:
 };
 

--- a/src/gui/qgsmaplayerconfigwidget.h
+++ b/src/gui/qgsmaplayerconfigwidget.h
@@ -67,6 +67,20 @@ class GUI_EXPORT QgsMapLayerConfigWidget : public QgsPanelWidget
      */
     virtual void apply() = 0;
 
+  signals:
+
+#ifndef SIP_RUN
+
+    /**
+     * Emitted whenever the dynamic temporal control option is toggled in the associated layer
+     * properties dialog.
+     *
+     * \note Not available in Python bindings
+     * \since QGIS 3.20
+     */
+    void dynamicTemporalControlToggled( bool enabled );
+#endif
+
   protected:
     QgsMapLayer *mLayer = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;

--- a/src/gui/raster/qgsrasterlayertemporalpropertieswidget.cpp
+++ b/src/gui/raster/qgsrasterlayertemporalpropertieswidget.cpp
@@ -38,6 +38,8 @@ QgsRasterLayerTemporalPropertiesWidget::QgsRasterLayerTemporalPropertiesWidget( 
 
   connect( mModeFixedRangeRadio, &QRadioButton::toggled, mFixedTimeRangeFrame, &QWidget::setEnabled );
 
+  connect( mTemporalGroupBox, &QGroupBox::toggled, this, &QgsRasterLayerTemporalPropertiesWidget::temporalGroupBoxChecked );
+
   mStartTemporalDateTimeEdit->setDisplayFormat( QStringLiteral( "yyyy-MM-dd HH:mm:ss" ) );
   mEndTemporalDateTimeEdit->setDisplayFormat( QStringLiteral( "yyyy-MM-dd HH:mm:ss" ) );
 
@@ -100,4 +102,12 @@ void QgsRasterLayerTemporalPropertiesWidget::addWidget( QgsMapLayerConfigWidget 
 {
   mExtraWidgets << widget;
   mExtraWidgetLayout->insertWidget( mExtraWidgetLayout->count() - 1, widget );
+}
+
+void QgsRasterLayerTemporalPropertiesWidget::temporalGroupBoxChecked( bool checked )
+{
+  for ( QgsMapLayerConfigWidget *widget : std::as_const( mExtraWidgets ) )
+  {
+    widget->emit dynamicTemporalControlToggled( checked );
+  }
 }

--- a/src/gui/raster/qgsrasterlayertemporalpropertieswidget.h
+++ b/src/gui/raster/qgsrasterlayertemporalpropertieswidget.h
@@ -59,6 +59,9 @@ class GUI_EXPORT QgsRasterLayerTemporalPropertiesWidget : public QWidget, privat
      */
     void addWidget( QgsMapLayerConfigWidget *widget SIP_TRANSFER );
 
+  private slots:
+    void temporalGroupBoxChecked( bool checked );
+
   private:
 
     /**

--- a/src/providers/wms/qgswmstsettingswidget.cpp
+++ b/src/providers/wms/qgswmstsettingswidget.cpp
@@ -66,6 +66,24 @@ QgsWmstSettingsWidget::QgsWmstSettingsWidget( QgsMapLayer *layer, QgsMapCanvas *
                                          "with valid values in order to use it here." ) );
     mProjectTemporalRangeLabel->setEnabled( false );
   }
+
+  connect( this, &QgsMapLayerConfigWidget::dynamicTemporalControlToggled, this, [ = ]( bool checked )
+  {
+    if ( checked )
+    {
+      mStaticWmstStackedWidget->setCurrentIndex( 0 );
+      // why do we hide this widget? well, the second page of the stacked widget is considerably higher
+      // then the first and we don't want to show a whole bunch of empty vertical space which Qt will give
+      // in order to accommodate the vertical height of the non-visible second page!
+      mStaticStackedWidgetFrame->hide();
+    }
+    else
+    {
+      mStaticWmstStackedWidget->setCurrentIndex( 1 );
+      mStaticStackedWidgetFrame->show();
+    }
+    mStaticWmstStackedWidget->updateGeometry();
+  } );
 }
 
 void QgsWmstSettingsWidget::syncToLayer( QgsMapLayer *layer )

--- a/src/ui/qgswmstsettingswidgetbase.ui
+++ b/src/ui/qgswmstsettingswidgetbase.ui
@@ -44,7 +44,7 @@
       <item row="1" column="0">
        <widget class="QStackedWidget" name="mStaticWmstStackedWidget">
         <property name="currentIndex">
-         <number>1</number>
+         <number>0</number>
         </property>
         <widget class="QWidget" name="page">
          <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -63,7 +63,7 @@
           <item>
            <widget class="QLabel" name="mWmstOptionsLabel">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The static WMS-T options are disabled because the layer is set to &lt;span style=&quot; font-weight:600;&quot;&gt;Dynamic Temporal Control&lt;/span&gt;. To enable them first disable &lt;span style=&quot; font-weight:600;&quot;&gt;Dynamic Temporal Control&lt;/span&gt; and click Apply.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The static WMS-T options are disabled because the layer is set to &lt;span style=&quot; font-weight:600;&quot;&gt;Dynamic Temporal Control&lt;/span&gt;. To enable them first disable &lt;span style=&quot; font-weight:600;&quot;&gt;Dynamic Temporal Control&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -197,7 +197,7 @@
                  <widget class="QgsDateTimeEdit" name="mStartStaticDateTimeEdit">
                   <property name="dateTime">
                    <datetime>
-                    <hour>21</hour>
+                    <hour>11</hour>
                     <minute>3</minute>
                     <second>57</second>
                     <year>2020</year>
@@ -345,7 +345,7 @@
        <widget class="QgsDateTimeEdit" name="mReferenceDateTimeEdit">
         <property name="dateTime">
          <datetime>
-          <hour>18</hour>
+          <hour>8</hour>
           <minute>20</minute>
           <second>36</second>
           <year>2020</year>


### PR DESCRIPTION
Not the nicest code approach, but I honestly can't think of any
other way to handle this...

![Peek 2021-03-25 12-35](https://user-images.githubusercontent.com/1829991/112410428-e7cbb600-8d66-11eb-86ba-8bfaae021327.gif)
