### PR TITLE
CMake build fix for qt plugins.

### DIFF
--- a/external/qspatialite/CMakeLists.txt
+++ b/external/qspatialite/CMakeLists.txt
@@ -3,7 +3,6 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${QGIS_OUTPUT_DIRECTORY}/${QGIS_PLUGIN_SUBDIR
 
 add_definitions(${QT_DEFINITIONS})
 add_definitions(-DQT_PLUGIN)
-add_definitions(-DQT_NO_DEBUG)
 add_definitions(-DQT_SHARED)
 
 include_directories(SYSTEM

--- a/src/customwidgets/CMakeLists.txt
+++ b/src/customwidgets/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_definitions(-DQT_PLUGIN)
-add_definitions(-DQT_NO_DEBUG)
 add_definitions(-DQT_SHARED)
 
 find_package(Qt5UiPlugin REQUIRED)

--- a/src/providers/oracle/ocispatial/CMakeLists.txt
+++ b/src/providers/oracle/ocispatial/CMakeLists.txt
@@ -6,7 +6,6 @@ find_package(OCI REQUIRED)
 
 add_definitions(${QT_DEFINITIONS})
 add_definitions(-DQT_PLUGIN)
-add_definitions(-DQT_NO_DEBUG)
 add_definitions(-DQT_SHARED)
 
 include_directories(SYSTEM


### PR DESCRIPTION
After building the Qt plugin ocispatial I noticed that the plugin cannot be loaded in the debug build with Qt. This is due to the compile flag "QT_NO_DEBUG", which does not have to be set manually. The Qt CMake Module sets this flag automatically for release builds.

The configuration in the CMake module can be found in the file Qt5CoreConfigExtras.cmake or for Qt6 in Qt6CoreConfigExtras.cmake.

`set_property(TARGET Qt5::Core APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS $<$<NOT:$<CONFIG:Debug>>:QT_NO_DEBUG>)`