### PR TITLE
upgrade cpp check from 16+18 to 18+20

### DIFF
--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -191,8 +191,10 @@ jobs:
       - name: Sip Files Up To Date
         run: ./tests/code_layout/test_sipfiles.sh
 
-  cppcheck_16_04:
-    runs-on: ubuntu-16.04
+
+  cppcheck_20_04:
+    name: cpp check on ubuntu 20.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -205,6 +207,7 @@ jobs:
         run: ./scripts/cppcheck.sh
 
   cppcheck_18_04:
+    name: cpp check on ubuntu 18.04
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout


### PR DESCRIPTION
16.04 seems to be failing right now, and I don't see a reason to keep it?