### PR TITLE
Add QgsVectorLayer::minimumAndMaximumValue()

### DIFF
--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -2411,11 +2411,22 @@ returned list).
 
 %Docstring
 Returns the minimum value for an attribute column or an invalid variant in case of error.
-Note that in some circumstances when unsaved changes are present for the layer then the
-returned value may be outdated (for instance when the attribute value in a saved feature has
-been changed inside the edit buffer then the previous saved value may be returned as the minimum).
+
+.. note::
+
+   In some circumstances when unsaved changes are present for the layer then the
+   returned value may be outdated (for instance when the attribute value in a saved feature has
+   been changed inside the edit buffer then the previous saved value may be returned as the minimum).
+
+.. note::
+
+   If both the minimum and maximum value are required it is more efficient to call :py:func:`~QgsVectorLayer.minimumAndMaximumValue`
+   instead of separate calls to :py:func:`~QgsVectorLayer.minimumValue` and :py:func:`~QgsVectorLayer.maximumValue`.
+
 
 .. seealso:: :py:func:`maximumValue`
+
+.. seealso:: :py:func:`minimumAndMaximumValue`
 
 .. seealso:: :py:func:`uniqueValues`
 %End
@@ -2424,13 +2435,52 @@ been changed inside the edit buffer then the previous saved value may be returne
 
 %Docstring
 Returns the maximum value for an attribute column or an invalid variant in case of error.
-Note that in some circumstances when unsaved changes are present for the layer then the
-returned value may be outdated (for instance when the attribute value in a saved feature has
-been changed inside the edit buffer then the previous saved value may be returned as the maximum).
+
+.. note::
+
+   In some circumstances when unsaved changes are present for the layer then the
+   returned value may be outdated (for instance when the attribute value in a saved feature has
+   been changed inside the edit buffer then the previous saved value may be returned as the maximum).
+
+.. note::
+
+   If both the minimum and maximum value are required it is more efficient to call :py:func:`~QgsVectorLayer.minimumAndMaximumValue`
+   instead of separate calls to :py:func:`~QgsVectorLayer.minimumValue` and :py:func:`~QgsVectorLayer.maximumValue`.
+
 
 .. seealso:: :py:func:`minimumValue`
 
+.. seealso:: :py:func:`minimumAndMaximumValue`
+
 .. seealso:: :py:func:`uniqueValues`
