### PR TITLE
[processing] A few UI improvements to the history dialog

### DIFF
--- a/python/plugins/processing/gui/HistoryDialog.py
+++ b/python/plugins/processing/gui/HistoryDialog.py
@@ -30,6 +30,8 @@ from qgis.PyQt import uic
 from qgis.PyQt.QtCore import Qt, QCoreApplication
 from qgis.PyQt.QtWidgets import QAction, QPushButton, QDialogButtonBox, QStyle, QMessageBox, QFileDialog, QMenu, QTreeWidgetItem
 from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.Qsci import QsciScintilla
+
 from processing.gui import TestTools
 from processing.core.ProcessingLog import ProcessingLog, LOG_SEPARATOR
 
@@ -48,6 +50,13 @@ class HistoryDialog(BASE, WIDGET):
         self.setupUi(self)
 
         QgsGui.instance().enableAutoGeometryRestore(self)
+
+        self.text.setReadOnly(True)
+        self.text.setCaretLineVisible(False)
+        self.text.setLineNumbersVisible(False)  # NO linenumbers for the input line
+        self.text.setFoldingVisible(False)
+        self.text.setEdgeMode(QsciScintilla.EdgeNone)
+        self.text.setWrapMode(QsciScintilla.SC_WRAP_WORD)
 
         self.groupIcon = QgsApplication.getThemeIcon('mIconFolder.svg')
 

--- a/python/plugins/processing/gui/HistoryDialog.py
+++ b/python/plugins/processing/gui/HistoryDialog.py
@@ -158,7 +158,8 @@ class HistoryDialog(BASE, WIDGET):
     def changeText(self):
         item = self.tree.currentItem()
         if isinstance(item, TreeLogEntryItem):
-            self.text.setText(item.entry.text.replace(LOG_SEPARATOR, '\n'))
+            self.text.setText('"""\n' + self.tr('Double-click on the history item or paste the command below to re-run the algorithm') + '\n"""\n\n' +
+                              item.entry.text.replace('processing.run(', 'processing.execAlgorithmDialog(').replace(LOG_SEPARATOR, '\n'))
 
     def createTest(self):
         item = self.tree.currentItem()

--- a/python/plugins/processing/gui/HistoryDialog.py
+++ b/python/plugins/processing/gui/HistoryDialog.py
@@ -23,6 +23,7 @@ __copyright__ = '(C) 2012, Victor Olaya'
 
 import os
 import warnings
+import re
 
 from qgis.core import QgsApplication
 from qgis.gui import QgsGui, QgsHelp
@@ -114,12 +115,29 @@ class HistoryDialog(BASE, WIDGET):
     def fillTree(self):
         self.tree.clear()
         entries = ProcessingLog.getLogEntries()
+        names = {}
+        icons = {}
         groupItem = QTreeWidgetItem()
         groupItem.setText(0, 'ALGORITHM')
         groupItem.setIcon(0, self.groupIcon)
         for entry in entries:
-            item = TreeLogEntryItem(entry, True)
-            item.setIcon(0, self.keyIcon)
+            icon = self.keyIcon
+            name = ''
+            match = re.search('processing.run\\("(.*?)"', entry.text)
+            if match.group:
+                algorithm_id = match.group(1)
+                if algorithm_id not in names:
+                    algorithm = QgsApplication.processingRegistry().algorithmById(algorithm_id)
+                    if algorithm:
+                        names[algorithm_id] = algorithm.displayName()
+                        icons[algorithm_id] = QgsApplication.processingRegistry().algorithmById(algorithm_id).icon()
+                    else:
+                        names[algorithm_id] = ''
+                        icons[algorithm_id] = self.keyIcon
+                name = names[algorithm_id]
+                icon = icons[algorithm_id]
+            item = TreeLogEntryItem(entry, True, name)
+            item.setIcon(0, icon)
             groupItem.insertChild(0, item)
         self.tree.addTopLevelItem(groupItem)
         groupItem.setExpanded(True)
@@ -161,8 +179,8 @@ class HistoryDialog(BASE, WIDGET):
 
 class TreeLogEntryItem(QTreeWidgetItem):
 
-    def __init__(self, entry, isAlg):
+    def __init__(self, entry, isAlg, algName):
         QTreeWidgetItem.__init__(self)
         self.entry = entry
         self.isAlg = isAlg
-        self.setText(0, '[' + entry.date + '] ' + entry.text.split(LOG_SEPARATOR)[0])
+        self.setText(0, '[' + entry.date + '] ' + algName + ' - ' + entry.text.split(LOG_SEPARATOR)[0])

--- a/python/plugins/processing/ui/DlgHistory.ui
+++ b/python/plugins/processing/ui/DlgHistory.ui
@@ -35,11 +35,7 @@
        </property>
       </column>
      </widget>
-     <widget class="QTextEdit" name="text">
-      <property name="readOnly">
-       <bool>true</bool>
-      </property>
-     </widget>
+     <widget class="QgsCodeEditorPython" name="text" native="true"/>
     </widget>
    </item>
    <item>
@@ -54,6 +50,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCodeEditorPython</class>
+   <extends>QWidget</extends>
+   <header>qgscodeeditorpython.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
## Description

By using a QgsCodeEditorPython widget instead of a plain text widget, we can dramatically improve processing's history dialog reading of the saved historical python command:
![image](https://user-images.githubusercontent.com/1728657/112787038-cf6adc80-9081-11eb-8c7c-fd9792dd2789.png)

This whole dialog needs a re-doing, but in the meantime, this is a zero-effort improvement :) 