### PR TITLE
[API] Add set m value from points

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -754,6 +754,12 @@ A Z dimension is added to ``point`` if one of the point in the list
 
 :return: ``True`` if the point is updated, ``False`` otherwise
 
+.. warning::
+
+   This method does not copy the z value of the coordinate from the
+   points whose z value is closest to the original x/y point, but only the first one found.
+
+
 .. versionadded:: 3.0
 %End
 
@@ -767,6 +773,12 @@ updated with the first M value found in list ``points``.
 :param point: The point to update with M dimension and value.
 
 :return: ``True`` if the point is updated, ``False`` otherwise
+
+.. warning::
+
+   This method does not copy the m value of the coordinate from the
+   points whose m value is closest to the original x/y point, but only the first one found.
+
 
 .. versionadded:: 3.20
 %End

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -757,6 +757,19 @@ A Z dimension is added to ``point`` if one of the point in the list
 .. versionadded:: 3.0
 %End
 
+    static bool setMValueFromPoints( const QgsPointSequence &points, QgsPoint &point );
+%Docstring
+A M dimension is added to ``point`` if one of the point in the list
+``points`` is in 3D. Moreover, the M value of ``point`` is updated with.
+
+:param points: List of points in which a 3D point is searched.
+:param point: The point to update with M dimension and value.
+
+:return: ``True`` if the point is updated, ``False`` otherwise
+
+.. versionadded:: 3.20
+%End
+
 
     static bool angleBisector( double aX, double aY, double bX, double bY, double cX, double cY, double dX, double dY,
                                double &pointX /Out/, double &pointY /Out/, double &angle /Out/ ) /HoldGIL/;

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -747,7 +747,9 @@ Returns a weighted point inside the triangle denoted by the points (``aX``, ``aY
  static bool setZValueFromPoints( const QgsPointSequence &points, QgsPoint &point ) /Deprecated/;
 %Docstring
 A Z dimension is added to ``point`` if one of the point in the list
-``points`` is in 3D. Moreover, the Z value of ``point`` is updated with.
+``points`` is in 3D. Moreover, the Z value of ``point`` is updated
+with the first Z value found in list ``points`` even if ``point``
+already contains a Z value.
 
 :param points: List of points in which a 3D point is searched.
 :param point: The point to update with Z dimension and value.
@@ -769,7 +771,9 @@ A Z dimension is added to ``point`` if one of the point in the list
     static bool transferFirstZValueToPoint( const QgsPointSequence &points, QgsPoint &point );
 %Docstring
 A Z dimension is added to ``point`` if one of the point in the list
-``points`` is in 3D. Moreover, the Z value of ``point`` is updated with.
+``points`` is in 3D. Moreover, the Z value of ``point`` is updated
+with the first Z value found in list ``points`` even if ``point``
+already contains a Z value.
 
 :param points: List of points in which a 3D point is searched.
 :param point: The point to update with Z dimension and value.
@@ -789,7 +793,8 @@ A Z dimension is added to ``point`` if one of the point in the list
 %Docstring
 A M dimension is added to ``point`` if one of the points in the list
 ``points`` contains an M value. Moreover, the M value of ``point`` is
-updated with the first M value found in list ``points``.
+updated with the first M value found in list ``points`` even if ``point``
+already contains a M value.
 
 :param points: List of points in which a M point is searched.
 :param point: The point to update with M dimension and value.

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -759,10 +759,11 @@ A Z dimension is added to ``point`` if one of the point in the list
 
     static bool setMValueFromPoints( const QgsPointSequence &points, QgsPoint &point );
 %Docstring
-A M dimension is added to ``point`` if one of the point in the list
-``points`` is in 3D. Moreover, the M value of ``point`` is updated with.
+A M dimension is added to ``point`` if one of the points in the list
+``points`` contains an M value. Moreover, the M value of ``point`` is
+updated with the first M value found in list ``points``.
 
-:param points: List of points in which a 3D point is searched.
+:param points: List of points in which a M point is searched.
 :param point: The point to update with M dimension and value.
 
 :return: ``True`` if the point is updated, ``False`` otherwise

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -744,7 +744,7 @@ Returns a weighted point inside the triangle denoted by the points (``aX``, ``aY
 .. versionadded:: 3.10
 %End
 
-    static bool setZValueFromPoints( const QgsPointSequence &points, QgsPoint &point );
+ static bool setZValueFromPoints( const QgsPointSequence &points, QgsPoint &point ) /Deprecated/;
 %Docstring
 A Z dimension is added to ``point`` if one of the point in the list
 ``points`` is in 3D. Moreover, the Z value of ``point`` is updated with.
@@ -761,7 +761,6 @@ A Z dimension is added to ``point`` if one of the point in the list
 
 
 .. versionadded:: 3.0
-
 
 .. deprecated:: QGIS 3.20
    use transferFirstZValueToPoint( const :py:class:`QgsPointSequence` &points, :py:class:`QgsPoint` &point ) instead

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -761,6 +761,29 @@ A Z dimension is added to ``point`` if one of the point in the list
 
 
 .. versionadded:: 3.0
+
+
+.. deprecated:: QGIS 3.20
+   use transferFirstZValueToPoint( const :py:class:`QgsPointSequence` &points, :py:class:`QgsPoint` &point ) instead
+%End
+
+    static bool transferFirstZValueToPoint( const QgsPointSequence &points, QgsPoint &point );
+%Docstring
+A Z dimension is added to ``point`` if one of the point in the list
+``points`` is in 3D. Moreover, the Z value of ``point`` is updated with.
+
+:param points: List of points in which a 3D point is searched.
+:param point: The point to update with Z dimension and value.
+
+:return: ``True`` if the point is updated, ``False`` otherwise
+
+.. warning::
+
+   This method does not copy the z value of the coordinate from the
+   points whose z value is closest to the original x/y point, but only the first one found.
+
+
+.. versionadded:: 3.20
 %End
 
     static bool transferFirstMValueToPoint( const QgsPointSequence &points, QgsPoint &point );

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -763,7 +763,7 @@ A Z dimension is added to ``point`` if one of the point in the list
 .. versionadded:: 3.0
 %End
 
-    static bool setMValueFromPoints( const QgsPointSequence &points, QgsPoint &point );
+    static bool transferFirstMValueToPoint( const QgsPointSequence &points, QgsPoint &point );
 %Docstring
 A M dimension is added to ``point`` if one of the points in the list
 ``points`` contains an M value. Moreover, the M value of ``point`` is

--- a/src/core/geometry/qgscircle.cpp
+++ b/src/core/geometry/qgscircle.cpp
@@ -40,7 +40,7 @@ QgsCircle QgsCircle::from2Points( const QgsPoint &pt1, const QgsPoint &pt2 )
   double azimuth = QgsGeometryUtils::lineAngle( pt1.x(), pt1.y(), pt2.x(), pt2.y() ) * 180.0 / M_PI;
   double radius = pt1.distance( pt2 ) / 2.0;
 
-  QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << pt1 << pt2, center );
+  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << pt1 << pt2, center );
 
   return QgsCircle( center, radius, azimuth );
 }
