### PR TITLE
[labeling] Fix handling of data-defined callouts (both UI/UX and rendering)

### DIFF
--- a/src/app/labeling/qgslabelpropertydialog.cpp
+++ b/src/app/labeling/qgslabelpropertydialog.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgslabelpropertydialog.h"
+#include "qgscallout.h"
 #include "qgsfontutils.h"
 #include "qgslogger.h"
 #include "qgsfeatureiterator.h"
@@ -187,6 +188,7 @@ void QgsLabelPropertyDialog::init( const QString &layerId, const QString &provid
 
   mShowLabelChkbx->setChecked( true );
   mBufferDrawChkbx->setChecked( buffer.enabled() );
+  mShowCalloutChkbx->setChecked( layerSettings.callout() ? layerSettings.callout()->enabled() : false );
   mFontColorButton->setColor( format.color() );
   mBufferColorButton->setColor( buffer.color() );
   mMinScaleWidget->setScale( layerSettings.minimumScale );

--- a/src/core/callouts/qgscallout.cpp
+++ b/src/core/callouts/qgscallout.cpp
@@ -134,9 +134,6 @@ QgsCallout::DrawOrder QgsCallout::drawOrder() const
 
 void QgsCallout::render( QgsRenderContext &context, const QRectF &rect, const double angle, const QgsGeometry &anchor, QgsCalloutContext &calloutContext )
 {
-  if ( !mEnabled )
-    return;
-
 #if 0 // for debugging
   QPainter *painter = context.painter();
   painter->save();

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -468,7 +468,7 @@ void QgsTextFormatWidget::initWidget()
   {
     updateShadowFrameStatus();
   } );
-  connect( mCalloutDrawDDBtn, &QgsPropertyOverrideButton::activated, this, &QgsTextFormatWidget::updateCalloutFrameStatus );
+  connect( mCalloutDrawDDBtn, &QgsPropertyOverrideButton::changed, this, &QgsTextFormatWidget::updateCalloutFrameStatus );
   connect( mCalloutsDrawCheckBox, &QCheckBox::stateChanged, this, [ = ]( int )
   {
     updateCalloutFrameStatus();
@@ -809,7 +809,6 @@ void QgsTextFormatWidget::populateDataDefinedButtons()
   registerDataDefinedButton( mZIndexDDBtn, QgsPalLayerSettings::ZIndex );
 
   registerDataDefinedButton( mCalloutDrawDDBtn, QgsPalLayerSettings::CalloutDraw );
-  mCalloutDrawDDBtn->registerCheckedWidget( mCalloutsDrawCheckBox );
 
   registerDataDefinedButton( mLabelAllPartsDDBtn, QgsPalLayerSettings::LabelAllParts );
 }


### PR DESCRIPTION
## Description

Same as the buffer counterpart I committed earlier today. This PR fix data-defined callouts so the static UI setting can be off by default and a data-defined property is used to selectively turn it on for individual feature(s).