### PR TITLE
[Bugfix] geometry engine::main_angle : promote longer box in case of tie

### DIFF
--- a/resources/function_help/json/main_angle
+++ b/resources/function_help/json/main_angle
@@ -2,7 +2,7 @@
   "name": "main_angle",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description":"Returns the main angle of a geometry (clockwise, in degrees from North), which represents the angle of the oriented minimal bounding rectangle which completely covers the geometry.",
+  "description":"Returns the angle of the long axis (clockwise, in degrees from North) of the oriented minimal bounding rectangle, which completely covers the geometry.",
   "arguments": [ {"arg":"geometry","description":"a geometry"} ],
   "examples": [ { "expression":"main_angle(geom_from_wkt('Polygon ((321577 129614, 321581 129618, 321585 129615, 321581 129610, 321577 129614))'))", "returns":"38.66"}]
 }

--- a/src/core/geometry/qgsinternalgeometryengine.cpp
+++ b/src/core/geometry/qgsinternalgeometryengine.cpp
@@ -1507,7 +1507,7 @@ QgsGeometry QgsInternalGeometryEngine::orientedMinimumBoundingBox( double &area,
   {
     width = minRect.height();
     height = minRect.width();
-    angle = angle + 90;
+    angle = angle + 90.0;
   }
 
   QgsGeometry minBounds = QgsGeometry::fromRect( minRect );

--- a/src/core/geometry/qgsinternalgeometryengine.cpp
+++ b/src/core/geometry/qgsinternalgeometryengine.cpp
@@ -1505,8 +1505,8 @@ QgsGeometry QgsInternalGeometryEngine::orientedMinimumBoundingBox( double &area,
 
   if ( width > height )
   {
-    width = bounds.height();
-    height = bounds.width();
+    width = minRect.height();
+    height = minRect.width();
     angle = angle + 90;
   }
 

--- a/src/core/geometry/qgsinternalgeometryengine.cpp
+++ b/src/core/geometry/qgsinternalgeometryengine.cpp
@@ -1491,7 +1491,7 @@ QgsGeometry QgsInternalGeometryEngine::orientedMinimumBoundingBox( double &area,
 
     QgsRectangle bounds = hull->boundingBox();
     double currentArea = bounds.width() * bounds.height();
-    if ( currentArea  < area || ( qgsDoubleNear( currentArea, area, currentArea * 0.0000000001 ) && height < bounds.height() ) )
+    if ( currentArea  < area )
     {
       minRect = bounds;
       area = currentArea;
@@ -1501,6 +1501,13 @@ QgsGeometry QgsInternalGeometryEngine::orientedMinimumBoundingBox( double &area,
     }
 
     pt1 = hull->vertexAt( vertexId );
+  }
+
+  if ( width > height )
+  {
+    width = bounds.height();
+    height = bounds.width();
+    angle = angle + 90;
   }
 
   QgsGeometry minBounds = QgsGeometry::fromRect( minRect );

--- a/src/core/geometry/qgsinternalgeometryengine.cpp
+++ b/src/core/geometry/qgsinternalgeometryengine.cpp
@@ -1491,7 +1491,7 @@ QgsGeometry QgsInternalGeometryEngine::orientedMinimumBoundingBox( double &area,
 
     QgsRectangle bounds = hull->boundingBox();
     double currentArea = bounds.width() * bounds.height();
-    if ( currentArea  < area || ( qgsDoubleNear(currentArea, area, currentArea * 0.0000000001 ) && height < bounds.height() ) )
+    if ( currentArea  < area || ( qgsDoubleNear( currentArea, area, currentArea * 0.0000000001 ) && height < bounds.height() ) )
     {
       minRect = bounds;
       area = currentArea;

--- a/src/core/geometry/qgsinternalgeometryengine.cpp
+++ b/src/core/geometry/qgsinternalgeometryengine.cpp
@@ -1491,7 +1491,7 @@ QgsGeometry QgsInternalGeometryEngine::orientedMinimumBoundingBox( double &area,
 
     QgsRectangle bounds = hull->boundingBox();
     double currentArea = bounds.width() * bounds.height();
-    if ( currentArea  < area )
+    if ( currentArea  < area || ( qgsDoubleNear(currentArea, area, currentArea * 0.0000000001 ) && height < bounds.height() ) )
     {
       minRect = bounds;
       area = currentArea;

--- a/src/core/geometry/qgsinternalgeometryengine.h
+++ b/src/core/geometry/qgsinternalgeometryengine.h
@@ -199,7 +199,7 @@ class QgsInternalGeometryEngine
     /**
      * Returns the oriented minimum bounding box for the geometry, which is the smallest (by area)
      * rotated rectangle which fully encompasses the geometry.
-     * The area, angle of the longest axis (clockwise in degrees from North),
+     * The area, angle of the long axis (clockwise in degrees from North),
      * width and height of the rotated bounding box will also be returned.
      *
      * If an error was encountered while creating the result, more information can be retrieved

--- a/src/core/geometry/qgsinternalgeometryengine.h
+++ b/src/core/geometry/qgsinternalgeometryengine.h
@@ -198,7 +198,8 @@ class QgsInternalGeometryEngine
 
     /**
      * Returns the oriented minimum bounding box for the geometry, which is the smallest (by area)
-     * rotated rectangle which fully encompasses the geometry. The area, angle (clockwise in degrees from North),
+     * rotated rectangle which fully encompasses the geometry.
+     * The area, angle of the longest axis (clockwise in degrees from North),
      * width and height of the rotated bounding box will also be returned.
      *
      * If an error was encountered while creating the result, more information can be retrieved

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1295,6 +1295,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "m_min line M NaN" ) << "m_min(make_line(geom_from_wkt('PointZM (0 0 0 nan)'),geom_from_wkt('PointZM (1 1 1 2)')))" << false << QVariant( );
       QTest::newRow( "m_min line" ) << "m_min(make_line(make_point_m(0,0,1),make_point_m(-1,-1,2),make_point_m(-2,-2,0)))" << false << QVariant( 0.0 );
       QTest::newRow( "main angle polygon" ) << "round(main_angle( geom_from_wkt('POLYGON((0 0,2 9,9 2,0 0))')))" << false << QVariant( 77 );
+      QTest::newRow( "main angle polygon edge case" ) << "round(main_angle( geom_from_wkt('POLYGON((353542.63843526 378974.92373469, 353544.95808017 378975.73690545, 353545.27173175 378974.84218528, 353542.95208684 378974.02901451, 353542.63843526 378974.92373469))')))" << false << QVariant( 71 );
       QTest::newRow( "main angle multi polygon" ) << "round(main_angle( geom_from_wkt('MULTIPOLYGON(((0 0,3 10,1 10,1 6,0 0)))')))" << false << QVariant( 17 );
       QTest::newRow( "main angle point" ) << "main_angle( geom_from_wkt('POINT (1.5 0.5)') )" << true << QVariant();
       QTest::newRow( "main angle line" ) << "round(main_angle( geom_from_wkt('LINESTRING (-1 2, 9 12)') ))" << false << QVariant( 45 );


### PR DESCRIPTION
## Description

Fixes #41022 

Takes into account the length of the bounding box when comparing results of similar area. A minimal relative epsilon was used, below that comparisong doesn't work. Could be upped if needed.

The 'bug' occured since it went from the first vertex, and if the result was optimal, it kept the same, resulting in the inconsistent results presented in the issue ticket.