### PR TITLE
 Add QgsVectorFileWriter::writeAsVectorFormatV3 

### DIFF
--- a/python/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -455,13 +455,13 @@ Create a new vector file writer.
 .. versionadded:: 3.10.3
 %End
 
-    static QgsVectorFileWriter::WriterError writeAsVectorFormatV2( QgsVectorLayer *layer,
+ static QgsVectorFileWriter::WriterError writeAsVectorFormatV2( QgsVectorLayer *layer,
         const QString &fileName,
         const QgsCoordinateTransformContext &transformContext,
         const QgsVectorFileWriter::SaveVectorOptions &options,
         QString *newFilename = 0,
         QString *newLayer = 0,
-        QString *errorMessage /Out/ = 0 );
+        QString *errorMessage /Out/ = 0 ) /Deprecated/;
 %Docstring
 Writes a layer out to a vector file.
 

--- a/python/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -475,7 +475,31 @@ Writes a layer out to a vector file.
 :return: - Error message code, or QgsVectorFileWriter.NoError if the write operation was successful
          - errorMessage: will be set to the error message text, if an error occurs while writing the layer
 
-.. versionadded:: 3.10.3
+.. deprecated:: QGIS 3.20
+  use writeAsVectorFormatV3 instead
+%End
+
+    static QgsVectorFileWriter::WriterError writeAsVectorFormatV3( QgsVectorLayer *layer,
+        const QString &fileName,
+        const QgsCoordinateTransformContext &transformContext,
+        const QgsVectorFileWriter::SaveVectorOptions &options,
+        QString *errorMessage /Out/ = 0,
+        QString *newFilename /Out/ = 0,
+        QString *newLayer /Out/ = 0 );
+%Docstring
+Writes a layer out to a vector file.
+
+:param layer: source layer to write
+:param fileName: file name to write to
+:param transformContext: coordinate transform context
+:param options: save options
+:param newFilename: potentially modified file name (output parameter)
+:param errorMessage: will be set to the error message text, if an error occurs while writing the layer
+
+:return: - Error message code, or QgsVectorFileWriter.NoError if the write operation was successful
+         - newLayer: potentially modified layer name (output parameter)
+
+.. versionadded:: 3.20
 %End
 
     struct FilterFormatDetails

