### PR TITLE
When using the temporal controller in filter mode, the time filter should be begin <= t < end, not begin <= t <= end

### DIFF
--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -864,9 +864,9 @@ bool QgsLayoutItemMap::readPropertiesFromElement( const QDomElement &itemElem, c
   setIsTemporal( itemElem.attribute( QStringLiteral( "isTemporal" ) ).toInt() );
   if ( isTemporal() )
   {
-    QDateTime begin = QDateTime::fromString( itemElem.attribute( QStringLiteral( "temporalRangeBegin" ) ), Qt::ISODate );
-    QDateTime end = QDateTime::fromString( itemElem.attribute( QStringLiteral( "temporalRangeEnd" ) ), Qt::ISODate );
-    setTemporalRange( QgsDateTimeRange( begin, end ) );
+    const QDateTime begin = QDateTime::fromString( itemElem.attribute( QStringLiteral( "temporalRangeBegin" ) ), Qt::ISODate );
+    const QDateTime end = QDateTime::fromString( itemElem.attribute( QStringLiteral( "temporalRangeEnd" ) ), Qt::ISODate );
+    setTemporalRange( QgsDateTimeRange( begin, end, true, begin == end ) );
   }
 
   mUpdatesEnabled = true;
@@ -1922,7 +1922,7 @@ void QgsLayoutItemMap::refreshDataDefinedProperty( const QgsLayoutObject::DataDe
     if ( property == QgsLayoutObject::EndDateTime || property == QgsLayoutObject::AllProperties )
       end = mDataDefinedProperties.valueAsDateTime( QgsLayoutObject::EndDateTime, context, temporalRange().end() );
 
-    setTemporalRange( QgsDateTimeRange( begin, end ) );
+    setTemporalRange( QgsDateTimeRange( begin, end, true, begin == end ) );
   }
 
   //force redraw

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -525,9 +525,6 @@ void QgsLayoutMapWidget::mTemporalCheckBox_toggled( bool checked )
     return;
   }
 
-  mStartDateTime->setEnabled( checked );
-  mEndDateTime->setEnabled( checked );
-
   mMapItem->layout()->undoStack()->beginCommand( mMapItem, tr( "Toggle Temporal Range" ) );
   mMapItem->setIsTemporal( checked );
   mMapItem->layout()->undoStack()->endCommand();
@@ -548,7 +545,9 @@ void QgsLayoutMapWidget::updateTemporalExtent()
     return;
   }
 
