### PR TITLE
Fix fid collisions when pasting features into a gpkg/spatialite dataset

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10449,7 +10449,7 @@ void QgisApp::pasteFromClipboard( QgsMapLayer *destinationLayer )
   int nTotalFeatures = features.count();
   QgsExpressionContext context = pasteVectorLayer->createExpressionContext();
 
-  QgsFeatureList compatibleFeatures( QgsVectorLayerUtils::makeFeaturesCompatible( features, pasteVectorLayer ) );
+  QgsFeatureList compatibleFeatures( QgsVectorLayerUtils::makeFeaturesCompatible( features, pasteVectorLayer, QgsFeatureSink::RegeneratePrimaryKey ) );
   QgsVectorLayerUtils::QgsFeaturesDataList newFeaturesDataList;
   newFeaturesDataList.reserve( compatibleFeatures.size() );
 


### PR DESCRIPTION
## Description

Scenario: you have a dozen geopackage datasets and want to select a few features in each to paste into a newly created geopackage dataset. You'll most likely (and very quickly) run into fid collisions. What more, the pasting itself will be fine, you'll just end up with a bunch of intimidating error messages when hitting the save action or trying - and failing - to disable edit mode.

I ran into this issue myself yesterday, and I must say it made QGIS look rather bad :-/ 

The solution is to regenerate the primary (auto-generated, unique) key when pasting into a layer that has such a field.

@nyalldawson , as discussed.