--- a/src/analysis/processing/qgsalgorithmexporttospreadsheet.cpp
+++ b/src/analysis/processing/qgsalgorithmexporttospreadsheet.cpp
@@ -261,7 +261,7 @@ bool QgsExportToSpreadsheetAlgorithm::exportVectorLayer( QgsVectorLayer *layer, 
   QString error;
   QString newFilename;
   QString newLayer;
-  if ( QgsVectorFileWriter::writeAsVectorFormatV2( layer, path, context.transformContext(), options, &newFilename, &newLayer, &error ) != QgsVectorFileWriter::NoError )
+  if ( QgsVectorFileWriter::writeAsVectorFormatV3( layer, path, context.transformContext(), options, &error, &newFilename, &newLayer ) != QgsVectorFileWriter::NoError )
   {
     feedback->reportError( QObject::tr( "Exporting layer failed: %1" ).arg( error ) );
     return false;

--- a/src/analysis/processing/qgsalgorithmpackage.cpp
+++ b/src/analysis/processing/qgsalgorithmpackage.cpp
@@ -240,7 +240,7 @@ bool QgsPackageAlgorithm::packageVectorLayer( QgsVectorLayer *layer, const QStri
   QString error;
   QString newFilename;
   QString newLayer;
-  if ( QgsVectorFileWriter::writeAsVectorFormatV2( layer, path, context.transformContext(), options, &newFilename, &newLayer, &error ) != QgsVectorFileWriter::NoError )
+  if ( QgsVectorFileWriter::writeAsVectorFormatV3( layer, path, context.transformContext(), options, &error, &newFilename, &newLayer ) != QgsVectorFileWriter::NoError )
   {
     feedback->reportError( QObject::tr( "Packaging layer failed: %1" ).arg( error ) );
     return false;

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -67,7 +67,7 @@ static OGRDataSourceH myOGROpen( const char *pszName, int bUpdate, OGRSFDriverH 
   if ( hDS && bUpdate )
   {
     QString drvName = OGR_Dr_GetName( hDriver );
-    if ( drvName == "BNA" )
+    if ( drvName == QLatin1String( "BNA" ) )
     {
       OGR_DS_Destroy( hDS );
       if ( phDriver )
@@ -108,7 +108,7 @@ QgsVectorFileWriter::QgsVectorFileWriter(
   SymbologyExport symbologyExport,
   QgsFeatureSink::SinkFlags sinkFlags,
   QString *newLayer,
-  QgsCoordinateTransformContext transformContext,
+  const QgsCoordinateTransformContext &transformContext,
   FieldNameSource fieldNameSource
 )
   : mError( NoError )
@@ -136,7 +136,7 @@ QgsVectorFileWriter::QgsVectorFileWriter(
   const QString &layerName,
   ActionOnExistingFile action,
   QString *newLayer,
-  QgsCoordinateTransformContext transformContext,
+  const QgsCoordinateTransformContext &transformContext,
   QgsFeatureSink::SinkFlags sinkFlags,
   FieldNameSource fieldNameSource
 )
@@ -2112,7 +2112,7 @@ class QgsVectorFileWriterMetadataContainer
                                QStringList()
                                << QStringLiteral( "CRLF" )
                                << QStringLiteral( "LF" ),
-                               QString( "LF" ), // Default value
+                               QStringLiteral( "LF" ), // Default value
                                false // Allow None
                              ) );
 
@@ -2174,7 +2174,7 @@ class QgsVectorFileWriterMetadataContainer
       layerOptions.insert( QStringLiteral( "POSTGIS_VERSION" ), new QgsVectorFileWriter::StringOption(
                              QObject::tr( "Can be set to 2.0 or 2.2 for PostGIS 2.0/2.2 compatibility. "
                                           "Important to set it correctly if using non-linear geometry types" ),
-                             QString( "2.2" ) // Default value
+                             QStringLiteral( "2.2" ) // Default value
                            ) );
 
       driverMetadata.insert( QStringLiteral( "PGDUMP" ),
@@ -2502,7 +2502,7 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
             if ( count > 0 )
             {
               int pos = 0;
-              for ( QString string : list )
+              for ( const QString &string : list )
               {
                 lst[pos] = mCodec->fromUnicode( string ).data();
                 pos++;
@@ -2962,7 +2962,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormatV2( Pre
   // Special rules for OGR layers
   if ( details.providerType == QLatin1String( "ogr" ) && !details.dataSourceUri.isEmpty() )
   {
-    QString srcFileName( details.providerUriParams.value( QLatin1String( "path" ) ).toString() );
+    QString srcFileName( details.providerUriParams.value( QStringLiteral( "path" ) ).toString() );
     if ( QFile::exists( srcFileName ) && QFileInfo( fileName ).canonicalFilePath() == QFileInfo( srcFileName ).canonicalFilePath() )
     {
       // Check the layer name too if it's a GPKG/SpatiaLite/SQLite OGR driver (pay attention: camel case in layerName)
@@ -2970,7 +2970,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormatV2( Pre
       if ( !( ( options.driverName == QLatin1String( "GPKG" ) ||
                 options.driverName == QLatin1String( "SpatiaLite" ) ||
                 options.driverName == QLatin1String( "SQLite" ) ) &&
-              options.layerName != details.providerUriParams.value( QLatin1String( "layerName" ) ) ) )
+              options.layerName != details.providerUriParams.value( QStringLiteral( "layerName" ) ) ) )
       {
         if ( errorMessage )
           *errorMessage = QObject::tr( "Cannot overwrite a OGR layer in place" );
@@ -3204,10 +3204,9 @@ bool QgsVectorFileWriter::deleteShapeFile( const QString &fileName )
   QDir dir = fi.dir();
 
   QStringList filter;
-  const char *suffixes[] = { ".shp", ".shx", ".dbf", ".prj", ".qix", ".qpj", ".cpg", ".sbn", ".sbx", ".idm", ".ind" };
-  for ( std::size_t i = 0; i < sizeof( suffixes ) / sizeof( *suffixes ); i++ )
+  for ( const char *suffix : { ".shp", ".shx", ".dbf", ".prj", ".qix", ".qpj", ".cpg", ".sbn", ".sbx", ".idm", ".ind" } )
   {
-    filter << fi.completeBaseName() + suffixes[i];
+    filter << fi.completeBaseName() + suffix;
   }
 
   bool ok = true;

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2755,7 +2755,7 @@ QgsVectorFileWriter::writeAsVectorFormat( QgsVectorLayer *layer,
   options.includeZ = includeZ;
   options.attributes = attributes;
   options.fieldValueConverter = fieldValueConverter;
-  return writeAsVectorFormatV2( layer, fileName, layer->transformContext(), options, newFilename, newLayer, errorMessage );
+  return writeAsVectorFormatV3( layer, fileName, layer->transformContext(), options, errorMessage, newFilename, newLayer );
 }
 
 QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVectorLayer *layer,
@@ -2796,7 +2796,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVe
   options.includeZ = includeZ;
   options.attributes = attributes;
   options.fieldValueConverter = fieldValueConverter;
-  return writeAsVectorFormatV2( layer, fileName, layer->transformContext(), options, newFilename, newLayer, errorMessage );
+  return writeAsVectorFormatV3( layer, fileName, layer->transformContext(), options, errorMessage, newFilename, newLayer );
 }
 
 
@@ -3179,6 +3179,16 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormatV2( Qgs
     QString *newFilename,
     QString *newLayer,
     QString *errorMessage )
+{
+  QgsVectorFileWriter::PreparedWriterDetails details;
+  WriterError err = prepareWriteAsVectorFormat( layer, options, details );
+  if ( err != NoError )
+    return err;
+
+  return writeAsVectorFormatV2( details, fileName, transformContext, options, errorMessage, newFilename, newLayer );
+}
+
+QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormatV3( QgsVectorLayer *layer, const QString &fileName, const QgsCoordinateTransformContext &transformContext, const QgsVectorFileWriter::SaveVectorOptions &options, QString *errorMessage, QString *newFilename, QString *newLayer )
 {
   QgsVectorFileWriter::PreparedWriterDetails details;
   WriterError err = prepareWriteAsVectorFormat( layer, options, details );

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -587,7 +587,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
                                            QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags()
 #ifndef SIP_RUN
                                                , QString *newLayer = nullptr,
-                                           QgsCoordinateTransformContext transformContext = QgsCoordinateTransformContext(),
+                                           const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext(),
                                            FieldNameSource fieldNameSource = Original
 #endif
                                          ) SIP_DEPRECATED;
@@ -628,7 +628,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
                                            const QString &layerName,
                                            QgsVectorFileWriter::ActionOnExistingFile action,
                                            QString *newLayer = nullptr,
-                                           QgsCoordinateTransformContext transformContext = QgsCoordinateTransformContext(),
+                                           const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext(),
                                            QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags(),
                                            FieldNameSource fieldNameSource = Original
                                          ) SIP_SKIP;

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -671,15 +671,35 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * \param newLayer potentially modified layer name (output parameter)
      * \param errorMessage will be set to the error message text, if an error occurs while writing the layer
      * \returns Error message code, or QgsVectorFileWriter.NoError if the write operation was successful
-     * \since QGIS 3.10.3
+     * \deprecated since QGIS 3.20, use writeAsVectorFormatV3 instead
      */
-    static QgsVectorFileWriter::WriterError writeAsVectorFormatV2( QgsVectorLayer *layer,
+    Q_DECL_DEPRECATED static QgsVectorFileWriter::WriterError writeAsVectorFormatV2( QgsVectorLayer *layer,
         const QString &fileName,
         const QgsCoordinateTransformContext &transformContext,
         const QgsVectorFileWriter::SaveVectorOptions &options,
         QString *newFilename = nullptr,
         QString *newLayer = nullptr,
-        QString *errorMessage SIP_OUT = nullptr );
+        QString *errorMessage SIP_OUT = nullptr ) SIP_DEPRECATED;
+
+    /**
+     * Writes a layer out to a vector file.
+     * \param layer source layer to write
+     * \param fileName file name to write to
+     * \param transformContext coordinate transform context
+     * \param options save options
+     * \param newFilename potentially modified file name (output parameter)
+     * \param newLayer potentially modified layer name (output parameter)
+     * \param errorMessage will be set to the error message text, if an error occurs while writing the layer
+     * \returns Error message code, or QgsVectorFileWriter.NoError if the write operation was successful
+     * \since QGIS 3.20
+     */
+    static QgsVectorFileWriter::WriterError writeAsVectorFormatV3( QgsVectorLayer *layer,
+        const QString &fileName,
+        const QgsCoordinateTransformContext &transformContext,
+        const QgsVectorFileWriter::SaveVectorOptions &options,
+        QString *errorMessage SIP_OUT = nullptr,
+        QString *newFilename SIP_OUT = nullptr,
+        QString *newLayer SIP_OUT = nullptr );
 
     /**
      * Details of available filters and formats.

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
@@ -342,7 +342,7 @@ void QgsGeometryCheckerSetupTab::runChecks()
       saveOptions.fileEncoding = layer->dataProvider()->encoding();
       saveOptions.driverName = outputDriverName;
       saveOptions.onlySelectedFeatures = selectedOnly;
-      QgsVectorFileWriter::WriterError err =  QgsVectorFileWriter::writeAsVectorFormatV2( layer, outputPath, layer->transformContext(), saveOptions, nullptr, nullptr, &errMsg );
+      QgsVectorFileWriter::WriterError err =  QgsVectorFileWriter::writeAsVectorFormatV3( layer, outputPath, layer->transformContext(), saveOptions, &errMsg, nullptr, nullptr );
       if ( err != QgsVectorFileWriter::NoError )
       {
         createErrors.append( errMsg );

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -378,7 +378,7 @@ void TestQgsAttributeTable::testRegression15974()
   QgsVectorFileWriter::SaveVectorOptions saveOptions;
   saveOptions.fileEncoding = QStringLiteral( "system" );
   saveOptions.driverName = QStringLiteral( "ESRI Shapefile" );
-  QgsVectorFileWriter::writeAsVectorFormatV2( tempLayer.get(), path, tempLayer->transformContext(), saveOptions );
+  QgsVectorFileWriter::writeAsVectorFormatV3( tempLayer.get(), path, tempLayer->transformContext(), saveOptions );
   std::unique_ptr< QgsVectorLayer> shpLayer( new QgsVectorLayer( path, QStringLiteral( "test" ),  QStringLiteral( "ogr" ) ) );
   QgsFeature f1( shpLayer->dataProvider()->fields(), 1 );
   QgsGeometry geom;

--- a/tests/src/core/testqgsvectorfilewriter.cpp
+++ b/tests/src/core/testqgsvectorfilewriter.cpp
@@ -487,11 +487,11 @@ void TestQgsVectorFileWriter::prepareWriteAsVectorFormat()
   options.driverName = "GPKG";
   options.layerName = "test";
   QString newFilename;
-  QgsVectorFileWriter::WriterError error( QgsVectorFileWriter::writeAsVectorFormatV2(
+  QgsVectorFileWriter::WriterError error( QgsVectorFileWriter::writeAsVectorFormatV3(
       &ml,
       fileName,
       ml.transformContext(),
-      options,
+      options, nullptr,
       &newFilename ) );
 
   QCOMPARE( error, QgsVectorFileWriter::WriterError::NoError );
@@ -519,11 +519,11 @@ void TestQgsVectorFileWriter::testTextFieldLength()
   options.driverName = "GPKG";
   options.layerName = "test";
   QString newFilename;
-  QgsVectorFileWriter::WriterError error( QgsVectorFileWriter::writeAsVectorFormatV2(
+  QgsVectorFileWriter::WriterError error( QgsVectorFileWriter::writeAsVectorFormatV3(
       &vl,
       fileName,
       vl.transformContext(),
-      options,
+      options, nullptr,
       &newFilename ) );
   QCOMPARE( error, QgsVectorFileWriter::WriterError::NoError );
   QCOMPARE( newFilename, fileName );
@@ -572,11 +572,11 @@ void TestQgsVectorFileWriter::_testExportToGpx( const QString &geomTypeName,
   options.layerName = inputLayerName;
   options.layerOptions = layerOptions;
   QString outLayerName;
-  QgsVectorFileWriter::WriterError error( QgsVectorFileWriter::writeAsVectorFormatV2(
+  QgsVectorFileWriter::WriterError error( QgsVectorFileWriter::writeAsVectorFormatV3(
       &vl,
       fileName,
       vl.transformContext(),
-      options,
+      options, nullptr,
       nullptr, // newFilename
       &outLayerName ) );
   QCOMPARE( error, QgsVectorFileWriter::WriterError::NoError );

--- a/tests/src/gui/testqgsrasterlayersaveasdialog.cpp
+++ b/tests/src/gui/testqgsrasterlayersaveasdialog.cpp
@@ -132,14 +132,15 @@ QString TestQgsRasterLayerSaveAsDialog::prepareDb()
   options.driverName = QStringLiteral( "GPKG" );
   options.layerName = QStringLiteral( "test_vector_layer" );
   QString errorMessage;
-  QgsVectorFileWriter::writeAsVectorFormatV2(
+  QgsVectorFileWriter::writeAsVectorFormatV3(
     &vl,
     fileName,
     vl.transformContext(),
     options,
+    &errorMessage,
     nullptr,
-    nullptr,
-    &errorMessage );
+    nullptr
+  );
   QgsVectorLayer vl2( QStringLiteral( "%1|layername=test_vector_layer" ).arg( fileName ), "test_vector_layer", "ogr" );
   Q_ASSERT( vl2.isValid() );
   return tmpFile.fileName( );


### PR DESCRIPTION
Unfortunately QgsVectorFileWriter::writeAsVectorFormatV2 is missing
SIP_OUT arguments necessary to get the desired output arguments,
and it's not possible to add these now without breaking existing PyQGIS
code.

Solution = v3!