### PR TITLE
Prepare Jenks set without using randomisation

### DIFF
--- a/src/core/classification/qgsclassificationjenks.cpp
+++ b/src/core/classification/qgsclassificationjenks.cpp
@@ -77,6 +77,7 @@ QList<double> QgsClassificationJenks::calculateBreaks( double &minimum, double &
   }
 
   QVector<double> sample;
+  QVector<double> sorted;
 
   // if we have lots of values, we need to take a random sample
   if ( values.size() > mMaximumSize )
@@ -93,18 +94,22 @@ QList<double> QgsClassificationJenks::calculateBreaks( double &minimum, double &
     sample[ 0 ] = minimum;
     sample[ 1 ] = maximum;
 
-    for ( int i = 2; i < sample.size(); i++ )
-    {
-      // pick a random integer from 0 to n
+    sorted = values.toVector();
+    std::sort( sorted.begin(), sorted.end() );
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-      double r = QRandomGenerator::global()->generate();
-      int j = std::floor( r / QRandomGenerator::max() * ( values.size() - 1 ) );
-#else
-      double r = qrand();
-      int j = std::floor( r / RAND_MAX * ( values.size() - 1 ) );
-#endif
-      sample[ i ] = values[ j ];
+    int j = -1;
+
+    // loop through all values in initial array
+    // skip the first value as it is a minimum one
+    // skip the last value as that one is a maximum one
+    // and those are already in the sample as items 0 and 1
+    for ( int i = 1; i < sorted.size() - 2; i++ )
+    {
+      if ( ( i * ( mMaximumSize - 2 ) / ( sorted.size() - 2 ) ) > j )
+      {
+        j++;
+        sample[ j + 2 ] = sorted[ i ];
+      }
     }
   }
   else

--- a/tests/src/python/test_qgsclassificationmethod.py
+++ b/tests/src/python/test_qgsclassificationmethod.py
@@ -11,10 +11,11 @@ __date__ = '3/09/2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
 
 import qgis  # NOQA
+import random
 
 from qgis.PyQt.QtCore import QLocale
 from qgis.testing import unittest, start_app
-from qgis.core import QgsClassificationMethod, QgsClassificationLogarithmic, QgsFeature, QgsVectorLayer, QgsPointXY, \
+from qgis.core import QgsClassificationMethod, QgsClassificationLogarithmic, QgsClassificationJenks, QgsFeature, QgsVectorLayer, QgsPointXY, \
     QgsGeometry
 
 start_app()
@@ -84,6 +85,34 @@ class TestQgsClassificationMethods(unittest.TestCase):
         r = m.classes(vl, 'value', 4)
         self.assertEqual(r[0].label(), '-2 - 10^0')
         self.assertEqual(QgsClassificationMethod.rangesToBreaks(r), [1.0, 10.0, 100.0, 1000.0, 10000.0])
+
+    def testQgsClassificationJenksSimple(self):
+        # This is a simple Natural Breaks Jenks test checking if simple calculation can be done
+        # when number of values is below 3000 (value hardcoded in qgsclassificationjenks.h)
+        # And if returned values are consistent (the same as at the time of creation of this test)
+        values = [-33, -41, -43, 16, 29, 9, -35, 57, 26, -30]
+        vl = createMemoryLayer(values)
+        m = QgsClassificationJenks()
+
+        r = m.classes(vl, 'value', 4)
+        self.assertEqual(len(r), 4)
+        self.assertEqual(QgsClassificationMethod.rangesToBreaks(r),
+                         [-30.0, 16.0, 29.0, 57.0])
+
+    def testQgsClassificationJenksHighNumber(self):
+        # This test checks if Jenkis classification does not crash when number of
+        # values in a set is higher than 3000 (value hardcoded in qgsclassificationjenks.h)
+        # And if returned values are consistent (the same as at the time of creation of this test)
+        random.seed(42*42);
+        values = [random.randint(-1000, 1000) for _ in range(5000)]
+        vl = createMemoryLayer(values)
+        m = QgsClassificationJenks()
+
+        r = m.classes(vl, 'value', 4)
+        print('result high=',QgsClassificationMethod.rangesToBreaks(r))
+        self.assertEqual(len(r), 4)
+        self.assertEqual(QgsClassificationMethod.rangesToBreaks(r),
+                         [-506.0, -4.0, 499.0, 1000.0])
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsclassificationmethod.py
+++ b/tests/src/python/test_qgsclassificationmethod.py
@@ -103,13 +103,12 @@ class TestQgsClassificationMethods(unittest.TestCase):
         # This test checks if Jenkis classification does not crash when number of
         # values in a set is higher than 3000 (value hardcoded in qgsclassificationjenks.h)
         # And if returned values are consistent (the same as at the time of creation of this test)
-        random.seed(42*42);
+        random.seed(42 * 42)
         values = [random.randint(-1000, 1000) for _ in range(5000)]
         vl = createMemoryLayer(values)
         m = QgsClassificationJenks()
 
         r = m.classes(vl, 'value', 4)
-        print('result high=',QgsClassificationMethod.rangesToBreaks(r))
         self.assertEqual(len(r), 4)
         self.assertEqual(QgsClassificationMethod.rangesToBreaks(r),
                          [-506.0, -4.0, 499.0, 1000.0])


### PR DESCRIPTION
## Shot description

Current Natural Breaks (Jenks) classification is using randomisation to prepare the set for calculation. This PR makes it deterministic.

## Long description

Current Natural Breaks (Jenks) classification is going through two steps:
* Preparing a set for calculation
* Doing the calculation

Calculation step is **not** impacted by this PR.
This PR is only altering the preparation step. And only the case when number of values in initial set is above the _mMaximumSize_ (which is currently defined as 3000).

### Problems of current implementation

These are the problems with Jenks classification of sets with more values than _mMaximumSize_ (3000):
* randomisation is used, therefore the result is not deterministic, each time you ask QGIS to classify it comes up with a different result
* the size of a set is calculated as _mMaximumSize_ or 10% of initial set, whichever is larger. This means that for an initial set larger than _mMaximumSize_*10 (30000) resulting set will be larger than defined _mMaximumSize_. For example if initial set is 1M values, a set for calculation will be 100000, way larger than 3000 and will take a looooong time to compute.
* values for the calculation set are chosen from initial set randomly, meaning that the same value can be added more than once while more values will be missed. For example if initial set is 3001 values, 3000 will be chosen as the size of a calculation set, but those values will be picked by random function, therefore while in principal only one value should be skipped, actually a lot of values will be added more than once and a lot of values will be skipped. Giving less correct result.

## Suggested implementation

Suggested solution is to skip randomisation and always chose the _mMaximumSize_ values (we're talking about the case when initial set is larger than _mMaximumSize_) from sorted initial set by proportionally spreading the values chosen. For example if initial set is twice as large as _mMaximumSize_, the values chosen will be 1, 3, 5 etc. If initial set is 50% larger, the values chosen will be 1, 2, 4, 5, 7, 8 etc.

Therefore:
* results are deterministic (recalculation does not change the result)
* complexity of final calculation is actually controlled by _mMaximumSize_
* more representative set is prepared for calculation giving better final results