### PR TITLE
Open a specific page in the layer properties dialog using the iface instance

### DIFF
--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -1140,7 +1140,40 @@ Removes the specified ``dock`` widget from main window (without deleting it).
 
     virtual void showLayerProperties( QgsMapLayer *l, const QString &page = QString() ) = 0;
 %Docstring
-Open layer properties dialog
+Opens layer properties dialog for the layer ``l``.
+Optionally, a ``page`` to open can be specified (since QGIS 3.20).
+The list below contains valid page names:
+
+Vector Layer:
+mOptsPage_Information, mOptsPage_Source, mOptsPage_Style, mOptsPage_Labels,
+mOptsPage_Masks, mOptsPage_Diagrams, mOptsPage_SourceFields, mOptsPage_AttributesForm,
+mOptsPage_Joins, mOptsPage_AuxiliaryStorage, mOptsPage_Actions, mOptsPage_Display,
+mOptsPage_Rendering, mOptsPage_Temporal, mOptsPage_Variables, mOptsPage_Metadata,
+mOptsPage_DataDependencies, mOptsPage_Legend, mOptsPage_Server
+
+Raster Layer:
+mOptsPage_Information, mOptsPage_Source, mOptsPage_Style, mOptsPage_Transparency,
+mOptsPage_Histogram, mOptsPage_Rendering, mOptsPage_Temporal, mOptsPage_Pyramids,
+mOptsPage_Metadata, mOptsPage_Legend, mOptsPage_Server
+
+Mesh Layer:
+mOptsPage_Information, mOptsPage_Source, mOptsPage_Style, mOptsPage_StyleContent,
+mOptsPage_Rendering, mOptsPage_Temporal, mOptsPage_Metadata
+
+Point Cloud Layer:
+mOptsPage_Information, mOptsPage_Source, mOptsPage_Metadata, mOptsPage_Statistics
+
+Vector Tile Layer:
+mOptsPage_Information, mOptsPage_Style, mOptsPage_Labeling, mOptsPage_Metadata
+
+.. note::
+
+   Page names are subject to change without notice between QGIS versions,
+   and that the tab names themselves aren't considered part of the stable API.
+
+.. note::
+
+   More strings may be available depending on the context, e.g. via plugins.
 %End
 
     virtual QDialog *showAttributeTable( QgsVectorLayer *l, const QString &filterExpression = QString() ) = 0;

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -1138,7 +1138,7 @@ Removes the specified ``dock`` widget from main window (without deleting it).
 .. seealso:: :py:func:`addDockWidget`
 %End
 
-    virtual void showLayerProperties( QgsMapLayer *l ) = 0;
+    virtual void showLayerProperties( QgsMapLayer *l, const QString &page = QString() ) = 0;
 %Docstring
 Open layer properties dialog
 %End

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -1169,7 +1169,7 @@ mOptsPage_Information, mOptsPage_Style, mOptsPage_Labeling, mOptsPage_Metadata
 .. note::
 
    Page names are subject to change without notice between QGIS versions,
-   and that the tab names themselves aren't considered part of the stable API.
+   they are not considered part of the stable API.
 
 .. note::
 

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -497,11 +497,11 @@ QgsAdvancedDigitizingDockWidget *QgisAppInterface::cadDockWidget()
   return qgis->cadDockWidget();
 }
 
-void QgisAppInterface::showLayerProperties( QgsMapLayer *l )
+void QgisAppInterface::showLayerProperties( QgsMapLayer *l, const QString &page )
 {
   if ( l && qgis )
   {
-    qgis->showLayerProperties( l );
+    qgis->showLayerProperties( l, page );
   }
 }
 

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -137,7 +137,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     void addTabifiedDockWidget( Qt::DockWidgetArea area, QDockWidget *dockwidget, const QStringList &tabifyWith = QStringList(), bool raiseTab = false ) override;
     void removeDockWidget( QDockWidget *dockwidget ) override;
     QgsAdvancedDigitizingDockWidget *cadDockWidget() override;
