### PR TITLE
Add a public method to clear the rubber band for the QgsMapToolExtent

### DIFF
--- a/python/gui/auto_generated/qgsmaptoolextent.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolextent.sip.in
@@ -59,6 +59,13 @@ If the aspect ratio isn't fixed, the width and height will be set to zero.
 Returns the current extent drawn onto the canvas.
 %End
 
+    void clearRubberBand();
+%Docstring
+Removes the tool's rubber band from the canvas.
+
+.. versionadded:: 3.20
+%End
+
   signals:
 
     void extentChanged( const QgsRectangle &extent );

--- a/src/gui/qgsmaptoolextent.cpp
+++ b/src/gui/qgsmaptoolextent.cpp
@@ -34,8 +34,7 @@ void QgsMapToolExtent::activate()
 
 void QgsMapToolExtent::deactivate()
 {
-  mRubberBand->reset( QgsWkbTypes::PolygonGeometry );
-
+  clearRubberBand();
   QgsMapTool::deactivate();
 }
 
@@ -95,6 +94,11 @@ QgsRectangle QgsMapToolExtent::extent() const
   }
 }
 
+void QgsMapToolExtent::clearRubberBand()
+{
+  mRubberBand->reset( QgsWkbTypes::PolygonGeometry );
+}
+
 void QgsMapToolExtent::calculateEndPoint( QgsPointXY &point )
 {
   if ( mRatio.width() > 0 && mRatio.height() > 0 )
@@ -111,8 +115,6 @@ void QgsMapToolExtent::drawExtent()
 {
   if ( qgsDoubleNear( mStartPoint.x(), mEndPoint.x() ) && qgsDoubleNear( mStartPoint.y(), mEndPoint.y() ) )
     return;
-
-  mRubberBand->reset( QgsWkbTypes::PolygonGeometry );
 
   QgsRectangle rect( mStartPoint, mEndPoint );
 

--- a/src/gui/qgsmaptoolextent.h
+++ b/src/gui/qgsmaptoolextent.h
@@ -64,6 +64,13 @@ class GUI_EXPORT QgsMapToolExtent : public QgsMapTool
      */
     QgsRectangle extent() const;
 
+    /**
+     * Removes the tool's rubber band from the canvas.
+     *
+     * \since QGIS 3.20
+     */
+    void clearRubberBand();
+
   signals:
 
     //! signal emitted on extent change


### PR DESCRIPTION
Otherwise plugins have no way to remove this from the canvas
