### PR TITLE
[Backport release-3_16] Fill QgsNetworkReplyContent.content() on HTTP error

### DIFF
--- a/src/core/qgsblockingnetworkrequest.cpp
+++ b/src/core/qgsblockingnetworkrequest.cpp
@@ -383,6 +383,7 @@ void QgsBlockingNetworkRequest::replyFinished()
         QgsMessageLog::logMessage( mErrorMessage, tr( "Network" ) );
       }
       mReplyContent = QgsNetworkReplyContent( mReply );
+      mReplyContent.setContent( mReply->readAll() );
     }
   }
   if ( mTimedout )

--- a/tests/src/python/test_qgsblockingnetworkrequest.py
+++ b/tests/src/python/test_qgsblockingnetworkrequest.py
@@ -73,7 +73,7 @@ class TestQgsBlockingNetworkRequest(unittest.TestCase):
         self.assertIn('File not found', request.errorMessage())
         reply = request.reply()
         self.assertEqual(reply.error(), QNetworkReply.ContentNotFoundError)
-        self.assertFalse(reply.content())
+        self.assertEqual(reply.content(), '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"\n        "http://www.w3.org/TR/html4/strict.dtd">\n<html>\n    <head>\n        <meta http-equiv="Content-Type" content="text/html;charset=utf-8">\n        <title>Error response</title>\n    </head>\n    <body>\n        <h1>Error response</h1>\n        <p>Error code: 404</p>\n        <p>Message: File not found.</p>\n        <p>Error code explanation: HTTPStatus.NOT_FOUND - Nothing matches the given URI.</p>\n    </body>\n</html>\n')
 
     def testGet(self):
         request = QgsBlockingNetworkRequest()


### PR DESCRIPTION
## Description

Backport of https://github.com/qgis/QGIS/pull/42553