@@ -141,7 +141,7 @@ QgsCircle QgsCircle::from3Points( const QgsPoint &pt1, const QgsPoint &pt2, cons
   double bSlope = yDelta_b / xDelta_b;
 
   // set z coordinate for center
-  QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << p1 << p2 << p3, center );
+  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << p1 << p2 << p3, center );
 
   if ( ( std::fabs( xDelta_a ) <= epsilon ) && ( std::fabs( yDelta_b ) <= epsilon ) )
   {
@@ -183,7 +183,7 @@ QgsCircle QgsCircle::fromCenterPoint( const QgsPoint &center, const QgsPoint &pt
   double azimuth = QgsGeometryUtils::lineAngle( center.x(), center.y(), pt1.x(), pt1.y() ) * 180.0 / M_PI;
 
   QgsPoint centerPt( center );
-  QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << center << pt1, centerPt );
+  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << center << pt1, centerPt );
 
   return QgsCircle( centerPt, centerPt.distance( pt1 ), azimuth );
 }
@@ -388,7 +388,7 @@ QgsCircle QgsCircle::fromExtent( const QgsPoint &pt1, const QgsPoint &pt2 )
   }
 
   QgsPoint center = QgsGeometryUtils::midpoint( pt1, pt2 );
-  QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << pt1 << pt2, center );
+  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << pt1 << pt2, center );
 
   return QgsCircle( center, delta_x / 2.0, 0 );
 }

