### PR TITLE
fix mesh 3D level of detail slide bar

### DIFF
--- a/src/app/3d/qgsmesh3dsymbolwidget.cpp
+++ b/src/app/3d/qgsmesh3dsymbolwidget.cpp
@@ -81,7 +81,7 @@ void QgsMesh3dSymbolWidget::setSymbol( const QgsMesh3DSymbol *symbol )
   mGroupBoxWireframe->setChecked( symbol->wireframeEnabled() );
   mColorButtonWireframe->setColor( symbol->wireframeLineColor() );
   mSpinBoxWireframeLineWidth->setValue( symbol->wireframeLineWidth() );
-  if ( mLayer )
+  if ( mLayer && mLayer->meshSimplificationSettings().isEnabled() )
     mLodSlider->setValue( mLayer->triangularMeshLevelOfDetailCount() - symbol->levelOfDetailIndex() - 1 );
   else
     mLodSlider->setValue( mLodSlider->maximum() );
@@ -128,16 +128,15 @@ void QgsMesh3dSymbolWidget::setLayer( QgsMeshLayer *meshLayer, bool updateSymbol
 
   if ( meshLayer && meshLayer->meshSimplificationSettings().isEnabled() )
   {
-    mLodSlider->setVisible( true );
-    mLabelLod->setVisible( true );
+    mLodSlider->setEnabled( true );
     int lodCount = meshLayer->triangularMeshLevelOfDetailCount();
     mLodSlider->setTickInterval( 1 );
     mLodSlider->setMaximum( lodCount - 1 );
   }
   else
   {
-    mLodSlider->setVisible( false );
-    mLabelLod->setVisible( false );
+    mLodSlider->setValue( mLodSlider->maximum() );
+    mLodSlider->setEnabled( false );
   }
 
   if ( !updateSymbol )

--- a/src/ui/3d/qgsmesh3dpropswidget.ui
+++ b/src/ui/3d/qgsmesh3dpropswidget.ui
@@ -103,6 +103,12 @@
       </item>
       <item row="2" column="1" colspan="2">
        <widget class="QSlider" name="mLodSlider">
+        <property name="toolTip">
+         <string>Need mesh simplification</string>
+        </property>
+        <property name="value">
+         <number>99</number>
+        </property>
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
@@ -407,6 +413,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsColorRampShaderWidget</class>
+   <extends>QWidget</extends>
+   <header>raster/qgscolorrampshaderwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
@@ -421,12 +433,6 @@
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorRampShaderWidget</class>
-   <extends>QWidget</extends>
-   <header>raster/qgscolorrampshaderwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/3d/qgsmesh3dpropswidget.ui
+++ b/src/ui/3d/qgsmesh3dpropswidget.ui
@@ -104,7 +104,7 @@
       <item row="2" column="1" colspan="2">
        <widget class="QSlider" name="mLodSlider">
         <property name="toolTip">
-         <string>Need mesh simplification</string>
+         <string>Level of detail can only be set set when mesh simplification is enabled (see Rendering tab in the Mesh Layer Properties)</string>
         </property>
         <property name="value">
          <number>99</number>


### PR DESCRIPTION
For mesh in 3D view, the level of detail can only be set if the mesh simplification is activated.
The associated slider hide when simplification is disable did not work well (it was in a collapsible group, not sure why...). 
The workaround is to disable/enable the slider instead of visible/hide it.
I see 2 PROS:
- allows to fix the issue
- allows the user to know the mesh simplification and several LOD are possible (a tool tip appears with "Need mesh simplification").


