### PR TITLE
Minor tweaks to expression dialog and default expression function

### DIFF
--- a/python/user.py
+++ b/python/user.py
@@ -66,7 +66,7 @@ if not os.path.exists(initfile):
 template = """from qgis.core import *
 from qgis.gui import *
 
-@qgsfunction(args='auto', group='Custom')
+@qgsfunction(args='auto', group='Custom', referenced_columns=[])
 def my_sum(value1, value2, feature, parent):
     \"\"\"
     Calculates the sum of the two parameters value1 and value2.

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -399,8 +399,8 @@ void QgsExpressionBuilderWidget::updateFunctionFileList( const QString &path )
   {
     // Create default sample entry.
     newFunctionFile( "default" );
-    txtPython->setText( QStringLiteral( "'''\n#Sample custom function file\n "
-                                        "(uncomment to use and customize or Add button to create a new file) \n%1 \n '''" ).arg( txtPython->text() ) );
+    txtPython->setText( QStringLiteral( "'''\n#Sample custom function file\n"
+                                        "#(uncomment to use and customize or Add button to create a new file) \n%1 \n '''" ).arg( txtPython->text() ) );
     saveFunctionFile( "default" );
   }
 }

--- a/src/gui/qgsexpressionpreviewwidget.cpp
+++ b/src/gui/qgsexpressionpreviewwidget.cpp
@@ -85,7 +85,7 @@ void QgsExpressionPreviewWidget::refreshPreview()
       if ( !mExpression.referencedColumns().isEmpty() || mExpression.needsGeometry() )
       {
         mPreviewLabel->setText( tr( "No feature was found on this layer to evaluate the expression." ) );
-        mPreviewLabel->setStyleSheet( QStringLiteral( "color: rgba(255, 6, 10,  255);" ) );
+        mPreviewLabel->setStyleSheet( QStringLiteral( "color: rgba(220, 125, 0, 255);" ) );
         return;
       }
     }
@@ -116,7 +116,7 @@ void QgsExpressionPreviewWidget::refreshPreview()
         tooltip += QStringLiteral( "<b>%1:</b> %2" ).arg( tr( "Eval Error" ), mExpression.evalErrorString() );
 
       mPreviewLabel->setText( tr( "Expression is invalid <a href=""more"">(more info)</a>" ) );
-      mPreviewLabel->setStyleSheet( QStringLiteral( "color: rgba(255, 6, 10,  255);" ) );
+      mPreviewLabel->setStyleSheet( QStringLiteral( "color: rgba(255, 6, 10, 255);" ) );
       setExpressionToolTip( tooltip );
       emit expressionParsed( false );
       setParserError( mExpression.hasParserError() );


### PR DESCRIPTION
This PR includes 3 minor changes to the expression dialog and to the default expression function:

1. Add parameter to decorator in default custom expression function to avoid `No feature was found on this layer to evaluate the expression` message and be able to get a preview of the calculated value even on empty layers. 

    See this [answer](https://gis.stackexchange.com/questions/393249/writing-custom-qgis-function-that-works-without-a-feature-given-as-input/393253#393253) for more details.

2. Comment line in default custom expression function. It should remain commented when a user removes the ''' to uncomment the whole function.

   As of now, if you uncomment the whole function (as the first line suggests), you end up with a Python error because the second line is not commented. This minor change removes such error.

   ![image](https://user-images.githubusercontent.com/652785/114246063-4a23d980-9957-11eb-9f61-8f79be957b42.png)


3. Change color of message 'No feature was found [...]' from red to orange in preview expression widget to make it less scary.

   In fact, it is not an error, but a warning, so an orange color is more appropriate. The color definition was copied from [here](https://github.com/qgis/QGIS/blob/2d1aa68f0d044f2aced7ebeca8d2fa6b754ac970/resources/qgis_global_settings.ini#L175).

   **Before**
   ![before](https://user-images.githubusercontent.com/652785/114245816-cff35500-9956-11eb-9a97-59853222b8ad.png)

    **After**
    ![after](https://user-images.githubusercontent.com/652785/114245854-deda0780-9956-11eb-8ee4-899ed94d9501.png)

