### PR TITLE
make methods of QgsMapLayerAction virtual so the canRunUsingLayer can be fine tuned

### DIFF
--- a/python/gui/auto_generated/qgsmaplayeractionregistry.sip.in
+++ b/python/gui/auto_generated/qgsmaplayeractionregistry.sip.in
@@ -15,7 +15,7 @@ class QgsMapLayerAction : QAction
 %Docstring(signature="appended")
 An action which can run on map layers
 The class can be used in two manners:
-* by instantiating it and connect to its signals to perform an action
+* by instantiating it and connecting to its signals to perform an action
 * by subclassing and reimplementing its method (only since QGIS 3.18.2)
 %End
 

--- a/python/gui/auto_generated/qgsmaplayeractionregistry.sip.in
+++ b/python/gui/auto_generated/qgsmaplayeractionregistry.sip.in
@@ -14,6 +14,9 @@ class QgsMapLayerAction : QAction
 {
 %Docstring(signature="appended")
 An action which can run on map layers
+The class can be used in two manners:
+* by instantiating it and connect to its signals to perform an action
+* by subclassing and reimplementing its method (only since QGIS 3.18.2)
 %End
 
 %TypeHeaderCode
@@ -66,22 +69,22 @@ Layer behavior flags.
 .. versionadded:: 3.0
 %End
 
-    bool canRunUsingLayer( QgsMapLayer *layer ) const;
+    virtual bool canRunUsingLayer( QgsMapLayer *layer ) const;
 %Docstring
 True if action can run using the specified layer
 %End
 
-    void triggerForFeatures( QgsMapLayer *layer, const QList<QgsFeature> &featureList );
+    virtual void triggerForFeatures( QgsMapLayer *layer, const QList<QgsFeature> &featureList );
 %Docstring
 Triggers the action with the specified layer and list of feature.
 %End
 
-    void triggerForFeature( QgsMapLayer *layer, const QgsFeature &feature );
+    virtual void triggerForFeature( QgsMapLayer *layer, const QgsFeature &feature );
 %Docstring
 Triggers the action with the specified layer and feature.
 %End
 
-    void triggerForLayer( QgsMapLayer *layer );
+    virtual void triggerForLayer( QgsMapLayer *layer );
 %Docstring
 Triggers the action with the specified layer.
 %End

--- a/src/gui/qgsmaplayeractionregistry.h
+++ b/src/gui/qgsmaplayeractionregistry.h
@@ -31,7 +31,7 @@ class QgsFeature;
  * \ingroup gui
 * \brief An action which can run on map layers
 * The class can be used in two manners:
-* * by instantiating it and connect to its signals to perform an action
+* * by instantiating it and connecting to its signals to perform an action
 * * by subclassing and reimplementing its method (only since QGIS 3.18.2)
 */
 class GUI_EXPORT QgsMapLayerAction : public QAction

--- a/src/gui/qgsmaplayeractionregistry.h
+++ b/src/gui/qgsmaplayeractionregistry.h
@@ -30,6 +30,9 @@ class QgsFeature;
 /**
  * \ingroup gui
 * \brief An action which can run on map layers
+* The class can be used in two manners:
+* * by instantiating it and connect to its signals to perform an action
+* * by subclassing and reimplementing its method (only since QGIS 3.18.2)
 */
 class GUI_EXPORT QgsMapLayerAction : public QAction
 {
@@ -83,16 +86,16 @@ class GUI_EXPORT QgsMapLayerAction : public QAction
     QgsMapLayerAction::Flags flags() const;
 
     //! True if action can run using the specified layer
-    bool canRunUsingLayer( QgsMapLayer *layer ) const;
+    virtual bool canRunUsingLayer( QgsMapLayer *layer ) const;
 
     //! Triggers the action with the specified layer and list of feature.
-    void triggerForFeatures( QgsMapLayer *layer, const QList<QgsFeature> &featureList );
+    virtual void triggerForFeatures( QgsMapLayer *layer, const QList<QgsFeature> &featureList );
 
     //! Triggers the action with the specified layer and feature.
-    void triggerForFeature( QgsMapLayer *layer, const QgsFeature &feature );
+    virtual void triggerForFeature( QgsMapLayer *layer, const QgsFeature &feature );
 
     //! Triggers the action with the specified layer.
-    void triggerForLayer( QgsMapLayer *layer );
+    virtual void triggerForLayer( QgsMapLayer *layer );
 
     //! Define the targets of the action
     void setTargets( Targets targets ) {mTargets = targets;}


### PR DESCRIPTION
for instance, this allows to fine tune the appearance of the action in the identify menu (based on geometry type, CRS, extent, etc.)

if there is no objection, I will backport to 3.18.
This is obviously not any API break and bring just better behavior for plugins.