### PR TITLE
Improving the naming of layout templates (.QPT)

### DIFF
--- a/src/app/layout/qgslayoutmanagerdialog.cpp
+++ b/src/app/layout/qgslayoutmanagerdialog.cpp
@@ -200,7 +200,7 @@ QMap<QString, QString> QgsLayoutManagerDialog::templatesFromPath( const QString 
   {
     if ( info.suffix().compare( QLatin1String( "qpt" ), Qt::CaseInsensitive ) == 0 )
     {
-      templateMap.insert( info.baseName(), info.absoluteFilePath() );
+      templateMap.insert( info.completeBaseName(), info.absoluteFilePath() );
     }
   }
   return templateMap;


### PR DESCRIPTION
## Description

Enables the use of a dot in the file name when using layout paths for templates, e.g. for version control of the templates.

Example for the file company_layout_1.2.qpt:

Before:
![Screenshot 2021-04-16 232508](https://user-images.githubusercontent.com/18557959/115085999-bd0af280-9f0b-11eb-94f0-8b0883a1f4d5.jpg)

After:
![Bildschirmfoto vom 2021-04-16 23-35-16](https://user-images.githubusercontent.com/18557959/115086483-9f8a5880-9f0c-11eb-8a8e-4841b54932f4.png)

If nothing stands in the way, I would be in favor of a backport in the LTR.



