### PR TITLE
Fix auth basic encoding (no auth system)

### DIFF
--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -635,7 +635,7 @@ void QgsDataSourceUri::setEncodedUri( const QByteArray &uri )
   mAuthConfigId.clear();
 
   QUrl url;
-  url.setQuery( QString::fromUtf8( uri ) );
+  url.setQuery( QString::fromLatin1( uri ) );
   const QUrlQuery query( url );
 
   const auto constQueryItems = query.queryItems( QUrl::ComponentFormattingOption::FullyDecoded );

--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -635,7 +635,7 @@ void QgsDataSourceUri::setEncodedUri( const QByteArray &uri )
   mAuthConfigId.clear();
 
   QUrl url;
-  url.setQuery( QString::fromLatin1( uri ) );
+  url.setQuery( QString::fromUtf8( uri ) );
   const QUrlQuery query( url );
 
   const auto constQueryItems = query.queryItems( QUrl::ComponentFormattingOption::FullyDecoded );
@@ -654,7 +654,7 @@ void QgsDataSourceUri::setEncodedUri( const QByteArray &uri )
 
 void QgsDataSourceUri::setEncodedUri( const QString &uri )
 {
-  setEncodedUri( uri.toLatin1() );
+  setEncodedUri( uri.toUtf8() );
 }
 
 QString QgsDataSourceUri::quotedTablename() const

--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -654,7 +654,7 @@ void QgsDataSourceUri::setEncodedUri( const QByteArray &uri )
 
 void QgsDataSourceUri::setEncodedUri( const QString &uri )
 {
-  setEncodedUri( uri.toUtf8() );
+  setEncodedUri( uri.toLatin1() );
 }
 
 QString QgsDataSourceUri::quotedTablename() const

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -764,7 +764,7 @@ struct QgsWmsAuthorization
     }
     else if ( !mUserName.isEmpty() || !mPassword.isEmpty() )
     {
-      request.setRawHeader( "Authorization", "Basic " + QStringLiteral( "%1:%2" ).arg( mUserName, mPassword ).toLatin1().toBase64() );
+      request.setRawHeader( "Authorization", "Basic " + QStringLiteral( "%1:%2" ).arg( mUserName, mPassword ).toUtf8().toBase64() );
     }
 
     if ( !mReferer.isEmpty() )

--- a/tests/src/core/testqgsdatasourceuri.cpp
+++ b/tests/src/core/testqgsdatasourceuri.cpp
@@ -299,6 +299,19 @@ void TestQgsDataSourceUri::checkAuthParams()
   QCOMPARE( uri4.param( QStringLiteral( "password" ) ), QStringLiteral( "pa%%word" ) );
   QCOMPARE( uri4.password(), QStringLiteral( "pa%%word" ) );
 
+  // issue GH #42405
+  uri4.setEncodedUri( QStringLiteral( "dpiMode=7&url=http://localhost:8000/ows/?MAP%3D/home/bug.qgs&username=username&password=qgis%C3%A8%C3%A9" ) );
+  QCOMPARE( uri4.param( QStringLiteral( "username" ) ), QStringLiteral( "username" ) );
+  QCOMPARE( uri4.username(), QStringLiteral( "username" ) );
+  QCOMPARE( uri4.param( QStringLiteral( "password" ) ), QStringLiteral( "qgisèé" ) );
+  QCOMPARE( uri4.password(), QStringLiteral( "qgisèé" ) );
+
+  uri4.setEncodedUri( QStringLiteral( "dpiMode=7&url=http://localhost:8000/&username=username&password=%1" ).arg( QString( QUrl::toPercentEncoding( QStringLiteral( "😁😂😍" ) ) ) ) );
+  QCOMPARE( uri4.param( QStringLiteral( "username" ) ), QStringLiteral( "username" ) );
+  QCOMPARE( uri4.username(), QStringLiteral( "username" ) );
+  QCOMPARE( uri4.param( QStringLiteral( "password" ) ), QStringLiteral( "😁😂😍" ) );
+  QCOMPARE( uri4.password(), QStringLiteral( "😁😂😍" ) );
+
 }
 
 


### PR DESCRIPTION
Followup #42410 (which fixed the auth system stored configuration part, this fixes the plain unencrypted storage)

Fixes #42405

