### PR TITLE
[QgsQuick] Updates default values when an attribute value is updated

### DIFF
--- a/src/quickgui/attributes/qgsquickattributemodel.cpp
+++ b/src/quickgui/attributes/qgsquickattributemodel.cpp
@@ -347,8 +347,8 @@ void QgsQuickAttributeModel::updateDefaultValuesAttributes( const QgsField &edit
     QgsDefaultValue defaultDefinition = fields.at( i ).defaultValueDefinition();
     if ( !defaultDefinition.expression().isEmpty() && defaultDefinition.applyOnUpdate() )
     {
-      // Skip evaluation for a given (last edited ) field to have same behaviour as it is in QGIS
-      // This allows to edit value, but eventually it will be overwritten by "on update" default value if defined
+      // Skip evaluation for a given (last edited ) field to have same behavior as it is in QGIS
+      // Editing a value is allowed, but eventually it will be overwritten by "on update" default value if defined
       // when all attributes are saved and form is closed (as in QGIS)
       if ( editedField.name() == fields.at( i ).name() )
         continue;

--- a/src/quickgui/attributes/qgsquickattributemodel.h
+++ b/src/quickgui/attributes/qgsquickattributemodel.h
@@ -122,6 +122,13 @@ class QUICK_EXPORT QgsQuickAttributeModel : public QAbstractListModel
     //! Resets remembered attributes
     Q_INVOKABLE virtual void resetAttributes();
 
+    /**
+     * Updates attributes according their default value definition.
+     * Only for attributes with defined default value definition and flag `applyOnUpdate`.
+     * @param editedField QgsField reference of last edited field which triggers update attributes.
+     */
+    Q_INVOKABLE void updateDefaultValuesAttributes( const QgsField &editedField );
+
     //! Gives information whether field with given index is remembered or not
     bool isFieldRemembered( const int fieldIndex ) const;
 

--- a/src/quickgui/plugin/qgsquickfeatureform.qml
+++ b/src/quickgui/plugin/qgsquickfeatureform.qml
@@ -458,7 +458,12 @@ Item {
         Connections {
           target: attributeEditorLoader.item
           onValueChanged: {
+            var valueChanged = value != AttributeValue
             AttributeValue = isNull ? undefined : value
+            // updates other attributes if a user males a change
+            if (valueChanged) {
+              form.model.attributeModel.updateDefaultValuesAttributes(Field)
+            }
           }
         }
 
@@ -662,4 +667,3 @@ Item {
     }
   }
 }
-


### PR DESCRIPTION
This is an improvement for handling fields with default value definition and "Apply default value on update" option on.

Before, the process of applying default values on update was completely omitted. Now, after any attribute value is changed in the feature form, values for other fields are recalculated if possible (have default value definition and "on update" option on).
This provides an immediate update of the feature form as it is in QGIS desktop app.  