--- a/src/core/geometry/qgsellipse.cpp
+++ b/src/core/geometry/qgsellipse.cpp
@@ -57,7 +57,7 @@ QgsEllipse QgsEllipse::fromFoci( const QgsPoint &pt1, const QgsPoint &pt2, const
   double axis_a = dist / 2.0;
   double axis_b = std::sqrt( std::pow( axis_a, 2.0 ) - std::pow( dist_p1p2 / 2.0, 2.0 ) );
 
-  QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << pt1 << pt2 << pt3, center );
+  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << pt1 << pt2 << pt3, center );
 
   return QgsEllipse( center, axis_a, axis_b, azimuth );
 }
@@ -69,7 +69,7 @@ QgsEllipse QgsEllipse::fromExtent( const QgsPoint &pt1, const QgsPoint &pt2 )
   double axis_b = std::fabs( pt2.y() - pt1.y() ) / 2.0;
   double azimuth = 90.0;
 
-  QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << pt1 << pt2, center );
+  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << pt1 << pt2, center );
 
   return QgsEllipse( center, axis_a, axis_b, azimuth );
 }
@@ -81,7 +81,7 @@ QgsEllipse QgsEllipse::fromCenterPoint( const QgsPoint &center, const QgsPoint &
   double azimuth = 90.0;
 
   QgsPoint centerPt( center );
-  QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << center << pt1, centerPt );
+  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << center << pt1, centerPt );
 
   return QgsEllipse( centerPt, axis_a, axis_b, azimuth );
 }
@@ -96,7 +96,7 @@ QgsEllipse QgsEllipse::fromCenter2Points( const QgsPoint &center, const QgsPoint
   double axis_b = center.distance( pp );
 
   QgsPoint centerPt( center );
-  QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << center << pt1 << pt2, centerPt );
+  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << center << pt1 << pt2, centerPt );
 
   return QgsEllipse( centerPt, axis_a, axis_b, azimuth );
 }

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -255,7 +255,7 @@ bool QgsGeometryUtils::lineIntersection( const QgsPoint &p1, QgsVector v1, const
   // z support for intersection point
   QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << p1 << p2, intersection );
   // m support for intersection point
-  QgsGeometryUtils::setMValueFromPoints( QgsPointSequence() << p1 << p2, intersection );
+  QgsGeometryUtils::transferFirstMValueToPoint( QgsPointSequence() << p1 << p2, intersection );
 
   return true;
 }
@@ -857,7 +857,7 @@ bool QgsGeometryUtils::segmentMidPoint( const QgsPoint &p1, const QgsPoint &p2, 
   // add z support if necessary
   QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << p1 << p2, result );
   // add m support if necessary
-  QgsGeometryUtils::setMValueFromPoints( QgsPointSequence() << p1 << p2, result );
+  QgsGeometryUtils::transferFirstMValueToPoint( QgsPointSequence() << p1 << p2, result );
 
   return true;
 }
@@ -1810,7 +1810,7 @@ void QgsGeometryUtils::weightedPointInTriangle( const double aX, const double aY
   pointY = rBy + rCy + aY;
 }
 
-bool QgsGeometryUtils::setMValueFromPoints( const QgsPointSequence &points, QgsPoint &point )
+bool QgsGeometryUtils::transferFirstMValueToPoint( const QgsPointSequence &points, QgsPoint &point )
 {
   bool rc = false;
 

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -254,6 +254,8 @@ bool QgsGeometryUtils::lineIntersection( const QgsPoint &p1, QgsVector v1, const
 
   // z support for intersection point
   QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << p1 << p2, intersection );
+  // m support for intersection point
+  QgsGeometryUtils::setMValueFromPoints( QgsPointSequence() << p1 << p2, intersection );
 
   return true;
 }
@@ -854,6 +856,8 @@ bool QgsGeometryUtils::segmentMidPoint( const QgsPoint &p1, const QgsPoint &p2, 
 
   // add z support if necessary
   QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << p1 << p2, result );
+  // add m support if necessary
+  QgsGeometryUtils::setMValueFromPoints( QgsPointSequence() << p1 << p2, result );
 
   return true;
 }
