### PR TITLE
Fix geometries in maptoolmovefeature tests

### DIFF
--- a/tests/src/app/testqgsmaptoolmovefeature.cpp
+++ b/tests/src/app/testqgsmaptoolmovefeature.cpp
@@ -88,10 +88,10 @@ void TestQgsMapToolMoveFeature::initTestCase()
   QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mLayerBase );
 
   mLayerBase->startEditing();
-  QString wkt1 = "Polygon ((0 0, 0 1, 1 1, 1 0))";
+  QString wkt1 = "Polygon ((0 0, 0 1, 1 1, 1 0, 0 0))";
   QgsFeature f1;
   f1.setGeometry( QgsGeometry::fromWkt( wkt1 ) );
-  QString wkt2 = "Polygon ((2 0, 2 5, 3 5, 3 0))";
+  QString wkt2 = "Polygon ((2 0, 2 5, 3 5, 3 0, 2 0))";
   QgsFeature f2;
   f2.setGeometry( QgsGeometry::fromWkt( wkt2 ) );
 
@@ -135,9 +135,9 @@ void TestQgsMapToolMoveFeature::testMoveFeature()
   utils.mouseClick( 1, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
   utils.mouseClick( 2, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
 
-  QString wkt1 = "Polygon ((1 0, 1 1, 2 1, 2 0))";
+  QString wkt1 = "Polygon ((1 0, 1 1, 2 1, 2 0, 1 0))";
   QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt(), wkt1 );
-  QString wkt2 = "Polygon ((2 0, 2 5, 3 5, 3 0))";
+  QString wkt2 = "Polygon ((2 0, 2 5, 3 5, 3 0, 2 0))";
   QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt(), wkt2 );
 
   mLayerBase->undoStack()->undo();
@@ -153,9 +153,9 @@ void TestQgsMapToolMoveFeature::testTopologicalMoveFeature()
   utils.mouseClick( 1, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
   utils.mouseClick( 2, 1, Qt::LeftButton, Qt::KeyboardModifiers(), true );
 
-  QString wkt1 = "Polygon ((1 0, 1 1, 2 1, 2 0))";
+  QString wkt1 = "Polygon ((1 0, 1 1, 2 1, 2 0, 1 0))";
   QCOMPARE( mLayerBase->getFeature( 1 ).geometry().asWkt(), wkt1 );
-  QString wkt2 = "Polygon ((2 0, 2 1, 2 5, 3 5, 3 0))";
+  QString wkt2 = "Polygon ((2 0, 2 1, 2 5, 3 5, 3 0, 2 0))";
   QCOMPARE( mLayerBase->getFeature( 2 ).geometry().asWkt(), wkt2 );
 
   mLayerBase->undoStack()->undo();


### PR DESCRIPTION
## Description
The Polygon rings are not closed. The test does not really mind, but it might cause trouble at some point, like it did on the rotate features test where the polygons lost a vertex after rotating.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
