### PR TITLE
Support for WCS in the GeoNode provider

### DIFF
--- a/python/core/auto_generated/geocms/geonode/qgsgeonodeconnection.sip.in
+++ b/python/core/auto_generated/geocms/geonode/qgsgeonodeconnection.sip.in
@@ -68,6 +68,14 @@ Adds uri parameters relating to the settings for a WFS layer on the connection t
 .. seealso:: :py:func:`addWmsConnectionSettings`
 %End
 
+    QgsDataSourceUri &addWcsConnectionSettings( QgsDataSourceUri &uri ) const;
+%Docstring
+Adds uri parameters relating to the settings for a WCS layer on the connection to a :py:class:`QgsDataSourceUri` ``uri``.
+
+.. seealso:: :py:func:`addWmsConnectionSettings`
+%End
+
+
 };
 
 class QgsGeoNodeConnectionUtils

--- a/python/core/auto_generated/geocms/geonode/qgsgeonodeconnection.sip.in
+++ b/python/core/auto_generated/geocms/geonode/qgsgeonodeconnection.sip.in
@@ -73,6 +73,8 @@ Adds uri parameters relating to the settings for a WFS layer on the connection t
 Adds uri parameters relating to the settings for a WCS layer on the connection to a :py:class:`QgsDataSourceUri` ``uri``.
 
 .. seealso:: :py:func:`addWmsConnectionSettings`
+
+.. versionadded:: 3.20
 %End
 
 

--- a/python/core/auto_generated/geocms/geonode/qgsgeonoderequest.sip.in
+++ b/python/core/auto_generated/geocms/geonode/qgsgeonoderequest.sip.in
@@ -56,6 +56,7 @@ server instance, for instance requesting all available layers or layer styles.
       QString title;
       QString wmsURL;
       QString wfsURL;
+      QString wcsURL;
       QString xyzURL;
       BackendServer server;
     };

--- a/src/core/geocms/geonode/qgsgeonodeconnection.cpp
+++ b/src/core/geocms/geonode/qgsgeonodeconnection.cpp
@@ -81,6 +81,11 @@ QgsDataSourceUri &QgsGeoNodeConnection::addWfsConnectionSettings( QgsDataSourceU
   return QgsOwsConnection::addWfsConnectionSettings( uri, settingsKey() + QStringLiteral( "/wfs" ) );
 }
 
