### PR TITLE
Fix digitizing polygons with curves

### DIFF
--- a/src/app/qgsmaptooladdcircularstring.cpp
+++ b/src/app/qgsmaptooladdcircularstring.cpp
@@ -144,8 +144,8 @@ void QgsMapToolAddCircularString::activate()
         {
           //mParentTool->captureCurve() is in layer coordinates, but we need map coordinates
           QgsPoint endPointLayerCoord = curve->endPoint();
-          QgsPointXY mapPoint = toMapCoordinates( mCanvas->currentLayer(), QgsPointXY( endPointLayerCoord.x(), endPointLayerCoord.y() ) );
-          mPoints.append( QgsPoint( mapPoint ) );
+          QgsPoint mapPoint = toMapCoordinates( mCanvas->currentLayer(),  endPointLayerCoord );
+          mPoints.append( mapPoint );
           if ( !mTempRubberBand )
           {
             mTempRubberBand = createGeometryRubberBand( mLayerType, true );

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -633,7 +633,7 @@ int QgsMapToolCapture::addVertex( const QgsPointXY &point, const QgsPointLocator
         mCaptureLastPoint = mapPoint;
         mTempRubberBand->reset( mCaptureMode == CapturePolygon ? QgsWkbTypes::PolygonGeometry : QgsWkbTypes::LineGeometry, mDigitizingType, firstCapturedMapPoint() );
       }
-      else if ( mCaptureCurve.numPoints() == 0 )
+      else if ( mTempRubberBand->pointsCount() == 0 )
       {
         mCaptureLastPoint = mapPoint;
         mCaptureCurve.addVertex( layerPoint );


### PR DESCRIPTION
fix #42626.
Indeed a case was not covered : when `mCaptureCurve` isn't void and this is the first digitized point.
That happens when you digitize after adding a curve string with the old tool add curve string.
with this PR, the test on `mTempRubberBand` cover do the job: the rubber band is void even after adding a curve string with the old tool.