@@ -1804,6 +1808,24 @@ void QgsGeometryUtils::weightedPointInTriangle( const double aX, const double aY
 
   pointX = rBx + rCx + aX;
   pointY = rBy + rCy + aY;
+}
+
+bool QgsGeometryUtils::setMValueFromPoints( const QgsPointSequence &points, QgsPoint &point )
+{
+  bool rc = false;
+
+  for ( const QgsPoint &pt : points )
+  {
+    if ( pt.isMeasure() )
+    {
+      point.convertTo( QgsWkbTypes::addM( point.wkbType() ) );
+      point.setM( pt.m() );
+      rc = true;
+      break;
+    }
+  }
+
+  return rc;
 }
 
 bool QgsGeometryUtils::setZValueFromPoints( const QgsPointSequence &points, QgsPoint &point )

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -253,7 +253,7 @@ bool QgsGeometryUtils::lineIntersection( const QgsPoint &p1, QgsVector v1, const
   intersection = QgsPoint( p1.x() + v1.x() * k, p1.y() + v1.y() * k );
 
   // z support for intersection point
-  QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << p1 << p2, intersection );
+  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << p1 << p2, intersection );
   // m support for intersection point
   QgsGeometryUtils::transferFirstMValueToPoint( QgsPointSequence() << p1 << p2, intersection );
 
@@ -855,7 +855,7 @@ bool QgsGeometryUtils::segmentMidPoint( const QgsPoint &p1, const QgsPoint &p2, 
   result = possibleMidPoints.at( minDistIndex );
 
   // add z support if necessary
-  QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << p1 << p2, result );
+  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << p1 << p2, result );
   // add m support if necessary
   QgsGeometryUtils::transferFirstMValueToPoint( QgsPointSequence() << p1 << p2, result );
 
@@ -1828,7 +1828,7 @@ bool QgsGeometryUtils::transferFirstMValueToPoint( const QgsPointSequence &point
   return rc;
 }
 
