### PR TITLE
"Flatten relationships" alg output should not be optional

### DIFF
--- a/src/analysis/processing/qgsalgorithmflattenrelationships.cpp
+++ b/src/analysis/processing/qgsalgorithmflattenrelationships.cpp
@@ -69,7 +69,7 @@ void QgsFlattenRelationshipsAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterVectorLayer( QStringLiteral( "INPUT" ),
                 QObject::tr( "Input layer" ), QList< int>() << QgsProcessing::TypeVector ) );
 
-  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Flattened layer" ), QgsProcessing::TypeVectorAnyGeometry, QVariant(), true, true ) );
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Flattened layer" ), QgsProcessing::TypeVectorAnyGeometry ) );
 }
 
 QgsFlattenRelationshipsAlgorithm *QgsFlattenRelationshipsAlgorithm::createInstance() const


### PR DESCRIPTION
It's the single output of the alg and trying to skip it crashes QGIS