### PR TITLE
[vectorlayer] Fix updateFeature() when an attribute's variant goes from null to default null value

### DIFF
--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -1072,7 +1072,7 @@ bool QgsVectorLayer::updateFeature( QgsFeature &updatedFeature, bool skipDefault
 
     for ( int attr = 0; attr < fa.count(); ++attr )
     {
-      if ( fa.at( attr ) != ca.at( attr ) )
+      if ( !qgsVariantEqual( fa.at( attr ), ca.at( attr ) ) )
       {
         if ( changeAttributeValue( updatedFeature.id(), attr, fa.at( attr ), ca.at( attr ), true ) )
         {


### PR DESCRIPTION
## Description

A regression slipped in out of this commit (https://github.com/qgis/QGIS/commit/b078be618520f925e07e40599036f00f806fbc3e). Since that commit has changed the way OGR features's null values are represented from QVariant( QString() ) to QVariant( QVariant::Type ). 

This meant that what used to work before in checking whether an attribute has changed (i.e. a QVariant( QString() ) == QVariant( 0 )) doesn't work anymore because Qt - somewhat stupidly? - says that eg QVariant( 0 ) == QVariant( QVariant::Int ).

The fix is to use our nifty qgsVariantEqual() to compare whether an attribute value truly has changed.