-bool QgsGeometryUtils::setZValueFromPoints( const QgsPointSequence &points, QgsPoint &point )
+bool QgsGeometryUtils::transferFirstZValueToPoint( const QgsPointSequence &points, QgsPoint &point )
 {
   bool rc = false;
 

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -781,6 +781,18 @@ class CORE_EXPORT QgsGeometryUtils
     static bool setZValueFromPoints( const QgsPointSequence &points, QgsPoint &point );
 
     /**
+     * A M dimension is added to \a point if one of the point in the list
+     * \a points is in 3D. Moreover, the M value of \a point is updated with.
+     *
+     * \param points List of points in which a 3D point is searched.
+     * \param point The point to update with M dimension and value.
+     * \returns TRUE if the point is updated, FALSE otherwise
+     *
+     * \since QGIS 3.20
+     */
+    static bool setMValueFromPoints( const QgsPointSequence &points, QgsPoint &point );
+
+    /**
      * Returns the point (\a pointX, \a pointY) forming the bisector from segment (\a aX \a aY) (\a bX \a bY)
      * and segment (\a bX, \a bY) (\a dX, \a dY).
      * The bisector segment of AB-CD is (point, projection of point by \a angle)

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -776,6 +776,9 @@ class CORE_EXPORT QgsGeometryUtils
      * \param point The point to update with Z dimension and value.
      * \returns TRUE if the point is updated, FALSE otherwise
      *
+     * \warning This method does not copy the z value of the coordinate from the
+     * points whose z value is closest to the original x/y point, but only the first one found.
+     *
      * \since QGIS 3.0
      */
     static bool setZValueFromPoints( const QgsPointSequence &points, QgsPoint &point );
@@ -788,6 +791,9 @@ class CORE_EXPORT QgsGeometryUtils
      * \param points List of points in which a M point is searched.
      * \param point The point to update with M dimension and value.
      * \returns TRUE if the point is updated, FALSE otherwise
+     *
+     * \warning This method does not copy the m value of the coordinate from the
+     * points whose m value is closest to the original x/y point, but only the first one found.
      *
      * \since QGIS 3.20
      */

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -780,8 +780,28 @@ class CORE_EXPORT QgsGeometryUtils
      * points whose z value is closest to the original x/y point, but only the first one found.
      *
      * \since QGIS 3.0
+     *
+     * \deprecated since QGIS 3.20 use transferFirstZValueToPoint( const QgsPointSequence &points, QgsPoint &point ) instead
      */
-    static bool setZValueFromPoints( const QgsPointSequence &points, QgsPoint &point );
+    static bool setZValueFromPoints( const QgsPointSequence &points, QgsPoint &point )
+    {
+      return transferFirstZValueToPoint( points, point );
+    }
+
+    /**
+     * A Z dimension is added to \a point if one of the point in the list
+     * \a points is in 3D. Moreover, the Z value of \a point is updated with.
+     *
+     * \param points List of points in which a 3D point is searched.
+     * \param point The point to update with Z dimension and value.
+     * \returns TRUE if the point is updated, FALSE otherwise
+     *
+     * \warning This method does not copy the z value of the coordinate from the
+     * points whose z value is closest to the original x/y point, but only the first one found.
+     *
+     * \since QGIS 3.20
+     */
+    static bool transferFirstZValueToPoint( const QgsPointSequence &points, QgsPoint &point );
 
     /**
      * A M dimension is added to \a point if one of the points in the list

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -797,7 +797,7 @@ class CORE_EXPORT QgsGeometryUtils
      *
      * \since QGIS 3.20
      */
-    static bool setMValueFromPoints( const QgsPointSequence &points, QgsPoint &point );
+    static bool transferFirstMValueToPoint( const QgsPointSequence &points, QgsPoint &point );
 
     /**
      * Returns the point (\a pointX, \a pointY) forming the bisector from segment (\a aX \a aY) (\a bX \a bY)

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -770,7 +770,9 @@ class CORE_EXPORT QgsGeometryUtils
 
     /**
      * A Z dimension is added to \a point if one of the point in the list
-     * \a points is in 3D. Moreover, the Z value of \a point is updated with.
+     * \a points is in 3D. Moreover, the Z value of \a point is updated
+     * with the first Z value found in list \a points even if \a point
+     * already contains a Z value.
      *
      * \param points List of points in which a 3D point is searched.
      * \param point The point to update with Z dimension and value.
@@ -789,7 +791,9 @@ class CORE_EXPORT QgsGeometryUtils
 
     /**
      * A Z dimension is added to \a point if one of the point in the list
-     * \a points is in 3D. Moreover, the Z value of \a point is updated with.
+     * \a points is in 3D. Moreover, the Z value of \a point is updated
+     * with the first Z value found in list \a points even if \a point
+     * already contains a Z value.
      *
      * \param points List of points in which a 3D point is searched.
      * \param point The point to update with Z dimension and value.
@@ -805,7 +809,8 @@ class CORE_EXPORT QgsGeometryUtils
     /**
      * A M dimension is added to \a point if one of the points in the list
      * \a points contains an M value. Moreover, the M value of \a point is
-     * updated with the first M value found in list \a points.
+     * updated with the first M value found in list \a points even if \a point
+     * already contains a M value.
      *
      * \param points List of points in which a M point is searched.
      * \param point The point to update with M dimension and value.

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -781,10 +781,11 @@ class CORE_EXPORT QgsGeometryUtils
     static bool setZValueFromPoints( const QgsPointSequence &points, QgsPoint &point );
 
     /**
-     * A M dimension is added to \a point if one of the point in the list
-     * \a points is in 3D. Moreover, the M value of \a point is updated with.
+     * A M dimension is added to \a point if one of the points in the list
+     * \a points contains an M value. Moreover, the M value of \a point is
+     * updated with the first M value found in list \a points.
      *
-     * \param points List of points in which a 3D point is searched.
+     * \param points List of points in which a M point is searched.
      * \param point The point to update with M dimension and value.
      * \returns TRUE if the point is updated, FALSE otherwise
      *

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -780,10 +780,9 @@ class CORE_EXPORT QgsGeometryUtils
      * points whose z value is closest to the original x/y point, but only the first one found.
      *
      * \since QGIS 3.0
-     *
      * \deprecated since QGIS 3.20 use transferFirstZValueToPoint( const QgsPointSequence &points, QgsPoint &point ) instead
      */
-    static bool setZValueFromPoints( const QgsPointSequence &points, QgsPoint &point )
+    Q_DECL_DEPRECATED static bool setZValueFromPoints( const QgsPointSequence &points, QgsPoint &point ) SIP_DEPRECATED
     {
       return transferFirstZValueToPoint( points, point );
     }

--- a/src/core/geometry/qgstriangle.cpp
+++ b/src/core/geometry/qgstriangle.cpp
@@ -588,7 +588,7 @@ QgsPoint QgsTriangle::inscribedCenter() const
 
   QgsPointSequence points;
   points << vertexAt( 0 ) << vertexAt( 1 ) << vertexAt( 2 );
-  QgsGeometryUtils::setZValueFromPoints( points, center );
+  QgsGeometryUtils::transferFirstZValueToPoint( points, center );
 
   return center;
 }

