### PR TITLE
[ui][processing] Do not show clear buttons in the aggregate widget

### DIFF
--- a/src/gui/qgsfieldmappingwidget.cpp
+++ b/src/gui/qgsfieldmappingwidget.cpp
@@ -253,7 +253,6 @@ QWidget *QgsFieldMappingWidget::ExpressionDelegate::createEditor( QWidget *paren
   QgsFieldExpressionWidget *editor = new QgsFieldExpressionWidget( parent );
   editor->setAutoFillBackground( true );
   editor->setAllowEvalErrors( false );
-  editor->setAllowEmptyFieldName( true );
   if ( const QgsFieldMappingModel *model = qobject_cast<const QgsFieldMappingModel *>( index.model() ) )
   {
     editor->registerExpressionContextGenerator( model->contextGenerator() );


### PR DESCRIPTION
## Description

This PR removes the clear text button from processing aggregate algorithm's expression widgets:

![image](https://user-images.githubusercontent.com/1728657/113120139-78106c00-923b-11eb-8f58-999db196a115.png)
_Before (left) vs. PR (right)_

The dialog is already overcrowded and those clear buttons mostly took place. I'll also shamelessly admit I got confused thinking the button would remove the row from the aggregated table. I assume others might too.