### PR TITLE
[Feature] Theme manager

### DIFF
--- a/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -10,7 +10,6 @@
 
 
 
-
 class QgsLayerTreeProxyModel : QSortFilterProxyModel
 {
 %Docstring(signature="appended")
@@ -36,6 +35,13 @@ Constructs QgsLayerTreeProxyModel with source model ``treeModel`` and a ``parent
 Sets filter to ``filterText``.
 %End
 
+    void setApprovedIds( const QStringList &ids );
+%Docstring
+Sets a predefined list of layer Ids to process.
+
+.. versionadded:: 3.20
+%End
+
     bool showPrivateLayers() const;
 %Docstring
 Returns if private layers are shown.
@@ -44,6 +50,15 @@ Returns if private layers are shown.
     void setShowPrivateLayers( bool showPrivate );
 %Docstring
 Determines if private layers are shown.
+%End
+
+    void setShowAllNodes( bool show );
+%Docstring
+Allow non-spatial layers and empty groups to be show.
+
+:param show: If ``True`` (default behavior), non-spatial layers and groups will be shown.
+
+.. versionadded:: 3.20
 %End
 
   protected:
@@ -93,7 +108,9 @@ Constructor for QgsLayerTreeView
     virtual void setModel( QAbstractItemModel *model );
 
 %Docstring
-Overridden :py:func:`~QgsLayerTreeView.setModel` from base class. Only :py:class:`QgsLayerTreeModel` is an acceptable model.
+Overridden :py:func:`~QgsLayerTreeView.setModel` from base class.
+
+:param model: Model used to populate the view. Only :py:class:`QgsLayerTreeModel` models are accepted.
 %End
 
     QgsLayerTreeModel *layerTreeModel() const;
@@ -108,6 +125,13 @@ Returns the proxy model used by the view.
 This can be used to set filters controlling which layers are shown in the view.
 
 .. versionadded:: 3.18
+%End
+
+    void disconnectProxyModel();
+%Docstring
+Disconnects the Proxy Model to prevent crash when using a second view on the same model.
+
+.. versionadded:: 3.24
 %End
 
     QgsLayerTreeNode *index2node( const QModelIndex &index ) const;
@@ -293,6 +317,15 @@ Returns width of contextual menu mark, at right of layer node items.
 .. seealso:: :py:func:`setLayerMarkWidth`
 
 .. versionadded:: 3.8
+%End
+
+    void showAllNodes( bool show );
+%Docstring
+Allow non-spatial layers and empty groups to be show.
+
+:param show: If ``True`` (default behavior), non-spatial layers and groups will be shown.
+
+.. versionadded:: 3.20
 %End
 
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -69,6 +69,8 @@ set(QGIS_APP_SRCS
   qgsstatusbarscalewidget.cpp
   qgstemplateprojectsmodel.cpp
   qgstemporalcontrollerdockwidget.cpp
+  qgsthemeviewer.cpp
+  qgsthememanagerwidget.cpp
   qgsversioninfo.cpp
   qgsrecentprojectsitemsmodel.cpp
   qgsvectorlayerdigitizingproperties.cpp

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -382,6 +382,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgstaskmanagerwidget.h"
 #include "qgssymbolselectordialog.h"
 #include "qgstextannotation.h"
+#include "qgsthememanagerwidget.h"
 #include "qgsundowidget.h"
 #include "qgsuserinputwidget.h"
 #include "qgsvectordataprovider.h"
@@ -1434,6 +1435,10 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   activateDeactivateLayerRelatedActions( nullptr ); // after members were created
 
   connect( QgsGui::mapLayerActionRegistry(), &QgsMapLayerActionRegistry::changed, this, &QgisApp::refreshActionFeatureAction );
+
+  mThemeManager = new QgsThemeManagerWidget( this );
+  addDockWidget( Qt::LeftDockWidgetArea, mThemeManager );
+  mThemeManager->hide();
 
   // set application's caption
   QString caption = tr( "QGIS - %1 ('%2')" ).arg( Qgis::version(), Qgis::releaseName() );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -150,7 +150,7 @@ class QgsDevToolWidgetFactory;
 class QgsNetworkLogger;
 class QgsNetworkLoggerWidgetFactory;
 class QgsMapToolCapture;
-
+class QgsThemeManagerWidget;
 #include <QMainWindow>
 #include <QToolBar>
 #include <QAbstractSocket>
@@ -2659,6 +2659,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QMetaObject::Connection mRenderProgressBarTimerConnection;
 
     QgsBrowserGuiModel *mBrowserModel = nullptr;
+
+    QgsThemeManagerWidget *mThemeManager = nullptr;
 
     void setupDuplicateFeaturesAction();
 

--- a/src/app/qgsmapthemes.h
+++ b/src/app/qgsmapthemes.h
@@ -51,10 +51,12 @@ class APP_EXPORT QgsMapThemes : public QObject
     //! Convenience menu that lists available presets and actions for management
     QMenu *menu();
 
-  protected slots:
+  public slots:
 
     //! Handles adding a preset to the project's collection
     void addPreset();
+
+  protected slots:
 
     //! Handles apply a preset to the map canvas
     void presetTriggered();

--- a/src/app/qgsthememanagerwidget.cpp
+++ b/src/app/qgsthememanagerwidget.cpp
@@ -160,6 +160,7 @@ void QgsThemeManagerWidget::viewCurrentTheme() const
     return;
   QStringList themeIds;
   const QList<QgsMapLayer *> constMapThemeVisibleLayers = mThemeCollection->mapThemeVisibleLayers( mCurrentTheme );
+  // for symbol legend nodes support, maybe look into ./src/core/qgsmapthemecollection.cpp#L47-L65
   for ( QgsMapLayer *layer : constMapThemeVisibleLayers )
   {
     if ( layer->isValid() && layer->isSpatial() )

--- a/src/app/qgsthememanagerwidget.cpp
+++ b/src/app/qgsthememanagerwidget.cpp
@@ -1,0 +1,234 @@
+/***************************************************************************
+  qgsthememanagerwidget.cpp
+  --------------------------------------
+  Date                 : April 2021
+  Copyright            : (C) 2021 by Alex RL
+  Email                : ping me on github
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsthememanagerwidget.h"
+#include "qgsdockwidget.h"
+#include "qgsproject.h"
+#include "qgsmaplayer.h"
+#include "qgsmapthemecollection.h"
+#include "qgslayertreemodel.h"
+#include "qgslayertreeview.h"
+#include "qgslayertreenode.h"
+#include "qgslayertreegroup.h"
+#include "qgsthemeviewer.h"
+#include "qgsmapthemes.h"
+#include <QMessageBox>
+#include <QWidget>
+#include <QToolButton>
+#include <QComboBox>
+#include <QMenu>
+#include <QAction>
+#include "qgisapp.h"
+
+QgsThemeManagerWidget::QgsThemeManagerWidget( QWidget *parent )
+  : QgsDockWidget( parent )
+{
+  setupUi( this );
+  connect( this, &QgsDockWidget::opened, this, &QgsThemeManagerWidget::showWidget );
+  connect( QgsProject::instance(), &QgsProject::readProject, this, &QgsThemeManagerWidget::projectLoaded );
+  connect( mThemePrev, &QToolButton::clicked, this, &QgsThemeManagerWidget::previousTheme );
+  connect( mThemeNext, &QToolButton::clicked, this, &QgsThemeManagerWidget::nextTheme );
+  connect( mCreateTheme, &QToolButton::clicked, this, &QgsThemeManagerWidget::createTheme );
+  connect( mDeleteTheme, &QToolButton::clicked, this, &QgsThemeManagerWidget::removeTheme );
+  connect( mAddThemeLayer, &QToolButton::clicked, this, &QgsThemeManagerWidget::addSelectedLayers );
+  connect( mRemoveThemeLayer, &QToolButton::clicked, this, &QgsThemeManagerWidget::removeSelectedLayers );
+  connect( mThemeList, qOverload<int>( &QComboBox::activated ), [ = ]( int index ) { setTheme( index ); } );
+  connect( mThemeViewer, &QgsThemeViewer::layersAdded, this, &QgsThemeManagerWidget::addSelectedLayers );
+  connect( mThemeViewer, &QgsThemeViewer::showMenu, this, &QgsThemeManagerWidget::showContextMenu );
+  //connect( mThemeViewer, &QgsThemeViewer::layersDropped, this, &QgsThemeManagerWidget::removeSelectedLayers );
+  connect( this, &QgsThemeManagerWidget::droppedLayers, this, &QgsThemeManagerWidget::removeSelectedLayers );
+  connect( this, &QgsThemeManagerWidget::addLayerTreeLayers, this, &QgsThemeManagerWidget::addSelectedLayers );
+}
+
+void QgsThemeManagerWidget::projectLoaded()
+{
+  mThemeCollection = QgsProject::instance()->mapThemeCollection();
+  connect( mThemeCollection, &QgsMapThemeCollection::mapThemesChanged, this, &QgsThemeManagerWidget::populateCombo, Qt::UniqueConnection );
+  QgsLayerTreeModel *mModel = QgisApp::instance()->layerTreeView()->layerTreeModel();
+  if ( mThemeViewer && mModel )
+  {
+    mThemeViewer->setModel( mModel );
+    mThemeViewer->disconnectProxyModel();
+    mThemeViewer->showAllNodes( mShowAllLayers );
+  }
+  if ( mThemeCollection && mThemeCollection->mapThemes().length() > 0 )
+  {
+    if ( !mThemeCollection->hasMapTheme( mCurrentTheme ) )
+    {
+      mCurrentTheme = mThemeCollection->mapThemes()[0];
+      mThemeList->setCurrentText( mCurrentTheme );
+    }
+    populateCombo();
+    viewCurrentTheme();
+  }
+}
+
+void QgsThemeManagerWidget::showWidget()
+{
+  if ( mCurrentTheme.isEmpty() )
+    projectLoaded();
+}
+
+void QgsThemeManagerWidget::setTheme( const int index )
+{
+  QString themename;
+  if ( index > -1 && mThemeCollection->mapThemes().size() > index )
+  {
+    QString themename = mThemeCollection->mapThemes().at( index );
+    if ( !mThemeCollection->hasMapTheme( themename ) )
+      return;
+    mCurrentTheme = themename;
+    emit updateComboBox();
+  }
+}
+
+void QgsThemeManagerWidget::createTheme()
+{
+  QgsMapThemes::instance()->addPreset();
+  emit updateComboBox();
+}
+
+void QgsThemeManagerWidget::removeTheme()
+{
+  int res = QMessageBox::question( QgisApp::instance(), tr( "Remove Theme" ),
+                                   tr( "Are you sure you want to remove the existing theme “%1”?" ).arg( mCurrentTheme ),
+                                   QMessageBox::Yes | QMessageBox::No, QMessageBox::No );  if ( res == QMessageBox::Yes )
+  {
+    mThemeCollection->removeMapTheme( mCurrentTheme );
+    mCurrentTheme = mThemeCollection->mapThemes()[0];
+    emit updateComboBox();
+  }
+
+}
+
+void QgsThemeManagerWidget::previousTheme()
+{
+  QStringList themes = mThemeCollection->mapThemes();
+  int idx = themes.indexOf( mCurrentTheme );
+  if ( idx > 0 )
+  {
+    mCurrentTheme = themes.at( idx - 1 );
+    emit updateComboBox();
+  }
+}
+
+void QgsThemeManagerWidget::nextTheme()
+{
+  QStringList themes = mThemeCollection->mapThemes();
+  int idx = 1 + themes.indexOf( mCurrentTheme );
+  if ( idx < themes.size() )
+  {
+    mCurrentTheme = themes.at( idx );
+    emit updateComboBox();
+  }
+}
+
+void QgsThemeManagerWidget::populateCombo()
+{
+  mThemeList->clear();
+  QStringList themes = QgsProject::instance()->mapThemeCollection()->mapThemes();
+  if ( !themes.isEmpty() )
+  {
+    mThemeList->addItems( themes );
+    if ( themes.contains( mCurrentTheme ) )
+      mThemeList->setCurrentText( mCurrentTheme );
+  }
+
+}
+
+void QgsThemeManagerWidget::updateComboBox()
+{
+  mThemeList->setCurrentText( mCurrentTheme );
+  viewCurrentTheme();
+}
+
+void QgsThemeManagerWidget::viewCurrentTheme() const
+{
+  if ( !mThemeCollection->hasMapTheme( mCurrentTheme ) )
+    return;
+  QStringList themeIds;
+  const QList<QgsMapLayer *> constMapThemeVisibleLayers = mThemeCollection->mapThemeVisibleLayers( mCurrentTheme );
+  for ( QgsMapLayer *layer : constMapThemeVisibleLayers )
+  {
+    if ( layer->isValid() && layer->isSpatial() )
+    {
+      themeIds << layer->id();
+    }
+  }
+  mThemeViewer->proxyModel()->setApprovedIds( themeIds );
+}
+
+
+void QgsThemeManagerWidget::appendLayers( const QList<QgsMapLayer *> &layers )
+{
+  if ( !mThemeCollection->hasMapTheme( mCurrentTheme ) )
+    return;
+
+  QgsMapThemeCollection::MapThemeRecord theme = mThemeCollection->mapThemeState( mCurrentTheme );
+  for ( QgsMapLayer *layer : std::as_const( layers ) )
+  {
+    QgsMapThemeCollection::MapThemeLayerRecord newRecord( layer );
+    theme.addLayerRecord( newRecord );
+  }
+  mThemeCollection->update( mCurrentTheme, theme );
+  viewCurrentTheme();
+}
+
+void QgsThemeManagerWidget::addSelectedLayers()
+{
+  const QList<QgsMapLayer *> &selectedLayers = QgisApp::instance()->layerTreeView()->selectedLayers();
+  appendLayers( selectedLayers );
+}
+
+void QgsThemeManagerWidget::removeSelectedLayers()
+{
+  const QList<QgsMapLayer *> &selectedLayers = mThemeViewer->selectedLayers();
+  removeThemeLayers( selectedLayers );
+}
+
+void QgsThemeManagerWidget::removeThemeLayers( const QList<QgsMapLayer *> &layers )
+{
+  if ( !mThemeCollection->hasMapTheme( mCurrentTheme ) )
+    return;
+  QgsMapThemeCollection::MapThemeRecord theme = mThemeCollection->mapThemeState( mCurrentTheme );
+  for ( QgsMapLayer *layer : std::as_const( layers ) )
+  {
+    theme.removeLayerRecord( layer );
+  }
+  mThemeCollection->update( mCurrentTheme, theme );
+  viewCurrentTheme();
+}
+
+void QgsThemeManagerWidget::changeVisibility()
+{
+  mShowAllLayers = !mShowAllLayers;
+  if ( mThemeViewer )
+    mThemeViewer->showAllNodes( mShowAllLayers );
+}
+
+void QgsThemeManagerWidget::showContextMenu( const QPoint &pos )
+{
+  QMenu *menu = new QMenu();
+  QAction *hideToggle = new QAction( tr( "Display layers only" ), this );
+  hideToggle->setCheckable( true );
+  hideToggle->setChecked( !mShowAllLayers );
+  menu->addAction( hideToggle );
+  connect( hideToggle, &QAction::triggered, this, [ = ]() { changeVisibility(); } );
+  menu->exec( mapToGlobal( pos ) );
+  delete menu;
+}
+
+
+

--- a/src/app/qgsthememanagerwidget.h
+++ b/src/app/qgsthememanagerwidget.h
@@ -1,0 +1,147 @@
+/***************************************************************************
+  qgsthememanagerwidget.h
+  --------------------------------------
+  Date                 : April 2021
+  Copyright            : (C) 2021 by Alex RL
+  Email                : ping me on github
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSTHEMEMANAGERWIDGET_H
+#define QGSTHEMEMANAGERWIDGET_H
+
+#include <QWidget>
+#include <QToolButton>
+#include <QComboBox>
+#include "qgsdockwidget.h"
+#include "qgslayertreeview.h"
+#include "ui_qgsthememanagerwidgetbase.h"
+
+
+class QgsMapThemeCollection;
+class QMimeData;
+class QgsThemeViewer;
+#define SIP_NO_FILE
+
+
+/**
+ * QgsThemeManagerWidget class: Used to display layers of selected themes in order to easily modify existing themes.
+ * \since QGIS 3.20
+ */
+
+class QgsThemeManagerWidget : public QgsDockWidget, private Ui::QgsThemeManagerWidgetBase
+{
+    Q_OBJECT
+  public:
+
+    //! Base constructor for the widget
+    QgsThemeManagerWidget( QWidget *parent = nullptr );
+
+  signals:
+
+    /**
+     * Used to call viewCurrentTheme
+     */
+    void themeChanged();
+
+    /**
+     * Used to add layers from the layertree to the theme
+     */
+    void addLayerTreeLayers();
+
+    /**
+     * Used to remove layers from the theme
+     */
+    void droppedLayers();
+
+  private slots:
+
+    /**
+     * Reset members to match current project.
+     */
+    void projectLoaded();
+
+    /**
+     * Used to catche the ComboBox signal
+     */
+    void setTheme( const int index );
+
+    /**
+     * Triggered by the previous theme button
+     */
+    void previousTheme();
+
+    /**
+     * Triggered by the next theme button
+     */
+    void nextTheme();
+
+    /**
+     * Populate the ComboBox to keep the list synched
+     */
+    void populateCombo();
+
+    /**
+     * Populate the ThemeViewer
+     */
+    void viewCurrentTheme() const;
+
+    /**
+     * Triggered by the all layer button
+     */
+    void addSelectedLayers();
+
+    /**
+     * Triggered by the remove layer button
+     */
+    void removeSelectedLayers();
+
+    /**
+     * Update the comboBox
+     */
+    void updateComboBox();
+
+    //! Show the widget
+    void showWidget();
+
+    //! Remove selected theme from the project
+    void removeTheme();
+
+    //! Create a new theme based on visible layers/nodes.
+    void createTheme();
+
+    //! right click menu
+    void showContextMenu( const QPoint &pos );
+
+    //! show or hide all non-spatial layers & empty groups, used by context menu.
+    void changeVisibility();
+
+  private:
+
+    /**
+     * Used by the tool or drag & drop from the main layertree
+     */
+    void appendLayers( const QList<QgsMapLayer *> &layers );
+
+    /**
+     * Used by the tool or drag & drop
+     */
+    void removeThemeLayers( const QList<QgsMapLayer *> &layers );
+
+    //! Intercept drags to prevent loss of information.
+    void startDrag( Qt::DropActions );
+
+    bool mShowAllLayers = false;
+    QString mCurrentTheme;
+    QgsMapThemeCollection *mThemeCollection = nullptr;
+
+};
+
+
+#endif

--- a/src/app/qgsthemeviewer.cpp
+++ b/src/app/qgsthemeviewer.cpp
@@ -1,0 +1,97 @@
+/***************************************************************************
+  qgsthemeviewer.cpp
+  --------------------------------------
+  Date                 : April 2021
+  Copyright            : (C) 2021 by Alex RL
+  Email                : ping me on github
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsthemeviewer.h"
+#include "qgsmaplayer.h"
+#include <QDrag>
+#include <QDragEnterEvent>
+#include <QContextMenuEvent>
+#include <QDropEvent>
+#include <QWidget>
+#include <QMimeData>
+#include <QSignalBlocker>
+#include <QCoreApplication>
+
+QgsThemeViewer::QgsThemeViewer( QWidget *parent )
+  : QgsLayerTreeView( parent )
+{
+}
+
+
+QStringList QgsThemeViewer::mimeTypes() const
+{
+  QStringList types;
+  types << QStringLiteral( "application/qgis.thememanagerdata" );
+  return types;
+}
+
+void QgsThemeViewer::dragEnterEvent( QDragEnterEvent *event )
+{
+  if ( event->mimeData()->hasFormat( QStringLiteral( "application/qgis.layertreemodeldata" ) ) )
+    event->acceptProposedAction();
+}
+
+void QgsThemeViewer::dropEvent( QDropEvent *event )
+{
+  if ( event->mimeData()->hasFormat( QStringLiteral( "application/qgis.layertreemodeldata" ) ) )
+    emit layersAdded();
+
+}
+
+Qt::DropActions QgsThemeViewer::supportedDropActions() const
+{
+  return Qt::CopyAction | Qt::LinkAction;
+}
+
+
+QMimeData *QgsThemeViewer::mimeData() const
+{
+  QMimeData *mimeData = new QMimeData();
+  QList<QgsMapLayer *> layers = selectedLayers();
+  //QList<QgsLayerTreeNode *> nodesFinal = indexes2nodes( sortedIndexes, true );
+
+  if ( layers.isEmpty() )
+    return mimeData;
+
+  QStringList ids;
+  for ( QgsMapLayer *layer : std::as_const( layers ) )
+  {
+    ids << layer->id().toUtf8();
+  }
+
+  mimeData->setData( QStringLiteral( "application/qgis.thememanagerdata" ), ids.join( "+" ).toUtf8() );
+  mimeData->setData( QStringLiteral( "application/qgis.application.pid" ), QString::number( QCoreApplication::applicationPid() ).toUtf8() );
+
+  return mimeData;
+}
+
+
+
+void QgsThemeViewer::startDrag( Qt::DropActions )
+{
+  QMimeData *mimeDat = mimeData();
+  QDrag *drag = new QDrag( this );
+  drag->setMimeData( mimeDat );
+
+  if ( !( drag->target() == this ) )
+    emit layersDropped();
+
+}
+
+void QgsThemeViewer::contextMenuEvent( QContextMenuEvent *event )
+{
+  emit showMenu( event->pos() );
+}
+

--- a/src/app/qgsthemeviewer.h
+++ b/src/app/qgsthemeviewer.h
@@ -1,0 +1,75 @@
+/***************************************************************************
+  qgsthemeviewer.h
+  --------------------------------------
+  Date                 : April 2021
+  Copyright            : (C) 2021 by Alex RL
+  Email                : ping me on github
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSTHEMEVIEWER_H
+#define QGSTHEMEVIEWER_H
+
+#include <QObject>
+#include <QWidget>
+#include "qgslayertreeview.h"
+
+class QMimeData;
+class QContextMenuEvent;
+
+/**
+ * QgsThemeViewe class: QgsLayerTreeView with custom drag & drop handling to interact with QgsThemeManagerWidget
+ * \since QGIS 3.20
+ */
+
+class QgsThemeViewer :  public QgsLayerTreeView
+{
+    Q_OBJECT
+  public:
+    explicit QgsThemeViewer( QWidget *parent = nullptr );
+
+    //! List supported drop actions
+    Qt::DropActions supportedDropActions() const;
+
+
+    //! Overridden setModel() from base class. Only QgsLayerTreeModel is an acceptable model.
+    //void setModel( QAbstractItemModel *model ) override;
+
+
+  signals:
+
+    //! Used by QgsThemeManagerWidget to trigger the import of layers
+    void layersAdded();
+
+    //! Used by QgsThemeManagerWidget to trigger the removal of layers
+    void layersDropped();
+
+    void showMenu( const QPoint &pos );
+
+  protected:
+    void contextMenuEvent( QContextMenuEvent *event ) override;
+
+  private:
+
+    QStringList mimeTypes() const;
+
+    QMimeData *mimeData() const;
+
+    void dragEnterEvent( QDragEnterEvent *event ) override;
+
+    //! Call emit layersAdded if drop incoming from the layers widget
+    void dropEvent( QDropEvent *event ) override;
+
+    //! Prevent any outdrag and loss of layers when attemptint to move or select them.
+    void startDrag( Qt::DropActions ) override;
+
+
+};
+
+#endif // QGSTHEMEVIEWER_H

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -32,7 +32,6 @@ class QgsMapLayer;
 class QgsMessageBar;
 class QgsLayerTreeFilterProxyModel;
 
-
 #include <QSortFilterProxyModel>
 
 /**
@@ -60,6 +59,12 @@ class GUI_EXPORT QgsLayerTreeProxyModel : public QSortFilterProxyModel
     void setFilterText( const QString &filterText = QString() );
 
     /**
+     * Sets a predefined list of layer Ids to process.
+     * \since QGIS 3.20
+     */
+    void setApprovedIds( const QStringList &ids );
+
+    /**
      * Returns if private layers are shown.
      */
     bool showPrivateLayers() const;
@@ -68,6 +73,13 @@ class GUI_EXPORT QgsLayerTreeProxyModel : public QSortFilterProxyModel
      * Determines if private layers are shown.
      */
     void setShowPrivateLayers( bool showPrivate );
+
+    /**
+     * Allow non-spatial layers and empty groups to be show.
+     * \param show If TRUE (default behavior), non-spatial layers and groups will be shown.
+     * \since QGIS 3.20
+     */
+    void setShowAllNodes( bool show );
 
   protected:
 
@@ -79,7 +91,10 @@ class GUI_EXPORT QgsLayerTreeProxyModel : public QSortFilterProxyModel
 
     QgsLayerTreeModel *mLayerTreeModel = nullptr;
     QString mFilterText;
+    QStringList mDesiredIds;
     bool mShowPrivateLayers = false;
+    bool mShowAllNodes = true;
+
 
 };
 
@@ -120,7 +135,10 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
     explicit QgsLayerTreeView( QWidget *parent SIP_TRANSFERTHIS = nullptr );
     ~QgsLayerTreeView() override;
 
-    //! Overridden setModel() from base class. Only QgsLayerTreeModel is an acceptable model.
+    /**
+     * Overridden setModel() from base class.
+     * \param model Model used to populate the view. Only QgsLayerTreeModel models are accepted.
+     */
     void setModel( QAbstractItemModel *model ) override;
 
     //! Gets access to the model casted to QgsLayerTreeModel
@@ -134,6 +152,12 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
      * \since QGIS 3.18
      */
     QgsLayerTreeProxyModel *proxyModel() const;
+
+    /**
+     * Disconnects the Proxy Model to prevent crash when using a second view on the same model.
+     * \since QGIS3.24
+     */
+    void disconnectProxyModel();
 
     /**
      * Returns layer tree node for given proxy model tree \a index. Returns root node for invalid index.
@@ -290,6 +314,13 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
      * \since QGIS 3.8
      */
     int layerMarkWidth() const { return mLayerMarkWidth; }
+
+    /**
+     * Allow non-spatial layers and empty groups to be show.
+     * \param show If TRUE (default behavior), non-spatial layers and groups will be shown.
+     * \since QGIS 3.20
+     */
+    void showAllNodes( bool show );
 
 ///@cond PRIVATE
 

--- a/src/ui/qgsthememanagerwidgetbase.ui
+++ b/src/ui/qgsthememanagerwidgetbase.ui
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsThemeManagerWidgetBase</class>
+ <widget class="QgsDockWidget" name="QgsThemeManagerWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>280</width>
+    <height>293</height>
+   </rect>
+  </property>
+  <property name="acceptDrops">
+   <bool>true</bool>
+  </property>
+  <property name="windowTitle">
+   <string>Theme Manager</string>
+  </property>
+  <widget class="QWidget" name="dockWidgetContents">
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <property name="spacing">
+     <number>0</number>
+    </property>
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
+    <item>
+     <layout class="QVBoxLayout" name="verticalLayout" stretch="0,6,0">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="sizeConstraint">
+       <enum>QLayout::SetMaximumSize</enum>
+      </property>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,5,0">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QToolButton" name="mThemePrev">
+          <property name="toolTip">
+           <string>Select previous theme</string>
+          </property>
+          <property name="text">
+           <string>...</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionAtlasPrev.svg</normaloff>:/images/themes/default/mActionAtlasPrev.svg</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="mThemeList">
+          <property name="toolTip">
+           <string>Select theme</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="mThemeNext">
+          <property name="toolTip">
+           <string>Select next theme</string>
+          </property>
+          <property name="text">
+           <string>...</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionAtlasNext.svg</normaloff>:/images/themes/default/mActionAtlasNext.svg</iconset>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QgsThemeViewer" name="mThemeViewer" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>72</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="dragEnabled" stdset="0">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QGridLayout" name="gridLayout">
+        <property name="horizontalSpacing">
+         <number>2</number>
+        </property>
+        <item row="0" column="2">
+         <widget class="QToolButton" name="mCreateTheme">
+          <property name="toolTip">
+           <string>Create New Theme</string>
+          </property>
+          <property name="text">
+           <string>...</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionNewReport.svg</normaloff>:/images/themes/default/mActionNewReport.svg</iconset>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QToolButton" name="mAddThemeLayer">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Import Selected Layers</string>
+          </property>
+          <property name="autoFillBackground">
+           <bool>true</bool>
+          </property>
+          <property name="text">
+           <string>Add</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionSharingImport.svg</normaloff>:/images/themes/default/mActionSharingImport.svg</iconset>
+          </property>
+          <property name="popupMode">
+           <enum>QToolButton::InstantPopup</enum>
+          </property>
+          <property name="toolButtonStyle">
+           <enum>Qt::ToolButtonIconOnly</enum>
+          </property>
+          <property name="autoRaise">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QToolButton" name="mRemoveThemeLayer">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Remove selected layers</string>
+          </property>
+          <property name="autoFillBackground">
+           <bool>true</bool>
+          </property>
+          <property name="text">
+           <string>Delete</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/mIconSelectRemove.svg</normaloff>:/images/themes/default/mIconSelectRemove.svg</iconset>
+          </property>
+          <property name="popupMode">
+           <enum>QToolButton::InstantPopup</enum>
+          </property>
+          <property name="toolButtonStyle">
+           <enum>Qt::ToolButtonIconOnly</enum>
+          </property>
+          <property name="autoRaise">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="3">
+         <widget class="QToolButton" name="mDeleteTheme">
+          <property name="toolTip">
+           <string>Delete Current Theme</string>
+          </property>
+          <property name="text">
+           <string>...</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionDeleteSelected.svg</normaloff>:/images/themes/default/mActionDeleteSelected.svg</iconset>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsDockWidget</class>
+   <extends>QDockWidget</extends>
+   <header>qgsdockwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsThemeViewer</class>
+   <extends>QWidget</extends>
+   <header>qgsthemeviewer.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
+ <connections/>
+</ui>


### PR DESCRIPTION
## Description
As proposed in https://github.com/qgis/QGIS-Enhancement-Proposals/issues/211

As discussed the goal of this is to provide a better interface to interact with existing themes and their content to sort out errors and easily correct them without going the select->modify->replace route

The widget has theme browsing arrows and combo-box at the top, a dedicated layertreeview in the center and buttons to import, remove layers and to create and delete themes.

The import and remove buttons are voluntarily bigger as they should be more commonly used.

![theme_manager](https://user-images.githubusercontent.com/12854129/113455453-a5dee780-93d8-11eb-97ee-16879f6662a6.PNG)

GIF showcase (forgot to show the context menu to unhide non-layer items)
![theme_manager](https://user-images.githubusercontent.com/12854129/115561081-38113780-a283-11eb-9482-4a36dd5f7c19.gif)
### Here is a list of the changes and their reasons:
#### QgsMapThemes: 

-  Exposed the addPreset slot to use the existing dialog when creating a new theme

#### QgsLayerTreeViewer:

- Added fid based filtering to the QgsLayerTreeProxyModel, needed to only display layers within a theme

#### QgsThemeViewer:

-  Customized QgsLayerTreeView with specific dedicated drag&drop behaviour, had to be made separate to prevent circular dependencies.
-  Added custom slot handling to add selected layers from the layer view to the current theme
- Added custom code to prevent moving/remove layer from the project via bad transfer, prevent drag and drop and ease selection of layers.
- Also allow the control of layers (display or not, etc) from the widget to inspect elements. But does not allow reordering ( to prevent drag and drop issues).

#### QgsThemeManagerWidget:

- Base class with the logic and widgets
- Browse existing themes
- Add selected layers to a theme via drag & drop or with the 'import' button
- Remove selected layer from a theme
- Create new theme from current view (see changes in QgsMapTheme)
- Delete current theme

#### QgsLayerTreeView
 - Added a variable to the setModel method, otherwise multiple view connected to the same model would crash the model when a row was added as the secondary view would fetch invalid data to populate another row.
