### PR TITLE
[PostgreSQL] fix ROUND expression

### DIFF
--- a/src/providers/postgres/qgspostgresexpressioncompiler.cpp
+++ b/src/providers/postgres/qgspostgresexpressioncompiler.cpp
@@ -145,6 +145,10 @@ QStringList QgsPostgresExpressionCompiler::sqlArgumentsFromFunctionName( const Q
   {
     args << QStringLiteral( "8" );
   }
+  else if ( fnName == QLatin1String( "round" ) )
+  {
+    args[0] = QStringLiteral( "(%1)::numeric" ).arg( args[0] );
+  }
   // x and y functions have to be adapted
   return args;
 }


### PR DESCRIPTION
before:
```
2021-04-14 02:55:38.439 EEST [343226] dasha@qgis_test LOG:  statement: CLOSE qgis_1219;COMMIT
2021-04-14 02:55:38.439 EEST [343226] dasha@qgis_test LOG:  statement: BEGIN READ ONLY;DECLARE qgis_1220 BINARY CURSOR FOR SELECT "key1"::text,"key2"::text,"pk"::text,"cnt"::text,"name"::text,"name2"::text,"num_char"::text,"dt"::text,"date"::text,"time"::text FROM "qgis_test"."someDataCompound" WHERE (round(("cnt" / ((66.67)::real)),0) <= 2)
2021-04-14 02:55:38.439 EEST [343226] dasha@qgis_test ERROR:  function round(double precision, integer) does not exist at character 233
2021-04-14 02:55:38.439 EEST [343226] dasha@qgis_test HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
2021-04-14 02:55:38.439 EEST [343226] dasha@qgis_test STATEMENT:  BEGIN READ ONLY;DECLARE qgis_1220 BINARY CURSOR FOR SELECT "key1"::text,"key2"::text,"pk"::text,"cnt"::text,"name"::text,"name2"::text,"num_char"::text,"dt"::text,"date"::text,"time"::text FROM "qgis_test"."someDataCompound" WHERE (round(("cnt" / ((66.67)::real)),0) <= 2)
2021-04-14 02:55:38.439 EEST [343226] dasha@qgis_test LOG:  statement: ROLLBACK
```

after:
```
2021-04-14 12:38:50.033 EEST [412535] dasha@qgis_test LOG:  statement: CLOSE qgis_1935;COMMIT
2021-04-14 12:38:50.034 EEST [412535] dasha@qgis_test LOG:  statement: BEGIN READ ONLY;DECLARE qgis_1936 BINARY CURSOR FOR SELECT "key1"::text,"key2"::text,"pk"::text,"cnt"::text,"name"::text,"name2"::text,"num_char"::text,"dt"::text,"date"::text,"time"::text FROM "qgis_test"."someDataCompound" WHERE (round((("cnt" / ((66.67)::real)))::numeric,0) <= 2)
2021-04-14 12:38:50.034 EEST [412535] dasha@qgis_test LOG:  statement: FETCH FORWARD 2000 FROM qgis_1936
2021-04-14 12:38:50.034 EEST [412535] dasha@qgis_test LOG:  statement: CLOSE qgis_1936;COMMIT
2021-04-14 12:38:50.035 EEST [412535] dasha@qgis_test LOG:  statement: BEGIN READ ONLY;DECLARE qgis_1937 BINARY CURSOR FOR SELECT "key1"::text,"key2"::text,"pk"::text,"cnt"::text,"name"::text,"name2"::text,"num_char"::text,"dt"::text,"date"::text,"time"::text FROM "qgis_test"."someDataCompound" WHERE (round((("cnt" / ((66.67)::real)))::numeric,0) <= 2)
2021-04-14 12:38:50.035 EEST [412535] dasha@qgis_test LOG:  statement: FETCH FORWARD 2000 FROM qgis_1937
2021-04-14 12:38:50.035 EEST [412535] dasha@qgis_test LOG:  statement: CLOSE qgis_1937;COMMIT
2021-04-14 12:38:50.036 EEST [412535] dasha@qgis_test LOG:  statement: BEGIN READ ONLY;DECLARE qgis_1938 BINARY CURSOR FOR SELECT st_asbinary("geom",'NDR'),"key1"::text,"key2"::text,"pk"::text,"cnt"::text,"name"::text,"name2"::text,"num_char"::text,"dt"::text,"date"::text,"time"::text FROM "qgis_test"."someDataCompound" WHERE (round((("cnt" / ((66.67)::real)))::numeric,0) <= 2)
2021-04-14 12:38:50.036 EEST [412535] dasha@qgis_test LOG:  statement: FETCH FORWARD 2000 FROM qgis_1938
```