### PR TITLE
[qt6] Qt6 uses utf-8 by default

### DIFF
--- a/python/core/auto_generated/network/qgsnetworkcontentfetcher.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkcontentfetcher.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 class QgsNetworkContentFetcher : QObject
 {
 %Docstring(signature="appended")

--- a/src/core/annotations/qgshtmlannotation.cpp
+++ b/src/core/annotations/qgshtmlannotation.cpp
@@ -67,7 +67,9 @@ void QgsHtmlAnnotation::setSourceFile( const QString &htmlFile )
   else
   {
     QTextStream in( &file );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     in.setCodec( "UTF-8" );
+#endif
     mHtmlSource = in.readAll();
   }
 

--- a/src/core/network/qgsnetworkcontentfetcher.h
+++ b/src/core/network/qgsnetworkcontentfetcher.h
@@ -25,6 +25,8 @@
 
 #include "qgis_core.h"
 
+class QTextCodec;
+
 /**
  * \class QgsNetworkContentFetcher
  * \ingroup core

--- a/src/core/qgsabstractgeopdfexporter.cpp
+++ b/src/core/qgsabstractgeopdfexporter.cpp
@@ -98,7 +98,9 @@ bool QgsAbstractGeoPdfExporter::finalize( const QList<ComponentLayerDetail> &com
   if ( file.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) )
   {
     QTextStream out( &file );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     out.setCodec( "UTF-8" );
+#endif
     out << composition;
   }
   else

--- a/src/core/qgsbookmarkmanager.cpp
+++ b/src/core/qgsbookmarkmanager.cpp
@@ -411,7 +411,9 @@ bool QgsBookmarkManager::exportToFile( const QString &path, const QList<const Qg
   }
 
   QTextStream out( &f );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   out.setCodec( "UTF-8" );
+#endif
   doc.save( out, 2 );
   f.close();
 
@@ -486,7 +488,9 @@ void QgsBookmarkManager::store()
     doc.appendChild( elem );
 
     QTextStream out( &f );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     out.setCodec( "UTF-8" );
+#endif
     doc.save( out, 2 );
     f.close();
   }

--- a/src/core/qgscredentials.cpp
+++ b/src/core/qgscredentials.cpp
@@ -17,6 +17,7 @@
 #include "qgslogger.h"
 
 #include <QTextStream>
+#include <QIODevice>
 
 QgsCredentials *QgsCredentials::sInstance = nullptr;
 

--- a/src/core/qgsogrutils.h
+++ b/src/core/qgsogrutils.h
@@ -28,6 +28,8 @@
 #include "cpl_string.h"
 #include "qgssymbol.h"
 
+class QTextCodec;
+
 namespace gdal
 {
 

--- a/src/core/qgssettings.cpp
+++ b/src/core/qgssettings.cpp
@@ -40,7 +40,9 @@ void QgsSettings::init()
   if ( ! sGlobalSettingsPath()->isEmpty() )
   {
     mGlobalSettings = new QSettings( *sGlobalSettingsPath(), QSettings::IniFormat );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     mGlobalSettings->setIniCodec( "UTF-8" );
+#endif
   }
 }
 


### PR DESCRIPTION
setCodec is gone
Qt6 is all on for utf-8 for QTextStream and QSettings
