### PR TITLE
[QgsQuick] An extra option to edit a text field

### DIFF
--- a/src/quickgui/attributes/qgsquickattributeformmodelbase.cpp
+++ b/src/quickgui/attributes/qgsquickattributeformmodelbase.cpp
@@ -99,6 +99,7 @@ void QgsQuickAttributeFormModelBase::setAttributeModel( QgsQuickAttributeModel *
     disconnect( mAttributeModel, &QgsQuickAttributeModel::layerChanged, this, &QgsQuickAttributeFormModelBase::onLayerChanged );
     disconnect( mAttributeModel, &QgsQuickAttributeModel::featureChanged, this, &QgsQuickAttributeFormModelBase::onFeatureChanged );
     disconnect( mAttributeModel, &QgsQuickAttributeModel::modelReset, this, &QgsQuickAttributeFormModelBase::onFeatureChanged );
+    disconnect( mAttributeModel, &QgsQuickAttributeModel::dataChangedFailed, this, &QgsQuickAttributeFormModelBase::dataChangedFailed );
   }
 
   mAttributeModel = attributeModel;
@@ -108,6 +109,7 @@ void QgsQuickAttributeFormModelBase::setAttributeModel( QgsQuickAttributeModel *
     connect( mAttributeModel, &QgsQuickAttributeModel::layerChanged, this, &QgsQuickAttributeFormModelBase::onLayerChanged );
     connect( mAttributeModel, &QgsQuickAttributeModel::featureChanged, this, &QgsQuickAttributeFormModelBase::onFeatureChanged );
     connect( mAttributeModel, &QgsQuickAttributeModel::modelReset, this, &QgsQuickAttributeFormModelBase::onFeatureChanged );
+    connect( mAttributeModel, &QgsQuickAttributeModel::dataChangedFailed, this, &QgsQuickAttributeFormModelBase::dataChangedFailed );
   }
 
   emit attributeModelChanged();

--- a/src/quickgui/attributes/qgsquickattributeformmodelbase.h
+++ b/src/quickgui/attributes/qgsquickattributeformmodelbase.h
@@ -123,6 +123,8 @@ class QgsQuickAttributeFormModelBase : public QStandardItemModel
     void constraintsHardValidChanged();
     //! \copydoc QgsQuickAttributeFormModelBase::constraintsSoftValid
     void constraintsSoftValidChanged();
+    //! Emitted when setData failed
+    void dataChangedFailed( const QString &message );
 
   private slots:
     void onFeatureChanged();