+%End
+
+
+    void minimumAndMaximumValue( int index, QVariant &minimum /Out/, QVariant &maximum /Out/ ) const;
+%Docstring
+Calculates both the minimum and maximum value for an attribute column.
+
+This is more efficient then calling both :py:func:`~QgsVectorLayer.minimumValue` and :py:func:`~QgsVectorLayer.maximumValue` when both the minimum
+and maximum values are required.
+
+:param index: index of field to calculate minimum and maximum value for.
+
+.. note::
+
+   In some circumstances when unsaved changes are present for the layer then the
+   calculated values may be outdated (for instance when the attribute value in a saved feature has
+   been changed inside the edit buffer then the previous saved value may be returned as the maximum).
+
+
+.. seealso:: :py:func:`minimumValue`
+
+.. seealso:: :py:func:`maximumValue`
+
+
+:return: - minimum: will be set to minimum attribute value or an invalid variant in case of error.
+         - maximum: will be set to maximum attribute value or an invalid variant in case of error.
+
+.. versionadded:: 3.20
 %End
 
     QVariant aggregate( QgsAggregateCalculator::Aggregate aggregate,

--- a/src/core/classification/qgsclassificationmethod.cpp
+++ b/src/core/classification/qgsclassificationmethod.cpp
@@ -234,8 +234,11 @@ QList<QgsClassificationRange> QgsClassificationMethod::classes( const QgsVectorL
   }
   else
   {
-    minimum = layer->minimumValue( fieldIndex ).toDouble();
-    maximum = layer->maximumValue( fieldIndex ).toDouble();
+    QVariant minVal;
+    QVariant maxVal;
+    layer->minimumAndMaximumValue( fieldIndex, minVal, maxVal );
+    minimum = minVal.toDouble();
+    maximum = maxVal.toDouble();
   }
 
   // get the breaks, minimum and maximum might be updated by implementation

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2898,8 +2898,9 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::prepareWriteAsVectorFormat
     {
       if ( details.outputFields.at( i ).type() == QVariant::LongLong )
       {
-        QVariant min = layer->minimumValue( i );
-        QVariant max = layer->maximumValue( i );
+        QVariant min;
+        QVariant max;
+        layer->minimumAndMaximumValue( i, min, max );
         if ( std::max( std::llabs( min.toLongLong() ), std::llabs( max.toLongLong() ) ) < std::numeric_limits<int>::max() )
         {
           details.outputFields[i].setType( QVariant::Int );

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -2868,9 +2868,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     QgsVectorLayer( const QgsVectorLayer &rhs );
 #endif
     //! Returns the minimum or maximum value
-    void minimumOrMaximumValue( int index, QVariant &minimum, QVariant &maximum, bool calculateMinimum, bool calculateMaximum ) const;
+    void minimumOrMaximumValue( int index, QVariant *minimum, QVariant *maximum ) const;
 
-  private:                       // Private attributes
     QgsConditionalLayerStyles *mConditionalStyles = nullptr;
 
     //! Pointer to data provider derived from the abastract base class QgsDataProvider

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -2234,23 +2234,57 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     /**
      * Returns the minimum value for an attribute column or an invalid variant in case of error.
-     * Note that in some circumstances when unsaved changes are present for the layer then the
+     *
+     * \note In some circumstances when unsaved changes are present for the layer then the
      * returned value may be outdated (for instance when the attribute value in a saved feature has
      * been changed inside the edit buffer then the previous saved value may be returned as the minimum).
+     *
+     * \note If both the minimum and maximum value are required it is more efficient to call minimumAndMaximumValue()
+     * instead of separate calls to minimumValue() and maximumValue().
+     *
      * \see maximumValue()
+     * \see minimumAndMaximumValue()
      * \see uniqueValues()
      */
     QVariant minimumValue( int index ) const FINAL;
 
     /**
      * Returns the maximum value for an attribute column or an invalid variant in case of error.
-     * Note that in some circumstances when unsaved changes are present for the layer then the
+     *
+     * \note In some circumstances when unsaved changes are present for the layer then the
      * returned value may be outdated (for instance when the attribute value in a saved feature has
      * been changed inside the edit buffer then the previous saved value may be returned as the maximum).
+     *
+     * \note If both the minimum and maximum value are required it is more efficient to call minimumAndMaximumValue()
+     * instead of separate calls to minimumValue() and maximumValue().
+     *
      * \see minimumValue()
+     * \see minimumAndMaximumValue()
      * \see uniqueValues()
      */
     QVariant maximumValue( int index ) const FINAL;
+
+
+    /**
+     * Calculates both the minimum and maximum value for an attribute column.
+     *
+     * This is more efficient then calling both minimumValue() and maximumValue() when both the minimum
+     * and maximum values are required.
+     *
+     * \param index index of field to calculate minimum and maximum value for.
+     * \param minimum will be set to minimum attribute value or an invalid variant in case of error.
+     * \param maximum will be set to maximum attribute value or an invalid variant in case of error.
+     *
+     * \note In some circumstances when unsaved changes are present for the layer then the
+     * calculated values may be outdated (for instance when the attribute value in a saved feature has
+     * been changed inside the edit buffer then the previous saved value may be returned as the maximum).
+     *
+     * \see minimumValue()
+     * \see maximumValue()
+     *
+     * \since QGIS 3.20
+     */
+    void minimumAndMaximumValue( int index, QVariant &minimum SIP_OUT, QVariant &maximum SIP_OUT ) const;
 
     /**
      * Calculates an aggregated value from the layer's features.
@@ -2834,7 +2868,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     QgsVectorLayer( const QgsVectorLayer &rhs );
 #endif
     //! Returns the minimum or maximum value
-    QVariant minimumOrMaximumValue( int index, bool minimum ) const;
+    void minimumOrMaximumValue( int index, QVariant &minimum, QVariant &maximum, bool calculateMinimum, bool calculateMaximum ) const;
 
   private:                       // Private attributes
     QgsConditionalLayerStyles *mConditionalStyles = nullptr;

--- a/src/core/vector/qgsvectorlayertemporalproperties.cpp
+++ b/src/core/vector/qgsvectorlayertemporalproperties.cpp
@@ -63,8 +63,12 @@ QgsDateTimeRange QgsVectorLayerTemporalProperties::calculateTemporalExtent( QgsM
       const int fieldIndex = vectorLayer->fields().lookupField( mStartFieldName );
       if ( fieldIndex >= 0 )
       {
-        const QDateTime min = vectorLayer->minimumValue( fieldIndex ).toDateTime();
-        const QDateTime maxStartTime = vectorLayer->maximumValue( fieldIndex ).toDateTime();
+        QVariant minVal;
+        QVariant maxVal;
+        vectorLayer->minimumAndMaximumValue( fieldIndex, minVal, maxVal );
+
+        const QDateTime min = minVal.toDateTime();
+        const QDateTime maxStartTime = maxVal.toDateTime();
         const QgsInterval eventDuration = QgsInterval( mFixedDuration, mDurationUnit );
         return QgsDateTimeRange( min, maxStartTime + eventDuration );
       }
@@ -109,20 +113,33 @@ QgsDateTimeRange QgsVectorLayerTemporalProperties::calculateTemporalExtent( QgsM
       const int endFieldIndex = vectorLayer->fields().lookupField( mEndFieldName );
       if ( startFieldIndex >= 0 && endFieldIndex >= 0 )
       {
-        return QgsDateTimeRange( std::min( vectorLayer->minimumValue( startFieldIndex ).toDateTime(),
-                                           vectorLayer->minimumValue( endFieldIndex ).toDateTime() ),
-                                 std::max( vectorLayer->maximumValue( startFieldIndex ).toDateTime(),
-                                           vectorLayer->maximumValue( endFieldIndex ).toDateTime() ) );
+        QVariant startMinVal;
+        QVariant startMaxVal;
+        vectorLayer->minimumAndMaximumValue( startFieldIndex, startMinVal, startMaxVal );
+        QVariant endMinVal;
+        QVariant endMaxVal;
+        vectorLayer->minimumAndMaximumValue( endFieldIndex, endMinVal, endMaxVal );
+
+        return QgsDateTimeRange( std::min( startMinVal.toDateTime(),
+                                           endMinVal.toDateTime() ),
+                                 std::max( startMaxVal.toDateTime(),
+                                           endMaxVal.toDateTime() ) );
       }
       else if ( startFieldIndex >= 0 )
       {
-        return QgsDateTimeRange( vectorLayer->minimumValue( startFieldIndex ).toDateTime(),
-                                 vectorLayer->maximumValue( startFieldIndex ).toDateTime() );
+        QVariant startMinVal;
+        QVariant startMaxVal;
+        vectorLayer->minimumAndMaximumValue( startFieldIndex, startMinVal, startMaxVal );
+        return QgsDateTimeRange( startMinVal.toDateTime(),
+                                 startMaxVal.toDateTime() );
       }
       else if ( endFieldIndex >= 0 )
       {
-        return QgsDateTimeRange( vectorLayer->minimumValue( endFieldIndex ).toDateTime(),
-                                 vectorLayer->maximumValue( endFieldIndex ).toDateTime() );
+        QVariant endMinVal;
+        QVariant endMaxVal;
+        vectorLayer->minimumAndMaximumValue( endFieldIndex, endMinVal, endMaxVal );
+        return QgsDateTimeRange( endMinVal.toDateTime(),
+                                 endMaxVal.toDateTime() );
       }
       break;
     }

--- a/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
@@ -66,8 +66,9 @@ QgsRangeConfigDlg::QgsRangeConfigDlg( QgsVectorLayer *vl, int fieldIdx, QWidget 
       rangeWidget->addItem( tr( "Slider" ), QStringLiteral( "Slider" ) );
       rangeWidget->addItem( tr( "Dial" ), QStringLiteral( "Dial" ) );
 
-      QVariant min = vl->minimumValue( fieldIdx );
-      QVariant max = vl->maximumValue( fieldIdx );
+      QVariant min;
+      QVariant max;
+      vl->minimumAndMaximumValue( fieldIdx, min, max );
 
       text = tr( "Current minimum for this value is %1 and current maximum is %2." ).arg( min.toString(), max.toString() );
       break;

--- a/src/gui/qgspropertyassistantwidget.cpp
+++ b/src/gui/qgspropertyassistantwidget.cpp
@@ -309,12 +309,16 @@ bool QgsPropertyAssistantWidget::computeValuesFromField( const QString &fieldNam
     return false;
   }
 
+  QVariant min;
+  QVariant max;
+  mLayer->minimumAndMaximumValue( fieldIndex, min, max );
+
   bool ok = false;
-  double minDouble = mLayer->minimumValue( fieldIndex ).toDouble( &ok );
+  double minDouble = min.toDouble( &ok );
   if ( !ok )
     return false;
 
-  double maxDouble = mLayer->maximumValue( fieldIndex ).toDouble( &ok );
+  double maxDouble = max.toDouble( &ok );
   if ( !ok )
     return false;
 

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -992,8 +992,13 @@ void QgsGraduatedSymbolRendererWidget::classifyGraduated()
   Q_ASSERT( method );
 
   int attrNum = mLayer->fields().lookupField( attrName );
-  double minimum = mLayer->minimumValue( attrNum ).toDouble();
-  double maximum = mLayer->maximumValue( attrNum ).toDouble();
+
+  QVariant minVal;
+  QVariant maxVal;
+  mLayer->minimumAndMaximumValue( attrNum, minVal, maxVal );
+
+  double minimum = minVal.toDouble();
+  double maximum = maxVal.toDouble();
   mSymmetryPointValidator->setBottom( minimum );
   mSymmetryPointValidator->setTop( maximum );
   mSymmetryPointValidator->setDecimals( spinPrecision->value() );

--- a/src/server/qgsserverapiutils.cpp
+++ b/src/server/qgsserverapiutils.cpp
@@ -463,22 +463,31 @@ json QgsServerApiUtils::temporalExtent( const QgsVectorLayer *layer )
     {
       return result;
     }
-    QDateTime min { layer->minimumValue( fieldIdx ).toDateTime() };
-    QDateTime max { layer->maximumValue( fieldIdx ).toDateTime() };
+
+    QVariant minVal;
+    QVariant maxVal;
+    layer->minimumAndMaximumValue( fieldIdx, minVal, maxVal );
+
+    QDateTime min { minVal.toDateTime() };
+    QDateTime max { maxVal.toDateTime() };
     if ( ! dimInfo.endFieldName.isEmpty() )
     {
       fieldIdx = layer->fields().lookupField( dimInfo.endFieldName );
       if ( fieldIdx >= 0 )
       {
-        QDateTime minEnd { layer->minimumValue( fieldIdx ).toDateTime() };
-        QDateTime maxEnd { layer->maximumValue( fieldIdx ).toDateTime() };
+        QVariant minVal;
+        QVariant maxVal;
+        layer->minimumAndMaximumValue( fieldIdx, minVal, maxVal );
+
+        QDateTime minEnd { minVal.toDateTime() };
+        QDateTime maxEnd { maxVal.toDateTime() };
         if ( minEnd.isValid() )
         {
-          min = std::min<QDateTime>( min, layer->minimumValue( fieldIdx ).toDateTime() );
+          min = std::min<QDateTime>( min, minEnd );
         }
         if ( maxEnd.isValid() )
         {
-          max = std::max<QDateTime>( max, layer->maximumValue( fieldIdx ).toDateTime() );
+          max = std::max<QDateTime>( max, maxEnd );
         }
       }
     }

--- a/tests/src/core/testqgsvectorlayer.cpp
+++ b/tests/src/core/testqgsvectorlayer.cpp
@@ -74,6 +74,7 @@ class TestQgsVectorLayer : public QObject
     void uniqueValues();
     void minimumValue();
     void maximumValue();
+    void minimumAndMaximumValue();
     void isSpatial();
     void testAddTopologicalPoints();
     void testCopyPasteFieldConfiguration();
@@ -305,6 +306,16 @@ void TestQgsVectorLayer::maximumValue()
 {
   //test with invalid field
   QCOMPARE( mpPointsLayer->maximumValue( 1000 ), QVariant() );
+}
+
+void TestQgsVectorLayer::minimumAndMaximumValue()
+{
+  //test with invalid field
+  QVariant min;
+  QVariant max;
+  mpPointsLayer->minimumAndMaximumValue( 1000, min, max );
+  QCOMPARE( min, QVariant() );
+  QCOMPARE( max, QVariant() );
 }
 
 void TestQgsVectorLayer::isSpatial()


### PR DESCRIPTION
Instead of double-iterating over features caused by calling QgsVectorLayer::minimumValue and then QgsVectorLayer::maximumValue when we need BOTH the min and max value for a field, add an
optimised QgsVectorLayer::minimumAndMaximumValue() method which can calculate both min and max at the same time in
a single iteration.

Potentially halves the cost of calculating these values whenever we are forced to do a full iteration to calculate them.
