### PR TITLE
[qt6] Restore old Q_DECL_DEPRECATED method that also works for types

### DIFF
--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -312,6 +312,8 @@ QString geoEpsgCrsAuthId();
 //! Constant that holds the string representation for "No ellips/No CRS"
 QString geoNone();
 
+
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -22,6 +22,7 @@
 #include <cfloat>
 #include <memory>
 #include <cmath>
+#include <qcompilerdetection.h>
 
 #include "qgstolerance.h"
 #include "qgis_core.h"
@@ -840,3 +841,9 @@ QString CORE_EXPORT geoEpsgCrsAuthId();
 QString CORE_EXPORT geoNone();
 
 #endif
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#  undef Q_DECL_DEPRECATED
+#  define Q_DECL_DEPRECATED __attribute__ ((__deprecated__))
+#endif
+


### PR DESCRIPTION
```
../src/core/symbology/qgsgraduatedsymbolrenderer.h:274:12: error: 'deprecated' attribute cannot be applied to types
    static Q_DECL_DEPRECATED QgsGraduatedSymbolRenderer *createRenderer( QgsVectorLayer *vlayer,
           ^
/usr/include/qt6/QtCore/qcompilerdetection.h:1152:31: note: expanded from macro 'Q_DECL_DEPRECATED'
```

Qt6 uses the `[[deprecated]]` attribute that is not compatible with types, restore the old one in qgis.h