### PR TITLE
Don't always try to calculate temporal extents for all layer types

### DIFF
--- a/src/core/qgsmaplayertemporalproperties.cpp
+++ b/src/core/qgsmaplayertemporalproperties.cpp
@@ -32,7 +32,7 @@ QgsDateTimeRange QgsMapLayerTemporalProperties::calculateTemporalExtent( QgsMapL
   return QgsDateTimeRange();
 }
 
-QList<QgsDateTimeRange> QgsMapLayerTemporalProperties::allTemporalRanges( QgsMapLayer *layer ) const
+QList<QgsDateTimeRange> QgsMapLayerTemporalProperties::allTemporalRanges( QgsMapLayer * ) const
 {
-  return { calculateTemporalExtent( layer ) };
+  return {};
 }


### PR DESCRIPTION
… it's too expensive, and causes a long delay in loading projects with temporal vector layers