+QgsDataSourceUri &QgsGeoNodeConnection::addWcsConnectionSettings( QgsDataSourceUri &uri ) const
+{
+  return QgsOwsConnection::addWmsWcsConnectionSettings( uri, settingsKey() + QStringLiteral( "/wcs" ) );
+}
+
 QString QgsGeoNodeConnection::settingsKey() const
 {
   return QgsGeoNodeConnectionUtils::pathGeoNodeConnection() + QStringLiteral( "/" ) + mConnName;

--- a/src/core/geocms/geonode/qgsgeonodeconnection.h
+++ b/src/core/geocms/geonode/qgsgeonodeconnection.h
@@ -71,6 +71,13 @@ class CORE_EXPORT QgsGeoNodeConnection
      */
     QgsDataSourceUri &addWfsConnectionSettings( QgsDataSourceUri &uri ) const;
 
+    /**
+     * Adds uri parameters relating to the settings for a WCS layer on the connection to a QgsDataSourceUri \a uri.
+     * \see addWmsConnectionSettings()
+     */
+    QgsDataSourceUri &addWcsConnectionSettings( QgsDataSourceUri &uri ) const;
+
+
   private:
 
     //! The connection name

--- a/src/core/geocms/geonode/qgsgeonodeconnection.h
+++ b/src/core/geocms/geonode/qgsgeonodeconnection.h
@@ -74,6 +74,8 @@ class CORE_EXPORT QgsGeoNodeConnection
     /**
      * Adds uri parameters relating to the settings for a WCS layer on the connection to a QgsDataSourceUri \a uri.
      * \see addWmsConnectionSettings()
+     *
+     * \since QGIS 3.20
      */
     QgsDataSourceUri &addWcsConnectionSettings( QgsDataSourceUri &uri ) const;
 

--- a/src/core/geocms/geonode/qgsgeonoderequest.h
+++ b/src/core/geocms/geonode/qgsgeonoderequest.h
@@ -96,6 +96,8 @@ class CORE_EXPORT QgsGeoNodeRequest : public QObject
       QString wmsURL;
       //! WFS URL for layer
       QString wfsURL;
+      //! WCS URL for layer
+      QString wcsURL;
       //! XYZ tileserver URL for layer
       QString xyzURL;
       //! Backend server (geoserver or qgis-server)

--- a/src/providers/geonode/qgsgeonodedataitems.cpp
+++ b/src/providers/geonode/qgsgeonodedataitems.cpp
@@ -38,6 +38,7 @@ QVector<QgsDataItem *> QgsGeoNodeConnectionItem::createChildren()
 
   QStringList wmsUrl = geonodeRequest.fetchServiceUrlsBlocking( QStringLiteral( "WMS" ) );
   QStringList wfsUrl = geonodeRequest.fetchServiceUrlsBlocking( QStringLiteral( "WFS" ) );
+  QStringList wcsUrl = geonodeRequest.fetchServiceUrlsBlocking( QStringLiteral( "WCS" ) );
   QStringList xyzUrl = geonodeRequest.fetchServiceUrlsBlocking( QStringLiteral( "XYZ" ) );
 
   if ( !wmsUrl.isEmpty() )
@@ -51,6 +52,13 @@ QVector<QgsDataItem *> QgsGeoNodeConnectionItem::createChildren()
   {
     QString path = mPath + QStringLiteral( "/wfs" );
     QgsDataItem *service = new QgsGeoNodeServiceItem( this, mConnection.get(), QStringLiteral( "WFS" ), path );
+    services.append( service );
+  }
+
+  if ( !wcsUrl.isEmpty() )
+  {
+    QString path = mPath + QStringLiteral( "/wcs" );
+    QgsDataItem *service = new QgsGeoNodeServiceItem( this, mConnection.get(), QStringLiteral( "WCS" ), path );
     services.append( service );
   }
 
@@ -75,6 +83,10 @@ QgsGeoNodeServiceItem::QgsGeoNodeServiceItem( QgsDataItem *parent, QgsGeoNodeCon
   {
     mIconName = QStringLiteral( "mIconWms.svg" );
   }
+  else if ( serviceName == QLatin1String( "WCS" ) )
+  {
+    mIconName = QStringLiteral( "mIconWcs.svg" );
+  }
   else
   {
     mIconName = QStringLiteral( "mIconWfs.svg" );
@@ -95,7 +107,7 @@ QVector<QgsDataItem *> QgsGeoNodeServiceItem::createChildren()
 
   while ( !skipProvider )
   {
-    const QString &key = mServiceName != QLatin1String( "WFS" ) ? QStringLiteral( "wms" ) : mServiceName;
+    const QString &key = mServiceName != QLatin1String( "WFS" ) ? mServiceName == QLatin1String( "WCS" ) ? QStringLiteral( "wcs" ) : QStringLiteral( "wms" ) : mServiceName;
 
     const QList<QgsDataItemProvider *> providerList = QgsProviderRegistry::instance()->dataItemProviders( key );
     if ( providerList.isEmpty() )

--- a/src/providers/geonode/qgsgeonodesourceselect.cpp
+++ b/src/providers/geonode/qgsgeonodesourceselect.cpp
@@ -189,6 +189,7 @@ void QgsGeoNodeSourceSelect::connectToGeonodeConnection()
 
         QString wmsURL = layer.wmsURL;
         QString wfsURL = layer.wfsURL;
+        QString wcsURL = layer.wcsURL;
         QString xyzURL = layer.xyzURL;
 
         if ( !wmsURL.isEmpty() )
@@ -245,6 +246,36 @@ void QgsGeoNodeSourceSelect::connectToGeonodeConnection()
         {
           QgsDebugMsgLevel( QStringLiteral( "Layer %1 does not have WFS url." ).arg( layer.title ), 3 );
         }
+
+        if ( !wcsURL.isEmpty() )
+        {
+          QStandardItem *titleItem = new QStandardItem( layer.title );
+          QStandardItem *nameItem = nullptr;
+          if ( !layer.name.isEmpty() )
+          {
+            nameItem = new QStandardItem( layer.name );
+          }
+          else
+          {
+            nameItem = new QStandardItem( layer.title );
+          }
+          QStandardItem *serviceTypeItem = new QStandardItem( tr( "Layer" ) );
+          QStandardItem *webServiceTypeItem = new QStandardItem( tr( "WCS" ) );
+
+          QString typeName = layer.typeName;
+
+          titleItem->setData( uuid,  Qt::UserRole + 1 );
+          titleItem->setData( wcsURL,  Qt::UserRole + 2 );
+          titleItem->setData( typeName,  Qt::UserRole + 3 );
+
+          typedef QList< QStandardItem * > StandardItemList;
+          mModel->appendRow( StandardItemList() << titleItem << nameItem << serviceTypeItem << webServiceTypeItem );
+        }
+        else
+        {
+          QgsDebugMsgLevel( QStringLiteral( "Layer %1 does not have WCS url." ).arg( layer.title ), 3 );
+        }
+
         if ( !xyzURL.isEmpty() )
         {
           QStandardItem *titleItem = new QStandardItem( layer.title );
@@ -413,6 +444,18 @@ void QgsGeoNodeSourceSelect::addButtonClicked()
 
       QgsDebugMsg( "Add WMS from GeoNode : " + uri.encodedUri() );
       emit addRasterLayer( uri.encodedUri(), layerName, QStringLiteral( "wms" ) );
+    }
+    else if ( webServiceType == QLatin1String( "WCS" ) )
+    {
+      QgsDataSourceUri uri;
+      QString typeName = mModel->item( row, 0 )->data( Qt::UserRole + 3 ).toString();
+      uri.setParam( QStringLiteral( "url" ), serviceURL );
+
+      connection.addWcsConnectionSettings( uri );
+      uri.setParam( QStringLiteral( "identifier" ), typeName );
+
+      QgsDebugMsg( "Add WCS from GeoNode : " + uri.encodedUri() );
+      emit addRasterLayer( uri.encodedUri(), layerName, QStringLiteral( "wcs" ) );
     }
     else if ( webServiceType == QLatin1String( "WFS" ) )
     {

--- a/src/providers/wcs/qgswcsdataitems.cpp
+++ b/src/providers/wcs/qgswcsdataitems.cpp
@@ -19,6 +19,10 @@
 #include "qgsdatasourceuri.h"
 #include "qgsowsconnection.h"
 
+#include "qgsgeonodeconnection.h"
+#include "qgsgeonoderequest.h"
+#include "qgssettings.h"
+
 #ifdef HAVE_GUI
 #include "qgswcssourceselect.h"
 #endif
@@ -253,4 +257,51 @@ QgsDataItem *QgsWcsDataItemProvider::createDataItem( const QString &path, QgsDat
   }
 
   return nullptr;
+}
+
+
+QVector<QgsDataItem *> QgsWcsDataItemProvider::createDataItems( const QString &path, QgsDataItem *parentItem )
+{
+  QVector<QgsDataItem *> items;
+  if ( path.startsWith( QLatin1String( "geonode:/" ) ) )
+  {
+    QString connectionName = path.split( '/' ).last();
+    if ( QgsGeoNodeConnectionUtils::connectionList().contains( connectionName ) )
+    {
+      QgsGeoNodeConnection connection( connectionName );
+
+      QString url = connection.uri().param( QStringLiteral( "url" ) );
+      QgsGeoNodeRequest geonodeRequest( url, true );
+
+      const QStringList encodedUris( geonodeRequest.fetchServiceUrlsBlocking( QStringLiteral( "WCS" ) ) );
+
+      if ( !encodedUris.isEmpty() )
+      {
+        for ( const QString &encodedUri : encodedUris )
+        {
+          QgsDebugMsgLevel( encodedUri, 3 );
+          QgsDataSourceUri uri;
+          QgsSettings settings;
+          QString key( QgsGeoNodeConnectionUtils::pathGeoNodeConnection() + "/" + connectionName );
+
+          QString dpiMode = settings.value( key + "/wcs/dpiMode", "all" ).toString();
+          uri.setParam( QStringLiteral( "url" ), encodedUri );
+          if ( !dpiMode.isEmpty() )
+          {
+            uri.setParam( QStringLiteral( "dpiMode" ), dpiMode );
+          }
+
+          QgsDebugMsgLevel( QStringLiteral( "WCS full uri: '%1'." ).arg( QString( uri.encodedUri() ) ), 2 );
+
+          QgsDataItem *item = new QgsWCSConnectionItem( parentItem, QStringLiteral( "WCS" ), path, uri.encodedUri() );
+          if ( item )
+          {
+            items.append( item );
+          }
+        }
+      }
+    }
+  }
+
+  return items;
 }

--- a/src/providers/wcs/qgswcsdataitems.h
+++ b/src/providers/wcs/qgswcsdataitems.h
@@ -82,6 +82,7 @@ class QgsWcsDataItemProvider : public QgsDataItemProvider
     int capabilities() const override;
 
     QgsDataItem *createDataItem( const QString &pathIn, QgsDataItem *parentItem ) override;
+    QVector<QgsDataItem *> createDataItems( const QString &path, QgsDataItem *parentItem );
 };
 
 #endif // QGSWCSDATAITEMS_H

--- a/src/providers/wcs/qgswcsdataitems.h
+++ b/src/providers/wcs/qgswcsdataitems.h
@@ -82,7 +82,7 @@ class QgsWcsDataItemProvider : public QgsDataItemProvider
     int capabilities() const override;
 
     QgsDataItem *createDataItem( const QString &pathIn, QgsDataItem *parentItem ) override;
-    QVector<QgsDataItem *> createDataItems( const QString &path, QgsDataItem *parentItem );
+    QVector<QgsDataItem *> createDataItems( const QString &path, QgsDataItem *parentItem ) override;
 };
 
 #endif // QGSWCSDATAITEMS_H


### PR DESCRIPTION
Fixes https://github.com/qgis/QGIS/issues/42761.

Adds support for loading WCS resources via the GeoNode provider

Screenshot
![wcs_geonode_qgis_support](https://user-images.githubusercontent.com/2663775/114505080-83e72f80-9c38-11eb-894c-6699589d7fd2.gif)

**Note:** Some of GeoNode instances do not correctly expose the `names` of coverages in their APIs, this can lead to the corresponding coverages to not be loadable inside QGIS.