### PR TITLE
Use recommended osm tile url for server API - Features and landingpage

### DIFF
--- a/resources/server/api/ogc/templates/wfs3/describeCollection.html
+++ b/resources/server/api/ogc/templates/wfs3/describeCollection.html
@@ -44,7 +44,7 @@
         <script type="text/javascript">
         jQuery( document ).ready(function( $ ) {
             var map = L.map('mapid').setView([0, 0], 13);
-            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
                 attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
             }).addTo(map)
             var west = {{ extent.spatial.bbox.0.0 }};

--- a/resources/server/api/ogc/templates/wfs3/leaflet_map.html
+++ b/resources/server/api/ogc/templates/wfs3/leaflet_map.html
@@ -5,7 +5,7 @@
     <script type="text/javascript">
     jQuery( document ).ready(function( $ ) {
         var map = L.map('mapid').setView([0, 0], 13);
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
             attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         }).addTo(map)
         $.get( "{{ metadata.geojsonUrl }}", function( data ) {

--- a/resources/server/src/landingpage/src/views/Catalog.vue
+++ b/resources/server/src/landingpage/src/views/Catalog.vue
@@ -63,7 +63,7 @@
               @ready="loadMap(project, $event)"
             >
               <l-tile-layer
-                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
                 v-if="
                   project.capabilities.wmsOutputCrsList.includes('EPSG:3857')
                 "

--- a/resources/server/src/landingpage/src/views/WebGis.vue
+++ b/resources/server/src/landingpage/src/views/WebGis.vue
@@ -45,7 +45,7 @@
             >
               <l-tile-layer
                 :visible="baseMap == 'openstreetmap'"
-                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
                 v-if="
                   project &&
                   project.capabilities.wmsOutputCrsList.includes('EPSG:3857')

--- a/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.html
@@ -39,19 +39,19 @@
       <div class="container">
           <div id="navbar" class="navbar-collapse collapse d-flex justify-content-between align-items-center">
               <ol class="breadcrumb bg-light my-0 pl-0">
-
+              
                   <li class="breadcrumb-item"><a href="http://server.qgis.org/wfs3/" >Landing page</a></li>
-
+              
                   <li class="breadcrumb-item"><a href="http://server.qgis.org/wfs3/collections/" >Collections</a></li>
-
+              
                   <li class="breadcrumb-item active">
                      A test vector layer èé
                   </li>
               </ol>
               <ul class="list-unstyled list-separated m-0 p-0 text-muted">
-
+              
                   <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9.json" target="_blank">JSON</a></li>
-
+              
               </ul>
           </div>
 
@@ -65,27 +65,27 @@
 <div class="row">
     <div class="col-md-6">
         <h1><a title="View items of: A test vector layer èé" href="
-
-
-
-
-
-
-
+        
+        
+        
+        
+        
+        
+        
         http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.html
-
-
-
+        
+        
+        
         ">A test vector layer èé</a></h1>
         <h3>Available CRSs</h3>
         <ul>
-
+        
             <li>http://www.opengis.net/def/crs/OGC/1.3/CRS84</li>
-
+        
             <li>http://www.opengis.net/def/crs/EPSG/9.6.2/4326</li>
-
+        
             <li>http://www.opengis.net/def/crs/EPSG/9.6.2/3857</li>
-
+        
         </ul>
 
         <h3>Extent</h3>
@@ -102,25 +102,25 @@
 
         <h3>Links</h3>
             <ul>
-
-
+            
+                
                 <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9.json">Feature collection as JSON</a></li>
-
-
-
-
-
+                
+            
+                
+            
+                
                 <li><a rel="items" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.json">A test vector layer èé items as GEOJSON</a></li>
-
-
-
+                
+            
+                
                 <li><a rel="items" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.html">A test vector layer èé items as HTML</a></li>
-
-
-
+                
+            
+                
                 <li><a rel="describedBy" href="http://server.qgis.org/?request=DescribeFeatureType&typenames=testlayer%20èé&service=WFS&version=2.0">Schema for A test vector layer èé</a></li>
-
-
+                
+            
             </ul>
 
     </div>
@@ -180,3 +180,4 @@
     </script>
   </body>
 </html>
+

--- a/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.html
@@ -39,19 +39,19 @@
       <div class="container">
           <div id="navbar" class="navbar-collapse collapse d-flex justify-content-between align-items-center">
               <ol class="breadcrumb bg-light my-0 pl-0">
-              
+
                   <li class="breadcrumb-item"><a href="http://server.qgis.org/wfs3/" >Landing page</a></li>
-              
+
                   <li class="breadcrumb-item"><a href="http://server.qgis.org/wfs3/collections/" >Collections</a></li>
-              
+
                   <li class="breadcrumb-item active">
                      A test vector layer èé
                   </li>
               </ol>
               <ul class="list-unstyled list-separated m-0 p-0 text-muted">
-              
+
                   <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9.json" target="_blank">JSON</a></li>
-              
+
               </ul>
           </div>
 
@@ -65,27 +65,27 @@
 <div class="row">
     <div class="col-md-6">
         <h1><a title="View items of: A test vector layer èé" href="
-        
-        
-        
-        
-        
-        
-        
+
+
+
+
+
+
+
         http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.html
-        
-        
-        
+
+
+
         ">A test vector layer èé</a></h1>
         <h3>Available CRSs</h3>
         <ul>
-        
+
             <li>http://www.opengis.net/def/crs/OGC/1.3/CRS84</li>
-        
+
             <li>http://www.opengis.net/def/crs/EPSG/9.6.2/4326</li>
-        
+
             <li>http://www.opengis.net/def/crs/EPSG/9.6.2/3857</li>
-        
+
         </ul>
 
         <h3>Extent</h3>
@@ -102,25 +102,25 @@
 
         <h3>Links</h3>
             <ul>
-            
-                
+
+
                 <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9.json">Feature collection as JSON</a></li>
-                
-            
-                
-            
-                
+
+
+
+
+
                 <li><a rel="items" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.json">A test vector layer èé items as GEOJSON</a></li>
-                
-            
-                
+
+
+
                 <li><a rel="items" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.html">A test vector layer èé items as HTML</a></li>
-                
-            
-                
+
+
+
                 <li><a rel="describedBy" href="http://server.qgis.org/?request=DescribeFeatureType&typenames=testlayer%20èé&service=WFS&version=2.0">Schema for A test vector layer èé</a></li>
-                
-            
+
+
             </ul>
 
     </div>
@@ -131,7 +131,7 @@
         <script type="text/javascript">
         jQuery( document ).ready(function( $ ) {
             var map = L.map('mapid').setView([0, 0], 13);
-            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
                 attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
             }).addTo(map)
             var west = 8.203459307036344;
@@ -180,4 +180,3 @@
     </script>
   </body>
 </html>
-

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé.html
@@ -33,21 +33,21 @@
       <div class="container">
           <div id="navbar" class="navbar-collapse collapse d-flex justify-content-between align-items-center">
               <ol class="breadcrumb bg-light my-0 pl-0">
-              
+
                   <li class="breadcrumb-item"><a href="http://server.qgis.org/wfs3/" >Landing page</a></li>
-              
+
                   <li class="breadcrumb-item"><a href="http://server.qgis.org/wfs3/collections/" >Collections</a></li>
-              
+
                   <li class="breadcrumb-item"><a href="http://server.qgis.org/wfs3/collections/testlayer èé/" >A test vector layer èé</a></li>
-              
+
                   <li class="breadcrumb-item active">
                      Features in layer A test vector layer èé
                   </li>
               </ol>
               <ul class="list-unstyled list-separated m-0 p-0 text-muted">
-              
+
                   <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.geojson" target="_blank">GEOJSON</a></li>
-              
+
               </ul>
           </div>
 
@@ -61,11 +61,11 @@
     <div class="row">
         <nav aria-label="Page navigation example">
           <ul class="pagination">
-            
+
             <!-- TODO: full pagination: li class="page-item"><a class="page-link" href="#">1</a></li>
             <li class="page-item"><a class="page-link" href="#">2</a></li>
             <li class="page-item"><a class="page-link" href="#">3</a></li-->
-            
+
           </ul>
         </nav>
     </div>
@@ -74,49 +74,49 @@
         <div class="col-md-6">
             <h1>Features in layer A test vector layer èé</h1>
 
-            
+
                 <h2><a href="http://server.qgis.org/wfs3/collections/testlayer èé/items/0.html">A test vector layer èé 0</a></h2>
                 <dl class="row">
-                
+
                     <dt class="col-sm-3">id</dt>
                     <dd class="col-sm-9">1</dd>
-                
+
                     <dt class="col-sm-3">name</dt>
                     <dd class="col-sm-9">one</dd>
-                
+
                     <dt class="col-sm-3">utf8nameè</dt>
                     <dd class="col-sm-9">one èé</dd>
-                
+
                 </dl>
-            
+
                 <h2><a href="http://server.qgis.org/wfs3/collections/testlayer èé/items/1.html">A test vector layer èé 1</a></h2>
                 <dl class="row">
-                
+
                     <dt class="col-sm-3">id</dt>
                     <dd class="col-sm-9">2</dd>
-                
+
                     <dt class="col-sm-3">name</dt>
                     <dd class="col-sm-9">two</dd>
-                
+
                     <dt class="col-sm-3">utf8nameè</dt>
                     <dd class="col-sm-9">two àò</dd>
-                
+
                 </dl>
-            
+
                 <h2><a href="http://server.qgis.org/wfs3/collections/testlayer èé/items/2.html">A test vector layer èé 2</a></h2>
                 <dl class="row">
-                
+
                     <dt class="col-sm-3">id</dt>
                     <dd class="col-sm-9">3</dd>
-                
+
                     <dt class="col-sm-3">name</dt>
                     <dd class="col-sm-9">three</dd>
-                
+
                     <dt class="col-sm-3">utf8nameè</dt>
                     <dd class="col-sm-9">three èé↓</dd>
-                
+
                 </dl>
-            
+
         </div>
 
         <!-- template for the WFS3 API leaflet map -->
@@ -126,7 +126,7 @@
     <script type="text/javascript">
     jQuery( document ).ready(function( $ ) {
         var map = L.map('mapid').setView([0, 0], 13);
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
             attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         }).addTo(map)
         $.get( "http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.geojson", function( data ) {
@@ -172,4 +172,3 @@
     </script>
   </body>
 </html>
-

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé.html
@@ -33,21 +33,21 @@
       <div class="container">
           <div id="navbar" class="navbar-collapse collapse d-flex justify-content-between align-items-center">
               <ol class="breadcrumb bg-light my-0 pl-0">
-
+              
                   <li class="breadcrumb-item"><a href="http://server.qgis.org/wfs3/" >Landing page</a></li>
-
+              
                   <li class="breadcrumb-item"><a href="http://server.qgis.org/wfs3/collections/" >Collections</a></li>
-
+              
                   <li class="breadcrumb-item"><a href="http://server.qgis.org/wfs3/collections/testlayer èé/" >A test vector layer èé</a></li>
-
+              
                   <li class="breadcrumb-item active">
                      Features in layer A test vector layer èé
                   </li>
               </ol>
               <ul class="list-unstyled list-separated m-0 p-0 text-muted">
-
+              
                   <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.geojson" target="_blank">GEOJSON</a></li>
-
+              
               </ul>
           </div>
 
@@ -61,11 +61,11 @@
     <div class="row">
         <nav aria-label="Page navigation example">
           <ul class="pagination">
-
+            
             <!-- TODO: full pagination: li class="page-item"><a class="page-link" href="#">1</a></li>
             <li class="page-item"><a class="page-link" href="#">2</a></li>
             <li class="page-item"><a class="page-link" href="#">3</a></li-->
-
+            
           </ul>
         </nav>
     </div>
@@ -74,49 +74,49 @@
         <div class="col-md-6">
             <h1>Features in layer A test vector layer èé</h1>
 
-
+            
                 <h2><a href="http://server.qgis.org/wfs3/collections/testlayer èé/items/0.html">A test vector layer èé 0</a></h2>
                 <dl class="row">
-
+                
                     <dt class="col-sm-3">id</dt>
                     <dd class="col-sm-9">1</dd>
-
+                
                     <dt class="col-sm-3">name</dt>
                     <dd class="col-sm-9">one</dd>
-
+                
                     <dt class="col-sm-3">utf8nameè</dt>
                     <dd class="col-sm-9">one èé</dd>
-
+                
                 </dl>
-
+            
                 <h2><a href="http://server.qgis.org/wfs3/collections/testlayer èé/items/1.html">A test vector layer èé 1</a></h2>
                 <dl class="row">
-
+                
                     <dt class="col-sm-3">id</dt>
                     <dd class="col-sm-9">2</dd>
-
+                
                     <dt class="col-sm-3">name</dt>
                     <dd class="col-sm-9">two</dd>
-
+                
                     <dt class="col-sm-3">utf8nameè</dt>
                     <dd class="col-sm-9">two àò</dd>
-
+                
                 </dl>
-
+            
                 <h2><a href="http://server.qgis.org/wfs3/collections/testlayer èé/items/2.html">A test vector layer èé 2</a></h2>
                 <dl class="row">
-
+                
                     <dt class="col-sm-3">id</dt>
                     <dd class="col-sm-9">3</dd>
-
+                
                     <dt class="col-sm-3">name</dt>
                     <dd class="col-sm-9">three</dd>
-
+                
                     <dt class="col-sm-3">utf8nameè</dt>
                     <dd class="col-sm-9">three èé↓</dd>
-
+                
                 </dl>
-
+            
         </div>
 
         <!-- template for the WFS3 API leaflet map -->
@@ -172,3 +172,4 @@
     </script>
   </body>
 </html>
+


### PR DESCRIPTION
## Description

`tile.openstreetmap.org` is recommended and should be used instead of the a/b/c subdomains. 

from https://www.openstreetmap.org/user/pnorman/diary/396125#hosts :

> There’s a few ways to reach the standard tile layer. The recommended one is tile.openstreetmap.org, but there’s the legacy a.tile.openstreetmap.org, b.tile.openstreetmap.org, and c.tile.openstreetmap.org domains, and other domains that alias to the same service. If you’re setting up something new, use only tile.openstreetmap.org and HTTP/2 will handle multiple tile fetches in parallel.

from https://leafletjs.com/reference-1.7.1.html#tilelayer :

> {s} means one of the available subdomains (used sequentially to help with browser parallel requests per domain limitation; subdomain values are specified in options; a, b or c by default, can be omitted)

See also https://github.com/qgis/QGIS/issues/30855