### PR TITLE
Fix doxygen blocks which don't use the * prefix on all lines

### DIFF
--- a/python/analysis/auto_generated/raster/qgsninecellfilter.sip.in
+++ b/python/analysis/auto_generated/raster/qgsninecellfilter.sip.in
@@ -15,6 +15,7 @@ class QgsNineCellFilter
 %Docstring(signature="appended")
 Base class for raster analysis methods that work with a 3x3 cell filter and calculate the value of each cell based on
 the cell value and the eight neighbour cells.
+
 Common examples are slope and aspect calculation in DEMs. Subclasses only implement
 the method that calculates the new value from the nine values. Everything else (reading file, writing file) is done by this subclass
 %End

--- a/python/core/auto_generated/expression/qgsexpression.sip.in
+++ b/python/core/auto_generated/expression/qgsexpression.sip.in
@@ -10,7 +10,6 @@
 
 
 
-
 class QgsExpression
 {
 %Docstring(signature="appended")
@@ -20,15 +19,15 @@ The expressions try to follow both syntax and semantics of SQL expressions.
 Usage:
 .. code-block:: python
 
-    exp = QgsExpression("gid*2 > 10 and type not in ('D','F')")
-    if exp.hasParserError():
-    # show error message with parserErrorString() and exit
+       exp = QgsExpression("gid*2 > 10 and type not in ('D','F')")
+       if exp.hasParserError():
+           # show error message with parserErrorString() and exit
 
-    result = exp.evaluate(feature, fields)
-    if exp.hasEvalError():
-    # show error message with evalErrorString()
-    else:
-    # examine the result
+       result = exp.evaluate(feature, fields)
+       if exp.hasEvalError():
+           # show error message with evalErrorString()
+       else:
+           # examine the result
 
 Three Value Logic
 -----------------

--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -9,7 +9,6 @@
 
 
 
-
 class QgsApplication : QApplication
 {
 %Docstring(signature="appended")

--- a/python/core/auto_generated/qgspythonrunner.sip.in
+++ b/python/core/auto_generated/qgspythonrunner.sip.in
@@ -27,7 +27,7 @@ will then work as expected.
     static bool isValid();
 %Docstring
 Returns ``True`` if the runner has an instance
-(and thus is able to run commands) *
+(and thus is able to run commands)
 %End
 
     static bool run( const QString &command, const QString &messageOnError = QString() );

--- a/python/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -13,10 +13,12 @@
 class QgsVectorFileWriter : QgsFeatureSink
 {
 %Docstring(signature="appended")
-A convenience class for writing vector files to disk.
+A convenience class for writing vector layers to disk based formats (e.g. Shapefiles, GeoPackage).
+
 There are two possibilities how to use this class:
-1. static call to :py:class:`QgsVectorFileWriter`.writeAsVectorFormat(...) which saves the whole vector layer
-2. create an instance of the class and issue calls to addFeature(...)
+
+1. A static call to :py:class:`QgsVectorFileWriter`.writeAsVectorFormat(...) which saves the whole vector layer.
+2. Create an instance of the class and issue calls to addFeature(...).
 %End
 
 %TypeHeaderCode

--- a/python/core/auto_generated/vector/qgsvectorlayereditbuffer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayereditbuffer.sip.in
@@ -25,7 +25,6 @@ class QgsVectorLayerEditBuffer : QObject
 Returns ``True`` if the provider has been modified since the last commit
 %End
 
-
     virtual bool addFeature( QgsFeature &f );
 %Docstring
 Adds a feature
@@ -71,13 +70,13 @@ Changes values of attributes (but does not commit it).
 
     virtual bool addAttribute( const QgsField &field );
 %Docstring
-Add an attribute field (but does not commit it)
-returns true if the field was added
+Adds an attribute field (but does not commit it)
+returns ``True`` if the field was added
 %End
 
     virtual bool deleteAttribute( int attr );
 %Docstring
-Delete an attribute field (but does not commit it)
+Deletes an attribute field (but does not commit it)
 %End
 
     virtual bool renameAttribute( int attr, const QString &newName );

--- a/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
@@ -69,7 +69,6 @@ Returns the selected features in the attribute table in table sorted order.
 .. versionadded:: 3.4
 %End
 
-
     void scrollToFeature( const QgsFeatureId &fid, int column = -1 );
 %Docstring
 Scroll to a feature with a given ``fid``.
@@ -78,7 +77,6 @@ Optionally a ``column`` can be specified, which will also bring that column into
 
 .. versionadded:: 3.16
 %End
-
 
   protected:
 

--- a/python/gui/auto_generated/symbology/qgsrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgsrendererwidget.sip.in
@@ -14,6 +14,7 @@ class QgsRendererWidget : QgsPanelWidget
 Base class for renderer settings widgets.
 
 WORKFLOW:
+
 - open renderer dialog with some RENDERER  (never null!)
 - find out which widget to use
 - instantiate it and set in stacked widget

--- a/scripts/doxygen_space.pl
+++ b/scripts/doxygen_space.pl
@@ -133,6 +133,12 @@ while ($LINE_IDX < $LINE_COUNT){
           print $out_handle $BUFFERED_LINE."\n";
           $BUFFERED_LINE = "";
         }
+
+        if ($new_line !~ m/^\s*\*/ && $new_line =~ m/^(\s*?)(\s?)(.+?)$/ )
+        {
+          $new_line = "$1* $3";
+        }
+
         print $out_handle $new_line."\n";
         # print $out_handle "normal dox\n";
         $PREVIOUS_WAS_DOX_BLANKLINE = 0;

--- a/src/3d/chunks/qgschunkqueuejob_p.h
+++ b/src/3d/chunks/qgschunkqueuejob_p.h
@@ -48,8 +48,9 @@ namespace Qt3DCore
  * and will be processed by the parent chunked entity.
  *
  * There are currently two types of queue jobs:
- *  1. chunk loaders: prepares all data needed for creation of entities (ChunkLoader sub-class)
- *  2. chunk updaters: given a chunk with already existing entity, it updates the entity (e.g. update texture or geometry)
+ *
+ * 1. chunk loaders: prepares all data needed for creation of entities (ChunkLoader sub-class)
+ * 2. chunk updaters: given a chunk with already existing entity, it updates the entity (e.g. update texture or geometry)
  *
  * \since QGIS 3.0
  */

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -125,8 +125,8 @@ class _3D_EXPORT Qgs3DUtils
     static void extractPointPositions( const QgsFeature &f, const Qgs3DMapSettings &map, Qgs3DTypes::AltitudeClamping altClamp, QVector<QVector3D> &positions );
 
     /**
-        Returns true if bbox is completely outside the current viewing volume.
-        This is used to perform object culling checks.
+     * Returns TRUE if bbox is completely outside the current viewing volume.
+     * This is used to perform object culling checks.
     */
     static bool isCullable( const QgsAABB &bbox, const QMatrix4x4 &viewProjectionMatrix );
 

--- a/src/analysis/raster/qgsninecellfilter.h
+++ b/src/analysis/raster/qgsninecellfilter.h
@@ -28,7 +28,8 @@ class QgsFeedback;
 /**
  * \ingroup analysis
  * \brief Base class for raster analysis methods that work with a 3x3 cell filter and calculate the value of each cell based on
-the cell value and the eight neighbour cells.
+ * the cell value and the eight neighbour cells.
+ *
  * Common examples are slope and aspect calculation in DEMs. Subclasses only implement
  * the method that calculates the new value from the nine values. Everything else (reading file, writing file) is done by this subclass
  */

--- a/src/app/georeferencer/qgsresidualplotitem.h
+++ b/src/app/georeferencer/qgsresidualplotitem.h
@@ -22,7 +22,8 @@
 
 /**
  * A composer item to visualise the distribution of georeference residuals. For the visualisation,
-the length of the residual arrows are scaled*/
+ * the length of the residual arrows are scaled.
+*/
 class QgsResidualPlotItem: public QgsLayoutItem
 {
     Q_OBJECT

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -494,15 +494,7 @@ class QgsUserProfile;
 
 /**
  * Set the application title bar text
-
-  If the current project title is null
-  if the project file is null then
-  set title text to just application name
-  else
-  set set title text to the project file name
-  else
-  set the title text to project title
-  */
+ */
 static void setTitleBarText_( QWidget &qgisApp )
 {
   QString caption;
@@ -548,7 +540,7 @@ static void setTitleBarText_( QWidget &qgisApp )
 }
 
 /**
- Creator function for output viewer
+ * Creator function for output viewer
 */
 static QgsMessageOutput *messageOutputViewer_()
 {

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -240,8 +240,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     /**
      * Open the specified project file; prompt to save previous project if necessary.
-      Used to process a commandline argument, FileOpen or Drop event.
-      */
+     * Used to process a commandline argument, FileOpen or Drop event.
+     */
     void openProject( const QString &fileName );
 
     void openLayerDefinition( const QString &filename );
@@ -1105,7 +1105,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      */
     QgsBrowserGuiModel *browserModel();
 
-    /*
+    /**
      * Change data source for \a layer, a data source selection dialog
      * will be opened and if accepted the data selected source will be
      * applied.
@@ -1117,22 +1117,22 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     /**
      * Add a raster layer directly without prompting user for location
-      The caller must provide information compatible with the provider plugin
-      using the \a uri and \a baseName. The provider can use these
-      parameters in any way necessary to initialize the layer. The \a baseName
-      parameter is used in the Map Legend so it should be formed in a meaningful
-      way.
-      */
+     * The caller must provide information compatible with the provider plugin
+     * using the \a uri and \a baseName. The provider can use these
+     * parameters in any way necessary to initialize the layer. The \a baseName
+     * parameter is used in the Map Legend so it should be formed in a meaningful
+     * way.
+     */
     QgsRasterLayer *addRasterLayer( QString const &uri, QString const &baseName, QString const &providerKey );
 
     /**
      * Add a vector layer directly without prompting user for location
-      The caller must provide information compatible with the provider plugin
-      using the \a vectorLayerPath and \a baseName. The provider can use these
-      parameters in any way necessary to initialize the layer. The \a baseName
-      parameter is used in the Map Legend so it should be formed in a meaningful
-      way.
-      */
+     * The caller must provide information compatible with the provider plugin
+     * using the \a vectorLayerPath and \a baseName. The provider can use these
+     * parameters in any way necessary to initialize the layer. The \a baseName
+     * parameter is used in the Map Legend so it should be formed in a meaningful
+     * way.
+     */
     QgsVectorLayer *addVectorLayer( const QString &vectorLayerPath, const QString &baseName, const QString &providerKey );
 
     /**
@@ -2469,14 +2469,14 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     /**
      * String containing supporting vector file formats
-      Suitable for a QFileDialog file filter.  Build in ctor.
-      */
+     * Suitable for a QFileDialog file filter.  Build in ctor.
+     */
     QString mVectorFileFilter;
 
     /**
      * String containing supporting raster file formats
-      Suitable for a QFileDialog file filter.  Build in ctor.
-      */
+     * Suitable for a QFileDialog file filter.  Build in ctor.
+     */
     QString mRasterFileFilter;
 
     //! Timer for map tips

--- a/src/app/qgsannotationwidget.h
+++ b/src/app/qgsannotationwidget.h
@@ -27,8 +27,10 @@ class QgsMarkerSymbol;
 class QgsFillSymbol;
 
 /**
- * A configuration widget to configure the annotation item properties. Usually embedded by QgsAnnotation
-subclass configuration dialogs*/
+ * A configuration widget to configure the annotation item properties.
+ *
+ * Usually embedded by QgsAnnotation subclass configuration dialogs.
+*/
 class APP_EXPORT QgsAnnotationWidget: public QWidget, private Ui::QgsAnnotationWidgetBase
 {
     Q_OBJECT

--- a/src/app/qgsclipboard.h
+++ b/src/app/qgsclipboard.h
@@ -64,45 +64,45 @@ class APP_EXPORT QgsClipboard : public QObject
     QgsClipboard();
 
     /**
-     *  Place a copy of the selected features from the specified layer on
-     *  the internal clipboard, destroying the previous contents.
+     * Place a copy of the selected features from the specified layer on
+     * the internal clipboard, destroying the previous contents.
      */
     void replaceWithCopyOf( QgsVectorLayer *src );
 
     /**
-     *  Place a copy of features on the internal clipboard,
-     *  destroying the previous contents.
+     * Place a copy of features on the internal clipboard,
+     * destroying the previous contents.
      */
     void replaceWithCopyOf( QgsFeatureStore &featureStore );
 
     /**
-     *  Returns a copy of features on the internal clipboard.
+     * Returns a copy of features on the internal clipboard.
      */
     QgsFeatureList copyOf( const QgsFields &fields = QgsFields() ) const;
 
     /**
-     *  Clears the internal clipboard.
+     * Clears the internal clipboard.
      */
     void clear();
 
     /**
-     *  Inserts a copy of the feature on the internal clipboard.
+     * Inserts a copy of the feature on the internal clipboard.
      */
     void insert( const QgsFeature &feature );
 
     /**
-     *  Returns TRUE if the internal clipboard is empty, else FALSE.
+     * Returns TRUE if the internal clipboard is empty, else FALSE.
      */
     bool isEmpty() const;
 
     /**
-     *  Returns a copy of features on the internal clipboard, transformed
-     *  from the clipboard CRS to the destCRS.
+     * Returns a copy of features on the internal clipboard, transformed
+     * from the clipboard CRS to the destCRS.
      */
     QgsFeatureList transformedCopyOf( const QgsCoordinateReferenceSystem &destCRS, const QgsFields &fields = QgsFields() ) const;
 
     /**
-     *  Get the clipboard CRS
+     * Get the clipboard CRS
      */
     QgsCoordinateReferenceSystem crs() const;
 
@@ -171,8 +171,8 @@ class APP_EXPORT QgsClipboard : public QObject
 
     /**
      * QGIS-internal vector feature clipboard.
-        Stored as values not pointers as each clipboard operation
-        involves a deep copy anyway.
+     * Stored as values not pointers as each clipboard operation
+     * involves a deep copy anyway.
      */
     QgsFeatureList mFeatureClipboard;
     QgsFields mFeatureFields;

--- a/src/app/qgscustomprojectiondialog.h
+++ b/src/app/qgscustomprojectiondialog.h
@@ -26,7 +26,9 @@
 class QDir;
 
 /**
-The custom projection widget is used to define the projection family, ellipsoid and parameters needed by proj4 to assemble a customized projection definition. The resulting projection will be store in an sqlite backend.
+ * The custom projection widget is used to define the projection family, ellipsoid and parameters needed by proj4 to assemble a customized projection definition.
+ *
+ * The resulting projection will be stored in an sqlite backend.
 */
 class APP_EXPORT QgsCustomProjectionDialog : public QDialog, private Ui::QgsCustomProjectionDialogBase
 {

--- a/src/app/qgsmaptooladdcircle.h
+++ b/src/app/qgsmaptooladdcircle.h
@@ -51,8 +51,8 @@ class APP_EXPORT QgsMapToolAddCircle: public QgsMapToolCapture
 
     /**
      * The parent map tool, e.g. the add feature tool.
-     *  Completed circle will be added to this tool by calling its addCurve() method.
-     **/
+     * Completed circle will be added to this tool by calling its addCurve() method.
+     */
     QgsMapToolCapture *mParentTool = nullptr;
     //! Circle points (in map coordinates)
     QgsPointSequence mPoints;

--- a/src/app/qgsmaptooladdellipse.h
+++ b/src/app/qgsmaptooladdellipse.h
@@ -47,8 +47,8 @@ class APP_EXPORT QgsMapToolAddEllipse: public QgsMapToolCapture
 
     /**
      * The parent map tool, e.g. the add feature tool.
-     *  Completed ellipse will be added to this tool by calling its toLineString() method.
-     **/
+     * Completed ellipse will be added to this tool by calling its toLineString() method.
+     */
     QgsMapToolCapture *mParentTool = nullptr;
     //! Ellipse points (in map coordinates)
     QgsPointSequence mPoints;

--- a/src/app/qgsmaptooladdrectangle.h
+++ b/src/app/qgsmaptooladdrectangle.h
@@ -48,8 +48,8 @@ class APP_EXPORT QgsMapToolAddRectangle: public QgsMapToolCapture
 
     /**
      * The parent map tool, e.g. the add feature tool.
-     *  Completed regular shape will be added to this tool by calling its addCurve() method.
-     **/
+     * Completed regular shape will be added to this tool by calling its addCurve() method.
+     */
     QgsMapToolCapture *mParentTool = nullptr;
     //! Regular Shape points (in map coordinates)
     QgsPointSequence mPoints;

--- a/src/app/qgsmaptooladdregularpolygon.h
+++ b/src/app/qgsmaptooladdregularpolygon.h
@@ -56,8 +56,8 @@ class APP_EXPORT QgsMapToolAddRegularPolygon: public QgsMapToolCapture
 
     /**
      * The parent map tool, e.g. the add feature tool.
-     *  Completed regular polygon will be added to this tool by calling its addCurve() method.
-     **/
+     * Completed regular polygon will be added to this tool by calling its addCurve() method.
+     */
     QgsMapToolCapture *mParentTool = nullptr;
     //! Regular Shape points (in map coordinates)
     QgsPointSequence mPoints;

--- a/src/app/qgsmaptoolselectutils.h
+++ b/src/app/qgsmaptoolselectutils.h
@@ -33,7 +33,7 @@ class QMenu;
 class QgsHighlight;
 
 /**
-  Namespace containing methods which are useful for the select maptool widgets
+ * Namespace containing methods which are useful for the select maptool widgets
  */
 namespace QgsMapToolSelectUtils
 {
@@ -41,11 +41,11 @@ namespace QgsMapToolSelectUtils
   /**
    * Calculates a list of features matching a selection geometry and flags.
    * \param canvas the map canvas used to get the current selected vector layer and
-    for any required geometry transformations
+   * for any required geometry transformations
    * \param selectGeometry the geometry to select the layers features. This geometry
-    must be in terms of the canvas coordinate system.
+   * must be in terms of the canvas coordinate system.
    * \param doContains features will only be selected if fully contained within
-    the selection rubber band (otherwise intersection is enough).
+   * the selection rubber band (otherwise intersection is enough).
    * \param singleSelect only selects the closest feature to the selectGeometry.
    * \returns list of features which match search geometry and parameters
    * \since QGIS 2.16

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -61,7 +61,7 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     void setCurrentPage( const QString & );
 
     /**
-       Every project has a title
+      * Every project has a title
      */
     QString title() const;
     void title( QString const &title );

--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -152,8 +152,8 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
 
     /**
      * Temporarily override snapping config and snap to vertices and edges
-     of any editable vector layer, to allow selection of vertex for editing
-     (if snapped to edge, it would offer creation of a new vertex there).
+    * of any editable vector layer, to allow selection of vertex for editing
+    * (if snapped to edge, it would offer creation of a new vertex there).
     */
     QgsPointLocator::Match snapToEditableLayer( QgsMapMouseEvent *e );
 

--- a/src/auth/oauth2/qgso2.h
+++ b/src/auth/oauth2/qgso2.h
@@ -63,10 +63,12 @@ class QgsO2: public O2
 
     /**
      * Compute expiration delay from current timestamp and expires()
-     * Should only be called just after a refresh / link event. */
+     * Should only be called just after a refresh / link event.
+    */
     void computeExpirationDelay();
 
-    /** Returns expiration delay.
+    /**
+     * Returns expiration delay.
      * May be 0 if it is unknown
      */
     int expirationDelay() const { return mExpirationDelay; }

--- a/src/core/auth/qgsauthmethodmetadata.h
+++ b/src/core/auth/qgsauthmethodmetadata.h
@@ -26,15 +26,15 @@
 /**
  * \ingroup core
  * \brief Holds data auth method key, description, and associated shared library file information.
-
-   The metadata class is used in a lazy load implementation in
-   QgsAuthMethodRegistry.  To save memory, auth methods are only actually
-   loaded via QLibrary calls if they're to be used.  (Though they're all
-   iteratively loaded once to get their metadata information, and then
-   unloaded when the QgsAuthMethodRegistry is created.)  QgsProviderMetadata
-   supplies enough information to be able to later load the associated shared
-   library object.
- * \note Culled from QgsProviderMetadata
+ *
+ * The metadata class is used in a lazy load implementation in
+ * QgsAuthMethodRegistry.  To save memory, auth methods are only actually
+ * loaded via QLibrary calls if they're to be used.  (Though they're all
+ * iteratively loaded once to get their metadata information, and then
+ * unloaded when the QgsAuthMethodRegistry is created.)  QgsProviderMetadata
+ * supplies enough information to be able to later load the associated shared
+ * library object.
+ *
  * \note not available in Python bindings
  */
 class CORE_EXPORT QgsAuthMethodMetadata
@@ -50,23 +50,23 @@ class CORE_EXPORT QgsAuthMethodMetadata
     QgsAuthMethodMetadata( const QString &_key, const QString &_description, const QString &_library );
 
     /**
-     * This returns the unique key associated with the method
-
-        This key string is used for the associative container in QgsAtuhMethodRegistry
+     * Returns the unique key associated with the method
+     *
+     * This key string is used for the associative container in QgsAtuhMethodRegistry
      */
     QString key() const;
 
     /**
-     * This returns descriptive text for the method
-
-        This is used to provide a descriptive list of available data methods.
+     * Returns descriptive text for the method.
+     *
+     * This is used to provide a descriptive list of available data methods.
      */
     QString description() const;
 
     /**
-     * This returns the library file name
-
-        This is used to QLibrary calls to load the method.
+     * Returns the library file name.
+     *
+     * This is used to QLibrary calls to load the method.
      */
     QString library() const;
 

--- a/src/core/auth/qgsauthmethodregistry.cpp
+++ b/src/core/auth/qgsauthmethodregistry.cpp
@@ -169,11 +169,11 @@ QgsAuthMethodRegistry::~QgsAuthMethodRegistry()
 
 /**
  * Convenience function for finding any existing auth methods that match "authMethodKey"
-
-  Necessary because [] map operator will create a QgsProviderMetadata
-  instance.  Also you cannot use the map [] operator in const members for that
-  very reason.  So there needs to be a convenient way to find an auth method
-  without accidentally adding a null meta data item to the metadata map.
+ *
+ * Necessary because [] map operator will create a QgsProviderMetadata
+ * instance.  Also you cannot use the map [] operator in const members for that
+ * very reason.  So there needs to be a convenient way to find an auth method
+ * without accidentally adding a null meta data item to the metadata map.
 */
 static QgsAuthMethodMetadata *findMetadata_( QgsAuthMethodRegistry::AuthMethods const &metaData,
     QString const &authMethodKey )

--- a/src/core/expression/qgsexpression.h
+++ b/src/core/expression/qgsexpression.h
@@ -48,59 +48,57 @@ class QgsExpressionFunction;
  * \ingroup core
  * \brief Class for parsing and evaluation of expressions (formerly called "search strings").
  * The expressions try to follow both syntax and semantics of SQL expressions.
-
-Usage:
-\code{.py}
-  exp = QgsExpression("gid*2 > 10 and type not in ('D','F')")
-  if exp.hasParserError():
-      # show error message with parserErrorString() and exit
-
-  result = exp.evaluate(feature, fields)
-  if exp.hasEvalError():
-      # show error message with evalErrorString()
-  else:
-      # examine the result
-\endcode
-
-\section value_logic Three Value Logic
-
-Similarly to SQL, this class supports three-value logic: true/false/unknown.
-Unknown value may be a result of operations with missing data (NULL). Please note
-that NULL is different value than zero or an empty string. For example
-3 > NULL returns unknown.
-
-There is no special (three-value) 'boolean' type: true/false is represented as
-1/0 integer, unknown value is represented the same way as NULL values: NULL QVariant.
-
-\section performance Performance
-
-For better performance with many evaluations you may first call prepare(fields) function
-to find out indices of columns and then repeatedly call evaluate(feature).
-
-\section type_conversion Type conversion
-
-Operators and functions that expect arguments to be of a particular
-type automatically convert the arguments to that type, e.g. sin('2.1') will convert
-the argument to a double, length(123) will first convert the number to a string.
-Explicit conversion can be achieved with to_int, to_real, to_string functions.
-If implicit or explicit conversion is invalid, the evaluation returns an error.
-Comparison operators do numeric comparison in case both operators are numeric (int/double)
-or they can be converted to numeric types.
-
-\section implicit_sharing Implicit sharing
-
-This class is implicitly shared, copying has a very low overhead.
-It is normally preferable to call `QgsExpression( otherExpression )` instead of
-`QgsExpression( otherExpression.expression() )`. A deep copy will only be made
-when prepare() is called. For usage this means mainly, that you should
-normally keep an unprepared master copy of a QgsExpression and whenever using it
-with a particular QgsFeatureIterator copy it just before and prepare it using the
-same context as the iterator.
-
-Implicit sharing was added in 2.14
-
+ *
+ * Usage:
+ * \code{.py}
+ *   exp = QgsExpression("gid*2 > 10 and type not in ('D','F')")
+ *   if exp.hasParserError():
+ *       # show error message with parserErrorString() and exit
+ *
+ *   result = exp.evaluate(feature, fields)
+ *   if exp.hasEvalError():
+ *       # show error message with evalErrorString()
+ *   else:
+ *       # examine the result
+ * \endcode
+ *
+ * \section value_logic Three Value Logic
+ *
+ * Similarly to SQL, this class supports three-value logic: true/false/unknown.
+ * Unknown value may be a result of operations with missing data (NULL). Please note
+ * that NULL is different value than zero or an empty string. For example
+ * 3 > NULL returns unknown.
+ *
+ * There is no special (three-value) 'boolean' type: true/false is represented as
+ * 1/0 integer, unknown value is represented the same way as NULL values: NULL QVariant.
+ *
+ * \section performance Performance
+ *
+ * For better performance with many evaluations you may first call prepare(fields) function
+ * to find out indices of columns and then repeatedly call evaluate(feature).
+ *
+ * \section type_conversion Type conversion
+ *
+ * Operators and functions that expect arguments to be of a particular
+ * type automatically convert the arguments to that type, e.g. sin('2.1') will convert
+ * the argument to a double, length(123) will first convert the number to a string.
+ * Explicit conversion can be achieved with to_int, to_real, to_string functions.
+ * If implicit or explicit conversion is invalid, the evaluation returns an error.
+ * Comparison operators do numeric comparison in case both operators are numeric (int/double)
+ * or they can be converted to numeric types.
+ *
+ * \section implicit_sharing Implicit sharing
+ *
+ * This class is implicitly shared, copying has a very low overhead.
+ * It is normally preferable to call `QgsExpression( otherExpression )` instead of
+ * `QgsExpression( otherExpression.expression() )`. A deep copy will only be made
+ * when prepare() is called. For usage this means mainly, that you should
+ * normally keep an unprepared master copy of a QgsExpression and whenever using it
+ * with a particular QgsFeatureIterator copy it just before and prepare it using the
+ * same context as the iterator.
+ *
+ * Implicit sharing was added in 2.14
 */
-
 class CORE_EXPORT QgsExpression
 {
     Q_DECLARE_TR_FUNCTIONS( QgsExpression )

--- a/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.h
+++ b/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.h
@@ -36,8 +36,8 @@ class CORE_EXPORT QgsMeshDataProviderTemporalCapabilities: public QgsDataProvide
   public:
 
     /**
-     * Method for selection of temporal mesh dataset from a range time
-     **/
+     * Method for selection of temporal mesh dataset from a range time.
+     */
     enum MatchingTemporalDatasetMethod
     {
       FindClosestDatasetBeforeStartRangeTime, //! Finds the closest dataset which have its time before the requested start range time

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -123,12 +123,12 @@ class ScopedIntIncrementor
 
 
 /**
-    Take the given scope and key and convert them to a string list of key
-    tokens that will be used to navigate through a Property hierarchy
-
-    E.g., scope "someplugin" and key "/foo/bar/baz" will become a string list
-    of { "properties", "someplugin", "foo", "bar", "baz" }.  "properties" is
-    always first because that's the permanent ``root'' Property node.
+ * Takes the given scope and key and convert them to a string list of key
+ * tokens that will be used to navigate through a Property hierarchy
+ *
+ * E.g., scope "someplugin" and key "/foo/bar/baz" will become a string list
+ * of { "properties", "someplugin", "foo", "bar", "baz" }.  "properties" is
+ * always first because that's the permanent ``root'' Property node.
  */
 QStringList makeKeyTokens_( const QString &scope, const QString &key )
 {
@@ -163,13 +163,13 @@ QStringList makeKeyTokens_( const QString &scope, const QString &key )
 
 
 /**
-   return the property that matches the given key sequence, if any
-
-   \param scope scope of key
-   \param key keyname
-   \param rootProperty is likely to be the top level QgsProjectPropertyKey in QgsProject:e:Imp.
-
-   \return null if not found, otherwise located Property
+ * Returns the property that matches the given key sequence, if any
+ *
+ * \param scope scope of key
+ * \param key keyname
+ * \param rootProperty is likely to be the top level QgsProjectPropertyKey in QgsProject:e:Imp.
+ *
+ * \return null if not found, otherwise located Property
 */
 QgsProjectProperty *findKey_( const QString &scope,
                               const QString &key,
@@ -240,13 +240,13 @@ QgsProjectProperty *findKey_( const QString &scope,
 
 
 /**
- * Add the given key and value
-
-\param scope scope of key
-\param key key name
-\param rootProperty is the property from which to start adding
-\param value the value associated with the key
-\param propertiesModified the parameter will be set to true if the written entry modifies pre-existing properties
+ * Adds the given key and value.
+ *
+ * \param scope scope of key
+ * \param key key name
+ * \param rootProperty is the property from which to start adding
+ * \param value the value associated with the key
+ * \param propertiesModified the parameter will be set to true if the written entry modifies pre-existing properties
 */
 QgsProjectProperty *addKey_( const QString &scope,
                              const QString &key,
@@ -328,13 +328,12 @@ QgsProjectProperty *addKey_( const QString &scope,
 }
 
 /**
- * Remove a given key
-
-\param scope scope of key
-\param key key name
-\param rootProperty is the property from which to start adding
+ * Removes a given key.
+ *
+ * \param scope scope of key
+ * \param key key name
+ * \param rootProperty is the property from which to start adding
 */
-
 void removeKey_( const QString &scope,
                  const QString &key,
                  QgsProjectPropertyKey &rootProperty )
@@ -916,34 +915,32 @@ void dump_( const QgsProjectPropertyKey &topQgsPropertyKey )
 }
 
 /**
-
-Restore any optional properties found in "doc" to "properties".
-
-properties tags for all optional properties.  Within that there will be scope
-tags.  In the following example there exist one property in the "fsplugin"
-scope.  "layers" is a list containing three string values.
-
-\code{.xml}
-<properties>
-  <fsplugin>
-    <foo type="int" >42</foo>
-    <baz type="int" >1</baz>
-    <layers type="QStringList" >
-      <value>railroad</value>
-      <value>airport</value>
-    </layers>
-    <xyqzzy type="int" >1</xyqzzy>
-    <bar type="double" >123.456</bar>
-    <feature_types type="QStringList" >
-       <value>type</value>
-    </feature_types>
-  </fsplugin>
-</properties>
-\endcode
-
-\param doc xml document
-\param project_properties should be the top QgsProjectPropertyKey node.
-
+ * Restores any optional properties found in "doc" to "properties".
+ *
+ * properties tags for all optional properties.  Within that there will be scope
+ * tags.  In the following example there exist one property in the "fsplugin"
+ * scope.  "layers" is a list containing three string values.
+ *
+ * \code{.xml}
+ * <properties>
+ *   <fsplugin>
+ *     <foo type="int" >42</foo>
+ *     <baz type="int" >1</baz>
+ *     <layers type="QStringList" >
+ *       <value>railroad</value>
+ *       <value>airport</value>
+ *     </layers>
+ *     <xyqzzy type="int" >1</xyqzzy>
+ *     <bar type="double" >123.456</bar>
+ *     <feature_types type="QStringList" >
+ *        <value>type</value>
+ *     </feature_types>
+ *   </fsplugin>
+ * </properties>
+ * \endcode
+ *
+ * \param doc xml document
+ * \param project_properties should be the top QgsProjectPropertyKey node.
 */
 void _getProperties( const QDomDocument &doc, QgsProjectPropertyKey &project_properties )
 {
@@ -973,7 +970,7 @@ void _getProperties( const QDomDocument &doc, QgsProjectPropertyKey &project_pro
  * \param doc xml document
  * \param dataDefinedServerPropertyDefinitions property collection of the server overrides
  * \since QGIS 3.14
-**/
+*/
 QgsPropertyCollection getDataDefinedServerProperties( const QDomDocument &doc, const QgsPropertiesDefinition &dataDefinedServerPropertyDefinitions )
 {
   QgsPropertyCollection ddServerProperties;
@@ -990,8 +987,8 @@ QgsPropertyCollection getDataDefinedServerProperties( const QDomDocument &doc, c
 }
 
 /**
-   Get the project title
-   \todo XXX we should go with the attribute xor title, not both.
+* Get the project title
+* \todo XXX we should go with the attribute xor title, not both.
 */
 static void _getTitle( const QDomDocument &doc, QString &title )
 {

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -2359,21 +2359,16 @@ QgsGdalProvider *QgsGdalProviderMetadata::createProvider( const QString &uri, co
 }
 
 /**
-
-  Convenience function for readily creating file filters.
-
-  Given a long name for a file filter and a regular expression, return
-  a file filter string suitable for use in a QFileDialog::OpenFiles()
-  call.  The regular express, glob, will have both all lower and upper
-  case versions added.
-
-  \note
-
-  Copied from qgisapp.cpp.
-
-  \todo XXX This should probably be generalized and moved to a standard
-            utility type thingy.
-
+ * Convenience function for readily creating file filters.
+ *
+ * Given a long name for a file filter and a regular expression, return
+ * a file filter string suitable for use in a QFileDialog::OpenFiles()
+ * call.  The regular express, glob, will have both all lower and upper
+ * case versions added.
+ *
+ * \note Copied from qgisapp.cpp.=
+ * \todo XXX This should probably be generalized and moved to a standard
+ * utility type thingy.
 */
 static QString createFileFilter_( QString const &longName, QString const &glob )
 {
@@ -3313,14 +3308,13 @@ bool QgsGdalProvider::remove()
 }
 
 /**
-  Builds the list of file filter strings to later be used by
-  QgisApp::addRasterLayer()
-
-  We query GDAL for a list of supported raster formats; we then build
-  a list of file filter strings from that list.  We return a string
-  that contains this list that is suitable for use in a
-  QFileDialog::getOpenFileNames() call.
-
+ * Builds the list of file filter strings to later be used by
+ * QgisApp::addRasterLayer()
+ *
+ * We query GDAL for a list of supported raster formats; we then build
+ * a list of file filter strings from that list.  We return a string
+ * that contains this list that is suitable for use in a
+ * QFileDialog::getOpenFileNames() call.
 */
 QString QgsGdalProviderMetadata::filters( FilterType type )
 {

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3235,21 +3235,14 @@ QString  QgsOgrProvider::description() const
 
 
 /**
-
-  Convenience function for readily creating file filters.
-
-  Given a long name for a file filter and a regular expression, return
-  a file filter string suitable for use in a QFileDialog::OpenFiles()
-  call.  The regular express, glob, will have both all lower and upper
-  case versions added.
-
-  \note
-
-  Copied from qgisapp.cpp.
-
-  \todo XXX This should probably be generalized and moved to a standard
-            utility type thingy.
-
+ *  Convenience function for readily creating file filters.
+ *
+ *  Given a long name for a file filter and a regular expression, return
+ *  a file filter string suitable for use in a QFileDialog::OpenFiles()
+ *  call.  The regular express, glob, will have both all lower and upper
+ *  case versions added.
+ *  \note Copied from qgisapp.cpp.
+ *  \todo XXX This should probably be generalized and moved to a standard utility type thingy.
 */
 static QString createFileFilter_( QString const &longName, QString const &glob )
 {
@@ -3973,11 +3966,12 @@ QgsOgrProvider *QgsOgrProviderMetadata::createProvider( const QString &uri, cons
 
 /**
  * Creates an empty data source
-\param uri location to store the file(s)
-\param format data format (e.g. "ESRI Shapefile")
-\param vectortype point/line/polygon or multitypes
-\param attributes a list of name/type pairs for the initial attributes
-\return true in case of success*/
+ * \param uri location to store the file(s)
+ * \param format data format (e.g. "ESRI Shapefile")
+ * \param vectortype point/line/polygon or multitypes
+ * \param attributes a list of name/type pairs for the initial attributes
+ * \return true in case of success
+*/
 bool QgsOgrProviderUtils::createEmptyDataSource( const QString &uri,
     const QString &format,
     const QString &encoding,

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -74,15 +74,14 @@ class QgsCoordinateReferenceSystemRegistry;
  * as theme paths, database paths etc.
  *
  * This is a subclass of QApplication and should be instantiated in place of
-  QApplication. Most methods are static in keeping with the design of QApplication.
-
-  This class hides platform-specific path information and provides
-  a portable way of referencing specific files and directories.
-  Ideally, hard-coded paths should appear only here and not in other modules
-  so that platform-conditional code is minimized and paths are easier
-  to change due to centralization.
+ * QApplication. Most methods are static in keeping with the design of QApplication.
+ *
+ * This class hides platform-specific path information and provides
+ * a portable way of referencing specific files and directories.
+ * Ideally, hard-coded paths should appear only here and not in other modules
+ * so that platform-conditional code is minimized and paths are easier
+ * to change due to centralization.
  */
-
 class CORE_EXPORT QgsApplication : public QApplication
 {
 
@@ -285,7 +284,7 @@ class CORE_EXPORT QgsApplication : public QApplication
     static QString translatorsFilePath();
 
     /**
-      Returns the path to the licence file.
+     * Returns the path to the licence file.
      */
     static QString licenceFilePath();
 

--- a/src/core/qgsfeatureid.h
+++ b/src/core/qgsfeatureid.h
@@ -24,7 +24,7 @@ email                : matthias@opengis.ch
 /**
  * 64 bit feature ids
  * negative numbers are used for uncommitted/newly added features
- **/
+ */
 typedef qint64 QgsFeatureId SIP_SKIP;
 #define FID_NULL            std::numeric_limits<QgsFeatureId>::min()
 #define FID_IS_NULL(fid)    ( fid == std::numeric_limits<QgsFeatureId>::min() )

--- a/src/core/qgsfields.h
+++ b/src/core/qgsfields.h
@@ -293,9 +293,9 @@ class CORE_EXPORT  QgsFields
      * Looks up field's index from the field name.
      * This method matches in the following order:
      *
-     *  1. The exact field name taking case sensitivity into account
-     *  2. Looks for the field name by case insensitive comparison
-     *  3. The field alias (case insensitive)
+     * 1. The exact field name taking case sensitivity into account
+     * 2. Looks for the field name by case insensitive comparison
+     * 3. The field alias (case insensitive)
      *
      * \param fieldName The name to look for.
      *

--- a/src/core/qgsopenclutils.h
+++ b/src/core/qgsopenclutils.h
@@ -53,18 +53,18 @@
  * Usage:
  *
  * \code{.cpp}
-   // This will check if OpenCL is enabled in user options and if there is a suitable
-   // device, if a device is found it is initialized.
-   if ( QgsOpenClUtils::enabled() && QgsOpenClUtils::available() )
-   {
-      // Use the default context
-      cl::Context ctx = QgsOpenClUtils::context();
-      cl::CommandQueue queue( ctx );
-      // Load the program from a standard location and build it
-      cl::Program program = QgsOpenClUtils::buildProgram( ctx, QgsOpenClUtils::sourceFromBaseName( QStringLiteral ( "hillshade" ) ) );
-      // Continue with the usual OpenCL buffer, kernel and execution
-      ...
-   }
+ * // This will check if OpenCL is enabled in user options and if there is a suitable
+ * // device, if a device is found it is initialized.
+ * if ( QgsOpenClUtils::enabled() && QgsOpenClUtils::available() )
+ * {
+ *    // Use the default context
+ *    cl::Context ctx = QgsOpenClUtils::context();
+ *    cl::CommandQueue queue( ctx );
+ *    // Load the program from a standard location and build it
+ *    cl::Program program = QgsOpenClUtils::buildProgram( ctx, QgsOpenClUtils::sourceFromBaseName( QStringLiteral ( "hillshade" ) ) );
+ *    // Continue with the usual OpenCL buffer, kernel and execution
+ *    ...
+ * }
  * \endcode
  *
  * \note not available in Python bindings

--- a/src/core/qgsproviderregistry.cpp
+++ b/src/core/qgsproviderregistry.cpp
@@ -68,11 +68,11 @@ QgsProviderRegistry *QgsProviderRegistry::instance( const QString &pluginPath )
 
 /**
  * Convenience function for finding any existing data providers that match "providerKey"
-
-  Necessary because [] map operator will create a QgsProviderMetadata
-  instance.  Also you cannot use the map [] operator in const members for that
-  very reason.  So there needs to be a convenient way to find a data provider
-  without accidentally adding a null meta data item to the metadata map.
+ *
+ * Necessary because [] map operator will create a QgsProviderMetadata
+ * instance.  Also you cannot use the map [] operator in const members for that
+ * very reason.  So there needs to be a convenient way to find a data provider
+ * without accidentally adding a null meta data item to the metadata map.
 */
 static
 QgsProviderMetadata *findMetadata_( const QgsProviderRegistry::Providers &metaData,

--- a/src/core/qgspythonrunner.h
+++ b/src/core/qgspythonrunner.h
@@ -35,7 +35,8 @@ class CORE_EXPORT QgsPythonRunner
 
     /**
      * Returns TRUE if the runner has an instance
-        (and thus is able to run commands) */
+     * (and thus is able to run commands)
+    */
     static bool isValid();
 
     //! Execute a Python statement

--- a/src/core/qgssqlstatement.h
+++ b/src/core/qgssqlstatement.h
@@ -771,7 +771,7 @@ class CORE_EXPORT QgsSQLStatement
     /**
      * \ingroup core
      * \brief Support for visitor pattern - algorithms dealing with the statement
-        may be implemented without modifying the Node classes
+     * may be implemented without modifying the Node classes
     */
     class CORE_EXPORT Visitor
     {

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -37,10 +37,12 @@ class QgsFeatureIterator;
 
 /**
  * \ingroup core
-  * \brief A convenience class for writing vector files to disk.
- There are two possibilities how to use this class:
- 1. static call to QgsVectorFileWriter::writeAsVectorFormat(...) which saves the whole vector layer
- 2. create an instance of the class and issue calls to addFeature(...)
+ * \brief A convenience class for writing vector layers to disk based formats (e.g. Shapefiles, GeoPackage).
+ *
+ * There are two possibilities how to use this class:
+ *
+ * 1. A static call to QgsVectorFileWriter::writeAsVectorFormat(...) which saves the whole vector layer.
+ * 2. Create an instance of the class and issue calls to addFeature(...).
  */
 class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
 {

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -730,7 +730,7 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
 
     /**
      * Dots per inch. Extended WMS (e.g. QGIS mapserver) support DPI dependent output and therefore
-    are suited for printing. A value of -1 means it has not been set
+     * are suited for printing. A value of -1 means it has not been set
     */
     int mDpi = -1;
 

--- a/src/core/raster/qgsrasterdataprovidertemporalcapabilities.h
+++ b/src/core/raster/qgsrasterdataprovidertemporalcapabilities.h
@@ -48,14 +48,14 @@ class CORE_EXPORT QgsRasterDataProviderTemporalCapabilities : public QgsDataProv
 
     /**
      * Method to use when resolving a temporal range to a data provider layer or band.
-     **/
+     */
     enum IntervalHandlingMethod
     {
       MatchUsingWholeRange, //!< Use an exact match to the whole temporal range
       MatchExactUsingStartOfRange, //!< Match the start of the temporal range to a corresponding layer or band, and only use exact matching results
       MatchExactUsingEndOfRange, //!< Match the end of the temporal range to a corresponding layer or band, and only use exact matching results
-      FindClosestMatchToStartOfRange, //! Match the start of the temporal range to the least previous closest datetime.
-      FindClosestMatchToEndOfRange //! Match the end of the temporal range to the least previous closest datetime.
+      FindClosestMatchToStartOfRange, //!< Match the start of the temporal range to the least previous closest datetime.
+      FindClosestMatchToEndOfRange //!< Match the end of the temporal range to the least previous closest datetime.
     };
     // TODO -- add other methods
 
@@ -64,7 +64,7 @@ class CORE_EXPORT QgsRasterDataProviderTemporalCapabilities : public QgsDataProv
      * layers or bands in the data provider.
      *
      *\see setIntervalHandlingMethod()
-    **/
+    */
     IntervalHandlingMethod intervalHandlingMethod() const;
 
     /**
@@ -72,7 +72,7 @@ class CORE_EXPORT QgsRasterDataProviderTemporalCapabilities : public QgsDataProv
      * layers or bands in the data provider.
      *
      *\see intervalHandlingMethod()
-    **/
+    */
     void setIntervalHandlingMethod( IntervalHandlingMethod method );
 
     /**

--- a/src/core/raster/qgsrasterlayertemporalproperties.h
+++ b/src/core/raster/qgsrasterlayertemporalproperties.h
@@ -51,7 +51,7 @@ class CORE_EXPORT QgsRasterLayerTemporalProperties : public QgsMapLayerTemporalP
 
     /**
      * Mode of the raster temporal properties
-     **/
+     */
     enum TemporalMode
     {
       ModeFixedTemporalRange = 0, //!< Mode when temporal properties have fixed start and end datetimes.
@@ -62,14 +62,14 @@ class CORE_EXPORT QgsRasterLayerTemporalProperties : public QgsMapLayerTemporalP
      * Returns the temporal properties mode.
      *
      *\see setMode()
-    **/
+    */
     TemporalMode mode() const;
 
     /**
      * Sets the temporal properties \a mode.
      *
      *\see mode()
-    **/
+    */
     void setMode( TemporalMode mode );
 
     /**
@@ -82,7 +82,7 @@ class CORE_EXPORT QgsRasterLayerTemporalProperties : public QgsMapLayerTemporalP
      * layers or bands in the data provider.
      *
      *\see setIntervalHandlingMethod()
-    **/
+    */
     QgsRasterDataProviderTemporalCapabilities::IntervalHandlingMethod intervalHandlingMethod() const;
 
     /**
@@ -90,7 +90,7 @@ class CORE_EXPORT QgsRasterLayerTemporalProperties : public QgsMapLayerTemporalP
      * layers or bands in the data provider.
      *
      *\see intervalHandlingMethod()
-    **/
+    */
     void setIntervalHandlingMethod( QgsRasterDataProviderTemporalCapabilities::IntervalHandlingMethod method );
 
     /**
@@ -112,7 +112,7 @@ class CORE_EXPORT QgsRasterLayerTemporalProperties : public QgsMapLayerTemporalP
      * QgsRasterLayerTemporalProperties::ModeFixedTemporalRange
      *
      * \see setFixedTemporalRange()
-    **/
+    */
     const QgsDateTimeRange &fixedTemporalRange() const;
 
     QDomElement writeXml( QDomElement &element, QDomDocument &doc, const QgsReadWriteContext &context ) override;

--- a/src/core/raster/qgsrasterpipe.h
+++ b/src/core/raster/qgsrasterpipe.h
@@ -186,7 +186,7 @@ class CORE_EXPORT QgsRasterPipe
 
     /**
      * \brief Try to connect interfaces in pipe and to the provider at beginning.
-        Returns true if connected or false if connection failed
+     * Returns TRUE if connected or false if connection failed
     */
     bool connect( QVector<QgsRasterInterface *> interfaces );
 

--- a/src/core/vector/qgsvectordataprovidertemporalcapabilities.h
+++ b/src/core/vector/qgsvectordataprovidertemporalcapabilities.h
@@ -40,7 +40,7 @@ class CORE_EXPORT QgsVectorDataProviderTemporalCapabilities : public QgsDataProv
 
     /**
      * Provider temporal handling mode
-     **/
+     */
     enum TemporalMode
     {
       ProviderHasFixedTemporalRange = 0, //!< Entire dataset from provider has a fixed start and end datetime.
@@ -59,14 +59,14 @@ class CORE_EXPORT QgsVectorDataProviderTemporalCapabilities : public QgsDataProv
      * Returns the temporal properties mode.
      *
      *\see setMode()
-    **/
+    */
     TemporalMode mode() const;
 
     /**
      * Sets the temporal properties \a mode.
      *
      *\see mode()
-    **/
+    */
     void setMode( TemporalMode mode );
 
     /**

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -2894,8 +2894,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     /**
      * Set holding the feature IDs that are activated.  Note that if a feature
-        subsequently gets deleted (i.e. by its addition to mDeletedFeatureIds),
-        it always needs to be removed from mSelectedFeatureIds as well.
+     * subsequently gets deleted (i.e. by its addition to mDeletedFeatureIds),
+     * it always needs to be removed from mSelectedFeatureIds as well.
      */
     QgsFeatureIds mSelectedFeatureIds;
 

--- a/src/core/vector/qgsvectorlayereditbuffer.h
+++ b/src/core/vector/qgsvectorlayereditbuffer.h
@@ -42,7 +42,6 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     //! Returns TRUE if the provider has been modified since the last commit
     virtual bool isModified() const;
 
-
     /**
      * Adds a feature
      * \param f feature to add
@@ -73,12 +72,12 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     virtual bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues );
 
     /**
-     * Add an attribute field (but does not commit it)
-        returns true if the field was added
+     * Adds an attribute field (but does not commit it)
+     * returns TRUE if the field was added
     */
     virtual bool addAttribute( const QgsField &field );
 
-    //! Delete an attribute field (but does not commit it)
+    //! Deletes an attribute field (but does not commit it)
     virtual bool deleteAttribute( int attr );
 
     /**
@@ -90,19 +89,19 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     virtual bool renameAttribute( int attr, const QString &newName );
 
     /**
-      Attempts to commit any changes to disk.  Returns the result of the attempt.
-      If a commit fails, the in-memory changes are left alone.
-
-      This allows editing to continue if the commit failed on e.g. a
-      disallowed value in a Postgres database - the user can re-edit and try
-      again.
-
-      The commits occur in distinct stages,
-      (add attributes, add features, change attribute values, change
-      geometries, delete features, delete attributes)
-      so if a stage fails, it's difficult to roll back cleanly.
-      Therefore any error message also includes which stage failed so
-      that the user has some chance of repairing the damage cleanly.
+     * Attempts to commit any changes to disk.  Returns the result of the attempt.
+     * If a commit fails, the in-memory changes are left alone.
+     *
+     * This allows editing to continue if the commit failed on e.g. a
+     * disallowed value in a Postgres database - the user can re-edit and try
+     * again.
+     *
+     * The commits occur in distinct stages,
+     * (add attributes, add features, change attribute values, change
+     * geometries, delete features, delete attributes)
+     * so if a stage fails, it's difficult to roll back cleanly.
+     * Therefore any error message also includes which stage failed so
+     * that the user has some chance of repairing the damage cleanly.
      */
     virtual bool commitChanges( QStringList &commitErrors );
 
@@ -285,8 +284,8 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
 
     /**
      * Deleted feature IDs which are not committed.  Note a feature can be added and then deleted
-        again before the change is committed - in that case the added feature would be removed
-        from mAddedFeatures only and *not* entered here.
+     * again before the change is committed - in that case the added feature would be removed
+     * from mAddedFeatures only and *not* entered here.
      */
     QgsFeatureIds mDeletedFeatureIds;
 

--- a/src/core/vector/qgsvectorlayertemporalproperties.h
+++ b/src/core/vector/qgsvectorlayertemporalproperties.h
@@ -85,7 +85,7 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
 
     /**
      * Mode of the vector temporal properties
-     **/
+     */
     enum TemporalMode
     {
       ModeFixedTemporalRange = 0, //!< Mode when temporal properties have fixed start and end datetimes.
@@ -100,14 +100,14 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
      * Returns the temporal properties mode.
      *
      *\see setMode()
-    **/
+    */
     TemporalMode mode() const;
 
     /**
      * Sets the temporal properties \a mode.
      *
      *\see mode()
-    **/
+    */
     void setMode( TemporalMode mode );
 
     /**
@@ -134,7 +134,7 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
      * QgsVectorLayerTemporalProperties::ModeFixedTemporalRange
      *
      * \see setFixedTemporalRange()
-    **/
+    */
     const QgsDateTimeRange &fixedTemporalRange() const;
 
     /**

--- a/src/gui/attributetable/qgsattributetableview.h
+++ b/src/gui/attributetable/qgsattributetableview.h
@@ -88,16 +88,14 @@ class GUI_EXPORT QgsAttributeTableView : public QTableView
      */
     QList<QgsFeatureId> selectedFeaturesIds() const;
 
-
     /**
      * Scroll to a feature with a given \a fid.
-
-      Optionally a \a column can be specified, which will also bring that column into view.
-
+     *
+     * Optionally a \a column can be specified, which will also bring that column into view.
+     *
      * \since QGIS 3.16
      */
     void scrollToFeature( const QgsFeatureId &fid, int column = -1 );
-
 
   protected:
 

--- a/src/gui/mesh/qgsmeshrendereractivedatasetwidget.h
+++ b/src/gui/mesh/qgsmeshrendereractivedatasetwidget.h
@@ -42,7 +42,7 @@ class GUI_EXPORT QgsMeshRendererActiveDatasetWidget : public QWidget, private Ui
   public:
 
     /**
-    mTimeComboBox->setCurrentIndex( mTimeComboBox->count() - 1 );     * A widget to hold the renderer scalar settings for a mesh layer.
+     * A widget to hold the renderer scalar settings for a mesh layer.
      * \param parent Parent object
      */
     QgsMeshRendererActiveDatasetWidget( QWidget *parent = nullptr );

--- a/src/gui/qgsblendmodecombobox.h
+++ b/src/gui/qgsblendmodecombobox.h
@@ -26,7 +26,7 @@
 /**
  * \ingroup gui
  * \brief A combobox which lets the user select blend modes from a predefined list
- **/
+ */
 class GUI_EXPORT QgsBlendModeComboBox : public QComboBox
 {
     Q_OBJECT

--- a/src/gui/qgsencodingfiledialog.h
+++ b/src/gui/qgsencodingfiledialog.h
@@ -26,7 +26,7 @@ class QPushButton;
 /**
  * \ingroup gui
  * \brief A file dialog which lets the user select the preferred encoding type for a data provider.
- **/
+ */
 class GUI_EXPORT QgsEncodingFileDialog: public QFileDialog
 {
     Q_OBJECT

--- a/src/gui/qgsexternalresourcewidget.h
+++ b/src/gui/qgsexternalresourcewidget.h
@@ -42,7 +42,7 @@ class QgsPixmapLabel;
  * \ingroup gui
  * \brief Widget to display file path with a push button for an "open file" dialog
  * It can also be used to display a picture or a web page.
- **/
+ */
 class GUI_EXPORT QgsExternalResourceWidget : public QWidget
 {
 

--- a/src/gui/qgsfilterlineedit.h
+++ b/src/gui/qgsfilterlineedit.h
@@ -35,7 +35,7 @@ class QgsAnimatedIcon;
  * When using QgsFilterLineEdit the value(), setValue() and clearValue() methods should be used
  * instead of QLineEdit's text(), setText() and clear() methods, and the valueChanged()
  * signal should be used instead of textChanged().
- **/
+ */
 class GUI_EXPORT QgsFilterLineEdit : public QLineEdit
 {
 

--- a/src/gui/qgsguiutils.h
+++ b/src/gui/qgsguiutils.h
@@ -90,7 +90,6 @@ namespace QgsGuiUtils
    *
    * This method returns TRUE if cancel all was clicked, otherwise FALSE
   */
-
   bool GUI_EXPORT openFilesRememberingFilter( QString const &filterName,
       QString const &filters, QStringList &selectedFiles, QString &enc, QString &title,
       bool cancelAll = false );
@@ -107,12 +106,12 @@ namespace QgsGuiUtils
   QPair<QString, QString> GUI_EXPORT getSaveAsImageName( QWidget *parent, const QString &message, const QString &defaultFilename = QString() );
 
   /**
-    Convenience function for readily creating file filters.
-
-    Given a long name for a file filter and a regular expression, return
-    a file filter string suitable for use in a QFileDialog::OpenFiles()
-    call.  The regular express, glob, will have both all lower and upper
-    case versions added.
+   * Convenience function for readily creating file filters.
+   *
+   * Given a long name for a file filter and a regular expression, return
+   * a file filter string suitable for use in a QFileDialog::OpenFiles()
+   * call.  The regular express, glob, will have both all lower and upper
+   * case versions added.
   */
   QString GUI_EXPORT createFileFilter_( QString const &longName, QString const &glob );
 

--- a/src/gui/qgsmetadatawidget.cpp
+++ b/src/gui/qgsmetadatawidget.cpp
@@ -1104,6 +1104,7 @@ void QgsMetadataWidget::removeSelectedCategories()
   mDefaultCategoriesModel->sort( 0 );
 }
 
+///@cond PRIVATE
 LinkItemDelegate::LinkItemDelegate( QObject *parent )
   : QStyledItemDelegate( parent )
 {
@@ -1159,3 +1160,4 @@ QWidget *ConstraintItemDelegate::createEditor( QWidget *parent, const QStyleOpti
 
   return QStyledItemDelegate::createEditor( parent, option, index );
 }
+///@endcond

--- a/src/gui/qgsmetadatawidget.h
+++ b/src/gui/qgsmetadatawidget.h
@@ -236,9 +236,9 @@ class GUI_EXPORT QgsMetadataWidget : public QWidget, private Ui::QgsMetadataWidg
 
 #ifndef SIP_RUN
 
+///@cond PRIVATE
 
 /**
- \\\@cond PRIVATE
  * \ingroup gui
  * \class LinkItemDelegate
  * \brief Special delegate for the link view in the metadata wizard.
@@ -290,9 +290,8 @@ class ConstraintItemDelegate : public QStyledItemDelegate
     QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
 };
 
-/**
- \\\@endcond
- */
+
+///@endcond
 
 #endif
 #endif

--- a/src/gui/qgsproviderguiregistry.cpp
+++ b/src/gui/qgsproviderguiregistry.cpp
@@ -39,11 +39,11 @@
 
 /**
  * Convenience function for finding any existing data providers that match "providerKey"
-
-  Necessary because [] map operator will create a QgsProviderGuiMetadata
-  instance.  Also you cannot use the map [] operator in const members for that
-  very reason.  So there needs to be a convenient way to find a data provider
-  without accidentally adding a null meta data item to the metadata map.
+ *
+ * Necessary because [] map operator will create a QgsProviderGuiMetadata
+ * instance.  Also you cannot use the map [] operator in const members for that
+ * very reason.  So there needs to be a convenient way to find a data provider
+ * without accidentally adding a null meta data item to the metadata map.
 */
 static
 QgsProviderGuiMetadata *findMetadata_( QgsProviderGuiRegistry::GuiProviders const &metaData,

--- a/src/gui/qgsscalecombobox.h
+++ b/src/gui/qgsscalecombobox.h
@@ -26,7 +26,7 @@
  * \ingroup gui
  * \brief A combobox which lets the user select map scale from predefined list
  * and highlights nearest to current scale value
- **/
+ */
 class GUI_EXPORT QgsScaleComboBox : public QComboBox
 {
     Q_OBJECT

--- a/src/gui/qgsscalewidget.h
+++ b/src/gui/qgsscalewidget.h
@@ -30,7 +30,7 @@ class QgsMapCanvas;
  * \ingroup gui
  * \brief A combobox which lets the user select map scale from predefined list
  * and highlights nearest to current scale value
- **/
+ */
 class GUI_EXPORT QgsScaleWidget : public QWidget
 {
     Q_OBJECT
@@ -43,7 +43,7 @@ class GUI_EXPORT QgsScaleWidget : public QWidget
     /**
      * \brief QgsScaleWidget creates a combobox which lets the user select map scale from predefined list
      * and highlights nearest to current scale value
-     **/
+     */
     explicit QgsScaleWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
     /**

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -213,14 +213,6 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     //! \brief Pointer to the raster layer that this property dilog changes the behavior of.
     QgsRasterLayer *mRasterLayer = nullptr;
 
-    /**
-     * \brief If the underlying raster layer doesn't have a provider
-
-        This variable is used to determine if various parts of the Properties UI are
-        included or not
-     */
-    //bool mRasterLayerIsInternal;
-
     QgsRasterRendererWidget *mRendererWidget = nullptr;
     QgsMetadataWidget *mMetadataWidget = nullptr;
 

--- a/src/gui/symbology/qgsrendererwidget.h
+++ b/src/gui/symbology/qgsrendererwidget.h
@@ -33,13 +33,14 @@ class QgsMapCanvas;
 /**
  * \ingroup gui
  * \brief Base class for renderer settings widgets.
-
-WORKFLOW:
-- open renderer dialog with some RENDERER  (never null!)
-- find out which widget to use
-- instantiate it and set in stacked widget
-- on any change of renderer type, create some default (dummy?) version and change the stacked widget
-- when clicked OK/Apply, get the renderer from active widget and clone it for the layer
+ *
+ * WORKFLOW:
+ *
+ * - open renderer dialog with some RENDERER  (never null!)
+ * - find out which widget to use
+ * - instantiate it and set in stacked widget
+ * - on any change of renderer type, create some default (dummy?) version and change the stacked widget
+ * - when clicked OK/Apply, get the renderer from active widget and clone it for the layer
 */
 class GUI_EXPORT QgsRendererWidget : public QgsPanelWidget
 {

--- a/src/plugins/qgisplugin.h
+++ b/src/plugins/qgisplugin.h
@@ -178,9 +178,9 @@ class QgisPlugin
     /// UI or MAPLAYER plug-in
 
     /**
-      \todo Really, might be indicative that this needs to split into
-      maplayer vs. ui plug-in vs. other kind of plug-in
-      */
+     * \todo Really, might be indicative that this needs to split into
+     * maplayer vs. ui plug-in vs. other kind of plug-in
+     */
     PluginType mType;
 
 }; // class QgisPlugin

--- a/src/plugins/topology/topolTest.h
+++ b/src/plugins/topology/topolTest.h
@@ -72,7 +72,7 @@ class TopologyRule
 };
 
 /**
-  helper class to pass as comparator to map,set etc..
+ * helper class to pass as comparator to map,set etc..
   */
 class PointComparer
 {

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -26,7 +26,7 @@ class QgsFeedback;
 
 /**
  * \brief This class holds data, shared between QgsAfsProvider and QgsAfsFeatureIterator
- **/
+ */
 class QgsAfsSharedData : public QObject
 {
     Q_OBJECT

--- a/src/providers/db2/qgsdb2tablemodel.h
+++ b/src/providers/db2/qgsdb2tablemodel.h
@@ -44,8 +44,10 @@ class QIcon;
 
 /**
  * A model that holds the tables of a database in a hierarchy where the
-schemas are the root elements that contain the individual tables as children.
-The tables have the following columns: Type, Schema, Tablename, Geometry Column, Sql*/
+ * schemas are the root elements that contain the individual tables as children.
+ *
+ * The tables have the following columns: Type, Schema, Tablename, Geometry Column, Sql
+*/
 class QgsDb2TableModel : public QStandardItemModel
 {
     Q_OBJECT

--- a/src/providers/delimitedtext/qgsdelimitedtextfile.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextfile.h
@@ -31,9 +31,8 @@ class QTextStream;
 
 
 /**
-\class QgsDelimitedTextFile
-\brief Delimited text file parser extracts records from a QTextStream as a QStringList.
-*
+* \class QgsDelimitedTextFile
+* \brief Delimited text file parser extracts records from a QTextStream as a QStringList.
 *
 * The delimited text parser is used by the QgsDelimitedTextProvider to parse
 * a QTextStream into records of QStringList.  It provides a number of variants

--- a/src/providers/gpx/gpsdata.h
+++ b/src/providers/gpx/gpsdata.h
@@ -38,7 +38,8 @@
 
 /**
  * This is the parent class for all GPS data classes (except tracksegment).
-    It contains the variables that all GPS objects can have.
+ *
+ * It contains the variables that all GPS objects can have.
 */
 class QgsGpsObject
 {
@@ -52,7 +53,7 @@ class QgsGpsObject
 
 /**
  * This is the parent class for all GPS point classes. It contains common data
-    members and common initialization code for all point classes.
+ * members and common initialization code for all point classes.
 */
 class QgsGpsPoint : public QgsGpsObject
 {
@@ -66,8 +67,9 @@ class QgsGpsPoint : public QgsGpsObject
 
 /**
  * This is the parent class for all GPS object types that can have a nonempty
-    bounding box (Route, Track). It contains common data members for all
-    those classes. */
+ * bounding box (Route, Track). It contains common data members for all
+ * those classes.
+*/
 class QgsGpsExtended : public QgsGpsObject
 {
   public:
@@ -106,7 +108,7 @@ class QgsRoute : public QgsGpsExtended
 
 /**
  * This class represents a GPS track segment, which is a contiguous part of
-    a track. See the GPX specification for a better explanation.
+ * a track. See the GPX specification for a better explanation.
 */
 class QgsTrackSegment
 {
@@ -117,7 +119,7 @@ class QgsTrackSegment
 
 /**
  * This class represents a GPS tracklog. It consists of 0 or more track
-    segments.
+ * segments.
 */
 class QgsTrack : public QgsGpsExtended
 {
@@ -145,13 +147,15 @@ class QgsGpsData
 
     /**
      * This constructor initializes the extent to a nonsense value. Don't try
-        to use a GPSData object in QGIS without parsing a datafile into it. */
+     * to use a GPSData object in QGIS without parsing a datafile into it.
+    */
     QgsGpsData();
 
     /**
      * This function returns a pointer to a dynamically allocated QgsRectangle
-        which is the bounding box for this dataset. You'll have to deallocate it
-        yourself. */
+     * which is the bounding box for this dataset. You'll have to deallocate it
+     * yourself.
+    */
     QgsRectangle getExtent() const;
 
     //! Sets a default sensible extent. Only applies when there are no actual data.
@@ -177,23 +181,27 @@ class QgsGpsData
 
     /**
      * This function returns an iterator that points to the end of the
-        waypoint list. */
+     * waypoint list.
+    */
     WaypointIterator waypointsEnd();
 
     /**
      * This function returns an iterator that points to the end of the
-        route list. */
+     * route list.
+    */
     RouteIterator routesEnd();
 
     /**
      * This function returns an iterator that points to the end of the
-        track list. */
+     * track list.
+    */
     TrackIterator tracksEnd();
 
     /**
      * This function tries to add a new waypoint. An iterator to the new
-        waypoint will be returned (it will be waypointsEnd() if the waypoint
-        couldn't be added. */
+     * waypoint will be returned (it will be waypointsEnd() if the waypoint
+     * couldn't be added.
+    */
     WaypointIterator addWaypoint( double lat, double lon, const QString &name = "",
                                   double ele = -std::numeric_limits<double>::max() );
 
@@ -201,14 +209,16 @@ class QgsGpsData
 
     /**
      * This function tries to add a new route. It returns an iterator to the
-        new route. */
+     * new route.
+    */
     RouteIterator addRoute( const QString &name = "" );
 
     RouteIterator addRoute( const QgsRoute &rte );
 
     /**
      * This function tries to add a new track. An iterator to the new track
-        will be returned. */
+     * will be returned.
+    */
     TrackIterator addTrack( const QString &name = "" );
 
     TrackIterator addTrack( const QgsTrack &trk );
@@ -224,26 +234,29 @@ class QgsGpsData
 
     /**
      * This function will write the contents of this GPSData object as XML to
-        the given text stream. */
+     * the given text stream.
+    */
     void writeXml( QTextStream &stream );
 
     /**
      * This function returns a pointer to the GPSData object associated with
-        the file \c file name. If the file does not exist or can't be parsed,
-        NULL will be returned. If the file is already used by another layer,
-        a pointer to the same GPSData object will be returned. And if the file
-        is not used by any other layer, and can be parsed, a new GPSData object
-        will be created and a pointer to it will be returned. If you use this
-        function you should also call releaseData() with the same \c file name
-        when you're done with the GPSData pointer, otherwise the data will stay
-        in memory forever and you will get an ugly memory leak. */
+     * the file \c file name. If the file does not exist or can't be parsed,
+     * NULL will be returned. If the file is already used by another layer,
+     * a pointer to the same GPSData object will be returned. And if the file
+     * is not used by any other layer, and can be parsed, a new GPSData object
+     * will be created and a pointer to it will be returned. If you use this
+     * function you should also call releaseData() with the same \c file name
+     * when you're done with the GPSData pointer, otherwise the data will stay
+     * in memory forever and you will get an ugly memory leak.
+    */
     static QgsGpsData *getData( const QString &fileName );
 
     /**
      * Call this function when you're done with a GPSData pointer that you
-        got earlier using getData(). Do NOT call this function if you haven't
-        called getData() earlier with the same \c file name, that can cause data
-        that is still in use to be deleted. */
+     * got earlier using getData(). Do NOT call this function if you haven't
+     * called getData() earlier with the same \c file name, that can cause data
+     * that is still in use to be deleted.
+    */
     static void releaseData( const QString &fileName );
 
 
@@ -264,8 +277,9 @@ class QgsGpsData
 
     /**
      * This is the static container that maps file names to GPSData objects and
-        does reference counting, so several providers can use the same GPSData
-        object. */
+     * does reference counting, so several providers can use the same GPSData
+     * object.
+    */
     static DataMap dataObjects;
 
 };
@@ -281,17 +295,20 @@ class QgsGPXHandler
 
     /**
      * This function is called when expat encounters a new start element in
-        the XML stream. */
+     * the XML stream.
+    */
     bool startElement( const XML_Char *qName, const XML_Char **attr );
 
     /**
      * This function is called when expat encounters character data in the
-        XML stream. */
+     * XML stream.
+    */
     void characters( const XML_Char *chars, int len );
 
     /**
      * This function is called when expat encounters a new end element in
-        the XML stream. */
+     * the XML stream.
+    */
     bool endElement( const std::string &qName );
 
     // static wrapper functions for the XML handler functions (expat is in C,
@@ -342,7 +359,5 @@ class QgsGPXHandler
     int *mInt = nullptr;
     QString mCharBuffer;
 };
-
-
 
 #endif

--- a/src/providers/gpx/qgsgpxprovider.h
+++ b/src/providers/gpx/qgsgpxprovider.h
@@ -34,10 +34,9 @@ class QgsGpsData;
 class QgsGPXFeatureIterator;
 
 /**
-\class QgsGPXProvider
-\brief Data provider for GPX (GPS eXchange) files
-* This provider adds the ability to load GPX files as vector layers.
-*
+ * \class QgsGPXProvider
+ * \brief Data provider for GPX (GPS eXchange) files
+ * This provider adds the ability to load GPX files as vector layers.
 */
 class QgsGPXProvider final: public QgsVectorDataProvider
 {

--- a/src/providers/grass/qgsgrass.h
+++ b/src/providers/grass/qgsgrass.h
@@ -126,7 +126,7 @@ class GRASS_LIB_EXPORT QgsGrassObject
 
 /**
  * QString gisdbase()
-   Methods for C library initialization and error handling.
+ * Methods for C library initialization and error handling.
 */
 class GRASS_LIB_EXPORT QgsGrass : public QObject
 {

--- a/src/providers/grass/qgsgrassrasterprovider.h
+++ b/src/providers/grass/qgsgrassrasterprovider.h
@@ -170,10 +170,10 @@ class GRASS_LIB_EXPORT QgsGrassRasterProvider : public QgsRasterDataProvider
 
     /**
      * Returns a bitmask containing the supported capabilities
-        Note, some capabilities may change depending on which
-        sublayers are visible on this provider, so it may
-        be prudent to check this value per intended operation.
-      */
+     * Note, some capabilities may change depending on which
+     * sublayers are visible on this provider, so it may
+     * be prudent to check this value per intended operation.
+    */
     int capabilities() const override;
 
     Qgis::DataType dataType( int bandNo ) const override;

--- a/src/providers/hana/qgshanaprovider.h
+++ b/src/providers/hana/qgshanaprovider.h
@@ -38,9 +38,8 @@ class QgsHanaConnectionRef;
 class QgsHanaFeatureIterator;
 
 /**
-\class QgsHanaProvider
-\brief Data provider for SAP HANA database.
-*
+ * \class QgsHanaProvider
+ * \brief Data provider for SAP HANA database.
 */
 class QgsHanaProvider final : public QgsVectorDataProvider
 {

--- a/src/providers/hana/qgshanatablemodel.h
+++ b/src/providers/hana/qgshanatablemodel.h
@@ -57,8 +57,10 @@ class QIcon;
 
 /**
  * A model that holds the tables of a database in a hierarchy where the
-schemas are the root elements that contain the individual tables as children.
-The tables have the following columns: Type, Schema, Tablename, Geometry Column, Sql*/
+ * schemas are the root elements that contain the individual tables as children.
+ *
+ * The tables have the following columns: Type, Schema, Tablename, Geometry Column, Sql
+*/
 class QgsHanaTableModel : public QStandardItemModel
 {
     Q_OBJECT

--- a/src/providers/mssql/qgsmssqlgeometryparser.h
+++ b/src/providers/mssql/qgsmssqlgeometryparser.h
@@ -32,11 +32,9 @@
 
 
 /**
-\class QgsMssqlGeometryParser
-\brief Geometry parser for SqlGeometry/SqlGeography.
-*
+ * \class QgsMssqlGeometryParser
+ * \brief Geometry parser for SqlGeometry/SqlGeography.
 */
-
 class QgsMssqlGeometryParser
 {
 

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -52,9 +52,8 @@ enum QgsMssqlPrimaryKeyType
 };
 
 /**
-\class QgsMssqlProvider
-\brief Data provider for mssql server.
-*
+ * \class QgsMssqlProvider
+ * \brief Data provider for mssql server.
 */
 class QgsMssqlProvider final: public QgsVectorDataProvider
 {

--- a/src/providers/mssql/qgsmssqltablemodel.h
+++ b/src/providers/mssql/qgsmssqltablemodel.h
@@ -42,8 +42,10 @@ class QIcon;
 
 /**
  * A model that holds the tables of a database in a hierarchy where the
-schemas are the root elements that contain the individual tables as children.
-The tables have the following columns: Type, Schema, Tablename, Geometry Column, Sql*/
+ * schemas are the root elements that contain the individual tables as children.
+ *
+ * The tables have the following columns: Type, Schema, Tablename, Geometry Column, Sql
+*/
 class QgsMssqlTableModel : public QStandardItemModel
 {
     Q_OBJECT

--- a/src/providers/oracle/qgsoracletablemodel.h
+++ b/src/providers/oracle/qgsoracletablemodel.h
@@ -25,8 +25,10 @@ class QIcon;
 
 /**
  * A model that holds the tables of a database in a hierarchy where the
-schemas are the root elements that contain the individual tables as children.
-The tables have the following columns: Type, Owner, Tablename, Geometry Column, Sql*/
+ * schemas are the root elements that contain the individual tables as children.
+ *
+ * The tables have the following columns: Type, Owner, Tablename, Geometry Column, Sql
+*/
 class QgsOracleTableModel : public QStandardItemModel
 {
     Q_OBJECT

--- a/src/providers/postgres/qgspgtablemodel.h
+++ b/src/providers/postgres/qgspgtablemodel.h
@@ -25,8 +25,10 @@ class QIcon;
 
 /**
  * A model that holds the tables of a database in a hierarchy where the
-schemas are the root elements that contain the individual tables as children.
-The tables have the following columns: Type, Schema, Tablename, Geometry Column, Sql*/
+ * schemas are the root elements that contain the individual tables as children.
+ *
+ * The tables have the following columns: Type, Schema, Tablename, Geometry Column, Sql
+*/
 class QgsPgTableModel : public QStandardItemModel
 {
     Q_OBJECT

--- a/src/providers/spatialite/qgsspatialitetablemodel.h
+++ b/src/providers/spatialite/qgsspatialitetablemodel.h
@@ -24,8 +24,10 @@ class QIcon;
 
 /**
  * A model that holds the tables of a database in a hierarchy where the
-SQLite DB is the root elements that contain the individual tables as children.
-The tables have the following columns: Type, Tablename, Geometry Column*/
+ * SQLite DB is the root elements that contain the individual tables as children.
+ *
+ * The tables have the following columns: Type, Tablename, Geometry Column
+*/
 class QgsSpatiaLiteTableModel: public QStandardItemModel
 {
   Q_OBJECT public:

--- a/src/providers/wfs/qgswfsfeatureiterator.h
+++ b/src/providers/wfs/qgswfsfeatureiterator.h
@@ -58,11 +58,11 @@ class QgsWFSFeatureHitsAsyncRequest final: public QgsWfsRequest
 
 /**
  * This class runs one (or several if paging is needed) GetFeature request,
-    process the results as soon as they arrived and notify them to the
-    serializer to fill the case, and to the iterator that subscribed
-    Instances of this class may be run in a dedicated thread (QgsWFSThreadedFeatureDownloader)
-    A progress dialog may pop-up in GUI mode (if the download takes a certain time)
-    to allow canceling the download.
+ * process the results as soon as they arrived and notify them to the
+ * serializer to fill the case, and to the iterator that subscribed
+ * Instances of this class may be run in a dedicated thread (QgsWFSThreadedFeatureDownloader)
+ * A progress dialog may pop-up in GUI mode (if the download takes a certain time)
+ * to allow canceling the download.
 */
 class QgsWFSFeatureDownloaderImpl final: public QgsWfsRequest, public QgsFeatureDownloaderImpl
 {

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -44,8 +44,8 @@ class QgsWFSSharedData;
  * QgsWFSProvider class purpose:
  *
  * - in constructor, do a GetCapabilities request to determine server-side feature limit,
-     paging capabilities, WFS version, edition capabilities. Do a DescribeFeatureType request
-     to determine fields, geometry name and type.
+ *   paging capabilities, WFS version, edition capabilities. Do a DescribeFeatureType request
+ *   to determine fields, geometry name and type.
  * - in other methods, mostly WFS-T related operations.
  *
  * QgsWFSSharedData class purpose:

--- a/src/providers/wfs/qgswfssourceselect.h
+++ b/src/providers/wfs/qgswfssourceselect.h
@@ -81,9 +81,11 @@ class QgsWFSSourceSelect: public QgsAbstractDataSourceWidget, private Ui::QgsWFS
 
     /**
      * Returns the best suited CRS from a set of authority ids
+     *
      * 1. project CRS if contained in the set
      * 2. WGS84 if contained in the set
      * 3. the first entry in the set else
+     *
      * \returns the authority id of the crs or an empty string in case of error
     */
     QString getPreferredCrs( const QSet<QString> &crsSet ) const;

--- a/src/python/qgspythonutils.h
+++ b/src/python/qgspythonutils.h
@@ -32,15 +32,15 @@ class QgsServerInterface;
 
 
 /**
- All calls to Python functions in QGIS come here.
- This class is a singleton.
-
- Default path for Python plugins is:
- - QgsApplication::qgisSettingsDirPath() + "/python/plugins"
- - QgsApplication::pkgDataPath() + "/python/plugins"
-
+ * All calls to Python functions in QGIS come here.
+ * This class is a singleton.
+ *
+ * Default path for Python plugins is:
+ *
+ * - QgsApplication::qgisSettingsDirPath() + "/python/plugins"
+ * - QgsApplication::pkgDataPath() + "/python/plugins"
+ *
  */
-
 class PYTHON_EXPORT QgsPythonUtils
 {
   public:

--- a/tests/qt_modeltest/dynamictreemodel.h
+++ b/tests/qt_modeltest/dynamictreemodel.h
@@ -44,8 +44,8 @@ class DynamicTreeModel : public QAbstractItemModel
   protected slots:
 
     /**
-    Finds the parent id of the string with id @p searchId.
-    Returns -1 if not found.
+     * Finds the parent id of the string with id @p searchId.
+     * Returns -1 if not found.
     */
     qint64 findParentId( qint64 searchId ) const;
   private:
@@ -127,7 +127,7 @@ class ModelMoveCommand : public ModelChangeCommand
 };
 
 /**
-  A command which does a move and emits a reset signal.
+ * A command which does a move and emits a reset signal.
 */
 class ModelResetCommand : public ModelMoveCommand
 {
@@ -140,7 +140,7 @@ class ModelResetCommand : public ModelMoveCommand
 };
 
 /**
-  A command which does a move and emits a beginResetModel and endResetModel signals.
+ * A command which does a move and emits a beginResetModel and endResetModel signals.
 */
 class ModelResetCommandFixed : public ModelMoveCommand
 {

--- a/tests/qt_modeltest/tst_modeltest.cpp
+++ b/tests/qt_modeltest/tst_modeltest.cpp
@@ -193,7 +193,7 @@ void tst_ModelTest::testInsertThroughProxy()
 }
 
 /**
-  Makes the persistent index list publicly accessible
+*  Makes the persistent index list publicly accessible
 */
 class AccessibleProxyModel : public QSortFilterProxyModel
 {

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -1103,9 +1103,9 @@ void TestQgsCoordinateReferenceSystem::customSrsValidation()
 
   /**
    * \todo implement this test
-  "QgsCoordinateReferenceSystem myCrs;
-  static CUSTOM_CRS_VALIDATION customSrsValidation();
-  QVERIFY( myCrs.isValid() );
+  *  "QgsCoordinateReferenceSystem myCrs;
+  *  static CUSTOM_CRS_VALIDATION customSrsValidation();
+  *  QVERIFY( myCrs.isValid() );
   */
 }
 void TestQgsCoordinateReferenceSystem::postgisSrid()

--- a/tests/src/gui/testqgsmaptoolzoom.cpp
+++ b/tests/src/gui/testqgsmaptoolzoom.cpp
@@ -63,11 +63,11 @@ void TestQgsMapToolZoom::cleanup()
   delete canvas;
 }
 
-/**
+/*
  * Zero drag areas can happen on pen based computer when a mouse down,
-  * move, and up, all happened at the same spot due to the pen. In this case
-  * QGIS thinks it is in dragging mode but it's not really and fails to zoom in.
-  **/
+ * move, and up, all happened at the same spot due to the pen. In this case
+ * QGIS thinks it is in dragging mode but it's not really and fails to zoom in.
+ */
 void TestQgsMapToolZoom::zeroDragArea()
 {
   QPoint point = QPoint( 15, 15 );


### PR DESCRIPTION
This formatting style prevents the auto format and sipify scripts from doing their full formatting magic, so force use of the standard QGIS style which requires a * prefix for all lines in a block comment.