--- a/tests/src/core/testqgsgeometryutils.cpp
+++ b/tests/src/core/testqgsgeometryutils.cpp
@@ -86,7 +86,7 @@ class TestQgsGeometryUtils: public QObject
     void testPerpendicularOffsetPoint();
     void testClosestSideOfRectangle();
     void setZValueFromPoints();
-    void setMValueFromPoints();
+    void transferFirstMValueToPoint();
 };
 
 
@@ -1637,26 +1637,26 @@ void TestQgsGeometryUtils::setZValueFromPoints()
   QCOMPARE( pointM.z(), 4.0 );
 }
 
-void TestQgsGeometryUtils::setMValueFromPoints()
+void TestQgsGeometryUtils::transferFirstMValueToPoint()
 {
   QgsPoint point( 1, 2 );
 
   // Type: Point
-  bool ret = QgsGeometryUtils::setMValueFromPoints( QgsPointSequence() << QgsPoint( 0, 2 ), point );
+  bool ret = QgsGeometryUtils::transferFirstMValueToPoint( QgsPointSequence() << QgsPoint( 0, 2 ), point );
   QCOMPARE( ret, false );
 
   // Type: PointZ
-  ret = QgsGeometryUtils::setMValueFromPoints( QgsPointSequence() << QgsPoint( 0, 2, 4 ), point );
+  ret = QgsGeometryUtils::transferFirstMValueToPoint( QgsPointSequence() << QgsPoint( 0, 2, 4 ), point );
   QCOMPARE( ret, false );
 
   // Type: PointM
-  ret = QgsGeometryUtils::setMValueFromPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 2, 0, 4 ), point );
+  ret = QgsGeometryUtils::transferFirstMValueToPoint( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 2, 0, 4 ), point );
   QCOMPARE( ret, true );
   QCOMPARE( point.wkbType(), QgsWkbTypes::PointM );
   QCOMPARE( point.m(), 4.0 );
 
   // Type: PointM
-  ret = QgsGeometryUtils::setMValueFromPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 2, 0, 5 ), point );
+  ret = QgsGeometryUtils::transferFirstMValueToPoint( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 2, 0, 5 ), point );
   QCOMPARE( ret, true );
   QCOMPARE( point.wkbType(), QgsWkbTypes::PointM );
   QCOMPARE( point.m(), 5.0 ); // now point.z == 5. Shouldn't the current M be left if the point is already of type PointM?
@@ -1664,7 +1664,7 @@ void TestQgsGeometryUtils::setMValueFromPoints()
   // Add M to a PointZ
   QgsPoint pointZ( 1, 2, 4 );
   // Type: PointM
-  ret = QgsGeometryUtils::setMValueFromPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 2, 0, 5 ), pointZ );
+  ret = QgsGeometryUtils::transferFirstMValueToPoint( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 2, 0, 5 ), pointZ );
   QCOMPARE( ret, true );
   QCOMPARE( pointZ.wkbType(), QgsWkbTypes::PointZM );
   QCOMPARE( pointZ.m(), 5.0 );

--- a/tests/src/core/testqgsgeometryutils.cpp
+++ b/tests/src/core/testqgsgeometryutils.cpp
@@ -85,7 +85,7 @@ class TestQgsGeometryUtils: public QObject
     void testAngleBisector();
     void testPerpendicularOffsetPoint();
     void testClosestSideOfRectangle();
-    void setZValueFromPoints();
+    void transferFirstZValueToPoint();
     void transferFirstMValueToPoint();
 };
 
@@ -1604,26 +1604,26 @@ void TestQgsGeometryUtils::testClosestSideOfRectangle()
   QCOMPARE( QgsGeometryUtils::closestSideOfRectangle( 16, -20, 10, -18, 14, -19.5 ), 5 );
 }
 
