### PR TITLE
[Server] QgsServerFeatureId use STRING_TO_FID instead of toLongLong

### DIFF
--- a/src/server/qgsserverfeatureid.cpp
+++ b/src/server/qgsserverfeatureid.cpp
@@ -45,7 +45,7 @@ QgsFeatureRequest QgsServerFeatureId::updateFeatureRequestFromServerFids( QgsFea
     QgsFeatureIds fids;
     for ( const QString &serverFid : serverFids )
     {
-      fids.insert( serverFid.toLongLong() );
+      fids.insert( STRING_TO_FID( serverFid ) );
     }
     featureRequest.setFilterFids( fids );
     return featureRequest;


### PR DESCRIPTION
## Description

As in ohter part of the QGIS Server code, to insert into a QgsFeatureIds list, using STRING_TOFID instead of toLongLong.