-    void showLayerProperties( QgsMapLayer *l ) override;
+    void showLayerProperties( QgsMapLayer *l, const QString &page = QString() ) override;
     QDialog *showAttributeTable( QgsVectorLayer *l, const QString &filterExpression = QString() ) override;
     void addWindow( QAction *action ) override;
     void removeWindow( QAction *action ) override;

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -999,7 +999,7 @@ class GUI_EXPORT QgisInterface : public QObject
      * mOptsPage_Information, mOptsPage_Style, mOptsPage_Labeling, mOptsPage_Metadata
      *
      * \note Page names are subject to change without notice between QGIS versions,
-     * and that the tab names themselves aren't considered part of the stable API.
+     * they are not considered part of the stable API.
      *
      * \note More strings may be available depending on the context, e.g. via plugins.
      */

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -971,7 +971,38 @@ class GUI_EXPORT QgisInterface : public QObject
      */
     virtual void removeDockWidget( QDockWidget *dockwidget ) = 0;
 
-    //! Open layer properties dialog
+    /**
+     * Opens layer properties dialog for the layer \a l.
+     * Optionally, a \a page to open can be specified (since QGIS 3.20).
+     * The list below contains valid page names:
+     *
+     * Vector Layer:
+     * mOptsPage_Information, mOptsPage_Source, mOptsPage_Style, mOptsPage_Labels,
+     * mOptsPage_Masks, mOptsPage_Diagrams, mOptsPage_SourceFields, mOptsPage_AttributesForm,
+     * mOptsPage_Joins, mOptsPage_AuxiliaryStorage, mOptsPage_Actions, mOptsPage_Display,
+     * mOptsPage_Rendering, mOptsPage_Temporal, mOptsPage_Variables, mOptsPage_Metadata,
+     * mOptsPage_DataDependencies, mOptsPage_Legend, mOptsPage_Server
+     *
+     * Raster Layer:
+     * mOptsPage_Information, mOptsPage_Source, mOptsPage_Style, mOptsPage_Transparency,
+     * mOptsPage_Histogram, mOptsPage_Rendering, mOptsPage_Temporal, mOptsPage_Pyramids,
+     * mOptsPage_Metadata, mOptsPage_Legend, mOptsPage_Server
+     *
+     * Mesh Layer:
+     * mOptsPage_Information, mOptsPage_Source, mOptsPage_Style, mOptsPage_StyleContent,
+     * mOptsPage_Rendering, mOptsPage_Temporal, mOptsPage_Metadata
+     *
+     * Point Cloud Layer:
+     * mOptsPage_Information, mOptsPage_Source, mOptsPage_Metadata, mOptsPage_Statistics
+     *
+     * Vector Tile Layer:
+     * mOptsPage_Information, mOptsPage_Style, mOptsPage_Labeling, mOptsPage_Metadata
+     *
+     * \note Page names are subject to change without notice between QGIS versions,
+     * and that the tab names themselves aren't considered part of the stable API.
+     *
+     * \note More strings may be available depending on the context, e.g. via plugins.
+     */
     virtual void showLayerProperties( QgsMapLayer *l, const QString &page = QString() ) = 0;
 
     //! Open attribute table dialog

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -972,7 +972,7 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual void removeDockWidget( QDockWidget *dockwidget ) = 0;
 
     //! Open layer properties dialog
-    virtual void showLayerProperties( QgsMapLayer *l ) = 0;
+    virtual void showLayerProperties( QgsMapLayer *l, const QString &page = QString() ) = 0;
 
     //! Open attribute table dialog
     virtual QDialog *showAttributeTable( QgsVectorLayer *l, const QString &filterExpression = QString() ) = 0;


### PR DESCRIPTION
Everyone can enjoy a call like this:
```
from qgis.core import Qgis
from qgis.utils import iface

if Qgis.QGIS_VERSION_INT >= 32000:
    iface.showLayerProperties(iface.activeLayer(), 'mOptsPage_Style')
else:
    iface.showLayerProperties(iface.activeLayer())
```