### PR TITLE
Show paper properties if clicked on a Layout Page

### DIFF
--- a/src/gui/layout/qgslayoutviewtoolselect.cpp
+++ b/src/gui/layout/qgslayoutviewtoolselect.cpp
@@ -224,7 +224,7 @@ void QgsLayoutViewToolSelect::layoutReleaseEvent( QgsLayoutViewMouseEvent *event
     QgsLayoutItem *layoutItem = dynamic_cast<QgsLayoutItem *>( item );
     QgsLayoutItemPage *paperItem = dynamic_cast<QgsLayoutItemPage *>( item );
     if ( paperItem )
-        focusedPaperItem = paperItem;
+      focusedPaperItem = paperItem;
 
     if ( layoutItem && !paperItem )
     {

--- a/src/gui/layout/qgslayoutviewtoolselect.cpp
+++ b/src/gui/layout/qgslayoutviewtoolselect.cpp
@@ -50,7 +50,6 @@ void QgsLayoutViewToolSelect::layoutPressEvent( QgsLayoutViewMouseEvent *event )
     //swallow clicks while dragging/resizing items
     return;
   }
-
   if ( mMouseHandles->isVisible() )
   {
     //selection handles are being shown, get mouse action for current cursor position
@@ -218,10 +217,13 @@ void QgsLayoutViewToolSelect::layoutReleaseEvent( QgsLayoutViewMouseEvent *event
     itemList = layout()->items( rect.center(), selectionMode );
   else
     itemList = layout()->items( rect, selectionMode );
+
+  bool paperItemFocused = false;
   for ( QGraphicsItem *item : std::as_const( itemList ) )
   {
     QgsLayoutItem *layoutItem = dynamic_cast<QgsLayoutItem *>( item );
     QgsLayoutItemPage *paperItem = dynamic_cast<QgsLayoutItemPage *>( item );
+
     if ( layoutItem && !paperItem )
     {
       if ( !layoutItem->isLocked() )
@@ -241,13 +243,26 @@ void QgsLayoutViewToolSelect::layoutReleaseEvent( QgsLayoutViewMouseEvent *event
         }
       }
     }
+    else
+    {
+      if ( paperItem )
+      {
+        emit itemFocused( paperItem );
+        paperItemFocused = true;
+      }
+    }
   }
+
 
   //update item panel
   const QList<QgsLayoutItem *> selectedItemList = layout()->selectedLayoutItems();
   if ( !selectedItemList.isEmpty() )
   {
     emit itemFocused( selectedItemList.at( 0 ) );
+  }
+  else if ( paperItemFocused )
+  {
+    // do NOT emit nullptr because that will remove the page properties...
   }
   else
   {

--- a/src/gui/layout/qgslayoutviewtoolselect.cpp
+++ b/src/gui/layout/qgslayoutviewtoolselect.cpp
@@ -254,9 +254,9 @@ void QgsLayoutViewToolSelect::layoutReleaseEvent( QgsLayoutViewMouseEvent *event
   {
     emit itemFocused( selectedItemList.at( 0 ) );
   }
-  else if ( paperItemFocused )
+  else if ( focusedPaperItem )
   {
-    // do NOT emit nullptr because that will remove the page properties...
+    emit itemFocused( focusedPaperItem );
   }
   else
   {

--- a/src/gui/layout/qgslayoutviewtoolselect.cpp
+++ b/src/gui/layout/qgslayoutviewtoolselect.cpp
@@ -218,11 +218,13 @@ void QgsLayoutViewToolSelect::layoutReleaseEvent( QgsLayoutViewMouseEvent *event
   else
     itemList = layout()->items( rect, selectionMode );
 
-  bool paperItemFocused = false;
+  QgsLayoutItemPage *focusedPaperItem = nullptr;
   for ( QGraphicsItem *item : std::as_const( itemList ) )
   {
     QgsLayoutItem *layoutItem = dynamic_cast<QgsLayoutItem *>( item );
     QgsLayoutItemPage *paperItem = dynamic_cast<QgsLayoutItemPage *>( item );
+    if ( paperItem )
+        focusedPaperItem = paperItem;
 
     if ( layoutItem && !paperItem )
     {
@@ -241,14 +243,6 @@ void QgsLayoutViewToolSelect::layoutReleaseEvent( QgsLayoutViewMouseEvent *event
           // found an item, and only a click - nothing more to do
           break;
         }
-      }
-    }
-    else
-    {
-      if ( paperItem )
-      {
-        emit itemFocused( paperItem );
-        paperItemFocused = true;
       }
     }
   }

--- a/src/ui/layout/qgslayoutdesignerbase.ui
+++ b/src/ui/layout/qgslayoutdesignerbase.ui
@@ -182,7 +182,7 @@
      <x>0</x>
      <y>0</y>
      <width>2180</width>
-     <height>25</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="mLayoutMenu">
@@ -1127,7 +1127,7 @@
    </property>
   </action>
   <action name="mActionShowPage">
-   <property name="checkable">q
+   <property name="checkable">
     <bool>true</bool>
    </property>
    <property name="text">
@@ -1551,7 +1551,7 @@
   </action>
   <action name="mActionPageSetup">
    <property name="text">
-    <string>Pa&amp;ge Setup…</string>
+    <string>Printer Pa&amp;ge Setup…</string>
    </property>
    <property name="toolTip">
     <string>Page setup</string>
@@ -1577,34 +1577,6 @@
   </action>
  </widget>
  <resources>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
Currently the only way to see the current Page properties (most
notably the page orientation and size) is via a context menu.

In my experience several people failed to 'find' it.

See also: https://lists.osgeo.org/pipermail/qgis-developer/2021-March/063416.html
and #26237 (could be closed) and #25803

Took me some time to follow/understand all mouse pressed/move/released signals :-)
But I think this commit is a pretty clean solution?

Now if you click on a page the props will be shown (just like
if you use the context menu).

