### PR TITLE
Fill QgsNetworkReplyContent.content() on HTTP error

### DIFF
--- a/src/core/network/qgsblockingnetworkrequest.cpp
+++ b/src/core/network/qgsblockingnetworkrequest.cpp
@@ -295,6 +295,7 @@ void QgsBlockingNetworkRequest::replyFinished()
 {
   if ( !mIsAborted && mReply )
   {
+
     if ( mReply->error() == QNetworkReply::NoError && ( !mFeedback || !mFeedback->isCanceled() ) )
     {
       QgsDebugMsgLevel( QStringLiteral( "reply OK" ), 2 );
@@ -408,6 +409,7 @@ void QgsBlockingNetworkRequest::replyFinished()
         QgsMessageLog::logMessage( mErrorMessage, tr( "Network" ) );
       }
       mReplyContent = QgsNetworkReplyContent( mReply );
+      mReplyContent.setContent( mReply->readAll() );
     }
   }
   if ( mTimedout )


### PR DESCRIPTION
fixes #42442

## Description

So far there was no `content()` set on a `QgsNetworkReplyContent` object when the request failed server-side, and as a consequence it wasn't possible to read any server response detailing what went wrong. This one-line PR fixes that.

Snippet (taken from #42442) doesn't work before but after the changes applied:

```python
unworkingUrl = QUrl('https://api.mapbox.com/valhalla/v1')

request = QNetworkRequest(unworkingUrl)
networkAccessManager = QgsNetworkAccessManager()
response = networkAccessManager.blockingGet(request)
status_code = response.attribute(QNetworkRequest.HttpStatusCodeAttribute)
if status_code == 200:
    print(response.content())
else:
    print(response.error())
    print(response.errorString())
    print(bytes(response.content()))
```

I would've added a regression test at least (eg to `https://qgis.org/bogus`), but then I discovered that most of the tests in [testqgsnetworkaccessmanager.cpp](https://github.com/QGIS/QGIS/blob/master/tests/src/core/testqgsnetworkaccessmanager.cpp) are not working either. I'll file a separate bug report for that. 