### PR TITLE
fix API header references

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -12,6 +12,7 @@
 
 
 
+
 class QgsProcessingContext
 {
 %Docstring(signature="appended")

--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -31,6 +31,7 @@
 #include "qgslayoutmultiframe.h"
 #include "qgsfeatureid.h"
 #include "qgslayoutitemmap.h"
+#include "qgsmaplayerlistutils.h"
 
 QgsExpressionContextScope *QgsExpressionContextUtils::globalScope()
 {

--- a/src/core/processing/qgsprocessingcontext.cpp
+++ b/src/core/processing/qgsprocessingcontext.cpp
@@ -18,6 +18,7 @@
 #include "qgsprocessingcontext.h"
 #include "qgsprocessingutils.h"
 #include "qgsproviderregistry.h"
+#include "qgsmaplayerlistutils.h"
 #include "qgssettings.h"
 
 QgsProcessingContext::QgsProcessingContext()

--- a/src/core/processing/qgsprocessingcontext.h
+++ b/src/core/processing/qgsprocessingcontext.h
@@ -23,12 +23,13 @@
 #include "qgsproject.h"
 #include "qgsexpressioncontext.h"
 #include "qgsfeaturerequest.h"
-#include "qgsmaplayerlistutils.h"
 #include "qgsexception.h"
 #include "qgsprocessingfeedback.h"
 #include "qgsprocessingutils.h"
 
+
 #include <QThread>
+#include <QPointer>
 
 class QgsProcessingLayerPostProcessorInterface;
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1325,6 +1325,7 @@ set(QGIS_GUI_UI_HDRS
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmeshdatasetgrouptreewidgetbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmeshstaticdatasetwidgetbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgstemporalcontrollerwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsprocessingtinmeshdatawidgetbase.h
 )
 
 if(ENABLE_MODELTEST)


### PR DESCRIPTION
`qgsmaplayerlistutils.h` is not a API header. 
This PR removes its reference from `qgsprocessingcontext.h` API header to allow it from stand alone application using QGIS API. 
Also add an ui header file to the list of exported files for the same reasons.