### PR TITLE
make QGIS accept .LAZ and .LAS files as .laz & .las

### DIFF
--- a/src/providers/pdal/qgspdalprovider.cpp
+++ b/src/providers/pdal/qgspdalprovider.cpp
@@ -334,7 +334,7 @@ QString QgsPdalProviderMetadata::filters( QgsProviderMetadata::FilterType type )
 
     case QgsProviderMetadata::FilterType::FilterPointCloud:
       // TODO get the available/supported filters from PDAL library
-      return QObject::tr( "PDAL Point Clouds" ) + QStringLiteral( " (*.laz *.las)" );
+      return QObject::tr( "PDAL Point Clouds" ) + QStringLiteral( " (*.laz *.las *.LAZ *.LAS)" );
   }
   return QString();
 }

--- a/tests/src/providers/testqgspdalprovider.cpp
+++ b/tests/src/providers/testqgspdalprovider.cpp
@@ -91,11 +91,11 @@ void TestQgsPdalProvider::filters()
   QgsProviderMetadata *metadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "pdal" ) );
   QVERIFY( metadata );
 
-  QCOMPARE( metadata->filters( QgsProviderMetadata::FilterType::FilterPointCloud ), QStringLiteral( "PDAL Point Clouds (*.laz *.las)" ) );
+  QCOMPARE( metadata->filters( QgsProviderMetadata::FilterType::FilterPointCloud ), QStringLiteral( "PDAL Point Clouds (*.laz *.las *.LAZ *.LAS)" ) );
   QCOMPARE( metadata->filters( QgsProviderMetadata::FilterType::FilterVector ), QString() );
 
   const QString registryPointCloudFilters = QgsProviderRegistry::instance()->filePointCloudFilters();
-  QVERIFY( registryPointCloudFilters.contains( "(*.laz *.las)" ) );
+  QVERIFY( registryPointCloudFilters.contains( "(*.laz *.las *.LAZ *.LAS)" ) );
 }
 
 void TestQgsPdalProvider::encodeUri()


### PR DESCRIPTION
## Description
Previously file with .LAS and .LAZ extensions were not picked up by the browser.
This PR fixes this minor inconvenience.