### PR TITLE
Use QApplication::activeWindow() instead of QApplication::topLevelWidgets() to retrieve current screen

### DIFF
--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -1312,7 +1312,8 @@ QPixmap QgsPalLayerSettings::labelSettingsPreviewPixmap( const QgsPalLayerSettin
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
   const double logicalDpiX = QgsApplication::desktop()->logicalDpiX();
 #else
-  const double logicalDpiX = QApplication::topLevelWidgets().first()->screen()->logicalDotsPerInchX();
+  QWidget *activeWindow = QApplication::activeWindow();
+  const double logicalDpiX = activeWindow && activeWindow->screen() ? activeWindow->screen()->logicalDotsPerInchX() : 96.0;
 #endif
   context.setScaleFactor( logicalDpiX / 25.4 );
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1865,8 +1865,11 @@ int QgsApplication::scaleIconSize( int standardSize, bool applyDevicePixelRatio 
   if ( applyDevicePixelRatio && QApplication::desktop() )
     scaledIconSize *= QApplication::desktop()->devicePixelRatio();
 #else
-  if ( applyDevicePixelRatio && !QApplication::topLevelWidgets().isEmpty() )
-    scaledIconSize *= QApplication::topLevelWidgets().first()->screen()->devicePixelRatio();
+  if ( applyDevicePixelRatio )
+  {
+    if ( QWidget *activeWindow = QApplication::activeWindow() )
+      scaledIconSize *= ( activeWindow->screen() ? QApplication::activeWindow()->screen()->devicePixelRatio() : 1 );
+  }
 #endif
   return scaledIconSize;
 }

--- a/src/core/textrenderer/qgstextformat.cpp
+++ b/src/core/textrenderer/qgstextformat.cpp
@@ -963,7 +963,8 @@ QPixmap QgsTextFormat::textFormatPreviewPixmap( const QgsTextFormat &format, QSi
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
   const double logicalDpiX = QgsApplication::desktop()->logicalDpiX();
 #else
-  const double logicalDpiX = QApplication::topLevelWidgets().first()->screen()->logicalDotsPerInchX();
+  QWidget *activeWindow = QApplication::activeWindow();
+  const double logicalDpiX = activeWindow && activeWindow->screen() ? activeWindow->screen()->logicalDotsPerInchX() : 96.0;
 #endif
   context.setScaleFactor( logicalDpiX / 25.4 );
 


### PR DESCRIPTION
QApplication::topLevelWidgets() can  be EXTREMELY costly to call,
as it builds a list dynamically containing potentially dozens/hundreds
of widgets.

Fixes slow interaction with the layer tree in large projects

(master only)