### PR TITLE
When configurating a field calculator algorithm in a model, ensure that the correct expression context is set for the widget

### DIFF
--- a/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -332,10 +332,12 @@ Returns the current value of the parameter.
 Returns any custom properties set by the wrapper.
 %End
 
-    void registerProcessingContextGenerator( QgsProcessingContextGenerator *generator );
+    virtual void registerProcessingContextGenerator( QgsProcessingContextGenerator *generator );
 %Docstring
 Registers a Processing context ``generator`` class that will be used to retrieve
 a Processing context for the wrapper when required.
+
+Care must be taken to call the base class implementation if overwrite this method.
 %End
 
     void registerProcessingParametersGenerator( QgsProcessingParametersGenerator *generator );

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -373,8 +373,10 @@ class GUI_EXPORT QgsAbstractProcessingParameterWidgetWrapper : public QObject, p
     /**
      * Registers a Processing context \a generator class that will be used to retrieve
      * a Processing context for the wrapper when required.
+     *
+     * Care must be taken to call the base class implementation if overwrite this method.
      */
-    void registerProcessingContextGenerator( QgsProcessingContextGenerator *generator );
+    virtual void registerProcessingContextGenerator( QgsProcessingContextGenerator *generator );
 
     /**
      * Registers a Processing parameters \a generator class that will be used to retrieve

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -1990,6 +1990,16 @@ void QgsProcessingExpressionWidgetWrapper::postInitialize( const QList<QgsAbstra
   }
 }
 
+void QgsProcessingExpressionWidgetWrapper::registerProcessingContextGenerator( QgsProcessingContextGenerator *generator )
+{
+  QgsAbstractProcessingParameterWidgetWrapper::registerProcessingContextGenerator( generator );
+  if ( mExpBuilderWidget )
+  {
+    // we need to regenerate the expression context for use by this widget -- it doesn't fetch automatically on demand
+    mExpBuilderWidget->setExpressionContext( createExpressionContext() );
+  }
+}
+
 void QgsProcessingExpressionWidgetWrapper::setParentLayerWrapperValue( const QgsAbstractProcessingParameterWidgetWrapper *parentWrapper )
 {
   // evaluate value to layer

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -662,6 +662,7 @@ class GUI_EXPORT QgsProcessingExpressionWidgetWrapper : public QgsAbstractProces
     // QgsProcessingParameterWidgetWrapper interface
     QWidget *createWidget() override SIP_FACTORY;
     void postInitialize( const QList< QgsAbstractProcessingParameterWidgetWrapper * > &wrappers ) override;
+    void registerProcessingContextGenerator( QgsProcessingContextGenerator *generator ) override;
 
   public slots:
     void setParentLayerWrapperValue( const QgsAbstractProcessingParameterWidgetWrapper *parentWrapper );


### PR DESCRIPTION
Otherwise we don't see any of the available variables ready for use in the calculation.

We need to do this manually after creating the widget, because the context generator isn't set till after the widget is created, and
this particular widget configuration doesn't fetch the expression context on demand.
