### PR TITLE
When exporting a model to a python script, include comments for enum values

### DIFF
--- a/python/core/auto_generated/processing/models/qgsprocessingmodelchildparametersource.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelchildparametersource.sip.in
@@ -248,11 +248,18 @@ Loads this source from a QVariantMap.
 .. seealso:: :py:func:`toVariant`
 %End
 
-    QString asPythonCode( QgsProcessing::PythonOutputType outputType, const QgsProcessingParameterDefinition *definition, const QMap< QString, QString > &friendlydChildNames ) const;
+    QString asPythonCode( QgsProcessing::PythonOutputType outputType, const QgsProcessingParameterDefinition *definition, const QMap< QString, QString > &friendlyChildNames ) const;
 %Docstring
 Attempts to convert the source to executable Python code.
 
 The ``friendlyChildNames`` argument gives a map of child id to a friendly algorithm name, to be used in the code to identify that algorithm instead of the raw child id.
+%End
+
+    QString asPythonComment( const QgsProcessingParameterDefinition *definition ) const;
+%Docstring
+Returns an explanatory Python comment for the source, or an empty string if no comment is available.
+
+.. versionadded:: 3.20
 %End
 
     QString friendlyIdentifier( QgsProcessingModelAlgorithm *model ) const;

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -509,6 +509,13 @@ Returns a string version of the parameter input ``value``, which is suitable for
 parameter value when running an algorithm directly from a Python command.
 %End
 
+    virtual QString valueAsPythonComment( const QVariant &value, QgsProcessingContext &context ) const;
+%Docstring
+Returns a Python comment explaining a parameter ``value``, or an empty string if no comment is required.
+
+.. versionadded:: 3.20
+%End
+
     virtual QString asScriptCode() const;
 %Docstring
 Returns the parameter definition encoded in a string which can be used within a
@@ -2434,6 +2441,8 @@ Returns the type name for the parameter class.
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
     virtual QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const;