-void TestQgsGeometryUtils::setZValueFromPoints()
+void TestQgsGeometryUtils::transferFirstZValueToPoint()
 {
   QgsPoint point( 1, 2 );
 
   // Type: Point
-  bool ret = QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << QgsPoint( 0, 2 ), point );
+  bool ret = QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << QgsPoint( 0, 2 ), point );
   QCOMPARE( ret, false );
 
   // Type: PointM
-  ret = QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 2, 0, 4 ), point );
+  ret = QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 2, 0, 4 ), point );
   QCOMPARE( ret, false );
 
   // Type: PointZ
-  ret = QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << QgsPoint( 0, 2, 4 ), point );
+  ret = QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << QgsPoint( 0, 2, 4 ), point );
   QCOMPARE( ret, true );
   QCOMPARE( point.wkbType(), QgsWkbTypes::PointZ );
   QCOMPARE( point.z(), 4.0 );
 
   // Type: PointZ
-  ret = QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << QgsPoint( 0, 2, 5 ), point );
+  ret = QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << QgsPoint( 0, 2, 5 ), point );
   QCOMPARE( ret, true );
   QCOMPARE( point.wkbType(), QgsWkbTypes::PointZ );
   QCOMPARE( point.z(), 5.0 ); // now point.z == 5. Shouldn't the current Z be left if the point is already of type PointZ?
@@ -1631,7 +1631,7 @@ void TestQgsGeometryUtils::setZValueFromPoints()
   // Add Z to a PointM
   QgsPoint pointM( QgsWkbTypes::PointM, 1, 2, 0, 3 );
   // Type: PointZ
-  ret = QgsGeometryUtils::setZValueFromPoints( QgsPointSequence() << QgsPoint( 0, 2, 4 ), pointM );
+  ret = QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << QgsPoint( 0, 2, 4 ), pointM );
   QCOMPARE( ret, true );
   QCOMPARE( pointM.wkbType(), QgsWkbTypes::PointZM );
   QCOMPARE( pointM.z(), 4.0 );

--- a/tests/src/core/testqgsgeometryutils.cpp
+++ b/tests/src/core/testqgsgeometryutils.cpp
@@ -1626,7 +1626,7 @@ void TestQgsGeometryUtils::transferFirstZValueToPoint()
   ret = QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << QgsPoint( 0, 2, 5 ), point );
   QCOMPARE( ret, true );
   QCOMPARE( point.wkbType(), QgsWkbTypes::PointZ );
-  QCOMPARE( point.z(), 5.0 ); // now point.z == 5. Shouldn't the current Z be left if the point is already of type PointZ?
+  QCOMPARE( point.z(), 5.0 ); // now point.z == 5.
 
   // Add Z to a PointM
   QgsPoint pointM( QgsWkbTypes::PointM, 1, 2, 0, 3 );
@@ -1659,7 +1659,7 @@ void TestQgsGeometryUtils::transferFirstMValueToPoint()
   ret = QgsGeometryUtils::transferFirstMValueToPoint( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 2, 0, 5 ), point );
   QCOMPARE( ret, true );
   QCOMPARE( point.wkbType(), QgsWkbTypes::PointM );
-  QCOMPARE( point.m(), 5.0 ); // now point.z == 5. Shouldn't the current M be left if the point is already of type PointM?
+  QCOMPARE( point.m(), 5.0 ); // now point.m == 5
 
   // Add M to a PointZ
   QgsPoint pointZ( 1, 2, 4 );


### PR DESCRIPTION
## Description

This PR is the first of a series to improve the support of the M. It is the prequel of #42040

`setMValueFromPoints` will be used where `setZValueFromPoints` is already used.

@pblottiere I wonder if we should keep the existing Z if it exists or if we should add the first Z in the list anyway?

example
```python
point = QgsPoint(1, 2)
ret = QgsGeometryUtils.setZValueFromPoints([QgsPoint(0, 1, 2)], point) # ret == True, point == QgsPoint: PointZ (1 2 2)
ret = QgsGeometryUtils.setZValueFromPoints([QgsPoint(3, 4, 5)], point) # ret == True, point == QgsPoint: PointZ (1 2 5) z must be 5 or 2?
```

If we have to change the behavior (I don't think there is much impact, we'll see what the CI says) I'll do that in another PR.


Sponsored by: Métropole Européenne de Lille @Jean-Roc