### PR TITLE
Fixes TestQgsGeometry::splitGeometry() test with geos 3.9 and geos 3.8

### DIFF
--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -18071,11 +18071,20 @@ void TestQgsGeometry::minimalEnclosingCircle()
 
 void TestQgsGeometry::splitGeometry()
 {
-  QgsGeometry g1 = QgsGeometry::fromWkt( QStringLiteral( "Polygon ((492980.38648063864093274 7082334.45244149677455425, 493082.65415841294452548 7082319.87918917648494244, 492980.38648063858272508 7082334.45244149677455425, 492980.38648063864093274 7082334.45244149677455425))" ) );
   QVector<QgsGeometry> newGeoms;
   QgsPointSequence testPoints;
-  QCOMPARE( g1.splitGeometry( QgsPointSequence() << QgsPoint( 493825.46541286131832749, 7082214.02779923938214779 ) << QgsPoint( 492955.04876351181883365, 7082338.06309300474822521 ),
-                              newGeoms, false, testPoints ), QgsGeometry::NothingHappened );
+  qDebug() << GEOSversion() << "\n";
+  QgsGeometry g1 = QgsGeometry::fromWkt( QStringLiteral( "Polygon ((492980.38648063864093274 7082334.45244149677455425, 493082.65415841294452548 7082319.87918917648494244, 492980.38648063858272508 7082334.45244149677455425, 492980.38648063864093274 7082334.45244149677455425))" ) );
+  if ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR < 9 )
+  {
+    QCOMPARE( g1.splitGeometry( QgsPointSequence() << QgsPoint( 493825.46541286131832749, 7082214.02779923938214779 ) << QgsPoint( 492955.04876351181883365, 7082338.06309300474822521 ),
+                                newGeoms, false, testPoints ), QgsGeometry::NothingHappened );
+  }
+  else
+  {
+    QCOMPARE( g1.splitGeometry( QgsPointSequence() << QgsPoint( 493825.46541286131832749, 7082214.02779923938214779 ) << QgsPoint( 492955.04876351181883365, 7082338.06309300474822521 ),
+                                newGeoms, false, testPoints ), QgsGeometry::InvalidBaseGeometry );
+  }
   QVERIFY( newGeoms.isEmpty() );
 
   // Bug https://github.com/qgis/QGIS/issues/33489


### PR DESCRIPTION
## Description

I have encountered some differences in my processing with Geos 3.8 and 3.9. 

AFAIK, our CI use only Geos < 3.9 
![image](https://user-images.githubusercontent.com/7521540/112475203-d7b8d400-8d70-11eb-8ad7-c2d248bb5de2.png)

In particular, one test failed with geos 3.9.1. Here, the results on FreeBSD/ LLVM10 and Geos 3.81. vs 3.9.1

Geos 3.8.1

```
INFO   : TestQgsGeometry::splitGeometry() entering
INFO   : TestQgsGeometry::splitGeometry() QCOMPARE(g1.splitGeometry( QgsPointSequence() << QgsPoint( 493825.46541286131832749, 7082214.02779923938214779 ) << QgsPoint( 492955.04876351181883365, 7082338.06309300474822521 ), newGeoms, false, testPoints ), QgsGeometry::Not
hingHappened)
[...]
PASS   : TestQgsGeometry::splitGeometry()
```

Geos 3.9.1
```
FAIL!  : TestQgsGeometry::splitGeometry() Compared values are not the same
   Actual   (g1.splitGeometry( QgsPointSequence() << QgsPoint( 493825.46541286131832749, 7082214.02779923938214779 ) << QgsPoint( 492955.04876351181883365, 7082338.06309300474822521 ), newGeoms, false, testPoints )): InvalidBaseGeometry
   Expected (QgsGeometry::NothingHappened)                                                                                                                                                                             : NothingHappened
   Loc: [/home/lbartoletti/qgis/tests/src/core/testqgsgeometry.cpp(18079)]
```

