### PR TITLE
Ensure that cached vector getFeatures request respect provider ordering

### DIFF
--- a/src/core/qgscachedfeatureiterator.cpp
+++ b/src/core/qgscachedfeatureiterator.cpp
@@ -45,15 +45,15 @@ QgsCachedFeatureIterator::QgsCachedFeatureIterator( QgsVectorLayerCache *vlCache
   switch ( featureRequest.filterType() )
   {
     case QgsFeatureRequest::FilterFids:
-      mFeatureIds = featureRequest.filterFids();
+      mFeatureIds = QList< QgsFeatureId >( qgis::setToList( featureRequest.filterFids() ) );
       break;
 
     case QgsFeatureRequest::FilterFid:
-      mFeatureIds = QgsFeatureIds() << featureRequest.filterFid();
+      mFeatureIds = QList< QgsFeatureId >() << featureRequest.filterFid();
       break;
 
     default:
-      mFeatureIds = qgis::listToSet( mVectorLayerCache->mCache.keys() );
+      mFeatureIds = mVectorLayerCache->mCacheOrderedKeys;
       break;
   }
 

--- a/src/core/qgscachedfeatureiterator.h
+++ b/src/core/qgscachedfeatureiterator.h
@@ -76,9 +76,9 @@ class CORE_EXPORT QgsCachedFeatureIterator : public QgsAbstractFeatureIterator
     bool nextFeatureFilterFids( QgsFeature &f ) override { return fetchFeature( f ); }
 
   private:
-    QgsFeatureIds mFeatureIds;
+    QList< QgsFeatureId > mFeatureIds;
     QgsVectorLayerCache *mVectorLayerCache = nullptr;
-    QgsFeatureIds::ConstIterator mFeatureIdIterator;
+    QList< QgsFeatureId >::ConstIterator mFeatureIdIterator;
     QgsCoordinateTransform mTransform;
     QgsRectangle mFilterRect;
 };

--- a/src/core/vector/qgsvectorlayercache.cpp
+++ b/src/core/vector/qgsvectorlayercache.cpp
@@ -175,7 +175,10 @@ bool QgsVectorLayerCache::featureAtId( QgsFeatureId featureId, QgsFeature &featu
 
 bool QgsVectorLayerCache::removeCachedFeature( QgsFeatureId fid )
 {
-  return mCache.remove( fid );
+  bool removed = mCache.remove( fid );
+  if ( removed )
+    mCacheOrderedKeys.removeOne( fid );
+  return removed;
 }
 
 QgsVectorLayer *QgsVectorLayerCache::layer()
@@ -267,6 +270,7 @@ void QgsVectorLayerCache::onJoinAttributeValueChanged( QgsFeatureId fid, int fie
 void QgsVectorLayerCache::featureDeleted( QgsFeatureId fid )
 {
   mCache.remove( fid );
+  mCacheOrderedKeys.removeOne( fid );
 }
 
 void QgsVectorLayerCache::onFeatureAdded( QgsFeatureId fid )
@@ -325,6 +329,7 @@ void QgsVectorLayerCache::layerDeleted()
 void QgsVectorLayerCache::invalidate()
 {
   mCache.clear();
+  mCacheOrderedKeys.clear();
   mFullCache = false;
   emit invalidated();
 }

--- a/src/core/vector/qgsvectorlayercache.h
+++ b/src/core/vector/qgsvectorlayercache.h
@@ -393,10 +393,13 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
     {
       QgsCachedFeature *cachedFeature = new QgsCachedFeature( feat, this );
       mCache.insert( feat.id(), cachedFeature );
+      if ( !mCacheOrderedKeys.contains( feat.id() ) )
+        mCacheOrderedKeys << feat.id();
     }
 
     QgsVectorLayer *mLayer = nullptr;
     QCache< QgsFeatureId, QgsCachedFeature > mCache;
+    QList< QgsFeatureId > mCacheOrderedKeys;
 
     bool mCacheGeometry = true;
     bool mFullCache = false;

--- a/tests/src/core/testqgsvectorlayercache.cpp
+++ b/tests/src/core/testqgsvectorlayercache.cpp
@@ -267,11 +267,15 @@ void TestVectorLayerCache::testFullCacheThroughRequest()
     // suck in all features
   }
 
-  // cache should now contain all features
+  // cache should now contain all features, and should iterate through in the same order as the non-cached feature ordering
   it = mPointsLayer->getFeatures();
+  QgsFeatureIterator itCached = cache.getFeatures( QgsFeatureRequest() );
+  QgsFeature fCached;
   while ( it.nextFeature( f ) )
   {
     QVERIFY( cache.isFidCached( f.id() ) );
+    itCached.nextFeature( fCached );
+    QCOMPARE( f.id(), fCached.id() );
   }
 
   // so it should be a full cache!


### PR DESCRIPTION
This PR fixes (at least) #27127 and #29794 , whereas the attribute table's default ordering doesn't match that of the dataset fetched through its provider.

The issue lies within the caching mechanism used by the attribute table, which ends up returning a randomized fetchFeature order for non sorted cached datasets.