### PR TITLE
[qt6] QRegExp is gone

### DIFF
--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -378,9 +378,13 @@ colors are specified then the ``size`` argument also must be set.
 Returns the path to user's style.
 %End
 
+
     static QRegExp shortNameRegExp();
 %Docstring
 Returns the short name regular expression for line edit validator
+
+.. deprecated:: QGIS 3.20
+   for incompatibility with Qt6, use shortNameRegularExpression instead
 %End
 
     static QString userLoginName();

--- a/src/core/project/qgsprojectservervalidator.cpp
+++ b/src/core/project/qgsprojectservervalidator.cpp
@@ -20,6 +20,7 @@
 #include "qgslayertreelayer.h"
 #include "qgsprojectservervalidator.h"
 #include "qgsvectorlayer.h"
+#include <QRegularExpression>
 
 
 QString QgsProjectServerValidator::displayValidationError( QgsProjectServerValidator::ValidationError error )
@@ -94,11 +95,10 @@ bool QgsProjectServerValidator::validate( QgsProject *project, QList<QgsProjectS
   browseLayerTree( project->layerTreeRoot(), owsNames, encodingMessages );
 
   QStringList duplicateNames, regExpMessages;
-  QRegExp snRegExp = QgsApplication::shortNameRegExp();
-  const auto constOwsNames = owsNames;
-  for ( const QString &name : constOwsNames )
+  QRegularExpression snRegExp( QRegularExpression::anchoredPattern( QgsApplication::shortNameRegularExpression().pattern() ) );
+  for ( const QString &name : std::as_const( owsNames ) )
   {
-    if ( !snRegExp.exactMatch( name ) )
+    if ( !snRegExp.match( name ).hasMatch() )
     {
       regExpMessages << name;
     }
@@ -146,7 +146,7 @@ bool QgsProjectServerValidator::validate( QgsProject *project, QList<QgsProjectS
       results << ValidationResult( QgsProjectServerValidator::ProjectRootNameConflict, rootLayerName );
     }
 
-    if ( !snRegExp.exactMatch( rootLayerName ) )
+    if ( !snRegExp.match( rootLayerName ).hasMatch() )
     {
       result = false;
       results << ValidationResult( QgsProjectServerValidator::ProjectShortName, rootLayerName );

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1118,11 +1118,13 @@ QString QgsApplication::userStylePath()
   return qgisSettingsDirPath() + QStringLiteral( "symbology-style.db" );
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 QRegExp QgsApplication::shortNameRegExp()
 {
   const thread_local QRegExp regexp( QStringLiteral( "^[A-Za-z][A-Za-z0-9\\._-]*" ) );
   return regexp;
 }
+#endif
 
 QString QgsApplication::userLoginName()
 {

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -400,8 +400,15 @@ class CORE_EXPORT QgsApplication : public QApplication
     //! Returns the path to user's style.
     static QString userStylePath();
 
-    //! Returns the short name regular expression for line edit validator
-    static QRegExp shortNameRegExp();
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+
+    /**
+     * Returns the short name regular expression for line edit validator
+     *
+     * \deprecated since QGIS 3.20 for incompatibility with Qt6, use shortNameRegularExpression instead
+     */
+    static Q_DECL_DEPRECATED QRegExp shortNameRegExp();
+#endif
 
     /**
      * Returns the user's operating system login account name.


### PR DESCRIPTION
For good

All we can do is remove this deprecated method with Qt6.