-  QgsDateTimeRange range = QgsDateTimeRange( mStartDateTime->dateTime(), mEndDateTime->dateTime() );
+  const QDateTime begin = mStartDateTime->dateTime();
+  const QDateTime end = mEndDateTime->dateTime();
+  QgsDateTimeRange range = QgsDateTimeRange( begin, end, true, begin == end );
 
   mMapItem->layout()->undoStack()->beginCommand( mMapItem, tr( "Set Temporal Range" ) );
   mMapItem->setTemporalRange( range );

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -489,19 +489,19 @@ void QgsTemporalControllerWidget::updateSlider( const QgsDateTimeRange &range )
 
 void QgsTemporalControllerWidget::updateRangeLabel( const QgsDateTimeRange &range )
 {
-  QString timeFrameFormat = "yyyy-MM-dd HH:mm:ss";
+  QString timeFrameFormat = QStringLiteral( "yyyy-MM-dd HH:mm:ss" );
   // but if timesteps are < 1 second (as: in milliseconds), add milliseconds to the format
   if ( mTimeStepsComboBox->currentIndex() == mTimeStepsComboBox->findData( QgsUnitTypes::TemporalMilliseconds ) )
-    timeFrameFormat = "yyyy-MM-dd HH:mm:ss.zzz";
+    timeFrameFormat = QStringLiteral( "yyyy-MM-dd HH:mm:ss.zzz" );
   switch ( mNavigationObject->navigationMode() )
   {
     case QgsTemporalNavigationObject::Animated:
-      mCurrentRangeLabel->setText( tr( "Frame: %1 to %2" ).arg(
+      mCurrentRangeLabel->setText( tr( "Frame: %1 ≤ <i>t</i> &lt; %2" ).arg(
                                      range.begin().toString( timeFrameFormat ),
                                      range.end().toString( timeFrameFormat ) ) );
       break;
     case QgsTemporalNavigationObject::FixedRange:
-      mCurrentRangeLabel->setText( tr( "Range: %1 to %2" ).arg(
+      mCurrentRangeLabel->setText( tr( "Range: %1 ≤ <i>t</i> &lt; %2" ).arg(
                                      range.begin().toString( timeFrameFormat ),
                                      range.end().toString( timeFrameFormat ) ) );
       break;
@@ -627,10 +627,10 @@ void QgsTemporalControllerWidget::updateTimeStepInputs( const QgsInterval &timeS
   if ( ! timeStep.isValid() || timeStep.seconds() <= 0.0001 )
     return;
 
-  QString timeDisplayFormat = "yyyy-MM-dd HH:mm:ss";
+  QString timeDisplayFormat = QStringLiteral( "yyyy-MM-dd HH:mm:ss" );
   if ( QgsUnitTypes::TemporalMilliseconds == timeStep.originalUnit() )
   {
-    timeDisplayFormat = "yyyy-MM-dd HH:mm:ss.zzz";
+    timeDisplayFormat = QStringLiteral( "yyyy-MM-dd HH:mm:ss.zzz" );
     // very big change that you have to update the range too, as defaulting to NOT handling millis
     updateTemporalExtent();
   }

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -281,8 +281,13 @@ void QgsTemporalControllerWidget::togglePause()
 
 void QgsTemporalControllerWidget::updateTemporalExtent()
 {
-  QgsDateTimeRange temporalExtent = QgsDateTimeRange( mStartDateTime->dateTime(),
-                                    mEndDateTime->dateTime() );
+  // TODO - consider whether the overall time range set for animations should include the end date time or not.
+  // (currently it DOES include the end date time).
+  const QDateTime start = mStartDateTime->dateTime();
+  const QDateTime end = mEndDateTime->dateTime();
+  const bool isTimeInstant = start == end;
+  QgsDateTimeRange temporalExtent = QgsDateTimeRange( start, end,
+                                    true, !isTimeInstant && mNavigationObject->navigationMode() == QgsTemporalNavigationObject::FixedRange ? false : true );
   mNavigationObject->setTemporalExtents( temporalExtent );
   mSlider->setRange( 0, mNavigationObject->totalFrameCount() - 1 );
   mSlider->setValue( mNavigationObject->currentFrameNumber() );

--- a/src/ui/layout/qgslayoutmapwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapwidgetbase.ui
@@ -88,9 +88,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
+        <y>-376</y>
         <width>548</width>
-        <height>1336</height>
+        <height>1398</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -445,11 +445,8 @@
          <layout class="QGridLayout" name="gridLayout_5">
           <item row="0" column="0">
            <widget class="QLabel" name="mStartDateTimeLabel">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
             <property name="text">
-             <string>Start</string>
+             <string>Start (inclusive)</string>
             </property>
             <property name="wordWrap">
              <bool>false</bool>
@@ -484,11 +481,8 @@
           </item>
           <item row="1" column="0">
            <widget class="QLabel" name="mEndDateTimeLabel">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
             <property name="text">
-             <string>End</string>
+             <string>End (exclusive)</string>
             </property>
             <property name="wordWrap">
              <bool>false</bool>
@@ -1011,14 +1005,15 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsProjectionSelectionWidget</class>
@@ -1027,10 +1022,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsPropertyOverrideButton</class>
@@ -1125,8 +1119,6 @@
   <tabstop>mOverviewStackingLayerComboBox</tabstop>
  </tabstops>
  <resources>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/src/ui/qgstemporalcontrollerwidgetbase.ui
+++ b/src/ui/qgstemporalcontrollerwidgetbase.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>QgsTemporalControllerWidgetBase</class>
  <widget class="QgsPanelWidget" name="QgsTemporalControllerWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>703</width>
+    <height>118</height>
+   </rect>
+  </property>
   <property name="windowTitle">
    <string>QgsDockWidget</string>
   </property>
@@ -115,7 +123,7 @@
    <item>
     <widget class="QStackedWidget" name="mNavigationModeStackedWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="p1">
       <layout class="QVBoxLayout" name="verticalLayoutP1">
@@ -179,7 +187,7 @@
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_4">
+          <spacer name="horizontalSpacer_2">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -202,7 +210,7 @@
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_5">
+          <spacer name="horizontalSpacer_3">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -439,7 +447,7 @@
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_2">
+          <spacer name="horizontalSpacer_4">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -457,12 +465,12 @@
          <item>
           <widget class="QLabel" name="mRangeToLabel">
            <property name="text">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;≤ &lt;span style=&quot; font-style:italic;&quot;&gt;t&lt;/span&gt; &amp;lt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>to</string>
            </property>
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_3">
+          <spacer name="horizontalSpacer_5">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>

--- a/tests/src/core/testqgslayoutmap.cpp
+++ b/tests/src/core/testqgslayoutmap.cpp
@@ -514,9 +514,9 @@ void TestQgsLayoutMap::dataDefinedTemporalRange()
   map->dataDefinedProperties().setProperty( QgsLayoutObject::EndDateTime, QgsProperty::fromValue( dt2 ) );
   map->refreshDataDefinedProperty( QgsLayoutObject::StartDateTime );
   map->refreshDataDefinedProperty( QgsLayoutObject::EndDateTime );
-  QCOMPARE( map->temporalRange(), QgsDateTimeRange( dt1, dt2 ) );
+  QCOMPARE( map->temporalRange(), QgsDateTimeRange( dt1, dt2, true, false ) );
   QgsMapSettings ms = map->mapSettings( map->extent(), map->rect().size(), 300, false );
-  QCOMPARE( ms.temporalRange(), QgsDateTimeRange( dt1, dt2 ) );
+  QCOMPARE( ms.temporalRange(), QgsDateTimeRange( dt1, dt2, true, false ) );
 }
 
 void TestQgsLayoutMap::rasterized()
@@ -1937,7 +1937,7 @@ void TestQgsLayoutMap::testTemporal()
   settings = map->mapSettings( map->extent(), QSize( 512, 512 ), 72, false );
   renderContext = QgsRenderContext::fromMapSettings( settings );
   QVERIFY( renderContext.isTemporal() );
-  QCOMPARE( renderContext.temporalRange(), QgsDateTimeRange( begin, end ) );
+  QCOMPARE( renderContext.temporalRange(), QgsDateTimeRange( begin, end, true, false ) );
 }
 
 QGSTEST_MAIN( TestQgsLayoutMap )


### PR DESCRIPTION
We want the same range in animation mode to match the results we see in time filter mode, and the UI (now) shows clearly that
the upper range isn't included in the filter. Also fix the same situation for layout maps.

