### PR TITLE
[labeling] Fix handling of data-defined buffers (both UI/UX and rendering behavior)

### DIFF
--- a/src/app/labeling/qgslabelpropertydialog.cpp
+++ b/src/app/labeling/qgslabelpropertydialog.cpp
@@ -186,6 +186,7 @@ void QgsLabelPropertyDialog::init( const QString &layerId, const QString &provid
   mYCoordSpinBox->clear();
 
   mShowLabelChkbx->setChecked( true );
+  mBufferDrawChkbx->setChecked( buffer.enabled() );
   mFontColorButton->setColor( format.color() );
   mBufferColorButton->setColor( buffer.color() );
   mMinScaleWidget->setScale( layerSettings.minimumScale );

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -3051,7 +3051,6 @@ void QgsPalLayerSettings::parseTextBuffer( QgsRenderContext &context )
   }
   else if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::BufferDraw ) && exprVal.isNull() )
   {
-    drawBuffer = false;
     dataDefinedValues.insert( QgsPalLayerSettings::BufferDraw, QVariant( drawBuffer ) );
   }
 

--- a/src/gui/labeling/qgslabelinggui.cpp
+++ b/src/gui/labeling/qgslabelinggui.cpp
@@ -32,6 +32,7 @@
 #include "callouts/qgscalloutwidget.h"
 #include "qgslabelobstaclesettingswidget.h"
 #include "qgslabellineanchorwidget.h"
+
 #include <mutex>
 
 #include <QButtonGroup>
@@ -244,6 +245,7 @@ QgsLabelingGui::QgsLabelingGui( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, 
 
   // connections for groupboxes with separate activation checkboxes (that need to honor data defined setting)
   connect( mBufferDrawChkBx, &QAbstractButton::toggled, this, &QgsLabelingGui::updateUi );
+  connect( mBufferDrawDDBtn, &QgsPropertyOverrideButton::changed, this, &QgsLabelingGui::updateUi );
   connect( mEnableMaskChkBx, &QAbstractButton::toggled, this, &QgsLabelingGui::updateUi );
   connect( mShapeDrawChkBx, &QAbstractButton::toggled, this, &QgsLabelingGui::updateUi );
   connect( mCalloutsDrawCheckBox, &QAbstractButton::toggled, this, &QgsLabelingGui::updateUi );
@@ -627,11 +629,7 @@ QgsPalLayerSettings QgsLabelingGui::layerSettings()
 
 void QgsLabelingGui::syncDefinedCheckboxFrame( QgsPropertyOverrideButton *ddBtn, QCheckBox *chkBx, QFrame *f )
 {
-  if ( ddBtn->isActive() && !chkBx->isChecked() )
-  {
-    chkBx->setChecked( true );
-  }
-  f->setEnabled( chkBx->isChecked() );
+  f->setEnabled( chkBx->isChecked() || ddBtn->isActive() );
 }
 
 bool QgsLabelingGui::eventFilter( QObject *object, QEvent *event )

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -707,7 +707,6 @@ void QgsTextFormatWidget::populateDataDefinedButtons()
 
   // text buffer
   registerDataDefinedButton( mBufferDrawDDBtn, QgsPalLayerSettings::BufferDraw );
-  mBufferDrawDDBtn->registerCheckedWidget( mBufferDrawChkBx );
   registerDataDefinedButton( mBufferSizeDDBtn, QgsPalLayerSettings::BufferSize );
   registerDataDefinedButton( mBufferUnitsDDBtn, QgsPalLayerSettings::BufferUnit );
   registerDataDefinedButton( mBufferColorDDBtn, QgsPalLayerSettings::BufferColor );


### PR DESCRIPTION
## Description

This PR fixes a couple of issues with data-defined buffer handling:
1/ revert this commit (https://github.com/qgis/QGIS/commit/9322a0be7e61c17ba4d0a8dc1163d5695e763a16) so that a data defined property with a null value reverts to the static/UI defined value
2/ fix the UI so that the buffer frame UI elements are enabled when the [x] enable buffer checkbox _OR_ the data-defined property is active
3/ fix the label property tool's [x] draw buffer checkbox to reflect the static/UI defined value by default if not overwritten by a user-set true/false

Without these fixes, if you set a layer's labels to have a buffer by default, then use the change label properties tool to customize a single label, _all buffers are gone_ because the auxiliary field value null by default.