+
+    virtual QString valueAsPythonComment( const QVariant &value, QgsProcessingContext &context ) const;
 
     virtual QString asScriptCode() const;
 

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
@@ -241,28 +241,48 @@ QStringList QgsProcessingModelChildAlgorithm::asPythonCode( const QgsProcessing:
     lines << baseIndent + QStringLiteral( "# %1" ).arg( mComment.description() );
 
   QStringList paramParts;
+  QStringList paramComments;
   for ( auto paramIt = mParams.constBegin(); paramIt != mParams.constEnd(); ++paramIt )
   {
     QStringList sourceParts;
+    QStringList sourceComments;
     const QgsProcessingParameterDefinition *def = algorithm() ? algorithm()->parameterDefinition( paramIt.key() ) : nullptr;
     const auto parts = paramIt.value();
+    sourceParts.reserve( parts.size() );
+    sourceComments.reserve( parts.size() );
     for ( const QgsProcessingModelChildParameterSource &source : parts )
     {
       QString part = source.asPythonCode( outputType, def, friendlyChildNames );
       if ( !part.isEmpty() )
+      {
         sourceParts << part;
+        sourceComments << source.asPythonComment( def );
+      }
     }
     if ( sourceParts.count() == 1 )
+    {
       paramParts << QStringLiteral( "'%1': %2" ).arg( paramIt.key(), sourceParts.at( 0 ) );
+      paramComments << sourceComments.at( 0 );
+    }
     else
+    {
       paramParts << QStringLiteral( "'%1': [%2]" ).arg( paramIt.key(), sourceParts.join( ',' ) );
+      paramComments << QString();
+    }
   }
 
   lines << baseIndent + QStringLiteral( "alg_params = {" );
   lines.reserve( lines.size() + paramParts.size() );
+  int i = 0;
   for ( const QString &p : std::as_const( paramParts ) )
   {
-    lines << baseIndent + lineIndent + p + ',';
+    QString line = baseIndent + lineIndent + p + ',';
+    if ( !paramComments.value( i ).isEmpty() )
+    {
+      line += QStringLiteral( "  # %1" ).arg( paramComments.value( i ) );
+    }
+    lines << line;
+    i++;
   }
   for ( auto it = extraParameters.constBegin(); it != extraParameters.constEnd(); ++it )
   {

--- a/src/core/processing/models/qgsprocessingmodelchildparametersource.cpp
+++ b/src/core/processing/models/qgsprocessingmodelchildparametersource.cpp
@@ -161,7 +161,7 @@ bool QgsProcessingModelChildParameterSource::loadVariant( const QVariantMap &map
   return true;
 }
 
-QString QgsProcessingModelChildParameterSource::asPythonCode( const QgsProcessing::PythonOutputType, const QgsProcessingParameterDefinition *definition, const QMap< QString, QString > &friendlydChildNames ) const
+QString QgsProcessingModelChildParameterSource::asPythonCode( const QgsProcessing::PythonOutputType, const QgsProcessingParameterDefinition *definition, const QMap< QString, QString > &friendlyChildNames ) const
 {
   switch ( mSource )
   {
@@ -169,7 +169,7 @@ QString QgsProcessingModelChildParameterSource::asPythonCode( const QgsProcessin
       return QStringLiteral( "parameters['%1']" ).arg( mParameterName );
 
     case ChildOutput:
-      return QStringLiteral( "outputs['%1']['%2']" ).arg( friendlydChildNames.value( mChildId, mChildId ), mOutputName );
+      return QStringLiteral( "outputs['%1']['%2']" ).arg( friendlyChildNames.value( mChildId, mChildId ), mOutputName );
 
     case StaticValue:
       if ( definition )
@@ -190,6 +190,31 @@ QString QgsProcessingModelChildParameterSource::asPythonCode( const QgsProcessin
 
     case ModelOutput:
       return QString();
+  }
+  return QString();
+}
+
+QString QgsProcessingModelChildParameterSource::asPythonComment( const QgsProcessingParameterDefinition *definition ) const
+{
+  switch ( mSource )
+  {
+    case ModelParameter:
+    case ChildOutput:
+    case Expression:
+    case ExpressionText:
+    case ModelOutput:
+      return QString();
+
+    case StaticValue:
+      if ( definition )
+      {
+        QgsProcessingContext c;
+        return definition->valueAsPythonComment( mStaticValue, c );
+      }
+      else
+      {
+        return QString();
+      }
   }
   return QString();
 }

--- a/src/core/processing/models/qgsprocessingmodelchildparametersource.h
+++ b/src/core/processing/models/qgsprocessingmodelchildparametersource.h
@@ -227,7 +227,14 @@ class CORE_EXPORT QgsProcessingModelChildParameterSource
      *
      * The \a friendlyChildNames argument gives a map of child id to a friendly algorithm name, to be used in the code to identify that algorithm instead of the raw child id.
      */
-    QString asPythonCode( QgsProcessing::PythonOutputType outputType, const QgsProcessingParameterDefinition *definition, const QMap< QString, QString > &friendlydChildNames ) const;
+    QString asPythonCode( QgsProcessing::PythonOutputType outputType, const QgsProcessingParameterDefinition *definition, const QMap< QString, QString > &friendlyChildNames ) const;
+
+    /**
+     * Returns an explanatory Python comment for the source, or an empty string if no comment is available.
+     *
+     * \since QGIS 3.20
+     */
+    QString asPythonComment( const QgsProcessingParameterDefinition *definition ) const;
 
     /**
      * Returns a user-friendly identifier for this source, given the context of the specified \a model.

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -603,6 +603,13 @@ class CORE_EXPORT QgsProcessingParameterDefinition
     virtual QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const;
 
     /**
+     * Returns a Python comment explaining a parameter \a value, or an empty string if no comment is required.
+     *
+     * \since QGIS 3.20
+     */
+    virtual QString valueAsPythonComment( const QVariant &value, QgsProcessingContext &context ) const;
+
+    /**
      * Returns the parameter definition encoded in a string which can be used within a
      * Processing script.
      */
@@ -2377,6 +2384,7 @@ class CORE_EXPORT QgsProcessingParameterEnum : public QgsProcessingParameterDefi
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
+    QString valueAsPythonComment( const QVariant &value, QgsProcessingContext &context ) const override;
     QString asScriptCode() const override;
     QString asPythonString( QgsProcessing::PythonOutputType outputType = QgsProcessing::PythonQgsProcessingAlgorithmSubclass ) const override;
 

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -4940,6 +4940,11 @@ void TestQgsProcessing::parameterEnum()
   QCOMPARE( def->valueAsPythonString( QVariantList() << 1 << 2, context ), QStringLiteral( "[1,2]" ) );
   QCOMPARE( def->valueAsPythonString( QStringLiteral( "1,2" ), context ), QStringLiteral( "[1,2]" ) );
 
+  QCOMPARE( def->valueAsPythonComment( QVariant(), context ), QString() );
+  QCOMPARE( def->valueAsPythonComment( 2, context ), QStringLiteral( "C" ) );
+  QCOMPARE( def->valueAsPythonComment( QVariantList() << 1 << 2, context ), QStringLiteral( "B,C" ) );
+  QCOMPARE( def->valueAsPythonComment( QStringLiteral( "1,2" ), context ), QStringLiteral( "B,C" ) );
+
   pythonCode = def->asPythonString();
   QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterEnum('non_optional', '', options=['A','B','C'], allowMultiple=True, usesStaticStrings=False, defaultValue=5)" ) );
 
@@ -10329,9 +10334,9 @@ void TestQgsProcessing::modelExecution()
                               "    alg_params = {\n"
                               "      'DISSOLVE': False,\n"
                               "      'DISTANCE': parameters['DIST'],\n"
-                              "      'END_CAP_STYLE': 1,\n"
+                              "      'END_CAP_STYLE': 1,  # Flat\n"
                               "      'INPUT': parameters['SOURCE_LAYER'],\n"
-                              "      'JOIN_STYLE': 2,\n"
+                              "      'JOIN_STYLE': 2,  # Bevel\n"
                               "      'SEGMENTS': QgsExpression('@myvar*2').evaluate(),\n"
                               "      'OUTPUT': parameters['MyModelOutput']\n"
                               "    }\n"


### PR DESCRIPTION
When exporting a model to a python script, include helpful comments next to all static enum parameter values used in child algorithms with the corresponding text.

I.e. instead of

    alg_params = {
      'END_CAP_STYLE': 2,
    }

we now export

    alg_params = {
      'END_CAP_STYLE': 2,  # Flat
    }

Much more readable!
