### PR TITLE
Update SAGA Gaussian Filter cmd parameters

### DIFF
--- a/python/plugins/processing/algs/saga/description/GaussianFilter.txt
+++ b/python/plugins/processing/algs/saga/description/GaussianFilter.txt
@@ -2,6 +2,6 @@ Gaussian Filter
 grid_filter
 QgsProcessingParameterRasterLayer|INPUT|Grid|None|False
 QgsProcessingParameterNumber|SIGMA|Standard Deviation|QgsProcessingParameterNumber.Double|1.00|False|None|None
-QgsProcessingParameterEnum|MODE|Search Mode|[0] Square;[1] Circle
-QgsProcessingParameterNumber|RADIUS|Search Radius|QgsProcessingParameterNumber.Integer|3|False|None|None
+QgsProcessingParameterEnum|KERNEL_TYPE|Search Mode|[0] Square;[1] Circle
+QgsProcessingParameterNumber|KERNEL_RADIUS|Search Radius|QgsProcessingParameterNumber.Integer|3|False|None|None
 QgsProcessingParameterRasterDestination|RESULT|Filtered Grid


### PR DESCRIPTION
## Description

Update SAGA Gaussian Filter cmd parameters. Saga version > 3.x use KERNEL_TYPE and KERNEL_RADIUS instead of prior MODE and RADIUS parameters.

Version 4 docs: http://www.saga-gis.org/saga_tool_doc/4.0.0/grid_filter_1.html
Version 3 docs: http://www.saga-gis.org/saga_tool_doc/3.0.0/grid_filter_1.html

This will be dependent on the version of saga installed with QGIS, this change would require saga versions greater than 3.x for the change to be compatible.