### PR TITLE
[postgresraster] Fix invalid comparison of string to int

### DIFF
--- a/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
@@ -1874,9 +1874,9 @@ bool QgsPostgresRasterProvider::loadFields()
     QgsField newField = QgsField( fieldName, fieldType, fieldTypeName, fieldSize, fieldPrec, fieldComment, fieldSubType );
 
     QgsFieldConstraints constraints;
-    if ( notNullMap[tableoid][attnum] || ( mPrimaryKeyAttrs.size() == 1 && mPrimaryKeyAttrs[0] == i ) || identityMap[tableoid][attnum] != ' ' )
+    if ( notNullMap[tableoid][attnum] || ( mPrimaryKeyAttrs.size() == 1 && mPrimaryKeyAttrs[0] == fieldName ) || identityMap[tableoid][attnum] != ' ' )
       constraints.setConstraint( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintOriginProvider );
-    if ( uniqueMap[tableoid][attnum] || ( mPrimaryKeyAttrs.size() == 1 && mPrimaryKeyAttrs[0] == i ) || identityMap[tableoid][attnum] != ' ' )
+    if ( uniqueMap[tableoid][attnum] || ( mPrimaryKeyAttrs.size() == 1 && mPrimaryKeyAttrs[0] == fieldName ) || identityMap[tableoid][attnum] != ' ' )
       constraints.setConstraint( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintOriginProvider );
     newField.setConstraints( constraints );
 
@@ -2210,7 +2210,7 @@ QString QgsPostgresRasterProvider::pkSql()
   if ( mPrimaryKeyAttrs.count( ) > 1 )
   {
     QStringList pkeys;
-    for ( const auto &k : std::as_const( mPrimaryKeyAttrs ) )
+    for ( const QString &k : std::as_const( mPrimaryKeyAttrs ) )
     {
       pkeys.push_back( quotedIdentifier( k ) );
     }


### PR DESCRIPTION
@elpaso this looks like a copy/paste error from the postgres provider. The postgres provider uses QList< int > for mPrimaryKeyAttrs, but postgres raster uses QStringList. I *think* the intention here is to compare the field name against the primary key (as done here), but currently the code comparse the primary key attribute name against an integer value. 

Identified from the qt6 builds, since int to QString comparison no longer compiles (and previously it was nonsense anyway, because it went transparently via QChar( int ), so the results were never as expected!)