--- a/src/quickgui/attributes/qgsquickattributemodel.cpp
+++ b/src/quickgui/attributes/qgsquickattributemodel.cpp
@@ -181,7 +181,10 @@ bool QgsQuickAttributeModel::setData( const QModelIndex &index, const QVariant &
 
       if ( !fld.convertCompatible( val ) )
       {
-        QgsMessageLog::logMessage( tr( "Value \"%1\" %4 could not be converted to a compatible value for field %2(%3)." ).arg( value.toString(), fld.name(), fld.typeName(), value.isNull() ? "NULL" : "NOT NULL" ) );
+        QString msg( tr( "Value \"%1\" %4 could not be converted to a compatible value for field %2(%3)." ).arg( value.toString(), fld.name(), fld.typeName(), value.isNull() ? "NULL" : "NOT NULL" ) );
+        QString userFriendlyMsg( tr( "Value %1 is not compatible with field type %2." ).arg( value.toString(), fld.typeName() ) );
+        QgsMessageLog::logMessage( msg );
+        emit dataChangedFailed( userFriendlyMsg );
         return false;
       }
       bool success = mFeatureLayerPair.featureRef().setAttribute( index.row(), val );

--- a/src/quickgui/attributes/qgsquickattributemodel.h
+++ b/src/quickgui/attributes/qgsquickattributemodel.h
@@ -164,6 +164,9 @@ class QUICK_EXPORT QgsQuickAttributeModel : public QAbstractListModel
     //! Emitted when user allows reusing last entered values
     void rememberValuesAllowChanged();
 
+    //! Emitted when setData failed
+    void dataChangedFailed( const QString &message );
+
   protected:
     //! Commits model changes
     bool commit();

--- a/src/quickgui/plugin/editor/qgsquicktextedit.qml
+++ b/src/quickgui/plugin/editor/qgsquicktextedit.qml
@@ -109,7 +109,7 @@ Item {
     // Icon
     Item {
       id: importDataBtn
-      visible: supportDataImport
+      visible: supportsDataImport
       anchors.right: parent.right
       anchors.verticalCenter: parent.verticalCenter
       anchors.rightMargin: customStyle.fields.sideMargin

--- a/src/quickgui/plugin/editor/qgsquicktextedit.qml
+++ b/src/quickgui/plugin/editor/qgsquicktextedit.qml
@@ -17,6 +17,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QgsQuick 0.1 as QgsQuick
 import QtQuick.Layouts 1.3
+import QtGraphicalEffects 1.0
 
 /**
  * Text Edit for QGIS Attribute Form
@@ -25,6 +26,9 @@ import QtQuick.Layouts 1.3
  */
 Item {
   signal valueChanged(var value, bool isNull)
+  signal importDataRequested()
+  property var rowHeight: customStyle.fields.height * 0.75
+  property real iconSize: rowHeight
 
   id: fieldItem
   enabled: !readOnly
@@ -40,6 +44,8 @@ Item {
     height: textArea.height == 0 ? customStyle.fields.height : 0
     topPadding: 10 * QgsQuick.Utils.dp
     bottomPadding: 10 * QgsQuick.Utils.dp
+    leftPadding: customStyle.fields.sideMargin
+    rightPadding: textField.leftPadding + (importDataBtn.visible ? importDataBtn.width : 0)
     visible: height !== 0
     anchors.left: parent.left
     anchors.right: parent.right
@@ -79,6 +85,8 @@ Item {
     height: config['IsMultiline'] === true ? undefined : 0
     topPadding: customStyle.fields.height * 0.25
     bottomPadding: customStyle.fields.height * 0.25
+    leftPadding: customStyle.fields.sideMargin
+    rightPadding: textArea.leftPadding + (importDataBtn.visible ? importDataBtn.width : 0)
     visible: height !== 0
     anchors.left: parent.left
     anchors.right: parent.right
@@ -94,8 +102,49 @@ Item {
     }
 
     onEditingFinished: {
-      valueChanged( text, text == '' )
+        valueChanged( text, text == '' )
+      }
     }
-  }
 
+    // Icon
+    Item {
+      id: importDataBtn
+      visible: supportDataImport
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+      anchors.rightMargin: customStyle.fields.sideMargin
+
+      property int borderWidth: 50 * QgsQuick.Utils.dp
+      width: fieldItem.iconSize
+      height: width
+      antialiasing: true
+
+      MouseArea {
+        anchors.fill: parent
+        onClicked: {
+          fieldItem.importDataRequested()
+        }
+      }
+
+      Image {
+        id: importDataBtnIcon
+        height: fieldItem.iconSize
+        sourceSize.height: fieldItem.iconSize
+        autoTransform: true
+        fillMode: Image.PreserveAspectFit
+        source: customStyle.icons.importData
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        visible: fieldItem.enabled
+        anchors.rightMargin: fieldItem.anchors.rightMargin
+      }
+
+      ColorOverlay {
+        anchors.fill: importDataBtnIcon
+        anchors.centerIn: parent
+        source: importDataBtnIcon
+        color: customStyle.fields.fontColor
+        smooth: true
+      }
+    }
 }

--- a/src/quickgui/plugin/qgsquickfeatureform.qml
+++ b/src/quickgui/plugin/qgsquickfeatureform.qml
@@ -114,15 +114,15 @@ Item {
   }
 
   /**
-   * A handler for extra events withing a TextEdit widget .
+   * A handler for extra events for a TextEdit widget .
    */
   property var importDataHandler: QtObject {
 
     /**
-     * Suppose to set `supportDataImport` variable of a feature form. If true, enables to set data by this handler.
+     * Suppose to set `supportsDataImport` variable of a feature form. If true, enables to set data by this handler.
      * \param name "Name" property of field item. Expecting alias if defined, otherwise field name.
      */
-    property var supportImportData: function supportImportData(name) { return false }
+    property var supportsImportData: function supportsImportData(name) { return false }
 
     /**
      * Suppose to be called to invoke a component to set data automatically (e.g. code scanner, sensor).
@@ -474,7 +474,7 @@ Item {
           property var featurePair: form.model.attributeModel.featureLayerPair
           property var activeProject: form.project
           property var customWidget: form.customWidgetCallback
-          property bool supportDataImport: importDataHandler.supportImportData(Name)
+          property bool supportsDataImport: importDataHandler.supportsDataImport(Name)
 
           active: widget !== 'Hidden'
 

--- a/src/quickgui/plugin/qgsquickfeatureform.qml
+++ b/src/quickgui/plugin/qgsquickfeatureform.qml
@@ -122,7 +122,7 @@ Item {
      * Suppose to set `supportsDataImport` variable of a feature form. If true, enables to set data by this handler.
      * \param name "Name" property of field item. Expecting alias if defined, otherwise field name.
      */
-    property var supportsImportData: function supportsImportData(name) { return false }
+    property var supportsDataImport: function supportsDataImport(name) { return false }
 
     /**
      * Suppose to be called to invoke a component to set data automatically (e.g. code scanner, sensor).

--- a/src/quickgui/plugin/qgsquickfeatureform.qml
+++ b/src/quickgui/plugin/qgsquickfeatureform.qml
@@ -36,6 +36,11 @@ Item {
    */
   signal canceled
 
+  /**
+   * When any notification message has to be shown.
+   */
+  signal notify(var message)
+
    /**
     * A handler for extra events in externalSourceWidget.
     */
@@ -106,6 +111,30 @@ Item {
     property var getTypeOfWidget: function getTypeOfWidget( widget, valueRelationModel ) {
       return "combobox"
     }
+  }
+
+  /**
+   * A handler for extra events withing a TextEdit widget .
+   */
+  property var importDataHandler: QtObject {
+
+    /**
+     * Suppose to set `supportDataImport` variable of a feature form. If true, enables to set data by this handler.
+     * \param name "Name" property of field item. Expecting alias if defined, otherwise field name.
+     */
+    property var supportImportData: function supportImportData(name) { return false }
+
+    /**
+     * Suppose to be called to invoke a component to set data automatically (e.g. code scanner, sensor).
+     * \param itemWidget editorWidget for modified field to send valueChanged signal.
+     */
+    property var importData: function importData(itemWidget) {}
+
+    /**
+     * Suppose to be called after `importData` function as a callback to set the value to the widget.
+     * \param value Value to be set.
+     */
+    property var setValue: function setValue(value) {}
   }
 
   /**
@@ -445,6 +474,7 @@ Item {
           property var featurePair: form.model.attributeModel.featureLayerPair
           property var activeProject: form.project
           property var customWidget: form.customWidgetCallback
+          property bool supportDataImport: importDataHandler.supportImportData(Name)
 
           active: widget !== 'Hidden'
 
@@ -463,6 +493,14 @@ Item {
         }
 
         Connections {
+          target: attributeEditorLoader.item
+          ignoreUnknownSignals: true
+          onImportDataRequested: {
+           importDataHandler.importData(attributeEditorLoader.item)
+          }
+        }
+
+        Connections {
           target: form.model
           onDataChanged: {
             if ( attributeEditorLoader.item && attributeEditorLoader.item.dataUpdated )
@@ -470,6 +508,11 @@ Item {
               attributeEditorLoader.item.dataUpdated( form.model.attributeModel.featureLayerPair.feature )
             }
           }
+        }
+
+        Connections {
+          target: form.model.attributeModel
+          onDataChangedFailed: notify(message)
         }
 
         Connections {
@@ -662,4 +705,3 @@ Item {
     }
   }
 }
-

--- a/src/quickgui/plugin/qgsquickfeatureformstyling.qml
+++ b/src/quickgui/plugin/qgsquickfeatureformstyling.qml
@@ -81,6 +81,7 @@ QtObject {
     property var notAvailable: QgsQuick.Utils.getThemeIcon("ic_photo_notavailable_white")
     property var today: QgsQuick.Utils.getThemeIcon("ic_today")
     property var back: QgsQuick.Utils.getThemeIcon("ic_back")
+    property var importData: QgsQuick.Utils.getThemeIcon("ic_camera")
   }
 
   property QtObject checkboxComponent: QtObject {


### PR DESCRIPTION
## Support of importing data for a text field
Added extra functionality to allow to set a text field's value from external input (now the only option is to manually edit a field by writing into it). It's tend to be used for external sensors or scanners - e.g QR scanner. 

Default implementation is rather blank and disabled since this is only additional functionality to the form's text fields.
To make it working, `importDataHandler` object suppose to be overwritten. A new button with signal has been introduced in the text field widget to initiate an action which can be handled by custom handler (`importDataHandler`).


